### PR TITLE
Update EIP-3860: Update eip-3860.md

### DIFF
--- a/EIPS/eip-3860.md
+++ b/EIPS/eip-3860.md
@@ -100,7 +100,7 @@ We specified that initcode size limit violation for `CREATE`/`CREATE2` results i
 
 This EIP requires a "network upgrade", since it modifies consensus rules.
 
-Already deployed contracts should not be effected, but certain transactions (with `initcode` beyond the proposed limit) would still be includable in a block, but result in an exceptional abort.
+Already deployed contracts should not be affected, but certain transactions (with `initcode` beyond the proposed limit) would still be includable in a block, but result in an exceptional abort.
 
 ## Test Cases
 


### PR DESCRIPTION
Hi,

The word "effected" in 'Backwards Compatibility' section) seem to be incorrect in this context. The correct term is "affected".

I suggested a revision: "effected" to "affected".

Thanks.