### PR TITLE
Update EIP-6110: Fixed typo in eip-6110.md

### DIFF
--- a/EIPS/eip-6110.md
+++ b/EIPS/eip-6110.md
@@ -12,7 +12,7 @@ created: 2022-12-09
 
 ## Abstract
 
-Appends validator deposits to the Execution Layer block structure. This shifts responsibliity of deposit inclusion and validation to the Execution Layer and removes the need for deposit (or `eth1data`) voting from the Consensus Layer.
+Appends validator deposits to the Execution Layer block structure. This shifts responsibility of deposit inclusion and validation to the Execution Layer and removes the need for deposit (or `eth1data`) voting from the Consensus Layer.
 
 Validator deposits list supplied in a block is obtained by parsing deposit contract log events emitted by each deposit transaction included in a given block.
 


### PR DESCRIPTION
Fixed Typo in the following file :
https://github.com/ethereum/EIPs/blob/master/EIPS/eip-6110.md

We have a GitHub bot that automatically merges some PRs. It will merge yours immediately if certain criteria are met:

 - All builds' were passed
 - OmkarK97 -<omkar139797@gmail.com>
 - Changed typo error of responsibliity -> responsibility (line 15)
