### PR TITLE
Update EIP-7873: Align TXCREATE stack argument order with EOFCREATE

### DIFF
--- a/EIPS/eip-7873.md
+++ b/EIPS/eip-7873.md
@@ -117,7 +117,7 @@ Introduce a new instruction on the same block number [EIP-3540](./eip-3540.md) i
     
 - deduct `TX_CREATE_COST` gas
 - halt with exceptional failure if the current frame is in `static-mode`.
-- pop `tx_initcode_hash`, `value`, `salt`, `input_offset`, `input_size` from the operand stack
+- pop `tx_initcode_hash`, `salt`, `input_offset`, `input_size`, `value` from the operand stack
 - perform (and charge for) memory expansion using `[input_offset, input_size]`
 - load initcode EOF container from the transaction `initcodes` array which hashes to `tx_initcode_hash`
     - fails (returns 0 on the stack) if such initcode does not exist in the transaction, or if called from a transaction of `TransactionType` other than `INITCODE_TX_TYPE`


### PR DESCRIPTION
Align argument order with planned order for EOFCREATE, see https://github.com/ethereum/EIPs/pull/9503