### PR TITLE
Update EIP-4844: change op to `BLOBHASH`

### DIFF
--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -181,7 +181,7 @@ The `ethereum/consensus-specs` repository defines the following beacon-node chan
 
 ### Opcode to get versioned hashes
 
-We add an opcode `BLOBHASH` (with byte value `HASH_OPCODE_BYTE`) which reads `index` from the top of the stack
+We add an instruction `BLOBHASH` (with opcode `HASH_OPCODE_BYTE`) which reads `index` from the top of the stack
 as big-endian `uint256`, and replaces it on the stack with `tx.blob_versioned_hashes[index]`
 if `index < len(tx.blob_versioned_hashes)`, and otherwise with a zeroed `bytes32` value.
 The opcode has a gas cost of `HASH_OPCODE_GAS`.

--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -181,7 +181,7 @@ The `ethereum/consensus-specs` repository defines the following beacon-node chan
 
 ### Opcode to get versioned hashes
 
-We add an opcode `DATAHASH` (with byte value `HASH_OPCODE_BYTE`) which reads `index` from the top of the stack
+We add an opcode `BLOBHASH` (with byte value `HASH_OPCODE_BYTE`) which reads `index` from the top of the stack
 as big-endian `uint256`, and replaces it on the stack with `tx.blob_versioned_hashes[index]`
 if `index < len(tx.blob_versioned_hashes)`, and otherwise with a zeroed `bytes32` value.
 The opcode has a gas cost of `HASH_OPCODE_GAS`.


### PR DESCRIPTION
Right now `DATAHASH` sort of conflicts with the EOF data section concept (which will want to have things like `DATALOAD`, `DATACOPY`, etc for). So I propose we change the mnemonic for blob hashes to `BLOBHASH` instead.