### PR TITLE
EIP-4750: Change checks to asserts

### DIFF
--- a/EIPS/eip-4750.md
+++ b/EIPS/eip-4750.md
@@ -67,7 +67,7 @@ If the code is valid EOF1, the following execution rules apply:
 #### `CALLF`
 
 1. Has one immediate argument,`code_section_index`, encoded as a 16-bit unsigned big-endian value.
-2. If operand stack has less than `caller_stack_height + type[code_section_index].inputs` items, execution results in exceptional halt.
+2. EOF validation guarantees that operand stack has at least `caller_stack_height + type[code_section_index].inputs` items.
 3. If operand stack size exceeds `1024 - type[code_section_index].max_stack_height` (i.e. if the called function may exceed the global stack height limit), execution results in exceptional halt. This also guarantees that the stack height after the call is within the limits.
 4. If return stack already has `1024` items, execution results in exceptional halt.
 5. Charges 5 gas.
@@ -88,7 +88,7 @@ If the code is valid EOF1, the following execution rules apply:
 #### `RETF`
 
 1. Does not have immediate arguments.
-2. If operand stack does not equal `caller_stack_height + type[current_section_index].outputs` items, execution results in exceptional halt.
+2. EOF validation guarantees that operand stack has exactly `caller_stack_height + type[current_section_index].outputs` items.
 3. Charges 3 gas.
 4. Pops nothing and pushes nothing to operand stack.
 5. Pops an item from return stack and sets `current_section_index` and `PC` to values from this item.


### PR DESCRIPTION
Change runtime checks to asserts coming from EOF verification.