### PR TITLE
EIP-868: Node Discovery v4 ENR Extension

### DIFF
--- a/EIPS/eip-868.md
+++ b/EIPS/eip-868.md
@@ -1,0 +1,54 @@
+# Preamble
+
+    EIP: 868
+    Title: Node Discovery v4 ENR Extension
+    Author: Felix Lange <fjl@ethereum.org>
+    Type: Standard Track
+    Category: Networking
+    Status: Draft
+    Created: 2018-02-02
+    Requires: EIP-8, EIP-778
+
+# Abstract
+
+This EIP defines an extension to Node Discovery Protocol v4 to enable authoritative
+resolution of Ethereum Node Records (ENR).
+
+# Motivation
+
+To bridge current and future discovery networks and to aid the implementation of other
+relay mechanisms for ENR such as DNS, we need a way to request the most up-to-date version
+of a node record.
+
+# Specification
+
+Implementations of Node Discovery Protocol v4 should support two new packet types, a request
+and reply of the node record. The new packets are:
+
+### enrRequest (0x05)
+
+RLP: `[ expiration ]`
+
+When a packet of this type is received, the node should reply with an enrResponse packet
+containing the current version of its record.
+
+To guard against amplification attacks, the sender of enrRequest should have replied to a
+ping packet recently. The expiration field, a UNIX timestamp, should be handled as for all
+other existing packets, i.e. no reply should be sent if it refers to a time in the past.
+
+### enrResponse (0x06)
+
+RLP: `[ requestHash, ENR ]`
+
+This packet is the response to enrRequest. 
+
+- `requestHash` is the hash of the entire enrRequest packet being replied to.
+- `ENR` is the node record.
+
+The recipient of the packet should verify that the node record is signed by node who
+sent enrResponse.
+
+# Copyright
+
+Copyright and related rights waived via CC0.
+


### PR DESCRIPTION
This EIP defines an extension to Node Discovery Protocol v4 to enable authoritative
resolution of [Ethereum Node Records (ENR)](https://github.com/ethereum/EIPs/pull/778).
