### PR TITLE
Removes recommendation to link externally.

### DIFF
--- a/eip-template.md
+++ b/eip-template.md
@@ -34,7 +34,7 @@ The rationale fleshes out the specification by describing what motivated the des
 All EIPs that introduce backwards incompatibilities must include a section describing these incompatibilities and their severity. The EIP must explain how the author proposes to deal with these incompatibilities. EIP submissions without a sufficient backwards compatibility treatise may be rejected outright.
 
 ## Test Cases
-Test cases for an implementation are mandatory for EIPs that are affecting consensus changes. Other EIPs can choose to include links to test cases if applicable.
+Test cases for an implementation are mandatory for EIPs that are affecting consensus changes.  If the test suite is too large to reasonably be included inline, then consider adding it as one or more files in `../assets/eip-####/`.
 
 ## Reference Implementation
 An optional section that contains a reference/example implementation that people can use to assist in understanding or implementing this specification.  If the implementation is too large to reasonably be included inline, then consider adding it as one or more files in `../assets/eip-####/`.


### PR DESCRIPTION
We should not be encouraging users to put tests elsewhere and link to them.  Instead, we should be recommending users inline or include in ../assets any test cases that are applicable to the EIP.