### PR TITLE
Remove gas_target from block structure

### DIFF
--- a/EIPS/eip-1559.md
+++ b/EIPS/eip-1559.md
@@ -155,9 +155,15 @@ ELASTICITY_MULTIPLIER = 2
 
 class World(ABC):
 	def validate_block(self, block: Block) -> None:
+		parent_gas_target = self.parent(block).gas_limit // ELASTICITY_MULTIPLIER
+
+		# On the fork block, don't account for the ELASTICITY_MULTIPLIER to avoid
+		# unduly havling the gas_target. 
+		if INITIAL_FORK_BLOCK_NUMBER == block.number:
+			parent_gas_target = self.parent(block).gas_limit 
+
 		parent_base_fee_per_gas = self.parent(block).base_fee_per_gas
 		parent_gas_used = self.parent(block).gas_used
-		parent_gas_target = self.parent(block).gas_limit // ELASTICITY_MULTIPLIER
 		gas_target = block.gas_limit // ELASTICITY_MULTIPLIER
 		transactions = self.transactions(block)
 

--- a/EIPS/eip-1559.md
+++ b/EIPS/eip-1559.md
@@ -158,14 +158,15 @@ class World(ABC):
 		parent_base_fee_per_gas = self.parent(block).base_fee_per_gas
 		parent_gas_used = self.parent(block).gas_used
 		parent_gas_target = self.parent(block).gas_limit // ELASTICITY_MULTIPLIER
+		gas_target = block.gas_limit // ELASTICITY_MULTIPLIER
 		transactions = self.transactions(block)
 
 		# check if the block used too much gas
 		assert block.gas_used <= block.gas_limit, 'invalid block: too much gas used'
 
 		# check if the block changed the gas target too much
-		assert block.gas_target <= parent_gas_target + parent_gas_target // 1024, 'invalid block: gas target increased too much'
-		assert block.gas_target >= parent_gas_target - parent_gas_target // 1024, 'invalid block: gas target decreased too much'
+		assert gas_target <= parent_gas_target + parent_gas_target // 1024, 'invalid block: gas target increased too much'
+		assert gas_target >= parent_gas_target - parent_gas_target // 1024, 'invalid block: gas target decreased too much'
 
 		# check if the base fee is correct
 		if parent_gas_used == parent_gas_target:

--- a/EIPS/eip-1559.md
+++ b/EIPS/eip-1559.md
@@ -16,7 +16,7 @@ A transaction pricing mechanism that includes fixed-per-block network fee that i
 ## Abstract
 We introduce a new [EIP-2718](./eip-2718.md) transaction type, with the format `0x02 || rlp([chainId, nonce, maxPriorityFeePerGas, maxFeePerGas, gasLimit, to, value, data, access_list, signatureYParity, signatureR, signatureS])`.
 
-There is a base fee per gas in protocol, which can move up or down each block according to a formula which is a function of gas used in parent block and gas target (formerly known as gas limit) of parent block.
+There is a base fee per gas in protocol, which can move up or down each block according to a formula which is a function of gas used in parent block and gas target (block gas limit divided by elasticity multiplier) of parent block.
 The algorithm results in the base fee per gas increasing when blocks are above the gas target, and decreasing when blocks are below the gas target.
 The base fee per gas is burned.
 Transactions specify the maximum fee per gas they are willing to give to miners to incentivize them to include their transaction (aka: priority fee).
@@ -133,7 +133,7 @@ class Block:
 	logs_bloom: int = 0
 	difficulty: int = 0
 	number: int = 0
-	gas_target: int = 0 # note the name change to gas_target from gas_limit
+	gas_limit: int = 0 # note the gas_limit is the gas_target * ELASTICITY_MULTIPLIER
 	gas_used: int = 0
 	timestamp: int = 0
 	extra_data: bytes = bytes()
@@ -157,11 +157,11 @@ class World(ABC):
 	def validate_block(self, block: Block) -> None:
 		parent_base_fee_per_gas = self.parent(block).base_fee_per_gas
 		parent_gas_used = self.parent(block).gas_used
-		parent_gas_target = self.parent(block).gas_target
+		parent_gas_target = self.parent(block).gas_limit // ELASTICITY_MULTIPLIER
 		transactions = self.transactions(block)
 
 		# check if the block used too much gas
-		assert block.gas_used <= block.gas_target * ELASTICITY_MULTIPLIER, 'invalid block: too much gas used'
+		assert block.gas_used <= block.gas_limit, 'invalid block: too much gas used'
 
 		# check if the block changed the gas target too much
 		assert block.gas_target <= parent_gas_target + parent_gas_target // 1024, 'invalid block: gas target increased too much'

--- a/EIPS/eip-1559.md
+++ b/EIPS/eip-1559.md
@@ -158,7 +158,7 @@ class World(ABC):
 		parent_gas_target = self.parent(block).gas_limit // ELASTICITY_MULTIPLIER
 
 		# On the fork block, don't account for the ELASTICITY_MULTIPLIER to avoid
-		# unduly havling the gas_target. 
+		# unduly halving the gas target.
 		if INITIAL_FORK_BLOCK_NUMBER == block.number:
 			parent_gas_target = self.parent(block).gas_limit 
 


### PR DESCRIPTION
Per @karalabe's [document](https://gist.github.com/karalabe/1565e0bc1be6895ad85e2a0116367ba6) and [proposal](https://discord.com/channels/595666850260713488/749160974506000444/839548707859070996), this PR will remove the notion of `gasTarget` in the block structure. It will revert to the current status quo of `gasLimit`. The `gasTarget` will continue to be an integral part of EIP-1559, but it will be computed each block with the formula `gasLimit // ELASTICITY_MULTIPLIER`. On the fork block, the gas target will be interpreted as the parent block's gas limit to avoid unduly halving the gas target.