### PR TITLE
Update EIP-7702: add instruction to remove code at end of tx

### DIFF
--- a/EIPS/eip-7702.md
+++ b/EIPS/eip-7702.md
@@ -74,6 +74,8 @@ At the start of executing the transaction, after incrementing the sender's nonce
 
 If any of the above steps fail, immediately stop processing that tuple and continue to the next tuple in the list. It will in the case of multiple tuples for the same authority, set the code using the address in the last valid occurrence.
 
+At the end of the transaction, set the `contract_code` of each `authority` back to empty.
+
 Note that the signer of an authorization tuple may be different than `tx.origin` of the transaction.
 
 ##### Delegation Designation


### PR DESCRIPTION
Original version of the EIP had:

> At the end of the transaction, set the `contract_code` of each `signer` back to empty.

But currently no similar instruction is present. This PR replaces it.
