### PR TITLE
Fix typos in EIP-5189

### DIFF
--- a/EIPS/eip-5189.md
+++ b/EIPS/eip-5189.md
@@ -108,14 +108,14 @@ The `endorser` contracts may behave maliciously or erratically in the following 
 
 The bundler must always discard and re-evaluate the readiness status after a change on any of the dependencies of the `operation`, meaning that only operations considered `ready` are candidates for constructing the next block.
 
-If, when simulating the final inclusion of the operation, the bundler discovers that it does not result in correct payment (either because the transaction fails, or transfered amount is below the defined fee), then it should proceed to ban the `endorser` for one of the following reasons:
+If, when simulating the final inclusion of the operation, the bundler discovers that it does not result in correct payment (either because the transaction fails, or transferred amount is below the defined fee), then it should proceed to ban the `endorser` for one of the following reasons:
 
 1) The `endorser` returns `isOperationReady == true` even though the `operation` is not healthy to be included in a block.
 2) The `operation` changed readiness status from `true` to `false` while all dependencies remained unchanged.
 
 After an `endorser` is banned, the mempool operator should drop all `operations` related to such endorser.
 
-> Notice: The mempool operator could call one last time `isOperationReady` to determine if the `endorser` should be banned because `(1)` or `(2)`, but this step is not strictly neccesary since both scenarios lead to the `endoser` being banned.
+> Notice: The mempool operator could call one last time `isOperationReady` to determine if the `endorser` should be banned because `(1)` or `(2)`, but this step is not strictly necessary since both scenarios lead to the `endoser` being banned.
 
 ### Client behavior upon receiving an operation
 When a client receives an `operation`, it must first run some basic sanity checks, namely that:
@@ -124,17 +124,17 @@ When a client receives an `operation`, it must first run some basic sanity check
 * The endorser (i) is registered and has enough burn (>= `MIN_ENDORSER_BURN`), and (ii) it has not been internally flagged as banned.
 * The `gasLimit` is at least the cost of a `CALL` with a non-zero value.
 * The `maxFeePerGas` and `priorityPerGas` are above a configurable minimum value the client is willing to accept.
-* If another operation exists in the mempool with the exact same dependency set AND the same endorser address, the `maxFeePerGas` and `priorityFeePerGas` of the newly received operation MUST be 12% higher than the one on the mempool to replace it. (Similiar with how EOA with same nonce work)
+* If another operation exists in the mempool with the exact same dependency set AND the same endorser address, the `maxFeePerGas` and `priorityFeePerGas` of the newly received operation MUST be 12% higher than the one on the mempool to replace it. (Similar with how EOA with same nonce work)
 
 If the `operation` passes these checks, then the client MUST call `isOperationReady()` on the `endorser`. If the endorser considers the operation ready, then the client MUST add the operation to the mempool. Otherwise, the operation MUST discarded.
 
-The `endorser` result MUST be invalidated and its readiness be re-evaluated if any of the values of the provided dependencies change. If the operation readiness changes to `false`, the operation MUST be discared.
+The `endorser` result MUST be invalidated and its readiness be re-evaluated if any of the values of the provided dependencies change. If the operation readiness changes to `false`, the operation MUST be discarded.
 
 Before including the operation in a block, a last simulation MUST be performed, this time without calling the `endorser`, but by constructing the block and probing the result. All transactions in the block listed **before** the operation must be simulated and the endorser must be queried again there for readiness in-case some dependencies changed.
 
 If the operation fails during simulation, the endorser must be banned because (i) it returned a bad readiness state or (ii) it changed the operation readiness independently from the dependencies.
 
-Aditional events that must invalidate the readiness are:
+Additional events that must invalidate the readiness are:
 
 * A transaction or operation modifies the same storage slots (as the dependencies) is queued before the given operation.
 


### PR DESCRIPTION
`master` is currently broken due to these typos: https://github.com/ethereum/EIPs/runs/7322877908?check_suite_focus=true

Not sure how #5189 was merged.
