### PR TITLE
EIP-777: typo fix

### DIFF
--- a/EIPS/eip-777.md
+++ b/EIPS/eip-777.md
@@ -884,7 +884,7 @@ When called from a `transferFrom`, `operator` MUST be the address which issued t
 
 The `tokensReceived` hook notifies of any increment of the balance (send and mint) for a given *recipient*.
 Any address (regular or contract) wishing to be notified of token credits to their address
-MAY register the address of a contract implementing the `ERC777TokensSender` interface described below via [ERC1820].
+MAY register the address of a contract implementing the `ERC777TokensRecipient` interface described below via [ERC1820].
 
 > This is done by calling the `setInterfaceImplementer` function on the [ERC1820] registry
 > with the *recipient* address as the address,


### PR DESCRIPTION
Changed `ERC777TokensSender` to `ERC777TokensRecipient` in `ERC777TokensRecipient And The tokensReceived Hook` section.