### PR TITLE
Update EIP-7702: Add checks for signatures in authorization lists

### DIFF
--- a/EIPS/eip-7702.md
+++ b/EIPS/eip-7702.md
@@ -100,6 +100,9 @@ following:
 3. `authority = ecrecover(msg, y_parity, r, s)`
     * `msg = keccak(MAGIC || rlp([chain_id, address, nonce]))`
     * `s` value must be less than or equal to `secp256k1n/2`, as specified in [EIP-2](./eip-2.md).
+    * `r` value must be less than `secp256k1n`.
+    * `s` and `r` values must be non-zero.
+    * `y_parity` value must be either `0` or `1`.
 4. Add `authority` to `accessed_addresses` (as defined in [EIP-2929](./eip-2929.md).)
 5. Verify the code of `authority` is either empty or already delegated.
 6. Verify the nonce of `authority` is equal to `nonce`. In case `authority` does


### PR DESCRIPTION
This PR adds some checks that are being done by all EL clients to the signature values of authorization lists, which are not stated in the EIP. As such, developers following the spec may have issues, as they would be working with signatures that are invalid at the EL layer. As an example, see [Geth](https://github.com/ethereum/go-ethereum/blob/80753ba14787ba82954106d7b9025e3a623b96b0/crypto/crypto.go#L277) (this is called when checking the auth signatures [here](https://github.com/ethereum/go-ethereum/blob/80753ba14787ba82954106d7b9025e3a623b96b0/core/types/tx_setcode.go#L119))