### PR TITLE
ERC820: Move to Final

### DIFF
--- a/EIPS/eip-820.md
+++ b/EIPS/eip-820.md
@@ -3,12 +3,11 @@ eip: 820
 title: Pseudo-introspection Registry Contract
 author: Jordi Baylina <jordi@baylina.cat>, Jacques Dafflon <jacques@dafflon.tech>
 discussions-to: https://github.com/ethereum/EIPs/issues/820
-status: Last Call
+status: Final
 type: Standards Track
 category: ERC
 requires: 165, 214
 created: 2018-01-05
-review-period-end: 2018-12-30
 ---
 
 ## Simple Summary


### PR DESCRIPTION
The Last Call period for ERC820 ended on 2018-12-30 without further comments, suggestions or modifications. Hence I would like to move 820 to a final status.

I'd also like to thank everyone who contributed and helped with ERC820, (including in no particular order): @fulldecent @mcdee @jaycenhorton @Recmo @hyperfekt @wighawag @thegostep @Arachnid @Souptacular and everyone I forget.