### PR TITLE
Update EIP-6493: Fix `Optional` specification for signature profile

### DIFF
--- a/EIPS/eip-6493.md
+++ b/EIPS/eip-6493.md
@@ -148,8 +148,8 @@ class BlobFeesPerGas(Profile[FeesPerGas]):
     blob: FeePerGas
 
 class EcdsaTransactionSignature(Profile[TransactionSignature]):
-    from_: Optional[ExecutionAddress]
-    ecdsa_signature: Optional[ByteVector[ECDSA_SIGNATURE_SIZE]]
+    from_: ExecutionAddress
+    ecdsa_signature: ByteVector[ECDSA_SIGNATURE_SIZE]
 
 class ReplayableTransactionPayload(Profile[TransactionPayload]):
     type_: TransactionType

--- a/assets/eip-6493/ssz_types.py
+++ b/assets/eip-6493/ssz_types.py
@@ -92,8 +92,8 @@ class BlobFeesPerGas(Profile[FeesPerGas]):
     blob: FeePerGas
 
 class EcdsaTransactionSignature(Profile[TransactionSignature]):
-    from_: Optional[ExecutionAddress]
-    ecdsa_signature: Optional[ByteVector[ECDSA_SIGNATURE_SIZE]]
+    from_: ExecutionAddress
+    ecdsa_signature: ByteVector[ECDSA_SIGNATURE_SIZE]
 
 class ReplayableTransactionPayload(Profile[TransactionPayload]):
     type_: TransactionType


### PR DESCRIPTION
In `EcdsaTransactionSignature`, both `from` and `ecdsa_signature` fields are required.
