### PR TITLE
Center layout

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -25,6 +25,10 @@
 }
 
 main.page-content {
+  max-width: 960px;
+  display: flex;
+  align-self: center;
+
   div.wrapper {
     max-width: unset;
   }


### PR DESCRIPTION
# Description

This pull request centers layout of the EIP website.

# Motivation

The current layout is very hard to read on bigger screens. For example, an ultrawide monitor of 2560x1080 resolution displayed the website as the following:

![screenshot-2022-12-28-12-26-36](https://user-images.githubusercontent.com/3029017/209834463-69626693-6951-4524-92c3-bcd39e6b85df.png)

# Proof of concept

The proposed change fixes the maximum width of the content to 960px and centers the layout on all screen sizes:

![screenshot-2022-12-28-12-27-31](https://user-images.githubusercontent.com/3029017/209834621-d786589c-435d-4f42-8eda-b628c65ac51d.png)
