### PR TITLE
Update EIP-1: Feat/add caip

### DIFF
--- a/EIPS/eip-1.md
+++ b/EIPS/eip-1.md
@@ -350,6 +350,12 @@ Which renders to:
 
 [CAIP 10](https://github.com/ChainAgnostic/CAIPs/blob/5dd3a2f541d399a82bb32590b52ca4340b09f08b/CAIPs/caip-10.md)
 
+Permitted Chain Agnostic URLs must anchor to a specific commit, and so must match this regular expression:
+
+```regex
+^(https://github.com/ChainAgnostic/CAIPs/blob/[0-9a-f]{40}/CAIPs/caip-[0-9]+\.md)$
+```
+
 ### Ethereum Yellow Paper
 
 Links to the Ethereum Yellow Paper may be included using normal markdown syntax, such as:

--- a/EIPS/eip-1.md
+++ b/EIPS/eip-1.md
@@ -338,6 +338,18 @@ Which renders to:
 
 [CVE-2023-29638 (2023-10-17T10:14:15)](https://nvd.nist.gov/vuln/detail/CVE-2023-29638)
 
+### Chain Agnostic Improvement Proposals (CAIPs)
+
+Links to the Chain Agnostic Improvement Proposals (CAIPs) specificaitons may be included using normal markdown syntax, such as:
+
+```markdown
+[CAIP-10](https://github.com/ChainAgnostic/CAIPs/blob/5dd3a2f541d399a82bb32590b52ca4340b09f08b/CAIPs/caip-10.md)
+```
+
+Which renders to:
+
+[CAIP 10](https://github.com/ChainAgnostic/CAIPs/blob/5dd3a2f541d399a82bb32590b52ca4340b09f08b/CAIPs/caip-10.md)
+
 ### Ethereum Yellow Paper
 
 Links to the Ethereum Yellow Paper may be included using normal markdown syntax, such as:

--- a/EIPS/eip-1.md
+++ b/EIPS/eip-1.md
@@ -343,7 +343,7 @@ Which renders to:
 Links to a Chain Agnostic Improvement Proposals (CAIPs) specification may be included using normal markdown syntax, such as:
 
 ```markdown
-[CAIP-10](https://github.com/ChainAgnostic/CAIPs/blob/5dd3a2f541d399a82bb32590b52ca4340b09f08b/CAIPs/caip-10.md)
+[CAIP 10](https://github.com/ChainAgnostic/CAIPs/blob/5dd3a2f541d399a82bb32590b52ca4340b09f08b/CAIPs/caip-10.md)
 ```
 
 Which renders to:

--- a/EIPS/eip-1.md
+++ b/EIPS/eip-1.md
@@ -340,7 +340,7 @@ Which renders to:
 
 ### Chain Agnostic Improvement Proposals (CAIPs)
 
-Links to a Chain Agnostic Improvement Proposals (CAIPs) specificaiton may be included using normal markdown syntax, such as:
+Links to a Chain Agnostic Improvement Proposals (CAIPs) specification may be included using normal markdown syntax, such as:
 
 ```markdown
 [CAIP-10](https://github.com/ChainAgnostic/CAIPs/blob/5dd3a2f541d399a82bb32590b52ca4340b09f08b/CAIPs/caip-10.md)

--- a/EIPS/eip-1.md
+++ b/EIPS/eip-1.md
@@ -340,7 +340,7 @@ Which renders to:
 
 ### Chain Agnostic Improvement Proposals (CAIPs)
 
-Links to the Chain Agnostic Improvement Proposals (CAIPs) specificaitons may be included using normal markdown syntax, such as:
+Links to a Chain Agnostic Improvement Proposals (CAIPs) specificaiton may be included using normal markdown syntax, such as:
 
 ```markdown
 [CAIP-10](https://github.com/ChainAgnostic/CAIPs/blob/5dd3a2f541d399a82bb32590b52ca4340b09f08b/CAIPs/caip-10.md)

--- a/config/eipw.toml
+++ b/config/eipw.toml
@@ -151,6 +151,8 @@ exceptions = [
     '^https://(www\.)?github\.com/ethereum/devp2p/(blob|tree)/[0-9a-f]{40}/.+$',
     '^https://(www\.)?github\.com/ethereum/devp2p/commit/[0-9a-f]{40}$',
     '^https://(www\.)?github\.com/bitcoin/bips/(blob|tree)/[0-9a-f]{40}/bip-[0-9]+\.mediawiki$',
+    '^https://(www\.)?github\.com/ChainAgnostic/CAIPs/(blob|tree)/[a-f0-9]{40}/.+$',
+    '^https://(www\.)?github\.com/ChainAgnostic/CAIPs/commit/[0-9a-f]{40}$',
     '^https://www\.w3\.org/TR/[0-9][0-9][0-9][0-9]/.*$',
     '^https://[a-z]*\.spec\.whatwg\.org/commit-snapshots/[0-9a-f]{40}/$',
     '^https://www\.rfc-editor\.org/rfc/.*$',


### PR DESCRIPTION
This PR adds support for Chain Agnostic Improvement Proposals (CAIPs) as valid external links. Chain Agnostic Improvement Proposals (CAIPs) describe standards for blockchain projects that are not specific to a single chain.

Namely, one of the most important CAIPs is [CAIP-2](https://chainagnostic.org/CAIPs/caip-2) and [CAIP-10](https://chainagnostic.org/CAIPs/caip-10) which allow for deeply specified address from various different blockchians. 

The current limitation of not having CAIPs specified is we get half baked proposals such as [ERC-3770](https://eips.ethereum.org/EIPS/eip-3770) which take us half-way to the full solution, but stop short. For reference, 3770 was heavily inspired by CAIP-10, and has notably prevented users from pasting incorrect address across networks.

WalletConnect also comes with CAIP support by default, and thus any dapp using wallet connect automatically conforms to CAIP25, CAIP2, CAIP10.

With the rise of L2s, bridges, and AA tools, we're seeing an immediate demand for having a stronger set of defined standards for navigating this space, one which probably shouldn't be explicitly specified within the EIPs/ERCs as they related to more than just Ethereum.

Decision on this PR is a dependent to merge [erc-7555](https://github.com/ethereum/ERCs/pull/99)