### PR TITLE
Reduce block reward

### DIFF
--- a/EIPS/eip-858.md
+++ b/EIPS/eip-858.md
@@ -1,6 +1,6 @@
 ## Preamble
 
-    EIP: <to be assigned>
+    EIP: 858
     Title: Reduce block reward
     Author: Carl Larson <cslarson@gmail.com>
     Type: Standard Track

--- a/EIPS/eip-reduce_block_reward.md
+++ b/EIPS/eip-reduce_block_reward.md
@@ -1,0 +1,38 @@
+## Preamble
+
+    EIP: <to be assigned>
+    Title: Reduce block reward
+    Author: Carl Larson <cslarson@gmail.com>
+    Type: Standard Track
+    Category: Core
+    Status: Draft
+    Created: 2018-01-29
+
+## Simple Summary
+Reduce the block reward to 1 ETH.
+
+## Abstract
+The current public Ethereum network has a hashrate that corresponds to a tremendous level of energy consumption. As this energy consumption has a correlated environmental cost the network participants have an ethical obligation to ensure this cost is not higher than necessary. At this time, the most direct way to reduce this cost is to lower the block reward in order to limit the appeal of ETH mining. Unchecked growth in hashrate is also counterproductive from a security standpoint.
+
+## Motivation
+The current public Ethereum network has a hashrate of 205 TH/s). This hashrate corresponds to a **lower bound** for power usage of roughly 710MW, which would correspond to a yearly energy consumption of 6.2TWh (roughly 0.03% of [total](https://en.wikipedia.org/wiki/List_of_countries_by_electricity_consumption) global electricity consumption). [Assuming](http://www.carbonindependent.org/sources_home_energy.html) a rate of carbon emmisions of 0.527 kg/kWh this means at it's present hashrate the network contributes more than 1 million tons of CO2 per month. These numbers assume the [best GPU, perfectly overclocked](http://www.legitreviews.com/geforce-gtx-1070-ethereum-mining-small-tweaks-great-hashrate-low-power_195451), and running on a PC without it's own power draw, so again the true numbers are likely much higher. A future switch to full Proof of Stake will solve this issue entirely. Yet that switch remains enough in the future that action should be taken in the interim to limit excess harmful side affects of the present network.
+
+## Specification
+Block reward to be changed to 1 ETH / block.
+If any resulting hard forks need a name for that name to maybe be Perinthos.
+
+## Rationale
+partly TBD
+The network hashrate provides security by reducing the likelihood that an adversary could mount a 51% attack. A static block reward means that factors (price) may be such that participation in mining grows unchecked. This growth may be counterproductive and work to also grow and potential pool of adversaries. The means we have to arrest this growth is to reduce the appeal of mining and the most direct way to do that is to reduce the block reward.
+
+## Backwards Compatibility
+This EIP is consensus incompatible with the current public Ethereum chain and would cause a hard fork when enacted. The resulting fork would allow users to chose between two chains: a chain with a block reward of 1 ETH/block and another with a block reward of 3 ETH/block. This is a good choice to allow users to make.
+
+## Test Cases
+Tests have, as yet, not been completed.
+
+## Implementation
+A [fork of the go repo](https://github.com/cslarson/go-ethereum/tree/reduce-block-reward) with changes to reflect a block reward reduced to 1 ETH, activated at a fork to be called Perinthos.
+
+## Copyright
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
This EIP is proposal to reduce the block reward to 1 ETH / block from the present 3 ETH / block at a future, as present unplanned hard fork to be named Perinthos (before Constantinople). The rationale for reducing the block reward stems from the present tremendous growth in hashrate (and corresponding environmental costs) as well as the counter-productiveness of fostering growth in GPU mining.