### PR TITLE
1193: single object argument for `request` method

### DIFF
--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -29,8 +29,8 @@ Makes an Ethereum RPC method call.
 ```typescript
 interface RequestArguments {
   method: string;
-  params?: any;
-  [key: string]: any;
+  params?: unknown;
+  [key: string]: unknown;
 }
 
 Provider.request(args: RequestArguments): Promise<unknown>;
@@ -73,7 +73,7 @@ Historically, they have followed the [Ethereum JSON-RPC specification](https://g
 This method is deprecated in favor of [`request`](#request).
 
 ```typescript
-Provider.send(...args: Array<any>): unknown;
+Provider.send(...args: Array<unknown>): unknown;
 ```
 
 ### Events
@@ -171,7 +171,7 @@ Historically, this event has returned e.g. `eth_subscribe` subscription updates 
 interface ProviderRpcError extends Error {
   message: string;
   code: number;
-  data?: any;
+  data?: unknown;
 }
 ```
 
@@ -328,8 +328,8 @@ The Provider **MAY** expose methods and properties not specified in this documen
 ```typescript
 interface RequestArguments {
   method: string;
-  params?: any;
-  [key: string]: any;
+  params?: unknown;
+  [key: string]: unknown;
 }
 
 Provider.request(args: RequestArguments): Promise<unknown>;
@@ -381,7 +381,7 @@ If an RPC method defined in a finalized EIP is not supported, it **SHOULD** be r
 interface ProviderRpcError extends Error {
   message: string;
   code: number;
-  data?: any;
+  data?: unknown;
 }
 ```
 
@@ -442,7 +442,7 @@ interface EthSubscription extends ProviderMessage {
   type: 'eth_subscription';
   data: {
     subscription: string;
-    result: any;
+    result: unknown;
   };
 }
 ```

--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -27,16 +27,19 @@ The events `connect`, `disconnect`, `chainChanged`, and `accountsChanged` are pr
 Makes an Ethereum RPC method call.
 
 ```typescript
-type RequestParams = Array<any> | { [key: string]: any };
+interface RequestArguments {
+  method: string;
+  params?: Array<any> | { [key: string]: any };
+  [key: string]: any;
+}
 
-Provider.request(method: string, params?: RequestParams): Promise<unknown>;
+Provider.request(args: RequestArguments): Promise<unknown>;
 ```
 
 The Promise resolves with the method's result or rejects with a [`ProviderRpcError`](#errors). For example:
 
 ```javascript
-Provider
-  .request('eth_accounts')
+Provider.request({ method: 'eth_accounts' })
   .then((accounts) => console.log(accounts))
   .catch((error) => console.error(error));
 ```
@@ -146,7 +149,7 @@ interface ProviderMessage {
   data: unknown;
 }
 
-Provider.on('message', listener: (notification: ProviderMessage) => void): Provider;
+Provider.on('message', listener: (message: ProviderMessage) => void): Provider;
 ```
 
 ##### Subscriptions
@@ -189,7 +192,7 @@ var web3 = new Web3(ethereum);
 // B) Use Provider object directly
 // Example 1: Log chainId
 ethereum
-  .request('eth_chainId')
+  .request({ method: 'eth_chainId' })
   .then((chainId) => {
     console.log(`hexadecimal string: ${chainId}`);
     console.log(`decimal number: ${parseInt(chainId, 16)}`);
@@ -200,7 +203,10 @@ ethereum
 
 // Example 2: Log last block
 ethereum
-  .request('eth_getBlockByNumber', ['latest', 'true'])
+  .request({
+    method: 'eth_getBlockByNumber',
+    params: ['latest', 'true'],
+  })
   .then((block) => {
     console.log(`Block ${block.number}:`, block);
   })
@@ -213,7 +219,7 @@ ethereum
 
 // Example 3: Log available accounts
 ethereum
-  .request('eth_accounts')
+  .request({ method: 'eth_accounts' })
   .then((accounts) => {
     console.log(`Accounts:\n${accounts.join('\n')}`);
   })
@@ -226,11 +232,14 @@ ethereum
 
 // Example 4: Log new blocks
 ethereum
-  .request('eth_subscribe', ['newHeads'])
+  .request({
+    method: 'eth_subscribe',
+    params: ['newHeads'],
+  })
   .then((subscriptionId) => {
-    ethereum.on('notification', (notification) => {
-      if (notification.type === 'eth_subscription') {
-        const { data } = notification;
+    ethereum.on('message', (message) => {
+      if (message.type === 'eth_subscription') {
+        const { data } = message;
         if (data.subscription === subscriptionId) {
           if (typeof data.result === 'string' && data.result) {
             const block = data.result;
@@ -314,18 +323,24 @@ The Provider **MAY** expose methods and properties not specified in this documen
 
 #### request
 
+> The `request` method is intended as a transport- and protocol-agnostic wrapper function for Remote Procedure Calls (RPCs).
+
 ```typescript
-type RequestParams = Array<any> | { [key: string]: any };
+interface RequestArguments {
+  method: string;
+  params?: Array<any> | { [key: string]: any };
+  [key: string]: any;
+}
 
-Provider.request(method: string, params?: RequestParams): Promise<unknown>;
+Provider.request(args: RequestArguments): Promise<unknown>;
 ```
-
-The `request` method is intended as a transport- and protocol-agnostic wrapper function for Remote Procedure Calls (RPCs).
 
 The `request` method **MUST** send a properly formatted request to the Provider's Ethereum client.
 Requests **MUST** be handled such that, for a given set of arguments, the returned Promise either resolves with a value per the RPC method's specification, or rejects with an error.
 
-If present, the `params` argument **MUST** be structured value, either by-position as an `Array` or by-name as an `Object`.
+The `args` object **MAY** include properties not mentioned in this specification.
+
+If present, `args.params` **MUST** be a structured value, either by-position as an `Array` or by-name as an `Object`.
 
 If resolved, the Promise **MUST NOT** resolve with any RPC protocol-specific response objects, unless the RPC method's return type is so defined by its specification.
 
@@ -336,7 +351,7 @@ If the returned Promise rejects, it **MUST** reject with a `ProviderRpcError` as
 The returned Promise **MUST** reject if any of the following conditions are met:
 
 - The client returns an error for the RPC request.
-  - If error returned from the client is compatible with the `ProviderRpcError` interface, the Promise **MAY** reject with that error directly.
+  - If the error returned from the client is compatible with the `ProviderRpcError` interface, the Promise **MAY** reject with that error directly.
 - The Provider encounters an fails for any reason.
 - The request requires access to an unauthorized account, per [EIP 1102](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1102.md).
   - If rejecting for this reason, the Promise rejection error `code` **MUST** be `4100`.

--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -29,14 +29,14 @@ Makes an Ethereum RPC method call.
 ```typescript
 interface RequestArguments {
   method: string;
-  params?: Array<any> | { [key: string]: any };
+  params?: any;
   [key: string]: any;
 }
 
 Provider.request(args: RequestArguments): Promise<unknown>;
 ```
 
-The Promise resolves with the method's result or rejects with a [`ProviderRpcError`](#errors). For example:
+The returned Promise resolves with the method's result or rejects with a [`ProviderRpcError`](#errors). For example:
 
 ```javascript
 Provider.request({ method: 'eth_accounts' })
@@ -44,7 +44,7 @@ Provider.request({ method: 'eth_accounts' })
   .catch((error) => console.error(error));
 ```
 
-Consult each Ethereum RPC method's documentation for its return type.
+Consult each Ethereum RPC method's documentation for its `params` and return type.
 You can find a list of common methods [here](https://eips.ethereum.org/EIPS/eip-1474).
 
 #### RPC Protocols
@@ -328,7 +328,7 @@ The Provider **MAY** expose methods and properties not specified in this documen
 ```typescript
 interface RequestArguments {
   method: string;
-  params?: Array<any> | { [key: string]: any };
+  params?: any;
   [key: string]: any;
 }
 
@@ -339,8 +339,6 @@ The `request` method **MUST** send a properly formatted request to the Provider'
 Requests **MUST** be handled such that, for a given set of arguments, the returned Promise either resolves with a value per the RPC method's specification, or rejects with an error.
 
 The `args` object **MAY** include properties not mentioned in this specification.
-
-If present, `args.params` **MUST** be a structured value, either by-position as an `Array` or by-name as an `Object`.
 
 If resolved, the Promise **MUST NOT** resolve with any RPC protocol-specific response objects, unless the RPC method's return type is so defined by its specification.
 


### PR DESCRIPTION
File: https://github.com/rekmarks/EIPs/blob/1193-request-arg/EIPS/eip-1193.md

New signature for the `request` method:
```typescript
interface RequestArguments {
  method: string;
  params?: Array<any> | { [key: string]: any };
  [key: string]: any;
}

Provider.request(args: RequestArguments): Promise<unknown>;
```

Example call:
```javascript
Provider.request({ method: 'eth_accounts' })
  .then((accounts) => console.log(accounts))
  .catch((error) => console.error(error));
```

See document for further details.

This is motivated by discussions with @frozeman and others, and enables a future for the Provider interface generally and the `request` method specifically where any of the following holds:

- Multiple chains are served by a single Provider at once
- Multiple protocols are served by a single Provider at once
- The Provider needs some kind of metadata submitted along with `request` calls, for reasons we are unable to anticipate today

If we want EIP 1193 to function "in perpetuity", why not make the `request` method maximally flexible?