### PR TITLE
Update EIP-7819: fix spelling eip-7819.md

### DIFF
--- a/EIPS/eip-7819.md
+++ b/EIPS/eip-7819.md
@@ -84,7 +84,7 @@ Reusing EIP-7702 behavior, including clearing the code if the target is 0, resul
 
 ### Delegator chaining
 
-As documented in EIP-7702, designator chains or loops are not resolved. This means that, unlike clones, chaining is an issue. This is however something developpers are used to, as chaining proxy can result in strange behaviors, including infinite delegation loops.
+As documented in EIP-7702, designator chains or loops are not resolved. This means that, unlike clones, chaining is an issue. This is however something developers are used to, as chaining proxy can result in strange behaviors, including infinite delegation loops.
 
 Factories may want to protect against this risk by verifying that the `target` doesn't contain a designator. This can be achieved using a legacy contract helper that has access to `EXTCODEHASH`. It could also be done using other forms of introspection such as an `ACCOUNT_TYPE` instruction.
 


### PR DESCRIPTION
Fixed "developpers" to "developers"