### PR TITLE
Update EIP-1193: author username

### DIFF
--- a/EIPS/eip-1193.md
+++ b/EIPS/eip-1193.md
@@ -1,7 +1,7 @@
 ---
 eip: 1193
 title: Ethereum Provider JavaScript API
-author: Fabian Vogelsteller (@frozeman), Ryan Ghods (@ryanio), Victor Maia (@MaiaVictor), Marc Garreau (@marcgarreau), Erik Marks (@rekmarks)
+author: Fabian Vogelsteller (@frozeman), Ryan Ghods (@ryanio), Victor Maia (@MaiaVictor), Marc Garreau (@wolovim), Erik Marks (@rekmarks)
 discussions-to: https://github.com/ethereum/EIPs/issues/2319
 status: Final
 type: Standards Track


### PR DESCRIPTION
updated username in 2022; airdrop farmer registered the old one a few weeks ago.