### PR TITLE
EIP-165: Removes gas references.

### DIFF
--- a/EIPS/eip-165.md
+++ b/EIPS/eip-165.md
@@ -62,8 +62,7 @@ pragma solidity ^0.4.20;
 interface ERC165 {
     /// @notice Query if a contract implements an interface
     /// @param interfaceID The interface identifier, as specified in ERC-165
-    /// @dev Interface identification is specified in ERC-165. This function
-    ///  uses less than 30,000 gas.
+    /// @dev Interface identification is specified in ERC-165.
     /// @return `true` if the contract implements `interfaceID` and
     ///  `interfaceID` is not 0xffffffff, `false` otherwise
     function supportsInterface(bytes4 interfaceID) external view returns (bool);
@@ -85,7 +84,7 @@ Implementation note, there are several logical ways to implement this function. 
 
 ### How to Detect if a Contract Implements ERC-165
 
-1. The source contract makes a `STATICCALL` to the destination address with input data: `0x01ffc9a701ffc9a700000000000000000000000000000000000000000000000000000000` and gas 30,000. This corresponds to `contract.supportsInterface(0x01ffc9a7)`.
+1. The source contract makes a `STATICCALL` to the destination address with input data: `0x01ffc9a701ffc9a700000000000000000000000000000000000000000000000000000000`. This corresponds to `contract.supportsInterface(0x01ffc9a7)`.
 2. If the call fails or return false, the destination contract does not implement ERC-165.
 3. If the call returns true, a second call is made with input data `0x01ffc9a7ffffffff00000000000000000000000000000000000000000000000000000000`.
 4. If the second call fails or returns true, the destination contract does not implement ERC-165.
@@ -148,7 +147,7 @@ contract ERC165Query {
                 mstore(add(x, 0x04), _interfaceId) // Place first argument directly next to signature
 
                 success := staticcall(
-                                    30000,         // 30k gas
+                                    gas(),         // remaining gas
                                     _contract,     // To addr
                                     x,             // Inputs are stored at location x
                                     0x24,          // Inputs are 36 bytes long


### PR DESCRIPTION
Gas prices can (and frequently do) change, and no contract or specification can make any guarantees on how much an operation will cost in the future.  Saying "this will cost less than 30,000 gas" is an assertion that this specification **CANNOT** make.

This is a normative change to a final EIP, but I think in this case it is acceptable because the EIP currently makes an assertion about the universe that it cannot reasonably make and it should be fixed to no longer make such an assertion.