### PR TITLE
Update EIP-6093: Rename `ERC721InexistentToken` to `ERC721NonexistentToken`

### DIFF
--- a/EIPS/eip-6093.md
+++ b/EIPS/eip-6093.md
@@ -101,7 +101,7 @@ Used in balance queries.
 - MUST not be used for transfers.
   - Use `ERC721IncorrectOwner` instead.
 
-### `ERC721InexistentToken(uint256 tokenId)`
+### `ERC721NonexistentToken(uint256 tokenId)`
 
 Indicates a `tokenId` whose `owner` is the zero address.
 
@@ -353,7 +353,7 @@ interface ERC20Errors {
 ///  https://eips.ethereum.org/EIPS/eip-6093
 interface ERC721Errors {
     error ERC721InvalidOwner(address owner);
-    error ERC721InexistentToken(uint256 tokenId);
+    error ERC721NonexistentToken(uint256 tokenId);
     error ERC721IncorrectOwner(address sender, uint256 tokenId, address owner);
     error ERC721InvalidSender(address sender);
     error ERC721InvalidReceiver(address receiver);


### PR DESCRIPTION
### Description

Updating `ERC721InexistentToken` to `ERC721NonexistentToken`