### PR TITLE
Update EIP-2612: Move to Final

### DIFF
--- a/EIPS/eip-2612.md
+++ b/EIPS/eip-2612.md
@@ -1,6 +1,6 @@
 ---
 eip: 2612
-title: "Permits for EIP-20: Signed Approvals"
+title: "Permit Extension for EIP-20: Signed Approval"
 description: EIP-20 approvals via EIP-712 secp256k1 signatures
 author: Martin Lundfall (@Mrchico)
 discussions-to: https://github.com/ethereum/EIPs/issues/2613

--- a/EIPS/eip-2612.md
+++ b/EIPS/eip-2612.md
@@ -1,6 +1,6 @@
 ---
 eip: 2612
-title: "Permit Extension for EIP-20: Signed Approvals"
+title: "Permit Extension for EIP-20: Signed Approval"
 description: EIP-20 approvals via EIP-712 secp256k1 signatures
 author: Martin Lundfall (@Mrchico)
 discussions-to: https://github.com/ethereum/EIPs/issues/2613

--- a/EIPS/eip-2612.md
+++ b/EIPS/eip-2612.md
@@ -1,6 +1,6 @@
 ---
 eip: 2612
-title: "Permit Extension for EIP-20: Signed Approval"
+title: "Permits for EIP-20: Signed Approvals"
 description: EIP-20 approvals via EIP-712 secp256k1 signatures
 author: Martin Lundfall (@Mrchico)
 discussions-to: https://github.com/ethereum/EIPs/issues/2613

--- a/EIPS/eip-2612.md
+++ b/EIPS/eip-2612.md
@@ -1,6 +1,6 @@
 ---
 eip: 2612
-title: "Permit Extension for EIP-20: Signed Approval"
+title: Permit Extension for EIP-20 Signed Approvals
 description: EIP-20 approvals via EIP-712 secp256k1 signatures
 author: Martin Lundfall (@Mrchico)
 discussions-to: https://github.com/ethereum/EIPs/issues/2613

--- a/EIPS/eip-2612.md
+++ b/EIPS/eip-2612.md
@@ -1,11 +1,10 @@
 ---
 eip: 2612
-title: "EIP-20 Permit Extension: Signed Approvals"
+title: "Permit Extension for EIP-20: Signed Approvals"
 description: EIP-20 approvals via EIP-712 secp256k1 signatures
 author: Martin Lundfall (@Mrchico)
 discussions-to: https://github.com/ethereum/EIPs/issues/2613
-status: Last Call
-last-call-deadline: 2022-10-08
+status: Final
 type: Standards Track
 category: ERC
 created: 2020-04-13
@@ -36,7 +35,7 @@ While it may be tempting to introduce `*_by_signature` counterparts for every EI
  - they can be implemented using a combination of `permit` and additional helper contracts without loss of generality.
 
 ## Specification
-Three new functions are added to the EIP-20 ABI:
+Compliant contracts must implement 3 new functions in addition to EIP-20:
 ```sol
 function permit(address owner, address spender, uint value, uint deadline, uint8 v, bytes32 r, bytes32 s) external
 function nonces(address owner) external view returns (uint)


### PR DESCRIPTION
Two non-normative changes are included here in addition to the move to Final:

1. The title is slightly changed because the previous title looked awkward (was "**EIP-2612: EIP-20** Permit Extension ...")
2. The spec is changed to more explicitly say the contract "must" implement the 3 functions as suggested by @xinbenlv in https://github.com/ethereum/EIPs/pull/5506#issuecomment-1267523134. (Note: I didn't use all caps "MUST" because the RFC 2119 clause is not present and I don't want to add it to minimize changes.)