### PR TITLE
Update EIP-7600: Update eip-7600.md

### DIFF
--- a/EIPS/eip-7600.md
+++ b/EIPS/eip-7600.md
@@ -7,7 +7,7 @@ discussions-to: https://ethereum-magicians.org/t/eip-7600-hardfork-meta-prague-e
 status: Review
 type: Meta
 created: 2024-01-18
-requires: 2537, 2935, 6110, 7002, 7251, 7549, 7594, 7685, 7692, 7702, 7723
+requires: 2537, 2935, 6110, 7002, 7251, 7549, 7594, 7685, 7702, 7742
 ---
 
 ## Abstract
@@ -28,22 +28,22 @@ Definitions for `Scheduled for Inclusion` and `Considered for Inclusion` can be 
 * [EIP-7549](./eip-7549.md): Move committee index outside Attestation
 * [EIP-7685](./eip-7685.md): General purpose execution layer requests 
 * [EIP-7702](./eip-7702.md): Set EOA account code
+* [EIP-7742](./eip-7742.md): Uncouple blob count between CL and EL
 
 ### EIPs Considered for Inclusion
 
 * [EIP-7623](./eip-7623.md): Increase calldata cost
-* [EIP-7742](./eip-7742.md): Uncouple blob count between CL and EL
 * [EIP-7762](./eip-7762.md): Increase MIN_BASE_FEE_PER_BLOB_GAS 
 
 ### Full Specifications 
 
 #### Consensus Layer
 
-EIP-6110, EIP-7002 EIP-7251 and EIP-7549 require changes to Ethereum's consensus layer. While the EIPs present an overview of these changes, the full specifications can be found in the `specs/electra` and `specs/_features` directories of the `ethereum/consensus-specs` repository.
+EIP-6110, EIP-7002 EIP-7251, EIP-7549 and EIP-7742 require changes to Ethereum's consensus layer. While the EIPs present an overview of these changes, the full specifications can be found in the `specs/electra` and `specs/_features` directories of the `ethereum/consensus-specs` repository.
 
 #### Execution Layer
 
-EIP-2537, EIP-2935, EIP-6110, EIP-7685, EIP-7002 and EIP-7702 require changes to Ethereum's execution layer. The EIPs fully specify those changes. 
+EIP-2537, EIP-2935, EIP-6110, EIP-7685, EIP-7002, EIP-7702 and EIP-7742 require changes to Ethereum's execution layer. The EIPs fully specify those changes. 
 
 ### Activation 
 


### PR DESCRIPTION
Adds EIP-7742 to the SFI list, as agreed on [ACDE#199](https://github.com/ethereum/pm/issues/1177), also removes CFI'd EIPs from `requires` line, let's see if the bot lets me 😄 