### PR TITLE
EIP-778: simplify ENR for v4 compatibility

### DIFF
--- a/EIPS/eip-778.md
+++ b/EIPS/eip-778.md
@@ -61,26 +61,25 @@ Records are signed and encoded as follows:
 The keys in key/value pairs can technically be any byte sequence, but ASCII text is
 preferred. The following keys are pre-defined:
 
-| Key          | Value                                            |
-|:-------------|:-------------------------------------------------|
-| `id`         | name of identity scheme, e.g. "secp256k1-keccak" |
-| `secp256k1`  | compressed secp256k1 public key, 33 bytes        |
-| `ip4`        | IPv4 address, 4 bytes                            |
-| `ip6`        | IPv6 address, 16 bytes                           |
-| `discv5`     | UDP port for discovery v5                        |
+| Key         | Value                                     |
+|:------------|:------------------------------------------|
+| `id`        | name of identity scheme, e.g. "v4"        |
+| `secp256k1` | compressed secp256k1 public key, 33 bytes |
+| `ip`        | IP address, 4 or 16 bytes                 |
+| `tcp`       | TCP port                                  |
+| `udp`       | UDP port                                  |
 
-### secp256k1-keccak Identity Scheme
+### "v4" Identity Scheme
 
-This specification defines a single scheme to be used as the default: "secp256k1-keccak".
+This specification defines a single scheme to be used as the default. The "v4" scheme is
+backwards-compatible with the cryptosystem used by Node Discovery Protocol v4.
 
-- To sign record `content` with this scheme, apply the keccak256[^1] hash function to
-  `content`, then create a signature of the hash. The resulting 64-byte signature is
-  encoded as the concatenation of the `r` and `s` signature values.
+- To sign record `content` with this scheme, apply the keccak256 hash function (as used by
+  the EVM) to `content`, then create a signature of the hash. The resulting 64-byte
+  signature is encoded as the concatenation of the `r` and `s` signature values.
 - To verify a record, check that the signature was made by the public key in the
   "secp256k1" key/value pair.
-- To derive a node address, take the keccak256 hash of the public key.
-
-[^1]: As used by the EVM
+- To derive a node address, take the keccak256 hash of the uncompressed public key.
 
 # Rationale
 
@@ -94,9 +93,9 @@ The format is meant to suit future needs in two ways:
   get it implemented. The scheme can be used as soon as most clients accept it.
 
 The size of a record is limited because records are relayed frequently and may be included
-in size-constrained protocols such as DNS. A record containing IPv4 address, when signed
-using the "secp256k1-keccak" scheme occupies roughly 120 bytes, leaving plenty of room for
-additional metadata.
+in size-constrained protocols such as DNS. A record containing a IPv4 address, when signed
+using the "v4" scheme occupies roughly 120 bytes, leaving plenty of room for additional
+metadata.
 
 # Copyright
 


### PR DESCRIPTION
This change makes information in ENR compatible with the existing
discovery protocol:

- The default identity scheme is now called "v4" to make the name shorter.
- Node addresses are derived as the hash of the uncompressed public key.
- The "ip4" and "ip6" keys are merged into a single "ip" key which
  can hold a IPv4 or IPv6 address.
- The "discv5" key is now called "udp".
- The new "tcp" key holds the TCP port.
