### PR TITLE
EIP-2019: Fundable Token

### DIFF
--- a/EIPS/eip-2019.md
+++ b/EIPS/eip-2019.md
@@ -5,13 +5,13 @@ author: Fernando Paris <fer@io.builders>, Julio Faura <julio@adhara.io>, Daniel 
 discussions-to: https://github.com/ethereum/EIPs/issues/2105
 status: Draft
 type: Standards Track
-category:  ERC
+category: ERC
 created: 2019-05-10
 requires: 20
 ---
 
 ## Simple Summary
-An extension to the ERC-20 standard token that allows Token wallet owners to request a wallet to be funded, by calling the smart contract and attaching a fund instruction string.
+An extension to the [ERC-20] standard token that allows Token wallet owners to request a wallet to be funded, by calling the smart contract and attaching a fund instruction string.
 
 ## Actors
 
@@ -161,7 +161,7 @@ Retrieves all the fund request data. Only operator, tokenHolder, and orderer can
 | ---------|-------------|
 | operationId | The unique ID to identify the fund order.
 
-## Events
+### Events
 
 #### FundOrdered
 
@@ -241,7 +241,7 @@ The `operationId` is a string and not something more gas efficient to allow easy
 The `operationId` is a competitive resource. It is recommended, but not required, that the hold issuers used a unique prefix to avoid collisions.
 
 ## Backwards Compatibility
-This EIP is fully backwards compatible as its implementation extends the functionality of ERC-20.
+This EIP is fully backwards compatible as its implementation extends the functionality of [ERC-20].
 
 ## Implementation
 The GitHub repository [IoBuilders/fundable-token](https://github.com/IoBuilders/fundable-token) contains the work in progress implementation.
@@ -252,3 +252,4 @@ This proposal has been collaboratively implemented by [adhara.io](https://adhara
 ## Copyright
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
 
+[ERC-20]: https://eips.ethereum.org/EIPS/eip-20

--- a/EIPS/eip-2019.md
+++ b/EIPS/eip-2019.md
@@ -6,7 +6,7 @@ status: Draft
 type: Standards Track
 category:  ERC
 created: 2019-05-10
-requires: 20
+requires: 20, 1996
 
 ---
 
@@ -255,10 +255,10 @@ It's important to hightlight that the token operator, need to process all fundin
 
 Funding instruction format is  open. ISO payment standard like is a good start point,
 
-
+This EIP uses [EIP-1996][EIP-1996] to hold the money after a funding is ordered. The token contract owner or agent, whose implementation is not part of this proposal, acts as a predefined notary to decide if the funding is executed or not.
 
 ## Backwards Compatibility
-This EIP is fully backwards compatible as its implementation extends the functionality of ERC-20.
+This EIP is fully backwards compatible as its implementation extends the functionality of ERC-20 and ERC-1996.
 
 ## Implementation
 The GitHub repository [IoBuilders/fundable-token](https://github.com/IoBuilders/fundable-token) contains the work in progress implementation.
@@ -268,3 +268,5 @@ This proposal has been collaboratively implemented by [adhara.io](https://adhara
 
 ## Copyright
 Copyright and related rights waived via CC0.
+
+[EIP-1996]: https://github.com/ethereum/EIPs/pull/1996

--- a/EIPS/eip-2019.md
+++ b/EIPS/eip-2019.md
@@ -92,7 +92,7 @@ Wallet owner, revokes a given address to be fund orderer.
 
 #### orderFund
 
-Creates a fund request, that will be processed by the token operator.All fund requests,orders, will be linked to the orderer, associating operationId to orderer, to avoid global collision between operationIds. On operationId cannot be repeated for a given orderer, but there can be two equal operation id's for distinct orderers.
+Creates a fund request, that will be processed by the token operator. The function must revert if the operation ID has been used before.
 
 | Parameter | Description |
 | ---------|-------------|
@@ -102,7 +102,7 @@ Creates a fund request, that will be processed by the token operator.All fund re
 
 #### orderFundFrom
 
-Creates a fund request, on behalf of a wallet owner, that will be processed by the token operator. All fund requests,orders, will be linked to the orderer, associating operationId to orderer, to avoid global collision between operationIds. On operationId cannot be repeated for a given orderer, but there can be two equal operation id's for distinct orderers.
+Creates a fund request, on behalf of a wallet owner, that will be processed by the token operator. The function must revert if the operation ID has been used before.
 
 | Parameter | Description |
 | ---------|-------------|
@@ -167,6 +167,8 @@ Retrieves all the fund request data. Only operator, tokenHolder, and orderer can
 
 Emitted when an token wallet owner orders a funding request.
 
+| Parameter | Description |
+| ---------|-------------|
 | operationId | The unique ID to identify the request |
 | walletToFund | The wallet that the player is allowed to start funding requests |
 | value | The amount to be funded. |
@@ -179,7 +181,7 @@ Emitted when an operator starts a funding request after validating the instructi
 | Parameter | Description |
 | ---------|-------------|
 | orderer | The address of the fund request orderer. |
-| operationId | The unique ID per fund orderer to identify the fund. Operation ids are unique per requester/orderer. |
+| operationId | The unique ID to identify the fund. |
 
 #### FundExecuted
 
@@ -188,7 +190,7 @@ Emitted when an operator has executed a funding request.
 | Parameter | Description |
 | ---------|-------------|
 | orderer | The address of the fund request orderer. |
-| operationId | The unique ID per fund orderer to identify the fund. Operation ids are unique per requester/orderer.
+| operationId | The unique ID to identify the fund. |
 
 #### FundRejected
 
@@ -197,7 +199,7 @@ Emitted when an operator has rejected a funding request.
 | Parameter | Description |
 | ---------|-------------|
 | orderer | The address of the fund request orderer. |
-| operationId | The unique ID per fund orderer to identify the fund. Operation ids are unique per requester/orderer. |
+| operationId | The unique ID to identify the fund. |
 | reason | The specific reason that explains why the fund request was rejected. EIP 1066 codes can be used |
 
 #### FundCancelled
@@ -207,7 +209,7 @@ Emitted when a token holder, orderer,  has cancelled a funding request. This can
 | Parameter | Description |
 | ---------|-------------|
 | orderer | The address of the fund request orderer. |
-| operationId | The unique ID per fund orderer to identify the fund. Operation ids are unique per requester/orderer. |
+| operationId | The unique ID to identify the fund. |
 
 #### FundOperatorAuthorized
 

--- a/EIPS/eip-2019.md
+++ b/EIPS/eip-2019.md
@@ -19,10 +19,10 @@ An extension to the [ERC-20] standard token that allows Token wallet owners to r
 The person or company who owns the wallet, and will order a token fund request into the wallet.
 
 #### Token contract owner / agent 
-The entity, company responsible/owner of the token contract, and token issuing/minting. This actor is in charge of trying to fullfill all fund request(s), reading the fund instruction(s), and corelate the private payment details.
+The entity, company responsible/owner of the token contract, and token issuing/minting. This actor is in charge of trying to fulfill all fund request(s), reading the fund instruction(s), and correlate the private payment details.
 
 #### Orderer
-An actor who is enable to initiate funding orders on behalf ot a token wallet owner.
+An actor who is enabled to initiate funding orders on behalf of a token wallet owner.
 
 ## Abstract
 Token wallet owners (or approved addresses) can order tokenization requests through  blockchain. This is done by calling the ```orderFund``` or ```orderFundFrom``` methods, which initiate the workflow for the token contract operator to either honor or reject the fund request. In this case, fund instructions are provided when submitting the request, which are used by the operator to determine the source of the funds to be debited in order to do fund the token wallet (through minting).
@@ -34,7 +34,7 @@ Nowadays most of the token issuing/funding request, based on any fiat based paym
 In the aim of trying to bring all the needed steps into decentralization, exposing all the needed steps of token lifecycle and payment transactions, a funding request can allow wallet owner to initiate the funding request via  blockchain.
 Key benefits:
 
-* Funding and payment traceability is enhanced bringing the initation into the ledger. All payment stat
+* Funding and payment traceability is enhanced bringing the initiation into the ledger. All payment stat
 s can be stored on chain.
 * Almost all money/token lifecycle is covered via a decentralized approach, complemented with private communications which is common use in the ecosystem.
 

--- a/EIPS/eip-2019.md
+++ b/EIPS/eip-2019.md
@@ -218,7 +218,7 @@ Emitted when a given player, operator, company or a given persona, has been appr
 | Parameter | Description |
 | ---------|-------------|
 | walletToFund | The wallet that the player is allowed to start funding requests |
-| orderer |The address that allows the the player to start requests. |
+| orderer | The address that allows the the player to start requests. |
 
 #### FundOperatorRevoked
 
@@ -227,7 +227,7 @@ Emitted when a given player has been revoked initiate funding requests.
 | Parameter | Description |
 | ---------|-------------|
 | walletToFund | The wallet that the player is allowed to start funding requests |
-| orderer |The address that allows the the player to start requests. |
+| orderer | The address that allows the the player to start requests. |
 
 ## Rationale
 This standards provides a functionality to allow token holders to start funding requests in a decentralized way.

--- a/EIPS/eip-2019.md
+++ b/EIPS/eip-2019.md
@@ -1,13 +1,13 @@
 ---
 eip: 2019
 title: Fundable Token
-author: Fernando Paris <fer@io.builders>
+author: Fernando Paris <fer@io.builders>, Julio Faura <julio@adhara.io>, Daniel Lehrner <daniel@io.builders>
+discussions-to: https://github.com/ethereum/EIPs/issues/2105
 status: Draft
 type: Standards Track
 category:  ERC
 created: 2019-05-10
-requires: 20, 1996
-
+requires: 20
 ---
 
 ## Simple Summary
@@ -24,12 +24,10 @@ The entity, company responsible/owner of the token contract, and token issuing/m
 #### Orderer
 An actor who is enable to initiate funding orders on behalf ot a token wallet owner.
 
-
 ## Abstract
 Token wallet owners (or approved addresses) can order tokenization requests through  blockchain. This is done by calling the ```orderFund``` or ```orderFundFrom``` methods, which initiate the workflow for the token contract operator to either honor or reject the fund request. In this case, fund instructions are provided when submitting the request, which are used by the operator to determine the source of the funds to be debited in order to do fund the token wallet (through minting).
 
 In general, it is not advisable to place explicit routing instructions for debiting funds on a verbatim basis on the blockchain, and it is advised to use a private communication alternatives, such as private channels, encrypted storage or similar,  to do so (external to the blockchain ledger). Another (less desirable) possibility is to place these instructions on the instructions field in encrypted form.
-
 
 ## Motivation
 Nowadays most of the token issuing/funding request, based on any fiat based payment method  need a previous centralized transaction, to be able to get the desired tokens issued on requester's wallet.
@@ -39,7 +37,6 @@ Key benefits:
 * Funding and payment traceability is enhanced bringing the initation into the ledger. All payment stat
 s can be stored on chain.
 * Almost all money/token lifecycle is covered via a decentralized approach, complemented with private communications which is common use in the ecosystem.
-
 
 ## Specification
 
@@ -57,10 +54,10 @@ interface IFundable /* is ERC-20 */ {
     function revokeFundOperator(address orderer) external returns (bool) ;
     function orderFund(string calldata operationId, uint256 value, string calldata instructions) external returns (bool);
     function orderFundFrom(string calldata operationId, address walletToFund, uint256 value, string calldata instructions) external returns (bool);
-    function cancelFund(address orderer, string calldata operationId) external returns (bool);
-    function processFund(address orderer, string calldata operationId) external returns (bool);
-    function executeFund(address orderer, string calldata operationId) external returns (bool);
-    function rejectFund(address orderer, string calldata operationId, string calldata reason) external returns (bool);
+    function cancelFund(string calldata operationId) external returns (bool);
+    function processFund(string calldata operationId) external returns (bool);
+    function executeFund(string calldata operationId) external returns (bool);
+    function rejectFund(string calldata operationId, string calldata reason) external returns (bool);
 
     function isFundOperatorFor(address walletToFund, address orderer) external view returns (bool);
     function retrieveFundData(address orderer, string calldata operationId) external view returns (address walletToFund,       uint256 value, string memory instructions, FundStatusCode status);
@@ -73,7 +70,6 @@ interface IFundable /* is ERC-20 */ {
     event FundOperatorAuthorized(address indexed walletToFund, address indexed orderer);
     event FundOperatorRevoked(address indexed walletToFund, address indexed orderer);
 }
-
 ```
 
 ### Functions
@@ -98,10 +94,9 @@ Wallet owner, revokes a given address to be fund orderer.
 
 Creates a fund request, that will be processed by the token operator.All fund requests,orders, will be linked to the orderer, associating operationId to orderer, to avoid global collision between operationIds. On operationId cannot be repeated for a given orderer, but there can be two equal operation id's for distinct orderers.
 
-
 | Parameter | Description |
 | ---------|-------------|
-| operationId | The unique ID per token orderer to identify the request |
+| operationId | The unique ID to identify the request |
 | value | The amount to be funded. |
 | instruction | A string including the payment instruction. |
 
@@ -111,7 +106,7 @@ Creates a fund request, on behalf of a wallet owner, that will be processed by t
 
 | Parameter | Description |
 | ---------|-------------|
-| operationId |The unique ID per token orderer to identify the request |
+| operationId |The unique ID to identify the request |
 | walletToFund | The wallet to be funded on behalf.
 | value | The amount to be funded. |
 | instruction | A string including the payment instruction. |
@@ -122,10 +117,7 @@ Cancels a funding request.
 
 | Parameter | Description |
 | ---------|-------------|
-| orderer | The address of the orderer, to correlate the right data.
-| operationId | The unique ID per token orderer to identify the request that is going to be cancelled. This can only be done by token holder, or the fund initiator. |
-
-
+| operationId | The unique ID to identify the request that is going to be cancelled. This can only be done by token holder, or the fund initiator. |
 
 #### processFund
 
@@ -133,8 +125,7 @@ Marks a funding request as on process. After the status is on process, order can
 
 | Parameter | Description |
 | ---------|-------------|
-| orderer | The address of the orderer, to correlate the right data.
-| operationId | The unique ID per orderer to identify the request is in process.
+| operationId | The unique ID to identify the request is in process.
 
 #### executeFund
 
@@ -142,8 +133,7 @@ Issues the amount of tokens and marks a funding request as executed.
 
 | Parameter | Description |
 | ---------|-------------|
-| orderer | The address of the orderer, to correlate the right data.
-| operationId | The unique ID per orderer to identify the request that has been executed.
+| operationId | The unique ID to identify the request that has been executed.
 
 #### rejectFund
 
@@ -151,8 +141,7 @@ Rejects a given operation with a reason.
 
 | Parameter | Description |
 | ---------|-------------|
-| orderer | The address of the orderer, to correlate the right data.
-| operationId | The unique ID per orderer to identify the request that has been executed.
+| operationId | The unique ID to identify the request that has been executed.
 | reason | The specific reason that explains why the fund request was rejected. EIP 1066 codes can be used |
 
 #### isFundOperatorFor
@@ -164,16 +153,13 @@ Checks that given player is allowed to order fund requests, for a given wallet.
 | walletToFund | The wallet to be funded, and checked for approval permission.
 | orderer | The address of the orderer, to be checked for approval permission.
 
-
 #### retrieveFundData
 
 Retrieves all the fund request data. Only operator, tokenHolder, and orderer can get the given operation data.
 
 | Parameter | Description |
 | ---------|-------------|
-| orderer | The address of the orderer, to correlate the right data.
-| operationId | The unique ID per token orderer to identify the fund order.
-
+| operationId | The unique ID to identify the fund order.
 
 ## Events
 
@@ -181,7 +167,7 @@ Retrieves all the fund request data. Only operator, tokenHolder, and orderer can
 
 Emitted when an token wallet owner orders a funding request.
 
-| operationId | The unique ID per token orderer to identify the request |
+| operationId | The unique ID to identify the request |
 | walletToFund | The wallet that the player is allowed to start funding requests |
 | value | The amount to be funded. |
 | instruction | A string including the payment instruction. |
@@ -195,7 +181,6 @@ Emitted when an operator starts a funding request after validating the instructi
 | orderer | The address of the fund request orderer. |
 | operationId | The unique ID per fund orderer to identify the fund. Operation ids are unique per requester/orderer. |
 
-
 #### FundExecuted
 
 Emitted when an operator has executed a funding request.
@@ -203,8 +188,7 @@ Emitted when an operator has executed a funding request.
 | Parameter | Description |
 | ---------|-------------|
 | orderer | The address of the fund request orderer. |
-| operationId | The unique ID per fund orderer to identify the fund. Operation ids are unique per requester/orderer. |
-
+| operationId | The unique ID per fund orderer to identify the fund. Operation ids are unique per requester/orderer.
 
 #### FundRejected
 
@@ -216,7 +200,6 @@ Emitted when an operator has rejected a funding request.
 | operationId | The unique ID per fund orderer to identify the fund. Operation ids are unique per requester/orderer. |
 | reason | The specific reason that explains why the fund request was rejected. EIP 1066 codes can be used |
 
-
 #### FundCancelled
 
 Emitted when a token holder, orderer,  has cancelled a funding request. This can only be done if the operator hasn't put the funding order in process.
@@ -225,7 +208,6 @@ Emitted when a token holder, orderer,  has cancelled a funding request. This can
 | ---------|-------------|
 | orderer | The address of the fund request orderer. |
 | operationId | The unique ID per fund orderer to identify the fund. Operation ids are unique per requester/orderer. |
-
 
 #### FundOperatorAuthorized
 
@@ -245,20 +227,19 @@ Emitted when a given player has been revoked initiate funding requests.
 | walletToFund | The wallet that the player is allowed to start funding requests |
 | orderer |The address that allows the the player to start requests. |
 
-
-
-
 ## Rationale
 This standards provides a functionality to allow token holders to start funding requests in a decentralized way.
 
-It's important to hightlight that the token operator, need to process all funding request, updating the fund status based on the linked payment that will be done.
+It's important to highlight that the token operator, need to process all funding request, updating the fund status based on the linked payment that will be done.
 
-Funding instruction format is  open. ISO payment standard like is a good start point,
+Funding instruction format is open. ISO payment standard like is a good start point,
 
-This EIP uses [EIP-1996][EIP-1996] to hold the money after a funding is ordered. The token contract owner or agent, whose implementation is not part of this proposal, acts as a predefined notary to decide if the funding is executed or not.
+The `operationId` is a string and not something more gas efficient to allow easy traceability of the hold and allow human readable ids. It is up to the implementer if the string should be stored on-chain or only its hash, as it is enough to identify a hold.
+
+The `operationId` is a competitive resource. It is recommended, but not required, that the hold issuers used a unique prefix to avoid collisions.
 
 ## Backwards Compatibility
-This EIP is fully backwards compatible as its implementation extends the functionality of ERC-20 and ERC-1996.
+This EIP is fully backwards compatible as its implementation extends the functionality of ERC-20.
 
 ## Implementation
 The GitHub repository [IoBuilders/fundable-token](https://github.com/IoBuilders/fundable-token) contains the work in progress implementation.
@@ -267,6 +248,5 @@ The GitHub repository [IoBuilders/fundable-token](https://github.com/IoBuilders/
 This proposal has been collaboratively implemented by [adhara.io](https://adhara.io/) and [io.builders](https://io.builders/).
 
 ## Copyright
-Copyright and related rights waived via CC0.
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
 
-[EIP-1996]: https://github.com/ethereum/EIPs/pull/1996

--- a/EIPS/eip-2019.md
+++ b/EIPS/eip-2019.md
@@ -1,5 +1,5 @@
 ---
-eip: <to be assigned>
+eip: 2019
 title: Fundable Token
 author: Fernando Paris <fer@io.builders>
 status: Draft
@@ -266,5 +266,5 @@ The GitHub repository [IoBuilders/fundable-token](https://github.com/IoBuilders/
 ## Contributors
 This proposal has been collaboratively implemented by [adhara.io](https://adhara.io/) and [io.builders](https://io.builders/).
 
-Copyright
+## Copyright
 Copyright and related rights waived via CC0.

--- a/EIPS/fundable-token-draft.md
+++ b/EIPS/fundable-token-draft.md
@@ -264,7 +264,7 @@ This EIP is fully backwards compatible as its implementation extends the functio
 The GitHub repository [IoBuilders/fundable-token](https://github.com/IoBuilders/fundable-token) contains the work in progress implementation.
 
 ## Contributors
-This proposal has been collaboratively implemented  by adhara.io and io.builders.
+This proposal has been collaboratively implemented by [adhara.io](https://adhara.io/) and [io.builders](https://io.builders/).
 
 Copyright
 Copyright and related rights waived via CC0.

--- a/EIPS/fundable-token-draft.md
+++ b/EIPS/fundable-token-draft.md
@@ -53,8 +53,8 @@ interface IFundable /* is ERC-20 */ {
         Rejected,
         Cancelled
     }
-    function approveToOrderFund(address orderer) external returns (bool);
-    function revokeApprovalToOrderFund(address orderer) external returns (bool) ;
+    function authorizeFundOperator(address orderer) external returns (bool);
+    function revokeFundOperator(address orderer) external returns (bool) ;
     function orderFund(string calldata operationId, uint256 value, string calldata instructions) external returns (bool);
     function orderFundFrom(string calldata operationId, address walletToFund, uint256 value, string calldata instructions) external returns (bool);
     function cancelFund(address orderer, string calldata operationId) external returns (bool);
@@ -78,9 +78,9 @@ interface IFundable /* is ERC-20 */ {
 
 ### Functions
 
-#### approveToOrderFund
+#### authorizeFundOperator
 
-Wallet owner, allows a given address to be fund orderer.
+Wallet owner, authorizes a given address to be fund orderer.
 
 | Parameter | Description |
 | ---------|-------------|

--- a/EIPS/fundable-token-draft.md
+++ b/EIPS/fundable-token-draft.md
@@ -11,19 +11,22 @@ requires: 20
 ---
 
 ## Simple Summary
-An extension to the ERC-20 standard token that allows Token wallet owners to request a wallet to be funded, by calling the smart contract and attaching a funding instruction string. 
+An extension to the ERC-20 standard token that allows Token wallet owners to request a wallet to be funded, by calling the smart contract and attaching a fund instruction string.
 
 ## Actors
 
 #### Token Wallet Owners
-The person or company who owns the wallet, and will order a token funding request into the wallet.
+The person or company who owns the wallet, and will order a token fund request into the wallet.
 
 #### Token contract operator
-The entity, company responsible/ owner  of the token contract, and token issuing/minting. This actor is in charge of trying to fullfill all funding request, reading the funding instruction, and corelate the private payment details.
+The entity, company responsible/owner of the token contract, and token issuing/minting. This actor is in charge of trying to fullfill all fund request(s), reading the fund instruction(s), and corelate the private payment details.
+
+#### Orderer
+An actor who is enable to initiate funding orders on behalf ot a token wallet owner.
 
 
-## Abstract 
-Token wallet owners (or approved addresses) can order tokenization requests through  blockchain. This is done by calling the orderFunding or orderFundingFrom methods, which initiate the workflow for the token contract operator to either honor or reject the funding request. In this case, funding instructions are provided when submitting the request, which are used by the operator to determine the source of the funds to be debited in order to do fund the token wallet (through minting). 
+## Abstract
+Token wallet owners (or approved addresses) can order tokenization requests through  blockchain. This is done by calling the ```orderFund``` or ```orderFundFrom``` methods, which initiate the workflow for the token contract operator to either honor or reject the fund request. In this case, fund instructions are provided when submitting the request, which are used by the operator to determine the source of the funds to be debited in order to do fund the token wallet (through minting).
 
 In general, it is not advisable to place explicit routing instructions for debiting funds on a verbatim basis on the blockchain, and it is advised to use a private communication alternatives. such as private channels, encrypted storage or similar,  to do so (external to the blockchain ledger). Another (less desirable) possibility is to place these instructions on the instructions field on encrypted form.
 
@@ -33,7 +36,7 @@ Nowadays most of the token issuing/funding request, based on any fiat based paym
 In the aim of trying step by step to bring all the needed steps into decentralization, exposing all the needed steps of token lifecycle and payment transactions, a funding request can allow wallet owner to initiate the funding request via  blockchain.
 Key benefits:
 
-* Funding and payment traceability is enhanced bringing the initation into the ledger. All payment status con be stored on chain.
+* Funding and payment traceability is enhanced bringing the initation into the ledger. All payment statuses can be stored on chain.
 * Almost all money/token lifecycle is covered via an decentralized approach, complemented with private communications which is common used in the ecosystem.
 
 
@@ -44,34 +47,214 @@ interface IFundable /* is ERC-20 */ {
     enum FundStatusCode {
         Nonexistent,
         Ordered,
+        InProcess,
         Executed,
-        ReleasedByNotary,
-        ReleasedByPayee,
-        ReleasedOnExpiration
+        Rejected,
+        Cancelled
     }
     function approveToOrderFund(address orderer) external returns (bool);
     function revokeApprovalToOrderFund(address orderer) external returns (bool) ;
     function orderFund(string calldata operationId, uint256 value, string calldata instructions) external returns (bool);
     function orderFundFrom(string calldata operationId, address walletToFund, uint256 value, string calldata instructions) external returns (bool);
-    function cancelFund(string calldata operationId) external returns (bool);
+    function cancelFund(address orderer, string calldata operationId) external returns (bool);
     function processFund(address orderer, string calldata operationId) external returns (bool);
     function executeFund(address orderer, string calldata operationId) external returns (bool);
     function rejectFund(address orderer, string calldata operationId, string calldata reason) external returns (bool);
-    function isApprovedToOrderFunding(address walletToFund, address orderer) external view returns (bool);
-    function retrieveFundingData(address orderer, string calldata operationId) external view returns (address walletToFund,       uint256 value, string memory instructions, FundingStatusCode status);
-    event FundingOrdered(address indexed orderer, string indexed operationId, address indexed walletToFund, uint256 value,         string instructions);
-    event FundingInProcess(address indexed orderer, string indexed operationId);
-    event FundingExecuted(address indexed orderer, string indexed operationId);
-    event FundingRejected(address indexed orderer, string indexed operationId, string reason);
-    event FundingCancelled(address indexed orderer, string indexed operationId);
-    event ApprovalToOrderFunding(address indexed walletToFund, address indexed orderer);
-    event RevokeApprovalToOrderFunding(address indexed walletToFund, address indexed orderer);
+
+    function isApprovedToOrderFund(address walletToFund, address orderer) external view returns (bool);
+    function retrieveFundData(address orderer, string calldata operationId) external view returns (address walletToFund,       uint256 value, string memory instructions, FundStatusCode status);
+
+    event FundOrdered(address indexed orderer, string indexed operationId, address indexed , uint256 value,         string instructions);
+    event FundInProcess(address indexed orderer, string indexed operationId);
+    event FundExecuted(address indexed orderer, string indexed operationId);
+    event FundRejected(address indexed orderer, string indexed operationId, string reason);
+    event FundCancelled(address indexed orderer, string indexed operationId);
+    event ApprovalToOrderFund(address indexed walletToFund, address indexed orderer);
+    event RevokeApprovalToOrderFund(address indexed walletToFund, address indexed orderer);
 }
 
 ```
 
+### Functions
+
+#### approveToOrderFund
+
+Wallet owner, allows a given address to be fund orderer.
+
+| Parameter | Description |
+| ---------|-------------|
+| orderer | The address of the orderer.
+
+#### revokeApprovalToOrderFund
+
+Wallet owner, Revokes a given address to be fund orderer.
+
+| Parameter | Description |
+| ---------|-------------|
+| orderer | The address of the orderer.
+
+#### orderFund
+
+Creates a fund request, that will be processed by the token operator.All fund requests,orders, will be linked to the orderer, associating operationId to orderer, to avoid global collision between operationIds. On operationId cannot be repeated for a given orderer, but there can be two equal operation id's for distinct orderers.
+
+
+| Parameter | Description |
+| ---------|-------------|
+| operationId | The unique ID per token holder to identify the request |
+| value | The amount to be funded. |
+| instruction | A string including the payment instruction. |
+
+#### orderFundFrom
+
+Creates a fund request, on behalf of a wallet owner, that will be processed by the token operator. All fund requests,orders, will be linked to the orderer, associating operationId to orderer, to avoid global collision between operationIds. On operationId cannot be repeated for a given orderer, but there can be two equal operation id's for distinct orderers.
+
+| Parameter | Description |
+| ---------|-------------|
+| operationId |he unique ID per token holder to identify the request |
+| walletToFund | The wallet to be funded on behalf.
+| value | The amount to be funded. |
+| instruction | A string including the payment instruction. |
+
+#### cancelFund
+
+Cancels a funding request.
+
+| Parameter | Description |
+| ---------|-------------|
+| orderer | The address of the orderer, to correlate the right data.
+| operationId | The unique ID per token holder to identify the request that is going to be cancelled. This can only be done by token holder, or the fund initiator. |
+| reason | The unique ID per token holder to identify the request that is going to be cancelled. This can only be done by token holder, or the fund initiator. |
+
+
+#### processFund
+
+Marks a funding request as on process. After the status is on process, order cannot be cancelled.
+
+| Parameter | Description |
+| ---------|-------------|
+| orderer | The address of the orderer, to correlate the right data.
+| operationId | The unique ID per orderer to identify the request is in process.
+
+#### executeFund
+
+Issues the amount of tokens and marks a funding request as executed.
+
+| Parameter | Description |
+| ---------|-------------|
+| orderer | The address of the orderer, to correlate the right data.
+| operationId | The unique ID per orderer to identify the request that has been executed.
+
+#### rejectFund
+
+Rejects a given operation with a reason.
+
+| Parameter | Description |
+| ---------|-------------|
+| orderer | The address of the orderer, to correlate the right data.
+| operationId | The unique ID per orderer to identify the request that has been executed.
+| reason | The specific reason that explains why the fund request was rejected. EIP 1066 codes can be used |
+
+#### isApprovedToOrderFund
+
+Checks that given player is allowed to order fund requests, for a given wallet.
+
+| Parameter | Description |
+| ---------|-------------|
+| walletToFund | The wallet to be funded, and checked for approval permission.
+| orderer | The address of the orderer, to be checked for approval permission.
+
+
+#### retrieveFundData
+
+Retrieves all the fund request data. Only operator, tokenHolder, and orderer can get the given operation data.
+
+| Parameter | Description |
+| ---------|-------------|
+| orderer | The address of the orderer, to correlate the right data.
+| operationId | The unique ID per token holder to identify the fund order.
+
+
+## Events
+
+#### FundOrdered
+
+Emitted when an token wallet owner orders a funding request.
+
+| operationId | The unique ID per token holder to identify the request |
+| walletToFund | The wallet that the player is allowed to start funding requests |
+| value | The amount to be funded. |
+| instruction | A string including the payment instruction. |
+
+#### FundInProcess
+
+Emitted when an operator accepts a funding request, and the operation is in process.
+
+| Parameter | Description |
+| ---------|-------------|
+| orderer | The address of the fund request orderer. |
+| operationId | The unique ID per fund orderer to identify the fund. Operation ids are unique per requester/orderer. |
+
+
+#### FundExecuted
+
+Emitted when an operator has executed a funding request.
+
+| Parameter | Description |
+| ---------|-------------|
+| orderer | The address of the fund request orderer. |
+| operationId | The unique ID per fund orderer to identify the fund. Operation ids are unique per requester/orderer. |
+
+
+#### FundRejected
+
+Emitted when an operator has rejected a funding request.
+
+| Parameter | Description |
+| ---------|-------------|
+| orderer | The address of the fund request orderer. |
+| operationId | The unique ID per fund issuer to identify the fund. Operation ids are unique per requester/orderer. |
+| reason | The specific reason that explains why the fund request was rejected. EIP 1066 codes can be used |
+
+
+#### FundCancelled
+
+Emitted when a token holder, orderer,  has cancelled a funding request. This can only be done if the operator hasn't put the funding order in process.
+
+| Parameter | Description |
+| ---------|-------------|
+| orderer | The address of the fund request orderer. |
+| operationId | The unique ID per fund issuer to identify the fund. Operation ids are unique per requester/orderer. |
+
+
+#### ApprovalToOrderFund
+
+Emitted when a given player, operator, company or a given persona, has been approved to start fund request for a given token holder.
+
+| Parameter | Description |
+| ---------|-------------|
+| walletToFund | The wallet that the player is allowed to start funding requests |
+| orderer |The address that allows the the player to start requests. |
+
+#### RevokeApprovalToOrderFund
+
+Emitted when a given player has been revoked initiate funding requests.
+
+| Parameter | Description |
+| ---------|-------------|
+| walletToFund | The wallet that the player is allowed to start funding requests |
+| orderer |The address that allows the the player to start requests. |
+
+
+
+
 ## Rationale
-The rationale fleshes out the specification by describing what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work, e.g. how the feature is supported in other languages. The rationale may also provide evidence of consensus within the community, and should discuss important objections or concerns raised during discussion.-->
+This standards provides a functionality to allow token holders to start funding requests in a decentralized way.
+
+It's important to hightlight that the token operator, need to process all funding request, updating the fund status based on the linked payment that will be done.
+
+Funding instruction format is  open. ISO payment standard like is a good start point,
+
+
 
 ## Backwards Compatibility
 This EIP is fully backwards compatible as its implementation extends the functionality of ERC-20.

--- a/EIPS/fundable-token-draft.md
+++ b/EIPS/fundable-token-draft.md
@@ -1,0 +1,35 @@
+---
+eip: <to be assigned>
+title: Fundable Token
+author: fer@io.builders as part of the em-token working group built by adhara.io and io.builders
+status: Draft
+type: Standards Track
+category:  ERC
+created: 2019-05-10
+requires: 20, 1996
+
+---
+
+## Simple Summary
+An extension to the ERC-20 standard token that allows Token wallet owners to request a wallet to be funded, by calling the smart contract and attaching a debit instruction string. 
+
+Motivation
+The motivation is critical for EIPs that want to change the Ethereum protocol. It should clearly explain why the existing protocol specification is inadequate to address the problem that the EIP solves. EIP submissions without sufficient motivation may be rejected outright.
+
+Specification
+The technical specification should describe the syntax and semantics of any new feature. The specification should be detailed enough to allow competing, interoperable implementations for any of the current Ethereum platforms (go-ethereum, parity, cpp-ethereum, ethereumj, ethereumjs, and others).
+
+Rationale
+The rationale fleshes out the specification by describing what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work, e.g. how the feature is supported in other languages. The rationale may also provide evidence of consensus within the community, and should discuss important objections or concerns raised during discussion.-->
+
+Backwards Compatibility
+All EIPs that introduce backwards incompatibilities must include a section describing these incompatibilities and their severity. The EIP must explain how the author proposes to deal with these incompatibilities. EIP submissions without a sufficient backwards compatibility treatise may be rejected outright.
+
+Test Cases
+Test cases for an implementation are mandatory for EIPs that are affecting consensus changes. Other EIPs can choose to include links to test cases if applicable.
+
+Implementation
+The implementations must be completed before any EIP is given status "Final", but it need not be completed before the EIP is accepted. While there is merit to the approach of reaching consensus on the specification and rationale before writing code, the principle of "rough consensus and running code" is still useful when it comes to resolving many discussions of API details.
+
+Copyright
+Copyright and related rights waived via CC0.

--- a/EIPS/fundable-token-draft.md
+++ b/EIPS/fundable-token-draft.md
@@ -1,35 +1,55 @@
 ---
 eip: <to be assigned>
 title: Fundable Token
-author: fer@io.builders as part of the em-token working group built by adhara.io and io.builders
+author: Fernando Paris <fer@io.builders>
 status: Draft
 type: Standards Track
 category:  ERC
 created: 2019-05-10
-requires: 20, 1996
+requires: 20
 
 ---
 
 ## Simple Summary
-An extension to the ERC-20 standard token that allows Token wallet owners to request a wallet to be funded, by calling the smart contract and attaching a debit instruction string. 
+An extension to the ERC-20 standard token that allows Token wallet owners to request a wallet to be funded, by calling the smart contract and attaching a funding instruction string. 
 
-Motivation
-The motivation is critical for EIPs that want to change the Ethereum protocol. It should clearly explain why the existing protocol specification is inadequate to address the problem that the EIP solves. EIP submissions without sufficient motivation may be rejected outright.
+## Actors
 
-Specification
+#### Token Wallet Owners
+The person or company who owns the wallet, and will order a token funding request into the wallet.
+
+#### Token contract operator
+The entity, company responsible/ owner  of the token contract, and token issuing/minting. This actor is in charge of trying to fullfill all funding request, reading the funding instruction, and corelate the private payment details.
+
+
+## Abstract 
+Token wallet owners (or approved addresses) can order tokenization requests through  blockchain. This is done by calling the orderFunding or orderFundingFrom methods, which initiate the workflow for the token contract operator to either honor or reject the funding request. In this case, funding instructions are provided when submitting the request, which are used by the operator to determine the source of the funds to be debited in order to do fund the token wallet (through minting). 
+
+In general, it is not advisable to place explicit routing instructions for debiting funds on a verbatim basis on the blockchain, and it is advised to use a private communication alternatives. such as private channels, encrypted storage or similar,  to do so (external to the blockchain ledger). Another (less desirable) possibility is to place these instructions on the instructions field on encrypted form.
+
+## Motivation
+Nowadays most of the token issuing/funding request, based on any fiat based payment method  need a previous centralized transaction, to be able to get the desired tokens issued on requester's wallet.
+In the aim of trying step by step to bring all the needed steps into decentralization, exposing all the needed steps of token lifecycle and payment transactions, a funding request can allow wallet owner to initiate the funding request via  blockchain.
+Key benefits:
+
+* Funding and payment traceability is enhanced bringing the initation into the ledger. All payment status con be stored on chain.
+* Almost all money/token lifecycle is covered via an decentralized approach, complemented with private communications which is common used in the ecosystem.
+
+
+## Specification
 The technical specification should describe the syntax and semantics of any new feature. The specification should be detailed enough to allow competing, interoperable implementations for any of the current Ethereum platforms (go-ethereum, parity, cpp-ethereum, ethereumj, ethereumjs, and others).
 
 Rationale
 The rationale fleshes out the specification by describing what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work, e.g. how the feature is supported in other languages. The rationale may also provide evidence of consensus within the community, and should discuss important objections or concerns raised during discussion.-->
 
-Backwards Compatibility
-All EIPs that introduce backwards incompatibilities must include a section describing these incompatibilities and their severity. The EIP must explain how the author proposes to deal with these incompatibilities. EIP submissions without a sufficient backwards compatibility treatise may be rejected outright.
+## Backwards Compatibility
+This EIP is fully backwards compatible as its implementation extends the functionality of ERC-20.
 
-Test Cases
-Test cases for an implementation are mandatory for EIPs that are affecting consensus changes. Other EIPs can choose to include links to test cases if applicable.
+## Implementation
+The GitHub repository [IoBuilders/fundable-token](https://github.com/IoBuilders/fundable-token) contains the work in progress implementation.
 
-Implementation
-The implementations must be completed before any EIP is given status "Final", but it need not be completed before the EIP is accepted. While there is merit to the approach of reaching consensus on the specification and rationale before writing code, the principle of "rough consensus and running code" is still useful when it comes to resolving many discussions of API details.
+## Contributors
+This proposal has been collaboratively implemented  by adhara.io and io.builders.
 
 Copyright
 Copyright and related rights waived via CC0.

--- a/EIPS/fundable-token-draft.md
+++ b/EIPS/fundable-token-draft.md
@@ -27,6 +27,7 @@ Token wallet owners (or approved addresses) can order tokenization requests thro
 
 In general, it is not advisable to place explicit routing instructions for debiting funds on a verbatim basis on the blockchain, and it is advised to use a private communication alternatives. such as private channels, encrypted storage or similar,  to do so (external to the blockchain ledger). Another (less desirable) possibility is to place these instructions on the instructions field on encrypted form.
 
+
 ## Motivation
 Nowadays most of the token issuing/funding request, based on any fiat based payment method  need a previous centralized transaction, to be able to get the desired tokens issued on requester's wallet.
 In the aim of trying step by step to bring all the needed steps into decentralization, exposing all the needed steps of token lifecycle and payment transactions, a funding request can allow wallet owner to initiate the funding request via  blockchain.
@@ -37,9 +38,39 @@ Key benefits:
 
 
 ## Specification
-The technical specification should describe the syntax and semantics of any new feature. The specification should be detailed enough to allow competing, interoperable implementations for any of the current Ethereum platforms (go-ethereum, parity, cpp-ethereum, ethereumj, ethereumjs, and others).
 
-Rationale
+```solidity
+interface IFundable /* is ERC-20 */ {
+    enum FundStatusCode {
+        Nonexistent,
+        Ordered,
+        Executed,
+        ReleasedByNotary,
+        ReleasedByPayee,
+        ReleasedOnExpiration
+    }
+    function approveToOrderFund(address orderer) external returns (bool);
+    function revokeApprovalToOrderFund(address orderer) external returns (bool) ;
+    function orderFund(string calldata operationId, uint256 value, string calldata instructions) external returns (bool);
+    function orderFundFrom(string calldata operationId, address walletToFund, uint256 value, string calldata instructions) external returns (bool);
+    function cancelFund(string calldata operationId) external returns (bool);
+    function processFund(address orderer, string calldata operationId) external returns (bool);
+    function executeFund(address orderer, string calldata operationId) external returns (bool);
+    function rejectFund(address orderer, string calldata operationId, string calldata reason) external returns (bool);
+    function isApprovedToOrderFunding(address walletToFund, address orderer) external view returns (bool);
+    function retrieveFundingData(address orderer, string calldata operationId) external view returns (address walletToFund,       uint256 value, string memory instructions, FundingStatusCode status);
+    event FundingOrdered(address indexed orderer, string indexed operationId, address indexed walletToFund, uint256 value,         string instructions);
+    event FundingInProcess(address indexed orderer, string indexed operationId);
+    event FundingExecuted(address indexed orderer, string indexed operationId);
+    event FundingRejected(address indexed orderer, string indexed operationId, string reason);
+    event FundingCancelled(address indexed orderer, string indexed operationId);
+    event ApprovalToOrderFunding(address indexed walletToFund, address indexed orderer);
+    event RevokeApprovalToOrderFunding(address indexed walletToFund, address indexed orderer);
+}
+
+```
+
+## Rationale
 The rationale fleshes out the specification by describing what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work, e.g. how the feature is supported in other languages. The rationale may also provide evidence of consensus within the community, and should discuss important objections or concerns raised during discussion.-->
 
 ## Backwards Compatibility


### PR DESCRIPTION
An extension to the ERC-20 standard token that allows Token wallet owners to request a wallet to be funded, by calling the smart contract and attaching a fund instruction string.

Token wallet owners (or approved addresses) can order tokenization requests through  blockchain. This is done by calling the ```orderFund``` or ```orderFundFrom``` methods, which initiate the workflow for the token contract operator to either honor or reject the fund request. In this case, fund instructions are provided when submitting the request, which are used by the operator to determine the source of the funds to be debited in order to do fund the token wallet (through minting).