### PR TITLE
Update EIP-5000: Fix abstract for 0 special case

### DIFF
--- a/EIPS/eip-5000.md
+++ b/EIPS/eip-5000.md
@@ -12,7 +12,7 @@ created: 2022-03-14
 
 ## Abstract
 
-Introduce a new instruction, `MULDIV(x, y, z)`, to perform `((x * y) / z) % 2**256` in 512-bit precision. `z = 0` is a special case for `(x * y) % 2**256`.
+Introduce a new instruction, `MULDIV(x, y, z)`, to perform `((x * y) / z) % 2**256` in 512-bit precision. `z = 0` is a special case for `(x * y) / 2**256`.
 
 ## Motivation
 


### PR DESCRIPTION
The abstract says

> Introduce a new instruction, `MULDIV(x, y, z)`, to perform `((x * y) / z) % 2**256` in 512-bit precision. `z = 0` is a special case for `(x * y) % 2**256`.

The specification says

> If `z == 0`, `r = (uint512(x) * y) / 2**256`.

and in plain text

> `muldiv(x, y, 0)` computes the higher order 256 bits.

Hence fix the abstract to match the spec