### PR TITLE
Eip2333 clarifications

### DIFF
--- a/EIPS/eip-2333.md
+++ b/EIPS/eip-2333.md
@@ -182,7 +182,7 @@ The child key derivation function takes in the parent's private key and the inde
 
 ##### Inputs
 
-* `seed`, the source entropy for the entire tree, a octet string >= 256 bits in length and containing at least 128 bits of entropy
+* `seed`, the source entropy for the entire tree, a octet string >= 256 bits in length
 
 ##### Outputs
 

--- a/EIPS/eip-2333.md
+++ b/EIPS/eip-2333.md
@@ -158,6 +158,7 @@ Every key generated via the key derivation process derives a child key via a set
 
 ### `derive_child_SK`
 
+The child key derivation function takes in the parent's private key and the index of the child and returns the child private key.
 
 ##### Inputs
 

--- a/EIPS/eip-2333.md
+++ b/EIPS/eip-2333.md
@@ -131,7 +131,7 @@ Every key generated via the key derivation process derives a child key via a set
 
 ##### Inputs
 
-* `IKM`, a secret octet string.
+* `IKM`, a secret octet string >= 256 bits in length
 
 ##### Outputs
 

--- a/EIPS/eip-2333.md
+++ b/EIPS/eip-2333.md
@@ -158,7 +158,6 @@ Every key generated via the key derivation process derives a child key via a set
 
 ### `derive_child_SK`
 
-The child key derivation function takes in the parent's private key and the index of the child and returns the child private key.
 
 ##### Inputs
 
@@ -179,9 +178,11 @@ The child key derivation function takes in the parent's private key and the inde
 
 ### `derive_master_SK`
 
+The child key derivation function takes in the parent's private key and the index of the child and returns the child private key. The seed should ideally be derived from a mnemonic, with the intention being that [BIP39 mnemonics](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki), with the associated [mnemonic_to_seed method](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki#from-mnemonic-to-seed) be used.
+
 ##### Inputs
 
-* `seed`, the source entropy for the entire tree, a octet string >= 128 bits
+* `seed`, the source entropy for the entire tree, a octet string >= 256 bits in length and containing at least 128 bits of entropy
 
 ##### Outputs
 
@@ -231,6 +232,13 @@ seed = 0xc55257c360c07c72029aebc1b53c05ed0362ada38ead3e3e9efa3708e53495531f09a69
 master_SK = 12513733877922233913083619867448865075222526338446857121953625441395088009793
 child_index = 0
 child_SK = 7419543105316279183937430842449358701327973165530407166294956473095303972104
+```
+
+This test case can be extended to test the entire mnemonic-to -child_SK` stack, assuming [BIP39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) is used as the mnemonic generation mechanism. Using the following parameters, the above seed can be calculated:
+
+```test
+mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+passphrase = "TREZOR"
 ```
 
 ### Test Case 1

--- a/EIPS/eip-2333.md
+++ b/EIPS/eip-2333.md
@@ -115,13 +115,15 @@ Every key generated via the key derivation process derives a child key via a set
 3. not_IKM = flip_bits(IKM)
 4. lamport_1 = IKM_to_lamport_SK(not_IKM, salt)
 5. lamport_PK = ""
-6. for i = 0 to 255
+6. for i  in 1, .., 255
        lamport_PK = lamport_PK | SHA256(lamport_0[i])
-7. for i = 0 to 255
+7. for i  in 1, .., 255
        lamport_PK = lamport_PK | SHA256(lamport_1[i])
 8. compressed_lamport_PK = SHA256(lamport_PK)
 9. return compressed_lamport_PK
 ```
+
+**Note:** The indexing, `i`, in the above procedure iterates from 1 to 255 (inclusive). This is due to the limit to which HKDF can stretch the input bytes (255 times the length of the input bytes). The result of this is that the security of the lamport-backup signature is \*only\* 127.5 bit.
 
 #### `HKDF_mod_r`
 
@@ -139,7 +141,7 @@ Every key generated via the key derivation process derives a child key via a set
 
 * `HKDF-Extract` is as defined in RFC5869, instantiated with hash H.
 * `HKDF-Expand` is as defined in RFC5869, instantiated with hash H.
-* `L` is the integer given by ceil((1.5 * ceil(log2(r))) / 8).
+* `L` is the integer given by `ceil((3 * ceil(log2(r))) / 16)`.(`L=48`)
 * `"BLS-SIG-KEYGEN-SALT-"` is an ASCII string comprising 20 octets.
 * `""` is the empty string.
 * `OS2IP` is as defined in [RFC3447](https://ietf.org/rfc/rfc3447.txt) (Big endian encoding)


### PR DESCRIPTION
## Clarifications:

* It was unclear whether the indexing was inclusive or exclusive of the bounds
* That BIP39 should be used to derive seeds

## Changes:

* `derive_master_SK`, and `HKDF_mod_r` now require a minimum input length of 32 bytes to line up with the definition in the BLS specs