### PR TITLE
Update EIP-7600: Add PeerDAS

### DIFF
--- a/EIPS/eip-7600.md
+++ b/EIPS/eip-7600.md
@@ -7,7 +7,7 @@ discussions-to: https://ethereum-magicians.org/t/eip-7600-hardfork-meta-prague-e
 status: Draft
 type: Meta
 created: 2024-01-18
-requires: 2537, 2935, 6110, 7002, 7251, 7549, 7685, 7692, 7702
+requires: 2537, 2935, 6110, 7002, 7251, 7549, 7594, 7685, 7692, 7702
 ---
 
 ## Abstract
@@ -24,6 +24,7 @@ This Meta EIP lists the EIPs formally considered for and included in the Prague/
 * [EIP-7002](./eip-7002.md): Execution layer triggerable exits
 * [EIP-7251](./eip-7251.md): Increase the MAX_EFFECTIVE_BALANCE  
 * [EIP-7549](./eip-7549.md): Move committee index outside Attestation
+* [EIP-7594](./eip-7594.md): PeerDAS - Peer Data Availability Sampling
 * [EIP-7685](./eip-7685.md): General purpose execution layer requests 
 * [EIP-7702](./eip-7702.md): Set EOA account code for one transaction
 * EOF EIPs listed as part of [EIP-7692](./eip-7692.md), namely: 
@@ -49,7 +50,7 @@ This Meta EIP lists the EIPs formally considered for and included in the Prague/
 
 #### Consensus Layer
 
-EIP-6110, EIP-7002 EIP-7251 and EIP-7549 require changes to Ethereum's consensus layer. While the EIPs present an overview of these changes, the full specifications can be found in the `specs/electra` and `specs/_features` directories of the `ethereum/consensus-specs` repository.
+EIP-6110, EIP-7002 EIP-7251, EIP-7549 and EIP-7594 require changes to Ethereum's consensus layer. While the EIPs present an overview of these changes, the full specifications can be found in the `specs/electra` and `specs/_features` directories of the `ethereum/consensus-specs` repository.
 
 #### Execution Layer
 

--- a/EIPS/eip-7600.md
+++ b/EIPS/eip-7600.md
@@ -12,7 +12,7 @@ requires: 2537, 2935, 6110, 7002, 7251, 7549, 7594, 7685, 7692, 7702
 
 ## Abstract
 
-This Meta EIP lists the EIPs formally considered for and included in the Prague/Electra network upgrade. 
+This Meta EIP lists the EIPs formally considered for and included in the Prague/Electra network upgrade.
 
 ## Specification
 


### PR DESCRIPTION
Adds PeerDAS to the list of Pectra EIPs in the Meta EIP. I want to discuss this on https://github.com/ethereum/pm/issues/1069 before merging, as this EIP is a bit unique for two reasons. First, it's not a Core EIP, but "only" a networking change. Second, it's not if the special activation pattern for PeerDAS should be mentioned in this EIP. 

Nevertheless, given the overall consensus is "PeerDAS is in Pectra", the Meta EIP should reflect it. 