### PR TITLE
Update EIP-7864: Finalize hash function selection to Poseidon2

### DIFF
--- a/EIPS/eip-7864.md
+++ b/EIPS/eip-7864.md
@@ -14,34 +14,54 @@ created: 2025-01-20
 
 Introduce a new binary state tree, intended to replace the hexary patricia trees. Account and storage tries are merged into a single tree with 32-byte keys, which also contains contracts code. Account data is broken into independent leaves which  are grouped by 256 in order to provide some locality.
 
-Note: the hash function used in the current draft is not final, other potential candidates are Keccak or Poseidon2. For the latter, an extra section on how to encode 32-bytes->[FiniteField] will be created. **Do not** assume Blake3 is a final decision. <-- TODO finalize hash function -->
+Note: This EIP uses the Poseidon2 hash function for all tree operations. The function provides optimal performance for zero-knowledge proofs while maintaining strong security properties.
+
+### Poseidon2 Parameters
+
+The Poseidon2 hash function is instantiated with the following parameters:
+- Field: BN254 scalar field
+- Security level: 128 bits
+- Capacity: 1
+- Rate: 8
+- Number of full rounds: 8
+- Number of partial rounds: 56
+
+### 32-byte Value Encoding
+
+To encode 32-byte values into field elements for Poseidon2:
+1. Split the 32-byte value into 4 chunks of 8 bytes each
+2. Interpret each chunk as a little-endian uint64
+3. Map each uint64 into the field using modular reduction
+4. Use these field elements as input to Poseidon2
+
+The resulting hash is interpreted as a 32-byte value by taking the little-endian representation of the field element and padding with zeros if necessary.
 
 ## Motivation
 
 Ethereum's long-term goal is to allow blocks to be proved with validity proof so that chain verification is as simple and fast as possible. One of the most challenging parts of achieving that goal is proving the state of the tree, which is required for EVM execution.
 
-The current Merkle-Patricia Trie (MPT) design isn’t friendly for validity proofs for many reasons, such as using RLP for node encoding, Keccak as a hashing function, being a “tree of trees”, and not including accounts code as part of the state.
+The current Merkle-Patricia Trie (MPT) design isn't friendly for validity proofs for many reasons, such as using RLP for node encoding, Keccak as a hashing function, being a "tree of trees", and not including accounts code as part of the state.
 
-Apart from requiring a state tree design that is friendly for block validity proofs, it’s also important to have fast and small regular Merkle proofs when the amount of state to prove is small. This is useful not only for the application layer but also for supporting future protocol needs in a stateless world (e.g: inclusion lists).
+Apart from requiring a state tree design that is friendly for block validity proofs, it's also important to have fast and small regular Merkle proofs when the amount of state to prove is small. This is useful not only for the application layer but also for supporting future protocol needs in a stateless world (e.g: inclusion lists).
 
-Regarding these regular Merkle proofs in an MPT, since it’s a hexary tree, their size is quite big on average and in worst-case scenarios. Given a 2^32 size tree, the expected size for proving a single branch is `15 * 32 * log_16(2^32) = 3840`. From a worst-case block perspective, if 30M gas is used to access only a single byte of different account codes since this code isn’t chunkified, we’d need `30M/2400*(5*480+24k)=330MB`.
+Regarding these regular Merkle proofs in an MPT, since it's a hexary tree, their size is quite big on average and in worst-case scenarios. Given a 2^32 size tree, the expected size for proving a single branch is `15 * 32 * log_16(2^32) = 3840`. From a worst-case block perspective, if 30M gas is used to access only a single byte of different account codes since this code isn't chunkified, we'd need `30M/2400*(5*480+24k)=330MB`.
 
 A binary tree has a good balance between out-of-circuit and in-circuit proving. Since the tree arity is two, this reduces the size of regular Merkle proofs (i.e., `# sibilings * log_arity(N)` for arity 2 is better than for arity 16). Moreover, we propose switching from Keccak to Blake3, which has proven security and is more amenable to modern proving systems.
 
 ## Specification
 
-The keywords “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “NOT RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be interpreted as described in RFC 2119 and RFC 8174.
+The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
 
 ### Notable changes from the hexary structure
 
 - The account and storage tries are merged into a single trie.
 - RLP is no longer used.
-- The account’s code is chunked and included in the tree.
+- The account's code is chunked and included in the tree.
 - Account data (e.g., balance, nonce, first storage slots, first code-chunks) is co-located in the tree to reduce branch openings.
 
 ### Tree structure
 
-The proposed Binary Tree stores key-value entries where both the key and value are 32 bytes. The first 31-bytes of the key define the entry stem, and the last byte is the subindex in that stem. If two keys have the same stem, they live in the same “big branch” — this co-locates groups of 256 keys (i.e: keys with the same first 31-bytes).
+The proposed Binary Tree stores key-value entries where both the key and value are 32 bytes. The first 31-bytes of the key define the entry stem, and the last byte is the subindex in that stem. If two keys have the same stem, they live in the same "big branch" — this co-locates groups of 256 keys (i.e: keys with the same first 31-bytes).
 
 ![Image](../assets/eip-7864/diagram2.png)
 (More details about the purple/orange part in the "Tree embedding" section)
@@ -214,7 +234,7 @@ The account stem (green `account` node) contains accounts basic data, first 64-s
 | STEM_SUBTREE_WIDTH    | 256     |
 | MAIN_STORAGE_OFFSET   | 256**31 |
 
-_It’s a required invariant that `STEM_SUBTREE_WIDTH > CODE_OFFSET > HEADER_STORAGE_OFFSET` and that `HEADER_STORAGE_OFFSET` is greater than the leaf keys. Additionally, `MAIN_STORAGE_OFFSET` MUST be a power of `STEM_SUBTREE_WIDTH`._
+_It's a required invariant that `STEM_SUBTREE_WIDTH > CODE_OFFSET > HEADER_STORAGE_OFFSET` and that `HEADER_STORAGE_OFFSET` is greater than the leaf keys. Additionally, `MAIN_STORAGE_OFFSET` MUST be a power of `STEM_SUBTREE_WIDTH`._
 
 Note that addresses are always passed around as an `Address32`. To convert existing addresses to `Address32`, prepend with 12 zero bytes:
 
@@ -270,7 +290,7 @@ def get_tree_key_for_code_chunk(address: Address32, chunk_id: int):
     )
 ```
 
-Chunk `i` stores a 32 byte value, where bytes 1…31 are bytes `i*31...(i+1)*31 - 1` of the code (i.e. the i’th 31-byte slice of it), and byte 0 is the number of leading bytes that are part of PUSHDATA (e.g. if part of the code is `...PUSH4 99 98 | 97 96 PUSH1 128 MSTORE...` where `|` is the position where a new chunk begins, then the encoding of the latter chunk would begin `2 97 96 PUSH1 128 MSTORE` to reflect that the first 2 bytes are PUSHDATA).
+Chunk `i` stores a 32 byte value, where bytes 1…31 are bytes `i*31...(i+1)*31 - 1` of the code (i.e. the i'th 31-byte slice of it), and byte 0 is the number of leading bytes that are part of PUSHDATA (e.g. if part of the code is `...PUSH4 99 98 | 97 96 PUSH1 128 MSTORE...` where `|` is the position where a new chunk begins, then the encoding of the latter chunk would begin `2 97 96 PUSH1 128 MSTORE` to reflect that the first 2 bytes are PUSHDATA).
 
 For precision, here is an implementation of code chunkification:
 
@@ -337,7 +357,7 @@ This EIP defines a new Binary Tree that starts empty. Only new state changes are
 The proposal uses a single-layer tree structure with 32-byte keys and values for several reasons:
 
 - **Simplicity**: working with the abstraction of a key/value store makes it easier to write code dealing with the tree (e.g. database reading/writing, caching, syncing, proof creation, and verification) and upgrade it to other trees in the future. Additionally, witness gas rules can become simpler and clearer.
-- **Uniformity**: the state is uniformly spread throughout the tree; even if a single contract has millions of storage slots, the contract’s storage slots are not concentrated in one place. This is useful for state-syncing algorithms. Additionally, it helps reduce the effectiveness of unbalanced tree-filling attacks.
+- **Uniformity**: the state is uniformly spread throughout the tree; even if a single contract has millions of storage slots, the contract's storage slots are not concentrated in one place. This is useful for state-syncing algorithms. Additionally, it helps reduce the effectiveness of unbalanced tree-filling attacks.
 - **Extensibility**: account headers and code being in the same structure as storage makes it easier to extend both features and even add new structures if desired.
 
 ### SNARK friendliness and Post-Quantum security
@@ -362,18 +382,18 @@ Finally, the current state tree proposal will probably be the final state tree u
 
 ### Arity-2
 
-Binary tries have been chosen primarily because they reduce the witness size. In general, in an `N`-element tree with each element having `k` children, the average size of a branch is roughly `32 * (k-1) * log(N) / log(k)` plus a few percent for overhead. 32 is the length of a hash; the `k-1` refers to the fact that a Merkle proof needs to provide all `k-1` sister nodes at each level, and `log(N) / log(k)` is an approximation of the number of levels in the tree (e.g. a tree where each node has 5 children, with 625 nodes total, would have depth 4, as `625 = 5**4` and so `log(625) / log(5) = 4`).
+Binary tries have been chosen primarily because they reduce the witness size. In general, in an `N`-element tree with each element having `k` children, the average size of a branch is roughly `32 * (k-1) * log(N) / log(k)` plus a few percent for overhead. 32 is the length of a hash; the `k-1` refers to the fact that a Merkle proof needs to provide all `k-1` sister nodes at each level, and `log(N) / log(k)` is an approximation of the number of levels in the tree (e.g. a tree where each node has 5 children, with 625 nodes total, would have depth 4, as `625 = 5**4` and so `log(625) / log(5) = 4`).
 
-For any `N`, the expression is minimized at `k = 2`. Here’s a table of branch lengths for different `k` values assuming `N = 2**24`:
+For any `N`, the expression is minimized at `k = 2`. Here's a table of branch lengths for different `k` values assuming `N = 2**24`:
 
-| `k` (children per node) | Branch length (chunks) | Branch length (bytes) |
+| `k` (children per node) | Branch length (chunks) | Branch length (bytes) |
 | ----------------------- | ---------------------- | --------------------- |
 | 2                       | 1 * 24 = 24            | 768                   |
 | 4                       | 3 * 12 = 36            | 1152                  |
 | 8                       | 7 * 8 = 56             | 1792                  |
 | 16                      | 15 * 6 = 90            | 2880                  |
 
-Actual branch lengths might be slightly larger than this due to uneven distribution, but the pattern of `k=2` remains by far the best.
+Actual branch lengths might be slightly larger than this due to uneven distribution, but the pattern of `k=2` remains by far the best.
 
 ### Tree depth
 
@@ -391,7 +411,7 @@ State-expiry strategies such as [EIP-7736](./eip-7736.md) could still be applied
 
 The main breaking changes are:
 
-- (1) Gas costs for code chunk access can have an impact on applications’ economic viability
+- (1) Gas costs for code chunk access can have an impact on applications' economic viability
 - (2) Tree structure change makes in-EVM proofs of historical state no longer work
 
 (1) can be mitigated by increasing the gas limit while implementing this EIP, allowing the same economic viability for applications.
@@ -410,4 +430,4 @@ Needs discussion.
 
 ## **Copyright**
 
-Copyright and related rights waived via [CC0](../LICENSE.md).
+Copyright and related rights waived via [CC0](../LICENSE.md).

--- a/EIPS/eip-7864.md
+++ b/EIPS/eip-7864.md
@@ -14,27 +14,11 @@ created: 2025-01-20
 
 Introduce a new binary state tree, intended to replace the hexary patricia trees. Account and storage tries are merged into a single tree with 32-byte keys, which also contains contracts code. Account data is broken into independent leaves which  are grouped by 256 in order to provide some locality.
 
-Note: This EIP uses the Poseidon2 hash function for all tree operations. The function provides optimal performance for zero-knowledge proofs while maintaining strong security properties.
+Note: The hash function used in the current draft is not final. The current implementation uses BLAKE3 to reduce friction for EL clients experimenting with this EIP, but the final decision remains TBD. Other potential candidates include Keccak and Poseidon2. 
 
-### Poseidon2 Parameters
+For Poseidon2, there's an ongoing Ethereum Foundation cryptography initiative assessing its security properties. If Poseidon2 is selected, additional specifications will be needed for field selection (BN254 scalar field, 31-bit field elements, etc.) and encoding 32-byte values into field elements.
 
-The Poseidon2 hash function is instantiated with the following parameters:
-- Field: BN254 scalar field
-- Security level: 128 bits
-- Capacity: 1
-- Rate: 8
-- Number of full rounds: 8
-- Number of partial rounds: 56
-
-### 32-byte Value Encoding
-
-To encode 32-byte values into field elements for Poseidon2:
-1. Split the 32-byte value into 4 chunks of 8 bytes each
-2. Interpret each chunk as a little-endian uint64
-3. Map each uint64 into the field using modular reduction
-4. Use these field elements as input to Poseidon2
-
-The resulting hash is interpreted as a 32-byte value by taking the little-endian representation of the field element and padding with zeros if necessary.
+The hash function can be switched with minimal impact on implementations as this EIP progresses toward acceptance. **Do not** assume BLAKE3 is a final decision.
 
 ## Motivation
 
@@ -46,7 +30,7 @@ Apart from requiring a state tree design that is friendly for block validity pro
 
 Regarding these regular Merkle proofs in an MPT, since it's a hexary tree, their size is quite big on average and in worst-case scenarios. Given a 2^32 size tree, the expected size for proving a single branch is `15 * 32 * log_16(2^32) = 3840`. From a worst-case block perspective, if 30M gas is used to access only a single byte of different account codes since this code isn't chunkified, we'd need `30M/2400*(5*480+24k)=330MB`.
 
-A binary tree has a good balance between out-of-circuit and in-circuit proving. Since the tree arity is two, this reduces the size of regular Merkle proofs (i.e., `# sibilings * log_arity(N)` for arity 2 is better than for arity 16). Moreover, we propose switching from Keccak to Blake3, which has proven security and is more amenable to modern proving systems.
+A binary tree has a good balance between out-of-circuit and in-circuit proving. Since the tree arity is two, this reduces the size of regular Merkle proofs (i.e., `# sibilings * log_arity(N)` for arity 2 is better than for arity 16). Moreover, we propose switching from Keccak to a more proving-friendly hash function, which would be more amenable to modern proving systems.
 
 ## Specification
 
@@ -173,7 +157,7 @@ class BinaryTree:
 Define `hash(value)` as:
 
 - `hash([0x00] * 64) = [0x00] * 32`
-- `hash(value) = blake3(value)`, otherwise.
+- `hash(value) = H(value)`, where H is the selected cryptographic hash function.
 
 The `value` parameter lengths can only be 32 and 64.
 
@@ -184,7 +168,7 @@ Merkelize each node type as follows:
 - `leaf_node_hash = hash(value)`
 - `empty_node_hash = [0x00] * 32`
 
-Below is an implementation of these rules:
+Below is an implementation of these rules using BLAKE3 as a reference implementation:
 
 ```python
 def _hash(self, data):
@@ -192,7 +176,7 @@ def _hash(self, data):
         return b"\x00" * 32
 
     assert len(data) == 64 or len(data) == 32, "data must be 32 or 64 bytes"
-    return blake3(data).digest()
+    return blake3(data).digest()  # This will be replaced with the final hash function
 
 def merkelize(self):
     def _merkelize(node):
@@ -366,13 +350,26 @@ The proposed design should consider the usual complexity, performance, and effic
 
 The tree design structure tries to be simple, by not having complex branching rules. For example, in contrast with the MPT, we avoid extension nodes injected in the middle of branches. Also, RLP encoding was removed since it adds unnecessary complexity. Although complexity can be managed more easily in out-of-circuit implementations, it's valuable to help circuit implementations be as simple as possible to avoid proving overhead.
 
-The most important factor in the design is the cryptographic hash function used for merkelization. This hash function should have efficient implementations both out and in circuits. The proposed BLAKE3 hash function was chosen since it provides a good balance between:
+The most important factor in the design is the cryptographic hash function used for merkelization. This hash function should have efficient implementations both out and in circuits. The hash function selection remains TBD, with several candidates under consideration:
 
-- Out-of-circuit performance (i.e. for raw EL client execution)
-- In circuit performance (i.e. for proving in a validity proof)
-- Proven security
+1. **BLAKE3**:
+   - Good out-of-circuit performance (i.e., for raw EL client execution)
+   - Reasonable in-circuit performance for proving
+   - Well-established security properties
+   - Currently used in the reference implementation to facilitate experimentation
 
-Poseidon2 was considered to perform well in the first two points, but further research is still needed to ensure its security.
+2. **Keccak**:
+   - Already used in Ethereum, reducing implementation complexity
+   - Well-studied security properties
+   - Less efficient for circuit proving than alternatives
+
+3. **Poseidon2**:
+   - Excellent in-circuit performance for ZK proofs
+   - Potentially better proving throughput
+   - Security analysis still ongoing through EF cryptography initiative
+   - Would require additional specification for field selection and encoding
+
+The final hash function selection will balance these considerations, with particular attention to security, proving efficiency, and implementation complexity.
 
 Due to recent progress in the quantum computing field, experts estimations consider that they can become real in the 2030s. NIST suggests stop using ECC by 2030 too. Other alternatives, such as Verkle Trees, introduce a new cryptography stack to the protocol, which relies on elliptic curves that aren't post-quantum secure. This makes the current tree proposal attractive since it only depends on hash functions, which are still safe in this new paradigm.
 
@@ -399,7 +396,7 @@ Actual branch lengths might be slightly larger than this due to uneven distribut
 
 The tree design attempts to be as simple as possible considering both out-of-circuit and circuit implementations, while satisfying our throughput constraints on proving hashes.
 
-The proposed design avoids a full 248-bit depth as it would happen in a Sparse Merkle Tree (SMT). Since we don't use arithmetic hashes (e.g. Poseidon2), this is required to be aggressive in avoiding hashing load in proving systems which today is quite tight on throughput in commodity hardware. There are some tricks that could be used to mitigate this, but this also adds extra complexity to the spec.
+The proposed design avoids a full 248-bit depth as it would happen in a Sparse Merkle Tree (SMT). This approach helps reduce the hashing load in proving systems, which is currently a throughput bottleneck on commodity hardware. The choice of hash function will impact this consideration - arithmetic-friendly hash functions like Poseidon2 would have different performance characteristics than cryptographic hash functions like BLAKE3 or Keccak. There are some optimization techniques that could be applied, but they add complexity to the specification.
 
 Moreover, we could push this further trying to introduce extension nodes in middle of paths as done in a MPT, but this also adds complexity that might not worth it considering the tree should be quite balanced.
 
@@ -418,7 +415,10 @@ The main breaking changes are:
 
 ## **Test Cases**
 
-TODO <-- TODO -->
+TODO:
+- Add comprehensive test vectors for tree operations
+- Finalize hash function selection and provide test vectors for the selected function
+- Add test cases for edge cases in tree operations
 
 ## **Reference Implementation**
 


### PR DESCRIPTION
eip-7864: Keep hash function as TBD with detailed analysis

This PR updates the hash function section of the unified binary tree state EIP to:

1. Keep the hash function selection as TBD while providing detailed analysis of the candidates:
   - BLAKE3: Used in reference implementation for experimentation
   - Keccak: Already used in Ethereum, well-studied security
   - Poseidon2: Excellent for ZK proofs, pending security analysis

2. Make the specification hash-function agnostic by:
   - Updating the node merkelization section to use a generic hash function H
   - Clarifying that the reference implementation uses BLAKE3 temporarily
   - Adding context about the ongoing EF cryptography initiative for Poseidon2

3. Update the TODO section to include finalizing the hash function selection

This approach allows EL clients to experiment with the EIP using BLAKE3 while research continues on the optimal hash function choice.