### PR TITLE
Tighter function descriptions

### DIFF
--- a/EIPS/eip-4626.md
+++ b/EIPS/eip-4626.md
@@ -29,41 +29,49 @@ All tokenized vaults MUST implement ERC-20. If a vault is to be non-transferrabl
 
 #### deposit
 
-`function deposit(address _to, uint256 _value) public returns (uint256 _shares)`
+`function deposit(address to, uint256 value) public returns (uint256 shares)`
 
-Deposits exactly `_value` tokens into the vault and grants ownership of the corresponding `_shares` amount to `_to`.
+Mints `shares` amount of vault tokens to `to` by depositing `value` underlying tokens.
 
-MUST support ERC-20 tranferFrom deposit flow where the vault has at least `_value` approval over `msg.sender`'s balance of underlying. MAY support an additional deposit flow that is checked beforehand such as a skimbatch approach.
+MUST support the ERC-20 transferFrom flow where the vault has at least `value` approval over msg.sender's balance of underlying.
+
+MAY support an additional flow in which the underlying tokens are owned by the vault contract before the `deposit` execution, and are accounted for during `deposit`.
 
 MUST emit the `Deposit` event.
 
 #### mint
 
-`function mint(address _to, uint256 _shares) public returns (uint256 _value)`
+`function mint(address to, uint256 shares) public returns (uint256 value)`
 
-Mints exactly `_shares` amount of ownership to `_to` by depositing `_value` tokens.
+Mints `shares` amount of vault tokens to `to` by depositing `value` underlying tokens.
 
-MUST support ERC-20 tranferFrom deposit flow where the vault has at least `_value` approval over `msg.sender`'s balance of underlying. MAY support an additional deposit flow such as a skimbatch approach.
+MUST support the ERC-20 transferFrom flow where the vault has at least `value` approval over msg.sender's balance of underlying.
+
+MAY support an additional flow in which the underlying tokens are owned by the vault contract before the `mint` execution, and are accounted for during `mint`.
 
 MUST emit the `Deposit` event.
 
 #### withdraw
 
-`function withdraw(address _from, address _to, uint256 _value) public returns (uint256 _shares)`
+`function withdraw(address from, address to, uint256 value) public returns (uint256 shares)`
 
-Withdraws `_value` tokens from owner `_from` and transfers them to `_to`. 
+Burns `shares` vault tokens from `from`, withdrawing `value` underlying tokens to `to`.
 
-MUST support withdrawal flow where the `_from` address holds `_shares`, where the shares are burned. If `_from != msg.sender`, then `msg.sender` MUST have ERC-20 approval over `_from` shares. MAY support an additional withdrawal flow such as a skimbatch approach.
+MUST support the ERC-20 flow in which the `from` address holds the `shares` vault tokens being burned. If `from != msg.sender`, then `msg.sender` MUST have ERC-20 approval over at least `shares` vault tokens from `from`.
+
+MAY support an additional flow in which the vault tokens being burned are owned by the vault contract before the `withdraw` execution, instead of being owned by `from`.
 
 MUST emit the `Withdraw` event.
 
 #### redeem
 
-`function redeem(address _from, address _to, uint256 _shares) public returns (uint256 _value)`
+`function redeem(address from, address to, uint256 shares) public returns (uint256 value)`
 
-Redeems a specific number of `_shares` from owner `_from` for underlying tokens and transfers them to `_to`. 
+Burns `shares` vault tokens from `from`, withdrawing `value` underlying tokens to `to`.
 
-MUST support withdrawal flow where the `_from` address holds `_shares`, where the shares are burned. If `_from != msg.sender`, then `msg.sender` MUST have ERC-20 approval over `_from` shares. MAY support an additional withdrawal flow such as a skimbatch approach.
+MUST support the ERC-20 flow in which the `from` address holds the `shares` vault tokens being burned. If `from != msg.sender`, then `msg.sender` MUST have ERC-20 approval over at least `shares` vault tokens from `from`.
+
+MAY support an additional flow in which the vault tokens being burned are owned by the vault contract before the `redeem` execution, instead of being owned by `from`.
 
 MUST emit the `Withdraw` event.
 
@@ -73,9 +81,9 @@ MUST emit the `Withdraw` event.
 Returns the total amount of underlying tokens held/managed by the vault.
 
 #### balanceOfUnderlying
-`function balanceOfUnderlying(address _owner) public view returns (uint256)`
+`function balanceOfUnderlying(address owner) public view returns (uint256)`
 
-Returns the total amount underlying tokens held in the vault for `_owner`.
+Returns the total amount underlying tokens held in the vault for `owner`.
 
 #### underlying
 `function underlying() public view returns (address)`
@@ -101,18 +109,18 @@ Returns the amount of underlying tokens corresponding to a given amount of vault
 
 MUST be emitted when tokens are deposited into the vault.
 
-`event Deposit(address indexed _from, address indexed _to, uint256 _value)`
+`event Deposit(address indexed from, address indexed to, uint256 value)`
 
-Where `_from` is the user who triggered the deposit for `_value` underlying tokens to the vault, and `_to` is the user who is able to withdraw the deposited tokens. 
+Where `from` is the user who triggered the deposit for `value` underlying tokens to the vault, and `to` is the user who is able to withdraw the deposited tokens. 
 
 
 #### Withdraw
 
 MUST be emitted when tokens are withdrawn from the vault by a depositor.
 
-`event Withdraw(address indexed _from, address indexed _to, uint256 _value)`
+`event Withdraw(address indexed from, address indexed to, uint256 value)`
 
-Where `_from` is the owner who and held `_value` underlying tokens in the vault, and `_to` is the user who received the withdrawn tokens.
+Where `from` is the owner who and held `value` underlying tokens in the vault, and `to` is the user who received the withdrawn tokens.
 
 
 ## Rationale


### PR DESCRIPTION
The functions re now described in more precise language, covering all parameters and return values. The `skimbatch` mention has been replaced by an actual description.