### PR TITLE
Update EIP-7873: set tx type to a currently unused (?) first RLP byte

### DIFF
--- a/EIPS/eip-7873.md
+++ b/EIPS/eip-7873.md
@@ -33,7 +33,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 | Constant | Value |
 | - | - |
-| `INITCODE_TX_TYPE` | `Bytes1(0x05)` |
+| `INITCODE_TX_TYPE` | `Bytes1(0x06)` |
 | `MAX_INITCODE_COUNT` | `256` |
 | `CREATOR_CONTRACT_ADDRESS` | tbd |
 | `CREATOR_CONTRACT_BYTECODE` | tbd |


### PR DESCRIPTION
We should not use 0x05 as tx type for the InitcodeTransaction, because this is used as MAGIC byte when signing EIP-7702 authorities: https://eips.ethereum.org/EIPS/eip-7702#parameters

As far as I am aware, 0x06 is not used as magic byte or "RLP escape byte".