### PR TITLE
Update EIP-7685: exclude empty requests data in commitment

### DIFF
--- a/EIPS/eip-7685.md
+++ b/EIPS/eip-7685.md
@@ -45,21 +45,19 @@ Each request type will defines its own `requests` object using with its own
 
 #### Block Header
 
-Extend the header with a new 32 byte value `requests_hash`.
+Extend the header with a new 32 byte commitment value `requests_hash`.
 
-The construction looks like:
+A requests hash list is computed by hashing the elements of the block requests list, but
+only ones where `request_data` is non-empty. The commitment is then computed as the sha256
+hash of the list of requests element hashes.
 
-```
-sha256(sha256(requests_0) ++ sha256(requests_1) ++ ...)
-```
-
-Or in pseudocode:
 
 ```python
-def compute_requests_hash(requests):
+def compute_requests_hash(block_requests):
     m = sha256()
-    for r in requests:
-        m.update(sha256(r))
+    for r in block_requests:
+        if len(r) > 1:
+            m.update(sha256(r))
     return m.digest()
 
 block.header.requests_hash = compute_requests_hash(requests)
@@ -67,8 +65,8 @@ block.header.requests_hash = compute_requests_hash(requests)
 
 ### Consensus Layer
 
-Each proposal may choose how to extend the beacon chain types to include new EL
-request types.
+Each proposal may choose how to extend the beacon chain types to include new EL request
+types.
 
 ## Rationale
 
@@ -114,6 +112,12 @@ ordering by type is the most straightforward ordering which ensures integrity.
 Within the same type, order is not defined. This is because the data of the
 request is opaque as far as this EIP is concerned. Therefore, it is to be
 determined by each request type individually.
+
+### Removing empty requests in commitment
+
+We exclude empty requests elements from the `requests_hash` commitment in order to get a
+stable 'empty' hash value that is independent of the blockchain fork. For a block with no
+requests data, the `requests_hash` is simply `sha256("")`.
 
 ## Backwards Compatibility
 

--- a/EIPS/eip-7685.md
+++ b/EIPS/eip-7685.md
@@ -55,7 +55,7 @@ The commitment is then computed as the sha256 hash of the list of element hashes
 
 
 ```python
-def compute_requests_hash(block_requests):
+def compute_requests_hash(block_requests: Sequence[bytes]):
     m = sha256()
     for r in block_requests:
         if len(r) > 1:

--- a/EIPS/eip-7685.md
+++ b/EIPS/eip-7685.md
@@ -33,26 +33,30 @@ update on the execution block structure.
 
 #### Requests
 
-A `requests` object consists of a `request_type` prepended to an opaque byte
-array `request_data`.
+A `requests` object consists of a `request_type` prepended to an opaque byte array
+`request_data`. The `request_data` contains zero or more encoded request objects.
 
 ```
 requests = request_type ++ request_data
 ```
 
-Each request type will defines its own `requests` object using with its own
-`request_data` format.
+Each request type will defines its own `requests` object with its own `request_data` format.
 
 #### Block Header
 
 Extend the header with a new 32 byte commitment value `requests_hash`.
 
-A requests hash list is computed by hashing the elements of the block requests list, but
-only ones where `request_data` is non-empty. Note we assume `request_type` has a size of
-one byte.
+While processing a block, multiple `requests` objects with different `request_type`s will
+be produced by the system, and accumulated in the block requests list.
 
-The commitment is then computed as the sha256 hash of the list of element hashes.
+In order to compute the commitment, an intermediate hash list is first built by hashing
+all non-empty requests elements of the block requests list. Items with empty
+`request_data` are excluded, i.e. the intermediate list skips `requests` items which
+contain only the `request_type` (1 byte) and nothing else.
 
+Within the intermediate list, `requests` items must be ordered by `request_type` ascending.
+
+The final commitment is computed as the sha256 hash of the intermediate element hashes.
 
 ```python
 def compute_requests_hash(block_requests: Sequence[bytes]):

--- a/EIPS/eip-7685.md
+++ b/EIPS/eip-7685.md
@@ -48,8 +48,10 @@ Each request type will defines its own `requests` object using with its own
 Extend the header with a new 32 byte commitment value `requests_hash`.
 
 A requests hash list is computed by hashing the elements of the block requests list, but
-only ones where `request_data` is non-empty. The commitment is then computed as the sha256
-hash of the list of requests element hashes.
+only ones where `request_data` is non-empty. Note we assume `request_type` has a size of
+one byte.
+
+The commitment is then computed as the sha256 hash of the list of element hashes.
 
 
 ```python
@@ -57,7 +59,7 @@ def compute_requests_hash(block_requests):
     m = sha256()
     for r in block_requests:
         if len(r) > 1:
-            m.update(sha256(r))
+            m.update(sha256(r).digest())
     return m.digest()
 
 block.header.requests_hash = compute_requests_hash(requests)


### PR DESCRIPTION
Here I am proposing to change the `requests_hash` commitment so that empty items are excluded. The point of this is to ensure a stable empty requests hash which is independent of fork. Having such a hash makes testing a lot easier, and it mirrors how other execution-layer commitments behave.

There is also a corresponding engine API change: https://github.com/ethereum/execution-apis/pull/599