### PR TITLE
Promote EIP-3554 to Final.

### DIFF
--- a/EIPS/eip-3554.md
+++ b/EIPS/eip-3554.md
@@ -3,8 +3,7 @@ eip: 3554
 title: Difficulty Bomb Delay to December 2021
 author: James Hancock (@madeoftin)
 discussions-to: https://ethereum-magicians.org/t/eip-3554-ice-age-delay-targeting-december-2021/6188
-status: Last Call
-review-period-end: 2021-07-14
+status: Final
 type: Standards Track
 category: Core
 created: 2021-05-06


### PR DESCRIPTION
EIP-3554 deployed on the mainnet with London upgrade.