### PR TITLE
Update eip-4626.md

### DIFF
--- a/EIPS/eip-4626.md
+++ b/EIPS/eip-4626.md
@@ -383,6 +383,8 @@ MUST support a withdraw flow where the shares are burned from `owner` directly w
 
 MAY support an additional flow in which the shares are transferred to the Vault contract before the `withdraw` execution, and are accounted for during `withdraw`.
 
+MUST check msg.sender can spend owner funds, assets needs to be converted to shares and shares should be check for allowance.
+
 MUST revert if all of `assets` cannot be withdrawn (due to withdrawal limit being reached, slippage, the owner not having enough shares, etc).
 
 Note that some implementations will require pre-requesting to the Vault before a withdrawal may be performed. Those methods should be performed separately.
@@ -468,6 +470,8 @@ MUST support a redeem flow where the shares are burned from `owner` directly whe
 MUST support a redeem flow where the shares are burned from `owner` directly where `msg.sender` has ERC-20 approval over the shares of `owner`.
 
 MAY support an additional flow in which the shares are transferred to the Vault contract before the `redeem` execution, and are accounted for during `redeem`.
+
+MUST check msg.sender can spend owner funds using allowance.
 
 MUST revert if all of `shares` cannot be redeemed (due to withdrawal limit being reached, slippage, the owner not having enough shares, etc).
 

--- a/EIPS/eip-4626.md
+++ b/EIPS/eip-4626.md
@@ -471,7 +471,7 @@ MUST support a redeem flow where the shares are burned from `owner` directly whe
 
 MAY support an additional flow in which the shares are transferred to the Vault contract before the `redeem` execution, and are accounted for during `redeem`.
 
-MUST check msg.sender can spend owner funds using allowance.
+SHOULD check `msg.sender` can spend owner funds using allowance.
 
 MUST revert if all of `shares` cannot be redeemed (due to withdrawal limit being reached, slippage, the owner not having enough shares, etc).
 

--- a/EIPS/eip-4626.md
+++ b/EIPS/eip-4626.md
@@ -383,7 +383,7 @@ MUST support a withdraw flow where the shares are burned from `owner` directly w
 
 MAY support an additional flow in which the shares are transferred to the Vault contract before the `withdraw` execution, and are accounted for during `withdraw`.
 
-MUST check msg.sender can spend owner funds, assets needs to be converted to shares and shares should be check for allowance.
+MUST check msg.sender can spend owner funds, assets needs to be converted to shares and shares should be checked for allowance.
 
 MUST revert if all of `assets` cannot be withdrawn (due to withdrawal limit being reached, slippage, the owner not having enough shares, etc).
 

--- a/EIPS/eip-4626.md
+++ b/EIPS/eip-4626.md
@@ -1,7 +1,7 @@
 ---
 eip: 4626
 title: Tokenized Vault Standard
-description: A standard for tokenized Vaults with a single underlying ERC-20 token.
+description: A standard for tokenized Vaults with a single underlying EIP-20 token.
 author: Joey Santoro (@joeysantoro), t11s (@transmissions11), Jet Jadeja (@JetJadeja), Alberto Cuesta Cañada (@alcueca), Señor Doggo (@fubuloubu)
 discussions-to: https://ethereum-magicians.org/t/eip-4626-yield-bearing-vault-standard/7900
 status: Final
@@ -14,8 +14,8 @@ requires: 20, 2612
 ## Abstract
 
 The following standard allows for the implementation of a standard API for tokenized Vaults
-representing shares of a single underlying [ERC-20](./eip-20.md) token.
-This standard is an extension on the ERC-20 token that provides basic functionality for depositing
+representing shares of a single underlying [EIP-20](./eip-20.md) token.
+This standard is an extension on the EIP-20 token that provides basic functionality for depositing
 and withdrawing tokens and reading balances.
 
 ## Motivation
@@ -28,20 +28,20 @@ A standard for tokenized Vaults will lower the integration effort for yield-bear
 
 ## Specification
 
-All ERC-4626 tokenized Vaults MUST implement ERC-20 to represent shares.
+All [EIP-4626](./eip-4626.md) tokenized Vaults MUST implement EIP-20 to represent shares.
 If a Vault is to be non-transferrable, it MAY revert on calls to `transfer` or `transferFrom`.
-The ERC-20 operations `balanceOf`, `transfer`, `totalSupply`, etc. operate on the Vault "shares"
+The EIP-20 operations `balanceOf`, `transfer`, `totalSupply`, etc. operate on the Vault "shares"
 which represent a claim to ownership on a fraction of the Vault's underlying holdings.
 
-All ERC-4626 tokenized Vaults MUST implement ERC-20's optional metadata extensions.
+All EIP-4626 tokenized Vaults MUST implement EIP-20's optional metadata extensions.
 The `name` and `symbol` functions SHOULD reflect the underlying token's `name` and `symbol` in some way.
 
-ERC-4626 tokenized Vaults MAY implement [EIP-2612](./eip-2612.md) to improve the UX of approving shares on various integrations.
+EIP-4626 tokenized Vaults MAY implement [EIP-2612](./eip-2612.md) to improve the UX of approving shares on various integrations.
 
 ### Definitions:
 
 - asset: The underlying token managed by the Vault.
-  Has units defined by the corresponding ERC-20 contract.
+  Has units defined by the corresponding EIP-20 contract.
 - share: The token of the Vault. Has a ratio of underlying assets
   exchanged on mint/deposit/withdraw/redeem (as defined by the Vault).
 - fee: An amount of assets or shares charged to the user by the Vault. Fees can exists for
@@ -55,7 +55,7 @@ ERC-4626 tokenized Vaults MAY implement [EIP-2612](./eip-2612.md) to improve the
 
 The address of the underlying token used for the Vault for accounting, depositing, and withdrawing.
 
-MUST be an ERC-20 token contract.
+MUST be an EIP-20 token contract.
 
 MUST _NOT_ revert.
 
@@ -213,7 +213,7 @@ Mints `shares` Vault shares to `receiver` by depositing exactly `assets` of unde
 
 MUST emit the `Deposit` event.
 
-MUST support ERC-20 `approve` / `transferFrom` on `asset` as a deposit flow.
+MUST support EIP-20 `approve` / `transferFrom` on `asset` as a deposit flow.
 MAY support an additional flow in which the underlying tokens are owned by the Vault contract before the `deposit` execution, and are accounted for during `deposit`.
 
 MUST revert if all of `assets` cannot be deposited (due to deposit limit being reached, slippage, the user not approving enough underlying tokens to the Vault contract, etc).
@@ -296,7 +296,7 @@ Mints exactly `shares` Vault shares to `receiver` by depositing `assets` of unde
 
 MUST emit the `Deposit` event.
 
-MUST support ERC-20 `approve` / `transferFrom` on `asset` as a mint flow.
+MUST support EIP-20 `approve` / `transferFrom` on `asset` as a mint flow.
 MAY support an additional flow in which the underlying tokens are owned by the Vault contract before the `mint` execution, and are accounted for during `mint`.
 
 MUST revert if all of `shares` cannot be minted (due to deposit limit being reached, slippage, the user not approving enough underlying tokens to the Vault contract, etc).
@@ -379,7 +379,7 @@ MUST emit the `Withdraw` event.
 
 MUST support a withdraw flow where the shares are burned from `owner` directly where `owner` is `msg.sender`.
 
-MUST support a withdraw flow where the shares are burned from `owner` directly where `msg.sender` has ERC-20 approval over the shares of `owner`.
+MUST support a withdraw flow where the shares are burned from `owner` directly where `msg.sender` has EIP-20 approval over the shares of `owner`.
 
 MAY support an additional flow in which the shares are transferred to the Vault contract before the `withdraw` execution, and are accounted for during `withdraw`.
 
@@ -467,7 +467,7 @@ MUST emit the `Withdraw` event.
 
 MUST support a redeem flow where the shares are burned from `owner` directly where `owner` is `msg.sender`.
 
-MUST support a redeem flow where the shares are burned from `owner` directly where `msg.sender` has ERC-20 approval over the shares of `owner`.
+MUST support a redeem flow where the shares are burned from `owner` directly where `msg.sender` has EIP-20 approval over the shares of `owner`.
 
 MAY support an additional flow in which the shares are transferred to the Vault contract before the `redeem` execution, and are accounted for during `redeem`.
 
@@ -526,7 +526,7 @@ MUST be emitted when tokens are deposited into the Vault via the `mint` and `dep
 
 `sender` has exchanged `shares`, owned by `owner`, for `assets`, and transferred those `assets` to `receiver`.
 
-MUST be emitted when shares are withdrawn from the Vault in `ERC4626.redeem` or `ERC4626.withdraw` methods.
+MUST be emitted when shares are withdrawn from the Vault in `EIP-4626.redeem` or `EIP-4626.withdraw` methods.
 
 ```yaml
 - name: Withdraw
@@ -556,9 +556,9 @@ The Vault interface is designed to be optimized for integrators with a feature c
 Details such as accounting and allocation of deposited tokens are intentionally not specified,
 as Vaults are expected to be treated as black boxes on-chain and inspected off-chain before use.
 
-ERC-20 is enforced because implementation details like token approval
+EIP-20 is enforced because implementation details like token approval
 and balance calculation directly carry over to the shares accounting.
-This standardization makes the Vaults immediately compatible with all ERC-20 use cases in addition to ERC-4626.
+This standardization makes the Vaults immediately compatible with all EIP-20 use cases in addition to EIP-4626.
 
 The mint method was included for symmetry and feature completeness.
 Most current use cases of share-based Vaults do not ascribe special meaning to the shares such that
@@ -571,15 +571,15 @@ For applications that need an exact value that attempts to account for fees and 
 
 ## Backwards Compatibility
 
-ERC-4626 is fully backward compatible with the ERC-20 standard and has no known compatibility issues with other standards.
-For production implementations of Vaults which do not use ERC-4626, wrapper adapters can be developed and used.
+EIP-4626 is fully backward compatible with the EIP-20 standard and has no known compatibility issues with other standards.
+For production implementations of Vaults which do not use EIP-4626, wrapper adapters can be developed and used.
 
-## Reference Implementations
+## Reference Implementation
 
-See [Solmate ERC4626](https://github.com/Rari-Capital/solmate/blob/main/src/mixins/ERC4626.sol):
+See [Solmate EIP-4626](https://github.com/Rari-Capital/solmate/blob/main/src/mixins/ERC4626.sol):
 a minimal and opinionated implementation of the standard with hooks for developers to easily insert custom logic into deposits and withdrawals.
 
-See [Vyper ERC4626](https://github.com/fubuloubu/ERC4626):
+See [Vyper EIP-4626](https://github.com/fubuloubu/ERC4626):
 a demo implementation of the standard in Vyper, with hooks for share price manipulation and other testing needs.
 
 ## Security Considerations
@@ -594,17 +594,17 @@ and do _not_ have to confer the _exact_ amount of underlying assets their contex
 
 The `preview` methods return values that are as close as possible to exact as possible. For that reason, they are manipulable by altering the on-chain conditions and are not always safe to be used as price oracles. This specification includes `convert` methods that are allowed to be inexact and therefore can be implemented as robust price oracles. For example, it would be correct to implement the `convert` methods as using a time-weighted average price in converting between assets and shares.
 
-Integrators of ERC-4626 Vaults should be aware of the difference between these view methods when integrating with this standard. Additionally, note that the amount of underlying assets a user may receive from redeeming their Vault shares (`previewRedeem`) can be significantly different than the amount that would be taken from them when minting the same quantity of shares (`previewMint`). The differences may be small (like if due to rounding error), or very significant (like if a Vault implements withdrawal or deposit fees, etc). Therefore integrators should always take care to use the preview function most relevant to their use case, and never assume they are interchangeable.
+Integrators of EIP-4626 Vaults should be aware of the difference between these view methods when integrating with this standard. Additionally, note that the amount of underlying assets a user may receive from redeeming their Vault shares (`previewRedeem`) can be significantly different than the amount that would be taken from them when minting the same quantity of shares (`previewMint`). The differences may be small (like if due to rounding error), or very significant (like if a Vault implements withdrawal or deposit fees, etc). Therefore integrators should always take care to use the preview function most relevant to their use case, and never assume they are interchangeable.
 
-Finally, ERC-4626 Vault implementers should be aware of the need for specific, opposing rounding directions across the different mutable and view methods, as it is considered most secure to favor the Vault itself during calculations over its users:
+Finally, EIP-4626 Vault implementers should be aware of the need for specific, opposing rounding directions across the different mutable and view methods, as it is considered most secure to favor the Vault itself during calculations over its users:
 
 - If (1) it's calculating how many shares to issue to a user for a certain amount of the underlying tokens they provide or (2) it's determining the amount of the underlying tokens to transfer to them for returning a certain amount of shares, it should round _down_.
 
 - If (1) it's calculating the amount of shares a user has to supply to receive a given amount of the underlying tokens or (2) it's calculating the amount of underlying tokens a user has to provide to receive a certain amount of shares, it should round _up_.
 
-The only functions where the preferred rounding direction would be ambiguous are the `convertTo` functions. To ensure consistency across all ERC-4626 Vault implementations it is specified that these functions MUST both always round _down_. Integrators may wish to mimic rounding up versions of these functions themselves, like by adding 1 wei to the result.
+The only functions where the preferred rounding direction would be ambiguous are the `convertTo` functions. To ensure consistency across all EIP-4626 Vault implementations it is specified that these functions MUST both always round _down_. Integrators may wish to mimic rounding up versions of these functions themselves, like by adding 1 wei to the result.
 
-Although the `convertTo` functions should eliminate the need for any use of an ERC-4626 Vault's `decimals` variable, it is still strongly recommended to mirror
+Although the `convertTo` functions should eliminate the need for any use of an EIP-4626 Vault's `decimals` variable, it is still strongly recommended to mirror
 the underlying token's `decimals` if at all possible, to eliminate possible sources of confusion and simplify integration across front-ends and for other off-chain users.
 
 ## Copyright

--- a/EIPS/eip-4626.md
+++ b/EIPS/eip-4626.md
@@ -383,7 +383,7 @@ MUST support a withdraw flow where the shares are burned from `owner` directly w
 
 MAY support an additional flow in which the shares are transferred to the Vault contract before the `withdraw` execution, and are accounted for during `withdraw`.
 
-MUST check msg.sender can spend owner funds, assets needs to be converted to shares and shares should be checked for allowance.
+SHOULD check `msg.sender` can spend owner funds, assets needs to be converted to shares and shares should be checked for allowance.
 
 MUST revert if all of `assets` cannot be withdrawn (due to withdrawal limit being reached, slippage, the owner not having enough shares, etc).
 

--- a/EIPS/eip-4626.md
+++ b/EIPS/eip-4626.md
@@ -1,6 +1,6 @@
 ---
 eip: 4626
-title: Tokenized Vault Standard
+title: Tokenized Vaults
 description: A standard for tokenized Vaults with a single underlying EIP-20 token.
 author: Joey Santoro (@joeysantoro), t11s (@transmissions11), Jet Jadeja (@JetJadeja), Alberto Cuesta Cañada (@alcueca), Señor Doggo (@fubuloubu)
 discussions-to: https://ethereum-magicians.org/t/eip-4626-yield-bearing-vault-standard/7900

--- a/EIPS/eip-4626.md
+++ b/EIPS/eip-4626.md
@@ -1,7 +1,7 @@
 ---
 eip: 4626
 title: Tokenized Vaults
-description: A standard for tokenized Vaults with a single underlying EIP-20 token.
+description: Tokenized Vaults with a single underlying EIP-20 token.
 author: Joey Santoro (@joeysantoro), t11s (@transmissions11), Jet Jadeja (@JetJadeja), Alberto Cuesta Cañada (@alcueca), Señor Doggo (@fubuloubu)
 discussions-to: https://ethereum-magicians.org/t/eip-4626-yield-bearing-vault-standard/7900
 status: Final


### PR DESCRIPTION
With the recent hack of Byte-Masons/tarot-multi-strategy implementation of 4626, it seems we should make it clear, msg.sender should be allowed to spend owner funds.
