### PR TITLE
Update EIP-4762: unconditionnal account write during contract init

### DIFF
--- a/EIPS/eip-4762.md
+++ b/EIPS/eip-4762.md
@@ -132,11 +132,6 @@ When a contract creation is initialized, process these write events:
 
 ```
 (contract_address, 0, BASIC_DATA_LEAF_KEY)
-```
-
-When a contract is created, process these write events:
-
-```
 (contract_address, 0, CODEHASH_LEAF_KEY)
 ```
 


### PR DESCRIPTION
In the current state of the spec, there are a few instances where the basic leaf can be created but not the code hash leaf.

This unconditionally write-touch all leaves upon contract initialization, as this will result in an account no matter what happens. The only difference is that the value of the code hash will either be the hash of the contract code, or the empty hash, but that does not impact the gas costs.