### PR TITLE
Update EIP-3540: Remove mention of terminating instruction requirement

### DIFF
--- a/EIPS/eip-3540.md
+++ b/EIPS/eip-3540.md
@@ -35,7 +35,6 @@ A non-exhaustive list of proposed changes which could benefit from this format:
 
 - Including a `JUMPDEST`-table (to avoid analysis at execution time) and/or removing `JUMPDEST`s entirely.
 - Introducing static jumps (with relative addresses) and jump tables, and disallowing dynamic jumps at the same time.
-- Requiring the execution of a code section ends with a terminating instruction. (Assumptions like this can provide significant speed improvements in interpreters, such as a speed-up of ~7% seen in evmone (ethereum/evmone#295).
 - Multibyte opcodes without any workarounds.
 - Representing functions as individual code sections instead of subroutines.
 - Introducing special sections for different use cases, notably Account Abstraction.


### PR DESCRIPTION
Terminating instruction requirement was a feature of EIP-3670 from the early days of EOF, not relevant with current stack validation proposal