### PR TITLE
Update EIP-3770: Status to Review

### DIFF
--- a/EIPS/eip-3770.md
+++ b/EIPS/eip-3770.md
@@ -4,7 +4,7 @@ title: Chain-specific addresses
 description: A standard for displaying CAIP-10 account identifiers in a human readable format
 author: Lukas Schor (@lukasschor), Richard Meissner (@rmeissner), Pedro Gomes (@pedrouid), ligi <ligi@ligi.de>
 discussions-to: https://ethereum-magicians.org/t/chain-specific-addresses/6449
-status: Final
+status: Review
 type: Standards Track
 category: ERC
 created: 2021-08-26

--- a/EIPS/eip-3770.md
+++ b/EIPS/eip-3770.md
@@ -4,7 +4,7 @@ title: Chain-specific addresses
 description: A standard for displaying CAIP-10 account identifiers in a human readable format
 author: Lukas Schor (@lukasschor), Richard Meissner (@rmeissner), Pedro Gomes (@pedrouid), ligi <ligi@ligi.de>
 discussions-to: https://ethereum-magicians.org/t/chain-specific-addresses/6449
-status: Draft
+status: Final
 type: Standards Track
 category: ERC
 created: 2021-08-26


### PR DESCRIPTION
Safe has been using this EIP to display chain-specific addresses in the web and mobile applications since about a year, and other projects such as Zodiac already adopted it. To start pushing for wider adoption, we should push this EIP to final.