### PR TITLE
ERC-165 Standard Interface Detection

### DIFF
--- a/EIPS/eip-165.md
+++ b/EIPS/eip-165.md
@@ -86,7 +86,7 @@ Implementation note, there are several logical ways to implement this function. 
 
 ### How to Detect if a Contract Implements ERC-165
 
-1. The source contact makes a `STATICCALL` to the destination address with input data: `0x01ffc9a701ffc9a7000000000000000000000000` and gas 30,000. This corresponds to `contract.supportsInterface("0x01ffc9a7")`.
+1. The source contact makes a `STATICCALL` to the destination address with input data: `0x01ffc9a701ffc9a7000000000000000000000000` and gas 30,000. This corresponds to `contract.supportsInterface(0x01ffc9a7)`.
 2. If the call fails or return false, the destination contract does not implement ERC-165.
 3. If the call returns true, a second call is made with input data `0x01ffc9a7ffffffff000000000000000000000000`.
 4. If the second call fails or returns true, the destination contract does not implement ERC-165.

--- a/EIPS/eip-165.md
+++ b/EIPS/eip-165.md
@@ -86,9 +86,9 @@ Implementation note, there are several logical ways to implement this function. 
 
 ### How to Detect if a Contract Implements ERC-165
 
-1. The source contact makes a `STATICCALL` to the destination address with input data: `0x01ffc9a700000000000000000000000001ffc9a7` and gas 30,000. This corresponds to `contract.supportsInterface("0x01ffc9a7")`.
+1. The source contact makes a `STATICCALL` to the destination address with input data: `0x01ffc9a701ffc9a7000000000000000000000000` and gas 30,000. This corresponds to `contract.supportsInterface("0x01ffc9a7")`.
 2. If the call fails or return false, the destination contract does not implement ERC-165.
-3. If the call returns true, a second call is made with input data `0x01ffc9a7000000000000000000000000ffffffff`.
+3. If the call returns true, a second call is made with input data `0x01ffc9a7ffffffff000000000000000000000000`.
 4. If the second call fails or returns true, the destination contract does not implement ERC-165.
 5. Otherwise it implements ERC-165.
 

--- a/EIPS/eip-165.md
+++ b/EIPS/eip-165.md
@@ -36,11 +36,11 @@ For this standard, an *interface* is a set of [function selectors as calculated 
 We define the interface identifier as the XOR of all function selectors in the interface. This code example shows how to calculate an interface identifier:
 
 ```solidity
-pragma solidity ^0.4.19;
+pragma solidity ^0.4.20;
 
 interface Solidity101 {
-    function hello() public pure;
-    function world(int) public pure;
+    function hello() external pure;
+    function world(int) external pure;
 }
 
 contract Selector {
@@ -58,7 +58,7 @@ Note: interfaces do not permit optional functions, therefore, the interface iden
 A contract that is compliant with ERC-165 shall implement the following interface (referred as `ERC165.sol`):
 
 ```solidity
-pragma solidity ^0.4.19;
+pragma solidity ^0.4.20;
 
 interface ERC165 {
     /// @notice Query if a contract implements an interface
@@ -113,7 +113,7 @@ Also [the ENS](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-137.md) alr
 Following is a caching contract that detects which interfaces other contracts implement. From @fulldecent and @jbaylina.
 
 ```solidity
-pragma solidity ^0.4.19;
+pragma solidity ^0.4.20;
 
 contract ERC165Cache {
     bytes4 constant InvalidID = 0xffffffff;
@@ -139,25 +139,42 @@ contract ERC165Cache {
     }
 
     function determineInterfaceImplementationStatus(address _contract, bytes4 _interfaceId) internal view returns (ImplStatus) {
-        if (noThrowCall(_contract, InvalidID)) return ImplStatus.No;
-        if (!noThrowCall(_contract, ERC165ID)) return ImplStatus.No;
-        if (noThrowCall(_contract, _interfaceId)) return ImplStatus.Yes;
+        uint256 success;
+        uint256 result;
+        
+        (success, result) = noThrowCall(_contract, ERC165ID);
+        if ((success==0)||(result==0)) {
+            return ImplStatus.No;
+        }
+
+        (success, result) = noThrowCall(_contract, InvalidID);
+        if ((success==0)||(result!=0)) {
+            return ImplStatus.No;
+        }
+
+        (success, result) = noThrowCall(_contract, _interfaceId);
+        if ((success==1)&&(result==1)) {
+            return ImplStatus.Yes;
+        }
         return ImplStatus.No;
     }
 
-    function noThrowCall(address _contract, bytes4 _interfaceId) internal view returns (bool result) {
+    function noThrowCall(address _contract, bytes4 _interfaceId) constant internal returns (uint256 success, uint256 result) {
         bytes4 erc165ID = ERC165ID;
+
         assembly {
                 let x := mload(0x40)               // Find empty storage location using "free memory pointer"
                 mstore(x, erc165ID)                // Place signature at begining of empty storage
                 mstore(add(x, 0x04), _interfaceId) // Place first argument directly next to signature
-                staticcall(30000,                  // 30k gas
-                     _contract,                    // To addr
-                     x,                            // Inputs are stored at location x
-                     0x8,                          // Inputs are 8 byes long
-                     x,                            // Store output over input (saves space)
-                     0x20)                         // Outputs are 32 bytes long
-                pop                                // Discard call return value
+
+                success := staticcall(
+                                    30000,         // 5k gas
+                                    _contract,     // To addr
+                                    x,             // Inputs are stored at location x
+                                    0x8,           // Inputs are 8 byes long
+                                    x,             // Store output over input (saves space)
+                                    0x20)          // Outputs are 32 bytes long
+
                 result := mload(x)                 // Load the result
         }
     }

--- a/EIPS/eip-165.md
+++ b/EIPS/eip-165.md
@@ -1,0 +1,121 @@
+## Preamble
+
+```
+EIP: <to be assigned>
+Title: ERC-165 Standard Interface Detection
+Author: Christian Reitwießner @chriseth, Nick Johnson @Arachnid, RJ Catalano @VoR0220, Fabian Vogelsteller @frozeman, Hudson Jameson @Souptacular, Jordi Baylina @jbaylina, Griff Green @griffgreen, William Entriken <github.com@phor.net>
+Type: Standard Track
+Category: ERC
+Status: Draft
+Created: 2018-01-23
+```
+
+## Simple Summary
+
+Creates a standard method to publish and detect what interfaces a smart contract implements.
+
+## Abstract
+
+Herein, we standardize the following:
+
+1. How interfaces are identified
+2. How a contract will publish the interfaces it implements
+3. How to detect if a contract implements ERC-165
+4. How to detect if a contract implements any given interface
+
+## Motivation
+
+For some "standard interfaces" like [the ERC-20 token interface](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20-token-standard.md), it is sometimes useful to query whether a contract supports the interface and if yes, which version of the interface, in order to adapt the way in which the contract is to be interfaced with. Specifically for ERC-20, a version identifier has already been proposed. This proposal stadardizes the concept of interfaces and standardizes the identification (naming) of interfaces.
+
+## Specification
+
+### How Interfaces are Identified
+
+For this standard, an *interface* is a set of [function selectors as calculated in Solidity](http://solidity.readthedocs.io/en/develop/abi-spec.html#function-selector). This a subset of [Solidity's concept of interfaces](http://solidity.readthedocs.io/en/develop/abi-spec.html) and the  `interface` keyword definition which also define return types, mutability and events.
+
+We define the interface identifier as the XOR of all function selectors in the interface. This code example shows how to calculate an interface identifier:
+
+```solidity
+pragma solidity ^0.4.19;
+
+interface Solidity101 {
+    function hello() public pure;
+    function world(int) public pure;
+}
+
+contract Selector {
+    function calculateSelector() public pure returns (bytes4) {
+        Solidity101 i;
+        return i.hello.selector ^ i.world.selector;
+    }
+}
+```
+
+Note: interfaces do not permit optional functions, therefore, the interface identity will not them.
+
+### How a Contract will Publish the Interfaces it Implements
+
+A contract that is compliant with ERC-165 shall implement the following function:
+
+```solidity
+pragma solidity ^0.4.19;
+
+interface ERC165 {
+    /// @notice Query if a contract implements an interface
+    /// @param interfaceID The interface identifier, as specified in ERC-165
+    /// @dev Interface identification is specified in ERC-165. This function
+    ///  use less than 30000 gas.
+    /// @return `true` if the contract implements `interfaceID` and
+    ///  `interfaceID` is not 0xffffffff, `false` otherwise
+    function supportsInterface(bytes4 interfaceID) external view returns (bool);
+}
+```
+
+The interface identifier for this interface is `0x01ffc9a7`. You can calculate this by running `        bytes4(keccak256('supportsInterface(bytes4)'));` or using the `Selector` contract above.
+
+Therefore the implementing contract will have a `supportsInterface` function that returns:
+
+- `true` when `interfaceID` is `0x01ffc9a7` (EIP165 interface)
+- `false` when `interfaceID` is `0xffffffff`
+- `true` for any other `interfaceID` this contract implements
+- `false` for any other `interfaceID`
+
+This function must return a bool and use at most 30000 gas.
+
+Implementation note, there are several logical ways to implement this function. Please see the example implementations and the discussion on gas usage.
+
+### How to Detect if a Contract Implements ERC-165
+
+1. The source contact makes a `CALL` to the destination address with input data: `0x01ffc9a701ffc9a7` value: 0 and gas 30000. This corresponds to `contract.supportsInterface("0x01ffc9a7")`.
+2. If the call fails or return false, the destination contract does not implement ERC-165.
+3. If the call returns true, a second call is made with input data `0x01ffc9a7ffffffff`.
+4. If the second call fails or returns true, the destination contract does not implement ERC-165.
+5. Otherwise it implements EIP165.
+
+### How to Detect if a Contract Implements any Given Interface
+
+1. If you are not sure if the contract implements ERC-165 Interface, use the previous procedure to confirm.
+2. If it does not implement ERC-165, then you will have to see what methods it uses the old fashioned way.
+3. If it implements ERC-165 then just call `supportsInterface(interfaceID)` to determine if it implements an interface you can use.
+
+## Rationale
+
+We tried to keep this specification as simple as possible. This implementation is also compatible with the current Solidity version.
+
+## Backwards Compatibility
+
+The mechanism described above (with `0xffffffff`) should work with most of the contracts previous to this standard to determine that they do not implement ERC-165.
+
+Also [the ENS](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-137.md) already implements this EIP.
+
+## Test Cases
+
+XXXXXXXX HELP NEEDED XXXXXXXXX
+
+## Implementation
+
+XXXXXX IN PROGRES XXXXXX [https://github.com/jbaylina/EIP165Cache](https://github.com/jbaylina/EIP165Cache)
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/EIPS/eip-165.md
+++ b/EIPS/eip-165.md
@@ -171,7 +171,7 @@ contract ERC165Cache {
                                     30000,         // 30k gas
                                     _contract,     // To addr
                                     x,             // Inputs are stored at location x
-                                    0x8,           // Inputs are 8 byes long
+                                    0x8,           // Inputs are 8 bytes long
                                     x,             // Store output over input (saves space)
                                     0x20)          // Outputs are 32 bytes long
 
@@ -186,7 +186,7 @@ contract ERC165Cache {
 This approach uses a `view` function implementation of `supportsInterface`. The execution cost is 586 gas for any input. But contract initialization requires storing each interface (`SSTORE` is 20,000 gas). The `ERC165MappingImplementation` contract is generic and reusable.
 
 ```solidity
-pragma solidity ^0.4.19;
+pragma solidity ^0.4.20;
 
 import "./ERC165.sol";
 
@@ -221,7 +221,7 @@ contract Lisa is ERC165MappingImplementation, Simpson {
 Following is a `pure` function implementation of `supportsInterface`. The worst-case execution cost is 236 gas, but increases linearly with a higher number of supported interfaces.
 
 ```solidity
-pragma solidity ^0.4.19;
+pragma solidity ^0.4.20;
 
 import "./ERC165.sol";
 

--- a/EIPS/eip-165.md
+++ b/EIPS/eip-165.md
@@ -51,13 +51,11 @@ contract Selector {
 }
 ```
 
-Note: interfaces do not permit optional functions, therefore, the interface identity will not include them.
-
-Note: an ERC standard may define multiple interfaces to separate core functionality from optional features. For example, [one draft standard defines](https://github.com/ethereum/EIPs/pull/841) ERC721, ERC721Metadata and ERC721Enumerable interfaces.
+Note: interfaces do not permit optional functions, therefore, the interface identity will not them.
 
 ### How a Contract will Publish the Interfaces it Implements
 
-A contract that is compliant with ERC-165 shall implement the following function:
+A contract that is compliant with ERC-165 shall implement the following interface (referred as `ERC165.sol`):
 
 ```solidity
 pragma solidity ^0.4.19;
@@ -115,6 +113,61 @@ Also [the ENS](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-137.md) alr
 XXXXXXXX HELP NEEDED XXXXXXXXX
 
 ## Implementation
+
+This approach uses a `view` function implementation of `supportsInterface`. The execution cost is 478 gas for any input. But contract initialization requires storing each interface (`SSTORE` is 20,000 gas).
+
+```solidity
+pragma solidity ^0.4.19;
+
+import "./ERC165.sol";
+
+interface Simpson {
+    function is2D() external returns (bool);
+    function skinColor() external returns (string);
+}
+
+contract Lisa is ERC165, Simpson {
+    mapping(bytes4 => bool) supportedInterfaces;
+    
+    function Lisa() public {
+        supportedInterfaces[this.supportsInterface.selector] = true;
+        supportedInterfaces[this.is2D.selector ^ this.skinColor.selector] = true;
+    }
+    
+    function supportsInterface(bytes4 interfaceID) external view returns (bool) {
+        return supportedInterfaces[interfaceID];
+    }
+    
+    // ... is usually 2D
+    // skin color is yellow
+}
+```
+
+Following is a `pure` function implementation of `supportsInterface`. The worst-case execution cost is 236 gas, but increases linearly with a higher number of supported interfaces.
+
+```solidity
+pragma solidity ^0.4.19;
+
+import "./ERC165.sol";
+
+interface Simpson {
+    function is2D() external returns (bool);
+    function skinColor() external returns (string);
+}
+
+contract Homer is ERC165, Simpson {
+    function supportsInterface(bytes4 interfaceID) external view returns (bool) {
+        return 
+          interfaceID == this.supportsInterface.selector || // ERC165
+          interfaceID == this.is2D.selector 
+                         ^ this.skinColor.selector; // Simpson
+    }
+}
+```
+
+With three or more supported interfaces (including ERC165 itself as a required supported interface), the mapping table approach (for any case) costs less gas than the worst case for pure approach.
+
+
 
 XXXXXX IN PROGRES XXXXXX [https://github.com/jbaylina/EIP165Cache](https://github.com/jbaylina/EIP165Cache)
 

--- a/EIPS/eip-165.md
+++ b/EIPS/eip-165.md
@@ -115,48 +115,29 @@ Following is a caching contract that detects which interfaces other contracts im
 ```solidity
 pragma solidity ^0.4.20;
 
-contract ERC165Cache {
+contract ERC165Query {
     bytes4 constant InvalidID = 0xffffffff;
     bytes4 constant ERC165ID = 0x01ffc9a7;
 
-    enum ImplStatus { Unknown, No, Yes }
-    mapping (address => mapping (bytes4 => ImplStatus)) cache;
-
-    // Return value from cache if available
-    function interfaceSupported(address _contract, bytes4 _interfaceId) external returns (bool) {
-        ImplStatus status = cache[_contract][_interfaceId];
-        if (status == ImplStatus.Unknown) {
-            return checkInterfaceSupported(_contract, _interfaceId);
-        }
-        return status == ImplStatus.Yes;
-    }
-
-    // Repull result into cache
-    function checkInterfaceSupported(address _contract, bytes4 _interfaceId) public returns (bool) {
-        ImplStatus status = determineInterfaceImplementationStatus(_contract, _interfaceId);
-        cache[_contract][_interfaceId] = status;
-        return status == ImplStatus.Yes;
-    }
-
-    function determineInterfaceImplementationStatus(address _contract, bytes4 _interfaceId) internal view returns (ImplStatus) {
+    function doesContractImplementInterface(address _contract, bytes4 _interfaceId) external view returns (bool) {
         uint256 success;
         uint256 result;
         
         (success, result) = noThrowCall(_contract, ERC165ID);
         if ((success==0)||(result==0)) {
-            return ImplStatus.No;
+            return false;
         }
 
         (success, result) = noThrowCall(_contract, InvalidID);
         if ((success==0)||(result!=0)) {
-            return ImplStatus.No;
+            return false;
         }
 
         (success, result) = noThrowCall(_contract, _interfaceId);
         if ((success==1)&&(result==1)) {
-            return ImplStatus.Yes;
+            return true;
         }
-        return ImplStatus.No;
+        return false;
     }
 
     function noThrowCall(address _contract, bytes4 _interfaceId) constant internal returns (uint256 success, uint256 result) {
@@ -171,7 +152,7 @@ contract ERC165Cache {
                                     30000,         // 30k gas
                                     _contract,     // To addr
                                     x,             // Inputs are stored at location x
-                                    0x20,           // Inputs are 8 byes long
+                                    0x20,          // Inputs are 8 byes long
                                     x,             // Store output over input (saves space)
                                     0x20)          // Outputs are 32 bytes long
 

--- a/EIPS/eip-165.md
+++ b/EIPS/eip-165.md
@@ -86,9 +86,9 @@ Implementation note, there are several logical ways to implement this function. 
 
 ### How to Detect if a Contract Implements ERC-165
 
-1. The source contact makes a `STATICCALL` to the destination address with input data: `0x01ffc9a701ffc9a7000000000000000000000000` and gas 30,000. This corresponds to `contract.supportsInterface(0x01ffc9a7)`.
+1. The source contact makes a `STATICCALL` to the destination address with input data: `0x01ffc9a701ffc9a700000000000000000000000000000000000000000000000000000000` and gas 30,000. This corresponds to `contract.supportsInterface(0x01ffc9a7)`.
 2. If the call fails or return false, the destination contract does not implement ERC-165.
-3. If the call returns true, a second call is made with input data `0x01ffc9a7ffffffff000000000000000000000000`.
+3. If the call returns true, a second call is made with input data `0x01ffc9a7ffffffff00000000000000000000000000000000000000000000000000000000`.
 4. If the second call fails or returns true, the destination contract does not implement ERC-165.
 5. Otherwise it implements ERC-165.
 

--- a/EIPS/eip-165.md
+++ b/EIPS/eip-165.md
@@ -51,7 +51,9 @@ contract Selector {
 }
 ```
 
-Note: interfaces do not permit optional functions, therefore, the interface identity will not them.
+Note: interfaces do not permit optional functions, therefore, the interface identity will not include them.
+
+Note: an ERC standard may define multiple interfaces to separate core functionality from optional features. For example, [one draft standard defines](https://github.com/ethereum/EIPs/pull/841) ERC721, ERC721Metadata and ERC721Enumerable interfaces.
 
 ### How a Contract will Publish the Interfaces it Implements
 

--- a/EIPS/eip-165.md
+++ b/EIPS/eip-165.md
@@ -25,7 +25,7 @@ Herein, we standardize the following:
 
 ## Motivation
 
-For some "standard interfaces" like [the ERC-20 token interface](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20-token-standard.md), it is sometimes useful to query whether a contract supports the interface and if yes, which version of the interface, in order to adapt the way in which the contract is to be interfaced with. Specifically for ERC-20, a version identifier has already been proposed. This proposal stadardizes the concept of interfaces and standardizes the identification (naming) of interfaces.
+For some "standard interfaces" like [the ERC-20 token interface](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20.md), it is sometimes useful to query whether a contract supports the interface and if yes, which version of the interface, in order to adapt the way in which the contract is to be interfaced with. Specifically for ERC-20, a version identifier has already been proposed. This proposal stadardizes the concept of interfaces and standardizes the identification (naming) of interfaces.
 
 ## Specification
 

--- a/EIPS/eip-165.md
+++ b/EIPS/eip-165.md
@@ -3,7 +3,7 @@
 ```
 EIP: <to be assigned>
 Title: ERC-165 Standard Interface Detection
-Author: Christian Reitwießner @chriseth, Nick Johnson @Arachnid, RJ Catalano @VoR0220, Fabian Vogelsteller @frozeman, Hudson Jameson @Souptacular, Jordi Baylina @jbaylina, Griff Green @griffgreen, William Entriken <github.com@phor.net>
+Author: Christian Reitwießner <chris@ethereum.org>, Nick Johnson <nick@ethereum.org>, RJ Catalano <rj@monax.io>, Fabian Vogelsteller <fabian@frozeman.de>, Hudson Jameson <hudson@hudsonjameson.com>, Jordi Baylina <jordi@baylina.cat>, Griff Green <saveoursonics@gmail.com>, William Entriken <github.com@phor.net>
 Type: Standard Track
 Category: ERC
 Status: Draft

--- a/EIPS/eip-165.md
+++ b/EIPS/eip-165.md
@@ -25,7 +25,7 @@ Herein, we standardize the following:
 
 ## Motivation
 
-For some "standard interfaces" like [the ERC-20 token interface](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20.md), it is sometimes useful to query whether a contract supports the interface and if yes, which version of the interface, in order to adapt the way in which the contract is to be interfaced with. Specifically for ERC-20, a version identifier has already been proposed. This proposal stadardizes the concept of interfaces and standardizes the identification (naming) of interfaces.
+For some "standard interfaces" like [the ERC-20 token interface](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20.md), it is sometimes useful to query whether a contract supports the interface and if yes, which version of the interface, in order to adapt the way in which the contract is to be interacted with. Specifically for ERC-20, a version identifier has already been proposed. This proposal stadardizes the concept of interfaces and standardizes the identification (naming) of interfaces.
 
 ## Specification
 

--- a/EIPS/eip-165.md
+++ b/EIPS/eip-165.md
@@ -86,9 +86,9 @@ Implementation note, there are several logical ways to implement this function. 
 
 ### How to Detect if a Contract Implements ERC-165
 
-1. The source contact makes a `STATICCALL` to the destination address with input data: `0x01ffc9a701ffc9a7` and gas 30,000. This corresponds to `contract.supportsInterface("0x01ffc9a7")`.
+1. The source contact makes a `STATICCALL` to the destination address with input data: `0x01ffc9a700000000000000000000000001ffc9a7` and gas 30,000. This corresponds to `contract.supportsInterface("0x01ffc9a7")`.
 2. If the call fails or return false, the destination contract does not implement ERC-165.
-3. If the call returns true, a second call is made with input data `0x01ffc9a7ffffffff`.
+3. If the call returns true, a second call is made with input data `0x01ffc9a7000000000000000000000000ffffffff`.
 4. If the second call fails or returns true, the destination contract does not implement ERC-165.
 5. Otherwise it implements ERC-165.
 
@@ -171,7 +171,7 @@ contract ERC165Cache {
                                     30000,         // 30k gas
                                     _contract,     // To addr
                                     x,             // Inputs are stored at location x
-                                    0x8,           // Inputs are 8 bytes long
+                                    0x20,           // Inputs are 8 byes long
                                     x,             // Store output over input (saves space)
                                     0x20)          // Outputs are 32 bytes long
 

--- a/EIPS/eip-165.md
+++ b/EIPS/eip-165.md
@@ -31,7 +31,7 @@ For some "standard interfaces" like [the ERC-20 token interface](https://github.
 
 ### How Interfaces are Identified
 
-For this standard, an *interface* is a set of [function selectors as defined by the Ethereum ABI](http://solidity.readthedocs.io/en/develop/abi-spec.html#function-selector). This a subset of [Solidity's concept of interfaces](http://solidity.readthedocs.io/en/develop/abi-spec.html) and the  `interface` keyword definition which also define return types, mutability and events.
+For this standard, an *interface* is a set of [function selectors as defined by the Ethereum ABI](http://solidity.readthedocs.io/en/develop/abi-spec.html#function-selector). This a subset of [Solidity's concept of interfaces](http://solidity.readthedocs.io/en/develop/abi-spec.html) and the  `interface` keyword definition which also defines return types, mutability and events.
 
 We define the interface identifier as the XOR of all function selectors in the interface. This code example shows how to calculate an interface identifier:
 
@@ -51,7 +51,7 @@ contract Selector {
 }
 ```
 
-Note: interfaces do not permit optional functions, therefore, the interface identity will not them.
+Note: interfaces do not permit optional functions, therefore, the interface identity will not include them.
 
 ### How a Contract will Publish the Interfaces it Implements
 
@@ -64,7 +64,7 @@ interface ERC165 {
     /// @notice Query if a contract implements an interface
     /// @param interfaceID The interface identifier, as specified in ERC-165
     /// @dev Interface identification is specified in ERC-165. This function
-    ///  uses less than 30000 gas.
+    ///  uses less than 30,000 gas.
     /// @return `true` if the contract implements `interfaceID` and
     ///  `interfaceID` is not 0xffffffff, `false` otherwise
     function supportsInterface(bytes4 interfaceID) external view returns (bool);
@@ -80,22 +80,22 @@ Therefore the implementing contract will have a `supportsInterface` function tha
 - `true` for any other `interfaceID` this contract implements
 - `false` for any other `interfaceID`
 
-This function must return a bool and use at most 30000 gas.
+This function must return a bool and use at most 30,000 gas.
 
 Implementation note, there are several logical ways to implement this function. Please see the example implementations and the discussion on gas usage.
 
 ### How to Detect if a Contract Implements ERC-165
 
-1. The source contact makes a static `CALL` to the destination address with input data: `0x01ffc9a701ffc9a7` value: 0 and gas 30000. This corresponds to `contract.supportsInterface("0x01ffc9a7")`.
+1. The source contact makes a `STATICCALL` to the destination address with input data: `0x01ffc9a701ffc9a7` and gas 30,000. This corresponds to `contract.supportsInterface("0x01ffc9a7")`.
 2. If the call fails or return false, the destination contract does not implement ERC-165.
 3. If the call returns true, a second call is made with input data `0x01ffc9a7ffffffff`.
 4. If the second call fails or returns true, the destination contract does not implement ERC-165.
-5. Otherwise it implements EIP165.
+5. Otherwise it implements ERC-165.
 
 ### How to Detect if a Contract Implements any Given Interface
 
-1. If you are not sure if the contract implements ERC-165 Interface, use the previous procedure to confirm.
-2. If it does not implement ERC-165, then you will have to see what methods it uses the old fashioned way.
+1. If you are not sure if the contract implements ERC-165, use the above procedure to confirm.
+2. If it does not implement ERC-165, then you will have to see what methods it uses the old-fashioned way.
 3. If it implements ERC-165 then just call `supportsInterface(interfaceID)` to determine if it implements an interface you can use.
 
 ## Rationale
@@ -168,7 +168,7 @@ contract ERC165Cache {
                 mstore(add(x, 0x04), _interfaceId) // Place first argument directly next to signature
 
                 success := staticcall(
-                                    30000,         // 5k gas
+                                    30000,         // 30k gas
                                     _contract,     // To addr
                                     x,             // Inputs are stored at location x
                                     0x8,           // Inputs are 8 byes long
@@ -240,7 +240,7 @@ contract Homer is ERC165, Simpson {
 }
 ```
 
-With three or more supported interfaces (including ERC165 itself as a required supported interface), the mapping table approach (for any case) costs less gas than the worst case for pure approach.
+With three or more supported interfaces (including ERC165 itself as a required supported interface), the mapping approach (in every case) costs less gas than the pure approach (at worst case).
 
 ## Copyright
 

--- a/EIPS/eip-165.md
+++ b/EIPS/eip-165.md
@@ -3,7 +3,7 @@
 ```
 EIP: <to be assigned>
 Title: ERC-165 Standard Interface Detection
-Author: Christian Reitwießner <chris@ethereum.org>, Nick Johnson <nick@ethereum.org>, RJ Catalano <rj@monax.io>, Fabian Vogelsteller <fabian@frozeman.de>, Hudson Jameson <hudson@hudsonjameson.com>, Jordi Baylina <jordi@baylina.cat>, Griff Green <saveoursonics@gmail.com>, William Entriken <github.com@phor.net>
+Author: Christian Reitwießner <chris@ethereum.org>, Nick Johnson <nick@ethereum.org>, RJ Catalano <rj@monax.io>, Fabian Vogelsteller <fabian@frozeman.de>, Hudson Jameson <hudson@hudsonjameson.com>, Jordi Baylina <jordi@baylina.cat>, Griff Green <saveoursonics@gmail.com>, Konrad Feldmeier <konrad.feldmeier@brainbot.com>, William Entriken <github.com@phor.net>
 Type: Standard Track
 Category: ERC
 Status: Draft

--- a/EIPS/eip-165.md
+++ b/EIPS/eip-165.md
@@ -86,7 +86,7 @@ Implementation note, there are several logical ways to implement this function. 
 
 ### How to Detect if a Contract Implements ERC-165
 
-1. The source contact makes a `CALL` to the destination address with input data: `0x01ffc9a701ffc9a7` value: 0 and gas 30000. This corresponds to `contract.supportsInterface("0x01ffc9a7")`.
+1. The source contact makes a static `CALL` to the destination address with input data: `0x01ffc9a701ffc9a7` value: 0 and gas 30000. This corresponds to `contract.supportsInterface("0x01ffc9a7")`.
 2. If the call fails or return false, the destination contract does not implement ERC-165.
 3. If the call returns true, a second call is made with input data `0x01ffc9a7ffffffff`.
 4. If the second call fails or returns true, the destination contract does not implement ERC-165.
@@ -110,36 +110,96 @@ Also [the ENS](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-137.md) alr
 
 ## Test Cases
 
-XXXXXXXX HELP NEEDED XXXXXXXXX
+Following is a caching contract that detects which interfaces other contracts implement. From @fulldecent and @jbaylina.
+
+```solidity
+pragma solidity ^0.4.19;
+
+contract ERC165Cache {
+    bytes4 constant InvalidID = 0xffffffff;
+    bytes4 constant ERC165ID = 0x01ffc9a7;
+
+    enum ImplStatus { Unknown, No, Yes }
+    mapping (address => mapping (bytes4 => ImplStatus)) cache;
+
+    // Return value from cache if available
+    function interfaceSupported(address _contract, bytes4 _interfaceId) external returns (bool) {
+        ImplStatus status = cache[_contract][_interfaceId];
+        if (status == ImplStatus.Unknown) {
+            return checkInterfaceSupported(_contract, _interfaceId);
+        }
+        return status == ImplStatus.Yes;
+    }
+
+    // Repull result into cache
+    function checkInterfaceSupported(address _contract, bytes4 _interfaceId) public returns (bool) {
+        ImplStatus status = determineInterfaceImplementationStatus(_contract, _interfaceId);
+        cache[_contract][_interfaceId] = status;
+        return status == ImplStatus.Yes;
+    }
+
+    function determineInterfaceImplementationStatus(address _contract, bytes4 _interfaceId) internal view returns (ImplStatus) {
+        if (noThrowCall(_contract, InvalidID)) return ImplStatus.No;
+        if (!noThrowCall(_contract, ERC165ID)) return ImplStatus.No;
+        if (noThrowCall(_contract, _interfaceId)) return ImplStatus.Yes;
+        return ImplStatus.No;
+    }
+
+    // Update this after the Metropolis hard fork to use staticcall!
+    function noThrowCall(address _contract, bytes4 _interfaceId) internal view returns (bool result) {
+        bytes4 erc165ID = ERC165ID;
+        assembly {
+                let x := mload(0x40)               // Find empty storage location using "free memory pointer"
+                mstore(x, erc165ID)                // Place signature at begining of empty storage
+                mstore(add(x, 0x04), _interfaceId) // Place first argument directly next to signature
+                call(30000,                        // 30k gas
+                     _contract,                    // To addr
+                     0,                            // No value
+                     x,                            // Inputs are stored at location x
+                     0x8,                          // Inputs are 8 byes long
+                     x,                            // Store output over input (saves space)
+                     0x20)                         // Outputs are 32 bytes long
+                pop                                // Discard call return value
+                result := mload(x)                 // Load the result
+        }
+    }
+}
+```
 
 ## Implementation
 
-This approach uses a `view` function implementation of `supportsInterface`. The execution cost is 478 gas for any input. But contract initialization requires storing each interface (`SSTORE` is 20,000 gas).
+This approach uses a `view` function implementation of `supportsInterface`. The execution cost is 586 gas for any input. But contract initialization requires storing each interface (`SSTORE` is 20,000 gas). The `ERC165MappingImplementation` contract is generic and reusable.
 
 ```solidity
 pragma solidity ^0.4.19;
 
 import "./ERC165.sol";
 
+contract ERC165MappingImplementation is ERC165 {
+    /// @dev You must not set element 0xffffffff to true
+    mapping(bytes4 => bool) internal supportedInterfaces;
+
+    function ERC165MappingImplementation() internal {
+        supportedInterfaces[this.supportsInterface.selector] = true;
+    }
+
+    function supportsInterface(bytes4 interfaceID) external view returns (bool) {
+        return supportedInterfaces[interfaceID];
+    }
+}
+
 interface Simpson {
     function is2D() external returns (bool);
     function skinColor() external returns (string);
 }
 
-contract Lisa is ERC165, Simpson {
-    mapping(bytes4 => bool) supportedInterfaces;
-    
+contract Lisa is ERC165MappingImplementation, Simpson {
     function Lisa() public {
-        supportedInterfaces[this.supportsInterface.selector] = true;
         supportedInterfaces[this.is2D.selector ^ this.skinColor.selector] = true;
     }
     
-    function supportsInterface(bytes4 interfaceID) external view returns (bool) {
-        return supportedInterfaces[interfaceID];
-    }
-    
-    // ... is usually 2D
-    // skin color is yellow
+    function is2D() external returns (bool){}
+    function skinColor() external returns (string){}
 }
 ```
 
@@ -166,10 +226,6 @@ contract Homer is ERC165, Simpson {
 ```
 
 With three or more supported interfaces (including ERC165 itself as a required supported interface), the mapping table approach (for any case) costs less gas than the worst case for pure approach.
-
-
-
-XXXXXX IN PROGRES XXXXXX [https://github.com/jbaylina/EIP165Cache](https://github.com/jbaylina/EIP165Cache)
 
 ## Copyright
 

--- a/EIPS/eip-165.md
+++ b/EIPS/eip-165.md
@@ -3,7 +3,7 @@
 ```
 EIP: <to be assigned>
 Title: ERC-165 Standard Interface Detection
-Author: Christian Reitwießner <chris@ethereum.org>, Nick Johnson <nick@ethereum.org>, RJ Catalano <rj@monax.io>, Fabian Vogelsteller <fabian@frozeman.de>, Hudson Jameson <hudson@hudsonjameson.com>, Jordi Baylina <jordi@baylina.cat>, Griff Green <saveoursonics@gmail.com>, Konrad Feldmeier <konrad.feldmeier@brainbot.com>, William Entriken <github.com@phor.net>
+Author: Christian Reitwießner <chris@ethereum.org>, Nick Johnson <nick@ethereum.org>, Fabian Vogelsteller <fabian@frozeman.de>, Jordi Baylina <jordi@baylina.cat>, Konrad Feldmeier <konrad.feldmeier@brainbot.com>, William Entriken <github.com@phor.net>
 Type: Standard Track
 Category: ERC
 Status: Draft

--- a/EIPS/eip-165.md
+++ b/EIPS/eip-165.md
@@ -152,7 +152,7 @@ contract ERC165Query {
                                     30000,         // 30k gas
                                     _contract,     // To addr
                                     x,             // Inputs are stored at location x
-                                    0x20,          // Inputs are 8 byes long
+                                    0x20,          // Inputs are 32 bytes long
                                     x,             // Store output over input (saves space)
                                     0x20)          // Outputs are 32 bytes long
 

--- a/EIPS/eip-165.md
+++ b/EIPS/eip-165.md
@@ -64,7 +64,7 @@ interface ERC165 {
     /// @notice Query if a contract implements an interface
     /// @param interfaceID The interface identifier, as specified in ERC-165
     /// @dev Interface identification is specified in ERC-165. This function
-    ///  use less than 30000 gas.
+    ///  uses less than 30000 gas.
     /// @return `true` if the contract implements `interfaceID` and
     ///  `interfaceID` is not 0xffffffff, `false` otherwise
     function supportsInterface(bytes4 interfaceID) external view returns (bool);

--- a/EIPS/eip-165.md
+++ b/EIPS/eip-165.md
@@ -31,7 +31,7 @@ For some "standard interfaces" like [the ERC-20 token interface](https://github.
 
 ### How Interfaces are Identified
 
-For this standard, an *interface* is a set of [function selectors as calculated in Solidity](http://solidity.readthedocs.io/en/develop/abi-spec.html#function-selector). This a subset of [Solidity's concept of interfaces](http://solidity.readthedocs.io/en/develop/abi-spec.html) and the  `interface` keyword definition which also define return types, mutability and events.
+For this standard, an *interface* is a set of [function selectors as defined by the Ethereum ABI](http://solidity.readthedocs.io/en/develop/abi-spec.html#function-selector). This a subset of [Solidity's concept of interfaces](http://solidity.readthedocs.io/en/develop/abi-spec.html) and the  `interface` keyword definition which also define return types, mutability and events.
 
 We define the interface identifier as the XOR of all function selectors in the interface. This code example shows how to calculate an interface identifier:
 

--- a/EIPS/eip-165.md
+++ b/EIPS/eip-165.md
@@ -110,7 +110,7 @@ Also [the ENS](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-137.md) alr
 
 ## Test Cases
 
-Following is a caching contract that detects which interfaces other contracts implement. From @fulldecent and @jbaylina.
+Following is a contract that detects which interfaces other contracts implement. From @fulldecent and @jbaylina.
 
 ```solidity
 pragma solidity ^0.4.20;

--- a/EIPS/eip-165.md
+++ b/EIPS/eip-165.md
@@ -1,7 +1,7 @@
 ## Preamble
 
 ```
-EIP: <to be assigned>
+EIP: 165
 Title: ERC-165 Standard Interface Detection
 Author: Christian Reitwießner <chris@ethereum.org>, Nick Johnson <nick@ethereum.org>, Fabian Vogelsteller <fabian@frozeman.de>, Jordi Baylina <jordi@baylina.cat>, Konrad Feldmeier <konrad.feldmeier@brainbot.com>, William Entriken <github.com@phor.net>
 Type: Standard Track

--- a/EIPS/eip-165.md
+++ b/EIPS/eip-165.md
@@ -218,6 +218,9 @@ contract Homer is ERC165, Simpson {
           interfaceID == this.is2D.selector 
                          ^ this.skinColor.selector; // Simpson
     }
+    
+    function is2D() external returns (bool){}
+    function skinColor() external returns (string){}
 }
 ```
 

--- a/EIPS/eip-165.md
+++ b/EIPS/eip-165.md
@@ -145,16 +145,14 @@ contract ERC165Cache {
         return ImplStatus.No;
     }
 
-    // Update this after the Metropolis hard fork to use staticcall!
     function noThrowCall(address _contract, bytes4 _interfaceId) internal view returns (bool result) {
         bytes4 erc165ID = ERC165ID;
         assembly {
                 let x := mload(0x40)               // Find empty storage location using "free memory pointer"
                 mstore(x, erc165ID)                // Place signature at begining of empty storage
                 mstore(add(x, 0x04), _interfaceId) // Place first argument directly next to signature
-                call(30000,                        // 30k gas
+                staticcall(30000,                  // 30k gas
                      _contract,                    // To addr
-                     0,                            // No value
                      x,                            // Inputs are stored at location x
                      0x8,                          // Inputs are 8 byes long
                      x,                            // Store output over input (saves space)


### PR DESCRIPTION
**Reference**

* The original ERC-165 issue https://github.com/ethereum/EIPs/issues/165

**Work plan**

- [x] Need a best practice test case
   - [x] Update EIP165Cache from @jbaylina, https://github.com/jbaylina/EIP165Cache/issues/1, https://github.com/jbaylina/EIP165Cache/issues/2, https://github.com/jbaylina/EIP165Cache/issues/3, https://github.com/jbaylina/EIP165Cache/issues/4
- [x] Add implementations
   - [x] Add an example using the `mapping(bytes4=>bool)` approach (this is O(1) gas)
   - [x] Add an example using the `interfaceId == a || interfaceId == b || ...` approach (this is O(n) gas)
   - [x] Compare the gas costs, when does the O(n) exceed the O(1)?
- [ ] Get to draft status
- [ ] Get to approved

BELOW IS A COMPLETE COPY OF THE [LATEST FULL TEXT PROPOSAL](https://github.com/fulldecent/EIPs/blob/patch-4/EIPS/eip-165.md) **(VERSION 03c67d2)** FOR YOUR CONVENIENCE.

---

## Preamble

```
EIP: <to be assigned>
Title: ERC-165 Standard Interface Detection
Author: Christian Reitwießner <chris@ethereum.org>, Nick Johnson <nick@ethereum.org>, Fabian Vogelsteller <fabian@frozeman.de>, Jordi Baylina <jordi@baylina.cat>, Konrad Feldmeier <konrad.feldmeier@brainbot.com>, William Entriken <github.com@phor.net>
Type: Standard Track
Category: ERC
Status: Draft
Created: 2018-01-23
```

## Simple Summary

Creates a standard method to publish and detect what interfaces a smart contract implements.

## Abstract

Herein, we standardize the following:

1. How interfaces are identified
2. How a contract will publish the interfaces it implements
3. How to detect if a contract implements ERC-165
4. How to detect if a contract implements any given interface

## Motivation

For some "standard interfaces" like [the ERC-20 token interface](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20-token-standard.md), it is sometimes useful to query whether a contract supports the interface and if yes, which version of the interface, in order to adapt the way in which the contract is to be interfaced with. Specifically for ERC-20, a version identifier has already been proposed. This proposal stadardizes the concept of interfaces and standardizes the identification (naming) of interfaces.

## Specification

### How Interfaces are Identified

For this standard, an *interface* is a set of [function selectors as defined by the Ethereum ABI](http://solidity.readthedocs.io/en/develop/abi-spec.html#function-selector). This a subset of [Solidity's concept of interfaces](http://solidity.readthedocs.io/en/develop/abi-spec.html) and the  `interface` keyword definition which also defines return types, mutability and events.

We define the interface identifier as the XOR of all function selectors in the interface. This code example shows how to calculate an interface identifier:

```solidity
pragma solidity ^0.4.20;

interface Solidity101 {
    function hello() external pure;
    function world(int) external pure;
}

contract Selector {
    function calculateSelector() public pure returns (bytes4) {
        Solidity101 i;
        return i.hello.selector ^ i.world.selector;
    }
}
```

Note: interfaces do not permit optional functions, therefore, the interface identity will not include them.

### How a Contract will Publish the Interfaces it Implements

A contract that is compliant with ERC-165 shall implement the following interface (referred as `ERC165.sol`):

```solidity
pragma solidity ^0.4.20;

interface ERC165 {
    /// @notice Query if a contract implements an interface
    /// @param interfaceID The interface identifier, as specified in ERC-165
    /// @dev Interface identification is specified in ERC-165. This function
    ///  uses less than 30,000 gas.
    /// @return `true` if the contract implements `interfaceID` and
    ///  `interfaceID` is not 0xffffffff, `false` otherwise
    function supportsInterface(bytes4 interfaceID) external view returns (bool);
}
```

The interface identifier for this interface is `0x01ffc9a7`. You can calculate this by running `        bytes4(keccak256('supportsInterface(bytes4)'));` or using the `Selector` contract above.

Therefore the implementing contract will have a `supportsInterface` function that returns:

- `true` when `interfaceID` is `0x01ffc9a7` (EIP165 interface)
- `false` when `interfaceID` is `0xffffffff`
- `true` for any other `interfaceID` this contract implements
- `false` for any other `interfaceID`

This function must return a bool and use at most 30,000 gas.

Implementation note, there are several logical ways to implement this function. Please see the example implementations and the discussion on gas usage.

### How to Detect if a Contract Implements ERC-165

1. The source contact makes a `STATICCALL` to the destination address with input data: `0x01ffc9a701ffc9a700000000000000000000000000000000000000000000000000000000` and gas 30,000. This corresponds to `contract.supportsInterface(0x01ffc9a7)`.
2. If the call fails or return false, the destination contract does not implement ERC-165.
3. If the call returns true, a second call is made with input data `0x01ffc9a7ffffffff00000000000000000000000000000000000000000000000000000000`.
4. If the second call fails or returns true, the destination contract does not implement ERC-165.
5. Otherwise it implements ERC-165.

### How to Detect if a Contract Implements any Given Interface

1. If you are not sure if the contract implements ERC-165, use the above procedure to confirm.
2. If it does not implement ERC-165, then you will have to see what methods it uses the old-fashioned way.
3. If it implements ERC-165 then just call `supportsInterface(interfaceID)` to determine if it implements an interface you can use.

## Rationale

We tried to keep this specification as simple as possible. This implementation is also compatible with the current Solidity version.

## Backwards Compatibility

The mechanism described above (with `0xffffffff`) should work with most of the contracts previous to this standard to determine that they do not implement ERC-165.

Also [the ENS](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-137.md) already implements this EIP.

## Test Cases

Following is a contract that detects which interfaces other contracts implement. From @fulldecent and @jbaylina.

```solidity
pragma solidity ^0.4.20;

contract ERC165Query {
    bytes4 constant InvalidID = 0xffffffff;
    bytes4 constant ERC165ID = 0x01ffc9a7;

    function doesContractImplementInterface(address _contract, bytes4 _interfaceId) external view returns (bool) {
        uint256 success;
        uint256 result;
        
        (success, result) = noThrowCall(_contract, ERC165ID);
        if ((success==0)||(result==0)) {
            return false;
        }

        (success, result) = noThrowCall(_contract, InvalidID);
        if ((success==0)||(result!=0)) {
            return false;
        }

        (success, result) = noThrowCall(_contract, _interfaceId);
        if ((success==1)&&(result==1)) {
            return true;
        }
        return false;
    }

    function noThrowCall(address _contract, bytes4 _interfaceId) constant internal returns (uint256 success, uint256 result) {
        bytes4 erc165ID = ERC165ID;

        assembly {
                let x := mload(0x40)               // Find empty storage location using "free memory pointer"
                mstore(x, erc165ID)                // Place signature at begining of empty storage
                mstore(add(x, 0x04), _interfaceId) // Place first argument directly next to signature

                success := staticcall(
                                    30000,         // 30k gas
                                    _contract,     // To addr
                                    x,             // Inputs are stored at location x
                                    0x20,          // Inputs are 32 bytes long
                                    x,             // Store output over input (saves space)
                                    0x20)          // Outputs are 32 bytes long

                result := mload(x)                 // Load the result
        }
    }
}
```

## Implementation

This approach uses a `view` function implementation of `supportsInterface`. The execution cost is 586 gas for any input. But contract initialization requires storing each interface (`SSTORE` is 20,000 gas). The `ERC165MappingImplementation` contract is generic and reusable.

```solidity
pragma solidity ^0.4.20;

import "./ERC165.sol";

contract ERC165MappingImplementation is ERC165 {
    /// @dev You must not set element 0xffffffff to true
    mapping(bytes4 => bool) internal supportedInterfaces;

    function ERC165MappingImplementation() internal {
        supportedInterfaces[this.supportsInterface.selector] = true;
    }

    function supportsInterface(bytes4 interfaceID) external view returns (bool) {
        return supportedInterfaces[interfaceID];
    }
}

interface Simpson {
    function is2D() external returns (bool);
    function skinColor() external returns (string);
}

contract Lisa is ERC165MappingImplementation, Simpson {
    function Lisa() public {
        supportedInterfaces[this.is2D.selector ^ this.skinColor.selector] = true;
    }
    
    function is2D() external returns (bool){}
    function skinColor() external returns (string){}
}
```

Following is a `pure` function implementation of `supportsInterface`. The worst-case execution cost is 236 gas, but increases linearly with a higher number of supported interfaces.

```solidity
pragma solidity ^0.4.20;

import "./ERC165.sol";

interface Simpson {
    function is2D() external returns (bool);
    function skinColor() external returns (string);
}

contract Homer is ERC165, Simpson {
    function supportsInterface(bytes4 interfaceID) external view returns (bool) {
        return 
          interfaceID == this.supportsInterface.selector || // ERC165
          interfaceID == this.is2D.selector 
                         ^ this.skinColor.selector; // Simpson
    }
    
    function is2D() external returns (bool){}
    function skinColor() external returns (string){}
}
```

With three or more supported interfaces (including ERC165 itself as a required supported interface), the mapping approach (in every case) costs less gas than the pure approach (at worst case).

## Copyright

Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).