### PR TITLE
Update EIP-5219: Fix major brainfart

### DIFF
--- a/assets/eip-5219/IDecentralizedApp.sol
+++ b/assets/eip-5219/IDecentralizedApp.sol
@@ -13,5 +13,5 @@ interface IDecentralizedApp {
     /// @return statusCode          The HTTP status code (e.g. 200)
     /// @return body                The body of the response
     /// @return headers             A list of header names (e.g. [{ key: "Content-Type", value: "application/json" }])
-    function request(string[] memory resource, KeyValue[] memory params) external view returns (uint8 statusCode, string memory body, KeyValue[] headers);
+    function request(string[] memory resource, KeyValue[] memory params) external view returns (uint16 statusCode, string memory body, KeyValue[] headers);
 }


### PR DESCRIPTION
When I had written this, I had a brainfart and thought that `uint8` was 8 *bytes*, and not 8 *bits*.

As the specification references that any status code is allowed, the EIP-712 "that specification doesn't work" rule applies.