### PR TITLE
Update EIP-7591: fix eip 7591 typo

### DIFF
--- a/EIPS/eip-7591.md
+++ b/EIPS/eip-7591.md
@@ -23,6 +23,8 @@ This will reduce growth of the chain history.
 
 ## Specification
 
+BLS_TX_TYPE = Bytes1(0x04)
+
 ### Transaction Type
 
 The transaction type will have the following format: 
@@ -35,7 +37,7 @@ with `sender` being the BLS public key of an account with address `address = [0:
 
 The signature value `signature` is calculated by constructing a BLS signature over the following digest:
 
-`tx_hash = keccak256(BLOB_TX_TYPE || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit, to, value, data, access_list, sender]))`.
+`tx_hash = keccak256(BLS_TX_TYPE || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit, to, value, data, access_list, sender]))`.
 
 ### Header changes
 


### PR DESCRIPTION
Introduces a new transaction type instead of reusing `BLOB_TX_TYPE`.