### PR TITLE
Update interface definition code section

### DIFF
--- a/EIPS/eip-2981.md
+++ b/EIPS/eip-2981.md
@@ -95,16 +95,17 @@ interface IERC2981 is IERC165 {
         address receiver,
         uint256 royaltyAmount
     );
-
-    /// @notice Informs callers that this contract supports ERC2981
-    /// @dev If `_registerInterface(_INTERFACE_ID_ERC2981)` is called
-    ///      in the initializer, this should be automatic
-    /// @param interfaceID The interface identifier, as specified in ERC-165
-    /// @return `true` if the contract implements
-    ///         `_INTERFACE_ID_ERC2981` and `false` otherwise
-    function supportsInterface(bytes4 interfaceID) external view returns (bool);
 }
 
+interface IERC165 {
+    /// @notice Query if a contract implements an interface
+    /// @param interfaceID The interface identifier, as specified in ERC-165
+    /// @dev Interface identification is specified in ERC-165. This function
+    ///  uses less than 30,000 gas.
+    /// @return `true` if the contract implements `interfaceID` and
+    ///  `interfaceID` is not 0xffffffff, `false` otherwise
+    function supportsInterface(bytes4 interfaceID) external view returns (bool);
+}
 ```
 
 ### Examples


### PR DESCRIPTION
* Removed supportsInterface from the IERC2981 interface
* Added a separate definition of the IERC165 interface with the original comment language
* For more details about this change, see; https://github.com/ethereum/EIPs/issues/2907#issuecomment-903283402