### PR TITLE
amend 161 (state trie clearing) to clarify revert behavior

### DIFF
--- a/EIPS/eip-161.md
+++ b/EIPS/eip-161.md
@@ -50,7 +50,13 @@ Same as #158 except that several edge cases are avoided since we do not break in
 
 `CREATE` avoids zero in the nonce to avoid any suggestion of the oddity of `CREATE`d accounts being reaped half-way through their creation.
 
+# Addendum (2017-08-15)
+
+On 2016-11-24, a consensus bug occurred due to two implementations having different behavior in the case of state reverts.[3] The specification was amended to clarify that empty account deletions are reverted when the state is reverted.
+
 # References
 
 1. EIP-158 issue and discussion: https://github.com/ethereum/EIPs/issues/158
 2. EIP-161 issue and discussion: https://github.com/ethereum/EIPs/issues/161
+3. https://blog.ethereum.org/2016/11/25/security-alert-11242016-consensus-bug-geth-v1-4-19-v1-5-2/
+> Details: Geth was failing to revert empty account deletions when the transaction causing the deletions of empty accounts ended with an an out-of-gas exception. An additional issue was found in Parity, where the Parity client incorrectly failed to revert empty account deletions in a more limited set of contexts involving out-of-gas calls to precompiled contracts; the new Geth behavior matches Parity’s, and empty accounts will cease to be a source of concern in general in about one week once the state clearing process finishes.


### PR DESCRIPTION
When EIP 161 was initially implemented in ethereumjs-vm, it also failed to revert empty account deletions. This clarification should be noted in the EIP text.