### PR TITLE
Update EIP-7761: clarify how EXTCODETYPE deals with EOF versions

### DIFF
--- a/EIPS/eip-7761.md
+++ b/EIPS/eip-7761.md
@@ -59,7 +59,7 @@ EOF code which contains this instruction before `FORK_BLKNUM` is considered inva
 - If `loaded_code` indicates a delegation designator (for example, `0xef0100` as defined in [EIP-7702]), 
   - replace `loaded_code` with the delegated code.
   - deduct gas in accordance with the delegation designation rules
-- If `loaded_code` indicates an EOFv1 packaged contract (starts with the bytes `0xef0001`) push `TYPE_EOF_CONTRACT` onto the stack and stop processing the operation
+- If `loaded_code` indicates an EOF packaged contract (starts with the bytes `0xef00`) push `TYPE_EOF_CONTRACT` onto the stack and stop processing the operation
 - Otherwise, push `TYPE_LEGACY_CONTRACT` onto the stack and stop processing the operation
 
 Note: if there is not enough gas to deduct for delegation designation the whole message frame will halt, making updating the `accessed_addresses` irrelevant.
@@ -67,6 +67,13 @@ Note: if there is not enough gas to deduct for delegation designation the whole 
 Note: If `target_address` or the delegation designator points to an account with a contract mid-creation then the code is empty and returns `0` (`TYPE_NONE`). This is aligned with similar behavior of instructions like `EXTCODESIZE`.
 
 ## Rationale
+
+### Commit to not discriminate between EOF versions
+
+`EXTCODETYPE` could be specced out to say that it returns `TYPE_EOF_CONTRACT` for EOFv1 contracts (starting with bytes `0xef0001`), therefore committing to return different values for future versions of EOF (presumably `TYPE_EOF_CONTRACT + 1` for a hypothetical EOFv2).
+
+It is cleaner to commit to the opposite - that the return value of `EXTCODETYPE` will not change for targets having a newer version of EOFv1. Otherwise, contract developers coding against EOFv1 will face the dilemma of whether to compare `EXTCODETYPE == 2` or `EXTCODETYPE >= 2` to check for EOF.
+In the unlikely event that discrimination between EOF versions is absolutely necessary for EOFv2, this could be handled by an extra opcode like `EXTEOFVERSION`, or, EOFv2 contracts may have `EXTCODETYPE` gain the ability to tell EOFv1 from EOFv2, while EOFv1 will not do so.
 
 ### Alternative solutions
 


### PR DESCRIPTION
Currently the EIP spec states that `2` is returned on EOFv1 (starting with `0xef0001`) targets, but doesn't commit to returning something else for potential future versions of EOF.

We can fix this two fold:
1/ commit to a particular return value scheme (simplest being return `3` for EOFv2, but there are alternatives discussed on the EthMag thread linked)
2/ (this PR) commit to not ever return anything else than `2` for any version of EOF contract, at least if executed in an EOFv1 code.

