### PR TITLE
2930: Adds receipt and non-normative change to improve readability.

### DIFF
--- a/EIPS/eip-2930.md
+++ b/EIPS/eip-2930.md
@@ -46,7 +46,13 @@ This EIP serves two functions:
 | `ACCESS_LIST_STORAGE_KEY_COST` | 1900 |
 | `ACCESS_LIST_ADDRESS_COST` | 2400 |
 
-As of `FORK_BLOCK_NUMBER`, we introduce a new transaction type, with the format `1 || rlp([chainId, nonce, gasPrice, gasLimit, to, value, data, access_list, yParity, senderR, senderS])`. The signing hash would be the hash of the RLP of the entire data structure but popping the last three items representing the signature, and prepending the transaction type: `rlp([1, chainId, nonce, gasPrice, gasLimit, to, value, data, access_list])`.
+As of `FORK_BLOCK_NUMBER`, a new [EIP-2718](./eip-2718.md) transaction is introduced with `TransactionType` `1`.
+
+The [EIP-2718](./eip-2718.md) `TransactionPayload` for this transaction is `rlp([chainId, nonce, gasPrice, gasLimit, to, value, data, access_list, yParity, senderR, senderS])`.
+
+The `yParity, senderR, senderS` elements of this transaction represent a secp256k1 signature over `keccak256(rlp([1, chainId, nonce, gasPrice, gasLimit, to, value, data, access_list]))`.
+
+The [EIP-2718](./eip-2718.md) `ReceiptPayload` for this transaction is `rlp([status, cumulativeGasUsed, logsBloom, logs])`.
 
 For the transaction to be valid, `access_list` must be of type `[[{20 bytes}, [{32 bytes}...]]...]`, where `...` means "zero or more of the thing to the left". For example, the following is a valid access list (all hex strings would in reality be in byte representation):
 


### PR DESCRIPTION
We forgot to define the receipt structure for this transaction (required by 2718).  I went with a mirror of legacy transaction receipts, though I am open to some alternative structure.

Some of the stuff we were defining here is already defined in 2718, and I believe redefining it was adding confusion and making iteration on this spec more challenging than it needed to be.