### PR TITLE
Update EIP-4844: Move 'Gas Accounting' section to improve readability

### DIFF
--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -166,6 +166,30 @@ def calc_excess_data_gas(parent: Header) -> int:
 
 For the first post-fork block, both `parent.data_gas_used` and `parent.excess_data_gas` are evaluated as `0`.
 
+### Gas accounting
+
+We introduce data gas as a new type of gas. It is independent of normal gas and follows its own targeting rule, similar to EIP-1559.
+We use the `excess_data_gas` header field to store persistent data needed to compute the data gas price. For now, only blobs are priced in data gas.
+
+```python
+def calc_data_fee(header: Header, tx: SignedBlobTransaction) -> int:
+    return get_total_data_gas(tx) * get_data_gasprice(header)
+
+def get_total_data_gas(tx: SignedBlobTransaction) -> int:
+    return DATA_GAS_PER_BLOB * len(tx.blob_versioned_hashes)
+
+def get_data_gasprice(header: Header) -> int:
+    return fake_exponential(
+        MIN_DATA_GASPRICE,
+        header.excess_data_gas,
+        DATA_GASPRICE_UPDATE_FRACTION
+    )
+```
+
+The block validity conditions are modified to include data gas checks (see the [Execution layer validation](#execution-layer-validation) section below).
+
+The actual `data_fee` as calculated via `calc_data_fee` is deducted from the sender balance before transaction execution and burned, and is not refunded in case of transaction failure.
+
 ### Opcode to get versioned hashes
 
 We add an instruction `BLOBHASH` (with opcode `HASH_OPCODE_BYTE`) which reads `index` from the top of the stack
@@ -205,30 +229,6 @@ def point_evaluation_precompile(input: Bytes) -> Bytes:
 ```
 
 The precompile MUST reject non-canonical field elements (i.e. provided field elements MUST be strictly less than `BLS_MODULUS`).
-
-### Gas accounting
-
-We introduce data gas as a new type of gas. It is independent of normal gas and follows its own targeting rule, similar to EIP-1559.
-We use the `excess_data_gas` header field to store persistent data needed to compute the data gas price. For now, only blobs are priced in data gas.
-
-```python
-def calc_data_fee(header: Header, tx: SignedBlobTransaction) -> int:
-    return get_total_data_gas(tx) * get_data_gasprice(header)
-
-def get_total_data_gas(tx: SignedBlobTransaction) -> int:
-    return DATA_GAS_PER_BLOB * len(tx.blob_versioned_hashes)
-
-def get_data_gasprice(header: Header) -> int:
-    return fake_exponential(
-        MIN_DATA_GASPRICE,
-        header.excess_data_gas,
-        DATA_GASPRICE_UPDATE_FRACTION
-    )
-```
-
-The block validity conditions are modified to include data gas checks (see the [Execution layer validation](#execution-layer-validation) section below).
-
-The actual `data_fee` as calculated via `calc_data_fee` is deducted from the sender balance before transaction execution and burned, and is not refunded in case of transaction failure.
 
 ### Consensus layer validation
 


### PR DESCRIPTION
This makes no changes to the text itself; it just moves the "Gas Accounting" section up to follow directly after the "Header Extension" section. This make the discussion of data gas read more continuously.
