### PR TITLE
Update EIP-4750: redefine code section header to be array of code section sizes

### DIFF
--- a/EIPS/eip-4750.md
+++ b/EIPS/eip-4750.md
@@ -30,7 +30,7 @@ Furthermore it aims to improve analysis opportunities by encoding the number of 
 ### EOF container changes
 
 1. The [EIP-3540](./eip-3540.md) code section header is redefined to be an array of code section sizes terminated with a `0x00` byte. E.g. `code_section_header := 1, (code_section_size)+, 0`.
-2. Total number of code sections MUST NOT exceed 1024 and they must all be contiguous.
+2. Total number of code sections MUST NOT exceed 1024 and they MUST all be contiguous.
 3. All code sections MUST precede a data section, if data section is present.
 4. New section with `kind = 3` is introduced called the *type section*.
 5. Exactly one type section MAY be present.

--- a/EIPS/eip-4750.md
+++ b/EIPS/eip-4750.md
@@ -29,12 +29,12 @@ Furthermore it aims to improve analysis opportunities by encoding the number of 
 
 ### EOF container changes
 
-1. The requirement of [EIP-3540](./eip-3540.md) "Exactly one code section MUST be present." is relaxed to "At least one code section MUST be present.", i.e. multiple code sections (`kind = 1`) are allowed.
-2. Total number of code sections MUST NOT exceed 1024.
+1. The [EIP-3540](./eip-3540.md) code section header is redefined to be an array of code section sizes terminated with a `0x00` byte. E.g. `code_section_header := 1, (code_section_size)+, 0`.
+2. Total number of code sections MUST NOT exceed 1024 and they must all be contiguous.
 3. All code sections MUST precede a data section, if data section is present.
 4. New section with `kind = 3` is introduced called the *type section*.
 5. Exactly one type section MAY be present.
-6. The type section, if present, MUST directly precede all code sections.
+6. The type section, if present, MUST directly precede the code sections.
 7. The type section, if present, contains a sequence of pairs of bytes: first byte in a pair encodes number of inputs, and second byte encodes number of outputs of the code section with the same index. *Note:* This implies that there is a limit of 256 stack for the input and in the output.
 8. Therefore type section size MUST be `n * 2` bytes, where `n` is the number of code sections.
 9. First code section MUST have 0 inputs and 0 outputs. 
@@ -43,7 +43,7 @@ section is present. In that case it implicitly defines 0 inputs and 0 outputs fo
 
 To summarize, a well-formed EOF bytecode will have the following format:
 ```
-bytecode := magic, version, [type_section_header], (code_section_header)+, [data_section_header], 0, [type_section_contents], (code_section_contents)+, [data_section_contents]
+bytecode := magic, version, [type_section_header], code_section_header, [data_section_header], 0, [type_section_contents], (code_section_contents)+, [data_section_contents]
 
 type_section_header := 3, number_of_code_sections * 2 # section kind and size
 type_section_contents := 0, 0, code_section_1_inputs, code_section_1_outputs, code_section_2_inputs, code_section_2_outputs, ..., code_section_n_inputs, code_section_n_outputs

--- a/EIPS/eip-4750.md
+++ b/EIPS/eip-4750.md
@@ -34,8 +34,8 @@ Furthermore it aims to improve analysis opportunities by encoding the number of 
 3. All code sections MUST precede a data section, if data section is present.
 4. New section with `kind = 3` is introduced called the *type section*.
 5. Exactly one type section MAY be present.
-6. The type section, if present, MUST directly precede the code sections.
-7. The type section, if present, contains a sequence of pairs of bytes: first byte in a pair encodes number of inputs, and second byte encodes number of outputs of the code section with the same index. *Note:* This implies that there is a limit of 256 stack for the input and in the output.
+6. The type section MUST directly precede the code sections.
+7. The type section contains a sequence of pairs of bytes: first byte in a pair encodes number of inputs, and second byte encodes number of outputs of the code section with the same index. *Note:* This implies that there is a limit of 256 stack for the input and in the output.
 8. Therefore type section size MUST be `n * 2` bytes, where `n` is the number of code sections.
 9. First code section MUST have 0 inputs and 0 outputs. 
 10. Type section MAY be omitted if only a single code 
@@ -43,7 +43,7 @@ section is present. In that case it implicitly defines 0 inputs and 0 outputs fo
 
 To summarize, a well-formed EOF bytecode will have the following format:
 ```
-bytecode := magic, version, [type_section_header], code_section_header, [data_section_header], 0, [type_section_contents], (code_section_contents)+, [data_section_contents]
+bytecode := magic, version, type_section_header, code_section_header, [data_section_header], 0, type_section_contents, (code_section_contents)+, [data_section_contents]
 
 type_section_header := 3, number_of_code_sections * 2 # section kind and size
 type_section_contents := 0, 0, code_section_1_inputs, code_section_1_outputs, code_section_2_inputs, code_section_2_outputs, ..., code_section_n_inputs, code_section_n_outputs


### PR DESCRIPTION
I like the idea from discord user `aymen` and @chfast about defining the code section header as an array of code section sizes. Since we're anticipating EIP-4750 to move forward together with EIP-3540, I think it makes sense to do this as it is not necessary to retain a semblance of backwards compatibility.

The new `code_section_header` would look something like this:

```
code_section_header = 1 || (code_section_size)+ || 0
```

Where `||` is a concatenation operator.