### PR TITLE
Changes 1559 to have a single shared pool for all transactions.

### DIFF
--- a/EIPS/eip-1559.md
+++ b/EIPS/eip-1559.md
@@ -119,7 +119,7 @@ class World(ABC):
 			expected_base_fee = parent_base_fee + fee_delta
 		else:
 			gas_delta = parent_gas_target - parent_gas_used
-			fee_delta = parent_base_fee * gas_delta // parent_gas_used // BASE_FEE_MAX_CHANGE_DENOMINATOR
+			fee_delta = parent_base_fee * gas_delta // parent_gas_target // BASE_FEE_MAX_CHANGE_DENOMINATOR
 			expected_base_fee = parent_base_fee - fee_delta
 		assert expected_base_fee == block.base_fee, 'invalid block: base fee not correct'
 

--- a/EIPS/eip-1559.md
+++ b/EIPS/eip-1559.md
@@ -16,7 +16,8 @@ A transaction pricing mechanism that includes fixed-per-block network fee that i
 There is a base fee per gas in protocol, which can move up or down each block according to a formula which is a function of gas used in parent block and gas target (formerly known as gas limit) of parent block.
 The algorithm results in the base fee per gas increasing when blocks are above the gas target, and decreasing when blocks are below the gas target.
 The base fee per gas is burned.
-Transactions specify both the maximum network fee per gas (aka: base fee) they are willing to pay, as well as the maximum fee per gas they are willing to give to miners to incentivize them to include their transaction (aka: miner bribe).
+Transactions specify the maximum fee per gas they are willing to give to miners to incentivize them to include their transaction (aka: miner bribe).
+Transactions also specify the maximum fee per gas they are willing to pay total (aka: fee cap), which covers both the miner bribe and the block's network fee per gas (aka: base fee).
 The transaction will always pay the base fee per gas of the block it was included in, and they will pay the bribe per gas set in the transaction, as long as the combined amount of the two fees doesn't exceed the transaction's maximum fee per gas.
 
 ## Motivation

--- a/EIPS/eip-1559.md
+++ b/EIPS/eip-1559.md
@@ -19,12 +19,8 @@ The base fee per gas is burned.
 Transactions specify both the maximum network fee per gas (aka: base fee) they are willing to pay, as well as the maximum fee per gas they are willing to give to miners to incentivize them to include their transaction (aka: miner bribe).
 The transaction will always pay the base fee per gas of the block it was included in, and they will pay the bribe per gas set in the transaction, as long as the combined amount of the two fees doesn't exceed the transaction's maximum fee per gas.
 
-This specification also includes a mechanism for migrating from the current transaction/block fee system to the new one.
-Initially, half of a block can be legacy transactions, and half of a block can be new transactions.
-Over time, the percentage of the block that can contain legacy transactions decreases, as more room for new transactions is made.
-
 ## Motivation
-Ethereum currently prices transaction fees using a simple auction mechanism, where users send transactions with bids ("gasprices") and miners choose transactions with the highest bids, and transactions that get included pay the bid that they specify. This leads to several large sources of inefficiency:
+Ethereum historically priced transaction fees using a simple auction mechanism, where users send transactions with bids ("gasprices") and miners choose transactions with the highest bids, and transactions that get included pay the bid that they specify. This leads to several large sources of inefficiency:
 
 * **Mismatch between volatility of transaction fee levels and social cost of transactions**: bids to include transactions on mature public blockchains, that have enough usage so that blocks are full, tend to be extremely volatile. On Ethereum, minimum bids range between 1 nanoeth (10^9 nanoeth = 1 ETH), but sometimes go over 100 nanoeth and have reached over 200 nanoeth. This clearly creates many inefficiencies, because it's absurd to suggest that the cost incurred by the network from accepting one more transaction into a block actually is 200x more when gas prices are 200 nanoeth than when they are 1 nanoeth; in both cases, it's a difference between 8 million gas and 8.02 million gas.
 * **Needless delays for users**: because of the hard per-block gas limit coupled with natural volatility in transaction volume, transactions often wait for several blocks before getting included, but this is socially unproductive; no one significantly gains from the fact that there is no "slack" mechanism that allows one block to be bigger and the next block to be smaller to meet block-by-block differences in demand.
@@ -34,8 +30,6 @@ Ethereum currently prices transaction fees using a simple auction mechanism, whe
 The proposal in this EIP is to start with a base fee amount which is adjusted up and down by the protocol based on how congested the network is. When the network exceeds the target per-block gas usage, the base fee increases slightly and when capacity is below the target, it decreases slightly. Because these base fee changes are constrained, the maximum difference in base fee from block to block is predictable. This then allows wallets to auto-set the gas fees for users in a highly reliable fashion. It is expected that most users will not have to manually adjust gas fees, even in periods of high network activity. For most users the base fee will be estimated by their wallet and a small miner bribe, which compensates miners taking on orphan risk (e.g. 1 nanoeth), will be automatically set. Users can also manually set the transaction fee cap to bound their total costs.
 
 An important aspect of this fee system is that miners only get to keep the miner bribe. The base fee is always burned (i.e. it is destroyed by the protocol). Burning this is important because it removes miner incentive to manipulate the fee in order to extract more fees from users. It also ensures that only ETH can ever be used to pay for transactions on Ethereum, cementing the economic value of ETH within the Ethereum platform. Additionally, this burn counterbalances Ethereum inflation without greatly diminishing miner rewards.
-
-The transition to this gas price system will occur in two phases, in the first phase both legacy and EIP1559 transactions will be accepted by the protocol. Over the course of this first phase the amount of gas available for processing legacy transactions will decrease while the amount of gas available for processing EIP1559 transactions will increase, moving gas from the legacy pool into the EIP1559 pool until the legacy pool is depleted and the EIP1559 pool contains the entire gas maximum. After all of the gas has transitioned to the EIP1559 pool, the second, finalized, phase is entered and legacy transactions will no longer be accepted on the network.
 
 ## Specification
 *Note: `//` is integer division, round down.*
@@ -198,8 +192,7 @@ class World(ABC):
 ```
 
 ## Backwards Compatibility
-We split the EIP1559 upgrade into two phases with a transition period during which both legacy and EIP1559 transaction can be accepted so that compatibility with wallets and other ETH-adjacent software is maintained while their maintainers have time to upgrade to using the new transaction type. During this transition period legacy transactions are accepted and processed identically to the current implementation, with the only difference being that the amount of gas (gas limit) dedicated to processing legacy transactions is calculated as above and decreases over this period.
-
+Legacy Ethereum transactions will still work and be included in blocks, but they will not benefit directly from the new pricing system.  This is due to the fact that upgrading from legacy transactions to new transactions results in the legacy transaction's `gas_price ` entirely being consumed either by the `base_fee` or the `miner_bribe`.
 
 ## Test Cases
 

--- a/EIPS/eip-1559.md
+++ b/EIPS/eip-1559.md
@@ -43,6 +43,7 @@ class TransactionLegacy:
 	account_nonce: int = 0
 	gas_price: int = 0
 	gas_limit: int = 0
+	destination: int = 0
 	amount: int = 0
 	payload: bytes = bytes()
 	v: int = 0
@@ -53,9 +54,10 @@ class TransactionLegacy:
 class Transaction1559:
 	account_nonce: int = 0
 	gas_limit: int = 0
+	destination: int = 0
 	amount: int = 0
 	payload: bytes = bytes()
-	max_max_miner_bribe_per_gas: int = 0
+	max_miner_bribe_per_gas: int = 0
 	fee_cap_per_gas: int = 0
 	v: int = 0
 	r: int = 0

--- a/EIPS/eip-1559.md
+++ b/EIPS/eip-1559.md
@@ -16,8 +16,8 @@ A transaction pricing mechanism that includes fixed-per-block network fee that i
 There is a base fee per gas in protocol, which can move up or down each block according to a formula which is a function of gas used in parent block and gas target (formerly known as gas limit) of parent block.
 The algorithm results in the base fee per gas increasing when blocks are above the gas target, and decreasing when blocks are below the gas target.
 The base fee per gas is burned.
-Transactions specify both the maximum fee per gas they are willing to pay, as well as the maximum fee per gas they are willing to give to miners to incentivize them to include their transaction (aka: gas premium).
-The transaction will always pay the base fee per gas of the block it was included in, and they will pay the premium per gas set in the transaction, as long as the combined amount of the two fees doesn't exceed the transaction's maximum fee per gas.
+Transactions specify both the maximum network fee per gas (aka: base fee) they are willing to pay, as well as the maximum fee per gas they are willing to give to miners to incentivize them to include their transaction (aka: miner bribe).
+The transaction will always pay the base fee per gas of the block it was included in, and they will pay the bribe per gas set in the transaction, as long as the combined amount of the two fees doesn't exceed the transaction's maximum fee per gas.
 
 This specification also includes a mechanism for migrating from the current transaction/block fee system to the new one.
 Initially, half of a block can be legacy transactions, and half of a block can be new transactions.
@@ -31,14 +31,14 @@ Ethereum currently prices transaction fees using a simple auction mechanism, whe
 * **Inefficiencies of first price auctions**: The current approach, where transaction senders publish a transaction with a bid a maximum fee, miners choose the highest-paying transactions, and everyone pays what they bid. This is well-known in mechanism design literature to be highly inefficient, and so complex fee estimation algorithms are required. But even these algorithms often end up not working very well, leading to frequent fee overpayment.
 * **Instability of blockchains with no block reward**: In the long run, blockchains where there is no issuance (including Bitcoin and Zcash) at present intend to switch to rewarding miners entirely through transaction fees. However, there are known issues with this that likely leads to a lot of instability, incentivizing mining "sister blocks" that steal transaction fees, opening up much stronger selfish mining attack vectors, and more. There is at present no good mitigation for this.
 
-The proposal in this EIP is to start with a base fee amount which is adjusted up and down by the protocol based on how congested the network is. When the network exceeds the target per-block gas usage, the base fee increases slightly and when capacity is below the target, it decreases slightly. Because these base fee changes are constrained, the maximum difference in base fee from block to block is predictable. This then allows wallets to auto-set the gas fees for users in a highly reliable fashion. It is expected that most users will not have to manually adjust gas fees, even in periods of high network activity. For most users the base fee will be estimated by their wallet and a small gas premium, which acts as a 'bribe' to compensate miners taking on orphan risk (e.g. 1 nanoeth), will be automatically set. Users can also manually set the transaction fee cap to bound their total costs.
+The proposal in this EIP is to start with a base fee amount which is adjusted up and down by the protocol based on how congested the network is. When the network exceeds the target per-block gas usage, the base fee increases slightly and when capacity is below the target, it decreases slightly. Because these base fee changes are constrained, the maximum difference in base fee from block to block is predictable. This then allows wallets to auto-set the gas fees for users in a highly reliable fashion. It is expected that most users will not have to manually adjust gas fees, even in periods of high network activity. For most users the base fee will be estimated by their wallet and a small miner bribe, which compensates miners taking on orphan risk (e.g. 1 nanoeth), will be automatically set. Users can also manually set the transaction fee cap to bound their total costs.
 
-An important aspect of this fee system is that miners only get to keep the gas premium. The base fee is always burned (i.e. it is destroyed by the protocol). Burning this is important because it removes miner incentive to manipulate the fee in order to extract more fees from users. It also ensures that only ETH can ever be used to pay for transactions on Ethereum, cementing the economic value of ETH within the Ethereum platform. Additionally, this burn counterbalances Ethereum inflation without greatly diminishing miner rewards.
+An important aspect of this fee system is that miners only get to keep the miner bribe. The base fee is always burned (i.e. it is destroyed by the protocol). Burning this is important because it removes miner incentive to manipulate the fee in order to extract more fees from users. It also ensures that only ETH can ever be used to pay for transactions on Ethereum, cementing the economic value of ETH within the Ethereum platform. Additionally, this burn counterbalances Ethereum inflation without greatly diminishing miner rewards.
 
 The transition to this gas price system will occur in two phases, in the first phase both legacy and EIP1559 transactions will be accepted by the protocol. Over the course of this first phase the amount of gas available for processing legacy transactions will decrease while the amount of gas available for processing EIP1559 transactions will increase, moving gas from the legacy pool into the EIP1559 pool until the legacy pool is depleted and the EIP1559 pool contains the entire gas maximum. After all of the gas has transitioned to the EIP1559 pool, the second, finalized, phase is entered and legacy transactions will no longer be accepted on the network.
 
 ## Specification
-*Note: `//` in Python is integer division with rounding toward negative infinity.*
+*Note: `//` is integer division, round down.*
 ```python
 from typing import Union, Sequence
 from dataclasses import dataclass, field
@@ -61,8 +61,8 @@ class Transaction1559:
 	gas_limit: int = 0
 	amount: int = 0
 	payload: bytes = bytes()
-	gas_premium: int = 0
-	fee_cap: int = 0
+	miner_bribe_per_gas: int = 0
+	fee_cap_per_gas: int = 0
 	v: int = 0
 	r: int = 0
 	s: int = 0
@@ -96,97 +96,85 @@ class Account:
 	code_hash: int = 0
 
 INITIAL_FORK_BLOCK_NUMBER = 10 # TBD
-MIGRATION_DURATION_IN_BLOCKS = 800000
-FINAL_FORK_BLOCK_NUMBER = INITIAL_FORK_BLOCK_NUMBER + MIGRATION_DURATION_IN_BLOCKS
 BASE_FEE_MAX_CHANGE_DENOMINATOR = 8
+ELLASTICITY_MULTIPLIER = 2
 
 class World(ABC):
 	def validate_block(self, block: Block) -> None:
 		parent_base_fee = self.parent(block).base_fee
 		parent_gas_used = self.parent(block).gas_used
 		parent_gas_target = self.parent(block).gas_target
-		transactions_all = self.transactions(block)
+		transactions = self.transactions(block)
+
+		# check if the block used too much gas
+		assert block.gas_used <= block.gas_target * ELLASTICITY_MULTIPLIER, 'invalid block: too much gas used'
 
 		# check if the block changed the gas target too much
 		assert block.gas_target <= parent_gas_target + parent_gas_target // 1024, 'invalid block: gas target increased too much'
 		assert block.gas_target >= parent_gas_target - parent_gas_target // 1024, 'invalid block: gas target decreased too much'
 
 		# check if the base fee is correct
-		if parent_gas_used >= parent_gas_target:
+		if parent_gas_used == parent_gas_target:
+			expected_base_fee = parent_base_fee
+		elif parent_gas_used > parent_gas_target:
 			gas_delta = parent_gas_used - parent_gas_target
 			fee_delta = max(parent_base_fee * gas_delta // parent_gas_target // BASE_FEE_MAX_CHANGE_DENOMINATOR, 1)
 			expected_base_fee = parent_base_fee + fee_delta
 		else:
 			gas_delta = parent_gas_target - parent_gas_used
-			fee_delta = (parent_base_fee * gas_delta - 1) // parent_gas_used // BASE_FEE_MAX_CHANGE_DENOMINATOR + 1
+			fee_delta = parent_base_fee * gas_delta // parent_gas_used // BASE_FEE_MAX_CHANGE_DENOMINATOR
 			expected_base_fee = parent_base_fee - fee_delta
 		assert expected_base_fee == block.base_fee, 'invalid block: base fee not correct'
 
 		# execute transactions and do gas accounting
-		cumulative_legacy_transaction_gas_used = 0
-		cumulative_1559_transaction_gas_used = 0
-		for transaction in transactions_all:
+		cumulative_transaction_gas_used = 0
+		for transaction in transactions:
+			# Note: this validates transaction signature which must happen before we normalize below since the signature won't match after that
 			signer = self.transaction_signer_account(transaction)
 			signer.balance -= transaction.amount
 			assert signer.balance >= 0, 'invalid transaction: signer does not have enough ETH to cover attached value'
 
-			# handle legacy transactions, can differentiate by number of items if desired (Legacy == 8 items)
-			if isinstance(transaction, TransactionLegacy):
-				signer.balance -= transaction.gas_limit * transaction.gas_price
-				assert signer.balance >= 0, 'invalid transaction: signer does not have enough ETH to cover gas'
-				gas_used = self.execute_transaction(transaction)
-				cumulative_legacy_transaction_gas_used += gas_used
-				signer.balance += (transaction.gas_limit - gas_used) * transaction.gas_price
-				self.account(block.author).balance += gas_used * transaction.gas_price
+			transaction = self.normalize_transaction(transaction)
 
-			# handle 1559 transactions, can differentiate by number of items if desired (1559 == 9 items)
-			elif isinstance(transaction, Transaction1559):
-				# premium is capped such that base fee is filled first
-				premium_per_gas = min(transaction.gas_premium, transaction.fee_cap - block.base_fee)
-				# ensure that the final fee isn't negative
-				assert premium_per_gas >= 0, 'invalid transaction: miner premium is negative'
-				# signer pays both the premium and the base fee
-				signer.balance -= transaction.gas_limit * premium_per_gas
-				signer.balance -= transaction.gas_limit * block.base_fee
-				assert signer.balance >= 0, 'invalid transaction: signer does not have enough ETH to cover gas'
-				gas_used = self.execute_transaction(transaction)
-				gas_refund = transaction.gas_limit - gas_used
-				cumulative_1559_transaction_gas_used += gas_used
-				# signer gets refunded for unused gas
-				signer.balance += gas_refund * block.base_fee
-				signer.balance += gas_refund * premium_per_gas
-				# miner only receives the premium; note that the base fee is not given to anyone (it is burned)
-				self.account(block.author).balance += gas_used * premium_per_gas
+			# bribe is capped such that base fee is filled first
+			bribe_per_gas = min(transaction.miner_bribe_per_gas, transaction.fee_cap_per_gas - block.base_fee)
+			# signer pays both the bribe and the base fee
+			signer.balance -= transaction.gas_limit * bribe_per_gas
+			signer.balance -= transaction.gas_limit * block.base_fee
+			assert signer.balance >= 0, 'invalid transaction: signer does not have enough ETH to cover gas'
+			gas_used = self.execute_transaction(transaction)
+			gas_refund = transaction.gas_limit - gas_used
+			cumulative_transaction_gas_used += gas_used
+			# signer gets refunded for unused gas
+			signer.balance += gas_refund * block.base_fee
+			signer.balance += gas_refund * bribe_per_gas
+			# miner only receives the bribe; note that the base fee is not given to anyone (it is burned)
+			self.account(block.author).balance += gas_used * bribe_per_gas
 
-			# any other length transaction is an error
-			else:
-				raise Exception('invalid transaction: unexpected number of items')
-
-		# check if the block spent too much gas on legacy transactions
-		assert cumulative_legacy_transaction_gas_used <= self.gas_target_legacy(block), 'invalid block: too much gas spent on legacy transactions'
-
-		# check if the block spent too much gas on 1559 transactions
-		assert cumulative_1559_transaction_gas_used <= self.gas_target_1559(block), 'invalid block: too much gas spent on EIP-1559 transactions'
+		# check if the block spent too much gas transactions
+		assert cumulative_transaction_gas_used == block.gas_used, 'invalid block: gas_used does not equal total gas used in all transactions'
 
 		# TODO: verify account balances match block's account balances (via state root comparison)
 		# TODO: validate the rest of the block
 
-	def gas_target_1559(self, block: Block) -> int:
-		# before the fork block, there is no space for 1559 transactions in a block
-		if block.number < INITIAL_FORK_BLOCK_NUMBER:
-			return 0
-		# at the start of the migration period, half of the block's gas target is for 1559 transactions
-		if block.number == INITIAL_FORK_BLOCK_NUMBER:
-			return block.gas_target // 2
-		# after the migration is over, the block's gas target is fully devoted to 1559 transactions
-		if block.number >= FINAL_FORK_BLOCK_NUMBER:
-			return block.gas_target
-		# during the migration, we slowly increase the space devoted to 1559 transactions
-		return (block.gas_target + block.gas_target * (block.number - INITIAL_FORK_BLOCK_NUMBER) // MIGRATION_DURATION_IN_BLOCKS) // 2
-
-	def gas_target_legacy(self, block: Block) -> int:
-		# legacy transactions get all of the block gas target that isn't used by 1559, which means they'll eventually have 0 space
-		return block.gas_target - self.gas_target_1559(block)
+	def normalize_transaction(self, transaction: Transaction) -> Transaction1559:
+		# handle legacy transactions, can differentiate by number of items if desired (Legacy == 8 items)
+		if isinstance(transaction, TransactionLegacy):
+			return Transaction1559(
+				account_nonce: int = transaction.account_nonce,
+				gas_limit: int = transaction.gas_limit,
+				amount: int = transaction.amount,
+				payload: bytes = transaction.payload,
+				miner_bribe_per_gas: int = transaction.gas_price,
+				fee_cap_per_gas: int = transaction.gas_price,
+				v: int = transaction.v,
+				r: int = transaction.r,
+				s: int = transaction.s,
+			)
+		elif isinstance(transaction, Transaction1559):
+			return transaction
+		else:
+			raise Exception('invalid transaction: unexpected number of items')
 
 	@abstractmethod
 	def parent(self, block: Block) -> Block: pass
@@ -224,7 +212,7 @@ This EIP will increase the maximum block size, which could cause problems if min
 With most people not competing on miner fees and instead using a baseline fee to get included, transaction ordering now depends on individual client internal implementation details such as how they store the transactions in memory.  It is recommended that transactions with the same miner fee be sorted by time the transaction was received to protect the network from spamming attacks where the attacker throws a bunch of transactions into the pending pool in order to ensure that at least one lands in a favorable position.  Miners should still prefer higher tip transactions over lower tip, purely from a selfish mining perspective.
 
 ### Miners Mining Empty Blocks
-It is possible that miners will mine empty blocks until such time as the base fee is very low and then proceed to mine half full blocks and revert to sorting transactions by the gas premium.  While this attack is possible, it is not a particularly stable equilibrium as long as mining is decentralized.  Any defector from this strategy will be more profitable than a miner participating in the attack for as long as the attack continues (even after the base fee reached 0).  Since any miner can anonymously defect from a cartel, and there is no way to prove that a particular miner defected, the only feasible way to execute this attack would be to control 50% or more of hashing power.  If an attacker had exectly 50% of hashing power, they would make no money from gas premium while defectors would make double the money from premiums.  For an attacker to turn a profit, they need to have some amount over 50% hashing power, which means they can alternatively execute double spend attacks or simply ignore any other miners which is a far more profitable strategy.
+It is possible that miners will mine empty blocks until such time as the base fee is very low and then proceed to mine half full blocks and revert to sorting transactions by the miner bribe.  While this attack is possible, it is not a particularly stable equilibrium as long as mining is decentralized.  Any defector from this strategy will be more profitable than a miner participating in the attack for as long as the attack continues (even after the base fee reached 0).  Since any miner can anonymously defect from a cartel, and there is no way to prove that a particular miner defected, the only feasible way to execute this attack would be to control 50% or more of hashing power.  If an attacker had exectly 50% of hashing power, they would make no money from miner bribe while defectors would make double the money from bribes.  For an attacker to turn a profit, they need to have some amount over 50% hashing power, which means they can alternatively execute double spend attacks or simply ignore any other miners which is a far more profitable strategy.
 
 Should a miner attempt to execute this attack, we can simply increase the elasticity multiplier (currently 2x) which requires they have even more hashing power available before the attack can even be theoretically profitable against defectors.
 

--- a/EIPS/eip-1559.md
+++ b/EIPS/eip-1559.md
@@ -61,7 +61,7 @@ class Transaction1559:
 	gas_limit: int = 0
 	amount: int = 0
 	payload: bytes = bytes()
-	miner_bribe_per_gas: int = 0
+	max_max_miner_bribe_per_gas: int = 0
 	fee_cap_per_gas: int = 0
 	v: int = 0
 	r: int = 0
@@ -139,7 +139,7 @@ class World(ABC):
 			# ensure that the user was willing to at least pay the base fee
 			assert transaction.fee_cap_per_gas >= block.base_fee
 			# bribe is capped such that base fee is filled first
-			bribe_per_gas = min(transaction.miner_bribe_per_gas, transaction.fee_cap_per_gas - block.base_fee)
+			bribe_per_gas = min(transaction.max_miner_bribe_per_gas, transaction.fee_cap_per_gas - block.base_fee)
 			# signer pays both the bribe and the base fee
 			signer.balance -= transaction.gas_limit * bribe_per_gas
 			signer.balance -= transaction.gas_limit * block.base_fee
@@ -167,7 +167,7 @@ class World(ABC):
 				gas_limit: int = transaction.gas_limit,
 				amount: int = transaction.amount,
 				payload: bytes = transaction.payload,
-				miner_bribe_per_gas: int = transaction.gas_price,
+				max_miner_bribe_per_gas: int = transaction.gas_price,
 				fee_cap_per_gas: int = transaction.gas_price,
 				v: int = transaction.v,
 				r: int = transaction.r,

--- a/EIPS/eip-1559.md
+++ b/EIPS/eip-1559.md
@@ -97,7 +97,7 @@ class Account:
 
 INITIAL_FORK_BLOCK_NUMBER = 10 # TBD
 BASE_FEE_MAX_CHANGE_DENOMINATOR = 8
-ELLASTICITY_MULTIPLIER = 2
+ELASTICITY_MULTIPLIER = 2
 
 class World(ABC):
 	def validate_block(self, block: Block) -> None:

--- a/EIPS/eip-1559.md
+++ b/EIPS/eip-1559.md
@@ -136,6 +136,8 @@ class World(ABC):
 
 			transaction = self.normalize_transaction(transaction)
 
+			# ensure that the user was willing to at least pay the base fee
+			assert transaction.fee_cap_per_gas >= block.base_fee
 			# bribe is capped such that base fee is filled first
 			bribe_per_gas = min(transaction.miner_bribe_per_gas, transaction.fee_cap_per_gas - block.base_fee)
 			# signer pays both the bribe and the base fee

--- a/EIPS/eip-1559.md
+++ b/EIPS/eip-1559.md
@@ -107,7 +107,7 @@ class World(ABC):
 		transactions = self.transactions(block)
 
 		# check if the block used too much gas
-		assert block.gas_used <= block.gas_target * ELLASTICITY_MULTIPLIER, 'invalid block: too much gas used'
+		assert block.gas_used <= block.gas_target * ELASTICITY_MULTIPLIER, 'invalid block: too much gas used'
 
 		# check if the block changed the gas target too much
 		assert block.gas_target <= parent_gas_target + parent_gas_target // 1024, 'invalid block: gas target increased too much'


### PR DESCRIPTION
Rather than having two pools and a migration, we instead have a single transaction pool and legacy transactions are "upgraded" into 1559 transactions using a *very* naive strategy of just setting `fee_cap == gas_bribe == gas_price`.

While in here, I also made a few other minor changes since this is a consensus change and will require all clients update:
1. Renamed premium to bribe.  I think this makes it more clear what this is, it is a bribe for the miner to convince them to include your transaction.
2. Changed the gas target calculation to be a bit simpler (per prior conversation with @i-norden)
3. Added special handling for when the gas_used == gas_target (no change in target for next block).
4. Adds missing assertion that gas_used wasn't more than 2x the gas target.
5. Added clarity to some names like `fee_cap` to `fee_cap_per_gas` and `miner_bribe` to `miner_bribe_per_gas`.