### PR TITLE
Update EIP-2681: Minor clarification

### DIFF
--- a/EIPS/eip-2681.md
+++ b/EIPS/eip-2681.md
@@ -1,7 +1,7 @@
 ---
 eip: 2681
 title: Limit account nonce to 2^64-1
-description: Limit account nonce to be between `0` and `2^64-1`(inclusive).
+description: Limit account nonce to be `0<=account_nonce<2^64-1`
 author: Alex Beregszaszi (@axic)
 discussions-to: https://ethereum-magicians.org/t/eip-2681-limit-account-nonce-to-2-64-1/4324
 status: Final
@@ -12,7 +12,7 @@ created: 2020-04-25
 
 ## Abstract
 
-Limit account nonce to be between `0` and `2^64-1`(inclusive).
+Limit account nonce to be between `0<=account_nonce<2^64-1`
 
 ## Motivation
 

--- a/EIPS/eip-2681.md
+++ b/EIPS/eip-2681.md
@@ -11,7 +11,7 @@ created: 2020-04-25
 
 ## Abstract
 
-Limit account nonce to be between `0` and `2^64-1`.
+Limit account nonce to be between `0` and `2^64-1`(inclusive).
 
 ## Motivation
 

--- a/EIPS/eip-2681.md
+++ b/EIPS/eip-2681.md
@@ -1,6 +1,7 @@
 ---
 eip: 2681
 title: Limit account nonce to 2^64-1
+description: Limit account nonce to be between `0` and `2^64-1`(inclusive).
 author: Alex Beregszaszi (@axic)
 discussions-to: https://ethereum-magicians.org/t/eip-2681-limit-account-nonce-to-2-64-1/4324
 status: Final


### PR DESCRIPTION
@axic: I was minorly confused by the wording so I propose some clarification..

Change from 
```
Limit account nonce to be between `0` and `2^64-1`.
```
to Option 1
```
Limit account nonce to be between `0` and `2^64-1`(inclusive).
```
or Option 2
```
Limit account nonce to be `0<=account_nonce<=2^64-1`
```
to clarify in the summary the inclusivity of two ends
