### PR TITLE
Update html title to be EIP-N

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,7 +3,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   {% if page.layout == "eip" %}
-    <title>EIP {{ page.eip }}: {{ page.title | escape }}</title>
+    <title>EIP-{{ page.eip }}: {{ page.title | escape }}</title>
     <meta property="og:title" content="EIP {{ page.eip }}: {{ page.title | escape }}" />
     <meta
       name="description"

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,16 +4,16 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   {% if page.layout == "eip" %}
     <title>EIP-{{ page.eip }}: {{ page.title | escape }}</title>
-    <meta property="og:title" content="EIP {{ page.eip }}: {{ page.title | escape }}" />
+    <meta property="og:title" content="EIP-{{ page.eip }}: {{ page.title | escape }}" />
     <meta
       name="description"
-      content="Details on Ethereum Improvement Proposal {{page.eip}} (EIP {{page.eip}}): {{page.title | escape}}"
+      content="Details on Ethereum Improvement Proposal {{page.eip}} (EIP-{{page.eip}}): {{page.title | escape}}"
     />
     <meta
       property="og:description"
-      content="Details on Ethereum Improvement Proposal {{page.eip}} (EIP {{page.eip}}): {{page.title | escape}}"
+      content="Details on Ethereum Improvement Proposal {{page.eip}} (EIP-{{page.eip}}): {{page.title | escape}}"
     />
-    <meta name="twitter:description" content="Details on Ethereum Improvement Proposal {{page.eip}} (EIP {{page.eip}}): {{page.title | escape}}" />
+    <meta name="twitter:description" content="Details on Ethereum Improvement Proposal {{page.eip}} (EIP-{{page.eip}}): {{page.title | escape}}" />
   {% else %}
   <title>{{ page.title | escape }} | {{site.title}}</title>
     <meta


### PR DESCRIPTION
Title before: `EIP 1: EIP Purpose and Guidelines`
Title after: `EIP-1: EIP Purpose and Guidelines`

Reflects the style guide in EIP-1:

> When referring to an EIP by number, it should be written in the hyphenated form EIP-X where X is the EIP’s assigned number.

