### PR TITLE
Update EIP-7702: Prohibit nonce-changing opcodes

### DIFF
--- a/EIPS/eip-7702.md
+++ b/EIPS/eip-7702.md
@@ -85,6 +85,18 @@ Specifically:
 * It allows EOAs to temporarily convert themselves into contracts to be included in ERC-4337 bundles, in a way that's compatible with the existing `EntryPoint`.
 * Once this is implemented, [EIP-5003](./eip-5003.md) is "only one line of code": just add a flag to not set the code back to empty at the end.
 
+### Opcode restriction
+
+For security reasons, some opcodes MUST not be executed in the context of an EOA:
+
+- `CREATE` (0xF0), `CREATE2` (0xF5) and `SELFDESTRUCT` (0xFF): There may be an expectation that transactions from a given sender should have consecutive nonces. This assumption would be broken if code placed at an EOA's address was to execute one or multiple operations that alter the sender account's nonce. Consequently, EOA performing a delegate transaction should not be able to use the `CREATE`, `CREATE2` or `SELFDESTRUCT` opcodes. Any CALL performed by the code placed at the EOA's address is free to create contracts normally.
+
+- `SSTORE` (0x55): Setting storage under an EOA breaks common assumptions. Conflits could arise from a single EOA using multiple code vertsion (in multiple transactions) that interpret the storage layout under the account differently. Therefore, EOAs should be forbiden from performing `SSTORE` if the code is to be cleared at the end of the transaction. Any CALL performed by the code placed at the EOA's address is free to manipulate storage normally.
+
+Any attempts to execute one of these restricted operations in the context of one of the signers MUST throw an exception.
+
+This restrictions only apply if the code placed at the signer's address is removed at the end of the transaction. If a flag is set to not set the code back to empty at the end of the transactions, then these restrictions do not apply.
+
 ## Backwards Compatibility
 
 This EIP breaks the invariant that an account balance can only decrease as a result of transactions originating from that account. This has consequences for mempool design, and for other EIPs such as inclusion lists. However, these issues are common to any proposal that provides similar functionality, including EIP-3074.

--- a/EIPS/eip-7702.md
+++ b/EIPS/eip-7702.md
@@ -89,9 +89,8 @@ Specifically:
 
 For security reasons, some opcodes MUST not be executed in the context of an EOA:
 
-- `CREATE` (0xF0), `CREATE2` (0xF5) and `SELFDESTRUCT` (0xFF): There may be an expectation that transactions from a given sender should have consecutive nonces. This assumption would be broken if code placed at an EOA's address was to execute one or multiple operations that alter the sender account's nonce. Consequently, EOA performing a delegate transaction should not be able to use the `CREATE`, `CREATE2` or `SELFDESTRUCT` opcodes. Any CALL performed by the code placed at the EOA's address is free to create contracts normally.
-
-- `SSTORE` (0x55): Setting storage under an EOA breaks common assumptions. Conflits could arise from a single EOA using multiple code vertsion (in multiple transactions) that interpret the storage layout under the account differently. Therefore, EOAs should be forbiden from performing `SSTORE` if the code is to be cleared at the end of the transaction. Any CALL performed by the code placed at the EOA's address is free to manipulate storage normally.
+* `CREATE` (0xF0), `CREATE2` (0xF5) and `SELFDESTRUCT` (0xFF): There may be an expectation that transactions from a given sender should have consecutive nonces. This assumption would be broken if code placed at an EOA's address was to execute one or multiple operations that alter the sender account's nonce. Consequently, EOA performing a delegate transaction should not be able to use the `CREATE`, `CREATE2` or `SELFDESTRUCT` opcodes. Any CALL performed by the code placed at the EOA's address is free to create contracts normally.
+* `SSTORE` (0x55): Setting storage under an EOA breaks common assumptions. Conflits could arise from a single EOA using multiple code vertsion (in multiple transactions) that interpret the storage layout under the account differently. Therefore, EOAs should be forbiden from performing `SSTORE` if the code is to be cleared at the end of the transaction. Any CALL performed by the code placed at the EOA's address is free to manipulate storage normally.
 
 Any attempts to execute one of these restricted operations in the context of one of the signers MUST throw an exception.
 

--- a/EIPS/eip-7702.md
+++ b/EIPS/eip-7702.md
@@ -57,7 +57,7 @@ At the start of executing the transaction, for each `[contract_code, y_parity, r
 2. Verify that the contract code of `signer` is empty.
 3. Set the contract code of `signer` to `contract_code`.
 
-At the end of the transaction, set the `contract_code` of each `signer` back to empty.
+At the end of the transaction, set the `contract_code` of each `signer` back to empty. Any storage set for the `signer` (by a call to `SSTORE` in the context of the `signer`) must also be cleared.
 
 Note that the signer of any of the `contract_code` signatures, and the `tx.origin` of the transaction, are allowed to be different.
 
@@ -90,7 +90,6 @@ Specifically:
 For security reasons, some opcodes MUST not be executed in the context of an EOA:
 
 * `CREATE` (0xF0), `CREATE2` (0xF5) and `SELFDESTRUCT` (0xFF): There may be an expectation that transactions from a given sender should have consecutive nonces. This assumption would be broken if code placed at an EOA's address was to execute one or multiple operations that alter the sender account's nonce. Consequently, EOA performing a delegate transaction should not be able to use the `CREATE`, `CREATE2` or `SELFDESTRUCT` opcodes. Any CALL performed by the code placed at the EOA's address is free to create contracts normally.
-* `SSTORE` (0x55): Setting storage under an EOA breaks common assumptions. Conflits could arise from a single EOA using multiple code vertsion (in multiple transactions) that interpret the storage layout under the account differently. Therefore, EOAs should be forbiden from performing `SSTORE` if the code is to be cleared at the end of the transaction. Any CALL performed by the code placed at the EOA's address is free to manipulate storage normally.
 
 Any attempts to execute one of these restricted operations in the context of one of the signers MUST throw an exception.
 

--- a/EIPS/eip-7702.md
+++ b/EIPS/eip-7702.md
@@ -89,7 +89,7 @@ Specifically:
 
 For security reasons, some opcodes MUST not be executed in the context of an EOA:
 
-* `CREATE` (0xF0), `CREATE2` (0xF5) and `SELFDESTRUCT` (0xFF): There may be an expectation that transactions from a given sender should have consecutive nonces. This assumption would be broken if code placed at an EOA's address was to execute one or multiple operations that alter the sender account's nonce. Consequently, EOA performing a delegate transaction should not be able to use the `CREATE`, `CREATE2` or `SELFDESTRUCT` opcodes. Any CALL performed by the code placed at the EOA's address is free to create contracts normally.
+* `CREATE` (0xF0), `CREATE2` (0xF5) and `SELFDESTRUCT` (0xFF): There may be an expectation that transactions from a given `signer` should have consecutive nonces. This assumption would be broken if code placed at an EOA's address was to execute one or multiple operations that alter the `signer`'s nonce. Consequently, EOA performing a delegate transaction should not be able to use the `CREATE`, `CREATE2` or `SELFDESTRUCT` opcodes. Any CALL performed by the code placed at the EOA's address is free to create contracts normally.
 
 Any attempts to execute one of these restricted operations in the context of one of the signers MUST throw an exception.
 

--- a/EIPS/eip-7702.md
+++ b/EIPS/eip-7702.md
@@ -57,7 +57,7 @@ At the start of executing the transaction, for each `[contract_code, y_parity, r
 2. Verify that the contract code of `signer` is empty.
 3. Set the contract code of `signer` to `contract_code`.
 
-At the end of the transaction, set the `contract_code` of each `signer` back to empty. Any storage set for the `signer` (by a call to `SSTORE` in the context of the `signer`) must also be cleared.
+At the end of the transaction, set the `contract_code` of each `signer` back to empty. Any storage set for the `signer` must also be cleared.
 
 Note that the signer of any of the `contract_code` signatures, and the `tx.origin` of the transaction, are allowed to be different.
 


### PR DESCRIPTION
Rational for this change is explained in the PR, but might deserve some discussion. All these are a transposition of a discussion that already happened on EIP-5806 (alghouth without all the attention/participation that EIP-7702 is getting today)

# Restricting nonce-changing operation

- Lets say Alice has an EOA, and gave a signature so that Bob (or anyone) can temporarily place code at Alice's EOA's address.
- Lets say Alice submits a "normal" transaction, with the correct nonce
- Lets say before Alice transaction is mined, Bob (or anyone) uses Alice signature, invokes the code at under Alice's EOA's address, and execute any of these opcodes

Then Alice's nonce would increase, and the "normal" transaction would no longer be valid. This could DoS Alice's ability to use her EOA. It would also mess up with the mempool. Therefore, I strongly believe that these opcode MUST be restrited.

# Restricting SSTORE

EDIT: The SSTORE part is the subject of #8539, no longer in this PR.

I understand people want to use SSTORE. I'm one of them, and I was very reluctant to add this restriction to EIP-5806. However, there is an invariant formulated somewhere (maybe @gballet can find the refenrence) that accounts without code SHOULD NOT have storage slot set. I believe this has to do with the transition to Verkle, or with safety assumption if permanent code is ever placed at this address. This restriction was recognised during the AA breakout session n°2.

I guess the proposed behavior is similar to what happens today if you use SSTORE in a contract that is selfdestructed within its construction transaction.

If you need persistent storage, you can use [a third party contract that holds it for you](https://gist.github.com/Amxx/664a6def831fa0a8731713bd71e861b0)

