### PR TITLE
Update eip-editors list.

### DIFF
--- a/EIPS/eip-1.md
+++ b/EIPS/eip-1.md
@@ -230,6 +230,11 @@ The current EIP editors are
 - Hudson Jameson (@Souptacular)
 - Nick Savers (@nicksavers)
 
+Emeritus EIP editors are 
+
+- Casey Detrio (@cdetrio)
+- Martin Becze (@wanderer)
+
 ## EIP Editor Responsibilities
 
 For each new EIP that comes in, an editor does the following:


### PR DESCRIPTION
Based on the group decision from [EIPIP meeting 40](https://github.com/ethereum-cat-herders/EIPIP/blob/master/All%20EIPIP%20Meetings/Meeting%20040.md), this pull request is to update the EIP editors list.

- Sorted based on activity reported on EIPs GitHub
- Removed Martin Becze & Casey Detrio. (Reason: inactive for over 2 years) 