### PR TITLE
Status changed to Last Call for ERC-1155

### DIFF
--- a/EIPS/eip-1155.md
+++ b/EIPS/eip-1155.md
@@ -4,7 +4,8 @@ title: ERC-1155 Multi Token Standard
 author: Witek Radomski <witek@enjin.com>, Andrew Cooke <andrew@enjin.com>, Philippe Castonguay <pc@horizongames.net>, James Therien <james@enjin.com>, Eric Binet <eric@enjin.com>
 type: Standards Track
 category: ERC
-status: Draft
+status: Last Call
+review-period-end: 2019-03-28
 created: 2018-06-17
 discussions-to: https://github.com/ethereum/EIPs/issues/1155
 requires: 165


### PR DESCRIPTION
Moving 1155 to last call. I've set the review end date to March 28 to provide adequate time for finalization.