### PR TITLE
Update EIP-7587: Moves 7587 from info to meta type

### DIFF
--- a/EIPS/eip-7587.md
+++ b/EIPS/eip-7587.md
@@ -5,7 +5,7 @@ description: Reserve precompile address range for use by the RIP process
 author: Carl Beekhuizen (@carlbeek), Ansgar Dietrichs (@adietrichs), Danny Ryan (@djrtwo), Tim Beiko (@timbeiko)
 discussions-to: https://ethereum-magicians.org/t/eip-75xx-reserve-precompile-address-range-for-rips-l2s/17828
 status: Review
-type: Informational
+type: Meta
 created: 2023-12-21
 ---
 


### PR DESCRIPTION
I realized this EIP should be a `Meta` type, not `Informational` as this EIP blocks an address range for precompiles. From [EIP-1](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1.md): "[Meta EIPs] often require community consensus; unlike Informational EIPs, they are more than recommendations, and users are typically not free to ignore them."
