### PR TITLE
Website: Request to add EIP builder tool link to eips.ethereum.org

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@ title: Home
   <a href="rss/last-call.xml"><img src="https://img.shields.io/badge/rss-Last Calls-red.svg" alt="RSS"></a>
   <a href="rss/nonerc.xml"><img src="https://img.shields.io/badge/rss-All except ERC-red.svg" alt="RSS"></a>
   <a href="https://eepurl.com/ikqNIP"><img src="https://img.shields.io/badge/-email%20alerts-red.svg" alt="RSS"></a>
+  <a href="https://eipsinsight.com/proposalbuilder"><img src="https://img.shields.io/badge/-EIP%20proposal%20builder-red.svg" alt="RSS"></a>
 </h1>
 <p>Ethereum Improvement Proposals (EIPs) describe standards for the Ethereum platform, including core protocol specifications, client APIs, and contract standards. Network upgrades are discussed separately in the <a target="_blank" href="https://github.com/ethereum/pm/">Ethereum Project Management</a> repository.</p>
 


### PR DESCRIPTION
Hello Team!

We have developed a tool to simplify the EIP proposal creation process and added checks to ensure the data is accurate and can be submitted as a draft for [EIPs](https://github.com/ethereum/EIPs)/[ERCs](https://github.com/ethereum/ERCs)/[RIPs](https://github.com/ethereum/RIPs).  

We kindly request the team to add this tool to the header of the [eips.ethereum.org](https://eips.ethereum.org) website to make it accessible to everyone.

Additionally, there is an import and modify option, where you can import existing EIP/ERC/RIP and modify it, and also integrated the eipw bot for checks.


Link to the tool: [Proposal Builder](https://eipsinsight.com/proposalbuilder)

### Key Features
Some basic checks include:
- Verifying that the references for an EIP/ERC/RIP are correct (ensures only existing references can be added).
- Type checks for fields like the `Created Date`, specified EIPs etc.
- Ensuring all necessary fields are completed.
- importing existing EIPs and modify.
- eipw bot for a standard check

### Additional Features
- Instructions and guidelines are provided for each step to make the process easier, especially for first-time EIP creators.
- Validation of data, followed by the option to download a markdown file for submission.

This tool can also be accessed from our website: [EIPsInsight](https://eipsinsight.com/) in the Tools section.

**Note**: The PR [#9244](https://github.com/ethereum/EIPs/pull/9244) had some technical issues on our end, so we had to close it and open this new PR for the update.