### PR TITLE
Update EIP-3540: Ensure num_container_sections is correct

### DIFF
--- a/EIPS/eip-3540.md
+++ b/EIPS/eip-3540.md
@@ -127,7 +127,7 @@ types_section := (inputs, outputs, max_stack_height)+
 | num_code_sections      | 2 bytes  | 0x0001-0x0400 | 16-bit unsigned big-endian integer denoting the number of the code sections                                  |
 | code_size              | 2 bytes  | 0x0001-0xFFFF | 16-bit unsigned big-endian integer denoting the length of the code section content                           |
 | kind_container         | 1 byte   | 0x03          | kind marker for container size section                                                                       |
-| num_container_sections | 2 bytes  | 0x0001-0x00FF | 16-bit unsigned big-endian integer denoting the number of the container sections                             |
+| num_container_sections | 2 bytes  | 0x0001-0x0100 | 16-bit unsigned big-endian integer denoting the number of the container sections                             |
 | container_size         | 2 bytes  | 0x0001-0xFFFF | 16-bit unsigned big-endian integer denoting the length of the container section content                      |
 | kind_data              | 1 byte   | 0x04          | kind marker for data size section                                                                            |
 | data_size              | 2 bytes  | 0x0000-0xFFFF | 16-bit unsigned big-endian integer denoting the length of the data section content (*)                       |


### PR DESCRIPTION
The text itself has this text: 

> the number of container sections must not exceed `256`. The number of container sections may not be `0`, if declared in the header

To encode 255 container sections, `0x0100` should thus be used, since `0` is disallowed. See also https://github.com/ipsilon/eof/pull/141