### PR TITLE
Update EIP-6690: fix typo & linter error

### DIFF
--- a/EIPS/eip-6690.md
+++ b/EIPS/eip-6690.md
@@ -242,7 +242,7 @@ def mulmont_quadratic(x: [int], y: [int], mod: [int], modinv: int) -> [int]:
         #    * modinv * mod_int * t[-1] === -1 % (2**SYSTEM_WORD_SIZE_BITS)
         #    * t_int === (t_int + (-1) t_int) % (2**SYSTEM_WORD_SIZE_BITS) === 0 % (2**SYSTEM_WORD_SIZE_BITS)
         #    so the shift in step 2 is a word-sized right shift.
-        #    Steps 1 and 2 are combined and the shift is implict.
+        #    Steps 1 and 2 are combined and the shift is implicit.
         for j in reversed(range(1, word_count)):
             c, t[j + 2] = hi_lo(t[j + 1] + mod[j - 1] * m + c)
 

--- a/EIPS/eip-6690.md
+++ b/EIPS/eip-6690.md
@@ -17,6 +17,7 @@ This EIP proposes the addition of new optimized modular addition, subtraction an
 ## Motivation
 
 Benefits of the changes proposed in this EIP:
+
 * enables elliptic curve arithmetic operations on various curves including BLS12-381 to be implemented as EVM contracts
 * For operations on values up to 256bits in size, reduces gas cost per operation by 90-95% compared to the current `MULMOD` and `ADDMOD` opcodes.
 * for all cases where modexp precompile is useful, it could now be implemented as an EVM contract.
@@ -515,6 +516,7 @@ mod_state.values[z_offset] = (mod_state.values[x_offset] + mod_state.values[y_of
 `SUBMODX {z_offset - byte}, {x_offset - byte}, {y_offset - byte}:`
 
 ##### Description
+
 Compute the modular subtraction of two EVMMAX values in the current active modulus state, storing the result in an output.
 
 ##### Gas Charging
@@ -543,6 +545,7 @@ mod_state.values[z_offset] = (mod_state.values[x_offset] - mod_state.values[y_of
 `MULMODX {z_offset - byte}, {x_offset - byte}, {y_offset - byte}:`
 
 ##### Description
+
 Compute the Montgomery modular multiplication of two EVMMAX values in the current active modulus state, storing the result in an output.
 
 ##### Gas Charging


### PR DESCRIPTION
1. fix typo: implict->implicit
2. fix linter error in CI