### PR TITLE
Update EIP-6206: fix discrepancy in stack height check JUMPF

### DIFF
--- a/EIPS/eip-6206.md
+++ b/EIPS/eip-6206.md
@@ -38,7 +38,7 @@ The first code section MUST have 0 inputs and be non-returning.
 A new instruction, `JUMPF (0xe5)`, is introduced.
 
 1. `JUMPF` has one immediate argument, `target_section_index`, encoded as a 16-bit unsigned big-endian value.
-2. If the operand stack size exceeds `1024 - type[target_section_index].max_stack_height` (i.e. if the called function may exceed the global stack height limit), execution results in an exceptional halt. This guarantees that the target function does not exceed global stack height limit.
+2. If the operand stack size exceeds `1024 - type[target_section_index].max_stack_height + type[target_section_index].inputs` (i.e. if the called function may exceed the global stack height limit), execution results in an exceptional halt. This guarantees that the target function does not exceed global stack height limit.
 3. `JUMPF` sets `current_section_index` to `target_section_index` and `PC` to `0`, but does not change the return stack. Execution continues in the target section. 
 4. `JUMPF` costs 5 gas.
 5. `JUMPF` neither pops nor pushes anything to the operand stack.


### PR DESCRIPTION
This aligns the EIP with https://github.com/ipsilon/eof/blob/main/spec/eof.md. Also `evmone` implementation has it like this, and `CALLF` also is like that, so I'm assuming the fix makes sense and the discrepancy was just by omission. 

Credit to @jochem-brouwer for reporting this. 