### PR TITLE
Replace a METROPOLIS with BYZANTIUM

### DIFF
--- a/EIPS/eip-100.md
+++ b/EIPS/eip-100.md
@@ -18,7 +18,7 @@ child_diff = int(max(parent.difficulty + (parent.difficulty // BLOCK_DIFF_FACTOR
 ...
 ```
 
-If `block.number >= METROPOLIS_FORK_BLKNUM`, we change the first line to the following:
+If `block.number >= BYZANTIUM_FORK_BLKNUM`, we change the first line to the following:
 
 ``` python
 adj_factor = max((2 if len(parent.uncles) else 1) - ((timestamp - parent.timestamp) // 9), -99)


### PR DESCRIPTION
I merged an EIP by mistake with `METROPOLIS` in it.  The fork should now be called `BYZANTIUM`.
