### PR TITLE
Update EIP-6093: EIP6093 Corrections for ERC721

### DIFF
--- a/EIPS/eip-6093.md
+++ b/EIPS/eip-6093.md
@@ -13,7 +13,7 @@ requires: 20, 721, 1155
 
 ## Abstract
 
-This EIP defines a standard set of custom errors for commonly-used tokens, which are defined as [EIP-20](./eip-20.md), [EIP-721](./eip-721.md), and [EIP-1155](./eip-1155.md) tokens.
+This EIP defines a standard set of custom errors for commonly-used tokens, which are defined as [ERC-20](./eip-20.md), [ERC-721](./eip-721.md), and [ERC-1155](./eip-1155.md) tokens.
 
 Ethereum applications and wallets have historically relied on revert reason strings to display the cause of transaction errors to users. Recent Solidity versions offer rich revert reasons with error-specific decoding (sometimes called "custom errors"). This EIP defines a standard set of errors designed to give at least the same relevant information as revert reason strings, but in a structured and expected way that clients can implement decoding for.
 
@@ -21,7 +21,7 @@ Ethereum applications and wallets have historically relied on revert reason stri
 
 Since the introduction of Solidity custom errors in v0.8.4, these have provided a way to show failures in a more expressive and gas efficient manner with dynamic arguments, while reducing deployment costs.
 
-However, [EIP-20](./eip-20.md), [EIP-721](./eip-721.md), [EIP-1155](./eip-1155.md) were already finalized when custom errors were released, so no errors are included in their specification.
+However, [ERC-20](./eip-20.md), [ERC-721](./eip-721.md), [ERC-1155](./eip-1155.md) were already finalized when custom errors were released, so no errors are included in their specification.
 
 Standardized errors allow users to expect more consistent error messages across applications or testing environments, while exposing pertinent arguments and overall reducing the need of writing expensive revert strings in the deployment bytecode.
 
@@ -35,7 +35,7 @@ This EIP defines standard errors that may be used by implementations in certain 
 
 The names of the error arguments are defined in the [Parameter Glossary](#parameter-glossary), and MUST be used according to those definitions.
 
-### [EIP-20](./eip-20.md)
+### [ERC-20](./eip-20.md)
 
 #### `ERC20InsufficientBalance(address sender, uint256 balance, uint256 needed)`
 
@@ -90,14 +90,14 @@ Used in approvals.
 - MUST NOT be used for transfer operations.
   - Use `ERC20InsufficientAllowance` instead.
 
-### [EIP-721](./eip-721.md)
+### [ERC-721](./eip-721.md)
 
 ### `ERC721InvalidOwner(address owner)`
 
 Indicates that an address can't be an owner.
 Used in balance queries.
 
-- MUST be used for addresses whose ownership is disallowed (eg. EIP-721 explicitly disallows `address(0)` to be an owner).
+- MUST be used for addresses whose ownership is disallowed (eg. ERC-721 explicitly disallows `address(0)` to be an owner).
 - MUST not be used for transfers.
   - Use `ERC721IncorrectOwner` instead.
 
@@ -160,7 +160,7 @@ Used in approvals.
 - MUST NOT be used for transfer operations.
   - Use `ERC721InsufficientApproval` instead.
 
-### [EIP-1155](./eip-1155.md)
+### [ERC-1155](./eip-1155.md)
 
 #### `ERC1155InsufficientBalance(address sender, uint256 balance, uint256 needed, uint256 tokenId)`
 

--- a/EIPS/eip-6093.md
+++ b/EIPS/eip-6093.md
@@ -92,7 +92,22 @@ Used in approvals.
 
 ### [EIP-721](./eip-721.md)
 
-#### `ERC721InvalidOwner(address sender, uint256 tokenId, address owner)`
+### `ERC721InvalidOwner(address owner)`
+
+Indicates that an address can't be an owner.
+Used in balance queries.
+
+- MUST be used for addresses whose ownership is disallowed (eg. EIP-721 explicitly disallows `address(0)` to be an owner).
+- MUST not be used for transfers.
+  - Use `ERC721IncorrectOwner` instead.
+
+### `ERC721InexistentToken(uint256 tokenId)`
+
+Indicates a `tokenId` whose `owner` is the zero address.
+
+- MUST be used when attempting to interact with a non-minted or burned token.
+
+#### `ERC721IncorrectOwner(address sender, uint256 tokenId, address owner)`
 
 Indicates an error related to the ownership over a particular token.
 Used in transfers.
@@ -102,17 +117,17 @@ Used in transfers.
 
 #### `ERC721InvalidSender(address sender)`
 
-Indicates a failure with the token sender.
+Indicates a failure with the token `sender`.
 Used in transfers.
 
 - MUST be used for disallowed transfers from the zero address.
 - MUST NOT be used for approval operations.
 - MUST NOT be used for ownership or approval requirements.
-  - Use `ERC721InvalidOwner` or `ERC721InsufficientApproval` instead.
+  - Use `ERC721IncorrectOwner` or `ERC721InsufficientApproval` instead.
 
 #### `ERC721InvalidReceiver(address receiver)`
 
-Indicates a failure with the token receiver.
+Indicates a failure with the token `receiver`.
 Used in transfers.
 
 - MUST be used for disallowed transfers to the zero address.
@@ -149,7 +164,7 @@ Used in approvals.
 
 #### `ERC1155InsufficientBalance(address sender, uint256 balance, uint256 needed, uint256 tokenId)`
 
-Indicates an error related to the current `balance` of a sender.
+Indicates an error related to the current `balance` of a `sender`.
 Used in transfers.
 
 - MUST be used when `balance` is less than `needed` for a `tokenId`.
@@ -157,7 +172,7 @@ Used in transfers.
 
 #### `ERC1155InvalidSender(address sender)`
 
-Indicates a failure with the token sender.
+Indicates a failure with the token `sender`.
 Used in transfers.
 
 - MUST be used for disallowed transfers from the zero address.
@@ -167,7 +182,7 @@ Used in transfers.
 
 #### `ERC1155InvalidReceiver(address receiver)`
 
-Indicates a failure with the token receiver.
+Indicates a failure with the token `receiver`.
 Used in transfers.
 
 - MUST be used for disallowed transfers to the zero address.
@@ -241,7 +256,7 @@ The main actions that can be performed within a token are:
 
 The subjects outlined above are expected to exhaustively represent _what_ can go wrong in a token transaction, deriving a specific error by adding an [error prefix](#error-prefixes).
 
-Note that the action is never seen as the subject of an error. Additionally, the token itself is not seen as the subject of an error but rather the context in which it happens, as identified in the domain.
+Note that the action is never seen as the subject of an error.
 
 If a subject is called different on a particular token standard, the error should be consistent with the standard's naming convention.
 
@@ -337,7 +352,9 @@ interface ERC20Errors {
 /// @dev See https://eips.ethereum.org/EIPS/eip-721
 ///  https://eips.ethereum.org/EIPS/eip-6093
 interface ERC721Errors {
-    error ERC721InvalidOwner(address sender, uint256 tokenId, address owner);
+    error ERC721InvalidOwner(address owner);
+    error ERC721InexistentToken(uint256 tokenId);
+    error ERC721IncorrectOwner(address sender, uint256 tokenId, address owner);
     error ERC721InvalidSender(address sender);
     error ERC721InvalidReceiver(address receiver);
     error ERC721InsufficientApproval(address operator, uint256 tokenId);


### PR DESCRIPTION
## Description

While implementing the standard, we realized there are some extra cases considered in ERC721 to take account of, rewording `ERC721InvalidOwner` into `ERC721IncorrectOwner` to avoid conflicting with a new `ERC721InvalidOwner` error that asserts the validity of an address as an owner (EIP-721 explicitly invalidates `address(0)` as an owner).

Additionally, errors for querying `ownerOf` and token existence were added.