### PR TITLE
Update EIP-6800: remove gas reform section

### DIFF
--- a/EIPS/eip-6800.md
+++ b/EIPS/eip-6800.md
@@ -262,20 +262,6 @@ The Verkle tree uses a single-layer tree structure with 32-byte keys and values 
 
 The single-layer tree design does have a major weakness: the inability to deal with entire storage trees as a single object. This is why this EIP includes removing most of the functionality of SELFDESTRUCT. If absolutely desired, SELFDESTRUCT’s functionality could be kept by adding and incrementing an account_state_offset parameter that increments every time an account self-destructs, but this would increase complexity.
 
-### Gas reform
-
-Gas costs for reading storage and code are reformed to more closely reflect the gas costs under the new Verkle tree design. WITNESS_CHUNK_COST is set to charge 6.25 gas per byte for chunks, and WITNESS_BRANCH_COST is set to charge ~13,2 gas per byte for branches on average (assuming 144 byte branch length) and ~2.5 gas per byte in the worst case if an attacker fills the tree with keys deliberately computed to maximize proof length.
-
-The main differences from gas costs in Berlin are:
-
- * 200 gas charged per 31 byte chunk of code. This has been estimated to increase average gas usage by ~6-12%
- * Cost for accessing adjacent storage slots (`key1 // 256 == key2 // 256`) decreases from 2100 to 200 for all slots after the first in the group,
- * Cost for accessing storage slots 0…63 decreases from 2100 to 200, including the first storage slot. This is likely to significantly improve performance of many existing contracts, which use those storage slots for single persistent variables.
-
-Gains from the latter two properties have not yet been analyzed, but are likely to significantly offset the losses from the first property. It’s likely that once compilers adapt to these rules, efficiency will increase further.
-
-The precise specification of when access events take place, which makes up most of the complexity of the gas repricing, is necessary to clearly specify when data needs to be saved to the period 1 tree.
-
 ## Backwards Compatibility
 
 The three main backwards-compatibility-breaking changes are:


### PR DESCRIPTION
Remove section that is the [same as EIP-4762 "Gas reform" section](https://eips.ethereum.org/EIPS/eip-4762#gas-reform) which explain gas changes for Verkle.
