### PR TITLE
Revert "last call" status

### DIFF
--- a/EIPS/eip-1283.md
+++ b/EIPS/eip-1283.md
@@ -3,7 +3,7 @@ eip: 1283
 title: Net gas metering for SSTORE without dirty maps
 author: Wei Tang (@sorpaas)
 discussions-to: https://github.com/sorpaas/EIPs/issues/1
-status: Last Call
+status: Draft
 review-period-end: 2018-10-29
 type: Standards Track
 category: Core

--- a/EIPS/eip-820.md
+++ b/EIPS/eip-820.md
@@ -3,7 +3,7 @@ eip: 820
 title: Pseudo-introspection Registry Contract
 author: Jordi Baylina <jordi@baylina.cat>, Jacques Dafflon <jacques@dafflon.tech>
 discussions-to: https://github.com/ethereum/EIPs/issues/820
-status: Last Call
+status: Draft
 type: Standards Track
 category: ERC
 requires: 165, 214


### PR DESCRIPTION
These EIPs have been in "last call" for more than two weeks, with no updates from their author justifying moving to final, or back to draft. As a result, this PR moves them back to draft state.