### PR TITLE
EIP1559: import original min gas limit

### DIFF
--- a/EIPS/eip-1559.md
+++ b/EIPS/eip-1559.md
@@ -176,6 +176,9 @@ class World(ABC):
 		assert block.gas_limit < parent_gas_limit + parent_gas_limit // 1024, 'invalid block: gas limit increased too much'
 		assert block.gas_limit > parent_gas_limit - parent_gas_limit // 1024, 'invalid block: gas limit decreased too much'
 
+		# check if the gas limit is at least the minimum gas limit
+		assert block.gas_limit >= 5000
+
 		# check if the base fee is correct
 		if INITIAL_FORK_BLOCK_NUMBER == block.number:
 			expected_base_fee_per_gas = INITIAL_BASE_FEE


### PR DESCRIPTION
Current spec seems to indicate we remove the min gas limit (see Yellow Paper reference):

![Screenshot from 2021-05-08 15-26-22](https://user-images.githubusercontent.com/29359032/117542881-c3782000-b01a-11eb-96a1-f9830f01155a.png)

This PR fixes this as removing the min gas limit is not desired.