### PR TITLE
EIP-4399: note that smart contracts may distinguish PoS blocks

### DIFF
--- a/EIPS/eip-4399.md
+++ b/EIPS/eip-4399.md
@@ -25,6 +25,8 @@ At the point of `TRANSITION_POS_BLOCK` of the Proof-of-Stake (PoS) upgrade descr
 
 Given prior analysis on the usage of `DIFFICULTY`, the value returned by the opcode mixed with other values is a common pattern used by smart contracts to obtain randomness. The instruction with the same number as the `DIFFICULTY` opcode returning the output of the beacon chain randomness makes the upgrade to PoS backwards compatible for existing smart contracts obtaining randomness from the `DIFFICULTY` opcode.
 
+Additionally, changes proposed by this EIP allow for smart contracts to determine whether the upgrade to the PoS has already happened. This can be done by analyzing the return value of the `DIFFICULTY` opcode. A value greater than `2**64` indicates that the transaction is being executed in the PoS block.
+
 
 ## Specification
 
@@ -84,6 +86,10 @@ The renaming should be done to make the field and the opcode names semantically 
 By utilizing `TRANSITION_POS_BLOCK` to trigger the change in logic defined in this EIP rather than a block or slot number, this EIP is tightly coupled to the PoS upgrade defined by [EIP-3675](./eip-3675.md).
 
 By tightly coupling to the PoS upgrade, we ensure that there is no discontinuity for the usecase of this opcode for randomness -- the primary [motivation](#motivation) for re-using `DIFFICULTY` rather than creating a new opcode.
+
+### Using `2**64` threshold to determine PoS blocks
+
+The probability of randomness output to fall into the range between `0` and `2**64` and, thus, to be mixed with PoW difficulty values, is drastically low. Though, proposed threshold might seem to have insufficient distance from difficulty values on Ethereum Mainnet (they are currently around `2**54`), it requires a thousand times increase of the hashrate to make this threshold insecure. Such an increase is considered impossible to occur before the upcoming consensus upgrade.
 
 
 ## Backwards Compatibility


### PR DESCRIPTION
Add a note that the changes introduce by 4399 allows for smart contracts to distinguish PoS blocks from PoW blocks