### PR TITLE
Update EIP-7623: add additional backwards compatibility considerations

### DIFF
--- a/EIPS/eip-7623.md
+++ b/EIPS/eip-7623.md
@@ -82,7 +82,13 @@ The calldata cost for transactions involving significant EVM computation remains
 
 This is a backwards incompatible gas repricing that requires a scheduled network upgrade.
 
-Users will be able to continue operating with no changes.
+Wallet developers and node operators MUST update their handling of gas estimation to accommodate the new calldata cost rules. Specifically:
+
+1. **Wallets**: Wallets using `eth_estimateGas` to calculate the gas limit for transactions MUST be updated to ensure that they correctly account for the `TOTAL_COST_FLOOR_PER_TOKEN` parameter. Failure to do so could result in underestimating gas, leading to failed transactions.
+   
+2. **Node Software**: RPC methods like `eth_estimateGas` must incorporate the revised formula for gas calculation to ensure accurate responses to client requests. Node developers MUST ensure compatibility with the updated calldata pricing logic.
+
+Users will be able to continue operating with no changes to their workflows, but underlying wallet and RPC implementations must be updated to ensure smooth functioning.
 
 ## Security Considerations
 

--- a/EIPS/eip-7623.md
+++ b/EIPS/eip-7623.md
@@ -64,7 +64,7 @@ tx.gasUsed = {
     )
 ```
 
-For implementation this means that a transaction must be able to pay the floor cost before execution.
+Any transaction with a gas limit less than `21000 + TOTAL_COST_FLOOR_PER_TOKEN * tokens_in_calldata` is invalid. This limitation exists because transactions must be able to pay for the floor price of their call data without relying the execution of the transaction. There are valid cases where `gasUsed` will be below this floor price, but the floor price needs to be reserved in the transaction gas limit.
 
 ## Rationale
 
@@ -87,6 +87,14 @@ Users will be able to continue operating with no changes.
 ## Security Considerations
 
 As the maximum possible block size is reduced, no security concerns were raised.
+
+In some cases, it might seem advantageous to combine two transactions into one to reduce costs—for example, bundling a transaction that uses a lot of calldata but minimal EVM resources with another that heavily uses EVM resources. However, this is not a significant concern for several reasons:
+
+1. This type of bundling is already possible today. Combining multiple transactions into one can save the 21,000 gas cost for each additional transaction beyond the first, a feature explicitly supported in [ERC-4337](./eip-4337.md).
+2. Such bundling does not bypass the block size reduction goals achieved by this EIP.
+3. In practice, transaction bundling faces challenges such as the need for trust and coordination, which often make it impractical to implement.
+
+These factors ensure that transaction bundling does not pose a significant issue.
 
 ## Copyright
 


### PR DESCRIPTION
Add additional "backwards compatibilty" info regarding eth_estimateGas.