### PR TITLE
Mention that modexp precompile replaced EIP74 (rsa precompile)

### DIFF
--- a/EIPS/eip-198.md
+++ b/EIPS/eip-198.md
@@ -5,6 +5,7 @@ author: Vitalik Buterin <v@buterin.com>
 status: Final
 type: Standards Track
 category: Core
+replaces: 74
 created: 2017-01-30
 ---
 


### PR DESCRIPTION
Closes #74.