### PR TITLE
EIP-2200: Change unordered list to ordered

### DIFF
--- a/EIPS/eip-2200.md
+++ b/EIPS/eip-2200.md
@@ -19,7 +19,7 @@ to make it interoperable with other gas changes such as [EIP-1884].
 
 This EIP provides a structured definition of net gas metering changes
 for `SSTORE` opcode, enabling new usages for contract storage, and
-reducing excessive gas costs where it doesn’t match how most
+reducing excessive gas costs where it doesn't match how most
 implementation works.
 
 This is a combination of [EIP-1283] and [EIP-1706].
@@ -73,31 +73,31 @@ defined in EIP-1283.
 Replace `SSTORE` opcode gas cost calculation (including refunds) with
 the following logic:
 
-* If *gasleft* is less than or equal to gas stipend, fail the current
-  call frame with 'out of gas' exception.
-* If *current value* equals *new value* (this is a no-op), `SLOAD_GAS`
-  is deducted.
-* If *current value* does not equal *new value*
-  * If *original value* equals *current value* (this storage slot has
-    not been changed by the current execution context)
-    * If *original value* is 0, `SSTORE_SET_GAS` is deducted.
-    * Otherwise, `SSTORE_RESET_GAS` gas is deducted. If *new value* is
-      0, add `SSTORE_CLEARS_SCHEDULE` gas to refund counter.
-  * If *original value* does not equal *current value* (this storage
-    slot is dirty), `SLOAD_GAS` gas is deducted. Apply both of the
-    following clauses.
-    * If *original value* is not 0
-      * If *current value* is 0 (also means that *new value* is not
-        0), remove `SSTORE_CLEARS_SCHEDULE` gas from refund
-        counter.
-      * If *new value* is 0 (also means that *current value* is not
-        0), add `SSTORE_CLEARS_SCHEDULE` gas to refund counter.
-    * If *original value* equals *new value* (this storage slot is
-      reset)
-      * If *original value* is 0, add `SSTORE_SET_GAS - SLOAD_GAS` to
-        refund counter.
-      * Otherwise, add `SSTORE_RESET_GAS - SLOAD_GAS` gas to refund
-        counter.
+1. If *gasleft* is less than or equal to gas stipend, fail the current
+   call frame with 'out of gas' exception.
+2. If *current value* equals *new value* (this is a no-op), `SLOAD_GAS`
+   is deducted.
+3. If *current value* does not equal *new value*
+   1. If *original value* equals *current value* (this storage slot has
+      not been changed by the current execution context)
+      1. If *original value* is 0, `SSTORE_SET_GAS` is deducted.
+      2. Otherwise, `SSTORE_RESET_GAS` gas is deducted. If *new value* is
+         0, add `SSTORE_CLEARS_SCHEDULE` gas to refund counter.
+   2. If *original value* does not equal *current value* (this storage
+      slot is dirty), `SLOAD_GAS` gas is deducted. Apply both of the
+      following clauses.
+      1. If *original value* is not 0
+         1. If *current value* is 0 (also means that *new value* is not
+            0), remove `SSTORE_CLEARS_SCHEDULE` gas from refund
+            counter.
+         2. If *new value* is 0 (also means that *current value* is not
+            0), add `SSTORE_CLEARS_SCHEDULE` gas to refund counter.
+      2. If *original value* equals *new value* (this storage slot is
+         reset)
+         1. If *original value* is 0, add `SSTORE_SET_GAS - SLOAD_GAS` to
+            refund counter.
+         2. Otherwise, add `SSTORE_RESET_GAS - SLOAD_GAS` gas to refund
+            counter.
 
 An implementation should also note that with the above definition, if
 the implementation uses call-frame refund counter, the counter can go


### PR DESCRIPTION
In the specification of EIP-2200 change the format of the list from
unordered to order. This way a particular rule can be referenced from
outside by e.g. "4.1.2".