### PR TITLE
Update EIP-2537: Rename multiexponentiation to MSM

### DIFF
--- a/EIPS/eip-2537.md
+++ b/EIPS/eip-2537.md
@@ -182,7 +182,7 @@ Error cases:
 - Input has invalid length 
 
 
-#### ABI for G2 NSN
+#### ABI for G2 MSM
 
 G2 MSM call expects `288*k` (`k` being a **positive** integer) bytes as an input that is interpreted as byte concatenation of `k` slices each of them being a byte concatenation of encoding of G2 point (`256` bytes) and encoding of a scalar value (`32` bytes). Output is an encoding of MSM operation result - a single G2 point (`256` bytes).
 

--- a/EIPS/eip-2537.md
+++ b/EIPS/eip-2537.md
@@ -29,10 +29,10 @@ The motivation of this precompile is to add a cryptographic primitive that allow
 |`FORK_TIMESTAMP`     | *TBD* | Mainnet            |
 |BLS12_G1ADD          | 0x0b  | precompile address |
 |BLS12_G1MUL          | 0x0c  | precompile address |
-|BLS12_G1MULTIEXP     | 0x0d  | precompile address |
+|BLS12_G1MSM          | 0x0d  | precompile address |
 |BLS12_G2ADD          | 0x0e  | precompile address |
 |BLS12_G2MUL          | 0x0f  | precompile address |
-|BLS12_G2MULTIEXP     | 0x10  | precompile address |
+|BLS12_G2MSM          | 0x10  | precompile address |
 |BLS12_PAIRING        | 0x11  | precompile address |
 |BLS12_MAP_FP_TO_G1   | 0x12  | precompile address |
 |BLS12_MAP_FP2_TO_G2  | 0x13  | precompile address |
@@ -41,10 +41,10 @@ If `block.timestamp >= FORK_TIMESTAMP` we introduce *nine* separate precompiles 
 
 - BLS12_G1ADD - to perform point addition in G1 (curve over base prime field) with a gas cost of `500` gas
 - BLS12_G1MUL - to perform point multiplication in G1 (curve over base prime field) with a gas cost of `12000` gas
-- BLS12_G1MULTIEXP - to perform multiexponentiation in G1 (curve over base prime field) with a gas cost formula defined in the corresponding section
+- BLS12_G1MSM - to perform multi-scalar-multiplication (MSM) in G1 (curve over base prime field) with a gas cost formula defined in the corresponding section
 - BLS12_G2ADD - to perform point addition in G2 (curve over quadratic extension of the base prime field) with a gas cost of `800` gas
 - BLS12_G2MUL - to perform point multiplication in G2 (curve over quadratic extension of the base prime field) with a gas cost of `45000` gas
-- BLS12_G2MULTIEXP - to perform multiexponentiation in G2 (curve over quadratic extension of the base prime field) with a gas cost formula defined in the corresponding section
+- BLS12_G2MSM - to perform multi-scalar-multiplication (MSM) in G2 (curve over quadratic extension of the base prime field) with a gas cost formula defined in the corresponding section
 - BLS12_PAIRING - to perform a pairing operations between a set of *pairs* of (G1, G2) points a gas cost formula defined in the corresponding section
 - BLS12_MAP_FP_TO_G1 - maps base field element into the G1 point with a gas cost of `5500` gas
 - BLS12_MAP_FP2_TO_G2 - maps extension field element into the G2 point with a gas cost of `75000` gas
@@ -127,7 +127,7 @@ A scalar for the multiplication operation is encoded as `32` bytes by performing
 
 #### Behavior on empty inputs:
 
-Certain operations have variable length input, such as multiexponentiations (takes a list of pairs `(point, scalar)`), or pairing (takes a list of `(G1, G2)` points). While their behavior is well-defined (from an arithmetic perspective) on empty inputs, this EIP discourages such use cases and variable input length operations must return an error if the input is empty.
+Certain operations have variable length input, such as MSMs (takes a list of pairs `(point, scalar)`), or pairing (takes a list of `(G1, G2)` points). While their behavior is well-defined (from an arithmetic perspective) on empty inputs, this EIP discourages such use cases and variable input length operations must return an error if the input is empty.
 
 ### ABI for operations
 
@@ -151,9 +151,9 @@ Error cases:
 - The point not in G1  (i.e. neither on a curve nor the infinity point)
 - Input has invalid length
 
-#### ABI for G1 multiexponentiation
+#### ABI for G1 MSM
 
-G1 multiexponentiation call expects `160*k` (`k` being a **positive** integer) bytes as an input that is interpreted as byte concatenation of `k` slices each of them being a byte concatenation of encoding of a G1 point (`128` bytes) and encoding of a scalar value (`32` bytes). Output is an encoding of multiexponentiation operation result - a single G1 point (`128` bytes).
+G1 MSM call expects `160*k` (`k` being a **positive** integer) bytes as an input that is interpreted as byte concatenation of `k` slices each of them being a byte concatenation of encoding of a G1 point (`128` bytes) and encoding of a scalar value (`32` bytes). Output is an encoding of MSM operation result - a single G1 point (`128` bytes).
 
 Error cases:
 
@@ -182,9 +182,9 @@ Error cases:
 - Input has invalid length 
 
 
-#### ABI for G2 multiexponentiation
+#### ABI for G2 NSN
 
-G2 multiexponentiation call expects `288*k` (`k` being a **positive** integer) bytes as an input that is interpreted as byte concatenation of `k` slices each of them being a byte concatenation of encoding of G2 point (`256` bytes) and encoding of a scalar value (`32` bytes). Output is an encoding of multiexponentiation operation result - a single G2 point (`256` bytes).
+G2 MSM call expects `288*k` (`k` being a **positive** integer) bytes as an input that is interpreted as byte concatenation of `k` slices each of them being a byte concatenation of encoding of G2 point (`256` bytes) and encoding of a scalar value (`32` bytes). Output is an encoding of MSM operation result - a single G2 point (`256` bytes).
 
 Error cases:
 
@@ -257,9 +257,9 @@ Assuming a constant `30 MGas/second`, the following prices are suggested.
 
 `45000` gas
 
-#### G1/G2 Multiexponentiation
+#### G1/G2 MSM
 
-Multiexponentiations are expected to be performed by the Pippenger algorithm (we can also say that is **must** be performed by Pippenger algorithm to have a speedup that results in a discount over naive implementation by multiplying each pair separately and adding the results). For this case there was a table prepared for discount in case of `k <= 128` points in the multiexponentiation with a discount cup `max_discount` for `k > 128`.
+MSMs are expected to be performed by the Pippenger algorithm (we can also say that is **must** be performed by Pippenger algorithm to have a speedup that results in a discount over naive implementation by multiplying each pair separately and adding the results). For this case there was a table prepared for discount in case of `k <= 128` points in the MSM with a discount cup `max_discount` for `k > 128`.
 
 To avoid non-integer arithmetic, the call cost is calculated as `(k * multiplication_cost * discount) / multiplier` where `multiplier = 1000`, `k` is a number of (scalar, point) pairs for the call, `multiplication_cost` is a corresponding single multiplication call cost for G1/G2.
 
@@ -285,9 +285,9 @@ Fp2 -> G2 mapping is `75000` gas
 
 #### Gas schedule clarifications for the variable-length input
 
-For multiexponentiation and pairing functions, the gas cost depends on the input length. The current state of how the gas schedule is implemented in major clients (at the time of writing) is that the gas cost function does *not* perform any validation of the length of the input and never returns an error. So we present a list of rules how the gas cost functions **must** be implemented to ensure consistency between clients and safety.
+For MSM and pairing functions, the gas cost depends on the input length. The current state of how the gas schedule is implemented in major clients (at the time of writing) is that the gas cost function does *not* perform any validation of the length of the input and never returns an error. So we present a list of rules how the gas cost functions **must** be implemented to ensure consistency between clients and safety.
 
-##### Gas schedule clarifications for G1/G2 Multiexponentiation
+##### Gas schedule clarifications for G1/G2 MSM
 
 Define a constant `LEN_PER_PAIR` that is equal to `160` for G1 operation and to `288` for G2 operation. Define a function `discount(k)` following the rules in the corresponding section, where `k` is number of pairs.
 
@@ -328,9 +328,9 @@ We use floor division to get the number of pairs. If the length of the input is 
 
 The motivation section covers a total motivation to have operations over the BLS12-381 curves available. We also extend a rationale for more specific fine points.
 
-### Multiexponentiation as a separate call
+### MSM as a separate call
 
-Explicit separate multiexponentiation operation that allows one to save execution time (so gas) by both the algorithm used (namely the Pippenger algorithm) and (usually forgotten) by the fact that `CALL` operation in Ethereum is expensive (at the time of writing), so one would have to pay non-negigible overhead if e.g. for multiexponentiation of `100` points would have to call the multipication precompile `100` times and addition for `99` times (roughly `138600` would be saved).
+Explicit separate MSM operation that allows one to save execution time (so gas) by both the algorithm used (namely the Pippenger algorithm) and (usually forgotten) by the fact that `CALL` operation in Ethereum is expensive (at the time of writing), so one would have to pay non-negigible overhead if e.g. for MSM of `100` points would have to call the multiplication precompile `100` times and addition for `99` times (roughly `138600` would be saved).
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
Discussion: https://ethereum-magicians.org/t/eip-2537-bls12-precompile-discussion-thread/4187/63

The spec is inconsistent and uses both additive notation (G!ADD and G1MUL) and multiplicative notation (G!MULTIEXP) for the elliptic curve group law.

Blockchain, cryptography and ZK research has settled in using the additive notation.
And previous BN254 EIPs (EIP196) already uses the additive notation.