### PR TITLE
Fix pseudocode on EIP-4337 paymaster reputation status

### DIFF
--- a/EIPS/eip-4337.md
+++ b/EIPS/eip-4337.md
@@ -209,9 +209,9 @@ def status(paymaster: Address,
     if paymaster not in opsSeen:
         return OK
     min_expected_included = opsSeen[paymaster] // MIN_INCLUSION_RATE_DENOMINATOR
-    if min_expected_included + THROTTLING_SLACK >= opsIncluded[paymaster]:
+    if min_expected_included <= opsIncluded[paymaster] + THROTTLING_SLACK:
         return OK
-    elif min_expected_included + BAN_SLACK >= opsIncluded[paymaster]:
+    elif min_expected_included <= opsIncluded[paymaster] + BAN_SLACK:
         return THROTTLED
     else:
         return BANNED


### PR DESCRIPTION
The logic on the snippet is wrong (i.e. having opsSeen > 0 and opsIncluded = 0 would return "OK" every time).
