### PR TITLE
Add field element to curve mapping operation

### DIFF
--- a/EIPS/eip-2539.md
+++ b/EIPS/eip-2539.md
@@ -1,7 +1,7 @@
 ---
 eip: 2539
 title: BLS12-377 curve operations
-author: Alex Vlasov (@shamatar)
+author: Alex Vlasov (@shamatar), hujw77 (@hujw77)
 discussions-to: https://ethereum-magicians.org/t/eip-2539-bls12-377-precompile-discussion-thread/4659
 status: Stagnant
 type: Standards Track

--- a/EIPS/eip-2539.md
+++ b/EIPS/eip-2539.md
@@ -24,20 +24,24 @@ If `block.number >= X` we introduce *nine* separate precompiles to perform the f
 - BLS12_377_G2MUL - to perform point multiplication on a curve twist defined over quadratic extension of the base field
 - BLS12_377_G2MULTIEXP - to perform multiexponentiation on a curve twist defined over quadratic extension of the base field
 - BLS12_377_PAIRING - to perform a pairing operations between a set of *pairs* of (G1, G2) points
+- BLS12_377_MAP_FP_TO_G1 - maps base field element into the G1 point
+- BLS12_377_MAP_FP2_TO_G2 - maps extension field element into the G2 point
 
 Multiexponentiation operation is included to efficiently aggregate public keys or individual signer's signatures during BLS signature verification.
 
 ### Proposed addresses table
 
-|Precompile   |Address   |
-|---|---|
-|BLS12_377_G1ADD          | 0x13  |
-|BLS12_377_G1MUL          | 0x14  |
-|BLS12_377_G1MULTIEXP     | 0x15  |
-|BLS12_377_G2ADD          | 0x16  |
-|BLS12_377_G2MUL          | 0x17  |
-|BLS12_377_G2MULTIEXP     | 0x18  |
-|BLS12_377_PAIRING        | 0x19  |
+| Precompile              | Address |
+| ----------------------- | ------- |
+| BLS12_377_G1ADD         | 0x13    |
+| BLS12_377_G1MUL         | 0x14    |
+| BLS12_377_G1MULTIEXP    | 0x15    |
+| BLS12_377_G2ADD         | 0x16    |
+| BLS12_377_G2MUL         | 0x17    |
+| BLS12_377_G2MULTIEXP    | 0x18    |
+| BLS12_377_PAIRING       | 0x19    |
+| BLS12_377_MAP_FP_TO_G1  | 0x20    |
+| BLS12_377_MAP_FP2_TO_G2 | 0x21    |
 
 ## Motivation
 Motivation of this precompile is to add a cryptographic primitive that allows to get 120+ bits of security for operations over pairing friendly curve compared to the existing BN254 precompile that only provides 80 bits of security. In addition it allows efficient one-time recursive proof aggregations, e.g. proofs about existence of BLS12-377 based signature.
@@ -171,6 +175,24 @@ Error cases:
 - Field elements encoding rules apply (obviously)
 - Input has invalid length
 
+##### ABI for mapping Fp element to G1 point
+
+Field-to-curve call expects `64` bytes an an input that is interpreted as a an element of the base field. Output of this call is `128` bytes and is G1 point following respective encoding rules.
+
+Error cases:
+
+- Input has invalid length
+- Input is not a valid field element
+
+##### ABI for mapping Fp2 element to G2 point
+
+Field-to-curve call expects `128` bytes an an input that is interpreted as a an element of the quadratic extension field. Output of this call is `256` bytes and is G2 point following respective encoding rules.
+
+Error cases:
+
+- Input has invalid length
+- Input is not a valid field element
+
 #### Prevention of DDoS on error handling
 
 This precompile performs extensive computations and in case of any errors during execution it MUST consume all gas from the the gas schedule for the corresponding operation.
@@ -212,6 +234,14 @@ Discounts table as a vector of pairs `[k, discount]`:
 ##### Pairing operation
 
 Cost of the pairing operation is `55000*k + 65000` where `k` is a number of pairs.
+
+##### Fp-to-G1 mapping operation
+
+Fp -> G1 mapping is `5500` gas.
+
+##### Fp2-to-G2 mapping operation
+
+Fp2 -> G2 mapping is `75000` gas
 
 ## Rationale
 Motivation section covers a total motivation to have operations over BLS12-377 curve available. We also extend a rationale for move specific fine points.


### PR DESCRIPTION
For [substrate light client](https://github.com/w3f/apk-proofs/tree/main) is a zk-solution which use BLS12-377, and requires the hash_to_curve function.
So I add the filed element to curve mapping operation like BLS12-381. 
