### PR TITLE
Update EIP-7873: Add ASE compatibility to Creator Contract

### DIFF
--- a/EIPS/eip-7873.md
+++ b/EIPS/eip-7873.md
@@ -176,13 +176,17 @@ At the start of the block in which [EIP-3540](./eip-3540.md) activates, set the 
     // mask out the 31 bytes that follow the flag in input data
     let unsafe_flag := byte(0, calldataload(64))
 
-    if iszero(unsafe_flag) {
-        // store caller in memory to hash, just after salt
-        mstore(64, caller())
-    } else {
-        // exclude sender from salt - susceptible to front-running
-        // assuming no bytes were written to memory word at 64 and it's all zeros
-    }
+    // normalize the unsafe_flag to 0 or 1
+    unsafe_flag := iszero(iszero(unsafe_flag))
+    
+    // create mask for the caller address: 0 if safe, all 1s if unsafe
+    let caller_mask := sub(0, unsafe_flag)
+
+    // mix in the caller address, if unsafe this is still all 1s
+    let caller_data := or(caller(), caller_mask)
+
+    // store caller data in memory to hash, just after salt
+    mstore(64, caller_data)
 
     let init_data_size := sub(size, 65)
 
@@ -190,7 +194,7 @@ At the start of the block in which [EIP-3540](./eip-3540.md) activates, set the 
     calldatacopy(96, 65, init_data_size)
 
     // final_salt = keccak256(tx_initcode_hash | salt | caller_or_zeros | init_data)
-    let final_salt := keccak256(0, 96 + init_data_size)
+    let final_salt := keccak256(0, add(96, init_data_size))
 
     let tx_initcode_hash := calldataload(0)
 


### PR DESCRIPTION
This changes how the caller address is included in the final salt in the Creator Contract: it is now left-padded with zeros to 32-bytes to make it compatible with Address Space Expansion.
Moreover, if unsafe flag is on the 32-byte placeholder for the caller address is filled with all 1s. Fix fixes the case when the caller address is 0 address.