### PR TITLE
EIP725 - remove 'SupportedStandards:ERC725Account

### DIFF
--- a/EIPS/eip-725.md
+++ b/EIPS/eip-725.md
@@ -10,8 +10,8 @@ requires: 165, 173
 created: 2017-10-02
 ---
 
-
 ## Simple Summary
+
 A standard interface for a smart contract based account with attachable key value store.
 
 ## Abstract
@@ -39,10 +39,9 @@ Smart contact based accounts following this standard have the following advantag
 - are extensible though additional standardisation of the key/value data.
 - can function as an owner/controller or proxy of other smart contracts
 
-
 ## Specification
 
-### ERC725X 
+### ERC725X
 
 ERC165 identifier: `0x44c028fe`
 
@@ -56,6 +55,7 @@ Executes a call on any other smart contracts, transfers the blockchains native t
 MUST only be called by the current owner of the contract.
 
 _Parameters:_
+
 - `operationType`: the operation to execute.
 - `to`: the smart contract or address to interact with. `to` will be unused if a contract is created (operation 1 and 2).
 - `value`: the value of ETH to transfer.
@@ -64,6 +64,7 @@ _Parameters:_
 _Returns:_ `bytes` , the returned data of the called function, or the address of the contract created (operation 1 and 2).
 
 The `operationType` can execute the following operations:
+
 - `0` for `call`
 - `1` for `create`
 - `2` for `create2`
@@ -72,7 +73,7 @@ The `operationType` can execute the following operations:
 
 Others may be added in the future.
 
-**Triggers Event:**  [ContractCreated](#contractcreated), [Executed](#executed) 
+**Triggers Event:** [ContractCreated](#contractcreated), [Executed](#executed)
 
 ### Events
 
@@ -80,15 +81,16 @@ Others may be added in the future.
 
 ```solidity
 event Executed(uint256 indexed _operation, address indexed _to, uint256 indexed _value, bytes _data);
-``` 
-MUST be triggered when `execute` creates a new call using the `operationType` `0`, `3`, `4`.
+```
 
+MUST be triggered when `execute` creates a new call using the `operationType` `0`, `3`, `4`.
 
 #### ContractCreated
 
 ```solidity
 event ContractCreated(uint256 indexed _operation, address indexed _contractAddress, uint256 indexed _value);
 ```
+
 MUST be triggered when `execute` creates a new contract using the `operationType` `1`, `2`.
 
 ### ERC725Y
@@ -100,20 +102,25 @@ ERC165 identifier: `0x5a988c0f`
 ```solidity
 function getData(bytes32[] memory _keys) public view returns(bytes[] memory)
 ```
+
 Gets array of data at multiple given key.
 
 _Parameters:_
+
 - `_keys`: the keys which values to retrieve.
 
 _Returns:_ `bytes[]` , array of the values for the requested keys.
+
 #### setData
 
 ```solidity
-function setData(bytes32[] memory _keys, bytes[] memory _values) public 
+function setData(bytes32[] memory _keys, bytes[] memory _values) public
 ```
+
 Sets array of data at multiple keys. MUST only be called by the current owner of the contract.
 
 _Parameters:_
+
 - `_keys`: the keys which values to retrieve.
 - `_values`: the array of bytes to set.
 
@@ -126,6 +133,7 @@ _Parameters:_
 ```solidity
 event DataChanged(bytes32 indexed key, bytes value)
 ```
+
 MUST be triggered when `setData` was successfully called.
 
 ### Ownership
@@ -137,6 +145,7 @@ This standard requires [ERC173](https://github.com/ethereum/EIPs/blob/master/EIP
 - `transferOwnership(address newOwner)` <br>
 
 The event:
+
 - `OwnershipTransferred(address indexed previousOwner, address indexed newOwner)`
 
 ### Data keys
@@ -145,20 +154,20 @@ Data keys, should be the keccak256 hash of a type name.
 e.g. `keccak256('ERCXXXMyNewKeyType')` is `0x6935a24ea384927f250ee0b954ed498cd9203fc5d2bf95c735e52e6ca675e047`
 
 The [ERC725JSONSchema standard](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-2-ERC725YJSONSchema.md) defines how keys should be named and generated.
-This JSON schema can be used to auto decode ERC725Y values from smart contracts for application and smart contract interactions. 
+This JSON schema can be used to auto decode ERC725Y values from smart contracts for application and smart contract interactions.
 
 #### Default key values
 
 ERC725 key standards need to be defined within new standards, we suggest the following defaults:
 
-| Name | Description | Key | value |
-| --- | --- | --- | --- |
-| SupportedStandards:XYZ | Allows to determine standards supported by this contract | `0xeafec4d89fa9619884b6b89135626455000000000000000000000000xxxxxxxx`, where `xxxxxxxx` is the 4 bytes identifier of the standard supported | Value can be defined by the standard, by default it should be the 4 bytes identifier  e.g. `0x7a30e6fc` |
-| SupportedStandards:ERC725Account | Allows to determine standards supported by this contract | `0xeafec4d89fa9619884b6b89135626455000000000000000000000000afdeb5d6`, where `afdeb5d6` is the 4 bytes part of the hash of `keccak256('ERC725Account')` | Value is the 4 bytes identifier `0xafdeb5d6` |
+| Name                   | Description                                              | Key                                                                                                                                        | value                                                                                                  |
+| ---------------------- | -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------ |
+| SupportedStandards:XYZ | Allows to determine standards supported by this contract | `0xeafec4d89fa9619884b6b89135626455000000000000000000000000xxxxxxxx`, where `xxxxxxxx` is the 4 bytes identifier of the standard supported | Value can be defined by the standard, by default it should be the 4 bytes identifier e.g. `0x7a30e6fc` |
 
 #### ERC725Account
 
 The specification of an ERC725Account can be found in [LSP0-ERC725Account](https://github.com/lukso-network/LIPs/blob/master/LSPs/LSP-0-ERC725Account.md).
+
 ## Rationale
 
 The purpose of an smart contract account is to allow an entity to exist as a first-class citizen with the ability to execute arbitrary contract calls.
@@ -167,8 +176,8 @@ The purpose of an smart contract account is to allow an entity to exist as a fir
 
 - [Latest implementation](https://github.com/ERC725Alliance/ERC725/tree/master/implementations/contracts)
 
-
 ### Solidity Interfaces
+
 ```solidity
 // SPDX-License-Identifier: CC0-1.0
 pragma solidity >=0.5.0 <0.7.0;
@@ -209,4 +218,5 @@ interface IERC725 /* is IERC725X, IERC725Y */ {
 - [Sovrin Foundation Self Sovereign Identity](https://sovrin.org/wp-content/uploads/2017/06/The-Inevitable-Rise-of-Self-Sovereign-Identity.pdf)
 
 ## Copyright
+
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
## What does this PR introduce?

- Remove `SupportedStandards:ERC725Account` dataKeys section, as per [PR#64 in ERC725Alliance/ERC725 repository.](https://github.com/ERC725Alliance/ERC725/pull/64/commits/6daac48fd9b0820a34b27de804c31fdd1f922c6e)
- Prettify Markdown with prettier