### PR TITLE
fix(4844): leave G_transaction at 21000

### DIFF
--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -334,7 +334,7 @@ Note that unlike existing transaction types, the gas cost is dependent on the pr
 
 ```python
 def get_intrinsic_gas(tx: SignedBlobTransaction, pre_state: ExecState) -> int:
-    intrinsic_gas = 20000  # G_transaction, previously 21000
+    intrinsic_gas = 21000  # G_transaction
     if tx.message.to == None:  # i.e. if a contract is created
         intrinsic_gas = 53000
     # EIP-2028 data gas cost reduction for zero bytes


### PR DESCRIPTION
This EIP changed the intrinsic `G_transaction ` to 20k, as maybe an incentive for people to use this new transaction type.

If we want to make this change, it should happen in a separate EIP that explains the motivation & solution like every other gas cost change.

[As discussed in Discord]