### PR TITLE
Update EIP-7762: Move to Draft

### DIFF
--- a/EIPS/eip-7762.md
+++ b/EIPS/eip-7762.md
@@ -1,10 +1,10 @@
 ---
-eip: 7762
-title: Increase MIN_BASE_FEE_PER_BLOB_GAS
-description: Adjust the MIN_BASE_FEE_PER_BLOB_GAS to speed up price discovery on blob space
-author: Max Resnick (@MaxResnick)
-discussions-to: https://ethereum-magicians.org/t/eip-7762-increase-min-base-fee-per-blob-gas/20949
-status: Review
+eip: 9999
+title: Adjust blob base fee mechanism
+description: AAdjust the blob base fee mechanism for improved price discovery and normalization across forks
+author: Toni Wahrstätter (@nerolation), Gajinder Singh (@g11tech), Bert (@bkellerman), Max Resnick (@MaxResnick), Ansgar Dietrichs (@adietrichs), Barnabé Monnot <barnabe.monnot@ethereum.org>
+discussions-to: 
+status: Draft
 type: Standards Track
 category: Core
 created: 2024-08-31
@@ -13,43 +13,81 @@ requires: 4844
 
 ## Abstract
 
-This EIP proposes an increase to the MIN_BASE_FEE_PER_BLOB_GAS to speed up price discovery on blob space. 
+This EIP proposes increasing `MIN_BASE_FEE_PER_BLOB_GAS`, automating blob base fee updates using target blob count, and normalizing excess gas to prevent abrupt base fee changes during forks.
 
 ## Motivation
 
-When scoping 4844, the thinking was that blobs would only enter price discovery once, relatively quickly after the blob rollout; however, this has not been the case. In fact, blobs have entered price discovery several times, and the frequency of price discovery events is likely to increase in the short term as we approach saturation of capacity. Moreover, the roadmap calls for further increases in blob capacity in subsequent hardforks, which may lead to price discovery events happening around those changes in the future. 
+With the experience of several months running EIP-4844, we have identified several minor issues with the blob base fee mechanism that we propose to address. We attempt to do so in a single EIP, summarizing the changes for simplicity.
 
-Increasing the MIN_BASE_FEE_PER_BLOB_GAS will speed up price discovery on blob space.
+First, increasing the MIN_BASE_FEE_PER_BLOB_GAS will speed up price discovery on blob space. Second, automating the blob base fee update fraction by using the target blob count in its calculation, we avoid having to update it in every future hard fork that touches the blob target. Third, normalizing excess gas will prevent blob base fee drops at forks that increase the target blob number. Eventually, symmetricising the blob base fee mechanism is discussed but not yet proposed.
 
 ## Specification
 
-The only specification change introduced by this EIP is setting MIN_BASE_FEE_PER_BLOB_GAS to 2**25:
+The specification change introduced by the first part of this EIP is setting MIN_BASE_FEE_PER_BLOB_GAS to 2**25:
 
 ```diff
 + MIN_BASE_FEE_PER_BLOB_GAS  =  2**25
 - MIN_BASE_FEE_PER_BLOB_GAS = 1
 ```
 
+Furthermore, to avoid sudden price jumps in the blob base fee, the excess gas MUST be reset to 0 at the time of the fork.
+
+The second part of this EIP, the automated adjustment of the blob base fee update fraction, we propose the following:
+
+```diff
++ MIN_BASE_FEE_PER_BLOB_GAS  =  TARGET_BLOB_GAS_PER_BLOCK / ln(1.125)
+- BLOB_BASE_FEE_UPDATE_FRACTION = 3338477
+```
+
+
+The third part of this EIP, the normalization is proposed the following:
+
+`excess_blob_gas` in the block now holds normalized excess blob gas accumulating `((blob_gas_used-target_blob_gas)/target_blob_gas) * EXCESS_BLOB_GAS_NORMALIZATION_FACTOR`. We choose `EXCESS_BLOB_GAS_NORMALIZATION_FACTOR` as 100E6 and this makes our choice of `NORMALIZED_BLOB_BASE_FEE_UPDATE_FRACTION as 3338477 * 100E6 // 393216 = 849018605`.
+
+| Constant |	Value |
+| EXCESS_BLOB_GAS_NORMALIZATION_FACTOR |	100E6 |
+| NORMALIZED_BLOB_BASE_FEE_UPDATE_FRACTION |	849018605 |
+| OLD_TARGET_BLOB_GAS_PER_BLOCK |	393216 |
+
+At the fork block (where `parent.timestamp < FORK_TIMESTAMP`), we convert reset the excess gas and begin accumulating normalized excess_blob_gas.
+
+```
+def calc_excess_blob_gas(parent: Header) -> int:
+    if parent.timestamp < FORK_TIMESTAMP:
+        normalized_parent_excess_blob_gas = parent.excess_blob_gas * EXCESS_BLOB_GAS_NORMALIZATION_FACTOR // OLD_TARGET_BLOB_GAS_PER_BLOCK
+        target_blob_gas = OLD_TARGET_BLOB_GAS_PER_BLOCK
+        max_excess_gas_diff_possible = OLD_TARGET_BLOB_GAS_PER_BLOCK
+    else:
+        normalized_parent_excess_blob_gas = parent.excess_blob_gas
+        target_blob_gas = parent.target_blob_count * GAS_PER_BLOB
+        max_excess_gas_diff_possible = max(parent.max_blob_count - parent.target_blob_count, parent.target_blob_count) * GAS_PER_BLOB
+
+    return (
+        normalized_parent_excess_blob_gas +
+        (parent.blob_gas_used - target_blob_gas) * EXCESS_BLOB_GAS_NORMALIZATION_FACTOR // max_excess_gas_diff_possible
+    )
+    
+def get_base_fee_per_blob_gas(header: Header) -> int:
+  if header.timestamp < FORK_TIMESTAMP:
+    update_fraction = BLOB_BASE_FEE_UPDATE_FRACTION
+  else:
+    update_fraction = NORMALIZED_BLOB_BASE_FEE_UPDATE_FRACTION
+
+  return fake_exponential(
+    MIN_BASE_FEE_PER_BLOB_GAS,
+    header.excess_blob_gas,
+    update_fraction
+    )
+```
+
 ## Rationale
 
 The current MIN_BASE_FEE_PER_BLOB_GAS is 1 wei. This is many orders of magnitude lower than the prevailing price of blobs when blobs enter price discovery. Whenever demand for blobs exceeds supply, blobs enter price discovery, but traversing the 8 orders of magnitude between 1 wei and the point where elasticity of demand starts to decrease takes a long time.
 
-The blob base fee can at most double every $\log_{1.125}(10) = 5.885$ blocks when blocks use all available blob space. When blobs enter price discovery, they must climb many factors of 2 to reach the prevailing price.
 
-To set the parameter apropriately, one aproach is to look at the cost of simple transfers when base fees are low. The cost of a simple transfer when the base fee is 1 GWEI  is ~5 cents USD at today's prices (2,445.77$ ETH/USDC). We can try to peg the minimum price of a blob to that. Today, to reach this price, it requires an excess blob gas of `63070646`. When you calculate how long this would take to reach from 0 excess blob gas, you get:
+We propose `MIN_BASE_FEE_PER_BLOB_GAS = 2**25` (~1 cent at today's prices) to strike a balance between speed of price discovery and avoiding excessive reserve price during high ETH price periods."
 
-```
-63070646/(3 * 2**17) = 160.396947225
-```
-
-The closest power of 2 to the corresponding reserve price would be `MIN_BASE_FEE_PER_BLOB_GAS = 2**27`. Out of an abundance of caution, we will go with `MIN_BASE_FEE_PER_BLOB_GAS = 2**25` to ensure that even if the price of ETH rises significantly, the reserve price will not be set too high. This value corresponds to a minimum blob price of ~1 cent at today's prices (2,445.77$ ETH/USDC). Further, decreasing the `MIN_BASE_FEE_PER_BLOB_GAS` beyond `2**25` would slow down price discovery without a significant decrease in the price of blobs when the network is unsaturated. 
-
-Below you will find a plot provided by @dataalways showing the fraction of type 3 transaction fees that are paid in blob base fees for different values of `MIN_BASE_FEE_PER_BLOB_GAS`. Note that even after the proposed change, for historical values of l1 gas, the price of blobs would have been dominated by the price of the L1 gas.  
-
-![Base Fee 1](../assets/eip-7762/base_fee_1.png)
-
-
-![Base Fee 2^25](../assets/eip-7762/base_fee_225.png)
+For the excess gas normalization, the argument is to avoid sudden base fee jumps or drops at forks that change the target blob number. Without normalization of the excess gas, we can see base fee changes of more than $\pm 12.4\%$. After implementing the proposed normalization, we decouple the excess gas value from the specific target blob gas and ensure continuity across forks.
 
 
 ---
@@ -57,11 +95,13 @@ Below you will find a plot provided by @dataalways showing the fraction of type 
 
 ## Backwards Compatibility
 
-This EIP is not backwards compatible and requires a coordinated upgrade across all clients at a specific block number.
+This EIP introduces non-backward-compatible changes requiring a coordinated client upgrade at a designated block number.
 
 ## Security Considerations
 
-Rollups that use blobs as a data availability layer will need to update their posting strategies. 
+Rollups relying on blobs for data availability must update posting strategies to accommodate the changes in base fee dynamics.
+
+Furthermore, the authors discussed and considered making the base fee scale symmetric around the target. This holds true as long as the target is half of the max, however, with more flexible settings, e.g. 6/9, we would end up with a base fee that scales down faster than it can scale upwards. Intuitively, this feels wrong, however, by introducing a scaling factor to make the base fee scale symmetric around the target, we introduce some path dependency. Finally, at the time of this update, there is no consensus around this change.
 
 ## Copyright
 

--- a/EIPS/eip-7762.md
+++ b/EIPS/eip-7762.md
@@ -1,9 +1,9 @@
 ---
-eip: 9999
+eip: 7762
 title: Adjust blob base fee mechanism
-description: AAdjust the blob base fee mechanism for improved price discovery and normalization across forks
+description: Adjust the blob base fee mechanism for improved price discovery and normalization across forks
 author: Toni Wahrstätter (@nerolation), Gajinder Singh (@g11tech), Bert (@bkellerman), Max Resnick (@MaxResnick), Ansgar Dietrichs (@adietrichs), Barnabé Monnot <barnabe.monnot@ethereum.org>
-discussions-to: 
+discussions-to: https://ethereum-magicians.org/t/eip-7762-increase-min-base-fee-per-blob-gas/20949
 status: Draft
 type: Standards Track
 category: Core
@@ -30,7 +30,7 @@ The specification change introduced by the first part of this EIP is setting MIN
 - MIN_BASE_FEE_PER_BLOB_GAS = 1
 ```
 
-Furthermore, to avoid sudden price jumps in the blob base fee, the excess gas MUST be reset to 0 at the time of the fork.
+Furthermore, to avoid sudden changes in the blob base fee, the excess gas MUST be reset to 0 at the time of the fork.
 
 The second part of this EIP, the automated adjustment of the blob base fee update fraction, we propose the following:
 
@@ -39,19 +39,20 @@ The second part of this EIP, the automated adjustment of the blob base fee updat
 - BLOB_BASE_FEE_UPDATE_FRACTION = 3338477
 ```
 
-
 The third part of this EIP, the normalization is proposed the following:
 
 `excess_blob_gas` in the block now holds normalized excess blob gas accumulating `((blob_gas_used-target_blob_gas)/target_blob_gas) * EXCESS_BLOB_GAS_NORMALIZATION_FACTOR`. We choose `EXCESS_BLOB_GAS_NORMALIZATION_FACTOR` as 100E6 and this makes our choice of `NORMALIZED_BLOB_BASE_FEE_UPDATE_FRACTION as 3338477 * 100E6 // 393216 = 849018605`.
 
-| Constant |	Value |
-| EXCESS_BLOB_GAS_NORMALIZATION_FACTOR |	100E6 |
-| NORMALIZED_BLOB_BASE_FEE_UPDATE_FRACTION |	849018605 |
-| OLD_TARGET_BLOB_GAS_PER_BLOCK |	393216 |
+| Constant                              | Value      |
+|---------------------------------------|------------|
+| EXCESS_BLOB_GAS_NORMALIZATION_FACTOR  | 100E6      |
+| NORMALIZED_BLOB_BASE_FEE_UPDATE_FRACTION | 849018605 |
+| OLD_TARGET_BLOB_GAS_PER_BLOCK         | 393216     |
 
-At the fork block (where `parent.timestamp < FORK_TIMESTAMP`), we convert reset the excess gas and begin accumulating normalized excess_blob_gas.
 
-```
+At the fork block (where `parent.timestamp < FORK_TIMESTAMP`), we reset the excess gas and begin accumulating normalized excess_blob_gas.
+
+```python
 def calc_excess_blob_gas(parent: Header) -> int:
     if parent.timestamp < FORK_TIMESTAMP:
         normalized_parent_excess_blob_gas = parent.excess_blob_gas * EXCESS_BLOB_GAS_NORMALIZATION_FACTOR // OLD_TARGET_BLOB_GAS_PER_BLOCK
@@ -106,3 +107,4 @@ Furthermore, the authors discussed and considered making the base fee scale symm
 ## Copyright
 
 Copyright and related rights waived via [CC0](../LICENSE.md).
+


### PR DESCRIPTION
As discussed in [ACDC 146](https://github.com/ethereum/pm/issues/1200), we may want to split the blob target increase from the base fee mechanism changes. Those include:

* Increasing the constant min base fee and reseting excess gas
* Normalizing excess gas over target blob gas
* Automate blob base fee update fraction updates
* (optional) Introduce scaling factor for excess gas to ensure symmetric base fee scaling

As of yesterday's call, it looks like we won't ship these updates in Pectra, but in Fusaka.