### PR TITLE
Update EIP-7623: remove formating error

### DIFF
--- a/EIPS/eip-7623.md
+++ b/EIPS/eip-7623.md
@@ -54,7 +54,7 @@ The formula for determining the gas used per transaction changes to:
 tx.gasused = (
     21000 +
     max(
-        TOTAL_COST_FLOOR_PER_TOKEN * tokens_in_calldata, 
+        TOTAL_COST_FLOOR_PER_TOKEN * tokens_in_calldata,
         STANDARD_TOKEN_COST * tokens_in_calldata + evm_gas_used
     )
 )


### PR DESCRIPTION
On the html page, there is a strange errer with whitespace symbols in the second python codeblock in the EIP. Not sure what causes it to be malformated.