### PR TITLE
EIP-1102: add deprecation warning about ethereum#enable

### DIFF
--- a/EIPS/eip-1102.md
+++ b/EIPS/eip-1102.md
@@ -35,6 +35,16 @@ Providers exposed by Ethereum-enabled DOM environments define a new RPC method: 
 ethereum.send('eth_requestAccounts'): Promise<string>
 ```
 
+#### Provider#enable (DEPRECATED)
+
+**Note: This method is deprecated in favor of the RPC method [`eth_requestAccounts`](#eth_requestAccounts).**
+
+Providers exposed by DOM environments define a new enable method that returns a Promise. Calling this method triggers a user interface that allows the user to approve or deny full provider access for a given dapp. The returned Promise is resolved if the user approves full provider access or rejected if the user denies full provider access.
+
+```js
+ethereum.enable(): Promise<any>
+```
+
 ### Protocol
 
 #### Legacy dapp initialization


### PR DESCRIPTION
This pull request updates EIP-1102 with a deprecation warning about `ethereum.enable()` and points developers to the new RPC method `eth_requestAccounts`.