### PR TITLE
Rewrite the `calculate*` descriptions

### DIFF
--- a/EIPS/eip-4626.md
+++ b/EIPS/eip-4626.md
@@ -87,13 +87,13 @@ MUST return the address of a token implementing the ERC-20 standard.
 #### calculateShares
 `function calculateShares(uint256 underlyingAmount) public view returns (uint256 shareAmount)`
 
-Returns the amount of vault shares corresponding to a given underlying amount, for the `withdraw` method. The return value is only guaranteed to be exact if executed immediately before a `withdraw` call in the same transaction.
+Returns the amount of vault shares corresponding to a given amount of underlying tokens. The return value of `calculateShares` MUST match the return value of a `withdraw` call executed immediately after in the same transaction.
     
 #### calculateUnderlying
    
 `function calculateUnderlying(uint256 shareAmount) public view returns (uint256 underlyingAmount)`;
 
-Returns the amount of underlying tokens corresponding to a given amount of vault shares, for the `mint` method. The return value is only guaranteed to be exact if executed immediately before a `mint` call in the same transaction.
+Returns the amount of underlying tokens corresponding to a given amount of vault shares. The return value of `calculateUnderlying` MUST match the return value of a `mint` call executed immediately after in the same transaction.
 
 ### Events
 


### PR DESCRIPTION
Descriptions rewritten for clarity