### PR TITLE
Remove social media links from the page (but keep Github)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,13 +19,7 @@ description: >-
   platform, including core protocol specifications, client APIs, and contract
   standards.
 url: "https://eips.ethereum.org"
-twitter_username: ethereum
 github_username:  ethereum
-youtube_username: channel/UCNOfzGXD_C9YMYmnefmPH0g
-
-twitter:
-  card: summary
-  username: ethereum
 
 header_pages:
  - all.html

--- a/_config.yml
+++ b/_config.yml
@@ -21,6 +21,12 @@ description: >-
 url: "https://eips.ethereum.org"
 twitter_username: ethereum
 github_username:  ethereum
+youtube_username: channel/UCNOfzGXD_C9YMYmnefmPH0g
+
+twitter:
+  card: summary
+  username: ethereum
+
 header_pages:
  - all.html
  - core.html
@@ -29,9 +35,6 @@ header_pages:
  - erc.html
  - meta.html
  - informational.html
-twitter:
-  card: summary
-  username: ethereum
 
 # Build settings
 highlighter: rouge


### PR DESCRIPTION
Not sure whether it is useful. The Youtube channel has ACD, Eth2.0 calls, Eth1.x calls, which have relevance here.