### PR TITLE
Add EIP-211 to metadata

### DIFF
--- a/EIPS/eip-1167.md
+++ b/EIPS/eip-1167.md
@@ -7,6 +7,7 @@ status: Final
 type: Standards Track
 category: ERC
 created: 2018-06-22
+requires: 211
 ---
 
 <!--You can leave these HTML comments in your merged EIP and delete the visible duplicate text guides, they will not appear and may be helpful to refer to if you edit it again. This is the suggested template for new EIPs. Note that an EIP number will be assigned by an editor. When opening a pull request to submit your EIP, please use an abbreviated title in the filename, `eip-draft_title_abbrev.md`. The title should be 44 characters or less.-->


### PR DESCRIPTION
This requirement is already specified in the EIP proper. The EIP-211 bytecodes (`0x3d`, `0x3e`) are used in the proxy specification. This PR adds EIP-211 as a requirement for EIP-1167 in the EIP metadata.