### PR TITLE
Improve Rendering of EIP-4881 on eips.ethereum.org

### DIFF
--- a/EIPS/eip-4881.md
+++ b/EIPS/eip-4881.md
@@ -33,11 +33,11 @@ Where the hashes in the `finalized` vector are defined in the [Deposit Finalizat
 /eth/v2/beacon/deposit_snapshot
 ```
 
-#### Deposit Finalization Flow
+### Deposit Finalization Flow
 
 During deposit processing, the beacon chain requires deposits to be submitted along with a Merkle path to the deposit root. This is required exactly once for each deposit. When a deposit has been processed by the beacon chain and the [deposit finalization conditions](#deposit-finalization-conditions) have been met, many of the hashes along the path to the deposit root will never be required again to construct Merkle proofs on chain. These unnecessary hashes MAY be pruned to save space. The image below illustrates the evolution of the deposit Merkle tree under this process alongside the corresponding `DepositTreeSnapshot` as new deposits are added and older deposits become finalized:
 
-![Deposit Tree Evolution](../assets/eip-4881/deposit_tree_evolution.png)
+<img src="../assets/eip-4881/deposit_tree_evolution.png" style="max-width: 1200px;">
 
 ## Rationale
 
@@ -49,11 +49,11 @@ The format in this specification was chosen to achieve several goals simultaneou
 4. Increase speed of weak subjectivity sync
 5. Compatibility with existing implementations of this mechanism (see [discussion](https://ethereum-magicians.org/t/eip-4881-deposit-contract-snapshot-interface/))
 
-#### Why not Reconstruct the Tree Directly from the Deposit Contract?
+### Why not Reconstruct the Tree Directly from the Deposit Contract?
 
 The deposit contract can only provide the tree at the head of the chain. Because the beacon chain's view of the deposit contract lags behind the execution chain by `ETH1_FOLLOW_DISTANCE`, there are almost always deposits which haven't yet been included in the chain that need proofs constructed from an earlier version of the tree than exists at the head.
 
-#### Why not Reconstruct the Tree from a Deposit in the Beacon Chain?
+### Why not Reconstruct the Tree from a Deposit in the Beacon Chain?
 
 In principle, a node could scan backwards through the chain starting from the weak subjectivity checkpoint to locate a suitable [`Deposit`](https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/phase0/beacon-chain.md#deposit), and then extract the rightmost branch of the tree from that. The node would also need to extract the `execution_block_hash` from which to start syncing new deposits from the `Eth1Data` in the corresponding `BeaconState`. This approach is less desirable for a few reasons:
 
@@ -262,11 +262,11 @@ If these files are downloaded to the same directory, the test cases can be run b
 
 ## Security Considerations
 
-#### Relying on Weak Subjectivity Sync
+### Relying on Weak Subjectivity Sync
 
 The upcoming switch to PoS will require newly synced nodes to rely on valid weak subjectivity checkpoints because of long-range attacks. This proposal relies on the weak subjectivity assumption that clients will not bootstrap with an invalid WS checkpoint.
 
-#### Deposit Finalization Conditions
+### Deposit Finalization Conditions
 
 Care must be taken not to send a snapshot which includes deposits that haven't been fully included in the finalized checkpoint. Let `state` be the [`BeaconState`](https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/phase0/beacon-chain.md#beaconstate) at a given block in the chain. Under normal operation, the [`Eth1Data`](https://github.com/ethereum/consensus-specs/blob/v1.1.9/specs/phase0/beacon-chain.md#eth1data) stored in `state.eth1_data` is replaced every `EPOCHS_PER_ETH1_VOTING_PERIOD` epochs. Thus, finalization of the deposit tree proceeds in increments of `state.eth1_data`. Let `eth1data` be some `Eth1Data`. Both of the following conditions MUST be met to consider `eth1data` finalized:
 
@@ -275,7 +275,7 @@ Care must be taken not to send a snapshot which includes deposits that haven't b
 
 When these conditions are met, the tree can be pruned in the [reference implementation](#reference-implementation) by calling `tree.finalize(eth1data)`
 
-#### Deposit Queue Exceeds EIP-4444 Pruning Period
+### Deposit Queue Exceeds EIP-4444 Pruning Period
 
 The proposed design could fail if the deposit queue becomes so large that deposits cannot be processed within the [EIP-4444 Pruning Period](./eip-4444.md) (currently set to 1 year). The beacon chain can process `MAX_DEPOSITS/SECONDS_PER_SLOT` deposits/second without skipped slots. Even under extreme conditions where 25% of slots are skipped, the deposit queue would need to be >31.5 million to hit this limit. This is more than 8x the total supply of ether assuming each deposit is a full validator. The minimum deposit is 1 ETH so an attacker would need to burn >30 Million ETH to create these conditions.
 


### PR DESCRIPTION
Sub-section headings should be bold and image shouldn't take up the whole page on high-res screens.