### PR TITLE
Config: Add ethereum/eip-review-bot to renovate ignorelist

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,6 +9,7 @@
   ],
   "ignoreDeps": [
     "Pandapip1/jekyll-label-action",
-    "ethereum/eipw-action"
+    "ethereum/eipw-action",
+    "ethereum/eip-review-bot"
   ]
 }


### PR DESCRIPTION
Renovate will try to update ethereum/eip-review-bot to the default branch, while the built action is in the `dist` branch.