### PR TITLE
Update EIP-2537: Rollback and fix formula

### DIFF
--- a/EIPS/eip-2537.md
+++ b/EIPS/eip-2537.md
@@ -273,7 +273,7 @@ Discounts table as a vector of pairs `[k, discount]`:
 
 #### Pairing operation
 
-The cost of the pairing operation is `23000*k + 115000` where `k` is a number of pairs.
+The cost of the pairing operation is `43000*k + 65000` where `k` is a number of pairs.
 
 #### Fp-to-G1 mapping operation
 
@@ -316,7 +316,7 @@ The following pseudofunction reflects how gas should be calculated:
 ```
   k = floor(len(input) / LEN_PER_PAIR);
 
-  gas_cost = 23000*k + 115000;
+  gas_cost = 43000*k + 65000;
 
   return gas_cost;
 


### PR DESCRIPTION
Rollbacks change in https://github.com/ethereum/EIPs/pull/8414 and actually fixes the conflicting formula.

After speaking with @MariusVanDerWijden, it seems like the duplicated formula to fix was `23000*k + 115000` -> `43000*k + 65000`, not the other way around as the previous PR implemented.