### PR TITLE
Update EIP-6800: Clarify BASIC_DATA layout and update naming

### DIFF
--- a/EIPS/eip-6800.md
+++ b/EIPS/eip-6800.md
@@ -116,7 +116,7 @@ Instead of a two-layer structure as in the Patricia tree, in the Verkle tree we 
 | Parameter             | Value   |
 | --------------------- | ------- |
 | BASIC_DATA_LEAF_KEY   | 0       |
-| CODE_KECCAK_LEAF_KEY  | 1       |
+| CODE_HASH_LEAF_KEY    | 1       |
 | HEADER_STORAGE_OFFSET | 64      |
 | CODE_OFFSET           | 128     |
 | VERKLE_NODE_WIDTH     | 256     |
@@ -158,8 +158,8 @@ def get_tree_key_for_basic_data(address: Address32):
     return get_tree_key(address, 0, BASIC_DATA_LEAF_KEY)
 
 # Backwards compatibility for EXTCODEHASH    
-def get_tree_key_for_code_keccak(address: Address32):
-    return get_tree_key(address, 0, CODE_KECCAK_LEAF_KEY)
+def get_tree_key_for_code_hash(address: Address32):
+    return get_tree_key(address, 0, CODE_HASH_LEAF_KEY)
 ```
 
 An account's `version`, `balance`, `nonce` and `code_size` fields are packed in the value found at `BASIC_DATA_LEAF_KEY`:
@@ -175,7 +175,7 @@ Bytes `1..4` are reserved for future use.
 
 Note: the code size is stored on 3 bytes. To allow for an extension to 4 bytes without changing the account version is possible, reserved byte #4 should be allocated last.
 
-When any account header field is set, the `version` field is also set to zero. The `code_keccak` and `code_size` fields are set upon contract or EoA creation.
+When any account header field is set, the `version` field is also set to zero. The `codehash` and `code_size` fields are set upon contract or EoA creation.
 
 #### Code
 

--- a/EIPS/eip-6800.md
+++ b/EIPS/eip-6800.md
@@ -173,7 +173,7 @@ An account's `version`, `balance`, `nonce` and `code_size` fields are packed wit
 
 Bytes `1..4` are reserved for future use.
 
-The current layout and encoding allows for an extension of `code_size` to 4 bytes without changing the account version.
+The current layout and encoding allow for an extension of `code_size` to 4 bytes without changing the account version.
 
 When any account header field is set, the `version` field is also set to zero. The `codehash` and `code_size` fields are set upon contract or EoA creation.
 

--- a/EIPS/eip-6800.md
+++ b/EIPS/eip-6800.md
@@ -162,7 +162,7 @@ def get_tree_key_for_code_hash(address: Address32):
     return get_tree_key(address, 0, CODE_HASH_LEAF_KEY)
 ```
 
-An account's `version`, `balance`, `nonce` and `code_size` fields are packed in the value found at `BASIC_DATA_LEAF_KEY`:
+An account's `version`, `balance`, `nonce` and `code_size` fields are packed with big-endian encoding in the value found at `BASIC_DATA_LEAF_KEY`:
 
 | Name        | Offset | Size |
 | ----------- | ------ | ---- |
@@ -173,7 +173,7 @@ An account's `version`, `balance`, `nonce` and `code_size` fields are packed in 
 
 Bytes `1..4` are reserved for future use.
 
-Note: the code size is stored on 3 bytes. To allow for an extension to 4 bytes without changing the account version is possible, reserved byte #4 should be allocated last.
+The current layout and encoding allows for an extension of `code_size` to 4 bytes without changing the account version.
 
 When any account header field is set, the `version` field is also set to zero. The `codehash` and `code_size` fields are set upon contract or EoA creation.
 


### PR DESCRIPTION
This PR proposes:
- Updates the name of the code hash field to be aligned with the latest EIP-4762.
- Clarify that packing in `BASIC_DATA` is done using big-endian. This is required for one of the reserved bytes to extend `code_size` to 4 bytes in the future.