### PR TITLE
Update EIP-2612: Move to Last Call

### DIFF
--- a/EIPS/eip-2612.md
+++ b/EIPS/eip-2612.md
@@ -4,7 +4,8 @@ title: permit – 712-signed approvals
 description: ERC-20 approvals via secp256k1 signatures
 author: Martin Lundfall (@Mrchico)
 discussions-to: https://github.com/ethereum/EIPs/issues/2613
-status: Review
+status: Last Call
+last-call-deadline: 2022-07-30
 type: Standards Track
 category: ERC
 created: 2020-04-13


### PR DESCRIPTION
eip-2612 has been discussed for 2 years and seen wide implementation in production ([uniswapV2](https://github.com/Uniswap/v2-core/blob/master/contracts/UniswapV2ERC20.sol)) and in contract libraries like [openzeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC20/extensions/draft-ERC20Permit.sol) and [solmate](https://github.com/Rari-Capital/solmate/blob/main/src/tokens/ERC20.sol). It seems time to finalize and move this as a standard extension for erc20 fungible tokens.


