### PR TITLE
eip-198: fix minor typo + clarify a bit.

### DIFF
--- a/EIPS/eip-198.md
+++ b/EIPS/eip-198.md
@@ -91,7 +91,7 @@ This input data:
     ffff
     80
     
-Would also parse as a base of 3, an exponent of 65535 and a modulus of `2**255`, as it attempts to grab 32 bytes for the modulus starting from 0x80, but then there is no further data so it right pads it with 31 zeroes.
+Would also parse as a base of 3, an exponent of 65535 and a modulus of `2**255`, as it attempts to grab 32 bytes for the modulus starting from 0x80 - but there is no further data, so it right-pads it with 31 zero bytes.
 
 # Rationale
 

--- a/EIPS/eip-198.md
+++ b/EIPS/eip-198.md
@@ -68,7 +68,7 @@ This input data:
     fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe
     fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd
     
-Would parse a base length of 0, a exponent length of 32, and an exponent length of `2**256 - 1`, where the base is empty, the exponent is `2**256 - 2` and the modulus is `(2**256 - 3) * 256**(2**256 - 33)` (yes, that's a really big number). It would then immediately fail, as it's not possible to provide enough gas to make that computation.
+Would parse a base length of 0, an exponent length of 32, and a modulus length of `2**256 - 1`, where the base is empty, the exponent is `2**256 - 2` and the modulus is `(2**256 - 3) * 256**(2**256 - 33)` (yes, that's a really big number). It would then immediately fail, as it's not possible to provide enough gas to make that computation.
 
 This input data:
 


### PR DESCRIPTION
"Exponent" used twice when listing lengths in the same example, where once "modulus" was meant to be.