### PR TITLE
Move ERC-721 to final status // FOR 2018-06-18

### DIFF
--- a/EIPS/eip-721.md
+++ b/EIPS/eip-721.md
@@ -4,7 +4,7 @@ title: ERC-721 Non-Fungible Token Standard
 author: William Entriken <github.com@phor.net>, Dieter Shirley <dete@axiomzen.co>, Jacob Evans <jacob@dekz.net>, Nastassia Sachs <nastassia.sachs@protonmail.com>
 type: Standards Track
 category: ERC
-status: Last Call
+status: Final
 review-period-end: 2018-06-18
 created: 2018-01-24
 requires: 165


### PR DESCRIPTION
This PR moves ERC-721 from LAST CALL status to FINAL status.

At the end of 2018-06-18 (I suppose 11:59 PM GMT is appropriate), an EIP Editor will please review the discussion during the LAST CALL period. You can see that the relevant discussion began starting here:

> https://github.com/ethereum/EIPs/issues/721#issuecomment-395474692

If your review finds that no controversy, material changes, or unresolved complains have developed during the LAST CALL, please accept this PR. Your review process is documented in [EIP-1 workflow](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1.md#eip-work-flow).

Also, dear editor, don't be shy, you can come to 721 and congratulate us, this is the first standard to go through LAST CALL review, and we all worked very hard on it! Thank you to ALL involved.