### PR TITLE
Update EIP-7251: change request to flat encoding

### DIFF
--- a/EIPS/eip-7251.md
+++ b/EIPS/eip-7251.md
@@ -61,10 +61,12 @@ The new consolidation request is an [EIP-7685](./eip-7685.md) request with type 
 2. `source_pubkey`: `Bytes48`
 3. `target_pubkey`: `Bytes48`
 
-The [EIP-7685](./eip-7685.md) encoding of a withdrawal request **MUST** be computed as follows:
+The [EIP-7685](./eip-7685.md) encoding of a consolidation request is as follows. Note we simply return the
+encoded request value as returned by the contract.
 
 ```python
-encoded = CONSOLIDATION_REQUEST_TYPE ++ rlp([source_address, source_pubkey, target_pubkey])
+request_type = CONSOLIDATION_REQUEST_TYPE
+request_data = source_address ++ source_pubkey ++ target_pubkey
 ```
 
 #### Consolidation request contract


### PR DESCRIPTION
I am proposing to change the encoding of consolidation requests to be exactly equal to how they are returned by the contract. The extra layer of RLP encoding is not necessary, and by removing it, we can avoid defining the structure of these requests in the execution layer client implementation.