### PR TITLE
Minor updates to EIP

### DIFF
--- a/EIPS/eip-1319.md
+++ b/EIPS/eip-1319.md
@@ -60,7 +60,7 @@ Implementations are free to choose any scheme for generating a **releaseId**. A 
 function generateReleaseId(string packageName, string version)
   public
   view
-  returns (bytes32)
+  returns (bytes32 releaseId)
   {
     return keccak256(abi.encodePacked(packageName, version));
   }
@@ -114,21 +114,21 @@ The read API consists of a set of methods that allows tooling to extract all con
 function getAllPackageIds(uint offset, uint limit) public view
   returns (
     bytes32[] packageIds,
-    uint offset
+    uint pointer
   );
 
 // Retrieves the unique string `name` associated with a package's id.
-function getPackageName(bytes32 packageId) public view returns (string name);
+function getPackageName(bytes32 packageId) public view returns (string packageName);
 
 // Retrieves the registry's unique identifier for an existing release of a package.
-function getReleaseId(string packageName, string version) public view returns (bytes32);
+function getReleaseId(string packageName, string version) public view returns (bytes32 releaseId);
 
 // Retrieves a slice of the list of all release ids for a package.
 // `offset` and `limit` enable paginated responses / retrieval of the complete set. (See note below)
 function getAllReleaseIds(string packageName, uint offset, uint limit) public view
   returns (
-    bytes32[] ids,
-    uint offset
+    bytes32[] releaseIds,
+    uint pointer
   );
 
 // Retrieves package name, release version and URI location data for a release id.
@@ -144,7 +144,7 @@ function getReleaseData(bytes32 releaseId) public view
 function generateReleaseId(string packageName, string version)
   public
   view
-  returns (bytes32);
+  returns (bytes32 releaseId);
 
 // Returns the total number of unique packages in a registry.
 function numPackageIds() public view returns (uint totalCount);
@@ -154,7 +154,7 @@ function numReleaseIds(string packageName) public view returns (uint totalCount)
 ```
 **Pagination**
 
-`getAllPackageIds` and `getAllReleaseIds` support paginated requests because it's possible that the return values for these methods could become quite large. The methods should return an `offset` that is a pointer to the next available item in a list of all items such that a caller can use it to pick up from where the previous request left off.  (See [here](https://mixmax.com/blog/api-paging-built-the-right-way) for a discussion of the merits and demerits of various pagination strategies.) The `limit` parameter defines the maximum number of items a registry should return per request.
+`getAllPackageIds` and `getAllReleaseIds` support paginated requests because it's possible that the return values for these methods could become quite large. The methods should return a `pointer` that points to the next available item in a list of all items such that a caller can use it to pick up from where the previous request left off.  (See [here](https://mixmax.com/blog/api-paging-built-the-right-way) for a discussion of the merits and demerits of various pagination strategies.) The `limit` parameter defines the maximum number of items a registry should return per request.
 
 ## Rationale
 The proposal hopes to accomplish the following:


### PR DESCRIPTION
Changed some variable names to enforce greater consistency across functions. 

`offset` -> `pointer` update for various return types, since Solidity doesn't allow you to declare the same variable name twice.