### PR TITLE
Update EIP-3074: update 3074 MAGIC byte

### DIFF
--- a/EIPS/eip-3074.md
+++ b/EIPS/eip-3074.md
@@ -37,7 +37,7 @@ With the extraordinary growth of tokens on Ethereum, it has become common for EO
 
 |     Constant     | Value  |
 | ---------------- | ------ |
-| `MAGIC`          | `0x03` |
+| `MAGIC`          | `0x04` |
 
 `MAGIC` is used for [EIP-3074](./eip-3074.md) signatures to prevent signature collisions with other signing formats.
 


### PR DESCRIPTION
per [this comment](https://ethereum-magicians.org/t/eip-3074-auth-and-authcall-opcodes/4880/133?u=anna-carroll), EIP-4844 blob transactions use `0x03` as the EIP-2718 TransactionType prefix. it was suggested that EIP-3074 `MAGIC` byte should choose a different prefix to avoid any possibility of collision.