### PR TITLE
EIP-778: address review feedback

### DIFF
--- a/EIPS/eip-778.md
+++ b/EIPS/eip-778.md
@@ -37,10 +37,10 @@ be able to determine which record is newer.
 The components of a node record are:
 
 - `signature`: cryptographic signature of record contents
-- `seq`: The sequence number, a 64 bit integer. Nodes should increase the number whenever
-   the record changes and republish the record.
+- `seq`: The sequence number, a 64-bit unsigned integer. Nodes should increase the number
+   whenever the record changes and republish the record.
 -  The remainder of the record consists of arbitrary key/value pairs, which must be sorted
-   by key.
+   by key. Keys must be unique.
 
 A record's signature is made and validated according to an *identity scheme*. The identity
 scheme is also responsible for deriving a node's address in the DHT.
@@ -53,9 +53,9 @@ records larger than this size.
 
 Records are signed and encoded as follows:
 
-    content   = rlp(seq) || rlp(k) || rlp(v) || ...
-    signature = rlp(sign(rlp_list(content)))
-    record    = rlp_list(signature || content)
+    content   = [seq, k, v, ...]
+    signature = sign(content)
+    record    = [signature, seq, k, v, ...]
 
 ### Key/Value Pairs
 
@@ -67,19 +67,20 @@ preferred. The following keys are pre-defined:
 | `id`        | name of identity scheme, e.g. "v4"        |
 | `secp256k1` | compressed secp256k1 public key, 33 bytes |
 | `ip`        | IP address, 4 or 16 bytes                 |
-| `tcp`       | TCP port                                  |
-| `udp`       | UDP port                                  |
+| `tcp`       | TCP port, big endian integer              |
+| `udp`       | UDP port, big endian integer              |
 
 ### "v4" Identity Scheme
 
 This specification defines a single scheme to be used as the default. The "v4" scheme is
-backwards-compatible with the cryptosystem used by Node Discovery Protocol v4.
+backwards-compatible with the cryptosystem used by Node Discovery v4.
 
 - To sign record `content` with this scheme, apply the keccak256 hash function (as used by
   the EVM) to `content`, then create a signature of the hash. The resulting 64-byte
-  signature is encoded as the concatenation of the `r` and `s` signature values.
+  signature is encoded as the concatenation of the `r` and `s` signature values (the
+  recovery ID `v` is omitted).
 - To verify a record, check that the signature was made by the public key in the
-  "secp256k1" key/value pair.
+  "secp256k1" key/value pair of the record.
 - To derive a node address, take the keccak256 hash of the uncompressed public key.
 
 # Rationale
@@ -97,6 +98,43 @@ The size of a record is limited because records are relayed frequently and may b
 in size-constrained protocols such as DNS. A record containing a IPv4 address, when signed
 using the "v4" scheme occupies roughly 120 bytes, leaving plenty of room for additional
 metadata.
+
+# Test Vectors
+
+Example (valid) record:
+
+```text
+f884b8407098ad865b00a582051940cb9cf36836572411a4727878307701
+1599ed5cd16b76f2635f4e234738f30813a89eb9137e3e3df5266e3a1f11
+df72ecf1145ccb9c01826964827634826970847f00000189736563703235
+366b31a103ca634cae0d49acb401d8a4c6b6fe8c55b70d115bf400769cc1
+400f3258cd31388375647082765f
+```
+
+The raw RLP structure of this record is:
+
+```text
+[
+  7098ad865b00a582051940cb9cf36836572411a47278783077011599ed5cd16b76f2635f4e234738f30813a89eb9137e3e3df5266e3a1f11df72ecf1145ccb9c,
+  01,
+  "id",
+  "v4",
+  "ip",
+  7f000001,
+  "secp256k1",
+  03ca634cae0d49acb401d8a4c6b6fe8c55b70d115bf400769cc1400f3258cd3138,
+  "udp",
+  765f,
+]
+```
+
+The record contains sequence number `1`.
+
+A v4 enode URL containing the same information (but no signature or sequence number):
+
+```text
+enode://ca634cae0d49acb401d8a4c6b6fe8c55b70d115bf400769cc1400f3258cd31387574077f301b421bc84df7266c44e9e6d569fc56be00812904767bf5ccd1fc7f@127.0.0.1:0?discport=30303
+```
 
 # Copyright
 


### PR DESCRIPTION
- Sequence number is unsigned integer
- Keys must be unique
- Ports are big-endian
- Remove confusing notation
- "v4" signature doesn't contain recovery ID
- Add test vector