### PR TITLE
Update EIP-6551: Add ERC6551 address

### DIFF
--- a/EIPS/eip-6551.md
+++ b/EIPS/eip-6551.md
@@ -77,7 +77,7 @@ For example, the token bound account with implementation address `0xbebebebebebe
 
 Each token bound account proxy SHALL delegate execution to a contract that implements the `IERC6551Account` interface.
 
-The registry contract is permissionless, immutable, and has no owner. The complete source code for the registry can be found in the [Registry Implementation](#registry-implementation) section below. The registry SHALL be deployed at address `TBD` using Nick's Factory (`0x4e59b44847b379578588920cA78FbF26c0B4956C`) with salt `0x6551655165516551655165516551655165516551655165516551655165516551`.
+The registry contract is permissionless, immutable, and has no owner. The complete source code for the registry can be found in the [Registry Implementation](#registry-implementation) section below. The registry SHALL be deployed at address `0x02101dfB77FDE026414827Fdc604ddAF224F0921` using Nick's Factory (`0x4e59b44847b379578588920cA78FbF26c0B4956C`) with salt `0x6551655165516551655165516551655165516551655165516551655165516551`.
 
 The registry SHALL deploy all token bound accounts using the `create2` opcode so that each account address is deterministic. Each token bound account address SHALL be derived from the unique combination of its implementation address, token contract address, token ID, [EIP-155](./eip-155.md) chain ID, and salt.
 


### PR DESCRIPTION
Many guides and tools already use this hard-coded registry address across many chains (with 2500+ txs on this address on Ethereum mainnet)

Given the registry address is meant to be static and the fact it's actively used, it may be good to add it to the EIP. If a change to the spec causes the address to change in the future, probably this address should be mentioned anyway as a migration path for any tool that used it
