### PR TITLE
Replace the Difficulty Bomb with a Difficulty Freeze

### DIFF
--- a/EIPS/eip-2515.md
+++ b/EIPS/eip-2515.md
@@ -23,7 +23,7 @@ The difficulty Freeze is a mechanism that is easy to predict and model, and the 
 
 ## Motivation
 <!--The motivation is critical for EIPs that want to change the Ethereum protocol. It should clearly explain why the existing protocol specification is inadequate to address the problem that the EIP solves. EIP submissions without sufficient motivation may be rejected outright.-->
-The current difficulty bombs' effect on the Block Time Targeting mechanism is rather complex to model, and it has both appeared when it was not expected (Muir Glacier) and negatively affected miners when they are not the target (in the case of delaying forks due to techincal difficulties). Miners are affected by a reduction in block rewards due to the increase in block time. Users are affected as a function of the usability of the chain is affected by increased block times. Both of these groups are unable on their own to address the difficulty bomb. In the case of the Difficulty Freeze, the consequences of missing it are more directly felt by the client maintainers and it is more predictiable and so knowing when to make the change is readily apparent.
+The current difficulty bombs' effect on the Block Time Targeting mechanism is rather complex to model, and it has both appeared when it was not expected (Muir Glacier) and negatively affected miners when they are not the target (in the case of delaying forks due to technical difficulties). Miners are affected by a reduction in block rewards due to the increase in block time. Users are affected as a function of the usability of the chain is affected by increased block times. Both of these groups are unable on their own to address the difficulty bomb. In the case of the Difficulty Freeze, the consequences of missing it are more directly felt by the client maintainers and it is more predictiable and so knowing when to make the change is readily apparent.
 
 ## Specification
 
@@ -85,7 +85,7 @@ The effect of missing the Difficulty Freeze has a different impact than missing 
  - The Hash rate decreases:
    Block times would increase. 
  - The Hash rate stays the same:
-   A consistent increase in blocktimes until the network is useable.
+   A consistent increase in blocktimes.
 
 Clients are motivated to have their client sync fully to the network and so are very motivated to keep this situation from occurring. Simultaneously delaying the Difficulty Freeze is most easily implemented by client teams. Therefore the group that is most negatively affected is also the group that can most efficiently address it.
 

--- a/EIPS/eip-2515.md
+++ b/EIPS/eip-2515.md
@@ -1,5 +1,5 @@
-<!--- -->
-eip: <to be assigned>
+---
+eip: 2512
 title: Implement Difficulty Freeze
 author: James Hancock (@madeoftin)
 discussions-to: <URL>
@@ -7,23 +7,23 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2020/02/10
-requires (*optional): <EIP number(s)>
-replaces (*optional): <EIP number(s)>
+requires (*optional):
+replaces (*optional):
 ---
 
 
 ## Simple Summary
 <!--"If you can't explain it simply, you don't understand it well enough." Provide a simplified and layman-accessible explanation of the EIP.-->
-The difficulty Freeze is an alternative to the Difficulty Bomb that is implemented within the protocals difficulty adjustment algorythm. The Difficulty Freeze begins at a certain block height, determined in advanced, and freezes the difficulty. This does not stop the chain, but it incentivizes devs to upgrade at a regular cadance and requires any chain split to address the difficulty freeze.
+The difficulty Freeze is an alternative to the Difficulty Bomb that is implemented within the protocols difficulty adjustment algorithm. The Difficulty Freeze begins at a certain block height, determined in advance, and freezes the difficulty. This does not stop the chain, but it incentivizes devs to upgrade at a regular cadence and requires any chain split to address the difficulty freeze.
 
 ## Abstract
 <!--A short (~200 word) description of the technical issue being addressed.-->
-The difficulty Freeze is a mechanism that is easy to predict and model, and the pressures of missing it are more readily felt by the core developers and client maintainers. The client mainters are positioned as the group that is most able to respond to an incoming Difficulty Freeze.
+The difficulty Freeze is a mechanism that is easy to predict and model, and the pressures of missing it are more readily felt by the core developers and client maintainers. The client maintainers are also positioned as the group that is most able to respond to an incoming Difficulty Freeze.
 
 
 ## Motivation
 <!--The motivation is critical for EIPs that want to change the Ethereum protocol. It should clearly explain why the existing protocol specification is inadequate to address the problem that the EIP solves. EIP submissions without sufficient motivation may be rejected outright.-->
-The current difficulty bombs' affect on the Block Time Targeting mechanism is rather complex to model and it has both appeared at times it was not expected (Muir Glacier) and negatively affected miners when they are not the target (in the case of delaying forks due to techincal difficulties). Miners are affected by a reduction in block rewards due to the increase in block time. Users are affected as a function of the usablilty of the chain is affected by increased block times. Both of these groups are unable on their own to address the difficulty bomb. In the case of the Difficulty Freeze the consequences of missing it are more directly felt by the the client maintainers.
+The current difficulty bombs' effect on the Block Time Targeting mechanism is rather complex to model, and it has both appeared when it was not expected (Muir Glacier) and negatively affected miners when they are not the target (in the case of delaying forks due to techincal difficulties). Miners are affected by a reduction in block rewards due to the increase in block time. Users are affected as a function of the usability of the chain is affected by increased block times. Both of these groups are unable on their own to address the difficulty bomb. In the case of the Difficulty Freeze, the consequences of missing it are more directly felt by the client maintainers.
 
 ## Specification
 
@@ -60,7 +60,7 @@ This approach would have the added benefit that updating the Difficulty Freeze i
 
 ## Rationale
 <!--The rationale fleshes out the specification by describing what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work, e.g. how the feature is supported in other languages. The rationale may also provide evidence of consensus within the community, and should discuss important objections or concerns raised during discussion.-->
-Block height is very easy to predict and evalute within the system. This removes the affect of the Difficulty Bomb on block time simplifying the block time targeting mechanism.
+Block height is very easy to predict and evaluate within the system. This removes the effect of the Difficulty Bomb on block time, simplifying the block time targeting mechanism.
 
 ## Backwards Compatibility
 <!--All EIPs that introduce backwards incompatibilities must include a section describing these incompatibilities and their severity. The EIP must explain how the author proposes to deal with these incompatibilities. EIP submissions without a sufficient backwards compatibility treatise may be rejected outright.-->

--- a/EIPS/eip-2515.md
+++ b/EIPS/eip-2515.md
@@ -2,7 +2,7 @@
 eip: 2512
 title: Implement Difficulty Freeze
 author: James Hancock (@madeoftin)
-discussions-to: <URL>
+discussions-to: https://ethereum-magicians.org/t/eip-2515-replace-the-difficulty-bomb-with-a-difficulty-freeze/3995
 status: Draft
 type: Standards Track
 category: Core

--- a/EIPS/eip-2515.md
+++ b/EIPS/eip-2515.md
@@ -14,16 +14,16 @@ replaces (*optional):
 
 ## Simple Summary
 <!--"If you can't explain it simply, you don't understand it well enough." Provide a simplified and layman-accessible explanation of the EIP.-->
-The difficulty Freeze is an alternative to the Difficulty Bomb that is implemented within the protocols difficulty adjustment algorithm. The Difficulty Freeze begins at a certain block height, determined in advance, and freezes the difficulty. This does not stop the chain, but it incentivizes devs to upgrade at a regular cadence and requires any chain split to address the difficulty freeze.
+The difficulty Freeze is an alternative to the Difficulty Bomb that is implemented within the protocols difficulty adjustment algorithm. The Difficulty Freeze begins at a certain block height, determined in advance, freezes the difficulty and increases by 1% after that block forever. This does not stop the chain, but it incentivizes devs to upgrade at a regular cadence and requires any chain split to address the difficulty freeze.
 
 ## Abstract
 <!--A short (~200 word) description of the technical issue being addressed.-->
-The difficulty Freeze is a mechanism that is easy to predict and model, and the pressures of missing it are more readily felt by the core developers and client maintainers. The client maintainers are also positioned as the group that is most able to respond to an incoming Difficulty Freeze.
+The difficulty Freeze is a mechanism that is easy to predict and model, and the pressures of missing it are more readily felt by the core developers and client maintainers. The client maintainers are also positioned as the group that is most able to respond to an incoming Difficulty Freeze. This combined with the predictability is more likely to lead to the timely diffusual of the bomb. 
 
 
 ## Motivation
 <!--The motivation is critical for EIPs that want to change the Ethereum protocol. It should clearly explain why the existing protocol specification is inadequate to address the problem that the EIP solves. EIP submissions without sufficient motivation may be rejected outright.-->
-The current difficulty bombs' effect on the Block Time Targeting mechanism is rather complex to model, and it has both appeared when it was not expected (Muir Glacier) and negatively affected miners when they are not the target (in the case of delaying forks due to techincal difficulties). Miners are affected by a reduction in block rewards due to the increase in block time. Users are affected as a function of the usability of the chain is affected by increased block times. Both of these groups are unable on their own to address the difficulty bomb. In the case of the Difficulty Freeze, the consequences of missing it are more directly felt by the client maintainers.
+The current difficulty bombs' effect on the Block Time Targeting mechanism is rather complex to model, and it has both appeared when it was not expected (Muir Glacier) and negatively affected miners when they are not the target (in the case of delaying forks due to techincal difficulties). Miners are affected by a reduction in block rewards due to the increase in block time. Users are affected as a function of the usability of the chain is affected by increased block times. Both of these groups are unable on their own to address the difficulty bomb. In the case of the Difficulty Freeze, the consequences of missing it are more directly felt by the client maintainers and it is more predictiable and so knowing when to make the change is readily apparent.
 
 ## Specification
 
@@ -38,7 +38,7 @@ if (BLOCK_HEIGHT <= DIFFICULTY_FREEZE_HEIGHT):
                 1 - (block_timestamp - parent_timestamp) // 10, -99)
 
 else:
- block_diff = parent_diff
+ block_diff = parent_diff + parent_diff * 0.01
 ```
 
 **Optional Implementation**
@@ -53,14 +53,16 @@ if (BLOCK_HEIGHT  <= LAST_FORK_HEIGHT + DIFFICUTLY_FREEZE_DIFFERENCE) :
                 1 - (block_timestamp - parent_timestamp) // 10, -99)
 
 else:
- block_diff = parent_diff
+ block_diff = parent_diff + parent_diff * 0.01
 ```
 
 This approach would have the added benefit that updating the Difficulty Freeze is easier as it happens automatically at the time of every upgrade. The trade-off is that the logic for checking is more complex and would require further analysis and test cases to ensure no consensus bugs arise. 
 
 ## Rationale
 <!--The rationale fleshes out the specification by describing what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work, e.g. how the feature is supported in other languages. The rationale may also provide evidence of consensus within the community, and should discuss important objections or concerns raised during discussion.-->
-Block height is very easy to predict and evaluate within the system. This removes the effect of the Difficulty Bomb on block time, simplifying the block time targeting mechanism.
+Block height is very easy to predict and evaluate within the system. This removes the effect of the Difficulty Bomb on block time, simplifying the block time targeting mechanism. The addition of an increase in the difficulty was added after feedback that the game theory of the mechanism did not reliably result in .
+
+https://twitter.com/quentinc137/status/1227110578235330562
 
 ## Backwards Compatibility
 <!--All EIPs that introduce backwards incompatibilities must include a section describing these incompatibilities and their severity. The EIP must explain how the author proposes to deal with these incompatibilities. EIP submissions without a sufficient backwards compatibility treatise may be rejected outright.-->
@@ -79,17 +81,17 @@ TBD
 The effect of missing the Difficulty Freeze has a different impact than missing the Difficulty Bomb. At the point of a Difficulty freeze, the protocol is no longer able to adapt to changes in hash power on the network. This can lead to one of three scenarios.
 
  - The Hash rate Increases:
-   Block Times would increase on the network. At the same time uncles would increase. At some point the blocktime would be short enough that clients would not be able to sync fully.
+   Block Times would increase on the network for short time until the increase in difficulty is too high for the network to add any more miners.
  - The Hash rate decreases:
    Block times would increase. 
  - The Hash rate stays the same:
-   No change to Block Time
+   A consistent increase in blocktimes until the network is useable.
 
 Clients are motivated to have their client sync fully to the network and so are very motivated to keep this situation from occurring. Simultaneously delaying the Difficulty Freeze is most easily implemented by client teams. Therefore the group that is most negatively affected is also the group that can most efficiently address it.
 
 ## Economic Considerations
 
-Under the current Difficult, Bomb issuance of ETH is reduced as the Ice Age takes affect. Under the Difficulty Freeze, it is more likely that issuance would increase; however, clients are motivated to prevent this and keep clients syncing effectively. This means it is much less likely to occur.
+Under the current Difficult, Bomb issuance of ETH is reduced as the Ice Age takes affect. Under the Difficulty Freeze, it is more likely that issuance would increase for a short time; however, clients are motivated to prevent this and keep clients syncing effectively. This means it is much less likely to occur. The increase to the difficulty over time will eventually reduce blocktimes and also issuance.
 
 It is also easy to predict when this change would happen, and stakeholders who are affected (Eth Holders) can keep client developers accountable by observing when the Difficulty Freeze is approaching and yell at them on twitter.
 

--- a/EIPS/eip-tbd.md
+++ b/EIPS/eip-tbd.md
@@ -1,0 +1,97 @@
+<!--- -->
+eip: <to be assigned>
+title: Implement Difficulty Freeze
+author: James Hancock (@madeoftin)
+discussions-to: <URL>
+status: Draft
+type: Standards Track
+category: Core
+created: 2020/02/10
+requires (*optional): <EIP number(s)>
+replaces (*optional): <EIP number(s)>
+---
+
+
+## Simple Summary
+<!--"If you can't explain it simply, you don't understand it well enough." Provide a simplified and layman-accessible explanation of the EIP.-->
+The difficulty Freeze is an alternative to the Difficulty Bomb that is implemented within the protocals difficulty adjustment algorythm. The Difficulty Freeze begins at a certain block height, determined in advanced, and freezes the difficulty. This does not stop the chain, but it incentivizes devs to upgrade at a regular cadance and requires any chain split to address the difficulty freeze.
+
+## Abstract
+<!--A short (~200 word) description of the technical issue being addressed.-->
+The difficulty Freeze is a mechanism that is easy to predict and model, and the pressures of missing it are more readily felt by the core developers and client maintainers. The client mainters are positioned as the group that is most able to respond to an incoming Difficulty Freeze.
+
+
+## Motivation
+<!--The motivation is critical for EIPs that want to change the Ethereum protocol. It should clearly explain why the existing protocol specification is inadequate to address the problem that the EIP solves. EIP submissions without sufficient motivation may be rejected outright.-->
+The current difficulty bombs' affect on the Block Time Targeting mechanism is rather complex to model and it has both appeared at times it was not expected (Muir Glacier) and negatively affected miners when they are not the target (in the case of delaying forks due to techincal difficulties). Miners are affected by a reduction in block rewards due to the increase in block time. Users are affected as a function of the usablilty of the chain is affected by increased block times. Both of these groups are unable on their own to address the difficulty bomb. In the case of the Difficulty Freeze the consequences of missing it are more directly felt by the the client maintainers.
+
+## Specification
+
+Add variable `DIFFICULTY_FREEZE_HEIGHT`
+
+
+The logic of the Difficulty Freeze is defined as follows:
+
+```
+if (BLOCK_HEIGHT <= DIFFICULTY_FREEZE_HEIGHT):
+   block_diff = parent_diff + parent_diff // 2048 * max(
+                1 - (block_timestamp - parent_timestamp) // 10, -99)
+
+else:
+ block_diff = parent_diff
+```
+
+**Optional Implementation**
+
+Add the variable `DIFFICULTY_FREEZE_DIFFERENCE` and use the `LAST_FORK_HEIGHT` to calculate when the Difficulty Freeze would occur.
+
+For example we can set the `DFD = 1,800,000 blocks` or approximately 9 months. The Difficulty Calculation would then be.
+
+```
+if (BLOCK_HEIGHT  <= LAST_FORK_HEIGHT + DIFFICUTLY_FREEZE_DIFFERENCE) :
+   block_diff = parent_diff + parent_diff // 2048 * max(
+                1 - (block_timestamp - parent_timestamp) // 10, -99)
+
+else:
+ block_diff = parent_diff
+```
+
+This approach would have the added benefit that updating the Difficulty Freeze is easier as it happens automatically at the time of every upgrade. The trade-off is that the logic for checking is more complex and would require further analysis and test cases to ensure no consensus bugs arise. 
+
+## Rationale
+<!--The rationale fleshes out the specification by describing what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work, e.g. how the feature is supported in other languages. The rationale may also provide evidence of consensus within the community, and should discuss important objections or concerns raised during discussion.-->
+Block height is very easy to predict and evalute within the system. This removes the affect of the Difficulty Bomb on block time simplifying the block time targeting mechanism.
+
+## Backwards Compatibility
+<!--All EIPs that introduce backwards incompatibilities must include a section describing these incompatibilities and their severity. The EIP must explain how the author proposes to deal with these incompatibilities. EIP submissions without a sufficient backwards compatibility treatise may be rejected outright.-->
+No backward incompatibilities
+
+## Test Cases
+<!--Test cases for an implementation are mandatory for EIPs that are affecting consensus changes. Other EIPs can choose to include links to test cases if applicable.-->
+TBD
+
+## Implementation
+<!--The implementations must be completed before any EIP is given status "Final", but it need not be completed before the EIP is accepted. While there is merit to the approach of reaching consensus on the specification and rationale before writing code, the principle of "rough consensus and running code" is still useful when it comes to resolving many discussions of API details.-->
+TBD
+
+## Security Considerations
+<!--All EIPs must contain a section that discusses the security implications/considerations relevant to the proposed change. Include information that might be important for security discussions, surfaces risks and can be used throughout the life cycle of the proposal. E.g. include security-relevant design decisions, concerns, important discussions, implementation-specific guidance and pitfalls, an outline of threats and risks and how they are being addressed. EIP submissions missing the "Security Considerations" section will be rejected. An EIP cannot proceed to status "Final" without a Security Considerations discussion deemed sufficient by the reviewers.-->
+The effect of missing the Difficulty Freeze has a different impact than missing the Difficulty Bomb. At the point of a Difficulty freeze, the protocol is no longer able to adapt to changes in hash power on the network. This can lead to one of three scenarios.
+
+ - The Hash rate Increases:
+   Block Times would increase on the network. At the same time uncles would increase. At some point the blocktime would be short enough that clients would not be able to sync fully.
+ - The Hash rate decreases:
+   Block times would increase. 
+ - The Hash rate stays the same:
+   No change to Block Time
+
+Clients are motivated to have their client sync fully to the network and so are very motivated to keep this situation from occurring. Simultaneously delaying the Difficulty Freeze is most easily implemented by client teams. Therefore the group that is most negatively affected is also the group that can most efficiently address it.
+
+## Economic Considerations
+
+Under the current Difficult, Bomb issuance of ETH is reduced as the Ice Age takes affect. Under the Difficulty Freeze, it is more likely that issuance would increase; however, clients are motivated to prevent this and keep clients syncing effectively. This means it is much less likely to occur.
+
+It is also easy to predict when this change would happen, and stakeholders who are affected (Eth Holders) can keep client developers accountable by observing when the Difficulty Freeze is approaching and yell at them on twitter.
+
+## Copyright
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
The difficulty Freeze is an alternative to the Difficulty Bomb that is implemented within the protocols difficulty adjustment algorithm. The Difficulty Freeze begins at a certain block height, determined in advance, and freezes the difficulty. This does not stop the chain, but it incentivizes devs to upgrade at a regular cadence and requires any chain split to address the difficulty freeze.