### PR TITLE
Update EIP-6093: Include error-decoded operations in the Security Considerations

### DIFF
--- a/EIPS/eip-6093.md
+++ b/EIPS/eip-6093.md
@@ -422,6 +422,8 @@ There are no known signature hash collisions for the specified errors.
 
 Tokens upgraded to implement this EIP may break assumptions in other systems relying on revert strings.
 
+Offchain applications should be cautious when dealing with untrusted contracts that may revert using these custom errors. For instance, if a user interface prompts actions based on error decoding, malicious contracts could exploit this to encourage untrusted and potentially harmful operations.
+
 ## Copyright
 
 Copyright and related rights waived via [CC0](../LICENSE.md).


### PR DESCRIPTION
Added an offchain security consideration when decoding errors for user action prompting.
