### PR TITLE
EIP-3675: Bring back extraData

### DIFF
--- a/EIPS/eip-3675.md
+++ b/EIPS/eip-3675.md
@@ -74,7 +74,6 @@ Beginning with `TRANSITION_BLOCK`, a number of previously dynamic block fields a
 |-|-|-|
 | **`ommersHash`** | `0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347` | `= Keccak256(RLP([]))` |
 | **`difficulty`** | `0` |  |
-| **`extraData`** | `b''` | `RLP(b'') = 0x80` |
 | **`mixHash`** | `0x0000000000000000000000000000000000000000000000000000000000000000` |  |
 | **`nonce`** | `0x0000000000000000` |  |
 | **`ommers`** | `[]` | `RLP([]) = 0xc0`  |
@@ -166,10 +165,6 @@ This change introduces an additional validity rule that enforces the replacement
 ### Replacing `difficulty` with `0`
 
 After deprecating the proof-of-work the notion of difficulty no longer exists and replacing the block header **`difficulty`** field with `0` constant is semantically sound.
-
-### Deprecating `extraData`
-
-The **`extraData`** field is deprecated in favour of the corresponding **`graffiti`** field of the beacon block.
 
 ### Changing block validity rules
 


### PR DESCRIPTION
### What's done?
Removes the deprecation of **`extraData`** block field.

### Rationale
The **`extraData`** field is pretty handy during investigation into various network incidents as the default usage of this field is to express the client software version that has been used to create a block.