### PR TITLE
remove appendix

### DIFF
--- a/EIPS/eip-2315.md
+++ b/EIPS/eip-2315.md
@@ -15,14 +15,12 @@ This proposal introduces three opcodes to support subroutines: `BEGINSUB`, `JUMP
 
 ## Motivation
 
-The EVM does not provide subroutines as a primitive.  Instead, calls can be synthesized by fetching and pushing the current program counter on the data stack and jumping to the subroutine address; returns can be synthesized by contriving to get the return address back to the top of stack and jumping back to it.  Complex calling conventions are then needed to use the same stack for computation and control flow.  Memory allows for simpler conventions but still costs gas.  Eschewing subroutines in user code is the least costly -- but also the most failure-prone.
+The EVM does not provide subroutines as a primitive.  Instead, calls can be synthesized by fetching and pushing the current program counter on the data stack and jumping to the subroutine address; returns can be synthesized by contriving to get the return address back to the top of stack and jumping back to it.  Sometimes omplex calling conventions are then needed to use the same stack for computation and control flow.  Memory allows for simpler conventions but still costs gas.  Eschewing subroutines in user code is the least costly -- but also the most failure-prone.
 
 Over the course of 30 years the computer industry struggled with this complexity and cost
 and settled in on opcodes to directly support subroutines.  These are provided in some form by most all physical and virtual machines going back at least 50 years.
 
 Our design is modeled on the original Forth two-stack machine of 1970.  The data stack is supplemented with a return stack to provide simple support for subroutines, as specified below.
-
-In the Appendix we show example solc output for a simple program that uses over three times as much gas just calling and returning from subroutines as comparable code using these opcodes.  Actual differences in run-time efficiency will of course vary widely.
 
 ## Specification
 
@@ -202,76 +200,5 @@ We suggest the following opcodes:
 
 These changes do introduce new flow control instructions, so any software which does static/dynamic analysis of evm-code
 needs to be modified accordingly. The `JUMPSUB` semantics are similar to `JUMP` (but jumping to a `BEGINSUB`), whereas the `RETURNSUB` instruction is different, since it can 'land' on any opcode (but the possible destinations can be statically inferred).
-
-
-## Appendix: Comparative costs.
-
-```
-contract fun {
-    function test(uint x, uint y) public returns (uint) {
-        return test_mul(2,3);
-    }
-    function test_mul(uint x, uint y) public returns (uint) {
-        return multiply(x,y);
-    }
-    function multiply(uint x, uint y) public returns (uint) {
-        return x * y;
-    }
-}
-
-```
-Here is solc 0.6.3 assembly code with labeled destinations.
-```
-TEST:
-     jumpdest
-     0x00
-     RTN
-     0x02
-     0x03
-     TEST_MUL
-     jump
-TEST_MUL:
-     jumpdest
-     0x00
-     RTN
-     dup4
-     dup4
-     MULTIPLY
-     jump
-RTN:
-     jumpdest
-     swap4
-     swap3
-     pop
-     pop
-     pop
-     jump
-MULTIPLY:   
-     jumpdest
-     mul
-     swap1
-     jump
-```
-solc does a good job with the multiply() function, which is a leaf.  Non-leaf functions are more awkward to get out of.  Calling `fun.test()` will cost _118 gas_, plus 5 for the `mul`.
-
-  This is the same code written using `jumpsub` and `returnsub`.  Calling `fun.test()` will cost _32 gas_  plus 5 for the `mul`.
-```
-TEST:
-     beginsub
-     0x02
-     0x03
-     TEST_MUL
-     jumpsub
-     returnsub
-TEST_MUL:
-     beginsub
-     MULTIPLY
-     jumpsub
-     returnsub
-MULTIPLY:
-     beginsub
-     mul
-     returnsub
-```
 
 **Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).**

--- a/EIPS/eip-2315.md
+++ b/EIPS/eip-2315.md
@@ -15,7 +15,7 @@ This proposal introduces three opcodes to support subroutines: `BEGINSUB`, `JUMP
 
 ## Motivation
 
-The EVM does not provide subroutines as a primitive.  Instead, calls can be synthesized by fetching and pushing the current program counter on the data stack and jumping to the subroutine address; returns can be synthesized by contriving to get the return address back to the top of stack and jumping back to it.  Sometimes omplex calling conventions are then needed to use the same stack for computation and control flow.  Memory allows for simpler conventions but still costs gas.  Eschewing subroutines in user code is the least costly -- but also the most failure-prone.
+The EVM does not provide subroutines as a primitive.  Instead, calls can be synthesized by fetching and pushing the current program counter on the data stack and jumping to the subroutine address; returns can be synthesized by contriving to get the return address back to the top of stack and jumping back to it.  Sometimes complex calling conventions are then needed to use the same stack for computation and control flow.  Memory allows for simpler conventions but still costs gas.  Eschewing subroutines in user code is the least costly -- but also the most failure-prone.
 
 Over the course of 30 years the computer industry struggled with this complexity and cost
 and settled in on opcodes to directly support subroutines.  These are provided in some form by most all physical and virtual machines going back at least 50 years.
@@ -60,7 +60,7 @@ _Note 3: The description above lays out the semantics of this feature in terms o
 
 ## Rationale
 
-This is the is a small change that provides native subroutines without breaking backwards compatibility.
+This is almost the smallest change that provides native subroutines without breaking backwards compatibility.
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
Remove outdated Appendix.  Solidity team has improved code generation, so example is obsolete.