### PR TITLE
Update EIP-2718: Fix the spelling of transaction

### DIFF
--- a/EIPS/eip-2718.md
+++ b/EIPS/eip-2718.md
@@ -29,7 +29,7 @@ By introducing an envelope transaction type, we only need to ensure backward com
 As of `FORK_BLOCK_NUMBER`, the transaction root in the block header **MUST** be the root hash of `patriciaTrie(rlp(Index) => Transaction)` where:
 * `Index` is the index in the block of this transaction
 * `Transaction` is either `TransactionType || TransactionPayload` or `LegacyTransaction`
-* `TransactionType` is a positive unsigned 8-bit number between `0` and `0x7f` that represents the type of the transcation
+* `TransactionType` is a positive unsigned 8-bit number between `0` and `0x7f` that represents the type of the transaction
 * `TransactionPayload` is an opaque byte array whose interpretation is dependent on the `TransactionType` and defined in future EIPs
 * `LegacyTransaction` is `rlp([nonce, gasPrice, gasLimit, to, value, data, v, r, s])`
 
@@ -40,7 +40,7 @@ This makes it so we do not have to worry about signatures for one transaction ty
 As of `FORK_BLOCK_NUMBER`, the receipt root in the block header **MUST** be the root hash of `patriciaTrie(rlp(Index) => Receipt)` where:
 * `Index` is the index in the block of the transaction this receipt is for
 * `Receipt` is either `TransactionType || ReceiptPayload` or `LegacyReceipt`
-* `TransactionType` is a positive unsigned 8-bit number between `0` and `0x7f` that represents the type of the transcation
+* `TransactionType` is a positive unsigned 8-bit number between `0` and `0x7f` that represents the type of the transaction
 * `ReceiptPayload` is an opaque byte array whose interpretation is dependent on the `TransactionType` and defined in future EIPs
 * `LegacyReceipt` is `rlp([status, cumulativeGasUsed, logsBloom, logs])`
 


### PR DESCRIPTION
 Change the word _transcation_ to _transaction_