### PR TITLE
Make clear that Berlin is tracked in eth1-specs

### DIFF
--- a/EIPS/eip-2070.md
+++ b/EIPS/eip-2070.md
@@ -4,36 +4,25 @@ title: "Hardfork Meta: Berlin"
 author: Alex Beregszaszi (@axic), Tim Beiko (@timbeiko)
 discussions-to: https://ethereum-magicians.org/t/hardfork-meta-eip-2070-berlin-discussion/3561
 type: Meta
-status: Draft
+status: Withdrawn
 created: 2019-05-20
 requires: 1679
 ---
 
 ## Abstract
 
-This meta-EIP specified the changes included in the Ethereum hardfork named Berlin. These changes are now tracked as part of the [eth1.0-specs repositoruy](https://github.com/ethereum/eth1.0-specs/tree/master/network-upgrades). The list of EIPs included in Berlin and current implementation status is specified in [`berlin.md`](https://github.com/ethereum/eth1.0-specs/blob/master/network-upgrades/berlin.md).
+This meta-EIP specified the changes included in the Ethereum hardfork named Berlin. These changes are now tracked as part of the [eth1.0-specs repository](https://github.com/ethereum/eth1.0-specs/tree/master/network-upgrades). The list of EIPs included in Berlin and current implementation status is available at [`berlin.md`](https://github.com/ethereum/eth1.0-specs/blob/master/network-upgrades/berlin.md).
 
-## Specification
+## Specification & Timeline
 
-See [`berlin.md`](https://github.com/ethereum/eth1.0-specs/blob/master/network-upgrades/berlin.md) in the [eth1.0-specs repositoruy](https://github.com/ethereum/eth1.0-specs/tree/master/network-upgrades).
-
-### Included EIPs
-
-See [`berlin.md`](https://github.com/ethereum/eth1.0-specs/blob/master/network-upgrades/berlin.md) in the [eth1.0-specs repositoruy](https://github.com/ethereum/eth1.0-specs/tree/master/network-upgrades).
-
-### Accepted EIPs
-
-See [`berlin.md`](https://github.com/ethereum/eth1.0-specs/blob/master/network-upgrades/berlin.md) in the [eth1.0-specs repositoruy](https://github.com/ethereum/eth1.0-specs/tree/master/network-upgrades).
-
-## Timeline
-
-See [`berlin.md`](https://github.com/ethereum/eth1.0-specs/blob/master/network-upgrades/berlin.md) in the [eth1.0-specs repositoruy](https://github.com/ethereum/eth1.0-specs/tree/master/network-upgrades).
+See [`berlin.md`](https://github.com/ethereum/eth1.0-specs/blob/master/network-upgrades/berlin.md) in the [eth1.0-specs repository](https://github.com/ethereum/eth1.0-specs/tree/master/network-upgrades).
 
 ## References
 
 - Tracking [EFI](https://github.com/orgs/ethereum/projects/5)
 - ACD meeting [notes 90](https://github.com/ethereum/pm/blob/master/All%20Core%20Devs%20Meetings/Meeting%2090.md), [notes 85](https://github.com/ethereum/pm/blob/ee277386af75621c48923f9740e4913ee241cd05/All%20Core%20Devs%20Meetings/Meeting%2085.md)
 - ["The New Ethereum Improvement Process"](https://medium.com/ethereum-cat-herders/the-new-ethereum-improvement-process-928c628b306e)
+- []
 
 ## Copyright
 

--- a/EIPS/eip-2070.md
+++ b/EIPS/eip-2070.md
@@ -9,20 +9,9 @@ created: 2019-05-20
 requires: 1679
 ---
 
-## Abstract
-
-This meta-EIP specified the changes included in the Ethereum hardfork named Berlin. These changes are now tracked as part of the [eth1.0-specs repository](https://github.com/ethereum/eth1.0-specs/tree/master/network-upgrades). The list of EIPs included in Berlin and current implementation status is available at [`berlin.md`](https://github.com/ethereum/eth1.0-specs/blob/master/network-upgrades/berlin.md).
-
-## Specification & Timeline
-
-See [`berlin.md`](https://github.com/ethereum/eth1.0-specs/blob/master/network-upgrades/berlin.md) in the [eth1.0-specs repository](https://github.com/ethereum/eth1.0-specs/tree/master/network-upgrades).
-
-## References
-
-- Tracking [EFI](https://github.com/orgs/ethereum/projects/5)
-- ACD meeting [notes 90](https://github.com/ethereum/pm/blob/master/All%20Core%20Devs%20Meetings/Meeting%2090.md), [notes 85](https://github.com/ethereum/pm/blob/ee277386af75621c48923f9740e4913ee241cd05/All%20Core%20Devs%20Meetings/Meeting%2085.md)
-- ["The New Ethereum Improvement Process"](https://medium.com/ethereum-cat-herders/the-new-ethereum-improvement-process-928c628b306e)
-- []
+This meta-EIP specified the changes included in the Ethereum hardfork named Berlin.
+These changes are now tracked as part of the [eth1.0-specs repository](https://github.com/ethereum/eth1.0-specs/tree/master/network-upgrades).
+The list of EIPs included in Berlin and current implementation status is available at [`berlin.md`](https://github.com/ethereum/eth1.0-specs/blob/master/network-upgrades/berlin.md).
 
 ## Copyright
 

--- a/EIPS/eip-2070.md
+++ b/EIPS/eip-2070.md
@@ -1,7 +1,7 @@
 ---
 eip: 2070
 title: "Hardfork Meta: Berlin"
-author: Alex Beregszaszi (@axic)
+author: Alex Beregszaszi (@axic), Tim Beiko (@timbeiko)
 discussions-to: https://ethereum-magicians.org/t/hardfork-meta-eip-2070-berlin-discussion/3561
 type: Meta
 status: Draft
@@ -11,37 +11,29 @@ requires: 1679
 
 ## Abstract
 
-This meta-EIP specifies the changes included in the Ethereum hardfork named Berlin.
+This meta-EIP specified the changes included in the Ethereum hardfork named Berlin. These changes are now tracked as part of the [eth1.0-specs repositoruy](https://github.com/ethereum/eth1.0-specs/tree/master/network-upgrades). The list of EIPs included in Berlin and current implementation status is specified in [`berlin.md`](https://github.com/ethereum/eth1.0-specs/blob/master/network-upgrades/berlin.md).
 
 ## Specification
 
-- Codename: Berlin
-- Activation: TBD
+See [`berlin.md`](https://github.com/ethereum/eth1.0-specs/blob/master/network-upgrades/berlin.md) in the [eth1.0-specs repositoruy](https://github.com/ethereum/eth1.0-specs/tree/master/network-upgrades).
 
 ### Included EIPs
 
-- TBD
+See [`berlin.md`](https://github.com/ethereum/eth1.0-specs/blob/master/network-upgrades/berlin.md) in the [eth1.0-specs repositoruy](https://github.com/ethereum/eth1.0-specs/tree/master/network-upgrades).
 
 ### Accepted EIPs
 
-- [EIP-2315](./eip-2315.md): Simple Subroutines for the EVM
-- [EIP-2537](./eip-2537.md): BLS12-381 curve operations
-
-### Proposed EIPs
-
-- [EIP-2046](./eip-2046.md): Reduced gas cost for static calls made to precompiles
-- [EIP-2565](./eip-2565.md): Repricing of the EIP-198 ModExp precompile
+See [`berlin.md`](https://github.com/ethereum/eth1.0-specs/blob/master/network-upgrades/berlin.md) in the [eth1.0-specs repositoruy](https://github.com/ethereum/eth1.0-specs/tree/master/network-upgrades).
 
 ## Timeline
 
-(Proposed)
-- Testnets - TBD
-- Mainnet - TBD
+See [`berlin.md`](https://github.com/ethereum/eth1.0-specs/blob/master/network-upgrades/berlin.md) in the [eth1.0-specs repositoruy](https://github.com/ethereum/eth1.0-specs/tree/master/network-upgrades).
 
 ## References
 
 - Tracking [EFI](https://github.com/orgs/ethereum/projects/5)
 - ACD meeting [notes 90](https://github.com/ethereum/pm/blob/master/All%20Core%20Devs%20Meetings/Meeting%2090.md), [notes 85](https://github.com/ethereum/pm/blob/ee277386af75621c48923f9740e4913ee241cd05/All%20Core%20Devs%20Meetings/Meeting%2085.md)
+- ["The New Ethereum Improvement Process"](https://medium.com/ethereum-cat-herders/the-new-ethereum-improvement-process-928c628b306e)
 
 ## Copyright
 


### PR DESCRIPTION
We now track Berlin (and future upgrades)'s spec in the eth1 specs repo, not Meta EIPs. This makes it clear in the Berlin Meta EIP, given this is where people go by default to learn about the upgrade. 