### PR TITLE
Update EIP-7702: various updates

### DIFF
--- a/EIPS/eip-7702.md
+++ b/EIPS/eip-7702.md
@@ -63,7 +63,7 @@ At the start of executing the transaction, for each `[chain_id, address, nonce, 
 6. Increase the nonce of `authority` by one.
 7. Add `authority` to `accessed_addresses` (as defined in [EIP-2929](./eip-2929.md).)
 
-If any of the above steps (expect 5) fail, immediately stop processing that tuple and continue to the next tuple in the list. It will in the case of multiple tuples for the same authority, set the code using the address in the last occurrence.
+If any of the above steps (except 5) fail, immediately stop processing that tuple and continue to the next tuple in the list. It will in the case of multiple tuples for the same authority, set the code using the address in the last occurrence.
 
 Note that the signer of an authorization tuple may be different than `tx.origin` of the transaction.
 

--- a/EIPS/eip-7702.md
+++ b/EIPS/eip-7702.md
@@ -27,11 +27,12 @@ There is a lot of interest in adding short-term functionality improvements to EO
 
 ### Parameters
 
-|     Parameter        | Value  |
-| -------------------- | ------ |
-| `SET_CODE_TX_TYPE`   | `0x04` |
-| `MAGIC`              | `0x05` |
-| `PER_AUTH_BASE_COST` | `2500` |
+|     Parameter            | Value   |
+| ------------------------ | ------- |
+| `SET_CODE_TX_TYPE`       | `0x04`  |
+| `MAGIC`                  | `0x05`  |
+| `PER_AUTH_BASE_COST`     | `2500`  |
+| `PER_EMPTY_ACCOUNT_COST` | `25000` |
 
 ### Set Code Transaction
 
@@ -43,9 +44,9 @@ rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit, dest
 authorization_list = [[chain_id, address, nonce, y_parity, r, s], ...]
 ```
 
-The fields `chain_id`, `nonce`, `max_priority_fee_per_gas`, `max_fee_per_gas`, `gas_limit`, `destination`, `value`, `data`, and `access_list` of the outer transaction follow the same semantics as [EIP-1559](./eip-1559.md).
+The fields `chain_id`, `nonce`, `max_priority_fee_per_gas`, `max_fee_per_gas`, `gas_limit`, `destination`, `value`, `data`, and `access_list` of the outer transaction follow the same semantics as [EIP-4844](./eip-4844.md). *Note, this means a null destination is not valid.*
 
-The `authorization_list` is a list of tuples that store the address to code which the signer desires to execute in the context of their EOA.
+The `authorization_list` is a list of tuples that store the address to code which the signer desires to execute in the context of their EOA. The transaction is considered invalid if the length of `authorization_list` is zero.
 
 The [EIP-2718](./eip-2718.md) `ReceiptPayload` for this transaction is `rlp([status, cumulative_transaction_gas_used, logs_bloom, logs])`.
 
@@ -57,11 +58,12 @@ At the start of executing the transaction, for each `[chain_id, address, nonce, 
 2. Verify the chain id is either 0 or the chain's current ID.
 3. Verify that the code of `authority` is either empty or already delegated.
 4. Verify the nonce of `authority` is equal to `nonce`.
+5. Charge the sender `PER_EMPTY_ACCOUNT_COST` if `authority` does not exist in the trie. Abort immediately if the sender balance is less than this value.
 5. Set the code of `authority` to be `0xef0100 || address`. This is a delegation designation.
 6. Increase the nonce of `authority` by one.
-7. Add the `authority` account to `accessed_addresses` (as defined in [EIP-2929](./eip-2929.md).)
+7. Add `authority` to `accessed_addresses` (as defined in [EIP-2929](./eip-2929.md).)
 
-If any of the above steps fail, immediately stop processing that tuple and continue to the next tuple in the list. It will In the case of multiple tuples for the same authority, set the code specified by the address in the last occurrence.
+If any of the above steps (expect 5) fail, immediately stop processing that tuple and continue to the next tuple in the list. It will in the case of multiple tuples for the same authority, set the code using the address in the last occurrence.
 
 Note that the signer of an authorization tuple may be different than `tx.origin` of the transaction.
 
@@ -78,6 +80,8 @@ In case a delegation designator points to another designator, creating a potenti
 The intrinsic cost of the new transaction is inherited from [EIP-2930](./eip-2930.md), specifically `21000 + 16 * non-zero calldata bytes + 4 * zero calldata bytes + 1900 * access list storage key count + 2400 * access list address count`. Additionally, we add a cost of `PER_AUTH_BASE_COST * authorization list length`.
 
 The transaction sender will pay for all authorization tuples, regardless of validity or duplication.
+
+If a code reading instruction accesses a cold account during the resolution of delegated code, assess an additional [EIP-2929](eip-2929.md) `COLD_ACCOUNT_READ` cost of `2600` gas to the normal cost.
 
 #### Transaction Origination
 


### PR DESCRIPTION
This PR makes a few changes:

* disallows contract creation via 7702 tx, like the restriction on 4844 txs
* bans zero length authorization lists in 7702 tx
* charges the regular 25k gas in case an account doesn't exist before placing the delegation designator
* charges an additional `COLD_ACCOUNT_READ` gas during delegate resolution if the account hasn't been warmed yet

h/t @gumb0 for most of these