### PR TITLE
EIP-1231: Reduce CALL cost for precompiles

### DIFF
--- a/EIPS/eip-1231.md
+++ b/EIPS/eip-1231.md
@@ -23,10 +23,16 @@ In the Spurious Dragon hard fork, the cost of CALLs across the board was raised 
 
 Following is a table with the current gas cost and new gas cost:
 
-| Contract                       | Opcode    | Current Gas Cost               | Updated Gas Cost    |
+| Opcode name                    | Opcodes   | Current Gas Cost               | Updated Gas Cost    |
 | ------------------------------ | --------- | -----------------------------  | ------------------- |
 | `CALL` (to precompiles)        | `0xf1`    | 700<sup>[1]</sup>              | 40                  |
+| `CALLCODE` (to precompiles)    | `0xf2`    | 700<sup>[1]</sup>              | 40                  |
+| `DELEGATECALL` (to precompiles)| `0xf3`    | 700<sup>[1]</sup>              | 40                  |
+| `STATICCALL` (to precompiles)  | `0xf4`    | 700<sup>[1]</sup>              | 40                  |
 | `CALL` (to contracts)          | `0xf1`    | 700<sup>[1]</sup>              | 700  (unchanged)    |
+| `CALLCODE` (to contracts)      | `0xf2`    | 700<sup>[1]</sup>              | 700  (unchanged)    |
+| `DELEGATECALL` (to contracts)  | `0xf3`    | 700<sup>[1]</sup>              | 700  (unchanged)    |
+| `STATICCALL` (to contracts)    | `0xf4`    | 700<sup>[1]</sup>              | 700  (unchanged)    |
 
 
 [1]- Per EIP-150

--- a/EIPS/eip-1231.md
+++ b/EIPS/eip-1231.md
@@ -15,9 +15,9 @@ The Spurious Dragon hard fork increased the cost of CALLs to mitigate protocol D
 
 ## Motivation
 
-There are useful precompiles such as a ECADD, SHA256, RIPEMD and the identity precompile (useful for memcpy) which have a gas cost that is far below or approximately equal to the cost of a CALL, which restricts their use cases in certain situations if they need to be called many times in a loop as they can become 2x to 10x more expensive due to the CALL cost overhead, particularly with SHA256 and ECADD which often require tight loops to certain cryptographic protocols.
+There are useful precompiles such as a ECADD, SHA256, RIPEMD and the identity precompile (useful for memcpy) which have a gas cost that is far below or approximately equal to the cost of a CALL, which restricts their usefulness if they need to be called many times in a loop. The overhead can cause 2x to 10x increase in gas cost due to the CALL cost overhead, particularly with SHA256 and ECADD which often require tight loops for certain cryptographic protocols.
 
-In the Spurious Dragon hard fork, the cost of CALLs across the board was raised to 700 gas to mitigate DoS from state reads, without making a distinction between precompiles and deployed contracts. It does not make sense that precompiles should also suffer from the DoS mitigation penalty, since the precompiles are part of the core node code and hence never need to be fetched from disk. The CALL cost for precompiles should be reverted back to pre-EIP150, to 40 gas per call.
+In the Spurious Dragon hard fork, the cost of CALLs across the board was raised to 700 gas to mitigate DoS from state reads, without making a distinction between precompiles and deployed contracts. It does not make sense that precompiles should also suffer from the DoS mitigation penalty, since the precompiles are part of the core node code and hence never need to be fetched from disk. The CALL cost for precompiles should be reverted back to pre-EIP150 values, to 40 gas per call.
 
 ## Specification
 

--- a/EIPS/eip-1231.md
+++ b/EIPS/eip-1231.md
@@ -15,7 +15,7 @@ The Spurious Dragon hard fork increased the cost of CALLs to mitigate protocol D
 
 ## Motivation
 
-There are useful precompiles such as a ECADD, SHA256, RIPEMD and the identity precompile (useful for memcpy) which have a gas cost that is far below or approximately equal to the cost of a CALL, which restricts their usefulness if they need to be called many times in a loop. The overhead can cause 2x to 10x increase in gas cost due to the CALL cost overhead, particularly with SHA256 and ECADD which often require tight loops for certain cryptographic protocols.
+There are useful precompiles such as a ECADD, SHA256, RIPEMD and the identity precompile (useful for memcpy) which have a gas cost that is far below or approximately equal to the cost of a CALL, which restricts their usefulness if they need to be called many times in a loop. This can cause a 2x to 10x increase in gas cost due to the CALL cost overhead, particularly with SHA256 and ECADD which often require tight loops for certain cryptographic protocols.
 
 In the Spurious Dragon hard fork, the cost of CALLs across the board was raised to 700 gas to mitigate DoS from state reads, without making a distinction between precompiles and deployed contracts. It does not make sense that precompiles should also suffer from the DoS mitigation penalty, since the precompiles are part of the core node code and hence never need to be fetched from disk. The CALL cost for precompiles should be reverted back to pre-EIP150 values, to 40 gas per call.
 

--- a/EIPS/eip-1231.md
+++ b/EIPS/eip-1231.md
@@ -1,0 +1,33 @@
+---
+eip: 1231
+title: Reduce cost of CALLs to precompiles
+author: Matthew Di Ferrante (@mattdf)
+status: Draft
+type: Standards Track
+category: Core
+created: 2018-07-19
+requires: 150, 158
+---
+
+## Short Description
+
+The Spurious Dragon hard fork increased the cost of CALLs to mitigate protocol DoS attacks that involved reads, but it failed to distinguish between CALLs to precompiles and CALLs to deployed contracts. This is an oversight that should be corrected.
+
+## Motivation
+
+There are useful precompiles such as a ECADD, SHA256, RIPEMD and the identity precompile (useful for memcpy) which have a gas cost that is far below or approximately equal to the cost of a CALL, which restricts their use cases in certain situations if they need to be called many times in a loop as they can become 2x to 10x more expensive due to the CALL cost overhead, particularly with SHA256 and ECADD which often require tight loops to certain cryptographic protocols.
+
+In the Spurious Dragon hard fork, the cost of CALLs across the board was raised to 700 gas to mitigate DoS from state reads, without making a distinction between precompiles and deployed contracts. It does not make sense that precompiles should also suffer from the DoS mitigation penalty, since the precompiles are part of the core node code and hence never need to be fetched from disk. The CALL cost for precompiles should be reverted back to pre-EIP150, to 40 gas per call.
+
+## Specification
+
+Following is a table with the current gas cost and new gas cost:
+
+| Contract                       | Opcode    | Current Gas Cost               | Updated Gas Cost    |
+| ------------------------------ | --------- | -----------------------------  | ------------------- |
+| `CALL` (to precompiles)        | `0xf1`    | 700<sup>[1]</sup>              | 40                  |
+| `CALL` (to contracts)          | `0xf1`    | 700<sup>[1]</sup>              | 700  (unchanged)    |
+
+
+[1]- Per EIP-150
+


### PR DESCRIPTION
EIP to reduce call cost to precompiles to pre-spurious dragon HF values. Precompiles don't have read overhead and as such should never have been subject to the penalty.