### PR TITLE
Defer EIP96 from Byzantium to Constantinople

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ First review [EIP-1](EIPS/eip-1.md). Then clone the repository and add your EIP 
 # Accepted EIPs (planned for adoption)
 | Number                                                  |Title                                                                                | Author                | Layer       | Status    |
 | ------------------------------------------------------- | ----------------------------------------------------------------------------------- | --------------------  | ------------| ----------|
-| [96](https://github.com/ethereum/EIPs/pull/210)         | Blockhash refactoring                                                               | Vitalik Buterin       | Core        | Accepted  |
 | [98](https://github.com/ethereum/EIPs/pull/98)          | Removal of intermediate state roots from receipts                                   | Vitalik Buterin       | Core        | Accepted  |
 | [100](https://github.com/ethereum/EIPs/issues/100)      | Change difficulty adjustment to target mean block time including uncles	            | Vitalik Buterin       | Core        | Accepted  |
 | [140](https://github.com/ethereum/EIPs/pull/206)        | REVERT instruction in the Ethereum Virtual Machine                                  | Beregszaszi, Mushegian| Core        | Accepted  |
@@ -34,6 +33,7 @@ First review [EIP-1](EIPS/eip-1.md). Then clone the repository and add your EIP 
 | Number                                                  |Title                                                                                | Author                | Layer       | Status    |
 | ------------------------------------------------------- | ----------------------------------------------------------------------------------- | --------------------  | ------------| ----------|
 | [86](https://github.com/ethereum/EIPs/pull/208)         | Abstraction of transaction origin and signature                                     | Vitalik Buterin       | Core        | Deferred  |
+| [96](https://github.com/ethereum/EIPs/pull/210)         | Blockhash refactoring                                                               | Vitalik Buterin       | Core        | Deferred  |
 
 # Finalized EIPs (standards that have been adopted)
 | Number                                                  |Title                                                        | Author          | Layer       | Status  |


### PR DESCRIPTION
According to the consensus seen in the [Core Dev meeting 22](https://github.com/ethereum/pm/issues/20), this PR moves EIP-96 from Accepted to Deferred.