### PR TITLE
Remove review period after final EIP-2384

### DIFF
--- a/EIPS/eip-2384.md
+++ b/EIPS/eip-2384.md
@@ -6,7 +6,6 @@ discussions-to: https://ethereum-magicians.org/t/eip-2384-difficulty-bomb-delay
 type: Standards Track
 category: Core
 status: Final
-review-period-end: 2019-12-12
 created: 2019-11-20
 ---
 


### PR DESCRIPTION
After a Last Call status is moved to Final, the **Review Period End <date>** column can be removed

Fixes #2447.