### PR TITLE
Change name and symbol functions to view for Metadata extension

### DIFF
--- a/EIPS/eip-721.md
+++ b/EIPS/eip-721.md
@@ -179,10 +179,10 @@ The **metadata extension** is OPTIONAL for ERC-721 smart contracts (see "caveats
 ///  Note: the ERC-165 identifier for this interface is 0x5b5e139f
 interface ERC721Metadata /* is ERC721 */ {
     /// @notice A descriptive name for a collection of NFTs in this contract
-    function name() external pure returns (string _name);
+    function name() external view returns (string _name);
 
     /// @notice An abbreviated name for NFTs in this contract
-    function symbol() external pure returns (string _symbol);
+    function symbol() external view returns (string _symbol);
 
     /// @notice A distinct Uniform Resource Identifier (URI) for a given asset.
     /// @dev Throws if `_tokenId` is not a valid NFT. URIs are defined in RFC


### PR DESCRIPTION
The mutability of the `name()` and `symbol()` functions in the metadata extension should be `view` not `pure`. Having it set to `pure` assumes that the token name and symbol will be hard-coded into the contract functions, rather than set (for example, in the constructor).

The mutability guarantee rules allow you to go stricter, (ie move from `view` to `pure`), but not the other way, so dropping it down to `view` wouldn't take anything away but would allow for these variables to be set and stored elsewhere in the contract.

When opening a pull request to submit a new EIP, please use the suggested template: https://github.com/ethereum/EIPs/blob/master/eip-X.md

We have a GitHub bot that automatically merges some PRs. It will merge yours immediately if certain criteria are met:

 - The PR edits only existing draft PRs.
 - The build passes.
 - Your Github username or email address is listed in the 'author' header of all affected PRs, inside <triangular brackets>.
 - If matching on email address, the email address is the one publicly listed on your GitHub profile.
