### PR TITLE
EIP-4844: minor fix to blob_to_kzg helper func

### DIFF
--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -79,9 +79,9 @@ Compared to full data sharding, this EIP has a reduced cap on the number of thes
 Converts a blob to its corresponding KZG point:
 
 ```python
-def blob_to_kzg(blob: Vector[BLSFieldElement, FIELD_ELEMENTS_PER_BLOB]) -> KZGCommitment:
+def blob_to_kzg(blob: Blob) -> KZGCommitment:
     computed_kzg = bls.Z1
-    for value, point_kzg in zip(tx.blob, KZG_SETUP_LAGRANGE):
+    for value, point_kzg in zip(blob, KZG_SETUP_LAGRANGE):
         assert value < BLS_MODULUS
         computed_kzg = bls.add(
             computed_kzg,


### PR DESCRIPTION
- Simplify `Blob` input argument type (there's an alias defined already)
- Fix `tx.blob` -> `blob` (input arg `blob`, not a transaction)

