### PR TITLE
erc3156: removed sentinel values for ether

### DIFF
--- a/EIPS/eip-3156.md
+++ b/EIPS/eip-3156.md
@@ -112,8 +112,6 @@ After the callback, the `flashLoan` function MUST take the `amount + fee` `token
 
 If successful, `flashLoan` MUST return `true`.
 
-For all functions above, including both mandatory and optional sections, address(1) is used as a sentinel value for Ether. If the token parameter is address(1) then the function should be processed as defined except using Ether instead of a token.
-
 ### Receiver Specification
 
 A `receiver` of flash loans MUST implement the IERC3156FlashBorrower interface:
@@ -146,8 +144,6 @@ interface IERC3156FlashBorrower {
 For the transaction to not revert, `receiver` MUST approve `amount + fee` of `token` to be taken by `msg.sender` before the end of `onFlashLoan`.
 
 If successful, `onFlashLoan` MUST return the keccak256 hash of "ERC3156FlashBorrower.onFlashLoan".
-
-For all functions above, including both mandatory and optional sections, address(1) is used as a sentinel value for Ether. If the token parameter is address(1) then the function should be processed as defined except using Ether instead of a token.
 
 ## Rationale
 


### PR DESCRIPTION
Ether cannot be pulled as when using `transferFrom`, so ERC3156 Ether flash loans are not possible. Therefore, references to sentinel values for Ether have been removed.