### PR TITLE
Update EIP-4844: change blob transaction type to 0x03

### DIFF
--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -39,7 +39,7 @@ Compared to full data sharding, this EIP has a reduced cap on the number of thes
 
 | Constant | Value |
 | - | - |
-| `BLOB_TX_TYPE` | `Bytes1(0x05)` |
+| `BLOB_TX_TYPE` | `Bytes1(0x03)` |
 | `FIELD_ELEMENTS_PER_BLOB` | `4096` |
 | `BLS_MODULUS` | `52435875175126190479447740508185965837690552500527637822603658699938581184513` |
 | `BLOB_COMMITMENT_VERSION_KZG` | `Bytes1(0x01)` |


### PR DESCRIPTION
This PR changes the blob tx type from 0x05 to 0x03. 
The types 0x03 and 0x04 are not set on mainnet. We should not create the expectation that we will care about transaction types on other chains. i think the expectation should be that at least the first 32 transaction types are reserved for mainnet use.