### PR TITLE
Simplify EIP 1193 error codes

### DIFF
--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -228,12 +228,11 @@ If an Error object is returned, it **MUST** contain a human readable string mess
 
 Appropriate error codes **SHOULD** follow the table of [`CloseEvent` status codes](https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent#Status_codes), along with the following table:
 
-| Status code | Name                         | Description                                                           |
-| ----------- | ---------------------------- | --------------------------------------------------------------------- |
-| 4001        | User Denied Request Accounts | User denied authorizing any accounts for the dapp.                    |
-| 4010        | User Denied Create Account   | User denied creating a new account.                                   |
-| 4100        | Unauthorized                 | The requested account has not been authorized by the user.            |
-| 4200        | Unsupported Method           | The requested method is not supported by the given Ethereum Provider. |
+| Status code | Name                         | Description                                                              |
+| ----------- | ---------------------------- | ------------------------------------------------------------------------ |
+| 4001        | User Rejected Request        | The user rejected the request.                                           |
+| 4100        | Unauthorized                 | The requested method and/or account has not been authorized by the user. |
+| 4200        | Unsupported Method           | The requested method is not supported by the given Ethereum Provider.    |
 
 ## Sample Class Implementation
 


### PR DESCRIPTION
I suggested the errors defined in the EIP be changed to:

| Status code | Name                         | Description                                                              |
| ----------- | ---------------------------- | ------------------------------------------------------------------------ |
| 4001        | User Rejected Request        | The user rejected the request.                                           |
| 4100        | Unauthorized                 | The requested method and/or account has not been authorized by the user. |
| 4200        | Unsupported Method           | The requested method is not supported by the given Ethereum Provider.    |

In summary, these changes:
- Generalize the meaning of the `4001` error code to `User Rejected Request`
  - A single "user rejection" error should suffice for all RPC methods
- Remove the `4010` error code
  - With the redefinition of `4001`, this error code is no longer needed
- Generalize the meaning of the "Unauthorized" error such that it can apply to other restrictions applied by the user/wallet
The `4200` error is unchanged.

The redefined errors are still effective for EIP 1193, but also flexible enough to be useful for RPC methods and patterns yet unimagined.