### PR TITLE
[EIP-1193] Strict readonly typing for typescript definitions

### DIFF
--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -71,8 +71,8 @@ All API entities **MUST** adhere to the types and interfaces defined in this sec
 
 ```typescript
 interface RequestArguments {
-  method: string;
-  params?: unknown[] | object;
+  readonly method: string;
+  readonly params?: readonly unknown[] | object;
 }
 
 Provider.request(args: RequestArguments): Promise<unknown>;
@@ -119,7 +119,6 @@ If an RPC method defined in a finalized EIP is not supported, it **SHOULD** be r
 
 ```typescript
 interface ProviderRpcError extends Error {
-  message: string;
   code: number;
   data?: unknown;
 }
@@ -176,8 +175,8 @@ When emitted, the `message` event **MUST** be emitted with an object argument of
 
 ```typescript
 interface ProviderMessage {
-  type: string;
-  data: unknown;
+  readonly type: string;
+  readonly data: unknown;
 }
 ```
 
@@ -189,10 +188,10 @@ If the Provider receives a subscription message from e.g. an `eth_subscribe` sub
 
 ```typescript
 interface EthSubscription extends ProviderMessage {
-  type: 'eth_subscription';
-  data: {
-    subscription: string;
-    result: unknown;
+  readonly type: 'eth_subscription';
+  readonly data: {
+    readonly subscription: string;
+    readonly result: unknown;
   };
 }
 ```
@@ -212,7 +211,7 @@ This event **MUST** be emitted with an object of the following form:
 
 ```typescript
 interface ProviderConnectInfo {
-  chainId: string;
+  readonly chainId: string;
 }
 ```
 
@@ -333,8 +332,8 @@ Makes an Ethereum RPC method call.
 
 ```typescript
 interface RequestArguments {
-  method: string;
-  params?: unknown[] | object;
+  readonly method: string;
+  readonly params?: readonly unknown[] | object;
 }
 
 Provider.request(args: RequestArguments): Promise<unknown>;
@@ -371,7 +370,7 @@ The Provider emits `connect` when it:
 
 ```typescript
 interface ProviderConnectInfo {
-  chainId: string;
+  readonly chainId: string;
 }
 
 Provider.on('connect', listener: (connectInfo: ProviderConnectInfo) => void): Provider;
@@ -416,8 +415,8 @@ Messages may include JSON-RPC notifications, GraphQL subscriptions, and/or any o
 
 ```typescript
 interface ProviderMessage {
-  type: string;
-  data: unknown;
+  readonly type: string;
+  readonly data: unknown;
 }
 
 Provider.on('message', listener: (message: ProviderMessage) => void): Provider;


### PR DESCRIPTION
Added `readonly` keyword to all typescript interface definitions.

I decided to avoid `readonly` on the `ProviderRpcError` because it extends `Error` which does not have its properties as readonly. We can assume that this is a really bad Javascript standard that we have to follow. In addition `message` property was removed from the interface because it is defined in original `Error` interface:  https://github.com/microsoft/TypeScript/blob/master/lib/lib.es5.d.ts#L972

https://github.com/ethereum/EIPs/issues/2319#issuecomment-654343547