### PR TITLE
Updates to EIPs 2464 and 2364.

### DIFF
--- a/EIPS/eip-2364.md
+++ b/EIPS/eip-2364.md
@@ -1,9 +1,10 @@
 ---
 eip: 2364
 title: "eth/64: forkid-extended protocol handshake"
-author: Péter Szilágyi <peterke@gmail.com>
+description: Introduces validation of the `forkid` when handshaking with peers.
+author: Péter Szilágyi <peterke@gmail.com>, Péter Szilágyi (@karalabe)
 discussions-to: https://github.com/ethereum/EIPs/issues/2365
-status: Stagnant
+status: Review
 type: Standards Track
 category: Networking
 created: 2019-11-08
@@ -12,21 +13,21 @@ requires: 2124
 
 ## Abstract
 
+This EIP specifies the inclusion of the `forkid`, originally defined in [(EIP-2124)](./eip-2124.md), as a new field in the Ethereum wire protocol (`eth`) handshake. This change is implemented as a new version of the wire protocol, `eth/64`.
+
+## Motivation
+
 The [`forkid` (EIP-2124)](./eip-2124.md) was designed to permit two Ethereum nodes to quickly and cheaply decide if they are compatible or not, not only at a genesis/networking level, but also from the perspective of the currently passed network updates (i.e. forks).
 
 [EIP-2124](./eip-2124.md) only defines how the `forkid` is calculated and validated, but does not specify how the `forkid` should be exchanged between peers. This EIP specifies the inclusion of the `forkid` as a new field in the Ethereum wire protocol (`eth`) handshake (releasing a new version, `eth/64`).
 
 By cross-validating `forkid` during the handshake, incompatible nodes can disconnect before expensive block exchanges and validations take place (PoW check, EVM execution, state reconstruction). This further prevents peer slots from being taken up by nodes that are incompatible, but have not yet been detected as such.
 
-## Motivation
-
 From a micro perspective, cutting off incompatible nodes from one another ensures that a node only spends its resources on tasks that are genuinely useful to it. The sooner we can decide the remote peer is useless, the less time and processing we expend in vain.
 
 From a macro perspective, keeping incompatible nodes partitioned from one another ensures that disjoint clusters retain more resources for maintaining their own chain, thus raising the quality of service for all networks globally.
 
 ## Specification
-
-The specification is tiny since most parts are already specified in EIP-2124. `eth/63` is not specified as an EIP, but is maintained [here](https://github.com/ethereum/devp2p/blob/master/caps/eth.md).
 
 - Implement `forkid` generation and validation per [EIP-2124](./eip-2124.md).
 - Advertise a new `eth` protocol capability (version) at `eth/64`.
@@ -40,7 +41,9 @@ Whenever two peers connect using the `eth/64` protocol, the updated `Status` mes
 
 ## Rationale
 
-##### EIP-2124 mentions advertising the `forkid` in the discovery protocol too. How does that compare to advertising in the `eth` protocol? Why is the redundancy needed?
+The specification is tiny since most parts are already specified in EIP-2124. `eth/63` is not specified as an EIP, but is maintained [here](https://github.com/ethereum/devp2p/blob/master/caps/eth.md).
+
+### EIP-2124 mentions advertising the `forkid` in the discovery protocol too. How does that compare to advertising in the `eth` protocol? Why is the redundancy needed?
 
 Advertising and validating the `forkid` in the discovery protocol is a more optimal solution, as it can help avoid the cost of setting up the TCP connection and cryptographic RLPx stream, only to be torn down if `eth/64` rejects it.
 
@@ -48,7 +51,7 @@ Compared to the `eth` protocol however, discovery is a bit fuzzy. The goal there
 
 Additionally, `forkid` validation via the discovery protocol requires ENR implementation ([EIP-778](./eip-778.md)) and ENR extension support ([EIP-868](./eip-868.md)), which is not mandated by the Ethereum network currently. Lastly, the discovery protocol is just one way to find peers, but systems that cannot use UDP or that rely on other mechanism (e.g. DNS discovery ([EIP-1459](./eip-1459.md))) still need a way to filter connections.
 
-##### The `forkid` implicitly contains the genesis hash checksummed into the `FORK_HASH` field. Why doesn't this proposal remove the `genesisHash` field from the `eth` handshake?
+### The `forkid` implicitly contains the genesis hash checksummed into the `FORK_HASH` field. Why doesn't this proposal remove the `genesisHash` field from the `eth` handshake?
 
 Originally this EIP did remove it as redundant data, since filtering based on the `forkid` is a superset of filtering based on genesis hash. The reason for backing out of that decision was that the genesis hash may be useful for other things too, not just connection filtering (network crawlers use it currently to split nodes across networks).
 
@@ -66,7 +69,11 @@ For calculating and validating fork IDs, see test cases in [EIP-2124](./eip-2124
 
 Testing proper advertising and validation at the networking level will require a [hive](https://github.com/ethereum/hive) test.
 
-## Implementation
+## Security Considerations
+
+None.
+
+## Reference Implementation
 
 Geth: https://github.com/ethereum/go-ethereum/pull/20140
 

--- a/EIPS/eip-2364.md
+++ b/EIPS/eip-2364.md
@@ -2,7 +2,7 @@
 eip: 2364
 title: "eth/64: forkid-extended protocol handshake"
 description: Introduces validation of the `forkid` when handshaking with peers.
-author: Péter Szilágyi <peterke@gmail.com>, Péter Szilágyi (@karalabe)
+author: Péter Szilágyi <peterke@gmail.com>, Péter Szilágyi (@karalabe), Tim Beiko (@timbeiko)
 discussions-to: https://github.com/ethereum/EIPs/issues/2365
 status: Review
 type: Standards Track
@@ -67,15 +67,9 @@ This EIP does not change the consensus engine, thus does _not_ require a hard fo
 
 For calculating and validating fork IDs, see test cases in [EIP-2124](./eip-2124.md).
 
-Testing proper advertising and validation at the networking level will require a [hive](https://github.com/ethereum/hive) test.
-
 ## Security Considerations
 
 None.
-
-## Reference Implementation
-
-Geth: https://github.com/ethereum/go-ethereum/pull/20140
 
 ## Copyright
 

--- a/EIPS/eip-2464.md
+++ b/EIPS/eip-2464.md
@@ -1,9 +1,10 @@
 ---
 eip: 2464
 title: "eth/65: transaction announcements and retrievals"
-author: Péter Szilágyi <peterke@gmail.com>, Gary Rong <garyrong0905@gmail.com>
+description: Introduces `NewPooledTransactionHashes`, `GetPooledTransactions`, and `PooledTransactions`.
+author: Péter Szilágyi <peterke@gmail.com>, Péter Szilágyi (@karalabe), Gary Rong <garyrong0905@gmail.com>
 discussions-to: https://github.com/ethereum/EIPs/issues/2465
-status: Stagnant
+status: Review
 type: Standards Track
 category: Networking
 created: 2020-01-13
@@ -12,6 +13,10 @@ requires: 2364
 
 ## Abstract
 
+This EIP introduces three additional message types into the `eth` protocol (releasing a new version, `eth/65`): `NewPooledTransactionHashes (0x08)` to announce a set of transactions without their content; `GetPooledTransactions (0x09)` to request a batch of transactions by their announced hash; and `PooledTransactions (0x0a)` to reply to a transaction request. This permits reducing the bandwidth used for transaction propagation from linear complexity in the number of peers to square root; and also reducing the initial transaction exchange from 10s-100s MB to `len(pool) * 32B ~= 128KB`.
+
+## Motivation
+
 The `eth` network protocol has two ways to propagate a newly mined block: it can be broadcast to a peer in its entirety (via `NewBlock (0x07)` [in `eth/64` and prior](https://github.com/ethereum/devp2p/blob/master/caps/eth.md)) or it can be announced only (via `NewBlockHashes (0x01)`). This duality allows nodes to do the high-bandwidth broadcasting (10s-100s KB) for a square root number of peers; and the low-bandwidth announcing (10s-100s B) for the remaining linear number of peers. The square root broadcast is enough to reach all well connected nodes, but the linear announce is needed to get across degenerate topologies. This works well.
 
 The `eth` protocol, however, does not have a similar dual mechanism for propagating transactions, so nodes need to rely on broadcasting (via `Transactions (0x02)`). To cater for degenerate topologies, transactions cannot be broadcast square rooted, rather they need to be transferred linearly to all peers. With N peers, each node will transfer the same transaction N times (counting both directions), whereas 1 would be enough in a perfect world. This is a significant waste.
@@ -19,8 +24,6 @@ The `eth` protocol, however, does not have a similar dual mechanism for propagat
 A similar issue arises when a new network connection is made between two nodes, as they need to sync up their transaction pools, but the pool is just a soup of dangling transactions. Without a way to deduplicate transactions remotely, each node is forced to naively transfer their entire list of transactions to the other side. With pools containing thousands of transactions, a naive transfer amounts to 10s-100s MB, most of which is useless. There is no better way, however.
 
 This EIP introduces three additional message types into the `eth` protocol (releasing a new version, `eth/65`): `NewPooledTransactionHashes (0x08)` to announce a set of transactions without their content; `GetPooledTransactions (0x09)` to request a batch of transactions by their announced hash; and `PooledTransactions (0x0a)` to reply to a transaction request. This permits reducing the bandwidth used for transaction propagation from linear complexity in the number of peers to square root; and also reducing the initial transaction exchange from 10s-100s MB to `len(pool) * 32B ~= 128KB`.
-
-## Motivation
 
 With transaction throughput (and size) picking up in Ethereum, transaction propagation is the current dominant component of the used network resources. Most of these resources are however wasted, as the `eth` protocol does not have a mechanism to deduplicate transactions remotely, so the same data is transferred over and over again across all network connections.
 
@@ -69,11 +72,11 @@ This EIP extends the `eth` protocol in a backwards incompatible way and requires
 
 This EIP does not change the consensus engine, thus does _not_ require a hard fork.
 
-## Test Cases
+## Security Considerations
 
-TODO
+None. 
 
-## Implementation
+## Reference Implementation
 
 Geth: https://github.com/ethereum/go-ethereum/pull/20234
 

--- a/EIPS/eip-2464.md
+++ b/EIPS/eip-2464.md
@@ -2,7 +2,7 @@
 eip: 2464
 title: "eth/65: transaction announcements and retrievals"
 description: Introduces `NewPooledTransactionHashes`, `GetPooledTransactions`, and `PooledTransactions`.
-author: Péter Szilágyi <peterke@gmail.com>, Péter Szilágyi (@karalabe), Gary Rong <garyrong0905@gmail.com>
+author: Péter Szilágyi <peterke@gmail.com>, Péter Szilágyi (@karalabe), Gary Rong <garyrong0905@gmail.com>, Tim Beiko (@timbeiko)
 discussions-to: https://github.com/ethereum/EIPs/issues/2465
 status: Review
 type: Standards Track
@@ -17,7 +17,7 @@ This EIP introduces three additional message types into the `eth` protocol (rele
 
 ## Motivation
 
-The `eth` network protocol has two ways to propagate a newly mined block: it can be broadcast to a peer in its entirety (via `NewBlock (0x07)` [in `eth/64` and prior](https://github.com/ethereum/devp2p/blob/master/caps/eth.md)) or it can be announced only (via `NewBlockHashes (0x01)`). This duality allows nodes to do the high-bandwidth broadcasting (10s-100s KB) for a square root number of peers; and the low-bandwidth announcing (10s-100s B) for the remaining linear number of peers. The square root broadcast is enough to reach all well connected nodes, but the linear announce is needed to get across degenerate topologies. This works well.
+The `eth` network protocol has two ways to propagate a newly mined block: it can be broadcast to a peer in its entirety (via `NewBlock (0x07)` in `eth/64` and prior or it can be announced only (via `NewBlockHashes (0x01)`). This duality allows nodes to do the high-bandwidth broadcasting (10s-100s KB) for a square root number of peers; and the low-bandwidth announcing (10s-100s B) for the remaining linear number of peers. The square root broadcast is enough to reach all well connected nodes, but the linear announce is needed to get across degenerate topologies. This works well.
 
 The `eth` protocol, however, does not have a similar dual mechanism for propagating transactions, so nodes need to rely on broadcasting (via `Transactions (0x02)`). To cater for degenerate topologies, transactions cannot be broadcast square rooted, rather they need to be transferred linearly to all peers. With N peers, each node will transfer the same transaction N times (counting both directions), whereas 1 would be enough in a perfect world. This is a significant waste.
 
@@ -74,11 +74,7 @@ This EIP does not change the consensus engine, thus does _not_ require a hard fo
 
 ## Security Considerations
 
-None. 
-
-## Reference Implementation
-
-Geth: https://github.com/ethereum/go-ethereum/pull/20234
+None.
 
 ## Copyright
 

--- a/EIPS/eip-4345.md
+++ b/EIPS/eip-4345.md
@@ -5,6 +5,7 @@ description: Delays the difficulty bomb to be noticeable in June 2022.
 author: Tim Beiko (@timbeiko), James Hancock (@MadeOfTin)
 discussions-to: https://ethereum-magicians.org/t/eip-4345-difficulty-bomb-delay-to-may-2022/7209
 status: Review
+review-period-end: 2021-10-29
 type: Standards Track
 category: Core
 created: 2021-10-05

--- a/EIPS/eip-4345.md
+++ b/EIPS/eip-4345.md
@@ -5,7 +5,6 @@ description: Delays the difficulty bomb to be noticeable in June 2022.
 author: Tim Beiko (@timbeiko), James Hancock (@MadeOfTin)
 discussions-to: https://ethereum-magicians.org/t/eip-4345-difficulty-bomb-delay-to-may-2022/7209
 status: Review
-review-period-end: 2021-10-29
 type: Standards Track
 category: Core
 created: 2021-10-05

--- a/EIPS/eip-4345.md
+++ b/EIPS/eip-4345.md
@@ -2,7 +2,7 @@
 eip: 4345
 title: Difficulty Bomb Delay to June 2022
 description: Delays the difficulty bomb to be noticeable in June 2022.
-author: Tim Beiko (@timbeiko), James Hancock (@MadeOfTin)
+author: Tim Beiko (@timbeiko), James Hancock (@MadeOfTin), Thomas Jay Rush (@tjayrush)
 discussions-to: https://ethereum-magicians.org/t/eip-4345-difficulty-bomb-delay-to-may-2022/7209
 status: Review
 type: Standards Track

--- a/EIPS/eip-4345.md
+++ b/EIPS/eip-4345.md
@@ -1,7 +1,7 @@
 ---
 eip: 4345
-title: Difficulty Bomb Delay to May 2022
-description: Delays the difficulty bomb to be noticeable in May 2022.
+title: Difficulty Bomb Delay to June 2022
+description: Delays the difficulty bomb to be noticeable in June 2022.
 author: Tim Beiko (@timbeiko), James Hancock (@MadeOfTin)
 discussions-to: https://ethereum-magicians.org/t/eip-4345-difficulty-bomb-delay-to-may-2022/7209
 status: Review

--- a/EIPS/eip-4345.md
+++ b/EIPS/eip-4345.md
@@ -4,38 +4,38 @@ title: Difficulty Bomb Delay to May 2022
 description: Delays the difficulty bomb to be noticeable in May 2022.
 author: Tim Beiko (@timbeiko), James Hancock (@MadeOfTin)
 discussions-to: https://ethereum-magicians.org/t/eip-4345-difficulty-bomb-delay-to-may-2022/7209
-status: Draft
+status: Review
 type: Standards Track
 category: Core
 created: 2021-10-05
 ---
 
 ## Abstract
-Starting with `FORK_BLOCK_NUMBER` the client will calculate the difficulty based on a fake block number suggesting to the client that the difficulty bomb is adjusting 10,500,000 blocks later than the actual block number.
+Starting with `FORK_BLOCK_NUMBER` the client will calculate the difficulty based on a fake block number suggesting to the client that the difficulty bomb is adjusting 10,700,000 blocks later than the actual block number.
 
 ## Motivation
-Targeting for the Shanghai upgrade and/or the Merge to occur before May 2022. Either the bomb can be readjusted at that time, or removed altogether.
+Targeting for The Merge to occur before June 2022. If it is not ready by then, the bomb can be delayed further.
 
 ## Specification
 #### Relax Difficulty with Fake Block Number
 For the purposes of `calc_difficulty`, simply replace the use of `block.number`, as used in the exponential ice age component, with the formula:
 ```py
-    fake_block_number = max(0, block.number - 10_500_000) if block.number >= FORK_BLOCK_NUMBER else block.number
+    fake_block_number = max(0, block.number - 10_700_000) if block.number >= FORK_BLOCK_NUMBER else block.number
 ```
 ## Rationale
 
-The following script predicts a 0.25 second delay to block time by May 2022 and a 1 second delay by June. This gives reason to address because the effect will be seen, but not so much urgency we don't have space to work around if needed.
+The following script predicts a ~0.1 second delay to block time by June 2022 and a ~0.5 second delay by July 2022. This gives reason to address because the effect will be seen, but not so much urgency we don't have space to work around if needed.
 
 ```python
 def predict_diff_bomb_effect(current_blknum, current_difficulty, block_adjustment, months):
     '''
     Predicts the effect on block time (as a ratio) in a specified amount of months in the future.
     Vars used for predictions:
-    current_blknum = 13346561
-    current_difficulty = 9191929451665642
-    block adjustment = 10500000
-    months = 7 # May 2022
-    months = 8 # June 2022
+    current_blknum = 13423376 # Oct 15, 2021
+    current_difficulty = 9545154427582720
+    block adjustment = 10700000
+    months = 7.5 # June 2022
+    months = 8.5 # July 2022
     '''
     blocks_per_month = (86400 * 30) // 13.3
     future_blknum = current_blknum + blocks_per_month * months
@@ -44,7 +44,8 @@ def predict_diff_bomb_effect(current_blknum, current_difficulty, block_adjustmen
     return diff_adjust_coeff
 
 
-diff_adjust_coeff = predict_diff_bomb_effect(13346561,9191929451665642,10500000,6.5)
+diff_adjust_coeff = predict_diff_bomb_effect(13423376,9545154427582720,10700000,7.5)
+diff_adjust_coeff = predict_diff_bomb_effect(13423376,9545154427582720,10700000,8.5)
 ```
 
 ## Backwards Compatibility
@@ -52,6 +53,8 @@ No known backward compatibility issues.
 
 ## Security Considerations
 Misjudging the effects of the difficulty can mean longer blocktimes than anticipated until a hardfork is released. Wild shifts in difficulty can affect this number severely. Also, gradual changes in blocktimes due to longer-term adjustments in difficulty can affect the timing of difficulty bomb epochs. This affects the usability of the network but unlikely to have security ramifications.
+
+In this specific instance, it is possible that the network hashrate drops considerably before The Merge, which could accelerate the timeline by which the bomb is felt in block times. The offset value chosen aimed to take this into account.
 
 ## Copyright
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
Combines the updates from https://github.com/ethereum/EIPs/pull/4367 and https://github.com/ethereum/EIPs/pull/4366, and addresses most comments from @MicahZoltu in a way which hopefully makes him happy, but recognizes the fact that these EIPs are already "ancient". Addressed all comments which were related to formatting/sections, but links are still present, and the specification has been left as is. 

Hopefully we can get a soft +1 on these before requiring Péter to review & approve. 
