### PR TITLE
Update EIP-6059: Align specification with interfaceID and example implementation

### DIFF
--- a/EIPS/eip-6059.md
+++ b/EIPS/eip-6059.md
@@ -352,12 +352,14 @@ interface IERC6059 /* is ERC165 */ {
      * @param to Address of the receiving token's collection smart contract
      * @param tokenId ID of the token being transferred
      * @param destinationId ID of the token to receive the token being transferred
+     * @param data Additional data with no specified format, which SHOULD be sent in the `nestTransferFrom` call
      */
     function nestTransferFrom(
         address from,
         address to,
         uint256 tokenId,
-        uint256 destinationId
+        uint256 destinationId,
+        bytes memory data
     ) external;
 }
 ```


### PR DESCRIPTION
During the proposal lifecycle from `Draft` to `Final` stage, an additional parameter was added to the `nestTransferFrom` method. This parameter is already taken into account within the `interfaceId`. This means that this PR fixes the inconsistency.

Additionally, there are other proposals (namely ERC-6220) that rely on the specification of this proposal that already implements the missing parameter.

While we understand that finalized proposals are not meant to be updated, we feel like updating the parameter that is already included in the example implementation as well as live implementations, will benefit the ecosystem. The current mismatch of `interfaceId` and the interface itself makes implementation according to the proposal impossible. Updating it will have a positive impact on the implementers as well as the ecosystem, as they are already relying on the complete interface (with the addition of the missing field) and have it integrated into their smart contracts.