### PR TITLE
Add .gitpod.yml to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
+# Website packaging
 _site
 .sass-cache
 .jekyll-metadata
 vendor
+
+# Editor files
+.gitpod.yml


### PR DESCRIPTION
This allows for GitPod (https://gitpod.io/) to be used for editing, without polluting the repository with a `.gitpod.yml` file. It is currently not possible to disable this feature, so the alternative to adding it to the gitignore is manually deleting the file every other commit.