### PR TITLE
Move 2718 to EFI

### DIFF
--- a/EIPS/eip-2378.md
+++ b/EIPS/eip-2378.md
@@ -51,6 +51,7 @@ Development of clear specifications and pull requests to existing Ethereum Clien
 | EIP-2046 | Reduced gas cost for static calls made to precompiles | ELIGIBLE | 2019-11-01 | [🔗](https://github.com/ethereum/pm/blob/master/All%20Core%20Devs%20Meetings/Meeting%2074.md) |
 | EIP-2315 | Simple Subroutines for the EVM                        | ELIGIBLE | 2020-02-21 | [🔗](https://github.com/ethereum/pm/blob/master/All%20Core%20Devs%20Meetings/Meeting%2081.md#decisions) |
 | EIP-2537 | Precompile for BLS12-381 curve operations             | ELIGIBLE | 2020-03-06 | [🔗](https://github.com/ethereum/pm/blob/master/All%20Core%20Devs%20Meetings/Meeting%2082.md) |
+| EIP-2718 | Typed Transaction Envelope                            | ELIGIBLE | 2020-07-24 | [🔗](https://github.com/ethereum/pm/blob/master/All%20Core%20Devs%20Meetings/Meeting%2092.md#22-eip-2718) |
 
 ## Rationale
 


### PR DESCRIPTION
This was decision was made unopposed in [ACD 92](https://github.com/ethereum/pm/blob/master/All%20Core%20Devs%20Meetings/Meeting%2092.md#22-eip-2718).