### PR TITLE
Adding spec about not emitting Transfer event

### DIFF
--- a/EIPS/eip-2309.md
+++ b/EIPS/eip-2309.md
@@ -28,7 +28,7 @@ The optional ERC-721 Consecutive Transfer Extension provides a standardized even
 
 <!--The motivation is critical for EIPs that want to change the Ethereum protocol. It should clearly explain why the existing protocol specification is inadequate to address the problem that the EIP solves. EIP submissions without sufficient motivation may be rejected outright.-->
 
-This extension is provides even more scalibility of the ERC-721 specification. It is possible to create, transfer, and burn 2^255 non-fungible tokens in one transaction. However, it is not possible to emit that many `Transfer` events in one transaction. The `Transfer` event is part of the original specification which states:
+This extension provides even more scalibility of the ERC-721 specification. It is possible to create, transfer, and burn 2^255 non-fungible tokens in one transaction. However, it is not possible to emit that many `Transfer` events in one transaction. The `Transfer` event is part of the original specification which states:
 
 > This emits when ownership of any NFT changes by any mechanism.
 > This event emits when NFTs are created (`from` == 0) and destroyed
@@ -69,6 +69,7 @@ interface ERC721ConsecutiveTransfer /* is ERC721 */ {
     The fromTokenId and toTokenId MUST be a consecutive range of tokens IDs.
     When minting/creating tokens, the `fromAddress` argument MUST be set to `0x0` (i.e. zero address).
     When burning/destroying tokens, the `toAddress` argument MUST be set to `0x0` (i.e. zero address).
+    When emitting the ConsecutiveTransfer event the Transfer event MUST NOT be emitted
 
     @param fromTokenId The token ID that begins the batch of tokens being transferred
     @param toTokenId The token ID that ends the batch of tokens being transferred
@@ -79,6 +80,8 @@ interface ERC721ConsecutiveTransfer /* is ERC721 */ {
 }
 ```
 
+---
+
 The `ConsecutiveTransfer` event can be used for a single token as well as many tokens:
 
 **Single token creation**
@@ -88,6 +91,18 @@ The `ConsecutiveTransfer` event can be used for a single token as well as many t
 **Batch token creation**
 
 `emit ConsecutiveTransfer(1, 100000, address(0), toAddress);`
+
+**Batch token transfer**
+
+`emit ConsecutiveTransfer(1, 100000, fromAddress, toAddress);`
+
+**Burn**
+
+`emit ConsecutiveTransfer(1, 100000, from, address(0));`
+
+---
+
+When emitting the `ConsecutiveTransfer` event the `Transfer` event **MUST NOT** be emitted. This can lead to bugs and unnecessary complex logic for platforms using these events to track token ownership.
 
 ## Rationale
 

--- a/EIPS/eip-2309.md
+++ b/EIPS/eip-2309.md
@@ -3,7 +3,7 @@ eip: 2309
 title: ERC-721 Consecutive Transfer Extension
 author: Sean Papanikolas (@pizza-r0b)
 discussions-to: https://github.com/ethereum/EIPs/issues/2309
-status: Draft
+status: Last Call
 type: Standards Track
 category: ERC
 created: 2019-10-08


### PR DESCRIPTION
When opening a pull request to submit a new EIP, please use the suggested template: https://github.com/ethereum/EIPs/blob/master/eip-template.md

We have a GitHub bot that automatically merges some PRs. It will merge yours immediately if certain criteria are met:

 - The PR edits only existing draft PRs.
 - The build passes.
 - Your GitHub username or email address is listed in the 'author' header of all affected PRs, inside <triangular brackets>.
 - If matching on email address, the email address is the one publicly listed on your GitHub profile.
