### PR TITLE
3675: Update PoS events

### DIFF
--- a/EIPS/eip-3675.md
+++ b/EIPS/eip-3675.md
@@ -42,14 +42,18 @@ There can be more than one terminal PoW block in the network, e.g. multiple chil
 * **`TRANSITION_BLOCK`** The earliest PoS block of the canonical chain, i.e. the PoS block with the lowest block height.
 `TRANSITION_BLOCK` **MUST** be a child of a terminal PoW block.
 * **`POS_CONSENSUS_VALIDATED`** An event occurring when the PoS block is validated with respect to the proof-of-stake consensus rules.
-* **`POS_CHAINHEAD_SET`** An event occurring when the PoS block is designated as the head of the canonical chain.
-* **`POS_BLOCK_FINALIZED`** An event occurring when the PoS block is considered as finalized.
+* **`POS_FORKCHOICE_UPDATED`** An event occurring when the state of the proof-of-stake fork choice is updated.
 
 #### PoS events
 
 Events having the `POS_` prefix in the name (PoS events) are emitted by the new proof-of-stake consensus mechanism. They signify the corresponding assertion that has been made regarding a block specified by the event. The underlying logic of PoS events can be found in the beacon chain specification. On the occurrence of each PoS event the corresponding action that is specified by this EIP **MUST** be taken.
 
-Each `POS_BLOCK_FINALIZED` event has a reference to the head of the canonical chain in addition to the finalized block and incorporates the semantics of the `POS_CHAINHEAD_SET` event. Thus, every action and effect that is specified on the occurrence of `POS_CHAINHEAD_SET` event according to this EIP **MUST** also be taken on every occurrence of `POS_BLOCK_FINALIZED` event.
+The details provided below must be taken into account when reading those parts of the specification that refer to the PoS events:
+* Reference to a block that is contained by PoS events is provided in a form of a block hash unless another is explicitly specified.
+* A `POS_CONSENSUS_VALIDATED` event contains a reference to a block that this event is related to. All ancestors of a referenced block are as well deemed valid with respect to the proof-of-stake consensus rules.
+* A `POS_FORKCHOICE_UPDATED` event contains references to the head of the canonical chain and to the most recent finalized block. Before the first finalized block occurs in the system the finalized block hash provided by this event is stubbed with `0x0000000000000000000000000000000000000000000000000000000000000000`. 
+* Any block that is designated by a `POS_FORKCHOICE_UPDATED` event as the head of the canonical chain and all ancestors of this block are deemed valid with respect to the proof-of-stake consensus rules.
+* **`FIRST_FINALIZED_BLOCK`** The first finalized block that is designated by `POS_FORKCHOICE_UPDATED` event and has the hash that differs from the stub.
 
 
 ### PoW block processing
@@ -81,8 +85,8 @@ Beginning with `TRANSITION_BLOCK`, the block validity conditions **MUST** be alt
 * Remove all validation rules that are evaluated over the list of ommers and each member of this list.
 * Add verification of the fields noted in [block structure](#block-structure) as their specified constant value.
 * Add verification of block validity with respect to the PoS consensus rules, i.e. assert that there **MUST** be a corresponding event for the block to consider it valid. Such events are limited to the following:
-    * A `POS_CONSENSUS_VALIDATED` event considering the block or any of its ancestors as valid.
-    * A `POS_CHAINHEAD_SET` event, including the `POS_BLOCK_FINALIZED` form of this event, designating the block as the head of the canonical chain.
+    * A `POS_CONSENSUS_VALIDATED` event considering the block or any of its descendants as valid.
+    * A `POS_FORKCHOICE_UPDATED` event designating the block or any of its descendants as the head of the canonical chain.
 
 *Note*: If one of the new rules fails then the block **MUST** be invalidated.
 
@@ -101,13 +105,16 @@ Beginning with `TRANSITION_BLOCK`, block and ommer rewards are deprecated. Speci
 
 ### Fork choice rule
 
-As of the first `POS_CHAINHEAD_SET` event, the fork choice rule **MUST** be altered in the following way:
+As of the first `POS_FORKCHOICE_UPDATED` event, the fork choice rule **MUST** be altered in the following way:
 * Remove the existing PoW heaviest chain rule.
 * Adhere to the new PoS LMD-GHOST rule.
 
-The new PoS LMD-GHOST fork choice rule is specified as follows. On each occurrence of a `POS_CHAINHEAD_SET` event including the first one, the following actions **MUST** be taken:
-* Consider the chain starting at genesis and ending with the block nominated by the event as the canonical blockchain.
-* Set the head of the canonical blockchain to the block nominated by the event.
+The new PoS LMD-GHOST fork choice rule is specified as follows. On each occurrence of a `POS_FORKCHOICE_UPDATED` event including the first one, the following actions **MUST** be taken:
+* Consider the chain starting at genesis and ending with the head block nominated by the event as the canonical blockchain.
+* Set the head of the canonical blockchain to the corresponding block nominated by the event.
+* Beginning with the `FIRST_FINALIZED_BLOCK`, set the most recent finalized block to the corresponding block nominated by the event.
+
+Changes to the block tree store that are related to the above actions **MUST** be applied atomically.
 
 
 ### Network
@@ -116,11 +123,11 @@ The networking stack **SHOULD NOT** send the following messages if they advertis
 * [`NewBlockHashes (0x01)`](https://github.com/ethereum/devp2p/blob/master/caps/eth.md#newblockhashes-0x01)
 * [`NewBlock (0x07)`](https://github.com/ethereum/devp2p/blob/master/caps/eth.md#newblock-0x07)
 
-Beginning with the first `POS_BLOCK_FINALIZED` event, the networking stack **MUST** discard the following ingress messages:
+Beginning with receiving the `FIRST_FINALIZED_BLOCK`, the networking stack **MUST** discard the following ingress messages:
 * [`NewBlockHashes (0x01)`](https://github.com/ethereum/devp2p/blob/master/caps/eth.md#newblockhashes-0x01)
 * [`NewBlock (0x07)`](https://github.com/ethereum/devp2p/blob/master/caps/eth.md#newblock-0x07)
 
-Beginning with the second `POS_BLOCK_FINALIZED` event, the networking stack **MUST** remove the handlers corresponding to the following messages:
+Beginning with receiving the finalized block next to the `FIRST_FINALIZED_BLOCK`, the networking stack **MUST** remove the handlers corresponding to the following messages:
 * [`NewBlockHashes (0x01)`](https://github.com/ethereum/devp2p/blob/master/caps/eth.md#newblockhashes-0x01)
 * [`NewBlock (0x07)`](https://github.com/ethereum/devp2p/blob/master/caps/eth.md#newblock-0x07)
 
@@ -227,7 +234,7 @@ To protect the network from this attack scenario, difficulty accumulated by the 
 
 There could be the case when a terminal PoW block is not observed by the majority of network participants due to (temporal) network partitioning. In such a case, this minority would switch their fork choice to the new rule provided by the PoS rooted on the minority terminal PoW block that they observed.
 
-The transition process allows the network to re-org between forks with different terminal PoW blocks as long as (a) these blocks satisfy the terminal PoW block conditions and (b) a `POS_BLOCK_FINALIZED` has not yet been received. This provides resilience against adverse network conditions during the transition process and prevents irreparable forks/partitions.
+The transition process allows the network to re-org between forks with different terminal PoW blocks as long as (a) these blocks satisfy the terminal PoW block conditions and (b) the `FIRST_FINALIZED_BLOCK` has not yet been received. This provides resilience against adverse network conditions during the transition process and prevents irreparable forks/partitions.
 
 #### Halt the importing of PoW blocks
 


### PR DESCRIPTION
- Unifies `POS_CHAINHEAD_SET` and `POS_BLOCK_FINALIZED` into `POS_FORKCHOICE_UPDATED`
- Adds more details to the PoS events description for the sake of clarity
- Introduces a small fix to the Block validity section, related to the PoS events