### PR TITLE
doc: typo fix eip-2069.md

### DIFF
--- a/EIPS/eip-2069.md
+++ b/EIPS/eip-2069.md
@@ -25,7 +25,7 @@ This proposal aims to solve all these issues.
 
 The [Standard Contract ABI] is usually represented as a JSON object.  This works well and several tools – including compilers and clients – support it to handle data encoding.
 
-One shortcoming of the JSON description is its inability to contain comments.  To counter this, we suggest the use of YAML for providing user readable specifications.  Given YAML was designed to be compatible with JSON, several tools exists to convert between the two formats.
+One shortcoming of the JSON description is its inability to contain comments.  To counter this, we suggest the use of YAML for providing user readable specifications.  Given YAML was designed to be compatible with JSON, several tools exist to convert between the two formats.
 
 The following example contains a single function, `transfer` with one input and one output in YAML:
 
@@ -83,7 +83,7 @@ The same in JSON:
 
 ## Rationale
 
-The aim was to chose a representation which is well supported by tools and supports comments. While inventing a more concise description language seems like a good idea, it felt as an unnecessary layer of complexity.
+The aim was to choose a representation which is well supported by tools and supports comments. While inventing a more concise description language seems like a good idea, it felt as an unnecessary layer of complexity.
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
# Changes

- Corrected "chose" to "choose" for proper tense consistency in the sentence.
- Changed "exists" to "exist" to match the plural subject "several tools."

Please let me know any additional changes are needed. Thanks.
