### PR TITLE
EIP-695: clarify what happens if a chain initially does not have chain ID or chain ID has changed

### DIFF
--- a/EIPS/eip-695.md
+++ b/EIPS/eip-695.md
@@ -36,6 +36,10 @@ the RPC.
 Returns the currently configured chain ID, a value used in replay-protected transaction
 signing as introduced by [EIP-155](./eip-155.md).
 
+The chain ID returned should always correspond to the information in the current known
+head block. This ensures that caller of this RPC method can always use the retrieved
+information to sign transactions built on top of the head.
+
 #### Parameters
 
 None.


### PR DESCRIPTION
This addresses https://ethereum-magicians.org/t/eip-695-create-eth-chainid-method-for-json-rpc/1845/19

We clarify that chain ID returned should always be corresponding to the head block. This is also how OpenEthereum currently implements it. The rationale is that by doing this we ensure caller can always use the retrieved information to sign transactions on top of the head.