### PR TITLE
Update EIP-7702: Reorder authorization fields for authority recovery

### DIFF
--- a/EIPS/eip-7702.md
+++ b/EIPS/eip-7702.md
@@ -53,7 +53,7 @@ The [EIP-2718](./eip-2718.md) `ReceiptPayload` for this transaction is `rlp([sta
 
 At the start of executing the transaction, for each `[chain_id, address, [nonce], y_parity, r, s]` tuple:
 
-1. `authority = ecrecover(keccak(MAGIC || rlp([chain_id, [nonce], address])), y_parity, r, s]`
+1. `authority = ecrecover(keccak(MAGIC || rlp([chain_id, address, [nonce]])), y_parity, r, s]`
 2. Verify the chain id is either 0 or the chain's current ID.
 3. Verify that the code of `authority` is empty.
 4. If nonce list item is length one, verify the nonce of `authority` is equal to `nonce`.


### PR DESCRIPTION
Currently items in the authorization list are ordered:

- Chain ID
- Address
- (Optional) nonce

but in order to recover the authority, we need to reorder the fields to

- Chain ID
- (Optional) Nonce
- Address

which in some cases necessitates a secondary type to encode the authorization for recovery. Using the same order for the fields simplifies implementation slightly.