### PR TITLE
Update EIP-4788: post audit tweaks

### DIFF
--- a/EIPS/eip-4788.md
+++ b/EIPS/eip-4788.md
@@ -29,9 +29,9 @@ restaking constructions, smart contract bridges, MEV mitigations and more.
 | constants                    | value                                        |
 |---                           |---                                           |
 | `FORK_TIMESTAMP`             | TBD                                          |
-| `HISTORY_BUFFER_LENGTH`      | `8191`                                      |
+| `HISTORY_BUFFER_LENGTH`      | `8191`                                       |
 | `SYSTEM_ADDRESS`             | `0xfffffffffffffffffffffffffffffffffffffffe` |
-| `BEACON_ROOTS_ADDRESS`       | `0xbEAC020008aFF7331c0A389CB2AAb67597567d7a` |
+| `BEACON_ROOTS_ADDRESS`       | `0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02` |
 
 ### Background
 
@@ -224,14 +224,14 @@ by working backwards from the desired deployment transaction:
   "input": "0x60618060095f395ff33373fffffffffffffffffffffffffffffffffffffffe14604d57602036146024575f5ffd5b5f35801560495762001fff810690815414603c575f5ffd5b62001fff01545f5260205ff35b5f5ffd5b62001fff42064281555f359062001fff015500",
   "v": "0x1b",
   "r": "0x539",
-  "s": "0x1337005f06a8b6a0a0b1f4",
-  "hash": "0x7186d3f6803018a58578464132f120d9420c0a00e37ed42c117fdb3d650e1dac"
+  "s": "0x1b9b6eb1f0",
+  "hash": "0xdf52c2d3bbe38820fff7b5eaab3db1b91f8e1412b56497d88388fb5d4ea1fde0"
 }
 ```
 
 Note, the input in the transaction has a simple constructor prefixing the desired runtime code.
 
-The sender of the transaction can be calculated as `0x4f6Da9ba1Cc8c37d9CE52311d4baFfc43bA42D0e`. The address of the first contract deployed from the account is `rlp([sender, 0])` which equals `0xbEAC020008aFF7331c0A389CB2AAb67597567d7a`. This is how `BEACON_ROOTS_ADDRESS` is determined. Although this style of contract creation is not tied to any specific initcode like create2 is, the synthetic address is cryptographically bound to the input data of the transaction (e.g. the initcode).
+The sender of the transaction can be calculated as `0x0B799C86a49DEeb90402691F1041aa3AF2d3C875`. The address of the first contract deployed from the account is `rlp([sender, 0])` which equals `0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02`. This is how `BEACON_ROOTS_ADDRESS` is determined. Although this style of contract creation is not tied to any specific initcode like create2 is, the synthetic address is cryptographically bound to the input data of the transaction (e.g. the initcode).
 
 ### Block processing
 

--- a/EIPS/eip-4788.md
+++ b/EIPS/eip-4788.md
@@ -31,7 +31,7 @@ restaking constructions, smart contract bridges, MEV mitigations and more.
 | `FORK_TIMESTAMP`             | TBD                                          |
 | `HISTORY_BUFFER_LENGTH`      | `8191`                                      |
 | `SYSTEM_ADDRESS`             | `0xfffffffffffffffffffffffffffffffffffffffe` |
-| `BEACON_ROOTS_ADDRESS`       | `0xbEaC02001Aedb23b4088c853e4C05c57491c8bCA` |
+| `BEACON_ROOTS_ADDRESS`       | `0xbEAC020008aFF7331c0A389CB2AAb67597567d7a` |
 
 ### Background
 
@@ -220,10 +220,24 @@ The beacon roots contract is deployed like any other smart contract. A special s
 by working backwards from the desired deployment transaction:
 
 ```json
-
+{
+  "type": "0x0",
+  "nonce": "0x0",
+  "to": null,
+  "gas": "0x3d090",
+  "gasPrice": "0xe8d4a51000",
+  "maxPriorityFeePerGas": null,
+  "maxFeePerGas": null,
+  "value": "0x0",
+  "input": "0x60618060095f395ff33373fffffffffffffffffffffffffffffffffffffffe14604d57602036146024575f5ffd5b5f35801560495762001fff810690815414603c575f5ffd5b62001fff01545f5260205ff35b5f5ffd5b62001fff42064281555f359062001fff015500",
+  "v": "0x1b",
+  "r": "0x539",
+  "s": "0x1337005f06a8b6a0a0b1f4",
+  "hash": "0x7186d3f6803018a58578464132f120d9420c0a00e37ed42c117fdb3d650e1dac"
+}
 ```
 
-The sender of the transaction can be calculated as `0xC7FbEC8522B39df17318A2F71FfA2f8EFcBdb6E0`. The address of the first contract deployed from the account is `rlp([sender, 0])` which equals `0xbEaC02001Aedb23b4088c853e4C05c57491c8bCA`. This is how `BEACON_ROOTS_ADDRESS` is determined. Although this style of contract creation is not tied to any specific initcode like create2 is, the synthetic address is cryptographically bound to the input data of the transaction (e.g. the initcode).
+The sender of the transaction can be calculated as `0x4f6Da9ba1Cc8c37d9CE52311d4baFfc43bA42D0e`. The address of the first contract deployed from the account is `rlp([sender, 0])` which equals `0xbEAC020008aFF7331c0A389CB2AAb67597567d7a`. This is how `BEACON_ROOTS_ADDRESS` is determined. Although this style of contract creation is not tied to any specific initcode like create2 is, the synthetic address is cryptographically bound to the input data of the transaction (e.g. the initcode).
 
 ### Block processing
 

--- a/EIPS/eip-4788.md
+++ b/EIPS/eip-4788.md
@@ -31,7 +31,7 @@ restaking constructions, smart contract bridges, MEV mitigations and more.
 | `FORK_TIMESTAMP`             | TBD                                          |
 | `HISTORY_BUFFER_LENGTH`      | `8191`                                      |
 | `SYSTEM_ADDRESS`             | `0xfffffffffffffffffffffffffffffffffffffffe` |
-| `BEACON_ROOTS_ADDRESS`       | `0xBEaC020001c6C8B69E5257f4754e46e25f5dc9cB` |
+| `BEACON_ROOTS_ADDRESS`       | `0xbEaC02001Aedb23b4088c853e4C05c57491c8bCA` |
 
 ### Background
 
@@ -137,81 +137,81 @@ def set():
 The exact initcode to deploy is shared below.
 
 ```asm
-push1 0x61
-dup1
-push1 0x09
-push0
-codecopy
-push0
-return
+   0:   push1 0x61
+   2:   dup1
+   3:   push1 0x09
+   5:   push0
+   6:   codecopy
+   7:   push0
+   8:   return
 
-caller
-push20 0xfffffffffffffffffffffffffffffffffffffffe
-eq
-push1 0x4d
-jumpi
+   9:   caller
+   a:   push20 0xfffffffffffffffffffffffffffffffffffffffe
+  1f:   eq
+  20:   push1 0x4d
+  22:   jumpi
 
-push1 0x20
-calldatasize
-eq
-push1 0x24
-jumpi
+  23:   push1 0x20
+  25:   calldatasize
+  26:   eq
+  27:   push1 0x24
+  29:   jumpi
 
-push0
-push0
-revert
+  2a:   push0
+  2b:   push0
+  2c:   revert
 
-jumpdest
-push0
-calldataload
-dup1
-iszero
-push1 0x49
-jumpi
+  2d:   jumpdest
+  2e:   push0
+  2f:   calldataload
+  30:   dup1
+  31:   iszero
+  32:   push1 0x49
+  34:   jumpi
 
-push3 0x016da0
-dup2
-mod
-swap1
-dup2
-sload
-eq
-push1 0x3c
-jumpi
+  35:   push3 0x001fff
+  39:   dup2
+  3a:   mod
+  3b:   swap1
+  3c:   dup2
+  3d:   sload
+  3e:   eq
+  3f:   push1 0x3c
+  41:   jumpi
 
-push0
-push0
-revert
+  42:   push0
+  43:   push0
+  44:   revert
 
-jumpdest
-push3 0x016da0
-add
-sload
-push0
-mstore
-push1 0x20
-push0
-return
+  45:   jumpdest
+  46:   push3 0x001fff
+  4a:   add
+  4b:   sload
+  4c:   push0
+  4d:   mstore
+  4e:   push1 0x20
+  50:   push0
+  51:   return
 
-jumpdest
-push0
-push0
-revert
+  52:   jumpdest
+  53:   push0
+  54:   push0
+  55:   revert
 
-jumpdest
-push3 0x016da0
-timestamp
-mod
-timestamp
-dup2
-sstore
-push0
-calldataload
-swap1
-push3 0x016da0
-add
-sstore
-stop
+  56:   jumpdest
+  57:   push3 0x001fff
+  5b:   timestamp
+  5c:   mod
+  5d:   timestamp
+  5e:   dup2
+  5f:   sstore
+  60:   push0
+  61:   calldataload
+  62:   swap1
+  63:   push3 0x001fff
+  67:   add
+  68:   sstore
+  69:   stop
 ```
 
 #### Deployment
@@ -220,25 +220,10 @@ The beacon roots contract is deployed like any other smart contract. A special s
 by working backwards from the desired deployment transaction:
 
 ```json
-{
-  "type": "0x0",
-  "nonce": "0x0",
-  "to": null,
-  "gas": "0x3d090",
-  "gasPrice": "0xe8d4a51000",
-  "maxPriorityFeePerGas": null,
-  "maxFeePerGas": null,
-  "value": "0x0",
-  "input": "0x60618060095f395ff33373fffffffffffffffffffffffffffffffffffffffe14604d57602036146024575f5ffd5b5f35801560495762016da0810690815414603c575f5ffd5b62016da001545f5260205ff35b5f5ffd5b62
-016da042064281555f359062016da0015500",
-  "v": "0x1b",
-  "r": "0x539",
-  "s": "0x133700f399526625760859",
-  "hash": "0x3bd7320b837cfe4efba41d333a1a6514b2ed691c4ffd63db84e39852df4a3292"
-}
+
 ```
 
-The sender of the transaction can be calculated as `0x6ccA914845EB5413c1b7D600dC4D47f6CE85601a`. The address of the first contract deployed from the account is `rlp([sender, 0])` which equals `0xBEaC020001c6C8B69E5257f4754e46e25f5dc9cB`. This is how `BEACON_ROOTS_ADDRESS` is determined. Although this style of contract creation is not tied to any specific initcode like create2 is, the synthetic address is cryptographically bound to the input data of the transaction (e.g. the initcode).
+The sender of the transaction can be calculated as `0xC7FbEC8522B39df17318A2F71FfA2f8EFcBdb6E0`. The address of the first contract deployed from the account is `rlp([sender, 0])` which equals `0xbEaC02001Aedb23b4088c853e4C05c57491c8bCA`. This is how `BEACON_ROOTS_ADDRESS` is determined. Although this style of contract creation is not tied to any specific initcode like create2 is, the synthetic address is cryptographically bound to the input data of the transaction (e.g. the initcode).
 
 ### Block processing
 

--- a/EIPS/eip-4788.md
+++ b/EIPS/eip-4788.md
@@ -29,9 +29,9 @@ restaking constructions, smart contract bridges, MEV mitigations and more.
 | constants                    | value                                        |
 |---                           |---                                           |
 | `FORK_TIMESTAMP`             | TBD                                          |
-| `HISTORY_BUFFER_LENGTH`      | `98304`                                      |
+| `HISTORY_BUFFER_LENGTH`      | `93600`                                      |
 | `SYSTEM_ADDRESS`             | `0xfffffffffffffffffffffffffffffffffffffffe` |
-| `BEACON_ROOTS_ADDRESS`       | `0xbEac00dDB15f3B6d645C48263dC93862413A222D` |
+| `BEACON_ROOTS_ADDRESS`       | `0xbEaC02f20e05eDcfcB49E623683E08dcbA550Ea3` |
 
 ### Background
 
@@ -87,6 +87,7 @@ The beacon roots contract has two operations: `get` and `set`. The input itself 
 
 * Callers provide the `timestamp` they are querying encoded as 32 bytes in big-endian format.
 * If the input is not exactly 32 bytes, the contract must revert.
+* If the input is equal to 0, the contract must revert.
 * Given `timestamp`, the contract computes the storage index in which the timestamp is stored by computing the modulo `timestamp % HISTORY_BUFFER_LENGTH` and reads the value.
 * If the `timestamp` does not match, the contract must revert.
 * Finally, the beacon root associated with the timestamp is returned to the user. It is stored at `timestamp % HISTORY_BUFFER_LENGTH + HISTORY_BUFFER_LENGTH`.
@@ -107,6 +108,9 @@ else:
 
 def get():
     if len(evm.calldata) != 32:
+        evm.revert()
+
+    if to_uint256_be(evm.calldata) == 0:
         evm.revert()
 
     timestamp_idx = to_uint256_be(evm.calldata) % HISTORY_BUFFER_LENGTH
@@ -133,7 +137,7 @@ def set():
 The exact initcode to deploy is shared below.
 
 ```asm
-push1 0x58
+push1 0x61
 dup1
 push1 0x09
 push0
@@ -144,7 +148,7 @@ return
 caller
 push20 0xfffffffffffffffffffffffffffffffffffffffe
 eq
-push1 0x44
+push1 0x4d
 jumpi
 
 push1 0x20
@@ -158,16 +162,21 @@ push0
 revert
 
 jumpdest
-push3 0x018000
 push0
 calldataload
-mod
 dup1
+iszero
+push1 0x49
+jumpi
+
+push3 0x016da0
+dup2
+mod
+swap1
+dup2
 sload
-push0
-calldataload
 eq
-push1 0x37
+push1 0x3c
 jumpi
 
 push0
@@ -175,7 +184,7 @@ push0
 revert
 
 jumpdest
-push3 0x018000
+push3 0x016da0
 add
 sload
 push0
@@ -185,7 +194,12 @@ push0
 return
 
 jumpdest
-push3 0x018000
+push0
+push0
+revert
+
+jumpdest
+push3 0x016da0
 timestamp
 mod
 timestamp
@@ -194,7 +208,7 @@ sstore
 push0
 calldataload
 swap1
-push3 0x018000
+push3 0x016da0
 add
 sstore
 stop
@@ -210,20 +224,20 @@ by working backwards from the desired deployment transaction:
   "type": "0x0",
   "nonce": "0x0",
   "to": null,
-  "gas": "0x27eac",
+  "gas": "0x3d090",
   "gasPrice": "0xe8d4a51000",
   "maxPriorityFeePerGas": null,
   "maxFeePerGas": null,
   "value": "0x0",
-  "input": "0x60588060095f395ff33373fffffffffffffffffffffffffffffffffffffffe14604457602036146024575f5ffd5b620180005f350680545f35146037575f5ffd5b6201800001545f5260205ff35b6201800042064281555f359062018000015500",
+  "input": "0x60618060095f395ff33373fffffffffffffffffffffffffffffffffffffffe14604d57602036146024575f5ffd5b5f35801560495762016da0810690815414603c575f5ffd5b62016da001545f5260205ff35b5f5ffd5b62016da042064281555f359062016da0015500",
   "v": "0x1b",
   "r": "0x539",
-  "s": "0x133700f3a77843802897db",
-  "hash": "0x14789a20c0508b81ab7a0287a12a3a41ca960aa18244af8e98689e37ed569f07"
+  "s": "0x133700018971c643803096",
+  "hash": "0xe51c1d6c56467add9ab579bcda47a3057280dfdf1f8174a2b9b05a4e7346cf0d"
 }
 ```
 
-The sender of the transaction can be calculated as `0x3e266d3c3a70c238bdddafef1ba06fbd58958d70`. The address of the first contract deployed from the account is `rlp([sender, 0])` which equals `0xbEac00dDB15f3B6d645C48263dC93862413A222D`. This is how `BEACON_ROOTS_ADDRESS` is determined. Although this style of contract creation is not tied to any specific initcode like create2 is, the synthetic address is cryptographically bound to the input data of the transaction (e.g. the initcode).
+The sender of the transaction can be calculated as `0x54049C55437B1a0b82C090655D4A45296641cAF4`. The address of the first contract deployed from the account is `rlp([sender, 0])` which equals `0xbEaC02f20e05eDcfcB49E623683E08dcbA550Ea3`. This is how `BEACON_ROOTS_ADDRESS` is determined. Although this style of contract creation is not tied to any specific initcode like create2 is, the synthetic address is cryptographically bound to the input data of the transaction (e.g. the initcode).
 
 ### Block processing
 

--- a/EIPS/eip-4788.md
+++ b/EIPS/eip-4788.md
@@ -134,84 +134,76 @@ def set():
 
 ##### Bytecode
 
-The exact initcode to deploy is shared below.
+The exact contract bytecode is shared below.
 
 ```asm
-   0:   push1 0x61
-   2:   dup1
-   3:   push1 0x09
-   5:   push0
-   6:   codecopy
-   7:   push0
-   8:   return
+caller
+push20 0xfffffffffffffffffffffffffffffffffffffffe
+eq
+push1 0x4d
+jumpi
 
-   9:   caller
-   a:   push20 0xfffffffffffffffffffffffffffffffffffffffe
-  1f:   eq
-  20:   push1 0x4d
-  22:   jumpi
+push1 0x20
+calldatasize
+eq
+push1 0x24
+jumpi
 
-  23:   push1 0x20
-  25:   calldatasize
-  26:   eq
-  27:   push1 0x24
-  29:   jumpi
+push0
+push0
+revert
 
-  2a:   push0
-  2b:   push0
-  2c:   revert
+jumpdest
+push0
+calldataload
+dup1
+iszero
+push1 0x49
+jumpi
 
-  2d:   jumpdest
-  2e:   push0
-  2f:   calldataload
-  30:   dup1
-  31:   iszero
-  32:   push1 0x49
-  34:   jumpi
+push3 0x001fff
+dup2
+mod
+swap1
+dup2
+sload
+eq
+push1 0x3c
+jumpi
 
-  35:   push3 0x001fff
-  39:   dup2
-  3a:   mod
-  3b:   swap1
-  3c:   dup2
-  3d:   sload
-  3e:   eq
-  3f:   push1 0x3c
-  41:   jumpi
+push0
+push0
+revert
 
-  42:   push0
-  43:   push0
-  44:   revert
+jumpdest
+push3 0x001fff
+add
+sload
+push0
+mstore
+push1 0x20
+push0
+return
 
-  45:   jumpdest
-  46:   push3 0x001fff
-  4a:   add
-  4b:   sload
-  4c:   push0
-  4d:   mstore
-  4e:   push1 0x20
-  50:   push0
-  51:   return
+jumpdest
+push0
+push0
+revert
 
-  52:   jumpdest
-  53:   push0
-  54:   push0
-  55:   revert
-
-  56:   jumpdest
-  57:   push3 0x001fff
-  5b:   timestamp
-  5c:   mod
-  5d:   timestamp
-  5e:   dup2
-  5f:   sstore
-  60:   push0
-  61:   calldataload
-  62:   swap1
-  63:   push3 0x001fff
-  67:   add
-  68:   sstore
-  69:   stop
+jumpdest
+push3 0x001fff
+timestamp
+mod
+timestamp
+dup2
+sstore
+push0
+calldataload
+swap1
+push3 0x001fff
+add
+sstore
+stop
 ```
 
 #### Deployment
@@ -236,6 +228,8 @@ by working backwards from the desired deployment transaction:
   "hash": "0x7186d3f6803018a58578464132f120d9420c0a00e37ed42c117fdb3d650e1dac"
 }
 ```
+
+Note, the input in the transaction has a simple constructor prefixing the desired runtime code.
 
 The sender of the transaction can be calculated as `0x4f6Da9ba1Cc8c37d9CE52311d4baFfc43bA42D0e`. The address of the first contract deployed from the account is `rlp([sender, 0])` which equals `0xbEAC020008aFF7331c0A389CB2AAb67597567d7a`. This is how `BEACON_ROOTS_ADDRESS` is determined. Although this style of contract creation is not tied to any specific initcode like create2 is, the synthetic address is cryptographically bound to the input data of the transaction (e.g. the initcode).
 

--- a/EIPS/eip-4788.md
+++ b/EIPS/eip-4788.md
@@ -31,7 +31,7 @@ restaking constructions, smart contract bridges, MEV mitigations and more.
 | `FORK_TIMESTAMP`             | TBD                                          |
 | `HISTORY_BUFFER_LENGTH`      | `93600`                                      |
 | `SYSTEM_ADDRESS`             | `0xfffffffffffffffffffffffffffffffffffffffe` |
-| `BEACON_ROOTS_ADDRESS`       | `0xbEaC02f20e05eDcfcB49E623683E08dcbA550Ea3` |
+| `BEACON_ROOTS_ADDRESS`       | `0xBEaC020001c6C8B69E5257f4754e46e25f5dc9cB` |
 
 ### Background
 
@@ -229,15 +229,16 @@ by working backwards from the desired deployment transaction:
   "maxPriorityFeePerGas": null,
   "maxFeePerGas": null,
   "value": "0x0",
-  "input": "0x60618060095f395ff33373fffffffffffffffffffffffffffffffffffffffe14604d57602036146024575f5ffd5b5f35801560495762016da0810690815414603c575f5ffd5b62016da001545f5260205ff35b5f5ffd5b62016da042064281555f359062016da0015500",
+  "input": "0x60618060095f395ff33373fffffffffffffffffffffffffffffffffffffffe14604d57602036146024575f5ffd5b5f35801560495762016da0810690815414603c575f5ffd5b62016da001545f5260205ff35b5f5ffd5b62
+016da042064281555f359062016da0015500",
   "v": "0x1b",
   "r": "0x539",
-  "s": "0x133700018971c643803096",
-  "hash": "0xe51c1d6c56467add9ab579bcda47a3057280dfdf1f8174a2b9b05a4e7346cf0d"
+  "s": "0x133700f399526625760859",
+  "hash": "0x3bd7320b837cfe4efba41d333a1a6514b2ed691c4ffd63db84e39852df4a3292"
 }
 ```
 
-The sender of the transaction can be calculated as `0x54049C55437B1a0b82C090655D4A45296641cAF4`. The address of the first contract deployed from the account is `rlp([sender, 0])` which equals `0xbEaC02f20e05eDcfcB49E623683E08dcbA550Ea3`. This is how `BEACON_ROOTS_ADDRESS` is determined. Although this style of contract creation is not tied to any specific initcode like create2 is, the synthetic address is cryptographically bound to the input data of the transaction (e.g. the initcode).
+The sender of the transaction can be calculated as `0x6ccA914845EB5413c1b7D600dC4D47f6CE85601a`. The address of the first contract deployed from the account is `rlp([sender, 0])` which equals `0xBEaC020001c6C8B69E5257f4754e46e25f5dc9cB`. This is how `BEACON_ROOTS_ADDRESS` is determined. Although this style of contract creation is not tied to any specific initcode like create2 is, the synthetic address is cryptographically bound to the input data of the transaction (e.g. the initcode).
 
 ### Block processing
 

--- a/EIPS/eip-7508.md
+++ b/EIPS/eip-7508.md
@@ -1,7 +1,7 @@
 ---
 eip: 7508
 title: Dynamic On-Chain Token Attributes Repository
-description: Store attributes related to NFTs with custom access control
+description: Dynamic on-chain storage of token attributes in a public-good repository.
 author: Steven Pineda (@steven2308), Jan Turk (@ThunderDeliverer)
 discussions-to: https://ethereum-magicians.org/t/dynamic-on-chain-token-attributes-repository/15667
 status: Draft


### PR DESCRIPTION
*repost from https://github.com/lightclient/4788asm/pull/16*

We've had a few really nice audits done on this code and things have generally been positive. There are a few pieces of feedback that I think are worth addressing before we settle on the final code though. Here is a list, ordered by priority:

1. Verify timestamp is non-zero -- currently the implementation allows an input of zero to return a zero root. This is because the current mainnet timestamp is not perfectly divisible by our modulus. Although no proof could be authenticated against the zero root, it's still an ugly correctness edge case that I think should be addressed.
2. ~~Update `buflen` to `93600` -- this value will share 500-1000[^1] more remainders if the slot time were to change versus the current modulus, decreasing the overall storage use of the contract (h/t @adietrichs).~~ updated to `8191` as the number is prime and there is 100% utilization for all potential slot time values.
3. Load calldata once -- minor nit, but in case the cost of retrieving calldata changes in the future, it would make more sense to only access it via `calldatacopy` a single time, instead of paying for that cost at each load. This require a bit of dup'ing and swap'ing, but still extremely manageable. As a part of this I was also able to delete the `get_input` macro (h/t @adietrichs).

[^1]: https://gist.github.com/lightclient/820a0d5c5861ed09c5cae5e384e9779e