### PR TITLE
Config: Allow yellow paper

### DIFF
--- a/config/eipw.toml
+++ b/config/eipw.toml
@@ -148,6 +148,8 @@ exceptions = [
     '^https://(www\.)?github\.com/ethereum/consensus-specs/commit/[a-f0-9]{40}$',
     '^https://(www\.)?github\.com/ethereum/execution-specs/(blob|tree)/[a-f0-9]{40}/.+$',
     '^https://(www\.)?github\.com/ethereum/execution-specs/commit/[a-f0-9]{40}$',
+    '^https://(www\.)?github\.com/ethereum/yellowpaper/(blob|tree)/[a-f0-9]{40}/.+$',
+    '^https://(www\.)?github\.com/ethereum/yellowpaper/commit/[a-f0-9]{40}$',
     '^https://(www\.)?github\.com/ethereum/devp2p/(blob|tree)/[0-9a-f]{40}/.+$',
     '^https://(www\.)?github\.com/ethereum/devp2p/commit/[0-9a-f]{40}$',
     '^https://(www\.)?github\.com/bitcoin/bips/(blob|tree)/[0-9a-f]{40}/bip-[0-9]+\.mediawiki$',


### PR DESCRIPTION
As per https://github.com/ethcatherders/EIPIP/issues/275 the Yellow Paper should be allowed.

_reported by @pdobacz (hopefully correct username) on discord_