### PR TITLE
EIP 4626 - Fix parameter names

### DIFF
--- a/EIPS/eip-4626.md
+++ b/EIPS/eip-4626.md
@@ -365,7 +365,7 @@ Note that any unfavorable discrepancy between `convertToShares` and `previewWith
 
 #### withdraw
 
-Redeems `shares` from `owner` and sends exactly `assets` of underlying tokens to `receiver`.
+Burns `shares` from `owner` and sends exactly `assets` of underlying tokens to `receiver`.
 
 MUST emit the `Withdraw` event.
 
@@ -447,7 +447,7 @@ Note that any unfavorable discrepancy between `convertToAssets` and `previewRede
 
 #### redeem
 
-Redeems exactly `shares` from `owner` and sends `assets` of underlying tokens to `receiver`.
+Burns exactly `shares` from `owner` and sends `assets` of underlying tokens to `receiver`.
 
 MUST emit the `Withdraw` event.
 

--- a/EIPS/eip-4626.md
+++ b/EIPS/eip-4626.md
@@ -479,7 +479,7 @@ Note that some implementations will require pre-requesting to the Vault before a
 
 #### Deposit
 
-`sender` has exchanged `assets` for `shares`, and transferred those `shares` to `receiver`.
+`caller` has exchanged `assets` for `shares`, and transferred those `shares` to `receiver`.
 
 MUST be emitted when tokens are deposited into the Vault via the `mint` and `deposit` methods.
 
@@ -489,7 +489,7 @@ MUST be emitted when tokens are deposited into the Vault via the `mint` and `dep
   type: event
 
   inputs:
-  - name: sender
+  - name: caller
     indexed: true
     type: address
   - name: receiver
@@ -505,7 +505,7 @@ MUST be emitted when tokens are deposited into the Vault via the `mint` and `dep
 
 #### Withdraw
 
-`sender` has exchanged `shares` for `assets`, and transferred those `assets` to `receiver`.
+`caller` has exchanged `shares` for `assets`, and transferred those `assets` to `receiver`.
 
 MUST be emitted when shares are withdrawn from the Vault in `ERC4626.redeem` or `ERC4626.withdraw` methods.
 
@@ -514,7 +514,7 @@ MUST be emitted when shares are withdrawn from the Vault in `ERC4626.redeem` or 
   type: event
 
   inputs:
-  - name: sender
+  - name: caller
     indexed: true
     type: address
   - name: receiver

--- a/EIPS/eip-4626.md
+++ b/EIPS/eip-4626.md
@@ -36,7 +36,7 @@ which represent a claim to ownership on a fraction of the Vault's underlying hol
 All ERC-4626 tokenized Vaults MUST implement ERC-20's optional metadata extensions.
 The `name` and `symbol` functions SHOULD reflect the underlying token's `name` and `symbol` in some way.
 The value of `decimals` MUST mirror the underlying's value of `decimals`,
-which may affect precision for computing the value of Vault shares
+which may affect precision for computing the value of vault shares
 
 ERC-4626 tokenized Vaults MAY implement [EIP-2612](./eip-2612.md) to improve the UX of approving shares on various integrations.
 
@@ -153,9 +153,9 @@ This calculation MAY NOT reflect the "per-user" price-per-share, and instead sho
 
 #### maxDeposit
 
-Total number of underlying assets that can be deposited by `to` into the Vault, where `to` corresponds to the input parameter of a `deposit` call.
+Maximum amount of the underlying asset that can be deposited into the vault for the `receiver`, through a `deposit` call.
 
-MUST return a limited value if `to` is subject to some deposit limit.
+MUST return a limited value if `receiver` is subject to some deposit limit.
 
 MUST return `2 ** 256 - 1` if there is no limit on the maximum amount of assets that may be deposited.
 
@@ -167,7 +167,7 @@ MUST _NOT_ revert.
   stateMutability: view
 
   inputs:
-  - name: to
+  - name: receiver
     type: address
 
   outputs:
@@ -179,7 +179,7 @@ MUST _NOT_ revert.
 
 Allows an on-chain or off-chain user to simulate the effects of their deposit at the current block, given current on-chain conditions.
 
-MUST return as close to and no more than the exact amount of Vault shares that would be minted in a `deposit` call in the same transaction. I.e. `deposit` should return the same or more `shares` as `previewDeposit` if called in the same transaction.
+MUST return as close to and no more than the exact amount of vault shares that would be minted in a `deposit` call in the same transaction. I.e. `deposit` should return the same or more `shares` as `previewDeposit` if called in the same transaction.
 
 MUST NOT account for deposit limits like those returned from maxDeposit and should always act as though the deposit would be accepted, regardless if the user has enough tokens approved, etc.
 
@@ -205,7 +205,7 @@ Note that any unfavorable discrepancy between `convertToShares` and `previewDepo
 
 #### deposit
 
-Mints `shares` Vault shares to `receiver` by depositing exactly `amount` of underlying tokens.
+Mints `shares` vault shares to `receiver` by depositing exactly `amount` of underlying tokens.
 
 MUST emit the `Deposit` event.
 
@@ -233,9 +233,9 @@ Note that most implementations will require pre-approval of the Vault with the V
 
 #### maxMint
 
-Total number of underlying shares that can be minted for `to`, where `to` corresponds to the input parameter of a `mint` call.
+Maximum amount of the vault shares that can be minted for the `receiver`, through a `mint` call.
 
-MUST return a limited value if `to` is subject to some deposit limit.
+MUST return a limited value if `receiver` is subject to some mint limit.
 
 MUST return `2 ** 256 - 1` if there is no limit on the maximum amount of shares that may be minted.
 
@@ -247,7 +247,7 @@ MUST _NOT_ revert.
   stateMutability: view
 
   inputs:
-  - name: to
+  - name: receiver
     type: address
 
   outputs:
@@ -286,7 +286,7 @@ Note that any unfavorable discrepancy between `convertToAssets` and `previewMint
 
 #### mint
 
-Mints exactly `shares` Vault shares to `receiver` by depositing `amount` of underlying tokens.
+Mints exactly `shares` vault shares to `receiver` by depositing `amount` of underlying tokens.
 
 MUST emit the `Deposit` event.
 
@@ -314,9 +314,9 @@ Note that most implementations will require pre-approval of the Vault with the V
 
 #### maxWithdraw
 
-Total number of underlying assets that can be withdrawn from the Vault by `from`, where `from` corresponds to the input parameter of a `withdraw` call.
+Maximum amount of the underlying asset that can be withdrawn from the `owner` balance in the Vault, through a `withdraw` call.
 
-MUST return a limited value if `from` is subject to some withdrawal limit or timelock.
+MUST return a limited value if `owner` is subject to some withdrawal limit or timelock.
 
 MUST _NOT_ revert.
 
@@ -326,7 +326,7 @@ MUST _NOT_ revert.
   stateMutability: view
 
   inputs:
-  - name: from
+  - name: owner
     type: address
 
   outputs:
@@ -338,7 +338,7 @@ MUST _NOT_ revert.
 
 Allows an on-chain or off-chain user to simulate the effects of their withdrawal at the current block, given current on-chain conditions.
 
-MUST return as close to and no fewer than the exact amount of Vault shares that would be burned in a `withdraw` call in the same transaction. I.e. `withdraw` should return the same or fewer `shares` as `previewWithdraw` if called in the same transaction.
+MUST return as close to and no fewer than the exact amount of vault shares that would be burned in a `withdraw` call in the same transaction. I.e. `withdraw` should return the same or fewer `shares` as `previewWithdraw` if called in the same transaction.
 
 MUST NOT account for withdrawal limits like those returned from maxWithdraw and should always act as though the withdrawal would be accepted, regardless if the user has enough shares, etc.
 
@@ -365,7 +365,7 @@ Note that any unfavorable discrepancy between `convertToShares` and `previewWith
 
 #### withdraw
 
-Redeems `shares` from `owner` and sends `assets` of underlying tokens to `receiver`.
+Redeems `shares` from `owner` and sends exactly `assets` of underlying tokens to `receiver`.
 
 MUST emit the `Withdraw` event.
 
@@ -395,11 +395,11 @@ Note that some implementations will require pre-requesting to the Vault before a
 
 #### maxRedeem
 
-Total number of underlying shares that can redeemed from the Vault by `from`, where `from` corresponds to the input parameter of a `redeem` call.
+Maximum amount of vault shares that can be redeemed from the `owner` balance in the Vault, through a `redeem` call.
 
-MUST return a limited value if `from` is subject to some withdrawal limit or timelock.
+MUST return a limited value if `owner` is subject to some withdrawal limit or timelock.
 
-MUST return `balanceOf(from)` if `from` is not subject to any withdrawal limit or timelock.
+MUST return `balanceOf(owner)` if `owner` is not subject to any withdrawal limit or timelock.
 
 MUST _NOT_ revert.
 
@@ -409,7 +409,7 @@ MUST _NOT_ revert.
   stateMutability: view
 
   inputs:
-  - name: caller
+  - name: owner
     type: address
 
   outputs:
@@ -447,7 +447,7 @@ Note that any unfavorable discrepancy between `convertToAssets` and `previewRede
 
 #### redeem
 
-Redeems `shares` from `owner` and sends `assets` of underlying tokens to `receiver`.
+Redeems exactly `shares` from `owner` and sends `assets` of underlying tokens to `receiver`.
 
 MUST emit the `Withdraw` event.
 

--- a/EIPS/eip-4626.md
+++ b/EIPS/eip-4626.md
@@ -36,7 +36,7 @@ which represent a claim to ownership on a fraction of the Vault's underlying hol
 All ERC-4626 tokenized Vaults MUST implement ERC-20's optional metadata extensions.
 The `name` and `symbol` functions SHOULD reflect the underlying token's `name` and `symbol` in some way.
 The value of `decimals` MUST mirror the underlying's value of `decimals`,
-which may affect precision for computing the value of vault shares
+which may affect precision for computing the value of Vault shares
 
 ERC-4626 tokenized Vaults MAY implement [EIP-2612](./eip-2612.md) to improve the UX of approving shares on various integrations.
 
@@ -97,7 +97,7 @@ MUST _NOT_ revert.
 
 #### convertToShares
 
-The amount of shares that the vault would exchange for the amount of assets provided, in an ideal scenario where all the conditions are met.
+The amount of shares that the Vault would exchange for the amount of assets provided, in an ideal scenario where all the conditions are met.
 
 MUST NOT be inclusive of any fees that are charged against assets in the Vault.
 
@@ -125,7 +125,7 @@ This calculation MAY NOT reflect the "per-user" price-per-share, and instead sho
 
 #### convertToAssets
 
-The amount of assets that the vault would exchange for the amount of shares provided, in an ideal scenario where all the conditions are met.
+The amount of assets that the Vault would exchange for the amount of shares provided, in an ideal scenario where all the conditions are met.
 
 MUST NOT be inclusive of any fees that are charged against assets in the Vault.
 
@@ -153,7 +153,7 @@ This calculation MAY NOT reflect the "per-user" price-per-share, and instead sho
 
 #### maxDeposit
 
-Maximum amount of the underlying asset that can be deposited into the vault for the `receiver`, through a `deposit` call.
+Maximum amount of the underlying asset that can be deposited into the Vault for the `receiver`, through a `deposit` call.
 
 MUST return a limited value if `receiver` is subject to some deposit limit.
 
@@ -179,7 +179,7 @@ MUST _NOT_ revert.
 
 Allows an on-chain or off-chain user to simulate the effects of their deposit at the current block, given current on-chain conditions.
 
-MUST return as close to and no more than the exact amount of vault shares that would be minted in a `deposit` call in the same transaction. I.e. `deposit` should return the same or more `shares` as `previewDeposit` if called in the same transaction.
+MUST return as close to and no more than the exact amount of Vault shares that would be minted in a `deposit` call in the same transaction. I.e. `deposit` should return the same or more `shares` as `previewDeposit` if called in the same transaction.
 
 MUST NOT account for deposit limits like those returned from maxDeposit and should always act as though the deposit would be accepted, regardless if the user has enough tokens approved, etc.
 
@@ -205,7 +205,7 @@ Note that any unfavorable discrepancy between `convertToShares` and `previewDepo
 
 #### deposit
 
-Mints `shares` vault shares to `receiver` by depositing exactly `amount` of underlying tokens.
+Mints `shares` Vault shares to `receiver` by depositing exactly `amount` of underlying tokens.
 
 MUST emit the `Deposit` event.
 
@@ -233,7 +233,7 @@ Note that most implementations will require pre-approval of the Vault with the V
 
 #### maxMint
 
-Maximum amount of the vault shares that can be minted for the `receiver`, through a `mint` call.
+Maximum amount of the Vault shares that can be minted for the `receiver`, through a `mint` call.
 
 MUST return a limited value if `receiver` is subject to some mint limit.
 
@@ -286,7 +286,7 @@ Note that any unfavorable discrepancy between `convertToAssets` and `previewMint
 
 #### mint
 
-Mints exactly `shares` vault shares to `receiver` by depositing `amount` of underlying tokens.
+Mints exactly `shares` Vault shares to `receiver` by depositing `amount` of underlying tokens.
 
 MUST emit the `Deposit` event.
 
@@ -338,7 +338,7 @@ MUST _NOT_ revert.
 
 Allows an on-chain or off-chain user to simulate the effects of their withdrawal at the current block, given current on-chain conditions.
 
-MUST return as close to and no fewer than the exact amount of vault shares that would be burned in a `withdraw` call in the same transaction. I.e. `withdraw` should return the same or fewer `shares` as `previewWithdraw` if called in the same transaction.
+MUST return as close to and no fewer than the exact amount of Vault shares that would be burned in a `withdraw` call in the same transaction. I.e. `withdraw` should return the same or fewer `shares` as `previewWithdraw` if called in the same transaction.
 
 MUST NOT account for withdrawal limits like those returned from maxWithdraw and should always act as though the withdrawal would be accepted, regardless if the user has enough shares, etc.
 
@@ -395,7 +395,7 @@ Note that some implementations will require pre-requesting to the Vault before a
 
 #### maxRedeem
 
-Maximum amount of vault shares that can be redeemed from the `owner` balance in the Vault, through a `redeem` call.
+Maximum amount of Vault shares that can be redeemed from the `owner` balance in the Vault, through a `redeem` call.
 
 MUST return a limited value if `owner` is subject to some withdrawal limit or timelock.
 
@@ -554,7 +554,7 @@ but `preview*` methods have been included for each one of the four mutable metho
 In each case, the value of a preview method is only guaranteed to equal the return value of the related mutable method
 if called immediately before in the same transaction.
 
-The `max*` methods are used to check for deposit/withdraw limits on vault capacity. These can be consumed off-chain for more user focused applications or on-chain for more on-chain aggregation/integration use cases.
+The `max*` methods are used to check for deposit/withdraw limits on Vault capacity. These can be consumed off-chain for more user focused applications or on-chain for more on-chain aggregation/integration use cases.
 
 If implementors intend to support EOA account access directly, they should consider adding an additional function with the means to accommodate slippage loss or deposit/withdrawal limits,
 since their transaction will revert if the exact amount is not achieved.


### PR DESCRIPTION
 - Use `owner` and `receiver` consistently, and rework the sentences where they appear for better grammatical flow and precision.
 - Talk about vault shares in lowercase
 - Introduce a couple of missing "exactly" remarks.