### PR TITLE
EIP4906: ERC-721 Metadata Update Extension

### DIFF
--- a/EIPS/eip-4906.md
+++ b/EIPS/eip-4906.md
@@ -13,22 +13,17 @@ requires: 721, 1155
 
 ## Abstract
 
-This specification defines standard metadata update event of [ERC-721](./eip-721.md) and [ERC-1155](./eip-1155.md).
-The proposal depends on and extends the existing [ERC-721](./eip-721.md) and [ERC-1155](./eip-1155.md).
+This specification defines standard metadata update event of [ERC-721](./eip-721.md) and [ERC-1155](./eip-1155.md). The proposal depends on and extends the existing [ERC-721](./eip-721.md) and [ERC-1155](./eip-1155.md).
 
 ## Motivation
 
-Many [ERC-721](./eip-721.md) and [ERC-1155](./eip-1155.md) contracts emit their custom event when metadata changed.
-It is easy to update metadata of one NFT by specific event, but it is difficult for third-party platforms such as
-NFT marketplace to update metadata of many NFTs based on custom events.
+Many [ERC-721](./eip-721.md) and [ERC-1155](./eip-1155.md) contracts emit their custom event when metadata changed. It is easy to update metadata of one NFT by specific event, but it is difficult for third-party platforms such as NFT marketplace to update metadata of many NFTs based on custom events.
 
-Having a standard `MetadataUpdate` event will make it easy for third-party platforms to timely update metadata of 
-many NFTs.
+Having a standard `MetadataUpdate` event will make it easy for third-party platforms to timely update metadata of many NFTs.
 
 ## Specification
 
-The keywords “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and
-“OPTIONAL” in this document are to be interpreted as described in RFC 2119.
+The keywords “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be interpreted as described in RFC 2119.
 
 The **metadata update extension** is OPTIONAL for ERC-721/ERC-1155 contracts.
 
@@ -47,12 +42,9 @@ The `MetadataUpdate` event MUST be emitted when the metadata of a token is chang
 
 ## Rationale
 
-Different NFTs have different metadata, and metadata generally has multiple fields. `bytes data` could be used to 
-represents the modified value of metadata.  It is difficult for third-party platforms to identify various types
-of `bytes data`, so there is only one parameter `uint256 indexed _tokenId` in `MetadataUpdate` event. 
+Different NFTs have different metadata, and metadata generally has multiple fields. `bytes data` could be used to represents the modified value of metadata.  It is difficult for third-party platforms to identify various types of `bytes data`, so there is only one parameter `uint256 indexed _tokenId` in `MetadataUpdate` event. 
 
-After capturing the `MetadataUpdate` event, a third party can update the metadata with information returned from 
-the `tokenURI(uint256 _tokenId)` of ERC721 or `uri(uint256 _tokenId)` of ERC1155.
+After capturing the `MetadataUpdate` event, a third party can update the metadata with information returned from the `tokenURI(uint256 _tokenId)` of ERC721 or `uri(uint256 _tokenId)` of ERC1155.
 
 ## Backwards Compatibility
 

--- a/EIPS/eip-4906.md
+++ b/EIPS/eip-4906.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: ERC
 created: 2022-03-13
-requires: 721, 1155
+requires: 165, 721, 1155
 ---
 
 ## Abstract

--- a/EIPS/eip-4906.md
+++ b/EIPS/eip-4906.md
@@ -1,0 +1,63 @@
+---
+eip: 4906
+title: ERC-721/ERC-1155 Metadata Update Extension
+description: Standard interface extension for ERC-721/ERC-115 metadata update 
+author: Anders (@0xanders)
+discussions-to: https://
+status: Draft
+type: Standards Track
+category: ERC
+created: 2022-03-13
+requires: 721 or 1155
+---
+
+## Abstract
+
+This specification defines standard metadata update event of [ERC-721](./eip-721.md) and [ERC-1155](./eip-1155.md).
+The proposal depends on and extends the existing [ERC-721](./eip-721.md) and [ERC-1155](./eip-1155.md).
+
+## Motivation
+
+Many [ERC-721](./eip-721.md) and [ERC-1155](./eip-1155.md) contracts emit their custom event when metadata changed.
+It is easy to update metadata of one NFT by specific event, but it is difficult for third-party platforms such as
+NFT marketplace to update metadata of many NFTs based on custom events.
+
+Having a standard `MetadataUpdate` event will make it easy for third-party platforms to timely update metadata of 
+many NFTs.
+
+## Specification
+
+The keywords “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and
+“OPTIONAL” in this document are to be interpreted as described in RFC 2119.
+
+The **metadata update extension** is OPTIONAL for ERC-721/ERC-1155 contracts.
+
+
+```solidity
+/// @title ERC-721/ERC-1155 Metadata Update Extension
+interface IERC4906MetadataUpdate  {
+    /// @dev This event emits when the metadata of a token is changed. 
+    /// So that the third-party platforms such as NFT market could
+    /// timely update the images and related attributes of the NFT
+    event MetadataUpdate(uint256 indexed _tokenId);   
+}
+```
+
+The `MetadataUpdate` event MUST be emitted when the metadata of a token is changed.
+
+## Rationale
+
+Different NFTs have different metadata, and metadata generally has multiple fields. `bytes data` could be used to 
+represents the modified value of metadata.  It is difficult for third-party platforms to identify various types
+of `bytes data`, so there is only one parameter `uint256 indexed _tokenId` in `MetadataUpdate` event. 
+
+After capturing the `MetadataUpdate` event, a third party can update the metadata with information returned from 
+the `tokenURI(uint256 _tokenId)` of ERC721 or `uri(uint256 _tokenId)` of ERC115.
+
+## Backwards Compatibility
+
+No issues.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/EIPS/eip-4906.md
+++ b/EIPS/eip-4906.md
@@ -3,7 +3,7 @@ eip: 4906
 title: ERC-721/ERC-1155 Metadata Update Extension
 description: Standard interface extension for ERC-721/ERC-115 metadata update 
 author: Anders (@0xanders)
-discussions-to: https://
+discussions-to: https://ethereum-magicians.org/t/eip4906-erc-721-erc-1155-metadata-update-extension/8588
 status: Draft
 type: Standards Track
 category: ERC

--- a/EIPS/eip-4906.md
+++ b/EIPS/eip-4906.md
@@ -50,6 +50,10 @@ After capturing the `MetadataUpdate` event, a third party can update the metadat
 
 No issues.
 
+## Security Considerations
+
+If there is an off-chain modification of metadata, a method that triggers `MetadataUpdate` can be added, but note the function's permission controls.
+
 ## Copyright
 
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/EIPS/eip-4906.md
+++ b/EIPS/eip-4906.md
@@ -52,7 +52,7 @@ represents the modified value of metadata.  It is difficult for third-party plat
 of `bytes data`, so there is only one parameter `uint256 indexed _tokenId` in `MetadataUpdate` event. 
 
 After capturing the `MetadataUpdate` event, a third party can update the metadata with information returned from 
-the `tokenURI(uint256 _tokenId)` of ERC721 or `uri(uint256 _tokenId)` of ERC115.
+the `tokenURI(uint256 _tokenId)` of ERC721 or `uri(uint256 _tokenId)` of ERC1155.
 
 ## Backwards Compatibility
 

--- a/EIPS/eip-4906.md
+++ b/EIPS/eip-4906.md
@@ -17,7 +17,7 @@ This specification defines standard metadata update event of [ERC-721](./eip-721
 
 ## Motivation
 
-Many [ERC-721](./eip-721.md) and [ERC-1155](./eip-1155.md) contracts emit their custom event when metadata changed. It is easy to update metadata of one NFT by specific event, but it is difficult for third-party platforms such as NFT marketplace to update metadata of many NFTs based on custom events.
+Many [ERC-721](./eip-721.md) and [ERC-1155](./eip-1155.md) contracts emit a custom event when a token's metadata is changed. It is easy to update metadata of one NFT by specific event, but it is difficult for third-party platforms such as NFT marketplace to update metadata of many NFTs based on custom events.
 
 Having a standard `MetadataUpdate` event will make it easy for third-party platforms to timely update metadata of many NFTs.
 

--- a/EIPS/eip-4906.md
+++ b/EIPS/eip-4906.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: ERC
 created: 2022-03-13
-requires: 721 or 1155
+requires: 721, 1155
 ---
 
 ## Abstract

--- a/EIPS/eip-4906.md
+++ b/EIPS/eip-4906.md
@@ -1,7 +1,7 @@
 ---
 eip: 4906
 title: ERC-721/ERC-1155 Metadata Update Extension
-description: Standard interface extension for ERC-721/ERC-115 metadata update 
+description: Standard interface extension for ERC-721/ERC-115 metadata update
 author: Anders (@0xanders)
 discussions-to: https://ethereum-magicians.org/t/eip4906-erc-721-erc-1155-metadata-update-extension/8588
 status: Draft
@@ -31,10 +31,10 @@ The **metadata update extension** is OPTIONAL for ERC-721/ERC-1155 contracts.
 ```solidity
 /// @title ERC-721/ERC-1155 Metadata Update Extension
 interface IERC4906  {
-    /// @dev This event emits when the metadata of a token is changed. 
+    /// @dev This event emits when the metadata of a token is changed.
     /// So that the third-party platforms such as NFT market could
     /// timely update the images and related attributes of the NFT
-    event MetadataUpdate(uint256 indexed _tokenId);   
+    event MetadataUpdate(uint256 indexed _tokenId);
 }
 ```
 
@@ -42,7 +42,7 @@ The `MetadataUpdate` event MUST be emitted when the metadata of a token is chang
 
 ## Rationale
 
-Different NFTs have different metadata, and metadata generally has multiple fields. `bytes data` could be used to represents the modified value of metadata.  It is difficult for third-party platforms to identify various types of `bytes data`, so there is only one parameter `uint256 indexed _tokenId` in `MetadataUpdate` event. 
+Different NFTs have different metadata, and metadata generally has multiple fields. `bytes data` could be used to represents the modified value of metadata.  It is difficult for third-party platforms to identify various types of `bytes data`, so there is only one parameter `uint256 indexed _tokenId` in `MetadataUpdate` event.
 
 After capturing the `MetadataUpdate` event, a third party can update the metadata with information returned from the `tokenURI(uint256 _tokenId)` of ERC721 or `uri(uint256 _tokenId)` of ERC1155.
 
@@ -53,3 +53,4 @@ No issues.
 ## Copyright
 
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+

--- a/EIPS/eip-4906.md
+++ b/EIPS/eip-4906.md
@@ -30,11 +30,11 @@ The **metadata update extension** is OPTIONAL for ERC-721/ERC-1155 contracts.
 
 ```solidity
 /// @title ERC-721 Metadata Update Extension
-interface IERC4906 {
+interface IERC4906 is IERC165{
     /// @dev This event emits when the metadata of a token is changed.
     /// So that the third-party platforms such as NFT market could
     /// timely update the images and related attributes of the NFT
-    event MetadataUpdate(uint256 indexed _tokenId);
+    event MetadataUpdate(uint256 _tokenId);
 }
 ```
 
@@ -67,7 +67,7 @@ contract ERC4906 is ERC721, IERC4906 {
     }
 
     /// @dev See {IERC165-supportsInterface}.
-    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+    function supportsInterface(bytes4 interfaceId) public view virtual override(IERC165, ERC721) returns (bool) {
         return interfaceId == bytes4(0x49064906) || super.supportsInterface(interfaceId);
     }
 }

--- a/EIPS/eip-4906.md
+++ b/EIPS/eip-4906.md
@@ -2,7 +2,7 @@
 eip: 4906
 title: ERC-721 Metadata Update Extension
 description: Add a `MetadataUpdate` event to ERC-721.
-author: Anders (@0xanders), Lance (@LanceSnow)
+author: Anders (@0xanders), Lance (@LanceSnow), Shrug <shrug@emojidao.org>
 discussions-to: https://ethereum-magicians.org/t/eip4906-erc-721-erc-1155-metadata-update-extension/8588
 status: Draft
 type: Standards Track

--- a/EIPS/eip-4906.md
+++ b/EIPS/eip-4906.md
@@ -85,5 +85,5 @@ If there is an off-chain modification of metadata, a method that triggers `Metad
 
 ## Copyright
 
-Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+Copyright and related rights waived via [CC0](../LICENSE).
 

--- a/EIPS/eip-4906.md
+++ b/EIPS/eip-4906.md
@@ -85,5 +85,5 @@ If there is an off-chain modification of metadata, a method that triggers `Metad
 
 ## Copyright
 
-Copyright and related rights waived via [CC0](../LICENSE).
+Copyright and related rights waived via [CC0](../LICENSE.md).
 

--- a/EIPS/eip-4906.md
+++ b/EIPS/eip-4906.md
@@ -35,7 +35,7 @@ The **metadata update extension** is OPTIONAL for ERC-721/ERC-1155 contracts.
 
 ```solidity
 /// @title ERC-721/ERC-1155 Metadata Update Extension
-interface IERC4906MetadataUpdate  {
+interface IERC4906  {
     /// @dev This event emits when the metadata of a token is changed. 
     /// So that the third-party platforms such as NFT market could
     /// timely update the images and related attributes of the NFT

--- a/EIPS/eip-4906.md
+++ b/EIPS/eip-4906.md
@@ -17,15 +17,15 @@ This standard is an extension of [ERC-721](./eip-721.md). It proposes adding a `
 
 ## Motivation
 
-Many [ERC-721](./eip-721.md) contracts emit a custom event when a token's metadata is changed. It is easy to update metadata of one NFT by specific event, but it is difficult for third-party platforms such as NFT marketplace to update metadata of many NFTs based on custom events.
+Many [ERC-721](./eip-721.md) contracts emit an event when one of its token's metadata is changed. While tracking changes based on these different events is possible, it is extra effort for third-party platforms, such as an NFT marketplace, to build bespoke solutions for each NFT collection.
 
-Having a standard `MetadataUpdate` event will make it easy for third-party platforms to timely update metadata of many NFTs.
+Having a standard `MetadataUpdate` event will make it easy for third-party platforms to timely update the metadata of many NFTs.
 
 ## Specification
 
 The keywords “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be interpreted as described in RFC 2119.
 
-The **metadata update extension** is OPTIONAL for ERC-721/ERC-1155 contracts.
+The **metadata update extension** is OPTIONAL for ERC-721 contracts.
 
 
 ```solidity
@@ -38,7 +38,13 @@ interface IERC4906 is IERC165{
 }
 ```
 
-The `MetadataUpdate` event MUST be emitted when the metadata of a token is changed.
+The `MetadataUpdate` event MUST be emitted when the JSON metadata of a token is changed.
+
+Not emitting `MetadataUpdate` event is RECOMMENDED when a token is minted.
+
+Not emitting `MetadataUpdate` event is RECOMMENDED  when a token is burned.
+
+Not emitting `MetadataUpdate` event is RECOMMENDED  when the tokenURI changes but the JSON metadata does not.
 
 The `supportsInterface` method MUST return `true` when called with `0x49064906`.
 
@@ -46,7 +52,7 @@ The `supportsInterface` method MUST return `true` when called with `0x49064906`.
 
 Different NFTs have different metadata, and metadata generally has multiple fields. `bytes data` could be used to represents the modified value of metadata.  It is difficult for third-party platforms to identify various types of `bytes data`, so there is only one parameter `uint256 indexed _tokenId` in `MetadataUpdate` event.
 
-After capturing the `MetadataUpdate` event, a third party can update the metadata with information returned from the `tokenURI(uint256 _tokenId)` of ERC721.
+After capturing the `MetadataUpdate` event, a third party can update the metadata with information returned from the `tokenURI(uint256 _tokenId)` of ERC-721.
 
 ## Backwards Compatibility
 

--- a/EIPS/eip-4906.md
+++ b/EIPS/eip-4906.md
@@ -1,23 +1,23 @@
 ---
 eip: 4906
-title: ERC-721/ERC-1155 Metadata Update Extension
-description: Standard interface extension for ERC-721/ERC-115 metadata update
+title: ERC-721 Metadata Update Extension
+description: Add a `MetadataUpdate` event to ERC-721.
 author: Anders (@0xanders), Lance (@LanceSnow)
 discussions-to: https://ethereum-magicians.org/t/eip4906-erc-721-erc-1155-metadata-update-extension/8588
 status: Draft
 type: Standards Track
 category: ERC
 created: 2022-03-13
-requires: 165, 721, 1155
+requires: 165, 721
 ---
 
 ## Abstract
 
-This specification defines standard metadata update event of [ERC-721](./eip-721.md) and [ERC-1155](./eip-1155.md). The proposal depends on and extends the existing [ERC-721](./eip-721.md) and [ERC-1155](./eip-1155.md).
+This standard is an extension of [ERC-721](./eip-721.md). It proposes adding a `MetadataUpdate` event to ERC-721 tokens.
 
 ## Motivation
 
-Many [ERC-721](./eip-721.md) and [ERC-1155](./eip-1155.md) contracts emit a custom event when a token's metadata is changed. It is easy to update metadata of one NFT by specific event, but it is difficult for third-party platforms such as NFT marketplace to update metadata of many NFTs based on custom events.
+Many [ERC-721](./eip-721.md) contracts emit a custom event when a token's metadata is changed. It is easy to update metadata of one NFT by specific event, but it is difficult for third-party platforms such as NFT marketplace to update metadata of many NFTs based on custom events.
 
 Having a standard `MetadataUpdate` event will make it easy for third-party platforms to timely update metadata of many NFTs.
 
@@ -29,8 +29,8 @@ The **metadata update extension** is OPTIONAL for ERC-721/ERC-1155 contracts.
 
 
 ```solidity
-/// @title ERC-721/ERC-1155 Metadata Update Extension
-interface IERC4906  {
+/// @title ERC-721 Metadata Update Extension
+interface IERC4906 {
     /// @dev This event emits when the metadata of a token is changed.
     /// So that the third-party platforms such as NFT market could
     /// timely update the images and related attributes of the NFT
@@ -40,15 +40,38 @@ interface IERC4906  {
 
 The `MetadataUpdate` event MUST be emitted when the metadata of a token is changed.
 
+The `supportsInterface` method MUST return `true` when called with `0x49064906`.
+
 ## Rationale
 
 Different NFTs have different metadata, and metadata generally has multiple fields. `bytes data` could be used to represents the modified value of metadata.  It is difficult for third-party platforms to identify various types of `bytes data`, so there is only one parameter `uint256 indexed _tokenId` in `MetadataUpdate` event.
 
-After capturing the `MetadataUpdate` event, a third party can update the metadata with information returned from the `tokenURI(uint256 _tokenId)` of ERC721 or `uri(uint256 _tokenId)` of ERC1155.
+After capturing the `MetadataUpdate` event, a third party can update the metadata with information returned from the `tokenURI(uint256 _tokenId)` of ERC721.
 
 ## Backwards Compatibility
 
 No issues.
+
+## Reference Implementation
+
+```solidity
+// SPDX-License-Identifier: CC0
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import "./IERC4906.sol";
+
+contract ERC4906 is ERC721, IERC4906 {
+
+    constructor(string memory name_, string memory symbol_) ERC721(name_, symbol_){
+    }
+
+    /// @dev See {IERC165-supportsInterface}.
+    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+        return interfaceId == bytes4(0x49064906) || super.supportsInterface(interfaceId);
+    }
+}
+```
 
 ## Security Considerations
 

--- a/EIPS/eip-4906.md
+++ b/EIPS/eip-4906.md
@@ -2,7 +2,7 @@
 eip: 4906
 title: ERC-721/ERC-1155 Metadata Update Extension
 description: Standard interface extension for ERC-721/ERC-115 metadata update
-author: Anders (@0xanders)
+author: Anders (@0xanders), Lance (@LanceSnow)
 discussions-to: https://ethereum-magicians.org/t/eip4906-erc-721-erc-1155-metadata-update-extension/8588
 status: Draft
 type: Standards Track


### PR DESCRIPTION
This standard is an extension of ERC-721. It proposes adding a `MetadataUpdate` event to ERC-721 tokens.
