### PR TITLE
Fix data-only contract example

### DIFF
--- a/EIPS/eip-3540.md
+++ b/EIPS/eip-3540.md
@@ -204,7 +204,7 @@ We have considered different questions for the sections:
 The EOF prevents deploying contracts with arbitrary bytes (data-only contracts: their purpose is to store data not execution). **EOF1 requires** presence of a **code section** therefore the minimal overhead EOF data contract consist of a data section and one code section with single instruction. We recommend to use `INVALID` instruction in this case. In total there are 11 additional bytes required.
 
 ```
-EF0001 000001 01<data-size> 00 FE <data>
+EF0001 010001 02<data-size> 00 FE <data>
 ```
 
 ### PC starts with 0 at the code section


### PR DESCRIPTION
Fix data-only contract example, currently it has the terminator byte (00) instead of code_section byte (01), and code_section byte instead of data_section byte (02).