### PR TITLE
Cleans up EIP-55

### DIFF
--- a/EIPS/eip-55.md
+++ b/EIPS/eip-55.md
@@ -2,6 +2,7 @@
 eip: 55
 title: Mixed-case checksum address encoding
 author: Vitalik Buterin <vitalik.buterin@ethereum.org>, Alex Van de Sande <avsa@ethereum.org>
+discussion-to: https://github.com/ethereum/eips/issues/55
 type: Standards Track
 category: ERC
 status: Final
@@ -116,37 +117,3 @@ Note that the input to the Keccak256 hash is the lowercase hexadecimal string (i
 0xdbF03B407c01E7cD3CBea99509d93f8DDDC8C6FB
 0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb
 ```
-
-# Adoption
-
-| Wallet                   | displays checksummed addresses | rejects invalid mixed-case | rejects too short | rejects too long |
-|--------------------------|--------------------------------|----------------------------|-------------------|------------------|
-| Etherwall 2.0.1          | Yes                            | Yes                        | Yes               | Yes              |
-| Jaxx 1.2.17              | No                             | Yes                        | Yes               | Yes              |
-| MetaMask 3.7.8           | Yes                            | Yes                        | Yes               | Yes              |
-| Mist 0.8.10              | Yes                            | Yes                        | Yes               | Yes              |
-| MyEtherWallet v3.9.4     | Yes                            | Yes                        | Yes               | Yes              |
-| Parity 1.6.6-beta (UI)   | Yes                            | Yes                        | Yes               | Yes              |
-| Jaxx Liberty 2.0.0       | Yes                            | Yes                        | Yes               | Yes              |
-| Coinomi 1.10             | Yes                            | Yes                        | Yes               | Yes              |
-| Trust Wallet             | Yes                            | Yes                        | Yes               | Yes              |
-
-### Exchange support for mixed-case address checksums, as of 2017-05-27:
-
-| Exchange     | displays checksummed deposit addresses | rejects invalid mixed-case | rejects too short | rejects too long |
-|--------------|----------------------------------------|----------------------------|-------------------|------------------|
-| Bitfinex     | No                                     | Yes                        | Yes               | Yes              |
-| Coinbase     | Yes                                    | No                         | Yes               | Yes              |
-| GDAX         | Yes                                    | Yes                        | Yes               | Yes              |
-| Kraken       | No                                     | No                         | Yes               | Yes              |
-| Poloniex     | No                                     | No                         | Yes               | Yes              |
-| Shapeshift   | No                                     | No                         | Yes               | Yes              |
-
-# References
-
-1. EIP 55 issue and discussion https://github.com/ethereum/eips/issues/55
-2. Python example by @Recmo https://github.com/ethereum/eips/issues/55#issuecomment-261521584
-3. Python implementation in [`ethereum-utils`](https://github.com/pipermerriam/ethereum-utils#to_checksum_addressvalue---text)
-4. Ethereumjs-util implementation https://github.com/ethereumjs/ethereumjs-util/blob/75f529458bc7dc84f85fd0446d0fac92d991c262/index.js#L452-L466
-5. Swift implementation in [`EthereumKit`](https://github.com/yuzushioh/EthereumKit/blob/master/EthereumKit/Helper/EIP55.swift)
-6. Kotlin implementation in [`KEthereum`](https://github.com/walleth/kethereum/tree/master/erc55)

--- a/EIPS/eip-55.md
+++ b/EIPS/eip-55.md
@@ -2,7 +2,7 @@
 eip: 55
 title: Mixed-case checksum address encoding
 author: Vitalik Buterin <vitalik.buterin@ethereum.org>, Alex Van de Sande <avsa@ethereum.org>
-discussion-to: https://github.com/ethereum/eips/issues/55
+discussions-to: https://github.com/ethereum/eips/issues/55
 type: Standards Track
 category: ERC
 status: Final


### PR DESCRIPTION
This EIP was written in a time when we were using EIPs for hardfork coordination and we weren't worried too much about link rot.  However, times have changed and maintaining EIPs like this is becoming more and more of a burden.  In this case, the specification is what is important, not who implements it.  Also, editors do not want to maintain external links to things that don't add *significant* value.