### PR TITLE
Update EIP-1: Remove `eip` preamble entry

### DIFF
--- a/EIPS/eip-1.md
+++ b/EIPS/eip-1.md
@@ -116,8 +116,6 @@ EIPs should be written in [markdown](https://github.com/adam-p/markdown-here/wik
 
 Each EIP must begin with an [RFC 822](https://www.ietf.org/rfc/rfc822.txt) style header preamble, preceded and followed by three hyphens (`---`). This header is also termed ["front matter" by Jekyll](https://jekyllrb.com/docs/front-matter/). The headers must appear in the following order.
 
-`eip`: *EIP number* (this is determined by the EIP editor)
-
 `title`: *The EIP title is a few words, not a complete sentence*
 
 `description`: *Description is one full (short) sentence*


### PR DESCRIPTION
Nothing really depends on the EIP number being in the preamble anymore, so we can safely remove it.