### PR TITLE
Update EIP-7801: Eip 7801 bitmask

### DIFF
--- a/EIPS/eip-7801.md
+++ b/EIPS/eip-7801.md
@@ -53,7 +53,7 @@ This EIP could be implemented without a new protocol version by adding a new fie
 
 The bitmask approach provides a flexible means to represent and retain block data while committing to future spans. This mechanism aligns with the pruning proposed in EIP-4444, while ensuring that historical and future data spans remain available across the network.
 
-The bitmask approach is already used in the Consensus Layer for attestation subnets, making it a familiar and efficient method for representing data spans. Additionally, committing to future spans ensures better predictability and stability for data locality.
+A similar bitlist approach is already used in the Consensus Layer for attestation subnets, making it a familiar and efficient method for representing data spans. Additionally, committing to future spans ensures better predictability and stability for data locality.
 
 ## Backwards Compatibility
 
@@ -65,8 +65,9 @@ This EIP does not affect the consensus engine or require a hard fork.
 
 There are some considerations:
 
-- The size of the network is not taken into account, so for an extended history, shard sizes may need to increase. However, this is not a major issue for Ethereum, as many nodes are active on the network at all times.
-- The more blocks in the network, the more shards there will be, potentially diluting peers across multiple shards. This could make querying specific shards more challenging in the future. However, with sufficiently large shard sizes, this should not pose a significant problem. For instance, if Ethereum has 200,000,000 blocks and a shard size of 100,000 blocks, and a node has 32 peers, then the probability that a peer has a specific shard is around 15%, which is manageable.
+- Data unavailability for any given shard can be modeled as: P = (0.9)^n, where n is the number of peers.  Assuming a random distribution of nodes that are participating in EIP-7801 history sharding, for 25 peers, this chance is 7%.  For 32 peers, this chance drops to 3.4%. This assumes that a significant number of nodes on the network are serving at least one shard.  Adoption by a majority of clients as a default would likely be necessary for a complete sharded history to be available and replicated sufficiently across the network.
+- As history grows, so will the size of the retained shards on disk, thus raising the storage requirements per node.  However, nodes will still benefit from a ~90% storage reduction over the present chain storage requirements, and will scale their future chain storage requirements by only 10% of the rate they would have by retaining all history.
+
 
 ## Copyright
 

--- a/EIPS/eip-7801.md
+++ b/EIPS/eip-7801.md
@@ -47,7 +47,7 @@ If a node is interested in querying a specific block span, it can use the bitmas
 
 ### ENR variation
 
-This EIP could be implemented without a new protocol version by adding a new field to the Ethereum Node Record (ENR) to advertise the bitmask. This would allow nodes to advertise their available block spans without requiring a handshake. However, this approach would not provide the same level of assurance as the handshake, as the ENR is not authenticated. Also, it would make the discovery process much simpler, as nodes just would need to take a look at the ENR to determine if a peer has the data they are looking for.
+This EIP could be implemented without a new protocol version by adding a new field to the Ethereum Node Record (ENR) to advertise the bitmask. This would allow nodes to advertise their available block spans without requiring a handshake. However, this approach would not provide the same level of assurance as the handshake, as the ENR is not authenticated. Also, it would make the discovery process much simpler, as nodes would only need to check the ENR to determine if a peer has the data they need.
 
 ## Rationale
 

--- a/EIPS/eip-7801.md
+++ b/EIPS/eip-7801.md
@@ -13,7 +13,7 @@ requires: 7642
 
 ## Abstract
 
-This EIP introduces a method enabling an Ethereum node to communicate its available block spans via a bitmask, where each bit represents a 100_000-block span within each 1_000_000 block range of chain history. Nodes use this bitmask to signal which spans of historical data they store and commit to storing future spans as they are created.  This enables peers to make informed decisions about data availability without first connecting and querying for availability. The bitmask repeats every 1 million blocks, making for a somewhat simple to reason about probability of data availability.
+This EIP introduces a method enabling an Ethereum node to communicate its available block spans via a bitmask, where each bit represents a 100_000-block span within each 1_000_000 block range of chain history. Nodes use this bitmask to signal which spans of historical data they store and commit to storing future spans as they are created. This enables peers to make informed decisions about data availability without first connecting and querying for availability. The bitmask repeats every 1 million blocks, making for a somewhat simple to reason about probability of data availability.
 
 The proposal extends the Ethereum wire protocol (`eth`) with version `eth/70`, introducing a `blockBitmask` field in the handshake.
 

--- a/EIPS/eip-7801.md
+++ b/EIPS/eip-7801.md
@@ -13,7 +13,7 @@ requires: 7642
 
 ## Abstract
 
-This EIP introduces a method enabling an Ethereum node to communicate its available block spans via a bitmask, where each bit represents a 100_000-block span within each 1_000_000 block range of chain history. Nodes use this bitmask to signal which spans of historical data they store and commit to storing future spans as they are created.  This enables peers to make informed decisions about data availability without first connecting and querying for availability. The bitmask repeats every 1 million blocks, improving network efficiency and supporting data locality across nodes.
+This EIP introduces a method enabling an Ethereum node to communicate its available block spans via a bitmask, where each bit represents a 100_000-block span within each 1_000_000 block range of chain history. Nodes use this bitmask to signal which spans of historical data they store and commit to storing future spans as they are created.  This enables peers to make informed decisions about data availability without first connecting and querying for availability. The bitmask repeats every 1 million blocks, making for a somewhat simple to reason about probability of data availability.
 
 The proposal extends the Ethereum wire protocol (`eth`) with version `eth/70`, introducing a `blockBitmask` field in the handshake.
 

--- a/EIPS/eip-7801.md
+++ b/EIPS/eip-7801.md
@@ -1,7 +1,7 @@
 ---
 eip: 7801
 title: eth/70 - Sharded Blocks Protocol
-description: Replaces block range with a bitlist representing 1-million-block spans in the handshake, with probabilistic shard retention
+description: Replaces block range with a bitmask representing 100,000-block spans in the handshake, committing to future block ranges
 author: Ahmad Bitar (@smartprogrammer93) <smartprogrammer@windowslive.com>, Giulio Rebuffo (@Giulio2002)
 discussions-to: https://ethereum-magicians.org/t/eip-7801-eth-70-sharded-blocks-protocol/21507
 status: Draft
@@ -13,45 +13,46 @@ requires: 7642
 
 ## Abstract
 
-This EIP introduces a method enabling an Ethereum node to communicate its available block spans via a bitlist, where each bit represents a 1-million-block span. Nodes use this bitlist to signal which spans of historical data they store, enabling peers to make informed decisions about data availability when requesting blocks. This aims to improve network efficiency by providing a probabilistic snapshot of data locality across nodes.
+This EIP introduces a method enabling an Ethereum node to communicate its available block spans via a bitmask, where each bit represents a 100_000-block span. Nodes use this bitmask to signal which spans of historical data they store and commit to storing future spans as they are created, enabling peers to make informed decisions about data availability. The bitmask repeats every 1 million blocks, improving network efficiency and supporting data locality across nodes.
 
-The proposal extends the Ethereum wire protocol (`eth`) with version `eth/70`, introducing a `blockBitlist` field in the handshake. Nodes probabilistically retain certain block spans to support data locality across the network.
+The proposal extends the Ethereum wire protocol (`eth`) with version `eth/70`, introducing a `blockBitmask` field in the handshake.
 
 ## Motivation
 
-With [EIP-4444](./eip-4444.md), nodes may begin pruning historical data while others continue to serve it. The current approach of connecting and requesting specific blocks to determine data availability is inefficient, consuming unnecessary bandwidth. This EIP addresses this by requiring nodes to retain at least one 1-million-block shard and retain additional shards probabilistically, enabling better-informed and targeted sync processes.
+With [EIP-4444](./eip-4444.md), nodes may begin pruning historical data while others continue to serve it. The current approach of connecting and requesting specific blocks to determine data availability is inefficient, consuming unnecessary bandwidth. This EIP addresses this by sharding chain history into 100_000 block segments, and allows nodes to signal which shards they store via a bitmask.
 
-By using a bitlist in place of a range, nodes provide a snapshot of data locality across historical epochs, supporting efficient data requests.
+By using a bitmask in place of a range, nodes provide a snapshot of data locality and future storage commitments, supporting efficient data requests.
 
 ## Specification
 
 - Advertise a new `eth` protocol capability (version) at `eth/70`.
   - The existing `eth/69` protocol will continue alongside `eth/70` until sufficient adoption.
-- Modify the `Status (0x00)` message for `eth/70` to add a `blockBitlist` field after the `forkid`:
+- Modify the `Status (0x00)` message for `eth/70` to add a `blockBitmask` field after the `forkid`:
   - Current packet for `eth/69`: `[version: P, networkid: P, blockhash: B_32, genesis: B_32, forkid]`
-  - New packet for `eth/70`: `[version: P, networkid: P, blockhash: B_32, genesis: B_32, forkid, blockBitlist]`,
-  where `blockBitlist` is a bitlist, with each bit representing a 1-million-block span.
+  - New packet for `eth/70`: `[version: P, networkid: P, blockhash: B_32, genesis: B_32, forkid, blockBitmask]`,
+  where `blockBitmask` is a 10-bit bitmask, with each bit representing a 100_000-block range per 1_000_000 blocks of history.  
 
-- Define node behavior based on the bitlist as follows:
-  - **Bitlist Initialization**: Upon startup, nodes **MUST** set at least one bit in the `blockBitlist` to `on` and backfill that 1-million-block span to ensure data availability for that shard.
-  - **Shard Retention Probability**: Nodes **SHOULD** probabilistically retain new block spans, with an `M%` probability (e.g., 5–10%) to maintain network data locality and avoid frequent pruning of new ranges.
-  - **Active Shard Maintenance**: Nodes **MUST** retain all blocks from shards that are still actively being created to support synchronization.
+- Define node behavior based on the bitmask as follows:
+  - **Bitmask Initialization**: Upon startup, nodes **MAY** set at least one bit in the `blockBitmask` to `on` and backfill that 100_000-block span to ensure data availability for that shard.
+  - **Shard Retention Probability**: Nodes **SHOULD** retain new block spans according to their bitmask, with participating nodes providing at least 10% of the chain history.
+  - **Commitment to Future Ranges**: Participating nodes **MUST** retain 100_000 block spans which correspond to their advertised bitmask as blocks are added to the chain.
+  - **Bitmask Space**: The 100_000 range `blockBitmask` repeats every 1 million blocks, enabling efficient representation of historical data locality across epochs.
 
-Upon connecting using `eth/70`, nodes exchange the `Status` message, including the `blockBitlist`. This single handshake message, which includes the bitlist, eliminates the need for additional message types.
+Upon connecting using `eth/70`, nodes exchange the `Status` message, including the `blockBitmask`. This single handshake message, which includes the bitmask, eliminates the need for additional message types.
 
-Nodes should maintain connections regardless of a peer’s bitlist state, except when peer slots are full. In this case, nodes may prioritize connections with peers that serve more relevant shards.
+Nodes should maintain connections regardless of a peer’s bitmask state, except when peer slots are full. In this case, nodes may prioritize connections with peers that serve more relevant shards.
 
-If a node is interested in querying a specific block span, it can use the bitlist to determine which peers are more likely to have the data. If the peer they are connected to does not have the data, they can disconnect and connect to another peer, until they find what they have been looking for.
+If a node is interested in querying a specific block span, it can use the bitmask to determine which peers are more likely to have the data. If the peer they are connected to does not have the data, they can disconnect and connect to another peer, until they find what they have been looking for.
 
 ### ENR variation
 
-This EIP could be implemented without a new protocol version by adding a new field to the Ethereum Node Record (ENR) to advertise the bitlist. This would allow nodes to advertise their available block spans without requiring a handshake. However, this approach would not provide the same level of assurance as the handshake, as the ENR is not authenticated. Also, it would make the discovery process much simpler, as nodes just would need to take a look at the ENR to determine if a peer has the data they are looking for.
+This EIP could be implemented without a new protocol version by adding a new field to the Ethereum Node Record (ENR) to advertise the bitmask. This would allow nodes to advertise their available block spans without requiring a handshake. However, this approach would not provide the same level of assurance as the handshake, as the ENR is not authenticated. Also, it would make the discovery process much simpler, as nodes just would need to take a look at the ENR to determine if a peer has the data they are looking for.
 
 ## Rationale
 
-The bitlist approach provides a flexible means to represent and retain block data with support for data locality, especially as nodes probabilistically retain certain shards. This mechanism aligns with the pruning proposed in EIP-4444, while ensuring that historical data spans remain available across the network.
+The bitmask approach provides a flexible means to represent and retain block data while committing to future spans. This mechanism aligns with the pruning proposed in EIP-4444, while ensuring that historical and future data spans remain available across the network.
 
-The bitlist approach is already used in the Consensus Layer for attestation subnets, making it a familiar and efficient method for representing data spans. Additionally, communicating shards this way is broadly used in many distributed systems, making it a natural fit for Ethereum.
+The bitmask approach is already used in the Consensus Layer for attestation subnets, making it a familiar and efficient method for representing data spans. Additionally, committing to future spans ensures better predictability and stability for data locality.
 
 ## Backwards Compatibility
 
@@ -64,7 +65,7 @@ This EIP does not affect the consensus engine or require a hard fork.
 There are some considerations:
 
 - The size of the network is not taken into account, so for an extended history, shard sizes may need to increase. However, this is not a major issue for Ethereum, as many nodes are active on the network at all times.
-- The more blocks in the network, the more shards there will be, potentially diluting peers across multiple shards. This could make querying specific shards more challenging in the future. However, with sufficiently large shard sizes, this should not pose a significant problem. For instance, if Ethereum has 200,000,000 blocks and a shard size of 1,000,000 blocks, and a node has 32 peers, then the probability that a peer has a specific shard is around 15%, which is manageable.
+- The more blocks in the network, the more shards there will be, potentially diluting peers across multiple shards. This could make querying specific shards more challenging in the future. However, with sufficiently large shard sizes, this should not pose a significant problem. For instance, if Ethereum has 200,000,000 blocks and a shard size of 100,000 blocks, and a node has 32 peers, then the probability that a peer has a specific shard is around 15%, which is manageable.
 
 ## Copyright
 

--- a/EIPS/eip-7801.md
+++ b/EIPS/eip-7801.md
@@ -13,7 +13,7 @@ requires: 7642
 
 ## Abstract
 
-This EIP introduces a method enabling an Ethereum node to communicate its available block spans via a bitmask, where each bit represents a 100_000-block span. Nodes use this bitmask to signal which spans of historical data they store and commit to storing future spans as they are created, enabling peers to make informed decisions about data availability. The bitmask repeats every 1 million blocks, improving network efficiency and supporting data locality across nodes.
+This EIP introduces a method enabling an Ethereum node to communicate its available block spans via a bitmask, where each bit represents a 100_000-block span within each 1_000_000 block range of chain history. Nodes use this bitmask to signal which spans of historical data they store and commit to storing future spans as they are created.  This enables peers to make informed decisions about data availability without first connecting and querying for availability. The bitmask repeats every 1 million blocks, improving network efficiency and supporting data locality across nodes.
 
 The proposal extends the Ethereum wire protocol (`eth`) with version `eth/70`, introducing a `blockBitmask` field in the handshake.
 
@@ -35,7 +35,8 @@ By using a bitmask in place of a range, nodes provide a snapshot of data localit
 - Define node behavior based on the bitmask as follows:
   - **Bitmask Initialization**: Upon startup, nodes **MAY** set at least one bit in the `blockBitmask` to `on` and backfill that 100_000-block span to ensure data availability for that shard.
   - **Shard Retention Probability**: Nodes **SHOULD** retain new block spans according to their bitmask, with participating nodes providing at least 10% of the chain history.
-  - **Commitment to Future Ranges**: Participating nodes **MUST** retain 100_000 block spans which correspond to their advertised bitmask as blocks are added to the chain.
+  - **Additional Shard Retention Buffer**: Retained shard ranges should also include 1_000 blocks prior to and after the shard boundary.  This will prevent edge effects where a typical range request size of 200 blocks which crosses a 100k shard boundary cannot be satisfied by any single node.
+  - **Commitment to Future Ranges**: Participating nodes **MUST** retain 100_000 block spans which correspond to their advertised bitmask as blocks are added to the chain
   - **Bitmask Space**: The 100_000 range `blockBitmask` repeats every 1 million blocks, enabling efficient representation of historical data locality across epochs.
 
 Upon connecting using `eth/70`, nodes exchange the `Status` message, including the `blockBitmask`. This single handshake message, which includes the bitmask, eliminates the need for additional message types.

--- a/EIPS/eip-7801.md
+++ b/EIPS/eip-7801.md
@@ -2,7 +2,7 @@
 eip: 7801
 title: eth/70 - Sharded Blocks Protocol
 description: Replaces block range with a bitmask representing 100,000-block spans in the handshake, committing to future block ranges
-author: Ahmad Bitar (@smartprogrammer93) <smartprogrammer@windowslive.com>, Giulio Rebuffo (@Giulio2002)
+author: Ahmad Bitar (@smartprogrammer93) <smartprogrammer@windowslive.com>, Giulio Rebuffo (@Giulio2002), Gary Schulte (@garyschulte) <garyschulte@gmail.com>
 discussions-to: https://ethereum-magicians.org/t/eip-7801-eth-70-sharded-blocks-protocol/21507
 status: Draft
 type: Standards Track


### PR DESCRIPTION
Update specification to use bitmask rather than an updating bitlist, so nodes will not need to update their ENR as the blockchain progresses across shard boundaries.  

Also change shard definition to 100k per 1M block span.  This makes data availability easy to reason about, and straightforward for a human to determine.