### PR TITLE
Add header row to support gfm for table formatting

### DIFF
--- a/EIPS/eip-2678.md
+++ b/EIPS/eip-2678.md
@@ -72,6 +72,7 @@ lifecycle.
 The following use cases were considered during the creation of this
 specification.
 
+| | |
 | --- | --- |
 | owned | A package which contains contracts which are not meant to be used by themselves but rather as base contracts to provide functionality to other contracts through inheritance. |
 | transferable | A package which has a single dependency. |
@@ -103,6 +104,7 @@ A [prefixed](#prefixed) hexadecimal value begins with `0x`.
 specified, all hexadecimal values **should** be represented with the
 `0x` prefix.
 
+| | |
 | --- | --- |
 | Prefixed | `0xdeadbeef` |
 | Unprefixed | `deadbeef` |
@@ -135,6 +137,7 @@ The following fields are defined for the package. Custom fields **may**
 be included. Custom fields **should** be prefixed with `x-` to prevent
 name collisions with future versions of the specification.
 
+| | |
 | --- | --- |
 | See Also | Formalized ([JSON-Schema](https://json-schema.org)) version of this specification: [package.spec.json](../assets/eip-2678/package.spec.json) |
 | Jump To | [Definitions](#object-definitions) |
@@ -146,6 +149,7 @@ document conforms to.
 
 -   Packages **must** include this field.
 
+| | |
 | --- | --- |
 | Required | Yes |
 | Key | `manifest` |
@@ -165,6 +169,7 @@ The `name` field defines a human readable name for this package.
 
 -   Package names **must** not exceed 255 characters in length.
 
+| | |
 | --- | --- |
 | Required | If `version` is included. |
 | Key | `name` |
@@ -182,6 +187,7 @@ The `version` field declares the version number of this release.
     [semver](http://semver.org/) version numbering
     specification.
 
+| | |
 | --- | --- |
 | Required | If `name` is included. |
 | Key | `version` |
@@ -195,6 +201,7 @@ or convenient to have on-hand for other reasons.
 
 -   This field **should** be included in all Packages.
 
+| | |
 | --- | --- |
 | Required | No |
 | Key | `meta` |
@@ -206,6 +213,7 @@ The `sources` field defines a source tree that **should** comprise the
 full source tree necessary to recompile the contracts contained in this
 release.
 
+| | |
 | --- | --- |
 | Required | No |
 | Key | `sources` |
@@ -224,6 +232,7 @@ Types](#contract-type) which have been included in this release.
 -   Packages **should not** include abstract contracts in the contract
     types section of a release.
 
+| | |
 | --- | --- |
 | Required | No |
 | Key | `contractTypes` |
@@ -236,6 +245,7 @@ The `compilers` field holds the information about the compilers and
 their settings that have been used to generate the various
 `contractTypes` included in this release.
 
+| | |
 | --- | --- |
 | Required | No |
 | Key | `compilers` |
@@ -251,6 +261,7 @@ by the [BIP122 URI](#bip122-uri) keys for this object **must** be
 unique. There cannot be two different URI keys in a deployments field
 representing the same blockchain.
 
+| | |
 | --- | --- |
 | Required | No |
 | Key | `deployments` |
@@ -262,6 +273,7 @@ representing the same blockchain.
 The `buildDependencies` field defines a key/value mapping of EthPM
 packages that this project depends on.
 
+| | |
 | --- | --- |
 | Required | No |
 | Key | `buildDependencies` |
@@ -290,6 +302,7 @@ Locations are 0-indexed from the beginning of the bytes representation
 of the corresponding bytecode. This field is invalid if it references a
 position that is beyond the end of the bytecode.
 
+| | |
 | --- | --- |
 | Required | Yes |
 | Type | Array |
@@ -300,6 +313,7 @@ The `length` field is an integer which defines the length in bytes of
 the link reference. This field is invalid if the end of the defined link
 reference exceeds the end of the bytecode.
 
+| | |
 | --- | --- |
 | Required | Yes |
 | Type | Integer |
@@ -310,6 +324,7 @@ The `name` field is a string which **must** be a valid
 [Identifier](#identifier). Any link references which **should** be
 linked with the same link value **should** be given the same name.
 
+| | |
 | --- | --- |
 | Required | No |
 | Type | String |
@@ -330,6 +345,7 @@ bytecode where the `value` for this link value was written. These
 locations are 0-indexed from the beginning of the bytes representation
 of the corresponding bytecode.
 
+| | |
 | --- | --- |
 | Required | Yes |
 | Type | Integer |
@@ -350,6 +366,7 @@ following.
 The `type` field defines the `value` type for determining what is
 encoded when [linking](#linking) the corresponding bytecode.
 
+| | |
 | --- | --- |
 | Required | Yes |
 | Type | String |
@@ -359,6 +376,7 @@ encoded when [linking](#linking) the corresponding bytecode.
 
 The `value` field defines the value which should be written when [linking](#linking) the corresponding bytecode.
 
+| | |
 | --- | --- |
 | Required | Yes |
 | Type | String |
@@ -424,6 +442,7 @@ A bytecode object has the following key/value pairs.
 The `bytecode` field is a string containing the `0x` prefixed
 hexadecimal representation of the bytecode.
 
+| | |
 | --- | --- |
 | Required | Yes |
 | Type | String |
@@ -434,6 +453,7 @@ hexadecimal representation of the bytecode.
 The `linkReferences` field defines the locations in the corresponding
 bytecode which require [linking](#linking).
 
+| | |
 | --- | --- |
 | Required | No |
 | Type | Array |
@@ -453,6 +473,7 @@ Intersection is defined as two link references which overlap.
 The `linkDependencies` defines the [Link Values](#link-value) that
 have been used to link the corresponding bytecode.
 
+| | |
 | --- | --- |
 | Required | No |
 | Type | Array |
@@ -483,6 +504,7 @@ pairs.
 The `authors` field defines a list of human readable names for the
 authors of this package. Packages **may** include this field.
 
+| | |
 | --- | --- |
 | Required | No |
 | Key | `authors` |
@@ -498,6 +520,7 @@ Object](#the-source-object) defines its own license, that license takes
 precedence for that particular file over this package-scoped `meta`
 license.
 
+| | |
 | --- | --- |
 | Required | No |
 | Key | `license` |
@@ -508,6 +531,7 @@ license.
 The `description` field provides additional detail that may be relevant
 for the package. Packages **may** include this field.
 
+| | |
 | --- | --- |
 | Required | No |
 | Key | `description` |
@@ -517,6 +541,7 @@ for the package. Packages **may** include this field.
 
 The `keywords` field provides relevant keywords related to this package.
 
+| | |
 | --- | --- |
 | Required | No |
 | Key | `keywords` |
@@ -534,6 +559,7 @@ for the following common resources.
 
 -   `repository`: Location of the project source code.
 
+| | |
 | --- | --- |
 | Required | No |
 | Key | `links` |
@@ -543,6 +569,7 @@ for the following common resources.
 
 A *Sources* object is defined to have the following fields.
 
+| | |
 | --- | --- |
 | Key | A unique identifier for the source file. (String) |
 | Value | [Source Object](#the-source-object) |
@@ -553,6 +580,7 @@ A *Sources* object is defined to have the following fields.
 
 Hash of the source file.
 
+| | |
 | --- | --- |
 | Required | Only **if** the `content` field is missing and none of the provided URLs contain a content hash. |
 | Key | `checksum` |
@@ -573,6 +601,7 @@ Array of urls that resolve to the same source file.
 -   If the resulting document is a file the key **should** be
     interpreted as a file path.
 
+| | |
 | --- | --- |
 | Required | If `content` is not included. |
 | Key | `urls` |
@@ -583,6 +612,7 @@ Array of urls that resolve to the same source file.
 Inlined contract source. If both `urls` and `content` are provided, the `content` value
 **must** match the content of the files identified in `urls`.
 
+| | |
 | --- | --- |
 | Required | If `urls` is not included. |
 | Key | `content` |
@@ -601,6 +631,7 @@ Filesystem path of source file.
 -   **Must not** contain `../` to avoid accessing files outside of 
 	the source folder in improper implementations.
 
+| | |
 | --- | --- |
 | Required | This field **must** be included for the package to be writable to disk. |
 | Key | `installPath` |
@@ -612,6 +643,7 @@ The `type` field declares the type of the source file. The field
 **should** be one of the following values: `solidity`, `vyper`,
 `abi-json`, `solidity-ast-json`.
 
+| | |
 | --- | --- |
 | Required | No |
 | Key | `type` |
@@ -623,6 +655,7 @@ The `license` field declares the type of license associated with
 this source file. When defined, this license overrides the
 package-scoped [meta license](#license).
 
+| | |
 | --- | --- |
 | Required | No |
 | Key | `license` |
@@ -638,6 +671,7 @@ The `algorithm` used to generate the corresponding hash. Possible
 algorithms include, but are not limited to `sha3`, `sha256`, `md5`,
 `keccak256`.
 
+| | |
 | --- | --- |
 | Required | Yes |
 | Type | String |
@@ -647,6 +681,7 @@ algorithms include, but are not limited to `sha3`, `sha256`, `md5`,
 The `hash` of a source files contents generated with the corresponding
 algorithm.
 
+| | |
 | --- | --- |
 | Required | Yes |
 | Type | String |
@@ -662,6 +697,7 @@ The `contractName` field defines the [Contract
 Name](#contract-name) for this [Contract
 Type](#contract-type).
 
+| | |
 | --- | --- |
 | Required | If the [Contract Name](#contract-name) and [Contract Alias](#contract-alias) are not the same. |
 | Type | String |
@@ -672,6 +708,7 @@ Type](#contract-type).
 The global source identifier for the source file from which this
 contract type was generated.
 
+| | |
 | --- | --- |
 | Required | No |
 | Type | String |
@@ -682,6 +719,7 @@ contract type was generated.
 The `deploymentBytecode` field defines the bytecode for this [Contract
 Type](#contract-type).
 
+| | |
 | --- | --- |
 | Required | No |
 | Type | Object |
@@ -693,6 +731,7 @@ The `runtimeBytecode` field defines the unlinked `0x`-prefixed runtime
 portion of [Bytecode](#bytecode) for this [Contract
 Type](#contract-type).
 
+| | |
 | --- | --- |
 | Required | No |
 | Type | Object |
@@ -700,6 +739,7 @@ Type](#contract-type).
 
 #### ABI: `abi`
 
+| | |
 | --- | --- |
 | Required | No |
 | Type | Array |
@@ -707,6 +747,7 @@ Type](#contract-type).
 
 #### UserDoc: `userdoc`
 
+| | |
 | --- | --- |
 | Required | No |
 | Type | Object |
@@ -714,6 +755,7 @@ Type](#contract-type).
 
 #### DevDoc: `devdoc`
 
+| | |
 | --- | --- |
 | Required | No |
 | Type | Object |
@@ -735,6 +777,7 @@ contract types found in any of the package dependencies from the
 `buildDependencies` section of the [Package
 Manifest](#package-manifest).
 
+| | |
 | --- | --- |
 | Required | Yes |
 | Type | String |
@@ -771,6 +814,7 @@ To reference a contract type from a dependency, use the format
 The `address` field defines the [Address](#address) of the
 [Contract Instance](#contract-instance).
 
+| | |
 | --- | --- |
 | Required | Yes |
 | Type | String |
@@ -781,6 +825,7 @@ The `address` field defines the [Address](#address) of the
 The `transaction` field defines the transaction hash in which this
 [Contract Instance](#contract-instance) was created.
 
+| | |
 | --- | --- |
 | Required | No |
 | Type | String |
@@ -791,6 +836,7 @@ The `transaction` field defines the transaction hash in which this
 The `block` field defines the block hash in which this the transaction
 which created this *contract instance* was mined.
 
+| | |
 | --- | --- |
 | Required | No |
 | Type | String |
@@ -804,6 +850,7 @@ value from this field supersedes the `runtimeBytecode` from the
 [Contract Type](#contract-type) for this [Contract
 Instance](#contract-instance).
 
+| | |
 | --- | --- |
 | Required | No |
 | Type | Object |
@@ -825,6 +872,7 @@ key/value pairs.
 
 The `name` field defines which compiler was used in compilation.
 
+| | |
 | --- | --- |
 | Required | Yes |
 | Key | `name` |
@@ -839,6 +887,7 @@ form of either the stable version in
 nightly should be denoted in the form of `<semver>-<commit-hash>` ex:
 `0.4.8-commit.60cc1668`.
 
+| | |
 | --- | --- |
 | Required | Yes |
 | Key | `version` |
@@ -851,6 +900,7 @@ in compilation. For the `"solc"` compiler, this **should** conform to
 the [Compiler Input and Output
 Description](http://solidity.readthedocs.io/en/latest/using-the-compiler.html#compiler-input-and-output-json-description).
 
+| | |
 | --- | --- |
 | Required | No |
 | Key | `settings` |
@@ -867,6 +917,7 @@ that used this compiler to generate its outputs.
 -   A single `contractTypes` **must** not be attributed to more than one
     compiler.
 
+| | |
 | --- | --- |
 | Required | No |
 | Key | `contractTypes` |
@@ -908,6 +959,7 @@ a whole number of bytes, and [prefixed](#prefixed) with `0x`.
 Bytecode can either be linked or unlinked. (see
 [Linking](#linking))
 
+| | |
 | --- | --- |
 | Unlinked Bytecode | The hexadecimal representation of a contract’s EVM instructions that contains sections of code that requires [linking](#linking) for the contract to be functional.<br>The sections of code which are unlinked **must** be filled in with zero bytes.<br>**Example**: `0x606060405260e06000730000000000000000000000000000000000000000634d536f` |
 | Linked Bytecode | The hexadecimal representation of a contract’s EVM instructions which has had all [Link References](#link-reference) replaced with the desired [Link Values](#link-value). **Example**: `0x606060405260e06000736fe36000604051602001526040518160e060020a634d536f` |
@@ -1012,6 +1064,7 @@ A string matching the regular expression
 A location within a contract’s bytecode which needs to be linked. A link
 reference has the following properties.
 
+| | |
 | --- | --- |
 | `offset` | Defines the location within the bytecode where the link reference begins. |
 | `length` | Defines the length of the reference. |
@@ -1038,12 +1091,14 @@ A machine-readable description of a package.
 #### Prefixed  
 [Bytecode](#bytecode) string with leading `0x`.
 
+| | |
 | --- | --- |
 | Example | `0xdeadbeef` |
 
 #### Unprefixed  
 Not [Prefixed](#prefixed).
 
+| | |
 | --- | --- |
 | Example | `deadbeef` |
 


### PR DESCRIPTION
When opening a pull request to submit a new EIP, please use the suggested template: https://github.com/ethereum/EIPs/blob/master/eip-template.md

We have a GitHub bot that automatically merges some PRs. It will merge yours immediately if certain criteria are met:

 - The PR edits only existing draft PRs.
 - The build passes.
 - Your GitHub username or email address is listed in the 'author' header of all affected PRs, inside <triangular brackets>.
 - If matching on email address, the email address is the one publicly listed on your GitHub profile.


Adds an empty header row to tables enable table formatting with github flavored markdown.
