### PR TITLE
Fix eip-1679 rendering

### DIFF
--- a/EIPS/eip-1679.md
+++ b/EIPS/eip-1679.md
@@ -1,6 +1,6 @@
 ---
 eip: 1679
-title: Hardfork Meta: Istanbul
+title: "Hardfork Meta: Istanbul"
 author: Alex Beregszaszi (@axic), Afri Schoedon (@5chdn)
 discussions-to: https://ethereum-magicians.org/t/hardfork-meta-istanbul-discussion/3207
 type: Meta

--- a/EIPS/eip-1679.md
+++ b/EIPS/eip-1679.md
@@ -6,7 +6,7 @@ discussions-to: https://ethereum-magicians.org/t/hardfork-meta-istanbul-discussi
 type: Meta
 status: Final
 created: 2019-01-04
-requires: 152, 1108, 1334, 1716, 1884, 2028, 2200
+requires: 152, 1108, 1344, 1716, 1884, 2028, 2200
 ---
 
 ## Abstract


### PR DESCRIPTION
The HTML generator is having trouble with the double colon in the title line of EIP-1679. I removed the quotes when adding the new validator, and for some reason the HTML generator raised it as a warning rather than an error. I've logged [this issue](https://github.com/lightclient/eipv/issues/6) with `eipv`, but we should go ahead and fix this ASAP. 