### PR TITLE
Update EIP-6110: Spec `parse_deposit_data`

### DIFF
--- a/EIPS/eip-6110.md
+++ b/EIPS/eip-6110.md
@@ -81,7 +81,7 @@ def parse_deposit_data(deposit_event_data):
     Parses deposit data from DepositContract.DepositEvent data.
     """
 
-    # TODO: verify byte length of deposit_event_data? Should be 576. Should this be part of the spec? (Yes?)
+    # TODO: verify byte length of deposit_event_data? Should be 576. Should this be part of the spec? 
     
     """ 
         The deposit event is encoded as:
@@ -94,31 +94,17 @@ def parse_deposit_data(deposit_event_data):
             );
     """
 
-    # Start offset of data reading skips over the first 5 32-byte values
-    # which represents the dynamic size of the encoded bytes event data
-    # The size itself is encoded in a 32-byte, so skip over this as well 
-    # to arrive at the first actual data offset to be read (pubkey)
-    currentOffset = 32 * 5 + 32
+    PUBKEY_OFFSET = 192
+    WITHDRAWAL_OFFSET = 288
+    AMOUNT_OFFSET = 352
+    SIGNATURE_OFFSET = 416
+    INDEX_OFFSET = 544
 
-    # Read the pubkey data
-    pubkey = deposit_event_data[currentOffset:currentOffset + 48]
-    # The ABI data is encoded in 32-byte chunks, so the 64 bytes are reserved for the data
-    # The next 32 bytes are reserved for the size of the next item (withdrawals) so skip over this as well
-    currentOffset += 48 + 16 + 32
-
-    withdrawal_credentials = deposit_event_data[currentOffset:currentOffset + 32]
-    # This data fits in one 32-byte chunk. Also skip over the size 32-bytes of the next item (amount)
-    currentOffset += 32 + 32
-
-    amount = deposit_event_data[currentOffset:currentOffset + 8]
-    # This data fits in a 32 byte chunk. Also skip over the size 32-bytes of the next item (signature)
-    currentOffset += 8 + 24 + 32
-
-    signature = deposit_event_data[currentOffset:currentOffset + 96]
-    # This data fits in three 32 byte chunks. Also skip over the size 32-bytes of the next item (index)
-    currentOffset += 96 + 32
-
-    index = deposit_event_data[currentOffset:currentOffset + 8]
+    pubkey = deposit_event_data[PUBKEY_OFFSET:PUBKEY_OFFSET + 48]
+    withdrawal_credentials = deposit_event_data[WITHDRAWAL_OFFSET:WITHDRAWAL_OFFSET + 32]
+    amount = deposit_event_data[AMOUNT_OFFSET:AMOUNT_OFFSET + 8]
+    signature = deposit_event_data[SIGNATURE_OFFSET:SIGNATURE_OFFSET + 96]
+    index = deposit_event_data[INDEX_OFFSET:INDEX_OFFSET + 8]
     
     return [pubkey, withdrawal_credentials, amount, signature, index]
 

--- a/EIPS/eip-6110.md
+++ b/EIPS/eip-6110.md
@@ -76,15 +76,17 @@ Beginning with the `FORK_BLOCK`, each deposit accumulated in the block **MUST** 
 in the order they appear in the logs. To illustrate:
 
 ```python
-def parse_deposit_data(deposit_event_data):
+def parse_deposit_data(deposit_event_data) -> bytes[]:
+  """
+  Parses deposit data from DepositContract.DepositEvent data
+  """
+  pass
+
+def is_valid_deposit_event_data(deposit_event_data: bytes) -> bool:
     """
-    Parses raw emitted EVM log data to decode the request data
-    This method throws if trying to read out-of-bounds
-    with respect to the `deposit_event_data`, which invalidates the block
+    Verifies the layout of the DepositEvent. Returns `False` if the layout is unsupported,
+    `True` if the layout is of the expected format.
     """
-    # These offsets points are data pointers which first encode the 
-    # size of the data (which is always 32 bytes)
-    # The data itself (of this size) is then appended after the size 32 bytes
     pubkey_offset = int.from_bytes(deposit_event_data[0:32], byteorder='big')
     withdrawal_credentials_offset = int.from_bytes(deposit_event_data[32:64], byteorder='big')
     amount_offset = int.from_bytes(deposit_event_data[64:96], byteorder='big')
@@ -98,13 +100,18 @@ def parse_deposit_data(deposit_event_data):
     signature_size = int.from_bytes(deposit_event_data[signature_offset:signature_offset+32], byteorder='big')
     index_size = int.from_bytes(deposit_event_data[index_offset:index_offset+32], byteorder='big')
 
-    pubkey = deposit_event_data[pubkey_offset + 32:pubkey_offset + 32 + pubkey_size]
-    withdrawal_credentials = deposit_event_data[withdrawal_credentials_offset + 32:withdrawal_credentials_offset + 32 + withdrawal_credentials_size]
-    amount = deposit_event_data[amount_offset + 32:amount_offset + 32 + amount_size]
-    signature = deposit_event_data[signature_offset + 32:signature_offset + 32 + signature_size]
-    index = deposit_event_data[index_offset + 32:index_offset + 32 + index_size]
-    
-    return [pubkey, withdrawal_credentials, amount, signature, index]
+    return (
+        pubkey_offset == 160
+        and withdrawal_credentials_offset == 256
+        and amount_offset == 320
+        and signature_offset == 384
+        and index_offset == 512
+        and pubkey_size == 48
+        and withdrawal_credentials_size == 32
+        and amount_size == 8
+        and signature_size == 96
+        and index_size == 8
+    )
 
 def event_data_to_deposit_request(deposit_event_data) -> bytes:
     deposit_data = parse_deposit_data(deposit_event_data)
@@ -121,11 +128,11 @@ def get_deposit_request_data(receipts)
     deposit_requests = []
     for receipt in receipts:
         for log in receipt.logs:
-            is_deposit_event = (len(log.topics) > 0 and log.topics[0] == DEPOSIT_EVENT_SIGNATURE_HASH)
-            if log.address == DEPOSIT_CONTRACT_ADDRESS and is_deposit_event:
-                assert len(log.data) === 576, 'invalid deposit log: not required length of 576 bytes'
-                deposit_request = event_data_to_deposit_request(log.data)
-                deposit_requests.append(deposit_request)
+            if log.address == DEPOSIT_CONTRACT_ADDRESS
+                if (len(log.topics) > 0 and log.topics[0] == DEPOSIT_EVENT_SIGNATURE_HASH):
+                    assert is_valid_deposit_event_data(log.data), 'invalid deposit log: unsupported data layout'
+                    deposit_request = event_data_to_deposit_request(log.data)
+                    deposit_requests.append(deposit_request)
 
     # Concatenate list of deposit request data
     return b''.join(deposit_requests)

--- a/EIPS/eip-6110.md
+++ b/EIPS/eip-6110.md
@@ -132,7 +132,7 @@ def get_deposit_request_data(receipts)
     for receipt in receipts:
         for log in receipt.logs:
             if log.address == DEPOSIT_CONTRACT_ADDRESS
-                if (len(log.topics) > 0 and log.topics[0] == DEPOSIT_EVENT_SIGNATURE_HASH):
+                if len(log.topics) > 0 and log.topics[0] == DEPOSIT_EVENT_SIGNATURE_HASH:
                     assert is_valid_deposit_event_data(log.data), 'invalid deposit log: unsupported data layout'
                     deposit_request = event_data_to_deposit_request(log.data)
                     deposit_requests.append(deposit_request)

--- a/EIPS/eip-6110.md
+++ b/EIPS/eip-6110.md
@@ -82,17 +82,6 @@ def parse_deposit_data(deposit_event_data):
     """
 
     # TODO: verify byte length of deposit_event_data? Should be 576. Should this be part of the spec? 
-    
-    """ 
-        The deposit event is encoded as:
-            event DepositEvent(
-                bytes pubkey,
-                bytes withdrawal_credentials,
-                bytes amount,
-                bytes signature,
-                bytes index
-            );
-    """
 
     PUBKEY_OFFSET = 192
     WITHDRAWAL_OFFSET = 288

--- a/EIPS/eip-6110.md
+++ b/EIPS/eip-6110.md
@@ -76,11 +76,51 @@ Beginning with the `FORK_BLOCK`, each deposit accumulated in the block **MUST** 
 in the order they appear in the logs. To illustrate:
 
 ```python
-def parse_deposit_data(deposit_event_data) -> bytes[]:
-  """
-  Parses deposit data from DepositContract.DepositEvent data
-  """
-  pass
+def parse_deposit_data(deposit_event_data):
+    """
+    Parses deposit data from DepositContract.DepositEvent data.
+    """
+
+    # TODO: verify byte length of deposit_event_data? Should be 576. Should this be part of the spec? (Yes?)
+    
+    """ 
+        The deposit event is encoded as:
+            event DepositEvent(
+                bytes pubkey,
+                bytes withdrawal_credentials,
+                bytes amount,
+                bytes signature,
+                bytes index
+            );
+    """
+
+    # Start offset of data reading skips over the first 5 32-byte values
+    # which represents the dynamic size of the encoded bytes event data
+    # The size itself is encoded in a 32-byte, so skip over this as well 
+    # to arrive at the first actual data offset to be read (pubkey)
+    currentOffset = 32 * 5 + 32
+
+    # Read the pubkey data
+    pubkey = deposit_event_data[currentOffset:currentOffset + 48]
+    # The ABI data is encoded in 32-byte chunks, so the 64 bytes are reserved for the data
+    # The next 32 bytes are reserved for the size of the next item (withdrawals) so skip over this as well
+    currentOffset += 48 + 16 + 32
+
+    withdrawal_credentials = deposit_event_data[currentOffset:currentOffset + 32]
+    # This data fits in one 32-byte chunk. Also skip over the size 32-bytes of the next item (amount)
+    currentOffset += 32 + 32
+
+    amount = deposit_event_data[currentOffset:currentOffset + 8]
+    # This data fits in a 32 byte chunk. Also skip over the size 32-bytes of the next item (signature)
+    currentOffset += 8 + 24 + 32
+
+    signature = deposit_event_data[currentOffset:currentOffset + 96]
+    # This data fits in three 32 byte chunks. Also skip over the size 32-bytes of the next item (index)
+    currentOffset += 96 + 32
+
+    index = deposit_event_data[currentOffset:currentOffset + 8]
+    
+    return [pubkey, withdrawal_credentials, amount, signature, index]
 
 def event_data_to_deposit_request(deposit_event_data) -> bytes:
     deposit_data = parse_deposit_data(deposit_event_data)

--- a/EIPS/eip-6110.md
+++ b/EIPS/eip-6110.md
@@ -79,30 +79,30 @@ in the order they appear in the logs. To illustrate:
 def parse_deposit_data(deposit_event_data):
     """
     Parses raw emitted EVM log data to decode the request data
+    This method throws if trying to read out-of-bounds
+    with respect to the `deposit_event_data`, which invalidates the block
     """
-
-
     # These offsets points are data pointers which first encode the 
     # size of the data (which is always 32 bytes)
     # The data itself (of this size) is then appended after the size 32 bytes
-    PUBKEY_OFFSET = deposit_event_data[0:32]
-    WITHDRAWAL_CREDENTIALS_OFFSET = deposit_event_data[32:64]
-    AMOUNT_OFFSET = deposit_event_data[64:96]
-    SIGNATURE_OFFSET = deposit_event_data[96:128]
-    INDEX_OFFSET = deposit_event_data[128:160]
+    pubkey_offset = int.from_bytes(deposit_event_data[0:32], byteorder='big')
+    withdrawal_credentials_offset = int.from_bytes(deposit_event_data[32:64], byteorder='big')
+    amount_offset = int.from_bytes(deposit_event_data[64:96], byteorder='big')
+    signature_offset = int.from_bytes(deposit_event_data[96:128], byteorder='big')
+    index_offset = int.from_bytes(deposit_event_data[128:160], byteorder='big')
 
     # These sizes are the sizes of the relevant data
-    PUBKEY_SIZE = deposit_event_data[PUBKEY_OFFSET:PUBKEY_OFFSET+32]
-    WITHDRAWAL_CREDENTIALS_SIZE = deposit_event_data[WITHDRAWAL_CREDENTIALS_OFFSET:WITHDRAWAL_CREDENTIALS_OFFSET+32]
-    AMOUNT_SIZE = deposit_event_data[AMOUNT_OFFSET:AMOUNT_OFFSET+32]
-    SIGNATURE_SIZE = deposit_event_data[SIGNATURE_OFFSET:SIGNATURE_OFFSET+32]
-    INDEX_SIZE = deposit_event_data[INDEX_OFFSET:INDEX_OFFSET+32]
+    pubkey_size = deposit_event_data[pubkey_offset:pubkey_offset+32]
+    withdrawal_credentials_size = deposit_event_data[withdrawal_credentials_offset:withdrawal_credentials_offset+32]
+    amount_size = deposit_event_data[amount_offset:amount_offset+32]
+    signature_size = deposit_event_data[signature_offset:signature_offset+32]
+    index_size = deposit_event_data[index_offset:index_offset+32]
 
-    pubkey = deposit_event_data[PUBKEY_OFFSET + 32:PUBKEY_OFFSET + 32 + PUBKEY_SIZE]
-    withdrawal_credentials = deposit_event_data[WITHDRAWAL_CREDENTIALS_OFFSET + 32:WITHDRAWAL_CREDENTIALS_OFFSET + 32 + WITHDRAWAL_CREDENTIALS_SIZE]
-    amount = deposit_event_data[AMOUNT_OFFSET + 32:AMOUNT_OFFSET + 32 + AMOUNT_SIZE]
-    signature = deposit_event_data[SIGNATURE_OFFSET + 32:SIGNATURE_OFFSET + 32 + SIGNATURE_SIZE]
-    index = deposit_event_data[INDEX_OFFSET + 32:INDEX_OFFSET + 32 + INDEX_SIZE]
+    pubkey = deposit_event_data[pubkey_offset + 32:pubkey_offset + 32 + pubkey_size]
+    withdrawal_credentials = deposit_event_data[withdrawal_credentials_offset + 32:withdrawal_credentials_offset + 32 + withdrawal_credentials_size]
+    amount = deposit_event_data[amount_offset + 32:amount_offset + 32 + amount_size]
+    signature = deposit_event_data[signature_offset + 32:signature_offset + 32 + signature_size]
+    index = deposit_event_data[index_offset + 32:index_offset + 32 + index_size]
     
     return [pubkey, withdrawal_credentials, amount, signature, index]
 
@@ -123,6 +123,7 @@ def get_deposit_request_data(receipts)
         for log in receipt.logs:
             is_deposit_event = (len(log.topics) > 0 and log.topics[0] == DEPOSIT_EVENT_SIGNATURE_HASH)
             if log.address == DEPOSIT_CONTRACT_ADDRESS and is_deposit_event:
+                assert len(log.data) === 576, 'invalid deposit log: not required length of 576 bytes'
                 deposit_request = event_data_to_deposit_request(log.data)
                 deposit_requests.append(deposit_request)
 

--- a/EIPS/eip-6110.md
+++ b/EIPS/eip-6110.md
@@ -78,22 +78,31 @@ in the order they appear in the logs. To illustrate:
 ```python
 def parse_deposit_data(deposit_event_data):
     """
-    Parses deposit data from DepositContract.DepositEvent data.
+    Parses raw emitted EVM log data to decode the request data
     """
 
-    # TODO: verify byte length of deposit_event_data? Should be 576. Should this be part of the spec? 
 
-    PUBKEY_OFFSET = 192
-    WITHDRAWAL_OFFSET = 288
-    AMOUNT_OFFSET = 352
-    SIGNATURE_OFFSET = 416
-    INDEX_OFFSET = 544
+    # These offsets points are data pointers which first encode the 
+    # size of the data (which is always 32 bytes)
+    # The data itself (of this size) is then appended after the size 32 bytes
+    PUBKEY_OFFSET = deposit_event_data[0:32]
+    WITHDRAWAL_CREDENTIALS_OFFSET = deposit_event_data[32:64]
+    AMOUNT_OFFSET = deposit_event_data[64:96]
+    SIGNATURE_OFFSET = deposit_event_data[96:128]
+    INDEX_OFFSET = deposit_event_data[128:160]
 
-    pubkey = deposit_event_data[PUBKEY_OFFSET:PUBKEY_OFFSET + 48]
-    withdrawal_credentials = deposit_event_data[WITHDRAWAL_OFFSET:WITHDRAWAL_OFFSET + 32]
-    amount = deposit_event_data[AMOUNT_OFFSET:AMOUNT_OFFSET + 8]
-    signature = deposit_event_data[SIGNATURE_OFFSET:SIGNATURE_OFFSET + 96]
-    index = deposit_event_data[INDEX_OFFSET:INDEX_OFFSET + 8]
+    # These sizes are the sizes of the relevant data
+    PUBKEY_SIZE = deposit_event_data[PUBKEY_OFFSET:PUBKEY_OFFSET+32]
+    WITHDRAWAL_CREDENTIALS_SIZE = deposit_event_data[WITHDRAWAL_CREDENTIALS_OFFSET:WITHDRAWAL_CREDENTIALS_OFFSET+32]
+    AMOUNT_SIZE = deposit_event_data[AMOUNT_OFFSET:AMOUNT_OFFSET+32]
+    SIGNATURE_SIZE = deposit_event_data[SIGNATURE_OFFSET:SIGNATURE_OFFSET+32]
+    INDEX_SIZE = deposit_event_data[INDEX_OFFSET:INDEX_OFFSET+32]
+
+    pubkey = deposit_event_data[PUBKEY_OFFSET + 32:PUBKEY_OFFSET + 32 + PUBKEY_SIZE]
+    withdrawal_credentials = deposit_event_data[WITHDRAWAL_CREDENTIALS_OFFSET + 32:WITHDRAWAL_CREDENTIALS_OFFSET + 32 + WITHDRAWAL_CREDENTIALS_SIZE]
+    amount = deposit_event_data[AMOUNT_OFFSET + 32:AMOUNT_OFFSET + 32 + AMOUNT_SIZE]
+    signature = deposit_event_data[SIGNATURE_OFFSET + 32:SIGNATURE_OFFSET + 32 + SIGNATURE_SIZE]
+    index = deposit_event_data[INDEX_OFFSET + 32:INDEX_OFFSET + 32 + INDEX_SIZE]
     
     return [pubkey, withdrawal_credentials, amount, signature, index]
 

--- a/EIPS/eip-6110.md
+++ b/EIPS/eip-6110.md
@@ -112,7 +112,7 @@ def get_deposit_request_data(receipts)
     deposit_requests = []
     for receipt in receipts:
         for log in receipt.logs:
-            is_deposit_event = (len(log.topics) > 0 and log.topics[0] == DEPOSIT_EVENT_SIGNATURE_HASH)
+            is_deposit_event = (len(log.topics) > 0 and log.topics[0] == DEPOSIT_EVENT_SIGNATURE_HASH and len(log.data) === 576)
             if log.address == DEPOSIT_CONTRACT_ADDRESS and is_deposit_event:
                 deposit_request = event_data_to_deposit_request(log.data)
                 deposit_requests.append(deposit_request)

--- a/EIPS/eip-6110.md
+++ b/EIPS/eip-6110.md
@@ -92,11 +92,11 @@ def parse_deposit_data(deposit_event_data):
     index_offset = int.from_bytes(deposit_event_data[128:160], byteorder='big')
 
     # These sizes are the sizes of the relevant data
-    pubkey_size = deposit_event_data[pubkey_offset:pubkey_offset+32]
-    withdrawal_credentials_size = deposit_event_data[withdrawal_credentials_offset:withdrawal_credentials_offset+32]
-    amount_size = deposit_event_data[amount_offset:amount_offset+32]
-    signature_size = deposit_event_data[signature_offset:signature_offset+32]
-    index_size = deposit_event_data[index_offset:index_offset+32]
+    pubkey_size = int.from_bytes(deposit_event_data[pubkey_offset:pubkey_offset+32], byteorder='big')
+    withdrawal_credentials_size = int.from_bytes(deposit_event_data[withdrawal_credentials_offset:withdrawal_credentials_offset+32], byteorder='big')
+    amount_size = int.from_bytes(deposit_event_data[amount_offset:amount_offset+32], byteorder='big')
+    signature_size = int.from_bytes(deposit_event_data[signature_offset:signature_offset+32], byteorder='big')
+    index_size = int.from_bytes(deposit_event_data[index_offset:index_offset+32], byteorder='big')
 
     pubkey = deposit_event_data[pubkey_offset + 32:pubkey_offset + 32 + pubkey_size]
     withdrawal_credentials = deposit_event_data[withdrawal_credentials_offset + 32:withdrawal_credentials_offset + 32 + withdrawal_credentials_size]

--- a/EIPS/eip-6110.md
+++ b/EIPS/eip-6110.md
@@ -87,6 +87,9 @@ def is_valid_deposit_event_data(deposit_event_data: bytes) -> bool:
     Verifies the layout of the DepositEvent. Returns `False` if the layout is unsupported,
     `True` if the layout is of the expected format.
     """
+    if len(deposit_event_data) != 576:
+        return False
+
     pubkey_offset = int.from_bytes(deposit_event_data[0:32], byteorder='big')
     withdrawal_credentials_offset = int.from_bytes(deposit_event_data[32:64], byteorder='big')
     amount_offset = int.from_bytes(deposit_event_data[64:96], byteorder='big')

--- a/EIPS/eip-6110.md
+++ b/EIPS/eip-6110.md
@@ -121,7 +121,7 @@ def get_deposit_request_data(receipts)
     deposit_requests = []
     for receipt in receipts:
         for log in receipt.logs:
-            is_deposit_event = (len(log.topics) > 0 and log.topics[0] == DEPOSIT_EVENT_SIGNATURE_HASH and len(log.data) === 576)
+            is_deposit_event = (len(log.topics) > 0 and log.topics[0] == DEPOSIT_EVENT_SIGNATURE_HASH)
             if log.address == DEPOSIT_CONTRACT_ADDRESS and is_deposit_event:
                 deposit_request = event_data_to_deposit_request(log.data)
                 deposit_requests.append(deposit_request)

--- a/EIPS/eip-6110.md
+++ b/EIPS/eip-6110.md
@@ -96,6 +96,15 @@ def is_valid_deposit_event_data(deposit_event_data: bytes) -> bool:
     signature_offset = int.from_bytes(deposit_event_data[96:128], byteorder='big')
     index_offset = int.from_bytes(deposit_event_data[128:160], byteorder='big')
 
+    if (
+        pubkey_offset != 160
+        or withdrawal_credentials_offset != 256
+        or amount_offset != 320
+        or signature_offset != 384
+        or index_offset != 512
+    ):
+        return False
+
     # These sizes are the sizes of the relevant data
     pubkey_size = int.from_bytes(deposit_event_data[pubkey_offset:pubkey_offset+32], byteorder='big')
     withdrawal_credentials_size = int.from_bytes(deposit_event_data[withdrawal_credentials_offset:withdrawal_credentials_offset+32], byteorder='big')
@@ -104,12 +113,7 @@ def is_valid_deposit_event_data(deposit_event_data: bytes) -> bool:
     index_size = int.from_bytes(deposit_event_data[index_offset:index_offset+32], byteorder='big')
 
     return (
-        pubkey_offset == 160
-        and withdrawal_credentials_offset == 256
-        and amount_offset == 320
-        and signature_offset == 384
-        and index_offset == 512
-        and pubkey_size == 48
+        pubkey_size == 48
         and withdrawal_credentials_size == 32
         and amount_size == 8
         and signature_size == 96

--- a/EIPS/eip-6110.md
+++ b/EIPS/eip-6110.md
@@ -131,7 +131,7 @@ def get_deposit_request_data(receipts)
     deposit_requests = []
     for receipt in receipts:
         for log in receipt.logs:
-            if log.address == DEPOSIT_CONTRACT_ADDRESS
+            if log.address == DEPOSIT_CONTRACT_ADDRESS:
                 if len(log.topics) > 0 and log.topics[0] == DEPOSIT_EVENT_SIGNATURE_HASH:
                     assert is_valid_deposit_event_data(log.data), 'invalid deposit log: unsupported data layout'
                     deposit_request = event_data_to_deposit_request(log.data)


### PR DESCRIPTION
EIP-6110 currently does not specify how to parse the deposit event data. This PR adds the specific layout of the mainnet (and Sepolia) log data to the spec. If the deposit contract logs a DepositEvent but the layout is incorrect, the block will be marked as invalid, because the deposit contract does not adhere the deposit event layout.

Note that this approach does only spec the layout of the log: the actual bytecode of the contract is not specified. Therefore, mainnet, sepolia and holesky all match this spec. (Mainnet/Holesky bytecode is the same: Sepolia is however a "permissioned" ERC20-token contract (instead of accepting native Eth deposits) and thus has different bytecode. This thus allows any bytecode contract to be valid, given that the `DepositEvent` as being LOG-ed having the layout per this PR)