### PR TITLE
EIP-1: disallow links to external domains

### DIFF
--- a/EIPS/eip-1.md
+++ b/EIPS/eip-1.md
@@ -207,6 +207,10 @@ EIPs may also have a `superseded-by` header indicating that an EIP has been rend
 
 References to other EIPs should follow the format `EIP-N` where `N` is the EIP number you are referring to.  Each EIP that is referenced in an EIP **MUST** be accompanied by a relative markdown link the first time it is referenced, and **MAY** be accompanied by a link on subsequent references.  The link **MUST** always be done via relative paths so that the links work in this GitHub repository, forks of this repository, the main EIPs site, mirrors of the main EIP site, etc.  For example, you would link to this EIP with `[EIP-1](./eip-1.md)`.
 
+## Linking to outside sources
+
+EIPs **MUST NOT** link to external domains.
+
 ## Auxiliary Files
 
 Images, diagrams and auxiliary files should be included in a subdirectory of the `assets` folder for that EIP as follows: `assets/eip-N` (where **N** is to be replaced with the EIP number). When linking to an image in the EIP, use relative links such as `../assets/eip-1/image.png`.


### PR DESCRIPTION
This PR updates EIP-1 to reflect current policy. 

I think this is a poor policy and should not be implemented for any academic publication such as the EIPs.

Reference: 

- https://github.com/ethereum/EIPs/pull/3302#issuecomment-792164329

---

I protest this "do not link" requirement on two bases:

1. There are currently 345 EIPS listed at https://eips.ethereum.org/all and all 345 of them do link to an external domain
2. I have never seen an academic publication which discourages linking to authoritative sources of information