### PR TITLE
Update EIP-5564: ERC-5564 - remove staking and add indexed caller

### DIFF
--- a/EIPS/eip-5564.md
+++ b/EIPS/eip-5564.md
@@ -280,4 +280,3 @@ Thus, the sender may attach a small amount of ETH to each stealth address transa
 ## Copyright
 
 Copyright and related rights waived via [CC0](../LICENSE.md).
-

--- a/EIPS/eip-5564.md
+++ b/EIPS/eip-5564.md
@@ -101,12 +101,13 @@ This specification additionally defines a singleton `ERC5564Messenger` contract 
 
 ```solidity
 /// @notice Interface for announcing when something is sent to a stealth address.
-contract IERC5564Messenger is StakeManager{
+contract IERC5564Messenger {
   /// @dev Emitted when sending something to a stealth address.
   /// @dev See the `announce` method for documentation on the parameters.
   event Announcement (
     uint256 indexed schemeId, 
     address indexed stealthAddress, 
+    address indexed caller, 
     bytes ephemeralPubKey, 
     bytes metadata
   );
@@ -141,54 +142,8 @@ contract IERC5564Messenger is StakeManager{
   )
     external
   {
-    emit Announcement(schemeId, stealthAddress, ephemeralPubKey, metadata);
+    emit Announcement(schemeId, stealthAddress, msg.sender, ephemeralPubKey, metadata);
   }
-}
-```
-
-The `ERC5564Messenger` contract inherits the `StakeManager` contract allowing users to stake ETH that is used as an anti-DoS measure. More details in the [DoS Countermeasures](#dos-countermeasures) section.
-
-```solidity
-/// @notice Interface for the Stake Manager contract.
-contract StakeManager{
-  
-  /// @dev Emitted when stake is deposited.
-  /// @param account The address of the staker who deposited the stake.
-  /// @param totalStaked The new total amount of staked tokens for the account.
-  event StakeDeposit (
-        address indexed account,
-        uint256 totalStaked
-  );
-    
-  /// @dev Emitted when stake is withdrawn.
-  /// @param account The address of the staker who withdrew the stake.
-  /// @param withdrawAddress The address to which the withdrawn amount was sent.
-  /// @param amount The amount of tokens withdrawn.
-  event StakeWithdrawal (
-        address indexed account,
-        address withdrawAddress,
-        uint256 amount
-  );
-  
-  /**
-   * @notice Returns the stake of the account.
-   * @param account The address of the staker to check the stake for.
-   * @return uint256 The amount of staked tokens for the account.
-   */
-  function balanceOf(address account) external view returns (uint256);
-
-  /**
-   * @notice Adds the specified amount to the account's stake.
-   * @dev The function is payable, so the amount is sent as value with the transaction.
-   * @param staker The address of the staker to add the stake for.
-   */
-  function addStake(address staker) external payable;
-  
-  /**
-   * @notice Withdraws the stake for the caller and sends it to the specified address.
-   * @param withdrawAddress The address to send the withdrawn amount to.
-   */
-  function withdrawStake(address payable withdrawAddress) external;
 }
 ```
 
@@ -289,13 +244,13 @@ The view tags approach is introduced to reduce the parsing time by around 6x. Us
 
 ## Rationale
 
-This EIP emerged from the need of having privacy-preserving ways to transfer ownership without disclosing any information about the recipients' identities. Token ownership can expose sensitive personal information. While individuals may wish to donate to a specific organization or country, they might prefer not to disclose a link between themselves and the recipient at the same time. Standardizing stealth address generation represents a significant step towards unlinkable interactions, since such privacy-enhancing solutions require standards to achieve widespread adoption. Consequently, it is crucial to concentrate on developing generalizable approaches for implementing related solutions.
+This EIP emerged from the need for privacy-preserving ways to transfer ownership without disclosing any information about the recipients' identities. Token ownership can expose sensitive personal information. While individuals may wish to donate to a specific organization or country, they might prefer not to disclose a link between themselves and the recipient simultaneously. Standardizing stealth address generation represents a significant step towards unlinkable interactions, since such privacy-enhancing solutions require standards to achieve widespread adoption. Consequently, it is crucial to focus on developing generalizable approaches for implementing related solutions.
 
 The stealth address specification standardizes a protocol for generating and locating stealth addresses, facilitating the transfer of assets without requiring prior interaction with the recipient. This enables recipients to verify the receipt of a transfer without the need to interact with the blockchain and query account balances. Importantly, stealth addresses enable token transfer recipients to verify receipt while maintaining their privacy, as only the recipient can recognize themselves as the recipient of the transfer.
 
 The authors recognize the trade-off between on- and off-chain efficiency. Although incorporating a Monero-like view tags mechanism enables recipients to parse announcements more efficiently, it adds complexity to the announcement event.
 
-The address of the recipient and the `viewTag` MUST be included in the announcement event, allowing users to quickly verify ownership without querying the chain for positive account balances.
+The recipient's address and the `viewTag` MUST be included in the announcement event, allowing users to quickly verify ownership without querying the chain for positive account balances.
 
 ## Backwards Compatibility
 
@@ -310,16 +265,19 @@ You can find an implementation of this standard in TBD.
 ### DoS Countermeasures
 
 There are potential denial of service (DoS) attack vectors that are not mitigated by network transaction fees. Stealth transfer senders cause an externality for recipients, as parsing announcement events consumes computational resources that are not compensated with gas. Therefore, spamming announcement events *can* be a detriment to the user experience, as it *can* lead to longer parsing times. 
-We consider the incentives to carry out such an attack to be low because **no monetary benefit can be obtained** and, in theory, nothing prevents parsing providers from ignoring the spamming when serving announcements to users.
-However, sophisticated spamming (*sybil attacks*), which are not considered worth the associated costs, could make it difficult for parsing providers to develop filters for such announcement events.
-Therefore, to counter spamming directly, a staking mechanism is introduced in the EIP that allows users to stake an unslashable amount of ETH. Staking allows parsing providers to better tackle potential spam through *sybil attacks*, enabling them to filter spam more effectively.
+We consider the incentives to carry out such an attack to be low because **no monetary benefit can be obtained**
+However, to tackle potential spam, parsing providers may adopt their own anti-DoS attack methods. These may include ignoring the spamming users when serving announcements to users or, less harsh, de-prioritizing them when ordering the announcements. The indexed `caller` keyword may help parsing providers to effectively filter known spammers.
 
-Similarly to [ERC-4337](./eip-4337), parsing providers agree on a `MINIMUM_STAKE`, such that the minimum required stake is not enforced on-chain. Users *can* withdraw their stake at any time without any delay. Parsing providers can de-prioritize senders who have not staked a certain minimum amount or withdrew their stake immediately.
+Furthermore, parsing providers have a few options to counter spam, such as introducing staking mechanisms or requiring senders to pay a `toll` before including their `Announcement`. Moreover, a Staking mechanism may allow users to stake an unslashable amount of ETH (similarly to [ERC-4337](./eip-4337)), to help mitigate potential spam through *sybil attacks* and enable parsing providers filtering spam more effectively.
+Introducing a `toll`, paid by sending users, would simply put a cost on each stealth address transaction, making spamming economically unattractive.
 
 ### Recipients' transaction costs
 
 The funding of the stealth address wallet represents a known issue that might breach privacy. The wallet that funds the stealth address MUST NOT have any physical connection to the stealth address owner in order to fully leverage the privacy improvements.
 
+Thus, the sender may attach a small amount of ETH to each stealth address transaction, thereby sponsoring subsequent transactions of the recipient.
+
 ## Copyright
 
 Copyright and related rights waived via [CC0](../LICENSE.md).
+


### PR DESCRIPTION
We decided to remove the staking mechanism (that was supposed to mitigate DoS attacks, or at least provide some additional measure agains them) for the sake of simplicity of the ERC.

We add another indexed keyword to the Announcement event to enable parsing providers to easily filter certain "caller" (msg.sender) for mitigating spam more effectively.