### PR TITLE
Update eip-2848.md

### DIFF
--- a/EIPS/eip-2848.md
+++ b/EIPS/eip-2848.md
@@ -64,7 +64,7 @@ Because there can be security implications parsing data sent by users, clients *
 |:--------|:------------|
 | `to` | **MUST** be the same account signing the transaction. |
 | `value` |  **MUST** be `0` wei. |
-| `data` | **MUST** be at least `1` byte. The first byte **MUST** be operational code and following bytes **MUST** be based on the operational codes listed below. |
+| `data` | **MUST** be at least `2` bytes. The first byte **MUST** be operational code and following bytes **MUST** be based on the operational codes listed below. |
 
 #### List of supported operations and messages
 


### PR DESCRIPTION
Data actually can't be less then 2 bytes, so client should not read payload with a size of 1 byte.