### PR TITLE
Fix: double curly braces causes syntax error on Liquid template system

### DIFF
--- a/EIPS/eip-225.md
+++ b/EIPS/eip-225.md
@@ -211,7 +211,9 @@ tests := []struct {
   {
     // Single signer, no votes cast
     signers: []string{"A"},
-    blocks:  []block{{signer: "A"}},
+    blocks:  []block{
+      {signer: "A"}
+    },
     results: []string{"A"},
   }, {
     // Single signer, voting to add two others (only accept first, second needs 2 votes)


### PR DESCRIPTION
The code `{{signer: "A"}}` gets hidden on the website. Liquid template system interprets the double curly braces as a template expression.

This PR changes indentation to fix the display problem.

[Website](https://eips.ethereum.org/EIPS/eip-225): 
<img width="378" alt="eip-225-parse-error" src="https://user-images.githubusercontent.com/47108/67975148-f81b4800-fbe9-11e9-9814-30d1fbd0eb0b.png">


Raw code:
<img width="338" alt="eip-225-parse-error-2" src="https://user-images.githubusercontent.com/47108/67975149-f81b4800-fbe9-11e9-96c4-57e179df5428.png">
