### PR TITLE
fix: Added "override" keyword to the ownerOf function in the ERC-4973 contract

### DIFF
--- a/assets/eip-4973/ERC-4973.sol
+++ b/assets/eip-4973/ERC-4973.sol
@@ -138,7 +138,7 @@ abstract contract ERC4973 is ERC165, IERC721Metadata, IERC4973 {
     return _balances[owner];
   }
 
-  function ownerOf(uint256 tokenId) public view virtual returns (address) {
+  function ownerOf(uint256 tokenId) public view virtual override returns (address) {
     address owner = _owners[tokenId];
     require(owner != address(0), "ownerOf: token doesn't exist");
     return owner;

--- a/assets/eip-4973/ERC-4973.sol
+++ b/assets/eip-4973/ERC-4973.sol
@@ -57,8 +57,8 @@ interface IERC721Metadata {
 
 /// @title Account-bound tokens
 /// @dev See https://eips.ethereum.org/EIPS/eip-4973
-///  Note: the ERC-165 identifier for this interface is 0x5164cf47.
-interface IERC4973 /* is ERC165, ERC721Metadata */ {
+/// Note: the ERC-165 identifier for this interface is 0x5164cf47
+interface IERC4973 {
   /// @dev This emits when a new token is created and bound to an account by
   /// any mechanism.
   /// Note: For a reliable `from` parameter, retrieve the transaction's
@@ -108,7 +108,7 @@ abstract contract ERC4973 is ERC165, IERC721Metadata, IERC4973 {
     _symbol = symbol_;
   }
 
-  function supportsInterface(bytes4 interfaceId) public view override returns (bool) {
+  function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
     return
       interfaceId == type(IERC721Metadata).interfaceId ||
       interfaceId == type(IERC4973).interfaceId ||
@@ -171,4 +171,3 @@ abstract contract ERC4973 is ERC165, IERC721Metadata, IERC4973 {
     emit Revoke(owner, tokenId);
   }
 }
-

--- a/assets/eip-4973/ERC-4973.sol
+++ b/assets/eip-4973/ERC-4973.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: CC0-1.0
-pragma solidity ^0.8.6;
+pragma solidity ^0.8.8;
 
 // OpenZeppelin Contracts v4.4.1 (utils/introspection/ERC165.sol)
 
@@ -138,7 +138,7 @@ abstract contract ERC4973 is ERC165, IERC721Metadata, IERC4973 {
     return _balances[owner];
   }
 
-  function ownerOf(uint256 tokenId) public view virtual override returns (address) {
+  function ownerOf(uint256 tokenId) public view virtual returns (address) {
     address owner = _owners[tokenId];
     require(owner != address(0), "ownerOf: token doesn't exist");
     return owner;


### PR DESCRIPTION
A compile error occurs because the ownerOf function is overridden but there is no "override" keyword
