### PR TITLE
Update EIP-3670: Align with EOF Megaspec and other EIPs

### DIFF
--- a/EIPS/eip-3670.md
+++ b/EIPS/eip-3670.md
@@ -38,12 +38,10 @@ The EOF1 format provides following forward compatibility properties:
 
 ## Specification
 
-*Remark:* We rely on the notation of *initcode*, *code* and *creation* as defined by [EIP-3540](./eip-3540.md).
-
 This feature is introduced on the same block EIP-3540 is enabled, therefore every EOF1-compatible bytecode MUST be validated according to these rules.
 
-1. Previously deprecated instructions `CALLCODE` (0xf2) and `SELFDESTRUCT` (0xff) are invalid and their opcodes are undefined.
-2. At contract creation time *instructions validation* is performed on both *initcode* and *code*. The code is invalid if any of the checks below fails. For each instruction:
+1. Previously deprecated instructions `CALLCODE` (0xf2) and `SELFDESTRUCT` (0xff), as well as instructions deprecated in EIP-3540, are invalid and their opcodes are undefined. (**NOTE** there are more instructions deprecated and rejected in EOF, as specced out by separate EIPs)
+2. At contract creation time *code validation* is performed on each code section of the EOF container. The code is invalid if any of the checks below fails. For each instruction:
    1. Check if the opcode is defined. The `INVALID` (0xfe) is considered defined.
    2. Check if all instructions' immediate bytes are present in the code (code does not end in the middle of instruction).
 
@@ -65,45 +63,48 @@ This change poses no risk to backwards compatibility, as it is introduced at the
 
 ### Contract creation
 
-Each case should be tested for creation transaction, `CREATE` and `CREATE2`.
+Each case should be tested by submitting an EOF container to EOF contract creation (as specced out in a separate EIP).
 
-- Invalid initcode
-- Valid initcode returning invalid code
-- Valid initcode returning valid code
+- EOF container with an invalid code at zeroth code section
+- EOF container with an invalid code at code sections placed in various positions
 
 ### Valid codes
 
 - EOF code containing `INVALID`
 - EOF code with data section containing bytes that are undefined instructions
-- Legacy code containing undefined instruction
-- Legacy code ending with incomplete PUSH instruction
 
 ### Invalid codes
 
-- EOF code containing undefined instruction
+- EOF code containing an undefined instruction
 - EOF code ending with incomplete `PUSH` instruction
-    - This can include `PUSH` instruction unreachable by execution, e.g. after `STOP`
 
 ## Reference Implementation
 
 ```python
-# The ranges below are as specified in the Yellow Paper.
+# The ranges below are as specified by Execution Specs for Shanghai.
 # Note: range(s, e) excludes e, hence the +1
-valid_opcodes = [
+shanghai_opcodes = [
     *range(0x00, 0x0b + 1),
     *range(0x10, 0x1d + 1),
     0x20,
     *range(0x30, 0x3f + 1),
     *range(0x40, 0x48 + 1),
     *range(0x50, 0x5b + 1),
+    0x5f,
     *range(0x60, 0x6f + 1),
     *range(0x70, 0x7f + 1),
     *range(0x80, 0x8f + 1),
     *range(0x90, 0x9f + 1),
     *range(0xa0, 0xa4 + 1),
     # Note: 0xfe is considered assigned.
-    0xf0, 0xf1, 0xf3, 0xf4, 0xf5, 0xfa, 0xfd, 0xfe
+    0xf0, 0xf1, 0xf2, 0xf3, 0xf4, 0xf5, 0xfa, 0xfd, 0xfe, 0xff
 ]
+
+# Drop the opcodes deprecated and rejected in here and in EIP-3540
+rejected_in_eof = [
+    0x38, 0x39, 0x3b, 0x3c, 0x3f, 0x5a, 0xf1, 0xf2, 0xf4, 0xfa, 0xff
+]
+valid_opcodes = [op for op in shanghai_opcodes not in rejected_in_eof]
 
 immediate_sizes = 256 * [0]
 immediate_sizes[0x60:0x7f + 1] = range(1, 32 + 1)  # PUSH1..PUSH32

--- a/EIPS/eip-3670.md
+++ b/EIPS/eip-3670.md
@@ -63,10 +63,7 @@ This change poses no risk to backwards compatibility, as it is introduced at the
 
 ### Contract creation
 
-Each case should be tested by submitting an EOF container to EOF contract creation (as specced out in a separate EIP).
-
-- EOF container with an invalid code at zeroth code section
-- EOF container with an invalid code at code sections placed in various positions
+Each case should be tested by submitting an EOF container to EOF contract creation (as specced out in a separate EIP). Each case should be tested with code placed in code sections at different indices.
 
 ### Valid codes
 


### PR DESCRIPTION
Updates the language of the EIP-3670, to align with [EOF Megaspec](https://github.com/ipsilon/eof/blob/main/spec/eof.md) and other changes in EOF EIPs. Mainly makes independent from the exact spec of EOF contract creation.

The gist of the EIP should remain the same.