### PR TITLE
Apparently codespell doesn't know `sting` is a word?

### DIFF
--- a/.codespell-whitelist
+++ b/.codespell-whitelist
@@ -10,3 +10,4 @@ iam
 espace
 acn
 ende
+sting


### PR DESCRIPTION
Failure: https://travis-ci.org/github/ethereum/EIPs/jobs/766589226