### PR TITLE
Update EIP-7069: EIP-7069 - Add Address Space Extension check

### DIFF
--- a/EIPS/eip-7069.md
+++ b/EIPS/eip-7069.md
@@ -63,21 +63,22 @@ Execution semantics of `EXT*CALL`:
 3. If `value` is non-zero:
     - Halt with exceptional failure if the current frame is in `static-mode`.
     - Charge `CALL_VALUE_COST` gas.
-4. Peform (and charge for) memory expansion using `[input_offset, input_size]`.
-5. If `target_address` is not in the `warm_account_list`, charge `COLD_ACCOUNT_ACCESS - WARM_STORAGE_READ_COST` (2500) gas.
-6. If `target_address` is not in the state and the call configuration would result in account creation, charge `ACCOUNT_CREATION_COST` (25000) gas.
+4. If `target_address` has any of the high 12 bytes set to a non-zero value(i.e. it does not contain a 20-byte address) then halt with an exceptional failure. 
+5. Perform (and charge for) memory expansion using `[input_offset, input_size]`.
+6. If `target_address` is not in the `warm_account_list`, charge `COLD_ACCOUNT_ACCESS - WARM_STORAGE_READ_COST` (2500) gas.
+7. If `target_address` is not in the state and the call configuration would result in account creation, charge `ACCOUNT_CREATION_COST` (25000) gas.
     - The only such case in this EIP is if `value` is non-zero.
-7. Calculate the gas available to callee as caller's remaining gas reduced by `max(floor(gas/64), MIN_RETAINED_GAS)`.
-8. Fail with status code `1` returned on stack if any of the following is true (only gas charged until this point is consumed):
+8. Calculate the gas available to callee as caller's remaining gas reduced by `max(floor(gas/64), MIN_RETAINED_GAS)`.
+9. Fail with status code `1` returned on stack if any of the following is true (only gas charged until this point is consumed):
     - Gas available to callee at this point is less than `MIN_CALLEE_GAS`.
     - Balance of the current account is less than `value`.
     - Current call stack depth equals `1024`.
-11. Perform the call with the available gas and configuration.
-12. Push a status code on the stack:
+10. Perform the call with the available gas and configuration.
+11. Push a status code on the stack:
     - `0` if the call was successful.
     - `1` if the call has reverted (also can be pushed earlier in a light failure scenario).
     - `2` if the call has failed.
-13. Gas not used by the callee is returned to the caller.
+12. Gas not used by the callee is returned to the caller.
 
 Execution semantics of `RETURNDATALOAD`:
 
@@ -172,6 +173,12 @@ It is also useful to have these as new opcodes instead of modifying the existing
 ### `CALLCODE`
 
 Since `CALLCODE` is deprecated, we do not introduce a counterpart here.
+
+### Halting when `target_address` is not a 20-byte ethereum addresses  
+
+When existing `CALL` series operations encounter an address that does not fit into 20 bytes the current behavior is to mask the address so that it fits into 20 bytes, ignoring all high bytes. For the `EXT*CALL` operations a halt was chosen over treating the contract as empty for two reasons. First, it handles the case of sending value to an address that doesn't exist without having to create a special case. Second, it keeps the `warm_access_list` from needing to track anything that is not a 20-byte ethereum address.
+
+Smart contract developers should not rely on the operation reverting when such addresses are passed in. When a suitable proposal for the use of Address Space Extension is adopted it is expected that the `EXT*CALL` series of operations will adopt those changes.
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
Add a step in EXT*CALL to validate no high bytes are set when executing a call, halting when set.  This preserves essential room for Address Space Expansion.
