### PR TITLE
Update EIP-3540: EOF1 contracts can only DELEGATECALL EOF1 contracts

### DIFF
--- a/EIPS/eip-3540.md
+++ b/EIPS/eip-3540.md
@@ -162,6 +162,7 @@ For clarity, the *container* refers to the complete account code, while *code* r
 4. `CODECOPY`/`CODESIZE`/`EXTCODECOPY`/`EXTCODESIZE`/`EXTCODEHASH` keeps operating on the entire *container*.
 5. The input to `CREATE`/`CREATE2` is still the entire *container*.
 6. The size limit for deployed code as specified in [EIP-170](./eip-170.md) and for initcode as specified in [EIP-3860](./eip-3860.md) is applied to the entire *container* size, not to the *code* size. This also means if initcode validation fails, it is still charged the EIP-3860 `initcode_cost`.
+7. When an EOF1 contract performs a `DELEGATECALL` the target must be EOF1. If it is not EOF1, the `DELEGATECALL` execution finishes as a failed call by pushing `0` to the stack. Only initial gas cost of `DELEGATECALL` is consumed (similarly to the call depth check) and the target address still becomes warm.
 
 (*Remark:* Due to [EIP-4750](./eip-4750.md), `JUMP` and `JUMPI` are disabled and therefore are not discussed in relation to EOF.)
 
@@ -250,6 +251,10 @@ It is possible in the future that this data will be accessible with data-specifi
 
 The value for `PC` is specified to start at 0 and to be within the active *code* section. We considered keeping `PC` to operate on the whole *container* and be consistent with `CODECOPY`/`EXTCODECOPY` but in the end decided otherwise. This also feels more natural and easier to implement in EVM: the new EOF EVM should only care about traversing *code* and accessing other parts of the *container* only on special occasions (e.g. in `CODECOPY` instruction).
 
+### EOF1 contracts can only `DELEGATECALL` EOF1 contracts
+
+Currently contracts can selfdestruct in three different ways (directly through `SELFDESTRUCT`, indirectly through `CALLCODE` and indirectly through `DELEGATECALL`). [EIP-3670](./eip-3670.md) disables the first two possibilities, however the third possibility remains. Allowing EOF1 contracts to only `DELEGATECALL` other EOF1 contracts allows the following strong statement: EOF1 contract can never be destructed. Attacks based on `SELFDESTRUCT` completely disappear for EOF1 contracts. These include destructed library contracts (e.g. Parity Multisig).
+
 ## Backwards Compatibility
 
 This is a breaking change given that any code starting with `0xEF` was not deployable before (and resulted in exceptional abort if executed), but now some subset of such codes can be deployed and executed successfully.
@@ -291,6 +296,10 @@ All cases should be checked for creation transaction, `CREATE` and `CREATE2`.
   - `EXTCODECOPY` can copy from target's EOF header
   - `EXTCODECOPY` can copy entire target container
   - Results don't differ when executed inside legacy or EOF contract
+- EOF1 `DELEGATECALL`
+  - `DELEGATECALL` to EOF1 code succeeds
+  - `DELEGATECALL` to EOF0 code fails
+  - `DELEGATECALL` to empty container fails
 
 ## Security Considerations
 


### PR DESCRIPTION
Originally proposed in https://github.com/ethereum/EIPs/pull/6359 by @ritzdorf.

The changes here in the spec are:
- `DELEGATECALL` returns 0 instead of "exceptionally halting" the execution,
- not all gas is consumed by `DELEGATECALL` in case it fails of this reason.

Also @ritzdorf removed from the EIP authors list. I believed I requested this some time ago but I cannot find it now so maybe the comment were never properly sent.