### PR TITLE
Mark all London EIPs as Last Call

### DIFF
--- a/EIPS/eip-1559.md
+++ b/EIPS/eip-1559.md
@@ -3,7 +3,8 @@ eip: 1559
 title: Fee market change for ETH 1.0 chain
 author: Vitalik Buterin (@vbuterin), Eric Conner (@econoar), Rick Dudley (@AFDudley), Matthew Slipper (@mslipper), Ian Norden (@i-norden), Abdelhamid Bakhta (@abdelhamidbakhta)
 discussions-to: https://ethereum-magicians.org/t/eip-1559-fee-market-change-for-eth-1-0-chain/2783
-status: Review
+status: Last Call
+review-period-end: 2021-07-14
 type: Standards Track
 category: Core
 created: 2019-04-13

--- a/EIPS/eip-3198.md
+++ b/EIPS/eip-3198.md
@@ -3,7 +3,8 @@ eip: 3198
 title: BASEFEE opcode
 author: Abdelhamid Bakhta (@abdelhamidbakhta), Vitalik Buterin (@vbuterin)
 discussions-to: https://ethereum-magicians.org/t/eip-3198-basefeeopcode/5162
-status: Review
+status: Last Call
+review-period-end: 2021-07-14
 type: Standards Track
 category: Core
 created: 2021-01-13

--- a/EIPS/eip-3529.md
+++ b/EIPS/eip-3529.md
@@ -3,7 +3,8 @@ eip: 3529
 title: Reduction in refunds
 author: Vitalik Buterin (@vbuterin), Martin Swende (@holiman)
 discussions-to: https://ethereum-magicians.org/t/eip-3529-reduction-in-refunds-alternative-to-eip-3298-and-3403-that-better-preserves-existing-clearing-incentives/6097
-status: Draft
+status: Last Call
+review-period-end: 2021-07-14
 type: Standards Track
 category: Core
 created: 2021-04-22

--- a/EIPS/eip-3541.md
+++ b/EIPS/eip-3541.md
@@ -3,7 +3,8 @@ eip: 3541
 title: Reject new contracts starting with the 0xEF byte
 author: Alex Beregszaszi (@axic), Paweł Bylica (@chfast), Andrei Maiboroda (@gumb0), Alexey Akhunov (@AlexeyAkhunov), Christian Reitwiessner (@chriseth), Martin Swende (@holiman)
 discussions-to: https://ethereum-magicians.org/t/evm-object-format-eof/5727/4
-status: Review
+status: Last Call
+review-period-end: 2021-07-14
 type: Standards Track
 category: Core
 created: 2021-03-16

--- a/EIPS/eip-3554.md
+++ b/EIPS/eip-3554.md
@@ -3,9 +3,10 @@ eip: 3554
 title: Difficulty Bomb Delay to December 1st 2021
 author: James Hancock (@madeoftin)
 discussions-to: https://ethereum-magicians.org/t/eip-3554-ice-age-delay-targeting-december-2021/6188
+status: Last Call
+review-period-end: 2021-07-14
 type: Standards Track
 category: Core
-status: Review
 created: 2021-05-06
 ---
 


### PR DESCRIPTION
Suggested on ACD by @timbeiko, with the end-date set to the date of mainnet fork.
