### PR TITLE
Update EIP-1271: Change `an` to `a` in ERC 1271, as it precedes `signed`

### DIFF
--- a/EIPS/eip-1271.md
+++ b/EIPS/eip-1271.md
@@ -55,7 +55,7 @@ This function should be implemented by contracts which desire to sign messages (
 
 
 ## Rationale
-We believe the name of the proposed function to be appropriate considering that an *authorized* signers providing proper signatures for a given data would see their signature as "valid" by the signing contract. Hence, an signed action message is only valid when the signer is authorized to perform a given action on the behalf of a smart wallet. 
+We believe the name of the proposed function to be appropriate considering that an *authorized* signers providing proper signatures for a given data would see their signature as "valid" by the signing contract. Hence, a signed action message is only valid when the signer is authorized to perform a given action on the behalf of a smart wallet. 
 
 Two arguments are provided for simplicity of separating the hash signed from the signature. A bytes32 hash is used instead of the unhashed message for simplicy, since contracts could expect a certain hashing function that is not standard, such as with [EIP-712](./eip-712.md). 
 


### PR DESCRIPTION
Change `an` to `a` in ERC 1271, as it precedes `signed`. I believe this was just a typo.

I also noticed the clause:

> considering that an *authorized* signers providing proper signatures for a given data would see their signature as "valid" by the signing contract

And think "signers" may be a typo, or I may just be misinterpreting the sentence.
