### PR TITLE
EIP 2135 stagnant (2021-Sep-19th@03.9.29)

### DIFF
--- a/EIPS/eip-2135.md
+++ b/EIPS/eip-2135.md
@@ -3,7 +3,7 @@ eip: 2135
 title: Consumable Interface
 author: Zainan Victor Zhou (@xinbenlv)
 discussions-to: https://github.com/ethereum/EIPs/issues/2135
-status: Draft
+status: Stagnant
 type: Standards Track
 category: ERC
 created: 2019-06-23


### PR DESCRIPTION
This EIP has not been active since (2020-Sep-29th@23.22.43); which, is greater than the allowed time of 6 months.

 authors: @xinbenlv 
 EIP Editors: @MicahZoltu, @lightclient, @arachnid, @cdetrio, @Souptacular, @vbuterin, @nicksavers, @wanderer, @gcolvin, @axic