### PR TITLE
EIP-4895: clarify types and allowed values for withdrawal data

### DIFF
--- a/EIPS/eip-4895.md
+++ b/EIPS/eip-4895.md
@@ -42,9 +42,9 @@ Define a new payload-level object called a `withdrawal` that describes withdrawa
 
 `Withdrawal`s provide key information from the consensus layer:
 1. a monotonically increasing `index`, starting from 0, as a `uint64` value that increments by 1 per withdrawal to uniquely identify each withdrawal
-2. the `validator_index` of the validator on the consensus layer the withdrawal corresponds to
+2. the `validator_index` of the validator, as a `uint64` value, on the consensus layer the withdrawal corresponds to
 3. a recipient for the withdrawn ether `address` as a 20-byte value
-4. an `amount` of ether given in wei as a 256-bit value.
+4. a nonzero `amount` of ether given in wei as a `uint64` value.
 
 *NOTE*: the `index` for each withdrawal is a global counter spanning the entire sequence of withdrawals.
 


### PR DESCRIPTION
clarify that:

validator indices are `uint64` types
withdrawals are never for 0 `amount`s of wei