### PR TITLE
Update EIP-6381: Add recalculated address and fix typos

### DIFF
--- a/EIPS/eip-6381.md
+++ b/EIPS/eip-6381.md
@@ -86,7 +86,7 @@ interface IERC6381 /*is IERC165*/ {
 
     /**
      * @notice Used to get the number of emotes for a specific emoji on a set of tokens.
-     * @param collection An array of addresses of the collections containing the tokens being checked for emoji count
+     * @param collections An array of addresses of the collections containing the tokens being checked for emoji count
      * @param tokenIds An array of IDs of the tokens to check for emoji count
      * @param emojis An array of unicode identifiers of the emojis
      * @return An array of numbers of emotes with the emoji on the tokens
@@ -117,9 +117,9 @@ interface IERC6381 /*is IERC165*/ {
     /**
      * @notice Used to get the information on whether the specified addresses have used specific emojis on specific
      *  tokens.
+     * @param emoters An array of addresses of the accounts we are checking for reactions to tokens
      * @param collections An array of addresses of the collection smart contracts containing the tokens being checked
      *  for emoji reactions
-     * @param emoters An array of addresses of the accounts we are checking for reactions to tokens
      * @param tokenIds An array of IDs of the tokens being checked for emoji reactions
      * @param emojis An array of the ASCII emoji codes being checked for reactions
      * @return An array of boolean values indicating whether the `emoter`s has used the `emoji`s on the tokens (`true`)
@@ -160,13 +160,13 @@ interface IERC6381 /*is IERC165*/ {
      * @param deadlines An array of UNIX timestamps of the deadlines for the signatures to be submitted
      * @return The array of messages to be signed by the `emoter` in order for the reaction to be submitted by someone else
      */
-    function prepareMessageToPresignEmote(
-        address collection,
-        uint256 tokenId,
-        bytes4 emoji,
-        bool state,
-        uint256 deadline
-    ) external view returns (bytes32);
+    function bulkPrepareMessagesToPresignEmote(
+        address[] memory collections,
+        uint256[] memory tokenIds,
+        bytes4[] memory emojis,
+        bool[] memory states,
+        uint256[] memory deadlines
+    ) external view returns (bytes32[] memory);
 
     /**
      * @notice Used to emote or undo an emote on a token.
@@ -212,7 +212,7 @@ interface IERC6381 /*is IERC165*/ {
      * @param collection The address of the collection smart contract containing the token being emoted at
      * @param tokenId IDs of the token being emoted
      * @param emoji Unicode identifier of the emoji
-     * @param states Boolean value signifying whether to emote (`true`) or undo (`false`) emote
+     * @param state Boolean value signifying whether to emote (`true`) or undo (`false`) emote
      * @param deadline UNIX timestamp of the deadline for the signature to be submitted
      * @param v `v` value of an ECDSA signature of the message obtained via `prepareMessageToPresignEmote`
      * @param r `r` value of an ECDSA signature of the message obtained via `prepareMessageToPresignEmote`
@@ -242,7 +242,7 @@ interface IERC6381 /*is IERC165*/ {
      * @param tokenIds An array of IDs of the tokens being emoted
      * @param emojis An array of unicode identifiers of the emojis
      * @param states An array of boolean values signifying whether to emote (`true`) or undo (`false`) emote
-     * @param deadline UNIX timestamp of the deadline for the signature to be submitted
+     * @param deadlines UNIX timestamp of the deadline for the signature to be submitted
      * @param v An array of `v` values of an ECDSA signatures of the messages obtained via `prepareMessageToPresignEmote`
      * @param r An array of `r` values of an ECDSA signatures of the messages obtained via `prepareMessageToPresignEmote`
      * @param s An array of `s` values of an ECDSA signatures of the messages obtained via `prepareMessageToPresignEmote`
@@ -307,7 +307,7 @@ Each chain, that the Emotable repository smart contract is deployed on, will hav
 The address of the Emotable repository smart contract is designed to resemble the function it serves. It starts with `0x311073` which is the abstract representation of `EMOTE`. The address is:
 
 ```
-0x311073569e12f7770719497cd3b3aa2db0a0c3d9
+0x31107354b61A0412E722455A771bC462901668eA
 ```
 
 ## Rationale


### PR DESCRIPTION
The newly recalculated address that was required to be added after the changes to the proposal were added.
Some additional typos were fixed.