### PR TITLE
2537: Fix failing codespell check

### DIFF
--- a/EIPS/eip-2537.md
+++ b/EIPS/eip-2537.md
@@ -240,7 +240,7 @@ Discounts table as a vector of pairs `[k, discount]`:
 
 `max_discount = 174`
 
-##### Pairing operaiton
+##### Pairing operation
 
 Cost of the pairing operation is `23000*k + 115000` where `k` is a number of pairs.
 


### PR DESCRIPTION
Fixes the following codespell failure, preventing CI from passing on all branches based on current `master`:
```
EIPS/eip-2537.md:243: operaiton ==> operation
```