### PR TITLE
EIP-2681: Fix CREATE/CREATE2 max nonce error reporting rule

### DIFF
--- a/EIPS/eip-2681.md
+++ b/EIPS/eip-2681.md
@@ -26,7 +26,7 @@ Lastly, this facilitates a minor optimisation in clients, because the nonce no l
 Introduce two new restrictions retroactively from genesis:
 
 1. Consider any transaction invalid, where the nonce exceeds or equals to `2^64-1`.
-2. The `CREATE` and `CREATE2` instructions to abort with an exceptional halt, where the account nonce is `2^64-1`.
+2. The `CREATE` and `CREATE2` instructions' execution ends with the result `0` pushed on stack, where the account nonce is `2^64-1`. Gas for initcode execution is not deducted in this case.
 
 ## Rationale
 


### PR DESCRIPTION
Unfortunately we have to update the spec of this retroactive EIP, because there was misunderstanding regarding how CREATE/CREATE2 instructions report nonce overflow error.
It makes much more sense to return 0 rather than abort entire execution in this case, because this is like all other create-specific errors are reported (e.g. insufficient balance for transfer, account already exists, code size above limit, code starts with 0xEF)

And in fact I assumed that 0 result is the expected behavior both in [go-ethereum implementation](https://github.com/ethereum/go-ethereum/pull/23853) and in [tests](https://github.com/ethereum/tests/pull/934), and these are already merged and released.

cc @axic @holiman 
