### PR TITLE
EIP-3030: Update API definition

### DIFF
--- a/EIPS/eip-3030.md
+++ b/EIPS/eip-3030.md
@@ -32,7 +32,7 @@ The situation is not better when the requirement is to execute the validators by
 
 The proposed solution comprises running a specialized node with exclusive access to the secret keys, listening to a simple API (defined in the [Specification](#specification) section), and returning the requested signatures. Operators working under this schema must utilize clients with the adequate feature supporting the consumption of this API.
 
-The focus of this specification is the supply of BLS signatures _on demand_. The aspects of authentication, key management (creation, update, and deletion), pre-image validation, and transport encryption are discussed in the [Rationale](#rationale) section of this document. Moreover, the [Threat Model](#threat-model) section of this document provides a (non-exhaustive) list of threats and attack vectors, along with the suggested related mitigation strategy.
+The focus of this specification is the supply of BLS signatures _on demand_. The aspects of authentication, key management (creation, update, and deletion), and transport encryption are discussed in the [Rationale](#rationale) section of this document. Moreover, the [Threat Model](#threat-model) section of this document provides a (non-exhaustive) list of threats and attack vectors, along with the suggested related mitigation strategy.
 
 ## Specification
 
@@ -64,13 +64,16 @@ Content | `{"keys": "[identifier]"}`
 
 URL Parameter | <br>
 --- | ---
-`identifier` | `Key for which data to sign`
+`:identifier` | `public_key_hex_string_without_0x`
 
 _**Request**_
 
 JSON Body | <br> | <br>
 --- | --- | ---
-`signingRoot` | **Required** | A string representation of a SHA256 Hash.<br>The result of the Ethereum 2.0 function [`compute_signing_root`](https://github.com/ethereum/eth2.0-specs/blob/dev/specs/phase0/beacon-chain.md#compute_signing_root).
+`bls_domain` | **Required** | The BLS Signature domain.<br>As defined in the [specification](https://github.com/ethereum/eth2.0-specs/blob/dev/specs/phase0/beacon-chain.md#domain-types), in lowercase, omitting the `domain` prefix.<br>Supporting `beacon_proposer`, `beacon_attester`, and `randao`.
+`data` | **Required** | The data to be signed.<br>As defined in the specifications for [block](https://github.com/ethereum/eth2.0-APIs/blob/master/types/block.yaml), [attestation](https://github.com/ethereum/eth2.0-APIs/blob/master/types/attestation.yaml), and [epoch](https://github.com/ethereum/eth2.0-APIs/blob/master/types/misc.yaml).
+`fork` | **Required** | A `Fork` object containing previous and current versions.<br>As defined in the [specification](https://github.com/ethereum/eth2.0-APIs/blob/master/types/misc.yaml)
+`genesis_validators_root` | **Required** | A `Hash256` for domain separation and chain versioning.
 <br> | Optional | Any other field will be ignored by the signer
 
 _**Responses**_
@@ -78,9 +81,7 @@ _**Responses**_
 Success | <br>
 --- | ---
 Code |  `200`
-Content | `{"signature": "<signature>"}`
-
-Where signature is a [BLS signature](https://github.com/ethereum/eth2.0-specs/blob/dev/specs/phase0/beacon-chain.md#bls-signatures) byte array encoded as a hexadecimal string.
+Content | `{"signature": "<signature_hex_string>"}`
 
 _or_
 
@@ -102,7 +103,7 @@ Content | `{"error": "Key not found: <identifier>"}`
 
 ### UNIX philosophy: Simple API
 
-This API specification contains only three methods: one for **status**, one for **listing the available keys**, and one to **produce a signature**. There are no methods for authentication, pre-image validation, key management, nor transport encryption.
+This API specification contains only three methods: one for **status**, one for **listing the available keys**, and one to **produce a signature**. There are no methods for authentication, key management, nor transport encryption.
 
 The following subsections discuss aspects to be considered by the client implementers relative to these subjects.
 
@@ -115,14 +116,6 @@ From an API pipeline view, we have two nodes: The validator client (1) that make
 Can be accomplished through the use of an HTTP Request Header. There are several ways to negotiate and issue a valid token to authenticate the communication between the validator client and the remote signer, each of them with potential drawbacks (e.g replay attacks, challenges in distributing the token to the validator client, etc.). In general, any method of authentication must be combined with transport encryption to be effective.
 
 The operator can also implement network Access Control Lists (ACLs) between the validator client's network and the remote signer's network, reducing the attack surface by requiring a potential attacker to be positioned in the same network as the validator client.
-
-#### Pre-image validation
-
-A key feature for a remote signer, pre-image validation, implies that not only the `signingRoot`, but all the required elements needed to perform complete validation of the message, are sent through the wire to obtain a signature.
-
-A control that parses this pre-image will not be breaking this document API specification, as any other field different from `signingRoot` will be ignored by the remote signer.
-
-Implementers should address the additional requirements emerging for each specific validation, such as, slashing protection, as this entails the needs to manage a database and the mechanisms to update it. Also new threats need to be addressed and controlled, among them, attackers looking into tampering the source of data.
 
 #### Key management
 
@@ -143,7 +136,6 @@ If the operator is working with self-signed certificates, it is required that th
   * Secret key: `0x68081afeb7ad3e8d469f87010804c3e8d53ef77d393059a55132637206cc59ec`.
 * Signing root: `0xb6bb8f3765f93f4f1e7c7348479289c9261399a3c6906685e320071a1a13955c`.
 * Expected signature: `0xb5d0c01cef3b028e2c5f357c2d4b886f8e374d09dd660cd7dd14680d4f956778808b4d3b2ab743e890fc1a77ae62c3c90d613561b23c6adaeb5b0e288832304fddc08c7415080be73e556e8862a1b4d0f6aa8084e34a901544d5bb6aeed3a612`.
-
 
 ### `GET /upcheck`
 
@@ -170,7 +162,6 @@ curl -v localhost:9000/upcheck
 <
 * Connection #0 to host localhost left intact
 {"status":"OK"}
-
 ```
 
 ### `GET /keys`
@@ -223,8 +214,6 @@ curl -v localhost:9000/keys
 <
 * Connection #0 to host localhost left intact
 {"error":"Storage error: PermissionDenied"}
-
-
 ```
 
 ### `POST /sign/:identifier`
@@ -233,7 +222,7 @@ curl -v localhost:9000/keys
 # Success
 
 ## Request
-curl -v -X POST -d '{"signingRoot":"0xb6bb8f3765f93f4f1e7c7348479289c9261399a3c6906685e320071a1a13955c"}' -H 'Content-Type: application/json' localhost:9000/sign/b7354252aa5bce27ab9537fd0158515935f3c3861419e1b4b6c8219b5dbd15fcf907bddf275442f3e32f904f79807a2a
+curl -v -X POST -d @payload.json -H 'Content-Type: application/json' localhost:9000/sign/b7354252aa5bce27ab9537fd0158515935f3c3861419e1b4b6c8219b5dbd15fcf907bddf275442f3e32f904f79807a2a
 
 ## Response
 Note: Unnecessary use of -X or --request, POST is already inferred.
@@ -260,7 +249,7 @@ Note: Unnecessary use of -X or --request, POST is already inferred.
 # Bad Request Error
 
 ## Request
-curl -v -X POST -d '{"signingRoot":"0xaa1"}' -H 'Content-Type: application/json' localhost:9000/sign/b7354252aa5bce27ab9537fd0158515935f3c3861419e1b4b6c8219b5dbd15fcf907bddf275442f3e32f904f79807a2a
+curl -v -X POST -d 'foobar' -H 'Content-Type: application/json' localhost:9000/sign/b7354252aa5bce27ab9537fd0158515935f3c3861419e1b4b6c8219b5dbd15fcf907bddf275442f3e32f904f79807a2a
 
 ## Response
 Note: Unnecessary use of -X or --request, POST is already inferred.
@@ -281,12 +270,12 @@ Note: Unnecessary use of -X or --request, POST is already inferred.
 < date: Wed, 30 Sep 2020 02:15:05 GMT
 <
 * Connection #0 to host localhost left intact
-{"error":"Invalid signingRoot: 0xaa1"}
+{"error":"Unable to parse body message from JSON: Error(\"expected ident\", line: 1, column: 2)"}
 
 # No Keys Available
 
 ## Request
-curl -v -X POST -d '{"signingRoot":"0xb6bb8f3765f93f4f1e7c7348479289c9261399a3c6906685e320071a1a13955c"}' -H 'Content-Type: application/json' localhost:9000/sign/000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+curl -v -X POST -d @payload.json -H 'Content-Type: application/json' localhost:9000/sign/000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
 
 ## Response
 Note: Unnecessary use of -X or --request, POST is already inferred.
@@ -316,7 +305,7 @@ Note: Unnecessary use of -X or --request, POST is already inferred.
 ## `chmod` back to 755 to delete them afterwards.
 
 ## Request
-curl -v -X POST -d '{"signingRoot":"0xb6bb8f3765f93f4f1e7c7348479289c9261399a3c6906685e320071a1a13955c"}' -H 'Content-Type: application/json' localhost:9000/sign/b7354252aa5bce27ab9537fd0158515935f3c3861419e1b4b6c8219b5dbd15fcf907bddf275442f3e32f904f79807a2a
+curl -v -X POST -d @payload.json -H 'Content-Type: application/json' localhost:9000/sign/b7354252aa5bce27ab9537fd0158515935f3c3861419e1b4b6c8219b5dbd15fcf907bddf275442f3e32f904f79807a2a
 
 ## Response
 Note: Unnecessary use of -X or --request, POST is already inferred.
@@ -346,8 +335,7 @@ Repository Url | Language | Organization | Commentary
 --- | --- | --- | ---
 [BLS Remote Signer](https://github.com/sigp/rust-bls-remote-signer) | Rust | Sigma Prime | Supports proposed specification.
 [Web3signer](https://github.com/PegaSysEng/web3signer) | Java | PegaSys | Supports proposed specification, although with [slightly different methods](https://pegasyseng.github.io/web3signer/web3signer-eth2.html):<br>{`/sign` => `/api/v1/eth2/sign`, `/publicKeys` => `/api/v1/eth2/publicKeys`}.
-
-The Prysm client supports a [Remote Signing Wallet](https://docs.prylabs.network/docs/wallet/remote/), however its API requires using gRPC as transport.
+[Remote Signing Wallet](https://docs.prylabs.network/docs/wallet/remote/) | Golang | Prysmatics Labs | Supports both gRPC and JSON over HTTP.
 
 ## Security Considerations
 
@@ -358,13 +346,13 @@ Let's consider the following threats and their mitigations:
 Threat | Mitigation(s)
 --- | ---
 An attacker can spoof the validator client. | See the discussion at [Authentication](#authentication).
-An attacker can send a crafted message to the signer. | See discussion at  [Pre-image validation](#pre-image-validation).
+An attacker can send a crafted message to the signer, leading to a slashing offense. | It is the responsibility of the operator of the remote signer to add a validation module, as discussed at [Implementation of additional features](#implementation-of-additional-features).
 An attacker can create, update, or delete secret keys. | Keys are not to be writable via any interface of the remote signer.
 An attacker can repudiate a sent message. | Implement logging in the signer. Enhance it by sending logs to a syslog box.
 An attacker can disclose the contents of a private key by retrieving the key from storage. | Storage in Hardware security module (HSM).<br>_or_<br>Storage in Secrets management applications (e.g. Hashicorp Vault).
 An attacker can eavesdrop on the uploading of a secret key. | Upload the keys using a secure channel, based on each storage specification.
 An attacker can eavesdrop on the retrieval of a key from the remote signer. | Always pass the data between storage and remote signer node using a secure channel.
-An attacker can dump the memory in the remote signer to disclose a secret key. |  Prevent physical access to the node running the remote signer.<br>_or_<br>Prevent access to the terminal of the node running the remote signer: Logs being sent to a syslog box. Deployments triggered by a simple, non-parameterized API.<br>_or_<br>Implement zeroization of the secret key at memory.<br>_or_<br>Explore the compilation and running of the remote signer in a Trusted execution environment (TEE).
+An attacker can dump the memory in the remote signer to disclose a secret key. | Prevent physical access to the node running the remote signer.<br>_or_<br>Prevent access to the terminal of the node running the remote signer: Logs being sent to a syslog box. Deployments triggered by a simple, non-parameterized API.<br>_or_<br>Implement zeroization of the secret key at memory.<br>_or_<br>Explore the compilation and running of the remote signer in a Trusted execution environment (TEE).
 An attacker can DoS the remote signer. | Implement IP filtering.<br>_or_<br>Implement Rate limiting.
 
 ## Copyright

--- a/EIPS/eip-3030.md
+++ b/EIPS/eip-3030.md
@@ -83,6 +83,8 @@ Success | <br>
 Code |  `200`
 Content | `{"signature": "<signature_hex_string>"}`
 
+Where signature is a [BLS signature](https://github.com/ethereum/eth2.0-specs/blob/dev/specs/phase0/beacon-chain.md#bls-signatures) byte array encoded as a hexadecimal string.
+
 _or_
 
 Error | <br>


### PR DESCRIPTION
Updates the API definition based on discussions at #3030.

- Instead of receiving `signingRoot`, the validator client must send to the remote signer `bls_domain`, object `data`, `fork`, and `genesis_validators_root`.
- Removes elements of rationale arguing in favor of not receiving the pre-image to be signed.
- Improves test cases.
- Adds the Remote Signing Wallet of Prysmatic Labs as an implementation.
- Adds an item to the threat model.
