### PR TITLE
Include last call review-end-date in the rendered summary

### DIFF
--- a/_includes/eiptable.html
+++ b/_includes/eiptable.html
@@ -14,11 +14,19 @@
     <h2 id="{{status|slugify}}">{{status}}</h2>
     <table class="eiptable">
       <thead>
-        <tr><th class="eipnum">Number</th><th class="title">Title</th><th class="author">Author</th></tr>
+        {% if status == "Last Call" %}
+          <tr>
+          <th class="eipnum">Number</th><th class="date">Review ends</th><th class="title">Title</th><th class="author">Author</th></tr>
+        {% else %}
+          <tr><th class="eipnum">Number</th><th class="title">Title</th><th class="author">Author</th></tr>
+        {% endif %}
       </thead>
       {% for page in eips %}
         <tr>
           <td class="eipnum"><a href="{{page.url|relative_url}}">{{page.eip|xml_escape}}</a></td>
+          {% if status == "Last Call" and page.review-period-end != undefined %}
+            <td class="date">{{ page.review-period-end | xml_escape }}</td>
+          {% endif %}
           <td class="title">{{page.title|xml_escape}}</td>
           <td class="author">{% include authorlist.html authors=page.author %}</td>
         </tr>

--- a/_layouts/eip.html
+++ b/_layouts/eip.html
@@ -14,7 +14,7 @@ layout: default
     {% endif %}
     <tr><th>Status</th><td>{{ page.status | xml_escape }}
     {% if page.review-period-end != undefined %}
-      <strong>(review ends {{ page.review-period-end | xml_escape }})</strong>
+      <tr><th>Review period ends</th><td>{{ page.review-period-end | xml_escape }}</td></tr>
     {% endif %}
     </td></tr>
     <tr><th>Type</th><td>{{ page.type | xml_escape }}</td></tr>


### PR DESCRIPTION
Fixes #1147.

Before:
![Screenshot 2020-08-28 at 23 26 30](https://user-images.githubusercontent.com/20340/91619762-e9c2c780-e985-11ea-94d0-31b268bcd707.png)

After:
![Screenshot 2020-08-28 at 23 26 57](https://user-images.githubusercontent.com/20340/91619783-f8a97a00-e985-11ea-91d2-f4ab67d4cff4.png)

---

And changes the EIP page render as well, though that commit can be removed.

Before:
![Screenshot 2020-08-28 at 23 27 57](https://user-images.githubusercontent.com/20340/91619823-1d9ded00-e986-11ea-8eda-a896c66e7077.png)

After:
![Screenshot 2020-08-28 at 23 28 37](https://user-images.githubusercontent.com/20340/91619852-34444400-e986-11ea-84aa-4f0df8f68c73.png)
