### PR TITLE
Update EIP-4844: clarify datahash return value

### DIFF
--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -243,9 +243,9 @@ The `ethereum/consensus-specs` repository defines the following beacon-node chan
 
 ### Opcode to get versioned hashes
 
-We add an opcode `DATAHASH` (with byte value `HASH_OPCODE_BYTE`) which takes as input one stack argument `index`,
-and returns `tx.message.blob_versioned_hashes[index]` if `index < len(tx.message.blob_versioned_hashes)`,
-and otherwise zero.
+We add an opcode `DATAHASH` (with byte value `HASH_OPCODE_BYTE`) which reads `index` from the top of the stack
+as big-endian `uint256`, and replaces it on the stack with `tx.message.blob_versioned_hashes[index]`
+if `index < len(tx.message.blob_versioned_hashes)`, and otherwise with a zeroed `bytes32` value.
 The opcode has a gas cost of `HASH_OPCODE_GAS`.
 
 ### Point evaluation precompile


### PR DESCRIPTION
This clarifies how the `DATAHASH` opcode return value is pushed back onto the stack in the previous place of the popped input, essentially replacing it. Also clarifies it's the top value of the stack, and the input `index` is interpreted as big-endian `uint256`.

No functionality changes.

Thanks to the EthereumJS team for reporting this.
