### PR TITLE
EIP 634 stagnant (2021-Sep-19th@04.20.59)

### DIFF
--- a/EIPS/eip-634.md
+++ b/EIPS/eip-634.md
@@ -5,7 +5,7 @@ author: Richard Moore (@ricmoo)
 type: Standards Track
 discussions-to: https://github.com/ethereum/EIPs/issues/2439
 category: ERC
-status: Draft
+status: Stagnant
 created: 2017-05-17
 ---
 


### PR DESCRIPTION
This EIP has not been active since (2021-Jan-27th@03.18.27); which, is greater than the allowed time of 6 months.

 authors: @ricmoo 
 EIP Editors: @MicahZoltu, @lightclient, @arachnid, @cdetrio, @Souptacular, @vbuterin, @nicksavers, @wanderer, @gcolvin, @axic