### PR TITLE
Update EIP-2935: restrict contract input to 8 bytes to prevent overflow in checks

### DIFF
--- a/EIPS/eip-2935.md
+++ b/EIPS/eip-2935.md
@@ -71,8 +71,8 @@ def resolve_blockhash(block: Block, state: State, arg: uint64):
 Exact evm assembly that can be used for the contract to resolve `BLOCKHASH`
 
 ```
-// check if inputsize>32 revert
-push1 0x20
+// check if inputsize>8 revert
+push1 0x08
 calldatasize
 gt
 push1 0x31
@@ -88,7 +88,7 @@ gt
 push1 0x29
 jumpi
 
-// check if blocknumber > input + 8192 then return 0
+// check if blocknumber > input + 8192 then return 0, no overflow expected for input of 8 bytes
 push0
 calldataload
 push2 0x2000
@@ -129,6 +129,8 @@ revert
 
 stop
 ```
+
+<!-- TODO: bytecode is based off on first version and will be updated once assembley is locked down as it changes contract sender and address -->
 
 Corresponding bytecode:
 `60203611603157600143035f35116029575f356120000143116029576120005f3506545f5260205ff35b5f5f5260205ff35b5f5ffd00`


### PR DESCRIPTION
addresses the issue raised in:
 - https://github.com/ethereum/EIPs/pull/8488/files