### PR TITLE
Update EIP-7623: add reference to eip-3860

### DIFF
--- a/EIPS/eip-7623.md
+++ b/EIPS/eip-7623.md
@@ -37,7 +37,7 @@ Let `isContractCreation` be a boolean indicating the respective event.
 
 Let `execution_gas_used` be the gas used for EVM execution with the gas refund subtracted.
 
-Let `INITCODE_WORD_COST` be defined in [EIP-3860](./eip-3860.md).
+Let `INITCODE_WORD_COST` be 2 as defined in [EIP-3860](./eip-3860.md).
 
 The current formula for determining the total gas used per transaction (`tx.gasUsed`) is equivalent to:
 

--- a/EIPS/eip-7623.md
+++ b/EIPS/eip-7623.md
@@ -37,6 +37,8 @@ Let `isContractCreation` be a boolean indicating the respective event.
 
 Let `execution_gas_used` be the gas used for EVM execution with the gas refund subtracted.
 
+Let `INITCODE_WORD_COST` be defined in [EIP-3860](./eip-3860.md).
+
 The current formula for determining the total gas used per transaction (`tx.gasUsed`) is equivalent to:
 
 ```python


### PR DESCRIPTION
Add a crossref to EIP-3860 to clarify the `INITCODE_WORD_COST` as suggested here:
https://github.com/ethereum/EIPs/pull/9350#issuecomment-2647826169