### PR TITLE
Update EIP-5643 interface

### DIFF
--- a/EIPS/eip-5643.md
+++ b/EIPS/eip-5643.md
@@ -36,8 +36,8 @@ interface IERC5643 {
     /// @notice Renews the subscription to an NFT
     /// Throws if `tokenId` is not a valid NFT
     /// @param tokenId The NFT to renew the subscription for
-    /// @param expiration The unix timestamp to extend the subscription to
-    function renewSubscription(uint256 tokenId, uint64 expiration) external payable;
+    /// @param duration The number of seconds to extend a subscription for
+    function renewSubscription(uint256 tokenId, uint64 duration) external payable;
 
     /// @notice Cancels the subscription of an NFT
     /// @dev Throws if `tokenId` is not a valid NFT
@@ -107,7 +107,7 @@ contract ERC5643Mock is ERC5643 {
     }
 }
 
-contract ContractTest is Test {
+contract ERC5643Test is Test {
     event SubscriptionUpdate(uint256 indexed tokenId, uint64 expiration);
 
     address user1;
@@ -123,9 +123,10 @@ contract ContractTest is Test {
     }
 
     function testRenewalValid() public {
+        vm.warp(1000);
         vm.prank(user1);
         vm.expectEmit(true, true, false, true);
-        emit SubscriptionUpdate(tokenId, 2000);
+        emit SubscriptionUpdate(tokenId, 3000);
         erc5643.renewSubscription(tokenId, 2000);
     }
 
@@ -147,10 +148,12 @@ contract ContractTest is Test {
     }
 
     function testExpiresAt() public {
+        vm.warp(1000);
+
         assertEq(erc5643.expiresAt(tokenId), 0);
         vm.startPrank(user1);
         erc5643.renewSubscription(tokenId, 2000);
-        assertEq(erc5643.expiresAt(tokenId), 2000);
+        assertEq(erc5643.expiresAt(tokenId), 3000);
 
         erc5643.cancelSubscription(tokenId);
         assertEq(erc5643.expiresAt(tokenId), 0);
@@ -174,10 +177,23 @@ contract ERC5643 is ERC721, IERC5643 {
 
     constructor(string memory name_, string memory symbol_) ERC721(name_, symbol_) {}
 
-    function renewSubscription(uint256 tokenId, uint64 expiration) external payable {
+    function renewSubscription(uint256 tokenId, uint64 duration) external payable {
         require(_isApprovedOrOwner(msg.sender, tokenId), "Caller is not owner nor approved");
-        _subscriptions[tokenId] = expiration;
-        emit SubscriptionUpdate(tokenId, expiration);
+
+        uint64 currentExpiration = _expirations[tokenId];
+        uint64 newExpiration;
+        if (currentExpiration == 0) {
+            newExpiration = uint64(block.timestamp) + duration;
+        } else {
+            if (!_isRenewable(tokenId)) {
+                revert SubscriptionNotRenewable();
+            }
+            newExpiration = currentExpiration + duration;
+        }
+
+        _expirations[tokenId] = newExpiration;
+
+        emit SubscriptionUpdate(tokenId, newExpiration);
     }
 
     function cancelSubscription(uint256 tokenId) external payable {


### PR DESCRIPTION
Instead of passing in an `expiration` date, I found it easier to pass in a `duration`. This allows contracts to calculate the price of renewal easier instead of having to derive the duration from the existing expiration.