### PR TITLE
Add rationale for precompile; s/relayer/invoker/ [EIP-3074]

### DIFF
--- a/EIPS/eip-3074.md
+++ b/EIPS/eip-3074.md
@@ -16,8 +16,8 @@ Creates a new precompile, analogous to `CALL` (`0xF1`), that sets `CALLER` (`0x3
 ## Abstract
 
 This EIP creates two precompiles:
- - `CALL_PRECOMPILE` - forwards a `CALL`, setting `CALLER` according to an ECDSA signature, using a relayer-sponsee nonce for replay protection.
- - `NONCE_PRECOMPILE` - provides access to relayer-sponsee nonces expected by `CALL_PRECOMPILE`.
+ - `CALL_PRECOMPILE` - forwards a `CALL`, setting `CALLER` according to an ECDSA signature, using a invoker-sponsee nonce for replay protection.
+ - `NONCE_PRECOMPILE` - provides access to invoker-sponsee nonces expected by `CALL_PRECOMPILE`.
 
 ## Motivation
 
@@ -32,16 +32,16 @@ While it is possible to emulate sponsored transactions (ex. [Gas Station Network
 Sponsored transactions are implemented with the addition of two precompiles:
 
  - The first, at address `0x13`, which functions like a `CALL` instruction that additionally sets the caller address based on an ECDSA signature.
- - The second, at address `0x14`, provides access to the current nonce for the given relayer-sponsee pair.
+ - The second, at address `0x14`, provides access to the current nonce for the given invoker-sponsee pair.
 
 ### Definitions
 
  - **`CALL_PRECOMPILE`** - the specific precompile at address `0x13`, introduced by this EIP, which implements the `CALL` analogue.
- - **`NONCE_PRECOMPILE`** - the specific precompile at address `0x14`, introduced by this EIP, which exposes relayer-sponsee nonces.
+ - **`NONCE_PRECOMPILE`** - the specific precompile at address `0x14`, introduced by this EIP, which exposes invoker-sponsee nonces.
  - **Transaction-like Package** - the signed arguments passed to `CALL_PRECOMPILE`.
- - **Sponsor** - the account which is responsible for paying gas fees and sending the transaction. May or may not be the same as the relayer.
+ - **Sponsor** - the account which is responsible for paying gas fees and sending the transaction. May or may not be the same as the invoker.
  - **Sponsee** - the account which signed the transactions-like package.
- - **Relayer** - the account or contract which directly calls into `CALL_PRECOMPILE`. May or may not be the same as the sponsor.
+ - **Invoker** - the account or contract which directly calls into `CALL_PRECOMPILE`. May or may not be the same as the sponsor.
  - **Callee** - the target of the call from `CALL_PRECOMPILE`.
 
 ### API
@@ -53,19 +53,19 @@ Sponsored transactions are implemented with the addition of two precompiles:
  - `nonce` - the next nonce value, as described below;
  - `to` - the address of the callee (not `CALL_PRECOMPILE`);
  - `gaslimit` - the minimum gas limit which must be provided with the call into `CALL_PRECOMPILE`;
- - `value` - the exact amount of Ether in wei to transfer from the relayer to the callee;
+ - `value` - the exact amount of Ether in wei to transfer from the invoker to the callee;
  - `data` - the calldata for the call into `to`; and
  - `v`, `r`, `s` - signature for the package, including chain id as specified in [EIP-155](./eip-155.md).
 
 The arguments to `CALL_PRECOMPILE` are encoded as `rlp([nonce, gaslimit, to, value, data, v, r, s])`.
 
-The signature (`v`, `r`, `s`) arguments are computed from `secp256k1(keccak256(rlp([nonce, gaslimit, to, value, data, relayer, chainid])))`.
+The signature (`v`, `r`, `s`) arguments are computed from `secp256k1(keccak256(rlp([nonce, gaslimit, to, value, data, invoker, chainid])))`.
 
 `CALL_PRECOMPILE` returns a failure without changing the nonce in the following situations:
  - Invalid signature
  - Future or past nonce
  - Gas limit supplied with the call into `CALL_PRECOMPILE` is less than the signed `gaslimit`
- - The relayer's balance is insufficient to pay for the supplied gas plus `value`
+ - The invoker's balance is insufficient to pay for the supplied gas plus `value`
 
 `CALL_PRECOMPILE` returns a success in all other cases.
 
@@ -75,14 +75,14 @@ The return data of `CALL_PRECOMPILE` will be a single byte to indicate the statu
 
 `NONCE_PRECOMPILE` requires the following two arguments:
 
- - `relayer` - the relayer address; and
+ - `invoker` - the invoker address; and
  - `sponsee` - the sponsee address.
 
 Assuming the calldata is the correct length, `NONCE_PRECOMPILE` will return a success, and place the nonce associated with the address pair in the return data.
 
 ### Nonces
 
-The two precompiles will maintain a nonce for each pair of relayer address and sponsee address, in essence:
+The two precompiles will maintain a nonce for each pair of invoker address and sponsee address, in essence:
 
 ```
 {
@@ -92,7 +92,7 @@ The two precompiles will maintain a nonce for each pair of relayer address and s
 ```
 
 Where:
- * `0x1234...5678` and `0x1122...3344` are the relayer addresses;
+ * `0x1234...5678` and `0x1122...3344` are the invoker addresses;
  * `0xEEEE...EEEE` and `0xBBBB...BBBB` are the sponsee addresses; and
  * `55` and `89` are the current nonce values for their respective pairs.
 
@@ -123,19 +123,23 @@ Besides better compatibility with AA, a precompile is a much less intrusive chan
 
 `CALL_PRECOMPILE`'s single purpose is to set `CALLER`. It implements the minimal functionality to enable sender abstraction for sponsored transactions. This single mindedness makes `CALL_PRECOMPILE` significantly more composable with existing Ethereum features.
 
-More logic can be implemented around the call into `CALL_PRECOMPILE`, giving more control to relayers and sponsors without sacrificing security or user experience for sponsees.
+More logic can be implemented around the call into `CALL_PRECOMPILE`, giving more control to invokers and sponsors without sacrificing security or user experience for sponsees.
 
 ### Nonces
 
 Other nonce schemes either do not provide enough security, or are too inefficient/inconvenient to be practical.
 
  - Use sponsor nonce: every transaction from the sponsor's account invalidates every transaction-like package.
- - Use relayer nonce: every sponsored transaction from the relayer's account invalidates every other transaction-like package. Also interacts with `SELFDESTRUCT`.
+ - Use invoker nonce: every sponsored transaction from the invoker's account invalidates every other transaction-like package. Also interacts with `SELFDESTRUCT`.
  - Use sponsee nonce: the sponsee could attack the sponsor by submitting another transaction with a conflicting nonce at a higher gas price.
 
-Instead, by creating an independent nonce per relayer-sponsee pair, we get some attractive properties:
- - A transaction package can only be invalidated if both the relayer and sponsee cooperate, which is nice for EOA sponsors, and necessary for AA contracts.
+Instead, by creating an independent nonce per invoker-sponsee pair, we get some attractive properties:
+ - A transaction package can only be invalidated if both the invoker and sponsee cooperate, which is nice for EOA sponsors, and necessary for AA contracts.
  - The `SELFDESTRUCT` operation doesn't introduce replay attacks.
+
+### Precompile vs. Opcode
+
+Opcodes do not have externally visible addresses, and therefore cannot be called directly by an EOA. Using a precompile allows a sponsor to avoid an intermediary contract call should they want to use this functionality directly.
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
To hopefully clear up some of the confusion when discussing this EIP,
I've renamed what I originally referred to as a "relayer" to the
"invoker", which I think is more clear.

The established vocabulary seems to agree that relayer is actually the
actor who _sends_ the transaction, and conflating that with some
optional intermediary contract is just a bad idea.