### PR TITLE
Add EIP: Multi-chain Native Tokens

### DIFF
--- a/EIPS/eip-6160.md
+++ b/EIPS/eip-6160.md
@@ -1,0 +1,77 @@
+---
+eip: 6160
+title: Multi-chain Native Tokens
+description: An interface for multi-chain native tokens.
+author:  Seun Lanlege (@seunlanlege), Sam Omidiora (@samparsky)
+discussions-to: https://ethereum-magicians.org/t/eip-6160-multichain-token-standard/12769
+status: Draft
+type: Standards Track
+category: ERC
+created: 2023-01-31
+requires: 20, 5679, 5982
+---
+
+## Abstract
+
+We propose new [`ERC20`](./eip-20.md), [`ERC721`](./eip-721.md) and [`ERC1155`](./eip-1155.md) extension interfaces which will allow provably secure, trustless bridge contracts to mint & burn tokens, enabling a new class of `ERC` tokens that can be native to multiple chains.
+
+## Motivation
+
+[EIP-4844](./eip-4844.md) will set the stage for the Cambrian explosion of L2s on Ethereum. With multiple L2s living on the ethereum blockchain, It therefore becomes necessary to standardize an interface that will allow for native `ERC` tokens to flow across these L2s, removing the need for wrapped representations of these assets.
+
+Optimisim and Arbitrum, optimistic L2s which are already live on Ethereum today currently have their own custom token interfaces¹ that allow their bridge contracts to mint & burn tokens on L1 & L2. In order to remove the cognitive load on token issuers & developers from extending multiple interface for all the various L2s that will live on Ethereum. It becomes necessary to define a standardized API that all token issuers should implement in order to provide these trustless bridge contracts with the interface needed to transport tokens across these different chains.
+
+## Specification
+
+The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be interpreted as described in RFC 2119.
+
+Smart contracts implementing the EIP-6160 standard MUST implement all of the functions in the `EIP-6160` interface.
+
+Smart contracts implementing the EIP-6160 standard MUST implement the `EIP-165 supportsInterface` function and MUST return the constant value `true` if *`0x01cbdea7`* is passed through the `interfaceID` argument.
+
+1. Any contract complying with [EIP-20](./eip-20.md) when extended with this EIP, **MUST** implement the following interface:
+
+```solidity
+// The EIP-165 identifier of this interface is 0x01cbdea7*
+interface IERC6160Ext20 is IERC5679Ext20, IERC_ACL_CORE, ERC165 {}
+```
+
+2. Any contract complying with [EIP-721](./eip-721.md) when extended with this EIP, **MUST** implement the following interface:
+
+```solidity
+// The EIP-165 identifier of this interface is 0x01cbdea7*
+*interface IERC6160Ext721 is IERC5679Ext721, IERC_ACL_CORE, ERC165 {}
+```
+
+3. Any contract complying with [EIP-1155](./eip-1155.md) when extended with this EIP, **MUST** implement the following interface:
+
+```solidity
+// The EIP-165 identifier of this interface is 0x01cbdea7*
+interface IERC6160Ext1155 is IERC5679Ext1155, IERC_ACL_CORE, ERC165 {}
+```
+
+4. It is RECOMMENDED for compliant contracts to implement the optional extension `IERC_ACL_GENERAL`.
+5. Compliant contracts MAY implement the optional extension `IERC_ACL_METADATA`.
+
+## Rationale
+
+1. We have chosen the [EIP-5679](./eip-5679.md) standard to provide the mint & burn interface.
+2. We have chosen [EIP-5982](./eip-5982.md) standard to provide the access control interface for trustless bridge contracts to check their permissions to mint & burn `ERC20` tokens.
+3. We have chosen NOT to create new events but to require the usage of existing transfer event as required by EIP-20 EIP-721 and EIP-1155 for maximum compatibility.
+
+## Backwards Compatibility
+
+This EIP is designed to be compatible with EIP-20, EIP-721, EIP-1155.
+
+## Security Considerations
+
+This EIP depends on the security and soundness of the underlying bridge contract. This EIP strongly recommends that token issuers permit only trustless, audited bridge contracts with permissions to mint & burn tokens or risk infinte token minting attacks.
+
+## References
+
+¹ Arbitrum: [ICustomToken](https://github.com/OffchainLabs/token-bridge-contracts/blob/main/contracts/tokenbridge/ethereum/ICustomToken.sol),  [IArbToken](https://github.com/OffchainLabs/token-bridge-contracts/blob/main/contracts/tokenbridge/arbitrum/IArbToken.sol). Optimism: [IL2StandardERC20](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts/contracts/standards/IL2StandardERC20.sol).
+
+
+## Copyright
+
+Copyright and related rights waived via [CC0](../LICENSE.md).

--- a/EIPS/eip-6160.md
+++ b/EIPS/eip-6160.md
@@ -32,22 +32,22 @@ Smart contracts implementing the EIP-6160 standard MUST implement the `EIP-165 
 1. Any contract complying with [EIP-20](./eip-20.md) when extended with this EIP, **MUST** implement the following interface:
 
 ```solidity
-// The EIP-165 identifier of this interface is 0x01cbdea7*
-interface IERC6160Ext20 is IERC5679Ext20, IERC_ACL_CORE, ERC165 {}
+// The EIP-165 identifier of this interface is 0xbbb8b47e
+interface IERC6160Ext20 is IERC5679Ext20, IERC_ACL_CORE {}
 ```
 
 2. Any contract complying with [EIP-721](./eip-721.md) when extended with this EIP, **MUST** implement the following interface:
 
 ```solidity
-// The EIP-165 identifier of this interface is 0x01cbdea7*
-*interface IERC6160Ext721 is IERC5679Ext721, IERC_ACL_CORE, ERC165 {}
+// The EIP-165 identifier of this interface is 0xa75a5a72
+*interface IERC6160Ext721 is IERC5679Ext721, IERC_ACL_CORE {}
 ```
 
 3. Any contract complying with [EIP-1155](./eip-1155.md) when extended with this EIP, **MUST** implement the following interface:
 
 ```solidity
-// The EIP-165 identifier of this interface is 0x01cbdea7*
-interface IERC6160Ext1155 is IERC5679Ext1155, IERC_ACL_CORE, ERC165 {}
+// The EIP-165 identifier of this interface is 0x9f77104c
+interface IERC6160Ext1155 is IERC5679Ext1155, IERC_ACL_CORE {}
 ```
 
 4. It is RECOMMENDED for compliant contracts to implement the optional extension `IERC_ACL_GENERAL`.
@@ -58,6 +58,9 @@ interface IERC6160Ext1155 is IERC5679Ext1155, IERC_ACL_CORE, ERC165 {}
 1. We have chosen the [EIP-5679](./eip-5679.md) standard to provide the mint & burn interface.
 2. We have chosen [EIP-5982](./eip-5982.md) standard to provide the access control interface for trustless bridge contracts to check their permissions to mint & burn `ERC20` tokens.
 3. We have chosen NOT to create new events but to require the usage of existing transfer event as required by EIP-20 EIP-721 and EIP-1155 for maximum compatibility.
+
+## Implementation
+We have made an example implementation for this EIP at [polytope-labs implementation](https://github.com/polytope-labs/multichain-native-tokens/tree/main/src/tokens)
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
This EIP standardizes the interface for `ERC20` token contracts which will allow provably secure, trustless bridge contracts to mint & burn tokens, enabling a new class of `ERC20` tokens that can be native to multiple chains.

[rendered](https://github.com/polytope-labs/EIPs/blob/master/EIPS/eip-6160.md)