### PR TITLE
Website: 💄 hide header/footer on print

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -88,3 +88,12 @@ h1 a {
   height: 100%;
   object-fit: cover;
 }
+
+@media print {
+
+  header,
+  footer {
+    display: none;
+  }
+}
+


### PR DESCRIPTION
Add a media query that automatically hides the header and the footer when printing an EIP.