### PR TITLE
Add EIP-Bot retrigger functionality

### DIFF
--- a/.github/workflows/auto-review-trigger.yml
+++ b/.github/workflows/auto-review-trigger.yml
@@ -14,6 +14,9 @@ on:
         description: Pull Request Number
         type: string
         required: true
+  issue_comment:
+    types:
+      - created
 
 name: Auto Review Bot Trigger
 jobs:
@@ -38,6 +41,12 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         env:
           PR_NUMBER: ${{ inputs.pr_number }}
+
+      - name: Write PR Number - Comment Retrigger
+        run: echo $PR_NUMBER > pr-number.txt
+        if: github.event_name == 'issue_comment' && github.event.issue.pull_request && startsWith(github.event.issue.comment.body, '@eth-bot retrigger')
+        env:
+          PR_NUMBER: ${{ github.event.issue.number }}
       
       - name: Check File Existence
         uses: andstor/file-existence-action@f02338908d150e00a4b8bebc2dad18bd9e5229b0

--- a/.github/workflows/auto-review-trigger.yml
+++ b/.github/workflows/auto-review-trigger.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Write PR Number - Comment Retrigger
         run: echo $PR_NUMBER > pr-number.txt
-        if: github.event_name == 'issue_comment' && github.event.issue.pull_request && startsWith(github.event.issue.comment.body, '@eth-bot retrigger')
+        if: github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.issue.comment.body, '@eth-bot rerun')
         env:
           PR_NUMBER: ${{ github.event.issue.number }}
       


### PR DESCRIPTION
Fixes https://github.com/ethereum/EIP-Bot/issues/49

When opening a pull request to submit a new EIP, please use the suggested template: https://github.com/ethereum/EIPs/blob/master/eip-template.md

We have a GitHub bot that automatically merges some PRs. It will merge yours immediately if certain criteria are met:

 - The PR edits only existing draft PRs.
 - The build passes.
 - Your GitHub username or email address is listed in the 'author' header of all affected PRs, inside <triangular brackets>.
 - If matching on email address, the email address is the one publicly listed on your GitHub profile.
