### PR TITLE
Fix erroneous function name

### DIFF
--- a/EIPS/eip-777.md
+++ b/EIPS/eip-777.md
@@ -624,7 +624,7 @@ Notify a send or mint (if `from` is `0x0`) of `amount` tokens from the `from` ad
 > <small>`data`: Extra information provided by the *token holder* for a send and nothing (empty bytes) for a mint.</small>  
 > <small>`operatorData`: Extra information provided by the address which triggered the balance increase.</small>
 
-The following rules apply when calling the `tokensToSend` hook:
+The following rules apply when calling the `tokensReceived` hook:
 
 - The `tokensReceived` hook MUST be called every time the balance is incremented.
 - The `tokensReceived` hook MUST be called *after* the state is updated&mdash;i.e. *after* the balance is incremented.
@@ -633,7 +633,6 @@ The following rules apply when calling the `tokensToSend` hook:
 - `from` MUST be `0x0` for a mint.
 - `to` MUST be the address of the *recipient* whose balance is increased.
 - `amount` MUST be the number of tokens the *recipient* balance is increased by.
-
 - `operatorData` MUST contain the extra information provided by the address which triggered the increase of the balance (if any).
 - The *token holder* MAY block an increase of its balance by `revert`ing. (I.e., reject the reception of tokens.)
 


### PR DESCRIPTION
Fix incorrect name of function (spec says `tokensToSend` but it should be `tokensReceived`).

Remove linebreak that separates `tokensReceived` notes.