### PR TITLE
1559: Adds dependency on 2718

### DIFF
--- a/EIPS/eip-1559.md
+++ b/EIPS/eip-1559.md
@@ -7,6 +7,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2019-04-13
+requires: 2718
 ---
 
 ## Simple Summary
@@ -16,9 +17,9 @@ A transaction pricing mechanism that includes fixed-per-block network fee that i
 There is a base fee per gas in protocol, which can move up or down each block according to a formula which is a function of gas used in parent block and gas target (formerly known as gas limit) of parent block.
 The algorithm results in the base fee per gas increasing when blocks are above the gas target, and decreasing when blocks are below the gas target.
 The base fee per gas is burned.
-Transactions specify the maximum fee per gas they are willing to give to miners to incentivize them to include their transaction (aka: miner bribe).
-Transactions also specify the maximum fee per gas they are willing to pay total (aka: fee cap), which covers both the miner bribe and the block's network fee per gas (aka: base fee).
-The transaction will always pay the base fee per gas of the block it was included in, and they will pay the bribe per gas set in the transaction, as long as the combined amount of the two fees doesn't exceed the transaction's maximum fee per gas.
+Transactions specify the maximum fee per gas they are willing to give to miners to incentivize them to include their transaction (aka: inclusion fee).
+Transactions also specify the maximum fee per gas they are willing to pay total (aka: max fee), which covers both the inclusion fee and the block's network fee per gas (aka: base fee).
+The transaction will always pay the base fee per gas of the block it was included in, and they will pay the inclnusion fee per gas set in the transaction, as long as the combined amount of the two fees doesn't exceed the transaction's maximum fee per gas.
 
 ## Motivation
 Ethereum historically priced transaction fees using a simple auction mechanism, where users send transactions with bids ("gasprices") and miners choose transactions with the highest bids, and transactions that get included pay the bid that they specify. This leads to several large sources of inefficiency:
@@ -28,23 +29,31 @@ Ethereum historically priced transaction fees using a simple auction mechanism, 
 * **Inefficiencies of first price auctions**: The current approach, where transaction senders publish a transaction with a bid a maximum fee, miners choose the highest-paying transactions, and everyone pays what they bid. This is well-known in mechanism design literature to be highly inefficient, and so complex fee estimation algorithms are required. But even these algorithms often end up not working very well, leading to frequent fee overpayment.
 * **Instability of blockchains with no block reward**: In the long run, blockchains where there is no issuance (including Bitcoin and Zcash) at present intend to switch to rewarding miners entirely through transaction fees. However, there are known issues with this that likely leads to a lot of instability, incentivizing mining "sister blocks" that steal transaction fees, opening up much stronger selfish mining attack vectors, and more. There is at present no good mitigation for this.
 
-The proposal in this EIP is to start with a base fee amount which is adjusted up and down by the protocol based on how congested the network is. When the network exceeds the target per-block gas usage, the base fee increases slightly and when capacity is below the target, it decreases slightly. Because these base fee changes are constrained, the maximum difference in base fee from block to block is predictable. This then allows wallets to auto-set the gas fees for users in a highly reliable fashion. It is expected that most users will not have to manually adjust gas fees, even in periods of high network activity. For most users the base fee will be estimated by their wallet and a small miner bribe, which compensates miners taking on orphan risk (e.g. 1 nanoeth), will be automatically set. Users can also manually set the transaction fee cap to bound their total costs.
+The proposal in this EIP is to start with a base fee amount which is adjusted up and down by the protocol based on how congested the network is. When the network exceeds the target per-block gas usage, the base fee increases slightly and when capacity is below the target, it decreases slightly. Because these base fee changes are constrained, the maximum difference in base fee from block to block is predictable. This then allows wallets to auto-set the gas fees for users in a highly reliable fashion. It is expected that most users will not have to manually adjust gas fees, even in periods of high network activity. For most users the base fee will be estimated by their wallet and a small inclusion fee, which compensates miners taking on orphan risk (e.g. 1 nanoeth), will be automatically set. Users can also manually set the transaction max fee to bound their total costs.
 
-An important aspect of this fee system is that miners only get to keep the miner bribe. The base fee is always burned (i.e. it is destroyed by the protocol). Burning this is important because it removes miner incentive to manipulate the fee in order to extract more fees from users. It also ensures that only ETH can ever be used to pay for transactions on Ethereum, cementing the economic value of ETH within the Ethereum platform. Additionally, this burn counterbalances Ethereum inflation without greatly diminishing miner rewards.
+An important aspect of this fee system is that miners only get to keep the inclusion fee. The base fee is always burned (i.e. it is destroyed by the protocol). Burning this is important because it removes miner incentive to manipulate the fee in order to extract more fees from users. It also ensures that only ETH can ever be used to pay for transactions on Ethereum, cementing the economic value of ETH within the Ethereum platform. Additionally, this burn counterbalances Ethereum inflation without greatly diminishing miner rewards.
 
 ## Specification
 Block validity is defined in the reference implementation below.
 The `GASPRICE` (`0x3a`) opcode **MUST** return the `effective_gas_price` as defined in the reference implementation below.
 
+As of `FORK_BLOCK_NUMBER`, a new [EIP-2718](./eip-2718.md) transaction is introduced with `TransactionType` 2.
+
+The [EIP-2718](./eip-2718.md) `TransactionPayload` for this transaction is `rlp([chainId, nonce, maxInclusionFeePerGas, maxFeePerGas, gasLimit, to, value, data, access_list, signatureYParity, signatureR, signatureS])`.
+
+The `signatureYParity, signatureR, signatureS` elements of this transaction represent a secp256k1 signature over `keccak256(rlp([2, chainId, nonce, maxInclusionFeePerGas, maxFeePerGas, gasLimit, to, value, data, access_list]))`.
+
+The [EIP-2718](./eip-2718.md) `ReceiptPayload` for this transaction is `rlp([status, effectiveGasPrice, cumulativeGasUsed, logsBloom, logs])`.
+
 *Note: `//` is integer division, round down.*
 ```python
-from typing import Union, Sequence
+from typing import Union, Dict, Sequence, List, Tuple, Literal
 from dataclasses import dataclass, field
 from abc import ABC, abstractmethod
 
 @dataclass
 class TransactionLegacy:
-	account_nonce: int = 0
+	signer_nonce: int = 0
 	gas_price: int = 0
 	gas_limit: int = 0
 	destination: int = 0
@@ -55,19 +64,59 @@ class TransactionLegacy:
 	s: int = 0
 
 @dataclass
-class Transaction1559:
-	account_nonce: int = 0
+class Transaction2930Payload:
+	chain_id: int = 0
+	signer_nonce: int = 0
+	gas_price: int = 0
 	gas_limit: int = 0
 	destination: int = 0
 	amount: int = 0
 	payload: bytes = bytes()
-	max_miner_bribe_per_gas: int = 0
-	fee_cap_per_gas: int = 0
-	v: int = 0
-	r: int = 0
-	s: int = 0
+	access_list: List[Tuple[int,List[int]]] = field(default_factory=list)
+	signature_y_parity: bool = False
+	signature_r: int = 0
+	signature_s: int = 0
 
-Transaction = Union[TransactionLegacy, Transaction1559]
+@dataclass
+class Transaction2930Envelope:
+	type: Literal[1] = 1
+	payload: Transaction2930Payload = Transaction2930Payload()
+
+@dataclass
+class Transaction1559Payload:
+	chain_id: int = 0
+	signer_nonce: int = 0
+	max_inclusion_fee_per_gas: int = 0
+	max_fee_per_gas: int = 0
+	gas_limit: int = 0
+	destination: int = 0
+	amount: int = 0
+	payload: bytes = bytes()
+	access_list: List[Tuple[int,List[int]]] = field(default_factory=list)
+	signature_y_parity: bool = False
+	signature_r: int = 0
+	signature_s: int = 0
+
+@dataclass
+class Transaction1559Envelope:
+	type: Literal[2] = 2
+	payload: Transaction1559Payload = Transaction1559Payload()
+
+Transaction2718 = Union[Transaction1559Envelope, Transaction2930Envelope]
+
+Transaction = Union[TransactionLegacy, Transaction2718]
+
+@dataclass
+class NormalizedTransaction:
+	signer_address: int = 0
+	signer_nonce: int = 0
+	max_inclusion_fee_per_gas: int = 0
+	max_fee_per_gas: int = 0
+	gas_limit: int = 0
+	destination: int = 0
+	amount: int = 0
+	payload: bytes = bytes()
+	access_list: List[Tuple[int,List[int]]] = field(default_factory=list)
 
 @dataclass
 class Block:
@@ -86,10 +135,11 @@ class Block:
 	extra_data: bytes = bytes()
 	proof_of_work: int = 0
 	nonce: int = 0
-	base_fee: int = 0 # default to 0 for blocks before INITIAL_FORK_BLOCK_NUMBER
+	base_fee_per_gas: int = 0 # default to 0 for blocks before INITIAL_FORK_BLOCK_NUMBER
 
 @dataclass
 class Account:
+	address: int = 0
 	nonce: int = 0
 	balance: int = 0
 	storage_root: int = 0
@@ -101,7 +151,7 @@ ELASTICITY_MULTIPLIER = 2
 
 class World(ABC):
 	def validate_block(self, block: Block) -> None:
-		parent_base_fee = self.parent(block).base_fee
+		parent_base_fee_per_gas = self.parent(block).base_fee_per_gas
 		parent_gas_used = self.parent(block).gas_used
 		parent_gas_target = self.parent(block).gas_target
 		transactions = self.transactions(block)
@@ -115,33 +165,35 @@ class World(ABC):
 
 		# check if the base fee is correct
 		if parent_gas_used == parent_gas_target:
-			expected_base_fee = parent_base_fee
+			expected_base_fee_per_gas = parent_base_fee_per_gas
 		elif parent_gas_used > parent_gas_target:
-			gas_delta = parent_gas_used - parent_gas_target
-			fee_delta = max(parent_base_fee * gas_delta // parent_gas_target // BASE_FEE_MAX_CHANGE_DENOMINATOR, 1)
-			expected_base_fee = parent_base_fee + fee_delta
+			gas_used_delta = parent_gas_used - parent_gas_target
+			base_fee_per_gas_delta = max(parent_base_fee_per_gas * gas_used_delta // parent_gas_target // BASE_FEE_MAX_CHANGE_DENOMINATOR, 1)
+			expected_base_fee_per_gas = parent_base_fee_per_gas + base_fee_per_gas_delta
 		else:
-			gas_delta = parent_gas_target - parent_gas_used
-			fee_delta = parent_base_fee * gas_delta // parent_gas_target // BASE_FEE_MAX_CHANGE_DENOMINATOR
-			expected_base_fee = parent_base_fee - fee_delta
-		assert expected_base_fee == block.base_fee, 'invalid block: base fee not correct'
+			gas_used_delta = parent_gas_target - parent_gas_used
+			base_fee_per_gas_delta = parent_base_fee_per_gas * gas_used_delta // parent_gas_target // BASE_FEE_MAX_CHANGE_DENOMINATOR
+			expected_base_fee_per_gas = parent_base_fee_per_gas - base_fee_per_gas_delta
+		assert expected_base_fee_per_gas == block.base_fee_per_gas, 'invalid block: base fee not correct'
 
 		# execute transactions and do gas accounting
 		cumulative_transaction_gas_used = 0
-		for transaction in transactions:
-			# Note: this validates transaction signature which must happen before we normalize below since the signature won't match after that
-			signer = self.transaction_signer_account(transaction)
+		for unnormalized_transaction in transactions:
+			# Note: this validates transaction signature and chain ID which must happen before we normalize below since normalized transactions don't include signature or chain ID
+			signer_address = self.validate_and_recover_signer_address(unnormalized_transaction)
+			transaction = self.normalize_transaction(unnormalized_transaction, signer_address)
+
+			signer = self.account(signer_address)
+
 			signer.balance -= transaction.amount
 			assert signer.balance >= 0, 'invalid transaction: signer does not have enough ETH to cover attached value'
 
-			transaction = self.normalize_transaction(transaction)
-
 			# ensure that the user was willing to at least pay the base fee
-			assert transaction.fee_cap_per_gas >= block.base_fee
-			# bribe is capped such that base fee is filled first
-			bribe_per_gas = min(transaction.max_miner_bribe_per_gas, transaction.fee_cap_per_gas - block.base_fee)
-			# signer pays both the bribe and the base fee
-			effective_gas_price = bribe_per_gas + block.base_fee
+			assert transaction.max_fee_per_gas >= block.base_fee_per_gas
+			# inclusion fee is capped because the base fee is filled first
+			inclusion_fee_per_gas = min(transaction.max_inclusion_fee_per_gas, transaction.max_fee_per_gas - block.base_fee_per_gas)
+			# signer pays both the inclusion fee and the base fee
+			effective_gas_price = inclusion_fee_per_gas + block.base_fee_per_gas
 			signer.balance -= transaction.gas_limit * effective_gas_price
 			assert signer.balance >= 0, 'invalid transaction: signer does not have enough ETH to cover gas'
 			gas_used = self.execute_transaction(transaction, effective_gas_price)
@@ -149,8 +201,8 @@ class World(ABC):
 			cumulative_transaction_gas_used += gas_used
 			# signer gets refunded for unused gas
 			signer.balance += gas_refund * effective_gas_price
-			# miner only receives the bribe; note that the base fee is not given to anyone (it is burned)
-			self.account(block.author).balance += gas_used * bribe_per_gas
+			# miner only receives the inclusion fee; note that the base fee is not given to anyone (it is burned)
+			self.account(block.author).balance += gas_used * inclusion_fee_per_gas
 
 		# check if the block spent too much gas transactions
 		assert cumulative_transaction_gas_used == block.gas_used, 'invalid block: gas_used does not equal total gas used in all transactions'
@@ -158,22 +210,46 @@ class World(ABC):
 		# TODO: verify account balances match block's account balances (via state root comparison)
 		# TODO: validate the rest of the block
 
-	def normalize_transaction(self, transaction: Transaction) -> Transaction1559:
-		# handle legacy transactions, can differentiate by number of items if desired (Legacy == 8 items)
+	def normalize_transaction(self, transaction: Transaction, signer_address: int) -> NormalizedTransaction:
+		# legacy transactions
 		if isinstance(transaction, TransactionLegacy):
-			return Transaction1559(
-				account_nonce: int = transaction.account_nonce,
-				gas_limit: int = transaction.gas_limit,
-				amount: int = transaction.amount,
-				payload: bytes = transaction.payload,
-				max_miner_bribe_per_gas: int = transaction.gas_price,
-				fee_cap_per_gas: int = transaction.gas_price,
-				v: int = transaction.v,
-				r: int = transaction.r,
-				s: int = transaction.s,
+			return NormalizedTransaction(
+				signer_address = signer_address,
+				signer_nonce = transaction.signer_nonce,
+				gas_limit = transaction.gas_limit,
+				max_inclusion_fee_per_gas = transaction.gas_price,
+				max_fee_per_gas = transaction.gas_price,
+				destination = transaction.destination,
+				amount = transaction.amount,
+				payload = transaction.payload,
+				access_list = [],
 			)
-		elif isinstance(transaction, Transaction1559):
-			return transaction
+		# 2930 transactions
+		elif isinstance(transaction, Transaction2930Envelope):
+			return NormalizedTransaction(
+				signer_address = signer_address,
+				signer_nonce = transaction.payload.signer_nonce,
+				gas_limit = transaction.payload.gas_limit,
+				max_inclusion_fee_per_gas = transaction.payload.gas_price,
+				max_fee_per_gas = transaction.payload.gas_price,
+				destination = transaction.payload.destination,
+				amount = transaction.payload.amount,
+				payload = transaction.payload.payload,
+				access_list = transaction.payload.access_list,
+			)
+		# 1559 transactions
+		elif isinstance(transaction, Transaction1559Envelope):
+			return NormalizedTransaction(
+				signer_address = signer_address,
+				signer_nonce = transaction.payload.signer_nonce,
+				gas_limit = transaction.payload.gas_limit,
+				max_inclusion_fee_per_gas = transaction.payload.max_inclusion_fee_per_gas,
+				max_fee_per_gas = transaction.payload.max_fee_per_gas,
+				destination = transaction.payload.destination,
+				amount = transaction.payload.amount,
+				payload = transaction.payload.payload,
+				access_list = transaction.payload.access_list,
+			)
 		else:
 			raise Exception('invalid transaction: unexpected number of items')
 
@@ -188,17 +264,17 @@ class World(ABC):
 
 	# effective_gas_price is the value returned by the GASPRICE (0x3a) opcode
 	@abstractmethod
-	def execute_transaction(self, transaction: Transaction, effective_gas_price: int) -> int: pass
+	def execute_transaction(self, transaction: NormalizedTransaction, effective_gas_price: int) -> int: pass
 
 	@abstractmethod
-	def transaction_signer_account(self, transaction: Transaction) -> Account: pass
+	def validate_and_recover_signer_address(self, transaction: Transaction) -> int: pass
 
 	@abstractmethod
 	def account(self, address: int) -> Account: pass
 ```
 
 ## Backwards Compatibility
-Legacy Ethereum transactions will still work and be included in blocks, but they will not benefit directly from the new pricing system.  This is due to the fact that upgrading from legacy transactions to new transactions results in the legacy transaction's `gas_price ` entirely being consumed either by the `base_fee` or the `miner_bribe`.
+Legacy Ethereum transactions will still work and be included in blocks, but they will not benefit directly from the new pricing system.  This is due to the fact that upgrading from legacy transactions to new transactions results in the legacy transaction's `gas_price ` entirely being consumed either by the `base_fee_per_gas` and the `inclusion_fee_per_gas`.
 
 ### GASPRICE
 Previous to this change, `GASPRICE` represented both the ETH paid by the signer per gas for a transaction as well as the ETH received by the miner per gas.  As of this change, `GASPRICE` now only represents the amount of ETH paid by the signer per gas, and the amount a miner was paid for the transaction is no longer accessible directly in the EVM.
@@ -216,7 +292,7 @@ This EIP will increase the maximum block size, which could cause problems if min
 With most people not competing on miner fees and instead using a baseline fee to get included, transaction ordering now depends on individual client internal implementation details such as how they store the transactions in memory.  It is recommended that transactions with the same miner fee be sorted by time the transaction was received to protect the network from spamming attacks where the attacker throws a bunch of transactions into the pending pool in order to ensure that at least one lands in a favorable position.  Miners should still prefer higher tip transactions over lower tip, purely from a selfish mining perspective.
 
 ### Miners Mining Empty Blocks
-It is possible that miners will mine empty blocks until such time as the base fee is very low and then proceed to mine half full blocks and revert to sorting transactions by the miner bribe.  While this attack is possible, it is not a particularly stable equilibrium as long as mining is decentralized.  Any defector from this strategy will be more profitable than a miner participating in the attack for as long as the attack continues (even after the base fee reached 0).  Since any miner can anonymously defect from a cartel, and there is no way to prove that a particular miner defected, the only feasible way to execute this attack would be to control 50% or more of hashing power.  If an attacker had exectly 50% of hashing power, they would make no money from miner bribe while defectors would make double the money from bribes.  For an attacker to turn a profit, they need to have some amount over 50% hashing power, which means they can alternatively execute double spend attacks or simply ignore any other miners which is a far more profitable strategy.
+It is possible that miners will mine empty blocks until such time as the base fee is very low and then proceed to mine half full blocks and revert to sorting transactions by the inclusion fee.  While this attack is possible, it is not a particularly stable equilibrium as long as mining is decentralized.  Any defector from this strategy will be more profitable than a miner participating in the attack for as long as the attack continues (even after the base fee reached 0).  Since any miner can anonymously defect from a cartel, and there is no way to prove that a particular miner defected, the only feasible way to execute this attack would be to control 50% or more of hashing power.  If an attacker had exectly 50% of hashing power, they would make no money from inclusion fee while defectors would make double the money from inclusion fees.  For an attacker to turn a profit, they need to have some amount over 50% hashing power, which means they can alternatively execute double spend attacks or simply ignore any other miners which is a far more profitable strategy.
 
 Should a miner attempt to execute this attack, we can simply increase the elasticity multiplier (currently 2x) which requires they have even more hashing power available before the attack can even be theoretically profitable against defectors.
 

--- a/EIPS/eip-1559.md
+++ b/EIPS/eip-1559.md
@@ -19,7 +19,7 @@ The algorithm results in the base fee per gas increasing when blocks are above t
 The base fee per gas is burned.
 Transactions specify the maximum fee per gas they are willing to give to miners to incentivize them to include their transaction (aka: inclusion fee).
 Transactions also specify the maximum fee per gas they are willing to pay total (aka: max fee), which covers both the inclusion fee and the block's network fee per gas (aka: base fee).
-The transaction will always pay the base fee per gas of the block it was included in, and they will pay the inclnusion fee per gas set in the transaction, as long as the combined amount of the two fees doesn't exceed the transaction's maximum fee per gas.
+The transaction will always pay the base fee per gas of the block it was included in, and they will pay the inclusion fee per gas set in the transaction, as long as the combined amount of the two fees doesn't exceed the transaction's maximum fee per gas.
 
 ## Motivation
 Ethereum historically priced transaction fees using a simple auction mechanism, where users send transactions with bids ("gasprices") and miners choose transactions with the highest bids, and transactions that get included pay the bid that they specify. This leads to several large sources of inefficiency:


### PR DESCRIPTION
Integrates 2718 (Typed Transactions) into EIP-1559.  Overall a pretty simple/small change, mostly with just some adjustments to pre-processing.

I took the opportunity to also rename some of the variables both to improve clarity and to reduce conflict in the community (bribe vs inclusion fee).  If someone feels strongly about it, I can split out the 2718 changes and the variable name changes.