### PR TITLE
Set ERC-1620 to "Last Call"

### DIFF
--- a/EIPS/eip-1620.md
+++ b/EIPS/eip-1620.md
@@ -1,90 +1,76 @@
 ---
 eip: 1620
 title: ERC-1620 Money Streaming
-author: Paul Berg (@PaulRBerg)
+author: Paul Razvan Berg (@PaulRBerg)
 discussions-to: https://github.com/ethereum/EIPs/issues/1620
-status: Draft
+status: Last Call
 type: Standards Track
 category: ERC
 created: 2018-11-24
+requires: 20
+review-period-end: 2020-09-22
 ---
 
 ## Simple Summary
-Money streaming represents the idea of continuous payments over a finite period of time. Block numbers are used as a proxy of time to continuously update balances.
+
+We define money streaming as continuous payments over a finite period of time. Block timestamps are used as an on-chain proxy for time.
 
 ## Abstract
-The following describes a standard whereby time is measured using block numbers and streams are mappings in a master contract.
 
-1. A provider sets up a money streaming contract.
-2. A prospective payer can interact with the contract and start the stream right away by depositing the funds required for the chosen period.
-3. The payee is able to withdraw money from the contract based on its ongoing solvency. That is: `payment rate * (current block height - starting block height)`
-4. The stream terms (payment rate, length, metadata) can be updated at any time if both parties pledge their signatures.
-5. The stream can be stopped at any point in time by any party without on-chain consensus.
-6. If the stream period ended and it was not previously stopped by any party, the payee is entitled to withdraw all the deposited funds.
+The following describes a standard whereby time is measured using block timestamps and streams are mappings in a master contract.
+
+1. Developer sets up a money streaming contract.
+2. A payer, henceforth referred to as sender, can create a stream by depositing funds in the contract and choosing a streaming duration.
+3. A payee, henceforth referred to as recipient, can withdraw money from the stream based on its continuous solvency. That is, `payment * (current block timestamp - starting block timestamp)`.
+4. The stream can be terminated by either the sender or the recipient.
+5. If the stream ended and has not been terminated, the recipient is entitled to withdraw all the remaining balance.
 
 ## Motivation
-This standardised interface aims to change the way we think about long-term financial commitments. Thanks to blockchains, payments need not be sent in chunks (e.g. monthly salaries), as there is much less overhead in paying-as-you-go. Money as a function of time would better align incentives in a host of scenarios.
+
+This standardised interface takes a stab at changing the way we think about trust in financial contracts. Thanks to blockchains, payments need not be sent in lumps (as with monthly salaries), as there is less overhead in pay-as-you-go. Money as a function of time would better align incentives in a host of scenarios.
 
 ### Use Cases
 
-This is just a preliminary list of use cases. There are other spooky ideas interesting to explore, such as time-dependent disincetivisation, but, for brevity, we have not included them here.
+This is just a preliminary list of use cases. There are other interesting ideas left to explore, such as time-dependent disincetivisation, but, for brevity, we have not included them here.
 
 - Salaries
+- Insurance
 - Subscriptions
 - Consultancies
-- CDPs
 - Rent
 - Parking
+- Lending
 
-### Crowdsales
-[RICOs](https://github.com/lukso-network/rico), or Reversible ICOs, were introduced at Devcon4 by @frozeman. The idea is to endow investors with more power and safety guarantees by allowing them to "reverse" the investment based on the evolution of the project. We previously discussed a similar concept called SICOs, or Streamable ICOs, in this research [thread](https://ethresear.ch/t/chronos-a-quirky-application-proposal-for-plasma/2928/14?u=paulrberg).
-
-Instead of investing a lump sum and giving the money away to the project developers, funds are held in a smart contract which allocates money based on the passage of time. Project developers can withdraw funds as the stream stays active, while investors have the power to get back a significant percentage of their initial commitment if the project halts.
+[Sablier](https://sablier.finance) is a champion project for this ERC. It is what we call the protocol for real-time finance.
 
 ## Specification
 
 ### Structs
 
-The structure of a `stream` should be as follows:
+The structure of a stream should be as follows:
 
-- `stream`
-    - `sender`: the `address` of the entity funding the stream
-    - `recipient`: the `address` where the money is being delivered to
-    - `tokenAddress`: the `address` of the ERC20 token used as payment asset
-    - `balance`: the total funds left in the stream
-    - `timeframe`: as defined below
-    - `rate`: as defined below
+- `Stream`
+    - `deposit`: the amount of money to be streamed
+    - `ratePerSecond`: the number of tokens allocated each second to the recipient
+    - `remainingBalance`: the left in the stream
+    - `startTime`: the unix timestamp for when the stream starts
+    - `stopTime`: the unix timestamp for when the stream stops
+    - `recipient`: the address towards which the money is streamed
+    - `sender`: the address of the party funding the stream
+    - `tokenAddress`: the ERC20 token to use as streaming currency
+    - `isEntity`: indicates whether the stream exists or not
 
 ```solidity
-  struct Stream {
-    address sender;
+struct Stream {
+    uint256 deposit;
+    uint256 ratePerSecond;
+    uint256 remainingBalance;
+    uint256 startTime;
+    uint256 stopTime;
     address recipient;
+    address sender;
     address tokenAddress;
-    uint256 balance;
-    Timeframe timeframe;
-    Rate rate;
-  }
-```
-
-- `timeframe`
-    - `start`: the starting block number of the stream
-    - `stop`: the stopping block number of the stream
-
-```solidity
-struct Timeframe {
-    uint256 start;
-    uint256 stop;
-}
-```
-
-- `rate`
-    - `payment`: how much money moves from `sender` to `recipient`
-    - `interval`: how often `payment` moves from `sender` to `recipient`
-
-```solidity
-struct Rate {
-  uint256 payment;
-  uint256 interval;
+    bool isEntity;
 }
 ```
 
@@ -92,205 +78,108 @@ struct Rate {
 
 ### Methods
 
-#### balanceOf
-
-Returns available funds for the given stream id and address.
-
-```solidity
-function balanceOf(uint256 _streamId, address _addr)
-```
-
 #### getStream
 
-Returns the full stream data, if the id points to a valid stream.
+Returns the stream object with all its properties.
 
 ```solidity
-function getStream(uint256 _streamId) returns (address sender, address recipient, address tokenAddress, uint256 balance, uint256 startBlock, uint256 stopBlock, uint256 payment, uint256 interval)
+function getStream(uint256 streamId) view returns (address sender, address recipient, uint256 deposit, address token, uint256 startTime, uint256 stopTime, uint256 remainingBalance, uint256 ratePerSecond)
 ```
 
-#### create
+#### balanceOf
 
-Creates a new stream between `msg.sender` and `_recipient`.
-
-MUST allow senders to create multiple streams in parallel. SHOULD not accept Ether and only use ERC20-compatible tokens.
-
-**Triggers Event**: [LogCreate](#logcreate)
+Returns the real-time balance of the account with address `who`.
 
 ```solidity
-function create(address _recipient, address _tokenAddress, uint256 _startBlock, uint256 _stopBlock, uint256 _payment, uint256 _interval)
+function balanceOf(uint256 streamId, address who) view returns (uint256 balance)
 ```
 
-#### withdraw
+#### createStream
 
-Withdraws all or a fraction of the available funds.
+Creates a new stream funded by `msg.sender` and paid towards `recipient`. MUST throw if `recipient` is the zero address, the contract itself or the caller themselves. MUST throw if `startTime` is before the current block timestamp. MUST throw if `stopTime` is before `startTime`. MUST throw if `deposit` is not a multiple of the time delta. MUST throw if the contract is not allowed to transfer enough tokens.
 
-MUST allow only the recipient to perform this action.
-
-**Triggers Event**: [LogWithdraw](#logwithdraw)
+**Triggers Event**: [CreateStream](#createstream)
 
 ```solidity
-function withdraw(uint256 _streamId, uint256 _funds)
+function createStream(address recipient, address deposit, address tokenAddress, uint256 startTime, uint256 stopTime) returns (uint256 streamId)
 ```
 
-#### redeem
+#### withdrawFromStream
 
-Redeems the stream by distributing the funds to the sender and the recipient.
+Withdraws from the contract to the recipient's account.
 
-SHOULD allow any party to redeem the stream.
+MUST throw if the caller is not the sender or the recipient. MUST throw if `amount` exceeds the available balance.
 
-**Triggers Event**: [LogRedeem](#logredeem)
+**Triggers Event**: [WithdrawFromStream](#withdrawfromstream)
 
 ```solidity
-function redeem(uint256 _streamId)
+function withdrawFromStream(uint256 streamId, uint256 amount) returns (bool success)
 ```
 
-#### confirmUpdate
+#### cancelStream
 
-Signals one party's willingness to update the stream
+Cancels the stream and transfers the tokens back on a pro rata basis.
 
-SHOULD allow any party to do this but MUST NOT be executed without consent from all involved parties.
+MUST throw if the caller is not the sender or the recipient.
 
-**Triggers Event**: [LogConfirmUpdate](#logconfirmupdate)
-
-**Triggers Event**: [LogExecuteUpdate](#logexecuteupdate) when the last involved party calls this function
+**Triggers Event**: [CancelStream](#cancelstream)
 
 ```solidity
-function update(uint256 _streamId, address _tokenAddress, uint256 _stopBlock, uint256 _payment, uint256 _interval)
-```
-
-#### revokeUpdate
-
-Revokes an update proposed by one of the involved parties. 
-
-MUST allow any party to do this.
-
-**Triggers Event**: [LogRevokeUpdate](#logrevokeupdate)
-
-```solidity
-function confirmUpdate(uint256 _streamId, address _tokenAddress, uint256 _stopBlock, uint256 _payment, uint256 _interval)
+function cancelStream(uint256 streamId) returns (bool success)
 ```
 
 ---
 
 ### Events
 
-#### LogCreate
+#### CreateStream
 
-MUST be triggered when `create` is successfully called.
+MUST be triggered when `createStream` is successfully called.
 
 ```solidity
-event LogCreate(uint256 indexed _streamId, address indexed _sender, address indexed _recipient, address _tokenAddress, uint256 _startBlock, uint256 _stopBlock, uint256 _payment, uint256 _interval)
+event CreateStream(uint256 indexed streamId, address indexed sender, address indexed recipient, uint256 deposit, address tokenAddress, uint256 startTime, uint256 stopTime);
 ```
 
-#### LogWithdraw
+#### WithdrawFromStream
 
-MUST be triggered when `withdraw` is successfully called.
+MUST be triggered when `withdrawFromStream` is successfully called.
 
 ```solidity
-event LogWithdraw(uint256 indexed _streamId, address indexed _recipient, uint256 _funds)
+event WithdrawFromStream(uint256 indexed streamId, address indexed recipient, uint256 amount);
 ```
 
-#### LogRedeem
+#### CancelStream
 
-MUST be triggered when `redeem` is successfully called.
-
-```solidity
-event LogRedeem(uint256 indexed _streamId, address indexed _sender, address indexed _recipient, uint256 _senderBalance, uint256 _recipientBalance)
-```
-
-#### LogConfirmUpdate
-
-MUST be triggered when `confirmUpdate` is successfully called.
+MUST be triggered when `cancelStream` is successfully called.
 
 ```solidity
-event LogConfirmUpdate(uint256 indexed _streamId, address indexed _confirmer, address _newTokenAddress, uint256 _newStopBlock, uint256 _newPayment, uint256 _newInterval);
-```
-
-#### LogRevokeUpdate
-
-MUST be triggered when `revokeUpdate` is successfully called.
-
-```solidity
-event LogRevokeUpdate(uint256 indexed _streamId, address indexed revoker, address _newTokenAddress, uint256 _newStopBlock, uint256 _newPayment, uint256 _newInterval)
-```
-
-#### LogExecuteUpdate
-
-MUST be triggered when an update is approved by all involved parties.
-
-```solidity
-event LogExecuteUpdate(uint256 indexed _newStreamId, address indexed _sender, address indexed _recipient, address _newTokenAddress, uint256 _newStopBlock, uint256 _newPayment, uint256 _newInterval)
+event CancelStream(uint256 indexed streamId, address indexed sender, address indexed recipient, uint256 senderBalance, uint256 recipientBalance);
 ```
 
 ## Rationale
 
-This specification was designed to serve as an entry point to the quirky concept of money as a function of time and it is definitely not set in stone. Several other designs, including payment channels and Plasma chains were also considered, but they were eventually deemed dense in assumptions unnecessary for an initial version.
+This specification is designed to serve as an entry point to the quirky concept of money as a function of time. Several other designs, including payment channels have been considered, but they were deemed dense in assumptions unnecessary for an initial draft.
 
-<!--
-- Block times and oracles for time calculation
-    - GCD
-    - Miners
-- Sidechain-compatible (and preferable)
-- The `update` function
-- Multi-hop streams
--->
+### Timestamps
 
-Block times are a reasonable, trustless proxy for time on the blockchain. Between 2016 and 2018, the Ethereum block time average value [hovered](https://etherscan.io/chart/blocktime) around 14 seconds, excluding the last two quarters of 2017. Mathematically speaking, it would be ideal to have a standard deviation as close to 0 as possible, but that is not how things work in the real world. This has huge implications on the feasibility of this ERC which we shall investigate below.
+Block timestamps are a reasonably secure proxy for time on the blockchain. Although miners handle them, there are game-theoretical incentives to not provide malicious timestamps. [Read this thread](https://ethereum.stackexchange.com/questions/413/can-a-contract-safely-rely-on-block-timestamp) on StackExchange for more details.
 
-### GCD
-When setting up a stream, a payer and a payee may want to make the total streaming duration a multiple of the "greatest common denominator" (GCD) of the chain they operate on; that is, the average block time. This is not imperative in the smart contracts per se, but there needs to be an off-chain process to map streams to real world time units in order to create a sound and fair payment mechanism.
-
-### Block Times
-Because there is uncertainty regarding block times, streams may not be settled on the blockchain as initially planned. Let `$d` be the total streaming duration measured in seconds, `$t` the average block time before the stream started and `$t'` the actual average block time over `$d` after the stream started. We distinguish two undesirable scenarios:
-
-1. `$t` < `$t'`: the payee will get their funds *later* than expected
-
-2. `$t` > `$t'`: the payee will get their funds *sooner* than expected
-
-If the combined error delta is smaller than the payment rate (fifth parameter of the `create` method, measured in wei), there is no problem at all. Conversely, we stumble upon trust issues because real-world time frames do not correspond to the stream terms. For instance, if an employee is normally entitled to withdraw all the funds from the stream at the end of the month, but block times cause case 1 from above to occur, the employee is in a financial disadvantage because their continuous effort is not compensated as promised.
-
-Limiting the problem scope only to Ethereum, we propose two remedies:
-
-1. Consensus on calling the `update` function to correct the stream terms. This might sound preposterous, but in most cases the stakes are low and stream participants are involved in long-term financial commitments. There is a high disincentive to refuse to cooperate.
-
-2. Autonomously fix significant error deltas. In theory, we could achieve this using previous blocks' timestamps, "checkpointing" the stream once in a predefined number of blocks. This is still an area of active research because of potentially high overheads in gas costs.
-
-Nonetheless, it is important to note that this is still a major improvement on the traditional model where absolute trust is required.
-
-### Sidechains
-
-It could be more efficient to implement this standard on independent sidechains like [POA Network](https://poa.network) or [xDai](https://medium.com/poa-network/poa-network-partners-with-makerdao-on-xdai-chain-the-first-ever-usd-stable-blockchain-65a078c41e6a) - thanks to their rather predictable nature. Admittedly, security is traded for scalability, but proper cryptoeconomic stakes could alleviate potential problems.
-
-Furthermore, it is intriguing to explore the prospect of stream-specific sidechains.
-
-### Oracles
-
-The proposed specification uses block numbers to proxy time, but this need not be the only method. Albeit it would imply different trust assumptions, oracles could be used to provide a feed of timestamps. Coupled with the aforementioned idea of stream-specific sidechains, oracles could efficiently solve the problems outlined in [Block Times](#block-times).
-
-### Multi-Hop Streams
-
-Future or upgraded versions of this standard may describe "multi-hop" streams. If:
-
-1. There is a stream between A and B
-2. There is another stream between B and C
-
-There could be a way to avoid running two different streams in parallel. That is, a fraction or all of the funds being streamed from A to B could be automatically wired to C. An interesting use case for this is taxes. Instead of manually moving money around, proactively calculating how much you owe and then transfer it, a stream could atomically perform those operations for you.
+The only dangerous scenario we can think of is when ERC-1620 derived implementations end up making up a significant share of the volume of money transferred on Ethereum. It is possible, although unlikely, that some stream recipients will have an incentive to coax miners in bumping the block timestamps for them to profit. But we posit the payoff (a few seconds or minutes times the payment rate) will not be high enough for this kind of attack to be worth it.
 
 ## Implementation
 
-- [ChronosProtocol WIP implementation](https://github.com/ChronosProtocol/monorepo)
+- [Sablier](https://github.com/sablierhq/sablier/)
 
 ## Additional References
+
+- [Sablier Launch Thread](https://twitter.com/SablierHQ/status/1205533344886411264)
+- [Introducing Sablier: Continuous Salaries on Ethereum](https://medium.com/sablier/introducing-sablier-continuous-payments-on-ethereum-c2bf04446d31)
 - [Chronos Protocol Ethresear.ch Plasma Proposal](https://ethresear.ch/t/chronos-a-quirky-application-proposal-for-plasma/2928?u=paulrberg)
-- [Chronos Protocol White Paper](http://chronosprotocol.org/chronos-white-paper.pdf)
 - [Flipper: Streaming Salaries @ CryptoLife Hackathon](https://devpost.com/software/flipper-3gvl4b)
 - [SICOs or Streamed ICOs](https://ethresear.ch/t/chronos-a-quirky-application-proposal-for-plasma/2928/14?u=paulrberg)
 - [RICOs or Reversible ICOs](https://twitter.com/feindura/status/1058057076306518017)
 - [Andreas Antonopoulos' Keynote on Bitcoin, Lightning and Money Streaming](https://www.youtube.com/watch?v=gF_ZQ_eijPs)
 
-## Final Notes
-
-Many thanks to @mmilton41 for countless brainstorming sessions. We have been doing research on the topic of money streaming for quite a while within the context of @ChronosProtocol. In August this year, we published the first version of our white paper describing a Plasma approach. However, in the meantime, we realised that it would be much more [fun](https://twitter.com/PaulRBerg/status/1056595919116910592) and easier to start small on Ethereum itself and sidechains like [xDai](https://blockscout.com/poa/dai).
-
 ## Copyright
+
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/EIPS/eip-1620.md
+++ b/EIPS/eip-1620.md
@@ -8,7 +8,7 @@ type: Standards Track
 category: ERC
 created: 2018-11-24
 requires: 20
-review-period-end: 2020-09-22
+review-period-end: 2020-09-24
 ---
 
 ## Simple Summary
@@ -41,7 +41,7 @@ This is just a preliminary list of use cases. There are other interesting ideas 
 - Parking
 - Lending
 
-[Sablier](https://sablier.finance) is a champion project for this ERC. It is what we call the protocol for real-time finance.
+[Sablier](https://sablier.finance) is a champion project for this ERC.
 
 ## Specification
 
@@ -57,7 +57,7 @@ The structure of a stream should be as follows:
     - `stopTime`: the unix timestamp for when the stream stops
     - `recipient`: the address towards which the money is streamed
     - `sender`: the address of the party funding the stream
-    - `tokenAddress`: the ERC20 token to use as streaming currency
+    - `tokenAddress`: the [ERC-20](https://eips.ethereum.org/EIPS/eip-20) token to use as streaming currency
     - `isEntity`: indicates whether the stream exists or not
 
 ```solidity
@@ -83,7 +83,7 @@ struct Stream {
 Returns the stream object with all its properties.
 
 ```solidity
-function getStream(uint256 streamId) view returns (address sender, address recipient, uint256 deposit, address token, uint256 startTime, uint256 stopTime, uint256 remainingBalance, uint256 ratePerSecond)
+function getStream(uint256 streamId) view returns (address sender, address recipient, uint256 deposit, address token, uint256 startTime, uint256 stopTime, uint256 remainingBalance, uint256 ratePerSecond);
 ```
 
 #### balanceOf
@@ -91,7 +91,7 @@ function getStream(uint256 streamId) view returns (address sender, address recip
 Returns the real-time balance of the account with address `who`.
 
 ```solidity
-function balanceOf(uint256 streamId, address who) view returns (uint256 balance)
+function balanceOf(uint256 streamId, address who) view returns (uint256 balance);
 ```
 
 #### createStream
@@ -101,7 +101,7 @@ Creates a new stream funded by `msg.sender` and paid towards `recipient`. MUST t
 **Triggers Event**: [CreateStream](#createstream)
 
 ```solidity
-function createStream(address recipient, address deposit, address tokenAddress, uint256 startTime, uint256 stopTime) returns (uint256 streamId)
+function createStream(address recipient, address deposit, address tokenAddress, uint256 startTime, uint256 stopTime) returns (uint256 streamId);
 ```
 
 #### withdrawFromStream
@@ -113,7 +113,7 @@ MUST throw if the caller is not the sender or the recipient. MUST throw if `amou
 **Triggers Event**: [WithdrawFromStream](#withdrawfromstream)
 
 ```solidity
-function withdrawFromStream(uint256 streamId, uint256 amount) returns (bool success)
+function withdrawFromStream(uint256 streamId, uint256 amount) returns (bool success);
 ```
 
 #### cancelStream
@@ -125,7 +125,7 @@ MUST throw if the caller is not the sender or the recipient.
 **Triggers Event**: [CancelStream](#cancelstream)
 
 ```solidity
-function cancelStream(uint256 streamId) returns (bool success)
+function cancelStream(uint256 streamId) returns (bool success);
 ```
 
 ---
@@ -164,7 +164,7 @@ This specification is designed to serve as an entry point to the quirky concept 
 
 Block timestamps are a reasonably secure proxy for time on the blockchain. Although miners handle them, there are game-theoretical incentives to not provide malicious timestamps. [Read this thread](https://ethereum.stackexchange.com/questions/413/can-a-contract-safely-rely-on-block-timestamp) on StackExchange for more details.
 
-The only dangerous scenario we can think of is when ERC-1620 derived implementations end up making up a significant share of the volume of money transferred on Ethereum. It is possible, although unlikely, that some stream recipients will have an incentive to coax miners in bumping the block timestamps for them to profit. But we posit the payoff (a few seconds or minutes times the payment rate) will not be high enough for this kind of attack to be worth it.
+The only dangerous scenario we can think of is when [ERC-1620](https://eips.ethereum.org/EIPS/eip-1620) derived implementations end up making up a significant share of the volume of money transferred on Ethereum. It is possible, although unlikely, that some stream recipients will have an incentive to coax miners in bumping the block timestamps for them to profit. But we posit the payoff (a few seconds or minutes times the payment rate) will not be high enough for this kind of attack to be worth it.
 
 ## Implementation
 


### PR DESCRIPTION
As per the announcement in #1620, update the markdown version of ERC-1620 to its final version from Sep 27, 2019.