### PR TITLE
[EIP-4844] Set A Minimum Data Gasprice

### DIFF
--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -47,7 +47,7 @@ Compared to full data sharding, this EIP has a reduced cap on the number of thes
 | `POINT_EVALUATION_PRECOMPILE_GAS` | `50000` |
 | `MAX_DATA_GAS_PER_BLOCK` | `2**21` |
 | `TARGET_DATA_GAS_PER_BLOCK` | `2**20` |
-| `MIN_DATA_GASPRICE` | `1` |
+| `MIN_DATA_GASPRICE` | `10**8` |
 | `DATA_GASPRICE_UPDATE_FRACTION` | `8902606` |
 | `MAX_VERSIONED_HASHES_LIST_SIZE` | `2**24` |
 | `MAX_CALLDATA_SIZE` | `2**24` |


### PR DESCRIPTION
The original fee market update PR https://github.com/ethereum/EIPs/pull/5707 initially included a `MIN_DATA_GASPRICE` of `10**8`. After some discussion (https://github.com/ethereum/pm/issues/647), it became clear that this is a contentious value. Thus, the fee market PR was merged with the smallest possible value of `1`.

This PR proposes to set `MIN_DATA_GASPRICE` back to `10**8`, which is merely meant as a starting point for discussion about this choice. The PR will stay in draft until agreement is reached.