### PR TITLE
Include EIP 8 in EIP 606

### DIFF
--- a/EIPS/eip-606.md
+++ b/EIPS/eip-606.md
@@ -22,6 +22,7 @@ This specifies the changes included in the hard fork named Homestead.
 - Included EIPs:
   - [EIP 2](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-2.md) (Homestead Hard-fork Changes)
   - [EIP 7](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7.md) (DELEGATECALL)
+  - [EIP 8](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-8.md) (Networking layer: devp2p Forward Compatibility Requirements for Homestead)
   
 ## References
 


### PR DESCRIPTION
As per https://blog.ethereum.org/2016/02/29/homestead-release/.