### PR TITLE
Update EIP-6120: Update to payload interface

### DIFF
--- a/EIPS/eip-6120.md
+++ b/EIPS/eip-6120.md
@@ -56,15 +56,6 @@ interface IUniversalTokenRouter {
         Output[] memory outputs,
         Action[] memory actions
     ) payable;
-
-    function pay(
-        address sender,
-        address recipient,
-        uint eip,
-        address token,
-        uint id,
-        uint amount
-    );
 }
 ```
 
@@ -125,7 +116,7 @@ struct Input {
 
 Each input in the `inputs` argument is processed sequentially. For simplicity, duplicated `PAYMENT` and `CALL_VALUE` inputs are valid, but only the last `amountIn` value is used.
 
-#### Payment
+#### Payment Input
 
 `PAYMENT` is the recommended mode for application contracts that use the *transfer-in-callback* pattern. E.g., flashloan contracts, Uniswap/v3-core, etc.
 
@@ -154,19 +145,39 @@ Token's allowance and `PAYMENT` are essentially different as:
 * allowance: allow a specific `spender` to transfer the token to anyone at any time.
 * `PAYMENT`: allow anyone to transfer the token to a specific `recipient` only in that transaction.
 
-#### Discard Payment
-
-Sometimes, it's useful to discard the payment instead of performing the transfer, for example, when the application contract wants to burn its own token from `msg.sender`. The following function can be used to verify the payment to the caller's address and discard a portion of it.
+##### Spend Payment
 
 ```solidity
-IUniversalTokenRouter.discard(
-    address sender,
-    uint eip,
-    address token,
-    uint id,
-    uint amount
+interface IUniversalTokenRouter {
+    function pay(bytes memory payment, uint amount);
+}
+```
+
+To call `pay`, the `payment` param must be encoded as follows:
+
+```solidity
+payment = abi.encode(
+    payer,      // address
+    recipient,  // address
+    eip,        // uint256
+    token,      // address
+    id          // uint256
 );
 ```
+
+The `payment` bytes can also be used by adapter UTR contracts to pass contexts and payloads for performing custom payment logic.
+
+##### Discard Payment
+
+Sometimes, it's useful to discard the payment instead of performing the transfer, for example, when the application contract wants to burn its own token from `payment.payer`. The following function can be used to verify the payment to the caller's address and discard a portion of it.
+
+```solidity
+interface IUniversalTokenRouter {
+    function discard(bytes memory payment, uint amount);
+}
+```
+
+See [Discard Payment](#discard-payment-1) in **Security Considerations** for an important security note.
 
 ### Usage Examples
 
@@ -248,7 +259,8 @@ contract SwapHelper {
     ) internal {
         ...
         // pull payment
-        UTR.pay(payer, recipient, 20, token, 0, value);
+        bytes memory payment = abi.encode(payer, recipient, 20, token, 0);
+        UTR.pay(payment, value);
     }
 }
 ```
@@ -388,19 +400,19 @@ Additional helper and adapter contracts might be needed, but they're mostly peri
 ## Reference Implementation
 
 ```solidity
-contract UniversalTokenRouter is IUniversalTokenRouter {
-    uint constant PAYMENT       = 0;
-    uint constant TRANSFER      = 1;
-    uint constant CALL_VALUE    = 2;
+contract UniversalTokenRouter is ERC165, IUniversalTokenRouter {
+    uint256 constant PAYMENT       = 0;
+    uint256 constant TRANSFER      = 1;
+    uint256 constant CALL_VALUE    = 2;
 
-    uint constant EIP_ETH       = 0;
+    uint256 constant EIP_ETH       = 0;
 
-    uint constant ERC_721_BALANCE = uint(keccak256('UniversalTokenRouter.ERC_721_BALANCE'));
+    uint256 constant ERC_721_BALANCE = uint256(keccak256('UniversalTokenRouter.ERC_721_BALANCE'));
 
     // transient pending payments
-    mapping(bytes32 => uint) t_payments;
+    mapping(bytes32 => uint256) t_payments;
 
-    // accepting ETH for WETH.withdraw
+    // accepting ETH for user execution (e.g. WETH.withdraw)
     receive() external payable {}
 
     function exec(
@@ -409,30 +421,34 @@ contract UniversalTokenRouter is IUniversalTokenRouter {
     ) override external payable {
     unchecked {
         // track the expected balances before any action is executed
-        for (uint i = 0; i < outputs.length; ++i) {
+        for (uint256 i = 0; i < outputs.length; ++i) {
             Output memory output = outputs[i];
-            uint balance = _balanceOf(output);
-            uint expected = output.amountOutMin + balance;
+            uint256 balance = _balanceOf(output);
+            uint256 expected = output.amountOutMin + balance;
             require(expected >= balance, 'UniversalTokenRouter: OUTPUT_BALANCE_OVERFLOW');
             output.amountOutMin = expected;
         }
 
         address sender = msg.sender;
 
-        for (uint i = 0; i < actions.length; ++i) {
+        for (uint256 i = 0; i < actions.length; ++i) {
             Action memory action = actions[i];
-            uint value;
-            for (uint j = 0; j < action.inputs.length; ++j) {
+            uint256 value;
+            for (uint256 j = 0; j < action.inputs.length; ++j) {
                 Input memory input = action.inputs[j];
-                uint mode = input.mode;
-                if (mode == PAYMENT) {
-                    bytes32 key = keccak256(abi.encodePacked(sender, input.recipient, input.eip, input.token, input.id));
-                    t_payments[key] = input.amountIn;
-                } else if (mode == TRANSFER) {
-                    _transferToken(sender, input.recipient, input.eip, input.token, input.id, input.amountIn);
-                } else if (mode == CALL_VALUE) {
+                uint256 mode = input.mode;
+                if (mode == CALL_VALUE) {
                     // eip and id are ignored
                     value = input.amountIn;
+                } else {
+                    if (mode == PAYMENT) {
+                        bytes32 key = keccak256(abi.encode(sender, input.recipient, input.eip, input.token, input.id));
+                        t_payments[key] = input.amountIn;
+                    } else if (mode == TRANSFER) {
+                        _transferToken(sender, input.recipient, input.eip, input.token, input.id, input.amountIn);
+                    } else {
+                        revert('UniversalTokenRouter: INVALID_MODE');
+                    }
                 }
             }
             if (action.data.length > 0) {
@@ -444,7 +460,7 @@ contract UniversalTokenRouter is IUniversalTokenRouter {
                 }
             }
             // clear all transient storages, allowances and left-overs
-            for (uint j = 0; j < action.inputs.length; ++j) {
+            for (uint256 j = 0; j < action.inputs.length; ++j) {
                 Input memory input = action.inputs[j];
                 if (input.mode == PAYMENT) {
                     // transient storages
@@ -455,63 +471,54 @@ contract UniversalTokenRouter is IUniversalTokenRouter {
         }
 
         // refund any left-over ETH
-        uint leftOver = address(this).balance;
+        uint256 leftOver = address(this).balance;
         if (leftOver > 0) {
             TransferHelper.safeTransferETH(sender, leftOver);
         }
 
         // verify balance changes
-        for (uint i = 0; i < outputs.length; ++i) {
+        for (uint256 i = 0; i < outputs.length; ++i) {
             Output memory output = outputs[i];
-            uint balance = _balanceOf(output);
+            uint256 balance = _balanceOf(output);
             // NOTE: output.amountOutMin is reused as `expected`
             require(balance >= output.amountOutMin, 'UniversalTokenRouter: INSUFFICIENT_OUTPUT_AMOUNT');
         }
     } }
-
-    function _reducePayment(
-        address sender,
-        address recipient,
-        uint eip,
-        address token,
-        uint id,
-        uint amount
-    ) internal {
-    unchecked {
-        bytes32 key = keccak256(abi.encodePacked(sender, recipient, eip, token, id));
-        require(t_payments[key] >= amount, 'UniversalTokenRouter: INSUFFICIENT_PAYMENT');
-        t_payments[key] -= amount;
-    } }
-
-    function pay(
-        address sender,
-        address recipient,
-        uint eip,
-        address token,
-        uint id,
-        uint amount
-    ) override external {
-        _reducePayment(sender, recipient, eip, token, id, amount);
+    
+    function pay(bytes memory payment, uint256 amount) external override {
+        discard(payment, amount);
+        (
+            address sender,
+            address recipient,
+            uint256 eip,
+            address token,
+            uint256 id
+        ) = abi.decode(payment, (address, address, uint256, address, uint256));
         _transferToken(sender, recipient, eip, token, id, amount);
     }
 
-    function discard(
-        address sender,
-        uint eip,
-        address token,
-        uint id,
-        uint amount
-    ) public override {
-        _reducePayment(sender, msg.sender, eip, token, id, amount);
+    function discard(bytes memory payment, uint256 amount) public override {
+        bytes32 key = keccak256(payment);
+        require(t_payments[key] >= amount, 'UniversalTokenRouter: INSUFFICIENT_PAYMENT');
+        unchecked {
+            t_payments[key] -= amount;
+        }
+    }
+
+    // IERC165-supportsInterface
+    function supportsInterface(bytes4 interfaceId) public view virtual override(ERC165, IERC165) returns (bool) {
+        return
+            interfaceId == type(IUniversalTokenRouter).interfaceId ||
+            super.supportsInterface(interfaceId);
     }
 
     function _transferToken(
         address sender,
         address recipient,
-        uint eip,
+        uint256 eip,
         address token,
-        uint id,
-        uint amount
+        uint256 id,
+        uint256 amount
     ) internal {
         if (eip == 20) {
             TransferHelper.safeTransferFrom(token, sender, recipient, amount);
@@ -526,8 +533,8 @@ contract UniversalTokenRouter is IUniversalTokenRouter {
 
     function _balanceOf(
         Output memory output
-    ) internal view returns (uint balance) {
-        uint eip = output.eip;
+    ) internal view returns (uint256 balance) {
+        uint256 eip = output.eip;
         if (eip == 20) {
             return IERC20(output.token).balanceOf(output.recipient);
         }
@@ -554,7 +561,9 @@ contract UniversalTokenRouter is IUniversalTokenRouter {
 
 ## Security Considerations
 
-Tokens transferred to the UTR contract will be lost forever, as there is no way to transfer them out.
+### Reentrancy
+
+Tokens transferred to the UTR contract will be permanently lost, as there is no way to transfer them out. Applications that require an intermediate address to hold tokens should use their own Helper contract with a reentrancy guard for secure execution.
 
 ETH must be transferred to the UTR contracts before the value is spent in an action call (using `CALL_VALUE`). This ETH value can be siphoned out of the UTR using a re-entrant call inside an action code or rogue token functions. This exploit will not be possible if users don't transfer more ETH than they will spend in that transaction.
 
@@ -577,6 +586,10 @@ UniversalTokenRouter.exec([
     value: 100,   // transfer 100 in
 })
 ```
+
+### Discard Payment
+
+The result of the `pay` function can be checked by querying the balance after the call, allowing the UTR contract to be called in a trustless manner. However, due to the inability to verify the execution of the `discard` function, it should only be used with a trusted UTR contract.
 
 ## Copyright
 

--- a/EIPS/eip-6120.md
+++ b/EIPS/eip-6120.md
@@ -2,7 +2,7 @@
 eip: 6120
 title: Universal Token Router
 description: A single router contract enables tokens to be sent to application contracts in the transfer-and-call pattern instead of approve-then-call.
-author: Zergity (@Zergity), Ngo Quang Anh (@anhnq82), BerlinP (@BerlinP), Khanh Pham (@blackskin18), Hal Blackburn (@h4l)
+author: Derivable (@derivable-labs), Zergity (@Zergity), Ngo Quang Anh (@anhnq82), BerlinP (@BerlinP), Khanh Pham (@blackskin18), Hal Blackburn (@h4l)
 discussions-to: https://ethereum-magicians.org/t/eip-6120-universal-token-router/12142
 status: Review
 type: Standards Track
@@ -118,7 +118,7 @@ Each input in the `inputs` argument is processed sequentially. For simplicity, d
 
 #### Payment Input
 
-`PAYMENT` is the recommended mode for application contracts that use the *transfer-in-callback* pattern. E.g., flashloan contracts, Uniswap/v3-core, etc.
+`PAYMENT` is the recommended mode for application contracts that use the *transfer-in-callback* pattern. E.g., flashloan contracts, Uniswap/v3-core, Derivable, etc.
 
 For each `Input` with `PAYMENT` mode, at most `amountIn` of the token can be transferred from `msg.sender` to the `recipient` by calling `UTR.pay` from anywhere in the same transaction.
 
@@ -398,6 +398,8 @@ contract WethAdapter {
 Additional helper and adapter contracts might be needed, but they're mostly peripheral and non-intrusive. They don't hold any tokens or allowances, so they can be frequently updated and have little to no security impact on the core application contracts.
 
 ## Reference Implementation
+
+A reference implementation by the Derivable protocol:
 
 ```solidity
 contract UniversalTokenRouter is ERC165, IUniversalTokenRouter {

--- a/EIPS/eip-6120.md
+++ b/EIPS/eip-6120.md
@@ -420,7 +420,7 @@ contract UniversalTokenRouter is ERC165, IUniversalTokenRouter {
     function exec(
         Output[] memory outputs,
         Action[] memory actions
-    ) override external payable {
+    ) external payable virtual override {
     unchecked {
         // track the expected balances before any action is executed
         for (uint256 i = 0; i < outputs.length; ++i) {
@@ -487,7 +487,7 @@ contract UniversalTokenRouter is ERC165, IUniversalTokenRouter {
         }
     } }
     
-    function pay(bytes memory payment, uint256 amount) external override {
+    function pay(bytes memory payment, uint256 amount) external virtual override {
         discard(payment, amount);
         (
             address sender,
@@ -499,7 +499,7 @@ contract UniversalTokenRouter is ERC165, IUniversalTokenRouter {
         _transferToken(sender, recipient, eip, token, id, amount);
     }
 
-    function discard(bytes memory payment, uint256 amount) public override {
+    function discard(bytes memory payment, uint256 amount) public virtual override {
         bytes32 key = keccak256(payment);
         require(t_payments[key] >= amount, 'UniversalTokenRouter: INSUFFICIENT_PAYMENT');
         unchecked {
@@ -521,7 +521,7 @@ contract UniversalTokenRouter is ERC165, IUniversalTokenRouter {
         address token,
         uint256 id,
         uint256 amount
-    ) internal {
+    ) internal virtual {
         if (eip == 20) {
             TransferHelper.safeTransferFrom(token, sender, recipient, amount);
         } else if (eip == 1155) {
@@ -535,7 +535,7 @@ contract UniversalTokenRouter is ERC165, IUniversalTokenRouter {
 
     function _balanceOf(
         Output memory output
-    ) internal view returns (uint256 balance) {
+    ) internal view virtual returns (uint256 balance) {
         uint256 eip = output.eip;
         if (eip == 20) {
             return IERC20(output.token).balanceOf(output.recipient);


### PR DESCRIPTION
Changes:
- Change the `pay` and `discard` interface to accept `bytes` payload for extensibility
- Add a Security Consideration for `discard`