### PR TITLE
EIP-4938: change EIP to Review status (eth/67)

### DIFF
--- a/EIPS/eip-4938.md
+++ b/EIPS/eip-4938.md
@@ -4,7 +4,7 @@ title: "eth/67: Removal of GetNodeData"
 description: "Remove GetNodeData and NodeData messages from the wire protocol"
 author: Marius van der Wijden (@MariusVanDerWijden), Felix Lange <fjl@ethereum.org>, Gary Rong <garyrong@ethereum.org>
 discussions-to: https://ethereum-magicians.org/t/eip-4938-removal-of-getnodedata/8893
-status: Stagnant
+status: Review
 type: Standards Track
 category: Networking
 created: 2022-03-23


### PR DESCRIPTION
EIP-4938 (eth/67) is blocking Review status of EIP-5793 (eth/68) and should not be Stagnant. I'm updating this to Review, but the authors may want to change it to Last Call / Final depending on the adoption of the eth/67 protocol.
