### PR TITLE
Remove fancy formatting in metadata

### DIFF
--- a/_layouts/eip.html
+++ b/_layouts/eip.html
@@ -50,7 +50,7 @@ https://schema.org/Article
   {
     "@context": "http://schema.org",
     "@type": "Article",
-    "author": "{% include authorlist.html authors=page.author %}",
+    "author": "{{ page.author }}",
     "name": "EIP-{{ page.eip | xml_escape }}: {{ page.title | xml_escape }}{% if page.status == "Draft" or page.status == "Last Call" %} [DRAFT]{% endif %}",
     "dateCreated": "{{ page.created | date: "%Y-%m-%d" }}",
 {% if page["discussions-to"] != undefined %}


### PR DESCRIPTION
Test case:

https://search.google.com/structured-data/testing-tool/u/0/#url=https%3A%2F%2Feips.ethereum.org%2FEIPS%2Feip-721

https://search.google.com/test/rich-results?utm_campaign=sdtt&utm_medium=url&id=yOTWiA3q_VkILqYA5dvtFQ

---

Originally introduced here: https://github.com/ethereum/EIPs/pull/2796

I tested it on production and some pages are not getting parsed properly by Google because of invalid tags. This fixes it.