### PR TITLE
Update EIP-7623: add extra comment about worst case EL payload sizes

### DIFF
--- a/EIPS/eip-7623.md
+++ b/EIPS/eip-7623.md
@@ -13,24 +13,23 @@ created: 2024-02-13
 
 ## Abstract
 
-The current calldata pricing permits EL payloads of up to 7.15 MB, while the average size is much smaller at around 100 KB. 
-This EIP proposes adjusting the calldata cost to reduce the maximum possible block size and its variance without negatively impacting regular users. 
+The current calldata pricing permits EL payloads of up to 7.15 MB, while the average size is much smaller at around 100 KB.
+This EIP proposes adjusting the calldata cost to reduce the maximum possible block size and its variance without negatively impacting regular users.
 This is achieved by increasing calldata costs for transactions that predominantly post data.
 
 ## Motivation
 
 The block gas limit has not been increased since [EIP-1559](./eip-1559.md), while the average size of blocks has continuously increased due to the growing number of rollups posting data to Ethereum. Moreover, calldata costs have remained unchanged since [EIP-2028](./eip-2028).
-[EIP-4844](./eip-4844.md) introduces blobs as a preferred method for data availability (DA). 
+[EIP-4844](./eip-4844.md) introduces blobs as a preferred method for data availability (DA).
 This transition demands a reevaluation of calldata pricing, especially in order to address the disparity between average and maximum block sizes.
 By introducing a floor cost dependent on the ratio of gas spent on EVM operations to calldata, this proposal aims to reduce the maximum block size to make room for additional blobs or potential block gas limit increases.
 
 ## Specification
 
 | Parameter                    | Value |
-|------------------------------|-------|
+| ---------------------------- | ----- |
 | `STANDARD_TOKEN_COST`        | `4`   |
 | `TOTAL_COST_FLOOR_PER_TOKEN` | `10`  |
-
 
 Let `tokens_in_calldata = zero_bytes_in_calldata + nonzero_bytes_in_calldata * 4`.
 
@@ -72,7 +71,7 @@ Any transaction with a gas limit below `21000 + TOTAL_COST_FLOOR_PER_TOKEN * tok
 
 The current maximum EL payload size is approximately 1.79 MB (`30_000_000/16`). It is possible to create payloads filled with zero bytes that expand to 7.15 MB. However, since blocks are typically compressed with Snappy at the P2P layer, zero-byte-heavy EL payloads generally compress to under 1.79 MB. The implementation of [EIP-4844](./eip-4844.md) increased the maximum possible compressed block size to approximately 2.54 MB.
 
-This proposal aims to increase the cost of calldata to 10/40 gas for transactions that do not exceed a certain threshold of gas spent on EVM operations relative to gas spent on calldata. This change will significantly reduce the maximum block size by limiting the size of data-heavy transactions that can fit into a single block. By increasing calldata costs from 4/16 to 10/40 gas per byte for data-heavy transactions, this EIP aims to reduce the maximum possible EL payload size to approximately 0.72 MB (`30_000_000/40`) without affecting the majority of users.
+This proposal aims to increase the cost of calldata to 10/40 gas for transactions that do not exceed a certain threshold of gas spent on EVM operations relative to gas spent on calldata. This change will significantly reduce the maximum block size by limiting the size of data-heavy transactions that can fit into a single block. By increasing calldata costs from 4/16 to 10/40 gas per byte, for data-heavy transactions this EIP aims to reduce the possible EL payload size to approximately 0.72 MB (`30_000_000/40`) without affecting the majority of users. Other adversarial block constructions can have a non-compressible EL payload size of approximately 1.26MiB.
 
 Notably, regular users (e.g. sending ETH/Tokens/NFTs, engaging in DeFi, social media, restaking, bridging, etc.), who do not use calldata predominantly for DA, may remain unaffected.
 The calldata cost for transactions involving significant EVM computation remains at 4/16 gas per byte, so those transactions are unaffected.
@@ -84,7 +83,7 @@ This is a backwards incompatible gas repricing that requires a scheduled network
 Wallet developers and node operators MUST update gas estimation handling to accommodate the new calldata cost rules. Specifically:
 
 1. **Wallets**: Wallets using `eth_estimateGas` MUST be updated to ensure that they correctly account for the `TOTAL_COST_FLOOR_PER_TOKEN` parameter. Failure to do so could result in underestimating gas, leading to failed transactions.
-   
+
 2. **Node Software**: RPC methods such as `eth_estimateGas` MUST incorporate the updated formula for gas calculation. Node developers MUST ensure compatibility with the updated calldata pricing logic.
 
 Users can maintain their usual workflows without modification, as wallet and RPC updates will handle these changes.


### PR DESCRIPTION
This PR adds an extra comment to mention bigger EL payload sizes that could happen for more adversarial constructions.

More details about the construction are in [this doc](https://hackmd.io/@jsign/eip-7623-big-el-payload), which builds a 1.05MB case. @nerolation pushed this idea further with a snappy inefficiency, leading to the mentioned 1.26MiB in this PR.

As mentioned in the doc linked above, this finding doesn't seem to justify a change in constants. Despite the worst case is updated, the constant also has a relationship with UX-impact. The doc references an Ethresearch post that can provide more insight into the rationale behind the current constant value.
