### PR TITLE
EIP-5192: add event LockingStatusChanged(uint256 tokenId, bool status)

### DIFF
--- a/EIPS/eip-5192.md
+++ b/EIPS/eip-5192.md
@@ -2,7 +2,7 @@
 eip: 5192
 title: Minimal Soulbound NFTs
 description: Minimal interface for soulbinding EIP-721 NFTs
-author: Tim Daubenschütz (@TimDaub)
+author: Tim Daubenschütz (@TimDaub), Anders (@0xanders)
 discussions-to: https://ethereum-magicians.org/t/eip-5192-minimal-soulbound-nfts/9814
 status: Review
 type: Standards Track
@@ -34,6 +34,9 @@ A token with a `uint256 tokenId` may be inseparably-nound to a receiving account
 pragma solidity ^0.8.0;
 
 interface IERC5192 {
+  /// @notice Emitted when locking status is changed
+  event UpdateLockingStatus(uint256 tokenId, bool status);
+
   /// @notice Returns the locking status of an Soulbound Token
   /// @dev SBTs assigned to zero address are considered invalid, and queries
   /// about them do throw.

--- a/EIPS/eip-5192.md
+++ b/EIPS/eip-5192.md
@@ -35,7 +35,7 @@ pragma solidity ^0.8.0;
 
 interface IERC5192 {
   /// @notice Emitted when locking status is changed
-  event LockinStatusChanged(uint256 tokenId, bool status);
+  event LockingStatusChanged(uint256 tokenId, bool status);
 
   /// @notice Returns the locking status of an Soulbound Token
   /// @dev SBTs assigned to zero address are considered invalid, and queries

--- a/EIPS/eip-5192.md
+++ b/EIPS/eip-5192.md
@@ -34,8 +34,15 @@ A token with a `uint256 tokenId` may be inseparably-nound to a receiving account
 pragma solidity ^0.8.0;
 
 interface IERC5192 {
-  /// @notice Emitted when locking status is changed
-  event LockingStatusChanged(uint256 tokenId, bool status);
+  /// @notice Emitted when the locking status is changed to locked.
+  /// @dev If a token is minted and the status is locked, this event should be emitted.
+  /// @param tokenId The identifier for a token.
+  event Locked(uint256 tokenId);
+
+  /// @notice Emitted when the locking status is changed to unlocked.
+  /// @dev If a token is minted and the status is unlocked, this event should be emitted.
+  /// @param tokenId The identifier for a token.
+  event Unlocked(uint256 tokenId);
 
   /// @notice Returns the locking status of an Soulbound Token
   /// @dev SBTs assigned to zero address are considered invalid, and queries

--- a/EIPS/eip-5192.md
+++ b/EIPS/eip-5192.md
@@ -35,7 +35,7 @@ pragma solidity ^0.8.0;
 
 interface IERC5192 {
   /// @notice Emitted when locking status is changed
-  event UpdateLockingStatus(uint256 tokenId, bool status);
+  event LockinStatusChanged(uint256 tokenId, bool status);
 
   /// @notice Returns the locking status of an Soulbound Token
   /// @dev SBTs assigned to zero address are considered invalid, and queries


### PR DESCRIPTION
Add `event LockingStatusChanged(uint256 tokenId, bool status)`

So the locking status of the NFT could be updated  off-chain.