### PR TITLE
Remove `pc` instruction from eof

### DIFF
--- a/EIPS/eip-3670.md
+++ b/EIPS/eip-3670.md
@@ -45,7 +45,6 @@ The EOF1 format provides following forward compatibility properties:
 This feature is introduced on the very same block EIP-3540 is enabled, therefore every EOF1-compatible bytecode MUST be validated according to these rules.
 
 1. Previously deprecated instructions `CALLCODE` (0xf2) and `SELFDESTRUCT` (0xff) are invalid and their opcodes are undefined.
-
 2. At contract creation time *instructions validation* is performed on both *initcode* and *code*. The code is invalid if any of the checks below fails. For each instruction:
    1. Check if the opcode is defined. The `INVALID` (0xfe) is considered defined.
    2. Check if all instructions' immediate bytes are present in the code (code does not end in the middle of instruction).

--- a/EIPS/eip-4200.md
+++ b/EIPS/eip-4200.md
@@ -63,7 +63,7 @@ Because the destinations are validated upfront, the cost of these instructions a
 
 We chose relative addressing in order to support code which is relocatable. This also means a code snippet can be injected. A technique seen used prior to this EIP to achieve the same goal was to inject code like `PUSHn PC ADD JUMPI`.
 
-We do not see any significant downside to relative addressing, but it also opens possibility to the deprecation of the `PC` instruction.
+We do not see any significant downside to relative addressing and it allows us to also deprecate the `PC` instruction.
 
 ### Immediate size
 

--- a/EIPS/eip-4750.md
+++ b/EIPS/eip-4750.md
@@ -133,9 +133,11 @@ In addition to container format validation rules above, we extend code section v
 
 ### Disallowed instructions
 
-Dynamic jump instructions `JUMP` (`0x56`) and `JUMPI` (`0x57`) and invalid and their opcodes are undefined.
+Dynamic jump instructions `JUMP` (`0x56`) and `JUMPI` (`0x57`) are invalid and their opcodes are undefined.
 
 `JUMPDEST` (`0x5b`) instruction is renamed to `NOP` ("no operation") without the change in behaviour: it pops nothing and pushes nothing to data stack and has no other effects except for `PC` increment and charging 1 gas.
+
+`PC` (0x58) instruction becomes invalid and its opcode is undefined.
 
 *Note:* This change implies that JUMPDEST analysis is no longer required for EOF code.
 


### PR DESCRIPTION
It seems like after the decision was made to add back `pc` instruction, people are [leaning more](https://discord.com/channels/595666850260713488/706868829900505180/1055540534883651697) again towards removing it from EOF. This PR accomplishes that.