### PR TITLE
CI: Re-enable CodeSpell

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,6 @@ jobs:
           ignore_words_file: config/.codespell-whitelist
           path: ${{ steps.changed-files.outputs.all_changed_files }}
           skip: .git,Gemfile.lock,**/*.png,**/*.gif,**/*.jpg,**/*.svg,.codespell-whitelist,vendor,_site,_config.yml,style.css
-          only_warn: 1
 
   eipw-validator:
     name: EIP Walidator


### PR DESCRIPTION
Now that the CodeSpell issue is fixed, we can now re-enable CI failures.