### PR TITLE
Remove unnecessary statements about handling BASEFEE opcode prior to EIP-1559 fork

### DIFF
--- a/EIPS/eip-3198.md
+++ b/EIPS/eip-3198.md
@@ -29,8 +29,6 @@ Add a `BASEFEE` opcode at `(0x48)`, with gas cost `G_base`.
 |:----:	|:-----:	|:------:	|:----:	|
 | 0x48 	|   0   	|    1   	|   2  	|
 
- Attempted execution of a `BASEFEE` prior to `eip-1559` fork causes an _`abort`_:  terminate execution with an `Invalid Operation` exception.
-
 ## Rationale
 
 ## Backwards Compatibility
@@ -51,19 +49,6 @@ Bytecode: `0x4800` (`BASEFEE, STOP`)
 
 Output: 0x
 Consumed gas: `2`
-
-### Failure 1: No base fee in current block
-Assuming a block header with no base fee (prior to `eip-1559` fork block).
-This should fail, since no base fee is present in current block header.
-
-Bytecode: `0x4800` (`BASEFEE, STOP`)
-
-|  Pc   |      Op     | Cost |   Stack   |   RStack  |
-|-------|-------------|------|-----------|-----------|
-|    0  |    BASEFEE  |    2 |        [] |        [] |
-|    1  |    STOP     |    0 |        [] |        [] |
-
-Expected behaviour: Terminate execution with an `Invalid Operation` exception.
 
 ## Security Considerations
 

--- a/EIPS/eip-3198.md
+++ b/EIPS/eip-3198.md
@@ -38,6 +38,33 @@ This EIP is backwards-compatible.
 
 ## Test Cases
 
+### Nominal case
+Assuming current block base fee is `7 wei`.
+This should push the value `7` (left padded byte32) to the stack.
+
+Bytecode: `0x4800` (`BASEFEE, STOP`)
+
+|  Pc   |      Op     | Cost |   Stack   |   RStack  |
+|-------|-------------|------|-----------|-----------|
+|    0  |    BASEFEE  |    2 |        [] |        [] |
+|    1  |    STOP     |    0 |       [7] |        [] |
+
+Output: 0x
+Consumed gas: `2`
+
+### Failure 1: No base fee in current block
+Assuming a block header with no base fee (prior to `eip-1559` fork block).
+This should fail, since no base fee is present in current block header.
+
+Bytecode: `0x4800` (`BASEFEE, STOP`)
+
+|  Pc   |      Op     | Cost |   Stack   |   RStack  |
+|-------|-------------|------|-----------|-----------|
+|    0  |    BASEFEE  |    2 |        [] |        [] |
+|    1  |    STOP     |    0 |        [] |        [] |
+
+Expected behaviour: Terminate execution with an `Invalid Operation` exception.
+
 ## Security Considerations
 
 ## Copyright

--- a/EIPS/eip-3198.md
+++ b/EIPS/eip-3198.md
@@ -25,6 +25,11 @@ The intended use case would be for contracts to get the value of the base fee. T
 ## Specification
 Add a `BASEFEE` opcode at `(0x48)`, with gas cost `G_base`.
 
+|  Op  	| Input 	| Output 	| Cost 	|
+|:----:	|:-----:	|:------:	|:----:	|
+| 0x48 	|   0   	|    1   	|   2  	|
+
+
 ## Rationale
 
 ## Backwards Compatibility

--- a/EIPS/eip-3198.md
+++ b/EIPS/eip-3198.md
@@ -29,6 +29,7 @@ Add a `BASEFEE` opcode at `(0x48)`, with gas cost `G_base`.
 |:----:	|:-----:	|:------:	|:----:	|
 | 0x48 	|   0   	|    1   	|   2  	|
 
+ Attempted execution of a `BASEFEE` prior to `eip-1559` fork causes an _`abort`_:  terminate execution with an `Invalid Operation` exception.
 
 ## Rationale
 

--- a/EIPS/eip-x.md
+++ b/EIPS/eip-x.md
@@ -1,5 +1,5 @@
 ---
-eip: <to be assigned>
+eip: 3198
 title: BASEFEE opcode
 author: Abdelhamid Bakhta (@abdelhamidbakhta)
 discussions-to: URL

--- a/EIPS/eip-x.md
+++ b/EIPS/eip-x.md
@@ -11,7 +11,7 @@ requires: 1559
 ---
 
 ## Simple Summary
-Add a `BASEFEE ($OPCODEVALUE)` that returns the value of the base fee of the current block it is executing in.
+Add a `BASEFEE (0x48)` that returns the value of the base fee of the current block it is executing in.
 
 ## Abstract
 
@@ -23,7 +23,7 @@ The intended use case would be for contracts to get the value of the base fee. T
 - Improve the security for state channels, plasma, optirolls and other fraud proof driven solutions. Having the `BASEFEE` as an input allows you to lengthen the challenge period automatically if you see that the `BASEFEE` is high.
 
 ## Specification
-Add a `BASEFEE` opcode at `($OPCODEVALUE)`, with gas cost `$OPCODEGASCOST`.
+Add a `BASEFEE` opcode at `(0x48)`, with gas cost `G_base`.
 
 ## Rationale
 

--- a/EIPS/eip-x.md
+++ b/EIPS/eip-x.md
@@ -1,0 +1,35 @@
+---
+eip: <to be assigned>
+title: BASEFEE opcode
+author: Abdelhamid Bakhta (@abdelhamidbakhta)
+discussions-to: URL
+status: Draft
+type: Standards Track
+category: Core
+created: 2021-01-13
+requires: 1559
+---
+
+## Simple Summary
+Add a `BASEFEE ($OPCODEVALUE)` that returns the value of the base fee at the `latest` block.
+
+## Abstract
+
+
+## Motivation
+The intended use case would be for contracts to get the value of the base fee.
+
+## Specification
+Add a `BASEFEE` opcode at `($OPCODEVALUE)`, with gas cost `$OPCODEGASCOST`.
+
+## Rationale
+
+## Backwards Compatibility
+This EIP is backwards-compatible.
+
+## Test Cases
+
+## Security Considerations
+
+## Copyright
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/EIPS/eip-x.md
+++ b/EIPS/eip-x.md
@@ -1,7 +1,7 @@
 ---
 eip: 3198
 title: BASEFEE opcode
-author: Abdelhamid Bakhta (@abdelhamidbakhta)
+author: Abdelhamid Bakhta (@abdelhamidbakhta), Vitalik Buterin (@vbuterin)
 discussions-to: https://ethereum-magicians.org/t/eip-3198-basefeeopcode/5162
 status: Draft
 type: Standards Track
@@ -11,13 +11,16 @@ requires: 1559
 ---
 
 ## Simple Summary
-Add a `BASEFEE ($OPCODEVALUE)` that returns the value of the base fee of the current block it is executing in. 
+Add a `BASEFEE ($OPCODEVALUE)` that returns the value of the base fee of the current block it is executing in.
 
 ## Abstract
 
 
 ## Motivation
-The intended use case would be for contracts to get the value of the base fee.
+The intended use case would be for contracts to get the value of the base fee. This feature would enable or improve existing use cases, such as:
+- Contracts that need to set bounties for anyone to "poke" them with a transaction could set the bounty to be `BASEFEE + x`, or `BASEFEE * (1 + x)`. This makes the mechanism more reliable, because they will always pay "enough" regardless of market conditions.
+- Gas futures can be implemented based on it. This would be more precise than gastokens.
+- Improve the security for state channels, plasma, optirolls and other fraud proof driven solutions. Having the `BASEFEE` as an input allows you to lengthen the challenge period automatically if you see that the `BASEFEE` is high.
 
 ## Specification
 Add a `BASEFEE` opcode at `($OPCODEVALUE)`, with gas cost `$OPCODEGASCOST`.

--- a/EIPS/eip-x.md
+++ b/EIPS/eip-x.md
@@ -2,7 +2,7 @@
 eip: 3198
 title: BASEFEE opcode
 author: Abdelhamid Bakhta (@abdelhamidbakhta)
-discussions-to: URL
+discussions-to: https://ethereum-magicians.org/t/eip-3198-basefeeopcode/5162
 status: Draft
 type: Standards Track
 category: Core

--- a/EIPS/eip-x.md
+++ b/EIPS/eip-x.md
@@ -11,7 +11,7 @@ requires: 1559
 ---
 
 ## Simple Summary
-Add a `BASEFEE ($OPCODEVALUE)` that returns the value of the base fee at the `latest` block.
+Add a `BASEFEE ($OPCODEVALUE)` that returns the value of the base fee of the current block it is executing in. 
 
 ## Abstract
 


### PR DESCRIPTION
Address comments from previous PR.