### PR TITLE
2696: Adds an author

### DIFF
--- a/EIPS/eip-2696.md
+++ b/EIPS/eip-2696.md
@@ -1,7 +1,7 @@
 ---
 eip: 2696
 title: JavaScript `request` method RPC transport
-author: Micah Zoltu (@MicahZoltu)
+author: Micah Zoltu (@MicahZoltu), Erik Marks (@rekmarks)
 discussions-to: https://github.com/ethereum/EIPs/issues/2697
 status: Final
 type: Standards Track


### PR DESCRIPTION
Non-normative change to final EIP.  This EIP was extracted from 1193 and @remarks indicated that adding their name as author was acceptable.