### PR TITLE
Update EIP-7620: Clarify `CREATE2` rules upheld in `EOFCREATE`

### DIFF
--- a/EIPS/eip-7620.md
+++ b/EIPS/eip-7620.md
@@ -8,7 +8,7 @@ status: Review
 type: Standards Track
 category: Core
 created: 2024-02-12
-requires: 170, 3540, 3541, 3670
+requires: 170, 684, 2929, 3540, 3541, 3670
 ---
 
 ## Abstract
@@ -74,6 +74,7 @@ Details on each instruction follow in the next sections.
 - execute the container and deduct gas for execution. The 63/64th rule from [EIP-150](./eip-150.md) applies.
 - increment `sender` account's nonce
 - calculate `new_address` as `keccak256(0xff || sender || salt || keccak256(initcontainer))[12:]`
+- behavior on `accessed_addresses` and address colission is same as `CREATE2` (rules for `CREATE2` from [EIP-684](./eip-684.md) and [EIP-2929](./eip-2929.md) apply to `EOFCREATE`)
 - an unsuccessful execution of initcode results in pushing `0` onto the stack
     - can populate returndata if execution `REVERT`ed
 - a successful execution ends with initcode executing `RETURNCONTRACT{deploy_container_index}(aux_data_offset, aux_data_size)` instruction (see below). After that:


### PR DESCRIPTION
Mirrors https://github.com/ipsilon/eof/pull/145
