### PR TITLE
Removes Living toggling between review and living.

### DIFF
--- a/EIPS/eip-1.md
+++ b/EIPS/eip-1.md
@@ -90,7 +90,7 @@ If this period results in necessary normative changes it will revert the EIP to 
 
 **Withdrawn** - The EIP Author(s) have withdrawn the proposed EIP. This state has finality and can no longer be resurrected using this EIP number. If the idea is pursued at later date it is considered a new proposal.
 
-**Living** - A special status for EIPs that are designed to be continually updated and not reach a state of finality. This includes most notably EIP-1. Any changes to these EIPs will move between `REVIEW` and `LIVING` states.
+**Living** - A special status for EIPs that are designed to be continually updated and not reach a state of finality. This includes most notably EIP-1.
 
 ## What belongs in a successful EIP?
 


### PR DESCRIPTION
I believe we decided in a previous EIPs meeting to just have Living stay living.  Having it toggle to review doesn't make sense, because then it means there is no living EIP-1 while it is in review.

cc @poojaranjan 