### PR TITLE
Fill in extra JSON-LD fields

### DIFF
--- a/_layouts/eip.html
+++ b/_layouts/eip.html
@@ -50,9 +50,11 @@ https://schema.org/TechArticle
   {
     "@context": "http://schema.org",
     "@type": "TechArticle",
+    "headline": "EIP-{{ page.eip | xml_escape }}: {{ page.title | xml_escape }}{% if page.status == "Draft" or page.status == "Last Call" %} [DRAFT]{% endif %}",
     "author": "{{ page.author }}",
     "name": "EIP-{{ page.eip | xml_escape }}: {{ page.title | xml_escape }}{% if page.status == "Draft" or page.status == "Last Call" %} [DRAFT]{% endif %}",
     "dateCreated": "{{ page.created | date: "%Y-%m-%d" }}",
+    "datePublished": "{{ page.created | date: "%Y-%m-%d" }}",
 {% if page["discussions-to"] != undefined %}
     "discussionUrl": "{{ page["discussions-to"] | uri_escape }}",
 {% endif %}    


### PR DESCRIPTION
This fills in extra JSON-LD fields, addressing Google errors raised here:

https://github.com/ethereum/EIPs/pull/2796#issuecomment-661912226

---

All this information is duplicative to other properties in the JSON-LD already. And I don't see that these fields are *required* by Schema.org. But the Google validator flagged them, so perhaps it is worth merging this.