### PR TITLE
eip 1459: stagnant -> review

### DIFF
--- a/EIPS/eip-1459.md
+++ b/EIPS/eip-1459.md
@@ -4,7 +4,7 @@ title: Node Discovery via DNS
 author: Felix Lange <fjl@ethereum.org>, Péter Szilágyi <peter@ethereum.org>
 type: Standards Track
 category: Networking
-status: Stagnant
+status: Review
 created: 2018-09-26
 requires: 778
 discussions-to: https://github.com/ethereum/devp2p/issues/50


### PR DESCRIPTION
This PR moves EIP 1459 from `Stagnant` to `Review`. I would like to move it to final, but I suspect that would not be allowed. 

The DNS discovery has been live on Ethereum mainnet, goerli, ropsten and rinkeby since February 2020.

A crawler is traversing all those networks, and harvesting node records (ENRs), which it the makes public in two ways: in a [git repository](https://github.com/ethereum/discv4-dns-lists) and via DNS. Examples of such dns lists are `all.goerli.ethdisco.net` for all types of goerli-nodes, `snap.goerli.ethdisco.net` for all snap-capable goerli nodes, or `les.goerli.ethdisco.net` for all public les-servers on goerli. 

(The EIP itself does not specify the naming conventions, which in the case of `ethdisco.net` uses different top level domains to denote different capability lists)