### PR TITLE
Update EIP-4844: Clarify Precompile Return Data Endianness

### DIFF
--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -267,7 +267,8 @@ def point_evaluation_precompile(input: Bytes) -> Bytes:
     # Verify KZG proof
     assert verify_kzg_proof(commitment, z, y, kzg_proof)
 
-    return Bytes(U256(FIELD_ELEMENTS_PER_BLOB).to_bytes32() + U256(BLS_MODULUS).to_bytes32())
+    # Return FIELD_ELEMENTS_PER_BLOB and BLS_MODULUS as padded 32 byte big endian values
+    return Bytes(U256(FIELD_ELEMENTS_PER_BLOB).to_be_bytes32() + U256(BLS_MODULUS).to_be_bytes32())
 ```
 
 ### Gas price of blobs (Simplified version)


### PR DESCRIPTION
Clarify that the precompile return values follow the usual EVM big endian encoding.