### PR TITLE
EIP-3675: update Network section

### DIFF
--- a/EIPS/eip-3675.md
+++ b/EIPS/eip-3675.md
@@ -116,11 +116,15 @@ The networking stack **SHOULD NOT** send the following messages if they advertis
 * [`NewBlockHashes (0x01)`](https://github.com/ethereum/devp2p/blob/master/caps/eth.md#newblockhashes-0x01)
 * [`NewBlock (0x07)`](https://github.com/ethereum/devp2p/blob/master/caps/eth.md#newblock-0x07)
 
-Beginning with the first `POS_BLOCK_FINALIZED` event, the networking stack **MUST** remove the handlers corresponding to the following ETH protocol messages:
+Beginning with the first `POS_BLOCK_FINALIZED` event, the networking stack **MUST** discard the following ingress messages:
 * [`NewBlockHashes (0x01)`](https://github.com/ethereum/devp2p/blob/master/caps/eth.md#newblockhashes-0x01)
 * [`NewBlock (0x07)`](https://github.com/ethereum/devp2p/blob/master/caps/eth.md#newblock-0x07)
 
-Beginning with the first `POS_BLOCK_FINALIZED` event, peers that keep sending these messages **SHOULD** be disconnected.
+Beginning with the second `POS_BLOCK_FINALIZED` event, the networking stack **MUST** remove the handlers corresponding to the following messages:
+* [`NewBlockHashes (0x01)`](https://github.com/ethereum/devp2p/blob/master/caps/eth.md#newblockhashes-0x01)
+* [`NewBlock (0x07)`](https://github.com/ethereum/devp2p/blob/master/caps/eth.md#newblock-0x07)
+
+Peers that keep sending these messages after the handlers have been removed **SHOULD** be disconnected.
 
 *Note:* The logic of message handlers that are not affected by this section **MUST** remain unchanged.
 


### PR DESCRIPTION
See https://ethereum-magicians.org/t/eip-3675-upgrade-consensus-to-proof-of-stake/6706/2 for details