### PR TITLE
EIP-1153: Specify almost identical behaviour to storage

### DIFF
--- a/EIPS/eip-1153.md
+++ b/EIPS/eip-1153.md
@@ -1,7 +1,7 @@
 ---
 eip: 1153
 title: Transient storage opcodes
-description: Add opcodes for manipulating state that behaves identically to storage but is discarded after every transaction
+description: Add opcodes for manipulating state that behaves almost identically to storage but is discarded after every transaction
 author: Alexey Akhunov (@AlexeyAkhunov), Moody Salem (@moodysalem)
 discussions-to: https://ethereum-magicians.org/t/eip-transient-storage-opcodes/553
 status: Last Call
@@ -14,7 +14,7 @@ requires: 2200, 3529
 
 ## Abstract
 
-This proposal introduces transient storage opcodes, which manipulate state that behaves identically to storage, except that transient storage is discarded after every transaction. In other words, the values of transient storage are never deserialized from storage or serialized to storage. Thus transient storage is cheaper since it never requires disk access. Transient storage is accessible to smart contracts via 2 new opcodes, `TLOAD` and `TSTORE`, where “T” stands for "transient:"
+This proposal introduces transient storage opcodes, which manipulate state that behaves almost identically to storage, except that transient storage is discarded after every transaction. In other words, the values of transient storage are never deserialized from storage or serialized to storage. Thus transient storage is cheaper since it never requires disk access. Transient storage is accessible to smart contracts via 2 new opcodes, `TLOAD` and `TSTORE`, where “T” stands for "transient:"
 
 ```
 TLOAD  (0x5c)
@@ -64,6 +64,8 @@ If a frame reverts, all writes to transient storage that took place between entr
 
 If the `TSTORE` opcode is called within the context of a `STATICCALL`, it will result in an exception instead of performing the modification. `TLOAD` is allowed within the context of a `STATICCALL`.
 
+The behavior of the opcodes for transient storage differs from the opcodes for storage in that they do not require _gasleft_, as defined in [EIP-2200](./eip-2200.md), to be less than or equal to the gas stipend (currently 2,300).
+
 ## Rationale
 
 Another option to solve the problem of inter-frame communication is repricing the `SSTORE` and `SLOAD` opcodes to be cheaper for the transient storage use case. This has already been done as of [EIP-2200](./eip-2200.md). However, [EIP-3529](./eip-3529.md) reduced the maximum refund to only 20% of the transaction gas cost, which means the use of transient storage is severely limited.
@@ -98,7 +100,7 @@ Since this EIP does not change behavior of any existing opcodes, it is backwards
 
 ## Reference Implementation
 
-Because the transient storage must behave identically to storage within the context of a single transaction with regards to revert behavior, it is necessary to be able to revert to a previous state of transient storage within a transaction. At the same time reverts are exceptional cases and loads, stores and returns should be cheap.
+Because the transient storage must behave almost identically to storage within the context of a single transaction with regards to revert behavior, it is necessary to be able to revert to a previous state of transient storage within a transaction. At the same time reverts are exceptional cases and loads, stores and returns should be cheap.
 
 A map of current state plus a journal of all changes and a list of checkpoints is recommended. This has the following time complexities:
 


### PR DESCRIPTION
[EIP-1153](https://eips.ethereum.org/EIPS/eip-1153) does not behave identically to storage for low-gas executions as the `gasleft` restriction from [EIP-2200](https://eips.ethereum.org/EIPS/eip-2200) for `SSTORE` is not applied to `TSTORE`. You can see this in the execution specs [here](https://github.com/ethereum/execution-specs/blob/cd9b7d6a9af2f5e07cad02a4971744dd6a553b10/src/ethereum/shanghai/vm/instructions/storage.py#L77):

```py
def sstore(evm: Evm) -> None:
    """
    Stores a value at a certain key in the current context's storage.

    Parameters
    ----------
    evm :
        The current EVM frame.

    """
    # STACK
    key = pop(evm.stack).to_be_bytes32()
    new_value = pop(evm.stack)

    # GAS
    ensure(evm.gas_left > GAS_CALL_STIPEND, OutOfGasError) # -> This line matters!
```

This PR tries to clarify this behaviour.