### PR TITLE
ERC-3156: Move to Last Call

### DIFF
--- a/EIPS/eip-3156.md
+++ b/EIPS/eip-3156.md
@@ -3,7 +3,8 @@ eip: 3156
 title: Flash Loans
 author: Alberto Cuesta Cañada (@albertocuestacanada), Fiona Kobayashi (@fifikobayashi), fubuloubu (@fubuloubu), Austin Williams (@onewayfunction)
 discussions-to: https://ethereum-magicians.org/t/erc-3156-flash-loans-review-discussion/5077
-status: Review
+status: Last Call
+review-period-end: 2021-02-16
 type: Standards Track
 category: ERC
 created: 2020-11-15

--- a/EIPS/eip-3156.md
+++ b/EIPS/eip-3156.md
@@ -18,13 +18,13 @@ This ERC provides standard interfaces and processes for single-asset flash loans
 
 Flash loans allow smart contracts to lend an amount of tokens without a requirement for collateral, with the condition that they must be returned within the same transaction.
 
-Early adopters of the flash loan pattern, such as [Aave](https://github.com/aave/aave-protocol/blob/e8d020e9752fbd4807a3b55f9cf98a88dcfb674d/contracts/flashloan), [DxDy](https://help.dydx.exchange/en/articles/3724602-flash-loans), [Uniswap](https://uniswap.org/docs/v2/core-concepts/flash-swaps/) and the [Yield Protocol](https://github.com/yieldprotocol/fyDai/blob/master/contracts/FYDai.sol) have produced different interfaces and different use patterns. The diversification is expected to intensify, and with it the technical debt required to integrate with diverse flash lending patterns.
+Early adopters of the flash loan pattern have produced different interfaces and different use patterns. The diversification is expected to intensify, and with it the technical debt required to integrate with diverse flash lending patterns.
 
 Some of the high level diferences in the approaches across the protocols include:
-- Repayment approaches at the end of the transaction, where Aave V2 pulls the flash lent amount plus the flash fee off the flash smart contract, compared to other protocols where the contract needs to explicitly calculate the debt+fee amount and manually return it to the lending pool.
-- Uniswap's Flash Swaps offer the ability to repay the flash transaction using a token that is different to what was originally flash borrowed, which can reduce the overall complexity of the flash transaction and gas fees, depending on the purpose of the flash swap (i.e. the second last step in flash self liquidation to swap back into the repayment token).
-- DyDx offering a single entry point into the protocol regardless of whether you're buying, selling, depositing or chaining them together as a flash loan, whereas other protocols offer discrete entry points (e.g. Uniswap V2's swap() and Aave V2's flashLoan() methods).
-- The Yield Protocol allows to flash mint any amount of its native token without charging a fee, effectively allowing flash loans bounded by computational constraints instead of asset ownership constraints.
+- Repayment approaches at the end of the transaction, where some pull the principal plus the fee from the loan receiver, and others where the loan receiver needs to manually return the principal and the fee to the lender.
+- Some lenders offer the ability to repay the loan using a token that is different to what was originally borrowed, which can reduce the overall complexity of the flash transaction and gas fees.
+- Some lenders offering a single entry point into the protocol regardless of whether you're buying, selling, depositing or chaining them together as a flash loan, whereas other protocols offer discrete entry points.
+- Some lenders allows to flash mint any amount of their native token without charging a fee, effectively allowing flash loans bounded by computational constraints instead of asset ownership constraints.
 
 ## Specification
 
@@ -159,7 +159,7 @@ The interfaces described in this ERC have been chosen as to cover the known flas
 
 `receiver` is taken as a parameter to allow flexibility on the implementation of separate loan initiators and receivers.
 
-Existing flash lenders (Aave, dYdX and Uniswap) all provide flash loans of several token types from the same contract (LendingPool, SoloMargin and UniswapV2Pair). Providing a `token` parameter in both the `flashLoan` and `onFlashLoan` functions matches closely the observed functionality.
+Existing flash lenders all provide flash loans of several token types from the same contract. Providing a `token` parameter in both the `flashLoan` and `onFlashLoan` functions matches closely the observed functionality.
 
 A `bytes calldata data` parameter is included for the caller to pass arbitrary information to the `receiver`, without impacting the utility of the `flashLoan` standard.
 
@@ -487,33 +487,30 @@ The typical quantum of tokens involved in flash mint transactions will give rise
 If there exists a lending protocol that offers stable interests rates, but it does not have floor/ceiling rate limits and it does not rebalance the fixed rate based on flash-induced liquidity changes, then it could be susceptible to the following scenario:
 
 FreeLoanAttack.sol
-1. Flash mint 1 quintillion DAI
-2. Deposit the 1 quintillion DAI + $1.5 million worth of ETH collateral
+1. Flash mint 1 quintillion STAB
+2. Deposit the 1 quintillion STAB + $1.5 million worth of ETH collateral
 3. The quantum of your total deposit now pushes the stable interest rate down to 0.00001% stable interest rate
-4. Borrow 1 million DAI on 0.00001% stable interest rate based on the 1.5M ETH collateral
-5. Withdraw and burn the 1 quint DAI to close the original flash mint
-6. You now have a 1 million DAI loan that is practically interest free for perpetuity ($0.10 / year in interest)
+4. Borrow 1 million STAB on 0.00001% stable interest rate based on the 1.5M ETH collateral
+5. Withdraw and burn the 1 quint STAB to close the original flash mint
+6. You now have a 1 million STAB loan that is practically interest free for perpetuity ($0.10 / year in interest)
 
 The key takeaway being the obvious need to implement a flat floor/ceiling rate limit and to rebalance the rate based on short term liquidity changes.
 
 #### Example 2 - arithmetic overflow and underflow
 If the flash mint provider does not place any limits on the amount of flash mintable tokens in a transaction, then anyone can flash mint 2^256-1 amount of tokens. 
 
-The protocols on the receiving end of the flash mints will need to ensure their contracts can handle this. One obvious way is to leverage OpenZeppelin's SafeMath libraries as a catch-all safety net, however consideration should be given to when it is or isn't used given the gas tradeoffs.
-
-If you recall there was a series of incidents in 2018 where exchanges such as OKEx, Poloniex, HitBTC and Huobi had to shutdown deposits and withdrawls of ERC20 tokens due to integer overflows within the ERC20 token contracts.
-    
+The protocols on the receiving end of the flash mints will need to ensure their contracts can handle this, either by using a compiler that embeds overflow protection in the smart contract bytecode, or by setting explicit checks.
 
 ### Flash minting internal security considerations
     
 The coupling of flash minting with business specific features in the same platform can easily lead to unintended consequences.
 
 #### Example - Treasury draining
-In early implementations of the Yield Protocol flash lent fyDai could be redeemed for Dai, which could be used to liquidate the Yield Protocol CDP vault in MakerDAO:
-1. Flash mint a very large amount of fyDai.
-2. Redeem for Dai as much fyDai as the Yield Protocol collateral would allow.
-3. Trigger a stability rate increase with a call to `jug.drip` which would make the Yield Protocol uncollateralized.
-4. Liquidate the Yield Protocol CDP vault in MakerDAO.
+Assume a smart contract that flash lends its native token. The same smart contract borrows from a third party when users burn the native token. This pattern would be used to aggregate in the smart contract the collateralized debt of several users into a single account in the third party. The flash mint could be used to cause the lender to borrow to its limit, and then pushing interest rates in the underlying lender, liquidate the flash lender:
+1. Flash mint from `lender` a very large amount of FOO.
+2. Redeem FOO for BAR, causing `lender` to borrow from `underwriter` all the way to its borrowing limit.
+3. Trigger a debt rate increase in `underwriter`, making `lender` undercollateralized.
+4. Liquidate the `lender` for profit.
 
 ## Copyright
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/EIPS/eip-3156.md
+++ b/EIPS/eip-3156.md
@@ -21,7 +21,7 @@ Flash loans allow smart contracts to lend an amount of tokens without a requirem
 Early adopters of the flash loan pattern, such as [Aave](https://github.com/aave/aave-protocol/blob/e8d020e9752fbd4807a3b55f9cf98a88dcfb674d/contracts/flashloan), [DxDy](https://help.dydx.exchange/en/articles/3724602-flash-loans), [Uniswap](https://uniswap.org/docs/v2/core-concepts/flash-swaps/) and the [Yield Protocol](https://github.com/yieldprotocol/fyDai/blob/master/contracts/FYDai.sol) have produced different interfaces and different use patterns. The diversification is expected to intensify, and with it the technical debt required to integrate with diverse flash lending patterns.
 
 Some of the high level diferences in the approaches across the protocols include:
-- Repayment approaches at the end of the transaction, where Aave V2 pulls the flash loaned amount plus the flash fee off the flash smart contract, compared to other protocols where the contract needs to explicitly calculate the debt+fee amount and manually return it to the lending pool.
+- Repayment approaches at the end of the transaction, where Aave V2 pulls the flash lent amount plus the flash fee off the flash smart contract, compared to other protocols where the contract needs to explicitly calculate the debt+fee amount and manually return it to the lending pool.
 - Uniswap's Flash Swaps offer the ability to repay the flash transaction using a token that is different to what was originally flash borrowed, which can reduce the overall complexity of the flash transaction and gas fees, depending on the purpose of the flash swap (i.e. the second last step in flash self liquidation to swap back into the repayment token).
 - DyDx offering a single entry point into the protocol regardless of whether you're buying, selling, depositing or chaining them together as a flash loan, whereas other protocols offer discrete entry points (e.g. Uniswap V2's swap() and Aave V2's flashLoan() methods).
 - The Yield Protocol allows to flash mint any amount of its native token without charging a fee, effectively allowing flash loans bounded by computational constraints instead of asset ownership constraints.
@@ -41,7 +41,7 @@ import "./IERC3156FlashBorrower.sol";
 interface IERC3156FlashLender {
 
     /**
-     * @dev The amount of currency available to be lended.
+     * @dev The amount of currency available to be lent.
      * @param token The loan currency.
      * @return The amount of `token` that can be borrowed.
      */
@@ -155,7 +155,7 @@ The interfaces described in this ERC have been chosen as to cover the known flas
 
 `flashFee` reverts on unsupported tokens, because returning a numerical value would be incorrect.
 
-`flashLoan` has been chosen as a function name as descriptive enough, unlikely to clash with other functions in the lender, and including both the use cases in which the tokens lended are held or minted by the lender.
+`flashLoan` has been chosen as a function name as descriptive enough, unlikely to clash with other functions in the lender, and including both the use cases in which the tokens lent are held or minted by the lender.
 
 `receiver` is taken as a parameter to allow flexibility on the implementation of separate loan initiators and receivers.
 
@@ -272,7 +272,7 @@ contract FlashMinter is ERC20, IERC3156FlashLender {
     }
 
     /**
-     * @dev The amount of currency available to be lended.
+     * @dev The amount of currency available to be lent.
      * @param token The loan currency.
      * @return The amount of `token` that can be borrowed.
      */
@@ -446,7 +446,7 @@ contract FlashLender is IERC3156FlashLender {
     }
 
     /**
-     * @dev The amount of currency available to be lended.
+     * @dev The amount of currency available to be lent.
      * @param token The loan currency.
      * @return The amount of `token` that can be borrowed.
      */
@@ -509,7 +509,7 @@ If you recall there was a series of incidents in 2018 where exchanges such as OK
 The coupling of flash minting with business specific features in the same platform can easily lead to unintended consequences.
 
 #### Example - Treasury draining
-In early implementations of the Yield Protocol flash loaned fyDai could be redeemed for Dai, which could be used to liquidate the Yield Protocol CDP vault in MakerDAO:
+In early implementations of the Yield Protocol flash lent fyDai could be redeemed for Dai, which could be used to liquidate the Yield Protocol CDP vault in MakerDAO:
 1. Flash mint a very large amount of fyDai.
 2. Redeem for Dai as much fyDai as the Yield Protocol collateral would allow.
 3. Trigger a stability rate increase with a call to `jug.drip` which would make the Yield Protocol uncollateralized.


### PR DESCRIPTION
After two months of intense developement and consultation, I'd like to move ERC-3156 to Last Call.

In its development we have discussed it with members of Aave, Uniswap, Sushiswap, Yearn, Yield, DefiSaver, OpenZeppelin, and StakeDAO. It's been discussed on Ethereum Magicians, Twitter, ETHSecurity and FlashF*ck Researchers. The feedback has been very positive.

