### PR TITLE
Config: Allow links to portal-network-specs

### DIFF
--- a/EIPS/eip-1.md
+++ b/EIPS/eip-1.md
@@ -252,6 +252,24 @@ Permitted Networking Specifications URLs must anchor to a specific commit, and s
 ^https://github.com/ethereum/devp2p/(blob|commit)/[0-9a-f]{40}/.*$
 ```
 
+### Portal Specifications
+
+Links to specific commits of files within the Ethereum Portal Specifications may be included using normal markdown syntax, such as:
+
+```markdown
+[Portal Wire Protocol](https://github.com/ethereum/portal-network-specs/blob/5e321567b67bded7527355be714993c24371de1a/portal-wire-protocol.md)
+```
+
+Which renders as:
+
+[Portal Wire Protocol](https://github.com/ethereum/portal-network-specs/blob/5e321567b67bded7527355be714993c24371de1a/portal-wire-protocol.md)
+
+Permitted Networking Specifications URLs must anchor to a specific commit, and so must match this regular expression:
+
+```regex
+^https://github.com/ethereum/portal-network-specs/(blob|commit)/[0-9a-f]{40}/.*$
+```
+
 ### World Wide Web Consortium (W3C)
 
 Links to a W3C "Recommendation" status specification may be included using normal markdown syntax. For example, the following link would be allowed:

--- a/config/eipw.toml
+++ b/config/eipw.toml
@@ -154,6 +154,8 @@ exceptions = [
     '^https://(www\.)?github\.com/ethereum/yellowpaper/commit/[a-f0-9]{40}$',
     '^https://(www\.)?github\.com/ethereum/devp2p/(blob|tree)/[0-9a-f]{40}/.+$',
     '^https://(www\.)?github\.com/ethereum/devp2p/commit/[0-9a-f]{40}$',
+    '^https://(www\.)?github\.com/ethereum/portal-network-specs/(blob|tree)/[0-9a-f]{40}/.+$',
+    '^https://(www\.)?github\.com/ethereum/portal-network-specs/commit/[0-9a-f]{40}$',
     '^https://(www\.)?github\.com/bitcoin/bips/(blob|tree)/[0-9a-f]{40}/bip-[0-9]+\.mediawiki$',
     '^https://(www\.)?github\.com/ChainAgnostic/CAIPs/(blob|tree)/[a-f0-9]{40}/.+$',
     '^https://(www\.)?github\.com/ChainAgnostic/CAIPs/commit/[0-9a-f]{40}$',


### PR DESCRIPTION
This PR updates the config to support links to the portal-network-specs