### PR TITLE
Update EIP-1046: Fix some issues

### DIFF
--- a/EIPS/eip-1046.md
+++ b/EIPS/eip-1046.md
@@ -173,11 +173,12 @@ interface ERC721TokenMetadataInterop extends ERC721TokenMetadata {
 pragma solidity ^0.8.0;
 
 /// @title  ERC-1155 Metadata URI Interoperability Extension
-interface ERC1155TokenMetadataInterop /* is ERC1155Metadata */ {
-    /// @notice     Gets an ERC-1046-compliant ERC-1155 token URI
-    /// @dev        The resolved data MUST be in JSON format and support ERC-1046's Extension to the ERC-1155 Token Metadata Schema
-    ///             This MUST be the same uri as the `uri()` function
-    function tokenURI() external view returns (string);
+interface ERC1155TokenMetadataInterop /* is ERC1155 */ {
+    /// @notice         Gets an ERC-1046-compliant ERC-1155 token URI
+    /// @param  tokenId The token ID to get the URI of
+    /// @dev            The resolved data MUST be in JSON format and support ERC-1046's Extension to the ERC-1155 Token Metadata Schema
+    ///                 This MUST be the same URI as the `uri(tokenId)` function, if present.
+    function tokenURI(uint256 tokenId) external view returns (string);
 }
 ```
 
@@ -196,7 +197,7 @@ interface ERC1155TokenMetadataInterop extends ERC1155TokenMetadata {
 
 ### Miscellaneous Recommendations
 
-To save gas, it is RECOMMENDED for compliant contracts not to implement the optional `name()`, `symbol()`, or `decimals()` functions, and instead to only include them in the metadata URI. Additionally, if the decimals is `18`, then it is NOT RECOMMENDED to include the `decimals` field in the metadata.
+To save gas, it is RECOMMENDED for compliant contracts not to implement the `name()`, `symbol()`, or `decimals()` functions, and instead to only include them in the metadata URI. Additionally, for ERC-20 tokens, if the decimals is `18`, then it is NOT RECOMMENDED to include the `decimals` field in the metadata.
 
 ## Rationale
 


### PR DESCRIPTION
1. `ERC1155TokenMetadataInterop` was missing a `tokenId` parameter.
2. Those metadata functions aren't always optional (specifically, in the case of ERC-721).
3. Decimals is `18` by default -- only for ERC-20.