### PR TITLE
Update EIP-7623: Clarify the gas refunds handling

### DIFF
--- a/EIPS/eip-7623.md
+++ b/EIPS/eip-7623.md
@@ -25,42 +25,45 @@ By introducing a floor cost dependent on the ratio of gas spent on EVM operation
 
 ## Specification
 
-| Parameter | Value |
-| - | - |
-| `STANDARD_TOKEN_COST`    |  `4` |
-| `TOTAL_COST_FLOOR_PER_TOKEN`    |  `10` |
+| Parameter                    | Value |
+|------------------------------|-------|
+| `STANDARD_TOKEN_COST`        | `4`   |
+| `TOTAL_COST_FLOOR_PER_TOKEN` | `10`  |
 
 
 Let `tokens_in_calldata = zero_bytes_in_calldata + nonzero_bytes_in_calldata * 4`.
 
 Let `isContractCreation` be a boolean indicating the respective event.
 
-The current formula for determining the gas used per transaction, typically described as `nonzero_bytes_in_calldata * 16 + zero_bytes_in_calldata * 4`, is equivalent to:
+Let `execution_gas_used` be the gas used for EVM execution with the gas refund subtracted.
+
+The current formula for determining the total gas used per transaction (`tx.gasUsed`) is equivalent to:
 
 ```python
 tx.gasUsed = (
     21000
-        + STANDARD_TOKEN_COST * tokens_in_calldata
-        + evm_gas_used
-        + isContractCreation * (32000 + InitCodeWordGas * words(calldata))
+    + STANDARD_TOKEN_COST * tokens_in_calldata
+    + execution_gas_used
+    + isContractCreation * (32000 + INITCODE_WORD_COST * words(calldata))
 )
 ```
 
 The formula for determining the gas used per transaction changes to:
 
 ```python
-tx.gasUsed = {
+tx.gasUsed = (
     21000
-    + 
-    max (
+    +
+    max(
         STANDARD_TOKEN_COST * tokens_in_calldata
-           + evm_gas_used
-           + isContractCreation * (32000 + InitCodeWordGas * words(calldata)),
+        + execution_gas_used
+        + isContractCreation * (32000 + INITCODE_WORD_COST * words(calldata)),
         TOTAL_COST_FLOOR_PER_TOKEN * tokens_in_calldata
     )
+)
 ```
 
-Any transaction with a gas limit below `21000 + TOTAL_COST_FLOOR_PER_TOKEN * tokens_in_calldata` or below it's intrinsic gas cost (take the maximum of these two calculations) is considered invalid. This limitation exists because transactions must cover the floor price of their calldata without relying on the execution of the transaction. There are valid cases where `gasUsed` will be below this floor price, but the floor price needs to be reserved in the transaction gas limit.
+Any transaction with a gas limit below `21000 + TOTAL_COST_FLOOR_PER_TOKEN * tokens_in_calldata` or below its intrinsic gas cost (take the maximum of these two calculations) is considered invalid. This limitation exists because transactions must cover the floor price of their calldata without relying on the execution of the transaction. There are valid cases where `gasUsed` will be below this floor price, but the floor price needs to be reserved in the transaction gas limit.
 
 ## Rationale
 


### PR DESCRIPTION
Previously, the `evm_gas_used` (now renamed to `execution_gas_used`) was not specified. This lead to two different interpretations whenever the `execution_gas_used` was the value after or before applying refunds.

We argue that the interpretation that `execution_gas_used` don't have refunds subtracted is incorrect because it would make the "current" formula for the `tx.gasUsed` incomplete and confusing as the total gas used by a transaction would actually be `tx.gasUsed - refunds`.

Using this reasoning, this change clarifies the specification by following the interpretation that the `execution_gas_used` is the value after the refunds are applied.