### PR TITLE
Update EIP-7600: Add EIPs 7623 & 7691

### DIFF
--- a/EIPS/eip-7600.md
+++ b/EIPS/eip-7600.md
@@ -26,24 +26,25 @@ Definitions for `Scheduled for Inclusion` and `Considered for Inclusion` can be 
 * [EIP-7002](./eip-7002.md): Execution layer triggerable exits
 * [EIP-7251](./eip-7251.md): Increase the MAX_EFFECTIVE_BALANCE  
 * [EIP-7549](./eip-7549.md): Move committee index outside Attestation
+* [EIP-7623](./eip-7623.md): Increase calldata cost
 * [EIP-7685](./eip-7685.md): General purpose execution layer requests 
+* [EIP-7691](./eip-7691.md): Blob throughput increase
 * [EIP-7702](./eip-7702.md): Set EOA account code
 * [EIP-7742](./eip-7742.md): Uncouple blob count between CL and EL
 
 ### EIPs Considered for Inclusion
 
-* [EIP-7623](./eip-7623.md): Increase calldata cost
 * [EIP-7762](./eip-7762.md): Increase MIN_BASE_FEE_PER_BLOB_GAS 
 
 ### Full Specifications 
 
 #### Consensus Layer
 
-EIP-6110, EIP-7002 EIP-7251, EIP-7549 and EIP-7742 require changes to Ethereum's consensus layer. While the EIPs present an overview of these changes, the full specifications can be found in the `specs/electra` and `specs/_features` directories of the `ethereum/consensus-specs` repository.
+EIP-6110, EIP-7002 EIP-7251, EIP-7549, EIP-7691 and EIP-7742 require changes to Ethereum's consensus layer. While the EIPs present an overview of these changes, the full specifications can be found in the `specs/electra` and `specs/_features` directories of the `ethereum/consensus-specs` repository.
 
 #### Execution Layer
 
-EIP-2537, EIP-2935, EIP-6110, EIP-7685, EIP-7002, EIP-7702 and EIP-7742 require changes to Ethereum's execution layer. The EIPs fully specify those changes. 
+EIP-2537, EIP-2935, EIP-6110, EIP-7685, EIP-7002, EIP-7623, EIP-7702 and EIP-7742 require changes to Ethereum's execution layer. The EIPs fully specify those changes. 
 
 ### Activation 
 

--- a/EIPS/eip-7600.md
+++ b/EIPS/eip-7600.md
@@ -7,16 +7,16 @@ discussions-to: https://ethereum-magicians.org/t/eip-7600-hardfork-meta-prague-e
 status: Review
 type: Meta
 created: 2024-01-18
-requires: 2537, 2935, 6110, 7002, 7251, 7549, 7594, 7685, 7702, 7742
+requires: 2537, 2935, 6110, 7002, 7251, 7549, 7594, 7685, 7702
 ---
 
 ## Abstract
 
-This Meta EIP lists the EIPs formally Considered and Scheduled for Inclusion in the Prague/Electra network upgrade.
+This Meta EIP lists the EIPs formally Scheduled for Inclusion in the Prague/Electra network upgrade.
 
 ## Specification
 
-Definitions for `Scheduled for Inclusion` and `Considered for Inclusion` can be found in [EIP-7723](./eip-7723.md).
+A formal definition for `Scheduled for Inclusion` can be found in [EIP-7723](./eip-7723.md).
 
 ### EIPs Scheduled for Inclusion  
 
@@ -30,21 +30,16 @@ Definitions for `Scheduled for Inclusion` and `Considered for Inclusion` can be 
 * [EIP-7685](./eip-7685.md): General purpose execution layer requests 
 * [EIP-7691](./eip-7691.md): Blob throughput increase
 * [EIP-7702](./eip-7702.md): Set EOA account code
-* [EIP-7742](./eip-7742.md): Uncouple blob count between CL and EL
-
-### EIPs Considered for Inclusion
-
-* [EIP-7762](./eip-7762.md): Increase MIN_BASE_FEE_PER_BLOB_GAS 
 
 ### Full Specifications 
 
 #### Consensus Layer
 
-EIP-6110, EIP-7002 EIP-7251, EIP-7549, EIP-7691 and EIP-7742 require changes to Ethereum's consensus layer. While the EIPs present an overview of these changes, the full specifications can be found in the `specs/electra` and `specs/_features` directories of the `ethereum/consensus-specs` repository.
+EIP-6110, EIP-7002 EIP-7251, EIP-7549 and EIP-7691 require changes to Ethereum's consensus layer. While the EIPs present an overview of these changes, the full specifications can be found in the `specs/electra` and `specs/_features` directories of the `ethereum/consensus-specs` repository.
 
 #### Execution Layer
 
-EIP-2537, EIP-2935, EIP-6110, EIP-7685, EIP-7002, EIP-7623, EIP-7702 and EIP-7742 require changes to Ethereum's execution layer. The EIPs fully specify those changes. 
+EIP-2537, EIP-2935, EIP-6110, EIP-7685, EIP-7002, EIP-7623 and EIP-7702 require changes to Ethereum's execution layer. The EIPs fully specify those changes. 
 
 ### Activation 
 

--- a/EIPS/eip-7600.md
+++ b/EIPS/eip-7600.md
@@ -39,7 +39,7 @@ EIP-6110, EIP-7002 EIP-7251, EIP-7549 and EIP-7691 require changes to Ethereum's
 
 #### Execution Layer
 
-EIP-2537, EIP-2935, EIP-6110, EIP-7685, EIP-7002, EIP-7623 and EIP-7702 require changes to Ethereum's execution layer. The EIPs fully specify those changes. 
+EIP-2537, EIP-2935, EIP-6110, EIP-7685, EIP-7002, EIP-7623 and EIP-7702 require changes to Ethereum's execution layer. The EIPs fully specify those changes.
 
 ### Activation 
 


### PR DESCRIPTION
EIP-7691 was SFI'd on [ACDC#146](https://github.com/ethereum/pm/issues/1200) and EIP-7623 was SFI'd on [ACDE#201](https://github.com/ethereum/pm/issues/1197)