### PR TITLE
Update EIP-6780: remove mention of verkle tree behavior

### DIFF
--- a/EIPS/eip-6780.md
+++ b/EIPS/eip-6780.md
@@ -44,7 +44,6 @@ The behaviour of `SELFDESTRUCT` is changed in the following way:
    - Note that if the target is the same as the contract calling `SELFDESTRUCT` that Ether will be burnt.
    - Note that no refund is given since [EIP-3529](./eip-3529.md).
    - Note that the rules of [EIP-2929](./eip-2929.md) regarding `SELFDESTRUCT` remain unchanged.
-   - Note that when verkle tries are implemented on Ethereum, the cleared storage will be marked as having been written before but empty. This leads to no observable differences in EVM execution, but a contract having been created and deleted will lead to different state roots compared to the action not happening.
 
 A contract is considered created at the beginning of a create transaction or when a CREATE series operation begins execution (CREATE, CREATE2, and other operations that deploy contracts in the future).  If a balance exists at the contract's new address it is still considered to be a contract creation. 
 


### PR DESCRIPTION
The current version of eip6780 specified that a contract created and selfdestructed in the same transaction, should write 0s after the verkle fork to mark that it was created and deleted.

This has no impact on EVM execution, but does create a special case in the codebase of clients. As a result, we have decided to remove this requirement during ACDE 171.

Another remark has been made that it makes little sense to specify a future-proof behavior in an EIP, and that the specific future behavior should be specified in the verkle EIP. As a result, this PR drops the paragraph regarding the behavior after the verkle fork.