### PR TITLE
Update EIP-4844: do not allow creation txs

### DIFF
--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -112,6 +112,8 @@ and `access_list` follows [EIP-2930](./eip-2930.md).
 
 The `max_fee_per_data_gas` is `uint256` and the `blob_versioned_hashes` field represents a list hash outputs from `kzg_to_versioned_hash`.
 
+Unlike existing transaction types, the `to` field MUST NOT not be `nil`. This implies that blob transactions are not able to deploy contracts.
+
 The [EIP-2718](./eip-2718.md) `ReceiptPayload` for this transaction is `rlp([status, cumulative_transaction_gas_used, logs_bloom, logs])`.
 
 #### Signature


### PR DESCRIPTION
this builds on https://github.com/ethereum/EIPs/pull/6985, so that PR should be merged first

--


Allowing contract creation from 4844 transactions is unnecessary. If in the unlikely event that there is a use case for creating a contract while also sending blobs to the chain, the transaction should simple do it via `CREATE` or `CREATE2`.