### PR TITLE
ERC1444: Preformat cardinality to avoid md table

### DIFF
--- a/EIPS/eip-1444.md
+++ b/EIPS/eip-1444.md
@@ -133,7 +133,7 @@ Text with 2 or more arguments SHOULD use the POSIX parameter field extension.
 
 ### `bytes32` Keys
 
-`bytes32` is very efficient since it is the EVM's base word size. Given the enormous number of elements (|A| > 1.1579 × 10<sup>77</sup>), it can embed nearly any practical signal, enum, or state. In cases where an application's key is longer than `bytes32`, hashing that long key can map that value into the correct width.
+`bytes32` is very efficient since it is the EVM's base word size. Given the enormous number of elements (<pre>|A| > 1.1579 × 10<sup>77</sup></pre>), it can embed nearly any practical signal, enum, or state. In cases where an application's key is longer than `bytes32`, hashing that long key can map that value into the correct width.
 
 Designs that use datatypes with small widths than `bytes32` (such as `bytes1` in [ERC-1066](https://eips.ethereum.org/EIPS/eip-1066)) can be directly embedded into the larger width. This is a trivial one-to-one mapping of the smaller set into the the larger one.
 


### PR DESCRIPTION
The markdown renderer is creating a table from `|A|` (unlike in Github-flavoured markdown)

# Issue Screenshot
<img width="826" alt="screen shot 2018-10-20 at 21 20 12" src="https://user-images.githubusercontent.com/1052016/47263047-f3d42f00-d4ad-11e8-8617-5fe692761b17.png">