### PR TITLE
Moving EIP-600 to last call.

### DIFF
--- a/EIPS/eip-600.md
+++ b/EIPS/eip-600.md
@@ -5,7 +5,7 @@ author: Nick Johnson (@arachnid), Micah Zoltu (@micahzoltu)
 type: Standards Track
 category: ERC
 status: Last Call
-review-period-end: 2019-06-08
+review-period-end: 2019-07-03
 discussions-to: https://ethereum-magicians.org/t/eip-erc-app-keys-application-specific-wallet-accounts/2742
 created: 2017-04-13
 ---

--- a/EIPS/eip-600.md
+++ b/EIPS/eip-600.md
@@ -4,7 +4,8 @@ title: Ethereum purpose allocation for Deterministic Wallets
 author: Nick Johnson (@arachnid), Micah Zoltu (@micahzoltu)
 type: Standards Track
 category: ERC
-status: Draft
+status: Last Call
+review-period-end: 2019-06-08
 discussions-to: https://ethereum-magicians.org/t/eip-erc-app-keys-application-specific-wallet-accounts/2742
 created: 2017-04-13
 ---


### PR DESCRIPTION
Has received no meaningful discussion for some time, and the longer we put this off the more entrenched the current non-standard derivation paths become.