### PR TITLE
Update EIP-7691: clarify parameter handling at the fork boundary

### DIFF
--- a/EIPS/eip-7691.md
+++ b/EIPS/eip-7691.md
@@ -40,6 +40,9 @@ The current long term plan of Ethereum is to implement peerDAS as specified by [
 `MAX_BLOBS_PER_BLOCK_ELECTRA` and `TARGET_BLOBS_PER_BLOCK_ELECTRA` are consumed by the consensus layer clients, and starting at `PECTRA_FORK_EPOCH` replace the respective old max and target values.
 
 `MAX_BLOB_GAS_PER_BLOCK`, `TARGET_BLOB_GAS_PER_BLOCK` and `BLOB_BASE_FEE_UPDATE_FRACTION_PRAGUE` are consumed by the execution layer clients, and starting at the epoch when this EIP is activated, replace the old max, target and update fraction values.
+Any references to `MAX_BLOB_GAS_PER_BLOCK` and `TARGET_BLOB_GAS_PER_BLOCK` in [EIP-4844](./eip-4844.md) should be updated to the new values defined in this EIP when processing the activation block.
+The value `BLOB_BASE_FEE_UPDATE_FRACTION_PRAGUE` replaces its previous equivalent when processing the activation block.
+These changes imply that `get_base_fee_per_blob_gas` and `calc_excess_blob_gas` functions defined in [EIP-4844](./eip-4844.md) use the new values for the first block of the fork (and for all subsequent blocks).
 
 ## Rationale
 

--- a/EIPS/eip-7691.md
+++ b/EIPS/eip-7691.md
@@ -22,8 +22,7 @@ As we now have the Dencun upgrade live, we are able to use monitoring tools to c
 
 Additional EIPs such as [EIP-7623](./eip-7623.md) proposes a calldata cost increase which would significantly lower the worst case base block size, thus creating more headroom for a potential blob throughput increase.
 
-The current long term plan of Ethereum is to implement peerDAS as specified by [EIP-7594](./eip-7594.md), but given the uncertain timelines, this EIP aims to increase the throughput short term to provide some scaling until future solutions are deployed. In order to alleviate valid concerns about solo-stakers, approaches such as the inclusion of a flag indicating the max blobs per block for locally built blocks could be considered.
-
+This EIP aims to increase the throughput short term to provide some scaling until future solutions are deployed. In order to alleviate valid concerns about solo-stakers, approaches such as the inclusion of a flag indicating the max blobs per block for locally built blocks could be considered.
 
 ## Specification
 


### PR DESCRIPTION
adds some text to clarify that the new values should be used within the fork activation block.

so that pre-fork, the old values are used, and at the first block of the new fork, the new values are used
