### PR TITLE
Update EIP-7691: Decouple from EIP-7742

### DIFF
--- a/EIPS/eip-7691.md
+++ b/EIPS/eip-7691.md
@@ -34,11 +34,13 @@ The current long term plan of Ethereum is to implement peerDAS as specified by [
 | `PECTRA_FORK_EPOCH`                      | `tbd` <!-- TODO --> |
 | `MAX_BLOBS_PER_BLOCK_ELECTRA`            | `9`                 |
 | `TARGET_BLOBS_PER_BLOCK_ELECTRA`         | `6`                 |
+| `MAX_BLOB_GAS_PER_BLOCK`                 | `1179648`           |
+| `TARGET_BLOB_GAS_PER_BLOCK`              | `786432`            |
 | `BLOB_BASE_FEE_UPDATE_FRACTION_ELECTRA`  | `5007716`           |
 
-`MAX_BLOBS_PER_BLOCK_ELECTRA` and `TARGET_BLOBS_PER_BLOCK_ELECTRA` are consumed by the consensus layer clients, and starting at `PECTRA_FORK_EPOCH` replace the respective old max and target values. `TARGET_BLOBS_PER_BLOCK_ELECTRA` is then passed via the engineAPI to the execution layer clients. The mechanism describing this uncoupling is specified in [EIP-7742](./eip-7742.md).
+`MAX_BLOBS_PER_BLOCK_ELECTRA` and `TARGET_BLOBS_PER_BLOCK_ELECTRA` are consumed by the consensus layer clients, and starting at `PECTRA_FORK_EPOCH` replace the respective old max and target values.
 
-`BLOB_BASE_FEE_UPDATE_FRACTION_ELECTRA` is consumed by the execution layer clients, and starting at `PECTRA_FORK_EPOCH` timestamp replaces the old update fraction value.
+`MAX_BLOB_GAS_PER_BLOCK`, `TARGET_BLOB_GAS_PER_BLOCK` and `BLOB_BASE_FEE_UPDATE_FRACTION_ELECTRA` are consumed by the execution layer clients, and starting at `PECTRA_FORK_EPOCH` timestamp replace the old max, target and update fraction values.
 
 ## Rationale
 
@@ -70,7 +72,9 @@ The `BLOB_BASE_FEE_UPDATE_FRACTION_ELECTRA` value in this EIP is chosen as the m
 
 ## Backwards Compatibility
 
-The consensus clients would continue to use `MAX_BLOBS_PER_BLOCK` for the deneb fork and once the `ELECTRA` fork is active, they would use `MAX_BLOBS_PER_BLOCK_ELECTRA`. 
+The consensus clients would continue to use `MAX_BLOBS_PER_BLOCK` and `TARGET_BLOBS_PER_BLOCK` for the deneb fork and once the `ELECTRA` fork is active, they would use `MAX_BLOBS_PER_BLOCK_ELECTRA` and `TARGET_BLOBS_PER_BLOCK_ELECTRA` respectively.
+
+The execution clients would continue to use `MAX_BLOB_GAS_PER_BLOCK`, `TARGET_BLOB_GAS_PER_BLOCK` and `BLOB_BASE_FEE_UPDATE_FRACTION` for the cancun fork and once the prague fork is active, they would use `MAX_BLOB_GAS_PER_BLOCK`, `TARGET_BLOB_GAS_PER_BLOCK` and `BLOB_BASE_FEE_UPDATE_FRACTION_ELECTRA` respectively.
 
 ## Security Considerations
 


### PR DESCRIPTION
Updates EIP-7691 to include EL constants `MAX_BLOB_GAS_PER_BLOCK` and `TARGET_BLOB_GAS_PER_BLOCK`.