### PR TITLE
Bold H3 headers

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@ title: Home
 
 <p>EIPs are separated into a number of types, and each has its own list of EIPs.</p>
 
-<h3>Standard Track ({{site.pages|where:"type","Standards Track"|size}})</h3>
+<h3><b>Standard Track ({{site.pages|where:"type","Standards Track"|size}})</b></h3>
 <p>Describes any change that affects most or all Ethereum implementations, such as a change to the network protocol, a change in block or transaction validity rules, proposed application standards/conventions, or any change or addition that affects the interoperability of applications using Ethereum. Furthermore Standard EIPs can be broken down into the following categories.</p>
 
 <h4><a href="{{"core"|relative_url}}">Core</a> ({{site.pages|where:"type","Standards Track"|where:"category","Core"|size}})</h4>
@@ -43,8 +43,8 @@ title: Home
 <h4><a href="{{"erc"|relative_url}}">ERC</a> ({{site.pages|where:"type","Standards Track"|where:"category","ERC"|size}})</h4>
 <p>Application-level standards and conventions, including contract standards such as token standards (<a href="EIPS/eip-20">ERC-20</a>), name registries (<a href="EIPS/eip-137">ERC-137</a>), URI schemes (<a href="EIPS/eip-681">ERC-681</a>), library/package formats (<a href="EIPS/eip-190">EIP190</a>), and wallet formats (<a href="https://github.com/ethereum/EIPs/issues/85">EIP-85</a>).</p>
 
-<h3><a href="{{"meta"|relative_url}}">Meta</a> ({{site.pages|where:"type","Meta"|size}})</h3>
+<h3><b><a href="{{"meta"|relative_url}}">Meta</a> ({{site.pages|where:"type","Meta"|size}})</b></h3>
 <p>Describes a process surrounding Ethereum or proposes a change to (or an event in) a process. Process EIPs are like Standards Track EIPs but apply to areas other than the Ethereum protocol itself. They may propose an implementation, but not to Ethereum's codebase; they often require community consensus; unlike Informational EIPs, they are more than recommendations, and users are typically not free to ignore them. Examples include procedures, guidelines, changes to the decision-making process, and changes to the tools or environment used in Ethereum development. Any meta-EIP is also considered a Process EIP.</p>
 
-<h3><a href="{{"informational"|relative_url}}">Informational</a> ({{site.pages|where:"type","Informational"|size}})</h3>
+<h3><b><a href="{{"informational"|relative_url}}">Informational</a> ({{site.pages|where:"type","Informational"|size}})</b></h3>
 <p>Describes a Ethereum design issue, or provides general guidelines or information to the Ethereum community, but does not propose a new feature. Informational EIPs do not necessarily represent Ethereum community consensus or a recommendation, so users and implementers are free to ignore Informational EIPs or follow their advice.</p>


### PR DESCRIPTION
When visiting eips.ethereum.org, it's unclear visually that "Standard", "Meta" and "Informational" are  3 top level categories, even though the font is slightly larger than the sub-categories. Bolding these can make it clearer they belong together.
