### PR TITLE
Clarify address casing for EIP-5375

### DIFF
--- a/EIPS/eip-5375.md
+++ b/EIPS/eip-5375.md
@@ -8,7 +8,7 @@ status: Review
 type: Standards Track
 category: ERC
 created: 2022-07-30
-requires: 155, 712, 721, 1155
+requires: 55, 155, 712, 721, 1155
 ---
 
 ## Abstract
@@ -40,6 +40,8 @@ This document thus defines a standard which allows the minter to provide authors
 ## Specification
 
 The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be interpreted as described in RFC 2119.
+
+All addresses used in this standard MUST follow the casing rules described in [EIP-55](./eip-55.md).
 
 ### Definitions
 


### PR DESCRIPTION
This PR clarifies that all addresses must be written following [EIP-55](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-55.md) casing.