### PR TITLE
Update EIP-7688: Adjustments for `v1.5.0-alpha.6` specs

### DIFF
--- a/EIPS/eip-7688.md
+++ b/EIPS/eip-7688.md
@@ -97,6 +97,7 @@ These types are used as part of the `StableContainer` definitions, and, as they 
 | `MAX_ATTESTATION_FIELDS` | `uint64(2**3)` (= 8) | Maximum number of fields to which `StableAttestation` can ever grow in the future |
 | `MAX_INDEXED_ATTESTATION_FIELDS` | `uint64(2**3)` (= 8) | Maximum number of fields to which `StableIndexedAttestation` can ever grow in the future |
 | `MAX_EXECUTION_PAYLOAD_FIELDS` | `uint64(2**6)` (= 64) | Maximum number of fields to which `StableExecutionPayload` can ever grow in the future |
+| `MAX_EXECUTION_REQUESTS_FIELDS` | `uint64(2**4)` (= 16) | Maximum number of fields to which `StableExecutionRequests` can ever grow in the future |
 | `MAX_BEACON_BLOCK_BODY_FIELDS` | `uint64(2**6)` (= 64) | Maximum number of fields to which `StableBeaconBlockBody` can ever grow in the future |
 | `MAX_BEACON_STATE_FIELDS` | `uint64(2**7)` (= 128) | Maximum number of fields to which `StableBeaconState` can ever grow in the future |
 
@@ -143,11 +144,6 @@ class StableExecutionPayload(StableContainer[MAX_EXECUTION_PAYLOAD_FIELDS]):
     withdrawals: Optional[List[Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD]]  # [New in Capella]
     blob_gas_used: Optional[uint64]  # [New in Deneb:EIP4844]
     excess_blob_gas: Optional[uint64]  # [New in Deneb:EIP4844]
-    deposit_requests: Optional[List[DepositRequest, MAX_DEPOSIT_REQUESTS_PER_PAYLOAD]]  # [New in Electra:EIP6110]
-    # [New in Electra:EIP7002:EIP7251]
-    withdrawal_requests: Optional[List[WithdrawalRequest, MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD]]
-    # [New in Electra:EIP7251]
-    consolidation_requests: Optional[List[ConsolidationRequest, MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD]]
 
 class StableExecutionPayloadHeader(StableContainer[MAX_EXECUTION_PAYLOAD_FIELDS]):
     parent_hash: Optional[Hash32]
@@ -167,9 +163,11 @@ class StableExecutionPayloadHeader(StableContainer[MAX_EXECUTION_PAYLOAD_FIELDS]
     withdrawals_root: Optional[Root]  # [New in Capella]
     blob_gas_used: Optional[uint64]  # [New in Deneb:EIP4844]
     excess_blob_gas: Optional[uint64]  # [New in Deneb:EIP4844]
-    deposit_requests_root: Optional[Root]  # [New in Electra:EIP6110]
-    withdrawal_requests_root: Optional[Root]  # [New in Electra:EIP7002:EIP7251]
-    consolidation_requests_root: Optional[Root]  # [New in Electra:EIP7251]
+
+class StableExecutionRequests(StableContainer[MAX_EXECUTION_REQUESTS_FIELDS]):
+    deposits: Optional[List[DepositRequest, MAX_DEPOSIT_REQUESTS_PER_PAYLOAD]]  # [New in Electra:EIP6110]
+    withdrawals: Optional[List[WithdrawalRequest, MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD]]  # [New in Electra:EIP7002:EIP7251]
+    consolidations: Optional[List[ConsolidationRequest, MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD]]  # [New in Electra:EIP7251]
 
 class StableBeaconBlockBody(StableContainer[MAX_BEACON_BLOCK_BODY_FIELDS]):
     randao_reveal: Optional[BLSSignature]
@@ -184,6 +182,7 @@ class StableBeaconBlockBody(StableContainer[MAX_BEACON_BLOCK_BODY_FIELDS]):
     execution_payload: Optional[StableExecutionPayload]  # [New in Bellatrix]
     bls_to_execution_changes: Optional[List[SignedBLSToExecutionChange, MAX_BLS_TO_EXECUTION_CHANGES]]  # [New in Capella]
     blob_kzg_commitments: Optional[List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK]]  # [New in Deneb:EIP4844]
+    execution_requests: Optional[StableExecutionRequests]  # [New in Electra]
 
 class StableBeaconState(StableContainer[MAX_BEACON_STATE_FIELDS]):
     # Versioning
@@ -254,6 +253,9 @@ class ExecutionPayload(Profile[StableExecutionPayload]):
     ...
 
 class ExecutionPayloadHeader(Profile[StableExecutionPayloadHeader]):
+    ...
+
+class ExecutionRequests(Profile[StableExecutionRequests]):
     ...
 
 class BeaconBlockBody(Profile[StableBeaconBlockBody]):


### PR DESCRIPTION
`deposit_requests`, `withdrawal_requests` and `consolidation_requests` were moved from `ExecutionPayload` to `ExecutionRequests`.
