### PR TITLE
Add a reentrancy protection to EIP 1283

### DIFF
--- a/EIPS/eip-1283.md
+++ b/EIPS/eip-1283.md
@@ -63,7 +63,8 @@ the following logic:
       gas to refund counter.
   * If *original value* does not equal *current value* (this storage
     slot is dirty), 200 gas is deducted. Apply both of the following
-    clauses.
+    clauses. If *gasleft* is less then or equal 2300, fail the transaction
+    with 'out of gas' exception.
     * If *original value* is not 0
       * If *current value* is 0 (also means that *new value* is not
         0), remove 15000 gas from refund counter. We can prove that
@@ -123,7 +124,10 @@ already issued the refund but it no longer applies (*current value* is
 issue the refund but it applies now (*new value* is 0), then adds this
 refund to the refund counter. It is not possible where a refund is not
 issued but we remove the refund in the above case, because all storage
-slot starts with **Fresh** state.
+slot starts with **Fresh** state. In order to keep in place the implicit
+reentrancy protection of existing contracts, transactions should not be
+allowed to modify state if the remaining gas is lower then the 2300
+stipend given to 'transfer'/'send' in Solidity.
 
 ### State Transition
 


### PR DESCRIPTION
An attack is described in:
https://medium.com/chainsecurity/constantinople-enables-new-reentrancy-attack-ace4088297d9

This is easily mitigated if SSTORE is not allowed in low gasleft state, without breaking the backward compatibility and the original intention of this EIP.