### PR TITLE
Formalize IPFS hash into ENS(Ethereum Name Service) resolver

### DIFF
--- a/EIPS/eip-1062.md
+++ b/EIPS/eip-1062.md
@@ -5,7 +5,7 @@ author: Phyrex Tsai <phyrex@portal.network>, Portal Network Team
 discussions-to: phyrex@portal.network
 status: Draft
 type: Standards Track
-category : ERC
+category: ERC
 created: 2018-05-02
 ---
 

--- a/EIPS/eip-1062.md
+++ b/EIPS/eip-1062.md
@@ -18,9 +18,9 @@ The following standard details the implementation of how to combine the IPFS cry
 We think that this implementation is not only aim to let more developers and communities to provide more use cases, but also leverage the human-readable features to gain more user adoption accessing decentralized resources. We considered the IPFS ENS resolver mapping standard a cornerstone for building future Web3.0 service.
 
 ## Motivation
-To build fully decentralized web service, it’s necessary to have a decentralized file sotrage system. Here comes the IPFS, for three following advantages :
-- Address large amounts of data, and has unique cryptographic hash for every records.
-- Since IPFS is also based on peer to peer network, it can be really helpful to delivers large amounts of data to users, with safer way and lower the millions of cost for the bandwidth.
+To build fully decentralized web service, it’s necessary to have a decentralized file storage system. Here comes the IPFS, for three following advantages :
+- Address large amounts of data, and has unique cryptographic hash for every record.
+- Since IPFS is also based on peer to peer network, it can be really helpful to deliver large amounts of data to users, with safer way and lower the millions of cost for the bandwidth.
 - IPFS stores files in high efficient way via tracking version history for every file, and removing the duplications across the network.
   
 Those features makes perfect match for integrating into ENS, and these make users can easily access content through ENS, and show up in the normal browser.
@@ -31,7 +31,7 @@ The condition now is that the IPFS file fingerprint using base58 and in the mean
 - Different data type, one is string, the other is integer.
 - The way to process the condition requires not only we need to transfer from IPFS to Ethereum, but also need to convert it back.
   
-To solve these requirements, we can use binary buffer briding that gap.  
+To solve these requirements, we can use binary buffer bridging that gap.  
 When mapping the IPFS base58 string to ENS resolver, first we convert the Base58 to binary buffer, turn the buffer to hex encrypted format, and save to the contract. Once we want to get the IPFS resources address represented by the specific ENS, we can first find the mapping information stored as hex format before, extract the hex format to binary buffer, and finally turn that to IPFS Base58 address string.
 
 

--- a/EIPS/eip-1062.md
+++ b/EIPS/eip-1062.md
@@ -1,7 +1,7 @@
 ---
-eip: <to be assigned>
+eip: 1062
 title: Formalize IPFS hash into ENS(Ethereum Name Service) resolver
-author: Phyrex Tsai<phyrex@portal.network> and Portal Network Team
+author: Phyrex Tsai <phyrex@portal.network>, Portal Network Team
 discussions-to: phyrex@portal.network
 status: Draft
 type: Standards Track

--- a/EIPS/eip-1062.md
+++ b/EIPS/eip-1062.md
@@ -2,7 +2,7 @@
 eip: 1062
 title: Formalize IPFS hash into ENS(Ethereum Name Service) resolver
 author: Phyrex Tsai <phyrex@portal.network>, Portal Network Team
-discussions-to: phyrex@portal.network
+discussions-to: https://ethereum-magicians.org/t/eip-1062-formalize-ipfs-hash-into-ens-ethereum-name-service-resolver/281
 status: Draft
 type: Standards Track
 category: ERC

--- a/EIPS/eip-1062.md
+++ b/EIPS/eip-1062.md
@@ -64,7 +64,7 @@ export const toHex = function(ipfsHash) {
 }
 ```
   
-To implement the method transfer from hex encryption fromat to IPFS(Base58) :
+To implement the method transfer from hex encryption format to IPFS(Base58) :
   
 ```
 import multihash from 'multihashes'

--- a/EIPS/eip-1062.md
+++ b/EIPS/eip-1062.md
@@ -27,52 +27,49 @@ Those features makes perfect match for integrating into ENS, and these make user
 
 
 ## Specification
-The condition now is that the IPFS file fingerprint using base58 and in the meantime, the Ethereum using hex encryption. These comes the two restrictions :
-- Different data type, one is string, the other is integer.
-- The way to process the condition requires not only we need to transfer from IPFS to Ethereum, but also need to convert it back.
+The condition now is that the IPFS file fingerprint using base58 and in the meantime, the Ethereum uses hex in API to encode the binary data. So that need a way to process the condition requires not only we need to transfer from IPFS to Ethereum, but also need to convert it back.
   
 To solve these requirements, we can use binary buffer bridging that gap.  
 When mapping the IPFS base58 string to ENS resolver, first we convert the Base58 to binary buffer, turn the buffer to hex encrypted format, and save to the contract. Once we want to get the IPFS resources address represented by the specific ENS, we can first find the mapping information stored as hex format before, extract the hex format to binary buffer, and finally turn that to IPFS Base58 address string.
 
 
 ## Rationale
-To implement the specification, need two methods from ENS public resolver contract, when we want to store IPFS file fingerprint to contract, convert the Base58 string identifier to the hex format and invoke the `setContent` method below :
+To implement the specification, need two methods from ENS public resolver contract, when we want to store IPFS file fingerprint to contract, convert the Base58 string identifier to the hex format and invoke the `setMultihash` method below :
   
 ```
-function setContent(bytes32 node, bytes32 hash) public only_owner(node);
+function setMultihash(bytes32 node, bytes32 hash) public only_owner(node);
 ```
   
-Whenever users need to visit the ENS content, we call the `content` method to get the IPFS hex data, transfer to the Base58 format, and return the IPFS resources to use.
+Whenever users need to visit the ENS content, we call the `multihash` method to get the IPFS hex data, transfer to the Base58 format, and return the IPFS resources to use.
   
 ```
-function content(bytes32 node) public view returns (bytes32);
+function multihash(bytes32 node) public view returns (bytes32);
 ```
 
 ## Test Cases
 
 To implement the way to transfer from base58 to hex format and the reverse one, using the ‘multihashes’ library to deal with the problem.  
 The library link : [https://www.npmjs.com/package/multihashes](https://www.npmjs.com/package/multihashes)  
-To implement the method transfer from IPFS(Base58) to hex encryption format :
+To implement the method transfer from IPFS(Base58) to hex format :
   
 ```
 import multihash from 'multihashes'
 
 export const toHex = function(ipfsHash) {
- let buf = multihash.fromB58String(ipfsHash)
- let digest = multihash.decode(buf).digest
- return '0x' + multihash.toHexString(digest)
+  let buf = multihash.fromB58String(ipfsHash);
+  return '0x' + multihash.toHexString(buf);
 }
 ```
   
-To implement the method transfer from hex encryption format to IPFS(Base58) :
+To implement the method transfer from hex format to IPFS(Base58) :
   
 ```
 import multihash from 'multihashes'
 
 export const toBase58 = function(contentHash) {
- let hex = contentHash.substring(2)
- let buf = multihash.fromHexString(hex)
- return multihash.toB58String(multihash.encode(buf, 'sha2-256'))
+  let hex = contentHash.substring(2)
+  let buf = multihash.fromHexString(hex);
+  return multihash.toB58String(buf);
 }
 ```
 

--- a/EIPS/eip-1062.md
+++ b/EIPS/eip-1062.md
@@ -37,13 +37,13 @@ When mapping the IPFS base58 string to ENS resolver, first we convert the Base58
 To implement the specification, need two methods from ENS public resolver contract, when we want to store IPFS file fingerprint to contract, convert the Base58 string identifier to the hex format and invoke the `setMultihash` method below :
   
 ```
-function setMultihash(bytes32 node, bytes32 hash) public only_owner(node);
+function setMultihash(bytes32 node, bytes hash) public only_owner(node);
 ```
   
 Whenever users need to visit the ENS content, we call the `multihash` method to get the IPFS hex data, transfer to the Base58 format, and return the IPFS resources to use.
   
 ```
-function multihash(bytes32 node) public view returns (bytes32);
+function multihash(bytes32 node) public view returns (bytes);
 ```
 
 ## Test Cases

--- a/EIPS/eip-X.md
+++ b/EIPS/eip-X.md
@@ -1,0 +1,87 @@
+---
+eip: <to be assigned>
+title: Formalize IPFS hash into ENS(Ethereum Name Service) resolver
+author: Phyrex Tsai<phyrex@portal.network> and Portal Network Team
+discussions-to: phyrex@portal.network
+status: Draft
+type: Standards Track
+category : ERC
+created: 2018-05-02
+---
+
+## Simple Summary
+To specify the mapping protocol between resources stored on IPFS and ENS(Ethereum Naming Service).
+
+## Abstract
+The following standard details the implementation of how to combine the IPFS cryptographic hash unique fingerprint with ENS public resolver. This standard provides a functionality to get and set IPFS online resources to ENS resolver.
+  
+We think that this implementation is not only aim to let more developers and communities to provide more use cases, but also leverage the human-readable features to gain more user adoption accessing decentralized resources. We considered the IPFS ENS resolver mapping standard a cornerstone for building future Web3.0 service.
+
+## Motivation
+To build fully decentralized web service, it’s necessary to have a decentralized file sotrage system. Here comes the IPFS, for three following advantages :
+- Address large amounts of data, and has unique cryptographic hash for every records.
+- Since IPFS is also based on peer to peer network, it can be really helpful to delivers large amounts of data to users, with safer way and lower the millions of cost for the bandwidth.
+- IPFS stores files in high efficient way via tracking version history for every file, and removing the duplications across the network.
+  
+Those features makes perfect match for integrating into ENS, and these make users can easily access content through ENS, and show up in the normal browser.
+
+
+## Specification
+The condition now is that the IPFS file fingerprint using base58 and in the meantime, the Ethereum using hex encryption. These comes the two restrictions :
+- Different data type, one is string, the other is integer.
+- The way to process the condition requires not only we need to transfer from IPFS to Ethereum, but also need to convert it back.
+  
+To solve these requirements, we can use binary buffer briding that gap.  
+When mapping the IPFS base58 string to ENS resolver, first we convert the Base58 to binary buffer, turn the buffer to hex encrypted format, and save to the contract. Once we want to get the IPFS resources address represented by the specific ENS, we can first find the mapping information stored as hex format before, extract the hex format to binary buffer, and finally turn that to IPFS Base58 address string.
+
+
+## Rationale
+To implement the specification, need two methods from ENS public resolver contract, when we want to store IPFS file fingerprint to contract, convert the Base58 string identifier to the hex format and invoke the `setContent` method below :
+  
+```
+function setContent(bytes32 node, bytes32 hash) public only_owner(node);
+```
+  
+Whenever users need to visit the ENS content, we call the `content` method to get the IPFS hex data, transfer to the Base58 format, and return the IPFS resources to use.
+  
+```
+function content(bytes32 node) public view returns (bytes32);
+```
+
+## Test Cases
+
+To implement the way to transfer from base58 to hex format and the reverse one, using the ‘multihashes’ library to deal with the problem.  
+The library link : [https://www.npmjs.com/package/multihashes](https://www.npmjs.com/package/multihashes)  
+To implement the method transfer from IPFS(Base58) to hex encryption format :
+  
+```
+import multihash from 'multihashes'
+
+export const toHex = function(ipfsHash) {
+ let buf = multihash.fromB58String(ipfsHash)
+ let digest = multihash.decode(buf).digest
+ return '0x' + multihash.toHexString(digest)
+}
+```
+  
+To implement the method transfer from hex encryption fromat to IPFS(Base58) :
+  
+```
+import multihash from 'multihashes'
+
+export const toBase58 = function(contentHash) {
+ let hex = contentHash.substring(2)
+ let buf = multihash.fromHexString(hex)
+ return multihash.toB58String(multihash.encode(buf, 'sha2-256'))
+}
+```
+
+## Implementation
+The use case can be implemented as browser extension. Users can easily download the extension, and easily get decentralized resources by just typing the ENS just like we normally type the DNS to browser the website. Solve the current pain for normal people can not easily visit the total decentralized website.
+
+The workable implementation repository : [https://github.com/PortalNetwork/portal-network-browser-extension](https://github.com/PortalNetwork/portal-network-browser-extension)
+
+## Copyright
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+
+


### PR DESCRIPTION
Initial pull request for the "Formalize IPFS hash into ENS(Ethereum Name Service) resolver" EIP.

The goal is to specify the mapping protocol between resources stored on IPFS and ENS(Ethereum Naming Service).