### PR TITLE
Makes signature have type as the first byte.

### DIFF
--- a/EIPS/eip-2930.md
+++ b/EIPS/eip-2930.md
@@ -50,7 +50,7 @@ As of `FORK_BLOCK_NUMBER`, a new [EIP-2718](./eip-2718.md) transaction is introd
 
 The [EIP-2718](./eip-2718.md) `TransactionPayload` for this transaction is `rlp([chainId, nonce, gasPrice, gasLimit, to, value, data, access_list, yParity, senderR, senderS])`.
 
-The `yParity, senderR, senderS` elements of this transaction represent a secp256k1 signature over `keccak256(rlp([1, chainId, nonce, gasPrice, gasLimit, to, value, data, access_list]))`.
+The `yParity, senderR, senderS` elements of this transaction represent a secp256k1 signature over `keccak256(1 || rlp([chainId, nonce, gasPrice, gasLimit, to, value, data, access_list]))`.
 
 The [EIP-2718](./eip-2718.md) `ReceiptPayload` for this transaction is `rlp([status, cumulativeGasUsed, logsBloom, logs])`.
 


### PR DESCRIPTION
This is a security requirement of EIP-2718.