### PR TITLE
dType Functions Extension - Decentralized Type System for EVM

### DIFF
--- a/EIPS/eip-1921.md
+++ b/EIPS/eip-1921.md
@@ -1,5 +1,5 @@
 ---
-eip: <to be assigned>
+eip: 1921
 title: dType Functions Extension
 author: Loredana Cirstea (@loredanacirstea), Christian Tzurcanu (@ctzurcanu)
 discussions-to: https://github.com/ethereum/EIPs/issues/1921
@@ -49,7 +49,6 @@ An example of a function registration object for the dType registry is:
     "types": [
         {"name": "TypeA", "label": "typeA", "relation":0, "dimensions":[]}
     ],
-    "lang": 0,
     "typeChoice": 4,
     "contractAddress": <address of the deployed smart contract where the function is defined>,
     "source": <bytes32 hash for referencing source files>,

--- a/EIPS/eip-dtype-functions.md
+++ b/EIPS/eip-dtype-functions.md
@@ -1,0 +1,146 @@
+---
+eip: <to be assigned>
+title: dType - Extending the Decentralized Type System for Functions
+author: Loredana Cirstea (@loredanacirstea), Christian Tzurcanu (@ctzurcanu)
+discussions-to: <URL>
+status: Draft
+type: Standards Track
+category: ERC
+created: 2019-04-06
+requires: 1900
+---
+
+
+## Simple Summary
+In the context of dType, the Decentralized Type System described in [EIP-1900](https://github.com/ethereum/EIPs/pull/1900), we are proposing to add support for registering functions in the dType Registry.
+
+
+## Abstract
+
+This proposal is part of a series of EIPs focused on expanding the concept of a Decentralized Type System, as explained in EIP-1900.
+The current EIP specifies the data definitions and interfaces needed to support registering individual smart contract functions, as entries in the dType Registry.
+
+
+## Motivation
+
+In order to evolve the EVM into a Singleton Operating System, we need a way to register, find and address contract functions that we want to run in an automated way.
+This implies having access to all the data needed to run the function inside the EVM.
+
+Aside from the above motivation, there are also near future benefits for this proposal. Having a globally available, non-custodial functions registry, will democratize development of tools, such as those targeting: blockchain data analysis (e.g. block explorers), smart contract IDEs, security analysis of smart contracts.
+
+Registering new smart contract functions can be done through the same consensus mechanism as EIP-1900 mentions, in order to avoid burdening the chain state with redundant or improper records.
+
+
+## Specification
+
+For each smart contract function, we must store:
+* unique function name
+* smart contract `address`
+* reference to the file containing the function source code
+* the type data and label of each input
+* the type data and label of each output
+
+The first four are handled by EIP-1900.
+Base types will not have output values. However, they may have optional components. Therefore, we are proposing to store these optional components together with function output interfaces in a separate mapping:
+
+```
+mapping(bytes32 => dTypes[]) public optionals;
+```
+
+The `dTypes` `struct` is defined in EIP-1900.
+
+We can then have an interface to register these optional inputs/outputs for an already registered type, referenced by `typeHash`.
+
+```
+function setOptionals(
+    bytes32 typeHash,
+    dTypes[] memory optionalValues
+)
+    public
+```
+
+Further, the `dType` Registry can be extended to have a function which calculates the function signature, based on the stored information:
+
+```
+function getSignature(bytes32 typeHash)
+    view
+    public
+    returns (bytes4 signature)
+```
+
+We also propose to extend the `dType` Registry with wrapper functions that are able to call the registered functions with user given input arguments or input arguments referenced by their storage hash, if they are part of a type's storage contract.
+This can be further extended to add chaining and composition capabilities.
+
+An example would be a base `run()` function, which takes the ABI encoded input data and the function's `typeHash`. The output will be the ABI encoded output data of the function, referenced by `typeHash`.
+
+```
+function run(bytes memory inputData, bytes32 memory typeHash)
+    public
+    returns(bytes memory outputData)
+```
+
+These wrapper functions can be defined in their own library, enabling chaining and composition:
+
+```
+using dTypeWrapperLibrary for bytes;
+...
+function () {
+    inputData.run(typeHash1).run(typeHash2).run(typeHash3)
+}
+```
+
+An example of the data object that is given when registering a function:
+
+```
+{
+    "name": "setStaked",
+    "types": [
+        {"name": "TypeA", "label": "typeA", "relation":0, "dimensions":[]}
+    ],
+    "lang": 0,
+    "typeChoice": 4,
+    "contractAddress": <address of the deployed smart contract where the function is defined>,
+    "source": <a SWARM hash for source files>,
+    "optionals": [
+        {"name": "TypeB", "label": "typeB", "relation":0, "dimensions":[]}
+    ]
+}
+```
+Note that the input and output types are based on types that have already been registered. This lowers the amount of ABI information needed to be stored for each function and enables developers to aggregate and find functions that use the same types for their I/O. This can be a powerful tool for interoperability and smart contract composition.
+
+
+## Rationale
+
+The suggestion to treat each function as a separate entity instead of having a contract-based approach allows us to:
+* have a global context of readily available functions
+* scale designs through functional programming patterns rather than contract-encapsulated logic (which can be successfully used to scale development efforts independently)
+* bidirectionally connect functions with the types they use, making automation easier
+* cherry pick functions from already deployed contracts if the other contract functions do not pass community consensus
+* have scope-restricted improvements - instead of redeploying entire contracts, we can just redeploy the new function versions that we want added to the registry
+
+The proposal to store the minimum ABI information on-chain, for each function, allows us to:
+* enable on-chain automation (e.g. function chaining and composition)
+* be backwards compatible in case the function signature format changes (e.g. from `bytes4` to `bytes32`)
+
+Concerns about this design might be:
+* redundancy of storing `contractAddress` for each function that is part of the same contract
+
+We think that state/storage cost will be compensated through DRYness across the chain, due to reusing types and functions that have already been registered and are now very easy to find. Other state/storage cost calculations will be added once the specification and implementation is closer to be finalized.
+
+## Backwards Compatibility
+
+This proposal does not affect extant Ethereum standards or implementations. Registering functions for existing contract deployments should be fully supported.
+The EIP implementation currently requires the experimental version of ABIEncoderV2.
+
+## Test Cases
+
+Will be added.
+
+
+## Implementation
+
+In work implementation examples can be found at https://github.com/ctzurcanu/dType/tree/master/contracts/contracts.
+This proposal will be updated with an appropriate implementation when consensus is reached on the specifications.
+
+## Copyright
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/EIPS/eip-dtype-functions.md
+++ b/EIPS/eip-dtype-functions.md
@@ -1,8 +1,8 @@
 ---
 eip: <to be assigned>
-title: dType - Extending the Decentralized Type System for Functions
+title: dType Functions Extension
 author: Loredana Cirstea (@loredanacirstea), Christian Tzurcanu (@ctzurcanu)
-discussions-to: <URL>
+discussions-to: https://github.com/ethereum/EIPs/issues/1921
 status: Draft
 type: Standards Track
 category: ERC
@@ -10,86 +10,38 @@ created: 2019-04-06
 requires: 1900
 ---
 
-
 ## Simple Summary
-In the context of dType, the Decentralized Type System described in [EIP-1900](https://github.com/ethereum/EIPs/pull/1900), we are proposing to add support for registering functions in the dType Registry.
-
+In the context of dType, the Decentralized Type System described in [EIP-1900](https://eips.ethereum.org/EIPS/eip-1900), we are proposing to add support for registering functions (with a preference for `pure` and `view`) in the dType Registry.
 
 ## Abstract
 
-This proposal is part of a series of EIPs focused on expanding the concept of a Decentralized Type System, as explained in EIP-1900.
+This proposal is part of a series of EIPs focused on expanding the concept of a Decentralized Type System, as explained in [EIP-1900](https://eips.ethereum.org/EIPS/eip-1900).
 The current EIP specifies the data definitions and interfaces needed to support registering individual smart contract functions, as entries in the dType Registry.
-
 
 ## Motivation
 
 In order to evolve the EVM into a Singleton Operating System, we need a way to register, find and address contract functions that we want to run in an automated way.
 This implies having access to all the data needed to run the function inside the EVM.
 
-Aside from the above motivation, there are also near future benefits for this proposal. Having a globally available, non-custodial functions registry, will democratize development of tools, such as those targeting: blockchain data analysis (e.g. block explorers), smart contract IDEs, security analysis of smart contracts.
+Aside from the above motivation, there are also near future benefits for this proposal. Having a globally available, non-custodial functions registry, will democratize the development of tools, such as those targeting: blockchain data analysis (e.g. block explorers), smart contract IDEs, security analysis of smart contracts.
 
-Registering new smart contract functions can be done through the same consensus mechanism as EIP-1900 mentions, in order to avoid burdening the chain state with redundant or improper records.
+Registering new smart contract functions can be done through the same consensus mechanism as [EIP-1900](https://eips.ethereum.org/EIPS/eip-1900) mentions, in order to avoid burdening the chain state with redundant or improper records.
 
 
 ## Specification
 
-For each smart contract function, we must store:
-* unique function name
-* smart contract `address`
-* reference to the file containing the function source code
-* the type data and label of each input
-* the type data and label of each output
+This specification targets `pure` and `view` functions.
 
-The first four are handled by EIP-1900.
-Base types will not have output values. However, they may have optional components. Therefore, we are proposing to store these optional components together with function output interfaces in a separate mapping:
+For each function, we can store:
+* `name` - type `string` unique function name, as defined in EIP-1900; required
+* `types` - the type data and label of each input, as defined in EIP-1900; required
+* `outputs` - the type data and label of each output; required
+* `contractAddress` - type `address` - smart contract where the function resides, as defined in EIP-1900; optional for interfaces
+* `source` - type `bytes32` - reference to an external file containing the function source code, as defined in EIP-1900; optional
 
-```
-mapping(bytes32 => dTypes[]) public optionals;
-```
+Therefore, this proposal adds `outputs` to the EIP-1900 type registration definition.
 
-The `dTypes` `struct` is defined in EIP-1900.
-
-We can then have an interface to register these optional inputs/outputs for an already registered type, referenced by `typeHash`.
-
-```
-function setOptionals(
-    bytes32 typeHash,
-    dTypes[] memory optionalValues
-)
-    public
-```
-
-Further, the `dType` Registry can be extended to have a function which calculates the function signature, based on the stored information:
-
-```
-function getSignature(bytes32 typeHash)
-    view
-    public
-    returns (bytes4 signature)
-```
-
-We also propose to extend the `dType` Registry with wrapper functions that are able to call the registered functions with user given input arguments or input arguments referenced by their storage hash, if they are part of a type's storage contract.
-This can be further extended to add chaining and composition capabilities.
-
-An example would be a base `run()` function, which takes the ABI encoded input data and the function's `typeHash`. The output will be the ABI encoded output data of the function, referenced by `typeHash`.
-
-```
-function run(bytes memory inputData, bytes32 memory typeHash)
-    public
-    returns(bytes memory outputData)
-```
-
-These wrapper functions can be defined in their own library, enabling chaining and composition:
-
-```
-using dTypeWrapperLibrary for bytes;
-...
-function () {
-    inputData.run(typeHash1).run(typeHash2).run(typeHash3)
-}
-```
-
-An example of the data object that is given when registering a function:
+An example of a function registration object for the dType registry is:
 
 ```
 {
@@ -100,37 +52,81 @@ An example of the data object that is given when registering a function:
     "lang": 0,
     "typeChoice": 4,
     "contractAddress": <address of the deployed smart contract where the function is defined>,
-    "source": <a SWARM hash for source files>,
-    "optionals": [
+    "source": <bytes32 hash for referencing source files>,
+    "outputs": [
         {"name": "TypeB", "label": "typeB", "relation":0, "dimensions":[]}
     ]
 }
 ```
-Note that the input and output types are based on types that have already been registered. This lowers the amount of ABI information needed to be stored for each function and enables developers to aggregate and find functions that use the same types for their I/O. This can be a powerful tool for interoperability and smart contract composition.
 
+The above object will be passed to `<dType registry>.insert({...})`
+
+An additional `setOutputs` function is proposed for the dType registry:
+
+```
+function setOutputs(
+    bytes32 identifier,
+    dTypes[] memory outputs
+)
+    public
+```
+
+- `identifier` - type `bytes32`, the type's identifier, as defined in EIP-1900
+- `outputs` - type `dTypes`, as defined in EIP-1900
+
+### Implementation Suggestions
+
+
+In the dType registry implementation, `outputs` can be stored in a `mapping`:
+
+```
+mapping(bytes32 => dTypes[]) public outputs;
+```
 
 ## Rationale
 
-The suggestion to treat each function as a separate entity instead of having a contract-based approach allows us to:
+
+The suggestion to treat each `pure` or `view` function as a separate entity instead of having a contract-based approach allows us to:
 * have a global context of readily available functions
 * scale designs through functional programming patterns rather than contract-encapsulated logic (which can be successfully used to scale development efforts independently)
 * bidirectionally connect functions with the types they use, making automation easier
-* cherry pick functions from already deployed contracts if the other contract functions do not pass community consensus
-* have scope-restricted improvements - instead of redeploying entire contracts, we can just redeploy the new function versions that we want added to the registry
+* cherry-pick functions from already deployed contracts if the other contract functions do not pass community consensus
+* have scope-restricted improvements - instead of redeploying entire contracts, we can just redeploy the new function versions that we want to be added to the registry
+* enable fine-grained auditing of individual functions, for the common good
+* enable testing directly on a production chain, without state side-effects
 
 The proposal to store the minimum ABI information on-chain, for each function, allows us to:
 * enable on-chain automation (e.g. function chaining and composition)
-* be backwards compatible in case the function signature format changes (e.g. from `bytes4` to `bytes32`)
+* be backward compatible in case the function signature format changes (e.g. from `bytes4` to `bytes32`): multiple signature calculation functions can be registered with dType. Examples:
+
+```
+function getSignatureBytes4(bytes32 identifier)
+    view
+    public
+    returns (bytes4 signature)
+
+function getSignatureBytes32(bytes32 identifier)
+    view
+    public
+    returns (bytes32 signature)
+```
+
+- `identifier` - the type's identifier, as defined in EIP-1900
+- `signature` - the function's signature
+
 
 Concerns about this design might be:
 * redundancy of storing `contractAddress` for each function that is part of the same contract
 
-We think that state/storage cost will be compensated through DRYness across the chain, due to reusing types and functions that have already been registered and are now very easy to find. Other state/storage cost calculations will be added once the specification and implementation is closer to be finalized.
+We think that state/storage cost will be compensated through DRYness across the chain, due to reusing types and functions that have already been registered and are now easy to find. Other state/storage cost calculations will be added once the specification and implementation are closer to be finalized.
+
+
+Note that the input and output types are based on types that have already been registered. This lowers the amount of ABI information needed to be stored for each function and enables developers to aggregate and find functions that use the same types for their I/O. This can be a powerful tool for interoperability and smart contract composition.
+
 
 ## Backwards Compatibility
 
 This proposal does not affect extant Ethereum standards or implementations. Registering functions for existing contract deployments should be fully supported.
-The EIP implementation currently requires the experimental version of ABIEncoderV2.
 
 ## Test Cases
 
@@ -139,7 +135,7 @@ Will be added.
 
 ## Implementation
 
-In work implementation examples can be found at https://github.com/ctzurcanu/dType/tree/master/contracts/contracts.
+In-work implementation examples can be found at https://github.com/pipeos-one/dType.
 This proposal will be updated with an appropriate implementation when consensus is reached on the specifications.
 
 ## Copyright


### PR DESCRIPTION
In the context of dType, the Decentralized Type System described in [EIP-1900](https://eips.ethereum.org/EIPS/eip-1900), we are proposing to add support for registering functions (with a preference for `pure` and `view`) in the dType Registry.