### PR TITLE
EIP 3267 stagnant (2021-Sep-19th@03.17.8)

### DIFF
--- a/EIPS/eip-3267.md
+++ b/EIPS/eip-3267.md
@@ -3,7 +3,7 @@ eip: 3267
 title: Giving Ethereum fees to Future Salaries
 author: Victor Porton (@vporton), Victor Porton <porton@narod.ru>
 discussions-to: https://ethereum-magicians.org/t/discussion-of-eip-3267/5343
-status: Draft
+status: Stagnant
 type: Standards Track
 category: Core
 created: 2021-02-13


### PR DESCRIPTION
This EIP has not been active since (2021-Feb-23rd@05.32.24); which, is greater than the allowed time of 6 months.

 authors: @vporton 
 EIP Editors: @MicahZoltu, @lightclient, @arachnid, @cdetrio, @Souptacular, @vbuterin, @nicksavers, @wanderer, @gcolvin, @axic