### PR TITLE
Update EIP-6454: Remove the simple method

### DIFF
--- a/EIPS/eip-6454.md
+++ b/EIPS/eip-6454.md
@@ -48,24 +48,16 @@ The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL 
 ```solidity
 /// @title EIP-6454 Minimalistic Non-Transferable interface for NFTs
 /// @dev See https://eips.ethereum.org/EIPS/eip-6454
-/// @dev Note: the ERC-165 identifier for this interface is 0xa7331ab1.
+/// @dev Note: the ERC-165 identifier for this interface is 0x91a6262f.
 
 pragma solidity ^0.8.16;
 
 interface IERC6454 /* is IERC165 */ {
     /**
      * @notice Used to check whether the given token is transferable or not.
-     * @dev If this function returns `false`, the transfer of the token MUST revert execution
-     * @dev If the tokenId does not exist, this method MUST revert execution
-     * @param tokenId ID of the token being checked
-     * @return Boolean value indicating whether the given token is transferable
-     */
-    function isTransferable(uint256 tokenId) external view returns (bool);
-
-    /**
-     * @notice Used to check whether the given token is transferable or not based on source and destination address.
-     * @dev If this function returns `false`, the transfer of the token MUST revert execution
-     * @dev If the tokenId does not exist, this method MUST revert execution
+     * @dev If this function returns `false`, the transfer of the token MUST revert execution.
+     * @dev If the tokenId does not exist, this method MUST revert execution, unless the token is being checked for
+     *  minting.
      * @param tokenId ID of the token being checked
      * @param from Address from which the token is being transferred
      * @param to Address to which the token is being transferred
@@ -74,6 +66,16 @@ interface IERC6454 /* is IERC165 */ {
     function isTransferable(uint256 tokenId, address from, address to) external view returns (bool);
 }
 ```
+
+In order to determine whether a token is transferable or not in general, the function SHOULD return the appropriate boolean value when passing the `0x0000000000000000000000000000000000000000` address as the `to` and `from` parameter.
+
+The general transferability of a token should not be affected by the ability to mint the token (value of `from` parameter is `0x0000000000000000000000000000000000000000`) and the ability to burn the token (value of `to` parameter is `0x0000000000000000000000000000000000000000`).
+
+If the general transferability of token is `false`, any kind of transfer of the token, save minting and burning, MUST revert execution.
+
+In order to determine whether a token is mintable, the exception SHOULD be made to allow the `tokenId` parameter for a token that does not exist. Additionally the `from` parameter SHOULD be `0x0000000000000000000000000000000000000000` and the `to` parameter SHOULD NOT be `0x0000000000000000000000000000000000000000`.
+
+In order to determine whether a token is burnable, the `from` parameter SHOULD NOT be `0x0000000000000000000000000000000000000000` and the `to` parameter SHOULD be `0x0000000000000000000000000000000000000000`.
 
 ## Rationale
 
@@ -85,11 +87,11 @@ Designing the proposal, we considered the following questions:
    The token can become non-transferable either at its creation, after being marked as non-transferable, or after a certain condition is met. This means that some cases of tokens becoming non-transferable cannot emit an event, such as if the token becoming non-transferable is determined by a block number. Requiring an event to be emitted upon the token becoming non-transferable is not feasible in such cases.
 3. **Should the transferability state management function be included in this proposal?**\
    A function that marks a token as non-transferable or releases the binding is referred to as the transferability management function. To maintain the objective of designing an agnostic minimal transferable proposal, we have decided not to specify the transferability management function. This allows for a variety of custom implementations that require the tokens to be non-transferable.
-4. **Why should this be an EIP if it only contains two methods?**\
+4. **Why should this be an EIP if it only contains one method?**\
    One could argue that since the core of this proposal is to only prevent ERC-721 tokens to be transferred, this could be done by overriding the transfer function. While this is true, the only way to assure that the token is non-transferable before the smart contract execution, is for it to have the transferable interface.\
    This also allows for smart contract to validate whether the token is not transferable and not attempt transferring it as this would result in failed transactions and wasted gas.
-5. **Why does this proposal contain two methods with the same name?**\
-   Both methods defined in this proposal address the same issue, but in different ways. The first method is used to check whether the token is transferable or not in general, while the second method is used to check whether the token is conditionally transferable or not based on the source and destination addresses. The second method is useful in cases where the transferability of the token is dependent on the source and destination addresses.
+5. **Should we include the most straightforward method possible that only accepts a `tokenId` parameter?**\
+   The initial version of the proposal contained a method that only accepted a `tokenId` parameter. This method would return a boolean value indicating whether the token is transferable. However, the fact that the token can be non-transferable for different reasons was brought up throughout the discussion. This is why the method was changed to accept additional parameters, allowing for a more flexible implementation. Additionally, we kept the original method’s functionality by specifying the methodology on how to achieve the same result (by passing the `0x0000000000000000000000000000000000000000` address as the `to` and `from` parameters).
 6. **What is the best user experience for frontend?**\
    The best user experience for the front end is having a single method that checks whether the token is transferable. This method should handle both cases of transferability, general and conditional. This is why the second method is defined as an overload of the first method.\
    The front end should also be able to handle the case where the token is not transferable and the transfer is attempted. This can be done by checking the return value of the transfer function, which will be false if the token is not transferable. If the token would just be set as non-transferable, without a standardized interface to check whether the token is transferable, the only way to validate transferability would be to attempt a gas calculation and check whether the transaction would revert. This is a bad user experience and should be avoided.

--- a/assets/eip-6454/contracts/IERC6454.sol
+++ b/assets/eip-6454/contracts/IERC6454.sol
@@ -3,20 +3,11 @@
 pragma solidity ^0.8.16;
 
 interface IERC6454 {
-
     /**
      * @notice Used to check whether the given token is transferable or not.
-     * @dev If this function returns `false`, the transfer of the token MUST revert execution
-     * @dev If the tokenId does not exist, this method MUST revert execution
-     * @param tokenId ID of the token being checked
-     * @return Boolean value indicating whether the given token is transferable
-     */
-    function isTransferable(uint256 tokenId) external view returns (bool);
-
-    /**
-     * @notice Used to check whether the given token is transferable or not based on source and destination address.
-     * @dev If this function returns `false`, the transfer of the token MUST revert execution
-     * @dev If the tokenId does not exist, this method MUST revert execution
+     * @dev If this function returns `false`, the transfer of the token MUST revert execution.
+     * @dev If the tokenId does not exist, this method MUST revert execution, unless the token is being checked for
+     *  minting.
      * @param tokenId ID of the token being checked
      * @param from Address from which the token is being transferred
      * @param to Address to which the token is being transferred

--- a/assets/eip-6454/test/transferable.ts
+++ b/assets/eip-6454/test/transferable.ts
@@ -3,18 +3,18 @@ import { expect } from "chai";
 import { BigNumber } from "ethers";
 import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import { ERC721NonTransferableMock } from "../typechain-types";
+import { ERC721TransferableMock } from "../typechain-types";
 
-async function transferableTokenFixture(): Promise<ERC721NonTransferableMock> {
-  const factory = await ethers.getContractFactory("ERC721NonTransferableMock");
+async function transferableTokenFixture(): Promise<ERC721TransferableMock> {
+  const factory = await ethers.getContractFactory("ERC721TransferableMock");
   const token = await factory.deploy("Chunky", "CHNK");
   await token.deployed();
 
   return token;
 }
 
-describe("NonTransferable", async function () {
-  let nonTransferable: ERC721NonTransferableMock;
+describe("Transferable", async function () {
+  let nonTransferable: ERC721TransferableMock;
   let owner: SignerWithAddress;
   let otherOwner: SignerWithAddress;
   const tokenId = 1;
@@ -30,7 +30,7 @@ describe("NonTransferable", async function () {
   });
 
   it("can support IRMRKNonTransferable", async function () {
-    expect(await nonTransferable.supportsInterface("0x23f06346")).to.equal(true);
+    expect(await nonTransferable.supportsInterface("0x91a6262f")).to.equal(true);
   });
 
   it("does not support other interfaces", async function () {
@@ -50,12 +50,12 @@ describe("NonTransferable", async function () {
   });
 
   it("returns the expected transferability state", async function () {
-    expect(await nonTransferable['isTransferable(uint256)'](tokenId)).to.equal(false);
-    expect(await nonTransferable['isTransferable(uint256,address,address)'](tokenId, owner.address, otherOwner.address)).to.equal(true);
+    expect(await nonTransferable['isTransferable(uint256,address,address)'](tokenId, ethers.constants.AddressZero, ethers.constants.AddressZero)).to.equal(false);
+    expect(await nonTransferable['isTransferable(uint256,address,address)'](tokenId, ethers.constants.AddressZero, otherOwner.address)).to.equal(true);
   })
 
   it("reverts if token does not exist", async function () {
-    await expect(nonTransferable['isTransferable(uint256)'](10)).to.be.revertedWith("ERC721: invalid token ID");
+    await expect(nonTransferable['isTransferable(uint256,address,address)'](10, owner.address, otherOwner.address)).to.be.revertedWith("ERC721: invalid token ID");
   });
 
   it("can burn", async function () {


### PR DESCRIPTION
After further discussion, it became clear that the proposal doesn't need two methods since you can get the behavior of the simple method using the more expansive one. So the specification and assets were updated to reflect this.