### PR TITLE
Set FORK_BLOCK in EIP-2929 and EIP-2930

### DIFF
--- a/EIPS/eip-2929.md
+++ b/EIPS/eip-2929.md
@@ -37,7 +37,7 @@ In the further future, there are similar benefits in the case of SNARK/STARK wit
 
 | Constant | Value |
 | - | - |
-| `FORK_BLOCK` | TBD |
+| `FORK_BLOCK` | 12244000 |
 | `COLD_SLOAD_COST` | 2100 |
 | `COLD_ACCOUNT_ACCESS_COST` | 2600 |
 | `WARM_STORAGE_READ_COST` | 100 |

--- a/EIPS/eip-2930.md
+++ b/EIPS/eip-2930.md
@@ -42,7 +42,7 @@ This EIP serves two functions:
 
 | Constant | Value |
 | - | - |
-| `FORK_BLOCK` | TBD |
+| `FORK_BLOCK` | 12244000 |
 | `ACCESS_LIST_STORAGE_KEY_COST` | 1900 |
 | `ACCESS_LIST_ADDRESS_COST` | 2400 |
 


### PR DESCRIPTION
Both EIP-2929 and EIP-2930 have been added in the Berlin hard fork.