### PR TITLE
EIP-2315: updated testcases + clarifications

### DIFF
--- a/EIPS/eip-2315.md
+++ b/EIPS/eip-2315.md
@@ -60,10 +60,8 @@ pushes: `0`
 
 **Note 3:** A value popped from `return_stack` _may_ be outside of the code length if the last `JUMPSUB` was the last byte of the `code`. In this case the next opcode is implicitly a `STOP`, which is not an error.
 
-**Note 4:** The description above lays out the _semantics_ of this feature in terms of a `return_stack`.  But the actual state of the `return_stack` is not observable to EVM code or consensus-critical to the protocol.
-> For example, a node implementor may code `JUMPSUB` to unobservably push `pc` on the `return_stack` rather than `pc+1`, which is allowed so long as `RETURNSUB` observably returns control to the `pc+1` location.
+**Note 4:** The description above lays out the _semantics_ of this feature in terms of a `return_stack`.  But the actual state of the `return_stack` is not observable to EVM code or consensus-critical to the protocol. For example, a node implementor may code `JUMPSUB` to unobservably push `pc` on the `return_stack` rather than `pc+1`, which is allowed so long as `RETURNSUB` observably returns control to the `pc+1` location.
 
-**Note 4:** The description above lays out the _semantics_ of this feature in terms of a `return_stack`. It's up to node implementations to decide the internal representation. For example, a node may decide to place `PC` on the `return_stack` at `JUMPSUB`, as long as the `RETURNSUB` correctly returns to the `PC+1` location. The internals of the `return_stack` is not one of the      "observable"/consensus-critical parts of the EVM.
 
 ## Rationale
 
@@ -80,7 +78,6 @@ These changes do not affect the semantics of existing EVM code.
 This should jump into a subroutine, back out and stop.
 
 Bytecode: `0x6004b300b2b7`
-
 
 |  Pc   |      Op     | Cost |   Stack   |   RStack  |
 |-------|-------------|------|-----------|-----------|
@@ -104,6 +101,7 @@ Bytecode: `0x6800000000000000000cb300b26011b3b7b2b7`
 |   16  |  RETURNSUB  |    2 |        [] |      [10] |
 |   11  |       STOP  |    0 |        [] |        [] |
 
+Consumed gas: `26`
 
 ### Failure 1: invalid jump
 
@@ -149,11 +147,23 @@ Bytecode: `0x600556b2b75b6003b3`
 |    5  |   JUMPDEST  |    1 |        [] |        [] |
 |    6  |      PUSH1  |    3 |        [] |        [] |
 |    8  |    JUMPSUB  |    8 |       [3] |        [] |
-|    3  |   BEGINSUB  |    1 |        [] |      [ 8] |
 |    4  |  RETURNSUB  |    2 |        [] |      [ 8] |
 |    9  |       STOP  |    0 |        [] |        [] |
 
-Consumed gas: `26`
+Consumed gas: `25`
+
+### Error on walk-into-subroutine
+
+In this example, the code 'walks' into a subroutine, which is not allowed, and causes an error
+
+|  Pc   |      Op     | Cost |   Stack   |   RStack  |
+|-------|-------------|------|-----------|-----------|
+|    0  |   BEGINSUB  |    1 |        [] |        [] |
+
+
+```
+Error: at pc=0, op=BEGINSUB: invalid subroutine entry
+```
 
 ## Implementations
 
@@ -167,7 +177,7 @@ The changes for the current version are trivial.
 
 ### Costs and Codes
 
-We suggest that the cost of `JUMPSUB` be _low_, and `RETURNSUB` be _verylow_.
+We suggest that the cost of `BEGINSUB` be _base_, `JUMPSUB` be _low_, and `RETURNSUB` be _verylow_.
  Measurement will tell.  We suggest the following opcodes:
 
 ```
@@ -175,6 +185,9 @@ We suggest that the cost of `JUMPSUB` be _low_, and `RETURNSUB` be _verylow_.
 0xb3 JUMPSUB
 0xb7 RETURNSUB
 ```
+
+**Note 5**: Although specified at _base_, the cost of `BEGINSUB` does not matter in practice, since `BEGINSUB` never executes without error.
+
 ## Security Considerations
 
 These changes do introduce new flow control instructions, so any software which does static/dynamic analysis of evm-code


### PR DESCRIPTION
This PR contains the updated testcases with the recent changes. Also some clarifications and I re-added cost of `BEGINSUB`. All opcodes should have a defined cost, IMO. 