### PR TITLE
EIP-161: Grammar fixes and block fork number parameters

### DIFF
--- a/EIPS/eip-161.md
+++ b/EIPS/eip-161.md
@@ -7,10 +7,14 @@ Category: Core
 Status: Final
 Created: 2016-10-24
 ```
+### Hard fork
+[Spurious Dragon](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-607.md)
+
 ### Parameters
 - `FORK_BLKNUM`: 2,675,000
 - `CHAIN_ID`: 1
-# Specification
+
+### Specification
 
 a. Account creation transactions and the `CREATE` operation SHALL, prior to the execution of the initialisation code, **increment** the **nonce** over and above its normal starting value by **one** (for normal networks, this will be simply 1, however test-nets with non-zero default starting nonces will be different).
 
@@ -36,7 +40,7 @@ An account _changes state_ when:
 - it is the source or creation of a `CREATE` operation or contract-creation transaction endowing **zero or more** value;
 - as the block author ("miner") it is the recipient of block-rewards or transaction-fees of **zero or more** value.
 
-## Notes
+#### Notes
 
 In the present Ethereum protocol, it should be noted that very few state changes can ultimately result in accounts that are empty following the execution of the transaction. In fact there are only four contexts that current implementations need track:
 - an empty account has zero value transferred to it through `CALL`;
@@ -44,7 +48,7 @@ In the present Ethereum protocol, it should be noted that very few state changes
 - an empty account has zero value transferred to it through a message-call transaction;
 - an empty account has zero value transferred to it through a zero-gas-price fees transfer.
 
-# Rationale
+### Rationale
 
 Same as #158 except that several edge cases are avoided since we do not break invariants:
 - ~~that an account can go from having code and storage to not having code or storage mid-way through the execution of a transaction;~~ [corrected]
@@ -52,11 +56,11 @@ Same as #158 except that several edge cases are avoided since we do not break in
 
 `CREATE` avoids zero in the nonce to avoid any suggestion of the oddity of `CREATE`d accounts being reaped half-way through their creation.
 
-# Addendum (2017-08-15)
+### Addendum (2017-08-15)
 
 On 2016-11-24, a consensus bug occurred due to two implementations having different behavior in the case of state reverts.[3] The specification was amended to clarify that empty account deletions are reverted when the state is reverted.
 
-# References
+### References
 
 1. EIP-158 issue and discussion: https://github.com/ethereum/EIPs/issues/158
 2. EIP-161 issue and discussion: https://github.com/ethereum/EIPs/issues/161

--- a/EIPS/eip-161.md
+++ b/EIPS/eip-161.md
@@ -12,7 +12,7 @@ Created: 2016-10-24
 
 ### Parameters
 - `FORK_BLKNUM`: 2,675,000
-- `CHAIN_ID`: 1
+- `CHAIN_ID`: 1 (main net)
 
 ### Specification
 

--- a/EIPS/eip-161.md
+++ b/EIPS/eip-161.md
@@ -7,7 +7,9 @@ Category: Core
 Status: Final
 Created: 2016-10-24
 ```
-
+### Parameters
+- `FORK_BLKNUM`: 2,675,000
+- `CHAIN_ID`: 1
 # Specification
 
 a. Account creation transactions and the `CREATE` operation SHALL, prior to the execution of the initialisation code, **increment** the **nonce** over and above its normal starting value by **one** (for normal networks, this will be simply 1, however test-nets with non-zero default starting nonces will be different).
@@ -31,8 +33,8 @@ _At the end of the transaction_ is immediately following the execution of the su
 An account _changes state_ when:
 - it is the target or refund of a `SUICIDE` operation for **zero or more** value;
 - it is the source or destination of a `CALL` operation or message-call transaction transferring **zero or more** value;
-- it is the source or newly-creation of a `CREATE` operation or contract-creation transaction endowing **zero or more** value;
-- as the block author ("miner") it is recipient of block-rewards or transaction-fees of **zero or more**.
+- it is the source or creation of a `CREATE` operation or contract-creation transaction endowing **zero or more** value;
+- as the block author ("miner") it is the recipient of block-rewards or transaction-fees of **zero or more** value.
 
 ## Notes
 


### PR DESCRIPTION
Newly-creation: this is wrong. You use adverbs before verbs. Creation implies that it is new, so it is a tautology to say new creation or newly created; rather like "I killed him dead".