### PR TITLE
SET_INDESTRUCTIBLE opcode

### DIFF
--- a/EIPS/eip-2937.md
+++ b/EIPS/eip-2937.md
@@ -17,7 +17,7 @@ Add a `SET_INDESTRUCTIBLE (0xA8)` opcode that prevents the contract from calling
 
 ## Specification
 
-Add a context-wide variable `locals.indestructible` (ie. a variable that lives in the same "space" as memory, stack, PC...), initialized to `False`.
+Add a context-wide variable `locals.indestructible` (i.e. a variable that lives in the same "space" as memory, stack, PC...), initialized to `False`.
 
 Add a `SET_INDESTRUCTIBLE` opcode at `0xA8`, with gas cost `G_base`, that sets `locals.indestructible` to `True`. If in the current execution context `locals.indestructible` is `True`, the `SELFDESTRUCT` opcode throws an exception.
 

--- a/EIPS/eip-2937.md
+++ b/EIPS/eip-2937.md
@@ -27,7 +27,17 @@ The intended use case would be for contracts to make their first byte of code be
 
 Unlike EIPs that disable the `SELFDESTRUCT` opcode entirely, this EIP does not modify behavior of any existing contracts.
 
-## Forwards Compatibility and Security
+## Rationale
+
+TBD
+
+## Backwards Compatibility
+
+TBD
+
+## Security Considerations
+
+TBD
 
 This breaks forward compatibility with _some_ forms of state rent, which would simply delete contracts that get too old without paying some maintenance fee. However, this is not the case with all state size control schemes; for example this is not an issue if we use [ReGenesis](https://ledgerwatch.github.io/regenesis_plan.html).
 

--- a/EIPS/eip-2937.md
+++ b/EIPS/eip-2937.md
@@ -17,9 +17,9 @@ Add a `SET_INDESTRUCTIBLE (0xA8)` opcode that prevents the contract from calling
 
 ## Specification
 
-Add a context-wide variable `locals.indestructible` (i.e. a variable that lives in the same "space" as memory, stack, PC...), initialized to `False`.
+Add a transaction-wide global variable `globals.indestructible: Set[Address]` (i.e. a variable that operates the same way as the selfdestructs set), initialized to the empty set.
 
-Add a `SET_INDESTRUCTIBLE` opcode at `0xA8`, with gas cost `G_base`, that sets `locals.indestructible` to `True`. If in the current execution context `locals.indestructible` is `True`, the `SELFDESTRUCT` opcode throws an exception.
+Add a `SET_INDESTRUCTIBLE` opcode at `0xA8`, with gas cost `G_base`, that adds the current `callee` to the `globals.indestructible` set. If in the current execution context the `callee` is in `globals.indestructible`, the `SELFDESTRUCT` opcode throws an exception.
 
 ## Motivation
 
@@ -29,15 +29,16 @@ Unlike EIPs that disable the `SELFDESTRUCT` opcode entirely, this EIP does not m
 
 ## Rationale
 
-TBD
+Alternative proposals to this include:
+
+* Simply banning `SELFDESTRUCT` outright. This would be ideal, but has larger backwards compatibility issues.
+* Using a local variable instead of a global variable. This is problematic because it would be broken by `DELEGATECALL`.
 
 ## Backwards Compatibility
 
 TBD
 
 ## Security Considerations
-
-TBD
 
 This breaks forward compatibility with _some_ forms of state rent, which would simply delete contracts that get too old without paying some maintenance fee. However, this is not the case with all state size control schemes; for example this is not an issue if we use [ReGenesis](https://ledgerwatch.github.io/regenesis_plan.html).
 

--- a/EIPS/eip-2937.md
+++ b/EIPS/eip-2937.md
@@ -11,7 +11,7 @@ created: 2020-09-04
 
 ## Simple Summary
 
-Add a `SET_INDESTRUCTIBLE (0xA8)` opcode that prevents the contract from calling `SELFDESTRUCT (0xff)`.
+Add a `SET_INDESTRUCTIBLE (0xA8)` opcode that prevents the contract from calling `SELFDESTRUCT (0xFF)`.
 
 ## Abstract
 

--- a/EIPS/eip-2937.md
+++ b/EIPS/eip-2937.md
@@ -13,6 +13,8 @@ created: 2020-09-04
 
 Add a `SET_INDESTRUCTIBLE (0xA8)` opcode that prevents the contract from calling `SELFDESTRUCT (0xff)`.
 
+## Abstract
+
 ## Specification
 
 Add a context-wide variable `locals.indestructible` (ie. a variable that lives in the same "space" as memory, stack, PC...), initialized to `False`.

--- a/EIPS/eip-2937.md
+++ b/EIPS/eip-2937.md
@@ -15,17 +15,17 @@ Add a `SET_INDESTRUCTIBLE (0xA8)` opcode that prevents the contract from calling
 
 ## Abstract
 
-## Specification
-
-Add a transaction-wide global variable `globals.indestructible: Set[Address]` (i.e. a variable that operates the same way as the selfdestructs set), initialized to the empty set.
-
-Add a `SET_INDESTRUCTIBLE` opcode at `0xA8`, with gas cost `G_base`, that adds the current `callee` to the `globals.indestructible` set. If in the current execution context the `callee` is in `globals.indestructible`, the `SELFDESTRUCT` opcode throws an exception.
-
 ## Motivation
 
 The intended use case would be for contracts to make their first byte of code be the `SET_INDESTRUCTIBLE` opcode if they wish to serve as libraries that guarantee to users that their code will exist unmodified forever. This is useful in account abstraction as well as other contexts.
 
 Unlike EIPs that disable the `SELFDESTRUCT` opcode entirely, this EIP does not modify behavior of any existing contracts.
+
+## Specification
+
+Add a transaction-wide global variable `globals.indestructible: Set[Address]` (i.e. a variable that operates the same way as the selfdestructs set), initialized to the empty set.
+
+Add a `SET_INDESTRUCTIBLE` opcode at `0xA8`, with gas cost `G_base`, that adds the current `callee` to the `globals.indestructible` set. If in the current execution context the `callee` is in `globals.indestructible`, the `SELFDESTRUCT` opcode throws an exception.
 
 ## Rationale
 

--- a/EIPS/eip-2937.md
+++ b/EIPS/eip-2937.md
@@ -1,0 +1,35 @@
+---
+eip: 2937
+title: SET_INDESTRUCTIBLE opcode
+author: Vitalik Buterin (@vbuterin)
+discussions-to: <URL>
+status: Draft
+type: Standards Track
+category: Core
+created: 2020-09-04
+---
+
+## Simple Summary
+
+Add a `SET_INDESTRUCTIBLE (0xA8)` opcode that prevents the contract from calling `SELFDESTRUCT (0xff)`.
+
+## Specification
+
+Add a context-wide variable `locals.indestructible` (ie. a variable that lives in the same "space" as memory, stack, PC...), initialized to `False`.
+
+Add a `SET_INDESTRUCTIBLE` opcode at `0xA8`, with gas cost 2 (`G_base`) , that sets `locals.indestructible` to `True`. If in the current execution context `locals.indestructible` is `True`, the `SELFDESTRUCT` opcode throws an exception.
+
+## Motivation
+
+The intended use case would be for contracts to make their first byte of code be the `SET_INDESTRUCTIBLE` opcode if they wish to serve as libraries that guarantee to users that their code will exist unmodified forever. This is useful in account abstraction as well as other contexts.
+
+Unlike EIPs that disable the `SELFDESTRUCT` opcode entirely, this EIP does not modify behavior of any existing contracts.
+
+## Forwards Compatibility and Security
+
+This breaks forward compatibility with _some_ forms of state rent, which would simply delete contracts that get too old without paying some maintenance fee. However, this is not the case with all state size control schemes; for example this is not an issue if we use [ReGenesis](https://ledgerwatch.github.io/regenesis_plan.html).
+
+If `SELFDESTRUCT` is ever removed in the future, this EIP would simply become a no-op.
+
+## Copyright
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/EIPS/eip-2937.md
+++ b/EIPS/eip-2937.md
@@ -2,7 +2,7 @@
 eip: 2937
 title: SET_INDESTRUCTIBLE opcode
 author: Vitalik Buterin (@vbuterin)
-discussions-to: <URL>
+discussions-to: https://ethereum-magicians.org/t/eip-2937-set-indestructible/4571
 status: Draft
 type: Standards Track
 category: Core
@@ -17,7 +17,7 @@ Add a `SET_INDESTRUCTIBLE (0xA8)` opcode that prevents the contract from calling
 
 Add a context-wide variable `locals.indestructible` (ie. a variable that lives in the same "space" as memory, stack, PC...), initialized to `False`.
 
-Add a `SET_INDESTRUCTIBLE` opcode at `0xA8`, with gas cost 2 (`G_base`) , that sets `locals.indestructible` to `True`. If in the current execution context `locals.indestructible` is `True`, the `SELFDESTRUCT` opcode throws an exception.
+Add a `SET_INDESTRUCTIBLE` opcode at `0xA8`, with gas cost `G_base`, that sets `locals.indestructible` to `True`. If in the current execution context `locals.indestructible` is `True`, the `SELFDESTRUCT` opcode throws an exception.
 
 ## Motivation
 


### PR DESCRIPTION
Add a `SET_INDESTRUCTIBLE` opcode that prevents the contract from calling `SELFDESTRUCT`.

When opening a pull request to submit a new EIP, please use the suggested template: https://github.com/ethereum/EIPs/blob/master/eip-template.md

We have a GitHub bot that automatically merges some PRs. It will merge yours immediately if certain criteria are met:

 - The PR edits only existing draft PRs.
 - The build passes.
 - Your GitHub username or email address is listed in the 'author' header of all affected PRs, inside <triangular brackets>.
 - If matching on email address, the email address is the one publicly listed on your GitHub profile.
