### PR TITLE
Update EIP-7623: EIP-7623 - Move CREATE inside max

### DIFF
--- a/EIPS/eip-7623.md
+++ b/EIPS/eip-7623.md
@@ -44,26 +44,24 @@ The current formula for determining the gas used per transaction, typically desc
 ```python
 tx.gasused = (
     21000 \ 
-        + isContractCreation * (32000 + InitCodeWordGas *  words(calldata))  \
-        + isCreate2Creation * Keccak256WordGas *  words(calldata)
-    + 
-    STANDARD_TOKEN_COST * tokens_in_calldata + evm_gas_used
+        + isContractCreation * (32000 + InitCodeWordGas * words(calldata)) \
+        + STANDARD_TOKEN_COST * tokens_in_calldata \
+        + evm_gas_used
 )
 ```
 
 The formula for determining the gas used per transaction changes to:
 
 ```python
-tx.gasused = (
+tx.gasUsed = {
     21000 \ 
-        + isContractCreation * (32000 + InitCodeWordGas *  words(calldata))  \
-        + isCreate2Creation * Keccak256WordGas *  words(calldata)
     + 
-    max(
-        TOTAL_COST_FLOOR_PER_TOKEN * tokens_in_calldata,
-        STANDARD_TOKEN_COST * tokens_in_calldata + evm_gas_used
+    max (
+        STANDARD_TOKEN_COST * tokens_in_calldata \
+           + evm_gas_used \
+           + isContractCreation * (32000 + InitCodeWordGas * words(calldata)),
+        TOTAL_COST_FLOOR_PER_TOKEN * tokens_in_calldata
     )
-)
 ```
 
 ## Rationale


### PR DESCRIPTION
This change makes sure that calldata heavy contract creations have lower threshold for getting the standard token price.