### PR TITLE
Update EIP-5792: Add showCallsStatus

### DIFF
--- a/EIPS/eip-5792.md
+++ b/EIPS/eip-5792.md
@@ -161,23 +161,23 @@ Returns the status of a call batch that was sent via `wallet_sendCalls`. The ide
 #### `wallet_getCallsStatus` RPC Specification
 
 ```typescript
-type GetCallsParams = string
+type GetCallsParams = string;
 
 type GetCallsResult = {
-  status: 'PENDING' | 'CONFIRMED'
+  status: 'PENDING' | 'CONFIRMED';
   receipts?: {
     logs: {
-      address: `0x${string}`
-      data: `0x${string}`
-      topics: `0x${string}`[]
-    }[]
-    status: `0x${string}` // Hex 1 or 0 for success or failure, respectively
-    blockHash: `0x${string}`
-    blockNumber: `0x${string}`
-    gasUsed: `0x${string}`
-    transactionHash: `0x${string}`
-  }[]
-}
+      address: `0x${string}`;
+      data: `0x${string}`;
+      topics: `0x${string}`[];
+    }[];
+    status: `0x${string}`; // Hex 1 or 0 for success or failure, respectively
+    blockHash: `0x${string}`;
+    blockNumber: `0x${string}`;
+    gasUsed: `0x${string}`;
+    transactionHash: `0x${string}`;
+  }[];
+};
 ```
 
 ##### `wallet_getCallsStatus` Example Parameters
@@ -216,6 +216,26 @@ As with the return value of `wallet_sendCalls`, the batch identifier may be any 
 }
 ```
 
+### `wallet_showCallsStatus`
+
+Requests that a wallet shows information about a given call bundle that was sent with `wallet_sendCalls`. Note that this method does not return anything.
+
+#### `wallet_showCallsStatus` RPC Specification
+
+```typescript
+type ShowCallsParams = string; // Call bundle identifier returned by wallet_sendCalls
+```
+
+##### `wallet_showCallsStatus` Example Parameters
+
+This method accepts a call bundle identifier returned by a `wallet_sendCalls` call.
+
+```json
+[
+  "0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331"
+]
+```
+
 ### `atomicBatch` Capability
 
 Indicates that a wallet can execute multiple calls atomically as part of a single transaction.
@@ -226,8 +246,8 @@ If a wallet indicates it supports the `atomicBatch` capability, it MUST submit c
 
 ```typescript
 type AtomicBatchCapability = {
-  supported: true
-}
+  supported: true;
+};
 ```
 
 ##### `wallet_getCapabilities` Example Return Value

--- a/EIPS/eip-5792.md
+++ b/EIPS/eip-5792.md
@@ -32,7 +32,9 @@ We define one capability related to call execution atomicity.
 
 ### `wallet_getCapabilities`
 
-RPC for an application to receive information about the capabilities that a connected wallet supports (e.g. batch transactions, paymaster communication).
+RPC for an application to receive information about the capabilities that a provided wallet supports (e.g. batch transactions, paymaster communication).
+
+This method SHOULD return an error if the user has not already approved a connection to the app with the provided address.
 
 The key of each item per chain is the name of a capability and the value can be of any shape. Capabilities are returned per chain because wallets may support different capabilities across chains.
 
@@ -41,9 +43,15 @@ We expect the community to align on the definition of capabilities in separate E
 #### `wallet_getCapabilities` RPC Specification
 
 ```typescript
-type GetCapabilitiesParams = [];
+type GetCapabilitiesParams = [`0x${string}`]; // Wallet address
 
 type GetCapabilitiesResult = Record<`0x${string}`, <Record<string, any>>; // Hex chain id
+```
+
+##### `wallet_getCapabilities` Example Parameters
+
+```json
+["0xd46e8dd67c5d32be8058bb8eb970870f07244567"]
 ```
 
 ##### `wallet_getCapabilities` Example Return Value
@@ -125,6 +133,7 @@ type SendCallsResult = string;
       }
     ],
     "capabilities": {
+      // Illustrative
       "paymasterService": {
         "url": "https://..."
       }
@@ -135,21 +144,21 @@ type SendCallsResult = string;
 
 ##### `wallet_sendCalls` Example Return Value
 
-The identifier can be any string. The only requirement is that for a given session, users should be able to call `wallet_getCallsReceipt` with this value and get a call batch status.
+The identifier can be any string. The only requirement is that for a given session, users should be able to call `wallet_getCallsStatus` with this value and get a call batch status.
 
 ```json
 "0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331"
 ```
 
-### `wallet_getCallsReceipt`
+### `wallet_getCallsStatus`
 
 Returns the status of a call batch that was sent via `wallet_sendCalls`. The identifier of the transaction is the value returned from the `wallet_sendCalls` RPC. Note this method only returns a subset of fields that `eth_getTransactionReceipt` returns, excluding any fields that may differ across wallet implementations.
 
 * If a wallet does not execute multiple calls atomically (i.e. in multiple transactions), the receipts in the `receipts` field MUST be in order of the calls sent.
-* If a wallet executes multiple calls atomically (i.e. in a single transaction), `wallet_getCallsReceipt` MUST return a single receipt, corresponding to the transaction in which the calls were included.
+* If a wallet executes multiple calls atomically (i.e. in a single transaction), `wallet_getCallsStatus` MUST return a single receipt, corresponding to the transaction in which the calls were included.
 * The `logs` in the receipt objects MUST only include logs relevant to the calls submitted using `wallet_sendCalls`. For example, in the case of a transaction submitted onchain by an [ERC-4337](./eip-4337.md) bundler, the logs must only include those relevant to the user operation constructed using the calls submitted via `wallet_sendCalls`. I.e. the logs should not include those from other unrelated user operations submitted in the same bundle.
 
-#### `wallet_getCallsReceipt` RPC Specification
+#### `wallet_getCallsStatus` RPC Specification
 
 ```typescript
 type GetCallsParams = string
@@ -171,7 +180,7 @@ type GetCallsResult = {
 }
 ```
 
-##### `wallet_getCallsReceipt` Example Parameters
+##### `wallet_getCallsStatus` Example Parameters
 
 As with the return value of `wallet_sendCalls`, the batch identifier may be any string.
 
@@ -181,7 +190,7 @@ As with the return value of `wallet_sendCalls`, the batch identifier may be any 
 ]
 ```
 
-##### `wallet_getCallsReceipt` Example Return Value
+##### `wallet_getCallsStatus` Example Return Value
 
 ```json
 {

--- a/EIPS/eip-5792.md
+++ b/EIPS/eip-5792.md
@@ -2,7 +2,7 @@
 eip: 5792
 title: Wallet Call API
 description: Adds JSON-RPC methods for sending multiple calls from the user's wallet, and checking their status
-author: Moody Salem (@moodysalem), Lukas Rosario (@lukasrosario), Wilson Cusack (@wilsoncusack), Dror Tirosh (@drortirosh), Jake Moxey (@jxom)
+author: Moody Salem (@moodysalem), Lukas Rosario (@lukasrosario), Wilson Cusack (@wilsoncusack), Dror Tirosh (@drortirosh), Jake Moxey (@jxom), Derek Rein (@arein)
 discussions-to: https://ethereum-magicians.org/t/eip-5792-wallet-abstract-transaction-send-api/11374
 status: Draft
 type: Standards Track


### PR DESCRIPTION
- add back `wallet_showCallsStatus`. this is a method that requests a wallet shows information about a call bundle. this was part of the original EIP-5792.
- added semicolons throughout ts
- add an address param to `wallet_getCapabilities`. capabilities can differ per address. also noted that apps should have an already-approved connection to this provided address.