### PR TITLE
Update EIP-3074: clarify handling of incorrect nonce

### DIFF
--- a/EIPS/eip-3074.md
+++ b/EIPS/eip-3074.md
@@ -95,7 +95,7 @@ If `length` is greater than 97, the extra bytes are ignored for signature verifi
 The arguments (`yParity`, `r`, `s`) are interpreted as an ECDSA signature on the secp256k1 curve over the message `keccak256(MAGIC || chainId || nonce || invokerAddress || commit)`, where:
 
  - `chainId` is the current chain's [EIP-155](./eip-155.md) unique identifier padded to 32 bytes.
- - `nonce` is the signer's current nonce, left-padded to 32 bytes. Any other value is considered invalid.
+ - `nonce` is the signer's current nonce, left-padded to 32 bytes.
  - `invokerAddress` is the address of the contract executing `AUTH` (or the active state address in the context of `CALLCODE` or `DELEGATECALL`), left-padded with zeroes to a total of 32 bytes (ex. `0x000000000000000000000000AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA`).
  - `commit`, one of the arguments passed into `AUTH`, is a 32-byte value that can be used to commit to specific additional validity conditions in the invoker's pre-processing logic.
 


### PR DESCRIPTION
The wording "invalid" can be confused with throwing "execution invalid", which is not what should happen. The signature should be considered invalid and the operation should terminate gracefully and unsuccessfully.