### PR TITLE
Update interface id in ERC1363

### DIFF
--- a/EIPS/eip-1363.md
+++ b/EIPS/eip-1363.md
@@ -43,22 +43,16 @@ This proposal has been inspired by the [ERC-721](./eip-721.md) `onERC721Received
 Implementing contracts **MUST** implement the [ERC-1363](./eip-1363.md) interface as well as the [ERC-20](./eip-20.md) and [ERC-165](./eip-165.md) interfaces.
 
 ```solidity
-pragma solidity ^0.7.0;
-
+pragma solidity ^0.8.0;
 
 interface ERC1363 /* is ERC20, ERC165 */ {
   /*
-   * Note: the ERC-165 identifier for this interface is 0x4bbee2df.
-   * 0x4bbee2df ===
+   * Note: the ERC-165 identifier for this interface is 0xb0202a11.
+   * 0xb0202a11 ===
    *   bytes4(keccak256('transferAndCall(address,uint256)')) ^
    *   bytes4(keccak256('transferAndCall(address,uint256,bytes)')) ^
    *   bytes4(keccak256('transferFromAndCall(address,address,uint256)')) ^
-   *   bytes4(keccak256('transferFromAndCall(address,address,uint256,bytes)'))
-   */
-
-  /*
-   * Note: the ERC-165 identifier for this interface is 0xfb9ec8ce.
-   * 0xfb9ec8ce ===
+   *   bytes4(keccak256('transferFromAndCall(address,address,uint256,bytes)')) ^
    *   bytes4(keccak256('approveAndCall(address,uint256)')) ^
    *   bytes4(keccak256('approveAndCall(address,uint256,bytes)'))
    */


### PR DESCRIPTION
Just update the interface id in comments by linking all in one instead of having them separate.

EIP says that they MUST be all implemented so there is no reason to keep them separate.
