### PR TITLE
Update EIP7623 to reflect correct invalid cost

### DIFF
--- a/EIPS/eip-7623.md
+++ b/EIPS/eip-7623.md
@@ -60,7 +60,7 @@ tx.gasUsed = {
     )
 ```
 
-Any transaction with a gas limit below `21000 + TOTAL_COST_FLOOR_PER_TOKEN * tokens_in_calldata` is considered invalid. This limitation exists because transactions must cover the floor price of their calldata without relying on the execution of the transaction. There are valid cases where `gasUsed` will be below this floor price, but the floor price needs to be reserved in the transaction gas limit.
+Any transaction with a gas limit below `21000 + isContractCreation * (32000 + InitCodeWordGas * words(calldata)) + TOTAL_COST_FLOOR_PER_TOKEN * tokens_in_calldata` is considered invalid. This limitation exists because transactions must cover the floor price of their calldata without relying on the execution of the transaction. There are valid cases where `gasUsed` will be below this floor price, but the floor price needs to be reserved in the transaction gas limit.
 
 ## Rationale
 


### PR DESCRIPTION
EIP 7623 currently marks transactions as "invalid" (these cannot be included in a block) for `21000 + TOTAL_COST_FLOOR_PER_TOKEN * tokens_in_calldata`. This does not reflect the case if a contract is being created, which should also bump this cost.