### PR TITLE
fix(EIP-3475): fix semantic error in code snippet

### DIFF
--- a/EIPS/eip-3475.md
+++ b/EIPS/eip-3475.md
@@ -53,7 +53,7 @@ mapping (address => mapping( uint256 =>mapping(uint256=> uint256))) private _bal
 *1 =>(5 => 25000000000); this example gives the total supply of： bond class 1, bond nonce 5 has a total supply of 25000000000 .*
 
 ```
-mapping (uint256 => mapping(uint256 => uint256)) private _activeSupply;
+mapping (uint256 => mapping(uint256 => uint256)) private _totalSupply;
 ```
 
 "_activeSupply"`Is the mapping from bond class and nonce to the total active supply.


### PR DESCRIPTION
The EIP includes a section where `_totalSupply` is being discussed but the
example code snippet attached with it is referring to the state variable `_activeSupply` which needs to replaced by the actual state variable `_totalSupply`.

The below image can illustrate this:

![image](https://cloud-am7rhy3m2-hack-club-bot.vercel.app/0image.png)