### PR TITLE
Added Jaxx Liberty 2.0.0

### DIFF
--- a/EIPS/eip-55.md
+++ b/EIPS/eip-55.md
@@ -105,6 +105,7 @@ Note that the input to the Keccak256 hash is the lowercase hexadecimal string (i
 | Mist 0.8.10              | Yes                            | Yes                        | Yes               | Yes              |
 | MyEtherWallet v3.9.4     | Yes                            | Yes                        | Yes               | Yes              |
 | Parity 1.6.6-beta (UI)   | Yes                            | Yes                        | Yes               | Yes              |
+| Jaxx Liberty 2.0.0       | Yes                            | Yes                        | Yes               | Yes              |
 
 ### Exchange support for mixed-case address checksums, as of 2017-05-27:
 


### PR DESCRIPTION
We have implemented eip-55 checksum addresses for ETH, ETC and ERC20 token addresses in the new version of Jaxx which is known as Jaxx Liberty.
