### PR TITLE
Update EIP-7545: clarify precompile interface

### DIFF
--- a/EIPS/eip-7545.md
+++ b/EIPS/eip-7545.md
@@ -91,7 +91,7 @@ TODO
 
 WIP
 
- * [First implementation in Optimism](https://github.com/ethereum-optimism/op-geth/pull/192) by @protolambda
+ * First implementation in Optimism (https://github.com/ethereum-optimism/op-geth/pull/192) by @protolambda
 
 ## Security Considerations
 

--- a/EIPS/eip-7545.md
+++ b/EIPS/eip-7545.md
@@ -91,7 +91,7 @@ TODO
 
 WIP
 
- * First implementation in Optimism (https://github.com/ethereum-optimism/op-geth/pull/192) by @protolambda
+ * First implementation in Optimism, pull request #192 of ethereum-optimism/op-geth by @protolambda
 
 ## Security Considerations
 

--- a/EIPS/eip-7545.md
+++ b/EIPS/eip-7545.md
@@ -26,7 +26,7 @@ A precompiled contract is added at address `0x21`, wrapping the stateless ethere
     
 The precompile's `input` is the tightly packed concatenation of the following fields:
 
-  * `version` (1 byte) specifies which version of the stateless proof verification function should be used. Version 0 is used for an MPT and version 1 is used for the polynomial commitment scheme multiproof used in EIP-6800.
+  * `version` (1 byte) specifies which version of the stateless proof verification function should be used. Version 0 is used for an MPT and version 1 is used for the polynomial commitment scheme multiproof used in [EIP-6800](./eip-6800.md).
   * `state_root` (32 bytes) specifies the state root that the proof is proving against.
   * `proof_data` (arbitrary long) is the proof data.
 

--- a/EIPS/eip-7545.md
+++ b/EIPS/eip-7545.md
@@ -2,7 +2,7 @@
 eip: 7545
 title: Verkle proof verification precompile
 description: Add a precompile to help dapps verify verkle proofs
-author: Guillaume Ballet (@gballet), ...
+author: Guillaume Ballet (@gballet), Diederik Loerakker (@protolambda)
 discussions-to: https://ethereum-magicians.org/t/verkle-proof-verification-precompile/16274
 status: Draft
 type: Standards Track
@@ -24,20 +24,27 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
     
 A precompiled contract is added at address `0x21`, wrapping the stateless ethereum proof verification function.
     
-The precompile `input` requires 4 items concatenated:
+The precompile's `input` is the tightly packed concatenation of the following fields:
 
-  * `version` (1 byte) specifies which version of the stateless proof verification function should be used
-  * `proof_data_location` (32 bytes) is a memory address where the start of the proof data can be found
-  * `proof_data_size` (8 bytes) specifies the length of the proof data.
+  * `version` (1 byte) specifies which version of the stateless proof verification function should be used. Version 0 is used for an MPT and version 1 is used for the polynomial commitment scheme multiproof used in EIP-6800.
   * `state_root` (32 bytes) specifies the state root that the proof is proving against.
+  * `proof_data` (arbitrary long) is the proof data.
 
 Pseudo-code behavior of the precompile:
     
 ```python
-def proof_verification_precompile(version, loc, size, root):
+def proof_verification_precompile(input):
+    version = input[0]
+    state_root = input[1:33]
+    proof_data = input[33:33+proof_data_size]
+
     if version == 0:
-        proof = deserialize_proof(root, memory[loc:loc+size])
-        return verify_multiproof_pcs(proof)
+        proof = deserialize_proof(state_root, proof_data)
+        return verify_mpt_multiproof(proof)
+
+    if version == 1:
+        proof = deserialize_proof(state_root, proof_data)
+        return verify_pcs_multiproof(proof)
     
     return 0
 ```
@@ -82,7 +89,9 @@ TODO
 
 ## Reference Implementation
 
-TODO
+WIP
+
+ * [First implementation in Optimism](https://github.com/ethereum-optimism/op-geth/pull/192) by @protolambda
 
 ## Security Considerations
 


### PR DESCRIPTION
The previous text of the EIP was quite confusing (and sometimes downright incorrect) regarding how the parameters are to be passed to the precompile. This PR updates it to specify that all parameters are passed, concatenated, via the regular `input` interface. The precompile no longer reads memory.