### PR TITLE
Update EIP-5507: Fix small typo

### DIFF
--- a/EIPS/eip-5507.md
+++ b/EIPS/eip-5507.md
@@ -49,7 +49,7 @@ interface ERC20Refund is ERC20, ERC165 {
     /// @notice           Emitted when a token is refunded
     /// @dev              Emitted by `refund`
     /// @param  _from     The account whose assets are refunded
-    /// @param  _amount   The amount of token (in terms of the smallest divisible unit) that was refunded
+    /// @param  _amount   The amount of token (in terms of the indivisible unit) that was refunded
     event Refund(
         address indexed _from,
         uint256 indexed _amount
@@ -59,7 +59,7 @@ interface ERC20Refund is ERC20, ERC165 {
     /// @dev              Emitted by `refundFrom`
     /// @param  _sender   The account that sent the refund
     /// @param  _from     The account whose assets are refunded
-    /// @param  _amount   The amount of token (in terms of the smallest divisible unit) that was refunded
+    /// @param  _amount   The amount of token (in terms of the indivisible unit) that was refunded
     event RefundFrom(
         address indexed _sender,
         address indexed _from,
@@ -79,7 +79,7 @@ interface ERC20Refund is ERC20, ERC165 {
     function refundFrom(address from, uint256 amount) external;
 
     /// @notice         Gets the refund price
-    /// @return _wei    The amount of ether (in wei) that would be refunded for a single token unit (10**decimals smallest divisible units)
+    /// @return _wei    The amount of ether (in wei) that would be refunded for a single token unit (10**decimals indivisible units)
     function refundOf() external view returns (uint256 _wei);
  
     /// @notice         Gets the first block for which the refund is not active


### PR DESCRIPTION
`smallest divisible unit` -> `indivisible unit`