### PR TITLE
Update EIP-7702: adjust tx validity

### DIFF
--- a/EIPS/eip-7702.md
+++ b/EIPS/eip-7702.md
@@ -44,18 +44,18 @@ rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit, dest
 authorization_list = [[chain_id, address, nonce, y_parity, r, s], ...]
 ```
 
-Transaction is considered invalid if authorization list items can't be decoded as:
-
-* `chain_id`: unsigned 256-bit integer.
-* `nonce`: unsigned 64-bit integer.
-* `address`: 20 bytes array.
-* `y_parity`: Value 0 or 1.
-* `r`: unsigned 256-bit integer.
-* `s`: unsigned 256-bit integer and value less or equal than `secp256k1n/2`, specified in [EIP-2](./eip-2.md).
-
 The fields `chain_id`, `nonce`, `max_priority_fee_per_gas`, `max_fee_per_gas`, `gas_limit`, `destination`, `value`, `data`, and `access_list` of the outer transaction follow the same semantics as [EIP-4844](./eip-4844.md). *Note, this means a null destination is not valid.*
 
 The `authorization_list` is a list of tuples that store the address to code which the signer desires to execute in the context of their EOA. The transaction is considered invalid if the length of `authorization_list` is zero.
+
+The transaction is also considered invalid when any integer field in an
+authorization list cannot fit within the following bounds:
+
+* `chain_id`: `2**256-1`
+* `nonce`:`2**64-1`.
+* `y_parity`: `2**256-1`.
+* `r`: `2**256-1`.
+* `s`: `2**256-1`.
 
 The [EIP-2718](./eip-2718.md) `ReceiptPayload` for this transaction is `rlp([status, cumulative_transaction_gas_used, logs_bloom, logs])`.
 

--- a/EIPS/eip-7702.md
+++ b/EIPS/eip-7702.md
@@ -48,14 +48,17 @@ The fields `chain_id`, `nonce`, `max_priority_fee_per_gas`, `max_fee_per_gas`, `
 
 The `authorization_list` is a list of tuples that store the address to code which the signer desires to execute in the context of their EOA. The transaction is considered invalid if the length of `authorization_list` is zero.
 
-The transaction is also considered invalid when any integer field in an
-authorization list cannot fit within the following bounds:
+The transaction is also considered invalid when any field in an authorization
+tuple cannot fit within the following bounds:
 
-* `chain_id`: `2**256-1`
-* `nonce`:`2**64-1`.
-* `y_parity`: `2**256-1`.
-* `r`: `2**256-1`.
-* `s`: `2**256-1`.
+```python
+assert auth.chain_id < 2**256
+assert auth.nonce < 2**64
+assert len(auth.address) == 20
+assert auth.y_parity < 2**256
+assert auth.r < 2**256
+assert auth.z < 2**256
+```
 
 The [EIP-2718](./eip-2718.md) `ReceiptPayload` for this transaction is `rlp([status, cumulative_transaction_gas_used, logs_bloom, logs])`.
 


### PR DESCRIPTION
The past few weeks we've been discussing validity conditions for 7702 transactions. Originally @rakita added the decoding limits for auth list items in #8746. Now we're looking at further constraining validity in #8833 to disallow chain ids other than zero or the current chain's id.

My philosophy here is 1) tx validity should be as simple as possible to ascertain and 2) we should retain as much similarity across tx types as possible.

The motivation for 1) is that tx originators are incentivized to not send junk authorizations with their txs, therefore they won't. What's the point of adding more constraints into the protocol when they aren't necessary?

For 2), I believe it's extremely important to follow existing conventions when possible. If every single tx type is designed as an ornate protocol fixture by core devs of that era, we will have a mess of formats that are extremely difficult to reason about as a whole or onboard new developers to understanding. Of course this doesn't mean we shouldn't improve the status quo when possible (see: separating chain id back out from `v` value), but unless the benefit is significant, let's not deviate from other tx formats.