### PR TITLE
Config: update pr template with ercs moved notice

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,7 @@
+**ATTENTION: ERC-RELATED PULL REQUESTS NOW OCCUR IN [ETHEREUM/ERCS](https://github.com/ethereum/ercs)**
+
+--
+
 When opening a pull request to submit a new EIP, please use the suggested template: https://github.com/ethereum/EIPs/blob/master/eip-template.md
 
 We have a GitHub bot that automatically merges some PRs. It will merge yours immediately if certain criteria are met:


### PR DESCRIPTION
Now that the repos are split we should make it very clear in case people continue to try and open PRs.