### PR TITLE
eip-2565: rework it

### DIFF
--- a/EIPS/eip-2565.md
+++ b/EIPS/eip-2565.md
@@ -15,22 +15,62 @@ requires: 198
 The [EIP-198](https://eips.ethereum.org/EIPS/eip-198) ‘big integer modular exponentiation’, or `ModExp`, precompile is currently overpriced. Re-pricing this precompile will enable more cost efficient verification of RSA signatures, verifiable delay functions (VDFs), primality checks, and more.
 
 ## Abstract
-After benchmarking the ModExp precompile, we discovered that it is ‘overpriced’ relative to other precompiles. We also discovered that the current gas pricing formula could be improved to better estimate the computational complexity of various ModExp input variables. To improve the gas cost pricing for this precompile the following options are available:
+After benchmarking the ModExp precompile, we discovered that it is ‘overpriced’ relative to other precompiles. We also discovered that the current gas pricing formula could be improved to better estimate the computational complexity of various ModExp input variables. 
+To improve the gas cost pricing for this precompile, this EIP specifies
 
-1. Modifying the gas pricing formula to better reflect the computational complexity of ModExp operations
-2. Changing the value of the `GQUADDIVISOR` parameter in the ModExp pricing formula to bring its costs more in-line with other precompiles
-3. Improving the underlying libraries beneath the ModExp Precompile
-4. Any combination of (1), (2), and (3)
-
-We recommend **Option (1) and (2)** which provides a large practical improvement to gas estimation while keeping implementation complexity low. Option (3) can be implemented at a later point to improve the gas pricing even further.
+* Changing the value of the `GQUADDIVISOR` parameter in the ModExp pricing formula to bring its costs more in-line with other precompiles
 
 ## Motivation
 Modular exponentiation is a foundational arithmetic operation for many cryptographic functions including signatures, VDFs, SNARKs, accumulators, and more. Unfortunately, the ModExp precompile is currently over-priced, making these operations inefficient and expensive. By reducing the cost of this precompile, these cryptographic functions become more practical, enabling improved security, stronger randomness (VDFs), and more.
 
 ## Specification
-The current gas pricing formula is defined in EIP-198. This formula divides a ‘computational complexity’ function by a ‘gas conversion’ parameter called `GQUADDIVISOR` to arrive at a gas cost: `floor(mult_complexity(x)/GQUADDIVISOR)`
 
-### **Recommended** Option (1): Modify ‘computational complexity’ function and add minimum gas cost
+The current gas pricing formula is defined in [EIP-198](eip-198.md) as: 
+
+```
+floor(mult_complexity(max(length_of_MODULUS, length_of_BASE)) * max(ADJUSTED_EXPONENT_LENGTH, 1) / GQUADDIVISOR)
+```
+
+At `fork_block`, 
+ - set `GQUADDIVISOR` to `200`.
+
+
+## Rationale
+
+With this change, the cost of the ModExp precompile will have a higher cost (gas/second) than other precompiles such as ECRecover.
+
+![Option 2 Graph](../assets/eip-2565/GQuad_Change.png)
+
+## Test Cases
+
+There are no changes to the underlying interface or arithmetic algorithms, so the existing test vectors can be reused. Gas values will need to be updated in the existing unit tests based on the final pricing decided in this EIP. This will ensure that the updated gas calculations are done correctly.
+
+Existing testvectors from [go-ethereum](https://github.com/ethereum/go-ethereum/blob/master/core/vm/testdata/precompiles/modexp.json):
+
+| testcase | EIP-198 gas| 2565 opt  1 gas| 2565 opt 2 gas | 
+| -|--|--|--
+|modexp_nagydani_1_square| 204 | 100| 100?|
+
+TODO fill this table
+
+
+
+## Security Considerations
+
+The biggest security consideration for this EIP is  creating a potential DoS vector by making ModExp operations too inexpensive relative to their computation time.
+
+To address this, clients should perform benchmarking to ensure that gas limits are not causing DoS problems. 
+
+## References
+[EIP-198](https://eips.ethereum.org/EIPS/eip-198) 
+
+## Copyright
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+
+## Appendix
+
+### Abandoned option : Modify ‘computational complexity’ function and add minimum gas cost
+
 The current complexity function, as defined in EIP-198 is as follow:
 
 ```
@@ -53,42 +93,11 @@ You can find comparison of these two complexity fomulas for the current test vec
 
 In addition to modifying the `mult_complexity` formula as above, we also recommend wrapping the entire function with a minimum gas price of 100 to ensure that a minimum amount of gas is used when the precompile is called e.g. `max(100,floor(mult_complexity(x)/GQUADDIVISOR))`
 
-### **Recommended** Option (2): Change value of GQUADDIVISOR
-`GQUADDIVISOR` is set to `20` per EIP-198. We recommend changing the value of this parameter to `3` to account for the changes in the recommended 'computational complexity' formula above.
+#### Rationale
 
-### Option (3): Replace libraries used by ModExp precompiles
-ModExp benchmarks for different libraries can be found at the following [spreadsheet](https://docs.google.com/spreadsheets/d/1Fq3d3wUjGN0R_FX-VPj7TKhCK33ac--P4QXB9MPQ8iw/edit?usp=sharing).
-
-While alternative libraries can provide improved a further 2-5x improvement in performance, this option is not recommended at this time.
-
-## Rationale
-
-### **Recommended** Option (1): Modify ‘computational complexity’ formula
 A comparison of the current ‘complexity’ function and the proposed function described above can be found at the following [spreadsheet](https://docs.google.com/spreadsheets/d/1-xBzA-2-l2ZQDQ1eh3XXGZjcRSBQ_Hnp7NubXpbiSUY/edit?usp=sharing).
 
 ![Option 1 Graph](../assets/eip-2565/Complexity_Regression.png)
 
 The new complexity function has a better fit vs. the execution time when compared to the current complexity function. This better fit is because the new complexity formula accounts for the use of binary exponentiation algorithms that are used by ‘bigint’ libraries for large exponents. You may also notice the regression line of the proposed complexity function bisects the test vector data points. This is because the run time varies depending on if the modulus is even or odd.
 
-### **Recommended** Option (2): Change value of GQUADDIVISOR:
-After changing the 'computational complexity' formula it is necessary to change `QGUADDIVSOR` to bring the gas costs inline with their runtime. We recommend changing the value from '20' to '3'. With this change, the cost of the ModExp precompile will have a higher cost (gas/second) than other precompiles such as ECRecover.
-
-![Option 2 Graph](../assets/eip-2565/GQuad_Change.png)
-
-### Option (3): Improving the ModExp precompile implementations
-
-![Option 3 Graph](../assets/eip-2565/Library_Benchmarks.png)
-
-Replacing the underlying library can improve the performance of the ModExp precompile by 2x-4x for large exponents, but comes at a high implementation cost. We do not recommend this option at this time.
-
-## Test Cases
-There are no changes to the underlying interface or arithmetic algorithms, so the existing test vectors can be reused. Gas values will need to be updated in the existing unit tests based on the final pricing decided in this EIP. This will ensure that the updated gas calculations are done correctly.
-
-## Security Considerations
-The biggest security consideration for this EIP is creating a potential DoS vector by making ModExp operations too inexpensive relative to their computation time.
-
-## References
-[EIP-198](https://eips.ethereum.org/EIPS/eip-198) 
-
-## Copyright
-Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/EIPS/eip-2565.md
+++ b/EIPS/eip-2565.md
@@ -53,8 +53,6 @@ Existing testvectors from [go-ethereum](https://github.com/ethereum/go-ethereum/
 
 TODO fill this table
 
-
-
 ## Security Considerations
 
 The biggest security consideration for this EIP is creating a potential DoS vector by making ModExp operations too inexpensive relative to their computation time.

--- a/EIPS/eip-2565.md
+++ b/EIPS/eip-2565.md
@@ -34,7 +34,6 @@ floor(mult_complexity(max(length_of_MODULUS, length_of_BASE)) * max(ADJUSTED_EXP
 At `fork_block`, 
  - set `GQUADDIVISOR` to `200`.
 
-
 ## Rationale
 
 With this change, the cost of the ModExp precompile will have a higher cost (gas/second) than other precompiles such as ECRecover.

--- a/EIPS/eip-2565.md
+++ b/EIPS/eip-2565.md
@@ -25,7 +25,7 @@ Modular exponentiation is a foundational arithmetic operation for many cryptogra
 
 ## Specification
 
-The current gas pricing formula is defined in [EIP-198](eip-198.md) as: 
+The current gas pricing formula is defined in [EIP-198](./eip-198.md) as: 
 
 ```
 floor(mult_complexity(max(length_of_MODULUS, length_of_BASE)) * max(ADJUSTED_EXPONENT_LENGTH, 1) / GQUADDIVISOR)

--- a/EIPS/eip-2565.md
+++ b/EIPS/eip-2565.md
@@ -57,7 +57,7 @@ TODO fill this table
 
 ## Security Considerations
 
-The biggest security consideration for this EIP is  creating a potential DoS vector by making ModExp operations too inexpensive relative to their computation time.
+The biggest security consideration for this EIP is creating a potential DoS vector by making ModExp operations too inexpensive relative to their computation time.
 
 To address this, clients should perform benchmarking to ensure that gas limits are not causing DoS problems. 
 
@@ -100,4 +100,3 @@ A comparison of the current ‘complexity’ function and the proposed function 
 ![Option 1 Graph](../assets/eip-2565/Complexity_Regression.png)
 
 The new complexity function has a better fit vs. the execution time when compared to the current complexity function. This better fit is because the new complexity formula accounts for the use of binary exponentiation algorithms that are used by ‘bigint’ libraries for large exponents. You may also notice the regression line of the proposed complexity function bisects the test vector data points. This is because the run time varies depending on if the modulus is even or odd.
-


### PR DESCRIPTION
The EIP-2565 is totally out of sync with the spec on the discussions-to, and also does not make sense, as 

- the suggested option 2 actually makes the precompile more expensive (divisor `20` to `3`),
- The quoted formula from `198` is actually not correct, 
- It has two recommended options, but we're actually only going to implement one
- It has a third option which is not consensus-related, and shouldn't be part of the EIP

Discussion at https://ethereum-magicians.org/t/eip-2565-big-integer-modular-exponentiation-eip-198-gas-cost/4150/5  
This PR is not ready to merge, just a starting point for rewriting it. 

Primarily, it needs filling on the gas-table of testcases, and I'd rather have the authors do that, to ensure that the values used for the benchmarkings/charts matches with what's in the testcases. 
