### PR TITLE
Remove key index restrictions from EIP-2334

### DIFF
--- a/EIPS/eip-2334.md
+++ b/EIPS/eip-2334.md
@@ -67,14 +67,6 @@ This level is designed to provide a set of related keys that can be used for any
 
 The coin type used for the BLS12-381 keys in Ethereum 2 is `3600`.
 
-#### Validator keys
-
-Each Eth2 validator has two keys, one for withdrawals and transfers (called the *withdrawal key*), and the other for performing their duties as a validator (henceforth referred to as the *signing key*).
-
-The path for withdrawal keys is `m/12381/3600/i/0` where `i` indicates the `i`th set of validator keys.
-
-The path for the signing key is `m/12381/3600/i/0/0` where again, `i` indicates the `i`th set of validator keys. Another way of phrasing this is that the signing key is the `0`th child of the associated withdrawal key for that validator.
-
 ## Rationale
 
 `purpose`, `coin_type`, and `account` are widely-adopted terms as per [BIP43](https://github.com/bitcoin/bips/blob/master/bip-0043.mediawiki) and [BIP44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki) and therefore reusing these terms and their associated meanings makes sense.


### PR DESCRIPTION
This PR removes the specifics for Ethereum 2 validator keys from EIP-2334.

EIP-2334 provides important information to allow for standardisation of key paths, however the addition of specifics about how to generate validator keys makes it impossible to fully implement in common staking situations.

This part of the spec removed in this PR defines a specific relationship between validator and withdrawal keys that often does not exist in the real world.  Situations that this part of the spec precludes include:

  - multi-party computation, where a validator key is created via distributed key generation (hence the validator key cannot be a child of the withdrawal key)
  - staking services, where separate entities hold the validator and withdrawal keys (hence the keys are not generated from the same seed)
  - hardware wallets, where the withdrawal key is held securely whilst the validator key is used for attesting (hence the keys are not generated from the same seed)

Removing these restrictions allow this EIP to be adhered to by more participants.