### PR TITLE
EIP-4895: fix typo from #6089 to use correct type for withdrawal `amount`

### DIFF
--- a/EIPS/eip-4895.md
+++ b/EIPS/eip-4895.md
@@ -44,7 +44,7 @@ Define a new payload-level object called a `withdrawal` that describes withdrawa
 1. a monotonically increasing `index`, starting from 0, as a `uint64` value that increments by 1 per withdrawal to uniquely identify each withdrawal
 2. the `validator_index` of the validator, as a `uint64` value, on the consensus layer the withdrawal corresponds to
 3. a recipient for the withdrawn ether `address` as a 20-byte value
-4. a nonzero `amount` of ether given in wei as a `uint64` value.
+4. a nonzero `amount` of ether given in wei as a `uint256` value.
 
 *NOTE*: the `index` for each withdrawal is a global counter spanning the entire sequence of withdrawals.
 


### PR DESCRIPTION
incorrect typo from #6089 and @eth-bot merged a little too quickly

thanks to @yperbasis for catching the error!