### PR TITLE
EIP-615: author's GH name, not hardcoded email

### DIFF
--- a/EIPS/eip-615.md
+++ b/EIPS/eip-615.md
@@ -4,7 +4,7 @@ title: Subroutines and Static Jumps for the EVM
 status: Draft
 type: Standards Track
 category: Core
-author: Greg Colvin <greg@colvin.org>, Brooklyn Zelenka <hello@brooklynzelenka.com> , Paweł Bylica (@chfast), Christian Reitwiessner(@chriseth)
+author: Greg Colvin <greg@colvin.org>, Brooklyn Zelenka (@expede), Paweł Bylica (@chfast), Christian Reitwiessner (@chriseth)
 discussion to: https://ethereum-magicians.org/t/eip-615-subroutines-and-static-jumps-for-the-evm/2728
 created: 2016-12-10
 ---


### PR DESCRIPTION
Another author was confused about automerge criterea. Putting my Github username back, as have had issues in the past when locked out of a specific email (GH will authenticate many email addresses).