### PR TITLE
Update EIP-6551: Preventing circular lock situation with initialize

### DIFF
--- a/EIPS/eip-6551.md
+++ b/EIPS/eip-6551.md
@@ -157,6 +157,34 @@ interface IERC6551Account {
     receive() external payable;
 
     /**
+     * @dev initialize function is used to initialize the tken bound account
+     *  after any ownership change
+     * 
+     *  The function can only be called by current owner of token
+     * 
+     *  The function is used to tract current and previous owner of the NFT
+     *  which is used during circular locks and to prevent previous owner to call 
+     *  the functions of the contract
+     * 
+     *  @return the status of the call in boolean format
+     */
+    function initialize() external returns (bool);
+
+    /**
+     * @dev the function is used to transfer token during the situations 
+     *  of circular lock
+     * 
+     *  The function first checks the circular lock condition i.e. when 
+     *  address(this) equals to the address returned by owner() function
+     * 
+     *  The function checks if the call is created by previous owner or not
+     *  and transfer ownership of token to the previous owner
+     * 
+     *  @return the status of the call in boolean format
+     */
+    function unlockCircularLock() external returns (bool);
+
+    /**
      * @dev Returns the identifier of the non-fungible token which owns the account
      *
      * The return value of this function MUST be constant - it MUST NOT change
@@ -323,6 +351,43 @@ contract ExampleERC6551Account is IERC165, IERC1271, IERC6551Account, IERC6551Ex
     uint256 public state;
 
     receive() external payable {}
+
+    address public _prevOwner;
+    address public _currOwner;
+
+    function initialize() external returns (bool) {
+        require(
+            owner() == msg.sender,
+            "only new owner could call this function"
+        );
+        if (_prevOwner == address(0)) {
+            _prevOwner = _currOwner = msg.sender;
+        } else {
+            _prevOwner = _currOwner;
+            _currOwner = msg.sender;
+        }
+
+        return true;
+    }
+
+    function unlockCircularLock() external returns (bool) {
+        require(
+            owner() == address(this),
+            "circular lock condition is not present"
+        );
+        require(
+            msg.sender == _prevOwner,
+            "could only be called by previous owner"
+        );
+        (, address _tokenAddr, uint256 _tokenId) = token();
+        IERC721(_tokenAddr).safeTransferFrom(
+            address(this),
+            _prevOwner,
+            _tokenId
+        );
+
+        return true;
+    }
 
     function execute(
         address to,


### PR DESCRIPTION
## Description
This pull request adds the `initialize` function for EIP-6551 as described in the guidelines. The `initialize` function can be called by the owner after ownership change to set the `currOwner` and `prevOwner` variables. Additionally, the `unlockCircularLock` function is introduced to handle situations of circular lock, allowing the previous owner to unlock it.

## Changes

### Added Functions
- `initialize(uint256 tokenId) external `: Initializes the `currOwner` and `prevOwner` variables after ownership change.

- `unlockCircularLock(uint256 tokenId) external `: Allows the previous owner to unlock the circular lock situation by calling this function.

### Modifications
- Modified the `ERC6551Account` contract to include the new variables `currOwner` and `prevOwner`.

### Tests
- Added comprehensive tests to cover the new functionalities, including the `initialize` and `unlockCircularLock` functions.

## Motivation
This enhancement is in line with the objectives of EIP-6551 and provides additional functionalities for handling ownership transitions and circular lock scenarios.

## Usage
1. After ownership change, the new owner can call the `initialize` function to set the current owner (`currOwner`) and previous owner (`prevOwner`) variables.

2. In cases of circular lock, the previous owner can use the `unlockCircularLock` function to release the lock.

## Issues
The `initialize` function could only be used to change `previousOwner`. and this value could only be used for account recovery. however if new owner of Token transfer it to another owner without initialization, the `previousOwner` is not changed, hence the recovery can be done by third last owner and he can call it without any restriction, which could be malicious.

## Checklist
- [ ] Code follows the EIP-6551 guidelines.
- [ ] Added appropriate tests for the new functionalities.
- [ ] Documentation has been updated to reflect the changes.
