### PR TITLE
Update EIP-4844: small clarification

### DIFF
--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -56,7 +56,6 @@ Compared to full data sharding, this EIP has a reduced cap on the number of thes
 | `MAX_TX_WRAP_KZG_COMMITMENTS` | `2**24` |
 | `LIMIT_BLOBS_PER_TX` | `2**24` |
 | `DATA_GAS_PER_BLOB` | `2**17` |
-| `SIMPLE_GAS_PER_BLOB` | `120000` |
 | `HASH_OPCODE_BYTE` | `Bytes1(0x49)` |
 | `HASH_OPCODE_GAS` | `3` |
 
@@ -271,13 +270,7 @@ def point_evaluation_precompile(input: Bytes) -> Bytes:
     return Bytes(U256(FIELD_ELEMENTS_PER_BLOB).to_be_bytes32() + U256(BLS_MODULUS).to_be_bytes32())
 ```
 
-### Gas price of blobs (Simplified version)
-
-___WARNING: This is only for testing___
-
-For early draft implementations, we simply change `get_data_gasprice(header)` to always return `SIMPLE_GAS_PER_BLOB`.
-
-### Gas accounting (Full version)
+### Gas accounting
 
 We introduce data gas as a new type of gas. It is independent of normal gas and follows its own targeting rule, similar to EIP-1559.
 We use the `excess_data_gas` header field to store persistent data needed to compute the data gas price. For now, only blobs are priced in data gas.

--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -275,7 +275,7 @@ def point_evaluation_precompile(input: Bytes) -> Bytes:
 
 ___WARNING: This is only for testing___
 
-For early draft implementations, we simply change `get_blob_gas(parent)` to always return `SIMPLE_GAS_PER_BLOB`.
+For early draft implementations, we simply change `get_data_gasprice(header)` to always return `SIMPLE_GAS_PER_BLOB`.
 
 ### Gas accounting (Full version)
 

--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -391,8 +391,7 @@ The work that remains to be done to get to full sharding includes:
 
 This EIP also sets the stage for longer-term protocol cleanups:
 
-- It adds an SSZ transaction type which is slightly gas-advantaged (1000 discount) to nudge people toward using it,
-  and paves the precedent that all new transaction types should be SSZ
+- It adds an SSZ transaction type, and paves the precedent that all new transaction types should be SSZ
 - It defines `TransactionNetworkPayload` to separate network and block encodings of a transaction type
 - Its (cleaner) gas price update rule could be applied to the primary basefee
 


### PR DESCRIPTION
This PR includes two clarifications:
- Remove deprecated gas price of blobs (simplified version)
- Remove outdated gas-advantage consideration