### PR TITLE
Bump eipv to v0.0.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
     - language: rust
       cache: cargo
       before_script:
-        - cargo install eipv --version=0.0.4
+        - cargo install eipv --version=0.0.5
       env: TASK='eip-validator'
     - python: 3.3
       env: TASK='codespell'


### PR DESCRIPTION
The validator was not correctly checking email addresses. This has been fixed in `eipv v0.0.5`: https://github.com/lightclient/eipv/pull/8