### PR TITLE
EIP-3675: introduce TERMINAL_BLOCK_HASH parameter

### DIFF
--- a/EIPS/eip-3675.md
+++ b/EIPS/eip-3675.md
@@ -178,9 +178,9 @@ This EIP was designed to minimize the complexity of hot-swapping the live consen
 
 See [Security considerations](#terminal-total-difficulty-vs-block-number).
 
-### Overriding terminal block hash
+### Parameterizing terminal block hash
 
-See [Security considerations](#terminal-pow-block-override)
+See [Security considerations](#terminal-pow-block-overriding).
 
 ### Halting the import of PoW blocks
 

--- a/EIPS/eip-3675.md
+++ b/EIPS/eip-3675.md
@@ -42,6 +42,8 @@ There can be more than one terminal PoW block in the network, e.g. multiple chil
 * **`TRANSITION_BLOCK`** The earliest PoS block of the canonical chain, i.e. the PoS block with the lowest block height.
 * **`POS_FORKCHOICE_UPDATED`** An event occurring when the state of the proof-of-stake fork choice is updated.
 * **`FORK_NEXT_VALUE`** A block number set to the `FORK_NEXT` parameter for the upcoming consensus upgrade.
+* **`TERMINAL_BLOCK_HASH`** Designates the hash of the terminal PoW block if set, i.e. if not stubbed with `0x0000000000000000000000000000000000000000000000000000000000000000`.
+* **`TERMINAL_BLOCK_NUMBER`** Designates the number of the terminal PoW block if `TERMINAL_BLOCK_HASH` is set.
 
 #### PoS events
 
@@ -53,9 +55,15 @@ The details provided below must be taken into account when reading those parts o
 * **`FIRST_FINALIZED_BLOCK`** The first finalized block that is designated by `POS_FORKCHOICE_UPDATED` event and has the hash that differs from the stub.
 
 
-### Terminal total difficulty
+### Client software configuration
 
-The `TERMINAL_TOTAL_DIFFICULTY` parameter is a part of client software configuration and **MUST** be included into its binary distribution.
+The following set of parameters is a part of client software configuration and **MUST** be included into its binary distribution:
+* `TERMINAL_TOTAL_DIFFICULTY`
+* `FORK_NEXT_VALUE`
+* `TERMINAL_BLOCK_HASH`
+* `TERMINAL_BLOCK_NUMBER`
+
+*Note*: Should `TERMINAL_BLOCK_HASH` be stubbed with `0x0000000000000000000000000000000000000000000000000000000000000000`, `TERMINAL_BLOCK_HASH` and `TERMINAL_BLOCK_NUMBER` parameters **MUST NOT** take an effect.
 
 
 ### PoW block processing
@@ -117,6 +125,11 @@ Beginning with `TRANSITION_BLOCK`, block and ommer rewards are deprecated. Speci
 
 ### Fork choice rule
 
+If set, `TERMINAL_BLOCK_HASH` parameter affects the PoW heaviest chain rule in the following way:
+* Canonical blockchain **MUST** contain a block with the hash defined by `TERMINAL_BLOCK_HASH` parameter at the height defined by `TERMINAL_BLOCK_NUMBER` parameter.
+
+*Note*: This rule is akin to block hash whitelisting functionality already presented in client software implementations.
+
 As of the first `POS_FORKCHOICE_UPDATED` event, the fork choice rule **MUST** be altered in the following way:
 * Remove the existing PoW heaviest chain rule.
 * Adhere to the new PoS LMD-GHOST rule.
@@ -164,6 +177,10 @@ This EIP was designed to minimize the complexity of hot-swapping the live consen
 ### Total difficulty triggering the upgrade
 
 See [Security considerations](#terminal-total-difficulty-vs-block-number).
+
+### Overriding terminal block hash
+
+See [Security considerations](#terminal-pow-block-override)
 
 ### Halting the import of PoW blocks
 
@@ -276,6 +293,24 @@ Suppose the part of the client software that is connected to the beacon chain ne
 * An application, a user or a service uses the data from the wrong fork (PoW chain that is kept being built) which can cause security issues on their side.
 
 Not importing PoW blocks that are beyond the terminal PoW block prevents these adverse effects on safety/re-orgs in the event of software or configuration failures *in favor* of a liveness failure.
+
+#### Terminal PoW block overriding
+
+There is a mechanism allowing for accelerating the consensus upgrade in emergency cases.
+This EIP considers the following emergency case scenarios for the acceleration to come into effect:
+* A drop of the network hashing rate which delays the upgrade significantly
+* Attacks on the PoW network before the upgrade
+
+The first case scenario induces updating of the following parameters:
+* `TERMINAL_TOTAL_DIFFICULTY` -- reset to a value that is closer in time than the original one.
+* `FORK_NEXT_VALUE` -- adjust accordingly.
+
+The second case scenario is more invasive in terms of overridden parameters:
+* `TERMINAL_BLOCK_HASH` -- set to the hash of a certain block to become the terminal PoW block.
+* `TERMINAL_BLOCK_NUMBER` -- set to the number of a block designated by `TERMINAL_BLOCK_HASH`.
+* `TERMINAL_TOTAL_DIFFICULTY` -- set to the total difficulty value of a block designated by `TERMINAL_BLOCK_HASH`.
+* `FORK_NEXT_VALUE` -- adjust accordingly.
+
 
 ### Ancient blocks are no longer a requisite for a network security
 

--- a/EIPS/eip-3675.md
+++ b/EIPS/eip-3675.md
@@ -63,7 +63,7 @@ The following set of parameters is a part of client software configuration and *
 * `TERMINAL_BLOCK_HASH`
 * `TERMINAL_BLOCK_NUMBER`
 
-*Note*: Should `TERMINAL_BLOCK_HASH` be stubbed with `0x0000000000000000000000000000000000000000000000000000000000000000`, `TERMINAL_BLOCK_HASH` and `TERMINAL_BLOCK_NUMBER` parameters **MUST NOT** take an effect.
+*Note*: If `TERMINAL_BLOCK_HASH` is stubbed with `0x0000000000000000000000000000000000000000000000000000000000000000` then `TERMINAL_BLOCK_HASH` and `TERMINAL_BLOCK_NUMBER` parameters **MUST NOT** take an effect.
 
 
 ### PoW block processing
@@ -128,7 +128,7 @@ Beginning with `TRANSITION_BLOCK`, block and ommer rewards are deprecated. Speci
 If set, `TERMINAL_BLOCK_HASH` parameter affects the PoW heaviest chain rule in the following way:
 * Canonical blockchain **MUST** contain a block with the hash defined by `TERMINAL_BLOCK_HASH` parameter at the height defined by `TERMINAL_BLOCK_NUMBER` parameter.
 
-*Note*: This rule is akin to block hash whitelisting functionality already presented in client software implementations.
+*Note*: This rule is akin to block hash whitelisting functionality already present in client software implementations.
 
 As of the first `POS_FORKCHOICE_UPDATED` event, the fork choice rule **MUST** be altered in the following way:
 * Remove the existing PoW heaviest chain rule.
@@ -298,19 +298,20 @@ Not importing PoW blocks that are beyond the terminal PoW block prevents these a
 
 There is a mechanism allowing for accelerating the consensus upgrade in emergency cases.
 This EIP considers the following emergency case scenarios for the acceleration to come into effect:
-* A drop of the network hashing rate which delays the upgrade significantly
-* Attacks on the PoW network before the upgrade
+* A drop of the network hashing rate which delays the upgrade significantly.
+* Attacks on the PoW network before the upgrade.
 
-The first case scenario induces updating of the following parameters:
+The first case can be safely accelerated by updating the following parameters:
 * `TERMINAL_TOTAL_DIFFICULTY` -- reset to a value that is closer in time than the original one.
 * `FORK_NEXT_VALUE` -- adjust accordingly.
 
-The second case scenario is more invasive in terms of overridden parameters:
+The second, more dire attack scenario requires a more invasive override:
 * `TERMINAL_BLOCK_HASH` -- set to the hash of a certain block to become the terminal PoW block.
 * `TERMINAL_BLOCK_NUMBER` -- set to the number of a block designated by `TERMINAL_BLOCK_HASH`.
 * `TERMINAL_TOTAL_DIFFICULTY` -- set to the total difficulty value of a block designated by `TERMINAL_BLOCK_HASH`.
 * `FORK_NEXT_VALUE` -- adjust accordingly.
 
+*Note*: Acceleration in the second case is considered for the most extreme of scenarios because it will result in a non-trivial liveness failure on Ethereum Mainnet.
 
 ### Ancient blocks are no longer a requisite for a network security
 


### PR DESCRIPTION
Adds `TERMINAL_BLOCK_HASH` parameter and describes scenarios when it may be used.
Additionally, covers scenario when `TERMINAL_TOTAL_DIFFICULTY` is considered to be overridden.