### PR TITLE
Update EIP-999 status

### DIFF
--- a/EIPS/eip-999.md
+++ b/EIPS/eip-999.md
@@ -3,7 +3,7 @@ eip: 999
 title: Restore Contract Code at 0x863DF6BFa4469f3ead0bE8f9F2AAE51c91A907b4
 author: Afri Schoedon (@5chdn)
 discussions-to: https://ethereum-magicians.org/t/eip-999-restore-contract-code-at-0x863df6bfa4/130
-status: Draft
+status: Accepted
 type: Standards Track
 category: Core
 created: 2018-04-04


### PR DESCRIPTION
As discussed at the FEM Berlin panel, the EIP-999 was technically not objected at Ethereum Core Devs Meeting 37 on April 20, 2018, and shall be moved to _accepted_ state within the scope of EIP-1.