### PR TITLE
EIP2315: update opcodes

### DIFF
--- a/EIPS/eip-2315.md
+++ b/EIPS/eip-2315.md
@@ -74,7 +74,7 @@ These changes do not affect the semantics of existing EVM code.
 
 This should jump into a subroutine, back out and stop.
 
-Bytecode: `0x6004b300b2b7`
+Bytecode: `0x60045e005c5d` (`PUSH1 0x04, JUMPSUB, STOP, BEGINSUB, RETURNSUB`)
 
 |  Pc   |      Op     | Cost |   Stack   |   RStack  |
 |-------|-------------|------|-----------|-----------|
@@ -90,7 +90,7 @@ Consumed gas: `18`
 
 This should execute fine, going into one two depths of subroutines
 
-Bytecode: `0x6800000000000000000cb300b26011b3b7b2b7`
+Bytecode: `0x6800000000000000000c5e005c60115e5d5c5d` (`PUSH9 0x00000000000000000c, JUMPSUB, STOP, BEGINSUB, PUSH1 0x11, JUMPSUB, RETURNSUB, BEGINSUB, RETURNSUB`)
 
 |  Pc   |      Op     | Cost |   Stack   |   RStack  |
 |-------|-------------|------|-----------|-----------|
@@ -109,7 +109,7 @@ Consumed gas: `36`
 This should fail, since the given location is outside of the code-range. The code is the same as previous example, 
 except that the pushed location is `0x01000000000000000c` instead of `0x0c`.
 
-Bytecode: `0x6801000000000000000cb300b26011b3b7b2b7`
+Bytecode: `0x6801000000000000000c5e005c60115e5d5c5d` (`PUSH9 0x01000000000000000c, JUMPSUB, STOP, BEGINSUB, PUSH1 0x11, JUMPSUB, RETURNSUB, BEGINSUB, RETURNSUB`)
 
 |  Pc   |      Op     | Cost |   Stack   |   RStack  |
 |-------|-------------|------|-----------|-----------|
@@ -124,7 +124,7 @@ Error: at pc=10, op=JUMPSUB: invalid jump destination
 
 This should fail at first opcode, due to shallow `return_stack`
 
-Bytecode: `0xb75858` (`RETURNSUB`, `PC`, `PC`)
+Bytecode: `0x5d5858` (`RETURNSUB, PC, PC`)
 
 |  Pc   |      Op     | Cost |   Stack   |   RStack  |
 |-------|-------------|------|-----------|-----------|
@@ -138,7 +138,7 @@ Error: at pc=0, op=RETURNSUB: invalid retsub
 
 In this example. the JUMPSUB is on the last byte of code. When the subroutine returns, it should hit the 'virtual stop' _after_ the bytecode, and not exit with error
 
-Bytecode: `0x600556b2b75b6003b3`
+Bytecode: `0x6005565c5d5b60035e` (`PUSH1 0x05, JUMP, BEGINSUB, RETURNSUB, JUMPDEST, PUSH1 0x03, JUMPSUB`)
 
 |  Pc   |      Op     | Cost |   Stack   |   RStack  |
 |-------|-------------|------|-----------|-----------|
@@ -156,7 +156,7 @@ Consumed gas: `30`
 
 In this example, the code 'walks' into a subroutine, which is not allowed, and causes an error
 
-Bytecode: `0xb2b700`
+Bytecode: `0x5c5d00` (`BEGINSUB, RETURNSUB, STOP`)
 
 
 |  Pc   |      Op     | Cost |   Stack   |   RStack  |
@@ -193,9 +193,9 @@ Benchmarking might be needed to tell if the costs are well-balanced.
 We suggest the following opcodes:
 
 ```
-0xb2 BEGINSUB
-0xb3 JUMPSUB
-0xb7 RETURNSUB
+0x5c BEGINSUB
+0x5d RETURNSUB
+0x5e JUMPSUB
 ```
 
 ## Security Considerations


### PR DESCRIPTION
Updates the opcodes to be aligned with the current instructionset in the EVM. Afaict, this was agreed upon on the latest ACD. 

