### PR TITLE
7702: charge empty account upfront, refund diff during processing

### DIFF
--- a/EIPS/eip-7702.md
+++ b/EIPS/eip-7702.md
@@ -56,14 +56,14 @@ At the start of executing the transaction, for each `[chain_id, address, nonce, 
 
 1. `authority = ecrecover(keccak(MAGIC || rlp([chain_id, address, nonce])), y_parity, r, s]`
 2. Verify the chain id is either 0 or the chain's current ID.
-3. Verify that the code of `authority` is either empty or already delegated.
+3. Verify the code of `authority` is either empty or already delegated.
 4. Verify the nonce of `authority` is equal to `nonce`.
-5. Charge the sender `PER_EMPTY_ACCOUNT_COST` if `authority` does not exist in the trie. Abort immediately if the sender balance is less than this value.
-5. Set the code of `authority` to be `0xef0100 || address`. This is a delegation designation.
-6. Increase the nonce of `authority` by one.
-7. Add `authority` to `accessed_addresses` (as defined in [EIP-2929](./eip-2929.md).)
+5. Refund the sender `PER_EMPTY_ACCOUNT_COST - PER_AUTH_BASE_COST` gas if `authority` exists in the trie.
+6. Set the code of `authority` to be `0xef0100 || address`. This is a delegation designation.
+7. Increase the nonce of `authority` by one.
+8. Add `authority` to `accessed_addresses` (as defined in [EIP-2929](./eip-2929.md).)
 
-If any of the above steps (except 5) fail, immediately stop processing that tuple and continue to the next tuple in the list. It will in the case of multiple tuples for the same authority, set the code using the address in the last occurrence.
+If any of the above steps fail, immediately stop processing that tuple and continue to the next tuple in the list. It will in the case of multiple tuples for the same authority, set the code using the address in the last occurrence.
 
 Note that the signer of an authorization tuple may be different than `tx.origin` of the transaction.
 
@@ -77,7 +77,7 @@ In case a delegation designator points to another designator, creating a potenti
 
 #### Gas Costs
 
-The intrinsic cost of the new transaction is inherited from [EIP-2930](./eip-2930.md), specifically `21000 + 16 * non-zero calldata bytes + 4 * zero calldata bytes + 1900 * access list storage key count + 2400 * access list address count`. Additionally, we add a cost of `PER_AUTH_BASE_COST * authorization list length`.
+The intrinsic cost of the new transaction is inherited from [EIP-2930](./eip-2930.md), specifically `21000 + 16 * non-zero calldata bytes + 4 * zero calldata bytes + 1900 * access list storage key count + 2400 * access list address count`. Additionally, we add a cost of `PER_EMPTY_ACCOUNT_COST * authorization list length`.
 
 The transaction sender will pay for all authorization tuples, regardless of validity or duplication.
 


### PR DESCRIPTION
Instead of potentially failing while processing the EIP-7702 authorization list, this PR charges the sender the `PER_EMPTY_ACCOUNT_COST` for each tuple and only during processing of the list does it refund the `PER_EMPTY_ACCOUNT_COST - PER_AUTH_BASE_COST` difference when it determines the account is not considered empty.