### PR TITLE
Add colon to eip-721.md

### DIFF
--- a/EIPS/eip-721.md
+++ b/EIPS/eip-721.md
@@ -5,7 +5,7 @@ EIP: 721
 Title: ERC-721 Non-Fungible Token Standard
 Author: William Entriken <github.com@phor.net>, Dieter Shirley <dete@axiomzen.co>, Jacob Evans <jacob@dekz.net>, Nastassia Sachs <nastassia.sachs@protonmail.com>
 Type: Standard
-Category ERC
+Category: ERC
 Status: Draft
 Created: 2018-01-24
 Requires: ERC-165


### PR DESCRIPTION
The preamble was missing a colon
