### PR TITLE
EIP 2677 stagnant (2021-Sep-19th@03.10.40)

### DIFF
--- a/EIPS/eip-2677.md
+++ b/EIPS/eip-2677.md
@@ -3,7 +3,7 @@ eip: 2677
 title: Limit size of `initcode`
 author: Martin Holst Swende (@holiman), Pawel Bylica (@chfast), Alex Beregszazi (@axic)
 discussions-to: https://ethereum-magicians.org/t/eip-2677-limit-size-of-initcode/4550
-status: Draft
+status: Stagnant
 type: Standards Track
 category: Core
 created: 2020-05-18


### PR DESCRIPTION
This EIP has not been active since (2020-Sep-29th@23.22.43); which, is greater than the allowed time of 6 months.

 authors: @holiman, @chfast, @axic 
 EIP Editors: @MicahZoltu, @lightclient, @arachnid, @cdetrio, @Souptacular, @vbuterin, @nicksavers, @wanderer, @gcolvin, @axic