### PR TITLE
Update EIP-3860: Move to Last Call

### DIFF
--- a/EIPS/eip-3860.md
+++ b/EIPS/eip-3860.md
@@ -37,7 +37,7 @@ Furthermore, the lack of a limit has caused lengthy discussions for some EVM pro
 We are motivated by three reasons:
 
 1. Ensuring `initcode` is fairly charged (most importantly cost is proportional to `initcode`'s length) to minimize the risks for the future.
-2. To have a cost system which is extendable in the future (i.e. for proposals like [EIP-3670](./eip-3670.md)).
+2. To have a cost system which is extendable in the future.
 3. To simplify EVM engines by the explicit limits (code size, code offsets (`PC`), and jump offsets fit 16-bits).
 
 ## Specification

--- a/EIPS/eip-3860.md
+++ b/EIPS/eip-3860.md
@@ -5,7 +5,7 @@ description: Limit the maximum size of initcode to 49152 and apply extra gas cos
 author: Martin Holst Swende (@holiman), Paweł Bylica (@chfast), Alex Beregszaszi (@axic), Andrei Maiboroda (@gumb0)
 discussions-to: https://ethereum-magicians.org/t/eip-3860-limit-and-meter-initcode/7018
 status: Last Call
-Last Call Deadline: 2023-04-12
+last-call-deadline: 2023-04-12
 type: Standards Track
 category: Core
 created: 2021-07-16

--- a/EIPS/eip-3860.md
+++ b/EIPS/eip-3860.md
@@ -4,7 +4,8 @@ title: Limit and meter initcode
 description: Limit the maximum size of initcode to 49152 and apply extra gas cost of 2 for every 32-byte chunk of initcode
 author: Martin Holst Swende (@holiman), Paweł Bylica (@chfast), Alex Beregszaszi (@axic), Andrei Maiboroda (@gumb0)
 discussions-to: https://ethereum-magicians.org/t/eip-3860-limit-and-meter-initcode/7018
-status: Review
+status: Last Call
+Last Call Deadline: 2023-04-12
 type: Standards Track
 category: Core
 created: 2021-07-16


### PR DESCRIPTION
This PR promote EIP-3860 to `Last call`.
