### PR TITLE
Update EIP-4361: Various Updates to EIP-4361 - Sign-In with Ethereum

### DIFF
--- a/EIPS/eip-4361.md
+++ b/EIPS/eip-4361.md
@@ -257,6 +257,7 @@ Resources:
 The following is a RECOMMENDED algorithm for Wallets to conform with the requirements on request origin verification defined by this specification.
 
 The algorithm takes the following input variables:
+
 - fields from the SIWE message.
 - `origin` of the signing request - in the case of a browser wallet implementation - the origin of the page which requested the signin via the provider.
 - `allowedSchemes` - a list of schemes allowed by the Wallet.
@@ -264,6 +265,7 @@ The algorithm takes the following input variables:
 - developer mode indication - a setting deciding if certain risks should be a warning instead of rejection. Can be manually configured or derived from `origin` being localhost.
 
 The algorithm is described as follows:
+
 - If `scheme` was not provided, then assign `defaultScheme` as `scheme`.
 - If `scheme` is not contained in `allowedSchemes`, then the `scheme` is not expected and the Wallet MUST reject the request. Wallet implementers in the browser SHOULD limit the list of `allowedSchemes` to just `'https'` unless a developer mode is activated.
 - If `scheme` does not match the scheme of `origin`, the Wallet SHOULD reject the request. Wallet implementers MAY show a warning instead of rejecting the request if a developer mode is activated. In that case the Wallet continues processing the request.

--- a/EIPS/eip-4361.md
+++ b/EIPS/eip-4361.md
@@ -2,7 +2,7 @@
 eip: 4361
 title: Sign-In with Ethereum
 description: Off-chain authentication for Ethereum accounts to establish sessions.
-author: Wayne Chang (@wyc), Gregory Rocco (@obstropolos), Brantly Millegan (@brantlymillegan), Nick Johnson (@Arachnid)
+author: Wayne Chang (@wyc), Gregory Rocco (@obstropolos), Brantly Millegan (@brantlymillegan), Nick Johnson (@Arachnid), Oliver Terbu (@awoie)
 discussions-to: https://ethereum-magicians.org/t/eip-4361-sign-in-with-ethereum/7263
 status: Review
 type: Standards Track
@@ -23,79 +23,26 @@ Already, many services support workflows to authenticate Ethereum accounts using
 
 ## Specification
 
-Sign-In with Ethereum works as follows:
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
 
-1. The wallet presents the user with a structured plaintext message or equivalent interface for signing with the [ERC-191](./eip-191.md) signed data format. Before signing, the `message` is prefixed with `\x19Ethereum Signed Message:\n<length of message>` as defined in [ERC-191](./eip-191.md).
-The `message` MUST incorporate an Ethereum `address`,  `domain` requesting the signing, `version` of the message, a chain identifier `chain-id`, `uri` for scoping, `nonce` acceptable to the relying party, and `issued-at` timestamp.
-2. The signature is then presented to the relying party, which checks the signature's validity and message content.
-3. Additional fields, including `expiration-time`, `not-before`, `request-id`, `statement`, and `resources` MAY be incorporated as part of the sign-in process.
-4. The relying party MAY further fetch data associated with the Ethereum address, such as from the Ethereum blockchain (e.g., ENS, account balances, [ERC-20](./eip-20.md)/[ERC-721](./eip-721.md)/[ERC-1155](./eip-1155.md) asset ownership), or other data sources that might or might not be permissioned.
+### Overview
 
-### Example message
+Sign-In with Ethereum (SIWE) works as follows:
 
-```
-service.invalid wants you to sign in with your Ethereum account:
-0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2
+1. The relying party generates a SIWE Message and prefixes the SIWE Message with `\x19Ethereum Signed Message:\n<length of message>` as defined in [ERC-191](./eip-191.md).
+2. The wallet presents the user with a structured plaintext message or equivalent interface for signing the SIWE Message with the [ERC-191](./eip-191.md) signed data format.
+3. The signature is then presented to the relying party, which checks the signature's validity and SIWE Message content.
+4. The relying party might further fetch data associated with the Ethereum address, such as from the Ethereum blockchain (e.g., ENS, account balances, [ERC-20](./eip-20.md)/[ERC-721](./eip-721.md)/[ERC-1155](./eip-1155.md) asset ownership), or other data sources that might or might not be permissioned.
 
-I accept the ServiceOrg Terms of Service: https://service.invalid/tos
+### Message Format
 
-URI: https://service.invalid/login
-Version: 1
-Chain ID: 1
-Nonce: 32891756
-Issued At: 2021-09-30T16:25:24Z
-Resources:
-- ipfs://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq/
-- https://example.com/my-web2-claim.json
-```
+#### ABNF Message Format
 
-### Informal Message Template
-
-A Bash-like informal template of the full message is presented below for readability and ease of understanding. Field descriptions are provided in the following section. A full ABNF description is provided in the section thereafter.
-
-```
-${domain} wants you to sign in with your Ethereum account:
-${address}
-
-${statement}
-
-URI: ${uri}
-Version: ${version}
-Chain ID: ${chain-id}
-Nonce: ${nonce}
-Issued At: ${issued-at}
-Expiration Time: ${expiration-time}
-Not Before: ${not-before}
-Request ID: ${request-id}
-Resources:
-- ${resources[0]}
-- ${resources[1]}
-...
-- ${resources[n]}
-```
-
-### Message Field Descriptions
-
-- `domain` is the RFC 3986 authority that is requesting the signing.
-- `address` is the Ethereum address performing the signing conformant to capitalization encoded checksum specified in [ERC-55](./eip-55.md) where applicable.
-- `statement` (optional) is a human-readable ASCII assertion that the user will sign, and it must not contain `'\n'` (the byte `0x0a`).
-- `uri` is an RFC 3986 URI referring to the resource that is the subject of the signing (as in the _subject of a claim_).
-- `version` is the current version of the `message`, which MUST be `1` for this specification.
-- `chain-id` is the [EIP-155](./eip-155.md) Chain ID to which the session is bound, and the network where Contract Accounts MUST be resolved.
-- `nonce` is a randomized token typically chosen by the relying party and used to prevent replay attacks, at least 8 alphanumeric characters.
-- `issued-at` is the ISO 8601 datetime string of the current time.
-- `expiration-time` (optional) is the ISO 8601 datetime string that, if present, indicates when the signed authentication message is no longer valid.
-- `not-before` (optional) is the ISO 8601 datetime string that, if present, indicates when the signed authentication message will become valid.
-- `request-id` (optional) is an system-specific identifier that may be used to uniquely refer to the sign-in request.
-- `resources` (optional) is a list of information or references to information the user wishes to have resolved as part of authentication by the relying party. They are expressed as RFC 3986 URIs separated by `"\n- "` where `\n` is the byte `0x0a`.
-
-### ABNF Message Format
-
-The `message` MUST conform with the following Augmented Backus–Naur Form (ABNF, RFC 5234) expression (note that `%s` denotes case sensitivity for a string term, as per RFC 7405).
+A SIWE Message MUST conform with the following Augmented Backus–Naur Form (ABNF, RFC 5234) expression (note that `%s` denotes case sensitivity for a string term, as per RFC 7405).
 
 ```abnf
 sign-in-with-ethereum =
-    domain %s" wants you to sign in with your Ethereum account:" LF
+    [ scheme "://" ] domain %s" wants you to sign in with your Ethereum account:" LF
     address LF
     LF
     [ statement LF ]
@@ -110,6 +57,10 @@ sign-in-with-ethereum =
     [ LF %s"Request ID: " request-id ]
     [ LF %s"Resources:"
     resources ]
+
+scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
+    ; See RFC 3986 for the fully contextualized
+    ; definition of "scheme".
 
 domain = authority
     ; From RFC 3986:
@@ -153,7 +104,106 @@ resources = *( LF resource )
 resource = "- " URI
 ```
 
-#### Signing and Verifying with Ethereum Accounts
+#### Message Fields
+
+This specification defines the following SIWE Message fields that can be parsed from a SIWE Message by following the rules in [ABNF Message Format](#abnf-message-format):
+
+- `scheme` OPTIONAL. The URI scheme of the origin of the request. Its value MUST be a RFC 3986 URI scheme.
+- `domain` REQUIRED. The domain that is requesting the signing. Its value MUST be a RFC 3986 authority. The authority includes an OPTIONAL port. If the port is not specified, the default port for the provided `scheme` is assumed (e.g., 443 for HTTPS). If `scheme` is not specified, HTTPS is assumed by default.
+- `address` REQUIRED. The Ethereum address performing the signing. Its value SHOULD be conformant to mixed-case checksum address encoding specified in [ERC-55](./eip-55.md) where applicable.
+- `statement` OPTIONAL. A human-readable ASCII assertion that the user will sign which MUST NOT include `'\n'` (the byte `0x0a`).
+- `uri` REQUIRED. An RFC 3986 URI referring to the resource that is the subject of the signing (as in the _subject of a claim_).
+- `version` REQUIRED. The current version of the SIWE Message, which MUST be `1` for this specification.
+- `chain-id` REQUIRED. The [EIP-155](./eip-155.md) Chain ID to which the session is bound, and the network where Contract Accounts MUST be resolved.
+- `nonce` REQUIRED. A random string typically chosen by the relying party and used to prevent replay attacks, at least 8 alphanumeric characters.
+- `issued-at` REQUIRED. The time when the message was generated, typically the current time. Its value MUST be an ISO 8601 datetime string.
+- `expiration-time` OPTIONAL. The time when the signed authentication message is no longer valid. Its value MUST be an ISO 8601 datetime string.
+- `not-before` OPTIONAL. The time when the signed authentication message will become valid. Its value MUST be an ISO 8601 datetime string.
+- `request-id` OPTIONAL. An system-specific identifier that MAY be used to uniquely refer to the sign-in request.
+- `resources` OPTIONAL. A list of information or references to information the user wishes to have resolved as part of authentication by the relying party. Every resource MUST be a RFC 3986 URI separated by `"\n- "` where `\n` is the byte `0x0a`.
+
+#### Informal Message Template
+
+A Bash-like informal template of the full SIWE Message is presented below for readability and ease of understanding, and it does not reflect the allowed optionality of the fields. Field descriptions are provided in the following section. A full ABNF description is provided in [ABNF Message Format](#abnf-message-format).
+
+```
+${scheme}:// ${domain} wants you to sign in with your Ethereum account:
+${address}
+
+${statement}
+
+URI: ${uri}
+Version: ${version}
+Chain ID: ${chain-id}
+Nonce: ${nonce}
+Issued At: ${issued-at}
+Expiration Time: ${expiration-time}
+Not Before: ${not-before}
+Request ID: ${request-id}
+Resources:
+- ${resources[0]}
+- ${resources[1]}
+...
+- ${resources[n]}
+```
+
+#### Examples
+
+The following is an example SIWE Message with an implicit scheme:
+
+```
+example.com wants you to sign in with your Ethereum account:
+0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2
+
+I accept the ExampleOrg Terms of Service: https://example.com/tos
+
+URI: https://example.com/login
+Version: 1
+Chain ID: 1
+Nonce: 32891756
+Issued At: 2021-09-30T16:25:24Z
+Resources:
+- ipfs://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq/
+- https://example.com/my-web2-claim.json
+```
+
+The following is an example SIWE Message with an implicit scheme and explicit port:
+
+```
+example.com:3388 wants you to sign in with your Ethereum account:
+0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2
+
+I accept the ExampleOrg Terms of Service: https://example.com/tos
+
+URI: https://example.com/login
+Version: 1
+Chain ID: 1
+Nonce: 32891756
+Issued At: 2021-09-30T16:25:24Z
+Resources:
+- ipfs://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq/
+- https://example.com/my-web2-claim.json
+```
+
+The following is an example SIWE Message with an explicit scheme:
+
+```
+https://example.com wants you to sign in with your Ethereum account:
+0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2
+
+I accept the ExampleOrg Terms of Service: https://example.com/tos
+
+URI: https://example.com/login
+Version: 1
+Chain ID: 1
+Nonce: 32891756
+Issued At: 2021-09-30T16:25:24Z
+Resources:
+- ipfs://bafybeiemxf5abjwjbikoz4mc3a3dla6ual3jsgpdr4cjr3oz3evfyavhwq/
+- https://example.com/my-web2-claim.json
+```
+
+### Signing and Verifying Messages with Ethereum Accounts
 
 - For Externally Owned Accounts (EOAs), the verification method specified in [ERC-191](./eip-191.md) MUST be used.
 
@@ -172,38 +222,63 @@ resource = "- " URI
 
 ### Relying Party Implementer Steps
 
-#### Verifying a signed `message`
+#### Specifying the Request Origin
 
-- The message MUST be checked for conformance to the ABNF above, checked against expected term values after parsing, and its signature MUST be verified.
+- The `domain` and, if present, the `scheme`, in the SIWE Message MUST correspond to the origin from where the signing request was made. For instance, if the signing request is made within a cross-origin iframe embedded in a parent browser window, the `domain` (and, if present, the `scheme`) have to match the origin of the iframe, rather than the origin of the parent. This is crucial to prevent the iframe from falsely asserting the origin of one of its ancestor windows for security reasons. This behavior is enforced by conforming wallets.
 
-#### Creating sessions
+#### Verifying a signed Message
+
+- The SIWE Message MUST be checked for conformance to the ABNF Message Format in the previous sections, checked against expected values after parsing (e.g., `expiration-time`, `nonce`, `request-uri` etc.), and its signature MUST be checked as defined in [Signing and Verifying Messages with Ethereum Accounts](#signing-and-verifying-messages-with-ethereum-accounts).
+
+#### Creating Sessions
 
 - Sessions MUST be bound to the `address` and not to further resolved resources that can change.
 
-#### Interpreting and resolving `resources`
+#### Interpreting and resolving Resources
 
-- The listed `resources` MUST be RFC 3986 URIs, but their interpretation is out of scope of this specification.
-- Implementers SHOULD ensure that that URIs are human-friendly when expressed in plaintext form.
+- Implementers SHOULD ensure that that URIs in the listed `resources` are human-friendly when expressed in plaintext form.
+- The intepretation of the listed `resources` in the SIWE Message is out of scope of this specification.
 
 ### Wallet Implementer Steps
 
-#### Verifying `message`
+#### Verifying the Message Format
 
-- The full `message` MUST be checked for conformance to the ABNF above.
+- The full SIWE message MUST be checked for conformance to the ABNF defined in [ABNF Message Format](#abnf-message-format).
 - Wallet implementers SHOULD warn users if the substring `"wants you to sign in
   with your Ethereum account"` appears anywhere in an [ERC-191](./eip-191.md) message signing
-  request unless the message fully conforms to the format defined in this specification.
+  request unless the message fully conforms to the format defined [ABNF Message Format](#abnf-message-format).
 
-#### Verifying `domain` binding
+#### Verifying the Request Origin
 
-- Wallet implementers MUST prevent phishing attacks by matching on the `domain` term when processing a signing request. For example, when processing the message beginning with `"service.invalid wants you to sign in..."`, the wallet checks that the request actually originated from `service.invalid`.
-- The domain SHOULD be read from a trusted data source such as the browser window or over WalletConnect ([ERC-1328](./eip-1328.md)) sessions for comparison against the signing message contents.
+- Wallet implementers MUST prevent phishing attacks by verifying the origin of the request against the `scheme` and `domain` fields in the SIWE Message. For example, when processing the SIWE message beginning with `"example.com wants you to sign in..."`, the wallet checks that the request actually originated from `https://example.com`.
+- The origin SHOULD be read from a trusted data source such as the browser window or over WalletConnect ([ERC-1328](./eip-1328.md)) sessions for comparison against the signing message contents.
+- Wallet implementers MAY warn instead of rejecting the verification if the origin is pointing to localhost.
 
-#### Creating Sign-In with Ethereum interfaces
+The following is a RECOMMENDED algorithm for Wallets to conform with the requirements on request origin verification defined by this specification.
 
-- Wallet implementers MUST display to the user the following terms from the Sign-In with Ethereum signing request by default and prior to signing, if they are present: `domain`, `address`, `statement`, and `resources`. Other present terms MUST also be made available to the user prior to signing either by default or through an extended interface.
-- Wallet implementers displaying a plaintext `message` to the user SHOULD require the user to scroll to the bottom of the text area prior to signing.
-- Wallet implementers MAY construct a custom Sign-In With Ethereum user interface by parsing the ABNF terms into data elements for use in the interface. The display rules above still apply to custom interfaces.
+The algorithm takes the following input variables:
+- fields from the SIWE message.
+- `origin` of the signing request - in the case of a browser wallet implementation - the origin of the page which requested the signin via the provider.
+- `allowedSchemes` - a list of schemes allowed by the Wallet.
+- `defaultScheme` - a scheme to assume when none was provided. Wallet implementers in the browser SHOULD use `https`.
+- developer mode indication - a setting deciding if certain risks should be a warning instead of rejection. Can be manually configured or derived from `origin` being localhost.
+
+The algorithm is described as follows:
+- If `scheme` was not provided, then assign `defaultScheme` as `scheme`.
+- If `scheme` is not contained in `allowedSchemes`, then the `scheme` is not expected and the Wallet MUST reject the request. Wallet implementers in the browser SHOULD limit the list of `allowedSchemes` to just `'https'` unless a developer mode is activated.
+- If `scheme` does not match the scheme of `origin`, the Wallet SHOULD reject the request. Wallet implementers MAY show a warning instead of rejecting the request if a developer mode is activated. In that case the Wallet continues processing the request.
+- If the `host` part of the `domain` and `origin` do not match, the Wallet MUST reject the request unless the Wallet is in developer mode. In developer mode the Wallet MAY show a warning instead and continues procesing the request.
+- If `domain` and `origin` have mismatching subdomains, the Wallet SHOULD reject the request unless the Wallet is in developer mode. In developer mode the Wallet MAY show a warning instead and continues procesing the request.
+- Let `port` be the port component of `domain`, and if no port is contained in `domain`, assign `port` the default port specified for the `scheme`.
+- If `port` is not empty, then the Wallet SHOULD show a warning if the `port` does not match the port of `origin`.
+- If `port` is empty, then the Wallet MAY show a warning if `origin` contains a specific port. (Note 'https' has a default port of 443 so this only applies if `allowedSchemes` contain unusual schemes)
+- Return request origin verification completed.
+
+#### Creating Sign-In with Ethereum Interfaces
+
+- Wallet implementers MUST display to the user the following fields from the SIWE Message request by default and prior to signing, if they are present: `scheme`, `domain`, `address`, `statement`, and `resources`. Other present fields MUST also be made available to the user prior to signing either by default or through an extended interface.
+- Wallet implementers displaying a plaintext SIWE Message to the user SHOULD require the user to scroll to the bottom of the text area prior to signing.
+- Wallet implementers MAY construct a custom SIWE user interface by parsing the ABNF terms into data elements for use in the interface. The display rules above still apply to custom interfaces.
 
 #### Supporting internationalization (i18n)
 
@@ -247,7 +322,7 @@ The following concerns are out of scope for this version of the specification to
 
 - Additional authentication not based on Ethereum addresses.
 - Authorization to server resources.
-- Interpretation of the URIs in the `resources` term as claims or other resources.
+- Interpretation of the URIs in the `resources` field as claims or other resources.
 - The specific mechanisms to ensure domain-binding.
 - The specific mechanisms to generate nonces and evaluation of their appropriateness.
 - Protocols for use without TLS connections.
@@ -269,55 +344,54 @@ The following items are considered for future support in either through an itera
 
 ## Reference Implementation
 
-A reference implementation is available [here](../assets/eip-4361/example.js). 
+A reference implementation is available [here](../assets/eip-4361/example.js).
 
 ## Security Considerations
 
-### Identifier reuse
+### Identifier Reuse
 
 - Towards perfect privacy, it would be ideal to use a new uncorrelated identifier (e.g., Ethereum address) per digital interaction, selectively disclosing the information required and no more.
 - This concern is less relevant to certain user demographics who are likely to be early adopters of this specification, such as those who manage an Ethereum address and/or ENS names intentionally associated with their public presence. These users often prefer identifier reuse to maintain a single correlated identity across many services.
 - This consideration will become increasingly important with mainstream adoption. There are several ways to move towards this model, such as using HD wallets, signed delegations, and zero-knowledge proofs. However, these approaches are out of scope for this specification and better suited for follow-on specifications.
 
-### Key management
+### Key Management
 
 - Sign-In with Ethereum gives users control through their keys. This is additional responsibility that mainstream users may not be accustomed to accepting, and key management is a hard problem especially for individuals. For example, there is no "forgot password" button as centralized identity providers commonly implement.
 - Early adopters of this specification are likely to be already adept at key management, so this consideration becomes more relevant with mainstream adoption.
 - Certain wallets can use smart contracts and multisigs to provide an enhanced user experiences with respect to key usage and key recovery, and these can be supported via [ERC-1271](./eip-1271.md) signing.
 
-### Wallet and relying party combined security
+### Wallet and Relying Party combined Security
 
-- Both the wallet and relying party have to implement this specification for improved security to the end user. Specifically, the wallet MUST confirm that the message is for the correct `domain` or provide the user means to do so manually (such as instructions to visually confirming the correct domain in a TLS-protected website prior to connecting via QR code or deeplink), otherwise the user is subject to phishing attacks.
+- Both the wallet and relying party have to implement this specification for improved security to the end user. Specifically, the wallet has to confirm that the SIWE Message is for the correct request origin or provide the user means to do so manually (such as instructions to visually confirming the correct domain in a TLS-protected website prior to connecting via QR code or deeplink), otherwise the user is subject to phishing attacks.
 
-### Minimizing wallet and server interaction
+### Minimizing Wallet and Server Interaction
 
-- In some implementions of wallet sign-in workflows, the server first sends parameters of the `message` to the wallet. Others generate the message for signing entirely in the client side (e.g., dapps). The latter approach without initial server interaction SHOULD be preferred when there is a user privacy advantage by minimizing wallet-server interaction. Often, the backend server first produces a `nonce` to prevent replay attacks, which it verifies after signing. Privacy-preserving alternatives are suggested in the next section on preventing replay attacks.
-- Before the wallet presents the message signing request to the user, it MAY consult the server for the proper contents of the message to be signed, such as an acceptable `nonce` or requested set of `resources`. When communicating to the server, the wallet SHOULD take precautions to protect user privacy by mitigating user information revealed as much as possible.
+- In some implementions of wallet sign-in workflows, the server first sends parameters of the SIWE Message to the wallet. Others generate the SIWE message for signing entirely in the client side (e.g., dapps). The latter approach without initial server interaction SHOULD be preferred when there is a user privacy advantage by minimizing wallet-server interaction. Often, the backend server first produces a `nonce` to prevent replay attacks, which it verifies after signing. Privacy-preserving alternatives are suggested in the next section on preventing replay attacks.
+- Before the wallet presents the SIWE message signing request to the user, it MAY consult the server for the proper contents of the message to be signed, such as an acceptable `nonce` or requested set of `resources`. When communicating to the server, the wallet SHOULD take precautions to protect user privacy by mitigating user information revealed as much as possible.
 - Prior to signing, the wallet MAY consult the user for preferences, such as the selection of one `address` out of many, or a preferred ENS name out of many.
 
-### Preventing replay attacks
+### Preventing Replay Attacks
 
 - A `nonce` SHOULD be selected per session initiation with enough entropy to prevent replay attacks, a man-in-the-middle attack in which an attacker is able to capture the user's signature and resend it to establish a new session for themselves.
 - Implementers MAY consider using privacy-preserving yet widely-available `nonce` values, such as one derived from a recent Ethereum block hash or a recent Unix timestamp.
 
-### Verification of domain binding
+### Preventing Phishing Attacks
 
-- Wallets MUST check that the `domain` matches the actual signing request source.
-- This value SHOULD be checked against a trusted data source such as the browser window or over another protocol.
+- To prevent phishing attacks Wallets have to implement request origin verification as described in [Verifying the Request Origin](#verifying-the-request-origin).
 
-### Channel security
+### Channel Security
 
 - For web-based applications, all communications SHOULD use HTTPS to prevent man-in-the-middle attacks on the message signing.
 - When using protocols other than HTTPS, all communications SHOULD be protected with proper techniques to maintain confidentiality, data integrity, and sender/receiver authenticity.
 
-### Session invalidation
+### Session Invalidation
 
 There are several cases where an implementer SHOULD check for state changes as they relate to sessions.
 
 - If an [ERC-1271](./eip-1271.md) implementation or dependent data changes the signature computation, the server SHOULD invalidate sessions appropriately.
 - If any resources specified in `resources` change, the server SHOULD invalidate sessions appropriately. However, the interpretation of `resources` is out of scope of this specification.
 
-### Maximum lengths for ABNF terms
+### Maximum Lengths for ABNF Terms
 
 - While this specification does not contain normative requirements around maximum string lengths, implementers SHOULD choose maximum lengths for terms that strike a balance across the prevention of denial of service attacks, support for arbitrary use cases, and user readability.
 


### PR DESCRIPTION
## Overview
This update contains a few **non-breaking** updates to the EIP-4361 specification to scope the responsibility of wallets further, and make changes to the `domain` field. Through implementation in major wallets, we have received feedback that it would be beneficial to support schemes other than `https`, such as using `http` for localhost to facilitate local development, and is generally aligned with the tenets of decentralization and protocol-agnosticism. Therefore we are introducing a non-breaking change to the specification that allows for non-https schemes to be explicitly specified while retaining the default scheme as `https` as the top suggestion for implementers. 

### Contains the Following Updates
- Various updates to the Overview section around how Sign-In with Ethereum messages are generated by relying parties, how they are presented to the user by the wallet, how the signature is presented to the relying party, and finally, how additional data can be added. 
- A reformat of the Message Format section to first present the ABNF conformance, and then the message fields are defined under a new "Message Fields" section
- A new section around specifying a request origin, and structuring siwe messages around an `origin` rather than a `domain` for a request. 
- Adds Oliver Terbu as an additional co-author for all of the contributions contained in this update. I am making this pull request simply as a co-author of the specification. 