### PR TITLE
Update EIP-3540: remove duplicate size constraints

### DIFF
--- a/EIPS/eip-3540.md
+++ b/EIPS/eip-3540.md
@@ -155,14 +155,8 @@ See [EIP-4750](./eip-4750.md) for more information on the type section content.
 
 The following validity constraints are placed on the container format:
 
-- `version` must be `0x01`
 - `types_size` is divisible by `4`
 - the number of code sections must be equal to `types_size / 4`
-- the number of code sections must be greater than `0` and not exceed `1024`
-- `code_size` may not be `0`
-- the number of container sections must not exceed `256`. The number of container sections may not be `0`, if declared in the header
-- `container_size` may not be `0`
-- data section is mandatory, but `data_size` may be `0`
 - data body length may be shorter than `data_size` for a not yet deployed container
 - the total size of a container must not exceed `MAX_INITCODE_SIZE` (as defined in [EIP-3860](./eip-3860.md))
 


### PR DESCRIPTION
Removes duplicate formulation of the container format size constraints, mirroring the recent https://github.com/ipsilon/eof/pull/143