### PR TITLE
Update EIP-7329: Wallet-related stuff to ERCs repo

### DIFF
--- a/EIPS/eip-7329.md
+++ b/EIPS/eip-7329.md
@@ -50,16 +50,16 @@ particulars of how each repository will govern itself is out of scope for this
 EIP, as it is the motivating point of this EIP that the divergent needs of the
 community will require highly divergent methods.
 
-1. All ERCs are removed from this repository and migrated to a new repo. The
-   history should be intact so that repo should be forked of this one with the
-   non-ERCs removed. I've written a script (see below) to perform this
+1. All ERCs and Interface-category EIPs are removed from this repository and migrated to
+   a new repo. The history should be intact so that repo should be forked of this one
+   with the non-ERCs removed. I've written a script (see below) to perform this
    operation. Once this PR is approved, it should be executed immediately before
    merging.
-2. The new ERCs repository goes live and includes the changes from the script.
-3. Setup ercs.ethereum.org subdomain and update the CI to point to the ERCs
+3. The new ERCs repository goes live and includes the changes from the script.
+4. Setup ercs.ethereum.org subdomain and update the CI to point to the ERCs
    repo.
-4. Set up a redirect for ERCs on eips.ethereum.org to go to the new website.
-5. Create a unified document for editors to assign EIP/ERC numbers. EIPs and
+5. Set up a redirect for ERCs on eips.ethereum.org to go to the new website.
+6. Create a unified document for editors to assign EIP/ERC numbers. EIPs and
    ERCs will no longer be based on an initial PR number but on a number
    incremented by the EIP editors of their respective repositories. EIPs will be
    assigned even numbers and ERCs will be assigned odd numbers. The exact timing


### PR DESCRIPTION
Rationale: the process for these EIPs follows a track more similar to ERCs than Core EIPs, and this EIP itself reserves the EIP repo for "core protocol changes, specifically the kind that would be discussed in one of the AllCoreDevs calls."