### PR TITLE
ercs past last call deadline to Final

### DIFF
--- a/EIPS/eip-1191.md
+++ b/EIPS/eip-1191.md
@@ -2,8 +2,7 @@
 eip: 1191
 title: Add chain id to mixed-case checksum address encoding
 author: Juliano Rizzo (@juli)
-status: Last Call
-last-call-deadline: 2019-11-18
+status: Final
 type: Standards Track
 category: ERC
 created: 2018-03-18

--- a/EIPS/eip-173.md
+++ b/EIPS/eip-173.md
@@ -5,8 +5,7 @@ author: Nick Mudge <nick@perfectabstractions.com>, Dan Finlay <dan@danfinlay.com
 discussions-to: https://github.com/ethereum/EIPs/issues/173
 type: Standards Track
 category: ERC
-status: Last Call
-last-call-deadline: 2020-09-06
+status: Final
 created: 2018-06-07
 ---
 

--- a/EIPS/eip-1967.md
+++ b/EIPS/eip-1967.md
@@ -4,8 +4,7 @@ title: Standard Proxy Storage Slots
 description: Standardise where proxies store the address of the logic contract they delegate to, as well as other proxy-specific information.
 author: Santiago Palladino (@spalladino), Francisco Giordano (@frangio)
 discussions-to: https://ethereum-magicians.org/t/eip-1967-standard-proxy-storage-slots/3185
-status: Last Call
-last-call-deadline: 2022-04-24
+status: Final
 type: Standards Track
 category: ERC
 created: 2019-04-24

--- a/EIPS/eip-2266.md
+++ b/EIPS/eip-2266.md
@@ -3,11 +3,10 @@ eip: 2266
 title: Atomic Swap-based American Call Option Contract Standard
 author: Runchao Han <runchao.han@monash.edu>, Haoyu Lin <chris.haoyul@gmail.com>, Jiangshan Yu <jiangshan.yu@monash.edu>
 discussions-to: https://github.com/ethereum/EIPs/issues/2266
-status: Last Call
+status: Final
 type: Standards Track
 category: ERC
 created: 2019-08-17
-last-call-deadline: 2020-12-31
 ---
 
 ## Simple Summary

--- a/EIPS/eip-2535.md
+++ b/EIPS/eip-2535.md
@@ -3,8 +3,7 @@ eip: 2535
 title: Diamonds, Multi-Facet Proxy
 author: Nick Mudge (@mudgen)
 discussions-to: https://github.com/ethereum/EIPs/issues/2535
-status: Last Call
-last-call-deadline: 2020-08-15
+status: Final
 type: Standards Track
 category: ERC
 created: 2020-02-22


### PR DESCRIPTION
This PR sets 5 ERCs past their Last Call deadline to Final (173, 1191, 1967, 2266, and 2535).

Pinging authors to approve:

- 173: @mudgen @danfinlay 
- <del>1191: @juli </del>
- <del>1967: @spalladino @frangio </del>
- <del> 2266: will try to add later, unsure </del>
- 2535: @mudgen

I'll crossthrough EIPs which have been approved