### PR TITLE
Update EIP-7851: simplifies some descriptions

### DIFF
--- a/EIPS/eip-7851.md
+++ b/EIPS/eip-7851.md
@@ -97,7 +97,7 @@ Alternative methods for deactivating and reactivating EOA private keys include:
 
 This approach ensures maximum compatibility with future migrations. EOAs can reactivate their private keys, delegate their accounts to an [EIP-7701](./eip-7701) contract, and then deactivate their private keys again. This avoids the limitations of contract upgrades. e.g., to remove legacy proxy contracts (reducing gas overhead) when upgrading to EOF contracts, one can reactivate the EOA and redelegate it to an EOF proxy contract.
 
-Reactivation can only be performed by the delegated contract. Since reactivating the private key grants full control over the wallet, including the ability to replace the delegated wallet, wallets must implement this interface with strict security measures. These measures should treat reactivation as the highest level of authority, equivalent to full wallet ownership. The signature payload should include the chain ID and a random challenge to ensure that the request cannot be replayed.
+Reactivation can only be performed by the delegated contract. Since reactivating the private key grants full control over the wallet, wallets must implement this interface with strict security measures. These measures should treat reactivation as the highest level of authority, equivalent to full wallet ownership. The signature payload should include the chain ID and a random challenge to ensure that the request cannot be replayed.
 
 ### Avoiding Delegated Code Prefix Modification
 

--- a/EIPS/eip-7851.md
+++ b/EIPS/eip-7851.md
@@ -97,11 +97,7 @@ Alternative methods for deactivating and reactivating EOA private keys include:
 
 This approach ensures maximum compatibility with future migrations. EOAs can reactivate their private keys, delegate their accounts to an [EIP-7701](./eip-7701) contract, and then deactivate their private keys again. This avoids the limitations of contract upgrades. e.g., to remove legacy proxy contracts (reducing gas overhead) when upgrading to EOF contracts, one can reactivate the EOA and redelegate it to an EOF proxy contract.
 
-Reactivation can only be performed by the delegated contract. Since reactivating the private key grants full control over the wallet, including the ability to replace the delegated wallet, wallets must implement this interface with strict security measures. These measures should treat reactivation as the highest level of authority, equivalent to full ownership of the wallet.
-
-The reactivation process is recommended to include a signed authorization from the private key. This signature payload should consist of the chain ID and a random challenge (e.g., a hash value of other signatures) to ensure that: (i) the request is non-replayable in other chains, and (ii) the the private key owner is also included in the reactivation process.
-
-Users should delegate their EOAs only to wallets that have been thoroughly audited and follow best practices for security.
+Reactivation can only be performed by the delegated contract. Since reactivating the private key grants full control over the wallet, including the ability to replace the delegated wallet, wallets must implement this interface with strict security measures. These measures should treat reactivation as the highest level of authority, equivalent to full wallet ownership. The signature payload should include the chain ID and a random challenge to ensure that the request cannot be replayed.
 
 ### Avoiding Delegated Code Prefix Modification
 
@@ -115,7 +111,7 @@ An alternative is to add a `deactivated` field in the account state to track the
 
 When the private key is deactivated, this EIP introduces: (i) an extra byte (`0x00`) to be appended to the end of the delegated code, and (ii) the delegated code length becomes `24` bytes (e.g., `EXTCODESIZE` would return `24`).
 
-These changes are not breaking. However, they require protocol, application, and contract implementations to use strict offsets to parse the delegated address correctly. Implementations must also check the delegated code prefix `0xef01` to determine whether it represents an EOA with delegated code, while avoiding over-restrictive checks, such as asserting the code length to be exactly `23`.
+These changes are not breaking. However, they require protocol, application, and contract implementations to use strict offsets to parse the delegated address correctly. Implementations must also check the delegated code prefix `0xef0100` to determine whether it represents an EOA with delegated code, while avoiding over-restrictive checks, such as asserting the code length to be exactly `23`.
 
 ## Test Cases
 
@@ -154,8 +150,8 @@ error, gas_left = precompile.execute(caller, state_db, gas=15000)
 assert error == b"the address is not an EOA delegated to code"
 assert gas_left == 0
 
-caller = "0x89ab"
-state_db.set_code(caller, bytes.fromhex("00")) # Not a delegated code prefix
+caller = "0x89ab" # This is a contract address.
+state_db.set_code(caller, bytes.fromhex("60006000f3"))
 error, gas_left = precompile.execute(caller, state_db, gas=15000)
 assert error == b"the address is not an EOA delegated to code"
 assert gas_left == 0
@@ -232,15 +228,15 @@ To handle deactivated EOAs, new or upgradeable contracts can check the signing a
 * If the code length is `24` bytes, use `EXTCODECOPY` to verify the code starts with `0xef0100` (delegated code prefix).
 * If both conditions are satisfied (i.e., the code size is `24` bytes and the code starts with `0xef0100`), the private key is confirmed to be deactivated, and the signature should be rejected.
 
-For non-upgradeable contracts, the above method cannot be applied directly. Another potential solution, at the protocol level, is to modify `ecRecover` precompiled contract: if the private key of the recovered address is deactivated, the `ecRecover` precompiled contract could return a precompile contract error (or, if not adding an error return path, return a zero address or a collision-resistant address like `0x1`). However, this approach also has limitations, as it cannot cover cases where contracts implement their own signature verification logic without relying on `ecRecover`.
+For non-upgradeable contracts, the above method cannot be applied directly. Another potential solution, at the protocol level, is to modify `ecRecover` precompiled contract: if the private key of the recovered address is deactivated, the `ecRecover` precompiled contract could return a precompile contract error (or, if not adding an error return path, return a zero address or a collision-resistant address, such as `0x1`). However, this approach also has limitations, as it cannot cover cases where contracts implement their own signature verification logic without relying on `ecRecover`.
 
 ### Irreversible Deactivation
 
-Delegating to a wallet that lacks reactivation support (e.g., by calling the precompiled contract through an appropriate interface) may result in irreversible deactivation. To mitigate this risk, users should only delegate their EOAs to implementations that have been thoroughly audited and explicitly support this EIP.
+Delegating to a wallet that lacks reactivation support (e.g., by calling the precompiled contract through an appropriate interface) may result in irreversible deactivation. To mitigate this risk, users should delegate their EOAs only to thoroughly audited implementations that explicitly support this EIP.
 
 ### Deactivation and Reactivation Replay
 
-Replay attacks can occur in two scenarios: (i) replaying the same authorization multiple times on a single chain, or (ii) replaying the authorization across different chains.
+Replay attacks can occur in two scenarios: (i) repeating the same authorization on a single chain, or (ii) using the authorization across different chains.
 
 For deactivation through EOA-signed transactions, the use of nonces in transactions ensures the same message cannot be replayed multiple times on the same chain. Additionally, the replay protection mechanism provided by [EIP-155](./eip-155), if enabled, effectively prevents cross-chain message replay.
 

--- a/EIPS/eip-7851.md
+++ b/EIPS/eip-7851.md
@@ -97,7 +97,7 @@ Alternative methods for deactivating and reactivating EOA private keys include:
 
 This approach ensures maximum compatibility with future migrations. EOAs can reactivate their private keys, delegate their accounts to an [EIP-7701](./eip-7701) contract, and then deactivate their private keys again. This avoids the limitations of contract upgrades. e.g., to remove legacy proxy contracts (reducing gas overhead) when upgrading to EOF contracts, one can reactivate the EOA and redelegate it to an EOF proxy contract.
 
-Reactivation can only be performed by the delegated contract. Since reactivating the private key grants full control over the wallet, wallets must implement this interface with strict security measures. These measures should treat reactivation as the highest level of authority, equivalent to full wallet ownership. The signature payload should include the chain ID and a random challenge to ensure that the request cannot be replayed.
+Reactivation can only be performed by the delegated contract. Since reactivating the private key grants full control over the wallet, wallets must implement this interface with strict security measures. These measures should treat reactivation as the highest level of authority, equivalent to full wallet ownership. Users should delegate their EOAs only to wallets that have been thoroughly audited and follow best practices for security.
 
 ### Avoiding Delegated Code Prefix Modification
 


### PR DESCRIPTION
This PR simplifies and refines some descriptions and unnecessary requirements, and fixes a typo in the meantime, it also updates the contract code in the "Test Cases" section to make it more meaningful.