### PR TITLE
Fix copy/paste mistake in function name

### DIFF
--- a/EIPS/eip-777.md
+++ b/EIPS/eip-777.md
@@ -624,7 +624,7 @@ Notify a send or mint (if `from` is `0x0`) of `amount` tokens from the `from` ad
 > <small>`data`: Extra information provided by the *token holder* for a send and nothing (empty bytes) for a mint.</small>  
 > <small>`operatorData`: Extra information provided by the address which triggered the balance increase.</small>
 
-The following rules apply when calling the `tokensToSend` hook:
+The following rules apply when calling the `tokensReceived` hook:
 
 - The `tokensReceived` hook MUST be called every time the balance is incremented.
 - The `tokensReceived` hook MUST be called *after* the state is updated&mdash;i.e. *after* the balance is incremented.


### PR DESCRIPTION
Fix a small copy/paste mistake where the wrong the `tokensToSend` hook is mentioned instead of the `tokensReceived`, leading to confusion.