### PR TITLE
Update EIP-2537: Replace "multiexponentiation"

### DIFF
--- a/EIPS/eip-2537.md
+++ b/EIPS/eip-2537.md
@@ -14,7 +14,7 @@ created: 2020-02-21
 
 Add functionality to efficiently perform operations over the BLS12-381 curve, including those for BLS signature verification.
 
-Along with the curve arithmetic, multiexponentiation operations are included to efficiently aggregate public keys or individual signer's signatures during BLS signature verification.
+Along with the curve arithmetic, multi-scalar-multiplication operations are included to efficiently aggregate public keys or individual signer's signatures during BLS signature verification.
 
 ## Motivation
 


### PR DESCRIPTION
Fully replace "multiexponentiation" with "multi-scalar-multiplication".