### PR TITLE
Add EIP669, token standard allowing derivative contracts

### DIFF
--- a/EIPS/eip-669.md
+++ b/EIPS/eip-669.md
@@ -1,0 +1,86 @@
+```
+EIP: 669
+Title: Token standard
+Author: Thorkil Værge (sword-smith), thorkilk@gmail.com; Mads Gram (PhDuck), mgmadsgram@gmail.com
+Type: Standard Track
+Category: ERC
+Status: Draft
+Created: 2017-07-16
+```
+
+## Abstract
+
+The following describes standard functions a token can implement to allow basic transfers of this token as well as the creation of derivative contracts which transfer these tokens upon their execution.
+
+## Motivation
+
+Problems of ERC20 that ERC669 will solve:
+1. ERC20 does not allow for enforceable derivative contracts on the blockchain which transfer tokens upon their execution.
+
+## Specifiction
+
+The ERC669 specification follows the ERC20 specification as closely as possible while still achieving its goal of allowing the creation of derivative contracts with these tokens as the underlying asset. The main change from ERC20 is that the method `approve` locks a balance on the callers account such that `transfer` and `transferFrom` will fail if they do not leave an amount larger than what has been locked.
+
+### Methods
+
+#### approve
+```solidity
+    function approve(address _spender, uint256 _value) returns (bool success)
+```
+Locks the `_value` amount on your account and allows `_spender` to withdraw from your account up to the `_value` amount. This function must only succeed when at least `_value` is present on the account and at least `_value` has not already been locked by a call to this method. The `_spender` address should represent a smart contract, not an externally controlled account.
+
+#### totalLockedAmount
+```solidity
+    function totalLockedAmount(address _from) constant returns (uint256 totalLockedAmount)
+```
+Returns the total amount which has been locked on `_from` account through the method `approve`. If several different addresses have been approved to withdraw from the `_from` account, then the sum of all these amounts should be returned.
+
+#### transfer
+```solidity
+    function transfer(address _to, uint256 _value) returns (bool success)
+```
+Send `_value` amount of tokens from caller address (`_caller`) to address `_to`. Fails if the new balance is less than the amount returned by `totalLockedAmount(_caller)`.
+
+#### transferFrom
+```solidity
+    function transferFrom(address _from, address _to, uint256 _value) returns (bool success)
+```
+Transfer `_amount` from address `_from` to address `_to`. This method must only succeed if the amount transferred is less than or equal to what is returned by `totalLockedAmount(_caller)` where `_caller` is the address of the caller. This method should only be used by smart contracts.
+
+#### allowance
+```solidity
+    function allowance(address _owner, address _spender) constant returns (uint256 remaining)
+```
+Returns the amount which `_spender` is still allowed to withdraw from `_owner`.
+
+#### totalSupply
+```solidity
+    function totalSupply() constant returns (uint256 totalSupply)
+```
+Get the total token supply
+
+#### balanceOf
+```solidity
+    function balanceOff(address _owner) constant returns (uint256 balance)
+```
+Get the account balance of another account with address `_owner`. Is not affected by calls to `approve`.
+
+#### releaseApproval
+```solidity
+    releaseApproval(address _cancelAddress) returns (bool success)
+```
+Cancels any amount that has been locked by a call to `approve` where `_cancelAddress` has been granted access to withdraw from `_caller` where `_caller` is the address of the caller. This method will only succeed if `_caller = _cancelAddress` or if `_cancelAddress` does not contain any code.
+
+### Events
+
+#### Transfer
+```solidity
+    event Transfer(address indexed _from, address indexed _to, uint256 _value)
+```
+Triggered when tokens are transferred.
+
+#### Approval
+```solidity
+    event Approval(address indexed _owner, address indexed _spender, uint256 _value)
+```
+Triggered whenever `approve(address _spender, uint256 _value)` is called.


### PR DESCRIPTION
This EIP is an ERC which modifies some methods in ERC20 and adds some
other methods. The goal is to allow users to make derivative contracts
using tokens complying with this standard as the underlying asset.
A compiler for these derivative contracts already exists on 
https://github.com/Sword-Smith/Daggerc

When opening a pull request to submit a new EIP, please use the suggested template: https://github.com/ethereum/EIPs/blob/master/eip-X.md
