### PR TITLE
EIP-1716 Hardfork Meta: Petersburg (a.k.a. "Constantinople Fix")  by @5chdn

### DIFF
--- a/EIPS/eip-1716.md
+++ b/EIPS/eip-1716.md
@@ -1,0 +1,38 @@
+---
+eip: 1716
+title: "Hardfork Meta: Petersburg"
+author: Afri Schoedon (@5chdn), Marius van der Wijden (@MariusVanDerWijden)
+type: Meta
+status: Final
+created: 2019-01-21
+requires: 1013, 1283
+---
+
+## Abstract
+
+This meta-EIP specifies the changes included in the Ethereum hardfork that removes [EIP-1283](./eip-1283.md) from [Constantinople](./eip-1013.md).
+
+## Specification
+
+- Codename: Petersburg
+- Aliases: St. Petersfork, Peter's Fork, Constantinople Fix
+- Activation:
+  - `Block >= 7_280_000` on the Ethereum mainnet
+  - `Block >= 4_939_394` on the Ropsten testnet
+  - `Block >= 10_255_201` on the Kovan testnet
+  - `Block >= 9_999_999` on the Rinkeby testnet
+  - `Block >= 0` on the Görli testnet
+- Removed EIPs:
+  - [EIP 1283](./eip-1283.md): Net gas metering for SSTORE without dirty maps
+
+If `Petersburg` and `Constantinople` are applied at the same block, `Petersburg` takes precedence: with the net effect of EIP-1283 being _disabled_.
+
+If `Petersburg` is defined with an earlier block number than `Constantinople`, then there is _no immediate effect_ from the `Petersburg` fork. However, when `Constantinople` is later activated, EIP-1283 should be _disabled_.
+
+## References
+
+The list above includes the EIPs that had to be removed from Constantinople due to a [potential reentrancy attack vector](https://medium.com/chainsecurity/constantinople-enables-new-reentrancy-attack-ace4088297d9). Removing this was agreed upon at the [All-Core-Devs call #53 in January 2019](https://github.com/ethereum/pm/issues/70).
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
```
eip: 1716
title: "Hardfork Meta: Petersburg"
author: Afri Schoedon (@5chdn)
type: Meta
status: Draft
created: 2019-01-21
requires: 1013, 1283
```

## Abstract

Since @5chdn doesn't want to coordinate the Hardfork process anymore, he deleted his PR.
This is just a copy of his PR which can be found here: https://github.com/ethereum/EIPs/pull/1716

This meta-EIP specifies the changes included in the Ethereum hardfork that removes [EIP-1283](./eip-1283.md) from [Constantinople](./eip-1013.md).