### PR TITLE
Update EIP-6206: Ban the EOF-only opcodes in legacy

### DIFF
--- a/EIPS/eip-6206.md
+++ b/EIPS/eip-6206.md
@@ -43,6 +43,8 @@ A new instruction, `JUMPF (0xe5)`, is introduced.
 4. `JUMPF` costs 5 gas.
 5. `JUMPF` neither pops nor pushes anything to the operand stack.
 
+If the code is legacy bytecode, `JUMPF` instruction results in an *exceptional halt*. (*Note: This means no change to behaviour.*)
+
 ### Code Validation
 
 Let the definition of `type[i]` be inherited from [EIP-4750](./eip-4750.md) and define `stack_height_min` and `stack_height_max` to be the stack height bounds at a certain instruction during the instruction flow traversal.

--- a/EIPS/eip-7620.md
+++ b/EIPS/eip-7620.md
@@ -55,7 +55,9 @@ We introduce two new instructions on the same block number [EIP-3540](./eip-3540
 - If instructions `CREATE` and `CREATE2` have EOF code as initcode (starting with `EF00` magic)
     - deployment fails (returns 0 on the stack)
     - caller's nonce is not updated and gas for initcode execution is not consumed
-    
+
+If the code is legacy bytecode, any of these instructions result in an *exceptional halt*. (*Note: This means no change to behaviour.*)
+
 #### Overview of the new contract creation flow
 
 In EOF EVM, new bytecode is delivered by means of creation transactions (with an empty `to`) in the form of an EOF container (`initcontainer`). Such a container may contain arbitrarily deeply nesting subcontainers. The `initcontainer` and its subcontainers are recursively validated according to all the validation rules applicable for the EOF version in question. Next, the 0th code section of the `initcontainer` is executed and may eventually call a `RETURNCODE` instruction, which will refer to a subcontainer to be finally deployed to an address.

--- a/EIPS/eip-7873.md
+++ b/EIPS/eip-7873.md
@@ -147,6 +147,8 @@ Introduce a new instruction on the same block number [EIP-3540](./eip-3540.md) i
 
 Note that the implementations are expected to cache the result of container validation for the time of current transaction execution, and therefore the cost of each container's validation is sufficiently covered by `InitcodeTransaction` intrinsic cost (initcodes charge).
 
+If the code is legacy bytecode, `TXCREATE` instruction results in an *exceptional halt*. (*Note: This means no change to behaviour.*)
+
 ### Creator Contract
 
 We introduce a standardised Creator Contract (i.e. written in EVM, but existing at a known address), which eliminates the need to have create transactions with empty `to`.


### PR DESCRIPTION
It seems that 3 EIPs weren't explicit about new EOF opcodes being exclusive to EOF. The EOF megaspec fortunately was explicit about this https://github.com/ipsilon/eof/blob/main/spec/eof.md and I think it wasn't ever source of confusion, but we need to make it explicit regardless.

