### PR TITLE
eip-615: BEGINDATA instruction finishes the analysis

### DIFF
--- a/EIPS/eip-615.md
+++ b/EIPS/eip-615.md
@@ -298,7 +298,7 @@ The basic approach is to call `validate_subroutine(i, 0, 0)`, for _i_ equal to t
             if SP > 1024
                 return false
 
-            if instruction is STOP, RETURN, or SUICIDE
+            if instruction is STOP, RETURN, SUICIDE or BEGINDATA
                 return true	   
 
             // violates single entry


### PR DESCRIPTION
The loop in `validate_subroutine()` should stop when it sees `BEGINDATA`.  I chose `return true` to exit the loop.