### PR TITLE
change example in eip-3135

### DIFF
--- a/EIPS/Exclusive_Claimable_Token.md
+++ b/EIPS/Exclusive_Claimable_Token.md
@@ -1,0 +1,198 @@
+---
+eip: 2871
+title: Exclusive Claimable Token
+author: Zhenyu Sun (@Ungigdu)
+discussions-to: https://github.com/ethereum/EIPs/issues/3132
+status: Draft
+type: Standards Track
+category: ERC
+created: 2020-8-10
+requires: 20
+---
+
+## Simple Summary
+<!--"If you can't explain it simply, you don't understand it well enough." Provide a simplified and layman-accessible explanation of the EIP.-->
+
+This standard defines a token which can be claimed only by token issuer with payer's signature.
+
+## Abstract
+<!--A short (~200 word) description of the technical issue being addressed.-->
+
+When monitoring network traffic, counting paid e-mail messages or buy merchandise in general store, small but frequent payments are needed. We can't directly transfer tokens on chain to make payment because the sum gas cost is big and it takes time for blockchain to reach a consensus. 
+
+This standard allows service provider to establish micropayment channels with many users by creating claimable token. A user gets claimable token and can make part of balance "active" as deposit to this channel. When using service, user should sign messages off chain to service provider and provider checks if user is honest with accumulating amount in message and checks if this amount is less than active balance. If check passed, provider continue to serve user, otherwise reject. 
+
+At anytime, the service provider can claim the right amount of token on chain providing the last signed message it accepts and this claim function can only be called by issuer to avoid double spending.
+
+## Motivation
+<!--The motivation is critical for EIPs that want to change the Ethereum protocol. It should clearly explain why the existing protocol specification is inadequate to address the problem that the EIP solves. EIP submissions without sufficient motivation may be rejected outright.-->
+There are two motivations for this standard, one is to reduce gas costs, the other is to link Ethereum to real-world payment problem: pay for usage.
+
+This token standard is useful in basically two types of businesses: 1. Real-world merchant (whose identity is known by user) can use this token as recharge card; 2. Online service provider (whose identity may not be known by user or is hard to reach) can use this token to build an automatic micropayment channel. In both cases, the token is the representation of provider's service/products, and should only be claimed by provider's "issuer" account.
+
+## Specification
+<!--The technical specification should describe the syntax and semantics of any new feature. The specification should be detailed enough to allow competing, interoperable implementations for any of the current Ethereum platforms (go-ethereum, parity, cpp-ethereum, ethereumj, ethereumjs, and [others](https://github.com/ethereum/wiki/wiki/Clients)).-->
+
+```solidity
+interface IStamp is IERC20{
+
+    function iconUrl() external view returns (string memory);
+    function issuer() external view returns (address);
+    function claim(address from, uint256 credit, uint256 epoch, bytes calldata signature) external;
+    function transferIssuer(address newIssuer) external;
+    function active(uint256 amount) external;
+    function deactive(address to, uint256 amount) external;
+    function activeBalanceOf(address user) external view returns(uint256 balance, uint256 activedSum, uint256 epoch);
+
+    event Active(
+        address indexed from,
+        uint256 amount
+    );
+
+    event Deactive(
+        address indexed to,
+        uint256 amount
+    );
+    
+    event TransferIssuer(
+        address indexed oldIssuer,
+        address indexed newIssuer
+    );
+
+    event Claim(
+        address indexed from,
+        address indexed to,
+        uint256 epoch,
+        uint256 credit
+    );
+}
+```
+
+### Functions
+
+#### iconUrl
+
+Returns the image url of this token or descriptive resources
+
+#### issuer
+
+Returns the issuer of this token. Only issuer can claim token so there is no generally double spending problems.
+
+#### transferIssuer
+
+Transfer issuer role by changing its address.
+
+| Parameter | Description |
+| ---------|-------------|
+| newIssuer | The new issuer address |
+
+#### active
+
+User can make part of token balance 'active' as deposit to ensure micropayments. Token can only be claimed from active balance. This works likes 'increaseAllowance', except the active amount is removed from user's balance.
+
+| Parameter | Description |
+| ---------|-------------|
+| amount | amount to active |
+
+#### deactive
+
+This function should have different implementation based on business model. For real-world businesses, such as recharge card of general store or membership card of fitness center, deactive should be called by merchant, act as refund function to return active balance to user's balance; for online businesses, user may found it hard to contact with service provider, so the deactive is called by user itself, with limitations such as epoch number didn't change for some period of time. Also gets token in active balance back.
+
+| Parameter | Description |
+| ---------|-------------|
+| to | the account to perform deactive on |
+| amount | amount to active |
+
+#### activeBalanceOf
+
+Returns balance, active balance and epoch of user account. The epoch is an increasing number which is added by one when account get claimed or deactive. Epoch is a part of sign data, verified by both user and provider, prevents double spend and double claim.
+
+| Parameter | Description |
+| ---------|-------------|
+| user | user account address |
+
+#### claim
+
+Service provider (account of issuer) recovers unsigned message, then checks the message with it's signature (probably using built-in function 'ecrecover'). If the signature is successfully verified, provider get "credit" amount token from user's active balance and epoch is increased by 1. It is worth mentioning that the provider may not need to get token back because this token is basically created by this provider and holds no value to itself. In that case, the claim function can release some other more valuable token to provider. 
+
+| Parameter | Description |
+| ---------|-------------|
+| from | which user account to be claimed |
+| credit | how many token should be claimed |
+| epoch | current epoch number |
+| signature| micropayment message signature signed by user|
+
+
+### Events
+
+#### Active
+
+Event emits when user calls active function
+
+| Parameter | Description |
+| ---------|-------------|
+| from | indexed msg.sender |
+| amount | amount to be active|
+
+#### Deactive
+
+| Parameter | Description |
+| ---------|-------------|
+| to | indexed account to deactive on |
+| amount | amount to deactive|
+
+#### TransferIssuer
+
+Event emits when transferIssuer is called
+
+| Parameter | Description |
+| ---------|-------------|
+| oldIssuer | old issuer/beneficiary |
+| newIssuer | new issuer/beneficiary |
+
+#### Claim
+
+Event emits when claim is called
+
+| Parameter | Description |
+| ---------|-------------|
+| from | user account to be claimed |
+| to | msg.sender, the issuer |
+| epoch | which epoch is based on |
+| credit | how many token be claimed |
+
+## Rationale
+This standards provides a way for user and service provider to establish micropayment channel to make free and repaid payment messages off blockchain. Those payment messages are linked one by one, providing a trace of service consumption and keeps an increasing number of credit, which is how much the payer owned to the service provider.
+
+The provider can stop serving when payer no longer send new valid payment message or the credit is bigger than active balance. The user can stop signing new message if provider is not available or is cheating. The provider can claim token on chain at any time using the message contains the largest credit number.
+
+Let's explain the usage of exclusive claimable token by two cases.
+
+### 1. Token as recharge card of general store
+
+Like ordinary recharge card, the user pays with money/cryptocurrency to store in advance for a recharge card (with bonus or discount). Then user "activate recharge card" by calling active function. When checking out, the user just sign a message with updated credit (old credit + consumption this time) to store server. Server then verify this message and check the credit off chain. Then the shopping process goes on and on with out any blockchain involved. Until the user want to fund money. The shopping service should first make claim call to remove all credit from active balance, then call deactive function to return remaining token to user. Finally the user should transfer all token back to store to get money back, which is not a part of this discussion. The advantages are as follows:
+
+- Token as card point can transfer between users freely
+- The functions are built in token contract so the interacts with blockchain can be minimal for both parties
+- The modification work from ordinary card system to token as card system is much less
+
+### 2. Token as counter of online service
+
+Assume we have a distributed VPN service which user pays by token. Unlike general store case, users and servers do not know each other and don't trust each other.  So there is two ways to implement claimable token based on the value of this token. If this token is widely accepted and holds value, token itself will serve as currency to buy service; if this token is just created on demand and is nothing more than number, this token will serve as a contract which user can deposit other token to. When using VPN service, the user active some token, and establish a counter channel with VPN service miner. For each x MB network traffic, the user signs a message to service miner, miner checks credit and user's active balance (this check can be done by pool rather than single miner) and decides to serve or not. This checking/serving process is in parallel. Because user can't trust VPN server, the deactive function must be called by user. To make sure user can't just use service and deactive balance back before server claims, some checks are needed, for example, user can only deactive token when epoch is not increased in a month. So, the server should claim at least monthly. The advantages are as follows:
+
+- Token is equal to service, and can be transferred
+- Token can act as stock of other valuable token
+- Token consumes only when server servers, no trust needed
+- Interaction with blockchain is minimal
+
+## Backwards Compatibility
+This EIP is fully backwards compatible as its implementation extends the functionality of [ERC-20].
+
+## Implementation
+The GitHub repository [Bmail_Token](https://github.com/realbmail/Bmail_token) contains the work in progress implementation.
+
+## Security Considerations
+There are many options to implement this token, leaving room for bugs and malicious codes. It's better to introduce factory contracts to create boilerplate claimable token.
+
+## Copyright
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/EIPS/eip-3135.md
+++ b/EIPS/eip-3135.md
@@ -20,36 +20,41 @@ This standard defines a token which can be claimed only by token issuer with pay
 
 When monitoring network traffic, counting paid e-mail messages or buy merchandise in general store, small but frequent payments are needed. We can't directly transfer tokens on chain to make payment because the sum gas cost is big and it takes time for blockchain to reach a consensus. 
 
-This standard allows service provider to establish micropayment channels with many users by creating claimable token. A user gets claimable token and can make part of balance "active" as deposit to this channel. When using service, user should sign messages off chain to service provider and provider checks if user is honest with accumulating amount in message and checks if this amount is less than active balance. If check passed, provider continue to serve user, otherwise reject. 
+This standard allows service provider to establish micropayment channels with many users by creating claimable token. A user gets claimable token and can take part of balance as deposit to this channel. When using service, user should sign messages off chain to service provider and provider checks if user is honest with the accumulating credit in message and checks if this amount is less than deposit balance. If check passed, provider continue to serve user, otherwise reject. 
 
-At anytime, the service provider can claim the right amount of token on chain providing the last signed message it accepts and this claim function can only be called by issuer to avoid double spending.
+At anytime, the service provider can claim the right amount of token on chain providing the last signed message it accepts. And this claim function can only be called by issuer to avoid double spending, that's the "exclusive" part of token.
 
 ## Motivation
 <!--The motivation is critical for EIPs that want to change the Ethereum protocol. It should clearly explain why the existing protocol specification is inadequate to address the problem that the EIP solves. EIP submissions without sufficient motivation may be rejected outright.-->
 There are two motivations for this standard, one is to reduce gas costs, the other is to link Ethereum to real-world payment problem: pay for usage.
 
-This token standard is useful in basically two types of businesses: 1. Real-world merchant (whose identity is known by user) can use this token as recharge card; 2. Online service provider (whose identity may not be known by user or is hard to reach) can use this token to build an automatic micropayment channel. In both cases, the token is the representation of provider's service/products, and should only be claimed by provider's "issuer" account.
+This token standard is useful in basically two types of businesses: 1. Real-world merchant (whose identity is known by user) can use this token as recharge card; 2. Online service provider (whose identity may not be known by user or is hard to reach) can use this token to build an automatic micropayment channel. In both cases, the token is the representation of provider's service/products, explained by provider and claimed by provider.
 
 ## Specification
 <!--The technical specification should describe the syntax and semantics of any new feature. The specification should be detailed enough to allow competing, interoperable implementations for any of the current Ethereum platforms (go-ethereum, parity, cpp-ethereum, ethereumj, ethereumjs, and [others](https://github.com/ethereum/wiki/wiki/Clients)).-->
 
 ```solidity
+pragma solidity  ^0.6;
+
+import "./IERC20.sol";
+// SPDX-License-Identifier: MIT
+
 interface IStamp is IERC20{
 
     function iconUrl() external view returns (string memory);
     function issuer() external view returns (address);
     function claim(address from, uint256 credit, uint256 epoch, bytes calldata signature) external;
     function transferIssuer(address newIssuer) external;
-    function active(uint256 amount) external;
-    function deactive(address to, uint256 amount) external;
-    function activeBalanceOf(address user) external view returns(uint256 balance, uint256 activedSum, uint256 epoch);
+    function deposit(uint256 amount) external;
+    function withdraw(address to, uint256 amount) external;
+    function depositBalanceOf(address user) external view returns(uint256 depositBalance, uint256 epoch);
 
-    event Active(
+    event Deposit(
         address indexed from,
         uint256 amount
     );
 
-    event Deactive(
+    event Withdraw(
         address indexed to,
         uint256 amount
     );
@@ -86,26 +91,26 @@ Transfer issuer role by changing its address.
 | ---------|-------------|
 | newIssuer | The new issuer address |
 
-#### active
+#### deposit
 
-User can make part of token balance 'active' as deposit to ensure micropayments. Token can only be claimed from active balance. This works likes 'increaseAllowance', except the active amount is removed from user's balance.
-
-| Parameter | Description |
-| ---------|-------------|
-| amount | amount to active |
-
-#### deactive
-
-This function should have different implementation based on business model. For real-world businesses, such as recharge card of general store or membership card of fitness center, deactive should be called by merchant, act as refund function to return active balance to user's balance; for online businesses, user may found it hard to contact with service provider, so the deactive is called by user itself, with limitations such as epoch number didn't change for some period of time. Also gets token in active balance back.
+User can take part of token balance as deposit to ensure micropayments. Token can only be claimed from deposit balance. This works likes 'increaseAllowance', except the deposit is removed from user's balance.
 
 | Parameter | Description |
 | ---------|-------------|
-| to | the account to perform deactive on |
-| amount | amount to active |
+| amount | amount to deposit |
 
-#### activeBalanceOf
+#### withdraw
 
-Returns balance, active balance and epoch of user account. The epoch is an increasing number which is added by one when account get claimed or deactive. Epoch is a part of sign data, verified by both user and provider, prevents double spend and double claim.
+This function should have different implementation based on business model. For real-world businesses, such as recharge card of general store or membership card of fitness center, withdraw should be called by merchant, act as refund function to return remaining deposit balance to user's balance; for online businesses, user may found it hard to contact with service provider, so the deposit is called by user itself, with limitations such as epoch number didn't change for some period of time. Also gets token in deposit back.
+
+| Parameter | Description |
+| ---------|-------------|
+| to | the deposit account |
+| amount | amount to return |
+
+#### depositBalanceOf
+
+Returns deposit balance and epoch of user account. The epoch is an increasing number which is added by one when account get claimed or withdraw. Epoch is a part of sign data, verified by both user and provider, prevents double spend and double claim.
 
 | Parameter | Description |
 | ---------|-------------|
@@ -113,7 +118,7 @@ Returns balance, active balance and epoch of user account. The epoch is an incre
 
 #### claim
 
-Service provider (account of issuer) recovers unsigned message, then checks the message with it's signature (probably using built-in function 'ecrecover'). If the signature is successfully verified, provider get "credit" amount token from user's active balance and epoch is increased by 1. It is worth mentioning that the provider may not need to get token back because this token is basically created by this provider and holds no value to itself. In that case, the claim function can release some other more valuable token to provider. 
+Service provider (issuer) recovers unsigned message, then checks the message with it's signature (probably using built-in function 'ecrecover'). If the signature is successfully verified, provider get "credit" amount token from user's deposit balance and epoch is increased by 1. It is worth mentioning that the provider may not need to get token back because this token is basically created by this provider and may holds no value to itself. In that case, the claim function can release some other more valuable token to provider. 
 
 | Parameter | Description |
 | ---------|-------------|
@@ -125,21 +130,21 @@ Service provider (account of issuer) recovers unsigned message, then checks the 
 
 ### Events
 
-#### Active
+#### Deposit
 
-Event emits when user calls active function
+Event emits when user calls deposit function
 
 | Parameter | Description |
 | ---------|-------------|
 | from | indexed msg.sender |
-| amount | amount to be active|
+| amount | deposit amount|
 
-#### Deactive
+#### Withdraw
 
 | Parameter | Description |
 | ---------|-------------|
-| to | indexed account to deactive on |
-| amount | amount to deactive|
+| to | the deposit account |
+| amount | amount to return |
 
 #### TransferIssuer
 
@@ -164,13 +169,13 @@ Event emits when claim is called
 ## Rationale
 This standards provides a way for user and service provider to establish micropayment channel to make free and repaid payment messages off blockchain. Those payment messages are linked one by one, providing a trace of service consumption and keeps an increasing number of credit, which is how much the payer owned to the service provider.
 
-The provider can stop serving when payer no longer send new valid payment message or the credit is bigger than active balance. The user can stop signing new message if provider is not available or is cheating. The provider can claim token on chain at any time using the message contains the largest credit number.
+The provider can stop serving when payer no longer send new valid payment message or the credit is bigger than deposit balance. The user can stop signing new message if provider is not available or is cheating. The provider can claim token on chain at any time using the message contains the largest credit number.
 
 Let's explain the usage of exclusive claimable token by two cases.
 
 ### 1. Token as recharge card of general store
 
-Like ordinary recharge card, the user pays with money/cryptocurrency to store in advance for a recharge card (with bonus or discount). Then user "activate recharge card" by calling active function. When checking out, the user just sign a message with updated credit (old credit + consumption this time) to store server. Server then verify this message and check the credit off chain. Then the shopping process goes on and on with out any blockchain involved. Until the user want to fund money. The shopping service should first make claim call to remove all credit from active balance, then call deactive function to return remaining token to user. Finally the user should transfer all token back to store to get money back, which is not a part of this discussion. The advantages are as follows:
+Like ordinary recharge card, the user pays with money/cryptocurrency to store in advance for a recharge card (with bonus or discount). Then user "activate recharge card" by calling deposit function. When checking out, the user just sign a message with updated credit (old credit + consumption this time) to store server. Server then verify this message and check the credit off chain. Then the shopping process goes on and on with out any blockchain involved. Until the user want to refund. The shopping service should first make claim call to remove all credit from deposit balance, then call withdraw function to return remaining deposit to user. Finally the user should transfer all token back to store to get money back, which is not a part of this discussion. The advantages are as follows:
 
 - Token as card point can transfer between users freely
 - The functions are built in token contract so the interacts with blockchain can be minimal for both parties
@@ -178,7 +183,7 @@ Like ordinary recharge card, the user pays with money/cryptocurrency to store in
 
 ### 2. Token as counter of online service
 
-Assume we have a distributed VPN service which user pays by token. Unlike general store case, users and servers do not know each other and don't trust each other.  So there is two ways to implement claimable token based on the value of this token. If this token is widely accepted and holds value, token itself will serve as currency to buy service; if this token is just created on demand and is nothing more than number, this token will serve as a contract which user can deposit other token to. When using VPN service, the user active some token, and establish a counter channel with VPN service miner. For each x MB network traffic, the user signs a message to service miner, miner checks credit and user's active balance (this check can be done by pool rather than single miner) and decides to serve or not. This checking/serving process is in parallel. Because user can't trust VPN server, the deactive function must be called by user. To make sure user can't just use service and deactive balance back before server claims, some checks are needed, for example, user can only deactive token when epoch is not increased in a month. So, the server should claim at least monthly. The advantages are as follows:
+Assume we have a distributed VPN service which user pays by token. Unlike general store case, users and servers do not know each other and don't trust each other. So there is two ways to implement claimable token based on the value of this token. If this token is widely accepted and holds value, token itself will serve as currency to buy service; if this token is just created on demand and is nothing more than number, this token will serve as a contract which user can deposit other token to. When using VPN service, the user deposit some token, and establish a counter channel with VPN service miner. For each x MB network traffic, the user signs a message to service miner, miner checks credit and user's deposit balance (this check can be done by pool rather than single miner) and decides to serve or not. This checking/serving process is in parallel. Because user can't trust VPN server, the withdraw function must be called by user. To make sure user can't just use service and withdraw deposit back before server claims, some checks are needed, for example, user can only withdraw token when epoch is not increased in a month. So, the server should claim at least monthly. The advantages are as follows:
 
 - Token is equal to service, and can be transferred
 - Token can act as stock of other valuable token
@@ -189,7 +194,7 @@ Assume we have a distributed VPN service which user pays by token. Unlike genera
 This EIP is fully backwards compatible as its implementation extends the functionality of [ERC-20].
 
 ## Implementation
-The GitHub repository [Bmail_Token](https://github.com/realbmail/Bmail_token) contains the work in progress implementation.
+The GitHub organization [realbmail](https://github.com/realbmail) contains the work in progress implementation about token, micropayment system and DApp.
 
 ## Security Considerations
 There are many options to implement this token, leaving room for bugs and malicious codes. It's better to introduce factory contracts to create boilerplate claimable token.

--- a/EIPS/eip-3135.md
+++ b/EIPS/eip-3135.md
@@ -5,7 +5,7 @@ author: Zhenyu Sun (@Ungigdu)
 discussions-to: https://github.com/ethereum/EIPs/issues/3132
 status: Draft
 type: Standards Track
-category: ERCs
+category: ERC
 created: 2020-08-10
 requires: 20
 ---
@@ -44,7 +44,7 @@ function issuer() external view returns (address);
  *  @dev      Check if msg.sender == issuer
  *  @param    from          Payer's address
  *  @param    consumption   How many token is consumed in this epoch, specified
- *  @param    epoch         Epoch increased by 1 after claim or withdraw, at the beginning of each epoch, comsumption goes back to 0
+ *  @param    epoch         Epoch increased by 1 after claim or withdraw, at the beginning of each epoch, consumption goes back to 0
  *  @param    signature     Signature of payment message signed by payer
 */
 function claim(address from, uint256 consumption, uint256 epoch, bytes calldata signature) external;
@@ -58,7 +58,7 @@ function deposit(uint256 amount) external;
  *  @notice   Give remaining deposite balance back to "to" account, act as "refund" function
  *  @dev      In prepayment module, withdraw is executed from issuer account
  *            In lock-release module, withdraw is executed from user account
- *  @param    to            the account receving remaining deposite
+ *  @param    to            the account receiving remaining deposite
  *  @param    amount        how many token is returned
 */
 function withdraw(address to, uint256 amount) external;

--- a/EIPS/eip-3135.md
+++ b/EIPS/eip-3135.md
@@ -178,7 +178,7 @@ In prepayment business model such as using token as recharge card of general sto
 
 2. lock-release model
 
-If we run a paid e-mail service that accepts token as payment, we can use lock-release model. Unlike prepayment, we charge X * N token for a mail sent to N recipients. In this "pay for usage" scenario, the counting of services happens on both client and server side. The client should not trust charge amount given by server in case the it's malfunctioning or malicious. When client decide not to trust server, it stops signing messages, but some of token is taken hostage in deposit balance. To fix this problem, the withdraw function should be executed by payer account with limitation such as epoch didn't change in a month.
+If we run a paid end-to-end encrypted e-mail service that accepts token as payment, we can use lock-release model. Unlike prepayment, we charge X * N token for an e-mail sent to N recipients. In this "pay for usage" scenario, the counting of services happens on both client and server side. The client should not trust charge amount given by server in case the it's malfunctioning or malicious. When client decide not to trust server, it stops signing messages, but some of token is taken hostage in deposit balance. To fix this problem, the withdraw function should be executed by payer account with limitation such as epoch didn't change in a month.
 
 ## Rationale
 

--- a/EIPS/eip-3135.md
+++ b/EIPS/eip-3135.md
@@ -5,199 +5,202 @@ author: Zhenyu Sun (@Ungigdu)
 discussions-to: https://github.com/ethereum/EIPs/issues/3132
 status: Draft
 type: Standards Track
-category: ERC
-created: 2020-8-10
+category: ERCs
+created: 2020-08-10
 requires: 20
 ---
 
 ## Simple Summary
-<!--"If you can't explain it simply, you don't understand it well enough." Provide a simplified and layman-accessible explanation of the EIP.-->
 
 This standard defines a token which can be claimed only by token issuer with payer's signature.
 
 ## Abstract
-<!--A short (~200 word) description of the technical issue being addressed.-->
 
-When monitoring network traffic, counting paid e-mail messages or buy merchandise in general store, small but frequent payments are needed. We can't directly transfer tokens on chain to make payment because the sum gas cost is big and it takes time for blockchain to reach a consensus. 
-
-This standard allows service provider to establish micropayment channels with many users by creating claimable token. A user gets claimable token and can take part of balance as deposit to this channel. When using service, user should sign messages off chain to service provider and provider checks if user is honest with the accumulating credit in message and checks if this amount is less than deposit balance. If check passed, provider continue to serve user, otherwise reject. 
-
-At anytime, the service provider can claim the right amount of token on chain providing the last signed message it accepts. And this claim function can only be called by issuer to avoid double spending, that's the "exclusive" part of token.
+This EIP defines a set of additions to the default token standard such as ERC-20, that allows online/offline service providers establish micropayment channels with any number of users by signing and verifying messages about the consumption of token off chain. Using this mechanism will reduce interactions with blockchain to minimal for both participants, thus saving gas and improve performance.
 
 ## Motivation
-<!--The motivation is critical for EIPs that want to change the Ethereum protocol. It should clearly explain why the existing protocol specification is inadequate to address the problem that the EIP solves. EIP submissions without sufficient motivation may be rejected outright.-->
-There are two motivations for this standard, one is to reduce gas costs, the other is to link Ethereum to real-world payment problem: pay for usage.
 
-This token standard is useful in basically two types of businesses: 1. Real-world merchant (whose identity is known by user) can use this token as recharge card; 2. Online service provider (whose identity may not be known by user or is hard to reach) can use this token to build an automatic micropayment channel. In both cases, the token is the representation of provider's service/products, explained by provider and claimed by provider.
+There are two main purposes of this EIP, one is to reduce interactions with blockchain, the second is to link Ethereum to real-world payment problems.
+
+Many small businesses want to build payment system based on blockchain but find it difficult. There are basically two ways: 
+
+1. Directly pay with token. There are many wallet can receive and transfer token but transactions on Ethereum cost gas and take time to confirm.
+2. User lock token on payment smart contract and service provider use payment messages signed by user to release token, establishing a micropayment channel. The advantage is interactions with blockchain is reduced and the signing/verifying process is off-chain. But interact with payment contract needs service provider to build a DApp, which require resources many small businesses do not have. Even if they managed to build DApps, they are all different, not standardized. Also, user should have a wallet with DApp browser and has to learn how to use it.
+
+This EIP helps to standardize the interactions of micropayment system, and make it possible for wallet build a universal UI in the future.
 
 ## Specification
-<!--The technical specification should describe the syntax and semantics of any new feature. The specification should be detailed enough to allow competing, interoperable implementations for any of the current Ethereum platforms (go-ethereum, parity, cpp-ethereum, ethereumj, ethereumjs, and [others](https://github.com/ethereum/wiki/wiki/Clients)).-->
 
 ```solidity
-pragma solidity  ^0.6;
 
-import "./IERC20.sol";
-// SPDX-License-Identifier: MIT
+/// @return Image url of this token or descriptive resources
+function iconUrl() external view returns (string memory);
 
-interface IStamp is IERC20{
+/// @return Issuer of this token. Only issuer can execute claim function
+function issuer() external view returns (address);
 
-    function iconUrl() external view returns (string memory);
-    function issuer() external view returns (address);
-    function claim(address from, uint256 credit, uint256 epoch, bytes calldata signature) external;
-    function transferIssuer(address newIssuer) external;
-    function deposit(uint256 amount) external;
-    function withdraw(address to, uint256 amount) external;
-    function depositBalanceOf(address user) external view returns(uint256 depositBalance, uint256 epoch);
+/**
+ *  @notice   Remove consumption from payer's deposite
+ *  @dev      Check if msg.sender == issuer
+ *  @param    from          Payer's address
+ *  @param    consumption   How many token is consumed in this epoch, specified
+ *  @param    epoch         Epoch increased by 1 after claim or withdraw, at the beginning of each epoch, comsumption goes back to 0
+ *  @param    signature     Signature of payment message signed by payer
+*/
+function claim(address from, uint256 consumption, uint256 epoch, bytes calldata signature) external;
 
-    event Deposit(
-        address indexed from,
-        uint256 amount
-    );
+function transferIssuer(address newIssuer) external;
 
-    event Withdraw(
-        address indexed to,
-        uint256 amount
-    );
+/// @notice   Move amount from payer's token balance to deposite balance to ensure payment is sufficient
+function deposit(uint256 amount) external;
+
+/**
+ *  @notice   Give remaining deposite balance back to "to" account, act as "refund" function
+ *  @dev      In prepayment module, withdraw is executed from issuer account
+ *            In lock-release module, withdraw is executed from user account
+ *  @param    to            the account receving remaining deposite
+ *  @param    amount        how many token is returned
+*/
+function withdraw(address to, uint256 amount) external;
+
+function depositBalanceOf(address user) external view returns(uint256 depositBalance, uint256 epoch);
+
+event Deposit(
+    address indexed from,
+    uint256 amount
+);
+
+event Withdraw(
+    address indexed to,
+    uint256 amount
+);
     
-    event TransferIssuer(
-        address indexed oldIssuer,
-        address indexed newIssuer
-    );
+event TransferIssuer(
+    address indexed oldIssuer,
+    address indexed newIssuer
+);
 
-    event Claim(
-        address indexed from,
-        address indexed to,
-        uint256 epoch,
-        uint256 credit
-    );
-}
+event Claim(
+    address indexed from,
+    address indexed to,
+    uint256 epoch,
+    uint256 consumption
+);
+
 ```
 
-### Functions
+### signature
 
-#### iconUrl
+the pseudo code generating an ECDSA signature:
+```
+sign(keccak256(abi_encode(
+    "\x19Ethereum Signed Message:\n32", 
+        keccak256(abi_encode(
+            token_address,
+            payer_address,
+            token_issuer,
+            token_consumption,        //calculated by user client
+            epoch
+        ))
+    ))
+,private_key)
 
-Returns the image url of this token or descriptive resources
+```
 
-#### issuer
+### verification process
 
-Returns the issuer of this token. Only issuer can claim token so there is no generally double spending problems.
+the verification contains check about both signature and token_consumption
 
-#### transferIssuer
+the pseudo code run by verification server is as follows:
 
-Transfer issuer role by changing its address.
+```
 
-| Parameter | Description |
-| ---------|-------------|
-| newIssuer | The new issuer address |
+serving_loop:
 
-#### deposit
+    for {
+        /**
+         * unpaied_consumption is calculated by provider
+         * signed_consumption is claimable amount
+         * tolerance allows payer "owes" provider to a certain degree
+        */
+        //getSignedConsumption returns amount that are already claimable 
+        if(unpaied_consumption <  signed_consumption + tolerance){
+            informUser("user need charge", unpaied_consumption)
+            interruptService() 
+        }else{
+            isServing() || recoverService()
+        }
+    }
 
-User can take part of token balance as deposit to ensure micropayments. Token can only be claimed from deposit balance. This works likes 'increaseAllowance', except the deposit is removed from user's balance.
+verification_loop:
 
-| Parameter | Description |
-| ---------|-------------|
-| amount | amount to deposit |
+    for {
+        message = incomingMessage()
+        if(recover_signer(message, signature) != payer_address){
+            informUser("check signature failed", hash(message))
+            continue
+        }
 
-#### withdraw
+        /**
+        * optional: when using echo server to sync messages between verification servers
+        * more info about this in Security Considerations section
+        */
+        if(query(message) != message){
+            informUser("message outdate", hash(message))
+            continue   
+        }
 
-This function should have different implementation based on business model. For real-world businesses, such as recharge card of general store or membership card of fitness center, withdraw should be called by merchant, act as refund function to return remaining deposit balance to user's balance; for online businesses, user may found it hard to contact with service provider, so the deposit is called by user itself, with limitations such as epoch number didn't change for some period of time. Also gets token in deposit back.
+        if(epoch != message.epoch || message.consumption > getDepositBalance()){
+            informUser("invalid message", epoch, unpaied_consumption)
+            continue
+        }
+       
+        signed_consumption = message.consumption
+        save(message)
+    }
+    
+claim_process:
 
-| Parameter | Description |
-| ---------|-------------|
-| to | the deposit account |
-| amount | amount to return |
+    if(claim()){
+        unpaied_consumption -= signed_consumption
+        signed_consumption = 0
+        epoch+=1
+    }
 
-#### depositBalanceOf
+```
+### About withdraw
 
-Returns deposit balance and epoch of user account. The epoch is an increasing number which is added by one when account get claimed or withdraw. Epoch is a part of sign data, verified by both user and provider, prevents double spend and double claim.
+The withdraw function is slightly different based on business models
 
-| Parameter | Description |
-| ---------|-------------|
-| user | user account address |
+1. prepayment model
 
-#### claim
+In prepayment business model such as using token as recharge card of general store, the user pays (crypto)currency to store in advance for claimable token as recharge card (with bonus or discount). When checking out, the customer signs a message with updated consumption (old consumption + consumption this time) to store and store verifies this message off chain. The shopping process loops without any blockchain involved, until the customer wants to return the card and get money back. Because the store already holds all currency, the withdraw function should be executed by token issuer (store) to return remaining deposit balance after claim. The prepayment model can easily be built into a wallet with QR-code scanning function.
 
-Service provider (issuer) recovers unsigned message, then checks the message with it's signature (probably using built-in function 'ecrecover'). If the signature is successfully verified, provider get "credit" amount token from user's deposit balance and epoch is increased by 1. It is worth mentioning that the provider may not need to get token back because this token is basically created by this provider and may holds no value to itself. In that case, the claim function can release some other more valuable token to provider. 
+2. lock-release model
 
-| Parameter | Description |
-| ---------|-------------|
-| from | which user account to be claimed |
-| credit | how many token should be claimed |
-| epoch | current epoch number |
-| signature| micropayment message signature signed by user|
-
-
-### Events
-
-#### Deposit
-
-Event emits when user calls deposit function
-
-| Parameter | Description |
-| ---------|-------------|
-| from | indexed msg.sender |
-| amount | deposit amount|
-
-#### Withdraw
-
-| Parameter | Description |
-| ---------|-------------|
-| to | the deposit account |
-| amount | amount to return |
-
-#### TransferIssuer
-
-Event emits when transferIssuer is called
-
-| Parameter | Description |
-| ---------|-------------|
-| oldIssuer | old issuer/beneficiary |
-| newIssuer | new issuer/beneficiary |
-
-#### Claim
-
-Event emits when claim is called
-
-| Parameter | Description |
-| ---------|-------------|
-| from | user account to be claimed |
-| to | msg.sender, the issuer |
-| epoch | which epoch is based on |
-| credit | how many token be claimed |
+If we run a VPN service that accepts token as payment, we can use lock-release model. Unlike prepayment, we charge user X token for every Y bits went through. In this "pay for usage" scenario, the counting of services happens on both client and server side. The client should not trust charge amount given by server in case the it's malfunctioning or malicious. When client decide not to trust server, it stops signing messages, but some of token is taken hostage in deposit balance. To fix this problem, the withdraw function should be executed by payer account with limitation such as epoch didn't change in a month.
 
 ## Rationale
-This standards provides a way for user and service provider to establish micropayment channel to make free and repaid payment messages off blockchain. Those payment messages are linked one by one, providing a trace of service consumption and keeps an increasing number of credit, which is how much the payer owned to the service provider.
 
-The provider can stop serving when payer no longer send new valid payment message or the credit is bigger than deposit balance. The user can stop signing new message if provider is not available or is cheating. The provider can claim token on chain at any time using the message contains the largest credit number.
+This EIP targets on ERC-20 tokens due to its widespread adoption. However, this extension is designed to be compatible with other token standard.
 
-Let's explain the usage of exclusive claimable token by two cases.
-
-### 1. Token as recharge card of general store
-
-Like ordinary recharge card, the user pays with money/cryptocurrency to store in advance for a recharge card (with bonus or discount). Then user "activate recharge card" by calling deposit function. When checking out, the user just sign a message with updated credit (old credit + consumption this time) to store server. Server then verify this message and check the credit off chain. Then the shopping process goes on and on with out any blockchain involved. Until the user want to refund. The shopping service should first make claim call to remove all credit from deposit balance, then call withdraw function to return remaining deposit to user. Finally the user should transfer all token back to store to get money back, which is not a part of this discussion. The advantages are as follows:
-
-- Token as card point can transfer between users freely
-- The functions are built in token contract so the interacts with blockchain can be minimal for both parties
-- The modification work from ordinary card system to token as card system is much less
-
-### 2. Token as counter of online service
-
-Assume we have a distributed VPN service which user pays by token. Unlike general store case, users and servers do not know each other and don't trust each other. So there is two ways to implement claimable token based on the value of this token. If this token is widely accepted and holds value, token itself will serve as currency to buy service; if this token is just created on demand and is nothing more than number, this token will serve as a contract which user can deposit other token to. When using VPN service, the user deposit some token, and establish a counter channel with VPN service miner. For each x MB network traffic, the user signs a message to service miner, miner checks credit and user's deposit balance (this check can be done by pool rather than single miner) and decides to serve or not. This checking/serving process is in parallel. Because user can't trust VPN server, the withdraw function must be called by user. To make sure user can't just use service and withdraw deposit back before server claims, some checks are needed, for example, user can only withdraw token when epoch is not increased in a month. So, the server should claim at least monthly. The advantages are as follows:
-
-- Token is equal to service, and can be transferred
-- Token can act as stock of other valuable token
-- Token consumes only when server servers, no trust needed
-- Interaction with blockchain is minimal
+The reason we chose to implement those functions in token contract rather than a separate record contract is as follows:
+- Token can transfer is more convenient and more general than interact with DApp
+- Token is more standardized and has better UI support
+- Token is equal to service, make token economy more prosperous
+- Remove the approve process
 
 ## Backwards Compatibility
-This EIP is fully backwards compatible as its implementation extends the functionality of [ERC-20].
+
+This EIP is fully backwards compatible as its implementation extends the functionality of [ERC-20](./eip-20.md).
 
 ## Implementation
-The GitHub organization [realbmail](https://github.com/realbmail) contains the work in progress implementation about token, micropayment system and DApp.
+
 
 ## Security Considerations
-There are many options to implement this token, leaving room for bugs and malicious codes. It's better to introduce factory contracts to create boilerplate claimable token.
+
+By restricting claim function to issuer, there is no race condition on chain layer. However double spending problem may occur when the issuer use multiple verifiers and payer signs many payment messages simultaneously. Some of those messages may get chance to be checked valid though only the message with the largest consumption can be claimed. This problem can be fixed by introducing an echo server which accepts messages from verifiers, returns the message sequentially with largest consumption and biggest epoch number. If a verifier gets an answer different from the message he send, it updates the message from echo server as the last message it receives along with local storage of the status about this payer. Then the verifier asks the payer again for a new message.
 
 ## Copyright
+
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/EIPS/eip-3135.md
+++ b/EIPS/eip-3135.md
@@ -196,6 +196,68 @@ This EIP is fully backwards compatible as its implementation extends the functio
 
 ## Implementation
 
+```solidity
+
+mapping (address => StampBalance) private _depositBalance;
+    
+struct StampBalance{
+    uint256 balance;
+    uint256 epoch;
+}
+    
+function deposit(uint256 value) override external{
+    require(value <= _balances[msg.sender]);
+    _balances[msg.sender] = _balances[msg.sender].sub(value);
+    _depositBalance[msg.sender].balance = _depositBalance[msg.sender].balance.add(value);
+    emit Deposit(msg.sender, value);
+}
+
+function withdraw(address to, uint256 value) override onlyIssuer external{
+    require(value <= _depositBalance[to].balance);
+    _depositBalance[to].balance = _depositBalance[to].balance.sub(value);
+    _depositBalance[to].epoch += 1;
+    _balances[to] = _balances[to].add(value);
+    emit Withdraw(to, value);
+}
+    
+function depositBalanceOf(address user) override public view returns(uint256 depositBalance, uint256 epoch){
+    return (_depositBalance[user].balance, _depositBalance[user].epoch);
+}
+
+// prepayment model
+function claim(address from, uint credit, uint epoch, bytes memory signature) override onlyIssuer external{
+    require(credit > 0);
+    require(_depositBalance[from].epoch + 1 == epoch);
+    require(_depositBalance[from].balance >= credit);
+    bytes32 message = keccak256(abi.encode(this, from, _issuer, credit, epoch));
+    bytes32 msgHash = prefixed(message);
+    require(recoverSigner(msgHash, signature) == from);
+    _depositBalance[from].balance = _depositBalance[from].balance.sub(credit);
+    _balances[_issuer] = _balances[_issuer].add(credit);
+    _depositBalance[from].epoch += 1;
+    emit Claim(from, msg.sender, credit, epoch);
+}
+
+function prefixed(bytes32 hash) internal pure returns (bytes32) {
+    return keccak256(abi.encode("\x19Ethereum Signed Message:\n32", hash));
+}
+
+function recoverSigner(bytes32 message, bytes memory sig) internal pure  returns (address) {
+    (uint8 v, bytes32 r, bytes32 s) = splitSignature(sig);
+    return ecrecover(message, v, r, s);
+}
+
+function splitSignature(bytes memory sig) internal pure returns (uint8 v, bytes32 r, bytes32 s) {
+    require(sig.length == 65);
+    assembly {
+        r := mload(add(sig, 32))
+        s := mload(add(sig, 64))
+        v := byte(0, mload(add(sig, 96)))
+    }
+    return (v, r, s);
+}
+
+```
 
 ## Security Considerations
 

--- a/EIPS/eip-3135.md
+++ b/EIPS/eip-3135.md
@@ -1,5 +1,5 @@
 ---
-eip: 2871
+eip: 3135
 title: Exclusive Claimable Token
 author: Zhenyu Sun (@Ungigdu)
 discussions-to: https://github.com/ethereum/EIPs/issues/3132

--- a/EIPS/eip-3135.md
+++ b/EIPS/eip-3135.md
@@ -178,7 +178,7 @@ In prepayment business model such as using token as recharge card of general sto
 
 2. lock-release model
 
-If we run a VPN service that accepts token as payment, we can use lock-release model. Unlike prepayment, we charge user X token for every Y bits went through. In this "pay for usage" scenario, the counting of services happens on both client and server side. The client should not trust charge amount given by server in case the it's malfunctioning or malicious. When client decide not to trust server, it stops signing messages, but some of token is taken hostage in deposit balance. To fix this problem, the withdraw function should be executed by payer account with limitation such as epoch didn't change in a month.
+If we run a paid e-mail service that accepts token as payment, we can use lock-release model. Unlike prepayment, we charge X * N token for a mail sent to N recipients. In this "pay for usage" scenario, the counting of services happens on both client and server side. The client should not trust charge amount given by server in case the it's malfunctioning or malicious. When client decide not to trust server, it stops signing messages, but some of token is taken hostage in deposit balance. To fix this problem, the withdraw function should be executed by payer account with limitation such as epoch didn't change in a month.
 
 ## Rationale
 


### PR DESCRIPTION
Change to a simpler example, because mail counts is clearly defined while bits going through VPN is a little ambiguous ( have to decide whether control signals and payment messages are counted as service bits, which is not important in this EIP).