### PR TITLE
Update EIP-7480: Change prices of DATALOAD and DATALOADN to be consistent with price of PUSH

### DIFF
--- a/EIPS/eip-7480.md
+++ b/EIPS/eip-7480.md
@@ -41,14 +41,14 @@ If the code is valid EOF1, the following execution rules apply:
 1. Pops one value, `offset`, from the stack.
 2. If `offset + 32` is greater than the data section size of the active container, execution results in exceptional halt.
 3. Reads `[offset:offset+32]` segment from the data section and pushes it as 32-byte value to the stack.
-4. Deducts 3 gas.
+4. Deducts 4 gas.
 
 ### `DATALOADN`
 
 1. Has one immediate argument,`offset`, encoded as a 16-bit unsigned big-endian value.
 2. Pops nothing from the stack.
 3. Reads `[offset:offset+32]` segment from the data section and pushes it as 32-byte value to the stack.
-4. Deducts 2 gas.
+4. Deducts 3 gas.
 
 `[offset:offset+32]` is guaranteed to be within data bounds by [code validation](#code-validation).
 


### PR DESCRIPTION
`PUSH` costs 3, there is no reason for `DATALOADN` to cost less.