### PR TITLE
EIP-3675: Simplify PoS events signalling the consensus validity

### DIFF
--- a/EIPS/eip-3675.md
+++ b/EIPS/eip-3675.md
@@ -50,9 +50,8 @@ Events having the `POS_` prefix in the name (PoS events) are emitted by the new 
 
 The details provided below must be taken into account when reading those parts of the specification that refer to the PoS events:
 * Reference to a block that is contained by PoS events is provided in a form of a block hash unless another is explicitly specified.
-* A `POS_CONSENSUS_VALIDATED` event contains a reference to a block that this event is related to. All ancestors of a referenced block are as well deemed valid with respect to the proof-of-stake consensus rules.
+* A `POS_CONSENSUS_VALIDATED` event contains a reference to a block that this event is related to.
 * A `POS_FORKCHOICE_UPDATED` event contains references to the head of the canonical chain and to the most recent finalized block. Before the first finalized block occurs in the system the finalized block hash provided by this event is stubbed with `0x0000000000000000000000000000000000000000000000000000000000000000`. 
-* Any block that is designated by a `POS_FORKCHOICE_UPDATED` event as the head of the canonical chain and all ancestors of this block are deemed valid with respect to the proof-of-stake consensus rules.
 * **`FIRST_FINALIZED_BLOCK`** The first finalized block that is designated by `POS_FORKCHOICE_UPDATED` event and has the hash that differs from the stub.
 
 
@@ -88,9 +87,7 @@ Beginning with `TRANSITION_BLOCK`, the block validity conditions **MUST** be alt
 * Remove verification of the block's **`nonce`** and **`mixHash`** values with respect to the Ethash function.
 * Remove all validation rules that are evaluated over the list of ommers and each member of this list.
 * Add verification of the fields noted in [block structure](#block-structure) as their specified constant value.
-* Add verification of block validity with respect to the PoS consensus rules, i.e. assert that there **MUST** be a corresponding event for the block to consider it valid. Such events are limited to the following:
-    * A `POS_CONSENSUS_VALIDATED` event considering the block or any of its descendants as valid.
-    * A `POS_FORKCHOICE_UPDATED` event designating the block or any of its descendants as the head of the canonical chain.
+* Add verification of block validity with respect to the PoS consensus rules, i.e. assert that there **MUST** be a corresponding `POS_CONSENSUS_VALIDATED` event for the block to consider it valid.
 
 *Note*: If one of the new rules fails then the block **MUST** be invalidated.
 


### PR DESCRIPTION
### What's done?

PoS events signalling validity of the block with respect to the proof-of-stake consensus rules are simplified in the following way:
- After this change `POS_CONSENSUS_VALIDATED` event relates to the block it has a reference to, the requirement to affect ancestors of this block is removed
- Additional semantics of signalling the block is valid wrt the consensus rules is removed from  `POS_FORKCHOICE_UPDATED` event

### Rational
Simplifies the spec and reduces implementation complexity. It adds a restriction on the events order which is gonna be satisfied by synchronous event processing in the Merge Interop implementations. Production ready solution for preserving the order of events is TBD.