### PR TITLE
Update EIP-5792: add `parallel` capability to ERC-5792

### DIFF
--- a/EIPS/eip-5792.md
+++ b/EIPS/eip-5792.md
@@ -242,6 +242,33 @@ The capabilities below are for illustrative purposes.
 }
 ```
 
+### `parallel` Capability
+Like the illustrative examples given above and other capabilities to be defined in future EIPs, the capability to execute calls delivered via the above-defined methods in a single transaction can be attested by the wallet in boolean form.
+This capability is expressed separately on each chain and should be interprested as a guarantee for transactions on that chain to be executed in parallel without taking into consideration of the calls being executed in sequence as ordered by the request for `wallet_sendCalls`.
+#### `parallel` Capability Specification
+```typescript
+type ParellelCapability = {
+  supported: true;
+};
+```
+The only valid JSON-RPC values for this capability's only member, `supported`, are `true` or `false`; if a returned value for `supported` is typed as a string or number, it SHOULD be considered malformed.
+For each chain on which a wallet can submit multiple calls atomically, the wallet SHOULD include an `parallel` capability with a `supported` field equal to `true`.
+#### `wallet_getCapabilities` Example Return Value including `parallel`
+```json
+{
+  "0x2105": {
+    "parallel": {
+      "supported": true
+    },
+  },
+  "0x14A34": {
+    "parallel": {
+      "supported": true
+    }
+  }
+}
+```
+
 ### `atomicBatch` Capability
 
 Like the illustrative examples given above and other capabilities to be defined in future EIPs, the capability to execute calls delivered via the above-defined methods in a single transaction can be attested by the wallet in boolean form.


### PR DESCRIPTION
add `parallel` capability to ERC-5792