### PR TITLE
Update EIP-162 as Standard Track with category ERC

### DIFF
--- a/EIPS/eip-162.md
+++ b/EIPS/eip-162.md
@@ -3,7 +3,8 @@ EIP: 162
 Title: Initial ENS Hash Registrar
 Author: Maurelian and Nick Johnson
 Status: Final
-Type: Informational
+Type: Standards Track
+Category: ERC
 Created: 2016-10-25
 ```
 


### PR DESCRIPTION
The header for this EIP was not consistent with EIP-1 which defines that and ERC is of type Standard Track.
Also added the sub category for clarity.
