### PR TITLE
3540: restrict number of code sections to 1024

### DIFF
--- a/EIPS/eip-3540.md
+++ b/EIPS/eip-3540.md
@@ -125,7 +125,7 @@ type_section := (inputs, outputs, max_stack_height)+
 | kind_type         | 1 byte   | 0x01          | kind marker for EIP-4750 type section header                                       |
 | type_size         | 2 bytes  | 0x0004-0xFFFC | uint16 denoting the length of the type section content, 4 bytes per code segment   |
 | kind_code         | 1 byte   | 0x02          | kind marker for code size section                                                  |
-| num_code_sections | 2 bytes  | 0x0001-0xFFFF | uint16 denoting the number of the code sections                                    |
+| num_code_sections | 2 bytes  | 0x0001-0x0400 | uint16 denoting the number of the code sections                                    |
 | code_size         | 2 bytes  | 0x0001-0xFFFF | uint16 denoting the length of the code section content                             |
 | kind_data         | 1 byte   | 0x03          | kind marker for data size section                                                  |
 | data_size         | 2 bytes  | 0x0000-0xFFFF | uint16 integer denoting the length of the data section content                     |


### PR DESCRIPTION
This bound already exists in 4750, just propagating it up to 3540.