### PR TITLE
1559: Change signer.balance assertion location

### DIFF
--- a/EIPS/eip-1559.md
+++ b/EIPS/eip-1559.md
@@ -206,6 +206,8 @@ class World(ABC):
 
 			signer.balance -= transaction.amount
 			assert signer.balance >= 0, 'invalid transaction: signer does not have enough ETH to cover attached value'
+			# the signer must be able to afford the transaction
+			assert signer.balance >= transaction.gas_limit * transaction.max_fee_per_gas
 
 			# ensure that the user was willing to at least pay the base fee
 			assert transaction.max_fee_per_gas >= block.base_fee_per_gas
@@ -217,8 +219,6 @@ class World(ABC):
 			assert transaction.max_priority_fee_per_gas < 2**256
 			# The total must be the larger of the two
 			assert transaction.max_fee_per_gas >= transaction.max_priority_fee_per_gas
-			# the signer must be able to afford the transaction
-			assert signer.balance >= transaction.gas_limit * transaction.max_fee_per_gas
 
 			# priority fee is capped because the base fee is filled first
 			priority_fee_per_gas = min(transaction.max_priority_fee_per_gas, transaction.max_fee_per_gas - block.base_fee_per_gas)


### PR DESCRIPTION
After the [Ropsten consensus issue](https://github.com/ethereum/eth1.0-specs/blob/master/network-upgrades/retrospectives/london.md) it was noted that the ordering of the `assert` statements made it unclear that the `signer.balance` field in `assert signer.balance >= transaction.gas_limit * transaction.max_fee_per_gas` had already had `transaction.amount` deducted from it (L207). This change simply bring up this `assert` statement closer to other assertions for `signer.balance` to increase clarity. 