### PR TITLE
Update ERC721 `onERC721Received` to have an additional `operator` parameter.

### DIFF
--- a/EIPS/eip-721.md
+++ b/EIPS/eip-721.md
@@ -85,7 +85,7 @@ interface ERC721 /* is ERC165 */ {
     ///  `_tokenId` is not a valid NFT. When transfer is complete, this function
     ///  checks if `_to` is a smart contract (code size > 0). If so, it calls
     ///  `onERC721Received` on `_to` and throws if the return value is not
-    ///  `bytes4(keccak256("onERC721Received(address,uint256,bytes)"))`.
+    ///  `bytes4(keccak256("onERC721Received(address,address,uint256,bytes)"))`.
     /// @param _from The current owner of the NFT
     /// @param _to The new owner
     /// @param _tokenId The NFT to transfer
@@ -155,7 +155,7 @@ interface ERC165 {
 A wallet/broker/auction application MUST implement the **wallet interface** if it will accept safe transfers.
 
 ```solidity
-/// @dev Note: the ERC-165 identifier for this interface is 0xf0b9e5ba
+/// @dev Note: the ERC-165 identifier for this interface is 0x150b7a02
 interface ERC721TokenReceiver {
     /// @notice Handle the receipt of an NFT
     /// @dev The ERC721 smart contract calls this function on the recipient
@@ -163,12 +163,14 @@ interface ERC721TokenReceiver {
     ///  transfer. Return of other than the magic value MUST result in the
     ///  transaction being reverted.
     ///  Note: the contract address is always the message sender.
-    /// @param _from The sending address
+    /// @param _operator The address which triggered `safeTransferFrom` function.
+    ///  Either previous owner or an approved operator (via `approve` or `setApprovalForAll`).
+    /// @param _from The address which previously owned the token.
     /// @param _tokenId The NFT identifier which is being transfered
     /// @param data Additional data with no specified format
-    /// @return `bytes4(keccak256("onERC721Received(address,uint256,bytes)"))`
+    /// @return `bytes4(keccak256("onERC721Received(address,address,uint256,bytes)"))`
     ///  unless throwing
-	function onERC721Received(address _from, uint256 _tokenId, bytes data) external returns(bytes4);
+	function onERC721Received(address _operator, address _from, uint256 _tokenId, bytes data) external returns(bytes4);
 }
 ```
 


### PR DESCRIPTION
This allows for permission checks on `safeTransferFrom` caller as discussed in #721.