### PR TITLE
Update EIP-1328 from Stagnant to Review

### DIFF
--- a/EIPS/eip-1328.md
+++ b/EIPS/eip-1328.md
@@ -4,7 +4,7 @@ title: WalletConnect URI Format
 description: Define URI format for initiating connections between applications and wallets
 author: ligi (@ligi), Pedro Gomes (@pedrouid)
 discussions-to: https://ethereum-magicians.org/t/wallet-connect-eip/850
-status: Stagnant
+status: Review
 type: Standards Track
 category: ERC
 created: 2018-08-15

--- a/EIPS/eip-1328.md
+++ b/EIPS/eip-1328.md
@@ -38,6 +38,7 @@ For WalletConnect v1.0 protocol (`version`=`1`) the parameters are:
 
 For WalletConnect v2.0 protocol (`version`=`2`) the parameters are:
 - `symKey` - symmetric key used for encrypting messages over relay
+- `methods` - jsonrpc methods supported for pairing topic
 - `relay-protocol` - transport protocol for relaying messages
 - `relay-data` - (optional) transport data for relaying messages
 
@@ -49,7 +50,7 @@ For WalletConnect v2.0 protocol (`version`=`2`) the parameters are:
 wc:8a5e5bdc-a0e4-4702-ba63-8f1a5655744f@1?bridge=https%3A%2F%2Fbridge.walletconnect.org&key=41791102999c339c844880b23950704cc43aa840f3739e365323cda4dfa89e7a
 
 # 2.0
-wc:c9e6d30fb34afe70a15c14e9337ba8e4d5a35dd695c39b94884b0ee60c69d168@2?relay-protocol=waku&symKey=7ff3e362f825ab868e20e767fe580d0311181632707e7c878cbeca0238d45b8b
+wc:7f6e504bfad60b485450578e05678ed3e8e8c4751d3c6160be17160d63ec90f9@2?relay-protocol=irn&symKey=587d5484ce2a2a6ee3ba1962fdd7e8588e06200c46823bd18fbd67def96ad303&methods=[wc_sessionPropose],[wc_authRequest,wc_authBatchRequest]"
 ```
 
 ## Rationale

--- a/EIPS/eip-1328.md
+++ b/EIPS/eip-1328.md
@@ -33,10 +33,12 @@ WalletConnect request URI with the following parameters:
 Required parameters are dependent on the WalletConnect protocol version:
 
 For WalletConnect v1.0 protocol (`version`=`1`) the parameters are:
+
 - `key` - symmetric key used for encryption
 - `bridge` - url of the bridge server for relaying messages
 
 For WalletConnect v2.0 protocol (`version`=`2`) the parameters are:
+
 - `symKey` - symmetric key used for encrypting messages over relay
 - `methods` - jsonrpc methods supported for pairing topic
 - `relay-protocol` - transport protocol for relaying messages


### PR DESCRIPTION
This EIP specifies a URI format for WalletConnect v1.0 and v2.0 and it's widely used in production already