### PR TITLE
Fix misformatted requires field for EIP-2565

### DIFF
--- a/EIPS/eip-2565.md
+++ b/EIPS/eip-2565.md
@@ -7,7 +7,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2020-03-20
-Requires: 198
+requires: 198
 ---
 
 ## Simple Summary


### PR DESCRIPTION
Current output from `eip-validator`:

```console
Warning: EIPS/eip-2565.md        undefined method `Requires=' for #<EipValidator::Validator:0x00005652718d22b8>
```