### PR TITLE
Update EIP-7607: Add EIP-7666 (EVM-ify the identity precompile) to proposed-for-inclusion in Fusaka

### DIFF
--- a/EIPS/eip-7607.md
+++ b/EIPS/eip-7607.md
@@ -41,6 +41,8 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion` and `Propo
 
 ### Proposed for Inclusion
 
+* [EIP-7666](./eip-7666.md): EVM-ify the identity precompile
+
 ### Activation 
 
 | Network Name     | Activation Epoch | Activation Timestamp |


### PR DESCRIPTION
We need to start having a pipeline to retire precompiles that are  outdated and underused, to reduce the protocol complexity and consensus risk over time.

The easiest precompile to start removing is the identity precompile. EIP-7666 removes the precompile, and replaces it with a piece of EVM code that has equivalent functionality (except naturally it costs more gas). If this approach works for this case, we can later start also applying it to other precompiles (eg. Blake, RIPEMD-160) that see very little usage.