### PR TITLE
Move EIP 3668 to Final

### DIFF
--- a/EIPS/eip-3668.md
+++ b/EIPS/eip-3668.md
@@ -4,11 +4,10 @@ title: "CCIP Read: Secure offchain data retrieval"
 description: CCIP Read provides a mechanism to allow a contract to fetch external data.
 author: Nick Johnson (@arachnid)
 discussions-to: https://ethereum-magicians.org/t/durin-secure-offchain-data-retrieval/6728
-status: Last Call
+status: Final
 type: Standards Track
 category: ERC
 created: 2020-07-19
-last-call-deadline: 2022-01-24
 ---
 
 ## Abstract


### PR DESCRIPTION
The following issues were raised during the last call process and addressed:
 - Optional (for gateways) support for POST requests because of the 2k limit on URL length.
 - Additional notes in the security section about fingerprinting risks and how to mitigate them.
 - Additional notes on how CCIP read aware contracts should handle nested calls.

With these addressed I do not believe there is any further barrier to moving this EIP to Final status.