### PR TITLE
Update EIP-6900: add missing members to IPlugin structs, correct install step statement

### DIFF
--- a/EIPS/eip-6900.md
+++ b/EIPS/eip-6900.md
@@ -229,7 +229,7 @@ interface IPlugin {
     function postExecutionHook(uint8 functionId, bytes calldata preExecHookData) external;
 
     /// @notice Describe the contents and intended configuration of the plugin.
-    /// @dev This function MUST NOT make any state changes.
+    /// @dev The manifest MUST stay constant over time.
     /// @return A manifest describing the contents and intended configuration of the plugin.
     function pluginManifest() external pure returns (PluginManifest memory);
 }
@@ -279,6 +279,7 @@ struct ManifestExecutionHook {
 }
 
 struct ManifestStandardExecutionHook {
+    bytes4 executionSelector;
     ManifestFunction validator;
     ManifestFunction preExecHook;
     ManifestFunction postExecHook;
@@ -318,6 +319,7 @@ struct PluginManifest {
     ManifestPreValidationHook[] preUserOpValidationHooks;
     ManifestPreValidationHook[] preRuntimeValidationHooks;
     ManifestExecutionHook[] executionHooks;
+    ManifestExecutionHook[] pluginExecutionHooks;
     ManifestStandardExecutionHook[] standardExecutionHooks;
 }
 ```
@@ -344,7 +346,7 @@ The function MUST store the plugin's permitted execution selectors and external 
 The function MUST parse through the execution functions, validation functions, and hooks in the manifest and add them to the modular account after resolving each `ManifestFunction` type.
 
 - Each execution selector MUST be added as a valid execution function on the modular account. If the execution selector has already been added or matches the selector of a native function, the function SHOULD revert.
-- If an associated function that is to be added already exists, execution SHOULD NOT revert but continue to the next operation.
+- If an associated function that is to be added already exists, the function SHOULD revert.
 
 Finally, the function MUST call the plugin's `onInstall` callback with the data provided in the `installData` parameter. This serves to initialize the plugin state for the modular account. If `onInstall` reverts, the `installPlugin` function MUST revert.
 


### PR DESCRIPTION
- `bytes4 executionSelector` was missing as a member of the `ManifestStandardExecutionHook` struct. This is required for the plugin to differentiate between applying hooks over `execute` vs. `executeBatch` as hooks for these will have different parameters.
- Corrected a comment on `pluginManifest()`.
- Corrected a statement in the installation flow that stated that installation should continue if encountering conflicts.