### PR TITLE
Update EIP-6206: Update opcode for JUMPF

### DIFF
--- a/EIPS/eip-6206.md
+++ b/EIPS/eip-6206.md
@@ -21,7 +21,7 @@ It is common for functions to make a call at the end of the routine only to then
 
 ## Specification
 
-A new instruction, `JUMPF (0xb2)`, is introduced.
+A new instruction, `JUMPF (0xe5)`, is introduced.
 
 ### Execution Semantics
 


### PR DESCRIPTION
Update opcode according to https://github.com/ethereum/execution-specs/blob/master/lists/evm/pending-opcodes.md.