### PR TITLE
Center Website Header

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -4,6 +4,14 @@
 
 @import 'minima';
 
+.site-header {
+  .wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+}
+
 .page-content {
   a.anchor-link {
     width: 16px;


### PR DESCRIPTION
Changed
<img width="1268" alt="Screen Shot 2021-10-07 at 2 23 33 PM" src="https://user-images.githubusercontent.com/27740273/136377049-6382f602-042c-41ab-a02c-ea9d7e0241c9.png">
to
<img width="1267" alt="Screen Shot 2021-10-07 at 2 36 54 PM" src="https://user-images.githubusercontent.com/27740273/136377066-c587b02c-2b62-4aa2-894c-7026ae1d4419.png">

____ 
## Mobile Views 

### 600px x 875px
| Old | New |
|-----|-----|
| <img width="300" alt="Screen Shot 2021-10-07 at 2 44 13 PM" src="https://user-images.githubusercontent.com/27740273/136379835-8ce86995-f04f-4af5-bfad-5074e2b4f73b.png">    |   <img width="300" alt="Screen Shot 2021-10-07 at 2 42 33 PM" src="https://user-images.githubusercontent.com/27740273/136379921-f62b07d9-4276-444d-93c6-8d85f72f7cc7.png">  |

### 360px x 640px
| Old | New |
|-----|-----|
| <img width="300" alt="Screen Shot 2021-10-07 at 2 46 58 PM" src="https://user-images.githubusercontent.com/27740273/136379747-8efcb815-57f4-4d30-9e56-1e62640c9a31.png"> | <img width="300" alt="Screen Shot 2021-10-07 at 2 47 09 PM" src="https://user-images.githubusercontent.com/27740273/136379549-9a57c9d6-847e-4575-bf33-b68b5432b076.png">  |
