### PR TITLE
Update EIP-7620: Align EOFCREATE stack args with EXTCALL

### DIFF
--- a/EIPS/eip-7620.md
+++ b/EIPS/eip-7620.md
@@ -72,7 +72,7 @@ Details on each instruction follow in the next sections.
 - deduct `TX_CREATE_COST` gas
 - halt with exceptional failure if the current frame is in `static-mode`.
 - read immediate operand `initcontainer_index`, encoded as 8-bit unsigned value
-- pop `value`, `salt`, `input_offset`, `input_size` from the operand stack
+- pop `salt`, `input_offset`, `input_size`, `value` from the operand stack
 - perform (and charge for) memory expansion using `[input_offset, input_size]`
 - load initcode EOF subcontainer at `initcontainer_index` in the container from which `EOFCREATE` is executed
     - let `initcontainer` be that EOF container
@@ -170,6 +170,10 @@ This alternative however goes against code non-observability, because it locks i
 Other ways of removing code observability, yet keeping some form of witness of the code, were considered. However, keeping only `sender` and `salt` allows the implementer of the factory contract (i.e. one containing the `EOFCREATE` instruction) to include the code witness via the `salt` anyway, if that's necessary for the particular use case. Therefore, keeping the `new_address` formula minimal is the most flexible approach with better separation of concerns.
 
 Leaving the `keccak256(initcontainer)` out of the `new_address` hash has also the benefit of making the `new_address` independent of the metadata section (proposed for the EOF in a separate EIP), which is a desired property. Unfortunately, if a factory wants to opt into committing to a particular `initcontainer`, it needs to include it in the `salt`, and that will include the metadata section.
+
+### `EOFCREATE` stack argument order
+
+`EXT*CALL` instructions from [EIP-7069](./eip-7069.md) have had their stack argument order changed, as compared to that of legacy instructions `*CALL`. We follow the same change to have `EOFCREATE` stack arg order match those of `EXTCALL`.
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
Align with eof-devnet-1 planned change https://github.com/ipsilon/eof/pull/156 . Goes in hand with https://github.com/ethereum/execution-spec-tests/pull/1274