### PR TITLE
Include superseded status on eips.ethereum.org

### DIFF
--- a/_data/statuses.yaml
+++ b/_data/statuses.yaml
@@ -4,3 +4,4 @@
 - Final
 - Active
 - Deferred
+- Superseded


### PR DESCRIPTION
EIP-5 is not displayed currently.

Also worth nothing that Active, WIP and Rejected statuses (valid according to EIP1) are not included either.

cc @Arachnid @Souptacular 