### PR TITLE
Fix ambiguity in syncing definition for eth_syncing (EIP-1474)

### DIFF
--- a/EIPS/eip-1474.md
+++ b/EIPS/eip-1474.md
@@ -2147,7 +2147,7 @@ _(none)_
 
 ##### Returns
 
-{`boolean|object`} - `false` if this client is not syncing with the network, otherwise an object with the following members:
+{`boolean|object`} - `false` if `currentBlock` is equal to `highestBlock` (as defined below), otherwise an object with the following members:
 
 - {[`Quantity`](#quantity)} `currentBlock` - number of the most-recent block synced
 - {[`Quantity`](#quantity)} `highestBlock` - number of latest block on the network


### PR DESCRIPTION
Previously we only said `eth_syncing` should return `false if this client is not syncing with the network`, but we didn't define what syncing meant. I have taken the liberty to define `not syncing` to mean `currentBlock == highestBlock`.
Note: client implementations seem to diverge from each other over the interpretation of what `syncing` means. With the change that is proposed here, clients would be continuously switching b/w syncing and not-syncing, because there will always be a newer block in the network. 