### PR TITLE
Update EIP-155: Added LUKSO for 42, with note to Kovan

### DIFF
--- a/EIPS/eip-155.md
+++ b/EIPS/eip-155.md
@@ -63,7 +63,7 @@ This would provide a way to send transactions that work on Ethereum without work
 | 3              | Ropsten                                    |
 | 4              | Rinkeby                                    |
 | 5              | Goerli                                     |
-| 42             | Kovan                                      |
+| 42             | LUKSO (formerly used by Kovan Testnet)     |
 | 1337           | Geth private chains (default)              |
 
 


### PR DESCRIPTION
This adds LUKSO as 42 to the EIP155, with reference to the Kovan testnet