### PR TITLE
EIP-2183: Increase the Clique MIN_WAIT for out-of-turn blocks

### DIFF
--- a/EIPS/eip-2183.md
+++ b/EIPS/eip-2183.md
@@ -38,5 +38,7 @@ This proposal introduces a **`MIN_WAIT`** period for an out-of-turn block to be 
 
 This change is not relevant to consensus. No activation schedule is required. All clients that implement Clique are encouraged to adapt the minimum-wait delay on top of EIP-225.
 
+This measure was discussed and proposed in: [goerli/testnet/#57](https://github.com/goerli/testnet/issues/57)
+
 ## Copyright
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/EIPS/eip-2183.md
+++ b/EIPS/eip-2183.md
@@ -1,0 +1,42 @@
+---
+eip: 2183
+title: Increase the Clique MIN_WAIT for out-of-turn blocks
+author: Jardel Webb (@soc1c)
+discussions-to: https://github.com/goerli/eips-poa/issues/16
+status: Draft
+type: Standards Track
+category: Core
+created: 2019-07-09
+requires: 225
+---
+
+## Simple Summary
+
+This document proposes a patch for the Clique proof-of-authority consensus engine that could be used by Ethereum testing and development networks in the future which improves performance and stability.
+
+## Abstract
+
+Edge-cases in Clique-based networks were discovered that eventually lead the chain to halt. One of the reasons is that some clients publish out-of-turn to the network too fast. EIP-2183 addresses this and encourages clients that implement Clique to streamline their block-authoring logic based on this proposal.
+
+## Motivation
+
+The _Kotti Classic_ and _Görli_ testnets running different implementations of the _Clique_ engine got stuck multiple times due to minor issues discovered. To increase the performance and stability of Clique-based networks, a series of proposals will be published to address this.
+
+## Specification
+
+This section specifies a protocol upgrade to the Clique engine which is not relevant to consensus. No activation schedule is required.
+
+All clients that implement Clique are encouraged to use the following definition as opposed to EIP-225:
+
+* **`MIN_WAIT`**: The minimum time to wait for an out-of-turn block to be published. It is suggested to set it to `BLOCK_PERIOD / 2`.
+
+This strategy will always ensure that an in-turn signer has a **substantial advantage** to sign and propagate versus the out-of-turn signers.
+
+## Rationale
+
+This proposal introduces a **`MIN_WAIT`** period for out-of-turn block to be published which is not present for Clique. This addresses the issue of out-of-turn blocks often getting pushed into the network too fast causing a lot of short reorganizations and in some rare cases causing the network to come to a halt. By holding back out-of-turn blocks, Cliquey allows in-turn validators to seal blocks even under non-optimal network conditions, such as high network latency or validators with unsynchronized clocks.
+
+This change is not relevant to consensus. No activation schedule is required. All clients that implement Clique are encouraged to adapt the minimum-wait delay on top of EIP-225.
+
+## Copyright
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/EIPS/eip-2183.md
+++ b/EIPS/eip-2183.md
@@ -26,9 +26,11 @@ The _Kotti Classic_ and _Görli_ testnets running different implementations of t
 
 This section specifies a protocol upgrade to the Clique engine which is not relevant to consensus. No activation schedule is required.
 
-All clients that implement Clique are encouraged to use the following definition as opposed to EIP-225:
+All clients that implement Clique are encouraged to use the following definition in addition to EIP-225:
 
 * **`MIN_WAIT`**: The minimum time to wait for an out-of-turn block to be published. It is suggested to set it to `BLOCK_PERIOD / 2`.
+
+There is a chance that clients don't honor this. Therefore, In case an out-of-turn block is received, an **in-turn signer should continue to publish their block** to ensure the chain always prefers in-turn blocks in any case. This strategy prevents in-turn validators from being hindered from publishing their block and potential network halting.
 
 This strategy will always ensure that an in-turn signer has a **substantial advantage** to sign and propagate versus the out-of-turn signers.
 

--- a/EIPS/eip-2183.md
+++ b/EIPS/eip-2183.md
@@ -34,7 +34,7 @@ This strategy will always ensure that an in-turn signer has a **substantial adva
 
 ## Rationale
 
-This proposal introduces a **`MIN_WAIT`** period for out-of-turn block to be published which is not present for Clique. This addresses the issue of out-of-turn blocks often getting pushed into the network too fast causing a lot of short reorganizations and in some rare cases causing the network to come to a halt. By holding back out-of-turn blocks, Cliquey allows in-turn validators to seal blocks even under non-optimal network conditions, such as high network latency or validators with unsynchronized clocks.
+This proposal introduces a **`MIN_WAIT`** period for an out-of-turn block to be published, which is not present for Clique. This addresses the issue of out-of-turn blocks often getting pushed into the network too fast, causing a lot of short reorganizations and in some rare cases causing the network to come to a halt. By holding back out-of-turn blocks, Cliquey allows in-turn validators to seal blocks even under non-optimal network conditions, such as high network latency or validators with unsynchronized clocks.
 
 This change is not relevant to consensus. No activation schedule is required. All clients that implement Clique are encouraged to adapt the minimum-wait delay on top of EIP-225.
 


### PR DESCRIPTION
Edge-cases in Clique-based networks were discovered that eventually lead the chain to halt. One of the reasons is that some clients publish out-of-turn to the network too fast. EIP-2183 addresses this and encourages clients that implement Clique to streamline their block-authoring logic based on this proposal.

resolves https://github.com/goerli/eips-poa/issues/16

resolves https://github.com/goerli/eips-poa/issues/15

partially replaces #1955 