### PR TITLE
Validate static JUMPSUB using immediate data

### DIFF
--- a/EIPS/eip-2315.md
+++ b/EIPS/eip-2315.md
@@ -17,29 +17,37 @@ created: 2019-10-17
 
 This proposal introduces three opcodes to support subroutines: `BEGINSUB`, `JUMPSUB` and `RETURNSUB`.  (The smallest possible change would do without  `BEGINSUB`). 
 
+Substantial gains in efficiency are achieved.
+
+Safety properties equivalent to  [EIP-615](https://eips.ethereum.org/EIPS/eip-615) can be ensured by enforcing a few simple rules, which can be validated with the provided algorithm, and without imposing syntactic constraints.
+
 ## Motivation
 
 The EVM does not provide subroutines as a primitive.  Instead, calls can be synthesized by fetching and pushing the current program counter on the data stack and jumping to the subroutine address; returns can be synthesized by getting the return address to the top of the stack and jumping back to it.  In the EVM the return 
 
-Facilities to directly support subroutines are provided in some form by most physical and virtual machines going back at least fifty years.  In whatever form, these operations provide for capturing the current context of execution, transferring control to a new context, and returning to the original context.
+Facilities to directly support subroutines are provided by all but one of the machines programmed by the lead author, including the B5000, CDC7600, IBM360, PDP8, PDP11, VAX, M68000, 80x86, SPARC, p-Machine, JVM and EVM.  In whatever form, these operations provide for capturing the current context of execution, transferring control to a new context, and returning to the original context.  The concept goes back to Turing:
 
-We propose a simple _return-stack_ mechanism, known to work well for stack machines, which we specify here.  Note that this specification is entirely semantic.  It constrains only stack usage and control flow and imposes no syntax on code beyond being a sequence of bytes to be executed.
+> We also wish to be able to arrange for the splitting up of operations into subsidiary operations.  This should be done in such a way that once we have written down how an operation is done we can use it as a subsidiary to any other operation.
+> ...
+> When we wish to start on a subsidiary operation we need only make a note of where we left off the major operation and then apply the first instruction of the subsidiary.  When the subsidiary is over we look up the note and continue with the major operation. Each subsidiary operation can end with instructions for this recovery of the note.  How is the burying and disinterring of the note to be done?  There are of course many ways.  One is to keep a list of these notes in one or more standard size delay lines, with the most recent last.  The position of the most recent of these will be kept in a fixed TS, and this reference will be modified every time a subsidiary is started or finished.  The burying and disinterring processes are fairly elaborate, but there is fortunately no need to repeat the instructions involved, each time, the burying being done through a standard instruction table BURY, and the disinterring by the table UNBURY.
+>
+> Notes: TS 1 contains the address of the currently executing instruction. "minor cycle" = word.
 
-In the future, amenability to static analysis equivalent to  [EIP-615](https://eips.ethereum.org/EIPS/eip-615) could be ensured by enforcing a few simple rules, and validated with the provided algorithm, still without imposing syntactic constraints.
+We propose to use Turing's simple _return-stack_ mechanism, long known to work well for virtual stack machines, which we specify here.  Note that this specification is entirely semantic.  It constrains only stack usage and control flow and imposes no syntax on code beyond being a sequence of bytes to be executed.
 
 ## Specification
 
-We introduce one more stack into the EVM in addition to the existing `data stack` which we call the `return stack`. The `return stack` is limited to `1024` items.
+We introduce one more stack into the EVM in addition to the existing `data stack` which we call the `return stack`. The `return stack` is limited to `1024` items. This stack supports the three new instructions for subroutines.
 
-#### `BEGINSUB`
+### `BEGINSUB`
 
 Marks the entry point to a subroutine.  Execution of a `BEGINSUB` is  a no-op.
 
-#### `JUMPSUB`
+#### `JUMPSUB <immediate data>`
 
 Transfers control to a subroutine.
 
-1. Pop the `location` off the `data stack`.
+1. Decode the `location` from the `immediate data`.  The data is encoded as two bytes MSB-first bytes.
 2. If the opcode at `location` is not a `BEGINSUB` _`abort`_.
 3. If the `return stack` already has `1024` items _`abort`_.
 4. Push the current `pc + 1` to the `return stack`.
@@ -63,19 +71,24 @@ _Note 2: Values popped off the `return stack` do not need to be validated, since
 
 _Note 3: The description above lays out the semantics of this feature in terms of a `return stack`.  But the actual state of the `return stack` is not observable by EVM code or consensus-critical to the protocol.  (For example, a node implementor may code `JUMPSUB` to unobservably push `pc` on the `return stack` rather than `pc + 1`, which is allowed so long as `RETURNSUB` observably returns control to the `pc + 1` location.)_
 
-### Indirect Jumps
+### Dependencies
 
-If [EIP-2327: BEGINDATA](https://eips.ethereum.org/EIPS/eip-2327) or similar is implemented then the indirect jumps from  [EIP-615](https://eips.ethereum.org/EIPS/eip-615) -- `JUMPV` and `JUMPSUBV` -- can be implemented.  These could take two arguments on the stack: a constant offset relative to `BEGINDATA` to a jump table, and a variable index into that table.
+[EVM Object Format (EOF) v1](https://eips.ethereum.org/EIPS/eip-3540)
+
+[EOF static relative jumps](https://github.com/ethereum/evmone/pull/351)
+
 
 ## Rationale
 
-We modeled this design on the simple, proven, archetypal Forth virtual machine of 1970.  It is a two-stack design -- the data stack is supplemented with a return stack to support jumping into and returning from subroutines, as specified above.  The separate return stack ensures that the return address cannot be overwritten or mislaid, and obviates any need to swap the return address past the arguments on the stack.  Importantly, a dynamic jump is not needed to implement subroutine returns, allowing for deprecation of dynamic uses of JUMP and JUMPI.  Eventually deprecating dynamic jumps is key to practical static analysis of code.
+We modeled this design on the simple, proven, archetypal Forth virtual machine of 1970.  It is a two-stack design -- the data stack is supplemented with Turing's return stack to support jumping into and returning from subroutines, as specified above.
 
-(JUMPSUB and RETURNSUB were also defined in terms of a `return stack` in [EIP-615](https://eips.ethereum.org/EIPS/eip-615))
+The separate return stack ensures that the return address cannot be overwritten or mislaid, and obviates any need to swap the return address past the arguments on the stack.  Importantly, a dynamic jump is not needed to implement subroutine returns, allowing for deprecation of dynamic uses of `JUMP` and `JUMPI`.
+
+(`JUMPSUB` and `RETURNSUB` are also defined in terms of a `return stack` in [EIP-615](https://eips.ethereum.org/EIPS/eip-615))
 .
 ## Backwards and Forwards Compatibility
 
-These changes do not affect the semantics of existing EVM code.
+These changes affect the semantics of existing EVM code.  The EVM Object Format is required to allow for immediate data.
 
 These changes are compatible with using [EIP-3337](https://eips.ethereum.org/EIPS/eip-3337) to provide stack frames, by associating a frame with each subroutine.
 
@@ -92,9 +105,10 @@ Three clients have implemented this (or an earlier version of this) proposal:
 We suggest that the cost of 
 
 - `BEGINSUB` be _jumpdest_ (`1`)
-- `JUMPSUB` be _high_ (`10`)
-  - This is the same as `JUMPI`, and `2` more than `JUMP`.
+- `JUMPSUB` be _low_ (`5`)
 - `RETURNSUB` be _low_ (`5`).
+
+The _low_ costs are justified by these instructions requiring only a few operations on the return stack and `pc`, woth no 256-bit arithmetic.
 
 Benchmarking might be needed to tell if the costs are well-balanced. 
 
@@ -106,55 +120,160 @@ We suggest the following opcodes:
 0x5e JUMPSUB
 ```
 
+### Efficiency
+
+Consider this example of calling a minimal subroutine.
+```
+TEST_DIV:
+    beginsub        ; 1 gas
+    0x02            ; 3 gas
+    0x03            ; 3 gas
+    jumpsub DIVIDE  ; 5 gas
+    returnsub       ; 5 gas
+
+DIVIDE:
+    beginsub        ; 1 gas
+    mul             ; 5 gas
+    returnsub       ; 5 gase
+```
+Total 28 gas.
+
+The same code, using JUMP.
+
+```
+TEST_DIV:
+   jumpdest         ; 1 gas
+   RTN_MUL          ; 3 gas
+   0x02             ; 3 gas
+   0x03             ; 3 gas
+   DIVIDE           ; 3 gas
+   jump             ; 8 gas
+RTN_DIV:
+   jumpdest         ; 1 gas
+   swap1            ; 3 gas
+   jump             ; 8 gas
+
+DIVIDE:
+   jumpdest         ; 1 gas
+   div              ; 5 gas
+   swap1            ; 3 gas
+   jump             ; 8 gas
+```
+50 gas total.
+
+Both approaches need to push two arguments and divide = 11 gas, so control flow gas is 39 using `JUMP` versus 17 using `JUMPSUB`.
+
+That’s a savings of 22 gas.
+
+In the general case of one routine calling another I don’t think the `JUMP` version can do better. Of course in this case we can optimize the tail call, so that the final jump in `DIVIDE` actually returns from TEST_DIV.
+```
+TEST_DIV:
+   jumpdest         ; 1 gas
+   0x02             ; 3 gas
+   0x03             ; 3 gas
+   DIVIDE           ; 3 gas
+   jump             ; 8 gas
+
+DIVIDE:
+   jumpdest         ; 1 gas
+   div              ; 5 gas
+   swap1            ; 3 gas
+   jump             ; 8 gas
+```
+Total 35 gas, which is still worse than with `JUMPSUB`.
+
+We could even take advantage of `DIVIDE` just happening to directly follow `TEST_DIV` and just fall through:
+```
+TEST_DIV:
+   jumpdest         ; 1 gas
+   0x02             ; 3 gas
+   0x03             ; 3 gas
+DIVIDE:
+   jumpdest         ; 1 gas
+   div              ; 5 gas
+   swap1            ; 3 gas
+   jump             ; 8 gas
+```
+Total 24 gas, better than `JUMPSUB`.
+
+However, `JUMPSUB` can do even better with the same optimizations.
+```
+TEST_DIV:
+    beginsub        ; 1 gas
+    0x02            ; 3 gas
+    0x03            ; 3 gas
+    DIVIDE          ; 3 gas
+    jump            ; 9 gas
+
+DIVIDE:
+    beginsub        ; 1 gas
+    div             ; 5 gas
+    returnsub       ; 5 gase
+```
+Total 30 gas.  5 better than with `JUMP`,
+
+```
+TEST_DIV:
+    beginsub        ; 1 gas
+    0x02            ; 3 gas
+    0x03            ; 3 gas
+DIVIDE:
+    beginsub        ; 1 gas
+    div             ; 5 gas
+    returnsub       ; 5 gase
+```
+Total 18 gas.  6 better than with `JUMP`.
+
 ## Security Considerations
 
 These changes do introduce new flow control instructions, so any software which does static/dynamic analysis of evm-code needs to be modified accordingly. The `JUMPSUB` semantics are similar to `JUMP` (but jumping to a `BEGINSUB`), whereas the `RETURNSUB` instruction is different, since it can 'land' on any opcode (but the possible destinations can be statically inferred).
 
-The safety and amenability to static analysis of valid programs can be made comparable to [EIP-615](https://eips.ethereum.org/EIPS/eip-615), but without imposing syntactic constraints, and thus with minimal impact on low-level optimizations.  Validity can ensured by following the rules given in the next section, and programs can be validated with the provided algorithm.  The validation algorithm is simple and bounded by the size of the code, allowing for validation at deploy time or at load time.
-
-While it is crucial going forward that it be possible to validate programs, this EIP does propose that validity be enforced.  Note that much value for people doing static analysis (e.g. for proofs that bytecode meets formal specifications of a contract) can be had without enforcement.  Code can be scanned in linear time to ensure that the rules are or are not followed before analysis begins.  And compilers can easily follow the rules up front.
+Safety and amenability to static analysis of valid programs can be made comparable to [EIP-615](https://eips.ethereum.org/EIPS/eip-615), but without imposing syntactic constraints, and thus with minimal impact on low-level optimizations (as shown above.)  Validity can ensured by following the rules given in the next section, and programs can be validated with the provided algorithm.  The validation algorithm is simple and bounded by the size of the code, allowing for validation at creation time.  And compilers can easily follow the rules.
 
 ### Validity
 
+We define safety here as avoiding exceptional halting states.
+
 #### Exceptional Halting States
 
-_Execution_ is as defined in the [Yellow Paper](https://ethereum.github.io/yellowpaper/paper.pdf)—a sequence of changes in the EVM state.  The conditions on valid code are preserved by state changes.  At runtime, if execution of an instruction would violate a condition the execution is in an exceptional halting state.  The Yellow Paper defines five such states.
+_Execution_ is as defined in the [Yellow Paper](https://ethereum.github.io/yellowpaper/paper.pdf) — a sequence of changes in the EVM state.  The conditions on valid code are preserved by state changes.  At runtime, if execution of an instruction would violate a condition the execution is in an exceptional halting state.  The Yellow Paper defines five such states.
 1. Insufficient gas
 2. More than 1024 stack items
 3. Insufficient stack items
 4. Invalid jump destination
 5. Invalid instruction
 
-We would like to consider EVM code valid iff no execution of the program can lead to an exceptional halting state, but we must be able to validate code in linear time to avoid denial of service attacks.  So in practice, we can only partially meet these requirements.  Our validation algorithm does not consider the code’s data and computations, only its control flow and stack use.  This means we will reject programs with any invalid code paths, even if those paths are not reachable at runtime.   Further, conditions 1 and 2 —Insufficient gas and stack overflow—must in general be checked at runtime.  Conditions 3, 4, and 5 cannot occur if the code conforms to the following rules.
+We would like to consider EVM code valid iff no execution of the program can lead to an exceptional halting state, but we must be able to validate code in linear time to avoid denial of service attacks.  So in practice, we can only partially meet these requirements.  Our validation algorithm does not consider the code’s data and computations, only its control flow and stack use.  This means we will reject programs with any invalid code paths, even if those paths are not reachable at runtime.   Further, conditions 1 and 2 — Insufficient gas and stack overflow — must in general be checked at runtime.  Conditions 3, 4, and 5 cannot occur if the code conforms to the following rules.
 
-#### The Rules 
+#### The Rules
 
-1. `JUMP` and `JUMPI` address only valid `JUMPDEST` instructions.
+0. `JUMP` and `JUMPI` are deprecated.
+1. `RJUMP` and `RJUMPI` address only valid `JUMPDEST` instructions.
 2. `JUMPSUB` addresses only valid `BEGINSUB` instructions.
-3. `JUMP`, `JUMPI` and `JUMPSUB` are always preceded by one of the `PUSH` instructions.
-4. For each instruction in the code the `stack depth` is always the same.
-5. The `stack depth` is always positive and at most 1024.
+3. For each instruction in the code the `stack depth` is always the same.
+4. The `stack depth` is always positive and at most 1024.
 
-Rules 1 and 2 are currently enforced at runtime.  _Note: Valid instructions are not part of PUSH data._
+Rule 0, depracating `JUMP` and `JUMPI`, would forbid dynamic jumps.  Absent dynamic jumps another mechanism is needed for subroutine returns, as provided here. 
 
-Rule 3, requiring a `PUSH` before each `JUMP*` would forbid dynamic jumps.  Absent dynamic jumps another mechanism is needed for subroutine returns, as provided here. 
+Jump destinations are currently checked at runtime.  Static jumps allow them to be validated at creation time, per rule 1.  _Note: Valid instructions are not part of PUSH data._
 
-For rules 4 and 5 we need to define `stack depth`.  The Yellow Paper has the `stack pointer` or `SP` pointing just past the top item on the `data stack`.   We define the `stack base` as where the `SP` pointed at the most recent `JUMPSUB`, or `0` on program entry.  So we can define the `stack depth` as the number of stack elements between the current `SP` and the current `stack base`.  
+For rules 3 and 4 we need to define `stack depth`.  The Yellow Paper has the `stack pointer` or `SP` pointing just past the top item on the `data stack`.   We define the `stack base` as where the `SP` pointed before the most recent `JUMPSUB`, or `0` on program entry.  So we can define the `stack depth` as the number of stack elements between the current `SP` and the current `stack base`.  
 
-Given our definition of `stack depth` Rule 4 ensures that control flows which return to the same place with a different `stack depth` are invalid.  These can be caused by irreducible paths like jumping into loops and subroutines, and calling subroutines with different numbers of arguments.  Taken together, these rules allow for code to be validated  by following the control-flow graph, traversing each edge only once.
+Given our definition of `stack depth` Rule 3 ensures that control flows which return to the same place with a different `stack depth` are invalid.  These can be caused by irreducible paths like jumping into loops and subroutines, and calling subroutines with different numbers of arguments.  Taken together, these rules allow for code to be validated  by following the control-flow graph, traversing each edge only once.
 
-Finally, Rule 5 precludes all stack underflows (and some stack overflows.)
+Finally, Rule 4 precludes all stack underflows (and some stack overflows.)
 
 ### Validation
 
-The following is a pseudo-Go specification of an algorithm for enforcing program validity.  It recursively traverses the bytecode, following its control flow and stack use and checking for violations of the rules above.  (For simplicity we ignore the issue of JUMPDEST or BEGINSUB bytes in PUSH data.)  It runs in time == O(vertices + edges) in the program's control-flow graph, where vertices represent control-flow instructions and the edges represent basic blocks.
+The following is a pseudo-Go specification of an algorithm for enforcing program validity.  It recursively traverses the bytecode, following its control flow and stack use and checking for violations of the rules above.  (For simplicity we ignore the issue of JUMPDEST or BEGINSUB bytes in PUSH data, assume an `advance_pc()` routine, and don't specify JUMPTABLE, which is just a loop over RJUMP.)  It runs in time == O(vertices + edges) in the program's control-flow graph, where vertices represent control-flow instructions and the edges represent basic blocks.
 ```
    var bytecode []byte
    var stack_depth []int
    var SP := 0
 
    func validate(PC :=0) boolean {
-      // traverse code sequentially, recurse for subroutines and conditional jumps
+      // traverse code sequentially
+      // recurse for subroutines and conditional jumps
       while true {
          instruction = bytecode[PC]
          if is_invalid(instruction) {
@@ -183,31 +302,29 @@ The following is a pseudo-Go specification of an algorithm for enforcing program
              return true
          }
 
-         if instruction == JUMP {
+         if instruction == RJUMP {
 
-             // check for constant and correct destination
-             if (bytecode[PC - 33] != PUSH32) {
-                 return false
-             }
-             PC = stack[PC-32]
-             if byte_code[PC] != JUMPDEST {
+             // check for valid destination
+             jumpdest = *PC, PC++, jumpdest << 8
+             if bytecode[jumpdest] != JUMPDEST {
                  return false
              }
 
              // reset PC to destination of jump 
-             PC = stack[PC-32]
+             PC = jumpdest
              continue
          }
-         if instruction == JUMPI {
+         if instruction == RJUMPI {
 
-             // check for constant and correct destination
-             if (bytecode[PC - 33] != PUSH32) {
+             // check for valid destination
+             jumpdest = *PC, PC++, jumpdest << 8
+             if bytecode[jumpdest] != JUMPDEST {
                  return false
              }
-             PC = stack[PC-32]
-             if byte_code[PC] != JUMPDEST {
-                 return false
-             }
+
+             // reset PC to destination of jump 
+             PC = jumpdest
+
              // recurse to jump to code to validate 
              if !validate(stack[SP])) {
                  return false
@@ -216,14 +333,11 @@ The following is a pseudo-Go specification of an algorithm for enforcing program
          }
          if instruction == JUMPSUB {
 
-            // check for constant and correct destination
-            if (bytecode[PC - 33] != PUSH32) 
-               return false
-             prevPC = PC
-             PC = stack[PC-32]
-             if byte_code[PC] != BEGINSUB {
+             // check for valid destination
+             jumpdest = *PC, PC++, jumpdest << 8
+             if bytecode[jumpdest] != BEGINSUB {
                  return false
-            }
+             }
 
              // recurse to jump to code to validate
              prevSP = SP
@@ -246,7 +360,10 @@ The following is a pseudo-Go specification of an algorithm for enforcing program
       }    
    }
 ```
+
 ## Test Cases
+
+*TO DO:  Test cases are not up-to-date.*
 
 ### Simple routine
 
@@ -331,6 +448,8 @@ Bytecode: `0x6005565c5d5b60035e` (`PUSH1 0x05, JUMP, BEGINSUB, RETURNSUB, JUMPDE
 Consumed gas: `30`
 
 ## References
+
+A.M. Turing, Proposals for the development in the Mathematics Division of an Automatic Computing Engine (ACE). Report E882, Executive Committee, NPL  1946
 Gavin Wood, [Ethereum:  A  Secure  Decentralized Generalized  Transaction  Ledger](https://ethereum.github.io/yellowpaper/paper.pdf), 2014-2021
 Greg Colvin, Brooklyn Zelenka, Paweł Bylica, Christian Reitwiessner, [EIP-615: Subroutines and Static Jumps for the EVM](https://eips.ethereum.org/EIPS/eip-615),  2016-2019
 Martin Lundfall, [EIP-2327: BEGINDATA Opcode](https://eips.ethereum.org/EIPS/eip-2327), 2019

--- a/EIPS/eip-2315.md
+++ b/EIPS/eip-2315.md
@@ -108,7 +108,7 @@ We suggest that the cost of
 - `JUMPSUB` be _low_ (`5`)
 - `RETURNSUB` be _low_ (`5`).
 
-The _low_ costs are justified by these instructions requiring only a few operations on the return stack and `pc`, woth no 256-bit arithmetic.
+The _low_ costs are justified by these instructions requiring only a few operations on the return stack and `pc`, with no 256-bit arithmetic.
 
 Benchmarking might be needed to tell if the costs are well-balanced. 
 


### PR DESCRIPTION
Ethereum object format allows immediate data, which https://github.com/ethereum/evmone/pull/351 uses to provide static, relative jumps.  This allows for static, validated subroutines.

When opening a pull request to submit a new EIP, please use the suggested template: https://github.com/ethereum/EIPs/blob/master/eip-template.md

We have a GitHub bot that automatically merges some PRs. It will merge yours immediately if certain criteria are met:

 - The PR edits only existing draft PRs.
 - The build passes.
 - Your GitHub username or email address is listed in the 'author' header of all affected PRs, inside <triangular brackets>.
 - If matching on email address, the email address is the one publicly listed on your GitHub profile.
