### PR TITLE
Update EIP-7701: Minor fixes

### DIFF
--- a/EIPS/eip-7701.md
+++ b/EIPS/eip-7701.md
@@ -50,7 +50,6 @@ AA_TX_TYPE || rlp([
   paymaster, paymasterData,
   senderExecutionData,
   validAfter, validUntil,
-  builderFee,
   maxPriorityFeePerGas, maxFeePerGas,
   senderValidationGasLimit, paymasterValidationGasLimit,
   senderExecutionGasLimit, paymasterPostOpGasLimit,
@@ -227,37 +226,33 @@ families.
    * `size`: byte size to copy.
 
 The valid values for `n` are described in the table below.
-| `n`  | Return value                  | Data size |
-|------|-------------------------------|-----------|
-| 0x00 | current transaction type      | 32        |
-| 0x01 | current transaction hash      | 32        |
-| 0x02 | current role                  | 32        |
-| 0x03 | `nonce`                       | 32        |
-| 0x04 | `sender`                      | 32        |
-| 0x05 | `senderValidationData`        | dynamic   |
-| 0x06 | `deployer`                    | 0 or 32   |
-| 0x07 | `deployerData`                | dynamic   |
-| 0x08 | `paymaster`                   | 0 or 32   |
-| 0x09 | `paymasterData`               | dynamic   |
-| 0x0A | `senderExecutionData`         | dynamic   |
-| 0x0B | `validAfter`                  | 32        |
-| 0x0C | `validUntil`                  | 32        |
-| 0x0D | `builderFee`                  | 32        |
-| 0x0E | `maxPriorityFeePerGas`        | 32        |
-| 0x0F | `maxFeePerGas`                | 32        |
-| 0x10 | `senderValidationGasLimit`    | 32        |
-| 0x11 | `paymasterValidationGasLimit` | 32        |
-| 0x12 | `senderExecutionGasLimit`     | 32        |
-| 0x13 | `paymasterPostOpGasLimit`     | 32        |
-| 0x14 | `accessList` hash             | 32        |
-| 0x15 | `authorizationList` hash      | 32        |
-| 0xA0 | `executionStatus`             | 32        |
-| 0xA1 | `executionGasCost`            | 32        |
+Note that some parameters are "optional" for AA transactions and these parameters have default values as stated below.
 
-### Default values
-
-Parameters `deployer` and `paymaster` are considered optional.
-Accessing them will return `address(0)` if these values are left empty by the transaction input.
+| `n`  | Return value                  | Data size | Default      |
+|------|-------------------------------|-----------|--------------|
+| 0x00 | current transaction type      | 32        |              |
+| 0x01 | current transaction hash      | 32        |              |
+| 0x02 | current role                  | 32        |              |
+| 0x03 | `nonce`                       | 32        |              |
+| 0x04 | `sender`                      | 32        |              |
+| 0x05 | `senderValidationData`        | dynamic   |              |
+| 0x06 | `deployer`                    | 0 or 32   | `address(0)` |
+| 0x07 | `deployerData`                | dynamic   | empty array  |
+| 0x08 | `paymaster`                   | 0 or 32   | `address(0)` |
+| 0x09 | `paymasterData`               | dynamic   | empty array  |
+| 0x0A | `senderExecutionData`         | dynamic   |              |
+| 0x0B | `validAfter`                  | 32        | `0`          |
+| 0x0C | `validUntil`                  | 32        | `2^256-1`    |
+| 0x0D | `maxPriorityFeePerGas`        | 32        |              |
+| 0x0E | `maxFeePerGas`                | 32        |              |
+| 0x0F | `senderValidationGasLimit`    | 32        |              |
+| 0x10 | `paymasterValidationGasLimit` | 32        | `0`          |
+| 0x11 | `senderExecutionGasLimit`     | 32        |              |
+| 0x12 | `paymasterPostOpGasLimit`     | 32        | `0`          |
+| 0x13 | `accessList` hash             | 32        |              |
+| 0x14 | `authorizationList` hash      | 32        |              |
+| 0xA0 | `executionStatus`             | 32        |              |
+| 0xA1 | `executionGasCost`            | 32        |              |
 
 ### Limitations on `TXPARAM*` opcodes
 
@@ -355,6 +350,13 @@ Note that some behaviours in the EVM depend on the transaction context. These be
 
 These features are not affected by the separation of the transaction into multiple frames.
 Meaning, for example, that a value set with `TSTORE (0x5D)` in one frame will remain available in the next one.
+
+### Costs of accessing cold addresses for Sender, Paymaster and Deployer
+
+The Sender address is pre-warmed as part of the `AA_BASE_GAS_COST`.
+
+When non-zero address, that is not equal to the Sender address, is provided for a Paymaster or a Deployer contract,
+an additional EIP-2929 `COLD_ACCOUNT_READ_COST` cost of 2600 gas is charged and the address is added to `accessed_addresses`.
 
 ### Flow diagrams
 
@@ -477,9 +479,9 @@ def buy_gas(tx, block):
 # refund the unused gas value of the transaction to the payer (sender or paymaster)
 def refund_gas(tx, gas_refund):
     if tx.paymaster is None:
-        balances[tx.paymaster] += total_max_cost
+        balances[tx.paymaster] += gas_refund
     else:
-        balances[tx.sender] += total_max_cost
+        balances[tx.sender] += gas_refund
 
 ```
 

--- a/EIPS/eip-7701.md
+++ b/EIPS/eip-7701.md
@@ -536,7 +536,7 @@ execution starting point, which might confuse some developer tooling that relies
 
 As the `kind_entry_points` code sections represent a generic way to authorize any action on behalf of the contract,
 correct and secure implementation of this code is critical.
-We expect compilers targeting EVM will play a major role in enabling and ensuring Smart Contract Accounts' security.
+We expect that compilers targeting EVM will play a major role in enabling and ensuring Smart Contract Accounts' security.
 
 For smart contract security auditors and security-oriented developer tools it is crucial to ensure that contracts not
 meant to have roles in AA transactions do not have unexpected code section defined in their `entry_points_section`.

--- a/EIPS/eip-7701.md
+++ b/EIPS/eip-7701.md
@@ -469,7 +469,7 @@ def get_code(target_address):
 def buy_gas(tx, block):
     max_gas = tx.senderValidationGasLimit + tx.paymasterValidationGasLimit + tx.senderExecutionGasLimit + tx.paymasterPostOpGasLimit
     gas_price = min(tx.maxFeePerGas, block.baseFeePerGas + tx.maxPriorityFeePerGas)
-    total_max_cost = tx.builderFee + max_gas * gas_price
+    total_max_cost = max_gas * gas_price
     if tx.paymaster is None:
         balances[tx.paymaster] -= total_max_cost
     else:

--- a/EIPS/eip-7701.md
+++ b/EIPS/eip-7701.md
@@ -89,8 +89,8 @@ AA_TX_TYPE || rlp([
   A set of EIP-7701 Call Frames that form a single step in an EIP-7701 Transaction flow.
   There are two phases in an EIP-7701 Transaction: *validation* and *execution*
 * **Validation phase**:
-  A set of EIP-7701 Call Frames that define the current EIP-7701 Transaction's **Validity** by executing the *
-  *validation** EVM code.
+  A set of EIP-7701 Call Frames that define the current EIP-7701 Transaction's **Validity** by executing the
+  **validation** EVM code.
 * **Execution phase**:
   A set of EIP-7701 Call Frames that perform the actions according to the `Sender` and the `Paymaster` contracts'
   interpretation of the user input.
@@ -148,7 +148,7 @@ This is reserved for execution of special roles in the `entry_point_role` range.
 
 Note: do not confuse code EOF's execution `entry_point` with the `EntryPoint` contract defined in ERC-4337.
 
-### Validation and PostTransaction code entry points
+### Validation and PostOp code entry points
 
 We define the following as a valid `entry_point_role` values:
 
@@ -157,14 +157,14 @@ role_sender_execution = 0x0001
 role_sender_deployment = 0x0002
 role_sender_validation = 0x00003
 role_paymaster_validation = 0x0004
-role_paymaster_post_tx = 0x0005
+role_paymaster_post_op = 0x0005
 ```
 
 The contract that acts as a `Deployer`  in an AA transaction MUST contain the `role_sender_deployment` code section.
 
 The contract that acts as a `Sender`  in an AA transaction MUST contain the `role_sender_validation` and `role_sender_execution` code sections.
 
-The contract that acts as a `Paymaster`  in an AA transaction MUST contain the `role_paymaster_validation` and `role_paymaster_post_tx` code sections.
+The contract that acts as a `Paymaster`  in an AA transaction MUST contain the `role_paymaster_validation` and `role_paymaster_post_op` code sections.
 
 Code from code sections with an assigned role can be executed during a legacy transaction execution and has no special effects.
 If it is the code section `0` of a contract it can even act as an entry point during legacy transaction execution.
@@ -227,29 +227,30 @@ families.
    * `size`: byte size to copy.
 
 The valid values for `n` are described in the table below.
-
 | `n`  | Return value                  | Data size |
 |------|-------------------------------|-----------|
 | 0x00 | current transaction type      | 32        |
-| 0x01 | current role                  | 32        |
-| 0x02 | `sender`                      | 32        |
-| 0x03 | `senderValidationData`        | dynamic   |
-| 0x04 | `deployer`                    | 0 or 32   |
-| 0x05 | `deployerData`                | dynamic   |
-| 0x06 | `paymaster`                   | 0 or 32   |
-| 0x07 | `paymasterData`               | dynamic   |
-| 0x08 | `senderExecutionData`         | dynamic   |
-| 0x09 | `validAfter`                  | 32        |
-| 0x0A | `validUntil`                  | 32        |
-| 0x0B | `builderFee`                  | 32        |
-| 0x0C | `maxPriorityFeePerGas`        | 32        |
-| 0x0D | `maxFeePerGas`                | 32        |
-| 0x0E | `senderValidationGasLimit`    | 32        |
-| 0x0F | `paymasterValidationGasLimit` | 32        |
-| 0x10 | `senderExecutionGasLimit`     | 32        |
-| 0x11 | `paymasterPostOpGasLimit`     | 32        |
-| 0x12 | `accessList` hash             | 32        |
-| 0x13 | `authorizationList` hash      | 32        |
+| 0x01 | current transaction hash      | 32        |
+| 0x02 | current role                  | 32        |
+| 0x03 | `nonce`                       | 32        |
+| 0x04 | `sender`                      | 32        |
+| 0x05 | `senderValidationData`        | dynamic   |
+| 0x06 | `deployer`                    | 0 or 32   |
+| 0x07 | `deployerData`                | dynamic   |
+| 0x08 | `paymaster`                   | 0 or 32   |
+| 0x09 | `paymasterData`               | dynamic   |
+| 0x0A | `senderExecutionData`         | dynamic   |
+| 0x0B | `validAfter`                  | 32        |
+| 0x0C | `validUntil`                  | 32        |
+| 0x0D | `builderFee`                  | 32        |
+| 0x0E | `maxPriorityFeePerGas`        | 32        |
+| 0x0F | `maxFeePerGas`                | 32        |
+| 0x10 | `senderValidationGasLimit`    | 32        |
+| 0x11 | `paymasterValidationGasLimit` | 32        |
+| 0x12 | `senderExecutionGasLimit`     | 32        |
+| 0x13 | `paymasterPostOpGasLimit`     | 32        |
+| 0x14 | `accessList` hash             | 32        |
+| 0x15 | `authorizationList` hash      | 32        |
 | 0xA0 | `executionStatus`             | 32        |
 | 0xA1 | `executionGasCost`            | 32        |
 
@@ -260,7 +261,7 @@ Accessing them will return `address(0)` if these values are left empty by the tr
 
 ### Limitations on `TXPARAM*` opcodes
 
-The `executionStatus` and `executionGasCost` parameters are only accessible in the `role_paymaster_post_tx` section.
+The `executionStatus` and `executionGasCost` parameters are only accessible in the `role_paymaster_post_op` section.
 
 The rest of parameters are only accessible in the following code sections:
 
@@ -270,7 +271,7 @@ The rest of parameters are only accessible in the following code sections:
 
 Accessing these values in any other code sections is considered to be an invalid opcode and reverts the execution.
 
-#### Time range validity
+#### Time range validity (optional)
 
 If the `validUntil` field is non-zero, the transaction is only valid for inclusion in a block with a timestamp at most `validUntil` value.
 Similarly, the transaction is only valid for inclusion in blocks with a timestamp at most the `validAfter` value.
@@ -301,11 +302,11 @@ If it does, the `Paymaster` contract is charged for the transaction gas costs in
 
 This step is performed with the `role_sender_execution` code section.
 
-Inputs to the `Sender` contract are not defined by the protocol and are controlled by the `callData` parameter.
+Inputs to the `Sender` contract are not defined by the protocol and are controlled by the `senderExecutionData` parameter.
 
 #### Paymaster post-transaction frame (optional)
 
-This step is performed with the `role_paymaster_post_tx` code section.
+This step is performed with the `role_paymaster_post_op` code section.
 
 It is intended to provide the Paymaster contract with an opportunity to finalize any calculations after the
 results of the Sender Execution are known.
@@ -330,7 +331,7 @@ The full list of possible frames and their corresponding code sections is as fol
     * `paymaster` validation frame (optional) - `role_paymaster_validation`
 2. **Execution Phase**
     * `sender` execution frame (required) - `role_sender_execution`
-    * `paymaster` post-transaction frame (optional) - `role_paymaster_post_tx`
+    * `paymaster` post-transaction frame (optional) - `role_paymaster_post_op`
 
 All execution frames in the **Validation Phase** must be completed successfully without reverting
 in order for the transaction to be considered valid for a given position in a block.
@@ -375,8 +376,8 @@ Meaning, for example, that a value set with `TSTORE (0x5D)` in one frame will re
 
 ```python
 
-def state_transition_function(tx):
-    buy_gas(tx)
+def state_transition_function(tx, block):
+    buy_gas(tx, block)
     deployer_result = deployer_frame(tx)
     paymaster_result = paymaster_validation_frame(tx)
     sender_result = sender_validation_frame(tx)
@@ -388,7 +389,8 @@ def state_transition_function(tx):
         raise Exception("validation failed")
     sender_execution_frame(tx)
     paymaster_postop_frame(tx)
-    refund_gas(tx)
+    gas_refund = calculate_gas_refund()
+    refund_gas(tx, gas_refund)
 
 
 def deployer_frame(tx):
@@ -432,7 +434,7 @@ def paymaster_postop_frame(tx):
     if tx.paymaster is None:
         return {"success": True}
     result = call_section(
-        AA_ENTRY_POINT, role_paymaster_post_tx,
+        AA_ENTRY_POINT, role_paymaster_post_op,
         tx.sender, [], tx.paymasterPostOpGasLimit)
     return result
 
@@ -462,13 +464,22 @@ def get_code(target_address):
 
 
 # pre-charge the entire maximum gas cost of the transaction
-def buy_gas(tx):
-    pass
+def buy_gas(tx, block):
+    max_gas = tx.senderValidationGasLimit + tx.paymasterValidationGasLimit + tx.senderExecutionGasLimit + tx.paymasterPostOpGasLimit
+    gas_price = min(tx.maxFeePerGas, block.baseFeePerGas + tx.maxPriorityFeePerGas)
+    total_max_cost = tx.builderFee + max_gas * gas_price
+    if tx.paymaster is None:
+        balances[tx.paymaster] -= total_max_cost
+    else:
+        balances[tx.sender] -= total_max_cost
 
 
 # refund the unused gas value of the transaction to the payer (sender or paymaster)
-def refund_gas(tx):
-    pass
+def refund_gas(tx, gas_refund):
+    if tx.paymaster is None:
+        balances[tx.paymaster] += total_max_cost
+    else:
+        balances[tx.sender] += total_max_cost
 
 ```
 
@@ -481,11 +492,10 @@ def block_transition_function(block):
             try:
                 if (tx.validUntil != 0 and tx.validUntil <= block.timestamp) or tx.validAfter >= block.timestamp:
                     raise Exception("time range violation")
-                state_transition_function(tx)
+                state_transition_function(tx, block)
             except Exception:
-                # validation failed and this transaction cannot be included in the current block
-                del block.txs[index]
-                continue
+                # validation failed and this transaction could not have been included in the current block
+                raise Exception("invalid AA Transaction in block")
         else:
             legacy_state_transition_function(tx)
 ```
@@ -499,9 +509,6 @@ details in order to be able to make an informed decision about either accepting 
 
 A small subset of this data is available with the existing opcodes, like `CALLER (0x33)` or `GASPRICE  (0x3A)`.
 However, creating an opcode for every transaction parameter is not feasible or desirable.
-
-Allowing wallets to specify their own encoding for this data is also not feasible as Smart Contract Accounts must
-avoid any ambiguity about the meaning of the received data.
 
 The `TXPARAM*` opcode family provides the Account Abstraction contracts with access to this data.
 
@@ -528,6 +535,12 @@ execution starting point, which might confuse some developer tooling that relies
 As the `kind_entry_points` code sections represent a generic way to authorize any action on behalf of the contract,
 correct and secure implementation of this code is critical.
 We expect compilers targeting EVM will play a major role in enabling and ensuring Smart Contract Accounts' security.
+
+For smart contract security auditors and security-oriented developer tools it is crucial to ensure that contracts not
+meant to have roles in AA transactions do not have unexpected code section defined in their `entry_points_section`.
+Otherwise, these contracts may present an immediate security threat.
+
+Block explorers should tag contracts as "user accounts" or "paymasters" if they have these sections.
 
 ## Copyright
 

--- a/EIPS/eip-7701.md
+++ b/EIPS/eip-7701.md
@@ -13,7 +13,7 @@ requires: 3540
 
 ## Abstract
 
-We propose splitting the Ethereum transaction scope into multiple steps: validations, execution, and post-transaction logic. Transaction validity is determined by the result of the validation steps of a transaction.
+We propose splitting the Ethereum transaction scope into multiple steps: validations, execution, and post-operation logic. Transaction validity is determined by the result of the validation steps of a transaction.
 
 We further separate transaction validation for the purposes of authorization and the gas fee payment, allowing one contract to pay gas for a transaction that will be executed from another contract.
 
@@ -304,7 +304,7 @@ This step is performed with the `role_sender_execution` code section.
 
 Inputs to the `Sender` contract are not defined by the protocol and are controlled by the `senderExecutionData` parameter.
 
-#### Paymaster post-transaction frame (optional)
+#### Paymaster post-operation frame (optional)
 
 This step is performed with the `role_paymaster_post_op` code section.
 
@@ -331,7 +331,7 @@ The full list of possible frames and their corresponding code sections is as fol
     * `paymaster` validation frame (optional) - `role_paymaster_validation`
 2. **Execution Phase**
     * `sender` execution frame (required) - `role_sender_execution`
-    * `paymaster` post-transaction frame (optional) - `role_paymaster_post_op`
+    * `paymaster` post-operation frame (optional) - `role_paymaster_post_op`
 
 All execution frames in the **Validation Phase** must be completed successfully without reverting
 in order for the transaction to be considered valid for a given position in a block.


### PR DESCRIPTION
1. Fix broken **bold** markdown
2. Rename "PostTransaction" back to "PostOp"
3. Add "current transaction hash" and "nonce" to the "TXPARAM" table
4. Mark "time range validity" as "optional"
5. Fix using deprecated "callData" term instead of "senderExecutionData"
6. Provide pseudocode for "buy_gas" and "refund_gas"
7. Raise exception instead of skipping invalid AA tx in block pseudocode
8. Add security considerations