### PR TITLE
Update EIP-7069: emphasis - `value` rules are EXTCALL only

### DIFF
--- a/EIPS/eip-7069.md
+++ b/EIPS/eip-7069.md
@@ -59,22 +59,22 @@ In case this EIP is included as part of the greater EOF upgrade, these four new 
 
 Execution semantics of `EXT*CALL`:
 
-1. Charge `WARM_STORAGE_READ_COST` (100) gas.
+1. Charge `WARM_STORAGE_READ_COST` gas.
 2. Pop required arguments from stack, halt with exceptional failure on stack underflow.
     - **NOTE**: When implemented in EOF, stack underflow check is done during stack validation and runtime check is omitted.
-3. If `value` is non-zero:
+3. If `value` is non-zero (only `EXTCALL`):
     - Halt with exceptional failure if the current frame is in `static-mode`.
     - Charge `CALL_VALUE_COST` gas.
-4. If `target_address` has any of the high 12 bytes set to a non-zero value(i.e. it does not contain a 20-byte address) then halt with an exceptional failure. 
+4. If `target_address` has any of the high 12 bytes set to a non-zero value (i.e. it does not contain a 20-byte address) then halt with an exceptional failure. 
 5. Perform (and charge for) memory expansion using `[input_offset, input_size]`.
-6. If `target_address` is not in the `warm_account_list`, charge `COLD_ACCOUNT_ACCESS - WARM_STORAGE_READ_COST` (2500) gas.
-7. If `target_address` is not in the state and the call configuration would result in account creation, charge `ACCOUNT_CREATION_COST` (25000) gas.
-    - The only such case in this EIP is if `value` is non-zero.
+6. If `target_address` is not in the `warm_account_list`, charge `COLD_ACCOUNT_ACCESS - WARM_STORAGE_READ_COST` gas.
+7. If `target_address` is not in the state and the call configuration would result in account creation, charge `ACCOUNT_CREATION_COST` gas.
+    - The only such case in this EIP is if `value` is non-zero (only `EXTCALL`).
 8. Calculate the gas available to callee as caller's remaining gas reduced by `max(floor(gas/64), MIN_RETAINED_GAS)`.
 9. Clear the returndata buffer.
 10. Fail with status code `1` returned on stack if any of the following is true (only gas charged until this point is consumed):
     - Gas available to callee at this point is less than `MIN_CALLEE_GAS`.
-    - Balance of the current account is less than `value`.
+    - Balance of the current account is less than `value` (only `EXTCALL`).
     - Current call stack depth equals `1024`.
 11. Perform the call with the available gas and configuration.
 12. Push a status code on the stack:


### PR DESCRIPTION
As title + redacted some hard-coded constants (they're in the constants table)