### PR TITLE
Update EIP-5791: Change payload to be type bytes

### DIFF
--- a/EIPS/eip-5791.md
+++ b/EIPS/eip-5791.md
@@ -65,7 +65,7 @@ interface IERC5791 {
     /// @param payload Arbitrary data that is signed by the chip to produce the signature param.
     /// @param signature Chip's signature of the passed-in payload.
     /// @return Whether the signature of the payload was signed by the chip linked to the token id.
-    function isChipSignatureForToken(uint256 tokenId, bytes32 payload, bytes calldata signature)
+    function isChipSignatureForToken(uint256 tokenId, bytes calldata payload, bytes calldata signature)
         external
         view
         returns (bool);
@@ -98,7 +98,7 @@ interface IERC5791 {
 
 ```
 
-To aid recognition that an [EIP-721](./eip-721.md) token implements physical binding via this EIP: upon calling [EIP-165](./eip-165.md)’s `function supportsInterface(bytes4 interfaceID) external view returns (bool)` with `interfaceID=0xa70d2657`, a contract implementing this EIP must return true.
+To aid recognition that an [EIP-721](./eip-721.md) token implements physical binding via this EIP: upon calling [EIP-165](./eip-165.md)’s `function supportsInterface(bytes4 interfaceID) external view returns (bool)` with `interfaceID=0x4901df9f`, a contract implementing this EIP must return true.
 
 The mint interface is up to the implementation. The minted NFT's owner should be the owner of the physical chip (this authentication could be implemented using the signature scheme defined for `transferTokenWithChip`).
 


### PR DESCRIPTION
The payload input argument should be of type `bytes calldata` because it doesn't make sense to limit the length of a payload that a chip can sign. This payload can be of arbitrary length.