### PR TITLE
Add reference to EIP-55 implementation in ethereum-utils library

### DIFF
--- a/EIPS/eip-55.md
+++ b/EIPS/eip-55.md
@@ -104,4 +104,5 @@ Benefits:
 
 1. EIP 55 issue and discussion https://github.com/ethereum/eips/issues/55
 2. Python example by @Recmo https://github.com/ethereum/eips/issues/55#issuecomment-261521584
-3. Ethereumjs-util implementation https://github.com/ethereumjs/ethereumjs-util/blob/75f529458bc7dc84f85fd0446d0fac92d991c262/index.js#L452-L466
+3. Python implementation in [`ethereum-utils`](https://github.com/pipermerriam/ethereum-utils#to_checksum_addressvalue---text)
+4. Ethereumjs-util implementation https://github.com/ethereumjs/ethereumjs-util/blob/75f529458bc7dc84f85fd0446d0fac92d991c262/index.js#L452-L466


### PR DESCRIPTION
### What was wrong

The reference implementations for EIP-55 didn't include the `ethereum-utils` library which includes tools for both generating checksummed addresses as well as verifying them.  This is a *better* reference as it's tested and installable as a library rather than copy/pasting code.

### How was it fixed.

Added the implementation to the list after the existing implementation.  I'd suggest replacing the current listed python implementation but I didn't want to take that liberty unless someone else concurs that it's the right thing to do.

#### Cute animal picture

![baby-bird-030](https://user-images.githubusercontent.com/824194/27613612-ae419b72-5b59-11e7-812d-b05ca880f824.jpg)

