### PR TITLE
3085: Move discussion to Ethereum Magicians

### DIFF
--- a/EIPS/eip-3085.md
+++ b/EIPS/eip-3085.md
@@ -2,7 +2,7 @@
 eip: 3085
 title: Wallet Add Ethereum Chain RPC Method (`wallet_addEthereumChain`)
 author: Erik Marks (@rekmarks), Pedro Gomes (@pedrouid)
-discussions-to: https://github.com/ethereum/EIPs/issues/3086
+discussions-to: https://ethereum-magicians.org/t/eip-3085-wallet-addethereumchain/5469
 status: Draft
 type: Standards Track
 category: Interface


### PR DESCRIPTION
This changes the discussions-to link to Ethereum Magicians instead of #3086.