### PR TITLE
Update EIP-721: delete broken openzeppelin links

### DIFF
--- a/EIPS/eip-721.md
+++ b/EIPS/eip-721.md
@@ -440,7 +440,6 @@ XXXXERC721, by William Entriken -- a scalable example implementation
 1. Curio Cards. https://mycuriocards.com
 1. Rare Pepe. https://rarepepewallet.com
 1. Auctionhouse Asset Interface. https://github.com/dob/auctionhouse/blob/master/contracts/Asset.sol
-1. OpenZeppelin ERC721.sol Implementation. https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC721/ERC721.sol
 
 ## Copyright
 

--- a/EIPS/eip-721.md
+++ b/EIPS/eip-721.md
@@ -440,7 +440,7 @@ XXXXERC721, by William Entriken -- a scalable example implementation
 1. Curio Cards. https://mycuriocards.com
 1. Rare Pepe. https://rarepepewallet.com
 1. Auctionhouse Asset Interface. https://github.com/dob/auctionhouse/blob/master/contracts/Asset.sol
-1. OpenZeppelin SafeERC20.sol Implementation. https://github.com/OpenZeppelin/zeppelin-solidity/blob/master/contracts/token/ERC20/SafeERC20.sol
+1. OpenZeppelin ERC721.sol Implementation. https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/token/ERC721/ERC721.sol
 
 ## Copyright
 


### PR DESCRIPTION
In the NFT Implementation and Other Projects column, the 17th link is to openzeppelin, which is already an invalid link and also a link to SafeERC20. openzeppelin has an ERC721 implementation.
The link should be to ERC721.sol

ref: https://eips.ethereum.org/EIPS/eip-721#references