### PR TITLE
1884: move SELFBALANCE op from 0x46 to 0x47

### DIFF
--- a/EIPS/eip-1884.md
+++ b/EIPS/eip-1884.md
@@ -7,7 +7,7 @@ category: Core
 discussions-to: https://ethereum-magicians.org/t/opcode-repricing/3024
 status: Draft
 created: 2019-03-28
-requires: 150
+requires: 150, 1052
 ---
 
 
@@ -37,7 +37,7 @@ At block `N`,
 - The `SLOAD` (`0x54`) operation changes from `200` to `800` gas,
 - The `BALANCE` (`0x31`) operation changes from `400` to `700` gas,
 - The `EXTCODEHASH` (`0x3F`) operation changes from `400` to `700` gas,
-- A new opcode, `SELFBALANCE` is introduced at `0x46`. 
+- A new opcode, `SELFBALANCE` is introduced at `0x47`. 
   - `SELFBALANCE` pops `0` arguments off the stack, 
   - `SELFBALANCE` pushes the `balance` of the current address to the stack,
   - `SELFBALANCE` is priced as `GasFastStep`, at `5` gas. 
@@ -94,7 +94,7 @@ opcodes: `EXTBALANCE(address)` and `SELFBALANCE`, and have two different prices.
 
 ### `EXTCODEHASH`
 
-`EXTCODEHASH` was introduced in Constantinople, with [EIP 1052](https://eips.ethereum.org/EIPS/eip-1052). It was priced at `400` with the reasoning:
+`EXTCODEHASH` was introduced in Constantinople, with [EIP-1052](https://eips.ethereum.org/EIPS/eip-1052). It was priced at `400` with the reasoning:
 
 > The gas cost is the same as the gas cost for the `BALANCE` opcode because the execution of the `EXTCODEHASH` requires the same account lookup as in `BALANCE`.
 


### PR DESCRIPTION
This PR

- Moves `SELFBALANCE` from `0x46` to `0x47`, to avoid conflicts with https://eips.ethereum.org/EIPS/eip-1344 which adds `CHAINID` at `0x46`. cc @fubuloubu 
- Addresses some review comments from https://github.com/ethereum/EIPs/pull/2175