### PR TITLE
Update eip-223.md

### DIFF
--- a/EIPS/eip-223.md
+++ b/EIPS/eip-223.md
@@ -38,7 +38,7 @@ Token transfers to contracts not implementing `tokenReceived` as described below
 function totalSupply() view returns (uint256 totalSupply)
 ```
 
-Gets the total supply of the token. The functionality of this method is identical to that of ERC-20.
+Returns the total supply of the token. The functionality of this method is identical to that of ERC-20.
 
 ##### `name`
 
@@ -46,17 +46,17 @@ Gets the total supply of the token. The functionality of this method is identica
 function name() view returns (string _name)
 ```
 
-Gets the name of the token.  The functionality of this method is identical to that of ERC-20.
+Returns the name of the token.  The functionality of this method is identical to that of ERC-20.
 
 OPTIONAL - This method can be used to improve usability, but interfaces and other contracts MUST NOT expect these values to be present.
 
 ##### `symbol`
 
 ```solidity
-function symbol() view returns (bytes32 _symbol)
+function symbol() view returns (string _symbol)
 ```
 
-Gets the symbol of the token. The functionality of this method is identical to that of ERC-20.
+Returns the symbol of the token. The functionality of this method is identical to that of ERC-20.
 
 OPTIONAL - This method can be used to improve usability, but interfaces and other contracts MUST NOT expect these values to be present.
 
@@ -66,7 +66,17 @@ OPTIONAL - This method can be used to improve usability, but interfaces and othe
 function decimals() view returns (uint8 _decimals)
 ```
 
-Gets the number of decimals of the token. The functionality of this method is identical to that of ERC-20.
+Returns the number of decimals of the token. The functionality of this method is identical to that of ERC-20.
+
+OPTIONAL - This method can be used to improve usability, but interfaces and other contracts MUST NOT expect these values to be present. 
+
+##### `standard`
+
+```solidity
+function standard() public view returns (string memory)  
+```
+
+Returns the identifier of the standard. If the token is [ERC-223](./eip-20.md) then it must return `"223"`.
 
 OPTIONAL - This method can be used to improve usability, but interfaces and other contracts MUST NOT expect these values to be present.
 
@@ -76,7 +86,7 @@ OPTIONAL - This method can be used to improve usability, but interfaces and othe
 function balanceOf(address _owner) view returns (uint256 balance)
 ```
 
-Gets the account balance of another account with address `_owner`. The functionality of this method is identical to that of ERC-20.
+Returns the account balance of another account with address `_owner`. The functionality of this method is identical to that of ERC-20.
 
 ##### `transfer(address, uint)`
 


### PR DESCRIPTION
Correct spelling.

Replace `bytes32` symbol type with `string` because it must be string. 

Add `standard` function to the ERC-223 standard description because it was removed as per this comment https://github.com/ethereum/EIPs/pull/6485#discussion_r1103853086

This must be noted that "Interface introspection" and "Standard recognition" are two different tasks and therefore EIP-165 is not applicable to standard recognition.

```solidity
interface HybridToken {
    function transfer(address to, uint256 value) external returns (bool);
    function approve(address spender, uint256 value) external returns (bool);
    function transferFrom(address from, address to, uint256 value) external returns (bool);
}
```

For example this hybrid token can utilize ERC-20 transferring patterns or ERC-223 transferring patterns depending on how it's `transfer` function is implemented.

Also, this is not a new method of introspection that I'm planning to introduce so there is no reason to submit it as a new EIP. This is just a method of identifying whether a token implements ERC-223 compatible  `transfer` function or not for UIs.