### PR TITLE
Update EIP-6963: make icon requirement wording consistent

### DIFF
--- a/EIPS/eip-6963.md
+++ b/EIPS/eip-6963.md
@@ -47,7 +47,7 @@ Each Wallet Provider will be announced with the following interface `EIP6963Prov
 
 - **`uuid`** - a globally unique identifier the Wallet Provider that MUST be ([UUIDv4][RFC-4122] compliant) to uniquely distinguish different [EIP-1193](./eip-1193.md) provider sessions that have matching properties defined below during the liftetime of the page. The cryptographic uniqueness provided by [UUIDv4][RFC-4122] guarantees that two independent `EIP6963ProviderInfo` objects can be separately identified.
 - **`name`** - a human-readable local alias of the Wallet Provider to be displayed to the user on the DApp. (e.g. `Example Wallet Extension` or `Awesome Example Wallet`)
-- **`icon`** - a [URI][RFC-3986] pointing to an image. Icon images MUST be square with 96x96px minimum resolution. See the [Images/Icons](#imagesicons) below for further requirements of this property.
+- **`icon`** - a [URI][RFC-3986] pointing to an image. The image SHOULD be a square with 96x96px minimum resolution. See the [Images/Icons](#imagesicons) below for further requirements of this property.
 - **`rdns`** - The Wallet MUST supply the `rdns` property which is intended to be a domain name from the Domain Name System in reverse syntax ordering such as `com.example.subdomain`. It's up to the Wallet to determine the domain name they wish to use, but it's generally expected the identifier will remain the same throughout the development of the Wallet. It's also worth noting that similar to a user agent string in browsers, there are times where the supplied value could be unknown, invalid, incorrect, or attempt to imitate a different Wallet. Therefore, the DApp SHOULD be able to handle these failure cases with minimal degradation to the functionality of the DApp.
 
 ```typescript
@@ -73,7 +73,7 @@ data:image/svg+xml,<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="
 data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==
 ```
 
-The `icon` string MUST be a data URI as defined in [RFC-2397]. The image SHOULD be squared with 96x96px minimum resolution. The image format is RECOMMENDED to be either lossless or vector based such as PNG, WebP or SVG to make the image easy to render on the DApp. Since SVG images can execute Javascript, applications and libraries MUST render SVG images using the `<img>` tag to ensure no untrusted Javascript execution can occur.
+The `icon` string MUST be a data URI as defined in [RFC-2397]. The image SHOULD be a square with 96x96px minimum resolution. The image format is RECOMMENDED to be either lossless or vector based such as PNG, WebP or SVG to make the image easy to render on the DApp. Since SVG images can execute Javascript, applications and libraries MUST render SVG images using the `<img>` tag to ensure no untrusted Javascript execution can occur.
 
 ### Provider Detail
 


### PR DESCRIPTION
Noticed this inconsistency with `SHOULD` and `MUST` for the icon aspect ratio and resolution. I believe this should be `SHOULD`