### PR TITLE
Update eip-3561.md

### DIFF
--- a/EIPS/eip-3561.md
+++ b/EIPS/eip-3561.md
@@ -11,7 +11,7 @@ created: 2021-05-09
 ---
 
 ## Abstract
-Removing trust from upgradeability proxy is required for anonymous developers. To achieve that, disallowing instant, potentially malicious upgrades is required. This EIP introduces additional storage slots for upgradeability proxy which are assumed to decrease trust in interaction with upgradeable smart contracts. Defined by the admin implementation becomes an active implementation only after Zero Trust Period(an amount of blocks defined only once) allows.
+Removing trust from upgradeability proxy is required for anonymous developers. To achieve that, disallowing instant, potentially malicious upgrades is required. This EIP introduces additional storage slots for upgradeability proxy which are assumed to decrease trust in interaction with upgradeable smart contracts. Defined by the admin implementation becomes an active implementation only after Zero Trust Period allows.
 
 ## Motivation
 It's usually not possible for anonymous developers who uses upgradeability proxies to gain community trust.
@@ -58,7 +58,7 @@ event ProposingUpgradesRestrictedUntil(uint block, uint nextProposedLogicEarlies
 
 ### Zero Trust Period
 Storage slot `0x7913203adedf5aca5386654362047f05edbd30729ae4b0351441c46289146720` (obtained as `bytes32(uint256(keccak256('eip3561.proxy.zero.trust.period')) - 1)`).
-Zero Trust Period in amount of blocks, can only be set once. While it is at default value(0), the proxy operates exactly as standard EIP-1967 transparent proxy. After zero trust period is set, all above specification is enforced.
+Zero Trust Period in amount of blocks, can only be set higher than previous value. While it is at default value(0), the proxy operates exactly as standard EIP-1967 transparent proxy. After zero trust period is set, all above specification is enforced.
 Admin interactions with this slot should correspond with this method and event:
 ```solidity
 function setZeroTrustPeriod(uint blocks) external onlyAdmin;
@@ -173,10 +173,10 @@ contract TrustMinimizedProxy{
 		emit ProposingUpgradesRestrictedUntil(b,b+_zeroTrustPeriod());
 	}
 
-	function setZeroTrustPeriod(uint blocks) external ifAdmin { // before this called acts like a normal eip 1967 transparent proxy
+	function setZeroTrustPeriod(uint blocks) external ifAdmin { // before this set at least once acts like a normal eip 1967 transparent proxy
 		uint ztp;
 		assembly { ztp := sload(ZERO_TRUST_PERIOD_SLOT) }
-		require(ztp==0,"already set");
+		require(blocks>ztp,"can be only set higher");
 		assembly{ sstore(ZERO_TRUST_PERIOD_SLOT, blocks) }
 		emit ZeroTrustPeriodSet(blocks);
 	}
@@ -226,7 +226,7 @@ A proxy without a time delay before an actual upgrade is obviously abusable. A t
 Propose block adds to convenience if used, so should be kept.
 
 ## Security Considerations
-Users must ensure that a trust-minimized proxy they interact with does not allow overflows, ideally represents the exact copy of the code in implementation example above, and also they must ensure that Zero Trust Period length is reasonable(at least a month).
+Users must ensure that a trust-minimized proxy they interact with does not allow overflows, ideally represents the exact copy of the code in implementation example above, and also they must ensure that Zero Trust Period length is reasonable(at the very least two weeks if finalized upgrades are usually being revealed beforehand, and in most cases at least a month).
 
 ## Copyright
 Copyright and related rights waived via [CC0](../LICENSE.md).


### PR DESCRIPTION
Zero Trust Period is now can be set many times but under a condition: always higher than previous. Makes it more robust, more "adoptable".
