### PR TITLE
Update EIP-7547: Change modification to payload attribute SSE event

### DIFF
--- a/EIPS/eip-7547.md
+++ b/EIPS/eip-7547.md
@@ -126,7 +126,7 @@ class BeaconBlockBody(Container):
 
 **Builder and API spec:**
 
-- ***Modified** payload attribute SSE endpoint:* Adjust the payload attribute SSE endpoint to include payload summaries.
+- ***Modified** payload attribute SSE endpoint:* Adjust the payload attribute SSE endpoint to include the `inclusion_list_summary`.
 
 ### Execution layer
 

--- a/EIPS/eip-7547.md
+++ b/EIPS/eip-7547.md
@@ -123,11 +123,6 @@ class BeaconBlockBody(Container):
 - ***New** duty for `inclusion_list`:* Proposer to prepare and sign the inclusion list.
 - ***Modified** duty for `BeaconBlockBody`:* Update the duty to prepare the beacon block body to include the `inclusion_list_summary`.
 
-
-**Builder and API spec:**
-
-- ***Modified** payload attribute SSE endpoint:* Adjust the payload attribute SSE endpoint to include the `inclusion_list_summary`.
-
 ### Execution layer
 
 - ***New** `get_inclusion_list`:* Introduce a new function for proposers to retrieve inclusion lists.


### PR DESCRIPTION
Change so that the `payload_attributes` SSE event output includes the inclusion list summary.

(I believe that this is what is meant, feel free to close this if not.)