### PR TITLE
Update EIP-4844: Cleanup transaction network payload references

### DIFF
--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -305,7 +305,7 @@ Each of these elements are defined as follows:
 
 The node MUST validate `tx_payload` and verify the wrapped data against it. To do so, ensure that:
 
-- There are an equal number of  `tx_payload.blob_versioned_hashes`, `blobs`, `commitments` and `proofs`.
+- There are an equal number of `tx_payload.blob_versioned_hashes`, `blobs`, `commitments`, and `proofs`.
 - The KZG `commitments` hash to the versioned hashes, i.e. `kzg_to_versioned_hash(commitments[i]) == tx_payload.blob_versioned_hashes[i]`
 - The KZG `commitments` match the corresponding `blobs` and `proofs`. (Note: this can be optimized using `blob_kzg_proofs`, with a proof for a
   random evaluation at a point derived from the commitment and blob data for each blob)


### PR DESCRIPTION
Followup to 
- https://github.com/ethereum/EIPs/pull/6985

Cleans up network payload references:

- Flatten blob in network rlp representation rather than a list of field elements
- removes aggregate proof references
- reorders the network payload to `[tx_payload, blobs, commitments, proofs]` rather than current [tx_payload, kzgs, blobs, kzg_proofs]
  i.e. blobs first then commitments and proofs rather than blobs in middle of commitments and proofs
- improve upon validations for network payload