### PR TITLE
Update EIP-1: add external links for post-quantum algorithm implementations

### DIFF
--- a/EIPS/eip-1.md
+++ b/EIPS/eip-1.md
@@ -356,6 +356,22 @@ Permitted Yellow Paper URLs must anchor to a specific commit, and so must match 
 ^(https://github\.com/ethereum/yellowpaper/blob/[0-9a-f]{40}/paper\.pdf)$
 ```
 
+### PQClean
+
+Links to PQClean (clean implementations of the post-quantum schemes that are in the NIST post-quantum project) may be included using normal markdown syntax, such as:
+
+```markdown
+[PQClean-Falcon-512](https://github.com/PQClean/PQClean/commit/8e220a87308154d48fdfac40abbb191ac7fce06a)
+```
+
+Which renders to:
+[PQClean-Falcon-512](https://github.com/PQClean/PQClean/commit/8e220a87308154d48fdfac40abbb191ac7fce06a)
+
+Permitted PQClean reference implementation URLs must anchor to a specific commit, and so must match this regular expression:
+
+```regex
+^(https://github.com/PQClean/PQClean/commit/[0-9a-f]{40})$
+```
 
 ### Digital Object Identifier System
 


### PR DESCRIPTION
Hello, this PR proposes to add new PQClean implementations. The intention of this PR is to allow such references in new EIP proposals such as [Precompile Falcon512 generic verifier](https://github.com/ethereum/EIPs/pull/8190)
