### PR TITLE
Fix typo in eip-627.md

### DIFF
--- a/EIPS/eip-627.md
+++ b/EIPS/eip-627.md
@@ -52,7 +52,7 @@ The following message codes are optional, but they are reserved for specific pur
 
 **Status** [`0`]
 
-This packet contains two objects: integer message code (0x00) followed by a list of values: integer version, float PoW requirement, and bloom filter, in this order. The bloom filter paramenter is optional; if it is missing or nil, the node is considered to be full node (i.e. accepts all messages). The format of PoW and bloom filter please see below (message codes 2 and 3).
+This packet contains two objects: integer message code (0x00) followed by a list of values: integer version, float PoW requirement, and bloom filter, in this order. The bloom filter parameter is optional; if it is missing or nil, the node is considered to be full node (i.e. accepts all messages). The format of PoW and bloom filter please see below (message codes 2 and 3).
 
 Status message should be sent after the initial handshake and prior to any other messages.
 


### PR DESCRIPTION
paramenter -> parameter
