### PR TITLE
Update EIP-7873: EOF - flag to include caller in Creator Contract

### DIFF
--- a/EIPS/eip-7873.md
+++ b/EIPS/eip-7873.md
@@ -168,7 +168,9 @@ At the start of the block in which [EIP-3540](./eip-3540.md) activates, set the 
     if lt(size, 65) { revert(0, 0) }
 
     // copy tx_initcode_hash, salt, unsafe_flag and init_data to memory to hash.
-    // note that the unsafe_flag is included to prevent pre-image attacks on the two paths to calculate salt below.
+    // note that the unsafe_flag is included to prevent hash collisions between the two branches:
+    //   - unsafe_flag == 0, caller's address is appended by the code
+    //   - unsafe_flag == 1, caller's address is sent via init_data
     calldatacopy(0, 0, size)
 
     // mask out the 31 bytes that follow the flag in input data

--- a/EIPS/eip-7873.md
+++ b/EIPS/eip-7873.md
@@ -160,36 +160,42 @@ At the start of the block in which [EIP-3540](./eip-3540.md) activates, set the 
 
     /// tx_initcode_hash and salt are 32 bytes wide, unsafe_flag is 1 byte wide, init_data can be any width.
     /// If unsafe_flag is 0x00, `CALLER` is included in the salt and impacts the target address of the created account.
-    /// If unsafe_flag is non-zero, `CALLER` is excluded. Deployment by any sender will result in same target address. 
+    /// If unsafe_flag is non-zero, `CALLER` is excluded, with 32 zero-bytes used instead. Deployment by any sender will result in same target address. 
     /// Deployments using non-zero unsafe_flag are susceptible to front-running.
 
     // init_data.length can be 0, but the first 65 bytes are mandatory
     let size := calldatasize()
     if lt(size, 65) { revert(0, 0) }
 
-    // copy tx_initcode_hash, salt, unsafe_flag and init_data to memory to hash.
-    // note that the unsafe_flag is included to prevent hash collisions between the two branches:
-    //   - unsafe_flag == 0, caller's address is appended by the code
-    //   - unsafe_flag == 1, caller's address is sent via init_data
-    calldatacopy(0, 0, size)
+    // copy tx_initcode_hash and salt to memory to hash.
+    // note that the unsafe_flag doesn't need to be included. If set to non-zero, 32 zero-bytes
+    // are used instead of the CALLER address bytes, which prevents hash collisions between
+    // deployments using unsafe_flag and those not using it.
+    calldatacopy(0, 0, 64)
 
     // mask out the 31 bytes that follow the flag in input data
     let unsafe_flag := byte(0, calldataload(64))
 
     if iszero(unsafe_flag) {
-        // Include sender into salt just after init_data
-        mstore(size, caller())
-        let final_salt := keccak256(0, size + 32)
+        // store caller in memory to hash, just after salt
+        mstore(64, caller())
     } else {
-        // Exclude sender from salt - susceptible to front-running
-        let final_salt := keccak256(0, size)
+        // exclude sender from salt - susceptible to front-running
+        // assuming no bytes were written to memory word at 64 and it's all zeros
     }
 
-    let tx_initcode_hash := calldataload(0)
     let init_data_size := sub(size, 65)
 
+    // copy init_data to memory to hash, just after caller (or zeros)
+    calldatacopy(96, 65, init_data_size)
+
+    // final_salt = keccak256(tx_initcode_hash | salt | caller_or_zeros | init_data)
+    let final_salt := keccak256(0, 96 + init_data_size)
+
+    let tx_initcode_hash := calldataload(0)
+
     // reuse init_data which has been already copied to memory above
-    let ret := txcreate(tx_initcode_hash, callvalue(), final_salt, 65, init_data_size)
+    let ret := txcreate(tx_initcode_hash, callvalue(), final_salt, 96, init_data_size)
 
     if iszero(ret) {
         let ret_data_size := returndatasize()

--- a/EIPS/eip-7873.md
+++ b/EIPS/eip-7873.md
@@ -155,10 +155,10 @@ At the start of the block in which [EIP-3540](./eip-3540.md) activates, set the 
 
 ```solidity
 {
-    /// Takes [unsafe_flag][tx_initcode_hash][salt][init_data] as input,
+    /// Takes [tx_initcode_hash][salt][unsafe_flag][init_data] as input,
     /// creates contract and returns the address or failure otherwise.
 
-    /// unsafe_flag is 1 byte wide. tx_initcode_hash and salt are 32 bytes wide, init_data can be any width.
+    /// tx_initcode_hash and salt are 32 bytes wide, unsafe_flag is 1 byte wide, init_data can be any width.
     /// If unsafe_flag is 0x00, `CALLER` is included in the salt and impacts the target address of the created account.
     /// If unsafe_flag is non-zero, `CALLER` is excluded. Deployment by any sender will result in same target address. 
     /// Deployments using non-zero unsafe_flag are susceptible to front-running.
@@ -167,12 +167,12 @@ At the start of the block in which [EIP-3540](./eip-3540.md) activates, set the 
     let size := calldatasize()
     if lt(size, 65) { revert(0, 0) }
 
-    // copy unsafe_flag, tx_initcode_hash, salt and init_data to memory to hash.
+    // copy tx_initcode_hash, salt, unsafe_flag and init_data to memory to hash.
     // note that the unsafe_flag is included to prevent pre-image attacks on the two paths to calculate salt below.
     calldatacopy(0, 0, size)
 
     // mask out the 31 bytes that follow the flag in input data
-    let unsafe_flag := calldataload(0) & (0xff << 248)
+    let unsafe_flag := calldataload(64) & (0xff << 248)
 
     if iszero(unsafe_flag) {
         // Include sender into salt just after init_data
@@ -183,7 +183,7 @@ At the start of the block in which [EIP-3540](./eip-3540.md) activates, set the 
         let final_salt := keccak256(0, size)
     }
 
-    let tx_initcode_hash := calldataload(1)
+    let tx_initcode_hash := calldataload(0)
     let init_data_size := sub(size, 65)
 
     // reuse init_data which has been already copied to memory above

--- a/EIPS/eip-7873.md
+++ b/EIPS/eip-7873.md
@@ -172,11 +172,11 @@ At the start of the block in which [EIP-3540](./eip-3540.md) activates, set the 
     calldatacopy(0, 0, size)
 
     // mask out the 31 bytes that follow the flag in input data
-    let unsafe_flag := calldataload(64) & (0xff << 248)
+    let unsafe_flag := byte(0, calldataload(64))
 
     if iszero(unsafe_flag) {
         // Include sender into salt just after init_data
-        mstore(msize(), caller())
+        mstore(size, caller())
         let final_salt := keccak256(0, size + 32)
     } else {
         // Exclude sender from salt - susceptible to front-running

--- a/EIPS/eip-7873.md
+++ b/EIPS/eip-7873.md
@@ -155,21 +155,39 @@ At the start of the block in which [EIP-3540](./eip-3540.md) activates, set the 
 
 ```solidity
 {
-    /// Takes [tx_initcode_hash][salt][init_data] as input,
-    /// creates contract and returns the address or failure otherwise
+    /// Takes [unsafe_flag][tx_initcode_hash][salt][init_data] as input,
+    /// creates contract and returns the address or failure otherwise.
 
-    // init_data.length can be 0, but the first 2 words are mandatory
+    /// unsafe_flag is 1 byte wide. tx_initcode_hash and salt are 32 bytes wide, init_data can be any width.
+    /// If unsafe_flag is 0x00, `CALLER` is included in the salt and impacts the target address of the created account.
+    /// If unsafe_flag is non-zero, `CALLER` is excluded. Deployment by any sender will result in same target address. 
+    /// Deployments using non-zero unsafe_flag are susceptible to front-running.
+
+    // init_data.length can be 0, but the first 65 bytes are mandatory
     let size := calldatasize()
-    if lt(size, 64) { revert(0, 0) }
+    if lt(size, 65) { revert(0, 0) }
 
-    calldatacopy(0, 0, size)  // copy tx_initcode_hash, salt and init_data to memory to hash
-    let final_salt := keccak256(0, size)
+    // copy unsafe_flag, tx_initcode_hash, salt and init_data to memory to hash.
+    // note that the unsafe_flag is included to prevent pre-image attacks on the two paths to calculate salt below.
+    calldatacopy(0, 0, size)
 
-    let tx_initcode_hash := calldataload(0)
-    let init_data_size := sub(size, 64)
+    // mask out the 31 bytes that follow the flag in input data
+    let unsafe_flag := calldataload(0) & (0xff << 248)
+
+    if iszero(unsafe_flag) {
+        // Include sender into salt just after init_data
+        mstore(msize(), caller())
+        let final_salt := keccak256(0, size + 32)
+    } else {
+        // Exclude sender from salt - susceptible to front-running
+        let final_salt := keccak256(0, size)
+    }
+
+    let tx_initcode_hash := calldataload(1)
+    let init_data_size := sub(size, 65)
 
     // reuse init_data which has been already copied to memory above
-    let ret := txcreate(tx_initcode_hash, callvalue(), final_salt, 64, init_data_size)
+    let ret := txcreate(tx_initcode_hash, callvalue(), final_salt, 65, init_data_size)
 
     if iszero(ret) {
         let ret_data_size := returndatasize()


### PR DESCRIPTION
It has been raised [here](https://github.com/ethereum/EIPs/pull/9391#issuecomment-2678451413) that the EOF Creator Contract would be a better default factory, if it allowed for the CALLER to be included in the salt (and newly created account's address) by default, only with the option to exclude it explicitly if needed.

Follow the thread linked above for details, but the rationale is that such Creator Contract is better versed to be useful over the long term, rather than just being a bootstrapping contract. Without this change, such bootstrap-only Creator Contract would need to be abandoned in practice for a more feature-rich factory. There are concerns that tooling will have a hard time to adapt to many competing factories, and as such, it makes sense to make the Creator Contract a sensible default from day 1.

The counterargument is that the simpler the Creator Contract is, the better, as its logic comes at a premium of extra attack vector, extra audit surface and general complexity

---

That being said, I did my best to represent the intended behavior in the pseudo code, but **I am very likely to have been very wrong**. This PR should be an invitation to discuss the pros and cons of the proposed change - thereby tagging @frangio @pcaversaccio @cameel @charles-cooper  @kuzdogan who have up to this point participated in the discussions.

But of course, if anyone can point out an error or an attack which this contract would be susceptible to, or just that it doesn't work at all :sweat_smile: , please LMK.