### PR TITLE
Clarify that initcode which fails validation still pays 3860 `initcode_cost`

### DIFF
--- a/EIPS/eip-3540.md
+++ b/EIPS/eip-3540.md
@@ -163,7 +163,7 @@ For clarity, the *container* refers to the complete account code, while *code* r
 3. `PC` returns the current position within the *code*.
 4. `CODECOPY`/`CODESIZE`/`EXTCODECOPY`/`EXTCODESIZE`/`EXTCODEHASH` keeps operating on the entire *container*.
 5. The input to `CREATE`/`CREATE2` is still the entire *container*.
-6. The size limit for deployed code as specified in [EIP-170](./eip-170.md) and for init code as specified in [EIP-3860](./eip-3860.md) is applied to the entire *container* size, not to the *code* size.
+6. The size limit for deployed code as specified in [EIP-170](./eip-170.md) and for initcode as specified in [EIP-3860](./eip-3860.md) is applied to the entire *container* size, not to the *code* size. This also means if initcode validation fails, it is still charged the EIP-3860 `initcode_cost`.
 
 (*Remark:* Due to [EIP-4750](./eip-4750.md), `JUMP` and `JUMPI` are disabled and therefore are not discussed in relation to EOF.)
 


### PR DESCRIPTION
There was a comment on discord to clarify the order of operations w.r.t. failed initcode validation and metering.