### PR TITLE
Bump eipv to v0.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
     - language: rust
       cache: cargo
       before_script:
-        - cargo install eipv --version=0.1.1
+        - cargo install eipv --version=0.2.0
       env: TASK='eip-validator'
     - python: 3.3
       env: TASK='codespell'


### PR DESCRIPTION
This adds support for the `description` field in the preamble. It enforces a maximum length of 140 characters (just like in the good old days on twitter!).

`eipv` PR: https://github.com/lightclient/eipv/pull/28