### PR TITLE
EIP-4844: v -> y_parity like EIP-1559, and fix intrinsic gas

### DIFF
--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -153,7 +153,7 @@ class AccessTuple(Container):
     storage_keys: List[Hash, MAX_ACCESS_LIST_STORAGE_KEYS]
 
 class ECDSASignature(Container):
-    v: uint8
+    y_parity: boolean
     r: uint256
     s: uint256
 ```
@@ -195,7 +195,8 @@ def tx_hash(tx: SignedBlobTransaction) -> Bytes32:
 
 def get_origin(tx: SignedBlobTransaction) -> Address:
     sig = tx.signature
-    return ecrecover(tx_hash(tx), sig.v, sig.r, sig.s)
+    # v = int(y_parity) + 27, same as EIP-1559
+    return ecrecover(tx_hash(tx), int(sig.y_parity)+27, sig.r, sig.s)
 ```
 
 ### Beacon chain validation
@@ -271,7 +272,7 @@ def point_evaluation_precompile(input: Bytes) -> Bytes:
 
 ### Gas price of blobs (Simplified version)
 
-For early draft implementations, we simply charge `GAS_PER_BLOB` per blob.
+For early draft implementations, we simply change `get_blob_gas(pre_state)` to always return `GAS_PER_BLOB`.
 
 ### Gas price update rule (Full version)
 
@@ -282,11 +283,16 @@ Note that unlike existing transaction types, the gas cost is dependent on the pr
 
 ```python
 def get_intrinsic_gas(tx: SignedBlobTransaction, pre_state: ExecState) -> int:
-    return (
-        20000 +
-        16 * len(tx.message.data) - 12 * len(tx.message.data.count(0)) +
-        len(tx.message.blob_versioned_hashes) * get_blob_gas(pre_state)
-    )
+    intrinsic_gas = 20000  # G_transaction, previously 21000
+    if tx.message.to == None:  # i.e. if a contract is created
+        intrinsic_gas = 53000
+    # EIP-2028 data gas cost reduction for zero bytes
+    intrinsic_gas += 16 * len(tx.message.data) - 12 * len(tx.message.data.count(0))
+    # EIP-2930 Optional access lists
+    intrinsic_gas += 1900 * sum(len(entry.storage_keys) for entry in tx.message.access_list) + 2400 * len(tx.message.access_list)
+    # New additional gas cost per blob
+    intrinsic_gas += len(tx.message.blob_versioned_hashes) * get_blob_gas(pre_state)
+    return intrinsic_gas
 
 def get_blob_gas(pre_state: ExecState) -> int:
     blocks_since_start = get_current_block(pre_state) - FORK_BLKNUM


### PR DESCRIPTION
- `v` is now encoded as `y_parity`, like EIP-1559 (and the AL tx type also) does.
- intrinsic gas now adds `Gtxcreate` (yellow paper gas cost for contract creation by tx) and access-list intrinsic gas.

Thanks to [yperbasis](https://ethereum-magicians.org/u/yperbasis) on eth-magicians for reporting these two issues.

This PR is getting auto-merged, but happy to adjust again if anything is wrong/missing.

The `21000` -> `20000` intrinsic gas cost reduction was already there since the original blob-transactions proposal by Vitalik ([here](https://notes.ethereum.org/@vbuterin/blob_transactions)). I realize we may need to add an explanation, I asked the other authors for clarification. In general it should encourage usage of the new SSZ-encoded transaction type.

