### PR TITLE
Defer Last Call

### DIFF
--- a/EIPS/eip-2387.md
+++ b/EIPS/eip-2387.md
@@ -4,8 +4,7 @@ title: "Hardfork Meta: Muir Glacier"
 author: James Hancock (@madeoftin)
 discussions-to: https://ethereum-magicians.org/t/hard-fork-to-address-the-ice-age-eip-2387
 type: Meta
-status: Last Call
-review-period-end: 2019-12-12
+status: Draft
 created: 2019-11-22
 requires: 1679, 2384
 ---


### PR DESCRIPTION
This EIP depends on another EIP that is currently in Last Call status. This means to cannot reason about the effects of this EIP because we don't know what will happen in the underlying.

Therefore this EIP should be kicked back to Draft status without further consideration.