### PR TITLE
1193: Fix example errata

### DIFF
--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -464,7 +464,7 @@ ethereum
 ethereum
   .request({
     method: 'eth_getBlockByNumber',
-    params: ['latest', 'true'],
+    params: ['latest', true],
   })
   .then((block) => {
     console.log(`Block ${block.number}:`, block);

--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -500,7 +500,7 @@ ethereum
       if (message.type === 'eth_subscription') {
         const { data } = message;
         if (data.subscription === subscriptionId) {
-          if (typeof data.result === 'string' && data.result) {
+          if (data.result && typeof data.result === 'object') {
             const block = data.result;
             console.log(`New block ${block.number}:`, block);
           } else {

--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -500,7 +500,7 @@ ethereum
       if (message.type === 'eth_subscription') {
         const { data } = message;
         if (data.subscription === subscriptionId) {
-          if (data.result && typeof data.result === 'object') {
+          if ('result' in data && typeof data.result === 'object') {
             const block = data.result;
             console.log(`New block ${block.number}:`, block);
           } else {


### PR DESCRIPTION
This PR fixes two errata in the EIP-1193 examples section, special thanks to @enolan for noting in https://github.com/ethereum/EIPs/issues/2319#issuecomment-734159349 and https://github.com/ethereum/EIPs/issues/2319#issuecomment-734169215.