### PR TITLE
EIP-1559: Add check that gas used is less than gas limit

### DIFF
--- a/EIPS/eip-1559.md
+++ b/EIPS/eip-1559.md
@@ -145,6 +145,7 @@ class World(ABC):
 			signer.balance -= transaction.gas_limit * effective_gas_price
 			assert signer.balance >= 0, 'invalid transaction: signer does not have enough ETH to cover gas'
 			gas_used = self.execute_transaction(transaction, effective_gas_price)
+			assert gas_used <= transaction.gas_limit, 'transaction used more gas than gas_limit'
 			gas_refund = transaction.gas_limit - gas_used
 			cumulative_transaction_gas_used += gas_used
 			# signer gets refunded for unused gas


### PR DESCRIPTION
In the specification logic as it stands, there's no check that the gas consumed by executing a transaction (`gas_used`) is below the max gas specified for the transaction (`transaction.gas_limit`). This means the `gas_refund` could be negative. This adds a simple check that the gas consumed by executing a transaction is less than the limit. (If this is meant to be implicit, i.e., `self.execute_transaction()` respects `transaction.gas_limit`, a comment should be added to this effect.)