### PR TITLE
EIP-1158: ENS resolver function dnsRecord()  is singular

### DIFF
--- a/EIPS/eip-1185.md
+++ b/EIPS/eip-1185.md
@@ -43,9 +43,9 @@ Although it is possible to clear records individually with `setDNSRecords()` as 
 The arguments for the function is as follows:
   - node: the namehash of the fully-qualified domain in ENS for which to clear the records.  Namehashes are defined in #137
 
-### dnsRecords(bytes32 node, bytes32 name, uint16 resource) view returns (bytes)
+### dnsRecord(bytes32 node, bytes32 name, uint16 resource) view returns (bytes)
 
-`dnsRecords()` obtains the DNS records for a given node, name and resource.  It has function signature `0x2461e851`.
+`dnsRecord()` obtains the DNS records for a given node, name and resource.  It has function signature `0xa8fa5682`.
 
 The arguments for the function are as follows:
   - node: the namehash of the fully-qualified domain in ENS for which to set the records.  Namehashes are defined in #137


### PR DESCRIPTION
Fix explained in title. Diff here for quick reference.

Function signature verified using https://piyolab.github.io/playground/ethereum/getEncodedFunctionSignature/ 

Also verified with an actual transaction using `ethers.js` library, example:

This function requests `A` records for `'fuckingfucker.eth'` (sorry, lol) from ENS:

`0xa8fa56827b2df66718e3f65df66e686e6a53bb581a13575ab1390522a0650094df29f19c37a8e5c0817339369eab80d226bbe78f4fedf57edc6d65160174db66b6daad120000000000000000000000000000000000000000000000000000000000000001`

```diff
diff --git a/EIPS/eip-1185.md b/EIPS/eip-1185.md
index 9d8bf26..d47eda9 100644
--- a/EIPS/eip-1185.md
+++ b/EIPS/eip-1185.md
@@ -43,9 +43,9 @@ Although it is possible to clear records individually with `setDNSRecords()` as
 The arguments for the function is as follows:
   - node: the namehash of the fully-qualified domain in ENS for which to clear the records.  Namehashes are defined in #137
 
-### dnsRecords(bytes32 node, bytes32 name, uint16 resource) view returns (bytes)
+### dnsRecord(bytes32 node, bytes32 name, uint16 resource) view returns (bytes)
 
-`dnsRecords()` obtains the DNS records for a given node, name and resource.  It has function signature `0x2461e851`.
+`dnsRecord()` obtains the DNS records for a given node, name and resource.  It has function signature `0xa8fa5682`.
 
 The arguments for the function are as follows:
   - node: the namehash of the fully-qualified domain in ENS for which to set the records.  Namehashes are defined in #137
```