### PR TITLE
docs: fix grammar and typo issues

### DIFF
--- a/EIPS/eip-1052.md
+++ b/EIPS/eip-1052.md
@@ -46,9 +46,9 @@ Only the 20 last bytes of the argument are significant (the first 12 bytes are
 ignored) similarly to the semantics of the `BALANCE` (`0x31`), `EXTCODESIZE` (`0x3b`) and 
 `EXTCODECOPY` (`0x3c`).
 
-The `EXTCODEHASH` distincts accounts without code and non-existing accounts.
+The `EXTCODEHASH` distinguishes accounts without code and non-existing accounts.
 This is consistent with the way accounts are represented in the state trie.
-This also allows smart contracts to check whenever an account exists.
+This also allows smart contracts to check whether an account exists.
 
 
 ## Backwards Compatibility
@@ -59,7 +59,7 @@ There are no backwards compatibility concerns.
 ## Test Cases
 
 1. The `EXTCODEHASH` of the account without code is `c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470`
-   what is the keccack256 hash of empty data.
+   what is the keccak256 hash of empty data.
 2. The `EXTCODEHASH` of non-existent account is `0`.
 3. The `EXTCODEHASH` of a precompiled contract is either `c5d246...` or `0`.
 4. If `EXTCODEHASH` of `A` is `X`, then `EXTCODEHASH` of `A + 2**160` is `X`.


### PR DESCRIPTION
### Description

- replaced incorrect verb usage of "distincts" with "distinguishes" — more natural and grammatically correct.
- swapped out "whenever" for "whether" when referring to conditional checking.
- corrected a typo in `keccack256`, now properly spelled as `keccak256`.
