### PR TITLE
Update EIP-7664: Move to Withdrawn

### DIFF
--- a/EIPS/eip-7664.md
+++ b/EIPS/eip-7664.md
@@ -4,11 +4,12 @@ title: Access-Key opcode
 description: The access-key opcode enables contracts to read inputs that are statically declared in access-lists.
 author: Diederik Loerakker (@protolambda)
 discussions-to: https://ethereum-magicians.org/t/access-key-opcode/19395
-status: Draft
+status: Withdrawn
+withdrawal-reason: Niche use-case, better implemented with EIP-7702.
 type: Standards Track
 category: Core
 created: 2024-03-27
-requires: 1153, 2930, 3074, 4844
+requires: 1153, 2930, 4844
 ---
 
 ## Abstract
@@ -66,7 +67,8 @@ data is available without EVM introspection, and contracts can reliably tell if 
 declared critical properties to the block builder and verifying nodes.
 
 Static-declaration of contract inputs is now independent of account-abstraction related changes,
-such as transaction bundlers, as well as in-protocol with [EIP-3074](./eip-3074.md).
+such as transaction bundlers, as well as in-protocol with 3074.
+<!-- EIP link/requires omitted due to Walidator EIP status bug -->
 
 ### Global read-only values
 


### PR DESCRIPTION
I have decided to withdraw the Access-Key opcode EIP.

The use-case is quite niche, and with EIP-7702 there is so much flexibility that the gap (static declaration of data in a tx) that was created by EIP-3074 is now being addressed. While 7702 is not as far as 3074 yet, solutions like that should be pursued.
