### PR TITLE
Use preferred reference format for EIP references

### DIFF
--- a/EIPS/eip-1155.md
+++ b/EIPS/eip-1155.md
@@ -38,7 +38,7 @@ pragma solidity ^0.5.2;
 
 /**
     @title ERC-1155 Multi Token Standard
-    @dev See https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1155.md
+    @dev See https://eips.ethereum.org/EIPS/eip-1155
     Note: The ERC-165 identifier for this interface is 0xd9b67a26.
  */
 interface ERC1155 /* is ERC165 */ {
@@ -191,7 +191,7 @@ The string format of the substituted hexadecimal ID MUST be lowercase alphanumer
 
 ### Metadata Extensions
 
-The following optional extensions can be identified with the (ERC-165 Standard Interface Detection)[https://github.com/ethereum/EIPs/blob/master/EIPS/eip-165.md].
+The following optional extensions can be identified with the (ERC-165 Standard Interface Detection)[https://eips.ethereum.org/EIPS/eip-165].
 
 Changes to the URI MUST emit the `URI` event if the change can be expressed with an event. If the optional ERC1155Metadata_URI extension is included, the value returned by this function SHOULD be used to retrieve values for which no event was emitted. The function MUST return the same value as the event if it was emitted.
 
@@ -367,7 +367,7 @@ fr.json:
 
 ## Approval
 
-The function `setApprovalForAll` allows an operator to manage one's entire set of tokens on behalf of the approver. To permit approval of a subset of token IDs, an interface such as [ERC-1761 Scoped Approval Interface](https://github.com/ethereum/EIPs/issues/1761) is suggested.
+The function `setApprovalForAll` allows an operator to manage one's entire set of tokens on behalf of the approver. To permit approval of a subset of token IDs, an interface such as [ERC-1761 Scoped Approval Interface (DRAFT)](https://eips.ethereum.org/EIPS/eip-1761) is suggested.
 
 ## Rationale
 
@@ -421,7 +421,7 @@ Approval</summary>
 
 The function `setApprovalForAll` allows an operator to manage one's entire set of tokens on behalf of the approver. It enables frictionless interaction with exchange and trade contracts.
 
-Restricting approval to a certain set of Token IDs, quantities or other rules may be done with an additional interface or an external contract. The rationale is to keep the ERC-1155 standard as generic as possible for all use-cases without imposing a specific approval scheme on implementations that may not need it. Standard token approval interfaces can be used, such as the suggested [ERC-1761 Scoped Approval Interface](https://github.com/ethereum/EIPs/issues/1761) which is compatible with ERC-1155.
+Restricting approval to a certain set of Token IDs, quantities or other rules may be done with an additional interface or an external contract. The rationale is to keep the ERC-1155 standard as generic as possible for all use-cases without imposing a specific approval scheme on implementations that may not need it. Standard token approval interfaces can be used, such as the suggested [ERC-1761 Scoped Approval Interface (DRAFT)](https://eips.ethereum.org/EIPS/eip-1761) which is compatible with ERC-1155.
 
 </details>
 
@@ -484,16 +484,16 @@ balanceOf(baseToken + index, msg.sender); // Get balance of the Non-Fungible tok
 ## References
 
 **Standards**
-- [ERC-721 Non-Fungible Token Standard](https://raw.githubusercontent.com/ethereum/EIPs/master/EIPS/eip-721.md)
-- [ERC-165 Standard Interface Detection](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-165.md)
-- [ERC-1538 Transparent Contract Standard](https://github.com/ethereum/EIPs/issues/1538)
+- [ERC-721 Non-Fungible Token Standard](https://eips.ethereum.org/EIPS/eip-721)
+- [ERC-165 Standard Interface Detection](https://eips.ethereum.org/EIPS/eip-165)
+- [ERC-1538 Transparent Contract Standard (DRAFT)](https://github.com/ethereum/EIPs/issues/1538)
 - [JSON Schema](https://json-schema.org/)
 - [RFC 2119 Key words for use in RFCs to Indicate Requirement Levels](https://www.ietf.org/rfc/rfc2119.txt)
 
 **Implementations**
 - [ERC-1155 Reference Implementation](https://github.com/enjin/erc-1155)
 - [Horizon Games - Multi-Token Standard](https://github.com/horizon-games/multi-token-standard)
-- [Enjin Coin](https://enjincoin.io) ([github](https://github.com/enjin))
+- [Enjin Coin](https://enjincoin.io) ([GitHub](https://github.com/enjin))
 - [The Sandbox - Dual ERC-1155/721 Contract](https://github.com/pixowl/thesandbox-contracts/tree/master/src/Asset)
 
 **Articles & Discussions**


### PR DESCRIPTION
This updates to use the preferred EIP format for all references.

Source: https://github.com/ethereum/EIPs#preferred-citation-format

Also I have added (DRAFT) for references that are not (yet!) published standards.