### PR TITLE
2976: Adjustments after latest round of iteration

### DIFF
--- a/EIPS/eip-2976.md
+++ b/EIPS/eip-2976.md
@@ -1,6 +1,6 @@
 ---
 eip: 2976
-title: 'eth/##: Typed Transactions over Gossip'
+title: 'Typed Transactions over Gossip'
 author: Micah Zoltu (@MicahZoltu)
 discussions-to: https://ethereum-magicians.org/t/eip-2976-eth-typed-transactions-over-gossip/4610
 status: Draft
@@ -16,7 +16,8 @@ Adds support for transmission of typed transactions over devp2p.
 ## Abstract
 [Typed Transactions](./eip-2718.md) can be sent over devp2p as `TransactionType || TransactionPayload`.
 The exact contents of the `TransactionPayload` are defined by the `TransactionType` in future EIPs, and clients may start supporting their gossip without incrementing the devp2p version.
-If a client receives a `TransactionType` that it doesn't recognize, it should disconnect from the peer who sent it.
+If a client receives a `TransactionType` that it doesn't recognize, it **SHOULD** disconnect from the peer who sent it.
+Clients **MUST NOT** send new transaction types before they believe the fork block is reached.
 
 ## Motivation
 [EIP-2718](./eip-2718.md) introduced new transaction types for blocks (which presents itself in the makeup of a block header's transaction root and receipts root).
@@ -26,23 +27,29 @@ By updating devp2p to support the gossip of Typed Transactions, we can benefit f
 *Note: See [EIP-2718](./eip-2718.md) for additional motivations of Typed Transactions.*
 
 ## Specification
-All changes specified below apply to the `eth/TBD` protocol/version and newer.
+All changes specified below apply to all protocol/versions retroactively.
 
 ### Definitions
+* `||` is the byte/byte-array concatenation operator.
+* `|` is the type union operator.
 * `DEVP2P_VERSION = TBD`
 * `Transaction` is either `TypedTransaction` or `LegacyTransaction`
 * `TypedTransaction` is a byte array containing `TransactionType || TransactionPayload`
+* `TypedTransactionHash` is `keccak256(TypedTransaction)`
 * `TransactionType` is a positive unsigned 8-bit number between `0` and `0x7f` that represents the type of the transcation
 * `TransactionPayload` is an opaque byte array whose interpretation is dependent on the `TransactionType` and defined in future EIPs
-* `LegacyTransaction` is an RLP encoded array of the form `[nonce, gasPrice, gasLimit, to, value, data, v, r, s]`
-* `TransactionId` is `keccak256(Transaction)`
+* `LegacyTransaction` is an array of the form `[nonce, gasPrice, gasLimit, to, value, data, v, r, s]`
+* `LegacyTransactionHash` is `keccak256(rlp(LegacyTransaction))`
+* `TransactionId` is `keccak256(TypedTransactionHash | LegacyTransactionHash)`
 
 ### Protocol Behavior
 If a client receives a `TransactionType` it doesn't recognize via any message, it **SHOULD** disconnect the peer that sent it.
 
 If a client receives a `TransactionPayload` that isn't valid for the `TransactionType`, it **SHOULD** disconnect the peer that sent it.
 
-Clients **SHOULD NOT** start propagating transactions of a new `TransactionType` until that transaction's fork block is reached to avoid being disconnected by their peers.
+Clients **MUST NOT** send transactions of a new `TransactionType` until that transaction type's introductory fork block.
+
+Clients **MAY** disconnect peers who send transactions of a new `TransactionType` significantly before that transaction type's introductory fork block.
 
 ### Protocol Messages
 `Transactions (0x02)`: `[Transaction_0, Transaction_1, ..., Transaction_n]`


### PR DESCRIPTION
* Adds hashing mechanism for typed transactions.
* Changes the way legacy transactions are encoded for backward compatibility.
* Adds assertion that clients must not send new typed transactions until their fork block.