### PR TITLE
Update EIP-196: Fix coordinate description

### DIFF
--- a/EIPS/eip-196.md
+++ b/EIPS/eip-196.md
@@ -39,7 +39,7 @@ p = 2188824287183927522224640574525727508869631115729782366268903789464522620858
 
 ### Encoding
 
-Field elements and scalars are encoded as 32 byte big-endian numbers. Curve points are encoded as two field elements `(x, y)`, where the point at infinity is encoded as `(0, 0)`.
+Field elements and scalars are encoded as 32 byte big-endian numbers. Curve points are encoded as two field elements `(x, y)` representing the affine coordinates, where the point at infinity is encoded as `(0, 0)`.
 
 Tuples of objects are encoded as their concatenation.
 

--- a/EIPS/eip-197.md
+++ b/EIPS/eip-197.md
@@ -75,7 +75,7 @@ Elements of `F_p` are encoded as 32 byte big-endian numbers. An encoding value o
 
 Elements `a * i + b` of `F_p^2` are encoded as two elements of `F_p`, `(a, b)`.
 
-Elliptic curve points are encoded as a Jacobian pair `(X, Y)` where the point at infinity is encoded as `(0, 0)`.
+Elliptic curve points are encoded as as two field elements `(x, y)` representing the affine coordinates where the point at infinity is encoded as `(0, 0)`.
 
 Note that the number `k` is derived from the input length.
 


### PR DESCRIPTION
The current EIP-197 specifies the point coordinate to be a "Jacobian pair".  However the current representation is the affine coordinates not Jacobian. See for example in the book *Handbook of Elliptic and Hyperelliptic Curve Cryptography* Section 13.2.1 or in the [Halo2 documentation](https://zcash.github.io/halo2/background/curves.html)

To avoid implementation mistakes this PR corrects the coordinate definition and clarify it in EIP-196.