### PR TITLE
Unify author header values

### DIFF
--- a/EIPS/eip-196.md
+++ b/EIPS/eip-196.md
@@ -1,7 +1,7 @@
 ---
 eip: 196
 title: Precompiled contracts for addition and scalar multiplication on the elliptic curve alt_bn128
-author: Christian Reitwiessner<chris@ethereum.org>
+author: Christian Reitwiessner <chris@ethereum.org>
 type: Standards Track
 category: Core
 status: Final

--- a/EIPS/eip-2645.md
+++ b/EIPS/eip-2645.md
@@ -1,7 +1,7 @@
 ---
 eip: 2645
 title: Hierarchical Deterministic Wallet for Layer-2
-author: Tom Brand (tom@starkware.co), Louis Guthmann (louis@starkware.co)
+author: Tom Brand <tom@starkware.co>, Louis Guthmann <louis@starkware.co>
 discussions-to: https://ethereum-magicians.org/t/hierarchical-deterministic-wallet-for-computation-integrity-proof-cip-layer-2/4286
 status: Draft
 type: Standards Track

--- a/EIPS/eip-2678.md
+++ b/EIPS/eip-2678.md
@@ -1,7 +1,7 @@
 ---
 eip: 2678
 title: Revised Ethereum Smart Contract Packaging Standard (EthPM v3)
-author: g. nicholas d’andrea (@gnidan), Piper Merriam (@pipermerriam), Nick Gheorghita (@njgheorghita), Christian Reitwiessner(@chriseth), Ben Hauser (@iamdefinitelyahuman), Bryant Eisenbach (@fubuloubu)
+author: g. nicholas d’andrea (@gnidan), Piper Merriam (@pipermerriam), Nick Gheorghita (@njgheorghita), Christian Reitwiessner (@chriseth), Ben Hauser (@iamdefinitelyahuman), Bryant Eisenbach (@fubuloubu)
 discussions-to: https://ethereum-magicians.org/t/ethpm-v3-specification-working-group/4086
 status: Review
 type: Standards Track

--- a/EIPS/eip-2680.md
+++ b/EIPS/eip-2680.md
@@ -1,7 +1,7 @@
 ---
 eip: 2680
 title: Ethereum 2 wallet layout
-author: Jim McDonald (Jim@mcdee.net)
+author: Jim McDonald <Jim@mcdee.net>
 discussions-to: https://ethereum-magicians.org/t/eip-2680-ethereum-2-wallet-layout/4323
 status: Draft
 type: Standards Track

--- a/EIPS/eip-615.md
+++ b/EIPS/eip-615.md
@@ -4,7 +4,7 @@ title: Subroutines and Static Jumps for the EVM
 status: Draft
 type: Standards Track
 category: Core
-author: Greg Colvin <greg@colvin.org>, Brooklyn Zelenka (@expede), Paweł Bylica (@chfast), Christian Reitwiessner(@chriseth)
+author: Greg Colvin <greg@colvin.org>, Brooklyn Zelenka (@expede), Paweł Bylica (@chfast), Christian Reitwiessner (@chriseth)
 discussions-to: https://ethereum-magicians.org/t/eip-615-subroutines-and-static-jumps-for-the-evm-last-call/3472
 created: 2016-12-10
 ---


### PR DESCRIPTION
I am currently extending the DIP-Checker to also check EIPs and will submit a PR soon that adds it as a github action.
So far most things are very clean in here (so the github action will only replace the manual work of checking it for future PRs) - but there have been some inconsistencies in the author header. This PR is fixing them.