### PR TITLE
Test cases: specify when contract creation fails in Valid initcode

### DIFF
--- a/EIPS/eip-3540.md
+++ b/EIPS/eip-3540.md
@@ -265,13 +265,13 @@ All cases should be checked for creation transaction, `CREATE` and `CREATE2`.
 - Legacy init code
   - Returns legacy code
   - Returns valid EOF1 code
-  - Returns invalid EOF1 code
-  - Returns 0xEF not followed by EOF1 code
+  - Returns invalid EOF1 code, contract creation fails
+  - Returns 0xEF not followed by EOF1 code, contract creation fails
 - Valid EOF1 init code
-  - Returns legacy code
+  - Returns legacy code, contract creation fails
   - Returns valid EOF1 code
-  - Returns invalid EOF1 code
-  - Returns 0xEF not followed by EOF1 code
+  - Returns invalid EOF1 code, contract creation fails
+  - Returns 0xEF not followed by EOF1 code, contract creation fails
 - Invalid EOF1 init code
 
 ### Contract execution


### PR DESCRIPTION
This makes explicit when contract creation fails even if initcode is valid.
