### PR TITLE
Updates to 1193

### DIFF
--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -1,7 +1,7 @@
 ---
 eip: 1193
 title: Ethereum Provider JavaScript API
-author: Fabian Vogelsteller (@frozeman), Ryan Ghods (@ryanio), Marc Garreau (@marcgarreau), Victor Maia (@MaiaVictor)
+author: Fabian Vogelsteller (@frozeman), Ryan Ghods (@ryanio), Victor Maia (@MaiaVictor), Marc Garreau (@marcgarreau)
 discussions-to: https://github.com/ethereum/EIPs/issues/2319
 status: Draft
 type: Standards Track
@@ -12,13 +12,13 @@ requires: 155, 695, 1102, 1474
 
 ## Summary
 
-This EIP formalizes an Ethereum Provider JavaScript API for consistency across clients and applications. The provider is designed to be minimal and is intended to be available on `window.ethereum` for cross environment compatibility.
+This EIP formalizes an Ethereum Provider JavaScript API for consistency across clients and applications. The provider is designed to be minimal and intended to be available on `window.ethereum` for cross environment compatibility. The events are provided as a convenience to enable reactive dapp UIs.
 
 ## API
 
 ### Send
 
-Ethereum API methods can be sent and received:
+Ethereum JSON-RPC API methods can be sent and received:
 
 ```js
 ethereum.send(method: String, params?: Array<any>): Promise<any>;
@@ -26,7 +26,7 @@ ethereum.send(method: String, params?: Array<any>): Promise<any>;
 
 Promise resolves with `result` or rejects with `Error`.
 
-See the [available methods](https://github.com/ethereum/wiki/wiki/JSON-RPC#json-rpc-methods).
+See [available JSON-RPC methods](https://github.com/ethereumproject/go-ethereum/wiki/JSON-RPC#json-rpc-methods).
 
 ### Events
 
@@ -40,7 +40,7 @@ All subscriptions from the node emit on notification. Attach listeners with:
 ethereum.on('notification', listener: (result: any) => void): this;
 ```
 
-To create a subscription, call `ethereum.send('eth_subscribe', [])` or `ethereum.send('shh_subscribe', [])`. 
+To create a subscription, call `ethereum.send('eth_subscribe', [])` or `ethereum.send('shh_subscribe', [])`.
 
 See the [eth subscription methods](https://github.com/ethereum/go-ethereum/wiki/RPC-PUB-SUB#supported-subscriptions) and [shh subscription methods](https://github.com/ethereum/go-ethereum/wiki/Whisper-v6-RPC-API#shh_subscribe).
 
@@ -52,11 +52,11 @@ The provider emits `connect` on connect to a network.
 ethereum.on('connect', listener: () => void): this;
 ```
 
-You can detect which network by sending `net_version`:
+You can detect which chain by sending `eth_chainId`:
 
 ```js
-const network = await ethereum.send('net_version');
-> '1'
+const chainId = await ethereum.send('eth_chainId');
+> 1
 ```
 
 #### close
@@ -74,20 +74,12 @@ The event emits with `code` and `reason`. The code follows the table of [`CloseE
 The provider emits `chainChanged` on connect to a new chain.
 
 ```js
-ethereum.on('chainChanged', listener: (chainId: String) => void): this;
+ethereum.on('chainChanged', listener: (chainId: Integer) => void): this;
 ```
 
-The event emits with `chainId`, the new chain returned from `eth_chainId`.
+The event emits with integer `chainId`, the new chain returned from `eth_chainId`.
 
-#### networkChanged
-
-The provider emits `networkChanged` on connect to a new network.
-
-```js
-ethereum.on('networkChanged', listener: (networkId: String) => void): this;
-```
-
-The event emits with `networkId`, the new network returned from `net_version`.
+The event `networkChanged` is deprecated in favor of `chainChanged`. For more info, see [EIP 155: Simple replay attack protection](https://eips.ethereum.org/EIPS/eip-155) and [EIP 695: Create eth_chainId method for JSON-RPC](https://eips.ethereum.org/EIPS/eip-695).
 
 #### accountsChanged
 
@@ -208,19 +200,11 @@ If the network connection closes, the Ethereum Provider **MUST** emit an event n
 
 #### chainChanged
 
-If the chain the provider is connected to changes, the provider **MUST** emit an event named `chainChanged` with args `chainId: String` containing the ID of the new chain (using the Ethereum JSON-RPC call `eth_chainId`).
-
-#### networkChanged
-
-If the network the provider is connected to changes, the provider **MUST** emit an event named `networkChanged` with args `networkId: String` containing the ID of the new network (using the Ethereum JSON-RPC call `net_version`).
+If the chain the provider is connected to changes, the provider **MUST** emit an event named `chainChanged` with args `chainId: Integer` containing the ID of the new chain (using the Ethereum JSON-RPC call `eth_chainId`).
 
 #### accountsChanged
 
 If the accounts connected to the Ethereum Provider change at any time, the Ethereum Provider **MUST** send an event with the name `accountsChanged` with args `accounts: Array<String>` containing the accounts' addresses.
-
-### web3.js Backwards Compatibility
-
-If the implementing Ethereum Provider would like to be compatible with `web3.js` prior to `1.0.0-beta38`, it **MUST** provide the method: `sendAsync(payload: Object, callback: (error: any, result: any) => void): void`.
 
 ### Error object and codes
 
@@ -243,14 +227,14 @@ class EthereumProvider extends EventEmitter {
     super();
 
     // Init storage
-    this._nextJsonrpcId = 0;
+    this._nextJsonRpcId = 0;
     this._promises = {};
 
     // Fire the connect
     this._connect();
 
     // Listen for jsonrpc responses
-    window.addEventListener('message', this._handleJsonrpcMessage.bind(this));
+    window.addEventListener('message', this._handleJsonRpcMessage.bind(this));
   }
 
   /* Methods */
@@ -264,7 +248,7 @@ class EthereumProvider extends EventEmitter {
       return new Error('Params is not a valid array.');
     }
 
-    const id = this._nextJsonrpcId++;
+    const id = this._nextJsonRpcId++;
     const jsonrpc = '2.0';
     const payload = { jsonrpc, id, method, params };
 
@@ -283,7 +267,7 @@ class EthereumProvider extends EventEmitter {
 
   /* Internal methods */
 
-  _handleJsonrpcMessage(event) {
+  _handleJsonRpcMessage(event) {
     // Return if no data to parse
     if (!event || !event.data) {
       return;
@@ -353,15 +337,17 @@ class EthereumProvider extends EventEmitter {
     this.emit('close', code, reason);
   }
 
-  _emitNetworkChanged(networkId) {
-    this.emit('networkChanged', networkId);
+  _emitChainChanged(chainId) {
+    this.emit('chainChanged', networkId);
   }
 
   _emitAccountsChanged(accounts) {
     this.emit('accountsChanged', accounts);
   }
 
-  /* web3.js Provider Backwards Compatibility */
+  /*
+     Provide `sendAsync` to be compatible as an older web3.js provider.
+  */
 
   sendAsync(payload, callback) {
     return this.send(payload.method, payload.params)


### PR DESCRIPTION
Updates to EIP 1193:
* Improve opening summary.
* Promote use of eth_chainId and note networkChanged as deprecated.
* Clarify web3.js provider backwards compatibility.