### PR TITLE
Update EIP-7691: fix typos

### DIFF
--- a/EIPS/eip-7691.md
+++ b/EIPS/eip-7691.md
@@ -73,7 +73,7 @@ The execution clients would continue to use `MAX_BLOB_GAS_PER_BLOCK`, `TARGET_BL
 
 ### Network Impacts
 
-Through the use of big block/blob tests on Ethereum mainnet as well as testnets, we can earn a high degree of certainity that the blob limit increase would not negatively impact the network. These tests as well as the associated analysis can be performed mostly by non-client team entities, with minimal input required. Since the changes are quite contained, the EIP should be able to reduce the risk of the blob limit increase.
+Through the use of big block/blob tests on Ethereum mainnet as well as testnets, we can earn a high degree of certainty that the blob limit increase would not negatively impact the network. These tests as well as the associated analysis can be performed mostly by non-client team entities, with minimal input required. Since the changes are quite contained, the EIP should be able to reduce the risk of the blob limit increase.
 
 ### Stability Around Fork Epoch
 


### PR DESCRIPTION
Fix a typo: certainity -> certainty 