### PR TITLE
EIP 1155: fix invalid link

### DIFF
--- a/EIPS/eip-1155.md
+++ b/EIPS/eip-1155.md
@@ -399,7 +399,7 @@ Example of such a URI: `https://token-cdn-domain/{id}.json` would be replaced wi
 
 #### Metadata Extensions
 
-The optional `ERC1155Metadata_URI` extension can be identified with the (ERC-165 Standard Interface Detection)[./eip-165.md].
+The optional `ERC1155Metadata_URI` extension can be identified with the [ERC-165 Standard Interface Detection](./eip-165.md).
 
 If the optional `ERC1155Metadata_URI` extension is included:
 * The ERC-165 `supportsInterface` function MUST return the constant value `true` if `0x0e89341c` is passed through the `interfaceID` argument.


### PR DESCRIPTION
Fixed `ERC-165 Standard Interface Detection` link which is invalid because of typo.