### PR TITLE
Update EIP-1: Decentralize the preferred choice of `discussion-to`

### DIFF
--- a/EIPS/eip-1.md
+++ b/EIPS/eip-1.md
@@ -167,7 +167,7 @@ At least one author must use a GitHub username, in order to get notified on chan
 
 While an EIP is a draft, a `discussions-to` header will indicate the URL where the EIP is being discussed.
 
-A preferred discussion URL is a that URL shall not point to any URL which is ephemeral, and any URL which can get locked over time. The following is a list of recommended choices: 
+A preferred discussion URL is one that is NOT ephemeral, or could get locked in a forseable future. The following is a list of recommended choices: 
 - A post on [Ethereum Magicians](https://ethereum-magicians.org/) that does not intend to be locked.
 - An issue or pull request on [Ethereum/EIPs Github repository](https://github.com/ethereum/EIPs).
 - A post on [ETH Research](https://ethresear.ch)

--- a/EIPS/eip-1.md
+++ b/EIPS/eip-1.md
@@ -167,7 +167,11 @@ At least one author must use a GitHub username, in order to get notified on chan
 
 While an EIP is a draft, a `discussions-to` header will indicate the URL where the EIP is being discussed.
 
-The preferred discussion URL is a topic on [Ethereum Magicians](https://ethereum-magicians.org/). The URL cannot point to Github pull requests, any URL which is ephemeral, and any URL which can get locked over time (i.e. Reddit topics).
+A preferred discussion URL is a that URL shall not point to any URL which is ephemeral, and any URL which can get locked over time. The following is a list of recommended choices: 
+- A post on [Ethereum Magicians](https://ethereum-magicians.org/) that does not intend to be locked.
+- An issue or pull request on [Ethereum/EIPs Github repository](https://github.com/ethereum/EIPs).
+- A post on [ETH Research](https://ethresear.ch)
+
 
 #### `type` header
 

--- a/EIPS/eip-1.md
+++ b/EIPS/eip-1.md
@@ -172,7 +172,6 @@ A preferred discussion URL is one that is NOT ephemeral, or could get locked in 
 - An issue or pull request on [Ethereum/EIPs Github repository](https://github.com/ethereum/EIPs).
 - A post on [ETH Research](https://ethresear.ch)
 
-
 #### `type` header
 
 The `type` header specifies the type of EIP: Standards Track, Meta, or Informational. If the track is Standards please include the subcategory (core, networking, interface, or ERC).


### PR DESCRIPTION
Since there is no guarantee the Ethereum-Magician is going to last forever or never lock post, or delete user account, same as Github, and *requiring* Ethereum-Magician seems a centralize decision, I move to decentralize the recommendation.

FYI: Here is the [WHOIS of ethereum-magicians](https://who.is/whois/ethereum-magicians.org)
Last time it was renewed was on 2022/06/25, and currently is to expire on Feb 2023. Most of the domain information are redacted (why?)

I am curious why are we trusting ethereum-magicians more than ANY OTHER choices?


```
Registrant Contact Information:
NameREDACTED FOR PRIVACY
Organization
AddressREDACTED FOR PRIVACY
CityREDACTED FOR PRIVACY
State / ProvinceParis
Postal CodeREDACTED FOR PRIVACY
CountryFR
PhoneREDACTED FOR PRIVACY
FaxREDACTED FOR PRIVACY
Email

Administrative Contact Information:
NameREDACTED FOR PRIVACY
Organization
AddressREDACTED FOR PRIVACY
CityREDACTED FOR PRIVACY
State / ProvinceParis
Postal CodeREDACTED FOR PRIVACY
CountryFR
PhoneREDACTED FOR PRIVACY
FaxREDACTED FOR PRIVACY
Email

Technical Contact Information:
NameREDACTED FOR PRIVACY
Organization
AddressREDACTED FOR PRIVACY
CityREDACTED FOR PRIVACY
State / ProvinceParis
Postal CodeREDACTED FOR PRIVACY
CountryFR
PhoneREDACTED FOR PRIVACY
FaxREDACTED FOR PRIVACY
Email

Information Updated: 2022-07-25 21:03:03
```