### PR TITLE
Add EIP: ERC-20 Update Allowance By Spender

### DIFF
--- a/EIPS/eip-7410.md
+++ b/EIPS/eip-7410.md
@@ -2,7 +2,7 @@
 eip: 7410
 title: ERC-20 Update Allowance By Spender
 description: Extension to enable revoking and decreasing allowance approval by spender for ERC-20
-author: Mohammad Zakeri Rad (@zakrad)
+author: Mohammad Zakeri Rad (@zakrad), Adam Boudjemaa (@aboudjem), Mohamad Hammoud (@mohamadhammoud)
 discussions-to: https://ethereum-magicians.org/t/erc20-extension-update-allowance-by-spender/15222
 status: Draft
 type: Standards Track

--- a/EIPS/eip-7410.md
+++ b/EIPS/eip-7410.md
@@ -1,0 +1,80 @@
+---
+eip: 7410
+title: EIP-20 Update Allowance By Spender
+description: Extension to enable revoking and decreasing allowance approval by spender for EIP-20
+author: Mohammad Zakeri Rad (@zakrad)
+discussions-to: https://ethereum-magicians.org/t/erc20-extension-update-allowance-by-spender/15222
+status: Draft
+type: Standards Track
+category: ERC
+created: 2023-07-26
+requires: 20, 165
+---
+
+## Abstract
+
+This extension adds a update allowance mechanism to ERC-20 allowances, in which a spender can revoke or decrease a given allowance by a specific address. This EIP extends [EIP-20](./eip-20.md).
+
+## Motivation
+
+Currently, ERC-20 tokens offer allowances, enabling token owners to authorize spenders to use a designated amount of tokens on their behalf. However, the process of decreasing an allowance is limited to the owner's side, which can be problematic if the token owner is a treasury wallet or a multi-signature wallet that has granted an excessive allowance to a spender. In such cases, reducing the allowance from the owner's perspective can be time-consuming and challenging.
+
+To address this issue and enhance security measures, this EIP proposes allowing spenders to decrease or revoke the granted allowance from their end. This feature provides an additional layer of security in the event of a potential hack in the future. It also eliminates the need for a consensus or complex procedures to decrease the allowance from the token owner's side.
+
+## Specification
+
+The keywords “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be interpreted as described in RFC 2119.
+
+Contracts using this EIP MUST implement the `IERC20ApproveBySpender` interface.
+
+### Interface implementation
+
+```solidity
+pragma solidity ^0.8.0;
+
+/**
+ * @title ERC-20 Modify Allowance By Spender Extension
+ * Note: the ERC-165 identifier for this interface is 0x2d474b5c
+ */
+interface IERC20ApproveBySpender is IERC20 {
+
+    /**
+     * @notice Updates any allowance by `owner` address for caller.
+     * Emits an {IERC20-Approval} event.
+     *
+     * Requirements:
+     * - `owner` cannot be the caller.
+     * - `amount` should be less than or equal to current allowance of `owner` for caller.
+     */
+    function approveBySpender(address owner, uint256 amount) external;
+
+}
+```
+
+The `approveBySpender(address owner, uint256 amount)` function MUST be either `public` or `external`.
+
+The `Approval` event MUST be emitted when `approveBySpender` is called.
+
+The `supportsInterface` method MUST return `true` when called with `0x2d474b5c`.
+
+## Rationale
+
+The name "EIP-20 Approval By Spender Extension" was chosen because it is a succinct description of this EIP. Spenders can decrease or revoke their allowance by `amount` from `owner`s.
+
+By having a way to approve and revoke in a manner similar to [EIP-20](./eip-20.md), the trust level can be more directly managed by spender:
+
+- Using the `approveBySpender` function, spenders can revoke or decrease their allowance to spend an `amount`.
+
+The [EIP-20](./eip-20.md) name patterns were used due to similarities with [EIP-20](./eip-20.md) approvals.
+
+## Backwards Compatibility
+
+This standard is compatible with [EIP-20](./eip-20.md).
+
+## Security Considerations
+
+Users of this EIP must thoroughly consider the amount of tokens they decrease from their allowance for an `owner`.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](../LICENSE.md).

--- a/EIPS/eip-7410.md
+++ b/EIPS/eip-7410.md
@@ -3,7 +3,7 @@ eip: 7410
 title: ERC-20 Update Allowance By Spender
 description: Extension to enable revoking and decreasing allowance approval by spender for ERC-20
 author: Mohammad Zakeri Rad (@zakrad), Adam Boudjemaa (@aboudjem), Mohamad Hammoud (@mohamadhammoud)
-discussions-to: https://ethereum-magicians.org/t/erc20-extension-update-allowance-by-spender/15222
+discussions-to: https://ethereum-magicians.org/t/eip-7410-decrease-allowance-by-spender/15222
 status: Draft
 type: Standards Track
 category: ERC
@@ -13,7 +13,7 @@ requires: 20, 165
 
 ## Abstract
 
-This extension adds a update allowance mechanism to [ERC-20](./eip-20.md) allowances, in which a spender can revoke or decrease a given allowance by a specific address. This EIP extends [ERC-20](./eip-20.md).
+This extension adds a decrease allowance mechanism to [ERC-20](./eip-20.md) allowances, in which a spender can revoke or decrease a given allowance by a specific address. This EIP extends [ERC-20](./eip-20.md).
 
 ## Motivation
 
@@ -34,34 +34,34 @@ pragma solidity ^0.8.0;
 
 /**
  * @title IERC-7410 Update Allowance By Spender Extension
- * Note: the ERC-165 identifier for this interface is 0x2d474b5c
+ * Note: the ERC-165 identifier for this interface is 0x12860fba
  */
 interface IERC7410 is IERC20 {
 
     /**
-     * @notice Updates any allowance by `owner` address for caller.
+     * @notice Decreases any allowance by `owner` address for caller.
      * Emits an {IERC20-Approval} event.
      *
      * Requirements:
      * - `owner` cannot be the caller.
-     * - `amount` should be less than or equal to current allowance of `owner` for caller.
+     * - `subtractedValue` should be less than or equal to current allowance of `owner` for caller.
      */
-    function approveBySpender(address owner, uint256 amount) external;
+    function decreaseAllowanceBySpender(address owner, uint256 subtractedValue) external;
 
 }
 ```
 
-The `approveBySpender(address owner, uint256 amount)` function MUST be either `public` or `external`.
+The `decreaseAllowanceBySpender(address owner, uint256 subtractedValue)` function MUST be either `public` or `external`.
 
-The `Approval` event MUST be emitted when `approveBySpender` is called.
+The `Approval` event MUST be emitted when `decreaseAllowanceBySpender` is called.
 
-The `supportsInterface` method MUST return `true` when called with `0x2d474b5c`.
+The `supportsInterface` method MUST return `true` when called with `0x12860fba`.
 
 ## Rationale
 
 By having a way to approve and revoke in a manner similar to [ERC-20](./eip-20.md), the trust level can be more directly managed by spender:
 
-- Using the `approveBySpender` function, spenders can revoke or decrease their allowance to spend an `amount`.
+- Using the `decreaseAllowanceBySpender` function, spenders can revoke or decrease their allowance by `subtractedValue`.
 
 The [ERC-20](./eip-20.md) name patterns were used due to similarities with [ERC-20](./eip-20.md) approvals.
 

--- a/EIPS/eip-7410.md
+++ b/EIPS/eip-7410.md
@@ -1,7 +1,7 @@
 ---
 eip: 7410
-title: EIP-20 Update Allowance By Spender
-description: Extension to enable revoking and decreasing allowance approval by spender for EIP-20
+title: ERC-20 Update Allowance By Spender
+description: Extension to enable revoking and decreasing allowance approval by spender for ERC-20
 author: Mohammad Zakeri Rad (@zakrad)
 discussions-to: https://ethereum-magicians.org/t/erc20-extension-update-allowance-by-spender/15222
 status: Draft
@@ -13,11 +13,11 @@ requires: 20, 165
 
 ## Abstract
 
-This extension adds a update allowance mechanism to ERC-20 allowances, in which a spender can revoke or decrease a given allowance by a specific address. This EIP extends [EIP-20](./eip-20.md).
+This extension adds a update allowance mechanism to [ERC-20](./eip-20.md) allowances, in which a spender can revoke or decrease a given allowance by a specific address. This EIP extends [ERC-20](./eip-20.md).
 
 ## Motivation
 
-Currently, ERC-20 tokens offer allowances, enabling token owners to authorize spenders to use a designated amount of tokens on their behalf. However, the process of decreasing an allowance is limited to the owner's side, which can be problematic if the token owner is a treasury wallet or a multi-signature wallet that has granted an excessive allowance to a spender. In such cases, reducing the allowance from the owner's perspective can be time-consuming and challenging.
+Currently, [ERC-20](./eip-20.md) tokens offer allowances, enabling token owners to authorize spenders to use a designated amount of tokens on their behalf. However, the process of decreasing an allowance is limited to the owner's side, which can be problematic if the token owner is a treasury wallet or a multi-signature wallet that has granted an excessive allowance to a spender. In such cases, reducing the allowance from the owner's perspective can be time-consuming and challenging.
 
 To address this issue and enhance security measures, this EIP proposes allowing spenders to decrease or revoke the granted allowance from their end. This feature provides an additional layer of security in the event of a potential hack in the future. It also eliminates the need for a consensus or complex procedures to decrease the allowance from the token owner's side.
 
@@ -25,7 +25,7 @@ To address this issue and enhance security measures, this EIP proposes allowing 
 
 The keywords “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be interpreted as described in RFC 2119.
 
-Contracts using this EIP MUST implement the `IERC20ApproveBySpender` interface.
+Contracts using this EIP MUST implement the `IERC7410` interface.
 
 ### Interface implementation
 
@@ -33,10 +33,10 @@ Contracts using this EIP MUST implement the `IERC20ApproveBySpender` interface.
 pragma solidity ^0.8.0;
 
 /**
- * @title ERC-20 Modify Allowance By Spender Extension
+ * @title IERC-7410 Update Allowance By Spender Extension
  * Note: the ERC-165 identifier for this interface is 0x2d474b5c
  */
-interface IERC20ApproveBySpender is IERC20 {
+interface IERC7410 is IERC20 {
 
     /**
      * @notice Updates any allowance by `owner` address for caller.
@@ -59,17 +59,21 @@ The `supportsInterface` method MUST return `true` when called with `0x2d474b5c`.
 
 ## Rationale
 
-The name "EIP-20 Approval By Spender Extension" was chosen because it is a succinct description of this EIP. Spenders can decrease or revoke their allowance by `amount` from `owner`s.
+The name "ERC-7410 Approval By Spender Extension" was chosen because it is a succinct description of this EIP. Spenders can decrease or revoke their allowance by `amount` from `owner`s.
 
-By having a way to approve and revoke in a manner similar to [EIP-20](./eip-20.md), the trust level can be more directly managed by spender:
+By having a way to approve and revoke in a manner similar to [ERC-20](./eip-20.md), the trust level can be more directly managed by spender:
 
 - Using the `approveBySpender` function, spenders can revoke or decrease their allowance to spend an `amount`.
 
-The [EIP-20](./eip-20.md) name patterns were used due to similarities with [EIP-20](./eip-20.md) approvals.
+The [ERC-20](./eip-20.md) name patterns were used due to similarities with [ERC-20](./eip-20.md) approvals.
 
 ## Backwards Compatibility
 
-This standard is compatible with [EIP-20](./eip-20.md).
+This standard is compatible with [ERC-20](./eip-20.md).
+
+## Reference Implementation
+
+An minimal implementation is included [here](../assets/eip-7410/ERC7410.sol).
 
 ## Security Considerations
 

--- a/EIPS/eip-7410.md
+++ b/EIPS/eip-7410.md
@@ -43,8 +43,8 @@ interface IERC7410 is IERC20 {
      * Emits an {IERC20-Approval} event.
      *
      * Requirements:
-     * - `owner` cannot be the caller.
-     * - `subtractedValue` should be less than or equal to current allowance of `owner` for caller.
+     * - when `subtractedValue` is equal or higher than current allowance of spender the new allowance is set to 0.
+     * Nullification also MUST be reflected for current allowance being type(uint256).max.
      */
     function decreaseAllowanceBySpender(address owner, uint256 subtractedValue) external;
 

--- a/EIPS/eip-7410.md
+++ b/EIPS/eip-7410.md
@@ -59,8 +59,6 @@ The `supportsInterface` method MUST return `true` when called with `0x2d474b5c`.
 
 ## Rationale
 
-The name "ERC-7410 Approval By Spender Extension" was chosen because it is a succinct description of this EIP. Spenders can decrease or revoke their allowance by `amount` from `owner`s.
-
 By having a way to approve and revoke in a manner similar to [ERC-20](./eip-20.md), the trust level can be more directly managed by spender:
 
 - Using the `approveBySpender` function, spenders can revoke or decrease their allowance to spend an `amount`.

--- a/assets/eip-7410/ERC7410.sol
+++ b/assets/eip-7410/ERC7410.sol
@@ -16,8 +16,12 @@ contract ERC7410 is ERC20, IERC7410 {
         uint256 _value
     ) public override(ERC20, IERC7410) returns (bool success) {
         address spender = _msgSender();
-        require(allowance(_owner, spender) >= _value, "Not enough allowance");
-        _approve(_owner, spender, allowance(_owner, spender) - _value);
+        if (allowance(_owner, spender) > _value) {
+            _spendAllowance(_owner, spender, _value);
+        } else {
+            _approve(_owner, spender, 0);
+        }
+        
         return true;
     }
 

--- a/assets/eip-7410/ERC7410.sol
+++ b/assets/eip-7410/ERC7410.sol
@@ -11,13 +11,13 @@ contract ERC7410 is ERC20, IERC7410 {
         string memory symbol_
     ) ERC20(name_, symbol_) {}
 
-    function approveBySpender(
+    function decreaseAllowanceBySpender(
         address _owner,
         uint256 _value
     ) public override(ERC20, IERC7410) returns (bool success) {
         address spender = _msgSender();
         require(allowance(_owner, spender) >= _value, "Not enough allowance");
-        _approve(_owner, spender, _value);
+        _approve(_owner, spender, allowance(_owner, spender) - _value);
         return true;
     }
 

--- a/assets/eip-7410/ERC7410.sol
+++ b/assets/eip-7410/ERC7410.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity 0.8.17;
+
+import "openzeppelin-contracts/token/ERC20/ERC20.sol";
+import "./IERC7410.sol";
+
+contract ERC7410 is ERC20, IERC7410 {
+
+    constructor(
+        string memory name_,
+        string memory symbol_
+    ) ERC20(name_, symbol_) {}
+
+    function approveBySpender(
+        address _owner,
+        uint256 _value
+    ) public override(ERC20, IERC7410) returns (bool success) {
+        address spender = _msgSender();
+        require(allowance(_owner, spender) >= _value, "Not enough allowance");
+        _approve(_owner, spender, _value);
+        return true;
+    }
+
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual returns (bool) {
+        return interfaceId == type(IERC7410).interfaceId;
+    }
+}

--- a/assets/eip-7410/IERC7410.sol
+++ b/assets/eip-7410/IERC7410.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.17;
+
+import "openzeppelin-contracts/interfaces/IERC20.sol";
+import "openzeppelin-contracts/interfaces/IERC165.sol";
+
+/**
+ * @title ERC-7410 Update Allowance By Spender Extension
+ * Note: the ERC-165 identifier for this interface is 0x2d474b5c
+ */
+interface IERC20ApproveBySpender is IERC20, IERC165 {
+
+    /**
+     * @notice Updates any allowance by `owner` address for caller.
+     * Emits an {IERC20-Approval} event.
+     *
+     * Requirements:
+     * - `owner` cannot be the caller.
+     * - `amount` should be less than or equal to current allowance of `owner` for caller.
+     */
+    function approveBySpender(address owner, uint256 amount) external;
+
+}

--- a/assets/eip-7410/IERC7410.sol
+++ b/assets/eip-7410/IERC7410.sol
@@ -15,8 +15,8 @@ interface IERC7410 is IERC20, IERC165 {
      * Emits an {IERC20-Approval} event.
      *
      * Requirements:
-     * - `owner` cannot be the caller.
-     * - `subtractedValue` should be less than or equal to current allowance of `owner` for caller.
+     * - when `subtractedValue` is equal or higher than current allowance of spender the new allowance is set to 0.
+     * Nullification also MUST be reflected for current allowance being type(uint256).max.
      */
     function decreaseAllowanceBySpender(address owner, uint256 subtractedValue) external;
 

--- a/assets/eip-7410/IERC7410.sol
+++ b/assets/eip-7410/IERC7410.sol
@@ -6,18 +6,18 @@ import "openzeppelin-contracts/interfaces/IERC165.sol";
 
 /**
  * @title ERC-7410 Update Allowance By Spender Extension
- * Note: the ERC-165 identifier for this interface is 0x2d474b5c
+ * Note: the ERC-165 identifier for this interface is 0x12860fba
  */
-interface IERC20ApproveBySpender is IERC20, IERC165 {
+interface IERC7410 is IERC20, IERC165 {
 
     /**
-     * @notice Updates any allowance by `owner` address for caller.
+     * @notice Decreases any allowance by `owner` address for caller.
      * Emits an {IERC20-Approval} event.
      *
      * Requirements:
      * - `owner` cannot be the caller.
-     * - `amount` should be less than or equal to current allowance of `owner` for caller.
+     * - `subtractedValue` should be less than or equal to current allowance of `owner` for caller.
      */
-    function approveBySpender(address owner, uint256 amount) external;
+    function decreaseAllowanceBySpender(address owner, uint256 subtractedValue) external;
 
 }


### PR DESCRIPTION
This EIP adds a update allowance mechanism to ERC-20 allowances, in which a spender can revoke or decrease a given allowance by a specific address. This EIP extends [ERC-20](./eip-20.md).

- Ethereum-magicians [discussion](https://ethereum-magicians.org/t/eip-7410-update-allowance-by-spender/15222)