### PR TITLE
Update EIP-2537: Remove redundant MUL precompiles

### DIFF
--- a/EIPS/eip-2537.md
+++ b/EIPS/eip-2537.md
@@ -28,22 +28,18 @@ The motivation of this precompile is to add a cryptographic primitive that allow
 |---------------------|-------|--------------------|
 | `FORK_TIMESTAMP`    | *TBD* | Mainnet            |
 | BLS12_G1ADD         | 0x0b  | precompile address |
-| BLS12_G1MUL         | 0x0c  | precompile address |
-| BLS12_G1MSM         | 0x0d  | precompile address |
-| BLS12_G2ADD         | 0x0e  | precompile address |
-| BLS12_G2MUL         | 0x0f  | precompile address |
-| BLS12_G2MSM         | 0x10  | precompile address |
-| BLS12_PAIRING_CHECK | 0x11  | precompile address |
-| BLS12_MAP_FP_TO_G1  | 0x12  | precompile address |
-| BLS12_MAP_FP2_TO_G2 | 0x13  | precompile address |
+| BLS12_G1MSM         | 0x0c  | precompile address |
+| BLS12_G2ADD         | 0x0d  | precompile address |
+| BLS12_G2MSM         | 0x0e  | precompile address |
+| BLS12_PAIRING_CHECK | 0x0f  | precompile address |
+| BLS12_MAP_FP_TO_G1  | 0x10  | precompile address |
+| BLS12_MAP_FP2_TO_G2 | 0x11  | precompile address |
 
-If `block.timestamp >= FORK_TIMESTAMP` we introduce *nine* separate precompiles to perform the following operations:
+If `block.timestamp >= FORK_TIMESTAMP` we introduce *seven* separate precompiles to perform the following operations:
 
 - BLS12_G1ADD - to perform point addition in G1 (curve over base prime field) with a gas cost of `500` gas
-- BLS12_G1MUL - to perform point multiplication in G1 (curve over base prime field) with a gas cost of `12000` gas
 - BLS12_G1MSM - to perform multi-scalar-multiplication (MSM) in G1 (curve over base prime field) with a gas cost formula defined in the corresponding section
 - BLS12_G2ADD - to perform point addition in G2 (curve over quadratic extension of the base prime field) with a gas cost of `800` gas
-- BLS12_G2MUL - to perform point multiplication in G2 (curve over quadratic extension of the base prime field) with a gas cost of `45000` gas
 - BLS12_G2MSM - to perform multi-scalar-multiplication (MSM) in G2 (curve over quadratic extension of the base prime field) with a gas cost formula defined in the corresponding section
 - BLS12_PAIRING_CHECK - to perform a pairing operations between a set of *pairs* of (G1, G2) points a gas cost formula defined in the corresponding section
 - BLS12_MAP_FP_TO_G1 - maps base field element into the G1 point with a gas cost of `5500` gas
@@ -145,17 +141,6 @@ Note:
 
 There is no subgroup check for the G1 addition precompile.
 
-#### ABI for G1 multiplication
-
-G1 multiplication call expects `160` bytes as an input that is interpreted as byte concatenation of encoding of a G1 point (`128` bytes) and encoding of a scalar value (`32` bytes). Output is an encoding of the multiplication operation result - a single G1 point (`128` bytes).
-
-Error cases:
-
-- Invalid coordinate encoding
-- An input is neither a point on the G1 elliptic curve nor the infinity point
-- An input is on the G1 elliptic curve but not in the correct subgroup
-- Input has invalid length
-
 #### ABI for G1 MSM
 
 G1 MSM call expects `160*k` (`k` being a **positive** integer) bytes as an input that is interpreted as byte concatenation of `k` slices each of them being a byte concatenation of encoding of a G1 point (`128` bytes) and encoding of a scalar value (`32` bytes). Output is an encoding of MSM operation result - a single G1 point (`128` bytes).
@@ -180,17 +165,6 @@ Error cases:
 Note:
 
 There is no subgroup check for the G2 addition precompile.
-
-#### ABI for G2 multiplication
-
-G2 multiplication call expects `288` bytes as an input that is interpreted as byte concatenation of encoding of G2 point (`256` bytes) and encoding of a scalar value (`32` bytes). Output is an encoding of multiplication operation result - single G2 point (`256` bytes).
-
-Error cases:
-
-- Invalid coordinate encoding
-- An input is neither a point on the G2 elliptic curve nor the infinity point
-- An input is on the G2 elliptic curve but not in the correct subgroup
-- Input has invalid length
 
 #### ABI for G2 MSM
 
@@ -275,7 +249,7 @@ Assuming `EcRecover` precompile as a baseline.
 
 MSMs are expected to be performed by Pippenger's algorithm (we can also say that it **must** be performed by Pippenger's algorithm to have a speedup that results in a discount over naive implementation by multiplying each pair separately and adding the results). For this case there was a table prepared for discount in case of `k <= 128` points in the MSM with a discount cap `max_discount` for `k > 128`.
 
-To avoid non-integer arithmetic, the call cost is calculated as `(k * multiplication_cost * discount) / multiplier` where `multiplier = 1000`, `k` is a number of (scalar, point) pairs for the call, `multiplication_cost` is a corresponding single multiplication call cost for G1/G2.
+To avoid non-integer arithmetic, the call cost is calculated as `(k * multiplication_cost * discount) / multiplier` where `multiplier = 1000`, `k` is a number of (scalar, point) pairs for the call, `multiplication_cost` is a corresponding G1/G2 multiplication cost presented above.
 
 G1 and G2 are priced separately, each having their own discount table and `max_discount`.
 
@@ -354,13 +328,18 @@ The motivation section covers a total motivation to have operations over the BLS
 
 Explicit separate MSM operation that allows one to save execution time (so gas) by both the algorithm used (namely Pippenger's algorithm) and (usually forgotten) by the fact that `CALL` operation in Ethereum is expensive (at the time of writing), so one would have to pay non-negligible overhead if e.g. for MSM of `100` points would have to call the multiplication precompile `100` times and addition for `99` times (roughly `138600` would be saved).
 
+### No dedicated MUL call
+
+Dedicated MUL precompiles which perform single G1/G2 point by scalar multiplication have exactly the same ABI as MSM with `k == 1`.
+MSM has to inspect the input length to reject inputs of invalid lengths. Therefore, it should recognize the case of `k == 1` and invoke the underlying implementation of single point multiplication to avoid the overhead of more complex multi-scalar multiplication algorithm.
+
 ## Backwards Compatibility
 
 There are no backward compatibility questions.
 
 ### Subgroup checks
 
-Scalar multiplications, MSMs and pairings MUST perform a subgroup check.
+MSMs and pairings MUST perform a subgroup check.
 Implementations SHOULD use the optimized subgroup check method detailed in a dedicated [document](../assets/eip-2537/fast_subgroup_checks.md).
 On any input that fails the subgroup check, the precompile MUST return an error.
 As endomorphism acceleration requires input on the correct subgroup, implementers MAY use endomorphism acceleration.


### PR DESCRIPTION
This removes `BLS12_G1MUL` and `BLS12_G2MUL` precompiles because they are trivially replaceable by corresponding MSM precompiles.

This reduces the number of precompile's addresses defined in this EIP from 9 to 7. The addresses of remaining 7 precompiles are changed to be continues.

The Rationale entry describes why this change make sense. Additionally, the cost of MSM for single input (`k==1`) has been corrected to match the original MUL cost. The specification now suggests how this case should be implemented.
Moreover, because of the ABI compatibility between MUL and MSM all existing tests for MULs can be easily converted to tests for MSMs.

The PoC of MUL and MSM precompiles equivalence is provided in [evmone PR#1042](https://github.com/ethereum/evmone/pull/1042).

The adjustment of the MSM implementation for single input in [evmone PR#1046](https://github.com/ethereum/evmone/pull/1046).