### PR TITLE
Add missing EIP states and bring en par with EIP-1

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,6 @@ title: Home
   <li><strong>Final</strong> - This EIP represents the final standard. A Final EIP exists in a state of finality and should only be updated to correct errata and add non-normative clarifications.</li>
   <li><strong>Stagnant</strong> - Any EIP in Draft or Review if inactive for a period of 6 months or greater is moved to Stagnant. An EIP may be resurrected from this state by Authors or EIP Editors through moving it back to Draft.</li>
   <li><strong>Withdrawn</strong> - The EIP Author(s) have withdrawn the proposed EIP. This state has finality and can no longer be resurrected using this EIP number. If the idea is pursued at later date it is considered a new proposal.</li>
-
   <li><strong>Living</strong> - A special status for EIPs that are designed to be continually updated and not reach a state of finality. This includes most notably EIP-1.</li>
 </ul>
 

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@ title: Home
   <li><strong>Review</strong> - An EIP Author marks an EIP as ready for and requesting Peer Review.</li>
   <li><strong>Last Call</strong> - This is the final review window for an EIP before moving to FINAL. An EIP editor will assign Last Call status and set a review end date (review-period-end), typically 14 days later. If this period results in necessary normative changes it will revert the EIP to Review.</li>
   <li><strong>Final</strong> - This EIP represents the final standard. A Final EIP exists in a state of finality and should only be updated to correct errata and add non-normative clarifications.</li>
-  <li><strong>Stagnant</strong> - Any EIP in DRAFT or REVIEW if inactive for a period of 6 months or greater is moved to STAGNANT. An EIP may be resurrected from this state by Authors or EIP Editors through moving it back to DRAFT.</li>
+  <li><strong>Stagnant</strong> - Any EIP in Draft or Review if inactive for a period of 6 months or greater is moved to Stagnant. An EIP may be resurrected from this state by Authors or EIP Editors through moving it back to Draft.</li>
   <li><strong>Withdrawn</strong> - The EIP Author(s) have withdrawn the proposed EIP. This state has finality and can no longer be resurrected using this EIP number. If the idea is pursued at later date it is considered a new proposal.</li>
 
   <li><strong>Living</strong> - A special status for EIPs that are designed to be continually updated and not reach a state of finality. This includes most notably EIP-1. Any changes to these EIPs will move between REVIEW and LIVING states.</li>

--- a/index.html
+++ b/index.html
@@ -14,11 +14,15 @@ title: Home
 
 <h2>EIP status terms</h2>
 <ul>
-  <li><strong>Draft</strong> - an EIP that is open for consideration and is undergoing rapid iteration and changes.</li>
-  <li><strong>Last Call</strong> - an EIP that is done with its initial iteration and ready for review by a wide audience.</li>
-  <li><strong>Accepted</strong> - a core EIP that has been in Last Call for at least 2 weeks and any technical changes that were requested have been addressed by the author. The process for Core Devs to decide whether to encode an EIP into their clients as part of a hard fork is not part of the EIP process. If such a decision is made, the EIP will move to final. </li>
-  <li><strong>Final (non-Core)</strong> - an EIP that has been in Last Call for at least 2 weeks and any technical changes that were requested have been addressed by the author.</li>
-  <li><strong>Final (Core)</strong> - an EIP that the Core Devs have decided to implement and release in a future hard fork or has already been released in a hard fork.</li>
+  <li><strong>Idea</strong> - An idea that is pre-draft. This is not tracked within the EIP Repository.
+  <li><strong>Draft</strong> - The first formally tracked stage of an EIP in development. An EIP is merged by an EIP Editor into the EIP repository when properly formatted.</li>
+  <li><strong>Review</strong> - An EIP Author marks an EIP as ready for and requesting Peer Review.</li>
+  <li><strong>Last Call</strong> - This is the final review window for an EIP before moving to FINAL. An EIP editor will assign Last Call status and set a review end date (review-period-end), typically 14 days later. If this period results in necessary normative changes it will revert the EIP to REVIEW.</li>
+  <li><strong>Final</strong> - This EIP represents the final standard. A Final EIP exists in a state of finality and should only be updated to correct errata and add non-normative clarifications.</li>
+  <li><strong>Stagnant</strong> - Any EIP in DRAFT or REVIEW if inactive for a period of 6 months or greater is moved to STAGNANT. An EIP may be resurrected from this state by Authors or EIP Editors through moving it back to DRAFT.</li>
+  <li><strong>Withdrawn</strong> - The EIP Author(s) have withdrawn the proposed EIP. This state has finality and can no longer be resurrected using this EIP number. If the idea is pursued at later date it is considered a new proposal.</li>
+
+  <li><strong>Living</strong> - A special status for EIPs that are designed to be continually updated and not reach a state of finality. This includes most notably EIP-1. Any changes to these EIPs will move between REVIEW and LIVING states.</li>
 </ul>
 
 <h2>EIP Types</h2>

--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@ title: Home
   <li><strong>Stagnant</strong> - Any EIP in Draft or Review if inactive for a period of 6 months or greater is moved to Stagnant. An EIP may be resurrected from this state by Authors or EIP Editors through moving it back to Draft.</li>
   <li><strong>Withdrawn</strong> - The EIP Author(s) have withdrawn the proposed EIP. This state has finality and can no longer be resurrected using this EIP number. If the idea is pursued at later date it is considered a new proposal.</li>
 
-  <li><strong>Living</strong> - A special status for EIPs that are designed to be continually updated and not reach a state of finality. This includes most notably EIP-1. Any changes to these EIPs will move between REVIEW and LIVING states.</li>
+  <li><strong>Living</strong> - A special status for EIPs that are designed to be continually updated and not reach a state of finality. This includes most notably EIP-1.</li>
 </ul>
 
 <h2>EIP Types</h2>

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@ title: Home
   <li><strong>Idea</strong> - An idea that is pre-draft. This is not tracked within the EIP Repository.
   <li><strong>Draft</strong> - The first formally tracked stage of an EIP in development. An EIP is merged by an EIP Editor into the EIP repository when properly formatted.</li>
   <li><strong>Review</strong> - An EIP Author marks an EIP as ready for and requesting Peer Review.</li>
-  <li><strong>Last Call</strong> - This is the final review window for an EIP before moving to FINAL. An EIP editor will assign Last Call status and set a review end date (review-period-end), typically 14 days later. If this period results in necessary normative changes it will revert the EIP to REVIEW.</li>
+  <li><strong>Last Call</strong> - This is the final review window for an EIP before moving to FINAL. An EIP editor will assign Last Call status and set a review end date (review-period-end), typically 14 days later. If this period results in necessary normative changes it will revert the EIP to Review.</li>
   <li><strong>Final</strong> - This EIP represents the final standard. A Final EIP exists in a state of finality and should only be updated to correct errata and add non-normative clarifications.</li>
   <li><strong>Stagnant</strong> - Any EIP in DRAFT or REVIEW if inactive for a period of 6 months or greater is moved to STAGNANT. An EIP may be resurrected from this state by Authors or EIP Editors through moving it back to DRAFT.</li>
   <li><strong>Withdrawn</strong> - The EIP Author(s) have withdrawn the proposed EIP. This state has finality and can no longer be resurrected using this EIP number. If the idea is pursued at later date it is considered a new proposal.</li>


### PR DESCRIPTION
Bring the states en par with EIP-1 - otherwise this can lead to confusion like here: https://github.com/ethereum/EIPs/pull/3838#discussion_r702400025 as the "Review" state is not reflected on https://eips.ethereum.org