### PR TITLE
Update EIP-4844: Ban Zero Blob Txs

### DIFF
--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -153,6 +153,7 @@ When a blob transaction is passed through the network (see the [Networking](#net
 the `TransactionNetworkPayload` version of the transaction also includes `blobs` and `kzgs` (commitments list).
 The execution layer verifies the wrapper validity against the inner `TransactionPayload` after signature verification as:
 
+- `blob_versioned_hashes` must not be empty
 - All hashes in `blob_versioned_hashes` must start with the byte `BLOB_COMMITMENT_VERSION_KZG`
 - There may be at most `MAX_DATA_GAS_PER_BLOCK // DATA_GAS_PER_BLOB` total blob commitments in a valid block.
 - There is an equal amount of versioned hashes, kzg commitments and blobs.
@@ -354,6 +355,7 @@ def validate_blob_transaction_wrapper(wrapper: BlobTransactionNetworkWrapper):
     blobs = wrapper.blobs
     # note: assert blobs are not malformatted
     assert len(versioned_hashes) == len(commitments) == len(blobs)
+    assert len(versioned_hashes) > 0
 
     # Verify that commitments match the blobs by checking the KZG proof
     assert verify_aggregate_kzg_proof(blobs, commitments, wrapper.kzg_aggregated_proof)


### PR DESCRIPTION
Minimal change to ban blob transactions with 0 blobs.
Note that the current EIP is somewhat unclear in distinguishing between network-layer and block validity rules, https://github.com/ethereum/EIPs/pull/6583 will address that with a proper refactor.