### PR TITLE
EIP-6093 Adjustment to ERC155 error

### DIFF
--- a/EIPS/eip-6093.md
+++ b/EIPS/eip-6093.md
@@ -178,7 +178,7 @@ Used in transfers.
 - MUST be used for disallowed transfers from the zero address.
 - MUST NOT be used for approval operations.
 - MUST NOT be used for balance or allowance requirements.
-  - Use `ERC1155InsufficientBalance` or `ERC1155InsufficientApproval` instead.
+  - Use `ERC1155InsufficientBalance` or `ERC1155InsufficientApprovalForAll` instead.
 
 #### `ERC1155InvalidReceiver(address receiver)`
 
@@ -189,7 +189,7 @@ Used in transfers.
 - MUST be used for disallowed transfers to non-`ERC1155TokenReceiver` contracts or those that reject a transfer. (eg. returning an invalid response in `onERC1155Received`).
 - MUST NOT be used for approval operations.
 
-#### `ERC1155InsufficientApproval(address operator, uint256 tokenId)`
+#### `ERC1155InsufficientApprovalForAll(address operator, address owner)`
 
 Indicates a failure with the `operator`'s approval in a transfer.
 Used in transfers.
@@ -369,7 +369,7 @@ interface ERC1155Errors {
     error ERC1155InsufficientBalance(address sender, uint256 balance, uint256 needed, uint256 tokenId);
     error ERC1155InvalidSender(address sender);
     error ERC1155InvalidReceiver(address receiver);
-    error ERC1155InsufficientApproval(address operator, uint256 tokenId);
+    error ERC1155InsufficientApprovalForAll(address operator, address owner)
     error ERC1155InvalidApprover(address approver);
     error ERC1155InvalidOperator(address operator);
     error ERC1155InvalidArrayLength(uint256 idsLength, uint256 valuesLength);


### PR DESCRIPTION
After further working in implementing the EIP, we realized that there's no other way of approval in ERC1155 than approving for all. Therefor, the `ERC1155InsufficientApproval` can't be applied to a particular `tokenId`.