### PR TITLE
Update EIP-3540: Change kind_data from 0x04 to 0xff

### DIFF
--- a/EIPS/eip-3540.md
+++ b/EIPS/eip-3540.md
@@ -129,7 +129,7 @@ types_section := (inputs, outputs, max_stack_height)+
 | kind_container         | 1 byte   | 0x03          | kind marker for container size section                                                                       |
 | num_container_sections | 2 bytes  | 0x0001-0x0100 | 16-bit unsigned big-endian integer denoting the number of the container sections                             |
 | container_size         | 2 bytes  | 0x0001-0xFFFF | 16-bit unsigned big-endian integer denoting the length of the container section content                      |
-| kind_data              | 1 byte   | 0x04          | kind marker for data size section                                                                            |
+| kind_data              | 1 byte   | 0xff          | kind marker for data size section                                                                            |
 | data_size              | 2 bytes  | 0x0000-0xFFFF | 16-bit unsigned big-endian integer denoting the length of the data section content (*)                       |
 | terminator             | 1 byte   | 0x00          | marks the end of the header                                                                                  |
 
@@ -236,6 +236,10 @@ Currently contracts can selfdestruct in three different ways (directly through `
 Imposing an EOF-validation time limit for the size of EOF containers provides a reference limit of how large the containers should EVM implementations be able to handle when validating and processing containers. `MAX_INITCODE_SIZE` was chosen for EOF1, as it is what contract creation currently allows for.
 
 Given one of the main reasons for the limit is to avoid attack vectors on `JUMPDEST`-analysis, and EOF removes the need for `JUMPDEST`-analysis and introduces a cost structure for deploy-time analysis, in the future this limit could be increased or even lifted for EOF.
+
+### `kind_data` could be `0x04` not `0xff`
+
+Putting the data section last as `0xff` has the advantage of aligning with the fact that it always comes last. We're avoiding a situation that a new section kind would need to go before the data section and break the section kind ordering. At the same time, data section being last is advantageous because it is the section which gets data appended to during contract deployment.
 
 ## Backwards Compatibility
 

--- a/EIPS/eip-7834.md
+++ b/EIPS/eip-7834.md
@@ -59,7 +59,7 @@ types_section := (inputs, outputs, max_stack_height)+
 | ...           | ...     | ...           | ...                                                                                     |
 | kind_metadata | 1 byte  | 0x05          | kind marker for metadata size section                                                   |
 | metadata_size | 2 bytes | 0x0001-0xFFFF | 16-bit unsigned big-endian integer denoting the length of the metadata section content  |
-| kind_data     | 1 byte  | 0x04          | kind marker for data size section                                                       |
+| kind_data     | 1 byte  | 0xff          | kind marker for data size section                                                       |
 | data_size     | 2 bytes | 0x0000-0xFFFF | 16-bit unsigned big-endian integer denoting the length of the data section content (\*) |
 | terminator    | 1 byte  | 0x00          | marks the end of the header                                                             |
 


### PR DESCRIPTION
Align with eof-devnet-1 change https://github.com/ipsilon/eof/issues/173. Goes in hand with https://github.com/ethereum/execution-spec-tests/pull/1339