### PR TITLE
EIP-1102: update injected provider variable name

### DIFF
--- a/EIPS/eip-1102.md
+++ b/EIPS/eip-1102.md
@@ -51,7 +51,7 @@ Dapps MUST request an Ethereum provider API by sending a message using the [`win
 
 #### `[2] INJECT`
 
-Ethereum-enabled DOM environments MUST expose an Ethereum provider API as a global `ETHEREUM_PROVIDER` variable on the `window` object.
+Ethereum-enabled DOM environments MUST expose an Ethereum provider API as a global `ethereum` variable on the `window` object.
 
 #### `[3] NOTIFY`
 
@@ -71,7 +71,7 @@ window.addEventListener('message', function (event) {
     if (!event.data || !event.data.type) { return; }
     if (event.data.type === 'ETHEREUM_PROVIDER_SUCCESS') {
         // Provider API exposed, continue
-        const networkVersion = await ETHEREUM_PROVIDER.send('net_version', []);
+        const networkVersion = await ethereum.send('net_version', []);
         console.log(networkVersion);
     }
 });


### PR DESCRIPTION
This pull request updates EIP-1102 by changing the global variable name of the user-approved provider object from `window.ETHEREUM_PROVIDER` to `window.ethereum` as originally discussed at ethereum/interfaces#16. Using `ethereum` vs. a provider-specific variable name future-proofs the user-approval protocol if it's ever decided that something other than a provider should be injected.

cc @ryanio