### PR TITLE
Update EIP-7516: Use "instruction" term

### DIFF
--- a/EIPS/eip-7516.md
+++ b/EIPS/eip-7516.md
@@ -1,7 +1,7 @@
 ---
 eip: 7516
-title: BLOBBASEFEE opcode
-description: Opcode that returns the current data-blob base-fee
+title: BLOBBASEFEE instruction
+description: Instruction that returns the current data-blob base-fee
 author: Carl Beekhuizen (@carlbeek)
 discussions-to: https://ethereum-magicians.org/t/eip-7516-blobbasefee-opcode/15761
 status: Draft
@@ -13,7 +13,7 @@ requires: 3198, 4844
 
 ## Abstract
 
-Add a `BLOBBASEFEE (0x4a)` that returns the value of the blob base-fee of the current block it is executing in. It is the identical to [EIP-3198](./eip-3198.md) (`BASEFEE` opcode) except that it returns the blob base-fee as per [EIP-4844](./eip-4844.md).
+Add a `BLOBBASEFEE (0x4a)` instruction that returns the value of the blob base-fee of the current block it is executing in. It is the identical to [EIP-3198](./eip-3198.md) (`BASEFEE` opcode) except that it returns the blob base-fee as per [EIP-4844](./eip-4844.md).
 
 ## Motivation
 
@@ -24,7 +24,7 @@ The intended use case would be for contracts to get the value of the blob base-f
 
 ## Specification
 
-Add a `BLOBBASEFEE` opcode at `(0x4a)`, with gas cost `2`.
+Add a `BLOBBASEFEE` instruction with opcode `0x4a`, with gas cost `2`.
 
 | Op   | Input | Output | Cost |
 |------|-------|--------|------|
@@ -37,11 +37,11 @@ Add a `BLOBBASEFEE` opcode at `(0x4a)`, with gas cost `2`.
 ### Gas cost
 
 The value of the blob base-fee is needed to process data-blob transactions. That means its value is already available before running the EVM code.
-The opcode does not add extra complexity and additional read/write operations, hence the choice of `2` gas cost. This is also identical to [EIP-3198](./eip-3198.md) (`BASEFEE` opcode)'s cost as it just makes available data that is in the header.
+The instruction does not add extra complexity and additional read/write operations, hence the choice of `2` gas cost. This is also identical to [EIP-3198](./eip-3198.md) (`BASEFEE` opcode)'s cost as it just makes available data that is in the header.
 
 ## Backwards Compatibility
 
-There are no known backward compatibility issues with this opcode.
+There are no known backward compatibility issues with this instruction.
 
 ## Test Cases
 
@@ -62,7 +62,7 @@ Consumed gas: `2`
 
 ## Security Considerations
 
-The value of the blob base-fee is not sensitive and is publicly accessible in the block header. There are no known security implications with this opcode.
+The value of the blob base-fee is not sensitive and is publicly accessible in the block header. There are no known security implications with this instruction.
 
 ## Copyright
 


### PR DESCRIPTION
Opcode is just the number the instruction is assigned to.