### PR TITLE
Update EIP-7639: format as new eth wire protocol

### DIFF
--- a/EIPS/eip-7639.md
+++ b/EIPS/eip-7639.md
@@ -1,6 +1,6 @@
 ---
 eip: 7639
-title: Cease serving history before PoS
+title: eth/71 - Cease serving history before PoS
 description: Execution layer clients will no longer serve block data before Paris over p2p.
 author: lightclient (@lightclient)
 discussions-to: https://ethereum-magicians.org/t/cease-serving-history-before-pos/18991
@@ -24,7 +24,16 @@ proposes the first steps to achieve such goal.
 
 ## Specification
 
-Clients must not make or respond to p2p queries about blocks before block 15537393.
+Add a new `eth` protocol capability with version `71`. 
+
+Clients connected on this version must not make or respond to p2p queries about
+block bodies or receipts before block 15537393.
+
+The affected protocol messages are:
+    * `GetBlockBodies (0x05)`
+    * `BlockBodies (0x06)`
+    * `GetReceipts (0x0f)`
+    * `Receipts (0x10)`
 
 ## Rationale
 


### PR DESCRIPTION
Note that only bodies and receipts are dropped. Header chain remains intact. 