### PR TITLE
Update EIP-998: Update/Correction eip-998.md

### DIFF
--- a/EIPS/eip-998.md
+++ b/EIPS/eip-998.md
@@ -22,7 +22,7 @@ This specification covers four different kinds of composable tokens:
 1. [`ERC998ERC721` top-down composable tokens that receive, hold and transfer ERC-721 tokens](#erc-721-top-down-composable)
 2. [`ERC998ERC20` top-down composable tokens that receive, hold and transfer ERC-20 tokens](#erc-20-top-down-composable)
 3. [`ERC998ERC721` bottom-up composable tokens that attach themselves to other ERC-721 tokens.](#erc-721-bottom-up-composable)
-4. [`ERC998ERC20` bottom-up composable tokens that attach themselves to ERC-721 tokens.](#erc-20-bottom-up-composable)
+4. [`ERC998ERC20` bottom-up composable tokens that attach themselves to ERC-20 tokens.](#erc-20-bottom-up-composable)
 
 which map to
 


### PR DESCRIPTION
Typo mistake - wrote ERC721 in place of ERC20 token
