### PR TITLE
Update EIP-2565: Update Spec

### DIFF
--- a/EIPS/eip-2565.md
+++ b/EIPS/eip-2565.md
@@ -27,18 +27,24 @@ def calculate_multiplication_complexity(base_length, modulus_length):
     words = math.ceil(max_length / 8)
     return words**2
 
-def calculate_iteration_count(exponent_length, exponent):
+def calculate_iteration_count(exponent_length, exponent_head):
+    bit_length = exponent_head.bit_length()
+    if bit_length > 0:
+        bit_length -= 1
+
     iteration_count = 0
-    if exponent_length <= 32 and exponent == 0: iteration_count = 0
-    elif exponent_length <= 32: iteration_count = exponent.bit_length() - 1
-    elif exponent_length > 32: iteration_count = (8 * (exponent_length - 32)) + ((exponent & (2**256 - 1)).bit_length() - 1)
+    if exponent_length <= 32 and exponent_head == 0: iteration_count = 0
+    elif exponent_length <= 32: iteration_count = bit_length
+    elif exponent_length > 32: iteration_count = (8 * (exponent_length - 32)) + bit_length
     return max(iteration_count, 1)
 
-def calculate_gas_cost(base_length, modulus_length, exponent_length, exponent):
+def calculate_gas_cost(base_length, modulus_length, exponent_length, exponent_head):
     multiplication_complexity = calculate_multiplication_complexity(base_length, modulus_length)
-    iteration_count = calculate_iteration_count(exponent_length, exponent)
-    return max(200, math.floor(multiplication_complexity * iteration_count / 3))
+    iteration_count = calculate_iteration_count(exponent_length, exponent_head)
+    return max(200, math.floor((multiplication_complexity * iteration_count) / 3))
 ```
+
+Where `exponent_head` is the unsigned integer decoded from the exponent's first 32 bytes (or all of its bytes, if shorter).
 
 ## Rationale
 After benchmarking the ModExp precompile, we discovered that it is ‘overpriced’ relative to other precompiles. We also discovered that the current gas pricing formula could be improved to better estimate the computational complexity of various ModExp input variables. The following changes improve the accuracy of the `ModExp` pricing:


### PR DESCRIPTION
The algorithm specified in this EIP has some ambiguities:

 - `exponent` isn't actually the full exponent, but rather just the first 32 bytes of it.
 - In Python, `(0).bit_length()` is zero, which leads to ambiguity with signed integers in the case where `exponent_length > 32`

References:

 - [Geth](https://github.com/ethereum/go-ethereum/blob/d740d6e741562e98b3d75a98e7decdfee3bdd904/core/vm/contracts.go#L328)
 - [Nethermind](https://github.com/NethermindEth/nethermind/blob/2e4bc1c82655f064472b886e0f14e4d589d6f8c1/src/Nethermind/Nethermind.Evm/Precompiles/ModExpPrecompile.cs#L78)