### PR TITLE
CI: Add concurrency

### DIFF
--- a/.github/workflows/auto-label-bot.yml
+++ b/.github/workflows/auto-label-bot.yml
@@ -1,6 +1,10 @@
 on:
   pull_request_target:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 name: Auto Label Bot
 jobs:
   jekyll-label-action:

--- a/.github/workflows/auto-review-bot.yml
+++ b/.github/workflows/auto-review-bot.yml
@@ -5,6 +5,10 @@ on:
     types:
       - completed
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 name: Auto Review Bot
 jobs:
   auto-review-bot:

--- a/.github/workflows/auto-review-trigger.yml
+++ b/.github/workflows/auto-review-trigger.yml
@@ -19,6 +19,10 @@ on:
     types:
       - created
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 name: Auto Review Bot Trigger
 jobs:
   trigger:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
       - ready_for_review
       - edited
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   save-pr:
     name: Save PR Number


### PR DESCRIPTION
Stops outdated CI runs from hogging the CI queue. Cancels the previous run on push.

Also provides protection against @eth-bot approving PRs that have been changed.