### PR TITLE
4844: use `hash_tree_root` for tx hash

### DIFF
--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -166,7 +166,7 @@ The signature is verified and `tx.origin` is calculated as follows:
 ```python
 def unsigned_tx_hash(tx: SignedBlobTransaction) -> Bytes32:
     # The pre-image is prefixed with the transaction-type to avoid hash collisions with other tx hashers and types
-    return keccak256(BLOB_TX_TYPE + ssz.serialize(tx.message))
+    return ssz.hash_tree_root(tx.message)
 
 def get_origin(tx: SignedBlobTransaction) -> Address:
     sig = tx.signature
@@ -178,7 +178,7 @@ The hash of a signed blob transaction should be computed as:
 
 ```python
 def signed_tx_hash(tx: SignedBlobTransaction) -> Bytes32:
-    return keccak256(BLOB_TX_TYPE + ssz.serialize(tx))
+    return ssz.hash_tree_root(tx)
 ```
 
 ### Header extension


### PR DESCRIPTION
I think we should move to `hash_tree_root` for calculating the transaction hash of 4844 transactions if we plan to migrate to an SSZ list of transactions. 

The reason for staying with (and originally choosing) keccak is that it fits nicely into the expectation that the MPT hashing algorithm has for leaves greater than 32 bytes, it will simply take the keccak of it.