### PR TITLE
Update EIP-6800: refer to eip 4762 for the state access costs

### DIFF
--- a/EIPS/eip-6800.md
+++ b/EIPS/eip-6800.md
@@ -240,7 +240,7 @@ TODO - see specific EIP
 
 #### Access events
 
-TODO
+Described in [EIP-4762](./eip-4762.md).
 
 ## Rationale
 


### PR DESCRIPTION
Replace a TODO in the "Access Events" section, with a link to the EIP where they are described.