### PR TITLE
CI: Get `eipw` running again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           unchecked: 1, 5069, 5757
+          options-file: config/eipw.toml
 
   markdownlint:
     name: Markdown Linter

--- a/EIPS/eip-1046.md
+++ b/EIPS/eip-1046.md
@@ -1,1 +1,7 @@
+---
+eip: 1046
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1046.md

--- a/EIPS/eip-1056.md
+++ b/EIPS/eip-1056.md
@@ -1,1 +1,7 @@
+---
+eip: 1056
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1056.md

--- a/EIPS/eip-1062.md
+++ b/EIPS/eip-1062.md
@@ -1,1 +1,7 @@
+---
+eip: 1062
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1062.md

--- a/EIPS/eip-1066.md
+++ b/EIPS/eip-1066.md
@@ -1,1 +1,7 @@
+---
+eip: 1066
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1066.md

--- a/EIPS/eip-1077.md
+++ b/EIPS/eip-1077.md
@@ -1,1 +1,7 @@
+---
+eip: 1077
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1077.md

--- a/EIPS/eip-1078.md
+++ b/EIPS/eip-1078.md
@@ -1,1 +1,7 @@
+---
+eip: 1078
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1078.md

--- a/EIPS/eip-1080.md
+++ b/EIPS/eip-1080.md
@@ -1,1 +1,7 @@
+---
+eip: 1080
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1080.md

--- a/EIPS/eip-1081.md
+++ b/EIPS/eip-1081.md
@@ -1,1 +1,7 @@
+---
+eip: 1081
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1081.md

--- a/EIPS/eip-1123.md
+++ b/EIPS/eip-1123.md
@@ -1,1 +1,7 @@
+---
+eip: 1123
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1123.md

--- a/EIPS/eip-1129.md
+++ b/EIPS/eip-1129.md
@@ -1,1 +1,7 @@
+---
+eip: 1129
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1129.md

--- a/EIPS/eip-1132.md
+++ b/EIPS/eip-1132.md
@@ -1,1 +1,7 @@
+---
+eip: 1132
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1132.md

--- a/EIPS/eip-1154.md
+++ b/EIPS/eip-1154.md
@@ -1,1 +1,7 @@
+---
+eip: 1154
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1154.md

--- a/EIPS/eip-1155.md
+++ b/EIPS/eip-1155.md
@@ -1,1 +1,7 @@
+---
+eip: 1155
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1155.md

--- a/EIPS/eip-1167.md
+++ b/EIPS/eip-1167.md
@@ -1,1 +1,7 @@
+---
+eip: 1167
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1167.md

--- a/EIPS/eip-1175.md
+++ b/EIPS/eip-1175.md
@@ -1,1 +1,7 @@
+---
+eip: 1175
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1175.md

--- a/EIPS/eip-1178.md
+++ b/EIPS/eip-1178.md
@@ -1,1 +1,7 @@
+---
+eip: 1178
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1178.md

--- a/EIPS/eip-1185.md
+++ b/EIPS/eip-1185.md
@@ -1,1 +1,7 @@
+---
+eip: 1185
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1185.md

--- a/EIPS/eip-1191.md
+++ b/EIPS/eip-1191.md
@@ -1,1 +1,7 @@
+---
+eip: 1191
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1191.md

--- a/EIPS/eip-1202.md
+++ b/EIPS/eip-1202.md
@@ -1,1 +1,7 @@
+---
+eip: 1202
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1202.md

--- a/EIPS/eip-1203.md
+++ b/EIPS/eip-1203.md
@@ -1,1 +1,7 @@
+---
+eip: 1203
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1203.md

--- a/EIPS/eip-1207.md
+++ b/EIPS/eip-1207.md
@@ -1,1 +1,7 @@
+---
+eip: 1207
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1207.md

--- a/EIPS/eip-1261.md
+++ b/EIPS/eip-1261.md
@@ -1,1 +1,7 @@
+---
+eip: 1261
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1261.md

--- a/EIPS/eip-1271.md
+++ b/EIPS/eip-1271.md
@@ -1,1 +1,7 @@
+---
+eip: 1271
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1271.md

--- a/EIPS/eip-1319.md
+++ b/EIPS/eip-1319.md
@@ -1,1 +1,7 @@
+---
+eip: 1319
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1319.md

--- a/EIPS/eip-1328.md
+++ b/EIPS/eip-1328.md
@@ -1,1 +1,7 @@
+---
+eip: 1328
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1328.md

--- a/EIPS/eip-1337.md
+++ b/EIPS/eip-1337.md
@@ -1,1 +1,7 @@
+---
+eip: 1337
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1337.md

--- a/EIPS/eip-1363.md
+++ b/EIPS/eip-1363.md
@@ -1,1 +1,7 @@
+---
+eip: 1363
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1363.md

--- a/EIPS/eip-137.md
+++ b/EIPS/eip-137.md
@@ -1,1 +1,7 @@
+---
+eip: 137
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-137.md

--- a/EIPS/eip-1386.md
+++ b/EIPS/eip-1386.md
@@ -1,1 +1,7 @@
+---
+eip: 1386
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1386.md

--- a/EIPS/eip-1387.md
+++ b/EIPS/eip-1387.md
@@ -1,1 +1,7 @@
+---
+eip: 1387
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1387.md

--- a/EIPS/eip-1388.md
+++ b/EIPS/eip-1388.md
@@ -1,1 +1,7 @@
+---
+eip: 1388
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1388.md

--- a/EIPS/eip-1417.md
+++ b/EIPS/eip-1417.md
@@ -1,1 +1,7 @@
+---
+eip: 1417
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1417.md

--- a/EIPS/eip-1438.md
+++ b/EIPS/eip-1438.md
@@ -1,1 +1,7 @@
+---
+eip: 1438
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1438.md

--- a/EIPS/eip-1444.md
+++ b/EIPS/eip-1444.md
@@ -1,1 +1,7 @@
+---
+eip: 1444
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1444.md

--- a/EIPS/eip-1450.md
+++ b/EIPS/eip-1450.md
@@ -1,1 +1,7 @@
+---
+eip: 1450
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1450.md

--- a/EIPS/eip-1462.md
+++ b/EIPS/eip-1462.md
@@ -1,1 +1,7 @@
+---
+eip: 1462
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1462.md

--- a/EIPS/eip-1484.md
+++ b/EIPS/eip-1484.md
@@ -1,1 +1,7 @@
+---
+eip: 1484
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1484.md

--- a/EIPS/eip-1491.md
+++ b/EIPS/eip-1491.md
@@ -1,1 +1,7 @@
+---
+eip: 1491
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1491.md

--- a/EIPS/eip-1504.md
+++ b/EIPS/eip-1504.md
@@ -1,1 +1,7 @@
+---
+eip: 1504
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1504.md

--- a/EIPS/eip-1523.md
+++ b/EIPS/eip-1523.md
@@ -1,1 +1,7 @@
+---
+eip: 1523
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1523.md

--- a/EIPS/eip-1538.md
+++ b/EIPS/eip-1538.md
@@ -1,1 +1,7 @@
+---
+eip: 1538
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1538.md

--- a/EIPS/eip-1577.md
+++ b/EIPS/eip-1577.md
@@ -1,1 +1,7 @@
+---
+eip: 1577
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1577.md

--- a/EIPS/eip-1581.md
+++ b/EIPS/eip-1581.md
@@ -1,1 +1,7 @@
+---
+eip: 1581
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1581.md

--- a/EIPS/eip-1592.md
+++ b/EIPS/eip-1592.md
@@ -1,1 +1,7 @@
+---
+eip: 1592
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1592.md

--- a/EIPS/eip-1613.md
+++ b/EIPS/eip-1613.md
@@ -1,1 +1,7 @@
+---
+eip: 1613
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1613.md

--- a/EIPS/eip-1616.md
+++ b/EIPS/eip-1616.md
@@ -1,1 +1,7 @@
+---
+eip: 1616
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1616.md

--- a/EIPS/eip-162.md
+++ b/EIPS/eip-162.md
@@ -1,1 +1,7 @@
+---
+eip: 162
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-162.md

--- a/EIPS/eip-1620.md
+++ b/EIPS/eip-1620.md
@@ -1,1 +1,7 @@
+---
+eip: 1620
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1620.md

--- a/EIPS/eip-1633.md
+++ b/EIPS/eip-1633.md
@@ -1,1 +1,7 @@
+---
+eip: 1633
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1633.md

--- a/EIPS/eip-165.md
+++ b/EIPS/eip-165.md
@@ -1,1 +1,7 @@
+---
+eip: 165
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-165.md

--- a/EIPS/eip-1710.md
+++ b/EIPS/eip-1710.md
@@ -1,1 +1,7 @@
+---
+eip: 1710
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1710.md

--- a/EIPS/eip-173.md
+++ b/EIPS/eip-173.md
@@ -1,1 +1,7 @@
+---
+eip: 173
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-173.md

--- a/EIPS/eip-1753.md
+++ b/EIPS/eip-1753.md
@@ -1,1 +1,7 @@
+---
+eip: 1753
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1753.md

--- a/EIPS/eip-1761.md
+++ b/EIPS/eip-1761.md
@@ -1,1 +1,7 @@
+---
+eip: 1761
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1761.md

--- a/EIPS/eip-1775.md
+++ b/EIPS/eip-1775.md
@@ -1,1 +1,7 @@
+---
+eip: 1775
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1775.md

--- a/EIPS/eip-181.md
+++ b/EIPS/eip-181.md
@@ -1,1 +1,7 @@
+---
+eip: 181
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-181.md

--- a/EIPS/eip-1812.md
+++ b/EIPS/eip-1812.md
@@ -1,1 +1,7 @@
+---
+eip: 1812
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1812.md

--- a/EIPS/eip-1820.md
+++ b/EIPS/eip-1820.md
@@ -1,1 +1,7 @@
+---
+eip: 1820
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1820.md

--- a/EIPS/eip-1822.md
+++ b/EIPS/eip-1822.md
@@ -1,1 +1,7 @@
+---
+eip: 1822
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1822.md

--- a/EIPS/eip-1844.md
+++ b/EIPS/eip-1844.md
@@ -1,1 +1,7 @@
+---
+eip: 1844
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1844.md

--- a/EIPS/eip-190.md
+++ b/EIPS/eip-190.md
@@ -1,1 +1,7 @@
+---
+eip: 190
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-190.md

--- a/EIPS/eip-1900.md
+++ b/EIPS/eip-1900.md
@@ -1,1 +1,7 @@
+---
+eip: 1900
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1900.md

--- a/EIPS/eip-191.md
+++ b/EIPS/eip-191.md
@@ -1,1 +1,7 @@
+---
+eip: 191
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-191.md

--- a/EIPS/eip-1921.md
+++ b/EIPS/eip-1921.md
@@ -1,1 +1,7 @@
+---
+eip: 1921
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1921.md

--- a/EIPS/eip-1922.md
+++ b/EIPS/eip-1922.md
@@ -1,1 +1,7 @@
+---
+eip: 1922
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1922.md

--- a/EIPS/eip-1923.md
+++ b/EIPS/eip-1923.md
@@ -1,1 +1,7 @@
+---
+eip: 1923
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1923.md

--- a/EIPS/eip-1948.md
+++ b/EIPS/eip-1948.md
@@ -1,1 +1,7 @@
+---
+eip: 1948
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1948.md

--- a/EIPS/eip-1967.md
+++ b/EIPS/eip-1967.md
@@ -1,1 +1,7 @@
+---
+eip: 1967
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1967.md

--- a/EIPS/eip-1973.md
+++ b/EIPS/eip-1973.md
@@ -1,1 +1,7 @@
+---
+eip: 1973
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1973.md

--- a/EIPS/eip-1996.md
+++ b/EIPS/eip-1996.md
@@ -1,1 +1,7 @@
+---
+eip: 1996
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-1996.md

--- a/EIPS/eip-20.md
+++ b/EIPS/eip-20.md
@@ -1,1 +1,7 @@
+---
+eip: 20
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-20.md

--- a/EIPS/eip-2009.md
+++ b/EIPS/eip-2009.md
@@ -1,1 +1,7 @@
+---
+eip: 2009
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2009.md

--- a/EIPS/eip-2018.md
+++ b/EIPS/eip-2018.md
@@ -1,1 +1,7 @@
+---
+eip: 2018
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2018.md

--- a/EIPS/eip-2019.md
+++ b/EIPS/eip-2019.md
@@ -1,1 +1,7 @@
+---
+eip: 2019
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2019.md

--- a/EIPS/eip-2020.md
+++ b/EIPS/eip-2020.md
@@ -1,1 +1,7 @@
+---
+eip: 2020
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2020.md

--- a/EIPS/eip-2021.md
+++ b/EIPS/eip-2021.md
@@ -1,1 +1,7 @@
+---
+eip: 2021
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2021.md

--- a/EIPS/eip-205.md
+++ b/EIPS/eip-205.md
@@ -1,1 +1,7 @@
+---
+eip: 205
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-205.md

--- a/EIPS/eip-2098.md
+++ b/EIPS/eip-2098.md
@@ -1,1 +1,7 @@
+---
+eip: 2098
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2098.md

--- a/EIPS/eip-2135.md
+++ b/EIPS/eip-2135.md
@@ -1,1 +1,7 @@
+---
+eip: 2135
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2135.md

--- a/EIPS/eip-2157.md
+++ b/EIPS/eip-2157.md
@@ -1,1 +1,7 @@
+---
+eip: 2157
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2157.md

--- a/EIPS/eip-2193.md
+++ b/EIPS/eip-2193.md
@@ -1,1 +1,7 @@
+---
+eip: 2193
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2193.md

--- a/EIPS/eip-223.md
+++ b/EIPS/eip-223.md
@@ -1,1 +1,7 @@
+---
+eip: 223
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-223.md

--- a/EIPS/eip-2266.md
+++ b/EIPS/eip-2266.md
@@ -1,1 +1,7 @@
+---
+eip: 2266
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2266.md

--- a/EIPS/eip-2304.md
+++ b/EIPS/eip-2304.md
@@ -1,1 +1,7 @@
+---
+eip: 2304
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2304.md

--- a/EIPS/eip-2309.md
+++ b/EIPS/eip-2309.md
@@ -1,1 +1,7 @@
+---
+eip: 2309
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2309.md

--- a/EIPS/eip-2333.md
+++ b/EIPS/eip-2333.md
@@ -1,1 +1,7 @@
+---
+eip: 2333
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2333.md

--- a/EIPS/eip-2334.md
+++ b/EIPS/eip-2334.md
@@ -1,1 +1,7 @@
+---
+eip: 2334
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2334.md

--- a/EIPS/eip-2335.md
+++ b/EIPS/eip-2335.md
@@ -1,1 +1,7 @@
+---
+eip: 2335
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2335.md

--- a/EIPS/eip-2386.md
+++ b/EIPS/eip-2386.md
@@ -1,1 +1,7 @@
+---
+eip: 2386
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2386.md

--- a/EIPS/eip-2390.md
+++ b/EIPS/eip-2390.md
@@ -1,1 +1,7 @@
+---
+eip: 2390
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2390.md

--- a/EIPS/eip-2400.md
+++ b/EIPS/eip-2400.md
@@ -1,1 +1,7 @@
+---
+eip: 2400
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2400.md

--- a/EIPS/eip-2470.md
+++ b/EIPS/eip-2470.md
@@ -1,1 +1,7 @@
+---
+eip: 2470
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2470.md

--- a/EIPS/eip-2477.md
+++ b/EIPS/eip-2477.md
@@ -1,1 +1,7 @@
+---
+eip: 2477
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2477.md

--- a/EIPS/eip-2494.md
+++ b/EIPS/eip-2494.md
@@ -1,1 +1,7 @@
+---
+eip: 2494
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2494.md

--- a/EIPS/eip-2520.md
+++ b/EIPS/eip-2520.md
@@ -1,1 +1,7 @@
+---
+eip: 2520
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2520.md

--- a/EIPS/eip-2525.md
+++ b/EIPS/eip-2525.md
@@ -1,1 +1,7 @@
+---
+eip: 2525
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2525.md

--- a/EIPS/eip-2535.md
+++ b/EIPS/eip-2535.md
@@ -1,1 +1,7 @@
+---
+eip: 2535
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2535.md

--- a/EIPS/eip-2544.md
+++ b/EIPS/eip-2544.md
@@ -1,1 +1,7 @@
+---
+eip: 2544
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2544.md

--- a/EIPS/eip-2569.md
+++ b/EIPS/eip-2569.md
@@ -1,1 +1,7 @@
+---
+eip: 2569
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2569.md

--- a/EIPS/eip-2612.md
+++ b/EIPS/eip-2612.md
@@ -1,1 +1,7 @@
+---
+eip: 2612
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2612.md

--- a/EIPS/eip-2615.md
+++ b/EIPS/eip-2615.md
@@ -1,1 +1,7 @@
+---
+eip: 2615
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2615.md

--- a/EIPS/eip-2645.md
+++ b/EIPS/eip-2645.md
@@ -1,1 +1,7 @@
+---
+eip: 2645
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2645.md

--- a/EIPS/eip-2678.md
+++ b/EIPS/eip-2678.md
@@ -1,1 +1,7 @@
+---
+eip: 2678
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2678.md

--- a/EIPS/eip-2680.md
+++ b/EIPS/eip-2680.md
@@ -1,1 +1,7 @@
+---
+eip: 2680
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2680.md

--- a/EIPS/eip-2746.md
+++ b/EIPS/eip-2746.md
@@ -1,1 +1,7 @@
+---
+eip: 2746
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2746.md

--- a/EIPS/eip-2767.md
+++ b/EIPS/eip-2767.md
@@ -1,1 +1,7 @@
+---
+eip: 2767
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2767.md

--- a/EIPS/eip-2770.md
+++ b/EIPS/eip-2770.md
@@ -1,1 +1,7 @@
+---
+eip: 2770
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2770.md

--- a/EIPS/eip-2771.md
+++ b/EIPS/eip-2771.md
@@ -1,1 +1,7 @@
+---
+eip: 2771
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2771.md

--- a/EIPS/eip-2848.md
+++ b/EIPS/eip-2848.md
@@ -1,1 +1,7 @@
+---
+eip: 2848
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2848.md

--- a/EIPS/eip-2876.md
+++ b/EIPS/eip-2876.md
@@ -1,1 +1,7 @@
+---
+eip: 2876
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2876.md

--- a/EIPS/eip-2917.md
+++ b/EIPS/eip-2917.md
@@ -1,1 +1,7 @@
+---
+eip: 2917
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2917.md

--- a/EIPS/eip-2942.md
+++ b/EIPS/eip-2942.md
@@ -1,1 +1,7 @@
+---
+eip: 2942
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2942.md

--- a/EIPS/eip-2980.md
+++ b/EIPS/eip-2980.md
@@ -1,1 +1,7 @@
+---
+eip: 2980
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2980.md

--- a/EIPS/eip-2981.md
+++ b/EIPS/eip-2981.md
@@ -1,1 +1,7 @@
+---
+eip: 2981
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-2981.md

--- a/EIPS/eip-3000.md
+++ b/EIPS/eip-3000.md
@@ -1,1 +1,7 @@
+---
+eip: 3000
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-3000.md

--- a/EIPS/eip-3005.md
+++ b/EIPS/eip-3005.md
@@ -1,1 +1,7 @@
+---
+eip: 3005
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-3005.md

--- a/EIPS/eip-3009.md
+++ b/EIPS/eip-3009.md
@@ -1,1 +1,7 @@
+---
+eip: 3009
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-3009.md

--- a/EIPS/eip-3135.md
+++ b/EIPS/eip-3135.md
@@ -1,1 +1,7 @@
+---
+eip: 3135
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-3135.md

--- a/EIPS/eip-3156.md
+++ b/EIPS/eip-3156.md
@@ -1,1 +1,7 @@
+---
+eip: 3156
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-3156.md

--- a/EIPS/eip-3224.md
+++ b/EIPS/eip-3224.md
@@ -1,1 +1,7 @@
+---
+eip: 3224
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-3224.md

--- a/EIPS/eip-3234.md
+++ b/EIPS/eip-3234.md
@@ -1,1 +1,7 @@
+---
+eip: 3234
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-3234.md

--- a/EIPS/eip-3386.md
+++ b/EIPS/eip-3386.md
@@ -1,1 +1,7 @@
+---
+eip: 3386
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-3386.md

--- a/EIPS/eip-3440.md
+++ b/EIPS/eip-3440.md
@@ -1,1 +1,7 @@
+---
+eip: 3440
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-3440.md

--- a/EIPS/eip-3448.md
+++ b/EIPS/eip-3448.md
@@ -1,1 +1,7 @@
+---
+eip: 3448
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-3448.md

--- a/EIPS/eip-3450.md
+++ b/EIPS/eip-3450.md
@@ -1,1 +1,7 @@
+---
+eip: 3450
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-3450.md

--- a/EIPS/eip-3475.md
+++ b/EIPS/eip-3475.md
@@ -1,1 +1,7 @@
+---
+eip: 3475
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-3475.md

--- a/EIPS/eip-3525.md
+++ b/EIPS/eip-3525.md
@@ -1,1 +1,7 @@
+---
+eip: 3525
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-3525.md

--- a/EIPS/eip-3561.md
+++ b/EIPS/eip-3561.md
@@ -1,1 +1,7 @@
+---
+eip: 3561
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-3561.md

--- a/EIPS/eip-3569.md
+++ b/EIPS/eip-3569.md
@@ -1,1 +1,7 @@
+---
+eip: 3569
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-3569.md

--- a/EIPS/eip-3589.md
+++ b/EIPS/eip-3589.md
@@ -1,1 +1,7 @@
+---
+eip: 3589
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-3589.md

--- a/EIPS/eip-3643.md
+++ b/EIPS/eip-3643.md
@@ -1,1 +1,7 @@
+---
+eip: 3643
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-3643.md

--- a/EIPS/eip-3668.md
+++ b/EIPS/eip-3668.md
@@ -1,1 +1,7 @@
+---
+eip: 3668
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-3668.md

--- a/EIPS/eip-3722.md
+++ b/EIPS/eip-3722.md
@@ -1,1 +1,7 @@
+---
+eip: 3722
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-3722.md

--- a/EIPS/eip-3754.md
+++ b/EIPS/eip-3754.md
@@ -1,1 +1,7 @@
+---
+eip: 3754
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-3754.md

--- a/EIPS/eip-3770.md
+++ b/EIPS/eip-3770.md
@@ -1,1 +1,7 @@
+---
+eip: 3770
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-3770.md

--- a/EIPS/eip-3772.md
+++ b/EIPS/eip-3772.md
@@ -1,1 +1,7 @@
+---
+eip: 3772
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-3772.md

--- a/EIPS/eip-4337.md
+++ b/EIPS/eip-4337.md
@@ -1,1 +1,7 @@
+---
+eip: 4337
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4337.md

--- a/EIPS/eip-4341.md
+++ b/EIPS/eip-4341.md
@@ -1,1 +1,7 @@
+---
+eip: 4341
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4341.md

--- a/EIPS/eip-4353.md
+++ b/EIPS/eip-4353.md
@@ -1,1 +1,7 @@
+---
+eip: 4353
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4353.md

--- a/EIPS/eip-4361.md
+++ b/EIPS/eip-4361.md
@@ -1,1 +1,7 @@
+---
+eip: 4361
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4361.md

--- a/EIPS/eip-4393.md
+++ b/EIPS/eip-4393.md
@@ -1,1 +1,7 @@
+---
+eip: 4393
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4393.md

--- a/EIPS/eip-4400.md
+++ b/EIPS/eip-4400.md
@@ -1,1 +1,7 @@
+---
+eip: 4400
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4400.md

--- a/EIPS/eip-4430.md
+++ b/EIPS/eip-4430.md
@@ -1,1 +1,7 @@
+---
+eip: 4430
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4430.md

--- a/EIPS/eip-4494.md
+++ b/EIPS/eip-4494.md
@@ -1,1 +1,7 @@
+---
+eip: 4494
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4494.md

--- a/EIPS/eip-4519.md
+++ b/EIPS/eip-4519.md
@@ -1,1 +1,7 @@
+---
+eip: 4519
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4519.md

--- a/EIPS/eip-4521.md
+++ b/EIPS/eip-4521.md
@@ -1,1 +1,7 @@
+---
+eip: 4521
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4521.md

--- a/EIPS/eip-4524.md
+++ b/EIPS/eip-4524.md
@@ -1,1 +1,7 @@
+---
+eip: 4524
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4524.md

--- a/EIPS/eip-4527.md
+++ b/EIPS/eip-4527.md
@@ -1,1 +1,7 @@
+---
+eip: 4527
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4527.md

--- a/EIPS/eip-4546.md
+++ b/EIPS/eip-4546.md
@@ -1,1 +1,7 @@
+---
+eip: 4546
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4546.md

--- a/EIPS/eip-4626.md
+++ b/EIPS/eip-4626.md
@@ -1,1 +1,7 @@
+---
+eip: 4626
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4626.md

--- a/EIPS/eip-4671.md
+++ b/EIPS/eip-4671.md
@@ -1,1 +1,7 @@
+---
+eip: 4671
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4671.md

--- a/EIPS/eip-4675.md
+++ b/EIPS/eip-4675.md
@@ -1,1 +1,7 @@
+---
+eip: 4675
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4675.md

--- a/EIPS/eip-4799.md
+++ b/EIPS/eip-4799.md
@@ -1,1 +1,7 @@
+---
+eip: 4799
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4799.md

--- a/EIPS/eip-4804.md
+++ b/EIPS/eip-4804.md
@@ -1,1 +1,7 @@
+---
+eip: 4804
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4804.md

--- a/EIPS/eip-4824.md
+++ b/EIPS/eip-4824.md
@@ -1,1 +1,7 @@
+---
+eip: 4824
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4824.md

--- a/EIPS/eip-4834.md
+++ b/EIPS/eip-4834.md
@@ -1,1 +1,7 @@
+---
+eip: 4834
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4834.md

--- a/EIPS/eip-4883.md
+++ b/EIPS/eip-4883.md
@@ -1,1 +1,7 @@
+---
+eip: 4883
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4883.md

--- a/EIPS/eip-4885.md
+++ b/EIPS/eip-4885.md
@@ -1,1 +1,7 @@
+---
+eip: 4885
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4885.md

--- a/EIPS/eip-4886.md
+++ b/EIPS/eip-4886.md
@@ -1,1 +1,7 @@
+---
+eip: 4886
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4886.md

--- a/EIPS/eip-4906.md
+++ b/EIPS/eip-4906.md
@@ -1,1 +1,7 @@
+---
+eip: 4906
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4906.md

--- a/EIPS/eip-4907.md
+++ b/EIPS/eip-4907.md
@@ -1,1 +1,7 @@
+---
+eip: 4907
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4907.md

--- a/EIPS/eip-4910.md
+++ b/EIPS/eip-4910.md
@@ -1,1 +1,7 @@
+---
+eip: 4910
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4910.md

--- a/EIPS/eip-4931.md
+++ b/EIPS/eip-4931.md
@@ -1,1 +1,7 @@
+---
+eip: 4931
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4931.md

--- a/EIPS/eip-4944.md
+++ b/EIPS/eip-4944.md
@@ -1,1 +1,7 @@
+---
+eip: 4944
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4944.md

--- a/EIPS/eip-4950.md
+++ b/EIPS/eip-4950.md
@@ -1,1 +1,7 @@
+---
+eip: 4950
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4950.md

--- a/EIPS/eip-4955.md
+++ b/EIPS/eip-4955.md
@@ -1,1 +1,7 @@
+---
+eip: 4955
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4955.md

--- a/EIPS/eip-4972.md
+++ b/EIPS/eip-4972.md
@@ -1,1 +1,7 @@
+---
+eip: 4972
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4972.md

--- a/EIPS/eip-4973.md
+++ b/EIPS/eip-4973.md
@@ -1,1 +1,7 @@
+---
+eip: 4973
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4973.md

--- a/EIPS/eip-4974.md
+++ b/EIPS/eip-4974.md
@@ -1,1 +1,7 @@
+---
+eip: 4974
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4974.md

--- a/EIPS/eip-4987.md
+++ b/EIPS/eip-4987.md
@@ -1,1 +1,7 @@
+---
+eip: 4987
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-4987.md

--- a/EIPS/eip-5005.md
+++ b/EIPS/eip-5005.md
@@ -1,1 +1,7 @@
+---
+eip: 5005
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5005.md

--- a/EIPS/eip-5006.md
+++ b/EIPS/eip-5006.md
@@ -1,1 +1,7 @@
+---
+eip: 5006
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5006.md

--- a/EIPS/eip-5007.md
+++ b/EIPS/eip-5007.md
@@ -1,1 +1,7 @@
+---
+eip: 5007
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5007.md

--- a/EIPS/eip-5008.md
+++ b/EIPS/eip-5008.md
@@ -1,1 +1,7 @@
+---
+eip: 5008
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5008.md

--- a/EIPS/eip-5018.md
+++ b/EIPS/eip-5018.md
@@ -1,1 +1,7 @@
+---
+eip: 5018
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5018.md

--- a/EIPS/eip-5023.md
+++ b/EIPS/eip-5023.md
@@ -1,1 +1,7 @@
+---
+eip: 5023
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5023.md

--- a/EIPS/eip-5050.md
+++ b/EIPS/eip-5050.md
@@ -1,1 +1,7 @@
+---
+eip: 5050
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5050.md

--- a/EIPS/eip-5058.md
+++ b/EIPS/eip-5058.md
@@ -1,1 +1,7 @@
+---
+eip: 5058
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5058.md

--- a/EIPS/eip-5094.md
+++ b/EIPS/eip-5094.md
@@ -1,1 +1,7 @@
+---
+eip: 5094
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5094.md

--- a/EIPS/eip-5095.md
+++ b/EIPS/eip-5095.md
@@ -1,1 +1,7 @@
+---
+eip: 5095
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5095.md

--- a/EIPS/eip-5114.md
+++ b/EIPS/eip-5114.md
@@ -1,1 +1,7 @@
+---
+eip: 5114
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5114.md

--- a/EIPS/eip-5115.md
+++ b/EIPS/eip-5115.md
@@ -1,1 +1,7 @@
+---
+eip: 5115
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5115.md

--- a/EIPS/eip-5131.md
+++ b/EIPS/eip-5131.md
@@ -1,1 +1,7 @@
+---
+eip: 5131
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5131.md

--- a/EIPS/eip-5139.md
+++ b/EIPS/eip-5139.md
@@ -1,1 +1,7 @@
+---
+eip: 5139
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5139.md

--- a/EIPS/eip-5143.md
+++ b/EIPS/eip-5143.md
@@ -1,1 +1,7 @@
+---
+eip: 5143
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5143.md

--- a/EIPS/eip-5164.md
+++ b/EIPS/eip-5164.md
@@ -1,1 +1,7 @@
+---
+eip: 5164
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5164.md

--- a/EIPS/eip-5169.md
+++ b/EIPS/eip-5169.md
@@ -1,1 +1,7 @@
+---
+eip: 5169
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5169.md

--- a/EIPS/eip-5173.md
+++ b/EIPS/eip-5173.md
@@ -1,1 +1,7 @@
+---
+eip: 5173
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5173.md

--- a/EIPS/eip-5185.md
+++ b/EIPS/eip-5185.md
@@ -1,1 +1,7 @@
+---
+eip: 5185
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5185.md

--- a/EIPS/eip-5187.md
+++ b/EIPS/eip-5187.md
@@ -1,1 +1,7 @@
+---
+eip: 5187
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5187.md

--- a/EIPS/eip-5189.md
+++ b/EIPS/eip-5189.md
@@ -1,1 +1,7 @@
+---
+eip: 5189
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5189.md

--- a/EIPS/eip-5192.md
+++ b/EIPS/eip-5192.md
@@ -1,1 +1,7 @@
+---
+eip: 5192
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5192.md

--- a/EIPS/eip-5202.md
+++ b/EIPS/eip-5202.md
@@ -1,1 +1,7 @@
+---
+eip: 5202
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5202.md

--- a/EIPS/eip-5216.md
+++ b/EIPS/eip-5216.md
@@ -1,1 +1,7 @@
+---
+eip: 5216
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5216.md

--- a/EIPS/eip-5218.md
+++ b/EIPS/eip-5218.md
@@ -1,1 +1,7 @@
+---
+eip: 5218
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5218.md

--- a/EIPS/eip-5219.md
+++ b/EIPS/eip-5219.md
@@ -1,1 +1,7 @@
+---
+eip: 5219
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5219.md

--- a/EIPS/eip-5247.md
+++ b/EIPS/eip-5247.md
@@ -1,1 +1,7 @@
+---
+eip: 5247
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5247.md

--- a/EIPS/eip-5252.md
+++ b/EIPS/eip-5252.md
@@ -1,1 +1,7 @@
+---
+eip: 5252
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5252.md

--- a/EIPS/eip-5267.md
+++ b/EIPS/eip-5267.md
@@ -1,1 +1,7 @@
+---
+eip: 5267
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5267.md

--- a/EIPS/eip-5269.md
+++ b/EIPS/eip-5269.md
@@ -1,1 +1,7 @@
+---
+eip: 5269
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5269.md

--- a/EIPS/eip-5289.md
+++ b/EIPS/eip-5289.md
@@ -1,1 +1,7 @@
+---
+eip: 5289
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5289.md

--- a/EIPS/eip-5298.md
+++ b/EIPS/eip-5298.md
@@ -1,1 +1,7 @@
+---
+eip: 5298
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5298.md

--- a/EIPS/eip-5313.md
+++ b/EIPS/eip-5313.md
@@ -1,1 +1,7 @@
+---
+eip: 5313
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5313.md

--- a/EIPS/eip-5334.md
+++ b/EIPS/eip-5334.md
@@ -1,1 +1,7 @@
+---
+eip: 5334
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5334.md

--- a/EIPS/eip-5375.md
+++ b/EIPS/eip-5375.md
@@ -1,1 +1,7 @@
+---
+eip: 5375
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5375.md

--- a/EIPS/eip-5380.md
+++ b/EIPS/eip-5380.md
@@ -1,1 +1,7 @@
+---
+eip: 5380
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5380.md

--- a/EIPS/eip-5409.md
+++ b/EIPS/eip-5409.md
@@ -1,1 +1,7 @@
+---
+eip: 5409
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5409.md

--- a/EIPS/eip-5437.md
+++ b/EIPS/eip-5437.md
@@ -1,1 +1,7 @@
+---
+eip: 5437
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5437.md

--- a/EIPS/eip-5453.md
+++ b/EIPS/eip-5453.md
@@ -1,1 +1,7 @@
+---
+eip: 5453
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5453.md

--- a/EIPS/eip-5484.md
+++ b/EIPS/eip-5484.md
@@ -1,1 +1,7 @@
+---
+eip: 5484
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5484.md

--- a/EIPS/eip-5485.md
+++ b/EIPS/eip-5485.md
@@ -1,1 +1,7 @@
+---
+eip: 5485
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5485.md

--- a/EIPS/eip-5489.md
+++ b/EIPS/eip-5489.md
@@ -1,1 +1,7 @@
+---
+eip: 5489
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5489.md

--- a/EIPS/eip-5496.md
+++ b/EIPS/eip-5496.md
@@ -1,1 +1,7 @@
+---
+eip: 5496
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5496.md

--- a/EIPS/eip-55.md
+++ b/EIPS/eip-55.md
@@ -1,1 +1,7 @@
+---
+eip: 55
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-55.md

--- a/EIPS/eip-5501.md
+++ b/EIPS/eip-5501.md
@@ -1,1 +1,7 @@
+---
+eip: 5501
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5501.md

--- a/EIPS/eip-5505.md
+++ b/EIPS/eip-5505.md
@@ -1,1 +1,7 @@
+---
+eip: 5505
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5505.md

--- a/EIPS/eip-5507.md
+++ b/EIPS/eip-5507.md
@@ -1,1 +1,7 @@
+---
+eip: 5507
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5507.md

--- a/EIPS/eip-5516.md
+++ b/EIPS/eip-5516.md
@@ -1,1 +1,7 @@
+---
+eip: 5516
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5516.md

--- a/EIPS/eip-5521.md
+++ b/EIPS/eip-5521.md
@@ -1,1 +1,7 @@
+---
+eip: 5521
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5521.md

--- a/EIPS/eip-5528.md
+++ b/EIPS/eip-5528.md
@@ -1,1 +1,7 @@
+---
+eip: 5528
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5528.md

--- a/EIPS/eip-5539.md
+++ b/EIPS/eip-5539.md
@@ -1,1 +1,7 @@
+---
+eip: 5539
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5539.md

--- a/EIPS/eip-5553.md
+++ b/EIPS/eip-5553.md
@@ -1,1 +1,7 @@
+---
+eip: 5553
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5553.md

--- a/EIPS/eip-5554.md
+++ b/EIPS/eip-5554.md
@@ -1,1 +1,7 @@
+---
+eip: 5554
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5554.md

--- a/EIPS/eip-5559.md
+++ b/EIPS/eip-5559.md
@@ -1,1 +1,7 @@
+---
+eip: 5559
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5559.md

--- a/EIPS/eip-5560.md
+++ b/EIPS/eip-5560.md
@@ -1,1 +1,7 @@
+---
+eip: 5560
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5560.md

--- a/EIPS/eip-5564.md
+++ b/EIPS/eip-5564.md
@@ -1,1 +1,7 @@
+---
+eip: 5564
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5564.md

--- a/EIPS/eip-5568.md
+++ b/EIPS/eip-5568.md
@@ -1,1 +1,7 @@
+---
+eip: 5568
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5568.md

--- a/EIPS/eip-5570.md
+++ b/EIPS/eip-5570.md
@@ -1,1 +1,7 @@
+---
+eip: 5570
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5570.md

--- a/EIPS/eip-5573.md
+++ b/EIPS/eip-5573.md
@@ -1,1 +1,7 @@
+---
+eip: 5573
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5573.md

--- a/EIPS/eip-5585.md
+++ b/EIPS/eip-5585.md
@@ -1,1 +1,7 @@
+---
+eip: 5585
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5585.md

--- a/EIPS/eip-5604.md
+++ b/EIPS/eip-5604.md
@@ -1,1 +1,7 @@
+---
+eip: 5604
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5604.md

--- a/EIPS/eip-5606.md
+++ b/EIPS/eip-5606.md
@@ -1,1 +1,7 @@
+---
+eip: 5606
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5606.md

--- a/EIPS/eip-5615.md
+++ b/EIPS/eip-5615.md
@@ -1,1 +1,7 @@
+---
+eip: 5615
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5615.md

--- a/EIPS/eip-5625.md
+++ b/EIPS/eip-5625.md
@@ -1,1 +1,7 @@
+---
+eip: 5625
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5625.md

--- a/EIPS/eip-5630.md
+++ b/EIPS/eip-5630.md
@@ -1,1 +1,7 @@
+---
+eip: 5630
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5630.md

--- a/EIPS/eip-5633.md
+++ b/EIPS/eip-5633.md
@@ -1,1 +1,7 @@
+---
+eip: 5633
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5633.md

--- a/EIPS/eip-5635.md
+++ b/EIPS/eip-5635.md
@@ -1,1 +1,7 @@
+---
+eip: 5635
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5635.md

--- a/EIPS/eip-5639.md
+++ b/EIPS/eip-5639.md
@@ -1,1 +1,7 @@
+---
+eip: 5639
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5639.md

--- a/EIPS/eip-5643.md
+++ b/EIPS/eip-5643.md
@@ -1,1 +1,7 @@
+---
+eip: 5643
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5643.md

--- a/EIPS/eip-5646.md
+++ b/EIPS/eip-5646.md
@@ -1,1 +1,7 @@
+---
+eip: 5646
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5646.md

--- a/EIPS/eip-5679.md
+++ b/EIPS/eip-5679.md
@@ -1,1 +1,7 @@
+---
+eip: 5679
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5679.md

--- a/EIPS/eip-5700.md
+++ b/EIPS/eip-5700.md
@@ -1,1 +1,7 @@
+---
+eip: 5700
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5700.md

--- a/EIPS/eip-5719.md
+++ b/EIPS/eip-5719.md
@@ -1,1 +1,7 @@
+---
+eip: 5719
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5719.md

--- a/EIPS/eip-5725.md
+++ b/EIPS/eip-5725.md
@@ -1,1 +1,7 @@
+---
+eip: 5725
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5725.md

--- a/EIPS/eip-5727.md
+++ b/EIPS/eip-5727.md
@@ -1,1 +1,7 @@
+---
+eip: 5727
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5727.md

--- a/EIPS/eip-5732.md
+++ b/EIPS/eip-5732.md
@@ -1,1 +1,7 @@
+---
+eip: 5732
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5732.md

--- a/EIPS/eip-5744.md
+++ b/EIPS/eip-5744.md
@@ -1,1 +1,7 @@
+---
+eip: 5744
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5744.md

--- a/EIPS/eip-5750.md
+++ b/EIPS/eip-5750.md
@@ -1,1 +1,7 @@
+---
+eip: 5750
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5750.md

--- a/EIPS/eip-5753.md
+++ b/EIPS/eip-5753.md
@@ -1,1 +1,7 @@
+---
+eip: 5753
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5753.md

--- a/EIPS/eip-5773.md
+++ b/EIPS/eip-5773.md
@@ -1,1 +1,7 @@
+---
+eip: 5773
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5773.md

--- a/EIPS/eip-5791.md
+++ b/EIPS/eip-5791.md
@@ -1,1 +1,7 @@
+---
+eip: 5791
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5791.md

--- a/EIPS/eip-5805.md
+++ b/EIPS/eip-5805.md
@@ -1,1 +1,7 @@
+---
+eip: 5805
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5805.md

--- a/EIPS/eip-5827.md
+++ b/EIPS/eip-5827.md
@@ -1,1 +1,7 @@
+---
+eip: 5827
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5827.md

--- a/EIPS/eip-5850.md
+++ b/EIPS/eip-5850.md
@@ -1,1 +1,7 @@
+---
+eip: 5850
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5850.md

--- a/EIPS/eip-5851.md
+++ b/EIPS/eip-5851.md
@@ -1,1 +1,7 @@
+---
+eip: 5851
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5851.md

--- a/EIPS/eip-5883.md
+++ b/EIPS/eip-5883.md
@@ -1,1 +1,7 @@
+---
+eip: 5883
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5883.md

--- a/EIPS/eip-5902.md
+++ b/EIPS/eip-5902.md
@@ -1,1 +1,7 @@
+---
+eip: 5902
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5902.md

--- a/EIPS/eip-5982.md
+++ b/EIPS/eip-5982.md
@@ -1,1 +1,7 @@
+---
+eip: 5982
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-5982.md

--- a/EIPS/eip-600.md
+++ b/EIPS/eip-600.md
@@ -1,1 +1,7 @@
+---
+eip: 600
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-600.md

--- a/EIPS/eip-601.md
+++ b/EIPS/eip-601.md
@@ -1,1 +1,7 @@
+---
+eip: 601
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-601.md

--- a/EIPS/eip-6047.md
+++ b/EIPS/eip-6047.md
@@ -1,1 +1,7 @@
+---
+eip: 6047
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6047.md

--- a/EIPS/eip-6059.md
+++ b/EIPS/eip-6059.md
@@ -1,1 +1,7 @@
+---
+eip: 6059
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6059.md

--- a/EIPS/eip-6065.md
+++ b/EIPS/eip-6065.md
@@ -1,1 +1,7 @@
+---
+eip: 6065
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6065.md

--- a/EIPS/eip-6066.md
+++ b/EIPS/eip-6066.md
@@ -1,1 +1,7 @@
+---
+eip: 6066
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6066.md

--- a/EIPS/eip-6093.md
+++ b/EIPS/eip-6093.md
@@ -1,1 +1,7 @@
+---
+eip: 6093
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6093.md

--- a/EIPS/eip-6105.md
+++ b/EIPS/eip-6105.md
@@ -1,1 +1,7 @@
+---
+eip: 6105
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6105.md

--- a/EIPS/eip-6120.md
+++ b/EIPS/eip-6120.md
@@ -1,1 +1,7 @@
+---
+eip: 6120
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6120.md

--- a/EIPS/eip-6123.md
+++ b/EIPS/eip-6123.md
@@ -1,1 +1,7 @@
+---
+eip: 6123
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6123.md

--- a/EIPS/eip-6147.md
+++ b/EIPS/eip-6147.md
@@ -1,1 +1,7 @@
+---
+eip: 6147
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6147.md

--- a/EIPS/eip-6150.md
+++ b/EIPS/eip-6150.md
@@ -1,1 +1,7 @@
+---
+eip: 6150
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6150.md

--- a/EIPS/eip-6170.md
+++ b/EIPS/eip-6170.md
@@ -1,1 +1,7 @@
+---
+eip: 6170
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6170.md

--- a/EIPS/eip-6220.md
+++ b/EIPS/eip-6220.md
@@ -1,1 +1,7 @@
+---
+eip: 6220
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6220.md

--- a/EIPS/eip-6224.md
+++ b/EIPS/eip-6224.md
@@ -1,1 +1,7 @@
+---
+eip: 6224
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6224.md

--- a/EIPS/eip-6239.md
+++ b/EIPS/eip-6239.md
@@ -1,1 +1,7 @@
+---
+eip: 6239
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6239.md

--- a/EIPS/eip-6268.md
+++ b/EIPS/eip-6268.md
@@ -1,1 +1,7 @@
+---
+eip: 6268
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6268.md

--- a/EIPS/eip-6315.md
+++ b/EIPS/eip-6315.md
@@ -1,1 +1,7 @@
+---
+eip: 6315
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6315.md

--- a/EIPS/eip-6327.md
+++ b/EIPS/eip-6327.md
@@ -1,1 +1,7 @@
+---
+eip: 6327
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6327.md

--- a/EIPS/eip-634.md
+++ b/EIPS/eip-634.md
@@ -1,1 +1,7 @@
+---
+eip: 634
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-634.md

--- a/EIPS/eip-6353.md
+++ b/EIPS/eip-6353.md
@@ -1,1 +1,7 @@
+---
+eip: 6353
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6353.md

--- a/EIPS/eip-6357.md
+++ b/EIPS/eip-6357.md
@@ -1,1 +1,7 @@
+---
+eip: 6357
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6357.md

--- a/EIPS/eip-6358.md
+++ b/EIPS/eip-6358.md
@@ -1,1 +1,7 @@
+---
+eip: 6358
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6358.md

--- a/EIPS/eip-6366.md
+++ b/EIPS/eip-6366.md
@@ -1,1 +1,7 @@
+---
+eip: 6366
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6366.md

--- a/EIPS/eip-6372.md
+++ b/EIPS/eip-6372.md
@@ -1,1 +1,7 @@
+---
+eip: 6372
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6372.md

--- a/EIPS/eip-6381.md
+++ b/EIPS/eip-6381.md
@@ -1,1 +1,7 @@
+---
+eip: 6381
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6381.md

--- a/EIPS/eip-6384.md
+++ b/EIPS/eip-6384.md
@@ -1,1 +1,7 @@
+---
+eip: 6384
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6384.md

--- a/EIPS/eip-6454.md
+++ b/EIPS/eip-6454.md
@@ -1,1 +1,7 @@
+---
+eip: 6454
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6454.md

--- a/EIPS/eip-6464.md
+++ b/EIPS/eip-6464.md
@@ -1,1 +1,7 @@
+---
+eip: 6464
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6464.md

--- a/EIPS/eip-6492.md
+++ b/EIPS/eip-6492.md
@@ -1,1 +1,7 @@
+---
+eip: 6492
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6492.md

--- a/EIPS/eip-6506.md
+++ b/EIPS/eip-6506.md
@@ -1,1 +1,7 @@
+---
+eip: 6506
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6506.md

--- a/EIPS/eip-6538.md
+++ b/EIPS/eip-6538.md
@@ -1,1 +1,7 @@
+---
+eip: 6538
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6538.md

--- a/EIPS/eip-6551.md
+++ b/EIPS/eip-6551.md
@@ -1,1 +1,7 @@
+---
+eip: 6551
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6551.md

--- a/EIPS/eip-6596.md
+++ b/EIPS/eip-6596.md
@@ -1,1 +1,7 @@
+---
+eip: 6596
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6596.md

--- a/EIPS/eip-6604.md
+++ b/EIPS/eip-6604.md
@@ -1,1 +1,7 @@
+---
+eip: 6604
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6604.md

--- a/EIPS/eip-6617.md
+++ b/EIPS/eip-6617.md
@@ -1,1 +1,7 @@
+---
+eip: 6617
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6617.md

--- a/EIPS/eip-6662.md
+++ b/EIPS/eip-6662.md
@@ -1,1 +1,7 @@
+---
+eip: 6662
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6662.md

--- a/EIPS/eip-6672.md
+++ b/EIPS/eip-6672.md
@@ -1,1 +1,7 @@
+---
+eip: 6672
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6672.md

--- a/EIPS/eip-6682.md
+++ b/EIPS/eip-6682.md
@@ -1,1 +1,7 @@
+---
+eip: 6682
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6682.md

--- a/EIPS/eip-67.md
+++ b/EIPS/eip-67.md
@@ -1,1 +1,7 @@
+---
+eip: 67
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-67.md

--- a/EIPS/eip-6734.md
+++ b/EIPS/eip-6734.md
@@ -1,1 +1,7 @@
+---
+eip: 6734
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6734.md

--- a/EIPS/eip-6735.md
+++ b/EIPS/eip-6735.md
@@ -1,1 +1,7 @@
+---
+eip: 6735
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6735.md

--- a/EIPS/eip-6785.md
+++ b/EIPS/eip-6785.md
@@ -1,1 +1,7 @@
+---
+eip: 6785
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6785.md

--- a/EIPS/eip-6786.md
+++ b/EIPS/eip-6786.md
@@ -1,1 +1,7 @@
+---
+eip: 6786
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6786.md

--- a/EIPS/eip-6787.md
+++ b/EIPS/eip-6787.md
@@ -1,1 +1,7 @@
+---
+eip: 6787
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6787.md

--- a/EIPS/eip-6806.md
+++ b/EIPS/eip-6806.md
@@ -1,1 +1,7 @@
+---
+eip: 6806
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6806.md

--- a/EIPS/eip-6808.md
+++ b/EIPS/eip-6808.md
@@ -1,1 +1,7 @@
+---
+eip: 6808
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6808.md

--- a/EIPS/eip-6809.md
+++ b/EIPS/eip-6809.md
@@ -1,1 +1,7 @@
+---
+eip: 6809
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6809.md

--- a/EIPS/eip-681.md
+++ b/EIPS/eip-681.md
@@ -1,1 +1,7 @@
+---
+eip: 681
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-681.md

--- a/EIPS/eip-6821.md
+++ b/EIPS/eip-6821.md
@@ -1,1 +1,7 @@
+---
+eip: 6821
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6821.md

--- a/EIPS/eip-6823.md
+++ b/EIPS/eip-6823.md
@@ -1,1 +1,7 @@
+---
+eip: 6823
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6823.md

--- a/EIPS/eip-6860.md
+++ b/EIPS/eip-6860.md
@@ -1,1 +1,7 @@
+---
+eip: 6860
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6860.md

--- a/EIPS/eip-6864.md
+++ b/EIPS/eip-6864.md
@@ -1,1 +1,7 @@
+---
+eip: 6864
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6864.md

--- a/EIPS/eip-6865.md
+++ b/EIPS/eip-6865.md
@@ -1,1 +1,7 @@
+---
+eip: 6865
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6865.md

--- a/EIPS/eip-6900.md
+++ b/EIPS/eip-6900.md
@@ -1,1 +1,7 @@
+---
+eip: 6900
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6900.md

--- a/EIPS/eip-6909.md
+++ b/EIPS/eip-6909.md
@@ -1,1 +1,7 @@
+---
+eip: 6909
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6909.md

--- a/EIPS/eip-6944.md
+++ b/EIPS/eip-6944.md
@@ -1,1 +1,7 @@
+---
+eip: 6944
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6944.md

--- a/EIPS/eip-6956.md
+++ b/EIPS/eip-6956.md
@@ -1,1 +1,7 @@
+---
+eip: 6956
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6956.md

--- a/EIPS/eip-6960.md
+++ b/EIPS/eip-6960.md
@@ -1,1 +1,7 @@
+---
+eip: 6960
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6960.md

--- a/EIPS/eip-6981.md
+++ b/EIPS/eip-6981.md
@@ -1,1 +1,7 @@
+---
+eip: 6981
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6981.md

--- a/EIPS/eip-6982.md
+++ b/EIPS/eip-6982.md
@@ -1,1 +1,7 @@
+---
+eip: 6982
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6982.md

--- a/EIPS/eip-6997.md
+++ b/EIPS/eip-6997.md
@@ -1,1 +1,7 @@
+---
+eip: 6997
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-6997.md

--- a/EIPS/eip-7007.md
+++ b/EIPS/eip-7007.md
@@ -1,1 +1,7 @@
+---
+eip: 7007
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7007.md

--- a/EIPS/eip-7015.md
+++ b/EIPS/eip-7015.md
@@ -1,1 +1,7 @@
+---
+eip: 7015
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7015.md

--- a/EIPS/eip-7053.md
+++ b/EIPS/eip-7053.md
@@ -1,1 +1,7 @@
+---
+eip: 7053
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7053.md

--- a/EIPS/eip-7066.md
+++ b/EIPS/eip-7066.md
@@ -1,1 +1,7 @@
+---
+eip: 7066
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7066.md

--- a/EIPS/eip-7085.md
+++ b/EIPS/eip-7085.md
@@ -1,1 +1,7 @@
+---
+eip: 7085
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7085.md

--- a/EIPS/eip-7092.md
+++ b/EIPS/eip-7092.md
@@ -1,1 +1,7 @@
+---
+eip: 7092
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7092.md

--- a/EIPS/eip-7093.md
+++ b/EIPS/eip-7093.md
@@ -1,1 +1,7 @@
+---
+eip: 7093
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7093.md

--- a/EIPS/eip-7144.md
+++ b/EIPS/eip-7144.md
@@ -1,1 +1,7 @@
+---
+eip: 7144
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7144.md

--- a/EIPS/eip-7160.md
+++ b/EIPS/eip-7160.md
@@ -1,1 +1,7 @@
+---
+eip: 7160
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7160.md

--- a/EIPS/eip-7201.md
+++ b/EIPS/eip-7201.md
@@ -1,1 +1,7 @@
+---
+eip: 7201
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7201.md

--- a/EIPS/eip-721.md
+++ b/EIPS/eip-721.md
@@ -1,1 +1,7 @@
+---
+eip: 721
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-721.md

--- a/EIPS/eip-7231.md
+++ b/EIPS/eip-7231.md
@@ -1,1 +1,7 @@
+---
+eip: 7231
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7231.md

--- a/EIPS/eip-725.md
+++ b/EIPS/eip-725.md
@@ -1,1 +1,7 @@
+---
+eip: 725
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-725.md

--- a/EIPS/eip-7303.md
+++ b/EIPS/eip-7303.md
@@ -1,1 +1,7 @@
+---
+eip: 7303
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7303.md

--- a/EIPS/eip-7401.md
+++ b/EIPS/eip-7401.md
@@ -1,1 +1,7 @@
+---
+eip: 7401
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7401.md

--- a/EIPS/eip-7405.md
+++ b/EIPS/eip-7405.md
@@ -1,1 +1,7 @@
+---
+eip: 7405
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7405.md

--- a/EIPS/eip-7406.md
+++ b/EIPS/eip-7406.md
@@ -1,1 +1,7 @@
+---
+eip: 7406
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7406.md

--- a/EIPS/eip-7409.md
+++ b/EIPS/eip-7409.md
@@ -1,1 +1,7 @@
+---
+eip: 7409
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7409.md

--- a/EIPS/eip-7412.md
+++ b/EIPS/eip-7412.md
@@ -1,1 +1,7 @@
+---
+eip: 7412
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7412.md

--- a/EIPS/eip-7417.md
+++ b/EIPS/eip-7417.md
@@ -1,1 +1,7 @@
+---
+eip: 7417
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7417.md

--- a/EIPS/eip-7425.md
+++ b/EIPS/eip-7425.md
@@ -1,1 +1,7 @@
+---
+eip: 7425
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7425.md

--- a/EIPS/eip-7432.md
+++ b/EIPS/eip-7432.md
@@ -1,1 +1,7 @@
+---
+eip: 7432
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7432.md

--- a/EIPS/eip-7444.md
+++ b/EIPS/eip-7444.md
@@ -1,1 +1,7 @@
+---
+eip: 7444
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7444.md

--- a/EIPS/eip-7484.md
+++ b/EIPS/eip-7484.md
@@ -1,1 +1,7 @@
+---
+eip: 7484
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7484.md

--- a/EIPS/eip-7507.md
+++ b/EIPS/eip-7507.md
@@ -1,1 +1,7 @@
+---
+eip: 7507
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7507.md

--- a/EIPS/eip-7508.md
+++ b/EIPS/eip-7508.md
@@ -1,1 +1,7 @@
+---
+eip: 7508
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7508.md

--- a/EIPS/eip-7511.md
+++ b/EIPS/eip-7511.md
@@ -1,1 +1,7 @@
+---
+eip: 7511
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7511.md

--- a/EIPS/eip-7512.md
+++ b/EIPS/eip-7512.md
@@ -1,1 +1,7 @@
+---
+eip: 7512
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7512.md

--- a/EIPS/eip-7521.md
+++ b/EIPS/eip-7521.md
@@ -1,1 +1,7 @@
+---
+eip: 7521
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7521.md

--- a/EIPS/eip-7522.md
+++ b/EIPS/eip-7522.md
@@ -1,1 +1,7 @@
+---
+eip: 7522
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7522.md

--- a/EIPS/eip-7528.md
+++ b/EIPS/eip-7528.md
@@ -1,1 +1,7 @@
+---
+eip: 7528
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-7528.md

--- a/EIPS/eip-777.md
+++ b/EIPS/eip-777.md
@@ -1,1 +1,7 @@
+---
+eip: 777
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-777.md

--- a/EIPS/eip-801.md
+++ b/EIPS/eip-801.md
@@ -1,1 +1,7 @@
+---
+eip: 801
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-801.md

--- a/EIPS/eip-820.md
+++ b/EIPS/eip-820.md
@@ -1,1 +1,7 @@
+---
+eip: 820
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-820.md

--- a/EIPS/eip-823.md
+++ b/EIPS/eip-823.md
@@ -1,1 +1,7 @@
+---
+eip: 823
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-823.md

--- a/EIPS/eip-831.md
+++ b/EIPS/eip-831.md
@@ -1,1 +1,7 @@
+---
+eip: 831
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-831.md

--- a/EIPS/eip-875.md
+++ b/EIPS/eip-875.md
@@ -1,1 +1,7 @@
+---
+eip: 875
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-875.md

--- a/EIPS/eip-884.md
+++ b/EIPS/eip-884.md
@@ -1,1 +1,7 @@
+---
+eip: 884
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-884.md

--- a/EIPS/eip-897.md
+++ b/EIPS/eip-897.md
@@ -1,1 +1,7 @@
+---
+eip: 897
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-897.md

--- a/EIPS/eip-900.md
+++ b/EIPS/eip-900.md
@@ -1,1 +1,7 @@
+---
+eip: 900
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-900.md

--- a/EIPS/eip-902.md
+++ b/EIPS/eip-902.md
@@ -1,1 +1,7 @@
+---
+eip: 902
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-902.md

--- a/EIPS/eip-918.md
+++ b/EIPS/eip-918.md
@@ -1,1 +1,7 @@
+---
+eip: 918
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-918.md

--- a/EIPS/eip-926.md
+++ b/EIPS/eip-926.md
@@ -1,1 +1,7 @@
+---
+eip: 926
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-926.md

--- a/EIPS/eip-927.md
+++ b/EIPS/eip-927.md
@@ -1,1 +1,7 @@
+---
+eip: 927
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-927.md

--- a/EIPS/eip-998.md
+++ b/EIPS/eip-998.md
@@ -1,1 +1,7 @@
+---
+eip: 998
+category: ERC
+status: Moved
+---
+
 This file was moved to https://github.com/ethereum/ercs/blob/master/ERCS/erc-998.md

--- a/config/eipw.toml
+++ b/config/eipw.toml
@@ -1,0 +1,914 @@
+[[modifiers]]
+kind = "set-default-annotation"
+name = "status"
+value = "Stagnant"
+annotation_type = "warning"
+
+[[modifiers]]
+kind = "set-default-annotation"
+name = "status"
+value = "Withdrawn"
+annotation_type = "warning"
+
+[lints.preamble-refs-title]
+kind = "preamble-proposal-ref"
+name = "title"
+
+[lints.preamble-discussions-to]
+kind = "preamble-url"
+name = "discussions-to"
+
+[lints.preamble-re-title]
+kind = "preamble-regex"
+name = "title"
+mode = "excludes"
+pattern = '(?i)standar\w*\b'
+message = "preamble header `title` should not contain `standard` (or similar words.)"
+
+[lints.preamble-refs-description]
+kind = "preamble-proposal-ref"
+name = "description"
+
+[lints.preamble-date-created]
+kind = "preamble-date"
+name = "created"
+
+[lints.preamble-requires-ref-description]
+kind = "preamble-require-referenced"
+name = "description"
+requires = "requires"
+
+[lints.markdown-html-comments]
+kind = "markdown-html-comments"
+name = "status"
+warn_for = [
+    "Draft",
+    "Withdrawn",
+]
+
+[lints.markdown-re-erc-dash]
+kind = "markdown-regex"
+mode = "excludes"
+pattern = '(?i)erc[\s]*[0-9]+'
+message = "proposals must be referenced with the form `ERC-N` (not `ERCN` or `ERC N`)"
+
+[lints.markdown-link-first]
+kind = "markdown-link-first"
+pattern = "(?i)(?:eip|erc)-[0-9]+"
+
+[lints.markdown-refs]
+kind = "markdown-proposal-ref"
+
+[lints.preamble-enum-status]
+kind = "preamble-one-of"
+name = "status"
+values = [
+    "Draft",
+    "Review",
+    "Last Call",
+    "Final",
+    "Stagnant",
+    "Withdrawn",
+    "Living",
+]
+
+[lints.preamble-req]
+kind = "preamble-required"
+names = [
+    "eip",
+    "title",
+    "description",
+    "author",
+    "discussions-to",
+    "status",
+    "type",
+    "created",
+]
+
+[lints.preamble-requires-status]
+kind = "preamble-requires-status"
+requires = "requires"
+status = "status"
+flow = [
+    [
+    "Draft",
+    "Stagnant",
+],
+    ["Review"],
+    ["Last Call"],
+    [
+    "Final",
+    "Withdrawn",
+    "Living",
+    "Moved",
+],
+]
+
+[lints.markdown-req-section]
+kind = "markdown-section-required"
+sections = [
+    "Abstract",
+    "Specification",
+    "Rationale",
+    "Security Considerations",
+    "Copyright",
+]
+
+[lints.markdown-order-section]
+kind = "markdown-section-order"
+sections = [
+    "Abstract",
+    "Motivation",
+    "Specification",
+    "Rationale",
+    "Backwards Compatibility",
+    "Test Cases",
+    "Reference Implementation",
+    "Security Considerations",
+    "Copyright",
+]
+
+[lints.preamble-re-description-erc-dash]
+kind = "preamble-regex"
+name = "description"
+mode = "excludes"
+pattern = '(?i)erc[\s]*[0-9]+'
+message = "proposals must be referenced with the form `ERC-N` (not `ERCN` or `ERC N`)"
+
+[lints.preamble-req-withdrawal-reason]
+kind = "preamble-required-if-eq"
+when = "status"
+equals = "Withdrawn"
+then = "withdrawal-reason"
+
+[lints.markdown-rel-links]
+kind = "markdown-relative-links"
+exceptions = [
+    '^https://(www\.)?github\.com/ethereum/consensus-specs/blob/[a-f0-9]{40}/.+$',
+    '^https://(www\.)?github\.com/ethereum/consensus-specs/commit/[a-f0-9]{40}$',
+    '^https://(www\.)?github\.com/ethereum/devp2p/blob/[0-9a-f]{40}/.+$',
+    '^https://(www\.)?github\.com/ethereum/devp2p/commit/[0-9a-f]{40}$',
+    '^https://(www\.)?github\.com/bitcoin/bips/blob/[0-9a-f]{40}/bip-[0-9]+\.mediawiki$',
+    '^https://www\.w3\.org/TR/[0-9][0-9][0-9][0-9]/.*$',
+    '^https://[a-z]*\.spec\.whatwg\.org/commit-snapshots/[0-9a-f]{40}/$',
+    '^https://www\.rfc-editor\.org/rfc/.*$',
+]
+
+[lints.preamble-requires-ref-title]
+kind = "preamble-require-referenced"
+name = "title"
+requires = "requires"
+
+[lints.markdown-link-status]
+kind = "markdown-link-status"
+status = "status"
+flow = [
+    [
+    "Draft",
+    "Stagnant",
+],
+    ["Review"],
+    ["Last Call"],
+    [
+    "Final",
+    "Withdrawn",
+    "Living",
+    "Moved",
+],
+]
+
+[lints.preamble-file-name]
+kind = "preamble-file-name"
+name = "eip"
+prefix = "eip-"
+suffix = ".md"
+
+[lints.preamble-req-category]
+kind = "preamble-required-if-eq"
+when = "type"
+equals = "Standards Track"
+then = "category"
+
+[lints.preamble-author]
+kind = "preamble-author"
+name = "author"
+
+[lints.preamble-no-dup]
+kind = "preamble-no-duplicates"
+
+[lints.markdown-re-eip-dash]
+kind = "markdown-regex"
+mode = "excludes"
+pattern = '(?i)eip[\s]*[0-9]+'
+message = "proposals must be referenced with the form `EIP-N` (not `EIPN` or `EIP N`)"
+
+[lints.preamble-date-last-call-deadline]
+kind = "preamble-date"
+name = "last-call-deadline"
+
+[lints.preamble-re-title-eip-dash]
+kind = "preamble-regex"
+name = "title"
+mode = "excludes"
+pattern = '(?i)eip[\s]*[0-9]+'
+message = "proposals must be referenced with the form `EIP-N` (not `EIPN` or `EIP N`)"
+
+[lints.preamble-re-description]
+kind = "preamble-regex"
+name = "description"
+mode = "excludes"
+pattern = '(?i)standar\w*\b'
+message = "preamble header `description` should not contain `standard` (or similar words.)"
+
+[lints.preamble-len-requires]
+kind = "preamble-length"
+name = "requires"
+min = 1
+
+[lints.preamble-len-title]
+kind = "preamble-length"
+name = "title"
+min = 2
+max = 44
+
+[lints.preamble-re-title-colon]
+kind = "preamble-regex"
+name = "title"
+mode = "excludes"
+pattern = ":"
+message = "preamble header `title` should not contain `:`"
+
+[lints.preamble-re-title-erc-dash]
+kind = "preamble-regex"
+name = "title"
+mode = "excludes"
+pattern = '(?i)erc[\s]*[0-9]+'
+message = "proposals must be referenced with the form `ERC-N` (not `ERCN` or `ERC N`)"
+
+[lints.preamble-len-description]
+kind = "preamble-length"
+name = "description"
+min = 2
+max = 140
+
+[lints.preamble-order]
+kind = "preamble-order"
+names = [
+    "eip",
+    "title",
+    "description",
+    "author",
+    "discussions-to",
+    "status",
+    "last-call-deadline",
+    "type",
+    "category",
+    "created",
+    "requires",
+    "withdrawal-reason",
+]
+
+[lints.preamble-enum-type]
+kind = "preamble-one-of"
+name = "type"
+values = [
+    "Standards Track",
+    "Meta",
+    "Informational",
+]
+
+[lints.preamble-re-discussions-to]
+kind = "preamble-regex"
+name = "discussions-to"
+mode = "includes"
+pattern = "^https://ethereum-magicians.org/t/[^/]+/[0-9]+$"
+message = "preamble header `discussions-to` should point to a thread on ethereum-magicians.org"
+
+[lints.preamble-list-requires]
+kind = "preamble-list"
+name = "requires"
+
+[lints.preamble-enum-category]
+kind = "preamble-one-of"
+name = "category"
+values = [
+    "Core",
+    "Networking",
+    "Interface",
+]
+
+[lints.preamble-list-author]
+kind = "preamble-list"
+name = "author"
+
+[lints.preamble-trim]
+kind = "preamble-trim"
+
+[lints.preamble-eip]
+kind = "preamble-uint"
+name = "eip"
+
+[lints.preamble-re-description-colon]
+kind = "preamble-regex"
+name = "description"
+mode = "excludes"
+pattern = ":"
+message = "preamble header `description` should not contain `:`"
+
+[lints.markdown-json-cite]
+kind = "markdown-json-schema"
+language = "csl-json"
+additional_schemas = [[
+    "https://resource.citationstyles.org/schema/v1.0/input/json/csl-data.json",
+    """
+{
+  \"description\": \"JSON schema for CSL input data\",
+  \"$schema\": \"http://json-schema.org/draft-07/schema#\",
+  \"$id\": \"https://resource.citationstyles.org/schema/v1.0/input/json/csl-data.json\",
+  \"type\": \"array\",
+  \"items\": {
+    \"type\": \"object\",
+    \"properties\": {
+      \"type\": {
+        \"type\": \"string\",
+        \"enum\": [
+          \"article\",
+          \"article-journal\",
+          \"article-magazine\",
+          \"article-newspaper\",
+          \"bill\",
+          \"book\",
+          \"broadcast\",
+          \"chapter\",
+          \"classic\",
+          \"collection\",
+          \"dataset\",
+          \"document\",
+          \"entry\",
+          \"entry-dictionary\",
+          \"entry-encyclopedia\",
+          \"event\",
+          \"figure\",
+          \"graphic\",
+          \"hearing\",
+          \"interview\",
+          \"legal_case\",
+          \"legislation\",
+          \"manuscript\",
+          \"map\",
+          \"motion_picture\",
+          \"musical_score\",
+          \"pamphlet\",
+          \"paper-conference\",
+          \"patent\",
+          \"performance\",
+          \"periodical\",
+          \"personal_communication\",
+          \"post\",
+          \"post-weblog\",
+          \"regulation\",
+          \"report\",
+          \"review\",
+          \"review-book\",
+          \"software\",
+          \"song\",
+          \"speech\",
+          \"standard\",
+          \"thesis\",
+          \"treaty\",
+          \"webpage\"
+        ]
+      },
+      \"id\": {
+        \"type\": [\"string\", \"number\"]
+      },
+      \"citation-key\": {
+        \"type\": \"string\"
+      },
+      \"categories\": {
+        \"type\": \"array\",
+        \"items\": {
+          \"type\": \"string\"
+        }
+      },
+      \"language\": {
+        \"type\": \"string\"
+      },
+      \"journalAbbreviation\": {
+        \"type\": \"string\"
+      },
+      \"shortTitle\": {
+        \"type\": \"string\"
+      },
+      \"author\": {
+        \"type\": \"array\",
+        \"items\": {
+          \"$ref\": \"#/definitions/name-variable\"
+        }
+      },
+      \"chair\": {
+        \"type\": \"array\",
+        \"items\": {
+          \"$ref\": \"#/definitions/name-variable\"
+        }
+      },
+      \"collection-editor\": {
+        \"type\": \"array\",
+        \"items\": {
+          \"$ref\": \"#/definitions/name-variable\"
+        }
+      },
+      \"compiler\": {
+        \"type\": \"array\",
+        \"items\": {
+          \"$ref\": \"#/definitions/name-variable\"
+        }
+      },
+      \"composer\": {
+        \"type\": \"array\",
+        \"items\": {
+          \"$ref\": \"#/definitions/name-variable\"
+        }
+      },
+      \"container-author\": {
+        \"type\": \"array\",
+        \"items\": {
+          \"$ref\": \"#/definitions/name-variable\"
+        }
+      },
+      \"contributor\": {
+        \"type\": \"array\",
+        \"items\": {
+          \"$ref\": \"#/definitions/name-variable\"
+        }
+      },
+      \"curator\": {
+        \"type\": \"array\",
+        \"items\": {
+          \"$ref\": \"#/definitions/name-variable\"
+        }
+      },
+      \"director\": {
+        \"type\": \"array\",
+        \"items\": {
+          \"$ref\": \"#/definitions/name-variable\"
+        }
+      },
+      \"editor\": {
+        \"type\": \"array\",
+        \"items\": {
+          \"$ref\": \"#/definitions/name-variable\"
+        }
+      },
+      \"editorial-director\": {
+        \"type\": \"array\",
+        \"items\": {
+          \"$ref\": \"#/definitions/name-variable\"
+        }
+      },
+      \"executive-producer\": {
+        \"type\": \"array\",
+        \"items\": {
+          \"$ref\": \"#/definitions/name-variable\"
+        }
+      },
+      \"guest\": {
+        \"type\": \"array\",
+        \"items\": {
+          \"$ref\": \"#/definitions/name-variable\"
+        }
+      },
+      \"host\": {
+        \"type\": \"array\",
+        \"items\": {
+          \"$ref\": \"#/definitions/name-variable\"
+        }
+      },
+      \"interviewer\": {
+        \"type\": \"array\",
+        \"items\": {
+          \"$ref\": \"#/definitions/name-variable\"
+        }
+      },
+      \"illustrator\": {
+        \"type\": \"array\",
+        \"items\": {
+          \"$ref\": \"#/definitions/name-variable\"
+        }
+      },
+      \"narrator\": {
+        \"type\": \"array\",
+        \"items\": {
+          \"$ref\": \"#/definitions/name-variable\"
+        }
+      },
+      \"organizer\": {
+        \"type\": \"array\",
+        \"items\": {
+          \"$ref\": \"#/definitions/name-variable\"
+        }
+      },
+      \"original-author\": {
+        \"type\": \"array\",
+        \"items\": {
+          \"$ref\": \"#/definitions/name-variable\"
+        }
+      },
+      \"performer\": {
+        \"type\": \"array\",
+        \"items\": {
+          \"$ref\": \"#/definitions/name-variable\"
+        }
+      },
+      \"producer\": {
+        \"type\": \"array\",
+        \"items\": {
+          \"$ref\": \"#/definitions/name-variable\"
+        }
+      },
+      \"recipient\": {
+        \"type\": \"array\",
+        \"items\": {
+          \"$ref\": \"#/definitions/name-variable\"
+        }
+      },
+      \"reviewed-author\": {
+        \"type\": \"array\",
+        \"items\": {
+          \"$ref\": \"#/definitions/name-variable\"
+        }
+      },
+      \"script-writer\": {
+        \"type\": \"array\",
+        \"items\": {
+          \"$ref\": \"#/definitions/name-variable\"
+        }
+      },
+      \"series-creator\": {
+        \"type\": \"array\",
+        \"items\": {
+          \"$ref\": \"#/definitions/name-variable\"
+        }
+      },
+      \"translator\": {
+        \"type\": \"array\",
+        \"items\": {
+          \"$ref\": \"#/definitions/name-variable\"
+        }
+      },
+      \"accessed\": {
+        \"$ref\": \"#/definitions/date-variable\"
+      },
+      \"available-date\": {
+        \"$ref\": \"#/definitions/date-variable\"
+      },
+      \"event-date\": {
+        \"$ref\": \"#/definitions/date-variable\"
+      },
+      \"issued\": {
+        \"$ref\": \"#/definitions/date-variable\"
+      },
+      \"original-date\": {
+        \"$ref\": \"#/definitions/date-variable\"
+      },
+      \"submitted\": {
+        \"$ref\": \"#/definitions/date-variable\"
+      },
+      \"abstract\": {
+        \"type\": \"string\"
+      },
+      \"annote\": {
+        \"type\": \"string\"
+      },
+      \"archive\": {
+        \"type\": \"string\"
+      },
+      \"archive_collection\": {
+        \"type\": \"string\"
+      },
+      \"archive_location\": {
+        \"type\": \"string\"
+      },
+      \"archive-place\": {
+        \"type\": \"string\"
+      },
+      \"authority\": {
+        \"type\": \"string\"
+      },
+      \"call-number\": {
+        \"type\": \"string\"
+      },
+      \"chapter-number\": {
+        \"type\": [\"string\", \"number\"]
+      },
+      \"citation-number\": {
+        \"type\": [\"string\", \"number\"]
+      },
+      \"citation-label\": {
+        \"type\": \"string\"
+      },
+      \"collection-number\": {
+        \"type\": [\"string\", \"number\"]
+      },
+      \"collection-title\": {
+        \"type\": \"string\"
+      },
+      \"container-title\": {
+        \"type\": \"string\"
+      },
+      \"container-title-short\": {
+        \"type\": \"string\"
+      },
+      \"dimensions\": {
+        \"type\": \"string\"
+      },
+      \"division\": {
+        \"type\": \"string\"
+      },
+      \"DOI\": {
+        \"type\": \"string\"
+      },
+      \"edition\": {
+        \"type\": [\"string\", \"number\"]
+      },
+      \"event\": {
+        \"description\": \"[Deprecated - use 'event-title' instead. Will be removed in 1.1]\",
+        \"type\": \"string\"
+      },
+      \"event-title\": {
+        \"type\": \"string\"
+      },
+      \"event-place\": {
+        \"type\": \"string\"
+      },
+      \"first-reference-note-number\": {
+        \"type\": [\"string\", \"number\"]
+      },
+      \"genre\": {
+        \"type\": \"string\"
+      },
+      \"ISBN\": {
+        \"type\": \"string\"
+      },
+      \"ISSN\": {
+        \"type\": \"string\"
+      },
+      \"issue\": {
+        \"type\": [\"string\", \"number\"]
+      },
+      \"jurisdiction\": {
+        \"type\": \"string\"
+      },
+      \"keyword\": {
+        \"type\": \"string\"
+      },
+      \"locator\": {
+        \"type\": [\"string\", \"number\"]
+      },
+      \"medium\": {
+        \"type\": \"string\"
+      },
+      \"note\": {
+        \"type\": \"string\"
+      },
+      \"number\": {
+        \"type\": [\"string\", \"number\"]
+      },
+      \"number-of-pages\": {
+        \"type\": [\"string\", \"number\"]
+      },
+      \"number-of-volumes\": {
+        \"type\": [\"string\", \"number\"]
+      },
+      \"original-publisher\": {
+        \"type\": \"string\"
+      },
+      \"original-publisher-place\": {
+        \"type\": \"string\"
+      },
+      \"original-title\": {
+        \"type\": \"string\"
+      },
+      \"page\": {
+        \"type\": [\"string\", \"number\"]
+      },
+      \"page-first\": {
+        \"type\": [\"string\", \"number\"]
+      },
+      \"part\": {
+        \"type\": [\"string\", \"number\"]
+      },
+      \"part-title\": {
+        \"type\": \"string\"
+      },
+      \"PMCID\": {
+        \"type\": \"string\"
+      },
+      \"PMID\": {
+        \"type\": \"string\"
+      },
+      \"printing\": {
+        \"type\": [\"string\", \"number\"]
+      },
+      \"publisher\": {
+        \"type\": \"string\"
+      },
+      \"publisher-place\": {
+        \"type\": \"string\"
+      },
+      \"references\": {
+        \"type\": \"string\"
+      },
+      \"reviewed-genre\": {
+        \"type\": \"string\"
+      },
+      \"reviewed-title\": {
+        \"type\": \"string\"
+      },
+      \"scale\": {
+        \"type\": \"string\"
+      },
+      \"section\": {
+        \"type\": \"string\"
+      },
+      \"source\": {
+        \"type\": \"string\"
+      },
+      \"status\": {
+        \"type\": \"string\"
+      },
+      \"supplement\": {
+        \"type\": [\"string\", \"number\"]
+      },
+      \"title\": {
+        \"type\": \"string\"
+      },
+      \"title-short\": {
+        \"type\": \"string\"
+      },
+      \"URL\": {
+        \"type\": \"string\"
+      },
+      \"version\": {
+        \"type\": \"string\"
+      },
+      \"volume\": {
+        \"type\": [\"string\", \"number\"]
+      },
+      \"volume-title\": {
+        \"type\": \"string\"
+      },
+      \"volume-title-short\": {
+        \"type\": \"string\"
+      },
+      \"year-suffix\": {
+        \"type\": \"string\"
+      },
+      \"custom\": {
+        \"title\": \"Custom key-value pairs.\",
+        \"type\": \"object\",
+        \"description\": \"Used to store additional information that does not have a designated CSL JSON field. The custom field is preferred over the note field for storing custom data, particularly for storing key-value pairs, as the note field is used for user annotations in annotated bibliography styles.\",
+        \"examples\": [
+          {
+            \"short_id\": \"xyz\",
+            \"other-ids\": [\"alternative-id\"]
+          },
+          {
+            \"metadata-double-checked\": true
+          }
+        ]
+      }
+    },
+    \"required\": [\"type\", \"id\"],
+    \"additionalProperties\": false
+  },
+  \"definitions\": {
+    \"name-variable\": {
+      \"anyOf\": [
+        {
+          \"properties\": {
+            \"family\": {
+              \"type\": \"string\"
+            },
+            \"given\": {
+              \"type\": \"string\"
+            },
+            \"dropping-particle\": {
+              \"type\": \"string\"
+            },
+            \"non-dropping-particle\": {
+              \"type\": \"string\"
+            },
+            \"suffix\": {
+              \"type\": \"string\"
+            },
+            \"comma-suffix\": {
+              \"type\": [\"string\", \"number\", \"boolean\"]
+            },
+            \"static-ordering\": {
+              \"type\": [\"string\", \"number\", \"boolean\"]
+            },
+            \"literal\": {
+              \"type\": \"string\"
+            },
+            \"parse-names\": {
+              \"type\": [\"string\", \"number\", \"boolean\"]
+            }
+          },
+          \"additionalProperties\": false
+        }
+      ]
+    },
+    \"date-variable\": {
+      \"title\": \"Date content model.\",
+      \"description\": \"The CSL input model supports two different date representations: an EDTF string (preferred), and a more structured alternative.\",
+      \"anyOf\": [
+        {
+          \"properties\": {
+            \"date-parts\": {
+              \"type\": \"array\",
+              \"items\": {
+                \"type\": \"array\",
+                \"items\": {
+                  \"type\": [\"string\", \"number\"]
+                },
+                \"minItems\": 1,
+                \"maxItems\": 3
+              },
+              \"minItems\": 1,
+              \"maxItems\": 2
+            },
+            \"season\": {
+              \"type\": [\"string\", \"number\"]
+            },
+            \"circa\": {
+              \"type\": [\"string\", \"number\", \"boolean\"]
+            },
+            \"literal\": {
+              \"type\": \"string\"
+            },
+            \"raw\": {
+              \"type\": \"string\"
+            }
+          },
+          \"additionalProperties\": false
+        }
+      ]
+    }
+  }
+}
+""",
+]]
+schema = """
+{
+  \"$id\": \"https://eips.ethereum.org/assets/eip-1/schema/json/citation.json\",
+  \"description\": \"Citation format for EIPs\",
+  \"$schema\": \"http://json-schema.org/draft-07/schema#\",
+  \"allOf\": [
+    {
+        \"$ref\": \"https://resource.citationstyles.org/schema/v1.0/input/json/csl-data.json#/items\"
+    },
+    {
+      \"required\": [
+        \"DOI\",
+        \"URL\"
+      ],
+      \"properties\": {
+        \"URL\": {
+            \"format\": \"uri\"
+        },
+        \"custom\": {
+          \"properties\": {
+            \"additional-urls\": {
+              \"type\": \"array\",
+              \"items\": {
+                \"format\": \"uri\"
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}
+"""
+help = "see https://github.com/ethereum/eipw/blob/master/eipw-lint/src/lints/markdown/json_schema/citation.json"
+
+[lints.preamble-uint-requires]
+kind = "preamble-uint-list"
+name = "requires"
+
+[lints.preamble-req-last-call-deadline]
+kind = "preamble-required-if-eq"
+when = "status"
+equals = "Last Call"
+then = "last-call-deadline"
+
+[lints.preamble-re-description-eip-dash]
+kind = "preamble-regex"
+name = "description"
+mode = "excludes"
+pattern = '(?i)eip[\s]*[0-9]+'
+message = "proposals must be referenced with the form `EIP-N` (not `EIPN` or `EIP N`)"
+
+


### PR DESCRIPTION
First commit adds an `eipw` configuration file that:
 - Removes ERC as a valid category.
 - Treats "Moved" as a special status (at the same level as Final) for the purposes of allowing links.

Second commit adds a stub preamble to all the moved files.