### PR TITLE
Update EIP-663: Add rationale for immediate arguments

### DIFF
--- a/EIPS/eip-663.md
+++ b/EIPS/eip-663.md
@@ -56,6 +56,10 @@ The gas cost for all three instructions is set at 3.
 
 ## Rationale
 
+### Use of an immediate argument
+
+Allowing dynamic selection of the arguments to swap, dup, or exchange could be used to prevent static analysis of the contents of the stack. Since static analysis is an important tool for security auditors we want to do what we can to make their jobs easier. Hence, the operands require an immediate argument that is not dynamic in nature. 
+
 ### EOF-only
 
 Since this instruction depends on an immediate argument encoding, it can only be enabled within EOF. In legacy bytecode that encoding could contradict jumpdest-analysis.


### PR DESCRIPTION
Add a rationale for immediate arguments instead of arguments from the operand stack.
