### PR TITLE
1102, 1474: Replace author email with GitHub username

### DIFF
--- a/EIPS/eip-1102.md
+++ b/EIPS/eip-1102.md
@@ -1,7 +1,7 @@
 ---
 eip: 1102
 title: Opt-in account exposure
-author: Paul Bouchon <mail@bitpshr.net>, Erik Marks <rekmarks@protonmail.com>
+author: Paul Bouchon <mail@bitpshr.net>, Erik Marks (@rekmarks)
 discussions-to: https://ethereum-magicians.org/t/eip-1102-opt-in-provider-access/414
 status: Draft
 type: Standards Track

--- a/EIPS/eip-1474.md
+++ b/EIPS/eip-1474.md
@@ -1,7 +1,7 @@
 ---
 eip: 1474
 title: Remote procedure call specification
-author: Paul Bouchon <mail@bitpshr.net>, Erik Marks <rekmarks@protonmail.com>
+author: Paul Bouchon <mail@bitpshr.net>, Erik Marks (@rekmarks)
 discussions-to: https://ethereum-magicians.org/t/eip-remote-procedure-call-specification/1537
 status: Draft
 type: Standards Track


### PR DESCRIPTION
This PR replaces my email address with my GitHub username for EIPs 1102 and 1474, as suggested [here](https://github.com/ethereum/EIPs/pull/3048#issuecomment-711889333).