### PR TITLE
EIP 2981 improvements

### DIFF
--- a/EIPS/eip-2981.md
+++ b/EIPS/eip-2981.md
@@ -68,13 +68,18 @@ interface IERC2981 is ERC165 {
     /**
 
     /**
-     *      @notice Called to return both the creator's address and the royalty percentage - this would be the main function called by marketplaces unless they specifically        *       need just the royaltyAmount
-     *       @notice Percentage is calculated as a fixed point with a scaling factor of 100,000, such that 100% would be the value 10000000, as 10000000/100000 = 100. 1%          *        would be the value 100000, as 100000/100000 = 1
+     *      @notice Called to return both the creator's address and the royalty percentage -
+     *              this would be the main function called by marketplaces unless they specifically
+     *              need to adjust the royaltyAmount
+     *      @notice Percentage is calculated as a fixed point with a scaling factor of 100000,
+     *              such that 100% would be the value 10000000, as 10000000/100000 = 100.
+     *              1% would be the value 100000, as 100000/100000 = 1
      */
     function royaltyInfo(uint256 _tokenId) external returns (address receiver, uint256 amount);
 
     /**
-     *      @notice Called when royalty is transferred to the receiver. We wrap emitting the event as we want the NFT contract itself to contain the event.
+     *      @notice Called when royalty is transferred to the receiver. We wrap emitting
+     *              the event as we want the NFT contract itself to contain the event.
      */
     function receivedRoyalties(address _royaltyRecipient, address _buyer, uint256 _tokenId, address _tokenPaid, uint256 _amount) external;
 }
@@ -124,8 +129,8 @@ constructor (string memory name, string memory symbol, string memory baseURI)  p
 **Checking if the NFT being purchased/sold on your marketplace implemented royalties (note using address.call() is completely **OPTIONAL** and is just one method)**
 
 ```solidity  
-function checkRoyalties(address _token) internal  returns(bool) {
-   (bool success,) = address(_token).call(abi.encodeWithSignature("royaltyInfo(uint256)"));
+function checkRoyalties(address _token) internal  returns (bool) {
+    (bool success) = address(_token).call(abi.encodeWithSignature("royaltyInfo(uint256)"));
     return success;
  }
 ```

--- a/EIPS/eip-2981.md
+++ b/EIPS/eip-2981.md
@@ -16,22 +16,21 @@ A standardized way to handle royalty payments for ERC-721 tokens, including publ
 
 ## Abstract
 
-This extension provides even more flexibility to the [ERC-721 specification](./eip-721.md). It is possible to set a royalty amount that can be paid to the creator on any marketplace that implements this ERC
+This extension provides even more flexibility to the [ERC-721 specification](./eip-721.md). It is possible to set a royalty amount that can be paid to the creator on any marketplace that implements this ERC.
 
 
 ## Motivation
 There are many marketplaces for NFTs and the ones that support royalties are using their own standard version of royalties that are not easily compatible or usable by other marketplaces. Just as in the early days of Ethereum, smart contracts are varied by ecosystem and not compatible. This would solve that issue such that an NFT created, purchased, or sold on one marketplace, provides the royalties that the creator is entitled too, regardless of the next marketplace/ecosystem it is sold at. 
 
+Many of the largest ERC-721 marketplaces have implemented a form of royalties that is incompatible with other platforms and therefore makes it much harder to enforce when the NFT is sold on another marketplace, not fulfulling the potential of any implemented royalty system. This standard is a way to implement royalties that can be accepted across any type of NFT marketplace smart contracts. This minimalist proposal allows for standardized royalties to be accepted on all marketplaces - leaving the actual funds transfer up to the marketplace itself, and only providing a means to fetch the royalty amounts and an event to be emitted when the transfer has happened.
 
-Many of the largest ERC-721 marketplaces have implemented a form of royalties that is not compatible across the board and therefore making it much harder to enforce if the NFT is sold on another marketplace, not fulfulling the potential of any royalty system put in place. This standard is a proposed way to minimally implement royalties that can be accepted across any type of NFT marketplace smart contracts. This standard allows for a royalty standard to be accepted on all marketplaces - leaving the funds transfer up to the marketplace itself, and only providing a means to fetch the royalty amounts and a event to be fired off when transfer has happened.  
+This extension provides even more flexibility to the [ERC-721 specification](./eip-721.md). It is possible to set a royalty amount that can be paid to the creator on any marketplace that implements this ERC. If a marketplace chooses not to implement this ERC, then of course no funds are paid for secondary sales. But as most NFT marketplaces have developed some sort of royalty system themselves - and all of them are singular and only work within their own contracts - there should be an accepted standard way of providing royalties, if the creator chooses to set royalties on their NFTs.
 
-This extension provides even more flexibility to the [ERC-721 specification](./eip-721.md). It is possible to set a royalty amount that can be paid to the creator on any marketplace that implements this ERC. If a marketplace chooses not to implement this ERC then of course no funds are paid for secondary sales. But seeing as how most NFT marketplace have developed some sort of royalty system themselves - and all of them are singular and only work on their own contracts - there needs to be an accepted standard way of providing royalties - if the creator so chooses to set royalties on their NFTs.
-
-Without a set standard of way to do royalties, we won't have any effective means to provide royalties across the board, this obviously hampers the growth and adoption of NFTs, as the flexibility of the token and the UX is poor. 
+Without an agreed standard for implementing royalties, the NFT ecosystem will lack an effective means to collect royalties across all marketplaces. This will hamper the growth and adoption of NFTs and demotivate artists and other NFT creators from minting new and innovative tokens.
 
 *"Yes we have royalties, but if your NFT is sold on another marketplace, we cannot provide royalties" .... "But can't I sell my NFT anywhere with a click of my wallet?" .... "Yes... but we don't have a standard for royalties so you'll lose out"*
 
-This is poor UX and easily fixed with an accepted standard. 
+This is the current user experience, which is easily fixed with an accepted standard.
 
 ## Specification
 
@@ -42,29 +41,11 @@ RFC 2119.
 
 **ERC-721 compliant contracts MAY implement this ERC for royalties to provide a standard method of accepting royalty payments and receiving royalty information**
 
-The `_RoyaltyAmount` **MUST** be calculated as a percentage fixed point with a scaling factor of 10000 `(X/10000)` - such as "50000" - for 5%. This is **REQUIRED** to maintain uniformity across the standard. The max and min values would be - 100% (1,000,000) and 0.0001% (1).
+The `_RoyaltyAmount` **MUST** be calculated as a percentage fixed point with a scaling factor of 100000 `(X/100000)` - such as "500000" - for 5%. This is **REQUIRED** to maintain uniformity across the standard. The max and min values would be - 100% (10,000,000) and 0.00001% (1).
 
 Marketplaces that support this standard **MAY** implement any method of calculating or transferring royalties to the royalty recipient.
 
-Marketplaces that support this standard **MUST** emit the event, `ReceivedRoyalties`, after sending a payment. 
-
-```solidity
-/**
-    @notice This event is emitted when royalties are transferred.
-    @dev The marketplace would emit this event from their contracts. 
-    @param royaltyRecipient - The address of who is entitled to the royalties
-    @param buyer - The person buying the NFT on a secondary sale
-    @param tokenId - the token buying purchased/traded
-    @param amount - The amount being paid to the creator
-*/
-    event ReceivedRoyalties(
-        address indexed royaltyRecipient,
-        address indexed buyer,
-        uint256 indexed tokenId,
-        uint256 indexed amount
-    );
-```
-
+Marketplaces that support this standard **MUST** emit the event, `ReceivedRoyalties` by calling the receivedRoyalties() function on the NFT contract after sending a payment.
 
 ```solidity
 pragma solidity ^0.6.0;
@@ -78,37 +59,45 @@ interface IERC2981 is ERC165 {
     /*
      * ERC165 bytes to add to interface array - set in parent contract implementing this standard
      *
-     * bytes4(keccak256('royaltyInfo()')) == 0x46e80720
-     * bytes4 private constant _INTERFACE_ID_ERC721ROYALTIES = 0x46e80720;
+     * bytes4(keccak256('royaltyInfo(uint256)')) == 0xcef6d368
+     * bytes4(keccak256('receivedRoyalties(address,address,uint256,address,uint256)')) == 0x8589ff45
+     * bytes4(0xcef6d368) ^ bytes4(0x8589ff45) == 0x4b7f2c2d
+     * bytes4 private constant _INTERFACE_ID_ERC721ROYALTIES = 0x4b7f2c2d;
      * _registerInterface(_INTERFACE_ID_ERC721ROYALTIES);
      */
     /**
-    
+
     /**
      *      @notice Called to return both the creator's address and the royalty percentage - this would be the main function called by marketplaces unless they specifically        *       need just the royaltyAmount
-     *       @notice Percentage is calculated as a fixed point with a scaling factor of 10,000, such that 100% would be the value (1000000) where, 1000000/10000 = 100. 1%          *        would be the value 10000/10000 = 1
+     *       @notice Percentage is calculated as a fixed point with a scaling factor of 100,000, such that 100% would be the value 10000000, as 10000000/100000 = 100. 1%          *        would be the value 100000, as 100000/100000 = 1
      */
-    function royaltyInfo(uint256 _tokenId) external returns (address receiver, uint256 amount); 
+    function royaltyInfo(uint256 _tokenId) external returns (address receiver, uint256 amount);
+
+    /**
+     *      @notice Called when royalty is transferred to the receiver. We wrap emitting the event as we want the NFT contract itself to contain the event.
+     */
+    function receivedRoyalties(address _royaltyRecipient, address _buyer, uint256 _tokenId, address _tokenPaid, uint256 _amount) external;
 }
-  
-  
+
 ```
 
 ### Event `ReceivedRoyalties` to be used by marketplaces when transferring royalty payments 
 ```solidity
-  /**
+/**
     @notice This event is emitted when royalties are transferred.
     @dev The marketplace would emit this event from their contracts. 
     @param royaltyRecipient - The address of who is entitled to the royalties
-    @param buyer - The person buying the NFT on a secondary sale
+    @param buyer - The address buying the NFT on a secondary sale
     @param tokenId - the token buying purchased/traded
-    @param amount - The amount being paid to the creator
+    @param tokenPaid - The address of the token (ERC20) used to pay the fee. Set to 0x0 if native asset (ETH).
+    @param amount - The amount being paid to the creator using the correct decimals from tokenPaid (i.e. if 6 decimals, 1000000 for 1 token paid)
 */
     event ReceivedRoyalties(
-        address indexed royaltyRecipient,
-        address indexed buyer,
-        uint256 indexed tokenId,
-        uint256 indexed amount
+        address indexed _royaltyRecipient,
+        address indexed _buyer,
+        uint256 indexed _tokenId,
+        address _tokenPaid,
+        uint256 _amount
     );
 ```
 
@@ -136,22 +125,29 @@ constructor (string memory name, string memory symbol, string memory baseURI)  p
 
 ```solidity  
 function checkRoyalties(address _token) internal  returns(bool) {
-   (bool success,) = address(_token).call(abi.encodeWithSignature("royaltyInfo()"));
+   (bool success,) = address(_token).call(abi.encodeWithSignature("royaltyInfo(uint256)"));
     return success;
  }
 ```
 
-**Transferring funds and calling the event to be emitted**
+**Transferring funds (ETH) and calling function to emit the ReceivedRoyalties event inside the NFT contract**
 
 ```solidity 
    _recipient.transfer(amount);
-   IERC2981(_tokenAddress).royaltiesReceived(_recipient, _buyer, amount);
+   IERC2981(_tokenAddress).receivedRoyalties(_recipient, _buyer, _tokenId, address(0), amount);
 ```
 
+**Transferring funds (USDC) and calling function to emit the ReceivedRoyalties event inside the NFT contract**
+
+```solidity 
+   IERC20(0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48).transfer(_recipient, amount);
+   _recipient.transfer(amount);
+   IERC2981(_tokenAddress).receivedRoyalties(_recipient, _buyer, _tokenId, address(0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48), amount);
+```
 
 ## Rationale
 
-### Fixed percentage to 10^5 (10000)
+### Fixed percentage to 10^5 (100000)
 
 Having the flexibility to set any percentage a creator likes is important - although the reality of having users want a 0.00000000001% fee is not very likely. Instead the value can be limited to 5 decimal places with the lowest percentage being 0.00001% and the cap at 100%. 
 

--- a/EIPS/eip-2981.md
+++ b/EIPS/eip-2981.md
@@ -42,7 +42,7 @@ RFC 2119.
 
 **ERC-721 compliant contracts MAY implement this ERC for royalties to provide a standard method of accepting royalty payments and receiving royalty information**
 
-The `_RoyaltyAmount` **MUST** be calculated as a percentage fixed point with a scaling factor of 10000 `(X/10000)` - such as "50000" - for 5%. This is **REQUIRED** to maintain uniformity across the standard. The max and min values would be - 100% (1,000,000) and 0.00001% (1).
+The `_RoyaltyAmount` **MUST** be calculated as a percentage fixed point with a scaling factor of 10000 `(X/10000)` - such as "50000" - for 5%. This is **REQUIRED** to maintain uniformity across the standard. The max and min values would be - 100% (1,000,000) and 0.0001% (1).
 
 Marketplaces that support this standard **MAY** implement any method of calculating or transferring royalties to the royalty recipient.
 

--- a/EIPS/eip-2981.md
+++ b/EIPS/eip-2981.md
@@ -1,7 +1,7 @@
 ---
 eip: 2981
 title: ERC-721 Royalty Standard
-author: Zach Burks (@vexycats), James Morgan (@jamesmorgan), Blaine Malone (@blmalone)
+author: Zach Burks (@vexycats), James Morgan (@jamesmorgan), Blaine Malone (@blmalone), James Seibel (@seibelj)
 discussions-to: https://github.com/ethereum/EIPs/issues/2907
 status: Draft
 type: Standards Track


### PR DESCRIPTION
@VexyCats 

- Fixed issues in precision of the percentages. In some places 4 decimals were used, but we want 5 (0.00001) was the intention.
- tokenId was added to functions but inconsistently
- You can't emit an event on the NFT contract directly, you must wrap it in a function. Having this function requires adding it to the interface
- Interface ERC165 calculation was incorrect (didn't update it for the uint256 tokenId when it was added) plus I had to add in the new function for emitting the event
- Added `_tokenPaid` field to the `RoyaltiesReceived` event to support ERC20 payments
- Removed the 4th index in the event - events can only have 3 indexed parameters. ERC20 and ERC721 both don't index the amount, so not indexing the `_tokenPaid` and the `_amount` is consistent with the standards
- Updated and cleaned up the copy a bit