### PR TITLE
Set Status of EIP-1066 to Last Call

### DIFF
--- a/EIPS/eip-1066.md
+++ b/EIPS/eip-1066.md
@@ -3,7 +3,7 @@ eip: 1066
 title: Status Codes
 author: Brooklyn Zelenka (@expede), Tom Carchrae (@carchrae), Gleb Naumenko (@naumenkogs)
 discussions-to: https://ethereum-magicians.org/t/erc-1066-ethereum-status-codes-esc/
-status: Draft
+status: Last Call
 type: Standards Track
 category: ERC
 created: 2018-05-05
@@ -229,7 +229,7 @@ Special token and financial concepts. Many related concepts are included in othe
 | `0x5C` | [reserved]                      |
 | `0x5D` | [reserved]                      |
 | `0x5E` | [reserved]                      |
-| `0x5F` | Token or Fiunancial Information |
+| `0x5F` | Token or Financial Information |
 
 #### `0x6*` TBD
 
@@ -351,7 +351,7 @@ Among other things, the meta code `0xFF` may be used to describe what the off-ch
 | `0x*C` | `0x0C` [reserved]                              | `0x1C` [reserved]                                        | `0x2C` [reserved]                          | `0x3C` [reserved]                              | `0x4C` [reserved]                                           | `0x5C` [reserved]                      | `0x6C` [reserved] | `0x7C` [reserved] | `0x8C` [reserved] | `0x9C` [reserved] | `0xAC` [reserved]                             | `0xBC` [reserved] | `0xCC` [reserved] | `0xDC` [reserved] | `0xEC` [reserved]                          | `0xFC` [reserved]                        |
 | `0x*D` | `0x0D` [reserved]                              | `0x1D` [reserved]                                        | `0x2D` [reserved]                          | `0x3D` [reserved]                              | `0x4D` [reserved]                                           | `0x5D` [reserved]                      | `0x6D` [reserved] | `0x7D` [reserved] | `0x8D` [reserved] | `0x9D` [reserved] | `0xAD` [reserved]                             | `0xBD` [reserved] | `0xCD` [reserved] | `0xDD` [reserved] | `0xED` [reserved]                          | `0xFD` [reserved]                        |
 | `0x*E` | `0x0E` [reserved]                              | `0x1E` [reserved]                                        | `0x2E` [reserved]                          | `0x3E` [reserved]                              | `0x4E` [reserved]                                           | `0x5E` [reserved]                      | `0x6E` [reserved] | `0x7E` [reserved] | `0x8E` [reserved] | `0x9E` [reserved] | `0xAE` [reserved]                             | `0xBE` [reserved] | `0xCE` [reserved] | `0xDE` [reserved] | `0xEE` [reserved]                          | `0xFE` [reserved]                        |
-| `0x*F` | `0x0F` Informational or Metadata               | `0x1F` Permission Details or Control Conditions          | `0x2F` Matching Meta or Info               | `0x3F` Negotiation Rules or Participation Info | `0x4F` Availability Rules or Info (ex. time since or until) | `0x5F` Token or Fiunancial Information | `0x6F` [reserved] | `0x7F` [reserved] | `0x8F` [reserved] | `0x9F` [reserved] | `0xAF` App-Specific Meta or Info              | `0xBF` [reserved] | `0xCF` [reserved] | `0xDF` [reserved] | `0xEF` Cryptography, ID, or Proof Metadata | `0xFF` Off-Chain Info or Meta            |
+| `0x*F` | `0x0F` Informational or Metadata               | `0x1F` Permission Details or Control Conditions          | `0x2F` Matching Meta or Info               | `0x3F` Negotiation Rules or Participation Info | `0x4F` Availability Rules or Info (ex. time since or until) | `0x5F` Token or Financial Information  | `0x6F` [reserved] | `0x7F` [reserved] | `0x8F` [reserved] | `0x9F` [reserved] | `0xAF` App-Specific Meta or Info              | `0xBF` [reserved] | `0xCF` [reserved] | `0xDF` [reserved] | `0xEF` Cryptography, ID, or Proof Metadata | `0xFF` Off-Chain Info or Meta            |
 
 ### Example Function Change
 


### PR DESCRIPTION
Update EIP-1066 ("status codes") to last call for v1.0.0. This will still be open to further codes, but we are happy with this as a first version to be widely used.

(Also fix a typo 😅)