### PR TITLE
EIP 2542 - add TXGASLIMIT, CALLGASLIMIT opcodes

### DIFF
--- a/EIPS/eip-2542.md
+++ b/EIPS/eip-2542.md
@@ -1,6 +1,6 @@
 ---
 eip: 2542
-title: New opcodes TXGASLIMIT, CALLGASLIMIT, TXGASREFUND
+title: New opcodes TXGASLIMIT and CALLGASLIMIT
 author: Alex Forshtat <forshtat1@gmail.com>
 discussions-to: https://ethereum-magicians.org/t/eip-2542-add-txgaslimit-callgaslimit-txgasrefund-opcodes
 status: Draft
@@ -13,56 +13,77 @@ created: 2020-02-29
 
 ## Simple Summary
 <!--"If you can't explain it simply, you don't understand it well enough." Provide a simplified and layman-accessible explanation of the EIP.-->
-A mechanism to allow smart contracts to access information on gas limits and gas refunds for the current transaction and execution frame.
+A mechanism to allow smart contracts to access information on gas limits for the current transaction and execution frame.
 
 ## Abstract
-<!--A short (~200 word) description of the technical issue being addressed.-->
-Currently, there is an existing opcode `0x45 GASLIMIT` that provides access to the block gas limit. While this information may be useful in some cases, it is probably not a value that smart contract developers may be concerned about. The opcode `0x5a GAS` provides the remaining gas, not the initial one. Also it is worth noting how existing `0x32 ORIGIN`, `0x33 CALLER`,`0x34 CALLVALUE` and `0x3a	GASPRICE` opcodes set a pattern of having access to both the transacition and current execution frame state.
+Currently, there is an existing opcode `0x45 GASLIMIT` that provides access to the block gas limit. While this information may be useful in some cases, it is probably not a value that smart contract developers may be concerned about. The opcode `0x5a GAS` provides the remaining gas, not the initial one. Also, it is worth noting how existing `0x32 ORIGIN`, `0x33 CALLER`, `0x34 CALLVALUE` and `0x3a GASPRICE` opcodes set a pattern of having access to both the transaction and current execution frame state.
 TBD: as 0x30 opcode range is exhausted, the proposed opcodes can be added to 0x50 range, or a new range can be added.
 
 ## Motivation
 <!--The motivation is critical for EIPs that want to change the Ethereum protocol. It should clearly explain why the existing protocol specification is inadequate to address the problem that the EIP solves. EIP submissions without sufficient motivation may be rejected outright.-->
-As concepts of relaying, meta-transactions, gas fees and account abstraction gain popularity, it becomes critical for some contracts to be able to track gas expenditure with absolute precision. Without access to this data on an EVM level, such contracts resort to approximation, mimicking EVM logic on chain, and some use-cases even become infeasible.
+As concepts of relaying, meta-transactions, gas fees, and account abstraction gain popularity, it becomes critical for some contracts to be able to track gas expenditure with absolute precision. Without access to this data on an EVM level, such contracts resort to approximation, mimicking EVM logic on-chain, and some use-cases even become infeasible.
 
 ## Specification
-<!--The technical specification should describe the syntax and semantics of any new feature. The specification should be detailed enough to allow competing, interoperable implementations for any of the current Ethereum platforms (go-ethereum, parity, cpp-ethereum, ethereumj, ethereumjs, and [others](https://github.com/ethereum/wiki/wiki/Clients)).-->
-
 If block.number >= TBD, add three new opcodes:
 
 TXGASLIMIT: 0x5c
 
-Pushes the gas limit of the entire transaction onto the stack. Gas costs: 2 (same as `GASLIMIT`)
+Pushes the gas limit of the entire transaction onto the stack. This is a value of the 'startgas' parameter signed by the externally owned account.    
+Gas costs: 2 (same as `GASLIMIT`)
 
 CALLGASLIMIT: 0x5d
 
-Pushes the gas limit of the current execution frame onto the stack. Gas costs: 2 (same as `GASLIMIT`)
-
-TXGASREFUND: 0x5e
-
-Pushes the value of the gas refund counter of the entire transaction onto the stack. Gas costs: 2 (same as `GASLIMIT`)
+Pushes the gas limit of the current execution frame onto the stack. This is the 'callGas' value that was obtained after the application of the EIP-150 “all but one 64th” rule.  
+Gas costs: 2 (same as `GASLIMIT`)
 
 Also, consider renaming `0x45 GASLIMIT` to `BLOCKGASLIMIT` to avoid confusion.
 
 ## Rationale
 <!--The rationale fleshes out the specification by describing what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work, e.g. how the feature is supported in other languages. The rationale may also provide evidence of consensus within the community, and should discuss important objections or concerns raised during discussion.-->
-Consider a solidity smart contract that wants to emit an event like that: 
-```
-event MyEvent(gasUsed, gasRefunded);
-```
-
-It is absolutely not possible with the current EVM. With a proposed changes, using a pseudo-Solidity syntax, this information would be easily available:
+Consider a solidity smart contract that wants to know how much gas the entire transaction or a part of it had consumed. It is not entirely possible with the current EVM. With proposed changes, using a pseudo-Solidity syntax, this information would be easily available:
 ```
 function keepTrackOfGas(string memory message, uint256 number) public {
-	uint256 initRefundCounter = tx.gasRefund;
-	this.storageNumber = number;
-	emit MyEvent(tx.gasLimit - gasleft(), initRefundCounter - tx.gasRefund);
+    ...
+    uint gasUsed = msg.gasLimit - gasleft();
 }
 ```
-The state-of-the-art solution, at least for the `gasUsed` problem, is to access 'gasleft()' as the first line of your smart contract, but it can only provide some part of the expenses. Note how variable transaction input size means the gas used by the transaction depends on number of zero and non-zero bytes of input, as well `GTXDATANONZERO`. Another issue is that Solidity handles `public` methods by loading the entire input from `calldata` to `memory`, spending an unpredictable amount of gas. And, obviously, gas refund counter is completely unavailble.
+This is an extremely common use case, and multiple implementations suffer from not taking the non-accessible expenses into consideration. The state-of-the-art solution for the `gasUsed` problem is to access 'gasleft()' as the first line of your smart contract.  
+Note how variable transaction input size means the gas used by the transaction depends on the number of zero and non-zero bytes of input, as well `GTXDATANONZERO`. Another issue is that Solidity handles `public` methods by loading the entire input from `calldata` to `memory`, spending an unpredictable amount of gas.
+
+Another application is for a method to have a requirement for a gas limit given to it. This situation arises quite commonly in the context of meta-transactions, where the msg.sender's account holder may not be too interested in the inner transaction's success. Exaggerated pseudocode:
+
+```
+function verifyGasLimit(uint256 desiredGasLimit, bytes memory signature, address signer, bytes memory someOtherData) public {
+    require(ecrecover(abi.encodePacked(desiredGasLimit, someOtherData), signature) == signer, "Signature does not match");
+    require(tx.gasLimit == desiredGasLimit, "Transaction limit does not match the signed value. The signer did not authorize that.");
+    ...
+}
+``` 
+In this situation it is not possible to rely on 'gasleft()' value, because it is dynamic, depends on opcode and calldata pricing, and cannot be signed.
+
 
 ## Backwards Compatibility
-<!--All EIPs that introduce backwards incompatibilities must include a section describing these incompatibilities and their severity. The EIP must explain how the author proposes to deal with these incompatibilities. EIP submissions without a sufficient backwards compatibility treatise may be rejected outright.-->
-This proposal introduces three new opcodes and renames an existing one, but stays fully backwards compatible apart from that.
+This proposal introduces two new opcodes and renames an existing one, but stays fully backwards compatible apart from that.
+
+## Forwards Compatibility
+A major consideration for this proposal is its alignment with one or many possible future modifications to the EVM:
+
+1. EIP-2489 Deprecate the GAS opcode (a.k.a. 39-UNGAS proposal)  
+ There is a sentiment that the ability of smart contracts to perform "gas introspection" leads to the contracts being dependent on current opcode pricing.  
+ While criticizing said misconception is beyond the scope of this EIP, in case there is a need to make a breaking change to the behavior of the existing `0x5a GAS` opcode, the same considerations will apply to the proposed opcodes. This means this EIP does not add any new restraints on EMV evolution.
+ 
+2. Stateless Ethereum  
+ The UNGAS proposal is said to be related to the ongoing project of Stateless Ethereum. It’s not strictly necessary for stateless Ethereum, but it is an idea for how to make future breaking changes to gas schedules easier.  
+ As long as the concept of 'gas limit' is part of the EVM, the author sees no reason proposed opcodes would conflict with Stateless Ethereum. Gas schedules are not exposed by this proposal.
+ 
+3. Comparison with other controversial opcodes   
+ There are opcodes that are not proposed for deprecation but face criticism. Examples include `0x32 ORIGIN` being misused by smart contract developers, or `0x46 CHAINID` making some smart-contracts 'unforkable'.  
+ This EIP neither encourages nor enables any bad security practices, and does not introduce any concepts that are new for EVM either.  
+  
+## Security considerations 
+
+Existing smart contracts are not affected by this change.  
+Smart contracts that will use proposed opcodes must not use them for the core of any security features, but only as a source of information about their execution environment.
 
 ## Implementation
 <!--The implementations must be completed before any EIP is given status "Final", but it need not be completed before the EIP is accepted. While there is merit to the approach of reaching consensus on the specification and rationale before writing code, the principle of "rough consensus and running code" is still useful when it comes to resolving many discussions of API details.-->

--- a/EIPS/eip-2542.md
+++ b/EIPS/eip-2542.md
@@ -1,0 +1,72 @@
+---
+eip: 2542
+title: New opcodes TXGASLIMIT, CALLGASLIMIT, TXGASREFUND
+author: Alex Forshtat <forshtat1@gmail.com>
+discussions-to: https://ethereum-magicians.org/t/eip-2542-add-txgaslimit-callgaslimit-txgasrefund-opcodes
+status: Draft
+type: Standards Track
+category: Core
+created: 2020-02-29
+---
+
+<!--You can leave these HTML comments in your merged EIP and delete the visible duplicate text guides, they will not appear and may be helpful to refer to if you edit it again. This is the suggested template for new EIPs. Note that an EIP number will be assigned by an editor. When opening a pull request to submit your EIP, please use an abbreviated title in the filename, `eip-draft_title_abbrev.md`. The title should be 44 characters or less.-->
+
+## Simple Summary
+<!--"If you can't explain it simply, you don't understand it well enough." Provide a simplified and layman-accessible explanation of the EIP.-->
+A mechanism to allow smart contracts to access information on gas limits and gas refunds for the current transaction and execution frame.
+
+## Abstract
+<!--A short (~200 word) description of the technical issue being addressed.-->
+Currently, there is an existing opcode `0x45 GASLIMIT` that provides access to the block gas limit. While this information may be useful in some cases, it is probably not a value that smart contract developers may be concerned about. The opcode `0x5a GAS` provides the remaining gas, not the initial one. Also it is worth noting how existing `0x32 ORIGIN`, `0x33 CALLER`,`0x34 CALLVALUE` and `0x3a	GASPRICE` opcodes set a pattern of having access to both the transacition and current execution frame state.
+TBD: as 0x30 opcode range is exhausted, the proposed opcodes can be added to 0x50 range, or a new range can be added.
+
+## Motivation
+<!--The motivation is critical for EIPs that want to change the Ethereum protocol. It should clearly explain why the existing protocol specification is inadequate to address the problem that the EIP solves. EIP submissions without sufficient motivation may be rejected outright.-->
+As concepts of relaying, meta-transactions, gas fees and account abstraction gain popularity, it becomes critical for some contracts to be able to track gas expenditure with absolute precision. Without access to this data on an EVM level, such contracts resort to approximation, mimicking EVM logic on chain, and some use-cases even become infeasible.
+
+## Specification
+<!--The technical specification should describe the syntax and semantics of any new feature. The specification should be detailed enough to allow competing, interoperable implementations for any of the current Ethereum platforms (go-ethereum, parity, cpp-ethereum, ethereumj, ethereumjs, and [others](https://github.com/ethereum/wiki/wiki/Clients)).-->
+
+If block.number >= TBD, add three new opcodes:
+
+TXGASLIMIT: 0x5c
+
+Pushes the gas limit of the entire transaction onto the stack. Gas costs: 2 (same as `GASLIMIT`)
+
+CALLGASLIMIT: 0x5d
+
+Pushes the gas limit of the current execution frame onto the stack. Gas costs: 2 (same as `GASLIMIT`)
+
+TXGASREFUND: 0x5e
+
+Pushes the value of the gas refund counter of the entire transaction onto the stack. Gas costs: 2 (same as `GASLIMIT`)
+
+Also, consider renaming `0x45 GASLIMIT` to `BLOCKGASLIMIT` to avoid confusion.
+
+## Rationale
+<!--The rationale fleshes out the specification by describing what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work, e.g. how the feature is supported in other languages. The rationale may also provide evidence of consensus within the community, and should discuss important objections or concerns raised during discussion.-->
+Consider a solidity smart contract that wants to emit an event like that: 
+```
+event MyEvent(gasUsed, gasRefunded);
+```
+
+It is absolutely not possible with the current EVM. With a proposed changes, using a pseudo-Solidity syntax, this information would be easily available:
+```
+function keepTrackOfGas(string memory message, uint256 number) public {
+	uint256 initRefundCounter = tx.gasRefund;
+	this.storageNumber = number;
+	emit MyEvent(tx.gasLimit - gasleft(), initRefundCounter - tx.gasRefund);
+}
+```
+The state-of-the-art solution, at least for the `gasUsed` problem, is to access 'gasleft()' as the first line of your smart contract, but it can only provide some part of the expenses. Note how variable transaction input size means the gas used by the transaction depends on number of zero and non-zero bytes of input, as well `GTXDATANONZERO`. Another issue is that Solidity handles `public` methods by loading the entire input from `calldata` to `memory`, spending an unpredictable amount of gas. And, obviously, gas refund counter is completely unavailble.
+
+## Backwards Compatibility
+<!--All EIPs that introduce backwards incompatibilities must include a section describing these incompatibilities and their severity. The EIP must explain how the author proposes to deal with these incompatibilities. EIP submissions without a sufficient backwards compatibility treatise may be rejected outright.-->
+This proposal introduces three new opcodes and renames an existing one, but stays fully backwards compatible apart from that.
+
+## Implementation
+<!--The implementations must be completed before any EIP is given status "Final", but it need not be completed before the EIP is accepted. While there is merit to the approach of reaching consensus on the specification and rationale before writing code, the principle of "rough consensus and running code" is still useful when it comes to resolving many discussions of API details.-->
+The implementations must be completed before any EIP is given status "Final", but it need not be completed before the EIP is accepted. While there is merit to the approach of reaching consensus on the specification and rationale before writing code, the principle of "rough consensus and running code" is still useful when it comes to resolving many discussions of API details.
+
+## Copyright
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
During our work on the Gas Station Network we have encountered a problem with the way such concepts as gas limit and gas refund are somewhat hidden from smart contracts. With the current EVM, the core GSN smart contract (RelayHub) is not able to precisely track the gas usage by a transaction due to these limitations.

Exposing such parameters as transaction gas limit, current execution frame gas limit, and current refund counter is an extremely simple and useful improvement to the EVM.