### PR TITLE
Update EIP-663: Modify specification section for EIP-663

### DIFF
--- a/EIPS/eip-663.md
+++ b/EIPS/eip-663.md
@@ -29,7 +29,7 @@ Introducing `SWAPN`, `DUPN` and `EXCHANGE` will provide an option to compilers t
 
 ## Specification
 
-We introduce two new instructions:
+We introduce three new instructions:
 
 1. `DUPN` (`0xe6`)
 2. `SWAPN` (`0xe7`)


### PR DESCRIPTION
## Description

For [EIP-663 Specification](https://eips.ethereum.org/EIPS/eip-663#specification), there is a mistake in the description that includes only 2 instructions.

This PR makes corrections to the descriptions, indicating that there are actually three instructions.