### PR TITLE
Move eip-2535 to Last Call

### DIFF
--- a/EIPS/eip-2535.md
+++ b/EIPS/eip-2535.md
@@ -4,7 +4,7 @@ title: Diamonds, Multi-Facet Proxy
 author: Nick Mudge (@mudgen)
 discussions-to: https://github.com/ethereum/EIPs/issues/2535
 status: Last Call
-review-period-end: 2020-08-11
+review-period-end: 2020-08-15
 type: Standards Track
 category: ERC
 created: 2020-02-22

--- a/EIPS/eip-2535.md
+++ b/EIPS/eip-2535.md
@@ -3,7 +3,8 @@ eip: 2535
 title: Diamonds
 author: Nick Mudge (@mudgen)
 discussions-to: https://github.com/ethereum/EIPs/issues/2535
-status: Review
+status: Last Call
+review-period-end: 2020-08-11
 type: Standards Track
 category: ERC
 created: 2020-02-22

--- a/EIPS/eip-2535.md
+++ b/EIPS/eip-2535.md
@@ -1,6 +1,6 @@
 ---
 eip: 2535
-title: Diamonds
+title: Diamonds, Multi-Facet Proxy
 author: Nick Mudge (@mudgen)
 discussions-to: https://github.com/ethereum/EIPs/issues/2535
 status: Last Call


### PR DESCRIPTION
[EIP-2535](https://eips.ethereum.org/EIPS/eip-2535) is ready to move to Last Call.

EIP-2535 is a standard for building modular smart contract systems that can be extended in production.
An introduction to it is here: https://eip2535diamonds.substack.com/p/introduction-to-the-diamond-standard

EIP-2535 was released in February 2020. The standard has gotten a lot of feedback and much experience has been gained with it by implementing diamonds and using them in production. Feedback and experience started in 2018 when [EIP-1538](https://eips.ethereum.org/EIPS/eip-1538) was released. EIP-2535 is an improvement upon EIP-1538.

More than 20 projects are using EIP-2535.  Here is a link to a list of projects that are using EIP-2535: https://eip2535diamonds.substack.com/p/list-of-projects-using-eip-2535-diamonds

Here is a link to a list of smart contract security audits that have been done that include the EIP-2535 reference implementations: https://eip2535diamonds.substack.com/p/smart-contract-security-audits-for

Recently some discussion and feedback was done about possibly changing the title of the standard, "Diamonds". This was considered. There was a poll done that was sent out to the 200+ people in the EIP-2535 Diamonds discord about possibly changing the name. The poll is [here](https://twitter.com/mudgen/status/1419865781169446915). Also the poll was sent to the [EIP-2535 github issue](https://github.com/ethereum/EIPs/issues/2535). There wasn't enough consensus to change the name.