### PR TITLE
EIP-1108: Add gas cost clarification + copyright assignment

### DIFF
--- a/EIPS/eip-1108.md
+++ b/EIPS/eip-1108.md
@@ -59,13 +59,27 @@ Following is a table with the current gas cost and new gas cost:
 The gas costs for `ECADD` and `ECMUL` are updates to the costs listed in
 EIP-196, while the gas costs for the pairing check are updates to the cost
 listed in EIP-197. Updated gas costs have been adjusted to the less performant 
-client which is Parity, according to benchmarks<sup>[3]</sup>. The updated gas costs are scaled relative to the `ecrecover` precompile. i.e. in the benchmark, `ecrecover` ran in 116 microseconds. If we consider 3,000 gas the fair price for `ecrecover`, we can obtain a metric how much gas should be charged per microsecond of an algorithm's runtime, and use that to price the elliptic curve precompiles.
+client which is Parity, according to benchmarks<sup>[3]</sup>.
+
+To come up with these updates gas costs, the performance of the `ecrecover` precompile
+was measured at 116 microseconds per `ecrecover` invocation. Assuming the `ecrecover`
+gas price is fair at 3,000 gas, we get a price of 25.86 gas per microsecond of a precompile
+algorithm's runtime. With this in mind, the pairing precompile took 3,037 microseconds to
+compute 1 pairing, and 14,663 microseconds to compute 10 pairings. From this, the pairing
+algorithm has a fixed 'base' run-time of 1,745 microseconds, plus 1,292 microseconds per
+pairing. We can split the run-time into 'fixed cost' and 'linear cost per pairing'
+components because of the structure of the algorithm.
+
+Thus using a 'fair' price of 25.86 gas per microsecond, we get a gas formula of
+~`35,000 * k + 45,000` gas, where `k` is the number of pairings being computed. [4]
 
 [1]- Per [EIP-196](https://github.com/ethereum/EIPs/blob/984cf5de90bbf5fbe7e49be227b0c2f9567e661e/EIPS/eip-196.md#gas-costs).
 
 [2]- Per [EIP-197](https://github.com/ethereum/EIPs/blob/df132cd37efb3986f9cd3ef4922b15a767d2c54a/EIPS/eip-197.md#specification).
 
 [3]- [Parity benchmarks.](https://gist.github.com/zac-williamson/838410a3da179d47d31b25b586c15e53)
+
+[4]- [PR comment clarifying gas cost math](https://github.com/ethereum/EIPs/pull/1987#discussion_r280977066).
 
 ## Rationale  
 

--- a/EIPS/eip-1108.md
+++ b/EIPS/eip-1108.md
@@ -116,3 +116,7 @@ Both the Parity and Geth clients have already implemented cryptographic librarie
 * [Geth bn256 library (golang)](https://github.com/ethereum/go-ethereum/tree/master/crypto/bn256/cloudflare)  
 * [MCL, a portable C++ pairing library](https://github.com/herumi/mcl)  
 * [Libff, a C++ pairing library used in many zk-SNARK libraries](https://github.com/scipr-lab/libff)
+
+
+## Copyright
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
Per https://github.com/ethereum/EIPs/pull/1987#discussion_r282513653, added more details on the proposed gas cost for EC precompilesl Per https://github.com/ethereum/EIPs/pull/1987#issuecomment-494968355, added the copyright statement.

Not sure if we need an approval from @zac-williamson as well here since this adds a copyright statement on work that's already been written.