### PR TITLE
Update EIP-5216 with address zero control in _approve function like EIP-20 

### DIFF
--- a/assets/eip-5216/ERC1155ApprovalByAmount.sol
+++ b/assets/eip-5216/ERC1155ApprovalByAmount.sol
@@ -68,8 +68,10 @@ abstract contract ERC1155ApprovalByAmount is ERC1155, IERC1155ApprovalByAmount {
             from == msg.sender || isApprovedForAll(from, msg.sender) || allowance(from, msg.sender, id) >= amount,
             "ERC1155: caller is not owner nor approved nor approved for amount"
         );
-        unchecked {
-            _allowances[from][msg.sender][id] -= amount;
+        if(from != msg.sender && !isApprovedForAll(from, msg.sender)) {
+            unchecked {
+                _allowances[from][msg.sender][id] -= amount;
+            }
         }
         _safeTransferFrom(from, to, id, amount, data);
     }
@@ -108,7 +110,9 @@ abstract contract ERC1155ApprovalByAmount is ERC1155, IERC1155ApprovalByAmount {
 
         require(idsLength == amountsLength, "ERC1155ApprovalByAmount: ids and amounts length mismatch");
         for (uint256 i = 0; i < idsLength;) {
-            require(allowance(from, to, ids[i]) >= amounts[i], "ERC1155ApprovalByAmount: operator is not approved for that id or amount");
+            if(allowance(from, to, ids[i] < amounts[i])) {
+                return false;
+            }
             unchecked { 
                 _allowances[from][to][ids[i]] -= amounts[i];
                 ++i; 

--- a/assets/eip-5216/ERC1155ApprovalByAmount.sol
+++ b/assets/eip-5216/ERC1155ApprovalByAmount.sol
@@ -127,7 +127,8 @@ abstract contract ERC1155ApprovalByAmount is ERC1155, IERC1155ApprovalByAmount {
         uint256 id,
         uint256 amount
     ) internal virtual {
-        require(owner != operator, "ERC1155ApprovalByAmount: setting approval status for self");
+        require(owner != address(0), "ERC1155ApprovalByAmount: approve from the zero address");
+        require(operator != address(0), "ERC1155ApprovalByAmount: approve to the zero address");
         _allowances[owner][operator][id] = amount;
         emit ApprovalByAmount(owner, operator, id, amount);
     }

--- a/assets/eip-5216/ERC1155ApprovalByAmount.sol
+++ b/assets/eip-5216/ERC1155ApprovalByAmount.sol
@@ -110,7 +110,7 @@ abstract contract ERC1155ApprovalByAmount is ERC1155, IERC1155ApprovalByAmount {
 
         require(idsLength == amountsLength, "ERC1155ApprovalByAmount: ids and amounts length mismatch");
         for (uint256 i = 0; i < idsLength;) {
-            if(allowance(from, to, ids[i] < amounts[i])) {
+            if(_allowances[from][to][ids[i]] < amounts[i]) {
                 return false;
             }
             unchecked { 


### PR DESCRIPTION
After discussing _approve function requires here : https://ethereum-magicians.org/t/last-call-eip-5216-erc1155-approval-by-amount/9898/3 , I'm just updating it