### PR TITLE
Improvement proposal to 5192

### DIFF
--- a/EIPS/eip-5192.md
+++ b/EIPS/eip-5192.md
@@ -35,15 +35,15 @@ pragma solidity ^0.8.0;
 
 interface IERC5192 {
   /// @notice Emitted when the locking status is changed.
-  /// @dev    It is not emitted when the token is minted because the initial
-  ///         status is returned by defaultLocked().
-  /// @param  tokenId The identifier for a token.
+  /// @dev It is not emitted when the token is minted because that default
+  /// transferability is returned by defaultLocked().
+  /// @param tokenId The identifier for a token.
   event Locked(uint256 indexed tokenId, bool status);
 
   /// @notice Returns the locking status of an Soulbound Token
-  /// @dev    SBTs assigned to zero address are considered invalid, and queries
-  ///         about them do throw.
-  /// @param  tokenId The identifier for an SBT.
+  /// @dev SBTs assigned to zero address are considered invalid, and queries
+  /// about them do throw.
+  /// @param tokenId The identifier for an SBT.
   function locked(uint256 tokenId) external view returns (bool);
   
   /// @notice Returns the default locking status of an Soulbound Token

--- a/EIPS/eip-5192.md
+++ b/EIPS/eip-5192.md
@@ -34,21 +34,20 @@ A token with a `uint256 tokenId` may be bound to a receiving account with `funct
 pragma solidity ^0.8.0;
 
 interface IERC5192 {
-  /// @notice Emitted when the locking status is changed to locked.
-  /// @dev If a token is minted and the status is locked, this event should be emitted.
-  /// @param tokenId The identifier for a token.
-  event Locked(uint256 tokenId);
-
-  /// @notice Emitted when the locking status is changed to unlocked.
-  /// @dev If a token is minted and the status is unlocked, this event should be emitted.
-  /// @param tokenId The identifier for a token.
-  event Unlocked(uint256 tokenId);
+  /// @notice Emitted when the locking status is changed.
+  /// @dev    It is not emitted when the token is minted because the initial
+  ///         status is returned by defaultLocked().
+  /// @param  tokenId The identifier for a token.
+  event Locked(uint256 indexed tokenId, bool status);
 
   /// @notice Returns the locking status of an Soulbound Token
-  /// @dev SBTs assigned to zero address are considered invalid, and queries
-  /// about them do throw.
-  /// @param tokenId The identifier for an SBT.
+  /// @dev    SBTs assigned to zero address are considered invalid, and queries
+  ///         about them do throw.
+  /// @param  tokenId The identifier for an SBT.
   function locked(uint256 tokenId) external view returns (bool);
+  
+  /// @notice Returns the default locking status of an Soulbound Token
+  function defaultLocked() external view returns (bool);
 }
 ```
 

--- a/EIPS/eip-5192.md
+++ b/EIPS/eip-5192.md
@@ -50,7 +50,8 @@ interface IERC5192 {
   
   /// @notice Returns the default locking status of an Soulbound Token
   /// @dev it avoid enforcing the emission of a Locked or Unlocked event at minting
-  function defaultLocked() external pure returns (bool);
+  ///      It may be a `pure` function in most cases, but a view is more flexible
+  function defaultLocked() external view returns (bool);
 }
 ```
 

--- a/EIPS/eip-5192.md
+++ b/EIPS/eip-5192.md
@@ -34,11 +34,13 @@ A token with a `uint256 tokenId` may be bound to a receiving account with `funct
 pragma solidity ^0.8.0;
 
 interface IERC5192 {
-  /// @notice Emitted when the locking status is changed.
-  /// @dev It is not emitted when the token is minted because that default
-  /// transferability is returned by defaultLocked().
+  /// @notice Emitted when the locking status is changed to locked.
   /// @param tokenId The identifier for a token.
-  event Locked(uint256 indexed tokenId, bool status);
+  event Locked(uint256 tokenId);
+
+  /// @notice Emitted when the locking status is changed to unlocked.
+  /// @param tokenId The identifier for a token.
+  event Unlocked(uint256 tokenId);
 
   /// @notice Returns the locking status of an Soulbound Token
   /// @dev SBTs assigned to zero address are considered invalid, and queries
@@ -47,6 +49,7 @@ interface IERC5192 {
   function locked(uint256 tokenId) external view returns (bool);
   
   /// @notice Returns the default locking status of an Soulbound Token
+  /// @dev it avoid enforcing the emission of a Locked or Unlocked event at minting
   function defaultLocked() external pure returns (bool);
 }
 ```

--- a/EIPS/eip-5192.md
+++ b/EIPS/eip-5192.md
@@ -47,7 +47,7 @@ interface IERC5192 {
   function locked(uint256 tokenId) external view returns (bool);
   
   /// @notice Returns the default locking status of an Soulbound Token
-  function defaultLocked() external view returns (bool);
+  function defaultLocked() external pure returns (bool);
 }
 ```
 


### PR DESCRIPTION
I suggest to add a function `defaultLocked` to the interface, which becomes
```
// SPDX-License-Identifier: CC0-1.0
pragma solidity ^0.8.0;

interface IERC5192 {
  /// @notice Emitted when the locking status is changed to locked.
  /// @param tokenId The identifier for a token.
  event Locked(uint256 tokenId);

  /// @notice Emitted when the locking status is changed to unlocked.
  /// @param tokenId The identifier for a token.
  event Unlocked(uint256 tokenId);

  /// @notice Returns the locking status of an Soulbound Token
  /// @dev SBTs assigned to zero address are considered invalid, and queries
  /// about them do throw.
  /// @param tokenId The identifier for an SBT.
  function locked(uint256 tokenId) external view returns (bool);
  
  /// @notice Returns the default locking status of an Soulbound Token
  /// @dev it avoid enforcing the emission of a Locked or Unlocked event at minting
  ///      It may be a `pure` function in most cases, but a view is more flexible
  function defaultLocked() external view returns (bool);
}
```

**Why?**

I am currently working on a security-oriented project and developing a similar interface (https://github.com/ndujaLabs/protector-protected-protocol/blob/main/contracts/interfaces/IERC721Approvable.sol). In our case, we need to control the approvability of a token. While investigating, I realized a significant problem with emitting events (such as `Locked` and `Unlocked`) is that you have to emit them each time there's a change. However, when you mint a token, it typically starts with a default value for every tokenId, so emitting events at that point would be a waste of gas. For instance, with a typical soulbound token that is not transferable and never will be, it does not make any sense to emit the event. This would cause that whoever is deploying such a token would not use ERC5192.

In this proposal, the emission of the event at minting is unnecessary because an external actor can check if the token supports ERC5192 and query a function that returns the default status if no events have been emitted.


