### PR TITLE
Updated event names in EIP1132.md

### DIFF
--- a/EIPS/eip-1132.md
+++ b/EIPS/eip-1132.md
@@ -134,10 +134,10 @@ function totalBalanceOf(address _of)  view returns (uint256 amount)
 ```
 
 ### Lock event recorded in the token contract
-`event Lock(address indexed _of, uint256 indexed _reason, uint256 _amount, uint256 _validity)`
+`event Locked(address indexed _of, uint256 indexed _reason, uint256 _amount, uint256 _validity)`
 
 ### Unlock event recorded in the token contract
-`event Unlock(address indexed _of, uint256 indexed _reason, uint256 _amount)`
+`event Unlocked(address indexed _of, uint256 indexed _reason, uint256 _amount)`
 
 ## Test Cases
 


### PR DESCRIPTION
Updated event names to past tense, considering the fact that events are called once the action has taken place. Updated [reference implementation](https://github.com/nitika-goel/lockable-token/blob/master/contracts/ERC1132.sol).
