### PR TITLE
Update EIP-4788: Update the precompile address for 4788

### DIFF
--- a/EIPS/eip-4788.md
+++ b/EIPS/eip-4788.md
@@ -28,7 +28,7 @@ restaking constructions, smart contract bridges, MEV mitigations and more.
 | constants                    | value                                        | units
 |---                           |---                                           |---
 | `FORK_TIMESTAMP`             | TBD                                          |
-| `HISTORY_STORAGE_ADDRESS`    | `0xfffffffffffffffffffffffffffffffffffffffd` |
+| `HISTORY_STORAGE_ADDRESS`    | `Bytes20(0xB)`                               |
 | `G_beacon_root`              | 2100                                         | gas
 
 ### Background


### PR DESCRIPTION
I moved the 4844 precompile to the next available address in #7172 

and this PR updates the precompile address for 4788 to be right after that