### PR TITLE
Update EIP-4788: Use "blob" term consistent with EIP-4844

### DIFF
--- a/EIPS/eip-4788.md
+++ b/EIPS/eip-4788.md
@@ -68,8 +68,8 @@ rlp([
     0x0000000000000000, # nonce
     base_fee_per_gas,
     withdrawals_root,
-    data_gas_used,
-    excess_data_gas,
+    blob_gas_used,
+    excess_blob_gas,
     parent_beacon_block_root,
 ])
 ```


### PR DESCRIPTION
This PR makes the block header specification consistent with the changes introduced in EIP-4844. The change is necessary because the current terms are ambiguous.