### PR TITLE
Dynamic target base fee

### DIFF
--- a/EIPS/eip-dynamic-target-base-fee.md
+++ b/EIPS/eip-dynamic-target-base-fee.md
@@ -48,7 +48,7 @@ nextEpochTargetBlockGas = min(MAX_BLOCK_GAS, previousEpochTargetBlockGas + (targ
 
 BLOB_SIZE = 125000
 meanL2TxCost = average(blobCostsForLastEpoch) * L2_TX_COMPRESSED_SIZE / BLOB_SIZE
-l2TxCostDiff =  meanL2TxCost - targetL2TxCost
+l2TxCostDiff = meanL2TxCost - targetL2TxCost
 targetBlobCountDirection = -1 if l2TxCostDiff < -L2_TX_COST_CHANGE_MARGIN else (1 if l2TxCostDiff > L2_TX_COST_CHANGE_MARGIN else 0)
 nextEpochBlobCount = min(MAX_BLOB_COUNT, previousEpochTargetBlobCount + (targetBlobCountDirection * TARGET_BLOB_COUNT_CHANGE_RATE))
 ```

--- a/EIPS/eip-dynamic-target-base-fee.md
+++ b/EIPS/eip-dynamic-target-base-fee.md
@@ -12,7 +12,7 @@ requires: 7623, 7742, 7778
 
 ## Abstract
 
-This EIP proposes to modify the EIP-1559 mechanism to make the target block size and blob count adjust dynamically. This adjustment will target a specific price for a simple transfer on L1 (in the case of target block size) and on L2 (in the case of target blob count).
+This EIP proposes to modify the EIP-1559 mechanism to make the target block gas and blob count adjust dynamically. This adjustment will target a specific price for a simple transfer on L1 (in the case of target block gas) and on L2 (in the case of target blob count).
 
 ## Motivation
 
@@ -31,12 +31,12 @@ Ethereum currently uses an arbitrary target of 50% capacity, with EIP-1559 smoot
 
 ### Dynamic targeting
 
-The target block size and blob count change each epoch based on the mean transaction cost over the previous epoch. The cost of L2 transaction can be estimated using the minimum theoretical compressed size of a basic transfer.
+The target block gas and blob count change each epoch based on the mean transaction cost over the previous epoch. The cost of L2 transaction can be estimated using the minimum theoretical compressed size of a basic transfer.
 
 Calculating targets:
 
 ```python
-nextEpochTargetBlockSize = min(MAX_BLOCK_SIZE, 8 * (((targetL1TxCost - meanL1TxCost) / 21000) - 1) * previousTargetBlockSize)
+nextEpochTargetBlockGas = min(MAX_BLOCK_SIZE, 8 * (((targetL1TxCost - meanL1TxCost) / 21000) - 1) * previousTargetBlockGas)
 L2_TX_SIZE = L2_TX_COMPRESSED_SIZE / 125000
 meanL2TxCost = average(L2_TX_SIZE * blobCost)
 nextEpochBlobCount = min(MAX_BLOB_COUNT, round(8 * (((targetL2TxCost - meanL2TxCost) / L2_TX_SIZE) - 1) * previousTargetBlobCount))

--- a/EIPS/eip-dynamic-target-base-fee.md
+++ b/EIPS/eip-dynamic-target-base-fee.md
@@ -18,7 +18,7 @@ This EIP proposes to modify the EIP-1559 mechanism to make the target block size
 
 Ethereum currently uses an arbitrary target of 50% capacity, with EIP-1559 smoothing out short term spikes. This means that the de facto capacity is much lower than the maxiumum capacity, as in practice gas prices would rise exponentially as the maximum capacity is reached. A dynamic target adjusts to longer term changes in demand, which has benefits in two cases:
 - When demand is high the target increases, allowing throughput to increase without exorbitant gas fees.
-- When demand is low compared to maximum capacity (for example after a large increase in blob count), the protocol can still receive revenue without undercharging for blockspace or blobspace.
+- When demand is low compared to maximum capacity (for example after a large increase in blob count), the target decreases so that the protocol can still receive revenue without undercharging for blockspace or blobspace.
 
 ## Specification
 

--- a/EIPS/eip-dynamic-target-base-fee.md
+++ b/EIPS/eip-dynamic-target-base-fee.md
@@ -1,0 +1,69 @@
+---
+title: Dynamic target base fee
+description: 
+author: Marc Harvey-Hill (@Marchhill)
+discussions-to: <URL>
+status: Draft
+type: Standards Track
+category: Core
+created: 2024-10-15
+requires: 7623, 7742, 7778
+---
+
+## Abstract
+
+This EIP proposes to modify the EIP-1559 mechanism to make the target block size and blob count adjust dynamically. This adjustment will target a specific price for a simple transfer on L1 (in the case of target block size) and on L2 (in the case of target blob count).
+
+## Motivation
+
+Ethereum currently uses an arbitrary target of 50% capacity, with EIP-1559 smoothing out short term spikes. This means that the de facto capacity is much lower than the maxiumum capacity, as in practice gas prices would rise exponentially as the maximum capacity is reached. A dynamic target adjusts to longer term changes in demand, which has benefits in two cases:
+- When demand is high the target increases, allowing throughput to increase without exorbitant gas fees.
+- When demand is low compared to maximum capacity (for example after a large increase in blob count), the protocol can still receive revenue without undercharging for blockspace or blobspace.
+
+## Specification
+
+### Parameters
+
+| Parameter | Value |
+| - | - |
+| `FORK_TIMESTAMP` | TBD |
+| `L2_TX_COMPRESSED_SIZE` | `23` |
+
+### Dynamic targeting
+
+The target block size and blob count change each epoch based on the mean transaction cost over the previous epoch. The cost of L2 transaction can be estimated using the minimum theoretical compressed size of a basic transfer.
+
+Calculating targets:
+
+```python
+nextEpochTargetBlockSize = min(MAX_BLOCK_SIZE, 8 * (((targetL1TxCost - meanL1TxCost) / 21000) - 1) * previousTargetBlockSize)
+L2_TX_SIZE = L2_TX_COMPRESSED_SIZE / 125000
+meanL2TxCost = average(L2_TX_SIZE * blobCost)
+nextEpochBlobCount = min(MAX_BLOB_COUNT, round(8 * (((targetL2TxCost - meanL2TxCost) / L2_TX_SIZE) - 1) * previousTargetBlobCount))
+```
+
+### Voting
+
+Each epoch, validators can submit a vote for the target L1 and L2 transaction costs that will be used in calculations for the next epoch. Votes can be hidden with ZK-proofs. The resulting target is the average of all votes weighted by relative stake. (todo: add details to this part).
+
+## Rationale
+
+### Voting
+
+Validators voting on a target fee for transactions allows for a stable, neutral index to track. An alternative approach could be to target some arbitrary constant cost for a transaction in ETH, but this risks fees becoming too high in the event of an increase in the value of ETH. Yet another approach would be to track a target cost in fiat, but introducing ETH price oracles into the protocol could be an attack vector. In practice the community may reach rough consensus on a reasonable fiat cost to target, and validator votes would serve as a credibly neutral oracle.
+
+## Backwards Compatibility
+
+todo
+
+## Test Cases
+
+todo
+
+## Security Considerations
+
+The average block size MAY increase up to the maximum. This is why [EIP-7623](./eip-7623.md) and [EIP-7778](./eip-7888.md) are required to reduce the maximum block size to a safe amount.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](../LICENSE.md).

--- a/EIPS/eip-dynamic-target-base-fee.md
+++ b/EIPS/eip-dynamic-target-base-fee.md
@@ -61,7 +61,7 @@ Each epoch, validators can submit a vote for the target L1 and L2 transaction co
 
 ### Voting
 
-Validators voting on a target fee for transactions allows for a stable, neutral index to track. An alternative approach could be to target some arbitrary constant cost for a transaction in ETH, but this risks fees becoming too high in the event of an increase in the value of ETH. Yet another approach would be to track a target cost in fiat, but introducing ETH price oracles into the protocol could be an attack vector. In practice the community may reach rough consensus on a reasonable fiat cost to target, and validator votes would serve as a credibly neutral oracle.
+Validators voting on a desired transaction cost could be a credibly neutral index to track. An alternative approach could be to target some arbitrary constant cost for a transaction in ETH, but this risks fees becoming too high in the event of an increase in the value of ETH. Yet another approach would be to track a target cost in fiat, but introducing ETH price oracles into the protocol could be an attack vector. In practice the community may reach rough consensus on a reasonable fiat cost to target, and validator votes would serve as a credibly neutral oracle.
 
 ## Backwards Compatibility
 

--- a/EIPS/eip-dynamic-target-base-fee.md
+++ b/EIPS/eip-dynamic-target-base-fee.md
@@ -12,7 +12,7 @@ requires: 7623, 7742, 7778
 
 ## Abstract
 
-This EIP proposes to modify the EIP-1559 mechanism to make the target block gas and blob count adjust dynamically. This adjustment will target a specific price for a simple transfer on L1 (in the case of target block gas) and on L2 (in the case of target blob count).
+This EIP proposes to modify the EIP-1559 mechanism to make the target block gas and blob count adjust dynamically. This adjustment will target a specific price for a simple transfer on L1 (in the case of target block gas) and on L2 (in the case of target blob count). The price target will be set each epoch through validators voting.
 
 ## Motivation
 
@@ -33,7 +33,7 @@ Ethereum currently uses an arbitrary target of 50% capacity, with EIP-1559 smoot
 
 ### Dynamic targeting
 
-The target block gas and blob count change each epoch based on the mean transaction cost over the previous epoch. The cost of L2 transaction can be estimated using the minimum theoretical compressed size of a basic transfer.
+The target block gas and blob count change each epoch based on the mean transaction cost over the previous epoch. The cost of an L2 transaction can be estimated using the minimum theoretical compressed size of a basic transfer.
 
 Calculating targets:
 

--- a/EIPS/eip-dynamic-target-base-fee.md
+++ b/EIPS/eip-dynamic-target-base-fee.md
@@ -61,7 +61,7 @@ nextEpochBlobCount = min(MAX_BLOB_COUNT, previousEpochTargetBlobCount + (targetB
 
 A constant transaction cost target can keep transaction costs for end users affordable. Volatility in the price of ETH would affect affordability, but is unlikely to be significant compared to normal fluctuations in gas costs due to spikes in activity. In future the costs could be adjusted in the case of changes in the order of magnitude of ETH price.
 
-An alternative approach would be to track a target transaction cost in fiat, but chosing a specific fiat currency is not credibly neutral, and introducing ETH price oracles into the protocol could be an attack vector. Yet another alternative could be to have validators vote on the target price, but they may have conflicts of interest (for example if they are blobspace consumers) so again this is not credibly neutral.
+An alternative approach would be to track a target transaction cost in fiat, but chosing a specific fiat currency is not credibly neutral, and introducing exchange rate oracles into the protocol could be an attack vector. Yet another alternative could be to have validators vote on the target price, but they may have conflicts of interest (for example if they are blobspace consumers) so again this is not credibly neutral.
 
 ## Backwards Compatibility
 

--- a/EIPS/eip-dynamic-target-base-fee.md
+++ b/EIPS/eip-dynamic-target-base-fee.md
@@ -61,7 +61,7 @@ nextEpochBlobCount = min(MAX_BLOB_COUNT, previousEpochTargetBlobCount + (targetB
 
 A constant transaction cost target can keep transaction costs for end users affordable. Volatility in the price of ETH would affect affordability, but is unlikely to be significant compared to normal fluctuations in gas costs due to spikes in activity. In future the costs could be adjusted in the case of changes in the order of magnitude of ETH price.
 
-An alternative approach would be to track a target transaction cost in fiat, but chosing a specific fiat currency is not credibly neutral, and introducing exchange rate oracles into the protocol could be an attack vector. Yet another alternative could be to have validators vote on the target price, but they may have conflicts of interest (for example if they are blobspace consumers) so again this is not credibly neutral.
+An alternative approach would be to track a target transaction cost in fiat, but chosing a specific fiat currency is not credibly neutral, and introducing exchange rate oracles into the protocol could be an attack vector. Yet another alternative could be to have validators vote on the target transaction cost, but they may have conflicts of interest (for example if they are blobspace consumers) so again this is not credibly neutral.
 
 ## Backwards Compatibility
 

--- a/EIPS/eip-dynamic-target-base-fee.md
+++ b/EIPS/eip-dynamic-target-base-fee.md
@@ -27,6 +27,8 @@ Ethereum currently uses an arbitrary target of 50% capacity, with EIP-1559 smoot
 | Parameter | Value |
 | - | - |
 | `FORK_TIMESTAMP` | TBD |
+| `TARGET_BLOCK_GAS_CHANGE_RATE` | TBD |
+| `TARGET_BLOB_COUNT_CHANGE_RATE` | `1` |
 | `L2_TX_COMPRESSED_SIZE` | `23` |
 
 ### Dynamic targeting
@@ -36,10 +38,15 @@ The target block gas and blob count change each epoch based on the mean transact
 Calculating targets:
 
 ```python
-nextEpochTargetBlockGas = min(MAX_BLOCK_SIZE, 8 * (((targetL1TxCost - meanL1TxCost) / 21000) - 1) * previousTargetBlockGas)
-L2_TX_SIZE = L2_TX_COMPRESSED_SIZE / 125000
-meanL2TxCost = average(L2_TX_SIZE * blobCost)
-nextEpochBlobCount = min(MAX_BLOB_COUNT, round(8 * (((targetL2TxCost - meanL2TxCost) / L2_TX_SIZE) - 1) * previousTargetBlobCount))
+L1_TX_SIZE = 21000
+meanL1TxCost = average(gasCostsForTxsLastEpoch) * L1_TX_SIZE
+increaseTargetBlockGas = targetL1TxCost <= meanL1TxCost
+nextEpochTargetBlockGas = min(MAX_BLOCK_GAS, previousEpochTargetBlockGas + (TARGET_BLOCK_GAS_CHANGE_RATE if increaseTargetBlockGas else -TARGET_BLOCK_GAS_CHANGE_RATE))
+
+BLOB_SIZE = 125000
+meanL2TxCost = average(blobCostsForLastEpoch) * L2_TX_COMPRESSED_SIZE / BLOB_SIZE
+increaseTargetBlobCount = targetL2TxCost <= meanL2TxCost
+nextEpochBlobCount = min(MAX_BLOB_COUNT, previousEpochTargetBlobCount + (TARGET_BLOB_COUNT_CHANGE_RATE if increaseTargetBlobCount else -TARGET_BLOB_COUNT_CHANGE_RATE))
 ```
 
 ### Voting


### PR DESCRIPTION
This EIP proposes to make the target blob count adjust dynamically up to a safe maximum target. This adjustment will target a constant price in ETH for blobs, aiming for consistent costs for L2 transactions.