### PR TITLE
Bump Ruby min dependency to 2.7.x

### DIFF
--- a/EIPS/eip-3014.md
+++ b/EIPS/eip-3014.md
@@ -1,6 +1,6 @@
 ---
 eip: 3014
-title: `eth_symbol` JSON-RPC method
+title: "`eth_symbol` JSON-RPC method"
 author: Peter Grassberger (@PeterTheOne)
 discussions-to: https://github.com/ethereum/EIPs/issues/3012
 status: Draft

--- a/README.md
+++ b/README.md
@@ -52,13 +52,13 @@ The EIP repository contains an "auto merge" feature to ease the workload for EIP
 
 1. Open Terminal.
 
-2. Check whether you have Ruby 2.1.0 or higher installed:
+2. Check whether you have Ruby 2.7.x or higher installed:
 
 ```sh
 $ ruby --version
 ```
 
-3. If you don't have Ruby installed, install Ruby 2.1.0 or higher.
+3. If you don't have Ruby installed, install Ruby 2.7.x or higher.
 
 4. Install Bundler:
 


### PR DESCRIPTION
Bump Ruby min dependency to `2.7.x` for [minimum normal maintenance](Bump Ruby min dependency to 2.7.x). The current ruby version `2.1` has been EOL since 2017.

Temporary upgrade before bumping up to ruby `3.0.0` (latest)

Related to https://github.com/ethereum/EIPs/pull/3598