### PR TITLE
ERC777: remove default `from`

### DIFF
--- a/EIPS/eip-777.md
+++ b/EIPS/eip-777.md
@@ -292,7 +292,7 @@ Indicates the authorization of `operator` as an *operator* for `holder`.
 
 > <small>**parameters**</small>  
 > <small>`operator`: Address which became an *operator* of `holder`.</small>  
-> <small>`holder`: Address of a holder which authorized the `operator` address as an *operator*.</small>
+> <small>`holder`: Address of a *holder* which authorized the `operator` address as an *operator*.</small>
 
 **`RevokedOperator` event** <a id="revokedoperator"></a>
 
@@ -306,7 +306,7 @@ Indicates the revocation of `operator` as an *operator* for `holder`.
 
 > <small>**parameters**</small>  
 > <small>`operator`: Address which was revoked as an *operator* of `holder`.</small>  
-> <small>`holder`: Address of a holder which revoked the `operator` address as an *operator*.</small>
+> <small>`holder`: Address of a *holder* which revoked the `operator` address as an *operator*.</small>
 
 The `defaultOperators`, `authorizeOperator`, `revokeOperator` and `isOperatorFor` functions described below
 MUST be implemented to manage *operators*.
@@ -367,7 +367,7 @@ Indicate whether the `operator` address is an *operator* of the `holder` address
 
 > <small>**parameters**</small>  
 > <small>`operator`: Address which may be an *operator* of `holder`.</small>  
-> <small>`holder`: Address of a holder which may have the `operator` address as an *operator*.</small>
+> <small>`holder`: Address of a *holder* which may have the `operator` address as an *operator*.</small>
 >
 > <small>**returns:** `true` if `operator` is an *operator* of `holder` and `false` otherwise.
 
@@ -465,9 +465,9 @@ Indicate a send of `amount` of tokens from the `from` address to the `to` addres
 
 > <small>**parameters**</small>  
 > <small>`operator`: Address which triggered the send.</small>  
-> <small>`from`: Holder.</small>  
-> <small>`to`: Token recipient.</small>  
-> <small>`amount`: Number of tokens to send.</small>  
+> <small>`from`: *Holder* whose tokens were sent.</small>  
+> <small>`to`: Recipient of the tokens.</small>  
+> <small>`amount`: Number of tokens sent.</small>  
 > <small>`data`: Information provided by the *holder*.</small>  
 > <small>`operatorData`: Information provided by the *operator*.</small>
 
@@ -485,7 +485,7 @@ Send the `amount` of tokens from the address `msg.sender` to the address `to`.
 The *operator* and the *holder* MUST both be the `msg.sender`.
 
 > <small>**parameters**</small>  
-> <small>`to`: Token recipient.</small>  
+> <small>`to`: Recipient of the tokens.</small>  
 > <small>`amount`: Number of tokens to send.</small>  
 > <small>`data`: Information provided by the *holder*.</small>
 
@@ -581,9 +581,9 @@ Indicate the minting of `amount` of tokens to the `to` address by the `operator`
 
 > <small>**parameters**</small>  
 > <small>`operator`: Address which triggered the mint.</small>  
-> <small>`to`: Token recipient.</small>  
+> <small>`to`: Recipient of the tokens.</small>  
 > <small>`amount`: Number of tokens minted.</small>  
-> <small>`data`: Information provided by the *holder*.</small>  
+> <small>`data`: MUST be empty.</small>  
 > <small>`operatorData`: Information provided by the *operator*.</small>
 
 #### **Burning Tokens**
@@ -657,7 +657,7 @@ Indicate the burning of `amount` of tokens from the `from` address by the `opera
 
 > <small>**parameters**</small>  
 > <small>`operator`: Address which triggered the burn.</small>  
-> <small>`from`: Holder whose tokens are burned.</small>  
+> <small>`from`: *Holder* whose tokens were burned.</small>  
 > <small>`amount`: Number of tokens burned.</small>
 > <small>`data`: Information provided by the *holder*.</small>  
 > <small>`operatorData`: Information provided by the *operator*.</small>
@@ -742,8 +742,8 @@ by the `operator` address.
 
 > <small>**parameters**</small>  
 > <small>`operator`: Address which triggered the balance decrease (through sending or burning).</small>  
-> <small>`from`: *holder*.</small>  
-> <small>`to`: *token recipient* for a send and `0x` for a burn.</small>  
+> <small>`from`: *Holder* whose tokens were sent.</small>  
+> <small>`to`: Recipient of the tokens for a send (or `0x0` for a burn).</small>  
 > <small>`amount`: Number of tokens the *holder* balance is decreased by.</small>  
 > <small>`data`: Information provided by the *holder*.</small>  
 > <small>`operatorData`: Information provided by the *operator*.</small>
@@ -827,8 +827,8 @@ by the `operator` address.
 
 > <small>**parameters**</small>  
 > <small>`operator`: Address which triggered the balance increase (through sending or minting).</small>  
-> <small>`from`: *holder* for a send and `0x` for a mint.</small>  
-> <small>`to`: *token recipient*.</small>  
+> <small>`from`: *Holder* whose tokens were sent (or `0x0` for a mint).</small>  
+> <small>`to`: Recipient of the tokens.</small>  
 > <small>`amount`: Number of tokens the *recipient* balance is increased by.</small>  
 > <small>`data`: Information provided by the *holder*.</small>
 > <small>`operatorData`: Information provided by the *operator*.</small>

--- a/EIPS/eip-777.md
+++ b/EIPS/eip-777.md
@@ -497,10 +497,6 @@ function operatorSend(address from, address to, uint256 amount, bytes calldata d
 
 Send the `amount` of tokens on behalf of the address `from` to the address `to`.
 
-The *operator* MUST be `msg.sender`.
-The value of `from` MAY be `0x0`,
-then the `from` (*holder*) used for the send MUST be `msg.sender` (the `operator`).
-
 *Reminder*: If the *operator* address is not an authorized operator of the `from` address,
 then the send process MUST `revert`.
 
@@ -511,8 +507,8 @@ that the *operator* MAY specify an explicit value for `operatorData`
 (which cannot be done with the `send` function).
 
 > <small>**parameters**</small>  
-> <small>`from`: Holder (or `0x0` to set `from` to `msg.sender`).</small>  
-> <small>`to`: Token recipient.</small>  
+> <small>`from`: *Holder* whose tokens are being sent.</small>  
+> <small>`to`: Recipient of the tokens.</small>  
 > <small>`amount`: Number of tokens to send.</small>  
 > <small>`data`: Information provided by the *holder*.</small>  
 > <small>`operatorData`: Information provided by the *operator*.</small>
@@ -691,15 +687,11 @@ function operatorBurn(address from, uint256 amount, bytes calldata data, bytes c
 
 Burn the `amount` of tokens on behalf of the address `from`.
 
-The *operator* MUST be `msg.sender`.
-The value of `from` MAY be `0x0`,
-then the `from` (*holder*) used for the burn MUST be `msg.sender` (the `operator`).
-
 *Reminder*: If the *operator* address is not an authorized operator of the `from` address,
 then the burn process MUST `revert`.
 
 > <small>**parameters**</small>  
-> <small>`from`: Holder whose tokens will be burned (or `0x0` to set `from` to `msg.sender`).</small>  
+> <small>`from`: *Holder* whose tokens will be burned.</small>  
 > <small>`amount`: Number of tokens to burn.</small>  
 > <small>`data`: Information provided by the *holder*.</small>  
 > <small>`operatorData`: Information provided by the *operator*.</small>


### PR DESCRIPTION
- Remove default from for operatorSend/Burn
- cleanup of function parameters
