### PR TITLE
EIP-5007: Change uint64 to int64

### DIFF
--- a/EIPS/eip-5007.md
+++ b/EIPS/eip-5007.md
@@ -130,6 +130,7 @@ truffle test
 ```
  
 ## Reference Implementation
+
 See [`ERC5007.sol`](../assets/eip-5007/contracts/ERC5007.sol).
 
 ## Security Considerations
@@ -137,4 +138,5 @@ See [`ERC5007.sol`](../assets/eip-5007/contracts/ERC5007.sol).
 No security issues found.
 
 ## Copyright
+
 Copyright and related rights waived via [CC0](../LICENSE.md).

--- a/EIPS/eip-5007.md
+++ b/EIPS/eip-5007.md
@@ -40,7 +40,7 @@ interface IERC5007 /* is IERC721 */ {
      *
      * - `tokenId` must exist.
      */
-    function startTime(uint256 tokenId) external view returns (uint64);
+    function startTime(uint256 tokenId) external view returns (int64);
     
     /**
      * @dev Returns the end time of the NFT as a UNIX timestamp.
@@ -49,7 +49,7 @@ interface IERC5007 /* is IERC721 */ {
      *
      * - `tokenId` must exist.
      */
-    function endTime(uint256 tokenId) external view returns (uint64);
+    function endTime(uint256 tokenId) external view returns (int64);
 
 }
 ```
@@ -58,7 +58,7 @@ The **composable extension** is OPTIONAL for this standard. This allows your NFT
 
 ```solidity
 /**
- * @dev the EIP-165 identifier for this interface is 0xafeaab26.
+ * @dev the EIP-165 identifier for this interface is 0x620063db.
  */
 interface IERC5007Composable /* is IERC5007 */ {
     /**
@@ -85,7 +85,7 @@ interface IERC5007Composable /* is IERC5007 */ {
         uint256 oldTokenId,
         uint256 newTokenId,
         address newTokenOwner,
-        uint64 newTokenStartTime
+        int64 newTokenStartTime
     ) external;
 
     /**
@@ -111,7 +111,7 @@ interface IERC5007Composable /* is IERC5007 */ {
 
 ### Time Data Type
 
-The max value of `uint64` is 18446744073709551615. As a timestamp, 18446744073709551615 is about year 584942419325. `uint256` is too big for some software such as MySQL, Elastic Search, and `uint64` is natively supported on mainstream programming languages.
+The max value of `int64` is 9,223,372,036,854,775,807. As a timestamp, 9,223,372,036,854,775,807 is about year 292,471,210,648. `uint256` is too big for C, C++, Java, Go, etc, and `int64` is natively supported by mainstream programming languages.
 
 ## Backwards Compatibility
 

--- a/assets/eip-5007/contracts/ERC5007.sol
+++ b/assets/eip-5007/contracts/ERC5007.sol
@@ -6,8 +6,8 @@ import "./IERC5007.sol";
 
 abstract contract ERC5007 is ERC721, IERC5007 {
     struct TimeNftInfo {
-        uint64 startTime;
-        uint64 endTime;
+        int64 startTime;
+        int64 endTime;
     }
 
     mapping(uint256 => TimeNftInfo) internal _timeNftMapping;
@@ -20,7 +20,7 @@ abstract contract ERC5007 is ERC721, IERC5007 {
         view
         virtual
         override
-        returns (uint64) {
+        returns (int64) {
         require(_exists(tokenId), "ERC5007: invalid tokenId");
         return _timeNftMapping[tokenId].startTime;
     }
@@ -33,7 +33,7 @@ abstract contract ERC5007 is ERC721, IERC5007 {
         view
         virtual
         override
-        returns (uint64) {
+        returns (int64) {
         require(_exists(tokenId), "ERC5007: invalid tokenId");
         return _timeNftMapping[tokenId].endTime;
     }
@@ -50,8 +50,8 @@ abstract contract ERC5007 is ERC721, IERC5007 {
     function _mintTimeNft(
         address to_,
         uint256 tokenId_,
-        uint64 startTime_,
-        uint64 endTime_
+        int64 startTime_,
+        int64 endTime_
     ) internal virtual {
         require(endTime_ >= startTime_, 'ERC5007: invalid endTime');
         _mint(to_, tokenId_);

--- a/assets/eip-5007/contracts/ERC5007Composable.sol
+++ b/assets/eip-5007/contracts/ERC5007Composable.sol
@@ -26,15 +26,15 @@ abstract contract ERC5007Composable is ERC5007, IERC5007Composable {
         uint256 oldTokenId,
         uint256 newTokenId,
         address newTokenOwner,
-        uint64 newTokenStartTime
+        int64 newTokenStartTime
     ) public virtual override {
         require(
             _isApprovedOrOwner(_msgSender(), oldTokenId),
             "ERC5007: caller is not owner nor approved"
         );
 
-        uint64 oldTokenStartTime = _timeNftMapping[oldTokenId].startTime;
-        uint64 oldTokenEndTime = _timeNftMapping[oldTokenId].endTime;
+        int64 oldTokenStartTime = _timeNftMapping[oldTokenId].startTime;
+        int64 oldTokenEndTime = _timeNftMapping[oldTokenId].endTime;
         require(
             oldTokenStartTime < newTokenStartTime &&
                 newTokenStartTime <= oldTokenEndTime,
@@ -42,7 +42,7 @@ abstract contract ERC5007Composable is ERC5007, IERC5007Composable {
         );
 
         _timeNftMapping[oldTokenId].endTime = newTokenStartTime - 1;
-        uint64 newTokenEndTime = oldTokenEndTime;
+        int64 newTokenEndTime = oldTokenEndTime;
 
         _mintTimeNftWithRootId(
             newTokenOwner,
@@ -105,8 +105,8 @@ abstract contract ERC5007Composable is ERC5007, IERC5007Composable {
         address to_,
         uint256 tokenId_,
         uint256 rootId_,
-        uint64 startTime_,
-        uint64 endTime_
+        int64 startTime_,
+        int64 endTime_
     ) internal virtual {
         require(_exists(rootId_), "ERC5007: invalid rootId_");
         super._mintTimeNft(to_, tokenId_, startTime_, endTime_);
@@ -125,8 +125,8 @@ abstract contract ERC5007Composable is ERC5007, IERC5007Composable {
     function _mintTimeNft(
         address to_,
         uint256 tokenId_,
-        uint64 startTime_,
-        uint64 endTime_
+        int64 startTime_,
+        int64 endTime_
     ) internal virtual override {
         super._mintTimeNft(to_, tokenId_, startTime_, endTime_);
 

--- a/assets/eip-5007/contracts/ERC5007ComposableTest.sol
+++ b/assets/eip-5007/contracts/ERC5007ComposableTest.sol
@@ -15,8 +15,8 @@ contract ERC5007ComposableTest is ERC5007Composable  {
     function mint(
         address to_,
         uint256 id_,
-        uint64 startTime_,
-        uint64 endTime_
+        int64 startTime_,
+        int64 endTime_
     ) public {
         super._mintTimeNft(to_, id_, startTime_, endTime_);
     }

--- a/assets/eip-5007/contracts/ERC5007Demo.sol
+++ b/assets/eip-5007/contracts/ERC5007Demo.sol
@@ -18,8 +18,8 @@ contract ERC5007Demo is ERC5007 {
     function mint(
         address to_,
         uint256 tokenId_,
-        uint64 startTime_,
-        uint64 endTime_
+        int64 startTime_,
+        int64 endTime_
     ) public {
         _mintTimeNft(to_, tokenId_, startTime_, endTime_);
     }

--- a/assets/eip-5007/contracts/IERC5007.sol
+++ b/assets/eip-5007/contracts/IERC5007.sol
@@ -10,7 +10,7 @@ interface IERC5007 /* is IERC1155 */ {
      *
      * - `tokenId` must exist.
      */
-    function startTime(uint256 tokenId) external view returns (uint64);
+    function startTime(uint256 tokenId) external view returns (int64);
 
     /**
      * @dev Returns the end time of the NFT.
@@ -19,5 +19,5 @@ interface IERC5007 /* is IERC1155 */ {
      *
      * - `tokenId` must exist.
      */
-    function endTime(uint256 tokenId) external view returns (uint64);
+    function endTime(uint256 tokenId) external view returns (int64);
 }

--- a/assets/eip-5007/contracts/IERC5007Composable.sol
+++ b/assets/eip-5007/contracts/IERC5007Composable.sol
@@ -27,7 +27,7 @@ interface IERC5007Composable /* is IERC5007 */ {
         uint256 oldTokenId,
         uint256 newTokenId,
         address newTokenOwner,
-        uint64 newTokenStartTime
+        int64 newTokenStartTime
     ) external;
 
     /**

--- a/assets/eip-5007/test/test.js
+++ b/assets/eip-5007/test/test.js
@@ -26,7 +26,7 @@ contract("test ERC5007", async accounts => {
         assert.equal(inputStartTime1.comparedTo(outputStartTime1) == 0  && inputEndTime1.comparedTo(outputEndTime1) == 0, true, "wrong data");
 
 
-        console.log("InterfaceId:", await demo.getInterfaceId())
+        console.log("IERC5007 InterfaceId:", await demo.getInterfaceId())
         let isSupport = await demo.supportsInterface('0x7a0cdf92');
         assert.equal(isSupport, true , "supportsInterface error");
         
@@ -87,8 +87,8 @@ contract("test ERC5007", async accounts => {
         assert.equal(token3RootId == id1, true, 'wrong rootId');
         assert.equal(token3Owner == Carl, true, 'wrong owner');
 
-        console.log("InterfaceId:", await demo.getInterfaceId())
-        let isSupport = await demo.supportsInterface('0xafeaab26');
+        console.log("IERC5007Composable InterfaceId:", await demo.getInterfaceId())
+        let isSupport = await demo.supportsInterface('0x620063db');
         assert.equal(isSupport, true , "supportsInterface error");
     });
 


### PR DESCRIPTION
EIP-5007: Change uint64 to int64

The max value of `int64` is 9,223,372,036,854,775,807. As a timestamp, 9,223,372,036,854,775,807 is about year 292,471,210,648. `uint256` is too big for C, C++, Java, Go, etc, and `int64` is natively supported by mainstream programming languages.