### PR TITLE
Fix Last Call, remove jekyll-feeds plugin

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -36,8 +36,6 @@ twitter:
 # Build settings
 markdown: kramdown
 theme: minima
-plugins:
-  - jekyll-feed
 
 permalink: /:slug
 

--- a/last-call.xml
+++ b/last-call.xml
@@ -8,15 +8,28 @@ layout: null
     <description>All EIPs which are in the two-week "last call" status, please help review these and provide your feedback!</description>
     <link>{{ site.url }}</link>
     <atom:link href="{{ site.url }}/last-call.xml" rel="self" type="application/rss+xml" />
-    {% assign eips = site.pages|where:"status","Last Call"|sort:"eip" %}
-    {% for page in eips %}
+    <lastBuildDate>{{ site.time }}</lastBuildDate>
+    {% assign eips = site.pages | sort: 'eip' %}
+    {% for eip in eips %}
+      {% if eip.status == "Last Call" %}
+      {% capture description %}
+        <p><strong>EIP #{{ eip.eip }} - {{eip.title }}</strong> is in Last Call status. It is authored by {{ eip.author }} and was originally created {{ eip.created }}. It is in the {{ eip.category }} category of type {{ eip.type }}. Please review and note any changes that should block acceptance.</p>
+        {% if eip.discussions-to %}
+          <p>The author has requested that discussions happen at the following URL: {{ eip.discussions-to }}</p>
+        {% else %}
+          <p>Please visit the [ethereum/EIPs issues to comment](https://github.com/ethereum/EIPs/issues/{{eip.eip}}).</p>
+        {% endif %}
+        <hr />
+        {{ eip.content }}        
+      {% endcapture %}
       <item>
-        <title>{{ page.title | xml_escape }}</title>
-        <description>{{ page.content | xml_escape }}</description>
-        <pubDate>{{ page.date | date: "%a, %d %b %Y %H:%M:%S %z" }}</pubDate>
-        <link>{{ site.url }}/{{ page.url }}</link>
-        <guid isPermaLink="true">{{ site.url }}/{{ page.url }}</guid>
+        <title>{{ eip.title | xml_escape }}</title>
+        <description>{{ description | xml_escape }}</description>
+        <pubDate>{{ eip.date | date: "%a, %d %b %Y %H:%M:%S %z" }}</pubDate>
+        <link>{{ site.url }}/{{ eip.url }}</link>
+        <guid isPermaLink="true">{{ site.url }}/{{ eip.url }}</guid>
       </item>
+      {% endif %}
     {% endfor %}
   </channel>
 </rss>


### PR DESCRIPTION
This is a simple fix to make Last Call feed work.

I am also going to propose changes to fix #1535 and some additional feeds (e.g. global feed for all EIPs, JSON version of EIPs, etc. etc.)

I'll file a separate issue to gather suggestions for feed updates / wishlist.