### PR TITLE
I propose to update EIP2 status to 'final'.

### DIFF
--- a/EIPS/eip-2.mediawiki
+++ b/EIPS/eip-2.mediawiki
@@ -2,7 +2,7 @@
   EIP: 2
   Title: Homestead Hard-fork Changes
   Author: Vitalik Buterin <v@buterin.com>
-  Status: Accepted
+  Status: Final
   Type: Standard
   Layer: Consensus (hard-fork)
   Created: 2015-11-15
@@ -10,7 +10,7 @@
 
 ==Specification==
 
-If <code>block.number >= HOMESTEAD_FORK_BLKNUM</code> (eg. 1.150.000 (NOT YET SET IN STONE!) on livenet and Morden, 0 on future testnets), do the following:
+If <code>block.number >= HOMESTEAD_FORK_BLKNUM</code> (e.g., 1.150.000 on livenet, 494.000 on Morden and 0 on future testnets), do the following:
 
 # The gas cost ''for creating contracts via a transaction'' is increased from 21000 to 53000, ie. if you send a transaction and the to address is the empty string, the initial gas subtracted is 53000 plus the gas cost of the tx data, rather than 21000 as is currently the case. Contract creation from a contract using the <code>CREATE</code> opcode is unaffected.
 # All transaction signatures whose s-value is greater than <code>secp256k1n/2</code> are now considered invalid. The ECDSA recover precompiled contract remains unchanged and will keep accepting high s-values - this is useful if e.g. a contract recovers old Bitcoin signatures.


### PR DESCRIPTION
EIP2 should be set to 'final', because:

- EIP2 is already in 'accepted' state
- EIP2 is already implemented in more than two clients
- EIP2 is already added to the yellow paper specification

This PR might not be perfect, but you get the idea.