### PR TITLE
Update EIP-7702: make chain id u256

### DIFF
--- a/EIPS/eip-7702.md
+++ b/EIPS/eip-7702.md
@@ -52,7 +52,7 @@ The transaction is also considered invalid when any field in an authorization
 tuple cannot fit within the following bounds:
 
 ```python
-assert auth.chain_id < 2**64
+assert auth.chain_id < 2**256
 assert auth.nonce < 2**64
 assert len(auth.address) == 20
 assert auth.y_parity < 2**8


### PR DESCRIPTION
There has been a comment that there are efforts which will expect chain id to be u256. I think we should make this change to 7702. https://ethereum-magicians.org/t/eip-7702-set-eoa-account-code/19923/326?u=matt