### PR TITLE
Update EIP-7702: Switch order of authority warm access

### DIFF
--- a/EIPS/eip-7702.md
+++ b/EIPS/eip-7702.md
@@ -56,12 +56,12 @@ At the start of executing the transaction, for each `[chain_id, address, nonce, 
 
 1. `authority = ecrecover(keccak(MAGIC || rlp([chain_id, address, nonce])), y_parity, r, s]`
 2. Verify the chain id is either 0 or the chain's current ID.
-3. Verify the code of `authority` is either empty or already delegated.
-4. Verify the nonce of `authority` is equal to `nonce`.
-5. Refund the sender `PER_EMPTY_ACCOUNT_COST - PER_AUTH_BASE_COST` gas if `authority` exists in the trie.
-6. Set the code of `authority` to be `0xef0100 || address`. This is a delegation designation.
-7. Increase the nonce of `authority` by one.
-8. Add `authority` to `accessed_addresses` (as defined in [EIP-2929](./eip-2929.md).)
+3. Add `authority` to `accessed_addresses` (as defined in [EIP-2929](./eip-2929.md).)
+4. Verify the code of `authority` is either empty or already delegated.
+5. Verify the nonce of `authority` is equal to `nonce`.
+6. Refund the sender `PER_EMPTY_ACCOUNT_COST - PER_AUTH_BASE_COST` gas if `authority` exists in the trie.
+7. Set the code of `authority` to be `0xef0100 || address`. This is a delegation designation.
+8. Increase the nonce of `authority` by one.
 
 If any of the above steps fail, immediately stop processing that tuple and continue to the next tuple in the list. It will in the case of multiple tuples for the same authority, set the code using the address in the last occurrence.
 


### PR DESCRIPTION
Small change, it inserts step 8. `Add authority to accessed_addresses (as defined in [EIP-2929](./eip-2929.md).)` . to become step 3. (Before nonce and bytecode checks)

This is a better order as we load the account first and add authority to the access list before checking if the nonce is equal or if acc is empty/delegated.