### PR TITLE
Update EIP 1193

### DIFF
--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -101,15 +101,6 @@ ethereum.on('accountsChanged', listener: (accounts: Array<String>) => void): thi
 
 The event emits with `accounts`, an array of the accounts' addresses.
 
-### isEIP1193
-
-`isEIP1193` is a public read-only value on the provider to help distinguish itself.
-
-```js
-ethereum.isEIP1193;
-> true
-```
-
 ## Examples
 
 ```js
@@ -266,13 +257,9 @@ If the network the provider is connected to changes, the provider **MUST** emit 
 
 If the accounts connected to the Ethereum Provider change at any time, the Ethereum Provider **MUST** send an event with the name `accountsChanged` with args `accounts: Array<String>` containing the accounts' addresses.
 
-### isEIP1193
-
-The provider **MUST** define `public readonly ethereum.isEIP1193: Boolean`
-
 ### web3.js Backwards Compatibility
 
-If the implementing Ethereum Provider would like to be compatible with `web3.js` prior to `1.0.0-beta38`, it **MUST** provide two methods: `sendAsync(payload: Object, callback: (error: any, result: any) => void): void` and `isConnected(): Boolean`.
+If the implementing Ethereum Provider would like to be compatible with `web3.js` prior to `1.0.0-beta38`, it **MUST** provide the method: `sendAsync(payload: Object, callback: (error: any, result: any) => void): void`.
 
 ### Error object and codes
 
@@ -296,7 +283,6 @@ class EthereumProvider extends EventEmitter {
     super();
 
     // Init storage
-    this._isConnected = false;
     this._nextJsonrpcId = 0;
     this._promises = {};
 
@@ -305,10 +291,6 @@ class EthereumProvider extends EventEmitter {
 
     // Listen for jsonrpc responses
     window.addEventListener('message', this._handleJsonrpcMessage.bind(this));
-  }
-
-  static get isEIP1193() {
-    return true;
   }
 
   /* Methods */
@@ -404,12 +386,10 @@ class EthereumProvider extends EventEmitter {
   }
 
   _emitConnect() {
-    this._isConnected = true;
     this.emit('connect');
   }
 
   _emitClose(code, reason) {
-    this._isConnected = false;
     this.emit('close', code, reason);
   }
 
@@ -437,10 +417,6 @@ class EthereumProvider extends EventEmitter {
           `Error from EthereumProvider sendAsync ${payload}: ${error}`
         );
       });
-  }
-
-  isConnected() {
-    return this._isConnected;
   }
 }
 ```


### PR DESCRIPTION
Based on [ethereum-magicians discussion](https://ethereum-magicians.org/t/eip-1193-ethereum-provider-javascript-api/640/37), this PR removes isEIP1193 property and isConnected requirement.