### PR TITLE
EIP-2929: clarifications

### DIFF
--- a/EIPS/eip-2929.md
+++ b/EIPS/eip-2929.md
@@ -15,7 +15,7 @@ Increases gas cost for `SLOAD`, `*CALL`, `BALANCE`, `EXT*` and `SELFEDESTRUCT` w
 
 ## Abstract
 
-Increase the gas cost of `SLOAD` (`0x54`) to 2100, and the `*CALL` opcode family (`0xf1`, `f2`, `f4`, `fA`), `BALANCE` `0x31` and the `EXT*` opcode family (`0x3b`, `0x3c`, `0x3f`) to 2600. Exempts (i) precompiles, and (ii) addresses and storage slots that have already been accessed in the same transaction. Additionally reforms `SSTORE` metering and `SELFDESTRUCT` to ensure "de-facto storage loads" inherent in those opcodes are priced correctly.
+Increase the gas cost of `SLOAD` (`0x54`) to 2100, and the `*CALL` opcode family (`0xf1`, `f2`, `f4`, `fA`), `BALANCE` `0x31` and the `EXT*` opcode family (`0x3b`, `0x3c`, `0x3f`) to 2600. Exempts (i) precompiles, and (ii) addresses and storage slots that have already been accessed in the same transaction, which get a decreased gas cost. Additionally reforms `SSTORE` metering and `SELFDESTRUCT` to ensure "de-facto storage loads" inherent in those opcodes are priced correctly.
 
 ## Motivation
 
@@ -66,6 +66,8 @@ In all cases, the gas cost is charged and the map is updated at the time that th
 
 For `SLOAD`, if the `(address, storage_key)` pair (where `address` is the address of the contract whose storage is being read) is not yet in `accessed_storage_keys`, charge `COLD_SLOAD_COST` gas and add the pair to `accessed_storage_keys`. If the pair is already in `accessed_storage_keys`, charge `WARM_STORAGE_READ_COST` gas.
 
+Note: For call-variants, the `100`/`2600` cost is applied immediately (exactly like how `700` was charged before this EIP), i.e: before calculating the `63/64ths` available for entering the call. 
+
 ### SSTORE changes
 
 When calling `SSTORE`, check if the `(address, storage_key)` pair is in `accessed_storage_keys`. If it is not, charge an additional `COLD_SLOAD_COST` gas, and add the pair to `accessed_storage_keys`. Additionally, modify the parameters defined in [EIP 2200](https://eips.ethereum.org/EIPS/eip-2200) as follows:
@@ -76,6 +78,7 @@ When calling `SSTORE`, check if the `(address, storage_key)` pair is in `accesse
 | `SSTORE_RESET_GAS` | 5000 | `5000 - COLD_SLOAD_COST` |
 
 The other parameters defined in EIP 2200 are unchanged.
+Note: The constant `SLOAD_GAS` is used in several places in EIP 2200, e.g `SSTORE_SET_GAS - SLOAD_GAS`. Implementations that are using composite definitions have to ensure to update those definitions too.
 
 ### SELFDESTRUCT changes
 


### PR DESCRIPTION
Contains a few clarifications

- Request from @shamatar  to be more clear in the abstract that some ops become cheaper, 
- Clarification (maybe unnecessary), due to an error that was present in geth, found by @shemnon  
- Finding by @shemnon that geth incorrectly had not updated a composite variable 