### PR TITLE
Note that EIP-86 is going to be replaced

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ First review [EIP-1](EIPS/eip-1.md). Then clone the repository and add your EIP 
 # Deferred EIPs
 | Number                                             | Title                                                                                        | Author                                     | Layer      | Status   |
 | -------------------------------------------------- | -------------------------------------------------------------------------------------------- | ------------------------------------------ | ---------- | -------- |
-| [86](https://github.com/ethereum/EIPs/pull/208)    | Abstraction of transaction origin and signature                                              | Vitalik Buterin                            | Core       | Deferred |
+| [86](https://github.com/ethereum/EIPs/pull/208)    | Abstraction of transaction origin and signature                                              | Vitalik Buterin                            | Core       | Deferred (to be replaced) |
 | [96](https://github.com/ethereum/EIPs/pull/210)    | Blockhash refactoring                                                                        | Vitalik Buterin                            | Core       | Deferred |
 | [145](EIPS/eip-145.md)                             | Bitwise shifting instructions in EVM                                                         | Alex Beregszaszi, Paweł Bylica             | Core       | Deferred |
 


### PR DESCRIPTION
In [today's coredev meeting](https://github.com/ethereum/pm/issues/30), it was noted that EIP-86 is going to be replaced with another EIP.  This PR indicates that in the "Deferred EIPs" table in README.md.