### PR TITLE
Update EIP-1155: Add two GitHub usernames to ERC-1155

### DIFF
--- a/EIPS/eip-1155.md
+++ b/EIPS/eip-1155.md
@@ -1,7 +1,7 @@
 ---
 eip: 1155
 title: Multi Token Standard
-author: Witek Radomski <witek@enjin.io>, Andrew Cooke <ac0dem0nk3y@gmail.com>, Philippe Castonguay <pc@horizongames.net>, James Therien <james@turing-complete.com>, Eric Binet <eric@enjin.io>, Ronan Sandford <wighawag@gmail.com>
+author: Witek Radomski <witek@enjin.io>, Andrew Cooke <ac0dem0nk3y@gmail.com>, Philippe Castonguay (@phabc) <pc@horizongames.net>, James Therien <james@turing-complete.com>, Eric Binet <eric@enjin.io>, Ronan Sandford (@wighawag) <wighawag@gmail.com>
 type: Standards Track
 category: ERC
 status: Final


### PR DESCRIPTION
ERC-1155 doesn't have any GitHub usernames in the authors field, so no one gets the pull request notifications.

This pull request adds two GitHub usernames (@PhABC and @wighawag.)

### Identity Verification

For @wighawag:
 * [@wighawag](https://twitter.com/wighawag) -> https://ronan.eth.limo -> @wighawag
 * @wighawag -> [@wighawag](https://twitter.com/wighawag)

For @PhABC:
 * [@PhABCD](https://twitter.com/PhABCD) -> @PhABC
 * I know both of Philippe's accounts :rofl: