### PR TITLE
Update specificiation on handling EIP-2124 during the consensus upgrade

### DIFF
--- a/EIPS/eip-3675.md
+++ b/EIPS/eip-3675.md
@@ -132,7 +132,7 @@ For the purposes of the [EIP-2124 fork identifier](./eip-2124.md), nodes impleme
 
 Once the transition has happened, `TRANSITION_POS_BLOCK` will have some block number `N`.
 This block number cannot be known ahead of time given the dynamic nature of the transition trigger condition.
-Once this block number is known, nodes can update `FORK_HASH` by appending `uint64(N)` to the sequence of hashes used to calculate `FORK_HASH` as per EIP 2124.
+Starting with `TRANSITION_POS_BLOCK`, nodes **MUST** update `FORK_HASH` by appending `uint64(N)` to the sequence of hashes used to calculate `FORK_HASH` as per EIP 2124.
 `FORK_NEXT` can remain `0` after the transition.
 
 #### devp2p
@@ -206,7 +206,6 @@ This event was removed for two reasons:
 
 The value of `FORK_NEXT` refers to the block number of the next fork a given node knows about and `0` otherwise.
 As the block number of the terminal PoW block will not be known until the transition, nodes have no value to use for `FORK_NEXT` and in light of this fact will use the default `0`.
-Nodes can retroactively update their node identifier with the correct data once the fork block is known.
 Using a value of `0` does imply extra networking overhead that EIP-2124 intends to eliminate, but given the mechanics of the transition process this decision seems the most pragmatic.
 
 ### Removing block gossip

--- a/EIPS/eip-3675.md
+++ b/EIPS/eip-3675.md
@@ -128,7 +128,7 @@ Changes to the block tree store that are related to the above actions **MUST** b
 
 #### EIP-2124 fork identifier
 
-For the purposes of the [EIP-2124 fork identifier](./eip-2124.md), nodes implementing this EIP **SHOULD** keep values of `FORK_NEXT` and `FORK_HASH` unaffected, i.e. `FORK_NEXT` is set to `0` and `FORK_HASH` retains the same value.
+For the purposes of the [EIP-2124 fork identifier](./eip-2124.md), nodes implementing this EIP **MUST** keep values of `FORK_NEXT` and `FORK_HASH` unaffected, i.e. `FORK_NEXT` is set to `0` and `FORK_HASH` retains the same value.
 
 Once the transition has happened, `TRANSITION_POS_BLOCK` will have some block number `N`.
 This block number cannot be known ahead of time given the dynamic nature of the transition trigger condition.

--- a/EIPS/eip-3675.md
+++ b/EIPS/eip-3675.md
@@ -132,7 +132,7 @@ For the purposes of the [EIP-2124 fork identifier](./eip-2124.md), nodes impleme
 
 Once the transition has happened, `TRANSITION_POS_BLOCK` will have some block number `N`.
 This block number cannot be known ahead of time given the dynamic nature of the transition trigger condition.
-Starting with `TRANSITION_POS_BLOCK`, nodes **MUST** update `FORK_HASH` by appending `uint64(N)` to the sequence of hashes used to calculate `FORK_HASH` as per EIP 2124.
+Starting with `TRANSITION_POS_BLOCK`, nodes **MUST** update `FORK_HASH` by appending `uint64(N)` to the sequence of hashes used to calculate `FORK_HASH` as per EIP-2124.
 `FORK_NEXT` can remain `0` after the transition.
 
 #### devp2p

--- a/EIPS/eip-3675.md
+++ b/EIPS/eip-3675.md
@@ -128,7 +128,12 @@ Changes to the block tree store that are related to the above actions **MUST** b
 
 #### EIP-2124 fork identifier
 
-For the purposes of the [EIP-2124 fork identifier](https://eips.ethereum.org/EIPS/eip-2124), nodes implementing this EIP **SHOULD** keep values of `FORK_NEXT` and `FORK_HASH` unaffected, i.e. `FORK_NEXT` is set to `0` and `FORK_HASH` retains the same value.
+For the purposes of the [EIP-2124 fork identifier](./eip-2124.md), nodes implementing this EIP **SHOULD** keep values of `FORK_NEXT` and `FORK_HASH` unaffected, i.e. `FORK_NEXT` is set to `0` and `FORK_HASH` retains the same value.
+
+Once the transition has happened, `TRANSITION_POS_BLOCK` will have some block number `N`.
+This block number cannot be known ahead of time given the dynamic nature of the transition trigger condition.
+Once this block number is known, nodes can update `FORK_HASH` by appending `uint64(N)` to the sequence of hashes used to calculate `FORK_HASH` as per EIP 2124.
+`FORK_NEXT` can remain `0` after the transition.
 
 #### devp2p
 


### PR DESCRIPTION
Addressing PR feedback in #4411:

- Update link to EIP
- Specify what happens to the EIP-2124 values *after* the transition.
