### PR TITLE
Mark EIP-2159 Common Metrics as final

### DIFF
--- a/EIPS/eip-2159.md
+++ b/EIPS/eip-2159.md
@@ -3,8 +3,7 @@ eip: 2159
 title: Common Prometheus Metrics Names for Clients
 author: Adrian Sutton (@ajsutton)
 discussions-to: https://ethereum-magicians.org/t/common-chain-metrics/3415
-status: Last Call
-review-period-end: 2019-08-31
+status: Final
 type: Standards Track
 category: Interface
 created: 2019-07-01

--- a/EIPS/eip-2159.md
+++ b/EIPS/eip-2159.md
@@ -52,6 +52,8 @@ This is *not* a consensus affecting change.
 
 Clients may already be publishing these metrics using different names and changing to the new form may break existing alerts or dashboards. Clients that want to avoid this incompatibility can expose the metrics under both the old and new names.
 
+Clients may also be publishing metrics with a different meaning using these names. Backwards compatibility cannot be preserved in this case.
+
 
 ## Implementation
 <!--The implementations must be completed before any EIP is given status "Final", but it need not be completed before the EIP is accepted. While there is merit to the approach of reaching consensus on the specification and rationale before writing code, the principle of "rough consensus and running code" is still useful when it comes to resolving many discussions of API details.-->


### PR DESCRIPTION
Add a note to EIP-2159 about the potential for existing metrics with the same names but different meanings and move it to final.