### PR TITLE
Update EIP-1 with requirement of `title` and `description`

### DIFF
--- a/EIPS/eip-1.md
+++ b/EIPS/eip-1.md
@@ -117,9 +117,9 @@ Each EIP must begin with an [RFC 822](https://www.ietf.org/rfc/rfc822.txt) style
 
 `eip`: *EIP number* (this is determined by the EIP editor)
 
-`title`: *The EIP title is a few words, not a complete sentence*
+`title`: *The EIP title is a few words, not a complete sentence. It should not contain `standard` (or similar words.)*
 
-`description`: *Description is one full (short) sentence*
+`description`: *Description is one full (short) sentence. It should not contain `standard` (or similar words.)*
 
 `author`: *The list of the author's or authors' name(s) and/or username(s), or name(s) and email(s). Details are below.*
 


### PR DESCRIPTION
Example: https://github.com/ethereum/EIPs/runs/7331910338?check_suite_focus=true
```
Error: error[preamble-order]: preamble has extra header(s)
 --> EIPS/eip-5247.md:5:1
  |
5 | authors: Zainan Victor Zhou (@xinbenlv)
  | ^^^^^^^ unrecognized header
  |
Error: preamble header `description` should not contain `standard` (or similar words.)
Error: preamble header `title` should not contain `standard` (or similar words.)
Error: error[preamble-req]: preamble is missing header(s): `author`
--> EIPS/eip-5247.md
 |
 |
Error: validation found errors :(
```
