### PR TITLE
Add description field to the EIP header

### DIFF
--- a/EIPS/eip-1.md
+++ b/EIPS/eip-1.md
@@ -119,6 +119,8 @@ Each EIP must begin with an [RFC 822](https://www.ietf.org/rfc/rfc822.txt) style
 
 ` title:` *EIP title*
 
+` description:` *Provide a simplified and layman-accessible explanation of the EIP.*
+
 ` author:` *a list of the author's or authors' name(s) and/or username(s), or name(s) and email(s). Details are below.*
 
 ` * discussions-to:` *a url pointing to the official discussion thread*

--- a/EIPS/eip-1.md
+++ b/EIPS/eip-1.md
@@ -96,7 +96,7 @@ If this period results in necessary normative changes it will revert the EIP to 
 
 Each EIP should have the following parts:
 
-- Preamble - RFC 822 style headers containing metadata about the EIP, including the EIP number, a short descriptive title (limited to a maximum of 44 characters), and the author details. Irrespective of the category, the title should not include EIP number. See [below](./eip-1.md#eip-header-preamble) for details.
+- Preamble - RFC 822 style headers containing metadata about the EIP, including the EIP number, a short descriptive title (limited to a maximum of 44 characters), a description (limited to a maximum of 140 characters), and the author details. Irrespective of the category, the title and description should not include EIP number. See [below](./eip-1.md#eip-header-preamble) for details.
 - Abstract - Abstract is a multi-sentence (short paragraph) technical summary. This should be a very terse and human-readable version of the specification section. Someone should be able to read only the abstract to get the gist of what this specification does.
 - Motivation (*optional) - A motivation section is critical for EIPs that want to change the Ethereum protocol. It should clearly explain why the existing protocol specification is inadequate to address the problem that the EIP solves. EIP submissions without sufficient motivation may be rejected outright.
 - Specification - The technical specification should describe the syntax and semantics of any new feature. The specification should be detailed enough to allow competing, interoperable implementations for any of the current Ethereum platforms (cpp-ethereum, go-ethereum, parity, ethereumJ, ethereumjs-lib, [and others](https://github.com/ethereum/wiki/wiki/Clients).

--- a/EIPS/eip-1.md
+++ b/EIPS/eip-1.md
@@ -97,7 +97,7 @@ If this period results in necessary normative changes it will revert the EIP to 
 Each EIP should have the following parts:
 
 - Preamble - RFC 822 style headers containing metadata about the EIP, including the EIP number, a short descriptive title (limited to a maximum of 44 characters), and the author details. Irrespective of the category, the title should not include EIP number. See [below](./eip-1.md#eip-header-preamble) for details.
-- Abstract - A short (~200 word) description of the technical issue being addressed.
+- Abstract - Abstract is a multi-sentence (short paragraph) technical summary. This should be a very terse and human-readable version of the specification section. Someone should be able to read only the abstract to get the gist of what this specification does.
 - Motivation (*optional) - A motivation section is critical for EIPs that want to change the Ethereum protocol. It should clearly explain why the existing protocol specification is inadequate to address the problem that the EIP solves. EIP submissions without sufficient motivation may be rejected outright.
 - Specification - The technical specification should describe the syntax and semantics of any new feature. The specification should be detailed enough to allow competing, interoperable implementations for any of the current Ethereum platforms (cpp-ethereum, go-ethereum, parity, ethereumJ, ethereumjs-lib, [and others](https://github.com/ethereum/wiki/wiki/Clients).
 - Rationale - The rationale fleshes out the specification by describing what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work, e.g. how the feature is supported in other languages. The rationale may also provide evidence of consensus within the community, and should discuss important objections or concerns raised during discussion.
@@ -117,9 +117,9 @@ Each EIP must begin with an [RFC 822](https://www.ietf.org/rfc/rfc822.txt) style
 
 ` eip:` *EIP number* (this is determined by the EIP editor)
 
-` title:` *EIP title*
+` title:` *The EIP title is a few words, not a complete sentence*
 
-` description:` *Provide a simplified and layman-accessible explanation of the EIP.*
+` description:` *Description is one full (short) sentence*
 
 ` author:` *a list of the author's or authors' name(s) and/or username(s), or name(s) and email(s). Details are below.*
 

--- a/EIPS/eip-2718.md
+++ b/EIPS/eip-2718.md
@@ -1,6 +1,7 @@
 ---
 eip: 2718
 title: Typed Transaction Envelope
+description: Defines a new transaction type that is an envelope for future transaction types.
 author: Micah Zoltu (@MicahZoltu)
 discussions-to: https://ethereum-magicians.org/t/eip-2718-typed-transaction-envelope/4355
 status: Final
@@ -8,9 +9,6 @@ type: Standards Track
 category: Core
 created: 2020-06-13
 ---
-
-## Simple Summary
-Defines a new transaction type that is an envelope for future transaction types.
 
 ## Abstract
 `TransactionType || TransactionPayload` is a valid transaction and `TransactionType || ReceiptPayload` is a valid transaction receipt where `TransactionType` identifies the format of the transaction and `*Payload` is the transaction/receipt contents, which are defined in future EIPs.

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -5,15 +5,9 @@
   {% if page.layout == "eip" %}
     <title>EIP-{{ page.eip }}: {{ page.title | escape }}</title>
     <meta property="og:title" content="EIP-{{ page.eip }}: {{ page.title | escape }}" />
-    <meta
-      name="description"
-      content="Details on Ethereum Improvement Proposal {{page.eip}} (EIP-{{page.eip}}): {{page.title | escape}}"
-    />
-    <meta
-      property="og:description"
-      content="Details on Ethereum Improvement Proposal {{page.eip}} (EIP-{{page.eip}}): {{page.title | escape}}"
-    />
-    <meta name="twitter:description" content="Details on Ethereum Improvement Proposal {{page.eip}} (EIP-{{page.eip}}): {{page.title | escape}}" />
+    <meta name="description" content="{{page.description | escape }}" />
+    <meta property="og:description" content="{{page.description | escape }}" />
+    <meta name="twitter:description" content="{{page.description | escape }}" />
   {% else %}
   <title>{{ page.title | escape }} | {{site.title}}</title>
     <meta

--- a/_layouts/eip.html
+++ b/_layouts/eip.html
@@ -29,8 +29,8 @@ layout: default
     EIP-{{ page.eip | xml_escape }}: {{ page.title | xml_escape }}
     <a href="{{site.github.repository_url}}/blob/master/{{page.path}}"><svg role="img" aria-label="Source" xmlns="https://www.w3.org/2000/svg" width="14" height="16" viewBox="0 0 14 16"><title>Source</title><path fill-rule="evenodd" d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z"/></svg></a>
   </h1>
+  <h3>{{ page.description | xml_escape }}</h3>
   <table>
-    <tr><th>Description</th><td>{{ page.description | xml_escape }}</td></tr>
     <tr><th>Author</th><td>{% include authorlist.html authors=page.author %}</td></tr>
     {% if page["discussions-to"] != undefined %}
       <tr><th>Discussions-To</th><td><a href="{{ page["discussions-to"] | uri_escape }}">{{ page["discussions-to"] | xml_escape }}</a></td></tr>

--- a/_layouts/eip.html
+++ b/_layouts/eip.html
@@ -30,6 +30,7 @@ layout: default
     <a href="{{site.github.repository_url}}/blob/master/{{page.path}}"><svg role="img" aria-label="Source" xmlns="https://www.w3.org/2000/svg" width="14" height="16" viewBox="0 0 14 16"><title>Source</title><path fill-rule="evenodd" d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z"/></svg></a>
   </h1>
   <table>
+    <tr><th>Description</th><td>{{ page.description | xml_escape }}</td></tr>
     <tr><th>Author</th><td>{% include authorlist.html authors=page.author %}</td></tr>
     {% if page["discussions-to"] != undefined %}
       <tr><th>Discussions-To</th><td><a href="{{ page["discussions-to"] | uri_escape }}">{{ page["discussions-to"] | xml_escape }}</a></td></tr>

--- a/eip-template.md
+++ b/eip-template.md
@@ -18,9 +18,6 @@ Note that an EIP number will be assigned by an editor. When opening a pull reque
 
 The title should be 44 characters or less. It should not repeat the EIP number in title, irrespective of the category. 
 
-## Simple Summary
-"If you can't explain it simply, you don't understand it well enough." Provide a simplified and layman-accessible explanation of the EIP. Imagine an email subject line, GitHub PR title, or forum post title.
-
 ## Abstract
 A short (~200 word) description of the technical issue being addressed. This should be a very terse and human-readable version of the specification section. Someone should be able to read only the abstract to get the gist of what this specification does.
 

--- a/eip-template.md
+++ b/eip-template.md
@@ -1,6 +1,7 @@
 ---
 eip: <to be assigned>
 title: <EIP title>
+description: <Provide a simplified and layman-accessible explanation of the EIP.>
 author: <a list of the author's or authors' name(s) and/or username(s), or name(s) and email(s), e.g. (use with the parentheses or triangular brackets): FirstName LastName (@GitHubUsername), FirstName LastName <foo@bar.com>, FirstName (@GitHubUsername) and GitHubUsername (@GitHubUsername)>
 discussions-to: <URL>
 status: Draft

--- a/eip-template.md
+++ b/eip-template.md
@@ -1,7 +1,7 @@
 ---
 eip: <to be assigned>
-title: <EIP title>
-description: <Provide a simplified and layman-accessible explanation of the EIP.>
+title: <The EIP title is a few words, not a complete sentence>
+description: <Description is one full (short) sentence>
 author: <a list of the author's or authors' name(s) and/or username(s), or name(s) and email(s), e.g. (use with the parentheses or triangular brackets): FirstName LastName (@GitHubUsername), FirstName LastName <foo@bar.com>, FirstName (@GitHubUsername) and GitHubUsername (@GitHubUsername)>
 discussions-to: <URL>
 status: Draft
@@ -19,7 +19,7 @@ Note that an EIP number will be assigned by an editor. When opening a pull reque
 The title should be 44 characters or less. It should not repeat the EIP number in title, irrespective of the category. 
 
 ## Abstract
-A short (~200 word) description of the technical issue being addressed. This should be a very terse and human-readable version of the specification section. Someone should be able to read only the abstract to get the gist of what this specification does.
+Abstract is a multi-sentence (short paragraph) technical summary. This should be a very terse and human-readable version of the specification section. Someone should be able to read only the abstract to get the gist of what this specification does.
 
 ## Motivation
 The motivation section should describe the "why" of this EIP. What problem does it solve? Why should someone want to implement this standard? What benefit does it provide to the Ethereum ecosystem? What use cases does this EIP address?


### PR DESCRIPTION
Implementation of https://github.com/ethereum/EIPs/pull/3564#issuecomment-837367526.

The header:
![Screenshot](https://user-images.githubusercontent.com/20340/128564463-223cca1c-0b6c-4384-be9e-57d1e81273d6.png)

Twitter before:
![Screenshot](https://user-images.githubusercontent.com/20340/128564956-43732e5f-084b-4ca5-9259-f4c61fefa8e3.png)

Twitter after:
![Screenshot](https://user-images.githubusercontent.com/20340/128564972-09c1bff2-e77f-4aae-9778-f1b45249e33c.png)

**Could also render the `description` prominently after the header.**