### PR TITLE
Update EIP-5283: few grammatical corrections

### DIFF
--- a/EIPS/eip-5283.md
+++ b/EIPS/eip-5283.md
@@ -59,9 +59,9 @@ abstract contract ReentrancyGuard2 {
 }
 ```
 
-### Parallellizable storage-based RPGs
+### Parallelizable storage-based RPGs
  
-The only way to paralellize prexistent contracts that are using the storage RPG construction is that the VM automatically detects that a storage variable is used for the RPG, and proves that is works as required. This requires static code analysys. This is difficult to implement in consensus for two reasons. First, the CPU cost of detection and/or proving may be high. Second, some contract functions may not be protected by the RPG, meaning that some execution paths do not alter the RPG, which may complicate proving. Therefore this proposal aims to protect future contracts and let them be parallelizable, rather than to paralellize already deployed ones.
+The only way to parallelize preexistent contracts that are using the storage RPG construction is that the VM automatically detects that a storage variable is used for the RPG, and proves that it works as required. This requires static code analysis. This is difficult to implement in consensus for two reasons. First, the CPU cost of detection and/or proving may be high. Second, some contract functions may not be protected by the RPG, meaning that some execution paths do not alter the RPG, which may complicate proving. Therefore this proposal aims to protect future contracts and let them be parallelizable, rather than to parallelize already deployed ones.
 
 ### Alternatives
 


### PR DESCRIPTION
Hi, just a few typos I found. Also I'm pretty sure "transaction execution parallelization" (line 24) should be remplaced with "parallelized transaction execution", but I'm not sure. Let me know if you wish me to correct that aswell. Have a nice day