### PR TITLE
Update EIP-7702: Update description

### DIFF
--- a/EIPS/eip-7702.md
+++ b/EIPS/eip-7702.md
@@ -1,7 +1,7 @@
 ---
 eip: 7702
 title: Set EOA account code
-description: Add a new tx type that permanently sets the code for an EOA
+description: Add a new tx type that sets the code for an EOA
 author: Vitalik Buterin (@vbuterin), Sam Wilson (@SamWilsn), Ansgar Dietrichs (@adietrichs), lightclient (@lightclient)
 discussions-to: https://ethereum-magicians.org/t/eip-set-eoa-account-code-for-one-transaction/19923
 status: Review


### PR DESCRIPTION
The word *permanently* was added in 52c5677 but this seems to be outdated. In the latest version of EIP-7702, `SET_CODE_TX_TYPE` transactions can set, update, or clear an account's delegation designation.