### PR TITLE
Update EIP-4844: Remove system contract concept

### DIFF
--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -235,7 +235,7 @@ def get_origin(tx: SignedBlobTransaction) -> Address:
 ### Header extension
 
 The current header encoding is extended with a new 256-bit unsigned integer field `blob_txs`. This is the running
-total of blob txs included on chain since this EIP was activated. The resulting RLP encoding of the header is therefore:
+total of excess blob txs included on chain since this EIP was activated. The resulting RLP encoding of the header is therefore:
 
 ```
 rlp([
@@ -262,12 +262,9 @@ rlp([
 The value of `blob_txs` can be calculated using the parent header and number of blob transactions in the block.
 
 ```python
-def calc_blob_gas(parent: Header, blob_txs_in_block: int) -> int:
-    # Don't let the new total fall behind the targeted total to avoid
-    # accumulating a long period of very low fees
-    blocks_since_start = header.Number - FORK_BLKNUM
-    targeted_total = blocks_since_start * TARGET_BLOB_TXS_PER_BLOCK
-    return max(header.blob_txs + blob_txs_in_block, targeted_total)
+def calc_excess_blob_txs(parent: Header, blobs: int) -> int:
+    adjusted = parent.blob_txs + blobs
+    return adjusted - min(TARGET_BLOB_TXS_PER_BLOCK, adjusted)
 ```
 
 ### Beacon chain validation
@@ -346,7 +343,7 @@ def get_intrinsic_gas(tx: SignedBlobTransaction, pre_state: ExecState) -> int:
 def get_blob_gas(header: Header) -> int:
     blocks_since_start = get_current_block(pre_state) - FORK_BLKNUM
     targeted_total = blocks_since_start * TARGET_BLOB_TXS_PER_BLOCK
-    actual_total = header.blob_txs
+    actual_total = targeted_total + header.blob_txs
     if actual_total < targeted_total:
         return 0
     else:

--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -49,7 +49,7 @@ Compared to full data sharding, this EIP has a reduced cap on the number of thes
 | `POINT_EVALUATION_PRECOMPILE_ADDRESS` | `Bytes20(0x14)` |
 | `POINT_EVALUATION_PRECOMPILE_GAS` | `50000` |
 | `MAX_BLOBS_PER_BLOCK` | `16` |
-| `TARGET_BLOB_TXS_PER_BLOCK` | `8` |
+| `TARGET_BLOBS_PER_BLOCK` | `8` |
 | `MAX_BLOBS_PER_TX` | `2` |
 | `GASPRICE_UPDATE_FRACTION_PER_BLOB` | `64` |
 | `MAX_VERSIONED_HASHES_LIST_SIZE` | `2**24` |
@@ -264,7 +264,7 @@ The value of `blob_txs` can be calculated using the parent header and number of 
 ```python
 def calc_excess_blob_txs(parent: Header, blobs: int) -> int:
     adjusted = parent.blob_txs + blobs
-    return adjusted - min(TARGET_BLOB_TXS_PER_BLOCK, adjusted)
+    return adjusted - min(TARGET_BLOBS_PER_BLOCK, adjusted)
 ```
 
 ### Beacon chain validation
@@ -342,7 +342,7 @@ def get_intrinsic_gas(tx: SignedBlobTransaction, pre_state: ExecState) -> int:
 
 def get_blob_gas(header: Header) -> int:
     blocks_since_start = get_current_block(pre_state) - FORK_BLKNUM
-    targeted_total = blocks_since_start * TARGET_BLOB_TXS_PER_BLOCK
+    targeted_total = blocks_since_start * TARGET_BLOBS_PER_BLOCK
     actual_total = targeted_total + header.blob_txs
     if actual_total < targeted_total:
         return 0
@@ -500,12 +500,12 @@ sequencers would simply have to switch over to using a new transaction type at t
 ### Blob gasprice update rule
 
 The blob gasprice update rule is intended to approximate the formula `blob_gas = 2**(excess_blobs / GASPRICE_UPDATE_FRACTION_PER_BLOB)`,
-where `excess_blobs` is the total "extra" number of blobs that the chain has accepted relative to the "targeted" number (`TARGET_BLOB_TXS_PER_BLOCK` per block).
+where `excess_blobs` is the total "extra" number of blobs that the chain has accepted relative to the "targeted" number (`TARGET_BLOBS_PER_BLOCK` per block).
 Like EIP-1559, it's a self-correcting formula: as the excess goes higher, the `blob_gas` increases exponentially, reducing usage and eventually forcing the excess back down.
 
 The block-by-block behavior is roughly as follows.
-If in block `N`, `blob_gas = G1`, and block `N` has `X` blobs, then in block `N+1`, `excess_blobs` increases by `X - TARGET_BLOB_TXS_PER_BLOCK`,
-and so the `blob_gas` of block `N+1` increases by a factor of `2**((X - TARGET_BLOB_TXS_PER_BLOCK) / GASPRICE_UPDATE_FRACTION_PER_BLOB)`.
+If in block `N`, `blob_gas = G1`, and block `N` has `X` blobs, then in block `N+1`, `excess_blobs` increases by `X - TARGET_BLOBS_PER_BLOCK`,
+and so the `blob_gas` of block `N+1` increases by a factor of `2**((X - TARGET_BLOBS_PER_BLOCK) / GASPRICE_UPDATE_FRACTION_PER_BLOB)`.
 Hence, it has a similar effect to the existing EIP-1559, but is more "stable" in the sense that it responds in the same way to the same total usage regardless of how it's distributed.
 
 ## Backwards Compatibility

--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -344,7 +344,6 @@ def get_intrinsic_gas(tx: SignedBlobTransaction, pre_state: ExecState) -> int:
     return intrinsic_gas
 
 def get_blob_gas(header: Header) -> int:
-    blocks_since_start = get_current_block(pre_state) - FORK_BLKNUM
     if header.blobs == 0:
         return 0
     else:

--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -49,7 +49,7 @@ Compared to full data sharding, this EIP has a reduced cap on the number of thes
 | `POINT_EVALUATION_PRECOMPILE_ADDRESS` | `Bytes20(0x14)` |
 | `POINT_EVALUATION_PRECOMPILE_GAS` | `50000` |
 | `MAX_BLOBS_PER_BLOCK` | `16` |
-| `TARGET_BLOBS_PER_BLOCK` | `8` |
+| `TARGET_BLOB_TXS_PER_BLOCK` | `8` |
 | `MAX_BLOBS_PER_TX` | `2` |
 | `GASPRICE_UPDATE_FRACTION_PER_BLOB` | `64` |
 | `MAX_VERSIONED_HASHES_LIST_SIZE` | `2**24` |

--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -39,8 +39,6 @@ Compared to full data sharding, this EIP has a reduced cap on the number of thes
 
 | Constant | Value |
 | - | - |
-| `SYSTEM_STATE_ADDRESS` | `0x000.....0100`|
-| `TOTAL_BLOB_TXS_STORAGE_SLOT` | `0` |
 | `BLOB_TX_TYPE` | `Bytes1(0x05)` |
 | `FIELD_ELEMENTS_PER_BLOB` | `4096` |
 | `BLS_MODULUS` | `52435875175126190479447740508185965837690552500527637822603658699938581184513` |
@@ -234,6 +232,44 @@ def get_origin(tx: SignedBlobTransaction) -> Address:
     return ecrecover(tx_hash(tx), int(sig.y_parity)+27, sig.r, sig.s)
 ```
 
+### Header extension
+
+The current header encoding is extended with a new 256-bit unsigned integer field `blob_txs`. This is the running
+total of blob txs included on chain since this EIP was activated. The resulting RLP encoding of the header is therefore:
+
+```
+rlp([
+    parent_hash,
+    ommers_hash,
+    coinbase,
+    state_root,
+    tx_root,
+    receipt_root,
+    bloom,
+    difficulty,
+    number,
+    gas_limit,
+    gas_used,
+    time,
+    extra,
+    mix_digest,
+    nonce,
+    base_fee,
+    blob_txs
+])
+```
+
+The value of `blob_txs` can be calculated using the parent header and number of blob transactions in the block.
+
+```python
+def calc_blob_gas(parent: Header, blob_txs_in_block: int) -> int:
+    # Don't let the new total fall behind the targeted total to avoid
+    # accumulating a long period of very low fees
+    blocks_since_start = header.Number - FORK_BLKNUM
+    targeted_total = blocks_since_start * TARGET_BLOB_TXS_PER_BLOCK
+    return max(header.blob_txs + blob_txs_in_block, targeted_total)
+```
+
 ### Beacon chain validation
 
 On the consensus-layer the blobs are now referenced, but not fully encoded, in the beacon block body.
@@ -290,8 +326,8 @@ For early draft implementations, we simply change `get_blob_gas(pre_state)` to a
 ### Gas price update rule (Full version)
 
 We propose a simple independent EIP-1559-style targeting rule to compute the gas cost of the transaction.
-We use the `TOTAL_BLOB_TXS_STORAGE_SLOT` storage slot of the `SYSTEM_STATE_ADDRESS` address
-to store persistent data needed to compute the cost.
+We use the `blob_txs` header field to store persistent data needed to compute the cost.
+
 Note that unlike existing transaction types, the gas cost is dependent on the pre-state of the block.
 
 ```python
@@ -307,14 +343,10 @@ def get_intrinsic_gas(tx: SignedBlobTransaction, pre_state: ExecState) -> int:
     intrinsic_gas += len(tx.message.blob_versioned_hashes) * get_blob_gas(pre_state)
     return intrinsic_gas
 
-def get_blob_gas(pre_state: ExecState) -> int:
+def get_blob_gas(header: Header) -> int:
     blocks_since_start = get_current_block(pre_state) - FORK_BLKNUM
     targeted_total = blocks_since_start * TARGET_BLOB_TXS_PER_BLOCK
-    actual_total = read_storage(
-        pre_state,
-        SYSTEM_STATE_ADDRESS,
-        TOTAL_BLOB_TXS_STORAGE_SLOT
-    )
+    actual_total = header.blob_txs
     if actual_total < targeted_total:
         return 0
     else:
@@ -322,28 +354,6 @@ def get_blob_gas(pre_state: ExecState) -> int:
             actual_total - targeted_total,
             GASPRICE_UPDATE_FRACTION_PER_BLOB
         )
-```
-
-We update at the end of a block, as follows:
-
-```python
-def update_blob_gas(state: ExecState, blob_txs_in_block: int):
-    current_total = read_storage(
-        state,
-        SYSTEM_STATE_ADDRESS,
-        TOTAL_BLOB_TXS_STORAGE_SLOT
-    )
-    # Don't let the new total fall behind the targeted total to avoid
-    # accumulating a long period of very low fees
-    blocks_since_start = get_current_block(pre_state) - FORK_BLKNUM
-    targeted_total = blocks_since_start * TARGET_BLOB_TXS_PER_BLOCK
-    new_total = max(current_total + blob_txs_in_block, targeted_total)
-    write_storage(
-        state,
-        SYSTEM_STATE_ADDRESS,
-        TOTAL_BLOB_TXS_STORAGE_SLOT,
-        new_total
-    )
 ```
 
 ### Networking
@@ -465,7 +475,6 @@ This EIP also sets the stage for longer-term protocol cleanups:
   and paves the precedent that all new transaction types should be SSZ
 * It defines `TransactionNetworkPayload` to separate network and block encodings of a transaction type
 * Its (cleaner) gas price update rule could be applied to the primary basefee.
-  It also starts the trend toward using the state to store system state instead of having "implied state" such as historical blocks and hashes.
 
 ### How rollups would function
 

--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -234,8 +234,11 @@ def get_origin(tx: SignedBlobTransaction) -> Address:
 
 ### Header extension
 
-The current header encoding is extended with a new 256-bit unsigned integer field `blob_txs`. This is the running
-total of excess blob txs included on chain since this EIP was activated. The resulting RLP encoding of the header is therefore:
+The current header encoding is extended with a new 256-bit unsigned integer field `blobs`. This is the running
+total of excess blobs included on chain since this EIP was activated. If the total number of blobs is below the
+average, `blobs` is capped at zero.
+
+The resulting RLP encoding of the header is therefore:
 
 ```
 rlp([
@@ -255,15 +258,15 @@ rlp([
     mix_digest,
     nonce,
     base_fee,
-    blob_txs
+    blobs
 ])
 ```
 
-The value of `blob_txs` can be calculated using the parent header and number of blob transactions in the block.
+The value of `blobs` can be calculated using the parent header and number of blobs in the block.
 
 ```python
-def calc_excess_blob_txs(parent: Header, blobs: int) -> int:
-    adjusted = parent.blob_txs + blobs
+def calc_excess_blobs(parent: Header, blobs: int) -> int:
+    adjusted = parent.blobs + blobs
     return adjusted - min(TARGET_BLOBS_PER_BLOCK, adjusted)
 ```
 
@@ -323,7 +326,7 @@ For early draft implementations, we simply change `get_blob_gas(pre_state)` to a
 ### Gas price update rule (Full version)
 
 We propose a simple independent EIP-1559-style targeting rule to compute the gas cost of the transaction.
-We use the `blob_txs` header field to store persistent data needed to compute the cost.
+We use the `blobs` header field to store persistent data needed to compute the cost.
 
 Note that unlike existing transaction types, the gas cost is dependent on the pre-state of the block.
 
@@ -342,13 +345,11 @@ def get_intrinsic_gas(tx: SignedBlobTransaction, pre_state: ExecState) -> int:
 
 def get_blob_gas(header: Header) -> int:
     blocks_since_start = get_current_block(pre_state) - FORK_BLKNUM
-    targeted_total = blocks_since_start * TARGET_BLOBS_PER_BLOCK
-    actual_total = targeted_total + header.blob_txs
-    if actual_total < targeted_total:
+    if header.blobs == 0:
         return 0
     else:
         return fake_exponential(
-            actual_total - targeted_total,
+            header.blobs,
             GASPRICE_UPDATE_FRACTION_PER_BLOB
         )
 ```

--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -234,9 +234,9 @@ def get_origin(tx: SignedBlobTransaction) -> Address:
 
 ### Header extension
 
-The current header encoding is extended with a new 256-bit unsigned integer field `blobs`. This is the running
+The current header encoding is extended with a new 256-bit unsigned integer field `excess_blobs`. This is the running
 total of excess blobs included on chain since this EIP was activated. If the total number of blobs is below the
-average, `blobs` is capped at zero.
+average, `excess_blobs` is capped at zero.
 
 The resulting RLP encoding of the header is therefore:
 
@@ -258,16 +258,18 @@ rlp([
     mix_digest,
     nonce,
     base_fee,
-    blobs
+    excess_blobs
 ])
 ```
 
-The value of `blobs` can be calculated using the parent header and number of blobs in the block.
+The value of `excess_blobs` can be calculated using the parent header and number of blobs in the block.
 
 ```python
-def calc_excess_blobs(parent: Header, blobs: int) -> int:
-    adjusted = parent.blobs + blobs
-    return adjusted - min(TARGET_BLOBS_PER_BLOCK, adjusted)
+def calc_excess_blobs(parent: Header, new_blobs: int) -> int:
+    if parent.excess_blobs + new_blobs < TARGET_BLOBS_PER_BLOCK:
+        return 0
+    else:
+        return parent.excess_blobs + new_blobs - TARGET_BLOBS_PER_BLOCK
 ```
 
 ### Beacon chain validation
@@ -344,13 +346,10 @@ def get_intrinsic_gas(tx: SignedBlobTransaction, pre_state: ExecState) -> int:
     return intrinsic_gas
 
 def get_blob_gas(header: Header) -> int:
-    if header.blobs == 0:
-        return 0
-    else:
-        return fake_exponential(
-            header.blobs,
-            GASPRICE_UPDATE_FRACTION_PER_BLOB
-        )
+    return fake_exponential(
+        header.excess_blobs,
+        GASPRICE_UPDATE_FRACTION_PER_BLOB
+    )
 ```
 
 ### Networking


### PR DESCRIPTION
This PR removes the "system contract" concept from EIP-4844. Although the approach has several pros, it tends to be a sticking point in the discussions around EIP-4844 due to the fact that we don't currently have the concept of a system contract with storage and that concept would need to be implemented into clients - whereas the header extension approach has already been performed to add `baseFee` to the header in EIP-1559.

Additionally, it resolves an issue in the original draft that conflated blobs and blob txs.

Will leave in draft until some consensus among authors is reached.