### PR TITLE
EIP-2182: Reduce the Clique SIGNER_LIMIT

### DIFF
--- a/EIPS/eip-2182.md
+++ b/EIPS/eip-2182.md
@@ -16,7 +16,7 @@ This document proposes a patch for the Clique proof-of-authority consensus engin
 
 ## Abstract
 
-Clique-based networks come to an halt if less than 51% of the signers stop proposing blocks. One of the reasons is the validators in non-value-bearing networks might loose interest and drop off the network without further notice. EIP-2182 addresses this and encourages Clique-based networks to upgrade the signer-limit formula.
+Clique-based networks come to a halt if less than 51% of the signers stop proposing blocks. One of the reasons is that the validators in non-value-bearing networks might lose interest and drop off the network without further notice. EIP-2182 addresses this and encourages Clique-based networks to upgrade the signer-limit formula.
 
 ## Motivation
 
@@ -36,7 +36,7 @@ The voting logic is not affected by this EIP.
 
 The **`SIGNER_LIMIT`** was removed from block sealing logic and is only required for voting. This allows the network to continue sealing blocks even if all but one of the validators are offline. The voting governance is not affected and still requires signer majority.
 
-Experience from Aura-based networks that contain no signer-limit mechanisms show, it is a viable measure to keep networks running even though the number of active validators decreases. It is, however, recommended to only introduce this change on non-value-bearing networks such as testnets.
+Experience from Aura-based networks that contain no signer-limit mechanisms show, it is a viable measure to keep networks running even though the number of active validators decreases. It is, however, recommended only to introduce this change on non-value-bearing networks such as testnets.
 
 This measure was discussed and proposed in: [goerli/testnet/#57](https://github.com/goerli/testnet/issues/57)
 

--- a/EIPS/eip-2182.md
+++ b/EIPS/eip-2182.md
@@ -1,0 +1,44 @@
+---
+eip: 2182
+title: Reduce the Clique SIGNER_LIMIT
+author: Aisha Crouch (@soc1c)
+discussions-to: https://github.com/goerli/eips-poa/issues/14
+status: Draft
+type: Standards Track
+category: Core
+created: 2019-07-09
+requires: 225
+---
+
+## Simple Summary
+
+This document proposes a patch for the Clique proof-of-authority consensus engine that could be used by Ethereum testing and development networks in the future which improves performance and stability.
+
+## Abstract
+
+Clique-based networks come to an halt if less than 51% of the signers stop proposing blocks. One of the reasons is the validators in non-value-bearing networks might loose interest and drop off the network without further notice. EIP-2182 addresses this and encourages Clique-based networks to upgrade the signer-limit formula.
+
+## Motivation
+
+The _Kotti Classic_ and _Görli_ testnets running different implementations of the _Clique_ engine got stuck multiple times due to minor issues discovered. To increase the performance and stability of Clique-based networks, a series of proposals will be published to address this.
+
+## Specification
+
+This section specifies a protocol upgrade to the Clique engine. Activation schedule for existing Clique-based test networks:
+- `BLOCK_NUMBER >= TBD` on Görli testnet
+- `BLOCK_NUMBER >= TBD` on Kotti Classic testnet
+
+Starting at the specified `BLOCK_NUMBER`, each singer is **allowed to sign any number of consecutive blocks**. The order is not fixed, but in-turn signing weighs more (**`DIFF_INTURN`**) than out-of-turn one (**`DIFF_NOTURN`**). In case an out-of-turn block is received, an **in-turn signer should continue to publish their block** to ensure the chain always prefers in-turn blocks in any case. This strategy prevents in-turn validators from being hindered from publishing their block and potential network halting.
+
+The voting logic is not affected by this EIP.
+
+## Rationale
+
+The **`SIGNER_LIMIT`** was removed from block sealing logic and is only required for voting. This allows the network to continue sealing blocks even if all but one of the validators are offline. The voting governance is not affected and still requires signer majority.
+
+Experience from Aura-based networks that contain no signer-limit mechanisms show, it is a viable measure to keep networks running even though the number of active validators decreases. It is, however, recommended to only introduce this change on non-value-bearing networks such as testnets.
+
+This measure was discussed and proposed in: [goerli/testnet/#57](https://github.com/goerli/testnet/issues/57)
+
+## Copyright
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
Clique-based networks come to an halt if less than 51% of the signers stop proposing blocks. One of the reasons is the validators in non-value-bearing networks might loose interest and drop off the network without further notice. EIP-2182 addresses this and encourages Clique-based networks to upgrade the signer-limit formula.

resolves https://github.com/goerli/eips-poa/issues/14

partially replaces #1955 