### PR TITLE
[DRAFT] ERC-4884 Rentable NFT Standard

### DIFF
--- a/EIPS/eip-4884.md
+++ b/EIPS/eip-4884.md
@@ -2,7 +2,7 @@
 eip: 4884
 title: Rentable NFT Standard
 description: An extension for NFT contracts to enable tokens to be rentable
-author: Muhammed Emin Aydın (@muhammedea)
+author: Muhammed Emin Aydın (@muhammedea), Dmitry Savonin (@dmitry123)
 discussions-to: https://github.com/ethereum/EIPs/issues/4918
 status: Draft
 type: Standards Track

--- a/EIPS/eip-4884.md
+++ b/EIPS/eip-4884.md
@@ -2,7 +2,7 @@
 eip: 4884
 title: Renting Extension For ERC-721 Standard
 description: An extension of the ERC-721 standard to enable NFT tokens to be rentable
-author: @muhammedea (muhammedea@gmail.com)
+author: Muhammed Emin Aydın (@muhammedea)
 discussions-to: https://github.com/ethereum/EIPs/issues/4918
 status: Draft
 type: Standards Track

--- a/EIPS/eip-4884.md
+++ b/EIPS/eip-4884.md
@@ -1,6 +1,6 @@
 ---
-eip: <to be assigned>
-title: Renting Extension For ERC-721 Standart
+eip: 4884
+title: Renting Extension For ERC-721 Standard
 description: An extension of the ERC-721 standard to enable NFT tokens to be rentable 
 author: @muhammedea (muhammedea@gmail.com)
 discussions-to: 
@@ -11,11 +11,11 @@ created: 2022-02-15
 requires: 165
 ---
 
-# Renting Extension For ERC-721 Standart
+# Renting Extension For ERC-721 Standard
 
 ## Abstract
 
-This extension defines some extra functions to the ERC-721 standart for renting NFT tokens to another account.
+This extension defines some extra functions to the ERC-721 standard for renting NFT tokens to another account.
 This helps NFT owners to rent their assets to someone for some period of time. 
 Because an ERC-721 contract can have fungible tokens (FT) and non-fungible tokens (NFT), this functionality will be usable by only NFTs.
 It's significantly important for the gaming industry where such NFTs might have additional abilities that affect the gaming process.
@@ -81,4 +81,9 @@ interface ERC721Rentable /* is ERC165 */ {
     */
     function isRented(uint256 tokenId) external returns (bool);
 }
+```
 
+## Security Considerations
+No security considerations.
+## Copyright
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/EIPS/eip-4884.md
+++ b/EIPS/eip-4884.md
@@ -1,7 +1,7 @@
 ---
 eip: 4884
-title: Renting Extension For ERC-721 Standard
-description: An extension of the ERC-721 standard to enable NFT tokens to be rentable
+title: Rentable NFT Standard
+description: An extension for NFT contracts to enable tokens to be rentable
 author: Muhammed Emin Aydın (@muhammedea)
 discussions-to: https://github.com/ethereum/EIPs/issues/4918
 status: Draft
@@ -11,20 +11,35 @@ created: 2022-02-15
 requires: 165
 ---
 
-# Renting Extension For ERC-721 Standard
+# Renting Extension For NFT Contracts
 
 ## Abstract
 
 This extension defines some extra functions to the ERC-721 standard for renting NFT tokens to another account.
-This helps NFT owners to rent their assets to someone for some period of time. 
-Because an ERC-721 contract can have fungible tokens (FT) and non-fungible tokens (NFT), this functionality will be usable by only NFTs.
-It's significantly important for the gaming industry where such NFTs might have additional abilities that affect the gaming process.
+This enables NFT owners to rent their assets to someone else for some period of time. 
+So the owner of the token will be changed temporarily. 
+
+This can be applied to ERC-1155 tokens too. 
+Because an ERC-1155 contract can have fungible tokens (FT) and non-fungible tokens (NFT), so this functionality will be usable by only NFTs.
+So the contract should implement [split id proposal](https://eips.ethereum.org/EIPS/eip-1155#split-id-bits) in ERC-1155 standard
+
+## Motivation
+
+This kind of functionality is specifically important for gaming industry. 
+It is important for a gamer to have the ability to give an NFT to someone else for a period of time. 
+For example, you can give an NFT to someone else for playing for a period of time. So sharing an NFT will be possible.
 
 
 ## Specification
 
-This functionality will be usable for only NFT tokens. This requires that the contract should implement the split id functionality. 
-So if the most significant bit of the token id is 1 then that token is NFT.
+This specification defines an interface for ERC-721 and ERC-1155 contracts. 
+
+**rentOut** function will transfer the ownership to the renter. 
+After the renting period has passed, the actual owner can use **finishRenting** function to take the ownership back.
+Renter can finish renting earlier than that.
+
+**principalOwner** and **isRented** functions are helper functions.
+
 
 ```solidity
 pragma solidity ^0.8.0;
@@ -40,7 +55,7 @@ interface ERC721Rentable /* is ERC165 */ {
         renter: renter address
         expiresAt:  end of renting period as timestamp
     */
-    event Rented(uint256 indexed tokenId, address indexed lord, address indexed renter, uint256 expiresAt);
+    event Rented(uint256 indexed tokenId, address indexed owner, address indexed renter, uint256 expiresAt);
 
     /**
         @dev This event will be emitted when renting is finished by the owner or renter
@@ -49,11 +64,11 @@ interface ERC721Rentable /* is ERC165 */ {
         renter: renter address
         expiresAt:  end of renting period as timestamp
     */
-    event FinishedRent(uint256 indexed tokenId, address indexed lord, address indexed renter, uint256 expiresAt);
+    event FinishedRent(uint256 indexed tokenId, address indexed owner, address indexed renter, uint256 expiresAt);
 
     /**
         @notice rentOut
-        @dev rent a token to another address
+        @dev Rent a token to another address. This will change the owner.
         @param renter: renter address
         @param tokenId: token id to be rented
         @param expiresAt: end of renting period as timestamp 
@@ -62,21 +77,21 @@ interface ERC721Rentable /* is ERC165 */ {
 
     /**
         @notice finishRenting
-        @dev  Renter can run this anytime but owner can run after expire time.
+        @dev This will returns the token, back to the actual owner. Renter can run this anytime but owner can run after expire time.
         @param tokenId: token id
     */
     function finishRenting(uint256 tokenId) external;
 
     /**
         @notice principalOwner
-        @dev  get the actual ownert of the rented token
+        @dev  Get the actual owner of the rented token
         @param tokenId: token id
     */
     function principalOwner(uint256 tokenId) external returns (address);
 
     /**
         @notice isRented
-        @dev  get whether or not the token is rented
+        @dev  Get whether or not the token is rented
         @param tokenId: token id
     */
     function isRented(uint256 tokenId) external returns (bool);
@@ -84,6 +99,11 @@ interface ERC721Rentable /* is ERC165 */ {
 ```
 
 ## Security Considerations
-No security considerations.
+### Transfer Checks
+A rented token can not be transferred to someone else. So on every transfer the token status should be checked. 
+If the token is rented, it can not be transferred to someone else.
+### Finishing Renting
+**finishRenting** function can be called by the renter anytime, but the owner can run only after expire time.
+
 ## Copyright
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/EIPS/eip-4884.md
+++ b/EIPS/eip-4884.md
@@ -1,9 +1,9 @@
 ---
 eip: 4884
 title: Renting Extension For ERC-721 Standard
-description: An extension of the ERC-721 standard to enable NFT tokens to be rentable 
+description: An extension of the ERC-721 standard to enable NFT tokens to be rentable
 author: @muhammedea (muhammedea@gmail.com)
-discussions-to: 
+discussions-to: https://github.com/ethereum/EIPs/issues/4918
 status: Draft
 type: Standards Track
 category: ERC

--- a/EIPS/eip-rentable-nft.md
+++ b/EIPS/eip-rentable-nft.md
@@ -1,0 +1,84 @@
+---
+eip: <to be assigned>
+title: Renting Extension For ERC-721 Standart
+description: An extension of the ERC-721 standard to enable NFT tokens to be rentable 
+author: @muhammedea (muhammedea@gmail.com)
+discussions-to: 
+status: Draft
+type: Standards Track
+category: ERC
+created: 2022-02-15
+requires: 165
+---
+
+# Renting Extension For ERC-721 Standart
+
+## Abstract
+
+This extension defines some extra functions to the ERC-721 standart for renting NFT tokens to another account.
+This helps NFT owners to rent their assets to someone for some period of time. 
+Because an ERC-721 contract can have fungible tokens (FT) and non-fungible tokens (NFT), this functionality will be usable by only NFTs.
+It's significantly important for the gaming industry where such NFTs might have additional abilities that affect the gaming process.
+
+
+## Specification
+
+This functionality will be usable for only NFT tokens. This requires that the contract should implement the split id functionality. 
+So if the most significant bit of the token id is 1 then that token is NFT.
+
+```solidity
+pragma solidity ^0.8.0;
+
+/**
+    @title ERC-721 Rentable
+ */
+interface ERC721Rentable /* is ERC165 */ {
+    /**
+        @dev This event will be emitted when token is rented
+        tokenId: token id to be rented
+        owner:  principal owner address
+        renter: renter address
+        expiresAt:  end of renting period as timestamp
+    */
+    event Rented(uint256 indexed tokenId, address indexed lord, address indexed renter, uint256 expiresAt);
+
+    /**
+        @dev This event will be emitted when renting is finished by the owner or renter
+        tokenId: token id to be rented
+        owner:  principal owner address
+        renter: renter address
+        expiresAt:  end of renting period as timestamp
+    */
+    event FinishedRent(uint256 indexed tokenId, address indexed lord, address indexed renter, uint256 expiresAt);
+
+    /**
+        @notice rentOut
+        @dev rent a token to another address
+        @param renter: renter address
+        @param tokenId: token id to be rented
+        @param expiresAt: end of renting period as timestamp 
+    */
+    function rentOut(address renter, uint256 tokenId, uint256 expiresAt) external;
+
+    /**
+        @notice finishRenting
+        @dev  Renter can run this anytime but owner can run after expire time.
+        @param tokenId: token id
+    */
+    function finishRenting(uint256 tokenId) external;
+
+    /**
+        @notice principalOwner
+        @dev  get the actual ownert of the rented token
+        @param tokenId: token id
+    */
+    function principalOwner(uint256 tokenId) external returns (address);
+
+    /**
+        @notice isRented
+        @dev  get whether or not the token is rented
+        @param tokenId: token id
+    */
+    function isRented(uint256 tokenId) external returns (bool);
+}
+


### PR DESCRIPTION
An extension of the ERC-721 standard to enable NFT tokens to be rentable 
