### PR TITLE
Add EIP-5920: PAY opcode

### DIFF
--- a/EIPS/eip-5920.md
+++ b/EIPS/eip-5920.md
@@ -24,20 +24,26 @@ Currently, to send ether to an address requires you to call a function of that a
 | ------------------- | ------- |
 | `FORK_BLKNUM`       | TBD     |
 | `PAY_OPCODE`        | TBD     |
-| `BASE_GAS_COST`     | `9000`  |
-| `COLD_GAS_COST`     | `2600`  |
-| `CREATION_GAS_COST` | `25000` |
+| `BASE_GAS_COST`     | `8600`  |
+| `COLD_GAS_COST`     | `11100`  |
+| `CREATION_GAS_COST` | `32600` |
 
 A new opcode is introduced: `PAY` (`PAY_OPCODE`), which:
 
 - Pops two values from the stack: `addr` then `val`.
 - Transfers `val` wei to the address `addr`.
 
-The cost of this opcode is `BASE_GAS_COST` if `addr` is a warm account, `BASE_GAS_COST+COLD_GAS_COST` if `addr` is a cold account that is already in the state trie, or `BASE_GAS_COST+CREATION_GAS_COST` if `addr` has not yet been added to the state trie.
+The cost of this opcode is `BASE_GAS_COST` if `addr` is a warm account, `COLD_GAS_COST` if `addr` is a cold account that is already in the state trie, or `BASE_GAS_COST+CREATION_GAS_COST` if `addr` has not yet been added to the state trie.
 
 ## Rationale
 
-The order of arguments is similar to that of the `CALL` family, which have `addr` before `val`. Beyond consistency, though, this ordering aid validators in pattern-matching MEV opportunities, so that the `PAY` always appears immediately after `COINBASE` in the order of execution.
+## Gas pricing
+
+The gas pricing is that of a `CALL` with a positive `msg.value`, but without any memory expansion costs or "gas sent with call" costs, with a gas reduction of `500` to compensate for the reduced amount of computation.
+
+## Argument order
+
+The order of arguments mimicks that of `CALL`, which pops `addr` before `val`. Beyond consistency, though, this ordering aids validators pattern-matching MEV opportunities, so `PAY` always appears immediately after `COINBASE`.
 
 ## Backwards Compatibility
 

--- a/EIPS/eip-5920.md
+++ b/EIPS/eip-5920.md
@@ -2,7 +2,7 @@
 eip: 5920
 title: PAY opcode
 description: Introduces a new opcode, PAY, to send ether to an address without calling any of its functions
-author: Pandapip1 (@Pandapip1)
+author: Pandapip1 (@Pandapip1), Zainan Victor Zhou (@xinbenlv)
 discussions-to: https://ethereum-magicians.org/t/eip-5920-pay-opcode/11717
 status: Draft
 type: Standards Track

--- a/EIPS/eip-5920.md
+++ b/EIPS/eip-5920.md
@@ -1,4 +1,5 @@
 ---
+eip: 5920
 title: PAY opcode
 description: Introduces a new opcode, PAY, to send ether to an address without calling it
 author: Pandapip1 (@Pandapip1)

--- a/EIPS/eip-5920.md
+++ b/EIPS/eip-5920.md
@@ -1,7 +1,7 @@
 ---
 eip: 5920
 title: PAY opcode
-description: Introduces a new opcode, PAY, to send ether to an address without calling it
+description: Introduces a new opcode, PAY, to send ether to an address without calling a function
 author: Pandapip1 (@Pandapip1)
 discussions-to: https://ethereum-magicians.org/t/eip-5920-pay-opcode/11717
 status: Draft

--- a/EIPS/eip-5920.md
+++ b/EIPS/eip-5920.md
@@ -20,12 +20,12 @@ Currently, to send ether to an address requires you to call a function of that a
 
 ## Specification
 
-| Parameter | Value |
-| - | - |
-| `FORK_BLKNUM` | TBD |
-| `PAY_OPCODE` | TBD |
-| `BASE_GAS_COST` | `9000` |
-| `COLD_GAS_COST` | `2600` |
+| Parameter           | Value   |
+| ------------------- | ------- |
+| `FORK_BLKNUM`       | TBD     |
+| `PAY_OPCODE`        | TBD     |
+| `BASE_GAS_COST`     | `9000`  |
+| `COLD_GAS_COST`     | `2600`  |
 | `CREATION_GAS_COST` | `25000` |
 
 A new opcode is introduced: `PAY` (`PAY_OPCODE`), which:

--- a/EIPS/eip-5920.md
+++ b/EIPS/eip-5920.md
@@ -1,7 +1,7 @@
 ---
 eip: 5920
 title: PAY opcode
-description: Introduces a new opcode, PAY, to send ether to an address without calling a function
+description: Introduces a new opcode, PAY, to send ether to an address without calling any of its functions
 author: Pandapip1 (@Pandapip1)
 discussions-to: https://ethereum-magicians.org/t/eip-5920-pay-opcode/11717
 status: Draft

--- a/EIPS/eip-5920.md
+++ b/EIPS/eip-5920.md
@@ -24,15 +24,16 @@ Currently, to send ether to an address requires you to call a function of that a
 | - | - |
 | `FORK_BLKNUM` | TBD |
 | `PAY_OPCODE` | TBD |
-| `HOT_GAS_COST` | `500` |
-| `COLD_GAS_COST` | `3000` |
+| `BASE_GAS_COST` | `9000` |
+| `COLD_GAS_COST` | `2600` |
+| `CREATION_GAS_COST` | `25000` |
 
 A new opcode is introduced: `PAY` (`PAY_OPCODE`), which:
 
 - Pops two values from the stack: `addr` then `val`.
 - Transfers `val` wei to the address `addr`.
 
-The cost of this opcode is `HOT_GAS_COST` if `addr` is a warm account, and `COLD_GAS_COST` if it is a cold account.
+The cost of this opcode is `BASE_GAS_COST` if `addr` is a warm account, `BASE_GAS_COST+COLD_GAS_COST` if `addr` is a cold account that is already in the state trie, or `BASE_GAS_COST+CREATION_GAS_COST` if `addr` has not yet been added to the state trie.
 
 ## Rationale
 

--- a/EIPS/eip-5920.md
+++ b/EIPS/eip-5920.md
@@ -37,11 +37,11 @@ The cost of this opcode is `BASE_GAS_COST` if `addr` is a warm account, `COLD_GA
 
 ## Rationale
 
-## Gas pricing
+### Gas pricing
 
 The gas pricing is that of a `CALL` with a positive `msg.value`, but without any memory expansion costs or "gas sent with call" costs, with a gas reduction of `500` to compensate for the reduced amount of computation.
 
-## Argument order
+### Argument order
 
 The order of arguments mimicks that of `CALL`, which pops `addr` before `val`. Beyond consistency, though, this ordering aids validators pattern-matching MEV opportunities, so `PAY` always appears immediately after `COINBASE`.
 

--- a/EIPS/eip-5920.md
+++ b/EIPS/eip-5920.md
@@ -12,7 +12,7 @@ created: 2022-03-14
 
 ## Abstract
 
-This EIP adds a new opcode, `PAY(addr, val)`, that transfers `val` wei to the address `addr` without calling it.
+This EIP introduces a new opcode, `PAY(addr, val)`, that transfers `val` wei to the address `addr` without calling it. After `FORK_BLKNUM`, this opcode is added to the EVM.
 
 ## Motivation
 

--- a/EIPS/eip-5920.md
+++ b/EIPS/eip-5920.md
@@ -3,6 +3,7 @@ eip: 5920
 title: PAY opcode
 description: Introduces a new opcode, PAY, to send ether to an address without calling it
 author: Pandapip1 (@Pandapip1)
+discussions-to: https://ethereum-magicians.org/t/eip-5920-pay-opcode/11717
 status: Draft
 type: Standards Track
 category: Core


### PR DESCRIPTION
Adds a new opcode to do simple ether transfers.


discussions-to: https://ethereum-magicians.org/t/eip-5920-pay-opcode/11717