### PR TITLE
EIP-4803: Transaction gas limit field

### DIFF
--- a/EIPS/eip-4803.md
+++ b/EIPS/eip-4803.md
@@ -3,7 +3,7 @@ eip: 4803
 title: Limit transaction gas to a maximum of 2^63-1
 description: Valid transactions must have a reasonable gas limit
 author: Alex Beregszaszi (@axic)
-discussions-to: <URL>
+discussions-to: https://ethereum-magicians.org/t/eip-4803-limit-transaction-gas-to-a-maximum-of-2-63-1/8296
 status: Draft
 type: Standards Track
 category: Core

--- a/EIPS/eip-4803.md
+++ b/EIPS/eip-4803.md
@@ -1,5 +1,5 @@
 ---
-eip: <to be assigned>
+eip: 4803
 title: Limit transaction gas to a maximum of 2^63-1
 description: Valid transactions must have a reasonable gas limit
 author: Alex Beregszaszi (@axic)

--- a/EIPS/eip-draft-gaslimit.md
+++ b/EIPS/eip-draft-gaslimit.md
@@ -1,0 +1,51 @@
+---
+eip: <to be assigned>
+title: Limit transaction gas to a maximum of 2^63-1
+description: Valid transactions must have a reasonable gas limit
+author: Alex Beregszaszi (@axic)
+discussions-to: <URL>
+status: Draft
+type: Standards Track
+category: Core
+created: 2022-02-02
+---
+
+## Abstract
+
+Limit transaction gas to be between `0` and `2^63-1`.
+
+## Motivation
+
+The gas limit field in the transaction is specified to be an arbitrary long unsigned integer, but various clients put limits on this value. This EIP brings a reasonable limit into consensus.
+
+## Specification
+
+Introduce one new restrictions retroactively from genesis: any transaction is invalid and not includeable in a block, where the gas limit exceeds `2^63-1`.
+
+## Rationale
+
+### `2^63-1` vs `2^64-1`
+
+`2^63-1` is chosen because it allows representing the gas value as a signed integer, and so the out of gas check can be done as a simple "less than zero" check after subtraction.
+
+### Current limit
+
+Due to the nature of RLP encoding, there is no fixed upper bound for the value, but most implementations limit it to 256-bits. Furthermore, most client implementations (such as geth) internally handle gas as a 64-bit value.
+
+## Backwards Compatibility
+
+While this is a breaking change, no actual effect should be visible.
+
+Before [EIP-1559](./eip-1559.md) it was possible to include transactions with `gasPrice = 0` and thus the `gasLimit * gasPrice <= accountBalance` calculation could have allowed for arbitrarily large values of `gasLimit`. However, the rule that the transaction list cannot exceed the block gas limit, and the strict rules about how the block gas limit can change, prevented arbitrarily large values of `gasLimit` to be in the historical state.
+
+## Security Considerations
+
+None.
+
+## Test Cases
+
+TBA
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
This is a follow up of [ACD#120](https://github.com/ethereum/pm/blob/master/AllCoreDevs-Meetings/Meeting%20120.md#limiting-account-nonce-eip-2681-vs-3338) where it was agreed to follow up the EIP-2681 and split more of EIP-1985 content into individual EIPs.