### PR TITLE
EIP-4399: Rename RANDOM to PREVRANDAO

### DIFF
--- a/EIPS/eip-4399.md
+++ b/EIPS/eip-4399.md
@@ -1,6 +1,6 @@
 ---
 eip: 4399
-title: Supplant DIFFICULTY opcode with RANDOM
+title: Supplant DIFFICULTY opcode with PREVRANDAO
 description: Expose beacon chain randomness in the EVM by supplanting DIFFICULTY opcode semantics
 author: Mikhail Kalinin (@mkalinin), Danny Ryan (@djrtwo)
 discussions-to: https://ethereum-magicians.org/t/eip-4399-supplant-difficulty-opcode-with-random/7368
@@ -13,20 +13,20 @@ requires: 3675
 
 ## Abstract
 
-This EIP supplants the semantics of the return value of existing `DIFFICULTY (0x44)` opcode and renames the opcode to `RANDOM (0x44)`.
+This EIP supplants the semantics of the return value of existing `DIFFICULTY (0x44)` opcode and renames the opcode to `PREVRANDAO (0x44)`.
 
-The return value of the `DIFFICULTY (0x44)` opcode after this change is the output of the randomness beacon provided by the beacon chain.
+The return value of the `DIFFICULTY (0x44)` instruction after this change is the output of the randomness beacon provided by the beacon chain.
 
 
 ## Motivation
 
 Applications may benefit from using the randomness accumulated by the beacon chain. Thus, randomness outputs produced by the beacon chain should be accessible in the EVM.
 
-At the point of `TRANSITION_BLOCK` of the Proof-of-Stake (PoS) upgrade described in [EIP-3675](./eip-3675.md), the `difficulty` block field **MUST** be `0` thereafter because there is no longer any Proof-of-Work (PoW) seal on the block. This means that the `DIFFICULTY` instruction no longer has it's previous semantic meaning, nor a clear "correct" value to return.
+At the point of `TRANSITION_BLOCK` of the Proof-of-Stake (PoS) upgrade described in [EIP-3675](./eip-3675.md), the `difficulty` block field **MUST** be `0` thereafter because there is no longer any Proof-of-Work (PoW) seal on the block. This means that the `DIFFICULTY (0x44)` instruction no longer has it's previous semantic meaning, nor a clear "correct" value to return.
 
-Given prior analysis on the usage of `DIFFICULTY`, the value returned by the opcode mixed with other values is a common pattern used by smart contracts to obtain randomness. The instruction with the same number as the `DIFFICULTY` opcode returning the output of the beacon chain randomness makes the upgrade to PoS backwards compatible for existing smart contracts obtaining randomness from the `DIFFICULTY` opcode.
+Given prior analysis on the usage of `DIFFICULTY`, the value returned by the instruction mixed with other values is a common pattern used by smart contracts to obtain randomness. The instruction with the same number as the `DIFFICULTY` opcode returning outputs of the beacon chain RANDAO implementation makes the upgrade to PoS backwards compatible for existing smart contracts obtaining randomness from the `DIFFICULTY` instruction.
 
-Additionally, changes proposed by this EIP allow for smart contracts to determine whether the upgrade to the PoS has already happened. This can be done by analyzing the return value of the `DIFFICULTY` opcode. A value greater than `2**64` indicates that the transaction is being executed in the PoS block. Decompilers and other similar tooling may also use this trick to discern the new semantics of the opcode if block header data is available.
+Additionally, changes proposed by this EIP allow for smart contracts to determine whether the upgrade to the PoS has already happened. This can be done by analyzing the return value of the `DIFFICULTY` instruction. A value greater than `2**64` indicates that the transaction is being executed in the PoS block. Decompilers and other similar tooling may also use this trick to discern the new semantics of the instruction if data of the block including the transaction in question is available.
 
 
 ## Specification
@@ -37,7 +37,7 @@ Additionally, changes proposed by this EIP allow for smart contracts to determin
 
 ### Block structure
 
-Beginning with `TRANSITION_BLOCK`, client software **MUST** set the value of the `mixHash`, i.e. the field with the number `13` (0-indexed) in a block header, to the output of the randomness beacon provided by the beacon chain.
+Beginning with `TRANSITION_BLOCK`, client software **MUST** set the value of the `mixHash`, i.e. the field with the number `13` (0-indexed) in a block header, to the beacon chain RANDAO output of the previous block. That is, the output obtained from the result of applying beacon chain state transition function to the parent block.
 
 ### EVM
 
@@ -47,16 +47,16 @@ Beginning with `TRANSITION_BLOCK`, the `DIFFICULTY (0x44)` instruction **MUST** 
 
 ### Renaming
 
-The `mixHash` field **SHOULD** further be renamed to `random`.
+The `mixHash` field **SHOULD** further be renamed to `prevRandao`.
 
-The `DIFFICULTY (0x44)` opcode **SHOULD** further be renamed to `RANDOM (0x44)`.
+The `DIFFICULTY (0x44)` opcode **SHOULD** further be renamed to `PREVRANDAO (0x44)`.
 
 
 ## Rationale
 
-### Including randomness output in the block header
+### Including RANDAO output in the block header
 
-Including the randomness output in the block header provides a straightforward method of accessing it from inside of the EVM as block header data is already available in the EVM context.
+Including a RANDAO output in the block header provides a straightforward method of accessing it from inside of the EVM as block header data is already available in the EVM context.
 
 Additionally, this ensures that the execution layer can be fully executed with the block alone rather than requiring extra inputs from the PoS consensus layer.
 
@@ -90,7 +90,7 @@ By tightly coupling to the PoS upgrade, we ensure that there is no discontinuity
 
 ### Using `2**64` threshold to determine PoS blocks
 
-The probability of randomness output to fall into the range between `0` and `2**64` and, thus, to be mixed with PoW difficulty values, is drastically low. Though, proposed threshold might seem to have insufficient distance from difficulty values on Ethereum Mainnet (they are currently around `2**54`), it requires a thousand times increase of the hashrate to make this threshold insecure. Such an increase is considered impossible to occur before the upcoming consensus upgrade.
+The probability of RANDAO value to fall into the range between `0` and `2**64` and, thus, to be mixed with PoW difficulty values, is drastically low. Though, proposed threshold might seem to have insufficient distance from difficulty values on Ethereum Mainnet (they are currently around `2**54`), it requires a thousand times increase of the hashrate to make this threshold insecure. Such an increase is considered impossible to occur before the upcoming consensus upgrade.
 
 
 ## Backwards Compatibility
@@ -113,13 +113,15 @@ Testing this functionality goes beyond this document and should be done in a for
 
 ## Security Considerations
 
-The `RANDOM` opcode in PoS Ethereum (based on the beacon chain RANDAO implementation) is a source of randomness with different properties to the randomness supplied by `BLOCKHASH` or `DIFFICULTY` opcodes in the PoW network.
+The `PREVRANDAO (0x44)` opcode in PoS Ethereum (based on the beacon chain RANDAO implementation) is a source of randomness with different properties to the randomness supplied by `BLOCKHASH (0x40)` or `DIFFICULTY (0x44)` opcodes in the PoW network.
 
 ### Biasability
 
 The beacon chain RANDAO implementation gives every block proposer 1 bit of influence power per slot. Proposer may deliberately refuse to propose a block on the opportunity cost of proposer and transaction fees to prevent beacon chain randomness (a RANDAO mix) from being updated in a particular slot.
 
-An effect of proposer's influence power is limited in time and lasts until the first honest RANDAO reveal is made afterwards. This limitation does also exist in the case when proposers of `n` consecutive slots are colluding to get `n` bits of influence power. Simply speaking, one honest block proposal is enough to produce an unbiased RANDAO mix disregarding the size of influence power gained by proposers of previous slots.
+An effect of proposer's influence power is limited in time and lasts until the first honest RANDAO reveal is made afterwards. This limitation does also exist in the case when proposers of `n` consecutive slots are colluding to get `n` bits of influence power. Simply speaking, one honest block proposal is enough to restore unbiasability of the RANDAO disregarding the size of influence power gained by proposers of previous slots.
+
+Additionally, semantics of the `PREVRANDAO (0x44)` instruction gives proposers another way to gain 1 bit of influence power on applications. Biased proposer may censor a rolling the dice transaction to force it to be included into the next block, thus, force it to use a RANDAO mix that the proposer knows in advance. The opportunity cost in this case would be negligible.
 
 ### Predictability
 
@@ -135,6 +137,8 @@ These inputs may be predictable and malleable on a short range of slots but the 
 
 ### Tips for application developers
 
+The following tips attempt to reduce predictability and biasability of randomness outputs returned by `PREVRANDAO (0x44)`:
+
 1. Make your applications rely on the future randomness with a reasonably high lookahead. For example, an application stops accepting bids at the end of epoch `K` and uses a RANDAO mix produced in slot `K + N + ε` to roll the dice, where `N` is a lookahead in epochs and `ε` is a few slots into epoch `N + 1`.
 2. At least four epochs of lookahead results in the following outcome:
   * A proposer set of epoch `N + 1` isn't known at the end of epoch `K` breaking a direct link between bidders and dice rollers
@@ -142,9 +146,8 @@ These inputs may be predictable and malleable on a short range of slots but the 
   * Due to Mainnet statistics, there is about a `100%` chance for the network to accidentally miss a proposal during this period of time which reduces predictability of a RANDAO mix used to roll the dice.
 3. Setting `ε` to a small number, e.g. 2 or 4 slots, gives a third party a little time to gain influence power on the future randomness that is being used to roll the dice. This amount of time is defined by `MIN_SEED_LOOKAHEAD` parameter and is about 6 minutes on the Mainnet.
 
-These tips attempt to significantly reduce predictability and biasability of randomness used by an application. Keeping a reasonably high distance between bidding and rolling the dice leaves a negligible chance for validators which have decided to become bidders to directly exploit their influence power.
+A reasonably high distance between bidding and rolling the dice attempts to leave low chance for bidders controlling a subset of validators to directly exploit their influence power. Ultimately, this chance depends on the type of the game and on a number of controlled validators. For instance, a chance of a single validator to affect a one-time game is negligible, and becomes bigger for multiple validators in a repeated game scenario.
 
-Though, a third party bidder may still bribe proposers in an attempt to impact the process of rolling the dice. Bribed proposer has options to either refuse to propose a block or censor a transaction that rolls the dice to make it included in a future block resulting in a better payout for a briber. A fast off chain communication channel between bribers and proposers, and a sequence of dishonest proposers willing to collude near a slot in question would give a chance for a third party to gain a few bits of influence power.
 
 ## Copyright
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/EIPS/eip-4399.md
+++ b/EIPS/eip-4399.md
@@ -37,7 +37,7 @@ Additionally, changes proposed by this EIP allow for smart contracts to determin
 
 ### Block structure
 
-Beginning with `TRANSITION_BLOCK`, client software **MUST** set the value of the `mixHash`, i.e. the field with the number `13` (0-indexed) in a block header, to the beacon chain RANDAO output of the previous block. That is, the output obtained from the result of applying beacon chain state transition function to the parent block.
+Beginning with `TRANSITION_BLOCK`, client software **MUST** set the value of the `mixHash`, i.e. the field with the number `13` (0-indexed) in a block header, to the latest RANDAO mix of the post beacon state of the previous block.
 
 ### EVM
 
@@ -119,7 +119,7 @@ The `PREVRANDAO (0x44)` opcode in PoS Ethereum (based on the beacon chain RANDAO
 
 The beacon chain RANDAO implementation gives every block proposer 1 bit of influence power per slot. Proposer may deliberately refuse to propose a block on the opportunity cost of proposer and transaction fees to prevent beacon chain randomness (a RANDAO mix) from being updated in a particular slot.
 
-An effect of proposer's influence power is limited in time and lasts until the first honest RANDAO reveal is made afterwards. This limitation does also exist in the case when proposers of `n` consecutive slots are colluding to get `n` bits of influence power. Simply speaking, one honest block proposal is enough to restore unbiasability of the RANDAO disregarding the size of influence power gained by proposers of previous slots.
+An effect of proposer's influence power is limited in time and lasts until the first honest RANDAO reveal is made afterwards. This limitation does also exist in the case when proposers of `n` consecutive slots are colluding to get `n` bits of influence power. Simply speaking, one honest block proposal is enough to unbias the RANDAO even if it was biased during several slots in a row.
 
 Additionally, semantics of the `PREVRANDAO (0x44)` instruction gives proposers another way to gain 1 bit of influence power on applications. Biased proposer may censor a rolling the dice transaction to force it to be included into the next block, thus, force it to use a RANDAO mix that the proposer knows in advance. The opportunity cost in this case would be negligible.
 


### PR DESCRIPTION
* Renames the EIP, opcode and block header field
* Adjusts specification and other sections accordingly
* A bit of polishing here and there