### PR TITLE
Update EIP-7639: protocol version should be 70

### DIFF
--- a/EIPS/eip-7639.md
+++ b/EIPS/eip-7639.md
@@ -1,6 +1,6 @@
 ---
 eip: 7639
-title: eth/71 - Cease serving history before PoS
+title: eth/70 - Cease serving history before PoS
 description: Execution layer clients will no longer serve block data before Paris over p2p.
 author: lightclient (@lightclient)
 discussions-to: https://ethereum-magicians.org/t/cease-serving-history-before-pos/18991
@@ -24,7 +24,7 @@ proposes the first steps to achieve such goal.
 
 ## Specification
 
-Add a new `eth` protocol capability with version `71`. 
+Add a new `eth` protocol capability with version `70`. 
 
 Clients connected on this version must not make or respond to p2p queries about
 block bodies or receipts before block 15537393.


### PR DESCRIPTION
Downgrade wire protocol version from 71 to 70.