### PR TITLE
Update EIP-4844: check input length of the precompile

### DIFF
--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -262,6 +262,7 @@ def point_evaluation_precompile(input: Bytes) -> Bytes:
     Also verify that the provided commitment matches the provided versioned_hash.
     """
     # The data is encoded as follows: versioned_hash | z | y | commitment | proof |
+    assert len(input) == 192
     versioned_hash = input[:32]
     z = input[32:64]
     y = input[64:96]


### PR DESCRIPTION
Different precompiles treat non-canonical input lengths differently (ECREC pads & truncates, BLAKE2F fails). A.t.m. EIP-4844 is mute on the matter. This change stipulates that inputs with incorrect lengths to the point evaluation precompile result in failure.