### PR TITLE
Update new design for better compatibility

### DIFF
--- a/EIPS/eip-6120.md
+++ b/EIPS/eip-6120.md
@@ -2,13 +2,13 @@
 eip: 6120
 title: Universal Token Router
 description: A single router contract enables tokens to be sent to application contracts in the transfer-and-call manner instead of approve-then-call.
-author: Zergity (@Zergity), Zergity <zergity@gmail.com>
+author: Zergity (@Zergity), Ngo Quang Anh (@anhnq82), BerlinP (@BerlinP)
 discussions-to: https://ethereum-magicians.org/t/eip-6120-universal-token-router/12142
 status: Review
 type: Standards Track
 category: ERC
 created: 2022-12-12
-requires: 20, 721, 1155
+requires: 20, 721, 1014, 1155
 ---
 
 ## Abstract
@@ -21,14 +21,14 @@ The Universal Token Router (UTR) separates the token allowance from the applicat
 
 Tokens approved to the Universal Token Router can only be spent in transactions directly signed by their owner, and they have clearly visible token transfer behavior, including token types (ETH, [EIP-20](./eip-20.md), [EIP-721](./eip-721.md) or [EIP-1155](./eip-1155.md)), `amountInMax`, `amountOutMin`, and `recipient`.
 
-The Universal Token Router contract is counter-factually deployed using `CREATE2` at a single address across all EVM-compatible networks, so new token contracts can pre-configure it as a trusted spender and no approval transaction is necessary ever again.
+The Universal Token Router contract is counter-factually deployed using [EIP-1014](./eip-1014.md) at a single address across all EVM-compatible networks, so new token contracts can pre-configure it as a trusted spender and no approval transaction is necessary ever again.
 
 ## Motivation
 
 When users approve their tokens to a contract, they trust that:
 
-* it only spends the tokens with their permission (usually from `msg.sender` or using `ecrecover`)
-* it does not use `delegatecall` (mostly in upgradable proxies)
+* it only spends the tokens with their permission (from `msg.sender` or `ecrecover`)
+* it does not use `delegatecall` (e.g. upgradable proxies)
 
 By performing the same security conditions above, the Universal Token Router can be shared by all applications, saving `(n-1)*m*l` approval transactions for old tokens and **ALL** approval transactions for new tokens.
 
@@ -42,85 +42,189 @@ Application contracts follow this standard can use the Universal Token Router to
 * Freely update their helper contract logic.
 * Save development and security audit costs on router contracts.
 
-The Universal Token Router promotes the **security-by-result** model in decentralized applications instead of **security-by-process**. By directly querying token balance change for output verification, user transactions can be secured even while interacting with erroneous or malicious contracts. With non-token results, application helper contracts can provide additional result-checking functions for UTR's output action.
+The Universal Token Router promotes the **security-by-result** model in decentralized applications instead of **security-by-process**. By directly querying token balance change for output verification, user transactions can be secured even when interacting with erroneous or malicious contracts. With non-token results, application helper contracts can provide additional result-checking functions for UTR's output verification.
 
 ## Specification
 
-```solidity
-struct Token {
-    uint eip;       // token standard: 0 for ETH or EIP number
-    address adr;    // token contract address
-    uint id;        // token id for EIP721 and EIP1155
-    uint amount;    // amountInMax for input action, amountOutMin for output action
-    uint offset;    // with input actions: byte offset to get the amountIn from the lastInputResult bytes
-                    // with output actions: 0 for token balance change verification, or output token transfer
-    address recipient;
-}
-```
+The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “NOT RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be interpreted as described in RFC 2119 and RFC 8174.
 
-```solidity
-struct Action {
-    uint output;    // 0 for input, 1 for mandatory output, 2 for optional (failable) output
-    address code;   // contract code address
-    bytes data;     // contract input data
-    Token[] tokens; // tokens to transfer or verify balance
-}
-```
+The main interface of the UTR contract:
 
 ```solidity
 interface IUniversalTokenRouter {
-    function exec(Action[] calldata actions) external payable;
+    function exec(
+        Output[] memory outputs,
+        Action[] memory actions
+    ) external payable;
+    ...
 }
 ```
 
-### Input Action
+### Output Verification
 
-Actions with `action.output == 0` declare which and how many tokens are transferred from `msg.sender` to `token.recipient`.
+`Output` defines expected token balances change for verification.
 
-1. If the `action.data` is not empty, `action.code.call(action.data)` is executed and the value returned is recorded in `lastInputResult` as a `bytes` for subsequence token transfer amounts.
-2. For each `token` in `action.tokens`:
-   * (a) The amount of token to be transferred is determined as:
-     * if `offset < 32`, `amountIn = token.amount`
-     * if `offset >= 32`, `amountIn = lastInputResult.slice(offset-32, offset)`
-     * `amountIn` MUST NOT be greater than `token.amount`, otherwise, the transaction will be reverted with `EXCESSIVE_INPUT_AMOUNT`.
-   * (b) If the token is `ETH` and the `recipient` is `0x0`, the next step **(c)** is skipped and the `amountIn` will be passed to the next output action as the transaction value.
-   * (c) Transfer `amountIn` of token from `msg.sender` to `recipient`.
-
-Note: `lastInputResult` is the last value returned by an input action's code contract call. It can be shared by multiple input actions until another action's code is executed. Using `lastInputResult` before any input action execution can produce unexpected `amountIn` values.
-
-### Output Action
-
-Actions with `action.output > 0` declare the main application action to execute, and optionally transfer and verify the output tokens after that.
-
-1. If the `action.data` is not empty, execute the `action.code.call{value: value}(action.data)`, where:
-   * `value` can be zero or the `amountIn` of the last `ETH` input with `recipient == 0x0` (see Input Action 2b),
-   * any failure of the output execution will be ignored if the `action.output == 2`
-2. For each `token` in `action.tokens`:
-   * if `token.offset > 0`, transfer the following `amountOut` of token from `this` (UTR contract) to `token.recipient`:
-     * if `token.offset >= 32`, `amountOut = lastInputResult.slice(offset-32, offset)`
-     * if `token.offset == 1`:
-       * if `token.amount > 0`, `amountOut = token.amount`,
-       * if `token.amount == 0`, `amountOut` is the current token balance owned by `this` (UTR contract).
-   * if `token.offset == 0`, verify the balance change of `token.recipient`. The balance change MUST NOT be less than `token.amount` of each token, otherwise, the transaction will be reverted with `INSUFFICIENT_OUTPUT_AMOUNT`.
-
-The last `lastInputResult` bytes can be passed to an output action code execution by:
-
-* using a function with the last param as a `bytes` type.
-* pass the following value to that last param in the output `action.data`:
-
-```
-LAST_INPUT_RESULT = keccak256('UniversalTokenRouter.LAST_INPUT_RESULT')
+```solidity
+struct Output {
+    address recipient;
+    uint eip;           // token standard: 0 for ETH or EIP number
+    address token;      // token contract address
+    uint id;            // token id for EIP-721 and EIP-1155
+    uint amountOutMin;
+}
 ```
 
-### Output Token Verification
+Token balances of `recipient` are queried before and after of the `exec` function for each item in `outputs` and compare against `amountOutMin`. Transaction will revert with `INSUFFICIENT_OUTPUT_AMOUNT` if any of the balance change is less than its `amountOutMin`.
 
-At the very beginning of the `exec` function, for all output actions, each token with `token.offset == 0` has its balance of `token.recipient` recorded for later verification. After each output action, those token balances are queried again for comparison.
+A special id `ID_721_ALL` is reserved for EIP-721, which can be used in output actions to verify the total amount of all ids owned by the `recipient` address.
 
-A special id `EIP_721_ALL` is reserved for EIP-721, which can be used in output actions to verify the total amount of all ids owned by the `recipient` address.
-
+```solidity
+ID_721_ALL = keccak256('UniversalTokenRouter.ID_721_ALL')
 ```
-EIP_721_ALL = keccak256('UniversalTokenRouter.EIP_721_ALL')
+
+### Action
+
+`Action` defines the contract call and its token inputs to be done in advance.
+
+```solidity
+struct Action {
+    Input[] inputs;
+    uint flags;
+    address code;       // contract code address
+    bytes data;         // contract input data
+}
 ```
+
+`flags` can take any number of the following bit flags:
+
+* `0x1 = ACTION_IGNORE_ERROR` ignores the contract call failure.
+* `0x2 = ACTION_RECORD_CALL_RESULT` records the contract call result in a `bytes` for subsequence action.
+* `0x4 = ACTION_INJECT_CALL_RESULT` injects the last call result `bytes` recorded to the last `bytes` param of the contract function `data`.
+* `0x8 = ACTION_FORWARD_CALLBACK` stores the `code` address as the target for callback forwarding. This address will be reset before the `exec` function ends.
+
+### Input
+
+`Input` defines input token to transfer or prepare before the action contract is executed.
+
+```solidity
+struct Input {
+    uint mode;
+    address recipient;
+    uint eip;           // token standard: 0 for ETH or EIP number
+    address token;      // token contract address
+    uint id;            // token id for EIP721 and EIP1155
+    uint amountInMax;
+    uint amountSource;  // where to get the actual amountIn
+}
+```
+
+`mode` can takes one of the following values:
+
+* `0x0 = TRANSFER_FROM_SENDER`: transfers the token from `msg.sender` to `recipient`.
+* `0x1 = TRANSFER_FROM_ROUTER`: transfers the token from `this` UTR contract to `recipient`.
+* `0x2 = TRANSFER_CALL_VALUE`: passes the ETH amount to the action call as `value`.
+* `0x100 = ALLOWANCE_CALLBACK`: allows the token to be spent in a callback of the same transaction.
+* `0x200 = ALLOWANCE_BRIDGE`: transfers the token from `msg.sender` to `this` UTR contract and allows them to be spent in the contract call.
+
+`amountSource` defines how the actual token `amountIn` is aqquired from:
+
+* `0x0 = AMOUNT_EXACT`: use the exact value of `amountInMax`.
+* `0x1 = AMOUNT_ALL`: use the entire balance of the sender.
+* otherwise, extracts the `uint256` value starting from the `amountSource`-th byte of the last recorded call result `bytes`. This value can be arbitrary if there's no prior action with the `ACTION_RECORD_CALL_RESULT` flag.
+
+`amountIn` MUST NOT be greater than `amountInMax`, otherwise, the transaction will be reverted with `EXCESSIVE_INPUT_AMOUNT`.
+
+#### Allowance Bridge
+
+`ALLOWANCE_BRIDGE` is the compatibility mode for application contracts that require token approval directly from `msg.sender`.
+
+For each `Input` with `ALLOWANCE_BRIDGE` mode:
+
+* `amountIn` of token is transfered from `msg.sender` to `this` UTR contract.
+* `recipient` is allowed to spend the token from `this` UTR contract.
+
+Before the end of the `exec` function:
+
+* all allowances are revoked.
+* all left-over token is transfered back to `msg.sender`.
+
+#### Payment In Callback
+
+`ALLOWANCE_CALLBACK` is used for application contracts that use transfer-in-callback pattern. (E.g. flashloan contracts, Uniswap/v3-core, etc.)
+
+```solidity
+struct Transfer {
+    address sender;
+    address recipient;
+    uint eip;
+    address token;
+    uint id;
+    uint amount;
+}
+
+interface IUniversalTokenRouter {
+    ...
+
+    function transferToken(
+        address sender,
+        address recipient,
+        uint eip,
+        address token,
+        uint id,
+        uint amount
+    ) external;
+
+    function transferTokens(Transfer[] calldata transfers) external;
+}
+```
+
+For each `Input` with `ALLOWANCE_CALLBACK` mode, atmost `amountIn` of the token is allowed to transfered from `msg.sender` to `recipient` by calling `UTR.transferToken` in the same transaction. The `UTR.transferToken` function is expected to be called by application contract directly or indirectly via callbacks. Calling `UTR.transferToken` only success with the same token, sender and recipient in the same transaction.
+
+    UTR
+     |
+     | TOKEN_ALLOWANCE_CALLBACK
+     | (allowance for UTR.transferToken)
+     |
+     |                                  Application Contracts
+    action.code.call ---------------------> |
+                                            |
+    UTR.transferToken <------------- (call) |
+                                            |
+     | <-------------------------- (return) |
+     |
+     | (clear all allowance)
+     |
+    END
+
+### Callback Forwarding
+
+Some application contracts invoke callback from its caller (e.g. Uniswap/v3-core), which is the UTR contract in this case. Action flag `ACTION_FORWARD_CALLBACK` can be used to register an `IUTRCallback` target address so any unknown function calls to the UTR contract in the same transaction will be wrapped and forwarded to it.
+
+```solidity
+interface IUTRCallback {
+    // 0x3696d736
+    function utrCallback(
+        address caller,
+        bytes memory data
+    ) external payable;
+}
+```
+
+The `data` param contains both the 4 bytes function signature and its param of the original callback function call.
+
+                       UTR
+                        |
+                        | ACTION_FORWARD_CALLBACK
+                        |
+                        |                   Application Contracts
+                       action.code.call ------> |
+                                                |
+                                                | 
+      (target) <------ UTR <-------- (callback) |
+    IUTRCallback --------------------> (return) |
+                                                |
+                        | <----------- (return) |
+                        :
 
 ### Usage Samples
 
@@ -154,29 +258,30 @@ This transaction is signed by users to execute the swap instead of the legacy fu
 
 ```javascript
 UniversalTokenRouter.exec([{
-    output: 0,
-    code: AddressZero,
-    data: '0x',
-    tokens: [{
+    recipient: to,
+    eip: 20,
+    token: path[path.length-1],
+    id: 0,
+    amountOutMin,
+}], [{
+    inputs: [{
+        mode: TRANSFER_FROM_SENDER,
+        recipient: UniswapV2Library.pairFor(factory, path[0], path[1]),
         eip: 20,
         token: path[0],
         id: 0,
-        offset: 0, // use the exact amount specified bellow
-        amount: amountIn,
-        recipient: UniswapV2Library.pairFor(factory, path[0], path[1]),
+        amountInMax: amountIn,
+        amountSource: AMOUNT_EXACT,
     }],
-}, {
-    output: 1,
+    flags: 0,
     code: UniswapV2Helper01.address,
-    data: encodeFunctionData("swapExactTokensForTokens", [amountIn, amountOutMin, path, to, deadline]),
-    tokens: [{
-        offset: 0, // balance change verification
-        eip: 20,
-        token: path[path.length-1],
-        id: 0,
-        amount: amountOutMin,
-        recipient: to,
-    }],
+    data: encodeFunctionData("swapExactTokensForTokens", [
+        amountIn,
+        amountOutMin,
+        path,
+        to,
+        deadline,
+    ]),
 }])
 ```
 
@@ -197,9 +302,13 @@ UniswapV2Router01.swapTokensForExactTokens(
 This function accepts the `uint[] amounts` as the last `bytes` param, decode and pass to the internal function `_swap` of `UniswapV2Helper01`.
 
 ```solidity
-UniswapV2Helper01.swap(address[] calldata path, address _to, bytes calldata amountsBytes) external {
+UniswapV2Helper01.swap(
+    address[] calldata path,
+    address to,
+    bytes calldata amountsBytes
+) external {
     uint[] memory amounts = abi.decode(amountsBytes, (uint[]));
-    _swap(amounts, path, _to);
+    _swap(amounts, path, to);
 }
 ```
 
@@ -207,33 +316,33 @@ This transaction is signed by users to execute the swap instead of the legacy fu
 
 ```javascript
 UniversalTokenRouter.exec([{
-    output: 0,
+    eip: 20,
+    token: path[path.length-1],
+    id: 0,
+    amountOutMin: amountOut,
+    recipient: to,
+}], [{
+    inputs: [],
+    flags: ACTION_RECORD_CALL_RESULT,
     code: UniswapV2Helper01.address,
     data: encodeFunctionData("getAmountIns", [amountOut, path]),
-    tokens: [{
+}, {
+    inputs: [{
+        mode: TRANSFER_FROM_SENDER,
         eip: 20,
         token: path[0],
         id: 0,
-        offset: 32*3, // first item of getAmountIns result array
-        amount: amountInMax,
+        amountInMax,
+        amountSource: 32*3, // first item of getAmountIns result array
         recipient: UniswapV2Library.pairFor(factory, path[0], path[1]),
     }],
-}, {
-    output: 1,
+    flags: ACTION_INJECT_CALL_RESULT,
     code: UniswapV2Helper01.address,
-    data: encodeFunctionData("swap", [path, to, LAST_INPUT_RESULT]),
-    tokens: [{
-        offset: 0, // balance change verification
-        eip: 20,
-        token: path[path.length-1],
-        id: 0,
-        amount: amountOut,
-        recipient: to,
-    }],
+    data: encodeFunctionData("swap", [path, to, '0x']),
 }])
 ```
 
-The result of input action's `getAmountIns` will replace the `LAST_INPUT_RESULT` bytes, save the transaction from calculating twice with the same data.
+The result of `getAmountIns` is recorded and injected into the empty `bytes`, save the transaction from calculating twice with the same data.
 
 #### `UniswapRouter.addLiquidity`
 
@@ -252,11 +361,18 @@ UniswapV2Router01.addLiquidity(
 )
 ```
 
-This transaction is signed by users to execute the swap instead of the legacy function:
+This transaction is signed by users instead of the legacy function:
 
 ```javascript
 UniversalTokenRouter.exec([{
-    output: 0,
+    eip: 20,
+    token: UniswapV2Library.pairFor(factory, tokenA, tokenB),
+    id: 0,
+    amountOutMin: 1,  // just enough to verify the correct recipient
+    recipient: to,
+}], [{
+    inputs: [],
+    flags: ACTION_RECORD_CALL_RESULT,
     code: UniswapV2Helper01.address,
     data: encodeFunctionData("_addLiquidity", [
         tokenA,
@@ -266,43 +382,113 @@ UniversalTokenRouter.exec([{
         amountAMin,
         amountBMin,
     ]),
-    tokens: [{
+}, {
+    inputs: [{
+        mode: TRANSFER_FROM_SENDER,
         eip: 20,
         token: tokenA,
         id: 0,
-        offset: 32,             // first item of _addLiquidity results
-        amount: amountADesired, // amountInMax
+        amountSource: 32,             // first item of _addLiquidity results
+        amountInMax: amountADesired,
         recipient: UniswapV2Library.pairFor(factory, tokenA, tokenB),
     }, {
+        mode: TRANSFER_FROM_SENDER,
         eip: 20,
         token: tokenB,
         id: 0,
-        offset: 64,             // second item of _addLiquidity results
-        amount: amountBDesired, // amountInMax
+        amountSource: 64,             // second item of _addLiquidity results
+        amountInMax: amountBDesired,
         recipient: UniswapV2Library.pairFor(factory, tokenA, tokenB),
     }],
-}, {
-    output: 1,
+    flags: 0,
     code: UniswapV2Library.pairFor(factory, tokenA, tokenB),
     data: encodeFunctionData("mint", [to]),
-    tokens: [{
-        offset: 0,  // balance change verification
-        eip: 20,
-        token: UniswapV2Library.pairFor(factory, tokenA, tokenB),
-        id: 0,
-        amount: 1,  // amountOutMin: just enough to verify the correct recipient
-        recipient: to,
-    }],
 }])
 ```
 
-The `tokens` verification of the last output action is not performed by Uniswap's legacy function and can be skipped. But the output token verification SHOULD always be done for the `UniversalTokenRouter` so user can see and review the token behavior instead of blindly trust the front-end code.
+The output token verification is not performed by Uniswap's legacy function and can be skipped. But it SHOULD always be done for the `UniversalTokenRouter` so user can see and review the token behavior instead of blindly trust the front-end code.
+
+#### Uniswap V3 `SwapRouter`
+
+Legacy router contract functions:
+
+```solidity
+contract SwapRouter {
+    // this function is called by pool to pay the input tokens
+    function pay(
+        address token,
+        address payer,
+        address recipient,
+        uint256 value
+    ) internal {
+        ...
+        // pull payment
+        TransferHelper.safeTransferFrom(token, payer, recipient, value);
+    }
+}
+```
+
+Helper contract to use with the `UTR` instead of `SwapRouter`
+
+```solidity
+contract SwapHelper {
+    // this function is called by pool to pay the input tokens
+    function pay(
+        address token,
+        address payer,
+        address recipient,
+        uint256 value
+    ) internal {
+        ...
+        // pull payment
+        UTR.transferToken(
+            payer,
+            recipient,
+            20,     // EIP
+            token,
+            0,      // id
+            value
+        );
+    }
+}
+```
+
+This transaction is signed by users to execute the `mint` instead of the legacy function:
+
+```javascript
+UniversalTokenRouter.exec([{
+    eip: 20,
+    token: pool.address,
+    id: ID_721_ALL,
+    amountOutMin: 1,  // expect one more liquidity NFT 
+    recipient: to,
+}], [{
+    inputs: [{
+        mode: ALLOWANCE_CALLBACK,
+        eip: 20,
+        token: tokenA,
+        id: 0,
+        amountSource: AMOUNT_EXACT,
+        amountInMax: amountADesired,
+        recipient: pool.address,
+    }, {
+        mode: ALLOWANCE_CALLBACK,
+        eip: 20,
+        token: tokenB,
+        id: 0,
+        amountSource: AMOUNT_EXACT,
+        amountInMax: amountBDesired,
+        recipient: pool.address,
+    }],
+    flags: 0,
+    code: SwapHelper.address,
+    data: encodeFunctionData("mint", [...]),
+}])
+```
 
 ## Rationale
 
 The `Permit` type signature is not supported since the purpose of the Universal Token Router is to eliminate all `approve` signatures for new tokens, and *most* for old tokens.
-
-Flashloan transactions are out of scope since it requires support from the application contracts themself.
 
 ## Backwards Compatibility
 
@@ -314,6 +500,8 @@ New token contracts can pre-configure the Universal Token Router as a trusted sp
 
 ### Application Contracts
 
+Application contracts that use `msg.sender` as the beneficiary address in their internal storage without any function for ownership transfer are **INCOMPATIBLE** with the UTR.
+
 All application contracts that accept `recipient` (or `to`) argument instead of using `msg.sender` as the beneficiary address are compatible with the UTR out of the box.
 
 Application contracts that transfer tokens (EIP-20, EIP-721, and EIP-1155) to `msg.sender` can use the UTR output token transfer sub-action to re-direct tokens to another `recipient` address.
@@ -321,31 +509,38 @@ Application contracts that transfer tokens (EIP-20, EIP-721, and EIP-1155) to `m
 ```javascript
 // sample code to deposit WETH and transfer them out
 UniversalTokenRouter.exec([{
-    output: 0,
-    code: AddressZero,
-    data: '0x',
-    tokens: [{
-        eip: 0,                 // ETH
-        adr: AddressZero,
+    eip: 20,
+    token: WETH.address,
+    id: 0,
+    amountOutMin: 1,
+    recipient: SomeRecipient,
+}], [{
+    inputs: [{
+        mode: TRANSFER_CALL_VALUE,
+        eip: 0, // ETH
+        token: AddressZero,
         id: 0,
-        offset: 0,              // use the exact amount specified bellow
-        amount: 123,
+        amountInMax: 123,
+        amountSource: AMOUNT_EXACT,
         recipient: AddressZero, // pass it as the value for the next output action
     }],
-}, {
-    output: 1,
+    flags: 0,
     code: WETH.address,
-    data: encodeFunctionData('deposit', []),    // WETH.deposit returns WETH token to the UTR contract
-    tokens: [{
-        offset: 1,  // token transfer sub-action
+    data: encodeFunctionData('deposit', []), // WETH.deposit returns WETH token to the UTR contract
+}, {
+    inputs: [{
+        mode: TRANSFER_FROM_ROUTER,
         eip: 20,
-        adr: WETH.address,
+        token: WETH.address,
         id: 0,
-        amount: 0,  // entire WETH balance of this UTR contract
+        amountInMax: 0,             // no limit
+        amountSource: AMOUNT_ALL,   // entire WETH balance of this UTR contract
         recipient: SomeRecipient,
     }],
-}, {
     // ... continue to use WETH in SomeRecipient
+    flags: 0,
+    code: AddressZero,
+    data: '0x',
 }], {value: 123})
 ```
 
@@ -362,97 +557,145 @@ contract WethAdapter {
 }
 ```
 
-Application contracts that use `msg.sender` as the beneficiary address in their internal storage without any function for ownership transfer are incompatible with the UTR.
-
 ## Reference Implementation
 
 ```solidity
 contract UniversalTokenRouter is IUniversalTokenRouter {
-    uint constant LAST_INPUT_RESULT = uint(keccak256('UniversalTokenRouter.LAST_INPUT_RESULT'));
-    uint constant EIP_721_ALL = uint(keccak256('UniversalTokenRouter.EIP_721_ALL'));
+    uint constant TRANSFER_FROM_SENDER  = 0x0;
+    uint constant TRANSFER_FROM_ROUTER  = 0x1;
+    uint constant TRANSFER_CALL_VALUE   = 0x2;
+
+    uint constant ALLOWANCE_CALLBACK  = 0x100;
+    uint constant ALLOWANCE_BRIDGE    = 0x200;
+
+    uint constant AMOUNT_EXACT      = 0;
+    uint constant AMOUNT_ALL        = 1;
+
+    uint constant EIP_ETH           = 0;
+
+    uint constant ID_721_ALL = uint(keccak256('UniversalTokenRouter.ID_721_ALL'));
+
+    uint constant ACTION_IGNORE_ERROR       = 1;
+    uint constant ACTION_RECORD_CALL_RESULT = 2;
+    uint constant ACTION_INJECT_CALL_RESULT = 4;
+    uint constant ACTION_FORWARD_CALLBACK   = 8;
+
+    // Storages: non-persistent, in-transaction use only
+    address internal s_forwardCallbackTo;
+    mapping(bytes32 => uint) s_allowances;
+
+    constructor() {
+        s_forwardCallbackTo = address(this);
+    }
 
     function exec(
-        Action[] calldata actions
+        Output[] memory outputs,
+        Action[] memory actions
     ) override external payable {
     unchecked {
-        // track the balances before any action is executed
-        uint[][] memory balances = new uint[][](actions.length);
+        // track the expected balances before any action is executed
+        for (uint i = 0; i < outputs.length; ++i) {
+            Output memory output = outputs[i];
+            uint balance = _balanceOf(output.recipient, output.eip, output.token, output.id);
+            uint expected = output.amountOutMin + balance;
+            require(expected >= balance, 'UniversalTokenRouter: OVERFLOW');
+            output.amountOutMin = expected;
+        }
+
+        bool forwarded = false;
+        bool allowed = false;
+
+        bytes memory callResult;
         for (uint i = 0; i < actions.length; ++i) {
-            if (actions[i].output == 0 || actions[i].tokens.length == 0) {
-                continue;
+            Action memory action = actions[i];
+            uint value;
+            for (uint j = 0; j < action.inputs.length; ++j) {
+                Input memory input = action.inputs[j];
+                uint mode = input.mode;
+                address sender = mode == TRANSFER_FROM_ROUTER ? address(this) : msg.sender; 
+                uint amount;
+                if (input.amountSource == AMOUNT_EXACT) {
+                    amount = input.amountInMax;
+                } else {
+                    if (input.amountSource == AMOUNT_ALL) {
+                        amount = _balanceOf(sender, input.eip, input.token, input.id);
+                    } else {
+                        amount = _sliceUint(callResult, input.amountSource);
+                    }
+                    if (amount > 0 && input.amountInMax > 0) {
+                        require(amount <= input.amountInMax, "UniversalTokenRouter: EXCESSIVE_INPUT_AMOUNT");
+                    }
+                }
+                if (mode == TRANSFER_CALL_VALUE) {
+                    value = amount;
+                    continue;
+                }
+                if (mode == TRANSFER_FROM_SENDER || mode == TRANSFER_FROM_ROUTER) {
+                    _transferToken(sender, input.recipient, input.eip, input.token, input.id, amount);
+                    continue;
+                }
+                if (mode == ALLOWANCE_CALLBACK) {
+                    bytes32 key = keccak256(abi.encodePacked(msg.sender, input.recipient, input.eip, input.token, input.id));
+                    s_allowances[key] += amount;  // overflow: harmless
+                    allowed = true;
+                    continue;
+                }
+                if (mode == ALLOWANCE_BRIDGE) {
+                    // TODO: can this be optimized for multiple ids cases?
+                    _approve(input.recipient, input.eip, input.token, type(uint).max);
+                    _transferToken(msg.sender, address(this), input.eip, input.token, input.id, amount);
+                    allowed = true;
+                }
             }
-            balances[i] = new uint[](actions[i].tokens.length);
-            for (uint j = 0; j < balances[i].length; ++j) {
-                if (actions[i].tokens[j].offset == 0) {
-                    balances[i][j] = _balanceOf(actions[i].tokens[j], actions[i].tokens[j].recipient);
+            if (action.data.length > 0) {
+                if (action.flags & ACTION_FORWARD_CALLBACK != 0) {
+                    s_forwardCallbackTo = action.code;
+                    forwarded = true;
+                }
+                if (action.flags & ACTION_INJECT_CALL_RESULT != 0) {
+                    action.data = _concat(action.data, action.data.length, callResult);
+                }
+                (bool success, bytes memory result) = action.code.call{value: value}(action.data);
+                if (!success && action.flags & ACTION_IGNORE_ERROR == 0) {
+                    assembly {
+                        revert(add(result,32),mload(result))
+                    }
+                }
+                // delete value;   // clear the ETH value after call
+                if (action.flags & ACTION_RECORD_CALL_RESULT != 0) {
+                    callResult = result;
                 }
             }
         }
 
-        uint value; // track the ETH value to pass to next output action transaction value
-        bytes memory lastInputResult;
-        for (uint i = 0; i < actions.length; ++i) {
-            Action memory action = actions[i];
-            if (action.output == 0) {
-                // input action
-                if (action.data.length > 0) {
-                    bool success;
-                    (success, lastInputResult) = action.code.call(action.data);
-                    if (!success) {
-                        assembly {
-                            revert(add(lastInputResult,32),mload(lastInputResult))
+        // verify balance changes
+        for (uint i = 0; i < outputs.length; ++i) {
+            Output memory output = outputs[i];
+            uint balance = _balanceOf(output.recipient, output.eip, output.token, output.id);
+            require(balance >= output.amountOutMin, 'UniversalTokenRouter: INSUFFICIENT_OUTPUT_AMOUNT');
+        }
+
+        // clear all in-transaction storages
+        if (forwarded) {
+            s_forwardCallbackTo = address(this);
+        }
+        if (allowed) {
+            for (uint i = 0; i < actions.length; ++i) {
+                Action memory action = actions[i];
+                for (uint j = 0; j < action.inputs.length; ++j) {
+                    Input memory input = action.inputs[j];
+                    if (input.mode == ALLOWANCE_CALLBACK) {
+                        bytes32 key = keccak256(abi.encodePacked(msg.sender, input.recipient, input.eip, input.token, input.id));
+                        delete s_allowances[key];
+                        continue;
+                    }
+                    if (input.mode == ALLOWANCE_BRIDGE) {
+                        // TODO: can this be optimized for multiple ids cases?
+                        _approve(input.recipient, input.eip, input.token, 0);
+                        uint balance = _balanceOf(address(this), input.eip, input.token, input.id);
+                        if (balance > 0) {
+                            _transferToken(address(this), msg.sender, input.eip, input.token, input.id, balance);
                         }
-                    }
-                }
-                for (uint j = 0; j < action.tokens.length; ++j) {
-                    Token memory token = action.tokens[j];
-                    if (token.offset >= 32) {
-                        // require(inputParams.length > 0, "UniversalTokenRouter: OFFSET_OF_EMPTY_INPUT");
-                        uint amount = _sliceUint(lastInputResult, token.offset);
-                        require(amount <= token.amount, "UniversalTokenRouter: EXCESSIVE_INPUT_AMOUNT");
-                        token.amount = amount;
-                    }
-                    if (token.eip == 0 && token.recipient == address(0x0)) {
-                        value = token.amount;
-                        // ETH not transfered here will be passed to the next output call value
-                    } else if (token.amount > 0) {
-                        _transferFrom(token, msg.sender);
-                    }
-                }
-            } else {
-                // output action
-                if (action.data.length > 0) {
-                    uint length = action.data.length;
-                    if (length >= 4+32*3 &&
-                        _sliceUint(action.data, length) == LAST_INPUT_RESULT &&
-                        _sliceUint(action.data, length-32) == 32)
-                    {
-                        action.data = _concat(action.data, length-32, lastInputResult);
-                    }
-                    (bool success, bytes memory result) = action.code.call{value: value}(action.data);
-                    // ignore output action error if output == 2
-                    if (!success && action.output == 2) {
-                        assembly {
-                            revert(add(result,32),mload(result))
-                        }
-                    }
-                    delete value; // clear the ETH value after transfer
-                }
-                for (uint j = 0; j < action.tokens.length; ++j) {
-                    Token memory token = actions[i].tokens[j];
-                    if (token.offset > 0) {
-                        // token transfer sub-action
-                        if (token.offset >= 32) {
-                            token.amount = _sliceUint(lastInputResult, token.offset);
-                        } else if (token.amount == 0) {
-                            token.amount = _balanceOf(token, address(this));
-                        }
-                        _transferFrom(token, address(this));
-                    } else {
-                        // verify the balance change
-                        uint balance = _balanceOf(token, token.recipient);
-                        uint change = balance - balances[i][j]; // overflow checked with `change <= balance` bellow
-                        require(change >= token.amount && change <= balance, 'UniversalTokenRouter: INSUFFICIENT_OUTPUT_AMOUNT');
                     }
                 }
             }
@@ -465,52 +708,148 @@ contract UniversalTokenRouter is IUniversalTokenRouter {
         }
     } }
 
-    function _transferFrom(Token memory token, address from) internal {
-    unchecked {
-        if (token.eip == 20) {
-            if (from == address(this)) {
-                TransferHelper.safeTransfer(token.adr, token.recipient, token.amount);
-            } else {
-                TransferHelper.safeTransferFrom(token.adr, from, token.recipient, token.amount);
+    // accepting ETH
+    receive() external payable {}
+
+    // forward callback to s_forwardCallbackTo
+    fallback() external payable {
+        address target = s_forwardCallbackTo;
+        require(target != address(this), 'UniversalTokenRouter: MISSING_ACTION_FORWARD_CALLBACK');
+        bytes memory data;
+        assembly {
+            calldatacopy(data, 0, calldatasize())
+        }
+        data = abi.encodeWithSelector(0x3696d736, msg.sender, data);
+        assembly {
+            // forward the callback
+            let success := call(gas(), target, callvalue(), data, mload(data), 0, 0)
+
+            // We take full control of memory in this inline assembly
+            // block because it will not return to Solidity code. We overwrite the
+            // Solidity scratch pad at memory position 0.
+
+            // Copy the returned data.
+            returndatacopy(0, 0, returndatasize())
+
+            switch success
+            // call returns 0 on error.
+            case 0 {
+                revert(0, returndatasize())
             }
-        } else if (token.eip == 1155) {
-            IERC1155(token.adr).safeTransferFrom(from, token.recipient, token.id, token.amount, "");
-        } else if (token.eip == 721) {
-            IERC721(token.adr).safeTransferFrom(from, token.recipient, token.id);
-        } else if (token.eip == 0) {
-            TransferHelper.safeTransferETH(token.recipient, token.amount);
+            default {
+                return(0, returndatasize())
+            }
+        }
+    }
+
+    function transferTokens(
+        Transfer[] calldata transfers
+    ) external {
+    unchecked {
+        for (uint i = 0; i < transfers.length; ++i) {
+            transferToken(
+                transfers[i].sender,
+                transfers[i].recipient,
+                transfers[i].eip,
+                transfers[i].token,
+                transfers[i].id,
+                transfers[i].amount
+            );
+        }
+    } }
+
+    function transferToken(
+        address sender,
+        address recipient,
+        uint eip,
+        address token,
+        uint id,
+        uint amount
+    ) public {
+        // TODO: test gas for abi.encode
+        bytes32 key = keccak256(abi.encodePacked(sender, recipient, eip, token, id));
+        require(s_allowances[key] >= amount, 'UniversalTokenRouter: INSUFFICIENT_ALLOWANCE');
+        s_allowances[key] -= amount;
+        _transferToken(sender, recipient, eip, token, id, amount);
+    }
+
+    function _transferToken(
+        address sender,
+        address recipient,
+        uint eip,
+        address token,
+        uint id,
+        uint amount
+    ) internal {
+        if (eip == 20) {
+            if (sender == address(this)) {
+                TransferHelper.safeTransfer(token, recipient, amount);
+            } else {
+                TransferHelper.safeTransferFrom(token, sender, recipient, amount);
+            }
+        } else if (eip == 1155) {
+            IERC1155(token).safeTransferFrom(sender, recipient, id, amount, "");
+        } else if (eip == 721) {
+            IERC721(token).safeTransferFrom(sender, recipient, id);
+        } else if (eip == EIP_ETH) {
+            require(sender == address(this), 'UniversalTokenRouter: INVALID_ETH_SENDER');
+            TransferHelper.safeTransferETH(recipient, amount);
         } else {
             revert("UniversalTokenRouter: INVALID_EIP");
         }
-    } }
+    }
 
-    function _balanceOf(Token memory token, address owner) internal view returns (uint balance) {
-    unchecked {
-        if (token.eip == 20) {
-            return IERC20(token.adr).balanceOf(owner);
+    function _approve(
+        address recipient,
+        uint eip,
+        address token,
+        uint amount
+    ) internal {
+        if (eip == 20) {
+            TransferHelper.safeApprove(token, recipient, amount);
+        } else if (eip == 1155) {
+            IERC1155(token).setApprovalForAll(recipient, amount > 0);
+        } else if (eip == 721) {
+            IERC721(token).setApprovalForAll(recipient, amount > 0);
+        } else {
+            revert("UniversalTokenRouter: INVALID_EIP");
         }
-        if (token.eip == 1155) {
-            return IERC1155(token.adr).balanceOf(owner, token.id);
+    }
+
+    function _balanceOf(
+        address owner,
+        uint eip,
+        address token,
+        uint id
+    ) internal view returns (uint balance) {
+        if (eip == 20) {
+            return IERC20(token).balanceOf(owner);
         }
-        if (token.eip == 721) {
-            if (token.id == EIP_721_ALL) {
-                return IERC721(token.adr).balanceOf(owner);
+        if (eip == 1155) {
+            return IERC1155(token).balanceOf(owner, id);
+        }
+        if (eip == 721) {
+            if (id == ID_721_ALL) {
+                return IERC721(token).balanceOf(owner);
             }
-            return IERC721(token.adr).ownerOf(token.id) == owner ? 1 : 0;
+            try IERC721(token).ownerOf(id) returns (address currentOwner) {
+                return currentOwner == owner ? 1 : 0;
+            } catch {
+                return 0;
+            }
         }
-        if (token.eip == 0) {
+        if (eip == EIP_ETH) {
             return owner.balance;
         }
         revert("UniversalTokenRouter: INVALID_EIP");
-    } }
+    }
 
     function _sliceUint(bytes memory bs, uint start) internal pure returns (uint x) {
-    unchecked {
         // require(bs.length >= start + 32, "slicing out of range");
         assembly {
             x := mload(add(bs, start))
         }
-    } }
+    }
 
     /// https://github.com/GNSPS/solidity-bytes-utils/blob/master/contracts/BytesLib.sol
     /// @param length length of the first preBytes
@@ -577,10 +916,10 @@ contract UniversalTokenRouter is IUniversalTokenRouter {
             // next 32 byte block, then round down to the nearest multiple of
             // 32. If the sum of the length of the two arrays is zero then add
             // one before rounding down to leave a blank 32 bytes (the length block with 0).
-            mstore(0x40, and(
-              add(add(end, iszero(add(length, mload(preBytes)))), 31),
-              not(31) // Round down to the nearest 32 bytes.
-            ))
+            // mstore(0x40, and(
+            //   add(add(end, iszero(add(length, mload(preBytes)))), 31),
+            //   not(31) // Round down to the nearest 32 bytes.
+            // ))
         }
     }
 }
@@ -588,7 +927,7 @@ contract UniversalTokenRouter is IUniversalTokenRouter {
 
 ## Security Considerations
 
-`LAST_INPUT_RESULT` SHOULD only be used in output action for gas optimization, not as trusted conditions. Application contract code MUST always expect arbitruary, malformed or mallicious `bytes` data can be passed in where the `LAST_INPUT_RESULT` is expected.
+`ACTION_INJECT_CALL_RESULT` SHOULD only be used for gas optimization, not as trusted conditions. Application contract code MUST always expect arbitruary, malformed or mallicious `bytes` data can be passed in where the `ACTION_INJECT_CALL_RESULT` is expected.
 
 ## Copyright
 

--- a/EIPS/eip-6120.md
+++ b/EIPS/eip-6120.md
@@ -62,7 +62,7 @@ interface IUniversalTokenRouter {
 
 ### Output Verification
 
-`Output` defines expected token balances change for verification.
+`Output` defines the expected token balance change for verification.
 
 ```solidity
 struct Output {
@@ -74,7 +74,7 @@ struct Output {
 }
 ```
 
-Token balances of `recipient` are queried before and after of the `exec` function for each item in `outputs` and compare against `amountOutMin`. Transaction will revert with `INSUFFICIENT_OUTPUT_AMOUNT` if any of the balance change is less than its `amountOutMin`.
+Token balances of the `recipient` address are recorded at the beginning and the end of the `exec` function for each item in `outputs`. Transaction will revert with `INSUFFICIENT_OUTPUT_AMOUNT` if any of the balance changes are less than its `amountOutMin`.
 
 A special id `ID_721_ALL` is reserved for EIP-721, which can be used in output actions to verify the total amount of all ids owned by the `recipient` address.
 
@@ -84,7 +84,7 @@ ID_721_ALL = keccak256('UniversalTokenRouter.ID_721_ALL')
 
 ### Action
 
-`Action` defines the contract call and its token inputs to be done in advance.
+`Action` defines the token inputs and the contract call.
 
 ```solidity
 struct Action {
@@ -97,13 +97,13 @@ struct Action {
 
 `flags` can take any number of the following bit flags:
 
-* `0x1 = ACTION_IGNORE_ERROR` ignores the contract call failure.
-* `0x2 = ACTION_RECORD_CALL_RESULT` records the contract call result in a `bytes` for subsequence action.
-* `0x4 = ACTION_INJECT_CALL_RESULT` injects the last call result `bytes` recorded to the last `bytes` param of the contract function `data`.
+* `0x1 = ACTION_IGNORE_ERROR`: any contract call failure will be ignored.
+* `0x2 = ACTION_RECORD_CALL_RESULT`: the contract call result will be recorded in a `bytes` for subsequent actions.
+* `0x4 = ACTION_INJECT_CALL_RESULT`: the last call result `bytes` recorded will be injected to the last empty `bytes` param of the contract function `data`.
 
 ### Input
 
-`Input` defines input token to transfer or prepare before the action contract is executed.
+`Input` defines the input token to transfer or prepare before the action contract is executed.
 
 ```solidity
 struct Input {
@@ -119,37 +119,23 @@ struct Input {
 
 `mode` can takes one of the following values:
 
-* `0x0 = TRANSFER_FROM_SENDER`: transfers the token from `msg.sender` to `recipient`.
-* `0x1 = TRANSFER_FROM_ROUTER`: transfers the token from `this` UTR contract to `recipient`.
-* `0x2 = TRANSFER_CALL_VALUE`: passes the ETH amount to the action call as `value`.
-* `0x100 = ALLOWANCE_CALLBACK`: allows the token to be spent in a callback of the same transaction.
-* `0x200 = ALLOWANCE_BRIDGE`: transfers the token from `msg.sender` to `this` UTR contract and allows them to be spent in the contract call.
+* `0x0 = TRANSFER_FROM_SENDER`: the token will be transferred from `msg.sender` to `recipient`.
+* `0x1 = TRANSFER_FROM_ROUTER`: the token will be transferred from `this` UTR contract to `recipient`.
+* `0x2 = TRANSFER_CALL_VALUE`: the token amount will be passed to the action as the call `value`.
+* `0x100 = ALLOWANCE_CALLBACK`: the token will be allowed to be spent in this transaction by calling `UTR.transferToken`.
+* `0x200 = ALLOWANCE_BRIDGE`: the token will be transferred from `msg.sender` to `this` UTR contract and is allowed to be spent in this transaction.
 
-`amountSource` defines how the actual token `amountIn` is aqquired from:
+`amountSource` defines how the actual token `amountIn` is acquired from:
 
-* `0x0 = AMOUNT_EXACT`: use the exact value of `amountInMax`.
-* `0x1 = AMOUNT_ALL`: use the entire balance of the sender.
-* otherwise, extracts the `uint256` value starting from the `amountSource`-th byte of the last recorded call result `bytes`. This value can be arbitrary if there's no prior action with the `ACTION_RECORD_CALL_RESULT` flag.
+* `0x0 = AMOUNT_EXACT`: the `amountInMax` value is used.
+* `0x1 = AMOUNT_ALL`: the entire balance of the sender (`msg.sender` or `this`) is used.
+* otherwise, extracts the `uint256` value starting from the `amountSource`-th byte of the last recorded call result `bytes`. This value is unpredictable if there's no prior action with the `ACTION_RECORD_CALL_RESULT` flag.
 
 `amountIn` MUST NOT be greater than `amountInMax`, otherwise, the transaction will be reverted with `EXCESSIVE_INPUT_AMOUNT`.
 
-#### Allowance Bridge
-
-`ALLOWANCE_BRIDGE` is the compatibility mode for application contracts that require token approval directly from `msg.sender`.
-
-For each `Input` with `ALLOWANCE_BRIDGE` mode:
-
-* `amountIn` of token is transfered from `msg.sender` to `this` UTR contract.
-* `recipient` is allowed to spend the token from `this` UTR contract.
-
-Before the end of the `exec` function:
-
-* all allowances are revoked.
-* all left-over token is transfered back to `msg.sender`.
-
 #### Payment In Callback
 
-`ALLOWANCE_CALLBACK` is used for application contracts that use transfer-in-callback pattern. (E.g. flashloan contracts, Uniswap/v3-core, etc.)
+`ALLOWANCE_CALLBACK` is used for application contracts that use the transfer-in-callback pattern. (E.g. flashloan contracts, Uniswap/v3-core, etc.)
 
 ```solidity
 struct Transfer {
@@ -177,7 +163,7 @@ interface IUniversalTokenRouter {
 }
 ```
 
-For each `Input` with `ALLOWANCE_CALLBACK` mode, atmost `amountIn` of the token is allowed to transfered from `msg.sender` to `recipient` by calling `UTR.transferToken` in the same transaction. The `UTR.transferToken` function is expected to be called by application contract directly or indirectly via callbacks. Calling `UTR.transferToken` only success with the same token, sender and recipient in the same transaction.
+For each `Input` with `ALLOWANCE_CALLBACK` mode, at most `amountIn` of the token is allowed to be transferred from `msg.sender` to the `recipient` by calling `UTR.transferToken` from anywhere in the same transaction.
 
     UTR
      |
@@ -195,6 +181,20 @@ For each `Input` with `ALLOWANCE_CALLBACK` mode, atmost `amountIn` of the token 
      |
     END
 
+#### Allowance Bridge
+
+`ALLOWANCE_BRIDGE` is the compatibility mode for application contracts that require token approval directly from `msg.sender`.
+
+For each `Input` with `ALLOWANCE_BRIDGE` mode:
+
+* an `amountIn` of token is transferred from `msg.sender` to `this` UTR contract.
+* the `recipient` address is allowed to spend the token from `this` UTR contract.
+
+Before the end of the `exec` function:
+
+* all allowances are revoked.
+* all left-over tokens are transferred back to `msg.sender`.
+
 ### Usage Samples
 
 #### `UniswapRouter.swapExactTokensForTokens`
@@ -211,17 +211,7 @@ UniswapV2Router01.swapExactTokensForTokens(
 )
 ```
 
-This function does what `UniswapV2Router01.swapExactTokensForTokens` does, without the token transfer part:
-
-```solidity
-UniswapV2Helper01.swapExactTokensForTokens(
-    uint amountIn,
-    uint amountOutMin,
-    address[] calldata path,
-    address to,
-    uint deadline
-)
-```
+`UniswapV2Helper01.swapExactTokensForTokens` is a modified version of it without the token transfer part.
 
 This transaction is signed by users to execute the swap instead of the legacy function:
 
@@ -379,7 +369,7 @@ The output token verification is not performed by Uniswap's legacy function and 
 
 #### Uniswap V3 `SwapRouter`
 
-Legacy router contract functions:
+Legacy router contract:
 
 ```solidity
 contract SwapRouter {
@@ -397,7 +387,7 @@ contract SwapRouter {
 }
 ```
 
-Helper contract to use with the `UTR` instead of `SwapRouter`
+The helper contract to use with the `UTR`:
 
 ```solidity
 contract SwapHelper {
@@ -422,7 +412,7 @@ contract SwapHelper {
 }
 ```
 
-This transaction is signed by users to execute the `mint` instead of the legacy function:
+This transaction is signed by users to execute the `mint` functionality:
 
 ```javascript
 UniversalTokenRouter.exec([{
@@ -469,7 +459,7 @@ New token contracts can pre-configure the Universal Token Router as a trusted sp
 
 ### Application Contracts
 
-Application contracts that use `msg.sender` as the beneficiary address in their internal storage without any function for ownership transfer are **INCOMPATIBLE** with the UTR.
+Application contracts that use `msg.sender` as the beneficiary address in their internal storage without any function for ownership transfer are the only cases that are **INCOMPATIBLE** with the UTR.
 
 All application contracts that accept `recipient` (or `to`) argument instead of using `msg.sender` as the beneficiary address are compatible with the UTR out of the box.
 
@@ -851,7 +841,7 @@ contract UniversalTokenRouter is IUniversalTokenRouter {
 
 ## Security Considerations
 
-`ACTION_INJECT_CALL_RESULT` SHOULD only be used for gas optimization, not as trusted conditions. Application contract code MUST always expect arbitruary, malformed or mallicious `bytes` data can be passed in where the `ACTION_INJECT_CALL_RESULT` is expected.
+`ACTION_INJECT_CALL_RESULT` SHOULD only be used for gas optimization, not as trusted conditions. Application contract code MUST always expect arbitruary, malformed or mallicious data can be passed in where the call result `bytes` is expected.
 
 ## Copyright
 

--- a/EIPS/eip-6120.md
+++ b/EIPS/eip-6120.md
@@ -214,7 +214,7 @@ UniversalTokenRouter.exec([{
         eip: 20,
         token: path[0],
         id: 0,
-        offset: 64, // first item of getAmountIns result array
+        offset: 32*3, // first item of getAmountIns result array
         amount: amountInMax,
         recipient: UniswapV2Library.pairFor(factory, path[0], path[1]),
     }],

--- a/EIPS/eip-6120.md
+++ b/EIPS/eip-6120.md
@@ -161,7 +161,7 @@ UniversalTokenRouter.exec([{
         eip: 20,
         token: path[0],
         id: 0,
-        offset: 0, // use exact amount specified bellow
+        offset: 0, // use the exact amount specified bellow
         amount: amountIn,
         recipient: UniswapV2Library.pairFor(factory, path[0], path[1]),
     }],

--- a/EIPS/eip-6120.md
+++ b/EIPS/eip-6120.md
@@ -100,7 +100,6 @@ struct Action {
 * `0x1 = ACTION_IGNORE_ERROR` ignores the contract call failure.
 * `0x2 = ACTION_RECORD_CALL_RESULT` records the contract call result in a `bytes` for subsequence action.
 * `0x4 = ACTION_INJECT_CALL_RESULT` injects the last call result `bytes` recorded to the last `bytes` param of the contract function `data`.
-* `0x8 = ACTION_FORWARD_CALLBACK` stores the `code` address as the target for callback forwarding. This address will be reset before the `exec` function ends.
 
 ### Input
 
@@ -195,36 +194,6 @@ For each `Input` with `ALLOWANCE_CALLBACK` mode, atmost `amountIn` of the token 
      | (clear all allowance)
      |
     END
-
-### Callback Forwarding
-
-Some application contracts invoke callback from its caller (e.g. Uniswap/v3-core), which is the UTR contract in this case. Action flag `ACTION_FORWARD_CALLBACK` can be used to register an `IUTRCallback` target address so any unknown function calls to the UTR contract in the same transaction will be wrapped and forwarded to it.
-
-```solidity
-interface IUTRCallback {
-    // 0x3696d736
-    function utrCallback(
-        address caller,
-        bytes memory data
-    ) external payable;
-}
-```
-
-The `data` param contains both the 4 bytes function signature and its param of the original callback function call.
-
-                       UTR
-                        |
-                        | ACTION_FORWARD_CALLBACK
-                        |
-                        |                   Application Contracts
-                       action.code.call ------> |
-                                                |
-                                                | 
-      (target) <------ UTR <-------- (callback) |
-    IUTRCallback --------------------> (return) |
-                                                |
-                        | <----------- (return) |
-                        :
 
 ### Usage Samples
 
@@ -578,15 +547,12 @@ contract UniversalTokenRouter is IUniversalTokenRouter {
     uint constant ACTION_IGNORE_ERROR       = 1;
     uint constant ACTION_RECORD_CALL_RESULT = 2;
     uint constant ACTION_INJECT_CALL_RESULT = 4;
-    uint constant ACTION_FORWARD_CALLBACK   = 8;
 
     // Storages: non-persistent, in-transaction use only
-    address internal s_forwardCallbackTo;
     mapping(bytes32 => uint) s_allowances;
 
-    constructor() {
-        s_forwardCallbackTo = address(this);
-    }
+    // accepting ETH for WETH.withdraw
+    receive() external payable {}
 
     function exec(
         Output[] memory outputs,
@@ -602,7 +568,6 @@ contract UniversalTokenRouter is IUniversalTokenRouter {
             output.amountOutMin = expected;
         }
 
-        bool forwarded = false;
         bool allowed = false;
 
         bytes memory callResult;
@@ -648,10 +613,6 @@ contract UniversalTokenRouter is IUniversalTokenRouter {
                 }
             }
             if (action.data.length > 0) {
-                if (action.flags & ACTION_FORWARD_CALLBACK != 0) {
-                    s_forwardCallbackTo = action.code;
-                    forwarded = true;
-                }
                 if (action.flags & ACTION_INJECT_CALL_RESULT != 0) {
                     action.data = _concat(action.data, action.data.length, callResult);
                 }
@@ -676,9 +637,6 @@ contract UniversalTokenRouter is IUniversalTokenRouter {
         }
 
         // clear all in-transaction storages
-        if (forwarded) {
-            s_forwardCallbackTo = address(this);
-        }
         if (allowed) {
             for (uint i = 0; i < actions.length; ++i) {
                 Action memory action = actions[i];
@@ -707,40 +665,6 @@ contract UniversalTokenRouter is IUniversalTokenRouter {
             TransferHelper.safeTransferETH(msg.sender, leftOver);
         }
     } }
-
-    // accepting ETH
-    receive() external payable {}
-
-    // forward callback to s_forwardCallbackTo
-    fallback() external payable {
-        address target = s_forwardCallbackTo;
-        require(target != address(this), 'UniversalTokenRouter: MISSING_ACTION_FORWARD_CALLBACK');
-        bytes memory data;
-        assembly {
-            calldatacopy(data, 0, calldatasize())
-        }
-        data = abi.encodeWithSelector(0x3696d736, msg.sender, data);
-        assembly {
-            // forward the callback
-            let success := call(gas(), target, callvalue(), data, mload(data), 0, 0)
-
-            // We take full control of memory in this inline assembly
-            // block because it will not return to Solidity code. We overwrite the
-            // Solidity scratch pad at memory position 0.
-
-            // Copy the returned data.
-            returndatacopy(0, 0, returndatasize())
-
-            switch success
-            // call returns 0 on error.
-            case 0 {
-                revert(0, returndatasize())
-            }
-            default {
-                return(0, returndatasize())
-            }
-        }
-    }
 
     function transferTokens(
         Transfer[] calldata transfers

--- a/EIPS/eip-6120.md
+++ b/EIPS/eip-6120.md
@@ -119,38 +119,29 @@ struct Input {
 
 `mode` can takes one of the following values:
 
-* `0x0 = TRANSFER_FROM_SENDER`: the token will be transferred from `msg.sender` to `recipient`.
-* `0x1 = TRANSFER_FROM_ROUTER`: the token will be transferred from `this` UTR contract to `recipient`.
-* `0x2 = TRANSFER_CALL_VALUE`: the token amount will be passed to the action as the call `value`.
-* `0x100 = ALLOWANCE_CALLBACK`: the token will be allowed to be spent in this transaction by calling `UTR.transferToken`.
-* `0x200 = ALLOWANCE_BRIDGE`: the token will be transferred from `msg.sender` to `this` UTR contract and is allowed to be spent in this transaction.
+* `0 = TRANSFER_FROM_SENDER`: the token will be transferred from `msg.sender` to `recipient`.
+* `1 = TRANSFER_FROM_ROUTER`: the token will be transferred from `this` UTR contract to `recipient`.
+* `2 = TRANSFER_CALL_VALUE`: the token amount will be passed to the action as the call `value`.
+* `4 = IN_TX_PAYMENT`: the token will be allowed to be spent in this transaction by calling `UTR.pay`.
+* `8 = ALLOWANCE_BRIDGE`: the token will be transferred from `msg.sender` to `this` UTR contract and is allowed to be spent in this transaction.
 
 `amountSource` defines how the actual token `amountIn` is acquired from:
 
-* `0x0 = AMOUNT_EXACT`: the `amountInMax` value is used.
-* `0x1 = AMOUNT_ALL`: the entire balance of the sender (`msg.sender` or `this`) is used.
+* `0 = AMOUNT_EXACT`: the `amountInMax` value is used.
+* `1 = AMOUNT_ALL`: the entire balance of the sender (`msg.sender` or `this`) is used.
 * otherwise, extracts the `uint256` value starting from the `amountSource`-th byte of the last recorded call result `bytes`. This value is unpredictable if there's no prior action with the `ACTION_RECORD_CALL_RESULT` flag.
 
 `amountIn` MUST NOT be greater than `amountInMax`, otherwise, the transaction will be reverted with `EXCESSIVE_INPUT_AMOUNT`.
 
 #### Payment In Callback
 
-`ALLOWANCE_CALLBACK` is used for application contracts that use the transfer-in-callback pattern. (E.g. flashloan contracts, Uniswap/v3-core, etc.)
+`IN_TX_PAYMENT` is used for application contracts that use the transfer-in-callback pattern. (E.g. flashloan contracts, Uniswap/v3-core, etc.)
 
 ```solidity
-struct Transfer {
-    address sender;
-    address recipient;
-    uint eip;
-    address token;
-    uint id;
-    uint amount;
-}
-
 interface IUniversalTokenRouter {
     ...
 
-    function transferToken(
+    function pay(
         address sender,
         address recipient,
         uint eip,
@@ -158,26 +149,24 @@ interface IUniversalTokenRouter {
         uint id,
         uint amount
     ) external;
-
-    function transferTokens(Transfer[] calldata transfers) external;
 }
 ```
 
-For each `Input` with `ALLOWANCE_CALLBACK` mode, at most `amountIn` of the token is allowed to be transferred from `msg.sender` to the `recipient` by calling `UTR.transferToken` from anywhere in the same transaction.
+For each `Input` with `IN_TX_PAYMENT` mode, at most `amountIn` of the token is allowed to be transferred from `msg.sender` to the `recipient` by calling `UTR.pay` from anywhere in the same transaction.
 
     UTR
      |
-     | TOKEN_ALLOWANCE_CALLBACK
-     | (allowance for UTR.transferToken)
+     | IN_TX_PAYMENT
+     | (payments pended for UTR.pay)
      |
      |                                  Application Contracts
     action.code.call ---------------------> |
                                             |
-    UTR.transferToken <------------- (call) |
+    UTR.pay <----------------------- (call) |
                                             |
      | <-------------------------- (return) |
      |
-     | (clear all allowance)
+     | (clear all pending payments)
      |
     END
 
@@ -400,7 +389,7 @@ contract SwapHelper {
     ) internal {
         ...
         // pull payment
-        UTR.transferToken(
+        UTR.pay(
             payer,
             recipient,
             20,     // EIP
@@ -412,7 +401,7 @@ contract SwapHelper {
 }
 ```
 
-This transaction is signed by users to execute the `exactInput` functionality using `ALLOWANCE_CALLBACK` mode:
+This transaction is signed by users to execute the `exactInput` functionality using `IN_TX_PAYMENT` mode:
 
 ```javascript
 UniversalTokenRouter.exec([{
@@ -423,7 +412,7 @@ UniversalTokenRouter.exec([{
     recipient: to,
 }], [{
     inputs: [{
-        mode: ALLOWANCE_CALLBACK,
+        mode: IN_TX_PAYMENT,
         eip: 20,
         token: tokenIn,
         id: 0,
@@ -545,12 +534,12 @@ contract WethAdapter {
 
 ```solidity
 contract UniversalTokenRouter is IUniversalTokenRouter {
-    uint constant TRANSFER_FROM_SENDER  = 0x0;
-    uint constant TRANSFER_FROM_ROUTER  = 0x1;
-    uint constant TRANSFER_CALL_VALUE   = 0x2;
-
-    uint constant ALLOWANCE_CALLBACK  = 0x100;
-    uint constant ALLOWANCE_BRIDGE    = 0x200;
+    // values with a single 1-bit are preferred
+    uint constant TRANSFER_FROM_SENDER  = 0;
+    uint constant TRANSFER_FROM_ROUTER  = 1;
+    uint constant TRANSFER_CALL_VALUE   = 2;
+    uint constant IN_TX_PAYMENT         = 4;
+    uint constant ALLOWANCE_BRIDGE      = 8;
 
     uint constant AMOUNT_EXACT      = 0;
     uint constant AMOUNT_ALL        = 1;
@@ -563,8 +552,8 @@ contract UniversalTokenRouter is IUniversalTokenRouter {
     uint constant ACTION_RECORD_CALL_RESULT = 2;
     uint constant ACTION_INJECT_CALL_RESULT = 4;
 
-    // Storages: non-persistent, in-transaction use only
-    mapping(bytes32 => uint) s_allowances;
+    // non-persistent in-transaction pending payments
+    mapping(bytes32 => uint) s_payments;
 
     // accepting ETH for WETH.withdraw
     receive() external payable {}
@@ -583,7 +572,7 @@ contract UniversalTokenRouter is IUniversalTokenRouter {
             output.amountOutMin = expected;
         }
 
-        bool allowed = false;
+        bool dirty = false;
 
         bytes memory callResult;
         for (uint i = 0; i < actions.length; ++i) {
@@ -612,16 +601,16 @@ contract UniversalTokenRouter is IUniversalTokenRouter {
                     _transferToken(sender, input.recipient, input.eip, input.token, input.id, amount);
                     continue;
                 }
-                if (mode == ALLOWANCE_CALLBACK) {
+                if (mode == IN_TX_PAYMENT) {
                     bytes32 key = keccak256(abi.encodePacked(msg.sender, input.recipient, input.eip, input.token, input.id));
-                    s_allowances[key] += amount;  // overflow: harmless
-                    allowed = true;
+                    s_payments[key] += amount;  // overflow: harmless
+                    dirty = true;
                     continue;
                 }
                 if (mode == ALLOWANCE_BRIDGE) {
                     _approve(input.recipient, input.eip, input.token, type(uint).max);
                     _transferToken(msg.sender, address(this), input.eip, input.token, input.id, amount);
-                    allowed = true;
+                    dirty = true;
                 }
             }
             if (action.data.length > 0) {
@@ -649,14 +638,14 @@ contract UniversalTokenRouter is IUniversalTokenRouter {
         }
 
         // clear all in-transaction storages
-        if (allowed) {
+        if (dirty) {
             for (uint i = 0; i < actions.length; ++i) {
                 Action memory action = actions[i];
                 for (uint j = 0; j < action.inputs.length; ++j) {
                     Input memory input = action.inputs[j];
-                    if (input.mode == ALLOWANCE_CALLBACK) {
+                    if (input.mode == IN_TX_PAYMENT) {
                         bytes32 key = keccak256(abi.encodePacked(msg.sender, input.recipient, input.eip, input.token, input.id));
-                        delete s_allowances[key];
+                        delete s_payments[key];
                         continue;
                     }
                     if (input.mode == ALLOWANCE_BRIDGE) {
@@ -677,23 +666,7 @@ contract UniversalTokenRouter is IUniversalTokenRouter {
         }
     } }
 
-    function transferTokens(
-        Transfer[] calldata transfers
-    ) external {
-    unchecked {
-        for (uint i = 0; i < transfers.length; ++i) {
-            transferToken(
-                transfers[i].sender,
-                transfers[i].recipient,
-                transfers[i].eip,
-                transfers[i].token,
-                transfers[i].id,
-                transfers[i].amount
-            );
-        }
-    } }
-
-    function transferToken(
+    function pay(
         address sender,
         address recipient,
         uint eip,
@@ -701,11 +674,12 @@ contract UniversalTokenRouter is IUniversalTokenRouter {
         uint id,
         uint amount
     ) public {
+    unchecked {
         bytes32 key = keccak256(abi.encodePacked(sender, recipient, eip, token, id));
-        require(s_allowances[key] >= amount, 'UniversalTokenRouter: INSUFFICIENT_ALLOWANCE');
-        s_allowances[key] -= amount;
+        require(s_payments[key] >= amount, 'UniversalTokenRouter: INSUFFICIENT_ALLOWANCE');
+        s_payments[key] -= amount;
         _transferToken(sender, recipient, eip, token, id, amount);
-    }
+    } }
 
     function _transferToken(
         address sender,

--- a/EIPS/eip-6120.md
+++ b/EIPS/eip-6120.md
@@ -412,35 +412,60 @@ contract SwapHelper {
 }
 ```
 
-This transaction is signed by users to execute the `mint` functionality:
+This transaction is signed by users to execute the `exactInput` functionality using `ALLOWANCE_CALLBACK` mode:
 
 ```javascript
 UniversalTokenRouter.exec([{
     eip: 20,
-    token: pool.address,
-    id: ID_721_ALL,
-    amountOutMin: 1,  // expect one more liquidity NFT 
+    token: tokenOut,
+    id: 0,
+    amountOutMin: 1,
     recipient: to,
 }], [{
     inputs: [{
         mode: ALLOWANCE_CALLBACK,
         eip: 20,
+        token: tokenIn,
+        id: 0,
+        amountSource: AMOUNT_EXACT,
+        amountInMax: amountIn,
+        recipient: pool.address,
+    }],
+    flags: 0,
+    code: SwapHelper.address,
+    data: encodeFunctionData("exactInput", [...]),
+}])
+```
+
+This transaction is signed by users to execute the `mint` functionality using `ALLOWANCE_BRIDGE` mode:
+
+```javascript
+UniversalTokenRouter.exec([{
+    eip: 721,
+    token: PositionManager.address,
+    id: ID_721_ALL,
+    amountOutMin: 1,  // expect one more liquidity NFT 
+    recipient: to,
+}], [{
+    inputs: [{
+        mode: ALLOWANCE_BRIDGE,
+        eip: 20,
         token: tokenA,
         id: 0,
         amountSource: AMOUNT_EXACT,
         amountInMax: amountADesired,
-        recipient: pool.address,
+        recipient: PositionManager.address,
     }, {
-        mode: ALLOWANCE_CALLBACK,
+        mode: ALLOWANCE_BRIDGE,
         eip: 20,
         token: tokenB,
         id: 0,
         amountSource: AMOUNT_EXACT,
         amountInMax: amountBDesired,
-        recipient: pool.address,
+        recipient: PositionManager.address,
     }],
     flags: 0,
-    code: SwapHelper.address,
+    code: PositionManager.address,
     data: encodeFunctionData("mint", [...]),
 }])
 ```
@@ -577,9 +602,7 @@ contract UniversalTokenRouter is IUniversalTokenRouter {
                     } else {
                         amount = _sliceUint(callResult, input.amountSource);
                     }
-                    if (amount > 0 && input.amountInMax > 0) {
-                        require(amount <= input.amountInMax, "UniversalTokenRouter: EXCESSIVE_INPUT_AMOUNT");
-                    }
+                    require(amount <= input.amountInMax, "UniversalTokenRouter: EXCESSIVE_INPUT_AMOUNT");
                 }
                 if (mode == TRANSFER_CALL_VALUE) {
                     value = amount;
@@ -596,7 +619,6 @@ contract UniversalTokenRouter is IUniversalTokenRouter {
                     continue;
                 }
                 if (mode == ALLOWANCE_BRIDGE) {
-                    // TODO: can this be optimized for multiple ids cases?
                     _approve(input.recipient, input.eip, input.token, type(uint).max);
                     _transferToken(msg.sender, address(this), input.eip, input.token, input.id, amount);
                     allowed = true;
@@ -638,7 +660,6 @@ contract UniversalTokenRouter is IUniversalTokenRouter {
                         continue;
                     }
                     if (input.mode == ALLOWANCE_BRIDGE) {
-                        // TODO: can this be optimized for multiple ids cases?
                         _approve(input.recipient, input.eip, input.token, 0);
                         uint balance = _balanceOf(address(this), input.eip, input.token, input.id);
                         if (balance > 0) {
@@ -680,7 +701,6 @@ contract UniversalTokenRouter is IUniversalTokenRouter {
         uint id,
         uint amount
     ) public {
-        // TODO: test gas for abi.encode
         bytes32 key = keccak256(abi.encodePacked(sender, recipient, eip, token, id));
         require(s_allowances[key] >= amount, 'UniversalTokenRouter: INSUFFICIENT_ALLOWANCE');
         s_allowances[key] -= amount;


### PR DESCRIPTION
Changes:
* Using `mode` for input tokens and `flags` for action for better visibility
* add `IN_TX_PAYMENT` input token mode for payment-in-callback style contracts (e.g. Uniswap/v3)
* add `ALLOWANCE_BRIDGE` as a compatibility input token mode for contracts that directly called `transferFrom` for pull payment
* add more Sample Usages for Uniswap/v3 swap and liquidity functionalities.