### PR TITLE
Fix typo in EIP-721

### DIFF
--- a/EIPS/eip-721.md
+++ b/EIPS/eip-721.md
@@ -405,7 +405,7 @@ XXXXERC721, by William Entriken -- a scalable example implementation
 **Issues**
 
 1. The Original ERC-721 Issue. https://github.com/ethereum/eips/issues/721
-1. Solidity Issue \#2330 -- Interface Functions are Axternal. https://github.com/ethereum/solidity/issues/2330
+1. Solidity Issue \#2330 -- Interface Functions are External. https://github.com/ethereum/solidity/issues/2330
 1. Solidity Issue \#3412 -- Implement Interface: Allow Stricter Mutability. https://github.com/ethereum/solidity/issues/3412
 1. Solidity Issue \#3419 -- Interfaces Can't Inherit. https://github.com/ethereum/solidity/issues/3419
 1. Solidity Issue \#3494 -- Compiler Incorrectly Reasons About the `selector` Function. https://github.com/ethereum/solidity/issues/3494


### PR DESCRIPTION
Just fixing a simple typo in the EIP-721 text:
`Axternal` -> `External`