### PR TITLE
calculate* requirements and rationale

### DIFF
--- a/EIPS/eip-4626.md
+++ b/EIPS/eip-4626.md
@@ -87,17 +87,13 @@ MUST return the address of a token implementing the ERC-20 standard.
 #### calculateShares
 `function calculateShares(uint256 underlyingAmount) public view returns (uint256 shareAmount)`
 
-Returns the amount of vault shares corresponding to a given underlying amount.
-
-`calculateShares(calculateUnderlying(shareAmount))` MUST equal `shareAmount`
+Returns the amount of vault shares corresponding to a given underlying amount, for the `withdraw` method. The return value is only guaranteed to be exact if executed immediately before a `withdraw` call in the same transaction.
     
 #### calculateUnderlying
    
 `function calculateUnderlying(uint256 shareAmount) public view returns (uint256 underlyingAmount)`;
 
-Returns the amount of underlying tokens corresponding to a given amount of vault shares.
-
-`calculateUnderlying(calculateShares(underlyingAmount))` MUST equal `underlyingAmount`
+Returns the amount of underlying tokens corresponding to a given amount of vault shares, for the `mint` method. The return value is only guaranteed to be exact if executed immediately before a `mint` call in the same transaction.
 
 ### Events
 
@@ -128,6 +124,10 @@ ERC-20 is forced because implementation details like token approval and balance 
 The vaults are opinionated on a default deposit/withdraw flow because it gives integrators a default pattern to implement. Special use cases can be overloaded on these functions by including additional logic.
 
 The mint function was included for symmetry and feature completeness. Most current use cases of shares based vaults do not ascribe special meaning to the shares such that a user would optimize for a specific number of shares (mint) rather than specific amount of underlying (deposit). However, it is easy to imagine future vault strategies which would have unique and independently useful share representations.
+
+The `calculateShares` method cannot be guaranteed to be simultaneously exact with the return values for both `deposit` and `withdraw`. It matches the return value of `withdraw` to allow querying the vault for the exact amount of underlying that should be approved for transfer in a `withdraw` call for the current transaction. The inclusion of a `calculateSharesOnDeposit` function was considered unnecessary.
+
+The `calculateUnderlying` method cannot be guaranteed to be simultaneously exact with the return values for both `mint` and `redeem`. It matches the return value of `mint` to allow querying the vault for the exact amount of shares that should be taken from the caller in a `mint` call for the current transaction. The inclusion of a `calculateUnderlyingOnRedeem` function was considered unnecessary.
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
Replaced the `calculateShares` and `calculateUnderlying` requirements for a longer description that includes which function behaviour should they match, with an explanation on the rationale section.