### PR TITLE
Update EIP-7607: Add EIP-7898 to Fusaka PFI

### DIFF
--- a/EIPS/eip-7607.md
+++ b/EIPS/eip-7607.md
@@ -66,6 +66,7 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion` and `Propo
 * [EIP-7917](./eip-7917.md): Deterministic proposer lookahead
 * [EIP-7762](./eip-7762.md): Increase MIN_BASE_FEE_PER_BLOB_GAS
 * [EIP-7919](./eip-7919.md): Pureth Meta
+* [EIP-7898](./eip-7898.md): Uncouple execution payload from beacon block
 
 ### Activation
 


### PR DESCRIPTION
PFI  EIP-7898: Uncouple execution payload from beacon block 