### PR TITLE
fix: upgrade actions for github pages deployment

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -72,7 +72,7 @@ jobs:
           JEKYLL_ENV: production
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
 
   # Deployment job
   deploy:
@@ -84,4 +84,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
I've noticed the EIP website is outdated and doesn't get updated by the workflow anymore:
https://github.com/ethereum/EIPs/actions/workflows/jekyll.yml

Problem comes from the `actions/upload-pages-artifact@v2` action, which internally uses the deprecated `actions/upload-artifact@v3`.
I've updated the upload-pages-artifact action to v3. Following the [release notes](https://github.com/actions/upload-pages-artifact/releases/tag/v3.0.0) of upload-pages-artifact@v3, I've also updated the actions/deploy-pages to v4.
