### PR TITLE
Update EIP-1: Clarify when to use `requires`

### DIFF
--- a/EIPS/eip-1.md
+++ b/EIPS/eip-1.md
@@ -183,7 +183,9 @@ The `created` header records the date that the EIP was assigned a number. Both h
 
 #### `requires` header
 
-EIPs may have a `requires` header, indicating the EIP numbers that this EIP depends on.
+EIPs may have a `requires` header, indicating the EIP numbers that this EIP depends on. If such a dependency exists, this field is required.
+
+A `requires` dependency is created when the current EIP cannot be understood or implemented without a concept or technical element from another EIP. Merely mentioning another EIP does not necessarily create such a dependency.
 
 ## Linking to External Resources
 


### PR DESCRIPTION
As discussed in [EIPIP Meeting #64](https://github.com/ethereum-cat-herders/EIPIP/issues/174), here's a PR with my proposal for updating the `requires` text.