### PR TITLE
4626 -> fix`caller` is a reserved keyword in vyper

### DIFF
--- a/EIPS/eip-4626.md
+++ b/EIPS/eip-4626.md
@@ -495,7 +495,7 @@ Note that some implementations will require pre-requesting to the Vault before a
 
 #### Deposit
 
-`caller` has exchanged `assets` for `shares`, and transferred those `shares` to `owner`.
+`sender` has exchanged `assets` for `shares`, and transferred those `shares` to `owner`.
 
 MUST be emitted when tokens are deposited into the Vault via the `mint` and `deposit` methods.
 
@@ -504,7 +504,7 @@ MUST be emitted when tokens are deposited into the Vault via the `mint` and `dep
   type: event
 
   inputs:
-    - name: caller
+    - name: sender
       indexed: true
       type: address
     - name: owner
@@ -520,7 +520,7 @@ MUST be emitted when tokens are deposited into the Vault via the `mint` and `dep
 
 #### Withdraw
 
-`caller` has exchanged `shares`, owned by `owner`, for `assets`, and transferred those `assets` to `receiver`.
+`sender` has exchanged `shares`, owned by `owner`, for `assets`, and transferred those `assets` to `receiver`.
 
 MUST be emitted when shares are withdrawn from the Vault in `ERC4626.redeem` or `ERC4626.withdraw` methods.
 
@@ -529,7 +529,7 @@ MUST be emitted when shares are withdrawn from the Vault in `ERC4626.redeem` or 
   type: event
 
   inputs:
-    - name: caller
+    - name: sender
       indexed: true
       type: address
     - name: receiver


### PR DESCRIPTION
CALLER is a solidity OPCODEs, in vyper [OPCODES](https://github.com/vyperlang/vyper/blob/efe1dbef873af6995833d1220a3d56978dfb9de0/vyper/evm/opcodes.py#L69) are not [allowed](https://github.com/vyperlang/vyper/blob/48e326f0685723e24c9d8daa8d13a4011099483b/vyper/semantics/namespace.py#L109) to be used.

I suggest replacing caller by `sender` 