### PR TITLE
EIP2981 content revised ✍️

### DIFF
--- a/EIPS/eip-2981.md
+++ b/EIPS/eip-2981.md
@@ -23,7 +23,7 @@ There are many marketplaces for NFTs with multiple unique royalty payment implem
 
 Many of the largest NFT marketplaces have implemented bespoke royalty payment solutions that are incompatible with other marketplaces. This standard implements standardized royalty information retrieval that can be accepted across any type of NFT marketplace. This minimalist proposal only provides a mechanism to fetch the royalty amount and recipient. The actual funds transfer is something which the marketplace should execute.
 
-This standard allows NFTs that support [ERC-721](./eip-721.md) and [ERC-1155](./eip-1155.md) interfaces, to have a standardized way of signalling royalty information. More specifically, these contracts can now calculate a royalty amount and provide the rightful recipient of that royalty amount.
+This standard allows NFTs that support [ERC-721](./eip-721.md) and [ERC-1155](./eip-1155.md) interfaces, to have a standardized way of signalling royalty information. More specifically, these contracts can now calculate a royalty amount to provide to the rightful recipient.
 
 Royalty amounts are always a percentage of the sale price. If a marketplace chooses *not* to implement this EIP, then no funds will be paid for secondary sales. It is believed that the NFT marketplace ecosystem will voluntarily implement this royalty payment standard; in a bid to provide ongoing funding for artists/creators. NFT buyers will assess the royalty payment as a factor when making NFT purchasing decisions.
 
@@ -35,10 +35,10 @@ While this standard focuses on NFTs and compatibility with the ERC-721 and ERC-1
 
 Example conversation summarizing NFT royalty payments today:
 
->**Artist**: "Do you support royalty payments on your platform?          
->**Marketplace**: Yes we have royalty payments, but if your NFT is sold on another marketplace then we cannot enforce this payment.              
->**Artist**: What about other marketplaces that support royalties, don't you share my royalty information to make this work?              
->**Marketplace**: No, we do not share royalty information.
+>**Artist**: "Do you support royalty payments on your platform?"          
+>**Marketplace**: "Yes we have royalty payments, but if your NFT is sold on another marketplace then we cannot enforce this payment."              
+>**Artist**: "What about other marketplaces that support royalties, don't you share my royalty information to make this work?"              
+>**Marketplace**: "No, we do not share royalty information."
 
 ## Specification
 

--- a/EIPS/eip-2981.md
+++ b/EIPS/eip-2981.md
@@ -12,26 +12,33 @@ requires: 165
 
 ## Simple Summary
 
-A standardized way to retrieve royalty payment information for non-fungible tokens (NFTs) to enable universal support for royalty payments in all NFT marketplaces and ecosystem participants.
+A standardized way to retrieve royalty payment information for non-fungible tokens (NFTs) to enable universal support for royalty payments across all NFT marketplaces and ecosystem participants.
 
 ## Abstract
 
 This standard allows contracts, such as NFTs that support [ERC-721](./eip-721.md) and [ERC-1155](./eip-1155.md) interfaces, to signal a royalty amount to be paid to the NFT creator or rights holder every time the NFT is sold or re-sold. This is intended for NFT marketplaces that want to support the ongoing funding of artists and other NFT creators. The royalty payment must be voluntary, as transfer mechanisms such as `transferFrom()` include NFT transfers between wallets, and executing them does not always imply a sale occurred. Marketplaces and individuals implement this standard by retrieving the royalty payment information with `royaltyInfo()`, which specifies how much to pay to which address for a given sale price. The exact mechanism for paying and notifying the recipient will be defined in future EIPs. This ERC should be considered a minimal, gas-efficient building block for further innovation in NFT royalty payments.
 
 ## Motivation
-There are many marketplaces for NFTs with multiple unique royalty payment implementations that are not easily compatible or usable by other marketplaces. Just like the early days of ERC-20 tokens, NFT marketplace smart contracts are varied by ecosystem and not standardized. This EIP enables all marketplaces to retrieve royalty payment information that NFT creators specify and are entitled to, enabling accurate royalty payments regardless of which marketplace the NFT is sold or re-sold at.
+There are many marketplaces for NFTs with multiple unique royalty payment implementations that are not easily compatible or usable by other marketplaces. Just like the early days of ERC-20 tokens, NFT marketplace smart contracts are varied by ecosystem and not standardized. This EIP enables all marketplaces to retrieve royalty payment information for a given NFT. This enables accurate royalty payments regardless of which marketplace the NFT is sold or re-sold at.
 
-Many of the largest NFT marketplaces have implemented royalty payments that are incompatible with other platforms and therefore make it harder to enforce when the NFT is sold on another marketplace, not fulfilling the potential of any implemented royalty system. This standard implements standardized royalty information retrieval that can be accepted across any type of NFT marketplace. This minimalist proposal leaves the actual funds transfer up to the marketplace itself, and only provides a mechanism to fetch the royalty amounts. Future EIPs may build on this ERC to implement payment notifications and other features.
+Many of the largest NFT marketplaces have implemented bespoke royalty payment solutions that are incompatible with other marketplaces. This standard implements standardized royalty information retrieval that can be accepted across any type of NFT marketplace. This minimalist proposal only provides a mechanism to fetch the royalty amount and recipient. The actual funds transfer is something which the marketplace should execute.
 
-This standard allows contracts, such as NFTs that support [ERC-721](./eip-721.md) and [ERC-1155](./eip-1155.md) interfaces, to signal a royalty amount to be paid to the NFT creator or rights holder every time the NFT is sold or re-sold. Royalty amounts are always a fixed percentage of the sale price. If a marketplace chooses *not* to implement this EIP, then obviously no funds are paid for secondary sales. We've seen most NFT marketplaces already develop their own unique royalty systems. All of which are singular and only work within their own contracts. There must be an accepted standard for royalty payment information (if the creator chooses to set royalties on their NFTs). We believe the NFT marketplace ecosystem will voluntarily implement this royalty payment standard; in a bid to provide ongoing funding for artists/creators. NFT buyers will assess the royalty payment as a factor when making NFT purchasing decisions.
+This standard allows NFTs that support [ERC-721](./eip-721.md) and [ERC-1155](./eip-1155.md) interfaces, to have a standardized way of signalling royalty information. More specifically, these contracts can now calculate a royalty amount and provide the rightful recipient of that royalty amount.
+
+Royalty amounts are always a percentage of the sale price. If a marketplace chooses *not* to implement this EIP, then no funds will be paid for secondary sales. It is believed that the NFT marketplace ecosystem will voluntarily implement this royalty payment standard; in a bid to provide ongoing funding for artists/creators. NFT buyers will assess the royalty payment as a factor when making NFT purchasing decisions.
 
 Without an agreed royalty payment standard, the NFT ecosystem will lack an effective means to collect royalties across all marketplaces and artists and other creators will not receive ongoing funding. This will hamper the growth and adoption of NFTs and demotivate NFT creators from minting new and innovative tokens.
 
-Enabling all NFT marketplaces to unify on a single royalty payment standard will benefit the entire NFT ecosystem. An example conversation that highlights a key pain point between artists and marketplaces today is likely to be:
-
->*"Artist: Do you support royalty payments on your platform?" ... "Marketplace: Yes we have royalty payments, but if your NFT is sold on another marketplace then we cannot enforce this payment." ... "Artist: What about other marketplaces that support royalties, don't you share my royalty information to make this work?" ... "Marketplace: No, we do not share royalty information. That is not the correct approach for many reasons. The problem is with the absence of a royalty standard; meaning other marketplaces are unlikely to adhere to your original and bespoke royalty agreements. This means you'll lose out. We think that you shouldn't be tied to a specific marketplace to receive royalties that you're entitled to."*
+Enabling all NFT marketplaces to unify on a single royalty payment standard will benefit the entire NFT ecosystem.
 
 While this standard focuses on NFTs and compatibility with the ERC-721 and ERC-1155 standards, EIP-2981 does not require compatibility with ERC-721 and ERC-1155 standards. Any other contract could integrate with EIP-2981 to return royalty payment information. ERC-2981 is therefore a universal royalty standard for many asset types.
+
+Example conversation summarizing NFT royalty payments today:
+
+>**Artist**: "Do you support royalty payments on your platform?          
+>**Marketplace**: Yes we have royalty payments, but if your NFT is sold on another marketplace then we cannot enforce this payment.              
+>**Artist**: What about other marketplaces that support royalties, don't you share my royalty information to make this work?              
+>**Marketplace**: No, we do not share royalty information.
 
 ## Specification
 
@@ -44,13 +51,17 @@ RFC 2119.
 
 Marketplaces that support this standard **SHOULD** implement some method of transferring royalties to the royalty recipient. Standards for the actual transfer and notification of funds will be specified in future EIPs.
 
-Implementers of this standard **MUST** require that the sale price, the `_value` passed to `royaltyInfo()`, and the royalty payment must always be in the same unit of exchange. For example, if the sale price is in ETH, then the royalty payment must also be paid in ETH, and if the sale price is in USDC, then the royalty payment must also be paid in USDC.
+Implementers of this standard **MUST** require that the `_salePrice` parameter passed to `royaltyInfo()`, and the royalty payment must always be in the same unit of exchange. For example, if the sale price is in ETH, then the royalty payment must also be paid in ETH, and if the sale price is in USDC, then the royalty payment must also be paid in USDC.
 
-Implementers of this standard **MUST** use a fixed-percentage of the sale price when calculating the royalty amount. The fixed-percentage used must apply regardless of the sale price (i.e., if the royalty fee is 10%, then a 10% royalty fee **MUST** apply whether `_value` is 10, 10000, or 1234567890). If the royalty fee calculation results in a remainder, implementers **MAY** round up or round down to the nearest integer. For example, if the royalty fee is 10% and `_value` is 999, the implementer can return either 99 or 100 for `_royaltyAmount`) - both are valid.
+Implementers of this standard **MUST** calculate a percentage of the `_salePrice` when calculating the royalty amount. Subsequent invocations of `royaltyInfo()` **MAY** return a different `royaltyAmount`. Though there are some important considerations for implementers if they chose to perform different percentage calculations between `royaltyInfo()` invocations.
 
-Implementers of this standard **MAY** use a different fixed-percentage royalty fee for each different `_tokenId`. This EIP does not require the same fixed-percentage royalty fee for every asset - it can vary for each asset.
+The `royaltyInfo()` function is not aware of the unit of exchange for the sale and royalty payment. With that in mind, implementers **MUST NOT** return a fixed/constant `royaltyAmount`, wherein they're ignoring the `_salePrice`. For the same reason, implementers **MUST NOT** determine the `royaltyAmount` based on comparing the `_salePrice` with constant numbers. In both cases, the `royaltyInfo()` function makes assumptions on the unit of exchange, which **MUST** be avoided.
 
-Marketplaces that support this standard **SHOULD NOT** send a zero-value transaction if the `_royaltyAmount` returned is `0`. This would waste gas and serves no useful purpose in this EIP.
+The percentage value used must be independent of the sale price for reasons previously mentioned (i.e. if the percentage value 10%, then 10% **MUST** apply whether `_salePrice` is 10, 10000, or 1234567890). If the royalty fee calculation results in a remainder, implementers **MAY** round up or round down to the nearest integer. For example, if the royalty fee is 10% and `_salePrice` is 999, the implementer can return either 99 or 100 for `royaltyAmount`, both are valid.
+
+The implementer **MAY** chose to change the percentage value based on other predictable variables that do not make assumptions about the unit of exchange. For example, the percentage value may drop linearly over time. An approach like this **SHOULD NOT** be based on variables that are unpredictable like `block.timestamp`, but instead on other more predictable state changes. One more reasonable approach **MAY** use the number of transfers of an NFT to decide which percentage value is used to calculate the `royaltyAmount`. The idea being that the percentage value could decrease after each transfer of the NFT. Another example could be using a different percentage value for each unique `_tokenId`.
+
+Marketplaces that support this standard **SHOULD NOT** send a zero-value transaction if the `royaltyAmount` returned is `0`. This would waste gas and serves no useful purpose in this EIP.
 
 Marketplaces that support this standard **MUST** pay royalties no matter where the sale occurred or in what currency, including on-chain sales, over-the-counter (OTC) sales, and off-chain sales such as at auction houses. As royalty payments are voluntary, entities that respect this EIP must pay no matter where the sale occurred - a sale conducted outside of the blockchain is still a sale. The exact mechanism for paying and notifying the recipient will be defined in future EIPs.
 
@@ -74,15 +85,15 @@ interface IERC2981 is ERC165 {
     /// @notice Called with the sale price to determine how much royalty
     //          is owed and to whom.
     /// @param _tokenId - the NFT asset queried for royalty information
-    /// @param _value - the sale price of the NFT asset specified by _tokenId
-    /// @return _receiver - address of who should be sent the royalty payment
-    /// @return _royaltyAmount - the royalty payment amount for _value sale price
+    /// @param _salePrice - the sale price of the NFT asset specified by _tokenId
+    /// @return receiver - address of who should be sent the royalty payment
+    /// @return royaltyAmount - the royalty payment amount for _salePrice
     function royaltyInfo(
         uint256 _tokenId,
-        uint256 _value
+        uint256 _salePrice
     ) external view returns (
-        address _receiver,
-        uint256 _royaltyAmount
+        address receiver,
+        uint256 royaltyAmount
     );
 
     /// @notice Informs callers that this contract supports ERC2981
@@ -111,7 +122,7 @@ constructor (string memory name, string memory symbol, string memory baseURI) {
         _registerInterface(_INTERFACE_ID_ERC721);
         _registerInterface(_INTERFACE_ID_ERC721_METADATA);
         _registerInterface(_INTERFACE_ID_ERC721_ENUMERABLE);
-        // Royalties interface 
+        // Royalties interface
         _registerInterface(_INTERFACE_ID_ERC2981);
     }
 ```
@@ -122,7 +133,7 @@ constructor (string memory name, string memory symbol, string memory baseURI) {
 bytes4 private constant _INTERFACE_ID_ERC2981 = 0x2a55205a;
 
 function checkRoyalties(address _contract) internal returns (bool) {
-    (bool success) = IERC2981(_contract).supportsInterface(_INTERFACE_ID_ERC2981);
+    (bool success) = IERC165(_contract).supportsInterface(_INTERFACE_ID_ERC2981);
     return success;
  }
 ```
@@ -137,11 +148,17 @@ It is impossible to know which NFT transfers are the result of sales, and which 
 
 This EIP does not specify the manner of payment to the royalty recipient. Furthermore, it is impossible to fully know and efficiently implement all possible types of royalty payments logic. With that said, it is on the royalty payment receiver to implement all additional complexity and logic for fee splitting, multiple receivers, taxes, accounting, etc. in their own receiving contract or off-chain processes. Attempting to do this as part of this standard, it would dramatically increase the implementation complexity, increase gas costs, and could not possibly cover every potential use-case. This ERC should be considered a minimal, gas-efficient building block for further innovation in NFT royalty payments. Future EIPs can specify more details regarding payment transfer and notification.
 
-### Royalty payment fixed percentage of sale price
+### Royalty payment percentage calculation
 
-This EIP mandates a fixed-percentage royalty fee model. `_royaltyAmount` is always calculated from the sale price `_value` using a fixed percent - i.e. if the royalty fee is 10%, then a 10% royalty fee must apply whether `_value` is 10, 10000, or 1234567890.
+This EIP mandates a percentage-based royalty fee model. It is likely that the most common case of percentage calculation will be where the `royaltyAmount` is always calculated from the `_salePrice` using a fixed percent i.e. if the royalty fee is 10%, then a 10% royalty fee must apply whether `_salePrice` is 10, 10000, or 1234567890.
+As previously mentioned, implementers can get creative with this percentage-based calculation but there are some important caveats to consider. Mainly, ensuring that the `royaltyInfo()` function is not aware of the unit of exchange and that unpredictable variables are avoided in the percentage calculation. To follow up on the earlier `block.timestamp` example, there is some nuance which can be highlighted if the following events ensued:
 
-Rather than returning a percentage and letting the marketplace calculate the royalty amount based on the sale price, we return a specific `_royaltyAmount` so there is no dispute with a marketplace over how much is owed for a given sale price. The royalty fee payer must pay the `_royaltyAmount` that `royaltyInfo()` stipulates.
+1. Marketplace sells NFT.
+2. Marketplace delays `X` seconds before invoking `royaltyInfo()` and sending payment.
+3. Marketplace receives `Y` for `royaltyAmount` which was significantly different from the `royaltyAmount` amount that would've been calculated `X` seconds prior if no delay occurred.
+4. Buyer is dissatisfied with the delay from the marketplace and for this reason, they raise a dispute.
+
+Rather than returning a percentage and letting the marketplace calculate the royalty amount based on the sale price, a `royaltyAmount` value is returned so there is no dispute with a marketplace over how much is owed for a given sale price. The royalty fee payer must pay the `royaltyAmount` that `royaltyInfo()` stipulates.
 
 ### Unit-less royalty payment across all marketplaces, both on-chain and off-chain
 

--- a/EIPS/eip-2981.md
+++ b/EIPS/eip-2981.md
@@ -33,7 +33,7 @@ Enabling all NFT marketplaces to unify on a single royalty payment standard will
 
 While this standard focuses on NFTs and compatibility with the ERC-721 and ERC-1155 standards, EIP-2981 does not require compatibility with ERC-721 and ERC-1155 standards. Any other contract could integrate with EIP-2981 to return royalty payment information. ERC-2981 is therefore a universal royalty standard for many asset types.
 
-Example conversation summarizing NFT royalty payments today:
+At a glance, here's an example conversation summarizing NFT royalty payments today:
 
 >**Artist**: "Do you support royalty payments on your platform?"          
 >**Marketplace**: "Yes we have royalty payments, but if your NFT is sold on another marketplace then we cannot enforce this payment."              
@@ -69,12 +69,12 @@ Implementers of this standard **MUST** have all of the following functions:
 
 ```solidity
 pragma solidity ^0.6.0;
-import "./ERC165.sol";
+import "./IERC165.sol";
 
 ///
 /// @dev Interface for the NFT Royalty Standard
 ///
-interface IERC2981 is ERC165 {
+interface IERC2981 is IERC165 {
     /// ERC165 bytes to add to interface array - set in parent contract
     /// implementing this standard
     ///
@@ -151,11 +151,12 @@ This EIP does not specify the manner of payment to the royalty recipient. Furthe
 ### Royalty payment percentage calculation
 
 This EIP mandates a percentage-based royalty fee model. It is likely that the most common case of percentage calculation will be where the `royaltyAmount` is always calculated from the `_salePrice` using a fixed percent i.e. if the royalty fee is 10%, then a 10% royalty fee must apply whether `_salePrice` is 10, 10000, or 1234567890.
+
 As previously mentioned, implementers can get creative with this percentage-based calculation but there are some important caveats to consider. Mainly, ensuring that the `royaltyInfo()` function is not aware of the unit of exchange and that unpredictable variables are avoided in the percentage calculation. To follow up on the earlier `block.timestamp` example, there is some nuance which can be highlighted if the following events ensued:
 
 1. Marketplace sells NFT.
-2. Marketplace delays `X` seconds before invoking `royaltyInfo()` and sending payment.
-3. Marketplace receives `Y` for `royaltyAmount` which was significantly different from the `royaltyAmount` amount that would've been calculated `X` seconds prior if no delay occurred.
+2. Marketplace delays `X` days before invoking `royaltyInfo()` and sending payment.
+3. Marketplace receives `Y` for `royaltyAmount` which was significantly different from the `royaltyAmount` amount that would've been calculated `X` days prior if no delay had occurred.
 4. Royalty recipient is dissatisfied with the delay from the marketplace and for this reason, they raise a dispute.
 
 Rather than returning a percentage and letting the marketplace calculate the royalty amount based on the sale price, a `royaltyAmount` value is returned so there is no dispute with a marketplace over how much is owed for a given sale price. The royalty fee payer must pay the `royaltyAmount` that `royaltyInfo()` stipulates.

--- a/EIPS/eip-2981.md
+++ b/EIPS/eip-2981.md
@@ -156,7 +156,7 @@ As previously mentioned, implementers can get creative with this percentage-base
 1. Marketplace sells NFT.
 2. Marketplace delays `X` seconds before invoking `royaltyInfo()` and sending payment.
 3. Marketplace receives `Y` for `royaltyAmount` which was significantly different from the `royaltyAmount` amount that would've been calculated `X` seconds prior if no delay occurred.
-4. Buyer is dissatisfied with the delay from the marketplace and for this reason, they raise a dispute.
+4. Royalty recipient is dissatisfied with the delay from the marketplace and for this reason, they raise a dispute.
 
 Rather than returning a percentage and letting the marketplace calculate the royalty amount based on the sale price, a `royaltyAmount` value is returned so there is no dispute with a marketplace over how much is owed for a given sale price. The royalty fee payer must pay the `royaltyAmount` that `royaltyInfo()` stipulates.
 

--- a/EIPS/eip-2981.md
+++ b/EIPS/eip-2981.md
@@ -51,7 +51,7 @@ RFC 2119.
 
 Marketplaces that support this standard **SHOULD** implement some method of transferring royalties to the royalty recipient. Standards for the actual transfer and notification of funds will be specified in future EIPs.
 
-Implementers of this standard **MUST** require that the `_salePrice` parameter passed to `royaltyInfo()`, and the royalty payment must always be in the same unit of exchange. For example, if the sale price is in ETH, then the royalty payment must also be paid in ETH, and if the sale price is in USDC, then the royalty payment must also be paid in USDC.
+The `_salePrice` parameter and the `royaltyAmount` return value **MUST** be denominated in the same monetary unit. For example, if the sale price is in ETH, then the royalty payment must also be paid in ETH, and if the sale price is in USDC, then the royalty payment must also be paid in USDC.
 
 Implementers of this standard **MUST** calculate a percentage of the `_salePrice` when calculating the royalty amount. Subsequent invocations of `royaltyInfo()` **MAY** return a different `royaltyAmount`. Though there are some important considerations for implementers if they chose to perform different percentage calculations between `royaltyInfo()` invocations.
 


### PR DESCRIPTION
- _value is now _salePrice
- royaltyInfo() return values no longer have underscore prefix
- checkRoyalties function uses IERC165 interface instead of IERC2981 interface
- fixed-percentage wording revised 
- caveats added around percentage calculation
- conversation with artist and marketplace cleaned up
- ERC165 was being imported instead of IERC165

Also, I've removed parts where we repeated ourselves unnecessarily. 