### PR TITLE
Switch to upload-artifact@v4

### DIFF
--- a/.github/workflows/auto-review-trigger.yml
+++ b/.github/workflows/auto-review-trigger.yml
@@ -52,7 +52,7 @@ jobs:
           files: pr-number.txt
 
       - name: Save PR Number
-        uses: actions/upload-artifact@65d862660abb392b8c4a3d1195a2108db131dd05
+        uses: actions/upload-artifact@v4
         if: steps.check_pr_number_exists.outputs.files_exists == 'true'
         with:
           name: pr-number

--- a/.github/workflows/auto-review-trigger.yml
+++ b/.github/workflows/auto-review-trigger.yml
@@ -52,7 +52,7 @@ jobs:
           files: pr-number.txt
 
       - name: Save PR Number
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
         if: steps.check_pr_number_exists.outputs.files_exists == 'true'
         with:
           name: pr-number

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           echo $MERGE_SHA > ./pr/merge_sha
 
       - name: Upload PR Number
-        uses: actions/upload-artifact@65d862660abb392b8c4a3d1195a2108db131dd05
+        uses: actions/upload-artifact@v4
         with:
           name: pr_number
           path: pr/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           echo $MERGE_SHA > ./pr/merge_sha
 
       - name: Upload PR Number
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
         with:
           name: pr_number
           path: pr/
@@ -42,12 +42,12 @@ jobs:
 
     steps:
       - name: Checkout EIPs
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           repository: ethereum/EIPs
           path: ''
       - name: Checkout ERCs
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           repository: ethereum/ERCs
           path: ERCs


### PR DESCRIPTION
Don’t know for sure but this might help to resolve recent CI issues, [for example](https://github.com/ethereum/EIPs/actions/runs/13145370173/job/36682129698?pr=9319).

The commit of the `upload-artifact` which hash is currently used is from mid 2023. v1, v2, v3 versions have been deprecated last year, so the failure might be related to the deprecation.