### PR TITLE
Update EIP-6093: Improve specification clarity

### DIFF
--- a/EIPS/eip-6093.md
+++ b/EIPS/eip-6093.md
@@ -32,9 +32,9 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 The following errors were designed according to the criteria described in [Rationale](#rationale).
 
-This EIP defines standard errors that may be used by implementations in certain scenarios, but does not specify whether implementations should revert in those scenarios, which remains up to the implementers, unless a revert is mandated by the corresponding EIPs.
+This EIP defines standard errors that may be used by implementations in certain scenarios but it does not specify whether implementations should revert in those scenarios, which remains up to the implementers unless a revert is mandated by the corresponding EIPs.
 
-The names of the error arguments are defined in the [Parameter Glossary](#parameter-glossary), and MUST be used according to those definitions.
+The names of the error arguments are defined in the [Parameter Glossary](#parameter-glossary) and MUST be used according to those definitions.
 
 ### [ERC-20](./eip-20.md)
 
@@ -43,15 +43,18 @@ The names of the error arguments are defined in the [Parameter Glossary](#parame
 Indicates an error related to the current `balance` of a `sender`.
 Used in transfers.
 
-- MUST be used when `balance` is less than `needed`.
-- MUST NOT be used if `balance` is greater than or equal to `needed`.
+Usage guidelines:
+
+- `balance` MUST be less than `needed`.
 
 #### `ERC20InvalidSender(address sender)`
 
 Indicates a failure with the token `sender`.
 Used in transfers.
 
-- MUST be used for disallowed transfers from the zero address.
+Usage guidelines:
+
+- RECOMMENDED for disallowed transfers from the zero address.
 - MUST NOT be used for approval operations.
 - MUST NOT be used for balance or allowance requirements.
   - Use `ERC20InsufficientBalance` or `ERC20InsufficientAllowance` instead.
@@ -61,8 +64,10 @@ Used in transfers.
 Indicates a failure with the token `receiver`.
 Used in transfers.
 
-- MUST be used for disallowed transfers to the zero address.
-- MUST be used for disallowed transfers to non-compatible addresses (eg. contract addresses).
+Usage guidelines:
+
+- RECOMMENDED for disallowed transfers to the zero address.
+- RECOMMENDED for disallowed transfers to non-compatible addresses (eg. contract addresses).
 - MUST NOT be used for approval operations.
 
 #### `ERC20InsufficientAllowance(address spender, uint256 allowance, uint256 needed)`
@@ -70,15 +75,18 @@ Used in transfers.
 Indicates a failure with the `spender`'s `allowance`.
 Used in transfers.
 
-- MUST be used when `allowance` is less than `needed`.
-- MUST NOT be used if `allowance` is greater than or equal to `needed`.
+Usage guidelines:
+
+- `allowance` MUST be less than `needed`.
 
 #### `ERC20InvalidApprover(address approver)`
 
 Indicates a failure with the `approver` of a token to be approved.
 Used in approvals.
 
-- MUST be used for disallowed approvals from the zero address.
+Usage guidelines:
+
+- RECOMMENDED for disallowed approvals from the zero address.
 - MUST NOT be used for transfer operations.
 
 #### `ERC20InvalidSpender(address spender)`
@@ -86,34 +94,42 @@ Used in approvals.
 Indicates a failure with the `spender` to be approved.
 Used in approvals.
 
-- MUST be used for disallowed approvals to the zero address.
-- MUST be used for disallowed approvals to the owner itself.
+Usage guidelines:
+
+- RECOMMENDED for disallowed approvals to the zero address.
+- RECOMMENDED for disallowed approvals to the owner itself.
 - MUST NOT be used for transfer operations.
   - Use `ERC20InsufficientAllowance` instead.
 
 ### [ERC-721](./eip-721.md)
 
-### `ERC721InvalidOwner(address owner)`
+#### `ERC721InvalidOwner(address owner)`
 
 Indicates that an address can't be an owner.
 Used in balance queries.
 
-- MUST be used for addresses whose ownership is disallowed (eg. ERC-721 explicitly disallows `address(0)` to be an owner).
-- MUST not be used for transfers.
+Usage guidelines:
+
+- RECOMMENDED for addresses whose ownership is disallowed (eg. ERC-721 explicitly disallows `address(0)` to be an owner).
+- MUST NOT be used for transfers.
   - Use `ERC721IncorrectOwner` instead.
 
-### `ERC721NonexistentToken(uint256 tokenId)`
+#### `ERC721NonexistentToken(uint256 tokenId)`
 
 Indicates a `tokenId` whose `owner` is the zero address.
 
-- MUST be used when attempting to interact with a non-minted or burned token.
+Usage guidelines:
+
+- The `tokenId` MUST BE a non-minted or burned token.
 
 #### `ERC721IncorrectOwner(address sender, uint256 tokenId, address owner)`
 
 Indicates an error related to the ownership over a particular token.
 Used in transfers.
 
-- MUST be used when `sender` is not `owner`.
+Usage guidelines:
+
+- `sender` MUST NOT be `owner`.
 - MUST NOT be used for approval operations.
 
 #### `ERC721InvalidSender(address sender)`
@@ -121,7 +137,9 @@ Used in transfers.
 Indicates a failure with the token `sender`.
 Used in transfers.
 
-- MUST be used for disallowed transfers from the zero address.
+Usage guidelines:
+
+- RECOMMENDED for disallowed transfers from the zero address.
 - MUST NOT be used for approval operations.
 - MUST NOT be used for ownership or approval requirements.
   - Use `ERC721IncorrectOwner` or `ERC721InsufficientApproval` instead.
@@ -131,8 +149,10 @@ Used in transfers.
 Indicates a failure with the token `receiver`.
 Used in transfers.
 
-- MUST be used for disallowed transfers to the zero address.
-- MUST be used for disallowed transfers to non-`ERC721TokenReceiver` contracts or those that reject a transfer. (eg. returning an invalid response in `onERC721Received`).
+Usage guidelines:
+
+- RECOMMENDED for disallowed transfers to the zero address.
+- RECOMMENDED for disallowed transfers to non-`ERC721TokenReceiver` contracts or those that reject a transfer. (eg. returning an invalid response in `onERC721Received`).
 - MUST NOT be used for approval operations.
 
 #### `ERC721InsufficientApproval(address operator, uint256 tokenId)`
@@ -140,15 +160,19 @@ Used in transfers.
 Indicates a failure with the `operator`'s approval.
 Used in transfers.
 
-- MUST be used when operator `isApprovedForAll(owner, operator)` is false.
-- MUST be used when operator `getApproved(tokenId)` is not `operator`.
+Usage guidelines:
+
+- `isApprovedForAll(owner, operator)` MUST be false for the `tokenId`'s owner and `operator`.
+- `getApproved(tokenId)` MUST not be `operator`.
 
 #### `ERC721InvalidApprover(address approver)`
 
 Indicates a failure with the `owner` of a token to be approved.
 Used in approvals.
 
-- MUST be used for disallowed approvals from the zero address.
+Usage guidelines:
+
+- RECOMMENDED for disallowed approvals from the zero address.
 - MUST NOT be used for transfer operations.
 
 #### `ERC721InvalidOperator(address operator)`
@@ -156,8 +180,10 @@ Used in approvals.
 Indicates a failure with the `operator` to be approved.
 Used in approvals.
 
-- MUST be used for disallowed approvals to the zero address.
-- MUST be used for disallowed approvals to the owner itself.
+Usage guidelines:
+
+- RECOMMENDED for disallowed approvals to the zero address.
+- The `operator` MUST NOT be the owner of the approved token.
 - MUST NOT be used for transfer operations.
   - Use `ERC721InsufficientApproval` instead.
 
@@ -168,15 +194,18 @@ Used in approvals.
 Indicates an error related to the current `balance` of a `sender`.
 Used in transfers.
 
-- MUST be used when `balance` is less than `needed` for a `tokenId`.
-- MUST NOT be used if `balance` is greater than or equal to `needed` for a `tokenId`.
+Usage guidelines:
+
+- `balance` MUST be less than `needed` for a `tokenId`.
 
 #### `ERC1155InvalidSender(address sender)`
 
 Indicates a failure with the token `sender`.
 Used in transfers.
 
-- MUST be used for disallowed transfers from the zero address.
+Usage guidelines:
+
+- RECOMMENDED for disallowed transfers from the zero address.
 - MUST NOT be used for approval operations.
 - MUST NOT be used for balance or allowance requirements.
   - Use `ERC1155InsufficientBalance` or `ERC1155InsufficientApprovalForAll` instead.
@@ -186,8 +215,10 @@ Used in transfers.
 Indicates a failure with the token `receiver`.
 Used in transfers.
 
-- MUST be used for disallowed transfers to the zero address.
-- MUST be used for disallowed transfers to non-`ERC1155TokenReceiver` contracts or those that reject a transfer. (eg. returning an invalid response in `onERC1155Received`).
+Usage guidelines:
+
+- RECOMMENDED for disallowed transfers to the zero address.
+- RECOMMENDED for disallowed transfers to non-`ERC1155TokenReceiver` contracts or those that reject a transfer. (eg. returning an invalid response in `onERC1155Received`).
 - MUST NOT be used for approval operations.
 
 #### `ERC1155InsufficientApprovalForAll(address operator, address owner)`
@@ -195,14 +226,18 @@ Used in transfers.
 Indicates a failure with the `operator`'s approval in a transfer.
 Used in transfers.
 
-- MUST be used when operator `isApprovedForAll(owner, operator, tokenId)` is false.
+Usage guidelines:
+
+- `isApprovedForAll(owner, operator)` MUST be false for the `tokenId`'s owner and `operator`.
 
 #### `ERC1155InvalidApprover(address approver)`
 
 Indicates a failure with the `approver` of a token to be approved.
 Used in approvals.
 
-- MUST be used for disallowed approvals from the zero address.
+Usage guidelines:
+
+- RECOMMENDED for disallowed approvals from the zero address.
 - MUST NOT be used for transfer operations.
 
 #### `ERC1155InvalidOperator(address operator)`
@@ -210,7 +245,9 @@ Used in approvals.
 Indicates a failure with the `operator` to be approved.
 Used in approvals.
 
-- MUST be used for disallowed approvals to the zero address.
+Usage guidelines:
+
+- RECOMMENDED for disallowed approvals to the zero address.
 - MUST be used for disallowed approvals to the owner itself.
 - MUST NOT be used for transfer operations.
   - Use `ERC1155InsufficientApproval` instead.
@@ -220,7 +257,9 @@ Used in approvals.
 Indicates an array length mismatch between `ids` and `values` in a `safeBatchTransferFrom` operation.
 Used in batch transfers.
 
-- MUST be used only if `idsLength` is different from `valuesLength`
+Usage guidelines:
+
+- `idsLength` MUST NOT be `valuesLength`.
 
 ### Parameter Glossary
 
@@ -250,12 +289,12 @@ Considering this, the error names are designed following a basic grammatical str
 
 ### Actions and subjects
 
-The main actions that can be performed within a token are:
+An error is defined based on the following **actions** that can be performed on a token and its involved _subjects_:
 
 - **Transfer**: An operation in which a _sender_ moves to a _receiver_ any number of tokens (fungible _balance_ and/or non-fungible _token ids_).
 - **Approval**: An operation in which an _approver_ grants any form of _approval_ to an _operator_.
 
-The subjects outlined above are expected to exhaustively represent _what_ can go wrong in a token transaction, deriving a specific error by adding an [error prefix](#error-prefixes).
+These attempt to exhaustively represent what can go wrong in a token operation. Therefore, the errors can be constructed by specifying which _subject_ failed during an **action** execution, and prefixing with an [error prefix](#error-prefixes).
 
 Note that the action is never seen as the subject of an error.
 


### PR DESCRIPTION
Updated the use of `MUST` for each error and clarify its usage guidelines.
Also, updated the titles for `ERC721InvalidOwner(address owner)` and `ERC721NonexistentToken(uint256 tokenId)` so they don't show up in the table of contents