### PR TITLE
2930: Changes 1 to 0x01 for clarity and moved to Review.

### DIFF
--- a/EIPS/eip-2930.md
+++ b/EIPS/eip-2930.md
@@ -3,7 +3,7 @@ eip: 2930
 title: Optional access lists
 author: Vitalik Buterin (@vbuterin), Martin Swende (@holiman)
 discussions-to: https://ethereum-magicians.org/t/eip-2930-optional-access-lists/4561
-status: Draft
+status: Review
 type: Standards Track
 category: Core
 created: 2020-08-29
@@ -16,7 +16,7 @@ Adds a transaction type which contains an access list, a list of addresses and s
 
 ## Abstract
 
-We introduce a new [EIP-2718](./eip-2718.md) transaction type, with the format `1 || rlp([chainId, nonce, gasPrice, gasLimit, to, value, data, access_list, yParity, senderR, senderS])`.
+We introduce a new [EIP-2718](./eip-2718.md) transaction type, with the format `0x01 || rlp([chainId, nonce, gasPrice, gasLimit, to, value, data, access_list, yParity, senderR, senderS])`.
 
 The `access_list` specifies a list of addresses and storage keys; these addresses and storage keys are added into the `accessed_addresses` and `accessed_storage_keys` global sets (introduced in [EIP-2929](./eip-2929.md)). A gas cost is charged, though at a discount relative to the cost of accessing outside the list.
 
@@ -50,7 +50,7 @@ As of `FORK_BLOCK_NUMBER`, a new [EIP-2718](./eip-2718.md) transaction is introd
 
 The [EIP-2718](./eip-2718.md) `TransactionPayload` for this transaction is `rlp([chainId, nonce, gasPrice, gasLimit, to, value, data, access_list, yParity, senderR, senderS])`.
 
-The `yParity, senderR, senderS` elements of this transaction represent a secp256k1 signature over `keccak256(1 || rlp([chainId, nonce, gasPrice, gasLimit, to, value, data, access_list]))`.
+The `yParity, senderR, senderS` elements of this transaction represent a secp256k1 signature over `keccak256(0x01 || rlp([chainId, nonce, gasPrice, gasLimit, to, value, data, access_list]))`.
 
 The [EIP-2718](./eip-2718.md) `ReceiptPayload` for this transaction is `rlp([status, cumulativeGasUsed, logsBloom, logs])`.
 
@@ -123,13 +123,6 @@ This is done to ensure that the transaction cannot be "re-interpreted" as a tran
 ## Backwards Compatibility
 
 This EIP does make it more gas-expensive to perform "unexpected" SLOADs and account accesses. Because gas is prepaid and so does not affect fixed-gas local calls, it does not break contracts in the way that previous gas cost increases would risk. However, it does make applications that heavily rely on storage access much less economically viable.
-
-## Test Cases
-TBD
-
-## Implementation
-
-TBD
 
 ## Security Considerations
 


### PR DESCRIPTION
Also removed empty optional sections while here.  They can be added back if/when tests/implementations are added, but they are otherwise optional.

I also moved this to review, since that is a much more appropriate state for an EIP that is going into a soon-to-be-scheduled hard fork, and there are no major changes planned to this EIP by the authors that I know of.