### PR TITLE
Updated parameter names

### DIFF
--- a/EIPS/eip-1753.md
+++ b/EIPS/eip-1753.md
@@ -83,7 +83,7 @@ function hasAuthority(address who)
 Issues an ethereum address a permit between the specified date range.
 
 ``` js
-function issue(address who, uint256 from, uint256 to) public;
+function issue(address who, uint256 validFrom, uint256 validTo) public;
 ```
 
 #### revoke
@@ -178,7 +178,7 @@ interface EIP1753 {
 	function revoke(address who) public;
 	
 	function hasValid(address who) public view returns (boolean);
-	function purchase(uint256 from, uint256 to) public payable;
+	function purchase(uint256 validFrom, uint256 validTo) public payable;
 }
 
 pragma solidity ^0.5.3;
@@ -194,8 +194,8 @@ contract EIP is EIP1753 {
 	
 	struct Permit {
 		address issuer;
-		uint256 start;
-		uint256 end;
+		uint256 validFrom;
+		uint256 validTo;
 	}
 	
 	constructor() public {
@@ -227,7 +227,7 @@ contract EIP is EIP1753 {
 	    return _holders[who].start > now && _holders[who].end < now;
 	}
 
-	function purchase(uint256 from, uint256 to) public payable {
+	function purchase(uint256 validFrom, uint256 validTo) public payable {
 	    require(msg.value == 1 ether, "Incorrect fee");
 	    issue(msg.sender, from, to);
 	}


### PR DESCRIPTION
Parameter names to be line with naming convention on EIP-1812.  By aligning with this EIP, there could be a use case for inheriting 1812 stregthening both EIPs. https://eips.ethereum.org/EIPS/eip-1812
