### PR TITLE
Update EIP-4844: clarify to must be non-nil

### DIFF
--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -107,10 +107,11 @@ We introduce a new [EIP-2718](./eip-2718.md) transaction, "blob transaction", wh
 rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit, to, value, data, access_list, max_fee_per_data_gas, blob_versioned_hashes, y_parity, r, s])`.
 ```
 
-The `max_priority_fee_per_gas` and `max_fee_per_gas` fields follow [EIP-1559](./eip-1559.md) semantics
-and `access_list` follows [EIP-2930](./eip-2930.md).
+The fields `chain_id`, `nonce`, `max_priority_fee_per_gas`, `max_fee_per_gas`, `gas_limit`, `value`, `data`, and `access_list` follow the same semantics as [EIP-1559](./eip-1559.md).
 
-The `max_fee_per_data_gas` is `uint256` and the `blob_versioned_hashes` field represents a list of hash outputs from `kzg_to_versioned_hash`.
+The field `to` deviates slightly from the semantics with the exception that it MUST NOT be `nil` and therefore must always represent a 20-byte address.
+
+The field `max_fee_per_data_gas` is a `uint256` and the field `blob_versioned_hashes` represents a list of hash outputs from `kzg_to_versioned_hash`.
 
 The [EIP-2718](./eip-2718.md) `ReceiptPayload` for this transaction is `rlp([status, cumulative_transaction_gas_used, logs_bloom, logs])`.
 
@@ -269,9 +270,6 @@ def validate_block(block: Block) -> None:
 
         # add validity logic specific to blob txs
         if type(tx) is SignedBlobTransaction:
-
-            # destination must be not be empty
-            assert tx.to != None
             # there must be at least one blob
             assert len(tx.blob_versioned_hashes) > 0
 

--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -109,7 +109,7 @@ rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit, to, 
 
 The fields `chain_id`, `nonce`, `max_priority_fee_per_gas`, `max_fee_per_gas`, `gas_limit`, `value`, `data`, and `access_list` follow the same semantics as [EIP-1559](./eip-1559.md).
 
-The field `to` deviates slightly from the semantics with the exception that it MUST NOT be `nil` and therefore must always represent a 20-byte address. This means that blob transactions cannot have the form of a create transactions.
+The field `to` deviates slightly from the semantics with the exception that it MUST NOT be `nil` and therefore must always represent a 20-byte address. This means that blob transactions cannot have the form of a create transaction.
 
 The field `max_fee_per_data_gas` is a `uint256` and the field `blob_versioned_hashes` represents a list of hash outputs from `kzg_to_versioned_hash`.
 

--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -109,7 +109,7 @@ rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit, to, 
 
 The fields `chain_id`, `nonce`, `max_priority_fee_per_gas`, `max_fee_per_gas`, `gas_limit`, `value`, `data`, and `access_list` follow the same semantics as [EIP-1559](./eip-1559.md).
 
-The field `to` deviates slightly from the semantics with the exception that it MUST NOT be `nil` and therefore must always represent a 20-byte address.
+The field `to` deviates slightly from the semantics with the exception that it MUST NOT be `nil` and therefore must always represent a 20-byte address. This means that blob transactions cannot have the form of a create transactions.
 
 The field `max_fee_per_data_gas` is a `uint256` and the field `blob_versioned_hashes` represents a list of hash outputs from `kzg_to_versioned_hash`.
 


### PR DESCRIPTION
@karalabe raised a concern that the current transaction type spec in 4844 is not clear on whether a `nil` `to` field is allowed. This PR aims at clarifying any confusion around the correct representation of blob txs.