### PR TITLE
EIP-4626

### DIFF
--- a/EIPS/eip-4626.md
+++ b/EIPS/eip-4626.md
@@ -209,7 +209,7 @@ Note that any unfavorable discrepancy between `convertToShares` and `previewDepo
 
 #### deposit
 
-Mints `shares` Vault shares to `receiver` by depositing exactly `amount` of underlying tokens.
+Mints `shares` Vault shares to `receiver` by depositing exactly `assets` of underlying tokens.
 
 MUST emit the `Deposit` event.
 
@@ -292,7 +292,7 @@ Note that any unfavorable discrepancy between `convertToAssets` and `previewMint
 
 #### mint
 
-Mints exactly `shares` Vault shares to `receiver` by depositing `amount` of underlying tokens.
+Mints exactly `shares` Vault shares to `receiver` by depositing `assets` of underlying tokens.
 
 MUST emit the `Deposit` event.
 


### PR DESCRIPTION
Fix a typo by changing the name of the variable in the explanation of the methods `deposit` and `mint`