### PR TITLE
1559: Removes unnecessary max

### DIFF
--- a/EIPS/eip-1559.md
+++ b/EIPS/eip-1559.md
@@ -192,7 +192,7 @@ class World(ABC):
 		else:
 			gas_used_delta = parent_gas_target - parent_gas_used
 			base_fee_per_gas_delta = parent_base_fee_per_gas * gas_used_delta // parent_gas_target // BASE_FEE_MAX_CHANGE_DENOMINATOR
-			expected_base_fee_per_gas = max(parent_base_fee_per_gas - base_fee_per_gas_delta, 0)
+			expected_base_fee_per_gas = parent_base_fee_per_gas - base_fee_per_gas_delta
 		assert expected_base_fee_per_gas == block.base_fee_per_gas, 'invalid block: base fee not correct'
 
 		# execute transactions and do gas accounting


### PR DESCRIPTION
We can prove that the `parent_base_fee_per_gas - base_fee_per_gas_delta > 0`, so flooring to 0 is unnecessary.