### PR TITLE
Fix broken ConsenSys link in eip-20-token-standard.md

### DIFF
--- a/EIPS/eip-20-token-standard.md
+++ b/EIPS/eip-20-token-standard.md
@@ -175,7 +175,7 @@ Different implementations have been written by various teams that have different
 
 #### Example implementations are available at
 - https://github.com/OpenZeppelin/zeppelin-solidity/blob/master/contracts/token/StandardToken.sol
-- https://github.com/ConsenSys/Tokens/blob/master/contracts/StandardToken.sol
+- https://github.com/ConsenSys/Tokens/blob/master/contracts/eip20/EIP20.sol
 
 #### Implementation of adding the force to 0 before calling "approve" again:
 - https://github.com/Giveth/minime/blob/master/contracts/MiniMeToken.sol


### PR DESCRIPTION
Fix broken link to https://github.com/ConsenSys/Tokens/blob/master/contracts/StandardToken.sol, as ConsenSys renamed it to https://github.com/ConsenSys/Tokens/blob/master/contracts/eip20/EIP20.sol and made other associated changes recently in this commit https://github.com/ConsenSys/Tokens/commit/44c3a1e46dc9b5e49c65f20bddad1f7ad9e7e3fa

When opening a pull request to submit a new EIP, please use the suggested template: https://github.com/ethereum/EIPs/blob/master/eip-X.md
