### PR TITLE
Update EIP-7685: remove requests from block body

### DIFF
--- a/EIPS/eip-7685.md
+++ b/EIPS/eip-7685.md
@@ -55,7 +55,7 @@ Extend the header with a new 32 byte value `requests_hash`:
 def compute_requests_hash(list):
     return keccak256(rlp.encode([rlp.encode(req) for req in list]))
 
-block.header.requests_root = compute_requests_hash(requests)
+block.header.requests_hash = compute_requests_hash(requests)
 ```
 
 ### Consensus Layer
@@ -95,7 +95,7 @@ The authors' recommendations on source and validity of requests are:
 ### Ordering
 
 The ordering across types is ascending by type. This is to simplify the process
-of verifying that all requests which were committed to in `requests_root` were
+of verifying that all requests which were committed to in `requests_hash` were
 found in the block.
 
 An alternative could be to order by when the request was generated within the

--- a/EIPS/eip-7685.md
+++ b/EIPS/eip-7685.md
@@ -13,9 +13,9 @@ created: 2024-04-14
 ## Abstract
 
 This proposal defines a general purpose framework for storing contract-triggered
-requests. It extends the execution header and body with a single field each to
-store the request information. This inherently exposes the requests to the
-consensus layer, which can then process each one.
+requests. It extends the execution header with a single field to store the
+request information. This inherently exposes the requests to the consensus
+layer, which can then process each one.
 
 ## Motivation
 
@@ -47,21 +47,6 @@ order by type. For example:
 
 The ordering of requests within a type is to be defined by each request type.
 
-#### Block structure
-
-The block body is appended with a list of requests. RLP encoding of the extended
-block body structure is computed as follows:
-
-```python
-block_body_rlp = rlp([
-    field_0,
-    ...,
-    # Latest block body field before `requests`
-    field_n,
-    [request_0, ..., request_k],
-])
-```
-
 #### Block Header
 
 Extend the header with a new 32 byte value `requests_hash`:
@@ -70,7 +55,7 @@ Extend the header with a new 32 byte value `requests_hash`:
 def compute_requests_hash(list):
     return keccak256(rlp.encode([rlp.encode(req) for req in list]))
 
-block.header.requests_root = compute_requests_hash(block.body.requests)
+block.header.requests_root = compute_requests_hash(requests)
 ```
 
 ### Consensus Layer


### PR DESCRIPTION
This PR removes the requests from the block body. This change is motivated by a simplification to the engine api: https://github.com/ethereum/execution-apis/pull/591

>  Make EL validate requestsHash as a part of blockHash validation, note there is no need to keep requests_hash in the beacon block. CLs that run blockHash validation on their own will still be able to do that by implementing the algo EL uses to compute requestsHash
Make EL validate requestsHash in the EL block header against requests obtained from transaction execution