### PR TITLE
Update EIP-5450: Simplify stack overflow checks

### DIFF
--- a/EIPS/eip-5450.md
+++ b/EIPS/eip-5450.md
@@ -99,9 +99,10 @@ For each instruction:
 After all instructions are visited, determine the function maximum operand stack height increase:
 
 1. Compute the maximum stack height `max_stack_height` as the maximum of all recorded stack height upper bounds.
-2. **Check** if the maximum stack height `max_stack_height` does not exceed the limit of 1024.
-3. Compute the maximum stack height increase `max_stack_increase` as `max_stack_height - type[current_section_index].inputs`.
-4. **Check** if the maximum stack height increase `max_stack_increase` matches the value corresponding code section's within the type section: `types[current_section_index].max_stack_increase`.
+2. Compute the maximum stack height increase `max_stack_increase` as `max_stack_height - type[current_section_index].inputs`.
+3. **Check** if the maximum stack height increase `max_stack_increase` matches the value corresponding code section's within the type section: `types[current_section_index].max_stack_increase`.
+
+*Note: Although we check only that `max_stack_increase` matches the type section definition, which guarantees that it does not exceed 1023 by EOF header definition, it is also guaranteed that `max_stack_height` does not exceed 1024, because otherwise validation of `CALLF` and `JUMPF` into this section would fail at operand stack overflow check. Every section is required to have `CALLF` or `JUMPF` targeting it, except 0th section (non-reachable sections are not allowed). 0th section is required to have 0 inputs, which implies `max_stack_increase` equals `max_stack_height`.*
 
 The computational and space complexity of this pass is *O(len(code))*. Each instruction is visited at most once.
 


### PR DESCRIPTION
This removes one redundant rule.