### PR TITLE
Add review end date to EIP-1066

### DIFF
--- a/EIPS/eip-1066.md
+++ b/EIPS/eip-1066.md
@@ -6,6 +6,7 @@ discussions-to: https://ethereum-magicians.org/t/erc-1066-ethereum-status-codes-
 status: Last Call
 type: Standards Track
 category: ERC
+review-period-end: 2019-02-25
 created: 2018-05-05
 version: 1.0.0
 ---


### PR DESCRIPTION
Previous PR (#1735) was missing a `review-period-end`. Mea culpa!

https://ethereum-magicians.org/t/erc-1066-ethereum-status-codes-esc/283/38