### PR TITLE
Add EIP: Minimal Proxy Contract with PUSH0

### DIFF
--- a/EIPS/eip-7511.md
+++ b/EIPS/eip-7511.md
@@ -2,7 +2,7 @@
 eip: 7511
 title: Minimal Proxy Contract with `PUSH0`
 description: Optimize the previous Minimal Proxy Contract (ERC-1167) with the newly introduced `PUSH0` opcode
-author: 0xAA (@AmazingAng), vectorized (@Vectorized)
+author: 0xAA (@AmazingAng), vectorized (@Vectorized), 0age (@0age)
 discussions-to: https://ethereum-magicians.org/t/erc-7511-minimal-proxy-contract-with-push0/15662
 status: Draft
 type: Standards Track

--- a/EIPS/eip-7511.md
+++ b/EIPS/eip-7511.md
@@ -3,7 +3,7 @@ eip: 7511
 title: Minimal Proxy Contract with `PUSH0`
 description: Optimize the previous Minimal Proxy Contract (ERC-1167) with the newly introduced `PUSH0` opcode
 author: 0xAA (@AmazingAng), vectorized (@Vectorized) 
-discussions-to: https://ethereum-magicians.org/t/proposal-for-a-new-eip-minimal-proxy-contract-with-push0/15662
+discussions-to: https://ethereum-magicians.org/t/erc-7511-minimal-proxy-contract-with-push0/15662
 status: Draft
 type: Standards Track
 category: ERC

--- a/EIPS/eip-7511.md
+++ b/EIPS/eip-7511.md
@@ -13,7 +13,7 @@ requires: 7, 211, 1167, 3855
 
 ## Abstract
 
-With the newly introduced `PUSH0` opcode ([EIP-3855](./eip-3855)) at Shanghai Upgrade, we optimized the previous Minimal Proxy Contract ([ERC-1167](./eip-1167)) by 200 gas at deployment and 5 gas at runtime, while retaining same functionalities.
+With the newly introduced `PUSH0` opcode ([EIP-3855](./eip-3855.md)) at Shanghai Upgrade, we optimized the previous Minimal Proxy Contract ([ERC-1167](./eip-1167.md)) by 200 gas at deployment and 5 gas at runtime, while retaining same functionalities.
 
 ## Motivation
 
@@ -203,22 +203,6 @@ The length of the runtime code is `44` bytes, which reduced `1` byte from the pr
 
 Because the new minimal proxy contract uses `PUSH0` opcode, it can only be deployed after Shanghai Upgrade. It behaves the same as previous Minimal Proxy Contract.
 
-## Test Cases
-
-Test cases are performed using Foundry, which include:
-
-- invocation with no arguments.
-- invocation with arguments.
-- invocation with fixed length return values
-- invocation with variable length return values
-- invocation with revert
-- deploy with minimal creation code
-
-Tests for these cases are included in the GitHub repo Minimal-Proxy-PUSH0.
-
-## Reference Implementation
-
-GitHub Repo: Minimal-Proxy-PUSH0
 
 ## Security Considerations
 

--- a/EIPS/eip-7511.md
+++ b/EIPS/eip-7511.md
@@ -1,7 +1,7 @@
 ---
 eip: 7511
-title: Minimal Proxy Contract with `PUSH0`
-description: Optimize the previous Minimal Proxy Contract (ERC-1167) with the newly introduced `PUSH0` opcode
+title: Minimal Proxy Contract with PUSH0
+description: Optimizes the previous Minimal Proxy Contract with the PUSH0 opcode
 author: 0xAA (@AmazingAng), vectorized (@Vectorized), 0age (@0age)
 discussions-to: https://ethereum-magicians.org/t/erc-7511-minimal-proxy-contract-with-push0/15662
 status: Draft
@@ -13,11 +13,10 @@ requires: 7, 211, 1167, 3855
 
 ## Abstract
 
-With the newly introduced `PUSH0` opcode ([EIP-3855](./eip-3855.md)) at Shanghai Upgrade, we optimized the previous Minimal Proxy Contract ([ERC-1167](./eip-1167.md)) by 200 gas at deployment and 5 gas at runtime, while retaining same functionalities.
+With the `PUSH0` opcode ([EIP-3855](./eip-3855.md)), introduced with the Shanghai upgrade, we optimized the previous Minimal Proxy Contract ([ERC-1167](./eip-1167.md)) by 200 gas at deployment and 5 gas at runtime, while retaining the same functionality.
 
 ## Motivation
 
-This standard tries to optimize the Minimal Proxy Contract with the newly added `PUSH0` opcodes. The main motivations are:
 
 1. Reduce the contract bytecode size by `1` byte by removing a redundant `SWAP` opcode.
 2. Reduce the runtime gas by replacing two `DUP` (cost `3` gas each) to two `PUSH0` (cost `2` gas each).
@@ -33,11 +32,10 @@ The exact runtime code for the minimal proxy contract with `PUSH0` is:
 365f5f375f5f365f73bebebebebebebebebebebebebebebebebebebebe5af43d5f5f3e5f3d91602a57fd5bf3
 ```
 
-wherein the bytes at indices 9 - 28 (inclusive) are replaced with the 20 byte address of the master implementation contract. The length of the runtime code is `44` bytes.
+where the bytes at indices 9 - 28 (inclusive) are replaced with the 20 byte address of the master implementation contract. The length of the runtime code is `44` bytes.
 
-The disassembly of the new minimal proxy contract code:
+The disassembly of the new minimal proxy contract code is:
 
-```shell
 | pc   | op     | opcode         | stack              |
 |------|--------|----------------|--------------------|
 | [00] | 36     | CALLDATASIZE   | cds                |
@@ -63,7 +61,6 @@ The disassembly of the new minimal proxy contract code:
 | [29] | fd     | REVERT         |                    |
 | [2a] | 5b     | JUMPDEST       | 0 rds              |
 | [2b] | f3     | RETURN         |                    |
-```
 
 ### Minimal Creation Code
 
@@ -83,7 +80,7 @@ And the rest are runtime/contract code of the proxy. The length of the creation 
 
 ### Deploy with Solidity
 
-The minimal proxy contract can be deployed with Solidity using underlying contract:
+The minimal proxy contract can be deployed with Solidity using the following contract:
 
 ```solidity
 // SPDX-License-Identifier: MIT
@@ -134,20 +131,17 @@ The contract is built from first principals utilizing the newly introduced `PUSH
 
 To copy the calldata, we need to provide the arguments for the `CALLDATACOPY` opcodes, which are `[0, 0, cds]`, where `cds` represents calldata size.
 
-```shell
 | pc   | op     | opcode         | stack              |
 |------|--------|----------------|--------------------|
 | [00] | 36     | CALLDATASIZE   | cds                |
 | [01] | 5f     | PUSH0          | 0 cds              |
 | [02] | 5f     | PUSH0          | 0 0 cds            |
 | [03] | 37     | CALLDATACOPY   |                    |
-```
 
 ### Step 2: Delegatecall
 
 To forward the calldata to the delegate call, we need to prepare arguments for the `DELEGATECALL` opcodes, which are `[gas 0xbebe. 0 cds 0 0]`, where `gas` represents the remaining gas, `0xbebe.` represents the address of the implementation contract, and `suc` represents whether the delegatecall is successful. 
 
-```shell
 | pc   | op     | opcode         | stack              |
 |------|--------|----------------|--------------------|
 | [04] | 5f     | PUSH0          | 0                  |
@@ -157,20 +151,17 @@ To forward the calldata to the delegate call, we need to prepare arguments for t
 | [08] | 73bebe.| PUSH20 0xbebe. | 0xbebe. 0 cds 0 0  |
 | [1d] | 5a     | GAS            | gas 0xbebe. 0 cds 0 0|
 | [1e] | f4     | DELEGATECALL   | suc                |
-```
 
 ### Step 3: Copy the Returned Data from the `DELEGATECALL`
 
 To copy the returndata, we need to provide the arguments for the `RETURNDATACOPY` opcodes, which are `[0, 0, red]`, where `rds` represents size of returndata from the `DELEGATECALL`.
 
-```shell
 | pc   | op     | opcode         | stack              |
 |------|--------|----------------|--------------------|
 | [1f] | 3d     | RETURNDATASIZE | rds suc            |
 | [20] | 5f     | PUSH0          | 0 rds suc          |
 | [21] | 5f     | PUSH0          | 0 0 rds suc        |
 | [22] | 3e     | RETURNDATACOPY | suc                |
-```
 
 ### Step 4: Return or Revert
 
@@ -178,7 +169,6 @@ Lastly we need to return the data or revert the transaction based on whether the
 
  We also need to prepare the argument `[0, rds]` for `REVERT` and `RETURN` opcodes before the `JUMPI`, otherwise we have to prepare them twice. We cannot avoid the `SWAP` operation, because we can only get `rds` after the `DELEGATECALL`.
 
-```shell
 | pc   | op     | opcode         | stack              |
 |------|--------|----------------|--------------------|
 | [23] | 5f     | PUSH0          | 0 suc              |
@@ -189,7 +179,6 @@ Lastly we need to return the data or revert the transaction based on whether the
 | [29] | fd     | REVERT         |                    |
 | [2a] | 5b     | JUMPDEST       | 0 rds              |
 | [2b] | f3     | RETURN         |                    |
-```
 
 In the end, we arrived at the runtime code for Minimal Proxy Contract with `PUSH0`: 
 
@@ -201,8 +190,7 @@ The length of the runtime code is `44` bytes, which reduced `1` byte from the pr
 
 ## Backwards Compatibility
 
-Because the new minimal proxy contract uses `PUSH0` opcode, it can only be deployed after Shanghai Upgrade. It behaves the same as previous Minimal Proxy Contract.
-
+Because the new minimal proxy contract uses `PUSH0` opcode, it can only be deployed after Shanghai Upgrade. It behaves the same as the previous Minimal Proxy Contract.
 
 ## Security Considerations
 
@@ -215,7 +203,6 @@ The new proxy contract standard is identical to the previous one (ERC-1167). Her
 3. **Safety of Logic Contract**: Vulnerabilities in the logic contract affect all associated proxy contracts.
 
 4. **Transparency Issues**: Because of its complexity, users might see the proxy as an empty contract, making it challenging to trace back to the actual logic contract.
-
 
 ## Copyright
 

--- a/EIPS/eip-7511.md
+++ b/EIPS/eip-7511.md
@@ -2,7 +2,7 @@
 eip: 7511
 title: Minimal Proxy Contract with `PUSH0`
 description: Optimize the previous Minimal Proxy Contract (ERC-1167) with the newly introduced `PUSH0` opcode
-author: 0xAA (@AmazingAng), vectorized (@Vectorized) 
+author: 0xAA (@AmazingAng), vectorized (@Vectorized)
 discussions-to: https://ethereum-magicians.org/t/erc-7511-minimal-proxy-contract-with-push0/15662
 status: Draft
 type: Standards Track

--- a/EIPS/eip-7511.md
+++ b/EIPS/eip-7511.md
@@ -83,7 +83,7 @@ And the rest are runtime/contract code of the proxy. The length of the creation 
 The minimal proxy contract can be deployed with Solidity using the following contract:
 
 ```solidity
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: CC0-1.0
 pragma solidity ^0.8.20;
 
 // Note: this contract requires `PUSH0`, which is available in solidity > 0.8.20 and EVM version > Shanghai

--- a/EIPS/eip-7511.md
+++ b/EIPS/eip-7511.md
@@ -19,7 +19,7 @@ With the `PUSH0` opcode ([EIP-3855](./eip-3855.md)), introduced with the Shangha
 
 
 1. Reduce the contract bytecode size by `1` byte by removing a redundant `SWAP` opcode.
-2. Reduce the runtime gas by replacing two `DUP` (cost `3` gas each) to two `PUSH0` (cost `2` gas each).
+2. Reduce the runtime gas by replacing two `DUP` (cost `3` gas each) with two `PUSH0` (cost `2` gas each).
 3. Increase the readability of the proxy contract by redesigning it from first principles with `PUSH0`.
 
 ## Specification
@@ -32,7 +32,7 @@ The exact runtime code for the minimal proxy contract with `PUSH0` is:
 365f5f375f5f365f73bebebebebebebebebebebebebebebebebebebebe5af43d5f5f3e5f3d91602a57fd5bf3
 ```
 
-where the bytes at indices 9 - 28 (inclusive) are replaced with the 20 byte address of the master implementation contract. The length of the runtime code is `44` bytes.
+where the bytes at indices 9 - 28 (inclusive) are replaced with the 20-byte address of the master implementation contract. The length of the runtime code is `44` bytes.
 
 The disassembly of the new minimal proxy contract code is:
 
@@ -165,7 +165,7 @@ To copy the returndata, we need to provide the arguments for the `RETURNDATACOPY
 
 ### Step 4: Return or Revert
 
-Lastly we need to return the data or revert the transaction based on whether the `DELEGATECALL` is successful. There is no `if/else` in opcodes, so we need to use `JUMPI` and `JUMPDEST` instead. The auguments for `JUMPI` is `[0x2a, suc]`, where `0x2a` is the destination of the conditional jump.
+Lastly, we need to return the data or revert the transaction based on whether the `DELEGATECALL` is successful. There is no `if/else` in opcodes, so we need to use `JUMPI` and `JUMPDEST` instead. The arguments for `JUMPI` is `[0x2a, suc]`, where `0x2a` is the destination of the conditional jump.
 
  We also need to prepare the argument `[0, rds]` for `REVERT` and `RETURN` opcodes before the `JUMPI`, otherwise we have to prepare them twice. We cannot avoid the `SWAP` operation, because we can only get `rds` after the `DELEGATECALL`.
 
@@ -186,11 +186,11 @@ In the end, we arrived at the runtime code for Minimal Proxy Contract with `PUSH
 365f5f375f5f365f73bebebebebebebebebebebebebebebebebebebebe5af43d5f5f3e5f3d91602a57fd5bf3
 ```
 
-The length of the runtime code is `44` bytes, which reduced `1` byte from the previous Minimal Proxy Contract. Moreover, it replaced the `RETURNDATASIZE` and `DUP` operations with `PUSH0`, which saves gas and increase the readability of the code. In summary, the new Minimal Proxy Contract reduce `200` gas at deployment and `5` gas at runtime, while remaining same functionalities as the old one.
+The length of the runtime code is `44` bytes, which reduced `1` byte from the previous Minimal Proxy Contract. Moreover, it replaced the `RETURNDATASIZE` and `DUP` operations with `PUSH0`, which saves gas and increases the readability of the code. In summary, the new Minimal Proxy Contract reduces `200` gas at deployment and `5` gas at runtime, while remaining the same functionalities as the old one.
 
 ## Backwards Compatibility
 
-Because the new minimal proxy contract uses `PUSH0` opcode, it can only be deployed after Shanghai Upgrade. It behaves the same as the previous Minimal Proxy Contract.
+Because the new minimal proxy contract uses `PUSH0` opcode, it can only be deployed after the Shanghai Upgrade. It behaves the same as the previous Minimal Proxy Contract.
 
 ## Security Considerations
 

--- a/EIPS/eip-7511.md
+++ b/EIPS/eip-7511.md
@@ -1,8 +1,8 @@
 ---
 eip: 7511
 title: Minimal Proxy Contract with `PUSH0`
-description: Optimize the previous Minimal Proxy Contract (ERC-1167) with newly introduced `PUSH0` opcode
-author: 0xAA (@AmazingAng)
+description: Optimize the previous Minimal Proxy Contract (ERC-1167) with the newly introduced `PUSH0` opcode
+author: 0xAA (@AmazingAng), vectorized (@Vectorized) 
 discussions-to: https://ethereum-magicians.org/t/proposal-for-a-new-eip-minimal-proxy-contract-with-push0/15662
 status: Draft
 type: Standards Track

--- a/EIPS/eip-7511.md
+++ b/EIPS/eip-7511.md
@@ -199,11 +199,11 @@ In the end, we arrived at the runtime code for Minimal Proxy Contract with `PUSH
 
 The length of the runtime code is `44` bytes, which reduced `1` byte from the previous Minimal Proxy Contract. Moreover, it replaced the `RETURNDATASIZE` and `DUP` operations with `PUSH0`, which saves gas and increase the readability of the code. In summary, the new Minimal Proxy Contract reduce `200` gas at deployment and `5` gas at runtime, while remaining same functionalities as the old one.
 
-##  Backwards Compatibility
+## Backwards Compatibility
 
 Because the new minimal proxy contract uses `PUSH0` opcode, it can only be deployed after Shanghai Upgrade. It behaves the same as previous Minimal Proxy Contract.
 
-##  Test Cases
+## Test Cases
 
 Test cases are performed using Foundry, which include:
 

--- a/EIPS/eip-7511.md
+++ b/EIPS/eip-7511.md
@@ -1,5 +1,5 @@
 ---
-eip: minimal-proxy-push0
+eip: 7511
 title: Minimal Proxy Contract with `PUSH0`
 description: Optimize the previous Minimal Proxy Contract (ERC-1167) with newly introduced `PUSH0` opcode
 author: 0xAA (@AmazingAng)

--- a/EIPS/eip-7511.md
+++ b/EIPS/eip-7511.md
@@ -6,14 +6,14 @@ author: 0xAA (@AmazingAng)
 discussions-to: https://ethereum-magicians.org/t/proposal-for-a-new-eip-minimal-proxy-contract-with-push0/15662
 status: Draft
 type: Standards Track
-category: Core
+category: ERC
 created: 2023-09-04
 requires: 7, 211, 1167, 3855
 ---
 
 ## Abstract
 
-With the newly introduced `PUSH0` opcode ([EIP-3855](./eip-3855)) at Shanghai Upgrade, we minimized the previous Minimal Proxy Contract ([ERC-1167](./eip-1167)) by 200 gas at deployment and 5 gas at runtime, while retaining same functionalities.
+With the newly introduced `PUSH0` opcode ([EIP-3855](./eip-3855)) at Shanghai Upgrade, we optimized the previous Minimal Proxy Contract ([ERC-1167](./eip-1167)) by 200 gas at deployment and 5 gas at runtime, while retaining same functionalities.
 
 ## Motivation
 

--- a/EIPS/eip-7511.md
+++ b/EIPS/eip-7511.md
@@ -120,12 +120,12 @@ contract Clone0Factory {
 
 ## Rationale
 
-The contract is built from first principals utilizing the newly introduced `PUSH0` opcode. The essential components of the minimal proxy are:
+The optimized contract is constructed with essential components of the proxy contract and incorporates the recently added `PUSH0` opcode. The core elements of the minimal proxy include:
 
 1. Copy the calldata with `CALLDATACOPY`.
 2. Forward the calldata to the implementation contract using `DELEGATECALL`.
 3. Copy the returned data from the `DELEGATECALL`.
-4. Return the results or reverts the transaction based on wether the `DELEGATECALL` is successful.
+4. Return the results or revert the transaction based on whether the `DELEGATECALL` is successful.
 
 ### Step 1: Copy the Calldata
 

--- a/EIPS/eip-minimal-proxy-push0.md
+++ b/EIPS/eip-minimal-proxy-push0.md
@@ -7,7 +7,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2023-09-04
-requires: eip-7, eip-211, eip1167, eip-3855
+requires: 7, 211, 1167, 3855
 ---
 
 ## Simple Summary

--- a/EIPS/eip-minimal-proxy-push0.md
+++ b/EIPS/eip-minimal-proxy-push0.md
@@ -16,7 +16,7 @@ With the newly introduced `PUSH0` opcode ([eip-3855](https://eips.ethereum.org/E
 
 ## Abstract
 
-Use `PUSH0` opcode minimize gas cost of the previous Minimal Proxy Contract, which simply and cheaply clone contract functionality in an immutable way.
+Use `PUSH0` opcode to minimize gas cost of the previous Minimal Proxy Contract, which simply and cheaply clone contract functionality in an immutable way.
 
 ## Motivation
 

--- a/EIPS/eip-minimal-proxy-push0.md
+++ b/EIPS/eip-minimal-proxy-push0.md
@@ -12,7 +12,7 @@ requires: 7, 211, 1167, 3855
 
 ## Simple Summary
 
-With the newly introduced `PUSH0` opcode ([eip-3855](https://eips.ethereum.org/EIPS/eip-3855)) at Shanghai Upgrade, we minimized the previous Minimal Proxy Contract ([eip-1167](https://eips.ethereum.org/EIPS/eip-1167)) by 200 gas at deployment and 5 gas at runtime, while remain the same functionalities.
+With the newly introduced `PUSH0` opcode ([eip-3855](https://eips.ethereum.org/EIPS/eip-3855)) at Shanghai Upgrade, we minimized the previous Minimal Proxy Contract ([eip-1167](https://eips.ethereum.org/EIPS/eip-1167)) by 200 gas at deployment and 5 gas at runtime, while retaining same functionalities.
 
 ## Abstract
 

--- a/EIPS/eip-minimal-proxy-push0.md
+++ b/EIPS/eip-minimal-proxy-push0.md
@@ -1,7 +1,7 @@
 ---
 eip: minimal-proxy-push0
 title: Minimal Proxy Contract with `PUSH0`
-description: Optimize the previous Minimal Proxy Contract (eip-3855) with newly introduced `PUSH0` opcode
+description: Optimize the previous Minimal Proxy Contract (EIP-1167) with newly introduced `PUSH0` opcode
 author: 0xAA (@AmazingAng)
 discussions-to: https://ethereum-magicians.org/t/proposal-for-a-new-eip-minimal-proxy-contract-with-push0/15662
 status: Draft
@@ -11,13 +11,9 @@ created: 2023-09-04
 requires: 7, 211, 1167, 3855
 ---
 
-## Simple Summary
-
-With the newly introduced `PUSH0` opcode ([EIP-3855](./eip-3855)) at Shanghai Upgrade, we minimized the previous Minimal Proxy Contract ([EIP-1167](./eip-1167)) by 200 gas at deployment and 5 gas at runtime, while retaining same functionalities.
-
 ## Abstract
 
-Use `PUSH0` opcode to minimize gas cost of the previous Minimal Proxy Contract, which simply and cheaply clone contract functionality in an immutable way.
+With the newly introduced `PUSH0` opcode ([EIP-3855](./eip-3855)) at Shanghai Upgrade, we minimized the previous Minimal Proxy Contract ([ERC-1167](./eip-1167)) by 200 gas at deployment and 5 gas at runtime, while retaining same functionalities.
 
 ## Motivation
 
@@ -226,7 +222,7 @@ GitHub Repo: Minimal-Proxy-PUSH0
 
 ## Security Considerations
 
-The new proxy contract standard is identical to the previous one (EIP-1167). Here are the security considerations when using minimal proxy contracts:
+The new proxy contract standard is identical to the previous one (ERC-1167). Here are the security considerations when using minimal proxy contracts:
 
 1. **Non-Upgradability**: Minimal Proxy Contracts delegate their logic to another contract (often termed the "implementation" or "logic" contract). This delegation is fixed upon deployment, meaning you can't change which implementation contract the proxy delegates to after its creation.
    
@@ -242,10 +238,6 @@ The new proxy contract standard is identical to the previous one (EIP-1167). Her
 Copyright and related rights waived via [CC0](../LICENSE.md).
 
 ## Reference
-
-Peter Murray (@yarrumretep), Nate Welch (@flygoing), Joe Messerman (@JAMesserman), "ERC-1167: Minimal Proxy Contract," Ethereum Improvement Proposals, no. 1167, June 2018. [Online serial].
-
-Alex Beregszaszi (@axic), Hugo De la cruz (@hugo-dc), Paweł Bylica (@chfast), "EIP-3855: PUSH0 instruction," Ethereum Improvement Proposals, no. 3855, February 2021. [Online serial].
 
 Martin Abbatemarco, Deep dive into the Minimal Proxy contract
 

--- a/EIPS/eip-minimal-proxy-push0.md
+++ b/EIPS/eip-minimal-proxy-push0.md
@@ -17,7 +17,7 @@ With the newly introduced `PUSH0` opcode ([EIP-3855](./eip-3855)) at Shanghai Up
 
 ## Motivation
 
-This standard trys to mimnimize the Minimal Proxy Contract with the newly added `PUSH0` opcodes. The main motivations are:
+This standard tries to optimize the Minimal Proxy Contract with the newly added `PUSH0` opcodes. The main motivations are:
 
 1. Reduce the contract bytecode size by `1` byte by removing a redundant `SWAP` opcode.
 2. Reduce the runtime gas by replacing two `DUP` (cost `3` gas each) to two `PUSH0` (cost `2` gas each).
@@ -197,7 +197,7 @@ In the end, we arrived at the runtime code for Minimal Proxy Contract with `PUSH
 365f5f375f5f365f73bebebebebebebebebebebebebebebebebebebebe5af43d5f5f3e5f3d91602a57fd5bf3
 ```
 
-The length of the runtime code is `44` bytes, which reduced `1` byte from the previous Minimal Proxy Contract. Moreover, it replaced the `RETURNDATASIZE` and `DUP` operations with `PUSH0`, which saves gas and increase the readability of the code. In summary, the new Minimal Proxy Contract reduce `200` gas at deployment and `5` gas at runtime, while remain the same functionalities as the old one.
+The length of the runtime code is `44` bytes, which reduced `1` byte from the previous Minimal Proxy Contract. Moreover, it replaced the `RETURNDATASIZE` and `DUP` operations with `PUSH0`, which saves gas and increase the readability of the code. In summary, the new Minimal Proxy Contract reduce `200` gas at deployment and `5` gas at runtime, while remaining same functionalities as the old one.
 
 ##  Backwards Compatibility
 

--- a/EIPS/eip-minimal-proxy-push0.md
+++ b/EIPS/eip-minimal-proxy-push0.md
@@ -1,0 +1,251 @@
+---
+title: Minimal Proxy Contract with `PUSH0`
+description: Optimize the previous Minimal Proxy Contract (eip-3855) with newly introduced `PUSH0` opcode
+author: 0xAA (@AmazingAng)
+discussions-to: https://ethereum-magicians.org/t/proposal-for-a-new-eip-minimal-proxy-contract-with-push0/15662
+status: Draft
+type: Standards Track
+category: Core
+created: 2023-09-04
+requires: eip-7, eip-211, eip1167, eip-3855
+---
+
+## Simple Summary
+
+With the newly introduced `PUSH0` opcode ([eip-3855](https://eips.ethereum.org/EIPS/eip-3855)) at Shanghai Upgrade, we minimized the previous Minimal Proxy Contract ([eip-1167](https://eips.ethereum.org/EIPS/eip-1167)) by 200 gas at deployment and 5 gas at runtime, while remain the same functionalities.
+
+## Abstract
+
+Use `PUSH0` opcode minimize gas cost of the previous Minimal Proxy Contract, which simply and cheaply clone contract functionality in an immutable way.
+
+## Motivation
+
+This standard trys to mimnimize the Minimal Proxy Contract with the newly added `PUSH0` opcodes. The main motivations are:
+
+1. Reduce the contract bytecode size by `1` byte by removing a redundant `SWAP` opcode.
+2. Reduce the runtime gas by replacing two `DUP` (cost `3` gas each) to two `PUSH0` (cost `2` gas each).
+3. Increase the readability of the proxy contract by redesigning it from first principles with `PUSH0`.
+
+## Specification
+
+### Standard Proxy Contract
+
+The exact runtime code for the minimal proxy contract with `PUSH0` is: 
+
+```
+365f5f375f5f365f73bebebebebebebebebebebebebebebebebebebebe5af43d5f5f3e5f3d91602a57fd5bf3
+```
+
+wherein the bytes at indices 9 - 28 (inclusive) are replaced with the 20 byte address of the master implementation contract. The length of the runtime code is `44` bytes.
+
+The disassembly of the new minimal proxy contract code:
+
+```shell
+| pc   | op     | opcode         | stack              |
+|------|--------|----------------|--------------------|
+| [00] | 36     | CALLDATASIZE   | cds                |
+| [01] | 5f     | PUSH0          | 0 cds              |
+| [02] | 5f     | PUSH0          | 0 0 cds            |
+| [03] | 37     | CALLDATACOPY   |                    |
+| [04] | 5f     | PUSH0          | 0                  |
+| [05] | 5f     | PUSH0          | 0 0                |
+| [06] | 36     | CALLDATASIZE   | cds 0 0            |
+| [07] | 5f     | PUSH0          | 0 cds 0 0          |
+| [08] | 73bebe.| PUSH20 0xbebe. | 0xbebe. 0 cds 0 0  |
+| [1d] | 5a     | GAS            | gas 0xbebe. 0 cds 0 0|
+| [1e] | f4     | DELEGATECALL   | suc                |
+| [1f] | 3d     | RETURNDATASIZE | rds suc            |
+| [20] | 5f     | PUSH0          | 0 rds suc          |
+| [21] | 5f     | PUSH0          | 0 0 rds suc        |
+| [22] | 3e     | RETURNDATACOPY | suc                |
+| [23] | 5f     | PUSH0          | 0 suc              |
+| [24] | 3d     | RETURNDATASIZE | rds 0 suc          |
+| [25] | 91     | SWAP2          | suc 0 rds          |
+| [26] | 602a   | PUSH1 0x2a     | 0x2a suc 0 rds     |
+| [27] | 57     | JUMPI          | 0 rds              |
+| [29] | fd     | REVERT         |                    |
+| [2a] | 5b     | JUMPDEST       | 0 rds              |
+| [2b] | f3     | RETURN         |                    |
+```
+
+### Minimal Creation Code
+
+The minimal creation code of the minimal proxy contract is:
+
+```
+602c8060095f395ff3365f5f375f5f365f73bebebebebebebebebebebebebebebebebebebebe5af43d5f5f3e5f3d91602a57fd5bf3
+```
+
+where the first 9 bytes are the initcode: 
+
+```
+602c8060095f395ff3
+```
+
+And the rest are runtime/contract code of the proxy. The length of the creation code is `53` bytes.
+
+### Deploy with Solidity
+
+The minimal proxy contract can be deployed with Solidity using underlying contract:
+
+```solidity
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+// Note: this contract requires `PUSH0`, which is available in solidity > 0.8.20 and EVM version > Shanghai
+contract Clone0Factory {
+    error FailedCreateClone();
+
+    receive() external payable {}
+
+    /**
+     * @dev Deploys and returns the address of a clone0 (Minimal Proxy Contract with `PUSH0`) that mimics the behaviour of `implementation`.
+     *
+     * This function uses the create opcode, which should never revert.
+     */
+    function clone0(address impl) public payable returns (address addr) {
+        // first 18 bytes of the creation code 
+        bytes memory data1 = hex"602c8060095f395ff3365f5f375f5f365f73";
+        // last 15 bytes of the creation code
+        bytes memory data2 = hex"5af43d5f5f3e5f3d91602a57fd5bf3";
+        // complete the creation code of Clone0
+        bytes memory _code = abi.encodePacked(data1, impl, data2);
+
+        // deploy with create op
+        assembly {
+            // create(v, p, n)
+            addr := create(callvalue(), add(_code, 0x20), mload(_code))
+        }
+
+        if (addr == address(0)) {
+            revert FailedCreateClone();
+        }
+    }
+}
+```
+
+## Rationale
+
+The contract is built from [first principals](https://blog.openzeppelin.com/deep-dive-into-the-minimal-proxy-contract) utilizing the newly introduced `PUSH0` opcode. The essential components of the minimal proxy are:
+
+1. Copy the calldata with `CALLDATACOPY`.
+2. Forward the calldata to the implementation contract using `DELEGATECALL`.
+3. Copy the returned data from the `DELEGATECALL`.
+4. Return the results or reverts the transaction based on wether the `DELEGATECALL` is successful.
+
+### Step 1: Copy the Calldata
+
+To copy the calldata, we need to provide the arguments for the `CALLDATACOPY` opcodes, which are `[0, 0, cds]`, where `cds` represents calldata size.
+
+```shell
+| pc   | op     | opcode         | stack              |
+|------|--------|----------------|--------------------|
+| [00] | 36     | CALLDATASIZE   | cds                |
+| [01] | 5f     | PUSH0          | 0 cds              |
+| [02] | 5f     | PUSH0          | 0 0 cds            |
+| [03] | 37     | CALLDATACOPY   |                    |
+```
+
+### Step 2: Delegatecall
+
+To forward the calldata to the delegate call, we need to prepare arguments for the `DELEGATECALL` opcodes, which are `[gas 0xbebe. 0 cds 0 0]`, where `gas` represents the remaining gas, `0xbebe.` represents the address of the implementation contract, and `suc` represents whether the delegatecall is successful. 
+
+```shell
+| pc   | op     | opcode         | stack              |
+|------|--------|----------------|--------------------|
+| [04] | 5f     | PUSH0          | 0                  |
+| [05] | 5f     | PUSH0          | 0 0                |
+| [06] | 36     | CALLDATASIZE   | cds 0 0            |
+| [07] | 5f     | PUSH0          | 0 cds 0 0          |
+| [08] | 73bebe.| PUSH20 0xbebe. | 0xbebe. 0 cds 0 0  |
+| [1d] | 5a     | GAS            | gas 0xbebe. 0 cds 0 0|
+| [1e] | f4     | DELEGATECALL   | suc                |
+```
+
+### Step 3: Copy the Returned Data from the `DELEGATECALL`
+
+To copy the returndata, we need to provide the arguments for the `RETURNDATACOPY` opcodes, which are `[0, 0, red]`, where `rds` represents size of returndata from the `DELEGATECALL`.
+
+```shell
+| pc   | op     | opcode         | stack              |
+|------|--------|----------------|--------------------|
+| [1f] | 3d     | RETURNDATASIZE | rds suc            |
+| [20] | 5f     | PUSH0          | 0 rds suc          |
+| [21] | 5f     | PUSH0          | 0 0 rds suc        |
+| [22] | 3e     | RETURNDATACOPY | suc                |
+```
+
+### Step 4: Return or Revert
+
+Lastly we need to return the data or revert the transaction based on whether the `DELEGATECALL` is successful. There is no `if/else` in opcodes, so we need to use `JUMPI` and `JUMPDEST` instead. The auguments for `JUMPI` is `[0x2a, suc]`, where `0x2a` is the destination of the conditional jump.
+
+ We also need to prepare the argument `[0, rds]` for `REVERT` and `RETURN` opcodes before the `JUMPI`, otherwise we have to prepare them twice. We cannot avoid the `SWAP` operation, because we can only get `rds` after the `DELEGATECALL`.
+
+```shell
+| pc   | op     | opcode         | stack              |
+|------|--------|----------------|--------------------|
+| [23] | 5f     | PUSH0          | 0 suc              |
+| [24] | 3d     | RETURNDATASIZE | rds 0 suc          |
+| [25] | 91     | SWAP2          | suc 0 rds          |
+| [26] | 602a   | PUSH1 0x2a     | 0x2a suc 0 rds     |
+| [27] | 57     | JUMPI          | 0 rds              |
+| [29] | fd     | REVERT         |                    |
+| [2a] | 5b     | JUMPDEST       | 0 rds              |
+| [2b] | f3     | RETURN         |                    |
+```
+
+In the end, we arrived at the runtime code for Minimal Proxy Contract with `PUSH0`: 
+
+```
+365f5f375f5f365f73bebebebebebebebebebebebebebebebebebebebe5af43d5f5f3e5f3d91602a57fd5bf3
+```
+
+The length of the runtime code is `44` bytes, which reduced `1` byte from the previous Minimal Proxy Contract. Moreover, it replaced the `RETURNDATASIZE` and `DUP` operations with `PUSH0`, which saves gas and increase the readability of the code. In summary, the new Minimal Proxy Contract reduce `200` gas at deployment and `5` gas at runtime, while remain the same functionalities as the old one.
+
+##  Backwards Compatibility
+
+Because the new minimal proxy contract uses `PUSH0` opcode, it can only be deployed after Shanghai Upgrade. It behaves the same as previous Minimal Proxy Contract.
+
+##  Test Cases
+
+Test cases are performed using Foundry, which include:
+
+- invocation with no arguments.
+- invocation with arguments.
+- invocation with fixed length return values
+- invocation with variable length return values
+- invocation with revert
+- deploy with minimal creation code (tested on Goerli testnet, [link](https://goerli.etherscan.io/address/0xb4f95ad6256a27a5629d9c4c71bff02bc373c9be#code))
+
+Tests for these cases are included in the GitHub repo [Minimal Proxy PUSH0](https://github.com/AmazingAng/Minimal-Proxy-PUSH0).
+
+## Reference Implementation
+
+[Minimal Proxy PUSH0](https://github.com/AmazingAng/Minimal-Proxy-PUSH0)
+
+## Security Considerations
+
+The new proxy contract standard is identical to the previous one (eip-1167). Here are the security considerations when using minimal proxy contracts:
+
+1. **Non-Upgradability**: Minimal Proxy Contracts delegate their logic to another contract (often termed the "implementation" or "logic" contract). This delegation is fixed upon deployment, meaning you can't change which implementation contract the proxy delegates to after its creation.
+   
+2. **Initialization Concerns**: Proxy contracts lack constructors, so you need to use an initialization function after deployment. Skipping this step could leave the contract unsafe.
+
+3. **Safety of Logic Contract**: Vulnerabilities in the logic contract affect all associated proxy contracts.
+
+4. **Transparency Issues**: Because of its complexity, users might see the proxy as an empty contract, making it challenging to trace back to the actual logic contract.
+
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://github.com/ethereum/EIPs/blob/LICENSE.md).
+
+## Reference
+
+1. Peter Murray (@yarrumretep), Nate Welch (@flygoing), Joe Messerman (@JAMesserman), "ERC-1167: Minimal Proxy Contract," Ethereum Improvement Proposals, no. 1167, June 2018. [Online serial]. Available: https://eips.ethereum.org/EIPS/eip-1167.
+
+2. Alex Beregszaszi (@axic), Hugo De la cruz (@hugo-dc), Paweł Bylica (@chfast), "EIP-3855: PUSH0 instruction," Ethereum Improvement Proposals, no. 3855, February 2021. [Online serial]. Available: https://eips.ethereum.org/EIPS/eip-3855.
+
+3. Martin Abbatemarco, Deep dive into the Minimal Proxy contract, https://blog.openzeppelin.com/deep-dive-into-the-minimal-proxy-contract
+
+4. 0age, The More-Minimal Proxy, https://medium.com/@0age/the-more-minimal-proxy-5756ae08ee48

--- a/EIPS/eip-minimal-proxy-push0.md
+++ b/EIPS/eip-minimal-proxy-push0.md
@@ -1,7 +1,7 @@
 ---
 eip: minimal-proxy-push0
 title: Minimal Proxy Contract with `PUSH0`
-description: Optimize the previous Minimal Proxy Contract (EIP-1167) with newly introduced `PUSH0` opcode
+description: Optimize the previous Minimal Proxy Contract (ERC-1167) with newly introduced `PUSH0` opcode
 author: 0xAA (@AmazingAng)
 discussions-to: https://ethereum-magicians.org/t/proposal-for-a-new-eip-minimal-proxy-contract-with-push0/15662
 status: Draft
@@ -236,9 +236,3 @@ The new proxy contract standard is identical to the previous one (ERC-1167). Her
 ## Copyright
 
 Copyright and related rights waived via [CC0](../LICENSE.md).
-
-## Reference
-
-Martin Abbatemarco, Deep dive into the Minimal Proxy contract
-
-0age, The More-Minimal Proxy

--- a/EIPS/eip-minimal-proxy-push0.md
+++ b/EIPS/eip-minimal-proxy-push0.md
@@ -1,5 +1,5 @@
 ---
-eip: 7509
+eip: minimal-proxy-push0
 title: Minimal Proxy Contract with `PUSH0`
 description: Optimize the previous Minimal Proxy Contract (eip-3855) with newly introduced `PUSH0` opcode
 author: 0xAA (@AmazingAng)
@@ -13,7 +13,7 @@ requires: 7, 211, 1167, 3855
 
 ## Simple Summary
 
-With the newly introduced `PUSH0` opcode ([eip-3855](./eip-3855)) at Shanghai Upgrade, we minimized the previous Minimal Proxy Contract ([eip-1167](./eip-1167)) by 200 gas at deployment and 5 gas at runtime, while retaining same functionalities.
+With the newly introduced `PUSH0` opcode ([EIP-3855](./eip-3855)) at Shanghai Upgrade, we minimized the previous Minimal Proxy Contract ([EIP-1167](./eip-1167)) by 200 gas at deployment and 5 gas at runtime, while retaining same functionalities.
 
 ## Abstract
 
@@ -226,7 +226,7 @@ GitHub Repo: Minimal-Proxy-PUSH0
 
 ## Security Considerations
 
-The new proxy contract standard is identical to the previous one (eip-1167). Here are the security considerations when using minimal proxy contracts:
+The new proxy contract standard is identical to the previous one (EIP-1167). Here are the security considerations when using minimal proxy contracts:
 
 1. **Non-Upgradability**: Minimal Proxy Contracts delegate their logic to another contract (often termed the "implementation" or "logic" contract). This delegation is fixed upon deployment, meaning you can't change which implementation contract the proxy delegates to after its creation.
    
@@ -243,10 +243,10 @@ Copyright and related rights waived via [CC0](../LICENSE.md).
 
 ## Reference
 
-1. Peter Murray (@yarrumretep), Nate Welch (@flygoing), Joe Messerman (@JAMesserman), "ERC-1167: Minimal Proxy Contract," Ethereum Improvement Proposals, no. 1167, June 2018. [Online serial].
+Peter Murray (@yarrumretep), Nate Welch (@flygoing), Joe Messerman (@JAMesserman), "ERC-1167: Minimal Proxy Contract," Ethereum Improvement Proposals, no. 1167, June 2018. [Online serial].
 
-2. Alex Beregszaszi (@axic), Hugo De la cruz (@hugo-dc), Paweł Bylica (@chfast), "EIP-3855: PUSH0 instruction," Ethereum Improvement Proposals, no. 3855, February 2021. [Online serial].
+Alex Beregszaszi (@axic), Hugo De la cruz (@hugo-dc), Paweł Bylica (@chfast), "EIP-3855: PUSH0 instruction," Ethereum Improvement Proposals, no. 3855, February 2021. [Online serial].
 
-3. Martin Abbatemarco, Deep dive into the Minimal Proxy contract
+Martin Abbatemarco, Deep dive into the Minimal Proxy contract
 
-4. 0age, The More-Minimal Proxy
+0age, The More-Minimal Proxy

--- a/EIPS/eip-minimal-proxy-push0.md
+++ b/EIPS/eip-minimal-proxy-push0.md
@@ -1,4 +1,5 @@
 ---
+eip: 7509
 title: Minimal Proxy Contract with `PUSH0`
 description: Optimize the previous Minimal Proxy Contract (eip-3855) with newly introduced `PUSH0` opcode
 author: 0xAA (@AmazingAng)
@@ -12,7 +13,7 @@ requires: 7, 211, 1167, 3855
 
 ## Simple Summary
 
-With the newly introduced `PUSH0` opcode ([eip-3855](https://eips.ethereum.org/EIPS/eip-3855)) at Shanghai Upgrade, we minimized the previous Minimal Proxy Contract ([eip-1167](https://eips.ethereum.org/EIPS/eip-1167)) by 200 gas at deployment and 5 gas at runtime, while retaining same functionalities.
+With the newly introduced `PUSH0` opcode ([eip-3855](./eip-3855)) at Shanghai Upgrade, we minimized the previous Minimal Proxy Contract ([eip-1167](./eip-1167)) by 200 gas at deployment and 5 gas at runtime, while retaining same functionalities.
 
 ## Abstract
 
@@ -126,7 +127,7 @@ contract Clone0Factory {
 
 ## Rationale
 
-The contract is built from [first principals](https://blog.openzeppelin.com/deep-dive-into-the-minimal-proxy-contract) utilizing the newly introduced `PUSH0` opcode. The essential components of the minimal proxy are:
+The contract is built from first principals utilizing the newly introduced `PUSH0` opcode. The essential components of the minimal proxy are:
 
 1. Copy the calldata with `CALLDATACOPY`.
 2. Forward the calldata to the implementation contract using `DELEGATECALL`.
@@ -215,13 +216,13 @@ Test cases are performed using Foundry, which include:
 - invocation with fixed length return values
 - invocation with variable length return values
 - invocation with revert
-- deploy with minimal creation code (tested on Goerli testnet, [link](https://goerli.etherscan.io/address/0xb4f95ad6256a27a5629d9c4c71bff02bc373c9be#code))
+- deploy with minimal creation code
 
-Tests for these cases are included in the GitHub repo [Minimal Proxy PUSH0](https://github.com/AmazingAng/Minimal-Proxy-PUSH0).
+Tests for these cases are included in the GitHub repo Minimal-Proxy-PUSH0.
 
 ## Reference Implementation
 
-[Minimal Proxy PUSH0](https://github.com/AmazingAng/Minimal-Proxy-PUSH0)
+GitHub Repo: Minimal-Proxy-PUSH0
 
 ## Security Considerations
 
@@ -238,14 +239,14 @@ The new proxy contract standard is identical to the previous one (eip-1167). Her
 
 ## Copyright
 
-Copyright and related rights waived via [CC0](https://github.com/ethereum/EIPs/blob/LICENSE.md).
+Copyright and related rights waived via [CC0](../LICENSE.md).
 
 ## Reference
 
-1. Peter Murray (@yarrumretep), Nate Welch (@flygoing), Joe Messerman (@JAMesserman), "ERC-1167: Minimal Proxy Contract," Ethereum Improvement Proposals, no. 1167, June 2018. [Online serial]. Available: https://eips.ethereum.org/EIPS/eip-1167.
+1. Peter Murray (@yarrumretep), Nate Welch (@flygoing), Joe Messerman (@JAMesserman), "ERC-1167: Minimal Proxy Contract," Ethereum Improvement Proposals, no. 1167, June 2018. [Online serial].
 
-2. Alex Beregszaszi (@axic), Hugo De la cruz (@hugo-dc), Paweł Bylica (@chfast), "EIP-3855: PUSH0 instruction," Ethereum Improvement Proposals, no. 3855, February 2021. [Online serial]. Available: https://eips.ethereum.org/EIPS/eip-3855.
+2. Alex Beregszaszi (@axic), Hugo De la cruz (@hugo-dc), Paweł Bylica (@chfast), "EIP-3855: PUSH0 instruction," Ethereum Improvement Proposals, no. 3855, February 2021. [Online serial].
 
-3. Martin Abbatemarco, Deep dive into the Minimal Proxy contract, https://blog.openzeppelin.com/deep-dive-into-the-minimal-proxy-contract
+3. Martin Abbatemarco, Deep dive into the Minimal Proxy contract
 
-4. 0age, The More-Minimal Proxy, https://medium.com/@0age/the-more-minimal-proxy-5756ae08ee48
+4. 0age, The More-Minimal Proxy


### PR DESCRIPTION
Simple Summary
With the newly introduced `PUSH0` opcode ([eip-3855](https://eips.ethereum.org/EIPS/eip-3855)) at Shanghai Upgrade, we optimized the previous Minimal Proxy Contract ([eip-1167](https://eips.ethereum.org/EIPS/eip-1167)) from 55 bytes to 54 bytes, which saves 200 gas at deployment and 5 gas at runtime, while remain the same functionalities.

discussion: https://ethereum-magicians.org/t/proposal-for-a-new-eip-minimal-proxy-contract-with-push0/15662

implementation: https://github.com/AmazingAng/Minimal-Proxy-PUSH0