### PR TITLE
eip-3102: account balance is a u256

### DIFF
--- a/EIPS/eip-3102.md
+++ b/EIPS/eip-3102.md
@@ -71,7 +71,7 @@ Nodes with `empty_hash` as both children are called _leaf nodes_, and the remain
 
 Assuming an account `A ≡ (A_b, A_n, A_c, A_s)` at address `A_a`, the following elements can be found at the following addresses:
 
- * The account balance `A_b` can be found at key `hash(A_a)[0..253] ++ 0b00` and is of type `uint32`;
+ * The account balance `A_b` can be found at key `hash(A_a)[0..253] ++ 0b00` and is of type `uint256`;
  * The account nonce `A_n` can be found at key `hash(A_a)[0..253] ++ 0b01` and is of type `uint64`;
  * The code `A_c` is an arbitrary-length byte sequence that can be found at key `hash(A_a)[0..253] ++ 0b10`;
  * The root of the storage trie `A_s` can be found at key `hash(A_a)[0..253] ++ 0b11`


### PR DESCRIPTION
There is a typo on the type of an account's balance: it is `uint256`, not `uint32`.
