### PR TITLE
Update EIP-1046: update link to new ercs repo

### DIFF
--- a/EIPS/eip-1046.md
+++ b/EIPS/eip-1046.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1046.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1046.md

--- a/EIPS/eip-1056.md
+++ b/EIPS/eip-1056.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1056.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1056.md

--- a/EIPS/eip-1062.md
+++ b/EIPS/eip-1062.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1062.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1062.md

--- a/EIPS/eip-1066.md
+++ b/EIPS/eip-1066.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1066.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1066.md

--- a/EIPS/eip-1077.md
+++ b/EIPS/eip-1077.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1077.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1077.md

--- a/EIPS/eip-1078.md
+++ b/EIPS/eip-1078.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1078.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1078.md

--- a/EIPS/eip-1080.md
+++ b/EIPS/eip-1080.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1080.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1080.md

--- a/EIPS/eip-1081.md
+++ b/EIPS/eip-1081.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1081.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1081.md

--- a/EIPS/eip-1123.md
+++ b/EIPS/eip-1123.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1123.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1123.md

--- a/EIPS/eip-1129.md
+++ b/EIPS/eip-1129.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1129.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1129.md

--- a/EIPS/eip-1132.md
+++ b/EIPS/eip-1132.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1132.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1132.md

--- a/EIPS/eip-1154.md
+++ b/EIPS/eip-1154.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1154.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1154.md

--- a/EIPS/eip-1155.md
+++ b/EIPS/eip-1155.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1155.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1155.md

--- a/EIPS/eip-1167.md
+++ b/EIPS/eip-1167.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1167.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1167.md

--- a/EIPS/eip-1175.md
+++ b/EIPS/eip-1175.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1175.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1175.md

--- a/EIPS/eip-1178.md
+++ b/EIPS/eip-1178.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1178.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1178.md

--- a/EIPS/eip-1185.md
+++ b/EIPS/eip-1185.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1185.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1185.md

--- a/EIPS/eip-1191.md
+++ b/EIPS/eip-1191.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1191.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1191.md

--- a/EIPS/eip-1202.md
+++ b/EIPS/eip-1202.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1202.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1202.md

--- a/EIPS/eip-1203.md
+++ b/EIPS/eip-1203.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1203.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1203.md

--- a/EIPS/eip-1207.md
+++ b/EIPS/eip-1207.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1207.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1207.md

--- a/EIPS/eip-1261.md
+++ b/EIPS/eip-1261.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1261.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1261.md

--- a/EIPS/eip-1271.md
+++ b/EIPS/eip-1271.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1271.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1271.md

--- a/EIPS/eip-1319.md
+++ b/EIPS/eip-1319.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1319.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1319.md

--- a/EIPS/eip-1328.md
+++ b/EIPS/eip-1328.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1328.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1328.md

--- a/EIPS/eip-1337.md
+++ b/EIPS/eip-1337.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1337.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1337.md

--- a/EIPS/eip-1363.md
+++ b/EIPS/eip-1363.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1363.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1363.md

--- a/EIPS/eip-137.md
+++ b/EIPS/eip-137.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-137.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-137.md

--- a/EIPS/eip-1386.md
+++ b/EIPS/eip-1386.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1386.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1386.md

--- a/EIPS/eip-1387.md
+++ b/EIPS/eip-1387.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1387.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1387.md

--- a/EIPS/eip-1388.md
+++ b/EIPS/eip-1388.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1388.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1388.md

--- a/EIPS/eip-1417.md
+++ b/EIPS/eip-1417.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1417.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1417.md

--- a/EIPS/eip-1438.md
+++ b/EIPS/eip-1438.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1438.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1438.md

--- a/EIPS/eip-1444.md
+++ b/EIPS/eip-1444.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1444.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1444.md

--- a/EIPS/eip-1450.md
+++ b/EIPS/eip-1450.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1450.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1450.md

--- a/EIPS/eip-1462.md
+++ b/EIPS/eip-1462.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1462.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1462.md

--- a/EIPS/eip-1484.md
+++ b/EIPS/eip-1484.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1484.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1484.md

--- a/EIPS/eip-1491.md
+++ b/EIPS/eip-1491.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1491.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1491.md

--- a/EIPS/eip-1504.md
+++ b/EIPS/eip-1504.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1504.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1504.md

--- a/EIPS/eip-1523.md
+++ b/EIPS/eip-1523.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1523.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1523.md

--- a/EIPS/eip-1538.md
+++ b/EIPS/eip-1538.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1538.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1538.md

--- a/EIPS/eip-1577.md
+++ b/EIPS/eip-1577.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1577.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1577.md

--- a/EIPS/eip-1581.md
+++ b/EIPS/eip-1581.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1581.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1581.md

--- a/EIPS/eip-1592.md
+++ b/EIPS/eip-1592.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1592.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1592.md

--- a/EIPS/eip-1613.md
+++ b/EIPS/eip-1613.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1613.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1613.md

--- a/EIPS/eip-1616.md
+++ b/EIPS/eip-1616.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1616.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1616.md

--- a/EIPS/eip-162.md
+++ b/EIPS/eip-162.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-162.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-162.md

--- a/EIPS/eip-1620.md
+++ b/EIPS/eip-1620.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1620.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1620.md

--- a/EIPS/eip-1633.md
+++ b/EIPS/eip-1633.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1633.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1633.md

--- a/EIPS/eip-165.md
+++ b/EIPS/eip-165.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-165.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-165.md

--- a/EIPS/eip-1710.md
+++ b/EIPS/eip-1710.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1710.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1710.md

--- a/EIPS/eip-173.md
+++ b/EIPS/eip-173.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-173.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-173.md

--- a/EIPS/eip-1753.md
+++ b/EIPS/eip-1753.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1753.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1753.md

--- a/EIPS/eip-1761.md
+++ b/EIPS/eip-1761.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1761.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1761.md

--- a/EIPS/eip-1775.md
+++ b/EIPS/eip-1775.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1775.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1775.md

--- a/EIPS/eip-181.md
+++ b/EIPS/eip-181.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-181.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-181.md

--- a/EIPS/eip-1812.md
+++ b/EIPS/eip-1812.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1812.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1812.md

--- a/EIPS/eip-1820.md
+++ b/EIPS/eip-1820.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1820.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1820.md

--- a/EIPS/eip-1822.md
+++ b/EIPS/eip-1822.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1822.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1822.md

--- a/EIPS/eip-1844.md
+++ b/EIPS/eip-1844.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1844.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1844.md

--- a/EIPS/eip-190.md
+++ b/EIPS/eip-190.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-190.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-190.md

--- a/EIPS/eip-1900.md
+++ b/EIPS/eip-1900.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1900.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1900.md

--- a/EIPS/eip-191.md
+++ b/EIPS/eip-191.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-191.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-191.md

--- a/EIPS/eip-1921.md
+++ b/EIPS/eip-1921.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1921.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1921.md

--- a/EIPS/eip-1922.md
+++ b/EIPS/eip-1922.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1922.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1922.md

--- a/EIPS/eip-1923.md
+++ b/EIPS/eip-1923.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1923.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1923.md

--- a/EIPS/eip-1948.md
+++ b/EIPS/eip-1948.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1948.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1948.md

--- a/EIPS/eip-1967.md
+++ b/EIPS/eip-1967.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1967.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1967.md

--- a/EIPS/eip-1973.md
+++ b/EIPS/eip-1973.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1973.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1973.md

--- a/EIPS/eip-1996.md
+++ b/EIPS/eip-1996.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-1996.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1996.md

--- a/EIPS/eip-20.md
+++ b/EIPS/eip-20.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-20.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-20.md

--- a/EIPS/eip-2009.md
+++ b/EIPS/eip-2009.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-2009.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2009.md

--- a/EIPS/eip-2018.md
+++ b/EIPS/eip-2018.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-2018.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2018.md

--- a/EIPS/eip-2019.md
+++ b/EIPS/eip-2019.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-2019.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2019.md

--- a/EIPS/eip-2020.md
+++ b/EIPS/eip-2020.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-2020.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2020.md

--- a/EIPS/eip-2021.md
+++ b/EIPS/eip-2021.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-2021.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2021.md

--- a/EIPS/eip-205.md
+++ b/EIPS/eip-205.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-205.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-205.md

--- a/EIPS/eip-2098.md
+++ b/EIPS/eip-2098.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-2098.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2098.md

--- a/EIPS/eip-2135.md
+++ b/EIPS/eip-2135.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-2135.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2135.md

--- a/EIPS/eip-2157.md
+++ b/EIPS/eip-2157.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-2157.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2157.md

--- a/EIPS/eip-2193.md
+++ b/EIPS/eip-2193.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-2193.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2193.md

--- a/EIPS/eip-223.md
+++ b/EIPS/eip-223.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-223.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-223.md

--- a/EIPS/eip-2266.md
+++ b/EIPS/eip-2266.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-2266.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2266.md

--- a/EIPS/eip-2304.md
+++ b/EIPS/eip-2304.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-2304.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2304.md

--- a/EIPS/eip-2309.md
+++ b/EIPS/eip-2309.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-2309.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2309.md

--- a/EIPS/eip-2333.md
+++ b/EIPS/eip-2333.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-2333.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2333.md

--- a/EIPS/eip-2334.md
+++ b/EIPS/eip-2334.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-2334.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2334.md

--- a/EIPS/eip-2335.md
+++ b/EIPS/eip-2335.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-2335.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2335.md

--- a/EIPS/eip-2386.md
+++ b/EIPS/eip-2386.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-2386.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2386.md

--- a/EIPS/eip-2390.md
+++ b/EIPS/eip-2390.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-2390.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2390.md

--- a/EIPS/eip-2400.md
+++ b/EIPS/eip-2400.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-2400.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2400.md

--- a/EIPS/eip-2470.md
+++ b/EIPS/eip-2470.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-2470.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2470.md

--- a/EIPS/eip-2477.md
+++ b/EIPS/eip-2477.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-2477.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2477.md

--- a/EIPS/eip-2494.md
+++ b/EIPS/eip-2494.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-2494.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2494.md

--- a/EIPS/eip-2520.md
+++ b/EIPS/eip-2520.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-2520.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2520.md

--- a/EIPS/eip-2525.md
+++ b/EIPS/eip-2525.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-2525.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2525.md

--- a/EIPS/eip-2535.md
+++ b/EIPS/eip-2535.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-2535.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2535.md

--- a/EIPS/eip-2544.md
+++ b/EIPS/eip-2544.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-2544.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2544.md

--- a/EIPS/eip-2569.md
+++ b/EIPS/eip-2569.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-2569.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2569.md

--- a/EIPS/eip-2612.md
+++ b/EIPS/eip-2612.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-2612.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2612.md

--- a/EIPS/eip-2615.md
+++ b/EIPS/eip-2615.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-2615.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2615.md

--- a/EIPS/eip-2645.md
+++ b/EIPS/eip-2645.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-2645.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2645.md

--- a/EIPS/eip-2678.md
+++ b/EIPS/eip-2678.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-2678.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2678.md

--- a/EIPS/eip-2680.md
+++ b/EIPS/eip-2680.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-2680.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2680.md

--- a/EIPS/eip-2746.md
+++ b/EIPS/eip-2746.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-2746.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2746.md

--- a/EIPS/eip-2767.md
+++ b/EIPS/eip-2767.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-2767.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2767.md

--- a/EIPS/eip-2770.md
+++ b/EIPS/eip-2770.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-2770.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2770.md

--- a/EIPS/eip-2771.md
+++ b/EIPS/eip-2771.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-2771.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2771.md

--- a/EIPS/eip-2848.md
+++ b/EIPS/eip-2848.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-2848.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2848.md

--- a/EIPS/eip-2876.md
+++ b/EIPS/eip-2876.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-2876.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2876.md

--- a/EIPS/eip-2917.md
+++ b/EIPS/eip-2917.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-2917.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2917.md

--- a/EIPS/eip-2942.md
+++ b/EIPS/eip-2942.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-2942.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2942.md

--- a/EIPS/eip-2980.md
+++ b/EIPS/eip-2980.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-2980.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2980.md

--- a/EIPS/eip-2981.md
+++ b/EIPS/eip-2981.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-2981.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2981.md

--- a/EIPS/eip-3000.md
+++ b/EIPS/eip-3000.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-3000.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-3000.md

--- a/EIPS/eip-3005.md
+++ b/EIPS/eip-3005.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-3005.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-3005.md

--- a/EIPS/eip-3009.md
+++ b/EIPS/eip-3009.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-3009.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-3009.md

--- a/EIPS/eip-3135.md
+++ b/EIPS/eip-3135.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-3135.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-3135.md

--- a/EIPS/eip-3156.md
+++ b/EIPS/eip-3156.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-3156.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-3156.md

--- a/EIPS/eip-3224.md
+++ b/EIPS/eip-3224.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-3224.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-3224.md

--- a/EIPS/eip-3234.md
+++ b/EIPS/eip-3234.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-3234.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-3234.md

--- a/EIPS/eip-3386.md
+++ b/EIPS/eip-3386.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-3386.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-3386.md

--- a/EIPS/eip-3440.md
+++ b/EIPS/eip-3440.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-3440.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-3440.md

--- a/EIPS/eip-3448.md
+++ b/EIPS/eip-3448.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-3448.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-3448.md

--- a/EIPS/eip-3450.md
+++ b/EIPS/eip-3450.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-3450.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-3450.md

--- a/EIPS/eip-3475.md
+++ b/EIPS/eip-3475.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-3475.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-3475.md

--- a/EIPS/eip-3525.md
+++ b/EIPS/eip-3525.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-3525.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-3525.md

--- a/EIPS/eip-3561.md
+++ b/EIPS/eip-3561.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-3561.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-3561.md

--- a/EIPS/eip-3569.md
+++ b/EIPS/eip-3569.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-3569.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-3569.md

--- a/EIPS/eip-3589.md
+++ b/EIPS/eip-3589.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-3589.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-3589.md

--- a/EIPS/eip-3643.md
+++ b/EIPS/eip-3643.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-3643.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-3643.md

--- a/EIPS/eip-3668.md
+++ b/EIPS/eip-3668.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-3668.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-3668.md

--- a/EIPS/eip-3722.md
+++ b/EIPS/eip-3722.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-3722.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-3722.md

--- a/EIPS/eip-3754.md
+++ b/EIPS/eip-3754.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-3754.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-3754.md

--- a/EIPS/eip-3770.md
+++ b/EIPS/eip-3770.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-3770.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-3770.md

--- a/EIPS/eip-3772.md
+++ b/EIPS/eip-3772.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-3772.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-3772.md

--- a/EIPS/eip-4337.md
+++ b/EIPS/eip-4337.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-4337.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4337.md

--- a/EIPS/eip-4341.md
+++ b/EIPS/eip-4341.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-4341.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4341.md

--- a/EIPS/eip-4353.md
+++ b/EIPS/eip-4353.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-4353.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4353.md

--- a/EIPS/eip-4361.md
+++ b/EIPS/eip-4361.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-4361.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4361.md

--- a/EIPS/eip-4393.md
+++ b/EIPS/eip-4393.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-4393.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4393.md

--- a/EIPS/eip-4400.md
+++ b/EIPS/eip-4400.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-4400.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4400.md

--- a/EIPS/eip-4430.md
+++ b/EIPS/eip-4430.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-4430.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4430.md

--- a/EIPS/eip-4494.md
+++ b/EIPS/eip-4494.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-4494.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4494.md

--- a/EIPS/eip-4519.md
+++ b/EIPS/eip-4519.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-4519.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4519.md

--- a/EIPS/eip-4521.md
+++ b/EIPS/eip-4521.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-4521.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4521.md

--- a/EIPS/eip-4524.md
+++ b/EIPS/eip-4524.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-4524.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4524.md

--- a/EIPS/eip-4527.md
+++ b/EIPS/eip-4527.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-4527.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4527.md

--- a/EIPS/eip-4546.md
+++ b/EIPS/eip-4546.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-4546.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4546.md

--- a/EIPS/eip-4626.md
+++ b/EIPS/eip-4626.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-4626.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4626.md

--- a/EIPS/eip-4671.md
+++ b/EIPS/eip-4671.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-4671.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4671.md

--- a/EIPS/eip-4675.md
+++ b/EIPS/eip-4675.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-4675.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4675.md

--- a/EIPS/eip-4799.md
+++ b/EIPS/eip-4799.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-4799.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4799.md

--- a/EIPS/eip-4804.md
+++ b/EIPS/eip-4804.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-4804.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4804.md

--- a/EIPS/eip-4824.md
+++ b/EIPS/eip-4824.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-4824.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4824.md

--- a/EIPS/eip-4834.md
+++ b/EIPS/eip-4834.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-4834.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4834.md

--- a/EIPS/eip-4883.md
+++ b/EIPS/eip-4883.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-4883.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4883.md

--- a/EIPS/eip-4885.md
+++ b/EIPS/eip-4885.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-4885.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4885.md

--- a/EIPS/eip-4886.md
+++ b/EIPS/eip-4886.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-4886.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4886.md

--- a/EIPS/eip-4906.md
+++ b/EIPS/eip-4906.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-4906.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4906.md

--- a/EIPS/eip-4907.md
+++ b/EIPS/eip-4907.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-4907.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4907.md

--- a/EIPS/eip-4910.md
+++ b/EIPS/eip-4910.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-4910.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4910.md

--- a/EIPS/eip-4931.md
+++ b/EIPS/eip-4931.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-4931.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4931.md

--- a/EIPS/eip-4944.md
+++ b/EIPS/eip-4944.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-4944.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4944.md

--- a/EIPS/eip-4950.md
+++ b/EIPS/eip-4950.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-4950.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4950.md

--- a/EIPS/eip-4955.md
+++ b/EIPS/eip-4955.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-4955.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4955.md

--- a/EIPS/eip-4972.md
+++ b/EIPS/eip-4972.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-4972.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4972.md

--- a/EIPS/eip-4973.md
+++ b/EIPS/eip-4973.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-4973.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4973.md

--- a/EIPS/eip-4974.md
+++ b/EIPS/eip-4974.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-4974.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4974.md

--- a/EIPS/eip-4987.md
+++ b/EIPS/eip-4987.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-4987.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4987.md

--- a/EIPS/eip-5005.md
+++ b/EIPS/eip-5005.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5005.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5005.md

--- a/EIPS/eip-5006.md
+++ b/EIPS/eip-5006.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5006.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5006.md

--- a/EIPS/eip-5007.md
+++ b/EIPS/eip-5007.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5007.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5007.md

--- a/EIPS/eip-5008.md
+++ b/EIPS/eip-5008.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5008.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5008.md

--- a/EIPS/eip-5018.md
+++ b/EIPS/eip-5018.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5018.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5018.md

--- a/EIPS/eip-5023.md
+++ b/EIPS/eip-5023.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5023.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5023.md

--- a/EIPS/eip-5050.md
+++ b/EIPS/eip-5050.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5050.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5050.md

--- a/EIPS/eip-5058.md
+++ b/EIPS/eip-5058.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5058.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5058.md

--- a/EIPS/eip-5094.md
+++ b/EIPS/eip-5094.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5094.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5094.md

--- a/EIPS/eip-5095.md
+++ b/EIPS/eip-5095.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5095.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5095.md

--- a/EIPS/eip-5114.md
+++ b/EIPS/eip-5114.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5114.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5114.md

--- a/EIPS/eip-5115.md
+++ b/EIPS/eip-5115.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5115.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5115.md

--- a/EIPS/eip-5131.md
+++ b/EIPS/eip-5131.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5131.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5131.md

--- a/EIPS/eip-5139.md
+++ b/EIPS/eip-5139.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5139.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5139.md

--- a/EIPS/eip-5143.md
+++ b/EIPS/eip-5143.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5143.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5143.md

--- a/EIPS/eip-5164.md
+++ b/EIPS/eip-5164.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5164.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5164.md

--- a/EIPS/eip-5169.md
+++ b/EIPS/eip-5169.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5169.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5169.md

--- a/EIPS/eip-5173.md
+++ b/EIPS/eip-5173.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5173.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5173.md

--- a/EIPS/eip-5185.md
+++ b/EIPS/eip-5185.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5185.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5185.md

--- a/EIPS/eip-5187.md
+++ b/EIPS/eip-5187.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5187.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5187.md

--- a/EIPS/eip-5189.md
+++ b/EIPS/eip-5189.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5189.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5189.md

--- a/EIPS/eip-5192.md
+++ b/EIPS/eip-5192.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5192.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5192.md

--- a/EIPS/eip-5202.md
+++ b/EIPS/eip-5202.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5202.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5202.md

--- a/EIPS/eip-5216.md
+++ b/EIPS/eip-5216.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5216.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5216.md

--- a/EIPS/eip-5218.md
+++ b/EIPS/eip-5218.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5218.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5218.md

--- a/EIPS/eip-5219.md
+++ b/EIPS/eip-5219.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5219.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5219.md

--- a/EIPS/eip-5247.md
+++ b/EIPS/eip-5247.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5247.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5247.md

--- a/EIPS/eip-5252.md
+++ b/EIPS/eip-5252.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5252.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5252.md

--- a/EIPS/eip-5267.md
+++ b/EIPS/eip-5267.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5267.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5267.md

--- a/EIPS/eip-5269.md
+++ b/EIPS/eip-5269.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5269.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5269.md

--- a/EIPS/eip-5289.md
+++ b/EIPS/eip-5289.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5289.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5289.md

--- a/EIPS/eip-5298.md
+++ b/EIPS/eip-5298.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5298.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5298.md

--- a/EIPS/eip-5313.md
+++ b/EIPS/eip-5313.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5313.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5313.md

--- a/EIPS/eip-5334.md
+++ b/EIPS/eip-5334.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5334.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5334.md

--- a/EIPS/eip-5375.md
+++ b/EIPS/eip-5375.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5375.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5375.md

--- a/EIPS/eip-5380.md
+++ b/EIPS/eip-5380.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5380.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5380.md

--- a/EIPS/eip-5409.md
+++ b/EIPS/eip-5409.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5409.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5409.md

--- a/EIPS/eip-5437.md
+++ b/EIPS/eip-5437.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5437.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5437.md

--- a/EIPS/eip-5453.md
+++ b/EIPS/eip-5453.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5453.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5453.md

--- a/EIPS/eip-5484.md
+++ b/EIPS/eip-5484.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5484.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5484.md

--- a/EIPS/eip-5485.md
+++ b/EIPS/eip-5485.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5485.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5485.md

--- a/EIPS/eip-5489.md
+++ b/EIPS/eip-5489.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5489.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5489.md

--- a/EIPS/eip-5496.md
+++ b/EIPS/eip-5496.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5496.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5496.md

--- a/EIPS/eip-55.md
+++ b/EIPS/eip-55.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-55.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-55.md

--- a/EIPS/eip-5501.md
+++ b/EIPS/eip-5501.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5501.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5501.md

--- a/EIPS/eip-5505.md
+++ b/EIPS/eip-5505.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5505.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5505.md

--- a/EIPS/eip-5507.md
+++ b/EIPS/eip-5507.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5507.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5507.md

--- a/EIPS/eip-5516.md
+++ b/EIPS/eip-5516.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5516.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5516.md

--- a/EIPS/eip-5521.md
+++ b/EIPS/eip-5521.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5521.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5521.md

--- a/EIPS/eip-5528.md
+++ b/EIPS/eip-5528.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5528.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5528.md

--- a/EIPS/eip-5539.md
+++ b/EIPS/eip-5539.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5539.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5539.md

--- a/EIPS/eip-5553.md
+++ b/EIPS/eip-5553.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5553.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5553.md

--- a/EIPS/eip-5554.md
+++ b/EIPS/eip-5554.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5554.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5554.md

--- a/EIPS/eip-5559.md
+++ b/EIPS/eip-5559.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5559.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5559.md

--- a/EIPS/eip-5560.md
+++ b/EIPS/eip-5560.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5560.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5560.md

--- a/EIPS/eip-5564.md
+++ b/EIPS/eip-5564.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5564.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5564.md

--- a/EIPS/eip-5568.md
+++ b/EIPS/eip-5568.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5568.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5568.md

--- a/EIPS/eip-5570.md
+++ b/EIPS/eip-5570.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5570.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5570.md

--- a/EIPS/eip-5573.md
+++ b/EIPS/eip-5573.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5573.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5573.md

--- a/EIPS/eip-5585.md
+++ b/EIPS/eip-5585.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5585.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5585.md

--- a/EIPS/eip-5604.md
+++ b/EIPS/eip-5604.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5604.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5604.md

--- a/EIPS/eip-5606.md
+++ b/EIPS/eip-5606.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5606.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5606.md

--- a/EIPS/eip-5615.md
+++ b/EIPS/eip-5615.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5615.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5615.md

--- a/EIPS/eip-5625.md
+++ b/EIPS/eip-5625.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5625.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5625.md

--- a/EIPS/eip-5630.md
+++ b/EIPS/eip-5630.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5630.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5630.md

--- a/EIPS/eip-5633.md
+++ b/EIPS/eip-5633.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5633.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5633.md

--- a/EIPS/eip-5635.md
+++ b/EIPS/eip-5635.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5635.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5635.md

--- a/EIPS/eip-5639.md
+++ b/EIPS/eip-5639.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5639.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5639.md

--- a/EIPS/eip-5643.md
+++ b/EIPS/eip-5643.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5643.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5643.md

--- a/EIPS/eip-5646.md
+++ b/EIPS/eip-5646.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5646.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5646.md

--- a/EIPS/eip-5679.md
+++ b/EIPS/eip-5679.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5679.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5679.md

--- a/EIPS/eip-5700.md
+++ b/EIPS/eip-5700.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5700.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5700.md

--- a/EIPS/eip-5719.md
+++ b/EIPS/eip-5719.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5719.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5719.md

--- a/EIPS/eip-5725.md
+++ b/EIPS/eip-5725.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5725.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5725.md

--- a/EIPS/eip-5727.md
+++ b/EIPS/eip-5727.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5727.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5727.md

--- a/EIPS/eip-5732.md
+++ b/EIPS/eip-5732.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5732.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5732.md

--- a/EIPS/eip-5744.md
+++ b/EIPS/eip-5744.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5744.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5744.md

--- a/EIPS/eip-5750.md
+++ b/EIPS/eip-5750.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5750.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5750.md

--- a/EIPS/eip-5753.md
+++ b/EIPS/eip-5753.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5753.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5753.md

--- a/EIPS/eip-5773.md
+++ b/EIPS/eip-5773.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5773.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5773.md

--- a/EIPS/eip-5791.md
+++ b/EIPS/eip-5791.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5791.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5791.md

--- a/EIPS/eip-5805.md
+++ b/EIPS/eip-5805.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5805.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5805.md

--- a/EIPS/eip-5827.md
+++ b/EIPS/eip-5827.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5827.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5827.md

--- a/EIPS/eip-5850.md
+++ b/EIPS/eip-5850.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5850.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5850.md

--- a/EIPS/eip-5851.md
+++ b/EIPS/eip-5851.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5851.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5851.md

--- a/EIPS/eip-5883.md
+++ b/EIPS/eip-5883.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5883.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5883.md

--- a/EIPS/eip-5902.md
+++ b/EIPS/eip-5902.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5902.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5902.md

--- a/EIPS/eip-5982.md
+++ b/EIPS/eip-5982.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-5982.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5982.md

--- a/EIPS/eip-600.md
+++ b/EIPS/eip-600.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-600.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-600.md

--- a/EIPS/eip-601.md
+++ b/EIPS/eip-601.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-601.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-601.md

--- a/EIPS/eip-6047.md
+++ b/EIPS/eip-6047.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6047.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6047.md

--- a/EIPS/eip-6059.md
+++ b/EIPS/eip-6059.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6059.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6059.md

--- a/EIPS/eip-6065.md
+++ b/EIPS/eip-6065.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6065.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6065.md

--- a/EIPS/eip-6066.md
+++ b/EIPS/eip-6066.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6066.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6066.md

--- a/EIPS/eip-6093.md
+++ b/EIPS/eip-6093.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6093.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6093.md

--- a/EIPS/eip-6105.md
+++ b/EIPS/eip-6105.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6105.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6105.md

--- a/EIPS/eip-6120.md
+++ b/EIPS/eip-6120.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6120.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6120.md

--- a/EIPS/eip-6123.md
+++ b/EIPS/eip-6123.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6123.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6123.md

--- a/EIPS/eip-6147.md
+++ b/EIPS/eip-6147.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6147.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6147.md

--- a/EIPS/eip-6150.md
+++ b/EIPS/eip-6150.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6150.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6150.md

--- a/EIPS/eip-6170.md
+++ b/EIPS/eip-6170.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6170.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6170.md

--- a/EIPS/eip-6220.md
+++ b/EIPS/eip-6220.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6220.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6220.md

--- a/EIPS/eip-6224.md
+++ b/EIPS/eip-6224.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6224.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6224.md

--- a/EIPS/eip-6239.md
+++ b/EIPS/eip-6239.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6239.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6239.md

--- a/EIPS/eip-6268.md
+++ b/EIPS/eip-6268.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6268.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6268.md

--- a/EIPS/eip-6315.md
+++ b/EIPS/eip-6315.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6315.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6315.md

--- a/EIPS/eip-6327.md
+++ b/EIPS/eip-6327.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6327.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6327.md

--- a/EIPS/eip-634.md
+++ b/EIPS/eip-634.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-634.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-634.md

--- a/EIPS/eip-6353.md
+++ b/EIPS/eip-6353.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6353.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6353.md

--- a/EIPS/eip-6357.md
+++ b/EIPS/eip-6357.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6357.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6357.md

--- a/EIPS/eip-6358.md
+++ b/EIPS/eip-6358.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6358.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6358.md

--- a/EIPS/eip-6366.md
+++ b/EIPS/eip-6366.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6366.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6366.md

--- a/EIPS/eip-6372.md
+++ b/EIPS/eip-6372.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6372.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6372.md

--- a/EIPS/eip-6381.md
+++ b/EIPS/eip-6381.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6381.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6381.md

--- a/EIPS/eip-6384.md
+++ b/EIPS/eip-6384.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6384.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6384.md

--- a/EIPS/eip-6454.md
+++ b/EIPS/eip-6454.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6454.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6454.md

--- a/EIPS/eip-6464.md
+++ b/EIPS/eip-6464.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6464.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6464.md

--- a/EIPS/eip-6492.md
+++ b/EIPS/eip-6492.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6492.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6492.md

--- a/EIPS/eip-6506.md
+++ b/EIPS/eip-6506.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6506.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6506.md

--- a/EIPS/eip-6538.md
+++ b/EIPS/eip-6538.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6538.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6538.md

--- a/EIPS/eip-6551.md
+++ b/EIPS/eip-6551.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6551.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6551.md

--- a/EIPS/eip-6596.md
+++ b/EIPS/eip-6596.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6596.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6596.md

--- a/EIPS/eip-6604.md
+++ b/EIPS/eip-6604.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6604.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6604.md

--- a/EIPS/eip-6617.md
+++ b/EIPS/eip-6617.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6617.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6617.md

--- a/EIPS/eip-6662.md
+++ b/EIPS/eip-6662.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6662.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6662.md

--- a/EIPS/eip-6672.md
+++ b/EIPS/eip-6672.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6672.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6672.md

--- a/EIPS/eip-6682.md
+++ b/EIPS/eip-6682.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6682.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6682.md

--- a/EIPS/eip-67.md
+++ b/EIPS/eip-67.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-67.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-67.md

--- a/EIPS/eip-6734.md
+++ b/EIPS/eip-6734.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6734.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6734.md

--- a/EIPS/eip-6735.md
+++ b/EIPS/eip-6735.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6735.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6735.md

--- a/EIPS/eip-6785.md
+++ b/EIPS/eip-6785.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6785.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6785.md

--- a/EIPS/eip-6786.md
+++ b/EIPS/eip-6786.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6786.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6786.md

--- a/EIPS/eip-6787.md
+++ b/EIPS/eip-6787.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6787.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6787.md

--- a/EIPS/eip-6806.md
+++ b/EIPS/eip-6806.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6806.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6806.md

--- a/EIPS/eip-6808.md
+++ b/EIPS/eip-6808.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6808.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6808.md

--- a/EIPS/eip-6809.md
+++ b/EIPS/eip-6809.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6809.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6809.md

--- a/EIPS/eip-681.md
+++ b/EIPS/eip-681.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-681.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-681.md

--- a/EIPS/eip-6821.md
+++ b/EIPS/eip-6821.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6821.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6821.md

--- a/EIPS/eip-6823.md
+++ b/EIPS/eip-6823.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6823.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6823.md

--- a/EIPS/eip-6860.md
+++ b/EIPS/eip-6860.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6860.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6860.md

--- a/EIPS/eip-6864.md
+++ b/EIPS/eip-6864.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6864.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6864.md

--- a/EIPS/eip-6865.md
+++ b/EIPS/eip-6865.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6865.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6865.md

--- a/EIPS/eip-6900.md
+++ b/EIPS/eip-6900.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6900.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6900.md

--- a/EIPS/eip-6909.md
+++ b/EIPS/eip-6909.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6909.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6909.md

--- a/EIPS/eip-6944.md
+++ b/EIPS/eip-6944.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6944.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6944.md

--- a/EIPS/eip-6956.md
+++ b/EIPS/eip-6956.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6956.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6956.md

--- a/EIPS/eip-6960.md
+++ b/EIPS/eip-6960.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6960.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6960.md

--- a/EIPS/eip-6981.md
+++ b/EIPS/eip-6981.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6981.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6981.md

--- a/EIPS/eip-6982.md
+++ b/EIPS/eip-6982.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6982.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6982.md

--- a/EIPS/eip-6997.md
+++ b/EIPS/eip-6997.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-6997.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6997.md

--- a/EIPS/eip-7007.md
+++ b/EIPS/eip-7007.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-7007.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7007.md

--- a/EIPS/eip-7015.md
+++ b/EIPS/eip-7015.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-7015.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7015.md

--- a/EIPS/eip-7053.md
+++ b/EIPS/eip-7053.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-7053.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7053.md

--- a/EIPS/eip-7066.md
+++ b/EIPS/eip-7066.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-7066.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7066.md

--- a/EIPS/eip-7085.md
+++ b/EIPS/eip-7085.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-7085.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7085.md

--- a/EIPS/eip-7092.md
+++ b/EIPS/eip-7092.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-7092.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7092.md

--- a/EIPS/eip-7093.md
+++ b/EIPS/eip-7093.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-7093.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7093.md

--- a/EIPS/eip-7144.md
+++ b/EIPS/eip-7144.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-7144.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7144.md

--- a/EIPS/eip-7160.md
+++ b/EIPS/eip-7160.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-7160.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7160.md

--- a/EIPS/eip-7201.md
+++ b/EIPS/eip-7201.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-7201.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7201.md

--- a/EIPS/eip-721.md
+++ b/EIPS/eip-721.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-721.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-721.md

--- a/EIPS/eip-7231.md
+++ b/EIPS/eip-7231.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-7231.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7231.md

--- a/EIPS/eip-725.md
+++ b/EIPS/eip-725.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-725.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-725.md

--- a/EIPS/eip-7303.md
+++ b/EIPS/eip-7303.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-7303.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7303.md

--- a/EIPS/eip-7401.md
+++ b/EIPS/eip-7401.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-7401.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7401.md

--- a/EIPS/eip-7405.md
+++ b/EIPS/eip-7405.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-7405.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7405.md

--- a/EIPS/eip-7406.md
+++ b/EIPS/eip-7406.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-7406.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7406.md

--- a/EIPS/eip-7409.md
+++ b/EIPS/eip-7409.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-7409.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7409.md

--- a/EIPS/eip-7412.md
+++ b/EIPS/eip-7412.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-7412.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7412.md

--- a/EIPS/eip-7417.md
+++ b/EIPS/eip-7417.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-7417.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7417.md

--- a/EIPS/eip-7425.md
+++ b/EIPS/eip-7425.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-7425.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7425.md

--- a/EIPS/eip-7432.md
+++ b/EIPS/eip-7432.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-7432.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7432.md

--- a/EIPS/eip-7444.md
+++ b/EIPS/eip-7444.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-7444.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7444.md

--- a/EIPS/eip-7484.md
+++ b/EIPS/eip-7484.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-7484.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7484.md

--- a/EIPS/eip-7507.md
+++ b/EIPS/eip-7507.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-7507.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7507.md

--- a/EIPS/eip-7508.md
+++ b/EIPS/eip-7508.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-7508.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7508.md

--- a/EIPS/eip-7511.md
+++ b/EIPS/eip-7511.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-7511.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7511.md

--- a/EIPS/eip-7512.md
+++ b/EIPS/eip-7512.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-7512.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7512.md

--- a/EIPS/eip-7521.md
+++ b/EIPS/eip-7521.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-7521.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7521.md

--- a/EIPS/eip-7522.md
+++ b/EIPS/eip-7522.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-7522.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7522.md

--- a/EIPS/eip-7528.md
+++ b/EIPS/eip-7528.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-7528.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7528.md

--- a/EIPS/eip-777.md
+++ b/EIPS/eip-777.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-777.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-777.md

--- a/EIPS/eip-801.md
+++ b/EIPS/eip-801.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-801.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-801.md

--- a/EIPS/eip-820.md
+++ b/EIPS/eip-820.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-820.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-820.md

--- a/EIPS/eip-823.md
+++ b/EIPS/eip-823.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-823.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-823.md

--- a/EIPS/eip-831.md
+++ b/EIPS/eip-831.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-831.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-831.md

--- a/EIPS/eip-875.md
+++ b/EIPS/eip-875.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-875.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-875.md

--- a/EIPS/eip-884.md
+++ b/EIPS/eip-884.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-884.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-884.md

--- a/EIPS/eip-897.md
+++ b/EIPS/eip-897.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-897.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-897.md

--- a/EIPS/eip-900.md
+++ b/EIPS/eip-900.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-900.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-900.md

--- a/EIPS/eip-902.md
+++ b/EIPS/eip-902.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-902.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-902.md

--- a/EIPS/eip-918.md
+++ b/EIPS/eip-918.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-918.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-918.md

--- a/EIPS/eip-926.md
+++ b/EIPS/eip-926.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-926.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-926.md

--- a/EIPS/eip-927.md
+++ b/EIPS/eip-927.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-927.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-927.md

--- a/EIPS/eip-998.md
+++ b/EIPS/eip-998.md
@@ -1,1 +1,1 @@
-This file was moved to https://github.com/ethereum/ercs/blob/master/ercs/erc-998.md
+This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-998.md


### PR DESCRIPTION
Missed in #7206: the new ERCs repo has a folder `ERCS` similar to our `EIPS`. This is case sensitive in the path causing the redirects here to fail. This PR fixes the URLs accordingly. 