### PR TITLE
Update EIP-template: Add chain-specific considerations

### DIFF
--- a/eip-template.md
+++ b/eip-template.md
@@ -81,6 +81,21 @@ TBD
 
 No backward compatibility issues found.
 
+## Chain-specific Considerations
+
+<!--
+
+  This section is optional.
+
+  All EIPs that require changes for non-mainnet chains must include a section describing these changes. This includes considerations that must be made for testnets, Gnosis chain, and EVM-compatible L2s.
+
+  The current placeholder is acceptable for a draft.
+
+  TODO: Remove this comment before submitting
+-->
+
+No chain-specific considerations.
+
 ## Test Cases
 
 <!--


### PR DESCRIPTION
Added a section to the EIP template to address any chain-specific considerations.

The aim is to reduce the likelihood of incidents like [the recent one on Sepolia](https://blog.ethereum.org/2025/03/05/sepolia-pectra-incident), which are caused by minor differences between chains. If EIP authors address these considerations then such problems could be caught much earlier.