### PR TITLE
eip-3155: move to review

### DIFF
--- a/EIPS/eip-3155.md
+++ b/EIPS/eip-3155.md
@@ -3,7 +3,7 @@ eip: 3155
 title: EVM trace specification
 author: Martin Holst Swende (@holiman), Marius van der Wijden (@MariusVanDerWijden)
 discussions-to: https://ethereum-magicians.org/t/eip-3155-create-evm-trace-specification/5007
-status: Stagnant
+status: Review
 type: Standards Track
 category: Interface
 created: 2020-12-07


### PR DESCRIPTION
This moves EIP 3155 to review.
It has been implemented in a bunch of clients:
- go-ethereum
- besu
- reth
- erigon
- nethermind
- many more 

And in order to update it to eof, it should be finalized first