### PR TITLE
Updating Comments in EIP 1271

### DIFF
--- a/EIPS/eip-1271.md
+++ b/EIPS/eip-1271.md
@@ -38,7 +38,7 @@ contract ERC1271 {
   /**
    * @dev Should return whether the signature provided is valid for the provided data
    * @param _hash hash of the data that is signed on the behalf of address(this)
-   * @param _signature Signature byte array of the hash
+   * @param _signature Signature byte array associated with _hash
    *
    * MUST return the bytes4 magic value 0x1626ba7e when function passes.
    * MUST NOT modify state (using STATICCALL for solc < 0.5, view modifier for solc > 0.5)

--- a/EIPS/eip-1271.md
+++ b/EIPS/eip-1271.md
@@ -37,8 +37,8 @@ contract ERC1271 {
 
   /**
    * @dev Should return whether the signature provided is valid for the provided data
-   * @param _data Arbitrary length data signed on the behalf of address(this)
-   * @param _signature Signature byte array associated with _data
+   * @param _hash hash of the data that is signed on the behalf of address(this)
+   * @param _signature Signature byte array of the data
    *
    * MUST return the bytes4 magic value 0x1626ba7e when function passes.
    * MUST NOT modify state (using STATICCALL for solc < 0.5, view modifier for solc > 0.5)

--- a/EIPS/eip-1271.md
+++ b/EIPS/eip-1271.md
@@ -38,7 +38,7 @@ contract ERC1271 {
   /**
    * @dev Should return whether the signature provided is valid for the provided data
    * @param _hash hash of the data that is signed on the behalf of address(this)
-   * @param _signature Signature byte array of the data
+   * @param _signature Signature byte array of the hash
    *
    * MUST return the bytes4 magic value 0x1626ba7e when function passes.
    * MUST NOT modify state (using STATICCALL for solc < 0.5, view modifier for solc > 0.5)
@@ -63,7 +63,7 @@ Such a function is important because it allows *other contracts* to validate sig
 
 We believe the name of the proposed function to be appropriate considering that an *authorized* signers providing proper signatures for a given data would see their signature as "valid" by the smart wallet. Hence, an signed action message is only valid when the signer is authorized to perform a given action on the behalf of a smart wallet. 
 
-Two arguments are provided for simplicity of separating the data from the signature, but both could be concatenated in a single byte array if community prefers this.
+Two arguments are provided for simplicity of separating the data hash from the hash signature, but both could be concatenated in a single byte array if community prefers this.
 
 `isValidSignature()` should not be able to modify states in order to prevent `GasToken` minting or similar attack vectors. A gas limit being passed is being considered, but could prevent some interesting use cases like large multisignatures or more costly validation and cryptographic schemes.  
 


### PR DESCRIPTION
Updating the comments according to the early change of the parameter `_data` to be `_hash`.