### PR TITLE
1559: Remove deprecated comment

### DIFF
--- a/EIPS/eip-1559.md
+++ b/EIPS/eip-1559.md
@@ -212,7 +212,6 @@ class World(ABC):
 			# ensure that the user was willing to at least pay the base fee
 			assert transaction.max_fee_per_gas >= block.base_fee_per_gas
 
-			# The first two of these four rules are implicit due to the next two rules
 			# Prevent impossibly large numbers
 			assert transaction.max_fee_per_gas < 2**256
 			# Prevent impossibly large numbers


### PR DESCRIPTION
The comment is deprecated after https://github.com/ethereum/EIPs/pull/3681 was merged