### PR TITLE
enter only via jumpsub

### DIFF
--- a/EIPS/eip-2315.md
+++ b/EIPS/eip-2315.md
@@ -27,7 +27,7 @@ We introduce one more stack into the EVM, called `return_stack`. The `return_sta
 
 ##### `BEGINSUB`
 
-Marks the entry point to a subroutine.
+Marks the entry point to a subroutine.  Subroutines can only be entered via `JUMPSUB`.  Execution of BEGINSUB causes an exception (OOG: all gas consumed) and terminates execution. 
 
 pops: `0`
 pushes: `0`
@@ -38,14 +38,12 @@ pushes: `0`
   - 1.1 If the opcode at `location` is not a `BEGINSUB`, abort with error.
 2. Pushes the current `pc+1` to the `return_stack`. (See Note 1 below)
   - 2.1 If the `return_stack` already has `1023` items, abort with error.
-3. Sets the `pc` to `location`.
+3. Sets the `pc` to `location + 1`. 
+
+**Note 1:** If the resulting `pc` is beyond the last instruction then the opcode is implicitly a `STOP`, which is not an error.
 
 pops: `1`
 pushes: `0` (`return_stack` pushes: `1`)
-
-**Note 1:** The description above lays out the _semantics_ of the `JUMPSUB`. It's up to node implementations to decide the internal representation. For example, a node may decide
-to place `PC` on the `return_stack` at `JUMPSUB`, as long as the `RETURNSUB` correctly returns to the `PC+1` location. The internals of the `return_stack` is not one of the
-"observable"/consensus-critical parts of the EVM.
 
 ##### `RETURNSUB`
 
@@ -58,6 +56,8 @@ pushes: `0`
 
 **Note 2:** Values popped from `return_stack` do not need to be validated, since they cannot be set arbitrarily from code, only implicitly by the evm. 
 **Note 3:** A value popped from `return_stack` _may_ be outside of the code length, if the last `JUMPSUB` was the last byte of the `code`. In this case the next opcode is implicitly a `STOP`, which is not an error.
+
+**Note 4:** The description above lays out the _semantics_ of this feature in terms of a `return_stack`. It's up to node implementations to decide the internal representation. For example, a node may decide to place `PC` on the `return_stack` at `JUMPSUB`, as long as the `RETURNSUB` correctly returns to the `PC+1` location. The internals of the `return_stack` is not one of the      "observable"/consensus-critical parts of the EVM.
 
 ## Rationale
 


### PR DESCRIPTION
As proposed by Pawel, Andrei and Alex @chfast @gumb0 @axic 
> Change the specification in a way that `BEGINSUB` can only be reached via `JUMPSUB` . > 
> Specifically:
>
> 1. Execution of `BEGINSUB` causes exception (OOG: all gas consumed) and terminates execution. This way `BEGINSUB` behaves like `INVALID` (aka `0xfe` ) and it should never be executed in a well-formed EVM program.
> 2. `JUMPSUB` sets the `pc` to `location + 1` ( *As opposed to `location` in the current spec* ).
> 3. In the edge case when `BEGINSUB` is the last instruction in code and this subroutine is jumped-to, the implementations should execute `STOP` . This is consistent with the other similar case of returning from a subroutine jumped-to from the `JUMPSUB` being the last instruction in code.
