### PR TITLE
Update EIP-7623: Adjust Token from 16 to 12

### DIFF
--- a/EIPS/eip-7623.md
+++ b/EIPS/eip-7623.md
@@ -32,7 +32,7 @@ By increasing the gas cost for nonzero calldata bytes for transactions that are 
 | Parameter | Value |
 | - | - |
 | `STANDARD_TOKEN_COST`    |  `4` |
-| `TOTAL_COST_FLOOR_PER_TOKEN`    |  `17` |
+| `TOTAL_COST_FLOOR_PER_TOKEN`    |  `12` |
 
 
 Let `tokens_in_calldata = zero_bytes_in_calldata + nonzero_bytes_in_calldata * 4`.
@@ -66,9 +66,9 @@ tx.gasUsed = {
 
 ## Rationale
 
-The current maximum block size is approximately 1.79 MB (`30_000_000/16`). One can create blocks full of zero bytes that go up to 7.5 MB, but it is now standard to wrap blocks with snappy compression at the p2p layer and so such zero-byte-heavy blocks would end up smaller than 1.79 MB in practice. With the implementation of [EIP-4844](./eip-4844.md) this will increase to about 2.54 MB. Furthermore, the cost for nonzero calldata bytes hasn't been adjusted since [EIP-2028](./eip-2028).
+The current maximum block size is approximately 1.79 MB (`30_000_000/16`). One can create blocks full of zero bytes that go up to 7.5 MB, but it is now standard to wrap blocks with snappy compression at the p2p layer and so such zero-byte-heavy blocks would end up smaller than 1.79 MB in practice. With the implementation of [EIP-4844](./eip-4844.md) this increased to ~2.54 MB. Furthermore, the cost for nonzero calldata bytes hasn't been adjusted since [EIP-2028](./eip-2028).
 
-This proposal aims to increase the cost of calldata to 68 gas for transactions that do not exceed a certain threshold of gas spent on EVM operations. This change will significantly reduce the maximum block size by limiting the number and size of pure-data transactions that can fit into a single block. Specifically, by adjusting the cost of nonzero calldata bytes to 68 gas for DA transactions, the goal is to lower the maximum possible block size to roughly 0.55 MB without impacting the vast majority (~96% of transactions, 1.5% of addresses as of Feb. 2024) of users.
+This proposal aims to increase the cost of calldata to 48 gas for transactions that do not exceed a certain threshold of gas spent on EVM operations. This change will significantly reduce the maximum block size by limiting the number and size of pure-data transactions that can fit into a single block. Specifically, by adjusting the cost of nonzero calldata bytes to 48 gas for DA transactions, the goal is to lower the maximum possible block size to roughly 0.6 MB without impacting the vast majority of users.
 
 
 This reduction makes room for increasing the block gas limit or the number of blobs, while ensuring network security and efficiency. 


### PR DESCRIPTION
Adjust Token from 16 to 12 in consideration of:
* ** Access list costs**
* Impact on Merkle Proofs
* Imapct on certain cryptographic tools such as STARKs