### PR TITLE
Add IS_STATIC opcode

### DIFF
--- a/EIPS/eip-2970.md
+++ b/EIPS/eip-2970.md
@@ -1,0 +1,39 @@
+---
+eip: 2970
+title: IS_STATIC opcode
+author: Vitalik Buterin (@vbuterin)
+discussions-to: https://ethereum-magicians.org/t/is-static-opcode-useful-for-aa/4609
+status: Draft
+type: Standards Track
+category: Core
+created: 2020-09-13
+---
+
+## Simple Summary
+
+Add a `IS_STATIC (0x4A)` opcode that pushes `1` if the current context is static (ie. the execution is in a `STATICCALL` or a descendant thereof, so state-changing operations are not possible), and `0` if it is not.
+
+## Abstract
+
+## Motivation
+
+The main intended use case is to allow account abstraction (EIP 2938) to be extended so that accounts can allow static calls from the outside (which are harmless to AA's security model) but not state-changing calls.
+
+## Specification
+
+Add a `IS_STATIC (0x4A)` opcode that pushes `1` if the current context is static (ie. the execution is in a `STATICCALL` or a descendant thereof, so state-changing operations are not possible), and `0` if it is not.
+
+## Rationale
+
+Determining staticness is already possibly using the following hacky technique: make a `CALL` with limited gas, and inside that `CALL` issue one `LOG` and exit. If the context is static, the `CALL` would fail and leave a 0 on the stack; if the context is non-static, the `CALL` would succeed. However, this technique is fragile against changes to gas costs, and is needlessly wasteful. Hence, the status quo neither allows a reasonably effective way of determining whether or not the context is static, nor provides any kind of invariant that executions that do not fail outright will execute the same way in a static and non-static context. This EIP provides a cleaner way of determining staticness.
+
+## Backwards Compatibility
+
+TBD
+
+## Security Considerations
+
+TBD
+
+## Copyright
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
Add a `IS_STATIC (0x4A)` opcode that pushes `1` if the current context is static (ie. the execution is in a `STATICCALL` or a descendant thereof, so state-changing operations are not possible), and `0` if it is not.