### PR TITLE
Update EIP-6909: Author's github not being correctly rendered

### DIFF
--- a/EIPS/eip-6909.md
+++ b/EIPS/eip-6909.md
@@ -2,7 +2,7 @@
 eip: 6909
 title: Minimal Multi-Token Interface
 description: A minimal specification for managing multiple tokens by their id in a single contract.
-author: Joshua Trujillo (@jtriley)
+author: Joshua Trujillo (@jtriley-eth)
 discussions-to: https://ethereum-magicians.org/t/eip-6909-multi-token-standard/13891
 status: Draft
 type: Standards Track


### PR DESCRIPTION
The author being "jtriley" renders to https://github.com/jtriley on the EIPs website, when in reality the author is "jtriley-eth" --> https://github.com/jtriley-eth