### PR TITLE
Add goerli and stureby chain_ids

### DIFF
--- a/EIPS/eip-155.md
+++ b/EIPS/eip-155.md
@@ -66,3 +66,5 @@ This would provide a way to send transactions that work on Ethereum without work
 | 62             | Ethereum Classic testnet                   |
 | 66             | ewasm testnet                              |
 | 1337           | Geth private chains (default)              |
+| 6284           | Görli                                      |
+| 314158         | Stureby                                    |


### PR DESCRIPTION
Adding the chain ids for the two new testnets

**Görli:** (6284)
https://github.com/goerli/testnet

**Stureby:** (314158)
https://gist.github.com/5chdn/baf0eb40cbaff5a90befc52815d6950b