### PR TITLE
Remove @lightclient as ERC editor

### DIFF
--- a/.github/workflows/auto-review-bot.yml
+++ b/.github/workflows/auto-review-bot.yml
@@ -40,7 +40,7 @@ jobs:
           GITHUB-TOKEN: ${{ secrets.TOKEN }}
           PR_NUMBER: ${{ steps.save-pr-number.outputs.pr }}
           CORE_EDITORS: '@lightclient,@axic,@gcolvin,@SamWilsn,@Pandapip1'
-          ERC_EDITORS: '@lightclient,@axic,@SamWilsn,@Pandapip1'
+          ERC_EDITORS: '@axic,@SamWilsn,@Pandapip1'
           NETWORKING_EDITORS: '@lightclient,@axic,@SamWilsn'
           INTERFACE_EDITORS: '@lightclient,@axic,@SamWilsn,@Pandapip1'
           META_EDITORS: '@lightclient,@axic,@gcolvin,@SamWilsn,@Pandapip1'


### PR DESCRIPTION
Hi all, unfortunately have not been able to contribute much to ERC editing lately and my inbox if overflowing with notifications. I will be more effective if I focus on the other EIP areas and helping with the process.

@Pandapip1 and @SamWilsn have been doing a great job staying on top of ERCs. If we get to a point again where ERCs are not reviewed in a timely manner I can return to editing them.

Thanks for understanding.