### PR TITLE
EIP 1577: Add link to Python implementation

### DIFF
--- a/EIPS/eip-1577.md
+++ b/EIPS/eip-1577.md
@@ -102,12 +102,15 @@ In order to support names that have an IPFS or Swarm hash in their `content` fie
 
 ### Implementation
 
-To support `contenthash`, a new resolver has been developed and can be found [here](https://github.com/ensdomains/resolvers/blob/master/contracts/PublicResolver.sol), you can also find this smart contract deployed on :
+To support `contenthash`, a new resolver has been developed and can be found [here](https://github.com/ensdomains/resolvers/blob/master/contracts/PublicResolver.sol), you can also find this smart contract deployed on:
 
 * Mainnet : [0xd3ddccdd3b25a8a7423b5bee360a42146eb4baf3](https://etherscan.io/address/0xd3ddccdd3b25a8a7423b5bee360a42146eb4baf3)
 * Ropsten : [0xde469c7106a9fbc3fb98912bb00be983a89bddca](https://ropsten.etherscan.io/address/0xde469c7106a9fbc3fb98912bb00be983a89bddca)
 
-Moreover here is a [js implementation](https://github.com/pldespaigne/content-hash) to encode and decode `contenthash`.
+There are also implementations in multiple languages to encode and decode `contenthash`:
+
+* [JavaScript](https://github.com/pldespaigne/content-hash)
+* [Python](https://github.com/filips123/ContentHashPy)
 
 ## Copyright
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
I created my implementation of EIP 1577 for Python [here](https://github.com/filips123/ContentHashPy). I want to link it from EIP to notify developers about other implementations of the content hash in different programming languages.