### PR TITLE
Update to use preferred citation format

### DIFF
--- a/EIPS/eip-1013.md
+++ b/EIPS/eip-1013.md
@@ -20,11 +20,11 @@ This meta-EIP specifies the changes included in the Ethereum hardfork named Cons
   - Block >= TBD on the Ethereum mainnet
   - Block >= 4,230,000 on the Ropsten testnet
 - Included EIPs:
-  - [EIP 145](./eip-145.md): Bitwise shifting instructions in EVM
-  - [EIP 1014](./eip-1014.md): Skinny CREATE2
-  - [EIP 1052](./eip-1052.md): EXTCODEHASH Opcode
-  - [EIP 1234](./eip-1234.md): Delay difficulty bomb, adjust block reward
-  - [EIP 1283](./eip-1283.md): Net gas metering for SSTORE without dirty maps
+  - [EIP 145](https://eips.ethereum.org/EIPS/eip-145): Bitwise shifting instructions in EVM
+  - [EIP 1014](https://eips.ethereum.org/EIPS/eip-1014): Skinny CREATE2
+  - [EIP 1052](https://eips.ethereum.org/EIPS/eip-1052): EXTCODEHASH Opcode
+  - [EIP 1234](https://eips.ethereum.org/EIPS/eip-1234): Delay difficulty bomb, adjust block reward
+  - [EIP 1283](https://eips.ethereum.org/EIPS/eip-1283): Net gas metering for SSTORE without dirty maps
 
 ## References
 


### PR DESCRIPTION
This updates to use the preferred citation format as per https://github.com/ethereum/EIPs#preferred-citation-format
