### PR TITLE
Update eip2537: Add link to noble library.

### DIFF
--- a/EIPS/eip-2537.md
+++ b/EIPS/eip-2537.md
@@ -240,7 +240,7 @@ Discounts table as a vector of pairs `[k, discount]`:
 
 `max_discount = 174`
 
-##### Pairing operaiton
+##### Pairing operation
 
 Cost of the pairing operation is `23000*k + 115000` where `k` is a number of pairs.
 

--- a/EIPS/eip-2537.md
+++ b/EIPS/eip-2537.md
@@ -307,6 +307,7 @@ There is a various choice of existing implementations of the curve operations. I
 - BLS12-381 code bases for Eth 2.0 clients
   - Chia's library in [C++](https://github.com/Chia-Network/bls-signatures)
   - Milagro in [various languages](https://github.com/apache/incubator-milagro) 
+  - Noble in [TypeScript/Javascript](https://github.com/paulmillr/noble-bls12-381)
 - EIP1962 code bases with fixed parameters
   - [Rust](https://github.com/matter-labs/eip1962)
   - [Go](https://github.com/kilic/eip2537)


### PR DESCRIPTION
It's very useful to have it, because noble is the only library that has all possible optimizations of final exponentiation used for pairings. Go and Rust codes don't have all of 'em. Also, it's the only JS implementation. 

https://github.com/paulmillr/noble-bls12-381