### PR TITLE
Update EIP-7819: clarify what is `authority`

### DIFF
--- a/EIPS/eip-7819.md
+++ b/EIPS/eip-7819.md
@@ -46,7 +46,7 @@ Executing this instruction does the following:
 4. calculate `location` as `keccak256(MAGIC ++ address ++ salt)[12:]`
 5. halt if the code at `location` is not empty and does not start with `0xEF0100` (no empty and not a designator)
 6. add `EMPTY_ACCOUNT_COST - BASE_COST` gas to the global refund counter if `location` exists in the trie.
-7. set the code of `authority` to be `MAGIC || target`, matching the delegation process defined in EIP-7702.
+7. set the code of `location` to be `MAGIC || target`, matching the delegation process defined in EIP-7702.
     - Similarly to EIP-7702, if `target` is `0x0000000000000000000000000000000000000000` do not write the designation. Clear the code at `location` and reset the `location`'s code hash to the empty hash `0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470`.
 8. push `location` onto the stack
 


### PR DESCRIPTION
It seems like this got carried over from 7702 and `location` was meant instead.