### PR TITLE
1193: add global initialization event

### DIFF
--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -20,6 +20,8 @@ The Provider's interface is designed to be minimal, preferring that features are
 
 The events `connect`, `disconnect`, `chainChanged`, and `accountsChanged` are provided as a convenience to help enable reactive dapp UIs.
 
+For usage, see [Examples](#examples).
+
 ## API
 
 ### request
@@ -73,6 +75,21 @@ This method is deprecated in favor of [`request`](#request).
 ethereum.send(...args: Array<any>): unknown;
 ```
 
+### The Global Initialization Event
+
+In some environments, the Provider is made available asynchronously, and may not be available when the consumer script begins to execute.
+In order to notify the consumer when it becomes available as `globalThis.ethereum`, the Provider dispatches the `ethereum#initialized` event on `globalThis`, i.e. `window` in web browsers.
+
+This event may only be emitted if necessary, and if `globalThis` supports the [`EventTarget` Web API](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget).
+
+```typescript
+type ProviderInitializedListener = () => void;
+
+globalThis.addEventListener('ethereum#initialized', listener: ProviderInitializedListener): void;
+```
+
+If in an environment where the required Web APIs are not available, the Provider may implement this behavior in other ways. Consult the Provider implementation's documentation for details.
+
 ### Events
 
 Events follow the [Node.js `EventEmitter`](https://nodejs.org/api/events.html) API.
@@ -90,7 +107,7 @@ interface ProviderConnectInfo {
   [key: string]: unknown;
 }
 
-ethereum.on('connect', listener: (connectInfo: ProviderConnectInfo) => void): ethereum;
+ethereum.on('connect', listener: (connectInfo: ProviderConnectInfo) => void): Provider;
 ```
 
 The event emits an object with a hexadecimal string `chainId` per the `eth_chainId` Ethereum RPC method, and other properties as determined by the Provider.
@@ -100,7 +117,7 @@ The event emits an object with a hexadecimal string `chainId` per the `eth_chain
 The Provider emits `disconnect` when it becomes disconnected from all chains.
 
 ```typescript
-ethereum.on('disconnect', listener: (error: ProviderRpcError) => void): ethereum;
+ethereum.on('disconnect', listener: (error: ProviderRpcError) => void): Provider;
 ```
 
 This event emits a [`ProviderRpcError`](#errors). The error `code` follows the table of [`CloseEvent` status codes](https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent#Status_codes).
@@ -114,7 +131,7 @@ This event is deprecated in favor of [`disconnect`](#disconnect).
 The Provider emits `chainChanged` when connecting to a new chain.
 
 ```typescript
-ethereum.on('chainChanged', listener: (chainId: string) => void): ethereum;
+ethereum.on('chainChanged', listener: (chainId: string) => void): Provider;
 ```
 
 The event emits a hexadecimal string `chainId` per the `eth_chainId` Ethereum RPC method.
@@ -130,7 +147,7 @@ For details, see [EIP 155: Simple replay attack protection](https://eips.ethereu
 The Provider emits `accountsChanged` if the accounts returned from the Provider (`eth_accounts`) change.
 
 ```typescript
-ethereum.on('accountsChanged', listener: (accounts: Array<string>) => void): ethereum;
+ethereum.on('accountsChanged', listener: (accounts: Array<string>) => void): Provider;
 ```
 
 The event emits with `accounts`, an array of account addresses, per the `eth_accounts` Ethereum RPC method.
@@ -174,9 +191,31 @@ interface ProviderRpcError extends Error {
 
 ## Examples
 
-```javascript
-const ethereum = window.ethereum;
+> These examples assume a web browser environment.
 
+### Accessing the Provider
+
+```javascript
+let ethereum;
+
+if (window.ethereum) {
+  ethereum = window.ethereum;
+} else {
+  window.addEventListener('ethereum#initialized', () => {
+    ethereum = window.ethereum;
+  });
+
+  setTimeout(() => {
+    if (!ethereum) {
+      console.log('Does your browser have an Ethereum wallet?');
+    }
+  }, 5000); // 5 seconds, just as an example
+}
+```
+
+### Using the Provider
+
+```javascript
 // A) Set Provider in web3.js
 var web3 = new Web3(ethereum);
 // web3.eth.getBlock('latest', true).then(...)
@@ -273,7 +312,7 @@ _This section is non-normative._
 - Client
   - An endpoint accessed by a Provider, that receives Remote Procedure Call (RPC) requests and returns their results.
 - Remote Procedure Call (RPC)
-  - A Remote Procedure Call (RPC), is any request submitted to a Provider for some procedure that is to be processed by a Provider or its Client.
+  - A Remote Procedure Call (RPC), is any request submitted to a Provider for some procedure that is to be executed by a Provider or its Client.
 
 ### Availability
 
@@ -306,10 +345,10 @@ ethereum.request(method: string, params?: RequestParams): Promise<unknown>;
 
 The `request` method is intended as a transport- and protocol-agnostic wrapper function for Remote Procedure Calls (RPCs).
 
-The `request` method **MUST** send a properly formatted request to the Provider's Ethereum client.
+The `request` method **MUST** send a properly formatted request to the Provider's Ethereum Client.
 Requests **MUST** be handled such that, for a given set of arguments, the returned Promise either resolves with a value per the RPC method's specification, or rejects with an error.
 
-If present, the `params` argument **MUST** be structured value, either by-position as an `Array` or by-name as an `Object`.
+If present, the `params` argument **MUST** be a structured value, either by-position as an `Array` or by-name as an `Object`.
 
 If resolved, the Promise **MUST NOT** resolve with any RPC protocol-specific response objects, unless the RPC method's return type is so defined by its specification.
 
@@ -385,38 +424,21 @@ interface ProviderRpcError extends Error {
 | 4900        | Not Connected         | The Provider is not connected to any chains.                             |
 | 4901        | Chain Not Connected   | The Provider is not connected to the requested chain.                    |
 
+### The Global Initialization Event
+
+> This event is intended for cases where the Provider is asynchronously made available to its consumer.
+> The authors of this specification do not recommend using global events other purposes.
+
+When the Provider object is set as the value of `globalThis.ethereum`, the Provider **SHOULD** dispatch the event named `ethereum#initialized` on `globalThis`.
+
+If the Provider implements this event, the following rules apply:
+
+- If the Provider is in an environment where the `globalThis` object supports the [`EventTarget` Web API](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget), then this event **MUST** be implemented using that API.
+- If the Provider in an environment where `globalThis` does not support the `EventTarget` Web API, then the Provider **MAY** implement the global initialization event using a suitable event API and global object.
+
 ### Events
 
 The Provider **SHOULD** extend the [Node.js `EventEmitter`](https://nodejs.org/api/events.html) to provide dapps flexibility in listening to events. In place of full `EventEmitter` functionality, the Provider **MAY** provide as many methods as it can reasonably provide, but **MUST** provide at least `on`, `emit`, and `removeListener`.
-
-#### message
-
-The Provider **MAY** emit the event named `message`, for any reason.
-
-If the Provider supports Ethereum RPC subscriptions, e.g. [`eth_subscribe`](https://geth.ethereum.org/docs/rpc/pubsub), the Provider **MUST** emit the `message` event when it receives a subscription notification.
-
-When emitted, the `message` event **MUST** be emitted with an object argument of the following form:
-
-```typescript
-interface ProviderMessage {
-  type: string;
-  data: unknown;
-}
-```
-
-##### Converting a Subscription Message to a ProviderMessage
-
-If the Provider receives a subscription message from e.g. an `eth_subscribe` subscription, the Provider **MUST** emit a `message` event with a `ProviderMessage` object of the following form:
-
-```typescript
-interface EthSubscription extends ProviderMessage {
-  type: 'eth_subscription';
-  data: {
-    subscription: string;
-    result: any;
-  };
-}
-```
 
 #### connect
 
@@ -458,11 +480,41 @@ If the accounts available to the Provider change, the Provider **MUST** emit the
 
 The "accounts available to the Provider" change when the return value of `eth_accounts` changes.
 
+#### message
+
+The Provider **MAY** emit the event named `message`, for any reason.
+
+If the Provider supports Ethereum RPC subscriptions, e.g. [`eth_subscribe`](https://geth.ethereum.org/docs/rpc/pubsub), the Provider **MUST** emit the `message` event when it receives a subscription notification.
+
+When emitted, the `message` event **MUST** be emitted with an object argument of the following form:
+
+```typescript
+interface ProviderMessage {
+  type: string;
+  data: unknown;
+}
+```
+
+##### Converting a Subscription Message to a ProviderMessage
+
+If the Provider receives a subscription message from e.g. an `eth_subscribe` subscription, the Provider **MUST** emit a `message` event with a `ProviderMessage` object of the following form:
+
+```typescript
+interface EthSubscription extends ProviderMessage {
+  type: 'eth_subscription';
+  data: {
+    subscription: string;
+    result: any;
+  };
+}
+```
+
 ## References
 
 - [Initial discussion in `ethereum/interfaces`](https://github.com/ethereum/interfaces/issues/16)
 - [Ethereum Magicians thread](https://ethereum-magicians.org/t/eip-1193-ethereum-provider-javascript-api/640)
 - [Continuing EIP-1193 discussion](https://github.com/ethereum/EIPs/issues/2319)
+- [Web APIs](https://developer.mozilla.org/en-US/docs/Web/API)
 
 ## Copyright
 


### PR DESCRIPTION
_This PR is strictly additive; it does not break or modify any existing features of 1193._

_This PR is in draft awaiting #2586._

File: https://github.com/rekmarks/EIPs/blob/1193-global-event/EIPS/eip-1193.md

- Add a "Global Initialization Event": `ethereum#initialized`
  - This is intended for environments where the Provider is asynchronously injected
  - Today, in such environments, consumers have no recourse but to poll for `window.ethereum` via `setInterval` if the Provider is not synchronously available
  - This event is emitted using the event API of `globalThis`, if available
    - In browsers, this is the [`EventTarget` Web API](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget), which is supported by `window` (the browser `globalThis`)
- Various minor fixes (typos etc.)