### PR TITLE
Update EIP-5000: Renumber to EIP-5159

### DIFF
--- a/EIPS/eip-5159.md
+++ b/EIPS/eip-5159.md
@@ -111,4 +111,4 @@ TBA
 
 ## Copyright
 
-Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+Copyright and related rights waived via [CC0](../LICENSE.md).

--- a/EIPS/eip-5159.md
+++ b/EIPS/eip-5159.md
@@ -1,5 +1,5 @@
 ---
-eip: 5000
+eip: 5159
 title: MULDIV instruction
 description: Introduce a new instruction to perform x * y / z in 512-bit precision
 author: Harikrishnan Mulackal (@hrkrshnn), Alex Beregszaszi (@axic), Paweł Bylica (@chfast)


### PR DESCRIPTION
The EIP number was sniped using a bot. In order to discourage sniping,
we're renumbering the EIP to a less attractive number.