### PR TITLE
BEGINSUB as unexecutable marker

### DIFF
--- a/EIPS/eip-2315.md
+++ b/EIPS/eip-2315.md
@@ -8,7 +8,6 @@ author: Greg Colvin (greg@colvin.org), Martin Holst Swende (@holiman)
 discussions-to: https://ethereum-magicians.org/t/eip-2315-simple-subroutines-for-the-evm/3941
 created: 2019-10-17
 ---
-
 ## Abstract
 
 This proposal introduces three opcodes to support subroutines:  `BEGINSUB`, `JUMPSUB` and `RETURNSUB`.


### PR DESCRIPTION
This  PR incorporates the proposed fix to prevent the EVM from stepping (as opposed to jumping) to BEGINSUB -- JUMPSUB transfers control to the instruction after BEGINSUB; BEGINSUB itself aborts.   This PR does not prevent "jumping into subroutines."

EIP-2315 “Simple Subroutines for the EVM” - AnalysisPawel Bylica @chfast, Andrei Maiboroda @gumb0, and Alex Beregszaszi @axic.
https://ethereum-magicians.org/t/eip-2315-simple-subroutines-for-the-evm-analysis/4229