### PR TITLE
Update EIP-3074: add nonce to auth msg to provide revocation

### DIFF
--- a/EIPS/eip-3074.md
+++ b/EIPS/eip-3074.md
@@ -92,10 +92,11 @@ If `length` is greater than 97, the extra bytes are ignored for signature verifi
 
 `authority` is the address of the account which generated the signature.
 
-The arguments (`yParity`, `r`, `s`) are interpreted as an ECDSA signature on the secp256k1 curve over the message `keccak256(MAGIC || chainId || paddedInvokerAddress || commit)`, where:
+The arguments (`yParity`, `r`, `s`) are interpreted as an ECDSA signature on the secp256k1 curve over the message `keccak256(MAGIC || chainId || nonce || invokerAddress || commit)`, where:
 
  - `chainId` is the current chain's [EIP-155](./eip-155.md) unique identifier padded to 32 bytes.
- - `paddedInvokerAddress` is the address of the contract executing `AUTH` (or the active state address in the context of `CALLCODE` or `DELEGATECALL`), left-padded with zeroes to a total of 32 bytes (ex. `0x000000000000000000000000AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA`).
+ - `nonce` is the signer's nonce after which the message will be considered invalid, left-padded to 32 bytes.
+ - `invokerAddress` is the address of the contract executing `AUTH` (or the active state address in the context of `CALLCODE` or `DELEGATECALL`), left-padded with zeroes to a total of 32 bytes (ex. `0x000000000000000000000000AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA`).
  - `commit`, one of the arguments passed into `AUTH`, is a 32-byte value that can be used to commit to specific additional validity conditions in the invoker's pre-processing logic (e.g. a nonce for replay protection).
 
 Signature validity and signer recovery is handled analogously to transaction signatures, including the stricter `s` range for preventing ECDSA malleability. Note that `yParity` is expected to be `0` or `1`.
@@ -109,7 +110,8 @@ If the signature is valid and the signer address is equal to `authority`, the co
 The gas cost for `AUTH` is equal to the sum of:
 
  - fixed fee `3100`.
- - memory expansion gas cost (`auth_memory_expansion_fee`)
+ - memory expansion gas cost (`auth_memory_expansion_fee`).
+ - `100` if `authority` is warm, `2600` if it is cold (per [EIP-2929](./eip-2929.md)).
 
 The fixed fee is equal to the cost for the `ecrecover` precompile, plus a bit extra to cover a keccak256 hash and some additional logic.
 


### PR DESCRIPTION
This is one of the longest request features of 3074. Thanks to @yoavw and @shemnon for more recent discussions on the topic and inspiration for this adaptation.

--

This PR modifies the `AUTH` message to now include `nonce`. The full message, over which the signature is constructed, is now as follows:

```
keccak256(MAGIC || chainId || nonce || invokerAddress || commit)
```

This places `nonce` within the protocol-definition of the `AUTH` message, so no matter the security of the invoker it is possible for the user to revoke any and all outstanding `AUTH` signatures they've created.

Using the message *does not* increment the EOA's nonce. This allows the user to reuse the same `AUTH` signature as much as they like (until their EOA originates a tx), which provides a similar experience to the original 3074 proposal while still providing global revocation.

The anticipated usage of `nonce` is to be set the EOA's current nonce. This way, a single tx origination will revoke all outstanding signatures. The rationale for this is once a user has signed to an invoker, it should be possible for them to do almost all of their normal tasks via their invoker, so long as there is some entity relaying their ops on-chain.

Although this is the anticipated and recommended usage of `nonce`, it does prohibit other nonce values to be used. `2**64` would be equivalent to the previous version of 3074 where there was no in-protocol revocation. We strongly advise wallets do not allow signing `AUTH` messages this high, but do concede there may be occasional use cases for this, such as an extremely locked-down social recovery invoker that you do not want to be revocable via the nonce.

Hopefully this will provide enough protection and flexibility to please all sides of the 3074 debate!
