### PR TITLE
EIP-3091: Block Explorer API Routes

### DIFF
--- a/EIPS/eip-3091.md
+++ b/EIPS/eip-3091.md
@@ -1,0 +1,45 @@
+---
+eip: 3091
+title: Block Explorer API Routes
+author: Pedro Gomes (@pedrouid)
+discussions-to: https://github.com/ethereum/EIPs/pull/3091
+status: Draft
+type: Standards Track
+category: Interface
+created: 2020-11-02
+---
+
+## Simple Summary
+This proposal brings standardization between block explorers API routes when linking transactions, blocks, accounts and tokens. 
+
+## Abstract
+Currently wallets will link transactions and accounts to block explorers web pages but as chain diversity and layer two solutions grow it becomes harder to maintain a consistent user experience. Standardizing the API routes to these links improves interoperability between wallets and block explorers.
+
+## Motivation
+Adding new chains or layer two solutions becomes harder given these endpoints are inconsistent. This EIP makes RPC endpoints like EIP-2015 and EIP-2016 more feasible.
+
+## Specification
+Block explorers will route their webpages accordingly for the following data:
+
+### Blocks
+<BLOCK_EXPORER_URL>/block/<BLOCK_HASH_OR_HEIGHT>
+
+
+### Transactions
+<BLOCK_EXPORER_URL>/tx/<TX_HASH>
+
+### Accounts
+<BLOCK_EXPORER_URL>/address/<ACCOUNT_ADDRESS>
+
+
+### ERC-20 Tokens
+<BLOCK_EXPORER_URL>/token/<TOKEN_ADDRESS>
+
+## References
+
+- Related EIPs
+  - [EIP-2015: Wallet Update Ethereum Chain JSON-RPC Method (`wallet_updateChain`)](./eip-2015.md)
+  - [EIP-2016: Wallet Add Ethereum Chain RPC Method (`wallet_addEthereumChain`)](./eip-2016.md)
+
+## Copyright
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/EIPS/eip-3091.md
+++ b/EIPS/eip-3091.md
@@ -7,7 +7,6 @@ status: Draft
 type: Standards Track
 category: Interface
 created: 2020-11-02
-updated: 2020-11-03
 ---
 
 ## Simple Summary

--- a/EIPS/eip-3091.md
+++ b/EIPS/eip-3091.md
@@ -36,7 +36,7 @@ Block explorers will route their webpages accordingly for the following data:
 ### ERC-20 Tokens
 <BLOCK_EXPORER_URL>/token/<TOKEN_ADDRESS>
 
-## Backward Compatability
+## Backward Compatibility
 This EIP was designed with existing API routes in mind to reduce disruption. Incompatible block explorers should include either 301 redirects to their existing API routes to match this EIP.
 
 ## Security Considerations

--- a/EIPS/eip-3091.md
+++ b/EIPS/eip-3091.md
@@ -2,21 +2,22 @@
 eip: 3091
 title: Block Explorer API Routes
 author: Pedro Gomes (@pedrouid)
-discussions-to: https://github.com/ethereum/EIPs/pull/3091
+discussions-to: https://ethereum-magicians.org/t/eip-3091-block-explorer-api-routes/4907
 status: Draft
 type: Standards Track
 category: Interface
 created: 2020-11-02
+updated: 2020-11-03
 ---
 
 ## Simple Summary
-This proposal brings standardization between block explorers API routes when linking transactions, blocks, accounts and tokens. 
+Standard API Routes for Blockchain explorers
 
 ## Abstract
-Currently wallets will link transactions and accounts to block explorers web pages but as chain diversity and layer two solutions grow it becomes harder to maintain a consistent user experience. Standardizing the API routes to these links improves interoperability between wallets and block explorers.
+This proposal brings standardization between block explorers API routes when linking transactions, blocks, accounts and tokens. 
 
 ## Motivation
-Adding new chains or layer two solutions becomes harder given these endpoints are inconsistent. This EIP makes RPC endpoints like EIP-2015 and EIP-2016 more feasible.
+Currently wallets will link transactions and accounts to block explorers web pages but as chain diversity and layer two solutions grow it becomes harder to maintain a consistent user experience. Adding new chains or layer two solutions becomes harder given these endpoints are inconsistent. Standardizing the API routes to these links improves interoperability between wallets and block explorers. This EIP makes RPC endpoints like [EIP-2015](./eip-2015.md) more feasible.
 
 ## Specification
 Block explorers will route their webpages accordingly for the following data:
@@ -35,11 +36,11 @@ Block explorers will route their webpages accordingly for the following data:
 ### ERC-20 Tokens
 <BLOCK_EXPORER_URL>/token/<TOKEN_ADDRESS>
 
-## References
+## Backward Compatability
+This EIP was designed with existing API routes in mind to reduce disruption. Incompatible block explorers should include either 301 redirects to their existing API routes to match this EIP.
 
-- Related EIPs
-  - [EIP-2015: Wallet Update Ethereum Chain JSON-RPC Method (`wallet_updateChain`)](./eip-2015.md)
-  - [EIP-2016: Wallet Add Ethereum Chain RPC Method (`wallet_addEthereumChain`)](./eip-2016.md)
+## Security Considerations
+TBD
 
 ## Copyright
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
Providing wallet with a `blockExporerUrl` could be valuable given that applications can permissionessly interface with each other given that standards are followed and become interoperable.

Hence I've explored existing block explorers and identified existing patterns where these endpoints are in consensus and could be specified under a standard which this EIP describes

### L1 Blockchain Explorers

#### Blocks
Blockscout (chainId=100) -> https://blockscout.com/poa/xdai/blocks/<BLOCK_HASH_OR_HEIGHT>
Etherscan (chainId=1) -> https://etherscan.io/block/<BLOCK_HASH_OR_HEIGHT>
Etherchain (chainId=1) -> https://etherchain.org/block/<BLOCK_HASH_OR_HEIGHT>
Ethplorer (chainId=1) -> unsupported

Etherscan and Etherchain are in consensus for blocks endpoint but Blockscout uses `/blocks` endpoint instead and Ethplorer doesn't have a page for blocks so returns 404 not found.

#### Transactions
Blockscout (chainId=100) -> https://blockscout.com/poa/xdai/tx/<TX_HASH>
Etherscan (chainId=1) -> https://etherscan.io/tx/<TX_HASH>
Etherchain (chainId=1) -> https://etherchain.org/tx/<TX_HASH>
Ethplorer (chainId=1) -> https://ethplorer.io/tx/<TX_HASH>

All block explorers are in consensus for transactions endpoint.

#### Accounts
Blockscout (chainId=100) -> https://blockscout.com/poa/xdai/address/<ACCOUNT_ADDRESS>
Etherscan (chainId=1) -> https://etherscan.io/address/<ACCOUNT_ADDRESS>
Etherchain (chainId=1) -> https://etherchain.org/account/<ACCOUNT_ADDRESS>
Ethplorer (chainId=1) -> https://ethplorer.io/address/<ACCOUNT_ADDRESS>

All block explorers are in consensus for accounts endpoint except Etherchain which uses `/account` endpoint instead

#### ERC-20 Tokens
Blockscout (chainId=100) -> https://blockscout.com/poa/xdai/tokens/<TOKEN_ADDRESS>
Etherscan (chainId=1) -> https://etherscan.io/token/<TOKEN_ADDRESS>
Etherchain (chainId=1) -> https://etherchain.org/token/<TOKEN_ADDRESS>
Ethplorer (chainId=1) -> https://ethplorer.io/address/<TOKEN_ADDRESS>

Etherscan and Etherchain are in consensus but Blockscout uses `/tokens` endpoint instead and Ethplorer doesn't have a page for tokens so redirects to accounts page (`/address`).

### L2 Explorers

#### Blocks
Matic -> https://explorer.matic.network/blocks/<BLOCK_HEIGHT_OR_HASH>
zkScan -> https://zkscan.io/blocks/<BLOCK_NUMBER>
Fuel -> https://rinkeby.fuel.sh/block/<BLOCK_NUMBER>

#### Transactions
Matic -> https://explorer.matic.network/tx/<TX_HASH>
zkScan -> https://zkscan.io/transactions/<TX_HASH>
Fuel -> https://rinkeby.fuel.sh/tx/<TX_HASH>

#### Accounts
Matic -> https://explorer.matic.network/address/<ACCOUNT_ADDRESS>
zkScan -> https://zkscan.io/accounts/<ACCOUNT_ADDRESS>
Fuel -> https://rinkeby.fuel.sh/address/<ACCOUNT_ADDRESS>

#### ERC-20 Tokens
Matic -> https://explorer.matic.network/tokens/<TOKEN_ADDRESS>
zkScan -> unsupported (`/tokens` displays a list of tokens pointing to L1 explorer)
Fuel -> unsupported

## EIP-3091

### Blocks
<BLOCK_EXPORER_URL>/block/<BLOCK_HASH_OR_HEIGHT>


### Transactions
<BLOCK_EXPORER_URL>/tx/<TX_HASH>

### Accounts
<BLOCK_EXPORER_URL>/address/<ACCOUNT_ADDRESS>


### ERC-20 Tokens
<BLOCK_EXPORER_URL>/token/<TOKEN_ADDRESS>
