### PR TITLE
Errata: EIP-2200 should require EIP-1884

### DIFF
--- a/EIPS/eip-2200.md
+++ b/EIPS/eip-2200.md
@@ -56,11 +56,11 @@ changes in the future.
 
 ## Specification
 
-Define variables `SLOAD_GAS`, `SSTORE_SET_GAS`, `SSTORE_RESET_GAS` and
+Define variables `SSTORE_DIRTY_GAS`, `SSTORE_SET_GAS`, `SSTORE_RESET_GAS` and
 `SSTORE_CLEARS_SCHEDULE`. The old and new values for those variables
 are:
 
-* `SLOAD_GAS`: changed from `200` to `800`.
+* `SSTORE_DIRTY_GAS`: changed from `200` to `800`.
 * `SSTORE_SET_GAS`: `20000`, not changed.
 * `SSTORE_RESET_GAS`: `5000`, not changed.
 * `SSTORE_CLEARS_SCHEDULE`: `15000`, not changed.
@@ -75,7 +75,7 @@ the following logic:
 
 * If *gasleft* is less than or equal to gas stipend, fail the current
   call frame with 'out of gas' exception.
-* If *current value* equals *new value* (this is a no-op), `SLOAD_GAS`
+* If *current value* equals *new value* (this is a no-op), `SSTORE_DIRTY_GAS`
   is deducted.
 * If *current value* does not equal *new value*
   * If *original value* equals *current value* (this storage slot has
@@ -84,7 +84,7 @@ the following logic:
     * Otherwise, `SSTORE_RESET_GAS` gas is deducted. If *new value* is
       0, add `SSTORE_CLEARS_SCHEDULE` gas to refund counter.
   * If *original value* does not equal *current value* (this storage
-    slot is dirty), `SLOAD_GAS` gas is deducted. Apply both of the
+    slot is dirty), `SSTORE_DIRTY_GAS` gas is deducted. Apply both of the
     following clauses.
     * If *original value* is not 0
       * If *current value* is 0 (also means that *new value* is not
@@ -94,9 +94,9 @@ the following logic:
         0), add `SSTORE_CLEARS_SCHEDULE` gas to refund counter.
     * If *original value* equals *new value* (this storage slot is
       reset)
-      * If *original value* is 0, add `SSTORE_SET_GAS - SLOAD_GAS` to
+      * If *original value* is 0, add `SSTORE_SET_GAS - SSTORE_DIRTY_GAS` to
         refund counter.
-      * Otherwise, add `SSTORE_RESET_GAS - SLOAD_GAS` gas to refund
+      * Otherwise, add `SSTORE_RESET_GAS - SSTORE_DIRTY_GAS` gas to refund
         counter.
 
 An implementation should also note that with the above definition, if
@@ -138,7 +138,7 @@ properties that this EIP satisfies.
   its original value, and then changed again, EIP-1283 would move more
   gases to refund counter compared with EIP-1087.
 
-Examine examples provided in EIP-1087's Motivation (with `SLOAD_GAS` being
+Examine examples provided in EIP-1087's Motivation (with `SSTORE_DIRTY_GAS` being
 `200`):
 
 * If a contract with empty storage sets slot 0 to 1, then back to 0,
@@ -223,8 +223,8 @@ operations on a storage slot. For states discussed below, refer to
 *State Transition* in *Explanation* section.
 
 Below we do the proof under the assumption that all parameters are
-unchanged, meaning `SLOAD_GAS` is `200`. However, note that the proof
-still applies no matter how `SLOAD_GAS` is changed.
+unchanged, meaning `SSTORE_DIRTY_GAS` is `200`. However, note that the proof
+still applies no matter how `SSTORE_DIRTY_GAS` is changed.
 
 ### Original Value Being Zero
 

--- a/EIPS/eip-2200.md
+++ b/EIPS/eip-2200.md
@@ -6,6 +6,7 @@ discussions-to: https://github.com/sorpaas/EIPs/issues/1
 status: Final
 type: Standards Track
 category: Core
+requires: 1884
 created: 2019-07-18
 ---
 
@@ -56,11 +57,11 @@ changes in the future.
 
 ## Specification
 
-Define variables `SSTORE_DIRTY_GAS`, `SSTORE_SET_GAS`, `SSTORE_RESET_GAS` and
+Define variables `SLOAD_GAS`, `SSTORE_SET_GAS`, `SSTORE_RESET_GAS` and
 `SSTORE_CLEARS_SCHEDULE`. The old and new values for those variables
 are:
 
-* `SSTORE_DIRTY_GAS`: changed from `200` to `800`.
+* `SLOAD_GAS`: changed from `200` to `800`.
 * `SSTORE_SET_GAS`: `20000`, not changed.
 * `SSTORE_RESET_GAS`: `5000`, not changed.
 * `SSTORE_CLEARS_SCHEDULE`: `15000`, not changed.
@@ -75,7 +76,7 @@ the following logic:
 
 * If *gasleft* is less than or equal to gas stipend, fail the current
   call frame with 'out of gas' exception.
-* If *current value* equals *new value* (this is a no-op), `SSTORE_DIRTY_GAS`
+* If *current value* equals *new value* (this is a no-op), `SLOAD_GAS`
   is deducted.
 * If *current value* does not equal *new value*
   * If *original value* equals *current value* (this storage slot has
@@ -84,7 +85,7 @@ the following logic:
     * Otherwise, `SSTORE_RESET_GAS` gas is deducted. If *new value* is
       0, add `SSTORE_CLEARS_SCHEDULE` gas to refund counter.
   * If *original value* does not equal *current value* (this storage
-    slot is dirty), `SSTORE_DIRTY_GAS` gas is deducted. Apply both of the
+    slot is dirty), `SLOAD_GAS` gas is deducted. Apply both of the
     following clauses.
     * If *original value* is not 0
       * If *current value* is 0 (also means that *new value* is not
@@ -94,9 +95,9 @@ the following logic:
         0), add `SSTORE_CLEARS_SCHEDULE` gas to refund counter.
     * If *original value* equals *new value* (this storage slot is
       reset)
-      * If *original value* is 0, add `SSTORE_SET_GAS - SSTORE_DIRTY_GAS` to
+      * If *original value* is 0, add `SSTORE_SET_GAS - SLOAD_GAS` to
         refund counter.
-      * Otherwise, add `SSTORE_RESET_GAS - SSTORE_DIRTY_GAS` gas to refund
+      * Otherwise, add `SSTORE_RESET_GAS - SLOAD_GAS` gas to refund
         counter.
 
 An implementation should also note that with the above definition, if
@@ -138,7 +139,7 @@ properties that this EIP satisfies.
   its original value, and then changed again, EIP-1283 would move more
   gases to refund counter compared with EIP-1087.
 
-Examine examples provided in EIP-1087's Motivation (with `SSTORE_DIRTY_GAS` being
+Examine examples provided in EIP-1087's Motivation (with `SLOAD_GAS` being
 `200`):
 
 * If a contract with empty storage sets slot 0 to 1, then back to 0,
@@ -223,8 +224,8 @@ operations on a storage slot. For states discussed below, refer to
 *State Transition* in *Explanation* section.
 
 Below we do the proof under the assumption that all parameters are
-unchanged, meaning `SSTORE_DIRTY_GAS` is `200`. However, note that the proof
-still applies no matter how `SSTORE_DIRTY_GAS` is changed.
+unchanged, meaning `SLOAD_GAS` is `200`. However, note that the proof
+still applies no matter how `SLOAD_GAS` is changed.
 
 ### Original Value Being Zero
 


### PR DESCRIPTION
This PR add clause `requires: 1884` for EIP-2200, otherwise the variable name `SLOAD_GAS` in EIP-2200 can be a point of confusion.