### PR TITLE
feat: Create EIP 2424

### DIFF
--- a/EIPS/eip-10.md
+++ b/EIPS/eip-10.md
@@ -1,0 +1,83 @@
+---
+eip: 10
+title: EIP Code of Conduct
+status: Draft
+type: Meta
+author: YazzyYaz <yaz.khoury@gmail.com>
+created: 2019-12-03
+---
+This Code of Conduct EIP has been taken directly from [Contributor Covenant Open Source Code of Conduct](https://www.contributor-covenant.org/)
+under the [CC-By-4.0 License](https://github.com/ContributorCovenant/contributor_covenant/blob/release/LICENSE.md)
+
+This Code of Conduct EIP applies to all members wishing to participate in the EIP process:
+
+1) EIP Editors
+2) Hardfork Coordinators
+3) EIP Authors
+4) Ethereum Community Members Participating in the EIP Process.
+
+## Our Pledge
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others’ private information, such as a physical or email address, or real names, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at [INSERT CONTACT METHOD]. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+1. Correction 
+
+Community Impact: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+Consequence: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+2. Warning 
+Community Impact: A violation through a single incident or series of actions.
+Consequence: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+3. Temporary Ban 
+Community Impact: A serious violation of community standards, including sustained inappropriate behavior.
+Consequence: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+4. Permanent Ban 
+Community Impact: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+Consequence: A permanent ban from any sort of public interaction within the project community.
+
+Attribution This Code of Conduct is adapted from the Contributor Covenant, version 2.0, available at https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by Mozilla’s code of conduct enforcement ladder.
+
+For answers to common questions about this code of conduct, see the FAQ at https://www.contributor-covenant.org/faq. Translations are available at https://www.contributor-covenant.org/translations.

--- a/EIPS/eip-2424.md
+++ b/EIPS/eip-2424.md
@@ -3,7 +3,7 @@ eip: 2424
 title: EIP Code of Conduct
 status: Draft
 type: Meta
-author: YazzyYaz <yaz.khoury@gmail.com>
+author: Yaz Khoury <yaz.khoury@gmail.com>
 created: 2019-12-03
 discussions-to: https://github.com/ethereum/EIPs/issues/2425 
 ---

--- a/EIPS/eip-2424.md
+++ b/EIPS/eip-2424.md
@@ -5,6 +5,7 @@ status: Draft
 type: Meta
 author: YazzyYaz <yaz.khoury@gmail.com>
 created: 2019-12-03
+discussions-to: https://github.com/ethereum/EIPs/issues/2425 
 ---
 This Code of Conduct EIP has been taken directly from [Contributor Covenant Open Source Code of Conduct](https://www.contributor-covenant.org/)
 under the [CC-By-4.0 License](https://github.com/ContributorCovenant/contributor_covenant/blob/release/LICENSE.md)

--- a/EIPS/eip-2424.md
+++ b/EIPS/eip-2424.md
@@ -1,5 +1,5 @@
 ---
-eip: 10
+eip: 2424 
 title: EIP Code of Conduct
 status: Draft
 type: Meta

--- a/EIPS/eip-2424.md
+++ b/EIPS/eip-2424.md
@@ -5,7 +5,7 @@ status: Draft
 type: Meta
 author: Yaz Khoury <yaz.khoury@gmail.com>
 created: 2019-12-03
-discussions-to: https://github.com/ethereum/EIPs/issues/2425 
+discussions-to: https://ethereum-magicians.org/t/eip-2424-eip-code-of-conduct/3824 
 ---
 This Code of Conduct EIP has been taken directly from [Contributor Covenant Open Source Code of Conduct](https://www.contributor-covenant.org/)
 under the [CC-By-4.0 License](https://github.com/ContributorCovenant/contributor_covenant/blob/release/LICENSE.md)


### PR DESCRIPTION
Proposing a new EIP for Code of Conduct in the EIP process to its participants.

This is due to me noticing actions of some individuals in the larger cryptocurrency ecosystem engaging in behavior that would necessitate the existence of such a document.

The Code of Conduct follows Contributor Covenant: https://www.contributor-covenant.org/

which exists in several open-source communities. 

Currently, this Draft EIP will need a new commit to add an appropriate email so victims of harassment within the EIP process have a contact email to send complaints about any fellow member of the EIP process that are violating the Code of Conduct.

Happy to hear any feedback from the EIP community.

It doesn't fully follow the EIP guideline because it is referencing an external document which is licensed under CC-By-4.0 License.
