### PR TITLE
Remove review period after final EIP-2387

### DIFF
--- a/EIPS/eip-2387.md
+++ b/EIPS/eip-2387.md
@@ -5,7 +5,6 @@ author: James Hancock (@madeoftin)
 discussions-to: https://ethereum-magicians.org/t/hard-fork-to-address-the-ice-age-eip-2387
 type: Meta
 status: Final
-review-period-end: 2019-12-12
 created: 2019-11-22
 requires: 1679, 2384
 ---


### PR DESCRIPTION
After a Last Call status is moved to Final, the **Review Period End <date>** column can be removed

Fixes #2449.