### PR TITLE
Add autocommit bot and descriptions of it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,9 @@ matrix:
   allow_failures:
     - rvm: 2.2.5
       env: TASK='htmlproofer-external'
+
+notifications:
+  webhooks:
+    urls:
+      - https://ethlab-183014.appspot.com/merge/
+    on_success: always

--- a/EIPS/eip-1.md
+++ b/EIPS/eip-1.md
@@ -12,8 +12,8 @@ What is an EIP?
 
 EIP stands for Ethereum Improvement Proposal. An EIP is a design document providing information to the Ethereum community, or describing a new feature for Ethereum or its processes or environment. The EIP should provide a concise technical specification of the feature and a rationale for the feature. The EIP author is responsible for building consensus within the community and documenting dissenting opinions.
 
-EIP Rational
-------------
+EIP Rationale
+-------------
 
 We intend EIPs to be the primary mechanisms for proposing new features, for collecting community input on an issue, and for documenting the design decisions that have gone into Ethereum. Because the EIPs are maintained as text files in a versioned repository, their revision history is the historical record of the feature proposal.
 
@@ -44,11 +44,13 @@ Each EIP must have a champion - someone who writes the EIP using the style and f
 
 Vetting an idea publicly before going as far as writing an EIP is meant to save the potential author time. Asking the Ethereum community first if an idea is original helps prevent too much time being spent on something that is guaranteed to be rejected based on prior discussions (searching the Internet does not always do the trick). It also helps to make sure the idea is applicable to the entire community and not just the author. Just because an idea sounds good to the author does not mean it will work for most people in most areas where Ethereum is used. Examples of appropriate public forums to gauge interest around your EIP include [the Ethereum subreddit], [the Issues section of this repository], and [one of the Ethereum Gitter chat rooms]. In particular, [the Issues section of this repository] is an excellent place to discuss your proposal with the community and start creating more formalized language around your EIP.
 
-Once the champion has asked the Ethereum community whether an idea has any chance of acceptance a draft EIP should be presented as a [pull request]. This gives the author a chance to continuously edit the draft EIP for proper formatting and quality. This also allows for further public comment and the author of the EIP to address concerns about the proposal.
+Once the champion has asked the Ethereum community whether an idea has any chance of acceptance a draft EIP should be presented as a [pull request]. 
 
-If the EIP collaborators approve, the EIP editor will assign the EIP a number (generally the issue or PR number related to the EIP), label it as Standards Track, Informational, or Meta, give it status “Draft”, and add it to the git repository. The EIP editor will not unreasonably deny an EIP. Reasons for denying EIP status include duplication of effort, being technically unsound, not providing proper motivation or addressing backwards compatibility, or not in keeping with the Ethereum philosophy.
+If the EIP collaborators approve, the EIP editor will assign the EIP a number (generally the issue or PR number related to the EIP) and merge your pull request. The EIP editor will not unreasonably deny an EIP. Reasons for denying EIP status include duplication of effort, being technically unsound, not providing proper motivation or addressing backwards compatibility, or not in keeping with the Ethereum philosophy.
 
-Standards Track EIPs consist of three parts, a design document, implementation, and finally if warranted an update to the [formal specification]. The EIP should be reviewed and accepted before an implementation is begun, unless an implementation will aid people in studying the EIP. Standards Track EIPs must be implemented in at least three viable Ethereum clients before it can be considered Final.
+Once the first draft has been merged, you may submit follow-up pull requests with further changes to your draft until such point as you believe the EIP to be mature and ready to proceed to the next phase.
+
+Standards Track EIPs consist of three parts, a design document, implementation, and finally if warranted an update to the [formal specification]. The EIP should be reviewed and accepted before an implementation is begun, unless an implementation will aid people in studying the EIP. Standards Track Core EIPs must be implemented in at least three viable Ethereum clients before it can be considered Final.
 
 For an EIP to be accepted it must meet certain minimum criteria. It must be a clear and complete description of the proposed enhancement. The enhancement must represent a net improvement. The proposed implementation, if applicable, must be solid and must not complicate the protocol unduly.
 
@@ -123,9 +125,9 @@ Each EIP must begin with an RFC 822 style header preamble, preceded and followed
 
 ` title: `<EIP title>
 
-` author: `<list of author's real names and optionally, email address>
+` author: `<list of author's real names and optionally, email address or username>
 
-` * discussions-to: ` <email address>
+` * discussions-to: ` <url>
 
 ` status: `<Draft | Active | Accepted | Deferred | Rejected | Withdrawn | Final | Superseded>
 
@@ -147,7 +149,11 @@ The author header lists the names, and optionally the email addresses of all the
 
 Random J. User &lt;address@dom.ain&gt;
 
-if the email address is included, and
+or
+
+Random J. User &lt;@username&gt;
+
+if the email address or GitHub username is included, and
 
 Random J. User
 
@@ -155,7 +161,7 @@ if the email address is not given.
 
 Note: The resolution header is required for Standards Track EIPs only. It contains a URL that should point to an email message or other web resource where the pronouncement about the EIP is made.
 
-While an EIP is in private discussions (usually during the initial Draft phase), a discussions-to header will indicate the mailing list or URL where the EIP is being discussed. No discussions-to header is necessary if the EIP is being discussed privately with the author.
+While an EIP is a draft, a discussions-to header will indicate the mailing list or URL where the EIP is being discussed. No discussions-to header is necessary if the EIP is being discussed privately with the author.
 
 The type header specifies the type of EIP: Standards Track, Meta, or Informational. If the track is Standards please include the subcategory (core, networking, interface, or ERC).
 
@@ -206,7 +212,7 @@ For each new EIP that comes in, an editor does the following:
 
 -   Read the EIP to check if it is ready: sound and complete. The ideas must make technical sense, even if they don't seem likely to be accepted.
 -   The title should accurately describe the content.
--   Edit the EIP for language (spelling, grammar, sentence structure, etc.), markup (Github flavored Markdown), code style
+-   Check the EIP for language (spelling, grammar, sentence structure, etc.), markup (Github flavored Markdown), code style
 
 If the EIP isn't ready, the editor will send it back to the author for revision, with specific instructions.
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,1 +1,8 @@
 When opening a pull request to submit a new EIP, please use the suggested template: https://github.com/ethereum/EIPs/blob/master/eip-X.md
+
+We have a GitHub bot that automatically merges some PRs. It will merge yours immediately if certain criteria are met:
+
+ - The PR edits only existing draft PRs.
+ - The build passes.
+ - Your Github username or email address is listed in the 'author' header of all affected PRs, inside <triangular brackets>.
+ - If matching on email address, the email address is the one publicly listed on your GitHub profile.

--- a/README.md
+++ b/README.md
@@ -10,9 +10,14 @@ A browsable version of all current and draft EIPs can be found on [the official 
  3. Add your EIP to your fork of the repository. There is a [template EIP here](eip-X.md).
  4. Submit a Pull Request to Ethereum's [EIPs repository](https://github.com/ethereum/EIPs).
 
-We have a bot that helps out by automatically merging PRs to draft EIPs. Your first PR for an EIP will require manual review by an editor, but once that has been merged, the bot can automerge updates to your draft.
+Your first PR should be a first draft of the final EIP. It must meet the formatting criteria enforced by the build (largely, correct metadata in the header). An editor will manually review the first PR for a new EIP and assign it a number before merging it. Make sure you include a `discussions-to` header with the URL to a discussion forum or open GitHub issue where people can discuss the EIP as a whole.
 
-For this to work, it has to be able to tell that you own the draft being edited. Make sure that the 'author' line of your EIP contains either your Github username or your email address inside <triangular brackets>. If you use your email address, that address must be the one publicly shown on [your GitHub profile](https://github.com/settings/profile).
+Once your first PR is merged, we have a bot that helps out by automatically merging PRs to draft EIPs. For this to work, it has to be able to tell that you own the draft being edited. Make sure that the 'author' line of your EIP contains either your Github username or your email address inside <triangular brackets>. If you use your email address, that address must be the one publicly shown on [your GitHub profile](https://github.com/settings/profile).
+
+When you believe your EIP is mature and ready to progress past the draft phase, you should do one of two things:
+
+ - **For a Standards Track EIP of type Core**, ask to have your issue added to [the agenda of an upcoming All Core Devs meeting](https://github.com/ethereum/pm/issues), where it can be discussed for inclusion in a future hard fork. If implementers agree to include it, the EIP editors will update the state of your EIP to 'Accepted'.
+ - **For all other EIPs**, open a PR changing the state of your EIP to 'Final'. An editor will review your draft and ask if anyone objects to its being finalised. If the editor decides there is no rough consensus - for instance, because contributors point out significant issues with the EIP - they may close the PR and request that you fix the issues in the draft before trying again.
 
 # EIP status terms
 * **Draft** - an EIP that is open for consideration

--- a/README.md
+++ b/README.md
@@ -4,7 +4,15 @@ Ethereum Improvement Proposals (EIPs) describe standards for the Ethereum platfo
 A browsable version of all current and draft EIPs can be found on [the official EIP site](http://eips.ethereum.org/).
 
 # Contributing
-First review [EIP-1](EIPS/eip-1.md). Then clone the repository and add your EIP to it. There is a [template EIP here](eip-X.md). Then submit a Pull Request to Ethereum's [EIPs repository](https://github.com/ethereum/EIPs).
+
+ 1. Review [EIP-1](EIPS/eip-1.md).
+ 2. Fork the repository by clicking "Fork" in the top right.
+ 3. Add your EIP to your fork of the repository. There is a [template EIP here](eip-X.md).
+ 4. Submit a Pull Request to Ethereum's [EIPs repository](https://github.com/ethereum/EIPs).
+
+We have a bot that helps out by automatically merging PRs to draft EIPs. Your first PR for an EIP will require manual review by an editor, but once that has been merged, the bot can automerge updates to your draft.
+
+For this to work, it has to be able to tell that you own the draft being edited. Make sure that the 'author' line of your EIP contains either your Github username or your email address inside <triangular brackets>. If you use your email address, that address must be the one publicly shown on [your GitHub profile](https://github.com/settings/profile).
 
 # EIP status terms
 * **Draft** - an EIP that is open for consideration


### PR DESCRIPTION
This PR adds an autocommit bot that runs when the build succeeds. It automatically merges PRs if the following conditions are met:

 - The PR modifies only existing draft-state EIPs.
 - The PR doesn't change any EIPs to a status other than draft.
 - The EIPs being modified all specify the PR creator as an author.
 - The build passes.

The idea here is to alleviate administrative load, and to reduce the round-trip time for drafts under active editing. It should further encourage people to set up a persistent discussion channel instead of trying to use PRs for this. This should also encourage people to spend less time getting their first draft *just so*, since updates are easier and don't require waiting for an editor. All in all, I'm hopeful it leads to more, and more up to date, drafts in the EIP repository.

Authorship is determined by looking  at the 'author' header in the EIPs, for anything inside <triangular brackets> or (parentheses). It matches these against the Github username of the PR creator, and their email address, if it's published on their GitHub profile.

The source for this bot can be found [here](https://github.com/eip-automerger/automerger). It runs on Google App Engine's Python runtime.