### PR TITLE
fix signature to use `Header` rather than `ExecState`

### DIFF
--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -323,17 +323,15 @@ def point_evaluation_precompile(input: Bytes) -> Bytes:
 
 ### Gas price of blobs (Simplified version)
 
-For early draft implementations, we simply change `get_blob_gas(pre_state)` to always return `GAS_PER_BLOB`.
+For early draft implementations, we simply change `get_blob_gas(parent)` to always return `GAS_PER_BLOB`.
 
 ### Gas price update rule (Full version)
 
 We propose a simple independent EIP-1559-style targeting rule to compute the gas cost of the transaction.
 We use the `excess_blobs` header field to store persistent data needed to compute the cost.
 
-Note that unlike existing transaction types, the gas cost is dependent on the pre-state of the block.
-
 ```python
-def get_intrinsic_gas(tx: SignedBlobTransaction, pre_state: ExecState) -> int:
+def get_intrinsic_gas(tx: SignedBlobTransaction, parent: Header) -> int:
     intrinsic_gas = 21000  # G_transaction
     if tx.message.to == None:  # i.e. if a contract is created
         intrinsic_gas = 53000
@@ -342,7 +340,7 @@ def get_intrinsic_gas(tx: SignedBlobTransaction, pre_state: ExecState) -> int:
     # EIP-2930 Optional access lists
     intrinsic_gas += 1900 * sum(len(entry.storage_keys) for entry in tx.message.access_list) + 2400 * len(tx.message.access_list)
     # New additional gas cost per blob
-    intrinsic_gas += len(tx.message.blob_versioned_hashes) * get_blob_gas(pre_state)
+    intrinsic_gas += len(tx.message.blob_versioned_hashes) * get_blob_gas(parent)
     return intrinsic_gas
 
 def get_blob_gas(header: Header) -> int:


### PR DESCRIPTION
the EIP was refactored in a previous PR to keep the fee state in the block header but references to its prior location in the state remain. this PR fixes the outdated references