### PR TITLE
EIP-2181: Increase Clique's DIFF_INTURN

### DIFF
--- a/EIPS/eip-2181.md
+++ b/EIPS/eip-2181.md
@@ -16,15 +16,15 @@ This document proposes a patch for the Clique proof-of-authority consensus engin
 
 ## Abstract
 
-Edge-cases in Clique-based networks were discovered that eventually lead the chain to halt. One of the reasons is the difficulty value of in-turn blocks being only insignificantly higher than that of out-of-turn blocks. This proposals addresses this and encourages Clique-based networks to upgrade the difficulty formula.
+Edge-cases in Clique-based networks were discovered that eventually lead the chain to halt. One of the reasons is the difficulty value of in-turn blocks being only insignificantly higher than that of out-of-turn blocks. EIP-2181 addresses this and encourages Clique-based networks to upgrade the difficulty formula.
 
 ## Motivation
 
-The _Kotti Classic_ and _Görli_ testnets running different implementations of the _Clique_ engine got stuck multiple times due to minor issues discovered. To increase performance and stability of Clique-based networks, a series of proposals will be published to address this.
+The _Kotti Classic_ and _Görli_ testnets running different implementations of the _Clique_ engine got stuck multiple times due to minor issues discovered. To increase the performance and stability of Clique-based networks, a series of proposals will be published to address this.
 
 ## Specification
 
-This section specifies the an protocol upgrade to the Clique engine. Activation schedule for existing Clique-based test networks:
+This section specifies a protocol upgrade to the Clique engine. Activation schedule for existing Clique-based test networks:
 - `BLOCK_NUMBER >= TBD` on Görli testnet
 - `BLOCK_NUMBER >= TBD` on Kotti Classic testnet
 
@@ -32,7 +32,7 @@ At the specified `BLOCK_NUMBER`, change the block score (difficulty) calculation
 
 ## Rationale
 
-The **`DIFF_INTURN`** was increased from `2` to `7` to avoid situations where two different chain heads have the same total difficulty. This prevents the network from getting stuck by making in-turn blocks significantly more _heavy_ than out-of-turn blocks.
+The **`DIFF_INTURN`** was increased from `2` to `7` to avoid situations where two different chain heads have the same total difficulty. This prevents the network from getting stuck by making in-turn blocks significantly more _substantial_ than out-of-turn blocks.
 
 This measure was discussed and proposed in: [goerli/testnet/#57](https://github.com/goerli/testnet/issues/57)
 

--- a/EIPS/eip-2181.md
+++ b/EIPS/eip-2181.md
@@ -1,0 +1,50 @@
+---
+eip: 2181
+title: Increase Clique's DIFF_INTURN
+author: Shelly Holloway (@soc1c)
+discussions-to: https://github.com/goerli/eips-poa/issues/13
+status: Draft
+type: Standards Track
+category: Core
+created: 2019-07-09
+requires: 225
+---
+
+## Simple Summary
+
+This document proposes a patch for the Clique proof-of-authority consensus engine that could be used by Ethereum testing and development networks in the future which improves performance and stability.
+
+## Abstract
+
+Edge-cases in Clique-based networks were discovered that eventually lead the chain to halt. One of the reasons is the difficulty value of in-turn blocks being only insignificantly higher than that of out-of-turn blocks. This proposals addresses this and encourages Clique-based networks to upgrade the difficulty formula.
+
+## Motivation
+
+The _Kotti Classic_ and _Görli_ testnets running different implementations of the _Clique_ engine got stuck multiple times due to minor issues discovered. To increase performance and stability of Clique-based networks, a series of proposals will be published to address this.
+
+## Specification
+
+This section specifies the an protocol upgrade to the Clique engine. Activation schedule for existing Clique-based test networks:
+- `BLOCK_NUMBER >= TBD` on Görli testnet
+- `BLOCK_NUMBER >= TBD` on Kotti Classic testnet
+
+At the specified `BLOCK_NUMBER`, change the block score (difficulty) calculation for blocks signed _in turn_ **`DIFF_INTURN`** to `7`. The block score for out-of-turn signers remains at `1` since it just needs to be an arbitrary baseline constant.
+
+## Rationale
+
+The **`DIFF_INTURN`** was increased from `2` to `7` to avoid situations where two different chain heads have the same total difficulty. This prevents the network from getting stuck by making in-turn blocks significantly more _heavy_ than out-of-turn blocks.
+
+This measure was discussed and proposed in: [goerli/testnet/#57](https://github.com/goerli/testnet/issues/57)
+
+A script to simulate different block scores under the assumption of network fragmentation is published at: [goerli/diff-simulation](https://github.com/goerli/diff-simulation)
+
+## Test Cases
+
+Test cases can be inherited from EIP-225 by acknowledging the block score changes with this proposal.
+
+## Implementation
+
+_TBD._
+
+## Copyright
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
This document proposes a patch for the Clique proof-of-authority consensus engine that could be used by Ethereum testing and development networks in the future which improves performance and stability.

resolves https://github.com/goerli/eips-poa/issues/13

partially replaces #1955 

thanks to @tkstanczak for helping out with this