### PR TITLE
Fixed typos on sentinels, and removed batch flash loans

### DIFF
--- a/EIPS/eip-3156.md
+++ b/EIPS/eip-3156.md
@@ -84,13 +84,13 @@ The `flashLoan` function MUST include a callback to the `onFlashLoan` function i
 ```
 function flashLoan(
     IERC3156FlashBorrower receiver,
-    IERC20 token,
+    address token,
     uint256 amount,
     bytes calldata data
 ) external returns (bool) {
   ...
   require(
-      receiver.onFlashLoan(msg.sender, token, amount, fee, data),
+      receiver.onFlashLoan(msg.sender, token, amount, fee, data) == keccak256("ERC3156FlashBorrower.onFlashLoan"),
       "IERC3156: Callback failed"
   );
   ...
@@ -103,57 +103,13 @@ The `flashLoan` function MUST include `msg.sender` as the `sender` to `onFlashLo
 
 The `flashLoan` function MUST NOT modify the `token`, `amount` and `data` parameter received, and MUST pass them on to `onFlashLoan`.
 
-The `lender` MUST verify that the `onFlashLoan` callback returns `true`.
+The `flashLoan` function MUST include a `fee` argument to `onFlashLoan` with the fee to pay for the loan on top of the principal, ensuring that `fee == flashFee(token, amount)`.
+
+The `lender` MUST verify that the `onFlashLoan` callback returns the keccak256 hash of "ERC3156FlashBorrower.onFlashLoan".
 
 After the callback, the `flashLoan` function MUST take the `amount + fee` `token` from the `receiver`, or revert if this is not successful.
 
 If successful, `flashLoan` MUST return `true`.
-
-The *batch flash loans* extension is OPTIONAL for ERC-3156 smart contracts. This allows flash loans to be composed of several ERC20 tokens.
-
-A `lender` offering batch flash loans MUST implement the IERC3156BatchFlashLender interface.
-```
-interface IERC3156BatchFlashLender is IERC3156FlashLender {
-    function batchFlashLoan(
-        IERC3156BatchFlashBorrower receiver,
-        address[] tokens,
-        uint256[] amounts,
-        bytes calldata data
-    ) external returns (bool);
-}
-```
-
-The `batchFlashLoan` function MUST include a callback to the `onBatchFlashLoan` function in a `IERC3156BatchFlashBorrower` contract.
-
-```
-function batchFlashLoan(
-    IERC3156BatchFlashBorrower receiver,
-    address[] calldata tokens,
-    uint256[] calldata amounts,
-    bytes calldata data
-) external returns (bool){
-  ...
-  require(
-      receiver.onBatchFlashLoan(msg.sender, tokens, amounts, fees, data),
-      "IERC3156: Callback failed"
-  )
-  ...
-}
-```
-
-For each `token` in `tokens`, the `batchFlashLoan` function MUST transfer `amounts[i]` of `tokens[i]` to `receiver` before the callback to the borrower.
-
-The `batchFlashLoan` function MUST include `msg.sender` as the `sender` to `onBatchFlashLoan`.
-
-The `batchFlashLoan` function MUST include a `fees` argument to `onBatchFlashLoan` with the fee to pay for each individual `token` and `amount` lent, ensuring that `fees[i] = flashFee(tokens[i], amounts[i])`.
-
-The `batchFlashLoan` function MUST NOT modify the `tokens`, `amounts` and `data` parameters received, and MUST pass them on to `onBatchFlashLoan`.
-
-The `lender` MUST verify that the `onBatchFlashLoan` callback returns `true`.
-
-After the callback, for each `token` in `tokens`, the `batchFlashLoan` function MUST take the `amounts[i] + fees[i]` of `tokens[i]` from the `receiver`, or revert if this is not successful.
-
-If successful, `batchFlashLoan` MUST return the keccak256 hash of "ERC3156FlashBorrower.onFlashLoan".
 
 For all functions above, including both mandatory and optional sections, address(1) is used as a sentinel value for Ether. If the token parameter is address(1) then the function should be processed as defined except using Ether instead of a token.
 
@@ -188,34 +144,7 @@ interface IERC3156FlashBorrower {
 
 For the transaction to not revert, `receiver` MUST approve `amount + fee` of `token` to be taken by `msg.sender` before the end of `onFlashLoan`.
 
-If successful, `onFlashLoan` MUST return the keccak256 hash of "ERC3156BatchFlashBorrower.onBatchFlashLoan".
-
-The *batch flash loans* extension is OPTIONAL for ERC-3156 smart contracts. This allows flash loans to be composed of several ERC20 tokens.
-```
-
-interface IERC3156BatchFlashBorrower {
-    /**
-     * @dev Receive a batch flash loan.
-     * @param sender The initiator of the loan.
-     * @param tokens The loan currencies.
-     * @param amounts The amounts of tokens lent.
-     * @param fees The additional amount of tokens to repay.
-     * @param data Arbitrary data structure, intended to contain user-defined parameters.
-     * @return The keccak256 hash of "ERC3156BatchFlashBorrower.onBatchFlashLoan"
-     */
-    function onBatchFlashLoan(
-        address sender,
-        address[] calldata tokens,
-        uint256[] calldata amounts,
-        uint256[] calldata fees,
-        bytes calldata data
-    ) external returns (bytes32);
-}
-```
-
-For the transaction to not revert, for each `token` in `tokens`, `receiver` MUST approve `amounts[i] + fees[i]` of `tokens[i]` to be taken by `msg.sender` before the end of `onBatchFlashLoan`.
-
-If successful, `onBatchFlashLoan` MUST return `true`.
+If successful, `onFlashLoan` MUST return the keccak256 hash of "ERC3156FlashBorrower.onFlashLoan".
 
 For all functions above, including both mandatory and optional sections, address(1) is used as a sentinel value for Ether. If the token parameter is address(1) then the function should be processed as defined except using Ether instead of a token.
 


### PR DESCRIPTION
- One instance of `IERC20` used as the type for `token` instead of `address`.
- Missing specification of what the `fee` is.
- Added checks for sentinel value on code excerpts.
- Corrected specification to check for sentinel, and not `true`
- Removed batch flash loan functionality.