### PR TITLE
Update EIP-5792: update mention of top-level sendCalls properties

### DIFF
--- a/EIPS/eip-5792.md
+++ b/EIPS/eip-5792.md
@@ -34,7 +34,7 @@ We also define one capability expression for use with the fourth method, which f
 
 ### `wallet_sendCalls`
 
-Requests that a wallet submits a batch of calls. `from` and `chainId` are top-level properties rather than per-call properties because all calls should be sent from the same sender and on the same chain, identified by [EIP-155](./eip-155.md) integers expressed in hexadecimal notation. The items in the `calls` field are only those that are shared by all transaction types. Any other fields that a wallet may need to submit a transaction should be handled by the wallet.
+Requests that a wallet submits a batch of calls. `from` is a top-level property rather than a per-call property because all calls should be sent from the same sender. The items in the `calls` field are only those that are shared by all transaction types. Any other fields that a wallet may need to submit a transaction should be handled by the wallet.
 
 The capabilities field is how an app can communicate with a wallet about capabilities a wallet supports. For example, this is where an app can specify a paymaster service URL from which an [ERC-4337](./eip-4337.md) wallet can request a `paymasterAndData` input for a user operation.
 


### PR DESCRIPTION
In a previous commit, the field `chainId` was moved from a top-level property to per-call property. However, the statement at the beginning of the section wasn't updated.

Previous change: https://github.com/ethereum/EIPs/commit/2f46d4dd395cd672cfa6b8b7d8e34cac129ed0bf