### PR TITLE
Update EIP-7329: Fix major website issue

### DIFF
--- a/EIPS/eip-7329.md
+++ b/EIPS/eip-7329.md
@@ -56,14 +56,14 @@ community will require highly divergent methods.
    operation. Once this PR is approved, it should be executed immediately before
    merging.
 2. The new ERCs repository goes live and includes the changes from the script.
-3. Setup ercs.ethereum.org subdomain and update the CI to point to the ERCs
-   repo.
-4. Set up a redirect for ERCs on eips.ethereum.org to go to the new website.
-5. Create a unified document for editors to assign EIP/ERC numbers. EIPs and
+3. Set up a redirect for ERCs on eips.ethereum.org to go to the new website.
+4. Create a unified document for editors to assign EIP/ERC numbers. EIPs and
    ERCs will no longer be based on an initial PR number but on a number
    incremented by the EIP editors of their respective repositories. EIPs will be
    assigned even numbers and ERCs will be assigned odd numbers. The exact timing
    of this migration is a policy decision of the editors.
+5. Move website-specific code into a new repository, so that ERCs and EIPs are
+   easily accessible and existing links don't break.
 
 The EIP repository will be associated with core protocol changes, specifically
 the kind that would be discussed in one of the AllCoreDevs calls; whereas the

--- a/EIPS/eip-7329.md
+++ b/EIPS/eip-7329.md
@@ -56,14 +56,14 @@ community will require highly divergent methods.
    operation. Once this PR is approved, it should be executed immediately before
    merging.
 2. The new ERCs repository goes live and includes the changes from the script.
-3. Set up a redirect for ERCs on eips.ethereum.org to go to the new website.
-4. Create a unified document for editors to assign EIP/ERC numbers. EIPs and
+3. Create a unified document for editors to assign EIP/ERC numbers. EIPs and
    ERCs will no longer be based on an initial PR number but on a number
    incremented by the EIP editors of their respective repositories. EIPs will be
    assigned even numbers and ERCs will be assigned odd numbers. The exact timing
    of this migration is a policy decision of the editors.
-5. Move website-specific code into a new repository, so that ERCs and EIPs are
-   easily accessible and existing links don't break.
+4. Move website-specific code into a new repository, so that ERCs and EIPs are
+   easily accessible and existing links don't break. ERCs and EIPs remain on the
+   same website, on the same domain.
 
 The EIP repository will be associated with core protocol changes, specifically
 the kind that would be discussed in one of the AllCoreDevs calls; whereas the


### PR DESCRIPTION
As it currently stands, **this is bad for the SEO of ERCs, and I oppose this EIP until this is fixed.**

Also. You can't make 301 redirects using GitHub pages, and I will not support you using multiple anti-patterns as a workaround because of all the obvious reasons that all anti-patterns have, as well as less obvious ones like it tanks the SEO even lower.

Also. Some ERCs use relative links to EIPs, and vice versa. We should keep it that way, for SEO reasons, and because updating those might be a pain.

Finally - why do you want to split the website? I can understand the annoyance of having one repo have to share multiple different flows, but the *website*? Can't you just... click on the "Core" link? Is it really worth it to you to split the website, just so you can have a marginally easier time looking at new EIPs?