### PR TITLE
Updates Petersburg block number for Rinkeby

### DIFF
--- a/EIPS/eip-1716.md
+++ b/EIPS/eip-1716.md
@@ -20,7 +20,7 @@ This meta-EIP specifies the changes included in the Ethereum hardfork that remov
   - `Block >= 7_280_000` on the Ethereum mainnet
   - `Block >= 4_939_394` on the Ropsten testnet
   - `Block >= 10_255_201` on the Kovan testnet
-  - `Block >= 9_999_999` on the Rinkeby testnet
+  - `Block >= 4_321_234` on the Rinkeby testnet
   - `Block >= 0` on the Görli testnet
 - Removed EIPs:
   - [EIP 1283](./eip-1283.md): Net gas metering for SSTORE without dirty maps


### PR DESCRIPTION
I see that the EIP is finalized for a while, but the block number for Rinkeby is plain wrong. Block 9,999,999 would be created in [two years from now](https://rinkeby.etherscan.io/block/countdown/9999999).

For historical reasons, we should fix it to the block number 4,321,234, set by [geth 1.8.24](https://github.com/ethereum/go-ethereum/releases/tag/v1.8.24).

@5chdn @MariusVanDerWijden @karalabe