### PR TITLE
EIP-4400: Text format optimization

### DIFF
--- a/EIPS/eip-4400.md
+++ b/EIPS/eip-4400.md
@@ -14,39 +14,25 @@ requires: 165, 721
 
 ## Abstract
 
-This specification defines standard functions outlining a `consumer` role for instance(s)
-of [ERC-721](./eip-721.md). An implementation allows reading the current `consumer` for a given NFT (`tokenId`) along
-with a standardized event for when an `consumer` has changed. The proposal depends on and extends the
-existing [ERC-721](./eip-721.md).
+This specification defines standard functions outlining a `consumer` role for instance(s) of [ERC-721](./eip-721.md). An implementation allows reading the current `consumer` for a given NFT (`tokenId`) along with a standardized event for when an `consumer` has changed. The proposal depends on and extends the existing [ERC-721](./eip-721.md).
 
 ## Motivation
 
-Many [ERC-721](./eip-721.md) contracts introduce their own custom role that grants permissions for utilising/consuming a
-given NFT instance. The need for that role stems from the fact that other than owning the NFT instance, there are other
-actions that can be performed on an NFT. For example, various metaverses use `operator`
-/`contributor`
-roles for Land (ERC-721), so that owners of the land can authorise other addresses to deploy scenes to them (f.e.
-commissioning a service company to develop a scene).
+Many [ERC-721](./eip-721.md) contracts introduce their own custom role that grants permissions for utilising/consuming a given NFT instance. The need for that role stems from the fact that other than owning the NFT instance, there are other actions that can be performed on an NFT. For example, various metaverses use `operator` / `contributor` roles for Land (ERC-721), so that owners of the land can authorise other addresses to deploy scenes to them (f.e. commissioning a service company to develop a scene).
 
-It is common for NFTs to have utility other than ownership. That being said, it requires a separate standardized
-consumer role, allowing compatibility with user interfaces and contracts, managing those contracts.
+It is common for NFTs to have utility other than ownership. That being said, it requires a separate standardized consumer role, allowing compatibility with user interfaces and contracts, managing those contracts.
 
-Having a `consumer` role will enable protocols to integrate and build on top of dApps that issue ERC-721 tokens.
-One example is the creation of generic/universal NFT renting marketplaces.
+Having a `consumer` role will enable protocols to integrate and build on top of dApps that issue ERC-721 tokens. One example is the creation of generic/universal NFT renting marketplaces.
 
 Example of kinds of contracts and applications that can benefit from this standard are:
-- metaverses that have land and other types of digital assets in those metaverses (scene deployment on land, renting
-land/characters/clothes/passes to events etc.)
-- NFT-based yield-farming. Adopting the standard enables the "staker" (owner of the NFT) to have access to the utility benefits even 
-  after transferring his NFT to the staking contract
+- metaverses that have land and other types of digital assets in those metaverses (scene deployment on land, renting land/characters/clothes/passes to events etc.)
+- NFT-based yield-farming. Adopting the standard enables the "staker" (owner of the NFT) to have access to the utility benefits even after transferring his NFT to the staking contract
 
 ## Specification
 
-The keywords “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and
-“OPTIONAL” in this document are to be interpreted as described in RFC 2119.
+The keywords “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be interpreted as described in RFC 2119.
 
-Every contract compliant to the `ERC721Consumable` extension MUST implement the `IERC721Consumable` interface. The **
-consumer extension** is OPTIONAL for ERC-721 contracts.
+Every contract compliant to the `ERC721Consumable` extension MUST implement the `IERC721Consumable` interface. The **consumer extension** is OPTIONAL for ERC-721 contracts.
 
 ```solidity
 /// @title ERC-721 Consumer Role extension
@@ -76,10 +62,7 @@ interface IERC721Consumable /* is ERC721 */ {
 }
 ```
 
-Every contract implementing the `ERC721Consumable` extension is free to define the permissions of a `consumer` (e.g.
-what are consumers allowed to do within their system) with only one exception - consumers MUST NOT be considered owners,
-authorised operators or approved addresses as per the ERC-721 specification. Thus, they MUST NOT be able to execute
-transfers & approvals.
+Every contract implementing the `ERC721Consumable` extension is free to define the permissions of a `consumer` (e.g. what are consumers allowed to do within their system) with only one exception - consumers MUST NOT be considered owners, authorised operators or approved addresses as per the ERC-721 specification. Thus, they MUST NOT be able to execute transfers & approvals.
 
 The `consumerOf(uint256 _tokenId)` function MAY be implemented as `pure` or `view`.
 
@@ -87,8 +70,7 @@ The `changeConsumer(address _consumer, uint256 _tokenId)` function MAY be implem
 
 The `ConsumerChanged` event MUST be emitted when a consumer is changed.
 
-On every `transfer`, the consumer MUST be changed to a default address. It is RECOMMENDED for implementors to use 
-`address(0)` as that default address.
+On every `transfer`, the consumer MUST be changed to a default address. It is RECOMMENDED for implementors to use `address(0)` as that default address.
 
 The `supportsInterface` method MUST return `true` when called with `0x953c8dfa`.
 
@@ -103,22 +85,17 @@ Key factors influencing the standard:
 
 ### Name
 
-The chosen name resonates with the purpose of its existence. Consumers can be considered entities that utilise the token
-instances, without necessarily having ownership rights to it.
+The chosen name resonates with the purpose of its existence. Consumers can be considered entities that utilise the token instances, without necessarily having ownership rights to it.
 
-The other name for the role that was considered was `operator`, however it is already defined and used within
-the `ERC-721` standard.
+The other name for the role that was considered was `operator`, however it is already defined and used within the `ERC-721` standard.
 
 ### Restriction on the Permissions
 
-There are numerous use-cases where a distinct role for NFTs is required that MUST NOT have owner permissions. A contract
-that implements the consumer role and grants ownership permissions to the consumer renders this standard pointless.
+There are numerous use-cases where a distinct role for NFTs is required that MUST NOT have owner permissions. A contract that implements the consumer role and grants ownership permissions to the consumer renders this standard pointless.
 
 ## Backwards Compatibility
 
-This standard is compatible with current ERC-721 standards. There are no other standards that define a similar role for 
-NFTs and the name (`consumer`) is not used by other ERC-721
-related standards.
+This standard is compatible with current ERC-721 standards. There are no other standards that define a similar role for NFTs and the name (`consumer`) is not used by other ERC-721 related standards.
 
 ## Test Cases
 
@@ -130,10 +107,7 @@ The reference implementation can be found [here](../assets/eip-4400/contracts/ER
 
 ## Security Considerations
 
-Implementors of the `ERC721Consumable` standard must consider thoroughly the permissions they give to `consumers`. Even
-if they implement the standard correctly and do not allow transfer/burning of NFTs, they might still provide permissions
-to the `consumers` that they might not want to provide otherwise and should be restricted to `owners`
-only.
+Implementors of the `ERC721Consumable` standard must consider thoroughly the permissions they give to `consumers`. Even if they implement the standard correctly and do not allow transfer/burning of NFTs, they might still provide permissions to the `consumers` that they might not want to provide otherwise and should be restricted to `owners` only.
 
 ## Copyright
 

--- a/EIPS/eip-4400.md
+++ b/EIPS/eip-4400.md
@@ -25,7 +25,7 @@ It is common for NFTs to have utility other than ownership. That being said, it 
 Having a `consumer` role will enable protocols to integrate and build on top of dApps that issue ERC-721 tokens. One example is the creation of generic/universal NFT renting marketplaces.
 
 Example of kinds of contracts and applications that can benefit from this standard are:
-- metaverses that have land and other types of digital assets in those metaverses (scene deployment on land, renting land/characters/clothes/passes to events etc.)
+- metaverses that have land and other types of digital assets in those metaverses (scene deployment on land, renting land / characters / clothes / passes to events etc.)
 - NFT-based yield-farming. Adopting the standard enables the "staker" (owner of the NFT) to have access to the utility benefits even after transferring his NFT to the staking contract
 
 ## Specification


### PR DESCRIPTION
1. Change paragraphs to one line. The markdown renderer will add the newlines automatically.
2. Add a space before and after the slash makes text easier to read.  Reference: https://www.grammarly.com/blog/slash/