### PR TITLE
EIP-4844: declare withdrawals in 4895 as a dependency

### DIFF
--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2022-02-25
-requires: 1559, 2718, 2930
+requires: 1559, 2718, 2930, 4895
 ---
 
 ## Abstract
@@ -193,21 +193,22 @@ The resulting RLP encoding of the header is therefore:
 ```
 rlp([
     parent_hash,
-    ommers_hash,
+    0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347, # ommers hash
     coinbase,
     state_root,
-    tx_root,
-    receipt_root,
-    bloom,
-    difficulty,
+    txs_root,
+    receipts_root,
+    logs_bloom,
+    0, # difficulty
     number,
     gas_limit,
     gas_used,
-    time,
-    extra,
-    mix_digest,
-    nonce,
-    base_fee,
+    timestamp,
+    extradata,
+    prev_randao,
+    0x0000000000000000, # nonce
+    base_fee_per_gas,
+    withdrawals_root,
     excess_data_gas
 ])
 ```


### PR DESCRIPTION
Revise 4844 to include 4895 as a dependency; including reflecting that EIP's effects on the header format