### PR TITLE
Update EIP-7600: Update eip-7600.md

### DIFF
--- a/EIPS/eip-7600.md
+++ b/EIPS/eip-7600.md
@@ -16,7 +16,7 @@ This Meta EIP lists the EIPs formally considered for and included in the Prague/
 
 ## Specification
 
-### EIPs Included  
+### EIPs Scheduled for Inclusion  
 
 * [EIP-2537](./eip-2537.md): Precompile for BLS12-381 curve operations
 * [EIP-2935](./eip-2935.md): Save historical block hashes in state
@@ -45,8 +45,19 @@ This Meta EIP lists the EIPs formally considered for and included in the Prague/
 * RIP-7212: Precompile for secp256r1 Curve Support
 * [EIP-7547](./eip-7547.md): Inclusion lists
 * [EIP-7623](./eip-7623.md): Increase calldata cost
+* [EIP-7742](./eip-7742.md): Uncouple blob count between CL and EL 
+
+### EIPs Proposed for Inclusion
+For clarity, and due to the late addition of this section in the Pectra network upgrade planning process, only EIPs which have recently been proposed or discussed are listed here. For the full list of Pectra proposals, please refer to the `discussion-to` link for this EIP. If the author has missed relevant EIPs in this section, please propose additions by opening a pull request.  
+
+* [EIP-6493](./eip-6493.md): SSZ Transaction Signature Scheme
+* [EIP-7495](./eip-7495.md): SSZ StableContainer
+* [EIP-7688](./eip-7688.md): Forward compatible consensus data structures
+* [EIP-7761](./eip-7761.md): IS_CONTRACT instruction
 
 ### Full Specifications 
+
+Only EIPs Scheduled for Inclusion are mentioned in this section. 
 
 #### Consensus Layer
 
@@ -54,7 +65,7 @@ EIP-6110, EIP-7002 EIP-7251, EIP-7549 and EIP-7594 require changes to Ethereum's
 
 #### Execution Layer
 
-All EOF EIPs, listed in EIP-7692, as well as EIP-2537, EIP-2935, EIP-6110, EIP-7685, and EIP-7002 require changes to Ethereum's execution layer. The EIPs fully specify those changes. 
+All EOF EIPs, listed in EIP-7692, as well as EIP-2537, EIP-2935, EIP-6110, EIP-7002, EIP-7685, and EIP-7702 require changes to Ethereum's execution layer. The EIPs fully specify those changes. 
 
 ### Activation 
 

--- a/EIPS/eip-7600.md
+++ b/EIPS/eip-7600.md
@@ -54,7 +54,7 @@ For clarity, and due to the late addition of this section in the Pectra network 
 * [EIP-6493](./eip-6493.md): SSZ Transaction Signature Scheme
 * [EIP-7495](./eip-7495.md): SSZ StableContainer
 * [EIP-7688](./eip-7688.md): Forward compatible consensus data structures
-* [EIP-7761](./eip-7761.md): IS_CONTRACT instruction
+* [EIP-7761](./eip-7761.md): HASCODE instruction
 * [EIP-7762](./eip-7762.md): Increase MIN_BASE_FEE_PER_BLOB_GAS
 
 ### Full Specifications 

--- a/EIPS/eip-7600.md
+++ b/EIPS/eip-7600.md
@@ -55,6 +55,7 @@ For clarity, and due to the late addition of this section in the Pectra network 
 * [EIP-7495](./eip-7495.md): SSZ StableContainer
 * [EIP-7688](./eip-7688.md): Forward compatible consensus data structures
 * [EIP-7761](./eip-7761.md): IS_CONTRACT instruction
+* [EIP-7762](./eip-7762.md): Increase MIN_BASE_FEE_PER_BLOB_GAS
 
 ### Full Specifications 
 

--- a/EIPS/eip-7600.md
+++ b/EIPS/eip-7600.md
@@ -48,6 +48,7 @@ This Meta EIP lists the EIPs formally considered for and included in the Prague/
 * [EIP-7742](./eip-7742.md): Uncouple blob count between CL and EL 
 
 ### EIPs Proposed for Inclusion
+
 For clarity, and due to the late addition of this section in the Pectra network upgrade planning process, only EIPs which have recently been proposed or discussed are listed here. For the full list of Pectra proposals, please refer to the `discussion-to` link for this EIP. If the author has missed relevant EIPs in this section, please propose additions by opening a pull request.  
 
 * [EIP-6493](./eip-6493.md): SSZ Transaction Signature Scheme


### PR DESCRIPTION
This PR updates the Pectra Meta EIP to categorize EIPs as defined in [EIP-7723](https://eips.ethereum.org/EIPS/eip-7723). 

Note that given the late addition of these categories to the EIP, and discussions on [ACDE#195](https://github.com/ethereum/pm/issues/1142), I've opted to limit the `Proposed for Inclusion` section to EIPs which have been discussed in the past few ACD calls. If anyone feels something is missing, please propose it as an addition to the PR. 

One notable proposal still missing is the one about [increasing the blob gas reserve price](https://github.com/ethereum/pm/issues/1142#issuecomment-2316630318), which still does not have an EIP drafted. 