### PR TITLE
EIP-4361: fix mandatory fields (domain & chainId)

### DIFF
--- a/EIPS/eip-4361.md
+++ b/EIPS/eip-4361.md
@@ -22,7 +22,7 @@ Already, many services support workflows to authenticate Ethereum accounts using
 ## Specification
 Sign-In with Ethereum works as follows:
 
-1. The wallet presents the user with a structured plaintext message or equivalent interface for signing with the [EIP-191](./eip-191.md) signature scheme (string prefixed with `\x19Ethereum Signed Message:\n<length of message>`). The `message` MUST incorporate an Ethereum `address`, a `domain` of the website, `version` of the message, a chain identifier `chainId`, `uri` for scoping, `nonce` acceptable to the server, and `issued-at` timestamp.
+1. The wallet presents the user with a structured plaintext message or equivalent interface for signing with the [EIP-191](./eip-191.md) signature scheme (string prefixed with `\x19Ethereum Signed Message:\n<length of message>`). The `message` MUST incorporate an Ethereum `address`,  `domain` requesting the signing, `version` of the message, a chain identifier `chain-id`, `uri` for scoping, `nonce` acceptable to the server, and `issued-at` timestamp.
 2. The signature is then presented to the server, which checks the signature's validity and message content.
 3. Additional fields, including `expiration-time`, `not-before`, `request-id`, `chain-id`, and `resources` may be incorporated as part of authentication for the session.
 4. The server may further fetch data associated with the Ethereum address, such as from the Ethereum blockchain (e.g., ENS, account balances, ERC-20/ERC-721/ERC-1155 asset ownership), or other data sources that may or may not be permissioned.

--- a/EIPS/eip-4361.md
+++ b/EIPS/eip-4361.md
@@ -22,7 +22,7 @@ Already, many services support workflows to authenticate Ethereum accounts using
 ## Specification
 Sign-In with Ethereum works as follows:
 
-1. The wallet presents the user with a structured plaintext message or equivalent interface for signing with the [EIP-191](./eip-191.md) signature scheme (string prefixed with `\x19Ethereum Signed Message:\n<length of message>`). The `message` MUST incorporate an Ethereum `address`, `version` of the message, `uri` for scoping, `nonce` acceptable to the server, and `issued-at` timestamp.
+1. The wallet presents the user with a structured plaintext message or equivalent interface for signing with the [EIP-191](./eip-191.md) signature scheme (string prefixed with `\x19Ethereum Signed Message:\n<length of message>`). The `message` MUST incorporate an Ethereum `address`, a `domain` of the website, `version` of the message, a chain identifier `chainId`, `uri` for scoping, `nonce` acceptable to the server, and `issued-at` timestamp.
 2. The signature is then presented to the server, which checks the signature's validity and message content.
 3. Additional fields, including `expiration-time`, `not-before`, `request-id`, `chain-id`, and `resources` may be incorporated as part of authentication for the session.
 4. The server may further fetch data associated with the Ethereum address, such as from the Ethereum blockchain (e.g., ENS, account balances, ERC-20/ERC-721/ERC-1155 asset ownership), or other data sources that may or may not be permissioned.


### PR DESCRIPTION
The spec's ABNF and the ABNF in the reference implementation all mandate `domain` and `chainId` to be required fields in a message, so we add them to the specification text for completeness as well.

Comment on Ethereum Magicians is here: https://ethereum-magicians.org/t/eip-4361-sign-in-with-ethereum/7263/11