### PR TITLE
Address Collision of Contract Address Causes Exceptional Halt

### DIFF
--- a/EIPS/address-collision-exceptional-halt.md
+++ b/EIPS/address-collision-exceptional-halt.md
@@ -1,0 +1,51 @@
+## Preamble
+
+    EIP: <to be assigned>
+    Title: Address Collision of Contract Address Causes Exceptional Halt
+    Author: Yoichi Hirai <i@yoichihirai.com>
+    Type: Standard Track
+    Category: Core
+    Status: Draft
+    Created: 2017-08-15
+    Requires: none
+    Replaces: none
+
+
+## Simple Summary
+
+This EIP proposes to make contract creation fail on an account with nonempty code or non-zero nonce.
+
+## Abstract
+
+Some test cases in the consensus test suite try to deploy a contract at an address already with nonempty code. Although such cases can virtually never happen on the main network before the Constantinople fork block, the test cases detected discrepancies in clients' behavior.  Currently, the Yellow Paper says that the contract creation starts with the empty code and the initial nonce even in the case of address collisions. To simplify the semantics, this EIP proposes that address collisions cause failures of contract creation.
+
+## Motivation
+
+This EIP has no practical relevance to the main net history, but simplifies testing and reasoning.
+
+This EIP has no effects after Constantinople fork because [EIP-86](https://github.com/ethereum/EIPs/pull/208) contains the changes proposed in this EIP. Even before the Constantinople fork, this EIP has no practical relevance because the change is visible only in case of a hash collision of keccak256.
+
+Regarding testing, this EIP releaves clients from supporting reversion of code overwriting.
+
+Regarding reasoning, this EIP establishes an invariant that non-empty code is never modified.
+
+## Specification
+
+If `block.number >= 0`, when a contract creation is on an account with non-zero nonce or non-empty code, the creation fails as if init code execution resulted in an exceptional halt.  This applies to contract creation triggered by a contract creation transaction and by CREATE instruction.
+
+## Rationale
+
+It seems unpractical to implement never-used features just for passing tests.  Client implementations will be simpler with this EIP.
+
+## Backwards Compatibility
+
+This EIP is backwards compatible on the main network.
+
+## Test Cases
+
+At least the BlockchainTest called `createJS\_ExampleContract\_d0g0v0\_EIP158` will distinguish clients that implement this EIP.
+
+## Implementation
+
+## Copyright
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/EIPS/eip-689.md
+++ b/EIPS/eip-689.md
@@ -1,6 +1,6 @@
 ## Preamble
 
-    EIP: <to be assigned>
+    EIP: 689
     Title: Address Collision of Contract Address Causes Exceptional Halt
     Author: Yoichi Hirai <i@yoichihirai.com>
     Type: Standard Track

--- a/EIPS/eip-689.md
+++ b/EIPS/eip-689.md
@@ -1,15 +1,14 @@
 ## Preamble
 
-    EIP: 689
-    Title: Address Collision of Contract Address Causes Exceptional Halt
-    Author: Yoichi Hirai <i@yoichihirai.com>
-    Type: Standard Track
-    Category: Core
-    Status: Draft
-    Created: 2017-08-15
-    Requires: none
-    Replaces: none
-
+---
+eIP: 689
+title: Address Collision of Contract Address Causes Exceptional Halt
+author: Yoichi Hirai <i@yoichihirai.com>
+type: Standard Track
+category: Core
+status: Draft
+created: 2017-08-15
+---
 
 ## Simple Summary
 

--- a/EIPS/eip-689.md
+++ b/EIPS/eip-689.md
@@ -1,7 +1,5 @@
-## Preamble
-
 ---
-eIP: 689
+eip: 689
 title: Address Collision of Contract Address Causes Exceptional Halt
 author: Yoichi Hirai <i@yoichihirai.com>
 type: Standard Track
@@ -24,7 +22,7 @@ This EIP has no practical relevance to the main net history, but simplifies test
 
 This EIP has no effects after Constantinople fork because [EIP-86](https://github.com/ethereum/EIPs/pull/208) contains the changes proposed in this EIP. Even before the Constantinople fork, this EIP has no practical relevance because the change is visible only in case of a hash collision of keccak256.
 
-Regarding testing, this EIP releaves clients from supporting reversion of code overwriting.
+Regarding testing, this EIP relieves clients from supporting reversion of code overwriting.
 
 Regarding reasoning, this EIP establishes an invariant that non-empty code is never modified.
 
@@ -34,7 +32,7 @@ If `block.number >= 0`, when a contract creation is on an account with non-zero 
 
 ## Rationale
 
-It seems unpractical to implement never-used features just for passing tests.  Client implementations will be simpler with this EIP.
+It seems impractical to implement never-used features just for passing tests.  Client implementations will be simpler with this EIP.
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
This follows the discussion in [coredev meeting 22](https://github.com/ethereum/pm/issues/20), where no objections were made to the proposal to make contract creation fail in the case of address collision.