### PR TITLE
Update EIP-3525

### DIFF
--- a/EIPS/eip-3525.md
+++ b/EIPS/eip-3525.md
@@ -573,4 +573,3 @@ Since this EIP is EIP-721 compatible, any wallets and smart contracts that can h
 ## Copyright
 
 Copyright and related rights waived via [CC0](../LICENSE.md).
-

--- a/EIPS/eip-3525.md
+++ b/EIPS/eip-3525.md
@@ -573,5 +573,3 @@ Since this EIP is EIP-721 compatible, any wallets and smart contracts that can h
 ## Copyright
 
 Copyright and related rights waived via [CC0](../LICENSE.md).
-
-

--- a/EIPS/eip-3525.md
+++ b/EIPS/eip-3525.md
@@ -573,3 +573,5 @@ Since this EIP is EIP-721 compatible, any wallets and smart contracts that can h
 ## Copyright
 
 Copyright and related rights waived via [CC0](../LICENSE.md).
+
+

--- a/assets/eip-3525/contracts/ERC3525.sol
+++ b/assets/eip-3525/contracts/ERC3525.sol
@@ -91,7 +91,7 @@ contract ERC3525 is IERC3525, IERC3525Metadata, ERC721Enumerable {
     function transferFrom( uint256 fromTokenId_, address to_, uint256 value_) public payable virtual override returns (uint256) {
         _spendAllowance(_msgSender(), fromTokenId_, value_);
 
-        uint256 newTokenId = _getNewTokenId(fromTokenId_);
+        uint256 newTokenId = _getNewTokenId();
         _mint(to_, newTokenId, _slots[fromTokenId_]);
         _transfer(fromTokenId_, newTokenId, value_);
 
@@ -125,8 +125,9 @@ contract ERC3525 is IERC3525, IERC3525Metadata, ERC721Enumerable {
     }
 
     function _burn(uint256 tokenId_) internal virtual override {
-        ERC721._burn(tokenId_);
         address owner = ERC721.ownerOf(tokenId_);
+        ERC721._burn(tokenId_);
+
         uint256 slot = _slots[tokenId_];
         uint256 value = _values[tokenId_];
 
@@ -177,7 +178,7 @@ contract ERC3525 is IERC3525, IERC3525Metadata, ERC721Enumerable {
         emit ApprovalValue(tokenId_, to_, value_);
     }
 
-    function _getNewTokenId(uint256 fromTokenId_) internal virtual returns (uint256)
+    function _getNewTokenId() internal virtual returns (uint256)
     {
         return ERC721Enumerable.totalSupply() + 1;
     }

--- a/assets/eip-3525/contracts/ERC3525.sol
+++ b/assets/eip-3525/contracts/ERC3525.sol
@@ -91,7 +91,7 @@ contract ERC3525 is IERC3525, IERC3525Metadata, ERC721Enumerable {
     function transferFrom( uint256 fromTokenId_, address to_, uint256 value_) public payable virtual override returns (uint256) {
         _spendAllowance(_msgSender(), fromTokenId_, value_);
 
-        uint256 newTokenId = _getNewTokenId();
+        uint256 newTokenId = _getNewTokenId(fromTokenId_);
         _mint(to_, newTokenId, _slots[fromTokenId_]);
         _transfer(fromTokenId_, newTokenId, value_);
 
@@ -178,7 +178,7 @@ contract ERC3525 is IERC3525, IERC3525Metadata, ERC721Enumerable {
         emit ApprovalValue(tokenId_, to_, value_);
     }
 
-    function _getNewTokenId() internal virtual returns (uint256)
+    function _getNewTokenId(uint256 fromTokenId_) internal virtual returns (uint256)
     {
         return ERC721Enumerable.totalSupply() + 1;
     }


### PR DESCRIPTION
_getNewTokenId do not use the fromTokenId_  && when you call ERC721._burn(tokenId_) call ownerOf  can't get the valid tokenId Owner.