### PR TITLE
Promote EIP-2364 & EIP-2464 to "Review"

### DIFF
--- a/EIPS/eip-2364.md
+++ b/EIPS/eip-2364.md
@@ -3,7 +3,7 @@ eip: 2364
 title: "eth/64: forkid-extended protocol handshake"
 author: Péter Szilágyi <peterke@gmail.com>
 discussions-to: https://github.com/ethereum/EIPs/issues/2365
-status: Draft
+status: Review
 type: Standards Track
 category: Networking
 created: 2019-11-08

--- a/EIPS/eip-2464.md
+++ b/EIPS/eip-2464.md
@@ -3,7 +3,7 @@ eip: 2464
 title: "eth/65: transaction announcements and retrievals"
 author: Péter Szilágyi <peterke@gmail.com>, Gary Rong <garyrong0905@gmail.com>
 discussions-to: https://github.com/ethereum/EIPs/issues/2465
-status: Draft
+status: Review
 type: Standards Track
 category: Networking
 created: 2020-01-13


### PR DESCRIPTION
Based on the discussion in [ACD meeting 121](https://www.youtube.com/watch?v=09z-yijllWA&t=5589) & followed up on [Discord](https://discordapp.com/channels/595666850260713488/746566142700814426/883375828161921044), making the PR requesting the change of the status for [EIP-2364](https://eips.ethereum.org/EIPS/eip-2364) & [EIP-2464](https://eips.ethereum.org/EIPS/eip-2464). 