### PR TITLE
Update EIP-6800: change tree key hashing

### DIFF
--- a/EIPS/eip-6800.md
+++ b/EIPS/eip-6800.md
@@ -42,7 +42,7 @@ def group_to_scalar_field(point: Point) -> int:
     if point == bandersnatch.Z:
         return 0
     else:
-        return int.from_bytes(point.map_to_base_field().to_bytes(32, 'little'), 'little') % BANDERSNATCH_MODULUS
+        return point.map_to_base_field() % BANDERSNATCH_MODULUS
     
 def compute_commitment_root(children: Sequence[int]) -> Point:
     o = bandersnatch.Z
@@ -139,13 +139,17 @@ def old_style_address_to_address32(address: Address) -> Address32:
 These are the positions in the tree at which block header fields of an account are stored.
 
 ```
+def hash_point_to_bytes(point: Point) -> int:
+    return group_to_scalar_field(point).to_bytes(32, 'little')
+ 
+
 def pedersen_hash(inp: bytes) -> bytes32:
     assert len(inp) <= 255 * 16
     # Interpret input as list of 128 bit (16 byte) integers
     ext_input = inp + b"\0" * (255 * 16 - len(inp))
     ints = [2 + 256 * len(inp)] + \
            [int.from_bytes(ext_input[16 * i:16 * (i + 1)], 'little') for i in range(255)]
-    return compute_commitment_root(ints).serialize()
+    return compute_commitment_root(ints).hash_point_to_bytes()
 
 def get_tree_key(address: Address32, tree_index: int, sub_index: int):
     # Asssumes VERKLE_NODE_WIDTH = 256


### PR DESCRIPTION
This PR changes the way we do tree key hashing, switching from base field point serialization to mapping to a scalar field and byte serialization.