### PR TITLE
Fix eth-bot automerging & configure kodiak

### DIFF
--- a/.github/workflows/auto-merge-bot.yml
+++ b/.github/workflows/auto-merge-bot.yml
@@ -24,11 +24,3 @@ jobs:
           META_EDITORS: "@lightclient,@axic,@gcolvin,@SamWilsn"
           INFORMATIONAL_EDITORS: "@lightclient,@axic,@gcolvin,@SamWilsn"
           MAINTAINERS: "@alita-moore,@mryalamanchi"
-  enable-auto-merge:
-    if: github.event.pull_request.draft == false && github.repository == 'ethereum/eips'
-    runs-on: ubuntu-latest
-    needs: ["auto_merge_bot"]
-    steps:
-    - uses: alexwilson/enable-github-automerge-action@1.0.0
-      with:
-        github-token: ${{ secrets.TOKEN }}

--- a/.kodiak.toml
+++ b/.kodiak.toml
@@ -16,6 +16,3 @@ include_coauthors = true
 include_pull_request_author = true
 include_pull_request_url = true
 
-# Automatically keep PRs ahead of the main branch
-[update]
-always = true

--- a/.kodiak.toml
+++ b/.kodiak.toml
@@ -16,11 +16,6 @@ include_coauthors = true
 include_pull_request_author = true
 include_pull_request_url = true
 
-# Keep dependencies up-to-date automatically 
-[merge.automerge_dependencies]
-versions = ["minor", "patch"] # do not automerge major version upgrades
-usernames = ["dependabot"]
-
 # Automatically keep PRs ahead of the main branch
 [update]
 always = true

--- a/.kodiak.toml
+++ b/.kodiak.toml
@@ -4,12 +4,23 @@ version = 1
 [merge]
 
 method = "squash"
-
-notify_on_conflict = false
-
-dont_wait_on_status_checks = ["EIP Auto-Merge Bot", "Travis CI - Pull Request"]
-
+delete_branch_on_merge = true
 require_automerge_label = false
 
 # important
 block_on_neutral_required_check_runs = true
+
+# Add useful information & co-authors to the PR commit body
+[merge.message]
+include_coauthors = true
+include_pull_request_author = true
+include_pull_request_url = true
+
+# Keep dependencies up-to-date automatically 
+[merge.automerge_dependencies]
+versions = ["minor", "patch"] # do not automerge major version upgrades
+usernames = ["dependabot"]
+
+# Automatically keep PRs ahead of the main branch
+[update]
+always = true


### PR DESCRIPTION
This fixes the "pull request unstable" bug.

~~**The `EIP Auto-Merge Bot` check MUST be added to the branch protection required checks before this can be safely merged.**~~
Never mind, it already is. Yay!