### PR TITLE
Removed dynamic BLOCK_GAS_TARGET and BASE_FEE clamp

### DIFF
--- a/EIPS/eip-3416.md
+++ b/EIPS/eip-3416.md
@@ -11,7 +11,7 @@ created: 2021-03-18
 
 ## Simple Summary
 
-A transaction pricing mechanism with a fixed-per-block network fee and a median inclusion fee.
+A transaction pricing mechanism with a fixed-per-block network fee and a median inclusion fee with additive updates.
 
 ## Abstract
 
@@ -46,8 +46,6 @@ The proposal in this EIP is to start with a base fee amount which is adjusted up
 This is a classic fork without a long migration time.
 
 * `FORK_BLOCK_NUMBER`: TBD.  Block number at or after which EIP-3416 transactions are valid.
-* `BLOCK_GAS_TARGET`: 10th item in the block header: The gas limit field, controlled by miner voting.  Previously referred to colloquially as `gas limit`, now referred to as `gas target`.  Controlled by miners in the same way as before where each miner can increase or decrease it by a very small amount relative to the parent block.
-* `PARENT_GAS_TARGET`: same as `BLOCK_GAS_TARGET` for parent block. 
 * `GAS_TARGET_MAX_CHANGE`: `1 // 1024`.
 * `BLOCK_GAS_USED`: total gas consumed by transaction included in the block.
 * `PARENT_GAS_USED`: same as `BLOCK_GAS_USED` for parent block. 
@@ -59,12 +57,10 @@ This is a classic fork without a long migration time.
 
 ### Process
 
-* `BLOCK_GAS_TARGET` is set between `PARENT_GAS_TARGET * (1 - GAS_TARGET_MAX_CHANGE)` (inclusive) and `PARENT_GAS_TARGET * (1 + GAS_TARGET_MAX_CHANGE)` (inclusive), depending on miner decision.
 * At `block.number == FORK_BLOCK_NUMBER` we set `BASE_FEE = INITIAL_BASE_FEE`
 * `BASE_FEE` is set, from `FORK_BLOCK_NUMBER + 1`, as follows
   * Let `GAS_DELTA = (PARENT_GAS_USED - PARENT_GAS_TARGET) // PARENT_GAS_TARGET` (possibly negative).
   * Set `BASE_FEE = PARENT_BASE_FEE + GSA_DELTA * BASE_FEE_MAX_CHANGE`
-  * Clamp the resulting `BASE_FEE` inside of the allowable bounds if needed, where a valid `BASE_FEE` is one such that `abs(BASE_FEE - PARENT_BASE_FEE) <= max(1, PARENT_BASE_FEE // BASE_FEE_MAX_CHANGE)`
 * Transactions since `FORK_BLOCK_NUMBER` are encoded the same as the current ones `rlp([nonce, gasPrice, gasLimit, to, value, data, v, r, s])` where `v,r,s` is a signature of `rlp([nonce, gasPrice, gasLimit, to, value, data])` and `gasPrice` is the `FEE_CAP` specified by the sender according to this proposal.
 * To produce transactions since `FORK_BLOCK_NUMBER`, the new `FEE_CAP` field (maintaining legacy name of `gasPrice` in the transaction) is set as follows (and the `GAS_PREMIUM` is computed as specified):
   * `FEE_CAP`: `tx.gasPrice`, serves as the absolute maximum that the transaction sender is willing to pay.
@@ -87,9 +83,7 @@ The rationale for the `BASE_FEE` update formula is that we are using an additive
 
 Another rationale for the additive `BASE_FEE` update formula is that it guarantees (see [this](https://pdfs.semanticscholar.org/3d2d/773983c5201b58586af463f045befae5bbf2.pdf) article) that the optimal execution strategy (scheduling broadcasts in order to pay less fee) for a batch of nonurgent transactions is to spread the transactions across different blocks which in turn helps to avoid network congestion and lowers volatility. For the multiplicative formula, it is exactly the reverse, that is, spikes (dumping all your transactions at once) are incentivized as described [here](https://ethresear.ch/t/path-dependence-of-eip-1559-and-the-simulation-of-the-resulting-permanent-loss/8964).
 
-(TO BE REVIEWED) The rationale for the `BASE_FEE_MAX_CHANGE` being `1 // 8` is that the `BASE_FEE` is designed to be very adaptative to block utilization changes.
-
-(TO BE REVIEWED) The rationale for the `BLOCK_GAS_TARGET` to be `1 // 1024` is that miners need some adaptativity to high volumen intraday times (maximum change in 4 hours is 100%, considering 15 second blocks), but we do not want something to instable with big changes by the minute.
+The rationale for the `BASE_FEE_MAX_CHANGE` being `1 // 8` is that the `BASE_FEE` is designed to be very adaptative to block utilization changes.
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
Removed dynamic BLOCK_GAS_TARGET altogether to focus on the following:

* Median premium fee.
* Dynamic Base Fee with Additive updates.

Also removing the clamp for BASE_FEE border conditions that was redundant or useless.
