### PR TITLE
Update EIP-7703: typos in documentation files

### DIFF
--- a/EIPS/eip-7703.md
+++ b/EIPS/eip-7703.md
@@ -17,7 +17,7 @@ An adjustment in the Ethereum calldata cost which reduces the maximum possible b
 ## Motivation
 
 Larger blocks take longer to propagate through the network. 
-In this way, the maximium potential block size is constraining the block gas limit.
+In this way, the maximum potential block size is constraining the block gas limit.
 Therefore, in order to safely increase the block gas limit, the calldata gas must be increased.
 
 ## Specification
@@ -27,7 +27,7 @@ Therefore, in order to safely increase the block gas limit, the calldata gas mus
 
 ## Rationale
 
-Tripling the gas cost of calldata reduces the maximimum possible block size by a factor of three.
+Tripling the gas cost of calldata reduces the maximum possible block size by a factor of three.
 
 ## Backwards Compatibility
 

--- a/EIPS/eip-7732.md
+++ b/EIPS/eip-7732.md
@@ -120,7 +120,7 @@ The `BeaconState` container is modified with the addition of:
 
 - `latest_block_hash`, of type `Hash32`, to track the blockhash of the last execution payload in the blockchain. 
 - `latest_full_slot`, of type `Slot`, to track the latest slot in which an execution payload was included. 
-- `latest_widthdrawals_root` of type `Root` to track the hash tree root of the latests withdrawals deducted in the beacon chain when processing a `SignedBeaconBlock`. 
+- `latest_withdrawals_root` of type `Root` to track the hash tree root of the latests withdrawals deducted in the beacon chain when processing a `SignedBeaconBlock`. 
 
 The `BeaconBlockBody` is modified with the addition of:
 
@@ -133,7 +133,7 @@ State transition logic is modified by:
 
 - A new beacon state getter `get_ptc` returns the PTC members for a given slot. 
 - `get_attesting_indices` is modified to not return the beacon committee members that are included in the PTC.
-- `process_withdrawals` is modified as follows. Withdrawals are obtained directly from the beacon state instead of the execution payload. They are deducted from the beacon chain. The beacon state `latest_widthdrawals_root` is updated with the HTR of this list. The next execution payload MUST include withdrawals matching the `state.latest_withdrawals_root`. 
+- `process_withdrawals` is modified as follows. Withdrawals are obtained directly from the beacon state instead of the execution payload. They are deducted from the beacon chain. The beacon state `latest_withdrawals_root` is updated with the HTR of this list. The next execution payload MUST include withdrawals matching the `state.latest_withdrawals_root`. 
 - `process_execution_payload` is removed from `process_block`. Instead a new function `process_execution_payload_header` is included, this function validates the `SignedExecutionPayloadHeader` included in the `BeaconBlockBody` and transfers the payment from the builder's balance to the proposer. 
 - `process_deposit_request` is removed from `process_operations` and deferred until `process_execution_payload`. 
 - `process_withdrawal_request` is removed from `process_operations` and deferred until `process_execution_payload`. 
@@ -232,7 +232,7 @@ When a builder reveals an expected payload and the PTC achieved consensus that i
 
 Similarly, when a builder reveals a *payload withheld* message and the PTC achieved consensus by having at least `PAYLOAD_TIMELY_THRESHOLD` votes for `PAYLOAD_WITHHELD`, then the parent consensus block receives a boost equivalent to 40% of the beacon committee. Given the `(Block, Slot)` nature of fork choice voting, this boost counts **against** the consensus block containing the builder's commitment. 
 
-Both these boosts are present to guarantee the Builder's reveal and withhold safety under the parameters described in the [Secutiry Considerations](#security-considerations) section. 
+Both these boosts are present to guarantee the Builder's reveal and withhold safety under the parameters described in the [Security Considerations](#security-considerations) section. 
 
 ### PTC equivocations
 

--- a/EIPS/eip-7732.md
+++ b/EIPS/eip-7732.md
@@ -120,7 +120,7 @@ The `BeaconState` container is modified with the addition of:
 
 - `latest_block_hash`, of type `Hash32`, to track the blockhash of the last execution payload in the blockchain. 
 - `latest_full_slot`, of type `Slot`, to track the latest slot in which an execution payload was included. 
-- `latest_withdrawals_root` of type `Root` to track the hash tree root of the latests withdrawals deducted in the beacon chain when processing a `SignedBeaconBlock`. 
+- `latest_widthdrawals_root` of type `Root` to track the hash tree root of the latests withdrawals deducted in the beacon chain when processing a `SignedBeaconBlock`. 
 
 The `BeaconBlockBody` is modified with the addition of:
 
@@ -133,7 +133,7 @@ State transition logic is modified by:
 
 - A new beacon state getter `get_ptc` returns the PTC members for a given slot. 
 - `get_attesting_indices` is modified to not return the beacon committee members that are included in the PTC.
-- `process_withdrawals` is modified as follows. Withdrawals are obtained directly from the beacon state instead of the execution payload. They are deducted from the beacon chain. The beacon state `latest_withdrawals_root` is updated with the HTR of this list. The next execution payload MUST include withdrawals matching the `state.latest_withdrawals_root`. 
+- `process_withdrawals` is modified as follows. Withdrawals are obtained directly from the beacon state instead of the execution payload. They are deducted from the beacon chain. The beacon state `latest_widthdrawals_root` is updated with the HTR of this list. The next execution payload MUST include withdrawals matching the `state.latest_withdrawals_root`. 
 - `process_execution_payload` is removed from `process_block`. Instead a new function `process_execution_payload_header` is included, this function validates the `SignedExecutionPayloadHeader` included in the `BeaconBlockBody` and transfers the payment from the builder's balance to the proposer. 
 - `process_deposit_request` is removed from `process_operations` and deferred until `process_execution_payload`. 
 - `process_withdrawal_request` is removed from `process_operations` and deferred until `process_execution_payload`. 
@@ -232,7 +232,7 @@ When a builder reveals an expected payload and the PTC achieved consensus that i
 
 Similarly, when a builder reveals a *payload withheld* message and the PTC achieved consensus by having at least `PAYLOAD_TIMELY_THRESHOLD` votes for `PAYLOAD_WITHHELD`, then the parent consensus block receives a boost equivalent to 40% of the beacon committee. Given the `(Block, Slot)` nature of fork choice voting, this boost counts **against** the consensus block containing the builder's commitment. 
 
-Both these boosts are present to guarantee the Builder's reveal and withhold safety under the parameters described in the [Security Considerations](#security-considerations) section. 
+Both these boosts are present to guarantee the Builder's reveal and withhold safety under the parameters described in the [Secutiry Considerations](#security-considerations) section. 
 
 ### PTC equivocations
 


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `maximium` to `maximum`
Corrected `maximimum` to `maximum`
Corrected `latest_widthdrawals_root` to `latest_withdrawals_root` x2.
Corrected `Secutiry` to `Security`

Please review the changes and let me know if any additional changes are needed.