### PR TITLE
EIP2981 status changed to 'Last Call'. ✍️ 

### DIFF
--- a/EIPS/eip-2981.md
+++ b/EIPS/eip-2981.md
@@ -4,6 +4,7 @@ title: NFT Royalty Standard
 author: Zach Burks (@vexycats), James Morgan (@jamesmorgan), Blaine Malone (@blmalone), James Seibel (@seibelj)
 discussions-to: https://github.com/ethereum/EIPs/issues/2907
 status: Last Call
+Review period ends: 2021-07-16
 type: Standards Track
 category: ERC
 created: 2020-09-15

--- a/EIPS/eip-2981.md
+++ b/EIPS/eip-2981.md
@@ -4,7 +4,7 @@ title: NFT Royalty Standard
 author: Zach Burks (@vexycats), James Morgan (@jamesmorgan), Blaine Malone (@blmalone), James Seibel (@seibelj)
 discussions-to: https://github.com/ethereum/EIPs/issues/2907
 status: Last Call
-review-period-end: 2021-07-16
+review-period-end: 2021-07-22
 type: Standards Track
 category: ERC
 created: 2020-09-15

--- a/EIPS/eip-2981.md
+++ b/EIPS/eip-2981.md
@@ -4,7 +4,7 @@ title: NFT Royalty Standard
 author: Zach Burks (@vexycats), James Morgan (@jamesmorgan), Blaine Malone (@blmalone), James Seibel (@seibelj)
 discussions-to: https://github.com/ethereum/EIPs/issues/2907
 status: Last Call
-Review period ends: 2021-07-16
+review-period-end: 2021-07-16
 type: Standards Track
 category: ERC
 created: 2020-09-15

--- a/EIPS/eip-2981.md
+++ b/EIPS/eip-2981.md
@@ -3,7 +3,7 @@ eip: 2981
 title: NFT Royalty Standard
 author: Zach Burks (@vexycats), James Morgan (@jamesmorgan), Blaine Malone (@blmalone), James Seibel (@seibelj)
 discussions-to: https://github.com/ethereum/EIPs/issues/2907
-status: Review
+status: Last Call
 type: Standards Track
 category: ERC
 created: 2020-09-15
@@ -150,7 +150,7 @@ This EIP does not specify the manner of payment to the royalty recipient. Furthe
 
 ### Royalty payment percentage calculation
 
-This EIP mandates a percentage-based royalty fee model. It is likely that the most common case of percentage calculation will be where the `royaltyAmount` is always calculated from the `_salePrice` using a fixed percent i.e. if the royalty fee is 10%, then a 10% royalty fee must apply whether `_salePrice` is 10, 10000, or 1234567890.
+This EIP mandates a percentage-based royalty fee model. It is likely that the most common case of percentage calculation will be where the `royaltyAmount` is always calculated from the `_salePrice` using a fixed percent i.e. if the royalty fee is 10%, then a 10% royalty fee must apply whether `_salePrice` is 10, 10000 or 1234567890.
 
 As previously mentioned, implementers can get creative with this percentage-based calculation but there are some important caveats to consider. Mainly, ensuring that the `royaltyInfo()` function is not aware of the unit of exchange and that unpredictable variables are avoided in the percentage calculation. To follow up on the earlier `block.timestamp` example, there is some nuance which can be highlighted if the following events ensued:
 


### PR DESCRIPTION
fix: updating eip-2981 status from 'Review' to 'Last Call'.