### PR TITLE
Add EIP: EVM-ify the identity precompile

### DIFF
--- a/EIPS/eip-7666.md
+++ b/EIPS/eip-7666.md
@@ -1,5 +1,5 @@
 ---
-eip: 7651
+eip: 7666
 title: EVM-ify the identity precompile
 description: Remove the identity precompile, and put into place a piece of EVM code that has equivalent functionality
 author: Vitalik Buterin (@vbuterin)


### PR DESCRIPTION
Corrects the number of the EIP merged in #8366 with the next available number, 7666.