### PR TITLE
Move EIP-1283 status to Accepted

### DIFF
--- a/EIPS/eip-1283.md
+++ b/EIPS/eip-1283.md
@@ -3,8 +3,7 @@ eip: 1283
 title: Net gas metering for SSTORE without dirty maps
 author: Wei Tang (@sorpaas)
 discussions-to: https://github.com/sorpaas/EIPs/issues/1
-status: Last Call
-review-period-end: 2018-10-29
+status: Accepted
 type: Standards Track
 category: Core
 created: 2018-08-01


### PR DESCRIPTION
The Last Call period to 10-29 has ended. So I think it might be fine to move this to Accepted.

### All Changes

The entire set of changes are:

* Minor grammar fixes.
* Clarified in spec that while overall transaction refund counter cannot go negative, call-frame specific refund counter can go negative.
* Added a formal proof!

### All discussions

* @fulldecent raised a question about whether this gas scheme can result in high memory usage because of storage cache. The conclusion is that an attacker (given its goal is to cause as high memory usage as possible) cannot allocate more memory via storage cache -- whenever we need storage cache allocation, the gas cost is the same as current gas scheme, and refund counter cannot be used in current transaction.
* @fulldecent also raised some questions regarding the economics aspect of SSTORE. They may be better suited for *storage rent* discussions.