### PR TITLE
ERC-681 back to Review

### DIFF
--- a/EIPS/eip-681.md
+++ b/EIPS/eip-681.md
@@ -4,14 +4,14 @@ title: URL Format for Transaction Requests
 author: Daniel A. Nagy (@nagydani)
 type: Standards Track
 category: ERC
-status: Last Call
-review-period-end: 2021-02-07
+status: Review
+discussions-to: https://ethereum-magicians.org/t/erc-681-representing-various-transactions-as-urls
 created: 2017-08-01
 requires: 20, 137
 ---
 
 ## Simple Summary
-A standard way of representing various transactions, especially payment requests in Ethers and [ERC-20](./eip-20.md) tokens as URLs.
+A standard way of representing various transactions, especially payment requests in ether and [ERC-20](./eip-20.md) tokens as URLs.
 
 ## Abstract
 URLs embedded in QR-codes, hyperlinks in web-pages, emails or chat messages provide for robust cross-application signaling between very loosely coupled applications. A standardized URL format for payment requests allows for instant invocation of the user's preferred wallet application (even if it is a webapp or a swarm đapp), with the correct parameterization of the payment transaction only to be confirmed by the (authenticated) user.


### PR DESCRIPTION
Fixed the spelling of ether as a unit and added a required header linking to the discussion of ERC-681 at FEM's forum.