### PR TITLE
Update EIP-7702: Restrict chain_id to chain's id or zero

### DIFF
--- a/EIPS/eip-7702.md
+++ b/EIPS/eip-7702.md
@@ -46,7 +46,7 @@ authorization_list = [[chain_id, address, nonce, y_parity, r, s], ...]
 
 Transaction is considered invalid if authorization list items can't be decoded as:
 
-* `chain_id`: Value 1.
+* `chain_id`: Value 0 or 1.
 * `nonce`: unsigned 64-bit integer.
 * `address`: 20 bytes array.
 * `y_parity`: Value 0 or 1.

--- a/EIPS/eip-7702.md
+++ b/EIPS/eip-7702.md
@@ -46,7 +46,7 @@ authorization_list = [[chain_id, address, nonce, y_parity, r, s], ...]
 
 Transaction is considered invalid if authorization list items can't be decoded as:
 
-* `chain_id`: unsigned 256-bit integer.
+* `chain_id`: Value 1.
 * `nonce`: unsigned 64-bit integer.
 * `address`: 20 bytes array.
 * `y_parity`: Value 0 or 1.

--- a/EIPS/eip-7702.md
+++ b/EIPS/eip-7702.md
@@ -46,7 +46,7 @@ authorization_list = [[chain_id, address, nonce, y_parity, r, s], ...]
 
 Transaction is considered invalid if authorization list items can't be decoded as:
 
-* `chain_id`: Value 0 or 1.
+* `chain_id`: chain's current ID or zero
 * `nonce`: unsigned 64-bit integer.
 * `address`: 20 bytes array.
 * `y_parity`: Value 0 or 1.


### PR DESCRIPTION
As we already checking if `y_parity` and `s` values additionally adding a check for correct `chain_id` seems logical.

This would make the EIP-7702 transaction invalid if it is not zero (chain agnostic) or has chain_id different from the Ethereum-s chain_id.

Would propose that this change is added after `devnet-3` to not disrupt testing/developing efforts.