### PR TITLE
EIP-3541: fix erroneous comment

### DIFF
--- a/EIPS/eip-3541.md
+++ b/EIPS/eip-3541.md
@@ -38,7 +38,7 @@ The `0xEF` byte was chosen because it resembles **E**xecutable **F**ormat.
 
 Contracts using unassigned opcodes are generally understood to be at risk of changing semantics. Hence using the unassigned `0xEF` should have lesser effects, than choosing an assigned opcode, such as `0xFD` (`REVERT`), `0xFE` (`INVALID)`, or `0xFF` (`SELFDESTRUCT`). Arguably while such contracts may not be very useful, they are still using valid opcodes.
 
-Analysis at block 18084433 showed that there are 0 existing contracts starting with the `0xEF` byte, as opposed to 1, 4, and 12 starting with `0xFD`, `0xFE`, and `0xFF`, respectively.
+Analysis in May 2021, on `18084433` contracts in state, showed that there are 0 existing contracts starting with the `0xEF` byte, as opposed to 1, 4, and 12 starting with `0xFD`, `0xFE`, and `0xFF`, respectively.
 
 ## Test Cases
 


### PR DESCRIPTION
The info in the eip is wrong, see https://gist.github.com/holiman/466cf6598e4a967620b9833b5ce49a23. The actual block number where the state was based on, for some reason, got lost, and the number in the eip is something else (right now, the EIP-blocknumber the analysis was based on won't be mined for a few years yet). 