### PR TITLE
fix typo: "SELFEDESTRUCT" to "SELFDESTRUCT" for EIP-2929

### DIFF
--- a/EIPS/eip-2929.md
+++ b/EIPS/eip-2929.md
@@ -11,7 +11,7 @@ created: 2020-09-01
 
 ## Simple Summary
 
-Increases gas cost for `SLOAD`, `*CALL`, `BALANCE`, `EXT*` and `SELFEDESTRUCT` when used for the first time in a transaction.
+Increases gas cost for `SLOAD`, `*CALL`, `BALANCE`, `EXT*` and `SELFDESTRUCT` when used for the first time in a transaction.
 
 ## Abstract
 


### PR DESCRIPTION
EIP-2929: fix typo "SELFEDESTRUCT" to "SELFDESTRUCT"