### PR TITLE
Generalize EIP-152 to other BLAKE2 variants

### DIFF
--- a/EIPS/eip-152.md
+++ b/EIPS/eip-152.md
@@ -1,6 +1,6 @@
 ---
 eip: 152
-title: Add Blake2 compression function `F` precompile
+title: Add BLAKE2 compression function `F` precompile
 author: Tjaden Hess <tah83@cornell.edu>, Matt Luongo (@mhluongo), Piotr Dyraga (@pdyraga), James Hancock (@MadeOfTin)
 discussions-to: https://github.com/ethereum/EIPs/issues/152
 status: Draft
@@ -15,7 +15,7 @@ requires: 2046
 ## Simple Summary
 <!--"If you can't explain it simply, you don't understand it well enough." Provide a simplified and layman-accessible explanation of the EIP.-->
 
-This EIP will enable the Blake2b hash function to run cheaply on the EVM, allowing easier interoperability between Ethereum and Zcash as well as other Equihash-based PoW coins.
+This EIP will enable the BLAKE2b hash function to run cheaply on the EVM, allowing easier interoperability between Ethereum and Zcash as well as other Equihash-based PoW coins.
 
 ## Abstract
 <!--A short (~200 word) description of the technical issue being addressed.-->
@@ -34,7 +34,7 @@ Interoperability with Zcash could enable contracts like trustless atomic swaps b
 ## Specification
 <!--The technical specification should describe the syntax and semantics of any new feature. The specification should be detailed enough to allow competing, interoperable implementations for any of the current Ethereum platforms (go-ethereum, parity, cpp-ethereum, ethereumj, ethereumjs, and [others](https://github.com/ethereum/wiki/wiki/Clients)).-->
 
-We propose adding a precompiled contract at address `0x09` wrapping the [BLAkE2b `F` compression function](https://tools.ietf.org/html/rfc7693#section-3.2).
+We propose adding a precompiled contract at address `0x09` wrapping the [BLAKE2b `F` compression function](https://tools.ietf.org/html/rfc7693#section-3.2).
 
 The precompile requires 6 inputs tightly encoded, taking exactly 213 bytes, as explained below. The encoded inputs are corresponding to the ones specified in the [BLAKE2b RFC Section 3.2](https://tools.ietf.org/html/rfc7693#section-3.2):
 
@@ -48,8 +48,8 @@ The precompile requires 6 inputs tightly encoded, taking exactly 213 bytes, as e
 [4 bytes for rounds][64 bytes for h][128 bytes for m][8 bytes for t_0][8 bytes for t_1][1 byte for f]
 ```
 
-The boolean `f` parameter is considered as `true` if set to `1`. 
-The boolean `f` parameter is considered as `false` if set to `0`. 
+The boolean `f` parameter is considered as `true` if set to `1`.
+The boolean `f` parameter is considered as `false` if set to `0`.
 All other values yield an invalid encoding of `f` error.
 
 The precompile should compute the `F` function as [specified in the RFC](https://tools.ietf.org/html/rfc7693#section-3.2) and return the updated state vector `h` with unchanged encoding (little-endian).
@@ -77,15 +77,15 @@ function callF() public view returns (bytes32[2] memory) {
   uint32 rounds = 12;
 
   bytes32[2] memory h;
-  h[0] = hex"48c9bdf267e6096a3ba7ca8485ae67bb2bf894fe72f36e3cf1361d5f3af54fa5"; 
+  h[0] = hex"48c9bdf267e6096a3ba7ca8485ae67bb2bf894fe72f36e3cf1361d5f3af54fa5";
   h[1] = hex"d182e6ad7f520e511f6c3e2b8c68059b6bbd41fbabd9831f79217e1319cde05b";
-  
+
   bytes32[4] memory m;
   m[0] = hex"6162630000000000000000000000000000000000000000000000000000000000";
   m[1] = hex"0000000000000000000000000000000000000000000000000000000000000000";
   m[2] = hex"0000000000000000000000000000000000000000000000000000000000000000";
   m[3] = hex"0000000000000000000000000000000000000000000000000000000000000000";
- 
+
   bytes8[2] memory t;
   t[0] = hex"03000000";
   t[1] = hex"00000000";
@@ -96,7 +96,7 @@ function callF() public view returns (bytes32[2] memory) {
   // ba80a53f981c4d0d6a2797b69f12f6e94c212f14685ac4b74b12bb6fdbffa2d1
   // 7d87c5392aab792dc252d5de4533cc9518d38aa8dbf1925ab92386edd4009923
   return F(rounds, h, m, t, f);
-}    
+}
 ```
 
 ### Gas costs and benchmarks
@@ -139,17 +139,17 @@ There is very little risk of breaking backwards-compatibility with this EIP, the
 
 #### Test vector 0
 * input: (empty)
-* output: error "input length for Blake2 F precompile should be exactly 213 bytes"
+* output: error "input length for BLAKE2 F precompile should be exactly 213 bytes"
 
 #### Test vector 1
 * input:
 `00000c48c9bdf267e6096a3ba7ca8485ae67bb2bf894fe72f36e3cf1361d5f3af54fa5d182e6ad7f520e511f6c3e2b8c68059b6bbd41fbabd9831f79217e1319cde05b61626300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000300000000000000000000000000000001`
-* output: error "input length for Blake2 F precompile should be exactly 213 bytes"
+* output: error "input length for BLAKE2 F precompile should be exactly 213 bytes"
 
 #### Test vector 2
 * input:
 `000000000c48c9bdf267e6096a3ba7ca8485ae67bb2bf894fe72f36e3cf1361d5f3af54fa5d182e6ad7f520e511f6c3e2b8c68059b6bbd41fbabd9831f79217e1319cde05b61626300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000300000000000000000000000000000001`
-* output: error "input length for Blake2 F precompile should be exactly 213 bytes"
+* output: error "input length for BLAKE2 F precompile should be exactly 213 bytes"
 
 #### Test vector 3
 * input:
@@ -157,38 +157,38 @@ There is very little risk of breaking backwards-compatibility with this EIP, the
 * output: error "incorrect final block indicator flag"
 
 #### Test vector 4
-* input: 
+* input:
 `0000000048c9bdf267e6096a3ba7ca8485ae67bb2bf894fe72f36e3cf1361d5f3af54fa5d182e6ad7f520e511f6c3e2b8c68059b6bbd41fbabd9831f79217e1319cde05b61626300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000300000000000000000000000000000001`
-* output: 
+* output:
 `08c9bcf367e6096a3ba7ca8485ae67bb2bf894fe72f36e3cf1361d5f3af54fa5d282e6ad7f520e511f6c3e2b8c68059b9442be0454267ce079217e1319cde05b`
 
 #### Test vector 5
-* input: 
+* input:
 `0000000c48c9bdf267e6096a3ba7ca8485ae67bb2bf894fe72f36e3cf1361d5f3af54fa5d182e6ad7f520e511f6c3e2b8c68059b6bbd41fbabd9831f79217e1319cde05b61626300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000300000000000000000000000000000001`
 * output: `ba80a53f981c4d0d6a2797b69f12f6e94c212f14685ac4b74b12bb6fdbffa2d17d87c5392aab792dc252d5de4533cc9518d38aa8dbf1925ab92386edd4009923`
 
 #### Test vector 6
-* input: 
+* input:
 `0000000c48c9bdf267e6096a3ba7ca8485ae67bb2bf894fe72f36e3cf1361d5f3af54fa5d182e6ad7f520e511f6c3e2b8c68059b6bbd41fbabd9831f79217e1319cde05b61626300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000300000000000000000000000000000000`
-* output: 
+* output:
 `75ab69d3190a562c51aef8d88f1c2775876944407270c42c9844252c26d2875298743e7f6d5ea2f2d3e8d226039cd31b4e426ac4f2d3d666a610c2116fde4735`
 
 #### Test vector 7
 * input:
 `0000000148c9bdf267e6096a3ba7ca8485ae67bb2bf894fe72f36e3cf1361d5f3af54fa5d182e6ad7f520e511f6c3e2b8c68059b6bbd41fbabd9831f79217e1319cde05b61626300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000300000000000000000000000000000001`
-* output: 
+* output:
 `b63a380cb2897d521994a85234ee2c181b5f844d2c624c002677e9703449d2fba551b3a8333bcdf5f2f7e08993d53923de3d64fcc68c034e717b9293fed7a421`
 
 #### Test vector 8
-* input: 
+* input:
 `ffffffff48c9bdf267e6096a3ba7ca8485ae67bb2bf894fe72f36e3cf1361d5f3af54fa5d182e6ad7f520e511f6c3e2b8c68059b6bbd41fbabd9831f79217e1319cde05b61626300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000300000000000000000000000000000001`
-* output: 
+* output:
 `fc59093aafa9ab43daae0e914c57635c5402d8e3d2130eb9b3cc181de7f0ecf9b22bf99a7815ce16419e200e01846e6b5df8cc7703041bbceb571de6631d2615`
 
 ## Implementation
 <!--The implementations must be completed before any EIP is given status "Final", but it need not be completed before the EIP is accepted. While there is merit to the approach of reaching consensus on the specification and rationale before writing code, the principle of "rough consensus and running code" is still useful when it comes to resolving many discussions of API details.-->
 
-An initial implementation of the `F` function in Go, adapted from the standard library, can be found in our [Golang Blake2 library fork](https://github.com/keep-network/blake2-f). There's also an implementation of the precompile in our fork of [go-ethereum](https://github.com/keep-network/go-ethereum/pull/4).
+An initial implementation of the `F` function in Go, adapted from the standard library, can be found in our [Golang BLAKE2 library fork](https://github.com/keep-network/blake2-f). There's also an implementation of the precompile in our fork of [go-ethereum](https://github.com/keep-network/go-ethereum/pull/4).
 
 ## References
 

--- a/EIPS/eip-152.md
+++ b/EIPS/eip-152.md
@@ -15,28 +15,28 @@ requires: 2046
 ## Simple Summary
 <!--"If you can't explain it simply, you don't understand it well enough." Provide a simplified and layman-accessible explanation of the EIP.-->
 
-This EIP will enable the BLAKE2b hash function to run cheaply on the EVM, allowing easier interoperability between Ethereum and Zcash as well as other Equihash-based PoW coins.
+This EIP will enable the BLAKE2b hash function and higher-round 64-bit BLAKE2 variants to run cheaply on the EVM, allowing easier interoperability between Ethereum and Zcash as well as other Equihash-based PoW coins.
 
 ## Abstract
 <!--A short (~200 word) description of the technical issue being addressed.-->
 
-This EIP introduces a new precompiled contract which implements the compression function `F` used in the BLAKE2b cryptographic hashing algorithm, for the purpose of allowing interoperability between the EVM and Zcash, as well as introducing more flexible cryptographic hash primitives to the EVM.
+This EIP introduces a new precompiled contract which implements the compression function `F` used in the BLAKE2 cryptographic hashing algorithm, for the purpose of allowing interoperability between the EVM and Zcash, as well as introducing more flexible cryptographic hash primitives to the EVM.
 
 ## Motivation
 <!--The motivation is critical for EIPs that want to change the Ethereum protocol. It should clearly explain why the existing protocol specification is inadequate to address the problem that the EIP solves. EIP submissions without sufficient motivation may be rejected outright.-->
 
-Besides being a useful cryptographic hash function and SHA3 finalist, BLAKE2b allows for efficient verification of the Equihash PoW used in Zcash, making a BTC Relay - style SPV client possible on Ethereum. A single verification of an Equihash PoW verification requires 512 iterations of the hash function, making verification of Zcash block headers prohibitively expensive if a Solidity implementation of BLAKE2b is used.
+Besides being a useful cryptographic hash function and SHA3 finalist, BLAKE2 allows for efficient verification of the Equihash PoW used in Zcash, making a BTC Relay - style SPV client possible on Ethereum. A single verification of an Equihash PoW verification requires 512 iterations of the hash function, making verification of Zcash block headers prohibitively expensive if a Solidity implementation of BLAKE2 is used.
 
-The BLAKE2b algorithm is highly optimized for 64-bit CPUs, and is faster than MD5 on modern processors.
+BLAKE2b, the common 64-bit BLAKE2 variant, is highly optimized and faster than MD5 on modern processors.
 
 Interoperability with Zcash could enable contracts like trustless atomic swaps between the chains, which could provide a much needed aspect of privacy to the very public Ethereum blockchain.
 
 ## Specification
 <!--The technical specification should describe the syntax and semantics of any new feature. The specification should be detailed enough to allow competing, interoperable implementations for any of the current Ethereum platforms (go-ethereum, parity, cpp-ethereum, ethereumj, ethereumjs, and [others](https://github.com/ethereum/wiki/wiki/Clients)).-->
 
-We propose adding a precompiled contract at address `0x09` wrapping the [BLAKE2b `F` compression function](https://tools.ietf.org/html/rfc7693#section-3.2).
+We propose adding a precompiled contract at address `0x09` wrapping the [BLAKE2 `F` compression function](https://tools.ietf.org/html/rfc7693#section-3.2).
 
-The precompile requires 6 inputs tightly encoded, taking exactly 213 bytes, as explained below. The encoded inputs are corresponding to the ones specified in the [BLAKE2b RFC Section 3.2](https://tools.ietf.org/html/rfc7693#section-3.2):
+The precompile requires 6 inputs tightly encoded, taking exactly 213 bytes, as explained below. The encoded inputs are corresponding to the ones specified in the [BLAKE2 RFC Section 3.2](https://tools.ietf.org/html/rfc7693#section-3.2):
 
 - `rounds` - the number of rounds - 32-bit unsigned big-endian word
 - `h` - the state vector - 8 unsigned 64-bit little-endian words
@@ -106,11 +106,11 @@ Each operation will cost `GFROUND * rounds` gas, where `GFROUND = 1`. Detailed b
 ## Rationale
 <!--The rationale fleshes out the specification by describing what motivated the design and why particular design decisions  were made. It should describe alternate designs that were considered and related work, e.g. how the feature is supported in other languages. The rationale may also provide evidence of consensus within the community, and should discuss important objections or concerns raised during discussion.-->
 
-BLAKE2b is an excellent candidate for precompilation. It exhibits an extremely asymmetric efficiency. BLAKE2b is heavily optimized for modern 64-bit CPUs, specifically utilizing 24 and 63-bit rotations to allow parallelism through SIMD instructions and little-endian arithmetic. These characteristics provide exceptional speed on native CPUs: 3.08 cycles per byte, or 1 gibibyte per second on an Intel i5.
+BLAKE2 is an excellent candidate for precompilation. BLAKE2 is heavily optimized for modern 64-bit CPUs, specifically utilizing 24 and 63-bit rotations to allow parallelism through SIMD instructions and little-endian arithmetic. These characteristics provide exceptional speed on native CPUs: 3.08 cycles per byte, or 1 gibibyte per second on an Intel i5.
 
 In contrast, the big-endian 32 byte semantics of the EVM are not conducive to efficient implementation of BLAKE2, and thus the gas cost associated with computing the hash on the EVM is disproportionate to the true cost of computing the function natively.
 
-An obvious implementation would be a direct BLAKE2b precompile. At first glance, a BLAKE2b precompile satisfies most hashing and interoperability requirements on the EVM. Once we started digging in, however, it became clear that any BLAKE2b implementation would need specific features and internal modifications based on different projects' requirements and libraries.
+An obvious implementation would be a direct BLAKE2b hash function precompile. At first glance, a BLAKE2b precompile satisfies most hashing and interoperability requirements on the EVM. Once we started digging in, however, it became clear that any BLAKE2b implementation would need specific features and internal modifications based on different projects' requirements and libraries.
 
 A [thread with the Zcash team](https://github.com/ethereum/EIPs/issues/152#issuecomment-499240310) makes the issue clear.
 

--- a/EIPS/eip-152.md
+++ b/EIPS/eip-152.md
@@ -15,7 +15,7 @@ requires: 2046
 ## Simple Summary
 <!--"If you can't explain it simply, you don't understand it well enough." Provide a simplified and layman-accessible explanation of the EIP.-->
 
-This EIP will enable the BLAKE2b hash function and higher-round 64-bit BLAKE2 variants to run cheaply on the EVM, allowing easier interoperability between Ethereum and Zcash as well as other Equihash-based PoW coins.
+This EIP will enable the BLAKE2b hash function and other higher-round 64-bit BLAKE2 variants to run cheaply on the EVM, allowing easier interoperability between Ethereum and Zcash as well as other Equihash-based PoW coins.
 
 ## Abstract
 <!--A short (~200 word) description of the technical issue being addressed.-->


### PR DESCRIPTION
After [feedback from the last AllCoreDevs call](https://github.com/ethereum/EIPs/issues/152#issuecomment-528919091), I've adjusted the EIP to more accurately distinguish between the 64-bit BLAKE2 family of hash functions and functionality specific to BLAKE2b, the 12-round 64-bit BLAKE2 variant.

> The EIP also should include the actual compression function and parameters (SIGMA, IV) – and not leave it as a reference to the RFC.

Note that I wasn't easily able to follow the suggestion to include direct `SIGMA` and `IV` definitions -- as many client implementations might have different definitions due to library and language-specific optimizations, the `SIGMA` and `IV` definitions don't further specify the EIP over the provided test cases.

As there hasn't been much activity on [Gitter from implementors](https://gitter.im/ethereum/AllCoreDevs?at=5d77bccaa08e2b4bd2bf6249) around the inclusion of an `m_len` parameter and it's late in the game to substantially change precompile functionality, I've left the change out due to lack of consensus.