### PR TITLE
Update EIP-1013 with Ropsten fork and progress tracker

### DIFF
--- a/EIPS/eip-1013.md
+++ b/EIPS/eip-1013.md
@@ -28,7 +28,7 @@ This meta-EIP specifies the changes included in the Ethereum hardfork named Cons
 
 ## References
 
-The list above includes the EIPs discussed as candidates for Constantinople at the All Core Dev [Constantinople Session #1](https://github.com/ethereum/pm/issues/55). See also [Constantinople Progress Tracker](https://github.com/ethereum/pm/issues/53).
+The list above includes the EIPs discussed as candidates for Constantinople at the All Core Dev [Constantinople Session #1](https://github.com/ethereum/pm/issues/55). See also [Constantinople Progress Tracker](https://github.com/ethereum/pm/wiki/Constantinople-Progress-Tracker).
 
 ## Copyright
 

--- a/EIPS/eip-1013.md
+++ b/EIPS/eip-1013.md
@@ -17,8 +17,8 @@ This meta-EIP specifies the changes included in the Ethereum hardfork named Cons
 - Codename: Constantinople
 - Aliases: Metropolis/Constantinople, Metropolis part 2
 - Activation:
-  - `Block >= TBD` on the Ethereum mainnet
-  - `Block >= TBD` on the Ropsten testnet
+  - Block >= TBD on the Ethereum mainnet
+  - Block >= 4,230,000 on the Ropsten testnet
 - Included EIPs:
   - [EIP 145](./eip-145.md): Bitwise shifting instructions in EVM
   - [EIP 1014](./eip-1014.md): Skinny CREATE2


### PR DESCRIPTION
Added fork block 4,230,000 and new link to progress tracker on pm-wiki instead of the tracked issue.