### PR TITLE
Update EIP-2537: Gas pricing MAP, MUL and ADD operations

### DIFF
--- a/EIPS/eip-2537.md
+++ b/EIPS/eip-2537.md
@@ -295,7 +295,7 @@ Fp -> G1 mapping is `4125` gas.
 
 #### Fp2-to-G2 mapping operation
 
-Fp2 -> G2 mapping is `14055` gas
+Fp2 -> G2 mapping is `17000` gas
 
 #### Gas schedule clarifications for the variable-length input
 

--- a/EIPS/eip-2537.md
+++ b/EIPS/eip-2537.md
@@ -295,7 +295,7 @@ Fp -> G1 mapping is `4125` gas.
 
 #### Fp2-to-G2 mapping operation
 
-Fp2 -> G2 mapping is `75000` gas
+Fp2 -> G2 mapping is `15000` gas
 
 #### Gas schedule clarifications for the variable-length input
 

--- a/EIPS/eip-2537.md
+++ b/EIPS/eip-2537.md
@@ -291,11 +291,11 @@ The cost of the pairing check operation is `43000*k + 65000` where `k` is a numb
 
 #### Fp-to-G1 mapping operation
 
-Fp -> G1 mapping is `4125` gas.
+Fp -> G1 mapping is `5500` gas.
 
 #### Fp2-to-G2 mapping operation
 
-Fp2 -> G2 mapping is `17000` gas
+Fp2 -> G2 mapping is `23800` gas
 
 #### Gas schedule clarifications for the variable-length input
 

--- a/EIPS/eip-2537.md
+++ b/EIPS/eip-2537.md
@@ -253,11 +253,11 @@ A sane implementation of this EIP *should not* contain potential infinite loops 
 
 ### Gas schedule
 
-Assuming a constant `30 MGas/second`, the following prices are suggested.
+Assuming `EcRecover` precompile as a baseline.
 
 #### G1 addition
 
-`500` gas
+`375` gas
 
 #### G1 multiplication
 
@@ -265,11 +265,11 @@ Assuming a constant `30 MGas/second`, the following prices are suggested.
 
 #### G2 addition
 
-`800` gas
+`600` gas
 
 #### G2 multiplication
 
-`45000` gas
+`22500` gas
 
 #### G1/G2 MSM
 

--- a/EIPS/eip-2537.md
+++ b/EIPS/eip-2537.md
@@ -291,7 +291,7 @@ The cost of the pairing check operation is `43000*k + 65000` where `k` is a numb
 
 #### Fp-to-G1 mapping operation
 
-Fp -> G1 mapping is `5500` gas.
+Fp -> G1 mapping is `4125` gas.
 
 #### Fp2-to-G2 mapping operation
 

--- a/EIPS/eip-2537.md
+++ b/EIPS/eip-2537.md
@@ -295,7 +295,7 @@ Fp -> G1 mapping is `4125` gas.
 
 #### Fp2-to-G2 mapping operation
 
-Fp2 -> G2 mapping is `15000` gas
+Fp2 -> G2 mapping is `14055` gas
 
 #### Gas schedule clarifications for the variable-length input
 


### PR DESCRIPTION
Nethermind proposal of MUL and ADD operations. The speed of this precompile measured on Intel NUC 11 Intel Core i7-1165G7 and Nethermind client (EcRecover ~80 mgas/s). Full proposal: https://github.com/Marchhill/bls-precompile-benchmarks/blob/main/proposed-changes.md

```
g1add-1: 86.61 mgas/s (83.42-90.05)
g1mul-1: 86.90 mgas/s (83.24-90.89)
g2add-1: 82.34 mgas/s (78.50-86.58)
g2mul-1: 93.40 mgas/s (88.11-99.38)
mapfp-1: 89.96 mgas/s (85.91-94.40)
```


**ATTENTION: ERC-RELATED PULL REQUESTS NOW OCCUR IN [ETHEREUM/ERCS](https://github.com/ethereum/ercs)**

--

When opening a pull request to submit a new EIP, please use the suggested template: https://github.com/ethereum/EIPs/blob/master/eip-template.md

We have a GitHub bot that automatically merges some PRs. It will merge yours immediately if certain criteria are met:

 - The PR edits only existing draft PRs.
 - The build passes.
 - Your GitHub username or email address is listed in the 'author' header of all affected PRs, inside <triangular brackets>.
 - If matching on email address, the email address is the one publicly listed on your GitHub profile.
