### PR TITLE
Website: Fix MathJax

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -54,7 +54,7 @@
   <script type="text/javascript">
     window.MathJax = {
       loader: {
-        load: ['input/tex-base', 'output/chtml', 'ui/lazy']
+        load: ['input/tex-base', 'output/chtml']
       },
       tex: {
         inlineMath: [['$', '$']],


### PR DESCRIPTION
The documentation was out of date and that loader no longer exists.