### PR TITLE
Update EIP-7702: eip-7702.md

### DIFF
--- a/EIPS/eip-7702.md
+++ b/EIPS/eip-7702.md
@@ -68,7 +68,7 @@ At the start of executing the transaction, after incrementing the sender's nonce
 
 1. Verify the chain id is either 0 or the chain's current ID.
 2. Verify the `nonce` is less than `2**64 - 1`.
-3. `authority = ecrecover(keccak(MAGIC || rlp([chain_id, address, nonce])), y_parity, r, s]`
+3. `authority = ecrecover(keccak(MAGIC || rlp([chain_id, address, nonce])), y_parity, r, s)`
     * `s` value must be less than or equal to `secp256k1n/2`, as specified in [EIP-2](./eip-2.md).
 4. Add `authority` to `accessed_addresses` (as defined in [EIP-2929](./eip-2929.md).)
 5. Verify the code of `authority` is either empty or already delegated.


### PR DESCRIPTION
# EIP-7702 typo

Hi, i think a closing parentheses has to go instead of a closing bracket to match the `ecrecover(` opening.
