### PR TITLE
Update EIP-7620: Move to Review

### DIFF
--- a/EIPS/eip-7620.md
+++ b/EIPS/eip-7620.md
@@ -71,10 +71,11 @@ Details on each instruction follow in the next sections.
 - deduct `GAS_KECCAK256_WORD * ((initcontainer_size + 31) // 32)` gas (hashing charge)
 - check that current call depth is below `STACK_DEPTH_LIMIT` and that caller balance is enough to transfer `value`
   - in case of failure return 0 on the stack, caller's nonce is not updated and gas for initcode execution is not consumed.
-- caller's memory slice `[input_offset:input_size]` is used as calldata
-- execute the container and deduct gas for execution. The 63/64th rule from [EIP-150](./eip-150.md) applies.
-- increment `sender` account's nonce
 - calculate `new_address` as `keccak256(0xff || sender || salt || keccak256(initcontainer))[12:]`
+- **increment** the **nonce** of `state[new_address]` over and above its normal starting value by **one**, following [EIP-161](./eip-161.md) rules for `CREATE`
+- caller's memory slice `[input_offset:input_size]` is used as calldata
+- execute the `initcontainer` in the context of `new_address` and deduct gas for execution. The 63/64th rule from [EIP-150](./eip-150.md) applies.
+- increment `sender` account's nonce
 - behavior on `accessed_addresses` and address collision is same as `CREATE2` (rules for `CREATE2` from [EIP-684](./eip-684.md) and [EIP-2929](./eip-2929.md) apply to `EOFCREATE`)
 - an unsuccessful execution of initcode results in pushing `0` onto the stack
     - can populate returndata if execution `REVERT`ed

--- a/EIPS/eip-7698.md
+++ b/EIPS/eip-7698.md
@@ -4,7 +4,7 @@ title: EOF - Creation transaction
 description: Deploy EOF contracts using creation transactions
 author: Piotr Dobaczewski (@pdobacz), Andrei Maiboroda (@gumb0), Paweł Bylica (@chfast), Alex Beregszaszi (@axic)
 discussions-to: https://ethereum-magicians.org/t/eip-7698-eof-creation-transaction/19784
-status: Stagnant
+status: Review
 type: Standards Track
 category: Core
 created: 2024-04-24
@@ -41,16 +41,16 @@ In case a creation transaction (transaction with empty `to`) has `data` starting
     - Unlike in general validation, `initcontainer` is additionally required to have `data_size` declared in the header equal to actual `data_section` size.
     - Validation includes checking that the `initcontainer` does not contain `RETURN` or `STOP`
 4. If EOF header parsing or full container validation fails, transaction is considered valid and failing. Gas for initcode execution is not consumed, only intrinsic creation transaction costs are charged.
-5. `calldata` part of transaction `data` that follows `initcontainer` is treated as calldata to pass into the execution frame.
-6. Execute the container and deduct gas for execution.
-    1. Calculate `new_address` as `keccak256(sender || sender_nonce)[12:]`
-    2. A successful execution ends with initcode executing `RETURNCONTRACT{deploy_container_index}(aux_data_offset, aux_data_size)` instruction. After that:
-        - load deploy-contract from EOF subcontainer at `deploy_container_index` in the container from which `RETURNCONTRACT` is executed,
-        - concatenate data section with `(aux_data_offset, aux_data_offset + aux_data_size)` memory segment and update data size in the header,
-        - let `deployed_code_size` be updated deploy container size,
-        - if `deployed_code_size > MAX_CODE_SIZE` instruction exceptionally aborts,
-        - set `state[new_address].code` to the updated deploy container (rules of [EIP-3541](./eip-3541.md), prohibiting deployment of `code` starting with `EF` from creation transactions, do not apply in this case).
-7. Deduct `200 * deployed_code_size` gas.
+5. Calculate `new_address` as `keccak256(sender || sender_nonce)[12:]`
+6. **Increment** the **nonce** of `state[new_address]` over and above its normal starting value by **one**, following [EIP-161](./eip-161.md) rules for legacy creation transactions
+7. `calldata` part of transaction `data` that follows `initcontainer` is treated as calldata to pass into the execution frame.
+8. Execute the container and deduct gas for execution. A successful execution ends with initcode executing `RETURNCONTRACT{deploy_container_index}(aux_data_offset, aux_data_size)` instruction. After that:
+    - load deploy-contract from EOF subcontainer at `deploy_container_index` in the container from which `RETURNCONTRACT` is executed,
+    - concatenate data section with `(aux_data_offset, aux_data_offset + aux_data_size)` memory segment and update data size in the header,
+    - let `deployed_code_size` be updated deploy container size,
+    - if `deployed_code_size > MAX_CODE_SIZE` instruction exceptionally aborts,
+    - set `state[new_address].code` to the updated deploy container (rules of [EIP-3541](./eip-3541.md), prohibiting deployment of `code` starting with `EF` from creation transactions, do not apply in this case).
+9. Deduct `200 * deployed_code_size` gas.
 
 ## Rationale
 

--- a/EIPS/eip-7873.md
+++ b/EIPS/eip-7873.md
@@ -123,10 +123,11 @@ Introduce a new instruction on the same block number [EIP-3540](./eip-3540.md) i
     - validation includes checking that the `initcontainer` does not contain `RETURN` or `STOP`
 - fails (returns 0 on the stack) if container was invalid
     - caller’s nonce is not updated and gas for initcode execution is not consumed.
-- caller's memory slice `[input_offset:input_size]` is used as calldata
-- execute the container and deduct gas for execution. The 63/64th rule from [EIP-150](./eip-150.md) applies.
-- increment `sender` account's nonce
 - calculate `new_address` as `keccak256(0xff || sender || salt)[12:]`
+- **increment** the **nonce** of `state[new_address]` over and above its normal starting value by **one**, following [EIP-161](./eip-161.md) rules for `CREATE`
+- caller's memory slice `[input_offset:input_size]` is used as calldata
+- execute the `initcontainer` in the context of `new_address` and deduct gas for execution. The 63/64th rule from [EIP-150](./eip-150.md) applies.
+- increment `sender` account's nonce
 - behavior on `accessed_addresses` and address collision is same as `CREATE2` (rules for `CREATE2` from [EIP-684](./eip-684.md) and [EIP-2929](./eip-2929.md) apply to `TXCREATE`)
 - an unsuccessful execution of initcode results in pushing `0` onto the stack
     - can populate returndata if execution `REVERT`ed


### PR DESCRIPTION
EOFCREATE and TXCREATE (and also the soon-to-be-obsolete EOF creation txs) must obey EIP-161 and set the nonce of the newly created account to 1 before executing initcode