### PR TITLE
eip-7702: move the lighter check up

### DIFF
--- a/EIPS/eip-7702.md
+++ b/EIPS/eip-7702.md
@@ -52,9 +52,9 @@ The [EIP-2718](./eip-2718.md) `ReceiptPayload` for this transaction is `rlp([sta
 #### Behavior
 
 At the start of executing the transaction, for each `[chain_id, address, [nonce], y_parity, r, s]` tuple:
-
-1. `authority = ecrecover(keccak(MAGIC || rlp([chain_id, address, [nonce]])), y_parity, r, s]`
-2. Verify the chain id is either 0 or the chain's current ID.
+ 
+1. Verify the chain id is either 0 or the chain's current ID.
+2. `authority = ecrecover(keccak(MAGIC || rlp([chain_id, address, [nonce]])), y_parity, r, s]`
 3. Verify that the code of `authority` is empty.
 4. If nonce list item is length one, verify the nonce of `authority` is equal to `nonce`.
 5. Set the code of `authority` to code associated with `address`.


### PR DESCRIPTION
do the chain_id check first (as it is lighter). The next steps all involve authority recovery and checks based on authority.