### PR TITLE
Update EIP-7851: multiple fixes and refinements

### DIFF
--- a/EIPS/eip-7851.md
+++ b/EIPS/eip-7851.md
@@ -32,33 +32,37 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 | `PRECOMPILE_ADDRESS`              | `0xTBD`              |
 | `PRECOMPILE_GAS_COST`             | `8000`               |
 
+### Definitions
+
+* `||` is the byte/byte-array concatenation operator.
+
 ### Delegated Code Encoding
 
 The deactivation status is encoded by appending or removing the `0x00` byte at the end of the delegated code. The transitions between two states are as follows:
 
-- Active state: `0xef0100 || address`. The private key is active and can sign transactions.
-- Deactivated state: `0xef0100 || address || 0x00`. The private key is deactivated and cannot sign transactions or [EIP-7702](./eip-7702) delegation authorizations.
+* Active state: `0xef0100 || address`. The private key is active and can sign transactions.
+* Deactivated state: `0xef0100 || address || 0x00`. The private key is deactivated and cannot sign transactions or [EIP-7702](./eip-7702) delegation authorizations.
 
 ### Precompiled Contract
 
 A new precompiled contract is introduced at address `PRECOMPILE_ADDRESS`. It costs `PRECOMPILE_GAS_COST` and executes the following logic:
 
-- Returns a precompile contract error, consumes all gas, and no state changes are made if:
-  - Gas is insufficient.
-  - Called via `STATICCALL` (i.e. in a read-only context).
-  - Caller is not an EOA with delegated code (prefix `0xef0100` as per [EIP-7702](./eip-7702)).
-- Updates caller's delegated code based on length:
-  - `23` bytes (`0xef0100 || address`): Appends `0x00` to deactivate private key authorization.
-  - `24` bytes (`0xef0100 || address || 0x00`): Removes last byte `0x00` to activate private key authorization.
-- Saves updated code as caller's new account code.
+* Returns a precompile contract error, consumes all gas, and no state changes are made if:
+  * Gas is insufficient.
+  * Called via `STATICCALL` (i.e. in a read-only context).
+  * Caller is not an EOA with delegated code (prefix `0xef0100` as per [EIP-7702](./eip-7702)).
+* Updates caller's delegated code based on length:
+  * `23` bytes (`0xef0100 || address`): Appends `0x00` to deactivate private key authorization.
+  * `24` bytes (`0xef0100 || address || 0x00`): Removes last byte `0x00` to activate private key authorization.
+* Saves updated code as caller's new account code.
 
 ### Transaction Validation
 
 Validation to check whether a private key is deactivated (identified by a code prefix `0xef0100` and a code length of `24`) MUST be performed in the following scenarios:
 
-- During transaction validity checks before execution, nodes MUST reject transactions signed with deactivated private keys to ensure such transactions cannot be included in blocks.
-- The same validation MUST be applied to the transaction pool to prevent invalid transactions from propagating through the network.
-- Any [EIP-7702](./eip-7702) authorization issued by an authority with a deactivated private key MUST be treated as invalid and skipped.
+* During transaction validity checks before execution, nodes MUST reject transactions signed with deactivated private keys to ensure such transactions cannot be included in blocks.
+* The same validation MUST be applied to the transaction pool to prevent invalid transactions from propagating through the network.
+* Any [EIP-7702](./eip-7702) authorization issued by an authority with a deactivated private key MUST be treated as invalid and skipped.
 
 ## Rationale
 
@@ -66,8 +70,8 @@ Validation to check whether a private key is deactivated (identified by a code p
 
 The `PRECOMPILE_GAS_COST` represents the gas required to validate and potentially update an account's code. A fair cost for calling this precompiled contract can be determined by analyzing its impact on the node:
 
-- Reading the code of the address: `2600`.
-- Deploying at most `24` bytes of code: `200 * 24 = 4800`.
+* Reading the code of the address: `2600`.
+* Deploying at most `24` bytes of code: `200 * 24 = 4800`.
 
 The primary operation consumes a total of `7400` gas. To account for additional overhead, such as context switching during state transitions, as well as code prefix and length validations, the cost is rounded up to `8000`.
 
@@ -85,8 +89,8 @@ An alternative deprecation approach involves using a hard fork to edit all exist
 
 Alternative methods for deactivating and reactivating EOA private keys include:
 
-- Adding a new transaction type: Introducing a new transaction type could provide a mechanism to deactivate and reactivate EOA private keys. However, reactivating the private key would rely on a delegated contract as the authorizer, which complicates defining the rules for the new transaction type.
-- Deploying a smart contract: Compared to reusing the code field, using a smart contract has higher costs: (i) it requires new contract storage slots to track the deactivation status of each address (ii) executing bytecode increases the overhead of the node compared to precompiled contracts, (iii) during transaction validation, reusing the code field allows deactivation status check to be combined with existing code loading in some scenarios, thereby reducing the need for additional storage reads, as discussed in [Additional Transaction Validation Overhead](#additional-transaction-validation-overhead) section.
+* Adding a new transaction type: Introducing a new transaction type could provide a mechanism to deactivate and reactivate EOA private keys. However, reactivating the private key would rely on a delegated contract as the authorizer, which complicates defining the rules for the new transaction type.
+* Deploying a smart contract: Compared to reusing the code field, using a smart contract has higher costs: (i) it requires new contract storage slots to track the deactivation status of each address (ii) executing bytecode increases the overhead of the node compared to precompiled contracts, (iii) during transaction validation, reusing the code field allows deactivation status check to be combined with existing code loading in some scenarios, thereby reducing the need for additional storage reads, as discussed in [Additional Transaction Validation Overhead](#additional-transaction-validation-overhead) section.
 
 ### In-Protocol Reactivation
 
@@ -223,9 +227,9 @@ Contracts that have already been deployed and use ECDSA `secp256k1` signatures o
 
 To handle deactivated EOAs, new or upgradeable contracts can check the signing address's deactivation status, for example:
 
-- Use `EXTCODESIZE` to get the account's code length.
-- If the code length is `24` bytes, use `EXTCODECOPY` to verify the code starts with `0xef0100` (delegated code prefix).
-- If both conditions are satisfied (i.e. the code size is `24` bytes and the code starts with `0xef0100`), the private key is confirmed to be deactivated, and the signature should be rejected.
+* Use `EXTCODESIZE` to get the account's code length.
+* If the code length is `24` bytes, use `EXTCODECOPY` to verify the code starts with `0xef0100` (delegated code prefix).
+* If both conditions are satisfied (i.e. the code size is `24` bytes and the code starts with `0xef0100`), the private key is confirmed to be deactivated, and the signature should be rejected.
 
 For non-upgradeable contracts, the above method cannot be applied directly. Another potential solution, at the protocol level, is to modify `ecRecover` precompiled contract: if the private key of the recovered address is deactivated, the `ecRecover` precompiled contract could return a precompile contract error (or, if not adding an error return path, return a zero address or a collision-resistant address like `0x1`). However, this approach also has limitations, as it cannot cover cases where contracts implement their own signature verification logic without relying on `ecRecover`.
 

--- a/EIPS/eip-7851.md
+++ b/EIPS/eip-7851.md
@@ -30,16 +30,16 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 | Constant                          | Value                |
 |-----------------------------------|----------------------|
 | `PRECOMPILE_ADDRESS`              | `0xTBD`              |
-| `PRECOMPILE_GAS_COST`             | `5000`               |
+| `PRECOMPILE_GAS_COST`             | `8000`               |
 
-### Delegated code encoding
+### Delegated Code Encoding
 
 The deactivation status is encoded by appending or removing the `0x00` byte at the end of the delegated code. The transitions between two states are as follows:
 
 - Active state: `0xef0100 || address`. The private key is active and can sign transactions.
 - Deactivated state: `0xef0100 || address || 0x00`. The private key is deactivated and cannot sign transactions or [EIP-7702](./eip-7702) delegation authorizations.
 
-### Precompiled contract
+### Precompiled Contract
 
 A new precompiled contract is introduced at address `PRECOMPILE_ADDRESS`. It costs `PRECOMPILE_GAS_COST` and executes the following logic:
 
@@ -48,32 +48,47 @@ A new precompiled contract is introduced at address `PRECOMPILE_ADDRESS`. It cos
   - Called via `STATICCALL` (i.e. in a read-only context).
   - Caller is not an EOA with delegated code (prefix `0xef0100` as per [EIP-7702](./eip-7702)).
 - Updates caller's delegated code based on length:
-  - 23 bytes (`0xef0100 || address`): Appends `0x00` to deactivate private key authorization.
-  - 24 bytes (`0xef0100 || address || 0x00`): Removes last byte `0x00` to activate private key authorization.
+  - `23` bytes (`0xef0100 || address`): Appends `0x00` to deactivate private key authorization.
+  - `24` bytes (`0xef0100 || address || 0x00`): Removes last byte `0x00` to activate private key authorization.
 - Saves updated code as caller's new account code.
 
-### Transaction validation
+### Transaction Validation
 
-For EOAs with delegated code (begins with the prefix `0xef0100`), the following validations MUST be performed:
+Validation to check whether a private key is deactivated (identified by a code prefix `0xef0100` and a code length of `24`) MUST be performed in the following scenarios:
 
-- During the consensus rule's transaction validity check before execution: transactions signed by the private key MUST be rejected if the delegated code indicates the private key is in the deactivated state (i.e., `24` bytes long). This ensures such transactions cannot be included in blocks.
-- The transaction pool MUST implement the same validation to prevent invalid transactions from propagating across the network.
-- Any [EIP-7702](./eip-7702) authorization from an authority with a deactivated delegated code MUST be considered invalid and skipped. The gas consumption rules remain unchanged, consistent with [EIP-7702](./eip-7702).
-
-### Gas cost
-
-The `PER_EMPTY_ACCOUNT_COST` and `PER_AUTH_BASE_COST` constants defined in [EIP-7702](./eip-7702) remain unchanged, since account code will be loaded during the authorization validation. This EIP only adds a code length check, which is a small overhead compared to existing logic.
+- During transaction validity checks before execution, nodes MUST reject transactions signed with deactivated private keys to ensure such transactions cannot be included in blocks.
+- The same validation MUST be applied to the transaction pool to prevent invalid transactions from propagating through the network.
+- Any [EIP-7702](./eip-7702) authorization issued by an authority with a deactivated private key MUST be treated as invalid and skipped.
 
 ## Rationale
 
-### Using a precompiled contract
+### Cost of Precompiled Contract
+
+The `PRECOMPILE_GAS_COST` represents the gas required to validate and potentially update an account's code. A fair cost for calling this precompiled contract can be determined by analyzing its impact on the node:
+
+- Reading the code of the address: `2600`.
+- Deploying at most `24` bytes of code: `200 * 24 = 4800`.
+
+The primary operation consumes a total of `7400` gas. To account for additional overhead, such as context switching during state transitions, as well as code prefix and length validations, the cost is rounded up to `8000`.
+
+### Additional Transaction Validation Overhead
+
+Due to [EIP-3607](./eip-3607) and [EIP-7702](./eip-7702), nodes already load the account code during transaction validation to verify whether the sender is an EOA (empty code or code with prefix `0xef0100`). This EIP introduces only a code length check after loading the code, resulting in minimal additional overhead. Similarly, [EIP-7702](./eip-7702)’s authorization validation already involves retrieving the account code, with this EIP adding only a code length check.
+
+Transaction pools already perform state-based checks, such as those for nonce and balance. This EIP adds an account code read and a length check, which are comparable to nonce and balance validations. DoS prevention mechanisms, expected in transaction pools, also support these additional checks.
+
+### An Alternative EOA Deprecation Approach
+
+An alternative deprecation approach involves using a hard fork to edit all existing and new EOAs to pre-written upgradeable smart contracts, which utilize the original EOA private key for authorization. Users can add and replace keys, or upgrade the smart contracts to other implementations. However, this approach is incompatible with EOAs already delegated to smart contracts, as it will overwrite the existing smart contract implementations. This EIP aims to fill this migration gap.
+
+### Using a Precompiled Contract
 
 Alternative methods for deactivating and reactivating EOA private keys include:
 
 - Adding a new transaction type: Introducing a new transaction type could provide a mechanism to deactivate and reactivate EOA private keys. However, reactivating the private key would rely on a delegated contract as the authorizer, which complicates defining the rules for the new transaction type.
-- Deploying a smart contract: Using a smart contract to track the deactivated status of each address. However, calling this contract, which executes bytecode, is more expensive than a precompiled contract.
+- Deploying a smart contract: Compared to reusing the code field, using a smart contract has higher costs: (i) it requires new contract storage slots to track the deactivation status of each address (ii) executing bytecode increases the overhead of the node compared to precompiled contracts, (iii) during transaction validation, reusing the code field allows deactivation status check to be combined with existing code loading in some scenarios, thereby reducing the need for additional storage reads, as discussed in [Additional Transaction Validation Overhead](#additional-transaction-validation-overhead) section.
 
-### In-protocol reactivation
+### In-Protocol Reactivation
 
 This approach ensures maximum compatibility with future migrations. EOAs can reactivate their private keys, delegate their accounts to an [EIP-7701](./eip-7701) contract, and then deactivate their private keys again. This avoids the limitations of contract upgrades. e.g. to remove legacy proxy contracts (reducing gas overhead) when upgrading to EOF contracts, one can reactivate the EOA and redelegate it to an EOF proxy contract.
 
@@ -83,25 +98,19 @@ The reactivation process is recommended to include a signed authorization from t
 
 Users should delegate their EOAs only to wallets that have been thoroughly audited and follow best practices for security.
 
-### `5000` gas `PRECOMPILE_GAS_COST`
-
-The `5000` gas cost is sufficient for the precompiled contract's validation logic and storage updates.
-
-### Alternative EOA deprecation approach
-
-One alternative deprecation approach involves using a hard fork to edit all existing and new EOAs to pre-written upgradeable smart contracts, which utilize the original EOA private key for authorization. Users can add and replace keys, or upgrade the smart contracts to other implementations. However, this approach is incompatible with EOAs already delegated to smart contracts, as it will overwrite the existing smart contract implementations. This EIP aims to fill this migration gap.
-
-### Avoiding delegated code prefix modification
+### Avoiding Delegated Code Prefix Modification
 
 This EIP appends a byte (`0x00`) to the delegated code instead of modifying the prefix (`0xef0100`) of [EIP-7702](./eip-7702) to ensure forward compatibility. If new prefixes such as `0xef0101` are introduced in the future, changing the prefix to represent the deactivated status (e.g. `0xef01ff`) makes it unclear which prefix to restore (`0xef0100` or `0xef0101`) upon reactivation.
 
-### Avoiding account state changes
+### Avoiding Account State Changes
 
 An alternative is to add a `deactivated` field in the account state to track the status. However, this approach will introduce backward compatibility logic and more test vectors related to this optional field when enabling this EIP, because the field is not present in existing accounts.
 
 ## Backwards Compatibility
 
-This EIP maintains backwards compatibility with existing EOAs and contracts.
+When the private key is deactivated, this EIP introduces: (i) an extra byte (`0x00`) to be appended to the end of the delegated code, and (ii) the delegated code length becomes `24` bytes (e.g. `EXTCODESIZE` would return `24`).
+
+These changes are not breaking. However, they require protocol, application, and contract implementations to use strict offsets to parse the delegated address correctly. Implementations must also check the delegated code prefix `0xef01` to determine whether it represents an EOA with delegated code, while avoiding over-restrictive checks, such as asserting the code length to be exactly `23`.
 
 ## Test Cases
 
@@ -118,12 +127,12 @@ active_code = PrecompiledContract.DELEGATED_CODE_PREFIX + delegated_addr # Activ
 state_db.set_code(caller, active_code)
 error, gas_left = precompile.execute(caller, state_db, gas=10000)
 assert error == b""
-assert state_db.get_code(caller) == active_code + b"\x00"  # Deactivated state
+assert state_db.get_code(caller) == active_code + b"\x00" # Deactivated state
 assert gas_left == 10000 - PrecompiledContract.PRECOMPILE_GAS_COST
 
 error, gas_left = precompile.execute(caller, state_db, gas=10000)
 assert error == b""
-assert state_db.get_code(caller) == active_code  # Reactivated state
+assert state_db.get_code(caller) == active_code # Turns to the active state again
 assert gas_left == 10000 - PrecompiledContract.PRECOMPILE_GAS_COST
 
 # Test 2: Error cases
@@ -135,17 +144,15 @@ error, gas_left = precompile.execute(caller, state_db, gas=PrecompiledContract.P
 assert error == b"insufficient gas"
 assert gas_left == 0
 
-# EOA without delegated code
-caller = "0x4567"
+caller = "0x4567" # EOA that is not delegated to code
 error, gas_left = precompile.execute(caller, state_db, gas=10000)
-assert error == b"invalid delegated code prefix"
+assert error == b"the address is not an EOA delegated to code"
 assert gas_left == 0
 
-# Small contract code
 caller = "0x89ab"
-state_db.set_code(caller, bytes.fromhex("00")) # a fake contract
+state_db.set_code(caller, bytes.fromhex("00")) # Not a delegated code prefix
 error, gas_left = precompile.execute(caller, state_db, gas=10000)
-assert error == b"invalid delegated code prefix"
+assert error == b"the address is not an EOA delegated to code"
 assert gas_left == 0
 ```
 
@@ -154,7 +161,7 @@ assert gas_left == 0
 ```python
 class PrecompiledContract:
     DELEGATED_CODE_PREFIX = bytes.fromhex("ef0100")
-    PRECOMPILE_GAS_COST = 5000
+    PRECOMPILE_GAS_COST = 8000
 
     def execute(self, caller, state_db, gas, read_only=False):
         """
@@ -164,7 +171,7 @@ class PrecompiledContract:
         - caller: The address calling the contract
         - state_db: The state database
         - gas: Gas provided for execution
-        - read_only: Whether called in read-only context
+        - read_only: Whether called in a read-only context
 
         Returns:
         - Tuple of (result, gas_left)
@@ -182,13 +189,13 @@ class PrecompiledContract:
         # Get and validate caller's code
         code = state_db.get_code(caller)
         if not code.startswith(self.DELEGATED_CODE_PREFIX):
-            return b"invalid delegated code prefix", 0
+            return b"the address is not an EOA delegated to code", 0
 
         # Update delegated code based on length
-        if len(code) == 23:  # Active state
-            state_db.set_code(caller, code + b"\x00")  # Deactivate
-        elif len(code) == 24:  # Deactivated state
-            state_db.set_code(caller, code[:-1])  # Activate
+        if len(code) == 23: # Active state
+            state_db.set_code(caller, code + b"\x00") # Deactivate
+        elif len(code) == 24: # Deactivated state
+            state_db.set_code(caller, code[:-1]) # Activate
         else: # Although this is not possible, it's added for completeness
             return b"invalid delegated code length", 0
 
@@ -210,29 +217,29 @@ class StateDB:
 
 ## Security Considerations
 
-### Additional checks during transaction validation
+### Contracts Using ECDSA `Secp256k1` Signatures
 
-The deactivation status is determined by checking the length of the delegated code. This check introduces an additional storage read and check comparable to account state read and checks, such as nonce validation. It is integrated into the transaction validity check of the transaction pool and consensus rules, ensuring that invalid transactions are filtered out before propagation and execution.
+Contracts that have already been deployed and use ECDSA `secp256k1` signatures outside of transaction signatures (e.g. [ERC-20](./eip-20) tokens that support [ERC-2612](./eip-2612), the `permit` function) will not be able to verify the deactivated status of the EOA. This means that signatures signed by private keys will remain valid in these functions.
 
-### Additional checks for [EIP-7702](./eip-7702) transactions
+To handle deactivated EOAs, new or upgradeable contracts can check the signing address's deactivation status, for example:
 
-In applying authorizations of an [EIP-7702](./eip-7702) transaction, an additional check is introduced to validate the length of the delegated code. Since EIP-7702 already requires retrieving the code in authorization validation, the extra cost of verifying its length is negligible.
+- Use `EXTCODESIZE` to get the account's code length.
+- If the code length is `24` bytes, use `EXTCODECOPY` to verify the code starts with `0xef0100` (delegated code prefix).
+- If both conditions are satisfied (i.e. the code size is `24` bytes and the code starts with `0xef0100`), the private key is confirmed to be deactivated, and the signature should be rejected.
 
-### Risk of asset freezing
+For non-upgradeable contracts, the above method cannot be applied directly. Another potential solution, at the protocol level, is to modify `ecRecover` precompiled contract: if the private key of the recovered address is deactivated, the `ecRecover` precompiled contract could return a precompile contract error (or, if not adding an error return path, return a zero address or a collision-resistant address like `0x1`). However, this approach also has limitations, as it cannot cover cases where contracts implement their own signature verification logic without relying on `ecRecover`.
 
-In the worst case, a malicious wallet, through bypassing permission controls, could steal assets, and deactivate the account by calling the precompiled contract, it could also block reactivation, and thus freeze the account. In this case, the risk is inherent to delegating control and not solely introduced by this EIP.
+### Irreversible Deactivation
 
-The risk also exists when the delegated wallet does not support reactivation or implements a flawed reactivation interface, combined with partially functional or non-functional asset transfers. These issues could prevent the user from reactivating the account and result in partial or complete asset freezing. Users can mitigate these risks using thoroughly audited wallets that support this EIP.
+Delegating to a wallet that lacks reactivation support (e.g. by calling the precompiled contract through an appropriate interface) may result in irreversible deactivation. To mitigate this risk, users should only delegate their EOAs to implementations that have been thoroughly audited and explicitly support this EIP.
 
-### Permit extension for [ERC-20](./eip-20)
+### Deactivation and Reactivation Replay
 
-This EIP does not revoke [ERC-2612](./eip-2612) permissions. EOAs with deactivated private keys can still authorize transfers by calling the `permit` function of [ERC-20](./eip-20) tokens supporting [ERC-2612](./eip-2612). This issue also exists with [EIP-7702](./eip-7702). To support deactivated EOAs, [ERC-20](./eip-20) contracts should deprecate the `permit` function, or a new opcode could be introduced to help check the `deactivated` status of the EOA.
+Replay attacks can occur in two scenarios: (i) replaying the same authorization multiple times on a single chain, or (ii) replaying the authorization across different chains.
 
-### Message replay across EVM-compatible chains
+For deactivation through EOA-signed transactions, the use of nonces in transactions ensures the same message cannot be replayed multiple times on the same chain. Additionally, the replay protection mechanism provided by [EIP-155](./eip-155), if enabled, effectively prevents cross-chain message replay.
 
-For deactivation through EOA-signed transactions, the replay protection mechanism provided by [EIP-155](./eip-155), if enabled, can effectively prevent cross-chain message replay.
-
-For deactivation or reactivation called by the delegated contract, the contract should ensure that the chain ID is part of the message validation process (or implement alternative replay protection mechanisms) to prevent cross-chain message replay.
+For deactivation or reactivation via delegated contracts, the contract should implement robust replay protection mechanism(s) (e.g. adding a customized nonce and the chain ID to the signed message) to safeguard against replay attacks both within the same chain and across different chains. Especially when the EOA has been (or will be) delegated to the same implementation on multiple chains.
 
 ## Copyright
 

--- a/EIPS/eip-7851.md
+++ b/EIPS/eip-7851.md
@@ -30,7 +30,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 | Constant                          | Value                |
 |-----------------------------------|----------------------|
 | `PRECOMPILE_ADDRESS`              | `0xTBD`              |
-| `PRECOMPILE_GAS_COST`             | `8000`               |
+| `PRECOMPILE_GAS_COST`             | `13000`               |
 
 ### Definitions
 
@@ -71,9 +71,10 @@ Validation to check whether a private key is deactivated (identified by a code p
 The `PRECOMPILE_GAS_COST` represents the gas required to validate and potentially update an account's code. A fair cost for calling this precompiled contract can be determined by analyzing its impact on the node:
 
 * Reading the code of the address: `2600`.
+* Changing the code hash (from non-zero to non-zero): `5000`.
 * Deploying at most `24` bytes of code: `200 * 24 = 4800`.
 
-The primary operation consumes a total of `7400` gas. To account for additional overhead, such as context switching during state transitions, as well as code prefix and length validations, the cost is rounded up to `8000`.
+The primary operation consumes a total of `12400` gas. To account for additional overhead, such as context switching during state transitions, as well as code prefix and length validations, the cost is rounded up to `13000`.
 
 ### Additional Transaction Validation Overhead
 
@@ -129,18 +130,18 @@ delegated_addr = bytes.fromhex("1122334455667788990011223344556677889900")
 active_code = PrecompiledContract.DELEGATED_CODE_PREFIX + delegated_addr # Active state
 
 state_db.set_code(caller, active_code)
-error, gas_left = precompile.execute(caller, state_db, gas=10000)
+error, gas_left = precompile.execute(caller, state_db, gas=15000)
 assert error == b""
 assert state_db.get_code(caller) == active_code + b"\x00" # Deactivated state
-assert gas_left == 10000 - PrecompiledContract.PRECOMPILE_GAS_COST
+assert gas_left == 15000 - PrecompiledContract.PRECOMPILE_GAS_COST
 
-error, gas_left = precompile.execute(caller, state_db, gas=10000)
+error, gas_left = precompile.execute(caller, state_db, gas=15000)
 assert error == b""
 assert state_db.get_code(caller) == active_code # Turns to the active state again
-assert gas_left == 10000 - PrecompiledContract.PRECOMPILE_GAS_COST
+assert gas_left == 15000 - PrecompiledContract.PRECOMPILE_GAS_COST
 
 # Test 2: Error cases
-error, gas_left = precompile.execute(caller, state_db, gas=10000, read_only=True)
+error, gas_left = precompile.execute(caller, state_db, gas=15000, read_only=True)
 assert error == b"STATICCALL disallows state modification"
 assert gas_left == 0
 
@@ -149,13 +150,13 @@ assert error == b"insufficient gas"
 assert gas_left == 0
 
 caller = "0x4567" # EOA that is not delegated to code
-error, gas_left = precompile.execute(caller, state_db, gas=10000)
+error, gas_left = precompile.execute(caller, state_db, gas=15000)
 assert error == b"the address is not an EOA delegated to code"
 assert gas_left == 0
 
 caller = "0x89ab"
 state_db.set_code(caller, bytes.fromhex("00")) # Not a delegated code prefix
-error, gas_left = precompile.execute(caller, state_db, gas=10000)
+error, gas_left = precompile.execute(caller, state_db, gas=15000)
 assert error == b"the address is not an EOA delegated to code"
 assert gas_left == 0
 ```
@@ -165,7 +166,7 @@ assert gas_left == 0
 ```python
 class PrecompiledContract:
     DELEGATED_CODE_PREFIX = bytes.fromhex("ef0100")
-    PRECOMPILE_GAS_COST = 8000
+    PRECOMPILE_GAS_COST = 13000
 
     def execute(self, caller, state_db, gas, read_only=False):
         """

--- a/EIPS/eip-7851.md
+++ b/EIPS/eip-7851.md
@@ -19,7 +19,7 @@ This EIP introduces a precompiled contract that enables Externally Owned Account
 
 [EIP-7702](./eip-7702) enables EOAs to gain smart contract capabilities, but the private key of the EOA still retains full control over the account.
 
-With this EIP, EOAs can fully migrate to smart contract wallets, while retaining private key recovery options with reactivation. The flexible deactivate and reactivate design also paves the way for native account abstraction. e.g. [EIP-7701](./eip-7701).
+With this EIP, EOAs can fully migrate to smart contract wallets, while retaining private key recovery options with reactivation. The flexible deactivate and reactivate design also paves the way for native account abstraction. e.g., [EIP-7701](./eip-7701).
 
 ## Specification
 
@@ -49,7 +49,7 @@ A new precompiled contract is introduced at address `PRECOMPILE_ADDRESS`. It cos
 
 * Returns a precompile contract error, consumes all gas, and no state changes are made if:
   * Gas is insufficient.
-  * Called via `STATICCALL` (i.e. in a read-only context).
+  * Called via `STATICCALL` (i.e., in a read-only context).
   * Caller is not an EOA with delegated code (prefix `0xef0100` as per [EIP-7702](./eip-7702)).
 * Updates caller's delegated code based on length:
   * `23` bytes (`0xef0100 || address`): Appends `0x00` to deactivate private key authorization.
@@ -61,7 +61,7 @@ A new precompiled contract is introduced at address `PRECOMPILE_ADDRESS`. It cos
 Validation to check whether a private key is deactivated (identified by a code prefix `0xef0100` and a code length of `24`) MUST be performed in the following scenarios:
 
 * During transaction validity checks before execution, nodes MUST reject transactions signed with deactivated private keys to ensure such transactions cannot be included in blocks.
-* The same validation MUST be applied to the transaction pool to prevent invalid transactions from propagating through the network.
+* The same validation MUST be applied to the transaction pool when receiving new transactions to prevent invalid transactions from propagating through the network.
 * Any [EIP-7702](./eip-7702) authorization issued by an authority with a deactivated private key MUST be treated as invalid and skipped.
 
 ## Rationale
@@ -78,9 +78,9 @@ The primary operation consumes a total of `12400` gas. To account for additional
 
 ### Additional Transaction Validation Overhead
 
-Due to [EIP-3607](./eip-3607) and [EIP-7702](./eip-7702), nodes already load the account code during transaction validation to verify whether the sender is an EOA (empty code or code with prefix `0xef0100`). This EIP introduces only a code length check after loading the code, resulting in minimal additional overhead. Similarly, [EIP-7702](./eip-7702)’s authorization validation already involves retrieving the account code, with this EIP adding only a code length check.
+Due to [EIP-3607](./eip-3607) and [EIP-7702](./eip-7702), nodes already load the account code during transaction validation to verify whether the sender is an EOA (empty code or code with prefix `0xef0100`). This EIP introduces only a code length check after loading the code, resulting in minimal additional overhead. Similarly, [EIP-7702](./eip-7702)’s authorization validation already involves retrieving the account code, with this EIP adding only a code length check, which is negligible compared to code reading.
 
-Transaction pools already perform state-based checks, such as those for nonce and balance. This EIP adds an account code read and a length check, which are comparable to nonce and balance validations. DoS prevention mechanisms, expected in transaction pools, also support these additional checks.
+Transaction pools already perform state-based checks, such as those for nonce and balance. This EIP adds an account code read and a length check, which together are comparable to nonce and balance validations. DoS prevention mechanisms, expected in transaction pools, also support these additional checks.
 
 ### An Alternative EOA Deprecation Approach
 
@@ -95,17 +95,17 @@ Alternative methods for deactivating and reactivating EOA private keys include:
 
 ### In-Protocol Reactivation
 
-This approach ensures maximum compatibility with future migrations. EOAs can reactivate their private keys, delegate their accounts to an [EIP-7701](./eip-7701) contract, and then deactivate their private keys again. This avoids the limitations of contract upgrades. e.g. to remove legacy proxy contracts (reducing gas overhead) when upgrading to EOF contracts, one can reactivate the EOA and redelegate it to an EOF proxy contract.
+This approach ensures maximum compatibility with future migrations. EOAs can reactivate their private keys, delegate their accounts to an [EIP-7701](./eip-7701) contract, and then deactivate their private keys again. This avoids the limitations of contract upgrades. e.g., to remove legacy proxy contracts (reducing gas overhead) when upgrading to EOF contracts, one can reactivate the EOA and redelegate it to an EOF proxy contract.
 
 Reactivation can only be performed by the delegated contract. Since reactivating the private key grants full control over the wallet, including the ability to replace the delegated wallet, wallets must implement this interface with strict security measures. These measures should treat reactivation as the highest level of authority, equivalent to full ownership of the wallet.
 
-The reactivation process is recommended to include a signed authorization from the private key. This signature payload should consist of the chain ID and a random challenge (e.g. a hash value of other signatures) to ensure that: (i) the request is non-replayable in other chains, and (ii) the the private key owner is also included in the reactivation process.
+The reactivation process is recommended to include a signed authorization from the private key. This signature payload should consist of the chain ID and a random challenge (e.g., a hash value of other signatures) to ensure that: (i) the request is non-replayable in other chains, and (ii) the the private key owner is also included in the reactivation process.
 
 Users should delegate their EOAs only to wallets that have been thoroughly audited and follow best practices for security.
 
 ### Avoiding Delegated Code Prefix Modification
 
-This EIP appends a byte (`0x00`) to the delegated code instead of modifying the prefix (`0xef0100`) of [EIP-7702](./eip-7702) to ensure forward compatibility. If new prefixes such as `0xef0101` are introduced in the future, changing the prefix to represent the deactivated status (e.g. `0xef01ff`) makes it unclear which prefix to restore (`0xef0100` or `0xef0101`) upon reactivation.
+This EIP appends a byte (`0x00`) to the delegated code instead of modifying the prefix (`0xef0100`) of [EIP-7702](./eip-7702) to ensure forward compatibility. If new prefixes such as `0xef0101` are introduced in the future, changing the prefix to represent the deactivated status (e.g., `0xef01ff`) makes it unclear which prefix to restore (`0xef0100` or `0xef0101`) upon reactivation.
 
 ### Avoiding Account State Changes
 
@@ -113,7 +113,7 @@ An alternative is to add a `deactivated` field in the account state to track the
 
 ## Backwards Compatibility
 
-When the private key is deactivated, this EIP introduces: (i) an extra byte (`0x00`) to be appended to the end of the delegated code, and (ii) the delegated code length becomes `24` bytes (e.g. `EXTCODESIZE` would return `24`).
+When the private key is deactivated, this EIP introduces: (i) an extra byte (`0x00`) to be appended to the end of the delegated code, and (ii) the delegated code length becomes `24` bytes (e.g., `EXTCODESIZE` would return `24`).
 
 These changes are not breaking. However, they require protocol, application, and contract implementations to use strict offsets to parse the delegated address correctly. Implementations must also check the delegated code prefix `0xef01` to determine whether it represents an EOA with delegated code, while avoiding over-restrictive checks, such as asserting the code length to be exactly `23`.
 
@@ -224,19 +224,19 @@ class StateDB:
 
 ### Contracts Using ECDSA `Secp256k1` Signatures
 
-Contracts that have already been deployed and use ECDSA `secp256k1` signatures outside of transaction signatures (e.g. [ERC-20](./eip-20) tokens that support [ERC-2612](./eip-2612), the `permit` function) will not be able to verify the deactivated status of the EOA. This means that signatures signed by private keys will remain valid in these functions.
+Contracts that have already been deployed and use ECDSA `secp256k1` signatures outside of transaction signatures (e.g., [ERC-20](./eip-20) tokens that support [ERC-2612](./eip-2612), the `permit` function) will not be able to verify the deactivated status of the EOA. This means that signatures signed by private keys will remain valid in these functions.
 
 To handle deactivated EOAs, new or upgradeable contracts can check the signing address's deactivation status, for example:
 
 * Use `EXTCODESIZE` to get the account's code length.
 * If the code length is `24` bytes, use `EXTCODECOPY` to verify the code starts with `0xef0100` (delegated code prefix).
-* If both conditions are satisfied (i.e. the code size is `24` bytes and the code starts with `0xef0100`), the private key is confirmed to be deactivated, and the signature should be rejected.
+* If both conditions are satisfied (i.e., the code size is `24` bytes and the code starts with `0xef0100`), the private key is confirmed to be deactivated, and the signature should be rejected.
 
 For non-upgradeable contracts, the above method cannot be applied directly. Another potential solution, at the protocol level, is to modify `ecRecover` precompiled contract: if the private key of the recovered address is deactivated, the `ecRecover` precompiled contract could return a precompile contract error (or, if not adding an error return path, return a zero address or a collision-resistant address like `0x1`). However, this approach also has limitations, as it cannot cover cases where contracts implement their own signature verification logic without relying on `ecRecover`.
 
 ### Irreversible Deactivation
 
-Delegating to a wallet that lacks reactivation support (e.g. by calling the precompiled contract through an appropriate interface) may result in irreversible deactivation. To mitigate this risk, users should only delegate their EOAs to implementations that have been thoroughly audited and explicitly support this EIP.
+Delegating to a wallet that lacks reactivation support (e.g., by calling the precompiled contract through an appropriate interface) may result in irreversible deactivation. To mitigate this risk, users should only delegate their EOAs to implementations that have been thoroughly audited and explicitly support this EIP.
 
 ### Deactivation and Reactivation Replay
 
@@ -244,7 +244,7 @@ Replay attacks can occur in two scenarios: (i) replaying the same authorization 
 
 For deactivation through EOA-signed transactions, the use of nonces in transactions ensures the same message cannot be replayed multiple times on the same chain. Additionally, the replay protection mechanism provided by [EIP-155](./eip-155), if enabled, effectively prevents cross-chain message replay.
 
-For deactivation or reactivation via delegated contracts, the contract should implement robust replay protection mechanism(s) (e.g. adding a customized nonce and the chain ID to the signed message) to safeguard against replay attacks both within the same chain and across different chains. Especially when the EOA has been (or will be) delegated to the same implementation on multiple chains.
+For deactivation or reactivation via delegated contracts, the contract should implement robust replay protection mechanism(s) (e.g., adding a customized nonce and the chain ID to the signed message) to safeguard against replay attacks both within the same chain and across different chains. Especially when the EOA has been (or will be) delegated to the same implementation on multiple chains.
 
 ## Copyright
 


### PR DESCRIPTION
A PR based on some newly found fixes, recent EIP-7702 updates, and discussions in this thread, summarization of changes is as follows:
- Adding fact fixes in the "Additional Transaction Validation Overhead" section, because due to EIP-3607 and EIP-7702, there is already a code loading operation during transaction validation before executing the transaction, so this EIP introduces no additional code loading in this step. This EIP only introduces an extra code read when the transaction pool is validating a transaction to be added to the pool, narrowing DoS attack vectors.
- Changing `PRECOMPILE_GAS_COST` from `5000` to `13000`, and adding gas cost decomposition of `PRECOMPILE_GAS_COST`.
- Adding more details and potential solutions in the "Contracts Using ECDSA `Secp256k1` Signatures" section, aligning with the discussion in the EIP-7851 thread of Ethereum Magicians.
- Adding "how a contract can check the deactivation status of private key" as it is now doable without adding a new opcode, based on the [latest change of `EXTCODESIZE` and `EXTCODECOPY` in EIP-7702](https://github.com/ethereum/EIPs/commit/e4ba573bafc30d94d7b106a2136acd2ebea9b776).
- Removing "delegating to malicious wallet implementations" related discussions, as it is in the scope of EIP-7702, instead of this EIP.
- Adding "replaying the same authorization" discussions in the "Deactivation and Reactivation Replay" section.
- Rephrases, section restructures and code refactors.