### PR TITLE
Update EIP-7702: Update `nonce` validation for consistency with EIP-2681

### DIFF
--- a/EIPS/eip-7702.md
+++ b/EIPS/eip-7702.md
@@ -79,7 +79,7 @@ tuple cannot fit within the following bounds:
 
 ```python
 assert auth.chain_id < 2**256
-assert auth.nonce < 2**64
+assert auth.nonce < 2**64 - 1  # see EIP-2681
 assert len(auth.address) == 20
 assert auth.y_parity < 2**8
 assert auth.r < 2**256


### PR DESCRIPTION
Validate authority nonce as `< 2**64 - 1` as in EIP-2681. The `nonce` has the added implication that it is incremented at when processing a transaction, as well as an auth now. This prevents the `nonce` from ever having the value of ``2**64`` after processing a successful authority.
