### PR TITLE
Fix R_RESET refund for EIP-1087

### DIFF
--- a/EIPS/eip-1087.md
+++ b/EIPS/eip-1087.md
@@ -39,7 +39,7 @@ The following changes are made to the EVM:
  - At the end of the transaction, for each slot in the dirty map:
    - If the slot was 0 before the transaction and is 0 now, refund 19800 gas.
    - If the slot was nonzero before the transaction and its value has not changed, refund 4800 gas.
-   - If the slot was nonzero before the transaction and is 0 now, refund 10000 gas.
+   - If the slot was nonzero before the transaction and is 0 now, refund 15000 gas.
 
 After these changes, transactions that make only a single change to a storage slot will retain their existing costs. However, contracts that make multiple changes will see significantly reduced costs. Repeating the examples from the Motivation section:
 


### PR DESCRIPTION
Consider a transaction with only one SSTORE that sets a slot from 1 to 0. This shouldn't benefits from gas reduction. Currently it costs 5000 gas plus 15000 gas refund, and in this EIP it should cost the same.