### PR TITLE
Update EIP-7691: clarify that all 3 EL constants change in Prague

### DIFF
--- a/EIPS/eip-7691.md
+++ b/EIPS/eip-7691.md
@@ -22,7 +22,7 @@ As we now have the Dencun upgrade live, we are able to use monitoring tools to c
 
 Additional EIPs such as [EIP-7623](./eip-7623.md) proposes a calldata cost increase which would significantly lower the worst case base block size, thus creating more headroom for a potential blob throughput increase.
 
-The current long term plan of Ethereum is to implement peerDAS as specified by [EIP-7594](./eip-7594.md), but given the uncertain timelines, this EIP aims to increase the throughput short term to provide some scaling until future solutions are deployed. In order to alleviate valid concerns about solo-stakers, approaches such as the inclusion of a flag indicating the max blobs per block for locally built blocks could be considered.
+The current long term plan of Ethereum is to implement peerDAS, but given the uncertain timelines, this EIP aims to increase the throughput short term to provide some scaling until future solutions are deployed. In order to alleviate valid concerns about solo-stakers, approaches such as the inclusion of a flag indicating the max blobs per block for locally built blocks could be considered.
 
 
 ## Specification

--- a/EIPS/eip-7691.md
+++ b/EIPS/eip-7691.md
@@ -33,13 +33,13 @@ The current long term plan of Ethereum is to implement peerDAS as specified by [
 |------------------------------------------|---------------------|
 | `MAX_BLOBS_PER_BLOCK_ELECTRA`            | `9`                 |
 | `TARGET_BLOBS_PER_BLOCK_ELECTRA`         | `6`                 |
-| `MAX_BLOB_GAS_PER_BLOCK`                 | `1179648`           |
-| `TARGET_BLOB_GAS_PER_BLOCK`              | `786432`            |
+| `MAX_BLOB_GAS_PER_BLOCK_PRAGUE`          | `1179648`           |
+| `TARGET_BLOB_GAS_PER_BLOCK_PRAGUE`       | `786432`            |
 | `BLOB_BASE_FEE_UPDATE_FRACTION_PRAGUE`  | `5007716`           |
 
 `MAX_BLOBS_PER_BLOCK_ELECTRA` and `TARGET_BLOBS_PER_BLOCK_ELECTRA` are consumed by the consensus layer clients, and starting at `PECTRA_FORK_EPOCH` replace the respective old max and target values.
 
-`MAX_BLOB_GAS_PER_BLOCK`, `TARGET_BLOB_GAS_PER_BLOCK` and `BLOB_BASE_FEE_UPDATE_FRACTION_PRAGUE` are consumed by the execution layer clients, and starting at the epoch when this EIP is activated, replace the old max, target and update fraction values.
+`MAX_BLOB_GAS_PER_BLOCK_PRAGUE`, `TARGET_BLOB_GAS_PER_BLOCK_PRAGUE` and `BLOB_BASE_FEE_UPDATE_FRACTION_PRAGUE` are consumed by the execution layer clients, and starting at the epoch when this EIP is activated, replace the old max, target and update fraction values.
 
 ## Rationale
 
@@ -67,7 +67,7 @@ The `BLOB_BASE_FEE_UPDATE_FRACTION_PRAGUE` value in this EIP is chosen as the mi
 
 The consensus clients would continue to use `MAX_BLOBS_PER_BLOCK` and `TARGET_BLOBS_PER_BLOCK` for the deneb fork and once the `ELECTRA` fork is active, they would use `MAX_BLOBS_PER_BLOCK_ELECTRA` and `TARGET_BLOBS_PER_BLOCK_ELECTRA` respectively.
 
-The execution clients would continue to use `MAX_BLOB_GAS_PER_BLOCK`, `TARGET_BLOB_GAS_PER_BLOCK` and `BLOB_BASE_FEE_UPDATE_FRACTION` for the cancun fork and once the prague fork is active, they would use `MAX_BLOB_GAS_PER_BLOCK`, `TARGET_BLOB_GAS_PER_BLOCK` and `BLOB_BASE_FEE_UPDATE_FRACTION_PRAGUE` respectively.
+The execution clients would continue to use `MAX_BLOB_GAS_PER_BLOCK`, `TARGET_BLOB_GAS_PER_BLOCK` and `BLOB_BASE_FEE_UPDATE_FRACTION` for the cancun fork and once the prague fork is active, they would use `MAX_BLOB_GAS_PER_BLOCK_PRAGUE`, `TARGET_BLOB_GAS_PER_BLOCK_PRAGUE` and `BLOB_BASE_FEE_UPDATE_FRACTION_PRAGUE` respectively.
 
 ## Security Considerations
 


### PR DESCRIPTION
Otherwise the doc would say:

> "The execution clients would continue to use `MAX_BLOB_GAS_PER_BLOCK` (...) for the cancun fork"

while `MAX_BLOB_GAS_PER_BLOCK` is given a new value, which threw me off for a second.