### PR TITLE
Update EIP-1822: remove unnecessary toc

### DIFF
--- a/EIPS/eip-1822.md
+++ b/EIPS/eip-1822.md
@@ -30,7 +30,7 @@ The following describes a standard for proxy contracts which is universally comp
 - **Logic Contract** - The contract **B** which contains the logic used by Proxy Contract **A**
 - **Proxiable Contract** - Inherited in Logic Contract **B** to provide the upgrade functionality
 
-<p align="center"><img src="../assets/eip-1822/proxy-diagram.png" alt="diagram" width="600"/></p>
+![](../assets/eip-1822/proxy-diagram.png)
 
 ## Specification
 

--- a/EIPS/eip-1822.md
+++ b/EIPS/eip-1822.md
@@ -9,36 +9,6 @@ category: ERC
 created: 2019-03-04
 ---
 
-## Table of contents
-
-<!-- TOC -->
-
-- [Table of contents](#table-of-contents)
-- [Simple Summary](#simple-summary)
-- [Abstract](#abstract)
-- [Motivation](#motivation)
-- [Terminology](#terminology)
-- [Specification](#specification)
-  - [Proxy Contract](#proxy-contract)
-    - [Functions](#functions)
-      - [`fallback`](#fallback)
-    - [`constructor`](#constructor)
-  - [Proxiable Contract](#proxiable-contract)
-    - [Functions](#functions-1)
-      - [`proxiable`](#proxiable)
-      - [`updateCodeAddress`](#updatecodeaddress)
-- [Pitfalls when using a proxy](#pitfalls-when-using-a-proxy)
-  - [Separating Variables from Logic](#separating-variables-from-logic)
-  - [Restricting dangerous functions](#restricting-dangerous-functions)
-- [Examples](#examples)
-  - [Owned](#owned)
-  - [ERC-20 Token](#erc-20-token)
-    - [Proxy Contract](#proxy-contract-1)
-    - [Token Logic Contract](#token-logic-contract)
-- [References](#references)
-- [Copyright](#copyright)
-    <!-- /TOC -->
-
 ## Simple Summary
 
 Standard upgradeable proxy contract.


### PR DESCRIPTION
ToC is automatically generated, so removed the manual ToC.
https://eips.ethereum.org/EIPS/eip-1822

![image](https://github.com/ethereum/EIPs/assets/20497787/a3f78136-2ab6-4d5a-8698-16e7f30f7630)
