### PR TITLE
Proposal to add numPackageIds() and numReleaseIds()

### DIFF
--- a/EIPS/eip-1319.md
+++ b/EIPS/eip-1319.md
@@ -1,7 +1,7 @@
 ---
 eip: 1319
 title: Smart Contract Package Registry Interface
-author: Piper Merriam <piper@ethereum.org>, Christopher Gewecke <christophergewecke@gmail.com>, g. nicholas d'andrea <nick.dandrea@consensys.net>
+author: Piper Merriam <piper@ethereum.org>, Christopher Gewecke <christophergewecke@gmail.com>, g. nicholas d'andrea <nick.dandrea@consensys.net>, Nick Gheorghita <nickg@ethereum.org>
 type: Standards Track
 category: ERC
 status: Draft
@@ -103,7 +103,7 @@ The read API consists of a set of methods that allows tooling to extract all con
 // `offset` and `limit` enable paginated responses / retrieval of the complete set.  (See note below)
 function getAllPackageIds(uint offset, uint limit) public view
   returns (
-    bytes32 packageIds,
+    bytes32[] packageIds,
     uint offset
   );
 
@@ -135,6 +135,12 @@ function generateReleaseId(string packageName, string version)
   public
   view
   returns (bytes32);
+
+// Returns the total number of unique packages in a registry.
+function numPackageIds() public view returns (uint totalCount);
+
+// Returns the total number of unique releases belonging to the given packageName in a registry.
+function numReleaseIds(string packageName) public view returns (uint totalCount);
 ```
 **Pagination**
 

--- a/EIPS/eip-1319.md
+++ b/EIPS/eip-1319.md
@@ -94,6 +94,16 @@ details the contents of the release.
 function release(string packageName, string version, string manifestURI) public
   returns (bytes32 releaseId);
 ```
+
+### Events
+
+#### VersionRelease
+MUST be triggered when `release` is successfully called.
+
+```solidity
+event VersionRelease(string packageName, string version, string manifestURI)
+```
+
 ### Read API Specification
 
 The read API consists of a set of methods that allows tooling to extract all consumable data from a registry.


### PR DESCRIPTION
### Proposal to add `numPackageIds()` and `numReleaseIds()` to the standard Read API.

```solidity
// Returns the total number of unique packages in a registry.
function numPackageIds() public view returns (uint totalCount);

 // Returns the total number of unique releases belonging to the given packageName in a registry.
function numReleaseIds(string packageName) public view returns (uint totalCount);
```

This data can be typically found somewhere in a registry implementation (i.e. `ReleaseDB.getNumReleasesForNameHash()` in the [Solidity reference implementation](https://github.com/ethpm/escape-truffle/blob/master/contracts/ReleaseDB.sol)). However, it's quite useful to standardize how this data can be accessed via the primary registry interface since the `totalCount` is used in the pagination scheme of other standard interface functions (`getAllPackageIds()` and `getAllReleaseIds()`).

This pr also corrects a small typo, `getAllPackageIds()` should return an `packageIds` as an array of `bytes32` rather than a single `bytes32` value. And adds myself as an author.

Also included in this PR is an event spec `VersionRelease` to be triggered with every new version that is released.
