### PR TITLE
Removes implementation section.

### DIFF
--- a/EIPS/eip-3074.md
+++ b/EIPS/eip-3074.md
@@ -260,14 +260,6 @@ There are other approaches to mitigate this restriction which do not break the i
 
 No known issues.
 
-## Test Cases
-
-TODO
-
-## Implementation
-
-https://github.com/quilt/go-ethereum/tree/eip-3074
-
 ## Security Considerations
 
 ### Secure Invokers


### PR DESCRIPTION
EIPs shouldn't have external links.  I also removed the TODO section since it was empty (and it is optional anyway).