### PR TITLE
Remove effective gas price from EIP-1559 receipt

### DIFF
--- a/EIPS/eip-1559.md
+++ b/EIPS/eip-1559.md
@@ -47,7 +47,7 @@ The [EIP-2718](./eip-2718.md) `TransactionPayload` for this transaction is `rlp(
 
 The `signatureYParity, signatureR, signatureS` elements of this transaction represent a secp256k1 signature over `keccak256(0x02 || rlp([chainId, nonce, maxInclusionFeePerGas, maxFeePerGas, gasLimit, to, value, data, access_list]))`.
 
-The [EIP-2718](./eip-2718.md) `ReceiptPayload` for this transaction is `rlp([status, effectiveGasPrice, cumulativeGasUsed, logsBloom, logs])`.
+The [EIP-2718](./eip-2718.md) `ReceiptPayload` for this transaction is `rlp([status, cumulativeGasUsed, logsBloom, logs])`.
 
 *Note: `//` is integer division, round down.*
 ```python


### PR DESCRIPTION
I don't believe this extra field is useful in a consensus structure. Each field in the receipt can currently *only* be determined by reexecuting the transaction. `effectiveGasPrice` does not require reexecution, only the transaction's `feeCap` and `tip` in addition to the block's `baseFee`. This generally requires 1 additional RPC call to get the block `baseFee`, on top of what is done today (just `eth.getTransaction` today). Client could optimize this further by indexing transaction in relation to the block `baseFee`.