### PR TITLE
EIP 747: wallet_watchAsset

### DIFF
--- a/EIPS/eip-747.md
+++ b/EIPS/eip-747.md
@@ -1,0 +1,54 @@
+---
+eip: <to be assigned>
+title: <EIP title>
+author: <a list of the author's or authors' name(s) and/or username(s), or name(s) and email(s), e.g. (use with the parentheses or triangular brackets): FirstName LastName (@GitHubUsername), FirstName LastName <foo@bar.com>, FirstName (@GitHubUsername) and GitHubUsername (@GitHubUsername)>
+discussions-to: <URL>
+status: Draft
+type: <Standards Track (Core, Networking, Interface, ERC)  | Informational | Meta>
+category (*only required for Standard Track): <Core | Networking | Interface | ERC>
+created: <date created on, in ISO 8601 (yyyy-mm-dd) format>
+requires (*optional): <EIP number(s)>
+replaces (*optional): <EIP number(s)>
+---
+
+<!--You can leave these HTML comments in your merged EIP and delete the visible duplicate text guides, they will not appear and may be helpful to refer to if you edit it again. This is the suggested template for new EIPs. Note that an EIP number will be assigned by an editor. When opening a pull request to submit your EIP, please use an abbreviated title in the filename, `eip-draft_title_abbrev.md`. The title should be 44 characters or less.-->
+This is the suggested template for new EIPs.
+
+Note that an EIP number will be assigned by an editor. When opening a pull request to submit your EIP, please use an abbreviated title in the filename, `eip-draft_title_abbrev.md`.
+
+The title should be 44 characters or less.
+
+## Simple Summary
+<!--"If you can't explain it simply, you don't understand it well enough." Provide a simplified and layman-accessible explanation of the EIP.-->
+If you can't explain it simply, you don't understand it well enough." Provide a simplified and layman-accessible explanation of the EIP.
+
+## Abstract
+<!--A short (~200 word) description of the technical issue being addressed.-->
+A short (~200 word) description of the technical issue being addressed.
+
+## Motivation
+<!--The motivation is critical for EIPs that want to change the Ethereum protocol. It should clearly explain why the existing protocol specification is inadequate to address the problem that the EIP solves. EIP submissions without sufficient motivation may be rejected outright.-->
+The motivation is critical for EIPs that want to change the Ethereum protocol. It should clearly explain why the existing protocol specification is inadequate to address the problem that the EIP solves. EIP submissions without sufficient motivation may be rejected outright.
+
+## Specification
+<!--The technical specification should describe the syntax and semantics of any new feature. The specification should be detailed enough to allow competing, interoperable implementations for any of the current Ethereum platforms (go-ethereum, parity, cpp-ethereum, ethereumj, ethereumjs, and [others](https://github.com/ethereum/wiki/wiki/Clients)).-->
+The technical specification should describe the syntax and semantics of any new feature. The specification should be detailed enough to allow competing, interoperable implementations for any of the current Ethereum platforms (go-ethereum, parity, cpp-ethereum, ethereumj, ethereumjs, and [others](https://github.com/ethereum/wiki/wiki/Clients)).
+
+## Rationale
+<!--The rationale fleshes out the specification by describing what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work, e.g. how the feature is supported in other languages. The rationale may also provide evidence of consensus within the community, and should discuss important objections or concerns raised during discussion.-->
+The rationale fleshes out the specification by describing what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work, e.g. how the feature is supported in other languages. The rationale may also provide evidence of consensus within the community, and should discuss important objections or concerns raised during discussion.-->
+
+## Backwards Compatibility
+<!--All EIPs that introduce backwards incompatibilities must include a section describing these incompatibilities and their severity. The EIP must explain how the author proposes to deal with these incompatibilities. EIP submissions without a sufficient backwards compatibility treatise may be rejected outright.-->
+All EIPs that introduce backwards incompatibilities must include a section describing these incompatibilities and their severity. The EIP must explain how the author proposes to deal with these incompatibilities. EIP submissions without a sufficient backwards compatibility treatise may be rejected outright.
+
+## Test Cases
+<!--Test cases for an implementation are mandatory for EIPs that are affecting consensus changes. Other EIPs can choose to include links to test cases if applicable.-->
+Test cases for an implementation are mandatory for EIPs that are affecting consensus changes. Other EIPs can choose to include links to test cases if applicable.
+
+## Implementation
+<!--The implementations must be completed before any EIP is given status "Final", but it need not be completed before the EIP is accepted. While there is merit to the approach of reaching consensus on the specification and rationale before writing code, the principle of "rough consensus and running code" is still useful when it comes to resolving many discussions of API details.-->
+The implementations must be completed before any EIP is given status "Final", but it need not be completed before the EIP is accepted. While there is merit to the approach of reaching consensus on the specification and rationale before writing code, the principle of "rough consensus and running code" is still useful when it comes to resolving many discussions of API details.
+
+## Copyright
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/EIPS/eip-747.md
+++ b/EIPS/eip-747.md
@@ -37,7 +37,7 @@ A new method is added to web3 browsers' ethereum providers:
 ```javascript
 
 /**
-* @param  {Object}  opts - The options specifing the asset `type` and `options` specific for each of asset.
+* @param  {Object}  opts - The options specifying the asset `type` and `options` specific for each of asset.
 * @returns  {Promise} success - Whether the user added the asset to their wallet.
 */
 async  function  wallet_watchAsset (

--- a/EIPS/eip-747.md
+++ b/EIPS/eip-747.md
@@ -7,6 +7,7 @@ status: Draft
 type: Interface
 category: Interface
 created: 2018-08-13
+requires: 1474
 ---
 
 <!--You can leave these HTML comments in your merged EIP and delete the visible duplicate text guides, they will not appear and may be helpful to refer to if you edit it again. This is the suggested template for new EIPs. Note that an EIP number will be assigned by an editor. When opening a pull request to submit your EIP, please use an abbreviated title in the filename, `eip-draft_title_abbrev.md`. The title should be 44 characters or less.-->

--- a/EIPS/eip-747.md
+++ b/EIPS/eip-747.md
@@ -4,7 +4,7 @@ title: Add wallet_watchAsset to Provider
 author: Dan Finlay (@danfinlay), Esteban Mino (@estebanmino)
 discussions-to: https://ethereum-magicians.org/t/eip-747-eth-watchtoken/1048
 status: Draft
-type: Interface
+type: Standards Track
 category: Interface
 created: 2018-08-13
 requires: 1474

--- a/EIPS/eip-747.md
+++ b/EIPS/eip-747.md
@@ -1,54 +1,88 @@
 ---
 eip: <to be assigned>
-title: <EIP title>
-author: <a list of the author's or authors' name(s) and/or username(s), or name(s) and email(s), e.g. (use with the parentheses or triangular brackets): FirstName LastName (@GitHubUsername), FirstName LastName <foo@bar.com>, FirstName (@GitHubUsername) and GitHubUsername (@GitHubUsername)>
+title: Add eth_watchToken to Provider
+author: Dan Finlay (@danfinlay), Esteban Mino (@estebanmino)
 discussions-to: <URL>
-status: Draft
-type: <Standards Track (Core, Networking, Interface, ERC)  | Informational | Meta>
-category (*only required for Standard Track): <Core | Networking | Interface | ERC>
-created: <date created on, in ISO 8601 (yyyy-mm-dd) format>
-requires (*optional): <EIP number(s)>
-replaces (*optional): <EIP number(s)>
+status: WIP
+type: Interface
+category Interface
+created: August 13, 2018
 ---
 
 <!--You can leave these HTML comments in your merged EIP and delete the visible duplicate text guides, they will not appear and may be helpful to refer to if you edit it again. This is the suggested template for new EIPs. Note that an EIP number will be assigned by an editor. When opening a pull request to submit your EIP, please use an abbreviated title in the filename, `eip-draft_title_abbrev.md`. The title should be 44 characters or less.-->
-This is the suggested template for new EIPs.
-
-Note that an EIP number will be assigned by an editor. When opening a pull request to submit your EIP, please use an abbreviated title in the filename, `eip-draft_title_abbrev.md`.
-
-The title should be 44 characters or less.
 
 ## Simple Summary
 <!--"If you can't explain it simply, you don't understand it well enough." Provide a simplified and layman-accessible explanation of the EIP.-->
-If you can't explain it simply, you don't understand it well enough." Provide a simplified and layman-accessible explanation of the EIP.
+A method for allowing users to easily track new tokens with a suggestion from sites they are visiting.
 
 ## Abstract
 <!--A short (~200 word) description of the technical issue being addressed.-->
-A short (~200 word) description of the technical issue being addressed.
+Web3 JavaScript wallet browsers may implement `eth_watchToken()` to allow any website to suggest a token for the user's wallet to track.
 
 ## Motivation
 <!--The motivation is critical for EIPs that want to change the Ethereum protocol. It should clearly explain why the existing protocol specification is inadequate to address the problem that the EIP solves. EIP submissions without sufficient motivation may be rejected outright.-->
-The motivation is critical for EIPs that want to change the Ethereum protocol. It should clearly explain why the existing protocol specification is inadequate to address the problem that the EIP solves. EIP submissions without sufficient motivation may be rejected outright.
+Today, one of the major uses of ethereum wallets is to acquire and track tokens. Currently, each wallet either needs to pre-load a list of approved tokens, or users need to be stepped through a tedious process of adding a token for their given wallet.
+
+In the first case, wallets are burdened with both the security of managing this list, as well as the bandwidth of mass polling for known tokens on their wallet.
+
+In the second case, the user experience is terrible.
+
+By leveraging a user's existing trust with websites they are learning about tokens on, we are able to decentralize the responsibility of managing a user's list of known tokens.
 
 ## Specification
 <!--The technical specification should describe the syntax and semantics of any new feature. The specification should be detailed enough to allow competing, interoperable implementations for any of the current Ethereum platforms (go-ethereum, parity, cpp-ethereum, ethereumj, ethereumjs, and [others](https://github.com/ethereum/wiki/wiki/Clients)).-->
-The technical specification should describe the syntax and semantics of any new feature. The specification should be detailed enough to allow competing, interoperable implementations for any of the current Ethereum platforms (go-ethereum, parity, cpp-ethereum, ethereumj, ethereumjs, and [others](https://github.com/ethereum/wiki/wiki/Clients)).
+A new method is added to web3 browsers' ethereum providers:
+
+```javascript
+
+/**
+ * @param {String} tokenAddress - The address of the token to add
+ * @param {String} tokenSymbol - The abbreviated name of the token to add.
+ * @param {Number} tokenDecimals - The number of decimals to use when rendering the token count.
+ * @param {String} tokenImage - Optional - The URL for the image to render for the token's icon. (TODO: Finalize type of this parameter.)
+ * @returns {Promise} success - Whether the user added the token to their wallet.
+ */
+async function eth_watchToken (
+  tokenAddress,
+  tokenSymbol,
+  tokenDecimals,
+  tokenImage
+) {
+  /* Implementation would go here */
+}
+
+// Sample usage:
+web3.eth.watchToken(tokenAddress, tokenSymbol, tokenDecimals [, tokenImage] )
+```
+
+The `tokenImage` parameter should link to a web-standard image format (png, jpg, gif) of a reasonable size. To establish a baseline, let's say no greater than 512x512 pixels, and no greater than 256kb. However, this can be a client-defined setting.
+
+Upon calling this request, the user should be prompted with the opportunity to add this token to their wallet:
+
+![adding token](https://user-images.githubusercontent.com/12115171/44048738-a47ca2dc-9f08-11e8-968d-56f78262d65f.gif)
+
+If the user adds this token, it should appear somewhere in their wallet's UI, with its balance, etc.
 
 ## Rationale
 <!--The rationale fleshes out the specification by describing what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work, e.g. how the feature is supported in other languages. The rationale may also provide evidence of consensus within the community, and should discuss important objections or concerns raised during discussion.-->
-The rationale fleshes out the specification by describing what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work, e.g. how the feature is supported in other languages. The rationale may also provide evidence of consensus within the community, and should discuss important objections or concerns raised during discussion.-->
+Displaying a user's tokens is a basic feature that every modern dapp user expects. However, keeping this list, and polling for it from the network can be costly, especially on bandwidth constrained devices.
 
-## Backwards Compatibility
-<!--All EIPs that introduce backwards incompatibilities must include a section describing these incompatibilities and their severity. The EIP must explain how the author proposes to deal with these incompatibilities. EIP submissions without a sufficient backwards compatibility treatise may be rejected outright.-->
-All EIPs that introduce backwards incompatibilities must include a section describing these incompatibilities and their severity. The EIP must explain how the author proposes to deal with these incompatibilities. EIP submissions without a sufficient backwards compatibility treatise may be rejected outright.
+Most wallets today either manage their own token list, which they store client side, or they query a centralized API for token balances, which reduces decentralization, letting that API's owner easily correlate account holders with their IP addresses.
 
-## Test Cases
-<!--Test cases for an implementation are mandatory for EIPs that are affecting consensus changes. Other EIPs can choose to include links to test cases if applicable.-->
-Test cases for an implementation are mandatory for EIPs that are affecting consensus changes. Other EIPs can choose to include links to test cases if applicable.
+Maintaining one of these token lists becomes a political act, and maintainers can be subject to regular harrassment and pressure to list otherwise unknown tokens.
+
+Furthermore, automatically listing tokens makes tokens into a sort of spam mail: Users suddenly seeing new tokens that they don't care about in their wallet can be used to bombard them with information that they didn't opt into.
+
+This phenomenon is exacerbated by the trend towards airdropped tokens, which has been a cause of network congestion, because spamming people with new tokens has so far been rewarded with user attention.
+
+While some people might suggest we begin a TCR of trusted tokens to watch, this would not solve the client-side bandwidth issues, nor the airdropped token spam issues. What we really want is a small list of tokens the user cares about.
+
+Most of the time a user is adding a token, they learned about it on a website. At that moment, there is a natural alignment of interests, where the website wants the user to track their token, and the user wants to track it. This is a natural point to introduce an API to easily allow these parties to collaborate, without involving the politics of the wallet's developers.
 
 ## Implementation
 <!--The implementations must be completed before any EIP is given status "Final", but it need not be completed before the EIP is accepted. While there is merit to the approach of reaching consensus on the specification and rationale before writing code, the principle of "rough consensus and running code" is still useful when it comes to resolving many discussions of API details.-->
-The implementations must be completed before any EIP is given status "Final", but it need not be completed before the EIP is accepted. While there is merit to the approach of reaching consensus on the specification and rationale before writing code, the principle of "rough consensus and running code" is still useful when it comes to resolving many discussions of API details.
+One implementation in progress can be viewed [on the MetaMask GitHub repository](https://github.com/MetaMask/metamask-extension/pull/4606).
 
 ## Copyright
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+

--- a/EIPS/eip-747.md
+++ b/EIPS/eip-747.md
@@ -55,15 +55,46 @@ In the case of assets of type `ERC20`, this method works as follows.
 ```javascript
 web3.wallet.watchAsset({ 
 	type: 'ERC20', 
-	options: { tokenAddress, tokenSymbol, tokenDecimals [, tokenImage] }
+	options: { address, symbol, decimals [, image] }
 })
 ```
 
-The `tokenImage` parameter should link to a web-standard image format (png, jpg, gif) of a reasonable size. To establish a baseline, let's say no greater than 512x512 pixels, and no greater than 256kb. However, this can be a client-defined setting.
+The `image` parameter should link to a web-standard image format (png, jpg) of a reasonable size or a `Base64` image. To establish a baseline, let's say no greater than 512x512 pixels, and no greater than 256kb. However, this can be a client-defined setting.
 
+An example of use in the first case would be.
+
+```javascript
+web3.wallet.watchAsset({ 
+	type: 'ERC20', 
+	options: { 
+		address, 
+		symbol, 
+		decimals, 
+		image: 'linktoimage.jpg' 
+	}
+})
+```
 Upon calling this request, the user should be prompted with the opportunity to add this token to their wallet:
 
-![adding token](https://user-images.githubusercontent.com/12115171/44048738-a47ca2dc-9f08-11e8-968d-56f78262d65f.gif)
+![ezgif com-video-to-gif](https://user-images.githubusercontent.com/12115171/44558730-2666e300-a71c-11e8-9098-e27ec99b88fb.gif)
+
+For `Base64` images, the user just have to add it as `image` parameter.
+
+```javascript
+const base64image = 'data:image/png;base64, ... '
+web3.wallet.watchAsset({ 
+	type: 'ERC20', 
+	options: { 
+		address, 
+		symbol, 
+		decimals, 
+		image: base64image 
+	}
+})
+```
+Upon calling this request, the user should be prompted with the opportunity to add this token to their wallet:
+
+![ezgif com-video-to-gif 1](https://user-images.githubusercontent.com/12115171/44558734-2961d380-a71c-11e8-870b-b7d27cfccc87.gif)
 
 If the user adds this token, it should appear somewhere in their wallet's UI, with its balance, etc.
 

--- a/EIPS/eip-747.md
+++ b/EIPS/eip-747.md
@@ -1,11 +1,11 @@
 ---
 eip: <to be assigned>
-title: Add eth_watchToken to Provider
+title: Add wallet_watchAsset to Provider
 author: Dan Finlay (@danfinlay), Esteban Mino (@estebanmino)
 discussions-to: https://ethereum-magicians.org/t/eip-747-eth-watchtoken/1048
 status: WIP
 type: Interface
-category Interface
+category: Interface
 created: August 13, 2018
 ---
 
@@ -13,21 +13,21 @@ created: August 13, 2018
 
 ## Simple Summary
 <!--"If you can't explain it simply, you don't understand it well enough." Provide a simplified and layman-accessible explanation of the EIP.-->
-A method for allowing users to easily track new tokens with a suggestion from sites they are visiting.
+A method for allowing users to easily track new assets with a suggestion from sites they are visiting.
 
 ## Abstract
 <!--A short (~200 word) description of the technical issue being addressed.-->
-Web3 JavaScript wallet browsers may implement `eth_watchToken()` to allow any website to suggest a token for the user's wallet to track.
+Web3 JavaScript wallet browsers may implement `wallet_watchAsset()` to allow any website to suggest a token for the user's wallet to track.
 
 ## Motivation
 <!--The motivation is critical for EIPs that want to change the Ethereum protocol. It should clearly explain why the existing protocol specification is inadequate to address the problem that the EIP solves. EIP submissions without sufficient motivation may be rejected outright.-->
-Today, one of the major uses of ethereum wallets is to acquire and track tokens. Currently, each wallet either needs to pre-load a list of approved tokens, or users need to be stepped through a tedious process of adding a token for their given wallet.
+Today, one of the major uses of ethereum wallets is to acquire and track assets. Currently, each wallet either needs to pre-load a list of approved assets, or users need to be stepped through a tedious process of adding an asset for their given wallet.
 
-In the first case, wallets are burdened with both the security of managing this list, as well as the bandwidth of mass polling for known tokens on their wallet.
+In the first case, wallets are burdened with both the security of managing this list, as well as the bandwidth of mass polling for known assets on their wallet.
 
 In the second case, the user experience is terrible.
 
-By leveraging a user's existing trust with websites they are learning about tokens on, we are able to decentralize the responsibility of managing a user's list of known tokens.
+By leveraging a user's existing trust with websites they are learning about assets on, we are able to decentralize the responsibility of managing a user's list of known assets.
 
 ## Specification
 <!--The technical specification should describe the syntax and semantics of any new feature. The specification should be detailed enough to allow competing, interoperable implementations for any of the current Ethereum platforms (go-ethereum, parity, cpp-ethereum, ethereumj, ethereumjs, and [others](https://github.com/ethereum/wiki/wiki/Clients)).-->
@@ -36,23 +36,27 @@ A new method is added to web3 browsers' ethereum providers:
 ```javascript
 
 /**
- * @param {String} tokenAddress - The address of the token to add
- * @param {String} tokenSymbol - The abbreviated name of the token to add.
- * @param {Number} tokenDecimals - The number of decimals to use when rendering the token count.
- * @param {String} tokenImage - Optional - The URL for the image to render for the token's icon. (TODO: Finalize type of this parameter.)
- * @returns {Promise} success - Whether the user added the token to their wallet.
- */
-async function eth_watchToken (
-  tokenAddress,
-  tokenSymbol,
-  tokenDecimals,
-  tokenImage
+* @param  {Object}  opts - The options specifing the asset `type` and `options` specific for each of asset.
+* @returns  {Promise} success - Whether the user added the asset to their wallet.
+*/
+async  function  wallet_watchAsset (
+  opts
 ) {
-  /* Implementation would go here */
+/* Implementation would go here */
 }
 
 // Sample usage:
-web3.eth.watchToken(tokenAddress, tokenSymbol, tokenDecimals [, tokenImage] )
+web3.wallet.watchAsset({ type, options })
+```
+As there are several types of different assets, this method has to provide support for each of them in a separate way. If it doesn't, it should give a response according to that.
+
+In the case of assets of type `ERC20`, this method works as follows.
+
+```javascript
+web3.wallet.watchAsset({ 
+	type: 'ERC20', 
+	options: { tokenAddress, tokenSymbol, tokenDecimals [, tokenImage] }
+})
 ```
 
 The `tokenImage` parameter should link to a web-standard image format (png, jpg, gif) of a reasonable size. To establish a baseline, let's say no greater than 512x512 pixels, and no greater than 256kb. However, this can be a client-defined setting.
@@ -65,19 +69,19 @@ If the user adds this token, it should appear somewhere in their wallet's UI, wi
 
 ## Rationale
 <!--The rationale fleshes out the specification by describing what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work, e.g. how the feature is supported in other languages. The rationale may also provide evidence of consensus within the community, and should discuss important objections or concerns raised during discussion.-->
-Displaying a user's tokens is a basic feature that every modern dapp user expects. However, keeping this list, and polling for it from the network can be costly, especially on bandwidth constrained devices.
+Displaying a user's assets is a basic feature that every modern dapp user expects. However, keeping this list, and polling for it from the network can be costly, especially on bandwidth constrained devices.
 
-Most wallets today either manage their own token list, which they store client side, or they query a centralized API for token balances, which reduces decentralization, letting that API's owner easily correlate account holders with their IP addresses.
+Most wallets today either manage their own assets list, which they store client side, or they query a centralized API for balances, which reduces decentralization, letting that API's owner easily correlate account holders with their IP addresses.
 
-Maintaining one of these token lists becomes a political act, and maintainers can be subject to regular harrassment and pressure to list otherwise unknown tokens.
+Maintaining one of these assets lists becomes a political act, and maintainers can be subject to regular harassment and pressure to list otherwise unknown assets.
 
-Furthermore, automatically listing tokens makes tokens into a sort of spam mail: Users suddenly seeing new tokens that they don't care about in their wallet can be used to bombard them with information that they didn't opt into.
+Furthermore, automatically listing assets makes assets into a sort of spam mail: Users suddenly seeing new assets that they don't care about in their wallet can be used to bombard them with information that they didn't opt into.
 
 This phenomenon is exacerbated by the trend towards airdropped tokens, which has been a cause of network congestion, because spamming people with new tokens has so far been rewarded with user attention.
 
 While some people might suggest we begin a TCR of trusted tokens to watch, this would not solve the client-side bandwidth issues, nor the airdropped token spam issues. What we really want is a small list of tokens the user cares about.
 
-Most of the time a user is adding a token, they learned about it on a website. At that moment, there is a natural alignment of interests, where the website wants the user to track their token, and the user wants to track it. This is a natural point to introduce an API to easily allow these parties to collaborate, without involving the politics of the wallet's developers.
+Most of the time a user is adding a asset, they learned about it on a website. At that moment, there is a natural alignment of interests, where the website wants the user to track their asset, and the user wants to track it. This is a natural point to introduce an API to easily allow these parties to collaborate, without involving the politics of the wallet's developers.
 
 ## Implementation
 <!--The implementations must be completed before any EIP is given status "Final", but it need not be completed before the EIP is accepted. While there is merit to the approach of reaching consensus on the specification and rationale before writing code, the principle of "rough consensus and running code" is still useful when it comes to resolving many discussions of API details.-->

--- a/EIPS/eip-747.md
+++ b/EIPS/eip-747.md
@@ -2,7 +2,7 @@
 eip: <to be assigned>
 title: Add eth_watchToken to Provider
 author: Dan Finlay (@danfinlay), Esteban Mino (@estebanmino)
-discussions-to: <URL>
+discussions-to: https://ethereum-magicians.org/t/eip-747-eth-watchtoken/1048
 status: WIP
 type: Interface
 category Interface

--- a/EIPS/eip-747.md
+++ b/EIPS/eip-747.md
@@ -98,6 +98,14 @@ Upon calling this request, the user should be prompted with the opportunity to a
 
 If the user adds this token, it should appear somewhere in their wallet's UI, with its balance, etc.
 
+As a result of the addition or not of the asset a `Promise` should be returned, indicating if the user added the asset or an error if some parameter is not valid.
+
+In the case of an asset type that is not supported by the wallet, an error should appear indicating at least.
+
+```
+Asset of type (type) not supported
+```
+
 ## Rationale
 <!--The rationale fleshes out the specification by describing what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work, e.g. how the feature is supported in other languages. The rationale may also provide evidence of consensus within the community, and should discuss important objections or concerns raised during discussion.-->
 Displaying a user's assets is a basic feature that every modern dapp user expects. However, keeping this list, and polling for it from the network can be costly, especially on bandwidth constrained devices.

--- a/EIPS/eip-777.md
+++ b/EIPS/eip-777.md
@@ -75,7 +75,9 @@ The token contract MUST implement the above interface. The implementation MUST f
 
 The token contract MUST register the `ERC777Token` interface with its own address via [ERC820]. If the contract has a switch to enable or disable [ERC777] functions, every time the switch is triggered, the token MUST register or unregister the `ERC777Token` interface for its own address accordingly via [ERC820]. (Unregistering implies setting the address to `0x0`.)
 
-The basic unit token MUST be 10<sup>18</sup> (i.e., [ERC20]'s `decimals` MUST be `18`). All functions MUST consider any amount of tokens (such as balances and amount to send, mint, or burn) in the basic unit.
+The smallest unit&mdash;for all interactions with the token contract&mdash;MUST be `1`. I.e. all amounts and balances MUST be unsigned integers. The display denomination&mdash;to display any amount to the end user&mdash;MUST be 10<sup>18</sup> of the smallest.
+
+In other words the technical denomination is similar to a wei and the display denomination is similar to an ether. It is equivalent to an  [ERC20]'s `decimals` function returning `18`. E.g. if a token contract holds a balance of `500,000,000,000,000,000` (0.5&times;10<sup>18</sup>) for a user, the user interface SHOULD show `0.5` tokens to the user. If the user wishes to send `0.3` tokens, the contract MUST be called with an amount of `300,000,000,000,000,000` (0.3&times;10<sup>18</sup>).
 
 #### **View Functions**
 
@@ -111,7 +113,7 @@ Get the total number of minted tokens.
 
 The total supply MUST be equal to the sum of the balances of all addresses&mdash;as returned by the `balanceOf` function.
 
-The total supply MUST be equal to the sum of all the minted tokens as defined in all the `Minted` events minus the sum of all the burned tokens as defined in all the `Burned` events.
+The total supply MUST be equal to the sum of all the minted tokens as defined in all the `Minted` events minus the sum of all the burned tokens as defined in all the `Burned` events. One exception is a cloned token (with cloned balances) where the newer token contract MAY have a `totalSupply` greater than the difference of all the `Minted` and `Burned` events.
 
 > <small>**returns:** Total supply of tokens currently in circulation.</small>
 
@@ -138,22 +140,24 @@ function granularity() public view returns (uint256)
 
 Get the smallest part of the token that's not divisible.
 
+In other words, the granularity is the smallest number of tokens (in the basic unit) which MAY be minted, sent or burned at any time.
+
 The following rules MUST be applied regarding the *granularity*:
 
-- The *granularity* value MUST be at creation time.
+- The *granularity* value MUST be set at creation time.
 - The *granularity* value MUST NOT be changed ever.
 - The *granularity* value MUST be greater or equal to `1`.
 - Any minting, send or burning of tokens MUST be a multiple of the *granularity* value.
 - Any operation that would result in a balance that's not a multiple of the *granularity* value MUST be considered invalid, and the transaction MUST `revert`.
 
-*NOTE*: Most of the tokens SHOULD be fully partitionable. I.e., this function SHOULD return `1` unless there is a good reason for not allowing any partition of the token.
+*NOTE*: Most of the tokens SHOULD be fully partitionable. I.e., this function SHOULD return `1` unless there is a good reason for not allowing any fraction of the token.
 
 > <small>**returns:** The smallest non-divisible part of the token.</small>
 
 *NOTE*: [`defaultOperators`][defaultOperators] and [`isOperatorFor`][isOperatorFor] are also `view` functions, defined under the [operators] for consistency.
 
 *[ERC20] compatibility requirement*:  
-The decimals of the token MUST always be `18`. For a *pure* ERC777 token the [ERC20] `decimal` function is OPTIONAL, and its existence SHALL NOT be relied upon when interacting with the token contract. (The decimal value of `18` is implied.) For an [ERC20] enabled token, the `decimal` function is REQUIRED and MUST return `18`.
+The decimals of the token MUST always be `18`. For a *pure* ERC777 token the [ERC20] `decimal` function is OPTIONAL, and its existence SHALL NOT be relied upon when interacting with the token contract. (The decimal value of `18` is implied.) For an [ERC20] compatible token, the `decimal` function is REQUIRED and MUST return `18`. (In [ERC20], the `decimals` function is OPTIONAL, but the value if the function is not present, is not clearly defined and may be assumed to be `0`. Hence for compatibility reasons, `decimals` MUST be implemented for [ERC20] compatible tokens.)
 
 *[ERC20] compatibility requirement*:  
 The `name`, `symbol`, `totalSupply`, and `balanceOf` `view` functions MUST be backward compatible with [ERC20].
@@ -287,7 +291,7 @@ When an *operator* sends an `amount` of tokens from a *token holder* to a *recip
 - The balance of the *token holder* MUST be greater or equal to the `amount`&mdash;such that its resulting balance is greater or equal to zero (`0`) after the send.
 - The token contract MUST emit a `Sent` event with the correct values as defined in the [`Sent` Event][sent].
 - The *operator* MAY communicate any information in the `operatorData`.
-- The token contract MUST call the `tokensToSend` hook of the *token holder* if the *token holder* registers an `ERC777TokensRecipient` implementation via [ERC820].
+- The token contract MUST call the `tokensToSend` hook of the *token holder* if the *token holder* registers an `ERC777TokensSender` implementation via [ERC820].
 - The token contract MUST call the `tokensReceived` hook of the *recipient* if the *recipient* registers an `ERC777TokensRecipient` implementation via [ERC820].
 - The `data` and `operatorData` MUST be immutable during the entire send process&mdash;hence the same `data` and `operatorData` MUST be used to call both hooks and emit the `Sent` event.
 
@@ -397,6 +401,8 @@ The token contract MUST `revert` when minting in any of the following cases:
 - The resulting *recipient* balance after the mint is not a multiple of the *granularity* defined by the token contract.
 - The *recipient* is a contract, and it does not implement the `ERC777TokensRecipient` interface via [ERC820].
 - The address of the *recipient* is `0x0`.
+
+*NOTE*: The initial token supply at the creation of the token contract MUST be considered as minting for the amount of the initial supply to the address (or addresses) receiving the initial supply.
 
 *[ERC20] compatibility requirement*:  
 While a `Sent` event MUST NOT be emitted when minting, if the token contract is [ERC20] backward compatible, a `Transfer` event with the `from` parameter set to `0x0` SHOULD be emitted as defined in the [ERC20] standard.


### PR DESCRIPTION
A method for web3 wallets to allow Dapps to suggest assets that the user might want to "watch". The first reference example is for adding a token to the user's list of watched tokens.

This feature is in [MetaMask v4.10.0](https://github.com/MetaMask/metamask-extension/releases/tag/v4.10.0) and can be tested against [this web app](https://metamask.github.io/Add-Token/#add?tokenAddress=0xdc1adf1d0bf59ec597e1b1b8e3dceb31aafd793f&tokenImage=https%3A%2F%2Fpbs.twimg.com%2Fprofile_images%2F723268858644037632%2Fu-kjO4___400x400.jpg&tokenName=Danbucks&tokenNet=3&tokenSymbol=DBX&tokenDecimals=2).

Latest discussion on the feature can be found here:
https://ethereum-magicians.org/t/eip-747-eth-watchtoken/1048

Fixes #747.