### PR TITLE
Remove misformatted requires field on EIPs 2711 & 2718

### DIFF
--- a/EIPS/eip-2711.md
+++ b/EIPS/eip-2711.md
@@ -7,7 +7,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2020-06-11
-requires (*optional): 2718
+requires: 2718
 ---
 
 ## Simple Summary

--- a/EIPS/eip-2718.md
+++ b/EIPS/eip-2718.md
@@ -7,7 +7,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2020-06-13
-requires (*optional): 155
+requires: 155
 ---
 
 ## Simple Summary


### PR DESCRIPTION
Current output of `.travis-ci.sh`:

```console
Warning: EIPS/eip-2711.md        undefined method `requires (*optional)=' for #<EipValidator::Validator:0x000055bc8db14370>
Warning: EIPS/eip-2718.md        undefined method `requires (*optional)=' for #<EipValidator::Validator:0x000055bc8dab6860>
```