### PR TITLE
Update EIP-712: Fix incorrect byte counts

### DIFF
--- a/EIPS/eip-712.md
+++ b/EIPS/eip-712.md
@@ -172,7 +172,7 @@ Typed data is a JSON object containing type information, domain separator parame
 
 ##### Returns
 
-`DATA`: Signature. As in `eth_sign` it is a hex encoded 129 byte array starting with `0x`. It encodes the `r`, `s` and `v` parameters from appendix F of the yellow paper in big-endian format. Bytes 0...64 contain the `r` parameter, bytes 64...128 the `s` parameter and the last byte the `v` parameter. Note that the `v` parameter includes the chain id as specified in [EIP-155][eip-155].
+`DATA`: Signature. As in `eth_sign` it is a hex encoded 65 byte array starting with `0x`. It encodes the `r`, `s` and `v` parameters from appendix F of the yellow paper in big-endian format. Bytes 0...32 contain the `r` parameter, bytes 32...64 the `s` parameter and the last byte the `v` parameter. Note that the `v` parameter includes the chain id as specified in [EIP-155][eip-155].
 
 [eip-155]: ./eip-155.md
 


### PR DESCRIPTION
The current byte counts are plainly wrong and easy to fix. The first commit fixes it. The second gets the linter to be quiet - excepting a couple spurious errors.

The example signature only has 65 bytes, but is said to 129 bytes:

```
$ echo -n "0x4355c47d63924e8a72e509b65029052eb6c299d53a04e167c5775fd466751c9d07299936d304c153f6443dfa05f40ff007d72911b6f72307f996231605b915621c" | wc -c
132
```

Removing 2 characters for the `0x` prefix leaves 130 characters of hex, which encodes only 65 bytes.

(Oddly, the "last byte" on top of 128 bytes is counted as 1 character instead of 2)

Appendix F of the yellow paper and the function signature in EIP-191 (`signatureBasedExecution(address target, uint256 nonce, bytes memory payload, uint8 v, bytes32 r, bytes32 s) public payable`) reaffirm that these fields are 32 bytes, ergo 64 characters of hex, or when combined, 64 byte ergo 128 characters of hex. The final byte is one byte and 2 characters of hex for 65 total bytes and 130 hex characters, or 132 with the prefix.