### PR TITLE
3540: type size range should start at 0

### DIFF
--- a/EIPS/eip-3540.md
+++ b/EIPS/eip-3540.md
@@ -86,7 +86,7 @@ The EOF header is followed by at least one section header. Each section header c
 | description       | length  | value         |                   |
 |-------------------|---------|---------------|-------------------|
 | section_kind      | 1-byte  | 0x01–0xFF     | `uint8`           |
-| section_size      | 2-bytes | 0x0001–0xFFFF | `uint16`          |
+| section_size      | 2-bytes | 0x0000–0xFFFF | `uint16`          |
 | section_size_list | dynamic | n/a           | `uint16, uint16+` |
 
 The list of section headers is terminated with the *section headers terminator byte* `0x00`. The body content follows immediately after.


### PR DESCRIPTION
Now that data section is allowed to be 0, we should all expand the overall range.