### PR TITLE
Move the sentence about Transfer event at creation

### DIFF
--- a/EIPS/eip-20-token-standard.md
+++ b/EIPS/eip-20-token-standard.md
@@ -96,8 +96,6 @@ function balanceOf(address _owner) constant returns (uint256 balance)
 Transfers `_value` amount of tokens to address `_to`, and MUST fire the `Transfer` event.
 The function SHOULD `throw` if the `_from` account balance does not have enough tokens to spend.
 
-A token contract which creates new tokens SHOULD trigger a Transfer event with the `_from` address set to `0x0` when tokens are created.
-
 *Note* Transfers of 0 values MUST be treated as normal transfers and fire the `Transfer` event.
 
 ``` js
@@ -151,6 +149,8 @@ function allowance(address _owner, address _spender) constant returns (uint256 r
 #### Transfer
 
 MUST trigger when tokens are transferred, including zero value transfers.
+
+A token contract which creates new tokens SHOULD trigger a Transfer event with the `_from` address set to `0x0` when tokens are created.
 
 ``` js
 event Transfer(address indexed _from, address indexed _to, uint256 _value)


### PR DESCRIPTION
In the current file, the sentence "A token contract which creates new tokens SHOULD trigger a Transfer event with the _from address set to 0x0 when tokens are created." is part of the "transfer" method section.
This sentences is linked to the "Transfer" event, not the "transfer" method.
I suggest to move it to the appropriate "Transfer" section.
