### PR TITLE
Add EIP: Increase max attestation inclusion slot

### DIFF
--- a/EIPS/eip-7045.md
+++ b/EIPS/eip-7045.md
@@ -12,7 +12,7 @@ created: 2023-05-18
 
 ## Abstract
 
-Increases max attestaton inclusion slot from `attestation.slot + SLOTS_PER_EPOCH` the last slot in `N+1` where `N` is the epoch containing the attestations slot.
+Increases max attestation inclusion slot from `attestation.slot + SLOTS_PER_EPOCH` to the last slot of epoch `N+1` where `N` is the epoch containing the attestation slot.
 
 This increase is critical to the current LMD-GHOST security analysis as well as the confirmation rule.
 
@@ -20,7 +20,7 @@ This increase is critical to the current LMD-GHOST security analysis as well as 
 
 Attestations can currently be included after some minimum delay (`1` slot on mainnet) up until `SLOTS_PER_EPOCH` slots after the slot the attestation was created in. This rolling window of one epoch was decided upon during Phase 0 because the equal inclusion window for any attestation was assessed as "fair". The alternative considered path was to allow inclusion during the current and next epoch which means attestations created during the start of an epoch have more potential slots of inclusion than those at the end of the epoch.
 
-Since this decision was initially made, it has become apparent that the alternative design is critical for current LMD-GHOST security proofs as well as a new confirmation rule (which will allow for block confirmations in approximately 3-4 slots in normal mainnet conditions).
+Since this decision, it has become apparent that the alternative design is critical for current LMD-GHOST security proofs as well as a new confirmation rule (which will allow for block confirmations in approximately 3-4 slots in normal mainnet conditions).
 
 This specification, thus increases the max inclusion slot for attestations in accordance with the learned security proof and confirmation rule needs.
 
@@ -49,7 +49,7 @@ Additionally, the specification modifies the attestation and aggregate attestati
 
 ### Extended max inclusion slot
 
-As discussed in the Motivation, extending this max inclusion slot the end of the next epoch is critical for LMD-GHOST security proofs and confirmation rule.
+As discussed in the Motivation, extending this max inclusion slot to the end of the next epoch is critical for LMD-GHOST security proofs and confirmation rule.
 
 ### Removal of `inclusion_delay` consideration for target reward
 
@@ -63,7 +63,7 @@ This EIP introduces backwards incompatible changes to the block validation rule 
 
 ## Security Considerations
 
-This improves LMD-GHOSt security as well as enabling a fast confirmation rule.
+This improves LMD-GHOST security as well as enables a fast confirmation rule.
 
 There are no known negative impacts to security.
 

--- a/EIPS/eip-7045.md
+++ b/EIPS/eip-7045.md
@@ -3,7 +3,7 @@ eip: 7045
 title: Increase attestation slot inclusion range
 description: Increases attestaton slot inclusion range from `SLOTS_PER_EPOCH` to all slots greater than the attestation's slot and within epoch `N` and `N+1` where `N` the epoch containing the attestations slot.
 author: Danny Ryan (@djrtwo)
-discussions-to: 
+discussions-to: https://ethereum-magicians.org/t/eip-7045-increase-attestation-slot-inclusion-range/14342
 status: Draft
 type: Standards Track
 category: Core

--- a/EIPS/eip-7045.md
+++ b/EIPS/eip-7045.md
@@ -1,5 +1,5 @@
 ---
-eip: X
+eip: 7045
 title: Increase attestation slot inclusion range
 description: Increases attestaton slot inclusion range from `SLOTS_PER_EPOCH` to all slots greater than the attestation's slot and within epoch `N` and `N+1` where `N` the epoch containing the attestations slot.
 author: Danny Ryan (@djrtwo)

--- a/EIPS/eip-7045.md
+++ b/EIPS/eip-7045.md
@@ -1,7 +1,7 @@
 ---
 eip: 7045
 title: Increase max attestation inclusion slot
-description: Increases max attestaton inclusion slot from `attestation.slot + SLOTS_PER_EPOCH` the last slot in `N+1` where `N` is the epoch containing the attestations slot.
+description: Increases max attestaton inclusion slot to the last slot in `N+1` where `N` is the epoch containing the attestations slot.
 author: Danny Ryan (@djrtwo)
 discussions-to: https://ethereum-magicians.org/t/eip-7045-increase-attestation-slot-inclusion-range/14342
 status: Draft

--- a/EIPS/eip-7045.md
+++ b/EIPS/eip-7045.md
@@ -55,7 +55,7 @@ As discussed in the Motivation, extending this max inclusion slot to the end of 
 
 Previously, `get_attestation_participation_flag_indices` would only set the `TIMELY_TARGET_FLAG` (and thus reward for an attestation with correct target vote) if the attestation was included within a `SLOTS_PER_EPOCH` window.
 
-The `inclusion_delay` consideration for this flag is removed to ensure that whatever the valid inclusion window is for an attestation that an attestation can receive a baseline non-zero reward for correct target. This ensures that clients will still attempt to pack such attestations into blocks which is important for the security analysis.
+The `inclusion_delay` consideration for this flag is removed to ensure that whatever the valid inclusion window is for an attestation, it can receive a baseline non-zero reward for correct target. This ensures that clients will still attempt to pack such attestations into blocks which is important for the security analysis.
 
 ## Backwards Compatibility
 

--- a/EIPS/eip-7045.md
+++ b/EIPS/eip-7045.md
@@ -1,7 +1,7 @@
 ---
 eip: 7045
-title: Increase attestation slot inclusion range
-description: Increases attestaton slot inclusion range from `SLOTS_PER_EPOCH` to all slots greater than the attestation's slot and within epoch `N` and `N+1` where `N` the epoch containing the attestations slot.
+title: Increase max attestation inclusion slot
+description: Increases max attestaton inclusion slot from `attestation.slot + SLOTS_PER_EPOCH` the last slot in `N+1` where `N` is the epoch containing the attestations slot.
 author: Danny Ryan (@djrtwo)
 discussions-to: https://ethereum-magicians.org/t/eip-7045-increase-attestation-slot-inclusion-range/14342
 status: Draft
@@ -12,7 +12,7 @@ created: 2023-05-18
 
 ## Abstract
 
-Increases attestaton slot inclusion range from `SLOTS_PER_EPOCH` to all slots greater than the attestation's min inclusion slot and within epoch `N` and `N+1` where `N` the epoch containing the attestations slot.
+Increases max attestaton inclusion slot from `attestation.slot + SLOTS_PER_EPOCH` the last slot in `N+1` where `N` is the epoch containing the attestations slot.
 
 This increase is critical to the current LMD-GHOST security analysis as well as the confirmation rule.
 
@@ -22,7 +22,7 @@ Attestations can currently be included after some minimum delay (`1` slot on mai
 
 Since this decision was initially made, it has become apparent that the alternative design is critical for current LMD-GHOST security proofs as well as a new confirmation rule (which will allow for block confirmations in approximately 3-4 slots in normal mainnet conditions).
 
-This specification, thus increases the slot inclusion range for attestations in accordance with the learned security proof and confirmation rule needs.
+This specification, thus increases the max inclusion slot for attestations in accordance with the learned security proof and confirmation rule needs.
 
 ## Specification
 
@@ -39,6 +39,7 @@ This requires no changes to the Execution Layer.
 ### Consensus layer
 
 The specification makes two minor changes to the state transition function:
+
 * Modify `process_attestation` to not have an upper bound on the slot check and instead just rely on the minimum slot as well as the target epoch being in either current or previous epoch.
 * Modify `get_attestation_participation_flag_indices` to set the `TIMELY_TARGET_FLAG` without consideration of `inclusion_delay` to ensure that the extended inclusion attestations have a non-zero reward.
 
@@ -46,9 +47,9 @@ Additionally, the specification modifies the attestation and aggregate attestati
 
 ## Rationale
 
-### Extended inclusion range
+### Extended max inclusion slot
 
-As discussed in the Motivation, extending this inclusion range to the current and next epoch is critical for LMD-GHOST security proofs and confirmation rule.
+As discussed in the Motivation, extending this max inclusion slot the end of the next epoch is critical for LMD-GHOST security proofs and confirmation rule.
 
 ### Removal of `inclusion_delay` consideration for target reward
 

--- a/EIPS/eip-X.md
+++ b/EIPS/eip-X.md
@@ -1,0 +1,72 @@
+---
+eip: X
+title: Increase attestation slot inclusion range
+description: Increases attestaton slot inclusion range from `SLOTS_PER_EPOCH` to all slots greater than the attestation's slot and within epoch `N` and `N+1` where `N` the epoch containing the attestations slot.
+author: Danny Ryan (@djrtwo)
+discussions-to: 
+status: Draft
+type: Standards Track
+category: Core
+created: 2023-05-18
+---
+
+## Abstract
+
+Increases attestaton slot inclusion range from `SLOTS_PER_EPOCH` to all slots greater than the attestation's min inclusion slot and within epoch `N` and `N+1` where `N` the epoch containing the attestations slot.
+
+This increase is critical to the current LMD-GHOST security analysis as well as the confirmation rule.
+
+## Motivation
+
+Attestations can currently be included after some minimum delay (`1` slot on mainnet) up until `SLOTS_PER_EPOCH` slots after the slot the attestation was created in. This rolling window of one epoch was decided upon during Phase 0 because the equal inclusion window for any attestation was assessed as "fair". The alternative considered path was to allow inclusion during the current and next epoch which means attestations created during the start of an epoch have more potential slots of inclusion than those at the end of the epoch.
+
+Since this decision was initially made, it has become apparent that the alternative design is critical for current LMD-GHOST security proofs as well as a new confirmation rule (which will allow for block confirmations in approximately 3-4 slots in normal mainnet conditions).
+
+This specification, thus increases the slot inclusion range for attestations in accordance with the learned security proof and confirmation rule needs.
+
+## Specification
+
+### Constants
+
+| Name | Value | Comment |
+| - | - | - |
+|`FORK_TIMESTAMP` | *TBD* | Mainnet |
+
+### Execution layer
+
+This requires no changes to the Execution Layer.
+
+### Consensus layer
+
+The specification makes two minor changes to the state transition function:
+* Modify `process_attestation` to not have an upper bound on the slot check and instead just rely on the minimum slot as well as the target epoch being in either current or previous epoch.
+* Modify `get_attestation_participation_flag_indices` to set the `TIMELY_TARGET_FLAG` without consideration of `inclusion_delay` to ensure that the extended inclusion attestations have a non-zero reward.
+
+Additionally, the specification modifies the attestation and aggregate attestation gossip conditions to allow for gossip during this extended range.
+
+## Rationale
+
+### Extended inclusion range
+
+As discussed in the Motivation, extending this inclusion range to the current and next epoch is critical for LMD-GHOST security proofs and confirmation rule.
+
+### Removal of `inclusion_delay` consideration for target reward
+
+Previously, `get_attestation_participation_flag_indices` would only set the `TIMELY_TARGET_FLAG` (and thus reward for an attestation with correct target vote) if the attestation was included within a `SLOTS_PER_EPOCH` window.
+
+The `inclusion_delay` consideration for this flag is removed to ensure that whatever the valid inclusion window is for an attestation that an attestation can receive a baseline non-zero reward for correct target. This ensures that clients will still attempt to pack such attestations into blocks which is important for the security analysis.
+
+## Backwards Compatibility
+
+This EIP introduces backwards incompatible changes to the block validation rule set on the consensus layer and must be accompanied by a hard fork.
+
+## Security Considerations
+
+This improves LMD-GHOSt security as well as enabling a fast confirmation rule.
+
+There are no known negative impacts to security.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](../LICENSE.md).
+


### PR DESCRIPTION
Increases attestation inclusion range to aid security proofs and confirmation rule of LMD-GHOST. Note, this is planned for inclusion in CL deneb fork

accompanying CL spec changes -- https://github.com/ethereum/consensus-specs/pull/3360