### PR TITLE
Moved EIP 2481 to last call

### DIFF
--- a/EIPS/eip-2481.md
+++ b/EIPS/eip-2481.md
@@ -3,7 +3,7 @@ eip: 2481
 title: "eth/66: request identifier"
 author: Christoph Burgdorf <christoph@ethereum.org>
 discussions-to: https://github.com/ethereum/EIPs/issues/2482
-status: Draft
+status: Review
 type: Standards Track
 category: Networking
 created: 2020-01-17


### PR DESCRIPTION
I was asked to move this EIP to "Last Call" to draw attention to the EIP with the intention to move it to final in two weeks.

I'm a bit out of touch with the issue at hand (because I have changed roles and am currently no longer active in client development. For the curious, I'm working on [ethereum/fe](https://github.com/ethereum/fe) now)

I did a quick check on the latest development on the issue and my impression is that:

1. All client teams are on board to implement this

2. Most are waiting on Geth to move first

3. @karalabe from Geth said they would implement it before the Berlin fork (Citing from discord)

>Option A: We roll out 66 (request id), 67 (typed tx in blocks, tx-announce etc)
>- Drawback: Everyone must implement 65 (tx hashes), 66 and 67 before Berlin. - The entire network can drop support for eth<67 after the hard fork passes.

>Option B: We allow typed transactions in earlier eth protocol versions. BUT - Geth will implement 66 (request id), before Berlin. So after Berlin, all Geth nodes on the network will guaranteed speak eth/66.
>- Geth will drop eth/63 this year, eth/64 by spring 2021 and eth/65 by summer 2021  
**Either way, Geth will drop support for anything but the latest eth protocol by next year summer.**  

Given that, I'm moving this forward to "Last Call" under the impression that this would be in everyone's interest.
