### PR TITLE
Update EIP-6110: change request to flat encoding

### DIFF
--- a/EIPS/eip-6110.md
+++ b/EIPS/eip-6110.md
@@ -94,9 +94,9 @@ def event_data_to_deposit_request(deposit_event_data) -> bytes:
     deposit_data = parse_deposit_data(deposit_event_data)
     pubkey = Bytes48(deposit_data[0])
     withdrawal_credentials = Bytes32(deposit_data[1])
-    amount = deposit_data[2]   # 4 bytes uint64 LE
+    amount = deposit_data[2]   # 8 bytes uint64 LE
     signature = Bytes96(deposit_data[3])
-    index = deposit_data[4]    # 4 bytes uint64 LE
+    index = deposit_data[4]    # 8 bytes uint64 LE
 
     return DEPOSIT_REQUEST_TYPE + pubkey + withdrawal_credentials + amount + signature + index
 

--- a/EIPS/eip-6110.md
+++ b/EIPS/eip-6110.md
@@ -62,19 +62,15 @@ The structure denoting the new deposit operation consists of the following field
 4. `signature: Bytes96`
 5. `index: uint64`
 
-Deposits are a type of [EIP-7685](./eip-7685.md) request, therefore the encoding of the structure must be computed using the `DEPOSIT_REQUEST_TYPE` byte:
+Deposits are a type of [EIP-7685](./eip-7685.md) request, with the following encoding:
 
 ```python
-deposit_request_rlp = DEPOSIT_REQUEST_TYPE + rlp([
-    pubkey,
-    withdrawal_credentials,
-    amount,
-    signature,
-    index
-])
+request_type = DEPOSIT_REQUEST_TYPE
+request_data = pubkey ++ withdrawal_credentials ++ amount ++ signature ++ index
 ```
 
-The encoded deposits will be included in the header and body as generic requests following the format defined by EIP-7685.
+Note that the request payload is just the concatenation of the elements returned by the contract.
+The encoded deposits will be included in the header and body following the format defined by EIP-7685.
 
 #### Block validity
 
@@ -94,17 +90,15 @@ def parse_deposit_data(deposit_event_data) -> bytes[]:
 def little_endian_to_uint64(data: bytes) -> uint64:
     return uint64(int.from_bytes(data, 'little'))
 
-def event_data_to_deposit_request_rlp(deposit_event_data) -> bytes:
+def event_data_to_deposit_request(deposit_event_data) -> bytes:
     deposit_data = parse_deposit_data(deposit_event_data)
     pubkey = Bytes48(deposit_data[0])
     withdrawal_credentials = Bytes32(deposit_data[1])
-    amount = little_endian_to_uint64(deposit_data[2])
+    amount = deposit_data[2]   # 4 bytes uint64 LE
     signature = Bytes96(deposit_data[3])
-    index = little_endian_to_uint64(deposit_data[4])
+    index = deposit_data[4]    # 4 bytes uint64 LE
 
-    return DEPOSIT_REQUEST_TYPE + rlp([
-        pubkey, withdrawal_credentials, amount, signature, index
-    ])
+    return DEPOSIT_REQUEST_TYPE + pubkey + withdrawal_credentials + amount + signature + index
 
 # Obtain receipts from block execution result
 receipts = block.execution_result.receipts
@@ -114,8 +108,8 @@ expected_deposit_requests = []
 for receipt in receipts:
     for log in receipt.logs:
         if log.address == DEPOSIT_CONTRACT_ADDRESS:
-            deposit_request_rlp = event_data_to_deposit_request_rlp(log.data)
-            expected_deposit_requests.append(deposit_request_rlp)
+            deposit_request = event_data_to_deposit_request(log.data)
+            expected_deposit_requests.append(deposit_request)
 
 deposit_requests = [req for req in block.body.requests if req[:1] == DEPOSIT_REQUEST_TYPE]
 


### PR DESCRIPTION
I am proposing to change the encoding of deposit requests to be a flat concatenation of the fields returned by the contract. The extra layer of RLP encoding is not necessary, and by removing it, we can avoid defining the structure of these requests in the execution layer client implementation.
