### PR TITLE
add material to EIP-5630

### DIFF
--- a/EIPS/eip-5630.md
+++ b/EIPS/eip-5630.md
@@ -17,7 +17,7 @@ This EIP proposes a new way to encrypt and decrypt using Ethereum keys. This EIP
 
 ## Motivation
 
-We discuss a few motivating examples. One key motivation is direct-to-address encryption on Ethereum. Using our EIP, one can directly send encrypted messages to some desired recipient on-chain, without having a prior direct channel to that recipient. (Note that in this EIP, we standardize _only_ the encryption procedure—that is, the generation of the ciphertext—and _not_ how exactly the on-chain message should be sent. In practice, ideally, smart-contract infrastructure will be set up for this purpose; barring this, encryptors could make use of the raw `data` field.)
+We discuss a few motivating examples. One key motivation is direct-to-address encryption on Ethereum. Using our EIP, one can directly send encrypted messages to some desired recipient on-chain, without having a prior direct channel to that recipient. (Note that in this EIP, we standardize _only_ the encryption procedure—that is, the generation of the ciphertext—and _not_ how exactly the on-chain message should be sent. In practice, ideally, smart-contract infrastructure will be set up for this purpose; barring this, encryptors could make use of the raw `data` field available in each standard transfer.)
 
 We discuss a second sort of example. In a certain common design pattern, a dApp generates a fresh secret on behalf of a user. It is of interest if, instead of forcing this user to independently store, safeguard, and back up this latter secret, the dApp may instead encrypt this secret to a public key which the user controls—and whose secret key, crucially, resides within the user's HD wallet hierarchy—and then post the resulting ciphertext to secure storage (e.g., on-chain).  This design pattern allows the dApp/user to bootstrap the security of the _fresh_ secret onto the security of the user's existing HD wallet seed phrase, which the user has already gone through the trouble of safeguarding and storing. This represents a far lower UX burden than forcing the user to store and manage fresh keys directly (which can, and often does, lead to loss of funds). We note that this design pattern described above is used today by, various dApps (e.g., Tornado Cash).
 
@@ -68,6 +68,29 @@ where `account` is as above, and `encryptedMessage` is a JSON object with the pr
 - decode the resulting binary plaintext as a `utf-8` string, and return it.
 
 Test vectors are given below.
+
+### Encrypting to a smart contract
+
+In light of account abstraction, EIP-4337, and the advent of smart-contract wallets, we moreover specify a way to encrypt to a contract.
+More precisely, we specify a way for a contract to _advertise_ how it would like encryptions to it to be constructed. This should be viewed as an analogue of EIP-1271, but for encryption, as opposed to signing.
+
+Our specification is as follows.
+```solidity
+pragma solidity ^0.8.0;
+
+contract ERC5630 {
+  /**
+   * @dev Should return an encryption of the provided plaintext, using the provided randomness.
+   * @param plaintext_      Plaintext to be encrypted
+   * @param randomness_     Entropy to be used during encryption
+  function encryptTo(bytes memory plaintext, bytes32 randomness)
+    public
+    view
+    returns (string memory version, bytes memory ciphertext);
+}
+```
+Each contract should implement `encryptToAccount` as it desires; for example, it could use our specification above (i.e., for some fixed public key depending on the contract), or something arbitrary.
+
 ## Rationale
 
 There is _no security proof_ for a scheme which simultaneously invokes signing on the `secp256k1` curve and encryption on the `ec25519` curve, and where _the same secret key is moreover used in both cases_. Though no attacks are known, it is not desirable to use a scheme which lacks a proof in this way.

--- a/EIPS/eip-5630.md
+++ b/EIPS/eip-5630.md
@@ -45,6 +45,7 @@ request({
 ```
 
 where `account` is a standard 20-byte, `0x`-prefixed, hex-encoded Ethereum account, the client should operate as follows:
+
 - find the secret signing key `sk` corresponding to the Ethereum account `account`, or else return an error if none exists.
 - compute the `secp256k1` public key corresponding to `sk`.
 - return this public key in compressed, `0x`-prefixed, hex-encoded form.
@@ -59,6 +60,7 @@ request({
 ```
 
 where `account` is as above, and `encryptedMessage` is a JSON object with the properties `version` (an arbitrary string) and `ciphertext` (a `0x`-prefixed, hex-encoded, bytes-like string), the client should operate as follows:
+
 - perform a `switch` on the value `encryptedMessage.version`. if it equals:
    - `secp256k1-sha512kdf-aes256cbc-hmacsha256`, then break from the switch and proceed as in the bullets below;
    - `x25519-xsalsa20-poly1305`, then, optionally, use #1098's specification _if_ backwards compatibility is desired, and otherwise fallthrough;
@@ -71,10 +73,11 @@ Test vectors are given below.
 
 ### Encrypting to a smart contract
 
-In light of account abstraction, EIP-4337, and the advent of smart-contract wallets, we moreover specify a way to encrypt to a contract.
-More precisely, we specify a way for a contract to _advertise_ how it would like encryptions to it to be constructed. This should be viewed as an analogue of EIP-1271, but for encryption, as opposed to signing.
+In light of account abstraction, [EIP-4337](eip-4337.md), and the advent of smart-contract wallets, we moreover specify a way to encrypt to a contract.
+More precisely, we specify a way for a contract to _advertise_ how it would like encryptions to it to be constructed. This should be viewed as an analogue of [EIP-1271](eip-1271.md), but for encryption, as opposed to signing.
 
 Our specification is as follows.
+
 ```solidity
 pragma solidity ^0.8.0;
 
@@ -89,6 +92,7 @@ contract ERC5630 {
     returns (string memory version, bytes memory ciphertext);
 }
 ```
+
 Each contract should implement `encryptToAccount` as it desires; for example, it could use our specification above (i.e., for some fixed public key depending on the contract), or something arbitrary.
 
 ## Rationale
@@ -108,6 +112,7 @@ Indeed, it is possible to recover an account's `secp256k1` public key directly f
 - **Only applies when you fail to check a point is on the curve.** But this is inapplicable for us anyway, since we use compressed points (see above).
 
 ## Backwards Compatibility
+
 The previous EIP stipulated that encryption and decryption requests contain a `version` string. Our proposal merely adds a case for this string; encryption and decryption requests under the existing scheme will be handled identically.
 The previous proposal did _not_ include a version string in `encryptionPublicKey`, and merely returned the `ec25519` public key directly as a string. We thus propose to immediately return the `secp256k1` public key, overwriting the previous behavior.
 It is unlikely that this will be an issue, since encryption keys need be newly retrieved _only_ upon the time of encryption; on the other hand, _new_ ciphertexts will be generated using our new approach.
@@ -167,7 +172,9 @@ request({
 should return the string `I use Firn Protocol to gain privacy on Ethereum.`.
 
 ## Security Considerations
+
 Our proposal uses heavily standardized algorithms and follows all best practices.
 
 ## Copyright
+
 Copyright and related rights waived via [CC0](../LICENSE.md).

--- a/EIPS/eip-5630.md
+++ b/EIPS/eip-5630.md
@@ -13,37 +13,24 @@ created: 2022-09-07
 
 ## Abstract
 
-This EIP proposes a new way to encrypt and decrypt using Ethereum keys. This EIP uses separate, unlinkable, pseudorandom keys for signing and encryption; it uses _only_ the `secp256k1` curve, and it uses a standardized version of ECIES. In contrast, other EIPs reused secret keys across both signing and encryption, and moreover reused the same secret key across both the `secp256k1` and `ec25519` curves.
+This EIP proposes a new way to encrypt and decrypt using Ethereum keys. This EIP uses _only_ the `secp256k1` curve, and it uses a standardized version of ECIES. In contrast, a previous EIPs used the same secret key, in both signing and encryption, on two _different_ curves (namely, `secp256k1` and `ec25519`).
 
 ## Motivation
 
-We discuss a few motivating examples. In a certain common design pattern, a dApp generates a fresh secret on behalf of a user. It is of interest if, instead of forcing this user to independently store, safeguard, and back up this latter secret, the dApp may instead encrypt this secret to a public key which the user controls—and whose secret key, crucially, can be derived deterministically from the user's HD wallet hierarchy—and then post the resulting ciphertext to secure storage (e.g., on-chain).
+We discuss a few motivating examples. One key motivation is direct-to-address encryption on Ethereum. Using our EIP, one can directly send encrypted messages to some desired recipient on-chain, without having a prior direct channel to that recipient. (Note that in this EIP, we standardize _only_ the encryption procedure—that is, the generation of the ciphertext—and _not_ how exactly the on-chain message should be sent. In practice, ideally, smart-contract infrastructure will be set up for this purpose; barring this, encryptors could make use of the raw `data` field.)
 
-This design pattern allows the dApp/user to bootstrap the security of the _fresh_ secret onto the security of the user's existing HD wallet seed phrase, which the user has already gone through the trouble of safeguarding and storing. This represents a far lower UX burden than forcing the user to store and manage fresh keys directly (which can, and often does, lead to loss of funds). We note that this _exact_ design pattern described above is used today by, e.g., Tornado Cash.
-
-As a separate motivation, we mention the possibility of dApps which facilitate end-to-end encrypted messaging.
+We discuss a second sort of example. In a certain common design pattern, a dApp generates a fresh secret on behalf of a user. It is of interest if, instead of forcing this user to independently store, safeguard, and back up this latter secret, the dApp may instead encrypt this secret to a public key which the user controls—and whose secret key, crucially, resides within the user's HD wallet hierarchy—and then post the resulting ciphertext to secure storage (e.g., on-chain).  This design pattern allows the dApp/user to bootstrap the security of the _fresh_ secret onto the security of the user's existing HD wallet seed phrase, which the user has already gone through the trouble of safeguarding and storing. This represents a far lower UX burden than forcing the user to store and manage fresh keys directly (which can, and often does, lead to loss of funds). We note that this design pattern described above is used today by, various dApps (e.g., Tornado Cash).
 
 ## Specification
 
-We describe our approach here; we compare our approach to other EIPs in the **Rationale** section below.
+We describe our approach here; we compare our approach to prior EIPs in the **Rationale** section below.
 
-We use the `secp256k1` curve for both signing and encryption (with different keys, see below).
-In the latter case, we use ECIES; specifically, we use a standardized variant.
-Specifically, we propose the choices:
+We use the `secp256k1` curve for both signing and encryption.
+For encryption, we use ECIES. Specifically, we propose the standardized choices:
 
 - the KDF `ANSI-X9.63-KDF`, where the hash function `SHA-512` is used,
 - the HMAC `HMAC–SHA-256–256 with 32 octet or 256 bit keys`,
 - the symmetric encryption scheme `AES–256 in CBC mode`.
-
-We finally describe a method to derive encryption secret keys deterministically—but pseudorandomly—from signing keys, in such a way that a natural one-to-one relationship obtains between these keys (this latter property is essential, since it allows Ethereum accounts to be used as handles onto encryption/decryption keys, as both the former and current API interfaces do).
-Indeed, we propose that, given a signing private key _sk_ ∈ 𝔽_q—which is naturally represented as a 32-byte big-endian byte string—the corresponding decryption key _dk_ ∈ 𝔽_q be generated as the 32-byte secret:
-
-```solidity
-    dk := ANSI-X9.63-KDF(sk),
-```
-
-where moreover the _Ethereum `keccak256`_ hash is used for this KDF. This latter decision is essentially for implementation convenience; indeed, MetaMask's `eth-simple-keyring` already has something close to this functionality built in, and it requires only a minimal code change (see our implementation below).
-We set _SharedInfo_ to be empty here.
 
 We propose that the binary, _concatenated_ serialization mode for ECIES ciphertexts be used, both for encryption and decryption, where moreover elliptic curve points are _compressed_. This approach is considerably more space-efficient than the prior approach, which outputted a stringified JSON object (itself containing base64-encoded fields).
 We moreover propose that binary data be serialized to and from `0x`-prefixed hex strings. We moreover use `0x`-prefixed hex strings to specify private keys and public keys, and represent public keys in compressed form. We represent Ethereum accounts in the usual way (`0x`-prefixed, 20-byte hex strings).
@@ -58,10 +45,9 @@ request({
 ```
 
 where `account` is a standard 20-byte, `0x`-prefixed, hex-encoded Ethereum account, the client should operate as follows:
- - find the secret signing key `sk` corresponding to the Ethereum account `account`, or else return an error if none exists.
- - compute the 32-byte secret `dk := ANSI-X9.63-KDF(sk)`, where the `keccak256` hash is used in the KDF.
- - compute the `secp256k1` public key corresponding to `dk`.
- - return this public key in compressed, `0x`-prefixed, hex-encoded form.
+- find the secret signing key `sk` corresponding to the Ethereum account `account`, or else return an error if none exists.
+- compute the `secp256k1` public key corresponding to `sk`.
+- return this public key in compressed, `0x`-prefixed, hex-encoded form.
 
 On the request
 
@@ -73,45 +59,50 @@ request({
 ```
 
 where `account` is as above, and `encryptedMessage` is a JSON object with the properties `version` (an arbitrary string) and `ciphertext` (a `0x`-prefixed, hex-encoded, bytes-like string), the client should operate as follows:
- - perform a `switch` on the value `encryptedMessage.version`. if it equals:
-   - `x25519-xsalsa20-poly1305`, then use #1098's specification;
-   - `secp256k1-sha512kdf-aes256cbc-hmacsha256`, then proceed as described below;
-   - if it equals neither, throw an error.
- - find the secret key `sk` corresponding to the Ethereum account `account`, or else return an error if none exists.
- - compute the 32-byte secret `dk := ANSI-X9.63-KDF(sk)`, where the `keccak256` hash is used in the KDF.
- - using `dk`, perform an ECIES decryption of `encryptedMessage.ciphertext`, where the above choices of parameters are used.
- - decode the resulting binary plaintext as a `utf-8` string, and return it.
+- perform a `switch` on the value `encryptedMessage.version`. if it equals:
+   - `secp256k1-sha512kdf-aes256cbc-hmacsha256`, then break from the switch and proceed as in the bullets below;
+   - `x25519-xsalsa20-poly1305`, then, optionally, use #1098's specification _if_ backwards compatibility is desired, and otherwise fallthrough;
+   - `default`, throw an error.
+- find the secret key `sk` corresponding to the Ethereum account `account`, or else return an error if none exists.
+- using `sk`, perform an ECIES decryption of `encryptedMessage.ciphertext`, where the above choices of parameters are used.
+- decode the resulting binary plaintext as a `utf-8` string, and return it.
 
 Test vectors are given below.
 ## Rationale
 
 There is _no security proof_ for a scheme which simultaneously invokes signing on the `secp256k1` curve and encryption on the `ec25519` curve, and where _the same secret key is moreover used in both cases_. Though no attacks are known, it is not desirable to use a scheme which lacks a proof in this way.
-Certain papers have studied the reuse of the same key in signing and encryption, but where _the same curve is used in both_ (e.g., in the context of EMV payments). Those papers have found the joint scheme to be secure in the generic group model.
-Though this result provides _some level of_ assurance of security of this joint scheme (where, we stress, _only one_ curve is used), it is at least as secure to use different, pseudorandomly unlinkable keys for signing and encryption. Indeed, we note that if the hash function is modeled as a random oracle, then each decryption key `dk` is completely random, and in particular uncorrelated with its corresponding signing key.
+We, instead, propose the reuse of the same key in signing and encryption, but where _the same curve is used in both_. This very setting has been studied in prior work; see, e.g., Degabriele, Lehmann, Paterson, Smart and Strefler, _On the Joint Security of Encryption and Signature in EMV_, 2011. That work found this joint scheme to be secure in the generic group model.
+We note that this very joint scheme (i.e., using ECDSA and ECIES on the same curve) is used live in production in EMV payments.
+
+We now discuss a few further aspects of our approach.
+
+**On-chain public key discovery.** Our proposal has an important feature whereby an encryption _to_ some account can be constructed whenever that account has signed at least one transaction.
+Indeed, it is possible to recover an account's `secp256k1` public key directly from any signature on behalf of that account.
+
+**Twist attacks.** A certain GitHub post by Christian Lundkvist warns against "twist attacks" on the `secp256k1` curve. These attacks are not applicable to this EIP, for multiple _distinct_ reasons, which we itemize:
+- **Only applies to ECDH, not ECIES.** This attack only applies to a scenario in which an attacker can induce a victim to exponentiate an attacker-supplied point by a sensitive scalar, and then moreover send the result back to the attacker. But this pattern only happens in ECDH, and never ECIES. Indeed, in ECIES, we recall that the only sensitive Diffie–Hellman operation happens during decryption, but in this case, the victim (who would be the decryptor) never sends the resulting DH point back to the attacker (rather, the victim merely uses it locally to attempt an AES decryption). During _encryption_, the exponentiation is done by the encryptor, who has no secret at all (sure enough, the exponentiation is by an ephemeral scalar), so here there would be nothing for the attacker to learn.
+- **Only applies to uncompressed points.** Indeed, we use compressed points in this EIP; when compressed points are used, any 32-byte string supplied by an attacker will resolve canonically to a point on the right curve, or else generate an error; there is no possibility of a "wrong curve" point.
+- **Only applies when you fail to check a point is on the curve.** But this is inapplicable for us anyway, since we use compressed points (see above).
 
 ## Backwards Compatibility
-The previous proposal stipulated that encryption and decryption requests contain a `version` string. Our proposal merely adds a case for this string; encryption and decryption requests under the existing scheme will be handled identically. Unfortunately, the previous proposal did _not_ include a version string in `encryptionPublicKey`, and merely returned the `ec25519` public key directly as a string. We thus propose to immediately return the `secp256k1` public key, overwriting the previous behavior. The old behavior can be kept via a legacy method.
+The previous EIP stipulated that encryption and decryption requests contain a `version` string. Our proposal merely adds a case for this string; encryption and decryption requests under the existing scheme will be handled identically.
+The previous proposal did _not_ include a version string in `encryptionPublicKey`, and merely returned the `ec25519` public key directly as a string. We thus propose to immediately return the `secp256k1` public key, overwriting the previous behavior.
+It is unlikely that this will be an issue, since encryption keys need be newly retrieved _only_ upon the time of encryption; on the other hand, _new_ ciphertexts will be generated using our new approach.
 
-We note that the previous EIP is _not_ (to our knowledge) implemented in a non-deprecated manner in _any_ production code today, and the EIP stagnated. We thus have a lot of flexibility here; we only need enough backwards compatibility to allow dApps to migrate.
+In any case, the previous EIP was never standardized, and is _not_ (to our knowledge) implemented in a non-deprecated manner in _any_ production code today. We thus have a lot of flexibility here; we only need enough backwards compatibility to allow dApps to migrate.
 
 ### Test Cases
 
-Starting from the secret _signing key_
+The secret _signing key_
 
 ```
     0x439047a312c8502d7dd276540e89fe6639d39da1d8466f79be390579d7eaa3b2
 ```
 
-with Ethereum address `0x72682F2A3c160947696ac3c9CC48d290aa89549c`, the `keccak256`-based KDF described above yields the secret _decryption key_
+with Ethereum address `0x72682F2A3c160947696ac3c9CC48d290aa89549c`, has `secp256k1` public key
 
 ```
-    0xecb4fbc91b48954259469d13d2e69c6fe4b57b73dd9dd277085b2d5e764a4023
-```
-
-with `secp256k1` public key
-
-```
-    0x023e5feced05739d8aad239b037787ba763706fb603e3e92ff0a629e8b4ec2f9be
+    0x03ff5763a2d3113229f2eda8305fae5cc1729e89037532a42df357437532770010
 ```
 
 Thus, the request:
@@ -126,15 +117,15 @@ request({
 should return:
 
 ```javascript
-"0x023e5feced05739d8aad239b037787ba763706fb603e3e92ff0a629e8b4ec2f9be"
+"0x03ff5763a2d3113229f2eda8305fae5cc1729e89037532a42df357437532770010"
 ```
 
-Encrypting the message `"My name is Satoshi Buterin"` under the above public key could yield, for example:
+Encrypting the UTF-8 message `I use Firn Protocol to gain privacy on Ethereum.` under the above public key could yield, for example:
 
 ```javascript
 {
   version: 'secp256k1-sha512kdf-aes256cbc-hmacsha256',
-  ciphertext: '0x03ab54b1b866c5231787fddc2b4dfe9813b6222646b811a2a395040e24e098ae93e39ceedec5516dbf04dbd7b8f5f5030cde786f6aeed187b1d10965714f8d383c2240b4014809077248ddb66cc8bd86eb815dff0e42b0613bbdd3024532c19d0a',
+  ciphertext: '0x036f06f9355b0e3f7d2971da61834513d5870413d28a16d7d68ce05dc78744daf850e6c2af8fb38e3e31d679deac82bd12148332fa0e34aecb31981bd4fe8f7ac1b74866ce65cbe848ee7a9d39093e0de0bd8523a615af8d6a83bbd8541bf174f47b1ea2bd57396b4a950a0a2eb77af09e36bd5832b8841848a8b302bd816c41ce',
 }
 ```
 
@@ -145,12 +136,12 @@ request({
   method: 'eth_decrypt',
   params: [{
     version: 'secp256k1-sha512kdf-aes256cbc-hmacsha256',
-    ciphertext: '0x03ab54b1b866c5231787fddc2b4dfe9813b6222646b811a2a395040e24e098ae93e39ceedec5516dbf04dbd7b8f5f5030cde786f6aeed187b1d10965714f8d383c2240b4014809077248ddb66cc8bd86eb815dff0e42b0613bbdd3024532c19d0a',
+    ciphertext: '0x036f06f9355b0e3f7d2971da61834513d5870413d28a16d7d68ce05dc78744daf850e6c2af8fb38e3e31d679deac82bd12148332fa0e34aecb31981bd4fe8f7ac1b74866ce65cbe848ee7a9d39093e0de0bd8523a615af8d6a83bbd8541bf174f47b1ea2bd57396b4a950a0a2eb77af09e36bd5832b8841848a8b302bd816c41ce',
   }, "0x72682F2A3c160947696ac3c9CC48d290aa89549c"],
 })
 ```
 
-should return the string `"My name is Satoshi Buterin"`.
+should return the string `I use Firn Protocol to gain privacy on Ethereum.`.
 
 ## Security Considerations
 Our proposal uses heavily standardized algorithms and follows all best practices.


### PR DESCRIPTION
add material on encrypting to a contract. remove the HKDF. expand on rationale.