### PR TITLE
Make the return value of `account()` optional

### DIFF
--- a/EIPS/eip-1767.md
+++ b/EIPS/eip-1767.md
@@ -220,7 +220,7 @@ type Block {
     # Logs returns a filtered set of logs from this block.
     logs(filter: BlockFilterCriteria!): [Log!]!
     # Account fetches an Ethereum account at the current block's state.
-    account(address: Address!): Account!
+    account(address: Address!): Account
     # Call executes a local call operation at the current block's state.
     call(data: CallData!): CallResult
     # EstimateGas estimates the amount of gas that will be required for
@@ -303,7 +303,7 @@ type Pending {
   # Transactions is a list of transactions in the current pending state.
   transactions: [Transaction!]
   # Account fetches an Ethereum account for the pending state.
-  account(address: Address!): Account!
+  account(address: Address!): Account
   # Call executes a local call operation for the pending state.
   call(data: CallData!): CallResult
   # EstimateGas estimates the amount of gas that will be required for


### PR DESCRIPTION
Suppose I run `block { account(address: "0x...")  { balance, code, address }` with a valid but unknown address.  I find it clearer to get back null for the account than some default values for each field.