### PR TITLE
EIP for CALLDEPTH opcode

### DIFF
--- a/EIPS/eip-3.mediawiki
+++ b/EIPS/eip-3.mediawiki
@@ -29,13 +29,13 @@ It is possible to defend against this in two ways:
 # Check call stack depth experimentally. A library [2] by Piper Merriam exists for this purpose. This method is quite costly in gas.
 
 
-[1] a.k.a "shallow stack attack" and "stack attack". However, to be precise, the word `stack` has a different meaning within the EVM, and is not to be confused with the _call stack_.
+[1] a.k.a "shallow stack attack" and "stack attack". However, to be precise, the word ''stack'' has a different meaning within the EVM, and is not to be confused with the ''call stack''.
 
 [2] https://github.com/pipermerriam/ethereum-stack-depth-lib 
 
 ==Specification==
 
-The opcode <code>CALLDEPTH</code> should return the remaining call stack depth. A value of `0` means that the call stack is exhausted, and no further calls can be made. 
+The opcode <code>CALLDEPTH</code> should return the remaining call stack depth. A value of <code>0</code> means that the call stack is exhausted, and no further calls can be made. 
 
 ==Rationale==
 

--- a/EIPS/eip-3.mediawiki
+++ b/EIPS/eip-3.mediawiki
@@ -9,7 +9,7 @@
 
 ==Abstract==
 
-This is a proposal to add a new opcode, `CALLDEPTH`. The `CALLDEPTH` opcode would return the remaining available call stack depth. 
+This is a proposal to add a new opcode, <code>CALLDEPTH</code>. The <code>CALLDEPTH</code> opcode would return the remaining available call stack depth. 
 
 ==Motivation==
 
@@ -19,14 +19,14 @@ This behaviour makes it possible to subject a contract to a "call stack attack" 
 
 Example: 
 
-1. Contract `A` want's to be invoked regularly, and pays Ether to the invoker in every block.
-2. When contract `A` is invoked, it calls contracts `B` and `C`, which consumes a lot of gas. After invocation, contract `A` pays Ether to the caller. 
-3. Malicious user `X` ensures that the stack depth is shallow before invoking A. Both calls to `B` and `C` fail, but `X` can still collect the reward. 
+# Contract `A` want's to be invoked regularly, and pays Ether to the invoker in every block.
+# When contract `A` is invoked, it calls contracts `B` and `C`, which consumes a lot of gas. After invocation, contract `A` pays Ether to the caller. 
+# Malicious user `X` ensures that the stack depth is shallow before invoking A. Both calls to `B` and `C` fail, but `X` can still collect the reward. 
 
 It is possible to defend against this in two ways:
 
-1. Check return value after invocation. 
-2. Check call stack depth experimentally. A library [2] by Piper Merriam exists for this purpose. This method is quite costly in gas.
+# Check return value after invocation. 
+# Check call stack depth experimentally. A library [2] by Piper Merriam exists for this purpose. This method is quite costly in gas.
 
 
 [1] a.k.a "shallow stack attack" and "stack attack". However, to be precise, the word `stack` has a different meaning within the EVM, and is not to be confused with the _call stack_.
@@ -34,7 +34,7 @@ It is possible to defend against this in two ways:
 
 ==Specification==
 
-The opcode `CALLDEPTH` should return the remaining call stack depth. A value of `0` means that the call stack is exhausted, and no further calls can be made. 
+The opcode <code>CALLDEPTH</code> should return the remaining call stack depth. A value of `0` means that the call stack is exhausted, and no further calls can be made. 
 
 ==Rationale==
 

--- a/EIPS/eip-3.mediawiki
+++ b/EIPS/eip-3.mediawiki
@@ -1,0 +1,44 @@
+<pre>
+  EIP: 3
+  Title: Addition of CALLDEPTH opcode
+  Author: Martin Holst Swende <martin@swende.se>
+  Status: Draft
+  Type: Standards Track
+  Created: 2015-11-19
+</pre>
+
+==Abstract==
+
+This is a proposal to add a new opcode, `CALLDEPTH`. The `CALLDEPTH` opcode would return the remaining available call stack depth. 
+
+==Motivation==
+
+There is a limit specifying how deep contracts can call other contracts; the call stack. The limit is currently `256`. If a contract invokes another contract (either via `CALL` or `CALLCODE`), the operation will fail if the call stack depth limit has been reached. 
+
+This behaviour makes it possible to subject a contract to a "call stack attack" [1]. In such an attack, an attacker first creates a suitable depth of the stack, e.g. by recursive calls. After this step, the attacker invokes the targeted contract. If the targeted calls another contract, that call will fail. If the return value is not properly checked to see if the call was successfull, the consequences could be damaging. 
+
+Example: 
+
+1. Contract `A` want's to be invoked regularly, and pays Ether to the invoker in every block.
+2. When contract `A` is invoked, it calls contracts `B` and `C`, which consumes a lot of gas. After invocation, contract `A` pays Ether to the caller. 
+3. Malicious user `X` ensures that the stack depth is shallow before invoking A. Both calls to `B` and `C` fail, but `X` can still collect the reward. 
+
+It is possible to defend against this in two ways:
+
+1. Check return value after invocation. 
+2. Check call stack depth experimentally. A library [2] by Piper Merriam exists for this purpose. This method is quite costly in gas.
+
+
+[1] a.k.a "shallow stack attack" and "stack attack". However, to be precise, the word `stack` has a different meaning within the EVM, and is not to be confused with the _call stack_.
+[2] https://github.com/pipermerriam/ethereum-stack-depth-lib 
+
+==Specification==
+
+The opcode `CALLDEPTH` should return the remaining call stack depth. A value of `0` means that the call stack is exhausted, and no further calls can be made. 
+
+==Rationale==
+
+The actual call stack depth, as well as the call stack depth limit, are present in the EVM during execution, but just not available within the EVM. The implementation should be fairly simple and would provide a cheap and way to protect against call stack attacks. 
+
+==Implementation==
+

--- a/EIPS/eip-3.mediawiki
+++ b/EIPS/eip-3.mediawiki
@@ -30,6 +30,7 @@ It is possible to defend against this in two ways:
 
 
 [1] a.k.a "shallow stack attack" and "stack attack". However, to be precise, the word `stack` has a different meaning within the EVM, and is not to be confused with the _call stack_.
+
 [2] https://github.com/pipermerriam/ethereum-stack-depth-lib 
 
 ==Specification==
@@ -38,7 +39,8 @@ The opcode <code>CALLDEPTH</code> should return the remaining call stack depth. 
 
 ==Rationale==
 
-The actual call stack depth, as well as the call stack depth limit, are present in the EVM during execution, but just not available within the EVM. The implementation should be fairly simple and would provide a cheap and way to protect against call stack attacks. 
+The actual call stack depth, as well as the call stack depth limit, are present in the EVM during execution, but just not available within the EVM. The implementation should be fairly simple and would provide a cheap and way to protect against call stack attacks.
 
 ==Implementation==
 
+Not implemented. 


### PR DESCRIPTION
As discussed in [Gitter EIP](https://gitter.im/ethereum/EIPs) channel, this is a proposed EIP for introducing a new opcode, `CALLDEPTH`. 