### PR TITLE
Update eip-725.md (every key has one purpose)

### DIFF
--- a/EIPS/eip-725.md
+++ b/EIPS/eip-725.md
@@ -41,14 +41,14 @@ Keys are cryptographic public keys, or contract addresses associated with this i
 The structure should be as follows:
 
 - `key`: A public key owned by this identity
-    - `purpose`: `uint256[]` Array of the key types, like 1 = MANAGEMENT, 2 = ACTION, 3 = CLAIM, 4 = ENCRYPTION
+    - `purpose`: `uint256` The key purpose. e.g.,  1 = MANAGEMENT, 2 = ACTION, 3 = CLAIM, 4 = ENCRYPTION
     - `keyType`: The type of key used, which would be a `uint256` for different key types. e.g. 1 = ECDSA, 2 = RSA, etc.
     - `key`: `bytes32` The public key. // for non-hex and long keys, its the Keccak256 hash of the key 
 
 
 ```js
 struct Key {
-    uint256[] purposes;
+    uint256 purpose;
     uint256 keyType;
     bytes32 key;
 }
@@ -59,7 +59,7 @@ struct Key {
 Returns the full key data, if present in the identity.
 
 ``` js
-function getKey(bytes32 _key) constant returns(uint256[] purposes, uint256 keyType, bytes32 key);
+function getKey(bytes32 _key) constant returns(uint256 purpose, uint256 keyType, bytes32 key);
 ```
 
 #### keyHasPurpose
@@ -280,7 +280,7 @@ contract ERC725 {
         bytes32 key;
     }
 
-    function getKey(bytes32 _key) public constant returns(uint256[] purposes, uint256 keyType, bytes32 key);
+    function getKey(bytes32 _key) public constant returns(uint256 purpose, uint256 keyType, bytes32 key);
     function keyHasPurpose(bytes32 _key, uint256 _purpose) public constant returns (bool exists);
     function getKeysByPurpose(uint256 _purpose) public constant returns (bytes32[] keys);
     function addKey(bytes32 _key, uint256 _purpose, uint256 _keyType) public returns (bool success);


### PR DESCRIPTION
There was an inconsistency between the description and the proposed interface. At the description, the `key` has `uint256[] purposes`. But at the interface, it is `uint256 purpose`. I updated all the places to be to be a `uint256` instead of `uint256[]`.