### PR TITLE
EIP-3860: Change the failure to OOG

### DIFF
--- a/EIPS/eip-3860.md
+++ b/EIPS/eip-3860.md
@@ -56,8 +56,8 @@ We define `initcode_cost(initcode)` to equal `INITCODE_WORD_COST * ceil(len(init
 
 1. If length of transaction data (`initcode`) in a create transaction exceeds `MAX_INITCODE_SIZE`, transaction is invalid. (*Note that this is similar to transactions considered invalid for not meeting the intrinsic gas cost requirement.*)
 2. For a create transaction, extend the transaction data cost formula to include `initcode_cost(initcode)`. (*Note that this is included in transaction intrinsic cost, i.e. transaction with not enough gas to cover initcode cost is invalid.*)
-3. If length of `initcode` to `CREATE` or `CREATE2` instructions exceeds `MAX_INITCODE_SIZE`, instruction execution ends with the result `0` pushed on the stack. Gas for initcode execution is not deducted and caller's nonce is not incremented in this case.
-4. For the `CREATE` and `CREATE2` instructions charge an extra gas cost equaling to `initcode_cost(initcode)`. This cost is deducted before the calculation of the resulting contract address and the execution of `initcode`. (*Note that this means before or at the same time as the hashing cost is applied in `CREATE2`.*) If the instruction fails due to the `initcode` length check of point 3, this cost is not deducted. 
+3. If length of `initcode` to `CREATE` or `CREATE2` instructions exceeds `MAX_INITCODE_SIZE`, instruction execution exceptionally aborts (as if it runs out of gas).
+4. For the `CREATE` and `CREATE2` instructions charge an extra gas cost equaling to `initcode_cost(initcode)`. This cost is deducted before the calculation of the resulting contract address and the execution of `initcode`. (*Note that this means before or at the same time as the hashing cost is applied in `CREATE2`.*)
 
 ## Rationale
 
@@ -94,7 +94,7 @@ The initcode cost for create transaction data (0.0625 gas per byte) is negligibl
 
 ### How to report initcode limit violation?
 
-We specified that initcode size limit violation for `CREATE`/`CREATE2` results in `0` on stack. Most checks in these instructions are specified this way, except for 3 checks not specific to creation instructions (stack underflow, out of gas, static call violation). In these three cases the entire execution is exceptionally aborted. However, we decided to be consistent with the majority of the possible error conditions in order to keep the specification and implementations simple.
+We specified that initcode size limit violation for `CREATE`/`CREATE2` results in exceptional abort of the execution. This place it in the group of early out-of-gas checks, including: stack underflow, memory expansion, static call violation, initcode hashing cost, and initcode cost introduced by this EIP. They precede the later "light" checks: call depth and balance. The choice gives consistency to the order of checks and lowers implementation complexity (out-of-gas checks can be performed in any order).
 
 ## Backwards Compatibility
 

--- a/EIPS/eip-3860.md
+++ b/EIPS/eip-3860.md
@@ -94,7 +94,7 @@ The initcode cost for create transaction data (0.0625 gas per byte) is negligibl
 
 ### How to report initcode limit violation?
 
-We specified that initcode size limit violation for `CREATE`/`CREATE2` results in exceptional abort of the execution. This place it in the group of early out-of-gas checks, including: stack underflow, memory expansion, static call violation, initcode hashing cost, and initcode cost introduced by this EIP. They precede the later "light" checks: call depth and balance. The choice gives consistency to the order of checks and lowers implementation complexity (out-of-gas checks can be performed in any order).
+We specified that initcode size limit violation for `CREATE`/`CREATE2` results in exceptional abort of the execution. This places it in the group of early out-of-gas checks, including: stack underflow, memory expansion, static call violation, initcode hashing cost, and initcode cost introduced by this EIP. They precede the later "light" checks: call depth and balance. The choice gives consistency to the order of checks and lowers implementation complexity (out-of-gas checks can be performed in any order).
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
Change the failure in case of exceeding the initcode size limit for CREATE instructions to be OOG (same as the other check and many others).

See https://ethereum-magicians.org/t/eip-3860-limit-and-meter-initcode/7018/15.