### PR TITLE
EIP-712: Update assets to show array encoding

### DIFF
--- a/assets/eip-712/Example.js
+++ b/assets/eip-712/Example.js
@@ -16,7 +16,7 @@ const typedData = {
         ],
         Mail: [
             { name: 'from', type: 'Person' },
-            { name: 'to', type: 'Person' },
+            { name: 'to', type: 'Person[]' },
             { name: 'contents', type: 'string' }
         ],
     },
@@ -32,10 +32,10 @@ const typedData = {
             name: 'Cow',
             wallet: '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826',
         },
-        to: {
+        to: [{
             name: 'Bob',
             wallet: '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB',
-        },
+        }],
         contents: 'Hello, Bob!',
     },
 };
@@ -99,7 +99,10 @@ function encodeData(primaryType, data) {
             value = ethUtil.sha3(encodeData(field.type, value));
             encValues.push(value);
         } else if (field.type.lastIndexOf(']') === field.type.length - 1) {
-            throw 'TODO: Arrays currently unimplemented in encodeData';
+            encTypes.push('bytes32');
+            const parsedType = field.type.slice(0, field.type.lastIndexOf('['));
+            value = ethUtil.sha3(value.map(item => encodeData(parsedType, item)).join(''));
+            encValues.push(value);
         } else {
             encTypes.push(field.type);
             encValues.push(value);
@@ -128,21 +131,21 @@ const address = ethUtil.privateToAddress(privateKey);
 const sig = ethUtil.ecsign(signHash(), privateKey);
 
 const expect = chai.expect;
-expect(encodeType('Mail')).to.equal('Mail(Person from,Person to,string contents)Person(string name,address wallet)');
+expect(encodeType('Mail')).to.equal('Mail(Person from,Person[] to,string contents)Person(string name,address wallet)');
 expect(ethUtil.bufferToHex(typeHash('Mail'))).to.equal(
-    '0xa0cedeb2dc280ba39b857546d74f5549c3a1d7bdc2dd96bf881f76108e23dac2',
+    '0xdd57d9596af52b430ced3d5b52d4e3d5dccfdf3e0572db1dcf526baad311fbd1',
 );
 expect(ethUtil.bufferToHex(encodeData(typedData.primaryType, typedData.message))).to.equal(
-    '0xa0cedeb2dc280ba39b857546d74f5549c3a1d7bdc2dd96bf881f76108e23dac2fc71e5fa27ff56c350aa531bc129ebdf613b772b6604664f5d8dbe21b85eb0c8cd54f074a4af31b4411ff6a60c9719dbd559c221c8ac3492d9d872b041d703d1b5aadf3154a261abdd9086fc627b61efca26ae5702701d05cd2305f7c52a2fc8',
+    '0xdd57d9596af52b430ced3d5b52d4e3d5dccfdf3e0572db1dcf526baad311fbd1fc71e5fa27ff56c350aa531bc129ebdf613b772b6604664f5d8dbe21b85eb0c872ea07cf404427eb52aed74d9998e238434f046d95c4ff7802d628628bf77a16b5aadf3154a261abdd9086fc627b61efca26ae5702701d05cd2305f7c52a2fc8',
 );
 expect(ethUtil.bufferToHex(structHash(typedData.primaryType, typedData.message))).to.equal(
-    '0xc52c0ee5d84264471806290a3f2c4cecfc5490626bf912d01f240d7a274b371e',
+    '0x74d81a21341d4ee3434cd75927bce467aeba1fa381760f07f95d9daee6f21e2b',
 );
 expect(ethUtil.bufferToHex(structHash('EIP712Domain', typedData.domain))).to.equal(
     '0xf2cee375fa42b42143804025fc449deafd50cc031ca257e0b194a650a912090f',
 );
-expect(ethUtil.bufferToHex(signHash())).to.equal('0xbe609aee343fb3c4b28e1df9e632fca64fcfaede20f02e86244efddf30957bd2');
+expect(ethUtil.bufferToHex(signHash())).to.equal('0x89f2c3d1cb4d1aa3e9c41f664a590fe73bfccdf8be1f8e03b79f5c099a0bd090');
 expect(ethUtil.bufferToHex(address)).to.equal('0xcd2a3d9f938e13cd947ec05abc7fe734df8dd826');
 expect(sig.v).to.equal(28);
-expect(ethUtil.bufferToHex(sig.r)).to.equal('0x4355c47d63924e8a72e509b65029052eb6c299d53a04e167c5775fd466751c9d');
-expect(ethUtil.bufferToHex(sig.s)).to.equal('0x07299936d304c153f6443dfa05f40ff007d72911b6f72307f996231605b91562');
+expect(ethUtil.bufferToHex(sig.r)).to.equal('0x62c03af2a2efc2fc5023a11f6b1fffc01d27aad85bfc88dd2ba9aee8cb8b2cec');
+expect(ethUtil.bufferToHex(sig.s)).to.equal('0x450d8ce8999ccc65327e40dc3d96286b7d118ba087b7ce40fbdb8de4f6bc0c0d');


### PR DESCRIPTION
This pull request updates the example assets for EIP-712 to include support for array encoding per the specification:

> The array values are encoded as the keccak256 hash of the concatenated encodeData of their contents (i.e. the encoding of SomeType[5] is identical to that of a struct containing five members of type SomeType).

cc @Recmo