### PR TITLE
Update EIP-1155: Change title to 'Semi Fungible Token Standard'

### DIFF
--- a/EIPS/eip-1155.md
+++ b/EIPS/eip-1155.md
@@ -1,6 +1,6 @@
 ---
 eip: 1155
-title: Multi Token Standard
+title: Semi Fungible Token Standard
 author: Witek Radomski <witek@enjin.io>, Andrew Cooke <ac0dem0nk3y@gmail.com>, Philippe Castonguay <pc@horizongames.net>, James Therien <james@turing-complete.com>, Eric Binet <eric@enjin.io>, Ronan Sandford <wighawag@gmail.com>
 type: Standards Track
 category: ERC
@@ -16,7 +16,7 @@ A standard interface for contracts that manage multiple token types. A single de
 
 ## Abstract
 
-This standard outlines a smart contract interface that can represent any number of fungible and non-fungible token types. Existing standards such as ERC-20 require deployment of separate contracts per token type. The ERC-721 standard's token ID is a single non-fungible index and the group of these non-fungibles is deployed as a single contract with settings for the entire collection. In contrast, the ERC-1155 Multi Token Standard allows for each token ID to represent a new configurable token type, which may have its own metadata, supply and other attributes.
+This standard outlines a smart contract interface that can represent any number of fungible and non-fungible token types. Existing standards such as ERC-20 require deployment of separate contracts per token type. The ERC-721 standard's token ID is a single non-fungible index and the group of these non-fungibles is deployed as a single contract with settings for the entire collection. In contrast, the ERC-1155 Semi Fungible Token Standard allows for each token ID to represent a new configurable token type, which may have its own metadata, supply and other attributes.
 
 The `_id` argument contained in each function's argument set indicates a specific token or token type in a transaction.
 
@@ -38,7 +38,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 pragma solidity ^0.5.9;
 
 /**
-    @title ERC-1155 Multi Token Standard
+    @title ERC-1155 Semi Fungible Token Standard
     @dev See https://eips.ethereum.org/EIPS/eip-1155
     Note: The ERC-165 identifier for this interface is 0xd9b67a26.
  */


### PR DESCRIPTION
This is a change meant to reflect how ERC-1155 has been referred to over the years by projects and the community. The term Semi-Fungible Token (SFT) has been dominating the conversations and it would be appropriate for the title of this standard to reflect this.

Nothing in the implementation or specification is affected by this, only the title and a few references to the title.