### PR TITLE
Update interfaces, clarify type intentions

### DIFF
--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -30,7 +30,7 @@ Makes an Ethereum RPC method call.
 ```typescript
 interface RequestArguments {
   method: string;
-  params?: unknown;
+  params?: unknown[] | object;
 }
 
 Provider.request(args: RequestArguments): Promise<unknown>;
@@ -317,7 +317,7 @@ The Provider **MUST** implement and expose the API defined in this section. All 
 
 The Provider **MAY** expose methods and properties not specified in this section.
 
-The Provider **MAY** extend TypeScript `interface` declarations to include fields not listed in this specification.
+The Provider **MAY** extend TypeScript `interface` declarations to include properties not listed in this specification.
 
 The Provider **MAY** replace references to `unknown` with more specific types, if the possible values can be known at compile time.
 
@@ -334,7 +334,7 @@ The Provider **MAY** replace references to `unknown` with more specific types, i
 ```typescript
 interface RequestArguments {
   method: string;
-  params?: unknown;
+  params?: unknown[] | object;
 }
 
 Provider.request(args: RequestArguments): Promise<unknown>;
@@ -376,7 +376,13 @@ All supported RPC methods **MUST** be identified by unique strings.
 
 Providers **MAY** support whatever RPC methods required to fulfill their purpose, standardized or otherwise.
 
-If a Provider supports a method defined in a finalized EIP, the Provider's implementation of this method **MUST** adhere to the method's specification.
+If a Provider supports a method defined in a finalized EIP, the Provider's implementation of this method **MUST** adhere to the method's specification. This includes:
+
+- The method name, given as the string value of `RequestArguments.method`
+- The method parameters, given as the value of `RequestArguments.params`, either:
+  - By position, in an array
+  - By name, in an object
+- Any additional properties on `RequestArguments`, as necessary
 
 If an RPC method defined in a finalized EIP is not supported, it **SHOULD** be rejected with a `4200` error per the [Provider Errors](#provider-errors) section below, or an appropriate error per the RPC method's specification.
 

--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -311,15 +311,10 @@ The Provider is said to be "disconnected" when it cannot service RPC requests to
 
 ### API
 
-The Provider API is specified using TypeScript.
+> The Provider API is specified using TypeScript.
+> The authors encourage implementers to declare their own types and interfaces, using the ones in this section as a basis.
 
 The Provider **MUST** implement and expose the API defined in this section. All API entities **MUST** adhere to the types and interfaces defined in this section.
-
-> The TypeScript `interface` declarations are designed to be minimal and extensible.
-> The authors encourage implementers to make syntactically valid extensions of interfaces when necessary.
->
-> Furthermore, an `unknown` type indicates that the possible values depend on information external to this specification.
-> The authors encourage implementers to replace instances of `unknown` with more specific types in their own type definitions, if the possible values can be known at compile time.
 
 #### request
 
@@ -334,14 +329,13 @@ interface RequestArguments {
 Provider.request(args: RequestArguments): Promise<unknown>;
 ```
 
-> In practice, it is likely possible to enumerate the possible types of `params` at compile time, with reference to the Provider implementation's [Supported RPC Methods](#supported-rpc-methods).
+The Provider **MUST** identify the requested RPC method by the value of `RequestArguments.method`.
 
-The `request` method **MUST** send a properly formatted request to the Provider's Ethereum client.
-Requests **MUST** be handled such that, for a given set of arguments, the returned Promise either resolves with a value per the RPC method's specification, or rejects with an error.
+If the requested RPC method takes any parameters, the Provider **MUST** accept them as the value of `RequestArguments.params`.
 
-If resolved, the Promise **MUST NOT** resolve with any RPC protocol-specific response objects, unless the RPC method's return type is so defined by its specification.
+RPC requests **MUST** be handled such that the returned Promise either resolves with a value per the requested RPC method's specification, or rejects with an error.
 
-If resolved, the Promise **MUST** resolve with a result per the RPC method's specification.
+If resolved, the Promise **MUST** resolve with a result per the RPC method's specification. The Promise **MUST NOT** resolve with any RPC protocol-specific response objects, unless the RPC method's return type is so defined.
 
 If the returned Promise rejects, it **MUST** reject with a `ProviderRpcError` as specified in the [RPC Errors](#rpc-errors) section below.
 
@@ -369,11 +363,6 @@ A "supported RPC method" is any RPC method that may be called via the Provider.
 All supported RPC methods **MUST** be identified by unique strings.
 
 Providers **MAY** support whatever RPC methods required to fulfill their purpose, standardized or otherwise.
-
-If a Provider supports a method defined in a finalized EIP, the Provider's implementation of this method **MUST** adhere to the method's specification. This includes:
-
-- The method name, given as the value of `RequestArguments.method`
-- The method parameters, given as the value of `RequestArguments.params`
 
 If an RPC method defined in a finalized EIP is not supported, it **SHOULD** be rejected with a `4200` error per the [Provider Errors](#provider-errors) section below, or an appropriate error per the RPC method's specification.
 

--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -298,7 +298,7 @@ In practice, this convention does not handle some situations, including:
 - Multiple Providers being injected into the same page, e.g. when the user has multiple wallets installed
 - Asynchronously injected Providers, whether by choice or due to platform limitations
 
-Provider implementers are encouraged to work with each other and with dapp developers to solve these problems until standards emerge.
+The authors encourage Provider implementers to work with each other and with dapp developers to solve these problems until standards emerge.
 
 ### Connectivity
 
@@ -317,11 +317,15 @@ The Provider **MUST** implement and expose the API defined in this section. All 
 
 The Provider **MAY** expose methods and properties not specified in this section.
 
-> The TypeScript `interface` declarations in this section are designed to be minimal and extensible.
+The Provider **MAY** extend TypeScript `interface` declarations to include fields not listed in this specification.
+
+The Provider **MAY** replace references to `unknown` with more specific types, if the possible values can be known at compile time.
+
+> The TypeScript `interface` declarations are designed to be minimal and extensible.
 > The authors encourage implementers to make syntactically valid extensions of interfaces when necessary.
 >
 > Furthermore, an `unknown` type indicates that the possible values depend on information external to this specification.
-> The authors encourage implementers to replace instances of `unknown` with stronger types in their own type definitions, if the possible values can be known at compile time.
+> The authors encourage implementers to replace instances of `unknown` with more specific types in their own type definitions, if the possible values can be known at compile time.
 
 #### request
 
@@ -335,6 +339,8 @@ interface RequestArguments {
 
 Provider.request(args: RequestArguments): Promise<unknown>;
 ```
+
+> In practice, it is likely possible to enumerate the possible types of `params` at compile time, with reference to the Provider implementation's [Supported RPC Methods](#supported-rpc-methods).
 
 The `request` method **MUST** send a properly formatted request to the Provider's Ethereum client.
 Requests **MUST** be handled such that, for a given set of arguments, the returned Promise either resolves with a value per the RPC method's specification, or rejects with an error.

--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -31,7 +31,6 @@ Makes an Ethereum RPC method call.
 interface RequestArguments {
   method: string;
   params?: unknown;
-  [key: string]: unknown;
 }
 
 Provider.request(args: RequestArguments): Promise<unknown>;
@@ -312,9 +311,17 @@ The Provider is said to be "disconnected" when it cannot service RPC requests to
 
 ### API
 
-The Provider **MUST** expose the API defined in this section. All API entities **MUST** adhere to the types and interfaces defined in this section.
+The Provider API is specified using TypeScript.
 
-The Provider **MAY** expose methods and properties not specified in this document.
+The Provider **MUST** implement and expose the API defined in this section. All API entities **MUST** adhere to the types and interfaces defined in this section.
+
+The Provider **MAY** expose methods and properties not specified in this section.
+
+> The TypeScript `interface` declarations in this section are designed to be minimal and extensible.
+> The authors encourage implementers to make syntactically valid extensions of interfaces when necessary.
+>
+> Furthermore, an `unknown` type indicates that the possible values depend on information external to this specification.
+> The authors encourage implementers to replace instances of `unknown` with stronger types in their own type definitions, if the possible values can be known at compile time.
 
 #### request
 
@@ -324,7 +331,6 @@ The Provider **MAY** expose methods and properties not specified in this documen
 interface RequestArguments {
   method: string;
   params?: unknown;
-  [key: string]: unknown;
 }
 
 Provider.request(args: RequestArguments): Promise<unknown>;
@@ -332,8 +338,6 @@ Provider.request(args: RequestArguments): Promise<unknown>;
 
 The `request` method **MUST** send a properly formatted request to the Provider's Ethereum client.
 Requests **MUST** be handled such that, for a given set of arguments, the returned Promise either resolves with a value per the RPC method's specification, or rejects with an error.
-
-The `args` object **MAY** include properties not mentioned in this specification.
 
 If resolved, the Promise **MUST NOT** resolve with any RPC protocol-specific response objects, unless the RPC method's return type is so defined by its specification.
 
@@ -407,7 +411,7 @@ interface ProviderRpcError extends Error {
 | 4100        | Unauthorized          | The requested method and/or account has not been authorized by the user. |
 | 4200        | Unsupported Method    | The Provider does not support the requested method.                      |
 | 4900        | Disconnected          | The Provider is disconnected from all chains.                            |
-| 4901        | Chain Disconnected    | The Provider is not connected to the requested chain.                   |
+| 4901        | Chain Disconnected    | The Provider is not connected to the requested chain.                    |
 
 > `4900` is intended to indicate that the Provider is disconnected from all chains, while `4901` is intended to indicate that the Provider is disconnected from a specific chain only.
 > In other words, `4901` implies that the Provider is connected to other chains, just not the requested one.
@@ -461,7 +465,6 @@ This event **MUST** be emitted with an object of the following form:
 ```typescript
 interface ProviderConnectInfo {
   chainId: string;
-  [key: string]: unknown;
 }
 ```
 

--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -315,12 +315,6 @@ The Provider API is specified using TypeScript.
 
 The Provider **MUST** implement and expose the API defined in this section. All API entities **MUST** adhere to the types and interfaces defined in this section.
 
-The Provider **MAY** expose methods and properties not specified in this section.
-
-The Provider **MAY** extend TypeScript `interface` declarations to include properties not listed in this specification.
-
-The Provider **MAY** replace references to `unknown` with more specific types, if the possible values can be known at compile time.
-
 > The TypeScript `interface` declarations are designed to be minimal and extensible.
 > The authors encourage implementers to make syntactically valid extensions of interfaces when necessary.
 >
@@ -378,11 +372,8 @@ Providers **MAY** support whatever RPC methods required to fulfill their purpose
 
 If a Provider supports a method defined in a finalized EIP, the Provider's implementation of this method **MUST** adhere to the method's specification. This includes:
 
-- The method name, given as the string value of `RequestArguments.method`
-- The method parameters, given as the value of `RequestArguments.params`, either:
-  - By position, in an array
-  - By name, in an object
-- Any additional properties on `RequestArguments`, as necessary
+- The method name, given as the value of `RequestArguments.method`
+- The method parameters, given as the value of `RequestArguments.params`
 
 If an RPC method defined in a finalized EIP is not supported, it **SHOULD** be rejected with a `4200` error per the [Provider Errors](#provider-errors) section below, or an appropriate error per the RPC method's specification.
 
@@ -430,13 +421,13 @@ interface ProviderRpcError extends Error {
 
 ### Events
 
-The Provider **SHOULD** extend the [Node.js `EventEmitter`](https://nodejs.org/api/events.html) to provide dapps flexibility in listening to events. In place of full `EventEmitter` functionality, the Provider **MAY** provide as many methods as it can reasonably provide, but **MUST** provide at least `on`, `emit`, and `removeListener`.
+The Provider **SHOULD** extend the [Node.js `EventEmitter`](https://nodejs.org/api/events.html) to provide dapps flexibility in listening to events.
+
+The Provider **MUST** implement at least the following methods `EventEmitter` methods: `on`, `emit`, and `removeListener`
 
 #### message
 
-The Provider **MAY** emit the event named `message`, for any reason.
-
-If the Provider supports Ethereum RPC subscriptions, e.g. [`eth_subscribe`](https://geth.ethereum.org/docs/rpc/pubsub), the Provider **MUST** emit the `message` event when it receives a subscription notification.
+> The `message` event is intended for arbitrary notifications not covered by other events.
 
 When emitted, the `message` event **MUST** be emitted with an object argument of the following form:
 
@@ -446,6 +437,8 @@ interface ProviderMessage {
   data: unknown;
 }
 ```
+
+If the Provider supports Ethereum RPC subscriptions, e.g. [`eth_subscribe`](https://geth.ethereum.org/docs/rpc/pubsub), the Provider **MUST** emit the `message` event when it receives a subscription notification.
 
 ##### Converting a Subscription Message to a ProviderMessage
 
@@ -481,8 +474,6 @@ interface ProviderConnectInfo {
 ```
 
 `chainId` **MUST** specify the integer ID of the connected chain as a hexadecimal string, per the [`eth_chainId`](https://eips.ethereum.org/EIPS/eip-695) Ethereum RPC method.
-
-The `ProviderConnectInfo` object **MAY** contain any other `string` properties with values of any type.
 
 #### disconnect
 


### PR DESCRIPTION
Link to file: https://github.com/rekmarks/EIPs/blob/1193-update-interfaces/EIPS/eip-1193.md

### Summary of Changes

- Remove index signatures from interfaces
  - i.e. no more `[key: string]: unknown`; the ability to add properties is implied
- `RequestArguments`
  - `params?: unknown` -> `params?: unknown[] | object`
  - Explicitly define relationship between `RequestArguments` fields and RPC method names and parameters
    - You could say that relationship was heavily implied, but 🤷 
- Remove redundant **MAY** statements.
- Various minor fixups and clarifications
  - Clarify author intentions in certain places

### A Note on `request`

After review, here's where I currently stand on the signature of `request`.
- `request` takes a single, options bag argument, to make it as extensible as possible. We are extremely unlikely to have to revisit it ever again. This is a wonderful thing.
  - If devs find the options bag unergonomic, they can define their own wrapper functions. We, however, should not bloat the spec with syntactic sugar.
- Provider implementers should type `RequestArguments` and its `params` property however it makes practical sense to do so. Presumably, they'll type it such that it supports whatever RPC methods the implementation supports.
  - _That said_, I have not found an example of an RPC protocol that _does not_ take its parameters by name (object) or position (array). As such, we set the type to `params?: unknown[] | object`.
  - This is not normative for future RPC specifications. This only normative for how those methods are called via this API. If RPC standards emerge that map poorly to this concept, that's IMO an acceptable use case for errata.
- I recommend that implementers implement `request` in this way:
  - Do _basic_ input validation (i.e. `typeof args?.method === 'string'`).
  - Try to find a method handler.
  - If no handler, return error. If handler, hand off to handler; return result or error from handler.
    - Do detailed type checking of `params` in handler.

--------------------------

Ref #2319

cc: @alcuadrado @ryanio @MicahZoltu 