### PR TITLE
Updates the error response for not found block.

### DIFF
--- a/EIPS/eip-234.md
+++ b/EIPS/eip-234.md
@@ -36,7 +36,7 @@ The only potential issue here is the `fromBlock` and `toBlock` fields.  It would
 
 ## Test Cases
 
-`{ "jsonrpc": "2.0", "id": 1, "method": "eth_getLogs", params: [{"blockHash": "0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0c"}] }` should return all of the logs for the block with hash `0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0c`.  If a `topics` field is added to the filter options then a filtered set of logs for that block should be returned.  If no block exists with that hash then an error should be returned with a `code` of `-32602`, a `message` of `"Invalid params"` and a `data` of `"Block with hash 0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0c was not found."`.
+`{ "jsonrpc": "2.0", "id": 1, "method": "eth_getLogs", params: [{"blockHash": "0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0c"}] }` should return all of the logs for the block with hash `0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0c`.  If a `topics` field is added to the filter options then a filtered set of logs for that block should be returned.  If no block exists with that hash then an error should be returned with a `code` of `-32000`, a `message` of `"Block not found."` and a `data` of `"0xbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0cbl0c"`.
 
 ## Implementation
 


### PR DESCRIPTION
Invalid parameters isn't quite right, since the parameter in this case was valid, but the resource doesn't exist or isn't available.  Also changes `data` to just contain the block hash so that clients have an easier time parsing out the not-found block (no need to use a regex to pull out the block hash).