### PR TITLE
Update-4200: disallow empty jump table

### DIFF
--- a/EIPS/eip-4200.md
+++ b/EIPS/eip-4200.md
@@ -51,7 +51,7 @@ If the code is valid EOF1:
 
 The immediate argument `relative_offset` is encoded as a 16-bit **signed** (two's-complement) big-endian value. Under `PC_post_instruction` we mean the `PC` position after the entire immediate value.
 
-The immediate encoding of `RJUMPV` is more special: the 8-bit `count` value determines the number of `relative_offset` values following. Validation algorithm of [EIP-3670](./eip-3670.md) is extended to verify that `count >= 1`. The encoding of `RJUMPV` must have at least one `relative_offset` and thus it will take at minimum 4 bytes. Furthermore, the `case >= count` condition falling through means that in many use cases one would place the *default* path following the `RJUMPV` instruction.
+The immediate encoding of `RJUMPV` is more special: the 8-bit `count` value determines the number of `relative_offset` values following. Validation algorithm of [EIP-3670](./eip-3670.md) is extended to verify that `count >= 1`. The encoding of `RJUMPV` must have at least one `relative_offset` and thus it will take at minimum 4 bytes. Furthermore, the `case >= count` condition falling through means that in many use cases one would place the *default* path following the `RJUMPV` instruction. An interesting feature is that `RJUMPV 1 relative_offset` is an inverted-`RJUMPI`, which can be used in many cases instead of `ISZERO RJUMPI relative_offset`.
 
 We also extend the validation algorithm of [EIP-3670](./eip-3670.md) to verify that each `RJUMP`/`RJUMPI`/`RJUMPV` has a `relative_offset` pointing to an instruction. This means it cannot point to an immediate data of `PUSHn`/`RJUMP`/`RJUMPI`/`RJUMPV`. It cannot point outside of code bounds. It is allowed to point to a `JUMPDEST`, but is not required to.
 

--- a/EIPS/eip-4200.md
+++ b/EIPS/eip-4200.md
@@ -47,11 +47,11 @@ If the code is valid EOF1:
 
 1. `RJUMP relative_offset` sets the `PC` to `PC_post_instruction + relative_offset`.
 2. `RJUMPI relative_offset` pops a value (`condition`) from the stack, and sets the `PC` to `PC_post_instruction + ((condition == 0) ? 0 : relative_offset)`.
-3. `RJUMPV count relative_offset+` pops a value (`case`) from the stack, and sets the `PC` to `PC_post_instruction + ((case >= (count + 1)) ? 0 : relative_offset[case])`.
+3. `RJUMPV count relative_offset+` pops a value (`case`) from the stack, and sets the `PC` to `PC_post_instruction + ((case >= count) ? 0 : relative_offset[case])`.
 
 The immediate argument `relative_offset` is encoded as a 16-bit **signed** (two's-complement) big-endian value. Under `PC_post_instruction` we mean the `PC` position after the entire immediate value.
 
-The immediate encoding of `RJUMPV` is more special: the 8-bit `count` value incremented by 1 determines the number of `relative_offset` values following. Based on this it can be seen that the encoding of `RJUMPV` must have at least one `relative_offset` and thus it will take at minimum 4 bytes. Furthermore, the `case >= count` condition falling through means that in many use cases one would place the *default* path following the `RJUMPV` instruction.
+The immediate encoding of `RJUMPV` is more special: the 8-bit `count` value determines the number of `relative_offset` values following. Validation algorithm of [EIP-3670](./eip-3670.md) is extended to verify that `count >= 1`. The encoding of `RJUMPV` must have at least one `relative_offset` and thus it will take at minimum 4 bytes. Furthermore, the `case >= count` condition falling through means that in many use cases one would place the *default* path following the `RJUMPV` instruction.
 
 We also extend the validation algorithm of [EIP-3670](./eip-3670.md) to verify that each `RJUMP`/`RJUMPI`/`RJUMPV` has a `relative_offset` pointing to an instruction. This means it cannot point to an immediate data of `PUSHn`/`RJUMP`/`RJUMPI`/`RJUMPV`. It cannot point outside of code bounds. It is allowed to point to a `JUMPDEST`, but is not required to.
 
@@ -208,7 +208,9 @@ def validate_code(code: bytes):
         elif opcode == 0x5e:
             if pos + 1 > len(code):
                 raise ValidationException("truncated jump table")
-            jump_table_size = code[pos+1] + 1
+            jump_table_size = code[pos]
+            if jump_table_size == 0:
+                raise ValidationException("empty jump table")                
 
             pc_post_instruction = pos + 1 + 2 * jump_table_size
             if pc_post_instruction > len(code):


### PR DESCRIPTION
1.  Reject `RJUMPV` with empty jump table at validation.
2. Fix off-by-one bug in reference code when reading jump table size.
3. Update reference code to disallow CALLCODE ad SELFDESTRUCT according to current spec of EIP-3670.
