### PR TITLE
1559: Changes starting base fee to 1 nanoeth and floors base fee at 0.

### DIFF
--- a/EIPS/eip-1559.md
+++ b/EIPS/eip-1559.md
@@ -135,7 +135,7 @@ class Block:
 	extra_data: bytes = bytes()
 	proof_of_work: int = 0
 	nonce: int = 0
-	base_fee_per_gas: int = 0 # default to 0 for blocks before INITIAL_FORK_BLOCK_NUMBER
+	base_fee_per_gas: int = 0 # default to 1,000,000,000 for blocks before INITIAL_FORK_BLOCK_NUMBER
 
 @dataclass
 class Account:
@@ -173,7 +173,7 @@ class World(ABC):
 		else:
 			gas_used_delta = parent_gas_target - parent_gas_used
 			base_fee_per_gas_delta = parent_base_fee_per_gas * gas_used_delta // parent_gas_target // BASE_FEE_MAX_CHANGE_DENOMINATOR
-			expected_base_fee_per_gas = parent_base_fee_per_gas - base_fee_per_gas_delta
+			expected_base_fee_per_gas = max(parent_base_fee_per_gas - base_fee_per_gas_delta, 0)
 		assert expected_base_fee_per_gas == block.base_fee_per_gas, 'invalid block: base fee not correct'
 
 		# execute transactions and do gas accounting


### PR DESCRIPTION
Original spec had the starting base fee (at fork block) as 1 nanoeth, but this was unintentionally lost along the way. I believe current clients have implemented it the original way so this change shouldn't require any client changes.

Also fixed a bug in the spec that allowed the base fee to go negative by just flooring it to 0.