### PR TITLE
Update EIP-4844: simplify `calc_excess_blob_gas`

### DIFF
--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -154,10 +154,9 @@ The value of `excess_blob_gas` can be calculated using the parent header.
 
 ```python
 def calc_excess_blob_gas(parent: Header) -> int:
-    if parent.excess_blob_gas + parent.blob_gas_used < TARGET_BLOB_GAS_PER_BLOCK:
-        return 0
-    else:
-        return parent.excess_blob_gas + parent.blob_gas_used - TARGET_BLOB_GAS_PER_BLOCK
+    return max(
+        parent.excess_blob_gas + parent.blob_gas_used - TARGET_BLOB_GAS_PER_BLOCK, 0
+    )
 ```
 
 For the first post-fork block, both `parent.blob_gas_used` and `parent.excess_blob_gas` are evaluated as `0`.


### PR DESCRIPTION
Less code and easier to understand from the view of constraining `excess_blob_gas`. `excess_blob_gas` is a summation of  `parent.blob_gas_used - TARGET_BLOB_GAS_PER_BLOCK` that must always be non-negative.
