### PR TITLE
1193: Remove web3 from example

### DIFF
--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -186,11 +186,6 @@ interface ProviderRpcError extends Error {
 // Please consult the Provider implementation's documentation.
 const ethereum = window.ethereum;
 
-// A) Set Provider in web3.js
-var web3 = new Web3(ethereum);
-// web3.eth.getBlock('latest', true).then(...)
-
-// B) Use Provider object directly
 // Example 1: Log chainId
 ethereum
   .request({ method: 'eth_chainId' })


### PR DESCRIPTION
Removes `web3` from examples in 1193.

@ryanio 
#2319 