### PR TITLE
Move eip-2535 to Review

### DIFF
--- a/EIPS/eip-2535.md
+++ b/EIPS/eip-2535.md
@@ -3,7 +3,7 @@ eip: 2535
 title: Diamonds
 author: Nick Mudge (@mudgen)
 discussions-to: https://github.com/ethereum/EIPs/issues/2535
-status: Draft
+status: Review
 type: Standards Track
 category: ERC
 created: 2020-02-22
@@ -459,7 +459,7 @@ interface IDiamondLoupe {
 }
 ```
 
-See an [example implementation](https://github.com/mudgen/Diamond) to see how this can be implemented.
+See a [reference implementation](https://github.com/mudgen/Diamond) to see how this can be implemented.
 
 The loupe functions can be used in user-interface software. A user interface calls these functions to provide information about and visualize diamonds.
 
@@ -483,7 +483,7 @@ The diamond address is the address that users interact with. The diamond address
 
 ## Implementation
 
-Example diamond implementations exist in the [Diamond repository](https://github.com/mudgen/Diamond).
+Reference diamond implementations exist in the [Diamond repository](https://github.com/mudgen/Diamond).
 
 ## Rationale
 
@@ -504,7 +504,7 @@ Delegating function calls does have some gas overhead. This is mitigated in seve
 
 ### Diamond Storage
 
-Since Solidity 0.6.4 it is possible to create pointers to structs in arbitrary places in contract storage. This enables diamonds and their facets to create their own storage layouts that are separate from each other and do not conflict with each other, but can still be shared between them. See this blog post for more information: [New Storage Layout For Proxy Contracts and Diamonds](https://medium.com/1milliondevs/new-storage-layout-for-proxy-contracts-and-diamonds-98d01d0eadb). The example implementation for EIP-2535 uses diamond storage.
+Since Solidity 0.6.4 it is possible to create pointers to structs in arbitrary places in contract storage. This enables diamonds and their facets to create their own storage layouts that are separate from each other and do not conflict with each other, but can still be shared between them. See this blog post for more information: [New Storage Layout For Proxy Contracts and Diamonds](https://medium.com/1milliondevs/new-storage-layout-for-proxy-contracts-and-diamonds-98d01d0eadb). The reference implementations for EIP-2535 uses diamond storage.
 
 Diamond storage is not the same thing as unstructured storage. Unstructured storage reads and writes specific values like unsigned integers and addresses at specified locations in contract storage. Diamond storage uses structs at specified locations in contract storage for reading and writing. Structs can hold any number of state variables of any type.
 
@@ -590,6 +590,10 @@ This standard makes upgradeable diamonds compatible with future standards and fu
 
 ### Diamond Articles
 
+[Introduction to the Diamond Standard, EIP-2535 Diamonds](https://eip2535diamonds.substack.com/p/introduction-to-the-diamond-standard)
+
+[Smart Contract Security Audits for EIP-2535 Diamonds Implementations](https://eip2535diamonds.substack.com/p/smart-contract-security-audits-for)
+
 [Why Ethereum Diamonds Need A Standard](https://dev.to/mudgen/why-diamonds-need-a-standard-1i1h)
 
 [Ethereum's Maximum Contract Size Limit is Solved with EIP-2535 Diamonds](https://dev.to/mudgen/ethereum-s-maximum-contract-size-limit-is-solved-with-the-diamond-standard-2189)
@@ -630,7 +634,7 @@ This standard makes upgradeable diamonds compatible with future standards and fu
 
 ### Implementations
 
-[Diamond example implementations](https://github.com/mudgen/Diamond)
+[Diamond reference implementations](https://github.com/mudgen/Diamond)
 
 [GHST Staking](https://github.com/aavegotchi/ghst-staking)
 

--- a/EIPS/eip-2535.md
+++ b/EIPS/eip-2535.md
@@ -3,8 +3,7 @@ eip: 2535
 title: Diamonds
 author: Nick Mudge (@mudgen)
 discussions-to: https://github.com/ethereum/EIPs/issues/2535
-status: Last Call
-review-period-end: 2021-08-05
+status: Review
 type: Standards Track
 category: ERC
 created: 2020-02-22

--- a/EIPS/eip-2535.md
+++ b/EIPS/eip-2535.md
@@ -3,7 +3,8 @@ eip: 2535
 title: Diamonds
 author: Nick Mudge (@mudgen)
 discussions-to: https://github.com/ethereum/EIPs/issues/2535
-status: Draft
+status: Last Call
+review-period-end: 2021-08-05
 type: Standards Track
 category: ERC
 created: 2020-02-22

--- a/EIPS/eip-2535.md
+++ b/EIPS/eip-2535.md
@@ -3,7 +3,7 @@ eip: 2535
 title: Diamonds
 author: Nick Mudge (@mudgen)
 discussions-to: https://github.com/ethereum/EIPs/issues/2535
-status: Review
+status: Draft
 type: Standards Track
 category: ERC
 created: 2020-02-22


### PR DESCRIPTION
EIP-2535 has had feedback and been reviewed for many months. It is ready to move to Last Call.

Here is a link to a list of projects that are already using EIP-2535: https://eip2535diamonds.substack.com/p/list-of-projects-using-eip-2535-diamonds

Here is a link to a list of smart contract security audits that have been done that include the EIP-2535 reference implementations: https://eip2535diamonds.substack.com/p/smart-contract-security-audits-for