### PR TITLE
Switch to `dist` branch of `eipw-action`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Checkout EIP Repository
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
 
-      - uses: ethereum/eipw-action@master
+      - uses: ethereum/eipw-action@dist
         id: eipw
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
`eipw-action` now publishes the compiled output to a different branch.