### PR TITLE
Contract deploy updates

### DIFF
--- a/EIPS/eip-1011.md
+++ b/EIPS/eip-1011.md
@@ -49,6 +49,8 @@ The Casper FFG contract can be layered on top of any block proposal mechanism, p
 * `PURITY_CHECKER_CODE`: see below
 * `NULL_SENDER`: `2**160 - 1`
 * `NEW_BLOCK_REWARD`: 6e17 wei (0.6 ETH)
+* `CASPER_INIT_DATA`: TBD
+* `INITIALIZE_EPOCH_BYTES`: `0x5dcffc17`
 * `NON_REVERT_MIN_DEPOSIT`: amount in wei configurable by client
 
 ### Casper Contract Parameters
@@ -65,7 +67,7 @@ The Casper FFG contract can be layered on top of any block proposal mechanism, p
 
 #### Deploying Casper Contract
 
-If `block.number == HYBRID_CASPER_FORK_BLKNUM`, then when processing the block, before processing any transactions:
+If `block.number == HYBRID_CASPER_FORK_BLKNUM`, then when processing the block before processing any transactions:
 
 * set the code of `MSG_HASHER_ADDR` to `MSG_HASHER_CODE`
 * set the code of `PURITY_CHECKER_ADDR` to `PURITY_CHECKER_CODE`
@@ -73,37 +75,25 @@ If `block.number == HYBRID_CASPER_FORK_BLKNUM`, then when processing the block, 
 * set balance of `CASPER_ADDR` to `CASPER_BALANCE`
 
 Then execute a `CALL` with the following parameters before executing any normal block transactions:
-* `SENDER`: NULL_SENDER
+* `SENDER`: `NULL_SENDER`
 * `GAS`: 3141592
-* `TO`: CASPER_ADDR
+* `TO`: `CASPER_ADDR`
 * `VALUE`: 0
 * `NONCE`: 0
 * `GASPRICE`: 0
-* `DATA`: `0x5a5f9fb0` followed by 32-byte encodings of the following variables in the following order:
-  * `EPOCH_LENGTH`
-  * `WITHDRAWAL_DELAY`
-  * `DYNASTY_LOGOUT_DELAY`
-  * `MSG_HASHER_ADDR`
-  * `PURITY_CHECKER_ADDR`
-  * `BASE_INTEREST_FACTOR`
-  * `BASE_PENALTY_FACTOR`
-  * `MIN_DEPOSIT_SIZE`
-
-This `CALL` utilizes no gas and does not increment the nonce of `NULL_SENDER`
-
-`web3.sha3('init(int128,int128,int128,address,address,decimal,decimal,wei_value)') == 0x5a5f9fb0553d73d024d3671fd9a72414d0db73ca25524bf336a077d1e37b63f6`
+* `DATA`: CASPER_INIT_DATA
 
 #### Initialize Epochs
 
 If `block.number >= HYBRID_CASPER_FORK_BLKNUM` and `block.number % EPOCH_LENGTH == 0`, execute a `CALL` with the following parameters before executing any normal block transactions:
 
-* `SENDER`: NULL_SENDER
+* `SENDER`: `NULL_SENDER`
 * `GAS`: 3141592
-* `TO`: CASPER_ADDR
+* `TO`: `CASPER_ADDR`
 * `VALUE`: 0
 * `NONCE`: 0
 * `GASPRICE`: 0
-* `DATA`: `0x5dcffc17` followed by the 32-byte encoding of `block.number // EPOCH_LENGTH`
+* `DATA`: `INITIALIZE_EPOCH_BYTES` followed by the 32-byte encoding of `block.number // EPOCH_LENGTH`
 
 This `CALL` utilizes no gas and does not increment the nonce of `NULL_SENDER`
 
@@ -244,7 +234,24 @@ The finality gadget is designed to minimize changes across clients. For this rea
 
 Most other decisions were made to minimize changes across clients. For example, it would be possible to allow `CASPER_ADDR` to mint Ether each time it payed rewards (as compared to creating the contract with `CASPER_BALANCE`), but this would be more invasive and error-prone than relying on existing EVM mechanics.
 
+#### Deploying Casper Contract
+The `MSG_HASHER_CODE` and `PURITY_CHECKER_CODE` both do not require any initialization so the EVM bytecode can simply be placed at `MSG_HASHER_ADDR` and `PURITY_CHECKER_ADDR`. One the other hand, the casper contract _does_ require passing in parameters and initialization of state. This initialization would normally occur by the EVM init code interacting with the CREATE opcode. Due to the nature of this contract being deployed outside of normal block transactions and to a particular address, the EVM init code/CREATE method requires client specific "hacks" to make it work. For simplicity of specifying across clients, the EVM bytecode -- `CASPER_CODE` -- is placed at `CASPER_ADDR` followed by an explicit `CALL` to a one-time `init` method on the casper contract. `init` handles all of the logic that a constructor normally would, accepting contract parameters as arguments and setting initial variable values, and can only be run _once_.
+
+`CASPER_INIT_DATA` is composed of the the byte signature of the `init` method of the casper contract concatenated with the 32-byte encodings of the following variables in the following order:
+  * `EPOCH_LENGTH`
+  * `WITHDRAWAL_DELAY`
+  * `DYNASTY_LOGOUT_DELAY`
+  * `MSG_HASHER_ADDR`
+  * `PURITY_CHECKER_ADDR`
+  * `BASE_INTEREST_FACTOR`
+  * `BASE_PENALTY_FACTOR`
+  * `MIN_DEPOSIT_SIZE`
+The entirety of this data is provided as a bytestring to reduce the chance of encoding errors across clients, especially regarding fixed decimal types which are new in vyper and not yet supported by all clients.
+
+It should be noted that `HYBRID_CASPER_FORK_BLKNUM % EPOCH_LENGTH == 0` to ensure that the initial epoch is initialized immediately after contract initialization and before any block transactions are processed.
+
 #### Casper Contract Params
+
 `EPOCH_LENGTH` is set to 50 blocks as a balance between time to finality and message overhead.
 
 `WITHDRAWAL_DELAY` is set to 15000 epochs to freeze a validator's funds for approximately 4 months after logout. This allows for at least a 4 month window to identify and slash a validator for attempting to finalize two conflicting checkpoints. This also defines the window of time with which a client must log on to sync the network due to weak subjectivity.

--- a/EIPS/eip-1011.md
+++ b/EIPS/eip-1011.md
@@ -43,8 +43,8 @@ The Casper FFG contract can be layered on top of any block proposal mechanism, p
 * `CASPER_ADDR`: TBD
 * `CASPER_CODE`: see below
 * `CASPER_BALANCE`: 1e24 wei (1,000,000 ETH)
-* `SIGHASHER_ADDR`: TBD
-* `SIGHASHER_CODE`: see below
+* `MSG_HASHER_ADDR`: TBD
+* `MSG_HASHER_CODE`: see below
 * `PURITY_CHECKER_ADDR`: TBD
 * `PURITY_CHECKER_CODE`: see below
 * `NULL_SENDER`: `2**160 - 1`
@@ -67,10 +67,31 @@ The Casper FFG contract can be layered on top of any block proposal mechanism, p
 
 If `block.number == HYBRID_CASPER_FORK_BLKNUM`, then when processing the block, before processing any transactions:
 
-* set the code of `SIGHASHER_ADDR` to `SIGHASHER_CODE`
+* set the code of `MSG_HASHER_ADDR` to `MSG_HASHER_CODE`
 * set the code of `PURITY_CHECKER_ADDR` to `PURITY_CHECKER_CODE`
 * set the code of `CASPER_ADDR` to `CASPER_CODE`
 * set balance of `CASPER_ADDR` to `CASPER_BALANCE`
+
+Then execute a `CALL` with the following parameters before executing any normal block transactions:
+* `SENDER`: NULL_SENDER
+* `GAS`: 3141592
+* `TO`: CASPER_ADDR
+* `VALUE`: 0
+* `NONCE`: 0
+* `GASPRICE`: 0
+* `DATA`: `0x5a5f9fb0` followed by 32-byte encodings of the following variables in the following order:
+  * `EPOCH_LENGTH`
+  * `WITHDRAWAL_DELAY`
+  * `DYNASTY_LOGOUT_DELAY`
+  * `MSG_HASHER_ADDR`
+  * `PURITY_CHECKER_ADDR`
+  * `BASE_INTEREST_FACTOR`
+  * `BASE_PENALTY_FACTOR`
+  * `MIN_DEPOSIT_SIZE`
+
+This `CALL` utilizes no gas and does not increment the nonce of `NULL_SENDER`
+
+`web3.sha3('init(int128,int128,int128,address,address,decimal,decimal,wei_value)') == 0x5a5f9fb0553d73d024d3671fd9a72414d0db73ca25524bf336a077d1e37b63f6`
 
 #### Initialize Epochs
 
@@ -85,6 +106,8 @@ If `block.number >= HYBRID_CASPER_FORK_BLKNUM` and `block.number % EPOCH_LENGTH 
 * `DATA`: `0x5dcffc17` followed by the 32-byte encoding of `block.number // EPOCH_LENGTH`
 
 This `CALL` utilizes no gas and does not increment the nonce of `NULL_SENDER`
+
+`web3.sha3('initialize_epoch(int128)') == 0x5dcffc17b7ff22a89d60ccb99ce1033b7fd0d68f9b9c4f2bc4ae61871f82ef5d`
 
 #### Casper Votes
 
@@ -141,9 +164,9 @@ If `block.number >= HYBRID_CASPER_FORK_BLKNUM`, then `block_reward = NEW_BLOCK_R
 The mechanics and responsibilities of validators are not specified in this EIP because they rely upon network transactions to the contract at `CASPER_ADDR` rather than on protocol level implementation and changes.
 See the [Validator Implementation Guide](https://github.com/ethereum/casper/blob/master/VALIDATOR_GUIDE.md) for validator details.
 
-#### SIGHASHER_CODE
+#### MSG_HASHER_CODE
 
-The source code for `SIGHASHER_CODE` is located [here](https://github.com/ethereum/casper/blob/master/casper/contracts/sighash.se.py).
+The source code for `MSG_HASHER_CODE` is located [here](https://github.com/ethereum/casper/blob/master/casper/contracts/sighash.se.py).
 The source is to be migrated to Vyper LLL before it's bytecode is finalized for this EIP.
 
 The EVM init code is:


### PR DESCRIPTION
This adds the new `init` method of deploying -->`CASPER_CODE` to `CASPER_ADDR` then `casper.init(params)`