### PR TITLE
Change ERC1271 to bytes32 hash

### DIFF
--- a/EIPS/eip-1271.md
+++ b/EIPS/eip-1271.md
@@ -40,7 +40,7 @@ pragma solidity ^0.5.0;
 
 contract ERC1271 {
 
-  // bytes4(keccak256("isValidSignature(bytes,bytes)")
+  // bytes4(keccak256("isValidSignature(bytes32,bytes)")
   bytes4 constant internal MAGICVALUE = 0x1626ba7e;
 
   /**

--- a/EIPS/eip-1271.md
+++ b/EIPS/eip-1271.md
@@ -41,19 +41,19 @@ pragma solidity ^0.5.0;
 contract ERC1271 {
 
   // bytes4(keccak256("isValidSignature(bytes,bytes)")
-  bytes4 constant internal MAGICVALUE = 0x20c13b0b;
+  bytes4 constant internal MAGICVALUE = 0x1626ba7e;
 
   /**
    * @dev Should return whether the signature provided is valid for the provided data
    * @param _data Arbitrary length data signed on the behalf of address(this)
    * @param _signature Signature byte array associated with _data
    *
-   * MUST return the bytes4 magic value 0x20c13b0b when function passes.
+   * MUST return the bytes4 magic value 0x1626ba7e when function passes.
    * MUST NOT modify state (using STATICCALL for solc < 0.5, view modifier for solc > 0.5)
    * MUST allow external calls
    */ 
   function isValidSignature(
-    bytes memory _data, 
+    bytes32 _hash, 
     bytes memory _signature)
     public
     view 
@@ -88,6 +88,7 @@ This EIP is backward compatible with previous work on signature validation since
 
 Existing implementations : 
 
+* ERC725 [implemented in the ERC725Account](https://github.com/ERC725Alliance/ERC725/blob/master/implementations/contracts/ERC725/ERC725Account.sol#L73-L90).
 * The 0x project [implemented this method](https://github.com/0xProject/0x-monorepo/blob/05b35c0fdcbca7980d4195e96ec791c1c2d13398/packages/contracts/src/2.0.0/protocol/Exchange/MixinSignatureValidator.sol#L187) in their protocol version 2.
 * Zeppelin is [in the process](https://github.com/OpenZeppelin/openzeppelin-solidity/issues/1104) of implementing this method.
 


### PR DESCRIPTION
This changes the proposal to use a `bytes32` hash for the signature to prevent the requirement of specific implementation checks within this signature verification functions.

Those can be either done off-chain, or in other smart contract functions, and funnel those to this function to verify the signature.

When opening a pull request to submit a new EIP, please use the suggested template: https://github.com/ethereum/EIPs/blob/master/eip-template.md

We have a GitHub bot that automatically merges some PRs. It will merge yours immediately if certain criteria are met:

 - The PR edits only existing draft PRs.
 - The build passes.
 - Your GitHub username or email address is listed in the 'author' header of all affected PRs, inside <triangular brackets>.
 - If matching on email address, the email address is the one publicly listed on your GitHub profile.
