### PR TITLE
EIP-3540: Clarify contract creation rules

### DIFF
--- a/EIPS/eip-3540.md
+++ b/EIPS/eip-3540.md
@@ -62,6 +62,12 @@ At `block.number == HF_BLOCK` new contract creation is modified:
 - else if *code* starts with `0xEF`, creation continues to result in an exceptional abort (the rule introduced in EIP-3541),
 - otherwise code is considered *legacy code* and the following rules do not apply to it.
 
+For a create transaction, if *initcode* or *code* is invalid, the contract creation results in an exceptional abort. Such a transaction is valid and may be included in a block.
+
+For the `CREATE` and `CREATE2` instructions, if *initcode* or *code* is invalid, instructions' execution ends with the result `0` pushed on stack.
+
+In case *initcode* is invalid, gas for its execution is not deducted. In case *code* is invalid, all creation gas is deducted, similar to exceptional abort during *initcode* execution.
+
 ### Container specification
 
 EOF container is a binary format with the capability of providing the EOF version number and a list of EOF sections.
@@ -369,7 +375,7 @@ def validate_eof(code: bytes):
 
 Proposed validation rules can be checked at constant time, therefore it should not be easily attackable. This is subject to change with future extensions.
 
-Currently, *initcode* validation has no extra cost and the currently charged creation costs should be sufficient, however we consider adding a gas cost for contract creation.
+The validation of *initcode* adds additional overhead. We think that the charge introduced by [EIP-3860](./eip-3860.md) is sufficient to account for the overhead introduced in this EIP.
 
 ## Copyright
 

--- a/EIPS/eip-3540.md
+++ b/EIPS/eip-3540.md
@@ -8,7 +8,7 @@ status: Review
 type: Standards Track
 category: Core
 created: 2021-03-16
-requires: 3541
+requires: 3541, 3860
 ---
 
 ## Abstract
@@ -373,9 +373,11 @@ def validate_eof(code: bytes):
 
 ## Security Considerations
 
-Proposed validation rules can be checked at constant time, therefore it should not be easily attackable. This is subject to change with future extensions.
+With the anticipated EOF extensions, the validation is expected to have linear computational and space complexity.
+We think that the validation cost is sufficiently covered by:
 
-The validation of *initcode* adds additional overhead. We think that the charge introduced by [EIP-3860](./eip-3860.md) is sufficient to account for the overhead introduced in this EIP.
+- [EIP-3860](./eip-3860.md) for *initcode*,
+- high per-byte cost of deploying *code*.
 
 ## Copyright
 

--- a/EIPS/eip-3670.md
+++ b/EIPS/eip-3670.md
@@ -8,7 +8,7 @@ status: Review
 type: Standards Track
 category: Core
 created: 2021-06-23
-requires: 3540, 3860
+requires: 3540
 ---
 
 ## Abstract

--- a/EIPS/eip-3670.md
+++ b/EIPS/eip-3670.md
@@ -52,12 +52,6 @@ Bytecode is deemed invalid if any of these conditions is true:
 
 *Notice that due to the requirement of the terminating instruction, it is implicitly stated that truncated instructions (e.g. data portion of a `PUSHn`) are disallowed.*
 
-For a create transaction, if *initcode* or *code* is invalid, the contract creation results in an exceptional abort. Such a transaction is valid and may be included in a block.
-
-For the `CREATE` and `CREATE2` instructions, if *initcode* or *code* is invalid, instructions' execution ends with the result `0` pushed on stack.
-
-In case *initcode* is invalid, gas for its execution is not deducted. In case *code* is invalid, all creation gas is deducted, similar to exceptional abort during initcode execution.
-
 *Notice that since EOF1 disallows 0-length code section, a valid contract must contain at least a single byte, which must be a terminating instruction.*
 
 ## Rationale
@@ -158,7 +152,7 @@ def validate_code(code: bytes):
 
 ## Security Considerations
 
-The validation of *initcode* adds additional overhead.  We think that the charge introduced by [EIP-3860](./eip-3860.md) is sufficient to account for the overhead introduced in this EIP.
+See [Security Considerations of EIP-3540](./eip-3540.md#security-considerations).
 
 ## Copyright
 


### PR DESCRIPTION
Move detailed rules from EIP-3670 to clarify contract behavior in context of EOF validation.