### PR TITLE
Update EIP-7762: correct spelling errors in EIP-7762

### DIFF
--- a/EIPS/eip-7762.md
+++ b/EIPS/eip-7762.md
@@ -64,7 +64,7 @@ The current MIN_BASE_FEE_PER_BLOB_GAS is 1 wei. This is many orders of magnitude
 
 The blob base fee can at most double every $\log_{1.125}(10) = 5.885$ blocks when blocks use all available blob space. When blobs enter price discovery, they must climb many factors of 2 to reach the prevailing price.
 
-To set the parameter apropriately, one aproach is to look at the cost of simple transfers when base fees are low. The cost of a simple transfer when the base fee is 1 GWEI  is ~5 cents USD at today's prices (2,445.77$ ETH/USDC). We can try to peg the minimum price of a blob to that. Today, to reach this price, it requires an excess blob gas of `63070646`. When you calculate how long this would take to reach from 0 excess blob gas, you get:
+To set the parameter appropriately, one approach is to look at the cost of simple transfers when base fees are low. The cost of a simple transfer when the base fee is 1 GWEI  is ~5 cents USD at today's prices (2,445.77$ ETH/USDC). We can try to peg the minimum price of a blob to that. Today, to reach this price, it requires an excess blob gas of `63070646`. When you calculate how long this would take to reach from 0 excess blob gas, you get:
 
 ```
 63070646/(3 * 2**17) = 160.396947225


### PR DESCRIPTION
Fixed spelling errors in EIP-7762:
- "apropriately" -> "appropriately"
- "aproach" -> "approach"