### PR TITLE
EIP-4895: CL-EL withdrawals harmonization: using units of Gwei

### DIFF
--- a/EIPS/eip-4895.md
+++ b/EIPS/eip-4895.md
@@ -44,7 +44,7 @@ Define a new payload-level object called a `withdrawal` that describes withdrawa
 1. a monotonically increasing `index`, starting from 0, as a `uint64` value that increments by 1 per withdrawal to uniquely identify each withdrawal
 2. the `validator_index` of the validator, as a `uint64` value, on the consensus layer the withdrawal corresponds to
 3. a recipient for the withdrawn ether `address` as a 20-byte value
-4. a nonzero `amount` of ether given in wei as a `uint256` value.
+4. a nonzero `amount` of ether given in Gwei (1e9 wei) as a `uint64` value.
 
 *NOTE*: the `index` for each withdrawal is a global counter spanning the entire sequence of withdrawals.
 
@@ -128,6 +128,8 @@ assert execution_payload_header.withdrawals_root == compute_trie_root_from_index
 The `withdrawals` in an execution payload are processed **after** any user-level transactions are applied.
 
 For each `withdrawal` in the list of `execution_payload.withdrawals`, the implementation increases the balance of the `address` specified by the `amount` given.
+
+Recall that the `amount` is given in units of Gwei so a conversion of units of wei must be performed when working with account balances in the execution state.
 
 This balance change is unconditional and **MUST** not fail.
 

--- a/EIPS/eip-4895.md
+++ b/EIPS/eip-4895.md
@@ -129,7 +129,7 @@ The `withdrawals` in an execution payload are processed **after** any user-level
 
 For each `withdrawal` in the list of `execution_payload.withdrawals`, the implementation increases the balance of the `address` specified by the `amount` given.
 
-Recall that the `amount` is given in units of Gwei so a conversion of units of wei must be performed when working with account balances in the execution state.
+Recall that the `amount` is given in units of Gwei so a conversion to units of wei must be performed when working with account balances in the execution state.
 
 This balance change is unconditional and **MUST** not fail.
 

--- a/EIPS/eip-4895.md
+++ b/EIPS/eip-4895.md
@@ -41,6 +41,7 @@ Define a new payload-level object called a `withdrawal` that describes withdrawa
 `Withdrawal`s are syntactically similar to a user-level transaction but live in a different domain than user-level transactions.
 
 `Withdrawal`s provide key information from the consensus layer:
+
 1. a monotonically increasing `index`, starting from 0, as a `uint64` value that increments by 1 per withdrawal to uniquely identify each withdrawal
 2. the `validator_index` of the validator, as a `uint64` value, on the consensus layer the withdrawal corresponds to
 3. a recipient for the withdrawn ether `address` as a 20-byte value


### PR DESCRIPTION
Following discussion from here https://github.com/ethereum/pm/issues/702, protocol devs want to explore harmonization in the withdrawals format from CL to EL.

This PR updates EIP-4895 with the first part of this change to use the same units (`Gwei`) for the `amount` in each withdrawal.