### PR TITLE
Removes extraneous spaces.

### DIFF
--- a/EIPS/eip-165.md
+++ b/EIPS/eip-165.md
@@ -70,7 +70,7 @@ interface ERC165 {
 }
 ```
 
-The interface identifier for this interface is `0x01ffc9a7`. You can calculate this by running `        bytes4(keccak256('supportsInterface(bytes4)'));` or using the `Selector` contract above.
+The interface identifier for this interface is `0x01ffc9a7`. You can calculate this by running `bytes4(keccak256('supportsInterface(bytes4)'));` or using the `Selector` contract above.
 
 Therefore the implementing contract will have a `supportsInterface` function that returns:
 


### PR DESCRIPTION
This is an attempt to get this EIP to render correctly on the EIPs site.

Current rendering:
![image](https://user-images.githubusercontent.com/886059/101276886-112df980-37eb-11eb-983d-7bf4241e32f3.png)
