### PR TITLE
Add EIP-6206: EOF - JUMPF instruction

### DIFF
--- a/EIPS/eip-6206.md
+++ b/EIPS/eip-6206.md
@@ -24,12 +24,14 @@ It is common for function to make a call at the end of the routine only to then 
 a new instruction `JUMPF (0xb2)` is introduced.
 
 ### Execution Semantics
+
 1. Has one immediate argument, `code_section_index`, encoded as a 16-bit unsigned big-endian value.
 2. If data stack size exceeds `1024 - type[code_section_index].max_stack_height` (i.e. if the called function may exceed the global stack height limit), execution results in exceptional halt. This also guarantees that the stack height after the call is within the limits.
 3. Charges 5 gas.
 4. Pops nothing and pushes nothing to data stack.
 
 ### Code Validation
+
 Let the definition of `type[i]` be inherited from [EIP-4750](./eip-4750.md) and define `stack_height` to be the height of the stack at a certain instruction during the instruction flow traversal if the data stack at the start of the function were equal to `type[i].inputs`.
 * Immediate argument of `JUMPF` MUST be greater than or equal to the total number of code sections.
 * Stack height at `JUMPF` MUST be greater than or equal to `type[code_section_index].inputs`.

--- a/EIPS/eip-6206.md
+++ b/EIPS/eip-6206.md
@@ -33,6 +33,7 @@ a new instruction `JUMPF (0xb2)` is introduced.
 ### Code Validation
 
 Let the definition of `type[i]` be inherited from [EIP-4750](./eip-4750.md) and define `stack_height` to be the height of the stack at a certain instruction during the instruction flow traversal if the data stack at the start of the function were equal to `type[i].inputs`.
+
 * Immediate argument of `JUMPF` MUST be greater than or equal to the total number of code sections.
 * Stack height at `JUMPF` MUST be greater than or equal to `type[code_section_index].inputs`.
 * `type[current_section_index].outputs` MUST equal `stack_height - type[code_section_index].inputs + type[code_section_index].outputs`. This means that `code_section_index` can output less stack elements than the original code section called by the top element on the return stack if the `current_section_index` code section leaves the delta `type[current_section_index] - type[code_section_index]` element(s) on the stack.

--- a/EIPS/eip-6206.md
+++ b/EIPS/eip-6206.md
@@ -37,7 +37,7 @@ Let the definition of `type[i]` be inherited from [EIP-4750](./eip-4750.md) and 
 * Immediate argument of `JUMPF` MUST be greater than or equal to the total number of code sections.
 * Stack height at `JUMPF` MUST be greater than or equal to `type[code_section_index].inputs`.
 * `type[current_section_index].outputs` MUST equal `stack_height - type[code_section_index].inputs + type[code_section_index].outputs`. This means that `code_section_index` can output less stack elements than the original code section called by the top element on the return stack if the `current_section_index` code section leaves the delta `type[current_section_index] - type[code_section_index]` element(s) on the stack.
-* Extend [EIP-4200](./eip-4200) code validation to fail if any `RJUMP*` offset points to one of the two bytes directly following a `JUMPF` instruction.
+* Extend [EIP-4200](./eip-4200.md) code validation to fail if any `RJUMP*` offset points to one of the two bytes directly following a `JUMPF` instruction.
 
 ## Rationale
 

--- a/EIPS/eip-6206.md
+++ b/EIPS/eip-6206.md
@@ -1,9 +1,9 @@
 ---
-eip: <to be assigned>
+eip: 6206
 title: EOF - JUMPF instruction
 description: Introduces instruction for chaining function calls.
 author: Andrei Maiboroda (@gumb0), Alex Beregszaszi (@axic), Paweł Bylica (@chfast), Matt Garnett (@lightclient)
-discussions-to: <URL>
+discussions-to: https://ethereum-magicians.org/t/eip-4750-eof-functions/8195
 status: Draft
 type: Standards Track
 category: Core

--- a/EIPS/eip-6206.md
+++ b/EIPS/eip-6206.md
@@ -13,31 +13,31 @@ requires: 4750, 5450
 
 ## Abstract
 
-Allow tail call optimizations in [EOF functions](./eip-4750.md) by introducing a new instruction `JUMPF`, which jumps to a code sections without adding a new return stack frame.
+This EIP allows for tail call optimizations in EOF functions ([EIP-4750](./eip-4750.md)) by introducing a new instruction `JUMPF`, which jumps to a code section without adding a new return stack frame.
 
 ## Motivation
 
-It is common for function to make a call at the end of the routine only to then return. `JUMPF` optimizes this behavior by changing code sections without needing to update the return stack.
+It is common for functions to make a call at the end of the routine only to then return. `JUMPF` optimizes this behavior by changing code sections without needing to update the return stack.
 
 ## Specification
 
-a new instruction `JUMPF (0xb2)` is introduced.
+A new instruction, `JUMPF (0xb2)`, is introduced.
 
 ### Execution Semantics
 
-1. Has one immediate argument, `code_section_index`, encoded as a 16-bit unsigned big-endian value.
-2. If data stack size exceeds `1024 - type[code_section_index].max_stack_height` (i.e. if the called function may exceed the global stack height limit), execution results in exceptional halt. This also guarantees that the stack height after the call is within the limits.
-3. Charges 5 gas.
-4. Pops nothing and pushes nothing to data stack.
+1. `JUMPF` has one immediate argument, `code_section_index`, encoded as a 16-bit unsigned big-endian value.
+2. If the data stack size exceeds `1024 - type[code_section_index].max_stack_height` (i.e. if the called function may exceed the global stack height limit), execution results in an exceptional halt. This guarantees that the stack height after the call is within the limits.
+3. `JUMPF` costs 5 gas.
+4. `JUMPF` neither pops nor pushes anything to the data stack.
 
 ### Code Validation
 
 Let the definition of `type[i]` be inherited from [EIP-4750](./eip-4750.md) and define `stack_height` to be the height of the stack at a certain instruction during the instruction flow traversal if the data stack at the start of the function were equal to `type[i].inputs`.
 
-* Immediate argument of `JUMPF` MUST be greater than or equal to the total number of code sections.
-* Stack height at `JUMPF` MUST be greater than or equal to `type[code_section_index].inputs`.
+* The immediate argument of `JUMPF` MUST be greater than or equal to the total number of code sections.
+* The stack height at `JUMPF` MUST be greater than or equal to `type[code_section_index].inputs`.
 * `type[current_section_index].outputs` MUST equal `stack_height - type[code_section_index].inputs + type[code_section_index].outputs`. This means that `code_section_index` can output less stack elements than the original code section called by the top element on the return stack if the `current_section_index` code section leaves the delta `type[current_section_index] - type[code_section_index]` element(s) on the stack.
-* Extend [EIP-4200](./eip-4200.md) code validation to fail if any `RJUMP*` offset points to one of the two bytes directly following a `JUMPF` instruction.
+* The code validation defined in [EIP-4200](./eip-4200.md) also fails if any `RJUMP*` offset points to one of the two bytes directly following a `JUMPF` instruction.
 
 ## Rationale
 
@@ -51,7 +51,7 @@ This change is backward compatible as EOF does not allow undefined instructions 
 
 ## Security Considerations
 
-None.
+Needs discussion.
 
 ## Copyright
 

--- a/EIPS/jumpf.md
+++ b/EIPS/jumpf.md
@@ -1,0 +1,55 @@
+---
+eip: <to be assigned>
+title: EOF - JUMPF instruction
+description: Introduces instruction for chaining function calls.
+author: Andrei Maiboroda (@gumb0), Alex Beregszaszi (@axic), Paweł Bylica (@chfast), Matt Garnett (@lightclient)
+discussions-to: <URL>
+status: Draft
+type: Standards Track
+category: Core
+created: 2022-12-21
+requires: 4750, 5450
+---
+
+## Abstract
+
+Allow tail call optimizations in [EOF functions](./eip-4750.md) by introducing a new instruction `JUMPF`, which jumps to a code sections without adding a new return stack frame.
+
+## Motivation
+
+It is common for function to make a call at the end of the routine only to then return. `JUMPF` optimizes this behavior by changing code sections without needing to update the return stack.
+
+## Specification
+
+a new instruction `JUMPF (0xb2)` is introduced.
+
+### Execution Semantics
+1. Has one immediate argument, `code_section_index`, encoded as a 16-bit unsigned big-endian value.
+2. If data stack size exceeds `1024 - type[code_section_index].max_stack_height` (i.e. if the called function may exceed the global stack height limit), execution results in exceptional halt. This also guarantees that the stack height after the call is within the limits.
+3. Charges 5 gas.
+4. Pops nothing and pushes nothing to data stack.
+
+### Code Validation
+Let the definition of `type[i]` be inherited from [EIP-4750](./eip-4750.md) and define `stack_height` to be the height of the stack at a certain instruction during the instruction flow traversal if the data stack at the start of the function were equal to `type[i].inputs`.
+* Immediate argument of `JUMPF` MUST be greater than or equal to the total number of code sections.
+* Stack height at `JUMPF` MUST be greater than or equal to `type[code_section_index].inputs`.
+* `type[current_section_index].outputs` MUST equal `stack_height - type[code_section_index].inputs + type[code_section_index].outputs`. This means that `code_section_index` can output less stack elements than the original code section called by the top element on the return stack if the `current_section_index` code section leaves the delta `type[current_section_index] - type[code_section_index]` element(s) on the stack.
+* Extend [EIP-4200](./eip-4200) code validation to fail if any `RJUMP*` offset points to one of the two bytes directly following a `JUMPF` instruction.
+
+## Rationale
+
+### Allowing `JUMPF` to section with less outputs
+
+As long as `JUMPF` prepares the delta `type[current_section_index] - type[code_section_index]` stack elements before changing code sections, it is possible to jump to a section with less outputs than was originally entered via `CALLF`. This will reduce duplicated code as it will allow compilers more flexibility during code generation such that certain helpers can be used generically by functions, regardless of their output values.
+
+## Backwards Compatibility
+
+This change is backward compatible as EOF does not allow undefined instructions to be used or deployed, meaning no contracts will be affected.
+
+## Security Considerations
+
+None.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](../LICENSE.md).


### PR DESCRIPTION
This is a follow up from #6205 which removed `JUMPF` specification from EIP-4750. We have reintroduced it with a direct dependency to EIP-5450 to avoid specifying any runtime validation semantics (which would ultimately be discarded with EIP-5450).