### PR TITLE
Update EIP-7873: TXCREATE hashing scheme to EOFCREATE with ASE

### DIFF
--- a/EIPS/eip-7873.md
+++ b/EIPS/eip-7873.md
@@ -133,7 +133,7 @@ Introduce a new instruction on the same block number [EIP-3540](./eip-3540.md) i
 - caller's memory slice `[input_offset:input_size]` is used as calldata
 - execute the container and deduct gas for execution. The 63/64th rule from [EIP-150](./eip-150.md) applies.
 - increment `sender` account's nonce
-- calculate `new_address` as `keccak256(0xff || sender || salt)[12:]`
+- calculate `new_address` as `keccak256(0xff || sender32 || salt)[12:]`, where `sender32` is the sender address left-padded to 32 bytes with zeros
 - an unsuccessful execution of initcode results in pushing `0` onto the stack
     - can populate returndata if execution `REVERT`ed
     - `sender`'s nonce stays updated
@@ -229,7 +229,7 @@ This also makes [EIP-7698](./eip-7698.md) (EOF - Creation transaction) no longer
 
 ### New address hashing scheme
 
-`TXCREATE` uses the scheme `new_address = keccak256(0xff || sender || salt)[12:]`, same as `EOFCREATE` instruction. The decision whether to include initcontainer hash into salt is left to the `TXCREATE` caller. See [EIP-7620](./eip-7620.md) for detailed rationale.
+`TXCREATE` uses the scheme `new_address = keccak256(0xff || sender32 || salt)[12:]`, same as `EOFCREATE` instruction. The decision whether to include initcontainer hash into salt is left to the `TXCREATE` caller. See [EIP-7620](./eip-7620.md) for detailed rationale.
 
 ### EOF creation transactions vs deployment patterns
 


### PR DESCRIPTION
Piggybacking on the updates to the EOFCREATE hashing scheme happening anyway, we align the TXCREATE scheme to be forward compatible with ASE (address space extension), by allowing a natural progression to 32-byte addresses