### PR TITLE
EIP2565: Move from 'Last Call' to 'Final'

### DIFF
--- a/EIPS/eip-2565.md
+++ b/EIPS/eip-2565.md
@@ -3,7 +3,7 @@ eip: 2565
 title: ModExp Gas Cost
 author: Kelly Olson (@ineffectualproperty), Sean Gulley (@sean-sn), Simon Peffers (@simonatsn), Justin Drake (@justindrake), Dankrad Feist (@dankrad)
 discussions-to: https://ethereum-magicians.org/t/big-integer-modular-exponentiation-eip-198-gas-cost/4150
-status: Last Call
+status: Final
 review-period-end: 2020-10-09
 type: Standards Track
 category: Core

--- a/EIPS/eip-2565.md
+++ b/EIPS/eip-2565.md
@@ -4,7 +4,6 @@ title: ModExp Gas Cost
 author: Kelly Olson (@ineffectualproperty), Sean Gulley (@sean-sn), Simon Peffers (@simonatsn), Justin Drake (@justindrake), Dankrad Feist (@dankrad)
 discussions-to: https://ethereum-magicians.org/t/big-integer-modular-exponentiation-eip-198-gas-cost/4150
 status: Final
-review-period-end: 2020-10-09
 type: Standards Track
 category: Core
 created: 2020-03-20


### PR DESCRIPTION
Updates the status of EIP2565 after the Berlin hard fork