### PR TITLE
Update EIP-7623: Specify initcode word cost value

### DIFF
--- a/EIPS/eip-7623.md
+++ b/EIPS/eip-7623.md
@@ -28,6 +28,7 @@ By introducing a floor cost dependent on the ratio of gas spent on EVM operation
 | Parameter                    | Value |
 |------------------------------|-------|
 | `STANDARD_TOKEN_COST`        | `4`   |
+| `INITCODE_WORD_COST`         | `2`   |
 | `TOTAL_COST_FLOOR_PER_TOKEN` | `10`  |
 
 


### PR DESCRIPTION
`INITCODE_WORD_COST` is used but never defined.

Potentially might make sense to make EIP-3860, where it is first defined, a dependency, but I haven't done it here.