### PR TITLE
Update EIP-7873: Creator Contract - revert reason & magic value

### DIFF
--- a/EIPS/eip-7873.md
+++ b/EIPS/eip-7873.md
@@ -167,7 +167,7 @@ At the start of the block in which [EIP-3540](./eip-3540.md) activates, set the 
 
     if iszero(ret) {
         let ret_data_size := returndatasize()
-        returndatacopy(0, ret_data_size)
+        returndatacopy(0, 0, ret_data_size)
         revert(0, ret_data_size)
     }
 

--- a/EIPS/eip-7873.md
+++ b/EIPS/eip-7873.md
@@ -156,19 +156,20 @@ At the start of the block in which [EIP-3540](./eip-3540.md) activates, set the 
     let size := calldatasize()
     if lt(size, 64) { revert(0, 0) }
 
+    calldatacopy(0, 0, size)  // copy tx_initcode_hash, salt and init_data to memory to hash
+    let final_salt := keccak256(0, size)
+
     let tx_initcode_hash := calldataload(0)
-    let salt := calldataload(32)
-
-    mstore8(0, 0xff)  // a magic value to ensure a specific preimage space
-    calldatacopy(1, 0, size)  // copy tx_initcode_hash, salt and init_data to memory to hash
-    let commitment_size := add(size, 1)
-    let final_salt := keccak256(0, commitment_size)
-
     let init_data_size := sub(size, 64)
-    calldatacopy(0, 64, init_data_size)
 
-    let ret := txcreate(tx_initcode_hash, callvalue(), final_salt, 0, init_data_size)
-    if iszero(ret) { revert(0, 0) }
+    // reuse init_data which has been already copied to memory above
+    let ret := txcreate(tx_initcode_hash, callvalue(), final_salt, 64, init_data_size)
+
+    if iszero(ret) {
+        let ret_data_size := returndatasize()
+        returndatacopy(0, ret_data_size)
+        revert(0, ret_data_size)
+    }
 
     mstore(0, ret)
     return(0, 32)


### PR DESCRIPTION
Updates to the Creator Contract as done in https://github.com/ipsilon/eof/pull/177 :

- remove `0xff` magic value from the `final_salt` calculation (CC @gumb0 @frangio)
- pass on as return data the entire revert return data (presumably revert reason) in case deployment fails (CC @frangio )