### PR TITLE
Update EIP-7600: Move to Review

### DIFF
--- a/EIPS/eip-7600.md
+++ b/EIPS/eip-7600.md
@@ -4,7 +4,7 @@ title: Hardfork Meta - Pectra
 description: EIPs included in the Prague/Electra Ethereum network upgrade.
 author: Tim Beiko (@timbeiko)
 discussions-to: https://ethereum-magicians.org/t/eip-7600-hardfork-meta-prague-electra/18205
-status: Review
+status: Draft
 type: Meta
 created: 2024-01-18
 requires: 2537, 2935, 3074, 6110, 7002, 7251, 7549, 7569

--- a/EIPS/eip-7600.md
+++ b/EIPS/eip-7600.md
@@ -4,7 +4,7 @@ title: Hardfork Meta - Pectra
 description: EIPs included in the Prague/Electra Ethereum network upgrade.
 author: Tim Beiko (@timbeiko)
 discussions-to: https://ethereum-magicians.org/t/eip-7600-hardfork-meta-prague-electra/18205
-status: Draft
+status: Review
 type: Meta
 created: 2024-01-18
 requires: 2537, 2935, 3074, 6110, 7002, 7251, 7549, 7569
@@ -25,9 +25,11 @@ This Meta EIP lists the EIPs formally considered for and included in the Prague/
 * [EIP-7002](./eip-7002.md): Execution layer triggerable exits
 * [EIP-7251](./eip-7251.md): Increase the MAX_EFFECTIVE_BALANCE  
 * [EIP-7549](./eip-7549.md): Move committee index outside Attestation
+* [EIP-7685](./eip-7685.md): General purpose execution layer requests 
 
 ### EIPs Considered for Inclusion
 
+* [EIP-7212](./eip-7212.md): Precompile for secp256r1 Curve Support
 * [EIP-7547](./eip-7547.md): Inclusion lists
 * [EIP-7623](./eip-7623.md): Increase calldata cost
 * EOF, consisting of the following EIPs: 


### PR DESCRIPTION
Updates from [ACDE#186](https://github.com/ethereum/pm/issues/1016): 

- Include EIP-7685
- CFI EIP-7212
- CFI EIP-7623, which actually was previously CFI'd, so no changes in this PR. 