### PR TITLE
EIP-2929: clarifications about scope revertals

### DIFF
--- a/EIPS/eip-2929.md
+++ b/EIPS/eip-2929.md
@@ -44,9 +44,18 @@ In the further future, there are similar benefits in the case of SNARK/STARK wit
 
 For blocks where `block.number >= FORK_BLOCK`, the following changes apply.
 
-### Storage read changes
+When executing a transaction, maintain a set `accessed_addresses: Set[Address]` and `accessed_storage_keys: Set[Tuple[Address, Bytes32]]` . 
 
-When executing a transaction, maintain a set `accessed_addresses: Set[Address]` and `accessed_storage_keys: Set[Tuple[Address, Bytes32]]` (this is a transaction-context-wide set, implemented identically to self-destructs, in particular reverting similarly to how self-destructs revert). When a transaction execution begins, `accessed_storage_keys` is initialized to empty, and `accessed_addresses` is initialized to include the `tx.sender`, `tx.to` (or the address being created if it is a contract creation transaction) and the set of all precompiles.
+The sets are transaction-context-wide, implemented identically to other transaction-scoped constructs such as the self-destruct-list and global `refund` counter. In particular, if a scope reverts, the access lists should be in the state they were in before that scope was entered. 
+
+When a transaction execution begins, 
+  - `accessed_storage_keys` is initialized to empty, and
+  - `accessed_addresses` is initialized to include
+    - the `tx.sender`, `tx.to` (or the address being created if it is a contract creation transaction)
+    - and the set of all precompiles.
+
+
+### Storage read changes
 
 When an address is either the target of a (`EXTCODESIZE` (`0x3B`), `EXTCODECOPY` (`0x3C`), `EXTCODEHASH` (`0x3F`) or `BALANCE` (`0x31`)) opcode or the target of a (`CALL` (`0xF1`), `CALLCODE` (`0xF2`), `DELEGATECALL` (`0xF4`), `STATICCALL` (`0xFA`)) opcode, the gas costs are computed as follows:
 


### PR DESCRIPTION
This PR clarifies the behaviours about subscope revertals in 2929
PTAL @vbuterin 