### PR TITLE
Update eip-4907.md

### DIFF
--- a/EIPS/eip-4907.md
+++ b/EIPS/eip-4907.md
@@ -195,7 +195,7 @@ contract ERC4907 is ERC721, IERC4907 {
         require(_isApprovedOrOwner(msg.sender, tokenId), "ERC4907: transfer caller is not owner nor approved");
         UserInfo storage info =  _users[tokenId];
         info.user = user;
-        info.expires = expires;
+        info.expires = block.timestamp + expires;
         emit UpdateUser(tokenId, user, expires);
     }
 


### PR DESCRIPTION
Updating setUser function
Detail:
Updating the UesrInfo structure in setUser function by adding( block.timestamp +expires).
It support unix timestamp .
If the unix timestamp seconds are provided as an expire argument , UserOf function always return address(0).
So, only have to provide seconds(uint ) in expire argument of setUser function .



