### PR TITLE
EIP2335 Unicode Password support & Descriptions

### DIFF
--- a/EIPS/eip-2335.md
+++ b/EIPS/eip-2335.md
@@ -36,9 +36,17 @@ In Ethereum 1, [the Web3 Secret Storage Definition](https://github.com/ethereum/
 
 The process of decrypting the secret held within a keystore can be broken down into 3 sub-processes: obtaining the decryption key, verifying the password and decrypting the secret. Each process has its own functions which can be selected from as well as parameters required for the function all of which are specified within the keystore file itself.
 
+### Password requirements
+
+The password is a string of arbitrary unicode characters. The password is first converted to its NFKD representation, then the control codes (specified below) are stripped from the password and finally it is UTF-8 encoded.
+
+#### Control codes removal
+
+The C0, C1, and `Delete` control codes are not valid characters in the password and should therefore be stripped from the password. C0 are the control codes between `0x00` - `0x1F` (inclusive) and C1 codes lie between `0x80` and `0x9F` (inclusive). `Delete`, commonly known as "backspace", is the UTF-8 character `7F` which must also be stripped. Note that space (`Sp` UTF-8 `0x20`) is a valid character in passwords despite it being a pseudo-control character.
+
 ### Modules
 
-This standard makes use of the notion of a _module_ which serves to represent, in an abstract sense, the different cryptographic constructions and corresponding parameters for each component of the keystore. The idea being that components can be swapped out without affecting the rest of the specification should the need arise.
+This standard makes use of the notion of a _module_ which serves to represent, in an abstract sense, the different  cryptographic constructions and corresponding parameters for each component of the keystore. The idea being that components can be swapped out without affecting the rest of the specification should the need arise.
 
 A module is comprised of a `function`, which defines which cryptographic construct is being used, `params`, the parameters required by the function, and `message` the primary input to the function.
 
@@ -192,10 +200,11 @@ This specification is not backwards compatible with the [existing keystore stand
 
 ## Test Cases
 
-Password `'testpassword'`
-Secret `0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f`
-
 ### Scrypt Test Vector
+
+Password `"𝔱𝔢𝔰𝔱𝔭𝔞𝔰𝔰𝔴𝔬𝔯𝔡🔑"`
+Encoded Password: `0x7465737470617373776f7264f09f9491`
+Secret `0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f`
 
 ```json
 {
@@ -214,14 +223,14 @@ Secret `0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f`
         "checksum": {
             "function": "sha256",
             "params": {},
-            "message": "149aafa27b041f3523c53d7acba1905fa6b1c90f9fef137568101f44b531a3cb"
+            "message": "d2217fe5f3e9a1e34581ef8a78f7c9928e436d36dacc5e846690a5581e8ea484"
         },
         "cipher": {
             "function": "aes-128-ctr",
             "params": {
                 "iv": "264daa3f303d7259501c93d997d84fe6"
             },
-            "message": "54ecc8863c0550351eee5720f3be6a5d4a016025aa91cd6436cfec938d6a8d30"
+            "message": "06ae90d55fe0a6e9c5c3bc5b170827b2e5cce3929ed3f116c2811e6366dfe20f"
         }
     },
     "pubkey": "9612d7a727c9d0a22e185a1c768478dfe919cada9266988cb32359c11f2b7b27f4ae4040902382ae2910c15e2b420d07",
@@ -232,6 +241,10 @@ Secret `0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f`
 ```
 
 ### PBKDF2 Test Vector
+
+Password `"𝔱𝔢𝔰𝔱𝔭𝔞𝔰𝔰𝔴𝔬𝔯𝔡🔑"`
+Encoded Password: `0x7465737470617373776f7264f09f9491`
+Secret `0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f`
 
 ```json
 {
@@ -249,14 +262,14 @@ Secret `0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f`
         "checksum": {
             "function": "sha256",
             "params": {},
-            "message": "18b148af8e52920318084560fd766f9d09587b4915258dec0676cba5b0da09d8"
+            "message": "8a9f5d9912ed7e75ea794bc5a89bca5f193721d30868ade6f73043c6ea6febf1"
         },
         "cipher": {
             "function": "aes-128-ctr",
             "params": {
                 "iv": "264daa3f303d7259501c93d997d84fe6"
             },
-            "message": "a9249e0ca7315836356e4c7440361ff22b9fe71e2e2ed34fc1eb03976924ed48"
+            "message": "cee03fde2af33149775b7223e7845e4fb2c8ae1792e5f99fe9ecf474cc8c16ad"
         }
     },
     "pubkey": "9612d7a727c9d0a22e185a1c768478dfe919cada9266988cb32359c11f2b7b27f4ae4040902382ae2910c15e2b420d07",
@@ -270,7 +283,7 @@ Secret `0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f`
 
 Implementations exist in the following languages:
 
-* [Python3](https://github.com/CarlBeek/eth2.0-deposit-tooling/blob/master/keystores.py)
+* [Python3](https://github.com/ethereum/eth2.0-deposit-cli)
 * [TypeScript](https://github.com/nodefactoryio/bls-keystore)
 * [Go](https://github.com/wealdtech/go-eth2-wallet-encryptor-keystorev4/)
 

--- a/EIPS/eip-2733.md
+++ b/EIPS/eip-2733.md
@@ -1,0 +1,132 @@
+---
+eip: 2733
+title: Transaction package
+author: Matt Garnett (@lightclient)
+discussions-to: https://ethereum-magicians.org/t/eip-transaction-package/4365
+status: Draft
+type: Standards Track
+category: Core
+created: 2020-06-16
+requires: 2718
+---
+
+## Simple Summary
+Creates a new transaction type which executes a package of one or more
+transactions.
+
+## Abstract
+After `FORK_BLOCK`, a new [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718)
+transaction of type `N` is recognized. Transactions of type `N` will define a
+list of transactions, which must be executed serially by clients. Execution
+information (e.g. `success`, `gas_used`, etc.) will be propagated forward to
+the next transaction. 
+
+## Motivation
+Meta-transaction relay contracts have historically been designed to catch
+reversions in their inner transactions by only passing a portion of the
+available gas to the subcall. This has been considered bad practice for a long
+time, but in the case of untrust subcalls -- it is the only available solution.
+Transaction packages are an alternative solution which allow multiple
+transactions to be bundled into one package and executed atomically.
+
+## Specification
+
+### Definitions
+
+```
+N = TBD transaction type number
+INTRINSIC_COST = TBD
+TOTAL_COST = INTRINSIC_COST + inner_txs.reduce(|itx, acc| acc += itx.value + itx.gas_price * itx.gas_limit)
+TOTAL_GAS_LIMIT = inner_txs.reduce(|itx, acc| acc += itx.gas_limit)
+TX_HASH = hash of transaction as defined below
+SENDER = ecrecover(hash, v, r, s)
+RESULT = result as defined below for the previous transaction, empty if its the first tx in a package
+```
+
+### Serialization
+After `FORK_BLOCK`, a new [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718)
+transaction type `N` will be interpreted as follows:
+
+`rlp([N, rlp([nonce, v, r, s, [inner_tx_0, ..., inner_tx_n]])`
+
+where `inner_tx_n` is defined as:
+
+`[chain_id, to, value, data, gas_limit, gas_price]`
+
+### Hashing
+The hash of transaction type `N` is defined to be the Keccak-256 hash of the
+rlp encoding of the entire transaction with `v`, `r`, and `s` values omitted.
+
+### Results
+Subsequent transactions will be able to receive the result of the previous
+transaction via `RETURNDATACOPY (0x3E)` in first frame of exeuction, before
+making any subcalls. Each element except the last will be `0`-padded left to 32
+bytes.
+
+| Name | Type | Description  |
+|---|---|---|
+| `success`      | bool    | Status of the previous transaction |
+| `gas_used`     | uint256 | Total gas used by the previous transaction |
+| `cum_gas_used` | uint256 | Cumulative gas used by previous transactions |
+| `return_size`  | uint256 | The size of the return value |
+| `return_value` | bytes   | The return value of the previous transaction
+
+### Validation
+
+* (v, r, s) are a valid signature of the hash of the transaction
+* The nonce is one greater than recovered address' current nonce
+* The recovered address has a balance of at least `TOTAL_COST`
+* The `TOTAL_GAS_LIMIT` is less than the current block's `gas_limit`
+
+### Execution
+
+Transaction packages should be executed as follows:
+
+1. Deduct `TOTAL_COST` from `SENDER`'s balance
+2. Execute the first inner transaction in the list
+3. Refund any unused `gas`
+4. If there are no more transaction, stop
+5. Compute `RESULT` for the previously executed transaction
+6. Prepare `RESULT` to be available via return opcodes in the next
+   transaction's first frame
+7. Execute the transaction
+9. Goto `3`
+
+
+## Rationale
+
+#### Non-recursive inner transactions
+For simplicity, inner transactions are fully defined within this EIP. However,
+there is value in supporting recursive transaction definitions. For example,
+suppose there is a transaction type which can become invalid after a certain
+block number. It would be beneficial to support those types of transactions
+within a package, but the complexity of this EIP would dramatically increase.
+
+
+#### Appending result data to transaction input data
+An alternative to using return opcodes to propagate `RESULT` would be to append
+the `RESULT` to the subsequent transaction's `data` field. Unfortunately, in
+many cases contracts generated using Solidity [will
+fail](https://solidity.readthedocs.io/en/v0.6.0/contracts.html#overload-resolution-and-argument-matching)
+to resolve the intended function if additional data is present. Another
+alternative is introducing new opcodes to expose the result data were not
+proposed.
+
+
+## Backwards Compatibility
+Contracts which rely on `ORIGIN (0x32) == CALLER (0x33) && RETURNDATASIZE
+(0x3D) == 0x00` will now always fail in transaction packages, unless they are
+the first executed transaction. It's unknown if any contracts conduct this
+check.
+
+## Test Cases
+TBD
+
+## Implementation
+TBD
+
+## Security Considerations
+TBD
+
+## Copyright
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
* Unicode passwords are now explicitly supported via NFKD & UTF-8
* Descriptions have been added to help distinguish keystores. (Tackles the same thing as #2671, but under a different name to help make clear that descriptions are not necessarily unique)