### PR TITLE
Remove Deferred from the status list

### DIFF
--- a/EIPS/eip-1.md
+++ b/EIPS/eip-1.md
@@ -73,7 +73,6 @@ Each status change is requested by the EIP author and reviewed by the EIP editor
 
 Other exceptional statuses include:
 
-* **Deferred** -- This is for core EIPs that have been put off for a future hard fork.
 * **Abandoned** -- This EIP is no longer pursued by the original authors or it may not be a (technically) preferred option anymore.
 * **Rejected** -- An EIP that is fundamentally broken or a Core EIP that was rejected by the Core Devs and will not be implemented.
 * **Active** -- This is similar to Final, but denotes an EIP which may be updated without changing its EIP number.
@@ -111,7 +110,7 @@ Each EIP must begin with an [RFC 822](https://www.ietf.org/rfc/rfc822.txt) style
 
 ` * discussions-to:` \<a url pointing to the official discussion thread\>
 
-` status:` <Draft | Last Call | Accepted | Final | Active | Abandoned | Deferred | Rejected | Superseded>
+` status:` <Draft | Last Call | Accepted | Final | Active | Abandoned | Rejected | Superseded>
 
 `* review-period-end:` <date review period ends>
 

--- a/EIPS/eip-1015.md
+++ b/EIPS/eip-1015.md
@@ -3,7 +3,7 @@ eip: 1015
 title: Configurable On Chain Issuance
 author: Alex Van de Sande <avsa@ethereum.org>
 discussions-to: https://ethereum-magicians.org/t/eip-dynamic-block-rewards-with-governance-contract/204
-status: Deferred
+status: Draft
 type: Standards Track
 category: Core
 created: 2018-04-20

--- a/EIPS/eip-3.md
+++ b/EIPS/eip-3.md
@@ -2,7 +2,7 @@
 eip: 3
 title: Addition of CALLDEPTH opcode
 author: Martin Holst Swende <martin@swende.se>
-status: Deferred
+status: Draft
 type: Standards Track
 category: Core
 created: 2015-11-19

--- a/EIPS/eip-616.md
+++ b/EIPS/eip-616.md
@@ -4,7 +4,7 @@ title: SIMD Operations for the EVM
 author: Greg Colvin <greg@colvin.org>
 type: Standards Track
 category: Core
-status: Deferred
+status: Draft
 created: 2017-04-25
 ---
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ When you believe your EIP is mature and ready to progress past the draft phase, 
 * **Accepted** - a core EIP that has been in Last Call for at least 2 weeks and any technical changes that were requested have been addressed by the author. The process for Core Devs to decide whether to encode an EIP into their clients as part of a hard fork is not part of the EIP process. If such a decision is made, the EIP will move to final.
 * **Final (non-Core)** - an EIP that has been in Last Call for at least 2 weeks and any technical changes that were requested have been addressed by the author.
 * **Final (Core)** - an EIP that the Core Devs have decided to implement and release in a future hard fork or has already been released in a hard fork. 
-* **Deferred** - an EIP that is not being considered for immediate adoption. May be reconsidered in the future for a subsequent hard fork.
 
 # Preferred Citation Format
 

--- a/_data/statuses.yaml
+++ b/_data/statuses.yaml
@@ -4,6 +4,5 @@
 - Final
 - Active
 - Abandoned
-- Deferred
 - Rejected
 - Superseded

--- a/index.html
+++ b/index.html
@@ -19,7 +19,6 @@ title: Home
   <li><strong>Accepted</strong> - a core EIP that has been in Last Call for at least 2 weeks and any technical changes that were requested have been addressed by the author. The process for Core Devs to decide whether to encode an EIP into their clients as part of a hard fork is not part of the EIP process. If such a decision is made, the EIP will move to final. </li>
   <li><strong>Final (non-Core)</strong> - an EIP that has been in Last Call for at least 2 weeks and any technical changes that were requested have been addressed by the author.</li>
   <li><strong>Final (Core)</strong> - an EIP that the Core Devs have decided to implement and release in a future hard fork or has already been released in a hard fork.</li>
-  <li><strong>Deferred</strong> an EIP that is not being considered for immediate adoption. May be reconsidered in the future for a subsequent hard fork.</li>
 </ul>
 
 <h2>EIP Types</h2>


### PR DESCRIPTION
It doesn't seem to serve any purpose. It could suggest those EIPs have been properly discussed
and accepted, but are deferred. It could also suggest there's no point discussion them now,
but that doesn't seem to be too different from draft.