### PR TITLE
Add ethereum.org blog post about petersburg

### DIFF
--- a/EIPS/eip-1716.md
+++ b/EIPS/eip-1716.md
@@ -31,7 +31,8 @@ If `Petersburg` is defined with an earlier block number than `Constantinople`, t
 
 ## References
 
-The list above includes the EIPs that had to be removed from Constantinople due to a [potential reentrancy attack vector](https://medium.com/chainsecurity/constantinople-enables-new-reentrancy-attack-ace4088297d9). Removing this was agreed upon at the [All-Core-Devs call #53 in January 2019](https://github.com/ethereum/pm/issues/70).
+1. The list above includes the EIPs that had to be removed from Constantinople due to a [potential reentrancy attack vector](https://medium.com/chainsecurity/constantinople-enables-new-reentrancy-attack-ace4088297d9). Removing this was agreed upon at the [All-Core-Devs call #53 in January 2019](https://github.com/ethereum/pm/issues/70).
+2. https://blog.ethereum.org/2019/02/22/ethereum-constantinople-st-petersburg-upgrade-announcement/
 
 ## Copyright
 


### PR DESCRIPTION
All the other HF EIPs contain a link to the "ethereum.org blog" post about the HF. Not sure if this is useful, but follows "tradition".