### PR TITLE
Update EIP 1822 - 1967 Compatibility

### DIFF
--- a/EIPS/eip-1822.md
+++ b/EIPS/eip-1822.md
@@ -74,12 +74,12 @@ The Proxy Contract proposed here should be deployed _as is_, and used as a drop-
 
 The proposed fallback function follows the common pattern seen in other Proxy Contract implementations such as [Zeppelin][1] or [Gnosis][2].
 
-However, rather than forcing use of a variable, the address of the Logic Contract is stored at the defined storage position `keccak256("PROXIABLE")`. This eliminates the possibility of collision between variables in the Proxy and Logic Contracts, thus providing "universal" compatibility with any Logic Contract.
+However, rather than forcing use of a variable, the address of the Logic Contract is stored at the defined storage position `0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc` which is obtained as `bytes32(uint256(keccak256('eip1967.proxy.implementation')) - 1)`. This reduces the possibility of collision between variables in the Proxy and Logic Contracts, thus providing "universal" compatibility with any Logic Contract. The use of this particular storage position is futher discussed on the page for the [EIP 1967](https://eips.ethereum.org/EIPS/eip-1967).
 
 ```javascript
 function() external payable {
-    assembly { // solium-disable-line
-        let contractLogic := sload(0xc5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7)
+    assembly {
+        let contractLogic := sload(0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc)
         calldatacopy(0x0, 0x0, calldatasize)
         let success := delegatecall(sub(gas, 10000), contractLogic, 0x0, calldatasize, 0, 0)
         let retSz := returndatasize
@@ -107,19 +107,19 @@ The contract below shows the proposed implementation of the Proxy Contract.
 
 ```javascript
 contract Proxy {
-    // Code position in storage is keccak256("PROXIABLE") = "0xc5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7"
+    // Code position in storage is `bytes32(uint256(keccak256('eip1967.proxy.implementation')) - 1)` = "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc"
     constructor(bytes memory constructData, address contractLogic) public {
         // save the code address
-        assembly { // solium-disable-line
-            sstore(0xc5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7, contractLogic)
+        assembly { 
+            sstore(0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc, contractLogic)
         }
-        (bool success, bytes memory _ ) = contractLogic.delegatecall(constructData); // solium-disable-line
+        (bool success, bytes memory _ ) = contractLogic.delegatecall(constructData); 
         require(success, "Construction failed");
     }
 
     function() external payable {
-        assembly { // solium-disable-line
-            let contractLogic := sload(0xc5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7)
+        assembly { 
+            let contractLogic := sload(0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc)
             calldatacopy(0x0, 0x0, calldatasize)
             let success := delegatecall(sub(gas, 10000), contractLogic, 0x0, calldatasize, 0, 0)
             let retSz := returndatasize
@@ -150,21 +150,21 @@ Compatibility check to ensure the new Logic Contract implements the Universal Up
 
 ##### `updateCodeAddress`
 
-Stores the Logic Contract's address at storage `keccak256("PROXIABLE")` in the Proxy Contract.
+Stores the Logic Contract's address at storage slot `bytes32(uint256(keccak256('eip1967.proxy.implementation')) - 1)` in the Proxy Contract.
 
-The contract below shows the proposed implementation of the Proxiable Contract.
+The contract below shows a proposed implementation of the Proxiable Contract. In this example the compatibility check uses keccak256("PROXIABLE") for `proxiableUUID()`.
 
 ```javascript
 contract Proxiable {
-    // Code position in storage is keccak256("PROXIABLE") = "0xc5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7"
-
+    // Code position in storage is 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc
     function updateCodeAddress(address newAddress) internal {
+        // keccak256("PROXIABLE") is 0xc5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7
         require(
             bytes32(0xc5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7) == Proxiable(newAddress).proxiableUUID(),
             "Not compatible"
         );
-        assembly { // solium-disable-line
-            sstore(0xc5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7, newAddress)
+        assembly {
+            sstore(0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc, newAddress)
         }
     }
     function proxiableUUID() public pure returns (bytes32) {
@@ -225,19 +225,19 @@ contract Owned is Proxiable {
 pragma solidity ^0.5.1;
 
 contract Proxy {
-    // Code position in storage is keccak256("PROXIABLE") = "0xc5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7"
+    // Code position in storage is bytes32(uint256(keccak256('eip1967.proxy.implementation')) - 1) = "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc"
     constructor(bytes memory constructData, address contractLogic) public {
         // save the code address
-        assembly { // solium-disable-line
-            sstore(0xc5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7, contractLogic)
+        assembly {
+            sstore(0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc, contractLogic)
         }
-        (bool success, bytes memory _ ) = contractLogic.delegatecall(constructData); // solium-disable-line
+        (bool success, bytes memory _ ) = contractLogic.delegatecall(constructData);
         require(success, "Construction failed");
     }
 
     function() external payable {
-        assembly { // solium-disable-line
-            let contractLogic := sload(0xc5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7)
+        assembly {
+            let contractLogic := sload(0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc)
             calldatacopy(0x0, 0x0, calldatasize)
             let success := delegatecall(sub(gas, 10000), contractLogic, 0x0, calldatasize, 0, 0)
             let retSz := returndatasize
@@ -259,15 +259,15 @@ contract Proxy {
 ``` javascript
 
 contract Proxiable {
-    // Code position in storage is keccak256("PROXIABLE") = "0xc5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7"
+    // Code position in storage is 0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc
 
     function updateCodeAddress(address newAddress) internal {
         require(
             bytes32(0xc5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7) == Proxiable(newAddress).proxiableUUID(),
             "Not compatible"
         );
-        assembly { // solium-disable-line
-            sstore(0xc5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7, newAddress)
+        assembly {
+            sstore(0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc, newAddress)
         }
     }
     function proxiableUUID() public pure returns (bytes32) {

--- a/EIPS/eip-1822.md
+++ b/EIPS/eip-1822.md
@@ -45,11 +45,11 @@ Standard upgradeable proxy contract.
 
 ## Abstract
 
-The following describes a standard for proxy contracts which is universally compatible with all contracts, and does not create incompatibility between the proxy and business-logic contracts. This is achieved by utilizing a unique storage position in the proxy contract to store the Logic Contract's address. A compatibility check ensures successful upgrades. Upgrading can be performed unlimited times, or as determined by custom logic. In addition, a method for selecting from multiple constructors is provided, which does not inhibit the ability to verify bytecode.
+The following describes a standard for proxy contracts which is universally compatible with all contracts and does not create incompatibility between the proxy and business-logic contracts. This is achieved by utilizing a unique storage position in the proxy contract to store the Logic Contract's address. A compatibility check ensures successful upgrades. Upgrading can be performed unlimited times, or as determined by custom logic. In addition, a method for selecting from multiple constructors is provided, which does not inhibit the ability to verify bytecode.
 
 ## Motivation
 
-- Improve upon existing proxy implementations to improve developer experience for deploying and maintaining Proxy and Logic Contracts.
+- Improve upon existing proxy implementations to improve the developer experience for deploying and maintaining Proxy and Logic Contracts.
 
 - Standardize and improve the methods for verifying the bytecode used by the Proxy Contract.
 
@@ -64,7 +64,7 @@ The following describes a standard for proxy contracts which is universally comp
 
 ## Specification
 
-The Proxy Contract proposed here should be deployed _as is_, and used as a drop-in replacement for any existing methods of lifecycle management of contracts. In addition to the Proxy Contract, we propose the Proxiable Contract interface/base which establishes a pattern for the upgrade which does not interfere with existing business rules. The logic for allowing upgrades can be implemented as needed.
+The Proxy Contract proposed here should be deployed _as is_ and used as a drop-in replacement for any existing methods of lifecycle management of contracts. In addition to the Proxy Contract, we propose the Proxiable Contract interface/base which establishes a pattern for the upgrade which does not interfere with existing business rules. The logic for allowing upgrades can be implemented as needed.
 
 ### Proxy Contract
 
@@ -97,11 +97,11 @@ function() external payable {
 
 #### `constructor`
 
-The proposed constructor accepts any number of arguments of any type, and thus is compatible with any Logic Contract constructor function.
+The proposed constructor accepts any number of arguments of any type and thus is compatible with any Logic Contract constructor function.
 
 In addition, the arbitrary nature of the Proxy Contract's constructor provides the ability to select from one or more constructor functions available in the Logic Contract source code (e.g., `constructor1`, `constructor2`, ... etc. ). Note that if multiple constructors are included in the Logic Contract, a check should be included to prohibit calling a constructor again post-initialization.
 
-It's worth noting that the added functionality of supporting multiple constructors does not inhibit verification of the Proxy Contract's bytecode, since the initialization tx call data (input) can be decoded by first using the Proxy Contract ABI, and then using the Logic Contract ABI.
+It's worth noting that the added functionality of supporting multiple constructors does not inhibit verification of the Proxy Contract's bytecode since the initialization tx call data (input) can be decoded by first using the Proxy Contract ABI, and then using the Logic Contract ABI.
 
 The contract below shows the proposed implementation of the Proxy Contract.
 
@@ -138,9 +138,9 @@ contract Proxy {
 
 ### Proxiable Contract
 
-The Proxiable Contract is included in the Logic Contract, and provides the functions needed to perform an upgrade. The compatibility check `proxiable` prevents irreparable updates during an upgrade.
+The Proxiable Contract is included in the Logic Contract and provides the functions needed to perform an upgrade. The compatibility check `proxiable` prevents irreparable updates during an upgrade.
 
-> :warning: Warning: `updateCodeAddress` and `proxiable` must be present in the Logic Contract. Failure to include these may prevent upgrades, and could allow the Proxy Contract to become entirely unusable. See below [Restricting dangerous functions](#restricting-dangerous-functions)
+> :warning: Warning: `updateCodeAddress` and `proxiable` must be present in the Logic Contract. Failure to include these may prevent upgrades and could allow the Proxy Contract to become entirely unusable. See below [Restricting dangerous functions](#restricting-dangerous-functions)
 
 #### Functions
 
@@ -181,19 +181,19 @@ The following common best practices should be employed for all Logic Contracts w
 
 Careful consideration should be made when designing a new Logic Contract to prevent incompatibility with the existing storage of the Proxy Contract after an upgrade. Specifically, the order in which variables are instantiated in the new contract should not be modified, and any new variables should be added after all existing variables from the previous Logic Contract
 
-To facilitate this practice, we recommend utilizing a single "base" contract which holds all variables, and which is inherited in subsequent logic contract(s). This practice greatly reduces the chances of accidentally reordering variables or overwriting them in storage.
+To facilitate this practice, we recommend utilizing a single "base" contract which holds all variables, and which is inherited in a subsequent logic contract(s). This practice greatly reduces the chances of accidentally reordering variables or overwriting them in storage.
 
 ### Restricting dangerous functions
 
-The compatibility check in the Proxiable Contract is a safety mechanism to prevent upgrading to a Logic Contract which does not implement the Universal Upgradeable Proxy Standard. However, as occurred in the parity wallet hack, it is still possible to perform irreparable damage to the Logic Contract itself.
+The compatibility check in the Proxiable Contract is a safety mechanism to prevent upgrading to a Logic Contract which does not implement the Universal Upgradeable Proxy Standard. However, as occurred in the Parity wallet hack, it is still possible to perform irreparable damage to the Logic Contract itself.
 
-In order to prevent damage to the Logic Contract, we recommend restricting permissions for any potentially damaging functions to `onlyOwner`, and giving away ownership of the Logic Contract immediately upon deployment to a null address (e.g., address(1)). Potentially damaging functions include native functions such as `SELFDESTRUCT`, as well functions whose code may originate externally such as `CALLCODE`, and `delegatecall()`. In the [ERC-20 Token](#erc-20-token) example below, a `LibraryLock` contract is used to prevent destruction of the logic contract.
+In order to prevent damage to the Logic Contract, we recommend restricting permissions for any potentially damaging functions to `onlyOwner`, and giving away ownership of the Logic Contract immediately upon deployment to a null address (e.g., address(1)). Potentially damaging functions include native functions such as `SELFDESTRUCT`, as well functions whose code may originate externally such as `CALLCODE`, and `delegatecall()`. In the [ERC-20 Token](#erc-20-token) example below, a `LibraryLock` contract is used to prevent the destruction of the logic contract.
 
 ## Examples
 
 ### Owned
 
-In this example, we show the standard ownership example, and restrict the `updateCodeAddress` to only the owner.
+In this example, we show the standard ownership example and restrict the `updateCodeAddress` to only the owner.
 
 ```javascript
 contract Owned is Proxiable {

--- a/EIPS/eip-1822.md
+++ b/EIPS/eip-1822.md
@@ -1,7 +1,7 @@
 ---
 eip: 1822
 title: Universal Upgradeable Proxy Standard (UUPS)
-author: Gabriel Barros <gabriel@terminal.co>, Patrick Gallagher <blockchainbuddha@gmail.com>
+author: Gabriel Barros <gbbabarros@gmail.com>, Patrick Gallagher <blockchainbuddha@gmail.com>
 discussions-to: https://ethereum-magicians.org/t/eip-1822-universal-upgradeable-proxy-standard-uups
 status: Draft
 type: Standards Track


### PR DESCRIPTION
This PR is to address adding compatibility with EIP 1967. See discussion here https://ethereum-magicians.org/t/eip-1822-universal-upgradeable-proxy-standard-uups/2842/21