### PR TITLE
3074: Renames TXCALL to IMPERSONATE_CALL

### DIFF
--- a/EIPS/eip-3074.md
+++ b/EIPS/eip-3074.md
@@ -15,7 +15,7 @@ Creates a new EVM instruction, analogous to `CALL` (`0xF1`), that sets `CALLER` 
 
 ## Abstract
 
-This EIP creates an EVM instruction (`TXCALL`) which forwards a `CALL`, setting `CALLER` and `ORIGIN` according to an ECDSA signature.
+This EIP creates an EVM instruction (`IMPERSONATE_CALL`) which forwards a `CALL`, setting `CALLER` and `ORIGIN` according to an ECDSA signature.
 
 ## Motivation
 
@@ -34,12 +34,12 @@ An opcode, at `0xf9`, functions like a `CALL` instruction that additionally:
 
 ### Definitions
 
- - **`TXCALL`** - the specific instruction encoded as `0xf9`, introduced by this EIP, which implements the `CALL` analogue.
- - **Transaction-like Package** - the signed arguments passed to `TXCALL`.
+ - **`IMPERSONATE_CALL`** - the specific instruction encoded as `0xf9`, introduced by this EIP, which implements the `CALL` analogue.
+ - **Transaction-like Package** - the signed arguments passed to `IMPERSONATE_CALL`.
  - **Sponsor** - the account which is responsible for paying gas fees and sending the transaction.
  - **Sponsee** - the account which signed the transaction-like package.
- - **Invoker** - the account or contract which contains `TXCALL`.
- - **Callee** - the target of the call from `TXCALL`.
+ - **Invoker** - the account or contract which contains `IMPERSONATE_CALL`.
+ - **Callee** - the target of the call from `IMPERSONATE_CALL`.
 
 ### Constants
 
@@ -51,7 +51,7 @@ An opcode, at `0xf9`, functions like a `CALL` instruction that additionally:
 
 #### Inputs
 
-`TXCALL` requires the following stack arguments:
+`IMPERSONATE_CALL` requires the following stack arguments:
 
 | `top - 0` | `top - 1` | `top - 2`    | `top - 3`    | `top - 4`   | `top - 5`   |
 | --------- | --------- | ------------ | ------------ | ----------- | ----------- |
@@ -64,7 +64,7 @@ The arguments memory region shall be encoded as `type || abi.encode(sponsee, nex
  - `sponsee: address` - address of the sponsee;
  - `nextra: uint256` - extra data, which can be used in the invoker to implement replay protection;
  - `to: address` - address of the callee;
- - `mingas: uint256` - minimum gas limit which must be provided with the call into `TXCALL`;
+ - `mingas: uint256` - minimum gas limit which must be provided with the call into `IMPERSONATE_CALL`;
  - `valueTotal: uint256` - exact amount of Ether in wei to be received by the callee;
  - `valueSponseeMax: uint256` - maximum amount of Ether in wei that can be deducted from the sponsee's balance;
  - `data: bytes` - the calldata for the call into `to`; and
@@ -74,7 +74,7 @@ The signature (`v`, `r`, `s`) arguments are computed from `secp256k1(keccak256(t
 
 #### Outputs
 
-`TXCALL` pushes the following two values onto the stack:
+`IMPERSONATE_CALL` pushes the following two values onto the stack:
 
 | `top - 0`     | `top - 1`         |
 | ------------- | ----------------- |
@@ -87,7 +87,7 @@ The signature (`v`, `r`, `s`) arguments are computed from `secp256k1(keccak256(t
  - `type != SPONSORED_TYPE`
  - Invalid signature
  - The address recovered from `v`, `r`, and `s` does not match `sponsee`
- - Gas limit supplied with the call into `TXCALL` is less than the signed `mingas`
+ - Gas limit supplied with the call into `IMPERSONATE_CALL` is less than the signed `mingas`
  - The transaction's remaining gas is less than the signed `mingas`
  - The value sent with the call is less than `valueTotal - min(valueSponseeMax, valueTotal)`
  - The value sent with the call is greater than `valueTotal`
@@ -107,7 +107,7 @@ The signature (`v`, `r`, `s`) arguments are computed from `secp256k1(keccak256(t
 
 ### Gas Fees
 
-The gas fees for `TXCALL` are calculated according to the following pseudo-code:
+The gas fees for `IMPERSONATE_CALL` are calculated according to the following pseudo-code:
 
 ```python
 S_cd = len(data)    # In 256-bit words, rounded up
@@ -129,15 +129,15 @@ Where `len(data)` is the length of the region of memory defined by `argsOffset` 
 
 ### Two Return Values
 
-It is important to differentiate between a failure in `TXCALL`'s preconditions versus a failure in the callee. Correctly implementing replay protection requires the invoker to change its state even if the callee fails (to burn the nonce) but doing so if, for example, the signature failed would be nonsensical.
+It is important to differentiate between a failure in `IMPERSONATE_CALL`'s preconditions versus a failure in the callee. Correctly implementing replay protection requires the invoker to change its state even if the callee fails (to burn the nonce) but doing so if, for example, the signature failed would be nonsensical.
 
 ### Sponsee in Arguments
 
-Including `sponsee` in the arguments to `TXCALL` is a gas optimization. Without it, invokers would have to do their own `ecrecover` before calling into `TXCALL` to verify/adjust any state for replay protection.
+Including `sponsee` in the arguments to `IMPERSONATE_CALL` is a gas optimization. Without it, invokers would have to do their own `ecrecover` before calling into `IMPERSONATE_CALL` to verify/adjust any state for replay protection.
 
 ### Sponsoring an Account with Ether
 
-Allowing `TXCALL` to transfer Ether on the sponsee's behalf provides a uniform interface for all transactions a sponsee might want to perform. Sponsees with sufficient Ether might use a sponsor when swapping Ether for an ERC-20 on a subsidized exchange, or when relying on that sponsor to resubmit transactions to optimize gas pricing.
+Allowing `IMPERSONATE_CALL` to transfer Ether on the sponsee's behalf provides a uniform interface for all transactions a sponsee might want to perform. Sponsees with sufficient Ether might use a sponsor when swapping Ether for an ERC-20 on a subsidized exchange, or when relying on that sponsor to resubmit transactions to optimize gas pricing.
 
 ### Reserving an [EIP-2718](./eip-2718.md) Transaction Type
 
@@ -149,9 +149,9 @@ Other approaches to sponsored transactions, which rely on introducing a new tran
 
 Besides better compatibility with AA, an instruction is a much less intrusive change than a new transaction type. This approach requires no changes in existing wallets, and little change in other tooling.
 
-`TXCALL`'s single purpose is to set `CALLER`. It implements the minimal functionality to enable sender abstraction for sponsored transactions. This single mindedness makes `TXCALL` significantly more composable with existing Ethereum features.
+`IMPERSONATE_CALL`'s single purpose is to set `CALLER`. It implements the minimal functionality to enable sender abstraction for sponsored transactions. This single mindedness makes `IMPERSONATE_CALL` significantly more composable with existing Ethereum features.
 
-More logic can be implemented around the call into `TXCALL`, giving more control to invokers and sponsors without sacrificing security or user experience for sponsees.
+More logic can be implemented around the call into `IMPERSONATE_CALL`, giving more control to invokers and sponsors without sacrificing security or user experience for sponsees.
 
 ### Lack of Replay Protection
 
@@ -181,13 +181,13 @@ Properties (1) and (2) no longer hold when `tx.origin == msg.sender`, while prop
 
 It is unlikely, but not impossible, for a contract to only return a value when called by an EOA. It is difficult to imagine uses cases for such behavior, so invalidating property (1) seems to have low impact.
 
-Property (2) would likely have the greatest impact, for two reasons: it creates the opportunity for atomicity where there was none before, and it makes pre- and post-conditions undetectable to the callee. Since the topmost frame is always executed, a contract in that frame can be certain—barring revert and out-of-gas conditions—that it will execute, regardless of the state changes it makes. With `TXCALL`, an invoker could revert the callee if certain post-conditions were not met, allowing a retry at a later time. That said, a miner can break either of these assumptions by, respectively, executing two separate but adjacent transactions, or simply excluding a transaction that doesn't meet the pre- or post-conditions.
+Property (2) would likely have the greatest impact, for two reasons: it creates the opportunity for atomicity where there was none before, and it makes pre- and post-conditions undetectable to the callee. Since the topmost frame is always executed, a contract in that frame can be certain—barring revert and out-of-gas conditions—that it will execute, regardless of the state changes it makes. With `IMPERSONATE_CALL`, an invoker could revert the callee if certain post-conditions were not met, allowing a retry at a later time. That said, a miner can break either of these assumptions by, respectively, executing two separate but adjacent transactions, or simply excluding a transaction that doesn't meet the pre- or post-conditions.
 
 > Only one `tx.origin` can exist in a single transaction.
 
 Reentrancy guards that rely on `tx.origin` cease to function under this proposal.
 
-If setting `ORIGIN` is unacceptable, an alternative is to not set `ORIGIN` and for `TXCALL` to fail if `sponsor == sponsee`.
+If setting `ORIGIN` is unacceptable, an alternative is to not set `ORIGIN` and for `IMPERSONATE_CALL` to fail if `sponsor == sponsee`.
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
TXCALL doesn't really explain what this CALL does beyond the normal call.  IMPERSONATE_CALL is meant to make it clear that this is a call with impersonation of another caller.

Alternative proposal: `CALL_AS`.