### PR TITLE
Update EIP-6059: Clarify the backwards compatibility section

### DIFF
--- a/EIPS/eip-6059.md
+++ b/EIPS/eip-6059.md
@@ -450,6 +450,8 @@ This state change places the token in the pending array of the new parent token.
 
 The Nestable token standard has been made compatible with [ERC-721](./eip-721.md) in order to take advantage of the robust tooling available for implementations of ERC-721 and to ensure compatibility with existing ERC-721 infrastructure.
 
+The only incompatible part of the specification is the restriction to not use the token ID of 0.
+
 ## Test Cases
 
 Tests are included in [`nestable.ts`](../assets/eip-6059/test/nestable.ts).


### PR DESCRIPTION
The backwards compatibility section was updated to further clarify the proposal's relationship to EIP-721.