### PR TITLE
Fix broken link & automatically redirect

### DIFF
--- a/EIPS/eip-20-token-standard.md
+++ b/EIPS/eip-20-token-standard.md
@@ -1,1 +1,5 @@
-Moved to [EIP-20](./eip-20.md).
+Moved to [EIP-20](./eip-20).
+
+<script>
+  window.location.replace("./eip-20");
+</script>


### PR DESCRIPTION
- https://eips.ethereum.org/EIPS/eip-20.md actually 404s now. The backup link has been moved to https://eips.ethereum.org/EIPS/eip-20.
- Adds a script tag that simulates an HTTP redirect on page load.