### PR TITLE
Renaming LDGRToken to ERC-1450

### DIFF
--- a/EIPS/eip-1450.md
+++ b/EIPS/eip-1450.md
@@ -1,6 +1,6 @@
 ---
 eip: 1450
-title: LDGRToken
+title: ERC-1450
 author: John Shiple (@johnshiple), Howard Marks <howard@startengine.com>, David Zhang <david@startengine.com>
 discussions-to: https://ethereum-magicians.org/t/erc-proposal-ldgrtoken-a-compatible-security-token-for-issuing-and-trading-sec-compliant-securities/1468
 status: Draft
@@ -9,15 +9,15 @@ category: ERC
 created: 2018-09-25
 ---
 
-# LDGRToken - A compatible security token for issuing and trading SEC-compliant securities
+# ERC-1450 - A compatible security token for issuing and trading SEC-compliant securities
 
 ## Simple Summary
-`LDGRToken` is an `ERC-20` compatible token that enables issuing tokens representing securities that are required to comply with one or more of the following [Securities Act Regulations: Regulation Crowdfunding, Regulation D, and Regulation A](https://www.sec.gov/smallbusiness/exemptofferings).
+`ERC-1450` is an `ERC-20` compatible token that enables issuing tokens representing securities that are required to comply with one or more of the following [Securities Act Regulations: Regulation Crowdfunding, Regulation D, and Regulation A](https://www.sec.gov/smallbusiness/exemptofferings).
 
 ## Abstract
-`LDGRToken` facilitates the recording of ownership and transfer of securities sold in compliance with the [Securities Act Regulations CF, D and A](https://www.sec.gov/smallbusiness/exemptofferings). The issuance and trading of securities is subject to the Securities Exchange Commission (SEC) and specific U.S. state blue sky laws and regulations.
+`ERC-1450` facilitates the recording of ownership and transfer of securities sold in compliance with the [Securities Act Regulations CF, D and A](https://www.sec.gov/smallbusiness/exemptofferings). The issuance and trading of securities is subject to the Securities Exchange Commission (SEC) and specific U.S. state blue sky laws and regulations.
 
-`LDGRToken` manages securities ownership during issuance and trading. The Issuer is the only role that should create a `LDGRToken` and assign the RTA. The RTA is the only role that is allowed to execute `LDGRToken`’s `mint`, `burnFrom`, and `transferFrom` functions. No role is allowed to execute `LDGRToken`’s `transfer` function.
+`ERC-1450` manages securities ownership during issuance and trading. The Issuer is the only role that should create a `ERC-1450` and assign the RTA. The RTA is the only role that is allowed to execute `ERC-1450`’s `mint`, `burnFrom`, and `transferFrom` functions. No role is allowed to execute `ERC-1450`’s `transfer` function.
 
 ## Motivation
 With the advent of the [JOBS Act](https://www.sec.gov/spotlight/jobs-act.shtml) in 2012 and the launch of Regulation Crowdfunding and the amendments to Regulation A and Regulation D in 2016, there has been an expansion in the exemptions available to Issuers and Investors to sell and purchase securities that have not been "registered" with the SEC under the Securities Act of 1933.
@@ -25,29 +25,29 @@ With the advent of the [JOBS Act](https://www.sec.gov/spotlight/jobs-act.shtml) 
 There are currently no token standards that expressly facilitate conformity to securities law and related regulations. ERC-20 tokens do not support the regulated roles of Funding Portal, Broker Dealer, RTA, and Investor and do not support the [Bank Secrecy Act/USA Patriot Act KYC and AML requirements](https://www.occ.treas.gov/topics/compliance-bsa/bsa/index-bsa.html). Other improvements (notably [EIP-1404 (Simple Restricted Token Standard)](https://github.com/ethereum/EIPs/issues/1404) have tried to tackle KYC and AML regulatory requirement. This approach is novel because the RTA is solely responsible for performing KYC and AML and should be solely responsible for `transferFrom`, `mint`, and `burnFrom`.
 
 ## Specification
-`LDGRToken` extends `ERC-20`.
+`ERC-1450` extends `ERC-20`.
 
-### `LDGRToken`
-`LDGRToken` requires that only the Issuer can create a token representing the security that only the RTA manages. Instantiating the `LDGRToken` requires the `Owned` and `IssuerControlled` modifiers, and only the Issuer should execute the `LDGRToken` constructor for a compliant token. `LDGRToken` extends the general `Ownable` modifier to describe a specific subset of owners that automate and decentralize compliance through the contract modifiers `Owned` and `IssuerControlled` and the function modifiers `onlyOwner` and `onlyIssuerTransferAgent`. The `Owned` contract modifier instantiates the `onlyOwner` modifier for functions. The `IssuerControlled` modifier instantiates the `onlyIssuerTransferAgent` modifier for functions.
+### `ERC-1450`
+`ERC-1450` requires that only the Issuer can create a token representing the security that only the RTA manages. Instantiating the `ERC-1450` requires the `Owned` and `IssuerControlled` modifiers, and only the Issuer should execute the `ERC-1450` constructor for a compliant token. `ERC-1450` extends the general `Ownable` modifier to describe a specific subset of owners that automate and decentralize compliance through the contract modifiers `Owned` and `IssuerControlled` and the function modifiers `onlyOwner` and `onlyIssuerTransferAgent`. The `Owned` contract modifier instantiates the `onlyOwner` modifier for functions. The `IssuerControlled` modifier instantiates the `onlyIssuerTransferAgent` modifier for functions.
 
-`LDGRToken` must prevent anyone from executing the `transfer`, `allowance`, and `approve` functions and/or implement these functions to always fail. `LDGRToken` updates the `transferFrom`, `mint`, and `burnFrom` functions. `transferFrom`, `mint`, and `burnFrom` may only be executed by the RTA and are restricted with the `onlyIssuerTransferAgent` modifier. Additionally, `LDGRToken` defines the functions `transferOwnership`, `setTransferAgent`, `setPhysicalAddressOfOperation`, and `isTransferAgent`.  Only the issuer may call the `transferOwnership`, `setTransferAgent`, and `setPhysicalAddressOfOperation` functions. Anyone may call the `isTransferAgent` function.
+`ERC-1450` must prevent anyone from executing the `transfer`, `allowance`, and `approve` functions and/or implement these functions to always fail. `ERC-1450` updates the `transferFrom`, `mint`, and `burnFrom` functions. `transferFrom`, `mint`, and `burnFrom` may only be executed by the RTA and are restricted with the `onlyIssuerTransferAgent` modifier. Additionally, `ERC-1450` defines the functions `transferOwnership`, `setTransferAgent`, `setPhysicalAddressOfOperation`, and `isTransferAgent`.  Only the issuer may call the `transferOwnership`, `setTransferAgent`, and `setPhysicalAddressOfOperation` functions. Anyone may call the `isTransferAgent` function.
 
 ### Issuers and RTAs
-For compliance reasons, the `LDGRToken` constructor must specify the issuer (the `owner`), the RTA (`transferAgent`), the security’s `name`, and the security’s `symbol`.
+For compliance reasons, the `ERC-1450` constructor must specify the issuer (the `owner`), the RTA (`transferAgent`), the security’s `name`, and the security’s `symbol`.
 
 #### Issuer Owned
-`LDGRToken` must specify the `owner` in its constructor, apply the `Owned` modifier, and instantiate the `onlyOwner` modifier to enable specific functions to permit only the Issuer’s `owner` address to execute them. `LDGRToken` also defines the function `transferOwnership` which transfers ownership of the Issuer to the new `owner`’s address and can only be called by the `owner`. `transferOwnership` triggers the `OwnershipTransferred` event.
+`ERC-1450` must specify the `owner` in its constructor, apply the `Owned` modifier, and instantiate the `onlyOwner` modifier to enable specific functions to permit only the Issuer’s `owner` address to execute them. `ERC-1450` also defines the function `transferOwnership` which transfers ownership of the Issuer to the new `owner`’s address and can only be called by the `owner`. `transferOwnership` triggers the `OwnershipTransferred` event.
 
 #### Issuer Controlled
-`IssuerControlled` maintains the Issuer’s ownership of their securities by owning the contract and enables the Issuer to set and update the RTA for the Issuer’s securities. `LDGRToken`‘s constructor must have an `IssuerControlled` modifier with the issuer specified in its `LDGRToken` constructor. `IssuerControlled` instantiates the `onlyIssuerTransferAgent` modifier for `LDGRToken` to enable specific functions (`setPhysicalAddressOfOperation` and `setTransferAgent`) to permit only the Issuer to execute these functions.
+`IssuerControlled` maintains the Issuer’s ownership of their securities by owning the contract and enables the Issuer to set and update the RTA for the Issuer’s securities. `ERC-1450`‘s constructor must have an `IssuerControlled` modifier with the issuer specified in its `ERC-1450` constructor. `IssuerControlled` instantiates the `onlyIssuerTransferAgent` modifier for `ERC-1450` to enable specific functions (`setPhysicalAddressOfOperation` and `setTransferAgent`) to permit only the Issuer to execute these functions.
 
 #### Register Transfer Agent Controlled
-`LDGRToken` defines the `setTransferAgent` function (to change the RTA) and `setPhysicalAddressOfOperation` function (to change the Issuer’s address) and must restrict execution to the Issuer’s owner with the `onlyOwner` modifier. `setTransferAgent` must emit the `TransferAgentUpdated` event. `setPhysicalAddressOfOperation` must emit the `PhysicalAddressOfOperationUpdated` event.
+`ERC-1450` defines the `setTransferAgent` function (to change the RTA) and `setPhysicalAddressOfOperation` function (to change the Issuer’s address) and must restrict execution to the Issuer’s owner with the `onlyOwner` modifier. `setTransferAgent` must emit the `TransferAgentUpdated` event. `setPhysicalAddressOfOperation` must emit the `PhysicalAddressOfOperationUpdated` event.
 
-`LDGRToken` must specify the `transferAgent` in its constructor and instantiate the `onlyIssuerTransferAgent` modifier to enable specific functions (`transferFrom`, `mint`, and `burnFrom`) to permit only the Issuer’s `transferAgent` address to execute them. `LDGRToken` also defines the public function `isTransferAgent` to lookup and identify the Issuer’s RTA.
+`ERC-1450` must specify the `transferAgent` in its constructor and instantiate the `onlyIssuerTransferAgent` modifier to enable specific functions (`transferFrom`, `mint`, and `burnFrom`) to permit only the Issuer’s `transferAgent` address to execute them. `ERC-1450` also defines the public function `isTransferAgent` to lookup and identify the Issuer’s RTA.
 
 #### Securities
-`LDGRToken` updates the `transferFrom`, `mint`, and `burnFrom` functions by applying the `onlyIssuerTransferAgent` to enable the issuance, re-issuance, and trading of securities.
+`ERC-1450` updates the `transferFrom`, `mint`, and `burnFrom` functions by applying the `onlyIssuerTransferAgent` to enable the issuance, re-issuance, and trading of securities.
 
 ### ERC-20 Extension
 `ERC-20` tokens provide the following functionality:
@@ -69,15 +69,15 @@ contract ERC20 {
 
 ```
 /**
- * LDGRToken is an ERC-20 compatible token that facilitates compliance with one or more of Securities Act Regulations CF, D and A. 
+ * ERC-1450 is an ERC-20 compatible token that facilitates compliance with one or more of Securities Act Regulations CF, D and A. 
  *
- * Implementations of the LDGRToken standard must define the following optional ERC-20
+ * Implementations of the ERC-1450 standard must define the following optional ERC-20
  *     fields:
  * 
  * name - The name of the security
  * symbol - The symbol of the security
  * 
- * Implementations of the LDGRToken standard must specify the following constructor
+ * Implementations of the ERC-1450 standard must specify the following constructor
  *   arguments:
  * 
  * _owner - the address of the owner
@@ -85,14 +85,14 @@ contract ERC20 {
  * _name - the name of the security
  * _symbol - the symbol of the security
  *  
- *  Implementations of the LDGRToken standard must implement the following contract
+ *  Implementations of the ERC-1450 standard must implement the following contract
  *      modifiers:
  * 
  * Owned - Only the address of the security’s issuer is permitted to execute the
  *     token’s constructor. This modifier also sets up the onlyOwner function modifier.
  * IssuerControlled - This modifier sets up the onlyIssuerTransferAgent function modifier.
  * 
- * Implementations of the LDGRToken standard must implement the following function
+ * Implementations of the ERC-1450 standard must implement the following function
  *      modifiers:
  * 
  * onlyOwner - Only the address of the security’s issuer is permitted to execute the
@@ -100,13 +100,13 @@ contract ERC20 {
  * onlyIssuerTransferAgent - Only the address of the issuer’s Registered Transfer
  *     Agent is permitted to execute the functions transferFrom, mint, and burnFrom.
  * 
- * Implementations of the LDGRToken standard must implement the following required ERC-20
+ * Implementations of the ERC-1450 standard must implement the following required ERC-20
  *     event to always fail:
  * 
  * Approval - Should never be called as the functions that emit this event must be
  *     implemented to always fail. 
  * 
- * Implementations of the LDGRToken standard must implement the following required
+ * Implementations of the ERC-1450 standard must implement the following required
  *     ERC-20 functions to always fail:
  * 
  * transfer - Not a legal, regulated call for transferring securities because
@@ -119,11 +119,11 @@ contract ERC20 {
  *     the token holder may not allow third parties to initiate token transfers. The
  *     function must be implemented to always fail.
  * 
- * Implementations of the LDGRToken standard must implement the following optional
+ * Implementations of the ERC-1450 standard must implement the following optional
  *     ERC-20 function:
  * decimals - Must return '0' because securities are indivisible entities.
  * 
- * Implementations of the LDGRToken standard must implement the following functions:
+ * Implementations of the ERC-1450 standard must implement the following functions:
  * 
  * mint - Only the address of the issuer's Registered Transfer Agent may create new
  *     securities.
@@ -131,7 +131,7 @@ contract ERC20 {
  *     destroy securities.
  */
 
-Contract LDGRToken is Owned, IssuerControlled {
+Contract ERC-1450 is Owned, IssuerControlled {
 
   /**
    * The constructor must implement a modifier (Owned) that creates the onlyOwner modifier
@@ -240,7 +240,7 @@ Contract LDGRToken is Owned, IssuerControlled {
      * Transfer securities.
      *
      * transferFrom must implement the onlyIssuerTransferAgent modifier to only allow the
-     *     address of the issuer’s Registered Transfer Agent to transfer `LDGRToken`s.
+     *     address of the issuer’s Registered Transfer Agent to transfer `ERC-1450`s.
      * transferFrom requires the _from address to have _value tokens.
      * transferFrom requires that the _to address must not be 0 because securities must
      *     not destroyed in this manner.
@@ -252,7 +252,7 @@ Contract LDGRToken is Owned, IssuerControlled {
      * Create new securities.
      *
      * mint must implement the onlyIssuerTransferAgent modifier to only allow the address
-     *     of the issuer’s Registered Transfer Agent to mint `LDGRToken`s.
+     *     of the issuer’s Registered Transfer Agent to mint `ERC-1450` tokens.
      * mint requires that the _to address must not be 0 because securities must
      *     not destroyed in this manner.
      * mint must add _value tokens to the _to address and increase the totalSupply by
@@ -266,7 +266,7 @@ Contract LDGRToken is Owned, IssuerControlled {
      * Burn or destroy securities.
      *
      * burnFrom must implement the onlyIssuerTransferAgent modifier to only allow the
-     *     address of the issuer’s Registered Transfer Agent to burn `LDGRToken`s.
+     *     address of the issuer’s Registered Transfer Agent to burn `ERC-1450`s.
      * burnFrom requires the _from address to have _value tokens.
      * burnFrom must subtract _value tokens from the _from address and decrease the
      *     totalSupply by _value.
@@ -290,7 +290,7 @@ Special care and attention must be taken to ensure that the personally identifia
 ### Issuers who lost access to their address or private keys
 There is no recourse if the Issuer loses access to their address to an existing instance of their securities. Special care and efforts must be made by the Issuer to secure and safely store their address and associated private key. The Issuer can reassign ownership to another Issuer but not in the case where the Issuer loses their private key.
 
-If the Issuer loses access, the Issuer’s securities must be rebuilt using off-chain services. The Issuer must create (and secure) a new address. The RTA can read the existing Issuer securities, and the RTA can `mint` Investor securities accordingly under a new `LDGRToken` smart contract.
+If the Issuer loses access, the Issuer’s securities must be rebuilt using off-chain services. The Issuer must create (and secure) a new address. The RTA can read the existing Issuer securities, and the RTA can `mint` Investor securities accordingly under a new `ERC-1450` smart contract.
 
 ### Registered Transfer Agents who lost access to their address or private keys
 If the RTA loses access, the RTA can create a new Ethereum address, and the Issuer can execute the `setTransferAgent` function to reassign the RTA.
@@ -304,7 +304,7 @@ If an Investor (or, say, the Investor’s heir) loses their credentials, the Inv
 The are currently no token standards that faciliate compliance with SEC regulations. The closest token is [ERC-884 (Delaware General Corporations Law (DGCL) compatible share token)](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-884.md) which states that SEC requirements are out of scope. [EIP-1404 (Simple Restricted Token Standard)](https://github.com/ethereum/EIPs/issues/1404) does not go far enough to address SEC requirements around re-issuing securities to Investors.
 
 ## Backwards Compatibility
-`LDGRToken` maintains compatibility with ERC-20 tokens with the following stipulations:
+`ERC-1450` maintains compatibility with ERC-20 tokens with the following stipulations:
 * `function allowance(address tokenOwner, address spender) public constant returns (uint remaining);`
   * Must be implemented to always fail because allowance is not a legal, regulated call for a security.
 * `function transfer(address to, uint tokens) public returns (bool success);`


### PR DESCRIPTION
We are removing the references to LDGRToken to make sure this ERC is a standard and not interpreted as a custom company token project.