### PR TITLE
Update EIP-7639: Fix rendering of 7639 specification

### DIFF
--- a/EIPS/eip-7639.md
+++ b/EIPS/eip-7639.md
@@ -30,10 +30,11 @@ Clients connected on this version must not make or respond to p2p queries about
 block bodies or receipts before block 15537393.
 
 The affected protocol messages are:
-    * `GetBlockBodies (0x05)`
-    * `BlockBodies (0x06)`
-    * `GetReceipts (0x0f)`
-    * `Receipts (0x10)`
+
+- `GetBlockBodies (0x05)`
+- `BlockBodies (0x06)`
+- `GetReceipts (0x0f)`
+- `Receipts (0x10)`
 
 ## Rationale
 


### PR DESCRIPTION
Currently rendered like this:
<img width="1040" alt="Screenshot 2024-12-05 at 16 01 05" src="https://github.com/user-attachments/assets/9ec5d304-e2f0-4ecc-a0f0-ceda5d688f30">
