### PR TITLE
EIP-721: Remove throw condition for setApprovalForAll.

### DIFF
--- a/EIPS/eip-721.md
+++ b/EIPS/eip-721.md
@@ -122,8 +122,7 @@ interface ERC721 /* is ERC165 */ {
     function approve(address _approved, uint256 _tokenId) external payable;
 
     /// @notice Enable or disable approval for a third party ("operator") to manage
-    ///  all your assets.
-    /// @dev Throws unless `msg.sender` is the current NFT owner.
+    ///  all of `msg.sender`'s assets.
     /// @dev Emits the ApprovalForAll event
     /// @param _operator Address to add to the set of authorized operators.
     /// @param _approved True if the operators is approved, false to revoke approval


### PR DESCRIPTION
And tweak the description to more clearly indicate its difference from the other, per-NFT operations. Hopefully mentioning `msg.sender` specifically will make it more clear that this operation affects an address rather than an asset.

As discussed in #925.