### PR TITLE
Update EIP-3074: Move to Review

### DIFF
--- a/EIPS/eip-3074.md
+++ b/EIPS/eip-3074.md
@@ -69,10 +69,10 @@ A new opcode `AUTH` shall be created at `0xf6`. It shall take three stack elemen
 
 The final two stack arguments (`offset` and `length`) describe a range of memory. The format of the contents of that range is:
 
- - `memory[offset    : offset+32 ]` - `yParity`
- - `memory[offset+32 : offset+64 ]` - `r`
- - `memory[offset+64 : offset+96 ]` - `s`
- - `memory[offset+96 : offset+128]` - `commit`
+ - `memory[offset    : offset+1 ]` - `yParity`
+ - `memory[offset+32 : offset+33]` - `r`
+ - `memory[offset+64 : offset+65]` - `s`
+ - `memory[offset+96 : offset+97]` - `commit`
 
 #### Output
 
@@ -88,7 +88,7 @@ Memory is not modified by this instruction.
 
 #### Behavior
 
-If `length` is greater than 128, the extra bytes are ignored for signature verification (they still incur a gas cost as defined later). Bytes outside the range (in the event `length` is less than 128) are treated as if they had been zeroes.
+If `length` is greater than 97, the extra bytes are ignored for signature verification (they still incur a gas cost as defined later). Bytes outside the range (in the event `length` is less than 97) are treated as if they had been zeroes.
 
 `authority` is the address of the account which generated the signature.
 

--- a/EIPS/eip-3074.md
+++ b/EIPS/eip-3074.md
@@ -4,7 +4,7 @@ title: AUTH and AUTHCALL opcodes
 description: Allow externally owned accounts to delegate control to a contract.
 author: Sam Wilson (@SamWilsn), Ansgar Dietrichs (@adietrichs), Matt Garnett (@lightclient), Micah Zoltu (@micahzoltu)
 discussions-to: https://ethereum-magicians.org/t/eip-3074-sponsored-transaction-precompile/4880
-status: Stagnant
+status: Review
 type: Standards Track
 category: Core
 created: 2020-10-15


### PR DESCRIPTION
This moves 3074 back to review status from stagnant and it updates the `v` value of the signature input to `AUTH` to be only a single byte since it already can only be either `0` or `1`.