### PR TITLE
Update EIP-2384 to Final Status

### DIFF
--- a/EIPS/eip-2384.md
+++ b/EIPS/eip-2384.md
@@ -5,7 +5,7 @@ author: Eric Conner (@econoar)
 discussions-to: https://ethereum-magicians.org/t/eip-2384-difficulty-bomb-delay
 type: Standards Track
 category: Core
-status: Last Call
+status: Final
 review-period-end: 2019-12-12
 created: 2019-11-20
 ---


### PR DESCRIPTION
Move #2384 to Final from Last Call as three core clients have already implemented. Note: this would skip accepted but that is as a matter of formality due to the oversight in progressing the EIP prior to client teams implementing.