### PR TITLE
Update EIP-6206: clarify wording on JUMPF (EOF)

### DIFF
--- a/EIPS/eip-6206.md
+++ b/EIPS/eip-6206.md
@@ -52,7 +52,7 @@ Let the definition of `type[i]` be inherited from [EIP-4750](./eip-4750.md) and 
   * either `type[current_section_index].outputs` MUST be greater or equal `type[target_section_index].outputs`,
   * or `type[target_section_index].outputs` MUST be `0x80`
 * The stack height validation at `JUMPF` depends on whether the target section is non-returning:
-  * `JUMPF` into returning section (`type[target_section_index].outputs` does not equal `0x80`):  `stack_height_min` and `stack_height_max` MUST be equal to `type[current_section_index].outputs + type[target_section_index].inputs  - type[target_section_index].outputs`. This means that target section can output less stack elements than the original code section called by the top element on the return stack, if the current code section leaves the delta `type[current_section_index].outputs - type[target_section_index].outputs` element(s) on the stack.
+  * `JUMPF` into returning section (`type[target_section_index].outputs` does not equal `0x80`):  `stack_height_min` and `stack_height_max` MUST be equal to `type[current_section_index].outputs + type[target_section_index].inputs  - type[target_section_index].outputs`.
   * `JUMPF` into non-returning section (`type[target_section_index].outputs` equals `0x80`): `stack_height_min` MUST be greater than or equal to `type[target_section_index].inputs`.
 * Stack overflow check at `JUMPF`: `stack_height_max` MUST be less than or equal to `1024 - types[target_section_index].max_stack_height + types[target_section_index].inputs`.
 * `JUMPF` is considered terminating instruction, i.e. does not have successor instructions in code validation and MAY be final instruction in the section. 
@@ -60,7 +60,7 @@ Let the definition of `type[i]` be inherited from [EIP-4750](./eip-4750.md) and 
 
 `CALLF` instruction validation is extended to include the rule:
 
-* Code section is invalid in case an immediate argument `target_section_index` of any `CALLF` targets a non-returning section, i.e. `type[target_section_index]` equals `0x80`.
+* Code section is invalid in case an immediate argument `target_section_index` of any `CALLF` targets a non-returning section, i.e. `type[target_section_index].outputs` equals `0x80`.
 
 #### Non-returning status validation
 
@@ -71,7 +71,7 @@ Section type MUST be non-returning in case the section contains no `RETF` instru
 
 ### Allowing `JUMPF` to section with less outputs
 
-As long as `JUMPF` prepares the delta `type[current_section_index].outputs - type[target_section_index].outputs` stack elements before changing code sections, it is possible to jump to a section with less outputs than was originally entered via `CALLF`. This will reduce duplicated code as it will allow compilers more flexibility during code generation such that certain helpers can be used generically by functions, regardless of their output values.
+A code section with a `JUMPF` can, just before that instruction, have a delta of `type[current_section_index].outputs - type[target_section_index].outputs` output elements on the operand stack (i.e. counted on top of the target section inputs!). This makes it possible to `JUMPF` to a section with less outputs than those of the current section. This will reduce duplicated code as it will allow compilers more flexibility during code generation such that certain helpers can be used generically by functions, regardless of their output values.
 
 ## Backwards Compatibility
 

--- a/EIPS/eip-6206.md
+++ b/EIPS/eip-6206.md
@@ -52,7 +52,7 @@ Let the definition of `type[i]` be inherited from [EIP-4750](./eip-4750.md) and 
   * either `type[current_section_index].outputs` MUST be greater or equal `type[target_section_index].outputs`,
   * or `type[target_section_index].outputs` MUST be `0x80`
 * The stack height validation at `JUMPF` depends on whether the target section is non-returning:
-  * `JUMPF` into returning section (`type[target_section_index].outputs` does not equal `0x80`):  `stack_height_min` and `stack_height_max` MUST be equal to `type[current_section_index].outputs + type[target_section_index].inputs  - type[target_section_index].outputs`.
+  * `JUMPF` into returning section (`type[target_section_index].outputs` does not equal `0x80`):  `stack_height_min` and `stack_height_max` MUST be equal to `type[current_section_index].outputs - type[target_section_index].outputs + type[target_section_index].inputs`. This means that target section can output less stack elements than the original code section called by the top element on the return stack, if the current code section leaves the delta `type[current_section_index].outputs - type[target_section_index].outputs` element(s) on the stack.
   * `JUMPF` into non-returning section (`type[target_section_index].outputs` equals `0x80`): `stack_height_min` MUST be greater than or equal to `type[target_section_index].inputs`.
 * Stack overflow check at `JUMPF`: `stack_height_max` MUST be less than or equal to `1024 - types[target_section_index].max_stack_height + types[target_section_index].inputs`.
 * `JUMPF` is considered terminating instruction, i.e. does not have successor instructions in code validation and MAY be final instruction in the section. 
@@ -71,7 +71,9 @@ Section type MUST be non-returning if and only if the section contains no `RETF`
 
 ### Allowing `JUMPF` to section with less outputs
 
-A code section with a `JUMPF` can, just before that instruction, have a delta of `type[current_section_index].outputs - type[target_section_index].outputs` output elements on the operand stack (i.e. counted on top of the target section inputs!). This makes it possible to `JUMPF` to a section with less outputs than those of the current section. This will reduce duplicated code as it will allow compilers more flexibility during code generation such that certain helpers can be used generically by functions, regardless of their output values.
+An alternative rule for `JUMPF` stack validation could require the target section's outputs to be exactly equal to the current section's outputs. Under such rule, a particular target section (a shared "helper" piece of code) would only "match" sections (requiring some shared "helper" code to execute before returning) *of the same outputs*.
+
+Instead, we allow a given `JUMPF` target section to be called from sections with more outputs, as long as these sections provide these extra stack elements (the "delta") themselves. This will reduce duplicated code as it will allow compilers more flexibility during code generation such that certain helpers can be used generically by functions, regardless of their output values.
 
 ## Backwards Compatibility
 

--- a/EIPS/eip-6206.md
+++ b/EIPS/eip-6206.md
@@ -27,7 +27,7 @@ Knowing at validation time that a function will never return control allows for 
 
 ### Type section changes
 
-We define non-returning section as the one that can not return control (via `RETF` instruction) to the caller section.
+We define a non-returning section as one that cannot return control to its caller section.
 
 Type section `outputs` field contains a special value `0x80` when corresponding code section is non-returning. See [Non-returning status validation](#non-returning-status-validation) below for validation details.
 
@@ -64,7 +64,7 @@ Let the definition of `type[i]` be inherited from [EIP-4750](./eip-4750.md) and 
 
 #### Non-returning status validation
 
-Section type MUST be non-returning in case the section contains no `RETF` instructions and no `JUMPF` instructions targeting returning sections (target section's status is checked via its output value in type section.)
+Section type MUST be non-returning if and only if the section contains no `RETF` instructions and no `JUMPF` instructions targeting returning sections (target section's status is checked via its output value in type section.)
 *Note: This implies that section containing only `JUMPF`s into non-returning sections is non-returning itself.*
 
 ## Rationale

--- a/EIPS/eip-6206.md
+++ b/EIPS/eip-6206.md
@@ -71,7 +71,7 @@ Section type MUST be non-returning if and only if the section contains no `RETF`
 
 ### Allowing `JUMPF` to section with less outputs
 
-An alternative rule for `JUMPF` stack validation could require the target section's outputs to be exactly equal to the current section's outputs. Under such rule, a particular target section (a shared "helper" piece of code) would only "match" sections (requiring some shared "helper" code to execute before returning) *of the same outputs*.
+An alternative rule for `JUMPF` stack validation could require the target section's outputs to be exactly equal to the current section's outputs. Under such rule, a particular target section (a shared "helper" piece of code) would only "match" sections (requiring some shared "helper" code to execute before returning) *with the same number of outputs*.
 
 Instead, we allow a given `JUMPF` target section to be called from sections with more outputs, as long as these sections provide these extra stack elements (the "delta") themselves. This will reduce duplicated code as it will allow compilers more flexibility during code generation such that certain helpers can be used generically by functions, regardless of their output values.
 


### PR DESCRIPTION
`Update EIP-6206: clarify "JUMPF prepares the delta` raised in https://github.com/ethereum/solidity/pull/15550#issuecomment-2494801436

The other commit found when re-reading. The [megaspec](https://github.com/ipsilon/eof/blob/main/spec/eof.md?plain=1#L286) already has this "iff" formulation