### PR TITLE
Update EIP-7329: Remove unnecesary link and elaborate

### DIFF
--- a/EIPS/eip-7329.md
+++ b/EIPS/eip-7329.md
@@ -131,7 +131,10 @@ process with know governance checkpoints.
 
 ### Alternative: Specialized Editors
 
-This alternative has [already been implemented](../config/eip-editors.yml).
+This alternative has already been implemented with the introduction of the
+`eip-editors.yml` file. This allows for different groups of editors to review
+different types of EIPs.
+
 There has been no measurable impact on the divergence of the community. Most
 categories have a significant overlap with other categories.
 


### PR DESCRIPTION
The Specialized Editors link doesn't work as intended, and there is not a great description of that alternative.