### PR TITLE
Update EIP-4788: Mention genesis block with no existing beacon block root case

### DIFF
--- a/EIPS/eip-4788.md
+++ b/EIPS/eip-4788.md
@@ -75,6 +75,8 @@ Validity of the parent beacon block root is guaranteed from the consensus layer,
 
 When verifying a block, execution clients **MUST** ensure the root value in the block header matches the one provided by the consensus client.
 
+For a genesis block with no existing parent beacon block root the 32 zero bytes are used as a root placeholder.
+
 ### EVM changes
 
 #### Block processing


### PR DESCRIPTION
This just came up in a discussion on how to populate the new beacon block root header field for the case where Cancun starts at genesis and there is no beacon block root present for the genesis block.