### PR TITLE
Use preferred reference format

### DIFF
--- a/EIPS/eip-609.md
+++ b/EIPS/eip-609.md
@@ -20,15 +20,15 @@ This specifies the changes included in the hard fork named Byzantium.
   - Block >= 4,370,000 on Mainnet
   - Block >= 1,700,000 on Ropsten testnet
 - Included EIPs:
-  - [EIP 100](./eip-100.md) (Change difficulty adjustment to target mean block time including uncles)
-  - [EIP 140](./eip-140.md) (REVERT instruction in the Ethereum Virtual Machine)
-  - [EIP 196](./eip-196.md) (Precompiled contracts for addition and scalar multiplication on the elliptic curve alt_bn128)
-  - [EIP 197](./eip-197.md) (Precompiled contracts for optimal ate pairing check on the elliptic curve alt_bn128)
-  - [EIP 198](./eip-198.md) (Precompiled contract for bigint modular exponentiation)
-  - [EIP 211](./eip-211.md) (New opcodes: RETURNDATASIZE and RETURNDATACOPY)
-  - [EIP 214](./eip-214.md) (New opcode STATICCALL)
-  - [EIP 649](./eip-649.md) (Difficulty Bomb Delay and Block Reward Reduction)
-  - [EIP 658](./eip-658.md) (Embedding transaction status code in receipts)
+  - [EIP 100](https://eips.ethereum.org/EIPS/eip-100) (Change difficulty adjustment to target mean block time including uncles)
+  - [EIP 140](https://eips.ethereum.org/EIPS/eip-140) (REVERT instruction in the Ethereum Virtual Machine)
+  - [EIP 196](https://eips.ethereum.org/EIPS/eip-196) (Precompiled contracts for addition and scalar multiplication on the elliptic curve alt_bn128)
+  - [EIP 197](https://eips.ethereum.org/EIPS/eip-197) (Precompiled contracts for optimal ate pairing check on the elliptic curve alt_bn128)
+  - [EIP 198](https://eips.ethereum.org/EIPS/eip-198) (Precompiled contract for bigint modular exponentiation)
+  - [EIP 211](https://eips.ethereum.org/EIPS/eip-211) (New opcodes: RETURNDATASIZE and RETURNDATACOPY)
+  - [EIP 214](https://eips.ethereum.org/EIPS/eip-214) (New opcode STATICCALL)
+  - [EIP 649](https://eips.ethereum.org/EIPS/eip-649) (Difficulty Bomb Delay and Block Reward Reduction)
+  - [EIP 658](https://eips.ethereum.org/EIPS/eip-658) (Embedding transaction status code in receipts)
 
 ## References
 


### PR DESCRIPTION
This updates to use the preferred citation format as per https://github.com/ethereum/EIPs#preferred-citation-format