### PR TITLE
Update EIP-4844: Add explicit requirement of correct version byte for every versioned hash in blob txs

### DIFF
--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -182,7 +182,7 @@ def signed_tx_hash(tx: SignedBlobTransaction) -> Bytes32:
     return keccak256(BLOB_TX_TYPE + ssz.serialize(tx))
 ```
 
-Blob transactions with empty `blob_versioned_hashes` are also considered invalid during execution block verification, and must not be included in a valid block.
+Blob transactions with `blob_versioned_hashes` that is either empty or contains any versioned hash that does not start with the `BLOB_COMMITMENT_VERSION_KZG` byte are also considered invalid during execution block verification, and must not be included in a valid block.
 
 ### Header extension
 


### PR DESCRIPTION
Adds explicit requirement of `BLOB_COMMITMENT_VERSION_KZG` byte at the start of every versioned hash in blob transactions for a block to be considered valid during execution.