### PR TITLE
Update EIP-6963: Add `providerId` into the design

### DIFF
--- a/EIPS/eip-6963.md
+++ b/EIPS/eip-6963.md
@@ -2,7 +2,7 @@
 eip: 6963
 title: Multi Injected Provider Discovery
 description: Using window events to announce injected wallet providers
-author: Pedro Gomes (@pedrouid), Kosala Hemachandra (@kvhnuke), Richard Moore (@ricmoo), Gregory Markou (@GregTheGreek), Kyle Den Hartog (@kdenhartog), Glitch (@glitch-txs), Jake Moxey (@jxom), Pierre Bertet (@bpierre), Darryl Yeo (@darrylyeo), Yaroslav Sergievsky (@everdimension)
+author: Pedro Gomes (@pedrouid), Kosala Hemachandra (@kvhnuke), Richard Moore (@ricmoo), Gregory Markou (@GregTheGreek), Kyle Den Hartog (@kdenhartog), Glitch (@glitch-txs), Jake Moxey (@jxom), Pierre Bertet (@bpierre), Darryl Yeo (@darrylyeo), Yaroslav Sergievsky (@everdimension), Tom Meagher (@tmm)
 discussions-to: https://ethereum-magicians.org/t/eip-6963-multi-injected-provider-interface-aka-mipi/14076
 status: Draft
 type: Standards Track
@@ -39,15 +39,16 @@ Wallet: A user agent that manages keys and facilitates transactions with Ethereu
 
 Decentralized Application (DApp): A web page that relies upon one or many Web3 platform APIs which are exposed to the web page via the Wallet.
 
-Provider Discovery Library: A library or piece of software that assists a DApp to interact with the Wallet. 
+Provider Discovery Library: A library or piece of software that assists a DApp to interact with the Wallet (e.g. wagmi, Web3Modal, RainbowKit, Web3-Onboard, ConnectKit, etc).
 
 ### Provider Info
 
-Each wallet provider will be announced with the following interface `EIP6963ProviderInfo`. The values in the `EIP6963ProviderInfo` MUST be used as follows:
+Each Wallet Provider will be announced with the following interface `EIP6963ProviderInfo`. The values in the `EIP6963ProviderInfo` MUST be used as follows:
 
-- **`uuid`** - a globally unique of the wallet provider that MUST be (UUIDv4[^rfc4122] compliant) to uniquely distinguish different [EIP-1193](./eip-1193.md) provider sessions. The cryptographic uniqueness provided by UUIDv4[^rfc4122] guarantees that two independent `EIP6963ProviderInfo` objects can be separately identified.
-- **`name`** - A human-readable local alias of the wallet provider to be displayed to the user on the DApp. (e.g. `DopeWalletExtension` or `AwesomeWallet`)
-- **`icon`** - A URI[^rfc3986] pointing to an image. Icon images MUST be square with 96x96px minimum resolution
+- **`uuid`** - a universally unique identifier of the Wallet Provider that MUST be UUIDv4[^rfc4122] compliant and thus MUST BE non-deterministic between sessions.
+- **`walletId`** - a unique identifier for the Wallet Provider that MUST be unique to the Wallet Provider and MUST be deterministic between sessions.
+- **`name`** - a human-readable local alias of the Wallet Provider to be displayed to the user on the DApp and MAY be non-deterministic between sessions.
+- **`icon`** - a URI[^rfc3986] pointing to an image. Icon images MUST be square with 96x96px minimum resolution
 
 ```typescript
 /**
@@ -55,9 +56,53 @@ Each wallet provider will be announced with the following interface `EIP6963Prov
  */
 interface EIP6963ProviderInfo {
   uuid: string;
+  walletId: string;
   name: string;
   icon: string;
 }
+```
+
+#### Universally Unique Identifiers (UUIDs)
+
+The UUID (`uuid`) is a **non-deterministic unique identifier** used to uniquely distinguish different [EIP-1193](./eip-1193.md) provider sessions. The cryptographic uniqueness provided by UUIDv4[^rfc4122] guarantees that two independent `EIP6963ProviderInfo` objects can be separately identified.
+
+#### Wallet IDs
+
+The Wallet ID (`walletId`) is a **deterministic unique identifier** used by the Provider Discovery Library to "find" or "target" Wallet Providers.
+
+A **deterministic** Wallet ID is particularly useful for a Provider Discovery Library to:
+
+- Rehydrate Wallet Providers that have been persisted in a previous session via browser local storage or a database.
+- Group Wallets in the Provider Discovery Library or DApps UI (e.g. "Favorites", "Recent", etc).
+- Handle Wallet Providers that may implement optional `wallet_` RPC methods (e.g. `wallet_addEthereumChain`, etc).
+- Shim behaviour that may not be native of the Wallet Provider.
+
+Examples of Wallet IDs include:
+
+```
+metamask
+coinbase
+zerion
+brave
+taho
+rainbow
+```
+
+#### Wallet Names
+
+A Wallet Name (`name`) is a human-readable display name of the Wallet Provider.
+
+The Wallet Name is primarily used to display the Wallet to the user in the DApp's UI.
+
+Examples of Wallet Names include:
+
+```
+MetaMask
+Coinbase Wallet
+Zerion
+Brave Wallet
+Taho
+Rainbow
 ```
 
 #### Images/Icons
@@ -169,10 +214,31 @@ To follow the Javascript event name conventions, the names are written in presen
 
 ### Interfaces
 
-Standardizing a provider info interface (`EIP6963ProviderInfo`) allows determining the necessary information to populate a wallet selection popup. This is particularly useful for DApps and Ethereum libraries they might depend on such as Web3Modal, RainbowKit, Web3-Onboard, ConnectKit, etc.
+Standardizing a provider info interface (`EIP6963ProviderInfo`) allows determining the necessary information to populate a wallet selection popup. This is particularly useful for DApps and Provider Discovery Libraries they might depend on.
 
 Regarding the announced provider interface (`EIP6963ProviderDetail`) it was important to leave the [EIP-1193](./eip-1193.md) provider interface untouched for backwards compatibility therefore it's exposed in parallel. However, just as it is today there is no guarantee that this backwards compatible method will result in the user selected wallet being chosen.
 
+### Wallet IDs
+
+A Wallet ID (`walletId`) is included in the design to allow DApps & Provider Discovery Libraries to target or identify Wallet Providers. As the Wallet ID is the only deterministic identifier in the design, this means we can accurately achieve Wallet Provider identification between sessions compared to the UUID (`uuid`) or Wallet Name (`name`).
+
+Notable differences:
+
+- The difference between a Wallet ID (`walletId`) and a UUID (`uuid`) is that the Wallet ID is a **deterministic identifier** that **does not** change between sessions, whereas a UUID is a **non-deterministic identifier** that **does** change between sessions.
+- The difference between a Wallet ID (`walletId`) and a Wallet Name (`name`) is that the Wallet ID is a **deterministic identifier** that **does not** change between sessions, whereas a Wallet Name is a **non-deterministic display name** that **may** change between sessions, such as when a Wallet undergoes a brand change/modification (e.g. "Tally" → "Taho", or "Rabby" → "Rabby Wallet").
+
+Previously, we implicitly achieved Wallet IDs by extending `window.ethereum` to include a non-standard flag (ie. `isMetaMask`, `isBrave`, `isTrustWallet`, etc.) to identify Wallet Providers. This was problematic because it:
+
+1. is a non-standard
+2. introduces contradicting/"impossible" states (e.g. `isMetaMask` and `isOpera` being both `true`) that lead to challenges when identifying the correct wallet.
+
+Having a stringified Wallet ID (`walletId`) instead of a boolean flag allows us to accurately identify Wallet Providers between sessions and avoid the aforementioned challenges.
+
+Furthermore, some use-cases of Wallet IDs for Provider Discovery Libraries include:
+
+- **Rehydrating Wallet Providers**: If the Provider Discovery Library has persisted the Wallet Provider in a previous session via browser local storage or a database, they can rely on the Wallet ID to accurately rehydrate the Wallet Provider.
+- **Group Wallets**: If the Provider Discovery Library has a list of Wallet Providers they wish to group together (e.g. a "Recent", "Favourites", etc section) they can rely on the Wallet ID to accurately achieve this.
+- **`wallet_` RPC Method Differences**: If the Wallet Provider implements optional `wallet_` RPC methods, the Provider Discovery Library can rely on the Wallet ID to accurately determine how to facilitate the `wallet_` RPC method. For example, a Wallet may not support chain switching, and thus may not support `wallet_switchEthereumChain`, this means the Provider Discovery Library could not show a "Switch Network" button for that Wallet Provider.
 
 ## Backwards Compatibility
 

--- a/EIPS/eip-6963.md
+++ b/EIPS/eip-6963.md
@@ -236,7 +236,7 @@ Having a stringified Wallet ID (`walletId`) instead of a boolean flag allows us 
 
 Furthermore, some use-cases of Wallet IDs for Provider Discovery Libraries include:
 
-- **Rehydrating Wallet Providers**: If the Provider Discovery Library has persisted the Wallet Provider in a previous session via browser local storage or a database, they can rely on the Wallet ID to accurately rehydrate the Wallet Provider.
+- **Rehydrating Wallet Providers**: If the Provider Discovery Library has persisted the Wallet Provider in a previous session via browser local storage or a database, they can rely on the Wallet ID to accurately rehydrate the Wallet Provider. Same applies for if a Provider Discovery Library emits the `"eip6963:requestProvider"` event again in the same session.
 - **Group Wallets**: If the Provider Discovery Library has a list of Wallet Providers they wish to group together (e.g. a "Recent", "Favourites", etc section) they can rely on the Wallet ID to accurately achieve this.
 - **`wallet_` RPC Method Differences**: If the Wallet Provider implements optional `wallet_` RPC methods, the Provider Discovery Library can rely on the Wallet ID to accurately determine how to facilitate the `wallet_` RPC method. For example, a Wallet may not support chain switching, and thus may not support `wallet_switchEthereumChain`, this means the Provider Discovery Library could not show a "Switch Network" button for that Wallet Provider.
 

--- a/EIPS/eip-6963.md
+++ b/EIPS/eip-6963.md
@@ -46,7 +46,7 @@ Provider Discovery Library: A library or piece of software that assists a DApp t
 Each Wallet Provider will be announced with the following interface `EIP6963ProviderInfo`. The values in the `EIP6963ProviderInfo` MUST be used as follows:
 
 - **`uuid`** - a universally unique identifier of the Wallet Provider that MUST be UUIDv4[^rfc4122] compliant and thus MUST BE nondeterministic between sessions.
-- **`providerId`** - a unique identifier for the Wallet Provider that MUST be unique to the Wallet Provider and MUST be deterministic between sessions.
+- **`providerId`** - a unique identifier for the Wallet Provider that MUST be deterministic between sessions.
 - **`name`** - a human-readable local alias of the Wallet Provider to be displayed to the user on the DApp and MAY be nondeterministic between sessions.
 - **`icon`** - a URI[^rfc3986] pointing to an image. Icon images MUST be square with 96x96px minimum resolution
 

--- a/EIPS/eip-6963.md
+++ b/EIPS/eip-6963.md
@@ -46,7 +46,7 @@ Provider Discovery Library: A library or piece of software that assists a DApp t
 Each Wallet Provider will be announced with the following interface `EIP6963ProviderInfo`. The values in the `EIP6963ProviderInfo` MUST be used as follows:
 
 - **`uuid`** - a universally unique identifier of the Wallet Provider that MUST be UUIDv4[^rfc4122] compliant and thus MUST BE nondeterministic between sessions.
-- **`walletId`** - a unique identifier for the Wallet Provider that MUST be unique to the Wallet Provider and MUST be deterministic between sessions.
+- **`providerId`** - a unique identifier for the Wallet Provider that MUST be unique to the Wallet Provider and MUST be deterministic between sessions.
 - **`name`** - a human-readable local alias of the Wallet Provider to be displayed to the user on the DApp and MAY be nondeterministic between sessions.
 - **`icon`** - a URI[^rfc3986] pointing to an image. Icon images MUST be square with 96x96px minimum resolution
 
@@ -56,7 +56,7 @@ Each Wallet Provider will be announced with the following interface `EIP6963Prov
  */
 interface EIP6963ProviderInfo {
   uuid: string;
-  walletId: string;
+  providerId: string;
   name: string;
   icon: string;
 }
@@ -66,18 +66,18 @@ interface EIP6963ProviderInfo {
 
 The UUID (`uuid`) is a **nondeterministic unique identifier** used to uniquely distinguish different [EIP-1193](./eip-1193.md) provider sessions. The cryptographic uniqueness provided by UUIDv4[^rfc4122] guarantees that two independent `EIP6963ProviderInfo` objects can be separately identified.
 
-#### Wallet IDs
+#### Provider IDs
 
-The Wallet ID (`walletId`) is a **deterministic unique identifier** used by the Provider Discovery Library to "find" or "target" Wallet Providers.
+The Provider ID (`providerId`) is a **deterministic unique identifier** used by the Provider Discovery Library to "find" or "target" Wallet Providers.
 
-A **deterministic** Wallet ID is particularly useful for a Provider Discovery Library to:
+A **deterministic** Provider ID is particularly useful for a Provider Discovery Library to:
 
 - Rehydrate Wallet Providers that have been persisted in a previous session via browser local storage or a database.
 - Group Wallets in the Provider Discovery Library or DApps UI (e.g. "Favorites", "Recent", etc).
 - Handle Wallet Providers that may implement optional `wallet_` RPC methods (e.g. `wallet_addEthereumChain`, etc).
 - Shim behaviour that may not be native of the Wallet Provider.
 
-Examples of Wallet IDs include:
+Examples of Provider IDs include:
 
 ```
 metamask
@@ -218,27 +218,27 @@ Standardizing a provider info interface (`EIP6963ProviderInfo`) allows determini
 
 Regarding the announced provider interface (`EIP6963ProviderDetail`) it was important to leave the [EIP-1193](./eip-1193.md) provider interface untouched for backwards compatibility therefore it's exposed in parallel. However, just as it is today there is no guarantee that this backwards compatible method will result in the user selected wallet being chosen.
 
-### Wallet IDs
+### Provider IDs
 
-A Wallet ID (`walletId`) is included in the design to allow DApps & Provider Discovery Libraries to target or identify Wallet Providers. As the Wallet ID is the only deterministic identifier in the design, this means we can accurately achieve Wallet Provider identification between sessions compared to the UUID (`uuid`) or Wallet Name (`name`).
+A Provider ID (`providerId`) is included in the design to allow DApps & Provider Discovery Libraries to target or identify Wallet Providers. As the Provider ID is the only deterministic identifier in the design, this means we can accurately achieve Wallet Provider identification between sessions compared to the UUID (`uuid`) or Wallet Name (`name`).
 
 Notable differences:
 
-- The difference between a Wallet ID (`walletId`) and a UUID (`uuid`) is that the Wallet ID is a **deterministic identifier** that **does not** change between sessions, whereas a UUID is a **nondeterministic identifier** that **does** change between sessions.
-- The difference between a Wallet ID (`walletId`) and a Wallet Name (`name`) is that the Wallet ID is a **deterministic identifier** that **does not** change between sessions, whereas a Wallet Name is a **nondeterministic display name** that **may** change between sessions, such as when a Wallet undergoes a brand change/modification (e.g. "Tally" → "Taho", or "Rabby" → "Rabby Wallet").
+- The difference between a Provider ID (`providerId`) and a UUID (`uuid`) is that the Provider ID is a **deterministic identifier** that **does not** change between sessions, whereas a UUID is a **nondeterministic identifier** that **does** change between sessions.
+- The difference between a Provider ID (`providerId`) and a Wallet Name (`name`) is that the Provider ID is a **deterministic identifier** that **does not** change between sessions, whereas a Wallet Name is a **nondeterministic display name** that **may** change between sessions, such as when a Wallet undergoes a brand change/modification (e.g. "Tally" → "Taho", or "Rabby" → "Rabby Wallet").
 
-Previously, we implicitly achieved Wallet IDs by extending `window.ethereum` to include a non-standard flag (ie. `isMetaMask`, `isBrave`, `isTrustWallet`, etc.) to identify Wallet Providers. This was problematic because it:
+Previously, we implicitly achieved Provider IDs by extending `window.ethereum` to include a non-standard flag (ie. `isMetaMask`, `isBrave`, `isTrustWallet`, etc.) to identify Wallet Providers. This was problematic because it:
 
 1. is a non-standard
 2. introduces contradicting/"impossible" states (e.g. `isMetaMask` and `isOpera` being both `true`) that lead to challenges when identifying the correct wallet.
 
-Having a stringified Wallet ID (`walletId`) instead of a boolean flag allows us to accurately identify Wallet Providers between sessions and avoid the aforementioned challenges.
+Having a stringified Provider ID (`providerId`) instead of a boolean flag allows us to accurately identify Wallet Providers between sessions and avoid the aforementioned challenges.
 
-Furthermore, some use-cases of Wallet IDs for Provider Discovery Libraries include:
+Furthermore, some use-cases of Provider IDs for Provider Discovery Libraries include:
 
-- **Rehydrating Wallet Providers**: If the Provider Discovery Library has persisted the Wallet Provider in a previous session via browser local storage or a database, they can rely on the Wallet ID to accurately rehydrate the Wallet Provider. Same applies for if a Provider Discovery Library emits the `"eip6963:requestProvider"` event again in the same session.
-- **Group Wallets**: If the Provider Discovery Library has a list of Wallet Providers they wish to group together (e.g. a "Recent", "Favourites", etc section) they can rely on the Wallet ID to accurately achieve this.
-- **`wallet_` RPC Method Differences**: If the Wallet Provider implements optional `wallet_` RPC methods, the Provider Discovery Library can rely on the Wallet ID to accurately determine how to facilitate the `wallet_` RPC method. For example, a Wallet may not support chain switching, and thus may not support `wallet_switchEthereumChain`, this means the Provider Discovery Library could not show a "Switch Network" button for that Wallet Provider.
+- **Rehydrating Wallet Providers**: If the Provider Discovery Library has persisted the Wallet Provider in a previous session via browser local storage or a database, they can rely on the Provider ID to accurately rehydrate the Wallet Provider. Same applies for if a Provider Discovery Library emits the `"eip6963:requestProvider"` event again in the same session.
+- **Group Wallets**: If the Provider Discovery Library has a list of Wallet Providers they wish to group together (e.g. a "Recent", "Favourites", etc section) they can rely on the Provider ID to accurately achieve this.
+- **`wallet_` RPC Method Differences**: If the Wallet Provider implements optional `wallet_` RPC methods, the Provider Discovery Library can rely on the Provider ID to accurately determine how to facilitate the `wallet_` RPC method. For example, a Wallet may not support chain switching, and thus may not support `wallet_switchEthereumChain`, this means the Provider Discovery Library could not show a "Switch Network" button for that Wallet Provider.
 
 ## Backwards Compatibility
 

--- a/EIPS/eip-6963.md
+++ b/EIPS/eip-6963.md
@@ -39,7 +39,7 @@ Wallet: A user agent that manages keys and facilitates transactions with Ethereu
 
 Decentralized Application (DApp): A web page that relies upon one or many Web3 platform APIs which are exposed to the web page via the Wallet.
 
-Provider Discovery Library: A library or piece of software that assists a DApp to interact with the Wallet (e.g. wagmi, Web3Modal, RainbowKit, Web3-Onboard, ConnectKit, etc).
+Provider Discovery Library: A library or piece of software that assists a DApp to interact with the Wallet (e.g. Web3Modal, wagmi, RainbowKit, Web3-Onboard, ConnectKit, etc).
 
 ### Provider Info
 

--- a/EIPS/eip-6963.md
+++ b/EIPS/eip-6963.md
@@ -45,9 +45,9 @@ Provider Discovery Library: A library or piece of software that assists a DApp t
 
 Each Wallet Provider will be announced with the following interface `EIP6963ProviderInfo`. The values in the `EIP6963ProviderInfo` MUST be used as follows:
 
-- **`uuid`** - a universally unique identifier of the Wallet Provider that MUST be UUIDv4[^rfc4122] compliant and thus MUST BE non-deterministic between sessions.
+- **`uuid`** - a universally unique identifier of the Wallet Provider that MUST be UUIDv4[^rfc4122] compliant and thus MUST BE nondeterministic between sessions.
 - **`walletId`** - a unique identifier for the Wallet Provider that MUST be unique to the Wallet Provider and MUST be deterministic between sessions.
-- **`name`** - a human-readable local alias of the Wallet Provider to be displayed to the user on the DApp and MAY be non-deterministic between sessions.
+- **`name`** - a human-readable local alias of the Wallet Provider to be displayed to the user on the DApp and MAY be nondeterministic between sessions.
 - **`icon`** - a URI[^rfc3986] pointing to an image. Icon images MUST be square with 96x96px minimum resolution
 
 ```typescript
@@ -64,7 +64,7 @@ interface EIP6963ProviderInfo {
 
 #### Universally Unique Identifiers (UUIDs)
 
-The UUID (`uuid`) is a **non-deterministic unique identifier** used to uniquely distinguish different [EIP-1193](./eip-1193.md) provider sessions. The cryptographic uniqueness provided by UUIDv4[^rfc4122] guarantees that two independent `EIP6963ProviderInfo` objects can be separately identified.
+The UUID (`uuid`) is a **nondeterministic unique identifier** used to uniquely distinguish different [EIP-1193](./eip-1193.md) provider sessions. The cryptographic uniqueness provided by UUIDv4[^rfc4122] guarantees that two independent `EIP6963ProviderInfo` objects can be separately identified.
 
 #### Wallet IDs
 
@@ -164,7 +164,7 @@ interface EIP6963RequestProviderEvent extends Event {
 }
 ```
 
-The Wallet MUST announce to the DApp the `EIP6963AnnounceProviderEvent` via a `window.dispatchEvent()` function call. The Wallet MUST add an EventListener to catch an `EIP6963RequestProviderEvent` dispatched from the DApp. This EventListener MUST use a handler that will re-dispatch an `EIP6963AnnounceProviderEvent`. This re-announcement by the Wallet is useful for when a Wallet's initial Event announcement may have been delayed or fired before the DApp had initialized its EventListener. This allows the various Wallet Providers to react to the DApp without the need to pollute the `window.ethereum` namespace which can produce non-deterministic wallet behavior such as different wallets connecting each time.
+The Wallet MUST announce to the DApp the `EIP6963AnnounceProviderEvent` via a `window.dispatchEvent()` function call. The Wallet MUST add an EventListener to catch an `EIP6963RequestProviderEvent` dispatched from the DApp. This EventListener MUST use a handler that will re-dispatch an `EIP6963AnnounceProviderEvent`. This re-announcement by the Wallet is useful for when a Wallet's initial Event announcement may have been delayed or fired before the DApp had initialized its EventListener. This allows the various Wallet Providers to react to the DApp without the need to pollute the `window.ethereum` namespace which can produce nondeterministic wallet behavior such as different wallets connecting each time.
 
 The Wallet listens dispatches the `"eip6963:announceProvider"` event and listens to the `"eip6963:requestProvider"` event:
 
@@ -224,8 +224,8 @@ A Wallet ID (`walletId`) is included in the design to allow DApps & Provider Dis
 
 Notable differences:
 
-- The difference between a Wallet ID (`walletId`) and a UUID (`uuid`) is that the Wallet ID is a **deterministic identifier** that **does not** change between sessions, whereas a UUID is a **non-deterministic identifier** that **does** change between sessions.
-- The difference between a Wallet ID (`walletId`) and a Wallet Name (`name`) is that the Wallet ID is a **deterministic identifier** that **does not** change between sessions, whereas a Wallet Name is a **non-deterministic display name** that **may** change between sessions, such as when a Wallet undergoes a brand change/modification (e.g. "Tally" → "Taho", or "Rabby" → "Rabby Wallet").
+- The difference between a Wallet ID (`walletId`) and a UUID (`uuid`) is that the Wallet ID is a **deterministic identifier** that **does not** change between sessions, whereas a UUID is a **nondeterministic identifier** that **does** change between sessions.
+- The difference between a Wallet ID (`walletId`) and a Wallet Name (`name`) is that the Wallet ID is a **deterministic identifier** that **does not** change between sessions, whereas a Wallet Name is a **nondeterministic display name** that **may** change between sessions, such as when a Wallet undergoes a brand change/modification (e.g. "Tally" → "Taho", or "Rabby" → "Rabby Wallet").
 
 Previously, we implicitly achieved Wallet IDs by extending `window.ethereum` to include a non-standard flag (ie. `isMetaMask`, `isBrave`, `isTrustWallet`, etc.) to identify Wallet Providers. This was problematic because it:
 


### PR DESCRIPTION
The [wagmi](https://github.com/wagmi-dev) core team proposes to add a providerId into the design of EIP-6963, formally known as `walletId`.

Decided not to use an rdns (Reverse DNS) for the said deterministic identifier to keep the objective clear, focused and simple, without having to deal with the complexities of the rationale of a rDNS in this spec and potential side-effects of a rDNS that may impact the determinism of the identifier in the future.

Update: [changed `walletId` to `providerId`](https://github.com/ethereum/EIPs/pull/7167/commits/552cb791ca9880991b7f06928fe2976bf0bd1d8e) (ref: https://ethereum-magicians.org/t/eip-6963-multi-injected-provider-discovery/14076/23).