### PR TITLE
Remove link to force 0 implementation

### DIFF
--- a/EIPS/eip-20-token-standard.md
+++ b/EIPS/eip-20-token-standard.md
@@ -177,8 +177,5 @@ Different implementations have been written by various teams that have different
 - https://github.com/OpenZeppelin/zeppelin-solidity/blob/master/contracts/token/StandardToken.sol
 - https://github.com/ConsenSys/Tokens/blob/master/contracts/StandardToken.sol
 
-#### Implementation of adding the force to 0 before calling "approve" again:
-- https://github.com/Giveth/minime/blob/master/contracts/MiniMeToken.sol
-
 ## Copyright
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
About forcing 0 before non 0 approve, the standard states "THOUGH The contract itself shouldn't enforce it, to allow backwards compatibility with contracts deployed before".
But in the implementation, it lists a token forcing the 0 for approve, which is a violation of the standard.
This is quite confusing. Therefore I propose to remove the link to implementations not following the standard.

When opening a pull request to submit a new EIP, please use the suggested template: https://github.com/ethereum/EIPs/blob/master/eip-X.md
