### PR TITLE
Propose restrictions for jump.

### DIFF
--- a/EIPS/eip-2315.md
+++ b/EIPS/eip-2315.md
@@ -60,13 +60,30 @@ _Note 2: Values popped off the `return stack` do not need to be validated, since
 
 _Note 3: The description above lays out the semantics of this feature in terms of a `return stack`.  But the actual state of the `return stack` is not observable by EVM code or consensus-critical to the protocol.  (For example, a node implementor may code `JUMPSUB` to unobservably push `pc` on the `return stack` rather than `pc + 1`, which is allowed so long as `RETURNSUB` observably returns control to the `pc + 1` location.)_
 
+#### Restrictions on `JUMP` and `JUMPI`
+
+If a `JUMP` or `JUMPI` instruction is executed at code offset `pc` and is about to jump to
+the destination `target`, in addition to verifying that `target` is a `JUMPDEST` opcode, perform
+the following check:
+
+If there is a `BEGINSUB` opcode between `pc` and `target`, _`abort`_.
+
+_Note 1: As with `JUMPDEST` validation, only an actually jumping `JUMPI` is validated. It is not a failure if the jump would cross subroutine boundaries but the jump condition is zero._
+
+_Note 2: This restriction is added to allow for isolated analysis of the bytecode of subroutines. Jumping across subroutines is usually discouraged even in low-level programming languages and it is straightforward for compilers to generate code conforming to this rule. As the EVM is a machine designed for correctness instead of efficiency, this is in line with the design goals of the EVM._
+
 ## Rationale
 
 This is the is a small change that provides native subroutines without breaking backwards compatibility.
 
 ## Backwards Compatibility
 
-These changes do not affect the semantics of existing EVM code.
+These changes do not affect the semantics of existing EVM code that does not contain the new opcodes.
+
+For EVM code that contains a `BEGINSUB` opcode that was not meant to be executed but is jumped over, this change can result in such contracts starting to fail
+where they previously did not fail. While arbitrary data being appended to the end of the bytecode is common, such contracts would
+would have to contain data parts (non-executable code) enclosed by two chunks of executable code. The Solidity compiler is not known
+to be able to generate such code, not even with inline assembly, unless inline assembly is used to return custom-designed data as the runtime code in the constructor.
 
 # Test Cases
 
@@ -130,6 +147,22 @@ Bytecode: `0xb75858` (`RETURNSUB`, `PC`, `PC`)
 ```
 Error: at pc=0, op=RETURNSUB: evm: invalid retsub
 ```
+
+### Failure 3: subroutine-crossing `jump`
+
+This code fails at the `jump` because it crosses a subroutine boundary.
+
+Bytecode: `0x600456b25b` (`PUSH1 4 JUMP BEGINSUB JUMPDEST`)
+
+
+|  Pc   |      Op     |   Stack   |   RStack  |
+|-------|-------------|-----------|-----------|
+|    0  |      PUSH1  |        [] |        [] |
+|    2  |       JUMP  |       [4] |        [] |
+```
+Error: at pc=2, op=JUMP: evm: invalid jump
+```
+
 
 ### Subroutine at end of code
 


### PR DESCRIPTION
This is the specification for the restrictions on the jump and jumpi opcode outlined in https://ethereum-magicians.org/t/eip-2315-simple-subroutines-for-the-evm-analysis/4229 (this is not the EIP-2315 discussion itself, but a discussion of a restriction of it).

This specification was requested by @gcolvin as grounds for a discussion.