### PR TITLE
Add EIP: Nostr and NFT Compatible Social Media Publishing Standard

### DIFF
--- a/EIPS/eip-7832.md
+++ b/EIPS/eip-7832.md
@@ -70,3 +70,4 @@ event PostEvent(
     string content,
     string[][] tags
 );
+```

--- a/EIPS/eip-7832.md
+++ b/EIPS/eip-7832.md
@@ -1,0 +1,72 @@
+---
+eip: XXXX
+title: Generic Decentralized Social Post Token Standard with Multimedia Support and Editing
+author: [Author Name] <author@example.com>
+discussions-to: https://github.com/ethereum/EIPs/issues/XXXX
+status: Draft
+type: Standards Track
+category: ERC
+created: 2024-12-15
+requires: 721, 1155
+---
+
+## Simple Summary
+
+This proposal defines a standardized format for representing decentralized social media posts as tokens, compatible with both ERC-721 and ERC-1155, and introduces a flexible model where the meaning of a post (original, reply, repost) is derived from its metadata rather than separate functions or event types. Additionally, it provides a mechanism to edit existing posts through an `editPost` function and an `EditPostEvent`.
+
+## Abstract
+
+We introduce a generic token standard to represent social media posts on-chain, allowing:
+
+1. Representation as ERC-721 or ERC-1155 tokens.
+2. A single posting mechanism: `createPost`.
+3. Interpretation of post type (original, reply, repost) via the presence of certain tags in the metadata rather than separate functions or events.
+4. The ability to edit previously published posts with an `editPost` function and corresponding `EditPostEvent`.
+5. Multiple media attachments and external references through flexible tags.
+6. NFT metadata aligned with common NFT practices, including a descriptive `name` and a `description` identical to the post’s content.
+
+## Motivation
+
+By eliminating separate functions or events for different post types, this standard simplifies the interface and makes the contract more extensible. Developers and clients can determine post type from the metadata. The introduction of `editPost` addresses a common user need: correcting typos, updating references, or adding clarifications after a post is published.
+
+## Specification
+
+### Post Structure
+
+Each post includes:
+
+- **id:** A unique, deterministic identifier for the post.
+- **author:** The on-chain address of the post creator.
+- **created_at:** Timestamp of creation (e.g., block timestamp at minting).
+- **kind:** An integer representing the post category.
+- **tags:** Arrays of arrays of strings that describe attachments, references, and other metadata.
+  - For example, `["e", "<id_of_referenced_post>"]` could indicate a reply.
+  - `["m", "<media_url>", "<mime_type>"]` indicates attached media.
+  - `["r", "<URL>"]` references an external URL.
+  - `["ch", "<chain_id>"]`, `["c", "<contract_address>"]` for cross-chain/contract references.
+- **content:** The textual content of the post.
+
+All these fields are stored in the NFT’s metadata under `properties`. The `description` field of the NFT is identical to `content`. The `name` field includes the author and optionally the platform, formatted as `"<author> via <platform> as Social Post"` or `"<author> as Social Post"` if no platform is specified.
+
+### Token Standards Compatibility
+
+- **ERC-721:** Each post is a unique NFT (`tokenId`).
+- **ERC-1155:** A `tokenId` can represent one post event, potentially minted multiple times. The `id` ensures a unique reference to the event data.
+
+### Events
+
+#### PostEvent
+
+When a new post is created:
+
+```solidity
+event PostEvent(
+    address indexed author,
+    uint256 indexed tokenId,
+    bytes32 indexed id,
+    bytes32 pubkey,
+    uint256 created_at,
+    uint32 kind,
+    string content,
+    string[][] tags
+);

--- a/EIPS/eip-7832.md
+++ b/EIPS/eip-7832.md
@@ -83,9 +83,9 @@ Kinds specify how clients should interpret the meaning of each event and the oth
 0: user metadata: the content is set to a stringified JSON object {name: <username>, about: <string>, picture: <url, string>} describing the user who created the event. Extra metadata fields may be set. A relay may delete older events once it gets a new one for the same pubkey.
 1: text note: the content is set to the plaintext content of a note (anything the user wants to say). Content that must be parsed, such as Markdown and HTML, should not be used. Clients should also not parse content as those.
 
-Ref: [NIP-01 Basic Event Kinds](https://github.com/nostr-protocol/nips/blob/master/01.md) for basic tags and kinds
+Ref: [NIP-01 Basic Event Kinds](https://github.com/nostr-protocol/nips/blob/561059ff85c171b87a12b8381b724b4afc569a97/01.md) for basic tags and kinds
 
-Ref: [Current Full List of Kinds](https://github.com/nostr-protocol/nips?tab=readme-ov-file#event-kinds)
+Ref: [Current Full List of Kinds](https://github.com/nostr-protocol/nips/blob/561059ff85c171b87a12b8381b724b4afc569a97/README.md#event-kinds)
 
 ### Tags
 
@@ -106,15 +106,15 @@ tags is a flexible mechanism to attach additional structured data to a post. Eac
 
 [Basic Tags](https://github.com/nostr-protocol/nips/blob/561059ff85c171b87a12b8381b724b4afc569a97/01.md)
 
-[Current Full List of Tags](https://github.com/nostr-protocol/nips?tab=readme-ov-file#standardized-tags)
+[Current Full List of Tags](https://github.com/nostr-protocol/nips/blob/561059ff85c171b87a12b8381b724b4afc569a97/README.md#standardized-tags)
 
 ### Generating a Key
 
 **Private key:** A Nostr compatible key can be generated locally with a command like `openssl rand -hex 32` or `web3.utils.sha3(web3.utils.randomHex(32))`. This key is used to sign the post and is stored in the pubkey field. An ethereum private key or mnemonic phrase as long as the result is a 32 byte hex string.
 
-**Public key:** Public keys are based on Taproot + Schnorr, bitcoin [BIP-0341](https://en.bitcoin.it/wiki/BIP_034). And can be generated with a tool like [Nostril](https://github.com/jb55/nostril)
+**Public key:** Public keys are based on Taproot + Schnorr, bitcoin [BIP-0341](https://github.com/bitcoin/bips/blob/3db736243cd01389a4dfd98738204df1856dc5b9/bip-0034.mediawiki). And can be generated with nostril compatible signing tools.
 
-Alternatively bech32-(not-m) can be used to encode private and public keys so that the prefixes npub and nsec can be used to differentiate between the two. Ref: [NIP-19](https://github.com/nostr-protocol/nips/blob/master/19.md)
+Alternatively bech32-(not-m) can be used to encode private and public keys so that the prefixes npub and nsec can be used to differentiate between the two. Ref: [NIP-19](https://github.com/nostr-protocol/nips/blob/561059ff85c171b87a12b8381b724b4afc569a97/19.md)
 
 ### Token Standards Compatibility
 
@@ -123,7 +123,7 @@ Alternatively bech32-(not-m) can be used to encode private and public keys so th
 
 ### Events
 
-There are many possible types of events, but we will focus on posts as the would most likely be turned into an NFT as opposed to a like or a follow. A more completel list can be found here: [Complete list of events](https://github.com/nostr-protocol/nips/tree/master)
+There are many possible types of events, but we will focus on posts as the would most likely be turned into an NFT as opposed to a like or a follow. A more complete list can be found here: [List of event kinds](https://github.com/nostr-protocol/nips/blob/master/README.md#event-kinds)
 
 #### CreateEvent
 
@@ -174,11 +174,11 @@ To obtain the id, we sha256 the serialized properties. The serialization is done
   - A backspace, (0x08), use \b
   - A form feed, (0x0C), use \f
 
-A tool like [Nak](https://github.com/fiatjaf/nak) or [Nostril](https://github.com/jb55/nostril) can be used to derrive an id.
+Ref: [NIP-01](https://github.com/nostr-protocol/nips/blob/561059ff85c171b87a12b8381b724b4afc569a97/01.md)
 
 ### Sign a post
 
-Signatures are based on [schnorr signatures standard for the curve secp256k1](https://bips.xyz/340). A post may be signed with a tool like [Nostril](https://github.com/jb55/nostril), [Go-Nostr](https://github.com/nbd-wtf/go-nostr) or any number of other tools on [this list](https://github.com/aljazceru/awesome-nostr?tab=readme-ov-file).
+Signatures are based on [schnorr signatures standard for the curve secp256k1](https://github.com/bitcoin/bips/blob/3db736243cd01389a4dfd98738204df1856dc5b9/bip-0340.mediawiki).
 
 **When an existing post is edited:**
 
@@ -228,6 +228,8 @@ Event fields are stored in the NFT’s metadata under `properties`. The `descrip
 
 ### Example Solidity Functions
 
+These examples are possible partial implentations. Only metadata and events are required to be implemented. The rest is up to the implementor.
+
 ```solidity
 function createPost(
   uint256 tokenId,
@@ -264,50 +266,35 @@ function editPost(
 
 ```
 
-createPost mints a new token. The authorIdentifier and optional platform form the name field.
-editPost allows the author or an authorized party to modify content and tags. Must enforce access control.
+- `createPost` mints a new token. The authorIdentifier and optional platform form the name field.
 
-Backwards Compatibility
+- `editPost` allows the author or an authorized party to modify content and tags. Must enforce access control.
+
+### Backwards Compatibility
+
 This is an additive standard on top of ERC-721 and ERC-1155. Existing NFTs remain compatible; clients or platforms that understand this standard can interpret these tokens as social posts.
 
-Test Cases
-Original Post:
-createPost without e tags. Check PostEvent and metadata.
+### Security Considerations
 
-Reply Post:
-createPost with ["e", "<id_of_original_post>"] tag. Clients interpret it as a reply.
-
-Multiple Media:
-Add several ["m", ...] tags for multiple media files.
-
-Editing a Post:
-editPost changes content and/or adds new tags. Check EditPostEvent and updated metadata.
-
-Security Considerations
-Data Integrity:
+**Data Integrity:**
 Ensure that id (nostrId) is consistently derived, e.g., from metadata hash, to prevent forgeries.
 
-Off-Chain Signatures:
-The sig field in nostr_event is optional but recommended for Nostr authenticity. Off-chain signing by the author’s private key can be stored to improve trust.
+**Editing Posts:**
+While editing posts may have any platform-specific rules, events should be signed by the original author to be self verifying.
 
-Spam and Moderation:
+### Spam and Moderation:
+
 Nostr and NFTs both allow permissionless creation of content. Platforms built on this standard should implement their own moderation layers, blocklists, or reputation systems.
 
-Editing Control:
-editPost must only be callable by the token owner or an authorized party.
+## References
 
-Data Integrity:
-id should be deterministic (e.g., hash of content and tags).
+[ERC-721 Non-Fungible Token Standard](https://github.com/ethereum/ERCs/blob/b0a86b60c11afea5ce3f3e06f9e24b951a242991/ERCS/erc-721.md)
+[ERC-1155 Multi Token Standard](https://github.com/ethereum/ERCs/blob/b0a86b60c11afea5ce3f3e06f9e24b951a242991/ERCS/erc-1155.md)
+[Nostr Kinds and Events](https://github.com/nostr-protocol/nips/blob/561059ff85c171b87a12b8381b724b4afc569a97/README.md#event-kinds)
+[NIP-01 Basic Kinds](https://github.com/nostr-protocol/nips/blob/561059ff85c171b87a12b8381b724b4afc569a97/01.md)
+[NIP-10 Replies and Mentions](https://github.com/nostr-protocol/nips/blob/561059ff85c171b87a12b8381b724b4afc569a97/10.md)
+[NIP-18 Reposts](https://github.com/nostr-protocol/nips/blob/561059ff85c171b87a12b8381b724b4afc569a97/18.md)
 
-Spam & Moderation:
-Out of scope. Platforms should implement moderation as needed.
+## Copyright
 
-References
-ERC-721
-ERC-1155
-Nostr protocol
-[NIP-01 Basic Event Kinds](https://github.com/nostr-protocol/nips/blob/master/01.md)
-NIP-10 Replies and Mentions
-NIP-18 Reposts
-Copyright
-This EIP is licensed under Apache-2.0.
+Copyright and related rights waived via [CC0](../LICENSE.md).

--- a/EIPS/eip-7832.md
+++ b/EIPS/eip-7832.md
@@ -1,7 +1,7 @@
 ---
-eip: XXXX
-title: Generic Decentralized Social Post Token Standard with Multimedia Support and Editing
-author: [Author Name] <author@example.com>
+eip: 
+title: Nostr Compatible Decentralized Event Based Social Post Standard with Multimedia Support and Editing
+author: [Nick Juntilla] <nick@ownerfy.com>
 discussions-to: https://github.com/ethereum/EIPs/issues/XXXX
 status: Draft
 type: Standards Track
@@ -12,9 +12,22 @@ requires: 721, 1155
 
 ## Simple Summary
 
-This proposal defines a standardized format for representing decentralized social media posts as tokens, compatible with both ERC-721 and ERC-1155, and introduces a flexible model where the meaning of a post (original, reply, repost) is derived from its metadata rather than separate functions or event types. Additionally, it provides a mechanism to edit existing posts through an `editPost` function and an `EditPostEvent`.
+This proposal defines a standardized format for representing decentralized social media posts as nfts. It is mainly designed to be compatible with the Nostr protocol, but is genericized here so that it can be easily adapted to AT protocol, used in other event based decentralized social media protocols, or even as an RSS feed. It is compatible with both ERC-721 and ERC-1155, and introduces a flexible model where the meaning of a post (original, reply, repost) is derived from its metadata rather than separate functions or event types. Replies have a reply tag, e, quotes will include the q tag, and so on. Additionally, it provides a mechanism to edit existing posts through an `editPost` function and an `EditPostEvent`. An edited post is to be seen as an updated version of a post.
 
 ## Abstract
+
+This EIP defines a standardized way to create and manage NFTs that represent social media posts. These NFTs can be original posts, replies, reposts, or quote posts. The standard includes event emissions for these actions and specifies how to link replies to the original content using blockchain, smart contract, and token ID references.
+
+This EIP introduces a standard that allows ERC-721 NFTs to encode Nostr event data. Each NFT encapsulates a single social media post as a Nostr-compatible event, including fields such as pubkey, content, kind, tags, and created_at. The NFT must be issued (minted) to the author's address first, ensuring the author controls and originates their own content. By adhering to the Nostr data structure, any NFT minted under this standard can be interpreted by Nostr clients, relays, or indexing services. Additionally, this standard defines how replies, reposts, and quotes should reference prior events, enabling rich social media interactions in a multi-chain, multi-contract environment.
+
+We introduce a token standard (applicable to either ERC-721 or ERC-1155) for representing social media posts as Nostr events. By leveraging Nostr tags, posts can include multiple media files (images, audio, video) and external references (URLs, cross-chain references). A token minted under this standard can be integrated into a Nostr-based decentralized social ecosystem. Whether represented as a unique NFT (ERC-721) or a semi-fungible token (ERC-1155), the content remains interoperable and user-owned.
+
+This standard defines how to:
+
+Represent a social media post as an ERC-721 NFT that maps directly to a Nostr event.
+Support multiple content types (text, images, audio, video) by referencing external resources through tags.
+Enable linking to external content, such as URLs, blockchains, contracts, or other Nostr events.
+Each NFT can be interpreted by Nostr clients and relays, enabling cross-ecosystem interoperability. Posts are "owned" by their creators and can incorporate replies, quotes, reposts, multimedia attachments, and external links.
 
 We introduce a generic token standard to represent social media posts on-chain, allowing:
 
@@ -23,11 +36,27 @@ We introduce a generic token standard to represent social media posts on-chain, 
 3. Interpretation of post type (original, reply, repost) via the presence of certain tags in the metadata rather than separate functions or events.
 4. The ability to edit previously published posts with an `editPost` function and corresponding `EditPostEvent`.
 5. Multiple media attachments and external references through flexible tags.
-6. NFT metadata aligned with common NFT practices, including a descriptive `name` and a `description` identical to the post’s content.
+6. NFT metadata aligned with common NFT practices to so existing NFT apps will display as much of the NFT as possible using the most common metadata structure.
+7. By implementing a serparate public key and signature a third party may also publish a message on behalf of another user.
 
 ## Motivation
 
-By eliminating separate functions or events for different post types, this standard simplifies the interface and makes the contract more extensible. Developers and clients can determine post type from the metadata. The introduction of `editPost` addresses a common user need: correcting typos, updating references, or adding clarifications after a post is published.
+As social media becomes increasingly integrated with blockchain technology, there is a need for a standardized way to represent social media posts as NFTs. This standardization will facilitate the development of decentralized social media platforms, allowing users to own and control their content fully.
+
+Nostr is a simple and flexible protocol for decentralized social media. By making NFTs Nostr-compatible, this EIP allows NFTs to become a fundamental building block for decentralized social platforms, ensuring that:
+
+Interoperability: Content can be freely moved between Ethereum-based platforms and Nostr-based infrastructure.
+Decentralized Identity and Ownership: Users maintain full ownership and control of their posts through their wallet keys.
+Cross-Chain and Cross-Platform Referencing: A standardized tagging system enables referencing posts on other blockchains, other contracts, or even external URLs.
+
+Nostr’s minimal and extensible protocol is ideal for decentralized identity and publishing. Integrating Nostr with ERC-721 NFTs ensures that users own their content while maintaining interoperability with Nostr clients. Supporting multimedia and external links allows richer content, making NFTs viable as building blocks for decentralized social networks, forums, classifieds, and multimedia platforms.
+
+The proliferation of decentralized social platforms demands a standard that can represent a rich variety of posts as tokens. By defining a generic event-like structure, we enable:
+
+Interoperability: Multiple platforms can rely on the same standard to read, write, and index posts.
+Ownership and Portability: Users fully own their posts in their wallet as tokens.
+Rich Content: Support for text, images, audio, video, and external links.
+Cross-Platform Integration: A uniform structure that can integrate easily with various decentralized protocols, indexing services, and clients.
 
 ## Specification
 
@@ -38,15 +67,43 @@ Each post includes:
 - **id:** A unique, deterministic identifier for the post.
 - **author:** The on-chain address of the post creator.
 - **created_at:** Timestamp of creation (e.g., block timestamp at minting).
-- **kind:** An integer representing the post category.
-- **tags:** Arrays of arrays of strings that describe attachments, references, and other metadata.
-  - For example, `["e", "<id_of_referenced_post>"]` could indicate a reply.
+- **kind:** An integer representing the post category. This is expanded on below.
+- **tags:** Arrays of arrays of strings that describe attachments, references, and other metadata. There are more example tags below as well as all possible Nostr tags.
+  - For example, `["e", "<id_of_referenced_post>"]` indicates a reply.
   - `["m", "<media_url>", "<mime_type>"]` indicates attached media.
   - `["r", "<URL>"]` references an external URL.
   - `["ch", "<chain_id>"]`, `["c", "<contract_address>"]` for cross-chain/contract references.
 - **content:** The textual content of the post.
 
-All these fields are stored in the NFT’s metadata under `properties`. The `description` field of the NFT is identical to `content`. The `name` field includes the author and optionally the platform, formatted as `"<author> via <platform> as Social Post"` or `"<author> as Social Post"` if no platform is specified.
+Post Types (Examples)
+Original Post: kind=1
+Reply: kind=2 (or reuse kind=1 with reply-indicating tags)
+Repost: kind=6 (for example)
+Quote Post: Another distinct integer (e.g. 30023)
+These are just example values. Different implementations may standardize on their own kind values or sets.
+
+List of kinds https://github.com/nostr-protocol/nips?tab=readme-ov-file#event-kinds
+
+Tags
+tags is a flexible mechanism to attach additional structured data to a post. Some examples:
+
+List of tags
+https://github.com/nostr-protocol/nips?tab=readme-ov-file#standardized-tags
+
+Media Attachments:
+["m", "<media_url>", "<mime_type>"]
+Multiple media can be attached by including multiple ["m", ...] tags.
+
+References to Other Posts:
+["e", "<id_of_referenced_post>"]
+
+External URLs:
+["r", "<URL>"]
+
+Cross-Chain/Contract References:
+["ch", "<chain_id>"], ["c", "<contract_address>"]
+
+All these fields are stored in the NFT’s metadata under `properties`. The `description` field of the NFT is identical to `content`. The `name` field includes the author and optionally the platform, formatted as `"<author> via <platform> as Post"` or `"<author> as Post"` if no platform is specified.
 
 ### Token Standards Compatibility
 
@@ -64,10 +121,192 @@ event PostEvent(
     address indexed author,
     uint256 indexed tokenId,
     bytes32 indexed id,
-    bytes32 pubkey,
     uint256 created_at,
-    uint32 kind,
-    string content,
-    string[][] tags
+    bytes32 pubkey, // optional, may be the same as author
+    uint32 kind, // optional
+    string uri, // optional
+    string name, // optional
+    string content, // optional
+    string tags, // optional, stringified tags
+    sig // optional
+
 );
 ```
+
+Clients interpret whether a post is a reply or repost by examining tags.
+
+EditPostEvent
+When an existing post is edited:
+
+```solidity
+event EditPostEvent(
+    address indexed editor,
+    uint256 indexed tokenId,
+    bytes32 indexed id,
+    uint256 edited_at,
+    bytes32 pubkey, // optional, may be the same as author
+    uint32 kind, // optional
+    string uri, // optional
+    string name, // optional
+    string content, // optional
+    string tags, // optional, stringified tags
+    sig // optional
+);
+```
+
+EditPostEvent indicates that the specified post’s content and/or tags have changed. The contract must update the stored metadata for that token accordingly.
+
+Metadata JSON
+
+```
+{
+  "name": "<author> via <platform> as Publication",
+  "description": "<arbitrary string should match the content>",
+  "image": "https://example.com/thumbnail.jpg",
+  "external_url": "<optional same as first reference url if it exists>"
+  "properties": {
+    "id": "<32-bytes lowercase hex-encoded sha256 of the serialized properties data>",
+    "pubkey": "<32-bytes lowercase hex-encoded public key of the publicized creator>",
+    "created_at": <unix timestamp in seconds>,
+    "kind": <integer between 0 and 65535>,
+    "tags": [
+      ["e", "<id_of_referenced_post>"],
+      ["m", "https://example.com/image1.jpg", "image/jpeg"],
+      ["r", "https://example.com/external_resource"],
+      [<arbitrary string>...]
+    ],
+    "content": "<optional if this key exists it must match description, else if only description is used then use the description as content>",
+    "sig": "<64-bytes lowercase hex of the signature of the sha256 hash of the serialized properties data, which is the same as the "id" field>"
+  }
+}
+```
+
+To obtain the properties.id, we sha256 the serialized properties. The serialization is done over the UTF-8 JSON-serialized string (which is described below) of the following structure:
+
+```
+[
+  0,
+  <pubkey, as a lowercase hex string>,
+  <created_at, as a number>,
+  <kind, as a number>,
+  <tags, as an array of arrays of non-null strings>,
+  <content, as a string>
+]
+```
+
+To prevent implementation differences from creating a different event ID for the same event, the following rules MUST be followed while serializing:
+
+UTF-8 should be used for encoding.
+Whitespace, line breaks or other unnecessary formatting should not be included in the output JSON.
+The following characters in the content field must be escaped as shown, and all other characters must be included verbatim:
+A line break (0x0A), use \n
+A double quote (0x22), use \"
+A backslash (0x5C), use \\
+A carriage return (0x0D), use \r
+A tab character (0x09), use \t
+A backspace, (0x08), use \b
+A form feed, (0x0C), use \f
+
+Tags
+Each tag is an array of one or more strings, with some conventions around them. Take a look at the example below:
+
+```
+{
+  "tags": [
+    ["e", "5c83da77af1dec6d7289834998ad7aafbd9e2191396d75ec3cc27f5a77226f36", "wss://nostr.example.com"],
+    ["p", "f7234bd4c1394dda46d09f35bd384dd30cc552ad5541990f98844fb06676e9ca"],
+    ["a", "30023:f7234bd4c1394dda46d09f35bd384dd30cc552ad5541990f98844fb06676e9ca:abcd", "wss://nostr.example.com"],
+    ["alt", "reply"],
+    // ...
+  ],
+  // ...
+}
+```
+
+The first element of the tag array is referred to as the tag name or key and the second as the tag value. So we can safely say that the event above has an e tag set to "5c83da77af1dec6d7289834998ad7aafbd9e2191396d75ec3cc27f5a77226f36", an alt tag set to "reply" and so on. All elements after the second do not have a conventional name.
+
+This NIP defines 3 standard tags that can be used across all event kinds with the same meaning. They are as follows:
+
+The e tag, used to refer to an event: ["e", <32-bytes lowercase hex of the id of another event>, <recommended relay URL, optional>]
+The p tag, used to refer to another user: ["p", <32-bytes lowercase hex of a pubkey>, <recommended relay URL, optional>]
+The a tag, used to refer to an addressable or replaceable event
+for an addressable event: ["a", <kind integer>:<32-bytes lowercase hex of a pubkey>:<d tag value>, <recommended relay URL, optional>]
+for a normal replaceable event: ["a", <kind integer>:<32-bytes lowercase hex of a pubkey>:, <recommended relay URL, optional>]
+As a convention, all single-letter (only english alphabet letters: a-z, A-Z) key tags are expected to be indexed by relays, such that it is possible, for example, to query or subscribe to events that reference the event "5c83da77af1dec6d7289834998ad7aafbd9e2191396d75ec3cc27f5a77226f36" by using the {"#e": ["5c83da77af1dec6d7289834998ad7aafbd9e2191396d75ec3cc27f5a77226f36"]} filter. Only the first value in any given tag is indexed.
+
+Kinds
+Kinds specify how clients should interpret the meaning of each event and the other fields of each event (e.g. an "r" tag may have a meaning in an event of kind 1 and an entirely different meaning in an event of kind 10002). Each NIP may define the meaning of a set of kinds that weren't defined elsewhere. This NIP defines two basic kinds:
+
+0: user metadata: the content is set to a stringified JSON object {name: <username>, about: <string>, picture: <url, string>} describing the user who created the event. Extra metadata fields may be set. A relay may delete older events once it gets a new one for the same pubkey.
+1: text note: the content is set to the plaintext content of a note (anything the user wants to say). Content that must be parsed, such as Markdown and HTML, should not be used. Clients should also not parse content as those.
+
+Refer to [NIP-01 Basic Event Kinds](https://github.com/nostr-protocol/nips/blob/master/01.md) for basic tags and kinds
+
+Refer to https://github.com/nostr-protocol/nips/tree/master for more
+
+Functions
+
+```
+function createPost(
+    string memory content,
+    string[][] memory tags,
+    string memory authorIdentifier,
+    string memory platform // optional
+) public returns (uint256);
+
+function editPost(
+    uint256 tokenId,
+    string memory newContent,
+    string[][] memory newTags
+) public;
+```
+
+createPost mints a new token. The authorIdentifier and optional platform form the name field.
+editPost allows the author or an authorized party to modify content and tags. Must enforce access control.
+Rationale
+This design leverages a single event and function for creating posts. Post type determination occurs via metadata, making the standard adaptable to future social protocols or interpretations. The editPost function addresses a common need for updating published content.
+
+Backwards Compatibility
+This is an additive standard on top of ERC-721 and ERC-1155. Existing NFTs remain compatible; clients or platforms that understand this standard can interpret these tokens as social posts.
+
+Test Cases
+Original Post:
+createPost without e tags. Check PostEvent and metadata.
+
+Reply Post:
+createPost with ["e", "<id_of_original_post>"] tag. Clients interpret it as a reply.
+
+Multiple Media:
+Add several ["m", ...] tags for multiple media files.
+
+Editing a Post:
+editPost changes content and/or adds new tags. Check EditPostEvent and updated metadata.
+
+Security Considerations
+Data Integrity:
+Ensure that id (nostrId) is consistently derived, e.g., from metadata hash, to prevent forgeries.
+
+Off-Chain Signatures:
+The sig field in nostr_event is optional but recommended for Nostr authenticity. Off-chain signing by the author’s private key can be stored to improve trust.
+
+Spam and Moderation:
+Nostr and NFTs both allow permissionless creation of content. Platforms built on this standard should implement their own moderation layers, blocklists, or reputation systems.
+
+Editing Control:
+editPost must only be callable by the token owner or an authorized party.
+
+Data Integrity:
+id should be deterministic (e.g., hash of content and tags).
+
+Spam & Moderation:
+Out of scope. Platforms should implement moderation as needed.
+
+References
+ERC-721
+ERC-1155
+Nostr protocol
+[NIP-01 Basic Event Kinds](https://github.com/nostr-protocol/nips/blob/master/01.md)
+NIP-10 Replies and Mentions
+NIP-18 Reposts
+Copyright
+This EIP is licensed under Apache-2.0.

--- a/EIPS/eip-7832.md
+++ b/EIPS/eip-7832.md
@@ -1,35 +1,28 @@
 ---
-eip: 
+eip: 0000
 title: Nostr Compatible Decentralized Event Based Social Post Standard with Multimedia Support and Editing
-author: [Nick Juntilla] <nick@ownerfy.com>
+author: Nick Juntilla <nick@ownerfy.com>
 discussions-to: https://github.com/ethereum/EIPs/issues/XXXX
 status: Draft
 type: Standards Track
 category: ERC
 created: 2024-12-15
-requires: 721, 1155
+requires: "721, 1155"
 ---
 
 ## Simple Summary
 
-This proposal defines a standardized format for representing decentralized social media posts as nfts. It is mainly designed to be compatible with the Nostr protocol, but is genericized here so that it can be easily adapted to AT protocol, used in other event based decentralized social media protocols, or even as an RSS feed. It is compatible with both ERC-721 and ERC-1155, and introduces a flexible model where the meaning of a post (original, reply, repost) is derived from its metadata rather than separate functions or event types. Replies have a reply tag, e, quotes will include the q tag, and so on. Additionally, it provides a mechanism to edit existing posts through an `editPost` function and an `EditPostEvent`. An edited post is to be seen as an updated version of a post.
+This proposal defines a standardized format for representing decentralized social media posts as NFTs. The Nostr protocol has already done most of the heavy lifting for creating an open decentralized social media network. This EIP servces the purpose of adapting those standards to the most common blockchain non fungible standards to take advantage of the reach and logevity of the blockchain. It is genericized here so that it can be easily adapted to the AT protocol, used in other event based decentralized social media, blogs, encrypted messaging, an RSS feed or miscellaneous publication. This model is flexible where the meaning and type of post (original, reply, repost, images, video, text, etc...) is derived from its metadata. Additionally there is a mechanism to edit a post to a new version.
 
 ## Abstract
 
-This EIP defines a standardized way to create and manage NFTs that represent social media posts. These NFTs can be original posts, replies, reposts, or quote posts. The standard includes event emissions for these actions and specifies how to link replies to the original content using blockchain, smart contract, and token ID references.
+This EIP defines a standardized way to create and manage NFTs that represent social media posts. These NFTs can be original posts, replies, reposts, or quote posts. Each NFT encapsulates a single social media post as a Nostr-compatible object, including fields such as pubkey, content, kind, tags, and created_at. By providing a 1:1 mapping of nostr data structures, any NFT minted under this standard can be interpreted by Nostr-style clients, relays, or indexing services with minimal effort. Additionally, this standard defines how replies, reposts, and quotes should reference prior events, enabling rich social media interactions in a multi-chain, multi-contract, multi-platform environment.
 
-This EIP introduces a standard that allows ERC-721 NFTs to encode Nostr event data. Each NFT encapsulates a single social media post as a Nostr-compatible event, including fields such as pubkey, content, kind, tags, and created_at. The NFT must be issued (minted) to the author's address first, ensuring the author controls and originates their own content. By adhering to the Nostr data structure, any NFT minted under this standard can be interpreted by Nostr clients, relays, or indexing services. Additionally, this standard defines how replies, reposts, and quotes should reference prior events, enabling rich social media interactions in a multi-chain, multi-contract environment.
+Other kinds of common social network primitives including likes, follows and other interactions are easily represented by this standard using Nostr standard `kinds` and `tags` without changing this standard. This document will not be an exhaustive list of all possible events. Please refer to the Nostr protocol for more information on how to represent other kinds of events and further evolution.
 
-We introduce a token standard (applicable to either ERC-721 or ERC-1155) for representing social media posts as Nostr events. By leveraging Nostr tags, posts can include multiple media files (images, audio, video) and external references (URLs, cross-chain references). A token minted under this standard can be integrated into a Nostr-based decentralized social ecosystem. Whether represented as a unique NFT (ERC-721) or a semi-fungible token (ERC-1155), the content remains interoperable and user-owned.
+In some places in this standard the word "post" is used and in other places "event" is used. This is because the Nostr protocol uses the word "event" to describe a post. They should be understood as generally the same thing. An NFT using this standard should never create more than one initial `PostEvent` upon creation. Many `EditPostEvent`s may be created for a single NFT.
 
-This standard defines how to:
-
-Represent a social media post as an ERC-721 NFT that maps directly to a Nostr event.
-Support multiple content types (text, images, audio, video) by referencing external resources through tags.
-Enable linking to external content, such as URLs, blockchains, contracts, or other Nostr events.
-Each NFT can be interpreted by Nostr clients and relays, enabling cross-ecosystem interoperability. Posts are "owned" by their creators and can incorporate replies, quotes, reposts, multimedia attachments, and external links.
-
-We introduce a generic token standard to represent social media posts on-chain, allowing:
+This standard defines:
 
 1. Representation as ERC-721 or ERC-1155 tokens.
 2. A single posting mechanism: `createPost`.
@@ -39,30 +32,30 @@ We introduce a generic token standard to represent social media posts on-chain, 
 6. NFT metadata aligned with common NFT practices to so existing NFT apps will display as much of the NFT as possible using the most common metadata structure.
 7. By implementing a serparate public key and signature a third party may also publish a message on behalf of another user.
 
+Posts may be "owned" by their creators. This may be a useful mechanic, but the independant signature of the post allows for a third party to publish a message on behalf of another user. This is useful for the convenince of third party services to publish or enshrine messages. Additionally editing a post may be limited to the original author. This is a design decision that should be made by the implementor.
+
 ## Motivation
 
-As social media becomes increasingly integrated with blockchain technology, there is a need for a standardized way to represent social media posts as NFTs. This standardization will facilitate the development of decentralized social media platforms, allowing users to own and control their content fully.
+With the continued censorship and manipulation of social media platforms it becomes increasingly important for truly decentralized social media to exist. Unlike other attempts at blockchain decentralized social media, this method does not rely on a single set of smart contracts or even the blockchain itself. Blockchain integration of author-signed event based social media simply adds a powerful substrate for standardized decentralized social media to exist in. The benefits of blockchain include, but are not limited to longevity, censorship resistance, monetary, and neutrality. The NFT standard is the most common and widely used standard for representing unique digital data on the blockchain. Using the NFT standard and standard NFT properties means that every marketplace, wallet and app that makes NFTs viewable is also a publication channel. With the data publicly available custom feed algorithms can be generated to give the control back to users.
 
-Nostr is a simple and flexible protocol for decentralized social media. By making NFTs Nostr-compatible, this EIP allows NFTs to become a fundamental building block for decentralized social platforms, ensuring that:
+### Why Nostr
 
-Interoperability: Content can be freely moved between Ethereum-based platforms and Nostr-based infrastructure.
-Decentralized Identity and Ownership: Users maintain full ownership and control of their posts through their wallet keys.
-Cross-Chain and Cross-Platform Referencing: A standardized tagging system enables referencing posts on other blockchains, other contracts, or even external URLs.
+Nostr is a simple and flexible protocol for decentralized social media. By making NFTs Nostr-compatible, this EIP allows NFTs to become a fundamental building block for decentralized many exsiting and future social platforms.
 
-Nostr’s minimal and extensible protocol is ideal for decentralized identity and publishing. Integrating Nostr with ERC-721 NFTs ensures that users own their content while maintaining interoperability with Nostr clients. Supporting multimedia and external links allows richer content, making NFTs viable as building blocks for decentralized social networks, forums, classifieds, and multimedia platforms.
+- Interoperability: Content can be freely moved between Ethereum-based platforms and Nostr-based infrastructure.
+- Open permissionless Identity: Anyone can can create a private key and start posting.
+- Decentralized and Self Authenticating Content: Each post is signed by the author, ensuring authenticity and enabling third-party publishing.
+- Cross-Chain and Cross-Platform Referencing: A standardized tagging system enables referencing posts on other blockchains, other contracts, or external URLs.
+- Flexible Content: Support for multimedia, external links, and arbitrary metadata, making make this protocol suitable for a wide range of social media applications and publishing applications.
+- Strong community: Nostr has a strong community of developers and users who are actively building and using the protocol.
 
-The proliferation of decentralized social platforms demands a standard that can represent a rich variety of posts as tokens. By defining a generic event-like structure, we enable:
-
-Interoperability: Multiple platforms can rely on the same standard to read, write, and index posts.
-Ownership and Portability: Users fully own their posts in their wallet as tokens.
-Rich Content: Support for text, images, audio, video, and external links.
-Cross-Platform Integration: A uniform structure that can integrate easily with various decentralized protocols, indexing services, and clients.
+Nostr's minimal and extensible protocol is ideal for decentralized publishing. Integrating Nostr with NFTs ensures that users own their content while maintaining interoperability with Nostr clients. Supporting multimedia and external links allows richer content, making NFTs viable as building blocks for decentralized social networks, forums, classifieds, messaging, and multimedia platforms.
 
 ## Specification
 
 ### Post Structure
 
-Each post includes:
+Each post includes these fields emitted as an event and in the metadata. This metadata could be saved on-chain as well depending on the implementation:
 
 - **id:** A unique, deterministic identifier for the post.
 - **author:** The on-chain address of the post creator.
@@ -75,35 +68,53 @@ Each post includes:
   - `["ch", "<chain_id>"]`, `["c", "<contract_address>"]` for cross-chain/contract references.
 - **content:** The textual content of the post.
 
-Post Types (Examples)
-Original Post: kind=1
-Reply: kind=2 (or reuse kind=1 with reply-indicating tags)
-Repost: kind=6 (for example)
-Quote Post: Another distinct integer (e.g. 30023)
-These are just example values. Different implementations may standardize on their own kind values or sets.
+#### Post Types (Examples)
 
-List of kinds https://github.com/nostr-protocol/nips?tab=readme-ov-file#event-kinds
+- Original Post: kind=1
+- Reply: kind=2 (or reuse kind=1 with reply-indicating tags)
+- Repost: kind=6 (for example)
+- Quote Post: Another distinct integer (e.g. 30023)
+- These are just example values. Different implementations may standardize on their own kind values or sets.
 
-Tags
-tags is a flexible mechanism to attach additional structured data to a post. Some examples:
+### Kinds
 
-List of tags
-https://github.com/nostr-protocol/nips?tab=readme-ov-file#standardized-tags
+Kinds specify how clients should interpret the meaning of each event and the other fields of each event (e.g. an "r" tag may have a meaning in an event of kind 1 and an entirely different meaning in an event of kind 10002). Each NIP may define the meaning of a set of kinds that weren't defined elsewhere. This NIP defines two basic kinds:
 
-Media Attachments:
-["m", "<media_url>", "<mime_type>"]
-Multiple media can be attached by including multiple ["m", ...] tags.
+0: user metadata: the content is set to a stringified JSON object {name: <username>, about: <string>, picture: <url, string>} describing the user who created the event. Extra metadata fields may be set. A relay may delete older events once it gets a new one for the same pubkey.
+1: text note: the content is set to the plaintext content of a note (anything the user wants to say). Content that must be parsed, such as Markdown and HTML, should not be used. Clients should also not parse content as those.
 
-References to Other Posts:
-["e", "<id_of_referenced_post>"]
+Ref: [NIP-01 Basic Event Kinds](https://github.com/nostr-protocol/nips/blob/master/01.md) for basic tags and kinds
 
-External URLs:
-["r", "<URL>"]
+Ref: [Current Full List of Kinds](https://github.com/nostr-protocol/nips?tab=readme-ov-file#event-kinds)
 
-Cross-Chain/Contract References:
-["ch", "<chain_id>"], ["c", "<contract_address>"]
+### Tags
 
-All these fields are stored in the NFT’s metadata under `properties`. The `description` field of the NFT is identical to `content`. The `name` field includes the author and optionally the platform, formatted as `"<author> via <platform> as Post"` or `"<author> as Post"` if no platform is specified.
+tags is a flexible mechanism to attach additional structured data to a post. Each tag is an array of one or more strings, with some conventions around them. Some examples:
+
+- Media Attachments:
+  ["m", "<media_url>", "<mime_type>"]
+  Multiple media can be attached by including multiple ["m", ...] tags.
+
+- References to Other Posts:
+  ["e", "<id_of_referenced_post>"]
+
+- External URLs:
+  ["r", "<URL>"]
+
+- Cross-Chain/Contract References:
+  ["ch", "<chain_id>"], ["c", "<contract_address>"]
+
+[Basic Tags](https://github.com/nostr-protocol/nips/blob/561059ff85c171b87a12b8381b724b4afc569a97/01.md)
+
+[Current Full List of Tags](https://github.com/nostr-protocol/nips?tab=readme-ov-file#standardized-tags)
+
+### Generating a Key
+
+**Private key:** A Nostr compatible key can be generated locally with a command like `openssl rand -hex 32` or `web3.utils.sha3(web3.utils.randomHex(32))`. This key is used to sign the post and is stored in the pubkey field. An ethereum private key or mnemonic phrase as long as the result is a 32 byte hex string.
+
+**Public key:** Public keys are based on Taproot + Schnorr, bitcoin [BIP-0341](https://en.bitcoin.it/wiki/BIP_034). And can be generated with a tool like [Nostril](https://github.com/jb55/nostril)
+
+Alternatively bech32-(not-m) can be used to encode private and public keys so that the prefixes npub and nsec can be used to differentiate between the two. Ref: [NIP-19](https://github.com/nostr-protocol/nips/blob/master/19.md)
 
 ### Token Standards Compatibility
 
@@ -112,55 +123,88 @@ All these fields are stored in the NFT’s metadata under `properties`. The `des
 
 ### Events
 
-#### PostEvent
+There are many possible types of events, but we will focus on posts as the would most likely be turned into an NFT as opposed to a like or a follow. A more completel list can be found here: [Complete list of events](https://github.com/nostr-protocol/nips/tree/master)
 
-When a new post is created:
+#### CreateEvent
+
+**When a new post is created:**
 
 ```solidity
-event PostEvent(
-    address indexed author,
+event CreateEvent(
+    address indexed publisher,
     uint256 indexed tokenId,
+    string uri,
     bytes32 indexed id,
+    bytes32 pubkey,
     uint256 created_at,
-    bytes32 pubkey, // optional, may be the same as author
-    uint32 kind, // optional
-    string uri, // optional
-    string name, // optional
-    string content, // optional
-    string tags, // optional, stringified tags
-    sig // optional
-
+    uint32 kind,
+    string content,
+    string tags,
+    string sig,
 );
 ```
 
-Clients interpret whether a post is a reply or repost by examining tags.
+`publisher` is the address of the user who created the post. `tokenId` is the NFT ID. `uri` is the URI of the NFT metadata. `id` is the unique identifier of the post. `pubkey` is the public key of the post creator. `created_at` is the timestamp of creation. `kind` is the post category. `content` is the textual content of the post. `tags` is the structured metadata. `sig` is the signature of the post data.
 
-EditPostEvent
-When an existing post is edited:
+#### To derrive the id
+
+To obtain the id, we sha256 the serialized properties. The serialization is done over the UTF-8 JSON-serialized string (which is described below) of the following structure:
+
+```json
+[
+  0,
+  <pubkey, as a lowercase hex string>,
+  <created_at, as a number>,
+  <kind, as a number>,
+  <tags, as an array of arrays of non-null strings>,
+  <content, as a string>
+]
+```
+
+**To prevent implementation differences from creating a different event ID for the same event, the following rules MUST be followed while serializing:**
+
+- UTF-8 should be used for encoding.
+- Whitespace, line breaks or other unnecessary formatting should not be included in the output JSON.
+- The following characters in the content field must be escaped as shown, and all other characters must be included verbatim:
+  - A line break (0x0A), use \n
+  - A double quote (0x22), use \"
+  - A backslash (0x5C), use \\
+  - A carriage return (0x0D), use \r
+  - A tab character (0x09), use \t
+  - A backspace, (0x08), use \b
+  - A form feed, (0x0C), use \f
+
+A tool like [Nak](https://github.com/fiatjaf/nak) or [Nostril](https://github.com/jb55/nostril) can be used to derrive an id.
+
+### Sign a post
+
+Signatures are based on [schnorr signatures standard for the curve secp256k1](https://bips.xyz/340). A post may be signed with a tool like [Nostril](https://github.com/jb55/nostril), [Go-Nostr](https://github.com/nbd-wtf/go-nostr) or any number of other tools on [this list](https://github.com/aljazceru/awesome-nostr?tab=readme-ov-file).
+
+**When an existing post is edited:**
 
 ```solidity
-event EditPostEvent(
+event EditEvent(
     address indexed editor,
     uint256 indexed tokenId,
+    string uri,
     bytes32 indexed id,
-    uint256 edited_at,
-    bytes32 pubkey, // optional, may be the same as author
-    uint32 kind, // optional
-    string uri, // optional
-    string name, // optional
-    string content, // optional
-    string tags, // optional, stringified tags
-    sig // optional
+    string newContent,
+    string newTags,
+    string sig
 );
 ```
 
-EditPostEvent indicates that the specified post’s content and/or tags have changed. The contract must update the stored metadata for that token accordingly.
+`editor` is the address of the user who edited the post. `tokenId` is the NFT ID. `uri` is the URI of the NFT metadata. `id` is the unique identifier of the post. `newContent` is the updated textual content of the post. `newTags` is the updated structured metadata. `sig` is the signature of the post data.
 
-Metadata JSON
+The contract must update the stored metadata for that token accordingly.
 
-```
+### Metadata JSON
+
+Event fields are stored in the NFT’s metadata under `properties`. The `description` field of the NFT is identical to `content`. The `name` field includes the author and optionally the platform, formatted as `"<author> via <platform> as <type>"` where author should be a human readable name and platform should be a human readable platform name. If no platform is specified the format should be `"<author> as <type>"`. Type may be "Social Post" or "Event" or any other type that is appropriate.
+
+```json
 {
-  "name": "<author> via <platform> as Publication",
+  "name": "<author> via <platform> as <type>",
   "description": "<arbitrary string should match the content>",
   "image": "https://example.com/thumbnail.jpg",
   "external_url": "<optional same as first reference url if it exists>"
@@ -172,8 +216,9 @@ Metadata JSON
     "tags": [
       ["e", "<id_of_referenced_post>"],
       ["m", "https://example.com/image1.jpg", "image/jpeg"],
+      ["m", "https://example.com/image1.jpg", "image/jpeg"],
       ["r", "https://example.com/external_resource"],
-      [<arbitrary string>...]
+      ["<arbitrary string>", "<arbitrary string>"],
     ],
     "content": "<optional if this key exists it must match description, else if only description is used then use the description as content>",
     "sig": "<64-bytes lowercase hex of the signature of the sha256 hash of the serialized properties data, which is the same as the "id" field>"
@@ -181,90 +226,46 @@ Metadata JSON
 }
 ```
 
-To obtain the properties.id, we sha256 the serialized properties. The serialization is done over the UTF-8 JSON-serialized string (which is described below) of the following structure:
+### Example Solidity Functions
 
-```
-[
-  0,
-  <pubkey, as a lowercase hex string>,
-  <created_at, as a number>,
-  <kind, as a number>,
-  <tags, as an array of arrays of non-null strings>,
-  <content, as a string>
-]
-```
-
-To prevent implementation differences from creating a different event ID for the same event, the following rules MUST be followed while serializing:
-
-UTF-8 should be used for encoding.
-Whitespace, line breaks or other unnecessary formatting should not be included in the output JSON.
-The following characters in the content field must be escaped as shown, and all other characters must be included verbatim:
-A line break (0x0A), use \n
-A double quote (0x22), use \"
-A backslash (0x5C), use \\
-A carriage return (0x0D), use \r
-A tab character (0x09), use \t
-A backspace, (0x08), use \b
-A form feed, (0x0C), use \f
-
-Tags
-Each tag is an array of one or more strings, with some conventions around them. Take a look at the example below:
-
-```
-{
-  "tags": [
-    ["e", "5c83da77af1dec6d7289834998ad7aafbd9e2191396d75ec3cc27f5a77226f36", "wss://nostr.example.com"],
-    ["p", "f7234bd4c1394dda46d09f35bd384dd30cc552ad5541990f98844fb06676e9ca"],
-    ["a", "30023:f7234bd4c1394dda46d09f35bd384dd30cc552ad5541990f98844fb06676e9ca:abcd", "wss://nostr.example.com"],
-    ["alt", "reply"],
-    // ...
-  ],
-  // ...
-}
-```
-
-The first element of the tag array is referred to as the tag name or key and the second as the tag value. So we can safely say that the event above has an e tag set to "5c83da77af1dec6d7289834998ad7aafbd9e2191396d75ec3cc27f5a77226f36", an alt tag set to "reply" and so on. All elements after the second do not have a conventional name.
-
-This NIP defines 3 standard tags that can be used across all event kinds with the same meaning. They are as follows:
-
-The e tag, used to refer to an event: ["e", <32-bytes lowercase hex of the id of another event>, <recommended relay URL, optional>]
-The p tag, used to refer to another user: ["p", <32-bytes lowercase hex of a pubkey>, <recommended relay URL, optional>]
-The a tag, used to refer to an addressable or replaceable event
-for an addressable event: ["a", <kind integer>:<32-bytes lowercase hex of a pubkey>:<d tag value>, <recommended relay URL, optional>]
-for a normal replaceable event: ["a", <kind integer>:<32-bytes lowercase hex of a pubkey>:, <recommended relay URL, optional>]
-As a convention, all single-letter (only english alphabet letters: a-z, A-Z) key tags are expected to be indexed by relays, such that it is possible, for example, to query or subscribe to events that reference the event "5c83da77af1dec6d7289834998ad7aafbd9e2191396d75ec3cc27f5a77226f36" by using the {"#e": ["5c83da77af1dec6d7289834998ad7aafbd9e2191396d75ec3cc27f5a77226f36"]} filter. Only the first value in any given tag is indexed.
-
-Kinds
-Kinds specify how clients should interpret the meaning of each event and the other fields of each event (e.g. an "r" tag may have a meaning in an event of kind 1 and an entirely different meaning in an event of kind 10002). Each NIP may define the meaning of a set of kinds that weren't defined elsewhere. This NIP defines two basic kinds:
-
-0: user metadata: the content is set to a stringified JSON object {name: <username>, about: <string>, picture: <url, string>} describing the user who created the event. Extra metadata fields may be set. A relay may delete older events once it gets a new one for the same pubkey.
-1: text note: the content is set to the plaintext content of a note (anything the user wants to say). Content that must be parsed, such as Markdown and HTML, should not be used. Clients should also not parse content as those.
-
-Refer to [NIP-01 Basic Event Kinds](https://github.com/nostr-protocol/nips/blob/master/01.md) for basic tags and kinds
-
-Refer to https://github.com/nostr-protocol/nips/tree/master for more
-
-Functions
-
-```
+```solidity
 function createPost(
-    string memory content,
-    string[][] memory tags,
-    string memory authorIdentifier,
-    string memory platform // optional
-) public returns (uint256);
+  uint256 tokenId,
+  string uri,
+  bytes32 id,
+  bytes32 pubkey,
+  uint256 created_at,
+  uint32 kind,
+  string content,
+  string tags,
+  string sig
+) public {
+
+  address publisher = msg.sender;
+  mint(tokenId, uri);
+  emit CreateEvent(publisher, tokenId, uri, id, pubkey, created_at, kind, content, tags, sig);
+}
 
 function editPost(
     uint256 tokenId,
-    string memory newContent,
-    string[][] memory newTags
-) public;
+    string uri,
+    bytes32 id,
+    bytes32 pubkey,
+    string newContent,
+    string newTags,
+    string sig
+) public {
+    require(pubKeys[msg.sender] == pubkey, "Not authorized to edit this post");
+
+    address editor = msg.sender;
+    setUri(tokenId, uri);
+    emit EditEvent(editor, tokenId, uri, id, newContent, newTags, sig);
+}
+
 ```
 
 createPost mints a new token. The authorIdentifier and optional platform form the name field.
 editPost allows the author or an authorized party to modify content and tags. Must enforce access control.
-Rationale
-This design leverages a single event and function for creating posts. Post type determination occurs via metadata, making the standard adaptable to future social protocols or interpretations. The editPost function addresses a common need for updating published content.
 
 Backwards Compatibility
 This is an additive standard on top of ERC-721 and ERC-1155. Existing NFTs remain compatible; clients or platforms that understand this standard can interpret these tokens as social posts.

--- a/EIPS/eip-7832.md
+++ b/EIPS/eip-7832.md
@@ -2,10 +2,11 @@
 eip: 0000
 title: Nostr and NFT Compatible Social Media Publishing Standard
 author: Nick Juntilla <nick@ownerfy.com>
-discussions-to: https://github.com/ethereum/EIPs/issues/XXXX
+discussions-to: https://ethereum-magicians.org/t/eip-7832-nostr-and-nft-compatible-social-media-publishing-standard/22280
 status: Draft
 type: Standards Track
 category: ERC
+discussions: https://ethereum-magicians.org/t/eip-7832-nostr-and-nft-compatible-social-media-publishing-standard/22280
 created: 2024-12-18
 requires: "721, 1155"
 ---

--- a/EIPS/eip-7832.md
+++ b/EIPS/eip-7832.md
@@ -1,18 +1,18 @@
 ---
 eip: 0000
-title: Nostr Compatible Decentralized Event Based Social Post Standard with Multimedia Support and Editing
+title: Nostr and NFT Compatible Social Media Publishing Standard
 author: Nick Juntilla <nick@ownerfy.com>
 discussions-to: https://github.com/ethereum/EIPs/issues/XXXX
 status: Draft
 type: Standards Track
 category: ERC
-created: 2024-12-15
+created: 2024-12-18
 requires: "721, 1155"
 ---
 
 ## Simple Summary
 
-This proposal defines a standardized format for representing decentralized social media posts as NFTs. The Nostr protocol has already done most of the heavy lifting for creating an open decentralized social media network. This EIP servces the purpose of adapting those standards to the most common blockchain non fungible standards to take advantage of the reach and logevity of the blockchain. It is genericized here so that it can be easily adapted to the AT protocol, used in other event based decentralized social media, blogs, encrypted messaging, an RSS feed or miscellaneous publication. This model is flexible where the meaning and type of post (original, reply, repost, images, video, text, etc...) is derived from its metadata. Additionally there is a mechanism to edit a post to a new version.
+This proposal defines a standardized format for representing decentralized social media posts as NFTs. The Nostr protocol has already done most of the heavy lifting for creating an open decentralized social media network. This EIP servces the purpose of adapting those standards to the most common blockchain non-fungible standards to take advantage of the reach and longevity of the blockchain. It is genericized here so that it can be easily adapted to the AT protocol, used in other event based decentralized social media, blogs, encrypted messaging, an RSS feed or miscellaneous publication. This model is flexible where the meaning and type of post (original, reply, repost, images, video, text, etc...) is derived from its metadata. Additionally there is a mechanism to edit a post to a new version.
 
 ## Abstract
 
@@ -30,9 +30,9 @@ This standard defines:
 4. The ability to edit previously published posts with an `editPost` function and corresponding `EditPostEvent`.
 5. Multiple media attachments and external references through flexible tags.
 6. NFT metadata aligned with common NFT practices to so existing NFT apps will display as much of the NFT as possible using the most common metadata structure.
-7. By implementing a serparate public key and signature a third party may also publish a message on behalf of another user.
+7. By implementing a separate public key and signature a third party may also publish a message on behalf of another user.
 
-Posts may be "owned" by their creators. This may be a useful mechanic, but the independant signature of the post allows for a third party to publish a message on behalf of another user. This is useful for the convenince of third party services to publish or enshrine messages. Additionally editing a post may be limited to the original author. This is a design decision that should be made by the implementor.
+Posts may be "owned" by their creators. This may be a useful mechanic, but the independent signature of the post allows for a third party to publish a message on behalf of another user. This is useful for the convenince of third party services to publish or enshrine messages. Additionally editing a post may be limited to the original author. This is a design decision that should be made by the implementor.
 
 ## Motivation
 
@@ -40,10 +40,10 @@ With the continued censorship and manipulation of social media platforms it beco
 
 ### Why Nostr
 
-Nostr is a simple and flexible protocol for decentralized social media. By making NFTs Nostr-compatible, this EIP allows NFTs to become a fundamental building block for decentralized many exsiting and future social platforms.
+Nostr is a simple and flexible protocol for decentralized social media. By making NFTs Nostr-compatible, this EIP allows NFTs to become a fundamental building block for decentralized many existing and future social platforms.
 
 - Interoperability: Content can be freely moved between Ethereum-based platforms and Nostr-based infrastructure.
-- Open permissionless Identity: Anyone can can create a private key and start posting.
+- Open permissionless Identity: Anyone can create a private key and start posting.
 - Decentralized and Self Authenticating Content: Each post is signed by the author, ensuring authenticity and enabling third-party publishing.
 - Cross-Chain and Cross-Platform Referencing: A standardized tagging system enables referencing posts on other blockchains, other contracts, or external URLs.
 - Flexible Content: Support for multimedia, external links, and arbitrary metadata, making make this protocol suitable for a wide range of social media applications and publishing applications.
@@ -110,7 +110,7 @@ tags is a flexible mechanism to attach additional structured data to a post. Eac
 
 ### Generating a Key
 
-**Private key:** A Nostr compatible key can be generated locally with a command like `openssl rand -hex 32` or `web3.utils.sha3(web3.utils.randomHex(32))`. This key is used to sign the post and is stored in the pubkey field. An ethereum private key or mnemonic phrase as long as the result is a 32 byte hex string.
+**Private key:** A Nostr compatible key can be generated locally with a command like `openssl rand -hex 32` or `web3.utils.sha3(web3.utils.randomHex(32))`. This key is used to sign the post and is stored in the pubkey field. An Ethereum private key or mnemonic phrase can also be used, as long as the result is a 32-byte hex string.
 
 **Public key:** Public keys are based on Taproot + Schnorr, bitcoin [BIP-0341](https://github.com/bitcoin/bips/blob/3db736243cd01389a4dfd98738204df1856dc5b9/bip-0034.mediawiki). And can be generated with nostril compatible signing tools.
 
@@ -146,7 +146,7 @@ event CreateEvent(
 
 `publisher` is the address of the user who created the post. `tokenId` is the NFT ID. `uri` is the URI of the NFT metadata. `id` is the unique identifier of the post. `pubkey` is the public key of the post creator. `created_at` is the timestamp of creation. `kind` is the post category. `content` is the textual content of the post. `tags` is the structured metadata. `sig` is the signature of the post data.
 
-#### To derrive the id
+#### To derive the id
 
 To obtain the id, we sha256 the serialized properties. The serialization is done over the UTF-8 JSON-serialized string (which is described below) of the following structure:
 
@@ -228,7 +228,7 @@ Event fields are stored in the NFT’s metadata under `properties`. The `descrip
 
 ### Example Solidity Functions
 
-These examples are possible partial implentations. Only metadata and events are required to be implemented. The rest is up to the implementor.
+These examples are possible partial implementations. Only metadata and events are required to be implemented. The rest is up to the implementor.
 
 ```solidity
 function createPost(


### PR DESCRIPTION
---
eip: 0000
title: Nostr and NFT Compatible Social Media Publishing Standard
author: Nick Juntilla <nick@ownerfy.com>
discussions-to: https://ethereum-magicians.org/t/eip-7832-nostr-and-nft-compatible-social-media-publishing-standard/22280
status: Draft
type: Standards Track
category: ERC
discussions: https://ethereum-magicians.org/t/eip-7832-nostr-and-nft-compatible-social-media-publishing-standard/22280
created: 2024-12-18
requires: "721, 1155"
---

## Simple Summary

This proposal defines a standardized format for representing decentralized social media posts as NFTs. The Nostr protocol has already done most of the heavy lifting for creating an open decentralized social media network. This EIP servces the purpose of adapting those standards to the most common blockchain non-fungible standards to take advantage of the reach and longevity of the blockchain. It is genericized here so that it can be easily adapted to the AT protocol, used in other event based decentralized social media, blogs, encrypted messaging, an RSS feed or miscellaneous publication. This model is flexible where the meaning and type of post (original, reply, repost, images, video, text, etc...) is derived from its metadata. Additionally there is a mechanism to edit a post to a new version.
