### PR TITLE
Add EIP-8 to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ First review [EIP-1](EIPS/eip-1.mediawiki). Then clone the repository and add yo
 | [5](EIPS/eip-5.md)    | Gas Usage for `RETURN` and `CALL*` | Christian Reitwiessner | Standard | Consensus (hard-fork) | [Draft](https://github.com/ethereum/EIPs/issues/8) |
 | [6](EIPS/eip-6.md)    | Renaming Suicide Variable | Hudson Jameson | Meta |  | [Draft](https://github.com/ethereum/EIPs/pull/42) |
 | [7](EIPS/eip-7.md)    | DELEGATECALL | Vitalik Buterin | Standard | homestead (hard-fork) | [Accepted](https://github.com/ethereum/EIPs/issues/23) |
-
+| [8](EIPS/eip-8.md)    | devp2p Forward Compatibility Requirements for Homestead | Felix Lange | Standard | Networking | [Accepted](https://github.com/ethereum/EIPs/pull/49) |


### PR DESCRIPTION
Added link to EIP-8 which was accepted, but for some reason wasn't added to the README.md