### PR TITLE
Move links to a reference section

### DIFF
--- a/EIPS/eip-2159.md
+++ b/EIPS/eip-2159.md
@@ -14,7 +14,7 @@ created: 2019-07-01
 
 ## Simple Summary
 <!--"If you can't explain it simply, you don't understand it well enough." Provide a simplified and layman-accessible explanation of the EIP.-->
-Standardized names of common metrics for Ethereum clients to use with [Prometheus](https://prometheus.io), a widely used monitoring and alerting solution.
+Standardized names of common metrics for Ethereum clients to use with Prometheus, a widely used monitoring and alerting solution.
 
 ## Abstract
 <!--A short (~200 word) description of the technical issue being addressed.-->
@@ -44,7 +44,7 @@ Note that `ethereum_best_known_block_number` always has a value. When the `eth_s
 <!--The rationale fleshes out the specification by describing what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work, e.g. how the feature is supported in other languages. The rationale may also provide evidence of consensus within the community, and should discuss important objections or concerns raised during discussion.-->
 The defined metrics are independent of Ethereum client implementation but provide sufficient information to create an overview dashboard to support monitoring a group of Ethereum nodes.
 
-There is a similar, though more prescriptive, specification for [beacon chain client metrics](https://github.com/ethereum/eth2.0-metrics/blob/master/metrics.md).
+There is a similar, though more prescriptive, specification for beacon chain client metrics.
 The specific details of how to expose the metrics has been omitted as there is variance in existing implementations and standardising this does not provide any significant benefit.
 
 ## Backwards Compatibility
@@ -56,7 +56,12 @@ Clients may already be publishing these metrics using different names and changi
 
 ## Implementation
 <!--The implementations must be completed before any EIP is given status "Final", but it need not be completed before the EIP is accepted. While there is merit to the approach of reaching consensus on the specification and rationale before writing code, the principle of "rough consensus and running code" is still useful when it comes to resolving many discussions of API details.-->
-[Pantheon](https://pegasys.tech) switched to using these standard metric names in its 1.2 release ([see PR](https://github.com/PegaSysEng/pantheon/pull/1634)).
+Pantheon switched to using these standard metric names in its 1.2 release: https://github.com/PegaSysEng/pantheon/pull/1634.
+
+## References
+
+ 1. Prometheus. https://prometheus.io
+ 2. Beacon chain metrics specification. https://github.com/ethereum/eth2.0-metrics/blob/master/metrics.md
 
 ## Copyright
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
Links have all been moved to the bottom as a reference section and inline links removed.