### PR TITLE
Reject EIP-1355 "Ethash 1a"

### DIFF
--- a/EIPS/eip-1355.md
+++ b/EIPS/eip-1355.md
@@ -3,7 +3,7 @@ eip: 1355
 title: Ethash 1a
 author: Paweł Bylica (@chfast) <pawel@ethereum.org>, Jean M. Cyr (@jean-m-cyr)
 discussions-to: https://ethereum-magicians.org/t/eip-1355-ethash-1a/1167
-status: Draft
+status: Abandoned
 type: Standards Track
 category: Core
 created: 2018-08-26


### PR DESCRIPTION
Reject EIP-1355 "Ethash 1a" because it is not useful.
