### PR TITLE
CI: Fix typo in labels & add missing labels

### DIFF
--- a/config/.jekyll-labels.yml
+++ b/config/.jekyll-labels.yml
@@ -13,6 +13,14 @@ t-erc: this?.new?.category == "ERC" && this?.old?.status != "Living"
 # Living EIPs & EIP Template
 t-process: this?.old?.status == "Living" || this?.old?.title == "<The EIP title is a few words, not a complete sentence>"
 
+# Status
+s-draft: this?.new?.status == "Draft"
+s-final: this?.new?.status == "Final"
+s-lastcall: this?.new?.status == "Lastcall"
+s-review: this?.new?.status == "Review"
+s-stagnant: this?.new?.status == "Stagnant"
+s-withdrawn: this?.new?.status == "Withdrawn"
+
 #### PR Classification ####
 
 c-new: this?.new?.eip && !this?.old?.eip

--- a/config/.jekyll-labels.yml
+++ b/config/.jekyll-labels.yml
@@ -5,13 +5,13 @@ t-informational: this?.new?.type == "Informational" && this?.old?.status != "Liv
 t-meta: this?.new?.type == "Meta" && this?.old?.status != "Living"
 
 # Categories
-t-core": this?.new?.category == "Core" && this?.old?.status != "Living"
-t-networking": this?.new?.category == "Networking" && this?.old?.status != "Living"
-t-interface": this?.new?.category == "Interface" && this?.old?.status != "Living"
-t-erc": this?.new?.category == "ERC" && this?.old?.status != "Living"
+t-core: this?.new?.category == "Core" && this?.old?.status != "Living"
+t-networking: this?.new?.category == "Networking" && this?.old?.status != "Living"
+t-interface: this?.new?.category == "Interface" && this?.old?.status != "Living"
+t-erc: this?.new?.category == "ERC" && this?.old?.status != "Living"
 
 # Living EIPs & EIP Template
-t-process": this?.old?.status == "Living" || this?.old?.title == "<The EIP title is a few words, not a complete sentence>"
+t-process: this?.old?.status == "Living" || this?.old?.title == "<The EIP title is a few words, not a complete sentence>"
 
 #### PR Classification ####
 


### PR DESCRIPTION
There were some trailing `"`, this PR removes them. In addition, I forgot to re-include some of the old labels.