### PR TITLE
Add EIP: SSZ ProgressiveByteList

### DIFF
--- a/EIPS/eip-####.md
+++ b/EIPS/eip-####.md
@@ -1,0 +1,67 @@
+---
+title: SSZ ProgressiveByteList
+description: New SSZ type to improve efficiency for short lists
+author: Zsolt Felföldi (@zsfelfoldi)
+discussions-to: <URL>
+status: Draft
+type: Standards Track
+category: Core
+created: 2025-03-24
+---
+
+## Abstract
+
+This EIP introduces a new [Simple Serialize (SSZ) type](https://github.com/ethereum/consensus-specs/blob/b3e83f6691c61e5b35136000146015653b22ed38/ssz/simple-serialize.md) to make `List[T, N]` with large capacities `N` more efficient in cases where the list is much shorter than the capacity.
+
+## Specification
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
+
+### ProgressiveByteList container
+
+`ProgressiveByteList[CAPACITY, COMMON_RATIO]` is defined as a byte list container type that consists of multiple byte vectors of different size. The size of the first vector is 32 bytes (a single chunk) while the size of further vectors is growing according to a geometric sequence with the specified common ratio (a power of 2), with a potential exception for the last vector which might be smaller (but still a power of 2) according to the total number of chunks required for realizing the specified capacity. As shown on the figure below, in the Merkle hashing scheme the smaller vectors are close to the root, allowing less hashing and shorter proofs if the actual list is significantly smaller than the maximum capacity or only the first part of the list needs to be proven.
+
+```
+ProgressiveByteList[3000, 4]
+
+       V4  V5
+        \  /
+     V3  \/
+      \  /
+   V2  \/
+    \  /
+ V1  \/
+  \  /
+   \/  LEN
+    \  /
+     \/
+    ROOT
+
+V1: ByteVector[32]
+V2: ByteVector[128]
+V3: ByteVector[512]
+V4: ByteVector[2048]
+V5: ByteVector[512]
+
+Fig 1. Merkle hashing scheme of the ProgressiveByteList container
+```
+
+In this example a list with a capacity limit of 3000 is realized using 5 vectors. Note that the last vector is smaller than what would follow in the geometric sequence because the total size of 32+128+512+2048+512 is already enough to store 3000 bytes.
+
+## Rationale
+
+`ByteList` definitions sometimes are defined with capacities that exceed their typical practical usage, to avoid limiting design space. For example, the [`Transaction`](https://github.com/ethereum/consensus-specs/blob/3c028dc73f5d93defc9bfd38c44784573a0bc70a/specs/bellatrix/beacon-chain.md#custom-types) type has a maximum capacity of 1 GB [`MAX_BYTES_PER_TRANSACTION`](https://github.com/ethereum/consensus-specs/blob/3c028dc73f5d93defc9bfd38c44784573a0bc70a/specs/bellatrix/beacon-chain.md#execution), despite actual transactions often being below 1 KB. This difference results in at least 20 extra hashes for common cases, to offer a design space that is not practically viable.
+
+With this EIP, common cases can be hashed more efficiently while not restricting the design space, and while also retaining stable generalized Merkle indices for each individual chunk of the `ByteList`.
+
+## Backwards Compatibility
+
+The new SSZ type does not interfere with any existing types.
+
+## Security Considerations
+
+None
+
+## Copyright
+
+Copyright and related rights waived via [CC0](../LICENSE.md).

--- a/EIPS/eip-7745.md
+++ b/EIPS/eip-7745.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2024-07-17
-requires: ####
+requires: 7916
 ---
 
 ## Abstract

--- a/EIPS/eip-7745.md
+++ b/EIPS/eip-7745.md
@@ -71,7 +71,7 @@ rlp([
 
 #### Container types
 
-These definitions use the `ProgressiveByteList` SSZ type as defined in [EIP-####](./eip-####.md).
+These definitions use the `ProgressiveByteList` SSZ type as defined in [EIP-7916](./eip-7916.md).
 
 ```
 class LogIndex(Container):

--- a/EIPS/eip-7745.md
+++ b/EIPS/eip-7745.md
@@ -8,6 +8,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2024-07-17
+requires: ####
 ---
 
 ## Abstract
@@ -70,6 +71,8 @@ rlp([
 
 #### Container types
 
+These definitions use the `ProgressiveByteList` SSZ type as defined in [EIP-####](./eip-####.md).
+
 ```
 class LogIndex(Container):
     epochs: Vector[LogIndexEpoch, MAX_EPOCH_HISTORY]
@@ -106,37 +109,6 @@ class BlockDelimiterMeta(Container):
     timestamp: uint64
     dummy_value: uint64  # 2**64-1
 ```
-
-##### ProgressiveByteList container
-
-`ProgressiveByteList[CAPACITY, COMMON_RATIO]` is defined as a byte list container type that consists of multiple byte vectors of different size. The size of the first vector is 32 bytes (a single chunk) while the size of further vectors is growing according to a geometric sequence with the specified common ratio (a power of 2), with a potential exception for the last vector which might be smaller (but still a power of 2) according to the total number of chunks required for realizing the specified capacity. As shown on the figure below, in the Merkle hashing scheme the smaller vectors are close to the root, allowing less hashing and shorter proofs if the actual list is significantly smaller than the maximum capacity or only the first part of the list needs to be proven.
-
-```
-ProgressiveByteList[3000, 4]
-
-       V3  V4
-        \  /
-     V3  \/
-      \  /
-   V2  \/
-    \  /
- V1  \/
-  \  /
-   \/  LEN
-    \  /
-     \/
-    ROOT
-    
-V1: ByteVector[32]
-V2: ByteVector[128]
-V3: ByteVector[512]
-V4: ByteVector[2048]
-V5: ByteVector[512]
-
-Fig 1. Merkle hashing scheme of the ProgressiveByteList container
-```
-
-In this example a list with a capacity limit of 3000 is realized using 5 vectors. Note that the last vector is smaller than what would follow in the geometric sequence because the total size of 32+128+512+2048+512 is already enough to store 3000 bytes.
 
 #### Log entries and block delimiters
 
@@ -392,7 +364,7 @@ One question considered was whether to add separate keys for each unique _log va
 
 The other design decision considered here was whether to hash entire logs into the list of _log value_ occurences or just store position info and have a separate tree of log entries. This does not necessarily affect local storage efficiency which should probably only store position info in the local database anyways in order to avoid duplicating log data but could still generate the hash tree based on the full log data. Though the separate _filter maps_ and log entry trees do present some additional complexity, the second option was chosen because of the size of Merkle proofs proving matches of multiple _log value_ patterns. Tests have shown that realistic log searches often yield a lot more matches for the individual _log values_ themselves that the pattern itself. Hashing entire logs into the occurence lists would mean that the proof would have to include at least the root hashes of all the individual _log value_ matches, while in the second case only the position index is needed which is more than 10x smaller with the proposed parameters.
 
-In conclusion, for the given application the fixed tree size approach with separate position info plus probabilistic collision filter approach seemed to be the most appropriate approach. Since the _log value_ position info can be conveniently merged with the collision filter, the whole structure can be imagined as a sparse bit map on which each search operation can be thought of as applying a mask to the bit map. 
+In conclusion, for the given application the fixed tree size approach with separate position info plus probabilistic collision filter approach seemed to be the most appropriate approach. Since the _log value_ position info can be conveniently merged with the collision filter, the whole structure can be imagined as a sparse bit map on which each search operation can be thought of as applying a mask to the bit map.
 
 ### False positive rate
 

--- a/EIPS/eip-7916.md
+++ b/EIPS/eip-7916.md
@@ -3,7 +3,7 @@ eip: 7916
 title: SSZ ProgressiveByteList
 description: New SSZ type to improve efficiency for short lists
 author: Zsolt Felföldi (@zsfelfoldi)
-discussions-to: <URL>
+discussions-to: https://ethereum-magicians.org/t/eip-7745-two-dimensional-log-filter-data-structure/20580
 status: Draft
 type: Standards Track
 category: Core

--- a/EIPS/eip-7916.md
+++ b/EIPS/eip-7916.md
@@ -1,4 +1,5 @@
 ---
+eip: 7916
 title: SSZ ProgressiveByteList
 description: New SSZ type to improve efficiency for short lists
 author: Zsolt Felföldi (@zsfelfoldi)

--- a/EIPS/eip-7916.md
+++ b/EIPS/eip-7916.md
@@ -3,7 +3,7 @@ eip: 7916
 title: SSZ ProgressiveByteList
 description: New SSZ type to improve efficiency for short lists
 author: Zsolt Felföldi (@zsfelfoldi)
-discussions-to: https://ethereum-magicians.org/t/eip-7745-two-dimensional-log-filter-data-structure/20580
+discussions-to: https://ethereum-magicians.org/t/eip-7916-ssz-progressivebytelist/23254
 status: Draft
 type: Standards Track
 category: Core


### PR DESCRIPTION
Move SSZ ProgressiveByteList to its own EIP so that it can be worked on independently of the eth_getLogs filter usage.

Plans are to work with @wemeetagain to generalize it beyond byte lists, and to simplify the parameters with `CAPACITY = unbounded` as well as `COMMON_RATIO = 4`. That way, in EIPs such as EIP-6404 and EIP-6466 it is no longer necessary to define arbitrary bounds to byte lists, and in consensus we can use such an `UnboundedList[T]` construct to replace proposer / attester slashing lists (with a shared maximum allowed len), and could use it for attestations list that keeps changing across forks.

First step is to move this out to its own EIP with Zsolt as author, then do the followup work with me and @wemeetagain in separate PRs.
