### PR TITLE
EIP-6372: Specify CLOCK_NUMBER with "MUST" behavior

### DIFF
--- a/EIPS/eip-6372.md
+++ b/EIPS/eip-6372.md
@@ -12,7 +12,7 @@ created: 2023-01-25
 
 ## Abstract
 
-Many contracts rely on some clock for enforcing delays and storing historical data. While contracts rely on block numbers, others use timestamps. There is currently no easy way to discover which time-tracking function a contract internally uses. This EIP proposes to standardize an interface for contracts to expose their internal clock and thus improve composability.
+Many contracts rely on some clock for enforcing delays and storing historical data. While some contracts rely on block numbers, others use timestamps. There is currently no easy way to discover which time-tracking function a contract internally uses. This EIP proposes to standardize an interface for contracts to expose their internal clock and thus improve composability and interoperability.
 
 ## Motivation
 
@@ -20,15 +20,26 @@ Many contracts check or store time-related information. For example, timelock co
 
 Some contracts do time tracking using timestamps while others use block numbers. In some cases, more exotic functions might be used to track time.
 
-There is currently no interface for an external observer to detect which clock a contract uses. This seriously limits interoperability and forces devs to make assumptions.
+There is currently no interface for an external observer to detect which clock a contract uses. This seriously limits interoperability and forces devs to make risky assumptions.
 
 ## Specification
+
+The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be interpreted as described in RFC 2119.
+
+Compliant contracts MUST implement the `clock` and `CLOCK_MODE` functions as specified below.
+
+```solidity
+interface IERC6372 {
+  function clock() external view returns (uint48);
+  function CLOCK_MODE() external view returns (string);
+}
+```
 
 ### Methods
 
 #### clock
 
-This function returns the current timepoint. It could be `block.timestamp`, `block.number` (or any other **non-decreasing** function) depending on the mode the contract is operating on.
+This function returns the current timepoint according to the mode the contract is operating on. It MUST be a **non-decreasing** function of the chain, such as `block.timestamp` or `block.number`.
 
 ```yaml
 - name: clock
@@ -40,19 +51,17 @@ This function returns the current timepoint. It could be `block.timestamp`, `blo
       type: uint48
 ```
 
-### CLOCK_MODE
+#### CLOCK_MODE
 
-This function returns a string describing the clock the contract is operating on.
+This function returns a machine-readable string description of the clock the contract is operating on.
+
+This string MUST be formatted like a URL query string (a.k.a. `application/x-www-form-urlencoded`), decodable in standard JavaScript with `new URLSearchParams(CLOCK_MODE)`.
 
 - If operating using **block number**:
-  - If the block numbers are those of the `NUMBER` opcode (`0x43`), then this function SHOULD return `mode=blocknumber&from=default`.
-  - If it is any other block number, then this function SHOULD return `mode=blocknumber&from=<CAIP2ID>`, where `<CAIP2ID>` is a CAIP-2 Blockchain ID such as `eip155:1`.
-- If operating using **timestamp**, then this function SHOULD return `mode=timestamp`.
+  - If the block number is that of the `NUMBER` opcode (`0x43`), then this function MUST return `mode=blocknumber&from=default`.
+  - If it is any other block number, then this function MUST return `mode=blocknumber&from=<CAIP-2-ID>`, where `<CAIP-2-ID>` is a CAIP-2 Blockchain ID such as `eip155:1`.
+- If operating using **timestamp**, then this function MUST return `mode=timestamp`.
 - If operating using any other mode, then this function SHOULD return a unique identifier for the encoded `mode` field.
-
-Note that when operating using **block number**, the `clock()` is expected to return the value given by the `NUMBER` opcode (`0x43`). In some cases, this can be the block number of another chain (in arbitrum, opcode `0x43` returns the block number of the last recorded operation on the parent chain). A contract can use `from=default` to specify that the block number used is the one provided by the `NUMBER` opcode (`0x43`). If a more explicit description is needed, CAIP-2 blockchain id should be used to identify the corresponding blockchain.
-
-The return string MUST be formatted like a URL query string (a.k.a. `application/x-www-form-urlencoded`). This allows easy decoding in standard JavaScript with `new URLSearchParams(CLOCK_MODE)`.
 
 ```yaml
 - name: CLOCK_MODE
@@ -64,24 +73,11 @@ The return string MUST be formatted like a URL query string (a.k.a. `application
       type: string
 ```
 
-### Solidity interface
-
-```sol
-interface IERC6372 {
-  function clock() external view returns (uint48);
-  function CLOCK_MODE() external view returns (string);
-}
-```
-
-### Expected properties
-
-- The `clock()` function MUST be non-decreasing.
-
 ## Rationale
 
-`clock` returns `uint48` as it is largely sufficient for storing realistic values. In timestamp mode, `uint48` will be enough until the year 8921556. Even in block number mode, with 10,000 blocks per second, it would be enough until the year 2861. Using a type smaller than uint256 allows some storage packing of timepoints with other associated values. Greatly reducing the cost of writing and reading from storage.
+`clock` returns `uint48` as it is largely sufficient for storing realistic values. In timestamp mode, `uint48` will be enough until the year 8921556. Even in block number mode, with 10,000 blocks per second, it would be enough until the year 2861. Using a type smaller than `uint256` allows storage packing of timepoints with other associated values, greatly reducing the cost of writing and reading from storage.
 
-Depending on the evolution of the blockchain (particularly layer twos), using a smaller type, such as `uint32` might cause issues fairly quickly. On the other hand, anything bigger than `uint48` is overkill.
+Depending on the evolution of the blockchain (particularly layer twos), using a smaller type, such as `uint32` might cause issues fairly quickly. On the other hand, anything bigger than `uint48` appears wasteful.
 
 ## Security Considerations
 


### PR DESCRIPTION
This PR clarifies that functions and the specified semantics are required rather than recommended for compliance.

Additionally, some other simplifiations and wording changes.