### PR TITLE
[EIP EDITOR NEEDED TO] Debug the EIP bot

### DIFF
--- a/.github/workflows/auto-merge-bot.yml
+++ b/.github/workflows/auto-merge-bot.yml
@@ -1,4 +1,4 @@
-on: [pull_request_target]
+on: [ pull_request_target ]
 name: Auto-Merge Bot
 jobs:
   auto_merge_bot:


### PR DESCRIPTION
This is a test PR. I would like exactly one EIP editor to approve this, and NOT manually merge.

From the EIP bot logs, it appears that only one EIP editor approval is required to make changes to the editor list: https://github.com/ethereum/EIP-Bot/issues/79. This PR tests that by making a normal change to the workflow (which should probably then be reverted if it merges).

If exactly one editor approves this and this is merged, then https://github.com/ethereum/EIP-Bot/issues/79 is a real issue. Otherwise, it's a false alarm.

CC @MicahZoltu @lightclient @SamWilsn