### PR TITLE
Update EIP-999 status.

### DIFF
--- a/EIPS/eip-999.md
+++ b/EIPS/eip-999.md
@@ -3,7 +3,7 @@ eip: 999
 title: Restore Contract Code at 0x863DF6BFa4469f3ead0bE8f9F2AAE51c91A907b4
 author: Afri Schoedon (@5chdn)
 discussions-to: https://ethereum-magicians.org/t/eip-999-restore-contract-code-at-0x863df6bfa4/130
-status: Draft
+status: Rejected
 type: Standards Track
 category: Core
 created: 2018-04-04


### PR DESCRIPTION
Set EIP-999 status to rejected.

Community vote in which the majority voted against EIP-999: https://www.etherchain.org/coinvote/poll/35

Blog post by Parity in which they state they will work with the community: https://paritytech.io/our-commitment-to-ethereum-and-a-decentralised-future/