### PR TITLE
Update EIP-5773: Modify specification to consume less gas

### DIFF
--- a/EIPS/eip-5773.md
+++ b/EIPS/eip-5773.md
@@ -76,7 +76,7 @@ The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL 
 ```solidity
 /// @title ERC-5773 Context-Dependent Multi-Asset Tokens
 /// @dev See https://eips.ethereum.org/EIPS/eip-5773
-/// @dev Note: the ERC-165 identifier for this interface is 0xd1526708.
+/// @dev Note: the ERC-165 identifier for this interface is 0x06b4329a.
 
 pragma solidity ^0.8.16;
 
@@ -222,7 +222,7 @@ interface IERC5773 /* is ERC165 */ {
      * @param priorities An array of priorities of active assets. The succession of items in the priorities array
      *  matches that of the succession of items in the active array
      */
-    function setPriority(uint256 tokenId, uint16[] calldata priorities)
+    function setPriority(uint256 tokenId, uint64[] calldata priorities)
         external;
 
     /**
@@ -260,7 +260,7 @@ interface IERC5773 /* is ERC165 */ {
     function getActiveAssetPriorities(uint256 tokenId)
         external
         view
-        returns (uint16[] memory);
+        returns (uint64[] memory);
 
     /**
      * @notice Used to retrieve the asset that will be replaced if a given asset from the token's pending array

--- a/assets/eip-5773/contracts/IERC5773.sol
+++ b/assets/eip-5773/contracts/IERC5773.sol
@@ -49,7 +49,7 @@ interface IERC5773 {
 
     function setPriority(
         uint256 tokenId,
-        uint16[] calldata priorities
+        uint64[] calldata priorities
     ) external;
 
     function getActiveAssets(
@@ -62,7 +62,7 @@ interface IERC5773 {
 
     function getActiveAssetPriorities(
         uint256 tokenId
-    ) external view returns (uint16[] memory);
+    ) external view returns (uint64[] memory);
 
     function getAssetReplacements(
         uint256 tokenId,

--- a/assets/eip-5773/contracts/MultiAssetToken.sol
+++ b/assets/eip-5773/contracts/MultiAssetToken.sol
@@ -52,7 +52,7 @@ contract MultiAssetToken is Context, IERC721, IERC5773 {
     mapping(uint256 => uint64[]) internal _activeAssets;
 
     //mapping of tokenId to an array of asset priorities
-    mapping(uint256 => uint16[]) internal _activeAssetPriorities;
+    mapping(uint256 => uint64[]) internal _activeAssetPriorities;
 
     //Double mapping of tokenId to active assets
     mapping(uint256 => mapping(uint64 => bool)) private _tokenAssets;
@@ -71,7 +71,7 @@ contract MultiAssetToken is Context, IERC721, IERC5773 {
 
     function supportsInterface(bytes4 interfaceId) public view returns (bool) {
         return
-            interfaceId == type(IMultiAsset).interfaceId ||
+            interfaceId == type(IERC5773).interfaceId ||
             interfaceId == type(IERC721).interfaceId ||
             interfaceId == type(IERC165).interfaceId;
     }
@@ -447,7 +447,7 @@ contract MultiAssetToken is Context, IERC721, IERC5773 {
         } else {
             // We use the current size as next priority, by default priorities would be [0,1,2...]
             _activeAssetPriorities[tokenId].push(
-                uint16(_activeAssets[tokenId].length)
+                uint64(_activeAssets[tokenId].length)
             );
             _activeAssets[tokenId].push(assetId);
             replacesId = uint64(0);
@@ -514,7 +514,7 @@ contract MultiAssetToken is Context, IERC721, IERC5773 {
 
     function setPriority(
         uint256 tokenId,
-        uint16[] memory priorities
+        uint64[] memory priorities
     ) external virtual {
         uint256 length = priorities.length;
         require(
@@ -547,7 +547,7 @@ contract MultiAssetToken is Context, IERC721, IERC5773 {
 
     function getActiveAssetPriorities(
         uint256 tokenId
-    ) public view virtual returns (uint16[] memory) {
+    ) public view virtual returns (uint64[] memory) {
         return _activeAssetPriorities[tokenId];
     }
 
@@ -674,11 +674,11 @@ contract MultiAssetToken is Context, IERC721, IERC5773 {
 
     function _beforeSetPriority(
         uint256 tokenId,
-        uint16[] memory priorities
+        uint64[] memory priorities
     ) internal virtual {}
 
     function _afterSetPriority(
         uint256 tokenId,
-        uint16[] memory priorities
+        uint64[] memory priorities
     ) internal virtual {}
 }

--- a/assets/eip-5773/contracts/utils/MultiAssetRenderUtils.sol
+++ b/assets/eip-5773/contracts/utils/MultiAssetRenderUtils.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-import "../IMultiAsset.sol";
+import "../IERC5773.sol";
 
 pragma solidity ^0.8.15;
 
@@ -9,11 +9,11 @@ pragma solidity ^0.8.15;
  */
 
 contract MultiAssetRenderUtils {
-    uint16 private constant _LOWEST_POSSIBLE_PRIORITY = 2 ** 16 - 1;
+    uint64 private constant _LOWEST_POSSIBLE_PRIORITY = 2 ** 16 - 1;
 
     struct ActiveAsset {
         uint64 id;
-        uint16 priority;
+        uint64 priority;
         string metadata;
     }
 
@@ -28,10 +28,10 @@ contract MultiAssetRenderUtils {
         address target,
         uint256 tokenId
     ) public view virtual returns (ActiveAsset[] memory) {
-        IMultiAsset target_ = IMultiAsset(target);
+        IERC5773 target_ = IERC5773(target);
 
         uint64[] memory assets = target_.getActiveAssets(tokenId);
-        uint16[] memory priorities = target_.getActiveAssetPriorities(tokenId);
+        uint64[] memory priorities = target_.getActiveAssetPriorities(tokenId);
         uint256 len = assets.length;
         if (len == 0) {
             revert("Token has no assets");
@@ -57,7 +57,7 @@ contract MultiAssetRenderUtils {
         address target,
         uint256 tokenId
     ) public view virtual returns (PendingAsset[] memory) {
-        IMultiAsset target_ = IMultiAsset(target);
+        IERC5773 target_ = IERC5773(target);
 
         uint64[] memory assets = target_.getPendingAssets(tokenId);
         uint256 len = assets.length;
@@ -99,7 +99,7 @@ contract MultiAssetRenderUtils {
         uint256 tokenId,
         uint64[] calldata assetIds
     ) public view virtual returns (string[] memory) {
-        IMultiAsset target_ = IMultiAsset(target);
+        IERC5773 target_ = IERC5773(target);
         uint256 len = assetIds.length;
         string[] memory assets = new string[](len);
         for (uint256 i; i < len; ) {
@@ -118,18 +118,18 @@ contract MultiAssetRenderUtils {
         address target,
         uint256 tokenId
     ) external view returns (string memory) {
-        IMultiAsset target_ = IMultiAsset(target);
-        uint16[] memory priorities = target_.getActiveAssetPriorities(tokenId);
+        IERC5773 target_ = IERC5773(target);
+        uint64[] memory priorities = target_.getActiveAssetPriorities(tokenId);
         uint64[] memory assets = target_.getActiveAssets(tokenId);
         uint256 len = priorities.length;
         if (len == 0) {
             revert("Token has no assets");
         }
 
-        uint16 maxPriority = _LOWEST_POSSIBLE_PRIORITY;
+        uint64 maxPriority = _LOWEST_POSSIBLE_PRIORITY;
         uint64 maxPriorityAsset;
         for (uint64 i; i < len; ) {
-            uint16 currentPrio = priorities[i];
+            uint64 currentPrio = priorities[i];
             if (currentPrio < maxPriority) {
                 maxPriority = currentPrio;
                 maxPriorityAsset = assets[i];

--- a/assets/eip-5773/test/multiasset.ts
+++ b/assets/eip-5773/test/multiasset.ts
@@ -8,6 +8,7 @@ import {
   MultiAssetRenderUtils,
 } from "../typechain-types";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { BigNumber } from "ethers";
 
 describe("MultiAsset", async () => {
   let token: MultiAssetTokenMock;
@@ -61,7 +62,7 @@ describe("MultiAsset", async () => {
     });
 
     it("can support IERC5773", async function () {
-      expect(await token.supportsInterface("0xd1526708")).to.equal(true);
+      expect(await token.supportsInterface("0x06b4329a")).to.equal(true);
     });
 
     it("cannot support other interfaceId", async function () {
@@ -586,11 +587,11 @@ describe("MultiAsset", async () => {
       const tokenId = 1;
       await addAssetsToToken(tokenId);
 
-      expect(await token.getActiveAssetPriorities(tokenId)).to.be.eql([0, 1]);
+      expect(await token.getActiveAssetPriorities(tokenId)).to.be.eql([BigNumber.from(0), BigNumber.from(1)]);
       await expect(token.setPriority(tokenId, [2, 1]))
         .to.emit(token, "AssetPrioritySet")
         .withArgs(tokenId);
-      expect(await token.getActiveAssetPriorities(tokenId)).to.be.eql([2, 1]);
+      expect(await token.getActiveAssetPriorities(tokenId)).to.be.eql([BigNumber.from(2), BigNumber.from(1)]);
     });
 
     it("cannot set priorities for non owned token", async function () {

--- a/assets/eip-5773/test/renderUtils.ts
+++ b/assets/eip-5773/test/renderUtils.ts
@@ -64,8 +64,8 @@ describe("Render Utils", async function () {
       expect(
         await renderUtils.getActiveAssets(multiasset.address, tokenId)
       ).to.eql([
-        [resId, 10, "ipfs://res1.jpg"],
-        [resId2, 5, "ipfs://res2.jpg"],
+        [resId, BigNumber.from(10), "ipfs://res1.jpg"],
+        [resId2, BigNumber.from(5), "ipfs://res2.jpg"],
       ]);
     });
     it("can get pending assets", async function () {


### PR DESCRIPTION
Upon detailed examination we have concluded that priorities should be expressed in `uint64` instead of `uint16` as this consumes less gas upon implementation of the proposal.