### PR TITLE
Add ERC-2212 markdown

### DIFF
--- a/EIPS/eip-2212.md
+++ b/EIPS/eip-2212.md
@@ -1,7 +1,7 @@
 ---
 eip: 2212
 title: ERC-2212 Interest Earning Stakes
-author: Paul Razvan Berg (@PaulRBerg) <paul@sablier.finance>
+author: Paul Razvan Berg (@PaulRBerg)
 discussions-to: https://github.com/ethereum/EIPs/issues/2212
 status: Draft
 type: Standards Track

--- a/EIPS/eip-2212.md
+++ b/EIPS/eip-2212.md
@@ -1,0 +1,267 @@
+---
+eip: 2212
+title: ERC-2212 Interest Earning Stakes
+author: Paul Razvan Berg (@PaulRBerg) <paul@sablier.finance>
+discussions-to: https://github.com/ethereum/EIPs/issues/2212
+status: Draft
+type: Standards Track
+category: ERC
+created: 2019-07-26
+requires: 20
+---
+
+## Simple Summary
+
+We propose a new way to monetise decentralised apps that involves users staking tokens in exchange for a product or a service and creators earning interest on the pooled stakes through a continuous lending protocol such as [Compound](https://compound.finance).
+
+## Abstract
+
+The advent of decentralised lending brought to the web3 ecosystem a new primitive for designing business models. We herein describe a smart contract interface that accepts deposits ("stakes") in ERC20 tokens. These deposits are immediately lent on the market to earn interest either for just the owner of the contract, or for both them and the user. We assume that users get access to a product or a service for as long as they keep staking tokens.
+
+## Motivation
+
+While most web3 business models rely on paying a percentage fee on transfers, or committing to a monthly subscription, we aim to flip the model on its head. Users are their own banks now, so, instead of charging them, we make them stake tokens that can be claimed back, in full, at any point in time. We view this as a win-win-win scenario for users, dapp creators and lending protocols.
+
+It is worth it to mention PoolTogether, a "no-loss lottery" that launched recently. It works by having participants deposit money in their contracts, locking it up for a while and earning interest through Compound. Ultimately, they choose a lucky winner and return the deposits back to all other players. PoolTogether takes a 10% commission on the prize.
+
+We wrote this specification because interest earning stakes are a powerful financial instrument and a community-vetted standard and implementation will reduce the cost of replication.
+
+### Use Cases
+
+- Software products and services
+- Charity pools
+- Games
+- Gym memberships
+
+## Specification
+
+Assigning an owner is mandatory for this spec to make sense, thus we assume that a proper implementation would use a well-known contract such as OpenZeppelin's [Ownable](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/ownership/Ownable.sol). For brevity, we haven't included any method for assigning or transferring ownership.
+
+### Methods
+
+#### owner
+
+Returns the owner of the contract.
+
+```solidity
+function owner() external view returns (address);
+```
+
+#### fee
+
+Returns the fee as a percentage value scaled by 1e18.
+
+```solidity
+function fee() external view returns (uint256);
+```
+
+#### balanceOf
+
+Returns the stake that consists of the initial deposit plus the interest accrued over time.
+
+SHOULD revert if `staker` doesn't have an active stake. SHOULD revert if `tokenAddress` doesn't match either the cToken or the underlying of the stake.
+
+```solidity
+function balanceOf(address staker, address tokenAddress) external view returns (uint256);
+```
+
+#### depositOf
+
+Returns the initial deposit.
+
+SHOULD revert if `staker` doesn't have an active stake. SHOULD revert if `tokenAddress` doesn't match either the cToken or the underlying of the stake.
+
+```solidity
+function depositOf(address staker, address tokenAddress) external view returns (uint256);
+```
+
+#### whitelistCToken
+
+Whitelists a cToken to automatically convert its underlying when deposited.
+
+MUST revert if `msg.sender` is not the owner.
+
+**Triggers Event**: [WhitelistCToken](#whitelistctoken)
+
+```solidity
+function whitelistCToken(address cTokenAddress, address underlyingAddress) external;
+```
+
+#### discardCToken
+
+Discards a cToken that has been whitelisted before.
+
+MUST revert if `msg.sender` is not the owner.
+
+**Triggers Event**: [DiscardCToken](#discardctoken)
+
+```solidity
+function discardCToken(address cTokenAddress) external
+```
+
+#### resetAllowance
+
+Resets the allowance granted to the cToken contract to spend from the underlying contract to the maximum value possible in the EVM.
+
+```solidity
+function resetAllowance(address cTokenAddress, address underlyingAddress);
+```
+
+#### stake
+
+Creates a new stake object for `msg.sender`. Automatically converts an underlying to its cToken form so that the contract can earn interest.
+
+MUST revert if `msg.sender` already has an active stake. MUST revert if the cToken/ underlying pair has not been whitelisted.
+
+**Triggers Event**: [Stake](#stake)
+
+```solidity
+function stake(address tokenAddress, uint256 amount) external;
+```
+
+#### redeem
+
+Returns the deposit plus any accrued interest to the staker and levies the fee for the `owner`.
+
+MUST revert if `msg.sender` is not the staker or the owner.
+
+**Triggers Event**: [Redeem](#redeem)
+
+```solidity
+function redeem(address staker) external;
+```
+
+#### takeEarnings
+
+Withdraws the earnings accrued over time.
+
+MUST revert if `msg.sender` is not the owner.
+
+**Triggers Event**: [TakeEarnings](#takeearnings)
+
+```solidity
+function takeEarnings(address tokenAddress, uint256 amount) external;
+```
+
+#### updateFee
+
+Updates the fee practised by the contract. Has to be a percentage value scaled by 1e18. Can be anything between 0% and 100%.
+
+MUST revert if `msg.sender` is not the owner.
+
+**Triggers Event**: [UpdateFee](#updatefee)
+
+```solidity
+function updateFee(uint256 newFee) external;
+```
+
+---
+
+### Events
+
+#### WhitelistCToken
+
+MUST be triggered when `whitelistCToken` is successfully called.
+
+```solidity
+event WhitelistCToken(address indexed cTokenAddress, address underlyingAddress);
+```
+
+#### DiscardCToken
+
+MUST be triggered when `discardCToken` is successfully called.
+
+```solidity
+event DiscardCToken(address indexed cTokenAddress);
+```
+
+#### Stake
+
+MUST be triggered when `stake` is successfully called.
+
+```solidity
+event Stake(address indexed staker, address indexed cTokenAddress, address indexed underlyingAddress, bool converted, uint256 cTokenDeposit, uint256 exchangeRate);
+```
+
+#### Redeem
+
+MUST be triggered when `redeem` is successfully called.
+
+```solidity
+event Redeem(address indexed staker, address indexed cTokenAddress, address indexed underlyingAddress, uint256 cTokenFee, uint256 cTokenWithdrawal, uint256 exchangeRate);
+```
+
+#### TakeEarnings
+
+MUST be triggered when `takeEarnings` is successfully called.
+
+```solidity
+event TakeEarnings(address indexed tokenAddress, uint256 indexed amount);
+```
+
+#### UpdateFee
+
+MUST be triggered when `updateFee` is successfully called.
+
+```solidity
+event UpdateFee(uint256 indexed fee);
+```
+
+## Rationale
+
+We designed these interest earning stakes with simplicity in mind, but we acknowledge that there are some missing features and obvious concerns which we discuss below.
+
+---
+
+### Missing Features
+
+#### Update
+
+By and large, this is the most prominent missing feature. Dapp creators might want to update their staking requirements and the only way to achieve that would be to ask users to redeem their previous stake and put in the new amount.
+
+We assume that most apps don't need this and the spec as it is now is sufficient for running the very first experiments. Yet, time will tell best. We are looking forward to making updates if need be.
+
+#### Parallel Staking
+
+Large enterprises have multiple sources of revenue, hence switching to a business model based on staking would require a smart contract that accepts multiple stakes per user.
+
+However, the goal is to avoid writing an over-optimised standard. Parallel staking would require dapp creators to keep track of multiple stake ids, instead of only the user's account. Also, the user's interface would become more complex, as they would have to be aware of multiple stakes.
+
+#### Beyond Compound
+
+Some functions in the interface are highly specific to Compound, but the rationale behind that is simple. Compound is by far the best suited protocol for interest earning stakes. It is ultra-short term, which makes for frictionless business. We may update the interface when other continuous lending schemes, such as the Dai Savings Rate, will scale significantly.
+
+---
+
+### Concerns
+
+#### Loan Defaults
+
+Lending never comes without risks, so interest earning stakes are not a good fit for the ultra-sensitive business applications. That said, dapp creators have an incentive to monitor the market for borrowers that go under the collateral requirements and liquidate them. By doing so, they secure the network for their own users and also earn a fee in the process.
+
+#### Fluctuating Rates
+
+The market rates for lending stablecoins hovered around 10% in early 2019, but this is not a given. Dapp creators can accommodate this issue by asking for a stake that generates interest reasonably above what they deem as an acceptable revenue stream.
+
+#### Rent-Seeking
+
+Interest earning stakes work best for products or services that are priced on time instead of quantity (imagine subscription-based SaaS). If a dapp is quota-based, its creators would be better off charging a fee on every transfer.
+
+## Implementation
+
+[Head to the Sablier organisation on GitHub](https://github.com/sablierhq/erc2212) for a WIP implementation.
+
+## Additional References
+
+- [Thread on cTokens](https://twitter.com/PaulRBerg/status/1147980107740524544)
+- [Compound Protocol](https://github.com/compound-finance/compound-protocol)
+- [PoolTogether](https://pooltogether.us)
+- [Pooled cDAI](https://github.com/ZeframLou/pooled-cdai)
+- [Lending Proxy by Luciano Bertenasco](https://github.com/lbertenasco/lending-proxy)
+- [Web3 Revenue Primitives](https://github.com/FEMBusinessModelsRing/web3_revenue_primitives)
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+
+@PaulRBerg and @SablierHQ.

--- a/EIPS/eip-2212.md
+++ b/EIPS/eip-2212.md
@@ -16,7 +16,7 @@ We propose a new way to monetise decentralised apps that involves users staking 
 
 ## Abstract
 
-The advent of decentralised lending brought to the web3 ecosystem a new primitive for designing business models. We herein describe a smart contract interface that accepts deposits ("stakes") in ERC20 tokens. These deposits are immediately lent on the market to earn interest either for just the owner of the contract, or for both them and the user. We assume that users get access to a product or a service for as long as they keep staking tokens.
+The advent of decentralised lending brought to the web3 ecosystem a new primitive for designing business models. We herein describe a smart contract interface that accepts deposits ("stakes") in [ERC-20](https://eips.ethereum.org/EIPS/eip-20) tokens. These deposits are immediately lent on the market to earn interest either for just the owner of the contract, or for both them and the user. We assume that users get access to a product or a service for as long as they keep staking tokens.
 
 ## Motivation
 
@@ -35,7 +35,13 @@ We wrote this specification because interest earning stakes are a powerful finan
 
 ## Specification
 
-Assigning an owner is mandatory for this spec to make sense, thus we assume that a proper implementation would use a well-known contract such as OpenZeppelin's [Ownable](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/ownership/Ownable.sol). For brevity, we haven't included any method for assigning or transferring ownership.
+Assigning an owner is required for this spec to make sense, thus we assume that a proper implementation would use a
+well-known contract such as OpenZeppelin's
+[Ownable](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/ownership/Ownable.sol). For
+brevity, we haven't included any method for assigning or transferring ownership.
+
+Every time we refer to cTokens, we mean Compound Tokens, as defined in the official
+[documentation](https://compound.finance/ctokens). These are ERC-20 tokens with an interest accrual feature built in.
 
 ### Methods
 
@@ -209,9 +215,7 @@ event UpdateFee(uint256 indexed fee);
 
 ## Rationale
 
-We designed these interest earning stakes with simplicity in mind, but we acknowledge that there are some missing features and obvious concerns which we discuss below.
-
----
+We designed these interest earning stakes with simplicity in mind, but we acknowledge there are missing features and obvious concerns, which we discuss below.
 
 ### Missing Features
 

--- a/EIPS/eip-2212.md
+++ b/EIPS/eip-2212.md
@@ -41,7 +41,7 @@ well-known contract such as OpenZeppelin's
 brevity, we haven't included any method for assigning or transferring ownership.
 
 Every time we refer to cTokens, we mean Compound Tokens, as defined in the official
-[documentation](https://compound.finance/ctokens). These are ERC-20 tokens with an interest accrual feature built in.
+[documentation](https://compound.finance/ctokens). These are [ERC-20](https://eips.ethereum.org/EIPS/eip-20) tokens with an interest accrual feature built in.
 
 ### Methods
 
@@ -102,7 +102,7 @@ MUST revert if `msg.sender` is not the owner.
 **Triggers Event**: [DiscardCToken](#discardctoken)
 
 ```solidity
-function discardCToken(address cTokenAddress) external
+function discardCToken(address cTokenAddress) external;
 ```
 
 #### resetAllowance


### PR DESCRIPTION
As per @axic's comment in https://github.com/ethereum/EIPs/issues/2212, I add the markdown version of ERC-2212 so it can be viewed on [eips.ethereum.org](https://eips.ethereum.org).