### PR TITLE
Update EIP-725

### DIFF
--- a/EIPS/eip-725.md
+++ b/EIPS/eip-725.md
@@ -12,7 +12,7 @@ created: 2017-10-02
 
 ## Simple Summary
 
-A standard interface for a smart contract based account with attachable key value store.
+A standard interface for a smart contract based account with attachable data key/value store.
 
 ## Abstract
 
@@ -25,7 +25,7 @@ The standard is divided into two sub standards:
 Can execute arbitrary smart contracts and deploy other smart contracts.
 
 `ERC725Y`:
-Can hold arbitrary data through a generic key/value store.
+Can hold arbitrary data through a generic data key/value store.
 
 ## Motivation
 
@@ -100,57 +100,57 @@ ERC165 identifier: `0x714df77c`
 #### setData
 
 ```solidity
-function setData(bytes32 key, bytes memory value) public
+function setData(bytes32 dataKey, bytes memory dataValue) public
 ```
 
 Sets data as bytes in the storage for a single key. MUST only be called by the current owner of the contract.
 
 _Parameters:_
 
-- `key`: the key which value to set.
-- `value`: the data to set.
+- `dataKey`: the key which value to set.
+- `dataValue`: the data to set.
 
 **Triggers Event:** [DataChanged](#datachanged)
 #### setData (Array)
 
 ```solidity
-function setData(bytes32[] memory keys, bytes[] memory values) public
+function setData(bytes32[] memory dataKeys, bytes[] memory dataValues) public
 ```
 
 Sets array of data at multiple keys. MUST only be called by the current owner of the contract.
 
 _Parameters:_
 
-- `keys`: the keys which values to set.
-- `values`: the array of bytes to set.
+- `dataKeys`: the keys which values to set.
+- `dataValues`: the array of bytes to set.
 
 **Triggers Event:** [DataChanged](#datachanged)
 #### getData
 
 ```solidity
-function getData(bytes32 key) public view returns(bytes memory)
+function getData(bytes32 dataKey) public view returns(bytes memory)
 ```
 
-Gets the data set for the given key.
+Gets the data set for the given dataKey.
 
 _Parameters:_
 
-- `key`: the key which value to retrieve.
+- `dataKey`: the key which value to retrieve.
 
 _Returns:_ `bytes` , The data for the requested key.
 #### getData (Array)
 
 ```solidity
-function getData(bytes32[] memory keys) public view returns(bytes[] memory)
+function getData(bytes32[] memory dataKeys) public view returns(bytes[] memory)
 ```
 
-Gets array of data at multiple given key.
+Gets array of data at multiple given dataKeys.
 
 _Parameters:_
 
-- `keys`: the keys which values to retrieve.
+- `dataKeys`: the keys which values to retrieve.
 
-_Returns:_ `bytes[]` , array of the values for the requested keys.
+_Returns:_ `bytes[]` , array of the values for the requested dataKeys.
 
 
 
@@ -160,7 +160,7 @@ _Returns:_ `bytes[]` , array of the values for the requested keys.
 #### DataChanged
 
 ```solidity
-event DataChanged(bytes32 indexed key, bytes value)
+event DataChanged(bytes32 indexed dataKey, bytes dataValue)
 ```
 
 MUST be triggered when `setData` was successfully called.
@@ -221,12 +221,12 @@ interface IERC725X  /* is ERC165, ERC173 */ {
 
 //ERC165 identifier: `0x714df77c`
 interface IERC725Y /* is ERC165, ERC173 */ {
-    event DataChanged(bytes32 indexed key, bytes value);
+    event DataChanged(bytes32 indexed dataKey, bytes dataValue);
 
-    function setData(bytes32 key, bytes memory value) external;
-    function setData(bytes32[] memory keys, bytes[] memory values) external;
-    function getData(bytes32 key) external view returns(bytes memory);
-    function getData(bytes32[] memory keys) external view returns(bytes[] memory);
+    function setData(bytes32 dataKey, bytes memory dataValue) external;
+    function setData(bytes32[] memory dataKeys, bytes[] memory dataValues) external;
+    function getData(bytes32 dataKey) external view returns(bytes memory);
+    function getData(bytes32[] memory dataKeys) external view returns(bytes[] memory);
 }
 
 interface IERC725 /* is IERC725X, IERC725Y */ {

--- a/EIPS/eip-725.md
+++ b/EIPS/eip-725.md
@@ -1,9 +1,9 @@
 ---
 eip: 725
-title: General key-value store and execution standard
+title: General data key/value store and execution standard
 author: Fabian Vogelsteller (@frozeman), Tyler Yasaka (@tyleryasaka)
 discussions-to: https://github.com/ethereum/EIPs/issues/725
-status: Draft
+status: Review
 type: Standards Track
 category: ERC
 requires: 165, 173

--- a/EIPS/eip-725.md
+++ b/EIPS/eip-725.md
@@ -97,6 +97,13 @@ MUST be triggered when `execute` creates a new contract using the `operationType
 
 ERC165 identifier: `0x714df77c`
 
+**Note:** `setData()` and `getData()` uses function overloading, therefore it is better to reference them by the given function signature as follows: 
+```js
+myContract.methods['setData(bytes32[],bytes[])']([dataKeys, ...], [dataValues, ...]).send()
+// or 
+myContract.methods['0x14a6e293']([dataKeys, ...], [dataValues, ...]).send()
+```
+
 #### setData
 
 ```solidity

--- a/EIPS/eip-725.md
+++ b/EIPS/eip-725.md
@@ -80,7 +80,7 @@ Others may be added in the future.
 #### Executed
 
 ```solidity
-event Executed(uint256 indexed _operation, address indexed _to, uint256 indexed _value, bytes _data);
+event Executed(uint256 indexed _operation, address indexed _to, uint256 indexed _value, bytes4 _data);
 ```
 
 MUST be triggered when `execute` creates a new call using the `operationType` `0`, `3`, `4`.
@@ -214,7 +214,7 @@ pragma solidity >=0.5.0 <0.7.0;
 //ERC165 identifier: `0x44c028fe`
 interface IERC725X  /* is ERC165, ERC173 */ {
     event ContractCreated(uint256 indexed operation, address indexed contractAddress, uint256 indexed value);
-    event Executed(uint256 indexed operation, address indexed to, uint256 indexed  value, bytes data);
+    event Executed(uint256 indexed operation, address indexed to, uint256 indexed  value, bytes4 data);
 
     function execute(uint256 operationType, address to, uint256 value, bytes calldata data) external payable returns(bytes memory);
 }

--- a/EIPS/eip-725.md
+++ b/EIPS/eip-725.md
@@ -80,7 +80,7 @@ Others may be added in the future.
 #### Executed
 
 ```solidity
-event Executed(uint256 indexed _operation, address indexed _to, uint256 indexed _value, bytes4 _data);
+event Executed(uint256 indexed operation, address indexed to, uint256 indexed value, bytes4 data);
 ```
 
 MUST be triggered when `execute` creates a new call using the `operationType` `0`, `3`, `4`.
@@ -88,7 +88,7 @@ MUST be triggered when `execute` creates a new call using the `operationType` `0
 #### ContractCreated
 
 ```solidity
-event ContractCreated(uint256 indexed _operation, address indexed _contractAddress, uint256 indexed _value);
+event ContractCreated(uint256 indexed operation, address indexed contractAddress, uint256 indexed value);
 ```
 
 MUST be triggered when `execute` creates a new contract using the `operationType` `1`, `2`.

--- a/EIPS/eip-725.md
+++ b/EIPS/eip-725.md
@@ -103,6 +103,8 @@ ERC165 identifier: `0x714df77c`
 function setData(bytes32 dataKey, bytes memory dataValue) public
 ```
 
+Function Signature: `0x7f23690c`
+
 Sets data as bytes in the storage for a single key. MUST only be called by the current owner of the contract.
 
 _Parameters:_
@@ -116,6 +118,8 @@ _Parameters:_
 ```solidity
 function setData(bytes32[] memory dataKeys, bytes[] memory dataValues) public
 ```
+
+Function Signature: `0x14a6e293`
 
 Sets array of data at multiple keys. MUST only be called by the current owner of the contract.
 
@@ -131,6 +135,8 @@ _Parameters:_
 function getData(bytes32 dataKey) public view returns(bytes memory)
 ```
 
+Function Signature: `0x54f6127f`
+
 Gets the data set for the given dataKey.
 
 _Parameters:_
@@ -143,6 +149,8 @@ _Returns:_ `bytes` , The data for the requested key.
 ```solidity
 function getData(bytes32[] memory dataKeys) public view returns(bytes[] memory)
 ```
+
+Function Signature: `0x4e3e6e9c`
 
 Gets array of data at multiple given dataKeys.
 


### PR DESCRIPTION
## What does this PR introduce?
- Adding function signature for ERC725Y functions
- Add an example to use specific notations when calling ERC725Y overloaded functions
- Mark standard as Review instead of draft
- Change the terms keys and values to dataKeys and dataValues.
- Change the term key/value store to data key/value store. (Use key/value store instead of key-value store)
- Edit `Executed` event to use bytes4 instead of bytes