### PR TITLE
Update EIP-5792: make atomicBatch chain-specific per-batch, not per-call (both in protocol messages and in normative prose)

### DIFF
--- a/EIPS/eip-5792.md
+++ b/EIPS/eip-5792.md
@@ -246,6 +246,7 @@ The capabilities below are for illustrative purposes.
 ### `atomicBatch` Capability
 
 Like the illustrative examples given above and other capabilities to be defined in future EIPs, the capability to execute calls delivered via the above-defined methods in a single transaction can be attested by the wallet in boolean form.
+This capability is expressed separately on each network and should be interpreted as a guarantee only for batches of transactions on that network; batches including calls to multiple networks is out of scope of this capability and this specification.
 
 If a wallet has affirmatively expressed this `atomicBatch` capability to a calling application, it MUST submit calls submitted with `wallet_sendCalls` as part of a single transaction.
 


### PR DESCRIPTION
As per a conversation with @pedrouid and @jxom 