### PR TITLE
ERC1444: appease markdown renderer

### DIFF
--- a/EIPS/eip-1444.md
+++ b/EIPS/eip-1444.md
@@ -133,7 +133,7 @@ Text with 2 or more arguments SHOULD use the POSIX parameter field extension.
 
 ### `bytes32` Keys
 
-`bytes32` is very efficient since it is the EVM's base word size. Given the enormous number of elements (<pre>|A| > 1.1579 × 10<sup>77</sup></pre>), it can embed nearly any practical signal, enum, or state. In cases where an application's key is longer than `bytes32`, hashing that long key can map that value into the correct width.
+`bytes32` is very efficient since it is the EVM's base word size. Given the enormous number of elements (card(A) > 1.1579 × 10<sup>77</sup>), it can embed nearly any practical signal, enum, or state. In cases where an application's key is longer than `bytes32`, hashing that long key can map that value into the correct width.
 
 Designs that use datatypes with small widths than `bytes32` (such as `bytes1` in [ERC-1066](https://eips.ethereum.org/EIPS/eip-1066)) can be directly embedded into the larger width. This is a trivial one-to-one mapping of the smaller set into the the larger one.
 


### PR DESCRIPTION
Giving up on vertical bars of any kind, and switching to function notation to express cardinality