### PR TITLE
Update EIP-6110: harmonize request eips with 7685 changes

### DIFF
--- a/EIPS/eip-6110.md
+++ b/EIPS/eip-6110.md
@@ -66,12 +66,10 @@ Deposits are a type of [EIP-7685](./eip-7685.md) request, with the following enc
 
 ```python
 request_type = DEPOSIT_REQUEST_TYPE
-request_data = pubkey ++ withdrawal_credentials ++ amount ++ signature ++ index
+request_data = get_deposit_request_data(block.receipts)
 ```
 
-Note that the request payload is just the concatenation of the elements returned by the contract.
-The encoded deposits will be committed to by the `requestsHash` in the block header
-following the format defined by EIP-7685.
+Note that `deposits` is the list of the deposits parsed from the block's logs.
 
 #### Block validity
 
@@ -104,8 +102,8 @@ def get_deposit_request_data(receipts)
                 deposit_request = event_data_to_deposit_request(log.data)
                 deposit_requests.append(deposit_request)
 
-    # Concatenate list of deposit request data and prepend the type
-    return DEPOSIT_REQUEST_TYPE + b''.join(deposit_requests)
+    # Concatenate list of deposit request data
+    return b''.join(deposit_requests)
 ```
 
 ### Consensus layer

--- a/EIPS/eip-7002.md
+++ b/EIPS/eip-7002.md
@@ -73,10 +73,8 @@ Note that `amount` is returned by the contract little-endian, and must be encode
 
 ```python
 request_type = WITHDRAWAL_REQUEST_TYPE
-request_data = source_address ++ validator_pubkey ++ amount
+request_data = ssz.serialize(read_withdrawal_requests())
 ```
-
-The size of encoded withdrawal `request_data` is 76 bytes.
 
 #### Withdrawal Request Contract
 

--- a/EIPS/eip-7002.md
+++ b/EIPS/eip-7002.md
@@ -68,7 +68,7 @@ with type `0x01` and consists of the following fields:
 2. `validator_pubkey`: `Bytes48`
 3. `amount:` `uint64`
 
-The [EIP-7685](./eip-7685) encoding of a withdrawal request is computed as follows.
+The [EIP-7685](./eip-7685.md) encoding of a withdrawal request is computed as follows.
 Note that `amount` is returned by the contract little-endian, and must be encoded as such.
 
 ```python

--- a/EIPS/eip-7251.md
+++ b/EIPS/eip-7251.md
@@ -61,12 +61,11 @@ The new consolidation request is an [EIP-7685](./eip-7685.md) request with type 
 2. `source_pubkey`: `Bytes48`
 3. `target_pubkey`: `Bytes48`
 
-The [EIP-7685](./eip-7685.md) encoding of a consolidation request is as follows. Note we simply return the
-encoded request value as returned by the contract.
+The [EIP-7685](./eip-7685.md) encoding of a consolidation request is as follows. Note we simply return the encoded request value as returned by the contract.
 
 ```python
 request_type = CONSOLIDATION_REQUEST_TYPE
-request_data = source_address ++ source_pubkey ++ target_pubkey
+request_data = ssz.serialize(dequeue_consolidation_requests())
 ```
 
 #### Consolidation request contract


### PR DESCRIPTION
This cleans up 6110, 7002, and 7251 with respect to the modifications to 7685. Specifically, `request_data` now refers to the output of the system call to the contracts, not an individual request object's data.