### PR TITLE
Update EIP-6916: fix typo

### DIFF
--- a/EIPS/eip-6916.md
+++ b/EIPS/eip-6916.md
@@ -91,7 +91,7 @@ Note that depending on the client architecture, it may not be feasible to fully 
 
 Ephemeral testnets with deterministic parameters provide a sustainable alternative to traditional testnets, with the same infrastructure. At each reset, the validator set is cleared, faucets are filled again and the database is kept small.
 
-Upon reset the whole state is purged, which, on the one hand keeps the network small and easy to bootstrap but introduces problems for testing longer term / advanced applications. However, basic contract infrastracture can be automatically deployed after each reset by any user. Generally, using the network is recommended for short term testing, deploying `Hello World` kinds of contracts that don't need to stay forever on a long term testnet. However, there can be an offchain mechanism that automatically deploys standard contract primitives after each reset so application developers can also utilize the network more.
+Upon reset the whole state is purged, which, on the one hand keeps the network small and easy to bootstrap but introduces problems for testing longer term / advanced applications. However, basic contract infrastructure can be automatically deployed after each reset by any user. Generally, using the network is recommended for short term testing, deploying `Hello World` kinds of contracts that don't need to stay forever on a long term testnet. However, there can be an offchain mechanism that automatically deploys standard contract primitives after each reset so application developers can also utilize the network more.
 
 By defining two mechanisms for Genesis and Reset, this EIP enables two levels of how a client implementation can support the testnet;
 


### PR DESCRIPTION
fix a typo: infrastracture -> infrastructure 