### PR TITLE
EIP-615 to draft

### DIFF
--- a/EIPS/eip-615.md
+++ b/EIPS/eip-615.md
@@ -1,8 +1,7 @@
 ---
 eip: 615
 title: Subroutines and Static Jumps for the EVM
-status: Last Call
-review-period-end: 2019-07-29
+status: Draft
 type: Standards Track
 category: Core
 author: Greg Colvin <greg@colvin.org>, Brooklyn Zelenka (@expede) , Paweł Bylica (@chfast), Christian Reitwiessner(@chriseth)


### PR DESCRIPTION
This EIP is withdrawn without prejudice as per https://ethereum-magicians.org/t/eip-615-subroutines-and-static-jumps-for-the-evm-last-call/3472/22?u=fulldecent