### PR TITLE
Update EIP-3322 Opcodes to be compatible with EIP-3198

### DIFF
--- a/EIPS/eip-3322.md
+++ b/EIPS/eip-3322.md
@@ -27,12 +27,12 @@ Contract accounts gain an unsigned gas refund counter, initially zero.
 
 Three new opcodes are introduced to manage this state.
 
-* `SELFGAS` (`0x48`): Pushes the current account's gas refund counter onto the stack.
+* `SELFGAS` (`0x49`): Pushes the current account's gas refund counter onto the stack.
 Shares gas pricing with `SELFBALANCE`.
-* `USEGAS` (`0x49`): Pops `amount` from the stack.
+* `USEGAS` (`0x4a`): Pops `amount` from the stack.
 The minimum of `amount` and the current account's gas refund counter is transferred to the execution context's refund counter.
 Costs `5000` gas.
-* `STOREGAS` (`0x4a`): Pops `amount` from the stack.
+* `STOREGAS` (`0x4b`): Pops `amount` from the stack.
 Costs `5000 + amount` gas.
 Increases the current account's gas refund counter by `amount`.
 


### PR DESCRIPTION

#### Changes
This updates the draft so that the opcode specifications would be compatible with EIP-3198: BASEFEE opcode.