### PR TITLE
Update EIP-7691: fix typo

### DIFF
--- a/EIPS/eip-7691.md
+++ b/EIPS/eip-7691.md
@@ -39,7 +39,7 @@ The current long term plan of Ethereum is to implement peerDAS as specified by [
 
 `MAX_BLOBS_PER_BLOCK_ELECTRA` and `TARGET_BLOBS_PER_BLOCK_ELECTRA` are consumed by the consensus layer clients, and starting at `PECTRA_FORK_EPOCH` replace the respective old max and target values.
 
-`MAX_BLOB_GAS_PER_BLOCK`, `TARGET_BLOB_GAS_PER_BLOCK` and `BLOB_BASE_FEE_UPDATE_FRACTION_PRAGUE` are consumed by the execution layer clients, and starting at the epoch when this EIP is actived, replace the old max, target and update fraction values.
+`MAX_BLOB_GAS_PER_BLOCK`, `TARGET_BLOB_GAS_PER_BLOCK` and `BLOB_BASE_FEE_UPDATE_FRACTION_PRAGUE` are consumed by the execution layer clients, and starting at the epoch when this EIP is activated, replace the old max, target and update fraction values.
 
 ## Rationale
 


### PR DESCRIPTION
Hello, I fix a typo `actived` to `activated`.

Thank you very much.