### PR TITLE
Remove Mist from EIP-55 as it is deprecated

### DIFF
--- a/EIPS/eip-55.md
+++ b/EIPS/eip-55.md
@@ -102,7 +102,6 @@ Note that the input to the Keccak256 hash is the lowercase hexadecimal string (i
 | Etherwall 2.0.1          | Yes                            | Yes                        | Yes               | Yes              |
 | Jaxx 1.2.17              | No                             | Yes                        | Yes               | Yes              |
 | MetaMask 3.7.8           | Yes                            | Yes                        | Yes               | Yes              |
-| Mist 0.8.10              | Yes                            | Yes                        | Yes               | Yes              |
 | MyEtherWallet v3.9.4     | Yes                            | Yes                        | Yes               | Yes              |
 | Parity 1.6.6-beta (UI)   | Yes                            | Yes                        | Yes               | Yes              |
 | Jaxx Liberty 2.0.0       | Yes                            | Yes                        | Yes               | Yes              |


### PR DESCRIPTION
context: 

![Selection_042](https://user-images.githubusercontent.com/111600/55293290-52a2ba80-53f5-11e9-9536-42d06a90ae5d.png)

https://medium.com/@avsa/sunsetting-mist-da21c8e943d2
