### PR TITLE
Update eip-7702.md: change auth.chain_id to be strictly equal current chain id

### DIFF
--- a/EIPS/eip-7702.md
+++ b/EIPS/eip-7702.md
@@ -2,7 +2,7 @@
 eip: 7702
 title: Set EOA account code
 description: Add a new tx type that permanently sets the code for an EOA
-author: Vitalik Buterin (@vbuterin), Sam Wilson (@SamWilsn), Ansgar Dietrichs (@adietrichs), lightclient (@lightclient)
+author: Vitalik Buterin (@vbuterin), Sam Wilson (@SamWilsn), Ansgar Dietrichs (@adietrichs), lightclient (@lightclient), peersky (@peersky)
 discussions-to: https://ethereum-magicians.org/t/eip-set-eoa-account-code-for-one-transaction/19923
 status: Last Call
 last-call-deadline: 2025-04-01
@@ -53,7 +53,7 @@ The transaction is also considered invalid when any field in an authorization
 tuple cannot fit within the following bounds:
 
 ```python
-assert auth.chain_id < 2**256
+assert auth.chain_id == chain_id
 assert auth.nonce < 2**64
 assert len(auth.address) == 20
 assert auth.y_parity < 2**8


### PR DESCRIPTION
As far as I understand, current specification leaves room for cross-chain replay attack if authorization_list chain_id is null. 

Example attack flow:

1. User signs authorization with chain_id=0 on Goerli
2.  Attacker replays same signature on Mainnet:
```
   // Malicious tx on Mainnet
   authorization_list: [
     [0, 0x... (delegate address), ...] 
   ]
```