### PR TITLE
Update EIP-7702: Update Parameter to be more specific

### DIFF
--- a/EIPS/eip-7702.md
+++ b/EIPS/eip-7702.md
@@ -31,7 +31,7 @@ There is a lot of interest in adding short-term functionality improvements to EO
 |     Parameter            | Value   |
 | ------------------------ | ------- |
 | `SET_CODE_TX_TYPE`       | `0x04`  |
-| `MAGIC`                  | `0x05`  |
+| `SET_CODE_TX_MAGIC`      | `0x05`  |
 | `PER_AUTH_BASE_COST`     | `12500` |
 | `PER_EMPTY_ACCOUNT_COST` | `25000` |
 
@@ -69,7 +69,7 @@ At the start of executing the transaction, after incrementing the sender's nonce
 
 1. Verify the chain id is either 0 or the chain's current ID.
 2. Verify the `nonce` is less than `2**64 - 1`.
-3. `authority = ecrecover(keccak(MAGIC || rlp([chain_id, address, nonce])), y_parity, r, s)`
+3. `authority = ecrecover(keccak(SET_CODE_TX_MAGIC || rlp([chain_id, address, nonce])), y_parity, r, s)`
     * `s` value must be less than or equal to `secp256k1n/2`, as specified in [EIP-2](./eip-2.md).
 4. Add `authority` to `accessed_addresses` (as defined in [EIP-2929](./eip-2929.md).)
 5. Verify the code of `authority` is either empty or already delegated.


### PR DESCRIPTION
Update the `MAGIC` parameter to be specific to `SET_CODE_TX` scope.