### PR TITLE
Update EIP-6963: Add RDNS section for motivation and requirements

### DIFF
--- a/EIPS/eip-6963.md
+++ b/EIPS/eip-6963.md
@@ -80,7 +80,7 @@ The `icon` string MUST be a data URI as defined in [RFC-2397]. The image SHOULD 
 The **`rdns`** (Reverse-DNS) property serves to provide an identifier which DApps can rely on to be stable between sessions. The Reverse Domain Name Notation is chosen to prevent namespace collisions.
 The Reverse-DNS convention implies that the value should start with a reversed DNS domain name controlled by the Provider. The domain name should be followed by a subdomain or a product name. Example: `com.example.MyBrowserWallet`.
 
-- The DNS part of the `rdns` value MUST BE a valid [RFC-1034] Domain Name;
+- The `rdns` value MUST BE a valid [RFC-1034] Domain Name;
 - The DNS part of the `rdns` value SHOULD BE an active domain controlled by the Provider;
 - DApps MAY reject the Providers which do not follow the Reverse-DNS convention correctly;
 - DApps SHOULD NOT use the `rnds` value for feature detection as these are self-attested and prone to impersonation or bad incentives without an additional verification mechanism; feature-discovery and verification are both out of scope of this interface specification.

--- a/EIPS/eip-6963.md
+++ b/EIPS/eip-6963.md
@@ -83,7 +83,7 @@ The Reverse-DNS convention implies that the value should start with a reversed D
 - The DNS part of the `rdns` value MUST BE a valid [RFC-1034] Domain Name;
 - The DNS part of the `rdns` value SHOULD BE an active domain controlled by the Provider;
 - DApps MAY reject the Providers which do not follow the Reverse-DNS convention correctly;
-- DApps MUST NOT use the `rnds` value for feature detection;
+- DApps SHOULD NOT use the `rnds` value for feature detection as these are self-attested and prone to impersonation or bad incentives without an additional verification mechanism; feature-discovery and verification are both out of scope of this interface specification.
 
 ### Provider Detail
 

--- a/EIPS/eip-6963.md
+++ b/EIPS/eip-6963.md
@@ -75,6 +75,16 @@ data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12
 
 The `icon` string MUST be a data URI as defined in [RFC-2397]. The image SHOULD be squared with 96x96px minimum resolution. The image format is RECOMMENDED to be either lossless or vector based such as PNG, WebP or SVG to make the image easy to render on the DApp. Since SVG images can execute Javascript, applications and libraries MUST render SVG images using the `<img>` tag to ensure no untrusted Javascript execution can occur.
 
+#### RDNS
+
+The **`rdns`** (Reverse-DNS) property serves to provide an identifier which DApps can rely on to be stable between sessions. The Reverse Domain Name Notation is chosen to prevent namespace collisions.
+The Reverse-DNS convention implies that the value should start with a reversed DNS domain name controlled by the Provider. The domain name should be followed by a subdomain or a product name. Example: `com.example.MyBrowserWallet`.
+
+- The DNS part of the `rdns` value MUST BE a valid [RFC-1034] Domain Name;
+- The DNS part of the `rdns` value SHOULD BE an active domain controlled by the Provider;
+- DApps MAY reject the Providers which do not follow the Reverse-DNS convention correctly;
+- DApps MUST NOT use the `rnds` value for feature detection;
+
 ### Provider Detail
 
 The `EIP6963ProviderDetail` is used as a composition interface to announce a Wallet Provider and and related metadata about the Wallet Provider. The `EIP6963ProviderDetail` MUST contain an `info` property of type `EIP6963ProviderInfo` and a `provider` property of type `EIP1193Provider` defined by [EIP-1193](./eip-1193.md).
@@ -257,6 +267,7 @@ One advantage to the concurrency Event loop utilized by this design is that it o
 Copyright and related rights waived via [CC0](../LICENSE.md).
 
 
+[RFC-1034]: https://www.rfc-editor.org/rfc/rfc1034
 [RFC-2119]: https://www.rfc-editor.org/rfc/rfc2119
 [RFC-2397]: https://www.rfc-editor.org/rfc/rfc2397
 [RFC-3986]: https://www.rfc-editor.org/rfc/rfc3986


### PR DESCRIPTION
This update adds a section to provide requirements and motivation for the `rdns` property.

I was originally planning to add example UI flows where a DApp would use this value, but I'm not sure this belongs in the spec. I'm thinking that saying that the DApps can rely on this property being stable might be enough.

