### PR TITLE
erc3234: removed sentinel values for Ether

### DIFF
--- a/EIPS/eip-3234.md
+++ b/EIPS/eip-3234.md
@@ -104,8 +104,6 @@ After the callback, for each `token` in `tokens`, the `batchFlashLoan` function 
 
 If successful, `batchFlashLoan` MUST return `true`.
 
-For all functions above, including both mandatory and optional sections, address(1) is used as a sentinel value for Ether. If the token parameter is address(1) then the function should be processed as defined except using Ether instead of a token.
-
 ### Receiver Specification
 
 A `receiver` of flash loans MUST implement the IERC3234FlashBorrower interface:


### PR DESCRIPTION
Ether cannot be pulled as when using transferFrom, so Ether as part of an ERC3234 batch flash loan is not possible. Therefore, references to sentinel values for Ether have been removed.