### PR TITLE
EIP-1 - addition to "EIP Editor Responsibilities"

### DIFF
--- a/EIPS/eip-1.md
+++ b/EIPS/eip-1.md
@@ -227,10 +227,15 @@ For each new EIP that comes in, an editor does the following:
 
 If the EIP isn't ready, the editor will send it back to the author for revision, with specific instructions.
 
-If the editor cannot or is unwilling to provide further feedback on the EIP, he must appoint another editor to replace him (ping the other editor in the EIP's PR).
-If an editor cannot reach an agreement with the EIP proponent regarding the DRAFT status of an EIP, another editor must be pinged for providing clear technical and editorial feedback.
+Each EIP proposal must have an `assigned` editor, which ensures that the process steps are respected, the EIP changes are reviewed in due time and that the EIP status is clear for the author. However, any other editor can review the EIP.
 
-The editors have an obligation to review each EIP proposal, providing editorial or technical feedback necessary for either merging the EIP draft or closing the EIP pull request. Feedback, in the form of PR review comments on the EIP's PR, are required. The maximum amount of time that is allowed to pass between the time of making an EIP pull request and a first editor's review is 30 days. If this period is exceeded, the editor composition must be revised - e.g. new editors must be appointed, to remove the bottleneck.
+If the `assigned` editor cannot provide further feedback on the EIP, he must appoint another editor to replace him (ping the other editor in the EIP's PR).
+
+If an editor cannot reach an agreement with the EIP author regarding the DRAFT status of an EIP, another editor must be pinged for providing clear technical and editorial feedback.
+
+The editors have an obligation to review each EIP proposal, providing editorial or technical feedback necessary for either merging the EIP draft or closing the PR. Feedback, in the form of PR review comments on the EIP's PR, are required.
+
+The maximum amount of time that should pass between the author's request for review and an actual editor's review, is 30 days. This includes the first request for review, after the author publishes the EIP Draft and all subsequent requests for review, which are preceded by changes to the proposal. If this period is exceeded, another editor must provide feedback. If there are no free or willing editors, measures must be taken in order to appoint new editors.
 
 Once the EIP is ready for the repository, the EIP editor will:
 

--- a/EIPS/eip-1.md
+++ b/EIPS/eip-1.md
@@ -221,11 +221,16 @@ The current EIP editors are
 
 For each new EIP that comes in, an editor does the following:
 
-- Read the EIP to check if it is ready: sound and complete. The ideas must make technical sense, even if they don't seem likely to get to final status.
+- Read the EIP to check if it is ready: sound and complete. The ideas must make technical sense (they can be implemented), even if they don't seem likely to get to final status.
 - The title should accurately describe the content.
 - Check the EIP for language (spelling, grammar, sentence structure, etc.), markup (Github flavored Markdown), code style
 
 If the EIP isn't ready, the editor will send it back to the author for revision, with specific instructions.
+
+If the editor cannot or is unwilling to provide further feedback on the EIP, he must appoint another editor to replace him (ping the other editor in the EIP's PR).
+If an editor cannot reach an agreement with the EIP proponent regarding the DRAFT status of an EIP, another editor must be pinged for providing clear technical and editorial feedback.
+
+The editors have an obligation to review each EIP proposal, providing editorial or technical feedback necessary for either merging the EIP draft or closing the EIP pull request. Feedback, in the form of PR review comments on the EIP's PR, are required. The maximum amount of time that is allowed to pass between the time of making an EIP pull request and a first editor's review is 30 days. If this period is exceeded, the editor composition must be revised - e.g. new editors must be appointed, to remove the bottleneck.
 
 Once the EIP is ready for the repository, the EIP editor will:
 


### PR DESCRIPTION
This is an addition to EIP-1, regarding the EIP Editor Responsibilities, to avoid editors being a bottleneck for merging EIP Draft proposals, that can even be due to lack of time.

It mentions a process of appointing another editor to continue the job if the current one is unable to do so. It adds a maximum period of time that can pass between opening an EIP PR and a first editor review. If this is passed, it is a clear sign of a bottleneck. The editors' composition should be reevaluated and new editors must be added if lack of time is the cause.

`30 days` has been chosen because it is the default period for most government processes. Other suggestions are welcomed.

This proposal also signals the need for an `EIP Editor Criteria` section, to add more transparency to the process used to appoint new editors. This is covered in https://github.com/ethereum/EIPs/pull/2172