### PR TITLE
Explained typesize in the v.1 header

### DIFF
--- a/EIPS/eip-3540.md
+++ b/EIPS/eip-3540.md
@@ -123,7 +123,7 @@ type_section := (inputs, outputs, max_stack_height)+
 | magic             | 2 bytes  | 0xEF00        | EOF prefix                                                                         |
 | version           | 1 byte   | 0x01          | EOF version                                                                        |
 | kind_type         | 1 byte   | 0x01          | kind marker for EIP-4750 type section header                                       |
-| type_size         | 2 bytes  | 0x0003-0xFFFF | uint16 denoting the length of the type section content                             |
+| type_size         | 2 bytes  | 0x0004-0xFFFC | uint16 denoting the length of the type section content, 4 bytes per code segment   |
 | kind_code         | 1 byte   | 0x02          | kind marker for code size section                                                  |
 | num_code_sections | 2 bytes  | 0x0001-0xFFFF | uint16 denoting the number of the code sections                                    |
 | code_size         | 2 bytes  | 0x0001-0xFFFF | uint16 denoting the length of the code section content                             |


### PR DESCRIPTION
Also, fixed the minimum (0003 -> 0004) and maximum (FFFF -> FFFC) because it has to be divisible by four

When opening a pull request to submit a new EIP, please use the suggested template: https://github.com/ethereum/EIPs/blob/master/eip-template.md
