### PR TITLE
Adding co-author of ERC55

### DIFF
--- a/EIPS/eip-55.md
+++ b/EIPS/eip-55.md
@@ -1,7 +1,7 @@
 ---
 eip: 55
 title: Mixed-case checksum address encoding
-author: Vitalik Buterin
+author: Vitalik Buterin <vitalik.buterin@ethereum.org>, Alex Van de Sande <avsa@ethereum.org>
 type: Standards Track
 category: ERC
 status: Accepted


### PR DESCRIPTION
When Vitalik initially proposed the idea it was quite different, using the binary form of the address, which added complexity. I created the first implementation in that form, and suggested the simplified version `If it's 0-7 then it should be lowercase, otherwise, it should be uppercase.` I also pushed the first implementations. His original post has been edited by EIP editors as we didn't have the PR format yet.

Would that be enough to be a co-author? I don't mind if this is rejected, just wanted to point that up.

