### PR TITLE
Update EIP-4337: fix typo desribed -> described

### DIFF
--- a/EIPS/eip-4337.md
+++ b/EIPS/eip-4337.md
@@ -38,7 +38,7 @@ This proposal takes a different approach, avoiding any adjustments to the consen
 
 * **UserOperation** - a structure that describes a transaction to be sent on behalf of a user. To avoid confusion, it is named "transaction".
   * Like a transaction, it contains "sender", "to", "calldata", "maxFeePerGas", "maxPriorityFee", "signature", "nonce"
-  * unlike transaction, it contains several other fields, desribed below
+  * unlike transaction, it contains several other fields, described below
   * also, the "nonce" and "signature" fields usage is not defined by the protocol, but by each account implementation
 * **Sender** - the account contract sending a user operation.
 * **EntryPoint** - a singleton contract to execute bundles of UserOperations. Bundlers/Clients whitelist the supported entrypoint.


### PR DESCRIPTION
Fixes typo: 'desribed' -> 'described'