### PR TITLE
Update EIP-223: Remove `standard` function

### DIFF
--- a/EIPS/eip-223.md
+++ b/EIPS/eip-223.md
@@ -70,16 +70,6 @@ Returns the number of decimals of the token. The functionality of this method is
 
 OPTIONAL - This method can be used to improve usability, but interfaces and other contracts MUST NOT expect these values to be present. 
 
-##### `standard`
-
-```solidity
-function standard() view returns (string memory)  
-```
-
-Returns the identifier of the standard. If the token is [ERC-223](./eip-20.md) then it must return `"223"`.
-
-OPTIONAL - This method can be used to improve usability, but interfaces and other contracts MUST NOT expect these values to be present.
-
 ##### `balanceOf`
 
 ```solidity


### PR DESCRIPTION
ERC-223 needs an errata:

1. In https://github.com/ethereum/EIPs/pull/6485#discussion_r1103853086, I noted that the `standard` function was out-of-scope and insisted that it be removed
2. In https://github.com/ethereum/EIPs/pull/6485#discussion_r1124870613, @Dexaran acknowledged that it was indeed out-of-scope and removed it
3. In https://github.com/ethereum/EIPs/pull/7466 / https://github.com/ethereum/EIPs/commit/ff3ec32c03398c523e57df2ababcc2da7f0a0e65, the function was mistakenly re-introduced
4. The optional function remains out-of-scope and inadequately specified.

Removing this function is a backward compatible change, as applications cannot expect it to be present.