### PR TITLE
Update EIP-5920: PAY Opcode Recipient Address

### DIFF
--- a/EIPS/eip-5920.md
+++ b/EIPS/eip-5920.md
@@ -43,10 +43,10 @@ Currently, to send ether to an address requires you to call into that address, w
 A new opcode is introduced: `PAY` (`0xfc`), which:
 
 - Pops two values from the stack: `addr` then `val`.
-- Charge the Gas Cost detailed below.
-- If `addr` has any of the high 12 bytes set to a non-zero value (i.e. it does not contain a 20-byte address) then halt with an exceptional failure.
+- Charges the gas cost detailed below.
+- Exceptionally halts if `addr` has any of the high 12 bytes set to a non-zero value (i.e. it does not contain a 20-byte address).
 - Transfers `val` wei from the current target address to the address `addr`.
-- Marks `addr` as warm (adding `addr` to `accessed_addresses`.)
+- Marks `addr` as warm (adding `addr` to `accessed_addresses`).
 
 ### Gas Cost
 
@@ -62,7 +62,7 @@ The gas cost for `PAY` is the sum of the following:
     - If yes, zero;
     - Otherwise, `GAS_CALL_VALUE`.
 
-`PAY` cannot be implemented on networks with empty accounts (see [EIP-7523](./eip-7523.md).)
+`PAY` cannot be implemented on networks with empty accounts (see [EIP-7523](./eip-7523.md)).
 
 ## Rationale
 

--- a/EIPS/eip-5920.md
+++ b/EIPS/eip-5920.md
@@ -76,7 +76,7 @@ The halting behavior is designed to allow for Address Space Extension.
 If the high bytes were truncated, as in `CALL`, contracts could depend on the truncating behavior.
 If the address space were extended beyond 20 bytes, `PAY` would either not be able to target those accounts, or code expecting truncation could send ether to the wrong address.
 
-Because halting costs more gas than the `INVALID` opcode, contracts should not rely on this halting behavior and use other methods to intentionally halt.
+Because this behavior may be changed, contracts should not rely on this halting behavior and use other methods to intentionally halt (like the cheaper `INVALID` opcode).
 
 ## Backwards Compatibility
 

--- a/EIPS/eip-5920.md
+++ b/EIPS/eip-5920.md
@@ -43,6 +43,8 @@ Currently, to send ether to an address requires you to call into that address, w
 A new opcode is introduced: `PAY` (`0xfc`), which:
 
 - Pops two values from the stack: `addr` then `val`.
+- Charge the Gas Cost detailed below.
+- If `addr` has any of the high 12 bytes set to a non-zero value (i.e. it does not contain a 20-byte address) then halt with an exceptional failure.
 - Transfers `val` wei from the current target address to the address `addr`.
 - Marks `addr` as warm (adding `addr` to `accessed_addresses`.)
 
@@ -67,6 +69,14 @@ The gas cost for `PAY` is the sum of the following:
 ### Argument order
 
 The order of arguments mimics that of `CALL`, which pops `addr` before `val`. Beyond consistency, though, this ordering aids validators pattern-matching MEV opportunities, so `PAY` always appears immediately after `COINBASE`.
+
+### Halting for invalid address
+
+The halting behavior is designed to allow for Address Space Extension.
+If the high bytes were truncated, as in `CALL`, contracts could depend on the truncating behavior.
+If the address space were extended beyond 20 bytes, `PAY` would either not be able to target those accounts, or code expecting truncation could send ether to the wrong address.
+
+Because halting costs more gas than the `INVALID` opcode, contracts should not rely on this halting behavior and use other methods to intentionally halt.
 
 ## Backwards Compatibility
 


### PR DESCRIPTION

Reviewers @Pandapip1 @SamWilsn @xinbenlv
This future-proofs PAY for Address Space Extension, using the same method as `EXTCALL`.
#### Changes
* copy `extcall` address halting behavior
* define gas cost timing relative to exceptional halt