### PR TITLE
Update EIP-5639: Add missing forward slash

### DIFF
--- a/EIPS/eip-5639.md
+++ b/EIPS/eip-5639.md
@@ -77,7 +77,7 @@ Let:
 **A Delegation Registry must implement IDelegationRegistry**
 
 ```solidity
-**
+/**
  * @title An immutable registry contract to be deployed as a standalone primitive
  * @dev New project launches can read previous cold wallet -> hot wallet delegations
  * from here and integrate those permissions into their flow


### PR DESCRIPTION
The first commit section is missing the initial forward slash.

