### PR TITLE
Update EIP-3076: Update eip-3076.md

### DIFF
--- a/EIPS/eip-3076.md
+++ b/EIPS/eip-3076.md
@@ -173,14 +173,15 @@ After importing an interchange file with data field `data`, a signer must respec
 2. Refuse to sign any block with `slot <= min(b.slot for b in data.signed_blocks if b.pubkey == proposer_pubkey)`, except if it is a repeat signing as determined by the `signing_root`.
 
 3. Refuse to sign any attestation that is slashable with respect to the attestations contained in `data.signed_attestations`. For details of what constitutes a slashable attestation, see `is_slashable_attestation_data`.
+
 4. Refuse to sign any attestation with source epoch less than the minimum source epoch present in that signer's attestations (as seen in `data.signed_attestations`). In pseudocode:
 
-```python3
-source.epoch <
-    min(att.source_epoch
-        for att in data.signed_attestations
-        if att.pubkey == attester_pubkey)
-```
+  ```python3
+  source.epoch <
+      min(att.source_epoch
+          for att in data.signed_attestations
+          if att.pubkey == attester_pubkey)
+  ```
 
 5. Refuse to sign any attestation with target epoch less than or equal to the minimum target epoch present in that signer's attestations (as seen in `data.signed_attestations`), except if it is a repeat signing as determined by the `signing_root`. In pseudocode:
 


### PR DESCRIPTION
Fix ordered list rendering issue

Adding blank line after `4. Refuse to sign...` to comply with the markdown linter seems to reset the HTML ordered list...
![image](https://github.com/ethereum/EIPs/assets/4943830/0c32e09e-f285-4e44-82d9-dc38a8ab878f)

This PR removes the blank line. (The markdown linter will complain, but at least the HTML rendering will be OK.)