### PR TITLE
3607: Move eip-3607 to final

### DIFF
--- a/EIPS/eip-3607.md
+++ b/EIPS/eip-3607.md
@@ -4,11 +4,10 @@ title: Reject transactions from senders with deployed code
 description: Do not allow transactions for which `tx.sender` has any code deployed.
 author: Dankrad Feist (@dankrad), Dmitry Khovratovich (@khovratovich), Marius van der Wijden (@MariusVanDerWijden)
 discussions-to: https://github.com/ethereum/EIPs/issues/3608
-status: Last Call
+status: Final
 type: Standards Track
 category: Core
 created: 2021-06-10
-last-call-deadline: 2022-01-25
 ---
 
 ## Abstract


### PR DESCRIPTION
Last call deadline is over, so this can be moved to final. All major clients implement it already