### PR TITLE
EIP-712: fix assembly hashStruct example

### DIFF
--- a/EIPS/eip-712.md
+++ b/EIPS/eip-712.md
@@ -375,19 +375,19 @@ function hashStruct(Mail memory mail) pure returns (bytes32 hash) {
 
     assembly {
         // Back up select memory
-        let temp1 := mload(sub(order, 32))
-        let temp2 := mload(add(order, 128))
+        let temp1 := mload(sub(mail, 32))
+        let temp2 := mload(add(mail, 128))
 
         // Write typeHash and sub-hashes
         mstore(sub(mail, 32), typeHash)
-        mstore(add(order, 64), contentsHash)
+        mstore(add(mail, 64), contentsHash)
 
         // Compute hash
-        hash := keccak256(sub(order, 32), 128)
+        hash := keccak256(sub(mail, 32), 128)
 
         // Restore memory
-        mstore(sub(order, 32), temp1)
-        mstore(add(order, 64), temp2)
+        mstore(sub(mail, 32), temp1)
+        mstore(add(mail, 64), temp2)
     }
 }
 ```


### PR DESCRIPTION
This example originated as a copy-paste of the 0x codebase, and it still had "order" instead of "mail" in it