### PR TITLE
Update EIP-223: update the event specification code

### DIFF
--- a/EIPS/eip-223.md
+++ b/EIPS/eip-223.md
@@ -105,7 +105,7 @@ NOTE: A possible way to check whether the `_to` is a contract or an address is t
 ##### `Transfer`
 
 ```solidity
-event Transfer(address indexed _from, address indexed _to, uint256 _value)
+event Transfer(address indexed _from, address indexed _to, uint256 _value, bytes _data)
 ```
 
 Triggered when tokens are transferred. Compatible with and similar to the ERC-20 `Transfer` event.


### PR DESCRIPTION
Transfer event description does not match the reference implementation code. This needs to be fixed.
