### PR TITLE
Update EIP-7873: memory expansion of TXCREATE and remove 3860 charge mention

### DIFF
--- a/EIPS/eip-7873.md
+++ b/EIPS/eip-7873.md
@@ -111,18 +111,18 @@ Introduce a new instruction on the same block number [EIP-3540](./eip-3540.md) i
 - deduct `TX_CREATE_COST` gas
 - halt with exceptional failure if the current frame is in `static-mode`.
 - pop `tx_initcode_hash`, `value`, `salt`, `input_offset`, `input_size` from the operand stack
-- peform (and charge for) memory expansion using `[input_offset, input_size]`
+- perform (and charge for) memory expansion using `[input_offset, input_size]`
 - load initcode EOF container from the transaction `initcodes` array which hashes to `tx_initcode_hash`
     - fails (returns 0 on the stack) if such initcode does not exist in the transaction, or if called from a transaction of `TransactionType` other than `INITCODE_TX_TYPE`
-        - caller's nonce is not updated and gas for initcode execution is not consumed. Only `TX_CREATE_COST` constant gas was consumed
+        - caller's nonce is not updated and gas for initcode execution is not consumed.
     - let `initcontainer` be that EOF container, and `initcontainer_size` its length in bytes
 - check that current call depth is below `STACK_DEPTH_LIMIT` and that caller balance is enough to transfer `value`
-    - in case of failure return 0 on the stack, caller's nonce is not updated and gas for initcode execution is not consumed. Only `TX_CREATE_COST` constant gas was consumed.
+    - in case of failure return 0 on the stack, caller's nonce is not updated and gas for initcode execution is not consumed.
 - **validate the initcode container and all its subcontainers recursively**
     - unlike in general validation, `initcontainer` is additionally required to have `data_size` declared in the header equal to actual `data_section` size.
     - validation includes checking that the `initcontainer` does not contain `RETURN` or `STOP`
 - fails (returns 0 on the stack) if container was invalid
-    - caller’s nonce is not updated and gas for initcode execution is not consumed. Only `TX_CREATE_COST` constant gas was consumed.
+    - caller’s nonce is not updated and gas for initcode execution is not consumed.
 - caller's memory slice `[input_offset:input_size]` is used as calldata
 - execute the container and deduct gas for execution. The 63/64th rule from [EIP-150](./eip-150.md) applies.
 - increment `sender` account's nonce

--- a/EIPS/eip-7873.md
+++ b/EIPS/eip-7873.md
@@ -114,7 +114,7 @@ Introduce a new instruction on the same block number [EIP-3540](./eip-3540.md) i
 - peform (and charge for) memory expansion using `[input_offset, input_size]`
 - load initcode EOF container from the transaction `initcodes` array which hashes to `tx_initcode_hash`
     - fails (returns 0 on the stack) if such initcode does not exist in the transaction, or if called from a transaction of `TransactionType` other than `INITCODE_TX_TYPE`
-        - caller's nonce is not updated and gas for initcode execution is not consumed. Only `TXCREATE` constant gas was consumed
+        - caller's nonce is not updated and gas for initcode execution is not consumed. Only `TX_CREATE_COST` constant gas was consumed
     - let `initcontainer` be that EOF container, and `initcontainer_size` its length in bytes
 - check that current call depth is below `STACK_DEPTH_LIMIT` and that caller balance is enough to transfer `value`
     - in case of failure return 0 on the stack, caller's nonce is not updated and gas for initcode execution is not consumed. Only `TX_CREATE_COST` constant gas was consumed.
@@ -122,7 +122,7 @@ Introduce a new instruction on the same block number [EIP-3540](./eip-3540.md) i
     - unlike in general validation, `initcontainer` is additionally required to have `data_size` declared in the header equal to actual `data_section` size.
     - validation includes checking that the `initcontainer` does not contain `RETURN` or `STOP`
 - fails (returns 0 on the stack) if container was invalid
-    - caller’s nonce is not updated and gas for initcode execution is not consumed. Only `TX_CREATE_COST` constant and [EIP-3860](./eip-3860.md) gas are consumed.
+    - caller’s nonce is not updated and gas for initcode execution is not consumed. Only `TX_CREATE_COST` constant gas was consumed.
 - caller's memory slice `[input_offset:input_size]` is used as calldata
 - execute the container and deduct gas for execution. The 63/64th rule from [EIP-150](./eip-150.md) applies.
 - increment `sender` account's nonce


### PR DESCRIPTION
Rectifies two minor details I've found after reading the EIP post-merge