### PR TITLE
Update EIP-4844: Adjust Throughput Section

### DIFF
--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -400,7 +400,7 @@ The parameter `DATA_GASPRICE_UPDATE_FRACTION` controls the maximum rate of chang
 
 ### Throughput
 
-The values for `TARGET_DATA_GAS_PER_BLOCK` and `MAX_DATA_GAS_PER_BLOCK` are chosen to correspond to a target of 2 blobs (0.25 MB) and maximum of 4 blobs (0.5 MB) per block. These small initial limits are intended to minimize the strain on the network created by this EIP and are expected to be increased in future upgrades as the network demonstrates reliability under larger blocks.
+The values for `TARGET_DATA_GAS_PER_BLOCK` and `MAX_DATA_GAS_PER_BLOCK` are chosen to correspond to a target of 3 blobs (0.375 MB) and maximum of 6 blobs (0.75 MB) per block. These small initial limits are intended to minimize the strain on the network created by this EIP and are expected to be increased in future upgrades as the network demonstrates reliability under larger blocks.
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
Adjusts the throughput section to the updated 3/6 blobs case. This section was missed in the main update in https://github.com/ethereum/EIPs/pull/7154.