### PR TITLE
Correcting a mistake in a mass-update.

### DIFF
--- a/EIPS/eip-1057.md
+++ b/EIPS/eip-1057.md
@@ -3,7 +3,7 @@ eip: 1057
 title: ProgPoW, a Programmatic Proof-of-Work
 author: Greg Colvin <greg@colvin.org>, Andrea Lanfranchi (@AndreaLanfranchi), Michael Carter (@bitsbetrippin), IfDefElse <ifdefelse@protonmail.com>
 discussions-to: https://ethereum-magicians.org/t/eip-progpow-a-programmatic-proof-of-work/272
-status: Final
+status: Review
 type: Standards Track
 category: Core
 created: 2018-05-02


### PR DESCRIPTION
EIPs have a new set of statuses, Accepted is no longer a status but we accidentally mass updated Accepted => Final, when it should have been Accepted => Review.