### PR TITLE
EIP-1344: Add datatype to opcode return value

### DIFF
--- a/EIPS/eip-1344.md
+++ b/EIPS/eip-1344.md
@@ -18,7 +18,7 @@ This EIP adds an opcode that returns the current chain's EIP-155 unique identifi
 [EIP-155](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md) proposes to use the chain ID to prevent replay attacks between different chains. It would be a great benefit to have the same possibility inside smart contracts when handling signatures, especially for Layer 2 signature schemes using [EIP-712](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md).
 
 ## Specification
-Adds a new opcode `CHAINID` at 0x46, which uses 0 stack arguments. It pushes the current chain ID onto the stack. The operation costs `G_base` to execute.
+Adds a new opcode `CHAINID` at 0x46, which uses 0 stack arguments. It pushes the current chain ID onto the stack. Chain ID is a 256 bit value. The operation costs `G_base` to execute.
 
 The value of the current chain ID is obtained from the chain ID configuration, which should match the EIP-155 unique identifier a client will accept from incoming transactions. Please note that per EIP-155, it is not *required* that a transaction have an EIP-155 unique identifier, but in that scenario this opcode will still return the configured chain ID and not a default.
 


### PR DESCRIPTION
It was ambiguous what the return value was for this opcode, so added that the size is a 256 bit integer.

This size is justified as there have been discussions if setting the value of chain ID from a hash as potential future proposals.