### PR TITLE
Update EIP-7607: Add EIP-7823 (Set upper bounds for MODEXP) to proposeed-for-inclusion in Fusaka

### DIFF
--- a/EIPS/eip-7607.md
+++ b/EIPS/eip-7607.md
@@ -42,6 +42,7 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion` and `Propo
 ### Proposed for Inclusion
 
 * [EIP-7666](./eip-7666.md): EVM-ify the identity precompile
+* [EIP-7823](./eip-7823.md): Set upper bounds for MODEXP
 
 ### Activation 
 


### PR DESCRIPTION
See the motivation for more details:
1. Removes unused unbounded cases. Such cases are known to have caused numerous consensus bugs in the past.
2. Makes it easier for ZK systems to implement this precompile -- and many already have a similar limitation in place (like Polygon zkEVM).
3. Makes it easier to implement the precompile using EVMMAX.