### PR TITLE
Add EIP-6372: Contract clock

### DIFF
--- a/EIPS/eip-6372.md
+++ b/EIPS/eip-6372.md
@@ -83,6 +83,10 @@ interface IERC6372 {
 
 Depending on the evolution of the blockchain (particularly layer twos), using a smaller type, such as `uint32` might cause issues fairly quickly. On the other hand, anything bigger than `uint48` is overkill.
 
+## Security Considerations
+
+No known security issues.
+
 ## Copyright
 
 Copyright and related rights waived via [CC0](../LICENSE.md).

--- a/EIPS/eip-6372.md
+++ b/EIPS/eip-6372.md
@@ -12,15 +12,15 @@ created: 2023-01-25
 
 ## Abstract
 
-Many contract rely on some clock for enforcing delays and storing historical data. While contracts relly on block numbers, other use timestamp. There is currently no easy way to discover which time trancking function a contract internally uses. This EIP proposes to standardize an interface for contracts to expose their internal clock and thus improve composability.
+Many contracts rely on some clock for enforcing delays and storing historical data. While contracts rely on block numbers, others use timestamps. There is currently no easy way to discover which time-tracking function a contract internally uses. This EIP proposes to standardize an interface for contracts to expose their internal clock and thus improve composability.
 
 ## Motivation
 
-Many contracts check or store time-related informations. For example, timelock contracts enforce a delay before an operation can be executed. Similarly, DAOs enforce a voting period during which stakeholders can approve or reject a proposal. Last but not least, voting tokens often store the history of the voting power using timed snapshots.
+Many contracts check or store time-related information. For example, timelock contracts enforce a delay before an operation can be executed. Similarly, DAOs enforce a voting period during which stakeholders can approve or reject a proposal. Last but not least, voting tokens often store the history of voting power using timed snapshots.
 
-Some contract do time tracking using timestamps while other use block number. In same cases, more exotic functions might be used to track time.
+Some contracts do time tracking using timestamps while others use block numbers. In some cases, more exotic functions might be used to track time.
 
-There is currently no interface for an external observer to detect which clock a contract uses. This seriously limits interroperability and forces devs to make assumption.
+There is currently no interface for an external observer to detect which clock a contract uses. This seriously limits interoperability and forces devs to make assumptions.
 
 ## Specification
 
@@ -50,7 +50,7 @@ This function returns a string describing the clock the contract is operating on
 - If operating using **timestamp**, then this function SHOULD return `mode=timestamp`.
 - If operating using any other mode, then this function SHOULD return a unique identifier for the encoded `mode` field.
 
-Note that when operating using **block number**, the `clock()` is expected to returns the value given by the `NUMBER` opcode (`0x43`). In some cases this can be the block number of another chain (in arbitrum, opcode `0x43` returns the block number of the last recorded operation on the parent chain). A contract can use `from=default` to specify that the block number used is the one provided by the `NUMBER` opcode (`0x43`). If a more explicit description is needed, CAIP-2 blockchain id should be used to identify the corresponding blockchain.
+Note that when operating using **block number**, the `clock()` is expected to return the value given by the `NUMBER` opcode (`0x43`). In some cases, this can be the block number of another chain (in arbitrum, opcode `0x43` returns the block number of the last recorded operation on the parent chain). A contract can use `from=default` to specify that the block number used is the one provided by the `NUMBER` opcode (`0x43`). If a more explicit description is needed, CAIP-2 blockchain id should be used to identify the corresponding blockchain.
 
 The return string MUST be formatted like a URL query string (a.k.a. `application/x-www-form-urlencoded`). This allows easy decoding in standard JavaScript with `new URLSearchParams(CLOCK_MODE)`.
 
@@ -67,7 +67,7 @@ The return string MUST be formatted like a URL query string (a.k.a. `application
 ### Solidity interface
 
 ```sol
-interface IERCXXXX {
+interface IERC6372 {
   function clock() external view returns (uint48);
   function CLOCK_MODE() external view returns (string);
 }
@@ -79,9 +79,9 @@ interface IERCXXXX {
 
 ## Rationale
 
-`clock` returns `uint48` as it is largelly sufficient for storing realistic values. In timestamp mode, `uint48` will be enough until the year 8921556. Even in block number mode, with 10,000 blocks per seconds, it would be enough until the year 2861. Using a type smaller than uint256 allows some storage packing of timepoints with other associated values. Greatly reducing the cost of writting and reading from storage.
+`clock` returns `uint48` as it is largely sufficient for storing realistic values. In timestamp mode, `uint48` will be enough until the year 8921556. Even in block number mode, with 10,000 blocks per second, it would be enough until the year 2861. Using a type smaller than uint256 allows some storage packing of timepoints with other associated values. Greatly reducing the cost of writing and reading from storage.
 
-Depending on the evolution of the blockchain (particularly layer twos), using smaller type, such as `uint32` might cause issues fairly quickly. On the other hand, anything bigger than `uint48` is overkill.
+Depending on the evolution of the blockchain (particularly layer twos), using a smaller type, such as `uint32` might cause issues fairly quickly. On the other hand, anything bigger than `uint48` is overkill.
 
 ## Copyright
 

--- a/EIPS/eip-6372.md
+++ b/EIPS/eip-6372.md
@@ -1,5 +1,5 @@
 ---
-eip: XXX
+eip: 6372
 title: Contract clock
 description: An interface for exposing a contract's clock value and details
 author: Hadrien Croubois (@Amxx), Francisco Giordano (@frangio)

--- a/EIPS/eip-6372.md
+++ b/EIPS/eip-6372.md
@@ -3,7 +3,7 @@ eip: 6372
 title: Contract clock
 description: An interface for exposing a contract's clock value and details
 author: Hadrien Croubois (@Amxx), Francisco Giordano (@frangio)
-discussions-to: todo
+discussions-to: https://ethereum-magicians.org/t/eip-6372-contract-clock/12689
 status: Draft
 type: Standards Track
 category: ERC

--- a/EIPS/eip-XXXX.md
+++ b/EIPS/eip-XXXX.md
@@ -1,0 +1,88 @@
+---
+eip: XXX
+title: Contract clock
+description: An interface for exposing a contract's clock value and details
+author: Hadrien Croubois (@Amxx), Francisco Giordano (@frangio)
+discussions-to: todo
+status: Draft
+type: Standards Track
+category: ERC
+created: 2023-01-25
+---
+
+## Abstract
+
+Many contract rely on some clock for enforcing delays and storing historical data. While contracts relly on block numbers, other use timestamp. There is currently no easy way to discover which time trancking function a contract internally uses. This EIP proposes to standardize an interface for contracts to expose their internal clock and thus improve composability.
+
+## Motivation
+
+Many contracts check or store time-related informations. For example, timelock contracts enforce a delay before an operation can be executed. Similarly, DAOs enforce a voting period during which stakeholders can approve or reject a proposal. Last but not least, voting tokens often store the history of the voting power using timed snapshots.
+
+Some contract do time tracking using timestamps while other use block number. In same cases, more exotic functions might be used to track time.
+
+There is currently no interface for an external observer to detect which clock a contract uses. This seriously limits interroperability and forces devs to make assumption.
+
+## Specification
+
+### Methods
+
+#### clock
+
+This function returns the current timepoint. It could be `block.timestamp`, `block.number` (or any other **non-decreasing** function) depending on the mode the contract is operating on.
+
+```yaml
+- name: clock
+  type: function
+  stateMutability: view
+  inputs: []
+  outputs:
+    - name: timepoint
+      type: uint48
+```
+
+### CLOCK_MODE
+
+This function returns a string describing the clock the contract is operating on.
+
+- If operating using **block number**:
+  - If the block numbers are those of the `NUMBER` opcode (`0x43`), then this function SHOULD return `mode=blocknumber&from=default`.
+  - If it is any other block number, then this function SHOULD return `mode=blocknumber&from=<CAIP2ID>`, where `<CAIP2ID>` is a CAIP-2 Blockchain ID such as `eip155:1`.
+- If operating using **timestamp**, then this function SHOULD return `mode=timestamp`.
+- If operating using any other mode, then this function SHOULD return a unique identifier for the encoded `mode` field.
+
+Note that when operating using **block number**, the `clock()` is expected to returns the value given by the `NUMBER` opcode (`0x43`). In some cases this can be the block number of another chain (in arbitrum, opcode `0x43` returns the block number of the last recorded operation on the parent chain). A contract can use `from=default` to specify that the block number used is the one provided by the `NUMBER` opcode (`0x43`). If a more explicit description is needed, CAIP-2 blockchain id should be used to identify the corresponding blockchain.
+
+The return string MUST be formatted like a URL query string (a.k.a. `application/x-www-form-urlencoded`). This allows easy decoding in standard JavaScript with `new URLSearchParams(CLOCK_MODE)`.
+
+```yaml
+- name: CLOCK_MODE
+  type: function
+  stateMutability: view
+  inputs: []
+  outputs:
+    - name: descriptor
+      type: string
+```
+
+### Solidity interface
+
+```sol
+interface IERCXXXX {
+  function clock() external view returns (uint48);
+  function CLOCK_MODE() external view returns (string);
+}
+```
+
+### Expected properties
+
+- The `clock()` function MUST be non-decreasing.
+
+## Rationale
+
+`clock` returns `uint48` as it is largelly sufficient for storing realistic values. In timestamp mode, `uint48` will be enough until the year 8921556. Even in block number mode, with 10,000 blocks per seconds, it would be enough until the year 2861. Using a type smaller than uint256 allows some storage packing of timepoints with other associated values. Greatly reducing the cost of writting and reading from storage.
+
+Depending on the evolution of the blockchain (particularly layer twos), using smaller type, such as `uint32` might cause issues fairly quickly. On the other hand, anything bigger than `uint48` is overkill.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](../LICENSE.md).


### PR DESCRIPTION
Following discussion on EIP-5805, we decided to spin of clock part of the interface as its own EIP.

EIP-5805 will add a dependency on this once merged.