### PR TITLE
EIP: Opt-in web3 access

### DIFF
--- a/EIPS/eip-1102.md
+++ b/EIPS/eip-1102.md
@@ -1,5 +1,5 @@
 ---
-eip: <to be assigned>
+eip: 1102
 title: Opt-in web3 access
 author: Paul Bouchon <mail@bitpshr.net>
 discussions-to: https://ethereum-magicians.org/t/opt-in-web3-access/414

--- a/EIPS/eip-1102.md
+++ b/EIPS/eip-1102.md
@@ -108,7 +108,7 @@ An [open issue](https://github.com/MetaMask/metamask-extension/issues/714) again
 
 ## Backwards compatibility
 
-This proposal impacts dapp authors and requires that they request access to the web3 API before using it. This proposal also impacts developers of web3-enabled environments or dapp browsers as these tools should no longer auto-expose the web3 API; instead, they should only do so if a website requests the API and if the user consents to its access. As mentioned in the [constraints](/#constraints) section above, environments may continue to auto-expose the web3 API as long as users have the ability to disable this behavior.
+This proposal impacts dapp authors and requires that they request access to the web3 API before using it. This proposal also impacts developers of web3-enabled environments or dapp browsers as these tools should no longer auto-expose the web3 API; instead, they should only do so if a website requests the API and if the user consents to its access. Environments may continue to auto-expose the web3 API as long as users have the ability to disable this behavior.
 
 ## Implementation
 

--- a/EIPS/eip-web3-access.md
+++ b/EIPS/eip-web3-access.md
@@ -1,0 +1,109 @@
+---
+eip: <to be assigned>
+title: Opt-in web3 access
+author: Paul Bouchon <mail@bitpshr.net>
+discussions-to: https://ethereum-magicians.org/t/opt-in-web3-access/414
+status: Draft
+type: Standards Track
+category: Interface
+created: 2018-05-04
+---
+
+## Simple summary
+
+This proposal describes a new way for environments to expose the web3 API that requires user approval.
+
+## Abstract
+
+MetaMask and most other tools that provide access to web3-enabled environments do so automatically and without user consent. This exposes users of such environments to fingerprinting attacks since untrusted websites can check for a `web3` object and reliably identify web3-enabled clients.
+
+This proposal outlines a new dapp initialization strategy in which websites request access to the web3 API instead of relying on its preexistence in a given environment.
+
+## Specification
+
+### Typical dapp initialization
+
+```
+START dapp
+IF web3 is defined
+    CONTINUE dapp
+IF web3 is undefined
+    STOP dapp
+```
+
+### Proposed dapp initialization
+
+```
+START dapp
+IF web3 is defined
+    CONTINUE dapp
+IF web3 is undefined
+    REQUEST[1] web3 API
+    IF user approves
+        INJECT[2] web3 API
+        NOTIFY[3] dapp
+        CONTINUE dapp
+    IF user rejects
+        STOP dapp
+```
+
+**REQUEST[1]** This operation would be achieved by an implementation-level messaging API like `window.postMessage` and should pass a payload containing a `type` property with a value of “WEB3_API_REQUEST”.
+
+**INJECT[2]** This operation would be achieved by any implementation-level API that can expose the web3 API to the user’s browser context, such as HTML script tag injection.
+
+**NOTIFY[3]** This operation would be achieved by an implementation-level messaging API like `window.postMessage` and should pass a payload containing a `type` property with a value of “WEB3_API_SUCCESS” after successful web3 exposure or “WEB3_API_ERROR” after unsuccessful web3 exposure. In the case of an error, an optional `message` property can be included with additional information.
+
+### Example implementation: `postMessage`
+
+```js
+if (typeof web3 !== 'undefined') {
+    // web3 API defined, start dapp
+} else {
+    window.addEventListener('message', function (event) {
+        if (!event.data || !event.data.type) { return; }
+        if (event.data.type === 'WEB3_API_SUCCESS') {
+            // web3 API defined, start dapp
+        } else if (event.data.type === 'WEB3_API_ERROR') {
+            // Something went wrong, stop dapp
+        }
+    });
+    // request web3 API
+    window.postMessage({ type: 'WEB3_API_REQUEST' });
+}
+```
+
+## Rationale
+
+An [open issue](https://github.com/MetaMask/metamask-extension/issues/714) against the [MetaMask](https://github.com/MetaMask/metamask-extension) extension has received community upvotes and Richard Burton of the [Balance](https://github.com/balance-io) team published a well-received [blog post](https://medium.com/@ricburton/metamask-walletconnect-js-b47857efb4f7) discussing these potential changes.
+
+### Constraints
+
+* Web3 SHOULD NOT be exposed to websites by default.
+* Dapps SHOULD request web3 if it does not exist.
+* Users SHOULD be able to approve or reject web3 access.
+* Web3 SHOULD be exposed to websites after user consent.
+* Dapps MUST continue to work in environments that continue to auto-expose web3.
+* Environments MAY continue auto-exposing web3 if users can disable this behavior.
+
+### Immediate value-add
+
+* Users can reject web3 access on untrusted sites to prevent web3 fingerprinting.
+
+### Long-term value-add
+
+* Dapps could request specific account information based on user consent.
+* Dapps could request specific user information based on user consent (uPort, DIDs).
+* Dapps could request a specific network based on user consent.
+* Dapps could request multiple instances of the above based on user consent.
+
+## Backwards compatibility
+
+This proposal impacts dapp authors and requires that they request access to the web3 API before using it. This proposal also impacts developers of web3-enabled environments or dapp browsers as these tools should no longer auto-expose the web3 API; instead, they should only do so if a website requests the API and if the user consents to its access. As mentioned in the [constraints](/#constraints) section above, environments may continue to auto-expose the web3 API as long as users have the ability to disable this behavior.
+
+## Implementation
+
+The MetaMask team is currently working an [MVP implementation](https://github.com/MetaMask/metamask-extension/issues/3930) of the strategy described above and expects to begin limited user testing soon.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/EIPS/eip-web3-access.md
+++ b/EIPS/eip-web3-access.md
@@ -48,13 +48,13 @@ IF web3 is undefined
         NOOP[4]
 ```
 
-**REQUEST[1]** This operation would be achieved by an implementation-level messaging API like `window.postMessage` and should pass a payload containing a `type` property with a value of “WEB3_API_REQUEST” and an optional `id` property corresponding to an identifier of a specific wallet provider, such as "METAMASK".
+**[1]REQUEST** This operation would be achieved by an implementation-level messaging API like `window.postMessage` and should pass a payload containing a `type` property with a value of “WEB3_API_REQUEST” and an optional `id` property corresponding to an identifier of a specific wallet provider, such as "METAMASK".
 
-**INJECT[2]** This operation would be achieved by any implementation-level API that can expose the web3 API to the user’s browser context, such as HTML script tag injection.
+**[2]INJECT** This operation would be achieved by any implementation-level API that can expose the web3 API to the user’s browser context, such as HTML script tag injection.
 
-**NOTIFY[3]** This operation would be achieved by an implementation-level messaging API like `window.postMessage` and should pass a payload containing a `type` property with a value of “WEB3_API_SUCCESS” after successful web3 exposure.
+**[3]NOTIFY** This operation would be achieved by an implementation-level messaging API like `window.postMessage` and should pass a payload containing a `type` property with a value of “WEB3_API_SUCCESS” after successful web3 exposure.
 
-**NOOP[4]** If a user rejects web3 access on an untrusted site, the site itself shouldn't be notified in any way; notification of a rejection would allow third-party tools to still identify that a client is web3-enabled despite not being granted web3 access.
+**[4]NOOP** If a user rejects web3 access on an untrusted site, the site itself shouldn't be notified in any way; notification of a rejection would allow third-party tools to still identify that a client is web3-enabled despite not being granted web3 access.
 
 ### Example implementation: `postMessage`
 
@@ -68,8 +68,6 @@ if (typeof web3 !== 'undefined') {
         if (!event.data || !event.data.type) { return; }
         if (event.data.type === 'WEB3_API_SUCCESS') {
             // web3 API defined, start dapp
-        } else if (event.data.type === 'WEB3_API_ERROR') {
-            // Something went wrong, stop dapp
         }
     });
     // request web3 API

--- a/EIPS/eip-web3-access.md
+++ b/EIPS/eip-web3-access.md
@@ -44,7 +44,8 @@ IF web3 is undefined
         NOTIFY[3] dapp
         CONTINUE dapp
     IF user rejects
-        STOP dapp
+    IF non-web3 environment
+        NOOP[4]
 ```
 
 **REQUEST[1]** This operation would be achieved by an implementation-level messaging API like `window.postMessage` and should pass a payload containing a `type` property with a value of “WEB3_API_REQUEST”.
@@ -53,7 +54,11 @@ IF web3 is undefined
 
 **NOTIFY[3]** This operation would be achieved by an implementation-level messaging API like `window.postMessage` and should pass a payload containing a `type` property with a value of “WEB3_API_SUCCESS” after successful web3 exposure or “WEB3_API_ERROR” after unsuccessful web3 exposure. In the case of an error, an optional `message` property can be included with additional information.
 
+**NOOP[4]** If a user rejects web3 access on an untrusted site, the site itself shouldn't be notified in any way; notification of a rejection would allow third-party tools to still identify that a client is web3-enabled despite not being granted web3 access.
+
 ### Example implementation: `postMessage`
+
+The following example demonstrates one possible implementation of this strategy in a browser-based DOM environment. Note that web3 environments on other platforms would most likely use platform-specific native messaging protocols, not `postMessage`.
 
 ```js
 if (typeof web3 !== 'undefined') {
@@ -78,11 +83,10 @@ An [open issue](https://github.com/MetaMask/metamask-extension/issues/714) again
 
 ### Constraints
 
-* Web3 SHOULD NOT be exposed to websites by default.
-* Dapps SHOULD request web3 if it does not exist.
-* Users SHOULD be able to approve or reject web3 access.
-* Web3 SHOULD be exposed to websites after user consent.
-* Dapps MUST continue to work in environments that continue to auto-expose web3.
+* Web3 MUST NOT be exposed to websites by default.
+* Dapps MUST request web3 if it does not exist.
+* Users MUST be able to approve or reject web3 access.
+* Web3 MUST be exposed to websites after user consent.
 * Environments MAY continue auto-exposing web3 if users can disable this behavior.
 
 ### Immediate value-add

--- a/EIPS/eip-web3-access.md
+++ b/EIPS/eip-web3-access.md
@@ -52,7 +52,7 @@ IF web3 is undefined
 
 **[2]INJECT** This operation would be achieved by any implementation-level API that can expose the web3 API to the user’s browser context, such as HTML script tag injection.
 
-**[3]NOTIFY** This operation would be achieved by an implementation-level messaging API like `window.postMessage` and should pass a payload containing a `type` property with a value of “WEB3_API_SUCCESS” after successful web3 exposure.
+**[3]NOTIFY** This operation would be achieved by an implementation-level messaging API like `window.postMessage` and should pass a payload containing a `type` property with a value of “WEB3_API_SUCCESS" and an optional `id` property corresponding to an identifier of a specific wallet provider, such as "METAMASK".
 
 **[4]NOOP** If a user rejects web3 access on an untrusted site, the site itself shouldn't be notified in any way; notification of a rejection would allow third-party tools to still identify that a client is web3-enabled despite not being granted web3 access.
 

--- a/EIPS/eip-web3-access.md
+++ b/EIPS/eip-web3-access.md
@@ -11,13 +11,13 @@ created: 2018-05-04
 
 ## Simple summary
 
-This proposal describes a new way for environments to expose the web3 API that requires user approval.
+This proposal describes a new way for DOM environments to expose the web3 API that requires user approval.
 
 ## Abstract
 
 MetaMask and most other tools that provide access to web3-enabled environments do so automatically and without user consent. This exposes users of such environments to fingerprinting attacks since untrusted websites can check for a `web3` object and reliably identify web3-enabled clients.
 
-This proposal outlines a new dapp initialization strategy in which websites request access to the web3 API instead of relying on its preexistence in a given environment.
+This proposal outlines a new protocol in which dapps request access to the web3 API instead of relying on its preexistence in a given DOM environment.
 
 ## Specification
 
@@ -48,13 +48,21 @@ IF web3 is undefined
         NOOP[4]
 ```
 
-**[1]REQUEST** This operation would be achieved by an implementation-level messaging API like `window.postMessage` and should pass a payload containing a `type` property with a value of “WEB3_API_REQUEST” and an optional `id` property corresponding to an identifier of a specific wallet provider, such as "METAMASK".
+#### `[1] REQUEST`
 
-**[2]INJECT** This operation would be achieved by any implementation-level API that can expose the web3 API to the user’s browser context, such as HTML script tag injection.
+Dapps MUST request the web3 API by sending a message using [`window.postMessage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) API. This message MUST be sent with a payload object containing a `type` property with a value of “WEB3_API_REQUEST” and an optional `id` property corresponding to an identifier of a specific wallet provider, such as "METAMASK".
 
-**[3]NOTIFY** This operation would be achieved by an implementation-level messaging API like `window.postMessage` and should pass a payload containing a `type` property with a value of “WEB3_API_SUCCESS" and an optional `id` property corresponding to an identifier of a specific wallet provider, such as "METAMASK".
+#### `[2] INJECT`
 
-**[4]NOOP** If a user rejects web3 access on an untrusted site, the site itself shouldn't be notified in any way; notification of a rejection would allow third-party tools to still identify that a client is web3-enabled despite not being granted web3 access.
+Dapp browsers should inject the web3 API using an implementation-specific strategy that can expose the web3 API to the user’s browser context, such as HTML script tag injection.
+
+#### `[3] NOTIFY`
+
+Dapps browsers MUST notify dapps of successful web3 exposure by sending a message using [`window.postMessage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) API. This message MUST be sent with a payload object containing a `type` property with a value of “WEB3_API_SUCCESS" and an optional `id` property corresponding to an identifier of a specific wallet provider, such as "METAMASK".
+
+#### `[4] NOOP`
+
+If a user rejects web3 access on an untrusted site, the site itself MUST NOT be notified in any way; notification of a rejection would allow third-party tools to still identify that a client is web3-enabled despite not being granted web3 access.
 
 ### Example implementation: `postMessage`
 
@@ -86,8 +94,6 @@ An [open issue](https://github.com/MetaMask/metamask-extension/issues/714) again
 * Users MUST be able to approve or reject web3 access.
 * Web3 MUST be exposed to websites after user consent.
 * Environments MAY continue auto-exposing web3 if users can disable this behavior.
-
-_Note: This proposal intentionally omits platform-specific details like messaging protocols, and instead chooses only to detail a high-level strategy that can be applied agnostically of platform or available APIs._
 
 ### Immediate value-add
 

--- a/EIPS/eip-web3-access.md
+++ b/EIPS/eip-web3-access.md
@@ -48,11 +48,11 @@ IF web3 is undefined
         NOOP[4]
 ```
 
-**REQUEST[1]** This operation would be achieved by an implementation-level messaging API like `window.postMessage` and should pass a payload containing a `type` property with a value of “WEB3_API_REQUEST”.
+**REQUEST[1]** This operation would be achieved by an implementation-level messaging API like `window.postMessage` and should pass a payload containing a `type` property with a value of “WEB3_API_REQUEST” and an optional `id` property corresponding to an identifier of a specific wallet provider, such as "METAMASK".
 
 **INJECT[2]** This operation would be achieved by any implementation-level API that can expose the web3 API to the user’s browser context, such as HTML script tag injection.
 
-**NOTIFY[3]** This operation would be achieved by an implementation-level messaging API like `window.postMessage` and should pass a payload containing a `type` property with a value of “WEB3_API_SUCCESS” after successful web3 exposure or “WEB3_API_ERROR” after unsuccessful web3 exposure. In the case of an error, an optional `message` property can be included with additional information.
+**NOTIFY[3]** This operation would be achieved by an implementation-level messaging API like `window.postMessage` and should pass a payload containing a `type` property with a value of “WEB3_API_SUCCESS” after successful web3 exposure.
 
 **NOOP[4]** If a user rejects web3 access on an untrusted site, the site itself shouldn't be notified in any way; notification of a rejection would allow third-party tools to still identify that a client is web3-enabled despite not being granted web3 access.
 
@@ -88,6 +88,8 @@ An [open issue](https://github.com/MetaMask/metamask-extension/issues/714) again
 * Users MUST be able to approve or reject web3 access.
 * Web3 MUST be exposed to websites after user consent.
 * Environments MAY continue auto-exposing web3 if users can disable this behavior.
+
+_Note: This proposal intentionally omits platform-specific details like messaging protocols, and instead chooses only to detail a high-level strategy that can be applied agnostically of platform or available APIs._
 
 ### Immediate value-add
 


### PR DESCRIPTION
MetaMask and most other tools that provide access to web3-enabled environments do so automatically and without user consent. This exposes users of such environments to fingerprinting attacks since untrusted websites can check for a `web3` object and reliably identify web3-enabled clients.

This proposal outlines a new dapp initialization strategy in which websites request access to the web3 API instead of relying on its preexistence in a given environment

- [Ethereum Magician's discussion](https://ethereum-magicians.org/t/opt-in-web3-access/414)