### PR TITLE
EIP-2981 review comments

### DIFF
--- a/EIPS/eip-2981.md
+++ b/EIPS/eip-2981.md
@@ -1,6 +1,6 @@
 ---
 eip: 2981
-title: ERC-721 Royalty Standard
+title: NFT Royalty Standard
 author: Zach Burks (@vexycats), James Morgan (@jamesmorgan), Blaine Malone (@blmalone), James Seibel (@seibelj)
 discussions-to: https://github.com/ethereum/EIPs/issues/2907
 status: Draft
@@ -12,24 +12,26 @@ requires: 165
 
 ## Simple Summary
 
-A standardized way to retrieve royalty payment information for ERC-721 tokens to enable universal support for royalty payments in all NFT marketplaces and ecosystem participants.
+A standardized way to retrieve royalty payment information for NFT tokens to enable universal support for royalty payments in all NFT marketplaces and ecosystem participants.
 
 ## Abstract
 
-This standard extends the [ERC-721 specification](./eip-721.md) to enable setting a royalty amount paid to the NFT creator or rights holder every time an NFT is sold and re-sold. This is intended for NFT marketplaces that want to support the ongoing funding of artists and other NFT creators. The royalty payment must be voluntary as required by the EIP-721 standard, as `transferFrom()` includes NFT transfers between wallets, and executing `transferFrom()` does not always imply a sale occurred. Marketplaces and individuals implement this standard by retrieving the royalty payment information with `royaltyInfo()`, which specifies how much to pay to which address for a given sale price. The exact mechanism for paying and notifying the recipient will be defined in future EIPs. This ERC should be considered a minimal, gas-efficient building block for further innovation in NFT royalty payments.
+This standard extends NFT standards such as the [ERC-721](./eip-721.md) and [ERC-1155]](./eip-1155.md) specifications to enable setting a royalty amount paid to the NFT creator or rights holder every time an NFT is sold and re-sold. This is intended for NFT marketplaces that want to support the ongoing funding of artists and other NFT creators. The royalty payment must be voluntary, as `transferFrom()` includes NFT transfers between wallets, and executing `transferFrom()` does not always imply a sale occurred. Marketplaces and individuals implement this standard by retrieving the royalty payment information with `royaltyInfo()`, which specifies how much to pay to which address for a given sale price. The exact mechanism for paying and notifying the recipient will be defined in future EIPs. This ERC should be considered a minimal, gas-efficient building block for further innovation in NFT royalty payments.
 
 ## Motivation
-There are many marketplaces for NFTs with multiple unique royalty payment implementations that are not easily compatible or usable by other marketplaces. Just like the early days of ERC-20 tokens, ERC-721 marketplace smart contracts are varied by ecosystem and not standardized. This EIP enables all marketplaces to retrieve royalty payment information that NFT creators specify and are entitled to, enabling accurate royalty payments regardless of which marketplace the NFT is sold or re-sold at.
+There are many marketplaces for NFTs with multiple unique royalty payment implementations that are not easily compatible or usable by other marketplaces. Just like the early days of ERC-20 tokens, NFT marketplace smart contracts are varied by ecosystem and not standardized. This EIP enables all marketplaces to retrieve royalty payment information that NFT creators specify and are entitled to, enabling accurate royalty payments regardless of which marketplace the NFT is sold or re-sold at.
 
-Many of the largest ERC-721 marketplaces have implemented royalty payments that are incompatible with other platforms and therefore make it much harder to enforce when the NFT is sold on another marketplace, not fulfilling the potential of any implemented royalty system. This standard implements standardized royalty information retrieval that can be accepted across any type of NFT marketplace. This minimalist proposal leaves the actual funds transfer up to the marketplace itself, and only provides a mechanism to fetch the royalty amounts. Future EIPs may build on this ERC to implement payment notifications and other features.
+Many of the largest  NFT marketplaces have implemented royalty payments that are incompatible with other platforms and therefore make it much harder to enforce when the NFT is sold on another marketplace, not fulfilling the potential of any implemented royalty system. This standard implements standardized royalty information retrieval that can be accepted across any type of NFT marketplace. This minimalist proposal leaves the actual funds transfer up to the marketplace itself, and only provides a mechanism to fetch the royalty amounts. Future EIPs may build on this ERC to implement payment notifications and other features.
 
-This standard extends the [ERC-721 specification](./eip-721.md) to enable setting a royalty amount paid to the NFT creator or rights holder every time an NFT is sold and re-sold. If a marketplace chooses *not* to implement this EIP, then obviously no funds are paid for secondary sales. But as most NFT marketplaces have developed some unique royalty system themselves - and all of them are singular and only work within their own contracts - there should be an accepted standard for royalty payment information (if the creator chooses to set royalties on their NFTs). We believe the NFT marketplace ecosystem will voluntarily implement royalty payments to provide ongoing funding for artists and other creators, and NFT buyers will assess the royalty payment as a factor when making NFT purchasing decisions.
+This standard extends the [[ERC-721](./eip-721.md) and [ERC-1155]](./eip-1155.md) specifications to enable setting a royalty amount paid to the NFT creator or rights holder every time an NFT is sold and re-sold. If a marketplace chooses *not* to implement this EIP, then obviously no funds are paid for secondary sales. But as most NFT marketplaces have developed some unique royalty system themselves - and all of them are singular and only work within their own contracts - there should be an accepted standard for royalty payment information (if the creator chooses to set royalties on their NFTs). We believe the NFT marketplace ecosystem will voluntarily implement royalty payments to provide ongoing funding for artists and other creators, and NFT buyers will assess the royalty payment as a factor when making NFT purchasing decisions.
 
 Without an agreed royalty payment standard, the NFT ecosystem will lack an effective means to collect royalties across all marketplaces and artists and other creators will not receive ongoing funding. This will hamper the growth and adoption of NFTs and demotivate artists and other NFT creators from minting new and innovative tokens.
 
 *"Yes we have royalties, but if your NFT is sold on another marketplace, we cannot provide royalties" ... "But can't I sell my NFT anywhere with a click of my wallet?" ... "Yes... but we don't have a standard for royalties so you'll lose out."*
 
 This EIP fixes this issue, enabling all NFT marketplaces to unify on a single royalty payment information standard and benefiting the entire NFT ecosystem.
+
+While this standard is focused on NFTs and compatibility with the ERC-721 and ERC-1155 standards, EIP-2981 does not require compatibility with ERC-721 and ERC-1155 standards. Any other contract could integrate with EIP-2981 to return royalty payment information. ERC-2981 is therefore a universal royalty standard for many asset types.
 
 ## Specification
 
@@ -38,7 +40,7 @@ NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and
 "OPTIONAL" in this document are to be interpreted as described in
 RFC 2119.
 
-**ERC-721 compliant contracts MAY implement this ERC for royalties to provide a standard method of specifying royalty payment information.**
+**ERC-721 and ERC-1155 compliant contracts MAY implement this ERC for royalties to provide a standard method of specifying royalty payment information.**
 
 Marketplaces that support this standard **SHOULD** implement some method of transferring royalties to the royalty recipient. Standards for the actual transfer and notification of funds will be specified in future EIPs.
 
@@ -51,15 +53,15 @@ pragma solidity ^0.6.0;
 import "./ERC165.sol";
 
 ///
-/// @dev Implementation of royalties for 721s
+/// @dev Interface for the NFT Royalty Standard
 ///
 interface IERC2981 is ERC165 {
     /// ERC165 bytes to add to interface array - set in parent contract
     /// implementing this standard
     ///
-    /// bytes4(keccak256("royaltyInfo(uint256,uint256,bytes)")) == 0x6057361d
-    /// bytes4 private constant _INTERFACE_ID_ERC721ROYALTIES = 0x6057361d;
-    /// _registerInterface(_INTERFACE_ID_ERC721ROYALTIES);
+    /// bytes4(keccak256("royaltyInfo(uint256,uint256,bytes)")) == 0xc155531d
+    /// bytes4 private constant _INTERFACE_ID_ERC2981 = 0xc155531d;
+    /// _registerInterface(_INTERFACE_ID_ERC2981);
 
     /// @notice Called with the sale price to determine how much royalty
     //          is owed and to whom.
@@ -75,12 +77,12 @@ interface IERC2981 is ERC165 {
     ///                               EIP-2981 alone.
     function royaltyInfo(uint256 _tokenId, uint256 _value, bytes calldata _data) external returns (address _receiver, uint256 _royaltyAmount, bytes memory _royaltyPaymentData);
 
-    /// @notice Informs callers that this ERC721 supports ERC2981
-    /// @dev If `_registerInterface(_INTERFACE_ID_ERC721ROYALTIES)` is called
+    /// @notice Informs callers that this contract supports ERC2981
+    /// @dev If `_registerInterface(_INTERFACE_ID_ERC2981)` is called
     ///      in the initializer, this should be automatic
     /// @param interfaceID The interface identifier, as specified in ERC-165
     /// @return `true` if the contract implements
-    ///         `_INTERFACE_ID_ERC721ROYALTIES` and `false` otherwise
+    ///         `_INTERFACE_ID_ERC2981` and `false` otherwise
     function supportsInterface(bytes4 interfaceID) external view returns (bool);
 }
 
@@ -93,7 +95,7 @@ This standard being used on an ERC-721 during deployment:
 #### Deploying an ERC-721 and signaling support for ERC-2981
 
 ```solidity
-constructor (string memory name, string memory symbol, string memory baseURI)  public  Royalties(royalty_amount, msg.sender) {
+constructor (string memory name, string memory symbol, string memory baseURI) {
         _name = name;
         _symbol = symbol;
         _setBaseURI(baseURI);
@@ -102,7 +104,7 @@ constructor (string memory name, string memory symbol, string memory baseURI)  p
         _registerInterface(_INTERFACE_ID_ERC721_METADATA);
         _registerInterface(_INTERFACE_ID_ERC721_ENUMERABLE);
         // Royalties interface 
-        _registerInterface(_INTERFACE_ID_ERC721ROYALTIES);
+        _registerInterface(_INTERFACE_ID_ERC2981);
     }
 ```
 
@@ -111,8 +113,10 @@ constructor (string memory name, string memory symbol, string memory baseURI)  p
 Note: using address.call() is completely **OPTIONAL** and is just one method.
 
 ```solidity  
-function checkRoyalties(address _token) internal returns (bool) {
-    (bool success) = address(_token).call(abi.encodeWithSignature("royaltyInfo(uint256,uint256,bytes)"));
+bytes4 private constant _INTERFACE_ID_ERC2981 = 0xc155531d;
+
+function checkRoyalties(address _contract) internal returns (bool) {
+    (bool success) = IERC2981(_contract).supportsInterface(_INTERFACE_ID_ERC2981);
     return success;
  }
 ```
@@ -139,7 +143,11 @@ This EIP mandates the inclusion of the `_data` parameter and the `_royaltyPaymen
 
 ## Backwards Compatibility
 
-This standard is completely compatible with current ERC-721 standards - in fact it requires it.
+This standard is compatible with current ERC-721 and ERC-1155 standards.
+
+## Universal Royalty Payments
+
+Although designed specifically with NFTs in mind, this standard does not require compatibility with ERC-721 and ERC-1155 standards. Any other contract could integrate with this, provided it has a concept of uniquely identifying their asset by ID (like `tokenId`) to return royalty payment information. ERC-2981 is therefore a universal royalty standard for many other asset types.
 
 ## Security Considerations
 

--- a/EIPS/eip-2981.md
+++ b/EIPS/eip-2981.md
@@ -147,7 +147,7 @@ This standard is compatible with current ERC-721 and ERC-1155 standards.
 
 ## Universal Royalty Payments
 
-Although designed specifically with NFTs in mind, this standard does not require compatibility with ERC-721 and ERC-1155 standards. Any other contract could integrate with this, provided it has a concept of uniquely identifying their asset by ID (like `tokenId`) to return royalty payment information. ERC-2981 is therefore a universal royalty standard for many other asset types.
+Although designed specifically with NFTs in mind, this standard does not require that a contract implementing EIP-2981 is compatible with either ERC-721 or ERC-1155 standards. Any other contract could integrate with this, provided it uniquely identifies assets by ID (like `tokenId`) to return royalty payment information. ERC-2981 is therefore a universal royalty standard for many other asset types.
 
 ## Security Considerations
 


### PR DESCRIPTION
- Rename to `NFT Royalty Standard` to imply both 721 and 1155 compatibility
- Explain that it could potentially be a universal royalty standard, not just for NFTs
- Fix the 165 function calculation
- Rename the interface to _INTERFACE_ID_ERC2981
- Remove invalid return value from the constructor
- Use `supportsInterface()` for determining support in the example