### PR TITLE
EIP-1193: Add close method

### DIFF
--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -33,12 +33,12 @@ See the [available methods](https://github.com/ethereum/wiki/wiki/JSON-RPC#json-
 Provider connection can be closed using this method
 
 ```js
-ethereum.close(): Promise<any>;
+ethereum.close(): Promise<void>;
 ```
 
-Promise resolves with `result` or rejects with `Error`.
+Promise resolves with `undefined` or rejects with `Error`.
 
-See the [available methods](https://github.com/ethereum/wiki/wiki/JSON-RPC#json-rpc-methods).
+Some Ethereum providers may not require this method thus should implement it as a no-op.
 
 ### Events
 

--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -28,6 +28,18 @@ Promise resolves with `result` or rejects with `Error`.
 
 See the [available methods](https://github.com/ethereum/wiki/wiki/JSON-RPC#json-rpc-methods).
 
+### Close
+
+Provider connection can be closed using this method
+
+```js
+ethereum.close(): Promise<any>;
+```
+
+Promise resolves with `result` or rejects with `Error`.
+
+See the [available methods](https://github.com/ethereum/wiki/wiki/JSON-RPC#json-rpc-methods).
+
 ### Events
 
 Events are emitted using [EventEmitter](https://nodejs.org/api/events.html).


### PR DESCRIPTION
Add the close method to the Ethereum provider API to allow Dapps to close the connection.

The motivation behind this change is to allow Dapps to switch between providers and closing the connection with first one before opening the connection with the second one.

Example: User enables connection with injected provider but then wants to disconnect to connect to another provider like WalletConnect, Portis or Fortmatic