### PR TITLE
remove POS_CONSENSUS_VALIDATED from EIP 3675

### DIFF
--- a/EIPS/eip-3675.md
+++ b/EIPS/eip-3675.md
@@ -41,7 +41,6 @@ There can be more than one terminal PoW block in the network, e.g. multiple chil
 * **`TERMINAL_TOTAL_DIFFICULTY`** The amount of total difficulty reached by the network that triggers the consensus upgrade.
 * **`TRANSITION_BLOCK`** The earliest PoS block of the canonical chain, i.e. the PoS block with the lowest block height.
 `TRANSITION_BLOCK` **MUST** be a child of a terminal PoW block.
-* **`POS_CONSENSUS_VALIDATED`** An event occurring when the PoS block is validated with respect to the proof-of-stake consensus rules.
 * **`POS_FORKCHOICE_UPDATED`** An event occurring when the state of the proof-of-stake fork choice is updated.
 
 #### PoS events
@@ -50,7 +49,6 @@ Events having the `POS_` prefix in the name (PoS events) are emitted by the new 
 
 The details provided below must be taken into account when reading those parts of the specification that refer to the PoS events:
 * Reference to a block that is contained by PoS events is provided in a form of a block hash unless another is explicitly specified.
-* A `POS_CONSENSUS_VALIDATED` event contains a reference to a block that this event is related to.
 * A `POS_FORKCHOICE_UPDATED` event contains references to the head of the canonical chain and to the most recent finalized block. Before the first finalized block occurs in the system the finalized block hash provided by this event is stubbed with `0x0000000000000000000000000000000000000000000000000000000000000000`. 
 * **`FIRST_FINALIZED_BLOCK`** The first finalized block that is designated by `POS_FORKCHOICE_UPDATED` event and has the hash that differs from the stub.
 
@@ -87,7 +85,6 @@ Beginning with `TRANSITION_BLOCK`, the block validity conditions **MUST** be alt
 * Remove verification of the block's **`nonce`** and **`mixHash`** values with respect to the Ethash function.
 * Remove all validation rules that are evaluated over the list of ommers and each member of this list.
 * Add verification of the fields noted in [block structure](#block-structure) as their specified constant value.
-* Add verification of block validity with respect to the PoS consensus rules, i.e. assert that there **MUST** be a corresponding `POS_CONSENSUS_VALIDATED` event for the block to consider it valid.
 
 *Note*: If one of the new rules fails then the block **MUST** be invalidated.
 
@@ -117,6 +114,7 @@ The new PoS LMD-GHOST fork choice rule is specified as follows. On each occurren
 
 Changes to the block tree store that are related to the above actions **MUST** be applied atomically.
 
+*Note*: This rule **MUST** be strictly enforced. "Optimistic" updates to the head **MUST NOT** be made. That is -- if a new block is processed on top of the current head block, this new block becomes the new head if and only if an accompanying `POS_FORKCHOICE_UPDATED` event occurs.
 
 ### Network
 
@@ -177,6 +175,14 @@ Existing rewards for producing and sealing blocks are deprecated along with the 
 
 The fork choice rule of the PoW mechanism becomes completely irrelevant after the upgrade and is replaced with the corresponding rule of the new PoS consensus mechanism.
 
+### Remove of `POS_CONSENSUS_VALIDATED`
+
+In prior draft versions of this EIP, an additional POS event -- `POS_CONSENSUS_VALIDATED` -- was required as a validation condition for blocks. This event gave the signal to either fully incorporate or prune the block from the block tree.
+
+This event was removed for two reasons:
+1. This event was an unnecessary optimization to allow for pruning of "bad" blocks from the block tree. This optimization was unnecessary because the PoS consensus would never send `POS_FORKCHOICE_UPDATED` for any such bad blocks or their descendants, and eventually any such blocks would be able to be pruned after a PoS finality event of an alternative branch in the block tree.
+2. This event was dangerous in some scenarios because a block could be referenced by two *different* and conflicting PoS branches. Thus for the same block in some scenarios, both a `POS_CONSENSUS_VALIDATED == True` and `POS_CONSENSUS_VALIDATED == FALSE` event could sent, entirely negating the ability to safely perform the optimization in (1).
+
 ### Removing block gossip
 
 After the upgrade of the consensus mechanism only the beacon chain network will have enough information to validate a block. Thus, block gossip provided by the `eth` network protocol will become unsafe and is deprecated in favour of the block gossip existing in the beacon chain network.
@@ -211,7 +217,6 @@ Pseudo-random numbers obtained as the output of `BLOCKHASH` operation become mor
 ### Beacon chain
 
 See Security Considerations section of [EIP-2982](./eip-2982.md#security-considerations).
-
 
 ### Transition process
 


### PR DESCRIPTION
Remove `POS_CONSENSUS_VALIDATED` from EIP 3675.

This event was removed for two reasons:
1. This event was an unnecessary optimization to allow for pruning of "bad" blocks from the block tree. This optimization was unnecessary because the PoS consensus would never send `POS_FORKCHOICE_UPDATED` for any such bad blocks or their descendants, and eventually any such blocks would be able to be pruned after a PoS finality event of an alternative branch in the block tree.
2. This event was dangerous in some scenarios because a block could be referenced by two *different* and conflicting PoS branches. Thus for the same block in some scenarios, both a `POS_CONSENSUS_VALIDATED == True` and `POS_CONSENSUS_VALIDATED == FALSE` event could sent, entirely negating the ability to safely perform the optimization in (1).

