### PR TITLE
EIP 4626 - Removed outdated info from rationale

### DIFF
--- a/EIPS/eip-4626.md
+++ b/EIPS/eip-4626.md
@@ -543,21 +543,9 @@ Most current use cases of share-based Vaults do not ascribe special meaning to t
 a user would optimize for a specific number of shares (`mint`) rather than specific amount of underlying (`deposit`).
 However, it is easy to imagine future Vault strategies which would have unique and independently useful share representations.
 
-A single `assetsPerShare` method can only be guaranteed to be exact with one of the four mutable methods,
-unless significant conditions are placed on the use cases that can comply with this standard.
-Use cases that require to know the value of a Vault position need to know the result of a `redeem` call, without executing it.
-On the other hand, integrators that intend to call `withdraw` on Vaults with the user approving only the exact amount of
-underlying need the result of a `withdraw` call. Similar use cases can be found for `deposit` and `mint`.
-
-As such, the `assetsPerShare` method has been kept for ease of integration on part of the simpler use cases,
-but `preview*` methods have been included for each one of the four mutable methods.
-In each case, the value of a preview method is only guaranteed to equal the return value of the related mutable method
-if called immediately before in the same transaction.
-
 The `max*` methods are used to check for deposit/withdraw limits on vault capacity. These can be consumed off-chain for more user focused applications or on-chain for more on-chain aggregation/integration use cases.
 
-If implementors intend to support EOA account access directly, they should consider adding an additional function with the means to accommodate slippage loss or deposit/withdrawal limits,
-since their transaction will revert if the exact amount is not achieved.
+If implementors intend to support EOA account access directly, they should consider adding an additional function with the means to accommodate slippage loss or deposit/withdrawal limits, since their transaction will revert if the exact amount is not achieved.
 
 ## Backwards Compatibility
 

--- a/EIPS/eip-4626.md
+++ b/EIPS/eip-4626.md
@@ -545,8 +545,6 @@ However, it is easy to imagine future Vault strategies which would have unique a
 
 The `max*` methods are used to check for deposit/withdraw limits on vault capacity. These can be consumed off-chain for more user focused applications or on-chain for more on-chain aggregation/integration use cases.
 
-If implementors intend to support EOA account access directly, they should consider adding an additional function with the means to accommodate slippage loss or deposit/withdrawal limits, since their transaction will revert if the exact amount is not achieved.
-
 ## Backwards Compatibility
 
 ERC-4626 is fully backward compatible with the ERC-20 standard and has no known compatibility issues with other standards.
@@ -566,6 +564,8 @@ This specification has similar security considerations to the ERC-20 interface.
 
 Fully permissionless use cases could fall prey to malicious implementations which only conform to the interface but not the specification.
 It is recommended that all integrators review the implementation for potential ways of losing user deposits before integrating.
+
+If implementors intend to support EOA account access directly, they should consider adding an additional function call for `deposit`/`mint`/`withdraw`/`redeem` with the means to accommodate slippage loss or unexpected deposit/withdrawal limits, since they have no other means to revert the transaction if the exact output amount is not achieved.
 
 The methods `totalAssets`, `convertToShares` and `convertToAssets` are estimates useful for display purposes,
 and do _not_ have to confer the _exact_ amount of underlying assets their context suggests.


### PR DESCRIPTION
The reasons for `preview*` and `convert*` functions can now be easily inferred from the security considerations.