### PR TITLE
Update EIP-5115: Minor correction on interface

### DIFF
--- a/EIPS/eip-5115.md
+++ b/EIPS/eip-5115.md
@@ -127,11 +127,6 @@ On top of the definitions above for GYGPs, we need to define 2 more concepts:
 
 ```solidity
 interface IStandardizedYield {
-    enum AssetType {
-        TOKEN,
-        LIQUIDITY
-    }
-
     event Deposit(
         address indexed caller,
         address indexed receiver,


### PR DESCRIPTION
Minor correction on the interface removing the unused AssetType enum.