### PR TITLE
EIP-1066: clarify category headers

### DIFF
--- a/EIPS/eip-1066.md
+++ b/EIPS/eip-1066.md
@@ -105,7 +105,7 @@ explanatory and layout reasons.
 
 Unspecified codes are _not_ free for arbitrary use, but rather open for further specification.
 
-#### Generic
+#### `0x0*` Generic
 
 General codes. These double as bare "reasons", since `0x01 == 1`.
 
@@ -128,7 +128,7 @@ General codes. These double as bare "reasons", since `0x01 == 1`.
 | `0x0E`          |                         |
 | `0x0F`          | Meta or Info Only       |
 
-#### Permission
+#### `0x1*` Permission
 
 Related to permisson, authorization, approval, and so on.
 
@@ -151,7 +151,7 @@ Related to permisson, authorization, approval, and so on.
 | `0x1E`          |                          |
 | `0x1F`          | Permission Meta or Info  |
 
-#### Find, Match, &c
+#### `0x2*` Find, Match, &c
 
 This range is broadly intended for finding and matching.
 Data lookups and order matching are two common use cases.
@@ -175,7 +175,7 @@ Data lookups and order matching are two common use cases.
 | `0x2E`          |                          |
 | `0x2F`          | Matching Meta or Info    |
 
-#### Negotiation, Terms, and Offers
+#### `0x3*` Negotiation, Terms, and Offers
 
 Negotiation, and very broadly the flow of such transactions.
 Note that "other party" may be more than one actor (not necessarily the sender).
@@ -199,7 +199,7 @@ Note that "other party" may be more than one actor (not necessarily the sender).
 | `0x3E`          |                             |
 | `0x3F`          | Negotiation Meta or Info    |
 
-#### Availability
+#### `0x4*` Availability
 
 Service or action availability.
 
@@ -222,27 +222,27 @@ Service or action availability.
 | `0x4E`          |                             |
 | `0x4F`          | Availability Meta or Info   |
 
-#### `0x5_` TBD
+#### `0x5*` TBD
 
 Currently unspecified
 
-#### `0x6_` TBD
+#### `0x6*` TBD
 
 Currently unspecified
 
-#### `0x7_` TBD
+#### `0x7*` TBD
 
 Currently unspecified
 
-#### `0x8_` TBD
+#### `0x8*` TBD
 
 Currently unspecified
 
-#### `0x9_` TBD
+#### `0x9*` TBD
 
 Currently unspecified
 
-#### Application-Specific Codes
+#### `0xA*` Application-Specific Codes
 
 Contracts may have special states that they need to signal.
 This proposal only outlines the broadest meanings, but implementers may have very
@@ -267,19 +267,19 @@ specific meanings for each, as long as they are coherent with the broader defini
 | `0xAE`          |                                 |
 | `0xAF`          | App-Specific Meta or Info       |
 
-#### `0xB_` TBD
+#### `0xB*` TBD
 
 Currently unspecified
 
-#### `0xC_` TBD
+#### `0xC*` TBD
 
 Currently unspecified
 
-#### `0xD_` TBD
+#### `0xD*` TBD
 
 Currently unspecified
 
-#### Cryptography and Authentication
+#### `0xE*` Cryptography and Authentication
 
 Actions around signatures, cryptography, signing, and application-level authentication.
 
@@ -307,7 +307,7 @@ or process used.
 
 #### `0xF0` Off-Chain
 
-For off-chain actions. Much like th `0x0_: Generic` range, `0xF_` is very general,
+For off-chain actions. Much like th `0x0_: Generic` range, `0xF*` is very general,
 and does little to modify the reason.
 
 Among other things, the meta code `0xFF` may be used to describe what the off-chain process is.
@@ -489,7 +489,7 @@ most forwards-compatible method of transmission is as the first value of a multi
 
 Familiarity is also a motivating factor. A consistent position and encoding together
 follow the principle of least surprise. It is both viewable as a "header" in the HTTP analogy,
-or like the "tag" in BEAM tagged tupples.
+or like the "tag" in BEAM tagged tuples.
 
 ### Human Readable
 
@@ -500,7 +500,7 @@ Cognitive load is lowered by organizing the table into categories and reasons.
 While this repository includes helper enums, we have found working directly in
 the hex values to be quite natural. ESC `0x10` is just as comfortable as HTTP 401, for example.
 
-### Extensiblilty
+### Extensibility
 
 The `0xA` category is reserved for application-specific statuses.
 In the case that 256 codes become insufficient, `bytes1` may be embedded in larger byte arrays.
@@ -526,7 +526,7 @@ but becomes very natural after a couple hours of use.
 
 #### Short Forms
 
-Generic is `0x0_`, general codes are consistent with their integer representations
+Generic is `0x0*`, general codes are consistent with their integer representations
 
 ```solidity
 hex"1" == hex"01" == 1 // with casting


### PR DESCRIPTION
Fix a handful of typos, and clarify the headers. We're also in process of expanding the text in the EIP over the next few weeks as well, but this is a quick fix that a few people have asked for.