### PR TITLE
Update EIP-5792: multi-chain wallet_sendCalls

### DIFF
--- a/EIPS/eip-5792.md
+++ b/EIPS/eip-5792.md
@@ -62,7 +62,6 @@ type SendCallsParams = {
     value?: `0x${string}` | undefined; // Hex value
     chainId?: `0x${string}` | undefined; // Hex chain id
   }[];
-  parallel?: boolean;
   capabilities?: Record<string, any> | undefined;
 };
 

--- a/EIPS/eip-5792.md
+++ b/EIPS/eip-5792.md
@@ -55,12 +55,13 @@ The wallet:
 ```typescript
 type SendCallsParams = {
   version: string;
-  chainId: `0x${string}`; // Hex chain id
+  
   from: `0x${string}`;
   calls: {
     to?: `0x${string}` | undefined;
     data?: `0x${string}` | undefined;
     value?: `0x${string}` | undefined; // Hex value
+    chainId?: `0x${string}` | undefined; // Hex chain id
   }[];
   capabilities?: Record<string, any> | undefined;
 };
@@ -74,18 +75,19 @@ type SendCallsResult = string;
 [
   {
     "version": "1.0",
-    "chainId": "0x01",
     "from": "0xd46e8dd67c5d32be8058bb8eb970870f07244567",
     "calls": [
       {
         "to": "0xd46e8dd67c5d32be8058bb8eb970870f07244567",
         "value": "0x9184e72a",
-        "data": "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675"
+        "data": "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675",
+        "chainId": "0x01",
       },
       {
         "to": "0xd46e8dd67c5d32be8058bb8eb970870f07244567",
         "value": "0x182183",
-        "data": "0xfbadbaf01"
+        "data": "0xfbadbaf01",
+        "chainId": "0x01",
       }
     ],
     "capabilities": {
@@ -128,6 +130,7 @@ type GetCallsResult = {
       topics: `0x${string}`[];
     }[];
     status: `0x${string}`; // Hex 1 or 0 for success or failure, respectively
+    chainId: `0x${string}`;
     blockHash: `0x${string}`;
     blockNumber: `0x${string}`;
     gasUsed: `0x${string}`;
@@ -163,6 +166,7 @@ As with the return value of `wallet_sendCalls`, the batch identifier may be any 
         }
       ],
       "status": "0x1",
+      "chainId": "0x01",
       "blockHash": "0xf19bbafd9fd0124ec110b848e8de4ab4f62bf60c189524e54213285e7f540d4a",
       "blockNumber": "0xabcd",
       "gasUsed": "0xdef",
@@ -245,6 +249,8 @@ The capabilities below are for illustrative purposes.
 ### `atomicBatch` Capability
 
 Like the illustrative examples given above and other capabilities to be defined in future EIPs, the capability to execute calls delivered via the above-defined methods in a single transaction can be attested by the wallet in boolean form.
+
+This capability is expressed separately on each chain and should be interpreted as a guarantee only for batches of transactions on that chain; batches including calls to multiple chains is out of scope of this capability and this specification.
 
 If a wallet has affirmatively expressed this `atomicBatch` capability to a calling application, it MUST submit calls submitted with `wallet_sendCalls` as part of a single transaction.
 

--- a/EIPS/eip-5792.md
+++ b/EIPS/eip-5792.md
@@ -40,13 +40,13 @@ The capabilities field is how an app can communicate with a wallet about capabil
 
 The wallet:
 
-* MUST send these calls in the order specified in the request
-* MUST send the calls on the same chain identified by the request's `chainId` property
+* MUST send the calls in the order specified in the request
+* MUST send the calls on the same chain identified by the call's `chainId` property
+* MUST NOT await for any calls to be finalized to complete the batch
 * MUST NOT send any calls from the request if the user rejects the request
 * MAY revert all calls if any call fails
-* MAY send all the function calls as part of one transaction or multiple transactions, depending on wallet capability
+* MAY send all calls as part of one or more transactions, depending on wallet capability
 * SHOULD stop executing the calls if any call fails
-* MAY reject the request if the request chain ID does not match the currently selected chain ID
 * MAY reject the request if the from address does not match the enabled account
 * MAY reject the request if one or more calls in the batch is expected to fail, when simulated sequentially
 

--- a/EIPS/eip-5792.md
+++ b/EIPS/eip-5792.md
@@ -55,7 +55,6 @@ The wallet:
 ```typescript
 type SendCallsParams = {
   version: string;
-  
   from: `0x${string}`;
   calls: {
     to?: `0x${string}` | undefined;
@@ -63,6 +62,7 @@ type SendCallsParams = {
     value?: `0x${string}` | undefined; // Hex value
     chainId?: `0x${string}` | undefined; // Hex chain id
   }[];
+  parallel?: boolean;
   capabilities?: Record<string, any> | undefined;
 };
 
@@ -240,6 +240,41 @@ The capabilities below are for illustrative purposes.
   },
   "0x14A34": {
     "paymasterService": {
+      "supported": true
+    }
+  }
+}
+```
+
+### `parallel` Capability
+
+Like the illustrative examples given above and other capabilities to be defined in future EIPs, the capability to execute calls delivered via the above-defined methods in a single transaction can be attested by the wallet in boolean form.
+
+This capability is expressed separately on each chain and should be interprested as a guarantee for transactions on that chain to be executed in parallel without taking into consideration of the calls being executed in sequence as ordered by the request for `wallet_sendCalls`.
+
+#### `parallel` Capability Specification
+
+```typescript
+type ParellelBatchCapability = {
+  supported: true;
+};
+```
+
+The only valid JSON-RPC values for this capability's only member, `supported`, are `true` or `false`; if a returned value for `supported` is typed as a string or number, it SHOULD be considered malformed.
+
+For each chain on which a wallet can submit multiple calls atomically, the wallet SHOULD include an `parallel` capability with a `supported` field equal to `true`.
+
+#### `wallet_getCapabilities` Example Return Value including `atomicBatch`
+
+```json
+{
+  "0x2105": {
+    "parallel": {
+      "supported": true
+    },
+  },
+  "0x14A34": {
+    "parallel": {
       "supported": true
     }
   }

--- a/EIPS/eip-5792.md
+++ b/EIPS/eip-5792.md
@@ -264,7 +264,7 @@ The only valid JSON-RPC values for this capability's only member, `supported`, a
 
 For each chain on which a wallet can submit multiple calls atomically, the wallet SHOULD include an `parallel` capability with a `supported` field equal to `true`.
 
-#### `wallet_getCapabilities` Example Return Value including `atomicBatch`
+#### `wallet_getCapabilities` Example Return Value including `parallel`
 
 ```json
 {

--- a/EIPS/eip-5792.md
+++ b/EIPS/eip-5792.md
@@ -246,41 +246,6 @@ The capabilities below are for illustrative purposes.
 }
 ```
 
-### `parallel` Capability
-
-Like the illustrative examples given above and other capabilities to be defined in future EIPs, the capability to execute calls delivered via the above-defined methods in a single transaction can be attested by the wallet in boolean form.
-
-This capability is expressed separately on each chain and should be interprested as a guarantee for transactions on that chain to be executed in parallel without taking into consideration of the calls being executed in sequence as ordered by the request for `wallet_sendCalls`.
-
-#### `parallel` Capability Specification
-
-```typescript
-type ParellelBatchCapability = {
-  supported: true;
-};
-```
-
-The only valid JSON-RPC values for this capability's only member, `supported`, are `true` or `false`; if a returned value for `supported` is typed as a string or number, it SHOULD be considered malformed.
-
-For each chain on which a wallet can submit multiple calls atomically, the wallet SHOULD include an `parallel` capability with a `supported` field equal to `true`.
-
-#### `wallet_getCapabilities` Example Return Value including `parallel`
-
-```json
-{
-  "0x2105": {
-    "parallel": {
-      "supported": true
-    },
-  },
-  "0x14A34": {
-    "parallel": {
-      "supported": true
-    }
-  }
-}
-```
-
 ### `atomicBatch` Capability
 
 Like the illustrative examples given above and other capabilities to be defined in future EIPs, the capability to execute calls delivered via the above-defined methods in a single transaction can be attested by the wallet in boolean form.


### PR DESCRIPTION
Changes proposed:
- move `chainId` from top-level to call-level
- add comment on `atomicBatch` regarding multi-chain