### PR TITLE
Update Stale Bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,13 +20,15 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         ascending: true # Since we have so many issues, the stale bot finds it hard to keep track. This makes sure that at least the oldest are removed.
         # Issue config
-        stale-issue-message: There has been no activity on this issue in a month. It will be closed in a week if no further activity occurs
+        stale-issue-message: There has been no activity on this issue in a month. It will be closed in a week if no further activity occurs.
+        close-issue-message: This issue was closed due to inactivity. If you are still pursuing it, feel free to reopen it.
         days-before-issue-stale: 30
         days-before-issue-close: 7
         exempt-issue-labels: discussions-to,long-term
         stale-issue-label: stale
         # PR config
         stale-pr-message: There has been no activity on this pull request in a month. It will be closed in a week if no further activity occurs.
+        close-pr-message: This pull request was closed due to inactivity. If you are still pursuing it, feel free to reopen it and respond to any feedback or request a review in a comment.
         days-before-pr-stale: 30
         days-before-pr-close: 7
         exempt-pr-labels: long-term

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Mark stale PRs
     steps:
-    - uses: actions/stale@v3
+    - uses: actions/stale@532554b8a8498a0e006fbcde824b048728c4178f
       with:
         # General
         repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,35 +1,33 @@
-name: "Mark stale PRs & Issues"
+name: Mark stale PRs & Issues
 
 on:
   schedule:
-  # Run this every hour, so we are not spammed with changes at once. Later we could consider changing this to once a day.
-  - cron: "0 * * * *"
+  - cron: 0 0 * * *  # Runs at 00:00 UTC every day.
+
+permissions:
+  issues: write
+  pull-requests: write
 
 jobs:
-  stale-pr:
+  stale:
     if: github.repository == 'ethereum/eips'
     runs-on: ubuntu-latest
     name: "Mark stale PRs"
     steps:
     - uses: actions/stale@v3
       with:
+        # General
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        days-before-stale: 60
-        days-before-close: 7
-        stale-pr-label: 'stale'
-        stale-pr-message: 'There has been no activity on this pull request for two months. It will be closed in a week if no further activity occurs. If you would like to move this EIP forward, please respond to any outstanding feedback or add a comment indicating that you have addressed all required feedback and are ready for a review.'
-        close-pr-message: 'This pull request was closed due to inactivity. If you are still pursuing it, feel free to reopen it and respond to any feedback or request a review in a comment.'
-  stale-issue:
-    if: github.repository == 'ethereum/eips'
-    runs-on: ubuntu-latest
-    name: "Mark stale issues"
-    steps:
-    - uses: actions/stale@v3
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        days-before-stale: 180
-        days-before-close: 14
-        exempt-issue-labels: 'discussions-to'
-        stale-issue-label: 'stale'
-        stale-issue-message: 'There has been no activity on this issue for two months. It will be closed in a week if no further activity occurs. If you would like to move this EIP forward, please respond to any outstanding feedback or add a comment indicating that you have addressed all required feedback and are ready for a review.'
-        close-issue-message: 'This issue was closed due to inactivity. If you are still pursuing it, feel free to reopen it and respond to any feedback or request a review in a comment.'
+        ascending: true # Since we have so many issues, the stale bot finds it hard to keep track. This makes sure that at least the oldest are removed.
+        # Issue config
+        stale-issue-message: There has been no activity on this issue in a month. It will be closed in a week if no further activity occurs
+        days-before-issue-stale: 30
+        days-before-issue-close: 7
+        exempt-issue-labels: discussions-to,long-term
+        stale-issue-label: stale
+        # PR config
+        stale-pr-message: There has been no activity on this pull request in a month. It will be closed in a week if no further activity occurs.
+        days-before-pr-stale: 30
+        days-before-pr-close: 7
+        exempt-pr-labels: long-term
+        stale-pr-label: stale

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -27,10 +27,10 @@ jobs:
         exempt-issue-labels: discussions-to,long-term
         stale-issue-label: stale
         # PR config
-        stale-pr-message: There has been no activity on this pull request in a month. It will be closed in a week if no further activity occurs. If you are still pursuing it, feel free to respond to any feedback or request a review in a comment.
+        stale-pr-message: There has been no activity on this pull request in a week. It will be closed in a month if no further activity occurs. If you are still pursuing it, feel free to respond to any feedback or request a review in a comment.
         close-pr-message: This pull request was closed due to inactivity. If you are still pursuing it, feel free to reopen it and respond to any feedback or request a review in a comment.
-        days-before-pr-stale: 30
-        days-before-pr-close: 7
+        days-before-pr-stale: 7
+        days-before-pr-close: 30
         exempt-pr-labels: long-term
         only-pr-labels: newEIPFile,updateEIP,statusChange
-        stale-pr-label: stale
+        stale-pr-label: "waiting: response from author"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ jobs:
   stale:
     if: github.repository == 'ethereum/eips'
     runs-on: ubuntu-latest
-    name: Mark stale PRs
+    name: Mark Stale Issues
     steps:
     - uses: actions/stale@532554b8a8498a0e006fbcde824b048728c4178f
       with:
@@ -32,4 +32,5 @@ jobs:
         days-before-pr-stale: 30
         days-before-pr-close: 7
         exempt-pr-labels: long-term
+        only-pr-labels: newEIPFile,updateEIP,statusChange
         stale-pr-label: stale

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,14 +20,14 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         ascending: true # Since we have so many issues, the stale bot finds it hard to keep track. This makes sure that at least the oldest are removed.
         # Issue config
-        stale-issue-message: There has been no activity on this issue in a month. It will be closed in a week if no further activity occurs.
-        close-issue-message: This issue was closed due to inactivity. If you are still pursuing it, feel free to reopen it.
+        stale-issue-message: There has been no activity on this issue in a month. It will be closed in a week if no further activity occurs. If you are still pursuing it, feel free to respond to any feedback.
+        close-issue-message: This issue was closed due to inactivity. If you are still pursuing it, feel free to reopen it and respond to any feedback.
         days-before-issue-stale: 30
         days-before-issue-close: 7
         exempt-issue-labels: discussions-to,long-term
         stale-issue-label: stale
         # PR config
-        stale-pr-message: There has been no activity on this pull request in a month. It will be closed in a week if no further activity occurs.
+        stale-pr-message: There has been no activity on this pull request in a month. It will be closed in a week if no further activity occurs. If you are still pursuing it, feel free to respond to any feedback or request a review in a comment.
         close-pr-message: This pull request was closed due to inactivity. If you are still pursuing it, feel free to reopen it and respond to any feedback or request a review in a comment.
         days-before-pr-stale: 30
         days-before-pr-close: 7

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ jobs:
   stale:
     if: github.repository == 'ethereum/eips'
     runs-on: ubuntu-latest
-    name: "Mark stale PRs"
+    name: Mark stale PRs
     steps:
     - uses: actions/stale@v3
       with:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,17 +20,17 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         ascending: true # Since we have so many issues, the stale bot finds it hard to keep track. This makes sure that at least the oldest are removed.
         # Issue config
-        stale-issue-message: There has been no activity on this issue in a month. It will be closed in a week if no further activity occurs. If you are still pursuing it, feel free to respond to any feedback.
+        stale-issue-message: There has been no activity on this issue in three months. It will be closed in a week if no further activity occurs. If you are still pursuing it, feel free to respond to any feedback.
         close-issue-message: This issue was closed due to inactivity. If you are still pursuing it, feel free to reopen it and respond to any feedback.
-        days-before-issue-stale: 30
+        days-before-issue-stale: 90
         days-before-issue-close: 7
         exempt-issue-labels: discussions-to,long-term
         stale-issue-label: stale
         # PR config
-        stale-pr-message: There has been no activity on this pull request in a week. It will be closed in a month if no further activity occurs. If you are still pursuing it, feel free to respond to any feedback or request a review in a comment.
+        stale-pr-message: There has been no activity on this pull request in two months. It will be closed in a week if no further activity occurs. If you are still pursuing it, feel free to respond to any feedback or request a review in a comment.
         close-pr-message: This pull request was closed due to inactivity. If you are still pursuing it, feel free to reopen it and respond to any feedback or request a review in a comment.
-        days-before-pr-stale: 7
-        days-before-pr-close: 30
+        days-before-pr-stale: 60
+        days-before-pr-close: 7
         exempt-pr-labels: long-term
         only-pr-labels: newEIPFile,updateEIP,statusChange
-        stale-pr-label: "waiting: response from author"
+        stale-pr-label: stale


### PR DESCRIPTION
- Massively reduces the time required for an issue or PR to become stale or be closed because of it
- Reduces the verbosity of the message
- Reduces the frequency that the bot is run at
- Adds a "long-term" label that can be applied to PRs or issues that are awaiting e.g. author approval (will need to manually be created).
- Other stuff