### PR TITLE
EIP-1891: Contract-based Account Versioning

### DIFF
--- a/EIPS/eip-1891.md
+++ b/EIPS/eip-1891.md
@@ -3,9 +3,10 @@ eip: 1891
 title: Contract-based Account Versioning
 author: Wei Tang (@sorpaas)
 discussions-to: https://github.com/sorpaas/EIPs/issues/6
-status: Draft
+status: Abandoned
 type: Standards Track
 category: Core
+superseded-by: 1702
 created: 2019-03-31
 ---
 

--- a/EIPS/eip-1891.md
+++ b/EIPS/eip-1891.md
@@ -1,5 +1,5 @@
 ---
-eip: <to be assigned>
+eip: 1891
 title: Contract-based Account Versioning
 author: Wei Tang (@sorpaas)
 discussions-to: https://github.com/sorpaas/EIPs/issues/4

--- a/EIPS/eip-1891.md
+++ b/EIPS/eip-1891.md
@@ -6,7 +6,7 @@ discussions-to: https://github.com/sorpaas/EIPs/issues/4
 status: Draft
 type: Standards Track
 category: Core
-created: 2019-01-17
+created: 2019-03-31
 ---
 
 ## Simple Summary

--- a/EIPS/eip-1891.md
+++ b/EIPS/eip-1891.md
@@ -51,11 +51,10 @@ except that:
     * Set storage of `VERSION_CONTRACT_ADDR` where key is `address`
       (prefixed with 0 so that it's 256 bits), and value is `version`.
       
-When invoking a contract, either by a transaction or a variant of
-call:
+Before invoking a contract, either by a transaction, `CALL`, `STATICCALL`, `CALLCODE` or `DELEGATECALL`:
 
 * Check whether the storage of `VERSION_CONTRACT_ADDR` has non-zero
-  value with key `address` (prefixed with 0 so that it's 256 bits).
+  value with key `address` (`I_a` in yellow paper, prefixed with 0 so that it's 256 bits).
   * If so, invoke the VM version defined by value.
   * Otherwise, invoke the default (legacy) VM version.
   
@@ -63,6 +62,8 @@ When self-destruct a contract:
 
 * Set storage value of `VERSION_CONTRACT_ADDR` where key is `address`
   (prefixed with 0 so that it's 256 bits) to zero.
+  
+Contract creation transaction always uses the default (legacy) VM version.
 
 ## Copyright
 

--- a/EIPS/eip-1891.md
+++ b/EIPS/eip-1891.md
@@ -2,7 +2,7 @@
 eip: 1891
 title: Contract-based Account Versioning
 author: Wei Tang (@sorpaas)
-discussions-to: https://github.com/sorpaas/EIPs/issues/5
+discussions-to: https://github.com/sorpaas/EIPs/issues/6
 status: Draft
 type: Standards Track
 category: Core

--- a/EIPS/eip-1891.md
+++ b/EIPS/eip-1891.md
@@ -2,7 +2,7 @@
 eip: 1891
 title: Contract-based Account Versioning
 author: Wei Tang (@sorpaas)
-discussions-to: https://github.com/sorpaas/EIPs/issues/4
+discussions-to: https://github.com/sorpaas/EIPs/issues/5
 status: Draft
 type: Standards Track
 category: Core


### PR DESCRIPTION
Provide an alternative proposal compared with EIP-1702 / ECIP-1040 /
EIP-1707, with the following advantages:

* We don't need to modify existing account state format.
* We don't need to modify how precompiled contracts are invoked.
* The version bytes cannot be forged.

The basic idea is that we use a contract address' storage to store an
account's version bytes. Note that it is also possible to extend this
scheme to store other information about an account.