### PR TITLE
eip-4361: apply capitalization checksum

### DIFF
--- a/EIPS/eip-4361.md
+++ b/EIPS/eip-4361.md
@@ -31,7 +31,7 @@ Sign-In with Ethereum works as follows:
 ### Example message to be signed
 ```
 service.org wants you to sign in with your Ethereum account:
-0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2
+0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2
 
 I accept the ServiceOrg Terms of Service: https://service.org/tos
 


### PR DESCRIPTION
EIP 4361 states that 

> address is the Ethereum address performing the signing conformant to capitalization encoded checksum specified in EIP-55 where applicable.

But the example does not use EIP-55 checksum encoding. This PR fixes that. 