### PR TITLE
EIP-2315: Simple Subroutines for the EVM

### DIFF
--- a/EIPS/eip-2315.md
+++ b/EIPS/eip-2315.md
@@ -13,17 +13,17 @@ created: 2019-10-17
 
 This proposal introduces three opcodes to support subroutines: `BEGINSUB`, `JUMPSUB` and `RETURNSUB`.
 
-Safety and amenability to static analysis equivalent to EIP-615 can be provided by following a few simple rules, and validated with the provided algorithm.
+Safety and amenability to static analysis equivalent to EIP-615 can be ensured by following a few simple rules, and validated with the provided algorithm.
 
 ## Motivation
 
 The EVM does not provide subroutines as a primitive.  Instead, calls can be synthesized by fetching and pushing the current program counter on the data stack and jumping to the subroutine address; returns can be synthesized by contriving to get the return address back to the top of stack and jumping back to it.  Over the course of 30 years the computer industry struggled with this complexity and cost and settled in on opcodes to directly support subroutines.  These are provided in some form by most all physical and virtual machines going back at least 50 years.
 
-Seeking a simple, proven mechanism, we modeled our design on the [archetypal](http://www.ultratechnology.com/4th_1970.pdf) two-stack [Forth virtual machine](http://www.ultratechnology.com/4th_1970.pdf) of 1970.  The data stack is supplemented with a return stack to provide support for subroutines, as specified below.  The separate return stack ensures that the return address cannot be overwritten, and obviates any need to swap the return address past the arguments on the stack.  It also obviates the need for a dynamic jump to implement subroutine returns, allowing for deprecation of dynamic uses of JUMP and JUMPI.
+Seeking a simple, proven mechanism, we modeled our design on the [archetypal](http://www.ultratechnology.com/4th_1970.pdf) two-stack [Forth virtual machine](http://www.ultratechnology.com/4th_1970.pdf) of 1970 -- the data stack is supplemented with a return stack to provide support jumping into and returning from subroutines, as specified below.  Most other models place the return address on the stack.   The separate return stack ensures that the return address cannot be overwritten and obviates any need to swap the return address past the arguments on the stack.  Also, a dynamic jump is not needed to implement subroutine returns, allowing for deprecation of dynamic uses of JUMP and JUMPI.
 
 ## Specification
 
-We introduce one more stack into the EVM in addition to the existing `data stack` which we call the `return stack`. The `return stack` is limited to `1023` items.
+We introduce one more stack into the EVM in addition to the existing `data stack` which we call the `return stack`. The `return stack` is limited to `1024` items.
 
 #### `BEGINSUB`
 
@@ -99,7 +99,7 @@ We suggest the following opcodes:
 
 These changes do introduce new flow control instructions, so any software which does static/dynamic analysis of evm-code needs to be modified accordingly. The `JUMPSUB` semantics are similar to `JUMP` (but jumping to a `BEGINSUB`), whereas the `RETURNSUB` instruction is different, since it can 'land' on any opcode (but the possible destinations can be statically inferred).
 
-Safety and amenability to static analysis of valid programs is equivalent to EIP-615, with minimal impact on low-level optimizations.  Validity is ensured by the following rules, and programs can be validated with the provided algorithm.
+The safety and amenability to static analysis of valid programs is equivalent to EIP-615, but without imposing syntactic constraints, and thus with minimal impact on low-level optimizations.  Validity is ensured by the following rules, and programs can be validated with the provided algorithm.
 
 ### Validity
 
@@ -112,22 +112,28 @@ _Execution_ is as defined in the [Yellow Paper](https://ethereum.github.io/yello
 4. Invalid jump destination
 5. Invalid instruction
 
-Conditions 3, 4, and 5 cannot occur if the code conforms to following five rules.
+Conditions 3, 4, and 5 cannot occur if the code conforms to following rules.
 
-* `JUMP` and `JUMPI` address only `JUMPDEST` instructions.
-* `JUMPSUB`  addresses only `BEGINSUB` instructions.
-* `JUMP`, `JUMPI` and `JUMPSUB` are always preceded by `PUSH32`.
+* `JUMP` and `JUMPI` address only  valid `JUMPDEST` instructions.
+* `JUMPSUB`  addresses only valid `BEGINSUB` instructions.
 
-We define the `stack depth` as the number of stack elements between the current `SP` and the current `stack base` - `SP` at the most recent `JUMPSUB`.  So we can also check for all stack underflows, some stack overflows, and all invalid control flow:
+Valid instructions are not part of PUSH data.
 
-* `stack depth` is always positive and less than 1024.
+* `JUMP`, `JUMPI` and `JUMPSUB` are always preceded by one of the `PUSH` instructions.
+
+Requiring a `PUSH` before each `JUMP` forbids dynamic jumps.  This restriction could be relaxed with something using Wasm function tables, assume a [place to put the tables](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-3337.md).
+
+The `stack pointer` or `SP` points just past the top item on the `data stack`.  We define the `stack depth` as the number of stack elements between the current `SP` and the current `stack base`.  The `stack base` is the `SP` at the most recent `JUMPSUB or 0`.  So we can check for all stack underflows and some stack overflows.
+
+* The `stack depth` is always positive and at most 1024.
+
+And finally, control flows which return to the same place with a different `stack depth` are invalid.  These can be caused by irreducible control flows like jumping into the flow of loops and subroutines.
+
 * For each instruction in the code the `stack depth` is always the same.
-
-Effectively, each instruction always has enough of, and the same number of stack items available for it to use.  Control flows which return to the same place with a different stack depth are invalid.
 
 ### Validation
 
-The following is a pseudo-go specification of an algorithm for enforcing the above rules conditions.  It proceeds via abstract interpretation of the code, following its control flow and stack use and checking for violations of the rules above.
+The following is a pseudo-go specification of an algorithm for enforcing program validity.  It proceeds via abstract interpretation of the code, following its control flow and stack use and checking for violations of the rules above.  (For simplicity it ignores the issue of JUMPDEST or BEGINSUB bytes in PUSH data.)
 ```
     bytecode []byte
     stack_depth []int
@@ -304,7 +310,8 @@ Consumed gas: `30`
 ## References
 Charles H.Moore, Geoffrey C. Leach. [FORTH - A Language for Interactive Computing](http://www.ultratechnology.com/4th_1970.pdf). 1970
 Philip J. Koopman, Jr. [Stack Computers: the new wave](https://users.ece.cmu.edu/~koopman/stack_computers/index.html). 1989
-Gavin Wood. [Ethereum:  A  Secure  Decentralized Generalized  Transaction  Ledger](https://ethereum.github.io/yellowpaper/paper.pdf). 2021
+Gavin Wood. [Ethereum:  A  Secure  Decentralized Generalized  Transaction  Ledger](https://ethereum.github.io/yellowpaper/paper.pdf). 2015-2021
+Martin Lundfall.  [EIP-2327: BEGINDATA Opcode](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-2327.md). 2019
 Nick Johnson. [EIP-3337: Frame pointer support for memory load and store operations](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-3337.md). 2021
 
 **Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).**

--- a/EIPS/eip-2315.md
+++ b/EIPS/eip-2315.md
@@ -13,7 +13,7 @@ created: 2019-10-17
 
 This proposal introduces three opcodes to support subroutines: `BEGINSUB`, `JUMPSUB` and `RETURNSUB`.
 
-Safety and amenability to static analysis equivalent can be provided by following a few simple rules, and validated with the provided algorithm.
+Safety and amenability to static analysis equivalent to EIP-615 can be provided by following a few simple rules, and validated with the provided algorithm.
 
 ## Motivation
 

--- a/EIPS/eip-2315.md
+++ b/EIPS/eip-2315.md
@@ -99,7 +99,7 @@ We suggest the following opcodes:
 
 These changes do introduce new flow control instructions, so any software which does static/dynamic analysis of evm-code needs to be modified accordingly. The `JUMPSUB` semantics are similar to `JUMP` (but jumping to a `BEGINSUB`), whereas the `RETURNSUB` instruction is different, since it can 'land' on any opcode (but the possible destinations can be statically inferred).
 
-Safety and amenability to static analysis equivalent to EIP-615 is ensured by the following rules, and can be validated with the provided algorithm.
+Safety and amenability to static analysis equivalent to EIP-615 programs, with minimal impact on low-level optimizations.  Validity is ensured by the following rules, and programs can be validated with the provided algorithm.
 
 ### Validity
 
@@ -122,6 +122,8 @@ We define the `stack depth` as the number of stack elements between the current 
 
 * `stack depth` is always positive and less than 1024.
 * For each instruction in the code the `stack depth` is always the same.
+
+Effectively, each instruction always has enough of, and the same number of stack items available for it to use.  Control flows which return to the same place with a different stack depth are invalid.
 
 ### Validation
 
@@ -199,6 +201,7 @@ The following is a pseudo-go specification of an algorithm for enforcing the abo
                 if  !validate(stack[SP]+1))
                     return false
                 SP = prevSP - depth + SP
+                PC = prevPC
                 continue
             }
             if instruction == RETURNSUB

--- a/EIPS/eip-2315.md
+++ b/EIPS/eip-2315.md
@@ -65,7 +65,7 @@ This is almost the smallest change that provides native subroutines without brea
 
 These changes do not affect the semantics of existing EVM code.
 
-These changes are compatible with using [EIP-3337](https://eips.ethereum.org/EIPS/eip-3337) to provide stack frames, by associating a frame with each subroutine.
+These changes are compatible with using [EIP-3337](https://eips.ethereum.org/EIPS/eip-3337.md) to provide stack frames, by associating a frame with each subroutine.
 
 ## Implementations
 
@@ -302,6 +302,6 @@ Consumed gas: `30`
 Charles H.Moore, Geoffrey C. Leach. [FORTH - A Language for Interactive Computing](http://www.ultratechnology.com/4th_1970.pdf). 1970
 Philip J. Koopman, Jr. [Stack Computers: the new wave](https://users.ece.cmu.edu/~koopman/stack_computers/index.html). 1989
 Gavin Wood. [Ethereum:  A  Secure  Decentralized Generalized  Transaction  Ledger](https://ethereum.github.io/yellowpaper/paper.pdf). 2021
-Nick Johnson. [EIP-3337: Frame pointer support for memory load and store operations](https://eips.ethereum.org/EIPS/eip-3337). 2021
+Nick Johnson. [EIP-3337: Frame pointer support for memory load and store operations](https://eips.ethereum.org/EIPS/eip-3337.md). 2021
 
 **Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).**

--- a/EIPS/eip-2315.md
+++ b/EIPS/eip-2315.md
@@ -99,7 +99,7 @@ We suggest the following opcodes:
 
 These changes do introduce new flow control instructions, so any software which does static/dynamic analysis of evm-code needs to be modified accordingly. The `JUMPSUB` semantics are similar to `JUMP` (but jumping to a `BEGINSUB`), whereas the `RETURNSUB` instruction is different, since it can 'land' on any opcode (but the possible destinations can be statically inferred).
 
-Safety and amenability to static analysis equivalent to EIP-615 programs, with minimal impact on low-level optimizations.  Validity is ensured by the following rules, and programs can be validated with the provided algorithm.
+Safety and amenability to static analysis of valid programs is equivalent to EIP-615, with minimal impact on low-level optimizations.  Validity is ensured by the following rules, and programs can be validated with the provided algorithm.
 
 ### Validity
 

--- a/EIPS/eip-2315.md
+++ b/EIPS/eip-2315.md
@@ -101,9 +101,13 @@ These changes do introduce new flow control instructions, so any software which 
 
 The safety and amenability to static analysis of valid programs is equivalent to EIP-615, but without imposing syntactic constraints, and thus with minimal impact on low-level optimizations.  Validity is ensured by the following rules, and programs can be validated with the provided algorithm.
 
+As with EIP-615, contract code must be validated at deploy time for contracts created by external transactions.  Internal calls must not be validated, as they may be from older contracts generating older, unsafe code.  Unlike EIP-615, backwards compatibility means that no versioning is needed.
+
+However, as soon these rules are enforced Solidity and other compilers that generate dynamic jumps will be broken.  Therefore, in the initial upgrade there should not be any deploy-time validation.  A future upgrade can start enforcing the rules once compilers and tools are ready.
+
 ### Validity
 
-We would like to consider EVM code valid iff no execution of the program can lead to an exceptional halting state, but we must validate code in linear time.  (More precisely, in `O(edges + vertices) in the control-flow graph.) So our validation algorithm does not consider the code’s data and computations, only its control flow and stack use.  This means we will reject programs with invalid code paths, even if those paths are not reachable. 
+We would like to consider EVM code valid iff no execution of the program can lead to an exceptional halting state, but we must validate code in linear time.  (More precisely, in `O(vertices + edges) in the control-flow graph.) So our validation algorithm does not consider the code’s data and computations, only its control flow and stack use.  This means we will reject programs with invalid code paths, even if those paths are not reachable. 
 
 _Execution_ is as defined in the [Yellow Paper](https://ethereum.github.io/yellowpaper/paper.pdf)—a sequence of changes in the EVM state.  The conditions on valid code are preserved by state changes.  At runtime, if execution of an instruction would violate a condition the execution is in an exceptional halting state.  The Yellow Paper defines five such states.
 1. Insufficient gas
@@ -121,13 +125,13 @@ Valid instructions are not part of PUSH data.
 
 * `JUMP`, `JUMPI` and `JUMPSUB` are always preceded by one of the `PUSH` instructions.
 
-Requiring a `PUSH` before each `JUMP` forbids dynamic jumps.  This restriction could be relaxed with something using Wasm function tables, assume a [place to put the tables](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-3337.md).
+Requiring a `PUSH` before each `JUMP` forbids dynamic jumps.  This restriction could be relaxed with something like Wasm function tables, assuming we a [place to put the tables](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-3337.md).
 
-The `stack pointer` or `SP` points just past the top item on the `data stack`.  We define the `stack depth` as the number of stack elements between the current `SP` and the current `stack base`.  The `stack base` is the `SP` at the most recent `JUMPSUB or 0`.  So we can check for all stack underflows and some stack overflows.
+The `stack pointer` or `SP` points just past the top item on the `data stack`.  We define the `stack depth` as the number of stack elements between the current `SP` and the current `stack base`.  The `stack base` is the `SP` at the most recent `JUMPSUB` or `0`.  So we can check for all stack underflows and some stack overflows.
 
 * The `stack depth` is always positive and at most 1024.
 
-And finally, control flows which return to the same place with a different `stack depth` are invalid.  These can be caused by irreducible control flows like jumping into the flow of loops and subroutines.
+And finally, control flows which return to the same place with a different `stack depth` are invalid.  These can be caused by irreducible paths like jumping into loops and subroutines.
 
 * For each instruction in the code the `stack depth` is always the same.
 
@@ -314,4 +318,5 @@ Gavin Wood. [Ethereum:  A  Secure  Decentralized Generalized  Transaction  Ledge
 Martin Lundfall.  [EIP-2327: BEGINDATA Opcode](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-2327.md). 2019
 Nick Johnson. [EIP-3337: Frame pointer support for memory load and store operations](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-3337.md). 2021
 
-**Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).**
+## Copyright
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/EIPS/eip-2315.md
+++ b/EIPS/eip-2315.md
@@ -1,7 +1,7 @@
 ---
 eip: 2315
 title: Simple Subroutines for the EVM
-status: Draft
+status: Withdrawn 
 type: Standards Track
 category: Core
 author: Greg Colvin <greg@colvin.org>, Martin Holst Swende (@holiman)

--- a/EIPS/eip-2315.md
+++ b/EIPS/eip-2315.md
@@ -1,7 +1,7 @@
 ---
 eip: 2315
 title: Simple Subroutines for the EVM
-status: Withdrawn 
+status: Draft
 type: Standards Track
 category: Core
 author: Greg Colvin <greg@colvin.org>, Martin Holst Swende (@holiman)
@@ -13,14 +13,13 @@ created: 2019-10-17
 
 This proposal introduces three opcodes to support subroutines: `BEGINSUB`, `JUMPSUB` and `RETURNSUB`.
 
+Safety and amenability to static analysis equivalent can be provided by following a few simple rules, and validated with the provided algorithm.
+
 ## Motivation
 
-The EVM does not provide subroutines as a primitive.  Instead, calls can be synthesized by fetching and pushing the current program counter on the data stack and jumping to the subroutine address; returns can be synthesized by contriving to get the return address back to the top of stack and jumping back to it.  Sometimes complex calling conventions are then needed to use the same stack for computation and control flow.  Memory allows for simpler conventions but still costs gas.  Eschewing subroutines in user code is the least costly -- but also the most failure-prone.
+The EVM does not provide subroutines as a primitive.  Instead, calls can be synthesized by fetching and pushing the current program counter on the data stack and jumping to the subroutine address; returns can be synthesized by contriving to get the return address back to the top of stack and jumping back to it.  Over the course of 30 years the computer industry struggled with this complexity and cost and settled in on opcodes to directly support subroutines.  These are provided in some form by most all physical and virtual machines going back at least 50 years.
 
-Over the course of 30 years the computer industry struggled with this complexity and cost
-and settled in on opcodes to directly support subroutines.  These are provided in some form by most all physical and virtual machines going back at least 50 years.
-
-Our design is modeled on the original Forth two-stack machine of 1970.  The data stack is supplemented with a return stack to provide simple support for subroutines, as specified below.
+Seeking a simple, proven mechanism, we modeled our design on the [archetypal](http://www.ultratechnology.com/4th_1970.pdf) two-stack [Forth virtual machine](http://www.ultratechnology.com/4th_1970.pdf) of 1970.  The data stack is supplemented with a return stack to provide support for subroutines, as specified below.  The separate return stack ensures that the return address cannot be overwritten, and obviates any need to swap the return address past the arguments on the stack.  It also obviates the need for a dynamic jump to implement subroutine returns, allowing for deprecation of dynamic uses of JUMP and JUMPI.
 
 ## Specification
 
@@ -28,7 +27,7 @@ We introduce one more stack into the EVM in addition to the existing `data stack
 
 #### `BEGINSUB`
 
-Marks the entry point to a subroutine.  Attempted execution of a `BEGINSUB` causes an _`abort`_:  terminate execution with an `OOG` (Out Of Gas) exception.
+Marks the entry point to a subroutine.  Attempted execution of a `BEGINSUB` is  a no-op.
 
 #### `JUMPSUB`
 
@@ -36,7 +35,7 @@ Transfers control to a subroutine.
 
 1. Pop the `location` off the `data stack`.
 2. If the opcode at `location` is not a `BEGINSUB` _`abort`_.
-3. If the `return stack` already has `1023` items _`abort`_.
+3. If the `return stack` already has `1024` items _`abort`_.
 4. Push the current `pc + 1` to the `return stack`.
 5. Set `pc` to `location + 1`.
 
@@ -62,11 +61,160 @@ _Note 3: The description above lays out the semantics of this feature in terms o
 
 This is almost the smallest change that provides native subroutines without breaking backwards compatibility.
 
-## Backwards Compatibility
+## Backwards and Forwards Compatibility
 
 These changes do not affect the semantics of existing EVM code.
 
-# Test Cases
+These changes are compatible with using [EIP-3337](https://eips.ethereum.org/EIPS/eip-3337) to provide stack frames, by associating a frame with each subroutine.
+
+## Implementations
+
+Three clients have implemented this (or an earlier version of) this proposal:
+
+- [geth](https://github.com/ethereum/go-ethereum/pull/20619) .
+- [besu](https://github.com/hyperledger/besu/pull/717), and
+- [openethereum](https://github.com/openethereum/openethereum/pull/11629).
+
+### Costs and Codes
+
+We suggest that the cost of 
+
+- `BEGINSUB` be _base_ (`2`)
+  - Although formally specified, the cost of `BEGINSUB` does not matter in practice, since `BEGINSUB` never executes without error. 
+- `JUMPSUB` be _high_ (`10`)
+  - This is the same as `JUMPI`, and `2` more than `JUMP`.
+- `RETURNSUB` be _low_ (`5`).
+
+Benchmarking might be needed to tell if the costs are well-balanced. 
+
+We suggest the following opcodes:
+
+```
+0x5c BEGINSUB
+0x5d RETURNSUB
+0x5e JUMPSUB
+```
+
+## Security Considerations
+
+These changes do introduce new flow control instructions, so any software which does static/dynamic analysis of evm-code needs to be modified accordingly. The `JUMPSUB` semantics are similar to `JUMP` (but jumping to a `BEGINSUB`), whereas the `RETURNSUB` instruction is different, since it can 'land' on any opcode (but the possible destinations can be statically inferred).
+
+Safety and amenability to static analysis equivalent to EIP-615 is ensured by the following rules, and can be validated with the provided algorithm.
+
+### Validity
+
+We would like to consider EVM code valid iff no execution of the program can lead to an exceptional halting state, but we must validate code in linear time.  (More precisely, in `O(edges + vertices) in the control-flow graph.) So our validation algorithm does not consider the code’s data and computations, only its control flow and stack use.  This means we will reject programs with invalid code paths, even if those paths are not reachable. 
+
+_Execution_ is as defined in the [Yellow Paper](https://ethereum.github.io/yellowpaper/paper.pdf)—a sequence of changes in the EVM state.  The conditions on valid code are preserved by state changes.  At runtime, if execution of an instruction would violate a condition the execution is in an exceptional halting state.  The Yellow Paper defines five such states.
+1. Insufficient gas
+2. More than 1024 stack items
+3. Insufficient stack items
+4. Invalid jump destination
+5. Invalid instruction
+
+Conditions 3, 4, and 5 cannot occur if the code conforms to following five rules.
+
+* `JUMP` and `JUMPI` address only `JUMPDEST` instructions.
+* `JUMPSUB`  addresses only `BEGINSUB` instructions.
+* `JUMP`, `JUMPI` and `JUMPSUB` are always preceded by `PUSH32`.
+
+We define the `stack depth` as the number of stack elements between the current `SP` and the current `stack base` - `SP` at the most recent `JUMPSUB`.  So we can also check for all stack underflows, some stack overflows, and all invalid control flow:
+
+* `stack depth` is always positive and less than 1024.
+* For each instruction in the code the `stack depth` is always the same.
+
+### Validation
+
+The following is a pseudo-go specification of an algorithm for enforcing the above rules conditions.  It proceeds via abstract interpretation of the code, following its control flow and stack use and checking for violations of the rules above.
+```
+    bytecode []byte
+    stack_depth []int
+    SP := 0
+    validate(PC :=0)
+    {
+        // traverse code sequentially, recurse for subroutines and conditional jumps
+        while true
+            instruction = bytecode[PC]
+
+            // if stack depth set we have been here before 
+            // check for constant depth and return to break cycle
+            if stack_depth[PC] != 0 {
+                if SP != stack_depth[PC]
+                    return false
+                return true
+            }
+            stack_depth[PC] = SP
+
+            // effect of instruction on stack
+            SP -= removed_items(instruction)
+            SP += added_items(instruction)
+            if SP < 0 || 1024 < SP 
+                return false
+
+            // successful validation of path
+            if instruction == STOP, RETURN, or SUICIDE 
+                return true
+
+            if instruction == JUMP
+            {
+                // check for constant and correct destination
+                if (bytecode[PC - 33] != PUSH32) 
+                    return false
+                PC = stack[PC-32]
+                if byte_code[PC] != JUMPDEST
+                    return false
+
+                // reset PC to destination of jump 
+                PC = stack[PC-32]
+                continue
+            }
+            if instruction == JUMPI
+            {
+                // check for constant and correct destination
+                if (bytecode[PC - 33] != PUSH32) 
+                    return false
+                PC = stack[PC-32]
+                if byte_code[PC] != JUMPDEST
+                    return false
+
+                // recurse to jump to code to validate 
+                if !validate(stack[SP])) 
+                    return false
+                continue 
+            }
+            if instruction == JUMPSUB
+            {
+               // check for constant and correct destination
+               if (bytecode[PC - 33] != PUSH32) 
+                  return false
+                prevPC = PC
+                PC = stack[PC-32]
+                if byte_code[PC] != BEGINSUB
+                    return false
+
+                // recurse to jump to code to validate
+                prevSP = SP
+                depth = SP - prevSP
+                SP = depth
+                if  !validate(stack[SP]+1))
+                    return false
+                SP = prevSP - depth + SP
+                continue
+            }
+            if instruction == RETURNSUB
+            {
+                // successful return from recursion
+                PC = prevPC
+                return true
+            }
+
+            // advance PC according to instruction
+            PC = advance_pc(PC, instruction)
+        }
+        return true
+    }
+```
+## Test Cases
 
 ### Simple routine
 
@@ -150,55 +298,10 @@ Bytecode: `0x6005565c5d5b60035e` (`PUSH1 0x05, JUMP, BEGINSUB, RETURNSUB, JUMPDE
 
 Consumed gas: `30`
 
-### Error on "walk-into-subroutine"
-
-In this example, the code 'walks' into a subroutine, which is not allowed, and causes an error
-
-Bytecode: `0x5c5d00` (`BEGINSUB, RETURNSUB, STOP`)
-
-
-|  Pc   |      Op     | Cost |   Stack   |   RStack  |
-|-------|-------------|------|-----------|-----------|
-|    0  |   BEGINSUB  |    2 |        [] |        [] |
-
-```
-Error: at pc=0, op=BEGINSUB: invalid subroutine entry
-```
-
-**Note 5**: The content of the error message, (`invalid subroutine entry`) is implementation-specific.
-
-## Implementations
-
-Three clients have implemented this (or an earlier version of) this proposal:
-
-- [geth](https://github.com/ethereum/go-ethereum/pull/20619) .
-- [besu](https://github.com/hyperledger/besu/pull/717), and
-- [openethereum](https://github.com/openethereum/openethereum/pull/11629).
-
-
-### Costs and Codes
-
-We suggest that the cost of 
-
-- `BEGINSUB` be _base_ (`2`)
-  - Although formally specified, the cost of `BEGINSUB` does not matter in practice, since `BEGINSUB` never executes without error. 
-- `JUMPSUB` be _high_ (`10`)
-  - This is the same as `JUMPI`, and `2` more than `JUMP`.
-- `RETURNSUB` be _low_ (`5`).
-
-Benchmarking might be needed to tell if the costs are well-balanced. 
-
-We suggest the following opcodes:
-
-```
-0x5c BEGINSUB
-0x5d RETURNSUB
-0x5e JUMPSUB
-```
-
-## Security Considerations
-
-These changes do introduce new flow control instructions, so any software which does static/dynamic analysis of evm-code
-needs to be modified accordingly. The `JUMPSUB` semantics are similar to `JUMP` (but jumping to a `BEGINSUB`), whereas the `RETURNSUB` instruction is different, since it can 'land' on any opcode (but the possible destinations can be statically inferred).
+## References
+Charles H.Moore, Geoffrey C. Leach. [FORTH - A Language for Interactive Computing](http://www.ultratechnology.com/4th_1970.pdf). 1970
+Philip J. Koopman, Jr. [Stack Computers: the new wave](https://users.ece.cmu.edu/~koopman/stack_computers/index.html). 1989
+Gavin Wood. [Ethereum:  A  Secure  Decentralized Generalized  Transaction  Ledger](https://ethereum.github.io/yellowpaper/paper.pdf). 2021
+Nick Johnson. [EIP-3337: Frame pointer support for memory load and store operations](https://eips.ethereum.org/EIPS/eip-3337). 2021
 
 **Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).**

--- a/EIPS/eip-2315.md
+++ b/EIPS/eip-2315.md
@@ -65,7 +65,7 @@ This is almost the smallest change that provides native subroutines without brea
 
 These changes do not affect the semantics of existing EVM code.
 
-These changes are compatible with using [EIP-3337](https://eips.ethereum.org/EIPS/eip-3337.md) to provide stack frames, by associating a frame with each subroutine.
+These changes are compatible with using [EIP-3337](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-3337.md) to provide stack frames, by associating a frame with each subroutine.
 
 ## Implementations
 
@@ -302,6 +302,6 @@ Consumed gas: `30`
 Charles H.Moore, Geoffrey C. Leach. [FORTH - A Language for Interactive Computing](http://www.ultratechnology.com/4th_1970.pdf). 1970
 Philip J. Koopman, Jr. [Stack Computers: the new wave](https://users.ece.cmu.edu/~koopman/stack_computers/index.html). 1989
 Gavin Wood. [Ethereum:  A  Secure  Decentralized Generalized  Transaction  Ledger](https://ethereum.github.io/yellowpaper/paper.pdf). 2021
-Nick Johnson. [EIP-3337: Frame pointer support for memory load and store operations](https://eips.ethereum.org/EIPS/eip-3337.md). 2021
+Nick Johnson. [EIP-3337: Frame pointer support for memory load and store operations](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-3337.md). 2021
 
 **Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).**


### PR DESCRIPTION
This version is updated to specify rules for safe execution and amenability to static analysis.