### PR TITLE
1102: Revert discussions-to URL to Ethereum Magicians

### DIFF
--- a/EIPS/eip-1102.md
+++ b/EIPS/eip-1102.md
@@ -2,7 +2,7 @@
 eip: 1102
 title: Opt-in account exposure
 author: Paul Bouchon <mail@bitpshr.net>, Erik Marks (@rekmarks)
-discussions-to: https://github.com/ethereum/EIPs/issues/3257
+discussions-to: https://ethereum-magicians.org/t/eip-1102-opt-in-provider-access/414
 status: Draft
 type: Standards Track
 category: Interface


### PR DESCRIPTION
At the request of the Catherders, we should keep the discussion at Ethereum Magicians. (cc: @poojaranjan :) )