### PR TITLE
ERC-695: Specify behavior in absence of chainId

### DIFF
--- a/EIPS/eip-695.md
+++ b/EIPS/eip-695.md
@@ -40,6 +40,10 @@ The chain ID returned should always correspond to the information in the current
 head block. This ensures that caller of this RPC method can always use the retrieved
 information to sign transactions built on top of the head.
 
+If the current known head block does not specify a chain ID, the client should treat any
+calls to `eth_chainId` as though the method were not supported, and return a suitable
+error.
+
 #### Parameters
 
 None.


### PR DESCRIPTION
This PR specifies that `eth_chainId` should "return a suitable error" if the latest head block "has no chain id".