### PR TITLE
Update EIP-1 : allow multi file commit urls

### DIFF
--- a/EIPS/eip-1.md
+++ b/EIPS/eip-1.md
@@ -213,7 +213,7 @@ Which renders to:
 Permitted Execution Client Specifications URLs must anchor to a specific commit, and so must match this regular expression:
 
 ```regex
-^(https://github.com/ethereum/execution-specs/blob/[0-9a-f]{40}/.*|https://github.com/ethereum/execution-specs/tree/[0-9a-f]{40}/.*)$
+^(https://github.com/ethereum/execution-specs/(blob|commit)/[0-9a-f]{40}/.*|https://github.com/ethereum/execution-specs/tree/[0-9a-f]{40}/.*)$
 ```
 
 ### Consensus Layer Specifications
@@ -231,7 +231,7 @@ Which renders to:
 Permitted Consensus Layer Specifications URLs must anchor to a specific commit, and so must match this regular expression:
 
 ```regex
-^https://github.com/ethereum/consensus-specs/blob/[0-9a-f]{40}/.*$
+^https://github.com/ethereum/consensus-specs/(blob|commit)/[0-9a-f]{40}/.*$
 ```
 
 ### Networking Specifications
@@ -249,7 +249,7 @@ Which renders as:
 Permitted Networking Specifications URLs must anchor to a specific commit, and so must match this regular expression:
 
 ```regex
-^https://github.com/ethereum/devp2p/blob/[0-9a-f]{40}/.*$
+^https://github.com/ethereum/devp2p/(blob|commit)/[0-9a-f]{40}/.*$
 ```
 
 ### World Wide Web Consortium (W3C)


### PR DESCRIPTION
As a followup on the resolution of merging EIP draft PR: 
- https://github.com/ethereum/EIPs/pull/7044

it would be nice to allow these urls (see https://github.com/ethereum/EIPs/issues/7064)

`https://github.com/ethereum/consensus-specs/commit/14212958d3605c5dd4f8ab617f157328f53ce559` (https://github.com/ethereum/consensus-specs/commit/14212958d3605c5dd4f8ab617f157328f53ce559)

which can have multi file diffs to provide much cleaner insight into the changes being proposed.
