### PR TITLE
Revert 6009

### DIFF
--- a/EIPS/eip-3651.md
+++ b/EIPS/eip-3651.md
@@ -4,7 +4,7 @@ title: Warm COINBASE
 description: Starts the `COINBASE` address warm
 author: William Morriss (@wjmelements)
 discussions-to: https://ethereum-magicians.org/t/eip-3651-warm-coinbase/6640
-status: Stagnant
+status: Review
 type: Standards Track
 category: Core
 created: 2021-07-12


### PR DESCRIPTION

The annoying bot marked this EIP stagnant.
It hasn't changed for so long, in part due to its deferred inclusion; it was CFI for Shanghai before work began on the Merge.
#### Changes
Un-stagnant CFI EIP