### PR TITLE
Update eip-2612

### DIFF
--- a/EIPS/eip-2612.md
+++ b/EIPS/eip-2612.md
@@ -43,15 +43,13 @@ While it may be tempting to introduce `*_by_signature` counterparts for every ER
 
 
 ## Specification
-A new method 
-```solidity
-function permit(address owner, address spender, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s)
+Three new functions are added to the ERC20 ABI:
+```sol
+function permit(address owner, address spender, uint value, uint deadline, uint8 v, bytes32 r, bytes32 s) external
+function nonces(address owner) external view returns (uint)
+function DOMAIN_SEPARATOR() external view returns (bytes32)
 ```
-and a new storage item
-```solidity
-mapping(address=>uint256) nonces;
-```
-with accompanying getter function are introduced, the semantics of which are as follows:
+The semantics of which are as follows:
 
 For all addresses `owner`, `spender`, uint256s `value`, `deadline` and `nonce`, uint8 `v`, bytes32 `r` and `s`, 
 a call to `permit(owner, spender, value, deadline, v, r, s)` will set 
@@ -66,25 +64,32 @@ if and only if the following conditions are met:
 - `nonces[owner]` (before the state update) is equal to `nonce`.
 - `r`, `s` and `v` is a valid `secp256k1` signature from `owner` of the message:
 
-in solidity pseudocode:
-```solidity
-keccak256(hex"1901"
-          ++ keccak256(
-                keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)")
-             ++ keccak256(bytes(erc20name))
-             ++ keccak256(bytes(version))
-             ++ bytes(chainid)
-             ++ bytes(tokenAddress))
-          ++ keccak256(
-                 keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)")
-              ++ bytes(owner)
-              ++ bytes(spender)
-              ++ bytes(value)
-              ++ bytes(nonce)
-              ++ bytes(deadline))
+```sol
+keccak256(abi.encodePacked(
+   hex"1901",
+   DOMAIN_SEPARATOR,
+   keccak256(abi.encodePacked(
+            keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)"),
+            owner,
+            spender,
+            value,
+            nonce,
+            deadline))
 ))
 ```
-where `++` denotes bytestring concatenation, `tokenAddress` is the address of the token contract, `chainid` is the chain id of the network it is deployed to and `erc20name` is the name of the token as defined by `ERC-20`. `version` is a `string` defined at contract deployment which remains constant throughout the lifetime of the contract, but is otherwise unconstrained.
+where `DOMAIN_SEPARATOR` is defined according to EIP-712. The `DOMAIN_SEPARATOR` should be unique to the contract and chain to prevent replay attacks from other domains,
+and satisfy the requirements of EIP-712, but is otherwise unconstrained.
+A common choice for `DOMAIN_SEPARATOR` is:
+```solidity
+DOMAIN_SEPARATOR = keccak256(
+    abi.encode(
+        keccak256('EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)'),
+        keccak256(bytes(name)),
+        keccak256(bytes(version)),
+        chainid,
+        address(this)
+));
+```
 
 In other words, the message is the ERC-712 typed structure:
     
@@ -190,6 +195,8 @@ Since the ecrecover precompile fails silently and just returns the zero address 
 Signed `Permit` messages are censorable. The relaying party can always choose to not submit the `Permit` after having received it, withholding the option to submit it. The `deadline` parameter is one mitigation to this. If the signing party holds ETH they can also just submit the `Permit` themselves, which can render previously signed `Permit`s invalid.
 
 The standard [ERC-20 race condition for approvals](https://swcregistry.io/docs/SWC-114) applies to `permit` as well.
+
+If the `DOMAIN_SEPARATOR` contains the `chainId` and is defined at contract deployment instead of reconstructed for every signature, there is a risk of possible replay attacks between chains in the event of a fututre chain split.
 
 ## Copyright
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
Incorporates the suggestion of @wighawag to leave DOMAIN_SEPARATOR out of the scope of this standard, and points out a commonly voiced safety concern with respect to `permit` and future chain forks