### PR TITLE
Update EIP-7516: fix blobbasefee opcode number in nominal test case

### DIFF
--- a/EIPS/eip-7516.md
+++ b/EIPS/eip-7516.md
@@ -51,7 +51,7 @@ There are no known backward compatibility issues with this instruction.
 Assuming calling `get_blob_gasprice(header)` (as defined in [EIP-4844 §Gas accounting](./eip-4844.md#gas-accounting)) on the current block's header returns `7 wei`:
 `BLOBBASEFEE` should push the value `7` (left padded byte32) to the stack.
 
-Bytecode: `0x4900` (`BLOBBASEFEE, STOP`)
+Bytecode: `0x4a00` (`BLOBBASEFEE, STOP`)
 
 | Pc | Op          | Cost | Stack | RStack |
 |----|-------------|------|-------|--------|


### PR DESCRIPTION
Fixes the number of the BLOBBASEFEE opcode in the nominal test case. 0x4900 -> 0x4a00 for (BLOBBASEFEE, STOP)