### PR TITLE
EIP-4844: Change to versioned hashes

### DIFF
--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -351,14 +351,14 @@ We do network-level validation of `BlobTransactionNetworkWrapper` objects as fol
 
 ```python
 def validate_blob_transaction_wrapper(wrapper: BlobTransactionNetworkWrapper):
-    commitments = wrapper.tx.message.blob_commitments
+    versioned_hashes = wrapper.tx.message.blob_versioned_hashes
     kzgs = wrapper.blob_kzgs
     blobs = wrapper.blobs
-    assert len(commitments) == len(kzgs) == len(blobs)
-    for commitment, kzg, blob in zip(commitments, kzgs, blobs):
+    assert len(versioned_hashes) == len(kzgs) == len(blobs)
+    for versioned_hash, kzg, blob in zip(versioned_hashes, kzgs, blobs):
         # note: assert blob is not malformatted
         assert kzg == blob_to_kzg(blob)
-        assert commitment == kzg_to_commitment(kzg)
+        assert versioned_hash == kzg_to_versioned_hash(kzg)
 ```
 
 ## Rationale


### PR DESCRIPTION
In the `validate_blob_transaction_wrapper` function, it uses `blob_commmitments` which doesn't make sense. It makes more sense when it uses `blob_versioned_hashes` instead.
