### PR TITLE
EIP4907: ERC-721 User And Expires Extension

### DIFF
--- a/EIPS/eip-4907.md
+++ b/EIPS/eip-4907.md
@@ -1,0 +1,186 @@
+---
+eip: <to be assigned>
+title: ERC-721 User And Expires Extension
+description: Standard interface extension for ERC-721 user and expires.
+author: Anders (@0xanders), Lance (@LanceSnow), Shrug (shrug@emojidao.org)
+discussions-to: https://ethereum-magicians.org/t/idea-erc-721-user-and-expires-extension/8572
+status: Draft
+type: <Standards Track>
+category (*only required for Standards Track): <ERC>
+created: 2022-03-11
+requires (*optional): <EIP 165 721>
+---
+
+## Abstract
+This standard is an extension of [ERC-721](./eip-721.md). It proposes an additional role **user** and a valid duration indicator **expires**. It allows users and developers manage the use right more simple and efficient.
+
+## Motivation
+Some NFTs have certain utilities. In-game NFTs can be used to play, virtual land can be used to build scenes, music NFT can be used to enjoy , etc. But in some cases, the owner and user may not be the same person. People may invest in an NFT with utility, but they may not have time or ability to use it. So separating use right from ownership makes a lot of sense.
+
+Nowadays, many NFTs are managed by adding the role of **controller/operator** . People in  these roles can perform specific usage actions but can’t approve or transfer the NFT like an owner. If owner plans to set someone as **controller/operator** for a certain period of time, owner needs to submit two on-chain transactions, at the start time and the end time. 
+
+It is conceivable that with the further expansion of NFT application, the problem of usage rights management will become more common, so it is necessary to establish a unified standard to facilitate collaboration among all applications.
+
+By adding **user**, it enables multiple protocols to integrate and build on top of usage rights, while **expires** facilitates automatic ending of each usage without second transaction on chain.
+
+## Specification
+The keywords “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and
+“OPTIONAL” in this document are to be interpreted as described in RFC 2119.
+
+This standard proposes adding a **user** role to the existing **owner** role in ERC721. Their rights are as follows:
+- An **owner** has the right to:
+  1. Transfer the **owner** role
+  2. Set the **user** role and **expires**
+
+- A **user** has the right to:
+  1. use NFT
+
+
+```solidity
+interface IERC4907 {
+
+    // Logged when the user of a token assigns a new user or updates expires
+    /// @notice Emitted when the `user` of an NFT or the `expires` of the `user` is changed
+    /// The zero address for user indicates that there is no user address
+    event UpdateUser(uint256 indexed tokenId, address indexed user, uint64 expires);
+
+    /// @notice set the user and expires of a NFT
+    /// @dev The zero address indicates there is no user 
+    /// Throws if `tokenId` is not valid NFT
+    /// @param user  The new user of the NFT
+    /// @param expires  UNIX timestamp, The new user could use the NFT before expires
+    function setUser(uint256 tokenId, address user, uint64 expires) external ;
+
+    /// @notice Get the user address of an NFT
+    /// @dev The zero address indicates that there is no user or the user is expired
+    /// @param tokenId The NFT to get the user address for
+    /// @return The user address for this NFT
+    function userOf(uint256 tokenId) external view returns(address);
+
+    /// @notice Get the user expires of an NFT
+    /// @dev The zero value indicates that there is no user 
+    /// @param tokenId The NFT to get the user expires for
+    /// @return The user expires for this NFT
+    function userExpires(uint256 tokenId) external view returns(uint256);
+}
+
+```
+
+The `userOf(uint256 tokenId)` function MAY be implemented as `pure` or `view`.
+
+The `userExpires(uint256 tokenId)` function MAY be implemented as `pure` or `view`.
+
+The `setUser(uint256 tokenId, address user, uint64 expires)` function MAY be implemented as `public` or `external`.
+
+The `UpdateUser` event MUST be emitted when a user address is changed or the user expires is changed.
+
+The `supportsInterface` method MUST return `true` when called with `0xad092b5c`.
+
+## Rationale
+Many developers are trying to develop based on the NFT utility, and some of them have added roles already, but there are some key problems need to be solved.  The advantages of this standard are below.
+
+### Clear Permissions Management
+Usage rights are part of ownership, so **owner** can modify **user** at any time, while **user** is only granted some specific permissions, such as **user** usually does not have permission to make permanent changes to NFT's Metadata.
+
+NFTs may be used in multiple applications, and adding the user role to  NFTs  makes it easier for the application to make special grants of rights.
+
+### Simple On-chain Time Management
+Most NFTs do not take into account the expiration time even though the role of the user is added, resulting in the need for the owner to manually submit on-chain transaction to cancel the user rights, which does not allow accurate on-chain management of the use time and will waste gas.
+
+The usage right often corresponds to a specific time, such as deploying scenes on land, renting game props, etc. Therefore, it can reduce the on-chain transactions and save gas with **expires**.
+
+### Easy Third-Party Integration
+The standard makes it easier for third-party protocols to manage NFT usage rights without permission from the NFT issuer or the NFT application.
+
+## Backwards Compatibility
+As mentioned in the specifications section, this standard can be fully ERC721 compatible by adding an extension function set.
+
+In addition, new functions introduced in this standard have many similarities with the existing functions in ERC721. This allows developers to easily adopt the standard quickly.
+
+## Test Cases
+
+Test cases for EIP4907 are at https://github.com/emojidao/EIP4907
+
+
+## Reference Implementation
+```solidity
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0; 
+
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import "./IERC4907.sol";
+
+contract ERC4907 is ERC721, IERC4907 {
+    struct UserInfo 
+    {
+        address user;   // address of user role
+        uint64 expires; // unix timestamp, user expires
+    }
+
+    mapping (uint256  => UserInfo) internal _users;
+
+    constructor(string memory name_, string memory symbol_)
+     ERC721(name_,symbol_)
+     {         
+     }
+    
+    /// @notice set the user and expires of a NFT
+    /// @dev The zero address indicates there is no user 
+    /// Throws if `tokenId` is not valid NFT
+    /// @param user  The new user of the NFT
+    /// @param expires  UNIX timestamp, The new user could use the NFT before expires
+    function setUser(uint256 tokenId, address user, uint64 expires) public virtual{
+        require(_isApprovedOrOwner(msg.sender, tokenId),"ERC721: transfer caller is not owner nor approved");
+        UserInfo storage info =  _users[tokenId];
+        info.user = user;
+        info.expires = expires;
+        emit UpdateUser(tokenId,user,expires);
+    }
+
+    /// @notice Get the user address of an NFT
+    /// @dev The zero address indicates that there is no user or the user is expired
+    /// @param tokenId The NFT to get the user address for
+    /// @return The user address for this NFT
+    function userOf(uint256 tokenId)public view virtual returns(address){
+        if( uint256(_users[tokenId].expires) >=  block.timestamp){
+            return  _users[tokenId].user; 
+        }
+        else{
+            return address(0);
+        }
+    }
+
+    /// @notice Get the user expires of an NFT
+    /// @dev The zero value indicates that there is no user 
+    /// @param tokenId The NFT to get the user expires for
+    /// @return The user expires for this NFT
+    function userExpires(uint256 tokenId) public view virtual returns(uint256){
+        return _users[tokenId].expires;
+    }
+
+    /// @dev See {IERC165-supportsInterface}.
+    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+        return interfaceId == type(IERC4907).interfaceId || super.supportsInterface(interfaceId);
+    }
+
+    function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256 tokenId
+    ) internal virtual override{
+        super._beforeTokenTransfer(from, to, tokenId);
+
+        if (from != to) {
+            _users[tokenId].user = address(0);
+            _users[tokenId].expires = 0;
+            emit UpdateUser(tokenId,address(0),0);
+        }
+    }
+} 
+```
+
+## Security Considerations
+This EIP standard can completely protect the rights of the owner, the owner can change the NFT user and expires at any time.
+
+## Copyright
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/EIPS/eip-4907.md
+++ b/EIPS/eip-4907.md
@@ -24,8 +24,7 @@ It is conceivable that with the further expansion of NFT application, the proble
 By adding **user**, it enables multiple protocols to integrate and build on top of usage rights, while **expires** facilitates automatic ending of each usage without second transaction on chain.
 
 ## Specification
-The keywords “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and
-“OPTIONAL” in this document are to be interpreted as described in RFC 2119.
+The keywords “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be interpreted as described in RFC 2119.
 
 There is an **owner** role in ERC721,  this standard proposes adding a **user** role and **expires** for ERC721. Their rights are as follows:
 - An **owner** has the right to:

--- a/EIPS/eip-4907.md
+++ b/EIPS/eip-4907.md
@@ -27,13 +27,13 @@ By adding **user**, it enables multiple protocols to integrate and build on top 
 The keywords “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and
 “OPTIONAL” in this document are to be interpreted as described in RFC 2119.
 
-This standard proposes adding a **user** role to the existing **owner** role in ERC721. Their rights are as follows:
+There is an **owner** role in ERC721,  this standard proposes adding a **user** role and **expires** for ERC721. Their rights are as follows:
 - An **owner** has the right to:
   1. Transfer the **owner** role
   2. Set the **user** role and **expires**
 
 - A **user** has the right to:
-  1. use NFT
+  1. use NFT before expires
 
 
 ```solidity

--- a/EIPS/eip-4907.md
+++ b/EIPS/eip-4907.md
@@ -12,9 +12,11 @@ requires: 165, 721
 ---
 
 ## Abstract
+
 This standard is an extension of [ERC-721](./eip-721.md). It proposes an additional role **user** and a valid duration indicator **expires**. It allows users and developers manage the use right more simple and efficient.
 
 ## Motivation
+
 Some NFTs have certain utilities. In-game NFTs can be used to play, virtual land can be used to build scenes, music NFT can be used to enjoy , etc. But in some cases, the owner and user may not be the same person. People may invest in an NFT with utility, but they may not have time or ability to use it. So separating use right from ownership makes a lot of sense.
 
 Nowadays, many NFTs are managed by adding the role of **controller/operator** . People in  these roles can perform specific usage actions but can’t approve or transfer the NFT like an owner. If owner plans to set someone as **controller/operator** for a certain period of time, owner needs to submit two on-chain transactions, at the start time and the end time. 
@@ -24,6 +26,7 @@ It is conceivable that with the further expansion of NFT application, the proble
 By adding **user**, it enables multiple protocols to integrate and build on top of usage rights, while **expires** facilitates automatic ending of each usage without second transaction on chain.
 
 ## Specification
+
 The keywords “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be interpreted as described in RFC 2119.
 
 There is an **owner** role in ERC721,  this standard proposes adding a **user** role and **expires** for ERC721. Their rights are as follows:
@@ -33,7 +36,6 @@ There is an **owner** role in ERC721,  this standard proposes adding a **user** 
 
 - A **user** has the right to:
   1. use NFT before expires
-
 
 ```solidity
 interface IERC4907 {
@@ -62,7 +64,6 @@ interface IERC4907 {
     /// @return The user expires for this NFT
     function userExpires(uint256 tokenId) external view returns(uint256);
 }
-
 ```
 
 The `userOf(uint256 tokenId)` function MAY be implemented as `pure` or `view`.
@@ -76,22 +77,27 @@ The `UpdateUser` event MUST be emitted when a user address is changed or the use
 The `supportsInterface` method MUST return `true` when called with `0xad092b5c`.
 
 ## Rationale
+
 Many developers are trying to develop based on the NFT utility, and some of them have added roles already, but there are some key problems need to be solved.  The advantages of this standard are below.
 
 ### Clear Permissions Management
+
 Usage rights are part of ownership, so **owner** can modify **user** at any time, while **user** is only granted some specific permissions, such as **user** usually does not have permission to make permanent changes to NFT's Metadata.
 
 NFTs may be used in multiple applications, and adding the user role to  NFTs  makes it easier for the application to make special grants of rights.
 
 ### Simple On-chain Time Management
+
 Most NFTs do not take into account the expiration time even though the role of the user is added, resulting in the need for the owner to manually submit on-chain transaction to cancel the user rights, which does not allow accurate on-chain management of the use time and will waste gas.
 
 The usage right often corresponds to a specific time, such as deploying scenes on land, renting game props, etc. Therefore, it can reduce the on-chain transactions and save gas with **expires**.
 
 ### Easy Third-Party Integration
+
 The standard makes it easier for third-party protocols to manage NFT usage rights without permission from the NFT issuer or the NFT application.
 
 ## Backwards Compatibility
+
 As mentioned in the specifications section, this standard can be fully ERC721 compatible by adding an extension function set.
 
 In addition, new functions introduced in this standard have many similarities with the existing functions in ERC721. This allows developers to easily adopt the standard quickly.
@@ -101,6 +107,7 @@ In addition, new functions introduced in this standard have many similarities wi
 Test cases for EIP4907 are at https://github.com/emojidao/EIP4907
 
 ## Reference Implementation
+
 ```solidity
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0; 
@@ -178,8 +185,8 @@ contract ERC4907 is ERC721, IERC4907 {
 ```
 
 ## Security Considerations
+
 This EIP standard can completely protect the rights of the owner, the owner can change the NFT user and expires at any time.
 
 ## Copyright
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
-

--- a/EIPS/eip-4907.md
+++ b/EIPS/eip-4907.md
@@ -29,14 +29,6 @@ By adding **user**, it enables multiple protocols to integrate and build on top 
 
 The keywords “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be interpreted as described in RFC 2119.
 
-There is an **owner** role in ERC721,  this standard proposes adding a **user** role and **expires** for ERC721. Their rights are as follows:
-- An **owner** has the right to:
-  1. Transfer the **owner** role
-  2. Set the **user** role and **expires**
-
-- A **user** has the right to:
-  1. use NFT before expires
-
 ```solidity
 interface IERC4907 {
 

--- a/EIPS/eip-4907.md
+++ b/EIPS/eip-4907.md
@@ -5,10 +5,10 @@ description: Standard interface extension for ERC-721 user and expires.
 author: Anders (@0xanders), Lance (@LanceSnow), Shrug (shrug@emojidao.org)
 discussions-to: https://ethereum-magicians.org/t/idea-erc-721-user-and-expires-extension/8572
 status: Draft
-type: <Standards Track>
-category (*only required for Standards Track): <ERC>
+type: Standards Track
+category: ERC
 created: 2022-03-11
-requires (*optional): <EIP 165 721>
+requires: 165, 721
 ---
 
 ## Abstract

--- a/EIPS/eip-4907.md
+++ b/EIPS/eip-4907.md
@@ -100,7 +100,6 @@ In addition, new functions introduced in this standard have many similarities wi
 
 Test cases for EIP4907 are at https://github.com/emojidao/EIP4907
 
-
 ## Reference Implementation
 ```solidity
 // SPDX-License-Identifier: MIT
@@ -183,3 +182,4 @@ This EIP standard can completely protect the rights of the owner, the owner can 
 
 ## Copyright
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+

--- a/EIPS/eip-4907.md
+++ b/EIPS/eip-4907.md
@@ -17,9 +17,9 @@ This standard is an extension of [ERC-721](./eip-721.md). It proposes an additio
 
 ## Motivation
 
-Some NFTs have certain utilities. In-game NFTs can be used to play, virtual land can be used to build scenes, music NFT can be used to enjoy , etc. But in some cases, the owner and user may not be the same person. People may invest in an NFT with utility, but they may not have time or ability to use it. So separating use right from ownership makes a lot of sense.
+Some NFTs have certain utilities. In-game NFTs can be used to play, virtual land can be used to build scenes, music NFT can be used to enjoy, etc. But in some cases, the owner and user may not be the same person. People may invest in an NFT with utility, but they may not have time or ability to use it. So separating use right from ownership makes a lot of sense.
 
-Nowadays, many NFTs are managed by adding the role of **controller/operator** . People in  these roles can perform specific usage actions but can’t approve or transfer the NFT like an owner. If owner plans to set someone as **controller/operator** for a certain period of time, owner needs to submit two on-chain transactions, at the start time and the end time. 
+Nowadays, many NFTs are managed by adding the role of **controller/operator**. People in these roles can perform specific usage actions but can’t approve or transfer the NFT like an owner. If owner plans to set someone as **controller/operator** for a certain period of time, owner needs to submit two on-chain transactions, at the start time and the end time.
 
 It is conceivable that with the further expansion of NFT application, the problem of usage rights management will become more common, so it is necessary to establish a unified standard to facilitate collaboration among all applications.
 
@@ -32,7 +32,7 @@ The keywords “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL N
 ```solidity
 interface IERC4907 {
 
-    // Logged when the user of a token assigns a new user or updates expires
+    // Logged when the user of a NFT is changed or expires is changed
     /// @notice Emitted when the `user` of an NFT or the `expires` of the `user` is changed
     /// The zero address for user indicates that there is no user address
     event UpdateUser(uint256 indexed tokenId, address indexed user, uint64 expires);
@@ -70,13 +70,13 @@ The `supportsInterface` method MUST return `true` when called with `0xad092b5c`.
 
 ## Rationale
 
-Many developers are trying to develop based on the NFT utility, and some of them have added roles already, but there are some key problems need to be solved.  The advantages of this standard are below.
+Many developers are trying to develop based on the NFT utility, and some of them have added roles already, but there are some key problems need to be solved. The advantages of this standard are below.
 
 ### Clear Permissions Management
 
 Usage rights are part of ownership, so **owner** can modify **user** at any time, while **user** is only granted some specific permissions, such as **user** usually does not have permission to make permanent changes to NFT's Metadata.
 
-NFTs may be used in multiple applications, and adding the user role to  NFTs  makes it easier for the application to make special grants of rights.
+NFTs may be used in multiple applications, and adding the user role to NFTs makes it easier for the application to make special grants of rights.
 
 ### Simple On-chain Time Management
 
@@ -127,7 +127,7 @@ contract ERC4907 is ERC721, IERC4907 {
     /// @param user  The new user of the NFT
     /// @param expires  UNIX timestamp, The new user could use the NFT before expires
     function setUser(uint256 tokenId, address user, uint64 expires) public virtual{
-        require(_isApprovedOrOwner(msg.sender, tokenId),"ERC721: transfer caller is not owner nor approved");
+        require(_isApprovedOrOwner(msg.sender, tokenId),"ERC4907: transfer caller is not owner nor approved");
         UserInfo storage info =  _users[tokenId];
         info.user = user;
         info.expires = expires;
@@ -138,7 +138,7 @@ contract ERC4907 is ERC721, IERC4907 {
     /// @dev The zero address indicates that there is no user or the user is expired
     /// @param tokenId The NFT to get the user address for
     /// @return The user address for this NFT
-    function userOf(uint256 tokenId)public view virtual returns(address){
+    function userOf(uint256 tokenId) public view virtual returns(address){
         if( uint256(_users[tokenId].expires) >=  block.timestamp){
             return  _users[tokenId].user; 
         }
@@ -182,3 +182,4 @@ This EIP standard can completely protect the rights of the owner, the owner can 
 
 ## Copyright
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+

--- a/EIPS/eip-4907.md
+++ b/EIPS/eip-4907.md
@@ -1,5 +1,5 @@
 ---
-eip: <to be assigned>
+eip: 4907
 title: ERC-721 User And Expires Extension
 description: Standard interface extension for ERC-721 user and expires.
 author: Anders (@0xanders), Lance (@LanceSnow), Shrug (shrug@emojidao.org)


### PR DESCRIPTION
This standard is an extension of ERC-721. It proposes an additional role **user** and a valid duration indicator **expires**. It allows users and developers manage the use right more simple and efficient.