### PR TITLE
EIP-3675: Ancient blocks are no longer a requisite for a network security

### DIFF
--- a/EIPS/eip-3675.md
+++ b/EIPS/eip-3675.md
@@ -17,7 +17,7 @@ Specification of the consensus mechanism upgrade on Ethereum Mainnet that introd
 
 ## Abstract
 
-This EIP deprecates Proof-of-Work (PoW) and supersedes it with the new Proof-of-Stake consensus mechanism (PoS) driven by the beacon chain. Information on the bootstrapping of the new consensus mechanism is documented in [EIP-2982](./eip-2982.md). Full specification of the beacon chain can be found in the [eth2.0-specs](https://github.com/ethereum/eth2.0-specs/) repository.
+This EIP deprecates Proof-of-Work (PoW) and supersedes it with the new Proof-of-Stake consensus mechanism (PoS) driven by the beacon chain. Information on the bootstrapping of the new consensus mechanism is documented in [EIP-2982](./eip-2982.md). Full specification of the beacon chain can be found in the [consensus-specs](https://github.com/ethereum/consensus-specs/) repository.
 
 This document specifies the set of changes to the block structure, block processing, fork choice rule and network interface introduced by the consensus upgrade.
 
@@ -271,6 +271,14 @@ Suppose the part of the client software that is connected to the beacon chain ne
 * An application, a user or a service uses the data from the wrong fork (PoW chain that is kept being built) which can cause security issues on their side.
 
 Not importing PoW blocks that are beyond the terminal PoW block prevents these adverse effects on safety/re-orgs in the event of software or configuration failures *in favor* of a liveness failure.
+
+### Ancient blocks are no longer a requisite for a network security
+
+Keeping historical blocks starting from genesis is essential in the PoW network. A header of every block that belongs to a particular chain is required to justify the validity of this chain with respect to the PoW seal.
+
+Validating the entire history of the chain is not required by the new PoS mechanism. Instead, the sync process in the PoS network relies on weak subjectivity checkpoints, which are historical snapshots shared by peers on the network. This means historical blocks beyond weak subjectivity checkpoint are no longer a requisite for determining the canonical blockchain.
+
+Specification of weak subjectivity checkpoints can be found in the [consensus-specs](https://github.com/ethereum/consensus-specs/) repository.
 
 
 ## Copyright


### PR DESCRIPTION
Add a section to the security consideration about meaning of ancient blocks to the core of the PoS protocol