### PR TITLE
fix typed structure indentation in eip-2612.md

### DIFF
--- a/EIPS/eip-2612.md
+++ b/EIPS/eip-2612.md
@@ -128,13 +128,14 @@ In other words, the message is the ERC-712 typed structure:
         "name": "deadline",
         "type": "uint256"
       }
-    ],
-    "primaryType": "Permit",
-    "domain": {
-      "name": erc20name,
-      "version": version,
-      "chainId": chainid,
-      "verifyingContract": tokenAddress
+    ]
+  },
+  "primaryType": "Permit",
+  "domain": {
+    "name": erc20name,
+    "version": version,
+    "chainId": chainid,
+    "verifyingContract": tokenAddress
   },
   "message": {
     "owner": owner,
@@ -143,7 +144,7 @@ In other words, the message is the ERC-712 typed structure:
     "nonce": nonce,
     "deadline": deadline
   }
-}}
+}
 ```
 
 Note that nowhere in this definition we refer to `msg.sender`. The caller of the `permit` function can be any address.


### PR DESCRIPTION
per https://eips.ethereum.org/EIPS/eip-712, 'types', 'primaryType', 'domain', 'message' should be at the same indentation level. currently it's incorrect and thus misleading.

I reported the issue at #4856

When opening a pull request to submit a new EIP, please use the suggested template: https://github.com/ethereum/EIPs/blob/master/eip-template.md

We have a GitHub bot that automatically merges some PRs. It will merge yours immediately if certain criteria are met:

 - The PR edits only existing draft PRs.
 - The build passes.
 - Your GitHub username or email address is listed in the 'author' header of all affected PRs, inside <triangular brackets>.
 - If matching on email address, the email address is the one publicly listed on your GitHub profile.
