### PR TITLE
Update EIP-6049: fix (small) typo

### DIFF
--- a/EIPS/eip-6049.md
+++ b/EIPS/eip-6049.md
@@ -29,7 +29,7 @@ The Ethereum Blog and other official sources have not provided any warning to de
 
 ## Backwards Compatibility
 
-This EIP udpates non-normative text in the Yellow Paper. No changes to clients is applicable.
+This EIP updates non-normative text in the Yellow Paper. No changes to clients is applicable.
 
 ## Security Considerations
 


### PR DESCRIPTION
Changes "udpates" to "updates"
