### PR TITLE
Update EIP-7610: Point to correct EIP-161

### DIFF
--- a/EIPS/eip-7610.md
+++ b/EIPS/eip-7610.md
@@ -24,7 +24,7 @@ This EIP amends [EIP-684](./eip-684.md) with one extra condition, requiring empt
 
 ## Rationale
 
-EIP-684 defines two conditions for contract deployment: the destination address must have zero nonce and zero code length. Unfortunately, this is not sufficient. Before [EIP-158](./eip-158.md) was applied, the nonce of a newly deployed contract remained set to zero. Therefore, it was entirely possible to create a contract with a zero nonce and zero code length but with non-empty storage, if slots were set in the constructor. There exists 28 such contracts on Ethereum mainnet at this time.
+EIP-684 defines two conditions for contract deployment: the destination address must have zero nonce and zero code length. Unfortunately, this is not sufficient. Before [EIP-161](./eip-161.md) was applied, the nonce of a newly deployed contract remained set to zero. Therefore, it was entirely possible to create a contract with a zero nonce and zero code length but with non-empty storage, if slots were set in the constructor. There exists 28 such contracts on Ethereum mainnet at this time.
 
 As one of the core tenets of smart contracts is that its code will not change, even if the code is zero length. The contract creation must be rejected in such instanace.
 


### PR DESCRIPTION
The EIP currently points to EIP-158, which was never deployed, and should point to EIP-161.