### PR TITLE
Update EIP-7002: Change Withdrawal Request Terminology

### DIFF
--- a/EIPS/eip-7002.md
+++ b/EIPS/eip-7002.md
@@ -86,7 +86,7 @@ If call data input to the contract is exactly `56` bytes, perform the following:
 
 * Ensure enough ETH was sent to cover the current withdrawal request fee (`check_fee()`)
 * Increase withdrawal request count by 1 for the current block (`increment_count()`)
-* Insert a withdrawal request into the queue for the source address and validator pubkey (`insert_withdrawal_request_into_queue()`)
+* Insert a withdrawal request into the queue for the source address and validator pubkey (`insert_consolidation_request_into_queue()`)
 
 Specifically, the functionality is defined in pseudocode as the function `add_withdrawal_request()`:
 


### PR DESCRIPTION


This pull request updates the terminology in EIP-7002 (Execution layer triggerable withdrawals) by replacing "insert_withdrawal_request_into_queue()" with "insert_consolidation_request_into_queue()". This change better reflects the nature of the operation, which involves consolidating validator funds rather than just withdrawing them. The modification improves the clarity and precision of the documentation without changing the actual functionality of the protocol.
