### PR TITLE
EIP-5069: EIP editor handbook in EIP form

### DIFF
--- a/EIPS/eip-1.md
+++ b/EIPS/eip-1.md
@@ -222,7 +222,7 @@ Emeritus EIP editors are
 - Nick Savers (@nicksavers)
 - Martin Becze (@wanderer)
 
-If you would like to become an EIP editor, please check [EIP-5069](./EIPS/eip-5069.md).
+If you would like to become an EIP editor, please check [EIP-5069](./eip-5069.md).
 
 ## EIP Editor Responsibilities
 

--- a/EIPS/eip-1.md
+++ b/EIPS/eip-1.md
@@ -222,6 +222,8 @@ Emeritus EIP editors are
 - Nick Savers (@nicksavers)
 - Martin Becze (@wanderer)
 
+If you would like to become an EIP editor, please check [EIP-5069](./EIPS/eip-5069.md).
+
 ## EIP Editor Responsibilities
 
 For each new EIP that comes in, an editor does the following:
@@ -241,6 +243,8 @@ Once the EIP is ready for the repository, the EIP editor will:
 Many EIPs are written and maintained by developers with write access to the Ethereum codebase. The EIP editors monitor EIP changes, and correct any structure, grammar, spelling, or markup mistakes we see.
 
 The editors don't pass judgment on EIPs. We merely do the administrative & editorial part.
+
+
 
 ## Style Guide
 

--- a/EIPS/eip-1.md
+++ b/EIPS/eip-1.md
@@ -244,8 +244,6 @@ Many EIPs are written and maintained by developers with write access to the Ethe
 
 The editors don't pass judgment on EIPs. We merely do the administrative & editorial part.
 
-
-
 ## Style Guide
 
 ### EIP numbers

--- a/EIPS/eip-5069.md
+++ b/EIPS/eip-5069.md
@@ -95,4 +95,4 @@ This EIP MUST have the same rules regarding changes as [EIP-1](./eip-1.md).
 - This EIP requires special merging rules for the same reason [EIP-1](./eip-1.md) does.
 
 ## Copyright
-Copyright and related rights waived via [CC0](../LICENSE).
+Copyright and related rights waived via [CC0](../LICENSE.md).

--- a/EIPS/eip-5069.md
+++ b/EIPS/eip-5069.md
@@ -2,9 +2,9 @@
 eip: 5069
 title: EIP Editor "Apprentice" Handbook
 description: Formalizes the process for becoming an EIP editor
-author: Pooja Ranjan (@poojaranjan), Pandapip1 (@Pandapip1)
+author: Pooja Ranjan (@poojaranjan), Pandapip1 (@Pandapip1), et al.
 discussions-to: https://ethereum-magicians.org/t/pr-5069-eip-editor-apprentice-handbook/9137
-status: Draft
+status: Living
 type: Informational
 created: 2022-05-02
 requires: 1

--- a/EIPS/eip-5069.md
+++ b/EIPS/eip-5069.md
@@ -53,7 +53,7 @@ Requirements for other PRs (status change, edits to a final EIP) are provided in
 - EIP Authors MAY choose to ignore any improvement suggestions received during the LAST CALL period. Reviewers MAY submit a competing standard as a new EIP if they are unhappy with any of the authors' decisions.
 - EIP Authors MUST have an EIP editor approval to update the status from LAST CALL to FINAL.
 - FINAL EIPs SHALL NOT accept non-normative changes. New EIPs MAY be submitted.
-- If the correct type or category of an EIP is unclear, the EIP Editor MAY make an educated guess. The type or category MAY be changed.
+- If the correct type or category of an EIP is unclear, the EIP editor MAY make an educated guess. The type or category MAY be changed.
 - The Test Cases section is OPTIONAL, but RECOMMENDED for EIPs in REVIEW or a later state.
 - In the absence of an EIP author, EIP editors or the EIP Bot MAY merge non-normative changes.
 - EIP editors SHALL NOT judge proposals.

--- a/EIPS/eip-5069.md
+++ b/EIPS/eip-5069.md
@@ -10,8 +10,6 @@ created: 2022-05-02
 requires: 1
 ---
 
-<!-- I have put myself as an author tentatively. If @poojaranjan would prefer not to have me as one, I will remove myself from the list. -->
-
 ## Abstract
 An Ethereum Improvement Proposal (EIP) is a design document providing information to the Ethereum community, or describing a new feature for Ethereum or its processes or environment. The EIP standardization process is a mechanism for proposing new features, for collecting community technical input on an issue, and for documenting the design decisions that have gone into Ethereum. Because improvement proposals are key components of Ethereum blockchain, it is important that they are well reviewed before reaching FINAL status. EIPs are stored in text files in a versioned repository which is monitored by the EIP editors.
 

--- a/EIPS/eip-5069.md
+++ b/EIPS/eip-5069.md
@@ -1,7 +1,7 @@
 ---
 eip: 5069
 title: EIP Editor Handbook
-description: Formalizes the process for becoming an EIP editor
+description: Handy reference for EIP editors and those who want to become one
 author: Pooja Ranjan (@poojaranjan), Pandapip1 (@Pandapip1)
 discussions-to: https://ethereum-magicians.org/t/pr-5069-eip-editor-handbook/9137
 status: Living
@@ -19,14 +19,14 @@ This EIP describes the recommended process for becoming an EIP editor.
 The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be interpreted as described in RFC 2119.
 
 ### Application and Onboarding Process
-Any contributor of Ethereum ecosystem, having a good understanding of EIP standardization and network upgrade process, intermediate level experience on the core and/or application side of the Ethereum blockchain, and willingness to contribute to the process management MAY apply to become an EIP editor. Potential EIP editors SHOULD have the following skills:
+Anyone having a good understanding of the EIP standardization and network upgrade process, intermediate level experience on the core and/or application side of the Ethereum blockchain, and willingness to contribute to the process management MAY apply to become an EIP editor. Potential EIP editors SHOULD have the following skills:
 - Good communication skills
 - Ability to handle contentious discourse
 - 1-5 spare hours per week
 
 The best available resource to understand the EIP process is [EIP-1](./eip-1.md). Anyone desirous of becoming an EIP editor MUST understand this document. Afterwards, participating in the EIP process by commenting on and suggesting improvements to PRs and issues will familliarize the procedure, and is RECOMMENDED. The contributions of newer editors SHALL be monitored by other EIP editors.
 
-A pull request with a request to be listed as EIP editor MAY be made by anyone who feels comfortable with the EIP process. If the existing EIP editors agree, the author SHALL become a full EIP editor. This SHALL notify the editor of relevant new proposals submitted in the EIPs repository, and they SHALL review and merge pull requests. Once the first PR is merged, another pull request to update the editor list SHALL be made.
+Anyone meeting the above requirements MAY make a pull request adding themselves as an EIP editor. If the existing EIP editors approve, the author SHALL become a full EIP editor. This SHALL notify the editor of relevant new proposals submitted in the EIPs repository, and they SHALL review and merge pull requests. Once the first PR is merged, another pull request to update the editor list SHALL be made.
 
 The following are external links to example pull requests:
 - Add Sam Wilson as an editor: https://github.com/ethereum/EIPs/pull/4859

--- a/EIPS/eip-5069.md
+++ b/EIPS/eip-5069.md
@@ -53,13 +53,13 @@ Requirements for other PRs (status change, edits to a final EIP) are provided in
 - EIP Authors MAY choose to ignore any improvement suggestions received during the LAST CALL period. Reviewers MAY submit a competing standard as a new EIP if they are unhappy with any of the authors' decisions.
 - EIP Authors MUST have an EIP editor approval to update the status from LAST CALL to FINAL.
 - FINAL EIPs SHALL NOT accept non-normative changes. New EIPs MAY be submitted.
-- If the correct type or category of an EIP is unclear, the EIP Editor MAY make an educated guess. The type or catagory MAY be changed.
+- If the correct type or category of an EIP is unclear, the EIP Editor MAY make an educated guess. The type or category MAY be changed.
 - The Test Cases section is OPTIONAL, but RECOMMENDED for EIPs in REVIEW or a later state.
 - In the absence of an EIP author, EIP editors or the EIP Bot MAY merge non-normative changes.
 - EIP editors SHALL NOT judge proposals.
 
 ### EIP Editor Mentorship Program
-The EIP Editor Mentorship Program is an initiative by the Ethereum Cat Herders to attract potential talent of the community to accelerate and improve the EIP standardization process. The EIP Editor Mentorship Program includes completing editorial tasks under the guidance of more experienced editors for the inital 3 months as EIP editor trainee, to provide support until trainees are confident with the process and ready to work independently.
+The EIP Editor Mentorship Program is an initiative by the Ethereum Cat Herders to attract potential talent of the community to accelerate and improve the EIP standardization process. The EIP Editor Mentorship Program includes completing editorial tasks under the guidance of more experienced editors for the initial 3 months as EIP editor trainee, to provide support until trainees are confident with the process and ready to work independently.
 
 The EIP Editor Mentorship Program is not REQUIRED, but is RECOMMENDED.
 

--- a/EIPS/eip-5069.md
+++ b/EIPS/eip-5069.md
@@ -1,8 +1,8 @@
 ---
 eip: 5069
-title: EIP Editor "Apprentice" Handbook
+title: EIP Editor Apprentice Handbook
 description: Formalizes the process for becoming an EIP editor
-author: Pooja Ranjan (@poojaranjan), Pandapip1 (@Pandapip1), et al.
+author: Pooja Ranjan (@poojaranjan), Pandapip1 (@Pandapip1)
 discussions-to: https://ethereum-magicians.org/t/pr-5069-eip-editor-apprentice-handbook/9137
 status: Living
 type: Informational

--- a/EIPS/eip-5069.md
+++ b/EIPS/eip-5069.md
@@ -3,7 +3,7 @@ eip: 5069
 title: EIP Editor "Apprentice" Handbook
 description: Formalizes the process for becoming an EIP editor
 author: Pooja Ranjan (@poojaranjan), Pandapip1 (@Pandapip1)
-discussions-to: https://ethereum-magicians.org/t/eip-xxxx-eip-editor-apprentice-handbook/9137
+discussions-to: https://ethereum-magicians.org/t/pr-5069-eip-editor-apprentice-handbook/9137
 status: Draft
 type: Meta
 created: 2022-05-02

--- a/EIPS/eip-5069.md
+++ b/EIPS/eip-5069.md
@@ -26,10 +26,45 @@ Anyone having a good understanding of the EIP standardization and network upgrad
 
 The best available resource to understand the EIP process is [EIP-1](./eip-1.md). Anyone desirous of becoming an EIP editor MUST understand this document. Afterwards, participating in the EIP process by commenting on and suggesting improvements to PRs and issues will familliarize the procedure, and is RECOMMENDED. The contributions of newer editors SHALL be monitored by other EIP editors.
 
-Anyone meeting the above requirements MAY make a pull request adding themselves as an EIP editor. If the existing EIP editors approve, the author SHALL become a full EIP editor. This SHALL notify the editor of relevant new proposals submitted in the EIPs repository, and they SHALL review and merge pull requests. Once the first PR is merged, another pull request to update the editor list SHALL be made.
+Anyone meeting the above requirements MAY make a pull request adding themselves as an EIP editor. If the existing EIP editors approve, the author SHALL become a full EIP editor. This SHALL notify the editor of relevant new proposals submitted in the EIPs repository, and they SHALL review and merge pull requests. Once the first PR is merged, another pull request to update the editor list SHALL be made:
 
-The following are external links to example pull requests:
-- Add Sam Wilson as an editor: https://github.com/ethereum/EIPs/pull/4859
+```diff
+diff --git a/EIPS/eip-1.md b/EIPS/eip-1.md
+index 79558a3..079b196 100644
+--- a/EIPS/eip-1.md
++++ b/EIPS/eip-1.md
+@@ -207,6 +211,7 @@ The current EIP editors are
+ - Matt Garnett (@lightclient)
+ - Micah Zoltu (@MicahZoltu)
+ - Greg Colvin (@gcolvin)
++- Sam Wilson (@SamWilsn)
+ 
+ Emeritus EIP editors are 
+ 
+diff --git a/.github/workflows/auto-merge-bot.yml b/.github/workflows/auto-merge-bot.yml
+index 5730343..3d162ea 100644
+--- a/.github/workflows/auto-merge-bot.yml
++++ b/.github/workflows/auto-merge-bot.yml
+@@ -17,12 +17,12 @@ jobs:
+         id: auto-merge-bot
+         with:
+           GITHUB-TOKEN: ${{ secrets.TOKEN }} 
+-          CORE_EDITORS: "@MicahZoltu,@lightclient,@axic,@gcolvin"
+-          ERC_EDITORS: "@lightclient,@axic"
+-          NETWORKING_EDITORS: "@MicahZoltu,@lightclient,@axic"
+-          INTERFACE_EDITORS: "@lightclient,@axic"
+-          META_EDITORS: "@lightclient,@axic,@gcolvin"
+-          INFORMATIONAL_EDITORS: "@lightclient,@axic,@gcolvin"
++          CORE_EDITORS: "@MicahZoltu,@lightclient,@axic,@gcolvin,@SamWilsn"
++          ERC_EDITORS: "@lightclient,@axic,@SamWilsn"
++          NETWORKING_EDITORS: "@MicahZoltu,@lightclient,@axic,@SamWilsn"
++          INTERFACE_EDITORS: "@lightclient,@axic,@SamWilsn"
++          META_EDITORS: "@lightclient,@axic,@gcolvin,@SamWilsn"
++          INFORMATIONAL_EDITORS: "@lightclient,@axic,@gcolvin,@SamWilsn"
+           MAINTAINERS: "@alita-moore,@mryalamanchi"
+   enable-auto-merge:
+     if: github.repository == 'ethereum/eips'
+```
 
 ### Special Merging Rules for this EIP
 This EIP MUST have the same rules regarding changes as [EIP-1](./eip-1.md).

--- a/EIPS/eip-5069.md
+++ b/EIPS/eip-5069.md
@@ -95,4 +95,4 @@ This EIP MUST have the same rules regarding changes as [EIP-1](./eip-1.md).
 - This EIP requires special merging rules for the same reason [EIP-1](./eip-1.md) does.
 
 ## Copyright
-Copyright and related rights waived via [CC0](../LICENCE).
+Copyright and related rights waived via [CC0](../LICENSE).

--- a/EIPS/eip-5069.md
+++ b/EIPS/eip-5069.md
@@ -40,7 +40,7 @@ EIP editors MUST do the following for all new PRs submitted to the EIP repositor
 ### New Proposals
 EIP editors MUST do the following for all new proposals submitted to the EIP repository:
 1. Ensure relevance: New proposals MUST be related to the Ethereum ecosystem.
-1. Assign EIP numbers: New proposals SHALL have an EIP number assigned, which SHOULD be the PR number. In some cases, to discourage sqautting, an unused EIP number SHOULD be assigned instead.
+1. Assign EIP numbers: New proposals SHALL have an EIP number assigned, which SHOULD be the PR number. In some cases, to discourage squatting, an unused EIP number SHOULD be assigned instead.
 1. Perform the [All PRs](#all-prs) checklist
 
 ### Other Changes

--- a/EIPS/eip-5069.md
+++ b/EIPS/eip-5069.md
@@ -31,23 +31,23 @@ EIP editors MUST do the following for all new PRs submitted to the EIP repositor
     * The content MUST be not contain any language errors (spelling, grammar, and sentence structure).
     * The proposal MUST use GitHub-flavored Markdown for formatting.
     * The proposal MUST NOT have any blank sections, TODOs, or placeholders.
-    * The proposal MUST provide all required sections, and MUST NOT contain any sections not listed in [EIP-1][./eip-1.md].
+    * The proposal MUST provide all required sections, and MUST NOT contain any sections not listed in [EIP-1](./eip-1.md).
     * Any code provided MUST use best-practices for that programming language.
-    * The proposal MUST follow all latest [EIP-1][./eip-1.md] guidelines.
+    * The proposal MUST follow all latest [EIP-1](./eip-1.md) guidelines.
 1. Provide feedback: A review MUST be submitted, containing specific instructions to reject or improve the changes.
 1. Approve proposal: When the PR is ready to be merged, a review accepting the changes will result in the PR being merged.
 
 ### New Proposals
 EIP editors MUST do the following for all new proposals submitted to the EIP repository:
 1. Ensure relevance: New proposals MUST be related to the Ethereum ecosystem.
-1. Assign EIP numbers: New proposals will have an EIP number assigned, generally the PR number. In some cases, to discourage sqautting, an unused EIP number may be assigned instead.
+1. Assign EIP numbers: New proposals SHALL have an EIP number assigned, which SHOULD be the PR number. In some cases, to discourage sqautting, an unused EIP number SHOULD be assigned instead.
 1. Perform the [All PRs](#all-prs) checklist
 
 ### Other Changes
-Requirements for other PRs (status change, edits to a final EIP) are provided in [EIP-1][./eip-1.md].
+Requirements for other PRs (status change, edits to a final EIP) are provided in [EIP-1](./eip-1.md).
 
 ### Exceptional Cases / Miscellaneous Notes
-- When updating the status from STAGNANT to DRAFT, it is up to the original author to bring it back to the status as they find appropriate. It MAY contain the same content as when its state was changed to STAGNANT, but MUST pass the readiness check, which may have changed since the EIP was last updated.
+- When updating the status from STAGNANT to DRAFT, it is up to the original author to bring it back to the status as they find appropriate. It MAY contain the same content as when its state was changed to STAGNANT, but MUST pass the readiness check. Note that the readiness check MAY have changed since the EIP was last updated - the EIP MUST be updated to use the latest standards!
 - When a proposal has been in the STAGNANT state for more than 6 months <!-- NOTE: 6 months was arbitrarily chosen. This needs discussion. -->, then STAGNANT MAY be considered its terminal status. However, the original author MAY still update the EIP, changing the status from STAGNANT to DRAFT.
 - If a proposal needs to be moved to FINAL because the LAST CALL deadline was exceeded, but all authors are absent, an EIP champion MAY be added to the author list to deal with resulting comments. There are no requirements to become an EIP champion. Alternatively, the LAST CALL deadline may be extended.
 - EIP Authors MAY choose to ignore any improvement suggestions received during the LAST CALL period. Reviewers MAY submit a competing standard as a new EIP if they are unhappy with any of the authors' decisions.
@@ -74,17 +74,17 @@ The best available resource to understand the EIP process is [EIP-1](./eip-1.md)
 <!-- I'm going to hold off on including this if/until ECH and ETH merge: https://github.com/ethereum-cat-herders/EIPIP/issues/132 -->
 <!-- Following the monthly EIPs Insight page to keep track of upcoming Ethereum Improvement Proposals. Among other resources, ECH produces PEEPanEIP video series for a quick overview of these proposals. -->
 
-When the apprentice feels comfortable with the process, a pull request with a request to be listed as EIP editor MAY to be made. <!-- Add Sam's PR as an external link as an example? --> If the existing EIP editors agree, the apprentice SHALL a full EIP editor. This SHALL notify the editor of relevant new proposals submitted in the EIPs repository, and enable them to review and merge pull requests. Once the first PR is merged, another pull request to update the editor list in SHALL be made.
+When the apprentice feels comfortable with the process, a pull request with a request to be listed as EIP editor MAY to be made. <!-- Add Sam's PR as an external link as an example? --> If the existing EIP editors agree, the apprentice SHALL become a full EIP editor. This SHALL notify the editor of relevant new proposals submitted in the EIPs repository, and they SHALL review and merge pull requests. Once the first PR is merged, another pull request to update the editor list in SHALL be made.
 
 ### Funding
 Ecosystem Support Program provided a grant to ECH to work with present editors and individual applicants to provide a stipend for the purpose of increasing community engagement with the EIP process. Historically, though, EIP editing had been done by volunteers.
 
 ### Special Merging Rules for this EIP
-This EIP MUST have the same rules regarding changes as [EIP-1][./eip-1.md].
+This EIP MUST have the same rules regarding changes as [EIP-1](./eip-1.md).
 
 ## Rationale
 - "6 months" was chosen as the cutoff for denoting STAGNANT EIPs terminally-STAGNANT arbitrarily.
-- This EIP requires special merging rules for the same reason [EIP-1][./eip-1.md] does.
+- This EIP requires special merging rules for the same reason [EIP-1](./eip-1.md) does.
 
 ## Backwards Compatibility
 No backwards compatibility issues found.

--- a/EIPS/eip-5069.md
+++ b/EIPS/eip-5069.md
@@ -74,7 +74,7 @@ The best available resource to understand the EIP process is [EIP-1](./eip-1.md)
 <!-- I'm going to hold off on including this if/until ECH and ETH merge: https://github.com/ethereum-cat-herders/EIPIP/issues/132 -->
 <!-- Following the monthly EIPs Insight page to keep track of upcoming Ethereum Improvement Proposals. Among other resources, ECH produces PEEPanEIP video series for a quick overview of these proposals. -->
 
-When the apprentice feels comfortable with the process, a pull request with a request to be listed as EIP editor MAY to be made. <!-- Add Sam's PR as an external link as an example? --> If the existing EIP editors agree, the apprentice SHALL become a full EIP editor. This SHALL notify the editor of relevant new proposals submitted in the EIPs repository, and they SHALL review and merge pull requests. Once the first PR is merged, another pull request to update the editor list in SHALL be made.
+When the apprentice feels comfortable with the process, a pull request with a request to be listed as EIP editor MAY be made. <!-- Add Sam's PR as an external link as an example? --> If the existing EIP editors agree, the apprentice SHALL become a full EIP editor. This SHALL notify the editor of relevant new proposals submitted in the EIPs repository, and they SHALL review and merge pull requests. Once the first PR is merged, another pull request to update the editor list SHALL be made.
 
 ### Funding
 Ecosystem Support Program provided a grant to ECH to work with present editors and individual applicants to provide a stipend for the purpose of increasing community engagement with the EIP process. Historically, though, EIP editing had been done by volunteers.

--- a/EIPS/eip-5069.md
+++ b/EIPS/eip-5069.md
@@ -5,7 +5,7 @@ description: Formalizes the process for becoming an EIP editor
 author: Pooja Ranjan (@poojaranjan), Pandapip1 (@Pandapip1)
 discussions-to: https://ethereum-magicians.org/t/pr-5069-eip-editor-apprentice-handbook/9137
 status: Draft
-type: Meta
+type: Informational
 created: 2022-05-02
 requires: 1
 ---

--- a/EIPS/eip-5069.md
+++ b/EIPS/eip-5069.md
@@ -28,7 +28,7 @@ EIP editors MUST do the following for all new PRs submitted to the EIP repositor
 1. Review proposals: All updated proposals MUST pass a readiness check, unless this is unfeasable:
     * The title describing the content MUST be accurate.
     * The idea put forth MUST make sense technically.
-    * The content MUST be not contain any language errors (spelling, grammar, and sentence structure).
+    * The content MUST not contain any language errors (spelling, grammar, and sentence structure).
     * The proposal MUST use GitHub-flavored Markdown for formatting.
     * The proposal MUST NOT have any blank sections, TODOs, or placeholders.
     * The proposal MUST provide all required sections, and MUST NOT contain any sections not listed in [EIP-1](./eip-1.md).

--- a/EIPS/eip-5069.md
+++ b/EIPS/eip-5069.md
@@ -6,7 +6,7 @@ author: Pooja Ranjan (@poojaranjan), Pandapip1 (@Pandapip1)
 discussions-to: https://ethereum-magicians.org/t/eip-xxxx-eip-editor-apprentice-handbook/9137
 status: Draft
 type: Meta
-created: 5/2/2022
+created: 2022-05-02
 requires: 1
 ---
 

--- a/EIPS/eip-5069.md
+++ b/EIPS/eip-5069.md
@@ -15,9 +15,6 @@ An Ethereum Improvement Proposal (EIP) is a design document providing informatio
 
 This EIP describes the recommended process for becoming an EIP editor.
 
-## Motivation
-The process for becoming an EIP editor is previously undocumented in the EIP repository itself.
-
 ## Specification
 The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be interpreted as described in RFC 2119.
 

--- a/EIPS/eip-5069.md
+++ b/EIPS/eip-5069.md
@@ -18,71 +18,23 @@ This EIP describes the recommended process for becoming an EIP editor.
 ## Specification
 The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be interpreted as described in RFC 2119.
 
-### All PRs
-EIP editors MUST do the following for all new PRs submitted to the EIP repository:
-1. Review proposals: All updated proposals MUST pass a readiness check, unless this is unfeasable:
-    * The title describing the content MUST be accurate.
-    * The idea put forth MUST make sense technically.
-    * The content MUST not contain any language errors (spelling, grammar, and sentence structure).
-    * The proposal MUST use GitHub-flavored Markdown for formatting.
-    * The proposal MUST NOT have any blank sections, TODOs, or placeholders.
-    * The proposal MUST provide all required sections, and MUST NOT contain any sections not listed in [EIP-1](./eip-1.md).
-    * Any code provided MUST use best-practices for that programming language.
-    * The proposal MUST follow all latest [EIP-1](./eip-1.md) guidelines.
-1. Provide feedback: A review MUST be submitted, containing specific instructions to reject or improve the changes.
-1. Approve proposal: When the PR is ready to be merged, a review accepting the changes will result in the PR being merged.
-
-### New Proposals
-EIP editors MUST do the following for all new proposals submitted to the EIP repository:
-1. Ensure relevance: New proposals MUST be related to the Ethereum ecosystem.
-1. Assign EIP numbers: New proposals SHALL have an EIP number assigned, which SHOULD be the PR number. In some cases, to discourage squatting, an unused EIP number SHOULD be assigned instead.
-1. Perform the [All PRs](#all-prs) checklist
-
-### Other Changes
-Requirements for other PRs (status change, edits to a `Final` EIP) are provided in [EIP-1](./eip-1.md).
-
-### Exceptional Cases / Miscellaneous Notes
-- When updating the status from `Stagnant` to `Draft`, it is up to the original author to bring it back to the status as they find appropriate. It MAY contain the same content as when its state was changed to `Stagnant`, but MUST pass the readiness check. Note that the readiness check MAY have changed since the EIP was last updated - the EIP MUST be updated to use the latest standards!
-- When a proposal has been in the `Stagnant` state for more than 6 months, then `Stagnant` MAY be considered its terminal status. However, the original author MAY still update the EIP, changing the status from `Stagnant` to `Draft`.
-- If a proposal needs to be moved to `Final` because the `Last Call` deadline was exceeded, but all authors are absent, an EIP champion MAY be added to the author list to deal with resulting comments. There are no requirements to become an EIP champion. Alternatively, the `last call` deadline may be extended.
-- EIP Authors MAY choose to ignore any improvement suggestions received during the `Last Call` period. Reviewers MAY submit a competing standard as a new EIP if they are unhappy with any of the authors' decisions.
-- EIP Authors MUST have an EIP editor approval to update the status from `Last Call` to `Final`.
-- `Final` EIPs SHALL NOT accept non-normative changes. New EIPs MAY be submitted.
-- If the correct type or category of an EIP is unclear, the EIP editor MAY make an educated guess. The type or category MAY be changed.
-- The Test Cases section is OPTIONAL, but RECOMMENDED for EIPs in `Review` or a later status.
-- In the absence of an EIP author, EIP editors or the EIP Bot MAY merge non-normative changes.
-- EIP editors SHALL NOT judge proposals.
-
-### EIP Editor Mentorship Program
-The EIP Editor Mentorship Program is an initiative by the Ethereum Cat Herders to attract potential talent of the community to accelerate and improve the EIP standardization process. The EIP Editor Mentorship Program includes completing editorial tasks under the guidance of more experienced editors for the initial 3 months as EIP editor trainee, to provide support until trainees are confident with the process and ready to work independently.
-
-The EIP Editor Mentorship Program is RECOMMENDED.
-
 ### Application and Onboarding Process
-Any contributor of Ethereum ecosystem having a good understanding of EIP standardization and network upgrade process, intermediate level experties on core and/or application side of the Ethereum blockchain and the willingness to contribute to the process management MAY be an EIP editor. Potential EIP editors SHOULD have the following skills:
+Any contributor of Ethereum ecosystem, having a good understanding of EIP standardization and network upgrade process, intermediate level experience on the core and/or application side of the Ethereum blockchain, and willingness to contribute to the process management MAY apply to become an EIP editor. Potential EIP editors SHOULD have the following skills:
 - Good communication skills
 - Ability to handle contentious discourse
 - 1-5 spare hours per week
 
 The best available resource to understand the EIP process is [EIP-1](./eip-1.md). EIP editor apprentices MUST understand this document. Afterwards, participating in the EIP process by commenting on and suggesting improvements to PRs and issues will familliarize apprentices with the procedure, and is RECOMMENDED. The contributions of apprentice editors SHALL be monitored by other EIP editors.
 
-Attending EIPIP meetings is also RECOMMENDED, as it rapidly accelerates consensus. The EIP Insights page is another resource that may be useful.
-
-The following are external links to the resources mentioned above. These links are not durable.
-
-- EIP Insights: https://hackmd.io/@poojaranjan/EthereumImprovementProposalsInsight
-- ECH Discord (Meeting Links Posted Here): https://discord.io/EthCatHerders
-- Past EIP Apprenticeship Meetings: https://www.youtube.com/playlist?list=PL4cwHXAawZxoLnTTFQjqdZwd6pVTsjDid
-- Past EIPIP Meetings: https://www.youtube.com/playlist?list=PL4cwHXAawZxpLrRIkDlBjDUUrGgF91pQw
-- Past EIPIP Meeting Transcripts: https://github.com/ethereum-cat-herders/EIPIP
-
 When the apprentice feels comfortable with the process, a pull request with a request to be listed as EIP editor MAY be made. If the existing EIP editors agree, the apprentice SHALL become a full EIP editor. This SHALL notify the editor of relevant new proposals submitted in the EIPs repository, and they SHALL review and merge pull requests. Once the first PR is merged, another pull request to update the editor list SHALL be made.
 
-The following are external links to example Pull Requests. These links are not durable.
+The following are external links to example pull requests:
 - Add Sam Wilson as an editor: https://github.com/ethereum/EIPs/pull/4859
 
-### Funding
-Ecosystem Support Program provided a grant to ECH to work with present editors and individual applicants to provide a stipend for the purpose of increasing community engagement with the EIP process. Historically, though, EIP editing had been done by volunteers.
+### EIP Editor Mentorship Program
+The EIP Editor Mentorship Program is an initiative by the Ethereum Cat Herders to attract potential talent of the community to accelerate and improve the EIP standardization process. The EIP Editor Mentorship Program includes completing editorial tasks under the guidance of more experienced editors for the initial 3 months as an EIP editor trainee, to provide support until trainees are confident with the process and ready to work independently.
+
+The EIP Editor Mentorship Program is RECOMMENDED.
 
 ### Special Merging Rules for this EIP
 This EIP MUST have the same rules regarding changes as [EIP-1](./eip-1.md).

--- a/EIPS/eip-5069.md
+++ b/EIPS/eip-5069.md
@@ -26,7 +26,7 @@ Anyone having a good understanding of the EIP standardization and network upgrad
 
 The best available resource to understand the EIP process is [EIP-1](./eip-1.md). Anyone desirous of becoming an EIP editor MUST understand this document. Afterwards, participating in the EIP process by commenting on and suggesting improvements to PRs and issues will familliarize the procedure, and is RECOMMENDED. The contributions of newer editors SHALL be monitored by other EIP editors.
 
-Anyone meeting the above requirements MAY make a pull request adding themselves as an EIP editor. If the existing EIP editors approve, the author SHALL become a full EIP editor. This SHALL notify the editor of relevant new proposals submitted in the EIPs repository, and they SHALL review and merge pull requests. Once the first PR is merged, another pull request to update the editor list SHALL be made:
+Anyone meeting the above requirements MAY make a pull request adding themselves as an EIP editor and adding themselves to the editor list in [EIP-1](./eip-1.md). If the existing EIP editors approve, the author SHALL become a full EIP editor. This SHALL notify the editor of relevant new proposals submitted in the EIPs repository, and they SHALL review and merge pull requests:
 
 ```diff
 diff --git a/EIPS/eip-1.md b/EIPS/eip-1.md

--- a/EIPS/eip-5069.md
+++ b/EIPS/eip-5069.md
@@ -11,9 +11,9 @@ requires: 1
 ---
 
 ## Abstract
-An Ethereum Improvement Proposal (EIP) is a design document providing information to the Ethereum community, or describing a new feature for Ethereum or its processes or environment. The EIP standardization process is a mechanism for proposing new features, for collecting community technical input on an issue, and for documenting the design decisions that have gone into Ethereum. Because improvement proposals are key components of Ethereum blockchain, it is important that they are well reviewed before reaching FINAL status. EIPs are stored in text files in a versioned repository which is monitored by the EIP editors.
+An Ethereum Improvement Proposal (EIP) is a design document providing information to the Ethereum community, or describing a new feature for Ethereum or its processes or environment. The EIP standardization process is a mechanism for proposing new features, for collecting community technical input on an issue, and for documenting the design decisions that have gone into Ethereum. Because improvement proposals are key components of Ethereum blockchain, it is important that they are well reviewed before reaching `final` status. EIPs are stored in text files in a versioned repository which is monitored by the EIP editors.
 
-This Meta-EIP describes the process for becoming an EIP editor.
+This EIP describes the process for becoming an EIP editor.
 
 ## Motivation
 The process for becoming an EIP editor is previously undocumented in the EIP repository itself.
@@ -42,15 +42,15 @@ EIP editors MUST do the following for all new proposals submitted to the EIP rep
 1. Perform the [All PRs](#all-prs) checklist
 
 ### Other Changes
-Requirements for other PRs (status change, edits to a final EIP) are provided in [EIP-1](./eip-1.md).
+Requirements for other PRs (status change, edits to a `final` EIP) are provided in [EIP-1](./eip-1.md).
 
 ### Exceptional Cases / Miscellaneous Notes
-- When updating the status from STAGNANT to DRAFT, it is up to the original author to bring it back to the status as they find appropriate. It MAY contain the same content as when its state was changed to STAGNANT, but MUST pass the readiness check. Note that the readiness check MAY have changed since the EIP was last updated - the EIP MUST be updated to use the latest standards!
-- When a proposal has been in the STAGNANT state for more than 6 months <!-- NOTE: 6 months was arbitrarily chosen. This needs discussion. -->, then STAGNANT MAY be considered its terminal status. However, the original author MAY still update the EIP, changing the status from STAGNANT to DRAFT.
-- If a proposal needs to be moved to FINAL because the LAST CALL deadline was exceeded, but all authors are absent, an EIP champion MAY be added to the author list to deal with resulting comments. There are no requirements to become an EIP champion. Alternatively, the LAST CALL deadline may be extended.
-- EIP Authors MAY choose to ignore any improvement suggestions received during the LAST CALL period. Reviewers MAY submit a competing standard as a new EIP if they are unhappy with any of the authors' decisions.
-- EIP Authors MUST have an EIP editor approval to update the status from LAST CALL to FINAL.
-- FINAL EIPs SHALL NOT accept non-normative changes. New EIPs MAY be submitted.
+- When updating the status from `stagnant` to `draft`, it is up to the original author to bring it back to the status as they find appropriate. It MAY contain the same content as when its state was changed to `stagnant`, but MUST pass the readiness check. Note that the readiness check MAY have changed since the EIP was last updated - the EIP MUST be updated to use the latest standards!
+- When a proposal has been in the `stagnant` state for more than 6 months, then `stagnant` MAY be considered its terminal status. However, the original author MAY still update the EIP, changing the status from `stagnant` to `draft`.
+- If a proposal needs to be moved to `final` because the `last call` deadline was exceeded, but all authors are absent, an EIP champion MAY be added to the author list to deal with resulting comments. There are no requirements to become an EIP champion. Alternatively, the `last call` deadline may be extended.
+- EIP Authors MAY choose to ignore any improvement suggestions received during the `last call` period. Reviewers MAY submit a competing standard as a new EIP if they are unhappy with any of the authors' decisions.
+- EIP Authors MUST have an EIP editor approval to update the status from `last call` to `final`.
+- `final` EIPs SHALL NOT accept non-normative changes. New EIPs MAY be submitted.
 - If the correct type or category of an EIP is unclear, the EIP editor MAY make an educated guess. The type or category MAY be changed.
 - The Test Cases section is OPTIONAL, but RECOMMENDED for EIPs in REVIEW or a later state.
 - In the absence of an EIP author, EIP editors or the EIP Bot MAY merge non-normative changes.
@@ -59,7 +59,7 @@ Requirements for other PRs (status change, edits to a final EIP) are provided in
 ### EIP Editor Mentorship Program
 The EIP Editor Mentorship Program is an initiative by the Ethereum Cat Herders to attract potential talent of the community to accelerate and improve the EIP standardization process. The EIP Editor Mentorship Program includes completing editorial tasks under the guidance of more experienced editors for the initial 3 months as EIP editor trainee, to provide support until trainees are confident with the process and ready to work independently.
 
-The EIP Editor Mentorship Program is not REQUIRED, but is RECOMMENDED.
+The EIP Editor Mentorship Program is RECOMMENDED.
 
 ### Application and Onboarding Process
 Any contributor of Ethereum ecosystem having a good understanding of EIP standardization and network upgrade process, intermediate level experties on core and/or application side of the Ethereum blockchain and the willingness to contribute to the process management MAY be an EIP editor. Potential EIP editors SHOULD have the following skills:
@@ -67,12 +67,22 @@ Any contributor of Ethereum ecosystem having a good understanding of EIP standar
 - Ability to handle contentious discourse
 - 1-5 spare hours per week
 
-The best available resource to understand the EIP process is [EIP-1](./eip-1.md). EIP editor apprentices MUST understand this document. Afterwards, participating in the EIP process by commenting on and suggesting improvements to PRs and issues will familliarize apprentices with the procedure, and is RECOMMENDED. Attending EIPIP meetings <!-- is it okay to provide external links for this? --> is also RECOMMENDED, as it rapidly accelerates consensus. The contributions of apprentice editors SHALL be monitored by other EIP editors.
+The best available resource to understand the EIP process is [EIP-1](./eip-1.md). EIP editor apprentices MUST understand this document. Afterwards, participating in the EIP process by commenting on and suggesting improvements to PRs and issues will familliarize apprentices with the procedure, and is RECOMMENDED. The contributions of apprentice editors SHALL be monitored by other EIP editors.
 
-<!-- I'm going to hold off on including this if/until ECH and ETH merge: https://github.com/ethereum-cat-herders/EIPIP/issues/132 -->
-<!-- Following the monthly EIPs Insight page to keep track of upcoming Ethereum Improvement Proposals. Among other resources, ECH produces PEEPanEIP video series for a quick overview of these proposals. -->
+Attending EIPIP meetings is also RECOMMENDED, as it rapidly accelerates consensus. The EIP Insights page is another resource that may be useful.
 
-When the apprentice feels comfortable with the process, a pull request with a request to be listed as EIP editor MAY be made. <!-- Add Sam's PR as an external link as an example? --> If the existing EIP editors agree, the apprentice SHALL become a full EIP editor. This SHALL notify the editor of relevant new proposals submitted in the EIPs repository, and they SHALL review and merge pull requests. Once the first PR is merged, another pull request to update the editor list SHALL be made.
+The following are external links to the resources mentioned above. These links are not durable.
+
+- EIP Insights: https://hackmd.io/@poojaranjan/EthereumImprovementProposalsInsight
+- ECH Discord (Meeting Links Posted Here): https://discord.io/EthCatHerders
+- Past EIP Apprenticeship Meetings: https://www.youtube.com/playlist?list=PL4cwHXAawZxoLnTTFQjqdZwd6pVTsjDid
+- Past EIPIP Meetings: https://www.youtube.com/playlist?list=PL4cwHXAawZxpLrRIkDlBjDUUrGgF91pQw
+- Past EIPIP Meeting Transcripts: https://github.com/ethereum-cat-herders/EIPIP
+
+When the apprentice feels comfortable with the process, a pull request with a request to be listed as EIP editor MAY be made. If the existing EIP editors agree, the apprentice SHALL become a full EIP editor. This SHALL notify the editor of relevant new proposals submitted in the EIPs repository, and they SHALL review and merge pull requests. Once the first PR is merged, another pull request to update the editor list SHALL be made.
+
+The following are external links to example Pull Requests. These links are not durable.
+- Add Sam Wilson as an editor: https://github.com/ethereum/EIPs/pull/4859
 
 ### Funding
 Ecosystem Support Program provided a grant to ECH to work with present editors and individual applicants to provide a stipend for the purpose of increasing community engagement with the EIP process. Historically, though, EIP editing had been done by volunteers.
@@ -81,14 +91,8 @@ Ecosystem Support Program provided a grant to ECH to work with present editors a
 This EIP MUST have the same rules regarding changes as [EIP-1](./eip-1.md).
 
 ## Rationale
-- "6 months" was chosen as the cutoff for denoting STAGNANT EIPs terminally-STAGNANT arbitrarily.
+- "6 months" was chosen as the cutoff for denoting `stagnant` EIPs terminally-`stagnant` arbitrarily.
 - This EIP requires special merging rules for the same reason [EIP-1](./eip-1.md) does.
-
-## Backwards Compatibility
-No backwards compatibility issues found.
-
-## Security Considerations
-No security considerations found.
 
 ## Copyright
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/EIPS/eip-5069.md
+++ b/EIPS/eip-5069.md
@@ -11,9 +11,9 @@ requires: 1
 ---
 
 ## Abstract
-An Ethereum Improvement Proposal (EIP) is a design document providing information to the Ethereum community, or describing a new feature for Ethereum or its processes or environment. The EIP standardization process is a mechanism for proposing new features, for collecting community technical input on an issue, and for documenting the design decisions that have gone into Ethereum. Because improvement proposals are key components of Ethereum blockchain, it is important that they are well reviewed before reaching `final` status. EIPs are stored in text files in a versioned repository which is monitored by the EIP editors.
+An Ethereum Improvement Proposal (EIP) is a design document providing information to the Ethereum community, or describing a new feature for Ethereum or its processes or environment. The EIP standardization process is a mechanism for proposing new features, for collecting community technical input on an issue, and for documenting the design decisions that have gone into Ethereum. Because improvement proposals are key components of Ethereum blockchain, it is important that they are well reviewed before reaching `Final` status. EIPs are stored in text files in a versioned repository which is monitored by the EIP editors.
 
-This EIP describes the process for becoming an EIP editor.
+This EIP describes the recommended process for becoming an EIP editor.
 
 ## Motivation
 The process for becoming an EIP editor is previously undocumented in the EIP repository itself.
@@ -42,17 +42,17 @@ EIP editors MUST do the following for all new proposals submitted to the EIP rep
 1. Perform the [All PRs](#all-prs) checklist
 
 ### Other Changes
-Requirements for other PRs (status change, edits to a `final` EIP) are provided in [EIP-1](./eip-1.md).
+Requirements for other PRs (status change, edits to a `Final` EIP) are provided in [EIP-1](./eip-1.md).
 
 ### Exceptional Cases / Miscellaneous Notes
-- When updating the status from `stagnant` to `draft`, it is up to the original author to bring it back to the status as they find appropriate. It MAY contain the same content as when its state was changed to `stagnant`, but MUST pass the readiness check. Note that the readiness check MAY have changed since the EIP was last updated - the EIP MUST be updated to use the latest standards!
-- When a proposal has been in the `stagnant` state for more than 6 months, then `stagnant` MAY be considered its terminal status. However, the original author MAY still update the EIP, changing the status from `stagnant` to `draft`.
-- If a proposal needs to be moved to `final` because the `last call` deadline was exceeded, but all authors are absent, an EIP champion MAY be added to the author list to deal with resulting comments. There are no requirements to become an EIP champion. Alternatively, the `last call` deadline may be extended.
-- EIP Authors MAY choose to ignore any improvement suggestions received during the `last call` period. Reviewers MAY submit a competing standard as a new EIP if they are unhappy with any of the authors' decisions.
-- EIP Authors MUST have an EIP editor approval to update the status from `last call` to `final`.
-- `final` EIPs SHALL NOT accept non-normative changes. New EIPs MAY be submitted.
+- When updating the status from `Stagnant` to `Draft`, it is up to the original author to bring it back to the status as they find appropriate. It MAY contain the same content as when its state was changed to `Stagnant`, but MUST pass the readiness check. Note that the readiness check MAY have changed since the EIP was last updated - the EIP MUST be updated to use the latest standards!
+- When a proposal has been in the `Stagnant` state for more than 6 months, then `Stagnant` MAY be considered its terminal status. However, the original author MAY still update the EIP, changing the status from `Stagnant` to `Draft`.
+- If a proposal needs to be moved to `Final` because the `Last Call` deadline was exceeded, but all authors are absent, an EIP champion MAY be added to the author list to deal with resulting comments. There are no requirements to become an EIP champion. Alternatively, the `last call` deadline may be extended.
+- EIP Authors MAY choose to ignore any improvement suggestions received during the `Last Call` period. Reviewers MAY submit a competing standard as a new EIP if they are unhappy with any of the authors' decisions.
+- EIP Authors MUST have an EIP editor approval to update the status from `Last Call` to `Final`.
+- `Final` EIPs SHALL NOT accept non-normative changes. New EIPs MAY be submitted.
 - If the correct type or category of an EIP is unclear, the EIP editor MAY make an educated guess. The type or category MAY be changed.
-- The Test Cases section is OPTIONAL, but RECOMMENDED for EIPs in REVIEW or a later state.
+- The Test Cases section is OPTIONAL, but RECOMMENDED for EIPs in `Review` or a later status.
 - In the absence of an EIP author, EIP editors or the EIP Bot MAY merge non-normative changes.
 - EIP editors SHALL NOT judge proposals.
 
@@ -91,7 +91,7 @@ Ecosystem Support Program provided a grant to ECH to work with present editors a
 This EIP MUST have the same rules regarding changes as [EIP-1](./eip-1.md).
 
 ## Rationale
-- "6 months" was chosen as the cutoff for denoting `stagnant` EIPs terminally-`stagnant` arbitrarily.
+- "6 months" was chosen as the cutoff for denoting `Stagnant` EIPs terminally-`Stagnant` arbitrarily.
 - This EIP requires special merging rules for the same reason [EIP-1](./eip-1.md) does.
 
 ## Copyright

--- a/EIPS/eip-5069.md
+++ b/EIPS/eip-5069.md
@@ -1,5 +1,5 @@
 ---
-eip: 
+eip: 5069
 title: EIP Editor "Apprentice" Handbook
 description: Formalizes the process for becoming an EIP editor
 author: Pooja Ranjan (@poojaranjan), Pandapip1 (@Pandapip1)

--- a/EIPS/eip-5069.md
+++ b/EIPS/eip-5069.md
@@ -95,4 +95,4 @@ This EIP MUST have the same rules regarding changes as [EIP-1](./eip-1.md).
 - This EIP requires special merging rules for the same reason [EIP-1](./eip-1.md) does.
 
 ## Copyright
-Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+Copyright and related rights waived via [CC0](../LICENCE).

--- a/EIPS/eip-5069.md
+++ b/EIPS/eip-5069.md
@@ -1,9 +1,9 @@
 ---
 eip: 5069
-title: EIP Editor Apprentice Handbook
+title: EIP Editor Handbook
 description: Formalizes the process for becoming an EIP editor
 author: Pooja Ranjan (@poojaranjan), Pandapip1 (@Pandapip1)
-discussions-to: https://ethereum-magicians.org/t/pr-5069-eip-editor-apprentice-handbook/9137
+discussions-to: https://ethereum-magicians.org/t/pr-5069-eip-editor-handbook/9137
 status: Living
 type: Informational
 created: 2022-05-02
@@ -24,17 +24,12 @@ Any contributor of Ethereum ecosystem, having a good understanding of EIP standa
 - Ability to handle contentious discourse
 - 1-5 spare hours per week
 
-The best available resource to understand the EIP process is [EIP-1](./eip-1.md). EIP editor apprentices MUST understand this document. Afterwards, participating in the EIP process by commenting on and suggesting improvements to PRs and issues will familliarize apprentices with the procedure, and is RECOMMENDED. The contributions of apprentice editors SHALL be monitored by other EIP editors.
+The best available resource to understand the EIP process is [EIP-1](./eip-1.md). Anyone desirous of becoming an EIP editor MUST understand this document. Afterwards, participating in the EIP process by commenting on and suggesting improvements to PRs and issues will familliarize the procedure, and is RECOMMENDED. The contributions of newer editors SHALL be monitored by other EIP editors.
 
-When the apprentice feels comfortable with the process, a pull request with a request to be listed as EIP editor MAY be made. If the existing EIP editors agree, the apprentice SHALL become a full EIP editor. This SHALL notify the editor of relevant new proposals submitted in the EIPs repository, and they SHALL review and merge pull requests. Once the first PR is merged, another pull request to update the editor list SHALL be made.
+A pull request with a request to be listed as EIP editor MAY be made by anyone who feels comfortable with the EIP process. If the existing EIP editors agree, the author SHALL become a full EIP editor. This SHALL notify the editor of relevant new proposals submitted in the EIPs repository, and they SHALL review and merge pull requests. Once the first PR is merged, another pull request to update the editor list SHALL be made.
 
 The following are external links to example pull requests:
 - Add Sam Wilson as an editor: https://github.com/ethereum/EIPs/pull/4859
-
-### EIP Editor Mentorship Program
-The EIP Editor Mentorship Program is an initiative by the Ethereum Cat Herders to attract potential talent of the community to accelerate and improve the EIP standardization process. The EIP Editor Mentorship Program includes completing editorial tasks under the guidance of more experienced editors for the initial 3 months as an EIP editor trainee, to provide support until trainees are confident with the process and ready to work independently.
-
-The EIP Editor Mentorship Program is RECOMMENDED.
 
 ### Special Merging Rules for this EIP
 This EIP MUST have the same rules regarding changes as [EIP-1](./eip-1.md).

--- a/EIPS/eip-apprentice-handbook.md
+++ b/EIPS/eip-apprentice-handbook.md
@@ -1,0 +1,96 @@
+---
+eip: 
+title: EIP Editor "Apprentice" Handbook
+description: Formalizes the process for becoming an EIP editor
+author: Pooja Ranjan (@poojaranjan), Pandapip1 (@Pandapip1)
+discussions-to: https://ethereum-magicians.org/t/eip-xxxx-eip-editor-apprentice-handbook/9137
+status: Draft
+type: Meta
+created: 5/2/2022
+requires: 1
+---
+
+<!-- I have put myself as an author tentatively. If @poojaranjan would prefer not to have me as one, I will remove myself from the list. -->
+
+## Abstract
+An Ethereum Improvement Proposal (EIP) is a design document providing information to the Ethereum community, or describing a new feature for Ethereum or its processes or environment. The EIP standardization process is a mechanism for proposing new features, for collecting community technical input on an issue, and for documenting the design decisions that have gone into Ethereum. Because improvement proposals are key components of Ethereum blockchain, it is important that they are well reviewed before reaching FINAL status. EIPs are stored in text files in a versioned repository which is monitored by the EIP editors.
+
+This Meta-EIP describes the process for becoming an EIP editor.
+
+## Motivation
+The process for becoming an EIP editor is previously undocumented in the EIP repository itself.
+
+## Specification
+The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be interpreted as described in RFC 2119.
+
+### All PRs
+EIP editors MUST do the following for all new PRs submitted to the EIP repository:
+1. Review proposals: All updated proposals MUST pass a readiness check, unless this is unfeasable:
+    * The title describing the content MUST be accurate.
+    * The idea put forth MUST make sense technically.
+    * The content MUST be not contain any language errors (spelling, grammar, and sentence structure).
+    * The proposal MUST use GitHub-flavored Markdown for formatting.
+    * The proposal MUST NOT have any blank sections, TODOs, or placeholders.
+    * The proposal MUST provide all required sections, and MUST NOT contain any sections not listed in [EIP-1][./eip-1.md].
+    * Any code provided MUST use best-practices for that programming language.
+    * The proposal MUST follow all latest [EIP-1][./eip-1.md] guidelines.
+1. Provide feedback: A review MUST be submitted, containing specific instructions to reject or improve the changes.
+1. Approve proposal: When the PR is ready to be merged, a review accepting the changes will result in the PR being merged.
+
+### New Proposals
+EIP editors MUST do the following for all new proposals submitted to the EIP repository:
+1. Ensure relevance: New proposals MUST be related to the Ethereum ecosystem.
+1. Assign EIP numbers: New proposals will have an EIP number assigned, generally the PR number. In some cases, to discourage sqautting, an unused EIP number may be assigned instead.
+1. Perform the [All PRs](#all-prs) checklist
+
+### Other Changes
+Requirements for other PRs (status change, edits to a final EIP) are provided in [EIP-1][./eip-1.md].
+
+### Exceptional Cases / Miscellaneous Notes
+- When updating the status from STAGNANT to DRAFT, it is up to the original author to bring it back to the status as they find appropriate. It MAY contain the same content as when its state was changed to STAGNANT, but MUST pass the readiness check, which may have changed since the EIP was last updated.
+- When a proposal has been in the STAGNANT state for more than 6 months <!-- NOTE: 6 months was arbitrarily chosen. This needs discussion. -->, then STAGNANT MAY be considered its terminal status. However, the original author MAY still update the EIP, changing the status from STAGNANT to DRAFT.
+- If a proposal needs to be moved to FINAL because the LAST CALL deadline was exceeded, but all authors are absent, an EIP champion MAY be added to the author list to deal with resulting comments. There are no requirements to become an EIP champion. Alternatively, the LAST CALL deadline may be extended.
+- EIP Authors MAY choose to ignore any improvement suggestions received during the LAST CALL period. Reviewers MAY submit a competing standard as a new EIP if they are unhappy with any of the authors' decisions.
+- EIP Authors MUST have an EIP editor approval to update the status from LAST CALL to FINAL.
+- FINAL EIPs SHALL NOT accept non-normative changes. New EIPs MAY be submitted.
+- If the correct type or category of an EIP is unclear, the EIP Editor MAY make an educated guess. The type or catagory MAY be changed.
+- The Test Cases section is OPTIONAL, but RECOMMENDED for EIPs in REVIEW or a later state.
+- In the absence of an EIP author, EIP editors or the EIP Bot MAY merge non-normative changes.
+- EIP editors SHALL NOT judge proposals.
+
+### EIP Editor Mentorship Program
+The EIP Editor Mentorship Program is an initiative by the Ethereum Cat Herders to attract potential talent of the community to accelerate and improve the EIP standardization process. The EIP Editor Mentorship Program includes completing editorial tasks under the guidance of more experienced editors for the inital 3 months as EIP editor trainee, to provide support until trainees are confident with the process and ready to work independently.
+
+The EIP Editor Mentorship Program is not REQUIRED, but is RECOMMENDED.
+
+### Application and Onboarding Process
+Any contributor of Ethereum ecosystem having a good understanding of EIP standardization and network upgrade process, intermediate level experties on core and/or application side of the Ethereum blockchain and the willingness to contribute to the process management MAY be an EIP editor. Potential EIP editors SHOULD have the following skills:
+- Good communication skills
+- Ability to handle contentious discourse
+- 1-5 spare hours per week
+
+The best available resource to understand the EIP process is [EIP-1](./eip-1.md). EIP editor apprentices MUST understand this document. Afterwards, participating in the EIP process by commenting on and suggesting improvements to PRs and issues will familliarize apprentices with the procedure, and is RECOMMENDED. Attending EIPIP meetings <!-- is it okay to provide external links for this? --> is also RECOMMENDED, as it rapidly accelerates consensus. The contributions of apprentice editors SHALL be monitored by other EIP editors.
+
+<!-- I'm going to hold off on including this if/until ECH and ETH merge: https://github.com/ethereum-cat-herders/EIPIP/issues/132 -->
+<!-- Following the monthly EIPs Insight page to keep track of upcoming Ethereum Improvement Proposals. Among other resources, ECH produces PEEPanEIP video series for a quick overview of these proposals. -->
+
+When the apprentice feels comfortable with the process, a pull request with a request to be listed as EIP editor MAY to be made. <!-- Add Sam's PR as an external link as an example? --> If the existing EIP editors agree, the apprentice SHALL a full EIP editor. This SHALL notify the editor of relevant new proposals submitted in the EIPs repository, and enable them to review and merge pull requests. Once the first PR is merged, another pull request to update the editor list in SHALL be made.
+
+### Funding
+Ecosystem Support Program provided a grant to ECH to work with present editors and individual applicants to provide a stipend for the purpose of increasing community engagement with the EIP process. Historically, though, EIP editing had been done by volunteers.
+
+### Special Merging Rules for this EIP
+This EIP MUST have the same rules regarding changes as [EIP-1][./eip-1.md].
+
+## Rationale
+- "6 months" was chosen as the cutoff for denoting STAGNANT EIPs terminally-STAGNANT arbitrarily.
+- This EIP requires special merging rules for the same reason [EIP-1][./eip-1.md] does.
+
+## Backwards Compatibility
+No backwards compatibility issues found.
+
+## Security Considerations
+No security considerations found.
+
+## Copyright
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ This repository tracks ongoing improvements to Ethereum. It contains:
 
 For help *implementing* an EIP, please visit [Ethereum Stack Exchange](https://ethereum.stackexchange.com).
 
+If you would like to become an EIP Editor, please check [EIP-5069](./EIPS/eip-5069.md).
+
 ## Mission
 
 The goal of the EIP project is to document standardized protocols for Ethereum clients and applications and to document them in a high quality and implementable way.


### PR DESCRIPTION
CC: @poojaranjan

I've heavily modified https://hackmd.io/@poojaranjan/EIP-ERC-Editor-handbook to suit the EIP format and to make the document more formal, specific, inclusive, and easier to understand.

Notes to EIP-1 and the README are added to increase awareness.

Items that need discussion:
- [x] Threshold for terminal stagnant status (arbitrarily chosen as 6 months pending further discussion)
- [x] Determine whether the EIP should be Meta or Informational
- [x] Permission to use external links to @SamWilsn's PRs as examples
- [x] Permission to use external links to the EIPIP repository
- [x] Does this EIP _really_ need security considerations and a backward compatibility section?
- [x] Can this be merged as "Living"?

Fixes https://github.com/ethereum/EIPs/issues/5048