### PR TITLE
3085: Add "Chain Already Added" Error

### DIFF
--- a/EIPS/eip-3085.md
+++ b/EIPS/eip-3085.md
@@ -7,7 +7,7 @@ status: Draft
 type: Standards Track
 category: Interface
 created: 2020-11-01
-requires: 155, 695, 3091
+requires: 155, 695, 2696, 3091
 ---
 
 ## Simple Summary
@@ -37,13 +37,9 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 ### `wallet_addEthereumChain`
 
 The method accepts a single object parameter, with a `chainId` and some chain metadata.
-The method returns `null` if the chain was added to the wallet, and an error otherwise.
+The method returns `null` if the requested chain was added to the wallet as a result of the method call, and an error otherwise.
 
-The wallet **MAY** reject the request for any reason.
-The wallet **MUST** reject the request if the `chainId` is improperly formatted.
-The wallet **MUST** reject the request if the wallet does not support the chain with the specified `chainId`.
-
-> Note that this method makes **no** statement about whether the wallet should change the user's currently selected chain, if the wallet has a concept thereof.
+> Note that this specification makes **no** statement about whether the wallet should change the user's currently selected chain upon adding a chain, if the wallet has a concept thereof.
 
 #### Parameters
 
@@ -89,12 +85,33 @@ HTTPS **SHOULD** always be used over HTTP.
 
 #### Returns
 
-The method **MUST** return `null` if the request was successful, and an error otherwise.
+The method **MUST** return `null` if the requested chain was added to the wallet as a result of the method call.
+Otherwise, the method **MUST** return an error.
 
-If a chain with the provided parameters was already added, the request is considered successful, and the method **MUST** return `null`.
+The wallet **MUST** reject the request and cause the method to return an error if:
+
+- Any of the parameters fail to meet the requirements of this specification, as defined in the [Parameters](#parameters) section.
+- The wallet does not support the chain with the specified `chainId`.
 
 The wallet **SHOULD NOT** allow the same `chainId` to be added multiple times.
 See [Security Considerations](#security-considerations) for more information.
+
+#### Errors
+
+Per the pattern established by [EIP-2696](./eip-2696.md), the following error is defined to facilitate the handling of a failure mode specific to `wallet_addEthereumChain`:
+
+- Status code
+  - `4210`
+- Name
+  - Chain Already Added
+- Description
+  - The request is valid, but a chain with the provided chain ID was already added.
+
+The purpose of this error is to alert the caller that, while the request failed, a chain with the provided chain ID was already added to the wallet.
+In other words, the `wallet_addEthereumChain` request was unnecessary.
+
+If the wallet rejects an otherwise valid `wallet_addEthereumChain` request because a chain with the provided chain ID was already added,
+the wallet **MUST** return this error.
 
 ### Examples
 
@@ -174,6 +191,19 @@ A failure response:
 }
 ```
 
+A "chain already added" failure response:
+
+```json
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "error": {
+    "code": 4210,
+    "message": "The requested chain was already added."
+  }
+}
+```
+
 ## Rationale
 
 The design of `wallet_addEthereumChain` is deliberately ignorant of what it means to "add" a chain to a wallet.
@@ -181,14 +211,15 @@ The meaning of "adding" a chain to a wallet depends on the wallet implementation
 Ultimately, neither the user nor the dapp can now whether adding the chain "worked" until they have successfully interacted with it.
 
 When calling the method, specifying the `chainId` will always be necessary, since in the universe of Ethereum chains, the [EIP-155](./eip-155.md) chain ID is effectively the GUID of a chain.
-The remaining parameters amount to what, in the estimation of authors, a wallet will minimally require in order to effectively support a chain and accurately represent it to the user.
+The remaining parameters amount to what, in the estimation of the authors, a wallet will minimally require in order to effectively support a chain and accurately represent it to the user.
 The network ID (per the `net_version` RPC method) was omitted since it is effectively superseded by the chain ID.
 
 For [security reasons](#security-considerations), a wallet should always attempt to validate the chain metadata provided by the dapp, and may choose to fetch the metadata elsewhere entirely.
 Either way, there's no way to know what the wallet will _need_ with respect to the chain metadata.
 Therefore, all parameters except `chainId` are listed as optional, even though a wallet may require them in practice.
 
-This specification does not mandate that the wallet "switches" its active chain, if the result is successful.
+This specification does not mandate that the wallet "switches" its active chain if the request is successful,
+but it does allow it.
 
 For related work, see [EIP-2015](./eip-2015.md).
 


### PR DESCRIPTION
Per recent discussion in #3086, this PR adds a "Chain Already Added" error to EIP-3085. This error is to be returned by the method if the implementer (i.e. wallet) rejects the request because a chain with the provided chain ID was already added. _This is a breaking change in behavior_, since previously the method would return `null` in cases where the chain was already added.

Note that the error follows the precedent set by EIP-1193 / EIP-2696. Therefore, EIP-2696 (the relevant subset of 1193) is added as a dependency.

The PR also includes some minor cleanup / editing.