### PR TITLE
Update 4844: use clearer name for max fee value

### DIFF
--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -13,7 +13,7 @@ requires: 1559, 2718, 2930
 
 ## Abstract
 
-Introduce a new transaction format for "blob-carrying transactions" which contain a large amount of data that cannot be 
+Introduce a new transaction format for "blob-carrying transactions" which contain a large amount of data that cannot be
 accessed by EVM execution, but whose commitment can be accessed.
 The format is intended to be fully compatible with the format that will be used in full sharding.
 
@@ -24,7 +24,7 @@ Transaction fees on L1 have been very high for months and there is greater urgen
 Rollups are significantly reducing fees for many Ethereum users: Optimism and Arbitrum frequently provide fees that are ~3-8x lower than the Ethereum base layer itself,
 and ZK rollups, which have better data compression and can avoid including signatures, have fees ~40-100x lower than the base layer.
 
-However, even these fees are too expensive for many users. The long-term solution to the long-term inadequacy of rollups 
+However, even these fees are too expensive for many users. The long-term solution to the long-term inadequacy of rollups
 by themselves has always been data sharding, which would add ~16 MB per block of dedicated data space to the chain that rollups could use.
 However, data sharding will still take a considerable amount of time to finish implementing and deploying.
 
@@ -161,7 +161,7 @@ def fake_exponential(numerator: int, denominator: int) -> int:
 ### New transaction type
 
 We introduce a new [EIP-2718](./eip-2718.md) transaction type,
-with the format being the single byte `BLOB_TX_TYPE` followed by an SSZ encoding of the 
+with the format being the single byte `BLOB_TX_TYPE` followed by an SSZ encoding of the
 `SignedBlobTransaction` container comprising the transaction contents:
 
 ```python
@@ -215,7 +215,7 @@ The execution layer verifies the wrapper validity against the inner `Transaction
 * There may be at most `MAX_BLOBS_PER_BLOCK` total blob commitments in a valid block.
 * There is an equal amount of versioned hashes, kzg commitments and blobs.
 * The KZG commitments hash to the versioned hashes, i.e. `kzg_to_versioned_hash(kzg[i]) == versioned_hash[i]`
-* The KZG commitments match the blob contents. (Note: this can be optimized with additional data, using a proof for a 
+* The KZG commitments match the blob contents. (Note: this can be optimized with additional data, using a proof for a
   random evaluation at two points derived from the commitment and blob data)
 
 
@@ -284,7 +284,7 @@ Note that the consensus-layer is tasked with persisting the blobs for data avail
 
 The `ethereum/consensus-specs` repository defines the following beacon-node changes involved in this EIP:
 - Beacon chain: process updated beacon blocks and ensure blobs are available.
-- P2P network: gossip and sync updated beacon block types and new blobs sidecars. 
+- P2P network: gossip and sync updated beacon block types and new blobs sidecars.
 - Honest validator: produce beacon blocks with blobs, publish the blobs sidecars.
 
 ### Opcode to get versioned hashes

--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -173,7 +173,7 @@ class BlobTransaction(Container):
     chain_id: uint256
     nonce: uint64
     priority_fee_per_gas: uint256
-    max_basefee_per_gas: uint256
+    max_fee_per_gas: uint256
     gas: uint64
     to: Union[None, Address] # Address = Bytes20
     value: uint256
@@ -191,7 +191,7 @@ class ECDSASignature(Container):
     s: uint256
 ```
 
-The `priority_fee_per_gas` and `max_basefee_per_gas` fields follow [EIP-1559](./eip-1559.md) semantics,
+The `priority_fee_per_gas` and `max_fee_per_gas` fields follow [EIP-1559](./eip-1559.md) semantics,
 and `access_list` as in [`EIP-2930`](./eip-2930.md).
 
 [`EIP-2718`](./eip-2718.md) is extended with a "wrapper data", the typed transaction can be encoded in two forms, dependent on the context:


### PR DESCRIPTION
The existing text uses the name `max_basefee_per_gas` which suggests the maximum base fee value a transaction would be willing to pay.

This value actually refers to the maximum fee per gas the transaction would be willing to pay (base fee + priority fee) and this change reflects this with what I consider a clearer name.