### PR TITLE
ERC-721 Add reference for test case and implementation

### DIFF
--- a/EIPS/eip-721.md
+++ b/EIPS/eip-721.md
@@ -420,8 +420,8 @@ XXXXERC721, by William Entriken -- a scalable example implementation
 
 **NFT Implementations and Other Projects**
 
-1. 0xcert ERC-721 Token. https://github.com/0xcert/ethereum-erc721
 1. CryptoKitties. https://www.cryptokitties.co
+1. 0xcert ERC-721 Token. https://github.com/0xcert/ethereum-erc721
 1. Su Squares. https://tenthousandsu.com
 1. Decentraland. https://decentraland.org
 1. CryptoPunks. https://www.larvalabs.com/cryptopunks


### PR DESCRIPTION
Adding the 0xcert ERC-721 token as a complete reference implementation.

Why is the 0xcert ERC-721 notable?

1. It is a complete implementation of the standard.
2. It is MIT licensed.
3. It includes Truffle test cases.
4. It has a cash bug bounty that you can participate in.
5. It is the first implementation that meets all the above criteria.

---

Disclosure: I have a relationship with the 0xcert team and have reviewed this implementation.