### PR TITLE
Update EIP-7549: fix typo

### DIFF
--- a/EIPS/eip-7549.md
+++ b/EIPS/eip-7549.md
@@ -63,7 +63,7 @@ Gossip verification rules for the `beacon_attestation_${subnet_id}` topic includ
 > - [IGNORE] There has been no other valid attestation seen on an attestation subnet that has an identical attestation.data.target.epoch and participating validator index.
 > - [REJECT] The signature of attestation is valid.
 
-For an unaggregated attestation, the tupple (slot, index, aggregation_bits) uniquely identify a single public key. Thus there is a single correct value for the field `index`. If an attacker mutates the `index` field the signature will fail to verify and the message will be dropped. This is the same outcome of mutating the aggregation bits, which is possible today. If implementations verify the attestation signature before registering it in a 'first-seen' cache, there's no risk of cache pollution.
+For an unaggregated attestation, the tuple (slot, index, aggregation_bits) uniquely identify a single public key. Thus there is a single correct value for the field `index`. If an attacker mutates the `index` field the signature will fail to verify and the message will be dropped. This is the same outcome of mutating the aggregation bits, which is possible today. If implementations verify the attestation signature before registering it in a 'first-seen' cache, there's no risk of cache pollution.
 
 ## Copyright
 


### PR DESCRIPTION
fix EIP-7549 typo , `tupple` ->  `tuple`