### PR TITLE
EIP-721: Be explicit about setApprovalForAll's msg.sender requirement.

### DIFF
--- a/EIPS/eip-721.md
+++ b/EIPS/eip-721.md
@@ -122,7 +122,8 @@ interface ERC721 /* is ERC165 */ {
     function approve(address _approved, uint256 _tokenId) external payable;
 
     /// @notice Enable or disable approval for a third party ("operator") to manage
-    ///  all your asset.
+    ///  all your assets.
+    /// @dev Throws unless `msg.sender` is the current NFT owner.
     /// @dev Emits the ApprovalForAll event
     /// @param _operator Address to add to the set of authorized operators.
     /// @param _approved True if the operators is approved, false to revoke approval


### PR DESCRIPTION
We want it to only be callable by the NFT owner.

Also corrects a typo.

As mentioned on #841. cc @fulldecent 