### PR TITLE
Update label bot

### DIFF
--- a/.github/workflows/auto-label-bot.yml
+++ b/.github/workflows/auto-label-bot.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - uses: Pandapip1/jekyll-label-action@5fcfb7bef793a76df290f8b491a5529accb7ae46
+      - uses: Pandapip1/jekyll-label-action@28a89dbbef321fceaf3cff17f4d29c7a033c3d56
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-path: config/.jekyll-labels.yml


### PR DESCRIPTION
Fix: Doesn't remove all the labels now.