### PR TITLE
Add "EVM Improvements" section in Istanbul for account versioning

### DIFF
--- a/EIPS/eip-1679.md
+++ b/EIPS/eip-1679.md
@@ -71,6 +71,30 @@ This meta-EIP specifies the changes included in the Ethereum hardfork named Ista
 - [EIP-2045](https://eips.ethereum.org/EIPS/eip-2045): Particle gas costs for EVM opcodes
 - [EIP-2046](https://eips.ethereum.org/EIPS/eip-2046): Reduced gas cost for static calls made to precompiles
 
+### EVM Improvements
+
+Below we list all EVM improvement EIPs, where they're rleated to account versioning (EIP-1702).
+
+#### Version 0
+
+Apply the following EIPs on version 0 based on Petersburg EVM, and freeze version 0 *after those EIPs are applied*.
+
+- TBD
+
+### Version 1
+
+Apply the following EIPs via a new account version `1`, as specified in EIP-1702 "Specification" section:
+
+- EIP-1283: Net gas metering for SSTORE without dirty maps
+- EIP-1706: Disable SSTORE with gasleft lower than call stipend
+- TBD
+
+Specifically, with definition from EIP-1702 "Usage Template" section:
+
+- **Version**: `1`.
+- **Parent version**: `0`.
+- **Features**: EIP-1283, EIP-1702, TBD.
+
 ## Timeline
 
 * 2019-05-17 (Fri) hard deadline to accept proposals for "Istanbul"

--- a/EIPS/eip-1679.md
+++ b/EIPS/eip-1679.md
@@ -73,7 +73,7 @@ This meta-EIP specifies the changes included in the Ethereum hardfork named Ista
 
 ### EVM Improvements
 
-Below we list all EVM improvement EIPs, where they're rleated to account versioning (EIP-1702).
+Below we list all EVM improvement EIPs, where they're r to account versioning (EIP-1702).
 
 #### Version 0
 


### PR DESCRIPTION
This adds a section called "EVM Improvements" in Istanbul hard fork meta EIP. This defines a template to specify the technical details for how EIP-1702 is applied in relation with other EIPs:

- First, we have the category "Version 0". In this section, we apply those EIPs that do not want account versioning to be applied this time, based on Petersburg EVM. After this, we freeze version 0.
- And then, we define a new "Version 1" based on version 0, and apply those EIPs that want to use or are required to use account versioning.