### PR TITLE
EIP-1559 constant tip strategy

### DIFF
--- a/EIPS/eip-1559.md
+++ b/EIPS/eip-1559.md
@@ -61,7 +61,7 @@ class Transaction1559:
 	destination: int = 0
 	amount: int = 0
 	payload: bytes = bytes()
-	max_miner_bribe_per_gas: int = 0
+	miner_bribe_per_gas: int = 0
 	fee_cap_per_gas: int = 0
 	v: int = 0
 	r: int = 0
@@ -138,10 +138,8 @@ class World(ABC):
 
 			# ensure that the user was willing to at least pay the base fee
 			assert transaction.fee_cap_per_gas >= block.base_fee
-			# bribe is capped such that base fee is filled first
-			bribe_per_gas = min(transaction.max_miner_bribe_per_gas, transaction.fee_cap_per_gas - block.base_fee)
 			# signer pays both the bribe and the base fee
-			effective_gas_price = bribe_per_gas + block.base_fee
+			effective_gas_price = transaction.miner_bribe_per_gas + block.base_fee
 			signer.balance -= transaction.gas_limit * effective_gas_price
 			assert signer.balance >= 0, 'invalid transaction: signer does not have enough ETH to cover gas'
 			gas_used = self.execute_transaction(transaction, effective_gas_price)
@@ -150,7 +148,7 @@ class World(ABC):
 			# signer gets refunded for unused gas
 			signer.balance += gas_refund * effective_gas_price
 			# miner only receives the bribe; note that the base fee is not given to anyone (it is burned)
-			self.account(block.author).balance += gas_used * bribe_per_gas
+			self.account(block.author).balance += gas_used * transaction.miner_bribe_per_gas
 
 		# check if the block spent too much gas transactions
 		assert cumulative_transaction_gas_used == block.gas_used, 'invalid block: gas_used does not equal total gas used in all transactions'
@@ -161,13 +159,14 @@ class World(ABC):
 	def normalize_transaction(self, transaction: Transaction) -> Transaction1559:
 		# handle legacy transactions, can differentiate by number of items if desired (Legacy == 8 items)
 		if isinstance(transaction, TransactionLegacy):
+                       # take the upper byte from the gas price and use it as the miner bribe, then convert from gwei to wei
 			return Transaction1559(
 				account_nonce: int = transaction.account_nonce,
 				gas_limit: int = transaction.gas_limit,
 				amount: int = transaction.amount,
 				payload: bytes = transaction.payload,
-				max_miner_bribe_per_gas: int = transaction.gas_price,
-				fee_cap_per_gas: int = transaction.gas_price,
+				miner_bribe_per_gas: int = pow(transaction.gas_price.to_bytes(8, byteorder='big')[0], 9),
+				fee_cap_per_gas: int = transaction.gas_price.to_bytes(8, byteorder='big')[1:],
 				v: int = transaction.v,
 				r: int = transaction.r,
 				s: int = transaction.s,


### PR DESCRIPTION
It's clear that managing a mempool of EIP-1559 transactions is non-trivial. As the spec stands today, the value that a transaction may provide the miner is actually a function of the current `base_fee`. This is problematic as it implies that the mempool must constantly reorder its transactions lists as the `base_fee` fluctuates.

The alternative that I propose is to change from using a *dynamic tip* to a *constant tip*. The *constant tip* has several properties that are advantageous, most notably that a mempool can easily maintain an ordered list of the most lucrative transactions, since their payouts do not depend on the `base_fee`. 

I've done some preliminary comparisons between the *dynamic tip* mechanism vs. the *constant tip* mechanism, and shared some thoughts on how a mempool might handle the two: https://hackmd.io/@matt/HJ4YbvNcw

The main caveat is that *dynamic tip* transactions offered a very flexible mechanism for legacy transactions to be ported over. I believe that *constant tip* transactions can be similarly flexible, but require a bit more complexity. For example, I've packed the upper byte in `gas_price` to be used as the `tip` in `gwei`. This leaves 56 bits to specify a maximum `fee_cap` of `72_057_594` gwei. This should be acceptable for the foreseeable future.