### PR TITLE
Update EIP-6466: Update receipts-root reference

### DIFF
--- a/EIPS/eip-6466.md
+++ b/EIPS/eip-6466.md
@@ -108,7 +108,7 @@ The `logs_bloom` and intermediate state `root` (Homestead scheme) are not presen
 
 ### Execution block header changes
 
-The [execution block header's `receipts-root`](https://github.com/ethereum/devp2p/blob/6b259a7003b4bfb18365ba690f4b00ba8a26393b/caps/eth.md#block-encoding-and-validity) is transitioned from MPT to SSZ.
+The [execution block header's `receipts-root`](https://github.com/ethereum/devp2p/blob/5713591d0366da78a913a811c7502d9ca91d29a8/caps/eth.md#block-encoding-and-validity) is transitioned from MPT to SSZ.
 
 ```python
 receipts = List[Receipt, MAX_TRANSACTIONS_PER_PAYLOAD](


### PR DESCRIPTION
This PR updates the reference link to the receipts-root implementation in the execution block header changes section.

**Changes:**
- Updated the GitHub link to point to the latest implementation of receipts-root
