### PR TITLE
Update EIP-7830: Update table to 36M gas

### DIFF
--- a/EIPS/eip-7830.md
+++ b/EIPS/eip-7830.md
@@ -21,7 +21,7 @@ The contract size limit was introduced as a measure against DoS attacks. `JUMPDE
 
 For contract developers the limit poses annoying problems, given modern contracts with good error reporting would consume more space. They are forced to work with workarounds, like "libraries" (using `DELEGATECALL`), splitting an application across regular contracts (and `CALL`-ing across), or working with proxies (e.g. the "diamond pattern"). All these solutions have resulted in suboptimal patterns, bugs in deployed contracts, and loss of funds.
 
-With EOF the `JUMPDEST`-analysis is removed from runtime and a validation process is peformed once during deployment. The initcode cost [EIP-3860](./eip-3860.md) introduced accounts for this validation too. Therefore with EOF there are no known problems for increasing the limit, because the overheads are already accounted for.
+With EOF the `JUMPDEST`-analysis is removed from runtime and a validation process is performed once during deployment. The initcode cost [EIP-3860](./eip-3860.md) introduced accounts for this validation too. Therefore, with EOF there are no known problems for increasing the limit, because the overheads are already accounted for.
 
 Storage cost is already paid per contract byte.
 
@@ -39,22 +39,22 @@ A further increase can be proposed with applying these changes to EOF.
 
 This increase still fits within the gas schedule, limiting the size to less than what gas limits allow.  In [EIP-170](./eip-170.md) the gas limit was first set "by setting the cap at a value slightly higher than what is feasible with current gas limits." At that time the gas limit had not exceeded 5M gas.
 
-A simple analysis shows contract deployements for 64 KiB contracts to be between 14M and 16M gas, roughly close to the current 15M target.
+A simple analysis shows contract deployments for 64 KiB contracts to be between 14M and 16M gas, roughly close to the current 15M target.
 
-|                     |    Cancun |   This EIP |    30M Gas | Max Initcode |
+|                     |    Cancun |   This EIP |    36M Gas | Max Initcode |
 |---------------------|----------:|-----------:|-----------:|-------------:|
 | **Initcode bytes**  |       200 |        200 |        200 |       65,536 |
-| **Deployed Bytes**  |    24,576 |     65,536 |    137,656 |       65,536 |
+| **Deployed Bytes**  |    24,576 |     65,536 |    165,331 |       65,536 |
 | **Zero byte ratio** |       10% |        10% |        10% |          10% |
 | **Initcode Cost**   |      4/16 |       4/16 |       4/16 |         4/16 |
 |                     |           |            |            |              |
 | **Intrinsic Gas**   |    53,000 |     53,000 |     53,000 |       53,000 |
-| **Calldata Gas**    |   366,685 |    972,893 |  2,043,880 |    1,939,866 |
-| **EIP-3860 Gas**    |    49,552 |    131,472 |    276,200 |      262,144 |
+| **Calldata Gas**    |   366,685 |    972,893 |  2,449,859 |    1,939,866 |
+| **EIP-3860 Gas**    |    49,552 |    131,472 |    331,062 |      262,144 |
 | **EVM Execution**   |   100,000 |    100,000 |    100,000 |      100,000 |
-| **Code Deposit**    | 4,915,200 | 13,107,200 | 27,580,000 |   13,107,200 |
+| **Code Deposit**    | 4,915,200 | 13,107,200 | 33,066,200 |   13,107,200 |
 |                     |           |            |            |              |
-| **Total Cost**      | 5,484,437 | 14,364,565 | 30,000,181 |   15,462,210 |
+| **Total Cost**      | 5,484,437 | 14,364,565 | 36,000,121 |   15,462,210 |
 
 Note that the Max 30M gas contract size of 135 KiB is outside the limits of what is proposed in this EIP and is included to show what it would take to exceed current gas limits.
 
@@ -66,7 +66,7 @@ This is a backwards compatible change. Existing contracts are unaffected, and on
 
 Given the analysis cost is paid as part of deployment, the size of contract should have no effect on the runtime.
 
-A more thorough analysis may be needed to detemine whether the proposed limit poses any risk because of client storage architectures.
+A more thorough analysis may be needed to determine whether the proposed limit poses any risk because of client storage architectures.
 
 ## Copyright
 


### PR DESCRIPTION
Now that the standard gas is 18/36 update the gas table to reflect the new maximum. Also, fix tpyos.
