### PR TITLE
EIP 1285: Increase Gcallstipend gas in the CALL OPCODE

### DIFF
--- a/EIPS/eip-1285.md
+++ b/EIPS/eip-1285.md
@@ -1,0 +1,40 @@
+```
+eip: 1285
+title: Increase Gcallstipend gas in the CALL OPCODE
+author: Ben Kaufman <ben@daostack.io>
+status: Draft
+type: Standards Track
+category: Core
+created: 2018-08-01
+```
+
+## Simple Summary
+<!--"If you can't explain it simply, you don't understand it well enough." Provide a simplified and layman-accessible explanation of the EIP.-->
+Increase the ``Gcallstipend`` fee parameter in the ``CALL`` OPCODE from ``2,300`` to ``3,500`` gas units.
+
+## Abstract
+<!--A short (~200 word) description of the technical issue being addressed.-->
+Currently, the ``CALL`` OPCODE forwards a stipend of ``2,300`` gas units for a non zero value ``CALL`` operations where a contract is called. This stipend is given to the contract to allow execution of its ``fallback`` function. The stipend given is intentionally small in order to prevent the called contract from spending the call gas or performing an attack (like re-entrancy).
+While the stipend is small it should still give the sufficient gas required for some cheap OPCODES like ``LOG``, but it's not enough for some more complex and modern logics to be implemented.
+This EIP proposes to increase the given stipend from ``2,300`` to ``3,500`` to increase the usability of  the ``fallback`` function.
+
+
+## Motivation
+<!--The motivation is critical for EIPs that want to change the Ethereum protocol. It should clearly explain why the existing protocol specification is inadequate to address the problem that the EIP solves. EIP submissions without sufficient motivation may be rejected outright.-->
+The main motivation behind this EIP is to allow simple fallback functions to be implemented for contracts following the ``"Proxy"`` pattern. Simply explained, a ``"Proxy Contract"`` is a contract which use ``DELEGATECALL`` in its ``fallback`` function to behave according to the logic of another contract and serve as an independent instance for the logic of the contract it points to.
+This pattern is very useful for saving gas per deployment (as Proxy contracts are very lean) and it opens the ability to experiment with upgradability of contracts.
+On average, the ``DELEGATECALL`` functionality of a proxy contract costs about 1,000 gas units.
+When a contract transfers ETH to a proxy contract, the proxy logic will consume about 1,000 gas units before the ``fallback`` function of the logic contract will be executed. This leaves merely about 1,300 gas units for the execution of the logic. This is a severe limitation as it is not enough for an average ``LOG`` operation (it might be enough for a ``LOG`` with one parameter).
+By slightly increasing the gas units given in the stipend we allow proxy contracts have proper ``fallback`` logic without increasing the attack surface of the calling contract.
+
+## Specification
+<!--The technical specification should describe the syntax and semantics of any new feature. The specification should be detailed enough to allow competing, interoperable implementations for any of the current Ethereum platforms (go-ethereum, parity, cpp-ethereum, ethereumj, ethereumjs, and [others](https://github.com/ethereum/wiki/wiki/Clients)).-->
+Increase the ``Gcallstipend`` fee parameter in the ``CALL`` OPCODE from ``2,300`` to ``3,500`` gas units (further specification will be provided later).
+
+## Rationale
+<!--The rationale fleshes out the specification by describing what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work, e.g. how the feature is supported in other languages. The rationale may also provide evidence of consensus within the community, and should discuss important objections or concerns raised during discussion.-->
+The rational for increasing the ``Gcallstipend`` gas parameter by ``1,200`` gas units comes from the cost of performing ``DELEGATECALL`` and ``SLOAD`` with a small margin for some small additional operations. All while still keeping the stipend relatively small.
+
+## Backwards Compatibility
+<!--All EIPs that introduce backwards incompatibilities must include a section describing these incompatibilities and their severity. The EIP must explain how the author proposes to deal with these incompatibilities. EIP submissions without a sufficient backwards compatibility treatise may be rejected outright.-->
+This EIP requires a backwards incompatible change for the ``Gcallstipend`` gas parameter in the ``CALL`` OPCODE.

--- a/EIPS/eip-1285.md
+++ b/EIPS/eip-1285.md
@@ -1,4 +1,4 @@
-```
+---
 eip: 1285
 title: Increase Gcallstipend gas in the CALL OPCODE
 author: Ben Kaufman <ben@daostack.io>
@@ -6,7 +6,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2018-08-01
-```
+---
 
 ## Simple Summary
 <!--"If you can't explain it simply, you don't understand it well enough." Provide a simplified and layman-accessible explanation of the EIP.-->

--- a/EIPS/eip-1285.md
+++ b/EIPS/eip-1285.md
@@ -2,6 +2,7 @@
 eip: 1285
 title: Increase Gcallstipend gas in the CALL OPCODE
 author: Ben Kaufman <ben@daostack.io>
+discussions-to: https://ethereum-magicians.org/t/eip-1285-increase-gcallstipend-gas-in-the-call-opcode/941
 status: Draft
 type: Standards Track
 category: Core


### PR DESCRIPTION
Added EIP #1285 proposing to increase the gas stipend given for a called contract for a non zero value calls from 2,300 to 3,500.