### PR TITLE
Update EIP-7201: Move to Last Call

### DIFF
--- a/EIPS/eip-7201.md
+++ b/EIPS/eip-7201.md
@@ -4,7 +4,8 @@ title: Namespaced Storage Layout
 description: A formula for the storage location of structs in the namespaced storage pattern.
 author: Francisco Giordano (@frangio), Hadrien Croubois (@Amxx), Ernesto García (@ernestognw), Eric Lau (@ericglau)
 discussions-to: https://ethereum-magicians.org/t/eip-7201-namespaced-storage-layout/14796
-status: Review
+status: Last Call
+last-call-deadline: 2023-10-01
 type: Standards Track
 category: ERC
 created: 2023-06-20


### PR DESCRIPTION
Superceding #7519 which was blocked by old requested changes. The requested change was the addition of a Security Considerations section which has already been added.

Regarding the Last Call deadline: I recognize this is sooner than would normally be required. The move to Last Call was requested over a month ago and approved 2 weeks ago, and unfortunately it wasn't merged earlier. I believe there has already been plenty of time and active discussion about the ERC, including various comments that have been addressed. The authors are likely not going to accept normative changes after Oct 1st, so this deadline is the best way to represent that.