### PR TITLE
add debt standard

### DIFF
--- a/EIPS/debt_standard.md
+++ b/EIPS/debt_standard.md
@@ -1,0 +1,250 @@
+---
+eip: ?
+title: A Standard for Tokenized Debt
+author: Aaron Diamond-Reivich <aarondia@wharton.upenn.edu>, Gabriel Barros <gbbabarros@gmail.com>, Griffin Anderson <andergri1@gmail.com>, Brett Shear <Brett@terminal.co>
+status: Draft
+type: Standards Track
+category: ERC
+created: 2018-10-03
+---
+
+## Simple Summary
+The Ethereum community needs a standard for representing debt on the blockchain. The lack of a standard will lead to the creation of siloed pools of debt that are not interoperable. The adoption of this standard will allow for the creation of valuable applications and protocols to help individuals and organizations manage their debt.
+
+## Abstract
+From complex transactions like mortgages to simple transactions like purchasing coffee from Starbucks, there is a period of time when one party has yet to fulfill his/her side of the agreement; that party is in debt. The creation of debt is a method to ensure accountability for these incomplete business transactions.
+
+The Ethereum developer community has adopted the ERC20 and ERC721 token standards as a means of representing assets on the Ethereum blockchain. These common standards allow exchanges, wallets, and protocols to facilitate the transfer and custody of these assets. The common interface to enable the transfer of ownership of these digital assets is powerful. However, the inclusion of a few optional pieces of data has proven useful as well, namely, token name, symbol, and the number of decimals. Incorporating this extra information into the standard makes the aforementioned tools even more powerful.
+
+Similar to how additional standards have been built on top of the ERC20 token standard, we are proposing an additional standard on top of the ERC721 token standard. Our Debt Standard defines a common interface that is to be implemented by all ERC721 token smart contracts created to represent debt.
+
+By providing this common debt standard, individuals and applications will be able to gain insight into the debt that each token represents in a systematic way - similar to how applications know how to transfer ownership of an ERC20 token. This will allow for the creation of financial management tools that can be used to manage all forms of debt across the Ethereum blockchain.
+
+## Motivation
+The existing ERC 721 token standard is inadequate for representing debt on the blockchain because, although it does provide a standard for transferring ownership of unique tokens, the standard does not include basic functionality that is common across all debts. Importantly, the ERC 721 token standard does not have a standard for associating a value of debt with each token, nor does it have the necessary functions to gain insight into the what the token represents. Because all forms of debt have a value attached to it, it is beneficial to the Ethereum community to agree on a set of basic functions to interact with the value that each debt is worth.
+
+## Specification
+
+### Interface
+
+#### functions
+
+##### fulfill
+
+This function should retrieve information about the debt and try to fulfill the transfer of payments in order to fulfill the debt. It must accommodate the fulfillment by calling the transferFrom method of a ERC20 token or if msg.value is positive, fulfill the payment with Ether.  
+
+* @param debtID - is a unique identifier of a debt inside this contract space
+
+```solidity
+function fulfill(uint256 debtID) public payable;
+```
+
+##### withdraw
+
+This function should transfer the payment of a specific debtID to the ownerOf(debtID)
+
+* @param debtID - is an unique identifier of a debt inside this contract space
+
+```solidity
+function withdraw(uint debt) public;
+```
+
+
+##### status
+
+This function should return the status of a debt based on its time parameters. If the activation date has passed, it should return DebtStatus Materialized. If due date for fulfillment has passed, it should return DebtStatus Defaulted.
+
+* @param debtID - is a unique identifier of a debt inside this contract space
+
+```solidity
+function status(uint256 debtID) public view returns (DebtStatus _status);
+```
+
+##### info
+
+This function should return the basic static terms of a debt
+
+* @param debtID - is an unique identifier of a debt inside this contract space
+
+```solidity
+function info(uint256 debtID) public view returns
+(address debtor, address creditor, uint256 amount, address token, uint createdAt, uint validAt, uint defaultedAt);
+```
+
+##### calculateFulfillment
+
+This function should calculate all specific terms inherent to the debt and return the exact amount one must pay in order to fulfill the debt at the specified time.
+
+* @param debtID - is an unique identifier of a debt inside this contract space
+* @param fulfillmentTime - the period number to check the fulfillment of
+
+```solidity
+function calculateFulfillment(uint256 debtID, uint256 fulfillmentTime) public view returns (uint256 amount);
+```
+
+##### changeDebtor
+This function changes the debtor of a debt to msg.sender.  It must have the approval of the owner of the debt (the recipient of the payment) and the new debtor.
+
+* @param debtID - is an unique identifier of a debt inside this contract space
+* @param newDebtor - the address to make the debtor of all new debt
+* @param nonceNewDebtor - a unique uint for this transaction; used to prevent replay attacks
+* @param nonceOwner - a unique uint for this transaction; used to prevent replay attacks
+* @param {vND,rND,sND} - ECDSA signature used to verify approval of new debtor
+* @param {vO,rO,sO} - ECDSA signature used to verify approval of the owner of the debt
+
+
+```solidity
+function changeDebtor(
+uint256 debtID,
+address newDebtor,
+uint nonceDebtor,
+uint nonceOwner,
+uint8 vND,
+bytes32 rND,
+bytes32 sND,
+uint8 vO,
+bytes32 rO,
+bytes32 sO
+)
+public
+returns (bool success);
+```
+
+##### changeDebtContractOwner
+
+This function changes the owner of the debt contract to newOwner. It can only be called by the current owner. All future created debt for the debt contract should default to newOwner as the receiver of the payment
+
+* @param debtID - is a unique identifier of a debt inside this contract space
+* @param newOwner - the address to make the receiver of all new debt
+
+```solidity
+function changeDebtContractOwner (uint256 debtID, address newOwner) public;
+```
+
+#### events
+
+##### Debt Created
+```solidity
+event DebtCreated(uint indexed subscriptionID, uint indexed debtID, uint referencePeriod);
+```
+
+##### Debt Fulfilled
+```solidity
+event DebtFulfilled(uint indexed subscriptionID, uint indexed debtID);
+```
+
+#### State
+
+##### DebtStatus
+
+This user-defined type is used to represent the state of a specific debt.
+
+Approved - An agreement has been made that will result in the debt creation
+Materialized - The creditor has upheld his end of the agreement and now the debtor is liable to fulfill his end
+Defaulted - The debtor did not uphold his end of the agreement in the agreed upon time
+Fulfilled - The debtor fulfilled his terms of the agreement
+
+```solidity
+enum DebtStatus { Approved, Materialized, Defaulted, Fulfilled }
+```
+
+The above interface should be implemented by all tokens that represent debt of any sort. Additionally, for secured debt and interest-bearing debt, we propose the following supplemental interfaces.
+
+### Secured Debt
+The Secured Standard is used in addition to the debt standard to represent collateralized debt.
+
+#### Functions
+##### depositCollateral
+
+This function should enable the deposit of collateral goods for this debt. If @param token is set to a valid address, it should attempt to call the transferFrom method of the token address and send @param amount of the tokens from the msg.sender to this smart contract. If msg.value is positive, it should mark msg.value as collateral for this specific debt. It should only allow collateral to be paid in one form of currency for each debt. (Accepted: one ERC20 token or Ether. Not Accepted: Two different types of ERC20 tokens, ERC20 token and Ether).
+
+* @param debtID - is a unique identifier of a debt inside this contract space
+* @param token - the address of the token used as collateral
+* @param amount - the amount of the token to be collateralized
+
+```solidity
+function depositCollateral(uint debtID, address token, uint amount) public payable;
+```
+
+##### claimCollateral
+
+If this method is called by the debtor, it should check if the debt has been fulfilled. If the debt is fulfilled, allow the msg.sender to withdraw the collateral. If this method is not called by the debtor, it should check if the msg.sender is the owner of the debt and transfer the collateral only if debtor defaulted.
+
+```solidity
+function claimCollateral() public;
+```
+
+#### Events
+
+##### CollateralDeposited
+
+```solidity
+event CollateralDeposited(uint indexed reference);
+```
+
+##### CollateralWithdrawn
+
+```solidity
+event CollateralWithdrawn(uint indexed reference);
+```
+
+##### CollateralClaimed
+
+```solidity
+event CollateralClaimed(uint indexed reference);
+```
+
+### Interest
+
+The Interest Standard is used in addition to the debt standard to represent interest-bearing debt.
+
+#### Functions
+
+##### principalPaid
+
+This function should return the amount of principal that has already been repaid.
+
+* @param debtID - is a unique identifier of a debt inside this contract space
+
+```solidity
+function principalPaid(uint debtID) public returns (uint principal);
+```
+
+##### principalRemaining
+
+This function should return the amount of principal left to pay.
+
+* @param debtID - is a unique identifier of a debt inside this contract space
+
+```solidity
+function principalRemaining (uint debtID) public returns (uint principal);
+```
+
+##### totalInterestPaid
+
+This function should return the amount of interest paid.
+
+* @param debtID - is a unique identifier of a debt inside this contract space.
+
+```solidity
+function totalInterestPaid(uint debtID) public returns (uint interest);
+```
+
+## Rationale
+Each unique debt token is assigned to a unique debt. When that debt is repaid by the borrower, the owner of the token burns his/her debt token in order to receive the payment. This burned token is now an immutable receipt of the fulfilled debt.
+
+Representing the right to claim the payment for a debt as an EIP 721 NFT immediately allows the owner of the token to sell the debt through existing protocols like 0x.
+
+The debt standard smart contract can be implemented to accommodate a wide range of business processes. We have tested it  with subscriptions, mortgages, and loans. Because the standard does not dictate the creation of the debt, the developer has the freedom to use this standard across a multitude of different use cases.
+
+## Backwards Compatibility
+Backward Compatible with EIP 721
+
+## Test Cases
+WIP
+
+## Implementation
+WIP
+
+## Copyright
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/EIPS/eip-1532.md
+++ b/EIPS/eip-1532.md
@@ -184,8 +184,10 @@ function depositCollateral(uint debtID, address token, uint amount) public payab
 
 If this method is called by the debtor, it should check if the debt has been fulfilled. If the debt is fulfilled, allow the msg.sender to withdraw the collateral. If this method is not called by the debtor, it should check if the msg.sender is the owner of the debt and transfer the collateral only if debtor defaulted.
 
+* @param debtID - is a unique identifier of a debt inside this contract space
+
 ```solidity
-function claimCollateral() public;
+function claimCollateral(uint debtID) public;
 ```
 
 #### Events

--- a/EIPS/eip-1532.md
+++ b/EIPS/eip-1532.md
@@ -1,5 +1,5 @@
 ---
-eip: ?
+eip: 1532
 title: A Standard for Tokenized Debt
 author: Aaron Diamond-Reivich <aarondia@wharton.upenn.edu>, Gabriel Barros <gbbabarros@gmail.com>, Griffin Anderson <andergri1@gmail.com>, Brett Shear <Brett@terminal.co>
 status: Draft

--- a/EIPS/eip-1532.md
+++ b/EIPS/eip-1532.md
@@ -14,7 +14,7 @@ The Ethereum community needs a standard for representing debt on the blockchain.
 ## Abstract
 From complex transactions like mortgages to simple transactions like purchasing coffee from Starbucks, there is a period of time when one party has yet to fulfill his/her side of the agreement; that party is in debt. The creation of debt is a method to ensure accountability for these incomplete business transactions.
 
-The Ethereum developer community has adopted the ERC20 and ERC721 token standards as a means of representing assets on the Ethereum blockchain. These common standards allow exchanges, wallets, and protocols to facilitate the transfer and custody of these assets. The common interface to enable the transfer of ownership of these digital assets is powerful. However, the inclusion of a few optional pieces of data has proven useful as well, namely, token name, symbol, and the number of decimals. Incorporating this extra information into the standard makes the aforementioned tools even more powerful.
+The Ethereum developer community has adopted the ERC20 and ERC721 token standards as a means of representing assets on the Ethereum blockchain. These common standards allow exchanges, wallets, and protocols to facilitate the transfer and custody of these digital assets. The common interface to enable the transfer of ownership of these digital assets is powerful. However, the inclusion of a few optional pieces of data has proven useful as well, namely, token name, symbol, and the number of decimals. Incorporating this extra information into the standard makes the aforementioned tools even more powerful.
 
 Similar to how additional standards have been built on top of the ERC20 token standard, we are proposing an additional standard on top of the ERC721 token standard. Our Debt Standard defines a common interface that is to be implemented by all ERC721 token smart contracts created to represent debt.
 
@@ -31,12 +31,13 @@ The existing ERC 721 token standard is inadequate for representing debt on the b
 
 ##### fulfill
 
-This function should retrieve information about the debt and try to fulfill the transfer of payments in order to fulfill the debt. It must accommodate the fulfillment by calling the transferFrom method of a ERC20 token or if msg.value is positive, fulfill the payment with Ether.  
+This function should retrieve information about the debt and try to fulfill the transfer of payments in order to fulfill the debt. It must accommodate the fulfillment by calling the transferFrom method of a ERC20 token or if msg.value is positive, fulfill the payment with Ether.
 
 * @param debtID - is a unique identifier of a debt inside this contract space
+* @param amount - the amount of the debt denominated in the predetermined currency
 
 ```solidity
-function fulfill(uint256 debtID) public payable;
+function fulfill(uint256 debtID, uint amount) public payable;
 ```
 
 ##### withdraw
@@ -46,13 +47,17 @@ This function should transfer the payment of a specific debtID to the ownerOf(de
 * @param debtID - is an unique identifier of a debt inside this contract space
 
 ```solidity
-function withdraw(uint debt) public;
+function withdraw(uint debtID) public;
 ```
 
 
 ##### status
 
-This function should return the status of a debt based on its time parameters. If the activation date has passed, it should return DebtStatus Materialized. If due date for fulfillment has passed, it should return DebtStatus Defaulted.
+This function should return the status of a debt based on its time parameters:
+* If activation date has not yes passed, it should return DebtStatus Approved.
+* If the activation date has passed, it should return DebtStatus Materialized.
+* If due date for fulfillment has passed and it is not fulfilled, it should return DebtStatus Defaulted.
+* If due date for fulfillment has passed and it is fulfilled, it should return DebtStatus Fulfilled.
 
 * @param debtID - is a unique identifier of a debt inside this contract space
 
@@ -73,25 +78,26 @@ function info(uint256 debtID) public view returns
 
 ##### calculateFulfillment
 
-This function should calculate all specific terms inherent to the debt and return the exact amount one must pay in order to fulfill the debt at the specified time.
+This function should return the exact amount one must pay in order to fulfill the debt at the specified time.
 
 * @param debtID - is an unique identifier of a debt inside this contract space
-* @param fulfillmentTime - the period number to check the fulfillment of
+* @param fulfillmentTime - the time to check the cost of fulfillment at
 
 ```solidity
 function calculateFulfillment(uint256 debtID, uint256 fulfillmentTime) public view returns (uint256 amount);
 ```
 
 ##### changeDebtor
-This function changes the debtor of a debt to msg.sender.  It must have the approval of the owner of the debt (the recipient of the payment) and the new debtor.
+This function changes the debtor of a debt to newDebtor. It must have the approval of the owner of the debt (the recipient of the payment) and the current debtor.
 
 * @param debtID - is an unique identifier of a debt inside this contract space
 * @param newDebtor - the address to make the debtor of all new debt
 * @param nonceNewDebtor - a unique uint for this transaction; used to prevent replay attacks
+* @param nonceDebtor - a unique uint for this transaction; used to prevent replay attacks
 * @param nonceOwner - a unique uint for this transaction; used to prevent replay attacks
-* @param {vND,rND,sND} - ECDSA signature used to verify approval of new debtor
-* @param {vO,rO,sO} - ECDSA signature used to verify approval of the owner of the debt
-
+* @param {v1,r1,s1} - ECDSA signature used to verify approval of newDebtor
+* @param {v2,r2,s2} - ECDSA signature used to verify approval of current debtor
+* @param {v3,r3,s3} - ECDSA signature used to verify approval of the owner of the debt
 
 ```solidity
 function changeDebtor(
@@ -99,12 +105,15 @@ uint256 debtID,
 address newDebtor,
 uint nonceDebtor,
 uint nonceOwner,
-uint8 vND,
-bytes32 rND,
-bytes32 sND,
-uint8 vO,
-bytes32 rO,
-bytes32 sO
+uint8 v1,
+bytes32 r1,
+bytes32 s1,
+uint8 v2,
+bytes32 r2,
+bytes32 s2,
+uint8 v3,
+bytes32 r3,
+bytes32 s3
 )
 public
 returns (bool success);
@@ -125,12 +134,17 @@ function changeDebtContractOwner (uint256 debtID, address newOwner) public;
 
 ##### Debt Created
 ```solidity
-event DebtCreated(uint indexed subscriptionID, uint indexed debtID, uint referencePeriod);
+event DebtCreated(uint indexed debtID, uint indexed debtor, uint indexed creditor, uint amount);
 ```
 
 ##### Debt Fulfilled
 ```solidity
-event DebtFulfilled(uint indexed subscriptionID, uint indexed debtID);
+event DebtFulfilled(uint indexed debtID, uint indexed debtor, uint indexed creditor, uint amount);
+```
+
+##### Debtor Updated
+```solidity
+event DebtorUpdated(uint indexed debtID, uint indexed oldDebtor, uint indexed newDebtor uint creditor;
 ```
 
 #### State


### PR DESCRIPTION
The Ethereum community needs a standard for representing debt on the blockchain because most business transactions utilize the tracking of liabilities in order to facilitate interactions that cannot settle using an atomic swap of two assets. The lack of a standard creates siloed pools of debt that are not interoperable. The adoption of this standard will allow for the creation of valuable applications and protocols to help users manage their debt.