### PR TITLE
Add EIP: Historical Validity for ERC1271 Signatures

### DIFF
--- a/EIPS/eip-1272.md
+++ b/EIPS/eip-1272.md
@@ -1,0 +1,133 @@
+---
+eip: 1272
+title: Historical Validity for ERC1271 Signatures
+description: Extension of ERC1271 to include mechanisms for historical signature validation.
+author: Kyle Kaplan (@kylekaplan), Sina Sabet (@sinasab), Mihir Wadekar (@mw2000)
+discussions-to: https://ethereum-magicians.org/t/erc1271-versioning-to-maintain-signature-validity/19681
+status: Draft
+type: Standards Track
+category: ERC
+created: 2024-05-08
+---
+
+## Abstract
+The proposed standard extends ERC-1271 to include mechanisms for historical signature validation. This ensures that signatures remain valid and verifiable even after the signature validation logic (isValidSignature function) has been updated in a smart contract.
+
+## Motivation
+
+As smart contracts evolve, the logic to validate signatures may change, which can retroactively invalidate previously valid signatures. This inconsistency poses challenges for applications relying on these signatures to prove validity of statements or authorizations over time, particularly when interacting with smart contract-based accounts.
+
+## Specification
+
+### Functions
+
+#### `updateIsValidSignature`
+- **Purpose**: This function updates the contract's current verifier to a new address and logs this change.
+- **Requirements**:
+  - MUST emit an `ERC1271CheckerUpdated` event upon successful update.
+
+#### `wasValidSignature`
+- **Purpose**: This function checks if a signature was valid at a specific point in time based on the verifier active during that time.
+- **Parameters**:
+  - `_timestamp`: Timestamp at which the signature needs to be validated.
+  - `_hash`: Hash of the data to be signed.
+  - `_signature`: Signature byte array associated with the hash.
+  - `_data`: Arbitrary extra data used for verification.
+- **Returns**: The bytes4 magic value `0x1626ba7e` if the signature is verified as valid.
+- **Requirements**:
+  - MUST NOT modify state, ensuring it can be called safely by other contracts.
+  - MUST allow external calls.
+
+### Storage
+
+#### `verifiers`
+- **Description**: An array of `VerifierStruct` that stores the history of verifier changes.
+- **Type**: `VerifierStruct[]`
+
+### Structs
+
+#### `VerifierStruct`
+- **Purpose**: Stores each verifier along with the timestamp when it was set.
+- **Fields**:
+  - `timestamp`: uint64, the timestamp when the verifier was registered.
+  - `verifier`: address, the ERC1271 contract address that serves as the verifier.
+
+### Events
+
+#### `ERC1271CheckerUpdated`
+- **Purpose**: Emitted when the signature verifier is updated.
+- **Parameters**:
+  - `newChecker`: address indexed, the new verifier's address.
+
+### Solidity implementation
+
+```solidity
+pragma solidity ^0.5.0;
+
+/// @title Example interface for historical validity functionality extending ERC1271
+interface IERC1272 {
+
+    /// @title VerifierStruct
+    /// @dev This struct includes a timestamp and ERC1271 verifier. 
+    /// An array of VerifierStructs is maintained that updateIsValidSignature will push to.
+    struct VerifierStruct {
+        /// @notice The timestamp of the verifier
+        uint64 timestamp;
+        /// @notice The ERC1271 contract address
+        ERC1271 verifier;
+    }
+
+    /// @notice An array of VerifierStructs
+    VerifierStruct[] public verifiers;
+
+
+    /// @dev pushes to the array a new contract address with a current timestamp
+    /// @param _contract An ERC1271 contract address    
+    /// This function MUST emit the ERC1271CheckerUpdated event.
+    function updateIsValidSignature(address _contract) external;
+
+    /// @dev Should return whether the signature provided was valid at the time indicated by the timestamp.
+    /// @param _timestamp The timestamp at which the signature needs to be validated.
+    /// @param _hash Hash of the data to be signed.
+    /// @param _signature Signature byte array associated with _hash.
+    /// @param _data Arbitrary extra data that may be used by the verifier.
+    /// @return The bytes4 magic value 0x1626ba7e when function passes
+    /// MUST NOT modify state.
+    /// MUST allow external calls.
+    function wasValidSignature(
+        uint64 _timestamp,
+        bytes32 _hash,
+        bytes memory _signature,
+        bytes memory _data
+    ) external view returns (bytes4);
+    
+    /// @dev Event that is emitted when the signature verifier is updated.
+    event ERC1271CheckerUpdated(address indexed newChecker);
+}
+```
+
+## Rationale
+
+The introduction of historical validation mechanisms in EIP-1272 addresses a critical gap in the evolving landscape of smart contracts and their interaction with digital signatures. As smart contracts are updated over time, the logic governing signature validation can change, potentially rendering previously valid signatures invalid. This inconsistency poses significant risks in scenarios where historical transactions and signatures must remain verifiable indefinitely—such as legal, financial, and various compliance contexts.
+
+### Design Decisions
+
+#### Use of `VerifierStruct` Array
+The choice to utilize an array of `VerifierStructs` over other data structures like mappings is driven by the need for ordered historical records. An array inherently preserves the sequence of updates, making it easier to trace the evolution of validation logic chronologically. This is crucial for audits and any retrospective analysis that requires understanding the state of the system at a specific point in time.
+
+#### Functionality of `updateIsValidSignature` and `wasValidSignature`
+The design includes specific functions tailored to both update the validation logic and verify signatures against historical data:
+
+- **updateIsValidSignature**: Ensuring this function emits an `ERC1271CheckerUpdated` event provides transparency and traceability of changes, which is essential for maintaining trust in the system's integrity. It also allows systems and interfaces built on top of the contract to react or adjust to changes in validation logic.
+
+- **wasValidSignature**: By allowing verification against a specific timestamp, this function provides the flexibility needed for applications to confirm the validity of a signature based on the rules that were in place at the time it was created. This is particularly important in decentralized finance (DeFi) and other blockchain-based applications where historical decisions or transactions might need to be audited or challenged based on the context at that specific time.
+
+
+## Backwards Compatibility
+This EIP is designed to be fully compatible with EIP-1271 and does not affect existing implementations that do not require historical signature validation.
+
+## Reference Implementation
+TODO(mw2000): Add non witness reference implementation when finished
+
+## Security Considerations
+Care must be taken to ensure that the update mechanism for the signature validation logic is secure against unauthorized changes. Additionally, the storage method chosen must be optimized to prevent excessive gas costs associated with storing historical data.


### PR DESCRIPTION
This is an extension of ERC1271 to include mechanisms for historical signature validation.
