### PR TITLE
Update EIP-1066 to v1.0.0 (#6)

### DIFF
--- a/EIPS/eip-1066.md
+++ b/EIPS/eip-1066.md
@@ -7,6 +7,7 @@ status: Draft
 type: Standards Track
 category: ERC
 created: 2018-05-05
+version: 1.0.0
 ---
 
 ## Simple Summary
@@ -35,7 +36,7 @@ _End users get little to no feedback, and there is no translation layer._
 
 Since ERC1066 status codes are finite and known in advance, we can leverage [ERC1444](https://eips.ethereum.org/EIPS/eip-1444) to provide global, human-readable sets of status messages. These may also be translated into any language, differing levels of technical detail, added as `revert` messages, natspecs, and so on.
 
-We also see a desire for this [in transactions](http://eips.ethereum.org/EIPS/eip-658), and there's no reason that status codes couldn't be used by the EVM itself.
+Status codes convey a much richer set of information than Booleans, and are able to be reacted to autonomously unlike arbitrary strings.
 
 ### Developer Experience (DX)
 
@@ -44,6 +45,8 @@ _Developers currently have very little context exposed by their smart contracts.
 At time of writing, other than stepping through EVM execution and inspecting memory dumps directly, it is very difficult to understand what is happening during smart contract execution. By returning more context, developers can write well-decomposed tests and assert certain codes are returned as an expression of where the smart contract got to. This includes status codes as bare values, `event`s, and `revert`s.
 
 Having a fixed set of codes also makes it possible to write common helper functions to react in common ways to certain signals. This can live off- or on-chain library, lowering the overhead in building smart contracts, and helping raise code quality with trusted shared components.
+
+We also see a desire for this [in transactions](http://eips.ethereum.org/EIPS/eip-658), and there's no reason that these status codes couldn't be used by the EVM itself.
 
 ### Smart Contract Autonomy
 
@@ -94,120 +97,139 @@ Codes break nicely into a 16x16 matrix, represented as a 2-digit hex number. The
 
 General codes. These double as bare "reasons", since `0x01 == 1`.
 
-|  Code           | Description             |
-|-----------------|:------------------------|
-| `0x00`          | Failure                 |
-| `0x01`          | Success                 |
-| `0x02`          | Accepted / Started      |
-| `0x03`          | Awaiting / Before       |
-| `0x04`          | Action Required         |
-| `0x05`          | Expired                 |
-| `0x06`          | [reserved]              |
-| `0x07`          | [reserved]              |
-| `0x08`          | [reserved]              |
-| `0x09`          | [reserved]              |
-| `0x0A`          | [reserved]              |
-| `0x0B`          | [reserved]              |
-| `0x0C`          | [reserved]              |
-| `0x0D`          | [reserved]              |
-| `0x0E`          | [reserved]              |
-| `0x0F`          | Meta or Info Only       |
+| Code   | Description                             |
+|--------|-----------------------------------------|
+| `0x00` | Failure                                 |
+| `0x01` | Success                                 |
+| `0x02` | Awaiting Others                         |
+| `0x03` | Accepted                                |
+| `0x04` | Lower Limit or Insufficient             |
+| `0x05` | Reciever Action Requested               |
+| `0x06` | Upper Limit                             |
+| `0x07` | [reserved]                              |
+| `0x08` | Duplicate, Unnessesary, or Inapplicable |
+| `0x09` | [reserved]                              |
+| `0x0A` | [reserved]                              |
+| `0x0B` | [reserved]                              |
+| `0x0C` | [reserved]                              |
+| `0x0D` | [reserved]                              |
+| `0x0E` | [reserved]                              |
+| `0x0F` | Informational or Metadata               |
 
-#### `0x1*` Permission
+#### `0x1*` Permission & Control
 
-Related to permisson, authorization, approval, and so on.
+Also used for common state machine actions (ex. "stoplight" actions).
 
-|  Code           | Description              |
-|-----------------|:-------------------------|
-| `0x10`          | Disallowed               |
-| `0x11`          | Allowed                  |
-| `0x12`          | Requested Permission     |
-| `0x13`          | Awaiting Permission      |
-| `0x14`          | Awaiting Your Permission |
-| `0x15`          | No Longer Allowed        |
-| `0x16`          | [reserved]               |
-| `0x17`          | [reserved]               |
-| `0x18`          | [reserved]               |
-| `0x19`          | [reserved]               |
-| `0x1A`          | [reserved]               |
-| `0x1B`          | [reserved]               |
-| `0x1C`          | [reserved]               |
-| `0x1D`          | [reserved]               |
-| `0x1E`          | [reserved]               |
-| `0x1F`          | Permission Meta or Info  |
+| Code   | Description                                       |
+|--------|---------------------------------------------------|
+| `0x10` | Disallowed or Stop                                |
+| `0x11` | Allowed or Go                                     |
+| `0x12` | Awaiting Other's Permission                       |
+| `0x13` | Permission Requested                              |
+| `0x14` | Too Open / Insecure                               |
+| `0x15` | Needs Your Permission or Request for Continuation |
+| `0x16` | Revoked or Banned                                 |
+| `0x17` | [reserved]                                        |
+| `0x18` | Not Applicatable to Current State                 |
+| `0x19` | [reserved]                                        |
+| `0x1A` | [reserved]                                        |
+| `0x1B` | [reserved]                                        |
+| `0x1C` | [reserved]                                        |
+| `0x1D` | [reserved]                                        |
+| `0x1E` | [reserved]                                        |
+| `0x1F` | Permission Details or Control Conditions          |
 
-#### `0x2*` Find, Match, &c
+#### `0x2*` Find, Inequalities & Range
 
 This range is broadly intended for finding and matching. Data lookups and order matching are two common use cases.
 
-|  Code           | Description              |
-|-----------------|:-------------------------|
-| `0x20`          | Not Found                |
-| `0x21`          | Found                    |
-| `0x22`          | Match Request Sent       |
-| `0x23`          | Awaiting Match           |
-| `0x24`          | Match Request Received   |
-| `0x25`          | Out of Range             |
-| `0x26`          | [reserved]               |
-| `0x27`          | [reserved]               |
-| `0x28`          | [reserved]               |
-| `0x29`          | [reserved]               |
-| `0x2A`          | [reserved]               |
-| `0x2B`          | [reserved]               |
-| `0x2C`          | [reserved]               |
-| `0x2D`          | [reserved]               |
-| `0x2E`          | [reserved]               |
-| `0x2F`          | Matching Meta or Info    |
+| Code   | Description                         |
+|--------|-------------------------------------|
+| `0x20` | Not Found, Unequal, or Out of Range |
+| `0x21` | Found, Equal or In Range            |
+| `0x22` | Awaiting Match                      |
+| `0x23` | Match Request Sent                  |
+| `0x24` | Below Range or Underflow            |
+| `0x25` | Request for Match                   |
+| `0x26` | Above Range or Overflow             |
+| `0x27` | [reserved]                          |
+| `0x28` | Duplicate, Conflict, or Collision   |
+| `0x29` | [reserved]                          |
+| `0x2A` | [reserved]                          |
+| `0x2B` | [reserved]                          |
+| `0x2C` | [reserved]                          |
+| `0x2D` | [reserved]                          |
+| `0x2E` | [reserved]                          |
+| `0x2F` | Matching Meta or Info               |
 
-#### `0x3*` Negotiation, Terms, and Offers
+#### `0x3*` Negotiation & Governance
 
 Negotiation, and very broadly the flow of such transactions. Note that "other party" may be more than one actor (not necessarily the sender).
 
-|  Code           | Description                 |
-|-----------------|:----------------------------|
-| `0x30`          | Other Party Disagreed       |
-| `0x31`          | Other Party Agreed          |
-| `0x32`          | Sent Offer                  |
-| `0x33`          | Awaiting Their Ratification |
-| `0x34`          | Awaiting Your Ratification  |
-| `0x35`          | Offer Expired               |
-| `0x36`          | [reserved]                  |
-| `0x37`          | [reserved]                  |
-| `0x38`          | [reserved]                  |
-| `0x39`          | [reserved]                  |
-| `0x3A`          | [reserved]                  |
-| `0x3B`          | [reserved]                  |
-| `0x3C`          | [reserved]                  |
-| `0x3D`          | [reserved]                  |
-| `0x3E`          | [reserved]                  |
-| `0x3F`          | Negotiation Meta or Info    |
+| Code   | Description                             |
+|--------|-----------------------------------------|
+| `0x30` | Sender Disagrees or Nay                 |
+| `0x31` | Sender Agrees or Yea                    |
+| `0x32` | Awaiting Ratification                   |
+| `0x33` | Offer Sent or Voted                     |
+| `0x34` | Quorum Not Reached                      |
+| `0x35` | Receiver's Ratification Requested       |
+| `0x36` | Offer or Vote Limit Reached             |
+| `0x37` | [reserved]                              |
+| `0x38` | Already Voted                           |
+| `0x39` | [reserved]                              |
+| `0x3A` | [reserved]                              |
+| `0x3B` | [reserved]                              |
+| `0x3C` | [reserved]                              |
+| `0x3D` | [reserved]                              |
+| `0x3E` | [reserved]                              |
+| `0x3F` | Negotiation Rules or Participation Info |
 
-#### `0x4*` Availability
+#### `0x4*` Availability & Time
 
 Service or action availability.
 
-|  Code           | Description                 |
-|-----------------|:----------------------------|
-| `0x40`          | Unavailable                 |
-| `0x41`          | Available                   |
-| `0x42`          | You May Begin               |
-| `0x43`          | Not Yet Available           |
-| `0x44`          | Awaiting Your Availability  |
-| `0x45`          | No Longer Available         |
-| `0x46`          | [reserved]                  |
-| `0x47`          | [reserved]                  |
-| `0x48`          | [reserved]                  |
-| `0x49`          | [reserved]                  |
-| `0x4A`          | [reserved]                  |
-| `0x4B`          | [reserved]                  |
-| `0x4C`          | [reserved]                  |
-| `0x4D`          | [reserved]                  |
-| `0x4E`          | [reserved]                  |
-| `0x4F`          | Availability Meta or Info   |
+| Code   | Description                                          |
+|--------|------------------------------------------------------|
+| `0x40` | Unavailable                                          |
+| `0x41` | Available                                            |
+| `0x42` | Paused                                               |
+| `0x43` | Queued                                               |
+| `0x44` | Not Available Yet                                    |
+| `0x45` | Awaiting Your Availability                           |
+| `0x46` | Expired                                              |
+| `0x47` | [reserved]                                           |
+| `0x48` | Already Done                                         |
+| `0x49` | [reserved]                                           |
+| `0x4A` | [reserved]                                           |
+| `0x4B` | [reserved]                                           |
+| `0x4C` | [reserved]                                           |
+| `0x4D` | [reserved]                                           |
+| `0x4E` | [reserved]                                           |
+| `0x4F` | Availability Rules or Info (ex. time since or until) |
 
-#### `0x5*` TBD
+#### `0x5*` Tokens, Funds & Finance
 
-Currently unspecified. (Full range reserved)
+Special token and financial concepts. Many related concepts are included in other ranges.
+
+| Code   | Description                     |
+|--------|---------------------------------|
+| `0x50` | Transfer Failed                 |
+| `0x51` | Transfer Successful             |
+| `0x52` | Awaiting Payment From Others    |
+| `0x53` | Hold or Escrow                  |
+| `0x54` | Insufficient Funds              |
+| `0x55` | Funds Requested                 |
+| `0x56` | Transfer Volume Exceeded        |
+| `0x57` | [reserved]                      |
+| `0x58` | Funds Not Required              |
+| `0x59` | [reserved]                      |
+| `0x5A` | [reserved]                      |
+| `0x5B` | [reserved]                      |
+| `0x5C` | [reserved]                      |
+| `0x5D` | [reserved]                      |
+| `0x5E` | [reserved]                      |
+| `0x5F` | Token or Fiunancial Information |
 
 #### `0x6*` TBD
 
@@ -229,24 +251,24 @@ Currently unspecified. (Full range reserved)
 
 Contracts may have special states that they need to signal. This proposal only outlines the broadest meanings, but implementers may have very specific meanings for each, as long as they are coherent with the broader definition.
 
-|  Code           | Description                     |
-|-----------------|:--------------------------------|
-| `0xA0`          | App-Specific Failure            |
-| `0xA1`          | App-Specific Success            |
-| `0xA2`          | App-Specific Acceptance / Start |
-| `0xA3`          | App-Specific Awaiting / Before  |
-| `0xA4`          | App-Specific Action Required    |
-| `0xA5`          | App-Specific Expiry             |
-| `0xA6`          | [reserved]                      |
-| `0xA7`          | [reserved]                      |
-| `0xA8`          | [reserved]                      |
-| `0xA9`          | [reserved]                      |
-| `0xAA`          | [reserved]                      |
-| `0xAB`          | [reserved]                      |
-| `0xAC`          | [reserved]                      |
-| `0xAD`          | [reserved]                      |
-| `0xAE`          | [reserved]                      |
-| `0xAF`          | App-Specific Meta or Info       |
+| Code   | Description                            |
+|--------|----------------------------------------|
+| `0xA0` | App-Specific Failure                   |
+| `0xA1` | App-Specific Success                   |
+| `0xA2` | App-Specific Awaiting Others           |
+| `0xA3` | App-Specific Acceptance                |
+| `0xA4` | App-Specific Below Condition           |
+| `0xA5` | App-Specific Receiver Action Requested |
+| `0xA6` | App-Specific Expiry or Limit           |
+| `0xA7` | [reserved]                             |
+| `0xA8` | App-Specific Inapplicable Condition    |
+| `0xA9` | [reserved]                             |
+| `0xAA` | [reserved]                             |
+| `0xAB` | [reserved]                             |
+| `0xAC` | [reserved]                             |
+| `0xAD` | [reserved]                             |
+| `0xAE` | [reserved]                             |
+| `0xAF` | App-Specific Meta or Info              |
 
 #### `0xB*` TBD
 
@@ -260,77 +282,76 @@ Currently unspecified. (Full range reserved)
 
 Currently unspecified. (Full range reserved)
 
-#### `0xE*` Cryptography and Authentication
+#### `0xE*` Encryption, Identity & Proofs
 
 Actions around signatures, cryptography, signing, and application-level authentication.
 
-The meta code `0xEF` is often used to signal a payload describing the algorithm or process used.
+The meta code `0xEF` is often used to signal a payload descibing the algorithm or process used.
 
-|  Code           | Description                 |
-|-----------------|:----------------------------|
-| `0xE0`          | Decrypt Failure             |
-| `0xE1`          | Decrypt Success             |
-| `0xE2`          | Signed                      |
-| `0xE3`          | Their Signature Required    |
-| `0xE4`          | Your Signature Required     |
-| `0xE5`          | Auth Expired                |
-| `0xE6`          | [reserved]                  |
-| `0xE7`          | [reserved]                  |
-| `0xE8`          | [reserved]                  |
-| `0xE9`          | [reserved]                  |
-| `0xEA`          | [reserved]                  |
-| `0xEB`          | [reserved]                  |
-| `0xEC`          | [reserved]                  |
-| `0xED`          | [reserved]                  |
-| `0xEE`          | [reserved]                  |
-| `0xEF`          | Crypto Info or Meta         |
+| Code   | Description                         |
+|--------|-------------------------------------|
+| `0xE0` | Decrypt Failure                     |
+| `0xE1` | Decrypt Success                     |
+| `0xE2` | Awaiting Other Signatures or Keys   |
+| `0xE3` | Signed                              |
+| `0xE4` | Unsigned or Untrusted               |
+| `0xE5` | Signature Required                  |
+| `0xE6` | Known to be Compromised             |
+| `0xE7` | [reserved]                          |
+| `0xE8` | Already Signed or Not Encrypted     |
+| `0xE9` | [reserved]                          |
+| `0xEA` | [reserved]                          |
+| `0xEB` | [reserved]                          |
+| `0xEC` | [reserved]                          |
+| `0xED` | [reserved]                          |
+| `0xEE` | [reserved]                          |
+| `0xEF` | Cryptography, ID, or Proof Metadata |
 
-#### `0xF0` Off-Chain
+#### `0xF*` Off-Chain
 
-For off-chain actions. Much like th `0x0_: Generic` range, `0xF*` is very general, and does little to modify the reason.
+For off-chain actions. Much like th `0x0*: Generic` range, `0xF*` is very general, and does little to modify the reason.
 
 Among other things, the meta code `0xFF` may be used to describe what the off-chain process is.
 
-|  Code           | Description                   |
-|-----------------|:------------------------------|
-| `0xF0`          | Off-Chain Failure             |
-| `0xF1`          | Off-Chain Success             |
-| `0xF2`          | Off-Chain Process Stared      |
-| `0xF3`          | Awaiting Off-Chain Completion |
-| `0xF4`          | Off-Chain Action Required     |
-| `0xF5`          | Off-Chain Service Unavailable |
-| `0xF6`          | [reserved]                    |
-| `0xF7`          | [reserved]                    |
-| `0xF8`          | [reserved]                    |
-| `0xF9`          | [reserved]                    |
-| `0xFA`          | [reserved]                    |
-| `0xFB`          | [reserved]                    |
-| `0xFC`          | [reserved]                    |
-| `0xFD`          | [reserved]                    |
-| `0xFE`          | [reserved]                    |
-| `0xFF`          | Off-Chain Info or Meta        |
+| Code   | Description                       |
+|--------|-----------------------------------|
+| `0xF0` | Off-Chain Failure                 |
+| `0xF1` | Off-Chain Success                 |
+| `0xF2` | Awaiting Off-Chain Process        |
+| `0xF3` | Off-Chain Process Started         |
+| `0xF4` | Off-Chain Service Unreachable     |
+| `0xF5` | Off-Chain Action Required         |
+| `0xF6` | Off-Chain Expiry or Limit Reached |
+| `0xF7` | [reserved]                        |
+| `0xF8` | Duplicate Off-Chain Request       |
+| `0xF9` | [reserved]                        |
+| `0xFA` | [reserved]                        |
+| `0xFB` | [reserved]                        |
+| `0xFC` | [reserved]                        |
+| `0xFD` | [reserved]                        |
+| `0xFE` | [reserved]                        |
+| `0xFF` | Off-Chain Info or Meta            |
 
 ### As a Grid
 
-| X. Low Nibble                     | 0. Generic              | 10. Permission                | 20. Find/Match/&c       | 30. Negotiation / Offers         | 40. Availability                 | 50. [reserved] | 60. [reserved] | 70. [reserved] | 80. [reserved] | 90. [reserved] | A0. [reserved] | B0. [reserved] | C0. [reserved] | D0. [reserved] | E0. Cryptography                    | F0. Off Chain                                     |
-|-----------------------------------|-------------------------|-------------------------------|-------------------------|----------------------------------|----------------------------------|----------------|----------------|----------------|----------------|----------------|----------------|----------------|----------------|----------------|-------------------------------------|---------------------------------------------------|
-| 0. Failure                        | 0x00 Failure            | 0x10 Disallowed               | 0x20 Not Found          | 0x30 Other Party Disagreed       | 0x40 Unavailable or Expired      | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | 0xE0 Decrypt Failure                | 0xF0 Off Chain Failure                            |
-| 1. Success                        | 0x01 Success            | 0x11 Allowed                  | 0x21 Found              | 0x31 Other Party Agreed          | 0x41 Available                   | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | 0xE1 Decrypt Success                | 0xF1 Off Chain Success                            |
-| 2. Accepted / Started             | 0x02 Accepted / Started | 0x12 Requested Permission     | 0x22 Match Request Sent | 0x32 Sent Offer                  | [reserved]                       | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | 0xE2 Signed                         | 0xF2 Off Chain Process Started                    |
-| 3. Awaiting Others                | 0x03 Awaiting           | 0x13 Awaiting Permission      | 0x23 Awaiting Match     | 0x33 Awaiting Their Ratification | 0x43 Not Yet Available           | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | 0xE3 Other Party Signature Required | 0xF3 Awaiting Off Chain Completion                |
-| 4. Action Required / Awaiting You | 0x04 Action Required    | 0x14 Awaiting Your Permission | [reserved]              | 0x34 Awaiting Your Ratification  | 0x44 Awaiting Your Availability* | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | 0xE4 Your Signature Required        | 0xF4 Off Chain Action Required                    |
-| 5. [reserved]                     | [reserved]              | [reserved]                    | [reserved]              | [reserved]                       | [reserved]                       | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]                          | [reserved]                                        |
-| 6. [reserved]                     | [reserved]              | [reserved]                    | [reserved]              | [reserved]                       | [reserved]                       | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]                          | [reserved]                                        |
-| 7. [reserved]                     | [reserved]              | [reserved]                    | [reserved]              | [reserved]                       | [reserved]                       | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]                          | [reserved]                                        |
-| 8. [reserved]                     | [reserved]              | [reserved]                    | [reserved]              | [reserved]                       | [reserved]                       | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]                          | [reserved]                                        |
-| 9. [reserved]                     | [reserved]              | [reserved]                    | [reserved]              | [reserved]                       | [reserved]                       | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]                          | [reserved]                                        |
-| A. [reserved]                     | [reserved]              | [reserved]                    | [reserved]              | [reserved]                       | [reserved]                       | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]                          | [reserved]                                        |
-| B. [reserved]                     | [reserved]              | [reserved]                    | [reserved]              | [reserved]                       | [reserved]                       | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]                          | [reserved]                                        |
-| C. [reserved]                     | [reserved]              | [reserved]                    | [reserved]              | [reserved]                       | [reserved]                       | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]                          | [reserved]                                        |
-| D. [reserved]                     | [reserved]              | [reserved]                    | [reserved]              | [reserved]                       | [reserved]                       | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]                          | [reserved]                                        |
-| E. [reserved]                     | [reserved]              | [reserved]                    | [reserved]              | [reserved]                       | [reserved]                       | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]                          | [reserved]                                        |
-| F. Meta/Info                      | 0x0F Metadata Only      | [reserved]                    | [reserved]              | [reserved]                       | [reserved]                       | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]     | [reserved]                          | 0xFF Data Source is Off Chain (ie: no guarantees) |
-
+|        | `0x0*` General                                 | `0x1*` Permission & Control                              | `0x2*` Find, Inequalities & Range          | `0x3*` Negotiation & Governance                | `0x4*` Availability & Time                                  | `0x5*` Tokens, Funds & Finance         | `0x6*` TBD        | `0x7*` TBD        | `0x8*` TBD        | `0x9*` TBD        | `0xA*` Application-Specific Codes             | `0xB*` TBD        | `0xC*` TBD        | `0xD*` TBD        | `0xE*` Encryption, Identity & Proofs       | `0xF*` Off-Chain                         |
+|--------|------------------------------------------------|----------------------------------------------------------|--------------------------------------------|------------------------------------------------|-------------------------------------------------------------|----------------------------------------|-------------------|-------------------|-------------------|-------------------|-----------------------------------------------|-------------------|-------------------|-------------------|--------------------------------------------|------------------------------------------|
+| `0x*0` | `0x00` Failure                                 | `0x10` Disallowed or Stop                                | `0x20` Not Found, Unequal, or Out of Range | `0x30` Sender Disagrees or Nay                 | `0x40` Unavailable                                          | `0x50` Transfer Failed                 | `0x60` [reserved] | `0x70` [reserved] | `0x80` [reserved] | `0x90` [reserved] | `0xA0` App-Specific Failure                   | `0xB0` [reserved] | `0xC0` [reserved] | `0xD0` [reserved] | `0xE0` Decrypt Failure                     | `0xF0` Off-Chain Failure                 |
+| `0x*1` | `0x01` Success                                 | `0x11` Allowed or Go                                     | `0x21` Found, Equal or In Range            | `0x31` Sender Agrees or Yea                    | `0x41` Available                                            | `0x51` Transfer Successful             | `0x61` [reserved] | `0x71` [reserved] | `0x81` [reserved] | `0x91` [reserved] | `0xA1` App-Specific Success                   | `0xB1` [reserved] | `0xC1` [reserved] | `0xD1` [reserved] | `0xE1` Decrypt Success                     | `0xF1` Off-Chain Success                 |
+| `0x*2` | `0x02` Awaiting Others                         | `0x12` Awaiting Other's Permission                       | `0x22` Awaiting Match                      | `0x32` Awaiting Ratification                   | `0x42` Paused                                               | `0x52` Awaiting Payment From Others    | `0x62` [reserved] | `0x72` [reserved] | `0x82` [reserved] | `0x92` [reserved] | `0xA2` App-Specific Awaiting Others           | `0xB2` [reserved] | `0xC2` [reserved] | `0xD2` [reserved] | `0xE2` Awaiting Other Signatures or Keys   | `0xF2` Awaiting Off-Chain Process        |
+| `0x*3` | `0x03` Accepted                                | `0x13` Permission Requested                              | `0x23` Match Request Sent                  | `0x33` Offer Sent or Voted                     | `0x43` Queued                                               | `0x53` Hold or Escrow                  | `0x63` [reserved] | `0x73` [reserved] | `0x83` [reserved] | `0x93` [reserved] | `0xA3` App-Specific Acceptance                | `0xB3` [reserved] | `0xC3` [reserved] | `0xD3` [reserved] | `0xE3` Signed                              | `0xF3` Off-Chain Process Started         |
+| `0x*4` | `0x04` Lower Limit or Insufficient             | `0x14` Too Open / Insecure                               | `0x24` Below Range or Underflow            | `0x34` Quorum Not Reached                      | `0x44` Not Available Yet                                    | `0x54` Insufficient Funds              | `0x64` [reserved] | `0x74` [reserved] | `0x84` [reserved] | `0x94` [reserved] | `0xA4` App-Specific Below Condition           | `0xB4` [reserved] | `0xC4` [reserved] | `0xD4` [reserved] | `0xE4` Unsigned or Untrusted               | `0xF4` Off-Chain Service Unreachable     |
+| `0x*5` | `0x05` Receiver Action Required                | `0x15` Needs Your Permission or Request for Continuation | `0x25` Request for Match                   | `0x35` Receiver's Ratification Requested       | `0x45` Awaiting Your Availability                           | `0x55` Funds Requested                 | `0x65` [reserved] | `0x75` [reserved] | `0x85` [reserved] | `0x95` [reserved] | `0xA5` App-Specific Receiver Action Requested | `0xB5` [reserved] | `0xC5` [reserved] | `0xD5` [reserved] | `0xE5` Signature Required                  | `0xF5` Off-Chain Action Required         |
+| `0x*6` | `0x06` Upper Limit                             | `0x16` Revoked or Banned                                 | `0x26` Above Range or Overflow             | `0x36` Offer or Vote Limit Reached             | `0x46` Expired                                              | `0x56` Transfer Volume Exceeded        | `0x66` [reserved] | `0x76` [reserved] | `0x86` [reserved] | `0x96` [reserved] | `0xA6` App-Specific Expiry or Limit           | `0xB6` [reserved] | `0xC6` [reserved] | `0xD6` [reserved] | `0xE6` Known to be Compromised             | `0xF6` Off-Chain Expiry or Limit Reached |
+| `0x*7` | `0x07` [reserved]                              | `0x17` [reserved]                                        | `0x27` [reserved]                          | `0x37` [reserved]                              | `0x47` [reserved]                                           | `0x57` [reserved]                      | `0x67` [reserved] | `0x77` [reserved] | `0x87` [reserved] | `0x97` [reserved] | `0xA7` [reserved]                             | `0xB7` [reserved] | `0xC7` [reserved] | `0xD7` [reserved] | `0xE7` [reserved]                          | `0xF7` [reserved]                        |
+| `0x*8` | `0x08` Duplicate, Unnessesary, or Inapplicable | `0x18` Not Applicatable to Current State                 | `0x28` Duplicate, Conflict, or Collision   | `0x38` Already Voted                           | `0x48` Already Done                                         | `0x58` Funds Not Required              | `0x68` [reserved] | `0x78` [reserved] | `0x88` [reserved] | `0x98` [reserved] | `0xA8` App-Specific Inapplicable Condition    | `0xB8` [reserved] | `0xC8` [reserved] | `0xD8` [reserved] | `0xE8` Already Signed or Not Encrypted     | `0xF8` Duplicate Off-Chain Request       |
+| `0x*9` | `0x09` [reserved]                              | `0x19` [reserved]                                        | `0x29` [reserved]                          | `0x39` [reserved]                              | `0x49` [reserved]                                           | `0x59` [reserved]                      | `0x69` [reserved] | `0x79` [reserved] | `0x89` [reserved] | `0x99` [reserved] | `0xA9` [reserved]                             | `0xB9` [reserved] | `0xC9` [reserved] | `0xD9` [reserved] | `0xE9` [reserved]                          | `0xF9` [reserved]                        |
+| `0x*A` | `0x0A` [reserved]                              | `0x1A` [reserved]                                        | `0x2A` [reserved]                          | `0x3A` [reserved]                              | `0x4A` [reserved]                                           | `0x5A` [reserved]                      | `0x6A` [reserved] | `0x7A` [reserved] | `0x8A` [reserved] | `0x9A` [reserved] | `0xAA` [reserved]                             | `0xBA` [reserved] | `0xCA` [reserved] | `0xDA` [reserved] | `0xEA` [reserved]                          | `0xFA` [reserved]                        |
+| `0x*B` | `0x0B` [reserved]                              | `0x1B` [reserved]                                        | `0x2B` [reserved]                          | `0x3B` [reserved]                              | `0x4B` [reserved]                                           | `0x5B` [reserved]                      | `0x6B` [reserved] | `0x7B` [reserved] | `0x8B` [reserved] | `0x9B` [reserved] | `0xAB` [reserved]                             | `0xBB` [reserved] | `0xCB` [reserved] | `0xDB` [reserved] | `0xEB` [reserved]                          | `0xFB` [reserved]                        |
+| `0x*C` | `0x0C` [reserved]                              | `0x1C` [reserved]                                        | `0x2C` [reserved]                          | `0x3C` [reserved]                              | `0x4C` [reserved]                                           | `0x5C` [reserved]                      | `0x6C` [reserved] | `0x7C` [reserved] | `0x8C` [reserved] | `0x9C` [reserved] | `0xAC` [reserved]                             | `0xBC` [reserved] | `0xCC` [reserved] | `0xDC` [reserved] | `0xEC` [reserved]                          | `0xFC` [reserved]                        |
+| `0x*D` | `0x0D` [reserved]                              | `0x1D` [reserved]                                        | `0x2D` [reserved]                          | `0x3D` [reserved]                              | `0x4D` [reserved]                                           | `0x5D` [reserved]                      | `0x6D` [reserved] | `0x7D` [reserved] | `0x8D` [reserved] | `0x9D` [reserved] | `0xAD` [reserved]                             | `0xBD` [reserved] | `0xCD` [reserved] | `0xDD` [reserved] | `0xED` [reserved]                          | `0xFD` [reserved]                        |
+| `0x*E` | `0x0E` [reserved]                              | `0x1E` [reserved]                                        | `0x2E` [reserved]                          | `0x3E` [reserved]                              | `0x4E` [reserved]                                           | `0x5E` [reserved]                      | `0x6E` [reserved] | `0x7E` [reserved] | `0x8E` [reserved] | `0x9E` [reserved] | `0xAE` [reserved]                             | `0xBE` [reserved] | `0xCE` [reserved] | `0xDE` [reserved] | `0xEE` [reserved]                          | `0xFE` [reserved]                        |
+| `0x*F` | `0x0F` Informational or Metadata               | `0x1F` Permission Details or Control Conditions          | `0x2F` Matching Meta or Info               | `0x3F` Negotiation Rules or Participation Info | `0x4F` Availability Rules or Info (ex. time since or until) | `0x5F` Token or Fiunancial Information | `0x6F` [reserved] | `0x7F` [reserved] | `0x8F` [reserved] | `0x9F` [reserved] | `0xAF` App-Specific Meta or Info              | `0xBF` [reserved] | `0xCF` [reserved] | `0xDF` [reserved] | `0xEF` Cryptography, ID, or Proof Metadata | `0xFF` Off-Chain Info or Meta            |
 
 ### Example Function Change
 
@@ -350,7 +371,7 @@ function increase() public returns (bool _available) {
 
 // After
 function increase() public returns (byte _status) {
-    if (now < start) { return hex"43"; } // Not yet available
+    if (now < start) { return hex"44"; } // Not yet available
     if (counters[msg.sender] == 0) { return hex"10"; } // Not authorized
 
     counters[msg.sender] += 1;
@@ -364,7 +385,7 @@ function increase() public returns (byte _status) {
 0x03 = Waiting
 0x31 = Other Party (ie: not you) Agreed
 0x41 = Available
-0x43 = Not Yet Available
+0x44 = Not Yet Available
 
 
                           Exchange
@@ -377,14 +398,14 @@ AwesomeCoin                 DEX                     TraderBot
      |         buy()         |                          |
      | <---------------------+                          |
      |                       |                          |
-     |     Status [0x43]     |                          |
-     +---------------------> |       Status [0x43]      |
+     |     Status [0x44]     |                          |
+     +---------------------> |       Status [0x44]      |
      |                       +------------------------> |
      |                       |                          |
      |                       |        isDoneYet()       |
      |                       | <------------------------+
      |                       |                          |
-     |                       |       Status [0x43]      |
+     |                       |       Status [0x44]      |
      |                       +------------------------> |
      |                       |                          |
      |                       |                          |
@@ -459,6 +480,8 @@ AwesomeCoin                 DEX                     TraderBot
 ### Encoding
 
 Status codes are encoded as a `byte`. Hex values break nicely into high and low nibbles: `category` and `reason`. For instance, `0x01` stands for general success (ie: `true`) and `0x00` for general failure (ie: `false`).
+
+As a general approach, all even numbers are blocking conditions (where the receiver does not have control), and odd numbers are nonblocking (the receiver is free to contrinue as they wish). This aligns both a simple bit check with the common encoding of Booleans.
 
 `bytes1` is very lightweight, portable, easily interoperable with `uint8`, cast from `enum`s, and so on.
 
@@ -542,14 +565,14 @@ contract Whitelist {
 
 #### Helpers
 
-This above also means that working with app-specific enums is slightly easier:
+This above also means that working with app-specific enums is slightly easier, and also saves gas (fewer operations required).
 
 ```solidity
 enum Sleep {
     Awake,
     Asleep,
-    REM,
-    FallingAsleep
+    BedOccupied,
+    WindingDown
 }
 
 // From the helper library
@@ -569,7 +592,7 @@ function appCode(Sleep _state) returns (byte code) {
 
 Reference cases and helper libraries (Solidity and JS) can be found at:
 * [Source Code](https://github.com/fission-suite/fission-codes/)
-* [Package on npm](https://www.npmjs.com/package/ethereum-status-codes)
+* [Package on npm](https://www.npmjs.com/package/fission-codes/)
 
 ## Copyright
 


### PR DESCRIPTION
* Add many codes to ERC-1066
* General clean up
* Add version number
* Add clarifying text throughout
* Column updates:
  * 0x50: Token/finance
* Row updates:
  * Even rows are now consistently blocking conditions
  * Odd rows are consistently nonblocking conditions
  * Add 0x08 Duplicate
  * Move 0x05 Expired to 0x06
  * Swap 0x02 and 0x03 (awaiting and accepted)