### PR TITLE
EIP-4760: SELFDESTRUCT bomb

### DIFF
--- a/EIPS/eip-4760.md
+++ b/EIPS/eip-4760.md
@@ -1,0 +1,54 @@
+---
+eip: 4760
+title: SELFDESTRUCT bomb
+description: Deactivate SELFDESTRUCT by changing it to SENDALL, which does recover all funds to the caller but does not delete any contract code or storage. In order to give applications good time to switch to new constructions, do this via a stage of exponential gas cost increases.
+author: Guillaume Ballet (@gballet), Vitalik Buterin (@vbuterin), Dankrad Feist (@dankrad)
+discussions-to: https://github.com/ethereum/EIPs/issues/4761
+status: Draft
+type: Standards Track
+category: Core
+created: 2022-02-03
+requires: 
+---
+# SELFDESTRUCT bomb
+
+## Summary
+
+This EIP renames the `SELFDESCRUCT` opcode to `SENDALL`, and replaces its functionality. The new functionality will be only to send all Ether in the account to the caller.
+
+In order to give apps more warning even if their developers are completely unaware of the EIP process, this version will exponentially increase the gas costs of the opcode, so any developer has time to see this change and react by implementing a version of their contract that does not rely on `SELFDESTRUCT` .
+
+## Motivation
+
+The `SELFDESTRUCT` opcode requires large changes to the state of an account, in particular removing all code and storage. This will not be possible in the future with Verkle trees: Each account will be stored in many different account keys, which will not be obviously connected to the root account (see [Verkle tree EIP](https://notes.ethereum.org/5HDhQXstTaKtVqVbS7S9yw)).
+
+This EIP implements this change. Applications that only use SELFDESTRUCT to retrieve funds will still work.
+
+## Specification
+
+### Constants
+
+| Name | Value | Comment |
+|------|-------|---------|
+| `OLD_SELFDESTRUCT_COST` | 5000 | Current gas cost of `SELFDESTRUCT` opcode |
+| `HARD_FORK_BLOCK` | TBD | (Shanghai HF block height) |
+| `DOUBLING_SLOTS` | `2**16` | (Time for gas price to double, ca. 9 days) |
+| `DOUBLINGS_BEFORE_SENDALL` | `13` | `SELFDESTRUCT` will be converted to `SENDALL` at `HARD_FORK_BLOCK + DOUBLING_SLOTS * DOUBLINGS_BEFORE_SENDALL` |
+
+ * If `HARD_FORK_BLOCK <= slot < HARD_FORK_BLOCK + DOUBLING_SLOTS * DOUBLINGS_BEFORE_SENDALL`
+     * `SELFDESTRUCT` functionality remains unchanged
+     * `SELFDESTRUCT` gas cost is now `OLD_SELFDESTRUCT_COST * 2 ** ((slot - HARD_FORK_BLOCK) // DOUBLING_SLOTS)`
+ * For `slot >= HARD_FORK_BLOCK + DOUBLING_SLOTS * DOUBLINGS_BEFORE_SENDALL`
+     * The cost reverts back to `OLD_SELFDESTRUCT_COST`
+     * The `SELFDESTRUCT` opcode is renamed to `SENDALL`, and now only immediately moves all ETH in the account to the target; it no longer destroys code or storage or alters the nonce
+     * All refunds related to `SELFDESTRUCT` are removed
+
+## Rationale
+
+Getting rid of the `SELFDESTRUCT` opcode has been considered in the past (for arguments see [here](https://hackmd.io/@vbuterin/selfdestruct)), and there are currently no strong reasons to use it. Disabling it will be a requirement for statelessness.
+
+## Backward-Compatibility
+
+This EIP requires a hard fork, since it modifies consensus rules.
+
+Few applications are affected by this change. The only use that breaks is where a contract is re-created at the same address using `CREATE2` (after a `SELFDESTRUCT`). An analysis of the contracts where this happens has been made available [here](https://hackmd.io/@albus/rkAbjAsWF). The only application that is significantly affected (and where code can be analyzed) is able to switch to a different model, and should have ample time to do so.

--- a/EIPS/eip-4760.md
+++ b/EIPS/eip-4760.md
@@ -3,12 +3,11 @@ eip: 4760
 title: SELFDESTRUCT bomb
 description: Deactivate SELFDESTRUCT by changing it to SENDALL, which does recover all funds to the caller but does not delete any contract code or storage. In order to give applications good time to switch to new constructions, do this via a stage of exponential gas cost increases.
 author: Guillaume Ballet (@gballet), Vitalik Buterin (@vbuterin), Dankrad Feist (@dankrad)
-discussions-to: https://github.com/ethereum/EIPs/issues/4761
+discussions-to: https://ethereum-magicians.org/t/eip-4760-selfdestruct-bomb/8713
 status: Draft
 type: Standards Track
 category: Core
 created: 2022-02-03
-requires: 
 ---
 # SELFDESTRUCT bomb
 
@@ -52,3 +51,15 @@ Getting rid of the `SELFDESTRUCT` opcode has been considered in the past (for ar
 This EIP requires a hard fork, since it modifies consensus rules.
 
 Few applications are affected by this change. The only use that breaks is where a contract is re-created at the same address using `CREATE2` (after a `SELFDESTRUCT`). An analysis of the contracts where this happens has been made available [here](https://hackmd.io/@albus/rkAbjAsWF). The only application that is significantly affected (and where code can be analyzed) is able to switch to a different model, and should have ample time to do so.
+
+## Security Considerations
+
+The following applications of `SELFDESTRUCT` will be broken and applications that use it in this way are not safe anymore:
+1. Any use where `SELFDESTRUCT` is used to burn non-ETH token balances, such as ERC20, inside a contract. We do not know of any such use (since it can easily be done by sending to a burn address this seems an unlikely way to use `SELFDESTRUCT`)
+2. Where `CREATE2` is used to redeploy a contract in the same place. There are two ways in which this can fail:
+    - The destruction prevents the contract from being used outside of a certain context. For example, the contract allows anyone to withdraw funds, but `SELFDESTRUCT` is used at the end of an operation to prevent others from doing this. This type of operation can easily be modified to not depend on `SELFDESTRUCT`.
+    - The `SELFDESTRUCT` operation is used in order to make a contract upgradable. This is not supported anymore and delegates should be used.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/EIPS/eip-4760.md
+++ b/EIPS/eip-4760.md
@@ -9,9 +9,7 @@ type: Standards Track
 category: Core
 created: 2022-02-03
 ---
-# SELFDESTRUCT bomb
-
-## Summary
+## Abstract
 
 This EIP renames the `SELFDESCRUCT` opcode to `SENDALL`, and replaces its functionality. The new functionality will be only to send all Ether in the account to the caller.
 

--- a/EIPS/eip-4760.md
+++ b/EIPS/eip-4760.md
@@ -1,7 +1,7 @@
 ---
 eip: 4760
 title: SELFDESTRUCT bomb
-description: Deactivate SELFDESTRUCT by changing it to SENDALL, which does recover all funds to the caller but does not delete any contract code or storage. In order to give applications good time to switch to new constructions, do this via a stage of exponential gas cost increases.
+description: Deactivate SELFDESTRUCT by changing it to SENDALL and stage this via a stage of exponential gas cost increases.
 author: Guillaume Ballet (@gballet), Vitalik Buterin (@vbuterin), Dankrad Feist (@dankrad)
 discussions-to: https://ethereum-magicians.org/t/eip-4760-selfdestruct-bomb/8713
 status: Draft

--- a/EIPS/eip-4760.md
+++ b/EIPS/eip-4760.md
@@ -17,7 +17,7 @@ In order to give apps more warning even if their developers are completely unawa
 
 ## Motivation
 
-The `SELFDESTRUCT` opcode requires large changes to the state of an account, in particular removing all code and storage. This will not be possible in the future with Verkle trees: Each account will be stored in many different account keys, which will not be obviously connected to the root account (see [Verkle tree EIP](https://notes.ethereum.org/5HDhQXstTaKtVqVbS7S9yw)).
+The `SELFDESTRUCT` opcode requires large changes to the state of an account, in particular removing all code and storage. This will not be possible in the future with Verkle trees: Each account will be stored in many different account keys, which will not be obviously connected to the root account.
 
 This EIP implements this change. Applications that only use SELFDESTRUCT to retrieve funds will still work.
 
@@ -48,7 +48,7 @@ Getting rid of the `SELFDESTRUCT` opcode has been considered in the past (for ar
 
 This EIP requires a hard fork, since it modifies consensus rules.
 
-Few applications are affected by this change. The only use that breaks is where a contract is re-created at the same address using `CREATE2` (after a `SELFDESTRUCT`). An analysis of the contracts where this happens has been made available [here](https://hackmd.io/@albus/rkAbjAsWF). The only application that is significantly affected (and where code can be analyzed) is able to switch to a different model, and should have ample time to do so.
+Few applications are affected by this change. The only use that breaks is where a contract is re-created at the same address using `CREATE2` (after a `SELFDESTRUCT`). The only application that is significantly affected (and where code can be analyzed) is able to switch to a different model, and should have ample time to do so.
 
 ## Security Considerations
 

--- a/EIPS/eip-4760.md
+++ b/EIPS/eip-4760.md
@@ -44,7 +44,7 @@ This EIP implements this change. Applications that only use `SELFDESTRUCT` to re
 
 The idea behind this EIP is to disable `SELFDESTRUCT` in a way that gives ample warning to Dapp developers. Many developers do not watch the EIP process closely and can therefore be caught by surprise when an opcode is deactivated and does not fulfill its original purpose anymore. However, at least if the smart contract has regular use, then users will notice the price of the operation going up tremendously. The period over which this is happening (`HARD_FORK_BLOCK + DOUBLING_SLOTS * DOUBLINGS_BEFORE_SENDALL`) is chosen to be long enough (ca. 4 months) such that it gives developers time to react to this change and prepare their application.
 
-## Backward-Compatibility
+## Backward Compatibility
 
 This EIP requires a hard fork, since it modifies consensus rules.
 

--- a/EIPS/eip-4760.md
+++ b/EIPS/eip-4760.md
@@ -19,7 +19,7 @@ In order to give apps more warning even if their developers are completely unawa
 
 The `SELFDESTRUCT` opcode requires large changes to the state of an account, in particular removing all code and storage. This will not be possible in the future with Verkle trees: Each account will be stored in many different account keys, which will not be obviously connected to the root account.
 
-This EIP implements this change. Applications that only use SELFDESTRUCT to retrieve funds will still work.
+This EIP implements this change. Applications that only use `SELFDESTRUCT` to retrieve funds will still work.
 
 ## Specification
 
@@ -42,7 +42,7 @@ This EIP implements this change. Applications that only use SELFDESTRUCT to retr
 
 ## Rationale
 
-Getting rid of the `SELFDESTRUCT` opcode has been considered in the past (for arguments see [here](https://hackmd.io/@vbuterin/selfdestruct)), and there are currently no strong reasons to use it. Disabling it will be a requirement for statelessness.
+The idea behind this EIP is to disable `SELFDESTRUCT` in a way that gives ample warning to Dapp developers. Many developers do not watch the EIP process closely and can therefore be caught by surprise when an opcode is deactivated and does not fulfill its original purpose anymore. However, at least if the smart contract has regular use, then users will notice the price of the operation going up tremendously. The period over which this is happening (`HARD_FORK_BLOCK + DOUBLING_SLOTS * DOUBLINGS_BEFORE_SENDALL`) is chosen to be long enough (ca. 4 months) such that it gives developers time to react to this change and prepare their application.
 
 ## Backward-Compatibility
 


### PR DESCRIPTION
Deactivate SELFDESTRUCT by changing it to SENDALL, which does recover all funds to the caller but does not delete any contract code or storage. In order to give applications good time to switch to new constructions, do this via a stage of exponential gas cost increases.