### PR TITLE
Propose to move EIP-695 to last call status

### DIFF
--- a/EIPS/eip-695.md
+++ b/EIPS/eip-695.md
@@ -5,8 +5,7 @@ author: Isaac Ardis <isaac.ardis@gmail.com>, Wei Tang (@sorpaas), Fan Torchz (@t
 discussions-to: https://ethereum-magicians.org/t/eip-695-create-eth-chainid-method-for-json-rpc/1845
 type: Standards Track
 category: Interface
-status: Last Call
-review-period-end: 2018-11-30
+status: Draft
 created: 2017-08-21
 ---
 

--- a/EIPS/eip-695.md
+++ b/EIPS/eip-695.md
@@ -1,7 +1,7 @@
 ---
 eip: 695
 title: Create `eth_chainId` method for JSON-RPC
-author: Isaac Ardis <isaac.ardis@gmail.com>, Wei Tang <hi@that.world>, Fan Torchz (@tcz001)
+author: Isaac Ardis <isaac.ardis@gmail.com>, Wei Tang (@sorpaas), Fan Torchz (@tcz001)
 discussions-to: https://ethereum-magicians.org/t/eip-695-create-eth-chainid-method-for-json-rpc/1845
 type: Standards Track
 category: Interface

--- a/EIPS/eip-695.md
+++ b/EIPS/eip-695.md
@@ -18,7 +18,7 @@ Include `eth_chainId` method in `eth_`-namespaced JSON-RPC methods.
 
 The `eth_chainId` method should return a single STRING result
 for an integer value in hexadecimal format, describing the
-currently configured "Chain Id" value used for signing replay-protected transactions,
+currently configured `CHAIN_ID` value used for signing replay-protected transactions,
 introduced via [EIP-155](./eip-155.md).
 
 ## Motivation

--- a/EIPS/eip-695.md
+++ b/EIPS/eip-695.md
@@ -4,7 +4,8 @@ title: Create `eth_chainId` method for JSON-RPC
 author: Isaac Ardis <isaac.ardis@gmail.com>, Wei Tang <hi@that.world>, Fan Torchz (@tcz001)
 type: Standards Track
 category: Interface
-status: Draft
+status: Last Call
+review-period-end: 2018-11-30
 created: 2017-08-21
 ---
 

--- a/EIPS/eip-695.md
+++ b/EIPS/eip-695.md
@@ -11,37 +11,40 @@ created: 2017-08-21
 ---
 
 ## Simple Summary
+
 Include `eth_chainId` method in `eth_`-namespaced JSON-RPC methods.
 
 ## Abstract
+
 The `eth_chainId` method should return a single STRING result
 for an integer value in hexadecimal format, describing the
 currently configured "Chain Id" value used for signing replay-protected transactions,
 introduced via [EIP-155](./eip-155.md).
 
 ## Motivation
-Currently although we can use net_version RPC call to get the
+
+Currently although we can use `net_version` RPC call to get the
 current network ID, there's no RPC for querying the chain ID. This
 makes it impossible to determine the current actual blockchain using
 the RPC.
 
 ## Specification
 
-----
-
-### eth_chainId
+### `eth_chainId`
 
 Returns the currently configured chain id, a value used in replay-protected transaction
 signing as introduced by [EIP-155](./eip-155.md).
 
-##### Parameters
-none
+#### Parameters
 
-##### Returns
+None.
 
-`QUANTITY` - integer of the current chain id. Defaults are mainnet=61, morden=62.
+#### Returns
 
-##### Example
+`QUANTITY` - integer of the current chain id.
+
+#### Example
+
 ```js
 curl -X POST --data '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}'
 
@@ -53,33 +56,28 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}
 }
 ```
 
-----
-
 ## Rationale
+
 An ETH/ETC client can accidentally connect to an ETC/ETH RPC
 endpoint without knowing it unless it tries to sign a transaction or
 it fetch a transaction that is known to have signed with a chain
 ID. This has since caused trouble for application developers, such as
 MetaMask, to add multi-chain support.
 
-Please note related links:
-
-- [Parity PR](https://github.com/paritytech/parity/pull/6329)
-- [Geth Classic PR (merged)](https://github.com/ethereumproject/go-ethereum/pull/336)
-
-
 ## Backwards Compatibility
+
 Not relevant.
 
-## Test Cases
-Not currently implemented.
-
 ## Implementation
-Would be good to have a test to confirm that expected==got.
+
+- [Parity PR](https://github.com/paritytech/parity/pull/6329)
+- [Geth PR](https://github.com/ethereum/go-ethereum/pull/17617)
+- [Geth Classic PR](https://github.com/ethereumproject/go-ethereum/pull/336)
 
 ## Reference
 
 Return value `QUANTITY` adheres to standard JSON RPC hex value encoding, as documented here: https://github.com/ethereum/wiki/wiki/JSON-RPC#hex-value-encoding.
 
 ## Copyright
+
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/EIPS/eip-695.md
+++ b/EIPS/eip-695.md
@@ -2,6 +2,7 @@
 eip: 695
 title: Create `eth_chainId` method for JSON-RPC
 author: Isaac Ardis <isaac.ardis@gmail.com>, Wei Tang <hi@that.world>, Fan Torchz (@tcz001)
+discussions-to: https://ethereum-magicians.org/t/eip-695-create-eth-chainid-method-for-json-rpc/1845
 type: Standards Track
 category: Interface
 status: Last Call

--- a/EIPS/eip-695.md
+++ b/EIPS/eip-695.md
@@ -32,7 +32,7 @@ the RPC.
 
 ### `eth_chainId`
 
-Returns the currently configured chain id, a value used in replay-protected transaction
+Returns the currently configured chain ID, a value used in replay-protected transaction
 signing as introduced by [EIP-155](./eip-155.md).
 
 #### Parameters
@@ -41,7 +41,7 @@ None.
 
 #### Returns
 
-`QUANTITY` - integer of the current chain id.
+`QUANTITY` - integer of the current chain ID.
 
 #### Example
 


### PR DESCRIPTION
`eth_chainId` is implemented in geth and parity. And at this moment, for parity, we would want to know whether we can mark this API as standardized or experimental. So I propose to move EIP-695 to last call status.