### PR TITLE
Update EIP-7702: consistent signature validity checks

### DIFF
--- a/EIPS/eip-7702.md
+++ b/EIPS/eip-7702.md
@@ -50,8 +50,8 @@ Transaction is considered invalid if authorization list items can't be decoded a
 * `nonce`: unsigned 64-bit integer.
 * `address`: 20 bytes array.
 * `y_parity`: Value 0 or 1.
-* `r`: unsigned 256-bit integer.
-* `s`: unsigned 256-bit integer and value less or equal than `secp256k1n/2`, specified in [EIP-2](./eip-2.md).
+* `r`: unsigned 256-bit integer and `0 < r < secp256k1n`.
+* `s`: unsigned 256-bit integer and `0 < s <= secp256k1n/2`, specified in [EIP-2](./eip-2.md).
 
 The fields `chain_id`, `nonce`, `max_priority_fee_per_gas`, `max_fee_per_gas`, `gas_limit`, `destination`, `value`, `data`, and `access_list` of the outer transaction follow the same semantics as [EIP-4844](./eip-4844.md). *Note, this means a null destination is not valid.*
 


### PR DESCRIPTION
Currently EIP-7702 mentions that the validity of `s` is based on [EIP-2](https://eips.ethereum.org/EIPS/eip-2) (`s <= secp256k1n/2`), but EIP-2 itself is a tweak of the pre-Homestead validity check (`0 < r < secp256k1n`, `0 < s < secp256k1n`). See [ValidateSignatureValues](https://github.com/ethereum/go-ethereum/blob/v1.14.8/crypto/crypto.go#L271) in geth.