### PR TITLE
Update EIP-4750: Fix the definition of 0th code section type

### DIFF
--- a/EIPS/eip-4750.md
+++ b/EIPS/eip-4750.md
@@ -33,7 +33,7 @@ The type section of EOF containers must adhere to following requirements:
 
 1. The section is comprised of a list of metadata where the metadata index in the type section corresponds to a code section index. Therefore, the type section size MUST be `n * 4` bytes, where `n` is the number of code sections.
 2. Each metadata item has 3 attributes: a uint8 `inputs`, a uint8 `outputs`, and a uint16 `max_stack_height`. *Note:* This implies that there is a limit of 255 stack for the input and in the output. This is further restricted to 127 stack items, because the upper bit of both the input and output bytes are reserved for future use (`outputs == 0x80` is already used in EOF1 to denote non-returning functions, as introduced in a separate EIP). `max_stack_height` is further defined in [EIP-5450](./eip-5450.md).
-3. The 0th code section MUST have 0 inputs and 0 outputs.
+3. The 0th code section MUST have 0 inputs and be non-returning.
 
 Refer to [EIP-3540](./eip-3540.md) to see the full structure of a well-formed EOF bytecode.
 


### PR DESCRIPTION
This was a loose end not updated after introduction of non-returning functions. Mega-spec has correct type, and it is additionally specified (correcrly) in EIP-6206.