### PR TITLE
Update EIP-6551: Update eip-6551.md to fix typo

### DIFF
--- a/EIPS/eip-6551.md
+++ b/EIPS/eip-6551.md
@@ -114,7 +114,7 @@ interface IERC6551Registry {
         uint256 chainId,
         address tokenContract,
         uint256 tokenId,
-        uint256 seed,
+        uint256 salt,
         bytes calldata initData
     ) external returns (address);
 


### PR DESCRIPTION
In the Tokenbound Working Group Telegram channel, Jayden Windle mentioned seed was renamed to salt.
"Are you using the most up to date version of the contracts here? Seed was renamed to salt, and allows you to have multiple accounts per NFT."
