### PR TITLE
EIP-4844: fix typo

### DIFF
--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -328,7 +328,7 @@ For early draft implementations, we simply change `get_blob_gas(pre_state)` to a
 ### Gas price update rule (Full version)
 
 We propose a simple independent EIP-1559-style targeting rule to compute the gas cost of the transaction.
-We use the `blobs` header field to store persistent data needed to compute the cost.
+We use the `excess_blobs` header field to store persistent data needed to compute the cost.
 
 Note that unlike existing transaction types, the gas cost is dependent on the pre-state of the block.
 


### PR DESCRIPTION
Renamed the header field a few times and left an outdated reference. (h/t @axic)