### PR TITLE
Update EIP-4762: Fix references to CALLCODE and wording around its value-transfer costs

### DIFF
--- a/EIPS/eip-4762.md
+++ b/EIPS/eip-4762.md
@@ -41,7 +41,7 @@ Whenever the state is read, one or more of the access events of the form`(addres
 
 When:
 
- 1. a non-precompile which is also not a system contract is the target of a `*CALL`, `SELFDESTRUCT`, `EXTCODESIZE`, or `EXTCODECOPY` opcode,
+ 1. a non-precompile which is also not a system contract is the target of a `*CALL`, `CALLCODE`, `SELFDESTRUCT`, `EXTCODESIZE`, or `EXTCODECOPY` opcode,
  2. a non-precompile which is also not a system contract is the target address of a contract creation whose initcode starts execution,
  3. any address is the target of the `BALANCE` opcode
  4. a _deployed_ contract calls `CODECOPY`
@@ -52,9 +52,9 @@ process this access event:
 (address, 0, BASIC_DATA_LEAF_KEY)
 ```
 
-Note: a non-value-bearing `SELFDESTRUCT` or `*CALL`, targeting a precompile or a system contract, will not cause the `BASIC_DATA_LEAF_KEY` to be added to the witness.
+Note: a non-value-bearing `SELFDESTRUCT`, `*CALL` or `CALLCODE`, targeting a precompile or a system contract, will not cause the `BASIC_DATA_LEAF_KEY` to be added to the witness.
 
-If a `*CALL` or `SELFDESTRUCT` is value-bearing (ie. it transfers nonzero wei), whether or not the `callee` is a precompile or a system contract, process this additional access event:
+If a `*CALL`, `CALLCODE` or `SELFDESTRUCT` is value-bearing (ie. it transfers nonzero wei), whether or not the `callee` is a precompile or a system contract, process this additional access event:
 
 ```
 (caller, 0, BASIC_DATA_LEAF_KEY)
@@ -115,7 +115,7 @@ We define **write events** as follows. Note that when a write takes place, an ac
 
 #### Write events for account headers
 
-When a nonzero-balance-sending `CALL` or `SELFDESTRUCT` with a given sender and recipient takes place, process these write events:
+When a nonzero-balance-sending `CALL`, `CALLCODE` or `SELFDESTRUCT` with a given sender and recipient takes place, process these write events:
 
 ```
 (caller, 0, BASIC_DATA_LEAF_KEY)
@@ -193,7 +193,7 @@ Remove the following gas costs:
  * Increased gas cost of `CALL` if it is nonzero-value-sending
  * [EIP-2200](./eip-2200.md) `SSTORE` gas costs except for the `SLOAD_GAS`
  * 200 per byte contract code cost
- * static `CALLCODE` cost if it is nonzero-value-sending
+ * All `CALLCODE` costs related to nonzero-value-sending
 
 Reduce gas cost:
 
@@ -234,7 +234,7 @@ Note that values should only be added to the witness if there is sufficient gas 
 
 `CREATE*` and `*CALL` reserve 1/64th of the gas before the nested execution. In order to match the behavior of this charge with the pre-fork behavior of access lists: 
 
- * this minimum 1/64th gas reservation is checked **AFTER** charging the witness costs when performing a `CALL`, `CODECALL`, `DELEGATECALL` or`STATICCALL`
+ * this minimum 1/64th gas reservation is checked **AFTER** charging the witness costs when performing a `CALL`, `CALLCODE`, `DELEGATECALL` or`STATICCALL`
  * this 1/64th of the gas is subtracted **BEFORE** charging the witness costs when performing a `CREATE` or `CREATE2`
 
 ### Block-level operations


### PR DESCRIPTION
This is to correct a previous PR that was merged without applying these changes. I also found what I believe some missing references for CALLCODE since wildcarded `*CALL` does not cover this case.

