### PR TITLE
Update EIP-820: Fix accidental tag

### DIFF
--- a/EIPS/eip-820.md
+++ b/EIPS/eip-820.md
@@ -331,7 +331,9 @@ The contract has the address above for every chain on which it is deployed.
 <details>
 <summary>Raw metadata of <code>./contracts/ERC820Registry.sol</code></summary>
 <pre>
-<code>{
+
+```json
+{
   "compiler": {
     "version": "0.4.24+commit.e67f0147"
   },
@@ -649,7 +651,9 @@ The contract has the address above for every chain on which it is deployed.
     }
   },
   "version": 1
-}</code>
+}
+```
+
 </pre>
 </details>
 


### PR DESCRIPTION
The creative commons CC0 link, since it was contained in an HTML code block instead of a markdown one, was interpreted as an HTML tag instead of raw text.