### PR TITLE
Update EIP-6900: Correct phrasing

### DIFF
--- a/EIPS/eip-6900.md
+++ b/EIPS/eip-6900.md
@@ -346,7 +346,7 @@ The function MUST parse through the execution functions, validation functions, a
 - Each execution selector MUST be added as a valid execution function on the modular account. If the execution selector has already been added or matches the selector of a native function, the function SHOULD revert.
 - If an associated function that is to be added already exists, execution SHOULD NOT revert but continue to the next operation.
 
-Finally, the function MUST call the plugin's `onInstall` callback with the data provided in the `installData` parameter. This serves to initializes the plugin state for the modular account. If `onInstall` reverts, the `installPlugin` function MUST revert.
+Finally, the function MUST call the plugin's `onInstall` callback with the data provided in the `installData` parameter. This serves to initialize the plugin state for the modular account. If `onInstall` reverts, the `installPlugin` function MUST revert.
 
 #### Calls to `uninstallPlugin`
 


### PR DESCRIPTION
- Corrects the usage of "initializes" to "initialize"