### PR TITLE
Update EIP-6909: fix spelling mistakes

### DIFF
--- a/EIPS/eip-6909.md
+++ b/EIPS/eip-6909.md
@@ -536,20 +536,20 @@ contract ERC6909 {
 
     /// @notice Checks if a contract implements an interface.
     /// @param interfaceId The interface identifier, as specified in ERC-165.
-    /// @return supported True if the contract implements `interfaceId` and
+    /// @return supported True if the contract implements `interfaceId`.
     function supportsInterface(bytes4 interfaceId) public pure returns (bool supported) {
         return interfaceId == 0xb2e69f8a || interfaceId == 0x01ffc9a7;
     }
 
     function _mint(address receiver, uint256 id, uint256 amount) internal {
-      // WARNING: important safety checks should preceed calls to this method.
+      // WARNING: important safety checks should precede calls to this method.
       balanceOf[receiver][id] += amount;
       totalSupply[id] += amount;
       emit Transfer(address(0), receiver, id, amount);
     }
 
     function _burn(address sender, uint256 id, uint256 amount) internal {
-      // WARNING: important safety checks should preceed calls to this method.
+      // WARNING: important safety checks should precede calls to this method.
       balanceOf[sender][id] -= amount;
       totalSupply[id] -= amount;
       emit Transfer(sender, address(0), id, amount);


### PR DESCRIPTION
- Fixes `preceed` spelling with `precede`
- Removes trailing `and`
