### PR TITLE
Update eip-5585.md

### DIFF
--- a/EIPS/eip-5585.md
+++ b/EIPS/eip-5585.md
@@ -33,7 +33,7 @@ interface IERC5585 {
     struct UserRecord {
         address user;
         string[] rights;
-        uint expires
+        uint256 expires
     }
 
     /// @notice Get all available rights of this NFT project


### PR DESCRIPTION
to remain consistent with uint256 in the rest of the specification, the "uint expires" could become uint256. It could also be uint64, as in the EIP 4907 perhaps.

When opening a pull request to submit a new EIP, please use the suggested template: https://github.com/ethereum/EIPs/blob/master/eip-template.md

We have a GitHub bot that automatically merges some PRs. It will merge yours immediately if certain criteria are met:

 - The PR edits only existing draft PRs.
 - The build passes.
 - Your GitHub username or email address is listed in the 'author' header of all affected PRs, inside <triangular brackets>.
 - If matching on email address, the email address is the one publicly listed on your GitHub profile.
