### PR TITLE
EIPs: Fix typo on eip-1193.md

### DIFF
--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -176,7 +176,7 @@ ethereum.on('close', (code, reason) => {
 
 ### Errors
 
-If the Ethereum Provider request returns an error property then the Promise **MUST** reject with an Error object containing the `error.message` as the Error message, `error.code` as a code property on the error and `error.data` as a data property on the error.
+If the Ethereum Provider request returns an error property then the Promise **MUST** reject with an `Error` object containing the `error.message` as the Error message, `error.code` as a code property on the error and `error.data` as a data property on the error.
 
 If an error occurs during processing, such as an HTTP error or internal parsing error, then the Promise **MUST** reject with an `Error` object.
 


### PR DESCRIPTION
Fix typo; putting `Error` in backticks for consistency.

When opening a pull request to submit a new EIP, please use the suggested template: https://github.com/ethereum/EIPs/blob/master/eip-template.md

We have a GitHub bot that automatically merges some PRs. It will merge yours immediately if certain criteria are met:

 - The PR edits only existing draft PRs.
 - The build passes.
 - Your GitHub username or email address is listed in the 'author' header of all affected PRs, inside <triangular brackets>.
 - If matching on email address, the email address is the one publicly listed on your GitHub profile.
