### PR TITLE
Start with default base fee on fork block

### DIFF
--- a/EIPS/eip-1559.md
+++ b/EIPS/eip-1559.md
@@ -139,7 +139,7 @@ class Block:
 	extra_data: bytes = bytes()
 	proof_of_work: int = 0
 	nonce: int = 0
-	base_fee_per_gas: int = 0 # default to 1,000,000,000 for blocks before INITIAL_FORK_BLOCK_NUMBER
+	base_fee_per_gas: int = 0
 
 @dataclass
 class Account:
@@ -149,6 +149,7 @@ class Account:
 	storage_root: int = 0
 	code_hash: int = 0
 
+INITIAL_BASE_FEE = 1000000000
 INITIAL_FORK_BLOCK_NUMBER = 10 # TBD
 BASE_FEE_MAX_CHANGE_DENOMINATOR = 8
 ELASTICITY_MULTIPLIER = 2
@@ -157,7 +158,7 @@ class World(ABC):
 	def validate_block(self, block: Block) -> None:
 		parent_gas_target = self.parent(block).gas_limit // ELASTICITY_MULTIPLIER
 
-		# On the fork block, don't account for the ELASTICITY_MULTIPLIER to avoid
+		# on the fork block, don't account for the ELASTICITY_MULTIPLIER to avoid
 		# unduly halving the gas target.
 		if INITIAL_FORK_BLOCK_NUMBER == block.number:
 			parent_gas_target = self.parent(block).gas_limit 
@@ -175,7 +176,9 @@ class World(ABC):
 		assert gas_target >= parent_gas_target - parent_gas_target // 1024, 'invalid block: gas target decreased too much'
 
 		# check if the base fee is correct
-		if parent_gas_used == parent_gas_target:
+		if INITIAL_FORK_BLOCK_NUMBER == block.number:
+			expected_base_fee_per_gas = INITIAL_BASE_FEE
+		elif parent_gas_used == parent_gas_target:
 			expected_base_fee_per_gas = parent_base_fee_per_gas
 		elif parent_gas_used > parent_gas_target:
 			gas_used_delta = parent_gas_used - parent_gas_target


### PR DESCRIPTION
As discussed on the infrastructure call, we are going to update the spec to align with client implementations. Previously, the spec defined the base fee for all blocks *before* the fork block to be `1_000_000_000`. Clients ended up implementing this as *the fork block* base fee is set to `1_000_000_000`. There is very little difference in the two, and since clients have already implemented the latter, we're just going to make it official via the spec.

It's important to note that while the base fee calculation doesn't require a different interpretation of the parent blocks gas limit, the gas target adjustment does. So before calculating the allowed range in which the gas target can be adjusted, clients should not divide out the `ELASTICITY_PARAMETER`.