### PR TITLE
Changes the max width of EIPs site to be something reasonable.

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -15,3 +15,9 @@
     }
   }
 }
+
+main.page-content {
+  div.wrapper {
+    max-width: calc(1280px - (30px * 2));
+  }
+}


### PR DESCRIPTION
Uses a highly specific CSS selector to ensure that it overrides the minima selector of `.wrapper` which sets the max-width to 740px.