### PR TITLE
Add note about PoW constant validation.

### DIFF
--- a/EIPS/eip-3675.md
+++ b/EIPS/eip-3675.md
@@ -77,12 +77,15 @@ Beginning with `TRANSITION_BLOCK`, a number of previously dynamic block fields a
 |-|-|-|
 | **`ommersHash`** | `0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347` | `= Keccak256(RLP([]))` |
 | **`difficulty`** | `0` |  |
+| **`mixHash`** | `0x0000000000000000000000000000000000000000000000000000000000000000` |  |
 | **`nonce`** | `0x0000000000000000` |  |
 | **`ommers`** | `[]` | `RLP([]) = 0xc0`  |
 
 Beginning with `TRANSITION_BLOCK`, the validation of the block's **`extraData`** field changes: The length of the block's **`extraData`** **MUST** be less than or equal to **`MAX_EXTRA_DATA_BYTES`** bytes.
 
 *Note*: Logic and validity conditions of block fields that are *not* specified here **MUST** remain unchanged. Additionally, the overall block format **MUST** remain unchanged.
+
+*Note*: Subsequent EIPs may override the constant values specified above to provide additional functionality. For an example, see [EIP-4399](./eip-4399.md).
 
 
 ### Block validity
@@ -96,9 +99,6 @@ Beginning with `TRANSITION_BLOCK`, the block validity conditions **MUST** be alt
 *Note*: If one of the new rules fails then the block **MUST** be invalidated.
 
 *Note*: Validity rules that are not specified in the list above **MUST** remain unchanged.
-
-*Note*: the value of `mixHash` is purposefully non-validated here to provide flexibility for future EIPs.
-
 
 ### Block and ommer rewards
 

--- a/EIPS/eip-3675.md
+++ b/EIPS/eip-3675.md
@@ -77,7 +77,6 @@ Beginning with `TRANSITION_BLOCK`, a number of previously dynamic block fields a
 |-|-|-|
 | **`ommersHash`** | `0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347` | `= Keccak256(RLP([]))` |
 | **`difficulty`** | `0` |  |
-| **`mixHash`** | `0x0000000000000000000000000000000000000000000000000000000000000000` |  |
 | **`nonce`** | `0x0000000000000000` |  |
 | **`ommers`** | `[]` | `RLP([]) = 0xc0`  |
 
@@ -97,6 +96,8 @@ Beginning with `TRANSITION_BLOCK`, the block validity conditions **MUST** be alt
 *Note*: If one of the new rules fails then the block **MUST** be invalidated.
 
 *Note*: Validity rules that are not specified in the list above **MUST** remain unchanged.
+
+*Note*: the value of `mixHash` is purposefully non-validated here to provide flexibility for future EIPs.
 
 
 ### Block and ommer rewards


### PR DESCRIPTION
Make it clear that the various 0 values in the EIP can be overridden by subsequent EIPs. 