### PR TITLE
Move EIP-1283 status to last call

### DIFF
--- a/EIPS/eip-1283.md
+++ b/EIPS/eip-1283.md
@@ -3,7 +3,7 @@ eip: 1283
 title: Net gas metering for SSTORE without dirty maps
 author: Wei Tang (@sorpaas)
 discussions-to: https://github.com/sorpaas/EIPs/issues/1
-status: Draft
+status: Accepted
 type: Standards Track
 category: Core
 created: 2018-08-01

--- a/EIPS/eip-1283.md
+++ b/EIPS/eip-1283.md
@@ -4,6 +4,7 @@ title: Net gas metering for SSTORE without dirty maps
 author: Wei Tang (@sorpaas)
 discussions-to: https://github.com/sorpaas/EIPs/issues/1
 status: Last Call
+review-period-end: 2018-10-29
 type: Standards Track
 category: Core
 created: 2018-08-01

--- a/EIPS/eip-1283.md
+++ b/EIPS/eip-1283.md
@@ -3,7 +3,7 @@ eip: 1283
 title: Net gas metering for SSTORE without dirty maps
 author: Wei Tang (@sorpaas)
 discussions-to: https://github.com/sorpaas/EIPs/issues/1
-status: Accepted
+status: Last Call
 type: Standards Track
 category: Core
 created: 2018-08-01


### PR DESCRIPTION
The spec is finalized, covered with test cases, and had an [informal proof](https://gist.github.com/sorpaas/27b8026c40e4777ede889c40e3824a04). See discussion on https://github.com/ethereum/pm/issues/55