### PR TITLE
Update EIP-4844: Disable Blob Transaction Broadcast

### DIFF
--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2022-02-25
-requires: 1559, 2718, 2930, 4895, 5793
+requires: 1559, 2718, 2930, 4895
 ---
 
 ## Abstract
@@ -322,6 +322,8 @@ The actual `data_fee` as calculated via `calc_data_fee` is deducted from the sen
 
 ### Networking
 
+Blob transactions are not automatically broadcast to peers. Instead, they are only announced using `NewPooledTransactionHashes` messages, and can then be manually requested via `GetPooledTransactions`.
+
 Transactions are presented as `TransactionType || TransactionNetworkPayload` on the execution layer network,
 the payload is a SSZ encoded container:
 
@@ -468,7 +470,9 @@ instead, they go into the `BeaconBlockBody`. This means that there is now a part
 Blob transactions have a large data size at the mempool layer, which poses a mempool DoS risk,
 though not an unprecedented one as this also applies to transactions with large amounts of calldata.
 
-[EIP-5793](./eip-5793.md) addresses this by adding the transaction type and size to eth/68 announcement messages. Nodes are thus expected to no longer broadcast large transactions - including blob transactions - by default. This allows nodes to load balance or throttle peers based on past behavior.
+By only broadcasting announcements for blob transactions, nodes have control over which and how many transactions to receive,
+allowing them to throttle throughput to an acceptable level.
+[EIP-5793](./eip-5793.md) will give further fine-grained control to nodes by extending the `NewPooledTransactionHashes` announcement messages to include the transaction type and size.
 
 In addition, we recommend including a 1.1x data gasprice bump requirement to the mempool transaction replacement rules.
 

--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -322,7 +322,8 @@ The actual `data_fee` as calculated via `calc_data_fee` is deducted from the sen
 
 ### Networking
 
-Blob transactions are not automatically broadcast to peers. Instead, they are only announced using `NewPooledTransactionHashes` messages, and can then be manually requested via `GetPooledTransactions`.
+Nodes must not automatically broadcast blob transactions to their peers.
+Instead, those transactions are only announced using `NewPooledTransactionHashes` messages, and can then be manually requested via `GetPooledTransactions`.
 
 Transactions are presented as `TransactionType || TransactionNetworkPayload` on the execution layer network,
 the payload is a SSZ encoded container:

--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2022-02-25
-requires: 1559, 2718, 2930, 4895
+requires: 1559, 2718, 2930, 4895, 5793
 ---
 
 ## Abstract
@@ -468,10 +468,9 @@ instead, they go into the `BeaconBlockBody`. This means that there is now a part
 Blob transactions have a large data size at the mempool layer, which poses a mempool DoS risk,
 though not an unprecedented one as this also applies to transactions with large amounts of calldata.
 
-We recommend two solutions:
+[EIP-5793](./eip-5793.md) addresses this by adding the transaction type and size to eth/68 announcement messages. Nodes are thus expected to no longer broadcast large transactions - including blob transactions - by default. This allows nodes to load balance or throttle peers based on past behavior.
 
-- include a 1.1x (or potentially higher) data gasprice bump requirement to the mempool replacement rules
-- modify the Ethereum Wire Protocol to stop automatically broadcasting large transactions
+In addition, we recommend including a 1.1x data gasprice bump requirement to the mempool transaction replacement rules.
 
 ## Test Cases
 

--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -470,7 +470,7 @@ instead, they go into the `BeaconBlockBody`. This means that there is now a part
 Blob transactions have a large data size at the mempool layer, which poses a mempool DoS risk,
 though not an unprecedented one as this also applies to transactions with large amounts of calldata.
 
-By only broadcasting announcements for blob transactions, nodes have control over which and how many transactions to receive,
+By only broadcasting announcements for blob transactions, receiving nodes will have control over which and how many transactions to receive,
 allowing them to throttle throughput to an acceptable level.
 [EIP-5793](./eip-5793.md) will give further fine-grained control to nodes by extending the `NewPooledTransactionHashes` announcement messages to include the transaction type and size.
 


### PR DESCRIPTION
Specifies that blob transactions should not be broadcast to peers, but only announced (so that they can then be manually retrieved).

Adds a reference to https://github.com/ethereum/EIPs/pull/5793 which will give peers more fine-grained control by making it possible to identify blob transactions (and their size) from announcement messages.