### PR TITLE
Update EIP-7623: Add further clarification

### DIFF
--- a/EIPS/eip-7623.md
+++ b/EIPS/eip-7623.md
@@ -21,10 +21,10 @@ This is achieved by increasing the calldata cost for transactions primarily usin
 
 ## Motivation
 
-The block gas limit has not been increased since [EIP-1559](./eip-1559.md), while the average size of blocks has continuously increased due to the growing number of rollups posting data to Ethereum. Furthermore, the cost for nonzero calldata bytes hasn't been adjusted since [EIP-2028](./eip-2028).
+The block gas limit has not been increased since [EIP-1559](./eip-1559.md), while the average size of blocks has continuously increased due to the growing number of rollups posting data to Ethereum. Furthermore, the cost for calldata hasn't been adjusted since [EIP-2028](./eip-2028).
 [EIP-4844](./eip-4844.md) introduces blobs as a preferred method for data availability (DA). 
 This transition demands a reevaluation of calldata pricing, especially with regards to mitigating the inefficiency between the average block size and the maximum one possible.
-By increasing the gas cost for nonzero calldata bytes for transactions that are mainly using Ethereum for DA, this proposal aims to reduce the maximum block size to make room for adding more blobs. 
+By introducing a floor cost dependent on calldata for transactions that are mainly using Ethereum for DA, this proposal aims to reduce the maximum block size to make room for adding more blobs. 
 
 
 ## Specification
@@ -64,16 +64,18 @@ tx.gasUsed = {
     )
 ```
 
+For implementation this means that the `TOTAL_COST_FLOOR_PER_TOKEN` must be deducted before execution to avoid invalidation after execution.
+
 ## Rationale
 
-The current maximum block size is approximately 1.79 MB (`30_000_000/16`). One can create blocks full of zero bytes that go up to 7.5 MB, but it is now standard to wrap blocks with snappy compression at the p2p layer and so such zero-byte-heavy blocks would end up smaller than 1.79 MB in practice. With the implementation of [EIP-4844](./eip-4844.md) this increased to ~2.54 MB. Furthermore, the cost for nonzero calldata bytes hasn't been adjusted since [EIP-2028](./eip-2028).
+The current maximum block size is approximately 1.79 MB (`30_000_000/16`). One can create blocks full of zero bytes that go up to 7.5 MB, but it is now standard to wrap blocks with snappy compression at the p2p layer and so such zero-byte-heavy blocks would end up smaller than 1.79 MB in practice. With the implementation of [EIP-4844](./eip-4844.md) this increased to ~2.54 MB. Furthermore, the cost for calldata bytes hasn't been adjusted since [EIP-2028](./eip-2028).
 
-This proposal aims to increase the cost of calldata to 48 gas for transactions that do not exceed a certain threshold of gas spent on EVM operations. This change will significantly reduce the maximum block size by limiting the number and size of pure-data transactions that can fit into a single block. Specifically, by adjusting the cost of nonzero calldata bytes to 48 gas for DA transactions, the goal is to lower the maximum possible block size to roughly 0.6 MB without impacting the vast majority of users.
+This proposal aims to increase the cost of calldata to 16/48 gas for transactions that do not exceed a certain threshold of gas spent on EVM operations. This change will significantly reduce the maximum block size by limiting the number and size of pure-data transactions that can fit into a single block. Specifically, by adjusting the cost of calldata bytes to from 4/16 to 16/48 gas for DA transactions, the goal is to lower the maximum possible block size to roughly 0.6 MB without impacting the vast majority of users.
 
 
 This reduction makes room for increasing the block gas limit or the number of blobs, while ensuring network security and efficiency. 
 Importantly, regular users (sending ETH/Tokens/NFTs, engaging in DeFi, social media, restaking, bridging, etc.) who do not use Ethereum almost exclusively for DA, may remain unaffected.
-The calldata cost for transactions involving significant EVM computation remains at 16 gas per nonzero byte, ensuring those transactions experience no change.
+The calldata cost for transactions involving significant EVM computation remains at 4/16 gas per byte, ensuring those transactions experience no change.
 
 
 ## Backwards Compatibility


### PR DESCRIPTION
Add one sentence to clarify on implentation (deduction of floor before execution)
Remove focus from nonzero bytes