### PR TITLE
Update EIP-7685: Clarify block validity

### DIFF
--- a/EIPS/eip-7685.md
+++ b/EIPS/eip-7685.md
@@ -70,7 +70,7 @@ Let `requests_root` be the root of a Merkle-Patricia trie keyed by the index in
 the list of `requests`. This is equivalent to how the transaction trie root is
 computed.
 
- The `requests_root` field value is therefore computed as follows:
+The `requests_root` field value is therefore computed as follows:
 
 ```python
 def compute_trie_root_from_indexed_data(data):
@@ -79,6 +79,18 @@ def compute_trie_root_from_indexed_data(data):
 
 block.header.requests_root = compute_trie_root_from_indexed_data(block.body.requests)
 ```
+
+#### Block validity
+
+The execution client has an additional block validation to ensure that the `requests_root`
+matches the expected value given the list in the block body.
+
+```python
+assert block.header.requests_root == compute_trie_root_from_indexed_data(block.body.requests)
+```
+
+This validation should be performed in all cases, including when transactions in a block are executed
+by the execution client and produce requests.
 
 ### Consensus Layer
 


### PR DESCRIPTION
Clarifies the validation that an execution client needs to do in order to consider a block with `requests_root` valid.

This clarification is needed, because requests are not just received inside the block from P2P network or CL (like withdrawals for the `withdrawals_root` field), but also [derived](https://eips.ethereum.org/EIPS/eip-7685#request-source-and-validity) from the EVM execution (like receipts for `receipts_root` or cumulative gas usage for `gas_used`). This validation should be done everywhere.