### PR TITLE
Update ci.yml for ubuntu version fixing HTMLProofer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     
     steps:
       - name: Checkout EIP Repository
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        uses: actions/checkout@3
 
       - name: Install OpenSSL
         run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     
     steps:
       - name: Checkout EIP Repository
-        uses: actions/checkout@3
+        uses: actions/checkout@v3
 
       - name: Install OpenSSL
         run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,15 +42,15 @@ jobs:
     
     steps:
       - name: Checkout EIP Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
 
       - name: Install OpenSSL
         run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev
-    
+
       - name: Install Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@08245253a76fa4d1e459b7809579c62bd9eb718a
         with:
-          ruby-version: 3.1.2
+          ruby-version: 2.6.0
           bundler-cache: true
         
       - name: Build Website

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
 
   htmlproofer:
     name: HTMLProofer
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     
     steps:
       - name: Checkout EIP Repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,9 +48,9 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev
     
       - name: Install Ruby
-        uses: ruby/setup-ruby@08245253a76fa4d1e459b7809579c62bd9eb718a
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.6.0
+          ruby-version: 3.1.2
           bundler-cache: true
         
       - name: Build Website


### PR DESCRIPTION
Recently, Github updated its `ubuntu-latest` to a new version `ubuntu-22.04` so ruby 2.6 is no longer supported, resulting [this kind of failure](https://github.com/ethereum/EIPs/actions/runs/3654459792/jobs/6174903582)

```
Error: Error: Unknown version 2.6.0 for ruby on ubuntu-22.04
        available versions for ruby on ubuntu-22.04: 3.1.0, 3.1.1, 3.1.2, 3.2.0-preview1, head, debug
        Make sure you use the latest version of the action with - uses: ruby/setup-ruby@v1
```

Here is the fix steps tried:
1. Update the ruby to `3.1.2` which is latest stable release available. result: https://github.com/ethereum/EIPs/actions/runs/3654483141/jobs/6174948461 yields `minitest-5.14.1 requires ruby version ~> 2.2, which is incompatible with the`
2. Revert the `ubuntu-latest` to `ubuntu-20.04`, passed