### PR TITLE
Update eip-725.md

### DIFF
--- a/EIPS/eip-725.md
+++ b/EIPS/eip-725.md
@@ -1,6 +1,6 @@
 ---
 eip: 725
-title: Smart Contract Based Account
+title: ERC-725 Smart Contract Based Account
 author: Fabian Vogelsteller (@frozeman), Tyler Yasaka (@tyleryasaka)
 discussions-to: https://github.com/ethereum/EIPs/issues/725
 status: Draft
@@ -51,8 +51,8 @@ ERC165 identifier: `0x44c028fe`
 Executes a call on any other smart contracts, transfers the blockchains native token, or deploys a new smart contract.
 MUST only be called by the current owner of the contract.
 
-```js
-function execute(uint256 operationType, address to, uint256 value, bytes data)
+```solidity
+function execute(uint256 operationType, address to, uint256 value, bytes data) public
 ```
 
 The `operationType` can execute the following operations:
@@ -63,38 +63,46 @@ The `operationType` can execute the following operations:
 
 Others may be added in the future.
 
-**Triggers Event:** [ContractCreated](#contractcreated) if a contract was created
+**Triggers Event:**  [ContractCreated](#contractcreated), [Executed](#executed) 
 
 ### Events
 
+#### Executed
+
+MUST be triggered when `execute` creates a new call using any `operationType`.
+
+```solidity
+event Executed(uint256 indexed _operation, address indexed _to, uint256 indexed _value, bytes _data);
+``` 
+
 #### ContractCreated
 
-MUST be triggered when `execute` creates a new contract using the `_operationType` `1`.
+MUST be triggered when `execute` creates a new contract using the `operationType` `2`, `3`.
 
-```js
+```solidity
 event ContractCreated(address indexed contractAddress)
 ```
 
 ### ERC725Y
 
-ERC165 identifier: `0x2bd57b73`
+ERC165 identifier: `0x5a988c0f`
 
 #### getData
 
-Returns the data at the specified key.
+Returns array of data at multiple keys.
 
-```js
-function getData(bytes32 key) external view returns(bytes value)
+```solidity
+function getData(bytes32[] calldata _keys) public view returns(bytes[] memory)
 ```
 
 #### setData
 
-Sets the data at a specific key. MUST only be called by the current owner of the contract.
+Sets array of data at multiple keys. MUST only be called by the current owner of the contract.
 
 **Triggers Event:** [DataChanged](#datachanged)
 
-```js
-function setData(bytes32 _key, bytes memory _value) external
+```solidity
+function setData(bytes32[] calldata _keys, bytes[] calldata _values) public 
 ```
 
 ### Events
@@ -103,7 +111,7 @@ function setData(bytes32 _key, bytes memory _value) external
 
 MUST be triggered when `setData` was successfully called.
 
-```js
+```solidity
 event DataChanged(bytes32 indexed key, bytes value)
 ```
 
@@ -133,14 +141,6 @@ ERC725 key standards need to be defined within new standards, we suggest the fol
 | --- | --- | --- | --- |
 | SupportedStandards:XYZ | Allows to determine standards supported by this contract | `0xeafec4d89fa9619884b6b89135626455000000000000000000000000xxxxxxxx`, where `xxxxxxxx` is the 4 bytes identifier of the standard supported | Value can be defined by the standard, by default it should be the 4 bytes identifier  e.g. `0x7a30e6fc` |
 | SupportedStandards:ERC725Account | Allows to determine standards supported by this contract | `0xeafec4d89fa9619884b6b89135626455000000000000000000000000afdeb5d6`, where `afdeb5d6` is the 4 bytes part of the hash of `keccak256('ERC725Account')` | Value is the 4 bytes identifier `0xafdeb5d6` |
-
-
-Other key examples COULD be:
-
-| Name | Description | Key | value |
-| --- | --- | --- | --- |
-| ERC735 | A personal claim holder contract (per [ERC735](https://github.com/ethereum/EIPs/issues/735)) | `0x33f5765e0b3f726091f5ab06cd801c2bcd9bf89228534161c70fd7e257b8bfa3` | 20 bytes value `0xcafecafe69a9FD93d5F28D9Ec85E40f4cb69cafe` |
-| ERC780 | A registry claim holder contract (per [ERC780](https://github.com/ethereum/EIPs/issues/780)) | `0x62db7b9279d03518c54464b4946aade7cafabff066a90c55b054d5c5ee04c371` | 20 bytes value `0xcafecafe69a9FD93d5F28D9Ec85E40f4cb69cafe` |
 
 ##### ERC725Account
 
@@ -173,15 +173,15 @@ interface IERC725X  /* is ERC165, ERC173 */ {
     event ContractCreated(address indexed contractAddress);
     event Executed(uint256 indexed operation, address indexed to, uint256 indexed  value, bytes data);
 
-    function execute(uint256 operationType, address to, uint256 value, bytes memory data) external;
+    function execute(uint256 operationType, address to, uint256 value, bytes memory data) public;
 }
 
-//ERC165 identifier: `0x2bd57b73`
+//ERC165 identifier: `0x5a988c0f`
 interface IERC725Y /* is ERC165, ERC173 */ {
     event DataChanged(bytes32 indexed key, bytes value);
 
-    function getData(bytes32 key) external view returns (bytes memory value);
-    function setData(bytes32 key, bytes memory value) external;
+    function getData(bytes32[] calldata _keys) public view returns(bytes[] memory);
+    function setData(bytes32[] calldata _keys, bytes[] calldata _values) public ;
 }
 
 interface IERC725 /* is IERC725X, IERC725Y */ {


### PR DESCRIPTION
## Description

As i mentioned in the issue, @frozeman , @CJ42 and I found that the better way to setData in ERC725Y is by passing an array of data which can be set in one transaction, that way we can skip the need to to make a contract call each time we want to set singular form of data. Same applies for getData.

## Issue

For more information check the issue #3857
 
