### PR TITLE
Update EIP-2935: use 4788 method + future-proofiness warning

### DIFF
--- a/EIPS/eip-2935.md
+++ b/EIPS/eip-2935.md
@@ -138,9 +138,7 @@ Corresponding bytecode:
 
 #### Contract `get` and `set` mechanism
 
-Similar to [EIP-4788](./eip-4788.md) above contract provides a `set` mechanism which clients can choose to update the block's parent hash in the ring buffer instead of direct state update. For this clients should call this contract with `SYSTEM_ADDRESS` as caller and provide `32` bytes parent block hash as input.
-
-If caller is not `SYSTEM_ADDRESS` the contract treats it as `get` with contract reading `32` bytes input via `calldataload` as the `arg` to resolve the block hash for. Users and clients doing `get` EVM call should left pad the `arg` correctly.
+The update mechanism is the same as [EIP-4788](./eip-4788.md). While executing the system contract is not future-proof, this update method remains the favored one until the verkle fork.
 
 #### Deployment
 


### PR DESCRIPTION
Declare that the behavior of 2935 is the same as 4788, and warns that said behavior will change with verkle.
