### PR TITLE
Update EIP-1559: Remove empty test cases

### DIFF
--- a/EIPS/eip-1559.md
+++ b/EIPS/eip-1559.md
@@ -310,9 +310,6 @@ The datastructure that is passed into keccak256 to calculate the block hash is c
 ### GASPRICE
 Previous to this change, `GASPRICE` represented both the ETH paid by the signer per gas for a transaction as well as the ETH received by the miner per gas.  As of this change, `GASPRICE` now only represents the amount of ETH paid by the signer per gas, and the amount a miner was paid for the transaction is no longer accessible directly in the EVM.
 
-## Test Cases
-TODO
-
 ## Security Considerations
 ### Increased Max Block Size/Complexity
 This EIP will increase the maximum block size, which could cause problems if miners are unable to process a block fast enough as it will force them to mine an empty block.  Over time, the average block size should remain about the same as without this EIP, so this is only an issue for short term size bursts.  It is possible that one or more clients may handle short term size bursts poorly and error (such as out of memory or similar) and client implementations should make sure their clients can appropriately handle individual blocks up to max size.


### PR DESCRIPTION
While final core EIPs are supposed to have a complete test cases section, this rule is not currently enforced.

I would argue that the removal of the placeholder is better than keeping it.