### PR TITLE
Update EIP-1559: Clarify who pays gas fees

### DIFF
--- a/EIPS/eip-1559.md
+++ b/EIPS/eip-1559.md
@@ -21,7 +21,7 @@ The algorithm results in the base fee per gas increasing when blocks are above t
 The base fee per gas is burned.
 Transactions specify the maximum fee per gas they are willing to give to miners to incentivize them to include their transaction (aka: priority fee).
 Transactions also specify the maximum fee per gas they are willing to pay total (aka: max fee), which covers both the priority fee and the block's network fee per gas (aka: base fee).
-The transaction will always pay the base fee per gas of the block it was included in, and they will pay the priority fee per gas set in the transaction, as long as the combined amount of the two fees doesn't exceed the transaction's maximum fee per gas.
+Senders will always pay the base fee per gas of the block their transaction was included in, and they will pay the priority fee per gas set in the transaction, as long as the combined amount of the two fees doesn't exceed the transaction's maximum fee per gas.
 
 ## Motivation
 Ethereum historically priced transaction fees using a simple auction mechanism, where users send transactions with bids ("gasprices") and miners choose transactions with the highest bids, and transactions that get included pay the bid that they specify. This leads to several large sources of inefficiency:


### PR DESCRIPTION
This PR clarifies the language by replacing the term 'transaction' with 'senders' to explicitly identifies who pays the base and priority fee. Makes the fee payment process more understandable for new readers.