### PR TITLE
Update EIP-7516: removes remaning references to 0x49

### DIFF
--- a/EIPS/eip-7516.md
+++ b/EIPS/eip-7516.md
@@ -13,7 +13,7 @@ requires: 3198, 4844
 
 ## Abstract
 
-Add a `BLOBBASEFEE (0x49)` that returns the value of the blob base-fee of the current block it is executing in. It is the identical to [EIP-3198](./eip-3198.md) (`BASEFEE` opcode) except that it returns the blob base-fee as per [EIP-4844](./eip-4844.md).
+Add a `BLOBBASEFEE (0x4a)` that returns the value of the blob base-fee of the current block it is executing in. It is the identical to [EIP-3198](./eip-3198.md) (`BASEFEE` opcode) except that it returns the blob base-fee as per [EIP-4844](./eip-4844.md).
 
 ## Motivation
 
@@ -24,7 +24,7 @@ The intended use case would be for contracts to get the value of the blob base-f
 
 ## Specification
 
-Add a `BLOBBASEFEE` opcode at `(0x49)`, with gas cost `2`.
+Add a `BLOBBASEFEE` opcode at `(0x4a)`, with gas cost `2`.
 
 | Op   | Input | Output | Cost |
 |------|-------|--------|------|


### PR DESCRIPTION
As @smartprogrammer93 pointed out in #7714, there is an opcode conflict with `BLOBHASH` with `0x49`. #7714 fixed this by changing `BLOBBASEFEE` to `0x4a`, but they missed a few references, this PR fixes them.