### PR TITLE
mild approve()/Approval() clarifications

### DIFF
--- a/EIPS/eip-721.md
+++ b/EIPS/eip-721.md
@@ -54,7 +54,7 @@ interface ERC721 /* is ERC165 */ {
     ///  any transfer, the approved address for that NFT (if any) is reset to none.
     event Transfer(address indexed _from, address indexed _to, uint256 indexed _tokenId);
 
-    /// @dev This emits when the approved address for an NFT is changed or
+    /// @dev This emits when the approved address for an NFT is set or
     ///  reaffirmed. The zero address indicates there is no approved address.
     ///  When a Transfer event emits, this also indicates that the approved
     ///  address for that NFT (if any) is reset to none.
@@ -112,7 +112,7 @@ interface ERC721 /* is ERC165 */ {
     /// @param _tokenId The NFT to transfer
     function transferFrom(address _from, address _to, uint256 _tokenId) external payable;
 
-    /// @notice Set or reaffirm the approved address for an NFT
+    /// @notice Set or reaffirm the approved address for an NFT.
     /// @dev The zero address indicates there is no approved address.
     /// @dev Throws unless `msg.sender` is the current NFT owner, or an authorized
     ///  operator of the current owner.


### PR DESCRIPTION
In ERC721, specify that `Approval` should be emitted in a "set or reaffirmation" and not just on a "change or reaffirmation".