### PR TITLE
Fix JSON syntax

### DIFF
--- a/EIPS/eip-721.md
+++ b/EIPS/eip-721.md
@@ -202,15 +202,15 @@ This is the "ERC721 Metadata JSON Schema" referenced above.
     "properties": {
         "name": {
             "type": "string",
-            "description": "Identifies the asset to which this NFT represents",
+            "description": "Identifies the asset to which this NFT represents"
         },
         "description": {
             "type": "string",
-            "description": "Describes the asset to which this NFT represents",
+            "description": "Describes the asset to which this NFT represents"
         },
         "image": {
             "type": "string",
-            "description": "A URI pointing to a resource with mime type image/* representing the asset to which this NFT represents. Consider making any images at a width between 320 and 1080 pixels and aspect ratio between 1.91:1 and 4:5 inclusive.",
+            "description": "A URI pointing to a resource with mime type image/* representing the asset to which this NFT represents. Consider making any images at a width between 320 and 1080 pixels and aspect ratio between 1.91:1 and 4:5 inclusive."
         }
     }
 }


### PR DESCRIPTION
While the previous JSON may be valid for some interpreters (like JavaScript's) it's not valid according to [RFC 4627](https://www.ietf.org/rfc/rfc4627.txt) due to the trailing commas [1].

[1] "An object structure is represented [...]. A single comma separates a value from a following name."
