### PR TITLE
EIP-6206: Simplify JUMPF validation

### DIFF
--- a/EIPS/eip-6206.md
+++ b/EIPS/eip-6206.md
@@ -36,7 +36,7 @@ Let the definition of `type[i]` be inherited from [EIP-4750](./eip-4750.md) and 
 
 * The immediate argument of `JUMPF` MUST be less than the total number of code sections.
 * For each `JUMPF` instruction `type[current_section_index].outputs` MUST be greater or equal `type[code_section_index].outputs`.
-* The stack height at `JUMPF` MUST be equal to `type[code_section_index].inputs + type[current_section_index].outputs - type[code_section_index].outputs`. This means that `code_section_index` can output less stack elements than the original code section called by the top element on the return stack, if the `current_section_index` code section leaves the delta `type[current_section_index].outputs - type[code_section_index].outputs` element(s) on the stack.
+* The stack height at `JUMPF` MUST be equal to `type[current_section_index].outputs + type[code_section_index].inputs  - type[code_section_index].outputs`. This means that `code_section_index` can output less stack elements than the original code section called by the top element on the return stack, if the `current_section_index` code section leaves the delta `type[current_section_index].outputs - type[code_section_index].outputs` element(s) on the stack.
 * The code validation defined in [EIP-4200](./eip-4200.md) also fails if any `RJUMP*` offset points to one of the two bytes directly following a `JUMPF` instruction.
 
 ## Rationale

--- a/EIPS/eip-6206.md
+++ b/EIPS/eip-6206.md
@@ -35,8 +35,8 @@ A new instruction, `JUMPF (0xb2)`, is introduced.
 Let the definition of `type[i]` be inherited from [EIP-4750](./eip-4750.md) and define `stack_height` to be the height of the stack at a certain instruction during the instruction flow traversal if the operand stack at the start of the function were equal to `type[i].inputs`.
 
 * The immediate argument of `JUMPF` MUST be less than the total number of code sections.
-* The stack height at `JUMPF` MUST be greater than or equal to `type[code_section_index].inputs`.
-* `type[current_section_index].outputs` MUST equal `stack_height - type[code_section_index].inputs + type[code_section_index].outputs`. This means that `code_section_index` can output less stack elements than the original code section called by the top element on the return stack if the `current_section_index` code section leaves the delta `type[current_section_index].outputs - type[code_section_index].outputs` element(s) on the stack.
+* For each `JUMPF` instruction `type[current_section_index].outputs` MUST be greater or equal `type[code_section_index].outputs`.
+* The stack height at `JUMPF` MUST be equal to `type[code_section_index].inputs + type[current_section_index].outputs - type[code_section_index].outputs`. This means that `code_section_index` can output less stack elements than the original code section called by the top element on the return stack, if the `current_section_index` code section leaves the delta `type[current_section_index].outputs - type[code_section_index].outputs` element(s) on the stack.
 * The code validation defined in [EIP-4200](./eip-4200.md) also fails if any `RJUMP*` offset points to one of the two bytes directly following a `JUMPF` instruction.
 
 ## Rationale


### PR DESCRIPTION
This replaces two requirements on `stack_height` at JUMPF (inequality + equality) with equivalent combination of JUMPF instruction validation requirement and `stack_height` equality requirement.