### PR TITLE
Update params to reflect  "0.9.2" and "0.9.3" params

### DIFF
--- a/EIPS/eip-1057.md
+++ b/EIPS/eip-1057.md
@@ -33,7 +33,7 @@ The main elements of the algorithm are:
 * Adds reads from a small, low-latency cache that supports random addresses.
 * Increases the DRAM read from 128 bytes to 256 bytes.
 
-The random sequence changes every `PROGPOW_PERIOD` (2 to 12 minutes).  When mining source code is generated for the random sequence and compiled on the host CPU.  The GPU will execute the compiled code where what math to perform and what mix state to use are already resolved.
+The random sequence changes every `PROGPOW_PERIOD` (about 2 to 12 minutes depending on the configured value).  When mining source code is generated for the random sequence and compiled on the host CPU.  The GPU will execute the compiled code where what math to perform and what mix state to use are already resolved.
 
 While a custom ASIC to implement this algorithm is still possible, the efficiency gains available are minimal.  The majority of a commodity GPU is required to support the above elements. The only optimizations available are:
 * Remove the graphics pipeline (displays, geometry engines, texturing, etc)

--- a/EIPS/eip-1057.md
+++ b/EIPS/eip-1057.md
@@ -33,7 +33,7 @@ The main elements of the algorithm are:
 * Adds reads from a small, low-latency cache that supports random addresses.
 * Increases the DRAM read from 128 bytes to 256 bytes.
 
-The random sequence changes every `PROGPOW_PERIOD` (50 blocks or about 12.5 minutes).  When mining source code is generated for the random sequence and compiled on the host CPU.  The GPU will execute the compiled code where what math to perform and what mix state to use are already resolved.
+The random sequence changes every `PROGPOW_PERIOD` (2 to 12 minutes).  When mining source code is generated for the random sequence and compiled on the host CPU.  The GPU will execute the compiled code where what math to perform and what mix state to use are already resolved.
 
 While a custom ASIC to implement this algorithm is still possible, the efficiency gains available are minimal.  The majority of a commodity GPU is required to support the above elements. The only optimizations available are:
 * Remove the graphics pipeline (displays, geometry engines, texturing, etc)
@@ -107,17 +107,30 @@ Ethash requires external memory due to the large size of the DAG.  However that 
 The DAG is generated exactly as in Ethash.  All the parameters (ephoch length, DAG size, etc) are unchanged.  See the original [Ethash](https://github.com/ethereum/wiki/wiki/Ethash) spec for details on generating the DAG.
 
 ProgPoW can be tuned using the following parameters.  The proposed settings have been tuned for a range of existing, commodity GPUs:
+* `PROGPOW_PERIOD`: Number of blocks before changing the random program
+* `PROGPOW_LANES`: The number of parallel lanes that coordinate to calculate a single hash instance
+* `PROGPOW_REGS`: The register file usage size
+* `PROGPOW_DAG_LOADS`: Number of uint32 loads from the DAG per lane
+* `PROGPOW_CACHE_BYTES`: The size of the cache
+* `PROGPOW_CNT_DAG`: The number of DAG accesses, defined as the outer loop of the algorithm (64 is the same as ethash)
+* `PROGPOW_CNT_CACHE`: The number of cache accesses per loop
+* `PROGPOW_CNT_MATH`: The number of math operations per loop
 
-* `PROGPOW_PERIOD`: Number of blocks before changing the random program; default is `50`.
-* `PROGPOW_LANES`: The number of parallel lanes that coordinate to calculate a single hash instance; default is `16`.
-* `PROGPOW_REGS`: The register file usage size; default is `32`.
-* `PROGPOW_DAG_LOADS`: Number of uint32 loads from the DAG per lane; default is `4`;
-* `PROGPOW_CACHE_BYTES`: The size of the cache; default is `16 x 1024`.
-* `PROGPOW_CNT_DAG`: The number of DAG accesses, defined as the outer loop of the algorithm; default is `64` (same as Ethash).
-* `PROGPOW_CNT_CACHE`: The number of cache accesses per loop; default is `12`.
-* `PROGPOW_CNT_MATH`: The number of math operations per loop; default is `20`.
+The value of these parameters has been tweaked between version 0.9.2 (live on the gangnum testnet) and 0.9.3 (proposed for Ethereum adoption).  See [this medium post](https://medium.com/@ifdefelse/progpow-progress-da5bb31a651b) for details.
 
-The random program changes every `PROGPOW_PERIOD` blocks (default `50`, roughly 12.5 minutes) to ensure the hardware executing the algorithm is fully programmable.  If the program only changed every DAG epoch (roughly 5 days) certain miners could have time to develop hand-optimized versions of the random sequence, giving them an undue advantage.
+| Parameter             | 0.9.2     | 0.9.3     |
+|-----------------------|-----------|-----------|
+| `PROGPOW_PERIOD`      | `50`      | `10`      |
+| `PROGPOW_LANES`       | `16`      | `16`      |
+| `PROGPOW_REGS`        | `32`      | `32`      |
+| `PROGPOW_DAG_LOADS`   | `4`       | `4`       |
+| `PROGPOW_CACHE_BYTES` | `16x1024` | `16x1024` |
+| `PROGPOW_CNT_DAG`     | `64`      | `64`      |
+| `PROGPOW_CNT_CACHE`   | `12`      | `11`      |
+| `PROGPOW_CNT_MATH`    | `20`      | `18`      |
+
+
+The random program changes every `PROGPOW_PERIOD` blocks  to ensure the hardware executing the algorithm is fully programmable.  If the program only changed every DAG epoch (roughly 5 days) certain miners could have time to develop hand-optimized versions of the random sequence, giving them an undue advantage.
 
 Sample code is written in C++, this should be kept in mind when evaluating the code in the specification.
 
@@ -223,7 +236,7 @@ hash32_t keccak_f800_progpow(hash32_t header, uint64_t seed, hash32_t digest)
 
 The inner loop uses FNV and KISS99 to generate a random sequence from the `prog_seed`.  This random sequence determines which mix state is accessed and what random math is performed.
 
-Since the `prog_seed` changes only once per `PROGPOW_PERIOD` (50 blocks or about 12.5 minutes) it is expected that while mining `progPowLoop` will be evaluated on the CPU to generate source code for that period's sequence.  The source code will be compiled on the CPU before running on the GPU.  
+Since the `prog_seed` changes only once per `PROGPOW_PERIOD` it is expected that while mining `progPowLoop` will be evaluated on the CPU to generate source code for that period's sequence.  The source code will be compiled on the CPU before running on the GPU.  
 
 Test vectors can be found [in the test vectors file](../assets/eip-1057/test-vectors.md#progPowInit).
 


### PR DESCRIPTION
Update params to reflect original "0.9.2" values and proposed "0.9.3" params.  
0.9.2 are what is on the gangnam testnet and 0.9.3 are what @IfDefElse propse for mainnet

Also, remove references in text to 50 block default period.
