### PR TITLE
CI: Fix changed files detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Run CodeSpell
         uses: codespell-project/actions-codespell@2391250ab05295bddd51e36a8c6295edb6343b0e
-        if: steps.changed.outcome != 'success'
+        if: steps.changed.outcome == 'success'
         with:
           check_filenames: true
           ignore_words_file: config/.codespell-whitelist
@@ -124,7 +124,7 @@ jobs:
 
       - name: Lint
         uses: DavidAnson/markdownlint-cli2-action@16d9da45919c958a8d1ddccb4bd7028e8848e4f1
-        if: steps.changed.outcome != 'success'
+        if: steps.changed.outcome == 'success'
         with:
           command: config
           globs: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Get Changed Files
         run: |
           echo "CHANGED_FILES<<EOF" >> $GITHUB_ENV
-          gh pr diff --name-only | sed -e 's|$|,|' | xargs -i echo "{}" >> $GITHUB_ENV
+          gh pr diff ${{ github.event.number }} --name-only | sed -e 's|$|,|' | xargs -i echo "{}" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -112,7 +112,7 @@ jobs:
       - name: Get Changed Files
         run: |
           echo "CHANGED_FILES<<EOF" >> $GITHUB_ENV
-          gh pr diff --name-only | grep -E -x '.*\.md|EIPS/.*\.md' >> $GITHUB_ENV
+          gh pr diff ${{ github.event.number }} --name-only | grep -E -x '.*\.md|EIPS/.*\.md' >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,10 +73,12 @@ jobs:
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
 
       - name: Get Changed Files
-        uses: tj-actions/changed-files@1d6e210c970d01a876fbc6155212d068e79ca584
-        id: changed-files
-        with:
-          separator: ","
+        run: |
+          echo "CHANGED_FILES<<EOF" >> $GITHUB_ENV
+          gh pr diff --name-only | grep -E -x '.*\.md|EIPS/.*\.md' >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+        env: 
+          RAW_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
 
       - name: Run CodeSpell
         uses: codespell-project/actions-codespell@2391250ab05295bddd51e36a8c6295edb6343b0e
@@ -106,22 +108,11 @@ jobs:
     steps:
       - name: Checkout EIP Repository
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
-        with:
-          fetch-depth: 0
 
       - name: Get Changed Files
-        uses: tj-actions/changed-files@1d6e210c970d01a876fbc6155212d068e79ca584
-        id: changed-files
-        with:
-          separator: ","
-          files: |
-            EIPS/*.md
-            *.md
-
-      - name: Replace Commas with Newlines # Hack needed due to limitation of GitHub actions
         run: |
           echo "CHANGED_FILES<<EOF" >> $GITHUB_ENV
-          echo "$RAW_CHANGED_FILES" | tr , "\n" >> $GITHUB_ENV
+          gh pr diff --name-only | grep -E -x '.*\.md|EIPS/.*\.md' >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
         env: 
           RAW_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,8 @@ jobs:
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
 
       - name: Get Changed Files
+        id: changed
+        continue-on-error: true
         run: |
           echo "CHANGED_FILES<<EOF" >> $GITHUB_ENV
           gh pr diff ${{ github.event.number }} --name-only | sed -e 's|$|,|' | xargs -i echo "{}" >> $GITHUB_ENV
@@ -82,6 +84,7 @@ jobs:
 
       - name: Run CodeSpell
         uses: codespell-project/actions-codespell@2391250ab05295bddd51e36a8c6295edb6343b0e
+        if: steps.changed.outcome != 'success'
         with:
           check_filenames: true
           ignore_words_file: config/.codespell-whitelist
@@ -110,16 +113,18 @@ jobs:
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
 
       - name: Get Changed Files
+        id: changed
+        continue-on-error: true
         run: |
           echo "CHANGED_FILES<<EOF" >> $GITHUB_ENV
-          gh pr diff ${{ github.event.number }} --name-only | grep -E -x '.*\.md|EIPS/.*\.md' >> $GITHUB_ENV
+          gh pr diff ${{ github.event.number }} --name-only | grep -E -x '[^/]+\.md|EIPS/eip-[0-9]+\.md' >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Lint
         uses: DavidAnson/markdownlint-cli2-action@16d9da45919c958a8d1ddccb4bd7028e8848e4f1
-        if: steps.changed-files.outputs.any_changed == 'true'
+        if: steps.changed.outcome != 'success'
         with:
           command: config
           globs: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,8 @@ jobs:
           echo "CHANGED_FILES<<EOF" >> $GITHUB_ENV
           gh pr diff --name-only | sed -e 's|$|,|' | xargs -i echo "{}" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run CodeSpell
         uses: codespell-project/actions-codespell@2391250ab05295bddd51e36a8c6295edb6343b0e
@@ -112,6 +114,8 @@ jobs:
           echo "CHANGED_FILES<<EOF" >> $GITHUB_ENV
           gh pr diff --name-only | grep -E -x '.*\.md|EIPS/.*\.md' >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Lint
         uses: DavidAnson/markdownlint-cli2-action@16d9da45919c958a8d1ddccb4bd7028e8848e4f1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,17 +75,15 @@ jobs:
       - name: Get Changed Files
         run: |
           echo "CHANGED_FILES<<EOF" >> $GITHUB_ENV
-          gh pr diff --name-only | grep -E -x '.*\.md|EIPS/.*\.md' >> $GITHUB_ENV
+          gh pr diff --name-only | sed -e 's|$|,|' | xargs -i echo "{}" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
-        env: 
-          RAW_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
 
       - name: Run CodeSpell
         uses: codespell-project/actions-codespell@2391250ab05295bddd51e36a8c6295edb6343b0e
         with:
           check_filenames: true
           ignore_words_file: config/.codespell-whitelist
-          path: ${{ steps.changed-files.outputs.all_changed_files }}
+          path: ${{ env.CHANGED_FILES }}
           skip: .git,Gemfile.lock,**/*.png,**/*.gif,**/*.jpg,**/*.svg,.codespell-whitelist,vendor,_site,_config.yml,style.css
 
   eipw-validator:
@@ -114,8 +112,6 @@ jobs:
           echo "CHANGED_FILES<<EOF" >> $GITHUB_ENV
           gh pr diff --name-only | grep -E -x '.*\.md|EIPS/.*\.md' >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
-        env: 
-          RAW_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
 
       - name: Lint
         uses: DavidAnson/markdownlint-cli2-action@16d9da45919c958a8d1ddccb4bd7028e8848e4f1


### PR DESCRIPTION
Currently, the detection of the changed file detects out-of-date branches as changing files. This fixes it.