### PR TITLE
CI: Disable certain labels from becoming stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -24,11 +24,11 @@ jobs:
         close-issue-message: This issue was closed due to inactivity. If you are still pursuing it, feel free to reopen it and respond to any feedback.
         days-before-issue-stale: 7
         days-before-issue-close: 49 # 49 + 7 weeks = 3 months
-        exempt-issue-labels: discussions-to
+        exempt-issue-labels: discussions-to, e-consensus
         stale-issue-label: w-stale
         # PR config
         stale-pr-message: There has been no activity on this pull request for 2 weeks. It will be closed after 3 months of inactivity. If you would like to move this PR forward, please respond to any outstanding feedback or add a comment indicating that you have addressed all required feedback and are ready for a review.
         close-pr-message: This pull request was closed due to inactivity. If you are still pursuing it, feel free to reopen it and respond to any feedback or request a review in a comment.
         days-before-pr-stale: 14
         days-before-pr-close: 42 # 42 + 14 weeks = 3 months
-        stale-pr-label: w-stale
+        stale-pr-label: w-stale, e-review, a-review, e-consensus

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -31,5 +31,6 @@ jobs:
         close-pr-message: This pull request was closed due to inactivity. If you are still pursuing it, feel free to reopen it and respond to any feedback or request a review in a comment.
         days-before-pr-stale: 14
         days-before-pr-close: 42 # 42 + 14 weeks = 3 months
-        stale-pr-label: w-stale, e-review, a-review, e-consensus
+        exempt-pr-labels: e-review, e-consensus
         exempt-pr-milestones: "Manual Merge Queue"
+        stale-pr-label: w-stale

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -32,3 +32,4 @@ jobs:
         days-before-pr-stale: 14
         days-before-pr-close: 42 # 42 + 14 weeks = 3 months
         stale-pr-label: w-stale, e-review, a-review, e-consensus
+        exempt-pr-milestones: "Manual Merge Queue"


### PR DESCRIPTION
These labels mean that the PR is waiting on some other person in order to be merged, and the author may still be responsive.