### PR TITLE
Fixes typos: 'contact' -> 'contract'

### DIFF
--- a/EIPS/eip-1444.md
+++ b/EIPS/eip-1444.md
@@ -19,7 +19,7 @@ An on-chain system for providing user feedback by converting machine-efficient c
 
 ## Motivation
 
-There are many cases where an end user needs feedback or instruction from a smart contact. Directly exposing numeric codes does not make for good UX or DX. If Ethereum is to be a truly global system usable by experts and lay persons alike, systems to provide feedback on what happened during a transaction are needed in as many languages as possible.
+There are many cases where an end user needs feedback or instruction from a smart contract. Directly exposing numeric codes does not make for good UX or DX. If Ethereum is to be a truly global system usable by experts and lay persons alike, systems to provide feedback on what happened during a transaction are needed in as many languages as possible.
 
 Returning a hard-coded string (typically in English) only serves a small segment of the global population. This standard proposes a method to allow users to create, register, share, and use a decentralized collection of translations, enabling richer messaging that is more culturally and linguistically diverse.
 

--- a/EIPS/eip-3690.md
+++ b/EIPS/eip-3690.md
@@ -51,7 +51,7 @@ This feature is introduced on the very same block [EIP-3540](./eip-3540.md) is e
 
 ### Validation rules
 
-> This section extends contact creation validation rules (as defined in EIP-3540).
+> This section extends contract creation validation rules (as defined in EIP-3540).
 
 4. The `jumpdests` section MUST be present if and only if the `code` section contains `JUMP` or `JUMPI` opcodes.
 5. If the `jumpdests` section is present it MUST directly precede the `code` section. In this case a valid EOF bytecode will have the form of `format, magic, version, [jumpdests_section_header], code_section_header, [data_section_header], 0, [jumpdests_section_contents], code_section_contents, [data_section_contents]`.

--- a/EIPS/eip-5252.md
+++ b/EIPS/eip-5252.md
@@ -41,7 +41,7 @@ The interaction pattern consists of 4 components for interaction; manager, facto
 
 Interaction contract pattern is defined with these contracts:
 - A soul-bound or account bound token contract to give access to interact with a financial contract with credentials
-- A manager contract that interacts first contact with an investor
+- A manager contract that interacts first contract with an investor
 - A factory contract that creates a financial contract for each user
 - A finance contract that can interact with the investor
 

--- a/assets/eip-3267/contracts/BaseLock.sol
+++ b/assets/eip-3267/contracts/BaseLock.sol
@@ -159,7 +159,7 @@ abstract contract BaseLock is
         _collateralContractAddress.safeTransferFrom(_from, address(this), _collateralTokenId, _amount, _data); // last against reentrancy attack
     }
 
-    /// Gather a DeFi profit of a token previous donated to this contact.
+    /// Gather a DeFi profit of a token previous donated to this contract.
     /// @param _collateralContractAddress The collateral ERC-1155 contract address.
     /// @param _collateralTokenId The collateral ERC-1155 token ID.
     /// @param _oracleId The oracle ID to whose ecosystem to donate to.

--- a/assets/eip-3267/contracts/BidOnAddresses.sol
+++ b/assets/eip-3267/contracts/BidOnAddresses.sol
@@ -13,7 +13,7 @@ import "./BaseBidOnAddresses.sol";
 /// - a combination of a collateral contract address and collateral token ID
 ///   (a counter of donated amount of collateral tokens, don't confuse with collateral tokens themselves)
 ///
-/// In functions of this contact `condition` is always a customer's original address.
+/// In functions of this contract `condition` is always a customer's original address.
 ///
 /// We receive funds in ERC-1155, see also https://github.com/vporton/wrap-tokens
 contract BidOnAddresses is BaseBidOnAddresses {


### PR DESCRIPTION
Fixes typos: 'contact' -> 'contract'