### PR TITLE
Add Nick Savers, remove Yoichi on EIP editors list

### DIFF
--- a/EIPS/eip-1.md
+++ b/EIPS/eip-1.md
@@ -184,8 +184,6 @@ The current EIP editors are
 
 ` * Nick Johnson (@arachnid)`
 
-` * Yoichi Hirai (@pirapira)`
-
 ` * Vitalik Buterin (@vbuterin)`
 
 ` * Nick Savers (@nicksavers)`

--- a/EIPS/eip-1.md
+++ b/EIPS/eip-1.md
@@ -188,6 +188,9 @@ The current EIP editors are
 
 ` * Vitalik Buterin (@vbuterin)`
 
+` * Nick Savers (@nicksavers)`
+
+
 EIP Editor Responsibilities and Workflow
 --------------------------------------
 


### PR DESCRIPTION
As discussed in https://github.com/ethereum/pm/blob/master/All%20Core%20Devs%20Meetings/Meeting%2031.md#10957-decision-process-for-eips

@nicksavers is now an editor for the EIPs.