### PR TITLE
Update EIP-6909: update eip-6909

### DIFF
--- a/EIPS/eip-6909.md
+++ b/EIPS/eip-6909.md
@@ -249,10 +249,10 @@ SHOULD be logged with the `receiver` address as the zero address when an `amount
       type: address
     - name: id
       indexed: true
-      type: address
+      type: uint256
     - name: amount
       indexed: false
-      type: address
+      type: uint256
 ```
 
 #### `OperatorSet`

--- a/EIPS/eip-6909.md
+++ b/EIPS/eip-6909.md
@@ -130,6 +130,8 @@ MUST revert when the caller's balance for the token `id` is insufficient.
 
 MUST log the `Transfer` event.
 
+MUST return True.
+
 ```yaml
 - name: transfer
   type: function
@@ -143,7 +145,9 @@ MUST log the `Transfer` event.
     - name: amount
       type: uint256
 
-  outputs: []
+  outputs:
+    - name: success
+      type: bool
 ```
 
 #### `transferFrom`
@@ -162,6 +166,8 @@ SHOULD NOT decrease the caller's `allowance` for the token `id` for the `sender`
 
 SHOULD NOT decrease the caller's `allowance` for the token `id` for the `sender` if the caller is an operator.
 
+MUST return True.
+
 ```yaml
 - name: transferFrom
   type: function
@@ -177,7 +183,9 @@ SHOULD NOT decrease the caller's `allowance` for the token `id` for the `sender`
     - name: amount
       type: uint256
 
-  outputs: []
+  outputs:
+    - name: success
+      type: bool
 ```
 
 #### `approve`
@@ -187,6 +195,8 @@ Approves an `amount` of a token `id` that a `spender` is permitted to transfer o
 MUST set the `allowance` of the `spender` of the token `id` for the caller to the `amount`.
 
 MUST log the `Approval` event.
+
+MUST return True.
 
 ```yaml
 - name: approve
@@ -201,7 +211,9 @@ MUST log the `Approval` event.
     - name: amount
       type: uint256
 
-  outputs: []
+  outputs:
+    - name: success
+      type: bool
 ```
 
 #### `setOperator`
@@ -212,6 +224,8 @@ MUST set the operator status to the `approved` value.
 
 MUST log the `OperatorSet` event.
 
+MUST return True.
+
 ```yaml
 - name: setOperator
   type: function
@@ -221,6 +235,10 @@ MUST log the `OperatorSet` event.
     - name: spender
       type: address
     - name: approved
+      type: bool
+
+  outputs:
+    - name: success
       type: bool
 ```
 


### PR DESCRIPTION
- fix incorrect types in `Transfer` event
- add a `bool` return value for `transfer`, `transferFrom`, `approve`, `setOperator` because it makes calls from contracts cheaper