### PR TITLE
Update EIP-7620: Clarify EOFCREATE in static mode

### DIFF
--- a/EIPS/eip-7620.md
+++ b/EIPS/eip-7620.md
@@ -62,6 +62,7 @@ Details on each instruction follow in the next sections.
 #### `EOFCREATE`
     
 - deduct `TX_CREATE_COST` gas
+- halt with exceptional failure if the current frame is in `static-mode`.
 - read immediate operand `initcontainer_index`, encoded as 8-bit unsigned value
 - pop `value`, `salt`, `input_offset`, `input_size` from the operand stack
 - perform (and charge for) memory expansion using `[input_offset, input_size]`


### PR DESCRIPTION
Align with https://github.com/ipsilon/eof/pull/160. This rule is already tested in EEST tests (either recent or upcoming release).