### PR TITLE
Alter 3675 terminal block logic to account for overrides

### DIFF
--- a/EIPS/eip-3675.md
+++ b/EIPS/eip-3675.md
@@ -37,10 +37,9 @@ To understand the motivation of introducing the Proof-of-Stake consensus see the
 * **PoS block**: Block that is built and verified by the new proof-of-stake mechanism.
 * **Terminal PoW block**: A PoW block that satisfies the following conditions --
 `pow_block.total_difficulty >= TERMINAL_TOTAL_DIFFICULTY` *and* `pow_block.parent_block.total_difficulty < TERMINAL_TOTAL_DIFFICULTY`.
-There can be more than one terminal PoW block in the network, e.g. multiple children of the same pre-terminal block.
 * **`TERMINAL_TOTAL_DIFFICULTY`** The amount of total difficulty reached by the network that triggers the consensus upgrade.
-* **`TRANSITION_BLOCK`** The earliest PoS block of the canonical chain, i.e. the PoS block with the lowest block height.
-`TRANSITION_BLOCK` **MUST** be a child of a terminal PoW block.
+* **`TRANSITION_POW_BLOCK`** The latest PoW block of a branch in the chain, i.e. a PoW block that is a parent to a PoS block in the chain in question. There can be more than one valid `TRANSITION_POW_BLOCK` in the network, e.g. multiple children of the same pre-transition block. In normal conditions, `TRANSITION_POW_BLOCK` is a terminal PoW block, but in certain exceptional scenarios, `TRANSITION_POW_BLOCK` can come before the terminal PoW condition is met.
+* **`TRANSITION_POS_BLOCK`** The earliest PoS block of a branch in the chain, i.e. a PoS block with a PoW parent.
 * **`POS_FORKCHOICE_UPDATED`** An event occurring when the state of the proof-of-stake fork choice is updated.
 
 #### PoS events
@@ -49,7 +48,7 @@ Events having the `POS_` prefix in the name (PoS events) are emitted by the new 
 
 The details provided below must be taken into account when reading those parts of the specification that refer to the PoS events:
 * Reference to a block that is contained by PoS events is provided in a form of a block hash unless another is explicitly specified.
-* A `POS_FORKCHOICE_UPDATED` event contains references to the head of the canonical chain and to the most recent finalized block. Before the first finalized block occurs in the system the finalized block hash provided by this event is stubbed with `0x0000000000000000000000000000000000000000000000000000000000000000`. 
+* A `POS_FORKCHOICE_UPDATED` event contains references to the head of the canonical chain and to the most recent finalized block. Before the first finalized block occurs in the system the finalized block hash provided by this event is stubbed with `0x0000000000000000000000000000000000000000000000000000000000000000`.
 * **`FIRST_FINALIZED_BLOCK`** The first finalized block that is designated by `POS_FORKCHOICE_UPDATED` event and has the hash that differs from the stub.
 
 
@@ -60,8 +59,7 @@ The `TERMINAL_TOTAL_DIFFICULTY` parameter is a part of client software configura
 
 ### PoW block processing
 
-PoW blocks that are descendants of any terminal PoW block **MUST NOT** be imported. This implies that a terminal PoW block will be the last PoW block in the canonical chain.
-
+PoW blocks that are descendants of any terminal PoW block **MUST NOT** be imported.
 
 ### Constants
 
@@ -71,7 +69,7 @@ PoW blocks that are descendants of any terminal PoW block **MUST NOT** be import
 
 ### Block structure
 
-Beginning with `TRANSITION_BLOCK`, a number of previously dynamic block fields are deprecated by enforcing these values to instead be constants. Each block field listed in the table below **MUST** be replaced with the corresponding constant value.
+Beginning with `TRANSITION_POS_BLOCK`, a number of previously dynamic block fields are deprecated by enforcing these values to instead be constants. Each block field listed in the table below **MUST** be replaced with the corresponding constant value.
 
 | Field | Constant value | Comment |
 |-|-|-|
@@ -81,14 +79,14 @@ Beginning with `TRANSITION_BLOCK`, a number of previously dynamic block fields a
 | **`nonce`** | `0x0000000000000000` |  |
 | **`ommers`** | `[]` | `RLP([]) = 0xc0`  |
 
-Beginning with `TRANSITION_BLOCK`, the validation of the block's **`extraData`** field changes: The length of the block's **`extraData`** **MUST** be less than or equal to **`MAX_EXTRA_DATA_BYTES`** bytes.
+Beginning with `TRANSITION_POS_BLOCK`, the validation of the block's **`extraData`** field changes: The length of the block's **`extraData`** **MUST** be less than or equal to **`MAX_EXTRA_DATA_BYTES`** bytes.
 
 *Note*: Logic and validity conditions of block fields that are *not* specified here **MUST** remain unchanged. Additionally, the overall block format **MUST** remain unchanged.
 
 
 ### Block validity
 
-Beginning with `TRANSITION_BLOCK`, the block validity conditions **MUST** be altered by the following:
+Beginning with `TRANSITION_POS_BLOCK`, the block validity conditions **MUST** be altered by the following:
 * Remove verification of the block's **`difficulty`** value with respect to the difficulty formula.
 * Remove verification of the block's **`nonce`** and **`mixHash`** values with respect to the Ethash function.
 * Remove all validation rules that are evaluated over the list of ommers and each member of this list.
@@ -101,7 +99,7 @@ Beginning with `TRANSITION_BLOCK`, the block validity conditions **MUST** be alt
 
 ### Block and ommer rewards
 
-Beginning with `TRANSITION_BLOCK`, block and ommer rewards are deprecated. Specifically, the following actions **MUST** be taken:
+Beginning with `TRANSITION_POS_BLOCK`, block and ommer rewards are deprecated. Specifically, the following actions **MUST** be taken:
 * Remove increasing the balance of the block's **`beneficiary`** account by the block reward.
 * Remove increasing the balance of the block's **`beneficiary`** account by the ommer inclusion reward per each ommer.
 * Remove increasing the balance of the ommer's **`beneficiary`** account by the ommer block reward per each ommer.
@@ -121,6 +119,8 @@ The new PoS LMD-GHOST fork choice rule is specified as follows. On each occurren
 * Beginning with the `FIRST_FINALIZED_BLOCK`, set the most recent finalized block to the corresponding block nominated by the event.
 
 Changes to the block tree store that are related to the above actions **MUST** be applied atomically.
+
+*Note*: The `POS_FORKCHOICE_UPDATED` event **MUST** be respected even in the event that `TRANSITION_POW_BLOCK` of the forkchoice is not a terminal PoW block from view of `TERMINAL_TOTAL_DIFFICULTY`.
 
 *Note*: This rule **MUST** be strictly enforced. "Optimistic" updates to the head **MUST NOT** be made. That is -- if a new block is processed on top of the current head block, this new block becomes the new head if and only if an accompanying `POS_FORKCHOICE_UPDATED` event occurs.
 
@@ -243,11 +243,11 @@ An attacker may use a minority of hash power to build a malicious chain fork tha
 
 To protect the network from this attack scenario, difficulty accumulated by the chain (total difficulty) is used to trigger the upgrade.
 
-#### Ability to jump between terminal PoW blocks
+#### Ability to jump between transition PoW blocks
 
-There could be the case when a terminal PoW block is not observed by the majority of network participants due to (temporal) network partitioning. In such a case, this minority would switch their fork choice to the new rule provided by the PoS rooted on the minority terminal PoW block that they observed.
+There could be the case when a `TRANSITION_POW_BLOCK` is not observed by the majority of network participants due to (temporal) network partitioning. In such a case, this minority would switch their fork choice to the new rule provided by the PoS rooted on the minority `TRANSITION_POW_BLOCK` that they observed.
 
-The transition process allows the network to re-org between forks with different terminal PoW blocks as long as (a) these blocks satisfy the terminal PoW block conditions and (b) the `FIRST_FINALIZED_BLOCK` has not yet been received. This provides resilience against adverse network conditions during the transition process and prevents irreparable forks/partitions.
+The transition process allows the network to re-org between forks with different valid `TRANSITION_POW_BLOCK`s as long as (a) these blocks satisfy the transition conditions and (b) the `FIRST_FINALIZED_BLOCK` has not yet been received. This provides resilience against adverse network conditions during the transition process and prevents irreparable forks/partitions.
 
 #### Halt the importing of PoW blocks
 


### PR DESCRIPTION
Alter the terminal PoW block logic and `TRANSITION_POW_BLOCK` logic to be less strict on EL to allow for a simpler override mechanism in the event of attacks and other emergency overrides.

The details of the override mechanism and why this supports it can be found here -- https://github.com/ethereum/consensus-specs/issues/2643#issuecomment-953250363