### PR TITLE
Update EIP-7702: Clarify CODE* operations behavior

### DIFF
--- a/EIPS/eip-7702.md
+++ b/EIPS/eip-7702.md
@@ -91,6 +91,8 @@ The delegation designation uses the banned opcode `0xef` from [EIP-3541](./eip-3
 
 For example, `EXTCODESIZE` would return `23` (the size of `0xef0100 || address`), `EXTCODEHASH` would return `keccak256(0xef0100 || address)`, and `CALL` would load the code from `address` and execute it in the context of `authority`.
 
+`CODESIZE` and `CODECOPY` instructions operate on executable code, as before. *Note that in a delegated execution `CODESIZE` and `CODECOPY` produce different result comparing to `EXTCODESIZE` and `EXTCODECOPY` of execution target.*
+
 In case a delegation designator points to a precompile address, retrieved code is considered empty and `CALL`, `CALLCODE`, `STATICCALL`, `DELEGATECALL` instructions targeting this account will execute empty code, i.e. succeed with no execution given enough gas.
 
 In case a delegation designator points to another designator, creating a potential chain or loop of designators, clients must retrieve only the first code and then stop following the designator chain.


### PR DESCRIPTION
Clarify that `CODE*` operate on the code being executed, and not on the delegation designator.

(Tests' expectations agree with this.)

This clarification is motivated by confusion observed in this document: https://hackmd.io/5kcrdKgaQHSjrQ9MtAlBfg?comment=37baf7a2-fd97-4e3a-9972-e4a86c92ce8b