### PR TITLE
Update EIP-4750: Update opcodes for CALLF and RETF

### DIFF
--- a/EIPS/eip-4750.md
+++ b/EIPS/eip-4750.md
@@ -51,8 +51,8 @@ Additionally, EVM keeps track of the index of currently executing section - `cur
 
 We introduce two new instructions:
 
-1. `CALLF` (`0xb0`) - call a function
-2. `RETF` (`0xb1`) - return from a function
+1. `CALLF` (`0xe3`) - call a function
+2. `RETF` (`0xe4`) - return from a function
 
 If the code is legacy bytecode, any of these instructions results in an *exceptional halt*. (*Note: This means no change to behaviour.*)
 


### PR DESCRIPTION
Update opcodes according to https://github.com/ethereum/execution-specs/blob/master/lists/evm/pending-opcodes.md.