### PR TITLE
Update EIP-7843: specification update

### DIFF
--- a/EIPS/eip-7843.md
+++ b/EIPS/eip-7843.md
@@ -26,7 +26,7 @@ An example of a smart contract that needs the slot number is a validation contra
 
 If `block.timestamp >= TBD` a new precompiled contract `SLOT` shall be created at address `TBD`.
 
-`SLOT` returns as output the current slot number as an 8 byte ulong in big endian encoding.
+`SLOT` returns as output the current slot number as an 8-byte uint64 in big-endian encoding.
 
 ### Gas Cost
 


### PR DESCRIPTION
- Changed `8 byte ulong in big endian encoding` → `8-byte uint64 in big-endian encoding` for consistency and clarity.

The EIP-7843 specification already uses the `uint64` type, so replacing `ulong` with `uint64` ensures consistency in terminology. This helps avoid confusion and makes the description more precise in the context of Ethereum development.  

## Checklist:
- [x] The PR only modifies an existing draft EIP.
- [x] The change improves clarity without altering functionality.
- [x] The author of the EIP is listed in the metadata.
