### PR TITLE
695: Errata: remove EIP-1474 from dependencies

### DIFF
--- a/EIPS/eip-695.md
+++ b/EIPS/eip-695.md
@@ -7,7 +7,7 @@ type: Standards Track
 category: Interface
 status: Final
 created: 2017-08-21
-requires: 155, 1474
+requires: 155
 ---
 
 ## Simple Summary


### PR DESCRIPTION
EIP-695 still listed EIP-1474 as a dependency when it was finalized. This was an oversight on the part of the authors. 695 never required 1474. Rather, 1474 could be said to require 695. I'm author of both, and 1474 is still in draft.

Apologies to @axic and @Arachnid for missing this.