### PR TITLE
Update EIP-7685: simplify cl behavior

### DIFF
--- a/EIPS/eip-7685.md
+++ b/EIPS/eip-7685.md
@@ -40,9 +40,7 @@ Let `RequestsRoot` be the root of a Merkle-Patricia trie keyed by the index in t
 
 ### Consensus Layer
 
-Each proposal may choose how to extend `ExecutionPayload` to include the new EL request.
-
-A additional processing step is be added to `process_execution_payload` to iterate over and process all requests.
+Each proposal may choose how to extend `ExecutionPayload` to include the new EL request and how and when the request is processed.
 
 ## Rationale
 


### PR DESCRIPTION
Remove requirement for processing requests in the CL function `process_execution_payload(..)`.