### PR TITLE
Update EIP-5793: change size type to prevent leading zeros

### DIFF
--- a/EIPS/eip-5793.md
+++ b/EIPS/eip-5793.md
@@ -28,7 +28,7 @@ The added metadata fields will also enable future - upgradeless - protocol tweak
 Modify the `NewPooledTransactionHashes (0x08)` message:
 
 * **(eth/67)**: `[hash_0: B_32, hash_1: B_32, ...]`
-* **(eth/68)**: `[[type_0: B_1, type_1: B_1, ...], [size_0: B_4, size_1: B_4, ...], [hash_0: B_32, hash_1: B_32, ...]]`
+* **(eth/68)**: `[[type_0: B_1, type_1: B_1, ...], [size_0: P, size_1: P, ...], [hash_0: B_32, hash_1: B_32, ...]]`
 
 ## Rationale
 


### PR DESCRIPTION
changes the type of the size to P which implies non-leading zeros as discussed with @tbenr