### PR TITLE
Update EIP-1066 links to new code repo

### DIFF
--- a/EIPS/eip-1066.md
+++ b/EIPS/eip-1066.md
@@ -578,7 +578,9 @@ function appCode(Sleep _state) returns (byte code) {
 
 ## Implementation
 
-Reference cases and helper library can be found [here](https://github.com/Finhaven/EthereumStatusCodes)
+Reference cases and helper libraries (Solidity and JS) can be found at:
+* [Source Code](https://github.com/expede/ethereum-status-codes/)
+* [Package on npm](https://www.npmjs.com/package/ethereum-status-codes)
 
 ## Copyright
 


### PR DESCRIPTION
Work on implementation of ERC-1066 now happens [here](https://github.com/expede/ethereum-status-codes/). This PR updates the link. It also adds a link to the [npm](https://www.npmjs.com/package/ethereum-status-codes) deployment of the same.