### PR TITLE
EIP-2972: Deprecateds legacy transactions in blocks.

### DIFF
--- a/EIPS/eip-2972.md
+++ b/EIPS/eip-2972.md
@@ -36,7 +36,7 @@ As of `FORK_BLOCK_NUMBER`, `0x00 || yParity || r || s || 0x65000000 || rlp(nonce
 As of `FORK_BLOCK_NUMBER`, `0x01 || yParity || r || s || 0x65000000 || rlp(nonce, gasPrice, gasLimit, to, value, data, chainId, 0, 0)` will be a valid transaction where:
 * the RLP encoded transaction portion is signed/processed/handled exactly the same as legacy transactions were signed/processed/handled, with the exception of the final encoding
 
-As of `FORK_BLOCK_NUMBER`, `rlp(nonce, gasPrice, gasLimit, to, value, data, v, r, s)` will no longer be valid transaction in a block.
+As of `FORK_BLOCK_NUMBER`, `rlp(nonce, gasPrice, gasLimit, to, value, data, v, r, s)` will no longer be a valid transaction in a block.
 
 ### Receipts
 As of `FORK_BLOCK_NUMBER`, `0 || ssz(status, cumulativeGasUsed, logsBloom, logs)` will be a valid receipt where:

--- a/EIPS/eip-2972.md
+++ b/EIPS/eip-2972.md
@@ -36,12 +36,16 @@ As of `FORK_BLOCK_NUMBER`, `0x00 || yParity || r || s || 0x65000000 || rlp(nonce
 As of `FORK_BLOCK_NUMBER`, `0x01 || yParity || r || s || 0x65000000 || rlp(nonce, gasPrice, gasLimit, to, value, data, chainId, 0, 0)` will be a valid transaction where:
 * the RLP encoded transaction portion is signed/processed/handled exactly the same as legacy transactions were signed/processed/handled, with the exception of the final encoding
 
+As of `FORK_BLOCK_NUMBER`, `rlp(nonce, gasPrice, gasLimit, to, value, data, v, r, s)` will no longer be valid transaction in a block.
+
 ### Receipts
 As of `FORK_BLOCK_NUMBER`, `0 || ssz(status, cumulativeGasUsed, logsBloom, logs)` will be a valid receipt where:
 * the `ReceiptPayload` will be generated/processed/handled exactly the same as legacy receipts were processed/handled with the exception of its encoding
 
 As of `FORK_BLOCK_NUMBER`, `1 || ssz(status, cumulativeGasUsed, logsBloom, logs)` will be a valid receipt where:
 * the `ReceiptPayload` will be generated/processed/handled exactly the same as legacy receipts were processed/handled with the exception of its encoding
+
+As of `FORK_BLOCK_NUMBER`, `rlp(status, cumulativeGasUsed, logsBloom, logs)` will no longer be a valid receipt in a block.
 
 ## Rationale
 ### Signature doesn't include transaction type as first signature byte
@@ -63,6 +67,8 @@ By having the signature SSZ encoded up front, we can easily extract the signatur
 There is a weak consensus that RLP is not a particularly good encoding scheme for hashed data partially due to its inability to be streamed.
 SSZ is almost certainly going to be included in Ethereum at some point in the future, so clients likely have access to an SSZ decoder.
 For this particular case, manual decoding without a full SSZ decoder isn't too complicated, though it does require doing a bit of "pointer math" since `logs` is an array of variable length items
+### Deprecating legacy transactions
+By deprecating legacy transactions, we make it easier for clients as they can always deal with typed transactions in blocks.
 
 ## Backwards Compatibility
 The new transactions are signature compatible with legacy transactions.


### PR DESCRIPTION
Per discussion in ACD call.