### PR TITLE
2681: Clarify that 2^64-1 is invalid as a transaction nonce

### DIFF
--- a/EIPS/eip-2681.md
+++ b/EIPS/eip-2681.md
@@ -37,7 +37,7 @@ This mode of replay protection is out of fashion since [EIP-155](./eip-155.md) i
 
 3. Most clients already consider the nonce field to be 64-bit, such as go-ethereum.
 
-4. The reason a transaction with nonce `2^64-1` is invalid, because after inclusion the account's nonce would exceed `2^64-1`.
+4. The reason a transaction with nonce `2^64-1` is invalid, because otherwise after inclusion the sender account's nonce would exceed `2^64-1`.
 
 ## Backwards Compatibility
 

--- a/EIPS/eip-2681.md
+++ b/EIPS/eip-2681.md
@@ -25,7 +25,7 @@ Lastly, this facilitates a minor optimisation in clients, because the nonce no l
 
 Introduce two new restrictions retroactively from genesis:
 
-1. Consider any transaction invalid, where the nonce exceeds `2^64-1`.
+1. Consider any transaction invalid, where the nonce exceeds or equals to `2^64-1`.
 2. The `CREATE` and `CREATE2` instructions to abort with an exceptional halt, where the account nonce is `2^64-1`.
 
 ## Rationale
@@ -36,6 +36,8 @@ Introduce two new restrictions retroactively from genesis:
 This mode of replay protection is out of fashion since [EIP-155](./eip-155.md) introduced a more elegant way using chain identifiers.
 
 3. Most clients already consider the nonce field to be 64-bit, such as go-ethereum.
+
+4. The reason a transaction with nonce `2^64-1` is invalid, because after inclusion the account's nonce would exceed `2^64-1`.
 
 ## Backwards Compatibility
 

--- a/EIPS/eip-2681.md
+++ b/EIPS/eip-2681.md
@@ -45,7 +45,7 @@ While this is a breaking change, no actual effect should be visible:
 
 1. There is no account in the state currently which would have a nonce exceeding that value. As of November 2020, the account `0xea674fdde714fd979de3edf0f56aa9716b898ec8` is responsible for the highest account nonce at approximately 29 million.
 
-2. go-ethereum already has this restriction in place (`state.Account.Nonce` and `types.txdata.AccountNonce` it as a 64-bit number).
+2. go-ethereum already has this restriction partially in place (`state.Account.Nonce` and `types.txdata.AccountNonce` it as a 64-bit number).
 
 ## Security Considerations
 


### PR DESCRIPTION
Based on https://github.com/ethereum/go-ethereum/pull/23853.