### PR TITLE
Update eip-4788.md

### DIFF
--- a/EIPS/eip-4788.md
+++ b/EIPS/eip-4788.md
@@ -113,7 +113,7 @@ The suggested gas cost is just using the value for the `BLOCKHASH` opcode as `BE
 
 ### Why not repurpose `BLOCKHASH`?
 
-The `BLOCKHASH` opcode could be repurposed to provide a beacon block root instead of the current execution block hash.
+The `BLOCKHASH` opcode could be repurposed to provide a beacon state root instead of the current execution block hash.
 To minimize code change and simplify deployment to mainnet, this EIP suggests leaving `BLOCKHASH` alone and adding a new opcode with the desired semantics.
 
 ### Why not bound history of state roots?


### PR DESCRIPTION
Minor change to the wording in the section `Why not repurpose BLOCKHASH?`.  I *think* we want to say `beacon state root` instead of `beacon block root`