### PR TITLE
Update EIP-7742: Rename *_blob_count to *_blobs_per_block

### DIFF
--- a/EIPS/eip-7742.md
+++ b/EIPS/eip-7742.md
@@ -64,11 +64,11 @@ to preserve the security of optimistic sync.
 ### Block structure and validity
 
 Upon activation of this EIP, execution clients **MUST** extend the header schema with an
-additional 64-bit field: the `target_blob_count`. This value is set to the current target blob count. The Engine API
-is modified along with this EIP to provide the `target_blob_count` with each payload and implementations can use this
+additional 64-bit field: the `target_blobs_per_block`. This value is set to the current target blob count. The Engine API
+is modified along with this EIP to provide the `target_blobs_per_block` with each payload and implementations can use this
 value to correctly set the block header field.
 
-Validity of the `target_blob_count` is guaranteed from the consensus layer, much like how withdrawals are handled.
+Validity of the `target_blobs_per_block` is guaranteed from the consensus layer, much like how withdrawals are handled.
 
 When verifying a block, execution clients **MUST** ensure the target blob count in the block header matches the one
 provided by the consensus client.
@@ -81,13 +81,13 @@ target blob count given by that genesis block's protocol rule set.
 Upon activating this EIP (i.e. before processing any transactions),
 the verification of the blob maximum as given in EIP-4844 can be skipped. Concretely, this means any logic relating
 to `MAX_BLOB_GAS_PER_BLOCK` as given in EIP-4844 can be deprecated.
-Additionally, any reference to `TARGET_BLOB_GAS_PER_BLOCK` from EIP-4844 can be derived by taking the `target_blob_count` from the CL and multiplying by `GAS_PER_BLOB` as given in EIP-4844.
+Additionally, any reference to `TARGET_BLOB_GAS_PER_BLOCK` from EIP-4844 can be derived by taking the `target_blobs_per_block` from the CL and multiplying by `GAS_PER_BLOB` as given in EIP-4844.
 
 Otherwise, the specification of EIP-4844 is not changed. For example, blob base fee accounting and excess blob gas tracking occur in the exact same way.
 
 ### Block construction
 
-The Engine API is extended to provide both the `target_blob_count` and the `maximum_blob_count` when the CL requests the EL to construct a payload for proposal.
+The Engine API is extended to provide both the `target_blobs_per_block` and the `maximum_blobs_per_block` when the CL requests the EL to construct a payload for proposal.
 
 These values should be used to ensure the correct number of blobs are included in any constructed payload, and to ensure that the blob base fee accounting is correctly computed.
 

--- a/EIPS/eip-7742.md
+++ b/EIPS/eip-7742.md
@@ -87,7 +87,7 @@ Otherwise, the specification of EIP-4844 is not changed. For example, blob base 
 
 ### Block construction
 
-The Engine API is extended to provide both the `target_blobs_per_block` and the `maximum_blobs_per_block` when the CL requests the EL to construct a payload for proposal.
+The Engine API is extended to provide both the `target_blobs_per_block` and the `max_blobs_per_block` when the CL requests the EL to construct a payload for proposal.
 
 These values should be used to ensure the correct number of blobs are included in any constructed payload, and to ensure that the blob base fee accounting is correctly computed.
 


### PR DESCRIPTION
**ATTENTION: ERC-RELATED PULL REQUESTS NOW OCCUR IN [ETHEREUM/ERCS](https://github.com/ethereum/ercs)**

Rename these vars for consistency with other spec constants, eg:

* `MAX_BLOBS_PER_BLOCK`
* `TARGET_BLOB_GAS_PER_BLOCK`

Note: this PR also renames "maximum" to "max".

--

When opening a pull request to submit a new EIP, please use the suggested template: https://github.com/ethereum/EIPs/blob/master/eip-template.md

We have a GitHub bot that automatically merges some PRs. It will merge yours immediately if certain criteria are met:

 - The PR edits only existing draft PRs.
 - The build passes.
 - Your GitHub username or email address is listed in the 'author' header of all affected PRs, inside <triangular brackets>.
 - If matching on email address, the email address is the one publicly listed on your GitHub profile.
