### PR TITLE
Promote EIP-3436 to Review

### DIFF
--- a/EIPS/eip-3436.md
+++ b/EIPS/eip-3436.md
@@ -3,7 +3,7 @@ eip: 3436
 title: Expanded Clique Block Choice Rule
 author: Danno Ferrin (@shemnon)
 discussions-to: https://ethereum-magicians.org/t/eip-3436-expanded-clique-block-choice-rule/5809
-status: Draft
+status: Review
 type: Standards Track
 category: Networking
 created: 2021-03-25


### PR DESCRIPTION
As per author, the proposal is ready to be moved to "Review" status.

Feedbacks are requested at eth-magicians. - https://ethereum-magicians.org/t/eip-3436-expanded-clique-block-choice-rule/5809/5
