### PR TITLE
Update EIP-7607: Propose EIP-5920 for inclusion in Osaka

### DIFF
--- a/EIPS/eip-7607.md
+++ b/EIPS/eip-7607.md
@@ -47,6 +47,7 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion` and `Propo
 * [EIP-7843](./eip-7843.md): Precompile to get the current slot number
 * [EIP-7732](./eip-7732.md): Enshrined Proposer-Builder Separation
 * [EIP-7805](./eip-7805.md): Fork-choice enforced Inclusion Lists (FOCIL)
+* [EIP-5920](./eip-5920.md): PAY opcode
 
 
 ### Activation 


### PR DESCRIPTION

Reviewer @timbeiko
I think EOF needs the PAY opcode to maintain payment security, so I propose it will be considered for Osaka.
#### Changes
* add eip-5920 to proposed for inclusion