### PR TITLE
CI: Grab latest `eipw`, which won't block stagnant bot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Checkout EIP Repository
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
 
-      - uses: ethereum/eipw-action@bbf342b62cb8046439c3508f1e98e23a4a9cd27a
+      - uses: ethereum/eipw-action@d57d2afb71253fc7447d8a7a28d60f9dead2290b
         id: eipw
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The latest version of `eipw` will report warnings instead of errors for EIPs with a Stagnant status. This should let the stagnant bot work properly.