### PR TITLE
Small reference typo correction in EIP-3540 (EVM Object Format)

### DIFF
--- a/EIPS/eip-3540.md
+++ b/EIPS/eip-3540.md
@@ -60,7 +60,7 @@ We define the *EOF prefix* as the concatenation of `FORMAT` and the *magic*.
 
 At `block.number == HF_BLOCK` new contract creation is modified:
 - if *initcode* or *code* starts with the *EOF prefix*, it is considered to be EOF formatted and will undergo validation specified in the following sections,
-- else if *code* starts with `0xEF`, creation continues to result in an exceptional abort (the rule introduced in EIP-3540),
+- else if *code* starts with `0xEF`, creation continues to result in an exceptional abort (the rule introduced in EIP-3541),
 - otherwise code is considered *legacy code* and the following rules do not apply to it.
 
 ### Container specification


### PR DESCRIPTION
PR fixes a small typo referencing a wrong EIP in the EIP specification.