### PR TITLE
Expanded ERC-3156 with more security considerations

### DIFF
--- a/EIPS/eip-3156.md
+++ b/EIPS/eip-3156.md
@@ -2,7 +2,7 @@
 eip: 3156
 title: Flash Loans
 author: Alberto Cuesta Cañada (@albertocuestacanada), Fiona Kobayashi (@fifikobayashi), fubuloubu (@fubuloubu)
-discussions-to: https://ethereum-magicians.org/t/flash-loan-eip-early-draft/4993/2
+discussions-to: https://ethereum-magicians.org/t/erc-3156-flash-loans-review-discussion/5077
 status: Draft
 type: Standards Track
 category: ERC

--- a/EIPS/eip-3156.md
+++ b/EIPS/eip-3156.md
@@ -105,7 +105,7 @@ A `bytes calldata data` parameter is included for the caller to pass arbitrary i
 
 `onFlashLoan` has been chosen as descriptive enough, unlikely to clash with other functions in the `receiver`, and following the `onAction` naming pattern used as well in EIP-667.
 
-A `user` will often be required in the `onFlashLoan` function, which the lender knows as `msg.sender`. An alternative implementation which would embed the `user` in the `data` parameter by the caller would require an additional mechanism for the receiver to verify its accuracy, and is not advisable.
+A `sender` will often be required in the `onFlashLoan` function, which the lender knows as `msg.sender`. An alternative implementation which would embed the `sender` in the `data` parameter by the caller would require an additional mechanism for the receiver to verify its accuracy, and is not advisable.
 
 The `amount` will be required in the `onFlashLoan` function, which the lender took as a parameter. An alternative implementation which would embed the `amount` in the `data` parameter by the caller would require an additional mechanism for the receiver to verify its accuracy, and is not advisable.
 
@@ -139,7 +139,7 @@ import "@openzeppelin/contracts/math/SafeMath.sol";
 
 contract FlashBorrower {
 
-  function onFlashLoan(address user, address token, uint256 value, uint256 fee, bytes calldata) external {
+  function onFlashLoan(address sender, address token, uint256 value, uint256 fee, bytes calldata) external {
     // do something with the tokens received
 
     IERC20(token).transfer(msg.sender, value.add(fee));
@@ -196,7 +196,7 @@ contract ERC20FlashMinter is ERC20, IERC3156FlashLender {
 
     /**
      * @dev Loan `amount` tokens to `receiver`, which needs to return them plus a 0.1% fee to this contract within the same transaction.
-     * @param receiver The contract receiving the tokens, needs to implement the `onFlashLoan(address user, uint256 amount, uint256 fee, bytes calldata)` interface.
+     * @param receiver The contract receiving the tokens, needs to implement the `onFlashLoan(address sender, uint256 amount, uint256 fee, bytes calldata)` interface.
      * @param token The loan currency. Must match the address of this contract.
      * @param amount The amount of tokens lent.
      * @param data A data parameter to be passed on to the `receiver` for any custom use.
@@ -276,7 +276,7 @@ contract FlashLender is IERC3156FlashLender {
 
     /**
      * @dev Loan `amount` tokens to `receiver`, which needs to return them plus a 0.1% fee to this contract within the same transaction.
-     * @param receiver The contract receiving the tokens, needs to implement the `onFlashLoan(address user, uint256 amount, uint256 fee, bytes calldata)` interface.
+     * @param receiver The contract receiving the tokens, needs to implement the `onFlashLoan(address sender, uint256 amount, uint256 fee, bytes calldata)` interface.
      * @param token The loan currency.
      * @param amount The amount of tokens lent.
      * @param data A data parameter to be passed on to the `receiver` for any custom use.
@@ -304,6 +304,14 @@ contract FlashLender is IERC3156FlashLender {
 ```
 
 ## Security Considerations
+
+### Verification of callback arguments
+
+The arguments on the `onFlashLoan` callback can be divided in two groups, that require different checks before they can be trusted to be genuine.
+
+0. No arguments can be assumed to be genuine without some kind of verification. `sender`, `token` and `value` refer to a past transaction that might not have happened if the caller of `onFlashLoan` decides to lie. `fee` might be false or calculated incorrectly. `calldata` is not expected to have been verified or manipulated by the caller.
+1. To trust that the value of `sender`, `token`, `value` and `fee` are genuine a reasonable pattern is to verify that the `onFlashLoan` caller is in a whitelist of verified flash lenders. Since often the caller of `flashLoan` will also be receiving the `onFlashLoan` callback this will be trivial. In all other cases flash lenders will need to be approved if the arguments in `onFlashLoan` are to be trusted.
+2. To trust that the value of `data` is genuine, in addition to the check in point 1, it is recommended to implement the `flashLoan` caller to be also the `onFlashLoan` receiver. With this pattern, checking in `onFlashLoan` that `sender` is the current contract is enough to trust that the contents of `data` are genuine.
 
 ### Flash lending security considerations
 


### PR DESCRIPTION
Fixed the discussions-to link.

Added a new section to the Security Considerations, on how to trust that the `onFlashLoan` arguments are genuine.