### PR TITLE
EIP-225: mark Clique engine status as final

### DIFF
--- a/EIPS/eip-225.md
+++ b/EIPS/eip-225.md
@@ -3,7 +3,7 @@ eip: 225
 title: Clique proof-of-authority consensus protocol
 author: Péter Szilágyi <peterke@gmail.com>
 discussions-to: https://github.com/ethereum/EIPs/issues/225
-status: Draft
+status: Final
 type: Standards Track
 category: Core
 created: 2017-03-06


### PR DESCRIPTION
This changes the status of the clique EIP to **final**. cc @karalabe 

The reason behind this is that Clique engine is already implemented in the following clients:

- Go Ethereum (and Multi Geth)
- Parity Ethereum
- Pantheon
- Nethermind
- EthereumJS

In addition, this engine powers a couple of production networks, such as 

- Rinkeby
- Görli
- Kotti Classic

Changes to the clique engine would require a new proposal replacing or upgrading 225 at this stage. Therefore, I propose to move the Clique EIP to final.
