### PR TITLE
Add EIP-5192 - Minimal Soulbound NFTs

### DIFF
--- a/EIPS/eip-5192.md
+++ b/EIPS/eip-5192.md
@@ -35,7 +35,7 @@ pragma solidity ^0.8.0;
 
 interface IERC5192 {
   /// @notice Returns the locking status of an Soulbound Token
-  /// @dev SBTs assigned to zero address are considered invalid, and querie
+  /// @dev SBTs assigned to zero address are considered invalid, and queries
   /// about them do throw.
   /// @param tokenId The identifier for an SBT.
   function locked(uint256 tokenId) external view returns (bool);

--- a/EIPS/eip-5192.md
+++ b/EIPS/eip-5192.md
@@ -29,7 +29,7 @@ The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SH
 
 Upon minting a token implementing this EIP, it must be permanently inseparable from the receiving account. All [EIP-721](./eip-721.md) functions of the contract that transfer the token from one account to another must throw.
 
-To aid recognition that an [EIP-721](./eip-721.md) token implements soulbinding via `EIP-5192`, upon calling [EIP-721](./eip-721.md)'s `function supportsInterface(bytes4 interfaceID) external view returns (bool)` with EIP-5192's `SOULBOUND_VALUE=0x9e7d7f8` as `bytes4 interfaceID`, a contract implementing `EIP-5192` must return `true`.
+To aid recognition that an [EIP-721](./eip-721.md) token implements soulbinding via this EIP upon calling [EIP-721](./eip-721.md)'s `function supportsInterface(bytes4 interfaceID) external view returns (bool)` with EIP-5192's `SOULBOUND_VALUE=0x9e7d7f8` as `bytes4 interfaceID`, a contract implementing this EIP must return `true`.
 
 We compute `SOULBOUND_VALUE` by running the string "soulbound" through `keccak256` and casting it to a `bytes4`:
 

--- a/EIPS/eip-5192.md
+++ b/EIPS/eip-5192.md
@@ -1,7 +1,7 @@
 ---
 eip: 5192
 title: Minimal Soulbound NFTs
-description: Minimal standard interface for soulbinding EIP-721 NFTs
+description: Minimal interface for soulbinding EIP-721 NFTs
 author: Tim Daubenschütz (@TimDaub)
 discussions-to: https://ethereum-magicians.org/t/eip-5192-minimal-soulbound-nfts/9814
 status: Review
@@ -51,6 +51,10 @@ The above model is the simplest possible path towards a canonical interface for 
 ## Backwards Compatibility
 
 This proposal is fully backward compatible with [EIP-721](./eip-721.md).
+
+## Security Considerations
+
+There are no security considerations related directly to the implementation of this standard.
 
 ## Copyright
 

--- a/EIPS/eip-5192.md
+++ b/EIPS/eip-5192.md
@@ -31,8 +31,7 @@ Upon minting an EIP-5192 token, it must be permanently inseparable from the rece
 
 To aid recognition that an [EIP-721](./eip-721.md) token implements soulbinding via `EIP-5192`, upon calling [EIP-721](./eip-721.md)'s `function supportsInterface(bytes4 interfaceID) external view returns (bool)` with EIP-5192's `SOULBOUND_VALUE=0x9e7d7f8` as `bytes4 interfaceID`, a contract implementing `EIP-5192` must return `true`.
 
-We compute `SOULBOUND_VALUE` by running the string "soulbound" through `keccak256`
-and casting it to a `bytes4`:
+We compute `SOULBOUND_VALUE` by running the string "soulbound" through `keccak256` and casting it to a `bytes4`:
 
 ```solidity
 bytes4 constant SOULBOUND_VALUE = bytes4(keccak256("soulbound")); // 0x9e7ed7f8;

--- a/EIPS/eip-5192.md
+++ b/EIPS/eip-5192.md
@@ -29,13 +29,20 @@ The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SH
 
 Upon minting a token implementing this EIP, it must be permanently inseparable from the receiving account. All [EIP-721](./eip-721.md) functions of the contract that transfer the token from one account to another must throw.
 
-To aid recognition that an [EIP-721](./eip-721.md) token implements soulbinding via this EIP upon calling [EIP-721](./eip-721.md)'s `function supportsInterface(bytes4 interfaceID) external view returns (bool)` with EIP-5192's `SOULBOUND_VALUE=0x9e7d7f8` as `bytes4 interfaceID`, a contract implementing this EIP must return `true`.
-
-We compute `SOULBOUND_VALUE` by running the string "soulbound" through `keccak256` and casting it to a `bytes4`:
-
 ```solidity
-bytes4 constant SOULBOUND_VALUE = bytes4(keccak256("soulbound")); // 0x9e7ed7f8;
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.0;
+
+interface IERC5192 {
+  /// @notice Returns the locking status of an Soulbound Token
+  /// @dev SBTs assigned to zero address are considered invalid, and querie
+  /// about them do throw.
+  /// @param tokenId The identifier for an SBT.
+  function locked(uint256 tokenId) external view returns (bool);
+}
 ```
+
+To aid recognition that an [EIP-721](./eip-721.md) token implements soulbinding via this EIP upon calling [EIP-721](./eip-721.md)'s `function supportsInterface(bytes4 interfaceID) external view returns (bool)` with `interfaceID=0xb45a3c0e`, a contract implementing this EIP must return `true`.
 
 ## Rationale
 

--- a/EIPS/eip-5192.md
+++ b/EIPS/eip-5192.md
@@ -43,7 +43,7 @@ The above model is the simplest possible path towards a canonical interface for 
 
 ## Backwards Compatibility
 
-`EIP-5192` is fully backward compatible with [EIP-721](./eip-721.md).
+This proposal is fully backward compatible with [EIP-721](./eip-721.md).
 
 ## Copyright
 

--- a/EIPS/eip-5192.md
+++ b/EIPS/eip-5192.md
@@ -3,7 +3,7 @@ eip: 5192
 title: Minimal Soulbound NFTs
 description: Minimal standard interface for soulbinding EIP-721 NFTs
 author: Tim Daubenschütz (@TimDaub)
-discussions-to: https://ethereum-magicians.org/coming-soon
+discussions-to: https://ethereum-magicians.org/t/eip-5192-minimal-soulbound-nfts/9814
 status: Review
 type: Standards Track
 category: ERC

--- a/EIPS/eip-5192.md
+++ b/EIPS/eip-5192.md
@@ -1,7 +1,7 @@
 ---
-eip: 5555
+eip: 5192
 title: Minimal Soulbound NFTs
-description: Minimal standard interface for soulbinding ERC721 NFTs
+description: Minimal standard interface for soulbinding EIP-721 NFTs
 author: Tim Daubenschütz (@TimDaub)
 discussions-to: https://ethereum-magicians.org/coming-soon
 status: Review
@@ -27,9 +27,9 @@ The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SH
 
 ### Contract Interface
 
-Upon minting an EIP-5555 token, it must be permanently inseparable from the receiving account. All [EIP-721](./eip-721.md) functions of the contract that transfer the token from one account to another must throw.
+Upon minting an EIP-5192 token, it must be permanently inseparable from the receiving account. All [EIP-721](./eip-721.md) functions of the contract that transfer the token from one account to another must throw.
 
-To aid recognition that an [EIP-721](./eip-721.md) token implements soulbinding via `EIP-5555`, upon calling [EIP-721](./eip-721.md)'s `function supportsInterface(bytes4 interfaceID) external view returns (bool)` with EIP-5555's `SOULBOUND_VALUE=0x9e7d7f8` as `bytes4 interfaceID`, a contract implementing `EIP-5555` must return `true`.
+To aid recognition that an [EIP-721](./eip-721.md) token implements soulbinding via `EIP-5192`, upon calling [EIP-721](./eip-721.md)'s `function supportsInterface(bytes4 interfaceID) external view returns (bool)` with EIP-5192's `SOULBOUND_VALUE=0x9e7d7f8` as `bytes4 interfaceID`, a contract implementing `EIP-5192` must return `true`.
 
 We compute `SOULBOUND_VALUE` by running the string "soulbound" through `keccak256`
 and casting it to a `bytes4`:
@@ -44,7 +44,7 @@ The above model is the simplest possible path towards a canonical interface for 
 
 ## Backwards Compatibility
 
-`EIP-5555` is fully backward compatible with [EIP-721](./eip-721.md).
+`EIP-5192` is fully backward compatible with [EIP-721](./eip-721.md).
 
 ## Copyright
 

--- a/EIPS/eip-5192.md
+++ b/EIPS/eip-5192.md
@@ -27,7 +27,7 @@ The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SH
 
 ### Contract Interface
 
-Upon minting an EIP-5192 token, it must be permanently inseparable from the receiving account. All [EIP-721](./eip-721.md) functions of the contract that transfer the token from one account to another must throw.
+Upon minting a token implementing this EIP, it must be permanently inseparable from the receiving account. All [EIP-721](./eip-721.md) functions of the contract that transfer the token from one account to another must throw.
 
 To aid recognition that an [EIP-721](./eip-721.md) token implements soulbinding via `EIP-5192`, upon calling [EIP-721](./eip-721.md)'s `function supportsInterface(bytes4 interfaceID) external view returns (bool)` with EIP-5192's `SOULBOUND_VALUE=0x9e7d7f8` as `bytes4 interfaceID`, a contract implementing `EIP-5192` must return `true`.
 

--- a/EIPS/eip-5192.md
+++ b/EIPS/eip-5192.md
@@ -13,7 +13,7 @@ requires: 165, 721
 
 ## Abstract
 
-This standard is an extension of [EIP-721](./eip-721.md). It proposes a minimal interface to make tokens soulbound using the feature detection functionality of [EIP-165](./eip-165.md).
+This standard is an extension of [EIP-721](./eip-721.md). It proposes a minimal interface to make tokens soulbound using the feature detection functionality of [EIP-165](./eip-165.md). A soulbound token is a non-fungible token bound to a single account.
 
 ## Motivation
 

--- a/EIPS/eip-5555.md
+++ b/EIPS/eip-5555.md
@@ -1,0 +1,51 @@
+---
+eip: 5555
+title: Minimal Soulbound NFTs
+description: Minimal standard interface for soulbinding ERC721 NFTs
+author: Tim Daubenschütz (@TimDaub)
+discussions-to: https://ethereum-magicians.org/coming-soon
+status: Review
+type: Standards Track
+category: ERC
+created: 2022-07-01
+requires: 165, 721
+---
+
+## Abstract
+
+This standard is an extension of [EIP-721](./eip-721.md). It proposes a minimal interface to make tokens soulbound using the feature detection functionality of [EIP-165](./eip-165.md).
+
+## Motivation
+
+The Ethereum community has expressed a need for non-transferrable, non-fungible, and socially-priced tokens similar to World of Warcraft’s soulbound items. But the lack of a token standard leads many developers to simply throw errors upon a user's invocation of transfer functionalities. Over the long term, this will lead to fragmentation and less composability.
+
+In this document, we outline a minimal addition to [EIP-721](./eip-721.md) that allows wallet implementers to check for a token contract's permanent (non-)transferrability using [EIP-165](./eip-165.md).
+
+## Specification
+
+The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY" and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.
+
+### Contract Interface
+
+Upon minting an EIP-5555 token, it must be permanently inseparable from the receiving account. All [EIP-721](./eip-721.md) functions of the contract that transfer the token from one account to another must throw.
+
+To aid recognition that an [EIP-721](./eip-721.md) token implements soulbinding via `EIP-5555`, upon calling [EIP-721](./eip-721.md)'s `function supportsInterface(bytes4 interfaceID) external view returns (bool)` with EIP-5555's `SOULBOUND_VALUE=0x9e7d7f8` as `bytes4 interfaceID`, a contract implementing `EIP-5555` must return `true`.
+
+We compute `SOULBOUND_VALUE` by running the string "soulbound" through `keccak256`
+and casting it to a `bytes4`:
+
+```solidity
+bytes4 constant SOULBOUND_VALUE = bytes4(keccak256("soulbound")); // 0x9e7ed7f8;
+```
+
+## Rationale
+
+The above model is the simplest possible path towards a canonical interface for Soulbound tokens. It reflects upon the numerous Soulbound token implementations that simply revert upon transfers.
+
+## Backwards Compatibility
+
+`EIP-5555` is fully backward compatible with [EIP-721](./eip-721.md).
+
+## Copyright
+
+Copyright and related rights waived via [CC0](../LICENSE.md).


### PR DESCRIPTION
- I was looking at many of the current Soulbound token implementations and it upset me that they all revert upon transfer
- At least it'd be nice if developers would allow wallets to understand that a token is permanently non-transferrable
- With my previous attempt at Soulbound tokens (EIP-4973), we got a bit lost in the details
- This attempt is much cleaner: Yes, it still permanently binds a token to an account. But that's fine: Users are doing this and it'd be dogmatic to make that a taboo around here
- Rather, with this change, I think, if implementers adopt it, it'll actually make the life of wallet implementers easier.
- I put status: Review right away. I think this EIP is done and can be peer-reviewed