### PR TITLE
EIP2333 - ETH2 keygen: test vector 0 wasn't updated in #2985

### DIFF
--- a/EIPS/eip-2333.md
+++ b/EIPS/eip-2333.md
@@ -241,9 +241,9 @@ There are no major backwards compatibility issues brought upon by this EIP as it
 
 ```text
 seed = 0xc55257c360c07c72029aebc1b53c05ed0362ada38ead3e3e9efa3708e53495531f09a6987599d18264c1e1c92f2cf141630c7a3c4ab7c81b2f001698e7463b04
-master_SK = 5399117110774477986698372024995405256382522670366369834617409486544348441851
+master_SK = 6083874454709270928345386274498605044986640685124978867557563392430687146096
 child_index = 0
-child_SK = 11812940737387919040225825939013910852517748782307378293770044673328955938106
+child_SK = 20397789859736650942317412262472558107875392172444076792671091975210932703118
 ```
 
 This test case can be extended to test the entire mnemonic-to-`child_SK` stack, assuming [BIP39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) is used as the mnemonic generation mechanism. Using the following parameters, the above seed can be calculated:


### PR DESCRIPTION
## What was wrong

Test vector 0 was not updated in https://github.com/ethereum/EIPs/pull/2985

https://github.com/ethereum/EIPs/pull/2985/files#diff-8caacf51cadcfbe94a39cf606351c359R243

## Correction

Test vector 0 is actually detailed with intermediate value at the bottom of the EIP so this merely copies that information over: https://github.com/ethereum/EIPs/pull/2985/files#diff-8caacf51cadcfbe94a39cf606351c359R294

The correction was checked against the reference implementation at eth2.0-deposits-cli which uses the correct vector:
https://github.com/ethereum/eth2.0-deposit-cli/pull/108/files#diff-909cbf3d1a7e55f1731e90bc1f9a7ad9R5