### PR TITLE
Add chain ids for ThunderCore Blockchain

### DIFF
--- a/EIPS/eip-155.md
+++ b/EIPS/eip-155.md
@@ -69,7 +69,7 @@ This would provide a way to send transactions that work on Ethereum without work
 | 61             | Ethereum Classic mainnet                   |
 | 62             | Ethereum Classic testnet                   |
 | 66             | ewasm testnet                              |
-| 8888           | ThunderCore Mainnet                        |
+| 88             | ThunderCore Mainnet                        |
 | 1337           | Geth private chains (default)              |
 | 6284           | Görli                                      |
 | 43568          | Gangnam                                    |

--- a/EIPS/eip-155.md
+++ b/EIPS/eip-155.md
@@ -62,6 +62,7 @@ This would provide a way to send transactions that work on Ethereum without work
 | 4              | Rinkeby                                    |
 | 8              | Ubiq mainnet                               |
 | 9              | Ubiq testnet                               |
+| 18             | ThunderCore testnet                        |
 | 30             | Rootstock mainnet                          |
 | 31             | Rootstock testnet                          |
 | 42             | Kovan                                      |
@@ -70,5 +71,6 @@ This would provide a way to send transactions that work on Ethereum without work
 | 66             | ewasm testnet                              |
 | 1337           | Geth private chains (default)              |
 | 6284           | Görli                                      |
+| 8888           | ThunderCore Mainnet                        |
 | 43568          | Gangnam                                    |
 | 314158         | Stureby                                    |

--- a/EIPS/eip-155.md
+++ b/EIPS/eip-155.md
@@ -69,7 +69,7 @@ This would provide a way to send transactions that work on Ethereum without work
 | 61             | Ethereum Classic mainnet                   |
 | 62             | Ethereum Classic testnet                   |
 | 66             | ewasm testnet                              |
-| 188            | ThunderCore Mainnet                        |
+| 108            | ThunderCore Mainnet                        |
 | 1337           | Geth private chains (default)              |
 | 6284           | Görli                                      |
 | 43568          | Gangnam                                    |

--- a/EIPS/eip-155.md
+++ b/EIPS/eip-155.md
@@ -69,7 +69,7 @@ This would provide a way to send transactions that work on Ethereum without work
 | 61             | Ethereum Classic mainnet                   |
 | 62             | Ethereum Classic testnet                   |
 | 66             | ewasm testnet                              |
-| 88             | ThunderCore Mainnet                        |
+| 188            | ThunderCore Mainnet                        |
 | 1337           | Geth private chains (default)              |
 | 6284           | Görli                                      |
 | 43568          | Gangnam                                    |


### PR DESCRIPTION
ThunderCore (http://ThunderCore.com) is an EVM compatible blockchain which has both mainnet and testnet. We need to have separate chain ids for both of them. Please send any questions to chandan@thundercore.com

When opening a pull request to submit a new EIP, please use the suggested template: https://github.com/ethereum/EIPs/blob/master/eip-X.md

We have a GitHub bot that automatically merges some PRs. It will merge yours immediately if certain criteria are met:

 - The PR edits only existing draft PRs.
 - The build passes.
 - Your Github username or email address is listed in the 'author' header of all affected PRs, inside <triangular brackets>.
 - If matching on email address, the email address is the one publicly listed on your GitHub profile.
