### PR TITLE
Update EIP-2537: Fix conflicting gas formula

### DIFF
--- a/EIPS/eip-2537.md
+++ b/EIPS/eip-2537.md
@@ -273,7 +273,7 @@ Discounts table as a vector of pairs `[k, discount]`:
 
 #### Pairing operation
 
-The cost of the pairing operation is `43000*k + 65000` where `k` is a number of pairs.
+The cost of the pairing operation is `23000*k + 115000` where `k` is a number of pairs.
 
 #### Fp-to-G1 mapping operation
 


### PR DESCRIPTION
EIP-2537 currently lists two conflicting gas formulas for the pairing precompile, one in section [Pairing operation](https://eips.ethereum.org/EIPS/eip-2537#pairing-operation), and a different one in [Gas schedule clarifications for pairing](https://eips.ethereum.org/EIPS/eip-2537#gas-schedule-clarifications-for-pairing).

Geth currently implements "43000*k + 65000" and it's cause of failing tests. 

This PR fixes that by using only "23000*k + 115000", but let me know if this is not correct.