### PR TITLE
Update EIP-6059: Add the missing parameter to the specification

### DIFF
--- a/EIPS/eip-6059.md
+++ b/EIPS/eip-6059.md
@@ -355,7 +355,7 @@ interface IERC6059 /* is ERC165 */ {
      * @param to Address of the receiving token's collection smart contract
      * @param tokenId ID of the token being transferred
      * @param destinationId ID of the token to receive the token being transferred
-     * @param data Additional data with no specified format, sent in the addChild call
+     * @param data Additional data with no specified format, which SHOULD be sent in the addChild call
      */
     function nestTransferFrom(
         address from,
@@ -455,6 +455,10 @@ This state change places the token in the pending array of the new parent token.
 
 The Nestable token standard has been made compatible with [ERC-721](./eip-721.md) in order to take advantage of the robust tooling available for implementations of ERC-721 and to ensure compatibility with existing ERC-721 infrastructure.
 
+The only incompatibility with ERC-721 is that Nestable tokens cannot use a token ID of 0.
+
+There is some differentiation of how the `ownerOf` method behaves, compared to ERC-721. The `ownerOf` method will now recursively look up through parent tokens until it finds an address which is not an NFT, this is referred to as the *root owner*. Additionally we provide the `directOwnerOf` which returns the most immediate owner of a token using 3 values: the owner address, the tokenId which MUST be 0 if the direct owner is not an NFT, and a flag indicating whether or not the parent is an NFT. In case the token is owned by an EoA or an ERC721Receiver, the `ownerOf` method will behave the same as in ERC-721.
+
 ## Test Cases
 
 Tests are included in [`nestable.ts`](../assets/eip-6059/test/nestable.ts).
@@ -477,6 +481,8 @@ See [`NestableToken.sol`](../assets/eip-6059/contracts/NestableToken.sol).
 The same security considerations as with [ERC-721](./eip-721.md) apply: hidden logic may be present in any of the functions, including burn, add child, accept child, and more.
 
 Since the current owner of the token is allowed to manage the token, there is a possibility that after the parent token is listed for sale, the seller might remove a child token just before before the sale and thus the buyer would not receive the expected child token. This is a risk that is inherent to the design of this standard. Marketplaces should take this into account and provide a way to verify the expected child tokens are present when the parent token is being sold or to guard against such a malicious behaviour in another way.
+
+It is worth noting, that `balanceOf` method only accounts for immediate tokens owned by the address; the tokens that are nested into a token owned by this address will not be reflected in this value as the recursive lookup needed in order to calculate this value is potentially too deep and might break the method.
 
 Caution is advised when dealing with non-audited contracts.
 

--- a/EIPS/eip-6059.md
+++ b/EIPS/eip-6059.md
@@ -362,7 +362,7 @@ interface IERC6059 /* is ERC165 */ {
         address to,
         uint256 tokenId,
         uint256 destinationId,
-        bytes calldata data
+        bytes memory data
     ) external;
 }
 ```

--- a/EIPS/eip-6059.md
+++ b/EIPS/eip-6059.md
@@ -455,10 +455,6 @@ This state change places the token in the pending array of the new parent token.
 
 The Nestable token standard has been made compatible with [ERC-721](./eip-721.md) in order to take advantage of the robust tooling available for implementations of ERC-721 and to ensure compatibility with existing ERC-721 infrastructure.
 
-The only incompatibility with ERC-721 is that Nestable tokens cannot use a token ID of 0.
-
-There is some differentiation of how the `ownerOf` method behaves compared to ERC-721. The `ownerOf` method will now recursively look up through parent tokens until it finds an address that is not an NFT; this is referred to as the *root owner*. Additionally, we provide the `directOwnerOf`, which returns the most immediate owner of a token using 3 values: the owner address, the `tokenId`, which MUST be 0 if the direct owner is not an NFT, and a flag indicating whether or not the parent is an NFT. In case the token is owned by an EoA or an ERC-721 Receiver, the `ownerOf` method will behave the same as in ERC-721.
-
 ## Test Cases
 
 Tests are included in [`nestable.ts`](../assets/eip-6059/test/nestable.ts).
@@ -481,8 +477,6 @@ See [`NestableToken.sol`](../assets/eip-6059/contracts/NestableToken.sol).
 The same security considerations as with [ERC-721](./eip-721.md) apply: hidden logic may be present in any of the functions, including burn, add child, accept child, and more.
 
 Since the current owner of the token is allowed to manage the token, there is a possibility that after the parent token is listed for sale, the seller might remove a child token just before before the sale and thus the buyer would not receive the expected child token. This is a risk that is inherent to the design of this standard. Marketplaces should take this into account and provide a way to verify the expected child tokens are present when the parent token is being sold or to guard against such a malicious behaviour in another way.
-
-It is worth noting that `balanceOf` method only accounts for immediate tokens owned by the address; the tokens that are nested into a token owned by this address will not be reflected in this value as the recursive lookup needed in order to calculate this value is potentially too deep and might break the method.
 
 Caution is advised when dealing with non-audited contracts.
 

--- a/EIPS/eip-6059.md
+++ b/EIPS/eip-6059.md
@@ -67,6 +67,16 @@ pragma solidity ^0.8.16;
 
 interface IERC6059 /* is ERC165 */ {
     /**
+     * @notice The core child token struct, holding the information about the child tokens.
+     * @return tokenId ID of the child token in the child token's collection smart contract
+     * @return contractAddress Address of the child token's smart contract
+     */
+    struct Child {
+        uint256 tokenId;
+        address contractAddress;
+    }
+
+    /**
      * @notice The core struct of ownership.
      * @dev The `DirectOwner` struct is used to store information of the next immediate owner, be it the parent token,
      * an `ERC721Receiver` contract or an externally owned account.
@@ -144,24 +154,17 @@ interface IERC6059 /* is ERC165 */ {
      * @param childId ID of the child token in the child token's collection smart contract
      * @param fromPending A boolean value signifying whether the token was in the pending child tokens array (`true`) or
      *  in the active child tokens array (`false`)
+     * @param toZero A boolean value signifying whether the token is being transferred to the `0x0` address (`true`) or
+     *  not (`false`)
      */
     event ChildTransferred(
         uint256 indexed tokenId,
         uint256 childIndex,
         address indexed childAddress,
         uint256 indexed childId,
-        bool fromPending
+        bool fromPending,
+        bool toZero
     );
-
-    /**
-     * @notice The core child token struct, holding the information about the child tokens.
-     * @return tokenId ID of the child token in the child token's collection smart contract
-     * @return contractAddress Address of the child token's smart contract
-     */
-    struct Child {
-        uint256 tokenId;
-        address contractAddress;
-    }
 
     /**
      * @notice Used to retrieve the *root* owner of a given token.
@@ -352,12 +355,14 @@ interface IERC6059 /* is ERC165 */ {
      * @param to Address of the receiving token's collection smart contract
      * @param tokenId ID of the token being transferred
      * @param destinationId ID of the token to receive the token being transferred
+     * @param data Additional data with no specified format, sent in the addChild call
      */
     function nestTransferFrom(
         address from,
         address to,
         uint256 tokenId,
-        uint256 destinationId
+        uint256 destinationId,
+        bytes memory data
     ) external;
 }
 ```

--- a/EIPS/eip-6059.md
+++ b/EIPS/eip-6059.md
@@ -362,7 +362,7 @@ interface IERC6059 /* is ERC165 */ {
         address to,
         uint256 tokenId,
         uint256 destinationId,
-        bytes memory data
+        bytes calldata data
     ) external;
 }
 ```

--- a/EIPS/eip-6059.md
+++ b/EIPS/eip-6059.md
@@ -457,7 +457,7 @@ The Nestable token standard has been made compatible with [ERC-721](./eip-721.md
 
 The only incompatibility with ERC-721 is that Nestable tokens cannot use a token ID of 0.
 
-There is some differentiation of how the `ownerOf` method behaves, compared to ERC-721. The `ownerOf` method will now recursively look up through parent tokens until it finds an address which is not an NFT, this is referred to as the *root owner*. Additionally we provide the `directOwnerOf` which returns the most immediate owner of a token using 3 values: the owner address, the tokenId which MUST be 0 if the direct owner is not an NFT, and a flag indicating whether or not the parent is an NFT. In case the token is owned by an EoA or an ERC721Receiver, the `ownerOf` method will behave the same as in ERC-721.
+There is some differentiation of how the `ownerOf` method behaves compared to ERC-721. The `ownerOf` method will now recursively look up through parent tokens until it finds an address that is not an NFT; this is referred to as the *root owner*. Additionally, we provide the `directOwnerOf`, which returns the most immediate owner of a token using 3 values: the owner address, the `tokenId`, which MUST be 0 if the direct owner is not an NFT, and a flag indicating whether or not the parent is an NFT. In case the token is owned by an EoA or an ERC721Receiver, the `ownerOf` method will behave the same as in ERC-721.
 
 ## Test Cases
 
@@ -482,7 +482,7 @@ The same security considerations as with [ERC-721](./eip-721.md) apply: hidden l
 
 Since the current owner of the token is allowed to manage the token, there is a possibility that after the parent token is listed for sale, the seller might remove a child token just before before the sale and thus the buyer would not receive the expected child token. This is a risk that is inherent to the design of this standard. Marketplaces should take this into account and provide a way to verify the expected child tokens are present when the parent token is being sold or to guard against such a malicious behaviour in another way.
 
-It is worth noting, that `balanceOf` method only accounts for immediate tokens owned by the address; the tokens that are nested into a token owned by this address will not be reflected in this value as the recursive lookup needed in order to calculate this value is potentially too deep and might break the method.
+It is worth noting that `balanceOf` method only accounts for immediate tokens owned by the address; the tokens that are nested into a token owned by this address will not be reflected in this value as the recursive lookup needed in order to calculate this value is potentially too deep and might break the method.
 
 Caution is advised when dealing with non-audited contracts.
 

--- a/EIPS/eip-6059.md
+++ b/EIPS/eip-6059.md
@@ -457,7 +457,7 @@ The Nestable token standard has been made compatible with [ERC-721](./eip-721.md
 
 The only incompatibility with ERC-721 is that Nestable tokens cannot use a token ID of 0.
 
-There is some differentiation of how the `ownerOf` method behaves compared to ERC-721. The `ownerOf` method will now recursively look up through parent tokens until it finds an address that is not an NFT; this is referred to as the *root owner*. Additionally, we provide the `directOwnerOf`, which returns the most immediate owner of a token using 3 values: the owner address, the `tokenId`, which MUST be 0 if the direct owner is not an NFT, and a flag indicating whether or not the parent is an NFT. In case the token is owned by an EoA or an ERC721Receiver, the `ownerOf` method will behave the same as in ERC-721.
+There is some differentiation of how the `ownerOf` method behaves compared to ERC-721. The `ownerOf` method will now recursively look up through parent tokens until it finds an address that is not an NFT; this is referred to as the *root owner*. Additionally, we provide the `directOwnerOf`, which returns the most immediate owner of a token using 3 values: the owner address, the `tokenId`, which MUST be 0 if the direct owner is not an NFT, and a flag indicating whether or not the parent is an NFT. In case the token is owned by an EoA or an ERC-721 Receiver, the `ownerOf` method will behave the same as in ERC-721.
 
 ## Test Cases
 

--- a/EIPS/eip-6059.md
+++ b/EIPS/eip-6059.md
@@ -67,16 +67,6 @@ pragma solidity ^0.8.16;
 
 interface IERC6059 /* is ERC165 */ {
     /**
-     * @notice The core child token struct, holding the information about the child tokens.
-     * @return tokenId ID of the child token in the child token's collection smart contract
-     * @return contractAddress Address of the child token's smart contract
-     */
-    struct Child {
-        uint256 tokenId;
-        address contractAddress;
-    }
-
-    /**
      * @notice The core struct of ownership.
      * @dev The `DirectOwner` struct is used to store information of the next immediate owner, be it the parent token,
      * an `ERC721Receiver` contract or an externally owned account.
@@ -165,6 +155,16 @@ interface IERC6059 /* is ERC165 */ {
         bool fromPending,
         bool toZero
     );
+
+    /**
+     * @notice The core child token struct, holding the information about the child tokens.
+     * @return tokenId ID of the child token in the child token's collection smart contract
+     * @return contractAddress Address of the child token's smart contract
+     */
+    struct Child {
+        uint256 tokenId;
+        address contractAddress;
+    }
 
     /**
      * @notice Used to retrieve the *root* owner of a given token.

--- a/assets/eip-6059/contracts/IERC6059.sol
+++ b/assets/eip-6059/contracts/IERC6059.sol
@@ -108,6 +108,6 @@ interface IERC6059 {
         address to,
         uint256 tokenId,
         uint256 destinationId,
-        bytes memory data
+        bytes calldata data
     ) external;
 }

--- a/assets/eip-6059/contracts/IERC6059.sol
+++ b/assets/eip-6059/contracts/IERC6059.sol
@@ -4,6 +4,11 @@ pragma solidity ^0.8.16;
 
 
 interface IERC6059 {
+    struct Child {
+        uint256 tokenId;
+        address contractAddress;
+    }
+
     struct DirectOwner {
         uint256 tokenId;
         address ownerAddress;
@@ -38,13 +43,9 @@ interface IERC6059 {
         uint256 childIndex,
         address indexed childAddress,
         uint256 indexed childId,
-        bool fromPending
+        bool fromPending,
+        bool toZero
     );
-
-    struct Child {
-        uint256 tokenId;
-        address contractAddress;
-    }
 
     function ownerOf(uint256 tokenId) external view returns (address owner);
 

--- a/assets/eip-6059/contracts/IERC6059.sol
+++ b/assets/eip-6059/contracts/IERC6059.sol
@@ -108,6 +108,6 @@ interface IERC6059 {
         address to,
         uint256 tokenId,
         uint256 destinationId,
-        bytes calldata data
+        bytes memory data
     ) external;
 }

--- a/assets/eip-6059/contracts/IERC6059.sol
+++ b/assets/eip-6059/contracts/IERC6059.sol
@@ -4,11 +4,6 @@ pragma solidity ^0.8.16;
 
 
 interface IERC6059 {
-    struct Child {
-        uint256 tokenId;
-        address contractAddress;
-    }
-
     struct DirectOwner {
         uint256 tokenId;
         address ownerAddress;
@@ -46,6 +41,11 @@ interface IERC6059 {
         bool fromPending,
         bool toZero
     );
+
+    struct Child {
+        uint256 tokenId;
+        address contractAddress;
+    }
 
     function ownerOf(uint256 tokenId) external view returns (address owner);
 

--- a/assets/eip-6059/contracts/NestableToken.sol
+++ b/assets/eip-6059/contracts/NestableToken.sol
@@ -1099,7 +1099,8 @@ contract NestableToken is Context, IERC165, IERC721, IERC6059 {
             childIndex,
             childAddress,
             childId,
-            isPending
+            isPending,
+            to == address(0)
         );
         _afterTransferChild(
             tokenId,

--- a/assets/eip-6059/contracts/NestableToken.sol
+++ b/assets/eip-6059/contracts/NestableToken.sol
@@ -196,7 +196,7 @@ contract NestableToken is Context, IERC165, IERC721, IERC6059 {
         address to,
         uint256 tokenId,
         uint256 destinationId,
-        bytes calldata data
+        bytes memory data
     ) public virtual onlyApprovedOrDirectOwner(tokenId) {
         _nestTransfer(from, to, tokenId, destinationId, data);
     }

--- a/assets/eip-6059/contracts/NestableToken.sol
+++ b/assets/eip-6059/contracts/NestableToken.sol
@@ -196,7 +196,7 @@ contract NestableToken is Context, IERC165, IERC721, IERC6059 {
         address to,
         uint256 tokenId,
         uint256 destinationId,
-        bytes memory data
+        bytes calldata data
     ) public virtual onlyApprovedOrDirectOwner(tokenId) {
         _nestTransfer(from, to, tokenId, destinationId, data);
     }

--- a/assets/eip-6059/contracts/mocks/NestableTokenMock.sol
+++ b/assets/eip-6059/contracts/mocks/NestableTokenMock.sol
@@ -29,8 +29,9 @@ contract NestableTokenMock is NestableToken {
     function nestTransfer(
         address to,
         uint256 tokenId,
-        uint256 destinationId
+        uint256 destinationId,
+        bytes calldata data
     ) public virtual {
-        nestTransferFrom(_msgSender(), to, tokenId, destinationId, "");
+        nestTransferFrom(_msgSender(), to, tokenId, destinationId, data);
     }
 }

--- a/assets/eip-6059/contracts/mocks/NestableTokenMock.sol
+++ b/assets/eip-6059/contracts/mocks/NestableTokenMock.sol
@@ -29,9 +29,8 @@ contract NestableTokenMock is NestableToken {
     function nestTransfer(
         address to,
         uint256 tokenId,
-        uint256 destinationId,
-        bytes calldata data
+        uint256 destinationId
     ) public virtual {
-        nestTransferFrom(_msgSender(), to, tokenId, destinationId, data);
+        nestTransferFrom(_msgSender(), to, tokenId, destinationId, "");
     }
 }

--- a/assets/eip-6059/test/nestable.ts
+++ b/assets/eip-6059/test/nestable.ts
@@ -987,7 +987,7 @@ describe('NestableToken', function () {
       expect(await child.balanceOf(parent.address)).to.equal(1);
 
       // Transfers token parentId to (parent.address, token grandParentId)
-      await parent.connect(firstOwner).nestTransfer(parent.address, parentId, grandParentId, "0x");
+      await parent.connect(firstOwner).nestTransfer(parent.address, parentId, grandParentId);
 
       // Balances unchanged since root owner is the same
       expect(await parent.balanceOf(firstOwner.address)).to.equal(1);
@@ -1018,7 +1018,7 @@ describe('NestableToken', function () {
       expect(await child.balanceOf(parent.address)).to.equal(1);
 
       // firstOwner calls parent to transfer parent token parent
-      await parent.connect(firstOwner).nestTransfer(parent.address, parentId, grandParentId, "0x");
+      await parent.connect(firstOwner).nestTransfer(parent.address, parentId, grandParentId);
 
       // Balances update
       expect(await parent.balanceOf(firstOwner.address)).to.equal(0);
@@ -1052,33 +1052,33 @@ describe('NestableToken', function () {
       const otherParentId = 2;
       await parent.mint(firstOwner.address, otherParentId);
       // We send it to the parent first
-      await child.connect(firstOwner).nestTransfer(parent.address, childId1, parentId, "0x");
+      await child.connect(firstOwner).nestTransfer(parent.address, childId1, parentId);
       // We can no longer nest transfer it, even if we are the root owner:
       await expect(
-        child.connect(firstOwner).nestTransfer(parent.address, childId1, otherParentId, "0x"),
+        child.connect(firstOwner).nestTransfer(parent.address, childId1, otherParentId),
       ).to.be.revertedWithCustomError(child, 'NotApprovedOrDirectOwner');
     });
 
     it('cannot nest tranfer to same NFT', async function () {
       // We can no longer nest transfer it, even if we are the root owner:
       await expect(
-        child.connect(firstOwner).nestTransfer(child.address, childId1, childId1, "0x"),
+        child.connect(firstOwner).nestTransfer(child.address, childId1, childId1),
       ).to.be.revertedWithCustomError(child, 'NestableTransferToSelf');
     });
 
     it('cannot nest tranfer a descendant same NFT', async function () {
       // We can no longer nest transfer it, even if we are the root owner:
-      await child.connect(firstOwner).nestTransfer(parent.address, childId1, parentId, "0x");
+      await child.connect(firstOwner).nestTransfer(parent.address, childId1, parentId);
       const grandChildId = 999;
       await child.nestMint(child.address, grandChildId, childId1);
       // Ownership is now parent->child->granChild
       // Cannot send parent to grandChild
       await expect(
-        parent.connect(firstOwner).nestTransfer(child.address, parentId, grandChildId, "0x"),
+        parent.connect(firstOwner).nestTransfer(child.address, parentId, grandChildId),
       ).to.be.revertedWithCustomError(child, 'NestableTransferToDescendant');
       // Cannot send parent to child
       await expect(
-        parent.connect(firstOwner).nestTransfer(child.address, parentId, childId1, "0x"),
+        parent.connect(firstOwner).nestTransfer(child.address, parentId, childId1),
       ).to.be.revertedWithCustomError(child, 'NestableTransferToDescendant');
     });
 
@@ -1091,27 +1091,27 @@ describe('NestableToken', function () {
       // Ownership is now parent->child->child->child->child...->lastChild
       // Cannot send parent to lastChild
       await expect(
-        parent.connect(firstOwner).nestTransfer(child.address, parentId, lastId, "0x"),
+        parent.connect(firstOwner).nestTransfer(child.address, parentId, lastId),
       ).to.be.revertedWithCustomError(child, 'NestableTooDeep');
     });
 
     it('cannot nest tranfer if not owner', async function () {
       const notOwner = addrs[3];
       await expect(
-        child.connect(notOwner).nestTransfer(parent.address, childId1, parentId, "0x"),
+        child.connect(notOwner).nestTransfer(parent.address, childId1, parentId),
       ).to.be.revertedWithCustomError(child, 'NotApprovedOrDirectOwner');
     });
 
     it('cannot nest tranfer to address 0', async function () {
       await expect(
-        child.connect(firstOwner).nestTransfer(ADDRESS_ZERO, childId1, parentId, "0x"),
+        child.connect(firstOwner).nestTransfer(ADDRESS_ZERO, childId1, parentId),
       ).to.be.revertedWithCustomError(child, 'ERC721TransferToTheZeroAddress');
     });
 
     it('cannot nest tranfer to a non contract', async function () {
       const newOwner = addrs[2];
       await expect(
-        child.connect(firstOwner).nestTransfer(newOwner.address, childId1, parentId, "0x"),
+        child.connect(firstOwner).nestTransfer(newOwner.address, childId1, parentId),
       ).to.be.revertedWithCustomError(child, 'IsNotContract');
     });
 
@@ -1120,12 +1120,12 @@ describe('NestableToken', function () {
       const nonNestable = await ERC721.deploy('Non receiver', 'NR');
       await nonNestable.deployed();
       await expect(
-        child.connect(firstOwner).nestTransfer(nonNestable.address, childId1, parentId, "0x"),
+        child.connect(firstOwner).nestTransfer(nonNestable.address, childId1, parentId),
       ).to.be.revertedWithCustomError(child, 'NestableTransferToNonNestableImplementer');
     });
 
     it('can nest tranfer to IERC6059 contract', async function () {
-      await child.connect(firstOwner).nestTransfer(parent.address, childId1, parentId, "0x");
+      await child.connect(firstOwner).nestTransfer(parent.address, childId1, parentId);
       expect(await child.ownerOf(childId1)).to.eql(firstOwner.address);
       expect(await child.directOwnerOf(childId1)).to.eql([parent.address, bn(parentId), true]);
     });
@@ -1133,7 +1133,7 @@ describe('NestableToken', function () {
     it('cannot nest tranfer to non existing parent token', async function () {
       const notExistingParentId = 9999;
       await expect(
-        child.connect(firstOwner).nestTransfer(parent.address, childId1, notExistingParentId, "0x"),
+        child.connect(firstOwner).nestTransfer(parent.address, childId1, notExistingParentId),
       ).to.be.revertedWithCustomError(parent, 'ERC721InvalidTokenId');
     });
   });

--- a/assets/eip-6059/test/nestable.ts
+++ b/assets/eip-6059/test/nestable.ts
@@ -987,7 +987,7 @@ describe('NestableToken', function () {
       expect(await child.balanceOf(parent.address)).to.equal(1);
 
       // Transfers token parentId to (parent.address, token grandParentId)
-      await parent.connect(firstOwner).nestTransfer(parent.address, parentId, grandParentId);
+      await parent.connect(firstOwner).nestTransfer(parent.address, parentId, grandParentId, "0x");
 
       // Balances unchanged since root owner is the same
       expect(await parent.balanceOf(firstOwner.address)).to.equal(1);
@@ -1018,7 +1018,7 @@ describe('NestableToken', function () {
       expect(await child.balanceOf(parent.address)).to.equal(1);
 
       // firstOwner calls parent to transfer parent token parent
-      await parent.connect(firstOwner).nestTransfer(parent.address, parentId, grandParentId);
+      await parent.connect(firstOwner).nestTransfer(parent.address, parentId, grandParentId, "0x");
 
       // Balances update
       expect(await parent.balanceOf(firstOwner.address)).to.equal(0);
@@ -1052,33 +1052,33 @@ describe('NestableToken', function () {
       const otherParentId = 2;
       await parent.mint(firstOwner.address, otherParentId);
       // We send it to the parent first
-      await child.connect(firstOwner).nestTransfer(parent.address, childId1, parentId);
+      await child.connect(firstOwner).nestTransfer(parent.address, childId1, parentId, "0x");
       // We can no longer nest transfer it, even if we are the root owner:
       await expect(
-        child.connect(firstOwner).nestTransfer(parent.address, childId1, otherParentId),
+        child.connect(firstOwner).nestTransfer(parent.address, childId1, otherParentId, "0x"),
       ).to.be.revertedWithCustomError(child, 'NotApprovedOrDirectOwner');
     });
 
     it('cannot nest tranfer to same NFT', async function () {
       // We can no longer nest transfer it, even if we are the root owner:
       await expect(
-        child.connect(firstOwner).nestTransfer(child.address, childId1, childId1),
+        child.connect(firstOwner).nestTransfer(child.address, childId1, childId1, "0x"),
       ).to.be.revertedWithCustomError(child, 'NestableTransferToSelf');
     });
 
     it('cannot nest tranfer a descendant same NFT', async function () {
       // We can no longer nest transfer it, even if we are the root owner:
-      await child.connect(firstOwner).nestTransfer(parent.address, childId1, parentId);
+      await child.connect(firstOwner).nestTransfer(parent.address, childId1, parentId, "0x");
       const grandChildId = 999;
       await child.nestMint(child.address, grandChildId, childId1);
       // Ownership is now parent->child->granChild
       // Cannot send parent to grandChild
       await expect(
-        parent.connect(firstOwner).nestTransfer(child.address, parentId, grandChildId),
+        parent.connect(firstOwner).nestTransfer(child.address, parentId, grandChildId, "0x"),
       ).to.be.revertedWithCustomError(child, 'NestableTransferToDescendant');
       // Cannot send parent to child
       await expect(
-        parent.connect(firstOwner).nestTransfer(child.address, parentId, childId1),
+        parent.connect(firstOwner).nestTransfer(child.address, parentId, childId1, "0x"),
       ).to.be.revertedWithCustomError(child, 'NestableTransferToDescendant');
     });
 
@@ -1091,27 +1091,27 @@ describe('NestableToken', function () {
       // Ownership is now parent->child->child->child->child...->lastChild
       // Cannot send parent to lastChild
       await expect(
-        parent.connect(firstOwner).nestTransfer(child.address, parentId, lastId),
+        parent.connect(firstOwner).nestTransfer(child.address, parentId, lastId, "0x"),
       ).to.be.revertedWithCustomError(child, 'NestableTooDeep');
     });
 
     it('cannot nest tranfer if not owner', async function () {
       const notOwner = addrs[3];
       await expect(
-        child.connect(notOwner).nestTransfer(parent.address, childId1, parentId),
+        child.connect(notOwner).nestTransfer(parent.address, childId1, parentId, "0x"),
       ).to.be.revertedWithCustomError(child, 'NotApprovedOrDirectOwner');
     });
 
     it('cannot nest tranfer to address 0', async function () {
       await expect(
-        child.connect(firstOwner).nestTransfer(ADDRESS_ZERO, childId1, parentId),
+        child.connect(firstOwner).nestTransfer(ADDRESS_ZERO, childId1, parentId, "0x"),
       ).to.be.revertedWithCustomError(child, 'ERC721TransferToTheZeroAddress');
     });
 
     it('cannot nest tranfer to a non contract', async function () {
       const newOwner = addrs[2];
       await expect(
-        child.connect(firstOwner).nestTransfer(newOwner.address, childId1, parentId),
+        child.connect(firstOwner).nestTransfer(newOwner.address, childId1, parentId, "0x"),
       ).to.be.revertedWithCustomError(child, 'IsNotContract');
     });
 
@@ -1120,12 +1120,12 @@ describe('NestableToken', function () {
       const nonNestable = await ERC721.deploy('Non receiver', 'NR');
       await nonNestable.deployed();
       await expect(
-        child.connect(firstOwner).nestTransfer(nonNestable.address, childId1, parentId),
+        child.connect(firstOwner).nestTransfer(nonNestable.address, childId1, parentId, "0x"),
       ).to.be.revertedWithCustomError(child, 'NestableTransferToNonNestableImplementer');
     });
 
     it('can nest tranfer to IERC6059 contract', async function () {
-      await child.connect(firstOwner).nestTransfer(parent.address, childId1, parentId);
+      await child.connect(firstOwner).nestTransfer(parent.address, childId1, parentId, "0x");
       expect(await child.ownerOf(childId1)).to.eql(firstOwner.address);
       expect(await child.directOwnerOf(childId1)).to.eql([parent.address, bn(parentId), true]);
     });
@@ -1133,7 +1133,7 @@ describe('NestableToken', function () {
     it('cannot nest tranfer to non existing parent token', async function () {
       const notExistingParentId = 9999;
       await expect(
-        child.connect(firstOwner).nestTransfer(parent.address, childId1, notExistingParentId),
+        child.connect(firstOwner).nestTransfer(parent.address, childId1, notExistingParentId, "0x"),
       ).to.be.revertedWithCustomError(parent, 'ERC721InvalidTokenId');
     });
   });

--- a/assets/eip-6059/test/nestable.ts
+++ b/assets/eip-6059/test/nestable.ts
@@ -587,7 +587,7 @@ describe('NestableToken', function () {
           .transferChild(parentId, tokenOwner.address, 0, 0, child.address, childId1, false, '0x'),
       )
         .to.emit(parent, 'ChildTransferred')
-        .withArgs(parentId, 0, child.address, childId1, false);
+        .withArgs(parentId, 0, child.address, childId1, false, false);
 
       await checkChildMovedToRootOwner();
     });
@@ -600,7 +600,7 @@ describe('NestableToken', function () {
           .transferChild(parentId, toOwnerAddress, 0, 0, child.address, childId1, false, '0x'),
       )
         .to.emit(parent, 'ChildTransferred')
-        .withArgs(parentId, 0, child.address, childId1, false);
+        .withArgs(parentId, 0, child.address, childId1, false, false);
 
       await checkChildMovedToRootOwner(toOwnerAddress);
     });
@@ -624,7 +624,7 @@ describe('NestableToken', function () {
           ),
       )
         .to.emit(parent, 'ChildTransferred')
-        .withArgs(parentId, 0, child.address, childId1, false);
+        .withArgs(parentId, 0, child.address, childId1, false, false);
 
       expect(await child.ownerOf(childId1)).to.eql(newOwnerAddress);
       expect(await child.directOwnerOf(childId1)).to.eql([parent.address, bn(newParentId), true]);
@@ -747,7 +747,7 @@ describe('NestableToken', function () {
           .transferChild(parentId, tokenOwner.address, 0, 0, child.address, childId1, true, '0x'),
       )
         .to.emit(parent, 'ChildTransferred')
-        .withArgs(parentId, 0, child.address, childId1, true);
+        .withArgs(parentId, 0, child.address, childId1, true, false);
 
       await checkChildMovedToRootOwner();
     });
@@ -760,7 +760,7 @@ describe('NestableToken', function () {
           .transferChild(parentId, toOwnerAddress, 0, 0, child.address, childId1, true, '0x'),
       )
         .to.emit(parent, 'ChildTransferred')
-        .withArgs(parentId, 0, child.address, childId1, true);
+        .withArgs(parentId, 0, child.address, childId1, true, false);
 
       await checkChildMovedToRootOwner(toOwnerAddress);
     });
@@ -784,7 +784,7 @@ describe('NestableToken', function () {
           ),
       )
         .to.emit(parent, 'ChildTransferred')
-        .withArgs(parentId, 0, child.address, childId1, true);
+        .withArgs(parentId, 0, child.address, childId1, true, false);
 
       expect(await child.ownerOf(childId1)).to.eql(newOwnerAddress);
       expect(await child.directOwnerOf(childId1)).to.eql([parent.address, bn(newParentId), true]);


### PR DESCRIPTION
During the proposal lifecycle from Draft to Final stage, an additional parameter was added to the `nestTransferFrom` method. This parameter is already taken into account within the `interfaceId`. This means that this PR fixes the inconsistency.

Additionally, the `ChildTransferred` event was missing an important quality of life parameter which doesn’t impact the `interfaceId`, but it does provide better usability of the proposal.

We also expanded the _Rationale_ and _Security consideration_ to be more illustrative of the proposal.

While we understand that finalized proposals are not meant to be updated, we feel like this one might benefit from the correction proposed here. Anyone that uses the proposal in their project either used our open-source library (which already included the proposed changes before the finalization) or the interface provided within the assets (which also includes the proposed changes). This means that modifying the proposal will align it with current implementations.