### PR TITLE
Update EIP-5564: update contract name

### DIFF
--- a/EIPS/eip-5564.md
+++ b/EIPS/eip-5564.md
@@ -97,11 +97,11 @@ A one byte integer (`schemeId`) is used to identify stealth address schemes. The
 
 - The algorithm for the `computeStealthKey` method.
 
-This specification additionally defines a singleton `ERC5564Messenger` contract that emits events to announce when something is sent to a stealth address. This MUST be a singleton contract, with one instance per chain. The contract is specified as follows:
+This specification additionally defines a singleton `ERC5564Announcer` contract that emits events to announce when something is sent to a stealth address. This MUST be a singleton contract, with one instance per chain. The contract is specified as follows:
 
 ```solidity
 /// @notice Interface for announcing when something is sent to a stealth address.
-contract IERC5564Messenger {
+contract IERC5564Announcer {
   /// @dev Emitted when sending something to a stealth address.
   /// @dev See the `announce` method for documentation on the parameters.
   event Announcement (
@@ -165,7 +165,7 @@ Stealth meta-addresses may be managed by the user and/or registered within a pub
 
 ### Initial Implementation of SECP256k1 with View Tags
 
-This EIP provides a foundation that is not tied to any specific cryptographic system through the `IERC5564Messenger` contract. In addition, it introduces the first implementation of a [stealth address scheme](../assets/eip-5564/scheme_ids.md) that utilizes the SECP256k1 elliptic curve and view tags. The SECP256k1 elliptic curve is defined with the equation $y^2 = x^3 + 7 \pmod{p}$, where $p = 2^{256} - 2^{32} - 977$.
+This EIP provides a foundation that is not tied to any specific cryptographic system through the `IERC5564Announcer` contract. In addition, it introduces the first implementation of a [stealth address scheme](../assets/eip-5564/scheme_ids.md) that utilizes the SECP256k1 elliptic curve and view tags. The SECP256k1 elliptic curve is defined with the equation $y^2 = x^3 + 7 \pmod{p}$, where $p = 2^{256} - 2^{32} - 977$.
 
 The following reference is divided into three sections:
 


### PR DESCRIPTION
By changing the name of the contract, we aim to make it more aligned with the function name and avoid confusion with "text messaging" services that could potentially be built on top of the proposed standard.
