### PR TITLE
Update to new ABI spec URL

### DIFF
--- a/EIPS/eip-681.md
+++ b/EIPS/eip-681.md
@@ -37,7 +37,7 @@ Payment request URLs contain "ethereum" in their schema (protocol) part and are 
     number                  = [ "-" / "+" ] *DIGIT [ "." 1*DIGIT ] [ ( "e" / "E" ) [ 1*DIGIT ] [ "+" UNIT ]
 
 
-Where `TYPE` is a standard ABI type name, as defined in [Ethereum Contract ABI specification](https://github.com/ethereum/wiki/wiki/Ethereum-Contract-ABI). `STRING` is a URL-encoded unicode string of arbitrary length, where delimiters and the
+Where `TYPE` is a standard ABI type name, as defined in [Ethereum Contract ABI specification](https://solidity.readthedocs.io/en/develop/abi-spec.html). `STRING` is a URL-encoded unicode string of arbitrary length, where delimiters and the
 percentage symbol (`%`) are mandatorily hex-encoded with a `%` prefix.
 
 `UNIT` is a URL-encoded unicode string. If `UNIT` is ETH, it always means a multiplier of 10<sup>18</sup>. If it is something


### PR DESCRIPTION
The old one is not maintained anymore - the new one is updated - e.g. now contains tuples.

This also uncovers another problem here. We are specifying this against a moving target (OK a very slowly moving target - but still moving) - this could cause incompatibilities in the future.

cc @nagydani