### PR TITLE
'EXTCODEHASH' opcode

### DIFF
--- a/EIPS/eip-1052.md
+++ b/EIPS/eip-1052.md
@@ -1,8 +1,8 @@
 ---
-eip: <to be assigned>
-title: CODEHASH opcode
+eip: 1052
+title: EXTCODEHASH opcode
 author: Nick Johnson <arachnid@notdot.net>
-discussions-to: <email address>
+discussions-to: https://ethereum-magicians.org/t/extcodehash-opcode/262
 status: Draft
 type: Standards Track
 category: Core
@@ -15,10 +15,10 @@ This EIP specifies a new opcode, which returns the keccak256 hash of a contract'
 ## Motivation
 Many contracts need to perform checks on a contract's bytecode, but do not necessarily need the bytecode itself. For instance, a contract may want to check if another contract's bytecode is one of a set of permitted implementations, or it may perform analyses on code and whitelist any contract with matching bytecode if the analysis passes.
 
-Contracts can presently do this using the `CODECOPY` opcode, but this is expensive, especially for large contracts, in cases where only the hash is required. As a result, we propose a new opcode, `CODEHASH`, which returns the keccak256 hash of a contract's bytecode.
+Contracts can presently do this using the `EXTCODECOPY` opcode, but this is expensive, especially for large contracts, in cases where only the hash is required. As a result, we propose a new opcode, `EXTCODEHASH`, which returns the keccak256 hash of a contract's bytecode.
 
 ## Specification
-A new opcode, `CODEHASH`, is introduced, with number 0x3D. `CODEHASH` takes one argument from the stack, and pushes the keccak256 hash of the code at that address to the stack.
+A new opcode, `EXTCODEHASH`, is introduced, with number 0x3D. `EXTCODEHASH` takes one argument from the stack, and pushes the keccak256 hash of the code at that address to the stack.
 
 ## Rationale
 As described in the motivation section, this opcode is widely useful, and saves on wasted gas in many cases.

--- a/EIPS/eip-x-codehash.md
+++ b/EIPS/eip-x-codehash.md
@@ -1,0 +1,36 @@
+---
+eip: <to be assigned>
+title: CODEHASH opcode
+author: Nick Johnson <arachnid@notdot.net>
+discussions-to: <email address>
+status: Draft
+type: Standards Track
+category: Core
+created: 2018-05-02
+---
+
+## Abstract
+This EIP specifies a new opcode, which returns the keccak256 hash of a contract's code.
+
+## Motivation
+Many contracts need to perform checks on a contract's bytecode, but do not necessarily need the bytecode itself. For instance, a contract may want to check if another contract's bytecode is one of a set of permitted implementations, or it may perform analyses on code and whitelist any contract with matching bytecode if the analysis passes.
+
+Contracts can presently do this using the `CODECOPY` opcode, but this is expensive, especially for large contracts, in cases where only the hash is required. As a result, we propose a new opcode, `CODEHASH`, which returns the keccak256 hash of a contract's bytecode.
+
+## Specification
+A new opcode, `CODEHASH`, is introduced, with number 0x3D. `CODEHASH` takes one argument from the stack, and pushes the keccak256 hash of the code at that address to the stack.
+
+## Rationale
+As described in the motivation section, this opcode is widely useful, and saves on wasted gas in many cases.
+
+## Backwards Compatibility
+There are no backwards compatibility concerns.
+
+## Test Cases
+TBD
+
+## Implementation
+TBD
+
+## Copyright
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
This EIP proposes an 'EXTCODEHASH' opcode, which returns the keccak256 hash of a contract's code.