### PR TITLE
Update EIP-4844: Update eip-4844.md

### DIFF
--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -277,7 +277,7 @@ Each of these elements are defined as follows:
 - `blob_tx_payload` - standard EIP-2718 blob transaction `TransactionPayload`
 - `blob_kzgs` - list of `KZGCommitment`
 - `blobs` - list of `blob` where `blob` is a list of `BLSFieldElement`
-- `kzg_aggregated_proof` - `KZGProof`
+- `blob_kzg_proofs` - list of `KZGProof`
 
 The node MUST validate `blob_tx_payload` and verify the wrapped data against it. To do so, ensure that:
 


### PR DESCRIPTION
My understanding is that we have moved away from having a single aggregate proof included in the network wrapper and now instead send one proof per blob.

There _is_ an accelerated way to verify the entire batch (cf. https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/polynomial-commitments.md#verify_blob_kzg_proof_batch) but it seems that it is in the spirit of the EIP to leave this out of scope. I think the current text was left over during an edit done previously.