### PR TITLE
Update EIP-7702: 8905 copy

### DIFF
--- a/EIPS/eip-7702.md
+++ b/EIPS/eip-7702.md
@@ -67,11 +67,11 @@ The [EIP-2718](./eip-2718.md) `ReceiptPayload` for this transaction is `rlp([sta
 At the start of executing the transaction, after incrementing the sender's nonce, for each `[chain_id, address, nonce, y_parity, r, s]` tuple do the following:
 
 1. Verify the chain id is either 0 or the chain's current ID.
-2. `authority = ecrecover(keccak(MAGIC || rlp([chain_id, address, nonce])), y_parity, r, s])`
-3. Add `authority` to `accessed_addresses` (as defined in [EIP-2929](./eip-2929.md).)
-4. Verify the code of `authority` is either empty or already delegated.
-5. Verify the nonce of `authority` is equal to `nonce`.
-6. Verify the nonce of `authority` is less than `2**64 - 1`.
+2. Verify the `nonce` is less than `2**64 - 1`.
+3. `authority = ecrecover(keccak(MAGIC || rlp([chain_id, address, nonce])), y_parity, r, s]`
+4. Add `authority` to `accessed_addresses` (as defined in [EIP-2929](./eip-2929.md).)
+5. Verify the code of `authority` is either empty or already delegated.
+6. Verify the nonce of `authority` is equal to `nonce`.
 7. Add `PER_EMPTY_ACCOUNT_COST - PER_AUTH_BASE_COST` gas to the global refund counter if `authority` exists in the trie.
 8. Set the code of `authority` to be `0xef0100 || address`. This is a delegation designation.
 9. Increase the nonce of `authority` by one.

--- a/EIPS/eip-7702.md
+++ b/EIPS/eip-7702.md
@@ -53,7 +53,7 @@ tuple cannot fit within the following bounds:
 
 ```python
 assert auth.chain_id < 2**256
-assert auth.nonce < 2**64 - 1
+assert auth.nonce < 2**64
 assert len(auth.address) == 20
 assert auth.y_parity < 2**256
 assert auth.r < 2**256
@@ -71,9 +71,10 @@ At the start of executing the transaction, after incrementing the sender's nonce
 3. Add `authority` to `accessed_addresses` (as defined in [EIP-2929](./eip-2929.md).)
 4. Verify the code of `authority` is either empty or already delegated.
 5. Verify the nonce of `authority` is equal to `nonce`.
-6. Add `PER_EMPTY_ACCOUNT_COST - PER_AUTH_BASE_COST` gas to the global refund counter if `authority` exists in the trie.
-7. Set the code of `authority` to be `0xef0100 || address`. This is a delegation designation.
-8. Increase the nonce of `authority` by one.
+6. Verify the nonce of `authority` is less than `2**64 - 1`.
+7. Add `PER_EMPTY_ACCOUNT_COST - PER_AUTH_BASE_COST` gas to the global refund counter if `authority` exists in the trie.
+8. Set the code of `authority` to be `0xef0100 || address`. This is a delegation designation.
+9. Increase the nonce of `authority` by one.
 
 If any of the above steps fail, immediately stop processing that tuple and continue to the next tuple in the list. It will in the case of multiple tuples for the same authority, set the code using the address in the last valid occurrence.
 

--- a/EIPS/eip-7702.md
+++ b/EIPS/eip-7702.md
@@ -53,7 +53,7 @@ tuple cannot fit within the following bounds:
 
 ```python
 assert auth.chain_id < 2**256
-assert auth.nonce < 2**64
+assert auth.nonce < 2**64 - 1
 assert len(auth.address) == 20
 assert auth.y_parity < 2**256
 assert auth.r < 2**256


### PR DESCRIPTION
rebased copy of #8905, didn't have write access to the branch

repost:

It is important to not allow `authorization.nonce == 2**64 - 1`, because in this case incrementing authority nonce will result in nonce overflowing 64 bit, which is not allowed since [EIP-2681](https://eips.ethereum.org/EIPS/eip-2681)

~~Alternative to adding this to the transaction validity rules could be additional check during delegation setting, but it is simpler this way (fewer checks) and more aligned with existing transaction types validity.~~ It is checked at authorization list processing now.
