### PR TITLE
Fix misnamed EIP

### DIFF
--- a/EIPS/eip-2378.md
+++ b/EIPS/eip-2378.md
@@ -51,7 +51,7 @@ Development of clear specifications and pull requests to existing Ethereum Clien
 | EIP-1985 | Sane limits for certain EVM parameters                | ELIGIBLE | 2019-11-01 | [🔗](https://github.com/ethereum/pm/blob/master/All%20Core%20Devs%20Meetings/Meeting%2074.md) |
 | EIP-2046 | Reduced gas cost for static calls made to precompiles | ELIGIBLE | 2019-11-01 | [🔗](https://github.com/ethereum/pm/blob/master/All%20Core%20Devs%20Meetings/Meeting%2074.md) |
 | EIP-2315 | Simple Subroutines for the EVM                        | ELIGIBLE | 2020-02-21 | [🔗](https://github.com/ethereum/pm/blob/master/All%20Core%20Devs%20Meetings/Meeting%2081.md#decisions) |
-| EIP-2537 | Simple Subroutines for the EVM                        | ELIGIBLE | 2020-03-06 | [🔗](https://github.com/ethereum/pm/blob/master/All%20Core%20Devs%20Meetings/Meeting%2082.md) |
+| EIP-2537 | Precompile for BLS12-381 curve operations             | ELIGIBLE | 2020-03-06 | [🔗](https://github.com/ethereum/pm/blob/master/All%20Core%20Devs%20Meetings/Meeting%2082.md) |
 
 ## Rationale
 


### PR DESCRIPTION
Change name of EIP-2537 to its actual name, "Precompile for BLS12-381 curve operations". Source: https://github.com/ethereum/EIPs/pull/2537/files