### PR TITLE
Add ethereum.org blog post about constantinople

### DIFF
--- a/EIPS/eip-1013.md
+++ b/EIPS/eip-1013.md
@@ -28,7 +28,8 @@ This meta-EIP specifies the changes included in the Ethereum hardfork named Cons
 
 ## References
 
-The list above includes the EIPs discussed as candidates for Constantinople at the All Core Dev [Constantinople Session #1](https://github.com/ethereum/pm/issues/55). See also [Constantinople Progress Tracker](https://github.com/ethereum/pm/wiki/Constantinople-Progress-Tracker).
+1. The list above includes the EIPs discussed as candidates for Constantinople at the All Core Dev [Constantinople Session #1](https://github.com/ethereum/pm/issues/55). See also [Constantinople Progress Tracker](https://github.com/ethereum/pm/wiki/Constantinople-Progress-Tracker).
+2. https://blog.ethereum.org/2019/02/22/ethereum-constantinople-st-petersburg-upgrade-announcement/
 
 ## Copyright
 


### PR DESCRIPTION
All the other HF EIPs contain a link to the "ethereum.org blog" post about the HF. Not sure if this is useful, but follows "tradition".