### PR TITLE
Update EIP-6800: pack basic data in a single sub-index vector entry

### DIFF
--- a/EIPS/eip-6800.md
+++ b/EIPS/eip-6800.md
@@ -115,11 +115,8 @@ Instead of a two-layer structure as in the Patricia tree, in the Verkle tree we 
 
 | Parameter             | Value   |
 | --------------------- | ------- |
-| VERSION_LEAF_KEY      | 0       |
-| BALANCE_LEAF_KEY      | 1       |
-| NONCE_LEAF_KEY        | 2       |
-| CODE_KECCAK_LEAF_KEY  | 3       |
-| CODE_SIZE_LEAF_KEY    | 4       |
+| BASIC_DATA_LEAF_KEY   | 0       |
+| CODE_KECCAK_LEAF_KEY  | 1       |
 | HEADER_STORAGE_OFFSET | 64      |
 | CODE_OFFSET           | 128     |
 | VERKLE_NODE_WIDTH     | 256     |
@@ -135,6 +132,22 @@ def old_style_address_to_address32(address: Address) -> Address32:
 ```
 
 #### Header values
+
+Account header values include:
+- `version`
+- `balance`
+- `nonce`
+- `code_keccak`
+- `code_size`
+
+The `version`, `balance`, `nonce` and `code_size` values are compressed in a single `basic_data` 32-byte value to be stored in the `BASIC_DATA_LEAF_KEY` sub-index.
+This value is encoded as:
+- `basic_data[0]`: `version` (8 bits)
+- `basic_data[1:4]`: are unset (i.e: zeroes).
+- `basic_data[4:8]`: `code_size` (32 bits)
+- `basic_data[8:16]`: `nonce` (64 bits)
+- `basic_data[16:32]`: `balance` (128 bits)
+
 
 These are the positions in the tree at which block header fields of an account are stored.
 
@@ -157,15 +170,9 @@ def get_tree_key(address: Address32, tree_index: int, sub_index: int):
         bytes([sub_index])
     )
     
-def get_tree_key_for_version(address: Address32):
-    return get_tree_key(address, 0, VERSION_LEAF_KEY)
+def get_tree_key_basic_data(address: Address32):
+    return get_tree_key(address, 0, BASIC_DATA_LEAF_KEY)
     
-def get_tree_key_for_balance(address: Address32):
-    return get_tree_key(address, 0, BALANCE_LEAF_KEY)
-    
-def get_tree_key_for_nonce(address: Address32):
-    return get_tree_key(address, 0, NONCE_LEAF_KEY)
-
 # Backwards compatibility for EXTCODEHASH    
 def get_tree_key_for_code_keccak(address: Address32):
     return get_tree_key(address, 0, CODE_KECCAK_LEAF_KEY)


### PR DESCRIPTION
This is a draft PR to materialize @vbuterin's idea of packing multiple account header values into a basic data field: `version`, `balance`, `nonce`, and `code_size`. It can serve as a more detailed explanation for further discussion.

The original trigger for this idea was @vbuterin noticing this would simplify [EIP-4762](https://eips.ethereum.org/EIPS/eip-4762) when touching independent items under different instructions. Since all these values live in the same vector index, might be less error-prone to correctly define the spec and do the implementation.

Other benefits that I can think of:
- Reduce gas costs since you access only one chunk instead of multiple ones for many common operations. (i.e: up to 4 `CHUNK_COST` would be reduced to 1. Similar for writes)
- Having fewer vector openings gives proof generation and verification a lower average/worst case. (This might be debatable since gas cost is reduced, so more accesses can happen)
- Extra account header slots free for future use, or to assist more advanced code-chunking techniques.
- Witness `state_diff` size could be smaller since it would have to describe fewer VKT key-values.
- Simplify EL client's implementations trying to densely encode account header values to serialize account-header leaf nodes. Today's encoding has too many zero-bytes in different vector items. This proposal tightly packs more information in a single item.

Potential drawbacks:
- Introducing some bit-packing at the EVM level, which might not be ideal for zk-circuits?
- For state-proofs, clients would have to do some bit-unpacking to get the desired part of the basic data value. This shouldn't be a big deal since it's very fast under any non-zk context, but that's something that isn't required today since each field is in a dedicated sub-index.
