### PR TITLE
Fix a title of a Byzantium EIP

### DIFF
--- a/EIPS/eip-609.md
+++ b/EIPS/eip-609.md
@@ -21,15 +21,15 @@ This specifies the changes included in the hard fork named Byzantium.
   - Block >= 4,370,000 on Mainnet
   - Block >= 1,700,000 on Ropsten testnet
 - Included EIPs:
-  - EIP 100 (Change difficulty adjustment to target mean block time including uncles)
+  - [EIP 100](./eip-100.md) (Change difficulty adjustment to target mean block time including uncles)
   - EIP 140 (REVERT instruction in the Ethereum Virtual Machine)
   - EIP 196 (Precompiled contracts for addition and scalar multiplication on the elliptic curve alt_bn128)
   - EIP 197 (Precompiled contracts for optimal ate pairing check on the elliptic curve alt_bn128)
   - EIP 198 (Precompiled contract for bigint modular exponentiation)
   - EIP 211 (New opcodes: RETURNDATASIZE and RETURNDATACOPY)
   - EIP 214 (New opcode STATICCALL)
-  - EIP 649 (Difficulty Bomb Delay and Block Reward Reduction)
-  - EIP 658 (Embedding transaction return data in receipts)
+  - [EIP 649](./eip-649.md) (Difficulty Bomb Delay and Block Reward Reduction)
+  - [EIP 658](./eip-658.md) (Embedding transaction status code in receipts)
   
 ## References
 


### PR DESCRIPTION
This PR modifies a title of an EIP in the Byzantium EIP list.  The title has already been changed in the EIP itself.