### PR TITLE
Update EIP-4494: Include EIP-1271 and EIP-2098 as required

### DIFF
--- a/EIPS/eip-4494.md
+++ b/EIPS/eip-4494.md
@@ -12,19 +12,19 @@ requires: 165, 712, 721, 1271, 2098
 ---
 
 ## Abstract
-The "Permit" approval flow outlined in [ERC-2612](./eip-2612.md) has proven a very valuable advancement in UX by creating gasless approvals for ERC20 tokens. This EIP extends the pattern to ERC-721 NFTs. This EIP borrows heavily from ERC-2612.
+The "Permit" approval flow outlined in [EIP-2612](./eip-2612.md) has proven a very valuable advancement in UX by creating gasless approvals for [EIP-20](./eip-20.md) tokens. This EIP extends the pattern to [EIP-721](./eip-721.md) NFTs. This EIP borrows heavily from EIP-2612.
 
-This requires a separate EIP due to the difference in structure between ERC-20 and ERC-721 tokens. While ERC-20 permits use value (the amount of the ERC-20 token being approved) and a nonce based on the owner's address, ERC-721 permits focus on the `tokenId` of the NFT and increment nonce based on the transfers of the NFT.
+This requires a separate EIP due to the difference in structure between EIP-20 and EIP-721 tokens. While EIP-20 permits use value (the amount of the EIP-20 token being approved) and a nonce based on the owner's address, EIP-721 permits focus on the `tokenId` of the NFT and increment nonce based on the transfers of the NFT.
 
 ## Motivation
-The permit structure outlined in [ERC-2612](./eip-2612.md) allows for a signed message (structured as outlined in [ERC-712](./eip-712.md)) to be used in order to create an approval. Whereas the normal approval-based pull flow generally involves two transactions, one to approve a contract and a second for the contract to pull the asset, which is poor UX and often confuses new users, a permit-style flow only requires signing a message and a transaction. Additional information can be found in [ERC-2612](./eip-2612.md).
+The permit structure outlined in [EIP-2612](./eip-2612.md) allows for a signed message (structured as outlined in [EIP-712](./eip-712.md)) to be used in order to create an approval. Whereas the normal approval-based pull flow generally involves two transactions, one to approve a contract and a second for the contract to pull the asset, which is poor UX and often confuses new users, a permit-style flow only requires signing a message and a transaction. Additional information can be found in [EIP-2612](./eip-2612.md).
 
-[ERC-2612](./eip-2612.md) only outlines a permit architecture for ERC-20 tokens. This ERC proposes an architecture for ERC-721 NFTs, which also contain an approve architecture that would benefit from a signed message-based approval flow.
+[EIP-2612](./eip-2612.md) only outlines a permit architecture for EIP-20 tokens. This EIP proposes an architecture for EIP-721 NFTs, which also contain an approve architecture that would benefit from a signed message-based approval flow.
 
 ## Specification
 The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be interpreted as described in RFC 2119.
 
-Three new functions MUST be added to [ERC-721](./eip-721.md):
+Three new functions MUST be added to [EIP-721](./eip-721.md):
 ```solidity
 pragma solidity 0.8.10;
 
@@ -84,7 +84,8 @@ DOMAIN_SEPARATOR = keccak256(
         address(this)
 ));
 ```
-In other words, the message is the following ERC-712 typed structure:
+In other words, the message is the following EIP-712 typed structure:
+
 ```json
 {
   "types": {
@@ -145,7 +146,7 @@ In addition:
 
 Note that nowhere in this definition do we refer to `msg.sender`. The caller of the `permit` function can be any address.
 
-This EIP requires [EIP-165](./eip-165.md). EIP165 is already required in [ERC-721](./eip-721.md), but is further necessary here in order to register the interface of this EIP. Doing so will allow easy verification if an NFT contract has implemented this EIP or not, enabling them to interact accordingly. The interface of this EIP (as defined in EIP-165) is `0x5604e225`. Contracts implementing this EIP MUST have the `supportsInterface` function return `true` when called with `0x5604e225`.
+This EIP requires [EIP-165](./eip-165.md). EIP165 is already required in [EIP-721](./eip-721.md), but is further necessary here in order to register the interface of this EIP. Doing so will allow easy verification if an NFT contract has implemented this EIP or not, enabling them to interact accordingly. The interface of this EIP (as defined in EIP-165) is `0x5604e225`. Contracts implementing this EIP MUST have the `supportsInterface` function return `true` when called with `0x5604e225`.
 
 ## Rationale
 The `permit` function is sufficient for enabling a `safeTransferFrom` transaction to be made without the need for an additional transaction.
@@ -156,14 +157,14 @@ The `nonces` mapping is given for replay protection.
 
 A common use case of permit has a relayer submit a Permit on behalf of the owner. In this scenario, the relaying party is essentially given a free option to submit or withhold the Permit. If this is a cause of concern, the owner can limit the time a Permit is valid for by setting deadline to a value in the near future. The deadline argument can be set to uint(-1) to create Permits that effectively never expire.
 
-ERC-712 typed messages are included because of its use in [ERC-2612](./eip-2612.md), which in turn cites widespread adoption in many wallet providers.
+EIP-712 typed messages are included because of its use in [EIP-2612](./eip-2612.md), which in turn cites widespread adoption in many wallet providers.
 
-While ERC-2612 focuses on the value being approved, this EIP focuses on the `tokenId` of the NFT being approved via `permit`. This enables a flexibility that cannot be achieved with ERC-20 (or even [ERC-1155](./eip-1155.md)) tokens, enabling a single owner to give multiple permits on the same NFT. This is possible since each ERC-721 token is discrete (oftentimes referred to as non-fungible), which allows assertion that this token is still in the possession of the `owner` simply and conclusively.
+While EIP-2612 focuses on the value being approved, this EIP focuses on the `tokenId` of the NFT being approved via `permit`. This enables a flexibility that cannot be achieved with EIP-20 (or even [EIP-1155](./eip-1155.md)) tokens, enabling a single owner to give multiple permits on the same NFT. This is possible since each EIP-721 token is discrete (oftentimes referred to as non-fungible), which allows assertion that this token is still in the possession of the `owner` simply and conclusively.
 
-Whereas ERC-2612 splits signatures into their `v,r,s` components, this EIP opts to instead take a `bytes` array of variable length in order to support [EIP-2098](./eip-2098) signatures (64 bytes), which cannot be easily separated or reconstructed from `r,s,v` components (65 bytes).
+Whereas EIP-2612 splits signatures into their `v,r,s` components, this EIP opts to instead take a `bytes` array of variable length in order to support [EIP-2098](./eip-2098) signatures (64 bytes), which cannot be easily separated or reconstructed from `r,s,v` components (65 bytes).
 
 ## Backwards Compatibility
-There are already some ERC-721 contracts implementing a `permit`-style architecture, most notably Uniswap v3. 
+There are already some EIP-721 contracts implementing a `permit`-style architecture, most notably Uniswap v3. 
 
 Their implementation differs from the specification here in that: 
  * the `permit` architecture is based on `owner`
@@ -191,7 +192,7 @@ A reference implementation has been set up [here](https://github.com/dievardump/
 
 Extra care should be taken when creating transfer functions in which `permit` and a transfer function can be used in one function to make sure that invalid permits cannot be used in any way. This is especially relevant for automated NFT platforms, in which a careless implementation can result in the compromise of a number of user assets.
 
-The remaining considerations have been copied from [ERC-2612](./eip-2612.md) with minor adaptation, and are equally relevant here:
+The remaining considerations have been copied from [EIP-2612](./eip-2612.md) with minor adaptation, and are equally relevant here:
 
 Though the signer of a `Permit` may have a certain party in mind to submit their transaction, another party can always front run this transaction and call `permit` before the intended party. The end result is the same for the `Permit` signer, however.
 
@@ -199,7 +200,7 @@ Since the ecrecover precompile fails silently and just returns the zero address 
 
 Signed `Permit` messages are censorable. The relaying party can always choose to not submit the `Permit` after having received it, withholding the option to submit it. The `deadline` parameter is one mitigation to this. If the signing party holds ETH they can also just submit the `Permit` themselves, which can render previously signed `Permit`s invalid.
 
-The standard [ERC-20 race condition for approvals](https://swcregistry.io/docs/SWC-114) applies to `permit` as well.
+The standard EIP-20 race condition for approvals applies to `permit` as well.
 
 If the `DOMAIN_SEPARATOR` contains the `chainId` and is defined at contract deployment instead of reconstructed for every signature, there is a risk of possible replay attacks between chains in the event of a future chain split.
 

--- a/EIPS/eip-4494.md
+++ b/EIPS/eip-4494.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: ERC
 created: 2021-11-25
-requires: 165, 712, 721, 1271
+requires: 165, 712, 721, 1271, 2098
 ---
 
 ## Abstract

--- a/EIPS/eip-4494.md
+++ b/EIPS/eip-4494.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: ERC
 created: 2021-11-25
-requires: 165, 712, 721
+requires: 165, 712, 721, 1271
 ---
 
 ## Abstract

--- a/EIPS/eip-4494.md
+++ b/EIPS/eip-4494.md
@@ -1,7 +1,7 @@
 ---
 eip: 4494
-title: Permit for ERC-721 NFTs
-description: ERC-712-singed approvals for ERC-721 NFTs
+title: Permit for EIP-721 NFTs
+description: ERC-712-singed approvals for EIP-721 NFTs
 author: Simon Fremaux (@dievardump), William Schwab (@wschwab)
 discussions-to: https://ethereum-magicians.org/t/eip-extending-erc2612-style-permits-to-erc721-nfts/7519/2
 status: Draft
@@ -146,7 +146,7 @@ In addition:
 
 Note that nowhere in this definition do we refer to `msg.sender`. The caller of the `permit` function can be any address.
 
-This EIP requires [EIP-165](./eip-165.md). EIP165 is already required in [EIP-721](./eip-721.md), but is further necessary here in order to register the interface of this EIP. Doing so will allow easy verification if an NFT contract has implemented this EIP or not, enabling them to interact accordingly. The interface of this EIP (as defined in EIP-165) is `0x5604e225`. Contracts implementing this EIP MUST have the `supportsInterface` function return `true` when called with `0x5604e225`.
+This EIP requires [EIP-165](./eip-165.md). EIP-165 is already required in [EIP-721](./eip-721.md), but is further necessary here in order to register the interface of this EIP. Doing so will allow easy verification if an NFT contract has implemented this EIP or not, enabling them to interact accordingly. The interface of this EIP (as defined in EIP-165) is `0x5604e225`. Contracts implementing this EIP MUST have the `supportsInterface` function return `true` when called with `0x5604e225`.
 
 ## Rationale
 The `permit` function is sufficient for enabling a `safeTransferFrom` transaction to be made without the need for an additional transaction.


### PR DESCRIPTION
EIP-1271:
- EIP-4494 currently makes no mention of EIP-1271 but I strongly assume that there is interest to support signature validation through a smart contract
- There are strong reasons to believe so as [@dievardump's reference implementation](https://github.com/dievardump/erc721-with-permits/blob/main/contracts/ERC721WithPermit.sol#L116) uses OZ's [`SignatureChecker` that in turn implements EIP-1271](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/cryptography/SignatureChecker.sol#L36)
- Unclear to me: Whether or not the authors of the EIP document want to further mention 1271. Anyways, at least I think it should be mentioned in the header as required.

EIP-2098:
- document mentions: "sig is a valid secp256k1 or [EIP-2098](https://eips.ethereum.org/EIPS/eip-2098) signature from owner of the tokenId:"
