### PR TITLE
Add simple summary to eip-1

### DIFF
--- a/EIPS/eip-1.md
+++ b/EIPS/eip-1.md
@@ -97,6 +97,7 @@ If this period results in necessary normative changes it will revert the EIP to 
 Each EIP should have the following parts:
 
 - Preamble - RFC 822 style headers containing metadata about the EIP, including the EIP number, a short descriptive title (limited to a maximum of 44 characters), and the author details. See [below](./eip-1.md#eip-header-preamble) for details.
+- Simple Summary (*optional) - A short (~1 sentence) non-technical summary of the EIP.
 - Abstract - A short (~200 word) description of the technical issue being addressed.
 - Motivation (*optional) - A motivation section is critical for EIPs that want to change the Ethereum protocol. It should clearly explain why the existing protocol specification is inadequate to address the problem that the EIP solves. EIP submissions without sufficient motivation may be rejected outright.
 - Specification - The technical specification should describe the syntax and semantics of any new feature. The specification should be detailed enough to allow competing, interoperable implementations for any of the current Ethereum platforms (cpp-ethereum, go-ethereum, parity, ethereumJ, ethereumjs-lib, [and others](https://github.com/ethereum/wiki/wiki/Clients).

--- a/eip-template.md
+++ b/eip-template.md
@@ -17,8 +17,8 @@ Note that an EIP number will be assigned by an editor. When opening a pull reque
 
 The title should be 44 characters or less.
 
-## Simple Summary
-"If you can't explain it simply, you don't understand it well enough." Provide a simplified and layman-accessible explanation of the EIP. Imagine an email subject line, GitHub PR title, or forum post title.
+## Simple Summary 
+(*optional) "If you can't explain it simply, you don't understand it well enough." Provide a simplified and layman-accessible explanation of the EIP. Imagine an email subject line, GitHub PR title, or forum post title.
 
 ## Abstract
 A short (~200 word) description of the technical issue being addressed. This should be a very terse and human-readable version of the specification section. Someone should be able to read only the abstract to get the gist of what this specification does.


### PR DESCRIPTION
For quite a while, simple summary has been an optional section in EIPs. This formalizes that in EIP-1. This would close #3564.