### PR TITLE
erc3156: added return types to avoid vulnerability

### DIFF
--- a/EIPS/eip-3156.md
+++ b/EIPS/eip-3156.md
@@ -153,7 +153,7 @@ The `lender` MUST verify that the `onBatchFlashLoan` callback returns `true`.
 
 After the callback, for each `token` in `tokens`, the `batchFlashLoan` function MUST take the `amounts[i] + fees[i]` of `tokens[i]` from the `receiver`, or revert if this is not successful.
 
-If successful, `batchFlashLoan` MUST return `true`.
+If successful, `batchFlashLoan` MUST return the keccak256 hash of "ERC3156FlashBorrower.onFlashLoan".
 
 For all functions above, including both mandatory and optional sections, address(1) is used as a sentinel value for Ether. If the token parameter is address(1) then the function should be processed as defined except using Ether instead of a token.
 
@@ -174,6 +174,7 @@ interface IERC3156FlashBorrower {
      * @param amount The amount of tokens lent.
      * @param fee The additional amount of tokens to repay.
      * @param data Arbitrary data structure, intended to contain user-defined parameters.
+     * @return The keccak256 hash of "ERC3156FlashBorrower.onFlashLoan"
      */
     function onFlashLoan(
         address sender,
@@ -181,24 +182,34 @@ interface IERC3156FlashBorrower {
         uint256 amount,
         uint256 fee,
         bytes calldata data
-    ) external returns (bool);
+    ) external returns (bytes32);
 }
 ```
 
 For the transaction to not revert, `receiver` MUST approve `amount + fee` of `token` to be taken by `msg.sender` before the end of `onFlashLoan`.
 
-If successful, `onFlashLoan` MUST return `true`.
+If successful, `onFlashLoan` MUST return the keccak256 hash of "ERC3156BatchFlashBorrower.onBatchFlashLoan".
 
 The *batch flash loans* extension is OPTIONAL for ERC-3156 smart contracts. This allows flash loans to be composed of several ERC20 tokens.
 ```
+
 interface IERC3156BatchFlashBorrower {
+    /**
+     * @dev Receive a batch flash loan.
+     * @param sender The initiator of the loan.
+     * @param tokens The loan currencies.
+     * @param amounts The amounts of tokens lent.
+     * @param fees The additional amount of tokens to repay.
+     * @param data Arbitrary data structure, intended to contain user-defined parameters.
+     * @return The keccak256 hash of "ERC3156BatchFlashBorrower.onBatchFlashLoan"
+     */
     function onBatchFlashLoan(
         IERC3156BatchFlashLender sender,
         address[] calldata tokens,
         uint256[] calldata amounts,
         uint256[] calldata fees,
         bytes calldata data
-    ) external returns (bool);
+    ) external returns (bytes32);
 }
 ```
 
@@ -281,7 +292,7 @@ contract FlashBorrower is IERC3156FlashBorrower {
         } else if (action == Action.OTHER) {
             // do another
         }
-        return true;
+        return keccak256("ERC3156FlashBorrower.onFlashLoan");
     }
 
     /// @dev Initiate a flash loan
@@ -316,6 +327,7 @@ import "../interfaces/IERC3156FlashLender.sol";
  */
 contract FlashMinter is ERC20, IERC3156FlashLender {
 
+    bytes32 public constant CALLBACK_SUCCESS = keccak256("ERC3156FlashBorrower.onFlashLoan");
     uint256 public fee; //  1 == 0.0001 %.
 
     /**
@@ -369,7 +381,7 @@ contract FlashMinter is ERC20, IERC3156FlashLender {
         address token,
         uint256 amount,
         bytes calldata data
-    ) external override returns(bool) {
+    ) external override returns (bool){
         require(
             token == address(this),
             "FlashMinter: Unsupported currency"
@@ -377,7 +389,7 @@ contract FlashMinter is ERC20, IERC3156FlashLender {
         uint256 fee = _flashFee(token, amount);
         _mint(address(receiver), amount);
         require(
-            receiver.onFlashLoan(msg.sender, token, amount, fee, data),
+            receiver.onFlashLoan(msg.sender, token, amount, fee, data) == CALLBACK_SUCCESS,
             "FlashMinter: Callback failed"
         );
         uint256 _allowance = allowance(address(receiver), address(this));
@@ -421,6 +433,7 @@ import "../interfaces/IERC3156FlashLender.sol";
  */
 contract FlashLender is IERC3156FlashLender {
 
+    bytes32 public constant CALLBACK_SUCCESS = keccak256("ERC3156FlashBorrower.onFlashLoan");
     mapping(address => bool) public supportedTokens;
     uint256 public fee; //  1 == 0.0001 %.
 
@@ -462,9 +475,9 @@ contract FlashLender is IERC3156FlashLender {
             "FlashLender: Transfer failed"
         );
         require(
-            receiver.onFlashLoan(msg.sender, token, amount, fee, data),
-            "FlashLender: Callback failed"
-        );
+            receiver.onFlashLoan(msg.sender, token, amount, fee, data) == CALLBACK_SUCCESS,
+            "FlashLender: Callback failed")
+        ;
         require(
             IERC20(token).transferFrom(address(receiver), address(this), amount + fee),
             "FlashLender: Repay failed"
@@ -513,6 +526,7 @@ contract FlashLender is IERC3156FlashLender {
         return supportedTokens[token] ? IERC20(token).balanceOf(address(this)) : 0;
     }
 }
+
 ```
 
 ## Security Considerations
@@ -533,7 +547,7 @@ The safest approach is to implement an approval for `amount+fee` before the `fla
 
 Including in `onFlashLoan` the approval for the `lender` to take the `amount + fee` needs to be combined with a mechanism to verify that the borrower is trusted, such as those described above.
 
-If an unsuspecting contract with a non-reverting fallback function, or an EOA, would approve a `lender` implementing ERC3156, and not immediately use the approval, and if the `lender` would not verify the return value of `onFlashLoan`, then the unsuspecting contract or EOA could be drained of funds up to their allowance or balance limit. This would be executed by a `borrower` calling `flashLoan` on the victim. The flash loan would be executed and repaid, plus any fees, which would be accumulated by the `lender`. For this reason, it is important that the `lender` implements the specification in full and reverts if `onFlashLoan` doesn't return `true`.
+If an unsuspecting contract with a non-reverting fallback function, or an EOA, would approve a `lender` implementing ERC3156, and not immediately use the approval, and if the `lender` would not verify the return value of `onFlashLoan`, then the unsuspecting contract or EOA could be drained of funds up to their allowance or balance limit. This would be executed by a `borrower` calling `flashLoan` on the victim. The flash loan would be executed and repaid, plus any fees, which would be accumulated by the `lender`. For this reason, it is important that the `lender` implements the specification in full and reverts if `onFlashLoan` doesn't return the keccak256 hash for "ERC3156FlashBorrower.onFlashLoan".
 
 ### Flash minting external security considerations
 

--- a/EIPS/eip-3156.md
+++ b/EIPS/eip-3156.md
@@ -71,7 +71,7 @@ interface IERC3156FlashLender {
         address token,
         uint256 amount,
         bytes calldata data
-    ) external;
+    ) external returns (bool);
 }
 ```
 
@@ -87,9 +87,12 @@ function flashLoan(
     IERC20 token,
     uint256 amount,
     bytes calldata data
-) external {
+) external returns (bool) {
   ...
-  receiver.onFlashLoan(msg.sender, token, amount, fee, data);
+  require(
+      receiver.onFlashLoan(msg.sender, token, amount, fee, data),
+      "IERC3156: Callback failed"
+  );
   ...
 }
 ```
@@ -100,7 +103,11 @@ The `flashLoan` function MUST include `msg.sender` as the `sender` to `onFlashLo
 
 The `flashLoan` function MUST NOT modify the `token`, `amount` and `data` parameter received, and MUST pass them on to `onFlashLoan`.
 
+The `lender` MUST verify that the `onFlashLoan` callback returns `true`.
+
 After the callback, the `flashLoan` function MUST take the `amount + fee` `token` from the `receiver`, or revert if this is not successful.
+
+If successful, `flashLoan` MUST return `true`.
 
 The *batch flash loans* extension is OPTIONAL for ERC-3156 smart contracts. This allows flash loans to be composed of several ERC20 tokens.
 
@@ -112,7 +119,7 @@ interface IERC3156BatchFlashLender is IERC3156FlashLender {
         address[] tokens,
         uint256[] amounts,
         bytes calldata data
-    ) external;
+    ) external returns (bool);
 }
 ```
 
@@ -124,9 +131,12 @@ function batchFlashLoan(
     address[] calldata tokens,
     uint256[] calldata amounts,
     bytes calldata data
-) external {
+) external returns (bool){
   ...
-  receiver.onBatchFlashLoan(msg.sender, tokens, amounts, fees, data);
+  require(
+      receiver.onBatchFlashLoan(msg.sender, tokens, amounts, fees, data),
+      "IERC3156: Callback failed"
+  )
   ...
 }
 ```
@@ -139,7 +149,11 @@ The `batchFlashLoan` function MUST include a `fees` argument to `onBatchFlashLoa
 
 The `batchFlashLoan` function MUST NOT modify the `tokens`, `amounts` and `data` parameters received, and MUST pass them on to `onBatchFlashLoan`.
 
+The `lender` MUST verify that the `onBatchFlashLoan` callback returns `true`.
+
 After the callback, for each `token` in `tokens`, the `batchFlashLoan` function MUST take the `amounts[i] + fees[i]` of `tokens[i]` from the `receiver`, or revert if this is not successful.
+
+If successful, `batchFlashLoan` MUST return `true`.
 
 For all functions above, including both mandatory and optional sections, address(1) is used as a sentinel value for Ether. If the token parameter is address(1) then the function should be processed as defined except using Ether instead of a token.
 
@@ -167,11 +181,13 @@ interface IERC3156FlashBorrower {
         uint256 amount,
         uint256 fee,
         bytes calldata data
-    ) external;
+    ) external returns (bool);
 }
 ```
 
 For the transaction to not revert, `receiver` MUST approve `amount + fee` of `token` to be taken by `msg.sender` before the end of `onFlashLoan`.
+
+If successful, `onFlashLoan` MUST return `true`.
 
 The *batch flash loans* extension is OPTIONAL for ERC-3156 smart contracts. This allows flash loans to be composed of several ERC20 tokens.
 ```
@@ -182,11 +198,13 @@ interface IERC3156BatchFlashBorrower {
         uint256[] calldata amounts,
         uint256[] calldata fees,
         bytes calldata data
-    ) external;
+    ) external returns (bool);
 }
 ```
 
-For the transaction to not revert, for each `token` in `tokens`, `receiver` MUST approve `amounts[i] + fees[i]` of `tokens[i]` to be taken by `msg.sender` before the end of `onFlashLoan`.
+For the transaction to not revert, for each `token` in `tokens`, `receiver` MUST approve `amounts[i] + fees[i]` of `tokens[i]` to be taken by `msg.sender` before the end of `onBatchFlashLoan`.
+
+If successful, `onBatchFlashLoan` MUST return `true`.
 
 For all functions above, including both mandatory and optional sections, address(1) is used as a sentinel value for Ether. If the token parameter is address(1) then the function should be processed as defined except using Ether instead of a token.
 
@@ -248,7 +266,7 @@ contract FlashBorrower is IERC3156FlashBorrower {
         uint256 amount,
         uint256 fee,
         bytes calldata data
-    ) external override {
+    ) external override returns(bool) {
         require(
             msg.sender == address(lender),
             "FlashBorrower: Untrusted lender"
@@ -263,6 +281,7 @@ contract FlashBorrower is IERC3156FlashBorrower {
         } else if (action == Action.OTHER) {
             // do another
         }
+        return true;
     }
 
     /// @dev Initiate a flash loan
@@ -333,7 +352,7 @@ contract FlashMinter is ERC20, IERC3156FlashLender {
     ) external view override returns (uint256) {
         require(
             token == address(this),
-            "FlashMinter: unsupported loan currency"
+            "FlashMinter: Unsupported currency"
         );
         return _flashFee(token, amount);
     }
@@ -350,21 +369,25 @@ contract FlashMinter is ERC20, IERC3156FlashLender {
         address token,
         uint256 amount,
         bytes calldata data
-    ) external override {
+    ) external override returns(bool) {
         require(
             token == address(this),
-            "FlashMinter: unsupported loan currency"
+            "FlashMinter: Unsupported currency"
         );
         uint256 fee = _flashFee(token, amount);
         _mint(address(receiver), amount);
-        receiver.onFlashLoan(msg.sender, token, amount, fee, data);
+        require(
+            receiver.onFlashLoan(msg.sender, token, amount, fee, data),
+            "FlashMinter: Callback failed"
+        );
         uint256 _allowance = allowance(address(receiver), address(this));
         require(
             _allowance >= (amount + fee),
-            "FlashMinter: Flash loan repayment not approved"
+            "FlashMinter: Repay not approved"
         );
         _approve(address(receiver), address(this), _allowance - (amount + fee));
         _burn(address(receiver), amount + fee);
+        return true;
     }
 
     /**
@@ -428,7 +451,7 @@ contract FlashLender is IERC3156FlashLender {
         address token,
         uint256 amount,
         bytes calldata data
-    ) external override {
+    ) external override returns(bool) {
         require(
             supportedTokens[token],
             "FlashLender: Unsupported currency"
@@ -438,11 +461,15 @@ contract FlashLender is IERC3156FlashLender {
             IERC20(token).transfer(address(receiver), amount),
             "FlashLender: Transfer failed"
         );
-        receiver.onFlashLoan(msg.sender, token, amount, fee, data);
+        require(
+            receiver.onFlashLoan(msg.sender, token, amount, fee, data),
+            "FlashLender: Callback failed"
+        );
         require(
             IERC20(token).transferFrom(address(receiver), address(this), amount + fee),
             "FlashLender: Repay failed"
         );
+        return true;
     }
 
     /**
@@ -502,7 +529,11 @@ The arguments of `onFlashLoan` are expected to reflect the conditions of the fla
 ### Flash lending security considerations
 
 #### Automatic approvals for untrusted borrowers
-Including in `onFlashLoan` the approval for the `lender` to take the `amount + fee` needs to be combined with a mechanism to verify that the borrower is trusted, such as those described above. An even safer approach is to implement the approval before the `flashLoan` is executed.    
+The safest approach is to implement an approval for `amount+fee` before the `flashLoan` is executed.    
+
+Including in `onFlashLoan` the approval for the `lender` to take the `amount + fee` needs to be combined with a mechanism to verify that the borrower is trusted, such as those described above.
+
+If an unsuspecting contract with a non-reverting fallback function, or an EOA, would approve a `lender` implementing ERC3156, and not immediately use the approval, and if the `lender` would not verify the return value of `onFlashLoan`, then the unsuspecting contract or EOA could be drained of funds up to their allowance or balance limit. This would be executed by a `borrower` calling `flashLoan` on the victim. The flash loan would be executed and repaid, plus any fees, which would be accumulated by the `lender`. For this reason, it is important that the `lender` implements the specification in full and reverts if `onFlashLoan` doesn't return `true`.
 
 ### Flash minting external security considerations
 


### PR DESCRIPTION
BoringCrypto from SushiSwap revealed a vulnerability in the standard, that we are solving but requiring that `onFlashLoan` returns `true`, and requiring that the `lender` verifies that `true` was returned.

Aave v2 [already does this](https://github.com/aave/protocol-v2/blob/29448c19c1e9b8aa87dccd70b716d15cdf4128f6/contracts/protocol/lendingpool/LendingPool.sol#L507), thankfully.