### PR TITLE
Update README: Update vulnerable dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,4 +25,6 @@ gem "html-proofer", '>=5.0.7'
 
 gem "eip_validator", ">=0.8.2"
 
-gem "webrick", "~> 1.8" # needed for macOS builds
+gem "webrick", ">= 1.8.2"
+
+gem "rexml", ">= 3.3.9"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -257,7 +257,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rexml (3.2.5)
+    rexml (3.3.9)
     rouge (3.26.0)
     ruby-rc4 (0.1.5)
     ruby2_keywords (0.0.5)
@@ -285,7 +285,7 @@ GEM
       unf_ext
     unf_ext (0.0.8.2)
     unicode-display_width (1.8.0)
-    webrick (1.8.1)
+    webrick (1.8.2)
     yell (2.2.2)
     zeitwerk (2.6.7)
 

--- a/README.md
+++ b/README.md
@@ -41,9 +41,11 @@ All pull requests in this repository must pass automated checks before they can 
 
 It is possible to run the EIP validator locally:
 
+Make sure to add cargo's `bin` directory to your environment (typically `$HOME/.cargo/bin` in your `PATH` environment variable)
+
 ```sh
-cargo install eipv
-eipv <INPUT FILE / DIRECTORY>
+cargo install eipw
+eipw --config ./config/eipw.toml <INPUT FILE / DIRECTORY>
 ```
 
 ## Build the status page locally
@@ -79,6 +81,8 @@ eipv <INPUT FILE / DIRECTORY>
    ```sh
    bundle exec jekyll serve
    ```
+
+   **Note:** The site uses WEBrick for local development only. WEBrick is not intended for production use and has limitations. It is sufficient for previewing your changes locally, but should not be used to serve the site in a production environment.
 
 2. Preview your local Jekyll site in your web browser at `http://localhost:4000`.
 


### PR DESCRIPTION
Updates the following dependencies to resolve security vulnerabilities:
- webrick from 1.8.1 to 1.8.2 (fixes CVE-2024-47220)
- rexml from 3.2.5 to 3.3.9 (fixes CVE-2024-49761)

Fixes #9115