### PR TITLE
Update EIP-4844: clarify blob coupling

### DIFF
--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -462,7 +462,7 @@ The values for `TARGET_DATA_GAS_PER_BLOCK` and `MAX_DATA_GAS_PER_BLOCK` are chos
 
 This EIP introduces a transaction type that has a distinct mempool version (`BlobTransactionNetworkWrapper`) and execution-payload version (`SignedBlobTransaction`),
 with only one-way convertibility between the two. The blobs are in the `BlobTransactionNetworkWrapper` and not in the `SignedBlobTransaction`;
-instead, they go into the `BeaconBlockBody`. This means that there is now a part of a transaction that will not be accessible from the web3 API.
+instead, they are coupled with the beacon block. This means that there is now a part of a transaction that will not be accessible from the web3 API.
 
 ### Mempool issues
 


### PR DESCRIPTION
small clarification that blobs are _not_ in the beacon block body, and instead just coupled in some way (unspecified)