### PR TITLE
EIP 4626 - Add `convert` methods to provide price data

### DIFF
--- a/EIPS/eip-4626.md
+++ b/EIPS/eip-4626.md
@@ -89,6 +89,57 @@ MUST _NOT_ revert.
     type: uint256
 ```
 
+
+#### convertToShares
+
+The amount of shares that the vault would exchange for the amount of assets provided, in an ideal scenario where all the conditions are met.
+
+MUST NOT be inclusive of any fees that are charged against assets in the Vault.
+MUST NOT show any variations depending on the caller.
+MUST NOT reflect slippage or other on-chain conditions, when performing the actual exchange.
+MUST NOT revert.
+
+This calculation MAY NOT reflect the "per-user" price-per-share, and instead should reflect the "average-user's" price-per-share, meaning what the average user should expect to see when exchanging to and from.
+
+```yaml
+- name: convertToShares
+  type: function
+  stateMutability: view
+
+  inputs:
+  - name: assets
+    type: uint256
+
+  outputs:
+  - name: shares
+    type: uint256
+```
+
+#### convertToAssets
+
+The amount of assets that the vault would exchange for the amount of shares provided, in an ideal scenario where all the conditions are met.
+
+MUST NOT be inclusive of any fees that are charged against assets in the Vault.
+MUST NOT show any variations depending on the caller.
+MUST NOT reflect slippage or other on-chain conditions, when performing the actual exchange.
+MUST NOT revert.
+
+This calculation MAY NOT reflect the "per-user" price-per-share, and instead should reflect the "average-user's" price-per-share, meaning what the average user should expect to see when exchanging to and from.
+
+```yaml
+- name: convertToAssets
+  type: function
+  stateMutability: view
+
+  inputs:
+  - name: shares
+    type: uint256
+
+  outputs:
+  - name: assets
+    type: uint256
+```
+
 #### maxDeposit
 
 Total number of underlying assets that `caller` can deposit.
@@ -515,8 +566,11 @@ This specification has similar security considerations to the ERC-20 interface.
 Fully permissionless use cases could fall prey to malicious implementations which only conform to the interface but not the specification.
 It is recommended that all integrators review the implementation for potential ways of losing user deposits before integrating.
 
-The methods `totalAssets`, `assetsPerShare` and `assetsOf` are estimates useful for display purposes,
+The methods `totalAssets`, `convertToShares` and `convertToAssets` are estimates useful for display purposes,
 and do _not_ have to confer the _exact_ amount of underlying assets their context suggests.
+
+The `preview` methods return values that are as close as possible to exact as possible. For that reason, they are manipulable by altering the on-chain conditions and are not always safe to be used as price oracles. This specification includes `convert` methods that are allowed to be inexact and therefore can be implemented as robust price oracles. For example, it would be correct to implement the `convert` methods as using a time-weighted average price in converting between assets and shares.
+
 Integrators of ERC-4626 Vaults should be aware of the difference between these view methods when integrating with this standard.
 
 ## Copyright


### PR DESCRIPTION
`assetsPerShare` was removed in a previous PR, and is now being replaces by `convertToAssets` and `convertToShares`.

These two functions allow to implement robust price oracles from the Vault, since the `preview` methods are manipulable due to their exact nature. They are partially applied manipulations for the reasons explained in [this article](https://hackernoon.com/getting-prices-right).