### PR TITLE
EIP-2972: Embraces SSZ

### DIFF
--- a/EIPS/eip-2972.md
+++ b/EIPS/eip-2972.md
@@ -16,8 +16,8 @@ Two new transaction types for wrapping legacy transactions with and without a ch
 ## Abstract
 Introduces two new [EIP-2718](./eip-2718.md) transactions that are signature compatible with legacy transactions and can be automatically upgraded by any client.
 
-* `0x00 || yParity || r || s || 0x65000000 || rlp([nonce, gasPrice, gasLimit, to, value, data])`
-* `0x01 || yParity || r || s || 0x65000000 || rlp([nonce, gasPrice, gasLimit, to, value, data, chainId, 0, 0])`
+* `0x00 || ssz.serialize(yParity, r, s, rlp([nonce, gasPrice, gasLimit, to, value, data]))`
+* `0x01 || ssz.serialize(yParity, r, s, rlp([nonce, gasPrice, gasLimit, to, value, data, chainId, 0, 0]))`
 
 ## Motivation
 We would like to eventually deprecate legacy transactions so we no longer have to retain code in the networking and signer layer that deals with them.
@@ -30,43 +30,50 @@ This EIP provides a mechanism for transmitting/including transactions in a way t
 * `yParity` is the parity (0 for even, 1 for odd) of the `y` value of the curve point for which `r` is the `x` value in the secp256k1 signing process.
 
 ### Transactions
-As of `FORK_BLOCK_NUMBER`, `0x00 || yParity || r || s || 0x65000000 || rlp(nonce, gasPrice, gasLimit, to, value, data)` will be a valid transaction where:
+As of `FORK_BLOCK_NUMBER`, `0x00 || ssz.serialize(yParity, r, s, rlp([nonce, gasPrice, gasLimit, to, value, data]))` will be a valid transaction where:
 * the RLP encoded transaction portion is signed/processed/handled exactly the same as legacy transactions were signed/processed/handled, with the exception of the final encoding
+* TODO: Hashing or Merkleizing for block transaction root
 
-As of `FORK_BLOCK_NUMBER`, `0x01 || yParity || r || s || 0x65000000 || rlp(nonce, gasPrice, gasLimit, to, value, data, chainId, 0, 0)` will be a valid transaction where:
+As of `FORK_BLOCK_NUMBER`, `0x01 || ssz.serialize(yParity, r, s, rlp([nonce, gasPrice, gasLimit, to, value, data, chainId, 0, 0]))` will be a valid transaction where:
 * the RLP encoded transaction portion is signed/processed/handled exactly the same as legacy transactions were signed/processed/handled, with the exception of the final encoding
+* TODO: Hashing or Merkleizing for block transaction root
 
 The SSZ schema for both transaction types is:
   ```
-  Transaction:
-    type: uint8
-    yParity: boolean
-    r: bytes32
-    s: bytes32
-    signedData: bytes
+  Transaction[
+    yParity: boolean,
+    r: bytes32,
+    s: bytes32,
+    signedData: bytes,
+  ]
   ```
+
+Note: `sszencode(yParity, r, s, rlp(...))` is the same as `yParity || r || s || 0x45000000 || rlp(...)`
 
 As of `FORK_BLOCK_NUMBER`, `rlp(nonce, gasPrice, gasLimit, to, value, data, v, r, s)` will no longer be a valid transaction in a block.
 
 ### Receipts
-As of `FORK_BLOCK_NUMBER`, `0 || ssz(status, cumulativeGasUsed, logsBloom, logs)` will be a valid receipt where:
+As of `FORK_BLOCK_NUMBER`, `0 || ssz.serialize(status, cumulativeGasUsed, logsBloom, logs)` will be a valid receipt where:
 * the `ReceiptPayload` will be generated/processed/handled exactly the same as legacy receipts were processed/handled with the exception of its encoding
+* TODO: Hashing or Merkleizing for block receipt root
 
-As of `FORK_BLOCK_NUMBER`, `1 || ssz(status, cumulativeGasUsed, logsBloom, logs)` will be a valid receipt where:
+As of `FORK_BLOCK_NUMBER`, `1 || ssz.serialize(status, cumulativeGasUsed, logsBloom, logs)` will be a valid receipt where:
 * the `ReceiptPayload` will be generated/processed/handled exactly the same as legacy receipts were processed/handled with the exception of its encoding
+* TODO: Hashing or Merkleizing for block receipt root
 
 The SSZ schema for both receipt types is:
 ```
-Log:
-  address: bytes20
-  topics: List[bytes32, 4]
-  data: List[uint8, 0xffffff]
-Receipt:
-  type: uint8
-  status: uint8
-  cumulativeGasUsed: uint64
-  logsBloom: BitVector[2048]
-  logs: List[Log, 0xffffff]
+Log[
+  address: bytes20,
+  topics: List[bytes32, 4],
+  data: List[uint8, 0xffffff],
+]
+Receipt[
+  status: uint8,
+  cumulativeGasUsed: uint64,
+  logsBloom: BitVector[2048],
+  logs: List[Log, 0xffffff],
+]
 ```
 
 As of `FORK_BLOCK_NUMBER`, `rlp(status, cumulativeGasUsed, logsBloom, logs)` will no longer be a valid receipt in a block.
@@ -85,16 +92,15 @@ In the case of legacy transactions, this was a bit of a burden since you had to 
 EIP-155 made this process even worse by requiring the validator to further decode the `v` signature value to extract the chain ID (if present) and include that in the signed data payload.
 By having the signed data encoded exactly as it is signed, we make it so one can verify the transaction's signature without having to do any decoding before hand.
 By having the signature SSZ encoded up front, we can easily extract the signature without even having to use a decoder.
-### TransactionType 0/1 0x65000000 element
-`0x00 || yParity || r || s || 0x65000000 || rlp(nonce, gasPrice, gasLimit, to, value, data)` is the same as `ssz(0, yParity, r, s, rlp(nonce, gasPrice, gasLimit, to, value, data))`, which may prove convenient for some clients.  It costs us 4 extra bytes on the wire (mostly zeros), but the authors deem this a worthwhile trade to be SSZ encodable/decodable.
-### SSZ for receipt encoding
+### SSZ for serialization
 There is a weak consensus that RLP is not a particularly good encoding scheme for hashed data partially due to its inability to be streamed.
 SSZ is almost certainly going to be included in Ethereum at some point in the future, so clients likely have access to an SSZ decoder.
-For this particular case, manual decoding without a full SSZ decoder isn't too complicated, though it does require doing a bit of "pointer math" since `logs` is an array of variable length items
+For this particular case, manual decoding without a full SSZ decoder isn't too complicated, though it does require doing a bit of "pointer math" since `logs` is an array of variable length items.
 ### Deprecating legacy transactions
 By deprecating legacy transactions, we make it easier for clients as they can always deal with typed transactions in blocks.
 ### Max length of logs and logs data
-[EIP-706](./eip-706.md) limits devp2p messages to 24 bit length, which gives us a pragmatic cap at that for any single transaction at the moment.  This number seems to far exceed what is reasonable anytime in the near future, so feels like as reasonable of a cap as any.
+[EIP-706](./eip-706.md) limits devp2p messages to 24 bit length, which gives us a pragmatic cap at that for any single transaction at the moment.
+This number seems to far exceed what is reasonable anytime in the near future, so feels like as reasonable of a cap as any.
 
 ## Backwards Compatibility
 The new transactions are signature compatible with legacy transactions.


### PR DESCRIPTION
Since we are using SSZ in the receipt, we might as well use SSZ in the transaction as well and just show the non-SSZ version as a note.