### PR TITLE
Fixes "spelling error" in diff

### DIFF
--- a/assets/eip-5027/0001-unlimit-code-size.patch
+++ b/assets/eip-5027/0001-unlimit-code-size.patch
@@ -84,7 +84,7 @@ diff --git a/core/state/database.go b/core/state/database.go
 index bbcd2358e..7445e627f 100644
 --- a/core/state/database.go
 +++ b/core/state/database.go
-@@ -194,6 +194,12 @@ func (db *cachingDB) ContractCodeSize(addrHash, codeHash common.Hash) (int, erro
+@@ -194,6 +194,12 @@ func (db *cachingDB) ContractCodeSize(addrHash, codeHash common.Hash) (int, error
  	if cached, ok := db.codeSizeCache.Get(codeHash); ok {
  		return cached.(int), nil
  	}
@@ -118,7 +118,7 @@ diff --git a/core/vm/gas_table.go b/core/vm/gas_table.go
 index 4c2cb3e5c..d0118b1ee 100644
 --- a/core/vm/gas_table.go
 +++ b/core/vm/gas_table.go
-@@ -325,6 +325,16 @@ func gasExpEIP158(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memor
+@@ -325,6 +325,16 @@ func gasExpEIP158(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memory
  	return gas, nil
  }
  


### PR DESCRIPTION
I was hoping that this file would fail once, not every time someone submits a PR.  Unfortunately I was wrong.  I have no idea if this will invalidate the patch, but I'm optimistic that the diff is lenient on line lengths and having a few more characters than the diff's default line length won't break anything.  😬