### PR TITLE
Update eip-4804.md

### DIFF
--- a/EIPS/eip-4804.md
+++ b/EIPS/eip-4804.md
@@ -60,13 +60,13 @@ The manual mode will not do any interpretation of **path**, and put **path** as 
 The auto mode is the default mode to resolve (also applies when the "resolveMode" method is unavailable in the target contract). In the auto mode, if **path** is empty, then the protocol will call the target contract with empty calldata. Otherwise, the calldata of the EVM message will use standard Solidity contract ABI, where
 
 - **method** is a string of function method be called
-- **argument_i** is the ith argument of the method. If **type** is specified, the value will be translated to the corresponding type. The protocol currently supports the basic types such as uint256, bytes32, address, and bytes. If **type** is not specified, then the type will be automatically detected using the following rule in a sequential way:
+- **argument_i** is the ith argument of the method. If **type** is specified, the value will be translated to the corresponding type. The protocol currently supports the basic types such as uint256, bytes32, address, bytes, and string. If **type** is not specified, then the type will be automatically detected using the following rule in a sequential way:
 
-1. **type** = "uint256", if **value** is numeric; or
+1. **type**="uint256", if **value** is numeric; or
 2. **type**="bytes32", if **value** is in the form of 0x+32-byte-data hex; or
 3. **type**="address", if **value** is in the form of 0x+20-byte-data hex; or
-4. **type**="address", if **value** is in the form of **name**.**nsProviderSuffix**. In this case, the actual value of the argument will be obtained from **nsProviderSuffix**, e.g., eth, w3q, etc.
-5. else **type**="bytes"
+4. **type**="bytes", if **value** is in the form of 0x followed by any number of bytes besides 20 or 32; or
+5. else **type**="string".
 
 Note that if **method** does not exist, i.e., **path** is empty or "/", then the contract will be called with empty calldata.
 


### PR DESCRIPTION
Update auto type detection with new rules:
- remove type auto-detection on domain names as it may confuse with a filename with suffix (now will treat it as string expect the argument is explicitly address-typed;
- add type auto-detection rule for bytes;
- use string as the final fallback.

