### PR TITLE
Check root for eip files

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -15,8 +15,7 @@ elif [[ $TASK = 'htmlproofer-external' ]]; then
   bundle exec jekyll build
   bundle exec htmlproofer $HTMLPROOFER_OPTIONS --external_only
 elif [[ $TASK = 'eip-validator' ]]; then
-  ls | grep 'eip-' | grep -v 'eip-template.md' || EXIT=$?
-  if [ -z $EXIT ]; then
+  if [[ $(find . -maxdepth 1 -name 'eip-*' | wc -l) -ne 1 ]]; then
     echo "only 'eip-template.md' should be in the root"
     exit 1
   fi

--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -15,6 +15,11 @@ elif [[ $TASK = 'htmlproofer-external' ]]; then
   bundle exec jekyll build
   bundle exec htmlproofer $HTMLPROOFER_OPTIONS --external_only
 elif [[ $TASK = 'eip-validator' ]]; then
+  ls | grep 'eip-' | grep -v 'eip-template.md' || EXIT=$?
+  if [ -z $EXIT ]; then
+    echo "only 'eip-template.md' should be in the root"
+    exit 1
+  fi
   eipv EIPS/ --ignore=title_max_length,missing_discussions_to --skip=eip-20-token-standard.md
 elif [[ $TASK = 'codespell' ]]; then
   codespell -q4 -I .codespell-whitelist -S ".git,Gemfile.lock,**/*.png,**/*.gif,**/*.jpg,**/*.svg,.codespell-whitelist,vendor,_site,_config.yml,style.css"


### PR DESCRIPTION
Occasionally, people accidentally create EIP files in the root dir. This can be missed by editors very easily. This PR updates the CI script to check if any files in the root directory match the pattern `eip-*`. This should help reduce the number of accidental merges of EIP in the wrong location.