### PR TITLE
EIP-6059: Add a note about inter-contract compatibility of EIP-6059

### DIFF
--- a/EIPS/eip-6059.md
+++ b/EIPS/eip-6059.md
@@ -405,7 +405,7 @@ The proposal enforces that a parent token can't be nested into one of its child 
 
 7. **How does this proposal differ from the other proposals trying to address a similar problem?**
 
-This interface allows for tokens to both be sent to and receive other tokens. The propose-accept and parent governed patterns allow for a more secure use. The backward compatibility is only added for EIP-721, allowing for a simpler interface.
+This interface allows for tokens to both be sent to and receive other tokens. The propose-accept and parent governed patterns allow for a more secure use. The backward compatibility is only added for EIP-721, allowing for a simpler interface. The proposal also allows for different collections to inter-operate, meaning that nesting is not locked to a single smart contract, but can be executed between completely separate NFT collections.
 
 ### Propose-Commit pattern for child token management
 


### PR DESCRIPTION
The note about EIP-6059 being able to support inter-operation between multiple NFT collections was added.
