### PR TITLE
1186: Removes Implementation section

### DIFF
--- a/EIPS/eip-1186.md
+++ b/EIPS/eip-1186.md
@@ -134,12 +134,5 @@ Since this only adds a new Method there are no issues with Backwards Compatibili
 
 TODO: Tests still need to be implemented, but the core function creating the proof already exists inside the clients and are well tested.
 
-## Implementation
-
-We implemented this function for:
-
-- [x] [parity](https://github.com/paritytech/parity/pull/9001) (Status: pending pull request) - [Docker](https://hub.docker.com/r/slockit/parity-in3/tags/)
-- [x] [geth](https://github.com/ethereum/go-ethereum/pull/17737) (Status: pending pull request) - [Docker](https://hub.docker.com/r/slockit/geth-in3/tags/)
-
 ## Copyright
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
Implementation tracking is part of the hard fork coordination process which now lives at https://github.com/ethereum/eth1.0-specs/.  Removing this section to avoid causing confusion since it likely won't be maintained or represent a full view of reality.  Also, it isn't really appropriate for EIPs anymore.