### PR TITLE
Change `constant` modifier to `view` in functions

### DIFF
--- a/EIPS/eip-20.md
+++ b/EIPS/eip-20.md
@@ -42,7 +42,7 @@ but interfaces and other contracts MUST NOT expect these values to be present.
 
 
 ``` js
-function name() constant returns (string name)
+function name() view returns (string name)
 ```
 
 
@@ -54,7 +54,7 @@ OPTIONAL - This method can be used to improve usability,
 but interfaces and other contracts MUST NOT expect these values to be present.
 
 ``` js
-function symbol() constant returns (string symbol)
+function symbol() view returns (string symbol)
 ```
 
 
@@ -67,7 +67,7 @@ OPTIONAL - This method can be used to improve usability,
 but interfaces and other contracts MUST NOT expect these values to be present.
 
 ``` js
-function decimals() constant returns (uint8 decimals)
+function decimals() view returns (uint8 decimals)
 ```
 
 
@@ -76,7 +76,7 @@ function decimals() constant returns (uint8 decimals)
 Returns the total token supply.
 
 ``` js
-function totalSupply() constant returns (uint256 totalSupply)
+function totalSupply() view returns (uint256 totalSupply)
 ```
 
 
@@ -86,7 +86,7 @@ function totalSupply() constant returns (uint256 totalSupply)
 Returns the account balance of another account with address `_owner`.
 
 ``` js
-function balanceOf(address _owner) constant returns (uint256 balance)
+function balanceOf(address _owner) view returns (uint256 balance)
 ```
 
 
@@ -138,7 +138,7 @@ function approve(address _spender, uint256 _value) returns (bool success)
 Returns the amount which `_spender` is still allowed to withdraw from `_owner`.
 
 ``` js
-function allowance(address _owner, address _spender) constant returns (uint256 remaining)
+function allowance(address _owner, address _spender) view returns (uint256 remaining)
 ```
 
 


### PR DESCRIPTION
As the `constant` modifier for functions [is deprecated and planned to be dropped in Solidity 0.5](http://solidity.readthedocs.io/en/develop/contracts.html#view-functions), wouldn't it make sense to reflect this in this standard's code examples?