### PR TITLE
Adds chainId and yParity; removes senderV

### DIFF
--- a/EIPS/eip-2930.md
+++ b/EIPS/eip-2930.md
@@ -46,7 +46,7 @@ This EIP serves two functions:
 | `ACCESS_LIST_STORAGE_KEY_COST` | 1900 |
 | `ACCESS_LIST_ADDRESS_COST` | 2400 |
 
-As of `FORK_BLOCK_NUMBER`, we introduce a new transaction type, with the format `1 || rlp([chainId, nonce, gasPrice, gasLimit, to, value, data, access_list, senderYParity, senderR, senderS])`. The signing hash would be the hash of the RLP of the entire data structure but popping the last three items representing the signature, and prepending the transaction type: `rlp([1, chainId, nonce, gasPrice, gasLimit, to, value, data, access_list])`.
+As of `FORK_BLOCK_NUMBER`, we introduce a new transaction type, with the format `1 || rlp([chainId, nonce, gasPrice, gasLimit, to, value, data, access_list, yParity, senderR, senderS])`. The signing hash would be the hash of the RLP of the entire data structure but popping the last three items representing the signature, and prepending the transaction type: `rlp([1, chainId, nonce, gasPrice, gasLimit, to, value, data, access_list])`.
 
 For the transaction to be valid, `access_list` must be of type `[[{20 bytes}, [{32 bytes}...]]...]`, where `...` means "zero or more of the thing to the left". For example, the following is a valid access list (all hex strings would in reality be in byte representation):
 

--- a/EIPS/eip-2930.md
+++ b/EIPS/eip-2930.md
@@ -33,7 +33,7 @@ This EIP serves two functions:
 
 **`TransactionType`** `1`.  See [EIP-2718](./eip-2718.md)
 
-**`ChainId`** The transaction is valid if this value is `0` or it is included in a block on a chain whose ID is equal to this value.
+**`ChainId`** The transaction is valid only if this value is included in a block on a chain whose ID is equal to this value.
 
 **`YParity`** The parity (0 for even, 1 for odd) of the y-value of a secp256k1 signature.
 

--- a/EIPS/eip-2930.md
+++ b/EIPS/eip-2930.md
@@ -16,7 +16,7 @@ Adds a transaction type which contains an access list, a list of addresses and s
 
 ## Abstract
 
-We introduce a new [EIP-2718](./eip-2718.md) transaction type, with the format `1 || rlp([nonce, gasPrice, gasLimit, to, value, data, access_list, senderV, senderR, senderS])`.
+We introduce a new [EIP-2718](./eip-2718.md) transaction type, with the format `1 || rlp([chainId, nonce, gasPrice, gasLimit, to, value, data, access_list, senderYParity, senderR, senderS])`.
 
 The `access_list` specifies a list of addresses and storage keys; these addresses and storage keys are added into the `accessed_addresses` and `accessed_storage_keys` global sets (introduced in [EIP-2929](./eip-2929.md)). A gas cost is charged, though at a discount relative to the cost of accessing outside the list.
 
@@ -29,6 +29,15 @@ This EIP serves two functions:
 
 ## Specification
 
+### Definitions
+
+**`TransactionType`** `1`.  See [EIP-2718](./eip-2718.md)
+
+**`ChainId`** The transaction is valid if this value is `0` or it is included in a block on a chain whose ID is equal to this value.
+
+**`YParity`** The parity (0 for even, 1 for odd) of the y-value of a secp256k1 signature.
+
+
 ### Parameters
 
 | Constant | Value |
@@ -37,7 +46,7 @@ This EIP serves two functions:
 | `ACCESS_LIST_STORAGE_KEY_COST` | 1900 |
 | `ACCESS_LIST_ADDRESS_COST` | 2400 |
 
-As of `FORK_BLOCK_NUMBER`, we introduce a new transaction type, with the format `1 || rlp([chainId, nonce, gasPrice, gasLimit, to, value, data, access_list, senderV, senderR, senderS])`. The signing hash would be the hash of the RLP of the entire data structure but popping the last three items representing the signature, and prepending the transaction type: `rlp([1, chainId, nonce, gasPrice, gasLimit, to, value, data, access_list])`. `chainId` is defined to be an integer of arbitrary size. Since `chainId` no longer resides in the signature, `v` must be either 0 or 1 depending on recovery id.
+As of `FORK_BLOCK_NUMBER`, we introduce a new transaction type, with the format `1 || rlp([chainId, nonce, gasPrice, gasLimit, to, value, data, access_list, senderYParity, senderR, senderS])`. The signing hash would be the hash of the RLP of the entire data structure but popping the last three items representing the signature, and prepending the transaction type: `rlp([1, chainId, nonce, gasPrice, gasLimit, to, value, data, access_list])`.
 
 For the transaction to be valid, `access_list` must be of type `[[{20 bytes}, [{32 bytes}...]]...]`, where `...` means "zero or more of the thing to the left". For example, the following is a valid access list (all hex strings would in reality be in byte representation):
 
@@ -90,8 +99,6 @@ def process_access_list(access_list) -> Tuple[List[Set[Address], Set[Pair[Addres
 ```
 
 The access list is NOT charged per-byte fees like tx data is; the per-item costs described above are meant to cover the bandwidth costs of the access list data in addition to the costs of accessing those accounts and storage keys when evaluating the transaction.
-
-Clarification: the transaction is valid only if `chainId` is equal to the chain id of the current network. 
 
 ## Rationale
 

--- a/EIPS/eip-2930.md
+++ b/EIPS/eip-2930.md
@@ -16,7 +16,7 @@ Adds a transaction type which contains an access list, a list of addresses and s
 
 ## Abstract
 
-We introduce a new [EIP-2718](./eip-2718.md) transaction type, with the format `1 || rlp([chainId, nonce, gasPrice, gasLimit, to, value, data, access_list, senderYParity, senderR, senderS])`.
+We introduce a new [EIP-2718](./eip-2718.md) transaction type, with the format `1 || rlp([chainId, nonce, gasPrice, gasLimit, to, value, data, access_list, yParity, senderR, senderS])`.
 
 The `access_list` specifies a list of addresses and storage keys; these addresses and storage keys are added into the `accessed_addresses` and `accessed_storage_keys` global sets (introduced in [EIP-2929](./eip-2929.md)). A gas cost is charged, though at a discount relative to the cost of accessing outside the list.
 

--- a/EIPS/eip-2930.md
+++ b/EIPS/eip-2930.md
@@ -33,7 +33,7 @@ This EIP serves two functions:
 
 **`TransactionType`** `1`.  See [EIP-2718](./eip-2718.md)
 
-**`ChainId`** The transaction is valid only if this value is included in a block on a chain whose ID is equal to this value.
+**`ChainId`** The transaction only valid on networks with this `chainID`.
 
 **`YParity`** The parity (0 for even, 1 for odd) of the y-value of a secp256k1 signature.
 


### PR DESCRIPTION
`chainId` was missing from abstract.

Discussion in Discord landed on switching over to `yParity` instead of `v` since `chainId` so now part of the payload explicitly and the `+27` stuff is tech debt from Bitcoin.