### PR TITLE
Update EIP-5773: Update interface

### DIFF
--- a/EIPS/eip-5773.md
+++ b/EIPS/eip-5773.md
@@ -73,13 +73,13 @@ Alternative example of this, could be version control of an IoT device's firmwar
 The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be interpreted as described in RFC 2119.
 
 ```solidity
-/// @title EIP-5773 Context-Dependent Multi-Asset Tokens
+/// @title ERC-5773 Context-Dependent Multi-Asset Tokens
 /// @dev See https://eips.ethereum.org/EIPS/eip-5773
 /// @dev Note: the ERC-165 identifier for this interface is 0xd1526708.
 
 pragma solidity ^0.8.16;
 
-interface IMultiAsset {
+interface IERC5773 /* is ERC165 */ {
     /**
      * @notice Used to notify listeners that an asset object is initialised at `assetId`.
      * @param assetId ID of the asset that was initialised

--- a/assets/eip-5773/contracts/IERC5773.sol
+++ b/assets/eip-5773/contracts/IERC5773.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.0;
 
-interface IMultiAsset {
+interface IERC5773 {
     event AssetSet(uint64 assetId);
 
     event AssetAddedToTokens(

--- a/assets/eip-5773/contracts/MultiAssetToken.sol
+++ b/assets/eip-5773/contracts/MultiAssetToken.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.15;
 
-import "./IMultiAsset.sol";
+import "./IERC5773.sol";
 import "./library/MultiAssetLib.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
@@ -10,7 +10,7 @@ import "@openzeppelin/contracts/utils/Address.sol";
 import "@openzeppelin/contracts/utils/Strings.sol";
 import "@openzeppelin/contracts/utils/Context.sol";
 
-contract MultiAssetToken is Context, IERC721, IMultiAsset {
+contract MultiAssetToken is Context, IERC721, IERC5773 {
     using MultiAssetLib for uint256;
     using MultiAssetLib for uint64[];
     using MultiAssetLib for uint128[];

--- a/assets/eip-5773/test/multiasset.ts
+++ b/assets/eip-5773/test/multiasset.ts
@@ -60,7 +60,7 @@ describe("MultiAsset", async () => {
       expect(await token.supportsInterface("0x80ac58cd")).to.equal(true);
     });
 
-    it("can support IMultiAsset", async function () {
+    it("can support IERC5773", async function () {
       expect(await token.supportsInterface("0xd1526708")).to.equal(true);
     });
 


### PR DESCRIPTION
The interface was renamed to IERC5773 and the MultiAssetToken contract was updated to use the new interface.