### PR TITLE
EIP-3675: fix FORK_NEXT parameter

### DIFF
--- a/EIPS/eip-3675.md
+++ b/EIPS/eip-3675.md
@@ -41,6 +41,7 @@ There can be more than one terminal PoW block in the network, e.g. multiple chil
 * **`TERMINAL_TOTAL_DIFFICULTY`** The amount of total difficulty reached by the network that triggers the consensus upgrade.
 * **`TRANSITION_BLOCK`** The earliest PoS block of the canonical chain, i.e. the PoS block with the lowest block height.
 * **`POS_FORKCHOICE_UPDATED`** An event occurring when the state of the proof-of-stake fork choice is updated.
+* **`FORK_NEXT_VALUE`** A block number set to the `FORK_NEXT` parameter for the upcoming consensus upgrade.
 
 #### PoS events
 
@@ -133,10 +134,7 @@ Changes to the block tree store that are related to the above actions **MUST** b
 
 #### EIP-2124 fork identifier
 
-For the purposes of the [EIP-2124 fork identifier](./eip-2124.md), nodes implementing this EIP **MUST** keep values of `FORK_NEXT` and `FORK_HASH` unaffected before `TRANSITION_POS_BLOCK`, i.e. `FORK_NEXT` is set to `0` and `FORK_HASH` retains the same value.
-
-Starting with `TRANSITION_POS_BLOCK` that has block number `N`, nodes **MUST** update `FORK_HASH` by appending `uint64(N)` to the sequence of hashes used to calculate `FORK_HASH` as per EIP-2124.
-`FORK_NEXT` can remain `0` after the transition.
+For the purposes of the [EIP-2124 fork identifier](./eip-2124.md), nodes implementing this EIP **MUST** set the `FORK_NEXT` parameter to the `FORK_NEXT_VALUE`.
 
 #### devp2p
 
@@ -208,8 +206,10 @@ This event was removed for two reasons:
 ### EIP-2124 fork identifier
 
 The value of `FORK_NEXT` in EIP-2124 refers to the block number of the next fork a given node knows about and `0` otherwise.
-The block number of `TRANSITION_POS_BLOCK` cannot be known ahead of time given the dynamic nature of the transition trigger condition. As the block will not be known a priori, nodes have no value to use for `FORK_NEXT` and in light of this fact will use the default `0`.
-Using a value of `0` does imply extra networking overhead that EIP-2124 intends to eliminate, but given the mechanics of the transition process this decision seems the most pragmatic.
+
+The number of `TRANSITION_BLOCK` cannot be known ahead of time given the dynamic nature of the transition trigger condition. As the block will not be known a priori, nodes can't use its number for `FORK_NEXT` and in light of this fact an explicitly set `FORK_NEXT_VALUE` is used instead.
+
+The number set to `FORK_NEXT_VALUE` parameter should reference a block which is presumably happening a week earlier than `TRANSITION_BLOCK`. Picking the number this way gives enough time for users who forgot to upgrade their software to do so when they see their nodes are losing peers.
 
 ### Removing block gossip
 


### PR DESCRIPTION
Implements the proposal made [here](https://ethereum-magicians.org/t/eip-3675-upgrade-consensus-to-proof-of-stake/6706/8)