### PR TITLE
Fix use of EIP-165 supportsInterface in EIP-2981

### DIFF
--- a/EIPS/eip-2981.md
+++ b/EIPS/eip-2981.md
@@ -130,14 +130,7 @@ constructor (string memory name, string memory symbol, string memory baseURI) {
 
 #### Checking if the NFT being sold on your marketplace implemented royalties
 
-```solidity  
-bytes4 private constant _INTERFACE_ID_ERC2981 = 0x2a55205a;
-
-function checkRoyalties(address _contract) internal returns (bool) {
-    (bool success) = IERC165(_contract).supportsInterface(_INTERFACE_ID_ERC2981);
-    return success;
- }
-```
+To determine if an NFT implements royalties, integrators should check for the EIP-165 interface id `0x2a55205a` using the procedure specified in said EIP: ["How to Detect if a Contract Implements any Given Interface"](https://eips.ethereum.org/EIPS/eip-165#how-to-detect-if-a-contract-implements-any-given-interface).
 
 ## Rationale
 


### PR DESCRIPTION
There is a section in EIP-2981 that describes how to use EIP-165, but it's incorrect. Before checking for the relevant interface id, one has to first check that EIP-165 is supported (i.e. that `supportsInterface(0x01ffc9a7) = true` and `supportsInterface(0xffffffff) = false`).

I've replaced the instructions with a reference to the EIP where that is properly described.