### PR TITLE
EIP4844: Be explicit about precompile accepting canonical inputs

### DIFF
--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -71,12 +71,12 @@ Compared to full data sharding, this EIP has a reduced cap on the number of thes
 
 ### Cryptographic Helpers
 
-Throughout this proposal we use cryptographic methods and classes defined in the corresponding [consensus 4844 specs](https://github.com/ethereum/consensus-specs/blob/a45627164d34ddb60acca385e2324835fc14ca5c/specs/eip4844).
+Throughout this proposal we use cryptographic methods and classes defined in the corresponding [consensus 4844 specs](https://github.com/ethereum/consensus-specs/blob/23d3aeebba3b5da0df4bd25108461b442199f406/specs/eip4844).
 
-Specifically, we use the following methods from [`polynomial-commitments.md`](https://github.com/ethereum/consensus-specs/blob/a45627164d34ddb60acca385e2324835fc14ca5c/specs/eip4844/polynomial-commitments.md):
+Specifically, we use the following methods from [`polynomial-commitments.md`](https://github.com/ethereum/consensus-specs/blob/23d3aeebba3b5da0df4bd25108461b442199f406/specs/eip4844/polynomial-commitments.md):
 
-- [`verify_kzg_proof()`](https://github.com/ethereum/consensus-specs/blob/a45627164d34ddb60acca385e2324835fc14ca5c/specs/eip4844/polynomial-commitments.md#verify_kzg_proof)
-- [`verify_aggregate_kzg_proof()`](https://github.com/ethereum/consensus-specs/blob/a45627164d34ddb60acca385e2324835fc14ca5c/specs/eip4844/polynomial-commitments.md#verify_aggregate_kzg_proof)
+- [`verify_kzg_proof()`](https://github.com/ethereum/consensus-specs/blob/23d3aeebba3b5da0df4bd25108461b442199f406/specs/eip4844/polynomial-commitments.md#verify_kzg_proof)
+- [`verify_aggregate_kzg_proof()`](https://github.com/ethereum/consensus-specs/blob/23d3aeebba3b5da0df4bd25108461b442199f406/specs/eip4844/polynomial-commitments.md#verify_aggregate_kzg_proof)
 
 ### Helpers
 
@@ -243,8 +243,9 @@ The opcode has a gas cost of `HASH_OPCODE_GAS`.
 
 ### Point evaluation precompile
 
-Add a precompile at `POINT_EVALUATION_PRECOMPILE_ADDRESS` that evaluates a proof that a particular blob resolves
-to a particular value at a point.
+Add a precompile at `POINT_EVALUATION_PRECOMPILE_ADDRESS` that verifies a KZG proof which claims that a blob
+(represented by a commitment) evaluates to a given value at a given point.
+
 The precompile costs `POINT_EVALUATION_PRECOMPILE_GAS` and executes the following logic:
 
 ```python
@@ -269,6 +270,8 @@ def point_evaluation_precompile(input: Bytes) -> Bytes:
     # Return FIELD_ELEMENTS_PER_BLOB and BLS_MODULUS as padded 32 byte big endian values
     return Bytes(U256(FIELD_ELEMENTS_PER_BLOB).to_be_bytes32() + U256(BLS_MODULUS).to_be_bytes32())
 ```
+
+The precompile MUST reject non-canonical field elements (i.e. provided field elements MUST be strictly less than `BLS_MODULUS`).
 
 ### Gas accounting
 


### PR DESCRIPTION
Clarify that the precompile will reject non-canonical inputs. Also update the consensus-specs git reference to point to the latest version.