### PR TITLE
Update EIP-4844: reduce size of `excess_data_gas` to 64 bit

### DIFF
--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -123,7 +123,7 @@ The signature values `y_parity`, `r`, and `s` are calculated by constructing a s
 
 ### Header extension
 
-The current header encoding is extended with a new 64-bit unsigned integer field `data_gas_used` and a 256-bit unsigned integer field `excess_data_gas`. This is the running total of excess data gas consumed on chain since this EIP was activated. If the total amount of data gas is below the
+The current header encoding is extended with a new 64-bit unsigned integer field `data_gas_used` and a 64-bit unsigned integer field `excess_data_gas`. This is the running total of excess data gas consumed on chain since this EIP was activated. If the total amount of data gas is below the
 target, `excess_data_gas` is capped at zero.
 
 The resulting RLP encoding of the header is therefore:


### PR DESCRIPTION
It seems like an oversight on my part in #5353 to make `excess_blobs` a 256 bit unsigned integer and it has propagated through the various changes until now. @karalabe noticed that `excess_data_gas` will never even need more than a 64 bit unsigned integer. After 1500 blocks, the data fee ends up being around `2**256`, which is obviously much larger than could possibly be paid. `log2(1500*(MAX_DATA_GAS_PER_BLOCK - TARGET_DATA_GAS_PER_BLOCK)) = 28.5`, so 64 bit is fine.