### PR TITLE
Update EIP-7251: fix outdated statement

### DIFF
--- a/EIPS/eip-7251.md
+++ b/EIPS/eip-7251.md
@@ -72,7 +72,7 @@ request_data = dequeue_consolidation_requests()
 The contract has three different code paths, which can be summarized at a high level as follows:
 
 1. Add consolidation request - requires a `96` byte input, concatenated public keys of the source and the target validators.
-2. Excess consolidation requests getter - if the input length is zero, return the current excess consolidation requests count.
+2. Fee getter - if the input length is zero, return the current fee required to add a consolidation request.
 3. System process - if called by system address, pop off the consolidation requests for the current block from the queue.
 
 ##### Add Consolidation Request


### PR DESCRIPTION
The EIP-7251 consolidation contract returns the consolidation fee when called without arguments.  This adjusts the text to match reality.

Note that the text is largely copied from EIP-7002, which has a similar contract structure.