### PR TITLE
Add EFI EIPs

### DIFF
--- a/EIPS/eip-2378.md
+++ b/EIPS/eip-2378.md
@@ -50,6 +50,8 @@ Development of clear specifications and pull requests to existing Ethereum Clien
 | EIP-1962 | EC arithmetic and pairings with runtime definitions   | ELIGIBLE | 2019-11-01 | [🔗](https://github.com/ethereum/pm/blob/master/All%20Core%20Devs%20Meetings/Meeting%2074.md) |
 | EIP-1985 | Sane limits for certain EVM parameters                | ELIGIBLE | 2019-11-01 | [🔗](https://github.com/ethereum/pm/blob/master/All%20Core%20Devs%20Meetings/Meeting%2074.md) |
 | EIP-2046 | Reduced gas cost for static calls made to precompiles | ELIGIBLE | 2019-11-01 | [🔗](https://github.com/ethereum/pm/blob/master/All%20Core%20Devs%20Meetings/Meeting%2074.md) |
+| EIP-2315 | Simple Subroutines for the EVM                        | ELIGIBLE | 2020-02-21 | [🔗](https://github.com/ethereum/pm/blob/master/All%20Core%20Devs%20Meetings/Meeting%2081.md#decisions) |
+| EIP-2537 | Simple Subroutines for the EVM                        | ELIGIBLE | 2020-03-06 | [🔗](https://github.com/ethereum/pm/blob/master/All%20Core%20Devs%20Meetings/Meeting%2082.md) |
 
 ## Rationale
 


### PR DESCRIPTION
Adds EIP-2315 and EIP-2537 both of which are EFI and Accepted for Berlin.
