### PR TITLE
Update EIP-6780: say "target" instead of "caller"

### DIFF
--- a/EIPS/eip-6780.md
+++ b/EIPS/eip-6780.md
@@ -1,7 +1,7 @@
 ---
 eip: 6780
 title: SELFDESTRUCT only in same transaction
-description: SELFDESTRUCT will recover all funds to the caller but not delete the account, except when called in the same transaction as creation
+description: SELFDESTRUCT will recover all funds to the target but not delete the account, except when called in the same transaction as creation
 author: Guillaume Ballet (@gballet), Vitalik Buterin (@vbuterin), Dankrad Feist (@dankrad)
 discussions-to: https://ethereum-magicians.org/t/deactivate-selfdestruct-except-where-it-occurs-in-the-same-transaction-in-which-a-contract-was-created/13539
 status: Draft
@@ -13,7 +13,7 @@ requires: 2681, 2929, 3529
 
 ## Abstract
 
-This EIP changes the functionality of the `SELFDESTRUCT` opcode. The new functionality will be only to send all Ether in the account to the caller, except that the current behaviour is preserved when `SELFDESTRUCT` is called in the same transaction a contract was created.
+This EIP changes the functionality of the `SELFDESTRUCT` opcode. The new functionality will be only to send all Ether in the account to the target, except that the current behaviour is preserved when `SELFDESTRUCT` is called in the same transaction a contract was created.
 
 ## Motivation
 


### PR DESCRIPTION
I was reading EIP-6780, and I noticed that the title and the first paragraph mention "caller", whereas the rest of the EIP refers to the account being sent the self-destruct ETH as the "target".

I think that the latter is correct.

Cc @gballet.