### PR TITLE
Update eip-2981.md

### DIFF
--- a/EIPS/eip-2981.md
+++ b/EIPS/eip-2981.md
@@ -1,6 +1,6 @@
 ---
 eip: 2981
-title: ERC-721 Royalty Standard
+title: Royalty Signaling Standard
 author: Zach Burks (@vexycats), James Morgan (@jamesmorgan), Blaine Malone (@blmalone), James Seibel (@seibelj), Paul Ranford (@lenifoti)
 discussions-to: https://github.com/ethereum/EIPs/issues/2907
 status: Draft
@@ -16,14 +16,14 @@ A standardized way to retrieve royalty payment information for ERC-721 tokens to
 
 ## Abstract
 
-This standard complements the [ERC-721 specification](./eip-721.md) by enabling an NFT to signal the royalty amount to be paid to the creator or rights holder every time an NFT is sold or re-sold. This is intended for NFT marketplaces that want to support the ongoing funding of artists and other NFT creators. The royalty payment must be voluntary because transfers do not always imply that a sale occurred and enforcement of royalties during a sale can always be defeated. Marketplaces and individuals implement this standard by retrieving the royalty payment information with `royaltyInfo()`, which specifies how much to pay to which address for a given sale price. The exact mechanism for paying and notifying the recipient will be defined in future EIPs. This ERC should be considered a minimal, gas-efficient building block for further innovation in NFT royalty payments.
+This standard complements the [ERC-721 specification](./eip-721.md) and [ERC-1155 specification](./eip-1155.md) by enabling an NFT to signal the royalty amount to be paid to the creator or rights holder every time an NFT is sold or re-sold. This is intended for NFT marketplaces that want to support the ongoing funding of artists and other NFT creators. The royalty payment must be voluntary because transfers do not always imply that a sale occurred and enforcement of royalties during a sale can always be defeated. Marketplaces and individuals implement this standard by retrieving the royalty payment information with `royaltyInfo()`, which specifies how much to pay to which address for a given sale price. The exact mechanism for paying and notifying the recipient will be defined in future EIPs. This ERC should be considered a minimal, gas-efficient building block for further innovation in NFT royalty payments.
 
 ## Motivation
 There are many marketplaces for NFTs with multiple unique royalty payment implementations that are not easily compatible or usable by other marketplaces. Just like the early days of ERC-20 tokens, ERC-721 marketplace smart contracts are varied by ecosystem and not standardized. This EIP enables all marketplaces to retrieve royalty payment information that NFT creators specify and are entitled to, enabling accurate royalty payments regardless of which marketplace the NFT is sold or re-sold at.
 
 Many of the largest ERC-721 marketplaces have implemented royalty payments that are incompatible with other platforms and therefore make it much harder to enforce when the NFT is sold on another marketplace, not fulfilling the potential of any implemented royalty system. This standard implements standardized royalty information retrieval that can be accepted across any type of NFT marketplace. This minimalist proposal leaves the actual funds transfer up to the marketplace itself, and only provides a mechanism to fetch the royalty amounts. Future EIPs may build on this ERC to implement payment notifications and other features.
 
-This standard is intended as a complement to the [ERC-721 specification](./eip-721.md), allowing the NFT creator or rights holder to signal the royalty amount to be paid every time an NFT is sold and re-sold. If a marketplace chooses *not* to implement this EIP, then obviously no funds are paid for secondary sales. But as most NFT marketplaces have developed some unique royalty system themselves - and all of them are singular and only work within their own contracts - there should be an accepted standard for royalty payment information (if the creator chooses to set royalties on their NFTs). We believe the NFT marketplace ecosystem will voluntarily implement royalty payments to provide ongoing funding for artists and other creators, and NFT buyers will assess the royalty payment as a factor when making NFT purchasing decisions.
+This standard is intended as a complement to the [ERC-721 specification](./eip-721.md) and [ERC-1155 specification](./eip-1155.md), allowing the NFT creator or rights holder to signal the royalty amount to be paid every time an NFT is sold and re-sold. If a marketplace chooses *not* to implement this EIP, then obviously no funds are paid for secondary sales. But as most NFT marketplaces have developed some unique royalty system themselves - and all of them are singular and only work within their own contracts - there should be an accepted standard for royalty payment information (if the creator chooses to set royalties on their NFTs). We believe the NFT marketplace ecosystem will voluntarily implement royalty payments to provide ongoing funding for artists and other creators, and NFT buyers will assess the royalty payment as a factor when making NFT purchasing decisions.
 
 Without an agreed royalty payment standard, the NFT ecosystem will lack an effective means to collect royalties across all marketplaces and artists and other creators will not receive ongoing funding. This will hamper the growth and adoption of NFTs and demotivate artists and other NFT creators from minting new and innovative tokens.
 
@@ -63,7 +63,7 @@ interface IERC2981 is ERC165 {
     ///
     /// bytes4(keccak256("royaltyInfo(uint256,uint256,bytes)")) == 0x6057361d
     /// bytes4 private constant _INTERFACE_ID_ERC2981 = 0x6057361d;
-    /// _registerInterface(_INTERFACE_ID_ERC29781);
+    /// _registerInterface(_INTERFACE_ID_ERC2981);
 
     /// @notice Called with the sale price to determine how much royalty
     //          is owed and to whom.
@@ -143,11 +143,11 @@ This EIP mandates the inclusion of the `_data` parameter and the `_royaltyPaymen
 
 ## Backwards Compatibility
 
-This standard must implement ERC-165 to allow introspection, but it does not rely on, or extend, any other existing standard. However, there are already proprietary methods for royalty management used by existing marketplaces, so it will require additional re-work on the part of marketplaces.
+There are already proprietary methods for royalty management used by existing marketplaces, so supporting this standard will require additional re-work on the part of marketplaces.
 
 Existing NFTs that do not support this standard will have to continue to rely on non-standard methods if they are to receive royalties.
 
-Marketplaces will need to use ERC-165 introspection to check whether NFTs support the ERC-2981 interface and revert to their proprietary methods if they do not.
+Contracts that support this standard must implement ERC-165 to allow introspection. Marketplaces will need to use ERC-165 introspection to check whether NFTs support the ERC-2981 interface, and revert to their proprietary methods (where possible) if they do not.
 
 ## Security Considerations
 

--- a/EIPS/eip-2981.md
+++ b/EIPS/eip-2981.md
@@ -1,7 +1,7 @@
 ---
 eip: 2981
 title: ERC-721 Royalty Standard
-author: Zach Burks (@vexycats), James Morgan (@jamesmorgan), Blaine Malone (@blmalone), James Seibel (@seibelj)
+author: Zach Burks (@vexycats), James Morgan (@jamesmorgan), Blaine Malone (@blmalone), James Seibel (@seibelj), Paul Ranford (@lenifoti)
 discussions-to: https://github.com/ethereum/EIPs/issues/2907
 status: Draft
 type: Standards Track
@@ -16,20 +16,22 @@ A standardized way to retrieve royalty payment information for ERC-721 tokens to
 
 ## Abstract
 
-This standard extends the [ERC-721 specification](./eip-721.md) to enable setting a royalty amount paid to the NFT creator or rights holder every time an NFT is sold and re-sold. This is intended for NFT marketplaces that want to support the ongoing funding of artists and other NFT creators. The royalty payment must be voluntary as required by the EIP-721 standard, as `transferFrom()` includes NFT transfers between wallets, and executing `transferFrom()` does not always imply a sale occurred. Marketplaces and individuals implement this standard by retrieving the royalty payment information with `royaltyInfo()`, which specifies how much to pay to which address for a given sale price. The exact mechanism for paying and notifying the recipient will be defined in future EIPs. This ERC should be considered a minimal, gas-efficient building block for further innovation in NFT royalty payments.
+This standard complements the [ERC-721 specification](./eip-721.md) by enabling an NFT to signal the royalty amount to be paid to the creator or rights holder every time an NFT is sold or re-sold. This is intended for NFT marketplaces that want to support the ongoing funding of artists and other NFT creators. The royalty payment must be voluntary because transfers do not always imply that a sale occurred and enforcement of royalties during a sale can always be defeated. Marketplaces and individuals implement this standard by retrieving the royalty payment information with `royaltyInfo()`, which specifies how much to pay to which address for a given sale price. The exact mechanism for paying and notifying the recipient will be defined in future EIPs. This ERC should be considered a minimal, gas-efficient building block for further innovation in NFT royalty payments.
 
 ## Motivation
 There are many marketplaces for NFTs with multiple unique royalty payment implementations that are not easily compatible or usable by other marketplaces. Just like the early days of ERC-20 tokens, ERC-721 marketplace smart contracts are varied by ecosystem and not standardized. This EIP enables all marketplaces to retrieve royalty payment information that NFT creators specify and are entitled to, enabling accurate royalty payments regardless of which marketplace the NFT is sold or re-sold at.
 
 Many of the largest ERC-721 marketplaces have implemented royalty payments that are incompatible with other platforms and therefore make it much harder to enforce when the NFT is sold on another marketplace, not fulfilling the potential of any implemented royalty system. This standard implements standardized royalty information retrieval that can be accepted across any type of NFT marketplace. This minimalist proposal leaves the actual funds transfer up to the marketplace itself, and only provides a mechanism to fetch the royalty amounts. Future EIPs may build on this ERC to implement payment notifications and other features.
 
-This standard extends the [ERC-721 specification](./eip-721.md) to enable setting a royalty amount paid to the NFT creator or rights holder every time an NFT is sold and re-sold. If a marketplace chooses *not* to implement this EIP, then obviously no funds are paid for secondary sales. But as most NFT marketplaces have developed some unique royalty system themselves - and all of them are singular and only work within their own contracts - there should be an accepted standard for royalty payment information (if the creator chooses to set royalties on their NFTs). We believe the NFT marketplace ecosystem will voluntarily implement royalty payments to provide ongoing funding for artists and other creators, and NFT buyers will assess the royalty payment as a factor when making NFT purchasing decisions.
+This standard is intended as a complement to the [ERC-721 specification](./eip-721.md), allowing the NFT creator or rights holder to signal the royalty amount to be paid every time an NFT is sold and re-sold. If a marketplace chooses *not* to implement this EIP, then obviously no funds are paid for secondary sales. But as most NFT marketplaces have developed some unique royalty system themselves - and all of them are singular and only work within their own contracts - there should be an accepted standard for royalty payment information (if the creator chooses to set royalties on their NFTs). We believe the NFT marketplace ecosystem will voluntarily implement royalty payments to provide ongoing funding for artists and other creators, and NFT buyers will assess the royalty payment as a factor when making NFT purchasing decisions.
 
 Without an agreed royalty payment standard, the NFT ecosystem will lack an effective means to collect royalties across all marketplaces and artists and other creators will not receive ongoing funding. This will hamper the growth and adoption of NFTs and demotivate artists and other NFT creators from minting new and innovative tokens.
 
 *"Yes we have royalties, but if your NFT is sold on another marketplace, we cannot provide royalties" ... "But can't I sell my NFT anywhere with a click of my wallet?" ... "Yes... but we don't have a standard for royalties so you'll lose out."*
 
 This EIP fixes this issue, enabling all NFT marketplaces to unify on a single royalty payment information standard and benefiting the entire NFT ecosystem.
+
+While, ERC721 NFTs are the primary use case at this time, we envision that the functionality can be applied to all extensions to ERC721 and other contract interfaces that wish to derive royalties in this way. 
 
 ## Specification
 
@@ -41,6 +43,8 @@ RFC 2119.
 **ERC-721 compliant contracts MAY implement this ERC for royalties to provide a standard method of specifying royalty payment information.**
 
 Marketplaces that support this standard **SHOULD** implement some method of transferring royalties to the royalty recipient. Standards for the actual transfer and notification of funds will be specified in future EIPs.
+
+Marketplaces that support this standard **MUST NOT** pay royalties to NFTs that return data in `_royaltyPaymentData` uinless they also support an extension EIP that defines the semantics of this data.
 
 Implementers of this standard **MUST NOT** use the `_data` parameter and `_royaltyPaymentData` return value. These are intended for future EIPs that extend this ERC with additional features.
 
@@ -58,8 +62,8 @@ interface IERC2981 is ERC165 {
     /// implementing this standard
     ///
     /// bytes4(keccak256("royaltyInfo(uint256,uint256,bytes)")) == 0x6057361d
-    /// bytes4 private constant _INTERFACE_ID_ERC721ROYALTIES = 0x6057361d;
-    /// _registerInterface(_INTERFACE_ID_ERC721ROYALTIES);
+    /// bytes4 private constant _INTERFACE_ID_ERC2981 = 0x6057361d;
+    /// _registerInterface(_INTERFACE_ID_ERC29781);
 
     /// @notice Called with the sale price to determine how much royalty
     //          is owed and to whom.
@@ -76,11 +80,11 @@ interface IERC2981 is ERC165 {
     function royaltyInfo(uint256 _tokenId, uint256 _value, bytes calldata _data) external returns (address _receiver, uint256 _royaltyAmount, bytes memory _royaltyPaymentData);
 
     /// @notice Informs callers that this ERC721 supports ERC2981
-    /// @dev If `_registerInterface(_INTERFACE_ID_ERC721ROYALTIES)` is called
+    /// @dev If `_registerInterface(_INTERFACE_ID_ERC2981)` is called
     ///      in the initializer, this should be automatic
     /// @param interfaceID The interface identifier, as specified in ERC-165
     /// @return `true` if the contract implements
-    ///         `_INTERFACE_ID_ERC721ROYALTIES` and `false` otherwise
+    ///         `_INTERFACE_ID_ERC2981` and `false` otherwise
     function supportsInterface(bytes4 interfaceID) external view returns (bool);
 }
 
@@ -102,7 +106,7 @@ constructor (string memory name, string memory symbol, string memory baseURI)  p
         _registerInterface(_INTERFACE_ID_ERC721_METADATA);
         _registerInterface(_INTERFACE_ID_ERC721_ENUMERABLE);
         // Royalties interface 
-        _registerInterface(_INTERFACE_ID_ERC721ROYALTIES);
+        _registerInterface(_INTERFACE_ID_ERC2981);
     }
 ```
 
@@ -131,7 +135,7 @@ This EIP does not specify the manner of payment to the royalty recipient. Furthe
 
 This EIP does not specify how the `_royaltyAmount` is calculated from the sale price `_value`. Many NFT contracts may follow a fixed-percentage royalty that is the same regardless of price. However, EIP-2981 implementers may choose whatever logic they want to calculate the `_royaltyAmount` - this EIP does not mandate a fixed-percentage fee model.
 
-Additionally, we return a specific `_royaltyAmount` so there is no dispute with a marketplace over how much is owed for a given sale price.
+Additionally, we return a specific `_royaltyAmount`, which must be paid in the same token the sale (`_value`), so there is no dispute with a marketplace over how much is owed for a given sale price.
 
 ### Unused data parameters in function signature
 
@@ -139,7 +143,11 @@ This EIP mandates the inclusion of the `_data` parameter and the `_royaltyPaymen
 
 ## Backwards Compatibility
 
-This standard is completely compatible with current ERC-721 standards - in fact it requires it.
+This standard must implement ERC-165 to allow introspection, but it does not rely on, or extend, any other existing standard. However, there are already proprietary methods for royalty management used by existing marketplaces, so it will require additional re-work on the part of marketplaces.
+
+Existing NFTs that do not support this standard will have to continue to rely on non-standard methods if they are to receive royalties.
+
+Marketplaces will need to use ERC-165 introspection to check whether NFTs support the ERC-2981 interface and revert to their proprietary methods if they do not.
 
 ## Security Considerations
 


### PR DESCRIPTION
Proposed changes:
Remove/modify statements that imply that this is an extension of ERC-721.  There is no hard dependency.
Add a note to the effect that it is not exclusive to ERC-721.
Add requirement that marketplaces should not accept royalty amounts where the NFT uses the extra data, unless they are operating under an extended EIP.
Rename _INTERFACE_ID_ERC721ROYALTIES to _INTERFACE_ID_ERC2981, per the pattern used by ERC721.
Extra wording around the unenforcability of royalties to stress that even enforcing in code can be defeated.
Re-write the backward compatibility section.  I think this predated our cut-down version and there are no backward compatibility concerns other than 
- existing NFTs obviously cannot take advantage of it and 
- marketplaces will need to accommodate this EIP in addition to their current strategies.

When opening a pull request to submit a new EIP, please use the suggested template: https://github.com/ethereum/EIPs/blob/master/eip-template.md

We have a GitHub bot that automatically merges some PRs. It will merge yours immediately if certain criteria are met:

 - The PR edits only existing draft PRs.
 - The build passes.
 - Your GitHub username or email address is listed in the 'author' header of all affected PRs, inside <triangular brackets>.
 - If matching on email address, the email address is the one publicly listed on your GitHub profile.
