### PR TITLE
Add OpenZeppelin implementation link in ERC777

### DIFF
--- a/EIPS/eip-777.md
+++ b/EIPS/eip-777.md
@@ -1233,7 +1233,7 @@ then only the `Sent`, `Minted` and `Burned` events MUST be considered.
 
 The [repository with the reference implementation][0xjac/ERC777] contains all the [tests][ref tests].
 
-## Implementations
+## Implementation
 
 The GitHub repository [0xjac/ERC777] contains the [reference implementation].
 The reference implementation is also available via [npm][npm/erc777] and can be installed with `npm install erc777`.

--- a/EIPS/eip-777.md
+++ b/EIPS/eip-777.md
@@ -1262,7 +1262,7 @@ Copyright and related rights waived via [CC0].
 [reference implementation]: https://github.com/0xjac/ERC777/blob/master/contracts/examples/ReferenceToken.sol
 [EIP223]: https://github.com/ethereum/EIPs/issues/223
 [eth_estimateGas]: https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_estimategas
-[OpenZeppelin/ERC777]: https://github.com/OpenZeppelin/openzeppelin-solidity/blob/v2.3.0-rc.2/contracts/token/ERC777
+[OpenZeppelin/ERC777]: https://github.com/OpenZeppelin/openzeppelin-solidity/blob/v2.3.0-rc.3/contracts/token/ERC777
 
 [authorizedoperator]: #authorizedoperator
 [revokedoperator]: #revokedoperator

--- a/EIPS/eip-777.md
+++ b/EIPS/eip-777.md
@@ -1262,7 +1262,7 @@ Copyright and related rights waived via [CC0].
 [reference implementation]: https://github.com/0xjac/ERC777/blob/master/contracts/examples/ReferenceToken.sol
 [EIP223]: https://github.com/ethereum/EIPs/issues/223
 [eth_estimateGas]: https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_estimategas
-[OpenZeppelin/ERC777]: https://github.com/OpenZeppelin/openzeppelin-solidity/blob/v2.3.0-rc.3/contracts/token/ERC777
+[OpenZeppelin/ERC777]: https://github.com/OpenZeppelin/openzeppelin-solidity/blob/v2.3.0/contracts/token/ERC777
 
 [authorizedoperator]: #authorizedoperator
 [revokedoperator]: #revokedoperator

--- a/EIPS/eip-777.md
+++ b/EIPS/eip-777.md
@@ -1233,10 +1233,12 @@ then only the `Sent`, `Minted` and `Burned` events MUST be considered.
 
 The [repository with the reference implementation][0xjac/ERC777] contains all the [tests][ref tests].
 
-## Implementation
+## Implementations
 
 The GitHub repository [0xjac/ERC777] contains the [reference implementation].
 The reference implementation is also available via [npm][npm/erc777] and can be installed with `npm install erc777`.
+
+The OpenZeppelin implementation is also [available on GitHub][OpenZeppelin/ERC777].
 
 ## Copyright
 
@@ -1260,6 +1262,7 @@ Copyright and related rights waived via [CC0].
 [reference implementation]: https://github.com/0xjac/ERC777/blob/master/contracts/examples/ReferenceToken.sol
 [EIP223]: https://github.com/ethereum/EIPs/issues/223
 [eth_estimateGas]: https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_estimategas
+[OpenZeppelin/ERC777]: https://github.com/OpenZeppelin/openzeppelin-solidity/blob/v2.3.0-rc.2/contracts/token/ERC777
 
 [authorizedoperator]: #authorizedoperator
 [revokedoperator]: #revokedoperator


### PR DESCRIPTION
Hey there! We've implemented ERC777 in OpenZeppelin and would like to include the link in the document.