### PR TITLE
Withdraw EIP-1702 from Berlin Proposed EIP List

### DIFF
--- a/EIPS/eip-2070.md
+++ b/EIPS/eip-2070.md
@@ -36,7 +36,6 @@ This meta-EIP specifies the changes included in the Ethereum hardfork named Berl
     above and beyond standard security considerations, that should be evaluated
     prior to inclusion.
 - [EIP-1380](https://eips.ethereum.org/EIPS/eip-1380): Reduced gas cost for call to self
-- [EIP-1702](https://eips.ethereum.org/EIPS/eip-1702): Generalized account versioning scheme
 - [EIP-1962](https://eips.ethereum.org/EIPS/eip-1962): EC arithmetic and pairings with runtime definitions
   - replaces EIP-1829
 - [EIP-1985](https://eips.ethereum.org/EIPS/eip-1985): Sane limits for certain EVM parameters


### PR DESCRIPTION
After Istanbul, Ethereum community has decided to adopt an EIP-centric hard fork process, which means each proposed EIP now must have an "EIP champion".

I drafted the specifications for account versioning because I think it is a generally useful feature for Ethereum, so I proposed to included it in hard forks. However, championing it would mean that I need to take a political position of the EIP, which I don't want to. As I won't be championing this EIP, I'm withdrawing it from the proposed EIP list in Berlin.

If anyone's interested in championing account versioning for Ethereum, please let me know. I'm happy to provide any help needed!