### PR TITLE
Update ERC725 with new format and sub standards ERC725X and ERC725Y

### DIFF
--- a/EIPS/eip-725.md
+++ b/EIPS/eip-725.md
@@ -1,5 +1,5 @@
 ```
-eip: <to be assigned>
+eip: 725
 title: ERC-725 Smart Contract Based Account
 author: Fabian Vogelsteller <fabian@lukso.network>, Tyler Yasaka (@tyleryasaka)
 discussions-to: https://github.com/ethereum/EIPs/issues/725

--- a/EIPS/eip-725.md
+++ b/EIPS/eip-725.md
@@ -1,55 +1,93 @@
----
-eip: 725
-title: Proxy Account
-author: Fabian Vogelsteller (@frozeman), Tyler Yasaka (@tyleryasaka)
+```
+eip: <to be assigned>
+title: ERC-725 Smart Contract Based Account
+author: Fabian Vogelsteller <fabian@lukso.network>, Tyler Yasaka (@tyleryasaka)
 discussions-to: https://github.com/ethereum/EIPs/issues/725
 status: Draft
 type: Standards Track
 category: ERC
+requires: ERC165, ERC173, ERC1271 (optional)
 created: 2017-10-02
----
+updated: 2020-07-02
+```
+
+**This is the new 725 v2 standard, that is radically different from [ERC 725 v1](https://github.com/ethereum/EIPs/blob/ede8c26a77eb1ac8fa2d01d8743a8cf259d8d45b/EIPS/eip-725.md). ERC 725 v1 is be moved to #734 as a new key manager standard.**
+--------
 
 ## Simple Summary
-A standard interface for a simple proxy account.
+A standard interface for a smart contract based account with attachable key value store.
 
 ## Abstract
 
-The following describes standard functions for a unique identifiable proxy account to be used by humans, groups, organisations, objects and machines. The proxy has 2 abilities: (1) it can execute arbitrary contract calls, and (2) it can hold arbitrary data through a generic key/value store. One of these keys should hold the owner of the contract. The owner may be an address or a key manager contract for more complex management logic. Most importantly, this contract should be the reference point for a long-lasting identifiable profiles.
+The following describes standard functions for a unique smart contract based account that can be used by humans,
+groups, organisations, objects and machines.
+
+The standard is divided into two sub standards:
+
+`ERC725X`:
+Can execute arbitrary smart contracts using and deploy other smart contracts.
+
+`ERC725Y`:
+Can hold arbitrary data through a generic key/value store.
 
 ## Motivation
 
-Standardizing a minimal interface for an proxy account allows third parties to interact with various proxy accounts contracts in a consistent manner. 
-the benefit is a persistent account that is independent from single keys and can attach an arbitrary amount of information to verifiy, or enhance the accounts purpose.
+Standardizing a minimal interface for a smart contract based account allows any interface to operate through these account types.
+Smart contact based accounts following this standard have the following advantages:
+
+- can hold any asset (native token, e.g. ERC20 like tokens)
+- can execute any smart contract and deploy smart contracts
+- have upgradeable security (through owner change, e.g. to a gnosis safe)
+- are basic enough to work for for a long time
+- are extensible though additional standardisation of the key/value data.
+- can function as an owner/controller or proxy of other smart contracts
+
 
 ## Specification
 
+### ERC725X 
 
-### Methods
+ERC165 identifier: `0x44c028fe`
 
-#### owner
+#### execute
 
-Returns the current owner
-
-```js
-address public owner;
-```
-
-#### changeOwner
-
-Changes the current owner. MUST only be called by the current owner of the contract.
+Executes a call on any other smart contracts, transfers the blockchains native token, or deploys a new smart contract.
+MUST only be called by the current owner of the contract.
 
 ```js
-function changeOwner(address _owner);
+function execute(uint256 operationType, address to, uint256 value, bytes data)
 ```
 
-**Triggers Event:** [OwnerChanged](#ownerchanged)
+The `operationType` can execute the following operations:
+- `0` for `call`
+- `1` for `delegatecall`
+- `2` for `create2`
+- `3` for `create`
+
+Others may be added in the future.
+
+**Triggers Event:** [ContractCreated](#contractcreated) if a contract was created
+
+### Events
+
+#### ContractCreated
+
+MUST be triggered when `execute` creates a new contract using the `_operationType` `1`.
+
+```js
+event ContractCreated(address indexed contractAddress)
+```
+
+### ERC725Y
+
+ERC165 identifier: `0x2bd57b73`
 
 #### getData
 
 Returns the data at the specified key.
 
 ```js
-function getData(bytes32 _key) external view returns (bytes _value);
+function getData(bytes32 key) external view returns(bytes value)
 ```
 
 #### setData
@@ -59,111 +97,115 @@ Sets the data at a specific key. MUST only be called by the current owner of the
 **Triggers Event:** [DataChanged](#datachanged)
 
 ```js
-function setData(bytes32 _key, bytes _value) external;
+function setData(bytes32 _key, bytes memory _value) external
 ```
-
-#### execute
-
-Executes an action on other contracts or a transfer of the blockchains native cryptocurrency. MUST only be called by the current owner of the contract.
-
-```js
-function execute(uint256 _operationType, address _to, uint256 _value, bytes _data) external;
-```
-
-The `operationType` should represent the assembly operation as follows:
-- `0` for `call`
-- `1` for `create`
-
-Others may be added in the future. Inspired by [ERC1077](https://eips.ethereum.org/EIPS/eip-1077) and [Gnosis](https://github.com/gnosis/safe-contracts/blob/master/contracts/Enum.sol#L7)
 
 ### Events
-
 
 #### DataChanged
 
 MUST be triggered when `setData` was successfully called.
 
 ```js
-event DataChanged(bytes32 indexed key, bytes value);
-```
-
-#### ContractCreated
-
-MUST be triggered when `execute` creates a new contract using the `_operationType` `1`.
-
-```js
-event ContractCreated(address indexed contractAddress);
-```
-
-#### OwnerChanged
-
-MUST be triggered when `changeOwner` was successfully called.
-
-```js
-event OwnerChanged(address indexed ownerAddress);
+event DataChanged(bytes32 indexed key, bytes value)
 ```
 
 
 ### Ownership
 
-This contract is controlled by the owner. The owner can be a smart contract or an address, or itself.
+This contract is controlled by an owner. The owner can be a smart contract or an external account.
+This standard requires [ERC173](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-173.md) and should implement the functions:
+
+- `owner() view`
+- `transferOwnership(address newOwner)`
+- and the Event `event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)`
 
 ### Data keys
 
 Data keys, should be the keccak256 hash of a type name.
-e.g. `myNewKeyType` is `0xa94996022594f93c34a730df0ae89d1ecd69dff98c17d0387e69ce58346323a4`
+e.g. `keccak256('ERCXXXMyNewKeyType')` is `0x6935a24ea384927f250ee0b954ed498cd9203fc5d2bf95c735e52e6ca675e047`
 
 #### Multiple keys of the same type
 
-Multiple keys for the same key type must add a `keyTypeName-1` at the end of the key type.
+If you require multiple keys of the same key type they MUST be defined as follows:
 
-This would looks as follows for `myNewKeyType`:  
-version 0 `myNewKeyType`: `0xa94996022594f93c34a730df0ae89d1ecd69dff98c17d0387e69ce58346323a4`   
-version 1 `myNewKeyType-1`: `0xb6dace1ed14874742c4d1b8cd9b270305176f769e0ae22118a02c2db4e620f29`   
-version 2 `myNewKeyType-2`: `0x6cc96a01de588f4550e8c3a821aed065ae7897f8dfb61836c78c0389e499d9ed`   
+- The keytype name MUST have a `[]` add and then hashed
+- The key hash MUST contain the number of all elements, and is required to be updated when a new key element is added.
+
+For all other elements:
+- The first 16 bytes are the first 16 bytes of the key hash
+- The second 16 bytes is a `uint128` of the number of the element
+- Elements start at number `0`
+
+##### Example
+This would looks as follows for `ERCXXXMyNewKeyType[]` (keccak256: `0x4f876465dbe22c8495f4e4f823d846957ddb8ce6006afe66ddc5bac4f0626767`): 
+- element number: key: `0x4f876465dbe22c8495f4e4f823d846957ddb8ce6006afe66ddc5bac4f0626767`, value: `0x0000000000000000000000000000000000000000000000000000000000000002` (2 elements)
+- element 1: key: `0x4f876465dbe22c8495f4e4f823d8469500000000000000000000000000000000`, value: `0x123...` (element 0)
+- element 2: key: `0x4f876465dbe22c8495f4e4f823d8469500000000000000000000000000000001`, value: `0x321...` (element 1)
 ...
 
-Anyone that would like to standardize a new data key should make a pull request to update the table below.
+#### Default key values
+
+ERC725 key standards need to be defined within new standards, we offer the following default:
 
 | Name | Description | Key | value |
 | --- | --- | --- | --- |
-| owner | The owner of the proxy account | 0x0000000000000000000000000000000000000000000000000000000000000000 | left padded owner address, e.g. `0x000000000000000000000000de0B295669a9FD93d5F28D9Ec85E40f4cb697BAe` |
-| 735 | The proxy accounts claim holder contract (per [ERC735](https://github.com/ethereum/EIPs/issues/735)) | 0xb0f23aea7d77ce19f9393243a7b50a3bcaac893c7d68a5a309dea7cacf035fd0 | left padded address of the claim holder contract,  e.g. `0x000000000000000000000000de0B295669a9FD93d5F28D9Ec85E40f4cb697BAe` |
-| 780 | The proxy accounts claim holder contract (per [ERC735](https://github.com/ethereum/EIPs/issues/735)) | 0xdaf52dba5981246bcf8fd7c6b00dce587fdcf5e2a95b281eea95dcd1376afdcd | left padded address of the claim registry contract,  e.g. `0x000000000000000000000000de0B295669a9FD93d5F28D9Ec85E40f4cb697BAe` |
+| ERC725Type | The type of the ERC725 contract. Multiple types can be proposed: like ERC725 for smart contract based accounts, or as NFT2.0, etc | `0xee97c7dd2e734cf234c2ba0d83a74633e1ac7fc8a9fd779f8497a0109c71b993` | 32 bytes value (`keccak256('ERC725Account')`) `0xafdeb5d6e788fe0ba73c9eb2e30b8a4485e3a18fb31dd13e3b362f62a65c67a0` |
+| ERC735 | A personal claim holder contract (per [ERC735](https://github.com/ethereum/EIPs/issues/735)) | `0x33f5765e0b3f726091f5ab06cd801c2bcd9bf89228534161c70fd7e257b8bfa3` | 20 bytes value `0xcafecafe69a9FD93d5F28D9Ec85E40f4cb69cafe` |
+| ERC780 | A registry claim holder contract (per [ERC780](https://github.com/ethereum/EIPs/issues/780)) | `0x62db7b9279d03518c54464b4946aade7cafabff066a90c55b054d5c5ee04c371` | 20 bytes value `0xcafecafe69a9FD93d5F28D9Ec85E40f4cb69cafe` |
+
+##### ERC725Account
+
+An ERC725Account is an ERC725 smart contract based account for storing of assets and execution of other smart contracts.
+
+- `ERC173` to be controllable by an owner, that could be am external account, or smart contract
+- `ERC725X` to interact with other smart contracts
+- `ERC725Y` to attach data to the account for future extensibility
+- COULD have `ERC1271` to be able to verify signatures from owners.
+- Should fire the `event ValueReceived(address indexed sender, uint256 indexed value)` if ETH is received.
+
+A full implementation of an `ERC725Account` can be found [found here](https://github.com/ERC725Alliance/ERC725/tree/master/implementations/contracts).
 
 ## Rationale
 
-The purpose of an identity proxy is to allow an entity to exist as a first-class citizen in Ethereum, with the ability to execute arbitrary contract calls. At that same time the proxy account should be managed by an arbitrary simple or complex logic.
-
-It also opens up the possibility of [meta transactions](https://medium.com/@austin_48503/ethereum-meta-transactions-90ccf0859e84), where a third party can send a transaction to the owner contract, that then verifies the execution permission based on a signed message.
-
-It further allows any information to be attached to that proxy accounts which can be in the forms of claims via [ERC735](https://github.com/ethereum/EIPs/issues/735) or [ERC780](https://github.com/ethereum/EIPs/issues/780), or any arbitrary new systems and protocols.
-
-This specification was chosen to allow the most flexibility and experimentation around verifiable manageable accounts.
-
+The purpose of an smart contract account is to allow an entity to exist as a first-class citizen with the ability to execute arbitrary contract calls.
 
 ## Implementation
 
-- [Implementation by ERC725Alliance](https://github.com/ERC725Alliance/erc725/tree/master/contracts/contracts)
+- [Latest implementation](https://github.com/ERC725Alliance/ERC725/tree/master/implementations/contracts)
 
 
-### Solidity Interface
-```js
-pragma solidity ^0.5.4;
+### Solidity Interfaces
+```solidity
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity >=0.5.0 <0.7.0;
 
-interface ERC725 {
-    event DataChanged(bytes32 indexed key, bytes32 indexed value);
-    event OwnerChanged(address indexed ownerAddress);
+interface IERC725X  /* is ERC165, ERC173 */ {
     event ContractCreated(address indexed contractAddress);
+    event Executed(uint256 indexed operation, address indexed to, uint256 indexed  value, bytes data);
 
-    // address public owner;
+    function execute(uint256 operationType, address to, uint256 value, bytes memory data) external;
+}
 
-    function changeOwner(address _owner) external;
-    function getData(bytes32 _key) external view returns (bytes32 _value);
-    function setData(bytes32 _key, bytes32 _value) external;
-    function execute(uint256 _operationType, address _to, uint256 _value, bytes calldata _data) external;
+interface IERC725Y /* is ERC165, ERC173 */ {
+    event DataChanged(bytes32 indexed key, bytes value);
+
+    function getData(bytes32 key) external view returns (bytes memory value);
+    function setData(bytes32 key, bytes memory value) external;
+}
+
+interface IERC725 /* is IERC725X, IERC725Y */ {
+
+}
+
+interface IERC725Account /* is IERC725, IERC725Y, IERC1271 */ {
+    event ValueReceived(address indexed sender, uint256 indexed value);
 }
 ```
+
+## Flow chart
+
+![ERC725v2-flow](https://user-images.githubusercontent.com/232662/57334038-996a8b00-70ec-11e9-9179-4dda3f30e09d.PNG)
 
 ## Additional References
 


### PR DESCRIPTION
This updates ERC725 to the latest version, which separates the standard into two sub standards: `ERC725X` and `ERC725Y`