### PR TITLE
Update EIP-2537: Align gas cost in `Constants` section with `Gas schedule` section.

### DIFF
--- a/EIPS/eip-2537.md
+++ b/EIPS/eip-2537.md
@@ -36,13 +36,13 @@ The motivation of this precompile is to add a cryptographic primitive that allow
 
 We introduce *seven* separate precompiles to perform the following operations:
 
-- BLS12_G1ADD - to perform point addition in G1 (curve over base prime field) with a gas cost of `500` gas
+- BLS12_G1ADD - to perform point addition in G1 (curve over base prime field) with a gas cost of `375` gas
 - BLS12_G1MSM - to perform multi-scalar-multiplication (MSM) in G1 (curve over base prime field) with a gas cost formula defined in the corresponding section
-- BLS12_G2ADD - to perform point addition in G2 (curve over quadratic extension of the base prime field) with a gas cost of `800` gas
+- BLS12_G2ADD - to perform point addition in G2 (curve over quadratic extension of the base prime field) with a gas cost of `600` gas
 - BLS12_G2MSM - to perform multi-scalar-multiplication (MSM) in G2 (curve over quadratic extension of the base prime field) with a gas cost formula defined in the corresponding section
 - BLS12_PAIRING_CHECK - to perform a pairing operations between a set of *pairs* of (G1, G2) points a gas cost formula defined in the corresponding section
 - BLS12_MAP_FP_TO_G1 - maps base field element into the G1 point with a gas cost of `5500` gas
-- BLS12_MAP_FP2_TO_G2 - maps extension field element into the G2 point with a gas cost of `75000` gas
+- BLS12_MAP_FP2_TO_G2 - maps extension field element into the G2 point with a gas cost of `23800` gas
 
 A mapping functions specification is included as a separate [document](../assets/eip-2537/field_to_curve.md). This mapping function does NOT perform mapping of the byte string into a field element (as it can be implemented in many different ways and can be efficiently performed in EVM), but only does field arithmetic to map a field element into a curve point. Such functionality is required for signature schemes.
 


### PR DESCRIPTION
This PR aligns recently updated gas cost for `BLS12_G1ADD`, `BLS12_G2ADD` and `BLS12_MAP_FP2_TO_G2` between different sections of the document.