### PR TITLE
Update EIP-4762: fix typo

### DIFF
--- a/EIPS/eip-4762.md
+++ b/EIPS/eip-4762.md
@@ -52,7 +52,7 @@ process this access event:
 (address, 0, BASIC_DATA_LEAF_KEY)
 ```
 
-Note: a non-value-bearing `SELFDESTRUCT` or `*CALL`, targetting a precompile or a system contract, will not cause the `BASIC_DATA_LEAF_KEY` to be added to the witness.
+Note: a non-value-bearing `SELFDESTRUCT` or `*CALL`, targeting a precompile or a system contract, will not cause the `BASIC_DATA_LEAF_KEY` to be added to the witness.
 
 If a `*CALL` or `SELFDESTRUCT` is value-bearing (ie. it transfers nonzero wei), whether or not the `callee` is a precompile or a system contract, process this additional access event:
 


### PR DESCRIPTION
Fix a typo `targetting ` to `targeting`

Thank you very much!