### PR TITLE
Removed redundant submission of challenge_digest

### DIFF
--- a/EIPS/eip-918.md
+++ b/EIPS/eip-918.md
@@ -27,32 +27,33 @@ The general behavioral specification includes a primary function that defines th
 
 ``` js
 contract EIP918Interface  {
-
-    function mint(uint256 nonce, bytes32 challenge_digest) public returns (bool success);
-    
+    function mint(uint256 nonce) public returns (bool success);
+    function merge(uint256 nonce, address[] mineTokens) public returns (bool) {}
     function getAdjustmentInterval() public view returns (uint);
-
-    function getChallengeNumber() public constant returns (bytes32);
-    
-    function getMiningDifficulty() public constant returns (uint);
-
-    function getMiningTarget() public constant returns (uint);
-
-    function getMiningReward() public constant returns (uint);
-    
-    // Optional
-    function merge(uint256 nonce, bytes32 challenge_digest, address[] mineTokens) public returns (bool success){}
-    
+    function getChallengeNumber() public view returns (bytes32);
+    function getMiningDifficulty() public view returns (uint);
+    function getMiningTarget() public view returns (uint);
+    function getMiningReward() public view returns (uint);
+    function hash(uint256 nonce) public returns (bytes32 digest);
+    function _reward() internal returns (uint);
+    function _epoch() internal returns (uint);
+    function _adjustDifficulty() internal returns (uint);
     event Mint(address indexed from, uint reward_amount, uint epochCount, bytes32 newChallengeNumber);
-
 }
 ```
 
 #### Abstract Contract
 
-The Abstract Contract adheres to the EIP918 Interface and extends behavioral definition through the introduction of 4 internal phases of token mining and minting: hash, reward, epoch and adjust difficulty, all called during the mint() operation. This construct provides a balance between being too general for use while providing amply room for multiple mined implementation types.
+The Abstract Contract adheres to the EIP918 Interface and extends behavioral definition through the introduction of 4 internal phases of token mining and minting: hash, reward, epoch and adjust difficulty, all called during the mint() operation. This construct provides a balance between being too general for use while providing ample room for multiple mined implementation types.
 
 ### Fields
+
+#### adjustmentInterval
+The amount of time between difficulty adjustments in seconds.
+
+``` js
+bytes32 public adjustmentInterval;
+```
 
 #### challengeNumber
 The current challenge number. It is expected tha a new challenge number is generated after a new reward is minted.
@@ -75,13 +76,20 @@ Cumulative counter of the total minted tokens, usually modified during the \_rew
 uint public tokensMinted;
 ```
 
+#### epochCount
+Number of 'blocks' mined
+
+``` js
+uint public epochCount;
+```
+
 ### Mining Operations
 
 #### mint
 
 Returns a flag indicating a successful hash digest verification, and reward allocation to msg.sender. In order to prevent MiTM attacks, it is recommended that the digest include a recent ethereum block hash and msg.sender's address. Once verified, the mint function calculates and delivers a mining reward to the sender and performs internal accounting operations on the contract's supply.
 
-The mint operation exists as a public function that invokes 4 separate phases, represented as internal functions \_hash, \_reward, \_newEpoch, and \_adjustDifficulty. In order to create the most flexible implementation while adhering to a necessary contract protocol, it is recommended that token implementors override the internal methods, allowing the base contract to handle their execution via mint.
+The mint operation exists as a public function that invokes 4 separate phases, represented as functions hash, \_reward, \_newEpoch, and \_adjustDifficulty. In order to create the most flexible implementation while adhering to a necessary contract protocol, it is recommended that token implementors override the internal methods, allowing the base contract to handle their execution via mint.
 
 This externally facing function is called by miners to validate challenge digests, calculate reward,
 populate statistics, mutate epoch variables and adjust the solution difficulty as required. Once complete,
@@ -91,7 +99,7 @@ a Mint event is emitted before returning a boolean success flag.
 contract AbstractERC918 is EIP918Interface {
 
     // the amount of time between difficulty adjustments
-    uint public adjustmentInterval = 10 minutes;
+    uint public adjustmentInterval;
      
     // generate a new challenge number after a new reward is minted
     bytes32 public challengeNumber;
@@ -113,11 +121,11 @@ contract AbstractERC918 is EIP918Interface {
      * populate statistics, mutate epoch variables and adjust the solution difficulty as required. Once complete,
      * a Mint event is emitted before returning a success indicator.
      **/
-    function mint(uint256 nonce, bytes32 challenge_digest) public returns (bool success) {
+    function mint(uint256 nonce) public returns (bool success) {
         require(msg.sender != address(0));
 
         // perform the hash function validation
-        _hash(nonce, challenge_digest);
+        hash(nonce);
         
         // calculate the current reward
         uint rewardAmount = _reward();
@@ -137,31 +145,6 @@ contract AbstractERC918 is EIP918Interface {
         
         return true;
     }
-    
-    /*
-     * Internal interface function _hash. Overide in implementation to define hashing algorithm and 
-     * validation
-     **/
-    function _hash(uint256 nonce, bytes32 challenge_digest) internal returns (bytes32 digest);
-    
-    /*
-     * Internal interface function _reward. Overide in implementation to calculate and return reward
-     * amount
-     **/
-    function _reward() internal returns (uint);
-    
-    /*
-     * Internal interface function _newEpoch. Overide in implementation to define a cutpoint for mutating
-     * mining variables in preparation for the next epoch
-     **/
-    function _epoch() internal returns (uint);
-    
-    /*
-     * Internal interface function _adjustDifficulty. Overide in implementation to adjust the difficulty
-     * of the mining as required
-     **/
-    function _adjustDifficulty() internal returns (uint);
-
 }
 ```
 
@@ -180,15 +163,15 @@ event Mint(address indexed from, uint reward_amount, uint epochCount, bytes32 ne
 Operationally similar to mint, except the merge function offers a list of token target addresses intended to be used to merge multiple token rewards.
 
 ``` js
-function merge(uint256 nonce, bytes32 challenge_digest, address[] mineTokens) public returns (bool success);
+function merge(uint256 nonce, address[] mineTokens) public returns (bool success);
 ```
 
-#### \_hash
+#### hash
 
-Internal interface function \_hash, meant to be overridden in implementation to define hashing algorithm and validation. Returns the validated digest
+Public interface function hash, meant to be overridden in implementation to define hashing algorithm and validation. Returns the validated digest
 
 ``` js
-function _hash(uint256 nonce, bytes32 challenge_digest) internal returns (bytes32 digest);
+function _hash(uint256 nonce) public returns (bytes32 digest);
 ```
 
 #### \_reward


### PR DESCRIPTION
Per discussion with @montyanderson, it was determined that passing the challenge_digest to mint is practically redundant. Additionally pulled 4 phase mint operations into base ERC918 Interface

When opening a pull request to submit a new EIP, please use the suggested template: https://github.com/ethereum/EIPs/blob/master/eip-X.md

We have a GitHub bot that automatically merges some PRs. It will merge yours immediately if certain criteria are met:

 - The PR edits only existing draft PRs.
 - The build passes.
 - Your Github username or email address is listed in the 'author' header of all affected PRs, inside <triangular brackets>.
 - If matching on email address, the email address is the one publicly listed on your GitHub profile.
