### PR TITLE
Make minor updates to EIP-1123

### DIFF
--- a/EIPS/eip-1123.md
+++ b/EIPS/eip-1123.md
@@ -49,8 +49,7 @@ This version:
 -   Generalizes storage URIs to represent any content addressable URI
     scheme, not only IPFS.
 
--   Renames *release lockfile* to *package manifest*, or *package* for
-    short.
+-   Renames *release lockfile* to *package manifest*.
 
 -   Adds support for languages other than Solidity by generalizing the
     compiler information format.
@@ -117,10 +116,10 @@ document are to be interpreted as described in RFC 2119.
 
 ### Prefixed vs Unprefixed
 
-A [prefixed](#term-prefixed) hexadecimal value begins with `'0x'`.
+A [prefixed](#term-prefixed) hexadecimal value begins with `0x`.
 [Unprefixed](#term-unprefixed) values have no prefix. Unless otherwise
 specified, all hexadecimal values **should** be represented with the
-`'0x'` prefix.
+`0x` prefix.
 
 <table>
 <colgroup>
@@ -225,7 +224,7 @@ document conforms to. Packages **must** include this field.
 The `package_name` field defines a human readable name for this package.
 Packages **must** include this field. Package names **must** begin with
 a lowercase letter and be comprised of only lowercase letters, numeric
-characters, and the dash character `'-'`. Package names **must** not
+characters, and the dash character `-`. Package names **must** not
 exceed 214 characters in length.
 
 <table>
@@ -639,8 +638,8 @@ encoded when [linking](#term-linking) the corresponding bytecode.
 </tr>
 <tr class="odd">
 <td><p>Allowed Values</p></td>
-<td><p><code>'literal'</code> for bytecode literals</p>
-<p><code>'reference'</code> for named references to a particular <a href="#term-contract-instance">Contract Instance</a></p></td>
+<td><p><code>&quot;literal&quot;</code> for bytecode literals</p>
+<p><code>&quot;reference&quot;</code> for named references to a particular <a href="#term-contract-instance">Contract Instance</a></p></td>
 </tr>
 </tbody>
 </table>
@@ -1434,7 +1433,7 @@ nightly should be denoted in the form of `<semver>-<commit-hash>` ex:
 #### Settings: `settings`
 
 The `settings` field defines any settings or configuration that was used
-in compilation. For the `'solc'` compiler, this **should** conform to
+in compilation. For the `"solc"` compiler, this **should** conform to
 the [Compiler Input and Output
 Description](http://solidity.readthedocs.io/en/latest/using-the-compiler.html#compiler-input-and-output-json-description).
 
@@ -1558,7 +1557,7 @@ Bytecode
 
 The set of EVM instructions as produced by a compiler. Unless otherwise
 specified this should be assumed to be hexadecimal encoded, representing
-a whole number of bytes, and [prefixed](#term-prefixed) with `'0x'`.
+a whole number of bytes, and [prefixed](#term-prefixed) with `0x`.
 
 Bytecode can either be linked or unlinked. (see
 [Linking](#term-linking))
@@ -1793,7 +1792,7 @@ for package manifests.)
 Prefixed
 --------
 
-[Bytecode](#term-bytecode) string with leading `'0x'`.
+[Bytecode](#term-bytecode) string with leading `0x`.
 
 <table>
 <colgroup>


### PR DESCRIPTION
#1123 

- Remove extraneous quotes in inline code literals, or correct quotes to JSON-valid
- Remove suggestion to use "package" metonymously to mean "package manifest"