### PR TITLE
Update EIP-7251: replace check_fee with get_fee check

### DIFF
--- a/EIPS/eip-7251.md
+++ b/EIPS/eip-7251.md
@@ -80,7 +80,7 @@ The contract has three different code paths, which can be summarized at a high l
 
 If call data input to the contract is exactly `96` bytes, perform the following:
 
-1. Ensure enough ETH was sent to cover the current consolidation request fee (`check_fee()`)
+1. Ensure enough ETH was sent to cover the current consolidation request fee (`msg.value >= get_fee()`)
 2. Increase consolidation request count by `1` for the current block (`increment_count()`)
 3. Insert a consolidation request into the queue for the source address and pubkeys of the source and the target (`insert_withdrawal_request_into_queue()`)
 


### PR DESCRIPTION
There is no `check_fee` defined in the EIP, the reference in the text was probably referring to older pseudo code.

This changes the reference to `msg.value >= get_fee()`, a short version of the pseudo code in the EIP, part of `add_consolidation_request`:
```
    # Verify sufficient fee was provided.
    fee = get_fee()
    require(msg.value >= fee, 'Insufficient value for fee')
```
