### PR TITLE
Update EIP-4337: fix miscellaneous typos

### DIFF
--- a/EIPS/eip-4337.md
+++ b/EIPS/eip-4337.md
@@ -36,9 +36,9 @@ This proposal takes a different approach, avoiding any adjustments to the consen
 
 ### Definitions
 
-* **UserOperation** - a structure that describes a transaction to be sent on behalf of a user. To avoid confusion, it is named "transaction".
+* **UserOperation** - a structure that describes a transaction to be sent on behalf of a user. To avoid confusion, it is not named "transaction".
   * Like a transaction, it contains "sender", "to", "calldata", "maxFeePerGas", "maxPriorityFee", "signature", "nonce"
-  * unlike transaction, it contains several other fields, described below
+  * unlike a transaction, it contains several other fields, described below
   * also, the "nonce" and "signature" fields usage is not defined by the protocol, but by each account implementation
 * **Sender** - the account contract sending a user operation.
 * **EntryPoint** - a singleton contract to execute bundles of UserOperations. Bundlers/Clients whitelist the supported entrypoint.
@@ -203,7 +203,7 @@ In the execution loop, the `handleOps` call must perform the following steps for
 ![](../assets/eip-4337/image1.png)
 
 Before accepting a `UserOperation`, bundlers should use an RPC method to locally call the `simulateValidation` function of the entry point, to verify that the signature is correct and the operation actually pays fees; see the [Simulation section below](#simulation) for details.
-A node/bundler SHOULD drop (and not add to the mempool) `UserOperation` that fails the validation
+A node/bundler SHOULD drop (not add to the mempool) a `UserOperation` that fails the validation
 
 ### Extension: paymasters
 


### PR DESCRIPTION
Fixing small typos:

"To avoid confusion, it is **not** named "transaction".

"unlike **a** transaction, it contains several other fields, described below"

"A node/bundler SHOULD drop (~~not~~ add to the mempool) a `UserOperation`"