### PR TITLE
Update EIP-6900: More precise usage of words `account` and `wallet`

### DIFF
--- a/EIPS/eip-6900.md
+++ b/EIPS/eip-6900.md
@@ -19,13 +19,13 @@ This modular approach splits account functionality into three categories, delega
 
 ## Motivation
 
-One of the goals that ERC-4337 accomplishes is abstracting the logic for execution and validation to each smart contract wallet.
+One of the goals that ERC-4337 accomplishes is abstracting the logic for execution and validation to each smart contract account.
 
-Many new features of wallets can be built by customizing the logic that goes into the validation and execution steps. Examples of such features include session keys, subscriptions, spending limits, and role-based access control. Currently, some of these features are implemented natively by specific smart contract accounts, and others are able to be implemented by plugin systems. Examples of proprietary plugin systems include Safe modules and ZeroDev plugins.
+Many new features of accounts can be built by customizing the logic that goes into the validation and execution steps. Examples of such features include session keys, subscriptions, spending limits, and role-based access control. Currently, some of these features are implemented natively by specific smart contract accounts, and others are able to be implemented by plugin systems. Examples of proprietary plugin systems include Safe modules and ZeroDev plugins.
 
-However, managing multiple wallet instances provides a worse user experience, fragmenting accounts across supported features and security configurations. Additionally, it requires plugin developers to choose which platforms to support, causing either platform lock-in or duplicated development effort.
+However, managing multiple account instances provides a worse user experience, using an account on different wallet applictions may not be possible, fragmenting accounts across supported features and security configurations. Additionally, it requires plugin developers to choose which platforms to support, causing either platform lock-in or duplicated development effort.
 
-We propose a standard that coordinates the implementation work between plugin developers and wallet developers. This standard defines a modular smart contract account capable of supporting all standard-conformant plugins. This allows users to have greater portability of their data, and for plugin developers to not have to choose specific wallet implementations to support.
+We propose a standard that coordinates the implementation work between plugin developers and wallet developers. This standard defines a modular smart contract account capable of supporting all standard-conformant plugins. This allows users to have greater portability of their data, and for plugin developers to not have to choose specific account implementations to support.
 
 ![diagram showing relationship between accounts and plugins of each type](../assets/eip-modular-smart-contract-accounts-and-plugins/MSCA_Shared_Components_Diagram.svg)
 

--- a/EIPS/eip-6900.md
+++ b/EIPS/eip-6900.md
@@ -23,7 +23,7 @@ One of the goals that ERC-4337 accomplishes is abstracting the logic for executi
 
 Many new features of accounts can be built by customizing the logic that goes into the validation and execution steps. Examples of such features include session keys, subscriptions, spending limits, and role-based access control. Currently, some of these features are implemented natively by specific smart contract accounts, and others are able to be implemented by plugin systems. Examples of proprietary plugin systems include Safe modules and ZeroDev plugins.
 
-However, managing multiple account instances provides a worse user experience, using an account on different wallet applictions may not be possible, fragmenting accounts across supported features and security configurations. Additionally, it requires plugin developers to choose which platforms to support, causing either platform lock-in or duplicated development effort.
+However, managing multiple account instances provides a worse user experience, fragmenting accounts across supported features and security configurations. Additionally, it requires plugin developers to choose which platforms to support, causing either platform lock-in or duplicated development effort.
 
 We propose a standard that coordinates the implementation work between plugin developers and wallet developers. This standard defines a modular smart contract account capable of supporting all standard-conformant plugins. This allows users to have greater portability of their data, and for plugin developers to not have to choose specific account implementations to support.
 


### PR DESCRIPTION
Made adaptations to respect this generally accepted terminology:

- `account` = address + chain, the onchain object that holds user funds.
- `wallet` = account + secret, the client software that manages private keys and signs transactions.