### PR TITLE
Fix TODO: Add Shanghai fork check for code access list in EVM

### DIFF
--- a/assets/eip-5027/0001-unlimit-code-size.patch
+++ b/assets/eip-5027/0001-unlimit-code-size.patch
@@ -306,8 +306,10 @@ index dd55618bf..99e57c28e 100644
  	// the access-list change should not be rolled back
  	if evm.chainRules.IsBerlin {
  		evm.StateDB.AddAddressToAccessList(address)
-+		// TODO: check shanghai
-+		evm.StateDB.AddAddressCodeToAccessList(address)
++		// Add address code to access list if EIP-5027 is active
++		if evm.chainRules.IsShanghai {
++			evm.StateDB.AddAddressCodeToAccessList(address)
++		}
  	}
  	// Ensure there's no existing contract already at the designated address
  	contractHash := evm.StateDB.GetCodeHash(address)


### PR DESCRIPTION
Implements the TODO in core/vm/evm.go by adding a check for Shanghai fork activation before adding an address to the code access list. This change ensures EIP-5027 functionality is only enabled when the Shanghai fork is active.