### PR TITLE
EIP-170: Name the MAX_CODE_SIZE constant

### DIFF
--- a/EIPS/eip-170.md
+++ b/EIPS/eip-170.md
@@ -12,12 +12,13 @@ created: 2016-11-04
 [Spurious Dragon](./eip-607.md)
 
 ### Parameters
+- `MAX_CODE_SIZE`: `0x6000` (`2**14 + 2**13`)
 - `FORK_BLKNUM`: 2,675,000
-- `CHAIN_ID`: 1 (main net)
+- `CHAIN_ID`: 1 (Mainnet)
 
 ### Specification
 
-If `block.number >= FORK_BLKNUM`, then if contract creation initialization returns data with length of **more than** `0x6000` (`2**14 + 2**13`) bytes, contract creation fails with an out of gas error.
+If `block.number >= FORK_BLKNUM`, then if contract creation initialization returns data with length of **more than** `MAX_CODE_SIZE` bytes, contract creation fails with an out of gas error.
 
 ### Rationale
 


### PR DESCRIPTION
Name the `0x6000` constant in EIP-170 as `MAX_CODE_SIZE`.