### PR TITLE
eip-1559: revert to old gaslimit checks

### DIFF
--- a/EIPS/eip-1559.md
+++ b/EIPS/eip-1559.md
@@ -167,7 +167,6 @@ class World(ABC):
 
 		parent_base_fee_per_gas = self.parent(block).base_fee_per_gas
 		parent_gas_used = self.parent(block).gas_used
-		gas_target = block.gas_limit // ELASTICITY_MULTIPLIER
 		transactions = self.transactions(block)
 
 		# check if the block used too much gas

--- a/EIPS/eip-1559.md
+++ b/EIPS/eip-1559.md
@@ -172,7 +172,7 @@ class World(ABC):
 		# check if the block used too much gas
 		assert block.gas_used <= block.gas_limit, 'invalid block: too much gas used'
 
-		# check if the block changed the gas target too much
+		# check if the block changed the gas limit too much
 		assert block.gas_limit < parent_gas_limit + parent_gas_limit // 1024, 'invalid block: gas limit increased too much'
 		assert block.gas_limit > parent_gas_limit - parent_gas_limit // 1024, 'invalid block: gas limit decreased too much'
 

--- a/EIPS/eip-1559.md
+++ b/EIPS/eip-1559.md
@@ -157,11 +157,13 @@ ELASTICITY_MULTIPLIER = 2
 class World(ABC):
 	def validate_block(self, block: Block) -> None:
 		parent_gas_target = self.parent(block).gas_limit // ELASTICITY_MULTIPLIER
+		parent_gas_limit = self.parent(block).gas_limit
 
 		# on the fork block, don't account for the ELASTICITY_MULTIPLIER to avoid
 		# unduly halving the gas target.
 		if INITIAL_FORK_BLOCK_NUMBER == block.number:
-			parent_gas_target = self.parent(block).gas_limit 
+			parent_gas_target = self.parent(block).gas_limit
+			parent_gas_limit = self.parent(block).gas_limit * ELASTICITY_MULTIPLIER 
 
 		parent_base_fee_per_gas = self.parent(block).base_fee_per_gas
 		parent_gas_used = self.parent(block).gas_used
@@ -172,8 +174,8 @@ class World(ABC):
 		assert block.gas_used <= block.gas_limit, 'invalid block: too much gas used'
 
 		# check if the block changed the gas target too much
-		assert gas_target <= parent_gas_target + parent_gas_target // 1024, 'invalid block: gas target increased too much'
-		assert gas_target >= parent_gas_target - parent_gas_target // 1024, 'invalid block: gas target decreased too much'
+		assert block.gas_limit < parent_gas_limit + parent_gas_limit // 1024, 'invalid block: gas limit increased too much'
+		assert block.gas_limit > parent_gas_limit - parent_gas_limit // 1024, 'invalid block: gas limit decreased too much'
 
 		# check if the base fee is correct
 		if INITIAL_FORK_BLOCK_NUMBER == block.number:


### PR DESCRIPTION
This reverts `gasLimit` checks to use the same validation as was used previously. 

- [x] Checks based on `limit`, not `target`
- [x] Checks use `<,>` rather than `<=, >=` 