### PR TITLE
Update EIP-7742: use parent target blob count for excess blob gas calculation

### DIFF
--- a/EIPS/eip-7742.md
+++ b/EIPS/eip-7742.md
@@ -81,7 +81,17 @@ target blob count given by that genesis block's protocol rule set.
 Upon activating this EIP (i.e. before processing any transactions),
 the verification of the blob maximum as given in EIP-4844 can be skipped. Concretely, this means any logic relating
 to `MAX_BLOB_GAS_PER_BLOCK` as given in EIP-4844 can be deprecated.
-Additionally, any reference to `TARGET_BLOB_GAS_PER_BLOCK` from EIP-4844 can be derived by taking the `target_blobs_per_block` from the CL and multiplying by `GAS_PER_BLOB` as given in EIP-4844.
+
+Additionally, `calc_excess_blob_gas` is updated as follows:
+
+```python
+def calc_excess_blob_gas(parent: Header) -> int:
+    target_blob_gas = parent.target_blobs_per_block * GAS_PER_BLOB
+    if parent.excess_blob_gas + parent.blob_gas_used < target_blob_gas:
+        return 0
+    else:
+        return parent.excess_blob_gas + parent.blob_gas_used - target_blob_gas
+```
 
 Otherwise, the specification of EIP-4844 is not changed. For example, blob base fee accounting and excess blob gas tracking occur in the exact same way.
 


### PR DESCRIPTION
the EIP currently uses the target blob count of the current block, although closer inspection of this EIP surfaced the issue that really the excess blob gas computation should use the parent header

this is only really relevant at hard fork boundaries, but avoids weird edge cases with this calculation at hard fork boundaries