### PR TITLE
Patch for preventing GH actions/bots to run on the forked branches

### DIFF
--- a/.github/workflows/auto-merge-bot.yml
+++ b/.github/workflows/auto-merge-bot.yml
@@ -4,7 +4,7 @@ jobs:
   auto_merge_bot:
     runs-on: ubuntu-latest
     name: EIP Auto-Merge Bot
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false && github.repository == 'ethereum/eips'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -25,6 +25,7 @@ jobs:
           META_EDITORS: "@lightclient,@axic,@gcolvin"
           INFORMATIONAL_EDITORS: "@lightclient,@axic,@gcolvin"
   enable-auto-merge:
+    if: github.repository == 'ethereum/eips'
     runs-on: ubuntu-latest
     needs: ["auto_merge_bot"]
     steps:

--- a/.github/workflows/auto-stagnate-bot.yml
+++ b/.github/workflows/auto-stagnate-bot.yml
@@ -6,6 +6,7 @@ on:
 name: Auto Stagnant Bot
 jobs:
   auto_merge_bot:
+    if: github.repository == 'ethereum/eips'
     runs-on: ubuntu-latest
     name: Auto Stagnant Bot
     steps:

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -4,6 +4,7 @@ on: [pull_request, issues]
 
 jobs:
   greeting:
+    if: github.repository == 'ethereum/eips'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/first-interaction@v1

--- a/.github/workflows/manual-bot-rerun.yml
+++ b/.github/workflows/manual-bot-rerun.yml
@@ -16,6 +16,7 @@ on:
       
 jobs:
   rerun-bot:
+    if: github.repository == 'ethereum/eips'
     runs-on: ubuntu-latest
     name: Manual Bot Rerun
     steps:

--- a/.github/workflows/rerun-bot-pull-request-review.yml
+++ b/.github/workflows/rerun-bot-pull-request-review.yml
@@ -4,6 +4,7 @@ on:
 name: Rerun Bot
 jobs:
   rerun_bot_on_review:
+    if: github.repository == 'ethereum/eips'
     runs-on: ubuntu-latest
     name: Trigger Bot Rerun workflow_run
     steps:

--- a/.github/workflows/rerun-bot-workflow-run.yml
+++ b/.github/workflows/rerun-bot-workflow-run.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   rerun-bot:
+    if: github.repository == 'ethereum/eips'
     runs-on: ubuntu-latest
     name: Rerun Bot (workflow_run)
     steps:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   stale-pr:
+    if: github.repository == 'ethereum/eips'
     runs-on: ubuntu-latest
     name: "Mark stale PRs"
     steps:
@@ -19,6 +20,7 @@ jobs:
         stale-pr-message: 'There has been no activity on this pull request for two months. It will be closed in a week if no further activity occurs. If you would like to move this EIP forward, please respond to any outstanding feedback or add a comment indicating that you have addressed all required feedback and are ready for a review.'
         close-pr-message: 'This pull request was closed due to inactivity. If you are still pursuing it, feel free to reopen it and respond to any feedback or request a review in a comment.'
   stale-issue:
+    if: github.repository == 'ethereum/eips'
     runs-on: ubuntu-latest
     name: "Mark stale issues"
     steps:


### PR DESCRIPTION
This patch adds a condition to check and skip if the repository isn't 'ethereum/eips', solving the problem for forked branches.
Issue Ref: https://github.com/ethereum/EIPs/issues/4526
Sample test run: https://github.com/mryalamanchi/EIPs/runs/4579216649?check_suite_focus=true

Kindly review and merge

Note: The `if` checks don't allow for case-insensitive, as mentioned in the docs. 
So will have to keep an eye out if this can cause any problems later.