### PR TITLE
Update EIP-4200: Fix validation test cases

### DIFF
--- a/EIPS/eip-4200.md
+++ b/EIPS/eip-4200.md
@@ -127,11 +127,12 @@ This change poses no risk to backwards compatibility, as it is introduced at the
 - `RJUMP`/`RJUMPI`/`RJUMPV` with instruction other than `JUMPDEST` as target
     - `relative_offset` is positive/negative/`0`
 - `RJUMPV` with various valid table sizes from 1 to 256
+- `RJUMP` as a final instruction in code section
 
 #### Invalid cases
 
 - `RJUMP`/`RJUMPI`/`RJUMPV` with truncated immediate
-- `RJUMP`/`RJUMPI`/`RJUMPV` as a final instruction in code section
+- `RJUMPI`/`RJUMPV` as a final instruction in code section
 - `RJUMP`/`RJUMPI`/`RJUMPV` target outside of code section bounds
 - `RJUMP`/`RJUMPI`/`RJUMPV` target push data
 - `RJUMP`/`RJUMPI`/`RJUMPV` target another `RJUMP`/`RJUMPI`/`RJUMPV` immediate argument


### PR DESCRIPTION
The `RJUMP` is valid as a final instruction.
