### PR TITLE
Update EIP-4337: align `eth_estimateUserOperationGas` result with the bundler spec

### DIFF
--- a/EIPS/eip-4337.md
+++ b/EIPS/eip-4337.md
@@ -699,7 +699,7 @@ Still, it might require putting a "semi-valid" signature (e.g. a signature in th
 **Return Values:**
 
 * **preVerificationGas** gas overhead of this UserOperation
-* **verificationGasLimit** actual gas used by the validation of this UserOperation
+* **verificationGas** actual gas used by the validation of this UserOperation
 * **callGasLimit** value used by inner account execution
 
 ##### Error Codes:


### PR DESCRIPTION
According to the definition of [bundler-spec](https://github.com/eth-infinitism/bundler-spec/blob/9cafd4be1d9b21221a57bc06c219a73cbd6cdebd/src/schemas/transaction.yaml#L365), the validation gas result of the `eth_estimateUserOperationGas` should be called `verificationGas` without suffix `Limit`