### PR TITLE
Update EIP-4895: do not nest RLP encoding

### DIFF
--- a/EIPS/eip-4895.md
+++ b/EIPS/eip-4895.md
@@ -45,18 +45,18 @@ Define a new block-level object called a `withdrawal` that describes withdrawals
 2. a recipient for the withdrawn ether `address` as a 20-byte value
 3. an `amount` of ether given in wei as a 256-bit value.
 
-`Withdrawal` objects are serialized using RLP according to the schema: `RLP([index, address, amount])`.
+`Withdrawal` objects are serialized as a RLP list according to the schema: `[index, address, amount]`.
 
 ### New field in the execution block: withdrawals
 
-The execution block gains a new field referred to as `withdrawals` which is an RLP list of `Withdrawal` dataa.
+The execution block gains a new field referred to as `withdrawals` which is an RLP list of `Withdrawal` data.
 
 For example:
 
 ```python
-withdrawal_0 = RLP([index_0, address_0, amount_0])
-withdrawal_1 = RLP([index_1, address_1, amount_1])
-withdrawals = RLP([withdrawal_0, withdrawal_1])
+withdrawal_0 = [index_0, address_0, amount_0)
+withdrawal_1 = [index_1, address_1, amount_1)
+withdrawals = [withdrawal_0, withdrawal_1]
 ```
 
 This new field is encoded after the existing fields in the block structure and is considered part of the block's body.

--- a/EIPS/eip-4895.md
+++ b/EIPS/eip-4895.md
@@ -54,8 +54,8 @@ The execution block gains a new field referred to as `withdrawals` which is an R
 For example:
 
 ```python
-withdrawal_0 = [index_0, address_0, amount_0)
-withdrawal_1 = [index_1, address_1, amount_1)
+withdrawal_0 = [index_0, address_0, amount_0]
+withdrawal_1 = [index_1, address_1, amount_1]
 withdrawals = [withdrawal_0, withdrawal_1]
 ```
 


### PR DESCRIPTION
This point came up on ACD today to not nest the RLP encoding. This PR updates the EIP to reflect that.