### PR TITLE
Update EIP-5564: update eip-5564 - add staking mechanism

### DIFF
--- a/EIPS/eip-5564.md
+++ b/EIPS/eip-5564.md
@@ -2,7 +2,7 @@
 eip: 5564
 title: Stealth Addresses
 description: Private, non-interactive transfers and interactions
-author: Toni Wahrstätter (@nerolation), Matt Solomon (@mds1), Ben DiFrancesco (@apbendi), Vitalik Buterin <vitalik.buterin@ethereum.org>
+author: Toni Wahrstätter (@nerolation), Matt Solomon (@mds1), Ben DiFrancesco (@apbendi), Vitalik Buterin (@vbuterin)
 discussions-to: https://ethereum-magicians.org/t/eip-5566-stealth-addresses-for-smart-contract-wallets/10614
 status: Draft
 type: Standards Track
@@ -100,7 +100,7 @@ This specification additionally defines a singleton `ERC5564Messenger` contract 
 
 ```solidity
 /// @notice Interface for announcing when something is sent to a stealth address.
-contract IERC5564Messenger {
+contract IERC5564Messenger is StakeManager{
   /// @dev Emitted when sending something to a stealth address.
   /// @dev See the `announce` method for documentation on the parameters.
   event Announcement (
@@ -145,14 +145,83 @@ contract IERC5564Messenger {
   }
 }
 ```
+The `ERC5564Messenger` contract inherits the  `StakeManager` contract allowing users to stake ETH that is uses as an anti-DoS measure. More details in the ... section.
+```solidity
+/// @notice Interface for the Stake Manager contract.
+contract StakeManager{
+  
+  /// @dev Emitted when stake is deposited.
+  /// @param account The address of the staker who deposited the stake.
+  /// @param totalStaked The new total amount of staked tokens for the account.
+  event StakeDeposit (
+        address indexed account,
+        uint256 totalStaked
+  );
+    
+  /// @dev Emitted when stake is withdrawn.
+  /// @param account The address of the staker who withdrew the stake.
+  /// @param withdrawAddress The address to which the withdrawn amount was sent.
+  /// @param amount The amount of tokens withdrawn.
+  event StakeWithdrawal (
+        address indexed account,
+        address withdrawAddress,
+        uint256 amount
+  );
+  
+  /**
+   * @notice Returns the stake of the account.
+   * @param account The address of the staker to check the stake for.
+   * @return uint256 The amount of staked tokens for the account.
+   */
+  function balanceOf(address account) external view returns (uint256);
 
-An example stealth address scheme for elliptic curves is below. Other stealth schemes may need to modify this approach. 
+  /**
+   * @notice Adds the specified amount to the account's stake.
+   * @dev The function is payable, so the amount is sent as value with the transaction.
+   * @param staker The address of the staker to add the stake for.
+   */
+  function addStake(address staker) external payable;
+  
+  /**
+   * @notice Withdraws the stake for the caller and sends it to the specified address.
+   * @param withdrawAddress The address to send the withdrawn amount to.
+   */
+  function withdrawStake(address payable withdrawAddress) external;
+}
+```
+
+
+### Stealth meta-address format
+
+The new address format for the stealth meta-addresses is based on [ERC-3770](./eip-3770.md) and extends it by adding a `st:` (*stealth*) as prefix.
+Thus, stealth meta-addresses on Ethereum come with the following format:
+
+```
+st:eth:0x<spendingKey><viewingKey>
+``` 
+
+*Notably, the address-format is only used to differentiate stealth addresses from standard addresses, as the prefix is sliced away before doing any computations on the stealth meta-address.*
+
+---
+
+### Initial Implementation of SECP256k1 with View Tags
+
+This ERC provides a foundation that is not tied to any specific cryptographic system through the IERC5564Messenger contract. In addition, it introduces the first implementation of a [stealth address scheme](../assets/eip-5564/scheme_ids.md) that utilizes the SECP256k1 elliptic curve and `view tags`. The SECP256k1 elliptic curve is defined with the equation $y^2 = x^3 + 7 \pmod{p}$, where $p = 2^{256} - 2^{32} - 977$.
+
+The following reference is divided into three sections:
+1. Stealth address generation
+2. Parsing announcements
+3. Stealth private key derivation
+
+ Definitions:
 
 - $G$ represents the generator point of the curve.
 
-- Recipient has published a stealth meta-address that constists of the public keys $P_{spend}$ and $P_{view}$.
+#### Generation - Generate stealth address from stealth meta-address:
 
-- Recipient has has access to the private keys $p_{spend}$, $p_{view}$ from which $P_{spend}$ and $P_{view}$ are derived.
+- Recipient has access to the private keys $p_{spend}$, $p_{view}$ from which public keys $P_{spend}$ and $P_{view}$ are derived.
+
+- Recipient has published a stealth meta-address that consists of the public keys $P_{spend}$ and $P_{view}$.
 
 - Sender passes the stealth meta-address to the `generateStealthAddress` function.
 
@@ -169,7 +238,7 @@ An example stealth address scheme for elliptic curves is below. Other stealth sc
   - The function returns the stealth address $a_{stealth}$, the ephemeral public key $P_{ephemeral}$ and the view tag $v$. 
 
 
-An example function to check whether a stealth address belongs to oneself:
+#### Parsing - Locate one's own stealth address(es):
 
 - User has access to the viewing private key $p_{view}$ and the public spending key $P_{spend}$.
 
@@ -178,26 +247,26 @@ An example function to check whether a stealth address belongs to oneself:
 - The  `checkStealthAddress` function performs the following computations:
   - Shared secret $s$ is computed by multiplying the viewing private key with the ephemeral public key of the announcement $s = p_{view}$ * $P_{ephemeral}$.
   - The secret is hashed $s_{h} = h(s)$.
+  - The view tag $v$ is extracted by taking the most significant byte $s_{h}[0]$ and can be compared to the given view tag. If the view tags do not match, this `Announcement` is not for the user and the remaining steps can be skipped. If the view tags match, continue on.
   - Multiply the hashed shared secret with the generator point $S_h = s_h \cdot G$.
   - The stealth public key is computed as $P_{stealth} = P_{spend} + S_h$.
   - The derived stealth address $a_{stealth}$ is computed as $\textrm{pubkeyToAddress}(P_{stealth})$.
   - Return `true` if the stealth address of the announcement matches the derived stealth address, else return `false`.
 
-An example function to derive the private key of a stealth address:
+#### Private key derivation - Generate the stealth address private key from the hashed shared secret and the spending private key.
 
-- User has access to the viewing private key, spending private key $p_{spend}$.
+- User has access to the viewing private key $p_{view}$ and spending private key $p_{spend}$.
 
 - User has access to a set of `Announcement` events for which the `checkStealthAddress` function returns `true`. 
 
 - The  `computeStealthKey` function performs the following computations:
   - Shared secret $s$ is computed by multiplying the viewing private key with the ephemeral public key of the announcement $s = p_{view}$ * $P_{ephemeral}$.
   - The secret is hashed $s_{h} = h(s)$.
-  - The stealth private key is computed as $P_{stealth} = p_{spend} + s_h$.
-
----
+  - The stealth private key is computed as $p_{stealth} = p_{spend} + s_h$.
 
 
-### Parsing ad security considerations
+
+### Parsing considerations
 
 Usually, the recipient of a stealth address transaction has to perform the following operations to check weather he was the recipient of a certain transaction:
 
@@ -209,16 +278,7 @@ Usually, the recipient of a stealth address transaction has to perform the follo
 
 The view tags approach is introduced to reduce the parsing time by around 6x. Users only need to perform 1x ecMUL and 1x HASH (skipping 1x ecMUL, 1x ecADD and 1x HASH) for every parsed announcement. The 1 bytes length was is based on the maximum required space to reliably filter not matching announcement. With 1 bytes as `viewTag` the probability for users to skip the remaining computations after hashing the shared secret $h(s)$ is $1/256$. This means that users can almost certainly skip the above three operations for any announcements that to do not involve them. Since the view tag reveals one byte of the shared secret, the security margin is reduced from 128 bits to 124 bits. Notably, this only affects the privacy and not the secure generation of a stealth address.
 
-### Stealth meta-address format
-
-The new address format for the stealth meta-addresses is based on [ERC-3770](./eip-3770.md) and extends it by adding a `st:` (*stealth*) as prefix.
-Thus, stealth meta-addresses on Ethereum come with the following format:
-
-```
-st:eth:0x<spendingKey><viewingKey>
-``` 
-
-*Notably, the address-format is only used to differentiate stealth addresses from standard addresses, however, the prefix is sliced away before doing any computations on the stealth meta-address.*
+---
 
 ## Rationale
 
@@ -240,9 +300,18 @@ You can find an implementation of this standard in TBD.
 
 ## Security Considerations
 
+### DoS Measures
+
+There are potential DoS attack vectors that are not mitigated by network transaction fees. Stealth transfer senders cause an externality for recipients, as parsing announcement events consumes computational resources that are not compensated with gas. Therefore, spamming announcement events _can_ be a detriment to the user experience, as it _can_ lead to longer parsing times. 
+We consider the incentives to carry out such an attack as low because **no monetary benefit can be obtained** and, in theory, nothing prevents parsing providers to ignore the spamming when serving announcements to users.
+However, sophisticated spamming (_sybil attacks_), which are not considered worth the associated costs, could make it difficult for paprsing providers to develop filters for such announcement events.
+Therefore, to counter spamming directly, a staking mechanism is introduced in the EIP that allows users to stake an unslashable amount of ETH. Staking allows parsing providers to better tackle potential spam through _sybil attacks_, enabling them to filter spam more effectively filter.
+
+Similar to [ERC-4337](./eip-4337), parsing providers agree on a `MINIMUM_STAKE`, such that the minimum required stake is not enforce on-chain. Users _can_ withdraw their stake at any time without any delay. Parsing providers can de-prioritized senders who have not staked a certain minimum amount or withdrew their stake immediatly.
+
+### Recipients' transaction costs
 The funding of the stealth address wallet represents a known issue that might breach privacy. The wallet that funds the stealth address MUST NOT have any physical connection to the stealth address owner in order to fully leverage the privacy improvements.
 
 ## Copyright
 
 Copyright and related rights waived via [CC0](../LICENSE.md).
-

--- a/EIPS/eip-5564.md
+++ b/EIPS/eip-5564.md
@@ -208,7 +208,7 @@ st:eth:0x<spendingKey><viewingKey>
 
 ### Initial Implementation of SECP256k1 with View Tags
 
-This improvement proposal provides a foundation that is not tied to any specific cryptographic system through the IERC5564Messenger contract. In addition, it introduces the first implementation of a [stealth address scheme](../assets/eip-5564/scheme_ids.md) that utilizes the SECP256k1 elliptic curve and `view tags`. The SECP256k1 elliptic curve is defined with the equation $y^2 = x^3 + 7 \pmod{p}$, where $p = 2^{256} - 2^{32} - 977$.
+This improvement proposal provides a foundation that is not tied to any specific cryptographic system through the `IERC5564Messenger` contract. In addition, it introduces the first implementation of a [stealth address scheme](../assets/eip-5564/scheme_ids.md) that utilizes the SECP256k1 elliptic curve and `view tags`. The SECP256k1 elliptic curve is defined with the equation $y^2 = x^3 + 7 \pmod{p}$, where $p = 2^{256} - 2^{32} - 977$.
 
 The following reference is divided into three sections:
 

--- a/EIPS/eip-5564.md
+++ b/EIPS/eip-5564.md
@@ -145,7 +145,9 @@ contract IERC5564Messenger is StakeManager{
   }
 }
 ```
+
 The `ERC5564Messenger` contract inherits the  `StakeManager` contract allowing users to stake ETH that is uses as an anti-DoS measure. More details in the ... section.
+
 ```solidity
 /// @notice Interface for the Stake Manager contract.
 contract StakeManager{
@@ -206,11 +208,14 @@ st:eth:0x<spendingKey><viewingKey>
 
 ### Initial Implementation of SECP256k1 with View Tags
 
-This ERC provides a foundation that is not tied to any specific cryptographic system through the IERC5564Messenger contract. In addition, it introduces the first implementation of a [stealth address scheme](../assets/eip-5564/scheme_ids.md) that utilizes the SECP256k1 elliptic curve and `view tags`. The SECP256k1 elliptic curve is defined with the equation $y^2 = x^3 + 7 \pmod{p}$, where $p = 2^{256} - 2^{32} - 977$.
+This improvement proposal provides a foundation that is not tied to any specific cryptographic system through the IERC5564Messenger contract. In addition, it introduces the first implementation of a [stealth address scheme](../assets/eip-5564/scheme_ids.md) that utilizes the SECP256k1 elliptic curve and `view tags`. The SECP256k1 elliptic curve is defined with the equation $y^2 = x^3 + 7 \pmod{p}$, where $p = 2^{256} - 2^{32} - 977$.
 
 The following reference is divided into three sections:
+
 1. Stealth address generation
+
 2. Parsing announcements
+
 3. Stealth private key derivation
 
  Definitions:
@@ -302,14 +307,15 @@ You can find an implementation of this standard in TBD.
 
 ### DoS Measures
 
-There are potential DoS attack vectors that are not mitigated by network transaction fees. Stealth transfer senders cause an externality for recipients, as parsing announcement events consumes computational resources that are not compensated with gas. Therefore, spamming announcement events _can_ be a detriment to the user experience, as it _can_ lead to longer parsing times. 
+There are potential DoS attack vectors that are not mitigated by network transaction fees. Stealth transfer senders cause an externality for recipients, as parsing announcement events consumes computational resources that are not compensated with gas. Therefore, spamming announcement events *can* be a detriment to the user experience, as it *can* lead to longer parsing times. 
 We consider the incentives to carry out such an attack as low because **no monetary benefit can be obtained** and, in theory, nothing prevents parsing providers to ignore the spamming when serving announcements to users.
-However, sophisticated spamming (_sybil attacks_), which are not considered worth the associated costs, could make it difficult for paprsing providers to develop filters for such announcement events.
-Therefore, to counter spamming directly, a staking mechanism is introduced in the EIP that allows users to stake an unslashable amount of ETH. Staking allows parsing providers to better tackle potential spam through _sybil attacks_, enabling them to filter spam more effectively filter.
+However, sophisticated spamming (*sybil attacks*), which are not considered worth the associated costs, could make it difficult for paprsing providers to develop filters for such announcement events.
+Therefore, to counter spamming directly, a staking mechanism is introduced in the EIP that allows users to stake an unslashable amount of ETH. Staking allows parsing providers to better tackle potential spam through *sybil attacks*, enabling them to filter spam more effectively filter.
 
-Similar to [ERC-4337](./eip-4337), parsing providers agree on a `MINIMUM_STAKE`, such that the minimum required stake is not enforce on-chain. Users _can_ withdraw their stake at any time without any delay. Parsing providers can de-prioritized senders who have not staked a certain minimum amount or withdrew their stake immediatly.
+Similar to [ERC-4337](./eip-4337), parsing providers agree on a `MINIMUM_STAKE`, such that the minimum required stake is not enforce on-chain. Users *can* withdraw their stake at any time without any delay. Parsing providers can de-prioritized senders who have not staked a certain minimum amount or withdrew their stake immediatly.
 
 ### Recipients' transaction costs
+
 The funding of the stealth address wallet represents a known issue that might breach privacy. The wallet that funds the stealth address MUST NOT have any physical connection to the stealth address owner in order to fully leverage the privacy improvements.
 
 ## Copyright


### PR DESCRIPTION
By introducing a staking mechanism similar to eip-4337, we can handle DoS by filtering spamming senders within the parsing process. Parsing providers can either entirely filter the announcements of known spammer or de-prioritize them. 

