### PR TITLE
Initial draft for ERC3234 batch flash loans

### DIFF
--- a/EIPS/eip-3157.md
+++ b/EIPS/eip-3157.md
@@ -1,0 +1,265 @@
+---
+eip: 3157
+title: Batch Flash Loans
+author: Alberto Cuesta Cañada (@albertocuestacanada), Fiona Kobayashi (@fifikobayashi), fubuloubu (@fubuloubu), Austin Williams (@onewayfunction)
+discussions-to: https://ethereum-magicians.org/t/erc-3157-candidate-batch-flash-loans/5260
+status: Draft
+type: Standards Track
+category: ERC
+created: 2021-01-31
+---
+
+## Simple Summary
+
+This ERC provides standard interfaces and processes for flash lenders and borrowers, allowing for flash loan integration without a need to consider each particular implementation. The flash loans covered by this ERC can be composed of multiple assets at once, as opposed to ERC3156 where a single asset is included in each loan.
+
+## Motivation
+
+Flash loans of multiple assets, or batch flash loans, are a common offering of flash lenders, and have a strong use case in the simultaneous refinance of several positions between platforms. At the same time, batch flash loans are more complicated to use than single asset flash loans (ER3156). This divergence of use cases and user profiles calls for independent, but consistent, standards for single asset flash loans and batch flash loans.
+
+
+## Specification
+
+A batch flash lending feature integrates two smart contracts using a callback pattern. These are called the LENDER and the RECEIVER in this EIP.
+
+### Lender Specification
+
+A `lender` MUST implement the IERC3157BatchFlashLender interface.
+```
+pragma solidity ^0.7.0 || ^0.8.0;
+import "./IERC3157BatchFlashBorrower.sol";
+
+
+interface IERC3157BatchFlashLender {
+
+    /**
+     * @dev The amount of currency available to be lended.
+     * @param tokens The currency for each loan in the batch.
+     * @return The maximum amount that can be borrowed for each loan in the batch.
+     */
+    function maxFlashAmount(
+        address[] calldata tokens
+    ) external view returns (uint256[]);
+
+    /**
+     * @dev The fees to be charged for a given batch loan.
+     * @param tokens The loan currencies.
+     * @param amounts The amounts of tokens lent.
+     * @return The amount of each `token` to be charged for each loan, on top of the returned principal.
+     */
+    function flashFee(
+        address[] calldata tokens,
+        uint256[] calldata amounts
+    ) external view returns (uint256[]);
+
+    /**
+     * @dev Initiate a batch flash loan.
+     * @param receiver The receiver of the tokens in the loan, and the receiver of the callback.
+     * @param tokens The loan currencies.
+     * @param amounts The amount of tokens lent.
+     * @param data Arbitrary data structure, intended to contain user-defined parameters.
+     */
+    function flashLoan(
+        IERC3157BatchFlashBorrower receiver,
+        address[] calldata token,
+        uint256[] calldata amount,
+        bytes[] calldata data
+    ) external returns (bool);
+}
+```
+
+The `maxFlashAmount` function MUST return the maximum loan possible for each `token`. If a `token` is not currently supported `maxFlashAmount` MUST return 0, instead of reverting.
+
+The `flashFee` function MUST return the fees charged for each loan of `amount` `token`. If a token is not supported `flashFee` MUST revert.
+
+The `flashLoan` function MUST include a callback to the `onFlashLoan` function in a `IERC3157BatchFlashBorrower` contract.
+
+```
+function flashLoan(
+    IERC3157BatchFlashBorrower receiver,
+    address[] calldata tokens,
+    uint256[] calldata amounts,
+    bytes calldata data
+) external returns (bool) {
+  ...
+  require(
+      receiver.onFlashLoan(msg.sender, tokens, amounts, fees, data),
+      "IERC3157: Callback failed"
+  );
+  ...
+}
+```
+
+The `flashLoan` function MUST transfer `amount` of each `token` to `receiver` before the callback to the borrower.
+
+The `flashLoan` function MUST include `msg.sender` as the `sender` to `onFlashLoan`.
+
+The `flashLoan` function MUST NOT modify the `tokens`, `amounts` and `data` parameters received, and MUST pass them on to `onFlashLoan`.
+
+The `lender` MUST verify that the `onFlashLoan` callback returns the keccak256 hash of "ERC3157BatchFlashBorrower.onFlashLoan".
+
+The `flashLoan` function MUST include a `fees` argument to `onFlashLoan` with the fee to pay for each individual `token` and `amount` lent, ensuring that `fees[i] == flashFee(tokens[i], amounts[i])`.
+
+After the callback, for each `token` in `tokens`, the `batchFlashLoan` function MUST take the `amounts[i] + fees[i]` of `tokens[i]` from the `receiver`, or revert if this is not successful.
+
+If successful, `flashLoan` MUST return `true`.
+
+For all functions above, including both mandatory and optional sections, address(1) is used as a sentinel value for Ether. If the token parameter is address(1) then the function should be processed as defined except using Ether instead of a token.
+
+### Receiver Specification
+
+A `receiver` of flash loans MUST implement the IERC3157FlashBorrower interface:
+
+```
+pragma solidity ^0.7.0 || ^0.8.0;
+
+
+interface IERC3157FlashBorrower {
+
+    /**
+     * @dev Receive a flash loan.
+     * @param sender The initiator of the loan.
+     * @param token The loan currency.
+     * @param amount The amount of tokens lent.
+     * @param fee The additional amount of tokens to repay.
+     * @param data Arbitrary data structure, intended to contain user-defined parameters.
+     * @return The keccak256 hash of "ERC3157BatchFlashBorrower.onFlashLoan"
+     */
+    function onFlashLoan(
+        address sender,
+        address[] calldata tokens,
+        uint256[] calldata amount7,
+        uint256[] calldata fees,
+        bytes calldata data
+    ) external returns (bytes32);
+}
+```
+
+For the transaction to not revert, for each `token` in `tokens`, `receiver` MUST approve `amounts[i] + fees[i]` of `tokens[i]` to be taken by `msg.sender` before the end of `onFlashLoan`.
+
+If successful, `onFlashLoan` MUST return the keccak256 hash of "ERC3156BatchFlashBorrower.onFlashLoan".
+
+The *batch flash loans* extension is OPTIONAL for ERC-3156 smart contracts. This allows flash loans to be composed of several ERC20 tokens.
+```
+
+interface IERC3156BatchFlashBorrower {
+    /**
+     * @dev Receive a batch flash loan.
+     * @param sender The initiator of the loan.
+     * @param tokens The loan currencies.
+     * @param amounts The amounts of tokens lent.
+     * @param fees The additional amount of tokens to repay.
+     * @param data Arbitrary data structure, intended to contain user-defined parameters.
+     * @return The keccak256 hash of "ERC3156BatchFlashBorrower.onBatchFlashLoan"
+     */
+    function onBatchFlashLoan(
+        address sender,
+        address[] calldata tokens,
+        uint256[] calldata amounts,
+        uint256[] calldata fees,
+        bytes calldata data
+    ) external returns (bytes32);
+}
+```
+
+## Rationale
+
+The interfaces described in this ERC have been chosen as to cover the known flash lending use cases, while allowing for safe and gas efficient implementations.
+
+`flashFee` reverts on unsupported tokens, because returning a numerical value would be incorrect.
+
+`flashLoan` has been chosen as a function name as descriptive enough, unlikely to clash with other functions in the lender, and including both the use cases in which the tokens lended are held or minted by the lender.
+
+`receiver` is taken as a parameter to allow flexibility on the implementation of separate loan initiators and receivers.
+
+Existing flash lenders (Aave, dYdX and Uniswap) all provide flash loans of several token types from the same contract (LendingPool, SoloMargin and UniswapV2Pair). Providing a `token` parameter in both the `flashLoan` and `onFlashLoan` functions matches closely the observed functionality.
+
+A `bytes calldata data` parameter is included for the caller to pass arbitrary information to the `receiver`, without impacting the utility of the `flashLoan` standard.
+
+`onFlashLoan` has been chosen as a function name as descriptive enough, unlikely to clash with other functions in the `receiver`, and following the `onAction` naming pattern used as well in EIP-667.
+
+A `sender` will often be required in the `onFlashLoan` function, which the lender knows as `msg.sender`. An alternative implementation which would embed the `sender` in the `data` parameter by the caller would require an additional mechanism for the receiver to verify its accuracy, and is not advisable.
+
+The `amount` will be required in the `onFlashLoan` function, which the lender took as a parameter. An alternative implementation which would embed the `amount` in the `data` parameter by the caller would require an additional mechanism for the receiver to verify its accuracy, and is not advisable.
+
+A `fee` will often be calculated in the `flashLoan` function, which the `receiver` must be aware of for repayment. Passing the `fee` as a parameter instead of appended to `data` is simple and effective.
+
+The `amount + fee` are pulled from the `receiver` to allow the `lender` to implement other features that depend on using `transferFrom`, without having to lock them for the duration of a flash loan. An alternative implementation where the repayment is transferred to the `lender` is also possible, but would need all other features in the lender to be also based in using `transfer` instead of `transferFrom`. Given the lower complexity and prevalence of a "pull" architecture over a "push" architecture, "pull" was chosen.
+
+## Backwards Compatibility
+
+No backwards compatibility issues identified.
+
+## Implementation
+
+### Flash Borrower Reference Implementation
+
+TBA
+
+### Flash Mint Reference Implementation
+
+TBA - Flash mints make less sense as part of a batch flash loan
+
+### Flash Loan Reference Implementation
+
+TBA
+
+## Security Considerations
+
+_Copy from ERC3156, or reference it?_
+
+### Verification of callback arguments
+
+The arguments of `onFlashLoan` are expected to reflect the conditions of the flash loan, but cannot be trusted unconditionally. They can be divided in two groups, that require different checks before they can be trusted to be genuine.
+
+0. No arguments can be assumed to be genuine without some kind of verification. `sender`, `token` and `amount` refer to a past transaction that might not have happened if the caller of `onFlashLoan` decides to lie. `fee` might be false or calculated incorrectly. `data` might have been manipulated by the caller.
+1. To trust that the value of `sender`, `token`, `amount` and `fee` are genuine a reasonable pattern is to verify that the `onFlashLoan` caller is in a whitelist of verified flash lenders. Since often the caller of `flashLoan` will also be receiving the `onFlashLoan` callback this will be trivial. In all other cases flash lenders will need to be approved if the arguments in `onFlashLoan` are to be trusted.
+2. To trust that the value of `data` is genuine, in addition to the check in point 1, it is recommended to implement the `flashLoan` caller to be also the `onFlashLoan` receiver. With this pattern, checking in `onFlashLoan` that `sender` is the current contract is enough to trust that the contents of `data` are genuine.
+
+### Flash lending security considerations
+
+#### Automatic approvals for untrusted borrowers
+The safest approach is to implement an approval for `amount+fee` before the `flashLoan` is executed.    
+
+Including in `onFlashLoan` the approval for the `lender` to take the `amount + fee` needs to be combined with a mechanism to verify that the borrower is trusted, such as those described above.
+
+If an unsuspecting contract with a non-reverting fallback function, or an EOA, would approve a `lender` implementing ERC3156, and not immediately use the approval, and if the `lender` would not verify the return value of `onFlashLoan`, then the unsuspecting contract or EOA could be drained of funds up to their allowance or balance limit. This would be executed by a `borrower` calling `flashLoan` on the victim. The flash loan would be executed and repaid, plus any fees, which would be accumulated by the `lender`. For this reason, it is important that the `lender` implements the specification in full and reverts if `onFlashLoan` doesn't return the keccak256 hash for "ERC3156FlashBorrower.onFlashLoan".
+
+### Flash minting external security considerations
+
+The typical quantum of tokens involved in flash mint transactions will give rise to new innovative attack vectors.
+
+#### Example 1 - interest rate attack
+If there exists a lending protocol that offers stable interests rates, but it does not have floor/ceiling rate limits and it does not rebalance the fixed rate based on flash-induced liquidity changes, then it could be susceptible to the following scenario:
+
+FreeLoanAttack.sol
+1. Flash mint 1 quintillion DAI
+2. Deposit the 1 quintillion DAI + $1.5 million worth of ETH collateral
+3. The quantum of your total deposit now pushes the stable interest rate down to 0.00001% stable interest rate
+4. Borrow 1 million DAI on 0.00001% stable interest rate based on the 1.5M ETH collateral
+5. Withdraw and burn the 1 quint DAI to close the original flash mint
+6. You now have a 1 million DAI loan that is practically interest free for perpetuity ($0.10 / year in interest)
+
+The key takeaway being the obvious need to implement a flat floor/ceiling rate limit and to rebalance the rate based on short term liquidity changes.
+
+#### Example 2 - arithmetic overflow and underflow
+If the flash mint provider does not place any limits on the amount of flash mintable tokens in a transaction, then anyone can flash mint 2^256-1 amount of tokens. 
+
+The protocols on the receiving end of the flash mints will need to ensure their contracts can handle this. One obvious way is to leverage OpenZeppelin's SafeMath libraries as a catch-all safety net, however consideration should be given to when it is or isn't used given the gas tradeoffs.
+
+If you recall there was a series of incidents in 2018 where exchanges such as OKEx, Poloniex, HitBTC and Huobi had to shutdown deposits and withdrawls of ERC20 tokens due to integer overflows within the ERC20 token contracts.
+    
+
+### Flash minting internal security considerations
+    
+The coupling of flash minting with business specific features in the same platform can easily lead to unintended consequences.
+
+#### Example - Treasury draining
+In early implementations of the Yield Protocol flash loaned fyDai could be redeemed for Dai, which could be used to liquidate the Yield Protocol CDP vault in MakerDAO:
+1. Flash mint a very large amount of fyDai.
+2. Redeem for Dai as much fyDai as the Yield Protocol collateral would allow.
+3. Trigger a stability rate increase with a call to `jug.drip` which would make the Yield Protocol uncollateralized.
+4. Liquidate the Yield Protocol CDP vault in MakerDAO.
+
+## Copyright
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/EIPS/eip-3234.md
+++ b/EIPS/eip-3234.md
@@ -1,5 +1,5 @@
 ---
-eip: 3157
+eip: 3234
 title: Batch Flash Loans
 author: Alberto Cuesta Cañada (@albertocuestacanada), Fiona Kobayashi (@fifikobayashi), fubuloubu (@fubuloubu), Austin Williams (@onewayfunction)
 discussions-to: https://ethereum-magicians.org/t/erc-3157-candidate-batch-flash-loans/5260
@@ -11,7 +11,7 @@ created: 2021-01-31
 
 ## Simple Summary
 
-This ERC provides standard interfaces and processes for flash lenders and borrowers, allowing for flash loan integration without a need to consider each particular implementation. The flash loans covered by this ERC can be composed of multiple assets at once, as opposed to ERC3156 where a single asset is included in each loan.
+This ERC provides standard interfaces and processes for multiple-asset flash loans.
 
 ## Motivation
 
@@ -118,7 +118,7 @@ interface IERC3157FlashBorrower {
 
     /**
      * @dev Receive a flash loan.
-     * @param sender The initiator of the loan.
+     * @param initiator The initiator of the loan.
      * @param token The loan currency.
      * @param amount The amount of tokens lent.
      * @param fee The additional amount of tokens to repay.
@@ -126,7 +126,7 @@ interface IERC3157FlashBorrower {
      * @return The keccak256 hash of "ERC3157BatchFlashBorrower.onFlashLoan"
      */
     function onFlashLoan(
-        address sender,
+        address initiator,
         address[] calldata tokens,
         uint256[] calldata amount7,
         uint256[] calldata fees,
@@ -138,29 +138,6 @@ interface IERC3157FlashBorrower {
 For the transaction to not revert, for each `token` in `tokens`, `receiver` MUST approve `amounts[i] + fees[i]` of `tokens[i]` to be taken by `msg.sender` before the end of `onFlashLoan`.
 
 If successful, `onFlashLoan` MUST return the keccak256 hash of "ERC3156BatchFlashBorrower.onFlashLoan".
-
-The *batch flash loans* extension is OPTIONAL for ERC-3156 smart contracts. This allows flash loans to be composed of several ERC20 tokens.
-```
-
-interface IERC3156BatchFlashBorrower {
-    /**
-     * @dev Receive a batch flash loan.
-     * @param sender The initiator of the loan.
-     * @param tokens The loan currencies.
-     * @param amounts The amounts of tokens lent.
-     * @param fees The additional amount of tokens to repay.
-     * @param data Arbitrary data structure, intended to contain user-defined parameters.
-     * @return The keccak256 hash of "ERC3156BatchFlashBorrower.onBatchFlashLoan"
-     */
-    function onBatchFlashLoan(
-        address sender,
-        address[] calldata tokens,
-        uint256[] calldata amounts,
-        uint256[] calldata fees,
-        bytes calldata data
-    ) external returns (bytes32);
-}
-```
 
 ## Rationale
 
@@ -178,7 +155,7 @@ A `bytes calldata data` parameter is included for the caller to pass arbitrary i
 
 `onFlashLoan` has been chosen as a function name as descriptive enough, unlikely to clash with other functions in the `receiver`, and following the `onAction` naming pattern used as well in EIP-667.
 
-A `sender` will often be required in the `onFlashLoan` function, which the lender knows as `msg.sender`. An alternative implementation which would embed the `sender` in the `data` parameter by the caller would require an additional mechanism for the receiver to verify its accuracy, and is not advisable.
+An `initiator` will often be required in the `onFlashLoan` function, which the lender knows as `msg.sender`. An alternative implementation which would embed the `initiator` in the `data` parameter by the caller would require an additional mechanism for the receiver to verify its accuracy, and is not advisable.
 
 The `amount` will be required in the `onFlashLoan` function, which the lender took as a parameter. An alternative implementation which would embed the `amount` in the `data` parameter by the caller would require an additional mechanism for the receiver to verify its accuracy, and is not advisable.
 
@@ -186,35 +163,15 @@ A `fee` will often be calculated in the `flashLoan` function, which the `receive
 
 The `amount + fee` are pulled from the `receiver` to allow the `lender` to implement other features that depend on using `transferFrom`, without having to lock them for the duration of a flash loan. An alternative implementation where the repayment is transferred to the `lender` is also possible, but would need all other features in the lender to be also based in using `transfer` instead of `transferFrom`. Given the lower complexity and prevalence of a "pull" architecture over a "push" architecture, "pull" was chosen.
 
-## Backwards Compatibility
-
-No backwards compatibility issues identified.
-
-## Implementation
-
-### Flash Borrower Reference Implementation
-
-TBA
-
-### Flash Mint Reference Implementation
-
-TBA - Flash mints make less sense as part of a batch flash loan
-
-### Flash Loan Reference Implementation
-
-TBA
-
 ## Security Considerations
-
-_Copy from ERC3156, or reference it?_
 
 ### Verification of callback arguments
 
 The arguments of `onFlashLoan` are expected to reflect the conditions of the flash loan, but cannot be trusted unconditionally. They can be divided in two groups, that require different checks before they can be trusted to be genuine.
 
-0. No arguments can be assumed to be genuine without some kind of verification. `sender`, `token` and `amount` refer to a past transaction that might not have happened if the caller of `onFlashLoan` decides to lie. `fee` might be false or calculated incorrectly. `data` might have been manipulated by the caller.
-1. To trust that the value of `sender`, `token`, `amount` and `fee` are genuine a reasonable pattern is to verify that the `onFlashLoan` caller is in a whitelist of verified flash lenders. Since often the caller of `flashLoan` will also be receiving the `onFlashLoan` callback this will be trivial. In all other cases flash lenders will need to be approved if the arguments in `onFlashLoan` are to be trusted.
-2. To trust that the value of `data` is genuine, in addition to the check in point 1, it is recommended to implement the `flashLoan` caller to be also the `onFlashLoan` receiver. With this pattern, checking in `onFlashLoan` that `sender` is the current contract is enough to trust that the contents of `data` are genuine.
+0. No arguments can be assumed to be genuine without some kind of verification. `initiator`, `tokens` and `amounts` refer to a past transaction that might not have happened if the caller of `onFlashLoan` decides to lie. `fees` might be false or calculated incorrectly. `data` might have been manipulated by the caller.
+1. To trust that the value of `initiator`, `tokens`, `amounts` and `fees` are genuine a reasonable pattern is to verify that the `onFlashLoan` caller is in a whitelist of verified flash lenders. Since often the caller of `flashLoan` will also be receiving the `onFlashLoan` callback this will be trivial. In all other cases flash lenders will need to be approved if the arguments in `onFlashLoan` are to be trusted.
+2. To trust that the value of `data` is genuine, in addition to the check in point 1, it is recommended that the `receiver` verifies that the `initiator` is in some list of trusted addresses. Trusting the `lender` and the `initiator` is enough to trust that the contents of `data` are genuine.
 
 ### Flash lending security considerations
 


### PR DESCRIPTION
I've segregated the batch flash loan functionality from ERC3156, to allow lenders to support single-asset, multiple asset, or both kinds of flash loans.

I've taken the liberty to assign the 3157 number to the Batch Flash Loan ERC, as I think everyone will find it easier to deal with two very similar ERCs if they have consecutive numbers. Apologies if this can't be done.