### PR TITLE
change blob tx_hash to use serialize instead of hash_tree_root

### DIFF
--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -164,17 +164,17 @@ The execution layer verifies the wrapper validity against the inner `Transaction
 The signature is verified and `tx.origin` is calculated as follows:
 
 ```python
-def tx_hash(tx: SignedBlobTransaction) -> Bytes32:
+def unsigned_tx_hash(tx: SignedBlobTransaction) -> Bytes32:
     # The pre-image is prefixed with the transaction-type to avoid hash collisions with other tx hashers and types
-    return keccak256(BLOB_TX_TYPE + ssz.hash_tree_root(tx.message))
+    return keccak256(BLOB_TX_TYPE + ssz.serialize(tx.message))
 
 def get_origin(tx: SignedBlobTransaction) -> Address:
     sig = tx.signature
     # v = int(y_parity) + 27, same as EIP-1559
-    return ecrecover(tx_hash(tx), int(sig.y_parity)+27, sig.r, sig.s)
+    return ecrecover(unsigned_tx_hash(tx), int(sig.y_parity)+27, sig.r, sig.s)
 ```
 
-The transaction hash of a signed blob transaction should be computed as:
+The hash of a signed blob transaction should be computed as:
 
 ```python
 def signed_tx_hash(tx: SignedBlobTransaction) -> Bytes32:


### PR DESCRIPTION
this makes the tx hashing for the purposes of tx signing more consistent with computing the hash of a signed blob transaction, and should be more efficient.  Sister PR to https://github.com/ethereum/EIPs/pull/6238