### PR TITLE
3541: clarify the title

### DIFF
--- a/EIPS/eip-3541.md
+++ b/EIPS/eip-3541.md
@@ -1,6 +1,6 @@
 ---
 eip: 3541
-title: Reject new contracts starting with the 0xEF byte
+title: Reject new contract code starting with the 0xEF byte
 author: Alex Beregszaszi (@axic), Paweł Bylica (@chfast), Andrei Maiboroda (@gumb0), Alexey Akhunov (@AlexeyAkhunov), Christian Reitwiessner (@chriseth), Martin Swende (@holiman)
 discussions-to: https://ethereum-magicians.org/t/evm-object-format-eof/5727
 status: Last Call


### PR DESCRIPTION
Recently on Twitter it seems a common misunderstanding is that the rejection is for the contract address. This clarifies it.