### PR TITLE
Clarify validation conditions in EIP 3675 "The Merge"

### DIFF
--- a/EIPS/eip-3675.md
+++ b/EIPS/eip-3675.md
@@ -82,7 +82,7 @@ Beginning with `TRANSITION_BLOCK`, the block validity conditions **MUST** be alt
 * Add verification of the fields noted in [block structure](#block-structure) as their specified constant value.
 * Add verification of block validity with respect to the PoS consensus rules, i.e. assert that there **MUST** be a corresponding event for the block to consider it valid. Such events are limited to the following:
     * A `POS_CONSENSUS_VALIDATED` event considering the block or any of its ancestors as valid.
-    * A `POS_CHAINHEAD_SET` event, including the `POS_BLOCK_FINALIZED` form of this event, designating the head block as the head of the canonical chain.
+    * A `POS_CHAINHEAD_SET` event, including the `POS_BLOCK_FINALIZED` form of this event, designating the block as the head of the canonical chain.
 
 *Note*: If one of the new rules fails then the block **MUST** be invalidated.
 

--- a/EIPS/eip-3675.md
+++ b/EIPS/eip-3675.md
@@ -35,11 +35,11 @@ To understand the motivation of introducing the Proof-of-Stake consensus see the
 
 * **PoW block**: Block that is built and verified by the existing proof-of-work mechanism. In other words, a block of the Ethereum network before the consensus upgrade.
 * **PoS block**: Block that is built and verified by the new proof-of-stake mechanism.
-* **Terminal PoW block**: A PoW block that satisfies the following conditions -- 
-`pow_block.total_difficulty >= TERMINAL_TOTAL_DIFFICULTY` *and* `pow_block.parent_block.total_difficulty < TERMINAL_TOTAL_DIFFICULTY`.  
+* **Terminal PoW block**: A PoW block that satisfies the following conditions --
+`pow_block.total_difficulty >= TERMINAL_TOTAL_DIFFICULTY` *and* `pow_block.parent_block.total_difficulty < TERMINAL_TOTAL_DIFFICULTY`.
 There can be more than one terminal PoW block in the network, e.g. multiple children of the same pre-terminal block.
 * **`TERMINAL_TOTAL_DIFFICULTY`** The amount of total difficulty reached by the network that triggers the consensus upgrade.
-* **`TRANSITION_BLOCK`** The earliest PoS block of the canonical chain, i.e. the PoS block with the lowest block height.  
+* **`TRANSITION_BLOCK`** The earliest PoS block of the canonical chain, i.e. the PoS block with the lowest block height.
 `TRANSITION_BLOCK` **MUST** be a child of a terminal PoW block.
 * **`POS_CONSENSUS_VALIDATED`** An event occurring when the PoS block is validated with respect to the proof-of-stake consensus rules.
 * **`POS_CHAINHEAD_SET`** An event occurring when the PoS block is designated as the head of the canonical chain.
@@ -101,9 +101,9 @@ Beginning with `TRANSITION_BLOCK`, block and ommer rewards are deprecated. Speci
 
 ### Fork choice rule
 
-As of the first `POS_CHAINHEAD_SET` event, the fork choice rule **MUST** be altered in the following way: 
+As of the first `POS_CHAINHEAD_SET` event, the fork choice rule **MUST** be altered in the following way:
 * Remove the existing PoW heaviest chain rule.
-* Adhere to the new PoS LMD-GHOST rule. 
+* Adhere to the new PoS LMD-GHOST rule.
 
 The new PoS LMD-GHOST fork choice rule is specified as follows. On each occurrence of a `POS_CHAINHEAD_SET` event including the first one, the following actions **MUST** be taken:
 * Consider the chain starting at genesis and ending with the block nominated by the event as the canonical blockchain.
@@ -175,7 +175,7 @@ The fork choice rule of the PoW mechanism becomes completely irrelevant after th
 
 ### Removing block gossip
 
-After the upgrade of the consensus mechanism only the beacon chain network will have enough information to validate a block. Thus, block gossip provided by the `eth` network protocol will become unsafe and is deprecated in favour of the block gossip existing in the beacon chain network. 
+After the upgrade of the consensus mechanism only the beacon chain network will have enough information to validate a block. Thus, block gossip provided by the `eth` network protocol will become unsafe and is deprecated in favour of the block gossip existing in the beacon chain network.
 
 It is recommended for the client software to not propagate descendants of any terminal PoW block to reduce the load on processing the P2P component and stop operating in the environment with unknown security properties.
 

--- a/EIPS/eip-3675.md
+++ b/EIPS/eip-3675.md
@@ -81,8 +81,8 @@ Beginning with `TRANSITION_BLOCK`, the block validity conditions **MUST** be alt
 * Remove all validation rules that are evaluated over the list of ommers and each member of this list.
 * Add verification of the fields noted in [block structure](#block-structure) as their specified constant value.
 * Add verification of block validity with respect to the PoS consensus rules, i.e. assert that there **MUST** be a corresponding event for the block to consider it valid. Such events are limited to the following:
-    * A `POS_CONSENSUS_VALIDATED` event considering the block or any of its descendants as valid.
-    * A `POS_CHAINHEAD_SET` event, including the `POS_BLOCK_FINALIZED` form of this event, designating the block or any of its descendants as the head of the canonical chain.
+    * A `POS_CONSENSUS_VALIDATED` event considering the block or any of its ancestors as valid.
+    * A `POS_CHAINHEAD_SET` event, including the `POS_BLOCK_FINALIZED` form of this event, designating the head block as the head of the canonical chain.
 
 *Note*: If one of the new rules fails then the block **MUST** be invalidated.
 


### PR DESCRIPTION
This EIP provides events from the consensus client which indicate various validation meanings to the execution client.

Some of the language around these events is confusing or needs to be updated:

`POS_CONSENSUS_VALIDATED` should indicate that the referred block and any *ancestors* are considered valid, as a valid block implies all blocks reachable by `block.parent_root` are also valid.

`POS_CHAINHEAD_SET` has the same issue although as I understand this event, there will always be a single block referenced (even in the `FINALIZED` variant) that should be the unique head.

