### PR TITLE
Add Name to Label Bot

### DIFF
--- a/.github/workflows/auto-label-bot.yml
+++ b/.github/workflows/auto-label-bot.yml
@@ -1,9 +1,10 @@
 on:
   pull_request_target:
 
+name: Auto Label Bot
 jobs:
   jekyll-label-action:
-    name: Automatic Label Bot
+    name: Label
     runs-on: ubuntu-latest
     
     steps:


### PR DESCRIPTION
All this does is add a name to the only job that for some reason doesn't have one.