### PR TITLE
use abi.encode instead of abi.encodePacked in permit (EIP-2612)

### DIFF
--- a/EIPS/eip-2612.md
+++ b/EIPS/eip-2612.md
@@ -68,7 +68,7 @@ if and only if the following conditions are met:
 keccak256(abi.encodePacked(
    hex"1901",
    DOMAIN_SEPARATOR,
-   keccak256(abi.encodePacked(
+   keccak256(abi.encode(
             keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)"),
             owner,
             spender,


### PR DESCRIPTION
As per eip-712, the encodeData function corresponds to abi.encode, not abi.encodePacked in solidity. See:
https://eips.ethereum.org/EIPS/eip-712#definition-of-encodedata.
Existing implementations already conform to this.