### PR TITLE
Update/erc777

### DIFF
--- a/EIPS/eip-777.md
+++ b/EIPS/eip-777.md
@@ -86,7 +86,7 @@ The `view` functions detailed below MUST be implemented.
 **`name` function**
 
 ``` solidity
- function name() public view returns (string)
+ function name() external view returns (string)
 ```
 
 Returns the name of the token, e.g., `"MyToken"`.
@@ -96,7 +96,7 @@ Returns the name of the token, e.g., `"MyToken"`.
 **`symbol` function**
 
 ``` solidity
-function symbol() public view returns (string)
+function symbol() external view returns (string)
 ```
 
 Returns the symbol of the token, e.g., `"MYT"`.
@@ -106,7 +106,7 @@ Returns the symbol of the token, e.g., `"MYT"`.
 **`totalSupply` function**
 
 ``` solidity
-function totalSupply() public view returns (uint256)
+function totalSupply() external view returns (uint256)
 ```
 
 Get the total number of minted tokens.
@@ -121,7 +121,7 @@ Get the total number of minted tokens.
 **`balanceOf` function**
 
 ``` solidity
-function balanceOf(address tokenHolder) public view returns (uint256)
+function balanceOf(address tokenHolder) external view returns (uint256)
 ```
 
 Get the balance of the account with address `tokenHolder`.
@@ -136,7 +136,7 @@ The balance MUST be zero (`0`) or higher.
 **`granularity` function**
 
 ``` solidity
-function granularity() public view returns (uint256)
+function granularity() external view returns (uint256)
 ```
 
 Get the smallest part of the token that's not divisible.
@@ -231,7 +231,7 @@ Token contracts MAY implement other functions to manage *operators*.
 **`defaultOperators` function** <a id="defaultOperators"></a>
 
 ``` solidity
-function defaultOperators() public view returns (address[])
+function defaultOperators() external view returns (address[])
 ```
 
 Get the list of *default operators* as defined by the token contract.
@@ -243,7 +243,7 @@ Get the list of *default operators* as defined by the token contract.
 **`authorizeOperator` function**
 
 ``` solidity
-function authorizeOperator(address operator) public
+function authorizeOperator(address operator) external
 ```
 
 Set a third party `operator` address as an *operator* of `msg.sender` to send and burn tokens on its behalf.
@@ -256,7 +256,7 @@ Set a third party `operator` address as an *operator* of `msg.sender` to send an
 **`revokeOperator` function**
 
 ``` solidity
-function revokeOperator(address operator) public
+function revokeOperator(address operator) external
 ```
 
 Remove the right of the `operator` address to be an *operator* for `msg.sender` and to send and burn tokens on its behalf.
@@ -269,7 +269,7 @@ Remove the right of the `operator` address to be an *operator* for `msg.sender` 
 **`isOperatorFor` function** <a id="isOperatorFor"></a>
 
 ``` solidity
-function isOperatorFor(address operator, address tokenHolder) public view returns (bool)
+function isOperatorFor(address operator, address tokenHolder) external view returns (bool)
 ```
 
 Indicate whether the `operator` address is an *operator* of the `tokenHolder` address.
@@ -357,7 +357,7 @@ Token contracts MAY implement other functions to send tokens.
 **`send` function**
 
 ``` solidity
-function send(address to, uint256 amount, bytes data) public
+function send(address to, uint256 amount, bytes data) external
 ```
 
 Send the `amount` of tokens from the address `msg.sender` to the address `to`.
@@ -372,7 +372,7 @@ The *operator* and the *token holder* MUST both be the `msg.sender`.
 **`operatorSend` function**
 
 ``` solidity
-function operatorSend(address from, address to, uint256 amount, bytes data, bytes operatorData) public
+function operatorSend(address from, address to, uint256 amount, bytes data, bytes operatorData) external
 ```
 
 Send the `amount` of tokens on behalf of the address `from` to the address `to`.
@@ -511,7 +511,7 @@ Token contracts MAY implement other functions to burn tokens.
 **`burn` function**
 
 ``` solidity
-function burn(uint256 amount, bytes data) public;
+function burn(uint256 amount, bytes data) external;
 ```
 
 Burn the `amount` of tokens from the address `msg.sender`.
@@ -525,7 +525,7 @@ The *operator* and the *token holder* MUST both be the `msg.sender`.
 **`operatorBurn` function**
 
 ``` solidity
-function operatorBurn(address from, uint256 amount, bytes data, bytes operatorData) public;
+function operatorBurn(address from, uint256 amount, bytes data, bytes operatorData) external;
 ```
 
 Burn the `amount` of tokens on behalf of the address `from`.

--- a/EIPS/eip-777.md
+++ b/EIPS/eip-777.md
@@ -40,22 +40,22 @@ This standard tries to improve the widely used [ERC20] token standard. The main 
 
 ``` solidity
 interface ERC777Token {
-    function name() public view returns (string);
-    function symbol() public view returns (string);
-    function totalSupply() public view returns (uint256);
-    function balanceOf(address owner) public view returns (uint256);
-    function granularity() public view returns (uint256);
+    function name() external view returns (string);
+    function symbol() external view returns (string);
+    function totalSupply() external view returns (uint256);
+    function balanceOf(address owner) external view returns (uint256);
+    function granularity() external view returns (uint256);
 
-    function defaultOperators() public view returns (address[]);
-    function authorizeOperator(address operator) public;
-    function revokeOperator(address operator) public;
-    function isOperatorFor(address operator, address tokenHolder) public view returns (bool);
+    function defaultOperators() external view returns (address[]);
+    function authorizeOperator(address operator) external;
+    function revokeOperator(address operator) external;
+    function isOperatorFor(address operator, address tokenHolder) external view returns (bool);
 
-    function send(address to, uint256 amount, bytes data) public;
-    function operatorSend(address from, address to, uint256 amount, bytes data, bytes operatorData) public;
+    function send(address to, uint256 amount, bytes data) external;
+    function operatorSend(address from, address to, uint256 amount, bytes data, bytes operatorData) external;
 
-    function burn(uint256 amount, bytes data) public;
-    function operatorBurn(address from, uint256 amount, bytes data, bytes operatorData) public;
+    function burn(uint256 amount, bytes data) external;
+    function operatorBurn(address from, uint256 amount, bytes data, bytes operatorData) external;
 
     event Sent(
         address indexed operator,


### PR DESCRIPTION
Use `external` instead of `public` in the ERC777 interface and definitions