### PR TITLE
Removes block size and transaction size riders from EIP 1559.

### DIFF
--- a/EIPS/eip-1559.md
+++ b/EIPS/eip-1559.md
@@ -45,14 +45,23 @@ The transition to this gas price system will occur in two phases, in the first p
 <!--The technical specification should describe the syntax and semantics of any new feature. The specification should be detailed enough to allow competing, interoperable implementations for any of the current Ethereum platforms (go-ethereum, parity, cpp-ethereum, ethereumj, ethereumjs, and [others](https://github.com/ethereum/wiki/wiki/Clients)).-->
 **Parameters**
 * `INITIAL_FORK_BLKNUM`: TBD
-* `BASEFEE_MAX_CHANGE_DENOMINATOR`: 8
-* `TARGET_GAS_USED`: 10,000,000
-* `MAX_GAS_EIP1559`: 16,000,000
-* `EIP1559_DECAY_RANGE`: `MAX_GAS_EIP1559 / 20` == `800,000`
-* `FINAL_FORK_BLKNUM`:  `INITIAL_FORK_BLKNUM + EIP1559_DECAY_RANGE`
-* `EIP1559_GAS_INCREMENT_AMOUNT`: `(MAX_GAS_EIP1559 / 2) / EIP1559_DECAY_RANGE` == `10`
+* `MIGRATION_DURATION_IN_BLOCKS`: 800,000
+* `FINAL_FORK_BLKNUM`: `INITIAL_FORK_BLKNUM + MIGRATION_DURATION_IN_BLOCKS`
+* `EIP1559_INITIAL_GAS_TARGET`: `BLOCK_GAS_TARGET / 2`
+* `LEGACY_INITIAL_GAS_LIMIT`: `BLOCK_GAS_TARGET - EIP1559_GAS_TARGET`
+* `EIP1559_GAS_TARGET`:
+  ```
+  if CURRENT_BLKNUM >= FINAL_FORK_BLOKNUM then
+    BLOCK_GAS_TARGET
+  elif CURRNT_BLKNUM < INITIAL_FORK_BLKNUM then
+    0
+  else
+    EIP1559_INITIAL_GAS_TARGET + LEGACY_INITIAL_GAS_LIMIT * (CURRENT_BLKNUM - INITIAL_FORK_BLKNUM) / MIGRATION_DURATION_IN_BLOCKS
+  ```
+* `LEGACY_GAS_LIMIT`: `BLOCK_GAS_TARGET - EIP1559_GAS_TARGET`
+* `EIP1559_GAS_LIMIT`: `EIP1559_GAS_TARGET * 2`
+* `BASEFEE_MAX_CHANGE_DENOMINATOR`: `8`
 * `INITIAL_BASEFEE` : 1,000,000,000 wei (1 gwei)
-* `PER_TX_GASLIMIT`: 8,000,000
 
 
 **Proposal**
@@ -60,13 +69,12 @@ For all blocks where `block.number >= INITIAL_FORK_BLKNUM`:
 
 For the gas limit:
 
-* `MAX_GAS_EIP1559` acts as the hard in-protocol gas limit, instead of the gas limit calculated using the previously existing formulas
-* The `GASLIMIT` field in the block header is the gas limit for the EIP1559 gas pool, and over the transition period this value increases until it reaches `MAX_GAS_EIP1559` at `FINAL_FORK_BLKNUM`
-* The gas limit for the legacy gas pool is `MAX_GAS_EIP1559 - GASLIMIT`, as `GASLIMIT` increases towards `MAX_GAS_EIP1559` gas is moved from the legacy pool into the EIP1559 pool until all of the gas is in the EIP1559 pool
-* At `block.number == INITIAL_FORK_BLKNUM`, let `GASLIMIT = (MAX_GAS_EIP1559 / 2)` so that the gas maximum is split evenly between the legacy and EIP1559 gas pools
-* As `block.number` increases towards `FINAL_FORK_BLKNUM`, at every block we shift `EIP1559_GAS_INCREMENT_AMOUNT` from the legacy pool into the EIP1559 gas pool
-* At `block.number >= FINAL_FORK_BLKNUM` the entire `MAX_GAS_EIP1559` is assigned to the EIP1559 gas pool and the legacy pool is empty
-* We enforce a maximum gas usage on individual transactions: `PER_TX_GASLIMIT`
+* The field in the block header previously referred to as `GASLIMIT` will now be referred to colloquially as `GAS_TARGET`.  Its value will still be controlled by miners in the same way as previously.  It represents the total gas available to the legacy gas pool as well as the target gas of the EIP1559 gas pool.
+* `EIP1559_GAS_LIMIT` is the space available for EIP1559 transactions (EIP1559 gas pool) and it is a function of `BLOCK_GAS_TARGET` and blocks since `INITIAL_FORK_BLKNUM`.  It becomes equal to `BLOCK_GAS_TARGET * 2` for blocks >= `FINAL_FORK_BLKNUM`
+* The gas limit for the legacy gas pool is `BLOCK_GAS_TARGET - EIP1559_GAS_TARGET`.  As `EIP1559_GAS_TARGET` increases towards `BLOCK_GAS_TARGET`, gas is moved from the legacy pool into the EIP1559 pool until all of the gas is in the EIP1559 pool
+* At `block.number == INITIAL_FORK_BLKNUM`, let `EIP1559_GAS_LIMIT = (GASLIMIT / 2)` so that the gas maximum is split evenly between the legacy and EIP1559 gas pools
+* As `block.number` increases towards `FINAL_FORK_BLKNUM`, at every block we shift `1/MIGRATION_DURATION_IN_BLOCKS` gas from the legacy pool into the EIP1559 gas pool (effectively doubling it as it moves, since the EIP1559 gas target is half of the limit)
+* At `block.number >= FINAL_FORK_BLKNUM` the entire `BLOCK_GAS_TARGET` is assigned to the EIP1559 gas pool and the legacy pool is 0
 
 For the gas price:
 


### PR DESCRIPTION
This EIP previously changed the mechanism for calculating block size from a miner-voted mechanism to a hard-coded mechanism.  This change is not necessary for the implementation of EIP1559, so this PR removes it and updates EIP 1559 to retain miner voted block sizing.

## Opinion
Riders are very unhealthy for governance.  While in this case I suspect that the rider may not have been intentionally underhanded, I think we (EIP authors/editors/core devs) need to be very cautious about allowing riders to become a norm.  I have seen them included in more and more EIPs lately, especially controversial topics like miner issuance reductions.

I do not think it is unreasonable to change from miner voted block size to core dev defined block sizes, but that should occur as its own EIP and debated on its own merits, rather than being bundled in with this EIP.  It should also, ideally, be configurable per-chain separately from EIP-1559.

cc @vbuterin @econoar @AFDudley @mslipper @i-norden (EIP-1559 authors)