### PR TITLE
Config: Allow links to final CAIPs in linter (Draft)

### DIFF
--- a/config/eipw.toml
+++ b/config/eipw.toml
@@ -155,6 +155,7 @@ exceptions = [
     '^https://(www\.)?github\.com/ethereum/devp2p/(blob|tree)/[0-9a-f]{40}/.+$',
     '^https://(www\.)?github\.com/ethereum/devp2p/commit/[0-9a-f]{40}$',
     '^https://(www\.)?github\.com/bitcoin/bips/(blob|tree)/[0-9a-f]{40}/bip-[0-9]+\.mediawiki$',
+    '^https://chainagnostic\.org/final/caip-[0-9]{1,5}$',
     '^https://www\.w3\.org/TR/[0-9][0-9][0-9][0-9]/.*$',
     '^https://[a-z]*\.spec\.whatwg\.org/commit-snapshots/[0-9a-f]{40}/$',
     '^https://www\.rfc-editor\.org/rfc/.*$',


### PR DESCRIPTION
One-line change, only marked as draft because it's blocked by [CAIPs#269](https://github.com/ChainAgnostic/CAIPs/pull/269/files) staying open for review by the other editors.

Backstory at [ethcatherders/EIPIP#320](https://github.com/ethcatherders/EIPIP/issues/320)