### PR TITLE
Switch validator to eipv

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -15,14 +15,6 @@ elif [[ $TASK = 'htmlproofer-external' ]]; then
   bundle exec jekyll build
   bundle exec htmlproofer $HTMLPROOFER_OPTIONS --external_only
 elif [[ $TASK = 'eip-validator' ]]; then
-  BAD_FILES="$(ls EIPS | egrep -v "eip-[0-9]+.md|eip-20-token-standard.md")" || true
-  if [[ ! -z $BAD_FILES ]]; then
-    echo "Files found with invalid names:"
-    echo $BAD_FILES
-    exit 1
-  fi
-
-  FILES="$(ls EIPS/*.md | egrep "eip-[0-9]+.md")"
   eipv EIPS/ --ignore=title_max_length,missing_discussions_to --skip=eip-20-token-standard.md
 elif [[ $TASK = 'codespell' ]]; then
   codespell -q4 -I .codespell-whitelist eip-X.md EIPS/

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -23,7 +23,7 @@ elif [[ $TASK = 'eip-validator' ]]; then
   fi
 
   FILES="$(ls EIPS/*.md | egrep "eip-[0-9]+.md")"
-  bundle exec eip_validator $FILES
+  eipv EIPS/ --ignore=title_max_length,missing_discussions_to --skip=eip-20-token-standard.md
 elif [[ $TASK = 'codespell' ]]; then
   codespell -q4 -I .codespell-whitelist eip-X.md EIPS/
 fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 sudo: false # route your build to the container-based infrastructure for a faster build
 
-language: ruby
+language: ruby, rust
 
 before_install:
   - gem install bundler -v '< 2'
+  - cargo install eipv
      
 cache:
   # Cache Ruby bundles
@@ -27,7 +28,7 @@ matrix:
       env: TASK='htmlproofer'
     - rvm: 2.6.0
       env: TASK='htmlproofer-external'
-    - rvm: 2.6.0
+    - rust: 1.45.0
       env: TASK='eip-validator'
     - python: 3.3
       env: TASK='codespell'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ language: ruby, rust
 
 before_install:
   - gem install bundler -v '< 2'
-  - cargo install eipv
      
 cache:
   # Cache Ruby bundles

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
       env: TASK='htmlproofer-external'
     - language: rust
       before_script:
-        - cargo install eipv --version=0.0.3
+        - cargo install eipv --version=0.0.4
       env: TASK='eip-validator'
     - python: 3.3
       env: TASK='codespell'

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
       env: TASK='htmlproofer-external'
     - language: rust
       before_script:
-        - cargo install eipv
+        - cargo install eipv --version=0.0.3
       env: TASK='eip-validator'
     - python: 3.3
       env: TASK='codespell'

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ matrix:
     - rvm: 2.6.0
       env: TASK='htmlproofer-external'
     - language: rust
+      cache: cargo
       before_script:
         - cargo install eipv --version=0.0.4
       env: TASK='eip-validator'

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,9 @@ matrix:
       env: TASK='htmlproofer'
     - rvm: 2.6.0
       env: TASK='htmlproofer-external'
-    - rust: 1.45.0
+    - language: rust
+      before_script:
+        - cargo install eipv
       env: TASK='eip-validator'
     - python: 3.3
       env: TASK='codespell'

--- a/EIPS/eip-1.md
+++ b/EIPS/eip-1.md
@@ -4,7 +4,6 @@ title: EIP Purpose and Guidelines
 status: Active
 type: Meta
 author: Martin Becze <mb@ethereum.org>, Hudson Jameson <hudson@ethereum.org>, and others
-        https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1.md
 created: 2015-10-27
 updated: 2015-12-07, 2016-02-01, 2018-03-21, 2018-05-29, 2018-10-17, 2019-05-19, 2019-12-04, 2020-06-17
 ---

--- a/EIPS/eip-1057.md
+++ b/EIPS/eip-1057.md
@@ -1,7 +1,7 @@
 ---
 eip: 1057
 title: ProgPoW, a Programmatic Proof-of-Work
-author: Greg Colvin <greg@colvin.org>, Andrea Lanfranchi (@AndreaLanfranchi), Michael Carter (@bitsbetrippin),  IfDefElse <ifdefelse@protonmail.com>
+author: Greg Colvin <greg@colvin.org>, Andrea Lanfranchi (@AndreaLanfranchi), Michael Carter (@bitsbetrippin), IfDefElse <ifdefelse@protonmail.com>
 discussions-to: https://ethereum-magicians.org/t/eip-progpow-a-programmatic-proof-of-work/272
 status: Accepted
 type: Standards Track

--- a/EIPS/eip-1078.md
+++ b/EIPS/eip-1078.md
@@ -7,7 +7,7 @@ status: Draft
 type: Standards Track
 category: ERC
 created: 2018-05-04
-requires: 1077, 725, 681, 191
+requires: 191, 681, 725, 1077
 ---
 
 ## Abstract

--- a/EIPS/eip-1153.md
+++ b/EIPS/eip-1153.md
@@ -1,5 +1,5 @@
 ---
-eip: 1153 
+eip: 1153
 title: Transient storage opcodes
 author: Alexey Akhunov (@AlexeyAkhunov)
 discussions-to: https://ethereum-magicians.org/t/eip-transient-storage-opcodes/553

--- a/EIPS/eip-1186.md
+++ b/EIPS/eip-1186.md
@@ -1,6 +1,6 @@
 ---
 eip: 1186
-title: RPC-Method to get Merkle Proofs - eth_getProof 
+title: RPC-Method to get Merkle Proofs - eth_getProof
 author: Simon Jentzsch <simon.jentzsch@slock.it>, Christoph Jentzsch <christoph.jentzsch@slock.it>
 discussions-to: https://github.com/ethereum/EIPs/issues/1186
 status: Draft

--- a/EIPS/eip-1191.md
+++ b/EIPS/eip-1191.md
@@ -1,6 +1,6 @@
 ---
-eip: 1191 
-title: Add chain id to mixed-case checksum address encoding 
+eip: 1191
+title: Add chain id to mixed-case checksum address encoding
 author: Juliano Rizzo (@juli)
 status: Last Call
 review-period-end: 2019-11-18

--- a/EIPS/eip-1271.md
+++ b/EIPS/eip-1271.md
@@ -1,7 +1,7 @@
 ---
 eip: 1271
-title: Standard Signature Validation Method for Contracts 
-author:  Francisco Giordano (@frangio), Matt Condon (@shrugs), Philippe Castonguay (@PhABC), Amir Bandeali (@abandeali1), Jorge Izquierdo (@izqui), Bertrand Masius (@catageek)
+title: Standard Signature Validation Method for Contracts
+author: Francisco Giordano (@frangio), Matt Condon (@shrugs), Philippe Castonguay (@PhABC), Amir Bandeali (@abandeali1), Jorge Izquierdo (@izqui), Bertrand Masius (@catageek)
 discussions-to: https://github.com/ethereum/EIPs/issues/1271
 status: Draft
 type: Standards Track

--- a/EIPS/eip-1337.md
+++ b/EIPS/eip-1337.md
@@ -1,7 +1,7 @@
 ---
 eip: 1337
 title: Subscriptions on the blockchain
-author: Kevin Owocki <kevin@gitcoin.co> , Andrew Redden <andrew@blockcrushr.com>, Scott Burke <scott@blockcrushr.com> , Kevin Seagraves <k.s.seagraves@gmail.com> , Luka Kacil <luka.kacil@gmail.com>, Štefan Šimec <stefan.simec@gmail.com>, Piotr Kosiński (@kosecki123), ankit raj <tradeninja7@gmail.com>, John Griffin <john@atchai.com> , Nathan Creswell <nathantr@gmail.com>
+author: Kevin Owocki <kevin@gitcoin.co>, Andrew Redden <andrew@blockcrushr.com>, Scott Burke <scott@blockcrushr.com>, Kevin Seagraves <k.s.seagraves@gmail.com>, Luka Kacil <luka.kacil@gmail.com>, Štefan Šimec <stefan.simec@gmail.com>, Piotr Kosiński (@kosecki123), ankit raj <tradeninja7@gmail.com>, John Griffin <john@atchai.com>, Nathan Creswell <nathantr@gmail.com>
 discussions-to: https://ethereum-magicians.org/t/eip-1337-subscriptions-on-the-blockchain/4422
 type: Standards Track
 status: Draft

--- a/EIPS/eip-1355.md
+++ b/EIPS/eip-1355.md
@@ -1,7 +1,7 @@
 ---
 eip: 1355
 title: Ethash 1a
-author: Paweł Bylica (@chfast) <pawel@ethereum.org>, Jean M. Cyr (@jean-m-cyr)
+author: Paweł Bylica (@chfast), Jean M. Cyr (@jean-m-cyr)
 discussions-to: https://ethereum-magicians.org/t/eip-1355-ethash-1a/1167
 status: Abandoned
 type: Standards Track

--- a/EIPS/eip-1470.md
+++ b/EIPS/eip-1470.md
@@ -1,7 +1,7 @@
 ---
 eip: 1470
 title: Smart Contract Weakness Classification (SWC)
-author:  Gerhard Wagner (@thec00n)
+author: Gerhard Wagner (@thec00n)
 discussions-to: https://github.com/ethereum/EIPs/issues/1469
 status: Draft
 type: Informational

--- a/EIPS/eip-1485.md
+++ b/EIPS/eip-1485.md
@@ -1,7 +1,7 @@
 ---
 eip: 1485
 title: TEthashV1
-author: trustfarm KT Ahn - 안씨아저씨 <trustfarm.info@gmail.com>, trustfarm <cpplover@trustfarm.net>
+author: trustfarm <trustfarm.info@gmail.com>, trustfarm <cpplover@trustfarm.net>
 discussions-to: https://ethereum-magicians.org/t/anti-eth-asic-mining-eip-1488-pr/1807
 status: Draft
 type: Standards Track

--- a/EIPS/eip-1485.md
+++ b/EIPS/eip-1485.md
@@ -1,7 +1,7 @@
 ---
 eip: 1485
 title: TEthashV1
-author: trustfarm (KT Ahn - 안씨아저씨) <trustfarm.info@gmail.com>, trustfarm <cpplover@trustfarm.net>
+author: trustfarm KT Ahn - 안씨아저씨 <trustfarm.info@gmail.com>, trustfarm <cpplover@trustfarm.net>
 discussions-to: https://ethereum-magicians.org/t/anti-eth-asic-mining-eip-1488-pr/1807
 status: Draft
 type: Standards Track

--- a/EIPS/eip-1571.md
+++ b/EIPS/eip-1571.md
@@ -1,7 +1,7 @@
 ---
 eip: 1571
 title: EthereumStratum/2.0.0
-author: Andrea Lanfranchi (@AndreaLanfranchi) <andrea.lanfranchi@gmail.com>, Pawel Bylica (@chfast) <pawel@ethereum.org>, Marius Van Der Wijden (@MariusVanDerWijden)
+author: Andrea Lanfranchi (@AndreaLanfranchi), Pawel Bylica (@chfast), Marius Van Der Wijden (@MariusVanDerWijden)
 discussions-to: https://github.com/AndreaLanfranchi/EthereumStratum-2.0.0/issues
 status: Draft
 type: Standards Track

--- a/EIPS/eip-1613.md
+++ b/EIPS/eip-1613.md
@@ -1,5 +1,5 @@
 ---
-eip:  1613
+eip: 1613
 title: Gas stations network
 author: Yoav Weiss <yoav@tabookey.com>, Dror Tirosh <dror@tabookey.com>, Alex Forshtat <alex@tabookey.com>
 discussions-to: https://github.com/yoav-tabookey/EIPs/issues/1

--- a/EIPS/eip-1620.md
+++ b/EIPS/eip-1620.md
@@ -1,7 +1,7 @@
 ---
 eip: 1620
 title: ERC-1620 Money Streaming
-author: Paul Berg (@PaulRBerg) <hello@paulrberg.com>
+author: Paul Berg (@PaulRBerg)
 discussions-to: https://github.com/ethereum/EIPs/issues/1620
 status: Draft
 type: Standards Track

--- a/EIPS/eip-1679.md
+++ b/EIPS/eip-1679.md
@@ -1,12 +1,12 @@
 ---
 eip: 1679
-title: "Hardfork Meta: Istanbul"
+title: Hardfork Meta: Istanbul
 author: Alex Beregszaszi (@axic), Afri Schoedon (@5chdn)
 discussions-to: https://ethereum-magicians.org/t/hardfork-meta-istanbul-discussion/3207
 type: Meta
 status: Final
 created: 2019-01-04
-requires: 1716, 152, 1108, 1344, 1884, 2028, 2200
+requires: 152, 1108, 1334, 1716, 1884, 2028, 2200
 ---
 
 ## Abstract

--- a/EIPS/eip-1884.md
+++ b/EIPS/eip-1884.md
@@ -1,6 +1,6 @@
 ---
 eip: 1884
-title: Repricing for trie-size-dependent opcodes 
+title: Repricing for trie-size-dependent opcodes
 author: Martin Holst Swende (@holiman)
 type: Standards Track
 category: Core

--- a/EIPS/eip-1895.md
+++ b/EIPS/eip-1895.md
@@ -6,7 +6,7 @@ discussions-to: https://ethresear.ch/t/reducing-the-verification-cost-of-a-snark
 status: Draft
 type: Standards Track
 category: Core
-created: 2018-31-03
+created: 2018-03-31
 ---
 
 ## Simple Summary

--- a/EIPS/eip-196.md
+++ b/EIPS/eip-196.md
@@ -1,7 +1,6 @@
 ---
 eip: 196
-title: Precompiled contracts for addition and scalar multiplication
-       on the elliptic curve alt_bn128
+title: Precompiled contracts for addition and scalar multiplication on the elliptic curve alt_bn128
 author: Christian Reitwiessner<chris@ethereum.org>
 type: Standards Track
 category: Core

--- a/EIPS/eip-197.md
+++ b/EIPS/eip-197.md
@@ -1,7 +1,6 @@
 ---
 eip: 197
-title: Precompiled contracts for optimal ate pairing check
-       on the elliptic curve alt_bn128
+title: Precompiled contracts for optimal ate pairing check on the elliptic curve alt_bn128
 author: Vitalik Buterin <vitalik@ethereum.org>, Christian Reitwiessner <chris@ethereum.org>
 type: Standards Track
 category: Core

--- a/EIPS/eip-1973.md
+++ b/EIPS/eip-1973.md
@@ -1,6 +1,6 @@
 ---
-eip: 1973 
-title: Scalable Rewards 
+eip: 1973
+title: Scalable Rewards
 author: Lee Raj (@lerajk), Qin Jian (@qinjian)
 type: Standards Track
 category: ERC

--- a/EIPS/eip-2009.md
+++ b/EIPS/eip-2009.md
@@ -1,6 +1,6 @@
 ---
 eip: 2009
-title: Compliance Service 
+title: Compliance Service
 author: Daniel Lehrner <daniel@io.builders>
 discussions-to: https://github.com/ethereum/EIPs/issues/2022
 status: Draft

--- a/EIPS/eip-214.md
+++ b/EIPS/eip-214.md
@@ -1,7 +1,7 @@
 ---
 eip: 214
 title: New opcode STATICCALL
-author: Vitalik Buterin <vitalik@ethereum.org>, Christian Reitwiessner <chris@ethereum.org>;
+author: Vitalik Buterin <vitalik@ethereum.org>, Christian Reitwiessner <chris@ethereum.org>
 type: Standards Track
 category: Core
 status: Final

--- a/EIPS/eip-2193.md
+++ b/EIPS/eip-2193.md
@@ -7,7 +7,7 @@ status: Draft
 type: Standards Track
 category: ERC
 created: 2019-07-16
-requires: 1900, 2157, 155
+requires: 155, 1900, 2157
 ---
 
 ## Simple Summary

--- a/EIPS/eip-2378.md
+++ b/EIPS/eip-2378.md
@@ -6,7 +6,6 @@ discussions-to: https://gitter.im/ethereum/EIPs
 status: Draft
 type: Meta
 created: 2019-11-13
-
 ---
 
 <!--You can leave these HTML comments in your merged EIP and delete the visible duplicate text guides, they will not appear and may be helpful to refer to if you edit it again. This is the suggested template for new EIPs. Note that an EIP number will be assigned by an editor. When opening a pull request to submit your EIP, please use an abbreviated title in the filename, `eip-draft_title_abbrev.md`. The title should be 44 characters or less.-->

--- a/EIPS/eip-2458.md
+++ b/EIPS/eip-2458.md
@@ -1,7 +1,7 @@
 ---
 eip: 2458
 title: Updates and Updated-by Header
-author: Edson Ayllon (@edsonayllon) 
+author: Edson Ayllon (@edsonayllon)
 discussions-to: https://github.com/ethereum/EIPs/issues/2453
 status: Draft
 type: Informational

--- a/EIPS/eip-2470.md
+++ b/EIPS/eip-2470.md
@@ -6,7 +6,7 @@ discussions-to: https://ethereum-magicians.org/t/erc-2470-singleton-factory/3933
 status: Draft
 type: Standards Track
 category: ERC
-created: 15-01-2020
+created: 2020-01-15
 requires: 1014
 ---
 

--- a/EIPS/eip-2477.md
+++ b/EIPS/eip-2477.md
@@ -7,7 +7,7 @@ type: Standards Track
 category: ERC
 status: Draft
 created: 2020-01-02
-requires: 721, 1155, 165
+requires: 165, 721, 1155
 ---
 
 ## Simple Summary

--- a/EIPS/eip-2525.md
+++ b/EIPS/eip-2525.md
@@ -6,7 +6,7 @@ discussions-to: https://ethereum-magicians.org/t/discussion-ens-login/3569
 status: Draft
 type: Standards Track
 category: ERC
-created: 19/02/2020
+created: 2020-02-19
 requires: 137, 634, 1193, 2304
 ---
 

--- a/EIPS/eip-2657.md
+++ b/EIPS/eip-2657.md
@@ -2,7 +2,7 @@
 eip: 2657
 title: Ephemeral Testnet Yolo
 author: James Hancock (@madeoftin)
-discussion-to: https://gitter.im/ethereum/AllCoreDevs
+discussions-to: https://gitter.im/ethereum/AllCoreDevs
 status: Draft
 type: Meta
 created: 2020-04-19

--- a/EIPS/eip-2746.md
+++ b/EIPS/eip-2746.md
@@ -5,7 +5,7 @@ author: Aaron Kendall (@jaerith), Juan Blanco <@juanfranblanco>
 discussions-to: https://ethereum-magicians.org/t/eip-2746-rules-engine-interface/4435
 status: Draft
 type: Standards Track
-category : ERC
+category: ERC
 created: 2020-06-20
 ---
 

--- a/EIPS/eip-2767.md
+++ b/EIPS/eip-2767.md
@@ -7,7 +7,7 @@ status: Draft
 type: Standards Track
 category: ERC
 created: 2020-07-04
-requires: 173, 165, 191
+requires: 165, 173, 191
 ---
 
 ## Simple Summary

--- a/EIPS/eip-2771.md
+++ b/EIPS/eip-2771.md
@@ -1,7 +1,7 @@
 ---
 eip: 2771
 title: Secure Protocol for Native Meta Transactions
-author: Ronan Sandford (@wighawag), Liraz Siri (@lirazsiri),  Dror Tirosh (@drortirosh), Yoav Weiss (@yoavw), Alex Forshtat (@forshtat), Hadrien Croubois (@Amxx), Tomar Sachin (@tomarsachin2271), Patrick McCorry (@stonecoldpat), Nicolas Venturo (@nventuro), Fabian Vogelsteller (@frozeman) 
+author: Ronan Sandford (@wighawag), Liraz Siri (@lirazsiri), Dror Tirosh (@drortirosh), Yoav Weiss (@yoavw), Alex Forshtat (@forshtat), Hadrien Croubois (@Amxx), Tomar Sachin (@tomarsachin2271), Patrick McCorry (@stonecoldpat), Nicolas Venturo (@nventuro), Fabian Vogelsteller (@frozeman)
 discussions-to: https://ethereum-magicians.org/t/eip-2771-secure-protocol-for-native-meta-transactions
 status: Draft
 type: Standards Track

--- a/EIPS/eip-601.md
+++ b/EIPS/eip-601.md
@@ -3,7 +3,7 @@ eip: 601
 title: Ethereum hierarchy for deterministic wallets
 author: Nick Johnson (@arachnid), Micah Zoltu (@micahzoltu)
 type: Standards Track
-category : ERC
+category: ERC
 status: Final
 discussions-to: https://ethereum-magicians.org/t/eip-erc-app-keys-application-specific-wallet-accounts/2742
 created: 2017-04-13

--- a/EIPS/eip-615.md
+++ b/EIPS/eip-615.md
@@ -4,7 +4,7 @@ title: Subroutines and Static Jumps for the EVM
 status: Draft
 type: Standards Track
 category: Core
-author: Greg Colvin <greg@colvin.org>, Brooklyn Zelenka (@expede) , Paweł Bylica (@chfast), Christian Reitwiessner(@chriseth)
+author: Greg Colvin <greg@colvin.org>, Brooklyn Zelenka (@expede), Paweł Bylica (@chfast), Christian Reitwiessner(@chriseth)
 discussions-to: https://ethereum-magicians.org/t/eip-615-subroutines-and-static-jumps-for-the-evm-last-call/3472
 created: 2016-12-10
 ---

--- a/EIPS/eip-634.md
+++ b/EIPS/eip-634.md
@@ -1,6 +1,6 @@
 ---
 eip: 634
-title: Storage of text records in ENS 
+title: Storage of text records in ENS
 author: Richard Moore (@ricmoo)
 type: Standards Track
 discussions-to: https://github.com/ethereum/EIPs/issues/2439

--- a/EIPS/eip-698.md
+++ b/EIPS/eip-698.md
@@ -6,7 +6,7 @@ discussions-to: https://github.com/ethereum/EIPs/issues/698
 status: Draft
 type: Standards Track
 category: Core
-created: 2017-28-08
+created: 2017-08-28
 ---
 
 ## Simple Summary

--- a/EIPS/eip-712.md
+++ b/EIPS/eip-712.md
@@ -1,9 +1,7 @@
 ---
 eip: 712
 title: Ethereum typed structured data hashing and signing
-author: Remco Bloemen <remco@wicked.ventures>,
-        Leonid Logvinov <logvinov.leon@gmail.com>,
-        Jacob Evans <jacob@dekz.net>
+author: Remco Bloemen <remco@wicked.ventures>, Leonid Logvinov <logvinov.leon@gmail.com>, Jacob Evans <jacob@dekz.net>
 discussions-to: https://ethereum-magicians.org/t/eip-712-eth-signtypeddata-as-a-standard-for-machine-verifiable-and-human-readable-typed-data-signing/397
 status: Draft
 type: Standards Track

--- a/EIPS/eip-884.md
+++ b/EIPS/eip-884.md
@@ -1,7 +1,7 @@
 ---
 eip: 884
-title: 'DGCL Token'
-author: 'Dave Sag <davesag@gmail.com>'
+title: DGCL Token
+author: Dave Sag <davesag@gmail.com>
 type: Standards Track
 category: ERC
 status: Draft

--- a/EIPS/eip-998.md
+++ b/EIPS/eip-998.md
@@ -7,7 +7,7 @@ type: Standards Track
 category: ERC
 status: Draft
 created: 2018-07-07
-requires: 721, 165
+requires: 165, 721
 ---
 
 ## Simple Summary


### PR DESCRIPTION
As discussed in the [EIPIP](https://github.com/ethereum-cat-herders/EIPIP/issues/25) meetings, I've been working on a new validator called [`eipv`](https://github.com/lightclient/eipv). It isn't feature complete yet, but it should be comparable to the existing validator.