### PR TITLE
Promote EIP-3541 to Final.

### DIFF
--- a/EIPS/eip-3541.md
+++ b/EIPS/eip-3541.md
@@ -3,8 +3,7 @@ eip: 3541
 title: Reject new contracts starting with the 0xEF byte
 author: Alex Beregszaszi (@axic), Paweł Bylica (@chfast), Andrei Maiboroda (@gumb0), Alexey Akhunov (@AlexeyAkhunov), Christian Reitwiessner (@chriseth), Martin Swende (@holiman)
 discussions-to: https://ethereum-magicians.org/t/evm-object-format-eof/5727
-status: Last Call
-review-period-end: 2021-07-14
+status: Final
 type: Standards Track
 category: Core
 created: 2021-03-16


### PR DESCRIPTION
EIP-3541 deployed on the mainnet with the London upgrade.