### PR TITLE
Update EIP-7793, EIP-7843: Change precompiles to opcodes

### DIFF
--- a/EIPS/eip-7793.md
+++ b/EIPS/eip-7793.md
@@ -1,7 +1,7 @@
 ---
 eip: 7793
-title: TXINDEX precompile
-description: Precompile to get index of transaction within block
+title: TXINDEX opcode
+description: Opcode to get index of transaction within block
 author: Marc Harvey-Hill (@Marchhill), Ahmad Bitar (@smartprogrammer93)
 discussions-to: https://ethereum-magicians.org/t/eip-7793-txindex-precompile/21513
 status: Draft
@@ -12,19 +12,27 @@ created: 2024-10-17
 
 ## Abstract
 
-This EIP proposes to add a new precompile that returns the index of the transaction being executed within the current block.
+This EIP proposes to add a new opcode that returns the index of the transaction being executed within the current block.
 
 ## Motivation
 
-The new precompile aims to improve support for encrypted mempools. In order to be secure, the validity of encrypted mempool transactions should be tied to the inclusion of all transactions by a proposer in the correct slot, and following the ordering rules. If these rules are not enshrined as block validity conditions then they can be enforced by a smart contract.
+The new opcode aims to improve support for encrypted mempools. In order to be secure, the validity of encrypted mempool transactions should be tied to the inclusion of all transactions by a proposer in the correct slot, and following the ordering rules. If these rules are not enshrined as block validity conditions then they can be enforced by a smart contract.
 
 This proposal enables smart contract solutions to check their own transaction index, so they can enforce inclusion at the correct index. These out-of-protocol solutions could be used for experimentation until a design appropriate for enshrinement is agreed upon.
 
 ## Specification
 
-If `block.timestamp >= TBD` a new precompiled contract `TXINDEX` shall be created at address `TBD`.
+A new opcode `TXINDEX` shall be created at `TBD`. It shall return one stack element.
 
-`TXINDEX` returns as output the transaction index as a 4 byte uint in big endian encoding.
+### Output
+
+#### Stack
+
+| Stack      | Value        |
+| ---------- | -------------|
+| `top - 0`  | `Index`      |
+
+`Index` is a 4 byte uint in big endian encoding. 
 
 ### Gas Cost
 
@@ -34,15 +42,11 @@ The gas cost for `TXINDEX` is a fixed fee of `2`
 
 ### Gas Price
 
-The precompile is priced to match similar opcodes in the `W_base` set.
-
-### Precompile
-
-Making the feature a precompile rather than an opcode gives L2s flexibility to decide whether to implement it.
+The opcode is priced to match similar opcodes in the `W_base` set.
 
 ### ZK-VM proving
 
-The TXINDEX precompile should not increase the complexity of proving EVM execution, as it is similar to existing opcodes such as GAS. If a whole block is proven then no additional inputs to the circuit are required to prove transaction indices, as they can be inferred from the transaction ordering. If a transaction is proved individually then the index must be provided as an input to the circuit, along with the remaining gas for GAS, and more for other introspective opcodes.
+The TXINDEX opcode should not increase the complexity of proving EVM execution, as it is similar to existing opcodes such as GAS. If a whole block is proven then no additional inputs to the circuit are required to prove transaction indices, as they can be inferred from the transaction ordering. If a transaction is proved individually then the index must be provided as an input to the circuit, along with the remaining gas for GAS, and more for other introspective opcodes.
 
 ## Backwards Compatibility
 

--- a/EIPS/eip-7793.md
+++ b/EIPS/eip-7793.md
@@ -28,15 +28,15 @@ A new opcode `TXINDEX` shall be created at `TBD`. It shall return one stack elem
 
 #### Stack
 
-| Stack      | Value        |
-| ---------- | -------------|
-| `top - 0`  | `Index`      |
+| Stack      | Value    |
+| ---------- | -------- |
+| `top - 0`  | `Index`  |
 
 `Index` is a 4 byte uint in big endian encoding. 
 
 ### Gas Cost
 
-The gas cost for `TXINDEX` is a fixed fee of `2`
+The gas cost for `TXINDEX` is a fixed fee of `2`.
 
 ## Rationale
 

--- a/EIPS/eip-7843.md
+++ b/EIPS/eip-7843.md
@@ -1,6 +1,6 @@
 ---
 eip: 7843
-title: SLOT opcode
+title: SLOTNUM opcode
 description: Opcode to get the current slot number
 author: Marc Harvey-Hill (@Marchhill)
 discussions-to: https://ethereum-magicians.org/t/eip-7843-slot-precompile/22234
@@ -24,21 +24,21 @@ An example of a smart contract that needs the slot number is a validation contra
 
 ## Specification
 
-A new opcode `SLOT` shall be created at `TBD`. It shall return one stack element.
+A new opcode `SLOTNUM` shall be created at `TBD`. It shall return one stack element.
 
 ### Output
 
 #### Stack
 
-| Stack      | Value        |
-| ---------- | -------------|
-| `top - 0`  | `Slot`      |
+| Stack      | Value         |
+| ---------- | ------------- |
+| `top - 0`  | `SlotNumber`  |
 
-`Slot` is an 8 byte uint in big endian encoding. 
+`SlotNumber` is an 8 byte uint in big endian encoding.
 
 ### Gas Cost
 
-The gas cost for `SLOT` is a fixed fee of `2`.
+The gas cost for `SLOTNUM` is a fixed fee of `2`.
 
 ### RPC changes
 

--- a/EIPS/eip-7843.md
+++ b/EIPS/eip-7843.md
@@ -1,7 +1,7 @@
 ---
 eip: 7843
-title: SLOT precompile
-description: Precompile to get the current slot number
+title: SLOT opcode
+description: Opcode to get the current slot number
 author: Marc Harvey-Hill (@Marchhill)
 discussions-to: https://ethereum-magicians.org/t/eip-7843-slot-precompile/22234
 status: Draft
@@ -12,21 +12,29 @@ created: 2024-12-06
 
 ## Abstract
 
-This EIP proposes to add a new precompile that returns the corresponding slot number for the current block.
+This EIP proposes to add a new opcode that returns the corresponding slot number for the current block.
 
 ## Motivation
 
-It is currently possible to calculate the slot number from the block timestamp. However, this requires hardcoding the chain slot length into a smart contract. This would require the contract code to be changed in the event of a future change to slot length. A better approach is for the slot length to be abstracted away from applications, and instead the slot number can be calculated in the consensus layer client and exposed in a precompile.
+It is currently possible to calculate the slot number from the block timestamp. However, this requires hardcoding the chain slot length into a smart contract. This would require the contract code to be changed in the event of a future change to slot length. A better approach is for the slot length to be abstracted away from applications, and instead the slot number can be calculated in the consensus layer client and exposed by an opcode.
 
 ### Example application: Encrypted Mempools
 
-An example of a smart contract that needs the slot number is a validation contract for an encrypted mempool. In order to be secure, the validity of encrypted mempool transactions should be tied to the inclusion of all transactions by a proposer in the correct slot. This rule can be enforced by a smart contract using this precompile.
+An example of a smart contract that needs the slot number is a validation contract for an encrypted mempool. In order to be secure, the validity of encrypted mempool transactions should be tied to the inclusion of all transactions by a proposer in the correct slot. This rule can be enforced by a smart contract using this opcode.
 
 ## Specification
 
-If `block.timestamp >= TBD` a new precompiled contract `SLOT` shall be created at address `TBD`.
+A new opcode `SLOT` shall be created at `TBD`. It shall return one stack element.
 
-`SLOT` returns as output the current slot number as an 8-byte uint64 in big-endian encoding.
+### Output
+
+#### Stack
+
+| Stack      | Value        |
+| ---------- | -------------|
+| `top - 0`  | `Slot`      |
+
+`Slot` is an 8 byte uint in big endian encoding. 
 
 ### Gas Cost
 
@@ -55,11 +63,7 @@ Consensus layer clients **may** implement the following new RPC endpoints to con
 
 ### Gas Price
 
-The precompile is priced to match similar opcodes in the `W_base` set.
-
-### Precompile
-
-Making the feature a precompile rather than an opcode gives L2s flexibility to decide whether to implement it.
+The opcode is priced to match similar opcodes in the `W_base` set.
 
 ### Calculation in consensus layer
 


### PR DESCRIPTION
- Convert back to old version where `TXINDEX` and `SLOT` were opcodes instead of precompiles

- Rename `SLOT` to `SLOTNUM`