### PR TITLE
Adds clarifying text to the EIP-155 specification.

### DIFF
--- a/EIPS/eip-155.md
+++ b/EIPS/eip-155.md
@@ -17,7 +17,9 @@ created: 2016-10-14
 
 ### Specification
 
-If `block.number >= FORK_BLKNUM` and `v = CHAIN_ID * 2 + 35` or `v = CHAIN_ID * 2 + 36`, then when computing the hash of a transaction for purposes of signing or recovering, instead of hashing only the first six elements (i.e. nonce, gasprice, startgas, to, value, data), hash nine elements, with `v` replaced by `CHAIN_ID`, `r = 0` and `s = 0`. The currently existing signature scheme using `v = 27` and `v = 28` remains valid and continues to operate under the same rules as it does now.
+If `block.number >= FORK_BLKNUM` and `CHAIN_ID` is available, then when computing the hash of a transaction for the purposes of signing, instead of hashing only six rlp encoded elements `(nonce, gasprice, startgas, to, value, data)`, you **SHOULD** hash nine rlp encoded elements `(nonce, gasprice, startgas, to, value, data, chainid, 0, 0)`.  If you do, then the `v` of the signature **MUST** be set to `{0,1} + CHAIN_ID * 2 + 35` where `{0,1}` is the parity of the `y` value of the curve point for which `r` is the x-value in the secp256k1 signing process.  If you choose to only hash 6 values, then `v` continues to be set to `{0,1} + 27` as previously.
+
+If `block.number >= FORK_BLKNUM` and `v = CHAIN_ID * 2 + 35` or `v = CHAIN_ID * 2 + 36`, then when computing the hash of a transaction for purposes of recovering, instead of hashing six rlp encoded elements `(nonce, gasprice, startgas, to, value, data)`, hash nine rlp encoded elements `(nonce, gasprice, startgas, to, value, data, chainid, 0, 0)`. The currently existing signature scheme using `v = 27` and `v = 28` remains valid and continues to operate under the same rules as it did previously.
 
 ### Example
 


### PR DESCRIPTION
As someone implementing stuff related to signing in this space I have had to come back and read this EIP many times to remind myself how to properly sign/recover a transaction post EIP-155.  Each time, I read this EIP and am left confused about what I'm actually supposed to do when signing.  After once again digging to figure out what I'm supposed to do I decided to edit this EIP to hopefully prevent future developers (including myself) from running into the same frustration.

This change is non-normative and only attempts to improve clarity of the process.  If a normative change was made, this means my understanding is flawed and corrections should be made before this PR is merged.

The major change is to include a section for how to generate a valid post-155 signature.  The original text only explained how to _validate_ a post-155 signature and it was left up to the reader to figure out how to generate one.

I chose to use **SHOULD** here because it offers the users additional security against replay attacks and generally should be preferred unless you have good reason to not sign this way.  This could be widened to **MAY** if that is desirable.  **MUST** would be a normative change so that was intentionally not chosen.

I have also made a couple grammatical and formatting changes to the original text while editing which I felt helped improve readability.

When opening a pull request to submit a new EIP, please use the suggested template: https://github.com/ethereum/EIPs/blob/master/eip-template.md

We have a GitHub bot that automatically merges some PRs. It will merge yours immediately if certain criteria are met:

 - The PR edits only existing draft PRs.
 - The build passes.
 - Your Github username or email address is listed in the 'author' header of all affected PRs, inside <triangular brackets>.
 - If matching on email address, the email address is the one publicly listed on your GitHub profile.
