### PR TITLE
EIP-4844.md: Fixed punctuation inconsistency

### DIFF
--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -391,7 +391,7 @@ The work that is already done in this EIP includes:
 - _All_ of the execution / consensus cross-verification logic required for full sharding
 - Layer separation between `BeaconBlock` verification and data availability sampling blobs
 - Most of the `BeaconBlock` logic required for full sharding
-- A self-adjusting independent gasprice for blobs.
+- A self-adjusting independent gasprice for blobs
 
 The work that remains to be done to get to full sharding includes:
 
@@ -405,7 +405,7 @@ This EIP also sets the stage for longer-term protocol cleanups:
 - It adds an SSZ transaction type which is slightly gas-advantaged (1000 discount) to nudge people toward using it,
   and paves the precedent that all new transaction types should be SSZ
 - It defines `TransactionNetworkPayload` to separate network and block encodings of a transaction type
-- Its (cleaner) gas price update rule could be applied to the primary basefee.
+- Its (cleaner) gas price update rule could be applied to the primary basefee
 
 ### How rollups would function
 


### PR DESCRIPTION
Removed the dots behind two sentences because every other bullet point is punctuated this way, too.