### PR TITLE
Update EIP-4788: update ring buffer size rationale for new ring buffer size

### DIFF
--- a/EIPS/eip-4788.md
+++ b/EIPS/eip-4788.md
@@ -275,9 +275,9 @@ to store a pair of values necessitates two ring buffers, rather than just one.
 
 ### Size of ring buffers
 
-The ring buffer data structures are sized to hold 8192 roots from the consensus layer at current slot timings (`SECONDS_PER_SLOT` is 12 seconds on mainnet, and `8192 * 12 == 98304`).
-At mainnet values, 8192 roots provides about a day of coverage of the chain which gives users plenty of time to make a transaction with a verification against a given root in
-the chain and get the transaction included.
+The ring buffer data structures are sized to hold 8191 roots from the consensus layer. Using a prime number as the ring buffer size ensures that no value is overwritten until the entire ring buffer has been saturated and thereafter, each value will be updated once per iteration. This also means that even if the slot times were to change, we would continue to use at most 8191 storage slots.
+
+Given the current mainnet values, 8191 roots provides about a day of coverage. This gives users plenty of time to make a transaction with a verification against a specific root and get the transaction included on-chain.
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
Forgot to update rationale after ring buffer size update in #7672.