### PR TITLE
Fix/eip2718 grammar

### DIFF
--- a/EIPS/eip-2718.md
+++ b/EIPS/eip-2718.md
@@ -64,7 +64,8 @@ A future EIP may introduce a standard for TransactionType identifier assignment 
 By having the second byte on be opaque bytes, rather than an RLP (or other encoding) list, we can support different encoding formats for the transaction payload in the future such as SSZ, LEB128, or a fixed width format.
 ### ORIGIN and CALLER
 There was discussion about having ORIGIN and CALLER opcodes become dependent on the transaction type, so that each transaction type could define what those opcodes returned.
-However, there is a desire to make transaction type opaque to the contracts to discourage contracts treating different types of transactions differently and there also were concerns over backward compatibility with existing contracts which make assumptions about ORIGIN and CALLER opcodes.
+However, there is a desire to make transaction type opaque to the contracts to discourage contracts treating different types of transactions differently.
+There also were concerns over backward compatibility with existing contracts which make assumptions about ORIGIN and CALLER opcodes.
 Going forward, we will assume that all transaction types will have an address that reasonably represents a `CALLER` of the first EVM frame and `ORIGIN` will be the same address in all cases.
 If a transaction type needs to supply additional information to contracts, they will need a new opcode.
 

--- a/EIPS/eip-2718.md
+++ b/EIPS/eip-2718.md
@@ -64,7 +64,7 @@ A future EIP may introduce a standard for TransactionType identifier assignment 
 By having the second byte on be opaque bytes, rather than an RLP (or other encoding) list, we can support different encoding formats for the transaction payload in the future such as SSZ, LEB128, or a fixed width format.
 ### ORIGIN and CALLER
 There was discussion about having ORIGIN and CALLER opcodes become dependent on the transaction type, so that each transaction type could define what those opcodes returned.
-However, there is a desire to make transaction type opaque to the contracts to discourage contracts treating different different types of transactions differently and there also were concerns over backward compatibility with existing contracts which make assumptions about ORIGIN and CALLER opcodes.
+However, there is a desire to make transaction type opaque to the contracts to discourage contracts treating different types of transactions differently and there also were concerns over backward compatibility with existing contracts which make assumptions about ORIGIN and CALLER opcodes.
 Going forward, we will assume that all transaction types will have an address that reasonably represents a `CALLER` of the first EVM frame and `ORIGIN` will be the same address in all cases.
 If a transaction type needs to supply additional information to contracts, they will need a new opcode.
 


### PR DESCRIPTION
Grammar edits.
- [x] Remove duplicate word (typo) (https://github.com/ethereum/EIPs/commit/769c7d21779626dced7a7ff2ec6058d40214fb92).
- [x] Split a run on sentence into two sentences (https://github.com/ethereum/EIPs/commit/32e224337a7904243ccb74da670da54ad1a3e532). 
