### PR TITLE
EIP-2718: Fix spelling of envelope in EIP-2718.

### DIFF
--- a/EIPS/eip-2718.md
+++ b/EIPS/eip-2718.md
@@ -19,7 +19,7 @@ This was seen in [EIP-155](./eip-155.md) where the new value was bit-packed into
 There are multiple proposals in discussion that define new transaction types such as one that allows EOA accounts to execute code directly within their context, one that enables someone besides `msg.sender` to pay for gas, and proposals related to layer 1 multi-sig transactions.
 These all need to be defined in a way that is mutually compatible, which quickly becomes burdensome to EIP authors and to clients who now have to follow complex rules for differentiating transaction type.
 
-By introducing an envolope transaction type, we only need to ensure backward compatibility with existing transactions and from then on we just need to solve the much simpler problem of ensuring there is no numbering conflict between `TransactionType`s.
+By introducing an envelope transaction type, we only need to ensure backward compatibility with existing transactions and from then on we just need to solve the much simpler problem of ensuring there is no numbering conflict between `TransactionType`s.
 
 ## Specification
 ### Definitions


### PR DESCRIPTION
This PR fixes the spelling of "envelope".