### PR TITLE
Update EIP-2935: fix the input validation as 32 byte calldataload

### DIFF
--- a/EIPS/eip-2935.md
+++ b/EIPS/eip-2935.md
@@ -71,7 +71,9 @@ def resolve_blockhash(block: Block, state: State, arg: uint64):
 Exact evm assembly that can be used for the contract to resolve `BLOCKHASH`
 
 ```
-// check if input > 8 byte value revert
+// check if input > 8 byte value and revert if this isn't the case
+// the check is performed by comparing a the biggest 8 byte number with
+// the call data, which is a right-padded 32 byte number.
 push8 0xffffffffffffffff
 push0
 calldataload

--- a/EIPS/eip-2935.md
+++ b/EIPS/eip-2935.md
@@ -71,11 +71,12 @@ def resolve_blockhash(block: Block, state: State, arg: uint64):
 Exact evm assembly that can be used for the contract to resolve `BLOCKHASH`
 
 ```
-// check if inputsize>8 revert
-push1 0x08
-calldatasize
+// check if input > 8 byte value revert
+push8 0xffffffff
+push0
+calldataload
 gt
-push1 0x31
+push1 0x39
 jumpi
 
 // check if input > blocknumber-1 then return 0
@@ -85,7 +86,7 @@ sub
 push0
 calldataload
 gt
-push1 0x29
+push1 0x31
 jumpi
 
 // check if blocknumber > input + 8192 then return 0, no overflow expected for input of 8 bytes
@@ -95,7 +96,7 @@ push2 0x2000
 add
 number
 gt
-push1 0x29
+push1 0x31
 jumpi
 
 // mod 8192 and sload
@@ -129,6 +130,8 @@ revert
 
 stop
 ```
+
+Note that the input contract read `32` bytes input as `calldataload`. Users and clients doing EVM call to this contract should left pad the `arg` correctly.
 
 <!-- TODO: bytecode is based off on first version and will be updated once assembley is locked down as it changes contract sender and address -->
 

--- a/EIPS/eip-2935.md
+++ b/EIPS/eip-2935.md
@@ -72,7 +72,7 @@ Exact evm assembly that can be used for the contract to resolve `BLOCKHASH`
 
 ```
 // check if input > 8 byte value and revert if this isn't the case
-// the check is performed by comparing a the biggest 8 byte number with
+// the check is performed by comparing the biggest 8 byte number with
 // the call data, which is a right-padded 32 byte number.
 push8 0xffffffffffffffff
 push0

--- a/EIPS/eip-2935.md
+++ b/EIPS/eip-2935.md
@@ -72,7 +72,7 @@ Exact evm assembly that can be used for the contract to resolve `BLOCKHASH`
 
 ```
 // check if input > 8 byte value revert
-push8 0xffffffff
+push8 0xffffffffffffffff
 push0
 calldataload
 gt


### PR DESCRIPTION
realized that the contract uses calldataload which pads right with zeros so previous 8 byte check was incorrect (https://github.com/ethereum/EIPs/pull/8514)

now changes to direct compare against the max 8 byte val as the simplest option