### PR TITLE
EIP725 - Fix interface code

### DIFF
--- a/EIPS/eip-725.md
+++ b/EIPS/eip-725.md
@@ -281,8 +281,8 @@ contract ERC725 {
     }
 
     function getKey(bytes32 _key) public constant returns(uint256[] purposes, uint256 keyType, bytes32 key);
-    function keyHasPurpose(bytes32 _key, uint256 _purpose) public constant returns(bool exists);
-    function getKeysByPurpose(uint256 _purpose) public constant returns(bytes32[] keys);
+    function keyHasPurpose(bytes32 _key, uint256 _purpose) public constant returns (bool exists);
+    function getKeysByPurpose(uint256 _purpose) public constant returns (bytes32[] keys);
     function addKey(bytes32 _key, uint256 _purpose, uint256 _keyType) public returns (bool success);
     function execute(address _to, uint256 _value, bytes _data) public returns (uint256 executionId);
     function approve(uint256 _id, bool _approve) public returns (bool success);

--- a/EIPS/eip-725.md
+++ b/EIPS/eip-725.md
@@ -281,7 +281,7 @@ contract ERC725 {
     }
 
     function getKey(bytes32 _key) public constant returns(uint256[] purposes, uint256 keyType, bytes32 key);
-    function keyHasPurpose(bytes32 _key, uint256 purpose) constant returns(bool exists);
+    function keyHasPurpose(bytes32 _key, uint256 _purpose) public constant returns(bool exists);
     function getKeysByPurpose(uint256 _purpose) public constant returns(bytes32[] keys);
     function addKey(bytes32 _key, uint256 _purpose, uint256 _keyType) public returns (bool success);
     function execute(address _to, uint256 _value, bytes _data) public returns (uint256 executionId);

--- a/EIPS/eip-725.md
+++ b/EIPS/eip-725.md
@@ -284,6 +284,7 @@ contract ERC725 {
     function keyHasPurpose(bytes32 _key, uint256 _purpose) public constant returns (bool exists);
     function getKeysByPurpose(uint256 _purpose) public constant returns (bytes32[] keys);
     function addKey(bytes32 _key, uint256 _purpose, uint256 _keyType) public returns (bool success);
+    function removeKey(bytes32 _key, uint256 _purpose) public returns (bool success);
     function execute(address _to, uint256 _value, bytes _data) public returns (uint256 executionId);
     function approve(uint256 _id, bool _approve) public returns (bool success);
 }


### PR DESCRIPTION
- Added an underscore to the purpose parameter in `keyHasPurpose` to match other parameters of solidity functions.
- Added an explicit `public` keyword to `keyHasPurpose`.
- Added `removeKey` which is described in the spec but not found in interface.

When opening a pull request to submit a new EIP, please use the suggested template: https://github.com/ethereum/EIPs/blob/master/eip-X.md

We have a GitHub bot that automatically merges some PRs. It will merge yours immediately if certain criteria are met:

 - The PR edits only existing draft PRs.
 - The build passes.
 - Your Github username or email address is listed in the 'author' header of all affected PRs, inside <triangular brackets>.
 - If matching on email address, the email address is the one publicly listed on your GitHub profile.
