### PR TITLE
EIP3156: small fix in code example

### DIFF
--- a/EIPS/eip-3156.md
+++ b/EIPS/eip-3156.md
@@ -257,7 +257,7 @@ import "../interfaces/IERC3156FlashLender.sol";
 contract FlashMinter is ERC20, IERC3156FlashLender {
 
     bytes32 public constant CALLBACK_SUCCESS = keccak256("ERC3156FlashBorrower.onFlashLoan");
-    uint256 public fee; //  1 == 0.0001 %.
+    uint256 public fee; //  1 == 0.01 %.
 
     /**
      * @param fee_ The percentage of the loan `amount` that needs to be repaid, in addition to `amount`.
@@ -364,7 +364,7 @@ contract FlashLender is IERC3156FlashLender {
 
     bytes32 public constant CALLBACK_SUCCESS = keccak256("ERC3156FlashBorrower.onFlashLoan");
     mapping(address => bool) public supportedTokens;
-    uint256 public fee; //  1 == 0.0001 %.
+    uint256 public fee; //  1 == 0.01 %.
 
 
     /**


### PR DESCRIPTION
Fixed comment in code example.
The fee is in bps units (see in `_flashFee`, division by 10,000) -> hence 1 unit of fee is 0.01%

@alcueca 