### PR TITLE
Run EIP bot on draft PRs

### DIFF
--- a/.github/workflows/auto-merge-bot.yml
+++ b/.github/workflows/auto-merge-bot.yml
@@ -4,7 +4,7 @@ jobs:
   auto_merge_bot:
     runs-on: ubuntu-latest
     name: EIP Auto-Merge Bot
-    if: github.event.pull_request.draft == false && github.repository == 'ethereum/eips'
+    if: github.repository == 'ethereum/eips'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -25,7 +25,7 @@ jobs:
           INFORMATIONAL_EDITORS: "@lightclient,@axic,@gcolvin,@SamWilsn"
           MAINTAINERS: "@alita-moore,@mryalamanchi"
   enable-auto-merge:
-    if: github.repository == 'ethereum/eips'
+    if: github.event.pull_request.draft == false && github.repository == 'ethereum/eips'
     runs-on: ubuntu-latest
     needs: ["auto_merge_bot"]
     steps:


### PR DESCRIPTION
Fixes https://github.com/ethereum/EIP-Bot/issues/48 (probably)

I am making this a draft PR so it doesn't auto-merge. Please provide feedback if there's something that I've missed that might cause an issue!

Explanation: Always runs the EIP Bot (even with drafts). This will also (once some copyediting features are put in place) help users get their EIPs up to spec before requesting a review. It then disables the auto-merge step when the PR is in the draft state.