### PR TITLE
docs: fix minor typos in EIP-3855 and EIP-7069

### DIFF
--- a/EIPS/eip-3855.md
+++ b/EIPS/eip-3855.md
@@ -47,7 +47,7 @@ The `base` gas cost is used for instructions which place constant values onto th
 
 ## Backwards Compatibility
 
-This EIP introduces a new opcode which did not exists previously. Already deployed contracts using this opcode could change their behaviour after this EIP.
+This EIP introduces a new opcode which did not exist previously. Already deployed contracts using this opcode could change their behaviour after this EIP.
 
 ## Test Cases
 

--- a/EIPS/eip-7069.md
+++ b/EIPS/eip-7069.md
@@ -205,7 +205,7 @@ No existing instructions are changed and so we do not think any backwards compat
 
 It is expected that the attack surface will not grow. All of these operations can be modeled by existing operations with fixed gas (all available) and output range (zero length at zero memory).
 
-When implemented in EOF (where the GAS opcode and the original CALL operations are removed) existing out of gas attacks will be slightly more difficult, but not entirely prevented. Transactions can still pass in arbitrary gas values and clever contract construction can still result in specific gas values being passed to specific calls. It is expected the same surface will remain in EOF, but the ease of explotation will be reduced.
+When implemented in EOF (where the GAS opcode and the original CALL operations are removed) existing out of gas attacks will be slightly more difficult, but not entirely prevented. Transactions can still pass in arbitrary gas values and clever contract construction can still result in specific gas values being passed to specific calls. It is expected the same surface will remain in EOF, but the ease of exploitation will be reduced.
 
 ## Copyright
 


### PR DESCRIPTION
Corrected a couple of grammar mistakes:
- Replaced "exists" → "exist" in EIP-3855.
- Updated "explotation" → "exploitation" in EIP-7069.
No functional changes, just doc cleanup.
