### PR TITLE
Reserve chainId param for request method arguments

### DIFF
--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -329,6 +329,7 @@ The Provider **MAY** expose methods and properties not specified in this documen
 interface RequestArguments {
   method: string;
   params?: unknown;
+  chainId?: string;
   [key: string]: unknown;
 }
 
@@ -337,6 +338,12 @@ Provider.request(args: RequestArguments): Promise<unknown>;
 
 The `request` method **MUST** send a properly formatted request to the Provider's Ethereum client.
 Requests **MUST** be handled such that, for a given set of arguments, the returned Promise either resolves with a value per the RPC method's specification, or rejects with an error.
+
+If the `args` object includes the `chainId` property, its value **MUST** be the integer ID of a chain as a hexadecimal string, per the [`eth_chainId`](https://eips.ethereum.org/EIPS/eip-695) Ethereum RPC method.
+
+The Provider **MAY** handle the `chainId` property in any manner whatsoever.
+
+> The `chainId` property is specified here to reserve its name and format for the benefit of future Provider specifications. The authors recommend ignoring it unless there is good reason not to.
 
 The `args` object **MAY** include properties not mentioned in this specification.
 

--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -339,9 +339,9 @@ Provider.request(args: RequestArguments): Promise<unknown>;
 The `request` method **MUST** send a properly formatted request to the Provider's Ethereum client.
 Requests **MUST** be handled such that, for a given set of arguments, the returned Promise either resolves with a value per the RPC method's specification, or rejects with an error.
 
-If the `args` object includes the `chainId` property, its value **MUST** be the integer ID of a chain as a hexadecimal string, per the [`eth_chainId`](https://eips.ethereum.org/EIPS/eip-695) Ethereum RPC method.
+If the `args` object includes the `chainId` property, its value **SHOULD** be the integer ID of a chain as a hexadecimal string, per the [`eth_chainId`](https://eips.ethereum.org/EIPS/eip-695) Ethereum RPC method.
 
-The Provider **MAY** handle the `chainId` property in any manner whatsoever.
+The Provider **MAY** ignore the `chainId` property or interpret it in any manner whatsoever.
 
 > The `chainId` property is specified here to reserve its name and format for the benefit of future Provider specifications. The authors recommend ignoring it unless there is good reason not to.
 


### PR DESCRIPTION
File: https://github.com/rekmarks/EIPs/blob/1193-request-chainId/EIPS/eip-1193.md

Per @frozeman's suggestion, reserve the `chainId` key on the `RequestArguments` interface for values per the `eth_chainId` Ethereum RPC method.

Intentionally does not specify what to do with this property, and does not include it in the API portion of the documentation, as its already implicitly allowed, and specifying what it does is beyond the scope of this EIP.