### PR TITLE
EIP-1707: Use Version Byte Prefix for Contract Account Versioning

### DIFF
--- a/EIPS/eip-1707.md
+++ b/EIPS/eip-1707.md
@@ -3,7 +3,7 @@ eip: 1707
 title: Use Version Byte Prefix for Contract Account Versioning
 author: Wei Tang (@sorpaas)
 discussions-to: https://github.com/sorpaas/EIPs/issues/3
-status: Draft
+status: Abandoned
 type: Standards Track
 category: Core
 created: 2019-01-17

--- a/EIPS/eip-1707.md
+++ b/EIPS/eip-1707.md
@@ -6,6 +6,7 @@ discussions-to: https://github.com/sorpaas/EIPs/issues/3
 status: Abandoned
 type: Standards Track
 category: Core
+superseded-by: 1702
 created: 2019-01-17
 ---
 

--- a/EIPS/eip-1707.md
+++ b/EIPS/eip-1707.md
@@ -1,5 +1,5 @@
 ---
-eip: <to be assigned>
+eip: 1707
 title: Use Version Byte Prefix for Contract Account Versioning
 author: Wei Tang (@sorpaas)
 discussions-to: <URL>

--- a/EIPS/eip-1707.md
+++ b/EIPS/eip-1707.md
@@ -2,6 +2,7 @@
 eip: 1707
 title: Use Version Byte Prefix for Contract Account Versioning
 author: Wei Tang (@sorpaas)
+discussions-to: https://github.com/sorpaas/EIPs/issues/3
 status: Draft
 type: Standards Track
 category: Core

--- a/EIPS/eip-1707.md
+++ b/EIPS/eip-1707.md
@@ -36,6 +36,10 @@ defined by the version bits.
 * If version bytes are `asm`, then invoke WebAssembly virtual
   machine. This is compatible with the standard WebAssembly binary
   format because it always starts with `\0asm`.
+  
+If the above does not match, execute it on the default EVM. Note that
+if the first byte is `\0`, the client can short circuit and stop
+immediately.
 
 ## Copyright
 

--- a/EIPS/eip-1707.md
+++ b/EIPS/eip-1707.md
@@ -2,7 +2,6 @@
 eip: 1707
 title: Use Version Byte Prefix for Contract Account Versioning
 author: Wei Tang (@sorpaas)
-discussions-to: <URL>
 status: Draft
 type: Standards Track
 category: Core

--- a/EIPS/eip-code-prefix.md
+++ b/EIPS/eip-code-prefix.md
@@ -1,0 +1,43 @@
+---
+eip: <to be assigned>
+title: Use Version Byte Prefix for Contract Account Versioning
+author: Wei Tang (@sorpaas)
+discussions-to: <URL>
+status: Draft
+type: Standards Track
+category: Core
+created: 2019-01-17
+---
+
+## Simple Summary
+
+Provide an alternative proposal compared with EIP-1702 / ECIP-1040,
+with the following advantages:
+
+* We don't need to modify existing account state format.
+* We don't need to modify how precompiled contracts are invoked.
+* Compatible with the standard WebAssembly binary format.
+
+## Specification
+
+After `FORK_BLOCK`, before an account or contract creation transaction
+code is executed, check that whether:
+
+* The first byte is `\0` (`0x00`).
+* The code length is greater or equal to 4.
+
+If so, we define the second to fourth bytes as version bits. Instead
+of executing on the default EVM, pass the *whole* code array to a VM
+defined by the version bits.
+
+* If version bytes are `\0\0\1`, then invoke "EVM1", where the first 4
+  bytes are stripped, and the rest of the code bytes are executed in
+  an EVM with "EVM1" config.
+* If version bytes are `asm`, then invoke WebAssembly virtual
+  machine. This is compatible with the standard WebAssembly binary
+  format because it always starts with `\0asm`.
+
+## Copyright
+
+Copyright and related rights waived via
+[CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
Provide an alternative proposal compared with EIP-1702 / ECIP-1040, with the following advantages:

* We don't need to modify existing account state format.
* We don't need to modify how precompiled contracts are invoked.
* Compatible with the standard WebAssembly binary format.