### PR TITLE
EIP-3361: New JSON-RPC method for signing Ethereum messages (eth_signMessage)

### DIFF
--- a/EIPS/eip-3361.md
+++ b/EIPS/eip-3361.md
@@ -33,12 +33,12 @@ Calculates an Ethereum-specific signature in the form of `keccak256("\x19Ethereu
 
 |#|Type|Description|
 |-|-|-|
-|1|{[`Data`](#data)}|address to use for signing|
-|2|{[`Data`](#data)}|data to sign|
+|1|Data|address to use for signing|
+|2|Data|data to sign|
 
 #### Returns
 
-{[`Data`](#data)} - signature hash of the provided data
+Data - signature hash of the provided data
 
 #### Example
 

--- a/EIPS/eip-3361.md
+++ b/EIPS/eip-3361.md
@@ -1,7 +1,7 @@
 ---
-eip: <to be assigned>
+eip: 3361
 title: JSON-RPC method to sign Ethereum messages (eth_signMessage)
-author: Pedro Gomes <@pedrouid>
+author: Pedro Gomes (@pedrouid)
 discussions-to: <to be assigned>
 status: Draft
 type: Standards Track
@@ -11,7 +11,7 @@ requires: 191, 1474
 ---
 
 ## Simple Summary
-Introduces a new JSON-RPC method name to request Ethereum message signatures in light of eth_sign and personal_sign history
+Introduces a new JSON-RPC method name to request Ethereum message signatures considering of eth_sign and personal_sign history
 
 ## Abstract
 This proposal aims to reduce the fragmentation of both decentralizated applications and wallets regarding JSON-RPC methods to request message signatures. Also aims to incentivize implementers to move away from legacy methods that may have inherited broken implementations.
@@ -63,7 +63,6 @@ curl -X POST --data '{
 The specification maintains the parameters of the standardized eth_sign method with the prefixed signature behavior using a new method name that is less ambigious.
 
 ## Backwards Compatibility
-
 Wallets supporting either eth_sign or personal_sign should support this method in parallel for backwards-compatibility. Additionally EIP-1474 should replace eth_sign from its specification before finalization
 
 ## Security Considerations

--- a/EIPS/eip-3361.md
+++ b/EIPS/eip-3361.md
@@ -2,7 +2,7 @@
 eip: 3361
 title: JSON-RPC method to sign Ethereum messages (eth_signMessage)
 author: Pedro Gomes (@pedrouid)
-discussions-to: <to be assigned>
+discussions-to: https://ethereum-magicians.org/t/eip-3361-eth-signmessage/5969
 status: Draft
 type: Standards Track
 category: ERC


### PR DESCRIPTION
This proposal aims to reduce the fragmentation of both decentralizated applications and wallets regarding JSON-RPC methods to request message signatures. Also aims to incentivize implementers to move away from legacy methods that may have inherited broken implementations.