### PR TITLE
Only check sibling headers for sameness

### DIFF
--- a/config/.markdownlint.yaml
+++ b/config/.markdownlint.yaml
@@ -64,9 +64,7 @@ MD023: true
 # MD024/no-duplicate-heading/no-duplicate-header - Multiple headings with the same content
 MD024:
   # Only check sibling headings
-  allow_different_nesting: false
-  # Only check sibling headings
-  siblings_only: false
+  siblings_only: true
 
 # MD025/single-title/single-h1 - Multiple top-level headings in the same document
 MD025:


### PR DESCRIPTION
Currently, this is an error:

```markdown
### New Opcode One

#### Input

...

#### Output

...

### New Opcode Two

#### Input

...

#### Output

...
```

--

This PR allows the above and only throws an error in the following case:

```markdown
### New Opcode One

#### Input

...

#### Input

...
```

--

`allow_different_nesting` and `siblings_only` are [aliases](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md024---multiple-headings-with-the-same-content) of each other, so the former is removed.
