### PR TITLE
Create auto-withdraw-bot.yml

### DIFF
--- a/.github/workflows/auto-withdraw-bot.yml
+++ b/.github/workflows/auto-withdraw-bot.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           node-version: '14'
       - name: auto-withdraw-bot
-        uses: ethereum/EIP-Bot@a8bae07d5124287539524c6a2b7cc095e66c6811 # master
+        uses: ethereum/EIP-Bot@3d12afa46df84f7747cb5b01ba9abb0e748a9ee3 # mark-eips-stale
         id: auto-withdraw-bot
         with:
           GITHUB-TOKEN: ${{ secrets.TOKEN }}

--- a/.github/workflows/auto-withdraw-bot.yml
+++ b/.github/workflows/auto-withdraw-bot.yml
@@ -1,0 +1,22 @@
+on:
+  schedule:
+    # A job that runs every sunday at 00:00
+    - cron:  '0 0 * * 0'
+
+name: Auto Withdraw Bot
+jobs:
+  auto_merge_bot:
+    runs-on: ubuntu-latest
+    name: Auto Withdraw Bot
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Node.js Environment
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+      - name: auto-withdraw-bot
+        uses: ethereum/EIP-Bot@a8bae07d5124287539524c6a2b7cc095e66c6811 # master
+        id: auto-withdraw-bot
+        with:
+          GITHUB-TOKEN: ${{ secrets.TOKEN }}

--- a/.github/workflows/auto-withdraw-bot.yml
+++ b/.github/workflows/auto-withdraw-bot.yml
@@ -3,11 +3,11 @@ on:
     # A job that runs every sunday at 00:00
     - cron:  '0 0 * * 0'
 
-name: Auto Withdraw Bot
+name: Auto Stagnant Bot
 jobs:
   auto_merge_bot:
     runs-on: ubuntu-latest
-    name: Auto Withdraw Bot
+    name: Auto Stagnant Bot
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -15,8 +15,8 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: '14'
-      - name: auto-withdraw-bot
-        uses: ethereum/EIP-Bot@3d12afa46df84f7747cb5b01ba9abb0e748a9ee3 # mark-eips-stale
-        id: auto-withdraw-bot
+      - name: auto-stagnant-bot
+        uses: ethereum/EIP-Bot@b6a3ea6e7e1ca89391dc8c220905f7af72998193 # mark-eips-stale
+        id: auto-stagnant-bot
         with:
           GITHUB-TOKEN: ${{ secrets.TOKEN }}

--- a/.github/workflows/auto-withdraw-bot.yml
+++ b/.github/workflows/auto-withdraw-bot.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           node-version: '14'
       - name: auto-stagnant-bot
-        uses: ethereum/EIP-Bot@b6a3ea6e7e1ca89391dc8c220905f7af72998193 # mark-eips-stale
+        uses: ethereum/EIP-Bot@695e64c194456ebde5b9a102adc7443958bd364a # mark-eips-stale
         id: auto-stagnant-bot
         with:
           GITHUB-TOKEN: ${{ secrets.TOKEN }}


### PR DESCRIPTION
This is the implementation of the bot asked for here: https://github.com/ethereum-cat-herders/EIPIP/issues/73#issuecomment-879999394

This bot (every sunday at 00:00)
- Checks every eip file in EIPS for the last time it was edited longer than a year ago (from the time of running)
  - if no EIPs less than a year ago (stop)
  - if EIPs last edited longer than a year ago..
    -  if the EIP is in Draft, Stagnant, Last Call, or Review..
       - change the status to Withdrawn
- Assuming there are EIPs that should be withdrawn, it'll open a PR with those changes and mention the editors (example: https://github.com/alita-moore/EIPs/pull/20)
