### PR TITLE
Update EIP-7623: EIP-7623 - Incorporate Init Code

### DIFF
--- a/EIPS/eip-7623.md
+++ b/EIPS/eip-7623.md
@@ -54,7 +54,7 @@ The formula for determining the gas used per transaction changes to:
 tx.gasused = (
     21000 +
     max(
-        TOTAL_COST_FLOOR_PER_TOKEN * tokens_in_calldata, 
+        TOTAL_COST_FLOOR_PER_TOKEN * tokens_in_calldata,
         STANDARD_TOKEN_COST * tokens_in_calldata + evm_gas_used
     )
 )

--- a/EIPS/eip-7623.md
+++ b/EIPS/eip-7623.md
@@ -44,7 +44,7 @@ The current formula for determining the gas used per transaction, typically desc
 ```python
 tx.gasused = (
     21000 \ 
-        + (32000 + InitCodeWordGas *  words(calldata)) * isContractCreation  \
+        + isContractCreation * (32000 + InitCodeWordGas *  words(calldata))  \
         + isCreate2Creation * Keccak256WordGas *  words(calldata)
     + 
     STANDARD_TOKEN_COST * tokens_in_calldata + evm_gas_used
@@ -56,7 +56,7 @@ The formula for determining the gas used per transaction changes to:
 ```python
 tx.gasused = (
     21000 \ 
-        + (32000 + InitCodeWordGas *  words(calldata)) * isContractCreation  \
+        + isContractCreation * (32000 + InitCodeWordGas *  words(calldata))  \
         + isCreate2Creation * Keccak256WordGas *  words(calldata)
     + 
     max(

--- a/EIPS/eip-7623.md
+++ b/EIPS/eip-7623.md
@@ -21,7 +21,7 @@ This is achieved through increasing the calldata cost for transactions that use 
 
 ## Motivation
 
-The block gas limit has not been increased since [EIP-1559](./eip-1559.md), while the average size of blocks has continuously increased due to the growing number of rollups posting data to Ethereum. 
+The block gas limit has not been increased since [EIP-1559](./eip-1559.md), while the average size of blocks has continuously increased due to the growing number of rollups posting data to Ethereum. Furthermore, the cost for nonzero calldata bytes hasn't been adjusted since [EIP-2028](./eip-2028).
 [EIP-4844](./eip-4844.md) introduces blobs as a preferred method for data availability (DA). 
 This transition demands a reevaluation of calldata pricing, especially with regards to mitigating the inefficiency between the average block size and the maximum one possible.
 By increasing the gas cost for nonzero calldata bytes for transactions that are mainly using Ethereum for DA, this proposal aims to reduce the maximum block size to make room for adding more blobs. 
@@ -68,8 +68,8 @@ tx.gasused = (
 
 ## Rationale
 
-The current maximum block size is approximately 1.79 MB (`30_000_000/16`). One can create blocks full of zero bytes that go up to 7.5 MB, but it is now standard to wrap blocks with snappy compression at the p2p layer and so such zero-byte-heavy blocks would end up smaller than 1.79 MB in practice. With the implementation of [EIP-4844](./eip-4844.md) this will increase to about 2.54 MB.
-This proposal aims to increase the cost of calldata to 68 gas for transactions that do not exceed a certain threshold of gas spent on EVM operations. This change will significantly reduce the maximum block size by limiting the number and size of pure-data transactions that can fit into a single block. Specifically, by adjusting the price of nonzero calldata bytes to 68 gas for DA transactions, the goal is to lower the maximum block size to roughly 0.55 MB without impacting the vast majority (~96% as of Feb. 2024) of transactions.
+The current maximum block size is approximately 1.79 MB (`30_000_000/16`). One can create blocks full of zero bytes that go up to 7.5 MB, but it is now standard to wrap blocks with snappy compression at the p2p layer and so such zero-byte-heavy blocks would end up smaller than 1.79 MB in practice. With the implementation of [EIP-4844](./eip-4844.md) this will increase to about 2.54 MB. Furthermore, the cost for nonzero calldata bytes haven't been adjusted since [EIP-2028](https://eips.ethereum.org/EIPS/eip-2028).
+This proposal aims to increase the cost of calldata to 68 gas for transactions that do not exceed a certain threshold of gas spent on EVM operations. This change will significantly reduce the maximum block size by limiting the number and size of pure-data transactions that can fit into a single block. Specifically, by adjusting the price of nonzero calldata bytes to 68 gas for DA transactions, the goal is to lower the maximum possible block size to roughly 0.55 MB without impacting the vast majority (~96% as of Feb. 2024) of transactions.
 
 
 This reduction makes room for increasing the block gas limit or the number of blobs, while ensuring network security and efficiency. 

--- a/EIPS/eip-7623.md
+++ b/EIPS/eip-7623.md
@@ -42,8 +42,10 @@ The current formula for determining the gas used per transaction, typically desc
 
 ```python
 tx.gasused = (
-    21000 + 32000 * isContractCreation \
-        + isCreate2Creation * Keccak256WordGas * words(calldata)
+    21000 \ 
+        + (32000 + InitCodeWordGas *  words(calldata)) * isContractCreation  \
+        + isCreate2Creation * Keccak256WordGas *  words(calldata)
+    + 
     STANDARD_TOKEN_COST * tokens_in_calldata +
     evm_gas_used
 )
@@ -53,8 +55,10 @@ The formula for determining the gas used per transaction changes to:
 
 ```python
 tx.gasused = (
-    21000 + 32000 * isContractCreation \
-        + isCreate2Creation * Keccak256WordGas * words(calldata)
+    21000 \ 
+        + (32000 + InitCodeWordGas *  words(calldata)) * isContractCreation  \
+        + isCreate2Creation * Keccak256WordGas *  words(calldata)
+    + 
     max(
         TOTAL_COST_FLOOR_PER_TOKEN * tokens_in_calldata,
         STANDARD_TOKEN_COST * tokens_in_calldata + evm_gas_used

--- a/EIPS/eip-7623.md
+++ b/EIPS/eip-7623.md
@@ -68,7 +68,7 @@ tx.gasused = (
 
 ## Rationale
 
-The current maximum block size is approximately 1.79 MB (`30_000_000/16`). One can create blocks full of zero bytes that go up to 7.5 MB, but it is now standard to wrap blocks with snappy compression at the p2p layer and so such zero-byte-heavy blocks would end up smaller than 1.79 MB in practice. With the implementation of [EIP-4844](./eip-4844.md) this will increase to about 2.54 MB. Furthermore, the cost for nonzero calldata bytes haven't been adjusted since [EIP-2028](https://eips.ethereum.org/EIPS/eip-2028).
+The current maximum block size is approximately 1.79 MB (`30_000_000/16`). One can create blocks full of zero bytes that go up to 7.5 MB, but it is now standard to wrap blocks with snappy compression at the p2p layer and so such zero-byte-heavy blocks would end up smaller than 1.79 MB in practice. With the implementation of [EIP-4844](./eip-4844.md) this will increase to about 2.54 MB. Furthermore, the cost for nonzero calldata bytes haven't been adjusted since [EIP-2028](./eip-2028).
 This proposal aims to increase the cost of calldata to 68 gas for transactions that do not exceed a certain threshold of gas spent on EVM operations. This change will significantly reduce the maximum block size by limiting the number and size of pure-data transactions that can fit into a single block. Specifically, by adjusting the price of nonzero calldata bytes to 68 gas for DA transactions, the goal is to lower the maximum possible block size to roughly 0.55 MB without impacting the vast majority (~96% as of Feb. 2024) of transactions.
 
 

--- a/EIPS/eip-7623.md
+++ b/EIPS/eip-7623.md
@@ -15,16 +15,16 @@ created: 2024-02-13
 ## Abstract
 
 The current calldata pricing allows for significantly large blocks of up to 2.8 MB while the average block size is much smaller at 125 KB. 
-This EIP proposes an adjustment in the Ethereum calldata price to reduce the current maximum block size and its variance. 
-This is achieved through adjusting calldata pricing, aligning with emerging data storage practices in the network, especially in the context of [EIP-4844](./eip-4844.md).
+This EIP proposes an adjustment in the Ethereum calldata cost to reduce the maximum possible block size and its variance without impacting regular users. 
+This is achieved through increasing the calldata cost for transactions that use Ethereum mainly for DA.
 
 
 ## Motivation
 
 The block gas limit has not been increased since [EIP-1559](./eip-1559.md), while the average size of blocks has continuously increased due to the growing number of rollups posting data to Ethereum. 
-[EIP-4844](./eip-4844.md) introduces blobs as a preferred method for data availability, signaling a shift away from calldata-dependent strategies. 
-This transition demands a reevaluation of calldata pricing, especially with regards to mitigating the inefficiency between the average block size in bytes and the maximum one possible.
-By increasing the gas cost for nonzero calldata bytes for transactions that are mainly using Ethereum for Data Availability (DA), the proposal aims to balance the need for block space with the necessity of reducing the maximum block size to make room for adding more blobs. The move from using calldata for DA to blobs further strengthens the multidimensional fee market by incentivizing blob space.
+[EIP-4844](./eip-4844.md) introduces blobs as a preferred method for data availability (DA). 
+This transition demands a reevaluation of calldata pricing, especially with regards to mitigating the inefficiency between the average block size and the maximum one possible.
+By increasing the gas cost for nonzero calldata bytes for transactions that are mainly using Ethereum for DA, this proposal aims to reduce the maximum block size to make room for adding more blobs. 
 
 
 ## Specification
@@ -36,13 +36,14 @@ By increasing the gas cost for nonzero calldata bytes for transactions that are 
 
 
 Let `tokens_in_calldata = zero_bytes_in_calldata + nonzero_bytes_in_calldata * 4`.
-
+Let `isContractCreation` and `isCreate2Creation` be booleans indicating the respective event.
 
 The current formula for determining the gas used per transaction, typically described as `nonzero_bytes_in_calldata * 16 + zero_bytes_in_calldata * 4`, is equivalent to:
 
 ```python
 tx.gasused = (
-    21000 +
+    21000 + 32000 * isContractCreation \
+        + isCreate2Creation * Keccak256WordGas * words(calldata)
     STANDARD_TOKEN_COST * tokens_in_calldata +
     evm_gas_used
 )
@@ -52,7 +53,8 @@ The formula for determining the gas used per transaction changes to:
 
 ```python
 tx.gasused = (
-    21000 +
+    21000 + 32000 * isContractCreation \
+        + isCreate2Creation * Keccak256WordGas *  words(calldata)
     max(
         TOTAL_COST_FLOOR_PER_TOKEN * tokens_in_calldata,
         STANDARD_TOKEN_COST * tokens_in_calldata + evm_gas_used
@@ -63,12 +65,12 @@ tx.gasused = (
 ## Rationale
 
 The current maximum block size is approximately 1.79 MB (`30_000_000/16`). One can create blocks full of zero bytes that go up to 7.5 MB, but it is now standard to wrap blocks with snappy compression at the p2p layer and so such zero-byte-heavy blocks would end up smaller than 1.79 MB in practice. With the implementation of [EIP-4844](./eip-4844.md) this will increase to about 2.54 MB.
-This proposal aims to increase the cost of calldata to 68 gas for transactions that do not exceed a certain threshold of gas spent on EVM operations. This change will significantly reduce the maximum block size by limiting the number and size of pure-data transactions that can fit into a single block. Specifically, by adjusting the price of nonzero calldata bytes to 68 gas for DA transactions, the goal is to lower the maximum block size to roughly 0.55 MB.
+This proposal aims to increase the cost of calldata to 68 gas for transactions that do not exceed a certain threshold of gas spent on EVM operations. This change will significantly reduce the maximum block size by limiting the number and size of pure-data transactions that can fit into a single block. Specifically, by adjusting the price of nonzero calldata bytes to 68 gas for DA transactions, the goal is to lower the maximum block size to roughly 0.55 MB without impacting the vast majority (~96% as of Feb. 2024) of transactions.
 
 
 This reduction makes room for increasing the block gas limit or the number of blobs, while ensuring network security and efficiency. 
-Importantly, regular users (sending ETH/tokens/NFTs, engaging in DeFi, social media, restaking, etc.) who do not use Ethereum exclusively for DA, may remain unaffected.
-The calldata price for transactions involving significant EVM computation remains at 16 gas per nonzero byte, ensuring these users experience no change. This strategy protects users reliant on heavy calldata alongside EVM computations, ensuring they are not negatively impacted by the revised pricing structure.
+Importantly, regular users (sending ETH/Tokens/NFTs, engaging in DeFi, social media, restaking, bridging, etc.) who do not use Ethereum exclusively for DA, may remain unaffected.
+The calldata price for transactions involving significant EVM computation remains at 16 gas per nonzero byte, ensuring these transactions experience no change.
 
 
 ## Backwards Compatibility
@@ -84,4 +86,3 @@ As the maximum possible block size is reduced, no security concerns were raised.
 ## Copyright
 
 Copyright and related rights waived via [CC0](../LICENSE.md).
- 

--- a/EIPS/eip-7623.md
+++ b/EIPS/eip-7623.md
@@ -46,8 +46,7 @@ tx.gasused = (
         + (32000 + InitCodeWordGas *  words(calldata)) * isContractCreation  \
         + isCreate2Creation * Keccak256WordGas *  words(calldata)
     + 
-    STANDARD_TOKEN_COST * tokens_in_calldata +
-    evm_gas_used
+    STANDARD_TOKEN_COST * tokens_in_calldata + evm_gas_used
 )
 ```
 

--- a/EIPS/eip-7623.md
+++ b/EIPS/eip-7623.md
@@ -36,6 +36,7 @@ By increasing the gas cost for nonzero calldata bytes for transactions that are 
 
 
 Let `tokens_in_calldata = zero_bytes_in_calldata + nonzero_bytes_in_calldata * 4`.
+
 Let `isContractCreation` and `isCreate2Creation` be booleans indicating the respective event.
 
 The current formula for determining the gas used per transaction, typically described as `nonzero_bytes_in_calldata * 16 + zero_bytes_in_calldata * 4`, is equivalent to:

--- a/EIPS/eip-7623.md
+++ b/EIPS/eip-7623.md
@@ -16,7 +16,7 @@ created: 2024-02-13
 
 The current calldata pricing allows for significantly large blocks of up to 2.8 MB while the average block size is much smaller at 125 KB. 
 This EIP proposes an adjustment in the Ethereum calldata cost to reduce the maximum possible block size and its variance without impacting regular users. 
-This is achieved through increasing the calldata cost for transactions that use Ethereum mainly for DA.
+This is achieved through increasing the calldata cost for transactions that use Ethereum mainly for data availability.
 
 
 ## Motivation
@@ -54,7 +54,7 @@ The formula for determining the gas used per transaction changes to:
 ```python
 tx.gasused = (
     21000 + 32000 * isContractCreation \
-        + isCreate2Creation * Keccak256WordGas *  words(calldata)
+        + isCreate2Creation * Keccak256WordGas * words(calldata)
     max(
         TOTAL_COST_FLOOR_PER_TOKEN * tokens_in_calldata,
         STANDARD_TOKEN_COST * tokens_in_calldata + evm_gas_used


### PR DESCRIPTION
Based on @MariusVanDerWijden 's input at ethmagicians [here](https://ethereum-magicians.org/t/eip-7623-increase-calldata-cost/18647/3?u=nerolation), this PR incorporates the costs for init code into the formula to clarify that it is NOT part of the conditional max() part.