### PR TITLE
Formalize IPFS hash into ENS(Ethereum Name Service) resolver

### DIFF
--- a/EIPS/eip-X.md
+++ b/EIPS/eip-X.md
@@ -51,15 +51,31 @@ All EIPs that introduce backwards incompatibilities must include a section descr
 
 https://www.npmjs.com/package/multihashes
 
+IPFS to hex
+
 ```
 import multihash from 'multihashes'
 
-export const getContentHash = function(ipfsHash) {
+export const encode = function(ipfsHash) {
   let buf = multihash.fromB58String(ipfsHash)
   let digest = multihash.decode(buf).digest
   return '0x' + multihash.toHexString(digest)
 }
 ```
+
+hex to IPFS
+
+```
+import multihash from 'multihashes'
+
+export const decode = function(contentHash) {
+  let hex = contentHash.substring(2)
+  let buf = multihash.fromHexString(hex)
+  return multihash.toB58String(multihash.encode(buf, 'sha2-256'))
+}
+```
+
+Workable repository: https://github.com/PortalNetwork/portal-network-browser-extension
 
 ## Implementation
 <!--The implementations must be completed before any EIP is given status "Final", but it need not be completed before the EIP is accepted. While there is merit to the approach of reaching consensus on the specification and rationale before writing code, the principle of "rough consensus and running code" is still useful when it comes to resolving many discussions of API details.-->

--- a/EIPS/eip-X.md
+++ b/EIPS/eip-X.md
@@ -1,0 +1,69 @@
+---
+eip: <to be assigned>
+title: Ethereum Name Service integration with IPFS
+author: <a list of the author's or authors' name(s) and/or username(s), or name(s) and email(s), e.g. (use with the parentheses or triangular brackets): FirstName LastName (@GitHubUsername), FirstName LastName <foo@bar.com>, FirstName (@GitHubUsername) and GitHubUsername (@GitHubUsername)>
+discussions-to: <email address>
+status: Draft
+type: Standards Track
+category : ERC
+created: 2018-05-02
+---
+
+## Simple Summary
+<!--"If you can't explain it simply, you don't understand it well enough." Provide a simplified and layman-accessible explanation of the EIP.-->
+If you can't explain it simply, you don't understand it well enough." Provide a simplified and layman-accessible explanation of the EIP.
+
+## Abstract
+<!--A short (~200 word) description of the technical issue being addressed.-->
+A short (~200 word) description of the technical issue being addressed.
+
+## Motivation
+<!--The motivation is critical for EIPs that want to change the Ethereum protocol. It should clearly explain why the existing protocol specification is inadequate to address the problem that the EIP solves. EIP submissions without sufficient motivation may be rejected outright.-->
+The motivation is critical for EIPs that want to change the Ethereum protocol. It should clearly explain why the existing protocol specification is inadequate to address the problem that the EIP solves. EIP submissions without sufficient motivation may be rejected outright.
+
+## Specification
+<!--The technical specification should describe the syntax and semantics of any new feature. The specification should be detailed enough to allow competing, interoperable implementations for any of the current Ethereum platforms (go-ethereum, parity, cpp-ethereum, ethereumj, ethereumjs, and [others](https://github.com/ethereum/wiki/wiki/Clients)).-->
+The technical specification should describe the syntax and semantics of any new feature. The specification should be detailed enough to allow competing, interoperable implementations for any of the current Ethereum platforms (go-ethereum, parity, cpp-ethereum, ethereumj, ethereumjs, and [others](https://github.com/ethereum/wiki/wiki/Clients)).
+
+## Rationale
+<!--The rationale fleshes out the specification by describing what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work, e.g. how the feature is supported in other languages. The rationale may also provide evidence of consensus within the community, and should discuss important objections or concerns raised during discussion.-->
+The rationale fleshes out the specification by describing what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work, e.g. how the feature is supported in other languages. The rationale may also provide evidence of consensus within the community, and should discuss important objections or concerns raised during discussion.-->
+
+Set IPFS hex into this function 
+
+```
+function setContent(bytes32 node, bytes32 hash) public only_owner(node);
+```
+
+Get IPFS hex from this function
+
+```
+function content(bytes32 node) public view returns (bytes32);
+```
+
+
+## Backwards Compatibility
+<!--All EIPs that introduce backwards incompatibilities must include a section describing these incompatibilities and their severity. The EIP must explain how the author proposes to deal with these incompatibilities. EIP submissions without a sufficient backwards compatibility treatise may be rejected outright.-->
+All EIPs that introduce backwards incompatibilities must include a section describing these incompatibilities and their severity. The EIP must explain how the author proposes to deal with these incompatibilities. EIP submissions without a sufficient backwards compatibility treatise may be rejected outright.
+
+
+## Test Cases
+
+https://www.npmjs.com/package/multihashes
+
+```
+import multihash from 'multihashes'
+
+export const getContentHash = function(ipfsHash) {
+  let buf = multihash.fromB58String(ipfsHash)
+  let digest = multihash.decode(buf).digest
+  return '0x' + multihash.toHexString(digest)
+}
+```
+
+## Implementation
+<!--The implementations must be completed before any EIP is given status "Final", but it need not be completed before the EIP is accepted. While there is merit to the approach of reaching consensus on the specification and rationale before writing code, the principle of "rough consensus and running code" is still useful when it comes to resolving many discussions of API details.-->
+The implementations must be completed before any EIP is given status "Final", but it need not be completed before the EIP is accepted. While there is merit to the approach of reaching consensus on the specification and rationale before writing code, the principle of "rough consensus and running code" is still useful when it comes to resolving many discussions of API details.
+
+## Copyright
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/EIPS/eip-X.md
+++ b/EIPS/eip-X.md
@@ -1,8 +1,8 @@
 ---
 eip: <to be assigned>
 title: Ethereum Name Service integration with IPFS
-author: Phyrex Tsai<phyrex@portal.network> and Portal Network
-discussions-to: <email address>
+author: Phyrex Tsai<phyrex@portal.network> and Portal Network Team
+discussions-to: phyrex@portal.network
 status: Draft
 type: Standards Track
 category : ERC

--- a/EIPS/eip-X.md
+++ b/EIPS/eip-X.md
@@ -1,6 +1,6 @@
 ---
 eip: <to be assigned>
-title: Ethereum Name Service integration with IPFS
+title: Formalize IPFS hash into ENS(Ethereum Name Service) resolver
 author: Phyrex Tsai<phyrex@portal.network> and Portal Network Team
 discussions-to: phyrex@portal.network
 status: Draft

--- a/EIPS/eip-X.md
+++ b/EIPS/eip-X.md
@@ -1,7 +1,7 @@
 ---
 eip: <to be assigned>
 title: Ethereum Name Service integration with IPFS
-author: <a list of the author's or authors' name(s) and/or username(s), or name(s) and email(s), e.g. (use with the parentheses or triangular brackets): FirstName LastName (@GitHubUsername), FirstName LastName <foo@bar.com>, FirstName (@GitHubUsername) and GitHubUsername (@GitHubUsername)>
+author: Phyrex Tsai<phyrex@portal.network> and Portal Network
 discussions-to: <email address>
 status: Draft
 type: Standards Track
@@ -31,18 +31,18 @@ The condition now is that the IPFS file fingerprint using base58 and in the mean
 - Different data type, one is string, the other is integer.
 - The way to process the condition requires not only we need to transfer from IPFS to Ethereum, but also need to convert it back.
   
-To solve this requirements, we can use binary buffer briding that gap.
+To solve this requirements, we can use binary buffer briding that gap.  
 When mapping the IPFS base58 string to ENS resolver, first we convert the Base58 to binary buffer, turn the buffer to hex encrypted format, and save to the contract. Once we want to get the IPFS resources address represented by the specific ENS, we can first find the mapping information stored as hex format before, extract the hex format to binary buffer, and finally turn that to IPFS Base58 address string.
 
 
 ## Rationale
-To implement the specification, need two methods from ENS public resolver contract, when we want to store IPFS file fingerprint to contract, convert the Base58 string identifier to the hex format and invoke the ‘setContent’ method below :
+To implement the specification, need two methods from ENS public resolver contract, when we want to store IPFS file fingerprint to contract, convert the Base58 string identifier to the hex format and invoke the `setContent` method below :
   
 ```
 function setContent(bytes32 node, bytes32 hash) public only_owner(node);
 ```
   
-Whenever user need to visit the ENS content, we call the ‘content’ method to get the IPFS hex data, transfer to the Base58 format, and return the IPFS resources to use.
+Whenever user need to visit the ENS content, we call the `content` method to get the IPFS hex data, transfer to the Base58 format, and return the IPFS resources to use.
   
 ```
 function content(bytes32 node) public view returns (bytes32);
@@ -50,8 +50,8 @@ function content(bytes32 node) public view returns (bytes32);
 
 ## Test Cases
 
-To implement the way to transfer from base58 to hex format and the reverse one, using the ‘multihashes’ library to deal with the problem.
-The library link : https://www.npmjs.com/package/multihashes
+To implement the way to transfer from base58 to hex format and the reverse one, using the ‘multihashes’ library to deal with the problem.  
+The library link : [https://www.npmjs.com/package/multihashes](https://www.npmjs.com/package/multihashes)  
 To implement the method transfer from IPFS(Base58) to hex encryption format :
   
 ```

--- a/EIPS/eip-X.md
+++ b/EIPS/eip-X.md
@@ -31,7 +31,7 @@ The condition now is that the IPFS file fingerprint using base58 and in the mean
 - Different data type, one is string, the other is integer.
 - The way to process the condition requires not only we need to transfer from IPFS to Ethereum, but also need to convert it back.
   
-To solve this requirements, we can use binary buffer briding that gap.  
+To solve these requirements, we can use binary buffer briding that gap.  
 When mapping the IPFS base58 string to ENS resolver, first we convert the Base58 to binary buffer, turn the buffer to hex encrypted format, and save to the contract. Once we want to get the IPFS resources address represented by the specific ENS, we can first find the mapping information stored as hex format before, extract the hex format to binary buffer, and finally turn that to IPFS Base58 address string.
 
 
@@ -42,7 +42,7 @@ To implement the specification, need two methods from ENS public resolver contra
 function setContent(bytes32 node, bytes32 hash) public only_owner(node);
 ```
   
-Whenever user need to visit the ENS content, we call the `content` method to get the IPFS hex data, transfer to the Base58 format, and return the IPFS resources to use.
+Whenever users need to visit the ENS content, we call the `content` method to get the IPFS hex data, transfer to the Base58 format, and return the IPFS resources to use.
   
 ```
 function content(bytes32 node) public view returns (bytes32);

--- a/EIPS/eip-X.md
+++ b/EIPS/eip-X.md
@@ -51,24 +51,24 @@ All EIPs that introduce backwards incompatibilities must include a section descr
 
 https://www.npmjs.com/package/multihashes
 
-IPFS to hex
+IPFS(Base58) to hex
 
 ```
 import multihash from 'multihashes'
 
-export const encode = function(ipfsHash) {
+export const toHex = function(ipfsHash) {
   let buf = multihash.fromB58String(ipfsHash)
   let digest = multihash.decode(buf).digest
   return '0x' + multihash.toHexString(digest)
 }
 ```
 
-hex to IPFS
+hex to IPFS(Base58)
 
 ```
 import multihash from 'multihashes'
 
-export const decode = function(contentHash) {
+export const toBase58 = function(contentHash) {
   let hex = contentHash.substring(2)
   let buf = multihash.fromHexString(hex)
   return multihash.toB58String(multihash.encode(buf, 'sha2-256'))

--- a/EIPS/eip-X.md
+++ b/EIPS/eip-X.md
@@ -64,7 +64,7 @@ export const toHex = function(ipfsHash) {
 }
 ```
   
-To implemnt the method transfer from hex encryption fromat to IPFS(Base58) :
+To implement the method transfer from hex encryption fromat to IPFS(Base58) :
   
 ```
 import multihash from 'multihashes'


### PR DESCRIPTION
Initial pull request for the "Formalize IPFS hash into ENS(Ethereum Name Service) resolver" EIP.

The goal is to specify the mapping protocol between resources stored on IPFS and ENS(Ethereum Naming Service).
