### PR TITLE
Update EIP-6913: Move to Draft

### DIFF
--- a/EIPS/eip-6913.md
+++ b/EIPS/eip-6913.md
@@ -36,8 +36,8 @@ Given the upcoming deprecation of `SELFDESTRUCT`, `SETCODE` introduces a better 
 ## Specification
 
 When within a read-only execution scope like the recursive kind created by `STATICCALL`, `SETCODE` causes an exceptional abort.
-When inside of a `CREATE`-like execution scope that returns new code for the executing address (the account returned by `ADDRESS`), `SETCODE` causes an exceptional abort.
-When inside of a `DELEGATECALL`-like execution scope where the currently executing code does not belong to the executing account, `SETCODE` causes an exceptional abort.
+
+When the currently executing code does not equal the code of the executing account, such as can happen inside of `DELEGATECALL` or `CREATE`, `SETCODE` causes an exceptional abort.
 
 Otherwise, `SETCODE` consumes two words from the stack: offset and length.
 These specify a range of memory containing the new code.
@@ -62,10 +62,11 @@ The gas cost of `SETCODE` is comparable to `CREATE` but excludes Gcreate because
 Other account modification costs are accounted for outside of execution gas.
 
 Unlike `SELFDESTRUCT`, execution proceeds normally after `SETCODE` in order to allow validation and return data.
-Post-update validation can undo a `SETCODE` operation with `REVERT` or with a subesequent `SETCODE`, but `REVERT` uses less-gas.
+Post-update validation can undo a `SETCODE` operation with `REVERT`, or with a recursive `SETCODE`, but `REVERT` uses less-gas.
 
-Preventing `SETCODE` within `DELEGATECALL` allows static analysis to easily identify mutable code.
+Preventing `SETCODE` within most `DELEGATECALL` allows static analysis to easily identify mutable code.
 Account code not containing the `SETCODE` operation can be safely assumed to be immutable.
+Code observed in a non-reverting context to be immutable will remain immutable, allowing on-chain static analysis for immutability.
 
 ## Backwards Compatibility
 

--- a/EIPS/eip-6913.md
+++ b/EIPS/eip-6913.md
@@ -1,10 +1,10 @@
 ---
 eip: 6913
 title: SETCODE instruction
-description: replace code in-place
+description: new instruction to replace code in-place
 author: William Morriss (@wjmelements)
 discussions-to: https://ethereum-magicians.org/t/eip-6913-setcode-instruction/13898
-status: Stagnant
+status: Draft
 type: Standards Track
 category: Core
 created: 2023-04-20
@@ -52,13 +52,13 @@ Unlike `SELFDESTRUCT`, `SETCODE` does not clear account balance, nonce, or stora
 
 ### Gas
 
-The gas cost of this operation is the sum of Gselfdestruct and the product of Gcodedeposit and the number of bytes in the new code.
+The gas cost of this operation is the sum of `Gselfdestruct` and the product of `Gcodedeposit` and the number of bytes in the new code.
 
 ## Rationale
 
 The behavior of `CODECOPY`, `CODESIZE`, `EXTCODESIZE`, and `EXTCODECOPY` match the behavior of `DELEGATECALL` and `CREATE`, where it is also possible for executing code to differ from the code of the executing account.
 
-The gas cost of `SETCODE` is comparable to `CREATE` but excludes Gcreate because no execution context is created, nor any new account.
+The gas cost of `SETCODE` is comparable to `CREATE` but excludes `Gcreate` because no execution context is created, nor any new account.
 Other account modification costs are accounted for outside of execution gas.
 
 Unlike `SELFDESTRUCT`, execution proceeds normally after `SETCODE` in order to allow validation and return data.

--- a/EIPS/eip-6913.md
+++ b/EIPS/eip-6913.md
@@ -62,7 +62,7 @@ The gas cost of `SETCODE` is comparable to `CREATE` but excludes Gcreate because
 Other account modification costs are accounted for outside of execution gas.
 
 Unlike `SELFDESTRUCT`, execution proceeds normally after `SETCODE` in order to allow validation and return data.
-Post-update validation can undo a `SETCODE` operation with `REVERT`, or with a recursive `SETCODE`, but `REVERT` uses less-gas.
+Post-update validation can undo a `SETCODE` operation with `REVERT`, or with a recursive `SETCODE`, but `REVERT` uses less gas.
 
 Preventing `SETCODE` within most `DELEGATECALL` allows static analysis to easily identify mutable code.
 Account code not containing the `SETCODE` operation can be safely assumed to be immutable.


### PR DESCRIPTION

This simplification has the same properties as the belongs-to spec but is clearer and combines separate rules into a general rule.
#### Changes
The general rule is now to allow when the currently executing code equals the code of the executing account.
This encapsulates the relevant cases of `DELEGATECALL` and `CREATE`, while keeping the same security properties as the more-complex belongs-to.