### PR TITLE
Update EIP-4762: add clarification regarding OOG behavior

### DIFF
--- a/EIPS/eip-4762.md
+++ b/EIPS/eip-4762.md
@@ -229,7 +229,7 @@ When a **write** event of `(address, sub_key, leaf_key)` occurs, perform the fol
 
 Note that tree keys can no longer be emptied: only the values `0...2**256-1` can be written to a tree key, and 0 is distinct from `None`. Once a tree key is changed from `None` to not-`None`, it can never go back to `None`.
 
-Note that values should only be added to the witness if there is sufficient gas to cover their associated event costs.
+Note that values should only be added to the witness if there is sufficient gas to cover their associated event costs. If there is not enough gas to cover the event costs, all the remaining gas should be consumed.
 
 `CREATE*` and `*CALL` reserve 1/64th of the gas before the nested execution. In order to match the behavior of this charge with the pre-fork behavior of access lists: 
 


### PR DESCRIPTION
This PR clarifies in the spec how implementations should treat OOG situations on write/read events.

We found a disagreement on this aspect in `execution-spec-tests`, so it's worth clarifying.

cc @gballet @tanishqjasoria @g11tech 
