### PR TITLE
EIP-627: move to Networking category

### DIFF
--- a/EIPS/eip-627.md
+++ b/EIPS/eip-627.md
@@ -2,7 +2,8 @@
 eip: 627
 title: Whisper Specification
 author: Vlad Gluhovsky <gluk256@gmail.com>
-type: Informational
+type: Standards Track
+category: Networking
 status: Draft
 created: 2017-05-05
 ---


### PR DESCRIPTION
I didn't write this EIP but it is clearly miscategorized. The document
describes a devp2p protocol and should be in the Networking category.