### PR TITLE
eip-225: add note about transaction execution

### DIFF
--- a/EIPS/eip-225.md
+++ b/EIPS/eip-225.md
@@ -120,6 +120,7 @@ We repurpose the `ethash` header fields as follows:
    * Should be filled with zeroes normally, modified only while voting.
    * Arbitrary values are permitted nonetheless (even meaningless ones such as voting out non signers) to avoid extra complexity in implementations around voting mechanics.
    * **Must** be filled with zeroes on checkpoint (i.e. epoch transition) blocks.
+   * Transaction execution **must** use the actual block signer (see `extraData`) for the `COINBASE` opcode.
  * **`nonce`**: Signer proposal regarding the account defined by the `beneficiary` field.
    * Should be **`NONCE_DROP`** to propose deauthorizing `beneficiary` as a existing signer.
    * Should be **`NONCE_AUTH`** to propose authorizing `beneficiary` as a new signer.


### PR DESCRIPTION
Adds a small note about transaction execution for Clique Consensus.  Clarifies spec ambiguity.