### PR TITLE
ACDE 185 Updates

### DIFF
--- a/EIPS/eip-7600.md
+++ b/EIPS/eip-7600.md
@@ -7,7 +7,7 @@ discussions-to: https://ethereum-magicians.org/t/eip-7600-hardfork-meta-prague-e
 status: Draft
 type: Meta
 created: 2024-01-18
-requires: 2537, 6110, 7002, 7549, 7569
+requires: 2537, 2935, 3074, 6110, 7002, 7251, 7549, 7569
 ---
 
 ## Abstract
@@ -19,6 +19,8 @@ This Meta EIP lists the EIPs formally considered for and included in the Prague/
 ### EIPs Included  
 
 * [EIP-2537](./eip-2537.md): Precompile for BLS12-381 curve operations
+* [EIP-2935](./eip-2935.md): Save historical block hashes in state
+* [EIP-3074](./eip-3074.md): AUTH and AUTHCALL opcodes
 * [EIP-6110](./eip-6110.md): Supply validator deposits on chain
 * [EIP-7002](./eip-7002.md): Execution layer triggerable exits
 * [EIP-7251](./eip-7251.md): Increase the MAX_EFFECTIVE_BALANCE  
@@ -27,16 +29,28 @@ This Meta EIP lists the EIPs formally considered for and included in the Prague/
 ### EIPs Considered for Inclusion
 
 * [EIP-7547](./eip-7547.md): Inclusion lists
+* [EIP-7623](./eip-7623.md): Increase calldata cost
+* EOF, consisting of the following EIPs: 
+    * [EIP-663](./eip-663.md): SWAPN, DUPN and EXCHANGE instructions
+    * [EIP-3540](./eip-3540.md): EOF - EVM Object Format v1
+    * [EIP-3670](./eip-3670.md): EOF - Code Validation
+    * [EIP-4200](./eip-4200.md): EOF - Static relative jumps
+    * [EIP-4750](./eip-4750.md): EOF - Functions
+    * [EIP-5450](./eip-5450.md): EOF - Stack Validation
+    * [EIP-6206](./eip-6206.md): EOF - JUMPF and non-returning functions
+    * [EIP-7069](./eip-7069.md): Revamped CALL instructions
+    * [EIP-7480](./eip-7480.md): EOF - Data section access instructions
+    * [EIP-7620](./eip-7620.md): EOF Contract Creation
 
 ### Full Specifications 
 
 #### Consensus Layer
 
-EIP-6110 and EIP-7002 require changes to Ethereum's consensus layer. While the EIPs present an overview of these changes, the full specifications can be found in the `_features` directory of the `ethereum/consensus-specs` repository: [6110](https://github.com/ethereum/consensus-specs/blob/19edc2d1ec9d17dd2e84d4ed727ebf6451abb1b9/specs/_features/eip6110), [7002](https://github.com/ethereum/consensus-specs/blob/19edc2d1ec9d17dd2e84d4ed727ebf6451abb1b9/specs/_features/eip7002).
+EIP-6110, EIP-7002 EIP-7251 and EIP-7549 require changes to Ethereum's consensus layer. While the EIPs present an overview of these changes, the full specifications can be found in the `specs/electra` and `specs/_features` directories of the `ethereum/consensus-specs` repository.
 
 #### Execution Layer
 
-EIP-2537, EIP-6110 and EIP-7002 require changes to Ethereum's execution layer. The EIPs fully specify those changes. 
+EIP-2537, EIP-2935, EIP-3074, EIP-6110 and EIP-7002 require changes to Ethereum's execution layer. The EIPs fully specify those changes. 
 
 ### Activation 
 

--- a/EIPS/eip-7607.md
+++ b/EIPS/eip-7607.md
@@ -24,7 +24,7 @@ This Meta EIP lists the EIPs formally considered for & included in the Osaka net
 * [EIP-6800](./eip-6800.md): Ethereum state using a unified verkle tree
 * [EIP-6873](./eip-6873.md): Preimage retention
 * [EIP-7545](./eip-7545.md): Verkle proof verification precompile
-
+* [EIP-7667](./eip-7667.md): Raise gas costs of hash functions
 
 ### Activation 
 


### PR DESCRIPTION
This PR reflects the decisions from [ACDE#185](https://github.com/ethereum/pm/issues/997) on the Pectra & Osaka upgrades. Namely:

- EIPs 2935 and 3074 included in Pectra
- EIP 7623 and EOF CFI'd for Pectra
- EIP-7667 CFI'd for Osaka 