### PR TITLE
EIP-1193: Add chainChanged event

### DIFF
--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -7,7 +7,7 @@ status: Draft
 type: Standards Track
 category: Interface
 created: 2018-06-30
-requires: 155, 695, 1474
+requires: 155, 695, 1102 1474
 ---
 
 ## Summary

--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -7,7 +7,7 @@ status: Draft
 type: Standards Track
 category: Interface
 created: 2018-06-30
-requires: 155, 695, 1102 1474
+requires: 155, 695, 1102, 1474
 ---
 
 ## Summary

--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -96,6 +96,16 @@ ethereum.on('chainChanged', listener: (chainId: String) => void): this;
 
 The event emits with `chainId`, the new chain returned from `eth_chainId`.
 
+#### networkChanged
+
+The provider emits `networkChanged` on connect to a new network.
+
+```js
+ethereum.on('networkChanged', listener: (networkId: String) => void): this;
+```
+
+The event emits with `networkId`, the new network returned from `net_version`.
+
 #### accountsChanged
 
 The provider emits `accountsChanged` if the accounts returned from the provider (`eth_accounts`) changes.
@@ -259,6 +269,10 @@ If the network connection closes, the Ethereum Provider **MUST** emit an event n
 #### chainChanged
 
 If the chain the provider is connected to changes, the provider **MUST** emit an event named `chainChanged` with args `chainId: String` containing the ID of the new chain (using the Ethereum JSON-RPC call `eth_chainId`).
+
+#### networkChanged
+
+If the network the provider is connected to changes, the provider **MUST** emit an event named `networkChanged` with args `networkId: String` containing the ID of the new network (using the Ethereum JSON-RPC call `net_version`).
 
 #### accountsChanged
 

--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -7,6 +7,7 @@ status: Draft
 type: Standards Track
 category: Interface
 created: 2018-06-30
+requires: 155, 695, 1474
 ---
 
 ## Summary
@@ -85,15 +86,15 @@ ethereum.on('close', listener: (code: Number, reason: String) => void): this;
 
 The event emits with `code` and `reason`. The code follows the table of [`CloseEvent` status codes](https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent#Status_codes).
 
-#### networkChanged
+#### chainChanged
 
-The provider emits `networkChanged` on connect to a new network.
+The provider emits `chainChanged` on connect to a new chain.
 
 ```js
-ethereum.on('networkChanged', listener: (networkId: String) => void): this;
+ethereum.on('chainChanged', listener: (chainId: String) => void): this;
 ```
 
-The event emits with `networkId`, the new network returned from `net_version`.
+The event emits with `chainId`, the new chain returned from `eth_chainId`.
 
 #### accountsChanged
 

--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -256,9 +256,9 @@ If the network connects, the Ethereum Provider **MUST** emit an event named `con
 
 If the network connection closes, the Ethereum Provider **MUST** emit an event named `close` with args `code: Number, reason: String` following the [status codes for `CloseEvent`](https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent#Status_codes).
 
-#### networkChanged
+#### chainChanged
 
-If the network the provider is connected to changes, the provider **MUST** emit an event named `networkChanged` with args `networkId: String` containing the ID of the new network (using the Ethereum JSON-RPC call `net_version`).
+If the chain the provider is connected to changes, the provider **MUST** emit an event named `chainChanged` with args `chainId: String` containing the ID of the new chain (using the Ethereum JSON-RPC call `eth_chainId`).
 
 #### accountsChanged
 


### PR DESCRIPTION
A Dapp should only concern with the integrity of the transactions and typed data messages signed by the provider, hence we should track the chainId which prevents transaction replay attacks as part of the EIP-155.

NetworkId only concerns with the p2p connection between peers but there is no guarantee that this Id is the same as the `chainId` which concerns with the transactions signed and broadcasted to a client.

The EIP-695 has been implemented by Parity and Geth to return the chainId using the `eth_chainId` method therefore we should stop using the networkId returned by the `net_version`.

My proposed change replaces the `networkChanged` event with `chainChanged` event. To ensure transactions and typed data messages are signed correctly we need to track the `chainId` and not the `networkId`

---------

**PS -**  As requested I've changed this PR to simply add the `chainChanged` event instead of replacing it completely with `networkChanged` to provide backwards compatibility with existing Dapps. I would like to still signal that `chainId` is used from now forward instead of `networkId` as this technical debt which being underestimated right now and has critical issues as the ones described above.