### PR TITLE
EIP-3540: Remove Simplified Implementation section

### DIFF
--- a/EIPS/eip-3540.md
+++ b/EIPS/eip-3540.md
@@ -296,8 +296,6 @@ All cases should be checked for creation transaction, `CREATE` and `CREATE2`.
 
 ## Reference Implementation
 
-### Generic Implementation
-
 ```python
 FORMAT = 0xEF
 MAGIC = 0x00
@@ -349,32 +347,6 @@ def validate_eof(code: bytes):
     # The entire container must be scanned
     assert len(code) == (pos + section_sizes[S_CODE] + section_sizes[S_DATA])
 ```
-
-### Simplified Implementation
-
-Given the rigid rules of EOF1 it is possible to implement support for the container in clients using very simple pattern matching:
-
-```python
-FORMAT = 0xEF
-MAGIC = 0x00
-VERSION = 0x01
-S_TERMINATOR = 0x00
-S_CODE = 0x01
-S_DATA = 0x02
-
-def validate_eof(code: bytes):
-    total_size = 0
-    if len(code) > 7 and code[0] == FORMAT and code[1] == MAGIC and code[2] == VERSION and code[3] == S_CODE and code[6] == S_TERMINATOR:
-        total_size = 7 + ((code[4] << 8) | code[5])
-    elif len(code) > 10 and code[0] == FORMAT and code[1] == MAGIC and code[2] == VERSION and code[3] == S_CODE and code[6] == S_DATA and code[9] == S_TERMINATOR:
-        total_size = 10 + ((code[4] << 8) | code[5]) + ((code[7] << 8) | code[8])
-    else:
-        assert len(code) == 0 or code[0] != FORMAT
-
-    assert len(code) == total_size
-```
-
-However, future versions may introduce more sections or loosen up restrictions, requiring clients to actually parse sections instead of pattern matching.
 
 ## Security Considerations
 


### PR DESCRIPTION
This implementation variant does not handle some of the cases we
currently care about. E.g. section size should never be 0.