### PR TITLE
Update EIP-7607: Propose EIP-7863 for Fusaka

### DIFF
--- a/EIPS/eip-7607.md
+++ b/EIPS/eip-7607.md
@@ -42,7 +42,8 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion` and `Propo
 ### Proposed for Inclusion
 
 * [EIP-7666](./eip-7666.md): EVM-ify the identity precompile
-
+* [EIP-7863](./eip-7863.md): Block-level warming
+  
 ### Activation 
 
 | Network Name     | Activation Epoch | Activation Timestamp |


### PR DESCRIPTION
This EIP proposed keeping accessed addresses and storage keys "warm" throughout the duration of a block.

This aligns more closely with the caching practices used in clients and improves overall efficiency.

Additional info in this ethresearch post:
https://ethresear.ch/t/block-level-warming/21452/8