### PR TITLE
Update EIP-721: Spell collectible consistently

### DIFF
--- a/EIPS/eip-721.md
+++ b/EIPS/eip-721.md
@@ -21,7 +21,7 @@ The following standard allows for the implementation of a standard API for NFTs 
 We considered use cases of NFTs being owned and transacted by individuals as well as consignment to third party brokers/wallets/auctioneers ("operators"). NFTs can represent ownership over digital or physical assets. We considered a diverse universe of assets, and we know you will dream up many more:
 
 - Physical property — houses, unique artwork
-- Virtual collectables — unique pictures of kittens, collectable cards
+- Virtual collectibles — unique pictures of kittens, collectible cards
 - "Negative value" assets — loans, burdens and other responsibilities
 
 In general, all houses are distinct and no two kittens are alike. NFTs are *distinguishable* and you must track the ownership of each one separately.


### PR DESCRIPTION
Change the spelling of "collectable" to "collectible", to match the spelling in the rest of this and all other EIPs.

This is consistent with definitions that differentiate between items to be collected (like "collectable payments") and items of value worth collecting (like "collectible cards"). The latter is the intended meaning of NFTs.