### PR TITLE
Abandon EIP-1706

### DIFF
--- a/EIPS/eip-1706.md
+++ b/EIPS/eip-1706.md
@@ -3,12 +3,14 @@ eip: 1706
 title: Disable SSTORE with gasleft lower than call stipend
 author: Alex Forshtat <alex@tabookey.com>, Yoav Weiss <yoav@tabookey.com>
 discussions-to: https://github.com/alex-forshtat-tbk/EIPs/issues/1
-status: Draft
+status: Superseded
 type: Standards Track
 category: Core
 created: 2019-01-15
 requires: 1283
+superseded-by: 2200
 ---
+> :information_source: **[EIP2200] has superseded [EIP1706].** :information_source:
 
 <!--You can leave these HTML comments in your merged EIP and delete the visible duplicate text guides, they will not appear and may be helpful to refer to if you edit it again. This is the suggested template for new EIPs. Note that an EIP number will be assigned by an editor. When opening a pull request to submit your EIP, please use an abbreviated title in the filename, `eip-draft_title_abbrev.md`. The title should be 44 characters or less.-->
 

--- a/EIPS/eip-1706.md
+++ b/EIPS/eip-1706.md
@@ -3,7 +3,7 @@ eip: 1706
 title: Disable SSTORE with gasleft lower than call stipend
 author: Alex Forshtat <alex@tabookey.com>, Yoav Weiss <yoav@tabookey.com>
 discussions-to: https://github.com/alex-forshtat-tbk/EIPs/issues/1
-status: Superseded
+status: Abandoned
 type: Standards Track
 category: Core
 created: 2019-01-15


### PR DESCRIPTION
While 1706 was never 'final' on its own, I think keeping it as 'draft', or marking it 'abandoned' or 'rejected' creates a false perception that the logic specified in it never made it to the EVM. 

EIP-2200 explicitly states it includes all provisions of this EIP word-by-word.
