### PR TITLE
Add ERC for wallet_getOwnedAssets

### DIFF
--- a/EIPS/eip-2256.md
+++ b/EIPS/eip-2256.md
@@ -1,8 +1,8 @@
 ---
-eip: <to be assigned>
+eip: 2256
 title: wallet_getOwnedTokens JSON-RPC Method
 author: Loredana Cirstea (@loredanacirstea)
-discussions-to: <URL>
+discussions-to: https://ethereum-magicians.org/t/eip-2256-add-wallet-getownedtokens-json-rpc-method/3600
 status: Draft
 type: Standards Track
 category: ERC

--- a/EIPS/eip-2256.md
+++ b/EIPS/eip-2256.md
@@ -5,7 +5,7 @@ author: Loredana Cirstea (@loredanacirstea)
 discussions-to: https://ethereum-magicians.org/t/eip-2256-add-wallet-getownedassets-json-rpc-method/3600
 status: Draft
 type: Standards Track
-category: ERC
+category: Interface
 created: 2019-08-29
 requires: 55, 155, 1474
 ---

--- a/EIPS/eip-2256.md
+++ b/EIPS/eip-2256.md
@@ -1,8 +1,8 @@
 ---
 eip: 2256
-title: wallet_getOwnedTokens JSON-RPC Method
+title: wallet_getOwnedAssets JSON-RPC Method
 author: Loredana Cirstea (@loredanacirstea)
-discussions-to: https://ethereum-magicians.org/t/eip-2256-add-wallet-getownedtokens-json-rpc-method/3600
+discussions-to: https://ethereum-magicians.org/t/eip-2256-add-wallet-getownedassets-json-rpc-method/3600
 status: Draft
 type: Standards Track
 category: ERC
@@ -12,52 +12,55 @@ requires: 55, 155, 1474
 
 ## Simple Summary
 
-This is a proposal for a new JSON-RPC call for retrieving from a wallet a selection of owned tokens by an Ethereum address, with the user's permission.
+This is a proposal for a new JSON-RPC call for retrieving from a wallet a selection of owned assets by an Ethereum address, with the user's permission.
 
 ## Abstract
 
-There is no standardized way for a dApp to request a list of owned tokens from a user. Now, each dApp needs to keep a list of all the popular or existing tokens and check the user's balance against the blockchain, for each of these tokens. This leads to duplicated effort across dApps. It also leads to the user being presented with token options that the user does not care about, from various, unwanted airdrops.
+There is no standardized way for a dApp to request a list of owned assets from a user. Now, each dApp needs to keep a list of all the popular or existing assets and check the user's balance against the blockchain, for each of these assets. This leads to duplicated effort across dApps. It also leads to the user being presented with asset options that the user does not care about, from various, unwanted airdrops.
 
 ## Motivation
 
-There are financial dApps that require a list of owned tokens from a user, for various purposes - calculating taxes, selecting customized payment options, etc. Each of these dApps are now forced to keep a list of popular tokens (smart contract addresses, ABIs) and retrieve the user's data from the blockchain, for each token. This leads to effort duplication and nonoptimal UX where the user is presented with either more or less token options than the user would like - various airdrops, incomplete list of tokens kept by the dApp.
+There are financial dApps that require a list of owned assets from a user, for various purposes - calculating taxes, selecting customized payment options, etc. Each of these dApps are now forced to keep a list of popular assets (smart contract addresses, ABIs) and retrieve the user's data from the blockchain, for each asset. This leads to effort duplication and nonoptimal UX where the user is presented with either more or less asset options than the user would like - various airdrops, incomplete list of assets kept by the dApp.
 
-This list of owned token can be retrieved from the wallet used by the user. The wallet can allow the user to manage only the tokens that the user is interested in. Therefore, a new JSON-RPC method is proposed: `wallet_getOwnedTokens`.
+This list of owned assets can be retrieved from the wallet used by the user. The wallet can allow the user to manage only the assets that the user is interested in. Therefore, a new JSON-RPC method is proposed: `wallet_getOwnedAssets`. This method is complementary to [EIP-747](https://eips.ethereum.org/EIPS/eip-747), which proposes a way for sites to suggest users new assets to watch on their wallet.
 
 ## Specification
 
-New JSON-RPC method: `wallet_getOwnedTokens`.
+New JSON-RPC method to be added to web3 browsers: `wallet_getOwnedAssets`. This method is for dApp-wallet communication and only targets the assets that have already been whitelisted by the wallet, for the user account.
 
 **Arguments:**
-- type `address`, Ethereum address that owns the tokens
+- type `address`, Ethereum address that owns the assets
 - filter object, optional:
-  - `chainId` - type `uint256`, chain id respecting [EIP-155](https://eips.ethereum.org/EIPS/eip-155); optional
-  - `count` - type `uint256`, number of owned tokens to return; optional
+  - `chainId` - type `uint`, chain id respecting [EIP-155](https://eips.ethereum.org/EIPS/eip-155); optional
+  - `count` - type `uint`, number of owned assets to return; optional
+  - `types` - type `string[]`, array of asset interface identifiers such as `['ERC20', 'ERC721']`; optional
 
 **Result:**
-- array with token records:
+- array with asset records:
   - `address` - type `address`, Ethereum checksummed address
-  - `chainId` - type `uint256`, identifier for the chain on which the tokens are deployed
-  - `interface` - type `string`, token interface ERC identifier; e.g. `ERC20`; optional - [EIP-1820](https://eips.ethereum.org/EIPS/eip-1820) could be used
-  - `name` - type `string`, token name; optional if the token does not implement it
-  - `symbol` - type `string`, token symbol; optional if the token does not implement it
-  - `icon`- type `base64`, token icon; optional
-  - `balance` - type `uint256`, the number of tokens that the user owns, in the smallest token denomination
+  - `chainId` - type `uint`, identifier for the chain on which the assets are deployed
+  - `type` - type `string`, asset interface ERC identifier; e.g. `ERC20`; optional - [EIP-1820](https://eips.ethereum.org/EIPS/eip-1820) could be used
+  - `options` - an object with asset-specific fields; `ERC20` tokens example:
+    - `name` - type `string`, token name; optional if the token does not implement it
+    - `symbol` - type `string`, token symbol; optional if the token does not implement it
+    - `icon`- type `base64`, token icon; optional
+    - `balance` - type `uint`, the number of tokens that the user owns, in the smallest token denomination
+    - `decimals` - type `uint`, the number of decimals implemented by the token; optional
 
 ### Examples
 
-**1) A request to return all of the user's owned tokens:**
-```javascript
+**1) A request to return all of the user's owned assets:**
+```json
 {
   "id":1,
   "jsonrpc": "2.0",
-  "method": "wallet_getOwnedTokens",
+  "method": "wallet_getOwnedAssets",
   "params": ["0x3333333333333333333333333333333333333333"]
 }
 ```
 Result:
 
-```javascript
+```json
 {
   "id":1,
   "jsonrpc": "2.0",
@@ -65,46 +68,54 @@ Result:
     {
       "address": "0x0000000000000000000000000000000000000001",
       "chainId": 1,
-      "interface": "ERC20",
-      "name": "TokenA",
-      "symbol": "TKA",
-      "icon": "data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==",
-      "balance": 1000000000000
+      "type": "ERC20",
+      "options": {
+        "name": "TokenA",
+        "symbol": "TKA",
+        "icon": "data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==",
+        "balance": 1000000000000,
+        "decimals": 18
+      }
     },
     {
       "address": "0x0000000000000000000000000000000000000002",
       "chainId": 3,
-      "interface": "ERC20",
-      "name": "TokenB",
-      "symbol": "TKB",
-      "icon": "data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==",
-      "balance": 2000000000000
+      "type": "ERC20",
+      "options": {
+        "name": "TokenB",
+        "symbol": "TKB",
+        "icon": "data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==",
+        "balance": 2000000000000,
+        "decimals": 18
+      }
     },
     {
       "address": "0x0000000000000000000000000000000000000003",
       "chainId": 42,
-      "interface": "ERC721",
-      "name": "TokenC",
-      "symbol": "TKC",
-      "icon": "data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==",
-      "balance": 2000000000000
+      "type": "ERC721",
+      "options": {
+        "name": "TokenC",
+        "symbol": "TKC",
+        "icon": "data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==",
+        "balance": 10
+      }
     },
   ]
 }
 ```
 
-**2) A request to return one owned token, deployed on `chainId` 1:**
-```javascript
+**2) A request to return one `ERC20` owned asset, deployed on `chainId` 1:**
+```json
 {
   "id":1,
   "jsonrpc": "2.0",
-  "method": "wallet_getOwnedTokens",
-  "params": ["0x3333333333333333333333333333333333333333", {"chainId": 1, "count": 1}]
+  "method": "wallet_getOwnedAssets",
+  "params": ["0x3333333333333333333333333333333333333333", {"chainId": 1, "count": 1, "types": ["ERC20"]}]
 }
 ```
 Result:
 
-```javascript
+```json
 {
   "id":1,
   "jsonrpc": "2.0",
@@ -112,11 +123,14 @@ Result:
     {
       "address": "0x0000000000000000000000000000000000000001",
       "chainId": 1,
-      "interface": "ERC20",
-      "name": "TokenA",
-      "symbol": "TKA",
-      "icon": "data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==",
-      "balance": 1000000000000
+      "type": "ERC20",
+      "options": {
+        "name": "TokenA",
+        "symbol": "TKA",
+        "icon": "data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==",
+        "balance": 1000000000000,
+        "decimals": 18
+      }
     }
   ]
 }
@@ -126,24 +140,26 @@ Result:
 
 The wallet should display a UI to the user, showing the request.
 The user can:
-- accept the request, in which case the dApp receives all the requested tokens
+- accept the request, in which case the dApp receives all the requested assets
 - reject the request
-- amend the request by lowering the number of owned tokens returned to the dApp
+- amend the request by lowering the number of owned assets returned to the dApp
 
 
-If all owned tokens are requested, the total number of owned tokens will be shown to the user. The user can also choose to select the tokens that will be returned to the dApp, amending the request.
+If all owned assets are requested, the total number of owned assets will be shown to the user. The user can also choose to select the assets that will be returned to the dApp, amending the request.
 
-If a selection is requested, the user will select from the list of owned tokens.
+If a selection is requested, the user will select from the list of owned assets.
 
-As an optimization, wallets can keep a list of frequently used tokens by the user, and show that list first, with the option of expanding that list with owned tokens that the user uses less frequently.
+As an optimization, wallets can keep a list of frequently used assets by the user, and show that list first, with the option of expanding that list with owned assets that the user uses less frequently.
 
 ## Rationale
 
-In order to avoid duplication of effort for dApps that require keeping a list of all or popular tokens and to provide optimal UX, the `wallet_getOwnedTokens` JSON-RPC method is proposed.
+In order to avoid duplication of effort for dApps that require keeping a list of all or popular assets and to provide optimal UX, the `wallet_getOwnedAssets` JSON-RPC method is proposed.
 
-The `name`, `symbol`, `icon` response fields enable better UX, compatible with the wallet used, making it easier for the user to understand the dApp's UI.
+The `chainId`, `count` and `types` parameters allow dApps to filter the selection list that the user will be presented with by the wallet, in accordance with the dApp's functionality.
 
-The `address`, `interface` response fields provide enough information about the token, enabling dApps to provide additional token-specific functionality.
+The `options` response field provides the dApp with asset-specific options, enabling better UX through using the same visual and text identifiers that the wallet uses, making it easier for the user to understand the dApp's UI.
+
+The `address`, `type` response fields provide enough information about the asset, enabling dApps to provide additional asset-specific functionality.
 
 The `balance` response field is an optimization, allowing dApps to show the user's balance without querying the blockchain. Usually, this information is already public.
 

--- a/EIPS/eip-2256.md
+++ b/EIPS/eip-2256.md
@@ -29,7 +29,8 @@ This list of owned token can be retrieved from the wallet used by the user. The 
 New JSON-RPC method: `wallet_getOwnedTokens`.
 
 **Arguments:**
-- number of owned tokens to return; optional
+- type `address`, Ethereum address that owns the tokens
+- type `uint256`, number of owned tokens to return; optional
 
 **Result:**
 - array with token records:
@@ -48,7 +49,7 @@ New JSON-RPC method: `wallet_getOwnedTokens`.
   "id":1,
   "jsonrpc": "2.0",
   "method": "wallet_getOwnedTokens",
-  "params": []
+  "params": ["0x3333333333333333333333333333333333333333"]
 }
 ```
 Result:
@@ -92,7 +93,7 @@ Result:
   "id":1,
   "jsonrpc": "2.0",
   "method": "wallet_getOwnedTokens",
-  "params": [1]
+  "params": ["0x3333333333333333333333333333333333333333", 1]
 }
 ```
 Result:

--- a/EIPS/eip-2256.md
+++ b/EIPS/eip-2256.md
@@ -7,7 +7,7 @@ status: Draft
 type: Standards Track
 category: ERC
 created: 2019-08-29
-requires: 55,1474
+requires: 55, 155, 1474
 ---
 
 ## Simple Summary
@@ -30,11 +30,14 @@ New JSON-RPC method: `wallet_getOwnedTokens`.
 
 **Arguments:**
 - type `address`, Ethereum address that owns the tokens
-- type `uint256`, number of owned tokens to return; optional
+- filter object, optional:
+  - `chainId` - type `uint256`, chain id respecting [EIP-155](https://eips.ethereum.org/EIPS/eip-155); optional
+  - `count` - type `uint256`, number of owned tokens to return; optional
 
 **Result:**
 - array with token records:
   - `address` - type `address`, Ethereum checksummed address
+  - `chainId` - type `uint256`, identifier for the chain on which the tokens are deployed
   - `interface` - type `string`, token interface ERC identifier; e.g. `ERC20`; optional - [EIP-1820](https://eips.ethereum.org/EIPS/eip-1820) could be used
   - `name` - type `string`, token name; optional if the token does not implement it
   - `symbol` - type `string`, token symbol; optional if the token does not implement it
@@ -44,7 +47,7 @@ New JSON-RPC method: `wallet_getOwnedTokens`.
 ### Examples
 
 **1) A request to return all of the user's owned tokens:**
-```
+```javascript
 {
   "id":1,
   "jsonrpc": "2.0",
@@ -54,13 +57,14 @@ New JSON-RPC method: `wallet_getOwnedTokens`.
 ```
 Result:
 
-```
+```javascript
 {
   "id":1,
   "jsonrpc": "2.0",
   "result": [
     {
       "address": "0x0000000000000000000000000000000000000001",
+      "chainId": 1,
       "interface": "ERC20",
       "name": "TokenA",
       "symbol": "TKA",
@@ -69,6 +73,7 @@ Result:
     },
     {
       "address": "0x0000000000000000000000000000000000000002",
+      "chainId": 3,
       "interface": "ERC20",
       "name": "TokenB",
       "symbol": "TKB",
@@ -77,6 +82,7 @@ Result:
     },
     {
       "address": "0x0000000000000000000000000000000000000003",
+      "chainId": 42,
       "interface": "ERC721",
       "name": "TokenC",
       "symbol": "TKC",
@@ -87,24 +93,25 @@ Result:
 }
 ```
 
-**2) A request to return one owned token:**
-```
+**2) A request to return one owned token, deployed on `chainId` 1:**
+```javascript
 {
   "id":1,
   "jsonrpc": "2.0",
   "method": "wallet_getOwnedTokens",
-  "params": ["0x3333333333333333333333333333333333333333", 1]
+  "params": ["0x3333333333333333333333333333333333333333", {"chainId": 1, "count": 1}]
 }
 ```
 Result:
 
-```
+```javascript
 {
   "id":1,
   "jsonrpc": "2.0",
   "result": [
     {
       "address": "0x0000000000000000000000000000000000000001",
+      "chainId": 1,
       "interface": "ERC20",
       "name": "TokenA",
       "symbol": "TKA",

--- a/EIPS/eip-2256.md
+++ b/EIPS/eip-2256.md
@@ -30,10 +30,11 @@ New JSON-RPC method to be added to web3 browsers: `wallet_getOwnedAssets`. This 
 
 **Arguments:**
 - type `address`, Ethereum address that owns the assets
-- filter object, optional:
+- options object, optional:
   - `chainId` - type `uint`, chain id respecting [EIP-155](https://eips.ethereum.org/EIPS/eip-155); optional
-  - `count` - type `uint`, number of owned assets to return; optional
+  - `limit` - type `uint`, the maximum number of owned assets expected by the dApp to be returned; optional
   - `types` - type `string[]`, array of asset interface identifiers such as `['ERC20', 'ERC721']`; optional
+  - `justification` - type `string`, human-readable text provided by the dApp, explaining the intended purpose of this request; optional but recommended
 
 **Result:**
 - array with asset records:
@@ -55,7 +56,12 @@ New JSON-RPC method to be added to web3 browsers: `wallet_getOwnedAssets`. This 
   "id":1,
   "jsonrpc": "2.0",
   "method": "wallet_getOwnedAssets",
-  "params": ["0x3333333333333333333333333333333333333333"]
+  "params": [
+    "0x3333333333333333333333333333333333333333",
+    {
+      "justification": "The dApp needs to know about all your assets in order to calculate your taxes properly."
+    }
+  ]
 }
 ```
 Result:
@@ -110,7 +116,15 @@ Result:
   "id":1,
   "jsonrpc": "2.0",
   "method": "wallet_getOwnedAssets",
-  "params": ["0x3333333333333333333333333333333333333333", {"chainId": 1, "count": 1, "types": ["ERC20"]}]
+  "params": [
+    "0x3333333333333333333333333333333333333333",
+    {
+      "chainId": 1,
+      "limit": 1,
+      "types": ["ERC20"],
+      "justification": "Select your token of choice, in order to pay for our services."
+    }
+  ]
 }
 ```
 Result:
@@ -155,7 +169,7 @@ As an optimization, wallets can keep a list of frequently used assets by the use
 
 In order to avoid duplication of effort for dApps that require keeping a list of all or popular assets and to provide optimal UX, the `wallet_getOwnedAssets` JSON-RPC method is proposed.
 
-The `chainId`, `count` and `types` parameters allow dApps to filter the selection list that the user will be presented with by the wallet, in accordance with the dApp's functionality.
+The `chainId` and `types` optional parameters enable dApps to provide options in order to restrict the selection list that the user will be presented with by the wallet, in accordance with the dApp's functionality. The `limit` parameter enables the dApp to tell the user an upper limit of accounts that the user can select. It remains to be seen if a lower bound should also be provided. At the moment, this lower bound can be considered as being `1`.
 
 The `options` response field provides the dApp with asset-specific options, enabling better UX through using the same visual and text identifiers that the wallet uses, making it easier for the user to understand the dApp's UI.
 

--- a/EIPS/eip-wallet_get_owned_tokens.md
+++ b/EIPS/eip-wallet_get_owned_tokens.md
@@ -1,0 +1,159 @@
+---
+eip: <to be assigned>
+title: wallet_getOwnedTokens JSON-RPC Method
+author: Loredana Cirstea (@loredanacirstea)
+discussions-to: <URL>
+status: Draft
+type: Standards Track
+category: ERC
+created: 2019-08-29
+requires: 55,1474
+---
+
+## Simple Summary
+
+This is a proposal for a new JSON-RPC call for retrieving from a wallet a selection of owned tokens by an Ethereum address, with the user's permission.
+
+## Abstract
+
+There is no standardized way for a dApp to request a list of owned tokens from a user. Now, each dApp needs to keep a list of all the popular or existing tokens and check the user's balance against the blockchain, for each of these tokens. This leads to duplicated effort across dApps. It also leads to the user being presented with token options that the user does not care about, from various, unwanted airdrops.
+
+## Motivation
+
+There are financial dApps that require a list of owned tokens from a user, for various purposes - calculating taxes, selecting customized payment options, etc. Each of these dApps are now forced to keep a list of popular tokens (smart contract addresses, ABIs) and retrieve the user's data from the blockchain, for each token. This leads to effort duplication and nonoptimal UX where the user is presented with either more or less token options than the user would like - various airdrops, incomplete list of tokens kept by the dApp.
+
+This list of owned token can be retrieved from the wallet used by the user. The wallet can allow the user to manage only the tokens that the user is interested in. Therefore, a new JSON-RPC method is proposed: `wallet_getOwnedTokens`.
+
+## Specification
+
+New JSON-RPC method: `wallet_getOwnedTokens`.
+
+**Arguments:**
+- number of owned tokens to return; optional
+
+**Result:**
+- array with token records:
+  - `address` - type `address`, Ethereum checksummed address
+  - `interface` - type `string`, token interface ERC identifier; e.g. `ERC20`; optional - [EIP-1820](https://eips.ethereum.org/EIPS/eip-1820) could be used
+  - `name` - type `string`, token name; optional if the token does not implement it
+  - `symbol` - type `string`, token symbol; optional if the token does not implement it
+  - `icon`- type `base64`, token icon; optional
+  - `balance` - type `uint256`, the number of tokens that the user owns, in the smallest token denomination
+
+### Examples
+
+**1) A request to return all of the user's owned tokens:**
+```
+{
+  "id":1,
+  "jsonrpc": "2.0",
+  "method": "wallet_getOwnedTokens",
+  "params": []
+}
+```
+Result:
+
+```
+{
+  "id":1,
+  "jsonrpc": "2.0",
+  "result": [
+    {
+      "address": "0x0000000000000000000000000000000000000001",
+      "interface": "ERC20",
+      "name": "TokenA",
+      "symbol": "TKA",
+      "icon": "data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==",
+      "balance": 1000000000000
+    },
+    {
+      "address": "0x0000000000000000000000000000000000000002",
+      "interface": "ERC20",
+      "name": "TokenB",
+      "symbol": "TKB",
+      "icon": "data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==",
+      "balance": 2000000000000
+    },
+    {
+      "address": "0x0000000000000000000000000000000000000003",
+      "interface": "ERC721",
+      "name": "TokenC",
+      "symbol": "TKC",
+      "icon": "data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==",
+      "balance": 2000000000000
+    },
+  ]
+}
+```
+
+**2) A request to return one owned token:**
+```
+{
+  "id":1,
+  "jsonrpc": "2.0",
+  "method": "wallet_getOwnedTokens",
+  "params": [1]
+}
+```
+Result:
+
+```
+{
+  "id":1,
+  "jsonrpc": "2.0",
+  "result": [
+    {
+      "address": "0x0000000000000000000000000000000000000001",
+      "interface": "ERC20",
+      "name": "TokenA",
+      "symbol": "TKA",
+      "icon": "data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==",
+      "balance": 1000000000000
+    }
+  ]
+}
+```
+
+### UI Best Practices
+
+The wallet should display a UI to the user, showing the request.
+The user can:
+- accept the request, in which case the dApp receives all the requested tokens
+- reject the request
+- amend the request by lowering the number of owned tokens returned to the dApp
+
+
+If all owned tokens are requested, the total number of owned tokens will be shown to the user. The user can also choose to select the tokens that will be returned to the dApp, amending the request.
+
+If a selection is requested, the user will select from the list of owned tokens.
+
+As an optimization, wallets can keep a list of frequently used tokens by the user, and show that list first, with the option of expanding that list with owned tokens that the user uses less frequently.
+
+## Rationale
+
+In order to avoid duplication of effort for dApps that require keeping a list of all or popular tokens and to provide optimal UX, the `wallet_getOwnedTokens` JSON-RPC method is proposed.
+
+The `name`, `symbol`, `icon` response fields enable better UX, compatible with the wallet used, making it easier for the user to understand the dApp's UI.
+
+The `address`, `interface` response fields provide enough information about the token, enabling dApps to provide additional token-specific functionality.
+
+The `balance` response field is an optimization, allowing dApps to show the user's balance without querying the blockchain. Usually, this information is already public.
+
+
+## Backwards Compatibility
+
+Not relevant, as this is a new method.
+
+
+## Test Cases
+
+To be done.
+
+
+## Implementation
+
+To be done.
+
+
+## Copyright
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
Add ERC for `wallet_getOwnedAssets`

This is a proposal targeting wallet API standardization: a new JSON-RPC method for retrieving a selection of owned assets by an Ethereum address, with the user's permission.

