### PR TITLE
Update EIP-4750: Clarify stack overflow rules

### DIFF
--- a/EIPS/eip-4750.md
+++ b/EIPS/eip-4750.md
@@ -81,10 +81,11 @@ If the code is valid EOF1, the following execution rules apply:
 
 1. Has one immediate argument,`code_section_index`, encoded as a 16-bit unsigned big-endian value.
 2. If data stack has less than `caller_stack_height +  type[code_section_index].inputs`, execution results in exceptional halt.
-3. If return stack already has `1024` items, execution results in exceptional halt.
-4. Charges 5 gas.
-5. Pops nothing and pushes nothing to data stack.
-6. Pushes to return stack an item:
+3. If data stack size after the call would exceed `1024` items, (i.e. if `caller_stack_height - type[code_section_index].inputs + type[code_section_index].ouputs > 1024`), execution results in exceptional halt.
+4. If return stack already has `1024` items, execution results in exceptional halt.
+5. Charges 5 gas.
+6. Pops nothing and pushes nothing to data stack.
+7. Pushes to return stack an item:
 
 ```
 (code_section_index = current_section_index, 
@@ -131,6 +132,7 @@ Dynamic jump instructions `JUMP` (`0x56`) and `JUMPI` (`0x57`) and invalid and t
 1. Execution starts at the first byte of the first code section, and PC is set to 0.
 2. Return stack is initialized to contain one item: `(code_section_index = 0, offset = 0, stack_height = 0)`
 3. If any instruction would access a data stack item below `caller_stack_height`, execution results in exceptional halt. This rule replaces the old stack underflow check.
+4. No change in stack overflow check: if any instruction would result in data stack size exceeding `1024` items, execution results in exceptional halt.
 
 ## Rationale
 


### PR DESCRIPTION
Clarify that data stack limit of 1024 items still applies.

Also make CALLF fail immediately if it would result in stack overflow.