### PR TITLE
Fix some typos on EIP3234

### DIFF
--- a/EIPS/eip-3234.md
+++ b/EIPS/eip-3234.md
@@ -61,8 +61,8 @@ interface IERC3234BatchFlashLender {
      */
     function batchFlashLoan(
         IERC3234BatchFlashBorrower receiver,
-        address[] calldata token,
-        uint256[] calldata amount,
+        address[] calldata tokens,
+        uint256[] calldata amounts,
         bytes[] calldata data
     ) external returns (bool);
 }
@@ -82,10 +82,16 @@ function batchFlashLoan(
     bytes calldata data
 ) external returns (bool) {
   ...
-  require(
-      receiver.onBatchFlashLoan(msg.sender, tokens, amounts, fees, data),
-      "IERC3234: Callback failed"
-  );
+    require(
+        receiver.onBatchFlashLoan(
+            msg.sender,
+            tokens,
+            amounts,
+            fees,
+            data
+        ) == keccak256("ERC3234BatchFlashBorrower.onBatchFlashLoan"),
+        "IERC3234: Callback failed"
+    );
   ...
 }
 ```
@@ -106,20 +112,20 @@ If successful, `batchFlashLoan` MUST return `true`.
 
 ### Receiver Specification
 
-A `receiver` of flash loans MUST implement the IERC3234FlashBorrower interface:
+A `receiver` of flash loans MUST implement the IERC3234BatchFlashBorrower interface:
 
 ```
 pragma solidity ^0.7.0 || ^0.8.0;
 
 
-interface IERC3234FlashBorrower {
+interface IERC3234BatchFlashBorrower {
 
     /**
      * @dev Receive a flash loan.
      * @param initiator The initiator of the loan.
-     * @param token The loan currency.
-     * @param amount The amount of tokens lent.
-     * @param fee The additional amount of tokens to repay.
+     * @param tokens The loan currency.
+     * @param amounts The amount of tokens lent.
+     * @param fees The additional amount of tokens to repay.
      * @param data Arbitrary data structure, intended to contain user-defined parameters.
      * @return The keccak256 hash of "ERC3234BatchFlashBorrower.onBatchFlashLoan"
      */


### PR DESCRIPTION

- pluralize function arguments
- IERC3234FlashBorrower -> IERC3234BatchFlashBorrower
- change success condition of example implementation