### PR TITLE
Update EIP-5192: Change name to "Lockable tokens"

### DIFF
--- a/EIPS/eip-5192.md
+++ b/EIPS/eip-5192.md
@@ -45,9 +45,9 @@ interface IERC5192 {
   event Unlocked(uint256 tokenId);
 
   /// @notice Returns the locking status of a token
-  /// @dev SBTs assigned to zero address are considered invalid, and queries
+  /// @dev Tokens assigned to zero address are considered invalid, and queries
   /// about them do throw.
-  /// @param tokenId The identifier for an SBT.
+  /// @param tokenId The identifier for a token.
   function locked(uint256 tokenId) external view returns (bool);
 }
 ```

--- a/EIPS/eip-5192.md
+++ b/EIPS/eip-5192.md
@@ -1,7 +1,7 @@
 ---
 eip: 5192
-title: Minimal Soulbound NFTs
-description: Minimal interface for soulbinding EIP-721 NFTs
+title: Lockable NFTs
+description: Minimal interface for lockable EIP-721 NFTs
 author: Tim Daubenschütz (@TimDaub), Anders (@0xanders)
 discussions-to: https://ethereum-magicians.org/t/eip-5192-minimal-soulbound-nfts/9814
 status: Final
@@ -13,7 +13,7 @@ requires: 165, 721
 
 ## Abstract
 
-This standard is an extension of [EIP-721](./eip-721.md). It proposes a minimal interface to make tokens soulbound using the feature detection functionality of [EIP-165](./eip-165.md). A soulbound token is a non-fungible token bound to a single account.
+This standard is an extension of [EIP-721](./eip-721.md). It proposes a minimal interface to make tokens lockable using the feature detection functionality of [EIP-165](./eip-165.md). A lockable token is a non-fungible token bound to a single account.
 
 ## Motivation
 
@@ -44,7 +44,7 @@ interface IERC5192 {
   /// @param tokenId The identifier for a token.
   event Unlocked(uint256 tokenId);
 
-  /// @notice Returns the locking status of an Soulbound Token
+  /// @notice Returns the locking status of a token
   /// @dev SBTs assigned to zero address are considered invalid, and queries
   /// about them do throw.
   /// @param tokenId The identifier for an SBT.
@@ -52,11 +52,11 @@ interface IERC5192 {
 }
 ```
 
-To aid recognition that an [EIP-721](./eip-721.md) token implements "soulbinding" via this EIP upon calling [EIP-721](./eip-721.md)'s `function supportsInterface(bytes4 interfaceID) external view returns (bool)` with `interfaceID=0xb45a3c0e`, a contract implementing this EIP must return `true`.
+To aid recognition that an [EIP-721](./eip-721.md) token implements locking via this EIP upon calling [EIP-721](./eip-721.md)'s `function supportsInterface(bytes4 interfaceID) external view returns (bool)` with `interfaceID=0xb45a3c0e`, a contract implementing this EIP must return `true`.
 
 ## Rationale
 
-The above model is the simplest possible path towards a canonical interface for Soulbound tokens. It reflects upon the numerous Soulbound token implementations that simply revert upon transfers.
+The above model is the simplest possible path towards a canonical interface for locking tokens. It reflects upon the numerous "Soulbound token" implementations that simply revert upon transfers.
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
When this standard was created, the term "Soulbound tokens" was cool and new. Many people understood that a Soulbound token is "bound to a soul," and so it is a permanently locked token of an account. But since then, it has become clear that a Soulbound token is an umbrella term for all kinds of tokens that break conventional norms around private property assumptions. And besides, EIP-5192 implements dynamic locking of a token. So "Lockable Tokens" is a much better term for this specification and also for developers arriving at it in the future.

I'm hence asking the EIP editors to make an exception regarding changing the contents of this EIP. The interface has not changed. Developers can still rely on using this token standard. The only change is an improvement in terms of accuracy in identifying what it is: A lockable token.