### PR TITLE
Update eip-1328.md

### DIFF
--- a/EIPS/eip-1328.md
+++ b/EIPS/eip-1328.md
@@ -47,13 +47,11 @@ For WalletConnect v2.0 protocol (`version`=`2`) the parameters are:
 
 ### Example
 
-```
-# 1.0
-wc:8a5e5bdc-a0e4-4702-ba63-8f1a5655744f@1?bridge=https%3A%2F%2Fbridge.walletconnect.org&key=41791102999c339c844880b23950704cc43aa840f3739e365323cda4dfa89e7a
+    # 1.0
+    wc:8a5e5bdc-a0e4-4702-ba63-8f1a5655744f@1?    bridge=https%3A%2F%2Fbridge.walletconnect.org&key=41791102999c339c844880b23950704cc43aa840f3739e365323cda4dfa89e7a
 
-# 2.0
-wc:c9e6d30fb34afe70a15c14e9337ba8e4d5a35dd695c39b94884b0ee60c69d168@2?relay-protocol=waku&symKey=7ff3e362f825ab868e20e767fe580d0311181632707e7c878cbeca0238d45b8b
-```
+    # 2.0
+    wc:c9e6d30fb34afe70a15c14e9337ba8e4d5a35dd695c39b94884b0ee60c69d168@2?relay-protocol=waku&symKey=7ff3e362f825ab868e20e767fe580d0311181632707e7c878cbeca0238d45b8b
 
 ## Rationale
 

--- a/EIPS/eip-1328.md
+++ b/EIPS/eip-1328.md
@@ -40,6 +40,7 @@ For WalletConnect v2.0 protocol (`version`=`2`) the parameters are:
 - `symKey` - symmetric key used for encrypting messages over relay
 - `relay-protocol` - transport protocol for relaying messages
 - `relay-data` - (optional) transport data for relaying messages
+- `relay-url` - (optional) url of the server for relaying messages
 
 
 ### Example

--- a/EIPS/eip-1328.md
+++ b/EIPS/eip-1328.md
@@ -33,10 +33,12 @@ WalletConnect request URI with the following parameters:
 Required parameters are dependent on the WalletConnect protocol version:
 
 For WalletConnect v1.0 protocol (`version`=`1`) the parameters are:
+
 - `key` - symmetric key used for encryption
 - `bridge` - url of the bridge server for relaying messages
 
 For WalletConnect v2.0 protocol (`version`=`2`) the parameters are:
+
 - `symKey` - symmetric key used for encrypting messages over relay
 - `relay-protocol` - transport protocol for relaying messages
 - `relay-data` - (optional) transport data for relaying messages


### PR DESCRIPTION
Providing a relay URL in the WC URI enables the application to indicate what relay they should use.  Currently WC20 clients can choose to specify a custom relay. However in practice they are forced to use relay.walletconnect.com which gives stats (IP, User-Agents, Application ID) about the users to the central relay and is not acceptable for many applications.
