### PR TITLE
Fix layout error in EIP-615

### DIFF
--- a/EIPS/eip-615.md
+++ b/EIPS/eip-615.md
@@ -63,9 +63,9 @@ Especially important is efficient translation to and from eWasm.  To that end we
 These forms
 > *`INSTRUCTION`*
 >
-> *`INSTRUCTION x`* 
+> *`INSTRUCTION x`*
 >
-> *`INSTRUCTION x, y`* 
+> *`INSTRUCTION x, y`*
 
 name an *`INSTRUCTION`* with no, one and two arguments, respectively. An instruction is represented in the bytecode as a single-byte opcode. Any arguments are laid out as immediate data bytes following the opcode inline, interpreted as fixed length, MSB-first, two's-complement, two-byte positive integers. (Negative values are reserved for extensions.)
 
@@ -96,7 +96,7 @@ To support subroutines, `BEGINSUB`, `JUMPSUB`, and `RETURNSUB` are provided.  Br
 
 #### Switches, Callbacks, and Virtual Functions
 
-Dynamic jumps are also used for `O(1)` indirection: an address to jump to is selected to push on the stack and be jumped to.  So we also propose two more instructions to provide for constrained indirection.  We support these with vectors of `JUMPDEST` or `BEGINSUB` offsets stored inline, which can be selected with an index on the stack.  That constrains validation to a specified subset of all possible destinations.  The danger of quadratic blow up is avoided because it takes as much space to store the jump vectors as it does to code the worst case exploit. 
+Dynamic jumps are also used for `O(1)` indirection: an address to jump to is selected to push on the stack and be jumped to.  So we also propose two more instructions to provide for constrained indirection.  We support these with vectors of `JUMPDEST` or `BEGINSUB` offsets stored inline, which can be selected with an index on the stack.  That constrains validation to a specified subset of all possible destinations.  The danger of quadratic blow up is avoided because it takes as much space to store the jump vectors as it does to code the worst case exploit.
 
 Dynamic jumps to a `JUMPDEST` are used to implement `O(1)` jumptables, which are useful for dense switch statements, and are implemented as instructions similar to this one on most CPUs.
 
@@ -181,7 +181,7 @@ frame |             21
 ______|___________  22
                        <- SP
 ```
-and after pushing two arguments and branching with `JUMPSUB` to a `BEGINSUB 2, 3` 
+and after pushing two arguments and branching with `JUMPSUB` to a `BEGINSUB 2, 3`
 ```
 PUSH 10
 PUSH 11
@@ -244,7 +244,7 @@ _Execution_ is as defined in the [Yellow Paper](https://ethereum.github.io/yello
 
 >**5**  Invalid instruction
 
-We propose to expand and extend the Yellow Paper conditions to handle the new instructions we propose. 
+We propose to expand and extend the Yellow Paper conditions to handle the new instructions we propose.
 
 To handle the return stack we expand the conditions on stack size:
 >**2a**  The size of the data stack does not exceed 1024.
@@ -301,7 +301,7 @@ These changes would need to be implemented in phases at decent intervals:
 
 >**2.**  A later hard fork would require clients to place only valid code on the block chain.  Note that despite the fork old EVM code will still need to be supported indefinitely.
 
-If desired, the period of deprecation can be extended indefinitely by continuing to accept code not versioned as new—but without validation.  That is, by delaying phase 2.  Since we must continue to run old code this is not technically difficult. 
+If desired, the period of deprecation can be extended indefinitely by continuing to accept code not versioned as new—but without validation.  That is, by delaying phase 2.  Since we must continue to run old code this is not technically difficult.
 
 ## Rationale
 
@@ -330,7 +330,7 @@ Validating that jumps are to valid addresses takes two sequential passes over th
     is_sub[code_size]     // is there a BEGINSUB at PC?
     is_dest[code_size]    // is there a JUMPDEST at PC?
     sub_for_pc[code_size] // which BEGINSUB is PC in?
-    
+
     bool validate_jumps(PC)
     {
         current_sub = PC
@@ -350,7 +350,7 @@ Validating that jumps are to valid addresses takes two sequential passes over th
                 is_dest[PC] = true
             sub_for_pc[PC] = current_sub
         }
-        
+
         // check that targets are in subroutine
         for (PC = 0; instruction = bytecode[PC]; PC = advance_pc(PC))
         {
@@ -374,7 +374,7 @@ Note that code like this is already run by EVMs to check dynamic jumps, includin
 
 #### Subroutine Validation
 
-This function can be seen as a symbolic execution of a subroutine in the EVM code, where only the effect of the instructions on the state being validated is computed.  Thus the structure of this function is very similar to an EVM interpreter.  This function can also be seen as an acyclic traversal of the directed graph formed by taking instructions as vertexes and sequential and branching connections as edges, checking conditions along the way.  The traversal is accomplished via recursion, and cycles are broken by returning when a vertex which has already been visited is reached.  The time complexity of this traversal is `O(|E|+|V|): The sum of the number of edges and number of verticies in the graph.
+This function can be seen as a symbolic execution of a subroutine in the EVM code, where only the effect of the instructions on the state being validated is computed.  Thus the structure of this function is very similar to an EVM interpreter.  This function can also be seen as an acyclic traversal of the directed graph formed by taking instructions as vertexes and sequential and branching connections as edges, checking conditions along the way.  The traversal is accomplished via recursion, and cycles are broken by returning when a vertex which has already been visited is reached.  The time complexity of this traversal is `O(|E|+|V|)`: The sum of the number of edges and number of verticies in the graph.
 
 The basic approach is to call `validate_subroutine(i, 0, 0)`, for `i` equal to the first instruction in the EVM code through each `BEGINDATA` offset.  `validate_subroutine()` traverses instructions sequentially, recursing when `JUMP` and `JUMPI` instructions are encountered.  When a destination is reached that has been visited before it returns, thus breaking cycles.  It returns true if the subroutine is valid, false otherwise.
 
@@ -424,7 +424,7 @@ The basic approach is to call `validate_subroutine(i, 0, 0)`, for `i` equal to t
                 return false
 
             if instruction is STOP, RETURN, or SUICIDE
-                return true	   
+                return true
 
             // violates single entry
             if instruction is BEGINSUB
@@ -447,10 +447,10 @@ The basic approach is to call `validate_subroutine(i, 0, 0)`, for `i` equal to t
             if instruction is JUMPTO
             {
                 PC = jump_target(PC)
-                continue 
+                continue
             }
 
-            // recurse to jump to code to validate 
+            // recurse to jump to code to validate
             if instruction is JUMPIF
             {
                 if not validate_subroutine(jump_target(PC), return_pc, SP)


### PR DESCRIPTION
* Fix a layout typo
  * Missing a backtick turned it into a table
* Remove trailing whitespace

<img width="922" alt="screen shot 2019-03-04 at 16 36 55" src="https://user-images.githubusercontent.com/1052016/53764989-ca380500-3e9c-11e9-8200-d4f951c541e6.png">
