### PR TITLE
CI: Only run label bot on PRs to master

### DIFF
--- a/.github/workflows/auto-label-bot.yml
+++ b/.github/workflows/auto-label-bot.yml
@@ -1,5 +1,7 @@
 on:
   pull_request_target:
+    branches:
+      - master
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
Fixes a minor issue with labeling