### PR TITLE
Update EIP-4762: clarify change in behaviour for CALLCODE cost if value transfer

### DIFF
--- a/EIPS/eip-4762.md
+++ b/EIPS/eip-4762.md
@@ -193,6 +193,7 @@ Remove the following gas costs:
  * Increased gas cost of `CALL` if it is nonzero-value-sending
  * [EIP-2200](./eip-2200.md) `SSTORE` gas costs except for the `SLOAD_GAS`
  * 200 per byte contract code cost
+ * static `CALLCODE` cost if it is nonzero-value-sending
 
 Reduce gas cost:
 


### PR DESCRIPTION
I think the removal of CALLCODE cost for value transfer needs to be clarified and I didn't find any reference to it in the EIP. I remember that Besu bumped into this change and we actually applied the change to previous forks as well causing the CI pipeline to fail later on.

Even though it makes sense to not charge anything since CALLCODE transfers to itself, that's not the case with previous forks so this is a change in behaviour which IMO is worth documenting. 

cc @gballet @jsign 