### PR TITLE
Update EIP-6206: add `JUMPFI` instruction

### DIFF
--- a/EIPS/eip-6206.md
+++ b/EIPS/eip-6206.md
@@ -2,7 +2,7 @@
 eip: 6206
 title: EOF - JUMPF and non-returning functions
 description: Introduces instruction for chaining function calls.
-author: Andrei Maiboroda (@gumb0), Alex Beregszaszi (@axic), Paweł Bylica (@chfast), Matt Garnett (@lightclient)
+author: Andrei Maiboroda (@gumb0), Alex Beregszaszi (@axic), Paweł Bylica (@chfast), Matt Garnett (@lightclient), Charles Cooper (@charles-cooper)
 discussions-to: https://ethereum-magicians.org/t/eip-4750-eof-functions/8195
 status: Draft
 type: Standards Track
@@ -13,7 +13,7 @@ requires: 4750, 5450
 
 ## Abstract
 
-This EIP allows for tail call optimizations in EOF functions ([EIP-4750](./eip-4750.md)) by introducing a new instruction `JUMPF`, which jumps to a code section without adding a new return stack frame.
+This EIP allows for tail call optimizations in EOF functions ([EIP-4750](./eip-4750.md)) by introducing two new instructions, `JUMPF` and `JUMPFI`, which jump (unconditionally and conditionally, respectively) to a code section without adding a new return stack frame.
 
 Additionally the format of the type sections is extended to allow declaring sections as non-returning, with simplified stack validation for `JUMPF` to such section.
 
@@ -21,7 +21,8 @@ Additionally the format of the type sections is extended to allow declaring sect
 
 It is common for functions to make a call at the end of the routine only to then return. `JUMPF` optimizes this behavior by changing code sections without needing to update the return stack.
 
-Knowing at validation time that a function will never return control allows for `JUMPF` to such function to be treated similar to terminating instructions, where extra items may be left on the operand stack at execution termination. This provides opportunities for compilers to generate more optimal code, both in code size and in spent gas. It is particularly benefitial for small error handling helpers, that end execution with `REVERT`: they are commonly reused in multiple branches and extracting them into a helper function is efficient, when there is no need to pop extra stack items before `JUMPF` to such helper.
+Knowing at validation time that a function will never return control allows for `JUMPF` to such function to be treated similar to terminating instructions, where extra items may be left on the operand stack at execution termination. This provides opportunities for compilers to generate more optimal code, both in code size and in spent gas. It is particularly beneficial for small error handling helpers, that end execution with `REVERT`: they are commonly reused in multiple branches and extracting them into a helper function is efficient, when there is no need to pop extra stack items before `JUMPF` to such helper.
+
 
 ## Specification
 
@@ -35,42 +36,63 @@ The first code section MUST have 0 inputs and be non-returning.
 
 ### Execution Semantics
 
-A new instruction, `JUMPF (0xe5)`, is introduced.
+Two new instructions, `JUMPF (0xe5)` and `JUMPFI (0xe6)`, are introduced.
 
-1. `JUMPF` has one immediate argument, `code_section_index`, encoded as a 16-bit unsigned big-endian value.
-2. If the operand stack size exceeds `1024 - type[code_section_index].max_stack_height` (i.e. if the called function may exceed the global stack height limit), execution results in an exceptional halt. This guarantees that the target function does not exceed global stack height limit.
-3. `JUMPF` sets `current_section_index` to `code_section_index` and `PC` to `0`, but does not change the return stack. Execution continues in the target section. 
+1. `JUMPF` has one immediate argument, `target_section_index`, encoded as a 16-bit unsigned big-endian value. We define `current_section` as `type[current_section_index]`, and `target_section` as `type[target_section_index]`.
+2. If the operand stack size exceeds `1024 - target_section.max_stack_height` (i.e. if the called function may exceed the global stack height limit), execution results in an exceptional halt. This guarantees that the target function does not exceed global stack height limit.
+3. `JUMPF` sets `current_section_index` to `target_section_index` and `PC` to `0`, but does *not* modify the return stack. Execution continues in the target section.
 4. `JUMPF` costs 5 gas.
 5. `JUMPF` neither pops nor pushes anything to the operand stack.
+
+The execution rules for `JUMPFI` are similar, but it costs 7 gas, and accepts an additional stack argument, and steps 2. and 3. are conditionally executed only if the stack argument evaluates to non-zero.
+
+1. `JUMPFI` has one immediate argument, `target_section_index`, encoded as a 16-bit unsigned big-endian value.
+2. `JUMPFI` costs 7 gas.
+3. `JUMPFI` consumes one stack item, `condition`. If `condition` is 0, `PC` is incremented and execution continues.
+4. Otherwise, if `condition` is nonzero, perform the operand stack size check and jump into the indicated code section as in 2. and 3. above:
+  a. If the operand stack size exceeds `1024 - target_section.max_stack_height`, execution results in an exceptional halt.
+  b. Set `current_section_index` to `target_section_index` and `PC` to `0`, but does not change the return stack. Execution continues in the target section.
+
 
 ### Code Validation
 
 Let the definition of `type[i]` be inherited from [EIP-4750](./eip-4750.md) and define `stack_height` to be the height of the stack at a certain instruction during the instruction flow traversal if the operand stack at the start of the function were equal to `type[i].inputs`.
 
-* The immediate argument of `JUMPF` MUST be less than the total number of code sections.
-* For each `JUMPF` instruction:
-  * either `type[current_section_index].outputs` MUST be greater or equal `type[code_section_index].outputs`,
-  * or `type[code_section_index].outputs` MUST be `0x80`
-* The stack height validation at `JUMPF` depends on whether the target section is non-returning:
-  * `JUMPF` into returning section (`type[code_section_index].outputs` does not equal `0x80`): stack height MUST be equal to `type[current_section_index].outputs + type[code_section_index].inputs  - type[code_section_index].outputs`. This means that target section can output less stack elements than the original code section called by the top element on the return stack, if the current code section leaves the delta `type[current_section_index].outputs - type[code_section_index].outputs` element(s) on the stack.
-  * `JUMPF` into non-returning section (`type[code_section_index].outputs` equals `0x80`): stack height must be greater or equal than `type[code_section_index].inputs`.
-* `JUMPF` is considered terminating instruction, i.e. does not have successor instructions in code validation and MAY be final instruction in the section. 
-* The code validation defined in [EIP-4200](./eip-4200.md) also fails if any `RJUMP*` offset points to one of the two bytes directly following a `JUMPF` instruction.
+* The immediate argument of `JUMPF` or `JUMPFI` MUST be less than the total number of code sections.
+* For each `JUMPF` or `JUMPFI` instruction:
+  * either `current_section.outputs` MUST be greater or equal `target_section.outputs`,
+  * or `target_section.outputs` MUST be `0x80`
+* The stack height validation at `JUMPF` and `JUMPFI` depends on whether the target section is non-returning:
+  * `JUMPF` or `JUMPFI` into a returning section: stack height MUST be equal to `current_section.outputs + target_section.inputs - target_section.outputs`. Note that this means that target section can "consume" stack items. That is, the target can output fewer stack elements than are currently expected by the caller (thte top item of the return stack), iff at the time of the jump, the current code section prepares the remaining `current_section.outputs - target_section.outputs` stack items on the stack.
+  * `JUMPF` or `JUMPFI` into a non-returning section (`target_section.outputs` equals `0x80`): current stack height must be greater or equal than `target_section.inputs`.
+* `JUMPF` is a terminating instruction, i.e. successor instructions are disallowed in code validation, and it MAY be final instruction in the section.
+* `JUMPFI` is not a terminating instruction.
+* The code validation defined in [EIP-4200](./eip-4200.md) also fails if any `RJUMP*` offset points to one of the two bytes directly following a `JUMPF` or `JUMPFI` instruction.
 
 `CALLF` instruction validation is extended to include the rule:
 
-* Code section is invalid in case an immediate argument `code_section_index` of any `CALLF` targets a non-returning section, i.e. `type[code_section_index` equals `0x80`.
+* Code section is invalid in case an immediate argument `target_section_index` of any `CALLF` targets a non-returning section, i.e. `target_section.outputs` equals `0x80`.
 
 #### Non-returning status validation
 
 Section type MUST be non-returning in case the section contains no `RETF` instructions and no `JUMPF` instructions targeting returning sections (target section's status is checked via its output value in type section.)
-*Note: This implies that section containing only `JUMPF`s into non-returning sections is non-returning itself.*
+*Note: This implies that a code section containing only `JUMPF`s into non-returning sections is non-returning itself.*
 
 ## Rationale
 
-### Allowing `JUMPF` to section with less outputs
+### Allowing `JUMPF` to section with fewer outputs
 
-As long as `JUMPF` prepares the delta `type[current_section_index].outputs - type[code_section_index].outputs` stack elements before changing code sections, it is possible to jump to a section with less outputs than was originally entered via `CALLF`. This will reduce duplicated code as it will allow compilers more flexibility during code generation such that certain helpers can be used generically by functions, regardless of their output values.
+As long as `JUMPF` prepares the delta `current_section.outputs - target_section.outputs` stack elements before changing code sections, it is possible to jump to a section with fewer outputs than "expected" (that is, specified by the original `CALLF`). This will reduce duplicated code as it will allow compilers more flexibility during code generation such that certain helpers can be used generically by functions, regardless of their output values.
+
+### Inclusion of `JUMPFI`
+
+The stack validation rules introduced in ([EIP-5450](./eip-5450.md)) restrict a common pattern used in legacy EVM code, which is to conditionally jump to some helper code. It is not feasible to conditionally jump to helper code with `RJUMPI` under current ([EIP-5450](./eip-5450.md)) rules, because the helper code must have the same stack height no matter where it is entered from. This means that helper code must be factored out into a code section, and entered into with code that "branches" around a `CALLF` or `JUMPF` instruction. That is, what was originally `PUSH <some condition> PUSH <destination> JUMPI`, must now be written as `PUSH <some condition> ISZERO RJUMPI <join point> CALLF <destination> <label: join point> ...`. This can cause nontrivial codesize regressions. The solution here provided by `JUMPFI` is to allow conditional calls into the helper code sections.
+
+Another potential solution would be to relax the stack validation rules in ([EIP-5450](./eip-5450.md)) to allow the usage pattern described above, for instance by removing them entirely, or relaxing the stack validation rule for forward jumps (but not for backward jumps).
+
+### Disallowing `CALLF` to call non-returning sections
+
+`CALLF` is disallowed during validation from calling non-returning sections. This is because in this EIP, `JUMPF` provides a method to call code sections which do not modify the return stack, and non-returning code sections by definition do not modify the return stack. `JUMPF` is therefore the preferred way to call non-returning code sections.
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
add `JUMPFI` instruction including rationale, execution specification and validation rules.

- change `code_section` wording to `target_section`
- fix some spelling, and clarify wording of some existing sections
- include rationale for `CALLF` restriction on calling non-returning sections

When opening a pull request to submit a new EIP, please use the suggested template: https://github.com/ethereum/EIPs/blob/master/eip-template.md

We have a GitHub bot that automatically merges some PRs. It will merge yours immediately if certain criteria are met:

 - The PR edits only existing draft PRs.
 - The build passes.
 - Your GitHub username or email address is listed in the 'author' header of all affected PRs, inside <triangular brackets>.
 - If matching on email address, the email address is the one publicly listed on your GitHub profile.
