### PR TITLE
Update EIP-2935: Move to Draft

### DIFF
--- a/EIPS/eip-2935.md
+++ b/EIPS/eip-2935.md
@@ -1,9 +1,9 @@
 ---
 eip: 2935
 title: Save historical block hashes in state
-author: Vitalik Buterin (@vbuterin), Tomasz Stanczak (@tkstanczak)
+author: Vitalik Buterin (@vbuterin), Tomasz Stanczak (@tkstanczak), Guillaume Ballet (gballet), Gajinder Singh (@g11tech)
 discussions-to: https://ethereum-magicians.org/t/eip-2935-save-historical-block-hashes-in-state/4565
-status: Stagnant
+status: Draft
 type: Standards Track
 category: Core
 created: 2020-09-03
@@ -26,12 +26,14 @@ Additional secondary motivations include:
 
 | Parameter | Value |
 | - | - |
-| `FORK_BLKNUM` | TBD |
+| `FORK_BLKTIME` | TBD |
 | `HISTORY_STORAGE_ADDRESS` | `0xfffffffffffffffffffffffffffffffffffffffe`|
 
-At the start of processing any block where `block.number > FORK_BLKNUM` (ie. before processing any transactions), run `sstore(HISTORY_STORAGE_ADDRESS, block.number - 1, block.prevhash)`.
+At the start of processing any block where `block.timestamp > FORK_BLKTIME` (ie. before processing any transactions), run `sstore(HISTORY_STORAGE_ADDRESS, block.number - 1, block.prevhash)`.
 
-When `block.number > FORK_BLKNUM + 256`, change the logic of the `BLOCKHASH` opcode as follows: if `FORK_BLKNUM <= arg < block.number`, return `sload(HISTORY_STORAGE_ADDRESS, arg)`. Otherwise return 0.
+When `sload(HISTORY_STORAGE_ADDRESS, max(block.number - 256, 0)) != 0`, change the logic of the `BLOCKHASH` opcode as follows: return `sload(HISTORY_STORAGE_ADDRESS, arg)`.
+
+Note that this means that slot `max(block.number - 256, 0)` is accessed during block execution.
 
 ## Rationale
 
@@ -41,6 +43,11 @@ Very similar ideas were proposed before in EIP-98 and EIP-210. This EIP is a sim
 2. Writing the EIP in EVM code
 
 The former was intended to save space. Since then, however, storage usage has increased massively, to the point where even eg. 5 million new storage slots are fairly negligible compared to existing usage. The latter was intended as a first step toward "writing the Ethereum protocol in EVM" as much as possible, but this goal has since been de-facto abandoned.
+
+The touching of slot `max(block.number - 256, 0)` during block execution is necessary so that:
+
+ * detecting the activation of a fork now that forks are timestamp-activated; and
+ * stateless clients can determine if the fork has happened, and if the new behavior can be activated.
 
 ## Backwards Compatibility
 
@@ -52,7 +59,8 @@ TBD
 
 ## Implementation
 
-TBD
+ * PR 28878 of go-ethereum
+ * Active on verkle-gen-devet-3 for its verkle implementation
 
 ## Security Considerations
 

--- a/EIPS/eip-2935.md
+++ b/EIPS/eip-2935.md
@@ -10,7 +10,7 @@ category: Core
 created: 2020-09-03
 ---
 
-## Simple Summary
+## Abstract
 
 Store historical block hashes in a contract, and modify the `BLOCKHASH (0x40)` opcode to read this contract.
 
@@ -63,7 +63,7 @@ The range of `BLOCKHASH` is increased by this opcode, but behavior within the pr
 
 TBD
 
-## Implementation
+## Reference Implementation
 
  * PR 28878 of go-ethereum
  * Active on verkle-gen-devet-3 for its verkle implementation

--- a/EIPS/eip-2935.md
+++ b/EIPS/eip-2935.md
@@ -40,7 +40,7 @@ At the start of processing any block where `block.timestamp > FORK_TIMESTAMP` (i
 
 Edge cases:
 
- * For verkle at genesis, no history is written to the genesis state, and at the start of block `1`, genesis hash will be written as a normal operation to slot `0`.
+ * For the fork to be activated at genesis, no history is written to the genesis state, and at the start of block `1`, genesis hash will be written as a normal operation to slot `0`.
  * for verkle activated at block `1`, only genesis hash will be written at slot `0` as no additional history needs to be persisted.
  * for verkle activated at block `32`, block `31`'s hash will be written to slot `31` and additonal history for `0..30`'s hashes will be persisted, so all in all `0..31`'s hashes.
 

--- a/EIPS/eip-2935.md
+++ b/EIPS/eip-2935.md
@@ -1,7 +1,7 @@
 ---
 eip: 2935
 title: Save historical block hashes in state
-author: Vitalik Buterin (@vbuterin), Tomasz Stanczak (@tkstanczak), Guillaume Ballet (@gballet), Gajinder Singh (@g11tech)
+author: Vitalik Buterin (@vbuterin), Tomasz Stanczak (@tkstanczak), Guillaume Ballet (@gballet), Gajinder Singh (@g11tech), Tanishq Jasoria (@tanishqjasoria)
 description: store previous block hashes as storage slots of a system contract to allow for stateless execution
 discussions-to: https://ethereum-magicians.org/t/eip-2935-save-historical-block-hashes-in-state/4565
 status: Draft
@@ -27,14 +27,19 @@ Additional secondary motivations include:
 
 | Parameter | Value |
 | - | - |
-| `FORK_BLKTIME` | TBD |
+| `FORK_TIMESTAMP` | TBD |
 | `HISTORY_STORAGE_ADDRESS` | `0xfffffffffffffffffffffffffffffffffffffffe`|
+| `HISTORY_SERVE_WINDOW` | `256` |
 
-At the start of processing any block where `block.timestamp > FORK_BLKTIME` (ie. before processing any transactions), run `sstore(HISTORY_STORAGE_ADDRESS, block.number - 1, block.prevhash)`.
+At the start of processing any block where `block.timestamp > FORK_TIMESTAMP` (ie. before processing any transactions), 
+* run `sstore(HISTORY_STORAGE_ADDRESS, block.number - 1, block.prevhash)`. 
+* **additionally** if this is the first block of the fork, then store last `min(HISTORY_SERVE_WINDOW-1, block.number-1)` **blocks' prevhash** into their corresponding slots i.e persist the entire `HISTORY_SERVE_WINDOW` block hashes (up until the genesis) that can be accessed in the block.
+* change the logic of the `BLOCKHASH` opcode as follows: return `sload(HISTORY_STORAGE_ADDRESS, arg)`.
 
-When `sload(HISTORY_STORAGE_ADDRESS, max(block.number - 256, 0)) != 0`, change the logic of the `BLOCKHASH` opcode as follows: return `sload(HISTORY_STORAGE_ADDRESS, arg)`.
-
-Note that this means that slot `max(block.number - 256, 0)` is accessed during block execution.
+Edge cases:
+* For verkle at genesis, no history is written to the genesis state, and at the start of block `1`, genesis hash will be written as a normal operation to slot `0`.
+* for verkle activated at block `1`, only genesis hash will be written at slot `0` as no additional history needs to be persisted.
+* for verkle activated at block `32`, block `31`'s hash will be written to slot `31` and additonal history for `0..30`'s hashes will be persisted, so all in all `0..31`'s hashes.
 
 ## Rationale
 
@@ -45,10 +50,7 @@ Very similar ideas were proposed before in EIP-98 and EIP-210. This EIP is a sim
 
 The former was intended to save space. Since then, however, storage usage has increased massively, to the point where even eg. 5 million new storage slots are fairly negligible compared to existing usage. The latter was intended as a first step toward "writing the Ethereum protocol in EVM" as much as possible, but this goal has since been de-facto abandoned.
 
-The touching of slot `max(block.number - 256, 0)` during block execution is necessary so that:
-
- * detecting the activation of a fork now that forks are timestamp-activated; and
- * stateless clients can determine if the fork has happened, and if the new behavior can be activated.
+Storing of all last `HISTORY_SERVE_WINDOW` block hashes alleviates the need to detect fork activation height to transition to the new logic as the entire required history will be available from the first block of the fork itself. The cost of doing so is marginal considering the `HISTORY_SERVE_WINDOW` being small.
 
 ## Backwards Compatibility
 

--- a/EIPS/eip-2935.md
+++ b/EIPS/eip-2935.md
@@ -1,8 +1,8 @@
 ---
 eip: 2935
-title: Save historical block hashes in state
-description: store previous block hashes as storage slots of a system contract to allow for stateless execution
-author: Vitalik Buterin (@vbuterin), Tomasz Stanczak (@tkstanczak), Guillaume Ballet (@gballet), Gajinder Singh (@g11tech), Tanishq Jasoria (@tanishqjasoria)
+title: Serve historical block hashes from state
+description: Store and serve last 8192 block hashes as storage slots of a system contract to allow for stateless execution
+author: Vitalik Buterin (@vbuterin), Tomasz Stanczak (@tkstanczak), Guillaume Ballet (@gballet), Gajinder Singh (@g11tech), Tanishq Jasoria (@tanishqjasoria), Ignacio Hagopian (@jsign), Jochem Brouwer (@jochem-brouwer)
 discussions-to: https://ethereum-magicians.org/t/eip-2935-save-historical-block-hashes-in-state/4565
 status: Draft
 type: Standards Track
@@ -12,23 +12,24 @@ created: 2020-09-03
 
 ## Abstract
 
-Store last 256 historical block hashes in a contract, and modify the `BLOCKHASH (0x40)` opcode to read and serve from this contract storage.
+Store last `HISTORY_SERVE_WINDOW` historical block hashes in a contract, and modify the `BLOCKHASH (0x40)` opcode to read and serve from this contract storage.
 
 ## Motivation
 
-Currently BLOCKHASH opcode accesses history to resolve hash of the block number in EVM. However a more stateless client friendly way is to maintain and serve these hashes from state.
+Currently `BLOCKHASH` opcode accesses history to resolve hash of the block number in EVM. However a more stateless client friendly way is to maintain and serve these hashes from state.
 
-Although this is possible even in Merkle trie state, but Verkle trie state further allows bundling the BLOCKHASH witnesses (along with other witnesses) in an efficient manner making it worthwhile to have these in state.
+Although this is possible even in Merkle trie state, but Verkle trie state further allows bundling the `BLOCKHASH` witnesses (along with other witnesses) in an efficient manner making it worthwhile to have these in state.
 
-A side benefit of this approach could be that it allows building/validating proofs related to last 256 ancestors directly against the current state.
+A side benefit of this approach could be that it allows building/validating proofs related to last `HISTORY_SERVE_WINDOW` ancestors directly against the current state.
 
 ## Specification
 
 | Parameter | Value |
 | - | - |
 | `FORK_TIMESTAMP` | TBD |
-| `HISTORY_STORAGE_ADDRESS` | `0xfffffffffffffffffffffffffffffffffffffffe`|
-| `HISTORY_SERVE_WINDOW` | `256` |
+| `HISTORY_STORAGE_ADDRESS` | `0x25a219378dad9b3503c8268c9ca836a52427a4fb`|
+| `HISTORY_SERVE_WINDOW` | `8192` |
+| `BLOCKHASH_OLD_WINDOW` | `256` |
 
 This EIP specifies for storing last `HISTORY_SERVE_WINDOW` block hashes in a ring buffer storage of `HISTORY_SERVE_WINDOW` length.
 
@@ -40,7 +41,7 @@ def process_block_hash_history(block: Block, state: State):
     if block.timestamp >= FORK_TIMESTAMP:
         state.insert_slot(HISTORY_STORAGE_ADDRESS, (block.number-1) % HISTORY_SERVE_WINDOW , block.parent.hash)
 
-    # If this is the first fork block, add the parent's direct 255 ancestors as well
+    # If this is the fork block, add the parent's direct `HISTORY_SERVE_WINDOW - 1` ancestors as well
     if block.parent.timestamp < FORK_TIMESTAMP:
         ancestor = block.parent
         for i in range(HISTORY_SERVE_WINDOW - 1):
@@ -52,25 +53,119 @@ def process_block_hash_history(block: Block, state: State):
             state.insert_slot(HISTORY_STORAGE_ADDRESS, ancestor.number % HISTORY_SERVE_WINDOW, ancestor.hash)
 ```
 
-Note that if this is the fork block, then it persists the additional requisite history that could be needed while resolving `BLOCKHASH` opcode for all of the `HISTORY_SERVE_WINDOW` ancestors (up until genesis).
+Note that if this is the fork block, then it persists the additional requisite history that could be needed while resolving `BLOCKHASH` opcode for all of the `HISTORY_SERVE_WINDOW` > `BLOCKHASH_OLD_WINDOW` ancestors (up until genesis).
 
 For resolving the `BLOCKHASH` opcode this fork onwards (`block.timestamp >= FORK_TIMESTAMP`), switch the logic to:
 
 ```python
 def resolve_blockhash(block: Block, state: State, arg: uint64):
   # check the wrap around range
-  if arg >= block.number or arg < max(block.number - HISTORY_SERVE_WINDOW, 0)
+  if arg >= block.number or (arg + HISTORY_SERVE_WINDOW) < block.number
     return 0
 
   return state.load_slot(HISTORY_STORAGE_ADDRESS, arg % HISTORY_SERVE_WINDOW)
 ```
+
+### Contract Implementation
+
+Exact evm assembly that can be used for the contract to resolve `BLOCKHASH`
+
+```
+// check if inputsize>32 revert
+push1 0x20
+calldatasize
+gt
+push1 0x31
+jumpi
+
+// check if input > blocknumber-1 then return 0
+push1 0x1
+number
+sub
+push0
+calldataload
+gt
+push1 0x29
+jumpi
+
+// check if blocknumber > input + 8192 then return 0
+push0
+calldataload
+push2 0x2000
+add
+number
+gt
+push1 0x29
+jumpi
+
+// mod 8192 and sload
+push2 0x2000
+push0
+calldataload
+mod
+sload
+
+// load into mem and return 32 bytes
+push0
+mstore
+push1 0x20
+push0
+return
+
+// return 0
+jumpdest
+push0
+push0
+mstore
+push1 0x20
+push0
+return
+
+// revert
+jumpdest
+push0
+push0
+revert
+
+stop
+```
+
+Corresponding bytecode:
+`60203611603157600143035f35116029575f356120000143116029576120005f3506545f5260205ff35b5f5f5260205ff35b5f5ffd00`
+
+#### Deployment
+
+A special synthetic address is generated by working backwards from the desired deployment transaction:
+
+```json
+{
+  "type": "0x0",
+  "nonce": "0x0",
+  "to": null,
+  "gas": "0x3d090",
+  "gasPrice": "0xe8d4a51000",
+  "maxPriorityFeePerGas": null,
+  "maxFeePerGas": null,
+  "value": "0x0",
+  "input": "0x60368060095f395ff360203611603157600143035f35116029575f356120000143116029576120005f3506545f5260205ff35b5f5f5260205ff35b5f5ffd00",
+  "v": "0x1b",
+  "r": "0x539",
+  "s": "0x1b9b6eb1f0",
+  "hash": "7ba81426bfa88a2cf4ea5c9abbbe83619505acd1173bc8450f93cf17cde3784b",
+}
+```
+
+Note, the input in the transaction has a simple constructor prefixing the desired runtime code.
+
+The sender of the transaction can be calculated as `0xa4690f0ed0d089faa1e0ad94c8f1b4a2fd4b0734`. The address of the first contract deployed from the account is `rlp([sender, 0])` which equals `0x25a219378dad9b3503c8268c9ca836a52427a4fb`. This is how `HISTORY_STORAGE_ADDRESS` is determined. Although this style of contract creation is not tied to any specific initcode like create2 is, the synthetic address is cryptographically bound to the input data of the transaction (e.g. the initcode).
+
 
 Some activation scenarios:
 
  * For the fork to be activated at genesis, no history is written to the genesis state, and at the start of block `1`, genesis hash will be written as a normal operation to slot `0`.
  * for activation at block `1`, only genesis hash will be written at slot `0` as there is no additional history that needs to be persisted.
  * for activation at block `32`, block `31`'s hash will be written to slot `31` and additonal history for `0..30`'s hashes will be persisted, so all in all `0..31`'s hashes.
- * for activation at block `1000`, block `744-999`'s hashes will be presisted in the slot and `BLOCKHASH` for `743` or less would resolve to `0` as only `HISTORY_SERVE_WINDOW` can be served.
+ * for activation at block `10000`, block `1808-9999`'s hashes will be presisted in the slot and `BLOCKHASH` for `1807` or less would resolve to `0` as only `HISTORY_SERVE_WINDOW` are persisted.
 
 ### [EIP-158](./eip-158.md) handling
 
@@ -82,7 +177,7 @@ This address is currently exempt from [EIP-158](./eip-158.md) cleanup in Kaustin
 
 ### Gas costs and witnesses
 
-We propose not to modify any gas costs since clients can directly resolve `BLOCKHASH` from an in-memory maintained structure or do a direct actual `SLOAD` or even a "system" execution of the deployed contract's `get`. However, for purposes of bundling block witnesses for stateless clients (for e.g. in Verkle activated networks), client should record corresponding witness accesses and bundle in the witnesses along with the corresponding proofs.
+Since now `BLOCKHASH` is served from state, the clients now **additionally** charge the corresponding warm or cold `SLOAD` costs. For verkle based networks this would imply doing and bundling corresponding accesses (and gas charges) of `SLOAD`.
 
 ## Rationale
 
@@ -99,11 +194,12 @@ Second concern was how to best transition the BLOCKHASH resolution logic post fo
 1. Either waiting for  `HISTORY_SERVE_WINDOW` blocks for the entire relevant history to persist
 2. Storing of all last `HISTORY_SERVE_WINDOW` block hashes on the fork block.
 
-We choose to go with later as it alleviates the need to detect fork activation height to transition to the new logic in backward compatible manner as the entire requisite history will be available from the first block of the fork itself. The cost of doing so is marginal considering the `HISTORY_SERVE_WINDOW` being small.
+We choose to go with later as it alleviates the need to detect fork activation height to transition to the new logic in backward compatible manner as the entire `BLOCKHASH` requisite history will be available from the first block of the fork itself.
+The cost of doing so is marginal considering the `HISTORY_SERVE_WINDOW` being relatively limited. Most clients write this into their flat db/memory caches and just requires reading last `HISTORY_SERVE_WINDOW` from the chain history.
 
 ## Backwards Compatibility
 
-The behavior of `BLOCKHASH` opcode remains same and this EIP doesn't affect backward compatibility with the contracts deployed or the gas consumption costs as the resolution of the opcode is handled "directly" by the clients.
+The behavior of `BLOCKHASH` opcode gets extended in backward compatible manner as the history it can serve will get extended upto `HISTORY_SERVE_WINDOW` on the fork block. However the gas charges will also get bumped as per the additional `SLOAD` costs.
 
 ## Test Cases
 

--- a/EIPS/eip-2935.md
+++ b/EIPS/eip-2935.md
@@ -66,6 +66,15 @@ Edge cases:
  * for activation at block `1`, only genesis hash will be written at slot `0` as there is no additional history that needs to be persisted.
  * for activation at block `32`, block `31`'s hash will be written to slot `31` and additonal history for `0..30`'s hashes will be persisted, so all in all `0..31`'s hashes.
 
+### EIP-158 exception
+
+This address is currently exempt from [EIP-158](./eip-158.md) cleanup in Kaustinen Verkle Testnet but there are two ways this could be addressed before this EIP is adopted by ACD:
+
+* Update the nonce to 1 in the fork block, or
+* Deploy a contract à la [EIP-4788](./eip-4788.md) with `BLOCKHASH` opcode delegating call to this contract with appropriate args.
+
+While the second option looks more elegant, but it has higher complexity as well as gas consumption considerations.
+
 ## Rationale
 
 Very similar ideas were proposed before in [EIP-210](./eip-210.md) et al. This EIP is a simplification, removing two sources of needless complexity:

--- a/EIPS/eip-2935.md
+++ b/EIPS/eip-2935.md
@@ -31,17 +31,39 @@ Additional secondary motivations include:
 | `HISTORY_STORAGE_ADDRESS` | `0xfffffffffffffffffffffffffffffffffffffffe`|
 | `HISTORY_SERVE_WINDOW` | `256` |
 
-At the start of processing any block where `block.timestamp > FORK_TIMESTAMP` (ie. before processing any transactions):
+At the start of processing any block where `block.timestamp > FORK_TIMESTAMP` (ie. before processing any transactions), update the history in the following way:
 
- * run `sstore(HISTORY_STORAGE_ADDRESS, block.number - 1, block.prevhash)`. 
- * **additionally** if this is the first block of the fork, then store last `min(HISTORY_SERVE_WINDOW-1, block.number-1)` **blocks' prevhash** into their corresponding slots i.e persist the entire `HISTORY_SERVE_WINDOW` block hashes (up until the genesis) that can be accessed in the block.
- * change the logic of the `BLOCKHASH` opcode as follows: return `sload(HISTORY_STORAGE_ADDRESS, arg)`.
+```python
+def process_block_hash_history(block :Block, state: State):
+    if block.timestamp >= FORK_TIMESTAMP:
+        state.insert_slot(HISTORY_STORAGE_ADDRESS, block.number-1, block.parent.hash)
+
+    # If this is the first fork block, add the parent's direct 255 ancestors as well
+    if block.parent.timestamp < FORK_TIMESTAMP:
+        ancestor = block.parent
+        for i in range(255):
+            # stop at genesis block
+            if ancestor.number == 0:
+                break
+
+            ancestor = ancestor.parent
+            state.insert_slot(HISTORY_STORAGE_ADDRESS, ancestor.number, ancestor.hash)
+```
+
+Note that if this is the fork block, then it persists the additional requisite history that could be needed while resolving `BLOCKHASH` opcode for all of the `256` ancestors (up untill the genesis).
+
+For resolving the `BLOCKHASH` opcode this fork onwards, switch the logic to:
+
+```python
+def resolve_blockhash(block: Block, state: State, arg: uint64):
+  assert(arg < block.number)
+  return state.load_slot(HISTORY_STORAGE_ADDRESS, arg)
+```
  
-
 Edge cases:
 
  * For the fork to be activated at genesis, no history is written to the genesis state, and at the start of block `1`, genesis hash will be written as a normal operation to slot `0`.
- * for activation at block `1`, only genesis hash will be written at slot `0` as no additional history needs to be persisted.
+ * for activation at block `1`, only genesis hash will be written at slot `0` as there is no additional history that needs to be persisted.
  * for activation at block `32`, block `31`'s hash will be written to slot `31` and additonal history for `0..30`'s hashes will be persisted, so all in all `0..31`'s hashes.
 
 ## Rationale

--- a/EIPS/eip-2935.md
+++ b/EIPS/eip-2935.md
@@ -57,7 +57,7 @@ For resolving the `BLOCKHASH` opcode this fork onwards (`block.timestamp >= FORK
 ```python
 def resolve_blockhash(block: Block, state: State, arg: uint64):
   # check the wrap around range
-  if arg > block.number or arg < max(block.number - 2**256, 0)
+  if arg >= block.number or arg < max(block.number - 2**256, 0)
     return 0
 
   return state.load_slot(HISTORY_STORAGE_ADDRESS, arg)

--- a/EIPS/eip-2935.md
+++ b/EIPS/eip-2935.md
@@ -41,8 +41,8 @@ At the start of processing any block where `block.timestamp > FORK_TIMESTAMP` (i
 Edge cases:
 
  * For the fork to be activated at genesis, no history is written to the genesis state, and at the start of block `1`, genesis hash will be written as a normal operation to slot `0`.
- * for verkle activated at block `1`, only genesis hash will be written at slot `0` as no additional history needs to be persisted.
- * for verkle activated at block `32`, block `31`'s hash will be written to slot `31` and additonal history for `0..30`'s hashes will be persisted, so all in all `0..31`'s hashes.
+ * for activation at block `1`, only genesis hash will be written at slot `0` as no additional history needs to be persisted.
+ * for activation at block `32`, block `31`'s hash will be written to slot `31` and additonal history for `0..30`'s hashes will be persisted, so all in all `0..31`'s hashes.
 
 ## Rationale
 

--- a/EIPS/eip-2935.md
+++ b/EIPS/eip-2935.md
@@ -71,7 +71,7 @@ Edge cases:
  * for activation at block `1`, only genesis hash will be written at slot `0` as there is no additional history that needs to be persisted.
  * for activation at block `32`, block `31`'s hash will be written to slot `31` and additonal history for `0..30`'s hashes will be persisted, so all in all `0..31`'s hashes.
 
-### EIP-158 exception
+### [EIP-158](./eip-158.md) exception
 
 This address is currently exempt from [EIP-158](./eip-158.md) cleanup in Kaustinen Verkle Testnet but there are two ways this could be addressed before this EIP is adopted by ACD:
 

--- a/EIPS/eip-2935.md
+++ b/EIPS/eip-2935.md
@@ -52,7 +52,7 @@ def process_block_hash_history(block :Block, state: State):
 
 Note that if this is the fork block, then it persists the additional requisite history that could be needed while resolving `BLOCKHASH` opcode for all of the `256` ancestors (up untill the genesis).
 
-For resolving the `BLOCKHASH` opcode this fork onwards, switch the logic to:
+For resolving the `BLOCKHASH` opcode this fork onwards (`block.timestamp > FORK_TIMESTAMP`), switch the logic to:
 
 ```python
 def resolve_blockhash(block: Block, state: State, arg: uint64):

--- a/EIPS/eip-2935.md
+++ b/EIPS/eip-2935.md
@@ -12,16 +12,15 @@ created: 2020-09-03
 
 ## Abstract
 
-Store historical block hashes in a contract, and modify the `BLOCKHASH (0x40)` opcode to read this contract.
+Store last 256 historical block hashes in a contract, and modify the `BLOCKHASH (0x40)` opcode to read and serve from this contract storage.
 
 ## Motivation
 
-There is increasingly a desire to remove the need for most clients to store history older than some relatively short duration (often between 1 week and 1 year) to save disk space. This requires some form of layer-2 network to help clients access historical information. These protocols can be made much simpler if blocks contained a quick Merkle path to historical blocks.
+Currently BLOCKHASH opcode accesses history to resolve hash of the block number in EVM. However a more stateless client friendly way is to maintain and serve these hashes from state.
 
-Additional secondary motivations include:
+Although this is possible even in Merkle trie state, but Verkle trie state further allows bundling the BLOCKHASH witnesses (along with other witnesses) in an efficient manner making it worthwhile to have these in state.
 
-* The protocol can be used to make more secure efficient light clients with flyclient-like technology (while the "optimal" flyclient protocol is fairly complex, large security gains over the status quo (trusted "canonical hash trees") can be made cheaply)
-* Improving cleanness of the protocol, as the BLOCKHASH opcode would then access state and not history.
+A side benefit of this approach could be that it allows building/validating proofs related to last 256 ancestors directly against the current state.
 
 ## Specification
 
@@ -29,58 +28,61 @@ Additional secondary motivations include:
 | - | - |
 | `FORK_TIMESTAMP` | TBD |
 | `HISTORY_STORAGE_ADDRESS` | `0xfffffffffffffffffffffffffffffffffffffffe`|
-| `MIN_HISTORY_SERVE_WINDOW` | `256` |
-| `MAX_HISTORY_SERVE_WINDOW` | `2**256` |
+| `HISTORY_SERVE_WINDOW` | `256` |
+
+This EIP specifies for storing last `HISTORY_SERVE_WINDOW` block hashes in a ring buffer storage of `HISTORY_SERVE_WINDOW` length.
+
 
 At the start of processing any block where `block.timestamp >= FORK_TIMESTAMP` (ie. before processing any transactions), update the history in the following way:
 
 ```python
-def process_block_hash_history(block :Block, state: State):
+def process_block_hash_history(block: Block, state: State):
     if block.timestamp >= FORK_TIMESTAMP:
-        state.insert_slot(HISTORY_STORAGE_ADDRESS, block.number-1, block.parent.hash)
+        state.insert_slot(HISTORY_STORAGE_ADDRESS, (block.number-1) % HISTORY_SERVE_WINDOW , block.parent.hash)
 
     # If this is the first fork block, add the parent's direct 255 ancestors as well
     if block.parent.timestamp < FORK_TIMESTAMP:
         ancestor = block.parent
-        for i in range(MIN_HISTORY_SERVE_WINDOW - 1):
+        for i in range(HISTORY_SERVE_WINDOW - 1):
             # stop at genesis block
             if ancestor.number == 0:
                 break
 
             ancestor = ancestor.parent
-            state.insert_slot(HISTORY_STORAGE_ADDRESS, ancestor.number, ancestor.hash)
+            state.insert_slot(HISTORY_STORAGE_ADDRESS, ancestor.number % HISTORY_SERVE_WINDOW, ancestor.hash)
 ```
 
-Note that if this is the fork block, then it persists the additional requisite history that could be needed while resolving `BLOCKHASH` opcode for all of the `MIN_HISTORY_SERVE_WINDOW` ancestors (up until genesis).
+Note that if this is the fork block, then it persists the additional requisite history that could be needed while resolving `BLOCKHASH` opcode for all of the `HISTORY_SERVE_WINDOW` ancestors (up until genesis).
 
 For resolving the `BLOCKHASH` opcode this fork onwards (`block.timestamp >= FORK_TIMESTAMP`), switch the logic to:
 
 ```python
 def resolve_blockhash(block: Block, state: State, arg: uint64):
   # check the wrap around range
-  if arg >= block.number or arg < max(block.number - MAX_HISTORY_SERVE_WINDOW, 0)
+  if arg >= block.number or arg < max(block.number - HISTORY_SERVE_WINDOW, 0)
     return 0
 
-  return state.load_slot(HISTORY_STORAGE_ADDRESS, arg)
+  return state.load_slot(HISTORY_STORAGE_ADDRESS, arg % HISTORY_SERVE_WINDOW)
 ```
 
-Note that the above logic allows access deeper than `MIN_HISTORY_SERVE_WINDOW` if it exists all the way upto `MAX_HISTORY_SERVE_WINDOW`.
-
-Edge cases:
+Some activation scenarios:
 
  * For the fork to be activated at genesis, no history is written to the genesis state, and at the start of block `1`, genesis hash will be written as a normal operation to slot `0`.
  * for activation at block `1`, only genesis hash will be written at slot `0` as there is no additional history that needs to be persisted.
  * for activation at block `32`, block `31`'s hash will be written to slot `31` and additonal history for `0..30`'s hashes will be persisted, so all in all `0..31`'s hashes.
- * for activation at block `1000`, block `744-999`'s hashes will be presisted in the slot and `BLOCKHASH` for `733` or less would resolve to `0` as only `MIN_HISTORY_SERVE_WINDOW` is persisted.
+ * for activation at block `1000`, block `744-999`'s hashes will be presisted in the slot and `BLOCKHASH` for `743` or less would resolve to `0` as only `HISTORY_SERVE_WINDOW` can be served.
 
-### [EIP-158](./eip-158.md) exception
+### [EIP-158](./eip-158.md) handling
 
-This address is currently exempt from [EIP-158](./eip-158.md) cleanup in Kaustinen Verkle Testnet but there are two ways this could be addressed before this EIP is adopted by ACD:
+This address is currently exempt from [EIP-158](./eip-158.md) cleanup in Kaustinen Verkle Testnet but we plan to address this in the following way:
 
-* Update the nonce to 1 in the fork block, or
-* Deploy a contract à la [EIP-4788](./eip-4788.md) with `BLOCKHASH` opcode delegating call to this contract with appropriate args.
+* Deploy a contract à la [EIP-4788](./eip-4788.md) which just supports `get` method to resolve the BLOCKHASH as per the logic defined in `resolve_blockhash` (and use the generated address as the BLOCKHASH contract address).
+* While the clients are expected to directly read from state (or maintain and serve from memory) to resolve BLOCKHASH opcode, this contract's `get` could be invoked by transaction (via another contract or directly) leading to a normal contract execution (and gas consumption) as per the semantics of the contract call.
 
-While the second option looks more elegant, it has a higher complexity as well as gas consumption considerations.
+
+### Gas costs and witnesses
+
+We propose not to modify any gas costs since clients can directly resolve `BLOCKHASH` from an in-memory maintained structure or do a direct actual `SLOAD` or even a "system" execution of the deployed contract's `get`. However, for purposes of bundling block witnesses for stateless clients (for e.g. in Verkle activated networks), client should record corresponding witness accesses and bundle in the witnesses along with the corresponding proofs.
 
 ## Rationale
 
@@ -88,14 +90,20 @@ Very similar ideas were proposed before in [EIP-210](./eip-210.md) et al. This E
 
 1. Having a tree-like structure with multiple layers as opposed to a single list
 2. Writing the EIP in EVM code
+3. Serial unbounded storage of hashes for a deep access to the history
 
-The former was intended to save space. Since then, however, storage usage has increased massively, to the point where even eg. 5 million new storage slots are fairly negligible compared to existing usage. The latter was intended as a first step toward "writing the Ethereum protocol in EVM" as much as possible, but this goal has since been de-facto abandoned.
+However after weighing pros and cons, we decided to go with just a limited ring buffer to only serve the requisite `HISTORY_SERVE_WINDOW` as [EIP-4788](./eip-4788.md) and beacon state accumulators allow (albeit a bit more complex) proof against any ancestor since merge.
 
-Storing of all last `MIN_HISTORY_SERVE_WINDOW` block hashes alleviates the need to detect fork activation height to transition to the new logic in backward compatible manner as the entire requisite history will be available from the first block of the fork itself. The cost of doing so is marginal considering the `MIN_HISTORY_SERVE_WINDOW` being small.
+Second concern was how to best transition the BLOCKHASH resolution logic post fork by:
+
+1. Either waiting for  `HISTORY_SERVE_WINDOW` blocks for the entire relevant history to persist
+2. Storing of all last `HISTORY_SERVE_WINDOW` block hashes on the fork block.
+
+We choose to go with later as it alleviates the need to detect fork activation height to transition to the new logic in backward compatible manner as the entire requisite history will be available from the first block of the fork itself. The cost of doing so is marginal considering the `HISTORY_SERVE_WINDOW` being small.
 
 ## Backwards Compatibility
 
-The range of `BLOCKHASH` is increased by this opcode, but behavior within the previous `MIN_HISTORY_SERVE_WINDOW`-block range remains unchanged.
+The behavior of `BLOCKHASH` opcode remains same and this EIP doesn't affect backward compatibility with the contracts deployed or the gas consumption costs as the resolution of the opcode is handled "directly" by the clients.
 
 ## Test Cases
 
@@ -104,11 +112,11 @@ TBD
 ## Reference Implementation
 
  * PR 28878 of go-ethereum
- * Active on verkle-gen-devet-3 for its verkle implementation
+ * Active on verkle-gen-devnet-5 for its verkle implementation
 
 ## Security Considerations
 
-Adding ~2.5 million storage slots per year bloats the state somewhat but not much relative to the hundreds of millions of existing state objects.
+Having contracts (system or otherwise) with hot update paths (branches) poses a risk of "branch" poisioning attacks where attacker could sprinkle trivial amounts of eth around these hot paths (branches). But it has been deemed that cost of attack would escalate significantly to cause any meaningful slow down of state root updates.
 
 ## Copyright
 

--- a/EIPS/eip-2935.md
+++ b/EIPS/eip-2935.md
@@ -78,7 +78,7 @@ This address is currently exempt from [EIP-158](./eip-158.md) cleanup in Kaustin
 * Update the nonce to 1 in the fork block, or
 * Deploy a contract à la [EIP-4788](./eip-4788.md) with `BLOCKHASH` opcode delegating call to this contract with appropriate args.
 
-While the second option looks more elegant, but it has higher complexity as well as gas consumption considerations.
+While the second option looks more elegant, it has a higher complexity as well as gas consumption considerations.
 
 ## Rationale
 

--- a/EIPS/eip-2935.md
+++ b/EIPS/eip-2935.md
@@ -29,7 +29,8 @@ Additional secondary motivations include:
 | - | - |
 | `FORK_TIMESTAMP` | TBD |
 | `HISTORY_STORAGE_ADDRESS` | `0xfffffffffffffffffffffffffffffffffffffffe`|
-| `HISTORY_SERVE_WINDOW` | `256` |
+| `MIN_HISTORY_SERVE_WINDOW` | `256` |
+| `MAX_HISTORY_SERVE_WINDOW` | `2**256` |
 
 At the start of processing any block where `block.timestamp >= FORK_TIMESTAMP` (ie. before processing any transactions), update the history in the following way:
 
@@ -41,7 +42,7 @@ def process_block_hash_history(block :Block, state: State):
     # If this is the first fork block, add the parent's direct 255 ancestors as well
     if block.parent.timestamp < FORK_TIMESTAMP:
         ancestor = block.parent
-        for i in range(HISTORY_SERVE_WINDOW - 1):
+        for i in range(MIN_HISTORY_SERVE_WINDOW - 1):
             # stop at genesis block
             if ancestor.number == 0:
                 break
@@ -50,26 +51,27 @@ def process_block_hash_history(block :Block, state: State):
             state.insert_slot(HISTORY_STORAGE_ADDRESS, ancestor.number, ancestor.hash)
 ```
 
-Note that if this is the fork block, then it persists the additional requisite history that could be needed while resolving `BLOCKHASH` opcode for all of the `HISTORY_SERVE_WINDOW` ancestors (up until genesis).
+Note that if this is the fork block, then it persists the additional requisite history that could be needed while resolving `BLOCKHASH` opcode for all of the `MIN_HISTORY_SERVE_WINDOW` ancestors (up until genesis).
 
 For resolving the `BLOCKHASH` opcode this fork onwards (`block.timestamp >= FORK_TIMESTAMP`), switch the logic to:
 
 ```python
 def resolve_blockhash(block: Block, state: State, arg: uint64):
   # check the wrap around range
-  if arg >= block.number or arg < max(block.number - 2**256, 0)
+  if arg >= block.number or arg < max(block.number - MAX_HISTORY_SERVE_WINDOW, 0)
     return 0
 
   return state.load_slot(HISTORY_STORAGE_ADDRESS, arg)
 ```
 
-Note that the above logic allows access deeper than `HISTORY_SERVE_WINDOW` if it exists.
+Note that the above logic allows access deeper than `MIN_HISTORY_SERVE_WINDOW` if it exists all the way upto `MAX_HISTORY_SERVE_WINDOW`.
 
 Edge cases:
 
  * For the fork to be activated at genesis, no history is written to the genesis state, and at the start of block `1`, genesis hash will be written as a normal operation to slot `0`.
  * for activation at block `1`, only genesis hash will be written at slot `0` as there is no additional history that needs to be persisted.
  * for activation at block `32`, block `31`'s hash will be written to slot `31` and additonal history for `0..30`'s hashes will be persisted, so all in all `0..31`'s hashes.
+ * for activation at block `1000`, block `744-999`'s hashes will be presisted in the slot and `BLOCKHASH` for `733` or less would resolve to `0` as only `MIN_HISTORY_SERVE_WINDOW` is persisted.
 
 ### [EIP-158](./eip-158.md) exception
 
@@ -89,11 +91,11 @@ Very similar ideas were proposed before in [EIP-210](./eip-210.md) et al. This E
 
 The former was intended to save space. Since then, however, storage usage has increased massively, to the point where even eg. 5 million new storage slots are fairly negligible compared to existing usage. The latter was intended as a first step toward "writing the Ethereum protocol in EVM" as much as possible, but this goal has since been de-facto abandoned.
 
-Storing of all last `HISTORY_SERVE_WINDOW` block hashes alleviates the need to detect fork activation height to transition to the new logic as the entire required history will be available from the first block of the fork itself. The cost of doing so is marginal considering the `HISTORY_SERVE_WINDOW` being small.
+Storing of all last `MIN_HISTORY_SERVE_WINDOW` block hashes alleviates the need to detect fork activation height to transition to the new logic in backward compatible manner as the entire requisite history will be available from the first block of the fork itself. The cost of doing so is marginal considering the `MIN_HISTORY_SERVE_WINDOW` being small.
 
 ## Backwards Compatibility
 
-The range of `BLOCKHASH` is increased by this opcode, but behavior within the previous 256-block range remains unchanged.
+The range of `BLOCKHASH` is increased by this opcode, but behavior within the previous `MIN_HISTORY_SERVE_WINDOW`-block range remains unchanged.
 
 ## Test Cases
 

--- a/EIPS/eip-2935.md
+++ b/EIPS/eip-2935.md
@@ -1,8 +1,8 @@
 ---
 eip: 2935
 title: Save historical block hashes in state
-author: Vitalik Buterin (@vbuterin), Tomasz Stanczak (@tkstanczak), Guillaume Ballet (@gballet), Gajinder Singh (@g11tech), Tanishq Jasoria (@tanishqjasoria)
 description: store previous block hashes as storage slots of a system contract to allow for stateless execution
+author: Vitalik Buterin (@vbuterin), Tomasz Stanczak (@tkstanczak), Guillaume Ballet (@gballet), Gajinder Singh (@g11tech), Tanishq Jasoria (@tanishqjasoria)
 discussions-to: https://ethereum-magicians.org/t/eip-2935-save-historical-block-hashes-in-state/4565
 status: Draft
 type: Standards Track
@@ -32,14 +32,16 @@ Additional secondary motivations include:
 | `HISTORY_SERVE_WINDOW` | `256` |
 
 At the start of processing any block where `block.timestamp > FORK_TIMESTAMP` (ie. before processing any transactions), 
-* run `sstore(HISTORY_STORAGE_ADDRESS, block.number - 1, block.prevhash)`. 
-* **additionally** if this is the first block of the fork, then store last `min(HISTORY_SERVE_WINDOW-1, block.number-1)` **blocks' prevhash** into their corresponding slots i.e persist the entire `HISTORY_SERVE_WINDOW` block hashes (up until the genesis) that can be accessed in the block.
-* change the logic of the `BLOCKHASH` opcode as follows: return `sload(HISTORY_STORAGE_ADDRESS, arg)`.
+ * run `sstore(HISTORY_STORAGE_ADDRESS, block.number - 1, block.prevhash)`. 
+ * **additionally** if this is the first block of the fork, then store last `min(HISTORY_SERVE_WINDOW-1, block.number-1)` **blocks' prevhash** into their corresponding slots i.e persist the entire `HISTORY_SERVE_WINDOW` block hashes (up until the genesis) that can be accessed in the block.
+ * change the logic of the `BLOCKHASH` opcode as follows: return `sload(HISTORY_STORAGE_ADDRESS, arg)`.
+ 
 
 Edge cases:
-* For verkle at genesis, no history is written to the genesis state, and at the start of block `1`, genesis hash will be written as a normal operation to slot `0`.
-* for verkle activated at block `1`, only genesis hash will be written at slot `0` as no additional history needs to be persisted.
-* for verkle activated at block `32`, block `31`'s hash will be written to slot `31` and additonal history for `0..30`'s hashes will be persisted, so all in all `0..31`'s hashes.
+
+ * For verkle at genesis, no history is written to the genesis state, and at the start of block `1`, genesis hash will be written as a normal operation to slot `0`.
+ * for verkle activated at block `1`, only genesis hash will be written at slot `0` as no additional history needs to be persisted.
+ * for verkle activated at block `32`, block `31`'s hash will be written to slot `31` and additonal history for `0..30`'s hashes will be persisted, so all in all `0..31`'s hashes.
 
 ## Rationale
 

--- a/EIPS/eip-2935.md
+++ b/EIPS/eip-2935.md
@@ -41,7 +41,7 @@ def process_block_hash_history(block :Block, state: State):
     # If this is the first fork block, add the parent's direct 255 ancestors as well
     if block.parent.timestamp < FORK_TIMESTAMP:
         ancestor = block.parent
-        for i in range(255):
+        for i in range(HISTORY_SERVE_WINDOW - 1):
             # stop at genesis block
             if ancestor.number == 0:
                 break
@@ -50,7 +50,7 @@ def process_block_hash_history(block :Block, state: State):
             state.insert_slot(HISTORY_STORAGE_ADDRESS, ancestor.number, ancestor.hash)
 ```
 
-Note that if this is the fork block, then it persists the additional requisite history that could be needed while resolving `BLOCKHASH` opcode for all of the `256` ancestors (up untill the genesis).
+Note that if this is the fork block, then it persists the additional requisite history that could be needed while resolving `BLOCKHASH` opcode for all of the `HISTORY_SERVE_WINDOW` ancestors (up untill genesis).
 
 For resolving the `BLOCKHASH` opcode this fork onwards (`block.timestamp > FORK_TIMESTAMP`), switch the logic to:
 

--- a/EIPS/eip-2935.md
+++ b/EIPS/eip-2935.md
@@ -31,7 +31,8 @@ Additional secondary motivations include:
 | `HISTORY_STORAGE_ADDRESS` | `0xfffffffffffffffffffffffffffffffffffffffe`|
 | `HISTORY_SERVE_WINDOW` | `256` |
 
-At the start of processing any block where `block.timestamp > FORK_TIMESTAMP` (ie. before processing any transactions), 
+At the start of processing any block where `block.timestamp > FORK_TIMESTAMP` (ie. before processing any transactions):
+
  * run `sstore(HISTORY_STORAGE_ADDRESS, block.number - 1, block.prevhash)`. 
  * **additionally** if this is the first block of the fork, then store last `min(HISTORY_SERVE_WINDOW-1, block.number-1)` **blocks' prevhash** into their corresponding slots i.e persist the entire `HISTORY_SERVE_WINDOW` block hashes (up until the genesis) that can be accessed in the block.
  * change the logic of the `BLOCKHASH` opcode as follows: return `sload(HISTORY_STORAGE_ADDRESS, arg)`.
@@ -45,7 +46,7 @@ Edge cases:
 
 ## Rationale
 
-Very similar ideas were proposed before in EIP-98 and EIP-210. This EIP is a simplification, removing two sources of needless complexity:
+Very similar ideas were proposed before in [EIP-98](./eip-98.md) and [EIP-210](./eip-210.md). This EIP is a simplification, removing two sources of needless complexity:
 
 1. Having a tree-like structure with multiple layers as opposed to a single list
 2. Writing the EIP in EVM code
@@ -69,7 +70,7 @@ TBD
 
 ## Security Considerations
 
-Adding ~2.5 million storage slots per year bloats the state somewhat (but not much relative to the hundreds of millions of existing state objects). However, this EIP is not intended to be permanent; when eth1 is merged into eth2, the BLOCKHASH opcode would likely be repurposed to use eth2's built-in history accumulator structure (see [phase 0 spec](https://github.com/ethereum/annotated-spec/blob/master/phase0/beacon-chain.md#slots_per_historical_root)).
+Adding ~2.5 million storage slots per year bloats the state somewhat but not much relative to the hundreds of millions of existing state objects.
 
 ## Copyright
 

--- a/EIPS/eip-2935.md
+++ b/EIPS/eip-2935.md
@@ -46,7 +46,7 @@ Edge cases:
 
 ## Rationale
 
-Very similar ideas were proposed before in [EIP-98](./eip-98.md) and [EIP-210](./eip-210.md). This EIP is a simplification, removing two sources of needless complexity:
+Very similar ideas were proposed before in [EIP-210](./eip-210.md) et al. This EIP is a simplification, removing two sources of needless complexity:
 
 1. Having a tree-like structure with multiple layers as opposed to a single list
 2. Writing the EIP in EVM code

--- a/EIPS/eip-2935.md
+++ b/EIPS/eip-2935.md
@@ -1,7 +1,8 @@
 ---
 eip: 2935
 title: Save historical block hashes in state
-author: Vitalik Buterin (@vbuterin), Tomasz Stanczak (@tkstanczak), Guillaume Ballet (gballet), Gajinder Singh (@g11tech)
+author: Vitalik Buterin (@vbuterin), Tomasz Stanczak (@tkstanczak), Guillaume Ballet (@gballet), Gajinder Singh (@g11tech)
+description: store previous block hashes as storage slots of a system contract to allow for stateless execution
 discussions-to: https://ethereum-magicians.org/t/eip-2935-save-historical-block-hashes-in-state/4565
 status: Draft
 type: Standards Track

--- a/EIPS/eip-2935.md
+++ b/EIPS/eip-2935.md
@@ -31,7 +31,7 @@ Additional secondary motivations include:
 | `HISTORY_STORAGE_ADDRESS` | `0xfffffffffffffffffffffffffffffffffffffffe`|
 | `HISTORY_SERVE_WINDOW` | `256` |
 
-At the start of processing any block where `block.timestamp > FORK_TIMESTAMP` (ie. before processing any transactions), update the history in the following way:
+At the start of processing any block where `block.timestamp >= FORK_TIMESTAMP` (ie. before processing any transactions), update the history in the following way:
 
 ```python
 def process_block_hash_history(block :Block, state: State):
@@ -50,16 +50,21 @@ def process_block_hash_history(block :Block, state: State):
             state.insert_slot(HISTORY_STORAGE_ADDRESS, ancestor.number, ancestor.hash)
 ```
 
-Note that if this is the fork block, then it persists the additional requisite history that could be needed while resolving `BLOCKHASH` opcode for all of the `HISTORY_SERVE_WINDOW` ancestors (up untill genesis).
+Note that if this is the fork block, then it persists the additional requisite history that could be needed while resolving `BLOCKHASH` opcode for all of the `HISTORY_SERVE_WINDOW` ancestors (up until genesis).
 
-For resolving the `BLOCKHASH` opcode this fork onwards (`block.timestamp > FORK_TIMESTAMP`), switch the logic to:
+For resolving the `BLOCKHASH` opcode this fork onwards (`block.timestamp >= FORK_TIMESTAMP`), switch the logic to:
 
 ```python
 def resolve_blockhash(block: Block, state: State, arg: uint64):
-  assert(arg < block.number)
+  # check the wrap around range
+  if arg > block.number or arg < max(block.number - 2**256, 0)
+    return 0
+
   return state.load_slot(HISTORY_STORAGE_ADDRESS, arg)
 ```
- 
+
+Note that the above logic allows access deeper than `HISTORY_SERVE_WINDOW` if it exists.
+
 Edge cases:
 
  * For the fork to be activated at genesis, no history is written to the genesis state, and at the start of block `1`, genesis hash will be written as a normal operation to slot `0`.


### PR DESCRIPTION
This heretofore stagnant eip is now necessary for stateless clients to be able to execute the `BLOCKHASH` opcode. This PR:

 * moves the eip from a stagnant status to a draft status
 * change how the PR is activated since forks are now timestamp-based
 * adds additional history persist step on fork activation so that new retrieval logic can be transitioned to from first block itself
