### PR TITLE
Change category of EIP-2015 from ERC to Interface

### DIFF
--- a/EIPS/eip-2015.md
+++ b/EIPS/eip-2015.md
@@ -5,7 +5,7 @@ author: Pedro Gomes (@pedrouid)
 discussions-to: https://ethereum-magicians.org/t/eip-2015-wallet-update-chain-json-rpc-method-wallet-updatechain/3274
 status: Draft
 type: Standards Track
-category: ERC
+category: Interface
 created: 2019-05-12
 requires: 155, 1474
 ---


### PR DESCRIPTION
Every other RPC extension is under the Interface category.

@pedrouid please acknowledge this.