### PR TITLE
Remove note about block/pending filters for eth_getLogs

### DIFF
--- a/EIPS/eip-1474.md
+++ b/EIPS/eip-1474.md
@@ -974,8 +974,6 @@ Returns a list of all logs based on a filter object
 - {[`Data`](#data)} `topics` - list of order-dependent topics
 - {`boolean`} `removed` - `true` if this filter has been destroyed and is invalid
 
-**Note:** The return value of `eth_getLogs` when retrieving logs from `eth_newBlockFilter` and `eth_newPendingTransactionFilter` filters will be an array of hashes, not an array of Log objects.
-
 ##### Example
 
 ```sh


### PR DESCRIPTION
The note doesn't make sense because it isn't possible to get logs for block/pending filters.