### PR TITLE
Fixed typo on eip-721.md

### DIFF
--- a/EIPS/eip-721.md
+++ b/EIPS/eip-721.md
@@ -290,7 +290,7 @@ The transfer and accept functions' documentation only specify conditions when th
 - **Blocklist certain address from receiving NFTs** — prior art, CryptoKitties deployed contract, lines 565, 566
 - **Disallow unsafe transfers** — `transferFrom` throws unless `_to` equals `msg.sender` or `countOf(_to)` is non-zero or was non-zero previously (because such cases are safe)
 - **Charge a fee to both parties of a transaction** — require payment when calling `approve` with a non-zero `_approved` if it was previously the zero address, refund payment if calling `approve` with the zero address if it was previously a non-zero address, require payment when calling any transfer function, require transfer parameter `_to` to equal `msg.sender`, require transfer parameter `_to` to be the approved address for the NFT
-- **Read only NFT registry** — always throw from `unsafeTransfer`, `transferFrom`, `approve` and `setApprovalForAll`
+- **Read only NFT registry** — always throw from `safeTransferFrom`, `transferFrom`, `approve` and `setApprovalForAll`
 
 Failed transactions will throw, a best practice identified in ERC-223, ERC-677, ERC-827 and OpenZeppelin's implementation of SafeERC20.sol. ERC-20 defined an `allowance` feature, this caused a problem when called and then later modified to a different amount, as on OpenZeppelin issue \#438. In ERC-721, there is no allowance because every NFT is unique, the quantity is none or one. Therefore we receive the benefits of ERC-20's original design without problems that have been later discovered.
 


### PR DESCRIPTION
Fixing typo for function name.
Actually I'm not sure if it is intended or just a typo, but there is no function with this name even though it is wrapped with backquotes.