### PR TITLE
fix: correct wrong link in template

### DIFF
--- a/eip-template.md
+++ b/eip-template.md
@@ -44,4 +44,4 @@ An optional section that contains a reference/example implementation that people
 All EIPs must contain a section that discusses the security implications/considerations relevant to the proposed change. Include information that might be important for security discussions, surfaces risks and can be used throughout the life cycle of the proposal. E.g. include security-relevant design decisions, concerns, important discussions, implementation-specific guidance and pitfalls, an outline of threats and risks and how they are being addressed. EIP submissions missing the "Security Considerations" section will be rejected. An EIP cannot proceed to status "Final" without a Security Considerations discussion deemed sufficient by the reviewers.
 
 ## Copyright
-Copyright and related rights waived via [CC0](./LICENSE.md).
+Copyright and related rights waived via [CC0](/LICENSE.md).

--- a/eip-template.md
+++ b/eip-template.md
@@ -44,4 +44,4 @@ An optional section that contains a reference/example implementation that people
 All EIPs must contain a section that discusses the security implications/considerations relevant to the proposed change. Include information that might be important for security discussions, surfaces risks and can be used throughout the life cycle of the proposal. E.g. include security-relevant design decisions, concerns, important discussions, implementation-specific guidance and pitfalls, an outline of threats and risks and how they are being addressed. EIP submissions missing the "Security Considerations" section will be rejected. An EIP cannot proceed to status "Final" without a Security Considerations discussion deemed sufficient by the reviewers.
 
 ## Copyright
-Copyright and related rights waived via [CC0](../LICENSE.md).
+Copyright and related rights waived via [CC0](./LICENSE.md).


### PR DESCRIPTION
Correct wrong link in template:
> Copyright and related rights waived via [CC0](../LICENSE.md). `(../LICENSE.md)`
> ↓
> Copyright and related rights waived via [CC0](./LICENSE.md). `(/LICENSE.md)`

