### PR TITLE
Update EIP-5164: Move to Last Call

### DIFF
--- a/EIPS/eip-5164.md
+++ b/EIPS/eip-5164.md
@@ -4,7 +4,8 @@ title: Cross-Chain Execution
 description: Defines an interface that supports execution across EVM networks.
 author: Brendan Asselstine (@asselstine), Pierrick Turelier (@PierrickGT), Chris Whinfrey (@cwhinfrey)
 discussions-to: https://ethereum-magicians.org/t/eip-5164-cross-chain-execution/9658
-status: Final
+status: Last Call
+last-call-deadline: 2023-11-08
 type: Standards Track
 category: ERC
 created: 2022-06-14

--- a/EIPS/eip-5164.md
+++ b/EIPS/eip-5164.md
@@ -4,7 +4,7 @@ title: Cross-Chain Execution
 description: Defines an interface that supports execution across EVM networks.
 author: Brendan Asselstine (@asselstine), Pierrick Turelier (@PierrickGT), Chris Whinfrey (@cwhinfrey)
 discussions-to: https://ethereum-magicians.org/t/eip-5164-cross-chain-execution/9658
-status: Review
+status: Final
 type: Standards Track
 category: ERC
 created: 2022-06-14


### PR DESCRIPTION
Finalizes ERC-5164.

The spec has seen a number of implementations, and is ready to be finalized.

- PoolTogether 5164 wrappers for [Optimism, Arbitrum and Polygon](https://github.com/pooltogether/erc5164)
- [Hyperlane has implemented ERC-5164](https://docs.hyperlane.xyz/docs/apis-and-sdks/hooks#erc-5164-hook)
- [Multi-bridge Message Aggregator](https://multi-message-aggregation.gitbook.io/multi-message-aggregation/start-here/multi-bridge-message-aggregation) that originated from the Uniswap Forums.
- Hop Protocol has committed to using the standard

Additionally we have endorsement from Uniswap:

- Uniswap Bridge Report [recommendations](https://uniswap.notion.site/Bridge-Assessment-Report-0c8477afadce425abac9c0bd175ca382) were to lean into ERC-5164
