### PR TITLE
Update EIP-3643: Move to Last Call

### DIFF
--- a/EIPS/eip-3643.md
+++ b/EIPS/eip-3643.md
@@ -4,7 +4,8 @@ title: T-REX - Token for Regulated EXchanges
 description: An institutional grade security token contract that provides interfaces for the management and compliant transfer of security tokens.
 author: Joachim Lebrun (@Joachim-Lebrun), Tony Malghem (@TonyMalghem), Kevin Thizy (@Nakasar), Luc Falempin (@lfalempin), Adam Boudjemaa (@Aboudjem)
 discussions-to: https://ethereum-magicians.org/t/eip-3643-proposition-of-the-t-rex-token-standard-for-securities/6844
-status: Review
+status: Last Call
+last-call-deadline: 2023-11-01
 type: Standards Track
 category: ERC
 created: 2021-07-09


### PR DESCRIPTION
Move the EIP-3643 to Last Call status after 3 month of call for reviews from the community and successful review sessions with the [erc3643 association](https://www.erc3643.org/), where we passed in review with all the members of the association the whole description of the EIP and got approval from all to move forward to final status 
