### PR TITLE
Moves EIP 601 to Last Call.

### DIFF
--- a/EIPS/eip-601.md
+++ b/EIPS/eip-601.md
@@ -4,7 +4,8 @@ title: Ethereum hierarchy for deterministic wallets
 author: Nick Johnson (@arachnid), Micah Zoltu (@micahzoltu)
 type: Standards Track
 category : ERC
-status: Draft
+status: Last Call
+review-period-end: 2019-06-08
 discussions-to: https://ethereum-magicians.org/t/eip-erc-app-keys-application-specific-wallet-accounts/2742
 created: 2017-04-13
 ---

--- a/EIPS/eip-601.md
+++ b/EIPS/eip-601.md
@@ -5,7 +5,7 @@ author: Nick Johnson (@arachnid), Micah Zoltu (@micahzoltu)
 type: Standards Track
 category : ERC
 status: Last Call
-review-period-end: 2019-06-08
+review-period-end: 2019-07-03
 discussions-to: https://ethereum-magicians.org/t/eip-erc-app-keys-application-specific-wallet-accounts/2742
 created: 2017-04-13
 ---


### PR DESCRIPTION
No discussion has happened for a while and the longer we wait, the more entrenched current non-standard paths become.