### PR TITLE
Update EIP-7607: Proposing 7825 for Fusaka

### DIFF
--- a/EIPS/eip-7607.md
+++ b/EIPS/eip-7607.md
@@ -47,7 +47,7 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion` and `Propo
 * [EIP-7843](./eip-7843.md): Precompile to get the current slot number
 * [EIP-7732](./eip-7732.md): Enshrined Proposer-Builder Separation
 * [EIP-7805](./eip-7805.md): Fork-choice enforced Inclusion Lists (FOCIL)
-
+* [EIP-7825](./eip-7825.md): Transaction Gas Limit Cap
 
 ### Activation 
 


### PR DESCRIPTION
I want to cap Transaction gas limit ASAP before we increase Block limit too much so that we won't be nerfing it later. The actual limit (30mln) is up for debate.
