### PR TITLE
EIP 1271 Suggest Adding `getSignatureDataHash()`

### DIFF
--- a/EIPS/eip-1271.md
+++ b/EIPS/eip-1271.md
@@ -43,7 +43,7 @@ contract ERC1271 {
    * MUST NOT modify state (using STATICCALL for solc < 0.5, view modifier for solc > 0.5)
    * MUST allow external calls
    */ 
-    function getDataHash(bytes memory _data)
+    function getSignatureDataHash(bytes memory _data)
       public
       view
       returns (bytes32);
@@ -78,9 +78,9 @@ We believe the name of the proposed function to be appropriate considering that 
 
 Two arguments are provided for simplicity of separating the data from the signature, but both could be concatenated in a single byte array if community prefers this.
 
-Each smart contract is free to implement its custom hashing function in `getDataHash()`. The returned hash of the data along with the associated hash signature would be then passed to `isValidSignature()`.
+Each smart contract is free to implement its custom hashing function in `getSignatureDataHash()`. The returned hash of the data along with the associated hash signature would be then passed to `isValidSignature()`.
 
-`isValidSignature()` and `getDataHash()` should not be able to modify states in order to prevent `GasToken` minting or similar attack vectors. A gas limit being passed is being considered, but could prevent some interesting use cases like large multisignatures or more costly validation and cryptographic schemes.  
+`isValidSignature()` and `getSignatureDataHash()` should not be able to modify states in order to prevent `GasToken` minting or similar attack vectors. A gas limit being passed is being considered, but could prevent some interesting use cases like large multisignatures or more costly validation and cryptographic schemes.  
 
 
 

--- a/EIPS/eip-1271.md
+++ b/EIPS/eip-1271.md
@@ -36,6 +36,19 @@ contract ERC1271 {
   bytes4 constant internal MAGICVALUE = 0x1626ba7e;
 
   /**
+   * @dev Should return the hash of an arbitrary data
+   * @param _data Data that should be hashed
+   *
+   * MUST return the bytes32 hash when function passes.
+   * MUST NOT modify state (using STATICCALL for solc < 0.5, view modifier for solc > 0.5)
+   * MUST allow external calls
+   */ 
+    function getDataHash(bytes memory _data)
+      public
+      view
+      returns (bytes32);
+
+  /**
    * @dev Should return whether the signature provided is valid for the provided data
    * @param _data Arbitrary length data signed on the behalf of address(this)
    * @param _signature Signature byte array associated with _data
@@ -65,7 +78,9 @@ We believe the name of the proposed function to be appropriate considering that 
 
 Two arguments are provided for simplicity of separating the data from the signature, but both could be concatenated in a single byte array if community prefers this.
 
-`isValidSignature()` should not be able to modify states in order to prevent `GasToken` minting or similar attack vectors. A gas limit being passed is being considered, but could prevent some interesting use cases like large multisignatures or more costly validation and cryptographic schemes.  
+Each smart contract is free to implement its custom hashing function in `getDataHash()`. The returned hash of the data along with the associated hash signature would be then passed to `isValidSignature()`.
+
+`isValidSignature()` and `getDataHash()` should not be able to modify states in order to prevent `GasToken` minting or similar attack vectors. A gas limit being passed is being considered, but could prevent some interesting use cases like large multisignatures or more costly validation and cryptographic schemes.  
 
 
 


### PR DESCRIPTION
Actually, in a project we are working on, in which we use a modified version of Gnosis Safe, need the hash to be created in a specific way.

And for this, we suggest that this EIP should probably include the method `getSignatureDataHash()` that the Smart Contract should implement for hashing. So, the caller will call this hashing function first to get the bytes32 hash out of the data. And then pass this hash to `isValidSignature()`.