### PR TITLE
Add EIP: Hardfork Meta - Amsterdam

### DIFF
--- a/EIPS/eip-7600.md
+++ b/EIPS/eip-7600.md
@@ -7,16 +7,18 @@ discussions-to: https://ethereum-magicians.org/t/eip-7600-hardfork-meta-prague-e
 status: Review
 type: Meta
 created: 2024-01-18
-requires: 2537, 2935, 6110, 7002, 7251, 7549, 7594, 7685, 7692, 7702
+requires: 2537, 2935, 6110, 7002, 7251, 7549, 7594, 7685, 7692, 7702, 7723
 ---
 
 ## Abstract
 
-This Meta EIP lists the EIPs formally considered for and included in the Prague/Electra network upgrade.
+This Meta EIP lists the EIPs formally Considered and Scheduled for Inclusion in the Prague/Electra network upgrade.
 
 ## Specification
 
-### EIPs Included  
+Definitions for `Scheduled for Inclusion` and `Considered for Inclusion` can be found in [EIP-7723](./eip-7723.md).
+
+### EIPs Scheduled for Inclusion  
 
 * [EIP-2537](./eip-2537.md): Precompile for BLS12-381 curve operations
 * [EIP-2935](./eip-2935.md): Save historical block hashes in state
@@ -24,27 +26,14 @@ This Meta EIP lists the EIPs formally considered for and included in the Prague/
 * [EIP-7002](./eip-7002.md): Execution layer triggerable exits
 * [EIP-7251](./eip-7251.md): Increase the MAX_EFFECTIVE_BALANCE  
 * [EIP-7549](./eip-7549.md): Move committee index outside Attestation
-* [EIP-7594](./eip-7594.md): PeerDAS - Peer Data Availability Sampling
 * [EIP-7685](./eip-7685.md): General purpose execution layer requests 
 * [EIP-7702](./eip-7702.md): Set EOA account code for one transaction
-* EOF EIPs listed as part of [EIP-7692](./eip-7692.md), namely: 
-    * [EIP-663](./eip-663.md): SWAPN, DUPN and EXCHANGE instructions
-    * [EIP-3540](./eip-3540.md): EOF - EVM Object Format v1
-    * [EIP-3670](./eip-3670.md): EOF - Code Validation
-    * [EIP-4200](./eip-4200.md): EOF - Static relative jumps
-    * [EIP-4750](./eip-4750.md): EOF - Functions
-    * [EIP-5450](./eip-5450.md): EOF - Stack Validation
-    * [EIP-6206](./eip-6206.md): EOF - JUMPF and non-returning functions
-    * [EIP-7069](./eip-7069.md): Revamped CALL instructions
-    * [EIP-7480](./eip-7480.md): EOF - Data section access instructions
-    * [EIP-7620](./eip-7620.md): EOF Contract Creation
-    * [EIP-7698](./eip-7698.md): EOF - Creation transaction
 
 ### EIPs Considered for Inclusion
 
-* RIP-7212: Precompile for secp256r1 Curve Support
-* [EIP-7547](./eip-7547.md): Inclusion lists
 * [EIP-7623](./eip-7623.md): Increase calldata cost
+* [EIP-7742](./eip-7742.md): Uncouple blob count between CL and EL
+* [EIP-7762](./eip-7762.md): Increase MIN_BASE_FEE_PER_BLOB_GAS 
 
 ### Full Specifications 
 
@@ -54,7 +43,7 @@ EIP-6110, EIP-7002 EIP-7251, EIP-7549 and EIP-7594 require changes to Ethereum's
 
 #### Execution Layer
 
-All EOF EIPs, listed in EIP-7692, as well as EIP-2537, EIP-2935, EIP-6110, EIP-7685, and EIP-7002 require changes to Ethereum's execution layer. The EIPs fully specify those changes. 
+EIP-2537, EIP-2935, EIP-6110, EIP-7685, EIP-7002 and EIP-7702 require changes to Ethereum's execution layer. The EIPs fully specify those changes. 
 
 ### Activation 
 

--- a/EIPS/eip-7600.md
+++ b/EIPS/eip-7600.md
@@ -39,7 +39,7 @@ Definitions for `Scheduled for Inclusion` and `Considered for Inclusion` can be 
 
 #### Consensus Layer
 
-EIP-6110, EIP-7002 EIP-7251, EIP-7549 and EIP-7594 require changes to Ethereum's consensus layer. While the EIPs present an overview of these changes, the full specifications can be found in the `specs/electra` and `specs/_features` directories of the `ethereum/consensus-specs` repository.
+EIP-6110, EIP-7002 EIP-7251 and EIP-7549 require changes to Ethereum's consensus layer. While the EIPs present an overview of these changes, the full specifications can be found in the `specs/electra` and `specs/_features` directories of the `ethereum/consensus-specs` repository.
 
 #### Execution Layer
 

--- a/EIPS/eip-7607.md
+++ b/EIPS/eip-7607.md
@@ -12,19 +12,34 @@ requires: 7600
 
 ## Abstract
 
-This Meta EIP lists the EIPs formally considered for & included in the Fusaka network upgrade. 
+This Meta EIP lists the EIPs formally Proposed, Considered for & Scheduled for Inclusion in the Fulu/Osaka network upgrade. 
 
 ## Specification
 
-### Included EIPs 
+
+Definitions for `Scheduled for Inclusion`, `Considered for Inclusion` and `Proposed for Inclusion` can be found in [EIP-7723](./eip-7723.md).
+
+### EIPs Scheduled for Inclusion  
+
+* [EIP-7594](./eip-7594.md): PeerDAS - Peer Data Availability Sampling
+* EOF EIPs listed as part of [EIP-7692](./eip-7692.md), namely: 
+    * [EIP-663](./eip-663.md): SWAPN, DUPN and EXCHANGE instructions
+    * [EIP-3540](./eip-3540.md): EOF - EVM Object Format v1
+    * [EIP-3670](./eip-3670.md): EOF - Code Validation
+    * [EIP-4200](./eip-4200.md): EOF - Static relative jumps
+    * [EIP-4750](./eip-4750.md): EOF - Functions
+    * [EIP-5450](./eip-5450.md): EOF - Stack Validation
+    * [EIP-6206](./eip-6206.md): EOF - JUMPF and non-returning functions
+    * [EIP-7069](./eip-7069.md): Revamped CALL instructions
+    * [EIP-7480](./eip-7480.md): EOF - Data section access instructions
+    * [EIP-7620](./eip-7620.md): EOF Contract Creation
+    * [EIP-7698](./eip-7698.md): EOF - Creation transaction
 
 ### Considered for Inclusion
 
-* [EIP-4762](./eip-4762.md): Statelessness gas cost changes
-* [EIP-6800](./eip-6800.md): Ethereum state using a unified verkle tree
-* [EIP-6873](./eip-6873.md): Preimage retention
-* [EIP-7545](./eip-7545.md): Verkle proof verification precompile
-* [EIP-7667](./eip-7667.md): Raise gas costs of hash functions
+* RIP-7212: Precompile for secp256r1 Curve Support
+
+### Proposed for Inclusion
 
 ### Activation 
 

--- a/EIPS/eip-7773.md
+++ b/EIPS/eip-7773.md
@@ -1,9 +1,9 @@
 ---
-eip: xxxx
+eip: 7773
 title: Hardfork Meta - Amsterdam
 description: EIPs included in the Amsterdam Ethereum network upgrade.
 author: Tim Beiko (@timbeiko)
-discussions-to: https://ethereum-magicians.org/t/eip-x-amsterdam-network-upgrade-meta-thread/21195
+discussions-to: https://ethereum-magicians.org/t/eip-7773-amsterdam-network-upgrade-meta-thread/21195
 status: Draft
 type: Meta
 created: 2024-09-26

--- a/EIPS/eip-amsterdam.md
+++ b/EIPS/eip-amsterdam.md
@@ -1,0 +1,53 @@
+---
+eip: xxxx
+title: Hardfork Meta - Amsterdam
+description: EIPs included in the Amsterdam Ethereum network upgrade.
+author: Tim Beiko (@timbeiko)
+discussions-to: https://ethereum-magicians.org/t/eip-x-amsterdam-network-upgrade-meta-thread/21195
+status: Draft
+type: Meta
+created: 2024-09-26
+requires: 7607, 7723
+---
+
+## Abstract
+
+This Meta EIP lists the EIPs formally Proposed, Considered for & Scheduled for Inclusion in the Amsterdam network upgrade. 
+
+## Specification
+
+Definitions for `Scheduled for Inclusion`, `Considered for Inclusion` and `Proposed for Inclusion` can be found in [EIP-7723](./eip-7723.md).
+
+### EIPs Scheduled for Inclusion  
+
+### Considered for Inclusion
+
+* [EIP-4762](./eip-4762.md): Statelessness gas cost changes
+* [EIP-6800](./eip-6800.md): Ethereum state using a unified verkle tree
+* [EIP-6873](./eip-6873.md): Preimage retention
+* [EIP-7545](./eip-7545.md): Verkle proof verification precompile
+* [EIP-7667](./eip-7667.md): Raise gas costs of hash functions
+
+### Proposed for Inclusion
+
+### Activation 
+
+| Network Name     | Activation Epoch | Activation Timestamp |
+|------------------|------------------|----------------------|
+| Sepolia          |                  |                      |
+| Holešky          |                  |                      |
+| Mainnet          |                  |                      |
+
+**Note**: rows in the table above will be filled as activation times are decided by client teams. 
+
+## Rationale
+
+This Meta EIP provides a global view of all changes included in the Amsterdam network upgrade, as well as links to full specification. 
+
+## Security Considerations
+
+None.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](../LICENSE.md).


### PR DESCRIPTION
This PR formalizes the changes to Pectra agreed to in [ACDE#197](https://github.com/ethereum/pm/issues/1153), namely: 
* Reducing the set of SFI'd Pectra EIPs to those which were already part of [devnet-3](https://notes.ethereum.org/@ethpandaops/pectra-devnet-3)
* CFI'ing EIPs 7742 and 7762 (note that we also agreed to "CFI" a blob count (or target) increase, but don't have an EIP for this yet)
* Moving EOF and PeerDAS from being SFI'd in Pectra to being SFI'd in Fusaka, as well as other Pectra CFI'd EIPs (7212) to CFI'd in Fusaka. 
* Moving Verkle EIPs from being CFI'd in Fusaka to CFI'd for Amsterdam (CL "G" star name TBD)

The PR also adds a pointer to [EIP-7723](https://eips.ethereum.org/EIPS/eip-7723), which defines `Proposed`, `Considered` and `Scheduled for Inclusion`. It supersedes https://github.com/ethereum/EIPs/pull/8846 .

- - - 

**Merge Blockers**
- [x] https://github.com/ethereum/EIPs/pull/8912 
- [x] Amsterdam Meta EIP needs a number