### PR TITLE
Update EIP-7251: Final system contract address

### DIFF
--- a/EIPS/eip-7251.md
+++ b/EIPS/eip-7251.md
@@ -29,7 +29,7 @@ With the security model of the protocol no longer dependent on a low value for `
 | Name | Value | Comment |
 | - | - | - |
 | `CONSOLIDATION_REQUEST_TYPE` | `0x02` | The [EIP-7685](./eip-7685.md) type prefix for consolidation request |
-| `CONSOLIDATION_REQUEST_PREDEPLOY_ADDRESS` | `0x00431F263cE400f4455c2dCf564e53007Ca4bbBb` | Where to call and store relevant details about consolidation request mechanism |
+| `CONSOLIDATION_REQUEST_PREDEPLOY_ADDRESS` | `0x0000BBdDc7CE488642fb579F8B00f3a590007251` | Where to call and store relevant details about consolidation request mechanism |
 | `SYSTEM_ADDRESS` | `0xfffffffffffffffffffffffffffffffffffffffe` | Address used to invoke system operation on contract |
 | `EXCESS_CONSOLIDATION_REQUESTS_STORAGE_SLOT` | `0` | |
 | `CONSOLIDATION_REQUEST_COUNT_STORAGE_SLOT` | `1` | |
@@ -524,14 +524,14 @@ The consolidation requests contract is deployed like any other smart contract. A
   "input": "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff5f5561019e80602d5f395ff33373fffffffffffffffffffffffffffffffffffffffe1460d35760115f54807fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff1461019a57600182026001905f5b5f82111560685781019083028483029004916001019190604d565b9093900492505050366060146088573661019a573461019a575f5260205ff35b341061019a57600154600101600155600354806004026004013381556001015f358155600101602035815560010160403590553360601b5f5260605f60143760745fa0600101600355005b6003546002548082038060021160e7575060025b5f5b8181146101295782810160040260040181607402815460601b815260140181600101548152602001816002015481526020019060030154905260010160e9565b910180921461013b5790600255610146565b90505f6002555f6003555b5f54807fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff141561017357505f5b6001546001828201116101885750505f61018e565b01600190035b5f555f6001556074025ff35b5f5ffd",
   "v": "0x1b",
   "r": "0x539",
-  "s": "0x332601ef36aa2ce9",
+  "s": "0xc0730f92dc275b663d377a7cbb141b6600052",
   "hash": "0xc7d223eb06267248bcd21f7af0223c8d467ef7e95ff51cef84c616973692169f"
 }
 ```
 
 ```
-Sender: 0xe24B968aB4319a580d9FFc7Ac29466894FeEb361
-Address: 0x00431F263cE400f4455c2dCf564e53007Ca4bbBb
+Sender: 0x13d1913d623E6a9D8811736359E50fD31Fe54fCA
+Address: 0x0000BBdDc7CE488642fb579F8B00f3a590007251
 ```
 
 #### Block processing

--- a/EIPS/eip-7251.md
+++ b/EIPS/eip-7251.md
@@ -525,7 +525,7 @@ The consolidation requests contract is deployed like any other smart contract. A
   "v": "0x1b",
   "r": "0x539",
   "s": "0xc0730f92dc275b663d377a7cbb141b6600052",
-  "hash": "0xc7d223eb06267248bcd21f7af0223c8d467ef7e95ff51cef84c616973692169f"
+  "hash": "0x379269d571beff3ed1d8eba3abb24076a7267b0eaf0cc66d728fb0544f5a690d"
 }
 ```
 


### PR DESCRIPTION
This PR updates the final EIP-7251 system contract address to a "nicer" looking one:
`0x0000BBdDc7CE488642fb579F8B00f3a590007251`

The address follows the pattern `0x0000...00<eip-number>` as for other pectra system contracts to make them more recognizable. The sender address for the deployment has been updated accordingly. 
I've also tested the deployment of the contract on ephemery:
https://explorer.ephemery.dev/tx/0x379269d571beff3ed1d8eba3abb24076a7267b0eaf0cc66d728fb0544f5a690d


Some alternative addresses (in case someone has a strong preference for one of these):
```
0x00001d2782329781e501777e0789fcc904007251  (sig-s: 0x37a53e94f77471e75c1d45be0ee4f3bd59004d)
0x0000b7a00b397dd82c8dbb9aec324c5a10007251  (sig-s: 0x55ddb8b7a99563bd7ec192c6605c6ff7150028)
```

fun fact: these addresses were mined by users on the PoW faucet for sepolia/holesky over the last 2 months.