### PR TITLE
Update EIP-4762: value-bearing clarification

### DIFF
--- a/EIPS/eip-4762.md
+++ b/EIPS/eip-4762.md
@@ -115,7 +115,7 @@ We define **write events** as follows. Note that when a write takes place, an ac
 
 #### Write events for account headers
 
-When a nonzero-balance-sending `*CALL` or `SELFDESTRUCT` with a given sender and recipient takes place, process these write events:
+When a nonzero-balance-sending `CALL` or `SELFDESTRUCT` with a given sender and recipient takes place, process these write events:
 
 ```
 (caller, 0, BASIC_DATA_LEAF_KEY)
@@ -198,13 +198,13 @@ Reduce gas cost:
 
  * `CREATE`/`CREATE2` to 1000
 
-|Constant |Value|
-|-|-|
-|`WITNESS_BRANCH_COST`|1900|
-|`WITNESS_CHUNK_COST`	|200|
-|`SUBTREE_EDIT_COST`	|3000|
-|`CHUNK_EDIT_COST`    |500|
-|`CHUNK_FILL_COST`    |6200|
+| Constant              | Value |
+| --------------------- | ----- |
+| `WITNESS_BRANCH_COST` | 1900  |
+| `WITNESS_CHUNK_COST`  | 200   |
+| `SUBTREE_EDIT_COST`   | 3000  |
+| `CHUNK_EDIT_COST`     | 500   |
+| `CHUNK_FILL_COST`     | 6200  |
 
 When executing a transaction, maintain four sets:
 


### PR DESCRIPTION
This PR downgrades a generic reference to `*CALL` instructions to only `CALL`.