### PR TITLE
Update EIP-4895

### DIFF
--- a/EIPS/eip-4895.md
+++ b/EIPS/eip-4895.md
@@ -85,7 +85,7 @@ block_header.withdrawals_root = compute_trie_root_from_indexed_data(block.withdr
 
 ### New field in the execution block header: withdrawals root
 
-The block header gains a new field containing the 32 byte root of the trie committing to the list of withdrawals provided in a given block (see [section on committment](#commitment-to-withdrawals)).
+The block header gains a new field containing the 32 byte root of the trie committing to the list of withdrawals provided in a given block (see [section on commitment](#commitment-to-withdrawals)).
 
 This new field, the `withdrawals_root`, is appended to the end of the existing list of fields in the block header.
 


### PR DESCRIPTION
This PR updates EIP-4895 to reflect the latest "rough consensus" to handling validator withdrawals after several conversations on ACD.