### PR TITLE
Use new preferred citation format

### DIFF
--- a/EIPS/eip-20-token-standard.md
+++ b/EIPS/eip-20-token-standard.md
@@ -1,1 +1,1 @@
-Moved to [eip-20.md](./eip-20.md).
+Moved to [EIP 20](https://eips.ethereum.org/EIPS/eip-20).


### PR DESCRIPTION
Preferred citation format is specified at https://github.com/ethereum/EIPs#preferred-citation-format