### PR TITLE
Update EIP-5920: Move to Draft

### DIFF
--- a/EIPS/eip-5920.md
+++ b/EIPS/eip-5920.md
@@ -4,7 +4,7 @@ title: PAY opcode
 description: Introduces a new opcode, PAY, to send ether to an address without calling any of its functions
 author: Gavin John (@Pandapip1), Zainan Victor Zhou (@xinbenlv), Sam Wilson (@SamWilsn)
 discussions-to: https://ethereum-magicians.org/t/eip-5920-pay-opcode/11717
-status: Stagnant
+status: Draft
 type: Standards Track
 category: Core
 created: 2022-03-14

--- a/EIPS/eip-5920.md
+++ b/EIPS/eip-5920.md
@@ -76,7 +76,7 @@ This change requires a hard fork.
 
 Existing contracts should not rely on their balance being under their control, since it is already possible to send ether to an address without calling it, by creating a temporary contract and immediately `SELFDESTRUCT`ing it, sending the ether to an arbitrary address.
 It is also possible to involuntarily fund an account using priority fees.
-However, this opcode does make this process cheaper for already-vulnerable contracts.
+However, this opcode does make this process cheaper and easier for already-vulnerable contracts.
 
 ## Copyright
 

--- a/EIPS/eip-5920.md
+++ b/EIPS/eip-5920.md
@@ -21,6 +21,7 @@ Currently, to send ether to an address requires you to call into that address, w
 
 - First of all, it opens a reentrancy attack vector, as the recipient can call back into the sender. More generally, the recipient can unilaterally execute arbitrary state changes, limited only by the gas stipend, which is not desirable from the point of view of the sender.
 - Secondly, it opens a DoS vector. Contracts which want to send ether must be cognizant of the possibility that the recipient will run out of gas or revert.
+- The `EXTCALL` opcode does not provide a way to restrict gas.
 - Finally, the `CALL` opcode is needlessly expensive for simple ether transfers, as it requires the memory and stack to be expanded, the recipient's full data including code and memory to be loaded, and finally needs to execute a call, which might do other unintentional operations. Having a dedicated opcode for ether transfers solves all of these issues, and would be a useful addition to the EVM.
 
 ## Specification
@@ -39,7 +40,7 @@ Currently, to send ether to an address requires you to call into that address, w
 
 ### Behavior
 
-A new opcode is introduced: `PAY` (`0xf9`), which:
+A new opcode is introduced: `PAY` (`0xfc`), which:
 
 - Pops two values from the stack: `addr` then `val`.
 - Transfers `val` wei from the current target address to the address `addr`.
@@ -73,7 +74,9 @@ This change requires a hard fork.
 
 ## Security Considerations
 
-Existing contracts should not rely on their balance being under their control, since it is already possible to send ether to an address without calling it, by creating a temporary contract and immediately `SELFDESTRUCT`ing it, sending the ether to an arbitrary address. However, this opcode does make this process cheaper for already-vulnerable contracts.
+Existing contracts should not rely on their balance being under their control, since it is already possible to send ether to an address without calling it, by creating a temporary contract and immediately `SELFDESTRUCT`ing it, sending the ether to an arbitrary address.
+It is also possible to involuntarily fund an account using priority fees.
+However, this opcode does make this process cheaper for already-vulnerable contracts.
 
 ## Copyright
 


### PR DESCRIPTION

Reviewers @pandapip1 @SamWilsn @xinbenlv
I plan to champion EIP-5920 for inclusion in Osaka, else Amsterdam.
The current PAY opcode is likely to be used for `EXTDELEGATECALL`, of [EIP-7069](https://eips.ethereum.org/EIPS/eip-7069)
#### Changes
* Specification: change opcode to unused 0xFC
* Motivation: Mention EOF `EXTCALL`
* Rationale: Mention priority fees