### PR TITLE
Update EIP-3074: allow only current nonce in auth msg

### DIFF
--- a/EIPS/eip-3074.md
+++ b/EIPS/eip-3074.md
@@ -304,7 +304,7 @@ Sending non-zero value with `CALL` increases its cost by 9,000. Of that, 6,700 c
 
 This EIP has gone [back and forth](#what-to-sign) on how to deal with `AUTH` message revocation. Without revocation, this EIP is a supremely powerful and flexible primitive for developers. However, it does have risk for users who use insecure and/or actively malicious invokers.
 
-Much of the risk is due to the new ability for users to batch many operations in a single transaction. It becomes easier for an account to be drained. This is a risk that will continue to grow, regardless of the adoption of this EIP or not, due to overwhelming desire for the feature and attempts to support it at the protocol level and at the app level.
+Much of the risk is due to the new ability for users to batch many operations in a single transaction. It becomes easier for an account to be drained. This is a risk that will continue to grow, regardless of the adoption of this EIP, due to overwhelming desire for the feature and attempts to support it at the protocol level and at the app level.
 
 A new class of risk is introduced for insecure and buggy invokers. If an invoker has implemented replay protection, as per the authors' recommendation, this should substantially contain the blast radius. However, if the bug allows an adversary to circumvent the replay proection mechanism, it may give them full access to any EOA which has interacted with the vulnerable invoker.
 
@@ -326,7 +326,7 @@ The following is a non-exhaustive list of checks/pitfalls/conditions that invoke
 
  - Replay protection (ex. a nonce) should be implemented by the invoker, and included in `commit`. Without it, a malicious actor can reuse a signature, repeating its effects.
  - `value` should be included in `commit`. Without it, a malicious sponsor could cause unexpected effects in the callee.
- - `gas` should be included in `commit`. Without it, a malicious sponsor could cause the callee to run out of gas and fail, griefing the sponsee.
+ - `gas` should be included in `commit`sdfp. Without it, a malicious sponsor could cause the callee to run out of gas and fail, griefing the sponsee.
  - `addr` and `calldata` should be included in `commit`. Without them, a malicious actor may call arbitrary functions in arbitrary contracts.
 
 A poorly implemented invoker can *allow a malicious actor to take near complete control over a signer's EOA*.

--- a/EIPS/eip-3074.md
+++ b/EIPS/eip-3074.md
@@ -279,15 +279,15 @@ Allowing `authorized` to equal `tx.origin` enables simple transaction batching, 
 
  1. Ensuring that `msg.sender` is an EOA (given that `tx.origin` always has to be an EOA). This invariant does not depend on the execution layer depth and, therefore, is not affected.
  2. Protecting against atomic sandwich attacks like flash loans, that rely on the ability to modify state before and after the execution of the target contract as part of the same atomic transaction. This protection would be broken by this EIP. However, relying on `tx.origin` in this way is considered bad practice, and can already be circumvented by miners conditionally including transactions in a block.
- 3. Preventing re-entrancy.
+ 3. Preventing reentrancy.
 
-Examples of (1) and (2) can be found in contracts deployed on Ethereum mainnet, with (1) being more common (and unaffected by this proposal.) On the other hand, use case (3) is more severely affected by this proposal, but the authors of this EIP did not find any examples of this form of re-entrancy protection, though the search was non-exhaustive.
+Examples of (1) and (2) can be found in contracts deployed on Ethereum mainnet, with (1) being more common (and unaffected by this proposal.) On the other hand, use case (3) is more severely affected by this proposal, but the authors of this EIP did not find any examples of this form of reentrancy protection, though the search was non-exhaustive.
 
 This distribution of occurrences—many (1), some (2), and no (3)—is exactly what the authors of this EIP expect, because:
 
  - Determining if `msg.sender` is an EOA without `tx.origin` is difficult (if not impossible.)
  - The only execution context which is safe from atomic sandwich attacks is the topmost context, and `tx.origin == msg.sender` is the only way to detect that context.
- - In contrast, there are many direct and flexible ways of preventing re-entrancy (ex. using a storage variable.) Since `msg.sender == tx.origin` is only true in the topmost context, it would make an obscure tool for preventing re-entrancy, rather than other more common approaches.
+ - In contrast, there are many direct and flexible ways of preventing reentrancy (ex. using a storage variable.) Since `msg.sender == tx.origin` is only true in the topmost context, it would make an obscure tool for preventing reentrancy, rather than other more common approaches.
 
 There are other approaches to mitigate this restriction which do not break the invariant:
 
@@ -306,7 +306,7 @@ This EIP has gone [back and forth](#what-to-sign) on how to deal with `AUTH` mes
 
 Much of the risk is due to the new ability for users to batch many operations in a single transaction. It becomes easier for an account to be drained. This is a risk that will continue to grow, regardless of the adoption of this EIP, due to overwhelming desire for the feature and attempts to support it at the protocol level and at the app level.
 
-A new class of risk is introduced for insecure and buggy invokers. If an invoker has implemented replay protection, as per the authors' recommendation, this should substantially contain the blast radius. However, if the bug allows an adversary to circumvent the replay proection mechanism, it may give them full access to any EOA which has interacted with the vulnerable invoker.
+A new class of risk is introduced for insecure and buggy invokers. If an invoker has implemented replay protection, as per the authors' recommendation, this should substantially contain the blast radius. However, if the bug allows an adversary to circumvent the replay protection mechanism, it may give them full access to any EOA which has interacted with the vulnerable invoker.
 
 Although this is truly catastrophic event which is not expected to be possible via reputable wallets, it is a serious consideration. Without in-protocol revocation, users have no way to remove their account from the vulnerable invoker.
 
@@ -314,7 +314,7 @@ For this reason, `AUTH` requires the `nonce` in the message be equal to the sign
 
 ## Backwards Compatibility
 
-Although this EIP poses no issues for backwards compatibility, there are concerns that it limits future changes to accounts by further enshrining ECDSA signatures. For example, it might be desirable to erradicate the concept of EOAs altogether, and replace them with smart contract wallets that emulate the same behavior. This is fully compatible with the EIP as written, however, it gets tricky if users can then elect to "upgrade" their smart contract wallets to use other methods of authentication -- e.g. convert into a multisig. Without any changes, `AUTH` would not respect this new logic and continue allowing the old private key to perform actions on behalf of the account.
+Although this EIP poses no issues for backwards compatibility, there are concerns that it limits future changes to accounts by further enshrining ECDSA signatures. For example, it might be desirable to eradicate the concept of EOAs altogether, and replace them with smart contract wallets that emulate the same behavior. This is fully compatible with the EIP as written, however, it gets tricky if users can then elect to "upgrade" their smart contract wallets to use other methods of authentication -- e.g. convert into a multi-sig. Without any changes, `AUTH` would not respect this new logic and continue allowing the old private key to perform actions on behalf of the account.
 
 A solution to this would be at the same time that EOAs are removed, to modify the logic of `AUTH` to actually call into the account with some standard message and allow the account to determine if the signature / witness is valid. Further research should be done to understand how invokers would need to change in this situation and how best to write them in a future-compatible manner.
 
@@ -336,7 +336,7 @@ A poorly implemented invoker can *allow a malicious actor to take near complete 
 Allowing `authorized` to equal `tx.origin` has the possibility to:
 
  - Break atomic sandwich protections which rely on `tx.origin`;
- - Break re-entrancy guards of the style `require(tx.origin == msg.sender)`.
+ - Break reentrancy guards of the style `require(tx.origin == msg.sender)`.
 
 The authors of this EIP believe the risks of allowing `authorized` to equal `tx.origin` are acceptable for the reasons outlined in the Rationale section.
 

--- a/EIPS/eip-3074.md
+++ b/EIPS/eip-3074.md
@@ -95,9 +95,9 @@ If `length` is greater than 97, the extra bytes are ignored for signature verifi
 The arguments (`yParity`, `r`, `s`) are interpreted as an ECDSA signature on the secp256k1 curve over the message `keccak256(MAGIC || chainId || nonce || invokerAddress || commit)`, where:
 
  - `chainId` is the current chain's [EIP-155](./eip-155.md) unique identifier padded to 32 bytes.
- - `nonce` is the signer's nonce after which the message will be considered invalid, left-padded to 32 bytes.
+ - `nonce` is the signer's current nonce, left-padded to 32 bytes. Any other value is considered invalid.
  - `invokerAddress` is the address of the contract executing `AUTH` (or the active state address in the context of `CALLCODE` or `DELEGATECALL`), left-padded with zeroes to a total of 32 bytes (ex. `0x000000000000000000000000AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA`).
- - `commit`, one of the arguments passed into `AUTH`, is a 32-byte value that can be used to commit to specific additional validity conditions in the invoker's pre-processing logic (e.g. a nonce for replay protection).
+ - `commit`, one of the arguments passed into `AUTH`, is a 32-byte value that can be used to commit to specific additional validity conditions in the invoker's pre-processing logic.
 
 Signature validity and signer recovery is handled analogously to transaction signatures, including the stricter `s` range for preventing ECDSA malleability. Note that `yParity` is expected to be `0` or `1`.
 
@@ -299,6 +299,18 @@ There are other approaches to mitigate this restriction which do not break the i
 ### `AUTHCALL` cheaper than `CALL` when sending value
 
 Sending non-zero value with `CALL` increases its cost by 9,000. Of that, 6,700 covers the increased overhead of the balance transfer and 2,300 is used as a stipend into the subcall to seed its gas counter. `AUTHCALL` does not provide a stipend and thus only charges the base 6,700.
+
+### In-Protocol Revocation
+
+This EIP has gone [back and forth](#what-to-sign) on how to deal with `AUTH` message revocation. Without revocation, this EIP is a supremely powerful and flexible primitive for developers. However, it does have risk for users who use insecure and/or actively malicious invokers.
+
+Much of the risk is due to the new ability for users to batch many operations in a single transaction. It becomes easier for an account to be drained. This is a risk that will continue to grow, regardless of the adoption of this EIP or not, due to overwhelming desire for the feature and attempts to support it at the protocol level and at the app level.
+
+A new class of risk is introduced for insecure and buggy invokers. If an invoker has implemented replay protection, as per the authors' recommendation, this should substantially contain the blast radius. However, if the bug allows an adversary to circumvent the replay proection mechanism, it may give them full access to any EOA which has interacted with the vulnerable invoker.
+
+Although this is truly catastrophic event which is not expected to be possible via reputable wallets, it is a serious consideration. Without in-protocol revocation, users have no way to remove their account from the vulnerable invoker.
+
+For this reason, `AUTH` requires the `nonce` in the message be equal to the signer's current nonce. This way, a single tx from the EOA will cause the nonce to increase, invalidating all outstanding authorizations.
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
As discussed on [ACD 182](https://github.com/ethereum/pm/issues/961), I am updating the authorization message in this EIP to only be valid for an account's _current_ nonce.