### PR TITLE
Add name to keystore

### DIFF
--- a/EIPS/eip-2335.md
+++ b/EIPS/eip-2335.md
@@ -120,6 +120,12 @@ The `uuid` provided in the keystore is a randomly generated UUID as specified by
 
 The `version` is set to `4`.
 
+## Name
+
+The `name` provided in the keystore is a UTF-8 string.  It is intended to serve as the user-friendly accessor.  The only restriction on the name is that it MUST NOT start with the underscore (`_`) character.
+
+This element MAY be present.  If not present, the `uuid` MAY be used, following the syntactic structure as laid out in [section 3 of RFC 4122](https://tools.ietf.org/html/rfc4122#section-3).
+
 ## JSON schema
 
 The keystore, at its core, is constructed with modules which allow for the configuration of the cryptographic constructions used password hashing, password verification and secret decryption. Each module is composed of: `function`, `params`, and `message` which corresponds with which construction is to be used, what the configuration for the construction is, and what the input is.

--- a/EIPS/eip-2335.md
+++ b/EIPS/eip-2335.md
@@ -167,6 +167,9 @@ The keystore, at its core, is constructed with modules which allow for the confi
                 "version": {
                     "type": "integer"
                 }
+                "name": {
+                    "type": "string"
+                },
             },
             "required": [
                 "crypto",
@@ -250,7 +253,8 @@ Secret `0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f`
     "pubkey": "9612d7a727c9d0a22e185a1c768478dfe919cada9266988cb32359c11f2b7b27f4ae4040902382ae2910c15e2b420d07",
     "path": "m/12381/60/3141592653/589793238",
     "uuid": "1d85ae20-35c5-4611-98e8-aa14a633906f",
-    "version": 4
+    "version": 4,
+    "name": "Scrypt account"
 }
 ```
 
@@ -290,7 +294,8 @@ Secret `0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f`
     "pubkey": "9612d7a727c9d0a22e185a1c768478dfe919cada9266988cb32359c11f2b7b27f4ae4040902382ae2910c15e2b420d07",
     "path": "m/12381/60/0/0",
     "uuid": "64625def-3331-4eea-ab6f-782f3ed16a83",
-    "version": 4
+    "version": 4,
+    "name": "PBKDF2 account"
 }
 ```
 


### PR DESCRIPTION
This adds an optional `name` element to the keystore.  The `name` element is useful to provide user-friendly access to keystores, reducing the chance for mis-use of keys.