### PR TITLE
Add EIP: Apply coinbase reward at end of block

### DIFF
--- a/EIPS/apply-coinbase-rewards-at-end-of-block.md
+++ b/EIPS/apply-coinbase-rewards-at-end-of-block.md
@@ -37,7 +37,7 @@ def execute_block(block: Block) -> None:
 		coinbase_reward += tx.fee - refund 
 
 	# apply coinbase reward at the end of the block
-	coinbase.balance += coinbase_reward
+	coinbase(block).balance += coinbase_reward
 ```
 
 ## Rationale

--- a/EIPS/apply-coinbase-rewards-at-end-of-block.md
+++ b/EIPS/apply-coinbase-rewards-at-end-of-block.md
@@ -1,0 +1,139 @@
+---
+eip: *
+title: Apply Coinbase Rewards At The End Of Block
+description: Apply rewards for all transactions to the coinbase at the end of the block.
+author: Dragan Rakita (@rakita), Roman Krasiuk (@rkrasiuk)
+discussions-to: *
+status: Draft
+type: Standards Track
+category: Core
+created: 2023-09-19
+---
+
+## Abstract
+
+The transaction fees shall be added to the `COINBASE` balance at the end of the block.
+
+## Motivation
+
+Currently, the transaction fees are applied to the `COINBASE`'s balance at the end of each transaction thus introducing an implicit dependency on each preceding transaction in the block. Moving the transaction reward to the end of the block removes this dependency allowing for various flavors of parallel execution.
+
+## Specification
+
+The sender of the transaction is still credited at the start of the transaction execution and the refund is still issued at the end in order to avoid double-spending. The `COINBASE` reward is accumulated from transaction fees and applied at the end of each block.
+
+```python
+def execute_block(block: Block) -> None:
+	...
+	coinbase_reward = 0
+
+	for tx in block.transactions:
+		signer(tx).balance -= tx.fee
+
+		# execute transaction
+		...
+
+		signer(tx).balance += refund
+		coinbase_reward += tx.fee - refund 
+
+	# apply coinbase reward at the end of the block
+	coinbase.balance += coinbase_reward
+```
+
+## Rationale
+
+This EIP removes the inherent dependency between transactions within a single block. By aggregating fees and applying them at the end, transactions might be executed in parallel without waiting for the previous ones to complete.
+
+## Backwards Compatibility
+
+Balance is only incremented once at the end of the block and this means that `COINBASE` will not have it incremented within this block.
+
+### Direct Coinbase Payments
+
+This change does not impact direct payments to `COINBASE`. They can still occur alongside the transaction fees.
+
+### Block Building
+
+This change will require block builders to accumulate transaction fees when evaluating block value. It does not have a fundamental impact on the profitability of the block.
+
+**Block Value**
+
+This change will require block builders to accumulate transaction fees when evaluating block value. It does not have a fundamental impact on the profitability of the block.
+
+**Block Payout**
+
+This change imposes an additional constraint on the builder’s balance to be able to pay for the block they build before receiving the reward as a refund. The effects of this change are discussed in Security Consideration section in more detail.
+
+### Smart Contracts
+
+The changes to the timing of fee application are only noticeable across transactions. In rare cases, smart contract developers might need to adapt their contracts to account for the possibility of coinbase balance increment occurring at the end of a block.
+
+## Test Cases
+
+**Test Case #1**
+
+```
+Sender A Balance Before Block: 1 ETH
+Coinbase Balance Before Block: 10 ETH
+
+Transaction #1 from Sender A
+Transaction Fee: 0.1 ETH
+Sender A Balance After Transaction #1: 0.9 ETH
+Coinbase Balance After Transaction #1: 10 ETH
+
+Transaction #2 from Sender A
+Transaction Fee: 0.2 ETH 
+Sender A Balance After Transaction #2: 0.7 ETH
+Coinbase Balance After Transaction #2: 10 ETH
+
+Sender A Balance After Block: 0.7 ETH
+Coinbase Balance After Block: 10.3 ETH
+```
+
+**Test Case #2**
+
+```
+Sender A Balance Before Block: 1 ETH
+Coinbase Balance Before Block: 10 ETH
+
+Transaction #1 from Sender A
+Transaction Fee: 0.1 ETH
+Sender A Balance After Transaction #1: 0.9 ETH
+Coinbase Balance After Transaction #1: 10 ETH
+
+Transaction #2 from Sender A
+Transaction Fee: 0.2 ETH 
+Sender A Balance After Transaction #2: 0.7 ETH
+Coinbase Balance After Transaction #2: 10 ETH
+
+Sender A Balance After Block: 0.7 ETH
+Coinbase Balance After Block: 10.3 ETH
+```
+
+## Security Considerations
+
+### Double Spending
+
+The sender is still credited at the start of the transaction and receives the refund at the end to avoid double spending.
+
+### Block Building
+
+**Favoring Builders With Higher Balances**
+
+By imposing an additional balance requirement on builders, the protocol inherently gives preference to those with more substantial balances. Builders can now bid up to their entire balance since they would receive the coinbase reward only after the payout, functioning as a refund.
+
+For demonstration purposes, let’s assume that we have a set of transactions in the public mempool that results in a block with value `3 ETH`  and all builders use the equivalent ordering algorithms.
+
+Given Builders A, B and C with respective balances `4 ETH`, `3 ETH` and `2 ETH`, Builder A is guaranteed to outbid the remaining two builders by placing a bid of `3 ETH 1 wei`.
+
+**Reward Distribution Between Builder And Proposer**
+
+Let’s define an `Honest Builder` as the builder which has no access to private orderflow and builds the block from publicly available transaction at no cost for themselves.
+
+Operating under the same assumptions of equivalent ordering algorithms, previously, any `Honest Builder` would be able to place the same bid of `sum(tx.reward)`, which means that the entirety of the block reward would be captured by the proposer.
+
+Under the proposed EIP, the maximum bid that can be placed by any `Honest Builder` becomes `min(sum(tx.reward), builder.balance)` and the winning bid would always be `min(sum(tx.reward), max(builder.balance))`. In situations where the `sum(tx.reward) <= max(builder.balance)`, the entire block reward is still captured by the proposer. However, when the block reward exceeds the maximum balance of any `Honest Builder` (`sum(tx.reward) > max(builder.balance)`) the surplus of the block reward would be captured by the builder instead.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](../LICENSE.md).

--- a/EIPS/eip-7541.md
+++ b/EIPS/eip-7541.md
@@ -1,8 +1,8 @@
 ---
-eip: *
+eip: 7541
 title: Apply Coinbase Rewards At The End Of Block
 description: Apply rewards for all transactions to the coinbase at the end of the block.
-author: Dragan Rakita (@rakita), Roman Krasiuk (@rkrasiuk)
+author: Roman Krasiuk (@rkrasiuk), Dragan Rakita (@rakita)
 discussions-to: *
 status: Draft
 type: Standards Track
@@ -48,13 +48,13 @@ This EIP removes the inherent dependency between transactions within a single bl
 
 Balance is only incremented once at the end of the block and this means that `COINBASE` will not have it incremented within this block.
 
+This EIP affects block building and transaction bundles. The delay of `COINBASE` rewards changes their mechanisms.
+
 ### Direct Coinbase Payments
 
 This change does not impact direct payments to `COINBASE`. They can still occur alongside the transaction fees.
 
 ### Block Building
-
-This change will require block builders to accumulate transaction fees when evaluating block value. It does not have a fundamental impact on the profitability of the block.
 
 **Block Value**
 
@@ -64,9 +64,9 @@ This change will require block builders to accumulate transaction fees when eval
 
 This change imposes an additional constraint on the builder’s balance to be able to pay for the block they build before receiving the reward as a refund. The effects of this change are discussed in Security Consideration section in more detail.
 
-### Smart Contracts
+### Transaction Bundles
 
-The changes to the timing of fee application are only noticeable across transactions. In rare cases, smart contract developers might need to adapt their contracts to account for the possibility of coinbase balance increment occurring at the end of a block.
+The changes to the timing of fee application are only noticeable across transactions. Transaction bundles that rely on coinbase reward being applied at the end of each transaction might need to adjust the logic.
 
 ## Test Cases
 

--- a/EIPS/eip-7541.md
+++ b/EIPS/eip-7541.md
@@ -1,6 +1,6 @@
 ---
 eip: 7541
-title: Apply Coinbase Rewards At The End Of Block
+title: Apply coinbase reward at end of block
 description: Apply rewards for all transactions to the coinbase at the end of the block.
 author: Roman Krasiuk (@rkrasiuk), Dragan Rakita (@rakita)
 discussions-to: https://ethereum-magicians.org/t/eip-7541-apply-coinbase-rewards-at-the-end-of-block/16180
@@ -20,7 +20,7 @@ Currently, the transaction fees are applied to the `COINBASE`'s balance at the e
 
 ## Specification
 
-The sender of the transaction is still credited at the start of the transaction execution and the refund is still issued at the end in order to avoid double-spending. The `COINBASE` reward is accumulated from transaction fees and applied at the end of each block.
+The sender of the transaction is still charged at the start of the transaction execution and the refund is still issued at the end in order to avoid double-spending. The `COINBASE` reward is accumulated from transaction fees and applied at the end of each block.
 
 ```python
 def execute_block(block: Block) -> None:
@@ -114,7 +114,7 @@ Coinbase Balance After Block: 10.3 ETH
 
 ### Double Spending
 
-The sender is still credited at the start of the transaction and receives the refund at the end to avoid double spending.
+The sender is still charged at the start of the transaction and receives the refund at the end to avoid double spending.
 
 ### Block Building
 

--- a/EIPS/eip-7541.md
+++ b/EIPS/eip-7541.md
@@ -3,7 +3,7 @@ eip: 7541
 title: Apply Coinbase Rewards At The End Of Block
 description: Apply rewards for all transactions to the coinbase at the end of the block.
 author: Roman Krasiuk (@rkrasiuk), Dragan Rakita (@rakita)
-discussions-to: *
+discussions-to: https://ethereum-magicians.org/t/eip-7541-apply-coinbase-rewards-at-the-end-of-block/16180
 status: Draft
 type: Standards Track
 category: Core


### PR DESCRIPTION
## Description

Add an EIP that proposes applying coinbase rewards at the end of the block.

## Additional Context

https://github.com/ethereum/EIPs/pull/7878 with amended security considerations.