### PR TITLE
Add EIP: Set EOA account code for one transaction

### DIFF
--- a/EIPS/eip-7702.md
+++ b/EIPS/eip-7702.md
@@ -46,18 +46,19 @@ As of `FORK_BLOCK_NUMBER`, a new [EIP-2718](./eip-2718.md) transaction is introd
 The [EIP-2718](./eip-2718.md) `TransactionPayload` for this transaction is
 
 ```
-rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit, destination, data, access_list, [[contract_code, y_parity, r, s], ...], signature_y_parity, signature_r, signature_s])
+rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit, destination, data, access_list, [[contract_code, flag, y_parity, r, s], ...], signature_y_parity, signature_r, signature_s])
 ```
 
 The intrinsic cost of the new transaction is inherited from [EIP-2930](./eip-2930.md), specifically `21000 + 16 * non-zero calldata bytes + 4 * zero calldata bytes + 1900 * access list storage key count + 2400 * access list address count`. Additionally, we add a cost of `16 * non-zero calldata bytes + 4 * zero calldata bytes` over each `contract_code`, plus `PER_CONTRACT_CODE_BASE_COST` times the length of the `contract_code` array.
 
-At the start of executing the transaction, for each `[contract_code, y_parity, r, s]` tuple:
+At the start of executing the transaction, for each `[contract_code, flag, y_parity, r, s]` tuple:
 
-1. Let `signer = ecrecover(keccak(MAGIC + contract_code), y_parity, r, s]`.
-2. Verify that the contract code of `signer` is empty.
-3. Set the contract code of `signer` to `contract_code`.
+1. Determine the signature algorithm type based on the `flag`.
+2. Let `signer = ecrecover(keccak(MAGIC + flag + contract_code), y_parity, r, s]`.
+3. Verify that the contract code of `signer` is empty.
+4. Set the contract code of `signer` to `contract_code`.
 
-At the end of the transaction, set the `contract_code` of each `signer` back to empty.
+At the end of the transaction, set the `contract_code` of each `signer` back to empty if `flag` marks temporarily.
 
 Note that the signer of any of the `contract_code` signatures, and the `tx.origin` of the transaction, are allowed to be different.
 


### PR DESCRIPTION
Add a new field named `flag`. Using the `flag`, we can differentiate signature algorithms and decide whether to revert the code after the transaction.