### PR TITLE
Update EIP-6066: Added ERC165 support, fixed interface ID

### DIFF
--- a/EIPS/eip-6066.md
+++ b/EIPS/eip-6066.md
@@ -8,7 +8,7 @@ status: Review
 type: Standards Track
 category: ERC
 created: 2022-11-29
-requires: 721, 1155, 1271, 5750
+requires: 165, 721, 1155, 1271, 5750
 ---
 
 ## Abstract
@@ -28,14 +28,14 @@ The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL 
 ```
 pragma solidity ^0.8.0;
 
-interface IEIP6066 {
+interface IERC6066 {
     /**
      * @dev MUST return if the signature provided is valid for the provided tokenId and hash
      * @param tokenId   Token ID of the signing NFT
      * @param hash      Hash of the data to be signed
      * @param data      OPTIONAL arbitrary data that may aid verification
      *
-     * MUST return the bytes4 magic value 0xdff13226 when function passes.
+     * MUST return the bytes4 magic value 0x12edb34f when function passes.
      * MUST NOT modify state (using STATICCALL for solc < 0.5, view modifier for solc > 0.5)
      * MUST allow external calls
      *
@@ -68,10 +68,11 @@ Example implementation of an [ERC-721](./eip-721.md) compliant contract that con
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
-import "./interfaces/draft-IEIP6066.sol";
+import "./interfaces/IERC6066.sol";
 
-contract EIP6066Reference is ERC721, IEIP6066 {
-    bytes4 public constant MAGICVALUE = 0xdff13226;
+contract ERC6066Reference is ERC721, IERC6066 {
+    // type(IERC6066).interfaceId
+    bytes4 public constant MAGICVALUE = 0x12edb34f;
     bytes4 public constant BADVALUE = 0xffffffff;
 
     mapping(uint256 => mapping(bytes32 => bool)) internal _signatures;
@@ -114,6 +115,17 @@ contract EIP6066Reference is ERC721, IEIP6066 {
     {
         // The data parameter is unused in this example
         return _signatures[tokenId][hash] ? MAGICVALUE : BADVALUE;
+    }
+
+    /**
+     * @dev ERC-165 support
+     */
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override returns (bool) {
+        return
+            interfaceId == type(IERC6066).interfaceId ||
+            super.supportsInterface(interfaceId);
     }
 }
 ```

--- a/EIPS/eip-6066.md
+++ b/EIPS/eip-6066.md
@@ -3,7 +3,7 @@ eip: 6066
 title: Signature Validation Method for NFTs
 description: A way to verify signatures when the signing entity is an ERC-721 or ERC-1155 NFT
 author: Jack Boyuan Xu (@boyuanx)
-discussions-to: https://ethereum-magicians.org/t/eip-6066-signature-validation-method-for-nfts
+discussions-to: https://ethereum-magicians.org/t/eip-6066-signature-validation-method-for-nfts/11943
 status: Review
 type: Standards Track
 category: ERC

--- a/EIPS/eip-6066.md
+++ b/EIPS/eip-6066.md
@@ -3,7 +3,7 @@ eip: 6066
 title: Signature Validation Method for NFTs
 description: A way to verify signatures when the signing entity is an ERC-721 or ERC-1155 NFT
 author: Jack Boyuan Xu (@boyuanx)
-discussions-to: https://ethereum-magicians.org/t/eip-6066-signature-validation-method-for-nfts/
+discussions-to: https://ethereum-magicians.org/t/eip-6066-signature-validation-method-for-nfts
 status: Review
 type: Standards Track
 category: ERC

--- a/EIPS/eip-6493.md
+++ b/EIPS/eip-6493.md
@@ -55,96 +55,55 @@ When representing such a transaction as part of the [execution block header's `t
 
 ### Network configuration
 
-Each SSZ transaction type is introduced to a network during a fork transition. For the new fork, the network-specific [EIP-2124](./eip-2124.md#specification) `FORK_HASH` is recorded. Furthermore, an [EIP-2718](./eip-2718.md) transaction type is assigned.
-
-### Domain types
-
-A [`DomainType`](https://github.com/ethereum/consensus-specs/blob/67c2f9ee9eb562f7cc02b2ff90d92c56137944e1/specs/phase0/beacon-chain.md#custom-types) range is defined for signing SSZ transactions.
-
-| Name | SSZ equivalent |
-| - | - |
-| [`DomainType`](https://github.com/ethereum/consensus-specs/blob/67c2f9ee9eb562f7cc02b2ff90d92c56137944e1/specs/phase0/beacon-chain.md#custom-types) | `Bytes4` |
-| `TransactionType` | `uint8` |
-
-| Name | Value |
-| - | - |
-| `DOMAIN_EXECUTION_MASK` | `DomainType('0x00000002')`
-| `DOMAIN_EXECUTION_TRANSACTION_BASE` | `DomainType('0x01000002')` |
-
-For a given [EIP-2718](./eip-2718.md) transaction type, the corresponding [`DomainType`](https://github.com/ethereum/consensus-specs/blob/67c2f9ee9eb562f7cc02b2ff90d92c56137944e1/specs/phase0/beacon-chain.md#custom-types) can be derived.
-
-```python
-def domain_type_for_transaction_type(tx_type: TransactionType) -> DomainType:
-    return DomainType(
-        DOMAIN_EXECUTION_TRANSACTION_BASE[0],
-        tx_type,
-        DOMAIN_EXECUTION_TRANSACTION_BASE[2],
-        DOMAIN_EXECUTION_TRANSACTION_BASE[3],
-    )
-```
+Each SSZ transaction type is introduced to a network during a fork transition. As part of this transition, an [EIP-2718](./eip-2718.md) transaction type is assigned.
 
 ### Signature scheme
 
-When an SSZ transaction is signed, additional information is mixed into the signed hash to uniquely identify the underlying transaction type scheme as well as the operating network.
+When an SSZ transaction is signed, additional information is mixed into the signed hash to uniquely identify the underlying SSZ scheme as well as the operating network.
 
 | Name | SSZ equivalent | Description |
 | - | - | - |
-| `tx_type` | `TransactionType` | Assigned [EIP-2718](./eip-2718) transaction type |
-| `tx_type_fork_version` | [`Version`](https://github.com/ethereum/consensus-specs/blob/67c2f9ee9eb562f7cc02b2ff90d92c56137944e1/specs/phase0/beacon-chain.md#custom-types) | Historic [EIP-2124](./eip-2124.md#specification) `FORK_HASH` of type's introduction |
-| `genesis_hash` | [`Hash32`](https://github.com/ethereum/consensus-specs/blob/67c2f9ee9eb562f7cc02b2ff90d92c56137944e1/specs/phase0/beacon-chain.md#custom-types) | Blockhash of the first block on the chain |
 | `chain_id` | `uint256` | [EIP-155](./eip-155.md) chain ID at time of signature |
+| `tx_type` | `TransactionType` | Assigned [EIP-2718](./eip-2718) transaction type |
 
 The following helper functions compute the [`Domain`](https://github.com/ethereum/consensus-specs/blob/67c2f9ee9eb562f7cc02b2ff90d92c56137944e1/specs/phase0/beacon-chain.md#custom-types) for signing an SSZ transaction.
 
 ```python
-class ExecutionForkData(Container):
-    fork_version: Version
-    genesis_hash: Hash32
+class TransactionDomainData(Container):
+    tx_type: TransactionType
     chain_id: uint256
-
-def compute_execution_fork_data_root(
-    fork_version: Version,
-    genesis_hash: Hash32,
-    chain_id: uint256,
-) -> Root:
-    return ExecutionForkData(
-        fork_version=fork_version,
-        genesis_hash=genesis_hash,
-        chain_id=chain_id,
-    ).hash_tree_root()
-
-def compute_execution_domain(
-    domain_type: DomainType,
-    fork_version: Version,
-    genesis_hash: Hash32,
-    chain_id: uint256,
-) -> Domain:
-    fork_data_root = compute_execution_fork_data_root(fork_version, genesis_hash, chain_id)
-    return Domain(domain_type + fork_data_root[:28])
 
 def compute_transaction_domain(
     tx_type: TransactionType,
-    tx_type_fork_version: Version,
-    genesis_hash: Hash32,
     chain_id: uint256,
 ) -> Domain:
-    domain_type = domain_type_for_transaction_type(tx_type)
-    return compute_execution_domain(domain_type, tx_type_fork_version, genesis_hash, chain_id)
+    return Domain(TransactionDomainData(
+        tx_type=tx_type,
+        chain_id=chain_id,
+    ).hash_tree_root())
 ```
 
 The [`Root`](https://github.com/ethereum/consensus-specs/blob/67c2f9ee9eb562f7cc02b2ff90d92c56137944e1/specs/phase0/beacon-chain.md#custom-types) to sign is computed using [`compute_signing_root`](https://github.com/ethereum/consensus-specs/blob/67c2f9ee9eb562f7cc02b2ff90d92c56137944e1/specs/phase0/beacon-chain.md#compute_signing_root) based on the unsigned transaction's `hash_tree_root` and the additional information about the transaction type.
 
+```python
+def compute_signing_root(ssz_object: SSZObject, domain: Domain) -> Root:
+    return hash_tree_root(SigningData(
+        object_root=hash_tree_root(ssz_object),
+        domain=domain,
+    ))
+```
+
 ## Rationale
+
+### Why mix in additional data?
+
+Simply using `hash_tree_root` of the unsigned transaction may lead to conflicting signatures, because objects from different SSZ types may result in the same root hash. Therefore, the transaction type must be mixed into the signed hash.
+
+Mixing in the chain ID allows SSZ transaction types to drop the chain ID in their payload. A transaction with incorrect chain ID still decodes correctly, but `ecrecover` computes a different signer (with no balance to pay for gas).
 
 ### Why not keccak256?
 
-SSZ and RLP objects encode differently. Namely, in an encoded SSZ transaction, it is not guaranteed that the `chain_id` and the signature are at the same location as in the RLP transaction. This could be problematic if two different networks accidentally use the same [EIP-2718](./eip-2718.md) transaction type number to define an RLP encoded transaction type on one network, but an SSZ encoded transaction type on the other. A signed transaction on one network could suddenly become a valid transaction on the other network.
-
-### Why the specific domain type value?
-
-[`DomainType`](https://github.com/ethereum/consensus-specs/blob/67c2f9ee9eb562f7cc02b2ff90d92c56137944e1/specs/phase0/beacon-chain.md#custom-types) is used in consensus to isolate signing domains for validating BLS signatures. So far, execution uses secp256k1 ECDSA signatures instead, so it is not strictly necessary to isolate consensus and execution domains from each other. However, with 4 bytes, avoiding collisions across layers is trivially possible and might be useful in future use cases.
-
-Consensus designates [`DOMAIN_APPLICATION_MASK`](https://github.com/ethereum/consensus-specs/blob/67c2f9ee9eb562f7cc02b2ff90d92c56137944e1/specs/phase0/beacon-chain.md#domain-types) as `DomainType('0x00000001')` for vendor specific use. Therefore, the next bit was used to refer to execution specific domains.
+SSZ and RLP objects encode differently. Namely, in an encoded signed SSZ transaction, it is not guaranteed that the `chain_id` and the signature are at the same location as in the RLP transaction. This could be problematic if two different networks accidentally use the same [EIP-2718](./eip-2718.md) transaction type number to define an RLP encoded transaction type on one network, but an SSZ encoded transaction type on the other. A signed transaction on one network could become a valid transaction on the other network.
 
 ## Backwards Compatibility
 
@@ -156,15 +115,12 @@ Existing software that incorrectly assumes that all transaction identifiers are 
 
 ```python
 # Network configuration
-GENESIS_HASH = Hash32('0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f')
 CHAIN_ID = uint256(424242)
 
 # Example SSZ transaction
 EXAMPLE_TX_TYPE = TransactionType(0xab)
-EXAMPLE_TX_TYPE_FORK_VERSION = Version('0x12345678')
 
 class ExampleTransaction(Container):
-    chain_id: uint256
     nonce: uint64
     max_fee_per_gas: uint256
     gas: uint64
@@ -181,8 +137,6 @@ class ExampleSignedTransaction(Container):
 def compute_example_sig_hash(message: ExampleTransaction) -> Hash32:
     domain = compute_transaction_domain(
         EXAMPLE_TX_TYPE,
-        EXAMPLE_TX_TYPE_FORK_VERSION,
-        GENESIS_HASH,
         CHAIN_ID,
     )
     return compute_signing_root(message, domain)
@@ -192,7 +146,6 @@ def compute_example_tx_hash(signed_tx: ExampleSignedTransaction) -> Hash32:
 
 # Example transaction
 message = ExampleTransaction(
-    chain_id=CHAIN_ID,
     nonce=42,
     max_fee_per_gas=69123456789,
     gas=21000,


### PR DESCRIPTION
- Added interface detection support
- Fixed a wrong interface ID (magic value)
- Revised wording slightly