### PR TITLE
End last call, revert ERC to draft

### DIFF
--- a/EIPS/eip-1066.md
+++ b/EIPS/eip-1066.md
@@ -3,7 +3,7 @@ eip: 1066
 title: Status Codes
 author: Brooklyn Zelenka (@expede), Tom Carchrae (@carchrae), Gleb Naumenko (@naumenkogs)
 discussions-to: https://ethereum-magicians.org/t/erc-1066-ethereum-status-codes-esc/
-status: Last Call
+status: Draft
 type: Standards Track
 category: ERC
 review-period-end: 2019-02-25


### PR DESCRIPTION
This formal review started over a month ago with no end in sight.

This PR reverts the EIP to draft status.