### PR TITLE
Updated solidity syntax in EIP-191 specs

### DIFF
--- a/EIPS/eip-191.md
+++ b/EIPS/eip-191.md
@@ -59,19 +59,23 @@ Using `0x19` thus makes it possible to extend the scheme by defining a version `
 
 ### Example
 
-    function submitTransactionPreSigned(address destination, uint value, bytes data, uint nonce, uint8 v, bytes32 r, bytes32 s)
-        public
-        returns (bytes32 transactionHash)
-    {
-        // Arguments when calculating hash to validate
-        // 1: byte(0x19) - the initial 0x19 byte
-        // 2: byte(0) - the version byte
-        // 3: this - the validator address
-        // 4-7 : Application specific data
-        transactionHash = keccak256(byte(0x19),byte(0),this,destination, value, data, nonce);
-        sender = ecrecover(transactionHash, v, r, s);
-        // ...
-    }
+The following snippet has been written in Solidity 0.5.0.
+
+```solidity
+function submitTransactionPreSigned(address destination, uint value, bytes data, uint nonce, uint8 v, bytes32 r, bytes32 s)
+    public
+    returns (bytes32 transactionHash)
+{
+    // Arguments when calculating hash to validate
+    // 1: byte(0x19) - the initial 0x19 byte
+    // 2: byte(0) - the version byte
+    // 3: this - the validator address
+    // 4-7 : Application specific data
+    transactionHash = keccak256(abi.encodePacked(byte(0x19),byte(0),address(this),destination, value, data, nonce));
+    sender = ecrecover(transactionHash, v, r, s);
+    // ...
+}
+```
 
 ## Copyright
 


### PR DESCRIPTION
As of the latest stable version of solidity (0.4.25), a contract can reference its own address by calling `address(this)` not just `this`. Furthermore, `keccak256` will no longer accept multiple parameters in the future, hence now we need to use `abi.encodePacked`.