### PR TITLE
ERC1820: Move to final, mark 820 as superseded

### DIFF
--- a/EIPS/eip-1820.md
+++ b/EIPS/eip-1820.md
@@ -3,8 +3,7 @@ eip: 1820
 title: Pseudo-introspection Registry Contract
 author: Jordi Baylina <jordi@baylina.cat>, Jacques Dafflon <mail@0xjac.com>
 discussions-to: https://github.com/ethereum/EIPs/pulls/1820
-status: Last Call
-review-period-end: 2019-04-04
+status: Final
 type: Standards Track
 category: ERC
 requires: 165, 214

--- a/EIPS/eip-820.md
+++ b/EIPS/eip-820.md
@@ -3,12 +3,21 @@ eip: 820
 title: Pseudo-introspection Registry Contract
 author: Jordi Baylina <jordi@baylina.cat>, Jacques Dafflon <jacques@dafflon.tech>
 discussions-to: https://github.com/ethereum/EIPs/issues/820
-status: Final
+status: Superseded
 type: Standards Track
 category: ERC
 requires: 165, 214
 created: 2018-01-05
+superseded-by: 1820
 ---
+
+> :information_source: **[ERC1820] has superseded [ERC820].** :information_source:  
+> [ERC1820] fixes the incompatibility in the [ERC165] logic which was introduced by the Solidty 0.5 update.  
+> Have a look at the [official announcement][erc1820-annoucement], and the comments about the [bug][erc820-bug] and the [fix][erc820-fix].  
+> Apart from this fix, [ERC1820] is functionally equivalent to [ERC820].
+>
+> :warning: [ERC1820] MUST be used in lieu of [ERC820]. :warning:
+
 
 ## Simple Summary
 
@@ -889,3 +898,7 @@ Copyright and related rights waived via [CC0].
 [Nick]: https://github.com/Arachnid/
 [William Entriken]: https://github.com/fulldecent
 [ENS]: https://ens.domains/
+[ERC1820]: https://eips.ethereum.org/EIPS/eip-1820
+[erc1820-annoucement]: https://github.com/ethereum/EIPs/issues/820#issuecomment-464109166
+[erc820-bug]: https://github.com/ethereum/EIPs/issues/820#issuecomment-452465748
+[erc820-fix]: https://github.com/ethereum/EIPs/issues/820#issuecomment-454021564


### PR DESCRIPTION
There was no significant changes and no functional changes to ERC1820.  
The only change made was a change to the natspec comments on the registry.  
(See 556cc58428a0044141a878ad5e68b18bc69e13f0 for the changes.)

Thanks to @mcdee and @fulldecent for the reviews.

@nicksavers Could you please merge the PR and make 1820 final? Thanks