### PR TITLE
ERC777: Clarify behavior with missing tokensReceived

### DIFF
--- a/EIPS/eip-777.md
+++ b/EIPS/eip-777.md
@@ -823,7 +823,9 @@ If the *recipient* is a contract, which has not registered an `ERC777TokensRecip
 then the token contract:
 
 - MUST `revert` if the `tokensReceived` hook is called from a mint or send call.
-- SHOULD accept if the `tokensReceived` hook is called from an ERC20 `transfer` or `transferFrom` call.
+
+- SHOULD continue processing the transaction
+  if the `tokensReceived` hook is called from an ERC20 `transfer` or `transferFrom` call.
 
 *NOTE*: A regular address MAY register a different address&mdash;the address of a contract&mdash;implementing
 the interface on its behalf.
@@ -987,8 +989,8 @@ when sending, minting and transferring token via [ERC777] and [ERC20]:
       <code>ERC777TokensRecipient</code><br/>not registered
     </td>
     <td>regular address</td>
-    <td align="center">SHOULD accept</td>
-    <td rowspan="2" align="center">SHOULD accept</td>
+    <td align="center">continue</td>
+    <td rowspan="2" align="center">continue</td>
   </tr>
   <tr>
     <td>contract</td>

--- a/EIPS/eip-777.md
+++ b/EIPS/eip-777.md
@@ -27,7 +27,7 @@ when they receive tokens as well as to allow compatibility with already-deployed
 
 ## Motivation
 
-This standard tries to improve the widely used [ERC20] token standard.
+This standard tries to improve upon the widely used [ERC20] token standard.
 The main advantages of this standard are:
 
 1. Uses the same philosophy as Ether in that tokens are sent with `send(dest, value, data)`.
@@ -41,7 +41,7 @@ The main advantages of this standard are:
    (Rejection is done by `revert`ing in the hook function.)
 
 4. The `tokensReceived` hook allows to send tokens to a contract and notify it in a single transaction,
-   unlike [ERC20] which require a double call (`approve`/`transferFrom`) to achieve this.
+   unlike [ERC20] which requires a double call (`approve`/`transferFrom`) to achieve this.
 
 5. The holder can "authorize" and "revoke" operators which can send tokens on their behalf.
    These operators are intended to be verified contracts
@@ -205,7 +205,7 @@ The following rules MUST be applied regarding the *granularity*:
 
 - The *granularity* value MUST be greater or equal to `1`.
 
-- Any amount of tokens (in the internal denomination) minted, sent or burnt
+- Any amount of tokens (in the internal denomination) minted, sent or burned
   MUST be a multiple of the *granularity* value.
 
 - Any operation that would result in a balance that's not a multiple of the *granularity* value


### PR DESCRIPTION
Changes to #777:
- Clarify behavior with missing `tokensReceived` hook
- Fix some language mistakes
