### PR TITLE
Update EIP-1: locally disable MD046 footnote demo

### DIFF
--- a/EIPS/eip-1.md
+++ b/EIPS/eip-1.md
@@ -269,6 +269,8 @@ Which renders to:
 
 This is a sentence with a footnote.[^1]
 
+<!-- markdownlint-disable MD046 -->
+
 [^1]:
     ```csl-json
     {
@@ -295,6 +297,8 @@ This is a sentence with a footnote.[^1]
       }
     }
     ```
+
+<!-- markdownlint-enable MD046 -->
 
 See the [Citation Style Language Schema](https://resource.citationstyles.org/schema/v1.0/input/json/csl-data.json) for the supported fields. In addition to passing validation against that schema, references must include a DOI and at least one URL.
 


### PR DESCRIPTION
A follow up for 

> We should turn off that error. I think it's the only way to get a code block to appear inside the footnote list.

_Originally posted by @SamWilsn in https://github.com/ethereum/EIPs/issues/6477#issuecomment-1424617429_
            
