### PR TITLE
Fixed Deposit Snapshot Endpoint

### DIFF
--- a/EIPS/eip-4881.md
+++ b/EIPS/eip-4881.md
@@ -30,7 +30,7 @@ DepositTreeSnapshot {
 Where the hashes in the `finalized` vector are defined in the [Deposit Finalization Flow](#deposit-finalization-flow) section below, `deposits` is the number of deposits stored in the snapshot, and `execution_block_hash` is the hash of the execution block containing the highest index deposit stored in the snapshot. Consensus clients MUST make this structure available via the Beacon Node API endpoint:
 
 ```
-/eth/v2/beacon/deposit_snapshot
+/eth/v1/beacon/deposit_snapshot
 ```
 
 ### Deposit Finalization Flow


### PR DESCRIPTION
Since this is the first version of this endpoint, it should be `v1`.