### PR TITLE
1559: Rename inclusion fee to priority fee.

### DIFF
--- a/EIPS/eip-1559.md
+++ b/EIPS/eip-1559.md
@@ -11,7 +11,7 @@ requires: 2718, 2930
 ---
 
 ## Simple Summary
-A transaction pricing mechanism that includes fixed-per-block network fee that is burned and dynamically expands/contracts block sizes to deal with transient congestion.
+A transaction pricing mechanism that includes fixed-per-block network fee that is burned and dynamically expands/contracts block sizes to deal with transient congestion. 
 
 ## Abstract
 We introduce a new [EIP-2718](./eip-2718.md) transaction type, with the format `0x02 || rlp([chainId, nonce, maxPriorityFeePerGas, maxFeePerGas, gasLimit, to, value, data, access_list, signatureYParity, signatureR, signatureS])`.

--- a/EIPS/eip-1559.md
+++ b/EIPS/eip-1559.md
@@ -14,14 +14,14 @@ requires: 2718, 2930
 A transaction pricing mechanism that includes fixed-per-block network fee that is burned and dynamically expands/contracts block sizes to deal with transient congestion.
 
 ## Abstract
-We introduce a new [EIP-2718](./eip-2718.md) transaction type, with the format `0x02 || rlp([chainId, nonce, maxInclusionFeePerGas, maxFeePerGas, gasLimit, to, value, data, access_list, signatureYParity, signatureR, signatureS])`.
+We introduce a new [EIP-2718](./eip-2718.md) transaction type, with the format `0x02 || rlp([chainId, nonce, maxPriorityFeePerGas, maxFeePerGas, gasLimit, to, value, data, access_list, signatureYParity, signatureR, signatureS])`.
 
 There is a base fee per gas in protocol, which can move up or down each block according to a formula which is a function of gas used in parent block and gas target (formerly known as gas limit) of parent block.
 The algorithm results in the base fee per gas increasing when blocks are above the gas target, and decreasing when blocks are below the gas target.
 The base fee per gas is burned.
-Transactions specify the maximum fee per gas they are willing to give to miners to incentivize them to include their transaction (aka: inclusion fee).
-Transactions also specify the maximum fee per gas they are willing to pay total (aka: max fee), which covers both the inclusion fee and the block's network fee per gas (aka: base fee).
-The transaction will always pay the base fee per gas of the block it was included in, and they will pay the inclusion fee per gas set in the transaction, as long as the combined amount of the two fees doesn't exceed the transaction's maximum fee per gas.
+Transactions specify the maximum fee per gas they are willing to give to miners to incentivize them to include their transaction (aka: priority fee).
+Transactions also specify the maximum fee per gas they are willing to pay total (aka: max fee), which covers both the priority fee and the block's network fee per gas (aka: base fee).
+The transaction will always pay the base fee per gas of the block it was included in, and they will pay the priority fee per gas set in the transaction, as long as the combined amount of the two fees doesn't exceed the transaction's maximum fee per gas.
 
 ## Motivation
 Ethereum historically priced transaction fees using a simple auction mechanism, where users send transactions with bids ("gasprices") and miners choose transactions with the highest bids, and transactions that get included pay the bid that they specify. This leads to several large sources of inefficiency:
@@ -31,9 +31,9 @@ Ethereum historically priced transaction fees using a simple auction mechanism, 
 * **Inefficiencies of first price auctions**: The current approach, where transaction senders publish a transaction with a bid a maximum fee, miners choose the highest-paying transactions, and everyone pays what they bid. This is well-known in mechanism design literature to be highly inefficient, and so complex fee estimation algorithms are required. But even these algorithms often end up not working very well, leading to frequent fee overpayment.
 * **Instability of blockchains with no block reward**: In the long run, blockchains where there is no issuance (including Bitcoin and Zcash) at present intend to switch to rewarding miners entirely through transaction fees. However, there are known issues with this that likely leads to a lot of instability, incentivizing mining "sister blocks" that steal transaction fees, opening up much stronger selfish mining attack vectors, and more. There is at present no good mitigation for this.
 
-The proposal in this EIP is to start with a base fee amount which is adjusted up and down by the protocol based on how congested the network is. When the network exceeds the target per-block gas usage, the base fee increases slightly and when capacity is below the target, it decreases slightly. Because these base fee changes are constrained, the maximum difference in base fee from block to block is predictable. This then allows wallets to auto-set the gas fees for users in a highly reliable fashion. It is expected that most users will not have to manually adjust gas fees, even in periods of high network activity. For most users the base fee will be estimated by their wallet and a small inclusion fee, which compensates miners taking on orphan risk (e.g. 1 nanoeth), will be automatically set. Users can also manually set the transaction max fee to bound their total costs.
+The proposal in this EIP is to start with a base fee amount which is adjusted up and down by the protocol based on how congested the network is. When the network exceeds the target per-block gas usage, the base fee increases slightly and when capacity is below the target, it decreases slightly. Because these base fee changes are constrained, the maximum difference in base fee from block to block is predictable. This then allows wallets to auto-set the gas fees for users in a highly reliable fashion. It is expected that most users will not have to manually adjust gas fees, even in periods of high network activity. For most users the base fee will be estimated by their wallet and a small priority fee, which compensates miners taking on orphan risk (e.g. 1 nanoeth), will be automatically set. Users can also manually set the transaction max fee to bound their total costs.
 
-An important aspect of this fee system is that miners only get to keep the inclusion fee. The base fee is always burned (i.e. it is destroyed by the protocol). This ensures that only ETH can ever be used to pay for transactions on Ethereum, cementing the economic value of ETH within the Ethereum platform and reducing risks associated with miner extractable value (MEV). Additionally, this burn counterbalances Ethereum inflation while still giving the block reward and inclusion fee to miners. Finally, ensuring the miner of a block does not receive the base fee is important because it removes miner incentive to manipulate the fee in order to extract more fees from users.
+An important aspect of this fee system is that miners only get to keep the priority fee. The base fee is always burned (i.e. it is destroyed by the protocol). This ensures that only ETH can ever be used to pay for transactions on Ethereum, cementing the economic value of ETH within the Ethereum platform and reducing risks associated with miner extractable value (MEV). Additionally, this burn counterbalances Ethereum inflation while still giving the block reward and priority fee to miners. Finally, ensuring the miner of a block does not receive the base fee is important because it removes miner incentive to manipulate the fee in order to extract more fees from users.
 
 ## Specification
 Block validity is defined in the reference implementation below.
@@ -43,9 +43,9 @@ As of `FORK_BLOCK_NUMBER`, a new [EIP-2718](./eip-2718.md) transaction is introd
 
 The intrinsic cost of the new transaction is inherited from [EIP-2930](./eip-2930.md), specifically `21000 + 16 * non-zero calldata bytes + 4 * zero calldata bytes + 1900 * access list storage key count + 2400 * access list address count`.
 
-The [EIP-2718](./eip-2718.md) `TransactionPayload` for this transaction is `rlp([chainId, nonce, maxInclusionFeePerGas, maxFeePerGas, gasLimit, to, value, data, access_list, signatureYParity, signatureR, signatureS])`.
+The [EIP-2718](./eip-2718.md) `TransactionPayload` for this transaction is `rlp([chainId, nonce, maxPriorityFeePerGas, maxFeePerGas, gasLimit, to, value, data, access_list, signatureYParity, signatureR, signatureS])`.
 
-The `signatureYParity, signatureR, signatureS` elements of this transaction represent a secp256k1 signature over `keccak256(0x02 || rlp([chainId, nonce, maxInclusionFeePerGas, maxFeePerGas, gasLimit, to, value, data, access_list]))`.
+The `signatureYParity, signatureR, signatureS` elements of this transaction represent a secp256k1 signature over `keccak256(0x02 || rlp([chainId, nonce, maxPriorityFeePerGas, maxFeePerGas, gasLimit, to, value, data, access_list]))`.
 
 The [EIP-2718](./eip-2718.md) `ReceiptPayload` for this transaction is `rlp([status, cumulativeGasUsed, logsBloom, logs])`.
 
@@ -90,7 +90,7 @@ class Transaction2930Envelope:
 class Transaction1559Payload:
 	chain_id: int = 0
 	signer_nonce: int = 0
-	max_inclusion_fee_per_gas: int = 0
+	max_priority_fee_per_gas: int = 0
 	max_fee_per_gas: int = 0
 	gas_limit: int = 0
 	destination: int = 0
@@ -114,7 +114,7 @@ Transaction = Union[TransactionLegacy, Transaction2718]
 class NormalizedTransaction:
 	signer_address: int = 0
 	signer_nonce: int = 0
-	max_inclusion_fee_per_gas: int = 0
+	max_priority_fee_per_gas: int = 0
 	max_fee_per_gas: int = 0
 	gas_limit: int = 0
 	destination: int = 0
@@ -194,10 +194,10 @@ class World(ABC):
 
 			# ensure that the user was willing to at least pay the base fee
 			assert transaction.max_fee_per_gas >= block.base_fee_per_gas
-			# inclusion fee is capped because the base fee is filled first
-			inclusion_fee_per_gas = min(transaction.max_inclusion_fee_per_gas, transaction.max_fee_per_gas - block.base_fee_per_gas)
-			# signer pays both the inclusion fee and the base fee
-			effective_gas_price = inclusion_fee_per_gas + block.base_fee_per_gas
+			# priority fee is capped because the base fee is filled first
+			priority_fee_per_gas = min(transaction.max_priority_fee_per_gas, transaction.max_fee_per_gas - block.base_fee_per_gas)
+			# signer pays both the priority fee and the base fee
+			effective_gas_price = priority_fee_per_gas + block.base_fee_per_gas
 			signer.balance -= transaction.gas_limit * effective_gas_price
 			assert signer.balance >= 0, 'invalid transaction: signer does not have enough ETH to cover gas'
 			gas_used = self.execute_transaction(transaction, effective_gas_price)
@@ -205,8 +205,8 @@ class World(ABC):
 			cumulative_transaction_gas_used += gas_used
 			# signer gets refunded for unused gas
 			signer.balance += gas_refund * effective_gas_price
-			# miner only receives the inclusion fee; note that the base fee is not given to anyone (it is burned)
-			self.account(block.author).balance += gas_used * inclusion_fee_per_gas
+			# miner only receives the priority fee; note that the base fee is not given to anyone (it is burned)
+			self.account(block.author).balance += gas_used * priority_fee_per_gas
 
 		# check if the block spent too much gas transactions
 		assert cumulative_transaction_gas_used == block.gas_used, 'invalid block: gas_used does not equal total gas used in all transactions'
@@ -221,7 +221,7 @@ class World(ABC):
 				signer_address = signer_address,
 				signer_nonce = transaction.signer_nonce,
 				gas_limit = transaction.gas_limit,
-				max_inclusion_fee_per_gas = transaction.gas_price,
+				max_priority_fee_per_gas = transaction.gas_price,
 				max_fee_per_gas = transaction.gas_price,
 				destination = transaction.destination,
 				amount = transaction.amount,
@@ -234,7 +234,7 @@ class World(ABC):
 				signer_address = signer_address,
 				signer_nonce = transaction.payload.signer_nonce,
 				gas_limit = transaction.payload.gas_limit,
-				max_inclusion_fee_per_gas = transaction.payload.gas_price,
+				max_priority_fee_per_gas = transaction.payload.gas_price,
 				max_fee_per_gas = transaction.payload.gas_price,
 				destination = transaction.payload.destination,
 				amount = transaction.payload.amount,
@@ -247,7 +247,7 @@ class World(ABC):
 				signer_address = signer_address,
 				signer_nonce = transaction.payload.signer_nonce,
 				gas_limit = transaction.payload.gas_limit,
-				max_inclusion_fee_per_gas = transaction.payload.max_inclusion_fee_per_gas,
+				max_priority_fee_per_gas = transaction.payload.max_priority_fee_per_gas,
 				max_fee_per_gas = transaction.payload.max_fee_per_gas,
 				destination = transaction.payload.destination,
 				amount = transaction.payload.amount,
@@ -278,7 +278,7 @@ class World(ABC):
 ```
 
 ## Backwards Compatibility
-Legacy Ethereum transactions will still work and be included in blocks, but they will not benefit directly from the new pricing system.  This is due to the fact that upgrading from legacy transactions to new transactions results in the legacy transaction's `gas_price ` entirely being consumed either by the `base_fee_per_gas` and the `inclusion_fee_per_gas`.
+Legacy Ethereum transactions will still work and be included in blocks, but they will not benefit directly from the new pricing system.  This is due to the fact that upgrading from legacy transactions to new transactions results in the legacy transaction's `gas_price ` entirely being consumed either by the `base_fee_per_gas` and the `priority_fee_per_gas`.
 
 ### Block Hash Changing
 The datastructure that is passed into keccak256 to calculate the block hash is changing, and all applications that are validating blocks are valid or using the block hash to verify block contents will need to be adapted to support the new datastructure (one additional item).  If you only take the block header bytes and hash them you should still correctly get a hash, but if you construct a block header from its constituent elements you will need to add in the new one at the end.
@@ -294,10 +294,10 @@ TODO
 This EIP will increase the maximum block size, which could cause problems if miners are unable to process a block fast enough as it will force them to mine an empty block.  Over time, the average block size should remain about the same as without this EIP, so this is only an issue for short term size bursts.  It is possible that one or more clients may handle short term size bursts poorly and error (such as out of memory or similar) and client implementations should make sure their clients can appropriately handle individual blocks up to max size.
 
 ### Transaction Ordering
-With most people not competing on inclusion fees and instead using a baseline fee to get included, transaction ordering now depends on individual client internal implementation details such as how they store the transactions in memory.  It is recommended that transactions with the same inclusion fee be sorted by time the transaction was received to protect the network from spamming attacks where the attacker throws a bunch of transactions into the pending pool in order to ensure that at least one lands in a favorable position.  Miners should still prefer higher tip transactions over those with a lower tip, purely from a selfish mining perspective.
+With most people not competing on priority fees and instead using a baseline fee to get included, transaction ordering now depends on individual client internal implementation details such as how they store the transactions in memory.  It is recommended that transactions with the same priority fee be sorted by time the transaction was received to protect the network from spamming attacks where the attacker throws a bunch of transactions into the pending pool in order to ensure that at least one lands in a favorable position.  Miners should still prefer higher tip transactions over those with a lower tip, purely from a selfish mining perspective.
 
 ### Miners Mining Empty Blocks
-It is possible that miners will mine empty blocks until such time as the base fee is very low and then proceed to mine half full blocks and revert to sorting transactions by the inclusion fee.  While this attack is possible, it is not a particularly stable equilibrium as long as mining is decentralized.  Any defector from this strategy will be more profitable than a miner participating in the attack for as long as the attack continues (even after the base fee reached 0).  Since any miner can anonymously defect from a cartel, and there is no way to prove that a particular miner defected, the only feasible way to execute this attack would be to control 50% or more of hashing power.  If an attacker had exactly 50% of hashing power, they would make no money from inclusion fee while defectors would make double the money from inclusion fees.  For an attacker to turn a profit, they need to have some amount over 50% hashing power, which means they can instead execute double spend attacks or simply ignore any other miners which is a far more profitable strategy.
+It is possible that miners will mine empty blocks until such time as the base fee is very low and then proceed to mine half full blocks and revert to sorting transactions by the priority fee.  While this attack is possible, it is not a particularly stable equilibrium as long as mining is decentralized.  Any defector from this strategy will be more profitable than a miner participating in the attack for as long as the attack continues (even after the base fee reached 0).  Since any miner can anonymously defect from a cartel, and there is no way to prove that a particular miner defected, the only feasible way to execute this attack would be to control 50% or more of hashing power.  If an attacker had exactly 50% of hashing power, they would make no money from priority fee while defectors would make double the money from priority fees.  For an attacker to turn a profit, they need to have some amount over 50% hashing power, which means they can instead execute double spend attacks or simply ignore any other miners which is a far more profitable strategy.
 
 Should a miner attempt to execute this attack, we can simply increase the elasticity multiplier (currently 2x) which requires they have even more hashing power available before the attack can even be theoretically profitable against defectors.
 


### PR DESCRIPTION
Feedback suggests that "inclusion fee" may not be immediately obvious since you have to pay the base fee to be included.  The idea with priority fee is "this is the number you need to increase in order to have higher priority over other people trying to transact on Ethereum during times of congestion".