### PR TITLE
EIP-2315: update jumpsub gascost and add back testcases

### DIFF
--- a/EIPS/eip-2315.md
+++ b/EIPS/eip-2315.md
@@ -80,7 +80,7 @@ Bytecode: `0x6004b300b2b7`
 |  Pc   |      Op     | Cost |   Stack   |   RStack  |
 |-------|-------------|------|-----------|-----------|
 |    0  |      PUSH1  |    3 |        [] |        [] |
-|    2  |    JUMPSUB  |    5 |       [4] |        [] |
+|    2  |    JUMPSUB  |    8 |       [4] |        [] |
 |    5  |  RETURNSUB  |    2 |        [] |      [ 2] |
 |    3  |       STOP  |    0 |        [] |        [] |
 
@@ -92,9 +92,9 @@ Bytecode: `0x6800000000000000000cb300b26011b3b7b2b7`
 |  Pc   |      Op     | Cost |   Stack   |   RStack  |
 |-------|-------------|------|-----------|-----------|
 |    0  |      PUSH9  |    3 |        [] |        [] |
-|   10  |    JUMPSUB  |    5 |      [12] |        [] |
+|   10  |    JUMPSUB  |    8 |      [12] |        [] |
 |   13  |      PUSH1  |    3 |        [] |      [10] |
-|   15  |    JUMPSUB  |    5 |      [17] |      [10] |
+|   15  |    JUMPSUB  |    8 |      [17] |      [10] |
 |   18  |  RETURNSUB  |    2 |        [] |   [10,15] |
 |   16  |  RETURNSUB  |    2 |        [] |      [10] |
 |   11  |       STOP  |    0 |        [] |        [] |
@@ -110,7 +110,7 @@ Bytecode: `0x6801000000000000000cb300b26011b3b7b2b7	`
 |  Pc   |      Op     | Cost |   Stack   |   RStack  |
 |-------|-------------|------|-----------|-----------|
 |    0  |      PUSH9  |    3 |        [] |        [] |
-|   10  |    JUMPSUB  |    5 |[18446744073709551628] |        [] |
+|   10  |    JUMPSUB  |    8 |[18446744073709551628] |        [] |
 
 ```
 Error: at pc=10, op=JUMPSUB: evm: invalid jump destination
@@ -143,12 +143,25 @@ Bytecode: `0x600556b2b75b6003b3`
 |    2  |       JUMP  |    8 |       [5] |        [] |
 |    5  |   JUMPDEST  |    1 |        [] |        [] |
 |    6  |      PUSH1  |    3 |        [] |        [] |
-|    8  |    JUMPSUB  |    5 |       [3] |        [] |
-|    3  |   BEGINSUB  |    1 |        [] |      [ 8] |
+|    8  |    JUMPSUB  |    8 |       [3] |        [] |
 |    4  |  RETURNSUB  |    2 |        [] |      [ 8] |
 |    9  |       STOP  |    0 |        [] |        [] |
 
-Consumed gas: `26`
+Consumed gas: `25`
+
+### Error on "walk-into-subroutine"
+
+In this example, the code 'walks' into a subroutine, which is not allowed, and causes an error
+
+|  Pc   |      Op     | Cost |   Stack   |   RStack  |
+|-------|-------------|------|-----------|-----------|
+|    0  |   BEGINSUB  |    1 |        [] |        [] |
+
+
+```
+Error: at pc=0, op=BEGINSUB: invalid subroutine entry
+```
+**Note 5**: The content of the error message, (`invalid subroutine entry`) is implementation-specific.
 
 ## Implementations
 
@@ -162,7 +175,7 @@ The changes for the current version are trivial.
 
 ### Costs and Codes
 
-We suggest that the cost of `JUMPSUB` be _low_, and `RETURNSUB` be _verylow_.
+We suggest that the cost of `BEGINSUB` be _base_, `JUMPSUB` be _mid_, and `RETURNSUB` be _verylow_.
  Measurement will tell.  We suggest the following opcodes:
 
 ```
@@ -170,6 +183,8 @@ We suggest that the cost of `JUMPSUB` be _low_, and `RETURNSUB` be _verylow_.
 0xb3 JUMPSUB
 0xb7 RETURNSUB
 ```
+
+**Note 6**: Although specified at _base_, the cost of `BEGINSUB` does not matter in practice, since `BEGINSUB` never executes without error. 
 
 ## Security Considerations
 


### PR DESCRIPTION
This PR 

- Adds back a testcase that went missing (walk into subroutine) in https://github.com/ethereum/EIPs/pull/2662
- Fixes another testcase where `BEGINSUB` was present, 
- Changes cost of `JUMPSUB` to `8`. 

I'm marking this as draft since otherwise the trigger-happy autobot will merge it. Can I please get a thumb up from: 

@gcolvin , @ordian (or @sorpaas , or @vorot93 ?), @makt 

Just want to make sure everyone is on the same page here...  