### PR TITLE
Updates interface Id and renames EIP references to ERC.

### DIFF
--- a/EIPS/eip-6059.md
+++ b/EIPS/eip-6059.md
@@ -13,7 +13,7 @@ requires: 165, 721
 
 ## Abstract
 
-The Parent-Governed Nestable NFT standard extends [EIP-721](./eip-721.md) by allowing for a new inter-NFT relationship and interaction.
+The Parent-Governed Nestable NFT standard extends [ERC-721](./eip-721.md) by allowing for a new inter-NFT relationship and interaction.
 
 At its core, the idea behind the proposal is simple: the owner of an NFT does not have to be an Externally Owned Account (EOA) or a smart contract, it can also be an NFT.
 
@@ -29,7 +29,7 @@ The graph illustrates how a child token can also be a parent token, but both are
 
 With NFTs being a widespread form of tokens in the Ethereum ecosystem and being used for a variety of use cases, it is time to standardize additional utility for them. Having the ability for tokens to own other tokens allows for greater utility, usability and forward compatibility.
 
-In the four years since [EIP-721](./eip-721.md) was published, the need for additional functionality has resulted in countless extensions. This EIP improves upon EIP-721 in the following areas:
+In the four years since [ERC-721](./eip-721.md) was published, the need for additional functionality has resulted in countless extensions. This ERC improves upon ERC-721 in the following areas:
 
 - [Bundling](#bundling)
 - [Collecting](#collecting)
@@ -38,7 +38,7 @@ In the four years since [EIP-721](./eip-721.md) was published, the need for addi
 
 ### Bundling
 
-One of the most frequent uses of [EIP-721](./eip-721.md) is to disseminate the multimedia content that is tied to the tokens. In the event that someone wants to offer a bundle of NFTs from various collections, there is currently no easy way of bundling all of these together and handle their sale as a single transaction. This proposal introduces a standardized way of doing so. Nesting all of the tokens into a simple bundle and selling that bundle would transfer the control of all of the tokens to the buyer in a single transaction.
+One of the most frequent uses of [ERC-721](./eip-721.md) is to disseminate the multimedia content that is tied to the tokens. In the event that someone wants to offer a bundle of NFTs from various collections, there is currently no easy way of bundling all of these together and handle their sale as a single transaction. This proposal introduces a standardized way of doing so. Nesting all of the tokens into a simple bundle and selling that bundle would transfer the control of all of the tokens to the buyer in a single transaction.
 
 ### Collecting
 
@@ -61,7 +61,7 @@ The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL 
 ```solidity
 /// @title EIP-6059 Parent-Governed Nestable Non-Fungible Tokens
 /// @dev See https://eips.ethereum.org/EIPS/eip-6059
-/// @dev Note: the ERC-165 identifier for this interface is 0x60b766e5.
+/// @dev Note: the ERC-165 identifier for this interface is 0x42b0e56f.
 
 pragma solidity ^0.8.16;
 
@@ -373,8 +373,8 @@ Designing the proposal, we considered the following questions:
 
 1. **How to name the proposal?**\
 In an effort to provide as much information about the proposal we identified the most important aspect of the proposal; the parent centered control over nesting. The child token's role is only to be able to be `Nestable` and support a token owning it. This is how we landed on the `Parent-Centered` part of the title.
-2. **Why is automatically accepting a child using [EIP-712](./eip-712.md) permit-style signatures not a part of this proposal?**\
-For consistency. This proposal extends EIP-721 which already uses 1 transaction for approving operations with tokens. It would be inconsistent to have this and also support signing messages for operations with assets.
+2. **Why is automatically accepting a child using [ERC-712](./eip-712.md) permit-style signatures not a part of this proposal?**\
+For consistency. This proposal extends ERC-721 which already uses 1 transaction for approving operations with tokens. It would be inconsistent to have this and also support signing messages for operations with assets.
 3. **Why use indexes?**\
 To reduce the gas consumption. If the token ID was used to find which token to accept or reject, iteration over arrays would be required and the cost of the operation would depend on the size of the active or pending children arrays. With the index, the cost is fixed. Lists of active and pending children per token need to be maintained, since methods to get them are part of the proposed interface.\
 To avoid race conditions in which the index of a token changes, the expected token ID as well as the expected token's collection smart contract is included in operations requiring token index, to verify that the token being accessed using the index is the expected one.\
@@ -388,7 +388,7 @@ The proposal enforces that a parent token can't be nested into one of its child 
 6. **Why is there not a "safe" nest transfer method?**\
 `nestTransfer` is always "safe" since it MUST check for `INestable` compatibility on the destination.
 7. **How does this proposal differ from the other proposals trying to address a similar problem?**\
-This interface allows for tokens to both be sent to and receive other tokens. The propose-accept and parent governed patterns allow for a more secure use. The backward compatibility is only added for EIP-721, allowing for a simpler interface. The proposal also allows for different collections to inter-operate, meaning that nesting is not locked to a single smart contract, but can be executed between completely separate NFT collections.
+This interface allows for tokens to both be sent to and receive other tokens. The propose-accept and parent governed patterns allow for a more secure use. The backward compatibility is only added for ERC-721, allowing for a simpler interface. The proposal also allows for different collections to inter-operate, meaning that nesting is not locked to a single smart contract, but can be executed between completely separate NFT collections.
 
 ### Propose-Commit pattern for child token management
 
@@ -400,7 +400,7 @@ The limitation that only the root owner can accept the child tokens also introdu
 
 The parent NFT of a nested token and the parent's root owner are in all aspects the true owners of it. Once you send a token to another one you give up ownership.
 
-We continue to use EIP-721's `ownerOf` functionality which will now recursively look up through parents until it finds an address which is not an NFT, this is referred to as the *root owner*. Additionally we provide the `directOwnerOf` which returns the most immediate owner of a token using 3 values: the owner address, the tokenId which MUST be 0 if the direct owner is not an NFT, and a flag indicating whether or not the parent is an NFT.
+We continue to use ERC-721's `ownerOf` functionality which will now recursively look up through parents until it finds an address which is not an NFT, this is referred to as the *root owner*. Additionally we provide the `directOwnerOf` which returns the most immediate owner of a token using 3 values: the owner address, the tokenId which MUST be 0 if the direct owner is not an NFT, and a flag indicating whether or not the parent is an NFT.
 
 The root owner or an approved party MUST be able do the following operations on children: `acceptChild`, `rejectAllChildren` and `transferChild`.
 
@@ -451,7 +451,7 @@ This state change places the token in the pending array of the new parent token.
 
 ## Backwards Compatibility
 
-The Nestable token standard has been made compatible with [EIP-721](./eip-721.md) in order to take advantage of the robust tooling available for implementations of EIP-721 and to ensure compatibility with existing EIP-721 infrastructure.
+The Nestable token standard has been made compatible with [ERC-721](./eip-721.md) in order to take advantage of the robust tooling available for implementations of ERC-721 and to ensure compatibility with existing ERC-721 infrastructure.
 
 ## Test Cases
 
@@ -472,7 +472,7 @@ See [`NestableToken.sol`](../assets/eip-6059/contracts/NestableToken.sol).
 
 ## Security Considerations
 
-The same security considerations as with [EIP-721](./eip-721.md) apply: hidden logic may be present in any of the functions, including burn, add resource, accept resource, and more.
+The same security considerations as with [ERC-721](./eip-721.md) apply: hidden logic may be present in any of the functions, including burn, add resource, accept resource, and more.
 
 Caution is advised when dealing with non-audited contracts.
 

--- a/EIPS/eip-6059.md
+++ b/EIPS/eip-6059.md
@@ -373,7 +373,7 @@ Designing the proposal, we considered the following questions:
 
 1. **How to name the proposal?**\
 In an effort to provide as much information about the proposal we identified the most important aspect of the proposal; the parent centered control over nesting. The child token's role is only to be able to be `Nestable` and support a token owning it. This is how we landed on the `Parent-Centered` part of the title.
-2. **Why is automatically accepting a child using [ERC-712](./eip-712.md) permit-style signatures not a part of this proposal?**\
+2. **Why is automatically accepting a child using ERC-712 permit-style signatures not a part of this proposal?**\
 For consistency. This proposal extends ERC-721 which already uses 1 transaction for approving operations with tokens. It would be inconsistent to have this and also support signing messages for operations with assets.
 3. **Why use indexes?**\
 To reduce the gas consumption. If the token ID was used to find which token to accept or reject, iteration over arrays would be required and the cost of the operation would depend on the size of the active or pending children arrays. With the index, the cost is fixed. Lists of active and pending children per token need to be maintained, since methods to get them are part of the proposed interface.\

--- a/EIPS/eip-6059.md
+++ b/EIPS/eip-6059.md
@@ -373,7 +373,7 @@ Designing the proposal, we considered the following questions:
 
 1. **How to name the proposal?**\
 In an effort to provide as much information about the proposal we identified the most important aspect of the proposal; the parent centered control over nesting. The child token's role is only to be able to be `Nestable` and support a token owning it. This is how we landed on the `Parent-Centered` part of the title.
-2. **Why is automatically accepting a child using ERC-712 permit-style signatures not a part of this proposal?**\
+2. **Why is automatically accepting a child using [EIP-712](./eip-712.md) permit-style signatures not a part of this proposal?**\
 For consistency. This proposal extends ERC-721 which already uses 1 transaction for approving operations with tokens. It would be inconsistent to have this and also support signing messages for operations with assets.
 3. **Why use indexes?**\
 To reduce the gas consumption. If the token ID was used to find which token to accept or reject, iteration over arrays would be required and the cost of the operation would depend on the size of the active or pending children arrays. With the index, the cost is fixed. Lists of active and pending children per token need to be maintained, since methods to get them are part of the proposed interface.\


### PR DESCRIPTION
The interface Id changed in a previous iteration.
The rename from EIP to ERC on the document was made to follow new rules.
