### PR TITLE
EIP-634: Add peepeth and made it more DRY

### DIFF
--- a/EIPS/eip-634.md
+++ b/EIPS/eip-634.md
@@ -46,9 +46,11 @@ services must be prefixed with `vnd.`.
 - **description** - A description of the name
 - **notice** - A notice regarding this name; 
 - **keywords** - A list of comma-separated keywords, ordered by most significant first; clients that interpresent this field may choose a threshold beyond which to ignore
+
+- **vnd.github** - a GitHub username
 - **vnd.peepeth** - a peepeth username
 - **vnd.twitter** - a twitter username
-- **vnd.github** - a GitHub username
+
 
 Usernames SHOULD not be prefixed with the @ symbol.
 

--- a/EIPS/eip-634.md
+++ b/EIPS/eip-634.md
@@ -46,9 +46,11 @@ services must be prefixed with `vnd.`.
 - **description** - A description of the name
 - **notice** - A notice regarding this name; 
 - **keywords** - A list of comma-separated keywords, ordered by most significant first; clients that interpresent this field may choose a threshold beyond which to ignore
-- **vnd.twitter** - a twitter username (SHOULD not be prefixed with an @ symbol)
-- **vnd.github** - a GitHub username (SHOULD not be prefixed with an @ symbol)
+- **vnd.peepeth** - a peepeth username
+- **vnd.twitter** - a twitter username
+- **vnd.github** - a GitHub username
 
+Usernames SHOULD not be prefixed with the @ symbol.
 
 ## Rationale
 


### PR DESCRIPTION
If we have twitter mentioned here -so we should also mention peepeth which is more native to Ethereum

paging @ricmoo 

also wondering as the implementations section is empty yet if I should do a PR to add https://github.com/komputing/KEthereum/tree/master/ens / https://github.com/komputing/KEthereum/tree/master/erc634 
Or should this section just be about smart-contract implementations of this EIP?