### PR TITLE
fix: edit eip-1153.md to treat transient storage the same as persistent storage with regards to reverts

### DIFF
--- a/EIPS/eip-1153.md
+++ b/EIPS/eip-1153.md
@@ -2,35 +2,47 @@
 eip: 1153
 title: Transient storage opcodes
 author: Alexey Akhunov (@AlexeyAkhunov)
+description: Add opcodes for manipulating state that behaves identically to storage but is discarded after every transaction
 discussions-to: https://ethereum-magicians.org/t/eip-transient-storage-opcodes/553
-status: Stagnant
+status: Draft
 type: Standards Track
 category: Core
 created: 2018-06-15
 ---
 
-## Simple Summary
-Support for efficient transient storage in EVM. It is like regular storage (`SLOAD`/`SSTORE`), but with the lifetime limited to one Ethereum transaction.
-Notable use case is efficient reentrancy lock.
-
 ## Abstract
-This proposal introduces transient storage, which behaves similar to storage,
-but the updates will only persist within one Ethereum transaction. Transient storage is accessible to smart contracts via new opcodes: `TLOAD` and `TSTORE` (“T” stands for Transient).
+This proposal introduces transient storage opcodes, which manipulate state that behaves identically to storage, 
+but is discarded after every transaction. Transient storage is cheaper since it never requires disk access.
+Transient storage is accessible to smart contracts via 2 new opcodes: `TLOAD` and `TSTORE`, where “T” stands for "transient."
 
 ## Motivation
 Running a transaction in Ethereum can generate multiple nested frames of execution, each created by `CALL` (or similar) instructions.
 Contracts can be re-entered during the same transaction, in which case there are more than one frame belonging to one contract.
 Currently, these frames can communicate in two ways - via inputs/outputs passed via `CALL` instructions, and via storage updates.
-If there is an intermediate frame belonging to another contract, communication via inputs/outputs is not secure. Notable example is a reentrancy lock which cannot rely on the intermediate frame to pass through the state of the lock.
+If there is an intermediate frame belonging to another untrusted contract, communication via inputs/outputs is not secure. 
+Notable example is a reentrancy lock which cannot rely on the intermediate frame to pass through the state of the lock.
 Communication via storage (`SSTORE`/`SLOAD`) is costly. Transient storage is a dedicated and gas efficient solution to the problem of inter frame communication.
 
-Language support could be added in relatively easy way. For example, in Solidity, a qualifier “transient” can be introduced (similar to the existing qualifiers “memory” and “storage”). Since addressing scheme of `TSTORE` and `TLOAD` is the same as for `SSTORE` and `SLOAD`, code generation routines that exist for storage variables, can be easily generalised to also support transient storage.
+Storage refunds accumulated due to inter frame communication are also limited to 20% of gas spent by a transaction as of [EIP-3529](./eip-3529.md) included in the London hard fork. 
+This greatly reduces the refunds for transiently-set storage slots in otherwise low-cost transactions. For example, in order to receive the full refund of one re-entrancy lock, 
+the transaction must spend ~80k gas on other operations.
 
-Potential use cases unlocked by this EIP include:
+Language support could be added in relatively easy way. For example, in Solidity, a qualifier “transient” can be introduced 
+(similar to the existing qualifiers “memory” and “storage”, and Java's own `transient` keyword with a similar meaning). 
+Since the addressing scheme of `TSTORE` and `TLOAD` is the same as for `SSTORE` and `SLOAD`,
+code generation routines that exist for storage variables, can be easily generalised to also support transient storage.
+
+Potential use cases enabled or improved by this EIP include:
 1. Reentrancy lock
-2. Passing error codes and messages from the execution frames up the execution stack
-3. More generic libraries that use callbacks, for example generalised sorting with functions `Less` and `Swap` defined.
-4. Shared memory (borrowed from early draft of similar EIP by @holiman). When implementing contract-proxies using `DELEGATECALL`, all direct arguments are relayed from the caller to the callee via the `CALLDATA`, leaving no room for meta-data between the proxy and the proxee. Also, the proxy must be careful about `storage` access to avoid collision with `target` `storage`-slots. Since `transient storage` would be shared, it would be possible to use `transient storage` to pass information between the `proxy` and the `target`.  
+2. Constructor arguments loaded from the factory contract (for on-chain-computable CREATE2 addresses as in Uniswap V3)
+3. Single transaction ERC20 approvals, e.g. `#approveAndCall(address callee, uint256 amount, bytes memory data)`
+4. Passing error codes and messages from the execution frames up the execution stack
+5. More generic libraries that use callbacks, for example generalised sorting with functions `Less` and `Swap` defined.
+6. Contracts that require control before and after method execution (e.g. via callbacks)
+7. Shared memory (borrowed from early draft of similar EIP by @holiman). When implementing contract-proxies using `DELEGATECALL`, all direct arguments are relayed from the caller to the callee via the `CALLDATA`, leaving no room for meta-data between the proxy and the proxee. Also, the proxy must be careful about `storage` access to avoid collision with `target` `storage`-slots. Since `transient storage` would be shared, it would be possible to use `transient storage` to pass information between the `proxy` and the `target`.
+
+These opcodes are more efficient to execute than the `SSTORE` and `SLOAD` opcodes because the original value never needs to be loaded from storage (i.e. is always 0). 
+The gas accounting rules are also simpler, and do not involve refunds.
 
 ## Specification
 Two new opcodes are added to EVM, `TLOAD` and `TSTORE`.
@@ -43,22 +55,36 @@ They use the same arguments on stack as `SLOAD` (`0x54`) and `SSTORE` (`0x55`).
 
 Addressing is the same as `SLOAD` and `SSTORE`. i.e. each 32-byte address points to a unique 32-byte word.
 
-Gas cost for both is 8 units of gas, regardless of values stored.
+Gas cost for `TSTORE` is the same as a hot dirty `SSTORE` (original value is not new value and is not current value, currently 100 gas), 
+and gas cost of `TLOAD` is the same as a hot `SLOAD` (value has been read before, currently 100 gas). Gas cost cannot be on par with memory access due to transient storage's interactions with reverts.
 
-The effects of transient storage are discarded at the end of the transaction.
+All values in transient storage are discarded at the end of the transaction.
 
-Transient storage is private to the contract that owns it, in the same way as "regular" storage is. Only owning contract frames may access their transient storage. And when they do, all the frames access the same transient store, in the same way as "regular" storage, but unlike "memory".
+Transient storage is private to the contract that owns it, in the same way as persistent storage. 
+Only owning contract frames may access their transient storage. 
+And when they do, all the frames access the same transient store, in the same way as persistent storage, but unlike memory.
 
-When transient storage is used in the context of `DELEGATECALL` or `CALLCODE`, then the owning contract of the transient storage is the contract that issued `DELEGATECALL` or `CALLCODE` instruction (the caller). When transient storage is used in the context of `CALL` or `STATICCALL`, then the owning contract of the transient storage is the contract that is the target of the `CALL` or `STATICCALL` instruction (the callee).
+When transient storage is used in the context of `DELEGATECALL` or `CALLCODE`, then the owning contract of the transient
+storage is the contract that issued `DELEGATECALL` or `CALLCODE` instruction (the caller) as with persistent storage. 
+When transient storage is used in the context of `CALL` or `STATICCALL`, then the owning contract of the transient storage
+is the contract that is the target of the `CALL` or `STATICCALL` instruction (the callee).
 
-Transient storage does not interact with reverts or invalid transactions, that means if a frame reverts, its effects on the transient storage remain until the end of the transaction.
+If a frame reverts, all writes to transient storage within that frame are also reverted, as with persistent storage.
 
 ## Rationale
-There is a proposal to alleviate the cost of inter-frame communication by reducing the cost of `SSTORE` when it modifies the same item multiple times within the same transaction (EIP-1087).
+There is a proposal to alleviate the cost of inter-frame communication by reducing the cost of `SSTORE` 
+when it modifies the same item multiple times within the same transaction ([EIP-1087](./eip-1087.md)).
 
-Relative cons of the transient storage: new opcodes; new code in the clients; new concept for the yellow paper (more to update); requires separation of concerns (persistence and inter-frame communication) when programming.
+Relative cons of the transient storage: new opcodes: 
+- New code in the clients
+- New concept for the yellow paper (more to update)
+- Does not address existing usages of temporary storage
 
-Relative pros of the transient storage:  cheaper to use; does not change the semantics of the existing operations; very simple gas accounting rules;
+Relative pros of the transient storage
+- Enshrines temporary storage in a way that cannot be inadvertently made impractical/broken by future EIPs (e.g. [EIP-3529](./eip-3529.md))
+- Cheaper to use
+- Does not change the semantics of the existing operations
+- Very simple gas accounting rules
 
 ## Backwards Compatibility
 This EIP requires a hard fork to implement.
@@ -68,8 +94,22 @@ Since this EIP does not change semantics of any existing opcodes, it does not po
 ## Test Cases
 TBD
 
-## Implementation
-Most straightforward implementation would be a dictionary (map), similar to what exists for the ‘dirty’ storage, with the difference that it gets re-initialised at the start of each transaction, and does not get persisted.
+## Reference Implementation
+Because the transient storage must behave identically to storage within the context of a single transaction with regards
+to revert behavior, it is necessary to be able to revert to a previous state of transient storage within a transaction. 
+
+A stack of maps is one possible implementation:
+- When a call frame is entered, a new empty map is pushed onto the stack in constant time
+- All transient storage writes are written to the map at the top of the stack in constant time
+- When a call reverts, the map at the top of the stack is popped and discarded in constant time
+- When a call frame exits successfully, the map at the top of the stack is popped and merged with the map now at the top of the stack in linear time with the number of keys written in that call frame
+
+## Security Considerations
+There are no security considerations for existing contracts not containing the new `TSTORE` or `TLOAD` opcodes.
+
+New contracts that use the `TSTORE` and `TLOAD` opcodes operate under all the same assumptions as with storage. This EIP
+introduces no additional mental overhead for the developer. In some cases, transient storage simplifies contracts in that contract
+transient storage does not need to be cleared at the end of every transaction, e.g. in the temporary approvals use case.
 
 ## Copyright
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/EIPS/eip-1153.md
+++ b/EIPS/eip-1153.md
@@ -1,7 +1,7 @@
 ---
 eip: 1153
 title: Transient storage opcodes
-author: Alexey Akhunov (@AlexeyAkhunov)
+author: Alexey Akhunov (@AlexeyAkhunov), Moody Salem (@moodysalem)
 description: Add opcodes for manipulating state that behaves identically to storage but is discarded after every transaction
 discussions-to: https://ethereum-magicians.org/t/eip-transient-storage-opcodes/553
 status: Draft


### PR DESCRIPTION
IMO passing revert information from inner call frames is not as useful as being able to rely on the data written to transient storage as if it were regular storage

It can also be supported by not reverting and instead returning an error code

Tried to flesh out some of the time complexity stuff and it seems like it justifies a gas cost more similar to hot `SLOAD`/`SSTORE`