### PR TITLE
Update EIP-3074: fail if account has code

### DIFF
--- a/EIPS/eip-3074.md
+++ b/EIPS/eip-3074.md
@@ -311,7 +311,7 @@ For this reason, `AUTH` requires the `nonce` in the message to be equal to the s
 
 ### Failing on `EXTCODESIZE` check
 
-In [EIP-3607](./eip-5607), it was determined that the protocol should reject any transaction which originates from an account with code. Although this EIP focused on transaction origination, the authors of EIP-3074 feel the intention is clear: an account that has both code and a known private key should not be allowed to make arbitrary calls on behalf of said account. Therefore, the property is upheld in this EIP. For full rationale, please refer to [EIP-3607](./eip-3607).
+In [EIP-3607](./eip-3607), it was determined that the protocol should reject any transaction which originates from an account with code. Although this EIP focused on transaction origination, the authors of EIP-3074 feel the intention is clear: an account that has both code and a known private key should not be allowed to make arbitrary calls on behalf of said account. Therefore, the property is upheld in this EIP. For full rationale, please refer to [EIP-3607](./eip-3607).
 
 ## Backwards Compatibility
 

--- a/EIPS/eip-3074.md
+++ b/EIPS/eip-3074.md
@@ -90,7 +90,7 @@ Memory is not modified by this instruction.
 
 If `length` is greater than 97, the extra bytes are ignored for signature verification (they still incur a gas cost as defined later). Bytes outside the range (in the event `length` is less than 97) are treated as if they had been zeroes.
 
-`authority` is the address of the account which generated the signature.
+`authority` is the address of the account which generated the signature. If `EXTCODESIZE` of `authority` is not zero, consider the operation unsuccessful and unset `authorized`.
 
 The arguments (`yParity`, `r`, `s`) are interpreted as an ECDSA signature on the secp256k1 curve over the message `keccak256(MAGIC || chainId || nonce || invokerAddress || commit)`, where:
 
@@ -308,6 +308,10 @@ A new class of risk is introduced for insecure and buggy invokers. If an invoker
 Although this is a truly catastrophic event which is not expected to be possible via reputable wallets, it is a serious consideration. Without in-protocol revocation, users have no way to remove their account from the vulnerable invoker.
 
 For this reason, `AUTH` requires the `nonce` in the message to be equal to the signer's current nonce. This way, a single tx from the EOA will cause the nonce to increase, invalidating all outstanding authorizations.
+
+### Failing on `EXTCODESIZE` check
+
+In [EIP-3607](./eip-5607), it was determined that the protocol should reject any transaction which originates from an account with code. Although this EIP focused on transaction origination, the authors of EIP-3074 feel the intention is clear: an account that has both code and a known private key should not be allowed to make arbitrary calls on behalf of said account. Therefore, the property is upheld in this EIP. For full rationale, please refer to [EIP-3607](./eip-3607).
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
Some housekeeping that we meant to add ages ago. This retains the properties set forth by EIP-3607.