### PR TITLE
Update EIP-4844: Clarify Fork Block Behavior

### DIFF
--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -224,6 +224,8 @@ def calc_excess_data_gas(parent: Header, new_blobs: int) -> int:
         return parent.excess_data_gas + consumed_data_gas - TARGET_DATA_GAS_PER_BLOCK
 ```
 
+For the first post-fork block, `parent.excess_data_gas` is evaluated as `0`.
+
 ### Beacon chain validation
 
 On the consensus-layer the blobs are now referenced, but not fully encoded, in the beacon block body.


### PR DESCRIPTION
Clarifies how to interpret `parent.excess_data_gas` for the first post-fork block, where that field is not defined for the parent.