### PR TITLE
Fix misformatted requires field on EIP-2615

### DIFF
--- a/EIPS/eip-2615.md
+++ b/EIPS/eip-2615.md
@@ -7,7 +7,7 @@ status: Draft
 type: Standards Track
 category: ERC
 created: 2020-04-25
-requires (*optional): 165 721
+requires: 165, 721
 ---
 
 ## Simple Summary


### PR DESCRIPTION
Current output of `eip_validator`:

```console
Warning: EIPS/eip-2615.md        undefined method `requires (*optional)=' for #<EipValidator::Validator:0x000055916209fc10>
```