### PR TITLE
EIP3561: Trust Minimized Upgradeability Proxy

### DIFF
--- a/EIPS/eip-3561.md
+++ b/EIPS/eip-3561.md
@@ -25,41 +25,48 @@ Extinction is more likely with closed internet borders. As long as internet has 
 ## Specification
 
 The specification is an addition to standard EIP-1967 transparent proxy design. EIP-1967 standard slots can be found here https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1967.md standard EIP-1967 
-The specification focuses on the slots it adds. All admin interactions with trust minimized proxy must emit an event to make admin actions trackable.
+The specification focuses on the slots it adds. All admin interactions with trust minimized proxy must emit an event to make admin actions trackable, and all admin actions must be guarded with `onlyAdmin()` modifier.
 
 ### Next Logic Contract Address
 Storage slot `0xe8c186b11a4be12af079b0a5c235146db6f3615b2a8b1b47f9bfe3a956337ef9` (obtained as `bytes32(uint256(keccak256('eip3561.proxy.next_implementation')) - 1)`).
 Logic address must be first defined as next logic, before it can function as actual logic implementation stored in EIP-1967 `IMPLEMENTATION_SLOT`.
-Next logic contract address is set by `proposeToAndCall(address implementation, bytes calldata data)` method. It can then be upgraded to or in case of a bug or any other reason canceled by `cancelUpgrade()`. Cancelling is possible for as long as `upgrade()` is not called.
-Changes to this slot must be notified with:
+Admin interactions with next logic contract address correspond with these methods and events:
 ```solidity
-event NextLogicDefined(address indexed nextLogic, uint earliestArrivalBlock);
+function proposeToAndCall(address implementation, bytes calldata data) external onlyAdmin; // sets next logic contract address and initializes. Emits NextLogicDefined. 0x as calldata is an equivalent of proposeTo()
+event NextLogicDefined(address indexed nextLogic, uint earliestArrivalBlock); // important to have
+function upgrade() external onlyAdmin; // sets the address stored as next implementation as current IMPLEMENTATION_SLOT after UPGRADE_BLOCK_SLOT allows
+function cancelUpgrade() external onlyAdmin; // in case of a bug or any other reason. Cancelling is possible for as long as upgrade() for given next logic was not called. Emits NextLogicCanceled
+event NextLogicCanceled(address indexed oldLogic); // important to have
 ```
 
 ### Upgrade Block
 Storage slot `0xd366e20ef9f21888e3d225d6a18f0bceb0ce0008a1e881be9a0467a0293afc96` (obtained as `bytes32(uint256(keccak256('eip3561.proxy.upgrade_block')) - 1)`).
-On/after this block by calling `upgrade()` method next logic contract address can be set to EIP-1967 `IMPLEMENTATION_SLOT` or, in other words, start to function as current logic. Updated automatically and is shown as `earliestArrivalBlock` in the event `NextLogicDefined`.
+On/after this block next logic contract address can be set to EIP-1967 `IMPLEMENTATION_SLOT` or, in other words, start to function as current logic. Updated automatically and is shown as `earliestArrivalBlock` in the event `NextLogicDefined`.
 
 ### Propose Block
 Storage slot `0x1e166c9744902ecbb9f589bbc9e7da5f078e553ad162c2ee62c71827916db75f` (obtained as `bytes32(uint256(keccak256('eip3561.proxy.propose_block')) - 1)`).
-Defines after/on which block *proposing* next logic is possible. Required for convenience, for example can be manually set to a year from given time by `prolongLock(uint n)`, so that the users can have peace of mind during the year. Can be set to maximum number to completely seal the code.
-Changes to this slot must be notified with:
+Defines after/on which block *proposing* next logic is possible. Required for convenience, for example can be manually set to a year from given time, so that the users can have peace of mind during the year. Can be set to maximum number to completely seal the code.
+Admin interactions with this slot correspond with this method and event:
 ```solidity
+function prolongLock(uint n) external onlyAdmin;
 event UpgradesRestrictedUntil(uint block);
 ```
 
 ### Deadline Block
 Storage slot `0x560a0645803da084600e483b1076fd54059fdee9045033b88b51d342faf2b2af` (obtained as `bytes32(uint256(keccak256('eip3561.proxy.deadline')) - 1)`).
 Defines after/on which block it becomes impossible to upgrade the contract, can be set in constructor if used or can be set many times as long as next value is lower than previous. Required in case of probability that the project development can be compromised, unlike `PROPOSE_BLOCK_SLOT`, deadline is less likely to require any urgent transaction like `PROPOSE_BLOCK_SLOT`.
-Changes to this slot should be notified with:
+Admin interactions with this slot should correspond with this method and event:
 ```solidity
+function setDeadline(uint block) external onlyAdmin;
 event DeadlineSet(uint block);
 ```
 
 ### "Trust_minimized" Boolean
 Storage slot `0x17dc395ab915c140774b2c05da17fd5b71a2d193e53bc9732d6b62d419a46635` (obtained as `bytes32(uint256(keccak256('eip3561.proxy.trust_minimized')) - 1)`).
-False by default and can only ever be set true by `removeTrust()` method. While it is false, then the proxy operates exactly as standard EIP-1967 transparent proxy, which allows to correct potential mistakes of first deployment. After set to true, all above specification becomes active.
+False by default and can only ever be set true. While it is false, then the proxy operates exactly as standard EIP-1967 transparent proxy, which allows to correct potential mistakes of first deployment. After set to true, all above specification becomes active.
+Admin interactions with this slot should correspond with this method and event:
 ```solidity
+function removeTrust() external onlyAdmin;
 event TrustRemoved();
 ```
 
@@ -69,7 +76,6 @@ An argument "just don't make such contracts upgadeable at all" fails when it com
 A proxy is easily abusable by anonymous soulless scammers without a time delay before an actual upgrade(change of current implementation address) goes live. A time delay is probably unavoidable, even if it means that inexperienced developers might not have confidence using it. Albeit this is a downside of this EIP, it's a critically important option to have in smart contract development today.
 
 Propose block adds to convenience if used, so should be kept. Deadline block, while can be omitted, can be critically important for some projects, it would be reasonable to rather keep it too. Unless developers always write correct automatic deployment scripts, trustless boolean is required from my own experience, because I once failed to execute 15 deployment steps correctly.
-
 
 ## Implementation
 The following implementation is an example which lacks trustless boolean slot and uses `NEXT_LOGIC_BLOCK_SLOT` instead of `UPGRADE_BLOCK_SLOT` to get farther slot value: [Aletheo repository](https://github.com/SamPorter1984/Aletheo/blob/e06e1b7229c099e4a834c032b9ee91e870ac5c32/contracts/TrustMinimizedProxy.sol).

--- a/EIPS/eip-3561.md
+++ b/EIPS/eip-3561.md
@@ -18,7 +18,7 @@ Removing trust from upgradeability proxy is required for anonymous developers. T
 ## Motivation
 It's usually not possible for anonymous developers who use upgradeability proxies to gain community trust.
 
-Fairer, better future for humanity absolutely requires some developers to stay anonymous while still attract vital attention to solutions they propose and at the same time leverage the benefits of possible upgradeability. For example, project like cap.finance allows to trade stocks and securities on the blockchain in a purely decentralized way making the developers of such projects potentially risking their freedom. Aletheo was born to fight advancing day by day surveillance and tools of control in Russia and China, so as I am Russian, you can count me as dead(I have to state this just in case).
+Fairer, better future for humanity absolutely requires some developers to stay anonymous while still attract vital attention to solutions they propose and at the same time leverage the benefits of possible upgradeability. For example, a project like Collateralized Asset Protocol allows to trade stocks and securities on the blockchain in a purely decentralized way making the developers of such projects potentially risking their freedom. Aletheo was born to fight advancing day by day surveillance and tools of control in Russia and China, so as I am Russian, you can count me as dead(I have to state this just in case).
 
 Extinction is more likely with closed internet borders. As long as internet has eyes everywhere, devastating conventional warfare is less likely to happen regardless of power vacuum or exponential increase in existential threats.
 
@@ -28,11 +28,11 @@ All admin interactions with trust minimized proxy must emit an event to make adm
 
 ### Logic contract address
 
-`NEXT_IMPLEMENTATION_SLOT` stores the address of next logic to be implemented by `proposeTo(address implementation)` method.
+`NEXT_IMPLEMENTATION_SLOT` stores the address of next logic to be implemented. Set by `proposeToAndCall(address implementation, bytes calldata data)` method.
 
 ### Upgrade Block
 
-`UPGRADE_BLOCK_SLOT` on/after this block, address stored in `NEXT_IMPLEMENTATION_SLOT` can be set to active `IMPLEMENTATION_SLOT` by `upgrade()` method.
+`UPGRADE_BLOCK_SLOT`. On/after this block address stored in `NEXT_IMPLEMENTATION_SLOT` can be set to active `IMPLEMENTATION_SLOT` by `upgrade()` method.
 
 ### Propose Block
 
@@ -47,13 +47,13 @@ All admin interactions with trust minimized proxy must emit an event to make adm
 ## Rationale
 An argument "just don't make such contracts upgadeable at all" fails when it comes to complex systems. It might be impossible to model complex systems right on first try.
 
-If we leave room for human error, it might not be possible to disallow exploits by soulless anonymous scammers. Therefore a time delay before an actual upgrade(change of current implementation address) goes live is probably unavoidable, even if it means that inexperienced developers might not have confidence using it. Albeit this is a downside of this EIP, it's a critically important option to have in smart contract development today.
+The proxy still can be abusable by anonymous soulless scammers without a time delay before an actual upgrade(change of current implementation address) goes live. A time delay is probably unavoidable, even if it means that inexperienced developers might not have confidence using it. Albeit this is a downside of this EIP, it's a critically important option to have in smart contract development today.
 
 Propose block adds to convenience if used, so should be kept. Deadline block, while can be omitted, can be critically important for some projects, it would be reasonable to rather keep it too. Unless developers always write correct automatic deployment scripts, trustless boolean is required from my own experience, because I once failed to execute 15 deployment steps correctly.
 
 
 ## Implementation
-The following implementation is an example which lacks trustless boolean slot and uses `NEXT_LOGIC_BLOCK_SLOT` instead of `UPGRADE_BLOCK_SLOT`: [Aletheo repository](https://github.com/SamPorter1984/Aletheo/blob/e52a19fd4f012a3ec2edadf112c9fc6b5ff843e0/contracts/TrustMinimizedProxy.sol).
+The following implementation is an example which lacks trustless boolean slot and uses `NEXT_LOGIC_BLOCK_SLOT` instead of `UPGRADE_BLOCK_SLOT`: [Aletheo repository](https://github.com/SamPorter1984/Aletheo/blob/e06e1b7229c099e4a834c032b9ee91e870ac5c32/contracts/TrustMinimizedProxy.sol).
 
 ## Copyright
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/EIPS/eip-3561.md
+++ b/EIPS/eip-3561.md
@@ -10,7 +10,7 @@ created: 2021-05-09
 ---
 
 ## Simple Summary
-Additional storage slots to decrease trust in interaction with upgradeable smart contracts.
+Additional storage slots for upgradeability proxy to decrease trust in interaction with upgradeable smart contracts.
 
 ## Abstract
 Removing trust from upgradeability proxy is required for anonymous developers. To achieve that, disallowing sudden, potentially malicious upgrades is required. This EIP introduces a time lock, a period of one month, before defined by proxy admin implementation becomes active implementation.
@@ -24,36 +24,55 @@ Extinction is more likely with closed internet borders. As long as internet has 
 
 ## Specification
 
-All admin interactions with trust minimized proxy must emit an event to make admin actions trackable. 
+The specification is an addition to standard EIP-1967 transparent proxy design. EIP-1967 standard slots can be found here https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1967.md standard EIP-1967 
+The specification focuses on the slots it adds. All admin interactions with trust minimized proxy must emit an event to make admin actions trackable.
 
-### Logic contract address
-
-`NEXT_IMPLEMENTATION_SLOT` stores the address of next logic to be implemented. Set by `proposeToAndCall(address implementation, bytes calldata data)` method.
+### Next Logic Contract Address
+Storage slot `0xe8c186b11a4be12af079b0a5c235146db6f3615b2a8b1b47f9bfe3a956337ef9` (obtained as `bytes32(uint256(keccak256('eip3561.proxy.next_implementation')) - 1)`).
+Logic address must be first defined as next logic, before it can function as actual logic implementation stored in EIP-1967 `IMPLEMENTATION_SLOT`.
+Next logic contract address is set by `proposeToAndCall(address implementation, bytes calldata data)` method. It can then be upgraded to or in case of a bug or any other reason canceled by `cancelUpgrade()`. Cancelling is possible for as long as `upgrade()` is not called.
+Changes to this slot must be notified with:
+```solidity
+event NextLogicDefined(address indexed nextLogic, uint earliestArrivalBlock);
+```
 
 ### Upgrade Block
-
-`UPGRADE_BLOCK_SLOT`. On/after this block address stored in `NEXT_IMPLEMENTATION_SLOT` can be set to active `IMPLEMENTATION_SLOT` by `upgrade()` method.
+Storage slot `0xd366e20ef9f21888e3d225d6a18f0bceb0ce0008a1e881be9a0467a0293afc96` (obtained as `bytes32(uint256(keccak256('eip3561.proxy.upgrade_block')) - 1)`).
+On/after this block by calling `upgrade()` method next logic contract address can be set to EIP-1967 `IMPLEMENTATION_SLOT` or, in other words, start to function as current logic. Updated automatically and is shown as `earliestArrivalBlock` in the event `NextLogicDefined`.
 
 ### Propose Block
-
-`PROPOSE_BLOCK_SLOT` defines after/on which block *proposing* next logic is possible. Required for convenience, for example can be manually set to a year from given time by `prolongLock(uint n)`, so that investors can have peace of mind during the year. Can be set to maximum number to completely seal the code.
+Storage slot `0x1e166c9744902ecbb9f589bbc9e7da5f078e553ad162c2ee62c71827916db75f` (obtained as `bytes32(uint256(keccak256('eip3561.proxy.propose_block')) - 1)`).
+Defines after/on which block *proposing* next logic is possible. Required for convenience, for example can be manually set to a year from given time by `prolongLock(uint n)`, so that the users can have peace of mind during the year. Can be set to maximum number to completely seal the code.
+Changes to this slot must be notified with:
+```solidity
+event UpgradesRestrictedUntil(uint block);
+```
 
 ### Deadline Block
-`DEADLINE_BLOCK_SLOT` is a block after which it becomes impossible to upgrade the contract, can be set in constructor if used. Required in case of probability that the project development can be compromised, unlike `PROPOSE_BLOCK_SLOT`, deadline is set once in constructor or can be set many times as long as next value is lower than previous, deadline is less likely to require any urgent transaction like `PROPOSE_BLOCK_SLOT`.
+Storage slot `0x560a0645803da084600e483b1076fd54059fdee9045033b88b51d342faf2b2af` (obtained as `bytes32(uint256(keccak256('eip3561.proxy.deadline')) - 1)`).
+Defines after/on which block it becomes impossible to upgrade the contract, can be set in constructor if used or can be set many times as long as next value is lower than previous. Required in case of probability that the project development can be compromised, unlike `PROPOSE_BLOCK_SLOT`, deadline is less likely to require any urgent transaction like `PROPOSE_BLOCK_SLOT`.
+Changes to this slot should be notified with:
+```solidity
+event DeadlineSet(uint block);
+```
 
-### Trustless Boolean
-`TRUSTLESS_SLOT` is a boolean that is false by default and can only ever be set true by `removeTrust()` method. While setting up the contracts and implementations for the first time, it can be an important option to counter human error.
+### "Trust_minimized" Boolean
+Storage slot `0x17dc395ab915c140774b2c05da17fd5b71a2d193e53bc9732d6b62d419a46635` (obtained as `bytes32(uint256(keccak256('eip3561.proxy.trust_minimized')) - 1)`).
+False by default and can only ever be set true by `removeTrust()` method. While it is false, then the proxy operates exactly as standard EIP-1967 transparent proxy, which allows to correct potential mistakes of first deployment. After set to true, all above specification becomes active.
+```solidity
+event TrustRemoved();
+```
 
 ## Rationale
 An argument "just don't make such contracts upgadeable at all" fails when it comes to complex systems. It might be impossible to model complex systems right on first try.
 
-The proxy still can be abusable by anonymous soulless scammers without a time delay before an actual upgrade(change of current implementation address) goes live. A time delay is probably unavoidable, even if it means that inexperienced developers might not have confidence using it. Albeit this is a downside of this EIP, it's a critically important option to have in smart contract development today.
+A proxy is easily abusable by anonymous soulless scammers without a time delay before an actual upgrade(change of current implementation address) goes live. A time delay is probably unavoidable, even if it means that inexperienced developers might not have confidence using it. Albeit this is a downside of this EIP, it's a critically important option to have in smart contract development today.
 
 Propose block adds to convenience if used, so should be kept. Deadline block, while can be omitted, can be critically important for some projects, it would be reasonable to rather keep it too. Unless developers always write correct automatic deployment scripts, trustless boolean is required from my own experience, because I once failed to execute 15 deployment steps correctly.
 
 
 ## Implementation
-The following implementation is an example which lacks trustless boolean slot and uses `NEXT_LOGIC_BLOCK_SLOT` instead of `UPGRADE_BLOCK_SLOT`: [Aletheo repository](https://github.com/SamPorter1984/Aletheo/blob/e06e1b7229c099e4a834c032b9ee91e870ac5c32/contracts/TrustMinimizedProxy.sol).
+The following implementation is an example which lacks trustless boolean slot and uses `NEXT_LOGIC_BLOCK_SLOT` instead of `UPGRADE_BLOCK_SLOT` to get farther slot value: [Aletheo repository](https://github.com/SamPorter1984/Aletheo/blob/e06e1b7229c099e4a834c032b9ee91e870ac5c32/contracts/TrustMinimizedProxy.sol).
 
 ## Copyright
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/EIPS/eip-3561.md
+++ b/EIPS/eip-3561.md
@@ -18,7 +18,7 @@ Removing trust from upgradeability proxy is required for anonymous developers. T
 ## Motivation
 It's usually not possible for anonymous developers who use upgradeability proxies to gain community trust.
 
-Fairer, better future for humanity absolutely requires some developers to stay anonymous while still attract vital attention to solutions they propose and at the same time leverage the benefits of possible upgradeability. Some developers could be risking their freedom or life. Aletheo was born to fight advancing day by day surveillance and tools of control in Russia and China, so as I am Russian, you can count me as dead(I have to state this just in case).
+Fairer, better future for humanity absolutely requires some developers to stay anonymous while still attract vital attention to solutions they propose and at the same time leverage the benefits of possible upgradeability. For example, project like cap.finance allows to trade stocks and securities on the blockchain in a purely decentralized way making the developers of such projects potentially risking their freedom. Aletheo was born to fight advancing day by day surveillance and tools of control in Russia and China, so as I am Russian, you can count me as dead(I have to state this just in case).
 
 ## Specification
 

--- a/EIPS/eip-3561.md
+++ b/EIPS/eip-3561.md
@@ -1,7 +1,7 @@
 ---
 eip: 3561
 title: Trust Minimized Upgradeability Proxy
-author: <@SamPorter1984>
+author: Sam Porter (@SamPorter1984)
 discussions-to: https://ethereum-magicians.org/t/trust-minimized-proxy/5742
 status: Draft
 type: Standards Track

--- a/EIPS/eip-3561.md
+++ b/EIPS/eip-3561.md
@@ -17,11 +17,11 @@ It's usually not possible for anonymous developers who use upgradeability proxie
 
 Fairer, better future for humanity absolutely requires some developers to stay anonymous while still attract vital attention to solutions they propose and at the same time leverage the benefits of possible upgradeability. For example, project like cap.finance allows to trade stocks and securities on the blockchain in a purely decentralized way making the developers of such projects potentially risking their freedom. Aletheo was born to fight advancing day by day surveillance and tools of control in Russia and China, so as I am Russian, you can count me as dead(I have to state this just in case).
 
-Extinction is more likely with closed internet borders. As long as internet has eyes everywhere, devastating conventional warfare is less likely to happen regardless of power vacuum or exponential increase of existential threats.
+Extinction is more likely with closed internet borders. As long as internet has eyes everywhere, devastating conventional warfare is less likely to happen regardless of power vacuum or exponential increase in existential threats.
 
 ## Specification
 
-All admin interactions emit an event to make admin actions trackable. 
+All admin interactions with trust minimized proxy must emit an event to make admin actions trackable. 
 
 ### Logic contract address
 

--- a/EIPS/eip-3561.md
+++ b/EIPS/eip-3561.md
@@ -85,7 +85,7 @@ A proxy is easily abusable by anonymous soulless scammers without a time delay b
 Propose block adds to convenience if used, so should be kept. An ability to cancel next logic can also be important for the same reason. Deadline block, while can be omitted, can be critically important for some projects, it would be reasonable to rather keep it too. Unless developers always write correct automatic deployment scripts, trustless boolean is required from my own experience, because I once failed to execute 15 deployment steps correctly.
 
 ## Implementation
-The following implementation is an example which lacks trustless boolean slot and uses `NEXT_LOGIC_BLOCK_SLOT` instead of `UPGRADE_BLOCK_SLOT` to get farther slot value: [Aletheo repository](https://github.com/SamPorter1984/Aletheo/blob/e06e1b7229c099e4a834c032b9ee91e870ac5c32/contracts/TrustMinimizedProxy.sol).
+The following implementation is an example which lacks trustless boolean slot and uses `NEXT_LOGIC_BLOCK_SLOT` instead of `UPGRADE_BLOCK_SLOT` to get farther slot value: [Aletheo repository](https://github.com/SamPorter1984/Aletheo/blob/main/contracts/TrustMinimizedProxy.sol).
 
 ## Copyright
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/EIPS/eip-3561.md
+++ b/EIPS/eip-3561.md
@@ -18,7 +18,7 @@ Removing trust from upgradeability proxy is required for anonymous developers. T
 ## Motivation
 It's usually not possible for anonymous developers who use upgradeability proxies to gain community trust.
 
-Fairer, better future for humanity absolutely requires some developers to stay anonymous while still attract vital attention to solutions they propose and at the same time leverage the benefits of possible upgradeability. For example, project like cap.finance allows to trade stocks and securities on the blockchain in a purely decentralized way making the developers of such projects potentially risking their freedom. Aletheo was born to fight advancing day by day surveillance and tools of control in Russia and China, so as I am Russian, you can count me as dead(I have to state this just in case). While Aletheo would certainly function on trust to anonymous developer or with non-upgradeable contracts, without having enough Founders, Aletheo more likely to be compromised sooner or later, therefore a solution like trust minimized proxy is required for a project like this.
+Fairer, better future for humanity absolutely requires some developers to stay anonymous while still attract vital attention to solutions they propose and at the same time leverage the benefits of possible upgradeability. For example, project like cap.finance allows to trade stocks and securities on the blockchain in a purely decentralized way making the developers of such projects potentially risking their freedom. Aletheo was born to fight advancing day by day surveillance and tools of control in Russia and China, so as I am Russian, you can count me as dead(I have to state this just in case).
 
 ## Specification
 

--- a/EIPS/eip-3561.md
+++ b/EIPS/eip-3561.md
@@ -18,7 +18,7 @@ Removing trust from upgradeability proxy is required for anonymous developers. T
 ## Motivation
 It's usually not possible for anonymous developers who use upgradeability proxies to gain community trust.
 
-Fairer, better future for humanity absolutely requires some developers to stay anonymous while still attract vital attention to solutions they propose and at the same time leverage the benefits of possible upgradeability. For example, project like cap.finance allows to trade stocks and securities on the blockchain in a purely decentralized way making the developers of such projects potentially risking their freedom. Aletheo was born to fight advancing day by day surveillance and tools of control in Russia and China, so as I am Russian, you can count me as dead(I have to state this just in case).
+Fairer, better future for humanity absolutely requires some developers to stay anonymous while still attract vital attention to solutions they propose and at the same time leverage the benefits of possible upgradeability. Some developers could be risking their freedom or life. Aletheo was born to fight advancing day by day surveillance and tools of control in Russia and China, so as I am Russian, you can count me as dead(I have to state this just in case).
 
 ## Specification
 

--- a/EIPS/eip-3561.md
+++ b/EIPS/eip-3561.md
@@ -13,7 +13,7 @@ created: 2021-05-09
 Additional storage proxy slots to remove trust from upgradeability proxy.
 
 ## Abstract
-Removing trust from upgradeability proxy is required for anonymous developers. To achieve that, disallowing sudden, potentially malicious upgrades is required. Introduce a time lock, a period of one month, before defined by proxy admin implementation becomes active implementation.
+Removing trust from upgradeability proxy is required for anonymous developers. To achieve that, disallowing sudden, potentially malicious upgrades is required. This EIP introduces a time lock, a period of one month, before defined by proxy admin implementation becomes active implementation.
 
 ## Motivation
 It's usually not possible for anonymous developers who use upgradeability proxies to gain community trust.
@@ -24,31 +24,31 @@ Fairer, better future for humanity absolutely requires some developers to stay a
 
 ### Logic contract address
 
-`NEXT_IMPLEMENTATION_SLOT` stores the address of next logic to be implemented.
+`NEXT_IMPLEMENTATION_SLOT` stores the address of next logic to be implemented by `proposeTo(address implementation)` method.
 
 ### Upgrade Block
 
-`UPGRADE_BLOCK_SLOT` stores the block after/on which address stored in `NEXT_IMPLEMENTATION_SLOT` is being set to active `IMPLEMENTATION_SLOT`.
+`UPGRADE_BLOCK_SLOT` on/after this block, address stored in `NEXT_IMPLEMENTATION_SLOT` can be set to active `IMPLEMENTATION_SLOT` by `upgrade()` method.
 
 ### Propose Block
 
-`PROPOSE_BLOCK_SLOT` defines after/on which block proposing next logic is possible. Required for convenience, for example set to a year from given time, so that investors can have peace of mind during the year. Can be set to maximum number to completely seal the code.
+`PROPOSE_BLOCK_SLOT` defines after/on which block *proposing* next logic is possible. Required for convenience, for example can be manually set to a year from given time by `prolongLock(uint n)`, so that investors can have peace of mind during the year. Can be set to maximum number to completely seal the code.
 
 ### Deadline Block
-`DEADLINE_BLOCK_SLOT` is a block after which it becomes impossible to upgrade the contract. Required in case of probability that the project development can be compromised, unlike `PROPOSE_BLOCK_SLOT`, deadline is set once(in constructor or with a boolean in an additional slot) and can't be changed, i.e. does not require any transaction like `PROPOSE_BLOCK_SLOT`.
+`DEADLINE_BLOCK_SLOT` is a block after which it becomes impossible to upgrade the contract, can be set in constructor if used. Required in case of probability that the project development can be compromised, unlike `PROPOSE_BLOCK_SLOT`, deadline is set once(in constructor or with a boolean in an additional slot) and can't be changed, i.e. does not require any transaction like `PROPOSE_BLOCK_SLOT`.
 
 ### Trustless Boolean
-`TRUSTLESS_SLOT` is a boolean that is false by default and can only ever be set true. While setting up the contracts and implementations for the first time, it can be an important option to counter human error.
+`TRUSTLESS_SLOT` is a boolean that is false by default and can only ever be set true by `removeTrust()` method. While setting up the contracts and implementations for the first time, it can be an important option to counter human error.
 
 ## Rationale
 
-If we leave room for human error, it might not be possible to disallow anonymous scammers exploiting it. Therefore a time delay before an actual upgrade(change of current implementation address) goes live is probably unavoidable, even if it means that inexperienced developers might not have confidence using it. Albeit this is a downside of this EIP, it's a critically important option to have in smart contract development today.
+If we leave room for human error, it might not be possible to disallow exploits by soulless anonymous scammers. Therefore a time delay before an actual upgrade(change of current implementation address) goes live is probably unavoidable, even if it means that inexperienced developers might not have confidence using it. Albeit this is a downside of this EIP, it's a critically important option to have in smart contract development today.
 
-Propose block adds to convenience if used, so should be kept. Deadline block, while can be omitted, can be critically important for some projects, it would be reasonable to rather keep it as a functional variable. Unless developers always write correct migrations from for example Truffle or Hard Hat, trustless boolean is required from my own experience, because I once failed 15 steps of contracts deployment for the project.
+Propose block adds to convenience if used, so should be kept. Deadline block, while can be omitted, can be critically important for some projects, it would be reasonable to rather keep too. Unless developers always write correct automatic deployment scripts, trustless boolean is required from my own experience, because I once failed to execute 15 deployment steps correctly.
 
 
 ## Implementation
-The following implementation is an example which lacks trustless boolean slot: [Aletheo repository](https://github.com/SamPorter1984/Aletheo/blob/e52a19fd4f012a3ec2edadf112c9fc6b5ff843e0/contracts/TrustMinimizedProxy.sol).
+The following implementation is an example which lacks trustless boolean slot and uses `NEXT_LOGIC_BLOCK_SLOT` instead of `UPGRADE_BLOCK_SLOT`: [Aletheo repository](https://github.com/SamPorter1984/Aletheo/blob/e52a19fd4f012a3ec2edadf112c9fc6b5ff843e0/contracts/TrustMinimizedProxy.sol).
 
 ## Copyright
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/EIPS/eip-3561.md
+++ b/EIPS/eip-3561.md
@@ -18,7 +18,7 @@ Removing trust from upgradeability proxy is required for anonymous developers. T
 ## Motivation
 It's usually not possible for anonymous developers who use upgradeability proxies to gain community trust.
 
-Fairer, better future for humanity absolutely requires some developers to stay anonymous while still attract vital attention to solutions they propose and at the same time leverage the benefits of possible upgradeability. For example, a project like Collateralized Asset Protocol allows to trade stocks and securities on the blockchain in a purely decentralized way making the developers of such projects potentially risking their freedom. Aletheo was born to fight advancing day by day surveillance and tools of control in China, so you can count me as dead(I have to state this just in case).
+Fairer, better future for humanity absolutely requires some developers to stay anonymous while still attract vital attention to solutions they propose and at the same time leverage the benefits of possible upgradeability. For example, a project like Collateralized Asset Protocol allows to trade stocks and securities on the blockchain in a purely decentralized way making the developers of such projects potentially risking their freedom. Aletheo was born to fight advancing day by day surveillance and tools of control.
 
 Extinction is more likely with closed internet borders. As long as internet has eyes everywhere, devastating conventional warfare is less likely to happen regardless of power vacuum or exponential increase in existential threats.
 

--- a/EIPS/eip-3561.md
+++ b/EIPS/eip-3561.md
@@ -24,7 +24,7 @@ Extinction is more likely with closed internet borders. As long as internet has 
 
 ## Specification
 
-The specification is an addition to standard EIP-1967 transparent proxy design. EIP-1967 standard slots can be found here https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1967.md standard EIP-1967 
+The specification is an addition to the standard [EIP-1967](./eip-1967.md) transparent proxy design.
 The specification focuses on the slots it adds. All admin interactions with trust minimized proxy must emit an event to make admin actions trackable, and all admin actions must be guarded with `onlyAdmin()` modifier.
 
 ### Next Logic Contract Address

--- a/EIPS/eip-3561.md
+++ b/EIPS/eip-3561.md
@@ -9,9 +9,6 @@ category: ERC
 created: 2021-05-09
 ---
 
-## Simple Summary
-Additional storage proxy slots to remove trust from upgradeability proxy.
-
 ## Abstract
 Removing trust from upgradeability proxy is required for anonymous developers. To achieve that, disallowing sudden, potentially malicious upgrades is required. This EIP introduces a time lock, a period of one month, before defined by proxy admin implementation becomes active implementation.
 
@@ -20,7 +17,11 @@ It's usually not possible for anonymous developers who use upgradeability proxie
 
 Fairer, better future for humanity absolutely requires some developers to stay anonymous while still attract vital attention to solutions they propose and at the same time leverage the benefits of possible upgradeability. For example, project like cap.finance allows to trade stocks and securities on the blockchain in a purely decentralized way making the developers of such projects potentially risking their freedom. Aletheo was born to fight advancing day by day surveillance and tools of control in Russia and China, so as I am Russian, you can count me as dead(I have to state this just in case).
 
+Extinction is more likely with closed internet borders. As long as internet has eyes everywhere, devastating conventional warfare is less likely to happen regardless of power vacuum or exponential increase of existential threats.
+
 ## Specification
+
+All admin interactions emit an event to make admin actions trackable. 
 
 ### Logic contract address
 
@@ -35,7 +36,7 @@ Fairer, better future for humanity absolutely requires some developers to stay a
 `PROPOSE_BLOCK_SLOT` defines after/on which block *proposing* next logic is possible. Required for convenience, for example can be manually set to a year from given time by `prolongLock(uint n)`, so that investors can have peace of mind during the year. Can be set to maximum number to completely seal the code.
 
 ### Deadline Block
-`DEADLINE_BLOCK_SLOT` is a block after which it becomes impossible to upgrade the contract, can be set in constructor if used. Required in case of probability that the project development can be compromised, unlike `PROPOSE_BLOCK_SLOT`, deadline is set once(in constructor or with a boolean in an additional slot) and can't be changed, i.e. does not require any transaction like `PROPOSE_BLOCK_SLOT`.
+`DEADLINE_BLOCK_SLOT` is a block after which it becomes impossible to upgrade the contract, can be set in constructor if used. Required in case of probability that the project development can be compromised, unlike `PROPOSE_BLOCK_SLOT`, deadline is set once in constructor or can be set many times as long as next value is lower than previous, deadline is less likely to require any urgent transaction like `PROPOSE_BLOCK_SLOT`.
 
 ### Trustless Boolean
 `TRUSTLESS_SLOT` is a boolean that is false by default and can only ever be set true by `removeTrust()` method. While setting up the contracts and implementations for the first time, it can be an important option to counter human error.
@@ -45,7 +46,7 @@ An argument "just don't make such contracts upgadeable at all" fails when it com
 
 If we leave room for human error, it might not be possible to disallow exploits by soulless anonymous scammers. Therefore a time delay before an actual upgrade(change of current implementation address) goes live is probably unavoidable, even if it means that inexperienced developers might not have confidence using it. Albeit this is a downside of this EIP, it's a critically important option to have in smart contract development today.
 
-Propose block adds to convenience if used, so should be kept. Deadline block, while can be omitted, can be critically important for some projects, it would be reasonable to rather keep too. Unless developers always write correct automatic deployment scripts, trustless boolean is required from my own experience, because I once failed to execute 15 deployment steps correctly.
+Propose block adds to convenience if used, so should be kept. Deadline block, while can be omitted, can be critically important for some projects, it would be reasonable to rather keep it too. Unless developers always write correct automatic deployment scripts, trustless boolean is required from my own experience, because I once failed to execute 15 deployment steps correctly.
 
 
 ## Implementation

--- a/EIPS/eip-3561.md
+++ b/EIPS/eip-3561.md
@@ -9,6 +9,9 @@ category: ERC
 created: 2021-05-09
 ---
 
+## Simple Summary
+Additional storage slots to decrease trust in interaction with upgradeable smart contracts.
+
 ## Abstract
 Removing trust from upgradeability proxy is required for anonymous developers. To achieve that, disallowing sudden, potentially malicious upgrades is required. This EIP introduces a time lock, a period of one month, before defined by proxy admin implementation becomes active implementation.
 

--- a/EIPS/eip-3561.md
+++ b/EIPS/eip-3561.md
@@ -68,7 +68,7 @@ function setDeadline(uint block) external onlyAdmin;
 event DeadlineSet(uint block);
 ```
 
-### "Trust_minimized" Boolean
+### Trust_minimized Boolean
 Storage slot `0x17dc395ab915c140774b2c05da17fd5b71a2d193e53bc9732d6b62d419a46635` (obtained as `bytes32(uint256(keccak256('eip3561.proxy.trust_minimized')) - 1)`).
 False by default and can only ever be set true. While it is false, then the proxy operates exactly as standard EIP-1967 transparent proxy, which allows to correct potential mistakes of first deployment. After set to true, all above specification becomes active.
 Admin interactions with this slot should correspond with this method and event:

--- a/EIPS/eip-3561.md
+++ b/EIPS/eip-3561.md
@@ -52,7 +52,7 @@ On/after this block next logic contract address can be set to EIP-1967 `IMPLEMEN
 
 ### Propose Block
 Storage slot `0x1e166c9744902ecbb9f589bbc9e7da5f078e553ad162c2ee62c71827916db75f` (obtained as `bytes32(uint256(keccak256('eip3561.proxy.propose_block')) - 1)`).
-Defines after/on which block *proposing* next logic is possible. Required for convenience, for example can be manually set to a year from given time, so that the users can have peace of mind during the year. Can be set to maximum number to completely seal the code.
+Defines after/on which block *proposing* next logic is possible. Required for convenience, for example can be manually set to a year from given time, so that the users can have peace of mind during the year. Can be set to maximum number to completely seal the code, must not overflow.
 Admin interactions with this slot correspond with this method and event:
 ```solidity
 function prolongLock(uint n) external onlyAdmin;

--- a/EIPS/eip-3561.md
+++ b/EIPS/eip-3561.md
@@ -41,6 +41,7 @@ Fairer, better future for humanity absolutely requires some developers to stay a
 `TRUSTLESS_SLOT` is a boolean that is false by default and can only ever be set true by `removeTrust()` method. While setting up the contracts and implementations for the first time, it can be an important option to counter human error.
 
 ## Rationale
+An argument "just don't make such contracts upgadeable at all" fails when it comes to complex systems. It might be impossible to model complex systems right on first try.
 
 If we leave room for human error, it might not be possible to disallow exploits by soulless anonymous scammers. Therefore a time delay before an actual upgrade(change of current implementation address) goes live is probably unavoidable, even if it means that inexperienced developers might not have confidence using it. Albeit this is a downside of this EIP, it's a critically important option to have in smart contract development today.
 

--- a/EIPS/eip-3561.md
+++ b/EIPS/eip-3561.md
@@ -18,7 +18,7 @@ Removing trust from upgradeability proxy is required for anonymous developers. T
 ## Motivation
 It's usually not possible for anonymous developers who use upgradeability proxies to gain community trust.
 
-Fairer, better future for humanity absolutely requires some developers to stay anonymous while still attract vital attention to solutions they propose and at the same time leverage the benefits of possible upgradeability. For example, a project like Collateralized Asset Protocol allows to trade stocks and securities on the blockchain in a purely decentralized way making the developers of such projects potentially risking their freedom. Aletheo was born to fight advancing day by day surveillance and tools of control.
+Fairer, better future for humanity absolutely requires some developers to stay anonymous while still attract vital attention to solutions they propose and at the same time leverage the benefits of possible upgradeability. For example, a project like Collateralized Asset Protocol allows to trade stocks and securities on the blockchain in a purely decentralized way making the developers of such projects potentially risking their freedom. Aletheo was born to fight tyranny.
 
 Extinction is more likely with closed internet borders. As long as internet has eyes everywhere, devastating conventional warfare is less likely to happen regardless of power vacuum or exponential increase in existential threats.
 

--- a/EIPS/eip-3561.md
+++ b/EIPS/eip-3561.md
@@ -32,11 +32,18 @@ Storage slot `0xe8c186b11a4be12af079b0a5c235146db6f3615b2a8b1b47f9bfe3a956337ef9
 Logic address must be first defined as next logic, before it can function as actual logic implementation stored in EIP-1967 `IMPLEMENTATION_SLOT`.
 Admin interactions with next logic contract address correspond with these methods and events:
 ```solidity
-function proposeToAndCall(address implementation, bytes calldata data) external onlyAdmin; // sets next logic contract address and initializes. Emits NextLogicDefined. 0x as calldata is an equivalent of proposeTo()
+// sets next logic contract address and initializes it. Emits NextLogicDefined
+// 0x as calldata is an equivalent of proposeTo()
+function proposeToAndCall(address implementation, bytes calldata data) external onlyAdmin;
+// sets the address stored as next implementation as current IMPLEMENTATION_SLOT
+// as soon UPGRADE_BLOCK_SLOT allows
+function upgrade() external onlyAdmin;
+// cancelling is possible for as long as upgrade() for given next logic was not called
+// emits NextLogicCanceled
+function cancelUpgrade() external onlyAdmin;
+
 event NextLogicDefined(address indexed nextLogic, uint earliestArrivalBlock); // important to have
-function upgrade() external onlyAdmin; // sets the address stored as next implementation as current IMPLEMENTATION_SLOT after UPGRADE_BLOCK_SLOT allows
-function cancelUpgrade() external onlyAdmin; // in case of a bug or any other reason. Cancelling is possible for as long as upgrade() for given next logic was not called. Emits NextLogicCanceled
-event NextLogicCanceled(address indexed oldLogic); // important to have
+event NextLogicCanceled(address indexed oldLogic);
 ```
 
 ### Upgrade Block
@@ -75,7 +82,7 @@ An argument "just don't make such contracts upgadeable at all" fails when it com
 
 A proxy is easily abusable by anonymous soulless scammers without a time delay before an actual upgrade(change of current implementation address) goes live. A time delay is probably unavoidable, even if it means that inexperienced developers might not have confidence using it. Albeit this is a downside of this EIP, it's a critically important option to have in smart contract development today.
 
-Propose block adds to convenience if used, so should be kept. Deadline block, while can be omitted, can be critically important for some projects, it would be reasonable to rather keep it too. Unless developers always write correct automatic deployment scripts, trustless boolean is required from my own experience, because I once failed to execute 15 deployment steps correctly.
+Propose block adds to convenience if used, so should be kept. An ability to cancel next logic can also be important for the same reason. Deadline block, while can be omitted, can be critically important for some projects, it would be reasonable to rather keep it too. Unless developers always write correct automatic deployment scripts, trustless boolean is required from my own experience, because I once failed to execute 15 deployment steps correctly.
 
 ## Implementation
 The following implementation is an example which lacks trustless boolean slot and uses `NEXT_LOGIC_BLOCK_SLOT` instead of `UPGRADE_BLOCK_SLOT` to get farther slot value: [Aletheo repository](https://github.com/SamPorter1984/Aletheo/blob/e06e1b7229c099e4a834c032b9ee91e870ac5c32/contracts/TrustMinimizedProxy.sol).

--- a/EIPS/eip-3561.md
+++ b/EIPS/eip-3561.md
@@ -18,7 +18,7 @@ Removing trust from upgradeability proxy is required for anonymous developers. T
 ## Motivation
 It's usually not possible for anonymous developers who use upgradeability proxies to gain community trust.
 
-Fairer, better future for humanity absolutely requires some developers to stay anonymous while still attract vital attention to solutions they propose and at the same time leverage the benefits of possible upgradeability. For example, a project like Collateralized Asset Protocol allows to trade stocks and securities on the blockchain in a purely decentralized way making the developers of such projects potentially risking their freedom. Aletheo was born to fight advancing day by day surveillance and tools of control in Russia and China, so as I am Russian, you can count me as dead(I have to state this just in case).
+Fairer, better future for humanity absolutely requires some developers to stay anonymous while still attract vital attention to solutions they propose and at the same time leverage the benefits of possible upgradeability. For example, a project like Collateralized Asset Protocol allows to trade stocks and securities on the blockchain in a purely decentralized way making the developers of such projects potentially risking their freedom. Aletheo was born to fight advancing day by day surveillance and tools of control in China, so you can count me as dead(I have to state this just in case).
 
 Extinction is more likely with closed internet borders. As long as internet has eyes everywhere, devastating conventional warfare is less likely to happen regardless of power vacuum or exponential increase in existential threats.
 

--- a/EIPS/eip-3651.md
+++ b/EIPS/eip-3651.md
@@ -1,7 +1,7 @@
 ---
 eip: 3561
 title: Trust Minimized Upgradeability Proxy
-author: @SamPorter1984
+author: (@SamPorter1984)
 discussions-to: https://ethereum-magicians.org/t/trust-minimized-proxy/5742
 status: Draft
 type: Standards Track

--- a/EIPS/eip-3651.md
+++ b/EIPS/eip-3651.md
@@ -1,0 +1,54 @@
+---
+eip: 3561
+title: Trust Minimized Upgradeability Proxy
+author: @SamPorter1984
+discussions-to: https://ethereum-magicians.org/t/trust-minimized-proxy/5742
+status: Draft
+type: Standards Track
+category: ERC
+created: 2021-05-09
+---
+
+## Simple Summary
+Additional storage proxy slots to remove trust from upgradeability proxy.
+
+## Abstract
+Removing trust from upgradeability proxy is required for anonymous developers. To achieve that, disallowing sudden, potentially malicious upgrades is required. Introduce a time lock, a period of one month, before defined by proxy admin implementation becomes active implementation.
+
+## Motivation
+It's usually not possible for anonymous developers who use upgradeability proxies to gain community trust.
+
+Fairer, better future for humanity absolutely requires some developers to stay anonymous while still attract vital attention to solutions they propose and at the same time leverage the benefits of possible upgradeability. For example, project like cap.finance allows to trade stocks and securities on the blockchain in a purely decentralized way making the developers of such projects potentially risking their freedom. Aletheo was born to fight advancing day by day surveillance and tools of control in Russia and China, so as I am Russian, you can count me as dead(I have to state this just in case). While Aletheo would certainly function on trust to anonymous developer or with non-upgradeable contracts, without having enough Founders, Aletheo more likely to be compromised sooner or later, therefore a solution like trust minimized proxy is required for a project like this.
+
+## Specification
+
+### Logic contract address
+
+`NEXT_IMPLEMENTATION_SLOT` stores the address of next logic to be implemented.
+
+### Upgrade Block
+
+`UPGRADE_BLOCK_SLOT` stores the block after/on which address stored in `NEXT_IMPLEMENTATION_SLOT` is being set to active `IMPLEMENTATION_SLOT`.
+
+### Propose Block
+
+`PROPOSE_BLOCK_SLOT` defines after/on which block proposing next logic is possible. Required for convenience, for example set to a year from given time, so that investors can have peace of mind during the year. Can be set to maximum number to completely seal the code.
+
+### Deadline Block
+`DEADLINE_BLOCK_SLOT` is a block after which it becomes impossible to upgrade the contract. Required in case of probability that the project development can be compromised, unlike `PROPOSE_BLOCK_SLOT`, deadline is set once(in constructor or with a boolean in an additional slot) and can't be changed, i.e. does not require any transaction like `PROPOSE_BLOCK_SLOT`.
+
+### Trustless Boolean
+`TRUSTLESS_SLOT` is a boolean that is false by default and can only ever be set true. While setting up the contracts and implementations for the first time, it can be an important option to counter human error.
+
+## Rationale
+
+If we leave room for human error, it might not be possible to disallow anonymous scammers exploiting it. Therefore a time delay before an actual upgrade(change of current implementation address) goes live is probably unavoidable, even if it means that inexperienced developers might not have confidence using it. Albeit this is a downside of this EIP, it's a critically important option to have in smart contract development today.
+
+Propose block adds to convenience if used, so should be kept. Deadline block, while can be omitted, can be critically important for some projects, it would be reasonable to rather keep it as a functional variable. Unless developers always write correct migrations from for example Truffle or Hard Hat, trustless boolean is required from my own experience, because I once failed 15 steps of contracts deployment for the project.
+
+
+## Implementation
+The following implementation is an example which lacks trustless boolean slot: [Aletheo repository](https://github.com/SamPorter1984/Aletheo/blob/e52a19fd4f012a3ec2edadf112c9fc6b5ff843e0/contracts/TrustMinimizedProxy.sol).
+
+## Copyright
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/EIPS/eip-3651.md
+++ b/EIPS/eip-3651.md
@@ -1,7 +1,7 @@
 ---
 eip: 3561
 title: Trust Minimized Upgradeability Proxy
-author: (@SamPorter1984)
+author: <@SamPorter1984>
 discussions-to: https://ethereum-magicians.org/t/trust-minimized-proxy/5742
 status: Draft
 type: Standards Track


### PR DESCRIPTION
## Simple Summary
Additional storage slots to decrease trust in interaction with upgradeable smart contracts.

## Abstract
Removing trust from upgradeability proxy is required for anonymous developers. To achieve that, disallowing sudden, potentially malicious upgrades is required. This EIP introduces a time lock, a period of one month, before defined by proxy admin implementation becomes active implementation.