### PR TITLE
docs: fix inconsistency in G2 group point notation

### DIFF
--- a/assets/eip-2537/fast_subgroup_checks.md
+++ b/assets/eip-2537/fast_subgroup_checks.md
@@ -8,7 +8,8 @@ Field Fp2 is defined as `Fp[X]/(X^2-nr2)` with elements  `el = c0 + c1 * v`, whe
  
 Group G1 is defined as a set of Fp pairs (points) `(x,y)` such that either `(x,y)` is  `(0,0)` or `x,y` satisfy the curve Fp equation.
 
-Group G2 is defined as a set of Fp2 pairs (points) `(x',y')` such that either `(x,y)` is `(0,0)` or `(x',y')` satisfy the curve Fp2 equation.
+Group G2 is defined as a set of Fp2 pairs (points) `(x', y')` such that either `(x', y')` is `(0,0)` or `(x', y')` satisfy the curve Fp2 equation.
+
 
 ## Curve parameters
 


### PR DESCRIPTION
I noticed that in the description of the G2 group, the points are referred to as **(x', y')**, but later, the endomorphism check is described using **(x, y)**. This inconsistency could lead to confusion, so I updated the description to consistently use **(x', y')** for G2 points.

Now the description reads:
```
Group G2 is defined as a set of Fp2 pairs (points) `(x', y')` such that either `(x', y')` is `(0,0)` or `(x', y')` satisfy the curve Fp2 equation.
```