### PR TITLE
EIP1884: EXTCODECOPY Increase and EXTBALANCE Conditional Pricing

### DIFF
--- a/EIPS/eip-1884.md
+++ b/EIPS/eip-1884.md
@@ -32,18 +32,18 @@ If operations are well-balanced, we can maximise the block gaslimit and have a m
 
 ## Specification
 
-At block `N`, 
+At block `N`,
 
-- The `SLOAD` (`0x54`) operation changes from `200` to `800` gas,
-- `EXTCODECOPY` (`0x3C`) cost per copy word changed from `3` to `800`
-- The `EXTCODEHASH` (`0x3F`) operation changes from `400` to `700` gas,
-- A new opcode, `SELFBALANCE` is introduced at `0x47`. 
-  - `SELFBALANCE` pops `0` arguments off the stack, 
+- The `SLOAD` (`0x54`) operation changes from `200` to `800` gas.
+- `EXTCODECOPY` (`0x3C`) cost per copy-word changed from `3` to `800`.
+- The `EXTCODEHASH` (`0x3F`) operation changes from `400` to `700` gas.
+- A new opcode, `SELFBALANCE` is introduced at `0x47`.
+  - `SELFBALANCE` pops `0` arguments off the stack,
   - `SELFBALANCE` pushes the `balance` of the current address to the stack,
   - `SELFBALANCE` is priced as `Gmid`, at `8` gas.
-- The `BALANCE` (`0x31`) operation is renamed to `EXTBALANCE`
-  - If the parameter is SELF, `EXTBALANCE` is priced as `Ghigh`, at `10` gas.
-  - Otherwise, `EXTBALANCE` cost changes from `400` to `700` gas
+- The `BALANCE` (`0x31`) operation is renamed to `EXTBALANCE`.
+  - If the parameter to `EXTBALANCE` is the executing account, `EXTBALANCE` is priced as `Ghigh`, at `10` gas.
+  - Otherwise, `EXTBALANCE` cost changes from `400` to `700` gas.
 
 ## Rationale
 

--- a/EIPS/eip-1884.md
+++ b/EIPS/eip-1884.md
@@ -35,12 +35,15 @@ If operations are well-balanced, we can maximise the block gaslimit and have a m
 At block `N`, 
 
 - The `SLOAD` (`0x54`) operation changes from `200` to `800` gas,
-- The `BALANCE` (`0x31`) operation changes from `400` to `700` gas,
+- `EXTCODECOPY` (`0x3C`) cost per copy word changed from `3` to `800`
 - The `EXTCODEHASH` (`0x3F`) operation changes from `400` to `700` gas,
 - A new opcode, `SELFBALANCE` is introduced at `0x47`. 
   - `SELFBALANCE` pops `0` arguments off the stack, 
   - `SELFBALANCE` pushes the `balance` of the current address to the stack,
-  - `SELFBALANCE` is priced as `GasFastStep`, at `5` gas. 
+  - `SELFBALANCE` is priced as `G`<sub>`low`</sub>, at `5` gas.
+- The `BALANCE` (`0x31`) operation is renamed to `EXTBALANCE`
+  - If the parameter is SELF, `EXTBALANCE` is priced as `G`<sub>`high`</sub>, at `10` gas.
+  - Otherwise, `EXTBALANCE` cost changes from `400` to `700` gas
 
 ## Rationale
 
@@ -107,6 +110,7 @@ The changes require a hardfork. The changes have the following consequences:
 
 - Certain calls will become more expensive.
 - Default-functions which access the storage and may in some cases require more than`2300` gas (the minimum gas that is always available in calls). 
+  - This is known to break at least 680 mainnet smart contracts.
 - Contracts that assume a certain fixed gas cost for calls (or internal sections) may cease to function.
   - A fixed gas cost is specified in [ERC-165](https://eips.ethereum.org/EIPS/eip-165) and implementations of this interface do use the affected opcodes.
     - The ERC-165 method `supportsInterface` must return a `bool` and use at most `30,000` gas.

--- a/EIPS/eip-1884.md
+++ b/EIPS/eip-1884.md
@@ -40,9 +40,9 @@ At block `N`,
 - A new opcode, `SELFBALANCE` is introduced at `0x47`. 
   - `SELFBALANCE` pops `0` arguments off the stack, 
   - `SELFBALANCE` pushes the `balance` of the current address to the stack,
-  - `SELFBALANCE` is priced as `G`<sub>`low`</sub>, at `5` gas.
+  - `SELFBALANCE` is priced as `Gmid`, at `8` gas.
 - The `BALANCE` (`0x31`) operation is renamed to `EXTBALANCE`
-  - If the parameter is SELF, `EXTBALANCE` is priced as `G`<sub>`high`</sub>, at `10` gas.
+  - If the parameter is SELF, `EXTBALANCE` is priced as `Ghigh`, at `10` gas.
   - Otherwise, `EXTBALANCE` cost changes from `400` to `700` gas
 
 ## Rationale


### PR DESCRIPTION
Discussions in the [forum](https://ethereum-magicians.org/t/opcode-repricing/3024/45) surfaced additional concerns of varying severity.

First, there is a [documented exploit](https://medium.com/@agusx1211/evm-istambul-storage-pricing-5befaac32403) of the current pricing scheme.
`EXTCODECOPY` is much cheaper now than SLOAD, so EIP 1884 makes it substantially cheaper to read from contract data in more contexts than before.
To discourage contract data from being externalized into ephemeral data contracts, EXTCODECOPY cost per word must increase to be on-par with `SLOAD`.
The cost of reading data from every other location has increased; code should not be excluded.

Second, the cost of `EXTBALANCE` is unfair for the most-common use case of checking ones own balance.
While it should not cost the same as `SELFBALANCE` in this case because of the necessary comparison, the cost should be similar because the data is in the same location.
This adjustment could reduce the scope of stipend breakage from `EXTBALANCE`.