### PR TITLE
Update EIP-7642: Move to Draft

### DIFF
--- a/EIPS/eip-7642.md
+++ b/EIPS/eip-7642.md
@@ -91,12 +91,11 @@ CPU intensive. The bandwidth gains amount to roughly 530GiB per syncing node or 
 95GiB snappy compressed.
 
 In Ethereum consensus, the encoding of receipts differs between legacy transactions and
-typed transactions. Typed transaction receipts are technically 'opaque' and have the data
-wrapped in a byte array. However, all receipt types ultimately contain the same four
-fields. With the removal of the bloom filter, the networking protocol now deviates from
-the encoding used by consensus, and there is no need to replicate the weird and expensive
-encoding used there. The proposed receipt encoding is just a flat list of the required
-data fields.
+typed transactions. Typed transaction receipts are 'opaque' and have the data wrapped in a
+byte array. However, all receipt types ultimately contain the same four fields. With the
+removal of the bloom filter, the networking protocol now deviates from the encoding used
+by consensus, and there is no need to replicate the weird and expensive encoding used
+there. The proposed receipt encoding is just a flat list of the required data fields.
 
 ## Backwards Compatibility
 

--- a/EIPS/eip-7642.md
+++ b/EIPS/eip-7642.md
@@ -65,9 +65,24 @@ legacy-receipt = [
 
 ## Rationale
 
+### Status changes
+
 After the merge, the `TD` field of the `Status` message became meaningless since the
 difficulty of post-merge blocks are 0. It could in theory be used to distinguish synced
 with unsynced nodes, but the same thing can be accomplished with the forkid as well.
+
+The new `earliestBlock` field is technically not required for history expiry, but there
+are a couple reasons why adding it can help:
+
+- It improves peer finding for clients that still want to sync history from p2p after the
+  agreed-upon removal of pre merge history has taken place. Without `earliestBlock`, the
+  client would have to perform a request for history to check if the earlier range exists,
+  and assume that a failed request means it's not there.
+- The new field can be used for census in a specialized crawler. We will be able to see
+  how many users/nodes enable history, and in which implementation.
+- It prepares us for a future where the history expiry window is dynamic.
+
+### Receipts changes
 
 Removing the bloom filters from the `Receipt` message reduces the CPU load of serving
 nodes as well as the bandwidth significantly. The receiving nodes will need to recompute

--- a/EIPS/eip-7642.md
+++ b/EIPS/eip-7642.md
@@ -33,7 +33,7 @@ bandwidth to every sync.
 ### earliestBlock in Status message
 
 In the history expiry working group, it was decided that clients may drop pre-merge
-history from their storage after April 1, 2025. For clients that want to sync history
+history from their storage after May 1, 2025. For clients that want to sync history
 through the 'eth' protocol, it is essential to know whether a peer still serves old
 history. A similar idea was proposed in [EIP-7542](./eip-7542.md) but was later withdrawn
 because a political decision on history expiry had not been reached at the time.

--- a/EIPS/eip-7642.md
+++ b/EIPS/eip-7642.md
@@ -90,6 +90,14 @@ the bloom filter in order to fully verify the receipt hash. The recomputation is
 CPU intensive. The bandwidth gains amount to roughly 530GiB per syncing node or (at least)
 95GiB snappy compressed.
 
+In Ethereum consensus, the encoding of receipts differs between legacy transactions and
+typed transactions. Typed transaction receipts are technically 'opaque' and have the data
+wrapped in a byte array. However, all receipt types ultimately contain the same four
+fields. Since the network protocol now introduces a deviation from the encoding used by
+consensus by removing the bloom filter, there is no need to replicate the weird and
+expensive encoding used by consensus. The proposed receipt encoding is just a flat list of
+the required data fields.
+
 ## Backwards Compatibility
 
 This EIP changes the eth protocol and requires rolling out a new version, `eth/69`.

--- a/EIPS/eip-7642.md
+++ b/EIPS/eip-7642.md
@@ -35,9 +35,8 @@ bandwidth to every sync.
 In the history expiry working group, it was decided that clients may drop pre-merge
 history from their storage after April 1, 2025. For clients that want to sync history
 through the 'eth' protocol, it is essential to know whether a peer still serves old
-history. A similar idea was proposed in
-[EIP-7542](https://eips.ethereum.org/EIPS/eip-7542) but was later withdrawn because a
-political decision on history expiry had not been reached at the time.
+history. A similar idea was proposed in [EIP-7542](./eip-7542.md) but was later withdrawn
+because a political decision on history expiry had not been reached at the time.
 
 ## Specification
 

--- a/EIPS/eip-7642.md
+++ b/EIPS/eip-7642.md
@@ -1,7 +1,7 @@
 ---
 eip: 7642
-title: eth/69 - Drop pre-merge fields
-description: Drop unnecessary fields after the merge
+title: eth/69 - Protocol version for history expiry and simplifying receipts
+description: Adds history serving window and removes bloom filter in receipt
 author: Marius van der Wijden (@MariusVanDerWijden), Felix Lange <fjl@ethereum.org>
 discussions-to: https://ethereum-magicians.org/t/eth-70-drop-pre-merge-fields-from-eth-protocol/19005
 status: Stagnant
@@ -13,21 +13,31 @@ requires: 5793
 
 ## Abstract
 
-After the merge the `td` field in the networking protocol became obsolete.
-This EIP modifies the networking messages such that this field is not sent anymore.
-Additionally we propose to remove the `Bloom` field from the receipts networking messages.
+This EIP modifies the 'eth' p2p protocol to announce the historical block range served by
+the node. We also simplify the handshake to remove total difficulty information, which
+isn't used anymore after the merge. Additionally we propose to remove the `Bloom` field
+from receipts transfered over the protocol.
 
 ## Motivation
 
-We recently discovered that none of the clients store the `Bloom` field of the receipts as it can be recomputed on demand.
-However the networking spec requires the `Bloom` field to be sent over the network.
-Thus a syncing node will ask for the Bloom filters for all receipts.
-The serving node will regenerate roughly 530GB of bloom filters (2.3B txs * 256 byte).
-These 530GBs are send over the network to the syncing peer, the syncing peer will verify them and not store them either.
-This adds an additional 530GB of unnecessary bandwidth to every sync.
+### Removing Bloom in Receipts
 
-Additionally we propose to remove the field that was deprecated by the merge, namely
-the `TD` field in the `Status` message. 
+We recently discovered that none of the clients store the `Bloom` field of the receipts as
+it can be recomputed on demand. However the networking spec requires the `Bloom` field to
+be sent over the network. Thus a syncing node will ask for the Bloom filters for all
+receipts. The serving node will regenerate roughly 530GB of bloom filters (2.3B txs * 256
+byte). These 530GBs are send over the network to the syncing peer, the syncing peer will
+verify them and not store them either. This adds an additional 530GB of unnecessary
+bandwidth to every sync.
+
+### earliestBlock in Status message
+
+In the history expiry working group, it was decided that clients may drop pre-merge
+history from their storage after April 1, 2025. For clients that want to sync history
+through the 'eth' protocol, it is essential to know whether a peer still serves old
+history. A similar idea was proposed in
+[EIP-7542](https://eips.ethereum.org/EIPS/eip-7542) but was later withdrawn because a
+political decision on history expiry had not been reached at the time.
 
 ## Specification
 
@@ -35,13 +45,15 @@ Modify the `Status (0x00)` message as follows:
 
 - (eth/68): `[version: P, networkid: P, td: P, blockhash: B_32, genesis: B_32, forkid]`
 
-- (eth/69): `[version: P, networkid: P, blockhash: B_32, genesis: B_32, forkid]`
+- (eth/69): `[version: P, networkid: P, blockhash: B_32, genesis: B_32, forkid, earliestBlock: P]`
 
 Modify the encoding for receipts in the `Receipts (0x10)` message as follows:
 
-- (eth/68): `receipt = {legacy-receipt, typed-receipt}` with `typed-receipt = tx-type || receipt-data` and
+- (eth/68): `receipt = {legacy-receipt, typed-receipt}` with
 
 ```
+typed-receipt = tx-type || legacy-receipt
+
 legacy-receipt = [
     post-state-or-status: {B_32, {0, 1}},
     cumulative-gas: P,
@@ -50,32 +62,26 @@ legacy-receipt = [
 ]
 ```
 
-- (eth/69): `receipt = {legacy-receipt, typed-receipt}` with `typed-receipt = tx-type || receipt-data` and
-
-```
-legacy-receipt = [
-    post-state-or-status: {B_32, {0, 1}},
-    cumulative-gas: P,
-    logs: [log₁, log₂, ...]
-]
-```
-
-We omit the bloom filter from both the legacy and typed receipts.
-Receiving nodes will be able to recompute the bloom filter based on the logs.
+- (eth/69): `receipt = [tx-type, post-state-or-status, cumulative-gas, logs]`
 
 ## Rationale
 
-After the merge, the `TD` field of the `Status` message became meaningless since the difficulty of post-merge blocks are 0.
-It could in theory be used to distinguish synced with unsynced nodes, 
-but the same thing can be accomplished with the forkid as well. 
-It is not used in the go-ethereum codebase in any way.
+After the merge, the `TD` field of the `Status` message became meaningless since the
+difficulty of post-merge blocks are 0. It could in theory be used to distinguish synced
+with unsynced nodes, but the same thing can be accomplished with the forkid as well.
 
-Removing the bloom filters from the `Receipt` message reduces the cpu load of serving nodes as well as the bandwidth significantly. The receiving nodes will need to recompute the bloom filter. The recomputation is not very CPU intensive. 
-The bandwidth gains amount to roughly 530GiB per syncing node or (at least) 95GiB snappy compressed. 
+Removing the bloom filters from the `Receipt` message reduces the CPU load of serving
+nodes as well as the bandwidth significantly. The receiving nodes will need to recompute
+the bloom filter in order to fully verify the receipt hash. The recomputation is not very
+CPU intensive. The bandwidth gains amount to roughly 530GiB per syncing node or (at least)
+95GiB snappy compressed.
 
 ## Backwards Compatibility
 
-This EIP changes the eth protocol and requires rolling out a new version, `eth/69`. Supporting multiple versions of a wire protocol is possible. Rolling out a new version does not break older clients immediately, since they can keep using protocol version `eth/68`.
+This EIP changes the eth protocol and requires rolling out a new version, `eth/69`.
+Supporting multiple versions of a wire protocol is possible. Rolling out a new version
+does not break older clients immediately, since they can keep using protocol version
+`eth/68`.
 
 This EIP does not change consensus rules of the EVM and does not require a hard fork.
 

--- a/EIPS/eip-7642.md
+++ b/EIPS/eip-7642.md
@@ -93,10 +93,10 @@ CPU intensive. The bandwidth gains amount to roughly 530GiB per syncing node or 
 In Ethereum consensus, the encoding of receipts differs between legacy transactions and
 typed transactions. Typed transaction receipts are technically 'opaque' and have the data
 wrapped in a byte array. However, all receipt types ultimately contain the same four
-fields. Since the network protocol now introduces a deviation from the encoding used by
-consensus by removing the bloom filter, there is no need to replicate the weird and
-expensive encoding used by consensus. The proposed receipt encoding is just a flat list of
-the required data fields.
+fields. With the removal of the bloom filter, the networking protocol now deviates from
+the encoding used by consensus, and there is no need to replicate the weird and expensive
+encoding used there. The proposed receipt encoding is just a flat list of the required
+data fields.
 
 ## Backwards Compatibility
 

--- a/EIPS/eip-7642.md
+++ b/EIPS/eip-7642.md
@@ -51,7 +51,7 @@ Modify the encoding for receipts in the `Receipts (0x10)` message as follows:
 - (eth/68): `receipt = {legacy-receipt, typed-receipt}` with
 
 ```
-typed-receipt = tx-type || legacy-receipt
+typed-receipt = tx-type || rlp(legacy-receipt)
 
 legacy-receipt = [
     post-state-or-status: {B_32, {0, 1}},

--- a/EIPS/eip-7642.md
+++ b/EIPS/eip-7642.md
@@ -1,6 +1,6 @@
 ---
 eip: 7642
-title: eth/69 - Protocol version for history expiry and simplifying receipts
+title: eth/69 - history expiry and simpler receipts
 description: Adds history serving window and removes bloom filter in receipt
 author: Marius van der Wijden (@MariusVanDerWijden), Felix Lange <fjl@ethereum.org>
 discussions-to: https://ethereum-magicians.org/t/eth-70-drop-pre-merge-fields-from-eth-protocol/19005

--- a/EIPS/eip-7642.md
+++ b/EIPS/eip-7642.md
@@ -2,9 +2,9 @@
 eip: 7642
 title: eth/69 - history expiry and simpler receipts
 description: Adds history serving window and removes bloom filter in receipt
-author: Marius van der Wijden (@MariusVanDerWijden), Felix Lange <fjl@ethereum.org>
+author: Marius van der Wijden (@MariusVanDerWijden), Felix Lange <fjl@ethereum.org>, Ahmad Bitar (@smartprogrammer93) <smartprogrammer@windowslive.com>
 discussions-to: https://ethereum-magicians.org/t/eth-70-drop-pre-merge-fields-from-eth-protocol/19005
-status: Stagnant
+status: Draft
 type: Standards Track
 category: Networking
 created: 2024-02-29
@@ -20,6 +20,14 @@ from receipts transfered over the protocol.
 
 ## Motivation
 
+### Block range in Status message
+
+In the history expiry working group, it was decided that clients may drop pre-merge
+history from their storage after May 1, 2025. For clients that want to sync history
+through the 'eth' protocol, it is essential to know whether a peer still serves old
+history. A similar idea was proposed in [EIP-7542](./eip-7542.md) but was later withdrawn
+because a political decision on history expiry had not been reached at the time.
+
 ### Removing Bloom in Receipts
 
 We recently discovered that none of the clients store the `Bloom` field of the receipts as
@@ -30,21 +38,25 @@ byte). These 530GBs are send over the network to the syncing peer, the syncing p
 verify them and not store them either. This adds an additional 530GB of unnecessary
 bandwidth to every sync.
 
-### earliestBlock in Status message
+### BlockRangeUpdate message
 
-In the history expiry working group, it was decided that clients may drop pre-merge
-history from their storage after May 1, 2025. For clients that want to sync history
-through the 'eth' protocol, it is essential to know whether a peer still serves old
-history. A similar idea was proposed in [EIP-7542](./eip-7542.md) but was later withdrawn
-because a political decision on history expiry had not been reached at the time.
+We want clients to be aware of the available block range in their peers. The new
+notification message can be used to detect sync status of peers, and adjust fetching
+behavior accordingly.
 
 ## Specification
+
+### Status message changes
 
 Modify the `Status (0x00)` message as follows:
 
 - (eth/68): `[version: P, networkid: P, td: P, blockhash: B_32, genesis: B_32, forkid]`
 
-- (eth/69): `[version: P, networkid: P, blockhash: B_32, genesis: B_32, forkid, earliestBlock: P]`
+- (eth/69): `[version: P, networkid: P, genesis: B_32, forkid, earliestBlock: P, latestBlock: P, latestBlockHash: B_32]`
+
+Note `blockhash` has moved to the end to match `BlockRangeUpdate`.
+
+### Receipts message changes
 
 Modify the encoding for receipts in the `Receipts (0x10)` message as follows:
 
@@ -62,6 +74,16 @@ legacy-receipt = [
 ```
 
 - (eth/69): `receipt = [tx-type, post-state-or-status, cumulative-gas, logs]`
+
+### BlockRangeUpdate message
+
+Add a new `BlockRangeUpdate (0x11)` message, with the following encoding
+
+`[earliestBlock: P, latestBlock: P, latestBlockHash: B_32]`
+
+The new message should be sent whenever the block range available from this client is
+updated. In order to reduce traffic, it is not necessary to send an update for every new
+block. Clients should send an update at most once per epoch (32 blocks).
 
 ## Rationale
 


### PR DESCRIPTION
Here I am updating the eth/69 proposal with two changes:

- Simplifying the receipts encoding. The original EIP proposed a new format for receipts with the bloom filter removed. It did that by mirroring the complex encoding for typed receipts which is also used by Ethereum consensus. Since the network protocol now introduces a deviation from the encoding used by consensus, there is no need to make it so complex. 

  Ultimately all receipt types contain the same four fields. So with this update, I am changing the network encoding to be the same for all receipt types.

- I am adding a new field `earliestBlock` in the `Status` message. This is somewhat similar to EIP-7542, which proposed adding a `blockRange`.
