### PR TITLE
EIP-4844: validate excess_data_gas in block header

### DIFF
--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -306,6 +306,7 @@ The block validity conditions are modified to include data gas checks:
 def validate_block(block: Block) -> None:
     ...
 
+    num_blobs = 0
     for tx in block.transactions:
         ...
 
@@ -314,6 +315,12 @@ def validate_block(block: Block) -> None:
 
         # ensure that the user was willing to at least pay the current data gasprice
         assert tx.message.max_fee_per_data_gas >= get_data_gasprice(parent(block).header)
+
+        num_blobs += len(tx.message.blob_versioned_hashes)
+
+    # check that the excess data gas is correct
+    expected_edg = calc_excess_data_gas(parent(block), num_blobs)
+    assert expected_edg == block.excess_data_gas
 ```
 
 The actual `data_fee` as calculated via `calc_data_fee` is deducted from the sender balance before transaction execution and burned, and is not refunded in case of transaction failure.


### PR DESCRIPTION
This adds `excess_data_gas` checks to block validation.