### PR TITLE
Update EIP-7742: update the required EL headers and the gas fee mecha…

### DIFF
--- a/EIPS/eip-7742.md
+++ b/EIPS/eip-7742.md
@@ -2,7 +2,7 @@
 eip: 7742
 title: Uncouple blob count between CL and EL
 description: Have CL verify blob maximum and have EL get target value from CL
-author: Alex Stokes (@ralexstokes)
+author: Alex Stokes (@ralexstokes), Gajinder Singh (@g11tech)
 discussions-to: https://ethereum-magicians.org/t/eip-7742-uncouple-blob-count-between-cl-and-el/20550
 status: Review
 type: Standards Track
@@ -61,20 +61,37 @@ to preserve the security of optimistic sync.
 
 ## Specification
 
-### Block structure and validity
+### EL Block structure and validity
 
 Upon activation of this EIP, execution clients **MUST** extend the header schema with an
-additional 64-bit field: the `target_blob_count`. This value is set to the current target blob count. The Engine API
-is modified along with this EIP to provide the `target_blob_count` with each payload and implementations can use this
-value to correctly set the block header field.
+additional 64-bit field: the `target_blob_gas` and `max_bob_gas` to allow target to be dynamically upgraded against max by the CLs as well as to not have an assumed static max vs target relationship.
 
-Validity of the `target_blob_count` is guaranteed from the consensus layer, much like how withdrawals are handled.
+Because the of the dynamic block target and max, the pricing mechanism will need to be modified from simple exponentiation of `excess_blob_gas`. It will be much simpler to now follow the block `base_fee` mechanism. So we retire `excess_blob_gas` mechanism and we introduce `blob_base_fee` as follows:
 
-When verifying a block, execution clients **MUST** ensure the target blob count in the block header matches the one
+```python
+  def calcBlockBlobBaseFee(parent: Header)
+    const blockExcessGas = abs(parent.blobGasUsed - parent.targetBlobGas)
+    # get update fraction that limits the gas update factor to <= 1.125 on either direction
+    # 3338477÷393216 = 8.49
+    const blockUpdateFraction = ciel(max(parent.targetBlobGas, parent.maxBlobGas - parent.targetBlobGas) * 8.49)
+    const gasUpdateFactor  = fakeExponential(1, blockExcessGas, blockUpdateFraction)
+    if(block.blobGasUsed >= block.targetBlobGas)
+      return parent.blobBaseFee * gasUpdateFactor
+    else
+      return max(ciel(parent.blobBaseFee/gasUpdateFactor), MIN_BLOB_BASE_FEE)
+
+  def BuildBlock(...)
+    ...
+    const blobBaseFee = calcBlockBlobBaseFee(parent)
+    ...
+```
+
+Validity of the `target_blob_gas` and `max_bob_gas` is guaranteed from the consensus layer which specify `target_blob_count` and `max_blob_count`, much like how withdrawals are handled.
+
+When verifying a block, execution clients **MUST** ensure the target and max blob gas in the block header corresponds to the one
 provided by the consensus client.
 
-For a genesis block with no existing parent, the value should be set according to the agreed specification for the
-target blob count given by that genesis block's protocol rule set.
+At hardfork transition, the `blob gas used` is set to the calculated in 4844 fashion from the parent post which the new mechanism kicks in. For a genesis block with no existing parent, one can just set it to `MIN_BLOB_BASE_FEE`.
 
 ### Block processing
 

--- a/EIPS/eip-7742.md
+++ b/EIPS/eip-7742.md
@@ -73,6 +73,8 @@ Because the of the dynamic block target and max, the pricing mechanism will need
     const blockExcessGas = abs(parent.blobGasUsed - parent.targetBlobGas)
     # get update fraction that limits the gas update factor to <= 1.125 on either direction
     # 3338477÷393216 = 8.49
+    # ELs can cache this fraction for a pair of target and max as target max aren't expected to actually
+    # vary block by block
     const blockUpdateFraction = ciel(max(parent.targetBlobGas, parent.maxBlobGas - parent.targetBlobGas) * 8.49)
     const gasUpdateFactor  = fakeExponential(1, blockExcessGas, blockUpdateFraction)
     if(block.blobGasUsed >= block.targetBlobGas)

--- a/EIPS/eip-7742.md
+++ b/EIPS/eip-7742.md
@@ -66,7 +66,7 @@ to preserve the security of optimistic sync.
 Upon activation of this EIP, execution clients **MUST** extend the header schema with an
 additional 64-bit field: the `target_blob_gas` and `max_bob_gas` to allow target to be dynamically upgraded against max by the CLs as well as to not have an assumed static max vs target relationship.
 
-Because the of the dynamic block target and max, the pricing mechanism will need to be modified from simple exponentiation of `excess_blob_gas`. It will be much simpler to now follow the block `base_fee` mechanism. So we retire `excess_blob_gas` mechanism and we introduce `blob_base_fee` as follows:
+Because the of the dynamic block target and max, the pricing update mechanism will need to be modified from simple exponentiation of `excess_blob_gas/BLOB_BASE_FEE_UPDATE_FRACTION`. It will be much simpler to now follow the block `base_fee` mechanism. So we retire `excess_blob_gas` mechanism and we introduce `blob_base_fee` as follows:
 
 ```python
   def calcBlockBlobBaseFee(parent: Header)


### PR DESCRIPTION
from: https://github.com/ethereum/execution-apis/pull/574#issuecomment-2423767938


we might need to add baseFeePerBlobGas in beacon's execution header and hence the api field, because the blob gas price can't just be now : minFee* e^(ecessBlobGasg/blobGasPriceUpdateFraction) since blobGasPriceUpdateFraction (for limiting change 1+-1.125 factor) could change block to block.

so we should return to the normal pricing mechanism like basefee, so blobBaseFee = parent.blobBaseFee * e^((blobGasUsed - targetBlobGas)/blockAdjustedTargetFraction))

where blockAdjustedTargetFraction makes sure fee doesn't "change" by 1.125 either direction and is calculated block to block.

so in EL block header, we now remove excessBlobGas and add three fields: baseFeePerBlobGas, targetBlobGas and maxBlobGas (since we don't want this to be a hardfork based setting anymore as well, and don't want to keep a static fraction between target and max for better control over the blob throughput and bandwidth params), and beacon execution header we just add baseFeePerBlobGas

if it makes sense i could update the EIP 7742 with the gas calc changes and introducing the new fields

(I am ok to replace target gas/max gas with target count/max count in the EL header and gas calcs, whatever seem more convenient)