### PR TITLE
EIP-1057: fix table formatting.

### DIFF
--- a/EIPS/eip-1057.md
+++ b/EIPS/eip-1057.md
@@ -316,16 +316,14 @@ This PoW algorithm was tested against six different models from two different ma
 
 As the algorithm nearly fully utilizes GPU functions in a natural way, the results reflect relative GPU performance that is similar to other gaming and graphics applications.
 
--------------------------------
 | Model     | Hashrate (MH/s) |
-| --------- | --------------- |
-| RX580     |      9.4        |
+| :-------- | :-------------: |
+| RX580     |       9.4       |
 | Vega56    |      16.6       |
 | Vega64    |      18.7       |
 | GTX1070Ti |      13.1       |
 | GTX1080   |      14.9       |
 | GTX1080Ti |      21.8       |
--------------------------------
 
 ## Implementation
 


### PR DESCRIPTION
The website at https://eips.ethereum.org/EIPS/eip-1057 does not render the table in the "Test Cases" section (at the bottom).

Hopefully, this is caused by the top/bottom lines, that get interpreted as horisontal breaks.

This PR tries to follow [github's help page on table formatting](https://help.github.com/articles/organizing-information-with-tables/) more closely, removing the lines, and explicitly denoting ~~content~~ column alignment.