### PR TITLE
Update EIP-6913: Remove Deferral and Clarify Staticcall

### DIFF
--- a/EIPS/eip-6913.md
+++ b/EIPS/eip-6913.md
@@ -56,7 +56,7 @@ The gas cost of this operation is the sum of Gselfdestruct and the product of Gc
 
 ## Rationale
 
-The behavior of `CODECOPY`, `CODESIZE`, `EXTCODESIZE`, and `EXTCODECOPY` match the behavior of `DELEGATECALL`, where it is also possible for executing code to differ from the code of the executing account.
+The behavior of `CODECOPY`, `CODESIZE`, `EXTCODESIZE`, and `EXTCODECOPY` match the behavior of `DELEGATECALL` and `CREATE`, where it is also possible for executing code to differ from the code of the executing account.
 
 The gas cost of `SETCODE` is comparable to `CREATE` but excludes Gcreate because no execution context is created, nor any new account.
 Other account modification costs are accounted for outside of execution gas.

--- a/EIPS/eip-6913.md
+++ b/EIPS/eip-6913.md
@@ -12,8 +12,7 @@ created: 2023-04-20
 
 ## Abstract
 
-Introduce the `SETCODE` (`0xfc`) instruction, which replaces the code of the current executing address from memory.
-Future calls to the modified contract use the new code.
+Introduce the `SETCODE` (`0xfc`) instruction, which replaces the code of the executing account from memory.
 
 ## Motivation
 
@@ -21,7 +20,7 @@ Many contracts are upgradeable in order to facilitate improvement or defer decis
 Contracts presently do this in several ways:
 
 The oldest method uses `CALL`.
-The limitation of this method is that owned state must be modifiable by all future implementations.
+The limitation of this method is that internal state must be modifiable by all future implementations.
 
 Second, `DELEGATECALL` can proxy the implementation.
 Some proxies are minimal while others branch to many separate implementation accounts.
@@ -36,23 +35,20 @@ Given the upcoming deprecation of `SELFDESTRUCT`, `SETCODE` introduces a better 
 
 ## Specification
 
+When within a read-only execution scope like the recursive kind created by `STATICCALL`, `SETCODE` causes an exceptional abort.
 When inside of a `CREATE`-like execution scope that returns new code for the executing address (the account returned by `ADDRESS`), `SETCODE` causes an exceptional abort.
-When inside of a `DELEGATECALL` execution scope where the currently executing code does not belong to the executing account, `SETCODE` causes an exceptional abort.
+When inside of a `DELEGATECALL`-like execution scope where the currently executing code does not belong to the executing account, `SETCODE` causes an exceptional abort.
+
 Otherwise, `SETCODE` consumes two words from the stack: offset and length.
 These specify a range of memory containing the new code.
 Any validations that would be performed on the result of `CREATE` or `CREATE2` occur immediately, potentially causing failure with exceptional abort.
-Code replacement is deferred; the current execution scope and its children proceed before code replacement.
-After the current execution scope exits successfully (neither reverting nor aborting), the code in the executing account is replaced.
-Like `SSTORE`, this account modification will be reverted if a parent scope reverts or aborts.
+The operations `EXTCODESIZE` and `EXTCODECOPY` now query the updated code, and message-calls such as `DELEGATECALL`, `CALLCODE`, `CALL`, and `STATICCALL` now execute the updated code.
+Any execution scopes already executing replaced code, including the one that `SETCODE`, will continue executing the prior code.
+Inside such scopes, `CODESIZE` and `CODECOPY` continue to query the executing code.
+
+Like `SSTORE`, this account modification will be reverted if the current scope or any parent scope reverts or aborts.
+
 Unlike `SELFDESTRUCT`, `SETCODE` does not clear account balance, nonce, or storage.
-
-
-Multiple `SETCODE` operations inside the same execution scope are allowed and replace the pending replacement.
-
-A `SELFDESTRUCT` operation discards the pending code.
-
-Any parent execution scopes executing replaced code will continue executing the prior code.
-As with `DELEGATECALL`, operations `CODESIZE` and `CODECOPY` in such parent scopes continue to query the executing code, while `EXTCODESIZE` and `EXTCODECOPY` query the updated code.
 
 ### Gas
 
@@ -60,20 +56,21 @@ The gas cost of this operation is the sum of Gselfdestruct and the product of Gc
 
 ## Rationale
 
+The behavior of `CODECOPY`, `CODESIZE`, `EXTCODESIZE`, and `EXTCODECOPY` match the behavior of `DELEGATECALL`, where it is also possible for executing code to differ from the code of the executing account.
+
 The gas cost of `SETCODE` is comparable to `CREATE` but excludes Gcreate because no execution context is created, nor any new account.
 Other account modification costs are accounted for outside of execution gas.
 
-Unlike `SELFDESTRUCT`, execution proceeds normally after `SETCODE` in order to allow return data.
-
-Also unlike `SELFDESTRUCT`, the code update takes effect after the call context rather than at the end of the transaction, to allow parent execution scopes to validate the update and revert if the update had an undesirable result.
+Unlike `SELFDESTRUCT`, execution proceeds normally after `SETCODE` in order to allow validation and return data.
+Post-update validation can undo a `SETCODE` operation with `REVERT` or with a subesequent `SETCODE`, but `REVERT` uses less-gas.
 
 Preventing `SETCODE` within `DELEGATECALL` allows static analysis to easily identify mutable code.
-Contracts not containing the `SETCODE` can be safely assumed to be immutable.
+Account code not containing the `SETCODE` operation can be safely assumed to be immutable.
 
 ## Backwards Compatibility
 
 The only prior operation changing code is `SELFDESTRUCT`.
-`SELFDESTRUCT` remains compatible by discarding any pending replacement code.
+As code modification via `SELFDESTRUCT` is deferred until the end of the transaction, its interactions with `SETCODE` are well-defined.
 
 ## Test Cases
 
@@ -87,7 +84,7 @@ The only prior operation changing code is `SELFDESTRUCT`.
 
 ## Security Considerations
 
-Risks related to SETCODE similarly apply to other upgrade patterns.
+Risks related to `SETCODE` similarly apply to other upgrade patterns.
 
 Most contracts should never be replaced and should not be upgradeable.
 Any upgrade mechanism can risk permanent failure.


### PR DESCRIPTION

By not deferring the update, the updating scope can perform validations without relying on a parent scope.
I had designed it with deferral because previously I was worried about `EXTCODE`- and `CODE`- operations but these are already well-defined in such situations due to `DELEGATECALL` and `CREATE`.
#### Changes
* `SETCODE` takes effect immediately
* Specify the behavior of `CODECOPY`, `CODESIZE`, `EXTCODECOPY`, and `EXTCODESIZE` to match `CREATE` and `DELEGATECALL`.
* Clarify that `SETCODE` violates the read-only rules of `STATICCALL`