### PR TITLE
Removes MicahZoltu as EIP editor.

### DIFF
--- a/.github/workflows/auto-merge-bot.yml
+++ b/.github/workflows/auto-merge-bot.yml
@@ -17,9 +17,9 @@ jobs:
         id: auto-merge-bot
         with:
           GITHUB-TOKEN: ${{ secrets.TOKEN }} 
-          CORE_EDITORS: "@MicahZoltu,@lightclient,@axic,@gcolvin,@SamWilsn,@Pandapip1"
+          CORE_EDITORS: "@lightclient,@axic,@gcolvin,@SamWilsn,@Pandapip1"
           ERC_EDITORS: "@lightclient,@axic,@SamWilsn,@Pandapip1"
-          NETWORKING_EDITORS: "@MicahZoltu,@lightclient,@axic,@SamWilsn"
+          NETWORKING_EDITORS: "@lightclient,@axic,@SamWilsn"
           INTERFACE_EDITORS: "@lightclient,@axic,@SamWilsn,@Pandapip1"
           META_EDITORS: "@lightclient,@axic,@gcolvin,@SamWilsn,@Pandapip1"
           INFORMATIONAL_EDITORS: "@lightclient,@axic,@gcolvin,@SamWilsn,@Pandapip1"

--- a/EIPS/eip-1.md
+++ b/EIPS/eip-1.md
@@ -211,17 +211,17 @@ The current EIP editors are
 - Gavin John (@Pandapip1)
 - Greg Colvin (@gcolvin)
 - Matt Garnett (@lightclient)
-- Micah Zoltu (@MicahZoltu)
 - Sam Wilson (@SamWilsn)
 
 Emeritus EIP editors are 
 
 - Casey Detrio (@cdetrio)
-- Nick Johnson (@arachnid)
-- Vitalik Buterin (@vbuterin)
 - Hudson Jameson (@Souptacular)
-- Nick Savers (@nicksavers)
 - Martin Becze (@wanderer)
+- Micah Zoltu (@MicahZoltu)
+- Nick Johnson (@arachnid)
+- Nick Savers (@nicksavers)
+- Vitalik Buterin (@vbuterin)
 
 If you would like to become an EIP editor, please check [EIP-5069](./eip-5069.md).
 


### PR DESCRIPTION
**Context**: We now have other editors who are relatively active so the response time for authors isn't as bad as it used to be (a week vs a year).  It also sounds like the process for consensus changes will be moving over to the executable specs repository in the near future and since that is the piece I care most about, I am less concerned now than I used to be about the EIP process remaining credibly neutral.

I also will be unsubscribing from this repository, so someone should probably take up the the task of making sure stuff doesn't get lost in the cracks.

**Note**: I also reordered the Emeritus editors list to be alphabetical rather than what appeared to be random order.