### PR TITLE
Change "hard fork" to "network upgrade" in EIPs documentation

### DIFF
--- a/EIPS/eip-1.md
+++ b/EIPS/eip-1.md
@@ -24,7 +24,7 @@ For Ethereum implementers, EIPs are a convenient way to track the progress of th
 There are three types of EIP:
 
 - A **Standard Track EIP** describes any change that affects most or all Ethereum implementations, such as a change to the network protocol, a change in block or transaction validity rules, proposed application standards/conventions, or any change or addition that affects the interoperability of applications using Ethereum. Furthermore Standard EIPs can be broken down into the following categories. Standards Track EIPs consist of three parts, a design document, implementation, and finally if warranted an update to the [formal specification].
-  - **Core** - improvements requiring a consensus fork (e.g. [EIP5], [EIP101]), as well as changes that are not necessarily consensus critical but may be relevant to [“core dev” discussions](https://github.com/ethereum/pm) (for example, [EIP90], and the miner/node strategy changes 2, 3, and 4 of [EIP86]).
+  - **Core** - improvements requiring a network upgrade (e.g. [EIP5], [EIP101]), as well as changes that are not necessarily consensus critical but may be relevant to [“core dev” discussions](https://github.com/ethereum/pm) (for example, [EIP90], and the miner/node strategy changes 2, 3, and 4 of [EIP86]).
   - **Networking** - includes improvements around [devp2p] ([EIP8]) and [Light Ethereum Subprotocol], as well as proposed improvements to network protocol specifications of [whisper] and [swarm].
   - **Interface** - includes improvements around client [API/RPC] specifications and standards, and also certain language-level standards like method names ([EIP6]) and [contract ABIs]. The label “interface” aligns with the [interfaces repo] and discussion should primarily occur in that repository before an EIP is submitted to the EIPs repository.
   - **ERC** - application-level standards and conventions, including contract standards such as token standards ([ERC20]), name registries ([ERC26], [ERC137]), URI schemes ([ERC67]), library/package formats ([EIP82]), and wallet formats ([EIP75], [EIP85]).
@@ -37,10 +37,16 @@ An EIP must meet certain minimum criteria. It must be a clear and complete descr
 
 ### Special requirements for Core EIPs
 
+#### EVM Changes
+
 If a **Core** EIP mentions or proposes changes to the EVM (Ethereum Virtual Machine), it should refer to the instructions by their mnemonics and define the opcodes of those mnemonics at least once. A preferred way is the following:
 ```
 REVERT (0xfe)
 ```
+
+#### Nomenclature
+
+Core EIPs are activated by nodes on the network at a coordinated block. While, strictly speaking, these events are technically "hard forks", for a large portion of users new to Ethereum, "hard fork" implies a chain split in a way that "network upgrade" does not. Given that the vast majority of past upgrades on Ethereum have been non-contentious, that the EIPs process focuses on technical standardization rather than upgrade coordination, and that the term "chain split" accurately describes the potential outcome of a contentious upgrade, the term "network upgrade" is preferred in EIPs. 
 
 ## EIP Work Flow
 

--- a/EIPS/eip-1.md
+++ b/EIPS/eip-1.md
@@ -46,7 +46,9 @@ REVERT (0xfe)
 
 #### Nomenclature
 
-Core EIPs are activated by nodes on the network at a coordinated block. While, strictly speaking, these events are technically "hard forks", for a large portion of users new to Ethereum, "hard fork" implies a chain split in a way that "network upgrade" does not. Given that the vast majority of past upgrades on Ethereum have been non-contentious, that the EIPs process focuses on technical standardization rather than upgrade coordination, and that the term "chain split" accurately describes the potential outcome of a contentious upgrade, the term "network upgrade" is preferred in EIPs. 
+Core EIPs are activated by nodes on the network at a specific block. Nodes that do not activate the upgrade on that block are disconnected from the rest of the network. Strictly speaking, these events are known as **hard forks**. While they can sometimes be contentious and lead to **chain splits**, where a pre- and post-upgrade version of the network keep running in parallel, historically, most upgrades have been non-contentious and have not led to splits. 
+
+Because of this, and because the term "hard fork" implies a chain split for newcomers to Ethereum in a way that "network upgrade" does not, the latter is preferred in EIPs. 
 
 ## EIP Work Flow
 
@@ -98,7 +100,7 @@ Each status change is requested by the EIP author and reviewed by the EIP editor
   * :x: -- A Last Call which results in material changes or substantial unaddressed technical complaints will cause the EIP to revert to Draft.
   * :arrow_right: Accepted (Core EIPs only) -- A successful Last Call without material changes or unaddressed technical complaints will become Accepted.
   * :arrow_right: Final (Non-Core EIPs) -- A successful Last Call without material changes or unaddressed technical complaints will become Final.
-* **Accepted (Core EIPs only)** -- This status signals that material changes are unlikely and Ethereum client developers should consider this EIP for inclusion. Their process for deciding whether to encode it into their clients as part of a hard fork is not part of the EIP process.
+* **Accepted (Core EIPs only)** -- This status signals that material changes are unlikely and Ethereum client developers should consider this EIP for inclusion. Their process for deciding whether to encode it into their clients as part of a network upgrade is not part of the EIP process.
   * :arrow_right: Draft -- The Core Devs can decide to move this EIP back to the Draft status at their discretion. E.g. a major, but correctable, flaw was found in the EIP.
   * :arrow_right: Rejected -- The Core Devs can decide to mark this EIP as Rejected at their discretion. E.g. a major, but uncorrectable, flaw was found in the EIP.
   * :arrow_right: Final -- Standards Track Core EIPs must be implemented in at least three viable Ethereum clients before it can be considered Final. When the implementation is complete and adopted by the community, the status will be changed to “Final”.

--- a/EIPS/eip-2070.md
+++ b/EIPS/eip-2070.md
@@ -1,6 +1,6 @@
 ---
 eip: 2070
-title: "Hardfork Meta: Berlin"
+title: "Network Upgrade Meta: Berlin"
 author: Alex Beregszaszi (@axic)
 discussions-to: https://ethereum-magicians.org/t/hardfork-meta-eip-2070-berlin-discussion/3561
 type: Meta
@@ -11,7 +11,7 @@ requires: 1679
 
 ## Abstract
 
-This meta-EIP specifies the changes included in the Ethereum hardfork named Berlin.
+This meta-EIP specifies the changes included in the Ethereum network upgrade named Berlin.
 
 ## Specification
 

--- a/README.md
+++ b/README.md
@@ -21,16 +21,16 @@ Once your first PR is merged, we have a bot that helps out by automatically merg
 
 When you believe your EIP is mature and ready to progress past the draft phase, you should do one of two things:
 
- - **For a Standards Track EIP of type Core**, ask to have your issue added to [the agenda of an upcoming All Core Devs meeting](https://github.com/ethereum/pm/issues), where it can be discussed for inclusion in a future hard fork. If implementers agree to include it, the EIP editors will update the state of your EIP to 'Accepted'.
+ - **For a Standards Track EIP of type Core**, ask to have your issue added to [the agenda of an upcoming All Core Devs meeting](https://github.com/ethereum/pm/issues), where it can be discussed for inclusion in a future network upgrade. If implementers agree to include it, the EIP editors will update the state of your EIP to 'Accepted'.
  - **For all other EIPs**, open a PR changing the state of your EIP to 'Final'. An editor will review your draft and ask if anyone objects to its being finalised. If the editor decides there is no rough consensus - for instance, because contributors point out significant issues with the EIP - they may close the PR and request that you fix the issues in the draft before trying again.
 
 # EIP Status Terms
 
 * **Draft** - an EIP that is undergoing rapid iteration and changes.
 * **Last Call** - an EIP that is done with its initial iteration and ready for review by a wide audience.
-* **Accepted** - a core EIP that has been in Last Call for at least 2 weeks and any technical changes that were requested have been addressed by the author. The process for Core Devs to decide whether to encode an EIP into their clients as part of a hard fork is not part of the EIP process. If such a decision is made, the EIP will move to final.
+* **Accepted** - a core EIP that has been in Last Call for at least 2 weeks and any technical changes that were requested have been addressed by the author. The process for Core Devs to decide whether to encode an EIP into their clients as part of a network upgrade is not part of the EIP process. If such a decision is made, the EIP will move to final.
 * **Final (non-Core)** - an EIP that has been in Last Call for at least 2 weeks and any technical changes that were requested have been addressed by the author.
-* **Final (Core)** - an EIP that the Core Devs have decided to implement and release in a future hard fork or has already been released in a hard fork. 
+* **Final (Core)** - an EIP that the Core Devs have decided to implement and release in a future network upgrade or has already been released in a network upgrade. 
 
 # Preferred Citation Format
 

--- a/index.html
+++ b/index.html
@@ -16,9 +16,9 @@ title: Home
 <ul>
   <li><strong>Draft</strong> - an EIP that is open for consideration and is undergoing rapid iteration and changes.</li>
   <li><strong>Last Call</strong> - an EIP that is done with its initial iteration and ready for review by a wide audience.</li>
-  <li><strong>Accepted</strong> - a core EIP that has been in Last Call for at least 2 weeks and any technical changes that were requested have been addressed by the author. The process for Core Devs to decide whether to encode an EIP into their clients as part of a hard fork is not part of the EIP process. If such a decision is made, the EIP will move to final. </li>
+  <li><strong>Accepted</strong> - a core EIP that has been in Last Call for at least 2 weeks and any technical changes that were requested have been addressed by the author. The process for Core Devs to decide whether to encode an EIP into their clients as part of a network upgrade is not part of the EIP process. If such a decision is made, the EIP will move to final. </li>
   <li><strong>Final (non-Core)</strong> - an EIP that has been in Last Call for at least 2 weeks and any technical changes that were requested have been addressed by the author.</li>
-  <li><strong>Final (Core)</strong> - an EIP that the Core Devs have decided to implement and release in a future hard fork or has already been released in a hard fork.</li>
+  <li><strong>Final (Core)</strong> - an EIP that the Core Devs have decided to implement and release in a future network upgrade or has already been released in a network upgrade.</li>
 </ul>
 
 <h2>EIP Types</h2>
@@ -29,7 +29,7 @@ title: Home
 <p>Describes any change that affects most or all Ethereum implementations, such as a change to the the network protocol, a change in block or transaction validity rules, proposed application standards/conventions, or any change or addition that affects the interoperability of applications using Ethereum. Furthermore Standard EIPs can be broken down into the following categories.</p>
 
 <h4><a href="{{"core"|relative_url}}">Core</a> ({{site.pages|where:"type","Standards Track"|where:"category","Core"|size}})</h4>
-<p>Improvements requiring a consensus fork (e.g. <a href="EIPS/eip-5">EIP5</a>, <a href="EIPS/eip-101">EIP101</a>), as well as changes that are not necessarily consensus critical but may be relevant to “core dev” discussions (for example, the miner/node strategy changes 2, 3, and 4 of <a href="EIPS/eip-86">EIP86</a>).</p>
+<p>Improvements requiring a network upgrade (e.g. <a href="EIPS/eip-5">EIP5</a>, <a href="EIPS/eip-101">EIP101</a>), as well as changes that are not necessarily consensus critical but may be relevant to “core dev” discussions (for example, the miner/node strategy changes 2, 3, and 4 of <a href="EIPS/eip-86">EIP86</a>).</p>
 
 <h4><a href="{{"networking"|relative_url}}">Networking</a> ({{site.pages|where:"type","Standards Track"|where:"category","Networking"|size}})</h4>
 <p>Includes improvements around devp2p (<a href="EIPS/eip-8">EIP8</a>) and Light Ethereum Subprotocol, as well as proposed improvements to network protocol specifications of whisper and swarm.</p>


### PR DESCRIPTION
As agreed to on the last AllCoreDevs call (see [stream](https://youtu.be/MOZ7_0Tb95M?t=3080)) and during the EIPIP meetings ([notes](https://github.com/ethereum-cat-herders/EIPIP/blob/master/All%20EIPIP%20Meetings/Meeting%20004.md)), I've changed the term "hard fork" to "network upgrade" in EIP-1, the eips.ethereum.org index page, the repo README and for the upcoming upgrade, Berlin (cc: @axic). 

The reasons for this change, as described on the call, were the following:
* "Hard Fork", while technically accurate, often is perceived by newcomers to Ethereum as to mean "chain split" (and possibly "free coins"). 
* Most previous HFs/upgrades on Ethereum did **not** result in a chain split, and using "network upgrade" does not bring this connotation to new users, so it should be used as a default, with the possibility of chain splits being explicit
* The EF has used "network upgrade" over "hard fork" for the past couple upgrades, see [Istanbul](https://blog.ethereum.org/2019/11/20/ethereum-istanbul-upgrade-announcement/), [Constantinople](https://blog.ethereum.org/2019/02/22/ethereum-constantinople-st-petersburg-upgrade-announcement/). 

On the last ACD call, it seem like there was agreement by core devs on moving this forward, modulo feedback on the specific wording. This is the place for that feedback 😄 

Note: this does **not** remove previous instances of the term "hard fork" across the EIP repo/all EIPs. Only in the "guidelines" document and for the upcoming upgrade. 

Ethereum Magicians discussion link: https://ethereum-magicians.org/t/using-network-upgrade-over-hard-fork-in-the-eips-repo/4255