### PR TITLE
Update eip-1155 errata.

### DIFF
--- a/EIPS/eip-1155.md
+++ b/EIPS/eip-1155.md
@@ -592,7 +592,7 @@ The `name` function (for human-readable asset names, on-chain) was removed from 
 
 ### Upgrades
 
-The requirement to emit `TransferSingle` or `TransferBatch` on balance change implies that a valid implementation of ERC-1155 redeploying to a new contract address MUST emit events from the new contract address to replicate the deprecated contract final state. It is valid to only emit a minimal number of events to reflect only the final balance and omit all the transactions that led to that state. The event emit requirement is to ensure that the current state of the contract can always be traced only through events. To alleviate the need to emit events when changing contract address, consider using the proxy pattern, such as described in ERC-1538. This will also have the added benefit of providing a stable contract address for users.
+The requirement to emit `TransferSingle` or `TransferBatch` on balance change implies that a valid implementation of ERC-1155 redeploying to a new contract address MUST emit events from the new contract address to replicate the deprecated contract final state. It is valid to only emit a minimal number of events to reflect only the final balance and omit all the transactions that led to that state. The event emit requirement is to ensure that the current state of the contract can always be traced only through events. To alleviate the need to emit events when changing contract address, consider using the proxy pattern, such as described in [EIP-2535](https://eips.ethereum.org/EIPS/eip-2535). This will also have the added benefit of providing a stable contract address for users.
 
 ### Design decision: Supporting non-batch
 


### PR DESCRIPTION
EIP-1155 is final but according to the eip process as defined in EIP-1 a final draft should be updated to correct errata.

EIP-1155 mentions EIP-1538 in the Upgrades section. But EIP-1538 has been abandoned and replaced with EIP-2535. This pull request replaces the mention of EIP-1538 with EIP-2535.

I am the author of both EIP-1538 and EIP-2535 and I have no problem with this.