### PR TITLE
eip-615: initialize current_sub variable

### DIFF
--- a/EIPS/eip-615.md
+++ b/EIPS/eip-615.md
@@ -211,9 +211,8 @@ Validating that jumps are to valid addresses takes two sequential passes over th
 
     bool validate_jumps(PC)
     {
-        current_sub = PC
-
         // build sets of BEGINSUBs and JUMPDESTs
+        current_sub = 0
         for (PC = 0; instruction = bytecode[PC]; PC = advance_pc(PC))
         {
             if instruction is invalid
@@ -230,6 +229,7 @@ Validating that jumps are to valid addresses takes two sequential passes over th
         }
 
         // check that targets are in subroutine
+        current_sub = 0
         for (PC = 0; instruction = bytecode[PC]; PC = advance_pc(PC))
         {
             if instruction is BEGINDATA


### PR DESCRIPTION
`validate_jumps()` function has two loops.  Both should start with `current_sub` initialized to zero.

After doing this, I didin't see the argument `PC` used anywhere.  So I removed it.