### PR TITLE
3076: Move to Last Call + Interface

### DIFF
--- a/EIPS/eip-3076.md
+++ b/EIPS/eip-3076.md
@@ -3,11 +3,12 @@ eip: 3076
 title: Slashing Protection Interchange Format
 author: Michael Sproul (@michaelsproul), Sacha Saint-Leger (@sachayves), Danny Ryan (@djrtwo)
 discussions-to: https://ethereum-magicians.org/t/eip-3076-validator-client-interchange-format-slashing-protection/
-status: Review
+status: Last Call
 type: Standards Track
-category: Core
+category: Interface
 created: 2020-10-27
-updated: 2021-02-08
+updated: 2021-09-20
+review-period-end: 2021-10-20
 ---
 
 ## Simple Summary


### PR DESCRIPTION
This PR moves EIP-3076: Slashing Protection Interchange Format to Last Call status.

The standard has been widely adopted by consensus clients, including Lighthouse, Teku, Prysm, Nimbus and Lodestar. No design issues have arisen during the course of implementation and use.

I have also reclassified the EIP as "Interface" rather than "Core", as it seems a better fit. Let me know if this change is not desirable.

I've set a review period for one month from today: 20th October 2021
