### PR TITLE
Update discussion-to in EIP-1193 and add References section

### DIFF
--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -2,7 +2,7 @@
 eip: 1193
 title: Ethereum Provider JavaScript API
 author: Fabian Vogelsteller (@frozeman), Ryan Ghods (@ryanio), Marc Garreau (@marcgarreau), Victor Maia (@MaiaVictor)
-discussions-to: https://ethereum-magicians.org/t/eip-1193-ethereum-provider-javascript-api/640
+discussions-to: https://github.com/ethereum/EIPs/issues/2319
 status: Draft
 type: Standards Track
 category: Interface
@@ -380,6 +380,11 @@ class EthereumProvider extends EventEmitter {
   }
 }
 ```
+
+## References
+
+* [Initial discussion in `ethereum/interfaces`](https://github.com/ethereum/interfaces/issues/16)
+* [Ethereum Magicians thread](https://ethereum-magicians.org/t/eip-1193-ethereum-provider-javascript-api/640)
 
 ## Copyright
 


### PR DESCRIPTION
This PR edits EIP-1193 in two ways:

* Updates it's `discussion-to` link
* Adds a References section with links to the previous discussion channels. 

Two Discord servers were used to discuss this EIP, but I didn't add their links in the Reference section as they are invitation links that may stop working in the future.