### PR TITLE
EIP-1102: expose isEnabled flag on provider

### DIFF
--- a/EIPS/eip-1102.md
+++ b/EIPS/eip-1102.md
@@ -39,6 +39,14 @@ This proposal outlines a protocol in which DOM environments expose a read-only p
     ethereum.enable(): Promise<any>
     ```
 
+4. **`Provider#isEnabled`**
+
+    Providers exposed by DOM environments define a new `isEnabled` property that is set to `true` if the user approves full provider access or `false` if the user denies full provider access.
+
+    ```js
+    ethereum.isEnabled: boolean
+    ```
+
 ### Protocol
 
 DOM environments expose a read-only provider globally at `window.ethereum` by default. Before initiating any RPC request that requires an account, like `eth_sendTransaction`, dapps must request a full provider by calling a new provider method, `ethereum.enable()`. This method triggers a user interface that allows the user to approve or deny full provider access for a given dapp. If the user approves full provider access, the provider at `window.ethereum` is populated with accounts and fully-enabled; if the user denies full provider access, the provider at `window.ethereum` is left unchanged.
@@ -71,15 +79,15 @@ IF provider is undefined
 
 ##### `[1] ENABLE`
 
-Dapps MUST request a full provider by calling the `enable` method on the default read-only provider. This method MUST trigger a user interface that allows the user to approve or deny full provider access for a given dapp. This method MUST return a Promise that is resolved with an array of the user's public keys if the user approves full provider access or rejected if the user denies full provider access.
+Dapps MUST request a full provider by calling the `enable` method on the default read-only provider. This method MUST trigger a user interface that allows the user to approve or deny full provider access for a given dapp. This method MUST return a Promise that is resolved with an array of the user's public addresses if the user approves full provider access or rejected if the user denies full provider access.
 
 ##### `[2] RESOLVE`
 
-If a user approves full provider access, DOM environments MUST expose a fully-enabled provider at `window.ethereum` that is populated with accounts. The Promise returned when calling the `enable` method MUST be resolved with an array of the user's public keys.
+If a user approves full provider access, DOM environments MUST expose a fully-enabled provider at `window.ethereum` that is populated with accounts. The Promise returned when calling the `enable` method MUST be resolved with an array of the user's public addresses. `Provider#isEnabled` MUST be set to `true`.
 
 ##### `[3] REJECT`
 
-If a user denies full provider access, the Promise returned when calling the `enable` method MUST be rejected with an informative Error.
+If a user denies full provider access, the Promise returned when calling the `enable` method MUST be rejected with an informative Error. `Provider#isEnabled` MUST be set to `false`.
 
 ### Example initialization
 


### PR DESCRIPTION
This pull request updates EIP-1102 so that providers expose an `isEnabled` flag. This flag is set to `true` if the user approves full provider access or `false` if the user denies full provider access.