### PR TITLE
Update EIP-627: fix typo

### DIFF
--- a/EIPS/eip-627.md
+++ b/EIPS/eip-627.md
@@ -1,10 +1,11 @@
 ---
 eip: 627
 title: Whisper Specification
+description: Format of Whisper messages within the ÐΞVp2p Wire Protocol
 author: Vlad Gluhovsky <gluk256@gmail.com>
-type: Standards Track
 category: Networking
 status: Final
+type: Standards Track
 created: 2017-05-05
 ---
 
@@ -178,6 +179,8 @@ This EIP is compatible with Whisper version 6. Any client which does not impleme
 ## Implementation
 
 The golang implementation of Whisper (v.6) already uses packet codes 0x00 - 0x03. Parity's implementation of v.6 will also use codes 0x00 - 0x03. Codes 0x7E and 0x7F are reserved, but still unused and left for custom implementation of Whisper Mail Server.
+
+## Security Considerations
 
 ## Copyright
 

--- a/EIPS/eip-627.md
+++ b/EIPS/eip-627.md
@@ -3,10 +3,10 @@ eip: 627
 title: Whisper Specification
 description: Format of Whisper messages within the ÐΞVp2p Wire Protocol
 author: Vlad Gluhovsky (@gluk256)
-discussions-to: https://github.com/ethereum/EIPs/pull/627
-category: Networking
+discussions-to: https://ethereum-magicians.org/t/whispeg-marking-eip-627-as-final/2220
 status: Final
 type: Standards Track
+category: Networking
 created: 2017-05-05
 ---
 

--- a/EIPS/eip-627.md
+++ b/EIPS/eip-627.md
@@ -3,9 +3,9 @@ eip: 627
 title: Whisper Specification
 description: Format of Whisper messages within the ÐΞVp2p Wire Protocol
 author: Vlad Gluhovsky <gluk256@gmail.com>
-category: Networking
 status: Final
 type: Standards Track
+category: Networking
 created: 2017-05-05
 ---
 

--- a/EIPS/eip-627.md
+++ b/EIPS/eip-627.md
@@ -2,18 +2,17 @@
 eip: 627
 title: Whisper Specification
 description: Format of Whisper messages within the ÐΞVp2p Wire Protocol
-author: Vlad Gluhovsky <gluk256@gmail.com>
+author: Vlad Gluhovsky (@gluk256)
+discussions-to: https://github.com/ethereum/EIPs/pull/627
+category: Networking
 status: Final
 type: Standards Track
-category: Networking
 created: 2017-05-05
 ---
 
 ## Abstract
 
 This EIP describes the format of Whisper messages within the ÐΞVp2p Wire Protocol.
-This EIP should substitute the [existing specification](https://github.com/ethereum/wiki/wiki/Whisper-Wire-Protocol).
-More detailed documentation on Whisper could be found [here](https://github.com/ethereum/go-ethereum/wiki/Whisper).
 
 ## Motivation
 
@@ -154,7 +153,7 @@ Data field contains encrypted message of the Envelope. In case of symmetric encr
 
 Those unable to decrypt the message data are also unable to access the signature. The signature, if provided, is the ECDSA signature of the Keccak-256 hash of the unencrypted data using the secret key of the originator identity. The signature is serialised as the concatenation of the `R`, `S` and `V` parameters of the SECP-256k1 ECDSA signature, in that order. `R` and `S` are both big-endian encoded, fixed-width 256-bit unsigned. `V` is an 8-bit big-endian encoded, non-normalised and should be either 27 or 28.
 
-The padding field was introduced in order to align the message size, since message size alone might reveal important Meta-information. Padding can be arbitrary size. However, it is recommended that the size of Data Field (excluding the Salt) before encryption (i.e. plain text) should be factor of 256 bytes.
+The padding field was introduced in order to align the message size, since message size alone might reveal important metainformation. Padding can be arbitrary size. However, it is recommended that the size of Data Field (excuding the Salt) before encryption (i.e. plain text) should be factor of 256 bytes.
 
 ### Payload Encryption
 
@@ -162,11 +161,15 @@ Asymmetric encryption uses the standard Elliptic Curve Integrated Encryption Sch
 
 Symmetric encryption uses AES GCM algorithm with random 96-bit nonce.
 
+### Implementation
+
+The golang implementation of Whisper (v.6) already uses packet codes 0x00 - 0x03. Parity's implementation of v.6 will also use codes 0x00 - 0x03. Codes 0x7E and 0x7F are reserved, but still unused and left for custom implementation of Whisper Mail Server.
+
 ## Rationale
 
 Packet codes 0x00 and 0x01 are already used in all Whisper versions.
 
-Packet code 0x02 will be necessary for the future development of Whisper. It will provide possibility to adjust the PoW requirement in real time. It is better to allow the network to govern itself, rather than hardcode any specific value for minimal PoW requirement.
+Packet code 0x02 will be necessary for the future development of Whisper. It will provide possiblitity to adjust the PoW requirement in real time. It is better to allow the network to govern itself, rather than hardcode any specific value for minimal PoW requirement.
 
 Packet code 0x03 will be necessary for scalability of the network. In case of too much traffic, the nodes will be able to request and receive only the messages they are interested in.
 
@@ -175,10 +178,6 @@ Packet codes 0x7E and 0x7F may be used to implement Whisper Mail Server and Clie
 ## Backwards Compatibility
 
 This EIP is compatible with Whisper version 6. Any client which does not implement certain packet codes should gracefully ignore the packets with those codes. This will ensure the forward compatibility. 
-
-## Implementation
-
-The golang implementation of Whisper (v.6) already uses packet codes 0x00 - 0x03. Parity's implementation of v.6 will also use codes 0x00 - 0x03. Codes 0x7E and 0x7F are reserved, but still unused and left for custom implementation of Whisper Mail Server.
 
 ## Security Considerations
 

--- a/EIPS/eip-627.md
+++ b/EIPS/eip-627.md
@@ -153,7 +153,7 @@ Data field contains encrypted message of the Envelope. In case of symmetric encr
 
 Those unable to decrypt the message data are also unable to access the signature. The signature, if provided, is the ECDSA signature of the Keccak-256 hash of the unencrypted data using the secret key of the originator identity. The signature is serialised as the concatenation of the `R`, `S` and `V` parameters of the SECP-256k1 ECDSA signature, in that order. `R` and `S` are both big-endian encoded, fixed-width 256-bit unsigned. `V` is an 8-bit big-endian encoded, non-normalised and should be either 27 or 28.
 
-The padding field was introduced in order to align the message size, since message size alone might reveal important metainformation. Padding can be arbitrary size. However, it is recommended that the size of Data Field (excuding the Salt) before encryption (i.e. plain text) should be factor of 256 bytes.
+The padding field was introduced in order to align the message size, since message size alone might reveal important Meta-information. Padding can be arbitrary size. However, it is recommended that the size of Data Field (excluding the Salt) before encryption (i.e. plain text) should be factor of 256 bytes.
 
 ### Payload Encryption
 
@@ -165,7 +165,7 @@ Symmetric encryption uses AES GCM algorithm with random 96-bit nonce.
 
 Packet codes 0x00 and 0x01 are already used in all Whisper versions.
 
-Packet code 0x02 will be necessary for the future development of Whisper. It will provide possiblitity to adjust the PoW requirement in real time. It is better to allow the network to govern itself, rather than hardcode any specific value for minimal PoW requirement.
+Packet code 0x02 will be necessary for the future development of Whisper. It will provide possibility to adjust the PoW requirement in real time. It is better to allow the network to govern itself, rather than hardcode any specific value for minimal PoW requirement.
 
 Packet code 0x03 will be necessary for scalability of the network. In case of too much traffic, the nodes will be able to request and receive only the messages they are interested in.
 


### PR DESCRIPTION
metainformation -> Meta-information
excuding -> excluding
possiblitity -> possibility