### PR TITLE
Rename and clarify disconnection errors

### DIFF
--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -407,7 +407,7 @@ interface ProviderRpcError extends Error {
 | 4100        | Unauthorized          | The requested method and/or account has not been authorized by the user. |
 | 4200        | Unsupported Method    | The Provider does not support the requested method.                      |
 | 4900        | Disconnected          | The Provider is disconnected from all chains.                            |
-| 4901        | Chain Disconnected    | The Provider is disconnected from the requested chain.                   |
+| 4901        | Chain Disconnected    | The Provider is not connected to the requested chain.                   |
 
 > `4900` is intended to indicate that the Provider is disconnected from all chains, while `4901` is intended to indicate that the Provider is disconnected from a specific chain only.
 > In other words, `4901` implies that the Provider is connected to other chains, just not the requested one.

--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -303,9 +303,9 @@ Provider implementers are encouraged to work with each other and with dapp devel
 
 ### Connectivity
 
-The Provider is said to be "connected" when it can service RPC requests to any chain.
+The Provider is said to be "connected" when it can service RPC requests to at least one chain.
 
-The Provider is said to "disconnected" when it cannot service RPC requests to any chain.
+The Provider is said to be "disconnected" when it cannot service RPC requests to any chain at all.
 
 > To service an RPC request, the Provider must successfully submit the request to the remote location, and receive a response.
 > In other words, if the Provider is unable to communicate with its Client, for example due to network issues, the Provider is disconnected.
@@ -353,7 +353,7 @@ The returned Promise **SHOULD** reject if any of the following conditions are me
 
 - The Provider is disconnected.
   - If rejecting for this reason, the Promise rejection error `code` **MUST** be `4900`.
-- The RPC request is directed at a specific chain, and the Provider is not connected to that chain.
+- The RPC request is directed at a specific chain, and the Provider is not connected to that chain, but is connected to at least one other chain.
   - If rejecting for this reason, the Promise rejection error `code` **MUST** be `4901`.
 
 See the section [Connectivity](#connectivity) for the definitions of "connected" and "disconnected".
@@ -406,8 +406,11 @@ interface ProviderRpcError extends Error {
 | 4001        | User Rejected Request | The user rejected the request.                                           |
 | 4100        | Unauthorized          | The requested method and/or account has not been authorized by the user. |
 | 4200        | Unsupported Method    | The Provider does not support the requested method.                      |
-| 4900        | Not Connected         | The Provider is not connected to any chains.                             |
-| 4901        | Chain Not Connected   | The Provider is not connected to the requested chain.                    |
+| 4900        | Disconnected          | The Provider is disconnected from all chains.                            |
+| 4901        | Chain Disconnected    | The Provider is disconnected from the requested chain.                   |
+
+> `4900` is intended to indicate that the Provider is disconnected from all chains, while `4901` is intended to indicate that the Provider is disconnected from a specific chain only.
+> In other words, `4901` implies that the Provider is connected to other chains, just not the requested one.
 
 ### Events
 


### PR DESCRIPTION
[Link to rendered file with updates.](https://github.com/rekmarks/EIPs/blob/1193-clarify-disconnect-errors/EIPS/eip-1193.md)

The errors related to connectivity were somewhat underspecified, and oddly named. Their names and descriptions have been updated, and a non-normative comment has been added.