### PR TITLE
Update EIP-1153: fix typo

### DIFF
--- a/EIPS/eip-1153.md
+++ b/EIPS/eip-1153.md
@@ -46,7 +46,7 @@ Two new opcodes are added to EVM, `TLOAD` (`0x5c`) and `TSTORE` (`0x5d`). (Note 
 
 They use the same arguments on stack as `SLOAD` (`0x54`) and `SSTORE` (`0x55`).
 
-`TLOAD` pops one 32-byte word from the top of the stack, treats this value as the address, fetches 32-byte word from the transient storage at that address, and pops the value on top of the stack.
+`TLOAD` pops one 32-byte word from the top of the stack, treats this value as the address, fetches 32-byte word from the transient storage at that address, and pushes the value on top of the stack.
 
 `TSTORE` pops two 32-byte words from the top of the stack. The word on the top is the address, and the next is the value. `TSTORE` saves the value at the given address in the transient storage.
 


### PR DESCRIPTION
`TLOAD` is expected to push the value it read from the transient storage to the stack, not pop it.