### PR TITLE
Fix discussions-to url of EIP-3541

### DIFF
--- a/EIPS/eip-3541.md
+++ b/EIPS/eip-3541.md
@@ -2,7 +2,7 @@
 eip: 3541
 title: Reject new contracts starting with the 0xEF byte
 author: Alex Beregszaszi (@axic), Paweł Bylica (@chfast), Andrei Maiboroda (@gumb0), Alexey Akhunov (@AlexeyAkhunov), Christian Reitwiessner (@chriseth), Martin Swende (@holiman)
-discussions-to: https://ethereum-magicians.org/t/evm-object-format-eof/5727/4
+discussions-to: https://ethereum-magicians.org/t/evm-object-format-eof/5727
 status: Last Call
 review-period-end: 2021-07-14
 type: Standards Track


### PR DESCRIPTION
It was pointing to a comment and not the topic starter.