### PR TITLE
chore(config): Update _config.yml to reflect repo split

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,11 +16,12 @@
 title: Ethereum Improvement Proposals
 description: >-
   Ethereum Improvement Proposals (EIPs) describe standards for the Ethereum
-  platform, including core protocol specifications, client APIs, and contract
-  standards.
+  platform, such as core protocol specifications.
 url: "https://eips.ethereum.org"
 github_username:  ethereum
 repository: ethereum/EIPs
+lang: en
+timezone: UTC
 
 header_pages:
  - all.html


### PR DESCRIPTION
Client API's are in their own repo and now that ERC's are separate as well, the description should reflect that.

Also added timezone and language to config.
