### PR TITLE
Update EIP-3074: Add `AUTHORIZED` opcode

### DIFF
--- a/EIPS/eip-3074.md
+++ b/EIPS/eip-3074.md
@@ -193,6 +193,44 @@ else:
 
 As with `CALL`, the full gas cost is charged immediately, independently of actually executing the call.
 
+### `AUTHORIZED` (`0x4b`)
+
+A new opcode `AUTHORIZED` shall be created at `0x4b`. It shall take one stack element as input, and it shall return one stack element.
+
+#### Input
+
+##### Stack
+
+| Stack      | Value                       |
+| ---------- | --------------------------- |
+| `top - 0`  | `currentOrParentCallframe`  |
+
+##### Memory 
+
+Memory is not modified by this instruction.
+
+#### Output 
+
+##### Stack
+
+| Stack      | Value                                            |
+| ---------- | ------------------------------------------------ |
+| `top - 0`  | `(currentCallframe\|parentCallframe).authorized` |
+
+##### Memory 
+
+Memory is not modified by this instruction.
+
+#### Behavior 
+
+If `currentOrParentCallframe` is 0, `AUTHORIZED` will return the `authorized` context variable of the current callframe. If `currentOrParentCallframe` is any value greater than 0, `AUTHORIZED` will return the `authorized` context variable of the parent callframe, if it exists.
+
+If `currentOrParentCallframe` is greater than zero, and the current callframe is the top-level callframe, `AUTHORIZED` will return 0.
+
+#### Gas Cost
+
+The fee for `AUTHORIZED` is the same as other context variable accessor opcodes, such as `ADDRESS`, `ORIGIN`, `CALLER`, and `CALLVALUE`, at a constant fee of `2` gas.
+
 ## Rationale
 
 ### Signature in Memory
@@ -335,7 +373,8 @@ Allowing `authorized` to equal `tx.origin` has the possibility to:
  - Break atomic sandwich protections which rely on `tx.origin`;
  - Break reentrancy guards of the style `require(tx.origin == msg.sender)`.
 
-The authors of this EIP believe the risks of allowing `authorized` to equal `tx.origin` are acceptable for the reasons outlined in the Rationale section.
+The authors of this EIP believe the risks of allowing `authorized` to equal `tx.origin` are acceptable for the reasons outlined in the Rationale section. In addition, with the `AUTHORIZED` opcode,
+smart contract authors may choose to reject transactions that are being relayed with `AUTHCALL` by checking if the parent context's `authorized` context variable is set to `msg.sender`.
 
 ## Copyright
 


### PR DESCRIPTION
## Overview

Introduces a new opcode to EIP-3074, `AUTHORIZED`, that allows for smart contracts to introspect the `authorized` context variable of the current or parent callframe.

### Rationale

1. Other callframe-level context variables are accessible within the executing context via accessor opcodes.
2. With 3074, checks in smart contracts of the style `msg.sender == tx.origin` to guarantee callframe depth = 0 or that `msg.sender` is in fact an EOA are no longer viable due to `authorized` being able to be set to `tx.origin`. While the rationale of this invariant not being affected by callframe depth is true in the context of an "isEOA" check today, that is only in the case if `msg.sender == parent_callframe.authorized == tx.origin` within an `AUTHCALL` context. It is no longer possible to tell if `msg.sender` is an EOA if the check is performed in an `AUTHCALL` context where `tx.origin` is not the parent callframe's `authorized` context variable.
    - Example:
        - Alice signs an `AUTH` message.
        - Bob relays Alice's `AUTH` message with an `AUTHCALL`, which calls `Contract`.
        - `Contract` checks if `tx.origin == msg.sender`, to determine if `msg.sender` is an EOA.
        - `Bob != Alice`, so `Alice` is wrongfully assumed by this contract to be a smart contract rather than an EOA.
    - Example 2:
        - Bob signs an `AUTH` message.
        - Bob relays his own `AUTH` message with an `AUTHCALL`, which calls `Contract`.
        - `Contract` checks if `tx.origin == msg.sender`, to determine if the current callframe depth is `0` (and therefore, the calldata will be available in the block body).
        - `Bob == Bob`, so the contract will wrongfully assume that the context is the originating callframe. The data that the contract believed would be available within the block body is now only available by executing the transaction and inspecting the memory passed to `AUTHCALL`.
    - Real world example: In the OP Stack's `OptimismPortal` contract, [Address Aliasing](https://specs.optimism.io/protocol/deposits.html?highlight=alias#address-aliasing) is applied for smart contracts that call the `depositTransaction` function [here](https://github.com/ethereum-optimism/optimism/blob/94f04ba950488353afa1881073a65baf2f202b44/packages/contracts-bedrock/src/L1/OptimismPortal.sol#L400-L404). Without being able to introspect the parent callframe's `authorized` context variable, it is now impossible to determine whether or not `msg.sender` is an EOA inside of an `AUTHCALL` frame, and therefore whether or not the `OptimismPortal` should alias the address. 
3. While this opcode can be used by existing contracts that rely on determining whether or not `msg.sender` is an EOA, or that the callframe depth is guaranteed to be zero when combined with `msg.sender == tx.origin`, it can also be used to detect when a message is being relayed on behalf of `msg.sender`. 