### PR TITLE
Move EIP-3651 to Last Call

### DIFF
--- a/EIPS/eip-3651.md
+++ b/EIPS/eip-3651.md
@@ -5,7 +5,7 @@ description: Starts the `COINBASE` address warm
 author: William Morriss (@wjmelements)
 discussions-to: https://ethereum-magicians.org/t/eip-3651-warm-coinbase/6640
 status: Last Call
-last-call-deadline: 2023-03-13
+last-call-deadline: 2023-03-28
 type: Standards Track
 category: Core
 created: 2021-07-12

--- a/EIPS/eip-3651.md
+++ b/EIPS/eip-3651.md
@@ -4,7 +4,8 @@ title: Warm COINBASE
 description: Starts the `COINBASE` address warm
 author: William Morriss (@wjmelements)
 discussions-to: https://ethereum-magicians.org/t/eip-3651-warm-coinbase/6640
-status: Review
+status: Last Call
+last-call-deadline: 2023-03-13
 type: Standards Track
 category: Core
 created: 2021-07-12

--- a/EIPS/eip-3651.md
+++ b/EIPS/eip-3651.md
@@ -20,7 +20,7 @@ The `COINBASE` address shall be warm at the start of transaction execution, in a
 
 Direct `COINBASE` payments are becoming increasingly popular because they allow conditional payments, which provide benefits such as implicit cancellation of transactions that would revert.
 But accessing `COINBASE` is overpriced; the address is initially cold under the access list framework introduced in [EIP-2929](./eip-2929.md).
-This gas cost mismatch can incentivize alternative payments besides ETH, such as [EIP-20](./eip-20.md), but ETH should be the primary means of paying for transactions on Ethereum.
+This gas cost mismatch can incentivize alternative payments besides ETH, such as [ERC-20](./eip-20.md), but ETH should be the primary means of paying for transactions on Ethereum.
 
 ## Specification
 


### PR DESCRIPTION

This EIP has been in review without changes for between one and two years.
Several times I have had to un-stagnant it.
Because of its [inclusion in Shanghai](https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/shanghai.md#eips-considered-for-inclusion), and because it was implemented by all recognized clients without sprouting ambiguity, I wish to begin the transition to Final.
#### Changes
Changes status to last-call
Sets a last-call-deadline two weeks from today.