### PR TITLE
Update ERC-6059: Move to Last Call

### DIFF
--- a/EIPS/eip-6059.md
+++ b/EIPS/eip-6059.md
@@ -4,7 +4,8 @@ title: Parent-Governed Nestable Non-Fungible Tokens
 description: An interface for Nestable Non-Fungible Tokens with emphasis on parent token's control over the relationship.
 author: Bruno Škvorc (@Swader), Cicada (@CicadaNCR), Steven Pineda (@steven2308), Stevan Bogosavljevic (@stevyhacker), Jan Turk (@ThunderDeliverer)
 discussions-to: https://ethereum-magicians.org/t/eip-6059-parent-governed-nestable-non-fungible-tokens/11914
-status: Review
+status: Last Call
+last-call-deadline: 2023-04-07
 type: Standards Track
 category: ERC
 created: 2022-11-15


### PR DESCRIPTION
As the discussion on the EIP-6059 seems to have been concluded, we are proposing to upgrade the EIP to Last Call.