### PR TITLE
Update EIP-3670: Use exceptions with error messages in reference code

### DIFF
--- a/EIPS/eip-3670.md
+++ b/EIPS/eip-3670.md
@@ -80,7 +80,10 @@ immediate_sizes = 256 * [0]
 for opcode in range(0x60, 0x7f + 1):  # PUSH1..PUSH32
     immediate_sizes[opcode] = opcode - 0x60 + 1
 
-# Fails with assertion on invalid code
+class ValidationException(Exception):
+    pass
+
+# Raises ValidationException on invalid code
 def validate_code(code: bytes):
     # Note that EOF1 already asserts this with the code section requirements
     assert len(code) > 0
@@ -91,16 +94,19 @@ def validate_code(code: bytes):
         # Ensure the opcode is valid
         opcode = code[pos]
         pos += 1
-        assert opcode in valid_opcodes
+        if not opcode in valid_opcodes:
+            raise ValidationException("undefined instruction")
 
         # Skip immediates
         pos += immediate_sizes[opcode]
 
     # Ensure last opcode's immediate doesn't go over code end
-    assert pos == len(code)
+    if pos != len(code):        
+        raise ValidationException("truncated immediate")
 
     # opcode is the *last opcode*
-    assert opcode in terminating_opcodes
+    if not opcode in terminating_opcodes:
+        raise ValidationException("no terminating instruction")
 ```
 
 ## Test Cases

--- a/EIPS/eip-3670.md
+++ b/EIPS/eip-3670.md
@@ -21,6 +21,14 @@ Currently existing contracts require no validation of correctness and EVM implem
 
 If it will be desired to introduce new instructions without bumping EOF version, having undefined instructions already deployed would mean such contracts potentially can be broken (since some of the instructions are changing their behaviour). Rejecting to deploy undefined instructions allows introducing new instructions with or without bumping the EOF version.
 
+### EOF1 forward compatibility
+
+The EOF1 format provides following forward compatibility properties:
+
+1. New instructions can be defined for previously unassigned opcodes. These instructions may have immediate values.
+2. Mandatory EOF sections may be made optional.
+3. New optional EOF sections may be introduced. They can be placed in any order in relation to previously defined sections.
+
 ## Specification
 
 *Remark:* We rely on the notation of *initcode*, *code* and *creation* as defined by [EIP-3540](./eip-3540.md).

--- a/EIPS/eip-3670.md
+++ b/EIPS/eip-3670.md
@@ -51,6 +51,37 @@ An efficient interpreter loop would only need to rely on checking if a terminati
 
 The deprecated `CALLCODE` (0xf2) opcode may be dropped from the `valid_opcodes` list to prevent use of this instruction in future. Likewise `SELFDESTRUCT` (0xff) could also be rejected. Yet we decided not to mix such changes in.
 
+## Backwards Compatibility
+
+This change poses no risk to backwards compatibility, as it is introduced at the same time EIP-3540 is. The validation does not cover legacy bytecode (code which is not EOF formatted).
+
+## Test Cases
+
+#### Contract creation
+
+Each case should be tested for creation transaction, `CREATE` and `CREATE2`.
+
+- Invalid initcode
+- Valid initcode returning invalid code
+- Valid initcode returning valid code
+
+#### Valid codes
+
+- EOF code containing `INVALID`
+- EOF codes ending with any of the terminating instructions
+- EOF code with data section containing bytes that are undefined instructions
+- Legacy code containing undefined instruction
+- Legacy code ending with incomplete PUSH instruction
+- Legacy code ending with any valid non-terminating instruction
+
+#### Invalid codes
+
+- EOF code containing undefined instruction
+- EOF code ending with incomplete `PUSH` instruction
+    - This can include `PUSH` instruction unreachable by execution, e.g. after `STOP`
+- EOF code ending with any defined instruction other than terminating ones
+    - This can include codes where non-terminating instruction is not reachable, e.g. `0030` (`STOP ADDRESS`).
+
 ## Reference Implementation
 
 ```python
@@ -108,37 +139,6 @@ def validate_code(code: bytes):
     if not opcode in terminating_opcodes:
         raise ValidationException("no terminating instruction")
 ```
-
-## Test Cases
-
-#### Contract creation
-
-Each case should be tested for creation transaction, `CREATE` and `CREATE2`.
-
-- Invalid initcode
-- Valid initcode returning invalid code
-- Valid initcode returning valid code
-
-#### Valid codes
-
-- EOF code containing `INVALID`
-- EOF codes ending with any of the terminating instructions
-- EOF code with data section containing bytes that are undefined instructions
-- Legacy code containing undefined instruction
-- Legacy code ending with incomplete PUSH instruction
-- Legacy code ending with any valid non-terminating instruction
-
-#### Invalid codes
-
-- EOF code containing undefined instruction
-- EOF code ending with incomplete `PUSH` instruction
-    - This can include `PUSH` instruction unreachable by execution, e.g. after `STOP`
-- EOF code ending with any defined instruction other than terminating ones
-    - This can include codes where non-terminating instruction is not reachable, e.g. `0030` (`STOP ADDRESS`).
-
-## Backwards Compatibility
-
-This change poses no risk to backwards compatibility, as it is introduced at the same time EIP-3540 is. The validation does not cover legacy bytecode (code which is not EOF formatted).
 
 ## Security Considerations
 


### PR DESCRIPTION
Also add `EOF1 Forward compatibility` subsection to `Motivation`.