### PR TITLE
Add chain id to 2930

### DIFF
--- a/EIPS/eip-2930.md
+++ b/EIPS/eip-2930.md
@@ -16,7 +16,7 @@ Adds a transaction type which contains an access list, a list of addresses and s
 
 ## Abstract
 
-We introduce a new [EIP-2718](./eip-2718.md) transaction type, with the format `rlp([3, [nonce, gasPrice, gasLimit, to, value, data, access_list, senderV, senderR, senderS]])`.
+We introduce a new [EIP-2718](./eip-2718.md) transaction type, with the format `rlp([3, [chainId, nonce, gasPrice, gasLimit, to, value, data, access_list, senderV, senderR, senderS]])`.
 
 The `access_list` specifies a list of addresses and storage keys; these addresses and storage keys are added into the `accessed_addresses` and `accessed_storage_keys` global sets (introduced in [EIP-2929](./eip-2929.md)). A gas cost is charged, though at a discount relative to the cost of accessing outside the list.
 
@@ -37,7 +37,7 @@ This EIP serves two functions:
 | `ACCESS_LIST_STORAGE_KEY_COST` | 1900 |
 | `ACCESS_LIST_ADDRESS_COST` | 2400 |
 
-As of `FORK_BLOCK_NUMBER`, we introduce a new transaction type, with the format `rlp([3, [nonce, gasPrice, gasLimit, to, value, data, access_list, senderV, senderR, senderS]])`. The signing hash would be the hash of the RLP of the entire data structure but popping the last three items representing the signature from the inner list: `rlp([3, [nonce, gasPrice, gasLimit, to, value, data, access_list]])`.
+As of `FORK_BLOCK_NUMBER`, we introduce a new transaction type, with the format `rlp([3, [nonce, gasPrice, gasLimit, to, value, data, access_list, senderV, senderR, senderS]])`. The signing hash would be the hash of the RLP of the entire data structure but popping the last three items representing the signature from the inner list: `rlp([3, [chainId, nonce, gasPrice, gasLimit, to, value, data, access_list]])`.
 
 For the transaction to be valid, `access_list` must be of type `[[{20 bytes}, [{32 bytes}...]]...]`, where `...` means "zero or more of the thing to the left". For example, the following is a valid access list (all hex strings would in reality be in byte representation):
 
@@ -90,6 +90,8 @@ def process_access_list(access_list) -> Tuple[List[Set[Address], Set[Pair[Addres
 ```
 
 The access list is NOT charged per-byte fees like tx data is; the per-item costs described above are meant to cover the bandwidth costs of the access list data in addition to the costs of accessing those accounts and storage keys when evaluating the transaction.
+
+Additionally, the `chainId` field must be equal to either the chain id of the current network or `0` if it is unprotected.
 
 ## Rationale
 

--- a/EIPS/eip-2930.md
+++ b/EIPS/eip-2930.md
@@ -37,7 +37,7 @@ This EIP serves two functions:
 | `ACCESS_LIST_STORAGE_KEY_COST` | 1900 |
 | `ACCESS_LIST_ADDRESS_COST` | 2400 |
 
-As of `FORK_BLOCK_NUMBER`, we introduce a new transaction type, with the format `rlp([1, [chainId, nonce, gasPrice, gasLimit, to, value, data, access_list, senderV, senderR, senderS]])`. The signing hash would be the hash of the RLP of the entire data structure but popping the last three items representing the signature from the inner list: `rlp([1, [chainId, nonce, gasPrice, gasLimit, to, value, data, access_list]])`.
+As of `FORK_BLOCK_NUMBER`, we introduce a new transaction type, with the format `rlp([1, [chainId, nonce, gasPrice, gasLimit, to, value, data, access_list, senderV, senderR, senderS]])`. The signing hash would be the hash of the RLP of the entire data structure but popping the last three items representing the signature from the inner list: `rlp([1, [chainId, nonce, gasPrice, gasLimit, to, value, data, access_list]])`. `chainId` is defined to be an integer of arbitrary size.
 
 For the transaction to be valid, `access_list` must be of type `[[{20 bytes}, [{32 bytes}...]]...]`, where `...` means "zero or more of the thing to the left". For example, the following is a valid access list (all hex strings would in reality be in byte representation):
 

--- a/EIPS/eip-2930.md
+++ b/EIPS/eip-2930.md
@@ -37,7 +37,7 @@ This EIP serves two functions:
 | `ACCESS_LIST_STORAGE_KEY_COST` | 1900 |
 | `ACCESS_LIST_ADDRESS_COST` | 2400 |
 
-As of `FORK_BLOCK_NUMBER`, we introduce a new transaction type, with the format `rlp([3, [nonce, gasPrice, gasLimit, to, value, data, access_list, senderV, senderR, senderS]])`. The signing hash would be the hash of the RLP of the entire data structure but popping the last three items representing the signature from the inner list: `rlp([3, [chainId, nonce, gasPrice, gasLimit, to, value, data, access_list]])`.
+As of `FORK_BLOCK_NUMBER`, we introduce a new transaction type, with the format `rlp([3, [chainId, nonce, gasPrice, gasLimit, to, value, data, access_list, senderV, senderR, senderS]])`. The signing hash would be the hash of the RLP of the entire data structure but popping the last three items representing the signature from the inner list: `rlp([3, [chainId, nonce, gasPrice, gasLimit, to, value, data, access_list]])`.
 
 For the transaction to be valid, `access_list` must be of type `[[{20 bytes}, [{32 bytes}...]]...]`, where `...` means "zero or more of the thing to the left". For example, the following is a valid access list (all hex strings would in reality be in byte representation):
 

--- a/EIPS/eip-2930.md
+++ b/EIPS/eip-2930.md
@@ -16,7 +16,7 @@ Adds a transaction type which contains an access list, a list of addresses and s
 
 ## Abstract
 
-We introduce a new [EIP-2718](./eip-2718.md) transaction type, with the format `rlp([3, [chainId, nonce, gasPrice, gasLimit, to, value, data, access_list, senderV, senderR, senderS]])`.
+We introduce a new [EIP-2718](./eip-2718.md) transaction type, with the format `rlp([1, [chainId, nonce, gasPrice, gasLimit, to, value, data, access_list, senderV, senderR, senderS]])`.
 
 The `access_list` specifies a list of addresses and storage keys; these addresses and storage keys are added into the `accessed_addresses` and `accessed_storage_keys` global sets (introduced in [EIP-2929](./eip-2929.md)). A gas cost is charged, though at a discount relative to the cost of accessing outside the list.
 
@@ -37,7 +37,7 @@ This EIP serves two functions:
 | `ACCESS_LIST_STORAGE_KEY_COST` | 1900 |
 | `ACCESS_LIST_ADDRESS_COST` | 2400 |
 
-As of `FORK_BLOCK_NUMBER`, we introduce a new transaction type, with the format `rlp([3, [chainId, nonce, gasPrice, gasLimit, to, value, data, access_list, senderV, senderR, senderS]])`. The signing hash would be the hash of the RLP of the entire data structure but popping the last three items representing the signature from the inner list: `rlp([3, [chainId, nonce, gasPrice, gasLimit, to, value, data, access_list]])`.
+As of `FORK_BLOCK_NUMBER`, we introduce a new transaction type, with the format `rlp([1, [chainId, nonce, gasPrice, gasLimit, to, value, data, access_list, senderV, senderR, senderS]])`. The signing hash would be the hash of the RLP of the entire data structure but popping the last three items representing the signature from the inner list: `rlp([1, [chainId, nonce, gasPrice, gasLimit, to, value, data, access_list]])`.
 
 For the transaction to be valid, `access_list` must be of type `[[{20 bytes}, [{32 bytes}...]]...]`, where `...` means "zero or more of the thing to the left". For example, the following is a valid access list (all hex strings would in reality be in byte representation):
 

--- a/EIPS/eip-2930.md
+++ b/EIPS/eip-2930.md
@@ -37,7 +37,7 @@ This EIP serves two functions:
 | `ACCESS_LIST_STORAGE_KEY_COST` | 1900 |
 | `ACCESS_LIST_ADDRESS_COST` | 2400 |
 
-As of `FORK_BLOCK_NUMBER`, we introduce a new transaction type, with the format `rlp([1, [chainId, nonce, gasPrice, gasLimit, to, value, data, access_list, senderV, senderR, senderS]])`. The signing hash would be the hash of the RLP of the entire data structure but popping the last three items representing the signature from the inner list: `rlp([1, [chainId, nonce, gasPrice, gasLimit, to, value, data, access_list]])`. `chainId` is defined to be an integer of arbitrary size.
+As of `FORK_BLOCK_NUMBER`, we introduce a new transaction type, with the format `rlp([1, [chainId, nonce, gasPrice, gasLimit, to, value, data, access_list, senderV, senderR, senderS]])`. The signing hash would be the hash of the RLP of the entire data structure but popping the last three items representing the signature from the inner list: `rlp([1, [chainId, nonce, gasPrice, gasLimit, to, value, data, access_list]])`. `chainId` is defined to be an integer of arbitrary size. Since `chainId` no longer resides in the signature, `v` must be either 0 or 1 depending on recovery id.
 
 For the transaction to be valid, `access_list` must be of type `[[{20 bytes}, [{32 bytes}...]]...]`, where `...` means "zero or more of the thing to the left". For example, the following is a valid access list (all hex strings would in reality be in byte representation):
 
@@ -91,7 +91,7 @@ def process_access_list(access_list) -> Tuple[List[Set[Address], Set[Pair[Addres
 
 The access list is NOT charged per-byte fees like tx data is; the per-item costs described above are meant to cover the bandwidth costs of the access list data in addition to the costs of accessing those accounts and storage keys when evaluating the transaction.
 
-Additionally, the `chainId` field must be equal to either the chain id of the current network or `0` if it is unprotected.
+Additionally, the transaction is valid only if `chainId` is equal to the chain id of the current network.
 
 ## Rationale
 

--- a/EIPS/eip-2930.md
+++ b/EIPS/eip-2930.md
@@ -91,7 +91,7 @@ def process_access_list(access_list) -> Tuple[List[Set[Address], Set[Pair[Addres
 
 The access list is NOT charged per-byte fees like tx data is; the per-item costs described above are meant to cover the bandwidth costs of the access list data in addition to the costs of accessing those accounts and storage keys when evaluating the transaction.
 
-Additionally, the transaction is valid only if `chainId` is equal to the chain id of the current network.
+Clarification: the transaction is valid only if `chainId` is equal to the chain id of the current network. 
 
 ## Rationale
 


### PR DESCRIPTION
This change will deprecate EIP-155 behaviour for this transaction type. Many proposed EIP-2718 transactions already separate the chain id from the `v` value, so I believe there is demand for this modification.