### PR TITLE
Added historical links to ERC20

### DIFF
--- a/EIPS/eip-20-token-standard.md
+++ b/EIPS/eip-20-token-standard.md
@@ -180,5 +180,17 @@ Different implementations have been written by various teams that have different
 #### Implementation of adding the force to 0 before calling "approve" again:
 - https://github.com/Giveth/minime/blob/master/contracts/MiniMeToken.sol
 
+
+
+## History
+
+Historical links releated to this standard:
+
+- Orginial proposal from Vitalik Buterin: https://github.com/ethereum/wiki/wiki/Standardized_Contract_APIs/499c882f3ec123537fc2fccd57eaa29e6032fe4a
+- Reddit discussion: https://www.reddit.com/r/ethereum/comments/3n8fkn/lets_talk_about_the_coin_standard/
+- Original Issue #20: https://github.com/ethereum/EIPs/issues/20
+
+
+
 ## Copyright
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
This PR adds historical links to the ERC 20 standard, so that people can follow the discussion up until the finalisation, and why certain choices where made.