### PR TITLE
Update EIP-4750: Clarify RETF not cleaning the stack automatically

### DIFF
--- a/EIPS/eip-4750.md
+++ b/EIPS/eip-4750.md
@@ -102,7 +102,7 @@ Under `PC_post_instruction` we mean the PC position after the entire immediate a
 #### `RETF`
 
 1. Does not have immediate arguments.
-2. If data stack has less than `caller_stack_height + types[code_section_index].outputs`, execution results in exceptional halt.
+2. If number of items on the data stack is not equal `caller_stack_height + type[code_section_index].outputs`, execution results in exceptional halt.
 3. Charges 3 gas.
 4. Pops nothing and pushes nothing to data stack.
 5. Pops an item from return stack and sets `current_section_index` and `PC` to values from this item.


### PR DESCRIPTION
Exception if not exactly `types[i].output` items on stack at `RETF`.

(This runtime check is superseded by deploy-time validation of EIP-5450)