### PR TITLE
Update EIP-4973: When unequip the token must not be re-equipable

### DIFF
--- a/EIPS/eip-4973.md
+++ b/EIPS/eip-4973.md
@@ -80,8 +80,7 @@ interface IERC4973 {
   /// @notice Removes the `uint256 tokenId` from an account. At any time, an
   ///  ABT receiver must be able to disassociate themselves from an ABT
   ///  publicly through calling this function. After successfully executing this
-  ///  function, given the parameters for calling `function give` or
-  ///  `function take` a token must be re-equipable.
+  ///  function, the token must not be re-equipable.
   /// @dev Must emit a `event Transfer` with the `address to` field pointing to
   ///  the zero address.
   /// @param tokenId The identifier for an ABT.


### PR DESCRIPTION
Acording this comment: https://github.com/ethereum/EIPs/pull/4973#issuecomment-1546429967