### PR TITLE
Revert "Change Stale Thresholds"

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,14 +22,13 @@ jobs:
         # Issue config
         stale-issue-message: There has been no activity on this issue for six months. It will be closed in a week if no further activity occurs. If you would like to move this EIP forward, please respond to any outstanding feedback or add a comment indicating that you have addressed all required feedback and are ready for a review.
         close-issue-message: This issue was closed due to inactivity. If you are still pursuing it, feel free to reopen it and respond to any feedback.
-        days-before-issue-stale: 7
-        days-before-issue-close: 49 # 49 + 7 weeks = 3 months
-        exempt-issue-labels: discussions-to,long-term
+        days-before-issue-stale: 180
+        days-before-issue-close: 14
+        exempt-issue-labels: discussions-to
         stale-issue-label: stale
         # PR config
         stale-pr-message: There has been no activity on this pull request for two months. It will be closed in a week if no further activity occurs. If you would like to move this EIP forward, please respond to any outstanding feedback or add a comment indicating that you have addressed all required feedback and are ready for a review.
         close-pr-message: This pull request was closed due to inactivity. If you are still pursuing it, feel free to reopen it and respond to any feedback or request a review in a comment.
-        days-before-pr-stale: 14
-        days-before-pr-close: 42 # 42 + 14 weeks = 3 months
-        exempt-pr-labels: long-term
-        stale-pr-label: "waiting: response from author"
+        days-before-pr-stale: 60
+        days-before-pr-close: 7
+        stale-pr-label: stale


### PR DESCRIPTION
Reverts ethereum/EIPs#5360

cc @Pandapip1 I'm reverting this, even though I think it is a good change, in an effort to disincentivize editors from merging changes to the process without getting approval from any other editors or waiting a sufficient amount of time for review.  This isn't the first time someone has merged without acquiring approval/waiting, and I want to make sure that it is clear to everyone that just merging anyway and saying "oops"/"sorry" afterward isn't a viable strategy for forcing changes through.