### PR TITLE
Make signature of signature optional

### DIFF
--- a/EIPS/eip-5570.md
+++ b/EIPS/eip-5570.md
@@ -46,7 +46,7 @@ The JSON schema is composed of 2 parts. The root schema contains high level deta
   "id": "receipt.json#",
   "description": "Receipt Schema for Digital Receipt Non-Fungible Tokens",
   "type": "object",
-  "required": ["name", "description", "image", "receipt", "signature"],
+  "required": ["name", "description", "image", "receipt"],
   "properties": {
     "name": {
       "title": "Name",
@@ -257,7 +257,7 @@ The JSON schema is composed of 2 parts. The root schema contains high level deta
 
 ## Rationale
 
-The schema introduced complies with EIP-721's metadata extension, conveniently allowing previous tools for viewing NFTs to show our receipts. The new property "receipt" contains our newly provided receipt structure and the signature property requires the vendor to digitally sign the receipt structure.
+The schema introduced complies with EIP-721's metadata extension, conveniently allowing previous tools for viewing NFTs to show our receipts. The new property "receipt" contains our newly provided receipt structure and the signature property optionally allows the vendor to digitally sign the receipt structure.
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
Although forcing signatures upon the vendors would be useful, allowing third parties and users to create their own receipts that are valid (but ultimately not legal receipts) does offer some opportunities for projects.
