### PR TITLE
Update EIP-6059: Adds comment about 7401 superseding 6059.

### DIFF
--- a/EIPS/eip-6059.md
+++ b/EIPS/eip-6059.md
@@ -13,6 +13,8 @@ requires: 165, 721
 
 ## Abstract
 
+❗️ **[ERC-7401](./eip-7401.md) supersedes [ERC-6059](./eip-6059.md).** ❗️
+
 The Parent-Governed Nestable NFT standard extends [ERC-721](./eip-721.md) by allowing for a new inter-NFT relationship and interaction.
 
 At its core, the idea behind the proposal is simple: the owner of an NFT does not have to be an Externally Owned Account (EOA) or a smart contract, it can also be an NFT.


### PR DESCRIPTION
7401 Is now final and addresses a missing parameter on 6059. They share `interfaceId` because the wrongly reported one on 6059 was calculated with all the expected parameters.