### PR TITLE
Update EIP-6963: use data URI for icon value in Wallet Provider implementation example

### DIFF
--- a/EIPS/eip-6963.md
+++ b/EIPS/eip-6963.md
@@ -189,7 +189,7 @@ function onPageLoad() {
     const info: EIP6963ProviderInfo = {
       uuid: "350670db-19fa-4704-a166-e52e178b59d2",
       name: "Example Wallet",
-      icon: "https://wallet.example.org/icon.png",
+      icon: "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg'/>",
       rdns: "com.example.wallet"
 };
     window.dispatchEvent(


### PR DESCRIPTION
Spec was updated to specify that `icon` must be data URI in [32fbcd8d7422958a9afe51f6ef02e96044af8594](https://github.com/ethereum/EIPs/commit/32fbcd8d7422958a9afe51f6ef02e96044af8594)

This updates the Wallet Provider implementation example to use a data uri for its `icon` value