### PR TITLE
EIP-823: security improvements

### DIFF
--- a/EIPS/eip-823.md
+++ b/EIPS/eip-823.md
@@ -95,11 +95,11 @@ NOTE: Callers MUST handle false from returns (bool success). Callers MUST NOT as
 
 ##### __targetExchangeCallback
 This function is called by the intermediate exchange service contract. This function should add `_amount` tokens of the target contract to the exchangers address for exchange to be completed successfully.
-s
+
 NOTE: It is required that only the exchange service contract has the authority to call this function.
 
 ``` js
-function __targetExchangeCallback (uint _amount) public returns(bool success)
+function __targetExchangeCallback (uint _to, uint _amount) public returns(bool success)
 ```
 
 ##### __targetExchangeAndSpendCallback
@@ -108,7 +108,7 @@ This function is called by the intermediate exchange service contract. This func
 NOTE: It is required that only the exchange service contract has the authority to call this function.
 
 ``` js
-function __targetExchangeAndSpendCallback (address _to,uint _amount) public returns(bool success)
+function __targetExchangeAndSpendCallback (address _from, address _to, uint _amount) public returns(bool success)
 ```
 
 #### Events
@@ -156,7 +156,7 @@ function registerToken(address _token) public returns(bool success)
 This function is called by the token holder who wants to exchange his token with the `_targetContract` tokens. This function queries the exchange rate, calculates the converted amount, calls `__exchangerCallback` and calls the `__targetExchangeCallback`. It takes address of the target contract and amount to exchange as parameter and returns boolean `success` and amount credited.
 
 ``` js
-function exchangeToken(address _targetContract, uint _amount) public returns(bool success, uint creditedAmount)
+function exchangeToken(address _targetContract, uint _amount, address _from) public returns(bool success, uint creditedAmount)
 ```
 
 ##### exchangeAndSpend
@@ -164,7 +164,7 @@ function exchangeToken(address _targetContract, uint _amount) public returns(boo
 This function is called by the token holder who wants to exchange his token with the `_targetContract` tokens. This function queries the exchange rate, calculates the converted amount, calls `__exchangerCallback` and calls the `__targetExchangeAndSpendCallback`. It takes address of the target contract and amount to exchange as parameter and returns boolean `success` and amount credited.
 
 ``` js
-function exchangeAndSpend(address _targetContract, uint _amount,address _to) public returns(bool success)
+function exchangeAndSpend(address _targetContract, uint _amount, address _from, address _to) public returns(bool success)
 ```
 
 #### Events


### PR DESCRIPTION
Current version of EIP-823 implies using of unsafe global variable `tx.origin`.
As you can see on `Exchanging Tokens` diagram, exchange service contract must call `__exchangerCalback` on source token contract with address of token holder (here `0xa12`), but it doesn't know this address from `exchangeToken` arguments. Next, `__targetExchangeCallback` in target token contract also must know token holder address (for correct changing balance and emitting `Exchange` event), but doesn't have such argument.
Same problem with `Exchanging And Spending Tokens` diagram.
I implemented current version of EIP-823 with `tx.origin` usage in test contracts and successfully stole tokens via phishing contract under some conditions.