### PR TITLE
EIP 137: Add warning for implementers against treating 0 like other addresses

### DIFF
--- a/EIPS/eip-137.md
+++ b/EIPS/eip-137.md
@@ -179,6 +179,7 @@ The following interfaces are defined:
 | `pubkey`    | 0xc8690233   | #619    |
 
 EIPs may define new interfaces to be added to this registry.
+
 ### <a name="addr"></a>Contract Address Interface
 
 Resolvers wishing to support contract address resources must provide the following function:
@@ -188,6 +189,8 @@ function addr(bytes32 node) constant returns (address);
 ```
 
 If the resolver supports `addr` lookups but the requested node does not have a record, the resolver MUST return the zero address.
+
+Clients resolving the `addr` record MUST check for a zero return value, and treat this in the same manner as a name that does not have a resolver specified - that is, refuse to send funds to or interact with the address. Failure to do this can result in users accidentally sending funds to the 0 address.
 
 Changes to an address MUST trigger the following event:
 


### PR DESCRIPTION
This PR adds a note to EIP 137, warning implementers about how to treat resolvers with unset addr records. This is intended to prevent user mistakes resulting in sends of funds or tokens to address 0.