### PR TITLE
Creates Remove Difficulty Bomb EIP

### DIFF
--- a/EIPS/eip-1240.md
+++ b/EIPS/eip-1240.md
@@ -1,5 +1,5 @@
 ---
-eip: XXXX
+eip: 1240
 title: Remove Difficulty Bomb
 author: Micah Zoltu (@MicahZoltu)
 discussions-to: https://ethereum-magicians.org/t/difficulty-bomb-removal/832

--- a/EIPS/eip-xxxx.md
+++ b/EIPS/eip-xxxx.md
@@ -20,7 +20,7 @@ The difficulty bomb operates under the assumption that miners decide what code e
 
 ## Specification
 #### Remove Difficulty with Fake Block Number
-For the purposes of `calc_difficulty`, simply remove the use of `block.number`, as used in the exponential ice age component.
+For the purposes of `calc_difficulty`, change the epsilon component to `0` rather than having it be a function of block number.
 
 ## Rationale
 With the difficulty bomb removed, when Casper is released it will be up to economic participants to decide whether they want the features that Casper enables or not.  If they do not want Casper, they are free to continue running unpatched clients and participating in the Ethereum network as it exists today.  This freedom of choice is the cornerstone of DLTs and making it hard for people to make that choice (by creating an artificial pressure) does not work towards that goal of freedom of choice.  If the development team is not confident that economic participants will want Casper, then they should re-evaluate their priorities rather than trying to force Casper onto users.

--- a/EIPS/eip-xxxx.md
+++ b/EIPS/eip-xxxx.md
@@ -1,0 +1,37 @@
+---
+eip: XXXX
+title: Remove Difficulty Bomb
+author: Micah Zoltu (@MicahZoltu)
+discussions-to: https://ethereum-magicians.org/t/difficulty-bomb-removal/832
+type: Standards Track
+category: Core
+status: Draft
+created: 2018-07-21
+---
+
+## Simple Summary
+The average block times are increasing due to the difficulty bomb (also known as the "_ice age_") slowly accelerating. This EIP proposes to remove the difficulty bomb with the Constantinople fork, the second part of the Metropolis fork.
+
+## Abstract
+Starting with `CNSTNTNPL_FORK_BLKNUM` the client will calculate the difficulty without considering the current block number.
+
+## Motivation
+The difficulty bomb operates under the assumption that miners decide what code economic participants are running, rather than economic participants deciding for themselves.  In reality, miners will mine whatever chain is most profitable and the most profitable chain is the one that economic participants use.  If 99% of miners mine a chain that no economic participants use then that chain will have no value and the miners will cease mining of it in favor of some other chain that does have economic participants.  Another way to put this is that miners will follow economic participants, not the other way around.
+
+## Specification
+#### Remove Difficulty with Fake Block Number
+For the purposes of `calc_difficulty`, simply remove the use of `block.number`, as used in the exponential ice age component.
+
+## Rationale
+With the difficulty bomb removed, when Casper is released it will be up to economic participants to decide whether they want the features that Casper enables or not.  If they do not want Casper, they are free to continue running unpatched clients and participating in the Ethereum network as it exists today.  This freedom of choice is the cornerstone of DLTs and making it hard for people to make that choice (by creating an artificial pressure) does not work towards that goal of freedom of choice.  If the development team is not confident that economic participants will want Casper, then they should re-evaluate their priorities rather than trying to force Casper onto users.
+
+Author Personal Note: I think we will see almost all economic participants in Ethereum switch to PoS/Sharding without any extra pressure beyond client defaults.
+
+## Backwards Compatibility
+This EIP is not forward compatible and introduces backwards incompatibilities in the difficulty calculation. Therefore, it should be included in a scheduled hardfork at a certain block number. It's suggested to include this EIP in the second Metropolis hard-fork, _Constantinople_.
+
+## Test Cases
+Test cases shall be created once the specification is to be accepted by the developers or implemented by the clients.
+
+## Copyright
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/EIPS/eip-xxxx.md
+++ b/EIPS/eip-xxxx.md
@@ -33,5 +33,8 @@ This EIP is not forward compatible and introduces backwards incompatibilities in
 ## Test Cases
 Test cases shall be created once the specification is to be accepted by the developers or implemented by the clients.
 
+## Implementations
+The yellow paper implements this change in https://github.com/ethereum/yellowpaper/pull/710
+
 ## Copyright
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
The difficulty bomb operates under the assumption that miners decide what code economic participants are running, rather than economic participants deciding for themselves. In reality, miners will mine whatever chain is most profitable and the most profitable chain is the one that economic participants use. If 99% of miners mine a chain that no economic participants use then that chain will have no value and the miners will cease mining of it in favor of some other chain that does have economic participants. Another way to put this is that miners will follow economic participants, not the other way around.

With the difficulty bomb removed, when Casper is released it will be up to economic participants to decide whether they want the features that Casper enables or not. If they do not want Casper, they are free to continue running unpatched clients and participating in the Ethereum network as it exists today. This freedom of choice is the cornerstone of DLTs and making it hard for people to make that choice (by creating an artificial pressure) does not work towards that goal of freedom of choice. If the development team is not confident that economic participants will want Casper, then they should re-evaluate their priorities rather than trying to force Casper onto users.

Personal Note: I think we will see almost all economic participants in Ethereum switch to PoS/Sharding without any extra pressure beyond client defaults.