### PR TITLE
Update EIP-7607: ACDE#208 Updates

### DIFF
--- a/EIPS/eip-7607.md
+++ b/EIPS/eip-7607.md
@@ -47,34 +47,28 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion` and `Propo
 
 ### Proposed for Inclusion
 
-* [EIP-7666](./eip-7666.md): EVM-ify the identity precompile
-* [EIP-7823](./eip-7823.md): Set upper bounds for MODEXP
-* [EIP-7793](./eip-7793.md): Precompile to get index of transaction within block
-* [EIP-7843](./eip-7843.md): Precompile to get the current slot number
-* [EIP-7732](./eip-7732.md): Enshrined Proposer-Builder Separation
 * [EIP-7642](./eip-7642.md): eth/69 - Drop pre-merge fields
-* [EIP-7805](./eip-7805.md): Fork-choice enforced Inclusion Lists (FOCIL)
-* [EIP-7783](./eip-7783.md): Controlled gas limit increase strategy
-* [EIP-7883](./eip-7883.md): ModExp Gas Cost Increase
-* [EIP-7825](./eip-7825.md): Transaction Gas Limit Cap
-* [EIP-7873](./eip-7873.md): EOF - TXCREATE and InitcodeTransaction type
-* [EIP-7834](./eip-7834.md): Separate Metadata Section for EOF
-* [EIP-7761](./eip-7761.md): EXTCODETYPE instruction
-* [EIP-7880](./eip-7880.md): EOF - EXTCODEADDRESS instruction
-* [EIP-5920](./eip-5920.md): PAY opcode
-* [EIP-7903](./eip-7903.md): Remove Initcode Size Limit
-* [EIP-7791](./eip-7791.md): GAS2ETH opcode
-* [EIP-7819](./eip-7819.md): CREATE DELEGATE opcode
-* [EIP-7907](./eip-7907.md): Meter Contract Code Size And Increase Limit
-* [EIP-7688](./eip-7688.md): Forward compatible consensus data structures
+* [EIP-7666](./eip-7666.md): EVM-ify the identity precompile
 * [EIP-7668](./eip-7668.md): Remove bloom filters
-* [EIP-7918](./eip-7918.md): Blob base fee bounded by execution cost
-* [EIP-7892](./eip-7892.md): Blob Parameter Only Hardforks
-* [EIP-7917](./eip-7917.md): Deterministic proposer lookahead
+* [EIP-7688](./eip-7688.md): Forward compatible consensus data structures
+* [EIP-7732](./eip-7732.md): Enshrined Proposer-Builder Separation
 * [EIP-7762](./eip-7762.md): Increase MIN_BASE_FEE_PER_BLOB_GAS
-* [EIP-7919](./eip-7919.md): Pureth Meta
-* [EIP-7898](./eip-7898.md): Uncouple execution payload from beacon block
+* [EIP-7783](./eip-7783.md): Controlled gas limit increase strategy
+* [EIP-7791](./eip-7791.md): GAS2ETH opcode
+* [EIP-7793](./eip-7793.md): Precompile to get index of transaction within block
+* [EIP-7805](./eip-7805.md): Fork-choice enforced Inclusion Lists (FOCIL)
+* [EIP-7819](./eip-7819.md): CREATE DELEGATE opcode
+* [EIP-7823](./eip-7823.md): Set upper bounds for MODEXP
+* [EIP-7825](./eip-7825.md): Transaction Gas Limit Cap
+* [EIP-7843](./eip-7843.md): Precompile to get the current slot number
 * [EIP-7889](./eip-7889.md): Emit log on revert
+* [EIP-7892](./eip-7892.md): Blob Parameter Only Hardforks
+* [EIP-7898](./eip-7898.md): Uncouple execution payload from beacon block
+* [EIP-7903](./eip-7903.md): Remove Initcode Size Limit
+* [EIP-7907](./eip-7907.md): Meter Contract Code Size And Increase Limit
+* [EIP-7917](./eip-7917.md): Deterministic proposer lookahead
+* [EIP-7918](./eip-7918.md): Blob base fee bounded by execution cost
+* [EIP-7919](./eip-7919.md): Pureth Meta
 
 ### Activation
 

--- a/EIPS/eip-7607.md
+++ b/EIPS/eip-7607.md
@@ -21,7 +21,7 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion` and `Propo
 ### EIPs Scheduled for Inclusion
 
 * [EIP-7594](./eip-7594.md): PeerDAS - Peer Data Availability Sampling
-* EOF EIPs listed as part of [EIP-7692](./eip-7692.md), namely:
+* EOF EIPs introduced in `eof-devnet-0` and `eof-devnet-1` in [EIP-7692](./eip-7692.md), namely:
     * [EIP-663](./eip-663.md): SWAPN, DUPN and EXCHANGE instructions
     * [EIP-3540](./eip-3540.md): EOF - EVM Object Format v1
     * [EIP-3670](./eip-3670.md): EOF - Code Validation
@@ -33,10 +33,17 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion` and `Propo
     * [EIP-7480](./eip-7480.md): EOF - Data section access instructions
     * [EIP-7620](./eip-7620.md): EOF Contract Creation
     * [EIP-7698](./eip-7698.md): EOF - Creation transaction
+    * [EIP-7873](./eip-7873.md): EOF - TXCREATE and InitcodeTransaction type
 
 ### Considered for Inclusion
 
 * RIP-7212: Precompile for secp256r1 Curve Support
+* EOF EIPs introduced in `eof-devnet-2` in [EIP-7692](./eip-7692.md), namely:
+    * [EIP-7834](./eip-7834.md): Separate Metadata Section for EOF
+    * [EIP-7761](./eip-7761.md): EXTCODETYPE instruction
+    * [EIP-7880](./eip-7880.md): EOF - EXTCODEADDRESS instruction
+    * [EIP-5920](./eip-5920.md): PAY opcode
+* [EIP-7883](./eip-7883.md): ModExp Gas Cost Increase 
 
 ### Proposed for Inclusion
 


### PR DESCRIPTION
CFI & SFI changes made on [ACDE#208](https://github.com/ethereum/pm/issues/1374). [The EOF Meta EIP changes](https://github.com/ethereum/EIPs/pull/9557) cannot be merged yet due to status issues. The devnet specs referenced are from ["Option A" in this document](https://notes.ethereum.org/@ipsilon/eof_fusaka_options#A---Complete-EOF). 