### PR TITLE
Update EIP-7702: Add decoding limits for AuthList items

### DIFF
--- a/EIPS/eip-6914.md
+++ b/EIPS/eip-6914.md
@@ -4,7 +4,7 @@ title: Reuse Withdrawn Validator Indices
 description: Reuse fully withdrawn and safe to reuse validator indices for new beacon chain deposits.
 author: Lion (@dapplion), Danny Ryan (@djrtwo)
 discussions-to: https://ethereum-magicians.org/t/eip-6914-reuse-withdrawn-validator-indices/15253
-status: Draft
+status: Stagnant
 type: Standards Track
 category: Core
 created: 2023-04-19

--- a/EIPS/eip-7702.md
+++ b/EIPS/eip-7702.md
@@ -45,11 +45,11 @@ authorization_list = [[chain_id, address, nonce, y_parity, r, s], ...]
 
 Transaction is considered invalid if authorization list items can't be decoded as:
 
-* `chain_id` and `nonce`: u64 number.
+* `chain_id` and `nonce`: unsigned 64-bit integer.
 * `address`: 20 bytes array.
-* `y_parity`: single byte with values 0 or 1.
-* `r` and `s`: 32 bytes array.
-* and `s`-value is greater than `secp256k1n/2`, specified in [EIP-2](./eip-2.md).
+* `y_parity`: Value 0 or 1.
+* `r`: 32 bytes array.
+* `s`: 32 bytes array and value less or equal than `secp256k1n/2`, specified in [EIP-2](./eip-2.md).
 
 The fields `chain_id`, `nonce`, `max_priority_fee_per_gas`, `max_fee_per_gas`, `gas_limit`, `destination`, `value`, `data`, and `access_list` of the outer transaction follow the same semantics as [EIP-1559](./eip-1559.md).
 

--- a/EIPS/eip-7702.md
+++ b/EIPS/eip-7702.md
@@ -45,7 +45,8 @@ authorization_list = [[chain_id, address, nonce, y_parity, r, s], ...]
 
 Transaction is considered invalid if authorization list items can't be decoded as:
 
-* `chain_id` and `nonce`: unsigned 64-bit integer.
+* `chain_id`: unsigned 256-bit integer.
+* `nonce`: unsigned 64-bit integer.
 * `address`: 20 bytes array.
 * `y_parity`: Value 0 or 1.
 * `r`: 32 bytes array.

--- a/EIPS/eip-7702.md
+++ b/EIPS/eip-7702.md
@@ -44,6 +44,7 @@ authorization_list = [[chain_id, address, nonce, y_parity, r, s], ...]
 ```
 
 Transaction is considered invalid if authorization list items can't be decoded as:
+
 * `chain_id` and `nonce`: u64 number.
 * `address`: 20 bytes array.
 * `y_parity`: single byte.

--- a/EIPS/eip-7702.md
+++ b/EIPS/eip-7702.md
@@ -8,7 +8,7 @@ status: Review
 type: Standards Track
 category: Core
 created: 2024-05-07
-requires: 2718, 2929, 2930, 3541, 3607
+requires: 2718, 2929, 2930, 3541, 3607, 2
 ---
 
 ## Abstract
@@ -47,8 +47,9 @@ Transaction is considered invalid if authorization list items can't be decoded a
 
 * `chain_id` and `nonce`: u64 number.
 * `address`: 20 bytes array.
-* `y_parity`: single byte.
+* `y_parity`: single byte with values 0 or 1.
 * `r` and `s`: 32 bytes array.
+* and `s`-value is greater than `secp256k1n/2`, specified in [EIP-2](./eip-2.md).
 
 The fields `chain_id`, `nonce`, `max_priority_fee_per_gas`, `max_fee_per_gas`, `gas_limit`, `destination`, `value`, `data`, and `access_list` of the outer transaction follow the same semantics as [EIP-1559](./eip-1559.md).
 

--- a/EIPS/eip-7702.md
+++ b/EIPS/eip-7702.md
@@ -8,7 +8,7 @@ status: Review
 type: Standards Track
 category: Core
 created: 2024-05-07
-requires: 2718, 2929, 2930, 3541, 3607, 2
+requires: 2, 2718, 2929, 2930, 3541, 3607
 ---
 
 ## Abstract

--- a/EIPS/eip-7702.md
+++ b/EIPS/eip-7702.md
@@ -43,6 +43,12 @@ rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit, dest
 authorization_list = [[chain_id, address, nonce, y_parity, r, s], ...]
 ```
 
+Transaction is considered invalid if authorization list items can't be decoded as:
+* `chain_id` and `nonce`: u64 number.
+* `address`: 20 bytes array.
+* `y_parity`: single byte.
+* `r` and `s`: 32 bytes array.
+
 The fields `chain_id`, `nonce`, `max_priority_fee_per_gas`, `max_fee_per_gas`, `gas_limit`, `destination`, `value`, `data`, and `access_list` of the outer transaction follow the same semantics as [EIP-1559](./eip-1559.md).
 
 The `authorization_list` is a list of tuples that store the address to code which the signer desires to execute in the context of their EOA.

--- a/EIPS/eip-7702.md
+++ b/EIPS/eip-7702.md
@@ -50,7 +50,7 @@ Transaction is considered invalid if authorization list items can't be decoded a
 * `nonce`: unsigned 64-bit integer.
 * `address`: 20 bytes array.
 * `y_parity`: Value 0 or 1.
-* `r`: 32 bytes array.
+* `r`: unsigned 256-bit integer.
 * `s`: unsigned 256-bit integer and value less or equal than `secp256k1n/2`, specified in [EIP-2](./eip-2.md).
 
 The fields `chain_id`, `nonce`, `max_priority_fee_per_gas`, `max_fee_per_gas`, `gas_limit`, `destination`, `value`, `data`, and `access_list` of the outer transaction follow the same semantics as [EIP-4844](./eip-4844.md). *Note, this means a null destination is not valid.*

--- a/EIPS/eip-7702.md
+++ b/EIPS/eip-7702.md
@@ -51,7 +51,7 @@ Transaction is considered invalid if authorization list items can't be decoded a
 * `address`: 20 bytes array.
 * `y_parity`: Value 0 or 1.
 * `r`: 32 bytes array.
-* `s`: 32 bytes array and value less or equal than `secp256k1n/2`, specified in [EIP-2](./eip-2.md).
+* `s`: unsigned 256-bit integer and value less or equal than `secp256k1n/2`, specified in [EIP-2](./eip-2.md).
 
 The fields `chain_id`, `nonce`, `max_priority_fee_per_gas`, `max_fee_per_gas`, `gas_limit`, `destination`, `value`, `data`, and `access_list` of the outer transaction follow the same semantics as [EIP-4844](./eip-4844.md). *Note, this means a null destination is not valid.*
 


### PR DESCRIPTION
Fields inside the Authorization List are accessed (validated) differently than items inside the Transaction. A very big nonce will invalidate the transaction while if the nonce is big in AuthorizationList (By current spec) tx will still be valid. This makes decoding a special case.

Introducing expected limits on items invalidates this edge case.