### PR TITLE
Limit title length

### DIFF
--- a/eip-X.md
+++ b/eip-X.md
@@ -14,6 +14,7 @@ Note that an EIP number will be assigned by an editor. When opening a pull reque
     Requires (*optional): <EIP number(s)>
     Replaces (*optional): <EIP number(s)>
 
+The title should be 44 characters or less.
 
 ## Simple Summary
 "If you can't explain it simply, you don't understand it well enough." Provide a simplified and layman-accessible explanation of the EIP.


### PR DESCRIPTION
Source of specification: 

https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1.md#what-belongs-in-a-successful-eip

> Preamble - RFC 822 style headers containing metadata about the EIP, including the EIP number, a short descriptive title (limited to a maximum of 44 characters), the names, and optionally the contact info for each author, etc.
