### PR TITLE
EIP-758 update

### DIFF
--- a/EIPS/eip-758.md
+++ b/EIPS/eip-758.md
@@ -55,10 +55,10 @@ The caller receives notifications about their transactions' return data in two c
 ```
 
 ### Polling
-Push notifications require full duplex connections (i.e., websocket or IPC).  Instead of subscribing, callers using HTTP send an `eth_newFilter` request:
+Push notifications require full duplex connections (i.e., websocket or IPC).  Instead of subscribing, callers using HTTP send an `eth_newReturnDataFilter` request:
 
 ```json
-{"jsonrpc": "2.0", "id": 1, "method": "eth_newFilter", "params": ["returnData"]}
+{"jsonrpc": "2.0", "id": 1, "method": "eth_newReturnDataFilter"}
 ```
 
 The Ethereum node responds with a filter ID:
@@ -86,7 +86,7 @@ The node responds with an array of transaction hashes and their corresponding re
 }
 ```
 
-All transactions submitted by the client that were sealed _after_ the initial `eth_newFilter` request are included in this array.
+All transactions submitted by the client that were sealed _after_ the initial `eth_newReturnDataFilter` request are included in this array.
 
 
 ## Rationale


### PR DESCRIPTION
Change eth_newFilter with params=["returnData"] to eth_newReturnDataFilter to be consistent with rest of JSON-RPC api.

This is the first and most straightforward of the modifications to EIP-758 I suggested in [Issue #963](https://github.com/ethereum/EIPs/issues/963).  I've been in contact with both @tinybike (original EIP author) and @adisney (he's working on the Parity implementation of it, while I'm working on the Geth implementation) about this, and both are in support of it.