### PR TITLE
Update EIP-152: Fix reference test

### DIFF
--- a/EIPS/eip-152.md
+++ b/EIPS/eip-152.md
@@ -80,8 +80,8 @@ function callF() public view returns (bytes32[2] memory) {
   m[3] = hex"0000000000000000000000000000000000000000000000000000000000000000";
 
   bytes8[2] memory t;
-  t[0] = hex"03000000";
-  t[1] = hex"00000000";
+  t[0] = hex"0300000000000000";
+  t[1] = hex"0000000000000000";
 
   bool f = true;
 


### PR DESCRIPTION
The solidity example with the reference test of https://datatracker.ietf.org/doc/html/rfc7693#appendix-A is at least confusing because it declares values of type `bytes8` using a literal of length of 4 bytes.
