### PR TITLE
Erc3156: Rename `maxFlashAmount` as `maxFlashLoan`

### DIFF
--- a/EIPS/eip-3156.md
+++ b/EIPS/eip-3156.md
@@ -44,7 +44,7 @@ interface IERC3156FlashLender {
      * @param token The loan currency.
      * @return The amount of `token` that can be borrowed.
      */
-    function maxFlashAmount(
+    function maxFlashLoan(
         address token
     ) external view returns (uint256);
 
@@ -75,7 +75,7 @@ interface IERC3156FlashLender {
 }
 ```
 
-The `maxFlashAmount` function MUST return the maximum loan possible for `token`. If a `token` is not currently supported `maxFlashAmount` MUST return 0, instead of reverting.
+The `maxFlashLoan` function MUST return the maximum loan possible for `token`. If a `token` is not currently supported `maxFlashLoan` MUST return 0, instead of reverting.
 
 The `flashFee` function MUST return the fee charged for a loan of `amount` `token`. If the token is not supported `flashFee` MUST revert.
 
@@ -275,7 +275,7 @@ contract FlashMinter is ERC20, IERC3156FlashLender {
      * @param token The loan currency.
      * @return The amount of `token` that can be borrowed.
      */
-    function maxFlashAmount(
+    function maxFlashLoan(
         address token
     ) external view override returns (uint256) {
         return type(uint256).max - totalSupply();
@@ -449,7 +449,7 @@ contract FlashLender is IERC3156FlashLender {
      * @param token The loan currency.
      * @return The amount of `token` that can be borrowed.
      */
-    function maxFlashAmount(
+    function maxFlashLoan(
         address token
     ) external view override returns (uint256) {
         return supportedTokens[token] ? IERC20(token).balanceOf(address(this)) : 0;


### PR DESCRIPTION
Shorter, easier to remember.