### PR TITLE
EIP 712 assets: fix example.js (cosmetic)

### DIFF
--- a/assets/eip-712/Example.js
+++ b/assets/eip-712/Example.js
@@ -76,7 +76,7 @@ function encodeType(primaryType) {
 }
 
 function typeHash(primaryType) {
-    return ethUtil.keccak256(encodeType(primaryType));
+    return ethUtil.keccakFromString(encodeType(primaryType), 256);
 }
 
 function encodeData(primaryType, data) {
@@ -92,7 +92,7 @@ function encodeData(primaryType, data) {
         let value = data[field.name];
         if (field.type == 'string' || field.type == 'bytes') {
             encTypes.push('bytes32');
-            value = ethUtil.keccak256(value);
+            value = ethUtil.keccakFromString(value, 256);
             encValues.push(value);
         } else if (types[field.type] !== undefined) {
             encTypes.push('bytes32');
@@ -123,7 +123,7 @@ function signHash() {
     );
 }
 
-const privateKey = ethUtil.keccak256('cow');
+const privateKey = ethUtil.keccakFromString('cow', 256);
 const address = ethUtil.privateToAddress(privateKey);
 const sig = ethUtil.ecsign(signHash(), privateKey);
 

--- a/assets/eip-712/Example.js
+++ b/assets/eip-712/Example.js
@@ -1,5 +1,10 @@
+// using ethereumjs-util 7.1.3
 const ethUtil = require('ethereumjs-util');
+
+// using ethereumjs-abi 0.6.9
 const abi = require('ethereumjs-abi');
+
+// using chai 4.3.4
 const chai = require('chai');
 
 const typedData = {


### PR DESCRIPTION
fixes the eip 712 javascript example (keccak on strings)

using ethereumjs-util `7.1.3` and node `16.10.0`

ref https://github.com/ethereumjs/ethereumjs-monorepo/commit/438b859d0184430ae22ce516c4f7f3b23fd10ac8
