### PR TITLE
Update EIP-7643: Fix MAX_HISTORICAL_EPOCHS for provided root

### DIFF
--- a/EIPS/eip-7643.md
+++ b/EIPS/eip-7643.md
@@ -37,7 +37,7 @@ associated total difficulty. The format for this data is defined as:
 
 ```python
 EPOCH_SIZE = 8192 # blocks
-MAX_HISTORICAL_EPOCHS = 131072  # 2**17
+MAX_HISTORICAL_EPOCHS = 2048
 
 # An individual record for a historical header.
 HeaderRecord = Container[block_hash: bytes32, total_difficulty: uint256]
@@ -53,7 +53,7 @@ HistoricalHashesAccumulator = Container[
 
 ### Pre-PoS Root
 
-The hash tree root of `HistoricalHashesAccumulator` for data before block 15537393 is
+The hash tree root of `HistoricalHashesAccumulator` for data before block 15537394 is
 `0xec8e040fd6c557b41ca8ddd38f7e9d58a9281918dc92bdb72342a38fb085e701`.
 
 ## Rationale


### PR DESCRIPTION
The hash_tree_root result of `0xec8e040fd6c557b41ca8ddd38f7e9d58a9281918dc92bdb72342a38fb085e701`  is with an SSZ List limit of `2048`.