### PR TITLE
Update EIP-4844: clarify transaction payload body

### DIFF
--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -99,12 +99,12 @@ def fake_exponential(factor: int, numerator: int, denominator: int) -> int:
     return output // denominator
 ```
 
-### New transaction type
+### Blob transaction
 
-We introduce a new [EIP-2718](./eip-2718.md) transaction, "blob transaction", where the `TransactionType` is `BLOB_TX_TYPE` and the `TransactionPayload` is the following RLP value:
+We introduce a new [EIP-2718](./eip-2718.md) transaction, "blob transaction", where the `TransactionType` is `BLOB_TX_TYPE` and the `TransactionPayload` is the RLP serialization of the following `TransactionPayloadBody`:
 
 ```
-rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit, to, value, data, access_list, max_fee_per_data_gas, blob_versioned_hashes, y_parity, r, s])`.
+[chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit, to, value, data, access_list, max_fee_per_data_gas, blob_versioned_hashes, y_parity, r, s]
 ```
 
 The fields `chain_id`, `nonce`, `max_priority_fee_per_gas`, `max_fee_per_gas`, `gas_limit`, `value`, `data`, and `access_list` follow the same semantics as [EIP-1559](./eip-1559.md).
@@ -296,20 +296,20 @@ def validate_block(block: Block) -> None:
 Blob transactions have two network representations. During transaction gossip responses (`PooledTransactions`), the EIP-2718 `TransactionPayload` of the blob transaction is wrapped to become:
 
 ```
-rlp([tx_payload, blobs, commitments, proofs])
+rlp([tx_payload_body, blobs, commitments, proofs])
 ```
 
 Each of these elements are defined as follows:
 
-- `tx_payload` - standard EIP-2718 blob transaction `TransactionPayload`
+- `tx_payload_body` - is the `TransactionPayloadBody` of standard EIP-2718 [blob transaction](#blob-transaction)
 - `blobs` - list of `blob` bytes where each `blob` is its `BLSFieldElement` list flattened in `big endian`
 - `commitments` - list of `KZGCommitment` of the corresponding `blobs`
 - `proofs` - list of `KZGProof` of the corresponding `blobs` and `commitments`
 
-The node MUST validate `tx_payload` and verify the wrapped data against it. To do so, ensure that:
+The node MUST validate `tx_payload_body` and verify the wrapped data against it. To do so, ensure that:
 
-- There are an equal number of `tx_payload.blob_versioned_hashes`, `blobs`, `commitments`, and `proofs`.
-- The KZG `commitments` hash to the versioned hashes, i.e. `kzg_to_versioned_hash(commitments[i]) == tx_payload.blob_versioned_hashes[i]`
+- There are an equal number of `tx_payload_body.blob_versioned_hashes`, `blobs`, `commitments`, and `proofs`.
+- The KZG `commitments` hash to the versioned hashes, i.e. `kzg_to_versioned_hash(commitments[i]) == tx_payload_body.blob_versioned_hashes[i]`
 - The KZG `commitments` match the corresponding `blobs` and `proofs`. (Note: this can be optimized using `blob_kzg_proofs`, with a proof for a
   random evaluation at a point derived from the commitment and blob data for each blob)
 


### PR DESCRIPTION
Clarify that the network representation's first array item is `TransactionPayloadBody` and not rlp `TransactionPayload` bytes