### PR TITLE
Bump eipv to 0.0.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
     - language: rust
       cache: cargo
       before_script:
-        - cargo install eipv --version=0.0.5
+        - cargo install eipv --version=0.0.6
       env: TASK='eip-validator'
     - python: 3.3
       env: TASK='codespell'


### PR DESCRIPTION
There was a breakage that caused eipv to fail to compile. The cause was that Cargo will happily replace a package dependency with the latest beta, unless specified differently. I've fixed the code to use beta 2 and updated the dependency requirement to used *exactly` beta 2. See the `eipv` PR here: https://github.com/lightclient/eipv/pull/24