### PR TITLE
1559: Removes Implementation Sectoin

### DIFF
--- a/EIPS/eip-1559.md
+++ b/EIPS/eip-1559.md
@@ -288,9 +288,6 @@ Previous to this change, `GASPRICE` represented both the ETH paid by the signer 
 
 ## Test Cases
 
-## Implementation
-Go-ethereum implementation by Vulcanize Inc: https://github.com/vulcanize/go-ethereum-EIP1559
-
 ## Security Considerations
 ### Increased Max Block Size/Complexity
 This EIP will increase the maximum block size, which could cause problems if miners are unable to process a block fast enough as it will force them to mine an empty block.  Over time, the average block size should remain about the same as without this EIP, so this is only an issue for short term size bursts.  It is possible that one or more clients may handle short term size bursts poorly and error (such as out of memory or similar) and client implementations should make sure their clients can appropriately handle individual blocks up to max size.


### PR DESCRIPTION
`## Implementation` isn't a valid EIP section.  Reference implementation is, but that should be inline or in assets and is an optional section.