### PR TITLE
Fix language for transfer function

### DIFF
--- a/EIPS/eip-20.md
+++ b/EIPS/eip-20.md
@@ -95,7 +95,7 @@ function balanceOf(address _owner) public view returns (uint256 balance)
 #### transfer
 
 Transfers `_value` amount of tokens to address `_to`, and MUST fire the `Transfer` event.
-The function SHOULD `throw` if the `_from` account balance does not have enough tokens to spend.
+The function SHOULD `throw` if the message caller's account balance does not have enough tokens to spend.
 
 *Note* Transfers of 0 values MUST be treated as normal transfers and fire the `Transfer` event.
 


### PR DESCRIPTION
The transfer function documentation currently references a non-existent `_from` parameter. This is clearly a copy-paste of the `transferFrom` function and clearly the intent is to reference the message caller (in Solidity, `msg.caller`). So I have corrected the language.