### PR TITLE
eip-5202: rename factory to blueprint

### DIFF
--- a/EIPS/eip-5202.md
+++ b/EIPS/eip-5202.md
@@ -1,7 +1,7 @@
 ---
 eip: 5202
-title: Factory contract format
-description: Define a bytecode container format for indexing and utilizing factory contracts
+title: Blueprint contract format
+description: Define a bytecode container format for indexing and utilizing blueprint contracts
 author: Charles Cooper (@charles-cooper), Edward Amor (@skellet0r)
 discussions-to: https://ethereum-magicians.org/t/erc-5202-standard-factory-contract-format/9851
 status: Draft
@@ -12,29 +12,29 @@ requires: 170
 ---
 
 ## Abstract
-Define a standard for "factory" contracts, or contracts which represent initcode that is stored on-chain.
+Define a standard for "blueprint" contracts, or contracts which represent initcode that is stored on-chain.
 
 ## Motivation
-To decrease deployer contract size, a useful pattern is to store initcode on chain as a "factory" contract, and then use `EXTCODECOPY` to copy the initcode into memory, followed by a call to `CREATE` or `CREATE2`. However, this comes with the following problems:
+To decrease deployer contract size, a useful pattern is to store initcode on chain as a "blueprint" contract, and then use `EXTCODECOPY` to copy the initcode into memory, followed by a call to `CREATE` or `CREATE2`. However, this comes with the following problems:
 
-- It is hard for external tools and indexers to detect if a contract is a "regular" runtime contract or a "factory" contract. Heuristically searching for patterns in bytecode to determine if it is initcode poses maintenance and correctness problems.
-- Storing initcode byte-for-byte on-chain is a correctness and security problem. Since the EVM does not have a native way to distinguish between executable code and other types of code, unless the initcode explicitly implements ACL rules, *anybody* can call such a "factory" contract and execute the initcode directly as ordinary runtime code. This is particularly problematic if the initcode stored by the factory contract has side effects such as writing to storage or calling external contracts. If the initcode stored by the factory contract executes a `SELFDESTRUCT` opcode, the factory contract could even be removed, preventing the correct operation of downstream deployer contracts that rely on the factory existing. For this reason, it would be good to prefix factory contracts with a special preamble to prevent execution.
+- It is hard for external tools and indexers to detect if a contract is a "regular" runtime contract or a "blueprint" contract. Heuristically searching for patterns in bytecode to determine if it is initcode poses maintenance and correctness problems.
+- Storing initcode byte-for-byte on-chain is a correctness and security problem. Since the EVM does not have a native way to distinguish between executable code and other types of code, unless the initcode explicitly implements ACL rules, *anybody* can call such a "blueprint" contract and execute the initcode directly as ordinary runtime code. This is particularly problematic if the initcode stored by the blueprint contract has side effects such as writing to storage or calling external contracts. If the initcode stored by the blueprint contract executes a `SELFDESTRUCT` opcode, the blueprint contract could even be removed, preventing the correct operation of downstream deployer contracts that rely on the blueprint existing. For this reason, it would be good to prefix blueprint contracts with a special preamble to prevent execution.
 
 ## Specification
 The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be interpreted as described in RFC 2119.
 
-A factory contract MUST use the preamble `0xFE71<version bits><length encoding bits>`. 6 bits are allocated to the version, and 2 bits to the length encoding. The first version begins at 0 (`0b000000`), and versions increment by 1. The value `0b11` for `<length encoding bits>` is reserved. In the case that the length bits are `0b11`, the third byte is considered a continuation byte (that is, the version requires multiple bytes to encode). The exact encoding of a multi-byte version is left to a future ERC.
+A blueprint contract MUST use the preamble `0xFE71<version bits><length encoding bits>`. 6 bits are allocated to the version, and 2 bits to the length encoding. The first version begins at 0 (`0b000000`), and versions increment by 1. The value `0b11` for `<length encoding bits>` is reserved. In the case that the length bits are `0b11`, the third byte is considered a continuation byte (that is, the version requires multiple bytes to encode). The exact encoding of a multi-byte version is left to a future ERC.
 
-A factory contract MUST contain at least one byte of initcode.
+A blueprint contract MUST contain at least one byte of initcode.
 
-A factory contract MAY insert any bytes (data or code) between the version byte(s) and the initcode. If such variable length data is used, the preamble must be `0xFE71<version bits><length encoding bits><length bytes><data>`. The `<length encoding bits>` represent a number between 0 and 2 (inclusive) describing how many bytes `<length bytes>` takes, and `<length bytes>` is the big-endian encoding of the number of bytes that `<data>` takes.
+A blueprint contract MAY insert any bytes (data or code) between the version byte(s) and the initcode. If such variable length data is used, the preamble must be `0xFE71<version bits><length encoding bits><length bytes><data>`. The `<length encoding bits>` represent a number between 0 and 2 (inclusive) describing how many bytes `<length bytes>` takes, and `<length bytes>` is the big-endian encoding of the number of bytes that `<data>` takes.
 
 ## Rationale
 - To save gas and storage space, the preamble should be as minimal as possible.
 
-- It is considered "bad" behavior to try to CALL a factory contract directly, therefore the preamble starts with `INVALID (0xfe)` to end execution with an exceptional halting condition (rather than a "gentler" opcode like `STOP (0x00)`).
+- It is considered "bad" behavior to try to CALL a blueprint contract directly, therefore the preamble starts with `INVALID (0xfe)` to end execution with an exceptional halting condition (rather than a "gentler" opcode like `STOP (0x00)`).
 
-- To help distinguish a factory contract from other contracts that may start with `0xFE`, a "magic" byte is used. The value `0x71` was arbitrarily chosen by taking the last byte of the keccak256 hash of the bytestring "factory" (i.e.: `keccak256(b"factory")[-1]`).
+- To help distinguish a blueprint contract from other contracts that may start with `0xFE`, a "magic" byte is used. The value `0x71` was arbitrarily chosen by taking the last byte of the keccak256 hash of the bytestring "blueprint" (i.e.: `keccak256(b"blueprint")[-1]`).
 
 - An empty initcode is disallowed by the spec to prevent what might be a common mistake.
 
@@ -44,7 +44,7 @@ A factory contract MAY insert any bytes (data or code) between the version byte(
 
 - The length of the initcode itself is not included by default in the preamble because it takes space, and it can be trivially determined using `EXTCODESIZE`.
 
-- The EOF ([EIP-3540](./eip-3540.md)) could provide another way of specifying factory contracts, by adding another section kind (3 - initcode). However, it is not yet in the EVM, and we would like to be able to standardize factory contracts today, without relying on EVM changes. If, at some future point, section kind 3 becomes part of the EOF spec, and the EOF becomes part of the EVM, this ERC will be considered to be obsolesced since the EOF validation spec provides much stronger guarantees than this ERC.
+- The EOF ([EIP-3540](./eip-3540.md)) could provide another way of specifying blueprint contracts, by adding another section kind (3 - initcode). However, it is not yet in the EVM, and we would like to be able to standardize blueprint contracts today, without relying on EVM changes. If, at some future point, section kind 3 becomes part of the EOF spec, and the EOF becomes part of the EVM, this ERC will be considered to be obsolesced since the EOF validation spec provides much stronger guarantees than this ERC.
 
 
 ## Backwards Compatibility
@@ -55,12 +55,12 @@ Needs discussion
 ```python
 from typing import Optional, Tuple
 
-def parse_factory_preamble(bytecode: bytes) -> Tuple[int, Optional[bytes], bytes]:
+def parse_blueprint_preamble(bytecode: bytes) -> Tuple[int, Optional[bytes], bytes]:
     """
-    Given bytecode as a sequence of bytes, parse the factory preamble and
+    Given bytecode as a sequence of bytes, parse the blueprint preamble and
     deconstruct the bytecode into:
         the ERC version, preamble data and initcode.
-    Raises an exception if the bytecode is not a valid factory contract
+    Raises an exception if the bytecode is not a valid blueprint contract
     according to this ERC.
     arguments:
         bytecode: a `bytes` object representing the bytecode
@@ -71,7 +71,7 @@ def parse_factory_preamble(bytecode: bytes) -> Tuple[int, Optional[bytes], bytes
         )
     """
     if bytecode[:2] != b"\xFE\x71":
-        raise Exception("Not a factory!")
+        raise Exception("Not a blueprint!")
 
     erc_version = (bytecode[2] & 0b11111100) >> 2
 


### PR DESCRIPTION
It was pointed out to me in private discussion that "factory" is an
overloaded term. In the Maker system, "factory" refers to a contract
which deploys other contracts. In object-oriented programming, a
"factory" is an object for creating other objects. Based on this, the
term "blueprint" is used to avoid confusion with these other usages of
"factory".
