### PR TITLE
Add EIP: Skip `JUMPDEST` immediate argument check

### DIFF
--- a/EIPS/eip-7921.md
+++ b/EIPS/eip-7921.md
@@ -1,11 +1,12 @@
 ---
 eip: 7921
 title: Skip `JUMPDEST` immediate argument check
-status: Draft
+description: All `JUMPDEST` bytes become valid `JUMPDEST`
 type: Standards Track
 category: Core
-author: William Morriss <wjmelements@gmail.com>
+author: William Morriss (@wjmelements)
 discussions-to: https://ethereum-magicians.org/t/eip-7921-skip-jumpdest-immediate-argument-check/23279
+status: Draft
 created: 2025-03-26
 ---
 

--- a/EIPS/eip-7921.md
+++ b/EIPS/eip-7921.md
@@ -1,5 +1,5 @@
 ---
-eip: TBD
+eip: 7921
 title: Skip `JUMPDEST` immediate argument check
 status: Draft
 type: Standards Track

--- a/EIPS/eip-7921.md
+++ b/EIPS/eip-7921.md
@@ -2,11 +2,11 @@
 eip: 7921
 title: Skip `JUMPDEST` immediate argument check
 description: All `JUMPDEST` bytes become valid `JUMPDEST`
-type: Standards Track
-category: Core
 author: William Morriss (@wjmelements)
 discussions-to: https://ethereum-magicians.org/t/eip-7921-skip-jumpdest-immediate-argument-check/23279
 status: Draft
+type: Standards Track
+category: Core
 created: 2025-03-26
 ---
 

--- a/EIPS/eip-7921.md
+++ b/EIPS/eip-7921.md
@@ -38,7 +38,11 @@ Removing the check solves several problems while reducing EVM complexity.
 
 ## Backwards Compatibility
 
-This change will not break any existing functionality.
+Code previously only had one interpretation for disassembly.
+With this change, a `JUMPDEST` located inside an immediate argument can cause multiple disassembly interpretations.
+Usually the interpretations will converge after a few bytes but the length of such a dispute can be unbounded.
+`CODECOPY` data has always been difficult to identify.
+It is recommended that disassemblers provide all possible interpretations in their output in order to reveal possible underhanded functionality.
 
 ## Security Considerations
 

--- a/EIPS/eip-7921.md
+++ b/EIPS/eip-7921.md
@@ -5,7 +5,7 @@ status: Draft
 type: Standards Track
 category: Core
 author: William Morriss <wjmelements@gmail.com>
-discussions-to: TBD
+discussions-to: https://ethereum-magicians.org/t/eip-7921-skip-jumpdest-immediate-argument-check/23279
 created: 2025-03-26
 ---
 

--- a/EIPS/eip-draft-remove-jumpdest-push-check.md
+++ b/EIPS/eip-draft-remove-jumpdest-push-check.md
@@ -43,8 +43,10 @@ This change will not break any existing functionality.
 
 Current contracts performing dynamic jumps may gain new unintended functionality if it is possible to jump to an immediate argument containing `JUMPDEST`.
 It is expected that very few contracts will become vulnerable in this way.
-Most smart contract programming languages do not even allow dynamic jumps, so few contracts will become vulnerable, and for many of them the newly possible codepaths will be invalid.
+Most smart contract programming languages do not even allow dynamic jumps, and of those that do, few will have `JUMPDEST` in an accessible immediate argument.
+Therefore it is expected that few contracts will become vulnerable, and for many of them the newly possible codepaths will contain invalid opcodes.
 A static analysis tool should be developed and made publicly available to test if a contract might become vulnerable, and the program should be run for all current contracts in order to notify projects about potential security issues.
+Affected programs will have ample time to migrate.
 
 ## Copyright
 

--- a/EIPS/eip-draft-remove-jumpdest-push-check.md
+++ b/EIPS/eip-draft-remove-jumpdest-push-check.md
@@ -1,0 +1,50 @@
+---
+eip: TBD
+title: Skip `JUMPDEST` immediate argument check
+status: Draft
+type: Standards Track
+category: Core
+author: William Morriss <wjmelements@gmail.com>
+created: 2025-03-26
+---
+
+## Abstract
+
+Allow `JUMP` and `JUMPI` to arrive at any byte matching `JUMPDEST` (`0x5b`), even if that byte is an immediate argument.
+
+## Motivation
+
+Immediate arguments are opcode parameters supplied within the code rather than the stack.
+Currently determining the validity of a `JUMPDEST` requires determining which bytes are immediate arguments to other opcodes, such as `PUSH1`.
+This presents several problems:
+
+1. Codesize is a linear DoS vector because code must be preprocessed to determine `JUMPDEST` validity.
+2. New opcodes with immediate arguments cannot be safely adopted.
+
+The rationale for this `JUMPDEST` validity check is to prevent unintended code execution.
+However, almost all `JUMP` and `JUMPI` target constant destinations.
+Removing this check allows larger programs and better opcodes.
+Therefore, the cost of this safety check outweighs the benefit.
+
+## Specification
+
+When activated, all `0x5b` bytes are valid `JUMPDEST` for `JUMPI` and `JUMP` opcodes.
+
+## Rationale
+
+Removing the check solves several problems while reducing EVM complexity.
+
+## Backwards Compatibility
+
+Contracts utilizing
+
+## Security Considerations
+
+Current contracts performing dynamic jumps may gain new unintended functionality if it is possible to jump to an immediate argument containing `JUMPDEST`.
+It is expected that very few contracts will become vulnerable in this way.
+Most smart contract programming languages do not even allow dynamic jumps, so few contracts will become vulnerable, and for many of them the newly possible codepaths will be invalid.
+A static analysis tool should be developed and made publicly available to test if a contract might become vulnerable, and the program should be run for all current contracts in order to notify projects about potential security issues.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](../LICENSE.md).

--- a/EIPS/eip-draft-remove-jumpdest-push-check.md
+++ b/EIPS/eip-draft-remove-jumpdest-push-check.md
@@ -21,6 +21,7 @@ This presents several problems:
 
 1. Codesize is a linear DoS vector because code must be preprocessed to determine `JUMPDEST` validity.
 2. New opcodes with immediate arguments cannot be safely adopted.
+3. `CODECOPY` data spans can invalidate subsequent `JUMPDEST`.
 
 The rationale for this `JUMPDEST` validity check is to prevent unintended code execution.
 However, almost all `JUMP` and `JUMPI` target constant destinations.

--- a/EIPS/eip-draft-remove-jumpdest-push-check.md
+++ b/EIPS/eip-draft-remove-jumpdest-push-check.md
@@ -5,6 +5,7 @@ status: Draft
 type: Standards Track
 category: Core
 author: William Morriss <wjmelements@gmail.com>
+discussions-to: TBD
 created: 2025-03-26
 ---
 
@@ -36,7 +37,7 @@ Removing the check solves several problems while reducing EVM complexity.
 
 ## Backwards Compatibility
 
-Contracts utilizing
+This change will not break any existing functionality.
 
 ## Security Considerations
 


### PR DESCRIPTION

I have long suggested this solution elsewhere but now I am making a formal proposal.
#### Changes
* add eip