### PR TITLE
Changes reference to `sha3` to `keccak256`.

### DIFF
--- a/EIPS/eip-55.md
+++ b/EIPS/eip-55.md
@@ -17,7 +17,7 @@ from ethereum import utils
 
 def checksum_encode(addr): # Takes a 20-byte binary address as input
     o = ''
-    v = utils.big_endian_to_int(utils.sha3(addr.hex()))
+    v = utils.big_endian_to_int(utils.keccak256(addr.hex()))
     for i, c in enumerate(addr.hex()):
         if c in '0123456789':
             o += c


### PR DESCRIPTION
Ethereum doesn't use `sha3` anywhere, and later in the document it explicitly states that this is actually `keccak256`.  To avoid people implementing SHA3 only to find out it doesn't work (like I did), I'm fixing this to be `keccak256`.