### PR TITLE
Add EIP-5548: NFT Operator Approval Control

### DIFF
--- a/EIPS/eip-5545.md
+++ b/EIPS/eip-5545.md
@@ -1,0 +1,129 @@
+---
+eip: 5545
+title: NFT Operator Approval Control
+author: Mitchell F Chan (@mitchellfchan) et al.
+discussions-to: TK
+status: Draft
+type: Standards Track
+category: ERC
+created: 2022-08-27
+requires: 165
+---
+
+## Simple Summary
+
+An extension to ERC721 which standardizes NFT creators' ability to deny specific marketplaces or smart contracts the ability to spend tokens on an owner's behalf. This is achieved by adding a check against an owner-defined denyList in the `Approve` or `SetApprovalForAll` functions.
+
+## Abstract
+
+This is intended for NFT creators who wish to exercise some control over where their creations may be bought and sold, without limiting the rights of token holders. 
+
+There are many reasons why an NFT creator may wish to exercise control over which intermediary smart-contracts may buy and sell their creations on an owner's behalf. An intermediary platform may present artwork in a manner which the creator finds objectionable or dishonest, or the intermediary platform may openly disregard off-chain codes, conventions, or practices which the creator considers to be an essential part of the artwork or their career.
+
+At the time of writing, several intermediary platforms have chosen to disregard the widely agreed-upon convention of remitting resale royalties to creators. It is expected that the extension proposed in this EIP will frequently be paired with [EIP-2981](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-2981.md), with EIP-2981 acting as a way of signalling standardized royalty information, and EIP-5545 acting as a method of denying non-compliant intermediary platforms.
+
+
+## Motivation
+
+The promise of creator empowerment has driven adoption of the NFT standard (and of the Ethereum blockchain in general) for artists and creators. The opportunity to cut out intermediaries, or "middlemen," is a central tenet not just of NFT culture, but of crypto culture in general. Nonetheless, intermediaries persist. In many cases, these intermediaries serve an important function, creating smoother experiences for end users, or presenting NFT metadata in easily consumable formats. 
+
+However, as intermediary platforms willfully circumvent social codes established by NFT creators, it is within the spirit of crypto to provide technological tools to deny allowances to those intermediaries.
+
+It should be noted that this extension will not (nor does it aim to) stamp out any nefarious behaviour (such as royalty-dodging) from token holders. The position of this EIP is that any restriction to owner's ability to `Transfer` their NFTs would be overreaching. And of course, denyListed platforms could deploy new smart contracts, placing creators in the position of playing "whack-a-mole" to add new deployments to the denyList. 
+
+Nonetheless, there is benefit to creating some punitive friction for bad actors, and to implementing an ERC721 extension which signals creator's intention to exert control over the monetization of their creations.
+
+## Specification
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.
+
+Our denyList is a single new mapping of operator addresses, paired with true/false values. An event is emitted when an address is added to the denyList.
+
+```solidity
+
+mapping (address => bool) public denyList;
+event OperatorDenied(address badOperator);
+
+```
+
+Addresses may be added to the denyList.
+
+
+
+```solidity
+
+function updateDenyList(address badOperator, bool status) public onlyOwner {
+       
+        require(
+            _msgSender() == owner ,
+            "ERC721: approve caller is not token owner nor approved for all"
+        );
+
+        _addToDenyList(badOperator, status);
+    }
+
+function _updateDenyList(address badOperator, bool status) internal virtual {
+        denyList[badOperator] = status;
+        emit OperatorDenied(badOperator);
+    }
+
+```
+
+
+The following functions in the standard OpenZeppelin [ERC721.sol](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v4.7.3/contracts/token/ERC721/ERC721.sol) are slightly modified.
+
+```solidity
+
+function setApprovalForAll(address operator, bool approved) public virtual override {
+  require(denyList[operator] == false, "Operator has been denied by contract owner.";   //ADD THIS LINE ONLY
+        _setApprovalForAll(_msgSender(), operator, approved);
+    }
+    
+function approve(address to, uint256 tokenId) public virtual override {
+      address owner = ERC721.ownerOf(tokenId);
+      require(to != owner, "ERC721: approval to current owner");
+
+      require(
+          _msgSender() == owner || isApprovedForAll(owner, _msgSender()),
+          "ERC721: approve caller is not token owner nor approved for all"
+      );
+      require(denyList[operator] == false, "Operator has been denied by contract owner."; //ADD THIS LINE ONLY
+      _approve(to, tokenId);
+  }
+    
+ ```
+
+
+ 
+## Rationale
+
+This code aims to empower creators using the lightest possible touch.
+
+This proposal involves only slight modifications to the `setApproval` or `setApprovalForAll` overrides, and places no restrictions on the `TransferFrom` function.
+
+As such, it remains impossible for the creator (or owner of the smart contract) to limit a collector's right to sell or transfer their property. No modifications have been made to any functions involving the Transfer of the token.
+
+Note that this is not a wrapper for existing NFTs. Existing NFT contracts will not be able to retroactively apply an approval denyList.  
+
+### approveList vs. denyList
+
+Within the community, some creators and devs have proposed implementing an approveList which *grants approval* to only specific operators, rather than a denyList which *denies approval* to only specific operators.
+
+It is the opinion of these authors that the inherently optimistic `denyList` approach is preferable. NFT contracts should be permissive of new marketplace smart contracts by default. This way, an NFT smart contract which is not actively maintained will be operable within newly created marketplaces. An NFT smart contract which must be regularly fed new addresses of permitted marketplaces would eventually become inoperable with most marketplaces if not actively maintained.
+
+### Denying Approval vs. Transfer
+
+Implementing a denyList at the Approval function is much better than implementing one at the Transfer function.
+
+1. **Effectiveness.** Centralized marketplaces require NFT owners to approve them as operators. This gives those marketplaces the ability to tansfer tokens on the owner's behalf (for example, after a sales offer has been accepted.) Even Sudoswap, which ultimately requires the NFTs to be transferred to an LP pool contract, still requires the NFT owner to approve the Sudoswap Pair Factory contract as an operator. The Sudoswap Pair Factory contract then moves the NFTs to the LP contract on the owner's behalf, using it's isApproved status.
+2. **Targeting the appropriate actors.** Any modification which could potentially limit a collector's a ability to directly transfer their token would be politically unfeasible and misguided. And I think it is important that this initiative be about action against unethical exchanges, such as Sudoswap, rather than individual collectors. In this proposal, collectors still have the ability to circumvent artist royalties by trading over-the-counter (OTC). Personally, I have no interest in policing the behaviour of individuals, but rich and powerful centralized marketplaces are fair game.
+
+
+
+## Security Considerations
+
+This standard requires auditing.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](../LICENSE.md).

--- a/EIPS/eip-5545.md
+++ b/EIPS/eip-5545.md
@@ -1,26 +1,25 @@
 ---
 eip: 5545
 title: NFT Operator Approval Control
-author: Mitchell F Chan (@mitchellfchan) et al.
+description: An EIP-721 extension to deny specific smart contracts the ability to spend tokens on an owner's behalf
+author: Mitchell F Chan (@mitchellfchan), et al.
 discussions-to: TK
 status: Draft
 type: Standards Track
 category: ERC
 created: 2022-08-27
-requires: 165
+requires: 165, 721
 ---
 
-## Simple Summary
-
-An extension to ERC721 which standardizes NFT creators' ability to deny specific marketplaces or smart contracts the ability to spend tokens on an owner's behalf. This is achieved by adding a check against an owner-defined denyList in the `Approve` or `SetApprovalForAll` functions.
-
 ## Abstract
+
+This EIP is an extension to [EIP-721](./eip-721.md) which standardizes NFT creators' ability to deny specific marketplaces or smart contracts the ability to spend tokens on an owner's behalf. This is achieved by adding a check against an owner-defined denyList in the `Approve` or `SetApprovalForAll` functions.
 
 This is intended for NFT creators who wish to exercise some control over where their creations may be bought and sold, without limiting the rights of token holders. 
 
 There are many reasons why an NFT creator may wish to exercise control over which intermediary smart-contracts may buy and sell their creations on an owner's behalf. An intermediary platform may present artwork in a manner which the creator finds objectionable or dishonest, or the intermediary platform may openly disregard off-chain codes, conventions, or practices which the creator considers to be an essential part of the artwork or their career.
 
-At the time of writing, several intermediary platforms have chosen to disregard the widely agreed-upon convention of remitting resale royalties to creators. It is expected that the extension proposed in this EIP will frequently be paired with [EIP-2981](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-2981.md), with EIP-2981 acting as a way of signalling standardized royalty information, and EIP-5545 acting as a method of denying non-compliant intermediary platforms.
+At the time of writing, several intermediary platforms have chosen to disregard the widely agreed-upon convention of remitting resale royalties to creators. It is expected that the extension proposed in this EIP will frequently be paired with [EIP-2981](./eip-2981.md), with EIP-2981 acting as a way of signalling standardized royalty information, and [EIP-5545](./eip-5545.md) acting as a method of denying non-compliant intermediary platforms.
 
 
 ## Motivation
@@ -31,7 +30,7 @@ However, as intermediary platforms willfully circumvent social codes established
 
 It should be noted that this extension will not (nor does it aim to) stamp out any nefarious behaviour (such as royalty-dodging) from token holders. The position of this EIP is that any restriction to owner's ability to `Transfer` their NFTs would be overreaching. And of course, denyListed platforms could deploy new smart contracts, placing creators in the position of playing "whack-a-mole" to add new deployments to the denyList. 
 
-Nonetheless, there is benefit to creating some punitive friction for bad actors, and to implementing an ERC721 extension which signals creator's intention to exert control over the monetization of their creations.
+Nonetheless, there is benefit to creating some punitive friction for bad actors, and to implementing an EIP-721 extension which signals creator's intention to exert control over the monetization of their creations.
 
 ## Specification
 
@@ -70,7 +69,7 @@ function _updateDenyList(address badOperator, bool status) internal virtual {
 ```
 
 
-The following functions in the standard OpenZeppelin [ERC721.sol](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v4.7.3/contracts/token/ERC721/ERC721.sol) are slightly modified.
+The following functions in the standard OpenZeppelin `ERC721.sol` are slightly modified.
 
 ```solidity
 
@@ -118,11 +117,9 @@ Implementing a denyList at the Approval function is much better than implementin
 1. **Effectiveness.** Centralized marketplaces require NFT owners to approve them as operators. This gives those marketplaces the ability to tansfer tokens on the owner's behalf (for example, after a sales offer has been accepted.) Even Sudoswap, which ultimately requires the NFTs to be transferred to an LP pool contract, still requires the NFT owner to approve the Sudoswap Pair Factory contract as an operator. The Sudoswap Pair Factory contract then moves the NFTs to the LP contract on the owner's behalf, using it's isApproved status.
 2. **Targeting the appropriate actors.** Any modification which could potentially limit a collector's a ability to directly transfer their token would be politically unfeasible and misguided. And I think it is important that this initiative be about action against unethical exchanges, such as Sudoswap, rather than individual collectors. In this proposal, collectors still have the ability to circumvent artist royalties by trading over-the-counter (OTC). Personally, I have no interest in policing the behaviour of individuals, but rich and powerful centralized marketplaces are fair game.
 
-
-
 ## Security Considerations
 
-This standard requires auditing.
+Needs discussion.
 
 ## Copyright
 

--- a/EIPS/eip-5548.md
+++ b/EIPS/eip-5548.md
@@ -3,7 +3,7 @@ eip: 5548
 title: NFT Operator Approval Control
 description: An EIP-721 extension to deny specific smart contracts the ability to spend tokens on an owner's behalf
 author: Mitchell F Chan (@mitchellfchan), et al.
-discussions-to: TK
+discussions-to: https://ethereum-magicians.org/t/eip-5548-eip-721-approve-operator-denylist/10549
 status: Draft
 type: Standards Track
 category: ERC

--- a/EIPS/eip-5548.md
+++ b/EIPS/eip-5548.md
@@ -74,7 +74,7 @@ The following functions in the standard OpenZeppelin `ERC721.sol` are slightly m
 ```solidity
 
 function setApprovalForAll(address operator, bool approved) public virtual override {
-  require(denyList[operator] == false, "Operator has been denied by contract owner.";   //ADD THIS LINE ONLY
+        require(denyList[operator] == false, "Operator has been denied by contract owner.");   //ADD THIS LINE ONLY
         _setApprovalForAll(_msgSender(), operator, approved);
     }
     

--- a/EIPS/eip-5548.md
+++ b/EIPS/eip-5548.md
@@ -2,7 +2,7 @@
 eip: 5548
 title: NFT Operator Approval Control
 description: An EIP-721 extension to deny specific smart contracts the ability to spend tokens on an owner's behalf
-author: Mitchell F Chan (@mitchellfchan), Harm van den Dorpel (@harmvandendorpel), et al.
+author: Mitchell F Chan (@mitchellfchan), Harm van den Dorpel (@harmvandendorpel), Billy Rennekamp (@okwme)
 discussions-to: https://ethereum-magicians.org/t/eip-5548-eip-721-approve-operator-denylist/10549
 status: Draft
 type: Standards Track
@@ -41,7 +41,7 @@ Our denyList is a single new mapping of operator addresses, paired with true/fal
 ```solidity
 
 mapping (address => bool) public denyList;
-event OperatorDenied(address badOperator);
+event OperatorFlagged(address indexed flaggedOperator, bool indexed status);
 
 ```
 
@@ -51,19 +51,14 @@ Addresses may be added to the denyList.
 
 ```solidity
 
-function updateDenyList(address badOperator, bool status) public onlyOwner {
+function updateDenyList(address flaggedOperator, bool status) public onlyOwner {
        
-        require(
-            _msgSender() == owner ,
-            "ERC721: approve caller is not token owner nor approved for all"
-        );
-
-        _addToDenyList(badOperator, status);
+        _updateDenyList(flaggedOperator, status);
     }
 
-function _updateDenyList(address badOperator, bool status) internal virtual {
-        denyList[badOperator] = status;
-        emit OperatorDenied(badOperator);
+function _updateDenyList(address flaggedOperator, bool status) internal virtual {
+        denyList[flaggedOperator] = status;
+        emit OperatorFlagged(flaggedOperator, status);
     }
 
 ```

--- a/EIPS/eip-5548.md
+++ b/EIPS/eip-5548.md
@@ -1,5 +1,5 @@
 ---
-eip: 5545
+eip: 5548
 title: NFT Operator Approval Control
 description: An EIP-721 extension to deny specific smart contracts the ability to spend tokens on an owner's behalf
 author: Mitchell F Chan (@mitchellfchan), et al.
@@ -19,7 +19,7 @@ This is intended for NFT creators who wish to exercise some control over where t
 
 There are many reasons why an NFT creator may wish to exercise control over which intermediary smart-contracts may buy and sell their creations on an owner's behalf. An intermediary platform may present artwork in a manner which the creator finds objectionable or dishonest, or the intermediary platform may openly disregard off-chain codes, conventions, or practices which the creator considers to be an essential part of the artwork or their career.
 
-At the time of writing, several intermediary platforms have chosen to disregard the widely agreed-upon convention of remitting resale royalties to creators. It is expected that the extension proposed in this EIP will frequently be paired with [EIP-2981](./eip-2981.md), with EIP-2981 acting as a way of signalling standardized royalty information, and [EIP-5545](./eip-5545.md) acting as a method of denying non-compliant intermediary platforms.
+At the time of writing, several intermediary platforms have chosen to disregard the widely agreed-upon convention of remitting resale royalties to creators. It is expected that the extension proposed in this EIP will frequently be paired with [EIP-2981](./eip-2981.md), with EIP-2981 acting as a way of signalling standardized royalty information, and this EIP acting as a method of denying non-compliant intermediary platforms.
 
 
 ## Motivation

--- a/EIPS/eip-5548.md
+++ b/EIPS/eip-5548.md
@@ -2,7 +2,7 @@
 eip: 5548
 title: NFT Operator Approval Control
 description: An EIP-721 extension to deny specific smart contracts the ability to spend tokens on an owner's behalf
-author: Mitchell F Chan (@mitchellfchan), Harm van den Dorpel (@harmvandendorpel) et al.
+author: Mitchell F Chan (@mitchellfchan), Harm van den Dorpel (@harmvandendorpel), et al.
 discussions-to: https://ethereum-magicians.org/t/eip-5548-eip-721-approve-operator-denylist/10549
 status: Draft
 type: Standards Track

--- a/EIPS/eip-5548.md
+++ b/EIPS/eip-5548.md
@@ -2,7 +2,7 @@
 eip: 5548
 title: NFT Operator Approval Control
 description: An EIP-721 extension to deny specific smart contracts the ability to spend tokens on an owner's behalf
-author: Mitchell F Chan (@mitchellfchan), et al.
+author: Mitchell F Chan (@mitchellfchan), Harm van den Dorpel (@harmvandendorpel) et al.
 discussions-to: https://ethereum-magicians.org/t/eip-5548-eip-721-approve-operator-denylist/10549
 status: Draft
 type: Standards Track

--- a/EIPS/eip-5548.md
+++ b/EIPS/eip-5548.md
@@ -86,7 +86,7 @@ function approve(address to, uint256 tokenId) public virtual override {
           _msgSender() == owner || isApprovedForAll(owner, _msgSender()),
           "ERC721: approve caller is not token owner nor approved for all"
       );
-      require(denyList[operator] == false, "Operator has been denied by contract owner."; //ADD THIS LINE ONLY
+      require(denyList[to] == false, "Operator has been denied by contract owner."; //ADD THIS LINE ONLY
       _approve(to, tokenId);
   }
     


### PR DESCRIPTION
This is a draft EIP proposing:

An extension to ERC721 which standardizes NFT creators' ability to deny specific marketplaces or smart contracts the ability to spend tokens on an owner's behalf. This is achieved by adding a check against an owner-defined denyList in the `Approve` or `SetApprovalForAll` functions.