### PR TITLE
Update EIP-2937 SETINDESTRUCTIBLE Opcode

### DIFF
--- a/EIPS/eip-2937.md
+++ b/EIPS/eip-2937.md
@@ -23,16 +23,16 @@ Unlike EIPs that disable the `SELFDESTRUCT` opcode entirely, this EIP does not m
 
 ## Specification
 
-Add a boolean variable `indestructible` in the EVM interpreter struct.
+Add a boolean variable `indestructible` to each execution frame.
 
-Add a `SETINDESTRUCTIBLE` opcode at `0xA8`, with gas cost `G_base`. If in the current execution context `interpreter.indestructible` is set to true, the `SELFDESTRUCT` opcode throws an exception. 
+Add a `SETINDESTRUCTIBLE` opcode at `0xA8`, with gas cost `G_base`. If in the current execution context variable `indestructible` is set to true, the `SELFDESTRUCT` opcode throws an exception.
 
 ## Rationale
 
 Alternative proposals to this include:
 
 * Simply banning `SELFDESTRUCT` outright. This would be ideal, but has larger backwards compatibility issues.
-* Adding a transaction-wide global variable `globals.indestructible: Set[Address]` (i.e. a variable that operates the same way as the selfdestructs set), initialized to the empty set. 
+* Adding a transaction-wide global variable `globals.indestructible: Set[Address]` (i.e. a variable that operates the same way as the selfdestructs set), initialized to the empty set.
 
 ## Backwards Compatibility
 

--- a/EIPS/eip-2937.md
+++ b/EIPS/eip-2937.md
@@ -1,7 +1,7 @@
 ---
 eip: 2937
-title: SET_INDESTRUCTIBLE opcode
-author: Vitalik Buterin (@vbuterin)
+title: SETINDESTRUCTIBLE opcode
+author: Vitalik Buterin (@vbuterin), Angela Lu (@astarinmymind), Tyler Goodman (@technicallyty)
 discussions-to: https://ethereum-magicians.org/t/eip-2937-set-indestructible/4571
 status: Draft
 type: Standards Track
@@ -11,32 +11,32 @@ created: 2020-09-04
 
 ## Simple Summary
 
-Add a `SET_INDESTRUCTIBLE (0xA8)` opcode that prevents the contract from calling `SELFDESTRUCT (0xFF)`.
+Add a `SETINDESTRUCTIBLE (0xA8)` opcode that prevents the contract from calling `SELFDESTRUCT (0xFF)`.
 
 ## Abstract
 
 ## Motivation
 
-The intended use case would be for contracts to make their first byte of code be the `SET_INDESTRUCTIBLE` opcode if they wish to serve as libraries that guarantee to users that their code will exist unmodified forever. This is useful in account abstraction as well as other contexts.
+The intended use case would be for contracts to make their first byte of code be the `SETINDESTRUCTIBLE` opcode if they wish to serve as libraries that guarantee to users that their code will exist unmodified forever. This is useful in account abstraction as well as other contexts.
 
 Unlike EIPs that disable the `SELFDESTRUCT` opcode entirely, this EIP does not modify behavior of any existing contracts.
 
 ## Specification
 
-Add a transaction-wide global variable `globals.indestructible: Set[Address]` (i.e. a variable that operates the same way as the selfdestructs set), initialized to the empty set.
+Add a boolean variable `indestructible` in the EVM interpreter struct.
 
-Add a `SET_INDESTRUCTIBLE` opcode at `0xA8`, with gas cost `G_base`, that adds the current `callee` to the `globals.indestructible` set. If in the current execution context the `callee` is in `globals.indestructible`, the `SELFDESTRUCT` opcode throws an exception.
+Add a `SETINDESTRUCTIBLE` opcode at `0xA8`, with gas cost `G_base`. If in the current execution context `interpreter.indestructible` is set to true, the `SELFDESTRUCT` opcode throws an exception. 
 
 ## Rationale
 
 Alternative proposals to this include:
 
 * Simply banning `SELFDESTRUCT` outright. This would be ideal, but has larger backwards compatibility issues.
-* Using a local variable instead of a global variable. This is problematic because it would be broken by `DELEGATECALL`.
+* Adding a transaction-wide global variable `globals.indestructible: Set[Address]` (i.e. a variable that operates the same way as the selfdestructs set), initialized to the empty set. 
 
 ## Backwards Compatibility
 
-TBD
+This EIP is backwards-compatible.
 
 ## Security Considerations
 

--- a/EIPS/eip-2937.md
+++ b/EIPS/eip-2937.md
@@ -25,7 +25,15 @@ Unlike EIPs that disable the `SELFDESTRUCT` opcode entirely, this EIP does not m
 
 Add a boolean variable `indestructible` to each execution frame.
 
-Add a `SETINDESTRUCTIBLE` opcode at `0xA8`, with gas cost `G_base`. If in the current execution context variable `indestructible` is set to true, the `SELFDESTRUCT` opcode throws an exception.
+Add a `SETINDESTRUCTIBLE` opcode at `0xA8`, with gas cost `G_base`. 
+
+If in the current execution context variable `indestructible` is set to true, the `SELFDESTRUCT` opcode throws an exception.
+
+If `SETINDESTRUCTIBLE` opcode is encountered when `PC!=0`, it will have no effect and the contract will not be set as indestructible. 
+
+Let there be a contract C with its first byte of code being the `SETINDESTRUCTIBLE` opcode.
+If contract X does delegatecall(C) && selfdestruct, contract C should fail to self destruct.
+If contract X does callcode(C) && selfdestruct, contract C should also fail to self destruct.
 
 ## Rationale
 


### PR DESCRIPTION
Updates the specification of EIP-2937 SETINDESTRUCTIBLE Opcode from transaction-wide global variable to a variable local to each execution frame. 
