### PR TITLE
Add a Chain-ID reservation for Ethereum-Vega.

### DIFF
--- a/EIPS/eip-155.md
+++ b/EIPS/eip-155.md
@@ -55,6 +55,8 @@ This would provide a way to send transactions that work on ethereum without work
 | 2              | Morden (disused), Expanse mainnet          |
 | 3              | Ropsten                                    |
 | 4              | Rinkeby                                    |
+| 7              | Ethereum Vega mainnet                      | 
+| 8              | Ethereum Vega testnet                      |
 | 30             | Rootstock mainnet                          |
 | 31             | Rootstock testnet                          |
 | 42             | Kovan                                      |


### PR DESCRIPTION
As a counter plan for Replay-attacks that is expected to be occur after Byzantium fork,
Our Ethereum-Vega developers decided to use EIP-155 as a method for defensing those attacks.
Therefore, we are using 7,8 as a new Chain-ID value.

See opcahf.co , github.com/cahf/EVA-00 for further information.