### PR TITLE
Update EIP-4844: fix typo on blob batch verification function name

### DIFF
--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -307,7 +307,7 @@ The node MUST validate `tx_payload_body` and verify the wrapped data against it.
 
 - There are an equal number of `tx_payload_body.blob_versioned_hashes`, `blobs`, `commitments`, and `proofs`.
 - The KZG `commitments` hash to the versioned hashes, i.e. `kzg_to_versioned_hash(commitments[i]) == tx_payload_body.blob_versioned_hashes[i]`
-- The KZG `commitments` match the corresponding `blobs` and `proofs`. (Note: this can be optimized using `blob_kzg_proofs`, with a proof for a
+- The KZG `commitments` match the corresponding `blobs` and `proofs`. (Note: this can be optimized using `verify_blob_kzg_proof_batch`, with a proof for a
   random evaluation at a point derived from the commitment and blob data for each blob)
 
 For body retrieval responses (`BlockBodies`), the standard EIP-2718 blob transaction `TransactionPayload` is used.


### PR DESCRIPTION
Use latest function name for batched blob verification
