### PR TITLE
4626: Tiny clarification for ABI

### DIFF
--- a/EIPS/eip-4626.md
+++ b/EIPS/eip-4626.md
@@ -88,7 +88,7 @@ MUST *NOT* revert.
   inputs: []
 
   outputs:
-  - name: totalAssets
+  - name: totalManagedAssets
     type: uint256
 ```
 


### PR DESCRIPTION
The function name is `totalAssets` and uses a name return value of `totalAssets`. If this YAML is used to auto-generate Solidity, it will result in a shadowing warning/error.