### PR TITLE
Specify that permit must revert on invalid signatures

### DIFF
--- a/EIPS/eip-2612.md
+++ b/EIPS/eip-2612.md
@@ -64,6 +64,8 @@ if and only if the following conditions are met:
 - `nonces[owner]` (before the state update) is equal to `nonce`.
 - `r`, `s` and `v` is a valid `secp256k1` signature from `owner` of the message:
 
+If any of these conditions are not met, the `permit` call must revert.
+
 ```sol
 keccak256(abi.encodePacked(
    hex"1901",
@@ -178,6 +180,8 @@ Its implementation differs slightly from the presentation here in that:
 There is also an implementation in the token [`Stake`](https://etherscan.io/address/0x0Ae055097C6d159879521C384F1D2123D1f195e6#code) with the same ABI as `dai` but with different semantics: it lets users issue "expiring approvals", that only allow `transferFrom` to occur while `expiry >= block.timestamp`.
 
 The specification presented here is in line with the implementation in [Uniswap-v2](https://github.com/uniswap/uniswap-v2-core).
+
+The requirement to revert if the permit is invalid was added when the EIP was already widely deployed, but at the moment it was consistent with all found implementations.
 
 ## Test Cases
 


### PR DESCRIPTION
As suggested in https://github.com/ethereum/EIPs/issues/2613#issuecomment-1024589197.

The [recent Multichain/AnySwap vulnerability](https://media.dedaub.com/phantom-functions-and-the-billion-dollar-no-op-c56f062ae49f) that put almost half a billion at risk was due to a combination of permit, infinite approvals, and "phantom functions" (i.e. a fallback function that accepts any function call).

A literal reading of the current text of the EIP shows that the last part is not strictly necessary. A compliant implementation of `permit` isn't required to revert if the permit is invalid or old, and such an implementation could lead to the same vulnerability that was found there.

This PR adds to the specification that `permit` must revert if the signature is invalid.