### PR TITLE
Fix markdown for routes

### DIFF
--- a/EIPS/eip-3091.md
+++ b/EIPS/eip-3091.md
@@ -22,18 +22,16 @@ Currently wallets will link transactions and accounts to block explorers web pag
 Block explorers will route their webpages accordingly for the following data:
 
 ### Blocks
-<BLOCK_EXPORER_URL>/block/<BLOCK_HASH_OR_HEIGHT>
-
+`<BLOCK_EXPORER_URL>/block/<BLOCK_HASH_OR_HEIGHT>`
 
 ### Transactions
-<BLOCK_EXPORER_URL>/tx/<TX_HASH>
+`<BLOCK_EXPORER_URL>/tx/<TX_HASH>`
 
 ### Accounts
-<BLOCK_EXPORER_URL>/address/<ACCOUNT_ADDRESS>
-
+`<BLOCK_EXPORER_URL>/address/<ACCOUNT_ADDRESS>`
 
 ### ERC-20 Tokens
-<BLOCK_EXPORER_URL>/token/<TOKEN_ADDRESS>
+`<BLOCK_EXPORER_URL>/token/<TOKEN_ADDRESS>`
 
 ## Backward Compatibility
 This EIP was designed with existing API routes in mind to reduce disruption. Incompatible block explorers should include either 301 redirects to their existing API routes to match this EIP.


### PR DESCRIPTION
Currently it renders suboptimal like this:

![image](https://user-images.githubusercontent.com/111600/116064822-accee200-a686-11eb-95ad-f1b25374be1a.png)
