### PR TITLE
Remove named return values from EIP721

### DIFF
--- a/EIPS/eip-721.md
+++ b/EIPS/eip-721.md
@@ -180,10 +180,10 @@ The **metadata extension** is OPTIONAL for ERC-721 smart contracts (see "caveats
 ///  Note: the ERC-165 identifier for this interface is 0x5b5e139f.
 interface ERC721Metadata /* is ERC721 */ {
     /// @notice A descriptive name for a collection of NFTs in this contract
-    function name() external view returns (string _name);
+    function name() external view returns (string);
 
     /// @notice An abbreviated name for NFTs in this contract
-    function symbol() external view returns (string _symbol);
+    function symbol() external view returns (string);
 
     /// @notice A distinct Uniform Resource Identifier (URI) for a given asset.
     /// @dev Throws if `_tokenId` is not a valid NFT. URIs are defined in RFC


### PR DESCRIPTION
The name of return values is not part of the interface.

