### PR TITLE
Add fem link for 3569

### DIFF
--- a/EIPS/eip-3569.md
+++ b/EIPS/eip-3569.md
@@ -2,7 +2,7 @@
 eip: 3569
 title: Sealed NFT Metadata Standard
 author: Sean Papanikolas (@pizzarob)
-discussions-to: https://github.com/ethereum/EIPs/pull/3569
+discussions-to: https://ethereum-magicians.org/t/eip-3569-sealed-nft-metadata-standard/7130
 status: Draft
 type: Standards Track
 category: ERC


### PR DESCRIPTION
Per EIP-1, `discussions-to` cannot point to Github pull requests. Unfortunately I missed this during review and accidentally merged the EIP before it had a Ethereum Magicians discussion thread. I've created one here: https://ethereum-magicians.org/t/eip-3569-sealed-nft-metadata-standard/7130