### PR TITLE
Update EIP-4844: Remove unused constants

### DIFF
--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -50,11 +50,6 @@ Compared to full data sharding, this EIP has a reduced cap on the number of thes
 | `TARGET_BLOB_GAS_PER_BLOCK` | `393216` |
 | `MIN_BLOB_GASPRICE` | `1` |
 | `BLOB_GASPRICE_UPDATE_FRACTION` | `3338477` |
-| `MAX_VERSIONED_HASHES_LIST_SIZE` | `2**24` |
-| `MAX_CALLDATA_SIZE` | `2**24` |
-| `MAX_ACCESS_LIST_SIZE` | `2**24` |
-| `MAX_ACCESS_LIST_STORAGE_KEYS` | `2**24` |
-| `MAX_TX_WRAP_COMMITMENTS` | `2**12` |
 | `LIMIT_BLOBS_PER_TX` | `2**12` |
 | `GAS_PER_BLOB` | `2**17` |
 | `HASH_OPCODE_BYTE` | `Bytes1(0x49)` |
@@ -253,12 +248,12 @@ On the execution layer, the block validity conditions are extended as follows:
 ```python
 def validate_block(block: Block) -> None:
     ...
-    
+
     # check that the excess blob gas was updated correctly
     assert block.header.excess_blob_gas == calc_excess_blob_gas(block.parent.header)
 
     blob_gas_used = 0
-    
+
     for tx in block.transactions:
         ...
 


### PR DESCRIPTION
Many constants that were introduced for older SSZ flavor of EIP-4844 are no longer used. Remove references to them.