### PR TITLE
EIP2333: Remove unnecessary I2OSP.

### DIFF
--- a/EIPS/eip-2333.md
+++ b/EIPS/eip-2333.md
@@ -116,7 +116,7 @@ Every key generated via the key derivation process derives a child key via a set
 
 ```text
 0. salt = I2OSP(index, 4)
-1. IKM = I2OSP(parent_SK, 32)
+1. IKM = parent_SK
 2. lamport_0 = IKM_to_lamport_SK(IKM, salt)
 3. not_IKM = flip_bits(IKM)
 4. lamport_1 = IKM_to_lamport_SK(not_IKM, salt)


### PR DESCRIPTION
I2OSP operates on numbers. parent_SK is not a number.
