### PR TITLE
Update EIP-7607: Switch out EIP-7915 in favor of new EIP *Blob base fee bounded by execution cost*

### DIFF
--- a/EIPS/eip-7607.md
+++ b/EIPS/eip-7607.md
@@ -61,7 +61,7 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion` and `Propo
 * [EIP-7907](./eip-7907.md): Meter Contract Code Size And Increase Limit
 * [EIP-7688](./eip-7688.md): Forward compatible consensus data structures
 * [EIP-7668](./eip-7668.md): Remove bloom filters
-* [EIP-7915](./eip-7915.md): Adaptive mean reversion blob pricing
+* EIP-XXXX ([Magician](https://ethereum-magicians.org/t/eip-blob-base-fee-bounded-by-execution-cost/23271)): Blob base fee bounded by execution cost
 * [EIP-7892](./eip-7892.md): Blob Parameter Only Hardforks
 * [EIP-7917](./eip-7917.md): Deterministic proposer lookahead
 * [EIP-7762](./eip-7762.md): Increase MIN_BASE_FEE_PER_BLOB_GAS


### PR DESCRIPTION
It is a simpler EIP that has better chances of inclusion in Fusaka.