### PR TITLE
Update ERC-6220 interface

### DIFF
--- a/EIPS/eip-6220.md
+++ b/EIPS/eip-6220.md
@@ -67,7 +67,7 @@ pragma solidity ^0.8.16;
 
 import "./IERC5773.sol";
 
-interface IEquippable is IERC5773 {
+interface IERC6220 is IERC5773 /*, ERC165 */ {
     /**
      * @notice Used to store the core structure of the `Equippable` component.
      * @return assetId The ID of the asset equipping a child
@@ -265,9 +265,7 @@ The interface of the Catalog containing the equippable parts. Catalogs are colle
 
 pragma solidity ^0.8.16;
 
-import "./IERC165.sol";
-
-interface ICatalog is IERC165 {
+interface ICatalog /* is IERC165 */ {
     /**
      * @notice Event to announce addition of a new part.
      * @dev It is emitted when a new part is added.

--- a/assets/eip-6220/contracts/EquippableToken.sol
+++ b/assets/eip-6220/contracts/EquippableToken.sol
@@ -5,7 +5,7 @@
 pragma solidity ^0.8.16;
 
 import "./ICatalog.sol";
-import "./IEquippable.sol";
+import "./IERC6220.sol";
 import "./IERC6059.sol";
 import "./library/EquippableLib.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
@@ -69,7 +69,7 @@ contract EquippableToken is
     IERC165,
     IERC721,
     IERC6059,
-    IEquippable
+    IERC6220
 {
     using Address for address;
     using EquippableLib for uint64[];
@@ -223,7 +223,7 @@ contract EquippableToken is
             interfaceId == type(IERC721).interfaceId ||
             interfaceId == type(IERC5773).interfaceId ||
             interfaceId == type(IERC6059).interfaceId ||
-            interfaceId == type(IEquippable).interfaceId;
+            interfaceId == type(IERC6220).interfaceId;
     }
 
     /**
@@ -1687,7 +1687,7 @@ contract EquippableToken is
     // --------------------- EQUIPPABLE GETTERS ---------------------
 
     /**
-     * @inheritdoc IEquippable
+     * @inheritdoc IERC6220
      */
     function canTokenBeEquippedWithAssetIntoSlot(
         address parent,
@@ -1705,7 +1705,7 @@ contract EquippableToken is
     }
 
     /**
-     * @inheritdoc IEquippable
+     * @inheritdoc IERC6220
      */
     function isChildEquipped(
         uint256 tokenId,
@@ -1716,7 +1716,7 @@ contract EquippableToken is
     }
 
     /**
-     * @inheritdoc IEquippable
+     * @inheritdoc IERC6220
      */
     function getAssetAndEquippableData(
         uint256 tokenId,
@@ -1736,7 +1736,7 @@ contract EquippableToken is
     }
 
     /**
-     * @inheritdoc IEquippable
+     * @inheritdoc IERC6220
      */
     function getEquipment(
         uint256 tokenId,
@@ -1749,7 +1749,7 @@ contract EquippableToken is
     // --------------------- EQUIPPABLE SETTERS ---------------------
 
     /**
-     * @inheritdoc IEquippable
+     * @inheritdoc IERC6220
      */
     function equip(
         IntakeEquip memory data
@@ -1758,7 +1758,7 @@ contract EquippableToken is
     }
 
     /**
-     * @inheritdoc IEquippable
+     * @inheritdoc IERC6220
      */
     function unequip(
         uint256 tokenId,
@@ -1802,7 +1802,7 @@ contract EquippableToken is
         // Check from child perspective intention to be used in part
         // We add reentrancy guard because of this call, it happens before updating state
         if (
-            !IEquippable(child.contractAddress)
+            !IERC6220(child.contractAddress)
                 .canTokenBeEquippedWithAssetIntoSlot(
                     address(this),
                     child.tokenId,

--- a/assets/eip-6220/contracts/IERC6220.sol
+++ b/assets/eip-6220/contracts/IERC6220.sol
@@ -5,11 +5,11 @@ pragma solidity ^0.8.16;
 import "./IERC5773.sol";
 
 /**
- * @title IEquippable
+ * @title IERC6220
  * @author RMRK team
  * @notice Interface smart contract of the equippable module.
  */
-interface IEquippable is IERC5773 {
+interface IERC6220 is IERC5773 {
     /**
      * @notice Used to store the core structure of the `Equippable` component.
      * @return assetId The ID of the asset equipping a child

--- a/assets/eip-6220/package.json
+++ b/assets/eip-6220/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "equippable-tokens",
+  "name": "erc-6220",
   "dependencies": {
     "@openzeppelin/contracts": "^4.6.0"
   },

--- a/assets/eip-6220/test/equippableSlotParts.ts
+++ b/assets/eip-6220/test/equippableSlotParts.ts
@@ -368,7 +368,7 @@ describe("EquippableTokenMock with Slots", async () => {
       await loadFixture(slotsFixture));
   });
 
-  it("can support IEquippable", async function () {
+  it("can support IERC6220", async function () {
     expect(await soldier.supportsInterface("0x28bc9ae4")).to.equal(true);
   });
 


### PR DESCRIPTION
The interface was renamed to IERC5773 and the MultiAssetToken contract was updated to use the new interface.