### PR TITLE
EIP-4750: Change bullet point list for markdown rendering

### DIFF
--- a/EIPS/eip-4750.md
+++ b/EIPS/eip-4750.md
@@ -100,7 +100,7 @@ Under `PC_post_instruction` we mean the PC position after the entire immediate a
 2. If data stack has less than `caller_stack_height + types[code_section_index].outputs`, execution results in exceptional halt.
 3. Pops nothing and pushes nothing to data stack.
 4. Pops an item from return stack and sets `current_section_index` and `PC` to values from this item.
-    4.1. If return stack is empty after this, execution halts with success.
+   1. If return stack is empty after this, execution halts with success.
 
 ### Code Validation
 
@@ -110,8 +110,8 @@ In addition to container format validation rules above, we extend code section v
 2. List of allowed *terminating instructions* in EIP-3670 is extended to include `RETF`. (*Note that `CALLF`, like other instructions with immediates, cannot be truncated.*)
 3. Code section is invalid in case an immediate argument of any `CALLF` is greater than or equal to the total number of code sections.
 4. `RJUMP` and `RJUMPI` immediate argument value (jump destination relative offset) validation:
-    4.1. Code section is invalid in case offset points to a position outside of section bounds.
-    4.2. Code section is invalid in case offset points to one of two bytes directly following `CALLF` instruction.
+    1. Code section is invalid in case offset points to a position outside of section bounds.
+    2. Code section is invalid in case offset points to one of two bytes directly following `CALLF` instruction.
 
 ### Execution
 


### PR DESCRIPTION
Unfortunately the current one does not render well:

<img width="1399" alt="Screenshot" src="https://user-images.githubusercontent.com/20340/186231159-9910baff-bbfb-4034-9bde-0f371d9d171e.png">
