### PR TITLE
EIP 721 : Metadata Signature Extension

### DIFF
--- a/EIPS/eip-721.md
+++ b/EIPS/eip-721.md
@@ -1,7 +1,7 @@
 ---
 eip: 721
 title: ERC-721 Non-Fungible Token Standard
-author: William Entriken <github.com@phor.net>, Dieter Shirley <dete@axiomzen.co>, Jacob Evans <jacob@dekz.net>, Nastassia Sachs <nastassia.sachs@protonmail.com>
+author: William Entriken <github.com@phor.net>, Dieter Shirley <dete@axiomzen.co>, Jacob Evans <jacob@dekz.net>, Nastassia Sachs <nastassia.sachs@protonmail.com>, Clay Graham <claytantor@gmail.com>
 discussions-to: https://github.com/ethereum/eips/issues/721
 type: Standards Track
 category: ERC

--- a/EIPS/eip-721.md
+++ b/EIPS/eip-721.md
@@ -212,7 +212,15 @@ This is the "ERC721 Metadata JSON Schema" referenced above.
         "image": {
             "type": "string",
             "description": "A URI pointing to a resource with mime type image/* representing the asset to which this NFT represents. Consider making any images at a width between 320 and 1080 pixels and aspect ratio between 1.91:1 and 4:5 inclusive."
-        }
+        },
+        "md5": {
+            "type": "string",
+            "description": "An md5 has of the entire minified json contents of the metadata (minus the m5 and signature fields) this has must be unique from all other tokens under the contract"
+        },
+        "sig": {
+            "type": "string",
+            "description": "The sha256 RSA siganture of the md5 hash made at time of minting. Requires published public key."
+        },      
     }
 }
 ```


### PR DESCRIPTION
Recently Tim Schneider, from Artnet posted a great story about how a whitehat hacker managed to trick the blockchain into forging tokens that would forge the Provenance of the originator of the NFT to look as though it was the originating artist.

[NFT Theft](https://news.artnet.com/opinion/sleepminting-nftheft-monsieur-personne-1960744)

I have added a proposal outlined in the article [Solving For Sleepminting](https://claytantor.wordpress.com/2021/04/22/solving-for-sleepminting/)

* Add md5 hash
* Metadata must be unique for token
* sha256 sig as base64 field
* Artist must publish public key

