### PR TITLE
Update EIP-7702: add "hash" to tuple, to allow single-signature for first eip-7702 tx initialization.

### DIFF
--- a/EIPS/eip-7702.md
+++ b/EIPS/eip-7702.md
@@ -199,8 +199,8 @@ Specifically:
 ### A signed "hash" value:
 
 The auth tuple contains a `hash` value, which is unused by this EIP, but can be used to authenticate the wrapping transaction.
-This way, a single signature by the user can be used for both eip-7702 delegate and the outer UserOperation.
-It can also be used by a single signature to initialize the eip-7702 delegate and authenticate the "initcode" call
+This way, a single signature by the user can be used for both EIP-7702 delegate and the outer UserOperation.
+It can also be used by a single signature to initialize the EIP-7702 delegate and authenticate the "initcode" call
 
 ### Clearing Delegation Designations
 


### PR DESCRIPTION
Add an optional "hash" field to the auth tuple, to support single signature when submitted through a wrapper protocol (such as ERC-4337's UserOperation)
