### PR TITLE
Update EIP4400 based on community feedback

### DIFF
--- a/EIPS/eip-4400.md
+++ b/EIPS/eip-4400.md
@@ -87,7 +87,8 @@ The `changeConsumer(address _consumer, uint256 _tokenId)` function MAY be implem
 
 The `ConsumerChanged` event MUST be emitted when a consumer is changed.
 
-On every `transfer`, the consumer MUST be changed to the zero address the same way `approve` address is changed.
+On every `transfer`, the consumer MUST be changed to a default address. It is RECOMMENDED for implementors to use 
+`address(0)` as that default address.
 
 The `supportsInterface` method MUST return `true` when called with `0x953c8dfa`.
 


### PR DESCRIPTION
Signed-off-by: Daniel Ivanov <daniel.k.ivanov95@gmail.com>

Updating the restriction on changing the address of the consumer after transfer based on the following [feedback](https://ethereum-magicians.org/t/erc-4400-erc-721-consumer-extension/7371/21?u=daniel-k-ivanov).