### PR TITLE
Add note about `FORK_NEXT` value re: EIP-2124

### DIFF
--- a/EIPS/eip-3675.md
+++ b/EIPS/eip-3675.md
@@ -128,7 +128,7 @@ Changes to the block tree store that are related to the above actions **MUST** b
 
 #### EIP-2124 fork identifier
 
-For the purposes of the [EIP-2124 fork identifier](https://eips.ethereum.org/EIPS/eip-2124), nodes implementing this EIP should set the value of `FORK_NEXT` to `0`.
+For the purposes of the [EIP-2124 fork identifier](https://eips.ethereum.org/EIPS/eip-2124), nodes implementing this EIP **SHOULD** keep values of `FORK_NEXT` and `FORK_HASH` unaffected, i.e. `FORK_NEXT` is set to `0` and `FORK_HASH` retains the same value.
 
 #### devp2p
 

--- a/EIPS/eip-3675.md
+++ b/EIPS/eip-3675.md
@@ -126,6 +126,12 @@ Changes to the block tree store that are related to the above actions **MUST** b
 
 ### Network
 
+#### EIP-2124 fork identifier
+
+For the purposes of the [EIP-2124 fork identifier](https://eips.ethereum.org/EIPS/eip-2124), nodes implementing this EIP should set the value of `FORK_NEXT` to `0`.
+
+#### devp2p
+
 The networking stack **SHOULD NOT** send the following messages if they advertise the descendant of any terminal PoW block:
 * [`NewBlockHashes (0x01)`](https://github.com/ethereum/devp2p/blob/master/caps/eth.md#newblockhashes-0x01)
 * [`NewBlock (0x07)`](https://github.com/ethereum/devp2p/blob/master/caps/eth.md#newblock-0x07)
@@ -190,6 +196,13 @@ In prior draft versions of this EIP, an additional POS event -- `POS_CONSENSUS_V
 This event was removed for two reasons:
 1. This event was an unnecessary optimization to allow for pruning of "bad" blocks from the block tree. This optimization was unnecessary because the PoS consensus would never send `POS_FORKCHOICE_UPDATED` for any such bad blocks or their descendants, and eventually any such blocks would be able to be pruned after a PoS finality event of an alternative branch in the block tree.
 2. This event was dangerous in some scenarios because a block could be referenced by two *different* and conflicting PoS branches. Thus for the same block in some scenarios, both a `POS_CONSENSUS_VALIDATED == TRUE` and `POS_CONSENSUS_VALIDATED == FALSE` event could sent, entirely negating the ability to safely perform the optimization in (1).
+
+### EIP-2124 fork identifier
+
+The value of `FORK_NEXT` refers to the block number of the next fork a given node knows about and `0` otherwise.
+As the block number of the terminal PoW block will not be known until the transition, nodes have no value to use for `FORK_NEXT` and in light of this fact will use the default `0`.
+Nodes can retroactively update their node identifier with the correct data once the fork block is known.
+Using a value of `0` does imply extra networking overhead that EIP-2124 intends to eliminate, but given the mechanics of the transition process this decision seems the most pragmatic.
 
 ### Removing block gossip
 


### PR DESCRIPTION
Concerning EIP-3675:

During the Amphora interop, it became clear we needed to agree on a value for `FORK_NEXT` as it pertains to EIP-2124.

This PR suggests a value of `0` and adds a short rationale for the decision.