### PR TITLE
Corrected wrong hex value in EIP-145

### DIFF
--- a/EIPS/eip-145.md
+++ b/EIPS/eip-145.md
@@ -348,7 +348,7 @@ The newly introduced instructions have no effect on bytecode created in the past
     ```
 16. ```
     PUSH 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-    PUSH 0x100
+    PUSH 0x0100
     SAR
     ---
     0x0000000000000000000000000000000000000000000000000000000000000000


### PR DESCRIPTION
The value `0x100` in test case 16 of the SAR test cases is supposed to mean `0x0100`

