### PR TITLE
proposes EIP-7805 (FOCIL) to be included in the Fusaka hardfork

### DIFF
--- a/EIPS/eip-7607.md
+++ b/EIPS/eip-7607.md
@@ -46,6 +46,7 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion` and `Propo
 * [EIP-7793](./eip-7793.md): Precompile to get index of transaction within block
 * [EIP-7843](./eip-7843.md): Precompile to get the current slot number
 * [EIP-7732](./eip-7732.md): Enshrined Proposer-Builder Separation
+* [EIP-7805](./eip-7805.md): Fork-choice enforced Inclusion Lists (FOCIL)
 
 ### Activation 
 


### PR DESCRIPTION
The upcoming hardfork (Fulu / Osaka, or Fusaka) should include censorship resistance in the form of FOCIL.

The EIP is already implemented well enough by clients that it has its own devnet. While edge cases are still being discovered, the specs seem stable, and implementation is well understood by multiple client teams.
