### PR TITLE
Cache external link checks

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e # halt script on error
 
-HTMLPROOFER_OPTIONS="./_site --internal-domains=eips.ethereum.org --check-html --check-opengraph --report-missing-names --log-level=:debug --assume-extension --empty-alt-ignore --url-ignore=/EIPS/eip-1,EIPS/eip-1,/EIPS/eip-107,/EIPS/eip-858"
+HTMLPROOFER_OPTIONS="./_site --internal-domains=eips.ethereum.org --check-html --check-opengraph --report-missing-names --log-level=:debug --assume-extension --empty-alt-ignore --timeframe=6w --url-ignore=/EIPS/eip-1,EIPS/eip-1,/EIPS/eip-107,/EIPS/eip-858"
 
 if [[ $TASK = 'htmlproofer' ]]; then
   bundle exec jekyll doctor

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# SUSHI
 set -e # halt script on error
 
 HTMLPROOFER_OPTIONS="./_site --internal-domains=eips.ethereum.org --check-html --check-opengraph --report-missing-names --log-level=:debug --assume-extension --empty-alt-ignore --timeframe=6w --url-ignore=/EIPS/eip-1,EIPS/eip-1,/EIPS/eip-107,/EIPS/eip-858"

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# SUSHI
 set -e # halt script on error
 
 HTMLPROOFER_OPTIONS="./_site --internal-domains=eips.ethereum.org --check-html --check-opengraph --report-missing-names --log-level=:debug --assume-extension --empty-alt-ignore --timeframe=6w --url-ignore=/EIPS/eip-1,EIPS/eip-1,/EIPS/eip-107,/EIPS/eip-858"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,12 @@ sudo: false # route your build to the container-based infrastructure for a faste
 
 language: ruby
 
-# Cache Ruby bundles
-cache: bundler
+cache:
+  # Cache Ruby bundles
+  - bundler
+  - directories:
+    - $TRAVIS_BUILD_DIR/tmp/.htmlproofer #https://github.com/gjtorikian/html-proofer/issues/381
+  
 
 # Assume bundler is being used, therefore
 # the `install` step will run `bundle install` by default.

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,3 +35,8 @@ notifications:
     urls:
       - https://ethlab-183014.appspot.com/merge/
     on_success: always
+
+addons:
+  apt:
+    packages:
+      "libcurl4-openssl-dev" # https://github.com/gjtorikian/html-proofer/issues/376#issuecomment-332767999


### PR DESCRIPTION
Best practice stolen from:

- https://github.com/fulldecent/html-website-template/blob/master/.travis.yml#L8-L10
- https://github.com/fulldecent/lightning-sites/blob/master/lib/lightning_sites.rb#L229-L231

Maybe you didn't know I'm also on the html-proofer project :-p

---

# Metrics

Build times of external link check.

BEFORE change 2 min 2 sec -- https://travis-ci.org/ethereum/EIPs/builds/394136680

AFTER change 1 min 29 sec -- https://travis-ci.org/ethereum/EIPs/builds/394195566

THE MAGIC -- https://travis-ci.org/ethereum/EIPs/jobs/394195569#L1147