### PR TITLE
Update EIP-4844: Align names and fix `KZGCommitment` description

### DIFF
--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -66,7 +66,7 @@ Compared to full data sharding, this EIP has a reduced cap on the number of thes
 | - | - | - |
 | `Blob` | `ByteVector[BYTES_PER_FIELD_ELEMENT * FIELD_ELEMENTS_PER_BLOB]` | |
 | `VersionedHash` | `Bytes32` | |
-| `KZGCommitment` | `Bytes48` | Same as BLS standard "is valid pubkey" check but also allows `0x00..00` for point-at-infinity |
+| `KZGCommitment` | `Bytes48` | Perform [BLS standard's](https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-04#section-2.5) "KeyValidate" check but do allow the identity point |
 | `KZGProof` | `Bytes48` | Same as for `KZGCommitment` |
 
 ### Cryptographic Helpers

--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -40,6 +40,7 @@ Compared to full data sharding, this EIP has a reduced cap on the number of thes
 | Constant | Value |
 | - | - |
 | `BLOB_TX_TYPE` | `Bytes1(0x03)` |
+| `BYTES_PER_FIELD_ELEMENT` | `32` |
 | `FIELD_ELEMENTS_PER_BLOB` | `4096` |
 | `BLS_MODULUS` | `52435875175126190479447740508185965837690552500527637822603658699938581184513` |
 | `VERSIONED_HASH_VERSION_KZG` | `Bytes1(0x01)` |
@@ -63,8 +64,7 @@ Compared to full data sharding, this EIP has a reduced cap on the number of thes
 
 | Type | Base type | Additional checks |
 | - | - | - |
-| `BLSFieldElement` | `uint256` | `x < BLS_MODULUS` |
-| `Blob` | `Vector[BLSFieldElement, FIELD_ELEMENTS_PER_BLOB]` | |
+| `Blob` | `ByteVector[BYTES_PER_FIELD_ELEMENT * FIELD_ELEMENTS_PER_BLOB]` | |
 | `VersionedHash` | `Bytes32` | |
 | `KZGCommitment` | `Bytes48` | Same as BLS standard "is valid pubkey" check but also allows `0x00..00` for point-at-infinity |
 | `KZGProof` | `Bytes48` | Same as for `KZGCommitment` |
@@ -304,7 +304,7 @@ rlp([tx_payload_body, blobs, commitments, proofs])
 Each of these elements are defined as follows:
 
 - `tx_payload_body` - is the `TransactionPayloadBody` of standard EIP-2718 [blob transaction](#blob-transaction)
-- `blobs` - list of `blob` bytes where each `blob` is its `BLSFieldElement` list flattened in `big endian`
+- `blobs` - list of `blob` bytes
 - `commitments` - list of `KZGCommitment` of the corresponding `blobs`
 - `proofs` - list of `KZGProof` of the corresponding `blobs` and `commitments`
 

--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -42,7 +42,7 @@ Compared to full data sharding, this EIP has a reduced cap on the number of thes
 | `BLOB_TX_TYPE` | `Bytes1(0x03)` |
 | `FIELD_ELEMENTS_PER_BLOB` | `4096` |
 | `BLS_MODULUS` | `52435875175126190479447740508185965837690552500527637822603658699938581184513` |
-| `BLOB_COMMITMENT_VERSION_KZG` | `Bytes1(0x01)` |
+| `VERSIONED_HASH_VERSION_KZG` | `Bytes1(0x01)` |
 | `POINT_EVALUATION_PRECOMPILE_ADDRESS` | `Bytes20(0x0A)` |
 | `POINT_EVALUATION_PRECOMPILE_GAS` | `50000` |
 | `MAX_BLOB_GAS_PER_BLOCK` | `786432` |
@@ -82,7 +82,7 @@ Specifically, we use the following methods from [`polynomial-commitments.md`](ht
 
 ```python
 def kzg_to_versioned_hash(commitment: KZGCommitment) -> VersionedHash:
-    return BLOB_COMMITMENT_VERSION_KZG + sha256(commitment)[1:]
+    return VERSIONED_HASH_VERSION_KZG + sha256(commitment)[1:]
 ```
 
 Approximates `factor * e ** (numerator / denominator)` using Taylor expansion:
@@ -275,9 +275,9 @@ def validate_block(block: Block) -> None:
             # there must be at least one blob
             assert len(tx.blob_versioned_hashes) > 0
 
-            # all versioned blob hashes must start with BLOB_COMMITMENT_VERSION_KZG
+            # all versioned blob hashes must start with VERSIONED_HASH_VERSION_KZG
             for h in tx.blob_versioned_hashes:
-                assert h[0] == BLOB_COMMITMENT_VERSION_KZG
+                assert h[0] == VERSIONED_HASH_VERSION_KZG
 
             # ensure that the user was willing to at least pay the current blob gasprice
             assert tx.max_fee_per_blob_gas >= get_blob_gasprice(block.header)

--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -66,7 +66,7 @@ Compared to full data sharding, this EIP has a reduced cap on the number of thes
 | - | - | - |
 | `Blob` | `ByteVector[BYTES_PER_FIELD_ELEMENT * FIELD_ELEMENTS_PER_BLOB]` | |
 | `VersionedHash` | `Bytes32` | |
-| `KZGCommitment` | `Bytes48` | Perform [BLS standard's](https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-04#section-2.5) "KeyValidate" check but do allow the identity point |
+| `KZGCommitment` | `Bytes48` | Perform IETF BLS signature "KeyValidate" check but do allow the identity point |
 | `KZGProof` | `Bytes48` | Same as for `KZGCommitment` |
 
 ### Cryptographic Helpers

--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -304,7 +304,7 @@ rlp([tx_payload_body, blobs, commitments, proofs])
 Each of these elements are defined as follows:
 
 - `tx_payload_body` - is the `TransactionPayloadBody` of standard EIP-2718 [blob transaction](#blob-transaction)
-- `blobs` - list of `blob` bytes
+- `blobs` - list of `Blob` items
 - `commitments` - list of `KZGCommitment` of the corresponding `blobs`
 - `proofs` - list of `KZGProof` of the corresponding `blobs` and `commitments`
 


### PR DESCRIPTION
Address https://github.com/ethereum/consensus-specs/issues/3462
1. Rename `BLOB_COMMITMENT_VERSION_KZG` to `VERSIONED_HASH_VERSION_KZG`
2. Use CL-specs defined `Blob: ByteVector[BYTES_PER_FIELD_ELEMENT * FIELD_ELEMENTS_PER_BLOB]` format.
    - Add `BYTES_PER_FIELD_ELEMENT` to EIP
    - Simplify the `blobs` field description in networking
3. **[New]** Fix `KZGCommitment` description: `0x00..00` is not the serialized format of G1 point at infinity. This PR copied [the CL spec defined `KZGCommitment` validation](https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/polynomial-commitments.md#custom-types) to EIP-4844.

