### PR TITLE
Remove ERC prefix from title

### DIFF
--- a/EIPS/eip-1155.md
+++ b/EIPS/eip-1155.md
@@ -1,6 +1,6 @@
 ---
 eip: 1155
-title: ERC-1155 Multi Token Standard
+title: Multi Token Standard
 author: Witek Radomski <witek@enjin.io>, Andrew Cooke <ac0dem0nk3y@gmail.com>, Philippe Castonguay <pc@horizongames.net>, James Therien <james@turing-complete.com>, Eric Binet <eric@enjin.io>, Ronan Sandford <wighawag@gmail.com>
 type: Standards Track
 category: ERC

--- a/EIPS/eip-1363.md
+++ b/EIPS/eip-1363.md
@@ -1,6 +1,6 @@
 ---
 eip: 1363
-title: ERC-1363 Payable Token
+title: Payable Token
 author: Vittorio Minacori (@vittominacori)
 discussions-to: https://github.com/ethereum/eips/issues/1363
 status: Final

--- a/EIPS/eip-1504.md
+++ b/EIPS/eip-1504.md
@@ -1,6 +1,6 @@
 ---
 eip: 1504
-title: ERC-1504 Upgradable Smart Contract
+title: Upgradable Smart Contract
 author: Kaidong Wu <wukd94@pku.edu.cn>, Chuqiao Ren <cr025@bucknell.edu>, Ruthia He <rujiahe@gmail.com>, Yun Ma <mayun@pku.edu.cn>, Xuanzhe Liu <liuxuanzhe@pku.edu.cn>
 discussions-to: https://github.com/ethereum/EIPs/issues/1503
 status: Draft

--- a/EIPS/eip-1616.md
+++ b/EIPS/eip-1616.md
@@ -1,6 +1,6 @@
 ---
 eip: 1616
-title: ERC-1616 Attribute Registry Standard
+title: Attribute Registry Standard
 author: 0age (@0age), Santiago Palladino (@spalladino), Leo Arias (@elopio), Alejo Salles (@fiiiu), Stephane Gosselin (@thegostep)
 discussions-to: https://github.com/ethereum/EIPs/issues/1616
 status: Draft

--- a/EIPS/eip-1620.md
+++ b/EIPS/eip-1620.md
@@ -1,6 +1,6 @@
 ---
 eip: 1620
-title: ERC-1620 Money Streaming
+title: Money Streaming
 author: Paul Berg (@PaulRBerg)
 discussions-to: https://github.com/ethereum/EIPs/issues/1620
 status: Draft

--- a/EIPS/eip-165.md
+++ b/EIPS/eip-165.md
@@ -1,6 +1,6 @@
 ---
 eip: 165
-title: ERC-165 Standard Interface Detection
+title: Standard Interface Detection
 author: Christian Reitwießner <chris@ethereum.org>, Nick Johnson <nick@ethereum.org>, Fabian Vogelsteller <fabian@lukso.network>, Jordi Baylina <jordi@baylina.cat>, Konrad Feldmeier <konrad.feldmeier@brainbot.com>, William Entriken <github.com@phor.net>
 type: Standards Track
 category: ERC

--- a/EIPS/eip-1761.md
+++ b/EIPS/eip-1761.md
@@ -1,6 +1,6 @@
 ---
 eip: 1761
-title: ERC-1761 Scoped Approval Interface
+title: Scoped Approval Interface
 author: Witek Radomski <witek@enjin.io>, Andrew Cooke <ac0dem0nk3y@gmail.com>, James Therien <james@enjin.io>, Eric Binet <eric@enjin.io>
 type: Standards Track
 category: ERC

--- a/EIPS/eip-20.md
+++ b/EIPS/eip-20.md
@@ -1,6 +1,6 @@
 ---
 eip: 20
-title: ERC-20 Token Standard
+title: Token Standard
 author: Fabian Vogelsteller <fabian@ethereum.org>, Vitalik Buterin <vitalik.buterin@ethereum.org>
 type: Standards Track
 category: ERC

--- a/EIPS/eip-721.md
+++ b/EIPS/eip-721.md
@@ -1,6 +1,6 @@
 ---
 eip: 721
-title: ERC-721 Non-Fungible Token Standard
+title: Non-Fungible Token Standard
 author: William Entriken <github.com@phor.net>, Dieter Shirley <dete@axiomzen.co>, Jacob Evans <jacob@dekz.net>, Nastassia Sachs <nastassia.sachs@protonmail.com>
 discussions-to: https://github.com/ethereum/eips/issues/721
 type: Standards Track

--- a/EIPS/eip-725.md
+++ b/EIPS/eip-725.md
@@ -1,6 +1,6 @@
 ---
 eip: 725
-title: ERC-725 Smart Contract Based Account
+title: Smart Contract Based Account
 author: Fabian Vogelsteller (@frozeman), Tyler Yasaka (@tyleryasaka)
 discussions-to: https://github.com/ethereum/EIPs/issues/725
 status: Draft

--- a/EIPS/eip-777.md
+++ b/EIPS/eip-777.md
@@ -1,6 +1,6 @@
 ---
 eip: 777
-title: ERC777 Token Standard
+title: Token Standard
 author: Jacques Dafflon <mail@0xjac.com>, Jordi Baylina <jordi@baylina.cat>, Thomas Shababi <tom@truelevel.io>
 discussions-to: https://github.com/ethereum/EIPs/issues/777
 status: Final

--- a/EIPS/eip-801.md
+++ b/EIPS/eip-801.md
@@ -1,6 +1,6 @@
 ---
 eip: 801
-title: ERC-801 Canary Standard
+title: Canary Standard
 author: ligi <ligi@ligi.de>
 type: Standards Track
 category: ERC

--- a/EIPS/eip-897.md
+++ b/EIPS/eip-897.md
@@ -1,6 +1,6 @@
 ---
 eip: 897
-title: ERC DelegateProxy
+title: DelegateProxy
 author: Jorge Izquierdo <jorge@aragon.one>, Manuel Araoz <manuel@zeppelin.solutions>
 type: Standards Track
 category: ERC


### PR DESCRIPTION
As we discussed on EIPIP, I have removed the "ERC" prefix from ERC titles.