### PR TITLE
Update EIP-7709: specify how all system contracts should behave post-verkle

### DIFF
--- a/EIPS/eip-7709.md
+++ b/EIPS/eip-7709.md
@@ -56,7 +56,7 @@ However the entire semantics and after effects of the `SLOAD` operation needs to
 * `SLOAD` after effects on the slot (warming the slot)
 * `SLOAD` accesses added to execution witnesses if Verkle ([EIP-6800](./eip-6800.md) and [EIP-4762](./eip-4762.md)) is activated
 
-System contracts execution is no longer favored over direct state updates. It it considered a protocol violation if an alternate network or testnet activates [EIP-4788](./eip-4788.md), EIP-2935, [EIP-7002](./eip-7002.md), or any other eip using system contracts, without deploying the corresponding contract.
+System contracts execution is no longer favored over direct state updates. It is considered a protocol violation if an alternate network or testnet activates [EIP-4788](./eip-4788.md), EIP-2935, [EIP-7002](./eip-7002.md), or any other eip using system contracts, without deploying the corresponding contract.
 
 ### Activation
 

--- a/EIPS/eip-7709.md
+++ b/EIPS/eip-7709.md
@@ -56,6 +56,8 @@ However the entire semantics and after effects of the `SLOAD` operation needs to
 * `SLOAD` after effects on the slot (warming the slot)
 * `SLOAD` accesses added to execution witnesses if Verkle ([EIP-6800](./eip-6800.md) and [EIP-4762](./eip-4762.md)) is activated
 
+System contracts execution is no longer favored over direct state updates. It it considered a protocol violation if an alternate network or testnet activates [EIP-4788](./eip-4788.md), EIP-2935, [EIP-7002](./eip-7002.md), or any other eip using system contracts, without deploying the corresponding contract.
+
 ### Activation
 
 This EIP specifies the transition to the new logic assuming that [EIP-2935](./eip-2935.md) has been activated:
@@ -69,9 +71,9 @@ The current proposal is to activate this EIP with Verkle to allow for stateless 
 
 As described above, if the `arg` to be resolved is within the correct window, the corresponding `SLOAD` charges and accesses are to be applied for the slot `arg % HISTORY_SERVE_WINDOW`. Note that the `HISTORY_SERVE_WINDOW` and `BLOCKHASH_SERVE_WINDOW` are different.
 
-### Reading from the System contract
+### System contracts execution and witness content
 
-Even if the clients choose to resolve `BLOCKHASH` through system call to [EIP-2935](./eip-2935.md) contract, the gas cost for the system code execution (and also the code witnesses if Verkle activated) is not applied. Only the effect of `SLOAD` is applied as described above.
+Even if the clients choose to resolve `BLOCKHASH` through system call to [EIP-2935](./eip-2935.md) contract, the gas cost for the system code execution (and also the code witnesses if Verkle activated) is not applied. Only the effect of `SLOAD` or `SSTORE` are applied as described above.
 
 ## Rationale
 


### PR DESCRIPTION
Change the wording to specify that when executing system contracts, clients should either prefer direct updates or implement code-filtering.
