### PR TITLE
3607: update to use empty code hash instead of codesize

### DIFF
--- a/EIPS/eip-3607.md
+++ b/EIPS/eip-3607.md
@@ -11,7 +11,7 @@ created: 2021-06-10
 
 ## Simple Summary
 
-Do not allow transactions for which `tx.sender` has any code deployed, i.e. `tx.sender` has `CODESIZE != 0`
+Do not allow transactions for which `tx.sender` has any code deployed, i.e. `tx.sender` has a `CODEHASH != EMPTYCODEHASH`
 
 ## Abstract
 
@@ -38,7 +38,8 @@ This EIP is to specify this behaviour to always forbid such transactions. This f
 
 ## Specification
 
-Any transaction where `tx.sender` has a `CODESIZE != 0` MUST be rejected as invalid.
+Any transaction where `tx.sender` has a `CODEHASH != EMPTYCODEHASH` MUST be rejected as invalid.
+With `EMPTYCODEHASH = 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470`.
 
 ## Rationale
 
@@ -76,8 +77,8 @@ A set of test cases can be found [here](https://github.com/ethereum/tests/pull/8
 The following check must be added to the state transition checks after checking that the nonce of the sender is correct.
 ```
 // Make sure the sender is an EOA
-Set cs to the CodeSize of the sender account
-if cs is not 0 then
+Set ch to the CodeHash of the sender account
+if cs is not equal to EmptyCodeHash then
 	return ErrSenderNoEOA
 end if
 ```

--- a/assets/eip-3607/geth.diff
+++ b/assets/eip-3607/geth.diff
@@ -7,9 +7,9 @@ index 18777d8d4..3b25155c6 100644
                 }
         }
 +       // Make sure the sender is an EOA
-+       if codesize := st.state.GetCodeSize(st.msg.From()); codesize != 0 {
-+               return fmt.Errorf("%w: address %v, codesize: %d", ErrSenderNoEOA,
-+                       st.msg.From().Hex(), codesize)
++       if codeHash := st.state.GetCodeHash(st.msg.From()); codeHash != emptyCodeHash {
++               return fmt.Errorf("%w: address %v, codehash: %s", ErrSenderNoEOA,
++                       st.msg.From().Hex(), codeHash)
 +       }
         // Make sure that transaction feeCap is greater than the baseFee (post london)
         if st.evm.ChainConfig().IsLondon(st.evm.Context.BlockNumber) {


### PR DESCRIPTION
As discussed on last ACD, we'd rather use the empty code hash instead of the code size cc @dankrad 