### PR TITLE
Update EIP-7002: move ssz serialization into system call

### DIFF
--- a/EIPS/eip-7002.md
+++ b/EIPS/eip-7002.md
@@ -73,7 +73,7 @@ Note that `amount` is returned by the contract little-endian, and must be encode
 
 ```python
 request_type = WITHDRAWAL_REQUEST_TYPE
-request_data = ssz.serialize(read_withdrawal_requests())
+request_data = read_withdrawal_requests()
 ```
 
 #### Withdrawal Request Contract
@@ -172,7 +172,7 @@ def read_withdrawal_requests():
     reqs = dequeue_withdrawal_requests()
     update_excess_withdrawal_requests()
     reset_withdrawal_requests_count()
-    return reqs
+    return ssz.serialize(reqs)
 
 ###########
 # Helpers #

--- a/EIPS/eip-7251.md
+++ b/EIPS/eip-7251.md
@@ -65,7 +65,7 @@ The [EIP-7685](./eip-7685.md) encoding of a consolidation request is as follows.
 
 ```python
 request_type = CONSOLIDATION_REQUEST_TYPE
-request_data = ssz.serialize(dequeue_consolidation_requests())
+request_data = dequeue_consolidation_requests()
 ```
 
 #### Consolidation request contract
@@ -162,7 +162,7 @@ def process_consolidation_requests():
     reqs = dequeue_consolidation_requests()
     update_excess_consolidation_requests()
     reset_consolidation_requests_count()
-    return reqs
+    return ssz.serialize(reqs)
 
 ###########
 # Helpers #


### PR DESCRIPTION
This PR should make it clearer that it is the system contract's responsibility to do the ssz serialization and not the caller (i.e. the execution layer client).