### PR TITLE
EIP-1108: Add reference to issue 1187

### DIFF
--- a/EIPS/eip-1108.md
+++ b/EIPS/eip-1108.md
@@ -131,6 +131,9 @@ Both the Parity and Geth clients have already implemented cryptographic librarie
 * [MCL, a portable C++ pairing library](https://github.com/herumi/mcl)  
 * [Libff, a C++ pairing library used in many zk-SNARK libraries](https://github.com/scipr-lab/libff)
 
+## Additional References
+
+@vbuterin independently proposed a similar reduction after this EIP was originally created, with similar rationale, as [ethereum/EIPs#1187](https://github.com/ethereum/EIPs/issues/1187).
 
 ## Copyright
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
As requested by @axic at https://ethereum-magicians.org/t/eip-1108-reduce-alt-bn128-precompile-gas-costs/3206/5 .