### PR TITLE
update links

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ First review [EIP-1](EIPS/eip-1.md). Then clone the repository and add your EIP 
 # Accepted EIPs (planned for adoption)
 | Number                                                  |Title                                                                                | Author                | Layer       | Status    |
 | ------------------------------------------------------- | ----------------------------------------------------------------------------------- | --------------------  | ------------| ----------|
-| [100](https://github.com/ethereum/EIPs/issues/100)      | Change difficulty adjustment to target mean block time including uncles	            | Vitalik Buterin       | Core        | Accepted  |
+| [100](https://github.com/ethereum/EIPs/issues/100)      | Change difficulty adjustment to target mean block time including uncles             | Vitalik Buterin       | Core        | Accepted  |
 | [140](https://github.com/ethereum/EIPs/pull/206)        | REVERT instruction in the Ethereum Virtual Machine                                  | Beregszaszi, Mushegian| Core        | Accepted  |
 | [196](https://github.com/ethereum/EIPs/pull/213)        | Precompiled contracts for addition and scalar multiplication on the elliptic curve alt_bn128 | Reitwiessner | Core        | Accepted  |
 | [197](https://github.com/ethereum/EIPs/pull/212)        | Precompiled contracts for optimal Ate pairing check on the elliptic curve alt_bn128 | Buterin, Reitwiessner | Core        | Accepted  |
-| [198](https://github.com/ethereum/EIPs/pull/198)        | Precompiled contract for bigint modular exponentiation				                      | Vitalik Buterin       | Core        | Accepted  |
+| [198](https://github.com/ethereum/EIPs/pull/198)        | Precompiled contract for bigint modular exponentiation                              | Vitalik Buterin       | Core        | Accepted  |
 | [211](https://github.com/ethereum/EIPs/pull/211)        | New opcodes: RETURNDATASIZE and RETURNDATACOPY                                      | Christian Reitwiessner| Core        | Accepted  |
 | [214](https://github.com/ethereum/EIPs/pull/214)        | New opcode STATICCALL                                                               | Buterin, Reitwiessner | Core        | Accepted  |
 | [649](https://github.com/ethereum/EIPs/pull/669)        | Metropolis Difficulty Bomb Delay and Issuance Reduction                             | Schoedon, Buterin     | Core        | Accepted  |
@@ -32,13 +32,13 @@ First review [EIP-1](EIPS/eip-1.md). Then clone the repository and add your EIP 
 # Finalized EIPs (standards that have been adopted)
 | Number                                                  |Title                                                        | Author          | Layer       | Status  |
 | ------------------------------------------------------- | ----------------------------------------------------------- | ----------------| ------------| --------|
-| [2](EIPS/eip-2.md)                               | Homestead Hard-fork Changes                                 | Vitalik Buterin | Core        | Final   |
+| [2](EIPS/eip-2.md)                                      | Homestead Hard-fork Changes                                 | Vitalik Buterin | Core        | Final   |
 | [6](EIPS/eip-6.md)                                      | Renaming Suicide Opcode                                     | Hudson Jameson  | Interface   | Final   |
 | [7](EIPS/eip-7.md)                                      | DELEGATECALL                                                | Vitalik Buterin | Core        | Final   |
 | [8](EIPS/eip-8.md)                                      | devp2p Forward Compatibility Requirements for Homestead     | Felix Lange     | Networking  | Final   |
 | [141](EIPS/eip-141.md)                                  | Designated invalid EVM instruction                          | Alex Beregsazszi| Core        | Final   |
-| [150](https://github.com/ethereum/EIPs/issues/150)      | Gas cost changes for IO-heavy operations                    | Vitalik Buterin | Core        | Final   |
-| [155](https://github.com/ethereum/EIPs/issues/155)      | Simple replay attack protection                             | Vitalik Buterin | Core        | Final   |
-| [160](https://github.com/ethereum/EIPs/issues/160)      | EXP cost increase                                           | Vitalik Buterin | Core        | Final   |
-| [161](https://github.com/ethereum/EIPs/issues/161)      | State trie clearing (invariant-preserving alternative)      | Gavin Wood      | Core        | Final   |
-| [170](https://github.com/ethereum/EIPs/issues/170)      | Contract code size limit                                    | Vitalik Buterin | Core        | Final   |
+| [150](EIPS/eip-150.md)                                  | Gas cost changes for IO-heavy operations                    | Vitalik Buterin | Core        | Final   |
+| [155](EIPS/eip-155.md)                                  | Simple replay attack protection                             | Vitalik Buterin | Core        | Final   |
+| [160](EIPS/eip-160.md)                                  | EXP cost increase                                           | Vitalik Buterin | Core        | Final   |
+| [161](EIPS/eip-161.md)                                  | State trie clearing (invariant-preserving alternative)      | Gavin Wood      | Core        | Final   |
+| [170](EIPS/eip-170.md)                                  | Contract code size limit                                    | Vitalik Buterin | Core        | Final   |

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ First review [EIP-1](EIPS/eip-1.md). Then clone the repository and add your EIP 
 | [6](EIPS/eip-6.md)                                      | Renaming Suicide Opcode                                     | Hudson Jameson  | Interface   | Final   |
 | [7](EIPS/eip-7.md)                                      | DELEGATECALL                                                | Vitalik Buterin | Core        | Final   |
 | [8](EIPS/eip-8.md)                                      | devp2p Forward Compatibility Requirements for Homestead     | Felix Lange     | Networking  | Final   |
-| [141](EIPS/eip-141.md)                                  | Designated invalid EVM instruction                          | Alex Beregsazszi| Core        | Final   |
+| [141](EIPS/eip-141.md)                                  | Designated invalid EVM instruction                          | Alex Beregszaszi| Core        | Final   |
 | [150](EIPS/eip-150.md)                                  | Gas cost changes for IO-heavy operations                    | Vitalik Buterin | Core        | Final   |
 | [155](EIPS/eip-155.md)                                  | Simple replay attack protection                             | Vitalik Buterin | Core        | Final   |
 | [160](EIPS/eip-160.md)                                  | EXP cost increase                                           | Vitalik Buterin | Core        | Final   |


### PR DESCRIPTION
Once EIPs are merged and have files, links should be updated to reference the files rather than the issues.

Also a couple of whitespace fixes.