### PR TITLE
Update EIP-1444: Fix typo

### DIFF
--- a/EIPS/eip-1444.md
+++ b/EIPS/eip-1444.md
@@ -19,7 +19,7 @@ An on-chain system for providing user feedback by converting machine-efficient c
 
 ## Motivation
 
-There are many cases where an end user needs feedback or instruction from a smart contact. Directly exposing numeric codes does not make for good UX or DX. If Ethereum is to be a truly global system usable by experts and lay persons alike, systems to provide feedback on what happened during a transaction are needed in as many languages as possible.
+There are many cases where an end user needs feedback or instruction from a smart contract. Directly exposing numeric codes does not make for good UX or DX. If Ethereum is to be a truly global system usable by experts and lay persons alike, systems to provide feedback on what happened during a transaction are needed in as many languages as possible.
 
 Returning a hard-coded string (typically in English) only serves a small segment of the global population. This standard proposes a method to allow users to create, register, share, and use a decentralized collection of translations, enabling richer messaging that is more culturally and linguistically diverse.
 


### PR DESCRIPTION
Fixes typo: 'contact' -> 'contract'