### PR TITLE
Update EIP-7251: fix CONSOLIDATION_REQUEST_PREDEPLOY_ADDRES

### DIFF
--- a/EIPS/eip-7251.md
+++ b/EIPS/eip-7251.md
@@ -29,7 +29,7 @@ With the security model of the protocol no longer dependent on a low value for `
 | Name | Value | Comment |
 | - | - | - |
 | `CONSOLIDATION_REQUEST_TYPE` | `0x02` | The [EIP-7685](./eip-7685.md) type prefix for consolidation request |
-| `CONSOLIDATION_REQUEST_PREDEPLOY_ADDRESS` | `0x01aBEa29659e5e97C95107F20bb753cD3e09bBBb` | Where to call and store relevant details about consolidation request mechanism |
+| `CONSOLIDATION_REQUEST_PREDEPLOY_ADDRESS` | `0x0046BB33B9eA028AE30BAd20702e36Ea8099BBbb` | Where to call and store relevant details about consolidation request mechanism |
 | `SYSTEM_ADDRESS` | `0xfffffffffffffffffffffffffffffffffffffffe` | Address used to invoke system operation on contract |
 | `EXCESS_CONSOLIDATION_REQUESTS_STORAGE_SLOT` | `0` | |
 | `CONSOLIDATION_REQUEST_COUNT_STORAGE_SLOT` | `1` | |


### PR DESCRIPTION
Fixes the address.

Verified with: https://gist.github.com/protolambda/58f73421b91602a6a0f5104a9f0f5c89

The `CONSOLIDATION_REQUEST_PREDEPLOY_ADDRESS` now matches the address in the bytecode deployment section again.

