### PR TITLE
Update EIP-3690: Fix typo

### DIFF
--- a/EIPS/eip-3690.md
+++ b/EIPS/eip-3690.md
@@ -51,7 +51,7 @@ This feature is introduced on the very same block [EIP-3540](./eip-3540.md) is e
 
 ### Validation rules
 
-> This section extends contact creation validation rules (as defined in EIP-3540).
+> This section extends contract creation validation rules (as defined in EIP-3540).
 
 4. The `jumpdests` section MUST be present if and only if the `code` section contains `JUMP` or `JUMPI` opcodes.
 5. If the `jumpdests` section is present it MUST directly precede the `code` section. In this case a valid EOF bytecode will have the form of `format, magic, version, [jumpdests_section_header], code_section_header, [data_section_header], 0, [jumpdests_section_contents], code_section_contents, [data_section_contents]`.


### PR DESCRIPTION
Fixes typo: 'contact' -> 'contract'