### PR TITLE
Update EIP-7620: Fix failed copy-paste

### DIFF
--- a/EIPS/eip-7620.md
+++ b/EIPS/eip-7620.md
@@ -48,14 +48,14 @@ We introduce two new instructions on the same block number [EIP-3540](./eip-3540
 1. `EOFCREATE` (`0xec`)
 2. `RETURNCODE` (`0xee`)
 
+If the code is legacy bytecode, any of these instructions result in an *exceptional halt*. (*Note: This means no change to behaviour.*)
+
 ### Execution Semantics
 
 - The instructions `CREATE`, `CREATE2` are made obsolete and rejected by validation in EOF contracts. They are only available in legacy contracts.
 - If instructions `CREATE` and `CREATE2` have EOF code as initcode (starting with `EF00` magic)
     - deployment fails (returns 0 on the stack)
     - caller's nonce is not updated and gas for initcode execution is not consumed
-
-If the code is legacy bytecode, any of these instructions result in an *exceptional halt*. (*Note: This means no change to behaviour.*)
 
 #### Overview of the new contract creation flow
 


### PR DESCRIPTION
Fixes a quite unfortunate fail to copy-paste done in #9592 . Obviously, it is EOFCREATE and RETURNCODE which result in an exceptional halt **in legacy**, not CREATE and CREATE2. Sorry about that, hoping this has not led to any confusion