### PR TITLE
1193: Move to Last Call

### DIFF
--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -3,7 +3,7 @@ eip: 1193
 title: Ethereum Provider JavaScript API
 author: Fabian Vogelsteller (@frozeman), Ryan Ghods (@ryanio), Victor Maia (@MaiaVictor), Marc Garreau (@marcgarreau)
 discussions-to: https://github.com/ethereum/EIPs/issues/2319
-status: Draft
+status: Last Call **(review ends 2020-06-04)**
 type: Standards Track
 category: Interface
 created: 2018-06-30

--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -3,7 +3,8 @@ eip: 1193
 title: Ethereum Provider JavaScript API
 author: Fabian Vogelsteller (@frozeman), Ryan Ghods (@ryanio), Victor Maia (@MaiaVictor), Marc Garreau (@marcgarreau)
 discussions-to: https://github.com/ethereum/EIPs/issues/2319
-status: Last Call **(review ends 2020-06-04)**
+status: Last Call
+review-period-end: 2020-06-04
 type: Standards Track
 category: Interface
 created: 2018-06-30


### PR DESCRIPTION
Moves EIP 1193 to Last Call, with the review period ending after 6 weeks on 2020-06-04 (June 4, 2020).

Review period format follows the convention of the majority of EIPs in Last Call, e.g. https://eips.ethereum.org/EIPS/eip-875