### PR TITLE
Fix eip-3009 relative links

### DIFF
--- a/EIPS/eip-3009.md
+++ b/EIPS/eip-3009.md
@@ -16,7 +16,7 @@ A contract interface that enables transferring of fungible assets via a signed a
 
 ## Abstract
 
-A function called `transferWithAuthorization` to enable meta-transactions and atomic interactions with [ERC-20](./eip-20) token contracts via signatures conforming to the [EIP-712](./eip-712) typed message signing specification.
+A function called `transferWithAuthorization` to enable meta-transactions and atomic interactions with [ERC-20](./eip-20.md) token contracts via signatures conforming to the [EIP-712](./eip-712.md) typed message signing specification.
 
 This enables the user to:
 
@@ -27,11 +27,11 @@ This enables the user to:
 - batch multiple transactions with minimal overhead, and
 - create and perform multiple transactions without having to worry about them failing due to accidental nonce-reuse or improper ordering by the miner.
 
-The popular USD-backed stablecoin [USDC v2](https://etherscan.io/token/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48) implements an expanded form of this spec. This can also be adopted alongside the [EIP-2612](./eip-2612) spec for maximum compatibility with existing applications.
+The popular USD-backed stablecoin [USDC v2](https://etherscan.io/token/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48) implements an expanded form of this spec. This can also be adopted alongside the [EIP-2612](./eip-2612.md) spec for maximum compatibility with existing applications.
 
 ## Motivation
 
-There is an existing spec, [EIP-2612](./eip-2612), that also allows meta-transactions. The two primary differences between this spec and EIP-2612 are that:
+There is an existing spec, [EIP-2612](./eip-2612.md), that also allows meta-transactions. The two primary differences between this spec and EIP-2612 are that:
 
 - EIP-2612 uses sequential nonces, but this uses random 32-byte nonces, and that
 - EIP-2612 relies on the ERC-20 `approve`/`transferFrom` ("ERC-20 allowance") pattern.
@@ -106,7 +106,7 @@ function transferWithAuthorization(
 ) external;
 ```
 
-The arguments `v`, `r`, and `s` can be obtained using the [EIP-712](./eip-712) typed message signing spec.
+The arguments `v`, `r`, and `s` can be obtained using the [EIP-712](./eip-712.md) typed message signing spec.
 
 **Example:**
 


### PR DESCRIPTION
I made a mistake on the previous review of EIP-3009, recommending @petejkim to replace links with relative versions. Although this is correct and appears to work on `eips.ethereum.org`, it doesn't work for linking within Github. As defined in EIP-1, relative links must be of the form `[EIP-XXXX](./eip-xxxx.md)`. I have fixed this in this PR.