### PR TITLE
Update EIP-5573: ERC-5573 update

### DIFF
--- a/EIPS/eip-5573.md
+++ b/EIPS/eip-5573.md
@@ -68,7 +68,7 @@ The following is a non-normative example of a SIWE message with the SIWE ReCap E
 example.com wants you to sign in with your Ethereum account:
 0x0000000000000000000000000000000000000000
 
-I further authorize the stated URI to perform the following actions on my behalf: (1) "example": "append", "read" for "https://example.com". (2) "other": "action" for "https://example.com". (3) "example": "append", "delete" for "my:resource:uri.1". (4) "example": "append" for "my:resource:uri.2". (5) "example": "append" for "my:resource:uri.3".
+I further authorize the stated URI to perform the following actions on my behalf: (1) 'example': 'append', 'read' for 'https://example.com'. (2) 'other': 'action' for 'https://example.com'. (3) 'example': 'append', 'delete' for 'my:resource:uri.1'. (4) 'example': 'append' for 'my:resource:uri.2'. (5) 'example': 'append' for 'my:resource:uri.3'.
 
 URI: did:key:example
 Version: 1
@@ -90,7 +90,7 @@ A ReCap URI starts with `urn:recap:` followed by `:` and the unpadded base64url-
 The following is a non-normative example of a ReCap Capability:
 
 ```text
-urn:recap:eyJhdHQiOnsiaHR0cHM6Ly9leGFtcGxlLmNvbS9waWN0dXJlcy8iOnsiY3J1ZC9kZWxldGUiOltdLCJjcnVkL3VwZGF0ZSI6W10sIm90aGVyL2FjdGlvbiI6W119LCJtYWlsdG86dXNlcm5hbWVAZXhhbXBsZS5jb20iOnsibXNnL3JlY2VpdmUiOlt7Im1heF9jb3VudCI6NSwidGVtcGxhdGVzIjpbIm5ld3NsZXR0ZXIiLCJtYXJrZXRpbmciXX1dLCJtc2cvc2VuZCI6W3sidG8iOiJzb21lb25lQGVtYWlsLmNvbSJ9LHsidG8iOiJqb2VAZW1haWwuY29tIn1dfX0sInByZiI6WyJiYWZ5YmVpZ2s3bHkzcG9nNnV1cHhrdTNiNmJ1YmlycjQzNGliNnRmYXltdm94NmdvdGFhYWFhYWFhYSJdfQ
+urn:recap:eyJhdHQiOnsiaHR0cHM6Ly9leGFtcGxlLmNvbS9waWN0dXJlcy8iOnsiY3J1ZC9kZWxldGUiOlt7fV0sImNydWQvdXBkYXRlIjpbe31dLCJvdGhlci9hY3Rpb24iOlt7fV19LCJtYWlsdG86dXNlcm5hbWVAZXhhbXBsZS5jb20iOnsibXNnL3JlY2VpdmUiOlt7Im1heF9jb3VudCI6NSwidGVtcGxhdGVzIjpbIm5ld3NsZXR0ZXIiLCJtYXJrZXRpbmciXX1dLCJtc2cvc2VuZCI6W3sidG8iOiJzb21lb25lQGVtYWlsLmNvbSJ9LHsidG8iOiJqb2VAZW1haWwuY29tIn1dfX0sInByZiI6WyJ6ZGo3V2o2Rk5TNHJVVWJzaUp2amp4Y3NOcVpkRENTaVlSOHNLUVhmb1BmcFNadUF3Il19
 ```
 
 ##### Ability Strings
@@ -159,9 +159,9 @@ The following is a non-normative example of a ReCap Capability Object with `att`
 {
    "att":{
       "https://example.com/pictures/":{
-         "crud/delete": [],
-         "crud/update": [],
-         "other/action": []
+         "crud/delete": [{}],
+         "crud/update": [{}],
+         "other/action": [{}]
       },
       "mailto:username@example.com":{
           "msg/receive": [{
@@ -175,20 +175,20 @@ The following is a non-normative example of a ReCap Capability Object with `att`
 }
 ```
 
-In the example above, the Relying Party is authorized to perform the actions `crud/update`, `crud/delete` and `other/action` on resource `https://example.com/pictures` without limitations for any. Additionally the Relying Party is authorized to perform actions `msg/send` and `msg/recieve` on resource `mailto:username@example.com`, where `msg/send` is limited to sending to `someone@email.com` or `joe@email.com` and `msg/recieve` is limited to a maximum of 5 and templates `newsletter` or `marketing`. Note, the Relying Party can invoke each action individually and independently from each other in the RS. Additionally the ReCap Capability Object contains some additional information that the RS will need during verification. The responsibility for defining the structure and semantics of this data lies with the RS. These action and restriction semantics are examples not intended to be universally understood.
+In the example above, the Relying Party is authorized to perform the actions `crud/update`, `crud/delete` and `other/action` on resource `https://example.com/pictures` without limitations for any. Additionally the Relying Party is authorized to perform actions `msg/send` and `msg/recieve` on resource `mailto:username@example.com`, where `msg/send` is limited to sending to `someone@email.com` or `joe@email.com` and `msg/recieve` is limited to a maximum of 5 and templates `newsletter` or `marketing`. Note, the Relying Party can invoke each action individually and independently from each other in the RS. Additionally the ReCap Capability Object contains some additional information that the RS will need during verification. The responsibility for defining the structure and semantics of this data lies with the RS. These action and restriction semantics are examples not intended to be universally understood. The Nota Bene objects appearing in the array associated with ability strings represent restrictions on use of an ability. An empty object implies that the action can be performed with no restrictions, but an empty array with no objects implies that there is no way to use this ability in a valid way.
 
 It is expected that RS implementers define which resources they want to expose through ReCap Details Objects and which actions they want to allow users to invoke on them.
 
 This example is expected to transform into the following `recap-transformed-statement` (for `URI` of `https://example.com`):
 
 ```text
-I further authorize the stated URI to perform the following actions on my behalf: (1) "crud": "delete", "update" for "https://example.com/pictures". (2) "other": "action" for "https://example.com/pictures". (3) "msg": "recieve", "send" for "mailto:username@example.com".
+I further authorize the stated URI to perform the following actions on my behalf: (1) 'crud': 'delete', 'update' for 'https://example.com/pictures'. (2) 'other': 'action' for 'https://example.com/pictures'. (3) 'msg': 'recieve', 'send' for 'mailto:username@example.com'.
 ```
 
 This example is also expected to transform into the following `recap-uri`:
 
 ```text
-urn:recap:eyJhdHQiOnsiaHR0cHM6Ly9leGFtcGxlLmNvbS9waWN0dXJlcy8iOnsiY3J1ZC9kZWxldGUiOltdLCJjcnVkL3VwZGF0ZSI6W10sIm90aGVyL2FjdGlvbiI6W119LCJtYWlsdG86dXNlcm5hbWVAZXhhbXBsZS5jb20iOnsibXNnL3JlY2VpdmUiOlt7Im1heF9jb3VudCI6NSwidGVtcGxhdGVzIjpbIm5ld3NsZXR0ZXIiLCJtYXJrZXRpbmciXX1dLCJtc2cvc2VuZCI6W3sidG8iOiJzb21lb25lQGVtYWlsLmNvbSJ9LHsidG8iOiJqb2VAZW1haWwuY29tIn1dfX0sInByZiI6WyJiYWZ5YmVpZ2s3bHkzcG9nNnV1cHhrdTNiNmJ1YmlycjQzNGliNnRmYXltdm94NmdvdGFhYWFhYWFhYSJdfQ
+urn:recap:eyJhdHQiOnsiaHR0cHM6Ly9leGFtcGxlLmNvbS9waWN0dXJlcy8iOnsiY3J1ZC9kZWxldGUiOlt7fV0sImNydWQvdXBkYXRlIjpbe31dLCJvdGhlci9hY3Rpb24iOlt7fV19LCJtYWlsdG86dXNlcm5hbWVAZXhhbXBsZS5jb20iOnsibXNnL3JlY2VpdmUiOlt7Im1heF9jb3VudCI6NSwidGVtcGxhdGVzIjpbIm5ld3NsZXR0ZXIiLCJtYXJrZXRpbmciXX1dLCJtc2cvc2VuZCI6W3sidG8iOiJzb21lb25lQGVtYWlsLmNvbSJ9LHsidG8iOiJqb2VAZW1haWwuY29tIn1dfX0sInByZiI6WyJ6ZGo3V2o2Rk5TNHJVVWJzaUp2amp4Y3NOcVpkRENTaVlSOHNLUVhmb1BmcFNadUF3Il19
 ```
 
 ##### Merging Capability Objects
@@ -199,7 +199,7 @@ Any two Recap objects can be merged together by recursive concatenation of their
 {
   "att": {
     "https://example1.com": {
-      "crud/read": []
+      "crud/read": [{}]
     }
   },
   "prf": ["bafyexample1"]
@@ -213,7 +213,7 @@ Any two Recap objects can be merged together by recursive concatenation of their
       }]
     },
     "https://example2.com": {
-      "crud/delete": []
+      "crud/delete": [{}]
     }
   },
   "prf": ["bafyexample2"]
@@ -226,13 +226,13 @@ combine into:
 {
   "att": {
     "https://example1.com": {
-      "crud/read": [],
+      "crud/read": [{}],
       "crud/update": [{
         "max_times": 1
       }]
     },
     "https://example2.com": {
-      "crud/delete": []
+      "crud/delete": [{}]
     }
   },
   "prf": ["bafyexample1", "bafyexample2"]
@@ -278,11 +278,11 @@ Algorithm:
   - Group the keys of the `abilities` object by their `ability-namespace`
   - For each `ability-namespace`, perform the following:
     - Append the string concatenation of `" ("`, `numbering`, `")"` to `recap-transformed-statement`.
-    - Append the string concatenation of `"`, `ability-namespace`, `":` to `recap-transformed-statement`.
+    - Append the string concatenation of `'`, `ability-namespace`, `':` to `recap-transformed-statement`.
     - For each `ability-name` in the `ability-namespace` group, perform the following:
-      - Append the string concatenation of `"`, `ability-name`, `"` to `recap-transformed-statement`
+      - Append the string concatenation of `'`, `ability-name`, `'` to `recap-transformed-statement`
       - If not the final `ability-name`, append `,` to `recap-transformed-statement`
-    - Append `for "`, `resource`, `".` to `recap-transformed-statement`
+    - Append `for '`, `resource`, `'.` to `recap-transformed-statement`
     - Increase `numbering` by 1
 - Return `recap-transformed-statement`.
 

--- a/EIPS/eip-5573.md
+++ b/EIPS/eip-5573.md
@@ -3,7 +3,7 @@ eip: 5573
 title: Sign-In with Ethereum Capabilities, ReCaps
 description: Mechanism on top of Sign-In with Ethereum for informed consent to delegate capabilities with an extensible scope mechanism
 author: Oliver Terbu (@awoie), Jacob Ward (@cobward), Charles Lehner (@clehner), Sam Gbafa (@skgbafa), Wayne Chang (@wyc), Charles Cunningham (@chunningham)
-discussions-to: https://ethereum-magicians.org/t/eip-5573-siwe-recap
+discussions-to: https://ethereum-magicians.org/t/eip-5573-siwe-recap/10627
 status: Draft
 type: Standards Track
 category: ERC


### PR DESCRIPTION
to prevent a conflict with the erc-4631 statement abnf definition, which only allows single quotes ', not double quotes ". This pr also adds more description of the meaning of the NB objects and their requirements (e.g. an empty [{}] object in the array implies no restrictions, while an empty array [] implies no options to apply when using a capability, i.e. it is not available). this grammar is [defined in the ucan spec v0.10 section 3.2.6.3](https://github.com/ucan-wg/spec/blob/0.10/README.md#3263-caveat-array)