### PR TITLE
EIP-7612: Update func implementations and add further clarifications

### DIFF
--- a/EIPS/eip-7612.md
+++ b/EIPS/eip-7612.md
@@ -134,6 +134,10 @@ def set_storage(
     state._overlay_tree.set(get_tree_key_for_storage_slot(addr, slot), value)
 ```
 
+### Changes to the block header
+
+At `FORK_TIME` the block header state root is changed from the MPT root to the VKT root.
+
 ## Rationale
 
 This approach doesn't convert the state, which is left to a subsequent EIP. This is meant as a stopgap in case we decide to push the conversion itself to a later time. It has the advantage of simplicity, which means that the Verge fork could happen at the same time as other, simpler EIPs. It also requires no change at the consensus layer.

--- a/EIPS/eip-7612.md
+++ b/EIPS/eip-7612.md
@@ -13,15 +13,15 @@ requires: 4762, 6800, 7545
 
 ## Abstract
 
-This EIP proposes a method to switch the state tree tree format from hexary Merkle Patricia Tree (MPT) to a verkle tree: the MPT tree is frozen, and new writes to the state are stored in a verkle tree “laid over” the hexary MPT. The historical MPT state is left untouched and its eventual migration is handled at a later time.
+This EIP proposes a method to switch the state tree tree format from hexary Merkle Patricia Tree (MPT) to a Verkle Tree (VKT): the MPT tree is frozen, and new writes to the state are stored in a VKT “laid over” the hexary MPT. The historical MPT state is left untouched and its eventual migration is handled at a later time.
 
 ## Motivation
 
-The Ethereum state is growing, and verkle trees offer a good mitigation strategy to stem this growth and enable weak statelessness. Owing to the difficulty of translating contracts with large storage while they are being accessed, proposals for migrating the current MPT state are complex and will require client teams to undergo a long process of refactoring their code to handle this conversion.
+The Ethereum state is growing, and VKTs offer a good mitigation strategy to stem this growth and enable weak statelessness. Owing to the difficulty of translating contracts with large storage while they are being accessed, proposals for migrating the current MPT state are complex and will require client teams to undergo a long process of refactoring their code to handle this conversion.
 
-The bigger the state, the longer any conversion process will take. This has an impact both while the conversion is happening, as well as when full-syncing the chain if the conversion is part of consensus. Fullsync is used extensively by core dev teams to test the performance of new code. A conversion longer than a month will impact the release schedule of client teams who typically release at this rate. Nodes that cannot follow the conversion will need to wait longer to rejoin. The conversion will also make reorg slower, so reducing its duration is desirable.
+The bigger the state, the longer any conversion process will take. This has an impact both while the conversion is happening, as well as when full-syncing the chain if the conversion is part of consensus. Fullsync is used extensively by core dev teams to test the performance of new code. A conversion longer than a month will impact the release schedule of client teams who typically release at this rate. Nodes that cannot follow the conversion will need to wait longer to rejoin. The conversion will also make reorgs slower, so reducing its duration is desirable.
 
-This current proposal suggests to stop the MPT state growth in its tracks by activating a new “overlay” verkle tree, that all new state updates are written to. The “base” MPT tree is frozen in place, until all execution clients are ready to perform the full transition. Data is read first from the overlay tree, and if not found there, from the MPT.
+This current proposal suggests to stop the MPT state growth in its tracks by activating a new “overlay” VKT, that all new state updates are written to. The “base” MPT is frozen in place, until all execution clients are ready to perform the full transition. Data is read first from the overlay tree, and if not found there, from the MPT.
 
 Whenever the block that freeze the MPT is finalized, internal node data can be deleted, in order to free up disk space.
 
@@ -31,9 +31,9 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ### Constants
 
-|Parameter|value|Description|
-|-|-|-|
-|`FORK_TIME`|`TDB`|Time at which the verkle, overlay tree is activated.|
+| Parameter   | value | Description                                  |
+| ----------- | ----- | -------------------------------------------- |
+| `FORK_TIME` | `TBD` | Time at which the overlay tree is activated. |
 
 ### Helper functions
 
@@ -81,7 +81,7 @@ def verkle_get_account(tree: VerkleTree, key: Bytes32) -> Optional[Account]:
     return account
 ```
 
-### Changes to the execution spec:
+### Changes to the execution spec
 
 In the execution spec, modify the `State` class as such:
 

--- a/EIPS/eip-7612.md
+++ b/EIPS/eip-7612.md
@@ -45,37 +45,29 @@ def is_fork_block(block):
 # Write an account in the verkle tree
 def verkle_set_account(tree: VerkleTree, key: Bytes32, account: Optional[Account]):
     if account is not None:
-        versionkey = key
-        tree.set(versionkey, 0)
-        balancekey = key
-        balancekey[31] = BALANCE_LEAF_KEY
-        tree.set(balancekey, account.balance)
-        noncekey = key
-        noncekey[31] = NONCE_LEAF_KEY
-        tree.set(noncekey, account.nonce)
+        basicdata = bytes(0) # Version
+        basicdata += bytes(4) # Reserved
+        basicdata += len(account.code).to_bytes(3, 'big')
+        basicdata += account.nonce.to_bytes(8, 'big')
+        basicdata += account.balance.to_bytes(16, 'big')
+        tree.set(key, basicdata)
         ckkey = key
-        ckkey[31] = CODE_KECCAK_LEAF_KEY
+        ckkey[31] = CODEHASH_LEAF_KEY
         tree.set(ckkey, account.code_hash)
-        cskey = key
-        cskey[31] = CODE_SIZE_LEAF_KEY
-        tree.set(cskey, len(account.code))
 
 # Reads an account from the verkle tree
 def verkle_get_account(tree: VerkleTree, key: Bytes32) -> Optional[Account]:
-    version_leaf = tree.get(key)
-    if version_leaf is not None:
-        balancekey = key
-        balancekey[31] = BALANCE_LEAF_KEY
-        balance = tree.get(balancekey, account.balance)
-        noncekey = key
-        noncekey[31] = NONCE_LEAF_KEY
-        nonce = tree.get(noncekey)
+    basicdata_leaf = tree.get(key)
+    if basicdata_leaf is not None:
+        cs = int.from_bytes(basicdata_leaf[5:8], 'big')
+        nonce = int.from_bytes(basicdata_leaf[8:16], 'big')
+        balance = int.from_bytes(basicdata_leaf[16:32], 'big')
         ckkey = key
-        ckkey[31] = CODE_KECCAK_LEAF_KEY
+        ckkey[31] = CODEHASH_LEAF_KEY
         ck = tree.get(ckkey)
         cskey = key
         cskey[31] = CODE_SIZE_LEAF_KEY
-        cs = tree.set(cskey)
+        cs = tree.get(cskey)
         account = Account(0, balance, nonce, ck, cs)
 
     return account

--- a/EIPS/eip-7612.md
+++ b/EIPS/eip-7612.md
@@ -134,6 +134,13 @@ def set_storage(
     state._overlay_tree.set(get_tree_key_for_storage_slot(addr, slot), value)
 ```
 
+Add the following function which is used when storing a contract in the tree:
+
+```python3
+def state_set_codechunk(state: State, addr: Address, chunk_num: int, chunk: Bytes):
+    state._overlay_tree.set(get_tree_key_for_code_chunk(addr, chunk_num), chunk)
+```
+
 ### Changes to the block header
 
 At `FORK_TIME` the block header state root is changed from the MPT root to the VKT root.


### PR DESCRIPTION
This PR proposes:
- Updating the spec to align with the latest EIP-6800 changes regarding multiple account fields being packed in `BASIC_DATA`.
- Add a missing new function to save code-chunks in the state. This is required not only for contract creations, but also for [the EIP](https://github.com/ethereum/EIPs/pull/8752) that explains how to do the MPT->VKT conversion.
- Explain block header changes.