### PR TITLE
Fixed misleading var name

### DIFF
--- a/EIPS/eip-137.md
+++ b/EIPS/eip-137.md
@@ -61,7 +61,7 @@ var resolver = ens.resolver(node);
 Then, ask the resolver for the address for the contract:
 
 ```
-var hash = resolver.addr(node);
+var address = resolver.addr(node);
 ```
 
 Because the `namehash` procedure depends only on the name itself, this can be precomputed and inserted into a contract, removing the need for string manipulation, and permitting O(1) lookup of ENS records regardless of the number of components in the raw name.


### PR DESCRIPTION
In the example addr function returns an address, not an hash