### PR TITLE
Attempt to fix rendering of header preamble.

### DIFF
--- a/EIPS/eip-1.md
+++ b/EIPS/eip-1.md
@@ -115,29 +115,29 @@ EIPs should be written in [markdown](https://github.com/adam-p/markdown-here/wik
 
 Each EIP must begin with an [RFC 822](https://www.ietf.org/rfc/rfc822.txt) style header preamble, preceded and followed by three hyphens (`---`). This header is also termed ["front matter" by Jekyll](https://jekyllrb.com/docs/front-matter/). The headers must appear in the following order.
 
-` eip:` *EIP number* (this is determined by the EIP editor)
+`eip`: *EIP number* (this is determined by the EIP editor)
 
-` title:` *The EIP title is a few words, not a complete sentence*
+`title`: *The EIP title is a few words, not a complete sentence*
 
-` description:` *Description is one full (short) sentence*
+`description`: *Description is one full (short) sentence*
 
-` author:` *The list of the author's or authors' name(s) and/or username(s), or name(s) and email(s). Details are below.*
+`author`: *The list of the author's or authors' name(s) and/or username(s), or name(s) and email(s). Details are below.*
 
-` discussions-to:` *The url pointing to the official discussion thread*
+`discussions-to`: *The url pointing to the official discussion thread*
 
-` status:` *Draft, Review, Last Call, Final, Stagnant, Withdrawn, Living*
+`status`: *Draft, Review, Last Call, Final, Stagnant, Withdrawn, Living*
 
-` last-call-deadline:` *The date last call period ends on* (Optional field, only needed when status is `Last Call`)
+`last-call-deadline`: *The date last call period ends on* (Optional field, only needed when status is `Last Call`)
 
-` type:` *One of `Standards Track`, `Meta`, or `Informational`*
+`type`: *One of `Standards Track`, `Meta`, or `Informational`*
 
-` category:` *One of `Core`, `Networking`, `Interface`, or `ERC`* (Optional field, only needed for `Standards Track` EIPs)
+`category`: *One of `Core`, `Networking`, `Interface`, or `ERC`* (Optional field, only needed for `Standards Track` EIPs)
 
-` created:` *Date the EIP was created on*
+`created`: *Date the EIP was created on*
 
-` requires:` *EIP number(s)* (Optional field)
+`requires`: *EIP number(s)* (Optional field)
 
-` withdrawal-reason:` *A sentence explaining why the EIP was withdrawn.* (Optional field, only needed when status is `Withdrawn`)
+`withdrawal-reason`: *A sentence explaining why the EIP was withdrawn.* (Optional field, only needed when status is `Withdrawn`)
 
 Headers that permit lists must separate elements with commas.
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/886059/146215665-4e32916a-60c2-4a6b-9ea8-ad39cb66afdd.png)
https://eips.ethereum.org/EIPS/eip-1#eip-header-preamble

I have no idea why it is rendering that way, this is a feeble attempt to fix it.