### PR TITLE
Add updateEIP to exempt labels

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -31,4 +31,5 @@ jobs:
         close-pr-message: This pull request was closed due to inactivity. If you are still pursuing it, feel free to reopen it and respond to any feedback or request a review in a comment.
         days-before-pr-stale: 60
         days-before-pr-close: 7
+        exempt-pr-labels: updateEIP
         stale-pr-label: stale


### PR DESCRIPTION
Rationale: if a `updateEIP` PR doesn't get merged immediately, it's either waiting on editor or author approval and should remain open until the author or editor approves.