### PR TITLE
Fix EIP-695 example `id` mismatch

### DIFF
--- a/EIPS/eip-695.md
+++ b/EIPS/eip-695.md
@@ -54,7 +54,7 @@ None.
 #### Example
 
 ```js
-curl -X POST --data '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":1}'
+curl -X POST --data '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":83}'
 
 // Result
 {


### PR DESCRIPTION
[JSON-RPC](https://www.jsonrpc.org/specification) specifies that when a client sends an `id`, the _Server MUST reply with the same value in the Response object_.
In [EIP-695](./EIPs/eip-695.md) example, the client sent `id: 1` and the server replied `id: 83`.

This commit updates Client's request to send `id: 83` instead.

Changes:
+ Update eip-695 example to conform JSON-RPC specification

When opening a pull request to submit a new EIP, please use the suggested template: https://github.com/ethereum/EIPs/blob/master/eip-template.md

We have a GitHub bot that automatically merges some PRs. It will merge yours immediately if certain criteria are met:

 - The PR edits only existing draft PRs.
 - The build passes.
 - Your GitHub username or email address is listed in the 'author' header of all affected PRs, inside <triangular brackets>.
 - If matching on email address, the email address is the one publicly listed on your GitHub profile.
