### PR TITLE
Remove one unnecessary sentence.

### DIFF
--- a/EIPS/eip-3525.md
+++ b/EIPS/eip-3525.md
@@ -568,7 +568,7 @@ As mentioned in the beginning, this EIP is backward compatible with EIP-721.
 
 The value level approval and slot level approval(optional) is isolated from EIP-721 approval models, so that approving value should not affect EIP-721 level approvals, implementations of this EIP must obey this principle.
 
-This EIP keeps the unsafe transfer model of values, so that when the receiver is a smart contract, the sender must be able to decide whether the receiving contract has the ability to manipulate EIP-3525 tokens. However, since this EIP is EIP-721 compatible, any wallets and smart contracts that can hold and manipulate standard EIP-721 tokens will have no risks of asset loss for EIP-3525 tokens.
+Since this EIP is EIP-721 compatible, any wallets and smart contracts that can hold and manipulate standard EIP-721 tokens will have no risks of asset loss for EIP-3525 tokens.
 
 ## Copyright
 


### PR DESCRIPTION
The meaning of the removed sentence is covered by the segment <Design decision: Notification/acceptance mechanism instead of 'Safe Transfer'>, so that it is redundant and some how misleading.
