### PR TITLE
Update EIP-6110: Fix typo

### DIFF
--- a/EIPS/eip-6110.md
+++ b/EIPS/eip-6110.md
@@ -12,7 +12,7 @@ created: 2022-12-09
 
 ## Abstract
 
-Appends validator deposits to the Execution Layer block structure. This shifts responsibliity of deposit inclusion and validation to the Execution Layer and removes the need for deposit (or `eth1data`) voting from the Consensus Layer.
+Appends validator deposits to the Execution Layer block structure. This shifts responsibility of deposit inclusion and validation to the Execution Layer and removes the need for deposit (or `eth1data`) voting from the Consensus Layer.
 
 Validator deposits list supplied in a block is obtained by parsing deposit contract log events emitted by each deposit transaction included in a given block.
 


### PR DESCRIPTION
`responsibliity` -> `responsibility`