### PR TITLE
Update EIP-2935: Point to correct EIP-161

### DIFF
--- a/EIPS/eip-2935.md
+++ b/EIPS/eip-2935.md
@@ -175,9 +175,9 @@ Some activation scenarios:
  * for activation at block `1`, only genesis hash will be written at slot `0`.
  * for activation at block `32`, block `31`'s hash will be written to slot `31`. Every other slot will be `0`.
 
-### [EIP-158](./eip-158.md) handling
+### [EIP-161](./eip-161.md) handling
 
-The bytecode above will be deployed à la [EIP-4788](./eip-4788.md). As such the account at `HISTORY_STORAGE_ADDRESS` will have code and a nonce of 1, and will be exempt from EIP-158 cleanup.
+The bytecode above will be deployed à la [EIP-4788](./eip-4788.md). As such the account at `HISTORY_STORAGE_ADDRESS` will have code and a nonce of 1, and will be exempt from EIP-161 cleanup.
 
 ### Gas costs
 


### PR DESCRIPTION
The EIP currently points to EIP-158, which was never deployed, and should point to EIP-161.