### PR TITLE
EIP-3085: wallet_addEthereumChain

### DIFF
--- a/EIPS/eip-2016.md
+++ b/EIPS/eip-2016.md
@@ -2,7 +2,7 @@
 eip: 2016
 title: Wallet Add Ethereum Chain RPC Method (`wallet_addEthereumChain`)
 author: Erik Mars (@rekmarks), Pedro Gomes (@pedrouid)
-discussions-to: https://github.com/ethereum/EIPs/issues/
+discussions-to: https://github.com/ethereum/EIPs/issues/3086
 status: Draft
 type: Standards Track
 category: Interface

--- a/EIPS/eip-2016.md
+++ b/EIPS/eip-2016.md
@@ -1,7 +1,7 @@
 ---
 eip: 2016
 title: Wallet Add Ethereum Chain RPC Method (`wallet_addEthereumChain`)
-author: Erik Mars (@rekmarks), Pedro Gomes (@pedrouid)
+author: Erik Marks (@rekmarks), Pedro Gomes (@pedrouid)
 discussions-to: https://github.com/ethereum/EIPs/issues/3086
 status: Draft
 type: Standards Track

--- a/EIPS/eip-2016.md
+++ b/EIPS/eip-2016.md
@@ -2,7 +2,7 @@
 eip: 2016
 title: Wallet Add Ethereum Chain RPC Method (`wallet_addEthereumChain`)
 author: Erik Mars (@rekmarks), Pedro Gomes (@pedrouid)
-discussions-to: about:blank
+discussions-to: https://github.com/ethereum/EIPs/issues/
 status: Draft
 type: Standards Track
 category: Interface

--- a/EIPS/eip-2016.md
+++ b/EIPS/eip-2016.md
@@ -71,8 +71,8 @@ Only the `chainId` is required per this specification, but a wallet **MAY** requ
 - `rpcUrl`
   - If provided, **MUST** specify the URL of the RPC endpoint used to communicate with the chain.
 
-All URL string fields **SHOULD** include the protocol component of the URL.
-If the protocol of the URL is HTTP, HTTPS **SHOULD** be used, and the `https://` prefix **SHOULD** be included.
+All URL string fields **MUST** include the protocol component of the URL.
+If the protocol of the URL is HTTP, HTTPS **SHOULD** be used.
 
 #### Returns
 

--- a/EIPS/eip-2016.md
+++ b/EIPS/eip-2016.md
@@ -1,0 +1,237 @@
+---
+eip: 2016
+title: Wallet Add Ethereum Chain RPC Method (`wallet_addEthereumChain`)
+author: Erik Mars (@rekmarks), Pedro Gomes (@pedrouid)
+discussions-to: about:blank
+status: Draft
+type: Standards Track
+category: Interface
+created: 2020-11-01
+requires: 155, 695
+---
+
+## Abstract
+
+The `wallet_addEthereumChain` RPC method allows Ethereum applications ("dapps") to suggest chains to be added to the wallet application.
+The caller must specify a chain ID and some chain metadata.
+The wallet application may arbitrarily refuse or accept the request.
+`true` is returned if the chain was added, and an error otherwise.
+
+Important cautions for implementers of this method are included in the [Security Considerations](#security-considerations) section.
+
+## Motivation
+
+Although Mainnet is by far the most important, a dapp may require the user to interact with other Ethereum chains in order to function.
+Such a chain may or may not be supported by the user's wallet application.
+`wallet_addEthereumChain` enables dapps to request any necessary chains to be added to the user's wallet.
+This provides UX benefits for dapps and wallets that want to provide such functionality.
+
+## Specification
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC-2119](https://www.ietf.org/rfc/rfc2119.txt).
+
+### `wallet_addEthereumChain`
+
+The method takes a `chainId` and some chain metadata, returning `true` if the chain was added to the wallet, and an error otherwise.
+
+The wallet **MAY** reject the request for any reason. The wallet **MUST** reject the request if the `chainId` is improperly formatted.
+
+> Note that this method makes **no** statement about whether the wallet should change the user's currently selected chain, if the wallet has a concept thereof.
+
+#### Parameters
+
+```typescript
+interface AddEthereumChainParams {
+  chainId: string;
+  blockExplorerUrl?: string;
+  chainName?: string;
+  nativeCurrency?: {
+    name: string;
+    symbol: string;
+    decimals: number;
+  };
+  rpcUrl?: string;
+}
+```
+
+Only the `chainId` is required per this specification, but a wallet **MAY** require any other fields listed, and impose additional requirements on them.
+
+- `chainId`
+  - **MUST** specify the integer ID of the chain as a hexadecimal string, per the [`eth_chainId`](./eip-695.md) Ethereum RPC method.
+- `blockExplorerUrl`
+  - If provided, **MUST** specify the URL of a block explorer web site for the chain.
+- `chainName`
+  - If provided, **MUST** specify a human-readable name for the chain.
+- `nativeCurrency`
+  - If provided, **MUST** describe the native currency of the chain using the `name`, `symbol`, and `decimals` fields.
+- `rpcUrl`
+  - If provided, **MUST** specify the URL of the RPC endpoint used to communicate with the chain.
+
+All URL string fields **SHOULD** include the protocol component of the URL.
+If the protocol of the URL is HTTP, HTTPS **SHOULD** be used, and the `https://` prefix **SHOULD** be included.
+
+#### Returns
+
+The method **MUST** return the boolean value `true` if the request was successful, and an error otherwise.
+
+If a chain with the provided parameters was already added, the request is considered successful, and the method **MUST** return the boolean value `true`.
+
+The wallet **MAY** define what it means for a chain to be "already added", but care should be taken to protect user security.
+The wallet **SHOULD NOT** allow the same `chainId` to be added multiple times.
+See [Security Considerations](#security-considerations) for more information.
+
+### Examples
+
+These examples use JSON-RPC, but the method could be implemented using other RPC protocols.
+
+To add the Goerli test chain:
+
+```json
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "method": "wallet_addEthereumChain",
+  "params": [
+    {
+      "chainId": "0x5",
+      "chainName": "Goerli",
+      "rpcUrl": "https://goerli.infura.io/v3/406405f9c65348f99d0d5c27104b2213",
+      "nativeCurrency": {
+        "name": "Goerli ETH",
+        "symbol": "gorETH"
+      },
+      "blockExplorerUrl": "https://goerli.etherscan.io"
+    }
+  ]
+}
+```
+
+To add POA Network's xDAI chain:
+
+```json
+{
+  "id":1,
+  "jsonrpc": "2.0",
+  "method": "wallet_addEthereumChain",
+  "params": [
+    {
+      "chainId": "0x64",
+      "chainName": "xDAI Chain",
+      "rpcUrl": "https://dai.poa.network",
+      "nativeCurrency": {
+        "name": "xDAI",
+        "symbol": "xDAI",
+        "decimals": 18,
+      }
+    }
+  ]
+}
+```
+
+A success response:
+
+```json
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "result": true
+}
+```
+
+A failure response:
+
+```json
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "error": {
+    "code": 4001,
+    "message": "The user rejected the request."
+  }
+}
+```
+
+## Rationale
+
+The design of `wallet_addEthereumChain` is deliberately ignorant of what it means to "add" a chain to a wallet.
+The meaning of "adding" a chain to a wallet depends on the wallet implementation.
+Ultimately, neither the user nor the dapp can now whether adding the chain "worked" until they have successfully interacted with it.
+
+When calling the method, specifying the `chainId` will always be necessary, since in the universe of Ethereum chains, the [EIP-155](./eip-155.md) chain ID is effectively the GUID of a chain.
+The remaining parameters amount to what, in the estimation of authors, a wallet will minimally require in order to effectively support a chain and accurately represent it to the user.
+The network ID (per the `net_version` RPC method) was omitted since it is effectively superseded by the chain ID.
+
+For [security reasons](#security-considerations), a wallet should always attempt to validate the chain metadata provided by the dapp, and may choose to fetch the metadata elsewhere entirely.
+Either way, there's no way to know what the wallet will _need_ with respect to the chain metadata.
+Therefore, all parameters except `chainId` are listed as optional, even though a wallet may require them in practice.
+
+This specification does not mandate that the wallet "switches" its active chain, if the result is successful.
+
+For related work, see [EIP-2015](./eip-2015.md).
+
+For requests of this feature in the community, see e.g. [this GitHub issue](https://github.com/MetaMask/metamask-extension/issues/3604).
+
+## Security Considerations
+
+`wallet_addEthereumChain` is a powerful method that exposes the end user to serious risks if implemented incorrectly.
+Most of these risks can be avoided by validating the request data in the wallet, and clearly disambiguating different chains in the wallet UI.
+
+### Chain IDs
+
+Since the chain ID used for signing determines which chain a transaction is valid for, handling the chain ID correctly is of utmost importance.
+The wallet should:
+
+- Ensure that a submitted chain ID is valid.
+  - It should be submitted as a `0x`-prefixed hexadecimal string per [EIP-695](./eip-695.md), and parse to an integer number.
+- Prevent the same chain ID from being added multiple times, for example with different RPC URLs.
+- Only use the submitted chain ID to sign transactions, **never** a chain ID received from an RPC endpoint.
+  - A malicious or faulty endpoint could return arbitrary chain IDs, and potentially cause the user to sign transactions for unintended chains.
+- Verify that the specified chain ID matches the return value of `eth_chainId` from the endpoint.
+  - This should be done before any other interactions with the endpoint.
+
+### RPC Endpoints
+
+Wallets generally interact with chains via an RPC endpoint, identified by some URL.
+Most wallets ship with a set of chains and corresponding trusted RPC endpoints.
+The endpoints identified by the `rpcUrl` parameter cannot be assumed to be honest or even correct.
+Moreover, even trusted endpoints endpoints can expose users to privacy risks depending on their data collection practices.
+
+Therefore, the wallet should:
+
+- Inform users that their on-chain activity and IP address will be exposed to the endpoint.
+- If the endpoint is unknown to the wallet, inform users that the endpoint may behave in unexpected ways.
+- Observe good web security practices when interacting with the endpoint, such as require HTTPS.
+
+### UX
+
+Adding a new chain to the wallet can have significant implications for the functionality of the wallet and the experience of the user.
+A chain should never be added without the explicit consent of the user, and different chains should be clearly differentiated in the wallet UI.
+In service of these goals, the wallet should:
+
+- When receiving a `wallet_addEthereumChain` request, display a user confirmation informing the user that a specific dapp has requested that the chain be added.
+  - The confirmation used in [EIP-1102](./eip-1102.md) may serve as a point of reference.
+- Ensure that any chain metadata, such as `nativeCurrency` and `blockExplorerUrl`, are validated and used to maximum effect in the UI.
+- If the wallet UI has a concept of a "currently selected" or "currently active" chain, ensure that the user understands when a chain added using `wallet_addEthereumChain` becomes selected.
+
+### Validating Chain Data
+
+A wallet that implements `wallet_addEthereumChain` should expect to encounter requests for chains completely unknown to the wallet maintainers.
+That said, community resources exist that can be leveraged to verify requests for many Ethereum chains.
+The wallet should maintain a list of known chains, and verify requests add chains against that list, perhaps preferring data from the list over data submitted with a `wallet_addEthereumChain` request.
+
+At present, such community resources include:
+
+- [chainId.network](https://chainid.network)
+
+## References
+
+- [chainId.network](https://chainid.network)
+- Related EIPs
+  - [EIP-155: Simple replay attack protection](./eip-155.md)
+  - [EIP-695: Create `eth_chainId` method for JSON-RPC](./eip-695.md)
+  - [EIP-1102: Opt-in Account Exposure](./eip-1102.md)
+  - [EIP-2015: Wallet Update Chain JSON-RPC Method (`wallet_updateChain`)](./eip-2015.md)
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/EIPS/eip-2016.md
+++ b/EIPS/eip-2016.md
@@ -10,6 +10,10 @@ created: 2020-11-01
 requires: 155, 695
 ---
 
+## Simple Summary
+
+An RPC method for adding Ethereum chains to wallet applications.
+
 ## Abstract
 
 The `wallet_addEthereumChain` RPC method allows Ethereum applications ("dapps") to suggest chains to be added to the wallet application.

--- a/EIPS/eip-3085.md
+++ b/EIPS/eip-3085.md
@@ -7,7 +7,7 @@ status: Draft
 type: Standards Track
 category: Interface
 created: 2020-11-01
-requires: 155, 695
+requires: 155, 695, 3091
 ---
 
 ## Simple Summary

--- a/EIPS/eip-3085.md
+++ b/EIPS/eip-3085.md
@@ -19,7 +19,7 @@ An RPC method for adding Ethereum chains to wallet applications.
 The `wallet_addEthereumChain` RPC method allows Ethereum applications ("dapps") to suggest chains to be added to the wallet application.
 The caller must specify a chain ID and some chain metadata.
 The wallet application may arbitrarily refuse or accept the request.
-`true` is returned if the chain was added, and an error otherwise.
+`null` is returned if the chain was added, and an error otherwise.
 
 Important cautions for implementers of this method are included in the [Security Considerations](#security-considerations) section.
 
@@ -37,7 +37,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 ### `wallet_addEthereumChain`
 
 The method accepts a single object parameter, with a `chainId` and some chain metadata.
-The method returns `true` if the chain was added to the wallet, and an error otherwise.
+The method returns `null` if the chain was added to the wallet, and an error otherwise.
 
 The wallet **MAY** reject the request for any reason.
 The wallet **MUST** reject the request if the `chainId` is improperly formatted.
@@ -147,7 +147,7 @@ A success response:
 {
   "id": 1,
   "jsonrpc": "2.0",
-  "result": true
+  "result": null
 }
 ```
 

--- a/EIPS/eip-3085.md
+++ b/EIPS/eip-3085.md
@@ -36,16 +36,21 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ### `wallet_addEthereumChain`
 
-The method takes a `chainId` and some chain metadata, returning `true` if the chain was added to the wallet, and an error otherwise.
+The method accepts a single object parameter, with a `chainId` and some chain metadata.
+The method returs `true` if the chain was added to the wallet, and an error otherwise.
 
-The wallet **MAY** reject the request for any reason. The wallet **MUST** reject the request if the `chainId` is improperly formatted.
+The wallet **MAY** reject the request for any reason.
+The wallet **MUST** reject the request if the `chainId` is improperly formatted.
+The wallet **MUST** reject the request if the wallet does not support the chain with the specified `chainId`.
 
 > Note that this method makes **no** statement about whether the wallet should change the user's currently selected chain, if the wallet has a concept thereof.
 
 #### Parameters
 
+`wallet_addEthereumChain` accepts a single object parameter, specified by the following TypeScript interface:
+
 ```typescript
-interface AddEthereumChainParams {
+interface AddEthereumChainParameters {
   chainId: string;
   blockExplorerUrl?: string;
   chainName?: string;
@@ -62,8 +67,11 @@ Only the `chainId` is required per this specification, but a wallet **MAY** requ
 
 - `chainId`
   - **MUST** specify the integer ID of the chain as a hexadecimal string, per the [`eth_chainId`](./eip-695.md) Ethereum RPC method.
+  - The wallet **SHOULD** compare the specified `chainId` value with the `eth_chainId` return value from the endpoint.
+    If these values are not identical, the wallet **MUST** reject the request.
 - `blockExplorerUrl`
   - If provided, **MUST** specify the URL of a block explorer web site for the chain.
+  - The block explorer API routes **SHOULD** be compatible with [EIP-3091](./eip-3091.md).
 - `chainName`
   - If provided, **MUST** specify a human-readable name for the chain.
 - `nativeCurrency`
@@ -72,13 +80,13 @@ Only the `chainId` is required per this specification, but a wallet **MAY** requ
   - If provided, **MUST** specify the URL of the RPC endpoint used to communicate with the chain.
 
 All URL string fields **MUST** include the protocol component of the URL.
-If the protocol of the URL is HTTP, HTTPS **SHOULD** be used.
+HTTPS **SHOULD** be used.
 
 #### Returns
 
-The method **MUST** return the boolean value `true` if the request was successful, and an error otherwise.
+The method **MUST** return `null` if the request was successful, and an error otherwise.
 
-If a chain with the provided parameters was already added, the request is considered successful, and the method **MUST** return the boolean value `true`.
+If a chain with the provided parameters was already added, the request is considered successful, and the method **MUST** return `null`.
 
 The wallet **MAY** define what it means for a chain to be "already added", but care should be taken to protect user security.
 The wallet **SHOULD NOT** allow the same `chainId` to be added multiple times.
@@ -99,10 +107,11 @@ To add the Goerli test chain:
     {
       "chainId": "0x5",
       "chainName": "Goerli",
-      "rpcUrl": "https://goerli.infura.io/v3/406405f9c65348f99d0d5c27104b2213",
+      "rpcUrl": "https://goerli.infura.io/v3/INSERT_API_KEY_HERE",
       "nativeCurrency": {
         "name": "Goerli ETH",
-        "symbol": "gorETH"
+        "symbol": "gorETH",
+        "decimals": 18
       },
       "blockExplorerUrl": "https://goerli.etherscan.io"
     }
@@ -114,7 +123,7 @@ To add POA Network's xDAI chain:
 
 ```json
 {
-  "id":1,
+  "id": 1,
   "jsonrpc": "2.0",
   "method": "wallet_addEthereumChain",
   "params": [
@@ -125,7 +134,7 @@ To add POA Network's xDAI chain:
       "nativeCurrency": {
         "name": "xDAI",
         "symbol": "xDAI",
-        "decimals": 18,
+        "decimals": 18
       }
     }
   ]
@@ -172,8 +181,6 @@ Therefore, all parameters except `chainId` are listed as optional, even though a
 This specification does not mandate that the wallet "switches" its active chain, if the result is successful.
 
 For related work, see [EIP-2015](./eip-2015.md).
-
-For requests of this feature in the community, see e.g. [this GitHub issue](https://github.com/MetaMask/metamask-extension/issues/3604).
 
 ## Security Considerations
 
@@ -222,19 +229,6 @@ In service of these goals, the wallet should:
 A wallet that implements `wallet_addEthereumChain` should expect to encounter requests for chains completely unknown to the wallet maintainers.
 That said, community resources exist that can be leveraged to verify requests for many Ethereum chains.
 The wallet should maintain a list of known chains, and verify requests add chains against that list, perhaps preferring data from the list over data submitted with a `wallet_addEthereumChain` request.
-
-At present, such community resources include:
-
-- [chainId.network](https://chainid.network)
-
-## References
-
-- [chainId.network](https://chainid.network)
-- Related EIPs
-  - [EIP-155: Simple replay attack protection](./eip-155.md)
-  - [EIP-695: Create `eth_chainId` method for JSON-RPC](./eip-695.md)
-  - [EIP-1102: Opt-in Account Exposure](./eip-1102.md)
-  - [EIP-2015: Wallet Update Chain JSON-RPC Method (`wallet_updateChain`)](./eip-2015.md)
 
 ## Copyright
 

--- a/EIPS/eip-3085.md
+++ b/EIPS/eip-3085.md
@@ -1,5 +1,5 @@
 ---
-eip: 2016
+eip: 3085
 title: Wallet Add Ethereum Chain RPC Method (`wallet_addEthereumChain`)
 author: Erik Marks (@rekmarks), Pedro Gomes (@pedrouid)
 discussions-to: https://github.com/ethereum/EIPs/issues/3086

--- a/EIPS/eip-3085.md
+++ b/EIPS/eip-3085.md
@@ -25,8 +25,8 @@ Important cautions for implementers of this method are included in the [Security
 
 ## Motivation
 
-Although Mainnet is by far the most important, a dapp may require the user to interact with other Ethereum chains in order to function.
-Such a chain may or may not be supported by the user's wallet application.
+A dapp may require the user to interact with multiple Ethereum chains in order to function.
+A may or may not be supported by the user's wallet application.
 `wallet_addEthereumChain` enables dapps to request any necessary chains to be added to the user's wallet.
 This provides UX benefits for dapps and wallets that want to provide such functionality.
 
@@ -88,7 +88,6 @@ The method **MUST** return `null` if the request was successful, and an error ot
 
 If a chain with the provided parameters was already added, the request is considered successful, and the method **MUST** return `null`.
 
-The wallet **MAY** define what it means for a chain to be "already added", but care should be taken to protect user security.
 The wallet **SHOULD NOT** allow the same `chainId` to be added multiple times.
 See [Security Considerations](#security-considerations) for more information.
 
@@ -197,8 +196,7 @@ The wallet should:
 - Prevent the same chain ID from being added multiple times, for example with different RPC URLs.
 - Only use the submitted chain ID to sign transactions, **never** a chain ID received from an RPC endpoint.
   - A malicious or faulty endpoint could return arbitrary chain IDs, and potentially cause the user to sign transactions for unintended chains.
-- Verify that the specified chain ID matches the return value of `eth_chainId` from the endpoint.
-  - This should be done before any other interactions with the endpoint.
+- Verify that the specified chain ID matches the return value of `eth_chainId` from the endpoint, as described in [this specification](#parameters).
 
 ### RPC Endpoints
 
@@ -228,7 +226,8 @@ In service of these goals, the wallet should:
 
 A wallet that implements `wallet_addEthereumChain` should expect to encounter requests for chains completely unknown to the wallet maintainers.
 That said, community resources exist that can be leveraged to verify requests for many Ethereum chains.
-The wallet should maintain a list of known chains, and verify requests add chains against that list, perhaps preferring data from the list over data submitted with a `wallet_addEthereumChain` request.
+The wallet should maintain a list of known chains, and verify requests add chains against that list.
+Indeed, unless there are good reasons not to, the wallet should _prefer its own chain metadata_ over anything submitted with a `wallet_addEthereumChain` request.
 
 ## Copyright
 

--- a/EIPS/eip-3085.md
+++ b/EIPS/eip-3085.md
@@ -37,7 +37,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 ### `wallet_addEthereumChain`
 
 The method accepts a single object parameter, with a `chainId` and some chain metadata.
-The method returs `true` if the chain was added to the wallet, and an error otherwise.
+The method returns `true` if the chain was added to the wallet, and an error otherwise.
 
 The wallet **MAY** reject the request for any reason.
 The wallet **MUST** reject the request if the `chainId` is improperly formatted.

--- a/EIPS/eip-3085.md
+++ b/EIPS/eip-3085.md
@@ -50,7 +50,7 @@ The wallet **MUST** reject the request if the wallet does not support the chain 
 `wallet_addEthereumChain` accepts a single object parameter, specified by the following TypeScript interface:
 
 ```typescript
-interface AddEthereumChainParameters {
+interface AddEthereumChainParameter {
   chainId: string;
   blockExplorerUrl?: string;
   chainName?: string;


### PR DESCRIPTION
Rendered file: https://github.com/rekmarks/EIPs/blob/2016/EIPS/eip-3085.md

This PR adds EIP-3085, which introduces the `wallet_addEthereumChain` RPC method. It's basically [EIP-2015](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-2015.md), without requiring the network to be switched.

I think 2015 is a great idea, but wallets may desire an RPC method that only adds a chain, without requiring that the network is changed. For example, allowing dapps to request network changes is bound to cause UX issues, especially as we see dapps moving to different layer 2 chains.

2015 and 3085 can proceed independently of each other.

Co-author credits go to @pedrouid 