### PR TITLE
Fix Wrong Input Length - ERC165 Example

### DIFF
--- a/EIPS/eip-165.md
+++ b/EIPS/eip-165.md
@@ -150,7 +150,7 @@ contract ERC165Query {
                                     30000,         // 30k gas
                                     _contract,     // To addr
                                     x,             // Inputs are stored at location x
-                                    0x20,          // Inputs are 32 bytes long
+                                    0x24,          // Inputs are 36 bytes long
                                     x,             // Store output over input (saves space)
                                     0x20)          // Outputs are 32 bytes long
 

--- a/EIPS/eip-165.md
+++ b/EIPS/eip-165.md
@@ -225,7 +225,7 @@ contract Homer is ERC165, Simpson {
 With three or more supported interfaces (including ERC165 itself as a required supported interface), the mapping approach (in every case) costs less gas than the pure approach (at worst case).
 
 ## Version history
-* EIP 1640, finalized 2019-01-23 -- This corrects the noThrowCall test case to use 36 bytes rather than the previous 32 bytes. The previous code was an error that still silently worked in Solidity 0.4.x but which was broken by new behavior introduced in Solidity 0.5.0. This change was discussed at [#1640](https://github.com/ethereum/EIPs/pull/1640).
+* PR 1640, finalized 2019-01-23 -- This corrects the noThrowCall test case to use 36 bytes rather than the previous 32 bytes. The previous code was an error that still silently worked in Solidity 0.4.x but which was broken by new behavior introduced in Solidity 0.5.0. This change was discussed at [#1640](https://github.com/ethereum/EIPs/pull/1640).
 
 * EIP 165, finalized 2018-04-20 -- Original published version.
 

--- a/EIPS/eip-165.md
+++ b/EIPS/eip-165.md
@@ -224,6 +224,11 @@ contract Homer is ERC165, Simpson {
 
 With three or more supported interfaces (including ERC165 itself as a required supported interface), the mapping approach (in every case) costs less gas than the pure approach (at worst case).
 
+## Version history
+* EIP 1640, finalized 2019-01-23 -- This corrects the noThrowCall test case to use 36 bytes rather than the previous 32 bytes. The previous code was an error that still silently worked in Solidity 0.4.x but which was broken by new behavior introduced in Solidity 0.5.0. This change was discussed at [#1640](https://github.com/ethereum/EIPs/pull/1640).
+
+* EIP 165, finalized 2018-04-20 -- Original published version.
+
 ## Copyright
 
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
```
eip: 165 v1.0.1
title: Fix Wrong Input Length - ERC165 Example
author: Agustin Aguilar (@Agusx1211)
type: Standards Track
category: ERC
status: --
created: 2018-12-07
```

Input should be 36 bytes (4 signature bytes + 32 bytes parameter)

Solidity 5 validates the length of msg.data, reverting on the 32 bytes input, all contracts using the broken 'doesContractImplementInterface' will not be able to read an ERC165 implementation targetting Solidity 5.

A legacy-compatible strategy should be defined to make all the "ERC165 readers" sending a 32 bytes sized data compatible with ERC165 contracts compiled targeting this new version of the compiler.

A possible solution could be to add a keyword on Solidity to disable the validation of the calldata length on a given function.
