### PR TITLE
3607: updated pseudocode, added diff

### DIFF
--- a/EIPS/eip-3607.md
+++ b/EIPS/eip-3607.md
@@ -74,14 +74,15 @@ A set of test cases can be found [here](https://github.com/ethereum/tests/pull/8
 ## Reference Implementation
 
 The following check must be added to the state transition checks after checking that the nonce of the sender is correct.
-```go
+```
 // Make sure the sender is an EOA
-if codesize := st.state.GetCodeSize(st.msg.From()); codesize != 0 {
+Set cs to the CodeSize of the sender account
+if cs is not 0 then
 	return ErrSenderNoEOA
-}
+end if
 ```
 
-An implementation in go-ethereum can be found [here](https://github.com/ethereum/go-ethereum/pull/23002)
+An diff to implement EIP-3607 in go-ethereum can be found [here](../assets/eip-3607/geth.diff)
 
 ## Security Considerations
 

--- a/EIPS/eip-3607.md
+++ b/EIPS/eip-3607.md
@@ -82,7 +82,7 @@ if cs is not 0 then
 end if
 ```
 
-An diff to implement EIP-3607 in go-ethereum can be found [here](../assets/eip-3607/geth.diff) 
+An diff to implement EIP-3607 in go-ethereum can be found [here](../assets/eip-3607/geth.diff)
 
 ## Security Considerations
 

--- a/EIPS/eip-3607.md
+++ b/EIPS/eip-3607.md
@@ -82,7 +82,7 @@ if cs is not 0 then
 end if
 ```
 
-An diff to implement EIP-3607 in go-ethereum can be found [here](../assets/eip-3607/geth.diff)
+An diff to implement EIP-3607 in go-ethereum can be found [here](../assets/eip-3607/geth.diff) 
 
 ## Security Considerations
 

--- a/assets/eip-3607/geth.diff
+++ b/assets/eip-3607/geth.diff
@@ -1,0 +1,16 @@
+diff --git a/core/state_transition.go b/core/state_transition.go
+index 18777d8d4..3b25155c6 100644
+--- a/core/state_transition.go
++++ b/core/state_transition.go
+@@ -219,6 +219,11 @@ func (st *StateTransition) preCheck() error {
+                                st.msg.From().Hex(), msgNonce, stNonce)
+                }
+        }
++       // Make sure the sender is an EOA
++       if codesize := st.state.GetCodeSize(st.msg.From()); codesize != 0 {
++               return fmt.Errorf("%w: address %v, codesize: %d", ErrSenderNoEOA,
++                       st.msg.From().Hex(), codesize)
++       }
+        // Make sure that transaction feeCap is greater than the baseFee (post london)
+        if st.evm.ChainConfig().IsLondon(st.evm.Context.BlockNumber) {
+                if l := st.feeCap.BitLen(); l > 256 {


### PR DESCRIPTION
Updates 3607 to use pseudocode instead of go.
Adds a git diff instead of a link to the implementation.