### PR TITLE
EIP-1193: Remove web3 compatibility section

### DIFF
--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -203,10 +203,6 @@ If the network the provider is connected to changes, the provider **MUST** emit 
 
 If the accounts connected to the Ethereum Provider change at any time, the Ethereum Provider **MUST** send an event with the name `accountsChanged` with args `accounts: Array<String>` containing the accounts' addresses.
 
-### web3.js Backwards Compatibility
-
-If the implementing Ethereum Provider would like to be compatible with `web3.js` prior to `1.0.0-beta38`, it **MUST** provide the method: `sendAsync(payload: Object, callback: (error: any, result: any) => void): void`.
-
 ### Error object and codes
 
 If an Error object is returned, it **MUST** contain a human readable string message describing the error and **SHOULD** populate the `code` and `data` properties on the error object with additional error details.


### PR DESCRIPTION
This EIP had a section describing how to be compatible with a certain beta version of web3 1.0.0. This would look fairly arbitrary to the uninformed reader. Also, it would be even weirder in the near future, as some changes to web3's versioning will be announced soon.

This PR removes that section, making the EIP independent from any particular library consuming it.