### PR TITLE
Update EIP-7702: Remove reference to post-tx code deletion

### DIFF
--- a/EIPS/eip-7702.md
+++ b/EIPS/eip-7702.md
@@ -164,12 +164,11 @@ This EIP is designed to be very forward-compatible with endgame account abstract
 
 Specifically:
 
-* The code that users would need to sign could literally be existing ERC-4337 wallet code.
+* The `address` that users sign could literally point to existing ERC-4337 wallet code.
 * The "code pathways" that are used are code pathways that would, in many cases (though perhaps not all), continue to "make sense" in a pure-smart-contract-wallet world.
 * Hence, it avoids the problem of "creating two separate code ecosystems", because to a large extent they would be the same ecosystem. There would be some workflows that require kludges under this solution that would be better done in some different "more native" under "endgame AA", but this is relatively a small subset.
 * It does not require adding any opcodes, that would become dangling and useless in a post-EOA world.
 * It allows EOAs to masquerade as contracts to be included in ERC-4337 bundles, in a way that's compatible with the existing `EntryPoint`.
-* Once this is implemented, allowing EOAs to migrate permanently is "only one line of code": just add a flag to not set the code back to empty at the end.
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
Prior versions of the EIP called for deleting the set code at the end of the transaction. This PR removes some dangling references to that deletion. 

@lightclient - following up from your comment on #8869.