### PR TITLE
EIP-4750: Make type section optional

### DIFF
--- a/EIPS/eip-4750.md
+++ b/EIPS/eip-4750.md
@@ -90,7 +90,7 @@ stack_height = data_stack.height - types[code_section_index].inputs)
 
 Under `PC_post_instruction` we mean the PC position after the entire immediate argument of `CALLF`. Data stack height is saved as it was before function inputs were pushed.
 
-*Note:* Code validation rules of EIP-3670 guarantee there is always an instruction following `CALLF` (since terminating instruction is required to be final one in the section), therefore `PC_post_instruction` always points to an instruction inside section bounds.
+*Note:* Code validation rules of [EIP-3670](./eip-3670.md) guarantee there is always an instruction following `CALLF` (since terminating instruction is required to be final one in the section), therefore `PC_post_instruction` always points to an instruction inside section bounds.
 
 6. Sets `current_section_index` to `code_section_index` and `PC` to `0`, and execution continues in the called section.
 

--- a/EIPS/eip-4750.md
+++ b/EIPS/eip-4750.md
@@ -33,15 +33,17 @@ Furthermore it aims to improve analysis opportunities by encoding the number of 
 2. Total number of code sections MUST NOT exceed 1024.
 3. All code sections MUST precede a data section, if data section is present.
 4. New section with `kind = 3` is introduced called the *type section*.
-5. Exactly one type section MUST be present.
-6. The type section MUST directly precede all code sections.
-7. The type section contains a sequence of pairs of bytes: first byte in a pair encodes number of inputs, and second byte encodes number of outputs of the code section with the same index. *Note:* This implies that there is a limit of 256 stack for the input and in the output.
+5. Exactly one type section MAY be present.
+6. The type section, if present, MUST directly precede all code sections.
+7. The type section, if present, contains a sequence of pairs of bytes: first byte in a pair encodes number of inputs, and second byte encodes number of outputs of the code section with the same index. *Note:* This implies that there is a limit of 256 stack for the input and in the output.
 8. Therefore type section size MUST be `n * 2` bytes, where `n` is the number of code sections.
 9. First code section MUST have 0 inputs and 0 outputs. 
+10. Type section MAY be omitted if only a single code 
+section is present. In that case it implicitly defines 0 inputs and 0 outputs for this code section.
 
 To summarize, a well-formed EOF bytecode will have the following format:
 ```
-bytecode := format, magic, version, type_section_header, (code_section_header)+, [data_section_header], 0, type_section_contents, (code_section_contents)+, [data_section_contents]
+bytecode := magic, version, [type_section_header], (code_section_header)+, [data_section_header], 0, [type_section_contents], (code_section_contents)+, [data_section_contents]
 
 type_section_header := 3, number_of_code_sections * 2 # section kind and size
 type_section_contents := 0, 0, code_section_1_inputs, code_section_1_outputs, code_section_2_inputs, code_section_2_outputs, ..., code_section_n_inputs, code_section_n_outputs


### PR DESCRIPTION
Type section in the container spec should better be optional in order to maintain backwards-compatibility with EOF1 spec.