### PR TITLE
EIP4844: Update crypto API (simplify precompile / sync with consensus-specs)

### DIFF
--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -257,22 +257,23 @@ The precompile costs `POINT_EVALUATION_PRECOMPILE_GAS` and executes the followin
 
 ```python
 def point_evaluation_precompile(input: Bytes) -> Bytes:
-    # Verify P(z) = a
-    # versioned hash: first 32 bytes
+    """
+    Verify p(z) = y given commitment that corresponds to the polynomial p(x) and a KZG proof.
+    Also verify that the provided commitment matches the provided versioned_hash.
+    """
+    # The data is encoded as follows: versioned_hash | z | y | commitment | proof |
     versioned_hash = input[:32]
-    # Evaluation point: next 32 bytes
-    x = int.from_bytes(input[32:64], 'little')
-    assert x < BLS_MODULUS
-    # Expected output: next 32 bytes
-    y = int.from_bytes(input[64:96], 'little')
-    assert y < BLS_MODULUS
-    # The remaining data will always be the proof, including in future versions
-    # input kzg point: next 48 bytes
-    data_kzg = input[96:144]
-    assert kzg_to_versioned_hash(data_kzg) == versioned_hash
-    # Quotient kzg: next 48 bytes
-    quotient_kzg = input[144:192]
-    assert verify_kzg_proof(data_kzg, x, y, quotient_kzg)
+    z = input[32:64]
+    y = input[64:96]
+    commitment = input[96:144]
+    kzg_proof = input[144:192]
+
+    # Verify commitment matches versioned_hash
+    assert kzg_to_versioned_hash(commitment) == versioned_hash
+
+    # Verify KZG proof
+    assert verify_kzg_proof(commitment, z, y, kzg_proof)
+
     return Bytes(U256(FIELD_ELEMENTS_PER_BLOB).to_bytes32() + U256(BLS_MODULUS).to_bytes32())
 ```
 

--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -72,19 +72,12 @@ Compared to full data sharding, this EIP has a reduced cap on the number of thes
 
 ### Cryptographic Helpers
 
-Throughout this proposal we use cryptographic methods and classes defined in the corresponding [consensus 4844 specs](https://github.com/ethereum/consensus-specs/blob/6c2b46ae3248760e0f6e52d61077d8b31e43ad1d/specs/eip4844).
+Throughout this proposal we use cryptographic methods and classes defined in the corresponding [consensus 4844 specs](https://github.com/ethereum/consensus-specs/blob/a45627164d34ddb60acca385e2324835fc14ca5c/specs/eip4844).
 
-Specifically, we use the following methods from [`polynomial-commitments.md`](https://github.com/ethereum/consensus-specs/blob/6c2b46ae3248760e0f6e52d61077d8b31e43ad1d/specs/eip4844/polynomial-commitments.md):
+Specifically, we use the following methods from [`polynomial-commitments.md`](https://github.com/ethereum/consensus-specs/blob/a45627164d34ddb60acca385e2324835fc14ca5c/specs/eip4844/polynomial-commitments.md):
 
-- [`verify_kzg_proof()`](https://github.com/ethereum/consensus-specs/blob/6c2b46ae3248760e0f6e52d61077d8b31e43ad1d/specs/eip4844/polynomial-commitments.md#verify_kzg_proof)
-- [`evaluate_polynomial_in_evaluation_form()`](https://github.com/ethereum/consensus-specs/blob/6c2b46ae3248760e0f6e52d61077d8b31e43ad1d/specs/eip4844/polynomial-commitments.md#evaluate_polynomial_in_evaluation_form)
-
-We also use the following methods and classes from [`validator.md`](https://github.com/ethereum/consensus-specs/blob/6c2b46ae3248760e0f6e52d61077d8b31e43ad1d/specs/eip4844/validator.md):
-
-- [`hash_to_bls_field()`](https://github.com/ethereum/consensus-specs/blob/6c2b46ae3248760e0f6e52d61077d8b31e43ad1d/specs/eip4844/validator.md#hash_to_bls_field)
-- [`compute_powers()`](https://github.com/ethereum/consensus-specs/blob/6c2b46ae3248760e0f6e52d61077d8b31e43ad1d/specs/eip4844/validator.md#compute_powers)
-- [`compute_aggregated_poly_and_commitment()`](https://github.com/ethereum/consensus-specs/blob/6c2b46ae3248760e0f6e52d61077d8b31e43ad1d/specs/eip4844/validator.md#compute_aggregated_poly_and_commitment)
-- [`PolynomialAndCommitment`](https://github.com/ethereum/consensus-specs/blob/6c2b46ae3248760e0f6e52d61077d8b31e43ad1d/specs/eip4844/validator.md#PolynomialAndCommitment)
+- [`verify_kzg_proof()`](https://github.com/ethereum/consensus-specs/blob/a45627164d34ddb60acca385e2324835fc14ca5c/specs/eip4844/polynomial-commitments.md#verify_kzg_proof)
+- [`verify_aggregate_kzg_proof()`](https://github.com/ethereum/consensus-specs/blob/a45627164d34ddb60acca385e2324835fc14ca5c/specs/eip4844/polynomial-commitments.md#verify_aggregate_kzg_proof)
 
 ### Helpers
 
@@ -347,20 +340,8 @@ def validate_blob_transaction_wrapper(wrapper: BlobTransactionNetworkWrapper):
     # note: assert blobs are not malformatted
     assert len(versioned_hashes) == len(commitments) == len(blobs)
 
-    aggregated_poly, aggregated_poly_commitment = compute_aggregated_poly_and_commitment(
-        blobs,
-        commitments,
-    )
-
-    # Generate challenge `x` and evaluate the aggregated polynomial at `x`
-    x = hash_to_bls_field(
-        PolynomialAndCommitment(polynomial=aggregated_poly, kzg_commitment=aggregated_poly_commitment)
-    )
-    # Evaluate aggregated polynomial at `x` (evaluation function checks for div-by-zero)
-    y = evaluate_polynomial_in_evaluation_form(aggregated_poly, x)
-
-    # Verify aggregated proof
-    assert verify_kzg_proof(aggregated_poly_commitment, x, y, wrapper.kzg_aggregated_proof)
+    # Verify that commitments match the blobs by checking the KZG proof
+    assert verify_aggregate_kzg_proof(blobs, commitments, wrapper.kzg_aggregated_proof)
 
     # Now that all commitments have been verified, check that versioned_hashes matches the commitments
     for versioned_hash, commitment in zip(versioned_hashes, commitments):


### PR DESCRIPTION
This PR does two things (split into corresponding commits):
- Simplifies the implementation of the point evaluation precompile by using the bytes-based `verify_kzg_proof()` from https://github.com/ethereum/consensus-specs/pull/3097 . This way the client developers don't need to understand what field elements are, and can just pass bytes to the KZG library.
- Syncs `validate_blob_transaction_wrapper()` to the latest high-level crypto API of the consensus specs introduced in https://github.com/ethereum/consensus-specs/pull/3038
