### PR TITLE
Update EIP-1363: Update erc1363 to modern recommendations

### DIFF
--- a/EIPS/eip-1363.md
+++ b/EIPS/eip-1363.md
@@ -6,7 +6,7 @@ discussions-to: https://github.com/ethereum/eips/issues/1363
 status: Final
 type: Standards Track
 category: ERC
-created: 2020-01-31
+created: 2018-08-30
 requires: 20, 165
 ---
 

--- a/EIPS/eip-1363.md
+++ b/EIPS/eip-1363.md
@@ -203,14 +203,6 @@ They want to highlight that they have the same behaviors of `transfer`, `transfe
 
 Unlike other [ERC-20](./eip-20.md) extension proposals, [ERC-1363](./eip-1363.md) doesn't override the [ERC-20](./eip-20.md) `transfer` and `transferFrom` methods and defines the interfaces IDs to be implemented maintaining backward compatibility with [ERC-20](./eip-20.md).
 
-## Test Cases
-
-* [ERC-1363 Test Cases](https://github.com/vittominacori/erc1363-payable-token/tree/master/test)
-
-## Reference Implementation
-
-* [ERC-1363 Reference Implementation](https://github.com/vittominacori/erc1363-payable-token)
-
 ## Security Considerations
 
 The `approveAndCall` and `transferFromAndCall` methods can be affected by the same issue of the standard [ERC-20](./eip-20.md) `approve` and `transferFrom` method.

--- a/EIPS/eip-1363.md
+++ b/EIPS/eip-1363.md
@@ -32,156 +32,149 @@ ERC-1363 tokens can be used for specific utilities in all cases that require a c
 ERC-1363 is also useful for avoiding token loss or token locking in contracts by verifying the recipient contract's ability to handle tokens.
 
 ## Specification
-Implementing contracts **MUST** implement the [ERC-1363](./eip-1363.md) interface as well as the [ERC-20](./eip-20.md) and [ERC-165](./eip-165.md) interfaces.
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
+
+Smart contracts implementing the ERC-1363 standard **MUST** implement all of the functions in the `ERC1363` interface, as well as the [ERC-20](./eip-20.md) and [ERC-165](./eip-165.md) interfaces.
 
 ```solidity
 pragma solidity ^0.8.0;
 
-interface ERC1363 /* is ERC20, ERC165 */ {
-  /*
-   * Note: the ERC-165 identifier for this interface is 0xb0202a11.
-   * 0xb0202a11 ===
-   *   bytes4(keccak256('transferAndCall(address,uint256)')) ^
-   *   bytes4(keccak256('transferAndCall(address,uint256,bytes)')) ^
-   *   bytes4(keccak256('transferFromAndCall(address,address,uint256)')) ^
-   *   bytes4(keccak256('transferFromAndCall(address,address,uint256,bytes)')) ^
-   *   bytes4(keccak256('approveAndCall(address,uint256)')) ^
-   *   bytes4(keccak256('approveAndCall(address,uint256,bytes)'))
-   */
+/**
+ * @title ERC1363
+ * @dev An extension interface for ERC20 tokens that supports executing code on a recipient contract after `transfer` or `transferFrom`, or code on a spender contract after `approve`, in a single transaction.
+ */
+interface ERC1363 is ERC20, ERC165 {
+    /*
+     * Note: the ERC-165 identifier for this interface is 0xb0202a11.
+     * 0xb0202a11 ===
+     *   bytes4(keccak256('transferAndCall(address,uint256)')) ^
+     *   bytes4(keccak256('transferAndCall(address,uint256,bytes)')) ^
+     *   bytes4(keccak256('transferFromAndCall(address,address,uint256)')) ^
+     *   bytes4(keccak256('transferFromAndCall(address,address,uint256,bytes)')) ^
+     *   bytes4(keccak256('approveAndCall(address,uint256)')) ^
+     *   bytes4(keccak256('approveAndCall(address,uint256,bytes)'))
+     */
 
-  /**
-   * @notice Transfer tokens from `msg.sender` to another address and then call `onTransferReceived` on receiver
-   * @param to address The address which you want to transfer to
-   * @param value uint256 The amount of tokens to be transferred
-   * @return true unless throwing
-   */
-  function transferAndCall(address to, uint256 value) external returns (bool);
+    /**
+     * @dev Moves a `value` amount of tokens from the caller's account to `to` and then calls `onTransferReceived` on `to`.
+     * @param to The address which you want to transfer to.
+     * @param value The amount of tokens to be transferred.
+     * @return A boolean value indicating whether the operation succeeded unless throwing.
+     */
+    function transferAndCall(address to, uint256 value) external returns (bool);
 
-  /**
-   * @notice Transfer tokens from `msg.sender` to another address and then call `onTransferReceived` on receiver
-   * @param to address The address which you want to transfer to
-   * @param value uint256 The amount of tokens to be transferred
-   * @param data bytes Additional data with no specified format, sent in call to `to`
-   * @return true unless throwing
-   */
-  function transferAndCall(address to, uint256 value, bytes memory data) external returns (bool);
+    /**
+     * @dev Moves a `value` amount of tokens from the caller's account to `to` and then calls `onTransferReceived` on `to`.
+     * @param to The address which you want to transfer to.
+     * @param value The amount of tokens to be transferred.
+     * @param data Additional data with no specified format, sent in call to `to`.
+     * @return A boolean value indicating whether the operation succeeded unless throwing.
+     */
+    function transferAndCall(address to, uint256 value, bytes calldata data) external returns (bool);
 
-  /**
-   * @notice Transfer tokens from one address to another and then call `onTransferReceived` on receiver
-   * @param from address The address which you want to send tokens from
-   * @param to address The address which you want to transfer to
-   * @param value uint256 The amount of tokens to be transferred
-   * @return true unless throwing
-   */
-  function transferFromAndCall(address from, address to, uint256 value) external returns (bool);
+    /**
+     * @dev Moves a `value` amount of tokens from `from` to `to` using the allowance mechanism and then calls `onTransferReceived` on `to`.
+     * @param from The address which you want to send tokens from.
+     * @param to The address which you want to transfer to.
+     * @param value The amount of tokens to be transferred.
+     * @return A boolean value indicating whether the operation succeeded unless throwing.
+     */
+    function transferFromAndCall(address from, address to, uint256 value) external returns (bool);
 
+    /**
+     * @dev Moves a `value` amount of tokens from `from` to `to` using the allowance mechanism and then calls `onTransferReceived` on `to`.
+     * @param from The address which you want to send tokens from.
+     * @param to The address which you want to transfer to.
+     * @param value The amount of tokens to be transferred.
+     * @param data Additional data with no specified format, sent in call to `to`.
+     * @return A boolean value indicating whether the operation succeeded unless throwing.
+     */
+    function transferFromAndCall(address from, address to, uint256 value, bytes calldata data) external returns (bool);
 
-  /**
-   * @notice Transfer tokens from one address to another and then call `onTransferReceived` on receiver
-   * @param from address The address which you want to send tokens from
-   * @param to address The address which you want to transfer to
-   * @param value uint256 The amount of tokens to be transferred
-   * @param data bytes Additional data with no specified format, sent in call to `to`
-   * @return true unless throwing
-   */
-  function transferFromAndCall(address from, address to, uint256 value, bytes memory data) external returns (bool);
+    /**
+     * @dev Sets a `value` amount of tokens as the allowance of `spender` over the caller's tokens and then calls `onApprovalReceived` on `spender`.
+     * @param spender The address which will spend the funds.
+     * @param value The amount of tokens to be spent.
+     * @return A boolean value indicating whether the operation succeeded unless throwing.
+     */
+    function approveAndCall(address spender, uint256 value) external returns (bool);
 
-  /**
-   * @notice Approve the passed address to spend the specified amount of tokens on behalf of msg.sender
-   * and then call `onApprovalReceived` on spender.
-   * @param spender address The address which will spend the funds
-   * @param value uint256 The amount of tokens to be spent
-   */
-  function approveAndCall(address spender, uint256 value) external returns (bool);
-
-  /**
-   * @notice Approve the passed address to spend the specified amount of tokens on behalf of msg.sender
-   * and then call `onApprovalReceived` on spender.
-   * @param spender address The address which will spend the funds
-   * @param value uint256 The amount of tokens to be spent
-   * @param data bytes Additional data with no specified format, sent in call to `spender`
-   */
-  function approveAndCall(address spender, uint256 value, bytes memory data) external returns (bool);
+    /**
+     * @dev Sets a `value` amount of tokens as the allowance of `spender` over the caller's tokens and then calls `onApprovalReceived` on `spender`.
+     * @param spender The address which will spend the funds.
+     * @param value The amount of tokens to be spent.
+     * @param data Additional data with no specified format, sent in call to `spender`.
+     * @return A boolean value indicating whether the operation succeeded unless throwing.
+     */
+    function approveAndCall(address spender, uint256 value, bytes calldata data) external returns (bool);
 }
 
 interface ERC20 {
-  function totalSupply() external view returns (uint256);
-  function balanceOf(address account) external view returns (uint256);
-  function transfer(address recipient, uint256 amount) external returns (bool);
-  function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
-  function allowance(address owner, address spender) external view returns (uint256);
-  function approve(address spender, uint256 amount) external returns (bool);
-  event Transfer(address indexed from, address indexed to, uint256 value);
-  event Approval(address indexed owner, address indexed spender, uint256 value);
+    event Transfer(address indexed from, address indexed to, uint256 value);
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+    function totalSupply() external view returns (uint256);
+    function balanceOf(address account) external view returns (uint256);
+    function transfer(address to, uint256 value) external returns (bool);
+    function transferFrom(address from, address to, uint256 value) external returns (bool);
+    function approve(address spender, uint256 value) external returns (bool);
+    function allowance(address owner, address spender) external view returns (uint256);
 }
 
 interface ERC165 {
-  function supportsInterface(bytes4 interfaceId) external view returns (bool);
+    function supportsInterface(bytes4 interfaceId) external view returns (bool);
 }
 ```
 
-A contract that wants to accept token payments via `transferAndCall` or `transferFromAndCall` **MUST** implement the following interface:
+A contract that wants to accept ERC-1363 tokens via `transferAndCall` or `transferFromAndCall` **MUST** implement the `ERC1363Receiver` interface:
 
 ```solidity
 /**
- * @title ERC1363Receiver interface
- * @dev Interface for any contract that wants to support `transferAndCall` or `transferFromAndCall`
- *  from ERC1363 token contracts.
+ * @title ERC1363Receiver
+ * @dev Interface for any contract that wants to support `transferAndCall` or `transferFromAndCall` from ERC1363 token contracts.
  */
 interface ERC1363Receiver {
-  /*
-   * Note: the ERC-165 identifier for this interface is 0x88a7ca5c.
-   * 0x88a7ca5c === bytes4(keccak256("onTransferReceived(address,address,uint256,bytes)"))
-   */
-
-  /**
-   * @notice Handle the receipt of ERC1363 tokens
-   * @dev Any ERC1363 smart contract calls this function on the recipient
-   * after a `transfer` or a `transferFrom`. This function MAY throw to revert and reject the
-   * transfer. Return of other than the magic value MUST result in the
-   * transaction being reverted.
-   * Note: the token contract address is always the message sender.
-   * @param operator address The address which called `transferAndCall` or `transferFromAndCall` function
-   * @param from address The address which are token transferred from
-   * @param value uint256 The amount of tokens transferred
-   * @param data bytes Additional data with no specified format
-   * @return `bytes4(keccak256("onTransferReceived(address,address,uint256,bytes)"))`
-   *  unless throwing
-   */
-  function onTransferReceived(address operator, address from, uint256 value, bytes memory data) external returns (bytes4);
+    /**
+     * @dev Whenever ERC1363 tokens are transferred to this contract via `transferAndCall` or `transferFromAndCall`
+     * by `operator` from `from`, this function is called.
+     *
+     * NOTE: To accept the transfer, this must return
+     * `bytes4(keccak256("onTransferReceived(address,address,uint256,bytes)"))`
+     * (i.e. 0x88a7ca5c, or its own function selector).
+     *
+     * @param operator The address which called `transferAndCall` or `transferFromAndCall` function.
+     * @param from The address which are tokens transferred from.
+     * @param value The amount of tokens transferred.
+     * @param data Additional data with no specified format.
+     * @return `bytes4(keccak256("onTransferReceived(address,address,uint256,bytes)"))` if transfer is allowed unless throwing.
+     */
+    function onTransferReceived(address operator, address from, uint256 value, bytes calldata data) external returns (bytes4);
 }
 ``` 
 
-A contract that wants to accept token payments via `approveAndCall` **MUST** implement the following interface:
+A contract that wants to accept ERC-1363 tokens via `approveAndCall` **MUST** implement the `ERC1363Spender` interface:
 
 ```solidity
 /**
- * @title ERC1363Spender interface
- * @dev Interface for any contract that wants to support `approveAndCall`
- *  from ERC1363 token contracts.
+ * @title ERC1363Spender
+ * @dev Interface for any contract that wants to support `approveAndCall` from ERC1363 token contracts.
  */
 interface ERC1363Spender {
-  /*
-   * Note: the ERC-165 identifier for this interface is 0x7b04a2d0.
-   * 0x7b04a2d0 === bytes4(keccak256("onApprovalReceived(address,uint256,bytes)"))
-   */
-
-  /**
-   * @notice Handle the approval of ERC1363 tokens
-   * @dev Any ERC1363 smart contract calls this function on the recipient
-   * after an `approve`. This function MAY throw to revert and reject the
-   * approval. Return of other than the magic value MUST result in the
-   * transaction being reverted.
-   * Note: the token contract address is always the message sender.
-   * @param owner address The address which called `approveAndCall` function
-   * @param value uint256 The amount of tokens to be spent
-   * @param data bytes Additional data with no specified format
-   * @return `bytes4(keccak256("onApprovalReceived(address,uint256,bytes)"))`
-   *  unless throwing
-   */
-  function onApprovalReceived(address owner, uint256 value, bytes memory data) external returns (bytes4);
+    /**
+     * @dev Whenever an ERC1363 tokens `owner` approved this contract via `approveAndCall`
+     * to spent their tokens, this function is called.
+     *
+     * NOTE: To accept the approval, this must return
+     * `bytes4(keccak256("onApprovalReceived(address,uint256,bytes)"))`
+     * (i.e. 0x7b04a2d0, or its own function selector).
+     *
+     * @param owner The address which called `approveAndCall` function and previously owned the tokens.
+     * @param value The amount of tokens to be spent.
+     * @param data Additional data with no specified format.
+     * @return `bytes4(keccak256("onApprovalReceived(address,uint256,bytes)"))` if approval is allowed unless throwing.
+     */
+    function onApprovalReceived(address owner, uint256 value, bytes calldata data) external returns (bytes4);
 }
-``` 
+```
 
 ## Rationale
 The choice to use `transferAndCall`, `transferFromAndCall` and `approveAndCall` derives from the [ERC-20](./eip-20.md) naming. They want to highlight that they have the same behaviours of `transfer`, `transferFrom` and `approve` with the addition of a callback on receiver or spender.

--- a/EIPS/eip-1363.md
+++ b/EIPS/eip-1363.md
@@ -195,6 +195,11 @@ They want to highlight that they have the same behaviors of `transfer`, `transfe
 ## Backwards Compatibility
 Unlike other [ERC-20](./eip-20.md) extension proposals, ERC-1363 doesn't override the [ERC-20](./eip-20.md) `transfer` and `transferFrom` methods and defines the interfaces IDs to be implemented maintaining backward compatibility with [ERC-20](./eip-20.md).
 
+## References
+
+- [ERC-1363 Test Cases](https://github.com/vittominacori/erc1363-payable-token/tree/master/test)
+- [ERC-1363 Implementation](https://github.com/vittominacori/erc1363-payable-token)
+
 ## Security Considerations
 The `approveAndCall` and `transferFromAndCall` methods can be affected by the same issue of the standard [ERC-20](./eip-20.md) `approve` and `transferFrom` method.
 Changing an allowance with the `approveAndCall` methods brings the risk that someone may use both the old and the new allowance by unfortunate transaction ordering.

--- a/EIPS/eip-1363.md
+++ b/EIPS/eip-1363.md
@@ -14,11 +14,12 @@ requires: 20, 165
 An extension interface for [ERC-20](./eip-20.md) tokens that supports executing code on a recipient contract after transfers, or code on a spender contract after approvals, in a single transaction.
 
 ## Abstract
-Standard functions a token contract and contracts working with tokens can implement to make a token Payable.
+The following standard allows for the implementation of a standard API for tokens interaction with smart contracts after `transfer`, `transferFrom` or `approve`.
+This standard provides basic functionality to transfer tokens, as well as allow tokens to be approved so they can be spent by another on-chain third party, and then make a callback on the receiver or spender contract.
 
-`transferAndCall` and `transferFromAndCall` will call an `onTransferReceived` on a `ERC1363Receiver` contract.  
-
-`approveAndCall` will call an `onApprovalReceived` on a `ERC1363Spender` contract.
+The following are functions and callbacks introduced by this EIP:
+* `transferAndCall` and `transferFromAndCall` will call an `onTransferReceived` on a `ERC1363Receiver` contract.
+* `approveAndCall` will call an `onApprovalReceived` on a `ERC1363Spender` contract.
 
 ## Motivation
 There is no way to execute code after a [ERC-20](./eip-20.md) transfer or approval (i.e. making a payment), so to make an action it is required to send another transaction and pay GAS twice.

--- a/EIPS/eip-1363.md
+++ b/EIPS/eip-1363.md
@@ -116,11 +116,11 @@ interface ERC1363 is ERC20, ERC165 {
 interface ERC20 {
     event Transfer(address indexed from, address indexed to, uint256 value);
     event Approval(address indexed owner, address indexed spender, uint256 value);
-    function totalSupply() external view returns (uint256);
-    function balanceOf(address account) external view returns (uint256);
     function transfer(address to, uint256 value) external returns (bool);
     function transferFrom(address from, address to, uint256 value) external returns (bool);
     function approve(address spender, uint256 value) external returns (bool);
+    function totalSupply() external view returns (uint256);
+    function balanceOf(address account) external view returns (uint256);
     function allowance(address owner, address spender) external view returns (uint256);
 }
 

--- a/EIPS/eip-1363.md
+++ b/EIPS/eip-1363.md
@@ -208,7 +208,7 @@ Unlike other [ERC-20](./eip-20.md) extension proposals, [ERC-1363](./eip-1363.md
 The `approveAndCall` and `transferFromAndCall` methods can be affected by the same issue of the standard [ERC-20](./eip-20.md) `approve` and `transferFrom` method.
 Changing an allowance with the `approveAndCall` methods brings the risk that someone may use both the old and the new allowance by unfortunate transaction ordering.
 
-One possible solution to mitigate this race condition is to first reduce the spender's allowance to 0 and set the desired value afterwards ([ERC-20#issuecomment-263524729](https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729)).
+One possible solution to mitigate this race condition is to first reduce the spender's allowance to 0 and set the desired value afterwards.
 
 ## Copyright
 

--- a/EIPS/eip-1363.md
+++ b/EIPS/eip-1363.md
@@ -11,7 +11,7 @@ requires: 20, 165
 ---
 
 ## Simple Summary
-Defines a token interface for [ERC-20](./eip-20.md) tokens that supports executing recipient code after `transfer` or `transferFrom`, or spender code after `approve`.
+An extension interface for [ERC-20](./eip-20.md) tokens that supports executing code on a recipient contract after transfers, or code on a spender contract after approvals, in a single transaction.
 
 ## Abstract
 Standard functions a token contract and contracts working with tokens can implement to make a token Payable.

--- a/EIPS/eip-1363.md
+++ b/EIPS/eip-1363.md
@@ -1,7 +1,7 @@
 ---
 eip: 1363
 title: Payable Token
-description: Fungible tokens extension that supports executing code on recipient or spender contracts after transfers or approvals, in a single transaction.
+description: Fungible tokens extension that supports executing callbacks on receiver contracts.
 author: Vittorio Minacori (@vittominacori)
 discussions-to: https://ethereum-magicians.org/t/erc-1363-payable-token/16225
 status: Final
@@ -38,7 +38,7 @@ This EIP is also useful for avoiding token loss or token locking in contracts by
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
 
-Smart contracts implementing the ERC-1363 standard **MUST** implement all of the functions in the `ERC1363` interface, as well as the [ERC-20](./eip-20.md) and [ERC-165](./eip-165.md) interfaces.
+Smart contracts implementing the [ERC-1363](./eip-1363.md) standard **MUST** implement all of the functions in the `ERC1363` interface, as well as the [ERC-20](./eip-20.md) and [ERC-165](./eip-165.md) interfaces.
 
 ```solidity
 pragma solidity ^0.8.0;

--- a/EIPS/eip-1363.md
+++ b/EIPS/eip-1363.md
@@ -46,7 +46,7 @@ pragma solidity ^0.8.0;
 
 /**
  * @title ERC1363
- * @dev An extension interface for ERC20 tokens that supports executing code on a recipient contract after `transfer` or `transferFrom`, or code on a spender contract after `approve`, in a single transaction.
+ * @dev An extension interface for ERC-20 tokens that supports executing code on a recipient contract after `transfer` or `transferFrom`, or code on a spender contract after `approve`, in a single transaction.
  */
 interface ERC1363 is ERC20, ERC165 {
     /*
@@ -135,11 +135,11 @@ A contract that wants to accept [ERC-1363](./eip-1363.md) tokens via `transferAn
 ```solidity
 /**
  * @title ERC1363Receiver
- * @dev Interface for any contract that wants to support `transferAndCall` or `transferFromAndCall` from ERC1363 token contracts.
+ * @dev Interface for any contract that wants to support `transferAndCall` or `transferFromAndCall` from ERC-1363 token contracts.
  */
 interface ERC1363Receiver {
     /**
-     * @dev Whenever ERC1363 tokens are transferred to this contract via `transferAndCall` or `transferFromAndCall`
+     * @dev Whenever ERC-1363 tokens are transferred to this contract via `transferAndCall` or `transferFromAndCall`
      * by `operator` from `from`, this function is called.
      *
      * NOTE: To accept the transfer, this must return
@@ -161,11 +161,11 @@ A contract that wants to accept [ERC-1363](./eip-1363.md) tokens via `approveAnd
 ```solidity
 /**
  * @title ERC1363Spender
- * @dev Interface for any contract that wants to support `approveAndCall` from ERC1363 token contracts.
+ * @dev Interface for any contract that wants to support `approveAndCall` from ERC-1363 token contracts.
  */
 interface ERC1363Spender {
     /**
-     * @dev Whenever an ERC1363 tokens `owner` approved this contract via `approveAndCall`
+     * @dev Whenever an ERC-1363 tokens `owner` approved this contract via `approveAndCall`
      * to spent their tokens, this function is called.
      *
      * NOTE: To accept the approval, this must return

--- a/EIPS/eip-1363.md
+++ b/EIPS/eip-1363.md
@@ -22,23 +22,14 @@ The following are functions and callbacks introduced by this EIP:
 * `approveAndCall` will call an `onApprovalReceived` on a `ERC1363Spender` contract.
 
 ## Motivation
-There is no way to execute code after a [ERC-20](./eip-20.md) transfer or approval (i.e. making a payment), so to make an action it is required to send another transaction and pay GAS twice.
+There is no way to execute code on a receiver/spender contract after an [ERC-20](./eip-20.md) `transfer`, `transferFrom` or `approve` so, to perform an action, it is required to send another transaction.
+This introduces complexity in UI development and friction on adoption as users must wait for the first transaction to be executed and then submit the second one. They must also pay GAS twice.
 
-This proposal wants to make token payments easier and working without the use of any other listener. It allows to make a callback after a transfer or approval in a single transaction.
+This proposal aims to make tokens capable of performing actions more easily and working without the use of any off-chain listener.
+It allows to make a callback on a receiver/spender contract, after a transfer or an approval, in a single transaction.
 
-There are many proposed uses of Ethereum smart contracts that can accept [ERC-20](./eip-20.md) payments. 
-
-Examples could be 
-* to create a token payable crowdsale
-* selling services for tokens 
-* paying invoices
-* making subscriptions
-
-For these reasons it was named as **"Payable Token"**.
-
-Anyway you can use it for specific utilities or for any other purposes who require the execution of a callback after a transfer or approval received.
-
-This proposal has been inspired by the [ERC-721](./eip-721.md) `onERC721Received` and `ERC721TokenReceiver` behaviours. 
+ERC-1363 tokens can be used for specific utilities in all cases that require a callback to be executed after a transfer or an approval received.
+ERC-1363 is also useful for avoiding token loss or token locking in contracts by verifying the recipient contract's ability to handle tokens.
 
 ## Specification
 Implementing contracts **MUST** implement the [ERC-1363](./eip-1363.md) interface as well as the [ERC-20](./eip-20.md) and [ERC-165](./eip-165.md) interfaces.

--- a/EIPS/eip-1363.md
+++ b/EIPS/eip-1363.md
@@ -177,7 +177,20 @@ interface ERC1363Spender {
 ```
 
 ## Rationale
-The choice to use `transferAndCall`, `transferFromAndCall` and `approveAndCall` derives from the [ERC-20](./eip-20.md) naming. They want to highlight that they have the same behaviours of `transfer`, `transferFrom` and `approve` with the addition of a callback on receiver or spender.
+There are many proposed uses of Ethereum smart contracts that can accept [ERC-20](./eip-20.md) callbacks.
+
+Examples could be:
+* creating a token payable crowdsale
+* selling services for tokens
+* paying invoices
+* making subscriptions
+
+For these reasons it was originally named **"Payable Token"**.
+
+The choice to use `transferAndCall`, `transferFromAndCall` and `approveAndCall` derives from the [ERC-20](./eip-20.md) naming. 
+They want to highlight that they have the same behaviors of `transfer`, `transferFrom` and `approve` with the addition of a callback on receiver or spender contracts.
+
+`ERC1363Receiver` and `ERC1363Spender` were inspired by the [ERC-721](./eip-721.md) `ERC721TokenReceiver` behavior.
 
 ## Backwards Compatibility
 This proposal has been inspired also by [ERC-223](https://github.com/ethereum/EIPs/issues/223) and [ERC-677](https://github.com/ethereum/EIPs/issues/677) but it uses the [ERC-721](./eip-721.md) approach, so it doesn't override the [ERC-20](./eip-20.md) `transfer` and `transferFrom` methods and defines the interfaces IDs to be implemented maintaining the [ERC-20](./eip-20.md) backwards compatibility.  

--- a/EIPS/eip-1363.md
+++ b/EIPS/eip-1363.md
@@ -1,8 +1,9 @@
 ---
 eip: 1363
 title: Payable Token
+description: Fungible tokens extension that supports executing code on recipient or spender contracts after transfers or approvals, in a single transaction.
 author: Vittorio Minacori (@vittominacori)
-discussions-to: https://github.com/ethereum/eips/issues/1363
+discussions-to: https://ethereum-magicians.org/t/erc-1363-payable-token/16225
 status: Final
 type: Standards Track
 category: ERC
@@ -10,11 +11,9 @@ created: 2018-08-30
 requires: 20, 165
 ---
 
-## Simple Summary
-
-An extension interface for [ERC-20](./eip-20.md) tokens that supports executing code on a recipient contract after transfers, or code on a spender contract after approvals, in a single transaction.
-
 ## Abstract
+
+This proposal defines an extension interface for [ERC-20](./eip-20.md) tokens that supports executing code on a recipient contract after transfers, or code on a spender contract after approvals, in a single transaction.
 
 The following standard allows for the implementation of a standard API for tokens interaction with smart contracts after `transfer`, `transferFrom` or `approve`.
 This standard provides basic functionality to transfer tokens, as well as allow tokens to be approved so they can be spent by another on-chain third party, and then make a callback on the receiver or spender contract.
@@ -32,14 +31,14 @@ This introduces complexity in UI development and friction on adoption as users m
 This proposal aims to make tokens capable of performing actions more easily and working without the use of any off-chain listener.
 It allows to make a callback on a receiver/spender contract, after a transfer or an approval, in a single transaction.
 
-[ERC-1363](./eip-1363.md) tokens can be used for specific utilities in all cases that require a callback to be executed after a transfer or an approval received.
-[ERC-1363](./eip-1363.md) is also useful for avoiding token loss or token locking in contracts by verifying the recipient contract's ability to handle tokens.
+Tokens defined by this EIP can be used for specific utilities in all cases that require a callback to be executed after a transfer or an approval received.
+This EIP is also useful for avoiding token loss or token locking in contracts by verifying the recipient contract's ability to handle tokens.
 
 ## Specification
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
 
-Smart contracts implementing the [ERC-1363](./eip-1363.md) standard **MUST** implement all of the functions in the `ERC1363` interface, as well as the [ERC-20](./eip-20.md) and [ERC-165](./eip-165.md) interfaces.
+Smart contracts implementing the ERC-1363 standard **MUST** implement all of the functions in the `ERC1363` interface, as well as the [ERC-20](./eip-20.md) and [ERC-165](./eip-165.md) interfaces.
 
 ```solidity
 pragma solidity ^0.8.0;
@@ -130,7 +129,7 @@ interface ERC165 {
 }
 ```
 
-A contract that wants to accept [ERC-1363](./eip-1363.md) tokens via `transferAndCall` or `transferFromAndCall` **MUST** implement the `ERC1363Receiver` interface:
+A contract that wants to accept ERC-1363 tokens via `transferAndCall` or `transferFromAndCall` **MUST** implement the `ERC1363Receiver` interface:
 
 ```solidity
 /**
@@ -156,7 +155,7 @@ interface ERC1363Receiver {
 }
 ``` 
 
-A contract that wants to accept [ERC-1363](./eip-1363.md) tokens via `approveAndCall` **MUST** implement the `ERC1363Spender` interface:
+A contract that wants to accept ERC-1363 tokens via `approveAndCall` **MUST** implement the `ERC1363Spender` interface:
 
 ```solidity
 /**
@@ -201,7 +200,7 @@ They want to highlight that they have the same behaviors of `transfer`, `transfe
 
 ## Backwards Compatibility
 
-Unlike other [ERC-20](./eip-20.md) extension proposals, [ERC-1363](./eip-1363.md) doesn't override the [ERC-20](./eip-20.md) `transfer` and `transferFrom` methods and defines the interfaces IDs to be implemented maintaining backward compatibility with [ERC-20](./eip-20.md).
+Unlike other [ERC-20](./eip-20.md) extension proposals, ERC-1363 doesn't override the [ERC-20](./eip-20.md) `transfer` and `transferFrom` methods and defines the interfaces IDs to be implemented maintaining backward compatibility with [ERC-20](./eip-20.md).
 
 ## Security Considerations
 

--- a/EIPS/eip-1363.md
+++ b/EIPS/eip-1363.md
@@ -11,30 +11,35 @@ requires: 20, 165
 ---
 
 ## Simple Summary
+
 An extension interface for [ERC-20](./eip-20.md) tokens that supports executing code on a recipient contract after transfers, or code on a spender contract after approvals, in a single transaction.
 
 ## Abstract
+
 The following standard allows for the implementation of a standard API for tokens interaction with smart contracts after `transfer`, `transferFrom` or `approve`.
 This standard provides basic functionality to transfer tokens, as well as allow tokens to be approved so they can be spent by another on-chain third party, and then make a callback on the receiver or spender contract.
 
 The following are functions and callbacks introduced by this EIP:
+
 * `transferAndCall` and `transferFromAndCall` will call an `onTransferReceived` on a `ERC1363Receiver` contract.
 * `approveAndCall` will call an `onApprovalReceived` on a `ERC1363Spender` contract.
 
 ## Motivation
+
 There is no way to execute code on a receiver/spender contract after an [ERC-20](./eip-20.md) `transfer`, `transferFrom` or `approve` so, to perform an action, it is required to send another transaction.
 This introduces complexity in UI development and friction on adoption as users must wait for the first transaction to be executed and then submit the second one. They must also pay GAS twice.
 
 This proposal aims to make tokens capable of performing actions more easily and working without the use of any off-chain listener.
 It allows to make a callback on a receiver/spender contract, after a transfer or an approval, in a single transaction.
 
-ERC-1363 tokens can be used for specific utilities in all cases that require a callback to be executed after a transfer or an approval received.
-ERC-1363 is also useful for avoiding token loss or token locking in contracts by verifying the recipient contract's ability to handle tokens.
+[ERC-1363](./eip-1363.md) tokens can be used for specific utilities in all cases that require a callback to be executed after a transfer or an approval received.
+[ERC-1363](./eip-1363.md) is also useful for avoiding token loss or token locking in contracts by verifying the recipient contract's ability to handle tokens.
 
 ## Specification
+
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
 
-Smart contracts implementing the ERC-1363 standard **MUST** implement all of the functions in the `ERC1363` interface, as well as the [ERC-20](./eip-20.md) and [ERC-165](./eip-165.md) interfaces.
+Smart contracts implementing the [ERC-1363](./eip-1363.md) standard **MUST** implement all of the functions in the `ERC1363` interface, as well as the [ERC-20](./eip-20.md) and [ERC-165](./eip-165.md) interfaces.
 
 ```solidity
 pragma solidity ^0.8.0;
@@ -125,7 +130,7 @@ interface ERC165 {
 }
 ```
 
-A contract that wants to accept ERC-1363 tokens via `transferAndCall` or `transferFromAndCall` **MUST** implement the `ERC1363Receiver` interface:
+A contract that wants to accept [ERC-1363](./eip-1363.md) tokens via `transferAndCall` or `transferFromAndCall` **MUST** implement the `ERC1363Receiver` interface:
 
 ```solidity
 /**
@@ -151,7 +156,7 @@ interface ERC1363Receiver {
 }
 ``` 
 
-A contract that wants to accept ERC-1363 tokens via `approveAndCall` **MUST** implement the `ERC1363Spender` interface:
+A contract that wants to accept [ERC-1363](./eip-1363.md) tokens via `approveAndCall` **MUST** implement the `ERC1363Spender` interface:
 
 ```solidity
 /**
@@ -177,9 +182,11 @@ interface ERC1363Spender {
 ```
 
 ## Rationale
+
 There are many proposed uses of Ethereum smart contracts that can accept [ERC-20](./eip-20.md) callbacks.
 
 Examples could be:
+
 * creating a token payable crowdsale
 * selling services for tokens
 * paying invoices
@@ -193,18 +200,24 @@ They want to highlight that they have the same behaviors of `transfer`, `transfe
 `ERC1363Receiver` and `ERC1363Spender` were inspired by the [ERC-721](./eip-721.md) `ERC721TokenReceiver` behavior.
 
 ## Backwards Compatibility
-Unlike other [ERC-20](./eip-20.md) extension proposals, ERC-1363 doesn't override the [ERC-20](./eip-20.md) `transfer` and `transferFrom` methods and defines the interfaces IDs to be implemented maintaining backward compatibility with [ERC-20](./eip-20.md).
 
-## References
+Unlike other [ERC-20](./eip-20.md) extension proposals, [ERC-1363](./eip-1363.md) doesn't override the [ERC-20](./eip-20.md) `transfer` and `transferFrom` methods and defines the interfaces IDs to be implemented maintaining backward compatibility with [ERC-20](./eip-20.md).
 
-- [ERC-1363 Test Cases](https://github.com/vittominacori/erc1363-payable-token/tree/master/test)
-- [ERC-1363 Implementation](https://github.com/vittominacori/erc1363-payable-token)
+## Test Cases
+
+* [ERC-1363 Test Cases](https://github.com/vittominacori/erc1363-payable-token/tree/master/test)
+
+## Reference Implementation
+
+* [ERC-1363 Reference Implementation](https://github.com/vittominacori/erc1363-payable-token)
 
 ## Security Considerations
+
 The `approveAndCall` and `transferFromAndCall` methods can be affected by the same issue of the standard [ERC-20](./eip-20.md) `approve` and `transferFrom` method.
 Changing an allowance with the `approveAndCall` methods brings the risk that someone may use both the old and the new allowance by unfortunate transaction ordering.
 
-One possible solution to mitigate this race condition is to first reduce the spender's allowance to 0 and set the desired value afterwards ([EIP-20#issuecomment-263524729](https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729)).
+One possible solution to mitigate this race condition is to first reduce the spender's allowance to 0 and set the desired value afterwards ([ERC-20#issuecomment-263524729](https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729)).
 
 ## Copyright
+
 Copyright and related rights waived via [CC0](../LICENSE.md).

--- a/EIPS/eip-1363.md
+++ b/EIPS/eip-1363.md
@@ -193,7 +193,7 @@ They want to highlight that they have the same behaviors of `transfer`, `transfe
 `ERC1363Receiver` and `ERC1363Spender` were inspired by the [ERC-721](./eip-721.md) `ERC721TokenReceiver` behavior.
 
 ## Backwards Compatibility
-This proposal has been inspired also by [ERC-223](https://github.com/ethereum/EIPs/issues/223) and [ERC-677](https://github.com/ethereum/EIPs/issues/677) but it uses the [ERC-721](./eip-721.md) approach, so it doesn't override the [ERC-20](./eip-20.md) `transfer` and `transferFrom` methods and defines the interfaces IDs to be implemented maintaining the [ERC-20](./eip-20.md) backwards compatibility.  
+Unlike other [ERC-20](./eip-20.md) extension proposals, ERC-1363 doesn't override the [ERC-20](./eip-20.md) `transfer` and `transferFrom` methods and defines the interfaces IDs to be implemented maintaining backward compatibility with [ERC-20](./eip-20.md).
 
 ## Security Considerations
 The `approveAndCall` and `transferFromAndCall` methods can be affected by the same issue of the standard [ERC-20](./eip-20.md) `approve` and `transferFrom` method.

--- a/EIPS/eip-1363.md
+++ b/EIPS/eip-1363.md
@@ -197,7 +197,6 @@ Unlike other [ERC-20](./eip-20.md) extension proposals, ERC-1363 doesn't overrid
 
 ## Security Considerations
 The `approveAndCall` and `transferFromAndCall` methods can be affected by the same issue of the standard [ERC-20](./eip-20.md) `approve` and `transferFrom` method.
-  
 Changing an allowance with the `approveAndCall` methods brings the risk that someone may use both the old and the new allowance by unfortunate transaction ordering.
 
 One possible solution to mitigate this race condition is to first reduce the spender's allowance to 0 and set the desired value afterwards ([EIP-20#issuecomment-263524729](https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729)).


### PR DESCRIPTION
This PR wants to only update EIP content in order to follow the most updated recommendation from EIP-1.

* Some texts have been updated to better explain the ERC-1363 behavior, after years of discussion. No changes in behavior.
* Some texts have been moved from abstract or motivation to the dedicated rationale section.
* References to EIPs have been moved to the `EIP-N` format.
* Code specification have been indented and commented.
* The creation date have been updated with the date of the first issue opening and the first commit into the reference implementation (erroneously it was the date of PR instead).
* <s>References to test cases and reference implementation have been aded as it was not permitted before (but it seems that many EIPs have them).</s>
