### PR TITLE
Make the stale bot ignore discussion urls

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,6 +18,7 @@ jobs:
         days-before-stale: 60
         days-before-close: 7
         stale-pr-label: 'stale'
+        exempt-issue-labels: 'discussion-url'
   stale-issue:
     runs-on: ubuntu-latest
     name: "Mark stale issues"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,12 +13,11 @@ jobs:
     - uses: actions/stale@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-pr-message: 'There has been no activity on this pull request for two months. It will be closed in a week if no further activity occurs. If you would like to move this EIP forward, please respond to any outstanding feedback or add a comment indicating that you have addressed all required feedback and are ready for a review.'
-        close-pr-message: 'This pull request was closed due to inactivity. If you are still pursuing it, feel free to reopen it and respond to any feedback or request a review in a comment.'
         days-before-stale: 60
         days-before-close: 7
         stale-pr-label: 'stale'
-        exempt-issue-labels: 'discussion-url'
+        stale-pr-message: 'There has been no activity on this pull request for two months. It will be closed in a week if no further activity occurs. If you would like to move this EIP forward, please respond to any outstanding feedback or add a comment indicating that you have addressed all required feedback and are ready for a review.'
+        close-pr-message: 'This pull request was closed due to inactivity. If you are still pursuing it, feel free to reopen it and respond to any feedback or request a review in a comment.'
   stale-issue:
     runs-on: ubuntu-latest
     name: "Mark stale issues"
@@ -28,8 +27,7 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         days-before-stale: 180
         days-before-close: 14
-        stale-pr-label: 'stale'
+        exempt-issue-labels: 'discussion-url'
         stale-issue-label: 'stale'
         stale-issue-message: 'There has been no activity on this issue for two months. It will be closed in a week if no further activity occurs. If you would like to move this EIP forward, please respond to any outstanding feedback or add a comment indicating that you have addressed all required feedback and are ready for a review.'
         close-issue-message: 'This issue was closed due to inactivity. If you are still pursuing it, feel free to reopen it and respond to any feedback or request a review in a comment.'
-     

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -27,7 +27,7 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         days-before-stale: 180
         days-before-close: 14
-        exempt-issue-labels: 'discussion-url'
+        exempt-issue-labels: 'discussions-to'
         stale-issue-label: 'stale'
         stale-issue-message: 'There has been no activity on this issue for two months. It will be closed in a week if no further activity occurs. If you would like to move this EIP forward, please respond to any outstanding feedback or add a comment indicating that you have addressed all required feedback and are ready for a review.'
         close-issue-message: 'This issue was closed due to inactivity. If you are still pursuing it, feel free to reopen it and respond to any feedback or request a review in a comment.'


### PR DESCRIPTION
See https://github.com/actions/stale#exempt-issue-labels

After this change, if an issue is labeled `discussion-url`, it will be exempt from closure.  We should reopen the actual discussion URLs which have been closed recently and label them too.