### PR TITLE
eip-1559: fix comparison error in abstract.

### DIFF
--- a/EIPS/eip-1559.md
+++ b/EIPS/eip-1559.md
@@ -13,7 +13,7 @@ created: 2019-04-13
 A transaction pricing mechanism that includes fixed-per-block network fee that is burned and dynamically expands/contracts block sizes to deal with transient congestion.
 
 ## Abstract
-There is a base fee per gas in protocol, which can move up or down by a maximum of 1/8 in each block. The base fee per gas is adjusted by the protocol to target an average gas usage per block instead of an absolute gas usage per block.  The base fee is increased when blocks are under the gas limit target and decreases when blocks are over the gas limit target. The base fee per gas is burned. Transaction senders specify their fees by providing two values:
+There is a base fee per gas in protocol, which can move up or down by a maximum of 1/8 in each block. The base fee per gas is adjusted by the protocol to target an average gas usage per block instead of an absolute gas usage per block.  The base fee is increased when blocks are over the gas limit target and decreases when blocks are under the gas limit target. The base fee per gas is burned. Transaction senders specify their fees by providing two values:
 
 * A gas premium which gets added onto the base fee to calculate the gas price. The gas premium can either be set to a fairly low value (eg. 1 gwei) to compensate miners for uncle rate risk or to a high value to compete during sudden bursts of activity. The gas premium is given to the miner.
 


### PR DESCRIPTION
I may be getting this entirely wrong, but it seems like the abstract flips around the compensatory actions when blocks are under/over the target gas limit?