### PR TITLE
EIP-3675: Execution engine must validate length of the block's extraData

### DIFF
--- a/EIPS/eip-3675.md
+++ b/EIPS/eip-3675.md
@@ -67,7 +67,7 @@ PoW blocks that are descendants of any terminal PoW block **MUST NOT** be import
 
 | Name | Value |
 |-|-|
-| **`MAX_BYTES_PER_EXTRA_DATA`** | `32` |
+| **`MAX_EXTRA_DATA_BYTES`** | `32` |
 
 ### Block structure
 
@@ -81,7 +81,7 @@ Beginning with `TRANSITION_BLOCK`, a number of previously dynamic block fields a
 | **`nonce`** | `0x0000000000000000` |  |
 | **`ommers`** | `[]` | `RLP([]) = 0xc0`  |
 
-Beginning with `TRANSITION_BLOCK`, the validation of the block's **`extraData`** field changes: The length of the block's **`extraData`** **MUST** be less or equal to **`MAX_BYTES_PER_EXTRA_DATA`** bytes.
+Beginning with `TRANSITION_BLOCK`, the validation of the block's **`extraData`** field changes: The length of the block's **`extraData`** **MUST** be less than or equal to **`MAX_EXTRA_DATA_BYTES`** bytes.
 
 *Note*: Logic and validity conditions of block fields that are *not* specified here **MUST** remain unchanged. Additionally, the overall block format **MUST** remain unchanged.
 
@@ -199,7 +199,7 @@ It is recommended for the client software to not propagate descendants of any te
 
 ### Restricting the length of `extraData`
 
-The `extraData` field has been specified as unbounded in the PoW spec even though mainnet and most PoW testnets only utilize `32` bytes for it.  `extraData` fields of greater length are used by clique testnets and other networks to carry special signature/consensus schemes. This EIP restricts the length of `extraData` to `32` bytes since any network that is transitioning from another consensus mechanism to a beacon chain PoS consensus mechanism no longer needs extended or unbounded `extraData`.
+The `extraData` field is defined as a maximum of `32` bytes in the yellow paper. Thus mainnet and most PoW testnets cap the value at `32` bytes.  `extraData` fields of greater length are used by clique testnets and other networks to carry special signature/consensus schemes. This EIP restricts the length of `extraData` to `32` bytes because any network that is transitioning from another consensus mechanism to a beacon chain PoS consensus mechanism no longer needs extended or unbounded `extraData`.
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
The [merge beacon-chain spec](https://github.com/ethereum/consensus-specs/blob/dev/specs/merge/beacon-chain.md) has set `MAX_EXTRA_DATA_BYTES` to 32. The execution engine must validate that this is the case.

/cc @djrtwo @mkalinin 