### PR TITLE
1193: Remove unnecessary EIP dependencies

### DIFF
--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -15,7 +15,7 @@ requires: 155, 695
 
 This EIP formalizes a JavaScript Ethereum Provider API for consistency across clients and applications.
 
-The Provider's interface is designed to be minimal, preferring that features are introduced in the API layer (see e.g. [`eth_requestAccounts`](https://eips.ethereum.org/EIPS/eip-1102)), and agnostic of transport and RPC protocols.
+The Provider's interface is designed to be minimal, preferring that features are introduced in the API layer (see e.g. [`eth_requestAccounts`](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1102.md)), and agnostic of transport and RPC protocols.
 
 Historically, Providers have been made available as `window.ethereum` in web browsers, but this convention is not part of the specification.
 
@@ -487,6 +487,10 @@ The "accounts available to the Provider" change when the return value of `eth_ac
 - [Initial discussion in `ethereum/interfaces`](https://github.com/ethereum/interfaces/issues/16)
 - [Ethereum Magicians thread](https://ethereum-magicians.org/t/eip-1193-ethereum-provider-javascript-api/640)
 - [Continuing EIP-1193 discussion](https://github.com/ethereum/EIPs/issues/2319)
+- Related EIPs
+  - [EIP 1102](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1102.md)
+  - [EIP 1474](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1474.md)
+  - [EIP 1767](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1767.md)
 
 ## Copyright
 

--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -488,7 +488,7 @@ The "accounts available to the Provider" change when the return value of `eth_ac
 - [Ethereum Magicians thread](https://ethereum-magicians.org/t/eip-1193-ethereum-provider-javascript-api/640)
 - [Continuing EIP-1193 discussion](https://github.com/ethereum/EIPs/issues/2319)
 - Related EIPs
-  - [EIP 1102](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1102.md)
+  - [EIP 1102](https://eips.ethereum.org/EIPS/eip-1102)
   - [EIP 1474](https://eips.ethereum.org/EIPS/eip-1474)
   - [EIP 1767](https://eips.ethereum.org/EIPS/eip-1767)
 

--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -8,14 +8,14 @@ review-period-end: 2020-06-04
 type: Standards Track
 category: Interface
 created: 2018-06-30
-requires: 155, 695, 1102, 1474, 1767
+requires: 155, 695
 ---
 
 ## Summary
 
 This EIP formalizes a JavaScript Ethereum Provider API for consistency across clients and applications.
 
-The Provider's interface is designed to be minimal, preferring that features are introduced in the API layer (e.g. see [`eth_requestAccounts`](https://eips.ethereum.org/EIPS/eip-1102)), and agnostic of transport and RPC protocols.
+The Provider's interface is designed to be minimal, preferring that features are introduced in the API layer (see e.g. [`eth_requestAccounts`](https://eips.ethereum.org/EIPS/eip-1102)), and agnostic of transport and RPC protocols.
 
 Historically, Providers have been made available as `window.ethereum` in web browsers, but this convention is not part of the specification.
 
@@ -50,11 +50,10 @@ You can find a list of common methods [here](https://eips.ethereum.org/EIPS/eip-
 
 #### RPC Protocols
 
-Multiple RPC protocols may be available.
+Multiple RPC protocols may be available. For examples, see:
 
-[EIP 1474](https://eips.ethereum.org/EIPS/eip-1474) specifies the Ethereum JSON-RPC API.
-
-[EIP 1767](https://eips.ethereum.org/EIPS/eip-1767) specifies the Ethereum GraphQL schema.
+- [EIP 1474](https://eips.ethereum.org/EIPS/eip-1474), the Ethereum JSON-RPC API
+- [EIP 1767](https://eips.ethereum.org/EIPS/eip-1767), the Ethereum GraphQL schema
 
 ### sendAsync (DEPRECATED)
 
@@ -346,9 +345,9 @@ The returned Promise **MUST** reject if any of the following conditions are met:
 
 - The client returns an error for the RPC request.
   - If the error returned from the client is compatible with the `ProviderRpcError` interface, the Promise **MAY** reject with that error directly.
-- The Provider encounters an fails for any reason.
-- The request requires access to an unauthorized account, per [EIP 1102](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1102.md).
-  - If rejecting for this reason, the Promise rejection error `code` **MUST** be `4100`.
+- The Provider encounters an error or fails to process the request for any reason.
+
+> If the Provider implements any kind of authorization logic, the authors recommend rejecting with a `4100` error in case of authorization failures.
 
 The returned Promise **SHOULD** reject if any of the following conditions are met:
 
@@ -369,7 +368,7 @@ Providers **MAY** support whatever RPC methods required to fulfill their purpose
 
 If a Provider supports a method defined in a finalized EIP, the Provider's implementation of this method **MUST** adhere to the method's specification.
 
-If an RPC method defined in a finalized EIP is not supported, it **SHOULD** be rejected with an appropriate error per [EIP 1474](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1474.md#error-codes).
+If an RPC method defined in a finalized EIP is not supported, it **SHOULD** be rejected with a `4200` error per the [Provider Errors](#provider-errors) section below, or an appropriate error per the RPC method's specification.
 
 #### RPC Errors
 
@@ -396,7 +395,7 @@ interface ProviderRpcError extends Error {
 
 1. The errors in the [Provider Errors](#provider-errors) section below
 
-2. The [Ethereum JSON-RPC API error codes](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1474.md#error-codes)
+2. Any errors mandated by the erroring RPC method's specification
 
 3. The [`CloseEvent` status codes](https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent#Status_codes)
 

--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -66,7 +66,7 @@ Provider.sendAsync(request: Object, callback: Function): void;
 ```
 
 The interfaces of request and response objects are not specified here.
-Historically, they have followed the [Ethereum JSON-RPC specification](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1474.md).
+Historically, they have followed the [Ethereum JSON-RPC specification](https://eips.ethereum.org/EIPS/eip-1474).
 
 ### send (DEPRECATED)
 
@@ -489,8 +489,8 @@ The "accounts available to the Provider" change when the return value of `eth_ac
 - [Continuing EIP-1193 discussion](https://github.com/ethereum/EIPs/issues/2319)
 - Related EIPs
   - [EIP 1102](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1102.md)
-  - [EIP 1474](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1474.md)
-  - [EIP 1767](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1767.md)
+  - [EIP 1474](https://eips.ethereum.org/EIPS/eip-1474)
+  - [EIP 1767](https://eips.ethereum.org/EIPS/eip-1767)
 
 ## Copyright
 

--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -15,7 +15,7 @@ requires: 155, 695
 
 This EIP formalizes a JavaScript Ethereum Provider API for consistency across clients and applications.
 
-The Provider's interface is designed to be minimal, preferring that features are introduced in the API layer (see e.g. [`eth_requestAccounts`](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1102.md)), and agnostic of transport and RPC protocols.
+The Provider's interface is designed to be minimal, preferring that features are introduced in the API layer (see e.g. [`eth_requestAccounts`](https://eips.ethereum.org/EIPS/eip-1102)), and agnostic of transport and RPC protocols.
 
 Historically, Providers have been made available as `window.ethereum` in web browsers, but this convention is not part of the specification.
 


### PR DESCRIPTION
File: https://github.com/rekmarks/EIPs/blob/1193-remove-dependencies/EIPS/eip-1193.md

Removes the following EIPs from the list of required EIPs, and adds them to references at the end of the document:
- 1102
- 1474
- 1767

#2319