### PR TITLE
Update EIP-7412: Rename Parts of Interface

### DIFF
--- a/EIPS/eip-7412.md
+++ b/EIPS/eip-7412.md
@@ -39,7 +39,7 @@ error OracleDataRequired(address oracleContract, bytes oracleQuery)
 ```solidity
 interface IERC7412 {
   function oracleId() view external returns (bytes32 oracleId);
-  function fulfillOracleData(bytes oracleQuery, bytes signedOffchainData) payable external;
+  function fulfillOracleQuery(bytes oracleQuery, bytes signedOffchainData) payable external;
 }
 ```
 
@@ -48,12 +48,12 @@ interface IERC7412 {
 The contract implementing the `IOracleContract` interface MUST revert with the following error message if it requires payment to fulfill the oracle data query:
 
 ```solidity
-error OracleFeeRequired(uint feeAmount)
+error FeeRequired(uint amount)
 ```
 
-`feeAmount` specifies the amount of native gas tokens required to execute the `fulfillOracleData` function, denominated in wei. This error MUST be resolved if the caller provides sufficient `msg.value` such that the fee amount can be collected by the oracle contract. The contract MAY NOT return gas tokens if they are provided in excess of the `feeAmount`. In practice, we would expect the fee amount to remain relatively stable, if not constant.
+`amount` specifies the amount of native gas tokens required to execute the `fulfillOracleQuery` function, denominated in wei. This error MUST be resolved if the caller provides sufficient `msg.value` such that the fee amount can be collected by the oracle contract. The contract MAY NOT return gas tokens if they are provided in excess of the `amount`. In practice, we would expect the fee amount to remain relatively stable, if not constant.
 
-It is the responsibility of the client to decide how to construct the multicall, where necessary the `fulfillOracleData` functions are being called before the intended function call in an atomic transaction. Wallets that support account abstraction (per [ERC-4337](./eip-4337.md)) should already have the ability to generate atomic multi-operations. For EOA support, protocols could implement [ERC-2771](./eip-2771.md). A standard multicall contract can only be used to construct multicalls including functions which do not reference `msg.sender` or `msg.data`.
+It is the responsibility of the client to decide how to construct the multicall, where necessary the `fulfillOracleQuery` functions are being called before the intended function call in an atomic transaction. Wallets that support account abstraction (per [ERC-4337](./eip-4337.md)) should already have the ability to generate atomic multi-operations. For EOA support, protocols could implement [ERC-2771](./eip-2771.md). A standard multicall contract can only be used to construct multicalls including functions which do not reference `msg.sender` or `msg.data`.
 
 To prevent data becoming too stale for a request between the simulation and a call's execution, ideally a contract could also emit the following event: `event OracleDataUsed(address oracleContract, bytes oracleQuery, uint expirationTime)` Here, `expirationTime` is the time after which the `OracleDataRequired` error would be thrown by the contract. (This would typically be a calculation involving a staleness tolerance and `block.timestamp`). Client applications that implement this standard would be able to recognize this event during simulation and estimate if an additional update will still be necessary, taking into account the speed of the chain. For example, the oracle query may request the latest quote available for a particular price feed and the expiration time may signal that the price cannot be older than three seconds prior to the current timestamp recognized by the blockchain. This has been omitted from the standard because there isn't a practical way to retrieve event data during transaction simulations on most JSON-RPC APIs at this time.
 
@@ -111,7 +111,7 @@ contract OracleContract is IERC7412 {
     return bytes32(abi.encodePacked("MY_ORACLE_ID"));
   }
 
-  function fulfillOracleData(bytes calldata oracleQuery, bytes calldata signedOffchainData) payable external {
+  function fulfillOracleQuery(bytes calldata oracleQuery, bytes calldata signedOffchainData) payable external {
     _verify(signedOffchainData);
     latestVerifiedData[keccak256(oracleQuery)] = signedOffchainData;
   }
@@ -129,7 +129,7 @@ contract OracleContract is IERC7412 {
 
   function _verify(bytes memory signedOffchainData) payable internal {
     // Insert verification code here
-    // This may revert with error OracleFeeRequired(uint feeAmount)
+    // This may revert with error FeeRequired(uint amount)
   }
 
 }


### PR DESCRIPTION
* Renames `fulfillOracleData` to `fulfillOracleQuery`. This feels more appropriate, as the _query_ is being fulfilled, moreso than the data.
* Renames `OracleFeeRequired` to `FeeRequired`. There is nothing oracle-specific about this revert.