### PR TITLE
Add EIP: Separate gas type for calldata

### DIFF
--- a/EIPS/eip-7706.md
+++ b/EIPS/eip-7706.md
@@ -63,7 +63,7 @@ def get_max_fees(tx: Transaction) -> [int, int, int]:
     elif tx.type == BLOB_TX_TYPE:
         return [tx.max_fee_per_gas, tx.max_fee_per_blob_gas, tx.max_fee_per_gas]
     elif is_eip_1559(tx.type):
-        return [tx.max_fee_per_gas, 0, max_fee_per_gas]
+        return [tx.max_fee_per_gas, 0, tx.max_fee_per_gas]
     else:
         return [tx.gasprice, 0, tx.gasprice]
 ```


### PR DESCRIPTION
Add a new type of gas for transaction calldata. Add a new transaction type that provides max_basefee and priority_fee as a vector, providing values for execution gas, blob gas and calldata gas. Modify EIP-1559 to use the same mechanism for the three types of gas.