### PR TITLE
CI: Update eip-review-bot username

### DIFF
--- a/.github/workflows/auto-review-bot.yml
+++ b/.github/workflows/auto-review-bot.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Auto Review Bot
         id: auto-review-bot
-        uses: Pandapip1/eip-review-bot@dist
+        uses: ethereum/eip-review-bot@dist
         with:
           token: ${{ secrets.TOKEN }}
           config: config/eip-editors.yml

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Consider any document not published at <https://eips.ethereum.org/> as a working
 
 All pull requests in this repository must pass automated checks before they can be automatically merged:
 
-- [eip-review-bot](https://github.com/Pandapip1/eip-review-bot/) determines when PRs can be automatically merged [^1]
+- [eip-review-bot](https://github.com/ethereum/eip-review-bot/) determines when PRs can be automatically merged [^1]
 - EIP-1 rules are enforced using [`eipw`](https://github.com/ethereum/eipw)[^2]
 - HTML formatting and broken links are enforced using [HTMLProofer](https://github.com/gjtorikian/html-proofer)[^2]
 - Spelling is enforced with [CodeSpell](https://github.com/codespell-project/codespell)[^2]


### PR DESCRIPTION
Uses `ethereum/eip-review-bot` instead of `Pandapip1/eip-review-bot`.