### PR TITLE
Update EIP-7549: fix typo #8015

### DIFF
--- a/EIPS/eip-7549.md
+++ b/EIPS/eip-7549.md
@@ -16,7 +16,7 @@ Move the committee `index` field outside of the signed Attestation message to al
 
 ## Motivation
 
-This proposal aims to make Casper FFG clients more efficient by reducing the average number of pairings needed to verify consensus rules. While all types of clients can benefit from this EIP, ZK circuits proving Casper FFG consensus are likely to have to most impact.
+This proposal aims to make Casper FFG clients more efficient by reducing the average number of pairings needed to verify consensus rules. While all types of clients can benefit from this EIP, ZK circuits proving Casper FFG consensus are likely to have the most impact.
 
 On a beacon chain network with at least 262144 active indexes it's necessary to verify a minimum of `ceil(32*64 * 2/3) = 1366` attestations to reach a 2/3 threshold. Participants cast two votes at once: LMD GHOST vote and Casper-FFG vote. However, the Attestation message contains three elements:
 
@@ -56,14 +56,14 @@ This EIP introduces backward incompatible changes to the block validation rule s
 
 ## Security Considerations
 
-Moving the `index` field outside of the sign message allows malicious mutation only on the p2p gossip topic `beacon_attestation_${subnet_id}`. Everywhere else, the `Attestation` message is wrapped with an outer signature that prevents mutation.
+Moving the `index` field outside of the signed message allows malicious mutation only on the p2p gossip topic `beacon_attestation_${subnet_id}`. Everywhere else, the `Attestation` message is wrapped with an outer signature that prevents mutation.
 
 Gossip verification rules for the `beacon_attestation_${subnet_id}` topic include:
 
 > - [IGNORE] There has been no other valid attestation seen on an attestation subnet that has an identical attestation.data.target.epoch and participating validator index.
 > - [REJECT] The signature of attestation is valid.
 
-For an unaggregated attestation, the tuple (slot, index, aggregation_bits) uniquely identify a single public key. Thus there is a single correct value for the field `index`. If an attacker mutates the `index` field the signature will fail to verify and the message will be dropped. This is the same outcome of mutating the aggregation bits, which is possible today. If implementations verify the attestation signature before registering it in a 'first-seen' cache, there's no risk of cache pollution.
+For an unaggregated attestation, the tuple (slot, index, aggregation_bits) uniquely identifies a single public key. Thus there is a single correct value for the field `index`. If an attacker mutates the `index` field the signature will fail to verify and the message will be dropped. This is the same outcome of mutating the aggregation bits, which is possible today. If implementations verify the attestation signature before registering it in a 'first-seen' cache, there's no risk of cache pollution.
 
 ## Copyright
 


### PR DESCRIPTION
fixed minor typos:
to -> the
sign -> signed
identify -> identifies