### PR TITLE
Add EIP-5568: Required Action Signals Using Revert Reasons

### DIFF
--- a/EIPS/eip-5568.md
+++ b/EIPS/eip-5568.md
@@ -27,29 +27,27 @@ The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL 
 
 ### Custom Revert Reason
 
-To send a signal to a wallet, a compliant smart contract MUST revert with the following [EIP-140](./eip-140.md) revert data:
-  
+To send a signal to a wallet, a compliant smart contract MUST revert with the following error:
+
 ```solidity
-abi.encodePacked(uint16(EIP_NUMBER), uint24(INSTRUCTION_ID1), uint16(bytes(INSTRUCTION_DATA1).length), bytes(INSTRUCTION_DATA1), uint24(INSTRUCTION_ID2), uint16(bytes(INSTRUCTION_DATA2).length), bytes(INSTRUCTION_DATA2), ...)
+error WalletSignal24(uint8 number_hint, uint24 instruction_id, bytes instruction_data)
 ```
 
-`EIP_NUMBER` MUST be `5568`.
+The `number_hint` is an estimate of the number of signals that will be sent after the current signal. If a guess is availabe, `number_hint` MUST be that estimate. If a guess is unavailable, `number_hint` MUST be `0`.
 
-The `INSTRUCTION_ID` of an instruction defined by an EIP MUST be its EIP number. An EIP MUST define exactly zero or one `INSTRUCTION_ID`. The structure of the instruction data for any `INSTRUCTION_ID` MUST be defined by the EIP that defines the `INSTRUCTION_ID`.
+The `instruction_id` of an instruction defined by an EIP MUST be its EIP number unless there are exceptional circumstances (be reasonable). An EIP MUST define exactly zero or one `instruction_id`. The structure of the instruction data for any `instruction_id` MUST be defined by the EIP that defines the `instruction_id`.
 
 ### Signal Response
 
-Before submitting a transaction to the mempool, it MUST be evaluated in a local fork of the chain. If it reverts and has a revert reason starting with the bytes `0x15C0`, then it MUST be treated as a signal.
+Before submitting a transaction to the mempool, it MUST be evaluated locally. If it reverts and the revert signature matches the custom error, then it MUST be treated as a signal. (It is RECOMMENDED for wallets to show a warning if the transaction reverts, even if the revert is not a signal).
 
-To parse the signal, discard the first 2 bytes (the `0x15C0` magic number). Then, repeat the following until the signal is fully read:
+The `number_hint`, `instruction_id`, and `instruction_data` MUST be parsed from the revert data. It is RECOMMENDED for wallets to show a progress indicator using the `number_hint`. The instruction SHOULD be evaluated as per the relevant EIP. If the instruction is not supported by the wallet, it MUST display an error to the user indicating that is the case. The wallet MUST then re-evaluate the transaction, except if an instruction explicitly states that the transaction MUST NOT be re-evaluated.
 
-Read the next 3 bytes to determine the `INSTRUCTION_ID`, and the next 2 bytes to determine the number of bytes to read. Then, read that many bytes to get the `INSTRUCTION_DATA`. Finally, evaluate the instruction as defined in its specification.
-
-After all the instructions have been followed, the wallet SHOULD NOT re-evaluate the transaction, except if an instruction explicitly states that the transaction should be re-evaluated.
+If an instruction is invalid, or the `number_hint`, `instruction_id`, and `instruction_data` cannot be parsed, then an error MUST be displayed to the user indicating that is the case.
 
 ## Rationale
 
-This EIP was explicitly optimized for deployment gas cost. It is expected that libraries will eventually be developed that makes sending and receiving signals more developer-friendly.
+This EIP was explicitly optimized for deployment gas cost and simplicity. It is expected that libraries will eventually be developed that makes= sending and receiving signals more developer-friendly.
 
 ## Backwards Compatibility
 
@@ -65,7 +63,7 @@ EIP-3668 can be used alongside this EIP, but it uses a different mechanism than 
 
 ### Revert Reason Collisions
 
-Collisions with existing human-readable revert messages are not possible, since the first ASCII character is `0x15 (NAK)`, which signifies a transmission error and is therefore unlikely to be contained in a human-readable revert message.
+It is unlikely that the signature of the custom error matches any custom errors in the wild. In the case that it does, no harm is caused unless the data happen to be a valid instruction, which is even more unlikely.
 
 ## Copyright
 

--- a/EIPS/eip-5568.md
+++ b/EIPS/eip-5568.md
@@ -27,7 +27,7 @@ The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL 
 
 ### Custom Revert Reason
 
-To send a signal to a wallet, a smart contract MUST revert with the following [EIP-140](./eip-140.md) revert data:
+To send a signal to a wallet, a compliant smart contract MUST revert with the following [EIP-140](./eip-140.md) revert data:
   
 ```solidity
 abi.encodePacked(uint16(EIP_NUMBER), uint24(INSTRUCTION_ID1), uint16(bytes(INSTRUCTION_DATA1).length), bytes(INSTRUCTION_DATA1), uint24(INSTRUCTION_ID2), uint16(bytes(INSTRUCTION_DATA2).length), bytes(INSTRUCTION_DATA2), ...)

--- a/EIPS/eip-5568.md
+++ b/EIPS/eip-5568.md
@@ -47,7 +47,7 @@ If an instruction is invalid, or the `number_hint`, `instruction_id`, and `instr
 
 ## Rationale
 
-This EIP was explicitly optimized for deployment gas cost and simplicity. It is expected that libraries will eventually be developed that makes= sending and receiving signals more developer-friendly.
+This EIP was explicitly optimized for deployment gas cost and simplicity. It is expected that libraries will eventually be developed that makes sending and receiving signals more developer-friendly.
 
 ## Backwards Compatibility
 

--- a/EIPS/eip-5568.md
+++ b/EIPS/eip-5568.md
@@ -53,11 +53,20 @@ This EIP was explicitly optimized for deployment gas cost. It is expected that l
 
 ## Backwards Compatibility
 
-Needs discussion.
+### Human-Readable Revert Messages
+
+See [Revert Reason Collisions](#revert-reason-collisions).
+
+### [EIP-3668](./eip-3668.md)
+
+EIP-3668 can be used alongside this EIP, but it uses a different mechanism than this EIP.
 
 ## Security Considerations
 
-Needs discussion.
+### Revert Reason Collisions
+
+Collisions with existing human-readable revert messages are not possible, since the first ASCII character is `0x15 (NAK)`, which signifies a transmission error and is therefore unlikely to be contained in a human-readable revert message.
 
 ## Copyright
+
 Copyright and related rights waived via [CC0](../LICENSE.md).

--- a/EIPS/eip-5568.md
+++ b/EIPS/eip-5568.md
@@ -13,7 +13,7 @@ requires: 140
 
 ## Abstract
 
-This EIP introduces a minimalistic machine-readable (binary) format to signal to wallets that an action needs to be taken by the user using a well-known revert reason. This custom revert reason contains just enough data to be extendable by future EIPs and to take in arbitrary parameters (up to 64 kB of data). Example use cases could include approving a token for an exchange, sending an HTTP request, or requesting the user to rotate their keys after a certain period of time to enforce good hygene.
+This EIP introduces a minimalistic machine-readable (binary) format to signal to wallets that an action needs to be taken by the user using a well-known revert reason. This custom revert reason contains just enough data to be extendable by future EIPs and to take in arbitrary parameters (up to 64 kB of data). Example use cases could include approving a token for an exchange, sending an HTTP request, or requesting the user to rotate their keys after a certain period of time to enforce good hygiene.
 
 ## Motivation
 

--- a/EIPS/eip-5568.md
+++ b/EIPS/eip-5568.md
@@ -33,7 +33,7 @@ To send a signal to a wallet, a smart contract MUST revert with the following [E
 abi.encodePacked(uint8(EIP_NUMBER), uint8(NUMBER_INSTRUCTIONS), uint24(INSTRUCTION_ID1), bytes(INSTRUCTION_DATA1), uint24(INSTRUCTION_ID2), bytes(INSTRUCTION_DATA2), ...)
 ```
 
-`EIP_NUMBER` MUST be `<to be assigned>`.
+`EIP_NUMBER` MUST be `5568`.
 
 The `INSTRUCTION_ID` of an instruction defined by an EIP MUST be its EIP number. An EIP MUST define exactly zero or one `INSTRUCTION_ID`. The structure of the instruction data for any `INSTRUCTION_ID` MUST be defined by the EIP that defines the `INSTRUCTION_ID`.
 

--- a/EIPS/eip-5568.md
+++ b/EIPS/eip-5568.md
@@ -1,6 +1,6 @@
 ---
 eip: 5568
-title: Revert Signals
+title: Required Action Signals Using Revert Reasons
 description: Signal to wallets that an action is needed by returning a custom revert code
 author: Pandapip1 (@Pandapip1)
 discussions-to: https://ethereum-magicians.org/t/eip-5568-revert-signals/10622

--- a/EIPS/eip-5568.md
+++ b/EIPS/eip-5568.md
@@ -3,7 +3,7 @@ eip: 5568
 title: Revert Signals
 description: Signal to wallets that an action is needed by returning a custom revert code
 author: Pandapip1 (@Pandapip1)
-discussions-to: <URL>
+discussions-to: https://ethereum-magicians.org/t/eip-5568-revert-signals/10622
 status: Draft
 type: Standards Track
 category: Interface

--- a/EIPS/eip-5568.md
+++ b/EIPS/eip-5568.md
@@ -13,7 +13,7 @@ requires: 140
 
 ## Abstract
 
-This EIP introduces a machine-readable format for reverts to signal to wallets that an action needs to be taken.
+This EIP introduces a minimalistic machine-readable (binary) format to signal to wallets that an action needs to be taken by the user using a well-known revert reason. This custom revert reason contains just enough data to be extendable by future EIPs and to take in arbitrary parameters (up to 64 kB of data). Example use cases could include approving a token for an exchange, sending an HTTP request, or requesting the user to rotate their keys after a certain period of time to enforce good hygene.
 
 ## Motivation
 

--- a/EIPS/eip-5568.md
+++ b/EIPS/eip-5568.md
@@ -1,5 +1,5 @@
 ---
-eip: <to be assigned>
+eip: 5568
 title: Revert Signals
 description: Signal to wallets that an action is needed by returning a custom revert code
 author: Pandapip1 (@Pandapip1)

--- a/EIPS/eip-5568.md
+++ b/EIPS/eip-5568.md
@@ -30,7 +30,7 @@ The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL 
 To send a signal to a wallet, a smart contract MUST revert with the following [EIP-140](./eip-140.md) revert data:
   
 ```solidity
-abi.encodePacked(uint16(EIP_NUMBER), uint8(NUMBER_INSTRUCTIONS), uint24(INSTRUCTION_ID1), bytes(INSTRUCTION_DATA1), uint24(INSTRUCTION_ID2), bytes(INSTRUCTION_DATA2), ...)
+abi.encodePacked(uint16(EIP_NUMBER), uint24(INSTRUCTION_ID1), uint16(bytes(INSTRUCTION_DATA1).length), bytes(INSTRUCTION_DATA1), uint24(INSTRUCTION_ID2), uint16(bytes(INSTRUCTION_DATA2).length), bytes(INSTRUCTION_DATA2), ...)
 ```
 
 `EIP_NUMBER` MUST be `5568`.
@@ -39,9 +39,13 @@ The `INSTRUCTION_ID` of an instruction defined by an EIP MUST be its EIP number.
 
 ### Signal Response
 
-Before submitting a transaction to the mempool, it should be evaluated in a local fork of the chain. If it reverts and has a revert reason starting with the bytes `0x15C0`, then it MUST be treated as a signal.
+Before submitting a transaction to the mempool, it MUST be evaluated in a local fork of the chain. If it reverts and has a revert reason starting with the bytes `0x15C0`, then it MUST be treated as a signal.
 
-TODO
+To parse the signal, discard the first 2 bytes (the `0x15C0` magic number). Then, repeat the following until the signal is fully read:
+
+Read the next 3 bytes to determine the `INSTRUCTION_ID`, and the next 2 bytes to determine the number of bytes to read. Then, read that many bytes to get the `INSTRUCTION_DATA`. Finally, evaluate the instruction as defined in its specification.
+
+After all the instructions have been followed, the wallet SHOULD NOT re-evaluate the transaction, except if an instruction explicitly states that the transaction should be re-evaluated.
 
 ## Rationale
 

--- a/EIPS/eip-5568.md
+++ b/EIPS/eip-5568.md
@@ -30,12 +30,18 @@ The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL 
 To send a signal to a wallet, a smart contract MUST revert with the following [EIP-140](./eip-140.md) revert data:
   
 ```solidity
-abi.encodePacked(uint8(EIP_NUMBER), uint8(NUMBER_INSTRUCTIONS), uint24(INSTRUCTION_ID1), bytes(INSTRUCTION_DATA1), uint24(INSTRUCTION_ID2), bytes(INSTRUCTION_DATA2), ...)
+abi.encodePacked(uint16(EIP_NUMBER), uint8(NUMBER_INSTRUCTIONS), uint24(INSTRUCTION_ID1), bytes(INSTRUCTION_DATA1), uint24(INSTRUCTION_ID2), bytes(INSTRUCTION_DATA2), ...)
 ```
 
 `EIP_NUMBER` MUST be `5568`.
 
 The `INSTRUCTION_ID` of an instruction defined by an EIP MUST be its EIP number. An EIP MUST define exactly zero or one `INSTRUCTION_ID`. The structure of the instruction data for any `INSTRUCTION_ID` MUST be defined by the EIP that defines the `INSTRUCTION_ID`.
+
+### Signal Response
+
+Before submitting a transaction to the mempool, it should be evaluated in a local fork of the chain. If it reverts and has a revert reason starting with the bytes `0x15C0`, then it MUST be treated as a signal.
+
+TODO
 
 ## Rationale
 

--- a/EIPS/eip-signal.md
+++ b/EIPS/eip-signal.md
@@ -1,0 +1,53 @@
+---
+eip: <to be assigned>
+title: Revert Signals
+description: Signal to wallets that an action is needed by returning a custom revert code
+author: Pandapip1 (@Pandapip1)
+discussions-to: <URL>
+status: Draft
+type: Standards Track
+category: Interface
+created: 2022-08-31
+requires: 140
+---
+
+## Abstract
+
+This EIP introduces a machine-readable format for reverts to signal to wallets that an action needs to be taken.
+
+## Motivation
+
+Oftentimes, a smart contract needs to signal to a wallet that an action needs to be taken, such as to sign a transaction or send an HTTP request to a URL. Traditionally, this has been done by hard-coding the logic into the frontend, but this EIP allows the smart contract itself to request the action.
+
+This means that, for example, an exchange or a market can directly tell the wallet to approve the smart contract to spend the token, vastly simplifying the front-end code.
+
+## Specification
+
+The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be interpreted as described in RFC 2119.
+
+### Custom Revert Reason
+
+To send a signal to a wallet, a smart contract MUST revert with the following [EIP-140](./eip-140.md) revert data:
+  
+```solidity
+abi.encodePacked(uint8(EIP_NUMBER), uint8(NUMBER_INSTRUCTIONS), uint24(INSTRUCTION_ID1), bytes(INSTRUCTION_DATA1), uint24(INSTRUCTION_ID2), bytes(INSTRUCTION_DATA2), ...)
+```
+
+`EIP_NUMBER` MUST be `<to be assigned>`.
+
+The `INSTRUCTION_ID` of an instruction defined by an EIP MUST be its EIP number. An EIP MUST define exactly zero or one `INSTRUCTION_ID`. The structure of the instruction data for any `INSTRUCTION_ID` MUST be defined by the EIP that defines the `INSTRUCTION_ID`.
+
+## Rationale
+
+This EIP was explicitly optimized for deployment gas cost. It is expected that libraries will eventually be developed that makes sending and receiving signals more developer-friendly.
+
+## Backwards Compatibility
+
+Needs discussion.
+
+## Security Considerations
+
+Needs discussion.
+
+## Copyright
+Copyright and related rights waived via [CC0](../LICENSE.md).


### PR DESCRIPTION
Apparently, descriptions are highly recommended. I suggest that you look at [the files tab](https://github.com/ethereum/EIPs/pull/5568/files) instead.