### PR TITLE
update EIP spec: add back slack coefficient; MaxGasEIP1559 = 20,000,0…

### DIFF
--- a/EIPS/eip-1559.md
+++ b/EIPS/eip-1559.md
@@ -23,7 +23,7 @@ There is a base fee value in protocol, which can move up or down by a maximum of
 
 * A fee cap which represents the maximum total (base fee + gas premium) that the transaction sender would be willing to pay to get their transaction included.
 
-The current miner-voting based gas limit is changed to a hard-coded gas limit of 16 million. Instead of miners directly adjusting the gas limit in response to changes in network demand, the protocol adjusts the base fee to apply economic pressure towards a target gas usage of 10 million.
+The current miner-voting based gas limit is changed to a hard-coded gas limit of 20 million. Instead of miners directly adjusting the gas limit in response to changes in network demand, the protocol adjusts the base fee to apply economic pressure towards a target gas usage of 10 million.
 
 ## Motivation
 <!--The motivation is critical for EIPs that want to change the Ethereum protocol. It should clearly explain why the existing protocol specification is inadequate to address the problem that the EIP solves. EIP submissions without sufficient motivation may be rejected outright.-->
@@ -34,7 +34,7 @@ Ethereum currently prices transaction fees using a simple auction mechanism, whe
 * **Inefficiencies of first price auctions**: see https://ethresear.ch/t/first-and-second-price-auctions-and-improved-transaction-fee-markets/2410 for a detailed writeup. In short, the current approach, where transaction senders publish a transaction with a fee, miners choose the highest-paying transactions, and everyone pays what they bid, is well-known in mechanism design literature to be highly inefficient, and so complex fee estimation algorithms are required, and even these algorithms often end up not working very well, leading to frequent fee overpayment. See also https://blog.bitgo.com/the-challenges-of-bitcoin-transaction-fee-estimation-e47a64a61c72 for a Bitcoin core developer's description of the challenges involved in fee estimation in the status quo.
 * **Instability of blockchains with no block reward**: in the long run, blockchains where there is no issuance (including Bitcoin and Zcash) at present intend to switch to rewarding miners entirely through transaction fees. However, there are [known results](http://randomwalker.info/publications/mining_CCS.pdf) showing that this likely leads to a lot of instability, incentivizing mining "sister blocks" that steal transaction fees, opening up much stronger selfish mining attack vectors, and more. There is at present no good mitigation for this.
 
-The proposal in this EIP is to start with a base fee amount which is adjusted up and down by the protocol based on how congested the network is. To accommodate this system, the total network capacity would be increased to 16 million gas. When the network exceeds the target 10 million gas usage, the base fee increments up slightly and when capacity is below the target, it decrements down slightly. Because these increments are constrained, the maximum difference in base fee from block to block is predictable. This then allows wallets to auto-set the gas fees for users in a highly reliable fashion. It is expected that most users will not have to manually adjust gas fees, even in periods of high network activity. For most users post 1559 implementation the base fee will be estimated by their wallet and a small gas premium- which acts as a 'tip' to compensate miners (e.g. 0.5 gwei)- will be automatically set. Users can also manually set the transaction fee cap to bound their total costs.
+The proposal in this EIP is to start with a base fee amount which is adjusted up and down by the protocol based on how congested the network is. To accommodate this system, the total network capacity would be increased to 20 million gas. When the network exceeds the target 10 million gas usage, the base fee increments up slightly and when capacity is below the target, it decrements down slightly. Because these increments are constrained, the maximum difference in base fee from block to block is predictable. This then allows wallets to auto-set the gas fees for users in a highly reliable fashion. It is expected that most users will not have to manually adjust gas fees, even in periods of high network activity. For most users post 1559 implementation the base fee will be estimated by their wallet and a small gas premium- which acts as a 'tip' to compensate miners (e.g. 0.5 gwei)- will be automatically set. Users can also manually set the transaction fee cap to bound their total costs.
 
 An important aspect of this upgraded fee system is that miners only get to keep the tips. The base fee is always burned (i.e. it is destroyed by the protocol). Burning this is important because it prevents miners from manipulating the fee in order to extract more fees from users. It also ensures that only ETH can ever be used to pay for transactions on Ethereum, cementing the economic value of ETH within the Ethereum platform. Additionally, this burn counterbalances Ethereum inflation without greatly diminishing miner rewards.
 
@@ -47,10 +47,11 @@ The transition to this gas price system will occur in two phases, in the first p
 * `INITIAL_FORK_BLKNUM`: TBD
 * `BASEFEE_MAX_CHANGE_DENOMINATOR`: 8
 * `TARGET_GAS_USED`: 10,000,000
-* `MAX_GAS_EIP1559`: 16,000,000
-* `EIP1559_DECAY_RANGE`: `MAX_GAS_EIP1559 / 20` == `800,000`
+* `SLACK_COEFFICIENT`: 2
+* `MAX_GAS_EIP1559`: `TARGET_GAS_USED` * `SLACK_COEFFICIENT` == 20,000,000
+* `EIP1559_DECAY_RANGE`: 1,000,000
 * `FINAL_FORK_BLKNUM`:  `INITIAL_FORK_BLKNUM + EIP1559_DECAY_RANGE`
-* `EIP1559_GAS_INCREMENT_AMOUNT`: `(MAX_GAS_EIP1559 / 2) / EIP1559_DECAY_RANGE` == `10`
+* `EIP1559_GAS_INCREMENT_AMOUNT`: `(MAX_GAS_EIP1559 / 2) / EIP1559_DECAY_RANGE` == 10
 * `INITIAL_BASEFEE` : 1,000,000,000 wei (1 gwei)
 * `PER_TX_GASLIMIT`: 8,000,000
 
@@ -61,33 +62,34 @@ For all blocks where `block.number >= INITIAL_FORK_BLKNUM`:
 For the gas limit:
 
 * `MAX_GAS_EIP1559` acts as the hard in-protocol gas limit, instead of the gas limit calculated using the previously existing formulas
-* The `GASLIMIT` field in the block header is the gas limit for the EIP1559 gas pool, and over the transition period this value increases until it reaches `MAX_GAS_EIP1559` at `FINAL_FORK_BLKNUM`
-* The gas limit for the legacy gas pool is `MAX_GAS_EIP1559 - GASLIMIT`, as `GASLIMIT` increases towards `MAX_GAS_EIP1559` gas is moved from the legacy pool into the EIP1559 pool until all of the gas is in the EIP1559 pool
-* At `block.number == INITIAL_FORK_BLKNUM`, let `GASLIMIT = (MAX_GAS_EIP1559 / 2)` so that the gas maximum is split evenly between the legacy and EIP1559 gas pools
+* The `gas_limit` field in the block header is the gas limit for the EIP1559 gas pool, and over the transition period this value increases until it reaches `MAX_GAS_EIP1559` at `FINAL_FORK_BLKNUM`
+* The gas limit for the legacy gas pool is `MAX_GAS_EIP1559 - gas_limit`, as `gas_limit` increases towards `MAX_GAS_EIP1559` gas is moved from the legacy pool into the EIP1559 pool until all of the gas is in the EIP1559 pool
+* At `block.number == INITIAL_FORK_BLKNUM`, let `gas_limit = (MAX_GAS_EIP1559 / 2)` so that the gas maximum is split evenly between the legacy and EIP1559 gas pools
 * As `block.number` increases towards `FINAL_FORK_BLKNUM`, at every block we shift `EIP1559_GAS_INCREMENT_AMOUNT` from the legacy pool into the EIP1559 gas pool
 * At `block.number >= FINAL_FORK_BLKNUM` the entire `MAX_GAS_EIP1559` is assigned to the EIP1559 gas pool and the legacy pool is empty
 * We enforce a maximum gas usage on individual transactions: `PER_TX_GASLIMIT`
 
 For the gas price:
 
-* We add a new field to the block header, `BASEFEE`
-  * `BASEFEE` is maintained under consensus by the ethash engine
-* At `block.number == INITIAL_FORK_BLKNUM` we set `BASEFEE = INITIAL_BASEFEE`
-* `BASEFEE` is set as follows
-  * Let `delta = block.gas_used - TARGET_GASUSED` (possibly negative).
-  * Set `BASEFEE = PARENT_BASEFEE + PARENT_BASEFEE * delta // TARGET_GASUSED // BASEFEE_MAX_CHANGE_DENOMINATOR`
-  * Clamp the resulting `BASEFEE` inside of the allowable bounds if needed, where a valid `BASEFEE` is one such that `abs(BASEFEE - PARENT_BASEFEE) <= max(1, PARENT_BASEFEE // BASEFEE_MAX_CHANGE_DENOMINATOR)`
-* We add two new fields to transactions: `GAS_PREMIUM` and `FEECAP`
+* We add a new field to the block header, `base_fee`.
+  * `base_fee` is maintained under consensus by the ethash engine.
+* At `block.number == INITIAL_FORK_BLKNUM` we set `base_fee = INITIAL_BASEFEE`
+* Otherwise, the `base_fee` for the current block is set as follows:
+  * Let `delta = parent_block.gas_used - TARGET_GAS_USED` (possibly negative)
+  * Set `base_fee = parent_block.base_fee + parent_block.base_fee * delta // TARGET_GAS_USED // BASEFEE_MAX_CHANGE_DENOMINATOR`
+  * Clamp the resulting `base_fee` inside of the allowable bounds if needed, where a valid `base_fee` is one such that `abs(base_fee - parent_block.base_fee) <= max(1, parent_block.base_fee // BASEFEE_MAX_CHANGE_DENOMINATOR)`
+  * We use Euclidean integer division (//): in the negative case, the integer is rounded towards negative infinity
+* We add two new fields to transactions: `gas_premium` and `fee_cap`
 * During the transition phase, these fields can be left `nil` and a `tx.gas_price` can be set as usual to generate a backwards compatible legacy transaction
-* To produce an EIP1559 transactions, `tx.gas_price` is set to `nil` while the new `GAS_PREMIUM` and `FEECAP` fields are set whereby:
-  * `GAS_PREMIUM` serves as a "tip" to the miner
-  * `FEECAP` serves as the absolute maximum that the transaction sender is willing to pay
+* To produce an EIP1559 transactions, `tx.gas_price` is set to `nil` while the new `gas_premium` and `fee_cap` fields are set whereby:
+  * `gas_premium` serves as a "tip" to the miner
+  * `fee_cap` serves as the absolute maximum that the transaction sender is willing to pay
 * During transaction execution, for EIP1559 transactions we calculate the cost to the `tx.origin` and the gain to the `block.coinbase` as follows:
-  * Set `GASPRICE = min(BASEFEE + tx.GasPremium, tx.fee_cap)`
-  * Let `GASUSED` be the gas used during the transaction execution/state transition
-  * The `tx.origin` initially pays `GASPRICE * tx.gas`, and gets refunded `GASPRICE * (tx.gas - GASUSED)`
-  * The `block.coinbase` gains `(GASPRICE - BASEFEE) * GASUSED`.
-    * If `GASPRICE < BASEFEE` (due to the `FEECAP`), this means that the `block.coinbase` _loses_ funds from this operation; in this case, we check that the post-balance is non-negative and throw an exception if it is negative.
+  * Set `gas_price = min(base_fee + tx.gas_premium, tx.fee_cap)`
+    * Assert `gas_price >= base_fee`
+  * Let `gas_used` be the gas used during the transaction execution/state transition
+  * The `tx.origin` initially pays `gas_price * tx.gas`, and gets refunded `gas_price * (tx.gas - gas_used)`
+  * The `block.coinbase` gains `(gas_price - base_fee) * gas_used`
 
 ## Backwards Compatibility
 We split the EIP1559 upgrade into two phases with a transition period during which both legacy and EIP1559 transaction can be accepted so that compatibility with wallets and other ETH-adjacent software is maintained while their maintainers have time to upgrade to using the new transaction type. During this transition period legacy transactions are accepted and processed identically to the current implementation, with the only difference being that the amount of gas (gas limit) dedicated to processing legacy transactions is calculated as above and incrementally decreases over this period.
@@ -106,7 +108,7 @@ Go-ethereum implementation by Vulcanize Inc: https://github.com/vulcanize/go-eth
 The security considerations for this EIP are:
 1. The consequences of raising the gas limit
     * This concern was brought up [here](https://ethereum-magicians.org/t/eip-1559-fee-market-change-for-eth-1-0-chain/2783/45)
-    * This EIP currently proposes to raise the total gas limit from 8,000,000 to 16,000,000
+    * This EIP currently proposes to raise the total gas limit from 10,000,000 to 20,000,000
 2. The consequences of the new gas pricing on total transaction order
     * This concern was brought up [here](https://ethereum-magicians.org/t/eip-1559-fee-market-change-for-eth-1-0-chain/2783/45)
     * This issue is avoided by maintaining a single total ordering of transactions by price and nonce, where the derived EIP1559 gas price is used like the legacy gas price


### PR DESCRIPTION
These are all the updates/changes/fixes to the EIP doc discussed in the last 1559 meeting. When https://github.com/ethereum/EIPs/pull/2635 or https://github.com/ethereum/EIPs/pull/2654 are merged I will rebase on-top of them.
