### PR TITLE
Update EIP-7702: remove outdated note on forward compatibility

### DIFF
--- a/EIPS/eip-7702.md
+++ b/EIPS/eip-7702.md
@@ -169,7 +169,6 @@ Specifically:
 * Hence, it avoids the problem of "creating two separate code ecosystems", because to a large extent they would be the same ecosystem. There would be some workflows that require kludges under this solution that would be better done in some different "more native" under "endgame AA", but this is relatively a small subset.
 * It does not require adding any opcodes, that would become dangling and useless in a post-EOA world.
 * It allows EOAs to masquerade as contracts to be included in ERC-4337 bundles, in a way that's compatible with the existing `EntryPoint`.
-* Once this is implemented, allowing EOAs to migrate permanently is "only one line of code": just add a flag to not set the code back to empty at the end.
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
I was reviewing the updated semantics of EIP-7702 after #8677, which now sets the account code permanently in the trie. One of the forward compatibility notes refers to the earlier version of this EIP and seems confusing / no longer relevant.