### PR TITLE
Update EIP-7002: add updated excess inhibitor logic

### DIFF
--- a/EIPS/eip-7002.md
+++ b/EIPS/eip-7002.md
@@ -51,6 +51,7 @@ Note, 0x00 withdrawal credentials can be changed into 0x01 withdrawal credential
 | `TARGET_WITHDRAWAL_REQUESTS_PER_BLOCK` | 2 | |
 | `MIN_WITHDRAWAL_REQUEST_FEE` | 1 | |
 | `WITHDRAWAL_REQUEST_FEE_UPDATE_FRACTION` | 17 | |
+| `EXCESS_INHIBITOR` | `2**256-1` | Excess value used to compute the fee before the first system call |
 
 ### Execution layer
 
@@ -126,6 +127,7 @@ The following pseudocode can compute the cost an individual withdrawal request, 
 ```python
 def get_fee() -> int:
     excess = sload(WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS, EXCESS_WITHDRAWAL_REQUESTS_STORAGE_SLOT)
+    require(excess != EXCESS_INHIBITOR, 'Inhibitor still active')
     return fake_exponential(
         MIN_WITHDRAWAL_REQUEST_FEE,
         excess,
@@ -242,7 +244,7 @@ Each withdrawal request must appear in the EIP-7685 requests list in the order t
 caller
 push20 0xfffffffffffffffffffffffffffffffffffffffe
 eq
-push1 0xa0
+push1 0xc7
 jumpi
 
 calldatasize
@@ -264,12 +266,18 @@ calldatasize
 push1 0x38
 eq
 iszero
-push2 0x01ab
+push2 0x01f0
 jumpi
 
 push1 0x11
 push0
 sload
+dup1
+push32 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+eq
+push2 0x01f0
+jumpi
+
 push1 0x01
 dup3
 mul
@@ -282,7 +290,7 @@ push0
 dup3
 gt
 iszero
-push1 0x59
+push1 0x80
 jumpi
 
 dup2
@@ -300,7 +308,7 @@ push1 0x01
 add
 swap2
 swap1
-push1 0x3e
+push1 0x65
 jump
 
 jumpdest
@@ -310,7 +318,7 @@ swap1
 div
 callvalue
 lt
-push2 0x01ab
+push2 0x01f0
 jumpi
 
 push1 0x01
@@ -370,7 +378,7 @@ sub
 dup1
 push1 0x10
 gt
-push1 0xb4
+push1 0xdb
 jumpi
 
 pop
@@ -383,7 +391,7 @@ jumpdest
 dup2
 dup2
 eq
-push2 0x0158
+push2 0x017f
 jumpi
 
 dup1
@@ -480,7 +488,7 @@ mstore8
 mstore8
 push1 0x01
 add
-push1 0xb6
+push1 0xdd
 jump
 
 jumpdest
@@ -489,13 +497,13 @@ add
 dup1
 swap3
 eq
-push2 0x016a
+push2 0x0191
 jumpi
 
 swap1
 push1 0x02
 sstore
-push2 0x0175
+push2 0x019c
 jump
 
 jumpdest
@@ -512,10 +520,10 @@ jumpdest
 push0
 sload
 dup1
-push2 0x049d
+push32 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 eq
 iszero
-push2 0x0184
+push2 0x01c9
 jumpi
 
 pop
@@ -529,13 +537,13 @@ dup3
 dup3
 add
 gt
-push2 0x0199
+push2 0x01de
 jumpi
 
 pop
 pop
 push0
-push2 0x019f
+push2 0x01e4
 jump
 
 jumpdest
@@ -575,17 +583,17 @@ The withdrawal requests contract is deployed like any other smart contract. A sp
   "maxPriorityFeePerGas": null,
   "maxFeePerGas": null,
   "value": "0x0",
-  "input": "0x61049d5f556101af80600f5f395ff33373fffffffffffffffffffffffffffffffffffffffe1460a0573615156028575f545f5260205ff35b36603814156101ab5760115f54600182026001905f5b5f82111560595781019083028483029004916001019190603e565b9093900434106101ab57600154600101600155600354806003026004013381556001015f35815560010160203590553360601b5f5260385f601437604c5fa0600101600355005b6003546002548082038060101160b4575060105b5f5b8181146101585780604c02838201600302600401805490600101805490600101549160601b83528260140152807fffffffffffffffffffffffffffffffff0000000000000000000000000000000016826034015260401c906044018160381c81600701538160301c81600601538160281c81600501538160201c81600401538160181c81600301538160101c81600201538160081c81600101535360010160b6565b910180921461016a5790600255610175565b90505f6002555f6003555b5f548061049d141561018457505f5b6001546002828201116101995750505f61019f565b01600290035b5f555f600155604c025ff35b5f5ffd",
+  "input": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff5f556101f480602d5f395ff33373fffffffffffffffffffffffffffffffffffffffe1460c7573615156028575f545f5260205ff35b36603814156101f05760115f54807fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff146101f057600182026001905f5b5f821115608057810190830284830290049160010191906065565b9093900434106101f057600154600101600155600354806003026004013381556001015f35815560010160203590553360601b5f5260385f601437604c5fa0600101600355005b6003546002548082038060101160db575060105b5f5b81811461017f5780604c02838201600302600401805490600101805490600101549160601b83528260140152807fffffffffffffffffffffffffffffffff0000000000000000000000000000000016826034015260401c906044018160381c81600701538160301c81600601538160281c81600501538160201c81600401538160181c81600301538160101c81600201538160081c81600101535360010160dd565b9101809214610191579060025561019c565b90505f6002555f6003555b5f54807fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff14156101c957505f5b6001546002828201116101de5750505f6101e4565b01600290035b5f555f600155604c025ff35b5f5ffd",
   "v": "0x1b",
   "r": "0x539",
-  "s": "0x48655fec580f6877",
-  "hash": "0xcf76a9eb8c38b162c697b6e58669dc2546284e84d752d79af9c4e49be6bdcb39"
+  "s": "0x10e740537d4d36b9",
+  "hash": "0x1cd8bf929988b27b07ba1c7b898b396c08c484bb0db83fdeb992aa21b5cdf0ce"
 }
 ```
 
 ```
-Sender: 0xAC6AfB9d8491e8b397F65331Ce41e338cBfe1048
-Address: 0x0511Ce19514e1298Fba96de582652A016E2CAaAa
+Sender: 0x57B8c3C2766D0623EA0A499365A6f5A26aD38B47
+Address: 0x09Fc772D0857550724b07B850a4323f39112aAaA
 ```
 
 ### Consensus layer

--- a/EIPS/eip-7251.md
+++ b/EIPS/eip-7251.md
@@ -40,7 +40,7 @@ With the security model of the protocol no longer dependent on a low value for `
 | `TARGET_CONSOLIDATION_REQUESTS_PER_BLOCK` | `1` | |
 | `MIN_CONSOLIDATION_REQUEST_FEE` | `1` | |
 | `CONSOLIDATION_REQUEST_FEE_UPDATE_FRACTION` | `17` | |
-| `EXCESS_INHIBITOR` | `1181` | Excess value used to compute the fee before the first system call |
+| `EXCESS_INHIBITOR` | `2**256-1` | Excess value used to compute the fee before the first system call |
 | `FORK_TIMESTAMP` | *TBD* | Mainnet |
 
 #### Consensus layer
@@ -118,6 +118,7 @@ The following pseudocode can compute the cost of an individual consolidation req
 ```python
 def get_fee() -> int:
     excess = sload(CONSOLIDATION_REQUEST_PREDEPLOY_ADDRESS, EXCESS_CONSOLIDATION_REQUESTS_STORAGE_SLOT)
+    require(excess != EXCESS_INHIBITOR, 'Inhibitor still active')
     return fake_exponential(
         MIN_CONSOLIDATION_REQUEST_FEE,
         excess,
@@ -230,7 +231,7 @@ def reset_consolidation_requests_count():
 caller
 push20 0xfffffffffffffffffffffffffffffffffffffffe
 eq
-push1 0xa8
+push1 0xcf
 jumpi
 
 calldatasize
@@ -252,12 +253,18 @@ calldatasize
 push1 0x60
 eq
 iszero
-push2 0x0155
+push2 0x019a
 jumpi
 
 push1 0x11
 push0
 sload
+dup1
+push32 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+eq
+push2 0x019a
+jumpi
+
 push1 0x01
 dup3
 mul
@@ -270,7 +277,7 @@ push0
 dup3
 gt
 iszero
-push1 0x59
+push1 0x80
 jumpi
 
 dup2
@@ -288,7 +295,7 @@ push1 0x01
 add
 swap2
 swap1
-push1 0x3e
+push1 0x65
 jump
 
 jumpdest
@@ -298,7 +305,7 @@ swap1
 div
 callvalue
 lt
-push2 0x0155
+push2 0x019a
 jumpi
 
 push1 0x01
@@ -364,7 +371,7 @@ sub
 dup1
 push1 0x01
 gt
-push1 0xbc
+push1 0xe3
 jumpi
 
 pop
@@ -377,7 +384,7 @@ jumpdest
 dup2
 dup2
 eq
-push2 0x0102
+push2 0x0129
 jumpi
 
 dup1
@@ -426,7 +433,7 @@ add
 mstore
 push1 0x01
 add
-push1 0xbe
+push1 0xe5
 jump
 
 jumpdest
@@ -435,13 +442,13 @@ add
 dup1
 swap3
 eq
-push2 0x0114
+push2 0x013b
 jumpi
 
 swap1
 push1 0x02
 sstore
-push2 0x011f
+push2 0x0146
 jump
 
 jumpdest
@@ -458,10 +465,10 @@ jumpdest
 push0
 sload
 dup1
-push2 0x049d
+push32 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 eq
 iszero
-push2 0x012e
+push2 0x0173
 jumpi
 
 pop
@@ -475,13 +482,13 @@ dup3
 dup3
 add
 gt
-push2 0x0143
+push2 0x0188
 jumpi
 
 pop
 pop
 push0
-push2 0x0149
+push2 0x018e
 jump
 
 jumpdest
@@ -521,17 +528,17 @@ The consolidation requests contract is deployed like any other smart contract. A
   "maxPriorityFeePerGas": null,
   "maxFeePerGas": null,
   "value": "0x0",
-  "input": "0x61049d5f5561015980600f5f395ff33373fffffffffffffffffffffffffffffffffffffffe1460a8573615156028575f545f5260205ff35b36606014156101555760115f54600182026001905f5b5f82111560595781019083028483029004916001019190603e565b90939004341061015557600154600101600155600354806004026004013381556001015f358155600101602035815560010160403590553360601b5f5260605f60143760745fa0600101600355005b6003546002548082038060011160bc575060015b5f5b8181146101025780607402838201600402600401805490600101805490600101805490600101549260601b84529083601401528260340152906054015260010160be565b9101809214610114579060025561011f565b90505f6002555f6003555b5f548061049d141561012e57505f5b6001546001828201116101435750505f610149565b01600190035b5f555f6001556074025ff35b5f5ffd",
+  "input": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff5f5561019e80602d5f395ff33373fffffffffffffffffffffffffffffffffffffffe1460cf573615156028575f545f5260205ff35b366060141561019a5760115f54807fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff1461019a57600182026001905f5b5f821115608057810190830284830290049160010191906065565b90939004341061019a57600154600101600155600354806004026004013381556001015f358155600101602035815560010160403590553360601b5f5260605f60143760745fa0600101600355005b6003546002548082038060011160e3575060015b5f5b8181146101295780607402838201600402600401805490600101805490600101805490600101549260601b84529083601401528260340152906054015260010160e5565b910180921461013b5790600255610146565b90505f6002555f6003555b5f54807fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff141561017357505f5b6001546001828201116101885750505f61018e565b01600190035b5f555f6001556074025ff35b5f5ffd",
   "v": "0x1b",
   "r": "0x539",
-  "s": "0xc4685471e9c721b4",
-  "hash": "0x57a60c23a80c7df7448c27ca04c7961506029371d90f611b779657e34188dd52"
+  "s": "0x832fdd8c49a416f1",
+  "hash": "0x5e174f35e55bc53c898f3c5e315d81e054363363a0e95dfd6e43c23e8ebb9407"
 }
 ```
 
 ```
-Sender: 0x4a4Fe09214d31cA1509797266683511750e67383
-Address: 0x00706203067988Ab3E2A2ab626EdCD6f28bDBbbb
+Sender: 0x81e9Afa909fe8B57Af2a6FD18862AE9daE3163F4
+Address: 0x01aBEa29659e5e97C95107F20bb753cD3e09bBBb
 ```
 
 #### Block processing


### PR DESCRIPTION
This updates 7002 and 7251 to account for the sys-asm PR https://github.com/lightclient/sys-asm/pull/26. This method is not fragile to gas cost / gas limit changes.