### PR TITLE
721, the first graduate from the Last Call process

### DIFF
--- a/EIPS/eip-721.md
+++ b/EIPS/eip-721.md
@@ -4,8 +4,7 @@ title: ERC-721 Non-Fungible Token Standard
 author: William Entriken <github.com@phor.net>, Dieter Shirley <dete@axiomzen.co>, Jacob Evans <jacob@dekz.net>, Nastassia Sachs <nastassia.sachs@protonmail.com>
 type: Standards Track
 category: ERC
-status: Last Call
-review-period-end: 2018-06-18
+status: Final
 created: 2018-01-24
 requires: 165
 ---


### PR DESCRIPTION
This pull requests promotes ERC-721 from Last Call status to Final status.

One immaterial change was made during the Last Call and all questions were addressed.

The time now is Thursday in UTC time zone. We have added two days to the Last Call in good taste.

# Policy

Relevant policy is given in [EIP-1](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1.md) for when to promote an EIP from Last Call status to Final status:

> ➡️ Final (Not core EIPs) -- A successful Last Call without material changes or unaddressed complaints will become Final.


# All changes

ERC-721 began Last Call with commit https://github.com/ethereum/EIPs/commit/c9a9320#diff-a87271f8186c59c075e229cd7421f205

Every change since then are viewable with the compare view: https://gith ub.com/ethereum/EIPs/compare/c9a9320...master#diff-a87271f8186c59c075e229cd7421f205

^ github bug / you need to copy paste and remove the space to access url

The entire set of changes is:

* Fix punctuation (add and remove periods, remove underscore)
* Make NatSpec documentation more clear, use consistent words
* Add `operator` parameter to `onERC721Received` callback function
* Add justification for `operator` parameter into rationale section

These documentation improvements and this additional parameter are not material changes.

# All discussion

The designated place for discussion is https://github.com/ethereum/EIPs/issues/721

The comment just before Last Call status is https://github.com/ethereum/EIPs/issues/721#issuecomment-393986275

The entire list of discussion topics were:

* @johnhforrest proposed to remove underscores from event parameter names -- RESOLUTION change not adopted, this is immaterial for an ABI
* @mg6maciej proposed to add the parameter `operator` to the token receiver callback, dissent from @paulbarclay was that this increases complexity because a workaround exists, counterpoint is that the workaround requires an extra transfer and does not follow the philosophy of 721 -- RESOLUTION this change was adopted
* @jacqueswww noted that Vyper is incompatible 721 because we use two functions with the same name (overloading) -- RESOLUTION no change is necessary, Vyper will update to support function default parameters and be compatible with 721
* @paulbarclay proposed to remove one transfer function -- RESOLUTION change not adopted, we have previously discussed this at length and our transfer mechanism has strong community support and documented rationale (the discussion during last call added no new arguments in this point)
* @mudgen proposed adding a the bytes data into the event log -- RESOLUTION change not adopted, this would cost much gas and not be useful, applications can do their own application-specific logging
* @mudgen questioned why functions throw rather than return false -- RESOLUTION change not adopted, ERC20's decision is well-recognized as a poor design choice
* @mudgen proposed allowing an arbitrary number of URIs per token -- RESOLUTION change not adopted, this smells like an application-specific requirement and does not benefit interoperability
* @frangio requested that a list of major changes should be published -- RESOLUTION this was added as a comment to the #721 discussion

All questions/comments have been fully addressed.


REFERENCE: - https://github.com/ethereum/EIPs/pull/1150