### PR TITLE
Update EIP-5216: Move to Review

### DIFF
--- a/EIPS/eip-5216.md
+++ b/EIPS/eip-5216.md
@@ -4,7 +4,7 @@ title: EIP-1155 Approval By Amount Extension
 description: Extension for EIP-1155 secure approvals
 author: Iván Mañús (@ivanmmurciaua), Juan Carlos Cantó (@EscuelaCryptoES)
 discussions-to: https://ethereum-magicians.org/t/eip-erc1155-approval-by-amount/9898
-status: Draft
+status: Review
 type: Standards Track
 category: ERC
 created: 2022-07-11

--- a/EIPS/eip-5216.md
+++ b/EIPS/eip-5216.md
@@ -67,7 +67,7 @@ The `safeTrasferFrom` function (as defined by EIP-1155) MUST:
 - Not revert if the user has approved `msg.sender` with a sufficient `amount`
 - Subtract the transferred amount of tokens from the approved amount if `msg.sender` is not approved with `setApprovalForAll`
 
-In additon, the `safeBatchTransferFrom` MUST:
+In addition, the `safeBatchTransferFrom` MUST:
 
 - Add an extra condition that checks if the `allowance` of all `ids` have the approved `amounts` (See `_checkApprovalForBatch` function reference implementation)
 

--- a/EIPS/eip-5216.md
+++ b/EIPS/eip-5216.md
@@ -18,7 +18,7 @@ This specification defines standard functions for approving amounts of an [EIP-1
 ## Motivation
 
 [EIP-1155](./eip-1155.md) has created a scenario where multiple token management and transactions occur on a daily basis. Although it can be used as [EIP-721](./eip-721.md), the most common way to use it is to create collections through its `ids` in order to have an indefinite `amount` of tokens of one type. These tokens have been implemented in a wide variety of projects, but the most important are marketplaces.
-The nature of tokens is trading, transfer and use, so it is important that your peer-to-peer transactions are as secure as possible.
+The nature of tokens is trading, transfer and use, so it is important that peer-to-peer transactions are as secure as possible.
 
 The way the [EIP-1155](./eip-1155.md) standard approves tokens is with the `setApprovalForAll(address operator, bool approved)` function, which approves ALL tokens of an `id`. However, this is a standard that combines ideas from the [EIP-20](./eip-20.md) and [EIP-721](./eip-721.md) standards, and it is important to create a trust mechanism, where an owner can allow a third party, such as a marketplace, to approve a limited number of tokens of an `id` and not all at once.
 
@@ -79,7 +79,7 @@ The `allowance(address account, address operator, uint256 id)` function MAY be i
 Every contract implementing the `ERC1155ApprovalByAmount` extension MUST implement `_checkApprovalForBatch(address from, address to, uint256[] memory ids, uint256[] memory amounts)` function in some way. This function is necessary to manage
 batch transfers subtracting the amount of tokens transferred.
 
-In same way, `safe(Batch)TrasferFrom` overrode function from `ERC1155` standard it is also important to change its implementation:
+In same way, `safe(Batch)TrasferFrom` function from `ERC1155` standard, it is also important to change its implementation:
 
 - In `safeTransferFrom` MUST be added to require an extra condition: `|| allowance(from, _msgSender(), id)`.
 - In `safeTransferFrom` MUST be subtracted from `_allowances` mapping the transferred amount of tokens: `_allowances[from][_msgSender()][id] -= amount`.

--- a/EIPS/eip-5216.md
+++ b/EIPS/eip-5216.md
@@ -13,31 +13,19 @@ requires: 20, 165, 1155
 
 ## Abstract
 
-This specification defines standard functions for granular approval of [EIP-1155](./eip-1155.md) tokens by both tokenId and amount. The proposal depends on and extends [EIP-1155](./eip-1155.md).
+This specification defines standard functions for granular approval of [EIP-1155](./eip-1155.md) tokens by both `id` and `amount`. This EIP extends [EIP-1155](./eip-1155.md).
 
 ## Motivation
 
-[EIP-1155](./eip-1155.md) has created a scenario where multi-token transactions and management occurs on a daily basis. Although it can be used as an alternative to [EIP-721](./eip-721.md), the most common way it is used is to create multiple `tokenId`s, each with multiple tokens. These tokens have been implemented in a wide variety of projects, but the most common interactions are with marketplaces.
+[EIP-1155](./eip-1155.md)'s popularity means that multi-token management transactions occur on a daily basis. Although it can be used as a more comprehensive alternative to [EIP-721](./eip-721.md), it is most commonly used as intended: creating multiple `id`s, each with multiple tokens. While many projects interface with these semi-fungible tokens, by far the most common interactions are with NFT marketplaces.
 
-The nature of tokens is trading, transfer and use, so it is important that peer-to-peer transactions are as secure as possible.
-
-[EIP-1155](./eip-1155.md) approves tokens with the `setApprovalForAll(address operator, bool approved)` function, which approves ALL tokens of an `id`. However, this system has some flaws. This EIP combines ideas from [EIP-20](./eip-20.md) and [EIP-721](./eip-721.md) in order to create a trust mechanism where an owner can allow a third party, such as a marketplace, to approve a limited (instead of unlimited) number of tokens of an `id`.
-
-In turn, it is also necessary to subtract the amount of tokens approved once they have been successfully transferred to avoid the scenario that we have now, where ALL tokens of an `id` are approved without revoking that approval at any time. This is quite dangerous because if you don't revoke that approval with `setApprovalForAll(operatorAddress, false)`, you leave your tokens vulnerable to abuse by the operator.
-
-By having a way to approve and revoke in a manner similar to [EIP-20](./eip-20.md), we reduce that security problem:
-
-- By `approve` function, we allow an operator to use an amount of tokens per id.
-- Through the function `allowance` you can see the amount of tokens that an approved account has per id.
-
-Both functions follow the [EIP-20](./eip-20.md) name patterns.
-
+Due to the nature of the blockchain, programming errors or malicious operators can cause permanent loss of funds. It is therefore essential that transactions are as trustless as possible. [EIP-1155](./eip-1155.md) approves tokens with the `setApprovalForAll` function, which approves ALL tokens with a specific `id`. This system has obvious minimum required trust flaws. This EIP combines ideas from [EIP-20](./eip-20.md) and [EIP-721](./eip-721.md) in order to create a trust mechanism where an owner can allow a third party, such as a marketplace, to approve a limited (instead of unlimited) number of tokens of one `id`.
 
 ## Specification
 
 The keywords “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be interpreted as described in RFC 2119.
 
-Contracts using this EIP MUST implement the `IERC1155ApprovalByAmount` interface. The **approval by amount extension** is OPTIONAL for [EIP-1155](./eip-1155.md) contracts.
+Contracts using this EIP MUST implement the `IERC1155ApprovalByAmount` interface.
 
 ### Interface implementation
 
@@ -64,27 +52,24 @@ interface IERC1155ApprovalByAmount is IERC1155 {
     function approve(address operator, uint256 id, uint256 amount) external;
 
     /**
-     * @notice Returns the amount allocated to `operator` approved to transfer ``account``'s tokens, according to `id`.
+     * @notice Returns the amount allocated to `operator` approved to transfer `account`'s tokens, according to `id`.
      */
     function allowance(address account, address operator, uint256 id) external view returns (uint256);
-    
 }
 ```
 
-The `_allowances` mapping MAY be implemented as `internal` or `private`.
+The `approve(address operator, uint256 id, uint256 amount)` function MUST be either `public` or `external`.
 
-The `approve(address operator, uint256 id, uint256 amount)` function MAY be implemented as `public` or `external` and it is RECOMMENDED implements `private` `_approve(address owner, address operator, uint256 id, uint256 amount)` function, which is responsible for performing the approval.
+The `allowance(address account, address operator, uint256 id)` function MUST be either `public` or `external` and MUST be `view`.
 
-The `allowance(address account, address operator, uint256 id)` function MAY be implemented as `public` or `external` for visibility and MUST be implemented as `view`.
+The `safeTrasferFrom` function (as defined by EIP-1155) MUST:
 
-Every contract implementing the `ERC1155ApprovalByAmount` extension MUST implement `_checkApprovalForBatch(address from, address to, uint256[] memory ids, uint256[] memory amounts)` function in some way. This function is necessary to manage
-batch transfers subtracting the amount of tokens transferred.
+- Not revert if the user has approved `msg.sender` with a sufficient `amount`
+- Subtract the transferred amount of tokens from the approved amount if `msg.sender` is not approved with `setApprovalForAll`
 
-In same way, `safe(Batch)TrasferFrom` function from `ERC1155` standard, it is also important to change its implementation:
+In additon, the `safeBatchTransferFrom` MUST:
 
-- In `safeTransferFrom` MUST be added to require an extra condition: `|| allowance(from, _msgSender(), id)`.
-- In `safeTransferFrom` MUST be subtracted from `_allowances` mapping the transferred amount of tokens: `_allowances[from][_msgSender()][id] -= amount`.
-- In `safeBatchTransferFrom` MUST be added to require an extra condition that checks if the `allowance` of all `ids` have the approved `amounts` (See `_checkApprovalForBatch` function reference implementation)
+- Add an extra condition that checks if the `allowance` of all `ids` have the approved `amounts` (See `_checkApprovalForBatch` function reference implementation)
 
 The `ApprovalByAmount` event MUST be emitted when a certain number of tokens are approved.
 
@@ -92,9 +77,14 @@ The `supportsInterface` method MUST return `true` when called with `0x1be07d74`.
 
 ## Rationale
 
-The chosen name resonates with the purpose of its existence. Users can approve their tokens by id and amounts to `operators`.
+The name "EIP-1155 Approval By Amount Extension" was chosen because it is a succinct description of this EIP. Users can approve their tokens by `id` and `amount` to `operator`s.
 
-The [EIP-20](./eip-20.md) standard name patterns, were used to simplify the understanding of how the interface works due to similarity with how [EIP-20](./eip-20.md) works with approvals.
+By having a way to approve and revoke in a manner similar to [EIP-20](./eip-20.md), the trust level can be more directly managed by users:
+
+- Using the `approve` function, users can approve an operator to spend an `amount` of tokens for each `id`.
+- Using the `allowance` function, users can see the approval that an operator has for each `id`.
+
+The [EIP-20](./eip-20.md) name patterns were used due to similarities with [EIP-20](./eip-20.md) approvals.
 
 ## Backwards Compatibility
 
@@ -106,7 +96,7 @@ The reference implementation can be found [here](../assets/eip-5216/ERC1155Appro
 
 ## Security Considerations
 
-Implementors of the `ERC1155ApprovalByAmount` standard must consider thoroughly the amount of tokens they give permission to `operators`. They should also revoke the rest.
+Users of this EIP must thoroughly consider the amount of tokens they give permission to `operators`, and should revoke unused authorizations.
 
 ## Copyright
 

--- a/EIPS/eip-5216.md
+++ b/EIPS/eip-5216.md
@@ -19,7 +19,7 @@ This specification defines standard functions for granular approval of [EIP-1155
 
 [EIP-1155](./eip-1155.md)'s popularity means that multi-token management transactions occur on a daily basis. Although it can be used as a more comprehensive alternative to [EIP-721](./eip-721.md), it is most commonly used as intended: creating multiple `id`s, each with multiple tokens. While many projects interface with these semi-fungible tokens, by far the most common interactions are with NFT marketplaces.
 
-Due to the nature of the blockchain, programming errors or malicious operators can cause permanent loss of funds. It is therefore essential that transactions are as trustless as possible. [EIP-1155](./eip-1155.md) approves tokens with the `setApprovalForAll` function, which approves ALL tokens with a specific `id`. This system has obvious minimum required trust flaws. This EIP combines ideas from [EIP-20](./eip-20.md) and [EIP-721](./eip-721.md) in order to create a trust mechanism where an owner can allow a third party, such as a marketplace, to approve a limited (instead of unlimited) number of tokens of one `id`.
+Due to the nature of the blockchain, programming errors or malicious operators can cause permanent loss of funds. It is therefore essential that transactions are as trustless as possible. EIP-1155 uses the `setApprovalForAll` function, which approves ALL tokens with a specific `id`. This system has obvious minimum required trust flaws. This EIP combines ideas from [EIP-20](./eip-20.md) and [EIP-721](./eip-721.md) in order to create a trust mechanism where an owner can allow a third party, such as a marketplace, to approve a limited (instead of unlimited) number of tokens of one `id`.
 
 ## Specification
 

--- a/EIPS/eip-5216.md
+++ b/EIPS/eip-5216.md
@@ -13,30 +13,31 @@ requires: 20, 165, 1155
 
 ## Abstract
 
-This specification defines standard functions for approving amounts of an [EIP-1155](./eip-1155.md). An implementation allows approve by id, different amounts both batch and individual. The proposal depends on and extends the existing [EIP-1155](./eip-1155.md).
+This specification defines standard functions for granular approval of [EIP-1155](./eip-1155.md) tokens by both tokenId and amount. The proposal depends on and extends [EIP-1155](./eip-1155.md).
 
 ## Motivation
 
-[EIP-1155](./eip-1155.md) has created a scenario where multiple token management and transactions occur on a daily basis. Although it can be used as [EIP-721](./eip-721.md), the most common way to use it is to create collections through its `ids` in order to have an indefinite `amount` of tokens of one type. These tokens have been implemented in a wide variety of projects, but the most important are marketplaces.
+[EIP-1155](./eip-1155.md) has created a scenario where multi-token transactions and management occurs on a daily basis. Although it can be used as an alternative to [EIP-721](./eip-721.md), the most common way it is used is to create multiple `tokenId`s, each with multiple tokens. These tokens have been implemented in a wide variety of projects, but the most common interactions are with marketplaces.
+
 The nature of tokens is trading, transfer and use, so it is important that peer-to-peer transactions are as secure as possible.
 
-The way the [EIP-1155](./eip-1155.md) standard approves tokens is with the `setApprovalForAll(address operator, bool approved)` function, which approves ALL tokens of an `id`. However, this is a standard that combines ideas from the [EIP-20](./eip-20.md) and [EIP-721](./eip-721.md) standards, and it is important to create a trust mechanism, where an owner can allow a third party, such as a marketplace, to approve a limited number of tokens of an `id` and not all at once.
+[EIP-1155](./eip-1155.md) approves tokens with the `setApprovalForAll(address operator, bool approved)` function, which approves ALL tokens of an `id`. However, this system has some flaws. This EIP combines ideas from [EIP-20](./eip-20.md) and [EIP-721](./eip-721.md) in order to create a trust mechanism where an owner can allow a third party, such as a marketplace, to approve a limited (instead of unlimited) number of tokens of an `id`.
 
-In turn, it is also necessary to subtract the amount of tokens approved once they have been successfully transferred to avoid the scenario that we have now, where ALL tokens of an `id` are approved without revoking that approval at any time. In our honest opinion, this is quite dangerous because if you don't revoke that approval with `setApprovalForAll(operatorAddress, false)`, you let that the operator do whateaver he wants whenever he wants with all your tokens.
+In turn, it is also necessary to subtract the amount of tokens approved once they have been successfully transferred to avoid the scenario that we have now, where ALL tokens of an `id` are approved without revoking that approval at any time. This is quite dangerous because if you don't revoke that approval with `setApprovalForAll(operatorAddress, false)`, you leave your tokens vulnerable to abuse by the operator.
 
-By having a way to approve and revoke as the [EIP-20](./eip-20.md) standard works, i.e. by amounts we reduce that security problem:
+By having a way to approve and revoke in a manner similar to [EIP-20](./eip-20.md), we reduce that security problem:
 
 - By `approve` function, we allow an operator to use an amount of tokens per id.
 - Through the function `allowance` you can see the amount of tokens that an approved account has per id.
 
-Both following the [EIP-20](./eip-20.md) standard name patterns.
+Both functions follow the [EIP-20](./eip-20.md) name patterns.
 
 
 ## Specification
 
 The keywords “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be interpreted as described in RFC 2119.
 
-Every contract compliant to the `ERC1155ApprovalByAmount` extension MUST implement the `IERC1155ApprovalByAmount` interface. The **approval by amount extension** is OPTIONAL for [EIP-1155](./eip-1155.md) contracts.
+Contracts using this EIP MUST implement the `IERC1155ApprovalByAmount` interface. The **approval by amount extension** is OPTIONAL for [EIP-1155](./eip-1155.md) contracts.
 
 ### Interface implementation
 

--- a/assets/eip-5216/ERC1155ApprovalByAmount.sol
+++ b/assets/eip-5216/ERC1155ApprovalByAmount.sol
@@ -44,7 +44,7 @@ abstract contract ERC1155ApprovalByAmount is ERC1155, IERC1155ApprovalByAmount {
      * @dev See {IERC1155ApprovalByAmount}
      */
     function approve(address operator, uint256 id, uint256 amount) public virtual {
-        _approve(_msgSender(), operator, id, amount);
+        _approve(msg.sender, operator, id, amount);
     }
 
     /**
@@ -65,11 +65,11 @@ abstract contract ERC1155ApprovalByAmount is ERC1155, IERC1155ApprovalByAmount {
         bytes memory data
     ) public override(IERC1155, ERC1155) {
         require(
-            from == _msgSender() || isApprovedForAll(from, _msgSender()) || allowance(from, _msgSender(), id) >= amount,
+            from == msg.sender || isApprovedForAll(from, msg.sender) || allowance(from, msg.sender, id) >= amount,
             "ERC1155: caller is not owner nor approved nor approved for amount"
         );
         unchecked {
-            _allowances[from][_msgSender()][id] -= amount;
+            _allowances[from][msg.sender][id] -= amount;
         }
         _safeTransferFrom(from, to, id, amount, data);
     }
@@ -85,7 +85,7 @@ abstract contract ERC1155ApprovalByAmount is ERC1155, IERC1155ApprovalByAmount {
         bytes memory data
     ) public virtual override(IERC1155, ERC1155) {
         require(
-            from == _msgSender() || isApprovedForAll(from, _msgSender()) || _checkApprovalForBatch(from, _msgSender(), ids, amounts),
+            from == msg.sender || isApprovedForAll(from, msg.sender) || _checkApprovalForBatch(from, msg.sender, ids, amounts),
             "ERC1155: transfer caller is not owner nor approved nor approved for some amount"
         );
         _safeBatchTransferFrom(from, to, ids, amounts, data);

--- a/assets/eip-5216/ERC1155ApprovalByAmount.sol
+++ b/assets/eip-5216/ERC1155ApprovalByAmount.sol
@@ -26,7 +26,7 @@ interface IERC1155ApprovalByAmount is IERC1155 {
     function approve(address operator, uint256 id, uint256 amount) external;
 
     /**
-     * @notice Returns the amount allocated to `operator` approved to transfer ``account``'s tokens, according to `id`.
+     * @notice Returns the amount allocated to `operator` approved to transfer `account`'s tokens, according to `id`.
      */
     function allowance(address account, address operator, uint256 id) external view returns (uint256);
     


### PR DESCRIPTION
Move EIP-5216 to review and changed OZ msgSender context function to native msg.sender.

Furthermore, I'd like to add some test cases how @MicahZoltu told me here: https://github.com/ethereum/EIPs/pull/5216#pullrequestreview-1048632814. There are some example of this?