### PR TITLE
Correctly escape triangular brackets in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Achieving "Final" status in this repository only represents that a proposal has 
 
 Browse all current and draft EIPs on [the official EIP site](https://eips.ethereum.org/).
 
-Once your first PR is merged, we have a bot that helps out by automatically merging PRs to draft EIPs. For this to work, it has to be able to tell that you own the draft being edited. Make sure that the 'author' line of your EIP contains either your GitHub username or your email address inside <triangular brackets>. If you use your email address, that address must be the one publicly shown on [your GitHub profile](https://github.com/settings/profile).
+Once your first PR is merged, we have a bot that helps out by automatically merging PRs to draft EIPs. For this to work, it has to be able to tell that you own the draft being edited. Make sure that the 'author' line of your EIP contains either your GitHub username or your email address inside \<triangular brackets>. If you use your email address, that address must be the one publicly shown on [your GitHub profile](https://github.com/settings/profile).
 
 ## Project Goal
 


### PR DESCRIPTION
This small change escapes the triangular brackets (`<>`) used in README.md. 
Previously the text inside the brackets was hidden by GitHub's markdown compiler.

