### PR TITLE
Update EIP-1108 to reflect Final status

### DIFF
--- a/EIPS/eip-1108.md
+++ b/EIPS/eip-1108.md
@@ -3,7 +3,7 @@ eip: 1108
 title: Reduce alt_bn128 precompile gas costs
 author: Antonio Salazar Cardozo (@shadowfiend), Zachary Williamson (@zac-williamson)
 discussions-to: https://ethereum-magicians.org/t/eip-1108-reduce-alt-bn128-precompile-gas-costs/3206
-status: Draft
+status: Final
 type: Standards Track
 category: Core
 created: 2018-05-21


### PR DESCRIPTION
Since the Istanbul meta-EIP has EIP-1108 listed for the hardfork and the implementation tracker lists everyone as having merged, this EIP seems reasonable to move to Final status.