### PR TITLE
Canary Interface ERC

### DIFF
--- a/EIPS/eip-801.md
+++ b/EIPS/eip-801.md
@@ -55,7 +55,7 @@ Returns the type of the canary:
 * `5` = Multiple mandatory feeders (as defined in ERC-TBD)
 * `6` = IOT (as defined in ERC-TBD)
 
-`1` might also be used for a special purpose contract that does not need a special type but still want to expose the functions and provide events as defined in this ERC.
+`1` might also be used for a special purpose contract that does not need a special type but still wants to expose the functions and provide events as defined in this ERC.
 
 ``` js
 function getType() constant returns (uint8 type)
@@ -65,7 +65,7 @@ function getType() constant returns (uint8 type)
 
 #### RIP
 
-MUST trigger when the canary died.
+MUST trigger when the contract is called the first time after the canary died.
 
 ``` js
 event RIP()

--- a/EIPS/eip-canary-standard.md
+++ b/EIPS/eip-canary-standard.md
@@ -2,7 +2,7 @@
 
     EIP: 801
     Title: ERC-801 Canary Standard
-    Author: ligi<ligi@ligi.de>
+    Author: ligi <ligi@ligi.de>
     Type: Standard
     Category: ERC
     Status: Draft
@@ -29,89 +29,46 @@ A standard interface allows other applications to easily interface with canaries
 
 #### isAlive()
 
-Returns if the canary was feed properly to signal e.g. that no warrant was received.
+Returns if the canary was fed properly to signal e.g. that no warrant was received.
 
 ``` js
 function isAlive() constant returns (bool alive)
 ```
 
-#### timeToLive()
+#### getBlockOfDeath()
 
-The time in seconds that can elapse between feed() calls without starving the canary dead.
+Returns the block the canary died.
+Throws if the canary is alive.
 
 ``` js
-function timeToLive() constant returns (uint256 ttl)
+function getBlockOfDeath() constant returns (uint256 block)
 ```
 
-#### feed()
+#### getType()
 
-Extend the life of the canary by timeToLive() seconds.
+Returns the type of the canary:
 
-**NOTE**: this should trigger the event listed below
+* `1` = Simple (just the pure interface as defined in this ERC)
+* `2` = Single feeder (as defined in ERC-TBD)
+* `3` = Single feeder with bad food (as defined in ERC-TBD)
+* `4` = Multiple feeders (as defined in ERC-TBD)
+* `5` = Multiple mandatory feeders (as defined in ERC-TBD)
+* `6` = IOT (as defined in ERC-TBD)
 
-``` js
-function feed()
-```
-
-#### poison()
-
-Kills the canary instantly. E.g. in a urgent case when a warrant was received.
-
-``` js
-function poison()
-```
-
-#### (optional) addFeeder(address feeder)
-
-Add address that is allowed to feed (and therefore also poison) the canary.
+`1` might also be used for a special purpose contract that does not need a special type but still want to expose the functions and provide events as defined in this ERC.
 
 ``` js
-function addFeeder(address feeder)
-```
-
-#### (optional) removeFeeder(address feeder)
-
-Remove address that is allowed to feed the canary.
-
-``` js
-function removeFeeder(address feeder)
-```
-
-#### (optional) getFeederCount()
-
-Returns the count of addresses that are allowed to feed the canary.
-
-``` js
-function getFeederCount() constant returns (int count)
-```
-
-#### (optional) getFeederByIndex(unit8 index)
-
-Returns the address of the feeder at the given index.
-
-``` js
-function getFeederByIndex(unit8 index) constant returns (address feederAddress)
-```
-
-#### (optional) needsAllFeeders()
-
-When true: all feeders need to call feed() in the intervals defined by timeToLive() - analog to a multisig.
-When false: all the feeders can extend the lifespan of the canary.
-
-This does not affect poisoning - one feeder is always enough to kill the canary.
-
-``` js
-function needsAllFeeders() constant returns (bool needsAllFeeders)
+function getType() constant returns (uint8 type)
 ```
 
 ### Events
 
-#### Feed
+#### RIP
 
-MUST trigger when the canary got food.
+MUST trigger when the canary died.
 
 ``` js
-event Feed(address feeder)
+event RIP()
 ```
 
 ## Implementation

--- a/EIPS/eip-canary-standard.md
+++ b/EIPS/eip-canary-standard.md
@@ -1,0 +1,122 @@
+## Preamble
+
+    EIP: 801
+    Title: ERC-801 Canary Standard
+    Author: ligi<ligi@ligi.de>
+    Type: Standard
+    Category: ERC
+    Status: Draft
+    Created: 2017-12-16
+
+
+## Simple Summary
+
+A standard interface for canary contracts.
+
+## Abstract
+
+The following standard allows the implementation of canaries within contracts.
+This standard provides basic functionality to check if a canary is alive, keeping the canary alive and optionally manage feeders.
+
+## Motivation
+
+The canary can e.g. be used as a [warrant canary](https://en.wikipedia.org/wiki/Warrant_canary).
+A standard interface allows other applications to easily interface with canaries on Ethereum - e.g. for visualizing the state, automated alarms, applications to feed the canary or contracts (e.g. insurance) that use the state.
+
+## Specification
+
+### Methods
+
+#### isAlive()
+
+Returns if the canary was feed properly to signal e.g. that no warrant was received.
+
+``` js
+function isAlive() constant returns (bool alive)
+```
+
+#### timeToLive()
+
+The time in seconds that can elapse between feed() calls without starving the canary dead.
+
+``` js
+function timeToLive() constant returns (uint256 ttl)
+```
+
+#### feed()
+
+Extend the life of the canary by timeToLive() seconds.
+
+**NOTE**: this should trigger the event listed below
+
+``` js
+function feed()
+```
+
+#### poison()
+
+Kills the canary instantly. E.g. in a urgent case when a warrant was received.
+
+``` js
+function poison()
+```
+
+#### (optional) addFeeder(address feeder)
+
+Add address that is allowed to feed (and therefore also poison) the canary.
+
+``` js
+function addFeeder(address feeder)
+```
+
+#### (optional) removeFeeder(address feeder)
+
+Remove address that is allowed to feed the canary.
+
+``` js
+function removeFeeder(address feeder)
+```
+
+#### (optional) getFeederCount()
+
+Returns the count of addresses that are allowed to feed the canary.
+
+``` js
+function getFeederCount() constant returns (int count)
+```
+
+#### (optional) getFeederByIndex(unit8 index)
+
+Returns the address of the feeder at the given index.
+
+``` js
+function getFeederByIndex(unit8 index) constant returns (address feederAddress)
+```
+
+#### (optional) needsAllFeeders()
+
+When true: all feeders need to call feed() in the intervals defined by timeToLive() - analog to a multisig.
+When false: all the feeders can extend the lifespan of the canary.
+
+This does not affect poisoning - one feeder is always enough to kill the canary.
+
+``` js
+function needsAllFeeders() constant returns (bool needsAllFeeders)
+```
+
+### Events
+
+#### Feed
+
+MUST trigger when the canary got food.
+
+``` js
+event Feed(address feeder)
+```
+
+## Implementation
+
+TODO
+
+## Copyright
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
The canary can e.g. be used as a [warrant canary](https://en.wikipedia.org/wiki/Warrant_canary).
A standard interface allows other applications to easily interface with canaries on Ethereum - e.g. for visualizing the state, automated alarms, apps to feed the canary or contracts (e.g. insurance) that use the data.

Solves the following problems with current (warrant) canaries:

> In addition to a digital signature, it provides a recent news headline as proof that the warrant canary was recently posted as well as mirroring the posting internationally.
>
> Source: https://en.wikipedia.org/wiki/Warrant_canary

Signing a news headline is more work and less secure than using Ethereum for this task. The effort it takes to sign a news headline also leads to organisations not going this route at all and e.g. just adding a signal to twitter or some other site - which is way less secure and brittle.

> the fact that canaries are non-standard makes it difficult to automatically monitor them for changes or takedowns
>
> Source: Quintin, Cooper (25 May 2016). "Canary Watch – One Year Later". Electronic Frontier Foundation. https://www.eff.org/deeplinks/2016/05/canary-watch-one-year-later

ERC-801 could be the standard to solve this problem

in the same post:

> Yet, in our time working with Canary Watch we have seen many canaries go away and come back, fail to be updated, or disappear altogether along with the website that was hosting it. 

The immutability of Ethereum can also help here. 
As far as I see a lot of problems that are outlined in the post could be solved by leveraging Ethereum for this use-case - this gives me hope that it could even bring back https://canarywatch.org or lead to a similar service as there is no more need for an authority like the EFF to do the otherwise difficult task of interpreting  the canary state.

Makes it also possible to keep the canaries alive with hardware wallets and improve security this way.