### PR TITLE
Update EIP-4844: minor clean-up

### DIFF
--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -50,7 +50,6 @@ Compared to full data sharding, this EIP has a reduced cap on the number of thes
 | `TARGET_BLOB_GAS_PER_BLOCK` | `393216` |
 | `MIN_BLOB_GASPRICE` | `1` |
 | `BLOB_GASPRICE_UPDATE_FRACTION` | `3338477` |
-| `LIMIT_BLOBS_PER_TX` | `2**12` |
 | `GAS_PER_BLOB` | `2**17` |
 | `HASH_OPCODE_BYTE` | `Bytes1(0x49)` |
 | `HASH_OPCODE_GAS` | `3` |

--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -166,10 +166,10 @@ We introduce blob gas as a new type of gas. It is independent of normal gas and 
 We use the `excess_blob_gas` header field to store persistent data needed to compute the blob gas price. For now, only blobs are priced in blob gas.
 
 ```python
-def calc_data_fee(header: Header, tx: SignedBlobTransaction) -> int:
+def calc_data_fee(header: Header, tx: Transaction) -> int:
     return get_total_blob_gas(tx) * get_blob_gasprice(header)
 
-def get_total_blob_gas(tx: SignedBlobTransaction) -> int:
+def get_total_blob_gas(tx: Transaction) -> int:
     return GAS_PER_BLOB * len(tx.blob_versioned_hashes)
 
 def get_blob_gasprice(header: Header) -> int:
@@ -258,14 +258,14 @@ def validate_block(block: Block) -> None:
 
         # modify the check for sufficient balance
         max_total_fee = tx.gas * tx.max_fee_per_gas
-        if type(tx) is SignedBlobTransaction:
+        if get_tx_type(tx) == BLOB_TX_TYPE:
             max_total_fee += get_total_blob_gas(tx) * tx.max_fee_per_blob_gas
         assert signer(tx).balance >= max_total_fee
 
         ...
 
         # add validity logic specific to blob txs
-        if type(tx) is SignedBlobTransaction:
+        if get_tx_type(tx) == BLOB_TX_TYPE:
             # there must be at least one blob
             assert len(tx.blob_versioned_hashes) > 0
 


### PR DESCRIPTION
Clean up the leftover of #6985

1. Remove the unused `LIMIT_BLOBS_PER_TX` definition
2. Since `SignedBlobTransaction` has been deleted, use a pseudo-code helper `get_tx_type` for checking tx type

/cc @lightclient 