### PR TITLE
1102: Emit a custom event upon user approval

### DIFF
--- a/EIPS/eip-1102.md
+++ b/EIPS/eip-1102.md
@@ -35,29 +35,24 @@ IF web3 is undefined
 
 ```
 START dapp
-REQUEST[1] Ethereum provider
+REQUEST[1] provider
 IF user approves
-    INJECT[2] provider API
-    NOTIFY[3] dapp
+    RESPOND[2] with provider
     CONTINUE dapp
 IF user rejects
 IF non-Ethereum environment
-    NOOP[4]
+    NOOP[3]
 ```
 
 #### `[1] REQUEST`
 
 Dapps MUST request an Ethereum provider API by sending a message using the [`window.postMessage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) API. This message MUST be sent with a payload object containing a `type` property with a value of "ETHEREUM_PROVIDER_REQUEST" and an optional `id` property corresponding to an identifier of a specific wallet provider, such as "METAMASK".
 
-#### `[2] INJECT`
+#### `[2] RESPOND`
 
-Ethereum-enabled DOM environments MUST expose an Ethereum provider API as a global `ethereum` variable on the `window` object.
+Ethereum-enabled DOM environments MUST respond with an Ethereum provider API by emitting an "ethereumprovider" [CustomEvent](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent) on the `window` object. This custom event MUST pass a provider API as an `ethereum` property on its `detail` data object.
 
-#### `[3] NOTIFY`
-
-Ethereum-enabled DOM environments MUST notify dapps of successful provider API exposure by sending a message using the [`window.postMessage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) API. This message MUST be sent with a payload object containing a `type` property with a value of "ETHEREUM_PROVIDER_SUCCESS" and an optional `id` property corresponding to an identifier of a specific wallet provider, such as "METAMASK"
-
-#### `[4] NOOP`
+#### `[3] NOOP`
 
 If a user rejects access to the Ethereum provider API on an untrusted site, the site itself MUST NOT be notified in any way; notification of a rejection would allow third-party tools to still identify that a client is Ethereum-enabled despite not being granted access to any provider API.
 
@@ -67,12 +62,10 @@ The following example demonstrates one possible implementation of this strategy 
 
 ```js
 window.addEventListener('load', () => {
-    // Listen for provider injection
-    window.addEventListener('message', ({ data }) => {
-        if (data && data.type && data.type === 'ETHEREUM_PROVIDER_SUCCESS') {
-            // Provider API exposed, continue
-            const networkVersion = await ethereum.send('net_version', []);
-        }
+    // Listen for provider response
+    window.addEventListener('ethereumprovider', async ({ detail: { ethereum } }) => {
+        // Provider API exposed, continue
+        const networkVersion = await ethereum.send('net_version', []);
     });
     // Request provider
     window.postMessage({ type: 'ETHEREUM_PROVIDER_REQUEST' }, '*');
@@ -81,7 +74,7 @@ window.addEventListener('load', () => {
 
 ## Rationale
 
-The pattern of provider auto-injection followed by the previous generation of Ethereum-enabled DOM environements failed to protect user privacy by allowing untrusted websites to uniquely identify Ethereum users. This proposal establishes a new pattern wherein dapps must request access to an Ethereum provider API. This protocol directly prevents fingerprinting attacks by giving users the ability to reject provider exposure on a given website.
+The pattern of provider auto-injection followed by the previous generation of Ethereum-enabled DOM environments failed to protect user privacy by allowing untrusted websites to uniquely identify Ethereum users. This proposal establishes a new pattern wherein dapps must request access to an Ethereum provider API. This protocol directly prevents fingerprinting attacks by giving users the ability to reject provider exposure on a given website.
 
 ### Constraints
 


### PR DESCRIPTION
This pull request updates EIP-1102 to respond with an Ethereum provider API by emitting a CustomEvent instead of injecting a global and posting a message back to the dapp context.