### PR TITLE
EIP1344 to be considered for next upgrade (Meta EIP1679)

### DIFF
--- a/EIPS/eip-1679.md
+++ b/EIPS/eip-1679.md
@@ -18,6 +18,9 @@ This meta-EIP specifies the changes included in the Ethereum hardfork named Ista
 - Activation: TBD
 - Included EIPs: TBD
 
+## Proposed Changes
+[EIP-1344](https://eips.ethereum.org/EIPS/eip-1344): Add ChainID opcode
+
 ## References
 
 TBA


### PR DESCRIPTION
Per the proposed process for handling EIPs for Hardforks (detailed [here](https://github.com/ethereum/EIPs/blob/9233fd6aaa99161079e395f8733c26c9f4a3b17d/EIPsForHardfork.md)), we would like to propose EIP-1344 be formally considered for inclusion into the Istanbul hardfork (EIP-1679)