### PR TITLE
Immutability Enforcement Proposal (IMP)

### DIFF
--- a/EIPS/eip-894.md
+++ b/EIPS/eip-894.md
@@ -1,0 +1,36 @@
+## Preamble
+
+    EIP: 894
+    Title: Immutability Enforcement Proposal (IMP)
+    Author: Marius Kjærstad
+    Type: Meta
+    Status: Draft
+    Created: 2018-02-21
+
+
+## Simple Summary
+Provide a standardized response against proposals for bailouts on the offical Ethereum repositories.
+
+
+## Abstract
+Proposals that advocate for any state changes to the Ethereum blockchain should not be merged into the official Ethereum repositories.
+
+
+## Motivation
+The issue of bailouts on the Ethereum blockchain is always controversial. This EIP attempts to raise the barriers for bailouts.
+
+
+## Specification
+If a pull request is opened that advocates for bailouts or implements code that can result in state changes on the Ethereum blockchain, it will be closed.
+
+
+### Justification
+Bailouts play favorites with some accounts on the Ethereum blockchain. This is corruption we can not tolerate in the offical Ethereum repositories.
+
+
+## Rationale
+The primary consideration for the approach described above was to reject all bailouts.  A secondary consideration was to standardize the response to such pull requests.
+
+
+## Copyright
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/EIPS/eip-894.md
+++ b/EIPS/eip-894.md
@@ -1,18 +1,20 @@
-## Preamble
-
-    EIP: 894
-    Title: Immutability Enforcement Proposal (IMP)
-    Author: Marius Kjærstad
-    Type: Meta
-    Status: Draft
-    Created: 2018-02-21
+---
+eip: 894
+title: Immutability Enforcement Proposal (IMP)
+author: Marius Kjærstad
+type: Meta
+category: Standards Track
+status: Draft
+created: 2018-02-21
+---
 
 
 ## Definition
 The definition of bailouts in this EIP is state changes to the Ethereum blockchain, through a hardfork, that treat account holders in different ways.
 
+
 ## Simple Summary
-Provide a standardized response against proposals for bailouts on the offical Ethereum repositories.
+Provide a standardized response against proposals for bailouts on the official Ethereum repositories.
 
 
 ## Abstract
@@ -28,7 +30,7 @@ If a pull request is opened that advocates for bailouts or implements code that 
 
 
 ## Justification
-Bailouts play favorites with some accounts on the Ethereum blockchain. This is corruption we can not tolerate in the offical Ethereum repositories.
+Bailouts play favorites with some accounts on the Ethereum blockchain. This is corruption we can not tolerate in the official Ethereum repositories.
 
 
 ## Rationale

--- a/EIPS/eip-894.md
+++ b/EIPS/eip-894.md
@@ -8,12 +8,15 @@
     Created: 2018-02-21
 
 
+## Definition
+The definition of bailouts in this EIP is state changes to the Ethereum blockchain, through a hardfork, that treat account holders in different ways.
+
 ## Simple Summary
 Provide a standardized response against proposals for bailouts on the offical Ethereum repositories.
 
 
 ## Abstract
-Proposals that advocate for any state changes to the Ethereum blockchain should not be merged into the official Ethereum repositories.
+Proposals that advocate for bailouts on the Ethereum blockchain should not be merged into the official Ethereum repositories.
 
 
 ## Motivation
@@ -21,15 +24,15 @@ The issue of bailouts on the Ethereum blockchain is always controversial. This E
 
 
 ## Specification
-If a pull request is opened that advocates for bailouts or implements code that can result in state changes on the Ethereum blockchain, it will be closed.
+If a pull request is opened that advocates for bailouts or implements code that will execute bailouts on the Ethereum blockchain, it will be closed by the maintainers.
 
 
-### Justification
+## Justification
 Bailouts play favorites with some accounts on the Ethereum blockchain. This is corruption we can not tolerate in the offical Ethereum repositories.
 
 
 ## Rationale
-The primary consideration for the approach described above was to reject all bailouts.  A secondary consideration was to standardize the response to such pull requests.
+The primary consideration for the approach described above was to reject all bailouts. A secondary consideration was to standardize the response to such pull requests.
 
 
 ## Copyright


### PR DESCRIPTION
Provide a standardized response against proposals for bailouts on the offical Ethereum repositories.