### PR TITLE
Update EIP-2535: fix typos (unnecessary/incorrect words)

### DIFF
--- a/EIPS/eip-2535.md
+++ b/EIPS/eip-2535.md
@@ -252,7 +252,7 @@ If the `_init` value is `address(0)` then `_calldata` execution is skipped. In t
 
 > A loupe is a small magnifying glass used to look at diamonds.
 
-Diamonds must support inspecting the facets and functions currently enabled by implementing the `IDiamondLoupe` interface.
+Diamonds must support inspecting facets and functions by implementing the `IDiamondLoupe` interface.
 
 #### `IDiamondLoupe` Interface
 


### PR DESCRIPTION
Removed incorrect words that describe Loupe functions.