### PR TITLE
EIP-2458: Updates, updated-by header

### DIFF
--- a/EIPS/eip-2457.md
+++ b/EIPS/eip-2457.md
@@ -6,7 +6,7 @@ discussions-to: https://github.com/ethereum/EIPs/issues/2453
 status: Draft
 type: Meta
 created: 2020-01-06
-updates: EIP1
+updates: 1
 ---
 
 ## Simple Summary
@@ -24,7 +24,7 @@ EIP headers `updates` and `updated-by` are used for updating `active` EIPs. This
 
 Currently, EIP1 specifies EIP headers: `updated`, `replaces`, and `superseded-by`. Headers `replaces` and `superseded-by` indicates when an entire EIP is being replaced by another EIP, indicating when an EIP is now historical, and is updated by a new standard. 
 
-The header  `updated` indicates the date an EIP has received an update by EIP authors and editors, an example EIP being EIP1. `updated` is reserved for EIPs in `draft` or `active` status. 
+The header `updated` indicates the date an EIP has received an update by EIP authors and editors, an example EIP being EIP1. `updated` is reserved for EIPs in `draft` or `active` status. 
 
 In the case of `active` status, an EIP may receive an update, but these updates don't operate as with EIPs in `final` status, where a historical EIP is created, and the new EIP is referenced by the historical one. While these updates are not kept immutably, updates to active EIPs can be done modularly by creating a new EIP that goes through the standard discussion and auditing process EIPs undergo. The EIP headers `updates` and `updated-by` are to facilitate this modularity. Creating a new EIP also provides sufficient notification to affected stakeholders of an active EIP before that EIP is `updated`. 
 
@@ -33,7 +33,7 @@ In the case of `active` status, an EIP may receive an update, but these updates 
 
 ### `updated-by` 
 
-`updated-by` is reserved for EIPs in `active` status.  For an EIP in status `active`, updates to that EIP, which update the header `updated`, should be started by opening a new EIP to start a vetting for that update. When an `active` EIP recieves a new entry to header `updated`, an associated `updated-by` EIP listing should be included, where that newly listed EIP has reached `final` status.
+`updated-by` is reserved for EIPs in `active` status. For an EIP in status `active`, updates to that EIP, which update the header `updated`, should be started by opening a new EIP to start vetting for that update. When an `active` EIP receives a new entry to header `updated`, an associated `updated-by` EIP listing should be included, where that newly listed EIP has reached `final` status.
 
 `updates` should be included as an EIP header, as all EIP headers, and include a reference to an EIP designation. When multiple EIP designations are referenced, each should be separated by a comma. Example:
 
@@ -58,14 +58,14 @@ updates: EIP1
 ## Rationale
 <!--The rationale fleshes out the specification by describing what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work, e.g. how the feature is supported in other languages. The rationale may also provide evidence of consensus within the community, and should discuss important objections or concerns raised during discussion.-->
 
-`updates` and `updated-by` apply only to EIPs in `active` status as updates to EIPs in `final` status are already handled by EIP headers `superceded-by` and `replaces`.
+`updates` and `updated-by` apply only to EIPs in `active` status as updates to EIPs in `final` status are already handled by EIP headers `superseded-by` and `replaces`.
 
-Syntax should align with previous EIP header syntax, as this EIP is not updating syntax, simply adding header options.
+The syntax should align with previous EIP header syntax, as this EIP is not updating syntax, simply adding header options.
 
 ## Backwards Compatibility
-<!--All EIPs that introduce backwards incompatibilities must include a section describing these incompatibilities and their severity. The EIP must explain how the author proposes to deal with these incompatibilities. EIP submissions without a sufficient backwards compatibility treatise may be rejected outright.-->
+<!--All EIPs that introduce backward incompatibilities must include a section describing these incompatibilities and their severity. The EIP must explain how the author proposes to deal with these incompatibilities. EIP submissions without a sufficient backward compatibility treatise may be rejected outright.-->
 
-These EIP headers are optional, and do not introduce compatibility issues.
+These EIP headers are optional and do not introduce compatibility issues.
 
 
 ## Implementation
@@ -74,9 +74,9 @@ These EIP headers are optional, and do not introduce compatibility issues.
 This EIP is an example implementation of `updates`, updating EIP1. 
 
 ## Security Considerations
-<!--All EIPs must contain a section that discusses the security implications/considerations relevant to the proposed change. Include information that might be important for security discussions, surfaces risks and can be used throughout the life cycle of the proposal. E.g. include security-relevant design decisions, concerns, important discussions, implementation-specific guidance and pitfalls, an outline of threats and risks and how they are being addressed. EIP submissions missing the "Security Considerations" section will be rejected. An EIP cannot proceed to status "Final" without a Security Considerations discussion deemed sufficient by the reviewers.-->
+<!--All EIPs must contain a section that discusses the security implications/considerations relevant to the proposed change. Include information that might be important for security discussions, surface risks and can be used throughout the life cycle of the proposal. E.g. include security-relevant design decisions, concerns, important discussions, implementation-specific guidance and pitfalls, an outline of threats and risks and how they are being addressed. EIP submissions missing the "Security Considerations" section will be rejected. An EIP cannot proceed to status "Final" without a Security Considerations discussion deemed sufficient by the reviewers.-->
 
-This standard is informational, and does not introduce technical security issues.
+This standard is informational and does not introduce technical security issues.
 
 ## Copyright
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/EIPS/eip-2457.md
+++ b/EIPS/eip-2457.md
@@ -1,0 +1,84 @@
+---
+eip: 2457
+title: Add updates and updated-by EIP Header Options for active EIPs
+author: Edson Ayllon (@edsonayllon) 
+discussions-to: https://github.com/ethereum/EIPs/issues/2453
+status: Draft
+type: Meta
+created: 2020-01-06
+updates: EIP1
+---
+
+## Simple Summary
+<!--"If you can't explain it simply, you don't understand it well enough." Provide a simplified and layman-accessible explanation of the EIP.-->
+
+Adds EIP header options `updates` and `updated-by` to frontmatter of `active` EIPs for use as needed.
+
+## Abstract
+<!--A short (~200 word) description of the technical issue being addressed.-->
+
+EIP headers `updates` and `updated-by` are used for updating `active` EIPs. This is to make the improvement process of EIPs more modular, and have updates to existing `active` EIPs receive similar exposures to EIPs which replace existing `final` EIPs. 
+
+## Motivation
+<!--The motivation is critical for EIPs that want to change the Ethereum protocol. It should clearly explain why the existing protocol specification is inadequate to address the problem that the EIP solves. EIP submissions without sufficient motivation may be rejected outright.-->
+
+Currently, EIP1 specifies EIP headers: `updated`, `replaces`, and `superseded-by`. Headers `replaces` and `superseded-by` indicates when an entire EIP is being replaced by another EIP, indicating when an EIP is now historical, and is updated by a new standard. 
+
+The header  `updated` indicates the date an EIP has received an update by EIP authors and editors, an example EIP being EIP1. `updated` is reserved for EIPs in `draft` or `active` status. 
+
+In the case of `active` status, an EIP may receive an update, but these updates don't operate as with EIPs in `final` status, where a historical EIP is created, and the new EIP is referenced by the historical one. While these updates are not kept immutably, updates to active EIPs can be done modularly by creating a new EIP that goes through the standard discussion and auditing process EIPs undergo. The EIP headers `updates` and `updated-by` are to facilitate this modularity. Creating a new EIP also provides sufficient notification to affected stakeholders of an active EIP before that EIP is `updated`. 
+
+## Specification
+<!--The technical specification should describe the syntax and semantics of any new feature. The specification should be detailed enough to allow competing, interoperable implementations for any of the current Ethereum platforms (go-ethereum, parity, cpp-ethereum, ethereumj, ethereumjs, and [others](https://github.com/ethereum/wiki/wiki/Clients)).-->
+
+### `updated-by` 
+
+`updated-by` is reserved for EIPs in `active` status.  For an EIP in status `active`, updates to that EIP, which update the header `updated`, should be started by opening a new EIP to start a vetting for that update. When an `active` EIP recieves a new entry to header `updated`, an associated `updated-by` EIP listing should be included, where that newly listed EIP has reached `final` status.
+
+`updates` should be included as an EIP header, as all EIP headers, and include a reference to an EIP designation. When multiple EIP designations are referenced, each should be separated by a comma. Example:
+
+```
+---
+updated-by: EIP9999, EIP9998
+---
+```
+
+### `updates` 
+
+`updates` is reserved for EIPs updating EIPs in `active` status. An EIP listed as `updates` is implied to also be `requires`; only `updates` is needed for those EIP listings. Having an EIP listing `updates` does not necessarily mean that referenced EIP must reference back with an `updated-by` listing.
+
+`updates` should be included as an EIP header, as all EIP headers, and include a reference to an EIP designation. When multiple EIP designations are referenced, each should be separated by a comma. Example:
+
+```
+---
+updates: EIP1
+---
+```
+
+## Rationale
+<!--The rationale fleshes out the specification by describing what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work, e.g. how the feature is supported in other languages. The rationale may also provide evidence of consensus within the community, and should discuss important objections or concerns raised during discussion.-->
+
+`updates` and `updated-by` apply only to EIPs in `active` status as updates to EIPs in `final` status are already handled by EIP headers `superceded-by` and `replaces`.
+
+Syntax should align with previous EIP header syntax, as this EIP is not updating syntax, simply adding header options.
+
+## Backwards Compatibility
+<!--All EIPs that introduce backwards incompatibilities must include a section describing these incompatibilities and their severity. The EIP must explain how the author proposes to deal with these incompatibilities. EIP submissions without a sufficient backwards compatibility treatise may be rejected outright.-->
+
+These EIP headers are optional, and do not introduce compatibility issues.
+
+
+## Implementation
+<!--The implementations must be completed before any EIP is given status "Final", but it need not be completed before the EIP is accepted. While there is merit to the approach of reaching consensus on the specification and rationale before writing code, the principle of "rough consensus and running code" is still useful when it comes to resolving many discussions of API details.-->
+
+This EIP is an example implementation of `updates`, updating EIP1. 
+
+## Security Considerations
+<!--All EIPs must contain a section that discusses the security implications/considerations relevant to the proposed change. Include information that might be important for security discussions, surfaces risks and can be used throughout the life cycle of the proposal. E.g. include security-relevant design decisions, concerns, important discussions, implementation-specific guidance and pitfalls, an outline of threats and risks and how they are being addressed. EIP submissions missing the "Security Considerations" section will be rejected. An EIP cannot proceed to status "Final" without a Security Considerations discussion deemed sufficient by the reviewers.-->
+
+This standard is informational, and does not introduce technical security issues.
+
+## Copyright
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+
+

--- a/EIPS/eip-2458.md
+++ b/EIPS/eip-2458.md
@@ -1,6 +1,6 @@
 ---
 eip: 2458
-title: Add updates and updated-by EIP Header Options for active EIPs
+title: Updates and Updated-by Header
 author: Edson Ayllon (@edsonayllon) 
 discussions-to: https://github.com/ethereum/EIPs/issues/2453
 status: Draft

--- a/EIPS/eip-2458.md
+++ b/EIPS/eip-2458.md
@@ -1,5 +1,5 @@
 ---
-eip: 2457
+eip: 2458
 title: Add updates and updated-by EIP Header Options for active EIPs
 author: Edson Ayllon (@edsonayllon) 
 discussions-to: https://github.com/ethereum/EIPs/issues/2453

--- a/EIPS/eip-2458.md
+++ b/EIPS/eip-2458.md
@@ -4,7 +4,7 @@ title: Add updates and updated-by EIP Header Options for active EIPs
 author: Edson Ayllon (@edsonayllon) 
 discussions-to: https://github.com/ethereum/EIPs/issues/2453
 status: Draft
-type: Meta
+type: Informational
 created: 2020-01-06
 updates: 1
 ---

--- a/EIPS/eip-2458.md
+++ b/EIPS/eip-2458.md
@@ -6,7 +6,6 @@ discussions-to: https://github.com/ethereum/EIPs/issues/2453
 status: Draft
 type: Informational
 created: 2020-01-06
-updates: 1
 ---
 
 ## Simple Summary
@@ -71,7 +70,7 @@ These EIP headers are optional and do not introduce compatibility issues.
 ## Implementation
 <!--The implementations must be completed before any EIP is given status "Final", but it need not be completed before the EIP is accepted. While there is merit to the approach of reaching consensus on the specification and rationale before writing code, the principle of "rough consensus and running code" is still useful when it comes to resolving many discussions of API details.-->
 
-This EIP is an example implementation of `updates`, updating EIP1. 
+An implementation is adding a header option. 
 
 ## Security Considerations
 <!--All EIPs must contain a section that discusses the security implications/considerations relevant to the proposed change. Include information that might be important for security discussions, surface risks and can be used throughout the life cycle of the proposal. E.g. include security-relevant design decisions, concerns, important discussions, implementation-specific guidance and pitfalls, an outline of threats and risks and how they are being addressed. EIP submissions missing the "Security Considerations" section will be rejected. An EIP cannot proceed to status "Final" without a Security Considerations discussion deemed sufficient by the reviewers.-->


### PR DESCRIPTION
## EIP

EIP-2458: Add updates and updated-by EIP Header Options for active EIPs
Type: Informational
Status: Draft

## Scope

Adds EIP header options for EIPs that are, or relate to, active EIPs. Proposes change to EIP update process for EIPs in `active` status. 

## Discussions To

#2453, https://ethereum-magicians.org/t/eip-2458-add-updates-and-updated-by-eip-header-options-for-active-eips/4113