### PR TITLE
Updates statuses to match EIP-1

### DIFF
--- a/_data/statuses.yaml
+++ b/_data/statuses.yaml
@@ -1,8 +1,7 @@
-- Last Call
-- Draft
-- Accepted
+- Living
 - Final
-- Active
-- Abandoned
-- Rejected
-- Superseded
+- Last Call
+- Review
+- Draft
+- Stagnant
+- Withdrawn


### PR DESCRIPTION
We forgot to update the statuses here, which causes Review items to not appear on the EIPs site.

I also re-ordered things in the *hope* that they show up on the page in this order, though I suspect they won't.