### PR TITLE
Update: EIP-6093: improve wording

### DIFF
--- a/EIPS/eip-6093.md
+++ b/EIPS/eip-6093.md
@@ -15,7 +15,7 @@ requires: 20, 721, 1155
 
 This EIP defines a standard set of custom errors for commonly-used tokens, which are defined as [EIP-20](./eip-20.md), [EIP-721](./eip-721.md), and [EIP-1155](./eip-1155.md) tokens.
 
-Ethereum applications and wallets have historically relied on revert reason strings to display the cause of transaction errors to users. More recent Solidity versions offer rich revert reasons with error-specific decoding (sometimes referred to as "custom errors"). This EIP defines a standard set of errors designed to give at least the same relevant information as revert reason strings, but in a structured and expected way that clients can implement decoding for.
+Ethereum applications and wallets have historically relied on revert reason strings to display the cause of transaction errors to users. Recent Solidity versions offer rich revert reasons with error-specific decoding (sometimes called "custom errors"). This EIP defines a standard set of errors designed to give at least the same relevant information as revert reason strings, but in a structured and expected way that clients can implement decoding for.
 
 ## Motivation
 
@@ -43,7 +43,7 @@ Indicates an error related to the current `balance` of a `sender`.
 Used in transfers.
 
 - MUST be used when `balance` is less than `needed`.
-- MUST NOT be used if `balance` is equal or greater than `needed`.
+- MUST NOT be used if `balance` is greater than or equal to `needed`.
 
 #### `ERC20InvalidSender(address sender)`
 
@@ -70,7 +70,7 @@ Indicates a failure with the `spender`'s `allowance`.
 Used in transfers.
 
 - MUST be used when `allowance` is less than `needed`.
-- MUST NOT be used if `allowance` is equal or greater than `needed`.
+- MUST NOT be used if `allowance` is greater than or equal to `needed`.
 
 #### `ERC20InvalidApprover(address approver)`
 
@@ -153,7 +153,7 @@ Indicates an error related to the current `balance` of a sender.
 Used in transfers.
 
 - MUST be used when `balance` is less than `needed` for a `tokenId`.
-- MUST NOT be used if `balance` is equal or greater than `needed` for an `tokenId`.
+- MUST NOT be used if `balance` is greater than or equal to `needed` for a `tokenId`.
 
 #### `ERC1155InvalidSender(address sender)`
 
@@ -204,7 +204,7 @@ Used in approvals.
 Indicates an array length mismatch between `ids` and `values` in a `safeBatchTransferFrom` operation.
 Used in batch transfers.
 
-- MUST be used only if `idsLength` is different to `valuesLength`
+- MUST be used only if `idsLength` is different from `valuesLength`
 
 ### Parameter Glossary
 
@@ -241,7 +241,7 @@ The main actions that can be performed within a token are:
 
 The subjects outlined above are expected to exhaustively represent _what_ can go wrong in a token transaction, deriving a specific error by adding an [error prefix](#error-prefixes).
 
-Note that the action is never seen as the subject of an error. Additionally the token itself is not seen as the subject of an error but rather the context in which it happens, as identified in the domain.
+Note that the action is never seen as the subject of an error. Additionally, the token itself is not seen as the subject of an error but rather the context in which it happens, as identified in the domain.
 
 If a subject is called different on a particular token standard, the error should be consistent with the standard's naming convention.
 
@@ -280,7 +280,7 @@ The selection of arguments depends on the subject involved, and it should follow
 2. _What_ failed (eg. `uint256 allowance`)
 3. _Why_ it failed, expressed in additional arguments (eg. `uint256 needed`)
 
-A particular argument may fall in overlapping categories (eg. _Who_ may also be _What_), so not all of these will be present but the order shouldn't be broken.
+A particular argument may fall into overlapping categories (eg. _Who_ may also be _What_), so not all of these will be present but the order shouldn't be broken.
 
 Some tokens may need a `tokenId`. This is suggested to include at the end as additional information instead of as a subject.
 
@@ -295,13 +295,13 @@ Given the above, we can summarize the construction of error names with a grammar
 Where:
 
 - _Domain_: `ERC20`, `ERC721` or `ERC1155`. Although other token standards may be suggested if not considered in this EIP.
-- _ErrorPrefix_: `Invalid`, `Insufficient`, or another if it's more appropriated.
-- _Subject_: `Sender`, `Receiver`, `Balance`, `Approver`, `Operator`, `Approval` or another if it's more appropriated, and must make adjustments based on domain's naming convention.
+- _ErrorPrefix_: `Invalid`, `Insufficient`, or another if it's more appropriate.
+- _Subject_: `Sender`, `Receiver`, `Balance`, `Approver`, `Operator`, `Approval` or another if it's more appropriate, and must make adjustments based on the domain's naming convention.
 - _Arguments_: Follow the [_who_, _what_ and _why_ order](#arguments).
 
 ## Backwards Compatibility
 
-Tokens already deployed rely mostly on revert strings and make use of `require` instead of custom errors. Even most of the new deployed tokens since Solidity's v0.8.4 release inherit from implementations using revert strings.
+Tokens already deployed rely mostly on revert strings and make use of `require` instead of custom errors. Even most of the newly deployed tokens since Solidity's v0.8.4 release inherit from implementations using revert strings.
 
 This EIP can not be enforced on non-upgradeable already deployed tokens, however, these tokens generally use similar conventions with small variations such as:
 
@@ -361,11 +361,10 @@ interface ERC1155Errors {
 
 ## Security Considerations
 
-There are no known signature hash collision for the specified errors.
+There are no known signature hash collisions for the specified errors.
 
 Tokens upgraded to implement this EIP may break assumptions in other systems relying on revert strings.
 
 ## Copyright
 
 Copyright and related rights waived via [CC0](../LICENSE.md).
-


### PR DESCRIPTION
Several language corrections and improvements for EIP-6093.

Most edits proposed in this PR should be uncontroversial, but I want to share the rationale behind my suggestion to say "greater than or equal to" instead of "equal or greater than". There are two reasons:

1. This is the formal definition ([reference](https://www.cuemath.com/numbers/greater-than-or-equal-to/)).
2. Closer to the actual mathematical sign `>=` (the sign starts with "greater than")

Cc @ernestognw.