### PR TITLE
Update EIP-7600: Update eip-7600.md

### DIFF
--- a/EIPS/eip-7600.md
+++ b/EIPS/eip-7600.md
@@ -45,6 +45,7 @@ This Meta EIP lists the EIPs formally considered for and included in the Prague/
 * RIP-7212: Precompile for secp256r1 Curve Support
 * [EIP-7547](./eip-7547.md): Inclusion lists
 * [EIP-7623](./eip-7623.md): Increase calldata cost
+* [EIP-7742](./eip-7742.md): Uncouple blob count between CL and EL
 
 ### Full Specifications 
 


### PR DESCRIPTION
Marks EIP-7742 as CFI, as decided on https://github.com/ethereum/pm/issues/1142