### PR TITLE
CI: Bump eipw to 0.4.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Checkout EIP Repository
         uses: actions/checkout@47fbe2df0ad0e27efb67a70beac3555f192b062f
 
-      - uses: ethereum/eipw-action@46f859303960fa252a9a8aa453f84020c19bf5ee
+      - uses: ethereum/eipw-action@59cdee4fc5d37c9391f3a0b52857fd5b021a39c2
         id: eipw
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
eipw-lint-js 0.4.5 fixes the unicode issue causing panics on #6916 