### PR TITLE
Update EIP-7569: Add Dencun mainnet epoch & time

### DIFF
--- a/EIPS/eip-7569.md
+++ b/EIPS/eip-7569.md
@@ -45,7 +45,7 @@ EIPs 1153, 4788, 4844, 5656, 6780 and 7526 require changes to Ethereum's executi
 | Goerli           |    `231680`      |    `1705473120`      |
 | Sepolia          |    `132608`      |    `1706655072`      |
 | Holešky          |    `29696`       |    `1707305664`      |
-| Mainnet          |                  |                      |
+| Mainnet          |    `269568       |    `1710338135`      |
 
 **Note**: rows in the table above will be filled as activation times are decided by client teams. 
 

--- a/EIPS/eip-7569.md
+++ b/EIPS/eip-7569.md
@@ -45,7 +45,7 @@ EIPs 1153, 4788, 4844, 5656, 6780 and 7526 require changes to Ethereum's executi
 | Goerli           |    `231680`      |    `1705473120`      |
 | Sepolia          |    `132608`      |    `1706655072`      |
 | Holešky          |    `29696`       |    `1707305664`      |
-| Mainnet          |    `269568       |    `1710338135`      |
+| Mainnet          |    `269568`      |    `1710338135`      |
 
 **Note**: rows in the table above will be filled as activation times are decided by client teams. 
 


### PR DESCRIPTION
On [ACDC#127](https://github.com/ethereum/pm/issues/951) we agreed to schedule Dencun's mainnet activation for epoch `269568`. I used https://slots.symphonious.net to confirm that the epoch's starting slot is `8626176`, which is an historical accumulator boundary (8626176 % 8192 = 0), and the corresponding timestamp is `1710338135`. At least one person should independently validate those numbers before we merge this 😄 