### PR TITLE
Errata for EIP-1052 empty account

### DIFF
--- a/EIPS/eip-1052.md
+++ b/EIPS/eip-1052.md
@@ -24,7 +24,7 @@ takes one argument from the stack, zeros the first 96 bits
 and pushes to the stack the keccak256 hash of the code of the account 
 at the address being the remaining 160 bits. 
 
-In case the account does not exist `0` is pushed to the stack.
+In case the account does not exist or is empty `0` is pushed to the stack.
 
 In case the account does not have code the keccak256 hash of empty data
 (i.e. `c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470`)


### PR DESCRIPTION
Errata to clarify EIP-1052's behavior in case it meets with EIP-161's empty account. Geth/Aleth is having this behavior already. Parity previously will return `keccak([])` for empty accounts, and now changed to return `0x0` as well in https://github.com/paritytech/parity-ethereum/pull/10775

Related to test `stExtCodeHash/codeCopyZero`.