### PR TITLE
Update EIP-7873: Move to Review

### DIFF
--- a/EIPS/eip-7873.md
+++ b/EIPS/eip-7873.md
@@ -25,6 +25,8 @@ Additionally, the new instruction and transaction type introduced in this EIP en
 
 This mechanism complements `EOFCREATE` and `RETURNCODE` instructions from [EIP-7620](./eip-7620.md), and thus all use cases of contract creation that are available in legacy EVM are enabled for EOF.
 
+Since `TXCREATE` is not restricted to EOF containers, it also serves the purpose of bootstrapping EOF contracts into the state.
+
 ## Specification
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
@@ -35,8 +37,6 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 | - | - |
 | `INITCODE_TX_TYPE` | `Bytes1(0x06)` |
 | `MAX_INITCODE_COUNT` | `256` |
-| `CREATOR_CONTRACT_ADDRESS` | tbd |
-| `CREATOR_CONTRACT_BYTECODE` | tbd |
 | `TX_CREATE_COST` | Defined as `32000` in the [Ethereum Execution Layer Specs](https://github.com/ethereum/execution-specs/blob/0f9e4345b60d36c23fffaa69f70cf9cdb975f4ba/src/ethereum/shanghai/fork_types.py#L42) |
 | `STACK_DEPTH_LIMIT` | Defined as `1024` in the [Ethereum Execution Layer Specs](https://github.com/ethereum/execution-specs/blob/0f9e4345b60d36c23fffaa69f70cf9cdb975f4ba/src/ethereum/shanghai/vm/interpreter.py#L60) |
 | `GAS_CODE_DEPOSIT` | Defined as `200` in the [Ethereum Execution Layer Specs](https://github.com/ethereum/execution-specs/blob/0f9e4345b60d36c23fffaa69f70cf9cdb975f4ba/src/ethereum/shanghai/vm/gas.py#L44) |
@@ -50,8 +50,6 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 Introduce new transaction `InitcodeTransaction` (type `INITCODE_TX_TYPE`) which extends [EIP-1559](./eip-1559.md) (type 2) transaction by adding a new field `initcodes: List[ByteList[MAX_INITCODE_SIZE], MAX_INITCODE_COUNT]`.
 
 The `initcodes` can only be accessed via the `TXCREATE` instruction (see below), therefore `InitcodeTransactions` are intended to be sent to contracts including `TXCREATE` in their execution.
-
-We introduce a standardized Creator Contract, which eliminates the need to have create transactions with empty `to`. See [Creator Contract](#creator-contract) for details.
 
 #### Gas schedule
 
@@ -147,85 +145,19 @@ Introduce a new instruction on the same block number [EIP-3540](./eip-3540.md) i
 
 Note that the implementations are expected to cache the result of container validation for the time of current transaction execution, and therefore the cost of each container's validation is sufficiently covered by `InitcodeTransaction` intrinsic cost (initcodes charge).
 
-If the code is legacy bytecode, `TXCREATE` instruction results in an *exceptional halt*. (*Note: This means no change to behaviour.*)
-
-### Creator Contract
-
-We introduce a standardised Creator Contract (i.e. written in EVM, but existing at a known address), which eliminates the need to have create transactions with empty `to`.
-
-At the start of the block in which [EIP-3540](./eip-3540.md) activates, set the code of `CREATOR_CONTRACT_ADDRESS` to `CREATOR_CONTRACT_BYTECODE`. `CREATOR_CONTRACT_ADDRESS` is not treated like a precompile. `CREATOR_CONTRACT_BYTECODE` corresponds to the following source code compiled to EOF:
-
-```solidity
-{
-    /// Takes [tx_initcode_hash][salt][unsafe_flag][init_data] as input,
-    /// creates contract and returns the address or failure otherwise.
-
-    /// tx_initcode_hash and salt are 32 bytes wide, unsafe_flag is 1 byte wide, init_data can be any width.
-    /// If unsafe_flag is 0x00, `CALLER` is included in the salt and impacts the target address of the created account.
-    /// If unsafe_flag is non-zero, `CALLER` is excluded, with 32 zero-bytes used instead. Deployment by any sender will result in same target address. 
-    /// Deployments using non-zero unsafe_flag are susceptible to front-running.
-
-    // init_data.length can be 0, but the first 65 bytes are mandatory
-    let size := calldatasize()
-    if lt(size, 65) { revert(0, 0) }
-
-    // copy tx_initcode_hash and salt to memory to hash.
-    // note that the unsafe_flag doesn't need to be included. If set to non-zero, 32 zero-bytes
-    // are used instead of the CALLER address bytes, which prevents hash collisions between
-    // deployments using unsafe_flag and those not using it.
-    calldatacopy(0, 0, 64)
-
-    // mask out the 31 bytes that follow the flag in input data
-    let unsafe_flag := byte(0, calldataload(64))
-
-    if iszero(unsafe_flag) {
-        // store caller in memory to hash, just after salt
-        mstore(64, caller())
-    } else {
-        // exclude sender from salt - susceptible to front-running
-        // assuming no bytes were written to memory word at 64 and it's all zeros
-    }
-
-    let init_data_size := sub(size, 65)
-
-    // copy init_data to memory to hash, just after caller (or zeros)
-    calldatacopy(96, 65, init_data_size)
-
-    // final_salt = keccak256(tx_initcode_hash | salt | caller_or_zeros | init_data)
-    let final_salt := keccak256(0, 96 + init_data_size)
-
-    let tx_initcode_hash := calldataload(0)
-
-    // reuse init_data which has been already copied to memory above
-    let ret := txcreate(tx_initcode_hash, callvalue(), final_salt, 96, init_data_size)
-
-    if iszero(ret) {
-        let ret_data_size := returndatasize()
-        returndatacopy(0, 0, ret_data_size)
-        revert(0, ret_data_size)
-    }
-
-    mstore(0, ret)
-    return(0, 32)
-
-    // Helper to compile this with existing Solidity (with --strict-assembly mode)
-    function txcreate(a, b, c, d, e) -> f {
-        f := verbatim_5i_1o(hex"ed", a, b, c, d, e)
-    }
-}
-```
-
 ## Rationale
+
+### `to: nil` transactions cannot use `TXCREATE`
+
+By ruling out `InitcodeTransactions` which have `to: nil` we're ruling out the possibility of making such transactions with a legacy EVM initcode which only calls into `TXCREATE` and `SELFDESTRUCTS`. Since the main purpose of allowing `TXCREATE` in legacy EVM code is to bootstrap proper EOF factories, the constrained rules make more sense.
 
 ### `TXCREATE` failure modes
     
 `TXCREATE` has two "light" failure modes in case the initcontainer is not present and in case the EOF validation is unsuccessful. An alternative design where both cases led to a "hard" failure (consuming the entire gas available) was considered. We decided to have the more granular and forgiving failure modes in order to align the gas costs incurred to the actual work the EVM performs.
 
-### Creator Contract
+### Allowing `TXCREATE` in legacy EVM
 
-EOF contract creation requires a predeployed Creator Contract to be introduced, because neither legacy contracts nor create transactions can deploy EOF code to bootstrap. The alternative approach was to continue using legacy creation mechanisms, by either still relying on fetching the *initcode* from memory and not satisfy the overarching requirement of code non-observability, or to abuse the legacy creation transactions mechanism.
-
-Since previous discussions about `TXCREATE`, which led to its removal from EOF along with the Creator Contract, there is wider consensus to allow predeploy contracts be put into the state, for example as a means to reduce the number of supported precompiles. Meanwhile, opinions about the importance of supporting deployments to deterministic, counterfactual, cross-chain addresses have been voiced by the community, making the case for this proposal stronger.
+EOF contract creation requires an exceptional possibility of calling an EOF opcode in legacy code - `TXCREATE`, because otherwise neither legacy contracts nor create transactions can deploy EOF code to bootstrap. The alternative approach was to continue using legacy creation mechanisms, by either still relying on fetching the *initcode* from memory and not satisfy the overarching requirement of code non-observability, or to abuse the legacy creation transactions mechanism, or to introduce a predeployed Creator Contract into the state.
 
 This also makes [EIP-7698](./eip-7698.md) (EOF - Creation transaction) no longer an essential requirement for deploying EOF contracts onto the chain. The EIP could be removed from EOFv1 and withdrawn.
 
@@ -235,13 +167,17 @@ This also makes [EIP-7698](./eip-7698.md) (EOF - Creation transaction) no longer
 
 ### EOF creation transactions vs deployment patterns
 
-Relying on the EOF creation transactions as alternative solution makes it impossible for smart contract wallets to deploy arbitrary EOF contracts (only EOAs can). At the same time, it is a use case current legacy creation rules allow, thanks to `CREATE` and `CREATE2` instructions. A workaround where those arbitrary EOF contracts are first "uploaded" to a factory contract, and then deployed using an `EXTDELEGATECALL`-`EOFCREATE` sequence, is very expensive, as it requires the deployed contract to be put on-chain twice. Because of this, the approach proposed in this EIP is more compatible with the Account Abstraction (AA) roadmap, where smart contract wallets should have feature parity with EOAs.
+Relying on the EOF creation transactions as the alternative solution makes it impossible for smart contract wallets to deploy arbitrary EOF contracts (only EOAs can). At the same time, it is a use case current legacy creation rules allow, thanks to `CREATE` and `CREATE2` instructions. A workaround where those arbitrary EOF contracts are first "uploaded" to a factory contract, and then deployed using an `EXTDELEGATECALL`-`EOFCREATE` sequence, is very expensive, as it requires the deployed contract to be put on-chain twice. Because of this, the approach proposed in this EIP is more compatible with the Account Abstraction (AA) roadmap, where smart contract wallets should have feature parity with EOAs.
 
-On top of this, relying on nonce-based hashing scheme to obtain addresses of newly created contracts, like in the case of the EOF creation transactions, would prevent EOF contracts from being deployed counterfactually to deterministic, cross-chain addresses. Introduction of the `TXCREATE` instruction, combined with the proposed "toehold" Creator Contract predeployed to an agreed upon address, supports this out of the box. ERCs can be written to provide other toehold contracts with features not supported by this inital contract, such as salt-less deployment and hashing in the sender's address as part of the salt.
+On top of this, relying on nonce-based hashing scheme to obtain addresses of newly created contracts, like in the case of the EOF creation transactions, would prevent EOF contracts from being deployed counterfactually to deterministic, cross-chain addresses. Introduction of the `TXCREATE` instruction, supports this out of the box. ERCs can be written to provide toehold contracts which will cater for the deployment patterns, such as salt-less deployment and hashing in the sender's address as part of the salt.
 
 ## Backwards Compatibility
 
-This change poses no risk to backwards compatibility, as it is introduced at the same time EIP-3540 is. The new instruction are not introduced for legacy bytecode (code which is not EOF formatted), and the contract creation options do not change for legacy bytecode. The transactions of the new type are invalid until this change activates.
+This change poses no risk to backwards compatibility, as it is introduced at the same time EIP-3540 is. Despite the new instruction being introduced for legacy bytecode (code which is not EOF formatted), there is little chance that a meaningful contract would unintentionally execute `0xed` instruction with formally valid operands and inadvertently cause it to run EOF initcode (which would also require an `InitcodeTransaction` to be used, otherwise the initcode lookup will fail).
+
+The transactions of the new type are invalid until this change activates.
+
+Contract creation options do not change for legacy bytecode.
 
 ## Security Considerations
 

--- a/EIPS/eip-7873.md
+++ b/EIPS/eip-7873.md
@@ -4,7 +4,7 @@ title: EOF - TXCREATE and InitcodeTransaction type
 description: Adds a `TXCREATE` instruction to EOF and an accompanying transaction type allowing to create EOF contracts from transaction data
 author: Piotr Dobaczewski (@pdobacz), Andrei Maiboroda (@gumb0), Paweł Bylica (@chfast), Alex Beregszaszi (@axic), Danno Ferrin (@shemnon)
 discussions-to: https://ethereum-magicians.org/t/eip-7873-eof-txcreate-instruction-and-initcodetransaction-type/22765
-status: Draft
+status: Review
 type: Standards Track
 category: Core
 created: 2025-01-31

--- a/EIPS/eip-7873.md
+++ b/EIPS/eip-7873.md
@@ -147,10 +147,6 @@ Note that the implementations are expected to cache the result of container vali
 
 ## Rationale
 
-### `to: nil` transactions cannot use `TXCREATE`
-
-By ruling out `InitcodeTransactions` which have `to: nil` we're ruling out the possibility of making such transactions with a legacy EVM initcode which only calls into `TXCREATE` and `SELFDESTRUCTS`. Since the main purpose of allowing `TXCREATE` in legacy EVM code is to bootstrap proper EOF factories, the constrained rules make more sense.
-
 ### `TXCREATE` failure modes
     
 `TXCREATE` has two "light" failure modes in case the initcontainer is not present and in case the EOF validation is unsuccessful. An alternative design where both cases led to a "hard" failure (consuming the entire gas available) was considered. We decided to have the more granular and forgiving failure modes in order to align the gas costs incurred to the actual work the EVM performs.
@@ -174,6 +170,8 @@ On top of this, relying on nonce-based hashing scheme to obtain addresses of new
 ## Backwards Compatibility
 
 This change poses no risk to backwards compatibility, as it is introduced at the same time EIP-3540 is. Despite the new instruction being introduced for legacy bytecode (code which is not EOF formatted), there is little chance that a meaningful contract would unintentionally execute `0xed` instruction with formally valid operands and inadvertently cause it to run EOF initcode (which would also require an `InitcodeTransaction` to be used, otherwise the initcode lookup will fail).
+
+`TXCREATE` instruction introduction into legacy EVM does not affect `JUMPDEST` analysis, because instruction has no immediate arguments.
 
 The transactions of the new type are invalid until this change activates.
 


### PR DESCRIPTION
Huge kudos to @jochem-brouwer for pointing us into this direction in the [EthMag thread](https://ethereum-magicians.org/t/eip-7873-eof-txcreate-and-initcodetransaction-type/22765/11).

Allowing legacy-TXCREATE to bootstrap the EOF contracts into existence, instead of the predeployed Creator Contract is a very tempting option. This PR aims to demonstrate the idea and provide venue for discussion.