### PR TITLE
Backlink hard fork Meta EIPs

### DIFF
--- a/EIPS/eip-7569.md
+++ b/EIPS/eip-7569.md
@@ -12,7 +12,7 @@ requires: 1153, 4788, 4844, 5656, 6780, 7044, 7045, 7514, 7516, 7568
 
 ## Abstract
 
-This Meta EIP lists the EIPs included in the Dencun network upgrade across both Ethereum's execution and consensus layers. 
+This Meta EIP lists the EIPs included in the Dencun network upgrade across both Ethereum's execution and consensus layers. See [EIP-7568](./eip-7568.md) for the specifications of past upgrades. 
 
 ## Specification
 

--- a/EIPS/eip-7600.md
+++ b/EIPS/eip-7600.md
@@ -8,12 +8,12 @@ status: Last Call
 last-call-deadline: 2025-04-01
 type: Meta
 created: 2024-01-18
-requires: 2537, 2935, 6110, 7002, 7251, 7549, 7623, 7685, 7691, 7702, 7840
+requires: 2537, 2935, 6110, 7002, 7251, 7549, 7569, 7623, 7685, 7691, 7702, 7840
 ---
 
 ## Abstract
 
-This Meta EIP lists the EIPs formally Scheduled for Inclusion in the Prague/Electra network upgrade.
+This Meta EIP lists the EIPs formally Scheduled for Inclusion in the Prague/Electra network upgrade. It follows the Dencun upgrade, documented in [EIP-7569](./eip-7569.md).
 
 ## Specification
 

--- a/EIPS/eip-7607.md
+++ b/EIPS/eip-7607.md
@@ -7,12 +7,12 @@ discussions-to: https://ethereum-magicians.org/t/eip-7607-fusaka-meta-eip/18439
 status: Draft
 type: Meta
 created: 2024-02-01
-requires: 7600
+requires: 663, 3540, 3670, 4200, 5450, 6206, 7480, 7594, 7600, 7620, 7698
 ---
 
 ## Abstract
 
-This Meta EIP lists the EIPs formally Proposed, Considered for & Scheduled for Inclusion in the Fulu/Osaka network upgrade. 
+This Meta EIP lists the EIPs formally Proposed, Considered for & Scheduled for Inclusion in the Fulu/Osaka network upgrade. It follows the Pectra upgrade, documented in [EIP-7600](./eip-7600.md)
 
 ## Specification
 


### PR DESCRIPTION
Adds references to the previous Hard Fork Meta EIP to make it clearer to readers what order network upgrades came in. 