### PR TITLE
EIP-2930: Make RLP encoding of access_list explicit

### DIFF
--- a/EIPS/eip-2930.md
+++ b/EIPS/eip-2930.md
@@ -54,7 +54,7 @@ The `yParity, senderR, senderS` elements of this transaction represent a secp256
 
 The [EIP-2718](./eip-2718.md) `ReceiptPayload` for this transaction is `rlp([status, cumulativeGasUsed, logsBloom, logs])`.
 
-For the transaction to be valid, `access_list` must be of type `[[{20 bytes}, [{32 bytes}...]]...]`, where `...` means "zero or more of the thing to the left". For example, the following is a valid access list (all hex strings would in reality be in byte representation):
+For the transaction to be valid, `access_list` must be an RLP-encoded list of type `[[{20 bytes}, [{32 bytes}...]]...]`, where `...` means "zero or more of the thing to the left". For example, the following is a valid access list (all hex strings would in reality be in byte representation):
 
 ```
 [


### PR DESCRIPTION
When reviewing EIP-2930 today I briefly misinterpreted the EIP to imply that the access_list should be a binary concatenated list of the values rather than RLP encoded; this is obviously wrong since it's open to ambiguity of inputs, so I figured making the RLP encoding of the access_list field explicit might help others from going down the same wrong path.