### PR TITLE
Removes Resources section.

### DIFF
--- a/EIPS/eip-1559.md
+++ b/EIPS/eip-1559.md
@@ -302,15 +302,5 @@ Should a miner attempt to execute this attack, we can simply increase the elasti
 ### ETH Burn Precludes Fixed Supply
 By burning the base fee, we can no longer guarantee a fixed token supply.  This could result in economic instabality as the long term supply of ETH will no longer be constant over time.  While a valid concern, it is difficult to quantify how much of an impact this will have.  If more is burned on base fee than is generated in mining rewards then ETH will be deflationary and if more is generated in mining rewards than is burned then ETH will be inflationary.  Since we cannot control user demand for block space, we cannot assert at the moment whether ETH will end up inflationary or deflationary, so this change causes the core developers to lose some control over Ethereum's long term monetary policy.
 
-## Resources
-* [Call notes](https://github.com/ethereum/pm/blob/master/All%20Core%20Devs%20Meetings/Meeting%2077.md)
-* [Original Magicians thread](https://ethereum-magicians.org/t/eip-1559-fee-market-change-for-eth-1-0-chain/2783)
-* [Ethresear.ch Post w/ Vitalik’s Paper](https://ethresear.ch/t/draft-position-paper-on-resource-pricing/2838)
-* [Go-ethereum implementation](https://github.com/vulcanize/go-ethereum-EIP1559)
-* [Implementation-specific Magicians thread](https://ethereum-magicians.org/t/eip-1559-go-etheruem-implementation/3918)
-* [First and second-price auctions and improved transaction-fee markets](https://ethresear.ch/t/first-and-second-price-auctions-and-improved-transaction-fee-markets/2410)
-* [The Challenges of Bitcoin Transaction Fee Estimation](https://blog.bitgo.com/the-challenges-of-bitcoin-transaction-fee-estimation-e47a64a61c72)
-* [On the Instability of Bitcoin Without the Block Reward](http://randomwalker.info/publications/mining_CCS.pdf)
-
 ## Copyright
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
This EIP was originally written quite a while ago, this change just brings it in line with modern EIP editing standards.

EIPs are technical documents, not repositories for general information about a particular change.  Generally speaking, people should not be linking to EIPs directly when talking with the general public.  The time you would link a human to an EIP is when you want to discuss the technical aspects of it or implementation details.  In most other cases (such as governance discussions), a higher level document should be linked to and the EIP should just be a footnote in the references, meant only for implementors and people interested in understanding the EIP at a technical level.

@timbeiko has created this Hack MD document (https://hackmd.io/@timbeiko/1559-resources) that contains a much more maintained collection of resources related to EIP-1559 and generally should be what we are linking people to when we want to give something other than a pure technical document.