### PR TITLE
Remove block-level-warming EIP from PFI

### DIFF
--- a/EIPS/eip-7607.md
+++ b/EIPS/eip-7607.md
@@ -41,7 +41,6 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion` and `Propo
 ### Proposed for Inclusion
 
 * [EIP-7666](./eip-7666.md): EVM-ify the identity precompile
-* [EIP-7863](./eip-7863.md): Block-level warming
 * [EIP-7823](./eip-7823.md): Set upper bounds for MODEXP
 * [EIP-7793](./eip-7793.md): Precompile to get index of transaction within block
 * [EIP-7843](./eip-7843.md): Precompile to get the current slot number


### PR DESCRIPTION
Based on different priorities for Fusaka and the goal of PeerDAS and EOF being rolled out as smooth as possible (without other parts of the protocol significantly changing), I'm taking the block-level warming EIP of fthe table for Fusaka.
Of course, if someone else wants to push for it for inclusion in Fusaka, feel free to do so.