### PR TITLE
Fix 721 punctuation natspec

### DIFF
--- a/EIPS/eip-721.md
+++ b/EIPS/eip-721.md
@@ -45,7 +45,7 @@ pragma solidity ^0.4.20;
 
 /// @title ERC-721 Non-Fungible Token Standard
 /// @dev See https://github.com/ethereum/EIPs/blob/master/EIPS/eip-721.md
-///  Note: the ERC-165 identifier for this interface is 0x80ac58cd
+///  Note: the ERC-165 identifier for this interface is 0x80ac58cd.
 interface ERC721 /* is ERC165 */ {
     /// @dev This emits when ownership of any NFT changes by any mechanism.
     ///  This event emits when NFTs are created (`from` == 0) and destroyed
@@ -94,7 +94,7 @@ interface ERC721 /* is ERC165 */ {
 
     /// @notice Transfers the ownership of an NFT from one address to another address
     /// @dev This works identically to the other function with an extra data parameter,
-    ///  except this function just sets data to ""
+    ///  except this function just sets data to "".
     /// @param _from The current owner of the NFT
     /// @param _to The new owner
     /// @param _tokenId The NFT to transfer
@@ -112,24 +112,24 @@ interface ERC721 /* is ERC165 */ {
     /// @param _tokenId The NFT to transfer
     function transferFrom(address _from, address _to, uint256 _tokenId) external payable;
 
-    /// @notice Change or reaffirm the approved address for an NFT.
+    /// @notice Change or reaffirm the approved address for an NFT
     /// @dev The zero address indicates there is no approved address.
-    /// @dev Throws unless `msg.sender` is the current NFT owner, or an authorized
+    ///  Throws unless `msg.sender` is the current NFT owner, or an authorized
     ///  operator of the current owner.
     /// @param _approved The new approved NFT controller
     /// @param _tokenId The NFT to approve
     function approve(address _approved, uint256 _tokenId) external payable;
 
     /// @notice Enable or disable approval for a third party ("operator") to manage
-    ///  all of `msg.sender`'s assets.
+    ///  all of `msg.sender`'s assets
     /// @dev Emits the ApprovalForAll event. The contract MUST allow
     ///  multiple operators per owner.
-    /// @param _operator Address to add to the set of authorized operators.
+    /// @param _operator Address to add to the set of authorized operators
     /// @param _approved True if the operator is approved, false to revoke approval
     function setApprovalForAll(address _operator, bool _approved) external;
 
     /// @notice Get the approved address for a single NFT
-    /// @dev Throws if `_tokenId` is not a valid NFT
+    /// @dev Throws if `_tokenId` is not a valid NFT.
     /// @param _tokenId The NFT to find the approved address for
     /// @return The approved address for this NFT, or the zero address if there is none
     function getApproved(uint256 _tokenId) external view returns (address);
@@ -155,8 +155,8 @@ interface ERC165 {
 A wallet/broker/auction application MUST implement the **wallet interface** if it will accept safe transfers.
 
 ```solidity
-/// @dev Note: the ERC-165 identifier for this interface is 0xf0b9e5ba
-/// @dev Note: the application will get the prior owner of the token
+/// @dev Note: the ERC-165 identifier for this interface is 0xf0b9e5ba.
+///  Note: the application will get the prior owner of the token
 ///  via _from parameter -- but it will NOT see who called safeTransferFrom.
 interface ERC721TokenReceiver {
     /// @notice Handle the receipt of an NFT
@@ -165,7 +165,7 @@ interface ERC721TokenReceiver {
     ///  transfer. Return of other than the magic value MUST result in the
     ///  transaction being reverted.
     ///  Note: the contract address is always the message sender.
-    /// @param _from The address which previously owned the token.
+    /// @param _from The address which previously owned the token
     /// @param _tokenId The NFT identifier which is being transfered
     /// @param data Additional data with no specified format
     /// @return `bytes4(keccak256("onERC721Received(address,uint256,bytes)"))`
@@ -179,7 +179,7 @@ The **metadata extension** is OPTIONAL for ERC-721 smart contracts (see "caveats
 ```solidity
 /// @title ERC-721 Non-Fungible Token Standard, optional metadata extension
 /// @dev See https://github.com/ethereum/EIPs/blob/master/EIPS/eip-721.md
-///  Note: the ERC-165 identifier for this interface is 0x5b5e139f
+///  Note: the ERC-165 identifier for this interface is 0x5b5e139f.
 interface ERC721Metadata /* is ERC721 */ {
     /// @notice A descriptive name for a collection of NFTs in this contract
     function name() external view returns (string _name);
@@ -223,7 +223,7 @@ The **enumeration extension** is OPTIONAL for ERC-721 smart contracts (see "cave
 ```solidity
 /// @title ERC-721 Non-Fungible Token Standard, optional enumeration extension
 /// @dev See https://github.com/ethereum/EIPs/blob/master/EIPS/eip-721.md
-///  Note: the ERC-165 identifier for this interface is 0x780e9d63
+///  Note: the ERC-165 identifier for this interface is 0x780e9d63.
 interface ERC721Enumerable /* is ERC721 */ {
     /// @notice Count NFTs tracked by this contract
     /// @return A count of valid NFTs tracked by this contract, where each one of

--- a/EIPS/eip-721.md
+++ b/EIPS/eip-721.md
@@ -165,12 +165,12 @@ interface ERC721TokenReceiver {
     ///  transfer. Return of other than the magic value MUST result in the
     ///  transaction being reverted.
     ///  Note: the contract address is always the message sender.
-    /// @param _from The sending address
+    /// @param _from The address which previously owned the token.
     /// @param _tokenId The NFT identifier which is being transfered
     /// @param data Additional data with no specified format
     /// @return `bytes4(keccak256("onERC721Received(address,uint256,bytes)"))`
     ///  unless throwing
-	function onERC721Received(address _from, uint256 _tokenId, bytes data) external returns(bytes4);
+    function onERC721Received(address _from, uint256 _tokenId, bytes data) external returns(bytes4);
 }
 ```
 

--- a/EIPS/eip-721.md
+++ b/EIPS/eip-721.md
@@ -54,7 +54,7 @@ interface ERC721 /* is ERC165 */ {
     ///  any transfer, the approved address for that NFT (if any) is reset to none.
     event Transfer(address indexed _from, address indexed _to, uint256 indexed _tokenId);
 
-    /// @dev This emits when the approved address for an NFT is set or
+    /// @dev This emits when the approved address for an NFT is changed or
     ///  reaffirmed. The zero address indicates there is no approved address.
     ///  When a Transfer event emits, this also indicates that the approved
     ///  address for that NFT (if any) is reset to none.
@@ -112,7 +112,7 @@ interface ERC721 /* is ERC165 */ {
     /// @param _tokenId The NFT to transfer
     function transferFrom(address _from, address _to, uint256 _tokenId) external payable;
 
-    /// @notice Set or reaffirm the approved address for an NFT.
+    /// @notice Change or reaffirm the approved address for an NFT.
     /// @dev The zero address indicates there is no approved address.
     /// @dev Throws unless `msg.sender` is the current NFT owner, or an authorized
     ///  operator of the current owner.


### PR DESCRIPTION
Thank you @shrugs.

This harmonizes punctuation used in NatSpec:

- @notice, @param, @return are fragments (not a sentence, no period at end)
- @dev is a sentence (period at end)

This PR supercedes https://github.com/ethereum/EIPs/pull/1151