### PR TITLE
Update EIP-7666: Add required PUSH0 EIP

### DIFF
--- a/EIPS/eip-7666.md
+++ b/EIPS/eip-7666.md
@@ -8,6 +8,7 @@ status: Stagnant
 type: Standards Track
 category: Core
 created: 2024-03-31
+requires: 3855
 ---
 
 ## Abstract


### PR DESCRIPTION
The EIP uses the `0x5F` (`PUSH0`) opcode in the bytecode. Therefore, the PUSH0 EIP has to be activated, otherwise this contract will always run into `INVALID` opcodes.