### PR TITLE
Makes the EIPs site maximally responsive.

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -18,6 +18,6 @@
 
 main.page-content {
   div.wrapper {
-    max-width: calc(1280px - (30px * 2));
+    max-width: unset;
   }
 }


### PR DESCRIPTION
If you don't like full-width pages, you can resize your browser window.  When looking at code, having artificial width limits can lead to unnecessary scroll bars.