### PR TITLE
eip-165: when the first loop hits BEGINDATA, the second loop should still run

### DIFF
--- a/EIPS/eip-615.md
+++ b/EIPS/eip-615.md
@@ -217,7 +217,7 @@ Validating that jumps are to valid addresses takes two sequential passes over th
             if instruction is invalid
                 return false
             if instruction is BEGINDATA
-                return true
+                break
             if instruction is BEGINSUB
                 is_sub[PC] = true
                 current_sub = PC


### PR DESCRIPTION
`validate_jumps()` function contains two loops, but the second loop was sometimes skipped before this PR.  The two loops check different kinds of properties, and somehow I thought the second loop should be entered in this case.