### PR TITLE
2786: Add disconnect event to specification

### DIFF
--- a/EIPS/eip-2786.md
+++ b/EIPS/eip-2786.md
@@ -49,6 +49,22 @@ All attached listeners **MUST** be called with the parameter `{ chainId }`.
 If the Provider supports the `eth_chainId` JSON-RPC method or a derivation of it, then the `chainId` **MUST** match the return value of `eth_chainId`.
 The Provider **MAY** call the attached listeners in any order.
 
+#### `disconnect`
+
+The Provider **MUST** emit a `disconnect` event to all attached [EIP-2700](./eip-2700) listeners if it transitions from a `connected` state to a `disconnected` state.
+All attached listeners **MUST** be called with the parameter `error: DisconnectError`.
+`error` **MUST** adhere to the `ProviderError` interface (see below).
+`error.code` **MUST** be an integer `number`.
+`error.message` **MUST** be a human-readable `string`.
+The Provider **MAY** call the attached listeners in any order.
+
+````ts
+interface DisconnectError extends Error {
+  code: number,
+  message: string,
+  data?: unknown,
+}
+
 ## Rationale
 
 This EIP is mostly a retrospective EIP meaning it codifies an already existing specification so there isn’t a lot of room for improving things such as by having a connect/disconnect event per chain.
@@ -66,6 +82,11 @@ Copyright and related rights waived via [CC0](https://creativecommons.org/public
 ```javascript
 // connect
 provider.on('connect', ({ chainId }) => {
-  console.log(`Provider connected to: ${chainId}`);
+  console.log(`Provider became connected to: ${chainId}`);
 });
-```
+
+// disconnect
+provider.on('disconnect', ({ code, message, data }) => {
+  console.log(`Provider became disconnected due to: ${code}: ${message}`);
+});
+````

--- a/EIPS/eip-2786.md
+++ b/EIPS/eip-2786.md
@@ -96,5 +96,8 @@ provider.on('connect', ({ chainId }) => {
 // disconnect
 provider.on('disconnect', ({ code, message, data }) => {
   console.log(`Provider became disconnected due to: ${code}: ${message}`);
+  if (data) {
+    console.log(`Additional error data:`, data);
+  }
 });
 ```

--- a/EIPS/eip-2786.md
+++ b/EIPS/eip-2786.md
@@ -44,10 +44,17 @@ The Provider is considered `disconnected` when it is unable to service RPC reque
 #### `connect`
 
 The Provider **MUST** emit a `connect` event to all attached [EIP-2700](./eip-2700) listeners if it transitions from a `disconnected` state to a `connected` state.
-All attached listeners **MUST** be called with the parameter `{ chainId }`.
-`chainId` **MUST** specify the integer ID of the connected chain encoded as a hexadecimal string.
-If the Provider supports the `eth_chainId` JSON-RPC method or a derivation of it, then the `chainId` **MUST** match the return value of `eth_chainId`.
+All attached listeners **MUST** be called with the parameter `connectInfo: ConnectInfo`.
+`connectInfo` **MUST** adhere to the `ConnectInfo` interface (see below).
+`connectInfo.chainId` **MUST** specify the integer ID of the connected chain encoded as a hexadecimal string.
+If the Provider supports the `eth_chainId` JSON-RPC method or a derivation of it, then the `connectInfo.chainId` value **MUST** match the return value of `eth_chainId`.
 The Provider **MAY** call the attached listeners in any order.
+
+```typescript
+interface ConnectInfo {
+  readonly chainId: string;
+}
+```
 
 #### `disconnect`
 
@@ -58,12 +65,13 @@ All attached listeners **MUST** be called with the parameter `error: DisconnectE
 `error.message` **MUST** be a human-readable `string`.
 The Provider **MAY** call the attached listeners in any order.
 
-````ts
+```typescript
 interface DisconnectError extends Error {
-  code: number,
-  message: string,
-  data?: unknown,
+  readonly code: number;
+  readonly message: string;
+  readonly data?: unknown;
 }
+```
 
 ## Rationale
 
@@ -89,4 +97,4 @@ provider.on('connect', ({ chainId }) => {
 provider.on('disconnect', ({ code, message, data }) => {
   console.log(`Provider became disconnected due to: ${code}: ${message}`);
 });
-````
+```


### PR DESCRIPTION
- Add the `disconnect` event to the specification section of 2786.
- Add `ConnectInfo` interface for `connect` event listener parameter (for consistency with `DisconnectError` interface for `disconnect` event)
- Makes all interface properties `readonly`
- Cleans up some faulty formatting