### PR TITLE
fix: Split `transferFrom` flows

### DIFF
--- a/EIPS/eip-4626.md
+++ b/EIPS/eip-4626.md
@@ -377,8 +377,11 @@ Burns `shares` from `owner` and sends exactly `assets` of underlying tokens to `
 
 MUST emit the `Withdraw` event.
 
-MUST support a withdraw flow where the shares are burned from `owner` directly where `owner` is `msg.sender` or `msg.sender` has ERC-20 approval over the shares of `owner`.
- MAY support an additional flow in which the shares are transferred to the Vault contract before the `withdraw` execution, and are accounted for during `withdraw`.
+MUST support a withdraw flow where the shares are burned from `owner` directly where `owner` is `msg.sender`.
+
+MUST support a withdraw flow where the shares are burned from `owner` directly where `msg.sender` has ERC-20 approval over the shares of `owner`.
+
+MAY support an additional flow in which the shares are transferred to the Vault contract before the `withdraw` execution, and are accounted for during `withdraw`.
 
 MUST revert if all of `assets` cannot be withdrawn (due to withdrawal limit being reached, slippage, the owner not having enough shares, etc).
 
@@ -460,8 +463,11 @@ Burns exactly `shares` from `owner` and sends `assets` of underlying tokens to `
 
 MUST emit the `Withdraw` event.
 
-MUST support a redeem flow where the shares are burned from `owner` directly where `owner` is `msg.sender` or `msg.sender` has ERC-20 approval over the shares of `owner`.
- MAY support an additional flow in which the shares are transferred to the Vault contract before the `redeem` execution, and are accounted for during `redeem`.
+MUST support a redeem flow where the shares are burned from `owner` directly where `owner` is `msg.sender`.
+
+MUST support a redeem flow where the shares are burned from `owner` directly where `msg.sender` has ERC-20 approval over the shares of `owner`.
+
+MAY support an additional flow in which the shares are transferred to the Vault contract before the `redeem` execution, and are accounted for during `redeem`.
 
 MUST revert if all of `shares` cannot be redeemed (due to withdrawal limit being reached, slippage, the owner not having enough shares, etc).
 


### PR DESCRIPTION
The language on reusing the `transferFrom` pattern in `withdraw` and `redeem` has been updated to make clear that both flows must be implemented.