### PR TITLE
Update eip-1538.md to add discussions-to field

### DIFF
--- a/EIPS/eip-1538.md
+++ b/EIPS/eip-1538.md
@@ -2,6 +2,7 @@
 eip: 1538
 title: Transparent Contract Standard
 author: Nick Mudge <nick@mokens.io>
+discussions-to: https://github.com/ethereum/EIPs/issues/1538
 status: Draft
 type: Standards Track
 category: ERC


### PR DESCRIPTION
@mudgen I merged https://github.com/ethereum/EIPs/pull/1879 too soon. Adding the missing `discussions-to`-field here.