### PR TITLE
Announce hard forks and allow discussion before top-down decision making

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Hard forks will not happen unless they are announced here first.
+
 # Ethereum Improvement Proposals (EIPs)
 
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/ethereum/EIPs?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)


### PR DESCRIPTION
This adds a specification that hard forks will be announced as EIPs BEFORE they are decided or scheduled.

Why I am first learning about London hard fork on Reuters? I am subscribed to EIPs, I created the Last Call process and the RSS feeds, we got everybody to agree to them. And still, last-minute upgrades are happening with Ethereum for EIPs that are not even in Final status (https://eips.ethereum.org/EIPS/eip-1559).

And this is the same thing that happened last upgrade.

If Ethereum will maintain the appearance that decisions include community input, can we please respect the processes we have for change management at least sometimes?

ping @Souptacular 