### PR TITLE
Website: add status anchors

### DIFF
--- a/_includes/eiptable.html
+++ b/_includes/eiptable.html
@@ -7,6 +7,16 @@
     width: 33%;
   }
 </style>
+
+{% assign statuses = include.eips | map: "status" %}
+{% for status in statuses %}
+  {% if forloop.last %}
+    <a href="#{{status|slugify}}">{{status}}</a><br><br>
+  {% else %}
+    <a href="#{{status|slugify}}">{{status}}</a> |&nbsp;
+  {% endif %}
+{% endfor %}
+
 {% for status in site.data.statuses %}
   {% assign eips = include.eips|where:"status",status|sort:"eip" %}
   {% assign count = eips|size %}


### PR DESCRIPTION
This adds status anchor links to the top of the page as can be seen here: https://i.imgur.com/vi2rL3I.png

Unlike in the image, this PR will only add anchor link if there are EIPs with that status (the image shows "Living" when it shouldn't)

![](https://i.imgur.com/vi2rL3I.png)