### PR TITLE
Update EIP-3670: Drop "terminating" instruction restriction

### DIFF
--- a/EIPS/eip-3540.md
+++ b/EIPS/eip-3540.md
@@ -35,7 +35,7 @@ A non-exhaustive list of proposed changes which could benefit from this format:
 
 - Including a `JUMPDEST`-table (to avoid analysis at execution time) and/or removing `JUMPDEST`s entirely.
 - Introducing static jumps (with relative addresses) and jump tables, and disallowing dynamic jumps at the same time.
-- Requiring code section(s) to be terminated by `STOP`. (Assumptions like this can provide significant speed improvements in interpreters, such as a speed-up of ~7% seen in evmone (ethereum/evmone#295).
+- Requiring the execution of a code section ends with a terminating instruction. (Assumptions like this can provide significant speed improvements in interpreters, such as a speed-up of ~7% seen in evmone (ethereum/evmone#295).
 - Multibyte opcodes without any workarounds.
 - Representing functions as individual code sections instead of subroutines.
 - Introducing special sections for different use cases, notably Account Abstraction.
@@ -125,7 +125,7 @@ For clarity, the *container* refers to the complete account code, while *code* r
 
 1. `JUMPDEST`-analysis is only run on the *code*.
 2. Execution starts at the first byte of the *code*, and `PC` is set to 0.
-3. If `PC` goes outside the code section bounds, execution aborts with failure.
+3. Execution stops if `PC` goes outside the code section bounds.
 4. `PC` returns the current position within the *code*.
 5. `JUMP`/`JUMPI` uses an absolute offset within the *code*.
 6. `CODECOPY`/`CODESIZE`/`EXTCODECOPY`/`EXTCODESIZE`/`EXTCODEHASH` keeps operating on the entire *container*.

--- a/EIPS/eip-3670.md
+++ b/EIPS/eip-3670.md
@@ -44,23 +44,19 @@ The EOF1 format provides following forward compatibility properties:
 
 This feature is introduced on the very same block EIP-3540 is enabled, therefore every EOF1-compatible bytecode MUST be validated according to these rules.
 
-Previously deprecated instructions `CALLCODE` (0xf2) and `SELFDESTRUCT` (0xff) are invalid and their opcodes do not have any instruction assigned.
+1. Previously deprecated instructions `CALLCODE` (0xf2) and `SELFDESTRUCT` (0xff) are invalid and their opcodes are undefined.
 
-At contract creation time both *initcode* and *code* are iterated instruction-by-instruction (the same process is used to perform "JUMPDEST-analysis").
-Bytecode is deemed invalid if any of these conditions is true:
+2. At contract creation time *instructions validation* is performed on both *initcode* and *code*. The code is invalid if any of the checks below fails. For each instruction:
+   1. Check if the opcode is defined. The `INVALID` (0xfe) is considered defined.
+   2. Check if all instructions' immediate bytes are present in the code (code does not end in the middle of instruction).
 
-- it contains opcodes which are not currently assigned to an instruction (for the sake of assigned instructions, we count `INVALID` (0xfe) as assigned),
-- the last opcode (*terminating instruction*) is not `STOP` (0x00),`RETURN` (0xf3), `REVERT` (0xfd) or `INVALID` (0xfe).
-
-*Notice that due to the requirement of the terminating instruction, it is implicitly stated that truncated instructions (e.g. data portion of a `PUSHn`) are disallowed.*
-
-*Notice that since EOF1 disallows 0-length code section, a valid contract must contain at least a single byte, which must be a terminating instruction.*
+3. Execution stops if reaches the end of the code (defined by the EOF code section).
 
 ## Rationale
 
-### Terminating instructions
+### Immediate data
 
-An efficient interpreter loop would only need to rely on checking if a terminating instruction has been encountered, and if so stopping execution. Currently, this is not possible in the EVM, because of the lack of requirement for a proper termination as well as allowing for truncated instructions, an interpreter must track and check these various conditions.
+Allowing implicit zero immediate data for `PUSH` instructions introduces inefficiencies to EVM implementations without any practical use-case (the value of a `PUSH` instruction at the code end cannot be observed by EVM). This EIP requires all immediate bytes to be explicitly present in the code.
 
 ### Rejection of deprecated instructions
 
@@ -83,19 +79,15 @@ Each case should be tested for creation transaction, `CREATE` and `CREATE2`.
 ### Valid codes
 
 - EOF code containing `INVALID`
-- EOF codes ending with any of the terminating instructions
 - EOF code with data section containing bytes that are undefined instructions
 - Legacy code containing undefined instruction
 - Legacy code ending with incomplete PUSH instruction
-- Legacy code ending with any valid non-terminating instruction
 
 ### Invalid codes
 
 - EOF code containing undefined instruction
 - EOF code ending with incomplete `PUSH` instruction
     - This can include `PUSH` instruction unreachable by execution, e.g. after `STOP`
-- EOF code ending with any defined instruction other than terminating ones
-    - This can include codes where non-terminating instruction is not reachable, e.g. `0030` (`STOP ADDRESS`).
 
 ## Reference Implementation
 

--- a/EIPS/eip-3670.md
+++ b/EIPS/eip-3670.md
@@ -50,8 +50,6 @@ This feature is introduced on the very same block EIP-3540 is enabled, therefore
    1. Check if the opcode is defined. The `INVALID` (0xfe) is considered defined.
    2. Check if all instructions' immediate bytes are present in the code (code does not end in the middle of instruction).
 
-3. Execution stops if reaches the end of the code (defined by the EOF code section).
-
 ## Rationale
 
 ### Immediate data

--- a/EIPS/eip-3670.md
+++ b/EIPS/eip-3670.md
@@ -108,38 +108,28 @@ valid_opcodes = [
     0xf0, 0xf1, 0xf3, 0xf4, 0xf5, 0xfa, 0xfd, 0xfe
 ]
 
-# STOP, RETURN, REVERT, INVALID
-terminating_opcodes = [ 0x00, 0xf3, 0xfd, 0xfe ]
-
-# Only for PUSH1..PUSH32
 immediate_sizes = 256 * [0]
-for opcode in range(0x60, 0x7f + 1):  # PUSH1..PUSH32
-    immediate_sizes[opcode] = opcode - 0x60 + 1
+immediate_sizes[0x60:0x7f + 1] = range(1, 32 + 1)  # PUSH1..PUSH32
+
 
 # Raises ValidationException on invalid code
-def validate_code(code: bytes):
+def validate_instructions(code: bytes):
     # Note that EOF1 already asserts this with the code section requirements
     assert len(code) > 0
 
-    opcode = 0
     pos = 0
     while pos < len(code):
         # Ensure the opcode is valid
         opcode = code[pos]
-        pos += 1
-        if not opcode in valid_opcodes:
-            raise ValidationException("undefined instruction")
+        if opcode not in valid_opcodes:
+            raise ValidationException("undefined opcode")
 
-        # Skip immediates
-        pos += immediate_sizes[opcode]
+        # Skip immediate data
+        pos += 1 + immediate_sizes[opcode]
 
-    # Ensure last opcode's immediate doesn't go over code end
-    if pos != len(code):        
+    # Ensure last instruction's immediate doesn't go over code end
+    if pos != len(code):
         raise ValidationException("truncated immediate")
-
-    # opcode is the *last opcode*
-    if not opcode in terminating_opcodes:
-        raise ValidationException("no terminating instruction")
 ```
 
 ## Security Considerations


### PR DESCRIPTION
Drop the requirement that the last instruction in code is "terminating". The change requires adding explicit rule about immediate data.