### PR TITLE
Update EIP-7069: Make explicit that returndata buffer is cleared

### DIFF
--- a/EIPS/eip-7069.md
+++ b/EIPS/eip-7069.md
@@ -71,16 +71,17 @@ Execution semantics of `EXT*CALL`:
 7. If `target_address` is not in the state and the call configuration would result in account creation, charge `ACCOUNT_CREATION_COST` (25000) gas.
     - The only such case in this EIP is if `value` is non-zero.
 8. Calculate the gas available to callee as caller's remaining gas reduced by `max(floor(gas/64), MIN_RETAINED_GAS)`.
-9. Fail with status code `1` returned on stack if any of the following is true (only gas charged until this point is consumed):
+9. Clear the returndata buffer.
+10. Fail with status code `1` returned on stack if any of the following is true (only gas charged until this point is consumed):
     - Gas available to callee at this point is less than `MIN_CALLEE_GAS`.
     - Balance of the current account is less than `value`.
     - Current call stack depth equals `1024`.
-10. Perform the call with the available gas and configuration.
-11. Push a status code on the stack:
+11. Perform the call with the available gas and configuration.
+12. Push a status code on the stack:
     - `0` if the call was successful.
     - `1` if the call has reverted (also can be pushed earlier in a light failure scenario).
     - `2` if the call has failed.
-12. Gas not used by the callee is returned to the caller.
+13. Gas not used by the callee is returned to the caller.
 
 Execution semantics of `RETURNDATALOAD`:
 


### PR DESCRIPTION
Fixes https://github.com/ipsilon/eof/issues/140