### PR TITLE
EIP-1102: Remove isEnabled flag from provider

### DIFF
--- a/EIPS/eip-1102.md
+++ b/EIPS/eip-1102.md
@@ -39,14 +39,6 @@ This proposal outlines a protocol in which DOM environments expose a read-only p
     ethereum.enable(): Promise<any>
     ```
 
-4. **`Provider#isEnabled`**
-
-    Providers exposed by DOM environments define a new `isEnabled` property that is set to `true` if the user approves full provider access or `false` if the user denies full provider access.
-
-    ```js
-    ethereum.isEnabled: boolean
-    ```
-
 ### Protocol
 
 DOM environments expose a read-only provider globally at `window.ethereum` by default. Before initiating any RPC request that requires an account, like `eth_sendTransaction`, dapps must request a full provider by calling a new provider method, `ethereum.enable()`. This method triggers a user interface that allows the user to approve or deny full provider access for a given dapp. If the user approves full provider access, the provider at `window.ethereum` is populated with accounts and fully-enabled; if the user denies full provider access, the provider at `window.ethereum` is left unchanged.
@@ -83,11 +75,11 @@ Dapps MUST request a full provider by calling the `enable` method on the default
 
 ##### `[2] RESOLVE`
 
-If a user approves full provider access, DOM environments MUST expose a fully-enabled provider at `window.ethereum` that is populated with accounts. The Promise returned when calling the `enable` method MUST be resolved with an array of the user's public addresses. `Provider#isEnabled` MUST be set to `true`.
+If a user approves full provider access, DOM environments MUST expose a fully-enabled provider at `window.ethereum` that is populated with accounts. The Promise returned when calling the `enable` method MUST be resolved with an array of the user's public addresses.
 
 ##### `[3] REJECT`
 
-If a user denies full provider access, the Promise returned when calling the `enable` method MUST be rejected with an informative Error. `Provider#isEnabled` MUST be set to `false`.
+If a user denies full provider access, the Promise returned when calling the `enable` method MUST be rejected with an informative Error.
 
 ### Example initialization
 


### PR DESCRIPTION
This pull request updates EIP-1102 by removing the `isEnabled` flag from the provider since this can be set manually by the dapp if desired.