### PR TITLE
Exact parameters, `calculate*` descriptions

### DIFF
--- a/EIPS/eip-4626.md
+++ b/EIPS/eip-4626.md
@@ -31,7 +31,7 @@ All tokenized vaults MUST implement ERC-20. If a vault is to be non-transferrabl
 
 `function deposit(address to, uint256 value) public returns (uint256 shares)`
 
-Mints `shares` amount of vault tokens to `to` by depositing `value` underlying tokens.
+Mints `shares` amount of vault tokens to `to` by depositing exactly `value` underlying tokens.
 
 MUST support the ERC-20 transferFrom flow where the vault has at least `value` approval over msg.sender's balance of underlying.
 
@@ -43,11 +43,15 @@ MUST emit the `Deposit` event.
 
 `function mint(address to, uint256 shares) public returns (uint256 value)`
 
-Mints `shares` amount of vault tokens to `to` by depositing `value` underlying tokens.
+Mints exactly `shares` amount of vault tokens to `to` by depositing `value` underlying tokens.
+
+`value` MUST equal the return value of a `calculateUnderlying` call, with `shares` as a parameter, executed immediately before `withdraw` in the same transaction.
 
 MUST support the ERC-20 transferFrom flow where the vault has at least `value` approval over msg.sender's balance of underlying.
 
 MAY support an additional flow in which the underlying tokens are owned by the vault contract before the `mint` execution, and are accounted for during `mint`.
+
+
 
 MUST emit the `Deposit` event.
 
@@ -55,7 +59,9 @@ MUST emit the `Deposit` event.
 
 `function withdraw(address from, address to, uint256 value) public returns (uint256 shares)`
 
-Burns `shares` vault tokens from `from`, withdrawing `value` underlying tokens to `to`.
+Burns `shares` vault tokens from `from`, withdrawing exactly `value` underlying tokens to `to`.
+
+`shares` MUST equal the return value of a `calculateShares` call, with `value` as a parameter, executed immediately before `mint` in the same transaction.
 
 MUST support the ERC-20 flow in which the `from` address holds the `shares` vault tokens being burned. If `from != msg.sender`, then `msg.sender` MUST have ERC-20 approval over at least `shares` vault tokens from `from`.
 
@@ -67,7 +73,7 @@ MUST emit the `Withdraw` event.
 
 `function redeem(address from, address to, uint256 shares) public returns (uint256 value)`
 
-Burns `shares` vault tokens from `from`, withdrawing `value` underlying tokens to `to`.
+Burns exactly `shares` vault tokens from `from`, withdrawing `value` underlying tokens to `to`.
 
 MUST support the ERC-20 flow in which the `from` address holds the `shares` vault tokens being burned. If `from != msg.sender`, then `msg.sender` MUST have ERC-20 approval over at least `shares` vault tokens from `from`.
 
@@ -95,13 +101,13 @@ MUST return the address of a token implementing the ERC-20 standard.
 #### calculateShares
 `function calculateShares(uint256 underlyingAmount) public view returns (uint256 shareAmount)`
 
-Returns the amount of vault shares corresponding to a given amount of underlying tokens. The return value of `calculateShares` MUST match the return value of a `withdraw` call executed immediately after in the same transaction.
+Returns the amount of vault tokens that need to be burned to obtain a given amount of underlying tokens in a `withdraw` call.
     
 #### calculateUnderlying
    
 `function calculateUnderlying(uint256 shareAmount) public view returns (uint256 underlyingAmount)`;
 
-Returns the amount of underlying tokens corresponding to a given amount of vault shares. The return value of `calculateUnderlying` MUST match the return value of a `mint` call executed immediately after in the same transaction.
+Returns the amount of underlying tokens that need to be given to the vault to obtain a given amount of vault tokens in a `mint` call.
 
 ### Events
 


### PR DESCRIPTION
Mention of exact parameters, and more clarity between `calculate*` and other functions