### PR TITLE
EIP-4200: fix RJUMPI -> JUMPI

### DIFF
--- a/EIPS/eip-4200.md
+++ b/EIPS/eip-4200.md
@@ -77,7 +77,7 @@ Should there be a need to have immediate encodings of other size (such as 8-bits
 
 ### `PUSHn JUMP` sequences
 
-If we chose absolute addressing, then `RJUMP` could be viewed similar to the sequence `PUSHn JUMP` (and `RJUMPI` similar to `PUSHn RJUMPI`). In that case one could argue that instead of introducing a new instruction, such sequences should get a discount, because EVMs could optimise them.
+If we chose absolute addressing, then `RJUMP` could be viewed similar to the sequence `PUSHn JUMP` (and `RJUMPI` similar to `PUSHn JUMPI`). In that case one could argue that instead of introducing a new instruction, such sequences should get a discount, because EVMs could optimise them.
 
 We think this is a bad direction to go:
 


### PR DESCRIPTION
Fixing typo when comparing RJUMP/RJUMPI to JUMP/JUMPI sequences.