### PR TITLE
Remove terminating instructions validation

### DIFF
--- a/EIPS/eip-4750.md
+++ b/EIPS/eip-4750.md
@@ -125,10 +125,9 @@ If the code is valid EOF1, the following execution rules apply:
 In addition to container format validation rules above, we extend code section validation rules (as defined in [EIP-3670](./eip-3670.md)).
 
 1. Code validation rules of EIP-3670 are applied to every code section.
-2. List of allowed *terminating instructions* in EIP-3670 is extended to include `RETF` and `JUMPF`. (*Note that `CALLF` and `JUMPF`, like other instructions with immediates, cannot be truncated.*)
-3. Code section is invalid in case an immediate argument of any `CALLF` or `JUMPF` is greater than or equal to the total number of code sections.
-4. Code section is invalid in case an immediate argument of any `JUMPF` is such that `type[callee_section_index].outputs != type[caller_section_index].outputs`, i.e. it is allowed to only jump to functions with the same output type.
-5. `RJUMP`, `RJUMPI` and `RJUMPV` immediate argument value (jump destination relative offset) validation:
+2. Code section is invalid in case an immediate argument of any `CALLF` or `JUMPF` is greater than or equal to the total number of code sections.
+3. Code section is invalid in case an immediate argument of any `JUMPF` is such that `type[callee_section_index].outputs != type[caller_section_index].outputs`, i.e. it is allowed to only jump to functions with the same output type.
+4. `RJUMP`, `RJUMPI` and `RJUMPV` immediate argument value (jump destination relative offset) validation:
     1. Code section is invalid in case offset points to a position outside of section bounds.
     2. Code section is invalid in case offset points to one of two bytes directly following `CALLF` or `JUMPF` instruction.
 


### PR DESCRIPTION
We have a GitHub bot that automatically merges some PRs. It will merge yours immediately if certain criteria are met:

 - The PR edits only existing draft PRs.
 - The build passes.
 - Your GitHub username or email address is listed in the 'author' header of all affected PRs, inside <triangular brackets>.
 - If matching on email address, the email address is the one publicly listed on your GitHub profile.
