### PR TITLE
Update EIP-7702: Add system contract for revocations

### DIFF
--- a/EIPS/eip-7702.md
+++ b/EIPS/eip-7702.md
@@ -13,7 +13,7 @@ requires: 2718, 2929, 2930
 
 ## Abstract
 
-Add a new transaction type that adds a list of `[address, y_parity, r, s]` authorization tuples, and converts the signing accounts (not necessarily the same as the `tx.origin`) into smart contract wallets for the duration of that transaction.
+Add a new transaction type that adds a list of `[address, y_parity, r, s]` authorization tuples, and converts the signing accounts (not necessarily the same as the `tx.origin`) into smart contract wallets for the duration of that transaction, and a new system contract to revoke past authorizations.
 
 ## Motivation
 
@@ -27,11 +27,12 @@ There is a lot of interest in adding short-term functionality improvements to EO
 
 ### Parameters
 
-|     Parameter        | Value  |
-| -------------------- | ------ |
-| `SET_CODE_TX_TYPE`   | `0x04` |
-| `MAGIC`              | `0x05` |
-| `PER_AUTH_BASE_COST` | `2500` |
+|     Parameter             | Value  |
+| ------------------------- | ------ |
+| `SET_CODE_TX_TYPE`        | `0x04` |
+| `MAGIC`                   | `0x05` |
+| `PER_AUTH_BASE_COST`      | `4600` |
+| `AUTH_REVOCATION_ADDRESS` | TBD    |
 
 ### Set Code Transaction
 
@@ -40,27 +41,27 @@ We introduce a new [EIP-2718](./eip-2718.md) transaction, "set code transaction"
 ```
 rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit, destination, value, data, access_list, authorization_list, signature_y_parity, signature_r, signature_s])
 
-authorization_list = [[chain_id, address, [nonce], y_parity, r, s], ...]
+authorization_list = [[chain_id, address, y_parity, r, s], ...]
 ```
 
 The fields `chain_id`, `nonce`, `max_priority_fee_per_gas`, `max_fee_per_gas`, `gas_limit`, `destination`, `value`, `data`, and `access_list` of the outer transaction follow the same semantics as [EIP-1559](./eip-1559.md).
 
-The `authorization_list` is a list of tuples that store the address to code which the signer desires to set in their EOA temporarily. The third element is a list item mimicking an optional value. When the list length is zero, consider the authorization nonce to be null. When the list length is one, consider the single integer value to be the provided nonce authorization. Other lengths and value types in this optional are invalid.
+The `authorization_list` is a list of tuples that store the address to code which the signer desires to set in their EOA temporarily.
 
 The [EIP-2718](./eip-2718.md) `ReceiptPayload` for this transaction is `rlp([status, cumulative_transaction_gas_used, logs_bloom, logs])`.
 
 #### Behavior
 
-At the start of executing the transaction, for each `[chain_id, address, [nonce], y_parity, r, s]` tuple:
+At the start of executing the transaction, for each `[chain_id, address, y_parity, r, s]` tuple:
 
-1. `authority = ecrecover(keccak(MAGIC || rlp([chain_id, [nonce], address])), y_parity, r, s]`
+1. `authority = ecrecover(keccak(MAGIC || rlp([chain_id, address])), y_parity, r, s)`
 2. Verify the chain id is either 0 or the chain's current ID.
 3. Verify that the code of `authority` is empty.
-4. If nonce list item is length one, verify the nonce of `authority` is equal to `nonce`.
+4. Verify that the storage slot `keccak(authority || address)` of account `AUTH_REVOCATION_ADDRESS` is empty. (`authority` and `address` should be padded to 32 bytes each.)
 5. Set the code of `authority` to code associated with `address`.
 6. Add the `authority` account to `accessed_addresses` (as defined in [EIP-2929](./eip-2929.md).)
 
-If any of the above steps fail, immediately stop processing that tuple and continue to the next tuple in the list. It will In the case of multiple tuples for the same authority, set the code specified by the address in the first occurrence.
+If any of the above steps fail, immediately stop processing that tuple and continue to the next tuple in the list. In the case of multiple tuples for the same authority, set the code specified by the address in the first occurrence.
 
 At the end of the transaction, set the code of each `authority` back to empty.
 
@@ -68,9 +69,38 @@ Note that the signer of an authorization tuple may be different than `tx.origin`
 
 #### Gas Costs
 
-The intrinsic cost of the new transaction is inherited from [EIP-2930](./eip-2930.md), specifically `21000 + 16 * non-zero calldata bytes + 4 * zero calldata bytes + 1900 * access list storage key count + 2400 * access list address count`. Additionally, we add a cost of `PER_CONTRACT_CODE_BASE_COST * authorization list length`.
+The intrinsic cost of the new transaction is inherited from [EIP-2930](./eip-2930.md), specifically `21000 + 16 * non-zero calldata bytes + 4 * zero calldata bytes + 1900 * access list storage key count + 2400 * access list address count`. Additionally, we add a cost of `PER_AUTH_BASE_COST * authorization list length`.
 
 The transaction sender will pay for all authorization tuples, regardless of validity or duplication.
+
+### Revocation Contract
+
+In order to revoke a previously signed authorization, the signer can invoke the revocation contract at `AUTH_REVOCATION_ADDRESS` with the address to be revoked in calldata, padded to 32 bytes. Revocation is permanent. Previously valid signatures for the address will be ignored in all subsequent EIP-7702 transactions.
+
+The assembly code of the revocation contract is:
+
+```
+// write caller to [0, 32)
+caller
+push0
+mstore
+
+// copy address argument to [32, 64)
+push0
+calldataload
+push1 0x20
+mstore
+
+push1 0x01
+
+// hash `caller || address` in [0, 64)
+push0
+push1 0x40
+keccak256
+
+// store 1 in said slot
+sstore
+```
 
 ## Rationale
 
@@ -108,9 +138,11 @@ An alternative to adding chain ID could be to sign over the code the address poi
 
 #### In-protocol revocation
 
-A hotly debated element of this EIP is the need for in-protocol revocation. Although it is possible to implement revocation logic within delegated code, for some this isn't sufficient and it is the duty of the protocol to provide a revocation option of last resort.
+A hotly debated element of this EIP is the need for in-protocol revocation. Although it is possible to implement revocation logic within delegated code, this arguably does not achieve true revocability, since it doesn't prevent revoked authorizations from being accepted as valid by the protocol and loading revoked code into the account. For some this isn't sufficient and it is the duty of the protocol to provide a revocation option of last resort.
 
-For this reason, the proposal provides two separate schemes. The first is an eternal delegation to a smart contract. At the protocol level, it is not possible to revoke. However, the contract you delegate to is one which can expect to use in your account for perpetuity; similar to how smart contract wallet users deploy proxy contracts to their account and point the target at a wallet implementation. The second is a scoped delegation with a revocation mechanism based on the EOA's nonce. This is a safer to begin using smart contract code in the context of your EOA without potentially committing to a specific piece of code forever.
+In-protocol revocation based on account nonces makes long-lived authorizations incompatible with standard EOA transactions. Making such a mechanism optional doesn't offer a solution for those who want both long-lived authorizations and true revocability as described above. Having to accept code in perpetuity is a high price to pay and may hinder adoption of this EIP.
+
+The revocation mechanism should allow users to express that they no longer authorize a particular address as code for their account. This proposal implements this functionality as a system contract. Using contract storage to keep track of this information carries a number of benefits: it avoids changes to the state trie, it is easily adaptable to statelessness, and it results in a simple revocation procedure that doesn't require a new transaction type.
 
 ### Self-sponsoring: allowing `tx.origin` to set code
 

--- a/EIPS/eip-7702.md
+++ b/EIPS/eip-7702.md
@@ -75,7 +75,7 @@ The transaction sender will pay for all authorization tuples, regardless of vali
 
 ### Revocation Contract
 
-In order to revoke a previously signed authorization, the signer can invoke the revocation contract at `AUTH_REVOCATION_ADDRESS` with the address to be revoked in calldata, padded to 32 bytes. Revocation is permanent. Previously valid signatures for the address will be ignored in all subsequent EIP-7702 transactions.
+In order to revoke a previously signed authorization, the signer can invoke the revocation contract at `AUTH_REVOCATION_ADDRESS` with the address to be revoked in calldata, padded to 32 bytes. Revocation is permanent. Previously valid signatures for the address will be ignored in all subsequent set-code transactions.
 
 The assembly code of the revocation contract is:
 

--- a/EIPS/eip-7702.md
+++ b/EIPS/eip-7702.md
@@ -142,7 +142,7 @@ A hotly debated element of this EIP is the need for in-protocol revocation. Alth
 
 In-protocol revocation based on account nonces makes long-lived authorizations incompatible with standard EOA transactions. Making such a mechanism optional doesn't offer a solution for those who want both long-lived authorizations and true revocability as described above. Having to accept code in perpetuity is a high price to pay and may hinder adoption of this EIP.
 
-The revocation mechanism should allow users to express that they no longer authorize a particular address as code for their account. This proposal implements this functionality as a system contract. Using contract storage to keep track of this information carries a number of benefits: it avoids changes to the state trie, it is easily adaptable to statelessness, and it results in a simple revocation procedure that doesn't require a new transaction type.
+The revocation mechanism should allow users to express that they no longer authorize a particular address as code for their account. This proposal implements this functionality as a system contract. Using contract storage to keep track of this information carries a number of benefits: it avoids changes to the state trie, it is easily adaptable to statelessness, and it results in a simple revocation procedure that doesn't require a new transaction type. It additionally enables single-use authorizations.
 
 ### Self-sponsoring: allowing `tx.origin` to set code
 


### PR DESCRIPTION
This proposes to replace optional nonce-based revocability with address-based revocability via a new system contract.

The cost per auth tuple is updated with an additional unit of `COLD_SLOAD_COST` from 2500 to 4600.