### PR TITLE
Move EIP-4987 to Review

### DIFF
--- a/EIPS/eip-4987.md
+++ b/EIPS/eip-4987.md
@@ -1,7 +1,7 @@
 ---
 eip: 4987
-title: Held token standard
-description: Standard interface to query ownership and balance of held tokens
+title: Held token interface
+description: Interface to query ownership and balance of held tokens
 author: Devin Conley (@devinaconley)
 discussions-to: https://ethereum-magicians.org/t/erc-standard-for-held-non-fungible-token-nfts-defi/7117
 status: Review
@@ -13,7 +13,7 @@ requires: 20, 165, 721, 1155
 
 ## Abstract
 
-The proposed standard defines a lightweight interface to expose functional ownership and balances of held tokens. A held token is a token owned by a contract. This standard may be implemented by smart contracts which hold [ERC-20](./eip-20.md), [ERC-721](./eip-721.md), or [ERC-1155](./eip-1155.md) and is intended to be consumed by both on-chain and off-chain systems that rely on ownership and balance verification.
+The proposed standard defines a lightweight interface to expose functional ownership and balances of held tokens. A held token is a token owned by a contract. This standard may be implemented by smart contracts which hold [EIP-20](./eip-20.md), [EIP-721](./eip-721.md), or [EIP-1155](./eip-1155.md) tokens and is intended to be consumed by both on-chain and off-chain systems that rely on ownership and balance verification.
 
 ## Motivation
 
@@ -202,12 +202,12 @@ This interface is designed to be extremely lightweight and compatible with any e
 
 The token address parameter is included to support contracts that can hold multiple token contracts simultaneously. While some contracts may only hold a single token address, this is more general to either scenario.
 
-Separate interfaces are proposed for each token type (ERC20, ERC721, ERC1155) because any contract logic to support holding these different tokens is likely independent. In the scenario where a single contract does hold multiple token types, it can simply implement each appropriate held token interface.
+Separate interfaces are proposed for each token type (EIP-20, EIP-721, EIP-1155) because any contract logic to support holding these different tokens is likely independent. In the scenario where a single contract does hold multiple token types, it can simply implement each appropriate held token interface.
 
 
 ## Backwards Compatibility
 
-Importantly, the proposed specification is fully compatible with all existing ERC20, ERC721, and ERC1155 token contracts. 
+Importantly, the proposed specification is fully compatible with all existing EIP-20, EIP-721, and EIP-1155 token contracts.
 
 Token holder contracts will need to be updated to implement this lightweight interface.
 

--- a/EIPS/eip-4987.md
+++ b/EIPS/eip-4987.md
@@ -4,7 +4,7 @@ title: Held token standard
 description: Standard interface to query ownership and balance of held tokens
 author: Devin Conley (@devinaconley)
 discussions-to: https://ethereum-magicians.org/t/erc-standard-for-held-non-fungible-token-nfts-defi/7117
-status: Draft
+status: Review
 type: Standards Track
 category: ERC
 created: 2021-09-21

--- a/assets/eip-4987/Consumer.sol
+++ b/assets/eip-4987/Consumer.sol
@@ -1,8 +1,6 @@
 /*
 Consumer
 
-https://github.com/devinaconley/token-hold-example
-
 SPDX-License-Identifier: CC0-1.0
 */
 

--- a/assets/eip-4987/Consumer.sol
+++ b/assets/eip-4987/Consumer.sol
@@ -3,7 +3,7 @@ Consumer
 
 https://github.com/devinaconley/token-hold-example
 
-SPDX-License-Identifier: MIT
+SPDX-License-Identifier: CC0-1.0
 */
 
 pragma solidity ^0.8.0;

--- a/assets/eip-4987/IERC1155Holder.sol
+++ b/assets/eip-4987/IERC1155Holder.sol
@@ -1,8 +1,6 @@
 /*
 IERC1155Holder
 
-https://github.com/devinaconley/token-hold-example
-
 SPDX-License-Identifier: CC0-1.0
 */
 

--- a/assets/eip-4987/IERC1155Holder.sol
+++ b/assets/eip-4987/IERC1155Holder.sol
@@ -3,7 +3,7 @@ IERC1155Holder
 
 https://github.com/devinaconley/token-hold-example
 
-SPDX-License-Identifier: MIT
+SPDX-License-Identifier: CC0-1.0
 */
 
 import "@openzeppelin/contracts/interfaces/IERC165.sol";

--- a/assets/eip-4987/IERC20Holder.sol
+++ b/assets/eip-4987/IERC20Holder.sol
@@ -3,7 +3,7 @@ IERC20Holder
 
 https://github.com/devinaconley/token-hold-example
 
-SPDX-License-Identifier: MIT
+SPDX-License-Identifier: CC0-1.0
 */
 
 import "@openzeppelin/contracts/interfaces/IERC165.sol";

--- a/assets/eip-4987/IERC20Holder.sol
+++ b/assets/eip-4987/IERC20Holder.sol
@@ -1,7 +1,6 @@
 /*
 IERC20Holder
 
-https://github.com/devinaconley/token-hold-example
 
 SPDX-License-Identifier: CC0-1.0
 */

--- a/assets/eip-4987/IERC721Holder.sol
+++ b/assets/eip-4987/IERC721Holder.sol
@@ -1,8 +1,6 @@
 /*
 IERC721Holder
 
-https://github.com/devinaconley/token-hold-example
-
 SPDX-License-Identifier: CC0-1.0
 */
 

--- a/assets/eip-4987/IERC721Holder.sol
+++ b/assets/eip-4987/IERC721Holder.sol
@@ -3,7 +3,7 @@ IERC721Holder
 
 https://github.com/devinaconley/token-hold-example
 
-SPDX-License-Identifier: MIT
+SPDX-License-Identifier: CC0-1.0
 */
 
 import "@openzeppelin/contracts/interfaces/IERC165.sol";

--- a/assets/eip-4987/Vault.sol
+++ b/assets/eip-4987/Vault.sol
@@ -3,7 +3,7 @@ Vault
 
 https://github.com/devinaconley/token-hold-example
 
-SPDX-License-Identifier: MIT
+SPDX-License-Identifier: CC0-1.0
 */
 
 pragma solidity ^0.8.0;
@@ -12,10 +12,6 @@ import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 import "./IERC721Holder.sol";
-
-import "hardhat/console.sol";
-import "./IERC1155Holder.sol";
-import "./IERC20Holder.sol";
 
 /**
  * @title Vault
@@ -41,11 +37,6 @@ contract Vault is ERC165, IERC721Holder {
   constructor(address token_, uint256 timelock_) {
     token = IERC721(token_);
     timelock = timelock_;
-    //  console.log("IERC20Holder id: %d", uint256());
-  }
-
-  function debug() public view returns (bytes4) {
-    return type(IERC1155Holder).interfaceId;
   }
 
   /**

--- a/assets/eip-4987/Vault.sol
+++ b/assets/eip-4987/Vault.sol
@@ -1,8 +1,6 @@
 /*
 Vault
 
-https://github.com/devinaconley/token-hold-example
-
 SPDX-License-Identifier: CC0-1.0
 */
 


### PR DESCRIPTION
This moves EIP-4987 into `Review` and also cleans up the example assets.

See ongoing discussion here
https://ethereum-magicians.org/t/erc-standard-for-held-non-fungible-token-nfts-defi/7117