### PR TITLE
EIP 1271: fix implementation example signature validation

### DIFF
--- a/EIPS/eip-1271.md
+++ b/EIPS/eip-1271.md
@@ -106,7 +106,7 @@ Example implementation of a signing contract:
     bytes32 _hash,
     bytes memory _signature
   ) internal pure returns (address signer) {
-    require(_signature.length == 66, "SignatureValidator#recoverSigner: invalid signature length");
+    require(_signature.length == 65, "SignatureValidator#recoverSigner: invalid signature length");
 
     // Variables are not scoped in Solidity.
     uint8 v = uint8(_signature[64]);


### PR DESCRIPTION
The industry standard is to encode signatures as `(bytes32 r, bytes32 s, uint8 v)` in 65 bytes, which is evident here: https://github.com/OpenZeppelin/openzeppelin-contracts/blob/d3c5bdf4def690228b08e0ac431437288a50e64a/contracts/utils/cryptography/ECDSA.sol#L32

But also in the implementation code which reads the first 32 bytes as r, then the next as s, and the last byte as v

However, it checks if the signature is 66 bytes long, rather than the 65 which it reads. As such I believe this is an error in the example.

----

When opening a pull request to submit a new EIP, please use the suggested template: https://github.com/ethereum/EIPs/blob/master/eip-template.md

We have a GitHub bot that automatically merges some PRs. It will merge yours immediately if certain criteria are met:

 - The PR edits only existing draft PRs.
 - The build passes.
 - Your GitHub username or email address is listed in the 'author' header of all affected PRs, inside <triangular brackets>.
 - If matching on email address, the email address is the one publicly listed on your GitHub profile.
