### PR TITLE
1193: Final edits in response to feedback

### DIFF
--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -15,7 +15,7 @@ requires: 155, 695
 
 This EIP formalizes a JavaScript Ethereum Provider API for consistency across clients and applications.
 
-The Provider's interface is designed to be minimal and agnostic of transport and RPC protocols.
+The Provider's interface is designed to be minimal, event-driven, and agnostic of transport and RPC protocols.
 
 Historically, Providers have been made available as `window.ethereum` in web browsers, but this convention is not part of the specification.
 
@@ -482,3 +482,47 @@ Instead, Providers should support RPC methods for explicitly requesting account 
 ## Copyright
 
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+
+## Appendix I: Legacy Provider API
+
+This section documents the legacy Provider API, which is extensively used in production at the time of writing.
+As it was never fully standardized, significant deviations occur in practice.
+The authors recommend against implementing it except to support legacy Ethereum applications.
+
+### sendAsync (DEPRECATED)
+
+This method is superseded by [`request`](#request).
+
+`sendAsync` is like `request`, but with JSON-RPC objects and a callback.
+
+```typescript
+Provider.sendAsync(request: Object, callback: Function): void;
+```
+
+Historically, the request and response object interfaces have followed the [Ethereum JSON-RPC specification](https://eips.ethereum.org/EIPS/eip-1474).
+
+### send (DEPRECATED)
+
+This method is superseded by [`request`](#request).
+
+```typescript
+Provider.send(...args: Array<unknown>): unknown;
+```
+
+### Legacy Events
+
+#### close (DEPRECATED)
+
+This event is superseded by [`disconnect`](#disconnect).
+
+#### networkChanged (DEPRECATED)
+
+The event `networkChanged` is superseded by [`chainChanged`](#chainchanged).
+
+For details, see [EIP-155: Simple replay attack protection](https://eips.ethereum.org/EIPS/eip-155) and [EIP-695: Create eth_chainId method for JSON-RPC](https://eips.ethereum.org/EIPS/eip-695).
+
+#### notification (DEPRECATED)
+
+This event is superseded by [`message`](#message).
+
+Historically, this event has been emitted with e.g. `eth_subscribe` subscription updates of the form `{ subscription: string, result: unknown }`.

--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -15,11 +15,9 @@ requires: 155, 695
 
 This EIP formalizes a JavaScript Ethereum Provider API for consistency across clients and applications.
 
-The Provider's interface is designed to be minimal, preferring that features are introduced in the API layer (see e.g. [`eth_requestAccounts`](https://eips.ethereum.org/EIPS/eip-1102)), and agnostic of transport and RPC protocols.
+The Provider's interface is designed to be minimal and agnostic of transport and RPC protocols.
 
 Historically, Providers have been made available as `window.ethereum` in web browsers, but this convention is not part of the specification.
-
-The events `connect`, `disconnect`, `chainChanged`, and `accountsChanged` are provided as a convenience to help enable reactive dapp UIs.
 
 ## API
 
@@ -54,27 +52,6 @@ Multiple RPC protocols may be available. For examples, see:
 - [EIP-1474](https://eips.ethereum.org/EIPS/eip-1474), the Ethereum JSON-RPC API
 - [EIP-1767](https://eips.ethereum.org/EIPS/eip-1767), the Ethereum GraphQL schema
 
-### sendAsync (DEPRECATED)
-
-This method is deprecated in favor of [`request`](#request).
-
-`sendAsync` is like `request`, but with JSON-RPC objects and a callback.
-
-```typescript
-Provider.sendAsync(request: Object, callback: Function): void;
-```
-
-The interfaces of request and response objects are not specified here.
-Historically, they have followed the [Ethereum JSON-RPC specification](https://eips.ethereum.org/EIPS/eip-1474).
-
-### send (DEPRECATED)
-
-This method is deprecated in favor of [`request`](#request).
-
-```typescript
-Provider.send(...args: Array<unknown>): unknown;
-```
-
 ### Events
 
 Events follow the [Node.js `EventEmitter`](https://nodejs.org/api/events.html) API.
@@ -89,7 +66,6 @@ The Provider emits `connect` when it:
 ```typescript
 interface ProviderConnectInfo {
   chainId: string;
-  [key: string]: unknown;
 }
 
 Provider.on('connect', listener: (connectInfo: ProviderConnectInfo) => void): Provider;
@@ -107,10 +83,6 @@ Provider.on('disconnect', listener: (error: ProviderRpcError) => void): Provider
 
 This event emits a [`ProviderRpcError`](#errors). The error `code` follows the table of [`CloseEvent` status codes](https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent#Status_codes).
 
-#### close (DEPRECATED)
-
-This event is deprecated in favor of [`disconnect`](#disconnect).
-
 #### chainChanged
 
 The Provider emits `chainChanged` when connecting to a new chain.
@@ -120,12 +92,6 @@ Provider.on('chainChanged', listener: (chainId: string) => void): Provider;
 ```
 
 The event emits a hexadecimal string `chainId` per the `eth_chainId` Ethereum RPC method.
-
-#### networkChanged (DEPRECATED)
-
-The event `networkChanged` is deprecated in favor of [`chainChanged`](#chainchanged).
-
-For details, see [EIP-155: Simple replay attack protection](https://eips.ethereum.org/EIPS/eip-155) and [EIP-695: Create eth_chainId method for JSON-RPC](https://eips.ethereum.org/EIPS/eip-695).
 
 #### accountsChanged
 
@@ -153,16 +119,9 @@ Provider.on('message', listener: (message: ProviderMessage) => void): Provider;
 
 ##### Subscriptions
 
-Some clients like [Geth](https://geth.ethereum.org/docs/rpc/pubsub) and [Parity](https://wiki.parity.io/JSONRPC-eth_pubsub-module) support Publish-Subscribe (_Pub-Sub_) using JSON-RPC notifications. This lets you subscribe and wait for events instead of polling for them.
-See the [`eth_` subscription methods](https://geth.ethereum.org/docs/rpc/pubsub) and [`shh_` subscription methods](https://github.com/ethereum/go-ethereum/wiki/Whisper-v6-RPC-API#shh_subscribe) for details.
+[`eth_` subscription methods](https://geth.ethereum.org/docs/rpc/pubsub) and [`shh_` subscription methods](https://github.com/ethereum/go-ethereum/wiki/Whisper-v6-RPC-API#shh_subscribe) rely on this event to emit subscription updates.
 
-For e.g. `eth_subscribe` subscription updates, `ProviderMessage.type` will equal the string `'eth_subscription'`.
-
-#### notification (DEPRECATED)
-
-This event is deprecated in favor of [`message`](#message).
-
-Historically, this event has returned e.g. `eth_subscribe` subscription updates of the form `{ subscription: string, result: unknown }`.
+For e.g. `eth_subscribe` subscription updates, `ProviderMessage.type` will equal the string `'eth_subscription'`, and the subscription data will be the value of `ProviderMessage.data`.
 
 ### Errors
 
@@ -277,30 +236,13 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 _This section is non-normative._
 
 - Provider
-  - A JavaScript object made available to a dapp, that provides access to Ethereum by means of a Client.
+  - A JavaScript object made available to a consumer, that provides access to Ethereum by means of a Client.
 - Client
   - An endpoint that receives Remote Procedure Call (RPC) requests from the Provider, and returns their results.
 - Wallet
   - An end-user application that manages private keys, performs signing operations, and acts as a middleware between the Provider and the Client.
 - Remote Procedure Call (RPC)
   - A Remote Procedure Call (RPC), is any request submitted to a Provider for some procedure that is to be processed by a Provider, its Wallet, or its Client.
-
-### Availability
-
-_This section is non-normative._
-
-How the Provider is made available to consumers is beyond the scope of this specification.
-At the time of writing, there exists no specification for Provider availability, merely a convention.
-This convention is described here for the benefit of dapp developers and Provider implementers.
-
-Historically, Providers have been injected into web pages as `window.ethereum` (more generally, `globalThis.ethereum`), such that they are available on page load.
-
-In practice, this convention does not handle some situations, including:
-
-- Multiple Providers being injected into the same page, e.g. when the user has multiple wallets installed
-- Asynchronously injected Providers, whether by choice or due to platform limitations
-
-The authors encourage Provider implementers to work with each other and with dapp developers to solve these problems until standards emerge.
 
 ### Connectivity
 
@@ -343,8 +285,8 @@ If the returned Promise rejects, it **MUST** reject with a `ProviderRpcError` as
 
 The returned Promise **MUST** reject if any of the following conditions are met:
 
-- The Client returns an error for the RPC request.
-  - If the error returned from the Client is compatible with the `ProviderRpcError` interface, the Promise **MAY** reject with that error directly.
+- An error is returned for the RPC request.
+  - If the returned error is compatible with the `ProviderRpcError` interface, the Promise **MAY** reject with that error directly.
 - The Provider encounters an error or fails to process the request for any reason.
 
 > If the Provider implements any kind of authorization logic, the authors recommend rejecting with a `4100` error in case of authorization failures.
@@ -412,9 +354,15 @@ interface ProviderRpcError extends Error {
 
 ### Events
 
-The Provider **SHOULD** extend the [Node.js `EventEmitter`](https://nodejs.org/api/events.html) to provide dapps flexibility in listening to events.
+The Provider **MUST** implement the following event handling methods:
 
-The Provider **MUST** implement at least the following methods `EventEmitter` methods: `on`, `emit`, and `removeListener`
+- `on`
+- `emit`
+- `removeListener`
+
+These methods **MUST** be implemented per the Node.js [`EventEmitter` API](https://nodejs.org/api/events.html).
+
+> To satisfy these requirements, Provider implementers should consider simply extending the Node.js `EventEmitter` class and bundling it for the target environment.
 
 #### message
 
@@ -490,7 +438,7 @@ The Provider is intended to pass messages between an Ethereum Client and an Ethe
 It is _not_ responsible for private key or account management; it merely processes RPC messages and emits events.
 Consequently, account security and user privacy need to be implemented in middlewares between the Provider and its Ethereum Client.
 In practice, we call these middleware applications "Wallets," and they usually manage the user's private keys and accounts.
-The Provider can be thought of as an extension of the Wallet, exposed in an untrusted environment, under the control of some third party (e.g. a dapp).
+The Provider can be thought of as an extension of the Wallet, exposed in an untrusted environment, under the control of some third party (e.g. a website).
 
 ### Handling Adversarial Behavior
 
@@ -526,10 +474,10 @@ Instead, Providers should support RPC methods for explicitly requesting account 
 - [Deprecated Ethereum Magicians thread](https://ethereum-magicians.org/t/eip-1193-ethereum-provider-javascript-api/640)
 - [Continuing discussion](https://github.com/ethereum/EIPs/issues/2319)
 - Related EIPs
-  - [EIP-1102 (`eth_requestAccounts`)](https://eips.ethereum.org/EIPS/eip-1102)
-  - [EIP-1474 (JSON-RPC specification)](https://eips.ethereum.org/EIPS/eip-1474)
-  - [EIP-1767 (GraphQL RPC specification)](https://eips.ethereum.org/EIPS/eip-1767)
-  - [EIP-2255 (wallet permissions)](https://eips.ethereum.org/EIPS/eip-2255)
+  - [EIP-1102](https://eips.ethereum.org/EIPS/eip-1102)
+  - [EIP-1474](https://eips.ethereum.org/EIPS/eip-1474)
+  - [EIP-1767](https://eips.ethereum.org/EIPS/eip-1767)
+  - [EIP-2255](https://eips.ethereum.org/EIPS/eip-2255)
 
 ## Copyright
 

--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -16,6 +16,7 @@ requires: 155, 695
 This EIP formalizes a JavaScript Ethereum Provider API for consistency across clients and applications.
 
 The Provider's interface is designed to be minimal, event-driven, and agnostic of transport and RPC protocols.
+New functionality is best introduced via new RPC methods.
 
 Historically, Providers have been made available as `window.ethereum` in web browsers, but this convention is not part of the specification.
 
@@ -257,6 +258,8 @@ The Provider is said to be "disconnected" when it cannot service RPC requests to
 
 > The Provider API is specified using TypeScript.
 > The authors encourage implementers to declare their own types and interfaces, using the ones in this section as a basis.
+>
+> The authors recommend that new functionality be introduced via new RPC methods instead of extensions of this interface, to the greatest extent possible.
 
 The Provider **MUST** implement and expose the API defined in this section. All API entities **MUST** adhere to the types and interfaces defined in this section.
 


### PR DESCRIPTION
Link to file: https://github.com/rekmarks/EIPs/blob/1193-final-draft/EIPS/eip-1193.md

- Normative
  - Update `Events` specification
    - Change recommendation to extend `EventEmitter` from normative to non-normative
      - In recognition that the `EventEmitter` API, while [stable](https://nodejs.org/api/documentation.html#documentation_stability_index) is growing over time
  - Remove leftover index type on one interface
    - This should have already been done
  - Remove all normative references to "Client"
- Non-normative
  - Trim "Summary" section
  - Trim `message` event "Subscription" subsection in API documentation
  - Remove all deprecated methods and events from the API documentation
    - They were only specified in the API documentation
  - Remove "Availability" section from specification (non-normative section)
  - Various minor fixups
