### PR TITLE
refactor: add caller context variable to `max*` view methods

### DIFF
--- a/EIPS/eip-4626.md
+++ b/EIPS/eip-4626.md
@@ -144,8 +144,9 @@ MUST *NOT* revert.
 
 #### maxDeposit
 
-Total number of underlying assets that can be deposited.
+Total number of underlying assets that `caller` can be deposit.
 
+MUST return a limited value if `caller` is subject to some deposit limit.
 MUST return `2 ** 256 - 1` if there is no limit on the maximum amount of assets that may be deposited.
 MAY be used in the `previewDeposit` or `deposit` methods for `assets` input parameter.
 MUST *NOT* revert.
@@ -155,7 +156,9 @@ MUST *NOT* revert.
   type: function
   stateMutability: view
 
-  inputs: []
+  inputs:
+  - name: caller
+    type: address
 
   outputs:
   - name: maxAssets
@@ -220,8 +223,9 @@ Note that most implementations will require pre-approval of the Vault with the V
 
 #### maxMint
 
-Total number of underlying shares that can be minted.
+Total number of underlying shares that `caller` can be mint.
 
+MUST return a limited value if `caller` is subject to some deposit limit.
 MUST return `2 ** 256 - 1` if there is no limit on the maximum amount of shares that may be minted.
 MAY be used in the `previewMint` or `mint` methods for `shares` input parameter.
 MUST *NOT* revert.
@@ -231,7 +235,9 @@ MUST *NOT* revert.
   type: function
   stateMutability: view
 
-  inputs: []
+  inputs:
+  - name: caller
+    type: address
 
   outputs:
   - name: maxShares
@@ -296,9 +302,10 @@ Note that most implementations will require pre-approval of the Vault with the V
 
 #### maxWithdraw
 
-Total number of underlying assets that can be withdrawn.
+Total number of underlying assets that `caller` can withdraw.
 
-MUST return `2 ** 256 - 1` if there is no limit on the maximum amount of assets that may be withdrawn.
+MUST return a limited value if `caller` is subject to some withdrawal limit or timelock.
+MUST return `assetsOf(caller)` if `caller` is not subject to any withdrawal limit or timelock.
 MAY be used in the `previewWithdraw` or `withdraw` methods for `assets` input parameter.
 MUST *NOT* revert.
 
@@ -307,7 +314,9 @@ MUST *NOT* revert.
   type: function
   stateMutability: view
 
-  inputs: []
+  inputs:
+  - name: caller
+    type: address
 
   outputs:
   - name: maxAssets
@@ -375,9 +384,10 @@ Those methods should be performed separately.
 
 #### maxRedeem
 
-Total number of underlying shares that can be redeemed.
+Total number of underlying shares that `caller` can redeem.
 
-MUST return `2 ** 256 - 1` if there is no limit on the maximum amount of shares that may be redeemed.
+MUST return a limited value if `caller` is subject to some withdrawal limit or timelock.
+MUST return `balanceOf(caller)` if `caller` is not subject to any withdrawal limit or timelock.
 MAY be used in the `previewRedeem` or `redeem` methods for `shares` input parameter.
 MUST *NOT* revert.
 
@@ -386,7 +396,9 @@ MUST *NOT* revert.
   type: function
   stateMutability: view
 
-  inputs: []
+  inputs:
+  - name: caller
+    type: address
 
   outputs:
   - name: maxShares


### PR DESCRIPTION
Update to add `caller` context to `max*` methods.
This changes context so that implementors can return discretionary values in case of a whitelist or deposit limit use case, or if there is some withdrawal limit or timelock in place that a given `caller` must use external means to configure prior to calling the mutable methods.