### PR TITLE
Remove redundant ValidationException definition from EOF EIPs

### DIFF
--- a/EIPS/eip-3670.md
+++ b/EIPS/eip-3670.md
@@ -130,9 +130,6 @@ immediate_sizes = 256 * [0]
 for opcode in range(0x60, 0x7f + 1):  # PUSH1..PUSH32
     immediate_sizes[opcode] = opcode - 0x60 + 1
 
-class ValidationException(Exception):
-    pass
-
 # Raises ValidationException on invalid code
 def validate_code(code: bytes):
     # Note that EOF1 already asserts this with the code section requirements

--- a/EIPS/eip-4200.md
+++ b/EIPS/eip-4200.md
@@ -163,9 +163,6 @@ immediate_sizes[0x5d] = 2  # RJUMPI
 for opcode in range(0x60, 0x7f + 1):  # PUSH1..PUSH32
     immediate_sizes[opcode] = opcode - 0x60 + 1
 
-class ValidationException(Exception):
-    pass
-
 # Raises ValidationException on invalid code
 def validate_code(code: bytes):
     # Note that EOF1 already asserts this with the code section requirements

--- a/EIPS/eip-4750.md
+++ b/EIPS/eip-4750.md
@@ -177,9 +177,6 @@ immediate_sizes[0xfb] = 2  # CALLF
 for opcode in range(0x60, 0x7f + 1):  # PUSH1..PUSH32
     immediate_sizes[opcode] = opcode - 0x60 + 1
 
-class ValidationException(Exception):
-    pass
-
 # Validate EOF code.
 # Raises ValidationException on invalid code
 def validate_eof(code: bytes):


### PR DESCRIPTION
We assume one definition in EIP-3540 code is enough and other EIPs' codes reuse it.
