### PR TITLE
Erc3156 review

### DIFF
--- a/EIPS/eip-3156.md
+++ b/EIPS/eip-3156.md
@@ -33,22 +33,46 @@ A flash lending feature integrates two smart contracts using a callback pattern.
 
 A `lender` MUST implement the IERC3156FlashLender interface.
 ```
+pragma solidity ^0.7.0 || ^0.8.0;
+import "./IERC3156FlashBorrower.sol";
+import "./IERC20.sol";
+
+
 interface IERC3156FlashLender {
-    function maxFlashAmount(
-        IERC20 token
-    ) external view returns (uint256);
-    
-    function flashFee(
-        IERC20 token,
-        uint256 amount
-    ) external view returns (uint256);
-    
+
+    /**
+     * @dev Initiate a flash loan.
+     * @param receiver The receiver of the tokens in the loan, and the receiver of the callback.
+     * @param token The loan currency.
+     * @param value The amount of tokens lent.
+     * @param data Arbitrary data structure, intended to contain user-defined parameters.
+     */
     function flashLoan(
         IERC3156FlashBorrower receiver,
         IERC20 token,
-        uint256 amount,
+        uint256 value,
         bytes calldata data
     ) external;
+
+    /**
+     * @dev The fee to be charged for a given loan.
+     * @param token The loan currency.
+     * @param value The amount of tokens lent.
+     * @return The amount of `token` to be charged for the loan, on top of the returned principal.
+     */
+    function flashFee(
+        IERC20 token,
+        uint256 value
+    ) external view returns (uint256);
+
+    /**
+     * @dev The amount of currency available to be lended.
+     * @param token The loan currency.
+     * @return The amount of `token` that can be borrowed.
+     */
+    function maxFlashAmount(
+        IERC20 token
+    ) external view returns (uint256);
 }
 ```
 
@@ -59,15 +83,27 @@ The `flashFee` function MUST return the fee charged for a loan of `amount` `toke
 The `flashLoan` function MUST include a callback to the `onFlashLoan` function in a `IERC3156FlashBorrower` contract.
 
 ```
-function flashLoan(
-    IERC3156FlashBorrower receiver,
-    IERC20 token,
-    uint256 amount,
-    bytes calldata data
-) external {
-  ...
-  receiver.onFlashLoan(msg.sender, token, amount, fee, data);
-  ...
+pragma solidity ^0.7.0 || ^0.8.0;
+import "./IERC20.sol";
+
+
+interface IERC3156FlashBorrower {
+
+    /**
+     * @dev Receive a flash loan.
+     * @param sender The initiator of the loan.
+     * @param token The loan currency.
+     * @param value The amount of tokens lent.
+     * @param fee The additional amount of tokens to repay.
+     * @param data Arbitrary data structure, intended to contain user-defined parameters.
+     */
+    function onFlashLoan(
+        address sender,
+        IERC20 token,
+        uint256 value,
+        uint256 fee,
+        bytes calldata data
+    ) external;
 }
 ```
 
@@ -100,8 +136,8 @@ The `batchFlashLoan` function MUST include a callback to the `onBatchFlashLoan` 
 ```
 function batchFlashLoan(
     IERC3156BatchFlashBorrower receiver,
-    IERC20[] calldata token,
-    uint256[] calldata amount,
+    IERC20[] calldata tokens,
+    uint256[] calldata amounts,
     bytes calldata data
 ) external {
   ...
@@ -123,14 +159,27 @@ After the callback, for each `token` in `tokens`, the `batchFlashLoan` function 
 
 ### Receiver Specification
 
-A `receiver` of flash loans MUST implement the IERC3156FlashBorrower interface with an `onFlashLoan` callback:
+A `receiver` of flash loans MUST implement the IERC3156FlashBorrower interface:
 
 ```
+pragma solidity ^0.7.0 || ^0.8.0;
+import "./IERC20.sol";
+
+
 interface IERC3156FlashBorrower {
+
+    /**
+     * @dev Receive a flash loan.
+     * @param sender The initiator of the loan.
+     * @param token The loan currency.
+     * @param value The amount of tokens lent.
+     * @param fee The additional amount of tokens to repay.
+     * @param data Arbitrary data structure, intended to contain user-defined parameters.
+     */
     function onFlashLoan(
-        IERC3156FlashLender sender,
+        address sender,
         IERC20 token,
-        uint256 amount,
+        uint256 value,
         uint256 fee,
         bytes calldata data
     ) external;
@@ -176,7 +225,7 @@ The `amount` will be required in the `onFlashLoan` function, which the lender to
 
 A `fee` will often be calculated in the `flashLoan` function, which the `receiver` must be aware of for repayment. Passing the `fee` as a parameter instead of appended to `data` is simple and effective.
 
-The `amount + fee` are pulled from the `receiver` to allow the `lender` to implement other functionality that depend on `token` balances, without having to lock it for the duration of a flash loan.
+The `amount + fee` are pulled from the `receiver` to allow the `lender` to implement other features that depend on using `transferFrom`, without having to lock them for the duration of a flash loan. An alternative implementation where the repayment is transferred to the `lender` is also possible, but would need all other features in the lender to be also based in using `transfer` instead of `transferFrom`. Given the lower complexity and prevalence of a "pull" architecture over a "push" architecture, "pull" was chosen.
 
 ## Backwards Compatibility
 
@@ -189,15 +238,38 @@ No backwards compatibility issues identified.
 ```
 pragma solidity ^0.8.0;
 
-import "../interfaces/IERC20.sol";
+import "./interfaces/IERC20.sol";
+import "./interfaces/IERC3156FlashBorrower.sol";
+import "./interfaces/IERC3156FlashLender.sol";
 
-contract FlashBorrower {
 
-    function flashBorrow(IERC3156FlashLender lender, IERC20 token, uint256 amount) public {
-        uint256 _allowance = token.allowance(address(this), lender);
+contract FlashBorrower is IERC3156FlashBorrower {
+    enum Action {NORMAL, OTHER}
+
+    IERC3156FlashLender lender;
+
+    constructor (IERC3156FlashLender lender_) {
+        lender = lender_;
+    }
+
+    /// @dev ERC-3156 Flash loan callback
+    function onFlashLoan(address sender, IERC20 token, uint256 amount, uint256 fee, bytes calldata data) external override {
+        require(msg.sender == address(lender), "FlashBorrower: Untrusted lender");
+        require(sender == address(this), "FlashBorrower: External loan initiator");
+        (Action action) = abi.decode(data, (Action));
+        if (action == Action.NORMAL) {
+            // do one thing
+        } else if (action == Action.OTHER) {
+            // do another
+        }
+    }
+
+    function flashBorrow(IERC20 token, uint256 amount) public {
+        bytes memory data = abi.encode(Action.NORMAL);
+        uint256 _allowance = token.allowance(address(this), address(lender));
         uint256 _fee = lender.flashFee(token, amount);
         uint256 _repayment = amount + _fee;
-        token.approve(lender, _allowance + _repayment);
+        token.approve(address(lender), _allowance + _repayment);
         lender.flashLoan(this, token, amount, data);
     }
 }
@@ -208,7 +280,8 @@ contract FlashBorrower {
 ```
 pragma solidity ^0.8.0;
 
-import "./ERC20.sol";
+import "../ERC20.sol";
+import "../interfaces/IERC20.sol";
 import "../interfaces/IERC3156FlashBorrower.sol";
 import "../interfaces/IERC3156FlashLender.sol";
 
@@ -219,16 +292,12 @@ import "../interfaces/IERC3156FlashLender.sol";
  */
 contract FlashMinter is ERC20, IERC3156FlashLender {
 
-    uint256 public fee; // Percentage charged on the amount, in bps
+    uint256 public fee; //  1 == 0.0001 %.
 
     /**
-     * @param fee_ The divisor that will be applied to the `amount` of a `loan`, with the result charged as a `fee`.
+     * @param fee_ The percentage of the loan `amount` that needs to be repaid, in addition to `amount`.
      */
-    constructor (
-        string memory name,
-        string memory symbol,
-        uint256 fee_
-    ) ERC20(name, symbol) {
+    constructor (string memory name, string memory symbol, uint256 fee_) ERC20(name, symbol) {
         fee = fee_;
     }
 
@@ -237,10 +306,8 @@ contract FlashMinter is ERC20, IERC3156FlashLender {
      * @param token The loan currency.
      * @return The amount of `token` that can be borrowed.
      */
-    function maxFlashAmount(
-        IERC20
-    ) external view override returns (uint256) {
-        return type(uint256).max;
+    function maxFlashAmount(IERC20 token) external view override returns (uint256) {
+        return type(uint256).max - totalSupply();
     }
 
     /**
@@ -249,31 +316,20 @@ contract FlashMinter is ERC20, IERC3156FlashLender {
      * @param amount The amount of tokens lent.
      * @return The amount of `token` to be charged for the loan, on top of the returned principal.
      */
-    function flashFee(
-        IERC20 token,
-        uint256 amount
-    ) external view override returns (uint256) {
-        require(
-            token == this,
-            "FlashMinter: unsupported loan currency"
-        );
+    function flashFee(IERC20 token, uint256 amount) external view override returns (uint256) {
+        require(token == IERC20(address(this)), "FlashMinter: unsupported loan currency");
         return _flashFee(token, amount);
     }
 
     /**
      * @dev Loan `amount` tokens to `receiver`, and takes it back plus a `flashFee` after the ERC3156 callback.
-     * @param receiver The contract receiving the tokens, needs to implement the `onFlashLoan(address user, uint256 amount, uint256 fee, bytes calldata data)` interface.
+     * @param receiver The contract receiving the tokens, needs to implement the `onFlashLoan(address user, uint256 amount, uint256 fee, bytes calldata)` interface.
      * @param token The loan currency. Must match the address of this contract.
      * @param amount The amount of tokens lent.
      * @param data A data parameter to be passed on to the `receiver` for any custom use.
      */
-    function flashLoan(
-        IERC3156FlashBorrower receiver,
-        IERC20 token,
-        uint256 amount,
-        bytes calldata data
-    ) external override {
-        require(token == this, "FlashMinter: unsupported loan currency");
+    function flashLoan(IERC3156FlashBorrower receiver, IERC20 token, uint256 amount, bytes calldata data) external override {
+        require(token == IERC20(address(this)), "FlashMinter: unsupported loan currency");
         uint256 fee = _flashFee(token, amount);
         _mint(address(receiver), amount);
         receiver.onFlashLoan(msg.sender, token, amount, fee, data);
@@ -289,12 +345,10 @@ contract FlashMinter is ERC20, IERC3156FlashLender {
      * @param amount The amount of tokens lent.
      * @return The amount of `token` to be charged for the loan, on top of the returned principal.
      */
-    function _flashFee(
-        IERC20,
-        uint256 amount
-    ) internal view returns (uint256) {
-        return fee == amount * fee / 10000;
+    function _flashFee(IERC20 token, uint256 amount) internal view returns (uint256) {
+        return amount * fee / 10000;
     }
+}
 ```
 
 ### Flash Loan Reference Implementation
@@ -309,22 +363,19 @@ import "../interfaces/IERC3156FlashLender.sol";
 
 /**
  * @author Alberto Cuesta Cañada
- * @dev Contract that allows flash lending of any ERC20 tokens it owns.
+ * @dev Extension of {ERC20} that allows flash lending.
  */
 contract FlashLender is IERC3156FlashLender {
 
     mapping(IERC20 => bool) public supportedTokens;
-    uint256 public fee; // Percentage charged on the amount, in bps
+    uint256 public fee; //  1 == 0.0001 %.
 
 
     /**
      * @param supportedTokens_ Token contracts supported for flash lending.
-     * @param fee_ The divisor that will be applied to the `amount` of a `loan`, with the result charged as a `fee`.
+     * @param fee_ The percentage of the loan `amount` that needs to be repaid, in addition to `amount`.
      */
-    constructor(
-        IERC20[] memory supportedTokens_,
-        uint256 fee_)
-    {
+    constructor(IERC20[] memory supportedTokens_, uint256 fee_) {
         for (uint256 i = 0; i < supportedTokens_.length; i++) {
             supportedTokens[supportedTokens_[i]] = true;
         }
@@ -333,31 +384,17 @@ contract FlashLender is IERC3156FlashLender {
 
     /**
      * @dev Loan `amount` tokens to `receiver`, and takes it back plus a `flashFee` after the callback.
-     * @param receiver The contract receiving the tokens, needs to implement the IERC3156FlashBorrower interface.
+     * @param receiver The contract receiving the tokens, needs to implement the `onFlashLoan(address user, uint256 amount, uint256 fee, bytes calldata)` interface.
      * @param token The loan currency.
      * @param amount The amount of tokens lent.
      * @param data A data parameter to be passed on to the `receiver` for any custom use.
      */
-    function flashLoan(
-        IERC3156FlashBorrower receiver,
-        IERC20 token,
-        uint256 amount,
-        bytes calldata data
-    ) external override {
-        require(
-            supportedTokens[token],
-            "FlashLender: Unsupported currency"
-        );
+    function flashLoan(IERC3156FlashBorrower receiver, IERC20 token, uint256 amount, bytes calldata data) external override {
+        require(supportedTokens[token], "FlashLender: Unsupported currency");
         uint256 fee = _flashFee(token, amount);
-        require(
-            token.transfer(address(receiver), amount),
-            "FlashLender: Transfer failed"
-        );
+        token.transfer(address(receiver), amount);
         receiver.onFlashLoan(msg.sender, token, amount, fee, data);
-        require(
-            token.transferFrom(address(receiver), address(this), amount + fee),
-            "FlashLender: Repay failed"
-        );
+        token.transferFrom(address(receiver), address(this), amount + fee);
     }
 
     /**
@@ -366,10 +403,7 @@ contract FlashLender is IERC3156FlashLender {
      * @param amount The amount of tokens lent.
      * @return The amount of `token` to be charged for the loan, on top of the returned principal.
      */
-    function flashFee(
-        IERC20 token,
-        uint256 amount
-    ) external view override returns (uint256) {
+    function flashFee(IERC20 token, uint256 amount) external view override returns (uint256) {
         require(supportedTokens[token], "FlashLender: Unsupported currency");
         return _flashFee(token, amount);
     }
@@ -380,10 +414,7 @@ contract FlashLender is IERC3156FlashLender {
      * @param amount The amount of tokens lent.
      * @return The amount of `token` to be charged for the loan, on top of the returned principal.
      */
-    function _flashFee(
-        IERC20 token,
-        uint256 amount
-    ) internal view returns (uint256) {
+    function _flashFee(IERC20 token, uint256 amount) internal view returns (uint256) {
         return amount * fee / 10000;
     }
 
@@ -392,10 +423,8 @@ contract FlashLender is IERC3156FlashLender {
      * @param token The loan currency.
      * @return The amount of `token` that can be borrowed.
      */
-    function maxFlashAmount(
-        IERC20 token
-    ) external view override returns (uint256) {
-        return supportedTokens[address(token)] ? token.balanceOf(address(this)) : 0;
+    function maxFlashAmount(IERC20 token) external view override returns (uint256) {
+        return supportedTokens[token] ? token.balanceOf(address(this)) : 0;
     }
 }
 ```

--- a/EIPS/eip-3156.md
+++ b/EIPS/eip-3156.md
@@ -158,13 +158,9 @@ For the transaction to not revert, for each `token` in `tokens`, `receiver` MUST
 
 The interfaces described in this ERC have been chosen as to cover the known flash lending use cases, while allowing for safe and gas efficient implementations.
 
-`flashFee(address token, uint256 amount)`
-
 `flashFee` reverts on unsupported tokens, because returning a numerical value would be incorrect.
 
-`flashLoan(address receiver, address token, uint256 amount, bytes calldata data)`
-
-`flashLoan` has been chosen as descriptive enough, unlikely to clash with other functions in the lender, and including both the use cases in which the tokens lended are held or minted by the lender.
+`flashLoan` has been chosen as a function name as descriptive enough, unlikely to clash with other functions in the lender, and including both the use cases in which the tokens lended are held or minted by the lender.
 
 `receiver` is taken as a parameter to allow flexibility on the implementation of separate loan initiators and receivers.
 
@@ -172,9 +168,7 @@ Existing flash lenders (Aave, dYdX and Uniswap) all provide flash loans of sever
 
 A `bytes calldata data` parameter is included for the caller to pass arbitrary information to the `receiver`, without impacting the utility of the `flashLoan` standard.
 
-`onFlashLoan(msg.sender, amount, fee, data)`
-
-`onFlashLoan` has been chosen as descriptive enough, unlikely to clash with other functions in the `receiver`, and following the `onAction` naming pattern used as well in EIP-667.
+`onFlashLoan` has been chosen as a function name as descriptive enough, unlikely to clash with other functions in the `receiver`, and following the `onAction` naming pattern used as well in EIP-667.
 
 A `sender` will often be required in the `onFlashLoan` function, which the lender knows as `msg.sender`. An alternative implementation which would embed the `sender` in the `data` parameter by the caller would require an additional mechanism for the receiver to verify its accuracy, and is not advisable.
 

--- a/EIPS/eip-3156.md
+++ b/EIPS/eip-3156.md
@@ -266,6 +266,7 @@ contract FlashBorrower is IERC3156FlashBorrower {
         }
     }
 
+    /// @dev Initiate a flash loan
     function flashBorrow(
         IERC20 token,
         uint256 amount

--- a/EIPS/eip-3156.md
+++ b/EIPS/eip-3156.md
@@ -248,12 +248,20 @@ contract FlashBorrower is IERC3156FlashBorrower {
 
     IERC3156FlashLender lender;
 
-    constructor (IERC3156FlashLender lender_) {
+    constructor (
+        IERC3156FlashLender lender_
+    ) {
         lender = lender_;
     }
 
     /// @dev ERC-3156 Flash loan callback
-    function onFlashLoan(address sender, IERC20 token, uint256 amount, uint256 fee, bytes calldata data) external override {
+    function onFlashLoan(
+        address sender,
+        IERC20 token,
+        uint256 amount,
+        uint256 fee,
+        bytes calldata data
+    ) external override {
         require(msg.sender == address(lender), "FlashBorrower: Untrusted lender");
         require(sender == address(this), "FlashBorrower: External loan initiator");
         (Action action) = abi.decode(data, (Action));
@@ -264,7 +272,10 @@ contract FlashBorrower is IERC3156FlashBorrower {
         }
     }
 
-    function flashBorrow(IERC20 token, uint256 amount) public {
+    function flashBorrow(
+        IERC20 token,
+        uint256 amount
+    ) public {
         bytes memory data = abi.encode(Action.NORMAL);
         uint256 _allowance = token.allowance(address(this), address(lender));
         uint256 _fee = lender.flashFee(token, amount);
@@ -306,7 +317,9 @@ contract FlashMinter is ERC20, IERC3156FlashLender {
      * @param token The loan currency.
      * @return The amount of `token` that can be borrowed.
      */
-    function maxFlashAmount(IERC20 token) external view override returns (uint256) {
+    function maxFlashAmount(
+        IERC20 token
+    ) external view override returns (uint256) {
         return type(uint256).max - totalSupply();
     }
 
@@ -316,7 +329,10 @@ contract FlashMinter is ERC20, IERC3156FlashLender {
      * @param amount The amount of tokens lent.
      * @return The amount of `token` to be charged for the loan, on top of the returned principal.
      */
-    function flashFee(IERC20 token, uint256 amount) external view override returns (uint256) {
+    function flashFee(
+        IERC20 token,
+        uint256 amount
+    ) external view override returns (uint256) {
         require(token == IERC20(address(this)), "FlashMinter: unsupported loan currency");
         return _flashFee(token, amount);
     }
@@ -328,7 +344,12 @@ contract FlashMinter is ERC20, IERC3156FlashLender {
      * @param amount The amount of tokens lent.
      * @param data A data parameter to be passed on to the `receiver` for any custom use.
      */
-    function flashLoan(IERC3156FlashBorrower receiver, IERC20 token, uint256 amount, bytes calldata data) external override {
+    function flashLoan(
+        IERC3156FlashBorrower receiver,
+        IERC20 token,
+        uint256 amount,
+        bytes calldata data
+    ) external override {
         require(token == IERC20(address(this)), "FlashMinter: unsupported loan currency");
         uint256 fee = _flashFee(token, amount);
         _mint(address(receiver), amount);
@@ -345,7 +366,10 @@ contract FlashMinter is ERC20, IERC3156FlashLender {
      * @param amount The amount of tokens lent.
      * @return The amount of `token` to be charged for the loan, on top of the returned principal.
      */
-    function _flashFee(IERC20 token, uint256 amount) internal view returns (uint256) {
+    function _flashFee(
+        IERC20 token,
+        uint256 amount
+    ) internal view returns (uint256) {
         return amount * fee / 10000;
     }
 }

--- a/EIPS/eip-3156.md
+++ b/EIPS/eip-3156.md
@@ -296,7 +296,11 @@ contract FlashMinter is ERC20, IERC3156FlashLender {
     /**
      * @param fee_ The percentage of the loan `amount` that needs to be repaid, in addition to `amount`.
      */
-    constructor (string memory name, string memory symbol, uint256 fee_) ERC20(name, symbol) {
+    constructor (
+        string memory name,
+        string memory symbol,
+        uint256 fee_
+    ) ERC20(name, symbol) {
         fee = fee_;
     }
 
@@ -387,7 +391,10 @@ contract FlashLender is IERC3156FlashLender {
      * @param supportedTokens_ Token contracts supported for flash lending.
      * @param fee_ The percentage of the loan `amount` that needs to be repaid, in addition to `amount`.
      */
-    constructor(IERC20[] memory supportedTokens_, uint256 fee_) {
+    constructor(
+        IERC20[] memory supportedTokens_,
+        uint256 fee_
+    ) {
         for (uint256 i = 0; i < supportedTokens_.length; i++) {
             supportedTokens[supportedTokens_[i]] = true;
         }
@@ -401,7 +408,12 @@ contract FlashLender is IERC3156FlashLender {
      * @param amount The amount of tokens lent.
      * @param data A data parameter to be passed on to the `receiver` for any custom use.
      */
-    function flashLoan(IERC3156FlashBorrower receiver, IERC20 token, uint256 amount, bytes calldata data) external override {
+    function flashLoan(
+        IERC3156FlashBorrower receiver,
+        IERC20 token,
+        uint256 amount,
+        bytes calldata data
+    ) external override {
         require(supportedTokens[token], "FlashLender: Unsupported currency");
         uint256 fee = _flashFee(token, amount);
         token.transfer(address(receiver), amount);
@@ -415,7 +427,10 @@ contract FlashLender is IERC3156FlashLender {
      * @param amount The amount of tokens lent.
      * @return The amount of `token` to be charged for the loan, on top of the returned principal.
      */
-    function flashFee(IERC20 token, uint256 amount) external view override returns (uint256) {
+    function flashFee(
+        IERC20 token,
+        uint256 amount
+    ) external view override returns (uint256) {
         require(supportedTokens[token], "FlashLender: Unsupported currency");
         return _flashFee(token, amount);
     }
@@ -426,7 +441,10 @@ contract FlashLender is IERC3156FlashLender {
      * @param amount The amount of tokens lent.
      * @return The amount of `token` to be charged for the loan, on top of the returned principal.
      */
-    function _flashFee(IERC20 token, uint256 amount) internal view returns (uint256) {
+    function _flashFee(
+        IERC20 token,
+        uint256 amount
+    ) internal view returns (uint256) {
         return amount * fee / 10000;
     }
 
@@ -435,7 +453,9 @@ contract FlashLender is IERC3156FlashLender {
      * @param token The loan currency.
      * @return The amount of `token` that can be borrowed.
      */
-    function maxFlashAmount(IERC20 token) external view override returns (uint256) {
+    function maxFlashAmount(
+        IERC20 token
+    ) external view override returns (uint256) {
         return supportedTokens[token] ? token.balanceOf(address(this)) : 0;
     }
 }

--- a/EIPS/eip-3156.md
+++ b/EIPS/eip-3156.md
@@ -143,6 +143,7 @@ The `batchFlashLoan` function MUST NOT modify the `tokens`, `amounts` and `data`
 
 After the callback, for each `token` in `tokens`, the `batchFlashLoan` function MUST take the `amounts[i] + fees[i]` of `tokens[i]` from the `receiver`, or revert if this is not successful.
 
+For all functions above, including both mandatory and optional sections, address(1) is used as a sentinel value for Ether. If the token parameter is address(1) then the function should be processed as defined except using Ether instead of a token.
 
 ### Receiver Specification
 
@@ -187,7 +188,9 @@ interface IERC3156BatchFlashBorrower {
 }
 ```
 
-For the transaction to not revert, for each `token` in `tokens`, `receiver` MUST approve `amounts[i] + fees[i]` of `tokens[i]` to be taken by `msg.sender` before the end of `onFlashLoan`. 
+For the transaction to not revert, for each `token` in `tokens`, `receiver` MUST approve `amounts[i] + fees[i]` of `tokens[i]` to be taken by `msg.sender` before the end of `onFlashLoan`.
+
+For all functions above, including both mandatory and optional sections, address(1) is used as a sentinel value for Ether. If the token parameter is address(1) then the function should be processed as defined except using Ether instead of a token.
 
 ## Rationale
 

--- a/EIPS/eip-3156.md
+++ b/EIPS/eip-3156.md
@@ -35,7 +35,6 @@ A `lender` MUST implement the IERC3156FlashLender interface.
 ```
 pragma solidity ^0.7.0 || ^0.8.0;
 import "./IERC3156FlashBorrower.sol";
-import "./IERC20.sol";
 
 
 interface IERC3156FlashLender {
@@ -46,7 +45,7 @@ interface IERC3156FlashLender {
      * @return The amount of `token` that can be borrowed.
      */
     function maxFlashAmount(
-        IERC20 token
+        address token
     ) external view returns (uint256);
 
     /**
@@ -56,7 +55,7 @@ interface IERC3156FlashLender {
      * @return The amount of `token` to be charged for the loan, on top of the returned principal.
      */
     function flashFee(
-        IERC20 token,
+        address token,
         uint256 amount
     ) external view returns (uint256);
 
@@ -69,7 +68,7 @@ interface IERC3156FlashLender {
      */
     function flashLoan(
         IERC3156FlashBorrower receiver,
-        IERC20 token,
+        address token,
         uint256 amount,
         bytes calldata data
     ) external;
@@ -110,7 +109,7 @@ A `lender` offering batch flash loans MUST implement the IERC3156BatchFlashLende
 interface IERC3156BatchFlashLender is IERC3156FlashLender {
     function batchFlashLoan(
         IERC3156BatchFlashBorrower receiver,
-        IERC20[] tokens,
+        address[] tokens,
         uint256[] amounts,
         bytes calldata data
     ) external;
@@ -124,7 +123,7 @@ The `batchFlashLoan` function MUST include a callback to the `onBatchFlashLoan` 
 ```
 function batchFlashLoan(
     IERC3156BatchFlashBorrower receiver,
-    IERC20[] calldata tokens,
+    address[] calldata tokens,
     uint256[] calldata amounts,
     bytes calldata data
 ) external {
@@ -151,7 +150,6 @@ A `receiver` of flash loans MUST implement the IERC3156FlashBorrower interface:
 
 ```
 pragma solidity ^0.7.0 || ^0.8.0;
-import "./IERC20.sol";
 
 
 interface IERC3156FlashBorrower {
@@ -166,7 +164,7 @@ interface IERC3156FlashBorrower {
      */
     function onFlashLoan(
         address sender,
-        IERC20 token,
+        address token,
         uint256 amount,
         uint256 fee,
         bytes calldata data
@@ -181,7 +179,7 @@ The *batch flash loans* extension is OPTIONAL for ERC-3156 smart contracts. This
 interface IERC3156BatchFlashBorrower {
     function onBatchFlashLoan(
         IERC3156BatchFlashLender sender,
-        IERC20[] calldata tokens,
+        address[] calldata tokens,
         uint256[] calldata amounts,
         uint256[] calldata fees,
         bytes calldata data
@@ -245,7 +243,7 @@ contract FlashBorrower is IERC3156FlashBorrower {
     /// @dev ERC-3156 Flash loan callback
     function onFlashLoan(
         address sender,
-        IERC20 token,
+        address token,
         uint256 amount,
         uint256 fee,
         bytes calldata data
@@ -268,14 +266,14 @@ contract FlashBorrower is IERC3156FlashBorrower {
 
     /// @dev Initiate a flash loan
     function flashBorrow(
-        IERC20 token,
+        address token,
         uint256 amount
     ) public {
         bytes memory data = abi.encode(Action.NORMAL);
-        uint256 _allowance = token.allowance(address(this), address(lender));
+        uint256 _allowance = IERC20(token).allowance(address(this), address(lender));
         uint256 _fee = lender.flashFee(token, amount);
         uint256 _repayment = amount + _fee;
-        token.approve(address(lender), _allowance + _repayment);
+        IERC20(token).approve(address(lender), _allowance + _repayment);
         lender.flashLoan(this, token, amount, data);
     }
 }
@@ -317,7 +315,7 @@ contract FlashMinter is ERC20, IERC3156FlashLender {
      * @return The amount of `token` that can be borrowed.
      */
     function maxFlashAmount(
-        IERC20 token
+        address token
     ) external view override returns (uint256) {
         return type(uint256).max - totalSupply();
     }
@@ -329,11 +327,11 @@ contract FlashMinter is ERC20, IERC3156FlashLender {
      * @return The amount of `token` to be charged for the loan, on top of the returned principal.
      */
     function flashFee(
-        IERC20 token,
+        address token,
         uint256 amount
     ) external view override returns (uint256) {
         require(
-            token == IERC20(address(this)),
+            token == address(this),
             "FlashMinter: unsupported loan currency"
         );
         return _flashFee(token, amount);
@@ -348,12 +346,12 @@ contract FlashMinter is ERC20, IERC3156FlashLender {
      */
     function flashLoan(
         IERC3156FlashBorrower receiver,
-        IERC20 token,
+        address token,
         uint256 amount,
         bytes calldata data
     ) external override {
         require(
-            token == IERC20(address(this)),
+            token == address(this),
             "FlashMinter: unsupported loan currency"
         );
         uint256 fee = _flashFee(token, amount);
@@ -375,7 +373,7 @@ contract FlashMinter is ERC20, IERC3156FlashLender {
      * @return The amount of `token` to be charged for the loan, on top of the returned principal.
      */
     function _flashFee(
-        IERC20 token,
+        address token,
         uint256 amount
     ) internal view returns (uint256) {
         return amount * fee / 10000;
@@ -399,7 +397,7 @@ import "../interfaces/IERC3156FlashLender.sol";
  */
 contract FlashLender is IERC3156FlashLender {
 
-    mapping(IERC20 => bool) public supportedTokens;
+    mapping(address => bool) public supportedTokens;
     uint256 public fee; //  1 == 0.0001 %.
 
 
@@ -408,7 +406,7 @@ contract FlashLender is IERC3156FlashLender {
      * @param fee_ The percentage of the loan `amount` that needs to be repaid, in addition to `amount`.
      */
     constructor(
-        IERC20[] memory supportedTokens_,
+        address[] memory supportedTokens_,
         uint256 fee_
     ) {
         for (uint256 i = 0; i < supportedTokens_.length; i++) {
@@ -426,7 +424,7 @@ contract FlashLender is IERC3156FlashLender {
      */
     function flashLoan(
         IERC3156FlashBorrower receiver,
-        IERC20 token,
+        address token,
         uint256 amount,
         bytes calldata data
     ) external override {
@@ -436,12 +434,12 @@ contract FlashLender is IERC3156FlashLender {
         );
         uint256 fee = _flashFee(token, amount);
         require(
-            token.transfer(address(receiver), amount),
+            IERC20(token).transfer(address(receiver), amount),
             "FlashLender: Transfer failed"
         );
         receiver.onFlashLoan(msg.sender, token, amount, fee, data);
         require(
-            token.transferFrom(address(receiver), address(this), amount + fee),
+            IERC20(token).transferFrom(address(receiver), address(this), amount + fee),
             "FlashLender: Repay failed"
         );
     }
@@ -453,7 +451,7 @@ contract FlashLender is IERC3156FlashLender {
      * @return The amount of `token` to be charged for the loan, on top of the returned principal.
      */
     function flashFee(
-        IERC20 token,
+        address token,
         uint256 amount
     ) external view override returns (uint256) {
         require(
@@ -470,7 +468,7 @@ contract FlashLender is IERC3156FlashLender {
      * @return The amount of `token` to be charged for the loan, on top of the returned principal.
      */
     function _flashFee(
-        IERC20 token,
+        address token,
         uint256 amount
     ) internal view returns (uint256) {
         return amount * fee / 10000;
@@ -482,9 +480,9 @@ contract FlashLender is IERC3156FlashLender {
      * @return The amount of `token` that can be borrowed.
      */
     function maxFlashAmount(
-        IERC20 token
+        address token
     ) external view override returns (uint256) {
-        return supportedTokens[token] ? token.balanceOf(address(this)) : 0;
+        return supportedTokens[token] ? IERC20(token).balanceOf(address(this)) : 0;
     }
 }
 ```

--- a/EIPS/eip-3156.md
+++ b/EIPS/eip-3156.md
@@ -41,20 +41,6 @@ import "./IERC20.sol";
 interface IERC3156FlashLender {
 
     /**
-     * @dev Initiate a flash loan.
-     * @param receiver The receiver of the tokens in the loan, and the receiver of the callback.
-     * @param token The loan currency.
-     * @param amount The amount of tokens lent.
-     * @param data Arbitrary data structure, intended to contain user-defined parameters.
-     */
-    function flashLoan(
-        IERC3156FlashBorrower receiver,
-        IERC20 token,
-        uint256 amount,
-        bytes calldata data
-    ) external;
-
-    /**
      * @dev The fee to be charged for a given loan.
      * @param token The loan currency.
      * @param amount The amount of tokens lent.
@@ -73,6 +59,20 @@ interface IERC3156FlashLender {
     function maxFlashAmount(
         IERC20 token
     ) external view returns (uint256);
+
+    /**
+     * @dev Initiate a flash loan.
+     * @param receiver The receiver of the tokens in the loan, and the receiver of the callback.
+     * @param token The loan currency.
+     * @param amount The amount of tokens lent.
+     * @param data Arbitrary data structure, intended to contain user-defined parameters.
+     */
+    function flashLoan(
+        IERC3156FlashBorrower receiver,
+        IERC20 token,
+        uint256 amount,
+        bytes calldata data
+    ) external;
 }
 ```
 

--- a/EIPS/eip-3156.md
+++ b/EIPS/eip-3156.md
@@ -250,8 +250,14 @@ contract FlashBorrower is IERC3156FlashBorrower {
         uint256 fee,
         bytes calldata data
     ) external override {
-        require(msg.sender == address(lender), "FlashBorrower: Untrusted lender");
-        require(sender == address(this), "FlashBorrower: External loan initiator");
+        require(
+            msg.sender == address(lender),
+            "FlashBorrower: Untrusted lender"
+        );
+        require(
+            sender == address(this),
+            "FlashBorrower: Untrusted loan initiator"
+        );
         (Action action) = abi.decode(data, (Action));
         if (action == Action.NORMAL) {
             // do one thing
@@ -325,7 +331,10 @@ contract FlashMinter is ERC20, IERC3156FlashLender {
         IERC20 token,
         uint256 amount
     ) external view override returns (uint256) {
-        require(token == IERC20(address(this)), "FlashMinter: unsupported loan currency");
+        require(
+            token == IERC20(address(this)),
+            "FlashMinter: unsupported loan currency"
+        );
         return _flashFee(token, amount);
     }
 
@@ -342,12 +351,18 @@ contract FlashMinter is ERC20, IERC3156FlashLender {
         uint256 amount,
         bytes calldata data
     ) external override {
-        require(token == IERC20(address(this)), "FlashMinter: unsupported loan currency");
+        require(
+            token == IERC20(address(this)),
+            "FlashMinter: unsupported loan currency"
+        );
         uint256 fee = _flashFee(token, amount);
         _mint(address(receiver), amount);
         receiver.onFlashLoan(msg.sender, token, amount, fee, data);
         uint256 _allowance = allowance(address(receiver), address(this));
-        require(_allowance >= (amount + fee), "FlashMinter: Flash loan repayment not approved");
+        require(
+            _allowance >= (amount + fee),
+            "FlashMinter: Flash loan repayment not approved"
+        );
         _approve(address(receiver), address(this), _allowance - (amount + fee));
         _burn(address(receiver), amount + fee);
     }
@@ -414,7 +429,10 @@ contract FlashLender is IERC3156FlashLender {
         uint256 amount,
         bytes calldata data
     ) external override {
-        require(supportedTokens[token], "FlashLender: Unsupported currency");
+        require(
+            supportedTokens[token],
+            "FlashLender: Unsupported currency"
+        );
         uint256 fee = _flashFee(token, amount);
         token.transfer(address(receiver), amount);
         receiver.onFlashLoan(msg.sender, token, amount, fee, data);
@@ -431,7 +449,10 @@ contract FlashLender is IERC3156FlashLender {
         IERC20 token,
         uint256 amount
     ) external view override returns (uint256) {
-        require(supportedTokens[token], "FlashLender: Unsupported currency");
+        require(
+            supportedTokens[token],
+            "FlashLender: Unsupported currency"
+        );
         return _flashFee(token, amount);
     }
 

--- a/EIPS/eip-3156.md
+++ b/EIPS/eip-3156.md
@@ -44,25 +44,25 @@ interface IERC3156FlashLender {
      * @dev Initiate a flash loan.
      * @param receiver The receiver of the tokens in the loan, and the receiver of the callback.
      * @param token The loan currency.
-     * @param value The amount of tokens lent.
+     * @param amount The amount of tokens lent.
      * @param data Arbitrary data structure, intended to contain user-defined parameters.
      */
     function flashLoan(
         IERC3156FlashBorrower receiver,
         IERC20 token,
-        uint256 value,
+        uint256 amount,
         bytes calldata data
     ) external;
 
     /**
      * @dev The fee to be charged for a given loan.
      * @param token The loan currency.
-     * @param value The amount of tokens lent.
+     * @param amount The amount of tokens lent.
      * @return The amount of `token` to be charged for the loan, on top of the returned principal.
      */
     function flashFee(
         IERC20 token,
-        uint256 value
+        uint256 amount
     ) external view returns (uint256);
 
     /**
@@ -93,14 +93,14 @@ interface IERC3156FlashBorrower {
      * @dev Receive a flash loan.
      * @param sender The initiator of the loan.
      * @param token The loan currency.
-     * @param value The amount of tokens lent.
+     * @param amount The amount of tokens lent.
      * @param fee The additional amount of tokens to repay.
      * @param data Arbitrary data structure, intended to contain user-defined parameters.
      */
     function onFlashLoan(
         address sender,
         IERC20 token,
-        uint256 value,
+        uint256 amount,
         uint256 fee,
         bytes calldata data
     ) external;
@@ -172,14 +172,14 @@ interface IERC3156FlashBorrower {
      * @dev Receive a flash loan.
      * @param sender The initiator of the loan.
      * @param token The loan currency.
-     * @param value The amount of tokens lent.
+     * @param amount The amount of tokens lent.
      * @param fee The additional amount of tokens to repay.
      * @param data Arbitrary data structure, intended to contain user-defined parameters.
      */
     function onFlashLoan(
         address sender,
         IERC20 token,
-        uint256 value,
+        uint256 amount,
         uint256 fee,
         bytes calldata data
     ) external;
@@ -436,8 +436,8 @@ contract FlashLender is IERC3156FlashLender {
 
 The arguments of `onFlashLoan` are expected to reflect the conditions of the flash loan, but cannot be trusted unconditionally. They can be divided in two groups, that require different checks before they can be trusted to be genuine.
 
-0. No arguments can be assumed to be genuine without some kind of verification. `sender`, `token` and `value` refer to a past transaction that might not have happened if the caller of `onFlashLoan` decides to lie. `fee` might be false or calculated incorrectly. `data` might have been manipulated by the caller.
-1. To trust that the value of `sender`, `token`, `value` and `fee` are genuine a reasonable pattern is to verify that the `onFlashLoan` caller is in a whitelist of verified flash lenders. Since often the caller of `flashLoan` will also be receiving the `onFlashLoan` callback this will be trivial. In all other cases flash lenders will need to be approved if the arguments in `onFlashLoan` are to be trusted.
+0. No arguments can be assumed to be genuine without some kind of verification. `sender`, `token` and `amount` refer to a past transaction that might not have happened if the caller of `onFlashLoan` decides to lie. `fee` might be false or calculated incorrectly. `data` might have been manipulated by the caller.
+1. To trust that the value of `sender`, `token`, `amount` and `fee` are genuine a reasonable pattern is to verify that the `onFlashLoan` caller is in a whitelist of verified flash lenders. Since often the caller of `flashLoan` will also be receiving the `onFlashLoan` callback this will be trivial. In all other cases flash lenders will need to be approved if the arguments in `onFlashLoan` are to be trusted.
 2. To trust that the value of `data` is genuine, in addition to the check in point 1, it is recommended to implement the `flashLoan` caller to be also the `onFlashLoan` receiver. With this pattern, checking in `onFlashLoan` that `sender` is the current contract is enough to trust that the contents of `data` are genuine.
 
 ### Flash lending security considerations

--- a/EIPS/eip-3156.md
+++ b/EIPS/eip-3156.md
@@ -135,7 +135,7 @@ For each `token` in `tokens`, the `batchFlashLoan` function MUST transfer `amoun
 
 The `batchFlashLoan` function MUST include `msg.sender` as the `sender` to `onBatchFlashLoan`.
 
-The `batchFlashLoan` function MUST include a `fees` argument to `onBatchFlashLoan` with the fee to pay for each individual `token` and `amount` lent.
+The `batchFlashLoan` function MUST include a `fees` argument to `onBatchFlashLoan` with the fee to pay for each individual `token` and `amount` lent, ensuring that `fees[i] = flashFee(tokens[i], amounts[i])`.
 
 The `batchFlashLoan` function MUST NOT modify the `tokens`, `amounts` and `data` parameters received, and MUST pass them on to `onBatchFlashLoan`.
 

--- a/EIPS/eip-3156.md
+++ b/EIPS/eip-3156.md
@@ -83,27 +83,15 @@ The `flashFee` function MUST return the fee charged for a loan of `amount` `toke
 The `flashLoan` function MUST include a callback to the `onFlashLoan` function in a `IERC3156FlashBorrower` contract.
 
 ```
-pragma solidity ^0.7.0 || ^0.8.0;
-import "./IERC20.sol";
-
-
-interface IERC3156FlashBorrower {
-
-    /**
-     * @dev Receive a flash loan.
-     * @param sender The initiator of the loan.
-     * @param token The loan currency.
-     * @param amount The amount of tokens lent.
-     * @param fee The additional amount of tokens to repay.
-     * @param data Arbitrary data structure, intended to contain user-defined parameters.
-     */
-    function onFlashLoan(
-        address sender,
-        IERC20 token,
-        uint256 amount,
-        uint256 fee,
-        bytes calldata data
-    ) external;
+function flashLoan(
+    IERC3156FlashBorrower receiver,
+    IERC20 token,
+    uint256 amount,
+    bytes calldata data
+) external {
+  ...
+  receiver.onFlashLoan(msg.sender, token, amount, fee, data);
+  ...
 }
 ```
 

--- a/EIPS/eip-3156.md
+++ b/EIPS/eip-3156.md
@@ -439,7 +439,10 @@ contract FlashLender is IERC3156FlashLender {
             "FlashLender: Transfer failed"
         );
         receiver.onFlashLoan(msg.sender, token, amount, fee, data);
-        token.transferFrom(address(receiver), address(this), amount + fee);
+        require(
+            token.transferFrom(address(receiver), address(this), amount + fee),
+            "FlashLender: Repay failed"
+        );
     }
 
     /**

--- a/EIPS/eip-3156.md
+++ b/EIPS/eip-3156.md
@@ -77,7 +77,7 @@ interface IERC3156FlashLender {
 
 The `maxFlashAmount` function MUST return the maximum loan possible for `token`. If a `token` is not currently supported `maxFlashAmount` MUST return 0, instead of reverting.
 
-The `flashFee` function MUST return the fee charged for a loan of `amount` `token`. If the loan cannot be executed `flashFee` MUST revert.
+The `flashFee` function MUST return the fee charged for a loan of `amount` `token`. If the token is not supported `flashFee` MUST revert.
 
 The `flashLoan` function MUST include a callback to the `onFlashLoan` function in a `IERC3156FlashBorrower` contract.
 

--- a/EIPS/eip-3156.md
+++ b/EIPS/eip-3156.md
@@ -116,8 +116,6 @@ interface IERC3156BatchFlashLender is IERC3156FlashLender {
 }
 ```
 
-The `batchFlashLoan` function MUST revert if the length of the `amounts` and `tokens` arrays differ.
-
 The `batchFlashLoan` function MUST include a callback to the `onBatchFlashLoan` function in a `IERC3156BatchFlashBorrower` contract.
 
 ```

--- a/EIPS/eip-3156.md
+++ b/EIPS/eip-3156.md
@@ -41,6 +41,15 @@ import "./IERC20.sol";
 interface IERC3156FlashLender {
 
     /**
+     * @dev The amount of currency available to be lended.
+     * @param token The loan currency.
+     * @return The amount of `token` that can be borrowed.
+     */
+    function maxFlashAmount(
+        IERC20 token
+    ) external view returns (uint256);
+
+    /**
      * @dev The fee to be charged for a given loan.
      * @param token The loan currency.
      * @param amount The amount of tokens lent.
@@ -49,15 +58,6 @@ interface IERC3156FlashLender {
     function flashFee(
         IERC20 token,
         uint256 amount
-    ) external view returns (uint256);
-
-    /**
-     * @dev The amount of currency available to be lended.
-     * @param token The loan currency.
-     * @return The amount of `token` that can be borrowed.
-     */
-    function maxFlashAmount(
-        IERC20 token
     ) external view returns (uint256);
 
     /**

--- a/EIPS/eip-3156.md
+++ b/EIPS/eip-3156.md
@@ -434,7 +434,10 @@ contract FlashLender is IERC3156FlashLender {
             "FlashLender: Unsupported currency"
         );
         uint256 fee = _flashFee(token, amount);
-        token.transfer(address(receiver), amount);
+        require(
+            token.transfer(address(receiver), amount),
+            "FlashLender: Transfer failed"
+        );
         receiver.onFlashLoan(msg.sender, token, amount, fee, data);
         token.transferFrom(address(receiver), address(this), amount + fee);
     }


### PR DESCRIPTION
Updated the reference implementations [to actually run](https://github.com/albertocuestacanada/ERC3156), fixing some things along the way:

 - Added natspec to interfaces
 - Used `amount` instead of `value` throughout the code
 - Corrected argument type on `onFlashLoan`
 - Minor descriptive edits
 - Added rationale on choosing `pull` over `push` repayment behaviour
 - Expanded reference implementation of flash borrower
 - Bug fixing on reference implementations
 - Better comments on reference implementations