### PR TITLE
Fix up URLs for the EIPs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,19 +16,19 @@ First review [EIP-1](EIPS/eip-1.md). Then clone the repository and add your EIP 
 | Number                      |Title                                                                                | Author                | Type      | Layer       | Status    | 
 | --------------------------  | ----------------------------------------------------------------------------------- | --------------------  | ----------| ------------| ----------|
 | [5](EIPS/eip-5.md)          | Gas Usage for `RETURN` and `CALL*`                                                  | Christian Reitwiessner| Standard  | Core        | Draft     |
-| [211](EIPs/pull/211)        | New opcodes: RETURNDATASIZE and RETURNDATACOPY                                      | Christian Reitwiessner| Standard  | Core        | Draft     |
+| [211](https://github.com/ethereum/EIPs/pull/211)        | New opcodes: RETURNDATASIZE and RETURNDATACOPY                                      | Christian Reitwiessner| Standard  | Core        | Draft     |
 
 
 
 # Accepted EIPs (planned for adoption)
 | Number                      |Title                                                                                | Author                | Type      | Layer       | Status    | 
 | --------------------------  | ----------------------------------------------------------------------------------- | --------------------  | ----------| ------------| ----------|
-| [86](EIPs/pull/208)         | Abstraction of transaction origin and signature                                     | Vitalik Buterin       | Standard  | Core        | Accepted  |
-| [96](EIPs/pull/210)         | Blockhash refactoring                                                               | Vitalik Buterin       | Standard  | Core        | Accepted  |
-| [100](EIPs/issues/100)      | Change difficulty adjustment to target mean block time including uncles	          | Vitalik Buterin       | Standard  | Core        | Accepted  |
-| [140](EIPs/pull/206)        | REVERT instruction in the Ethereum Virtual Machine                                  | Beregszaszi, Mushegian| Standard  | Core        | Accepted  |
-| [196](EIPs/pull/213)        | Precompiled contracts for addition and scalar multiplication on the elliptic curve alt_bn128 | Reitwiessner | Standard  | Core        | Accepted  |
-| [197](EIPs/pull/212)        | Precompiled contracts for optimal Ate pairing check on the elliptic curve alt_bn128 | Buterin, Reitwiessner | Standard  | Core        | Accepted  |
+| [86](https://github.com/ethereum/EIPs/pull/208)         | Abstraction of transaction origin and signature                                     | Vitalik Buterin       | Standard  | Core        | Accepted  |
+| [96](https://github.com/ethereum/EIPs/pull/210)         | Blockhash refactoring                                                               | Vitalik Buterin       | Standard  | Core        | Accepted  |
+| [100](https://github.com/ethereum/EIPs/issues/100)      | Change difficulty adjustment to target mean block time including uncles	          | Vitalik Buterin       | Standard  | Core        | Accepted  |
+| [140](https://github.com/ethereum/EIPs/pull/206)        | REVERT instruction in the Ethereum Virtual Machine                                  | Beregszaszi, Mushegian| Standard  | Core        | Accepted  |
+| [196](https://github.com/ethereum/EIPs/pull/213)        | Precompiled contracts for addition and scalar multiplication on the elliptic curve alt_bn128 | Reitwiessner | Standard  | Core        | Accepted  |
+| [197](https://github.com/ethereum/EIPs/pull/212)        | Precompiled contracts for optimal Ate pairing check on the elliptic curve alt_bn128 | Buterin, Reitwiessner | Standard  | Core        | Accepted  |
 
 
 
@@ -39,9 +39,9 @@ First review [EIP-1](EIPS/eip-1.md). Then clone the repository and add your EIP 
 | [6](EIPS/eip-6.md)          | Renaming Suicide Opcode                                     | Hudson Jameson  | Standard  | Interface   | Final   |
 | [7](EIPS/eip-7.md)          | DELEGATECALL                                                | Vitalik Buterin | Standard  | Core        | Final   |
 | [8](EIPS/eip-8.md)          | devp2p Forward Compatibility Requirements for Homestead     | Felix Lange     | Standard  | Networking  | Final   |
-| [150](EIPs/issues/150)      | Gas cost changes for IO-heavy operations                    | Vitalik Buterin | Standard  | Core        | Final   |
-| [155](EIPs/issues/155)      | Simple replay attack protection                             | Vitalik Buterin | Standard  | Core        | Final   |
-| [160](EIPs/issues/160)      | EXP cost increase                                           | Vitalik Buterin | Standard  | Core        | Final   |
-| [161](EIPs/issues/161)      | State trie clearing (invariant-preserving alternative)      | Gavin Wood      | Standard  | Core        | Final   |
-| [170](EIPs/issues/170)      | Contract code size limit                                    | Vitalik Buterin | Standard  | Core        | Final   |
+| [150](https://github.com/ethereum/EIPs/issues/150)      | Gas cost changes for IO-heavy operations                    | Vitalik Buterin | Standard  | Core        | Final   |
+| [155](https://github.com/ethereum/EIPs/issues/155)      | Simple replay attack protection                             | Vitalik Buterin | Standard  | Core        | Final   |
+| [160](https://github.com/ethereum/EIPs/issues/160)      | EXP cost increase                                           | Vitalik Buterin | Standard  | Core        | Final   |
+| [161](https://github.com/ethereum/EIPs/issues/161)      | State trie clearing (invariant-preserving alternative)      | Gavin Wood      | Standard  | Core        | Final   |
+| [170](https://github.com/ethereum/EIPs/issues/170)      | Contract code size limit                                    | Vitalik Buterin | Standard  | Core        | Final   |
 


### PR DESCRIPTION
Some of the URLs for the EIP numbers pointed to non-existent pages. Fixed by using absolute rather than relative paths.

When opening a pull request to submit a new EIP, please use the suggested template: https://github.com/ethereum/EIPs/blob/master/eip-X.md
