### PR TITLE
CI: New `eipw` version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Checkout EIP Repository
         uses: actions/checkout@47fbe2df0ad0e27efb67a70beac3555f192b062f
 
-      - uses: ethereum/eipw-action@af0856c89aa1a245cf0da9ae904eafbbddb94ecf
+      - uses: ethereum/eipw-action@b8de7ea9ad5cb842301e63898afb996c451c18cf
         id: eipw
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This version of `eipw` introduces support for f u l l y c o n f i g u r i n g from a TOML file.

For example:

```toml
[lints.banana]
kind = "preamble-regex"
name = "title"
mode = "includes"
pattern = "banana"
message = "`title` preamble field must include `banana`"

[[modifiers]]
kind = "set-default-annotation"
name = "eip"
value = "7444"
annotation_type = "info"
```

This would replace _all_ default lints with just `banana`, and replaces _all_ modifiers to just one that downgrades all messages for EIP-7444 to info.

To enable a configuration file, you need to specify a path in the workflow with `options-file`.