### PR TITLE
EIP-2315: fix opcodes in examples

### DIFF
--- a/EIPS/eip-2315.md
+++ b/EIPS/eip-2315.md
@@ -82,7 +82,7 @@ any `BEGINSUB` operation.
 
 This should jump into a subroutine, back out and stop.
 
-Bytecode: `0x6004b300b5b7`
+Bytecode: `0x6004b200b3b7`
 
 
 |  Pc   |      Op     | Cost |   Stack   |   RStack  |
@@ -96,7 +96,7 @@ Bytecode: `0x6004b300b5b7`
 ### Two levels of subroutines
 
 This should execute fine, going into one two depths of subroutines
-Bytecode: `0x6800000000000000000cb300b56011b3b7b5b7`
+Bytecode: `0x6800000000000000000cb200b36011b2b7b3b7`
 
 |  Pc   |      Op     | Cost |   Stack   |   RStack  |
 |-------|-------------|------|-----------|-----------|
@@ -116,7 +116,7 @@ Bytecode: `0x6800000000000000000cb300b56011b3b7b5b7`
 This should fail, since the given `location` is outside of the code-range. The code is the same as previous example, 
 except that the pushed `location` is `0x01000000000000000c` instead of `0x0c`.
 
-Bytecode: `0x6801000000000000000cb300b56011b3b7b5b7`
+Bytecode: `0x6801000000000000000cb200b36011b2b7b3b7	`
 
 |  Pc   |      Op     | Cost |   Stack   |   RStack  |
 |-------|-------------|------|-----------|-----------|


### PR DESCRIPTION
Ref: 
https://github.com/openethereum/openethereum/pull/11612#discussion_r404788297

Geth had the wrong opcodes defined, so the provided example bytecode/traces were wrong. Fixed with this PR