### PR TITLE
Promote EIP-3198 to Final.

### DIFF
--- a/EIPS/eip-3198.md
+++ b/EIPS/eip-3198.md
@@ -3,8 +3,7 @@ eip: 3198
 title: BASEFEE opcode
 author: Abdelhamid Bakhta (@abdelhamidbakhta), Vitalik Buterin (@vbuterin)
 discussions-to: https://ethereum-magicians.org/t/eip-3198-basefeeopcode/5162
-status: Last Call
-review-period-end: 2021-07-14
+status: Final
 type: Standards Track
 category: Core
 created: 2021-01-13


### PR DESCRIPTION
EIP-3198 deployed on the mainnet with the London upgrade.