### PR TITLE
Update EIP-725: Remove overloading from ERC725

### DIFF
--- a/EIPS/eip-725.md
+++ b/EIPS/eip-725.md
@@ -41,7 +41,7 @@ And the event:
 
 ### `ERC725X`
 
-**`ERC725X`** interface id according to [EIP-165](./eip-165.md): `0x570ef073`.
+**`ERC725X`** interface id according to [EIP-165](./eip-165.md): `0x7545acac`.
 
 Smart contracts implementing the `ERC725X` standard MUST implement the [EIP-165](./eip-165.md) `supportsInterface(..)` function and MUST support the `ERC165` and `ERC725X` interface ids.
 
@@ -106,13 +106,13 @@ data = <contract-creation-code> + <abi-encoded-constructor-arguments> + <bytes32
 
 > See [EIP-1014: Skinny CREATE2](./eip-1014.md) for more information.
 
-#### execute (Array)
+#### executeBatch
 
 ```solidity
-function execute(uint256[] memory operationsType, address[] memory targets, uint256[] memory values, bytes[] memory datas) external payable returns(bytes[] memory)
+function executeBatch(uint256[] memory operationsType, address[] memory targets, uint256[] memory values, bytes[] memory datas) external payable returns(bytes[] memory)
 ```
 
-Function Selector: `0x13ced88d`
+Function Selector: `0x31858452`
 
 Executes a batch of calls on any other smart contracts, transfers the blockchain native token, or deploys a new smart contract.
 
@@ -134,25 +134,6 @@ _Requirements:_
 _Returns:_ `bytes[]` , array list of returned data of the called function, or the address(es) of the contract deployed (operation types 1 and 2).
 
 **Triggers Event:** [ContractCreated](#contractcreated), [Executed](#executed) on each call iteration
-
-
-**Note:** The `execute()` functions use function overloading, therefore it is better to reference them by the given function signature as follows:
-
-```js
-// web3.js example
-
-// execute
-myContract.methods['execute(uint256,address,uint256,bytes)'](OPERATION_CALL, target.address, 2WEI, "0x").send();
-// execute Array 
-myContract.methods['execute(uint256[],address[],uint256[],bytes[])']([OPERATION_CALL, OPERATION_CREATE], [target.address, ZERO_ADDRESS], [2WEI, 0WEI], ["0x", CONTRACT_BYTECODE]).send();
-
-// OR
-
-// execute
-myContract.methods['0x44c028fe'](OPERATION_CALL, target.address, 2WEI, "0x").send();
-// execute Array 
-myContract.methods['0x13ced88d']([OPERATION_CALL, OPERATION_CREATE], [target.address, ZERO_ADDRESS], [2WEI, 0WEI], ["0x", CONTRACT_BYTECODE]).send();
-```
 
 ### `ERC725X` Events
 
@@ -176,7 +157,7 @@ MUST be triggered when `execute` creates a new contract using the `operationType
 
 ### `ERC725Y`
 
-**`ERC725Y`** interface id according to [EIP-165](./eip-165.md): `0x714df77c`.
+**`ERC725Y`** interface id according to [EIP-165](./eip-165.md): `0x629aa694`.
 
 Smart contracts implementing the `ERC725Y` standard MUST implement the [EIP-165](./eip-165.md) `supportsInterface(..)` function and MUST support the `ERC165` and `ERC725Y` interface ids.
 
@@ -200,13 +181,13 @@ _Parameters:_
 
 _Returns:_ `bytes` , The data for the requested data key.
 
-#### getData (Array)
+#### getDataBatch
 
 ```solidity
-function getData(bytes32[] memory dataKeys) external view returns(bytes[] memory)
+function getDataBatch(bytes32[] memory dataKeys) external view returns(bytes[] memory)
 ```
 
-Function Selector: `0x4e3e6e9c`
+Function Selector: `0xdedff9c6`
 
 Gets array of data at multiple given data keys.
 
@@ -237,13 +218,13 @@ _Requirements:_
 
 **Triggers Event:** [DataChanged](#datachanged)
 
-#### setData (Array)
+#### setDataBatch
 
 ```solidity
-function setData(bytes32[] memory dataKeys, bytes[] memory dataValues) external
+function setDataBatch(bytes32[] memory dataKeys, bytes[] memory dataValues) external
 ```
 
-Function Selector: `0x14a6e293`
+Function Selector: `0x97902421`
 
 Sets array of data at multiple data keys. MUST only be called by the current owner of the contract.
 
@@ -258,24 +239,6 @@ _Requirements:_
 - MUST only be called by the current owner of the contract.
 
 **Triggers Event:** [DataChanged](#datachanged)
-
-**Note:** `setData()` and `getData()` uses function overloading, therefore it is better to reference them by the given function signature as follows:
-
-```js
-// web3.js example
-
-// setData
-myContract.methods['setData(bytes32,bytes)'](dataKey, dataValue).send();
-// setData Array
-myContract.methods['setData(bytes32[],bytes[])']([dataKeys, ...], [dataValues, ...]).send();
-
-// OR
-
-// setData
-myContract.methods['0x7f23690c'](dataKey, dataValue).send();
-// setData Array
-myContract.methods['0x14a6e293']([dataKeys, ...], [dataValues, ...]).send();
-```
 
 ### `ERC725Y` Events
 
@@ -304,6 +267,8 @@ The data stored in an `ERC725Y` smart contract is not only readable/writable by 
 
 All contracts since `ERC725v2` from 2018/19 should be compatible with the current version of the standard. Mainly interface ID and Event parameters have changed, while `getData(bytes32[])` and `setData(bytes32[], bytes[])` was added as an efficient way to set/get multiple keys at once. The same applies to execution, as `execute(..[])` was added as an efficient way to batch calls.
 
+From 2023 onward, overloading was removed from ERC725 (including ERC725X and ERC725Y). This is because, while overloading is accommodated in Solidity, it isn't broadly supported across most blockchain languages. In order to make the standard language-independent, it was decided to shift from overloading to simply attach the term "Batch" to the functions that accept an array as parameters.
+
 ## Reference Implementation
 
 Reference implementations can be found in [`ERC725.sol`](../assets/eip-725/ERC725.sol).
@@ -321,7 +286,7 @@ When using the operation type `4` for `delegatecall`, it is important to conside
 
 pragma solidity >=0.5.0 <0.7.0;
 
-// ERC165 identifier: `0x570ef073`
+// ERC165 identifier: `0x7545acac`
 interface IERC725X  /* is ERC165, ERC173 */ {
 
     event Executed(uint256 indexed operationType, address indexed target, uint256 indexed  value, bytes4 data);
@@ -330,19 +295,19 @@ interface IERC725X  /* is ERC165, ERC173 */ {
 
     function execute(uint256 operationType, address target, uint256 value, bytes memory data) external payable returns(bytes memory);
 
-    function execute(uint256[] memory operationsType, address[] memory targets, uint256[] memory values, bytes memory datas) external payable returns(bytes[] memory);
+    function executeBatch(uint256[] memory operationsType, address[] memory targets, uint256[] memory values, bytes memory datas) external payable returns(bytes[] memory);
 }
 
-// ERC165 identifier: `0x714df77c`
+// ERC165 identifier: `0x629aa694`
 interface IERC725Y /* is ERC165, ERC173 */ {
     
     event DataChanged(bytes32 indexed dataKey, bytes dataValue);
 
     function getData(bytes32 dataKey) external view returns(bytes memory);
-    function getData(bytes32[] memory dataKeys) external view returns(bytes[] memory);
+    function getDataBatch(bytes32[] memory dataKeys) external view returns(bytes[] memory);
 
     function setData(bytes32 dataKey, bytes memory dataValue) external;
-    function setData(bytes32[] memory dataKeys, bytes[] memory dataValues) external;
+    function setDataBatch(bytes32[] memory dataKeys, bytes[] memory dataValues) external;
 }
 interface IERC725 /* is IERC725X, IERC725Y */ {
 }

--- a/EIPS/eip-725.md
+++ b/EIPS/eip-725.md
@@ -28,7 +28,7 @@ These standards (`ERC725` X and Y) can also be used separately as `ERC725Y` can 
 ### Ownership
 
 This contract is controlled by a single owner. The owner can be a smart contract or an external account.
-This standard requires [EIP-173](./eip-173.md) and SHOULD implement the functions:
+This standard requires [ERC-173](./eip-173.md) and SHOULD implement the functions:
 
 - `owner() view`
 - `transferOwnership(address newOwner)`
@@ -41,9 +41,9 @@ And the event:
 
 ### `ERC725X`
 
-**`ERC725X`** interface id according to [EIP-165](./eip-165.md): `0x7545acac`.
+**`ERC725X`** interface id according to [ERC-165](./eip-165.md): `0x7545acac`.
 
-Smart contracts implementing the `ERC725X` standard MUST implement the [EIP-165](./eip-165.md) `supportsInterface(..)` function and MUST support the `ERC165` and `ERC725X` interface ids.
+Smart contracts implementing the `ERC725X` standard MUST implement the [ERC-165](./eip-165.md) `supportsInterface(..)` function and MUST support the `ERC165` and `ERC725X` interface ids.
 
 ### `ERC725X` Methods
 
@@ -157,9 +157,9 @@ MUST be triggered when `execute` creates a new contract using the `operationType
 
 ### `ERC725Y`
 
-**`ERC725Y`** interface id according to [EIP-165](./eip-165.md): `0x629aa694`.
+**`ERC725Y`** interface id according to [ERC-165](./eip-165.md): `0x629aa694`.
 
-Smart contracts implementing the `ERC725Y` standard MUST implement the [EIP-165](./eip-165.md) `supportsInterface(..)` function and MUST support the `ERC165` and `ERC725Y` interface ids.
+Smart contracts implementing the `ERC725Y` standard MUST implement the [ERC-165](./eip-165.md) `supportsInterface(..)` function and MUST support the `ERC165` and `ERC725Y` interface ids.
 
 ### `ERC725Y` Methods
 
@@ -267,7 +267,7 @@ The data stored in an `ERC725Y` smart contract is not only readable/writable by 
 
 All contracts since `ERC725v2` from 2018/19 should be compatible with the current version of the standard. Mainly interface ID and Event parameters have changed, while `getData(bytes32[])` and `setData(bytes32[], bytes[])` was added as an efficient way to set/get multiple keys at once. The same applies to execution, as `execute(..[])` was added as an efficient way to batch calls.
 
-From 2023 onward, overloading was removed from ERC725 (including ERC725X and ERC725Y). This is because, while overloading is accommodated in Solidity, it isn't broadly supported across most blockchain languages. In order to make the standard language-independent, it was decided to shift from overloading to simply attach the term "Batch" to the functions that accept an array as parameters.
+From 2023 onward, overloading was removed from ERC-725 (including ERC725X and ERC725Y). This is because, while overloading is accommodated in Solidity, it isn't broadly supported across most blockchain languages. In order to make the standard language-independent, it was decided to shift from overloading to simply attach the term "Batch" to the functions that accept an array as parameters.
 
 ## Reference Implementation
 

--- a/EIPS/eip-725.md
+++ b/EIPS/eip-725.md
@@ -267,7 +267,7 @@ The data stored in an `ERC725Y` smart contract is not only readable/writable by 
 
 All contracts since `ERC725v2` from 2018/19 should be compatible with the current version of the standard. Mainly interface ID and Event parameters have changed, while `getData(bytes32[])` and `setData(bytes32[], bytes[])` was added as an efficient way to set/get multiple keys at once. The same applies to execution, as `execute(..[])` was added as an efficient way to batch calls.
 
-From 2023 onward, overloading was removed from ERC-725 (including ERC725X and ERC725Y). This is because, while overloading is accommodated in Solidity, it isn't broadly supported across most blockchain languages. In order to make the standard language-independent, it was decided to shift from overloading to simply attach the term "Batch" to the functions that accept an array as parameters.
+From 2023 onward, overloading was removed from `ERC-725` (including `ERC725-X` and `ERC725-Y`). This is because, while overloading is accommodated in Solidity, it isn't broadly supported across most blockchain languages. In order to make the standard language-independent, it was decided to shift from overloading to simply attach the term "Batch" to the functions that accept an array as parameters.
 
 ## Reference Implementation
 

--- a/assets/eip-725/ERC725.sol
+++ b/assets/eip-725/ERC725.sol
@@ -178,7 +178,7 @@ interface IERC725X is IERC165 {
      * Emits an {Executed} event, when a call is made with `operationType` 0 (CALL), 3 (STATICCALL) or 4 (DELEGATECALL)
      * Emits a {ContractCreated} event, when deploying a contract with `operationType` 1 (CREATE) or 2 (CREATE2)
      */
-    function execute(
+    function executeBatch(
         uint256[] memory operationsType,
         address[] memory targets,
         uint256[] memory values,
@@ -187,7 +187,7 @@ interface IERC725X is IERC165 {
 }
 
 // ERC165 INTERFACE IDs
-bytes4 constant _INTERFACEID_ERC725X = 0x570ef073;
+bytes4 constant _INTERFACEID_ERC725X = 0x7545acac;
 
 // ERC725X OPERATION TYPES
 uint256 constant OPERATION_0_CALL = 0;
@@ -278,7 +278,7 @@ contract ERC725X is ERC173, ERC165, IERC725X {
     /**
      * @inheritdoc IERC725X
      */
-    function execute(
+    function executeBatch(
         uint256[] memory operationsType,
         address[] memory targets,
         uint256[] memory values,
@@ -536,7 +536,7 @@ interface IERC725Y is IERC165 {
      * @param dataKeys The array of keys which values to retrieve
      * @return dataValues The array of data stored at multiple keys
      */
-    function getData(bytes32[] memory dataKeys)
+    function getDataBatch(bytes32[] memory dataKeys)
         external
         view
         returns (bytes[] memory dataValues);
@@ -559,12 +559,12 @@ interface IERC725Y is IERC165 {
      *
      * Emits a {DataChanged} event.
      */
-    function setData(bytes32[] memory dataKeys, bytes[] memory dataValues)
+    function setDataBatch(bytes32[] memory dataKeys, bytes[] memory dataValues)
         external;
 }
 
 // ERC165 INTERFACE IDs
-bytes4 constant _INTERFACEID_ERC725Y = 0x714df77c;
+bytes4 constant _INTERFACEID_ERC725Y = 0x629aa694;
 
 /**
  * @dev reverts when there is not the same number of elements in the lists of data keys and data values
@@ -615,7 +615,7 @@ contract ERC725Y is ERC173, ERC165, IERC725Y {
     /**
      * @inheritdoc IERC725Y
      */
-    function getData(bytes32[] memory dataKeys)
+    function getDataBatch(bytes32[] memory dataKeys)
         public
         view
         virtual
@@ -644,7 +644,7 @@ contract ERC725Y is ERC173, ERC165, IERC725Y {
     /**
      * @inheritdoc IERC725Y
      */
-    function setData(bytes32[] memory dataKeys, bytes[] memory dataValues)
+    function setDataBatch(bytes32[] memory dataKeys, bytes[] memory dataValues)
         public
         virtual
         onlyOwner


### PR DESCRIPTION
Function overloading is not supported in many blockchain programming languages (vyper, cairo), which can create interoperability issues. To ensure language independence and promote interoperability, it was decided to remove function overloading and simply rename the functions to include the word "batch" when taking an array.