### PR TITLE
Update EIP 1193

### DIFF
--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -88,25 +88,6 @@ ethereum.send(...args: Array<any>): unknown;
 
 Events follow the [Node.js `EventEmitter`](https://nodejs.org/api/events.html) API.
 
-#### notification
-
-The Provider emits `notification` upon receipt of a notification.
-Notifications may include JSON-RPC notifications, GraphQL subscriptions, and/or any other event that the Provider decides to treat as a notification.
-
-```typescript
-interface ProviderNotification {
-  type: string;
-  data: unknown;
-}
-
-ethereum.on('notification', listener: (notification: ProviderNotification) => void): ethereum;
-```
-
-##### Subscriptions
-
-Some clients like [Geth](https://geth.ethereum.org/docs/rpc/pubsub) and [Parity](https://wiki.parity.io/JSONRPC-eth_pubsub-module) support Publish-Subscribe (_Pub-Sub_) using JSON-RPC notifications. This lets you subscribe and wait for events instead of polling for them.
-See the [`eth_` subscription methods](https://geth.ethereum.org/docs/rpc/pubsub) and [`shh_` subscription methods](https://github.com/ethereum/go-ethereum/wiki/Whisper-v6-RPC-API#shh_subscribe) for details.
-
 #### connect
 
 The Provider emits `connect` when it:
@@ -158,6 +139,33 @@ ethereum.on('accountsChanged', listener: (accounts: Array<string>) => void): eth
 ```
 
 The event emits with `accounts`, an array of account addresses, per the `eth_accounts` Ethereum RPC method.
+
+#### message
+
+The Provider emits `message` to communicate arbitrary messages to the consumer.
+Messages may include JSON-RPC notifications, GraphQL subscriptions, and/or any other event as defined by the Provider.
+
+```typescript
+interface ProviderMessage {
+  type: string;
+  data: unknown;
+}
+
+ethereum.on('message', listener: (notification: ProviderMessage) => void): Provider;
+```
+
+##### Subscriptions
+
+Some clients like [Geth](https://geth.ethereum.org/docs/rpc/pubsub) and [Parity](https://wiki.parity.io/JSONRPC-eth_pubsub-module) support Publish-Subscribe (_Pub-Sub_) using JSON-RPC notifications. This lets you subscribe and wait for events instead of polling for them.
+See the [`eth_` subscription methods](https://geth.ethereum.org/docs/rpc/pubsub) and [`shh_` subscription methods](https://github.com/ethereum/go-ethereum/wiki/Whisper-v6-RPC-API#shh_subscribe) for details.
+
+For e.g. `eth_subscribe` subscription updates, `ProviderMessage.type` will equal the string `'eth_subscription'`.
+
+#### notification (DEPRECATED)
+
+This event should not be relied upon, and may not be implemented.
+
+Historically, it has returned e.g. `eth_subscribe` subscription updates of the form `{ subscription: string, result: unknown }`.
 
 ## Examples
 
@@ -354,27 +362,27 @@ interface ProviderRpcError extends Error {
 
 The Provider **SHOULD** extend the [Node.js `EventEmitter`](https://nodejs.org/api/events.html) to provide dapps flexibility in listening to events. In place of full `EventEmitter` functionality, the Provider **MAY** provide as many methods as it can reasonably provide, but **MUST** provide at least `on`, `emit`, and `removeListener`.
 
-#### notification
+#### message
 
-The Provider **MAY** emit the event named `notification`, for any reason.
+The Provider **MAY** emit the event named `message`, for any reason.
 
-If the Provider supports subscriptions, e.g. [`eth_subscribe`](https://geth.ethereum.org/docs/rpc/pubsub), the Provider **MUST** emit the `notification` event when it receives a subscription notification.
+If the Provider supports Ethereum RPC subscriptions, e.g. [`eth_subscribe`](https://geth.ethereum.org/docs/rpc/pubsub), the Provider **MUST** emit the `message` event when it receives a subscription notification.
 
-When emitted, the `notification` event **MUST** be emitted with an object argument of the following form:
+When emitted, the `message` event **MUST** be emitted with an object argument of the following form:
 
 ```typescript
-interface ProviderNotification {
+interface ProviderMessage {
   type: string;
   data: unknown;
 }
 ```
 
-##### Converting a Subscription Message to a Notification
+##### Converting a Subscription Message to a ProviderMessage
 
-If the Provider receives a subscription message from e.g. an `eth_subscribe` subscription, the Provider **MUST** emit a `notification` event with a `ProviderNotification` object of the following form:
+If the Provider receives a subscription message from e.g. an `eth_subscribe` subscription, the Provider **MUST** emit a `message` event with a `ProviderMessage` object of the following form:
 
 ```typescript
-interface EthSubscription extends ProviderNotification {
+interface EthSubscription extends ProviderMessage {
   type: 'eth_subscription';
   data: {
     subscription: string;

--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -16,7 +16,7 @@ This EIP formalizes a JavaScript Ethereum Provider API for consistency across cl
 
 The Provider is intended to be available as `globalThis.ethereum` (i.e. `window.ethereum` in browsers), so that JavaScript dapps can be written once and function in perpetuity.
 
-The Provider's interface is designed to be minimal, preferring for features to be introduced in the API layer (e.g. see [`eth_requestAccounts`](https://eips.ethereum.org/EIPS/eip-1102)), and agnostic of any particular transport protocol.
+The Provider's interface is designed to be minimal, preferring for features to be introduced in the API layer (e.g. see [`eth_requestAccounts`](https://eips.ethereum.org/EIPS/eip-1102)), and agnostic of transport and RPC protocols.
 
 Events are provided to enable reactive dapp UIs.
 
@@ -55,9 +55,9 @@ The Promise rejects with errors of the following form:
 
 See the [RPC Errors](#rpc-errors) section for more details.
 
-#### Transports
+#### RPC Protocols
 
-Multiple transports may be available.
+Multiple RPC protocols may be available.
 
 [EIP 1474](https://eips.ethereum.org/EIPS/eip-1474) specifies the Ethereum JSON-RPC API.
 
@@ -291,14 +291,14 @@ type RequestParams = Array<any> | { [key: string]: any };
 ethereum.request(method: string, params?: RequestParams): Promise<unknown>;
 ```
 
-The `request` method is intended as a transport-agnostic wrapper function for Remote Procedure Calls (RPCs).
+The `request` method is intended as a transport- and protocol-agnostic wrapper function for Remote Procedure Calls (RPCs).
 
 The `request` method **MUST** send a properly formatted request to the Provider's Ethereum client.
 Requests **MUST** be handled such that, for a given set of arguments, the returned Promise either resolves a value per the RPC method's specification, or rejects with an error.
 
 If present, the `params` argument **MUST** be structured value, either by-position as an `Array` or by-name as an `Object`.
 
-If resolved, the Promise **MUST NOT** resolve any transport-specific response objects, unless the RPC method's return type is so defined by its specification.
+If resolved, the Promise **MUST NOT** resolve any RPC protocol-specific response objects, unless the RPC method's return type is so defined by its specification.
 
 If resolved, the Promise **MUST** resolve a result per the RPC method's specification.
 

--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -18,7 +18,7 @@ The Provider is intended to be available as `globalThis.ethereum` (i.e. `window.
 
 The Provider's interface is designed to be minimal, preferring for features to be introduced in the API layer (e.g. see [`eth_requestAccounts`](https://eips.ethereum.org/EIPS/eip-1102)), and agnostic of transport and RPC protocols.
 
-Events are provided to enable reactive dapp UIs.
+The events `connect`, `close`, `chainChanged`, and `accountsChanged` are provided as a convenience to help enable reactive dapp UIs.
 
 ## API
 
@@ -434,8 +434,7 @@ The "accounts available to the Provider" change when the return value of the `et
 
 - [Initial discussion in `ethereum/interfaces`](https://github.com/ethereum/interfaces/issues/16)
 - [Ethereum Magicians thread](https://ethereum-magicians.org/t/eip-1193-ethereum-provider-javascript-api/640)
-- [EIP 1474](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1474.md)
-- [EIP 695](https://eips.ethereum.org/EIPS/eip-695.md)
+- [Continuing EIP-1193 discussion](https://github.com/ethereum/EIPs/issues/2319)
 
 ## Copyright
 

--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -213,22 +213,15 @@ ethereum
 ethereum
   .request('eth_subscribe', ['newHeads'])
   .then(subscriptionId => {
-
     ethereum.on('notification', notification => {
-
-      if (notification.method === 'eth_subscription') {
-
-        const { params } = notification;
-
-        if (params.subscription === subscriptionId) {
-
-          if (typeof params.result === 'string' && params.result) {
-
-            const block = params.result;
+      if (notification.type === 'eth_subscription') {
+        const { data } = notification;
+        if (data.subscription === subscriptionId) {
+          if (typeof data.result === 'string' && data.result) {
+            const block = data.result;
             console.log(`New block ${block.number}:`, block);
-
           } else {
-            console.error(`Something went wrong: ${params.result}`);
+            console.error(`Something went wrong: ${data.result}`);
           }
         }
       }

--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -97,14 +97,14 @@ The Provider emits `connect` when it becomes connected. This includes:
 
 ```typescript
 interface ConnectInfo {
-  chainId: number,
+  chainId: string,
   ...props?: Array<unknown>
 }
 
 ethereum.on('connect', listener: (connectInfo: ConnectInfo) => void): ethereum;
 ```
 
-The event emits an object with a `chainId` property per the `eth_chainId` Ethereum JSON-RPC method, and other properties as determined by the Provider.
+The event emits an object with a hexadecimal string `chainId` per the `eth_chainId` Ethereum JSON-RPC method, and other properties as determined by the Provider.
 
 #### close
 
@@ -121,10 +121,10 @@ This event emits with `code` and `reason`. The code follows the table of [`Close
 The Provider emits `chainChanged` when connecting to a new chain.
 
 ```typescript
-ethereum.on('chainChanged', listener: (chainId: number) => void): ethereum;
+ethereum.on('chainChanged', listener: (chainId: string) => void): ethereum;
 ```
 
-The event emits an integer `chainId` per the `eth_chainId` Ethereum JSON-RPC method.
+The event emits a hexadecimal string `chainId` per the `eth_chainId` Ethereum JSON-RPC method.
 
 #### networkChanged (DEPRECATED)
 
@@ -150,7 +150,18 @@ var web3 = new Web3(ethereum);
 // web3.eth.getBlock('latest', true).then(...)
 
 // B) Use Provider object directly
-// Example 1: Log last block
+// Example 1: Log chainId
+ethereum
+  .request('eth_chainId)
+  .then(chainId => {
+    console.log(`hexadecimal string: ${chainId}`);
+    console.log(`decimal number: ${parseInt(chainId, 16)}`);
+  })
+  .catch(error => {
+    console.error(`Error fetching chainId: ${error.code}: ${error.message}`);
+  })
+
+// Example 2: Log last block
 ethereum
   .request('eth_getBlockByNumber', ['latest', 'true'])
   .then(block => {
@@ -163,7 +174,7 @@ ethereum
     );
   });
 
-// Example 2: Log available accounts
+// Example 3: Log available accounts
 ethereum
   .request('eth_accounts')
   .then(accounts => {
@@ -176,7 +187,7 @@ ethereum
     );
   });
 
-// Example 3: Log new blocks
+// Example 4: Log new blocks
 ethereum
   .request('eth_subscribe', ['newHeads'])
   .then(subscriptionId => {
@@ -208,7 +219,7 @@ ethereum
     );
   });
 
-// Example 4: Log when accounts change
+// Example 5: Log when accounts change
 const logAccounts = accounts => {
   console.log(`Accounts:\n${accounts.join('\n')}`);
 };
@@ -216,7 +227,7 @@ ethereum.on('accountsChanged', logAccounts);
 // to unsubscribe
 ethereum.removeListener('accountsChanged', logAccounts);
 
-// Example 5: Log if connection ends
+// Example 6: Log if connection ends
 ethereum.on('close', (code, reason) => {
   console.log(`Ethereum Provider connection closed: ${reason}. Code: ${code}`);
 });
@@ -341,12 +352,12 @@ This event **MUST** be emitted with an object of the following form:
 
 ```typescript
 interface ConnectInfo {
-  chainId: number,
+  chainId: string,
   ...props?: Array<unknown>
 }
 ```
 
-`chainId` **MUST** specify the integer ID of the connected chain, the [`eth_chainId`](https://eips.ethereum.org/EIPS/eip-695) Ethereum JSON-RPC method.
+`chainId` **MUST** specify the integer ID of the connected chain as a hexadecimal string, per the [`eth_chainId`](https://eips.ethereum.org/EIPS/eip-695) Ethereum JSON-RPC method.
 
 #### close
 
@@ -354,7 +365,7 @@ If the Provider becomes disconnected from all chains, the Provider **MUST** emit
 
 #### chainChanged
 
-If the chain the Provider is connected to changes, the Provider **MUST** emit an event named `chainChanged` with argument `chainId: number`, specifying the integer ID of the new chain, per the [`eth_chainId`](https://eips.ethereum.org/EIPS/eip-695) Ethereum JSON-RPC method.
+If the chain the Provider is connected to changes, the Provider **MUST** emit an event named `chainChanged` with argument `chainId: string`, specifying the integer ID of the new chain as a hexadecimal string, per the [`eth_chainId`](https://eips.ethereum.org/EIPS/eip-695) Ethereum JSON-RPC method.
 
 #### accountsChanged
 

--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -117,7 +117,7 @@ The Provider emits `connect` when it becomes connected. This includes:
 ```typescript
 interface ProviderConnectInfo {
   chainId: string;
-  ...props?: Array<unknown;
+  [key: string]: unknown;
 }
 
 ethereum.on('connect', listener: (connectInfo: ProviderConnectInfo) => void): ethereum;
@@ -402,7 +402,7 @@ This event **MUST** be emitted with an object of the following form:
 ```typescript
 interface ProviderConnectInfo {
   chainId: string;
-  ...props?: Array<unknown>;
+  [key: string]: unknown;
 }
 ```
 

--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -36,7 +36,7 @@ The Promise resolves the method's result or rejects with an `Error`. For example
 
 ```javascript
 ethereum
-  .request("eth_accounts")
+  .request('eth_accounts')
   .then((accounts) => console.log(accounts))
   .catch((error) => console.error(error));
 ```
@@ -171,7 +171,7 @@ var web3 = new Web3(ethereum);
 // B) Use Provider object directly
 // Example 1: Log chainId
 ethereum
-  .request("eth_chainId")
+  .request('eth_chainId')
   .then((chainId) => {
     console.log(`hexadecimal string: ${chainId}`);
     console.log(`decimal number: ${parseInt(chainId, 16)}`);
@@ -182,7 +182,7 @@ ethereum
 
 // Example 2: Log last block
 ethereum
-  .request("eth_getBlockByNumber", ["latest", "true"])
+  .request('eth_getBlockByNumber', ['latest', 'true'])
   .then((block) => {
     console.log(`Block ${block.number}:`, block);
   })
@@ -195,9 +195,9 @@ ethereum
 
 // Example 3: Log available accounts
 ethereum
-  .request("eth_accounts")
+  .request('eth_accounts')
   .then((accounts) => {
-    console.log(`Accounts:\n${accounts.join("\n")}`);
+    console.log(`Accounts:\n${accounts.join('\n')}`);
   })
   .catch((error) => {
     console.error(
@@ -208,13 +208,13 @@ ethereum
 
 // Example 4: Log new blocks
 ethereum
-  .request("eth_subscribe", ["newHeads"])
+  .request('eth_subscribe', ['newHeads'])
   .then((subscriptionId) => {
-    ethereum.on("notification", (notification) => {
-      if (notification.type === "eth_subscription") {
+    ethereum.on('notification', (notification) => {
+      if (notification.type === 'eth_subscription') {
         const { data } = notification;
         if (data.subscription === subscriptionId) {
-          if (typeof data.result === "string" && data.result) {
+          if (typeof data.result === 'string' && data.result) {
             const block = data.result;
             console.log(`New block ${block.number}:`, block);
           } else {
@@ -233,14 +233,14 @@ ethereum
 
 // Example 5: Log when accounts change
 const logAccounts = (accounts) => {
-  console.log(`Accounts:\n${accounts.join("\n")}`);
+  console.log(`Accounts:\n${accounts.join('\n')}`);
 };
-ethereum.on("accountsChanged", logAccounts);
+ethereum.on('accountsChanged', logAccounts);
 // to unsubscribe
-ethereum.removeListener("accountsChanged", logAccounts);
+ethereum.removeListener('accountsChanged', logAccounts);
 
 // Example 6: Log if connection ends
-ethereum.on("close", (code, reason) => {
+ethereum.on('close', (code, reason) => {
   console.log(`Ethereum Provider connection closed: ${reason}. Code: ${code}`);
 });
 ```
@@ -375,7 +375,7 @@ If the Provider receives a subscription message from e.g. an `eth_subscribe` sub
 
 ```typescript
 interface EthSubscription extends ProviderNotification {
-  type: "eth_subscription";
+  type: 'eth_subscription';
   data: {
     subscription: string;
     result: any;

--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -24,7 +24,7 @@ Events are provided to enable reactive dapp UIs.
 
 ### request
 
-Makes an Ethereum API method call.
+Makes an Ethereum RPC method call.
 
 ```typescript
 type RequestParams = Array<any> | { [key: string]: any };
@@ -40,7 +40,7 @@ ethereum.request('eth_accounts')
 .catch(error => console.error(error))
 ```
 
-Consult each Ethereum API method's documentation for its return type.
+Consult each Ethereum RPC method's documentation for its return type.
 You can find a list of common methods [here](https://eips.ethereum.org/EIPS/eip-1474).
 
 The Promise rejects with errors of the following form:

--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -14,7 +14,7 @@ requires: 155, 695, 1102, 1474, 1767
 
 This EIP formalizes a JavaScript Ethereum Provider API for consistency across clients and applications.
 
-The Provider is intended to be available as `globalThis.ethereum` (`window.ethereum` in browsers), so that JavaScript dapps can be written once and function in perpetuity.
+The Provider is intended to be available as `globalThis.ethereum` (i.e. `window.ethereum` in browsers), so that JavaScript dapps can be written once and function in perpetuity.
 
 The Provider's interface is designed to be minimal, preferring for features to be introduced in the API layer (e.g. see [`eth_requestAccounts`](https://eips.ethereum.org/EIPS/eip-1102)), and agnostic of any particular transport protocol.
 

--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -16,7 +16,7 @@ This EIP formalizes a JavaScript Ethereum Provider API for consistency across cl
 
 The Provider is intended to be available as `globalThis.ethereum` (i.e. `window.ethereum` in browsers), so that JavaScript dapps can be written once and function in perpetuity.
 
-The Provider's interface is designed to be minimal, preferring for features to be introduced in the API layer (e.g. see [`eth_requestAccounts`](https://eips.ethereum.org/EIPS/eip-1102)), and agnostic of transport and RPC protocols.
+The Provider's interface is designed to be minimal, preferring that features are introduced in the API layer (e.g. see [`eth_requestAccounts`](https://eips.ethereum.org/EIPS/eip-1102)), and agnostic of transport and RPC protocols.
 
 The events `connect`, `close`, `chainChanged`, and `accountsChanged` are provided as a convenience to help enable reactive dapp UIs.
 
@@ -91,7 +91,7 @@ Events follow the [Node.js `EventEmitter`](https://nodejs.org/api/events.html) A
 #### notification
 
 The Provider emits `notification` upon receipt of a notification.
-Notifications may include JSON-RPC notifications, GraphQL subscriptions, or any other event that the Provider decides to treat as a notification.
+Notifications may include JSON-RPC notifications, GraphQL subscriptions, and/or any other event that the Provider decides to treat as a notification.
 
 ```typescript
 interface ProviderNotification {
@@ -109,10 +109,10 @@ See the [`eth_` subscription methods](https://geth.ethereum.org/docs/rpc/pubsub)
 
 #### connect
 
-The Provider emits `connect` when it becomes connected. This includes:
+The Provider emits `connect` when it:
 
-- when the Provider first connects to a chain after being initialized
-- when the Provider connects to a chain, after the `close` event was emitted
+- first connects to a chain after being initialized.
+- first connects to a chain, after the `close` event was emitted.
 
 ```typescript
 interface ProviderConnectInfo {
@@ -157,7 +157,7 @@ The Provider emits `accountsChanged` if the accounts returned from the Provider 
 ethereum.on('accountsChanged', listener: (accounts: Array<string>) => void): ethereum;
 ```
 
-The event emits with `accounts`, an array of account addresses.
+The event emits with `accounts`, an array of account addresses, per the `eth_accounts` Ethereum RPC method.
 
 ## Examples
 
@@ -390,12 +390,12 @@ interface EthSubscription extends ProviderNotification {
 
 #### connect
 
-If the Provider becomes connected to a chain, the Provider **MUST** emit the event named `connect`.
+If the Provider becomes connected, the Provider **MUST** emit the event named `connect`.
 
 The Provider "becomes connected" when:
 
-- it first connects to a chain after initialization
-- it connects to a chain after the `close` event was emitted
+- it first connects to a chain after initialization.
+- it connects to a chain after the `close` event was emitted.
 
 This event **MUST** be emitted with an object of the following form:
 
@@ -420,9 +420,9 @@ If the chain the Provider is connected to changes, the Provider **MUST** emit th
 
 #### accountsChanged
 
-If the accounts available to the Provider change, the Provider **MUST** emit the event named `accountsChanged` with value `accounts: Array<string>`, containing the account addresses.
+If the accounts available to the Provider change, the Provider **MUST** emit the event named `accountsChanged` with value `accounts: Array<string>`, containing the account addresses per the `eth_accounts` Ethereum RPC method.
 
-The "accounts available to the Provider" change when the return value of the `eth_accounts` Ethereum RPC method changes.
+The "accounts available to the Provider" change when the return value of `eth_accounts` changes.
 
 ## References
 

--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -32,7 +32,7 @@ type RequestParams = Array<any> | { [key: string]: any };
 ethereum.request(method: string, params?: RequestParams): Promise<unknown>;
 ```
 
-The Promise resolves the method's result or rejects with an `Error`. For example:
+The Promise resolves with the method's result or rejects with an `Error`. For example:
 
 ```javascript
 ethereum
@@ -291,13 +291,13 @@ ethereum.request(method: string, params?: RequestParams): Promise<unknown>;
 The `request` method is intended as a transport- and protocol-agnostic wrapper function for Remote Procedure Calls (RPCs).
 
 The `request` method **MUST** send a properly formatted request to the Provider's Ethereum client.
-Requests **MUST** be handled such that, for a given set of arguments, the returned Promise either resolves a value per the RPC method's specification, or rejects with an error.
+Requests **MUST** be handled such that, for a given set of arguments, the returned Promise either resolves with a value per the RPC method's specification, or rejects with an error.
 
 If present, the `params` argument **MUST** be structured value, either by-position as an `Array` or by-name as an `Object`.
 
-If resolved, the Promise **MUST NOT** resolve any RPC protocol-specific response objects, unless the RPC method's return type is so defined by its specification.
+If resolved, the Promise **MUST NOT** resolve with any RPC protocol-specific response objects, unless the RPC method's return type is so defined by its specification.
 
-If resolved, the Promise **MUST** resolve a result per the RPC method's specification.
+If resolved, the Promise **MUST** resolve with a result per the RPC method's specification.
 
 If the returned Promise rejects, it **MUST** reject with an `Error` of the form specified in the [RPC Errors](#rpc-errors) section below.
 

--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -36,7 +36,7 @@ The Promise resolves the method's result or rejects with an `Error`. For example
 
 ```javascript
 ethereum
-  .request("eth_accounts")
+  .request('eth_accounts')
   .then((accounts) => console.log(accounts))
   .catch((error) => console.error(error));
 ```

--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -90,7 +90,7 @@ Events follow the [Node.js `EventEmitter`](https://nodejs.org/api/events.html) A
 #### notification
 
 The Provider emits `notification` upon receipt of a notification.
-Notifications include JSON-RPC notifications, GraphQL subscriptions, or any other event that the Provider chooses to treat as a notification.
+Notifications may include JSON-RPC notifications, GraphQL subscriptions, or any other event that the Provider decides to treat as a notification.
 
 ```typescript
 interface ProviderNotification {

--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -95,8 +95,8 @@ Notifications may include JSON-RPC notifications, GraphQL subscriptions, or any 
 
 ```typescript
 interface ProviderNotification {
-  type: string,
-  data: unknown,
+  type: string;
+  data: unknown;
 }
 
 ethereum.on('notification', listener: (notification: ProviderNotification) => void): ethereum;
@@ -116,8 +116,8 @@ The Provider emits `connect` when it becomes connected. This includes:
 
 ```typescript
 interface ProviderConnectInfo {
-  chainId: string,
-  ...props?: Array<unknown>
+  chainId: string;
+  ...props?: Array<unknown;
 }
 
 ethereum.on('connect', listener: (connectInfo: ProviderConnectInfo) => void): ethereum;
@@ -401,8 +401,8 @@ This event **MUST** be emitted with an object of the following form:
 
 ```typescript
 interface ProviderConnectInfo {
-  chainId: string,
-  ...props?: Array<unknown>
+  chainId: string;
+  ...props?: Array<unknown>;
 }
 ```
 

--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -34,10 +34,11 @@ ethereum.request(method: string, params?: RequestParams): Promise<unknown>;
 
 The Promise resolves the method's result or rejects with an `Error`. For example:
 
-```js
-ethereum.request('eth_accounts')
-.then(accounts => console.log(accounts))
-.catch(error => console.error(error))
+```javascript
+ethereum
+  .request("eth_accounts")
+  .then((accounts) => console.log(accounts))
+  .catch((error) => console.error(error));
 ```
 
 Consult each Ethereum RPC method's documentation for its return type.
@@ -160,7 +161,7 @@ The event emits with `accounts`, an array of account addresses.
 
 ## Examples
 
-```js
+```javascript
 const ethereum = window.ethereum;
 
 // A) Set Provider in web3.js
@@ -262,7 +263,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ### Definitions
 
->This section is non-normative.
+> This section is non-normative.
 
 - Provider
   - A JavaScript object made available to a dapp, that provides access to Ethereum by means of a Client
@@ -328,9 +329,9 @@ If an RPC method defined in a finalized EIP is not supported, it **SHOULD** be r
 
 ```typescript
 interface ProviderRpcError extends Error {
-  message: string,
-  code: number,
-  data?: any
+  message: string;
+  code: number;
+  data?: any;
 }
 ```
 
@@ -355,11 +356,11 @@ interface ProviderRpcError extends Error {
 
 #### Provider Errors
 
-| Status code | Name                         | Description                                                              |
-| ----------- | ---------------------------- | ------------------------------------------------------------------------ |
-| 4001        | User Rejected Request        | The user rejected the request.                                           |
-| 4100        | Unauthorized                 | The requested method and/or account has not been authorized by the user. |
-| 4200        | Unsupported Method           | The requested method is not supported by the given Ethereum Provider.    |
+| Status code | Name                  | Description                                                              |
+| ----------- | --------------------- | ------------------------------------------------------------------------ |
+| 4001        | User Rejected Request | The user rejected the request.                                           |
+| 4100        | Unauthorized          | The requested method and/or account has not been authorized by the user. |
+| 4200        | Unsupported Method    | The requested method is not supported by the given Ethereum Provider.    |
 
 ### Events
 
@@ -375,8 +376,8 @@ When emitted, the `notification` event **MUST** be emitted with an object argume
 
 ```typescript
 interface ProviderNotification {
-  type: string,
-  data: unknown,
+  type: string;
+  data: unknown;
 }
 ```
 
@@ -386,11 +387,11 @@ If the Provider receives a subscription message from e.g. an `eth_subscribe` sub
 
 ```typescript
 interface EthSubscription extends ProviderNotification {
-  type: 'eth_subscription',
+  type: "eth_subscription";
   data: {
-    subscription: string,
-    result: any,
-  }
+    subscription: string;
+    result: any;
+  };
 }
 ```
 

--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -171,7 +171,7 @@ var web3 = new Web3(ethereum);
 // B) Use Provider object directly
 // Example 1: Log chainId
 ethereum
-  .request('eth_chainId)
+  .request('eth_chainId')
   .then(chainId => {
     console.log(`hexadecimal string: ${chainId}`);
     console.log(`decimal number: ${parseInt(chainId, 16)}`);

--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -12,99 +12,142 @@ requires: 155, 695, 1102, 1474
 
 ## Summary
 
-This EIP formalizes an Ethereum Provider JavaScript API for consistency across clients and applications. The provider is designed to be minimal and intended to be available on `window.ethereum` for cross environment compatibility. The events are provided as a convenience to enable reactive dapp UIs.
+This EIP specifies an Ethereum Provider JavaScript API for consistency across clients and applications.
+The Provider is designed to be minimal and intended to be available as `window.ethereum` for cross-environment compatibility.
 
 ## API
 
-### Send
+### request
 
-Ethereum JSON-RPC API methods can be sent and received:
+Makes a JSON-RPC method call.
 
-```js
-ethereum.send(method: String, params?: Array<any>): Promise<any>;
+```typescript
+ethereum.request(method: string, params?: Array<any>): Promise<any>;
 ```
 
-Promise resolves with `result` or rejects with `Error`.
+The Promise resolves the method's result or rejects with an `Error`. For example:
 
-See [available JSON-RPC methods](https://github.com/ethereumproject/go-ethereum/wiki/JSON-RPC#json-rpc-methods).
+```js
+ethereum.request('eth_accounts')
+.then(accounts => console.log(accounts))
+.catch(error => console.error(error))
+```
+
+Consult each RPC method's documentation for its return type.
+You can find the list of common Ethereum JSON-RPC methods [here](https://github.com/ethereumproject/go-ethereum/wiki/JSON-RPC).
+
+The Promise rejects with errors of the following form:
+
+```typescript
+{
+  message: string,
+  code: number,
+  data?: any
+}
+```
+
+See the [JSON-RPC Errors](#json-rpc-errors) section for more details.
+
+### sendAsync (DEPRECATED)
+
+Submits a JSON-RPC request to the Provider.
+As [`ethereum.request`](#request), but with a callback and JSON-RPC objects.
+
+```typescript
+ethereum.sendAsync(request: Object, callback: Function): Object;
+```
+
+The interfaces of request and response objects are not specified here.
+Historically, they have followed the [Ethereum JSON-RPC specification](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1474.md).
+
+### send (DEPRECATED)
+
+Due to conflicting implementations and specifications, this method is unreliable and should not be used.
+
+```typescript
+ethereum.send(...args: Array<any>): any;
+```
 
 ### Events
 
-Events are emitted using [EventEmitter](https://nodejs.org/api/events.html).
+Events follow the [Node.js `EventEmitter`](https://nodejs.org/api/events.html) API.
 
 #### notification
 
-All subscriptions from the node emit on notification. Attach listeners with:
+The Provider emits `notification` upon receipt of a JSON-RPC notification (see the [JSON-RPC specification](https://www.jsonrpc.org/specification#notification)).
 
-```js
+```typescript
 ethereum.on('notification', listener: (result: any) => void): this;
 ```
 
-To create a subscription, call `ethereum.send('eth_subscribe', [])` or `ethereum.send('shh_subscribe', [])`.
-
-See the [eth subscription methods](https://github.com/ethereum/go-ethereum/wiki/RPC-PUB-SUB#supported-subscriptions) and [shh subscription methods](https://github.com/ethereum/go-ethereum/wiki/Whisper-v6-RPC-API#shh_subscribe).
+Ethereum subscriptions cause this event to be emitted when received by the Provider.
+See the [Ethereum subscription methods](https://github.com/ethereum/go-ethereum/wiki/RPC-PUB-SUB#supported-subscriptions) and [SHH subscription methods](https://github.com/ethereum/go-ethereum/wiki/Whisper-v6-RPC-API#shh_subscribe) for details.
 
 #### connect
 
-The provider emits `connect` on connect to a network.
+The Provider emits `connect` when it becomes connected. This includes:
 
-```js
+- when the Provider first connects to a chain after being initialized
+- when the Provider connects to a chain, after the `close` event was emitted
+
+```typescript
 ethereum.on('connect', listener: () => void): this;
 ```
 
-You can detect which chain by sending `eth_chainId`:
+Which chain is connected can be determined by requesting `eth_chainId`:
 
-```js
-const chainId = await ethereum.send('eth_chainId');
+```typescript
+const chainId = await ethereum.request('eth_chainId');
 > 1
 ```
 
 #### close
 
-The provider emits `close` on disconnect from a network.
+The Provider emits `close` when it becomes disconnected from all chains.
 
-```js
-ethereum.on('close', listener: (code: Number, reason: String) => void): this;
+```typescript
+ethereum.on('close', listener: (code: number, reason: string) => void): this;
 ```
 
-The event emits with `code` and `reason`. The code follows the table of [`CloseEvent` status codes](https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent#Status_codes).
+This event emits with `code` and `reason`. The code follows the table of [`CloseEvent` status codes](https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent#Status_codes).
 
 #### chainChanged
 
-The provider emits `chainChanged` on connect to a new chain.
+The Provider emits `chainChanged` when connecting to a new chain.
 
-```js
+```typescript
 ethereum.on('chainChanged', listener: (chainId: Integer) => void): this;
 ```
 
-The event emits with integer `chainId`, the new chain returned from `eth_chainId`.
+The event emits an integer `chainId` per the `eth_chainId` Ethereum JSON-RPC method.
+
+#### networkChanged (DEPRECATED)
 
 The event `networkChanged` is deprecated in favor of `chainChanged`. For more info, see [EIP 155: Simple replay attack protection](https://eips.ethereum.org/EIPS/eip-155) and [EIP 695: Create eth_chainId method for JSON-RPC](https://eips.ethereum.org/EIPS/eip-695).
 
 #### accountsChanged
 
-The provider emits `accountsChanged` if the accounts returned from the provider (`eth_accounts`) changes.
+The Provider emits `accountsChanged` if the accounts returned from the Provider (`eth_accounts`) change.
 
-```js
-ethereum.on('accountsChanged', listener: (accounts: Array<String>) => void): this;
+```typescript
+ethereum.on('accountsChanged', listener: (accounts: Array<string>) => void): this;
 ```
 
-The event emits with `accounts`, an array of the accounts' addresses.
+The event emits with `accounts`, an array of account addresses.
 
 ## Examples
 
 ```js
 const ethereum = window.ethereum;
 
-// A) Set provider in web3.js
+// A) Set Provider in web3.js
 var web3 = new Web3(ethereum);
 // web3.eth.getBlock('latest', true).then(...)
 
-
-// B) Use provider object directly
+// B) Use Provider object directly
 // Example 1: Log last block
 ethereum
-  .send('eth_getBlockByNumber', ['latest', 'true'])
+  .request('eth_getBlockByNumber', ['latest', 'true'])
   .then(block => {
     console.log(`Block ${block.number}:`, block);
   })
@@ -117,7 +160,7 @@ ethereum
 
 // Example 2: Log available accounts
 ethereum
-  .send('eth_accounts')
+  .request('eth_accounts')
   .then(accounts => {
     console.log(`Accounts:\n${accounts.join('\n')}`);
   })
@@ -132,7 +175,7 @@ ethereum
 // Example 3: Log new blocks
 let subId;
 ethereum
-  .send('eth_subscribe', ['newHeads'])
+  .request('eth_subscribe', ['newHeads'])
   .then(subscriptionId => {
     subId = subscriptionId;
     ethereum.on('notification', result => {
@@ -157,7 +200,6 @@ ethereum
     );
   });
 
-
 // Example 4: Log when accounts change
 const logAccounts = accounts => {
   console.log(`Accounts:\n${accounts.join('\n')}`);
@@ -168,49 +210,89 @@ ethereum.removeListener('accountsChanged', logAccounts);
 
 // Example 5: Log if connection ends
 ethereum.on('close', (code, reason) => {
-  console.log(`Ethereum provider connection closed: ${reason}. Code: ${code}`);
+  console.log(`Ethereum Provider connection closed: ${reason}. Code: ${code}`);
 });
 ```
 
 ## Specification
 
-### Errors
+### Availability
 
-If the Ethereum Provider request returns an error property then the Promise **MUST** reject with an `Error` object containing the `error.message` as the Error message, `error.code` as a code property on the error and `error.data` as a data property on the error.
+If in a browser environment, the Provider **MUST** be made available as the `ethereum` property on the global `window` object.
 
-If an error occurs during processing, such as an HTTP error or internal parsing error, then the Promise **MUST** reject with an `Error` object.
+If in a non-browser environment, the Provider **SHOULD** be made available as the `ethereum` property on the `globalThis` object.
 
-If the request requires an account that is not yet authenticated, the Promise **MUST** reject with Error code 4100.
+### API
 
-### Events
+The Provider **MUST** expose the API defined in this section.
+The Provider **MAY** expose other methods and properties.
 
-The provider **SHOULD** extend from `EventEmitter` to provide dapps flexibility in listening to events. In place of full `EventEmitter` functionality, the provider **MAY** provide as many methods as it can reasonably provide, but **MUST** provide at least `on`, `emit`, and `removeListener`.
+#### request
 
-#### notification
+> This section suggests the existence of an _internal remote procedure call_ for each call to the `request` method.
+This suggestion is non-normative. For example, the return value of some RPC method may be cached locally, and directly resolved.
 
-All subscriptions received from the node **MUST** emit the `subscription` property with the subscription ID and a `results` property.
+```typescript
+Provider.request(method: string, params?: Array<any>): Promise<any>;
+```
 
-#### connect
+The `request` method is intended as a convenient wrapper for remote procedure calls.
 
-If the network connects, the Ethereum Provider **MUST** emit an event named `connect`.
+The `request` method **MUST** handle RPC requests such that, for a given set of arguments, the returned Promise either resolves a value per the RPC method's specification, or rejects with an error.
 
-#### close
+If the returned Promise resolves, it **MUST** resolve result per the RPC method's specification.
+The Promise **MUST NOT** resolve a JSON-RPC response object, unless the RPC method's return type is so defined by its specification.
 
-If the network connection closes, the Ethereum Provider **MUST** emit an event named `close` with args `code: Number, reason: String` following the [status codes for `CloseEvent`](https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent#Status_codes).
+If the returned Promise rejects, it **SHOULD** reject with an `Error` of the form specified in the [JSON-RPC Errors](#json-rpc-errors) section below.
 
-#### chainChanged
+The returned Promise **MUST** reject if any of the following conditions are met:
 
-If the chain the provider is connected to changes, the provider **MUST** emit an event named `chainChanged` with args `chainId: Integer` containing the ID of the new chain (using the Ethereum JSON-RPC call `eth_chainId`).
+- The _internal remote procedure call_ returns an error
+  - If the original error is compatible with the `EthereumJsonRpcError` interface, the Promise **SHOULD** reject with the original error
+- The _internal remote procedure call_ fails for any reason
+- The request requires access to an unauthorized account, per [EIP 1102](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1102.md)
+  - In this case, the Promise rejection error `code` **MUST** be `4100`
 
-#### accountsChanged
+#### Supported JSON-RPC Methods
 
-If the accounts connected to the Ethereum Provider change at any time, the Ethereum Provider **MUST** send an event with the name `accountsChanged` with args `accounts: Array<String>` containing the accounts' addresses.
+Providers **SHOULD** support all methods in the [Ethereum JSON-RPC specification](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1474.md).
 
-### Error object and codes
+Any supported method that is included in the Ethereum JSON-RPC specification **MUST** follow the Ethereum JSON-RPC API specification.
 
-If an Error object is returned, it **MUST** contain a human readable string message describing the error and **SHOULD** populate the `code` and `data` properties on the error object with additional error details.
+If an Ethereum JSON-RPC method is not supported, it **SHOULD** be rejected with an appropriate error per the [Ethereum JSON-RPC Specification](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1474.md#error-codes).
 
-Appropriate error codes **SHOULD** follow the table of [`CloseEvent` status codes](https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent#Status_codes), along with the following table:
+Providers **MAY** support JSON-RPC methods not specified by the Ethereum JSON-RPC API.
+
+#### JSON-RPC Errors
+
+```typescript
+interface EthereumJsonRpcError extends Error {
+  message: string,
+  code: number,
+  data?: any
+}
+```
+
+- `message`
+  - **MUST** be a human-readable string
+  - **SHOULD** adhere to the specifications in the [Error Standards](#error-standards) section below
+- `code`
+  - **MUST** be an integer number
+  - **SHOULD** adhere to the specifications in the [Error Standards](#error-standards) section below
+- `data`
+  - **SHOULD** contain any other useful information about the error
+
+##### Error Standards
+
+`EthereumJsonRpcError` codes and messages **SHOULD** follow these conventions, in order of priority:
+
+1. The errors in the [Provider Errors](#provider-errors) section below
+
+2. The [Ethereum JSON-RPC API error codes](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1474.md#error-codes)
+
+3. The [`CloseEvent` status codes](https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent#Status_codes)
+
+#### Provider Errors
 
 | Status code | Name                         | Description                                                              |
 | ----------- | ---------------------------- | ------------------------------------------------------------------------ |
@@ -218,19 +300,53 @@ Appropriate error codes **SHOULD** follow the table of [`CloseEvent` status code
 | 4100        | Unauthorized                 | The requested method and/or account has not been authorized by the user. |
 | 4200        | Unsupported Method           | The requested method is not supported by the given Ethereum Provider.    |
 
-## Sample Class Implementation
+### Events
+
+The Provider **SHOULD** extend the [Node.js `EventEmitter`](https://nodejs.org/api/events.html) to provide dapps flexibility in listening to events. In place of full `EventEmitter` functionality, the Provider **MAY** provide as many methods as it can reasonably provide, but **MUST** provide at least `on`, `emit`, and `removeListener`.
+
+#### notification
+
+The Provider **MUST** emit the `notification` event when receiving an update from a subscription, with an object containing the `subscription` and `result` properties of the subscription object.
+
+See the [Ethereum subscription methods](https://github.com/ethereum/go-ethereum/wiki/RPC-PUB-SUB#supported-subscriptions) for details.
+
+#### connect
+
+If the Provider becomes connected to a chain, the Provider **MUST** emit an event named `connect`.
+
+The Provider "becomes connected" when:
+
+- it first connects to a chain after initialization
+- it connects to a chain after the `close` event was emitted
+
+#### close
+
+If the Provider becomes disconnected from all chains, the Provider **MUST** emit an event named `close` with arguments `code: number, reason: string` following the [status codes for `CloseEvent`](https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent#Status_codes).
+
+#### chainChanged
+
+If the chain the Provider is connected to changes, the Provider **MUST** emit an event named `chainChanged` with argument `chainId: number`, specifying the integer ID of the new chain (per the [`eth_chainId`](https://eips.ethereum.org/EIPS/eip-695)) Ethereum JSON-RPC method.
+
+#### accountsChanged
+
+If the accounts available to the Provider change, the Provider **MUST** emit an event with the name `accountsChanged` with argument `accounts: Array<string>`, containing the account addresses.
+
+The "accounts available to the Provider" are defined as whatever is returned by the `eth_accounts` Ethereum JSON-RPC method.
+
+## Example Implementation
 
 ```js
 class EthereumProvider extends EventEmitter {
+
   constructor() {
-    // Call super for `this` to be defined
+
     super();
 
     // Init storage
     this._nextJsonRpcId = 0;
     this._promises = {};
 
-    // Fire the connect
+    // Emit the connect event
     this._connect();
 
     // Listen for jsonrpc responses
@@ -239,7 +355,7 @@ class EthereumProvider extends EventEmitter {
 
   /* Methods */
 
-  send(method, params = []) {
+  request(method, params = []) {
     if (!method || typeof method !== 'string') {
       return new Error('Method is not a valid string.');
     }
@@ -345,12 +461,12 @@ class EthereumProvider extends EventEmitter {
     this.emit('accountsChanged', accounts);
   }
 
-  /*
-     Provide `sendAsync` to be compatible as an older web3.js provider.
-  */
-
+  /**
+   * DEPRECATED
+   * For backwards compatibility only.
+   */
   sendAsync(payload, callback) {
-    return this.send(payload.method, payload.params)
+    return this.request(payload.method, payload.params)
       .then(result => {
         const response = payload;
         response.result = result;
@@ -358,7 +474,6 @@ class EthereumProvider extends EventEmitter {
       })
       .catch(error => {
         callback(error, null);
-        // eslint-disable-next-line no-console
         console.error(
           `Error from EthereumProvider sendAsync ${payload}: ${error}`
         );
@@ -369,8 +484,11 @@ class EthereumProvider extends EventEmitter {
 
 ## References
 
-* [Initial discussion in `ethereum/interfaces`](https://github.com/ethereum/interfaces/issues/16)
-* [Ethereum Magicians thread](https://ethereum-magicians.org/t/eip-1193-ethereum-provider-javascript-api/640)
+- [Initial discussion in `ethereum/interfaces`](https://github.com/ethereum/interfaces/issues/16)
+- [Ethereum Magicians thread](https://ethereum-magicians.org/t/eip-1193-ethereum-provider-javascript-api/640)
+- [EIP 1474](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1474.md)
+- [EIP 695](https://eips.ethereum.org/EIPS/eip-695.md)
+- [JSON-RPC 2.0 Specification](https://www.jsonrpc.org/specification)
 
 ## Copyright
 

--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -96,10 +96,15 @@ The Provider emits `connect` when it becomes connected. This includes:
 - when the Provider connects to a chain, after the `close` event was emitted
 
 ```typescript
-ethereum.on('connect', listener: (chainId: number) => void): ethereum;
+interface ConnectInfo {
+  chainId: number,
+  ...props?: Array<unknown>
+}
+
+ethereum.on('connect', listener: (connectInfo: ConnectInfo) => void): ethereum;
 ```
 
-The event emits an integer `chainId` per the `eth_chainId` Ethereum JSON-RPC method.
+The event emits an object with a `chainId` property per the `eth_chainId` Ethereum JSON-RPC method, and other properties as determined by the Provider.
 
 #### close
 
@@ -313,7 +318,7 @@ The Provider **MAY** emit the `notification` event, for any reason.
 
 If the Provider supports subscription JSON-RPC methods, e.g. [`eth_subscribe`](https://geth.ethereum.org/docs/rpc/pubsub), the Provider **MUST** emit the `notification` event when it receives a subscription notification.
 
-When emitted, the `notification` event **MUST** be emitted with a single object argument of the following form:
+When emitted, the `notification` event **MUST** be emitted with an object argument of the following form:
 
 ```typescript
 interface JsonRpcNotification {
@@ -332,13 +337,24 @@ The Provider "becomes connected" when:
 - it first connects to a chain after initialization
 - it connects to a chain after the `close` event was emitted
 
+This event **MUST** be emitted with an object of the following form:
+
+```typescript
+interface ConnectInfo {
+  chainId: number,
+  ...props?: Array<unknown>
+}
+```
+
+`chainId` **MUST** specify the integer ID of the connected chain, the [`eth_chainId`](https://eips.ethereum.org/EIPS/eip-695) Ethereum JSON-RPC method.
+
 #### close
 
 If the Provider becomes disconnected from all chains, the Provider **MUST** emit an event named `close` with arguments `code: number, reason: string` following the [status codes for `CloseEvent`](https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent#Status_codes).
 
 #### chainChanged
 
-If the chain the Provider is connected to changes, the Provider **MUST** emit an event named `chainChanged` with argument `chainId: number`, specifying the integer ID of the new chain (per the [`eth_chainId`](https://eips.ethereum.org/EIPS/eip-695)) Ethereum JSON-RPC method.
+If the chain the Provider is connected to changes, the Provider **MUST** emit an event named `chainChanged` with argument `chainId: number`, specifying the integer ID of the new chain, per the [`eth_chainId`](https://eips.ethereum.org/EIPS/eip-695) Ethereum JSON-RPC method.
 
 #### accountsChanged
 

--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -14,7 +14,7 @@ requires: 155, 695, 1102, 1474, 1767
 
 This EIP formalizes a JavaScript Ethereum Provider API for consistency across clients and applications.
 
-In browsers, the Provider is intended to be available as `window.ethereum` so JavaScript dapps can be written once and function in perpetuity.
+The Provider is intended to be available as `globalThis.ethereum` (`window.ethereum` in browsers), so that JavaScript dapps can be written once and function in perpetuity.
 
 The Provider's interface is designed to be minimal, preferring for features to be introduced in the API layer (e.g. see [`eth_requestAccounts`](https://eips.ethereum.org/EIPS/eip-1102)), and agnostic of any particular transport protocol.
 
@@ -41,7 +41,7 @@ ethereum.request('eth_accounts')
 ```
 
 Consult each Ethereum API method's documentation for its return type.
-You can find a list of common methods [here](https://github.com/ethereum/wiki/wiki/JSON-RPC#json-rpc-api-reference).
+You can find a list of common methods [here](https://eips.ethereum.org/EIPS/eip-1474).
 
 The Promise rejects with errors of the following form:
 
@@ -66,7 +66,7 @@ Multiple transports may be available.
 ### sendAsync (DEPRECATED)
 
 Submits a JSON-RPC request to the Provider.
-As [`ethereum.request`](#request), but with a callback and JSON-RPC objects.
+As [`ethereum.request`](#request), but with JSON-RPC objects and a callback.
 
 ```typescript
 ethereum.sendAsync(request: Object, callback: Function): Object;
@@ -122,7 +122,7 @@ interface ProviderConnectInfo {
 ethereum.on('connect', listener: (connectInfo: ProviderConnectInfo) => void): ethereum;
 ```
 
-The event emits an object with a hexadecimal string `chainId` per the `eth_chainId` Ethereum JSON-RPC method, and other properties as determined by the Provider.
+The event emits an object with a hexadecimal string `chainId` per the `eth_chainId` Ethereum RPC method, and other properties as determined by the Provider.
 
 #### close
 
@@ -142,7 +142,7 @@ The Provider emits `chainChanged` when connecting to a new chain.
 ethereum.on('chainChanged', listener: (chainId: string) => void): ethereum;
 ```
 
-The event emits a hexadecimal string `chainId` per the `eth_chainId` Ethereum JSON-RPC method.
+The event emits a hexadecimal string `chainId` per the `eth_chainId` Ethereum RPC method.
 
 #### networkChanged (DEPRECATED)
 
@@ -260,6 +260,17 @@ ethereum.on('close', (code, reason) => {
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC-2119](https://www.ietf.org/rfc/rfc2119.txt).
 
+### Definitions
+
+>This section is non-normative.
+
+- Provider
+  - A JavaScript object made available to a dapp, that provides access to Ethereum by means of a Client
+- Client
+  - An endpoint accessed by a Provider, that receives Remote Procedure Call (RPC) requests and returns their results
+- Remote Procedure Call (RPC)
+  - A Remote Procedure Call (RPC), is any request submitted to a Provider for some procedure that is to be processed by a Provider or its Client.
+
 ### Availability
 
 In a browser environment, the Provider **MUST** be made available as the `ethereum` property on the global `window` object.
@@ -303,11 +314,15 @@ The returned Promise **MUST** reject if any of the following conditions are met:
 
 ### Supported RPC Methods
 
+A "supported RPC method" is any RPC method that may be called via the Provider.
+
+All supported RPC methods **MUST** be identified by unique strings.
+
 Providers **MAY** support whatever RPC methods required to fulfill their purpose, standardized or otherwise.
 
-If a Provider supports a method defined in an EIP, the Provider's implementation of this method **MUST** adhere to the method's specification.
+If a Provider supports a method defined in a finalized EIP, the Provider's implementation of this method **MUST** adhere to the method's specification.
 
-If an RPC method defined in an EIP is not supported, it **SHOULD** be rejected with an appropriate error per [EIP 1474](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1474.md#error-codes).
+If an RPC method defined in a finalized EIP is not supported, it **SHOULD** be rejected with an appropriate error per [EIP 1474](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1474.md#error-codes).
 
 #### RPC Errors
 
@@ -397,7 +412,7 @@ interface ProviderConnectInfo {
 }
 ```
 
-`chainId` **MUST** specify the integer ID of the connected chain as a hexadecimal string, per the [`eth_chainId`](https://eips.ethereum.org/EIPS/eip-695) Ethereum JSON-RPC method.
+`chainId` **MUST** specify the integer ID of the connected chain as a hexadecimal string, per the [`eth_chainId`](https://eips.ethereum.org/EIPS/eip-695) Ethereum RPC method.
 
 The `ProviderConnectInfo` object **MAY** contain any other `string` properties with values of any type.
 
@@ -421,7 +436,6 @@ The "accounts available to the Provider" change when the return value of the `et
 - [Ethereum Magicians thread](https://ethereum-magicians.org/t/eip-1193-ethereum-provider-javascript-api/640)
 - [EIP 1474](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1474.md)
 - [EIP 695](https://eips.ethereum.org/EIPS/eip-695.md)
-- [JSON-RPC 2.0 Specification](https://www.jsonrpc.org/specification)
 
 ## Copyright
 

--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -36,7 +36,7 @@ The Promise resolves the method's result or rejects with an `Error`. For example
 
 ```javascript
 ethereum
-  .request('eth_accounts')
+  .request("eth_accounts")
   .then((accounts) => console.log(accounts))
   .catch((error) => console.error(error));
 ```
@@ -171,53 +171,50 @@ var web3 = new Web3(ethereum);
 // B) Use Provider object directly
 // Example 1: Log chainId
 ethereum
-  .request('eth_chainId')
-  .then(chainId => {
+  .request("eth_chainId")
+  .then((chainId) => {
     console.log(`hexadecimal string: ${chainId}`);
     console.log(`decimal number: ${parseInt(chainId, 16)}`);
   })
-  .catch(error => {
+  .catch((error) => {
     console.error(`Error fetching chainId: ${error.code}: ${error.message}`);
-  })
-
+  });
 
 // Example 2: Log last block
 ethereum
-  .request('eth_getBlockByNumber', ['latest', 'true'])
-  .then(block => {
+  .request("eth_getBlockByNumber", ["latest", "true"])
+  .then((block) => {
     console.log(`Block ${block.number}:`, block);
   })
-  .catch(error => {
+  .catch((error) => {
     console.error(
       `Error fetching last block: ${error.message}.
        Code: ${error.code}. Data: ${error.data}`
     );
   });
 
-
 // Example 3: Log available accounts
 ethereum
-  .request('eth_accounts')
-  .then(accounts => {
-    console.log(`Accounts:\n${accounts.join('\n')}`);
+  .request("eth_accounts")
+  .then((accounts) => {
+    console.log(`Accounts:\n${accounts.join("\n")}`);
   })
-  .catch(error => {
+  .catch((error) => {
     console.error(
       `Error fetching accounts: ${error.message}.
        Code: ${error.code}. Data: ${error.data}`
     );
   });
 
-
 // Example 4: Log new blocks
 ethereum
-  .request('eth_subscribe', ['newHeads'])
-  .then(subscriptionId => {
-    ethereum.on('notification', notification => {
-      if (notification.type === 'eth_subscription') {
+  .request("eth_subscribe", ["newHeads"])
+  .then((subscriptionId) => {
+    ethereum.on("notification", (notification) => {
+      if (notification.type === "eth_subscription") {
         const { data } = notification;
         if (data.subscription === subscriptionId) {
-          if (typeof data.result === 'string' && data.result) {
+          if (typeof data.result === "string" && data.result) {
             const block = data.result;
             console.log(`New block ${block.number}:`, block);
           } else {
@@ -227,25 +224,23 @@ ethereum
       }
     });
   })
-  .catch(error => {
+  .catch((error) => {
     console.error(
       `Error making newHeads subscription: ${error.message}.
        Code: ${error.code}. Data: ${error.data}`
     );
   });
 
-
 // Example 5: Log when accounts change
-const logAccounts = accounts => {
-  console.log(`Accounts:\n${accounts.join('\n')}`);
+const logAccounts = (accounts) => {
+  console.log(`Accounts:\n${accounts.join("\n")}`);
 };
-ethereum.on('accountsChanged', logAccounts);
+ethereum.on("accountsChanged", logAccounts);
 // to unsubscribe
-ethereum.removeListener('accountsChanged', logAccounts);
-
+ethereum.removeListener("accountsChanged", logAccounts);
 
 // Example 6: Log if connection ends
-ethereum.on('close', (code, reason) => {
+ethereum.on("close", (code, reason) => {
   console.log(`Ethereum Provider connection closed: ${reason}. Code: ${code}`);
 });
 ```

--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -22,7 +22,7 @@ The Provider is designed to be minimal and intended to be available as `window.e
 Makes a JSON-RPC method call.
 
 ```typescript
-ethereum.request(method: string, params?: Array<any>): Promise<any>;
+ethereum.request(method: string, params?: Array<any>): Promise<unknown>;
 ```
 
 The Promise resolves the method's result or rejects with an `Error`. For example:
@@ -34,7 +34,7 @@ ethereum.request('eth_accounts')
 ```
 
 Consult each RPC method's documentation for its return type.
-You can find the list of common Ethereum JSON-RPC methods [here](https://github.com/ethereumproject/go-ethereum/wiki/JSON-RPC).
+You can find a list of common Ethereum JSON-RPC methods [here](https://github.com/ethereum/wiki/wiki/JSON-RPC#json-rpc-api-reference).
 
 The Promise rejects with errors of the following form:
 
@@ -65,7 +65,7 @@ Historically, they have followed the [Ethereum JSON-RPC specification](https://g
 Due to conflicting implementations and specifications, this method is unreliable and should not be used.
 
 ```typescript
-ethereum.send(...args: Array<any>): any;
+ethereum.send(...args: Array<any>): unknown;
 ```
 
 ### Events
@@ -74,14 +74,19 @@ Events follow the [Node.js `EventEmitter`](https://nodejs.org/api/events.html) A
 
 #### notification
 
-The Provider emits `notification` upon receipt of a JSON-RPC notification (see the [JSON-RPC specification](https://www.jsonrpc.org/specification#notification)).
+The Provider emits `notification` upon receipt of a JSON-RPC notification intended for the dapp.
 
 ```typescript
-ethereum.on('notification', listener: (result: any) => void): this;
+interface JsonRpcNotification {
+  method: string,
+  params: Array<unknown> | Object,
+  jsonrpc?: '2.0'
+}
+
+ethereum.on('notification', listener: (notification: JsonRpcNotification) => void): ethereum;
 ```
 
-Ethereum subscriptions cause this event to be emitted when received by the Provider.
-See the [Ethereum subscription methods](https://github.com/ethereum/go-ethereum/wiki/RPC-PUB-SUB#supported-subscriptions) and [SHH subscription methods](https://github.com/ethereum/go-ethereum/wiki/Whisper-v6-RPC-API#shh_subscribe) for details.
+Notifications include `eth_subscription` messages, if supported by the Provider. See [here](https://geth.ethereum.org/docs/rpc/pubsub) for details.
 
 #### connect
 
@@ -91,22 +96,17 @@ The Provider emits `connect` when it becomes connected. This includes:
 - when the Provider connects to a chain, after the `close` event was emitted
 
 ```typescript
-ethereum.on('connect', listener: () => void): this;
+ethereum.on('connect', listener: (chainId: number) => void): ethereum;
 ```
 
-Which chain is connected can be determined by requesting `eth_chainId`:
-
-```typescript
-const chainId = await ethereum.request('eth_chainId');
-> 1
-```
+The event emits an integer `chainId` per the `eth_chainId` Ethereum JSON-RPC method.
 
 #### close
 
 The Provider emits `close` when it becomes disconnected from all chains.
 
 ```typescript
-ethereum.on('close', listener: (code: number, reason: string) => void): this;
+ethereum.on('close', listener: (code: number, reason: string) => void): ethereum;
 ```
 
 This event emits with `code` and `reason`. The code follows the table of [`CloseEvent` status codes](https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent#Status_codes).
@@ -116,21 +116,21 @@ This event emits with `code` and `reason`. The code follows the table of [`Close
 The Provider emits `chainChanged` when connecting to a new chain.
 
 ```typescript
-ethereum.on('chainChanged', listener: (chainId: Integer) => void): this;
+ethereum.on('chainChanged', listener: (chainId: number) => void): ethereum;
 ```
 
 The event emits an integer `chainId` per the `eth_chainId` Ethereum JSON-RPC method.
 
 #### networkChanged (DEPRECATED)
 
-The event `networkChanged` is deprecated in favor of `chainChanged`. For more info, see [EIP 155: Simple replay attack protection](https://eips.ethereum.org/EIPS/eip-155) and [EIP 695: Create eth_chainId method for JSON-RPC](https://eips.ethereum.org/EIPS/eip-695).
+The event `networkChanged` is deprecated in favor of `chainChanged`. For details, see [EIP 155: Simple replay attack protection](https://eips.ethereum.org/EIPS/eip-155) and [EIP 695: Create eth_chainId method for JSON-RPC](https://eips.ethereum.org/EIPS/eip-695).
 
 #### accountsChanged
 
 The Provider emits `accountsChanged` if the accounts returned from the Provider (`eth_accounts`) change.
 
 ```typescript
-ethereum.on('accountsChanged', listener: (accounts: Array<string>) => void): this;
+ethereum.on('accountsChanged', listener: (accounts: Array<string>) => void): ethereum;
 ```
 
 The event emits with `accounts`, an array of account addresses.
@@ -167,28 +167,31 @@ ethereum
   .catch(error => {
     console.error(
       `Error fetching accounts: ${error.message}.
-    Code: ${error.code}. Data: ${error.data}`
+       Code: ${error.code}. Data: ${error.data}`
     );
   });
 
-
 // Example 3: Log new blocks
-let subId;
 ethereum
   .request('eth_subscribe', ['newHeads'])
   .then(subscriptionId => {
-    subId = subscriptionId;
-    ethereum.on('notification', result => {
-      if (result.subscription === subscriptionId) {
-        if (result.result instanceof Error) {
-          const error = result.result;
-          console.error(
-            `Error from newHeads subscription: ${error.message}.
-             Code: ${error.code}. Data: ${error.data}`
-          );
-        } else {
-          const block = result.result;
-          console.log(`New block ${block.number}:`, block);
+
+    ethereum.on('notification', notification => {
+
+      if (notification.method === 'eth_subscription') {
+
+        const { params } = notification;
+
+        if (params.subscription === subscriptionId) {
+
+          if (typeof params.result === 'string' && params.result) {
+
+            const block = params.result;
+            console.log(`New block ${block.number}:`, block);
+
+          } else {
+            console.error(`Something went wrong: ${params.result}`);
+          }
         }
       }
     });
@@ -233,7 +236,7 @@ The Provider **MAY** expose other methods and properties.
 This suggestion is non-normative. For example, the return value of some RPC method may be cached locally, and directly resolved.
 
 ```typescript
-Provider.request(method: string, params?: Array<any>): Promise<any>;
+Provider.request(method: string, params?: Array<any>): Promise<unknown>;
 ```
 
 The `request` method is intended as a convenient wrapper for remote procedure calls.
@@ -306,9 +309,19 @@ The Provider **SHOULD** extend the [Node.js `EventEmitter`](https://nodejs.org/a
 
 #### notification
 
-The Provider **MUST** emit the `notification` event when receiving an update from a subscription, with an object containing the `subscription` and `result` properties of the subscription object.
+The Provider **MAY** emit the `notification` event, for any reason.
 
-See the [Ethereum subscription methods](https://github.com/ethereum/go-ethereum/wiki/RPC-PUB-SUB#supported-subscriptions) for details.
+If the Provider supports subscription JSON-RPC methods, e.g. [`eth_subscribe`](https://geth.ethereum.org/docs/rpc/pubsub), the Provider **MUST** emit the `notification` event when it receives a subscription notification.
+
+When emitted, the `notification` event **MUST** be emitted with a single object argument of the following form:
+
+```typescript
+interface JsonRpcNotification {
+  method: string,
+  params: Array<unknown> | Object,
+  jsonrpc?: '2.0'
+}
+```
 
 #### connect
 
@@ -421,7 +434,7 @@ class EthereumProvider extends EventEmitter {
     } else {
       if (method && method.indexOf('_subscription') > -1) {
         // Emit subscription notification
-        this._emitNotification(message.params);
+        this._emitNotification(message);
       }
     }
   }
@@ -441,8 +454,8 @@ class EthereumProvider extends EventEmitter {
 
   /* Events */
 
-  _emitNotification(result) {
-    this.emit('notification', result);
+  _emitNotification(notification) {
+    this.emit('notification', notification);
   }
 
   _emitConnect() {


### PR DESCRIPTION
Link to file: https://github.com/rekmarks/EIPs/blob/rekmarks-1193-update/EIPS/eip-1193.md

Makes the following updates to EIP 1193, in light of recent discussions in #2319:
- Deprecates `send` and `sendAsync`
  - Providers may continue to support these methods
- Specifies a new method, `request`, with the same Promise signature as the `send` currently at `ethereum/EIPs#master`
  - Per @MicahZoltu's [suggestion](https://github.com/ethereum/EIPs/issues/2319#issuecomment-591194700)
- Changes the interface of the `notification` event, such that a generalized object is emitted
  - This was done to support other notifications than `eth_subscription`
- Makes the spec transport- and RPC protocol-agnostic, per the contributions of @ryanio
- Adds the `message` event for generalized messaging, and deprecates the `notification` event
  - This is so that existing uses of the `notification` event do not break
  - All functionality previously handled by the `notification` event is now handled by the `message` event
- Various edits for clarity and stylistic consistency