### PR TITLE
Update EIP-7620: remove obsolete Rationale paragraph

### DIFF
--- a/EIPS/eip-7620.md
+++ b/EIPS/eip-7620.md
@@ -160,16 +160,6 @@ The data section is appended to during contract creation and also its size needs
     
 All of these alternatives either complicated the otherwise simple data structures or took away useful features (like the dynamically sized portion of the data section).
 
-### EOF validation checking initcode-mode
-
-Extra EOF validation rules were considered:
-
-- Each EOF subcontainer must either be referenced by an `EOFCREATE` or a `RETURNCONTRACT` instruction, but never both
-- Each EOF subcontainer may either contain `RETURNCONTRACT` or `RETURN` / `STOP` instructions, but never a mix of these two kinds
-- A subcontainer referenced by an `EOFCREATE` must never contain a `RETURN` / `STOP` instruction, whereas a subcontainer referenced by a `RETURNCONTRACT` must never contain a `RETURNCONTRACT`
-
-These rules were not adopted to avoid the extra logic and complexity (esp. the last rule causes EOF validation of subcontainers to not be self-contained).
-
 ## Backwards Compatibility
 
 This change poses no risk to backwards compatibility, as it is introduced at the same time EIP-3540 is. The new instructions are not introduced for legacy bytecode (code which is not EOF formatted), and the contract creation options do not change for legacy bytecode.


### PR DESCRIPTION
This was missed in #8586, where the EOF validation checking initcode-mode was actually introduced, contrary to what this paragraph says