### PR TITLE
Advise against external links & add myself as an active editor

### DIFF
--- a/EIPS/eip-1.md
+++ b/EIPS/eip-1.md
@@ -207,6 +207,7 @@ The current EIP editors are
 - Matt Garnett (@lightclient)
 - Micah Zoltu (@MicahZoltu)
 - Greg Colvin (@gcolvin)
+- Sam Wilson (@SamWilsn)
 
 Emeritus EIP editors are 
 

--- a/EIPS/eip-1.md
+++ b/EIPS/eip-1.md
@@ -185,6 +185,10 @@ The `created` header records the date that the EIP was assigned a number. Both h
 
 EIPs may have a `requires` header, indicating the EIP numbers that this EIP depends on.
 
+## Linking to External Resources
+
+Links to external resources **SHOULD NOT** be included. External resources may disappear, move, or change unexpectedly.
+
 ## Linking to other EIPs
 
 References to other EIPs should follow the format `EIP-N` where `N` is the EIP number you are referring to.  Each EIP that is referenced in an EIP **MUST** be accompanied by a relative markdown link the first time it is referenced, and **MAY** be accompanied by a link on subsequent references.  The link **MUST** always be done via relative paths so that the links work in this GitHub repository, forks of this repository, the main EIPs site, mirrors of the main EIP site, etc.  For example, you would link to this EIP with `[EIP-1](./eip-1.md)`.


### PR DESCRIPTION
External links aren't durable, and may not necessarily permit redistribution. Some links _may_ be durable and permit redistribution, but determining which links are/do is a subjective and onerous task for editors.

That said, I've chosen `SHOULD NOT` over `MUST NOT` to allow for special cases.

**Note to editors**: Signal approval with a comment, just in case the bot auto-merges on approval.