### PR TITLE
Update EIP-6953: Update Historical Boundary Definitions

### DIFF
--- a/EIPS/eip-6953.md
+++ b/EIPS/eip-6953.md
@@ -65,7 +65,7 @@ The Paris upgrade, the execution layer portion of "The Merge," was triggered by 
 
 ### Post-Merge Upgrades
 
-After The Merge, network upgrades are triggered at an epoch on the consensus layer (CL), which ideally maps to an historical roots accumulator boundary (i.e., a multiple of 7192 epochs). The epoch's corresponding timestamp, rather than a block number, is then used on the execution layer (EL) as the activation trigger. The following upgrades followed this pattern:
+After The Merge, network upgrades are triggered at an epoch on the consensus layer (CL), which ideally maps to an historical roots accumulator boundary (i.e., a multiple of 8192 slots). The epoch's corresponding timestamp, rather than a block number, is then used on the execution layer (EL) as the activation trigger. The following upgrades followed this pattern:
 
 | Upgrade Name     | Activation Epoch | Activation Timestamp |
 |------------------|------------------|----------------------|


### PR DESCRIPTION
Historical summaries are updated once every **8192 slots**, not 7192 epochs. 

Capella's epoch, 194048, is not even divisible by 7192. The associated starting slot (194048 x 32 = 6209536) is divisible by 8192. 