### PR TITLE
fix sample implementation, to match description

### DIFF
--- a/EIPS/eip-2771.md
+++ b/EIPS/eip-2771.md
@@ -149,16 +149,16 @@ contract RecipientExample {
         _trustedForwarder = trustedForwarder;
     }
 
-    function isTrustedForwarder(address forwarder) external returns(bool) {
+    function isTrustedForwarder(address forwarder) public returns(bool) {
         return forwarder == _trustedForwarder;
     }
 
     function _msgSender() internal view returns (address payable signer) {
         signer = msg.sender;
-        if (isTrustedForwarder(signer)) {
-            bytes memory data = msg.data;
-            uint256 length = msg.data.length;
-            assembly { signer := mload(add(data, length))) }
+        if (msg.data.length>=20 && isTrustedForwarder(signer)) {
+            assembly {
+                signer := shr(96,calldataload(sub(calldatasize(),20)))
+            }
         }    
     }
 


### PR DESCRIPTION
address is the last 20 bytes of the msg.data, not past the msg.data
also, use a simplified method to avoid copying entire msg.data just to read the last 20 bytes)