### PR TITLE
Update EIP-5793: update EIP to Review status (eth/68)

### DIFF
--- a/EIPS/eip-5793.md
+++ b/EIPS/eip-5793.md
@@ -4,7 +4,7 @@ title: eth/68 - Add tx type to tx announcement
 description: Adds the transaction type and transaction size to tx announcement messages in the wire protocol
 author: Marius van der Wijden (@MariusVanDerWijden)
 discussions-to: https://ethereum-magicians.org/t/eip-5793-eth-68-add-transaction-type-to-tx-announcement/11364
-status: Draft
+status: Review
 type: Standards Track
 category: Networking
 created: 2022-10-18


### PR DESCRIPTION
This PR changes EIP-5793 (`eth/68`) to Review status, on request of @MariusVanDerWijden.

The EIP is a soft-dependency of EIP-4844 (the EIP will work without, but propagation of larger transactions is derisked with the functionality of this EIP) and ready to move to Review status. 
