### PR TITLE
3014: Avoid using special characters in title

### DIFF
--- a/EIPS/eip-3014.md
+++ b/EIPS/eip-3014.md
@@ -1,6 +1,6 @@
 ---
 eip: 3014
-title: `eth_symbol` JSON-RPC method
+title: "`eth_symbol` JSON-RPC method"
 author: Peter Grassberger (@PeterTheOne)
 discussions-to: https://github.com/ethereum/EIPs/issues/3012
 status: Draft

--- a/EIPS/eip-3014.md
+++ b/EIPS/eip-3014.md
@@ -1,6 +1,6 @@
 ---
 eip: 3014
-title: "`eth_symbol` JSON-RPC method"
+title: eth_symbol JSON-RPC method
 author: Peter Grassberger (@PeterTheOne)
 discussions-to: https://github.com/ethereum/EIPs/issues/3012
 status: Draft


### PR DESCRIPTION
Came across this problem (jekyll complains about it). Picked from #3599.