### PR TITLE
Add 'Copyright Waiver' to 'What belongs in a successful EIP?'

### DIFF
--- a/EIPS/eip-1.md
+++ b/EIPS/eip-1.md
@@ -103,6 +103,10 @@ Each EIP should have the following parts:
 
 -   Implementations - The implementations must be completed before any EIP is given status “Final”, but it need not be completed before the EIP is accepted. While there is merit to the approach of reaching consensus on the specification and rationale before writing code, the principle of “rough consensus and running code” is still useful when it comes to resolving many discussions of API details.
 
+<!-- -->
+
+-   Copyright Waiver - All EIPs must be in public domain. See the bottom of this EIP for an example copyright waiver.
+
 EIP Formats and Templates
 -------------------------
 


### PR DESCRIPTION
In [the last Core Devs meeting](https://github.com/ethereum/pm/issues/27), there was a consensus that EIPs should be licenced with CC0.
