### PR TITLE
Update EIP-4844: 4844 - Add scenario for blob txs submitted via RPC

### DIFF
--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -296,6 +296,12 @@ Blob transactions have two network representations. During transaction gossip re
 rlp([tx_payload_body, blobs, commitments, proofs])
 ```
 
+Similarly, when a blob transaction is submitted to a node via the `eth_sendRawTransaction` RPC method, the transaction payload in the RPC call should be submitted form:
+
+```
+BLOB_TX_TYPE || rlp([tx_payload_body, blobs, commitments, proofs])
+```
+
 Each of these elements are defined as follows:
 
 - `tx_payload_body` - is the `TransactionPayloadBody` of standard EIP-2718 [blob transaction](#blob-transaction)
@@ -303,7 +309,7 @@ Each of these elements are defined as follows:
 - `commitments` - list of `KZGCommitment` of the corresponding `blobs`
 - `proofs` - list of `KZGProof` of the corresponding `blobs` and `commitments`
 
-The node MUST validate `tx_payload_body` and verify the wrapped data against it. To do so, ensure that:
+In both of the above cases, the node MUST validate `tx_payload_body` and verify the wrapped data against it. To do so, ensure that:
 
 - There are an equal number of `tx_payload_body.blob_versioned_hashes`, `blobs`, `commitments`, and `proofs`.
 - The KZG `commitments` hash to the versioned hashes, i.e. `kzg_to_versioned_hash(commitments[i]) == tx_payload_body.blob_versioned_hashes[i]`


### PR DESCRIPTION
Following discussion on the Eth R&D discord, it feels clear that the current 4844 specs are not 100% clear with regard to handling of blob transactions submitted to a node via `eth_sendRawTransaction` and this proposes an update to the spec that clarifies this (based on the actual implementations in the EthereumJS and Geth clients).