### PR TITLE
Update EIP-6800: remove text around SELFDESTRUCT deprecation

### DIFF
--- a/EIPS/eip-6800.md
+++ b/EIPS/eip-6800.md
@@ -260,8 +260,6 @@ The Verkle tree uses a single-layer tree structure with 32-byte keys and values 
  * **Uniformity**: the state is uniformly spread out throughout the tree; even if a single contract has many millions of storage slots, the contract’s storage slots are not concentrated in one place. This is useful for state syncing algorithms. Additionally, it helps reduce the effectiveness of unbalanced tree filling attacks.
  * **Extensibility**: account headers and code being in the same structure as storage makes it easier to extend the features of both, and even add new structures if later desired.
 
-The single-layer tree design does have a major weakness: the inability to deal with entire storage trees as a single object. This is why this EIP includes removing most of the functionality of SELFDESTRUCT. If absolutely desired, SELFDESTRUCT’s functionality could be kept by adding and incrementing an account_state_offset parameter that increments every time an account self-destructs, but this would increase complexity.
-
 ### Gas reform
 
 Gas costs for reading storage and code are reformed to more closely reflect the gas costs under the new Verkle tree design. WITNESS_CHUNK_COST is set to charge 6.25 gas per byte for chunks, and WITNESS_BRANCH_COST is set to charge ~13,2 gas per byte for branches on average (assuming 144 byte branch length) and ~2.5 gas per byte in the worst case if an attacker fills the tree with keys deliberately computed to maximize proof length.
@@ -278,13 +276,13 @@ The precise specification of when access events take place, which makes up most 
 
 ## Backwards Compatibility
 
-The three main backwards-compatibility-breaking changes are:
+The main backwards-compatibility-breaking changes are:
 
- * `SELFDESTRUCT` neutering (see [EIP-6780](./eip-6780.md) for a document stating the case for doing this despite the backwards compatibility loss)
- * Gas costs for code chunk access making some applications less economically viable
- * Tree structure change makes in-EVM proofs of historical state no longer work
+ * (1) Gas costs for code chunk access making some applications less economically viable
+ * (2) Tree structure change makes in-EVM proofs of historical state no longer work
 
-(2) can be mitigated by increasing the gas limit at the same time as implementing this EIP, reducing the risk that applications will no longer work at all due to transaction gas usage rising above the block gas limit. (3) cannot be mitigated this time, but this proposal could be implemented to make this no longer a concern for any tree structure changes in the future.
+(1) can be mitigated by increasing the gas limit at the same time as implementing this EIP, reducing the risk that applications will no longer work at all due to transaction gas usage rising above the block gas limit.
+(2) cannot be mitigated this time, but this proposal could be implemented to make this no longer a concern for any tree structure changes in the future.
 
 ## Test Cases
 

--- a/EIPS/eip-6800.md
+++ b/EIPS/eip-6800.md
@@ -282,7 +282,6 @@ The main backwards-compatibility-breaking changes are:
  * (2) Tree structure change makes in-EVM proofs of historical state no longer work
 
 (1) can be mitigated by increasing the gas limit at the same time as implementing this EIP, reducing the risk that applications will no longer work at all due to transaction gas usage rising above the block gas limit.
-(2) cannot be mitigated this time, but this proposal could be implemented to make this no longer a concern for any tree structure changes in the future.
 
 ## Test Cases
 


### PR DESCRIPTION
Since EIP-6780 was included in the Cancun fork, and that fork is deployed on mainnet, removal of SELFDESTRUCT is no longer a backwards-compatibility breaking change.