### PR TITLE
EIP-3675: Hardcode terminal total difficulty

### DIFF
--- a/EIPS/eip-3675.md
+++ b/EIPS/eip-3675.md
@@ -56,6 +56,11 @@ The details provided below must be taken into account when reading those parts o
 * **`FIRST_FINALIZED_BLOCK`** The first finalized block that is designated by `POS_FORKCHOICE_UPDATED` event and has the hash that differs from the stub.
 
 
+### Terminal total difficulty
+
+The `TERMINAL_TOTAL_DIFFICULTY` parameter is a part of client software configuration and **MUST** be included into its binary distribution.
+
+
 ### PoW block processing
 
 PoW blocks that are descendants of any terminal PoW block **MUST NOT** be imported. This implies that a terminal PoW block will be the last PoW block in the canonical chain.


### PR DESCRIPTION
### What's done?
Notes that `TERMINAL_TOTAL_DIFFICULTY` parameter must be hardcoded into client software distribution. See the corresponding change in the consensus layer for additional details and rationale https://github.com/ethereum/consensus-specs/pull/2605.

