### PR TITLE
Set the example name compatible with a real example

### DIFF
--- a/EIPS/eip-820.md
+++ b/EIPS/eip-820.md
@@ -241,13 +241,13 @@ Your interface name is hashed and sent to `getInterfaceImplementer()`. If you ar
 
 #### If it's an approved EIP
 
-The interface is named like `ERC###XXXXX`. The meaning of this interface is defined in the EIP specified. And XXX should be the name of the interface camelCase.
+The interface is named like `ERC###XXXXX`. The meaning of this interface is defined in the EIP specified. And XXXXX should be the name of the interface camelCase.
 
 Examples:
 
 `sha3("ERC20Token")`
 `sha3("ERC777Token")`
-`sha3("ERC777TokensReceiver")`
+`sha3("ERC777TokensRecipient")`
 `sha3("ERC777TokensSender")`
 
 #### [EIP-165](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-165.md) compatible interfaces


### PR DESCRIPTION
The name used in ERC777 is actually `TokensRecipient` instead of `TokensReceiver` so I changed the example to be coherent with the ERC777 standard.