### PR TITLE
 Remove deedName()

### DIFF
--- a/EIPS/eip-721.md
+++ b/EIPS/eip-721.md
@@ -1,0 +1,312 @@
+## Preamble
+
+```
+EIP: <to be assigned>
+Title: ERC-721 Deed Standard
+Author: William Entriken <github.com@phor.net>, Dieter Shirley <dete@axiomzen.co>
+Type: Standard
+Category ERC
+Status: Draft
+Created: 2018-01-31
+```
+
+## Simple Summary
+
+A standard interface for deeds, also known as non-fungible tokens.
+
+## Abstract
+
+**This a standard interface for smart contracts to handle deed ownership.** Deeds can represent ownership of physical property, like houses, or digital property, like unique pictures of kittens. In general, all houses are distinct and no two kittens are alike. Therefore you must track each deed separately; it is insufficient to simply count the deeds you own.
+
+The scope of this interface includes **interrogating the smart contract about deed ownership**. It also **allows deed owners to transfer assets**. The authors considered uses cases of individual deed ownership as well as custody by third party brokers/wallets/auctioneers.
+
+## Motivation
+
+A standard interface allows wallet/broker/auctioneer applications to work with any deed on Ethereum. This contract considers simple deed contracts as well as contract that track large number of deeds. Additional applications are discussed below.
+
+This standard is inspired by [the ERC-20 token standard](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20-token-standard.md) and builds on two years of experience since EIP-20 was created. EIP-20 is insufficient for tracking deed ownership because each deed is distinct (non-fungible) whereas each token is identical (fungible).
+
+Differences between this standard and EIP-20 are examined below.
+
+## Specification
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
+
+The **baseline specification** is REQUIRED for all ERC-721 implementations (subject to "caveats", below).
+
+```solidity
+pragma solidity ^0.4.19;
+
+/// @title Interface for contracts conforming to ERC-721: Deed Standard
+/// @author William Entriken (https://phor.net), et. al.
+/// @dev Specification at https://github.com/ethereum/eips/XXXFinalUrlXXX
+interface ERC721 {
+
+    // COMPLIANCE WITH ERC-165 (DRAFT) /////////////////////////////////////////
+
+    /// @dev ERC-165 (draft) interface signature for itself
+    // bytes4 internal constant INTERFACE_SIGNATURE_ERC165 = // 0x01ffc9a7
+    //     bytes4(keccak256('supportsInterface(bytes4)'));
+
+    /// @dev ERC-165 (draft) interface signature for ERC721
+    // bytes4 internal constant INTERFACE_SIGNATURE_ERC721 = // 0xe55729f5
+    //     bytes4(keccak256('ownerOf(uint256)')) ^
+    //     bytes4(keccak256('countOfDeeds()')) ^
+    //     bytes4(keccak256('countOfDeedsByOwner(address)')) ^
+    //     bytes4(keccak256('deedOfOwnerByIndex(uint256)')) ^
+    //     bytes4(keccak256('approve(address,uint256)')) ^
+    //     bytes4(keccak256('takeOwnership(uint256)'));
+
+    /// @notice Query a contract to see if it supports a certain interface
+    /// @dev Returns `true` the interface is supported and `false` otherwise,
+    ///  returns `true` for INTERFACE_SIGNATURE_ERC165 and
+    ///  INTERFACE_SIGNATURE_ERC721, see ERC-165 for other interface signatures.
+    function supportsInterface(bytes4 _interfaceID) external pure returns (bool);
+
+    // PUBLIC QUERY FUNCTIONS //////////////////////////////////////////////////
+
+    /// @notice Find the owner of a deed
+    /// @param _deedId The identifier for a deed we are inspecting
+    /// @dev Deeds assigned to zero address are considered destroyed, and
+    ///  queries about them do throw.
+    /// @return The non-zero address of the owner of deed `_deedId`, or `throw`
+    ///  if deed `_deedId` is not tracked by this contract
+    function ownerOf(uint256 _deedId) external view returns (address _owner);
+
+    /// @notice Count deeds tracked by this contract
+    /// @return A count of the deeds tracked by this contract, where each one of
+    ///  them has an assigned and queryable owner
+    function countOfDeeds() external view returns (uint256 _count);
+
+    /// @notice Count all deeds assigned to an owner
+    /// @dev Throws if `_owner` is the zero address, representing destroyed deeds.
+    /// @param _owner An address where we are interested in deeds owned by them
+    /// @return The number of deeds owned by `_owner`, possibly zero
+    function countOfDeedsByOwner(address _owner) external view returns (uint256 _count);
+
+    /// @notice Enumerate deeds assigned to an owner
+    /// @dev Throws if `_index` >= `countOfDeedsByOwner(_owner)` or if
+    ///  `_owner` is the zero address, representing destroyed deeds.
+    /// @param _owner An address where we are interested in deeds owned by them
+    /// @param _index A counter between zero and `countOfDeedsByOwner(_owner)`,
+    ///  inclusive
+    /// @return The identifier for the `_index`th deed assigned to `_owner`,
+    ///   (sort order not specified)
+    function deedOfOwnerByIndex(address _owner, uint256 _index) external view returns (uint256 _deedId);
+
+    // TRANSFER MECHANISM //////////////////////////////////////////////////////
+
+    /// @dev This event emits when ownership of any deed changes by any
+    ///  mechanism. This event emits when deeds are created (`from` == 0) and
+    ///  destroyed (`to` == 0). Exception: during contract creation, any
+    ///  transfers may occur without emitting `Transfer`.
+    event Transfer(address indexed from, address indexed to, uint256 indexed deedId);
+
+    /// @dev This event emits on any successful call to
+    ///  `approve(address _spender, uint256 _deedId)`. Exception: does not emit
+    ///  if an owner revokes approval (`_to` == 0x0) on a deed with no existing
+    ///  approval.
+    event Approval(address indexed owner, address indexed approved, uint256 indexed deedId);
+
+    /// @notice Approve a new owner to take your deed, or revoke approval by
+    ///  setting the zero address. You may `approve` any number of times while
+    ///  the deed is assigned to you, only the most recent approval matters.
+    /// @dev Throws if `msg.sender` does not own deed `_deedId` or if `_to` ==
+    ///  `msg.sender`.
+    /// @param _deedId The deed you are granting ownership of
+    function approve(address _to, uint256 _deedId) external payable;
+
+    /// @notice Become owner of a deed for which you are currently approved
+    /// @dev Throws if `msg.sender` is not approved to become the owner of
+    ///  `deedId` or if `msg.sender` currently owns `_deedId`.
+    /// @param _deedId The deed that is being transferred
+    function takeOwnership(uint256 _deedId) external payable;
+}
+```
+
+Implementations MAY also choose to implement the **ERC-721 Metadata extension**. This is RECOMMENDED and will allow third party wallets to show your deeds in the best way. It will be a lot more flattering than
+
+> You just received deed ID `0xb9d6a94f1ab16f461b2af06aebab7e1cfe10ada985da001f274f370fbb848a40` from contract `0x0dcd2f752394c41875e259e00bb44fd505297caf`!
+
+```
+/// @title Metadata extension to ERC-721 interface
+/// @author William Entriken (https://phor.net)
+/// @dev Specification at https://github.com/ethereum/eips/issues/XXXX
+interface ERC721Metadata is ERC721 {
+
+    /// @dev ERC-165 (draft) interface signature for ERC721
+    // bytes4 internal constant INTERFACE_SIGNATURE_ERC721Metadata = // 0x2a786f11
+    //     bytes4(keccak256('name()')) ^
+    //     bytes4(keccak256('symbol()')) ^
+    //     bytes4(keccak256('deedUri(uint256)'));
+
+    /// @notice A descriptive name for a collection of deeds managed by this
+    ///  contract
+    /// @dev Wallets and exchanges MAY display this to the end user.
+    function name() public pure returns (string _deedName);
+
+    /// @notice An abbreviated name for deeds managed by this contract
+    /// @dev Wallets and exchanges MAY display this to the end user.
+    function symbol() public pure returns (string _deedSymbol);
+
+    /// @notice A distinct URI (RFC 3986) for a given token.
+    /// @dev If:
+    ///  * The URI is a URL
+    ///  * The URL is accessible
+    ///  * The URL points to a valid JSON file format (ECMA-404 2nd ed.)
+    ///  * The JSON base element is an object
+    ///  then these names of the base element SHALL have special meaning:
+    ///  * "name": A string identifying the item to which `_deedId` grants
+    ///    ownership
+    ///  * "description": A string detailing the item to which `_deedId` grants
+    ///    ownership
+    ///  * "image": A URI pointing to a file of image/* mime type representing
+    ///    the item to which `_deedId` grants ownership
+    ///  Wallets and exchanges MAY display this to the end user.
+    ///  Consider making any images at a width between 320 and 1080 pixels and
+    ///  aspect ratio between 1.91:1 and 4:5 inclusive.
+    function deedUri(uint256 _deedId) external view returns (string _uri);
+}
+```
+
+A second extension, the **ERC-721 Accountability Extension**, is OPTIONAL and allows your contract to make all deeds discoverable.
+
+```solidity
+/// @title Enumeration extension to ERC-721 interface
+/// @author William Entriken (https://phor.net)
+/// @dev Specification at https://github.com/ethereum/eips/issues/XXXX
+contract ERC721Enumerable is ERC721 {
+
+    /// @dev ERC-165 (draft) interface signature for ERC721
+    // bytes4 internal constant INTERFACE_SIGNATURE_ERC721Metadata = // 0xa5e86824
+    //     bytes4(keccak256('deedByIndex()')) ^
+    //     bytes4(keccak256('countOfOwners()')) ^
+    //     bytes4(keccak256('ownerByIndex(uint256)'));
+
+    /// @notice Enumerate active deeds
+    /// @dev Throws if `_index` >= `countOfDeeds()`
+    /// @param _index A counter between zero and `countOfDeeds()`, inclusive
+    /// @return The identifier for the `_index`th deed, (sort order not
+    ///  specified)
+    function deedByIndex(uint256 _index) external view returns (uint256 _deedId);
+
+    /// @notice Count of owners which own at least one deed
+    /// @return A count of the number of owners which own deeds
+    function countOfOwners() external view returns (uint256 _count);
+
+    /// @notice Enumerate owners
+    /// @dev Throws if `_index` >= `countOfOwners()`
+    /// @param _index A counter between zero and `countOfOwners()`, inclusive
+    /// @return The address of the `_index`th owner (sort order not specified)
+    function ownerByIndex(uint256 _index) external view returns (address _owner);
+}
+```
+
+### Caveats
+
+The 0.4.19 Solidity interface grammar is not expressive enough to document the ERC-721 specification. A contract which complies with ERC-721 must also abide by the following:
+
+- [Solidity issue #3412](https://github.com/ethereum/solidity/issues/3412): This interface includes explicit mutability guarantees for each function. Mutability guarantees are, in order weak to strong: `payable`, implicit nonpayable, `view`, and `pure`. Your implementation must meet the mutability guarantee in this interface or you may meet a stronger guarantee. For example, a `payable` function in this interface may be implemented as nonpayble (no state mutability specified) in your contract. We expect a later Solidity release will allow your stricter contract to inherit from this interface, but a workaround for version 0.4.19 is that you can edit this interface to add stricter mutibility before inheriting from your contract.
+- [Solidity issue #3419](https://github.com/ethereum/solidity/issues/3419): If a contract is not compliant with `ERC721` then it is not compliant with `ERC721Metadata` or `ERC721Enumerable`.
+- [Solidity issue #2330](https://github.com/ethereum/solidity/issues/2330): If a function is shown in this specification as `external` then a contract will be compliant if it uses `public` visibility.
+
+*If a newer version of Solidity allows the caveats to be expressed in code, then this EIP MAY be updated and the caveats removed, such will be equivalent to the original specification.*
+
+## Rationale
+
+There are many proposed uses of Ethereum smart contracts that depend on tracking individual deeds (non-fungible tokens). Examples of existing or planned NFTs are LAND in [Decentraland](https://decentraland.org/), the eponymous punks in [CryptoPunks](https://www.larvalabs.com/cryptopunks), and in-game items using systems like [Dmarket](https://www.dmarket.io/) or [EnjinCoin](https://enjincoin.io/). Future uses include tracking real-world non-fungible assets, like real-estate (as envisioned by companies like [Ubitquity](https://www.ubitquity.io/) or [Propy](https://tokensale.propy.com/)). It is critical in each of these cases that these items are not "lumped together" as numbers in a ledger, but instead, each token must have its ownership individually and atomically tracked. Regardless of the nature of these items, the ecosystem will be stronger if we have a standardized interface that allows for cross-functional deed management and sales platforms.
+
+**"Deed" word choice**
+
+The noun deed is defined in the Oxford Dictionary as:
+
+> A legal document that is signed and delivered, especially one regarding the ownership of property or legal rights.
+
+This definition is consistent with the fact that ERC-721 contracts track ownership of other things, such as houses, pictures of kittens or collectable cards. If you gain ownership of a house via ERC-721 (first, that would be awesome) then the thing that the ERC-721 contract tracks is the *deed*, the place where you live (and invite Will for dinner) is the *asset*.
+
+*Alternatives considered: non-fungible token, token, asset, equity, ticket*
+
+**Deed identifiers**
+
+The basis of this standard is that every deed is identified by a unique 256-bit unsigned integer within its tracking contract. This ID number MUST NOT change for the life of the contract. The pair `(contract address, asset ID)` will then be a globally unique and fully-qualified identifier for a specific deed within the Ethereum ecosystem. While some contracts may find it convenient to start with ID 0 and simply increment by one for each new NFT, callers MUST NOT assume that ID numbers have any specific pattern to them, and should treat the ID as a "black box". Also note that a deeds MAY be destroyed and as such you cannot simply count from from `0` to `countOfDeeds()`. Please see the enumerations functions for a supported enumeration interface.
+
+**Transfer mechanism**
+
+ERC-721 standardizes a two-step process for transferring deeds inspired from [ERC-20](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20-token-standard.md). This requires the sender to approve sending and the receiver to accept approval. In the original ERC-20, this caused a problem when `allowance` was called and then later modified to a different amount, as [disucssed on OpenZeppelin](https://github.com/OpenZeppelin/zeppelin-solidity/issues/438). In this deed standard, there is no allowance because every deed is unique, the quantity is none or one. Therefore we receive the benefits of ERC-20's original design without problems that have been later discovered.
+
+With two years experience, we have found that the one-step `transfer(address _to, uint256 _value)` is underirible. This is because it is very simple to accidently send property to an address that cannot use it, as dicussed in [ERC-233](https://github.com/ethereum/EIPs/issues/223) and [ERC-677](https://github.com/ethereum/EIPs/issues/677).
+
+A careful reading of this standars `approve` and `takeOwnership` functions also shows that *any* business reason may be used to deny transactions. Failed transactions will throw, a best practice identified in [ERC-233](https://github.com/ethereum/EIPs/issues/223) , [ERC-677](https://github.com/ethereum/EIPs/issues/677), [ERC-827](https://github.com/ethereum/EIPs/issues/827) and [OpenZeppelin](https://github.com/OpenZeppelin/zeppelin-solidity/blob/master/contracts/token/ERC20/SafeERC20.sol).
+
+Creating of new deeds and destruction of deeds is not included in the specification. Your implementing contract may implement these by other means. Please see the `event` documentation for your responsibilities when creating or destroying deeds.
+
+**Function mutability**
+
+The transfer functions `approve` and `takeOwnership` are payable. Yes, really. The standard contemplates a real estate ownership application where transfer of property will require paying tax from the old and/or new owner. Such an application would be compliant under this specification. Note that your contract may be nonpayable (syntactical sugar for `require(msg.value == 0)`) and be compliant, see caveats.
+
+**Supports interface**
+
+This specification includes a function `supportsInterface` so that any contract MAY query your contract to see if it complies with ERC-721 and the extensions. In the interest of GETTING THINGS DONE, we have inlined ERC-165. This EIP does NOT require the passage of ERC-165. To be clear: if you ask a contract if it supports ERC-721 and get a positive response, then it is still possible that the contract has lied to you and that its implementation does not meet the specification in this document.
+
+This inlined `supportsInterface` function uses `pure` mutability. The significance is that a contract which is deployed and not compliant with ERC-721 cannot make changes to become ERC-721 compliant. The benefit is that results of `supportsInterface` can be cached. This decision [has not achieved full consensus in the ERC-165 discussion](https://github.com/ethereum/EIPs/issues/165).
+
+**Gas and compleixty**
+
+This specification contemplates contracts managing few and *many* deeds. Specifically, we note that a large contract, initially with `N` deeds owned by the contract owner, can be deployed with `O(1)` gas. All fuctnios in the baseline and extension specifications can be implemented with `O(1)` gas and `O(Deed Count)` storage.
+
+**Accountability**
+
+Minimally, only the fuctions `ownerOf`, `approve`, `takeOwnership` are necessary for a usable deed standard. But wallets/brokers/auctioneers identified in the motivation section have a strong need to identify which deeds an owner owns. 
+
+It may be interesting to consider a use case where deeds are not enumerable or deeds are not enumerable by owner, such as a private registry of property ownership, or a partially-private registry. However, privacy cannot be attained because an attacker can simply (!) call `ownerOf` for every possible `deedId`.  This is why we include just the most usefull accounting in the baseline standard and the full accounting in the extension.
+
+**Metadata**
+
+We have chosen to make `name` and `symbol` both optional. These are interesting properties but are of limited utility. We remind wallet application authors that `name` and `symbol` cannot be trusted, a contract can easily return a value which overlaps with an existing well-known contract — or they may return an empty string / unable value.
+
+A mechanism is provided to associate deeds with URIs. We expect that many implementations will take advantage of this to provide metadata for each deed. The image size recommendation is taken from Instagram, they probably know much about image usability. The URI MAY be mutable (i.e. it changes from time to time). We considered a deed representing ownership of a real-world asset, in this case metadata about such an asset may naturally change.
+
+Metadata is returned as a string value. Currently this is only usable as calling from `web3`, not from other contracts. This is acceptable because we have not considered a use case where an on-blockchain application would query such information.
+
+**Operators**
+
+[ERC-777 discusses "operators"](https://github.com/ethereum/EIPs/issues/777), entities that you may assign to control property for you. We have considered adding such a feature to this specification. We have considered against this beacuse it should not be required — many contracts will not need this feature and such contracts have merit enough to be considered compliant with ERC-721. At this time, the operator model does not have much real-world experience. We expect that a future extension to this deed standard may introduce such functionality if warranted.
+
+**Discussions**
+
+A significant amount of discussion occured on [the original ERC-721](ERC-721 issue), additionally we held a live meeting [on Gitter](https://gitter.im/ethereum/ERCs?at=5a62259b5ade18be3998eec4) that had good representation and [was](https://www.reddit.com/r/ethereum/comments/7r2ena/friday_119_live_discussion_on_erc_nonfungible/) [well](https://gitter.im/ethereum/EIPs?at=5a5f823fb48e8c3566f0a5e7) [advertised](https://github.com/ethereum/eips/issues/721#issuecomment-358369377) in relevant communities. Thank you  to the participants:
+
+- [@ImAllInNow](https://github.com/imallinnow) Rob from DEC Gaming / Presenting Michigan Ethereum Meetup Feb 7
+- [@Arachnid](https://github.com/arachnid) Nick Johnson
+- [@jadhavajay](https://github.com/jadhavajay) Ajay Jadhav from AyanWorks
+- [@superphly](https://github.com/superphly) Cody Marx Bailey - XRAM Capital / Sharing at hackathon Jan 20
+
+Cody, is presenting ERC-721 at the UN Future of Finance Hackathon.
+
+## Backwards Compatibility
+
+This standard is inspired by the semantics of ERC-20, but can't be compatible with it due to the fundamental differences between tokens and deeds.
+
+Example deeds implementations as of January 2018:
+
+- [CryptoKitties](https://www.cryptokitties.co/) — Compatible with an earlier version of this standard.
+- [CryptoPunks](https://www.larvalabs.com/cryptopunks) — Partially ERC-20 compatible, but not easily generalizable because it includes auction functionality directly in the contract and uses function names that explicitly refer to the deeds as "punks".
+- [Auctionhouse Asset Interface](https://github.com/dob/auctionhouse/blob/master/contracts/Asset.sol) — [@dob](https://github.com/dob) needed a generic interface for his Auctionhouse dapp (currently ice-boxed). His "Asset" contract is very simple, but is missing ERC-20 compatibility, `approve()` functionality, and metadata. This effort is referenced in the discussion for [EIP-173](https://github.com/ethereum/EIPs/issues/173).
+
+Note: "Limited edition, collectable tokens" like [Curio Cards](https://mycuriocards.com/) and [Rare Pepe](https://rarepepewallet.com/) are *not* deeds. They're actually a collection of individual fungible tokens, each of which is tracked by its own smart contract with its own total supply (which may be `1` in extreme cases).
+
+## Test Cases
+
+**TO DO**
+
+Test cases for an implementation are mandatory for EIPs that are affecting consensus changes. Other EIPs can choose to include links to test cases if applicable.
+
+## Implementation
+
+**TO DO**
+
+The implementations must be completed before any EIP is given status "Final", but it need not be completed before the EIP is accepted. While there is merit to the approach of reaching consensus on the specification and rationale before writing code, the principle of "rough consensus and running code" is still useful when it comes to resolving many discussions of API details.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/EIPS/eip-721.md
+++ b/EIPS/eip-721.md
@@ -49,11 +49,11 @@ interface ERC721 {
     //     bytes4(keccak256('supportsInterface(bytes4)'));
 
     /// @dev ERC-165 (draft) interface signature for ERC721
-    // bytes4 internal constant INTERFACE_SIGNATURE_ERC721 = // 0xe55729f5
+    // bytes4 internal constant INTERFACE_SIGNATURE_ERC721 = // 0xda671b9b
     //     bytes4(keccak256('ownerOf(uint256)')) ^
     //     bytes4(keccak256('countOfDeeds()')) ^
     //     bytes4(keccak256('countOfDeedsByOwner(address)')) ^
-    //     bytes4(keccak256('deedOfOwnerByIndex(uint256)')) ^
+    //     bytes4(keccak256('deedOfOwnerByIndex(address,uint256)')) ^
     //     bytes4(keccak256('approve(address,uint256)')) ^
     //     bytes4(keccak256('takeOwnership(uint256)'));
 

--- a/EIPS/eip-721.md
+++ b/EIPS/eip-721.md
@@ -7,7 +7,7 @@ Author: William Entriken <github.com@phor.net>, Dieter Shirley <dete@axiomzen.co
 Type: Standard
 Category ERC
 Status: Draft
-Created: 2018-01-31
+Created: 2018-01-24
 ```
 
 ## Simple Summary

--- a/EIPS/eip-721.md
+++ b/EIPS/eip-721.md
@@ -232,13 +232,13 @@ The noun deed is defined in the Oxford Dictionary as:
 
 > A legal document that is signed and delivered, especially one regarding the ownership of property or legal rights.
 
-This definition is consistent with the fact that ERC-721 contracts track ownership of other things, such as houses, pictures of kittens or collectable cards. If you gain ownership of a house via ERC-721 then the thing that the ERC-721 contract tracks is the *deed*, the place where you live is the *asset*.
+This definition is consistent with the fact that ERC-721 contracts track ownership of other things, such as houses, pictures of kittens or collectable cards. If you gain ownership of a house via ERC-721 then the thing that the ERC-721 contract tracks is the *deed*, the place where you live is the *asset*. This standard is not concerned with the *collectable*, *item*, *thing*, or *asset* that you own -- we use these words interchangeably.
 
 *Alternatives considered: non-fungible token, title, token, asset, equity, ticket*
 
 **Deed identifiers**
 
-The basis of this standard is that every deed is identified by a unique 256-bit unsigned integer within its tracking contract. This ID number MUST NOT change for the life of the contract. The pair `(contract address, asset ID)` will then be a globally unique and fully-qualified identifier for a specific deed within the Ethereum ecosystem. While some contracts may find it convenient to start with ID 0 and simply increment by one for each new NFT, callers MUST NOT assume that ID numbers have any specific pattern to them, and should treat the ID as a "black box". Also note that a deeds MAY become invalid (be destroyed). Please see the enumerations functions for a supported enumeration interface.
+The basis of this standard is that every deed is identified by a unique 256-bit unsigned integer within its tracking contract. This ID number MUST NOT change for the life of the contract. The pair `(contract address, deed ID)` will then be a globally unique and fully-qualified identifier for a specific deed within the Ethereum ecosystem. While some contracts may find it convenient to start with ID 0 and simply increment by one for each new NFT, callers MUST NOT assume that ID numbers have any specific pattern to them, and should treat the ID as a "black box". Also note that a deeds MAY become invalid (be destroyed). Please see the enumerations functions for a supported enumeration interface.
 
 **Transfer mechanism**
 

--- a/EIPS/eip-721.md
+++ b/EIPS/eip-721.md
@@ -222,7 +222,7 @@ The noun deed is defined in the Oxford Dictionary as:
 
 > A legal document that is signed and delivered, especially one regarding the ownership of property or legal rights.
 
-This definition is consistent with the fact that ERC-721 contracts track ownership of other things, such as houses, pictures of kittens or collectable cards. If you gain ownership of a house via ERC-721 (first, that would be awesome) then the thing that the ERC-721 contract tracks is the *deed*, the place where you live (and invite Will for dinner) is the *asset*.
+This definition is consistent with the fact that ERC-721 contracts track ownership of other things, such as houses, pictures of kittens or collectable cards. If you gain ownership of a house via ERC-721 then the thing that the ERC-721 contract tracks is the *deed*, the place where you live is the *asset*.
 
 *Alternatives considered: non-fungible token, title, token, asset, equity, ticket*
 

--- a/EIPS/eip-721.md
+++ b/EIPS/eip-721.md
@@ -178,7 +178,7 @@ A second extension, the **ERC-721 Accountability Extension**, is OPTIONAL and al
 contract ERC721Enumerable is ERC721 {
 
     /// @dev ERC-165 (draft) interface signature for ERC721
-    // bytes4 internal constant INTERFACE_SIGNATURE_ERC721Metadata = // 0xa5e86824
+    // bytes4 internal constant INTERFACE_SIGNATURE_ERC721Enumerable = // 0xa5e86824
     //     bytes4(keccak256('deedByIndex()')) ^
     //     bytes4(keccak256('countOfOwners()')) ^
     //     bytes4(keccak256('ownerByIndex(uint256)'));
@@ -206,7 +206,7 @@ contract ERC721Enumerable is ERC721 {
 
 The 0.4.19 Solidity interface grammar is not expressive enough to document the ERC-721 specification. A contract which complies with ERC-721 must also abide by the following:
 
-- [Solidity issue #3412](https://github.com/ethereum/solidity/issues/3412): This interface includes explicit mutability guarantees for each function. Mutability guarantees are, in order weak to strong: `payable`, implicit nonpayable, `view`, and `pure`. Your implementation must meet the mutability guarantee in this interface or you may meet a stronger guarantee. For example, a `payable` function in this interface may be implemented as nonpayble (no state mutability specified) in your contract. We expect a later Solidity release will allow your stricter contract to inherit from this interface, but a workaround for version 0.4.19 is that you can edit this interface to add stricter mutibility before inheriting from your contract.
+- [Solidity issue #3412](https://github.com/ethereum/solidity/issues/3412): This interface includes explicit mutability guarantees for each function. Mutability guarantees are, in order weak to strong: `payable`, implicit nonpayable, `view`, and `pure`. Your implementation must meet the mutability guarantee in this interface or you may meet a stronger guarantee. For example, a `payable` function in this interface may be implemented as nonpayble (no state mutability specified) in your contract. We expect a later Solidity release will allow your stricter contract to inherit from this interface, but a workaround for version 0.4.19 is that you can edit this interface to add stricter mutability before inheriting from your contract.
 - [Solidity issue #3419](https://github.com/ethereum/solidity/issues/3419): If a contract is not compliant with `ERC721` then it is not compliant with `ERC721Metadata` or `ERC721Enumerable`.
 - [Solidity issue #2330](https://github.com/ethereum/solidity/issues/2330): If a function is shown in this specification as `external` then a contract will be compliant if it uses `public` visibility.
 
@@ -234,31 +234,31 @@ The basis of this standard is that every deed is identified by a unique 256-bit 
 
 ERC-721 standardizes a two-step process for transferring deeds inspired from [ERC-20](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20-token-standard.md). This requires the sender to approve sending and the receiver to accept approval. In the original ERC-20, this caused a problem when `allowance` was called and then later modified to a different amount, as [disucssed on OpenZeppelin](https://github.com/OpenZeppelin/zeppelin-solidity/issues/438). In this deed standard, there is no allowance because every deed is unique, the quantity is none or one. Therefore we receive the benefits of ERC-20's original design without problems that have been later discovered.
 
-With two years experience, we have found that the one-step `transfer(address _to, uint256 _value)` is underirible. This is because it is very simple to accidently send property to an address that cannot use it, as dicussed in [ERC-233](https://github.com/ethereum/EIPs/issues/223) and [ERC-677](https://github.com/ethereum/EIPs/issues/677).
+With two years experience, we have found that the one-step `transfer(address _to, uint256 _value)` is undesirable. This is because it is very simple to accidentally send property to an address that cannot use it, as discussed in [ERC-233](https://github.com/ethereum/EIPs/issues/223) and [ERC-677](https://github.com/ethereum/EIPs/issues/677).
 
-A careful reading of this standars `approve` and `takeOwnership` functions also shows that *any* business reason may be used to deny transactions. Failed transactions will throw, a best practice identified in [ERC-233](https://github.com/ethereum/EIPs/issues/223) , [ERC-677](https://github.com/ethereum/EIPs/issues/677), [ERC-827](https://github.com/ethereum/EIPs/issues/827) and [OpenZeppelin](https://github.com/OpenZeppelin/zeppelin-solidity/blob/master/contracts/token/ERC20/SafeERC20.sol).
+A careful reading of this standard's `approve` and `takeOwnership` functions also shows that *any* business reason may be used to deny transactions. Failed transactions will throw, a best practice identified in [ERC-233](https://github.com/ethereum/EIPs/issues/223) , [ERC-677](https://github.com/ethereum/EIPs/issues/677), [ERC-827](https://github.com/ethereum/EIPs/issues/827) and [OpenZeppelin](https://github.com/OpenZeppelin/zeppelin-solidity/blob/master/contracts/token/ERC20/SafeERC20.sol).
 
 Creating of new deeds and destruction of deeds is not included in the specification. Your implementing contract may implement these by other means. Please see the `event` documentation for your responsibilities when creating or destroying deeds.
 
 **Function mutability**
 
-The transfer functions `approve` and `takeOwnership` are payable. Yes, really. The standard contemplates a real estate ownership application where transfer of property will require paying tax from the old and/or new owner. Such an application would be compliant under this specification. Note that your contract may be nonpayable (syntactical sugar for `require(msg.value == 0)`) and be compliant, see caveats.
+The transfer functions `approve` and `takeOwnership` are payable. Yes, really. The standard contemplates a real estate ownership application where transfer of property will require paying tax from the old and/or new owner. Such an application would be compliant under this specification. Note that your contract may be nonpayable (syntactic sugar for `require(msg.value == 0)`) and be compliant, see caveats.
 
 **Supports interface**
 
 This specification includes a function `supportsInterface` so that any contract MAY query your contract to see if it complies with ERC-721 and the extensions. In the interest of GETTING THINGS DONE, we have inlined ERC-165. This EIP does NOT require the passage of ERC-165. To be clear: if you ask a contract if it supports ERC-721 and get a positive response, then it is still possible that the contract has lied to you and that its implementation does not meet the specification in this document.
 
-This inlined `supportsInterface` function uses `pure` mutability. The significance is that a contract which is deployed and not compliant with ERC-721 cannot make changes to become ERC-721 compliant. The benefit is that results of `supportsInterface` can be cached. This decision [has not achieved full consensus in the ERC-165 discussion](https://github.com/ethereum/EIPs/issues/165).
+This inline `supportsInterface` function uses `pure` mutability. The significance is that a contract which is deployed and not compliant with ERC-721 cannot make changes to become ERC-721 compliant. The benefit is that results of `supportsInterface` can be cached. This decision [has not achieved full consensus in the ERC-165 discussion](https://github.com/ethereum/EIPs/issues/165).
 
-**Gas and compleixty**
+**Gas and complexity**
 
-This specification contemplates contracts managing few and *many* deeds. Specifically, we note that a large contract, initially with `N` deeds owned by the contract owner, can be deployed with `O(1)` gas. All fuctnios in the baseline and extension specifications can be implemented with `O(1)` gas and `O(Deed Count)` storage.
+This specification contemplates contracts managing few and *many* deeds. Specifically, we note that a large contract, initially with `N` deeds owned by the contract owner, can be deployed with `O(1)` gas. All functions in the baseline and extension specifications can be implemented with `O(1)` gas and `O(Deed Count)` storage.
 
 **Accountability**
 
-Minimally, only the fuctions `ownerOf`, `approve`, `takeOwnership` are necessary for a usable deed standard. But wallets/brokers/auctioneers identified in the motivation section have a strong need to identify which deeds an owner owns. 
+Minimally, only the functions `ownerOf`, `approve`, `takeOwnership` are necessary for a usable deed standard. But wallets/brokers/auctioneers identified in the motivation section have a strong need to identify which deeds an owner owns.
 
-It may be interesting to consider a use case where deeds are not enumerable or deeds are not enumerable by owner, such as a private registry of property ownership, or a partially-private registry. However, privacy cannot be attained because an attacker can simply (!) call `ownerOf` for every possible `deedId`.  This is why we include just the most usefull accounting in the baseline standard and the full accounting in the extension.
+It may be interesting to consider a use case where deeds are not enumerable or deeds are not enumerable by owner, such as a private registry of property ownership, or a partially-private registry. However, privacy cannot be attained because an attacker can simply (!) call `ownerOf` for every possible `deedId`.  This is why we include just the most useful accounting in the baseline standard and the full accounting in the extension.
 
 **Metadata**
 
@@ -270,7 +270,7 @@ Metadata is returned as a string value. Currently this is only usable as calling
 
 **Operators**
 
-[ERC-777 discusses "operators"](https://github.com/ethereum/EIPs/issues/777), entities that you may assign to control property for you. We have considered adding such a feature to this specification. We have considered against this beacuse it should not be required — many contracts will not need this feature and such contracts have merit enough to be considered compliant with ERC-721. At this time, the operator model does not have much real-world experience. We expect that a future extension to this deed standard may introduce such functionality if warranted.
+[ERC-777 discusses "operators"](https://github.com/ethereum/EIPs/issues/777), entities that you may assign to control property for you. We have considered adding such a feature to this specification. We have considered against this because it should not be required — many contracts will not need this feature and such contracts have merit enough to be considered compliant with ERC-721. At this time, the operator model does not have much real-world experience. We expect that a future extension to this deed standard may introduce such functionality if warranted.
 
 **Discussions**
 
@@ -293,7 +293,7 @@ Example deeds implementations as of January 2018:
 - [CryptoPunks](https://www.larvalabs.com/cryptopunks) — Partially ERC-20 compatible, but not easily generalizable because it includes auction functionality directly in the contract and uses function names that explicitly refer to the deeds as "punks".
 - [Auctionhouse Asset Interface](https://github.com/dob/auctionhouse/blob/master/contracts/Asset.sol) — [@dob](https://github.com/dob) needed a generic interface for his Auctionhouse dapp (currently ice-boxed). His "Asset" contract is very simple, but is missing ERC-20 compatibility, `approve()` functionality, and metadata. This effort is referenced in the discussion for [EIP-173](https://github.com/ethereum/EIPs/issues/173).
 
-Note: "Limited edition, collectable tokens" like [Curio Cards](https://mycuriocards.com/) and [Rare Pepe](https://rarepepewallet.com/) are *not* deeds. They're actually a collection of individual fungible tokens, each of which is tracked by its own smart contract with its own total supply (which may be `1` in extreme cases).
+Note: "Limited edition, collectible tokens" like [Curio Cards](https://mycuriocards.com/) and [Rare Pepe](https://rarepepewallet.com/) are *not* deeds. They're actually a collection of individual fungible tokens, each of which is tracked by its own smart contract with its own total supply (which may be `1` in extreme cases).
 
 ## Test Cases
 

--- a/EIPS/eip-721.md
+++ b/EIPS/eip-721.md
@@ -224,7 +224,7 @@ The noun deed is defined in the Oxford Dictionary as:
 
 This definition is consistent with the fact that ERC-721 contracts track ownership of other things, such as houses, pictures of kittens or collectable cards. If you gain ownership of a house via ERC-721 (first, that would be awesome) then the thing that the ERC-721 contract tracks is the *deed*, the place where you live (and invite Will for dinner) is the *asset*.
 
-*Alternatives considered: non-fungible token, token, asset, equity, ticket*
+*Alternatives considered: non-fungible token, title, token, asset, equity, ticket*
 
 **Deed identifiers**
 

--- a/EIPS/eip-721.md
+++ b/EIPS/eip-721.md
@@ -274,7 +274,7 @@ Metadata is returned as a string value. Currently this is only usable as calling
 
 **Discussions**
 
-A significant amount of discussion occured on [the original ERC-721](ERC-721 issue), additionally we held a live meeting [on Gitter](https://gitter.im/ethereum/ERCs?at=5a62259b5ade18be3998eec4) that had good representation and [was](https://www.reddit.com/r/ethereum/comments/7r2ena/friday_119_live_discussion_on_erc_nonfungible/) [well](https://gitter.im/ethereum/EIPs?at=5a5f823fb48e8c3566f0a5e7) [advertised](https://github.com/ethereum/eips/issues/721#issuecomment-358369377) in relevant communities. Thank you  to the participants:
+A significant amount of discussion occurred on [the original ERC-721](ERC-721 issue), additionally we held a live meeting [on Gitter](https://gitter.im/ethereum/ERCs?at=5a62259b5ade18be3998eec4) that had good representation and [was](https://www.reddit.com/r/ethereum/comments/7r2ena/friday_119_live_discussion_on_erc_nonfungible/) [well](https://gitter.im/ethereum/EIPs?at=5a5f823fb48e8c3566f0a5e7) [advertised](https://github.com/ethereum/eips/issues/721#issuecomment-358369377) in relevant communities. Thank you  to the participants:
 
 - [@ImAllInNow](https://github.com/imallinnow) Rob from DEC Gaming / Presenting Michigan Ethereum Meetup Feb 7
 - [@Arachnid](https://github.com/arachnid) Nick Johnson

--- a/EIPS/eip-721.md
+++ b/EIPS/eip-721.md
@@ -67,29 +67,28 @@ interface ERC721 {
 
     /// @notice Find the owner of a deed
     /// @param _deedId The identifier for a deed we are inspecting
-    /// @dev Deeds assigned to zero address are considered destroyed, and
+    /// @dev Deeds assigned to zero address are considered invalid, and
     ///  queries about them do throw.
     /// @return The non-zero address of the owner of deed `_deedId`, or `throw`
     ///  if deed `_deedId` is not tracked by this contract
     function ownerOf(uint256 _deedId) external view returns (address _owner);
 
     /// @notice Count deeds tracked by this contract
-    /// @return A count of the deeds tracked by this contract, where each one of
-    ///  them has an assigned and queryable owner
+    /// @return A count of valid deeds tracked by this contract, where each one of
+    ///  them has an assigned and queryable owner not equal to the zero address
     function countOfDeeds() external view returns (uint256 _count);
 
     /// @notice Count all deeds assigned to an owner
-    /// @dev Throws if `_owner` is the zero address, representing destroyed deeds.
+    /// @dev Throws if `_owner` is the zero address, representing invalid deeds.
     /// @param _owner An address where we are interested in deeds owned by them
     /// @return The number of deeds owned by `_owner`, possibly zero
     function countOfDeedsByOwner(address _owner) external view returns (uint256 _count);
 
     /// @notice Enumerate deeds assigned to an owner
     /// @dev Throws if `_index` >= `countOfDeedsByOwner(_owner)` or if
-    ///  `_owner` is the zero address, representing destroyed deeds.
+    ///  `_owner` is the zero address, representing invalid deeds.
     /// @param _owner An address where we are interested in deeds owned by them
-    /// @param _index A counter between zero and `countOfDeedsByOwner(_owner)`,
-    ///  inclusive
+    /// @param _index A counter less than `countOfDeedsByOwner(_owner)`
     /// @return The identifier for the `_index`th deed assigned to `_owner`,
     ///   (sort order not specified)
     function deedOfOwnerByIndex(address _owner, uint256 _index) external view returns (uint256 _deedId);
@@ -104,10 +103,10 @@ interface ERC721 {
     event Transfer(address indexed from, address indexed to, uint256 indexed deedId);
 
     /// @dev The Approve event emits to log the "approved taker" for a deed -- whether
-    ///  set for the first time, reaffirmed by setting the same value, or by setting to  
-    ///  to a new value. The "approved taker" is the zero address if nobody can take the
+    ///  set for the first time, reaffirmed by setting the same value, or setting to  
+    ///  a new value. The "approved taker" is the zero address if nobody can take the
     ///  deed now or it is an address if that address can call `takeOwnership` to attempt
-    ///  taking the deed. Any change to the "approved taker" for a deed SHALL cause cause
+    ///  taking the deed. Any change to the "approved taker" for a deed SHALL cause
     ///  Approve to emit. However, an exception, the Approve event will not emit when
     ///  Transfer emits, this is because Transfer implicitly denotes the "approved taker"
     ///  is reset to the zero address.
@@ -118,13 +117,14 @@ interface ERC721 {
     ///  the deed is assigned to you, only the most recent approval matters. Emits
     ///  an Approval event.
     /// @dev Throws if `msg.sender` does not own deed `_deedId` or if `_to` ==
-    ///  `msg.sender`.
+    ///  `msg.sender` or if `_deedId` is not a valid deed.
     /// @param _deedId The deed for which you are granting approval
     function approve(address _to, uint256 _deedId) external payable;
 
     /// @notice Become owner of a deed for which you are currently approved
     /// @dev Throws if `msg.sender` is not approved to become the owner of
-    ///  `deedId` or if `msg.sender` currently owns `_deedId`.
+    ///  `deedId` or if `msg.sender` currently owns `_deedId` or if `_deedId is not a
+    ///  valid deed.
     /// @param _deedId The deed that is being transferred
     function takeOwnership(uint256 _deedId) external payable;
 }
@@ -191,7 +191,7 @@ contract ERC721Enumerable is ERC721 {
 
     /// @notice Enumerate active deeds
     /// @dev Throws if `_index` >= `countOfDeeds()`
-    /// @param _index A counter between zero and `countOfDeeds()`, inclusive
+    /// @param _index A counter less than `countOfDeeds()`
     /// @return The identifier for the `_index`th deed, (sort order not
     ///  specified)
     function deedByIndex(uint256 _index) external view returns (uint256 _deedId);
@@ -202,7 +202,7 @@ contract ERC721Enumerable is ERC721 {
 
     /// @notice Enumerate owners
     /// @dev Throws if `_index` >= `countOfOwners()`
-    /// @param _index A counter between zero and `countOfOwners()`, inclusive
+    /// @param _index A counter less than `countOfOwners()`
     /// @return The address of the `_index`th owner (sort order not specified)
     function ownerByIndex(uint256 _index) external view returns (address _owner);
 }
@@ -234,7 +234,7 @@ This definition is consistent with the fact that ERC-721 contracts track ownersh
 
 **Deed identifiers**
 
-The basis of this standard is that every deed is identified by a unique 256-bit unsigned integer within its tracking contract. This ID number MUST NOT change for the life of the contract. The pair `(contract address, asset ID)` will then be a globally unique and fully-qualified identifier for a specific deed within the Ethereum ecosystem. While some contracts may find it convenient to start with ID 0 and simply increment by one for each new NFT, callers MUST NOT assume that ID numbers have any specific pattern to them, and should treat the ID as a "black box". Also note that a deeds MAY be destroyed and as such you cannot simply count from from `0` to `countOfDeeds()`. Please see the enumerations functions for a supported enumeration interface.
+The basis of this standard is that every deed is identified by a unique 256-bit unsigned integer within its tracking contract. This ID number MUST NOT change for the life of the contract. The pair `(contract address, asset ID)` will then be a globally unique and fully-qualified identifier for a specific deed within the Ethereum ecosystem. While some contracts may find it convenient to start with ID 0 and simply increment by one for each new NFT, callers MUST NOT assume that ID numbers have any specific pattern to them, and should treat the ID as a "black box". Also note that a deeds MAY become invalid (be destroyed). Please see the enumerations functions for a supported enumeration interface.
 
 **Transfer mechanism**
 

--- a/EIPS/eip-721.md
+++ b/EIPS/eip-721.md
@@ -262,7 +262,7 @@ It may be interesting to consider a use case where deeds are not enumerable or d
 
 **Metadata**
 
-We have chosen to make `name` and `symbol` both optional. These are interesting properties but are of limited utility. We remind wallet application authors that `name` and `symbol` cannot be trusted, a contract can easily return a value which overlaps with an existing well-known contract — or they may return an empty string / unable value.
+We have chosen to make `name` and `symbol` both optional. These are interesting properties but are of limited utility. We remind wallet application authors that `name` and `symbol` cannot be trusted, a contract can easily return a value which overlaps with an existing well-known contract — or they may return an empty string / unusable value.
 
 A mechanism is provided to associate deeds with URIs. We expect that many implementations will take advantage of this to provide metadata for each deed. The image size recommendation is taken from Instagram, they probably know much about image usability. The URI MAY be mutable (i.e. it changes from time to time). We considered a deed representing ownership of a real-world asset, in this case metadata about such an asset may naturally change.
 

--- a/EIPS/eip-721.md
+++ b/EIPS/eip-721.md
@@ -242,7 +242,7 @@ Creating of new deeds and destruction of deeds is not included in the specificat
 
 **Function mutability**
 
-The transfer functions `approve` and `takeOwnership` are payable. Yes, really. The standard contemplates a real estate ownership application where transfer of property will require paying tax from the old and/or new owner. Such an application would be compliant under this specification. Note that your contract may be nonpayable (syntactic sugar for `require(msg.value == 0)`) and be compliant, see caveats.
+The transfer functions `approve` and `takeOwnership` are payable. Yes, really. The standard contemplates a real estate ownership application where transfer of property will require paying tax and/or various fees (including, but not limited to mining fees and pre-set transference fees), which may be paid by the old and/or new owner in any pre-arranged amount. Such an application would be compliant under this specification. Note that your contract may be nonpayable (syntactic sugar for `require(msg.value == 0)`) and be compliant, see caveats.
 
 **Supports interface**
 

--- a/EIPS/eip-721.md
+++ b/EIPS/eip-721.md
@@ -138,7 +138,7 @@ Implementations MAY also choose to implement the **ERC-721 Metadata extension**.
 /// @title Metadata extension to ERC-721 interface
 /// @author William Entriken (https://phor.net)
 /// @dev Specification at https://github.com/ethereum/eips/issues/XXXX
-interface ERC721Metadata is ERC721 {
+interface ERC721Metadata {
 
     /// @dev ERC-165 (draft) interface signature for ERC721
     // bytes4 internal constant INTERFACE_SIGNATURE_ERC721Metadata = // 0x2a786f11
@@ -181,7 +181,7 @@ A second extension, the **ERC-721 Accountability Extension**, is OPTIONAL and al
 /// @title Enumeration extension to ERC-721 interface
 /// @author William Entriken (https://phor.net)
 /// @dev Specification at https://github.com/ethereum/eips/issues/XXXX
-contract ERC721Enumerable is ERC721 {
+interface ERC721Enumerable {
 
     /// @dev ERC-165 (draft) interface signature for ERC721
     // bytes4 internal constant INTERFACE_SIGNATURE_ERC721Enumerable = // 0xa5e86824

--- a/EIPS/eip-721.md
+++ b/EIPS/eip-721.md
@@ -149,11 +149,15 @@ interface ERC721Metadata {
     /// @notice A descriptive name for a collection of deeds managed by this
     ///  contract
     /// @dev Wallets and exchanges MAY display this to the end user.
-    function name() public pure returns (string _deedName);
+    function name() public pure returns (string _name);
 
     /// @notice An abbreviated name for deeds managed by this contract
     /// @dev Wallets and exchanges MAY display this to the end user.
-    function symbol() public pure returns (string _deedSymbol);
+    function symbol() public pure returns (string _symbol);
+
+    /// @notice A distinct name for a deed managed by this contract
+    /// @dev Wallets and exchanges MAY display this to the end user.
+    function deedName(uint256 _deedId) public pure returns (string _deedName);
 
     /// @notice A distinct URI (RFC 3986) for a given token.
     /// @dev If:
@@ -171,7 +175,7 @@ interface ERC721Metadata {
     ///  Wallets and exchanges MAY display this to the end user.
     ///  Consider making any images at a width between 320 and 1080 pixels and
     ///  aspect ratio between 1.91:1 and 4:5 inclusive.
-    function deedUri(uint256 _deedId) external view returns (string _uri);
+    function deedUri(uint256 _deedId) external view returns (string _deedUri);
 }
 ```
 

--- a/EIPS/eip-721.md
+++ b/EIPS/eip-721.md
@@ -99,21 +99,27 @@ interface ERC721 {
     /// @dev This event emits when ownership of any deed changes by any
     ///  mechanism. This event emits when deeds are created (`from` == 0) and
     ///  destroyed (`to` == 0). Exception: during contract creation, any
-    ///  transfers may occur without emitting `Transfer`.
+    ///  transfers may occur without emitting `Transfer`. At the time of any transfer,
+    ///  the "approved taker" is implicitly reset to the zero address.
     event Transfer(address indexed from, address indexed to, uint256 indexed deedId);
 
-    /// @dev This event emits on any successful call to
-    ///  `approve(address _spender, uint256 _deedId)`. Exception: does not emit
-    ///  if an owner revokes approval (`_to` == 0x0) on a deed with no existing
-    ///  approval.
+    /// @dev The Approve event emits to log the "approved taker" for a deed -- whether
+    ///  set for the first time, reaffirmed by setting the same value, or by setting to  
+    ///  to a new value. The "approved taker" is the zero address if nobody can take the
+    ///  deed now or it is an address if that address can call `takeOwnership` to attempt
+    ///  taking the deed. Any change to the "approved taker" for a deed SHALL cause cause
+    ///  Approve to emit. However, an exception, the Approve event will not emit when
+    ///  Transfer emits, this is because Transfer implicitly denotes the "approved taker"
+    ///  is reset to the zero address.
     event Approval(address indexed owner, address indexed approved, uint256 indexed deedId);
 
-    /// @notice Approve a new owner to take your deed, or revoke approval by
+    /// @notice Set the "approved taker" for your deed, or revoke approval by
     ///  setting the zero address. You may `approve` any number of times while
-    ///  the deed is assigned to you, only the most recent approval matters.
+    ///  the deed is assigned to you, only the most recent approval matters. Emits
+    ///  an Approval event.
     /// @dev Throws if `msg.sender` does not own deed `_deedId` or if `_to` ==
     ///  `msg.sender`.
-    /// @param _deedId The deed you are granting ownership of
+    /// @param _deedId The deed for which you are granting approval
     function approve(address _to, uint256 _deedId) external payable;
 
     /// @notice Become owner of a deed for which you are currently approved

--- a/EIPS/eip-721.md
+++ b/EIPS/eip-721.md
@@ -16,7 +16,7 @@ A standard interface for deeds, also known as non-fungible tokens.
 
 ## Abstract
 
-**This a standard interface for smart contracts to handle deed ownership.** Deeds can represent ownership of physical property, like houses, or digital property, like unique pictures of kittens. In general, all houses are distinct and no two kittens are alike. Therefore you must track each deed separately; it is insufficient to simply count the deeds you own.
+**This is a standard interface for smart contracts to handle deed ownership.** Deeds can represent ownership of physical property, like houses, or digital property, like unique pictures of kittens. In general, all houses are distinct and no two kittens are alike. Therefore you must track each deed separately; it is insufficient to simply count the deeds you own.
 
 The scope of this interface includes **interrogating the smart contract about deed ownership**. It also **allows deed owners to transfer assets**. The authors considered uses cases of individual deed ownership as well as custody by third party brokers/wallets/auctioneers.
 

--- a/EIPS/eip-721.md
+++ b/EIPS/eip-721.md
@@ -155,10 +155,6 @@ interface ERC721Metadata {
     /// @dev Wallets and exchanges MAY display this to the end user.
     function symbol() public pure returns (string _symbol);
 
-    /// @notice A distinct name for a deed managed by this contract
-    /// @dev Wallets and exchanges MAY display this to the end user.
-    function deedName(uint256 _deedId) public pure returns (string _deedName);
-
     /// @notice A distinct URI (RFC 3986) for a given token.
     /// @dev If:
     ///  * The URI is a URL


### PR DESCRIPTION
This function seems like an unnecessary and potentially confusing overlap/double-up of data that can already be part of deedUri() return data.