### PR TITLE
Update EIP-7805: Try fixing HTML rendering of bullets

### DIFF
--- a/EIPS/eip-7805.md
+++ b/EIPS/eip-7805.md
@@ -95,11 +95,11 @@ For each transaction `T` in ILs, perform the following:
 
 1. Check whether `T` is present in `B`. If `T` is present, then jump to the next transaction, else continue with next step.
 
-2. Validate `T` against `S`. 
+2. Validate `T` against `S`.
 
-  - If `T` is invalid, then continue to the next transaction. 
-  
-  - If `T` is valid, terminate process and assert block `B` as invalid.
+   - If `T` is invalid, then continue to the next transaction.
+
+   - If `T` is valid, terminate process and assert block `B` as invalid.
 
 3. Execute `T` on state `S`. Assert that the execution of `T` fails.
 
@@ -124,11 +124,11 @@ The full consensus changes can be found in the following GitHub repository. They
 
 ##### Preset
 
-| Name | Value |
-| - | - |
-| `DOMAIN_IL_COMMITTEE`       | `DomainType('0x0C000000')`  |
-| `IL_COMMITTEE_SIZE` | `uint64(2**4)` (=16)  |
-| `MAX_BYTES_PER_INCLUSION_LIST` |  `uint64(2**13)` (=8192) | 
+| Name                           | Value                      |
+| ------------------------------ | -------------------------- |
+| `DOMAIN_IL_COMMITTEE`          | `DomainType('0x0C000000')` |
+| `IL_COMMITTEE_SIZE`            | `uint64(2**4)` (=16)       |
+| `MAX_BYTES_PER_INCLUSION_LIST` | `uint64(2**13)` (=8192)    |
 
 ##### New containers
 


### PR DESCRIPTION
I was reading [this section from the rendered version](https://eips.ethereum.org/EIPS/eip-7805#execution-layer) and there' seems to be a glitch:
![image](https://github.com/user-attachments/assets/060bee39-d0f2-43ba-9157-0fb5c817e65f)

It looks weird that point is 1. again.

But if I look at the [rendered Markdown](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7805.md), it looks fine:
![image](https://github.com/user-attachments/assets/22b97628-d77e-4a56-ad8c-e44f2049c8ba)

I saw the Markdown linter suggest fixing some stuff that _maybe_ explains the problem?
I can't know if this fixes it until the full HTML is rendered (since the markdown preview was already showing the expected).

Maybe there's a way to render the EIP locally and check? or just merge the PR and see if it's fixed.