### PR TITLE
Update EIP-6913: Clarify Parent Execution Scopes, and add to Rationale

### DIFF
--- a/EIPS/eip-6913.md
+++ b/EIPS/eip-6913.md
@@ -44,11 +44,15 @@ Any validations that would be performed on the result of `CREATE` or `CREATE2` o
 Code replacement is deferred; the current execution scope and its children proceed before code replacement.
 After the current execution scope exits successfully (neither reverting nor aborting), the code in the executing account is replaced.
 Like `SSTORE`, this account modification will be reverted if a parent scope reverts or aborts.
-Unlike `SELFDESTRUCT`, `SETCODE` does not clear account balance or storage.
+Unlike `SELFDESTRUCT`, `SETCODE` does not clear account balance, nonce, or storage.
+
 
 Multiple `SETCODE` operations inside the same execution scope are allowed and replace the pending replacement.
 
 A `SELFDESTRUCT` operation discards the pending code.
+
+Any parent execution scopes executing replaced code will continue executing the prior code.
+As with `DELEGATECALL`, operations `CODESIZE` and `CODECOPY` in this parent scope continue to query the executing code, while `EXTCODESIZE` and `EXTCODECOPY` query the updated code.
 
 ### Gas
 
@@ -60,6 +64,8 @@ The gas cost of `SETCODE` is comparable to `CREATE` but excludes Gcreate because
 Other account modification costs are accounted for outside of execution gas.
 
 Unlike `SELFDESTRUCT`, execution proceeds normally after `SETCODE` in order to allow return data.
+
+Also unlike `SELFDESTRUCT`, the code update takes effect after the call context rather than at the end of the transaction, to allow parent execution scopes to validate the update and revert if the update had an undesirable result.
 
 Preventing `SETCODE` within `DELEGATECALL` allows static analysis to easily identify mutable code.
 Contracts not containing the `SETCODE` can be safely assumed to be immutable.

--- a/EIPS/eip-6913.md
+++ b/EIPS/eip-6913.md
@@ -52,7 +52,7 @@ Multiple `SETCODE` operations inside the same execution scope are allowed and re
 A `SELFDESTRUCT` operation discards the pending code.
 
 Any parent execution scopes executing replaced code will continue executing the prior code.
-As with `DELEGATECALL`, operations `CODESIZE` and `CODECOPY` in this parent scope continue to query the executing code, while `EXTCODESIZE` and `EXTCODECOPY` query the updated code.
+As with `DELEGATECALL`, operations `CODESIZE` and `CODECOPY` in such parent scopes continue to query the executing code, while `EXTCODESIZE` and `EXTCODECOPY` query the updated code.
 
 ### Gas
 


### PR DESCRIPTION

#### Changes
* Clarify that nonce is not updated
* Clarify how parent execution of updated code continues
* Clarify interaction with `CODECOPY`, `CODESIZE`, `EXTCODECOPY`, `EXTCODESIZE`