### PR TITLE
Update EIP-5375: Fix typo in JSON

### DIFF
--- a/EIPS/eip-5375.md
+++ b/EIPS/eip-5375.md
@@ -190,7 +190,7 @@ and the content of `metadataFields` is `["name", "description"]`, the content of
 ```json
 {
     "name": "The Holy Hand Grenade of Antioch",
-    "description": "Throw in the general direction of your favorite rabbit, et voilà"
+    "description": "Throw in the general direction of your favorite rabbit, et voil\u00E0"
 }
 ```
 


### PR DESCRIPTION
Unlike stated in the specifications, the example in line 193 did not escape the non-ASCII character "à". This PR fixes our mistake.