### PR TITLE
Update EIP-3525: verbiage improvements, typos

### DIFF
--- a/EIPS/eip-3525.md
+++ b/EIPS/eip-3525.md
@@ -536,25 +536,25 @@ The purpose of maintaining id-to-address transfer function is to maximize the co
 
 ### Design decision: Notification/acceptance mechanism instead of 'Safe Transfer'
 
-EIP-721 and some later token standards introduced 'Safe Transfer' model, for better control of the 'safety' when transferring tokens, this mechanism leaves the choice of different transfer mode (safe/unsafe) to the sender, and may cause some potential problem: 
+EIP-721 and some later token standards introduced 'Safe Transfer' model, for better control of the 'safety' when transferring tokens, this mechanism leaves the choice of different transfer modes (safe/unsafe) to the sender, and may cause some potential problems: 
 
-1. In most situation the sender don't know how to choose between two kinds of transfer methods (safe/unsafe);
-2. If the sender calls the `safeTransferFrom` method, the transfer may fail when the recipient contract didn't implements the callback function, even if that contract can receive and manipulate the token with no problem.
+1. In most situations the sender does not know how to choose between two kinds of transfer methods (safe/unsafe);
+2. If the sender calls the `safeTransferFrom` method, the transfer may fail if the recipient contract did not implement the callback function, even if that contract is capable of receiving and manipulating the token without issue.
 
 This EIP defines a simple 'Check, Notify and Response' model for better flexibility as well as simplicity:
 
 1. No extra `safeTransferFrom` methods are needed, all callers only need to call one kind of transfer;
-2. All EIP-3525 contracts need to MUST check for the existence of `onERC3525Received` on the recipient contract and call the function when it exists;
-3. Any smart contract can implement `onERC3525Received` function for purpose of being notified after receiving values, in this function it can return certain pre-defined value to accept the transfer, or any other value to reject.
+2. All EIP-3525 contracts MUST check for the existence of `onERC3525Received` on the recipient contract and call the function when it exists;
+3. Any smart contract can implement `onERC3525Received` function for the purpose of being notified after receiving values; this function MUST return 0x009ce20b (i.e. `bytes4(keccak256('onERC3525Received(address,uint256,uint256,uint256,bytes)'))`) if the transfer is accepted, or any other value if the transfer is rejected.
 
-There is a special case for this notification/acceptance mechanism, since EIP-3525 allow value transfer from an address to itself, so that when a smart contract which implements `onERC3525Received` transfers value to itself, this function will also be called. So that the contract is responsible to choose different rules of acceptance between self-value-transfer and receiving value from other addresses.
+There is a special case for this notification/acceptance mechanism: since EIP-3525 allows value transfer from an address to itself, when a smart contract which implements `onERC3525Received` transfers value to itself, `onERC3525Received` will also be called. This allows for the contract to implement different rules of acceptance between self-value-transfer and receiving value from other addresses.
 
 ### Design decision: Relationship between different approval models
 
 For semantic compatibility with EIP-721 as well as the flexibility of value manipulation of tokens, we decided to define the relationships between some of the levels of approval like that:
 
-1. Approval of an id will lead to the ability to partially transfer values from this id by the approved operator, this will simplify the value approval for an id. However, the approval of total values in a token should not lead to the ability to transfer the token entity by the approved operator.
-2. `setApprovalForAll` will lead to the ability to partially transfer values from any token, as well as the ability to approve partial transfer of values from any token to a third party, this will simplify the value transfer and approval of all tokens owned by an address.
+1. Approval of an id will lead to the ability to partially transfer values from this id by the approved operator; this will simplify the value approval for an id. However, the approval of total values in a token should not lead to the ability to transfer the token entity by the approved operator.
+2. `setApprovalForAll` will lead to the ability to partially transfer values from any token, as well as the ability to approve partial transfer of values from any token to a third party; this will simplify the value transfer and approval of all tokens owned by an address.
 
 ## Backwards Compatibility
 
@@ -566,9 +566,9 @@ As mentioned in the beginning, this EIP is backward compatible with EIP-721.
 
 ## Security Considerations
 
-The value level approval and slot level approval(optional) is isolated from EIP-721 approval models, so that approving value should not affect EIP-721 level approvals, implementations of this EIP must obey this principle.
+The value level approval and slot level approval (optional) is isolated from EIP-721 approval models, so that approving value should not affect EIP-721 level approvals. Implementations of this EIP must obey this principle.
 
-Since this EIP is EIP-721 compatible, any wallets and smart contracts that can hold and manipulate standard EIP-721 tokens will have no risks of asset loss for EIP-3525 tokens.
+Since this EIP is EIP-721 compatible, any wallets and smart contracts that can hold and manipulate standard EIP-721 tokens will have no risks of asset loss for EIP-3525 tokens due to incompatible standards implementations.
 
 ## Copyright
 


### PR DESCRIPTION
This PR fixes several typos and offers grammatical and verbiage improvements to help improve clarity.
