### PR TITLE
Config: Yeet eip_validator

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,4 @@ gem "wdm", "~> 0.1.1" if Gem.win_platform?
 
 gem "html-proofer", '>=5.0.7'
 
-gem "eip_validator", ">=0.8.2"
-
 gem "webrick", "~> 1.8" # needed for macOS builds


### PR DESCRIPTION
At this point, it is completely unused (superseded by eipw) and can be safely removed.