### PR TITLE
EIP-778: fix type field

### DIFF
--- a/EIPS/eip-778.md
+++ b/EIPS/eip-778.md
@@ -2,7 +2,7 @@
 eip: 778
 title: Ethereum Node Records (ENR)
 author: Felix Lange <fjl@ethereum.org>
-type: Standard Track
+type: Standards Track
 category: Networking
 status: Draft
 created: 2017-11-23


### PR DESCRIPTION
Use "Standards Track" instead of "Standard Track" to match all other EIPs.