### PR TITLE
CI: Fix Markdown Linter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,10 +103,20 @@ jobs:
     steps:
       - name: Checkout EIP Repository
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
-
-      - name: Delete Unchanged Files
+        
+      - name: Get Changed Files
+        uses: tj-actions/changed-files@1d6e210c970d01a876fbc6155212d068e79ca584
         id: changed-files
-        uses: Pandapip1/delete-unchanged-files@0937c94da2e9f9f262bbf2035e75065a1fd04bcf
+        with:
+          separator: ","
+      
+      - name: Replace Commas with Newlines # Hack needed due to limitation of GitHub actions
+        run:
+          echo "CHANGED_FILES<<EOF" >> $GITHUB_ENV
+          echo "$RAW_CHANGED_FILES" | tr , "\n" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+        env: 
+          RAW_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
 
       - name: Lint
         uses: DavidAnson/markdownlint-cli2-action@16d9da45919c958a8d1ddccb4bd7028e8848e4f1
@@ -114,5 +124,4 @@ jobs:
           command: config
           globs: |
             config/.markdownlint.yaml
-            EIPS/*.md
-            *.md
+            ${{ env.CHANGED_FILES }}


### PR DESCRIPTION
Wierd things happen with output variables and multi-line strings. This fixes the Markdownlint check.