### PR TITLE
Update EIP-7762: add excess gas reset

### DIFF
--- a/EIPS/eip-7762.md
+++ b/EIPS/eip-7762.md
@@ -13,7 +13,7 @@ requires: 4844
 
 ## Abstract
 
-This EIP proposes an increase to the MIN_BASE_FEE_PER_BLOB_GAS to speed up price discovery on blob space. 
+This EIP proposes an increase to the MIN_BASE_FEE_PER_BLOB_GAS to speed up price discovery on blob space. It also resets the excess blob gas to 0, to avoid a blob basefee spike.
 
 ## Motivation
 
@@ -23,11 +23,39 @@ Increasing the MIN_BASE_FEE_PER_BLOB_GAS will speed up price discovery on blob s
 
 ## Specification
 
-The only specification change introduced by this EIP is setting MIN_BASE_FEE_PER_BLOB_GAS to 2**25:
+### `MIN_BASE_FEE_PER_BLOB_GAS` Increase
+
+The main specification change introduced by this EIP is setting MIN_BASE_FEE_PER_BLOB_GAS to 2**25:
 
 ```diff
 + MIN_BASE_FEE_PER_BLOB_GAS  =  2**25
 - MIN_BASE_FEE_PER_BLOB_GAS = 1
+```
+
+### `excess_blob_gas` Reset
+
+To avoid a blob basefee spike, the `calc_excess_blob_gas` is modified to reset `excess_blob_gas` to 0 at the fork. To detect the fork height, the block timestamp needs to be passed into `calc_excess_blob_gas`.
+
+```python
+def calc_excess_blob_gas(parent: Header, block_timestamp: int) -> int:
+    # at the fork, set excess_blob_gas to 0
+    if parent.timestamp < PECTRA_FORK_TIMESTAMP and block_timestamp >= PECTRA_FORK_TIMESTAMP:
+        return 0
+    
+    # otherwise, calculate normally
+    ...
+```
+
+`validate_block` needs to be updated to pass the block timestamp into `calc_excess_blob_gas`:
+
+```python
+def validate_block(block: Block) -> None:
+    ...
+
+    # add timestamp parameter
+    assert block.header.excess_blob_gas == calc_excess_blob_gas(block.parent.header, block.header.timestamp)
+
+    ...
 ```
 
 ## Rationale


### PR DESCRIPTION
Reset the excess blob gas to 0, to avoid a blob basefee spike.

Todo (in followup PR): add rationale.