### PR TITLE
[site] Add Twitter Card metadata

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -29,6 +29,9 @@ header_pages:
  - erc.html
  - informational.html
  - meta.html
+twitter:
+  card: summary
+  username: ethereum
 
 # Build settings
 markdown: kramdown


### PR DESCRIPTION
This adds Twitter Card metadata to the site, using the format that
[`jekyll-seo-tag`](https://github.com/jekyll/jekyll-seo-tag/blob/master/docs/usage.md),
a dependency of Minima, understands. This should make the site render better
on Twitter.

I tested this locally and it seemed to work.