### PR TITLE
Add newline for Jekyll to render correct HTML indentation

### DIFF
--- a/EIPS/eip-1191.md
+++ b/EIPS/eip-1191.md
@@ -26,6 +26,7 @@ Convert the address using the same algorithm defined by EIP-55 but if a register
 ## Rationale 
  Benefits:
  - By means of a minimal code change on existing libraries, users are protected from losing funds by mixing addresses of different Ethereum based networks.
+
 ## Backwards Compatibility
 This proposal is fully backward compatible. The checksum calculation is changed only for new networks that choose to adopt this EIP and add their chain numbers to the Adoption Table included in this document.
 
@@ -45,6 +46,7 @@ def eth_checksum_encode(addr, chainid=1):
     out = addr[:2] + ''.join([c.upper() if int(a,16) >= 8 else c for c,a in aggregate])
     return out
 ```
+
 ## Test Cases
 ```python
 eth_mainnet = [
@@ -99,6 +101,7 @@ for chainid, cases in test_cases.items():
         assert ( addr == eth_checksum_encode(addr,chainid) )
 ```
 ## Adoption
+
 ### Adoption  Table
 
 | Network      | Chain id | Supports this EIP |


### PR DESCRIPTION
Fixes indentation mistake [discovered](https://github.com/ethereum/EIPs/issues/1121#issuecomment-550080361) by @MicahZoltu 