### PR TITLE
Editorial suggestions for EIP-3541

### DIFF
--- a/EIPS/eip-3541.md
+++ b/EIPS/eip-3541.md
@@ -15,7 +15,7 @@ Disallow new code starting with the `0xEF` byte to be deployed. Code already exi
 
 ## Motivation
 
-Contracts conforming to the EVM Object Format (EOF) are going to be validated at deploy time. In order to guarantee that every EOF-formatted contract in the state is valid, we need to prevent already deployed (and not validated) contracts from being recognized as such format. This will be achieved by choosing a byte sequence for the *magic* that doesn't exist in any of the already deployed contracts. To prevent the growth of the search space and to limit the analysis to the contracts existing before this fork, we disallow the starting byte of the format (the first byte of the magic).
+Contracts conforming to the EVM Object Format (EOF), as specified in [EIP-3540](./eip-3540.md) are going to be validated at deploy time. In order to guarantee that every EOF-formatted contract in the state is valid, we need to prevent already deployed (and not validated) contracts from being recognized as such format. This will be achieved by choosing a byte sequence for the *magic* that doesn't exist in any of the already deployed contracts. To prevent the growth of the search space and to limit the analysis to the contracts existing before this fork, we disallow the starting byte of the format (the first byte of the magic).
 
 Should the EVM Object Format proposal not be deployed in the future, the *magic* can be used by other features depending on versioning. In the case versioning becomes obsolete, it is simple to roll this back by allowing contracts starting with the `0xEF` byte to be deployed again.
 


### PR DESCRIPTION
Understood that EIP-3541 is already final, but wondering if it makes more sense to specify EVM Object Format (EOF) with what it refer to.

FYI: @axic