### PR TITLE
Create EIP-3554 for delaying the difficulty bomb until Shanghai and/or Merge.

### DIFF
--- a/EIPS/eip-3554
+++ b/EIPS/eip-3554
@@ -1,0 +1,59 @@
+---
+eip: 3554
+title: Difficulty Bomb Delay to December 1st 2021
+author: James Hancock (@madeoftin)
+discussions-to: https://github.com/ethereum/EIPs/issues/3554
+type: Standards Track
+category: Core
+status: Draft
+created: 2021-05-06
+---
+
+## Simple Summary
+Delays the difficulty bomb to show effect the first week of December 2021.
+
+## Abstract
+Starting with `FORK_BLOCK_NUMBER` the client will calculate the difficulty based on a fake block number suggesting to the client that the difficulty bomb is adjusting 9,500,000 blocks later than the actual block number.
+
+## Motivation
+Targeting for the Shanghai upgrde and/or the Merge to occur before Decemember 2021. Either the bomb can be readjusted at that time, or removed all together.
+
+## Specification
+#### Relax Difficulty with Fake Block Number
+For the purposes of `calc_difficulty`, simply replace the use of `block.number`, as used in the exponential ice age component, with the formula:
+
+    fake_block_number = max(0, block.number - 9_500_000) if block.number >= FORK_BLOCK_NUMBER else block.number
+
+## Rationale
+
+I choose this amount using the following script; credit @vbuterin with slight modifications by me to make it easier to use. The following predicts a 0.2 second delay to blocktime the first week of december and a 1 second delay by the end of the month. This gives reason to address because the effect will be seen, but not so much urgency we don't have space to work around if needed.
+
+The adjustment is less the usual because the difficulty is so much higher today then previous adjustments.
+
+```
+def predict_diff_bomb_effect(current_blknum, current_difficulty, block_adjustment, months):
+    '''
+    Predicts the effect on block time (as a ratio) in a specificed amount of months in the future.
+    Vars used in last prediction:
+    current_blknum = 12382958
+    current_difficulty = 7393633000000000
+    block adjustment = 9500000
+    months = 5
+    '''
+    blocks_per_month = (86400 * 30) // 13
+    future_blknum = current_blknum + blocks_per_month * months
+    diff_adjustment = 2 ** ((future_blknum - block_adjustment) // 100000 - 2)
+    diff_adjust_coeff = diff_adjustment / current_difficulty * 2048
+    return diff_adjust_coeff 
+
+
+diff_adjust_coeff = predict_diff_bomb_effect(12382958,7393633000000000,9500000,5)
+```
+
+## Backwards Compatibility
+This EIP is not forward compatible and introduces backwards incompatibilities in the difficulty calculation.
+
+## Security Considerations
+Misjudging the effects of the difficulty can mean longer blocktimes than anticpated until hardfork is released. Wild shifts in difficulty can effect this number greatly. Also gradual changes in blocktimes due to longer term adjustments in difficulty can effect the timing of difficulty bomb epochs. This affects useability of the network, but unlikely to have security ramifications.
+
+## Copyright

--- a/EIPS/eip-3554.md
+++ b/EIPS/eip-3554.md
@@ -2,7 +2,7 @@
 eip: 3554
 title: Difficulty Bomb Delay to December 1st 2021
 author: James Hancock (@madeoftin)
-discussions-to: https://github.com/ethereum/EIPs/issues/3554
+discussions-to: https://ethereum-magicians.org/t/eip-3554-ice-age-delay-targeting-december-2021/6188
 type: Standards Track
 category: Core
 status: Draft
@@ -21,14 +21,12 @@ Targeting for the Shanghai upgrde and/or the Merge to occur before Decemember 20
 ## Specification
 #### Relax Difficulty with Fake Block Number
 For the purposes of `calc_difficulty`, simply replace the use of `block.number`, as used in the exponential ice age component, with the formula:
-
+```py
     fake_block_number = max(0, block.number - 9_500_000) if block.number >= FORK_BLOCK_NUMBER else block.number
-
+```
 ## Rationale
 
-I choose this amount using the following script; credit @vbuterin with slight modifications by me to make it easier to use. The following predicts a 0.2 second delay to blocktime the first week of december and a 1 second delay by the end of the month. This gives reason to address because the effect will be seen, but not so much urgency we don't have space to work around if needed.
-
-The adjustment is less the usual because the difficulty is so much higher today then previous adjustments.
+The following script predicts a 0.2 second delay to blocktime the first week of december and a 1 second delay by the end of the month. This gives reason to address because the effect will be seen, but not so much urgency we don't have space to work around if needed.
 
 ```python
 def predict_diff_bomb_effect(current_blknum, current_difficulty, block_adjustment, months):
@@ -51,9 +49,10 @@ diff_adjust_coeff = predict_diff_bomb_effect(12382958,7393633000000000,9500000,5
 ```
 
 ## Backwards Compatibility
-This EIP is not forward compatible and introduces backwards incompatibilities in the difficulty calculation.
+No known backward compatibility issues.
 
 ## Security Considerations
 Misjudging the effects of the difficulty can mean longer blocktimes than anticipated until hardfork is released. Wild shifts in difficulty can effect this number greatly. Also gradual changes in blocktimes due to longer term adjustments in difficulty can effect the timing of difficulty bomb epochs. This affects usability of the network, but unlikely to have security ramifications.
 
 ## Copyright
+Copyright and related rights waived via [CC0]

--- a/EIPS/eip-3554.md
+++ b/EIPS/eip-3554.md
@@ -55,4 +55,4 @@ No known backward compatibility issues.
 Misjudging the effects of the difficulty can mean longer blocktimes than anticipated until a hardfork is released. Wild shifts in difficulty can affect this number severely. Also, gradual changes in blocktimes due to longer-term adjustments in difficulty can affect the timing of difficulty bomb epochs. This affects the usability of the network but unlikely to have security ramifications.
 
 ## Copyright
-Copyright and related rights waived via [CC0]
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/EIPS/eip-3554.md
+++ b/EIPS/eip-3554.md
@@ -52,7 +52,7 @@ diff_adjust_coeff = predict_diff_bomb_effect(12382958,7393633000000000,9500000,5
 No known backward compatibility issues.
 
 ## Security Considerations
-Misjudging the effects of the difficulty can mean longer blocktimes than anticipated until hardfork is released. Wild shifts in difficulty can effect this number greatly. Also gradual changes in blocktimes due to longer term adjustments in difficulty can effect the timing of difficulty bomb epochs. This affects usability of the network, but unlikely to have security ramifications.
+Misjudging the effects of the difficulty can mean longer blocktimes than anticipated until a hardfork is released. Wild shifts in difficulty can affect this number severely. Also, gradual changes in blocktimes due to longer-term adjustments in difficulty can affect the timing of difficulty bomb epochs. This affects the usability of the network but unlikely to have security ramifications.
 
 ## Copyright
 Copyright and related rights waived via [CC0]

--- a/EIPS/eip-3554.md
+++ b/EIPS/eip-3554.md
@@ -33,7 +33,7 @@ The adjustment is less the usual because the difficulty is so much higher today 
 ```
 def predict_diff_bomb_effect(current_blknum, current_difficulty, block_adjustment, months):
     '''
-    Predicts the effect on block time (as a ratio) in a specificed amount of months in the future.
+    Predicts the effect on block time (as a ratio) in a specified amount of months in the future.
     Vars used in last prediction:
     current_blknum = 12382958
     current_difficulty = 7393633000000000
@@ -54,6 +54,6 @@ diff_adjust_coeff = predict_diff_bomb_effect(12382958,7393633000000000,9500000,5
 This EIP is not forward compatible and introduces backwards incompatibilities in the difficulty calculation.
 
 ## Security Considerations
-Misjudging the effects of the difficulty can mean longer blocktimes than anticpated until hardfork is released. Wild shifts in difficulty can effect this number greatly. Also gradual changes in blocktimes due to longer term adjustments in difficulty can effect the timing of difficulty bomb epochs. This affects useability of the network, but unlikely to have security ramifications.
+Misjudging the effects of the difficulty can mean longer blocktimes than anticipated until hardfork is released. Wild shifts in difficulty can effect this number greatly. Also gradual changes in blocktimes due to longer term adjustments in difficulty can effect the timing of difficulty bomb epochs. This affects usability of the network, but unlikely to have security ramifications.
 
 ## Copyright

--- a/EIPS/eip-3554.md
+++ b/EIPS/eip-3554.md
@@ -30,7 +30,7 @@ I choose this amount using the following script; credit @vbuterin with slight mo
 
 The adjustment is less the usual because the difficulty is so much higher today then previous adjustments.
 
-```
+```python
 def predict_diff_bomb_effect(current_blknum, current_difficulty, block_adjustment, months):
     '''
     Predicts the effect on block time (as a ratio) in a specified amount of months in the future.


### PR DESCRIPTION
Targeting 0.1 second effect on the first week of December 2021 with a delay of 9.5 million blocks.