### PR TITLE
More sane limits on blobs per transactions

### DIFF
--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -53,8 +53,8 @@ Compared to full data sharding, this EIP has a reduced cap on the number of thes
 | `MAX_CALLDATA_SIZE` | `2**24` |
 | `MAX_ACCESS_LIST_SIZE` | `2**24` |
 | `MAX_ACCESS_LIST_STORAGE_KEYS` | `2**24` |
-| `MAX_TX_WRAP_KZG_COMMITMENTS` | `2**24` |
-| `LIMIT_BLOBS_PER_TX` | `2**24` |
+| `MAX_TX_WRAP_KZG_COMMITMENTS` | `2**12` |
+| `LIMIT_BLOBS_PER_TX` | `2**12` |
 | `DATA_GAS_PER_BLOB` | `2**17` |
 | `HASH_OPCODE_BYTE` | `Bytes1(0x49)` |
 | `HASH_OPCODE_GAS` | `3` |


### PR DESCRIPTION
These limits allow growth to up to `2**12` blobs per transaction, which is up to `512 MB` of blob data at the current blob size (4096 field elements) and `4 GB` of blob data at the maximum blob size currently supported by the trusted setup (`2**15` field elements).

When opening a pull request to submit a new EIP, please use the suggested template: https://github.com/ethereum/EIPs/blob/master/eip-template.md

We have a GitHub bot that automatically merges some PRs. It will merge yours immediately if certain criteria are met:

 - The PR edits only existing draft PRs.
 - The build passes.
 - Your GitHub username or email address is listed in the 'author' header of all affected PRs, inside <triangular brackets>.
 - If matching on email address, the email address is the one publicly listed on your GitHub profile.
