### PR TITLE
Clarify that empty accounts also return 0 in EIP-1052

### DIFF
--- a/EIPS/eip-1052.md
+++ b/EIPS/eip-1052.md
@@ -7,6 +7,7 @@ status: Final
 type: Standards Track
 category: Core
 created: 2018-05-02
+requires: 161
 ---
 
 ## Abstract
@@ -24,7 +25,7 @@ takes one argument from the stack, zeros the first 96 bits
 and pushes to the stack the keccak256 hash of the code of the account 
 at the address being the remaining 160 bits. 
 
-In case the account does not exist `0` is pushed to the stack.
+In case the account does not exist or is empty (as defined by [EIP-161](https://eips.ethereum.org/EIPS/eip-161)) `0` is pushed to the stack.
 
 In case the account does not have code the keccak256 hash of empty data
 (i.e. `c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470`)


### PR DESCRIPTION
This previously proposed by https://github.com/ethereum/EIPs/pull/2144/files#r296935881, but that fork cannot be updated by maintainers.

It was approved by @Arachnid and @chfast.

Closes #2144.