### PR TITLE
Update EIP-6046: Propose alternative deactivation

### DIFF
--- a/EIPS/eip-6046.md
+++ b/EIPS/eip-6046.md
@@ -27,21 +27,19 @@ Furthermore, with *Verkle trees*, accounts will be organised differently: accoun
 
 2. The behaviour of `SELFDESTRUCT` is changed such that:
 
-  - Does not delete any storage keys and also leave the account in place.
-  - Transfer the account balance to the target **and** set account balance to `0.`
-  - Set the account nonce to `2^64-1`.
+  - `SELFDESTRUCT` does not delete any storage keys
+  - `SELFDESTRUCT` transfers the account balance to the target **and** set account balance to `0.`
+  - `SELFDESTRUCT` sets the account nonce to `2^64-1`.
+  - `SELFDESTRUCT` sets the deactivated account's contract code to the deactivated account's address plus `1`
+  - `SELFDESTRUCT` sets the contract code of accounts directly preceding the deactivated account's address whose nonce is `2^64-1` and whose account code is equal to the deactivated account's address to the deactivated account's address plus `1`. `SELFDESTRUCT` costs an additional `5000` gas for each account modified this way (in addition to the normal gas costs associated with accessing an account's data).
   - Note that no refund is given since [EIP-3529](./eip-3529.md).
   - Note that the rules of [EIP-2929](./eip-2929.md) regarding `SELFDESTRUCT` remain unchanged.
 
-2. Modify account execution (triggered both via external transactions or CALL* instructions), such that execution succeeds and returns an empty buffer if the nonce equals `2^64-1`.
+3. Modify `CREATE` and `CREATE2` such that while the nonce of the account creation address equals `2^64-1`, the account creation address is set to the contract's code.
 
-  - Note that the account can still receive non-executable value transfers (such as coinbase transactions or other `SELFDESTRUCT`s).
+4. Modify external transactions, `CALL`, `STATICCALL`, `DELEGATECALL`, `EXTCODEHASH`, `EXTCODECOPY`, `EXTCODESIZE`, and `BALANCE` such that while the referenced account's nonce equals `2^64-1`, the referenced account is set to the contract's code. These instructions will also cost an additional `25` gas each time an account's nonce is checked beyond the first (in addition to the normal gas costs associated with accessing an account's data).
 
-3. Modify `CREATE` and `CREATE2` such that while the nonce of the account creation address equals `2^64-1`, the account creation address is incremented by `1`
-
-5. Modify `CALL`, `STATICCALL`, `DELEGATECALL`, `EXTCODEHASH`, `EXTCODECOPY`, `EXTCODESIZE`, and `BALANCE` such that while the referenced account's nonce equals `2^64-1`, the referenced account is incremente by `1`. These instructions will also cost an additional `15` gas each time an account's nonce is checked (in addition to the normal gas costs associated with accessing an account's data).
-
-6. Rename the `SELFDESTRUCT` instruction to `DEACTIVATE`, because the semantics of "account revival" are changed: the old storage items will remain, and newly deployed code must be aware of this.
+5. Rename the `SELFDESTRUCT` instruction to `DEACTIVATE`, because the semantics of "account revival" are changed.
 
 ## Rationale
 
@@ -55,7 +53,7 @@ Contracts using the revival pattern will still work, but the code deployed durin
 
 ## Security Considerations
 
-The additional gas costs may cause potential DoS attacks if they access an arbitrary contract's data. Contract authors must be aware and design contracts accordingly. There may be an effect on existing deployed code performing autonomous destruction and revival.
+The additional gas costs may cause potential DoS attacks if they access an arbitrary contract's data or make frequent contract deactivations. Contract authors must be aware and design contracts accordingly. There may be an effect on existing deployed code performing autonomous destruction and revival.
 
 ## Copyright
 

--- a/EIPS/eip-6046.md
+++ b/EIPS/eip-6046.md
@@ -2,7 +2,7 @@
 eip: 6046
 title: Replace SELFDESTRUCT with DEACTIVATE
 description: Change SELFDESTRUCT to not delete storage keys and use a special value in the account nonce to signal deactivation
-author: Alex Beregszaszi (@axic)
+author: Alex Beregszaszi (@axic), Pandapip1 (@Pandapip1)
 discussions-to: https://ethereum-magicians.org/t/almost-self-destructing-selfdestruct-deactivate/11886
 status: Draft
 type: Standards Track
@@ -13,7 +13,7 @@ requires: 2681, 2929, 3529
 
 ## Abstract
 
-Change `SELFDESTRUCT` to not delete all storage keys, and to use a special value in the account nonce to signal *deactivated* accounts. Because the semantics of revival change (storage keys may exists), we also rename the instruction to `DEACTIVATE`.
+Change `SELFDESTRUCT` to not delete all storage keys, and to use a special value in the account nonce to signal *deactivated* accounts, whose transactions are forwarded to subsequent deployments. Because the semantics of revival change (storage keys may exists), we also rename the instruction to `DEACTIVATE`.
 
 ## Motivation
 
@@ -37,18 +37,15 @@ Furthermore, with *Verkle trees*, accounts will be organised differently: accoun
 
   - Note that the account can still receive non-executable value transfers (such as coinbase transactions or other `SELFDESTRUCT`s).
 
-3. Modify `CREATE2` such that it allows account creation if the nonce equals `2^64-1`.
+3. Modify `CREATE` and `CREATE2` such that while the nonce equals `2^64-1`, the address that the contract will be created at is incremented
 
-  - Note that the account (especially code and storage) might not be empty prior to `CREATE2`.
-  - Note that a successful `CREATE2` will change the account code, nonce and potentially balance.
+5. Modify `CALL`, `STATICCALL`, `DELEGATECALL`, `EXTCODEHASH`, `EXTCODECOPY`, `EXTCODESIZE`, and `BALANCE` such that while the referenced account's nonce equals `2^64-1`, the address it refers to is incremented. These instructions cost an additional `10` gas, and another additional `10` gas each time this happens (in addition to the normal gas costs associated with accessing an account's data).
 
-4. Rename the `SELFDESTRUCT` instruction to `DEACTIVATE`, because the semantics of "account revival" are changed: the old storage items will remain, and newly deployed code must be aware of this.
+6. Rename the `SELFDESTRUCT` instruction to `DEACTIVATE`, because the semantics of "account revival" are changed: the old storage items will remain, and newly deployed code must be aware of this.
 
 ## Rationale
 
-There have been various proposals of removing `SELFDESTRUCT` and many would just outright remove the deletion capability. This breaks certain usage patterns, which the *deactivation* option leaves intact, albeit with minor changes. This only affects *newly* deployed code, and not existing one.
-
-All the proposals would leave data in the state, but this proposal provides the flexibility to reuse or remove storage slots one-by-one should the revived contract choose to do so.
+There have been various proposals of removing `SELFDESTRUCT` and many would just outright remove the deletion capability. This would break certain usage patterns, which the *deactivation* option leaves intact, albeit with minor changes.
 
 ## Backwards Compatibility
 
@@ -58,7 +55,7 @@ Contracts using the revival pattern will still work, but the code deployed durin
 
 ## Security Considerations
 
-The new behaviour of preserving storage has a potential effect on security. Contract authors must be aware and design contracts accordingly. There may be an effect on existing deployed code performing autonomous destruction and revival.
+The additional gas costs may cause potential DoS attacks if they access an arbitrary contract's data. Contract authors must be aware and design contracts accordingly. There may be an effect on existing deployed code performing autonomous destruction and revival.
 
 ## Copyright
 

--- a/EIPS/eip-6046.md
+++ b/EIPS/eip-6046.md
@@ -37,9 +37,9 @@ Furthermore, with *Verkle trees*, accounts will be organised differently: accoun
 
   - Note that the account can still receive non-executable value transfers (such as coinbase transactions or other `SELFDESTRUCT`s).
 
-3. Modify `CREATE` and `CREATE2` such that while the nonce equals `2^64-1`, the address that the contract will be created at is incremented
+3. Modify `CREATE` and `CREATE2` such that while the nonce of the account creation address equals `2^64-1`, the account creation address is incremented by `1`
 
-5. Modify `CALL`, `STATICCALL`, `DELEGATECALL`, `EXTCODEHASH`, `EXTCODECOPY`, `EXTCODESIZE`, and `BALANCE` such that while the referenced account's nonce equals `2^64-1`, the address it refers to is incremented. These instructions cost an additional `10` gas, and another additional `10` gas each time this happens (in addition to the normal gas costs associated with accessing an account's data).
+5. Modify `CALL`, `STATICCALL`, `DELEGATECALL`, `EXTCODEHASH`, `EXTCODECOPY`, `EXTCODESIZE`, and `BALANCE` such that while the referenced account's nonce equals `2^64-1`, the referenced account is incremente by `1`. These instructions will also cost an additional `15` gas each time an account's nonce is checked (in addition to the normal gas costs associated with accessing an account's data).
 
 6. Rename the `SELFDESTRUCT` instruction to `DEACTIVATE`, because the semantics of "account revival" are changed: the old storage items will remain, and newly deployed code must be aware of this.
 


### PR DESCRIPTION
This changes EIP-6046 such that deactivation effectively clears a contract's memory, at the cost of additional gas costs. Basically, it turns deactivated contracts into symbolic links to other contracts.

This may or may not get used, hence why I am keeping this PR as a draft.

CC @axic