### PR TITLE
Update EIP-2537: PAIRING_CHECK repricing

### DIFF
--- a/EIPS/eip-2537.md
+++ b/EIPS/eip-2537.md
@@ -287,7 +287,7 @@ Discounts table as a vector of pairs `[k, discount]`:
 
 #### Pairing check operation
 
-The cost of the pairing check operation is `43000*k + 65000` where `k` is a number of pairs.
+The cost of the pairing check operation is `16500*k + 17000` where `k` is a number of pairs.
 
 #### Fp-to-G1 mapping operation
 


### PR DESCRIPTION
Follow-up to:
- https://github.com/ethereum/EIPs/pull/9097
- https://github.com/ethereum/EIPs/pull/9116
- ACD breakout sessions
- bls-precompile discord breakout thread
- https://ethereum-magicians.org/t/eip-2537-bls12-precompile-discussion-thread/4187/76

On a Ryzen 7840U:

Before

```
--------------------------------------------------------------------------------------------------------------------------------
BLS12_PAIRINGCHECK 1      108000 gas     218.30 MGas/s        2021.309 ops/s       494729 ns/op      1629483 CPU cycles (approx)
BLS12_PAIRINGCHECK 2      151000 gas     222.94 MGas/s        1476.422 ops/s       677313 ns/op      2230872 CPU cycles (approx)
BLS12_PAIRINGCHECK 3      194000 gas     222.72 MGas/s        1148.038 ops/s       871051 ns/op      2868990 CPU cycles (approx)
BLS12_PAIRINGCHECK 4      237000 gas     223.83 MGas/s         944.446 ops/s      1058822 ns/op      3487463 CPU cycles (approx)
BLS12_PAIRINGCHECK 5      280000 gas     222.68 MGas/s         795.285 ops/s      1257411 ns/op      4141559 CPU cycles (approx)
BLS12_PAIRINGCHECK 6      323000 gas     224.12 MGas/s         693.859 ops/s      1441214 ns/op      4746960 CPU cycles (approx)
BLS12_PAIRINGCHECK 7      366000 gas     223.12 MGas/s         609.628 ops/s      1640344 ns/op      5402839 CPU cycles (approx)
BLS12_PAIRINGCHECK 8      409000 gas     223.75 MGas/s         547.073 ops/s      1827909 ns/op      6020628 CPU cycles (approx)
--------------------------------------------------------------------------------------------------------------------------------
```

After

```
--------------------------------------------------------------------------------------------------------------------------------
BLS12_PAIRINGCHECK 1       33500 gas      72.73 MGas/s        2171.067 ops/s       460603 ns/op      1516963 CPU cycles (approx)
BLS12_PAIRINGCHECK 2       50000 gas      79.67 MGas/s        1593.476 ops/s       627559 ns/op      2067001 CPU cycles (approx)
BLS12_PAIRINGCHECK 3       66500 gas      82.81 MGas/s        1245.245 ops/s       803055 ns/op      2645035 CPU cycles (approx)
BLS12_PAIRINGCHECK 4       83000 gas      84.13 MGas/s        1013.575 ops/s       986607 ns/op      3249599 CPU cycles (approx)
BLS12_PAIRINGCHECK 5       99500 gas      85.30 MGas/s         857.262 ops/s      1166505 ns/op      3842124 CPU cycles (approx)
BLS12_PAIRINGCHECK 6      116000 gas      71.85 MGas/s         619.379 ops/s      1614520 ns/op      5317666 CPU cycles (approx)
BLS12_PAIRINGCHECK 7      132500 gas      75.60 MGas/s         570.603 ops/s      1752531 ns/op      5772145 CPU cycles (approx)
BLS12_PAIRINGCHECK 8      149000 gas      77.11 MGas/s         517.504 ops/s      1932352 ns/op      6364178 CPU cycles (approx)
--------------------------------------------------------------------------------------------------------------------------------
```

## Comparison with EIP-4844

This change is very motivated by the KZG_POINT_PRECOMPILE from EIP-4844 priced at 50000 gas that does a double pairing check + extras.

https://github.com/ethereum/EIPs/blob/ca581e38eec22c10a48bf3663070d95e982f850e/EIPS/eip-4844.md#L48

https://github.com/ethereum/EIPs/blob/ca581e38eec22c10a48bf3663070d95e982f850e/EIPS/eip-4844.md#L200-L224

And from the consensus specs: https://github.com/ethereum/consensus-specs/blob/dev/specs/deneb/polynomial-commitments.md#verify_kzg_proof_impl

```python
def verify_kzg_proof(commitment_bytes: Bytes48,
                     z_bytes: Bytes32,
                     y_bytes: Bytes32,
                     proof_bytes: Bytes48) -> bool:
    """
    Verify KZG proof that ``p(z) == y`` where ``p(z)`` is the polynomial represented by ``polynomial_kzg``.
    Receives inputs as bytes.
    Public method.
    """
    assert len(commitment_bytes) == BYTES_PER_COMMITMENT
    assert len(z_bytes) == BYTES_PER_FIELD_ELEMENT
    assert len(y_bytes) == BYTES_PER_FIELD_ELEMENT
    assert len(proof_bytes) == BYTES_PER_PROOF

    return verify_kzg_proof_impl(bytes_to_kzg_commitment(commitment_bytes),
                                 bytes_to_bls_field(z_bytes),
                                 bytes_to_bls_field(y_bytes),
                                 bytes_to_kzg_proof(proof_bytes))

def verify_kzg_proof_impl(commitment: KZGCommitment,
                          z: BLSFieldElement,
                          y: BLSFieldElement,
                          proof: KZGProof) -> bool:
    """
    Verify KZG proof that ``p(z) == y`` where ``p(z)`` is the polynomial represented by ``polynomial_kzg``.
    """
    # Verify: P - y = Q * (X - z)
    X_minus_z = bls.add(
        bls.bytes96_to_G2(KZG_SETUP_G2_MONOMIAL[1]),
        bls.multiply(bls.G2(), -z),
    )
    P_minus_y = bls.add(bls.bytes48_to_G1(commitment), bls.multiply(bls.G1(), -y))
    return bls.pairing_check([
        [P_minus_y, bls.neg(bls.G2())],
        [bls.bytes48_to_G1(proof), X_minus_z]
    ])
```

i.e. if using the same backend for EIP-2537 and EIP-4844, KZG_POINT_PRECOMPILE 50k gas should be the ceiling for double pairing.
