### PR TITLE
Update EIP-1898: Move to Final

### DIFF
--- a/EIPS/eip-1898.md
+++ b/EIPS/eip-1898.md
@@ -5,7 +5,6 @@ description: Add `blockHash` option to JSON-RPC methods that currently support d
 author: Charles Cooper (@charles-cooper)
 discussions-to: https://ethereum-magicians.org/t/eip-1898-add-blockhash-option-to-json-rpc-methods-that-currently-support-defaultblock-parameter/11757
 status: Final
-last-call-deadline: 2025-03-04
 type: Standards Track
 category: Interface
 created: 2019-04-01

--- a/EIPS/eip-1898.md
+++ b/EIPS/eip-1898.md
@@ -4,7 +4,7 @@ title: Add `blockHash` to defaultBlock methods
 description: Add `blockHash` option to JSON-RPC methods that currently support defaultBlock parameter.
 author: Charles Cooper (@charles-cooper)
 discussions-to: https://ethereum-magicians.org/t/eip-1898-add-blockhash-option-to-json-rpc-methods-that-currently-support-defaultblock-parameter/11757
-status: Last Call
+status: Final
 last-call-deadline: 2025-03-04
 type: Standards Track
 category: Interface


### PR DESCRIPTION
Moving this EIP to Final. This eip has been widely supported by clients, devtools and libraries for multiple years, so no change or breakage is expected. I'm doing this mostly to clean up the ethereum ecosystem, especially with newcomers in mind.

Thanks @charles-cooper for creating the EIP and agreeing to go through this process.