### PR TITLE
add MetadataUpdate event for interface ERC721Metadata

### DIFF
--- a/EIPS/eip-721.md
+++ b/EIPS/eip-721.md
@@ -180,6 +180,11 @@ The **metadata extension** is OPTIONAL for ERC-721 smart contracts (see "caveats
 /// @dev See https://eips.ethereum.org/EIPS/eip-721
 ///  Note: the ERC-165 identifier for this interface is 0x5b5e139f.
 interface ERC721Metadata /* is ERC721 */ {
+    /// @dev This event emits when the result of tokenURI(_tokenID) will be 
+    /// changed. So that the third parties such as NFT market could timely 
+    /// update the NFT images and related attributes.
+    event MetadataUpdated(uint256 indexed _tokenId);
+
     /// @notice A descriptive name for a collection of NFTs in this contract
     function name() external view returns (string _name);
 


### PR DESCRIPTION
Add MetadataUpdated event for ERC721Metadata. 

This event emits when the result of tokenURI(_tokenID) will be  changed. So that the third parties such as NFT market could timely  update the NFT images and related attributes.