### PR TITLE
Update EIP-4788: set nonce of beacon root history address to nonzero

### DIFF
--- a/EIPS/eip-4788.md
+++ b/EIPS/eip-4788.md
@@ -82,7 +82,7 @@ When verifying a block, execution clients **MUST** ensure the root value in the 
 At the start of processing any execution block where `block.timestamp >= FORK_TIMESTAMP` (i.e. before processing any transactions),
 
 - write the parent beacon root provided in the block header into the storage of the contract at `HISTORY_STORAGE_ADDRESS`.
-- `iff` the `HISTORY_STORAGE_ADDRESS` has `nonce==0`, set `nonce` to `1`. This is to prevent touch-delete rules from deleting the account from the state.
+- If the `HISTORY_STORAGE_ADDRESS` has `nonce==0`, set `nonce` to `1`. This is to prevent touch-delete rules from deleting the account from the state.
 
 In order to bound the storage used by this precompile, two ring buffers are used: one to track the latest timestamp at a given index in the ring buffer and another to track
 the latest root at a given index.

--- a/EIPS/eip-4788.md
+++ b/EIPS/eip-4788.md
@@ -80,7 +80,9 @@ When verifying a block, execution clients **MUST** ensure the root value in the 
 #### Block processing
 
 At the start of processing any execution block where `block.timestamp >= FORK_TIMESTAMP` (i.e. before processing any transactions),
-write the parent beacon root provided in the block header into the storage of the contract at `HISTORY_STORAGE_ADDRESS`.
+
+- write the parent beacon root provided in the block header into the storage of the contract at `HISTORY_STORAGE_ADDRESS`.
+- `iff` the `HISTORY_STORAGE_ADDRESS` has `nonce==0`, set `nonce` to `1`. This is to prevent touch-delete rules from deleting the account from the state.
 
 In order to bound the storage used by this precompile, two ring buffers are used: one to track the latest timestamp at a given index in the ring buffer and another to track
 the latest root at a given index.

--- a/EIPS/eip-4788.md
+++ b/EIPS/eip-4788.md
@@ -81,7 +81,7 @@ When verifying a block, execution clients **MUST** ensure the root value in the 
 
 At the start of processing any execution block where `block.timestamp >= FORK_TIMESTAMP` (i.e. before processing any transactions),
 
-- write the parent beacon root provided in the block header into the storage of the contract at `HISTORY_STORAGE_ADDRESS`.
+- Write the parent beacon root provided in the block header into the storage of the contract at `HISTORY_STORAGE_ADDRESS`.
 - If the `HISTORY_STORAGE_ADDRESS` has `nonce==0`, set `nonce` to `1`. This is to prevent touch-delete rules from deleting the account from the state.
 
 In order to bound the storage used by this precompile, two ring buffers are used: one to track the latest timestamp at a given index in the ring buffer and another to track


### PR DESCRIPTION
This is a not-yet approved specification-change for EIP 4788. I put it up for discussion on next ACD. 