### PR TITLE
Add another reference implementation for ERC-900

### DIFF
--- a/EIPS/eip-900.md
+++ b/EIPS/eip-900.md
@@ -8,7 +8,7 @@ status: Draft
 created: 2018-02-22
 discussions-to: https://github.com/ethereum/EIPs/issues/900
 ---
-    
+
 ## Abstract
 
 The following standard describes a common staking interface allowing for easy to use staking systems. The interface is kept simple allowing for various use cases to be implemented. This standard describes the common functionality for staking as well as providing information on stakes.
@@ -78,7 +78,7 @@ Address of the token being used by the staking interface.
 
 ### supportsHistory
 
-MUST return true if the optional history functions are implemented, otherwise false. 
+MUST return true if the optional history functions are implemented, otherwise false.
 
 ### lastStakedFor
 
@@ -103,6 +103,7 @@ Returns the total tokens staked at block.
 - [Stakebank](https://github.com/HarbourProject/stakebank)
 - [Aragon](https://github.com/aragon/aragon-apps/pull/101)
 - [PoS Staking](https://github.com/maticnetwork/contracts/blob/master/contracts/StakeManager.sol)
+- [BasicStakeContract](https://github.com/codex-protocol/contract.erc-900)
 
 ## Copyright
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
Adding another reference implementation to ERC-900.

The reference includes:
- A basic implementation
- A credits implementation where staking rewards integer-based credits
- A weighted implementation where stakes can gain weight over time by accruing interest