### PR TITLE
Update username in EIP-1319

### DIFF
--- a/EIPS/eip-1319.md
+++ b/EIPS/eip-1319.md
@@ -1,7 +1,7 @@
 ---
 eip: 1319
 title: Smart Contract Package Registry Interface
-author: Piper Merriam <piper@ethereum.org>, Christopher Gewecke <christophergewecke@gmail.com>, g. nicholas d'andrea <nick.dandrea@consensys.net>, Nick Gheorghita <nickg@ethereum.org>
+author: Piper Merriam <piper@ethereum.org>, Christopher Gewecke <christophergewecke@gmail.com>, g. nicholas d'andrea <nick.dandrea@consensys.net>, Nick Gheorghita (@njgheorghita)
 type: Standards Track
 category: ERC
 status: Draft


### PR DESCRIPTION
Added the specification for ethPM uris. They've been an effective solution for handling packages so far - and are already implemented in the `ethpm-cli` and `Brownie`, and are also outlined in the [documentation](https://docs.ethpm.com/uris#registry-uris).