### PR TITLE
EIP-3540: Clarify contract creation failure

### DIFF
--- a/EIPS/eip-3540.md
+++ b/EIPS/eip-3540.md
@@ -129,8 +129,12 @@ For clarity, the *container* refers to the complete account code, while *code* r
 
 For clarity, the *EOF prefix* together with a version number *n* is denoted as the *EOFn prefix*, e.g. *EOF1 prefix*.
 
-1. If *initcode's container* has EOF1 prefix it must be valid EOF1 code.
-2. If *code's container* has EOF1 prefix it must be valid EOF1 code.
+If any of the following conditions is not fulfilled the *contract creation* fails
+and all gas provided to the create instruction/transaction is consumed
+(behavior is similar to initcode execution failure).
+
+1. If *initcode's container* has EOF1 prefix it MUST be valid EOF1 code.
+2. If *code's container* has EOF1 prefix it MUST be valid EOF1 code.
 
 ## Rationale
 


### PR DESCRIPTION
Clarify that in case of any of the new contract creation failure conditions all gas provided to the create instruction/transaction is consumed.

Current implementations do not consume all gas for the first condition but do for the second so this is a functional change.