### PR TITLE
EIP-2315 pre-review copyediting.

### DIFF
--- a/EIPS/eip-2315.md
+++ b/EIPS/eip-2315.md
@@ -1,7 +1,8 @@
+
 ---
 eip: 2315
 title: Simple Subroutines for the EVM
-status: Draft
+status: Review
 type: Standards Track
 category: Core
 author: Greg Colvin <greg@colvin.org>, Martin Holst Swende (@holiman)
@@ -15,17 +16,17 @@ A small change to the EVM that provides native subroutines.
 
 ## Abstract
 
-This proposal introduces three opcodes to support subroutines: `BEGINSUB`, `JUMPSUB` and `RETURNSUB`.  It deprecates `JUMP` and 'JUMPI`.
+This proposal introduces three opcodes to support subroutines: `BEGINSUB`, `JUMPSUB` and `RETURNSUB`.  It deprecates `JUMP` and `JUMPI`.
 
 Substantial gains in efficiency and reduced gas costs are achieved.
 
-Safety properties equivalent to  [EIP-615](https://eips.ethereum.org/EIPS/eip-615) — including valid jump destinations — can be ensured by following a few simple rules, which are validated at contract creation time — not runtime — by the provided algorithm, and without imposing syntactic constraints. 
+Safety properties equivalent to  [EIP-615](https://eips.ethereum.org/EIPS/eip-615) — including valid jump destinations — are ensured by following a few simple rules, which are validated at contract creation time — not runtime — by the provided algorithm, and without imposing syntactic constraints. 
 
 ## Motivation
 
 The EVM does not provide subroutines as a primitive.  Instead, calls can be synthesized by fetching and pushing the current program counter on the data stack and jumping to the subroutine address; returns can be synthesized by getting the return address to the top of the stack and jumping back to it.  These conventions are more costly than necessary, and impede static analysis of EVM code, especially rapid validation of some important safety properties.
 
-Facilities to directly support subroutines are provided by all but one of the real and virtual machines programmed by the lead author, including the Burroughs 5000, CDC 7600, IBM 360, DEC PDP 11 and VAX, Motorola 68000, a few generations of Intel silicon, Sun SPARC, USCD p-Machine, Sun JVM, Wasm, and the sole exception — the EVM.  In whatever form, these operations provide for
+Facilities to directly support subroutines are provided by all but one of the real and virtual machines programmed by the lead author, including the Burroughs 5000, CDC 7600, IBM 360, DEC PDP 11 and VAX, Motorola 68000, a few generations of Intel silicon, Sun SPARC, UCSD p-Machine, Sun JVM, Wasm, and the sole exception — the EVM.  In whatever form, these operations provide for
 * capturing the current context of execution,
 * transferring control to a new context, and 
 * returning to the original context
@@ -41,7 +42,7 @@ We propose to use Turing's simple mechanism, long known to work well for virtual
 
 ## Specification
 
-We introduce one more stack into the EVM in addition to the existing `data stack`, known as the `return stack`. The `return stack` is limited to `1024` items. This stack supports the three new instructions for subroutines.
+We introduce one more stack into the EVM in addition to the existing `data stack`, known as the `return stack`. The `return stack` is limited to `1024` items. This stack supports three new instructions for subroutines.
 
 ###  `BEGINSUB`
 
@@ -70,22 +71,22 @@ We introduce one more stack into the EVM in addition to the existing `data stack
 > * _pops one item off the `return stack`_
 
 _Notes:_
-* *If a resulting `PC` to be executed is beyond the last instruction then the opcode is implicitly a `STOP`, which is not an error.*
-* *Values popped off the `return stack` do not need to be validated, since they are alterable only by `JUMPSUB` and `RETURNSUB`.*
-* *The description above lays out the semantics of this feature in terms of a `return stack`.  But the actual state of the `return stack` is not observable by EVM code or consensus-critical to the protocol.  (For example, a node implementor may code `JUMPSUB` to unobservably push `PC` on the `return stack` rather than `PC + 1`, which is allowed so long as `RETURNSUB` observably returns control to the `PC + 1` location.)*
-* *The `return stack is the functional equivalent of Turing's "delay line" of "where we left off".*
+* _If a resulting `PC` to be executed is beyond the last instruction then the opcode is implicitly a `STOP`, which is not an error._
+* _Values popped off the `return stack` do not need to be validated, since they are alterable only by `JUMPSUB` and `RETURNSUB`._
+* _The description above lays out the semantics of this feature in terms of a `return stack`.  But the actual state of the `return stack` is not observable by EVM code or consensus-critical to the protocol.  (For example, a node implementor may code `JUMPSUB` to unobservably push `PC` on the `return stack` rather than `PC + 1`, which is allowed so long as `RETURNSUB` observably returns control to the `PC + 1` location.)_
+* _The `return stack is the functional equivalent of Turing's "delay line" of "where we left off"._
 
 ### Dependencies
 
-We need [EVM Object Format (EOF) v1](https://eips.ethereum.org/EIPS/eip-3540) to allow for immediate arguments without special encoding.
+We need [EVM Object Format (EOF)](https://eips.ethereum.org/EIPS/eip-3540) to allow for immediate arguments without special encoding.
 
-We need [EOF static relative jumps](https://github.com/ethereum/evmone/pull/351) or the equivalent to define and validate the rules for contract safety.  These jumps — `RJUMP offset` and `RJUMPI offset` — transfer control to a fixed location in the bytecode.
+We need [EOF Static Relative Jumps](https://github.com/ethereum/evmone/pull/351) or the equivalent to define and validate the rules for contract safety.  These jumps — `RJUMP offset` and `RJUMPI offset` — transfer control to a location in the bytecode at a fixed offset relative to the current `PC`.
 
 ## Rationale
 
-We modeled this design on the proven, archetypal Forth virtual machine of 1970.  It is a two-stack design — the data stack is supplemented with a return stack to support jumping into and returning from subroutines, as specified above.   The return address is pushed onto the return stack when calling,  and the stack is popped into `PC` when returning.
+We modeled this design on the proven, archetypal Forth virtual machine of 1970.  It is a two-stack design — the data stack is supplemented with a return stack to support jumping into and returning from subroutines, as specified above.   The return address (Turing's "note") is pushed onto the return stack when calling,  and the stack is popped into the `PC` when returning.
 
-The alternative design is to push the return address and the destination address on the data stack before jumping, and to pop the stack and jump back to the popped `PC` to return.  We prefer the separate return stack because it ensures that the return address cannot be overwritten or mislaid, uses fewer data stack slots, and obviates any need to swap the return address past the arguments or return values on the stack.  Crucially, a dynamic jump is not needed to implement subroutine returns, allowing for deprecation of `JUMP` and `JUMPI`.
+The alternative design is to push the return address and the destination address on the data stack before jumping, and to pop the data stack and jump back to the popped `PC` to return.  We prefer the separate return stack because it ensures that the return address cannot be overwritten or mislaid, uses fewer data stack slots, and obviates any need to swap the return address past the arguments or return values on the stack.  Crucially, a dynamic jump is not needed to implement subroutine returns, allowing for deprecation of `JUMP` and `JUMPI`.
 
 (`JUMPSUB` and `RETURNSUB` are also defined in terms of a `return stack` in [EIP-615](https://eips.ethereum.org/EIPS/eip-615)).
 
@@ -99,7 +100,7 @@ These changes are compatible with using [EIP-3337](https://eips.ethereum.org/EIP
 
 Three clients have implemented this (or an earlier version of this) proposal:
 
-- [geth](https://github.com/ethereum/go-ethereum/pull/20619) .
+- [geth](https://github.com/ethereum/go-ethereum/pull/20619),
 - [besu](https://github.com/hyperledger/besu/pull/717), and
 - [openethereum](https://github.com/openethereum/openethereum/pull/11629).
 
@@ -166,7 +167,7 @@ DIVIDE:
 
 Total: 50 gas
 ```
-Using `JUMP` is ***50 - 24 = 26*** gas more costly than `JUMPSUB`.
+Using `JUMP` uses **_50 - 24 = 26_** more gas than using `JUMPSUB`.
 
 #### Tail Call Optimization
 
@@ -176,14 +177,14 @@ TEST_DIV:
     beginsub        ; 1 gas
     0x02            ; 3 gas
     0x03            ; 3 gas
-    jumpr DIVIDE    ; 9 gas
+    rjump DIVIDE    ; 3 gas
 
 DIVIDE:
     beginsub        ; 1 gas
     div             ; 5 gas
-    returnsub       ; 3 gase
+    returnsub       ; 3 gas
 
-Total: 28 gas
+Total: 22 gas
 ```
 Or the same code, using `JUMP`
 ```
@@ -202,7 +203,7 @@ DIVIDE:
 
 Total: 35 gas
 ```
-Using `JUMP` is ***35 - 28 = 7*** gas more costly than `JUMPSUB`.
+Using `JUMP` cost **_35 - 22 = 13_** more gas than using `JUMPSUB`.
 
 #### Tail Call Elimination
 
@@ -233,13 +234,13 @@ DIVIDE:
 
 Total: 24 gas
 ```
-Using `JUMP` is ***24 - 16 = 8*** gas more costly than `JUMPSUB`.
+Using `JUMP` costs **_24 - 16 = 8_** more gas than using `JUMPSUB`.
 
 ## Security Considerations
 
 These changes do introduce new flow control instructions, so any software which does static/dynamic analysis of EVM code needs to be modified accordingly. The `JUMPSUB` semantics are similar to `JUMP` (but jumping to a `BEGINSUB`), whereas the `RETURNSUB` instruction is different, since it can 'land' on any opcode (but the possible destinations can be statically inferred).
 
-Safety and amenability to static analysis of valid programs can be made comparable to [EIP-615](https://eips.ethereum.org/EIPS/eip-615), but without imposing syntactic constraints, and thus with improved low-level optimizations (as shown above.)  Validity can ensured by following the rules given in the next section, and programs can be validated with the provided algorithm.  The validation algorithm is simple and bounded by the size of the code, allowing for validation at creation time.  And compilers can easily follow the rules.
+Safety and amenability to static analysis of valid programs are comparable to [EIP-615](https://eips.ethereum.org/EIPS/eip-615), but without imposing syntactic constraints, and thus with improved low-level optimizations (as shown above.)  Validity can ensured by following the rules given in the next section, and programs can be validated with the provided algorithm.  The validation algorithm is simple and bounded by the size of the code, allowing for validation at creation time.  And compilers can easily follow the rules.
 
 ### Validity
 
@@ -254,9 +255,7 @@ _Execution_ is as defined in the [Yellow Paper](https://ethereum.github.io/yello
 4. Invalid jump destination
 5. Invalid instruction
 
-We would like to consider EVM code valid iff no execution of the program can lead to an exceptional halting state, but we must be able to validate code in linear time to avoid denial of service attacks.  So in practice, we can only partially meet these requirements.  Our validation algorithm does not consider the code’s data and computations, only its control flow and stack use.  This means we will reject programs with any invalid code paths, even if those paths are not reachable at runtime.   Further, conditions 1 and 2 — Insufficient gas and stack overflow — must in general be checked at runtime.  Conditions 3, 4, and 5 cannot occur if the code conforms to the following rules.
-
-*Note: Checking for insufficient gas should be possible for programs that do not loop, recurse, or use opcodes with dynamic prices, but we do not attempt to do so here.*
+We would like to consider EVM code valid iff no execution of the program can lead to an exceptional halting state, but we must be able to validate code in linear time to avoid denial of service attacks.  So in practice, we can only partially meet these requirements.  Our validation algorithm does not consider the code’s data and computations, only its control flow and stack use.  This means we will reject programs with any invalid code paths, even if those paths are not reachable at runtime.   Further, conditions *1* and *2* — Insufficient gas and stack overflow — must in general be checked at runtime.  Conditions *3*, *4*, and *5* cannot occur if the code conforms to the following rules.
 
 #### The Rules
 
@@ -266,15 +265,15 @@ We would like to consider EVM code valid iff no execution of the program can lea
 3. For each instruction in the code the `stack depth` is always the same.
 4. The `stack depth` is always positive and at most 1024.
 
-*Rule 0*, deprecating `JUMP` and `JUMPI`, would forbid dynamic jumps.  Absent dynamic jumps another mechanism is needed for subroutine returns, as provided here. 
+*Rule 0*, deprecating `JUMP` and `JUMPI`, forbids dynamic jumps.  Absent dynamic jumps another mechanism is needed for subroutine returns, as provided here. 
 
-Jump destinations are currently checked at runtime.  Static jumps allow them to be validated at creation time, per *Rule 1*.  _Note: Valid instructions are not part of immediate data._
+Jump destinations are currently checked at runtime.  Static jumps allow them to be validated at creation time, per *rule 1* and *rule 2*.  *Note: Valid instructions are not part of immediate data.*
 
-For *Rule 3* and *Rule 4* we need to define `stack depth`.  The Yellow Paper has the `stack pointer` or `SP` pointing just past the top item on the `data stack`.   We define the `stack base` as where the `SP` pointed before the most recent `JUMPSUB`, or `0` on program entry.  So we can define the `stack depth` as the number of stack elements between the current `SP` and the current `stack base`.  
+For *rule 3* and *rule 4* we need to define `stack depth`.  The Yellow Paper has the `stack pointer` or `SP` pointing just past the top item on the `data stack`.   We define the `stack base` as where the `SP` pointed before the most recent `JUMPSUB`, or `0` on program entry.  So we can define the `stack depth` as the number of stack elements between the current `SP` and the current `stack base`.  
 
-Given our definition of `stack depth` *Rule 3* ensures that control flows which return to the same place with a different `stack depth` are invalid.  These can be caused by irreducible paths like jumping into loops and subroutines, and calling subroutines with different numbers of arguments.  Taken together, these rules allow for code to be validated  by following the control-flow graph, traversing each edge only once.
+Given our definition of `stack depth`, *rule 3* ensures that control flows which return to the same place with a different `stack depth` are invalid.  These can be caused by irreducible paths like jumping into loops and subroutines, and calling subroutines with different numbers of arguments.  Taken together, these rules allow for code to be validated  by following the control-flow graph, traversing each edge only once.
 
-Finally, *Rule 4* catches all stack underflows.  It also catches stack overflows in programs that overflow without (or before) recursion.
+Finally, *rule 4* catches all stack underflows.  It also catches stack overflows in programs that overflow without (or before) recursion.
 
 ### Validation
 
@@ -460,7 +459,7 @@ Consumed gas: `30`
 
 ## Appendix: Stack Frames
 
-Given [EIP-3337](https://eips.ethereum.org/EIPS/eip-3337) — which introduces a frame pointer register `FP` relative to which which memory can be addressed , we can easily create a frame stack — a list in memory for arguments and  local variables.  Two conventions are typical — either create the frame before calling the subroutine, or create the frame after the `BEGINSUB`.  Adding these two instructions to EIP-3337 would ease the way.  They are modeled on the corresponding Intel opcodes.
+Given [EIP-3337](https://eips.ethereum.org/EIPS/eip-3337) — which introduces a frame pointer register `FP` relative to which which memory can be addressed , we can create a frame stack — a list of data frames in memory for arguments and  local variables.  Two conventions are typical — either create the frame before calling the subroutine, or create the frame after the `BEGINSUB`.  Adding these two instructions to EIP-3337 would ease the way.  They are modeled on the corresponding Intel opcodes.
 
 #### ENTER _frame_size_
 
@@ -509,3 +508,4 @@ Nick Johnson, [EIP-3337: Frame pointer support for memory load and store operati
 
 ## Copyright
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+  

--- a/EIPS/eip-2315.md
+++ b/EIPS/eip-2315.md
@@ -1,8 +1,7 @@
-
 ---
 eip: 2315
 title: Simple Subroutines for the EVM
-status: Review
+status: Draft
 type: Standards Track
 category: Core
 author: Greg Colvin <greg@colvin.org>, Martin Holst Swende (@holiman)


### PR DESCRIPTION
There are three substantive changes to this proposal since the prior Last Call, made possible by other recent EVM work.
* Work on the Ethereum Object Format can make it possible to have immediate arguments for static operations.
* A static `JUMPSUB`, Static Relative Jumps, and deprecating dynamic jumps can support EIP-615-level safety guarantees against invalid instructions, stack underflow, and many stack overflows.
* A distinct contract-creation phase allows for validity checking to enforce those guarantees and eliminate the need for (and DOS vulnerability of) jumpdest-analysis.

The proposal has been expanded to:
* Demonstrate claimed efficiency gains.
* Provide safety rules and a validation algorithm for enforcing them.