### PR TITLE
[PROPOSAL] Add `TERMINAL_TOTAL_DIFFICULTY` override to EIP 3675

### DIFF
--- a/EIPS/eip-3675.md
+++ b/EIPS/eip-3675.md
@@ -126,8 +126,6 @@ Beginning with the first `POS_BLOCK_FINALIZED` event, peers that keep sending th
 
 ### `TERMINAL_TOTAL_DIFFICULTY` override
 
-Considering [network anomalies and/or attack scenarios](#ability-to-jump-between-terminal-pow-blocks), it may be necessary to quickly coordinate on a change in the transition point.
-
 Ethereum clients should support a `--terminal-total-difficulty-override DIFFICULTY` parameter that allows users to specify an override to `TERMINAL_TOTAL_DIFFICULTY`.
 
 *Note*: This client setting is only expected to be used in the event of unforseen exceptional scenarios. Docs should contain sufficient warnings of this flag's misusage.
@@ -181,6 +179,12 @@ The fork choice rule of the PoW mechanism becomes completely irrelevant after th
 After the upgrade of the consensus mechanism only the beacon chain network will have enough information to validate a block. Thus, block gossip provided by the `eth` network protocol will become unsafe and is deprecated in favour of the block gossip existing in the beacon chain network. 
 
 It is recommended for the client software to not propagate descendants of any terminal PoW block to reduce the load on processing the P2P component and stop operating in the environment with unknown security properties.
+
+### Allowing for transition difficulty changes
+
+Considering [network anomalies and/or attack scenarios](#ability-to-jump-between-terminal-pow-blocks), it may be necessary to quickly coordinate on a change in the transition point. 
+
+The `--terminal-total-difficulty-override` makes it easier to coordinate on difficulty changes out of band.
 
 ## Test Cases
 *TBD*

--- a/EIPS/eip-3675.md
+++ b/EIPS/eip-3675.md
@@ -126,7 +126,7 @@ Beginning with the first `POS_BLOCK_FINALIZED` event, peers that keep sending th
 
 ### `TERMINAL_TOTAL_DIFFICULTY` override
 
-Ethereum clients should support a `--terminal-total-difficulty-override DIFFICULTY` parameter that allows users to specify an override to `TERMINAL_TOTAL_DIFFICULTY`.
+Ethereum clients **SHOULD** support a `--terminal-total-difficulty-override DIFFICULTY` parameter that allows users to specify an override to `TERMINAL_TOTAL_DIFFICULTY`.
 
 *Note*: This client setting is only expected to be used in the event of unforseen exceptional scenarios. Docs should contain sufficient warnings of this flag's misusage.
 

--- a/EIPS/eip-3675.md
+++ b/EIPS/eip-3675.md
@@ -126,9 +126,11 @@ Beginning with the first `POS_BLOCK_FINALIZED` event, peers that keep sending th
 
 ### `TERMINAL_TOTAL_DIFFICULTY` override
 
-Considering [fork anomalies](#ability-to-jump-between-terminal-pow-blocks), it may be necessary to quickly coordinate on a change in the transition point. 
+Considering [network anomalies and/or attack scenarios](#ability-to-jump-between-terminal-pow-blocks), it may be necessary to quickly coordinate on a change in the transition point.
 
-Ethereum clients are suggested to add a `--terminal-total-difficulty-override DIFFICULTY` parameter that allows users to specify an override to `TERMINAL_TOTAL_DIFFICULTY`.
+Ethereum clients should support a `--terminal-total-difficulty-override DIFFICULTY` parameter that allows users to specify an override to `TERMINAL_TOTAL_DIFFICULTY`.
+
+*Note*: This client setting is only expected to be used in the event of unforseen exceptional scenarios. Docs should contain sufficient warnings of this flag's misusage.
 
 ## Rationale
 

--- a/EIPS/eip-3675.md
+++ b/EIPS/eip-3675.md
@@ -128,7 +128,7 @@ Beginning with the first `POS_BLOCK_FINALIZED` event, peers that keep sending th
 
 Ethereum clients **SHOULD** support a `--terminal-total-difficulty-override DIFFICULTY` parameter that allows users to specify an override to `TERMINAL_TOTAL_DIFFICULTY`.
 
-*Note*: This client setting is only expected to be used in the event of unforseen exceptional scenarios. Docs should contain sufficient warnings of this flag's misusage.
+*Note*: This client setting is only expected to be used in the event of unforeseen exceptional scenarios. Docs should contain sufficient warnings of this flag's misusage.
 
 ## Rationale
 

--- a/EIPS/eip-3675.md
+++ b/EIPS/eip-3675.md
@@ -124,6 +124,11 @@ Beginning with the first `POS_BLOCK_FINALIZED` event, peers that keep sending th
 
 *Note:* The logic of message handlers that are not affected by this section **MUST** remain unchanged.
 
+### `TERMINAL_TOTAL_DIFFICULTY` override
+
+Considering [fork anomalies](#ability-to-jump-between-terminal-pow-blocks), it may be necessary to quickly coordinate on a change in the transition point. 
+
+Ethereum clients are suggested to add a `--terminal-total-difficulty-override DIFFICULTY` parameter that allows users to specify an override to `TERMINAL_TOTAL_DIFFICULTY`.
 
 ## Rationale
 

--- a/EIPS/eip-3675.md
+++ b/EIPS/eip-3675.md
@@ -182,7 +182,7 @@ It is recommended for the client software to not propagate descendants of any te
 
 ### Allowing for transition difficulty changes
 
-Considering [network anomalies and/or attack scenarios](#ability-to-jump-between-terminal-pow-blocks), it may be necessary to quickly coordinate on a change in the transition point. 
+Considering [network anomalies](#ability-to-jump-between-terminal-pow-blocks) and/or attack scenarios, it may be necessary to quickly coordinate on a change in the transition point. 
 
 The `--terminal-total-difficulty-override` makes it easier to coordinate on difficulty changes out of band.
 


### PR DESCRIPTION
In the case of [adversarial action to disrupt the point of transition](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-3675.md#ability-to-jump-between-terminal-pow-blocks), we may want to specify a mechanism for clients to quickly change the transition point. 

This PR adds a client setting to the spec (`--terminal-total-difficulty-override`) that enables this.