### PR TITLE
normative language adjustments and additional privacy notes

### DIFF
--- a/EIPS/eip-4361.md
+++ b/EIPS/eip-4361.md
@@ -25,16 +25,16 @@ Already, many services support workflows to authenticate Ethereum accounts using
 
 Sign-In with Ethereum works as follows:
 
-1. The wallet presents the user with a structured plaintext message or equivalent interface for signing with the [ERC-191](./eip-191.md) signed data format. Before signing, the `message` is prefixed with `\x19Ethereum Signed Message:\n<length of message>` as defined in [ERC-191](./eip-191.md).
-The `message` MUST incorporate an Ethereum `address`,  `domain` requesting the signing, `version` of the message, a chain identifier `chain-id`, `uri` for scoping, `nonce` acceptable to the relying party, and `issued-at` timestamp.
+1. The wallet presents the user with a structured plaintext message or equivalent interface for signing with the [EIP-191](./eip-191.md) signed data format. Before signing, the `message` is prefixed with `\x19Ethereum Signed Message:\n<length of message>` as defined in [EIP-191](./eip-191.md).
+The `message` MUST incorporate an Ethereum `address`,  `origin` requesting the signing, `version` of the message, a chain identifier `chain-id`, `uri` for scoping, `nonce` acceptable to the relying party, and `issued-at` timestamp.
 2. The signature is then presented to the relying party, which checks the signature's validity and message content.
 3. Additional fields, including `expiration-time`, `not-before`, `request-id`, `statement`, and `resources` MAY be incorporated as part of the sign-in process.
-4. The relying party MAY further fetch data associated with the Ethereum address, such as from the Ethereum blockchain (e.g., ENS, account balances, [ERC-20](./eip-20.md)/[ERC-721](./eip-721.md)/[ERC-1155](./eip-1155.md) asset ownership), or other data sources that might or might not be permissioned.
+4. The relying party MAY further fetch data associated with the Ethereum address, such as from the Ethereum blockchain (e.g., ENS, account balances, [EIP-20](./eip-20.md)/[EIP-721](./eip-721.md)/[EIP-1155](./eip-1155.md) asset ownership), or other data sources that might or might not be permissioned.
 
 ### Example message
 
 ```
-service.invalid wants you to sign in with your Ethereum account:
+https://service.invalid wants you to sign in with your Ethereum account:
 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2
 
 I accept the ServiceOrg Terms of Service: https://service.invalid/tos
@@ -54,7 +54,7 @@ Resources:
 A Bash-like informal template of the full message is presented below for readability and ease of understanding. Field descriptions are provided in the following section. A full ABNF description is provided in the section thereafter.
 
 ```
-${domain} wants you to sign in with your Ethereum account:
+${origin} wants you to sign in with your Ethereum account:
 ${address}
 
 ${statement}
@@ -76,18 +76,18 @@ Resources:
 
 ### Message Field Descriptions
 
-- `domain` is the RFC 3986 authority that is requesting the signing.
-- `address` is the Ethereum address performing the signing conformant to capitalization encoded checksum specified in [ERC-55](./eip-55.md) where applicable.
-- `statement` (optional) is a human-readable ASCII assertion that the user will sign, and it must not contain `'\n'` (the byte `0x0a`).
+- `origin` MUST be a string containing an Origin defined by WHATWG
+- `address` MUST be the Ethereum address performing the signing conformant to capitalization encoded checksum specified in [EIP-55](./eip-55.md) where applicable.
+- `statement` MUST be a string which MAY be optionally present. If present it is a human-readable ASCII assertion that the user will sign in order, and it MUST NOT contain `'\n'` (the byte `0x0a`).
 - `uri` is an RFC 3986 URI referring to the resource that is the subject of the signing (as in the _subject of a claim_).
 - `version` is the current version of the `message`, which MUST be `1` for this specification.
-- `chain-id` is the [EIP-155](./eip-155.md) Chain ID to which the session is bound, and the network where Contract Accounts MUST be resolved.
-- `nonce` is a randomized token typically chosen by the relying party and used to prevent replay attacks, at least 8 alphanumeric characters.
-- `issued-at` is the ISO 8601 datetime string of the current time.
-- `expiration-time` (optional) is the ISO 8601 datetime string that, if present, indicates when the signed authentication message is no longer valid.
-- `not-before` (optional) is the ISO 8601 datetime string that, if present, indicates when the signed authentication message will become valid.
-- `request-id` (optional) is an system-specific identifier that may be used to uniquely refer to the sign-in request.
-- `resources` (optional) is a list of information or references to information the user wishes to have resolved as part of authentication by the relying party. They are expressed as RFC 3986 URIs separated by `"\n- "` where `\n` is the byte `0x0a`.
+- `chain-id` is the [EIP-155](./eip-155.md) Chain ID to which the session is bound, and the network where Contract Accounts MUST be resolved. If a Chain ID is unrecognized by a relying party it MUST be rejected.
+- `nonce` is a randomized token that MUST be chosen by the relying party. It's used to prevent replay attacks and MUST be at least 8 alphanumeric characters.
+- `issued-at` MUST be an RFC 3339 datetime string of the current time.
+- `expiration-time` MUST be an RFC 3339 datetime string that MAY be optionally present. If present, indicates when the signed authentication message is no longer valid.
+- `not-before` MUST be an RFC 3339 datetime string that MAY be optionally present. If present, indicates when the signed authentication message will become valid.
+- `request-id` MUST be a string that MAY be optionally present. If present, the request-id is a system-specific string identifier to uniquely refer to the sign-in request.
+- `resources` MUST be a string containing an ordered list of RFC 3986 URIs separated by `"\n- "` where `\n` is the byte `0x0a`, which MAY be optionally present. If present, the resources are information or references to information the user wishes to have resolved as part of authentication by the relying party.
 
 ### ABNF Message Format
 
@@ -95,7 +95,7 @@ The `message` MUST conform with the following Augmented Backus–Naur Form (ABNF
 
 ```abnf
 sign-in-with-ethereum =
-    domain %s" wants you to sign in with your Ethereum account:" LF
+    origin %s" wants you to sign in with your Ethereum account:" LF
     address LF
     LF
     [ statement LF ]
@@ -111,11 +111,10 @@ sign-in-with-ethereum =
     [ LF %s"Resources:"
     resources ]
 
-domain = authority
-    ; From RFC 3986:
+origin = :
     ;     authority     = [ userinfo "@" ] host [ ":" port ]
-    ; See RFC 3986 for the fully contextualized
-    ; definition of "authority".
+    ; See WHATWG for the fully contextualized
+    ; definition of "origin".
 
 address = "0x" 40*40HEXDIG
     ; Must also conform to captilization
@@ -155,20 +154,20 @@ resource = "- " URI
 
 #### Signing and Verifying with Ethereum Accounts
 
-- For Externally Owned Accounts (EOAs), the verification method specified in [ERC-191](./eip-191.md) MUST be used.
+- For Externally Owned Accounts (EOAs), the verification method specified in [EIP-191](./eip-191.md) MUST be used.
 
 - For Contract Accounts,
-    - The verification method specified in [ERC-1271](./eip-1271.md) SHOULD be used, and if it is not, the implementer MUST clearly define the verification method to attain security and interoperability for both wallets and relying parties.
-    - When performing [ERC-1271](./eip-1271.md) signature verification, the contract performing the verification MUST be resolved from the specified `chain-id`.
-    - Implementers SHOULD take into consideration that [ERC-1271](./eip-1271.md) implementations are not required to be pure functions, and can return different results for the same inputs depending on blockchain state. This can affect the security model and session validation rules. For example, a service with [ERC-1271](./eip-1271.md) signing enabled could rely on webhooks to receive notifications when state affecting the results is changed. When it receives a notification, it invalidates any matching sessions.
+  - The verification method specified in [EIP-1271](./eip-1271.md) SHOULD be used, and if it is not, the implementer MUST clearly define the verification method to attain security and interoperability for both wallets and relying parties.
+  - When performing [EIP-1271](./eip-1271.md) signature verification, the contract performing the verification MUST be resolved from the specified `chain-id`.
+  - Implementers SHOULD take into consideration that [EIP-1271](./eip-1271.md) implementations are not required to be pure functions, and can return different results for the same inputs depending on blockchain state. This can affect the security model and session validation rules. For example, a service with [EIP-1271](./eip-1271.md) signing enabled could rely on webhooks to receive notifications when state affecting the results is changed. When it receives a notification, it invalidates any matching sessions.
 
 ### Resolving Ethereum Name Service (ENS) Data
 
 - The relying party or wallet MAY additionally perform resolution of ENS data, as this can improve the user experience by displaying human-friendly information that is related to the `address`. Resolvable ENS data include:
-    - The [primary ENS name](./eip-181.md).
-    - The ENS avatar.
-    - Any other resolvable resources specified in the ENS documentation.
-- If resolution of ENS data is performed, implementers SHOULD take precautions to preserve user privacy and consent, as their `address` could be forwarded to third party services as part of the resolution process.
+  - The [primary ENS name](./eip-181.md).
+  - The ENS avatar.
+  - Any other resolvable resources specified in the ENS documentation.
+- If resolution of ENS data is performed, implementers SHOULD take precautions to preserve user privacy and consent, as their `address` could be forwarded to third party services as part of the resolution process. Some methods that could be utilized would be to pass the request over TOR network or have a trusted intermediary proxy the request to the the ENS resolver to de-corelate the IP address from the request and maintain greater K-Anonymity.
 
 ### Relying Party Implementer Steps
 
@@ -194,14 +193,14 @@ resource = "- " URI
   with your Ethereum account"` appears anywhere in an [ERC-191](./eip-191.md) message signing
   request unless the message fully conforms to the format defined in this specification.
 
-#### Verifying `domain` binding
+#### Verifying `origin` binding
 
-- Wallet implementers MUST prevent phishing attacks by matching on the `domain` term when processing a signing request. For example, when processing the message beginning with `"service.invalid wants you to sign in..."`, the wallet checks that the request actually originated from `service.invalid`.
-- The domain SHOULD be read from a trusted data source such as the browser window or over WalletConnect ([ERC-1328](./eip-1328.md)) sessions for comparison against the signing message contents.
+- Wallet implementers MUST prevent phishing attacks by matching on the `origin` term when processing a signing request. For example, when processing the message beginning with `"service.invalid wants you to sign in..."`, the wallet checks that the request actually originated from `service.invalid`.
+- The origin SHOULD be read from a trusted data source such as the browser window or over WalletConnect ([EIP-1328](./eip-1328.md)) sessions for comparison against the signing message contents.
 
 #### Creating Sign-In with Ethereum interfaces
 
-- Wallet implementers MUST display to the user the following terms from the Sign-In with Ethereum signing request by default and prior to signing, if they are present: `domain`, `address`, `statement`, and `resources`. Other present terms MUST also be made available to the user prior to signing either by default or through an extended interface.
+- Wallet implementers MUST display to the user the following terms from the Sign-In with Ethereum signing request by default and prior to signing, if they are present: `origin`, `address`, `statement`, and `resources`. Other present terms MUST also be made available to the user prior to signing either by default or through an extended interface.
 - Wallet implementers displaying a plaintext `message` to the user SHOULD require the user to scroll to the bottom of the text area prior to signing.
 - Wallet implementers MAY construct a custom Sign-In With Ethereum user interface by parsing the ABNF terms into data elements for use in the interface. The display rules above still apply to custom interfaces.
 
@@ -232,10 +231,10 @@ Additional functional requirements:
 
 ### Technical Decisions
 
-- Why [ERC-191](./eip-191.md) (Signed Data Standard) over [EIP-712](./eip-712.md) (Ethereum typed structured data hashing and signing)
-    - [ERC-191](./eip-191.md) is already broadly supported across wallets UX, while [EIP-712](./eip-712.md) support for friendly user display is pending. **(1, 2, 3, 4)**
-    - [ERC-191](./eip-191.md) is simple to implement using a pre-set prefix prior to signing, while [EIP-712](./eip-712.md) is more complex to implement requiring the further implementations of a bespoke Solidity-inspired type system, RLP-based encoding format, and custom keccak-based hashing scheme. **(2)**
-    - [ERC-191](./eip-191.md) produces more human-readable messages, while [EIP-712](./eip-712.md) creates signing outputs for machine consumption, with most wallets not displaying the payload to be signed in a manner friendly to humans. **(1)**![](../assets/eip-4361/signing.png)
+- Why [EIP-191](./eip-191.md) (Signed Data Standard) over [EIP-712](./eip-712.md) (Ethereum typed structured data hashing and signing)
+  - [EIP-191](./eip-191.md) is already broadly supported across wallets UX, while [EIP-712](./eip-712.md) support for friendly user display is pending. **(1, 2, 3, 4)**
+  - [EIP-191](./eip-191.md) is simple to implement using a pre-set prefix prior to signing, while [EIP-712](./eip-712.md) is more complex to implement requiring the further implementations of a bespoke Solidity-inspired type system, RLP-based encoding format, and custom keccak-based hashing scheme. **(2)**
+  - [EIP-191](./eip-191.md) produces more human-readable messages, while [EIP-712](./eip-712.md) creates signing outputs for machine consumption, with most wallets not displaying the payload to be signed in a manner friendly to humans. **(1)**![Signing Display Example](../assets/eip-4361/signing.png)
 
     - [EIP-712](./eip-712.md) has the advantage of on-chain representation and on-chain verifiability, such as for their use in metatransactions, but this feature is not relevant for the specification's scope. **(2)**
 - Why not use JWTs? Wallets don't support JWTs. The keccak hash function is not assigned by IANA for use as a JOSE algorithm. **(2, 3)**
@@ -248,7 +247,7 @@ The following concerns are out of scope for this version of the specification to
 - Additional authentication not based on Ethereum addresses.
 - Authorization to server resources.
 - Interpretation of the URIs in the `resources` term as claims or other resources.
-- The specific mechanisms to ensure domain-binding.
+- The specific mechanisms to ensure origin-binding.
 - The specific mechanisms to generate nonces and evaluation of their appropriateness.
 - Protocols for use without TLS connections.
 
@@ -264,12 +263,12 @@ The following items are considered for future support in either through an itera
 
 ## Backwards Compatibility
 
-- Most wallet implementations already support [ERC-191](./eip-191.md), so this is used as a base pattern with additional features.
+- Most wallet implementations already support [EIP-191](./eip-191.md), so this is used as a base pattern with additional features.
 - Requirements were gathered from existing implementations of similar sign-in workflows, including statements to allow the user to accept a Terms of Service, nonces for replay protection, and inclusion of the Ethereum address itself in the message.
 
 ## Reference Implementation
 
-A reference implementation is available [here](../assets/eip-4361/example.js). 
+A reference implementation is available [here](../assets/eip-4361/example.js).
 
 ## Security Considerations
 
@@ -283,38 +282,42 @@ A reference implementation is available [here](../assets/eip-4361/example.js).
 
 - Sign-In with Ethereum gives users control through their keys. This is additional responsibility that mainstream users may not be accustomed to accepting, and key management is a hard problem especially for individuals. For example, there is no "forgot password" button as centralized identity providers commonly implement.
 - Early adopters of this specification are likely to be already adept at key management, so this consideration becomes more relevant with mainstream adoption.
-- Certain wallets can use smart contracts and multisigs to provide an enhanced user experiences with respect to key usage and key recovery, and these can be supported via [ERC-1271](./eip-1271.md) signing.
+- Certain wallets can use smart contracts and multisigs to provide an enhanced user experiences with respect to key usage and key recovery, and these can be supported via [EIP-1271](./eip-1271.md) signing.
 
 ### Wallet and relying party combined security
 
-- Both the wallet and relying party have to implement this specification for improved security to the end user. Specifically, the wallet MUST confirm that the message is for the correct `domain` or provide the user means to do so manually (such as instructions to visually confirming the correct domain in a TLS-protected website prior to connecting via QR code or deeplink), otherwise the user is subject to phishing attacks.
+- Both the wallet and relying party have to implement this specification for improved security to the end user. Specifically, the wallet MUST confirm that the message is for the correct `origin` or provide the user means to do so manually (such as instructions to visually confirming the correct origin in a TLS-protected website prior to connecting via QR code or deeplink), otherwise the user is subject to phishing attacks.
 
 ### Minimizing wallet and server interaction
 
-- In some implementions of wallet sign-in workflows, the server first sends parameters of the `message` to the wallet. Others generate the message for signing entirely in the client side (e.g., dapps). The latter approach without initial server interaction SHOULD be preferred when there is a user privacy advantage by minimizing wallet-server interaction. Often, the backend server first produces a `nonce` to prevent replay attacks, which it verifies after signing. Privacy-preserving alternatives are suggested in the next section on preventing replay attacks.
-- Before the wallet presents the message signing request to the user, it MAY consult the server for the proper contents of the message to be signed, such as an acceptable `nonce` or requested set of `resources`. When communicating to the server, the wallet SHOULD take precautions to protect user privacy by mitigating user information revealed as much as possible.
+- In some implementions of wallet sign-in workflows, the server first sends parameters of the `message` to the wallet. Others generate the message for signing entirely in the client side (e.g., dapps). The latter approach without initial server interaction is preferred when there is a user privacy advantage by minimizing wallet-server interaction. Often, the backend server first produces a `nonce` to prevent replay attacks, which it verifies after signing. Privacy-preserving alternatives are suggested in the next section on preventing replay attacks.
+- Before the wallet presents the message signing request to the user, it MAY consult the server for the proper contents of the message to be signed, such as an acceptable `nonce` or requested set of `resources`. When communicating to the server, the wallet is expected take precautions to protect user privacy by mitigating user information revealed as much as possible.
 - Prior to signing, the wallet MAY consult the user for preferences, such as the selection of one `address` out of many, or a preferred ENS name out of many.
 
 ### Preventing replay attacks
 
-- A `nonce` SHOULD be selected per session initiation with enough entropy to prevent replay attacks, a man-in-the-middle attack in which an attacker is able to capture the user's signature and resend it to establish a new session for themselves.
+- A `nonce` SHOULD be selected per session initiation with enough entropy to prevent replay attacks, a man-in-the-middle attack in which an attacker is able to capture the user's signature and resend it to establish a new session for themselves. At a minimum 8 charcters are REQUIRED, but it's suggested that nonces should be of length 24 to 48 characters to meet a sufficient minimum of entropy to prevent possible collision of a request which could also be used to conduct a replay attack.
 - Implementers MAY consider using privacy-preserving yet widely-available `nonce` values, such as one derived from a recent Ethereum block hash or a recent Unix timestamp.
 
-### Verification of domain binding
+### Verification of origin binding
 
-- Wallets MUST check that the `domain` matches the actual signing request source.
-- This value SHOULD be checked against a trusted data source such as the browser window or over another protocol.
+- Wallets MUST check that the `origin` matches the actual signing request source.
+- It's generally expected the value will be checked against a trusted data source such as the browser window or over another protocol.
 
 ### Channel security
 
-- For web-based applications, all communications SHOULD use HTTPS to prevent man-in-the-middle attacks on the message signing.
+- For web-based applications, all communications MUST use a Secure Origin to prevent man-in-the-middle attacks on the message signing. 
 - When using protocols other than HTTPS, all communications SHOULD be protected with proper techniques to maintain confidentiality, data integrity, and sender/receiver authenticity.
+
+### Pairwise login identifiers
+
+For privacy reasons, it's generally a good idea for wallets to not utilize a globally unique identifier like an address across different web pages. These can be used to perform cross site tracking. In order to prevent this, relying parties SHOULD expect that the address used to sign in will be a unique generated address used only for signing into the relying party service. A [EIP-1193](.eip-1193.md) SHOULD return at least 2 addresses where the 0th index of the array MUST be the address used to sign in and the remaining indexes of the array SHOULD be application specific addresses such as an address associated with assets to interact with a Decentralized Finance (DeFi) protocol.
 
 ### Session invalidation
 
 There are several cases where an implementer SHOULD check for state changes as they relate to sessions.
 
-- If an [ERC-1271](./eip-1271.md) implementation or dependent data changes the signature computation, the server SHOULD invalidate sessions appropriately.
+- If an [EIP-1271](./eip-1271.md) implementation or dependent data changes the signature computation, the server SHOULD invalidate sessions appropriately.
 - If any resources specified in `resources` change, the server SHOULD invalidate sessions appropriately. However, the interpretation of `resources` is out of scope of this specification.
 
 ### Maximum lengths for ABNF terms


### PR DESCRIPTION
This modifies normative language to align it better with the expected outcomes defined. Additionally, it defines how pairwise SIWE accounts MAY be used (there's a tradeoff here that asset accounts will probably still act as global cross site tracking identifiers).

One other notable aspect is that "domain" was changed to "origin" in order to make sure that the scheme is also included. This is important to prevent attacks where the same site is presented over multiple protocols such as wss:// and https:// which would potentially allow for a replay attack to occur to the same backend service. If these services weren't treated as independent and shared a backend service, this could potentially allow for multiple authenticated sessions to be created even if the nonce was implemented properly.

other just general clean up was also done in this EIP in order to prepare it for final call.
