### PR TITLE
3085: Minor specification change, unrequire EIP-3091, copy edits

### DIFF
--- a/EIPS/eip-3085.md
+++ b/EIPS/eip-3085.md
@@ -222,6 +222,13 @@ Therefore, the wallet should:
 - Observe good web security practices when interacting with the endpoint, such as require HTTPS.
 - Clearly inform the user which RPC URL is being used to communicate with a chain at any given moment, and inform the user of the risks of using multiple RPC endpoints to interact with the same chain.
 
+### Validating Chain Data
+
+A wallet that implements `wallet_addEthereumChain` should expect to encounter requests for chains completely unknown to the wallet maintainers.
+That said, community resources exist that can be leveraged to verify requests for many Ethereum chains.
+The wallet should maintain a list of known chains, and verify requests to add chains against that list.
+Indeed, a wallet may even prefer its own chain metadata over anything submitted with a `wallet_addEthereumChain` request.
+
 ### UX
 
 Adding a new chain to the wallet can have significant implications for the wallet's functionality and the experience of the user.
@@ -233,13 +240,6 @@ In service of these goals, the wallet should:
 - Ensure that any chain metadata, such as `nativeCurrency` and `blockExplorerUrls`, are validated and used to maximum effect in the UI.
 - If any images are provided via `iconUrls`, ensure that the user understands that the icons could misrepresent the actual chain added.
 - If the wallet UI has a concept of a "currently selected" or "currently active" chain, ensure that the user understands when a chain added using `wallet_addEthereumChain` becomes selected.
-
-### Validating Chain Data
-
-A wallet that implements `wallet_addEthereumChain` should expect to encounter requests for chains completely unknown to the wallet maintainers.
-That said, community resources exist that can be leveraged to verify requests for many Ethereum chains.
-The wallet should maintain a list of known chains, and verify requests to add chains against that list.
-Indeed, a wallet may even prefer its own chain metadata over anything submitted with a `wallet_addEthereumChain` request.
 
 ## Copyright
 

--- a/EIPS/eip-3085.md
+++ b/EIPS/eip-3085.md
@@ -16,7 +16,7 @@ An RPC method for adding Ethereum chains to wallet applications.
 
 ## Abstract
 
-The `wallet_addEthereumChain` RPC method allows Ethereum applications ("dapps") to suggest chains to be added to the wallet application.
+The `wallet_addEthereumChain` RPC method allows Ethereum applications ("dapps") to suggest chains to be added to the user's wallet application.
 The caller must specify a chain ID and some chain metadata.
 The wallet application may arbitrarily refuse or accept the request.
 `null` is returned if the chain was added, and an error otherwise.
@@ -25,10 +25,10 @@ Important cautions for implementers of this method are included in the [Security
 
 ## Motivation
 
-A dapp may require the user to interact with multiple Ethereum chains in order to function.
-A may or may not be supported by the user's wallet application.
-`wallet_addEthereumChain` enables dapps to request any necessary chains to be added to the user's wallet.
-This provides UX benefits for dapps and wallets that want to provide such functionality.
+All dapps require the user to interact with one or more Ethereum chains in order to function.
+Any given chain may or may not be supported by the user's wallet application.
+`wallet_addEthereumChain` enables dapps to request chains to be added to the user's wallet.
+This enables UX improvements for both dapps and wallets.
 
 ## Specification
 
@@ -40,8 +40,6 @@ The method accepts a single object parameter, with a `chainId` and some chain me
 The method returns `null` if the chain was added to the wallet, and an error otherwise.
 
 The wallet **MAY** reject the request for any reason.
-The wallet **MUST** reject the request if the `chainId` is improperly formatted.
-The wallet **MUST** reject the request if the wallet does not support the chain with the specified `chainId`.
 
 > Note that this method makes **no** statement about whether the wallet should change the user's currently selected chain, if the wallet has a concept thereof.
 
@@ -65,13 +63,14 @@ interface AddEthereumChainParameter {
 ```
 
 Only the `chainId` is required per this specification, but a wallet **MAY** require any other fields listed, impose additional requirements on them, or ignore them outright.
+If a field does not meet the requirements of this specification and the wallet does not ignore the field, the wallet **MUST** reject the request.
 
 - `chainId`
   - **MUST** specify the integer ID of the chain as a hexadecimal string, per the [`eth_chainId`](./eip-695.md) Ethereum RPC method.
   - The wallet **SHOULD** compare the specified `chainId` value with the `eth_chainId` return value from the endpoint.
     If these values are not identical, the wallet **MUST** reject the request.
 - `blockExplorerUrls`
-  - If provided, **MUST** specify one or more URLs of a block explorer web site for the chain.
+  - If provided, **MUST** specify one or more URLs pointing to block explorer web sites for the chain.
   - The block explorer API routes **SHOULD** be compatible with [EIP-3091](./eip-3091.md).
 - `chainName`
   - If provided, **MUST** specify a human-readable name for the chain.
@@ -82,9 +81,9 @@ Only the `chainId` is required per this specification, but a wallet **MAY** requ
     - `decimals` **MUST** be a non-negative integer.
     - `name` and `symbol` **SHOULD** be human-readable strings.
 - `rpcUrls`
-  - If provided, **MUST** specify one or more URLs of the RPC endpoint used to communicate with the chain.
+  - If provided, **MUST** specify one or more URLs pointing to RPC endpoints that can be used to communicate with the chain.
 
-All URL string fields **MUST** include the protocol component of the URL.
+All URL strings **MUST** include the protocol component of the URL.
 HTTPS **SHOULD** always be used over HTTP.
 
 #### Returns
@@ -178,32 +177,32 @@ A failure response:
 
 The design of `wallet_addEthereumChain` is deliberately ignorant of what it means to "add" a chain to a wallet.
 The meaning of "adding" a chain to a wallet depends on the wallet implementation.
-Ultimately, neither the user nor the dapp can now whether adding the chain "worked" until they have successfully interacted with it.
 
-When calling the method, specifying the `chainId` will always be necessary, since in the universe of Ethereum chains, the [EIP-155](./eip-155.md) chain ID is effectively the GUID of a chain.
-The remaining parameters amount to what, in the estimation of authors, a wallet will minimally require in order to effectively support a chain and accurately represent it to the user.
-The network ID (per the `net_version` RPC method) was omitted since it is effectively superseded by the chain ID.
+When calling the method, specifying the `chainId` will always be necessary, since in the universe of Ethereum chains, the [EIP-155](./eip-155.md) chain ID is effectively the chain GUID.
+The remaining parameters amount to what, in the estimation of the authors, a wallet will minimally require in order to effectively support a chain and represent it to the user.
+The network ID (per the `net_version` RPC method) is omitted since it is effectively superseded by the chain ID.
 
-For [security reasons](#security-considerations), a wallet should always attempt to validate the chain metadata provided by the dapp, and may choose to fetch the metadata elsewhere entirely.
-Either way, there's no way to know what the wallet will _need_ with respect to the chain metadata.
-Therefore, all parameters except `chainId` are listed as optional, even though a wallet may require them in practice.
+For [security reasons](#security-considerations), a wallet should always attempt to validate the chain metadata provided by the requester, and may choose to fetch the metadata elsewhere entirely.
+Either way, only the wallet can know which chain metadata it needs from the requester in order to "add" the chain.
+Therefore, all parameters except `chainId` are specified as optional, even though a wallet may require them in practice.
 
-This specification does not mandate that the wallet "switches" its active chain, if the result is successful.
+This specification does not mandate that the wallet "switches" its "active" or "currently selected" chain after a successful request, if the wallet has a concept thereof.
+Just like the meaning of "adding" a chain, "switching" between chains is a wallet implementation detail, and therefore out of scope.
 
 For related work, see [EIP-2015](./eip-2015.md).
 
 ## Security Considerations
 
 `wallet_addEthereumChain` is a powerful method that exposes the end user to serious risks if implemented incorrectly.
-Most of these risks can be avoided by validating the request data in the wallet, and clearly disambiguating different chains in the wallet UI.
+Many of these risks can be avoided by validating the request data in the wallet, and clearly disambiguating different chains in the wallet UI.
 
 ### Chain IDs
 
-Since the chain ID used for signing determines which chain a transaction is valid for, handling the chain ID correctly is of utmost importance.
+Since the chain ID used for transaction signing determines which chain the transaction is valid for, handling the chain ID correctly is of utmost importance.
 The wallet should:
 
 - Ensure that a submitted chain ID is valid.
-  - It should be submitted as a `0x`-prefixed hexadecimal string per [EIP-695](./eip-695.md), and parse to an integer number.
+  - It should be a `0x`-prefixed hexadecimal string per [EIP-695](./eip-695.md), and parse to an integer number.
 - Prevent the same chain ID from being added multiple times.
   - See the next section for how to handle multiple RPC endpoints.
 - Only use the submitted chain ID to sign transactions, **never** a chain ID received from an RPC endpoint.
@@ -214,23 +213,23 @@ The wallet should:
 
 Wallets generally interact with chains via an RPC endpoint, identified by some URL.
 Most wallets ship with a set of chains and corresponding trusted RPC endpoints.
-The endpoints identified by the `rpcUrls` parameter cannot be assumed to be honest, correct, or ultimately pointing to the same chain.
-Moreover, even trusted endpoints endpoints can expose users to privacy risks depending on their data collection practices.
+The endpoints identified by the `rpcUrls` parameter cannot be assumed to be honest, correct, or even pointing to the same chain.
+Moreover, even trusted endpoints can expose users to privacy risks depending on their data collection practices.
 
 Therefore, the wallet should:
 
-- Inform users that their on-chain activity and IP address will be exposed to the endpoint.
-- If the endpoint is unknown to the wallet, inform users that the endpoint may behave in unexpected ways.
+- Inform users that their on-chain activity and IP address will be exposed to RPC endpoints.
+- If an endpoint is unknown to the wallet, inform users that the endpoint may behave in unexpected ways.
 - Observe good web security practices when interacting with the endpoint, such as require HTTPS.
 - Clearly inform the user which RPC URL is being used to communicate with a chain at any given moment, and inform the user of the risks of using multiple RPC endpoints to interact with the same chain.
 
 ### UX
 
-Adding a new chain to the wallet can have significant implications for the functionality of the wallet and the experience of the user.
+Adding a new chain to the wallet can have significant implications for the wallet's functionality and the experience of the user.
 A chain should never be added without the explicit consent of the user, and different chains should be clearly differentiated in the wallet UI.
 In service of these goals, the wallet should:
 
-- When receiving a `wallet_addEthereumChain` request, display a user confirmation informing the user that a specific dapp has requested that the chain be added.
+- When receiving a `wallet_addEthereumChain` request, display a confirmation informing the user that a specific requester has requested that the chain be added.
   - The confirmation used in [EIP-1102](./eip-1102.md) may serve as a point of reference.
 - Ensure that any chain metadata, such as `nativeCurrency` and `blockExplorerUrls`, are validated and used to maximum effect in the UI.
 - If any images are provided via `iconUrls`, ensure that the user understands that the icons could misrepresent the actual chain added.
@@ -240,8 +239,8 @@ In service of these goals, the wallet should:
 
 A wallet that implements `wallet_addEthereumChain` should expect to encounter requests for chains completely unknown to the wallet maintainers.
 That said, community resources exist that can be leveraged to verify requests for many Ethereum chains.
-The wallet should maintain a list of known chains, and verify requests add chains against that list.
-Indeed, unless there are good reasons not to, the wallet should _prefer its own chain metadata_ over anything submitted with a `wallet_addEthereumChain` request.
+The wallet should maintain a list of known chains, and verify requests to add chains against that list.
+Indeed, a wallet may even prefer its own chain metadata over anything submitted with a `wallet_addEthereumChain` request.
 
 ## Copyright
 

--- a/EIPS/eip-3085.md
+++ b/EIPS/eip-3085.md
@@ -89,7 +89,7 @@ HTTPS **SHOULD** always be used over HTTP.
 
 The method **MUST** return `null` if the request was successful, and an error otherwise.
 
-If a chain with the provided parameters was already added, the request is considered successful, and the method **MUST** return `null`.
+A request for a chain that was already added **SHOULD** be considered successful.
 
 The wallet **SHOULD NOT** allow the same `chainId` to be added multiple times.
 See [Security Considerations](#security-considerations) for more information.
@@ -240,6 +240,12 @@ In service of these goals, the wallet should:
 - Ensure that any chain metadata, such as `nativeCurrency` and `blockExplorerUrls`, are validated and used to maximum effect in the UI.
 - If any images are provided via `iconUrls`, ensure that the user understands that the icons could misrepresent the actual chain added.
 - If the wallet UI has a concept of a "currently selected" or "currently active" chain, ensure that the user understands when a chain added using `wallet_addEthereumChain` becomes selected.
+
+### Preserving User Privacy
+
+Although a request to add a chain that was already added should generally be considered a success, treating such requests as _automatic_ successes leaks information to requesters about the chains a user has added to their wallet.
+In the interest of preserving user privacy, implementers of `wallet_addEthereumChain` should consider displaying user confirmations even in these cases.
+If the user denies the request, the wallet should return the same user rejection error as normal so that requesters cannot learn which chains are supported by the wallet without explicit permission to do so.
 
 ## Copyright
 

--- a/EIPS/eip-3085.md
+++ b/EIPS/eip-3085.md
@@ -7,7 +7,7 @@ status: Draft
 type: Standards Track
 category: Interface
 created: 2020-11-01
-requires: 155, 695, 3091
+requires: 155, 695
 ---
 
 ## Simple Summary
@@ -71,7 +71,6 @@ If a field does not meet the requirements of this specification and the wallet d
     If these values are not identical, the wallet **MUST** reject the request.
 - `blockExplorerUrls`
   - If provided, **MUST** specify one or more URLs pointing to block explorer web sites for the chain.
-  - The block explorer API routes **SHOULD** be compatible with [EIP-3091](./eip-3091.md).
 - `chainName`
   - If provided, **MUST** specify a human-readable name for the chain.
 - `iconUrls`


### PR DESCRIPTION
- Various copy edits / fixes and specification language simplifications
- Unrequire EIP-3091
  - If 3091 becomes standardized, wallets are free to choose to mandate that block explorers are compatible with it, but we shouldn't hold up this EIP on 3091.
- Do **not** mandate that requests for chains that were already added should be treated as successful
  - This amounts to changing a "**MUST**" to a "**SHOULD**".
  - See new subsection of Security Considerations, "Preserving User Privacy", for details. 