### PR TITLE
Update EIP-4844: add `data_gas_used` to header

### DIFF
--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -250,10 +250,12 @@ On the execution layer, the block validity conditions are extended as follows:
 ```python
 def validate_block(block: Block) -> None:
     ...
+    
     # check that the excess data gas was updated correctly
     assert block.header.excess_data_gas == calc_excess_data_gas(block.parent.header)
 
     data_gas_used = 0
+    
     for tx in block.transactions:
         ...
 
@@ -288,7 +290,6 @@ def validate_block(block: Block) -> None:
 
     # ensure data_gas_used matches header
     assert block.header.data_gas_used == data_gas_used
-
 
 ```
 

--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -122,7 +122,7 @@ The signature values `y_parity`, `r`, and `s` are calculated by constructing a s
 
 ### Header extension
 
-The current header encoding is extended with a new 64-bit unsigned integer field `data_gas_used` and a 256-bit unsigned integer field `excess_data_gas` . This is the running total of excess data gas consumed on chain since this EIP was activated. If the total amount of data gas is below the
+The current header encoding is extended with a new 64-bit unsigned integer field `data_gas_used` and a 256-bit unsigned integer field `excess_data_gas`. This is the running total of excess data gas consumed on chain since this EIP was activated. If the total amount of data gas is below the
 target, `excess_data_gas` is capped at zero.
 
 The resulting RLP encoding of the header is therefore:

--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -122,7 +122,7 @@ The signature values `y_parity`, `r`, and `s` are calculated by constructing a s
 
 ### Header extension
 
-The current header encoding is extended with a new 256-bit unsigned integer field `excess_data_gas`. This is the running total of excess data gas consumed on chain since this EIP was activated. If the total amount of data gas is below the
+The current header encoding is extended with a new 64-bit unsigned integer field `data_gas_used` and a 256-bit unsigned integer field `excess_data_gas` . This is the running total of excess data gas consumed on chain since this EIP was activated. If the total amount of data gas is below the
 target, `excess_data_gas` is capped at zero.
 
 The resulting RLP encoding of the header is therefore:
@@ -146,21 +146,22 @@ rlp([
     0x0000000000000000, # nonce
     base_fee_per_gas,
     withdrawals_root,
-    excess_data_gas
+    data_gas_used,
+    excess_data_gas,
 ])
 ```
 
-The value of `excess_data_gas` can be calculated using the parent header and number of blobs in the block.
+The value of `excess_data_gas` can be calculated using the parent header.
 
 ```python
-def calc_excess_data_gas(parent: Header, consumed_data_gas: int) -> int:
-    if parent.excess_data_gas + consumed_data_gas < TARGET_DATA_GAS_PER_BLOCK:
+def calc_excess_data_gas(parent: Header) -> int:
+    if parent.excess_data_gas + parent.data_gas_used < TARGET_DATA_GAS_PER_BLOCK:
         return 0
     else:
-        return parent.excess_data_gas + consumed_data_gas - TARGET_DATA_GAS_PER_BLOCK
+        return parent.excess_data_gas + parent.data_gas_used - TARGET_DATA_GAS_PER_BLOCK
 ```
 
-For the first post-fork block, `parent.excess_data_gas` is evaluated as `0`.
+For the first post-fork block, both `parent.data_gas_used` and `parent.excess_data_gas` are evaluated as `0`.
 
 ### Opcode to get versioned hashes
 
@@ -208,8 +209,8 @@ We introduce data gas as a new type of gas. It is independent of normal gas and 
 We use the `excess_data_gas` header field to store persistent data needed to compute the data gas price. For now, only blobs are priced in data gas.
 
 ```python
-def calc_data_fee(tx: SignedBlobTransaction, parent: Header) -> int:
-    return get_total_data_gas(tx) * get_data_gasprice(parent)
+def calc_data_fee(header: Header, tx: SignedBlobTransaction) -> int:
+    return get_total_data_gas(tx) * get_data_gasprice(header)
 
 def get_total_data_gas(tx: SignedBlobTransaction) -> int:
     return DATA_GAS_PER_BLOB * len(tx.blob_versioned_hashes)
@@ -249,9 +250,10 @@ On the execution layer, the block validity conditions are extended as follows:
 ```python
 def validate_block(block: Block) -> None:
     ...
+    # check that the excess data gas was updated correctly
+    assert block.header.excess_data_gas == calc_excess_data_gas(block.parent.header)
 
-    block_data_gas = 0
-
+    data_gas_used = 0
     for tx in block.transactions:
         ...
 
@@ -276,16 +278,18 @@ def validate_block(block: Block) -> None:
                 assert h[0] == BLOB_COMMITMENT_VERSION_KZG
 
             # ensure that the user was willing to at least pay the current data gasprice
-            assert tx.max_fee_per_data_gas >= get_data_gasprice(parent(block).header)
+            assert tx.max_fee_per_data_gas >= get_data_gasprice(block.header)
 
             # keep track of total data gas spent in the block
-            block_data_gas += get_total_data_gas(tx)
+            data_gas_used += get_total_data_gas(tx)
 
     # ensure the total data gas spent is at most equal to the limit
-    assert block_data_gas <= MAX_DATA_GAS_PER_BLOCK
+    assert data_gas_used <= MAX_DATA_GAS_PER_BLOCK
 
-    # check that the excess data gas was updated correctly
-    assert block.header.excess_data_gas == calc_excess_data_gas(parent(block).header, block_data_gas)
+    # ensure data_gas_used matches header
+    assert block.header.data_gas_used == data_gas_used
+
+
 ```
 
 ### Networking


### PR DESCRIPTION
At the moment, EIP-4844 uses the `excess_data_gas` from a block's parent header in order to determine the data gas price of transactions in the current block. This is a bit different than EIP-1559 which first ensures the header's `base_fee` is correctly derived from the parent header, then proceeds to use that value for further gas price calculation.

tldr; `excess_data_gas` is pricing for _next_ block, while `base_fee` is pricing for _current_ block -- this PR aligns them so that both represent pricing information for the current block