### PR TITLE
Fix test in EIP-2333

### DIFF
--- a/EIPS/eip-2333.md
+++ b/EIPS/eip-2333.md
@@ -253,13 +253,6 @@ mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon aban
 passphrase = "TREZOR"
 ```
 
-This test case can be extended to test the entire `mnemonic-to -child_SK` stack, assuming [BIP39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) is used as the mnemonic generation mechanism. Using the following parameters, the above seed can be calculated:
-
-```text
-mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
-passphrase = "TREZOR"
-```
-
 ### Test Case 1
 
 ```text


### PR DESCRIPTION
EIP-2333 was recently updated, however one of the test vectors was not.  This updates the relevant test vector with correct values.

It also removes a duplicated paragraph in the text.