### PR TITLE
Update EIP-7201: eip-7201.md

### DIFF
--- a/EIPS/eip-7201.md
+++ b/EIPS/eip-7201.md
@@ -28,7 +28,7 @@ A _namespace_ consists of a set of variables that are placed contiguous in the s
 
 A _namespace id_ is a string that uniquely identifies a namespace in a contract. It should not contain any whitespace characters.
 
-The storage location for a namespace is defined as `ns_loc(id: string) = keccak256(uint256(keccak256(id)) - 1)`.
+The storage location for a namespace is defined as `ns_loc(id: string) = keccak256(abi.encode(uint256(keccak256(id)) - 1))`.
 
 A Solidity contract using namespaced storage can annotate a struct with the NatSpec tag `@custom:storage-location erc7201:<NAMESPACE_ID>` to identify it as a namespace with id `<NAMESPACE_ID>`. _(Note: The Solidity compiler includes this annotation in the AST since v0.8.20, so this is recommended as the minimum compiler version when using this pattern.)_
 


### PR DESCRIPTION
The spec definition is missing abi encoding so it cannot be compiled as is. Fixed by simply wrapping with  `abi.encode` before keccak256 hashing.

The reference implementation correctly includes the abi encoding, as seen in line 66- this edit simply updates the spec definition to reflect that code.

When opening a pull request to submit a new EIP, please use the suggested template: https://github.com/ethereum/EIPs/blob/master/eip-template.md

We have a GitHub bot that automatically merges some PRs. It will merge yours immediately if certain criteria are met:

 - The PR edits only existing draft PRs.
 - The build passes.
 - Your GitHub username or email address is listed in the 'author' header of all affected PRs, inside <triangular brackets>.
 - If matching on email address, the email address is the one publicly listed on your GitHub profile.
