### PR TITLE
Update EIP-6110: get rid of Deposit struct definition

### DIFF
--- a/EIPS/eip-6110.md
+++ b/EIPS/eip-6110.md
@@ -65,21 +65,13 @@ The structure denoting the new deposit operation consists of the following field
 Deposits are a type of [EIP-7685](./eip-7685.md) request, therefore the encoding of the structure must be computed using the `DEPOSIT_REQUEST_TYPE` byte:
 
 ```python
-class Deposit(object):
-    pubkey: Bytes48
-    withdrawal_credentials: Bytes32
-    amount: uint64
-    signature: Bytes96
-    index: uint64
-
-def rlp_deposit_request(deposit: Deposit) -> bytes:
-    return DEPOSIT_REQUEST_TYPE + rlp([
-        rlp(deposit.pubkey),
-        rlp(deposit.withdrawal_credentials),
-        rlp(deposit.amount),
-        rlp(deposit.signature),
-        rlp(deposit.index)
-    ])
+deposit_request_rlp = DEPOSIT_REQUEST_TYPE + rlp([
+    pubkey,
+    withdrawal_credentials,
+    amount,
+    signature,
+    index
+])
 ```
 
 The encoded deposits will be included in the header and body as generic requests following the format defined by EIP-7685.
@@ -102,15 +94,17 @@ def parse_deposit_data(deposit_event_data): bytes[]
 def little_endian_to_uint64(data: bytes): uint64
     return uint64(int.from_bytes(data, 'little'))
 
-def event_data_to_deposit(deposit_event_data): Deposit
+def event_data_to_deposit_request_rlp(deposit_event_data): Deposit
     deposit_data = parse_deposit_data(deposit_event_data)
-    return Deposit(
-        pubkey=Bytes48(deposit_data[0]),
-        withdrawal_credentials=Bytes32(deposit_data[1]),
-        amount=little_endian_to_uint64(deposit_data[2]),
-        signature=Bytes96(deposit_data[3]),
-        index=little_endian_to_uint64(deposit_data[4])
-    )
+    pubkey = Bytes48(deposit_data[0])
+    withdrawal_credentials = Bytes32(deposit_data[1])
+    amount = little_endian_to_uint64(deposit_data[2])
+    signature = Bytes96(deposit_data[3])
+    index = little_endian_to_uint64(deposit_data[4])
+
+    return DEPOSIT_REQUEST_TYPE + rlp([
+        pubkey, withdrawal_credentials, amount, signature, index
+    ])
 
 # Obtain receipts from block execution result
 receipts = block.execution_result.receipts
@@ -120,8 +114,7 @@ expected_deposit_requests = []
 for receipt in receipts:
     for log in receipt.logs:
         if log.address == DEPOSIT_CONTRACT_ADDRESS:
-            deposit = event_data_to_deposit(log.data)
-            deposit_request_rlp = rlp_deposit_request(deposit)
+            deposit_request_rlp = event_data_to_deposit_request_rlp(log.data)
             expected_deposit_requests.append(deposit_request_rlp)
 
 deposit_requests = [req for req in block.body.requests if req[:1] == DEPOSIT_REQUEST_TYPE]

--- a/EIPS/eip-6110.md
+++ b/EIPS/eip-6110.md
@@ -85,16 +85,16 @@ Beginning with the `FORK_BLOCK`, client software **MUST** extend block validity 
 2. Each deposit accumulated in the block must appear in the EIP-7685 requests list in the order they appear in the logs. To illustrate:
 
 ```python
-def parse_deposit_data(deposit_event_data): bytes[]
+def parse_deposit_data(deposit_event_data) -> bytes[]:
   """
   Parses Deposit operation from DepositContract.DepositEvent data
   """
   pass
 
-def little_endian_to_uint64(data: bytes): uint64
+def little_endian_to_uint64(data: bytes) -> uint64:
     return uint64(int.from_bytes(data, 'little'))
 
-def event_data_to_deposit_request_rlp(deposit_event_data): Deposit
+def event_data_to_deposit_request_rlp(deposit_event_data) -> bytes:
     deposit_data = parse_deposit_data(deposit_event_data)
     pubkey = Bytes48(deposit_data[0])
     withdrawal_credentials = Bytes32(deposit_data[1])


### PR DESCRIPTION
Simplifies python code by removing `Deposit` structure