### PR TITLE
Update Eip 6913: Disable Inside DELEGATECALL

### DIFF
--- a/EIPS/eip-6913.md
+++ b/EIPS/eip-6913.md
@@ -37,6 +37,7 @@ Given the upcoming deprecation of `SELFDESTRUCT`, `SETCODE` introduces a better 
 ## Specification
 
 When inside of a `CREATE`-like execution scope that returns new code for the executing address (the account returned by `ADDRESS`), `SETCODE` causes an exceptional abort.
+When inside of a `DELEGATECALL` execution scope where the currently executing code is not the code of the executing account, `SETCODE` causes an exceptional abort.
 Otherwise, `SETCODE` consumes two words from the stack: offset and length.
 These specify a range of memory containing the new code.
 Any validations that would be performed on the result of `CREATE` or `CREATE2` occur immediately, potentially causing failure with exceptional abort.
@@ -59,6 +60,9 @@ The gas cost of `SETCODE` is comparable to `CREATE` but excludes Gcreate because
 Other account modification costs are accounted for outside of execution gas.
 
 Unlike `SELFDESTRUCT`, execution proceeds normally after `SETCODE` in order to allow return data.
+
+Preventing `SETCODE` within `DELEGATECALL` allows static analysis to easily identify mutable code.
+Contracts not containing the `SETCODE` can be safely assumed to be immutable.
 
 ## Backwards Compatibility
 

--- a/EIPS/eip-6913.md
+++ b/EIPS/eip-6913.md
@@ -37,7 +37,7 @@ Given the upcoming deprecation of `SELFDESTRUCT`, `SETCODE` introduces a better 
 ## Specification
 
 When inside of a `CREATE`-like execution scope that returns new code for the executing address (the account returned by `ADDRESS`), `SETCODE` causes an exceptional abort.
-When inside of a `DELEGATECALL` execution scope where the currently executing code is not the code of the executing account, `SETCODE` causes an exceptional abort.
+When inside of a `DELEGATECALL` execution scope where the currently executing code does not belong to the executing account, `SETCODE` causes an exceptional abort.
 Otherwise, `SETCODE` consumes two words from the stack: offset and length.
 These specify a range of memory containing the new code.
 Any validations that would be performed on the result of `CREATE` or `CREATE2` occur immediately, potentially causing failure with exceptional abort.


### PR DESCRIPTION

In discussion with yoavw it was determined that the benefits of disabling within delegatecall outweighed the benefits.
#### Changes
Disable SETCODE within DELEGATECALL.