### PR TITLE
Update EIP-4844: amend inconsistency in calc_data_fee

### DIFF
--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -291,7 +291,7 @@ We use the `excess_data_gas` header field to store persistent data needed to com
 
 ```python
 def calc_data_fee(tx: SignedBlobTransaction, parent: Header) -> int:
-    return get_total_data_gas(tx) * get_data_gasprice(header)
+    return get_total_data_gas(tx) * get_data_gasprice(parent)
 
 def get_total_data_gas(tx: SignedBlobTransaction) -> int:
     return DATA_GAS_PER_BLOB * len(tx.message.blob_versioned_hashes)


### PR DESCRIPTION
The second argument of `calc_data_fee` is `parent` rather than `header`.