### PR TITLE
Update EIP-3540: Claify, improve and fill missing sections of EOF EIPs

### DIFF
--- a/EIPS/eip-3540.md
+++ b/EIPS/eip-3540.md
@@ -129,7 +129,7 @@ types_section := (inputs, outputs, max_stack_increase)+
 | kind_container         | 1 byte  | 0x03                  | kind marker for container size section                                                                       |
 | num_container_sections | 2 bytes | 0x0001-0x0100         | 16-bit unsigned big-endian integer denoting the number of the container sections                             |
 | container_size         | 4 bytes | 0x00000001-0xFFFFFFFF | 32-bit unsigned big-endian integer denoting the length of the container section content                      |
-| kind_data              | 1 byte  | 0xff                  | kind marker for data size section                                                                            |
+| kind_data              | 1 byte  | 0xFF                  | kind marker for data size section                                                                            |
 | data_size              | 2 bytes | 0x0000-0xFFFF         | 16-bit unsigned big-endian integer denoting the length of the data section content (*)                       |
 | terminator             | 1 byte  | 0x00                  | marks the end of the header                                                                                  |
 
@@ -220,7 +220,7 @@ We have considered different questions for the sections:
 
 - Streaming headers (i.e. `section_header, section_data, section_header, section_data, ...`) are used in some other formats (such as WebAssembly). They are handy for formats which are subject to editing (adding/removing sections). That is not a useful feature for EVM. One minor benefit applicable to our case is that they do not require a specific "header terminator". On the other hand they seem to play worse with code chunking / merkleization, as it is better to have all section headers in a single chunk.
 - Whether to have a header terminator or to encode `number_of_sections` or `total_size_of_headers`. Both raise the question of how large of a value these fields should be able to hold. A terminator byte seems to avoid the problem of choosing a size which is too small without any perceptible downside, so it is the path taken.
-- (EOF1) Whether to encode section sizes as fixed 16-bit values or some kind of variable length field (e.g. LEB128). We have opted for fixed size, because it simplifies client implementations, and 16-bit seems enough, because of the currently exposed code size limit of 24576 bytes (see [EIP-170](./eip-170.md) and [EIP-3860](./eip-3860.md)). Should this be limiting in the future, a new EOF version could change the format. Besides simplifying client implementations, not using LEB128 also greatly simplifies on-chain parsing.
+- (EOF1) Whether to encode section sizes as fixed 16-bit (32-bit for container section size) values or some kind of variable length field (e.g. LEB128). We have opted for fixed size. Should this be limiting in the future, a new EOF version could change the format. Besides simplifying client implementations, not using LEB128 also greatly simplifies on-chain parsing.
 - Whether or not to have more structure to the container header for all EOF versions to follow. In order to allow future formats optimized for chunking and merkleization (verkleization) it was decided to keep it generic and specify the structure only for a specific EOF version.
 
 ### Data-only contracts

--- a/EIPS/eip-4200.md
+++ b/EIPS/eip-4200.md
@@ -157,7 +157,11 @@ This change poses no risk to backwards compatibility, as it is introduced at the
 
 ## Security Considerations
 
-TBA
+Adding new instructions with immediate arguments should be carefully considered when implementing the EOF container validation algorithm.
+
+Static relative jump execution does not require runtime check of the jump destination. It greatly reduces execution cost. Therefore the gas cost of the new instructions can also be significantly reduced.
+
+The `RJUMPV` instruction relative offset table can have up to 256 one-byte entries, so reading an offset cannot be a potential attack surface.         
 
 ## Copyright
 

--- a/EIPS/eip-4750.md
+++ b/EIPS/eip-4750.md
@@ -43,7 +43,7 @@ A return stack is introduced, separate from the operand stack. It is a stack of 
 
 Note: Implementations are free to choose particular encoding for a stack item. In the specification below we assume that representation is two unsigned integers: `code_section_index`, `offset`.
 
-The return stack is limited to a maximum 1024 items.
+The return stack is limited to a maximum of `1024` items.
 
 Additionally, EVM keeps track of the index of currently executing section - `current_section_index`.
 
@@ -70,7 +70,7 @@ If the code is valid EOF1, the following execution rules apply:
 2. *Note:* EOF validation [EIP-5450](./eip-5450.md) guarantees that operand stack has enough items to use as callee's inputs.
 3. If operand stack size exceeds `1024 - type[target_section_index].max_stack_increase` (i.e. if the called function may exceed the global stack height limit), execution results in exceptional halt. This also guarantees that the stack height after the call is within the limits.
 4. If return stack already has `1024` items, execution results in exceptional halt.
-5. Charges 5 gas.
+5. Charges `5` gas.
 6. Pops nothing and pushes nothing to operand stack.
 7. Pushes to return stack an item:
 
@@ -88,7 +88,7 @@ If the code is valid EOF1, the following execution rules apply:
 
 1. Does not have immediate arguments.
 2. *Note:* EOF validation [EIP-5450](./eip-5450.md) guarantees that operand stack has exact number of items to use as outputs.
-3. Charges 3 gas.
+3. Charges `3` gas.
 4. Pops nothing and pushes nothing to operand stack.
 5. Pops an item from return stack and sets `current_section_index` and `PC` to values from this item.
 
@@ -98,7 +98,7 @@ If the code is valid EOF1, the following execution rules apply:
 
 In addition to container format validation rules above, we extend code section validation rules (as defined in [EIP-3670](./eip-3670.md)).
 
-1. Code validation rules of EIP-3670 are applied to every code section.
+1. Code validation rules of [EIP-3670](./eip-3670.md) are applied to every code section.
 2. Code section is invalid in case an immediate argument of any `CALLF` is greater than or equal to the total number of code sections.
 3. `RJUMP`, `RJUMPI` and `RJUMPV` immediate argument value (jump destination relative offset) validation:
     1. Code section is invalid in case offset points to a position outside of section bounds.
@@ -117,7 +117,7 @@ Dynamic jump instructions `JUMP` (`0x56`) and `JUMPI` (`0x57`) are invalid and t
 
 ### Execution
 
-1. Execution starts at the first byte of the 0th code section, and PC is set to 0.
+1. Execution starts at the first byte of the 0th code section, and `PC` is set to `0`.
 2. Return stack is initialized empty.
 3. Stack underflow check is not performed anymore. *Note:* EOF validation [EIP-5450](./eip-5450.md) guarantees that it cannot happen at run-time.
 3. Stack overflow check is not performed anymore, except during `CALLF` as specified above.
@@ -154,7 +154,7 @@ Instead of deprecating `JUMPDEST` we repurpose it as `NOP` instruction, because 
 
 ### Deprecating `JUMPDEST` analysis
 
-The purpose of `JUMPDEST` analysis was to find in code the valid `JUMPDEST` bytes that do not happen to be inside `PUSH` immediate data. Only dynamic jump instructions (`JUMP`, `JUMPI`) required destination to be `JUMPDEST` instruction. Relative static jumps (`RJUMP` and `RJUMPI`) do not have this requirement and are validated once at deploy-time EOF instruction validation. Therefore, without dynamic jump instructions, `JUMPDEST` analysis is not required.
+The purpose of `JUMPDEST` analysis was to find in code the valid `JUMPDEST` bytes that do not happen to be inside `PUSH` immediate data. Only dynamic jump instructions (`JUMP`, `JUMPI`) required destination to be `JUMPDEST` instruction. Relative static jumps (`RJUMP`, `RJUMPI` and `RJUMPV`) do not have this requirement and are validated once at deploy-time during EOF instructions validation. Therefore, without dynamic jump instructions, `JUMPDEST` analysis is not required.
 
 ## Backwards Compatibility
 
@@ -164,7 +164,9 @@ The new execution state and multi-section control flow pose no risk to backwards
 
 ## Security Considerations
 
-TBA
+The gas cost of introduced instructions reflects the need to manipulate return stack entries and jumping to proper code section offset in memory when interpreting the bytecode.
+
+These new instructions need to be carefully considered during implementation of the EOF container validation algorithm.
 
 ## Copyright
 

--- a/EIPS/eip-5450.md
+++ b/EIPS/eip-5450.md
@@ -87,8 +87,8 @@ For each instruction:
       - after any other non-terminating instruction stack height bounds are adjusted by subtracting the number of instruction inputs and adding the number of instruction outputs,
       - terminating instructions do not need to update stack height bounds.
 3. Determine the list of successor instructions that can follow the current instructions:
-   1. The next instruction for all instructions other than terminating instructions and unconditional jump.
-   2. All targets of a conditional or unconditional jump.
+   1. The next instruction if the current instruction is not a terminating instruction nor unconditional jump (`RJUMP`).
+   2. All the current instruction targets if the current instruction is a conditional (`RJUMPI` or `RJUMPV`) or unconditional jump (`RJUMP`).
 4. For each successor instruction:
    1. **Check** if the instruction is present in the code (i.e. execution must not "fall off" the code).
    2. If the successor is reached via forwards jump or sequential flow from previous instruction:
@@ -163,7 +163,7 @@ It poses no risk to backwards compatibility, as it is introduced only for EOF1 c
 
 ## Security Considerations
 
-Needs discussion.
+As mentioned above, the proposed validation algorithm has linear computational and space complexity and its cost is covered by the transaction data costs [EIP-2028](./eip-2028).
 
 ## Copyright
 

--- a/EIPS/eip-6206.md
+++ b/EIPS/eip-6206.md
@@ -83,7 +83,7 @@ This change is backward compatible as EOF does not allow undefined instructions 
 
 ## Security Considerations
 
-Needs discussion.
+This new instruction needs to be carefully considered during implementation of the EOF container validation algorithm.
 
 ## Copyright
 

--- a/EIPS/eip-663.md
+++ b/EIPS/eip-663.md
@@ -41,7 +41,7 @@ If the code is valid EOF1, the following rules apply:
 
 1. The instructions are followed by an 8-bit immediate value, which we call `imm`, and can have a value of 0 to 255.
    1. In the case of `DUPN` and `SWAPN`, we introduce the variable `n` which equals to `imm + 1`.
-   2. In the case of `EXCHANGE`, we introduce the variable `n` which is equal to `imm >> 4 + 1`, and the variable `m` which is equal to `imm & 0x0F + 1` (i.e., the first and second nibbles of `imm`, converted to one-indexing).
+   2. In the case of `EXCHANGE`, we introduce the variable `n` which is equal to `(imm >> 4) + 1`, and the variable `m` which is equal to `(imm & 0x0F) + 1` (i.e., the first and second nibbles of `imm`, converted to one-indexing).
 2. Code validation is extended to check that no relative jump instruction (`RJUMP`/`RJUMPI`/`RJUMPV`) targets immediate values of `DUPN`, `SWAPN` or `EXCHANGE`.
 3. The stack validation algorithm of [EIP-5450](./eip-5450.md) is extended:
    1. Before `DUPN` if the current stack height is less than `n`, code is invalid. After `DUPN`, the stack height is incremented.

--- a/EIPS/eip-7069.md
+++ b/EIPS/eip-7069.md
@@ -13,7 +13,7 @@ requires: 150, 211, 214, 2929, 3540
 
 ## Abstract
 
-Introduce three new call instructions, `EXTCALL`, `EXTDELEGATECALL` and `EXTSTATICCALL`, with simplified semantics. Introduce another instruction, `RETURNDATALOAD` for loading a word from return data into stack. Modify the behavior of `RETURNDATACOPY` instruction executed within EOF formatted code (as defined by [EIP-3540](./eip-3540.md)). The existing `*CALL` instructions remain unchanged.
+Introduce three new call instructions, `EXTCALL`, `EXTDELEGATECALL` and `EXTSTATICCALL`, with simplified semantics. Introduce another instruction, `RETURNDATALOAD` for loading a word from return data into stack. Modify the behavior of `RETURNDATACOPY` instruction executed within EOF formatted code (as defined by [EIP-3540](./eip-3540.md)). The existing `*CALL` instructions are rejected by EOF validation.
 
 The new instructions do not allow specifying a gas limit, but rather rely on the "63/64th rule" ([EIP-150](./eip-150.md)) to limit gas. An important improvement is the rules around the "stipend" are simplified, and callers do not need to perform special calculation whether the value is sent or not. 
 
@@ -21,19 +21,17 @@ Furthermore, the obsolete functionality of specifying output buffer address is r
 
 Lastly, instead of returning a boolean for execution status, an extensible list of status codes is returned: `0` for success, `1` for revert, `2` for failure.
 
-We expect most new contracts to rely on the new instructions (for simplicity and in order to save gas), and some specific contracts where gas limiting is required to keep using the old instructions (e.g. [ERC-4337](./eip-4337.md)).
-
 ## Motivation
 
 Observability of gas has been a problem for very long. The system of gas has been (and likely must be) flexible in adapting to changes to both how Ethereum is used as well as changes in underlying hardware.
 
 Unfortunately, in many cases compromises or workarounds had to be made to avoid affecting call instructions negatively, mostly due to the complex semantics and expectations of them.
 
-This change aims to remove gas observability from the new instructions and opening the door for new classes of contracts that are not affected by repricings. Furthermore, once the EVM Object Format (EOF) is introduced, the legacy call instructions can be rejected within EOF contracts, making sure they are mostly unaffected by changes in gas fees. Because these operations are required for removing gas observability they will be required for EOF in lieu of the existing instructions.
+This change removes gas observability from the new instructions and opens the door for new classes of contracts that are not affected by repricings. Furthermore, the legacy call instructions are rejected within EOF contracts, making sure they are mostly unaffected by changes in gas fees. Because these operations are required for removing gas observability they are required for EOF in lieu of the existing legacy instructions.
 
 It is important to note that starting Solidity 0.4.21, the compiler already passes all remaining gas to calls (using `call(gas(), ...`), unless the developer uses the explicit override (`{gas: ...}`) in the language. This suggests most contracts don't rely on controlling gas.
 
-Besides the above, this change introduces a convenience feature of returning more detailed status codes: success (0), revert (1), failure (2). This moves from the boolean option to codes, which are extensible in the future.
+Besides the above, this change introduces a convenience feature of returning more detailed status codes: `success (0)`, `revert (1)`, `failure (2)`. This moves from the boolean option to codes, which are extensible in the future.
 
 Lastly, the introduction of the `RETURNDATA*` instructions ([EIP-211](./eip-211.md)) has obsoleted the output parameters of calls, in a large number of cases rendering them unused. Using the output buffers have caused "bugs" in the past: in the case of [ERC-20](./eip-20.md), conflicting implementations caused a lot of trouble, where some would return something, while others would not. With relying on `RETURNDATA*` instructions this is implicitly clarified. This proposal also adds the "missing" `RETURNDATALOAD` instruction to round out returndata buffer access instructions.
 
@@ -55,7 +53,7 @@ We introduce four new instructions:
 - `EXTSTATICCALL` (`0xfb`) with arguments `(target_address, input_offset, input_size)`
 - `RETURNDATALOAD` (`0xf7`) with argument `offset`
 
-In case this EIP is included as part of the greater EOF upgrade, these four new instructions are undefined in legacy code and only available in EOF code.
+These four new instructions are undefined in legacy code and only available in EOF code.
 
 Execution semantics of `EXT*CALL`:
 
@@ -80,22 +78,23 @@ Execution semantics of `EXT*CALL`:
 11. Perform the call with the available gas and configuration.
 12. Push a status code on the stack:
     - `0` if the call was successful.
-    - `1` if the call has reverted (also can be pushed earlier in a light failure scenario).
-    - `2` if the call has failed.
+    - `1` if the call has reverted (also can be pushed earlier in a light failure scenario described in step 10).
+    - `2` if the call has failed (in case of general OOG failure or any scenario where all gas passed to the callee is burnt in case of an error).
 13. Gas not used by the callee is returned to the caller.
 
 Execution semantics of `RETURNDATALOAD`:
 
-1. Charge `G_verylow` (3) gas
+1. Charge `3` gas
 2. Pop 1 item from the stack, to be referred to as `offset`
 3. Push 1 item onto the stack, the 32-byte word read from the returndata buffer starting at `offset`.
 4. If `offset + 32 > len(returndata buffer)`, the result is zero-padded.
 
-In case this EIP is included as part of the greater EOF upgrade, execution semantics of `RETURNDATACOPY` in EOF formatted code ([EIP-3540](./eip-3540.md)) is modified as follows:
+Execution semantics of `RETURNDATACOPY` in EOF formatted code ([EIP-3540](./eip-3540.md)) is modified as follows:
 
-1. Assume the 3 arguments popped from stack are `destOffset`, `offset` and `size`.
-2. If `offset + size > len(returndata buffer)` **do not** halt with exceptional failure, but instead set the `offset + size - len(returndata buffer)` memory bytes after the copied ones to zero.
-3. Gas charged for memory copying remains `3 * num_words(size)`, regardless of the number of bytes actually copied or set to zero.
+1. Assume the 3 arguments popped from stack are `destOffset`, `offset` and `size`. _(no change)_
+2. Performs memory expansion to `destOffset + size` and deducts memory expansion cost. _(no change)_
+3. If `offset + size > len(returndata buffer)` **do not** halt with exceptional failure, but instead set the `offset + size - len(returndata buffer)` memory bytes after the copied ones to zero.
+4. Gas charged for memory copying remains `3 * num_words(size)`, regardless of the number of bytes actually copied or set to zero.
     
 Execution of `RETURNDATACOPY` which is not in EOF formatted code (i.e. is in legacy code) is not changed.
 
@@ -161,7 +160,9 @@ Current call instructions return a boolean value to signal success: 0 means fail
 
 We change the value from boolean to a status code, where `0` signals success and thus it will be possible to introduce more non-success codes in the future, if desired.
 
-Status code `1` is used for both reverts coming from the callee frame and light failures encountered in the execution of the instructions. The reason for combining them is keeping the semantics similar to the original CALLs - both scenarios preserve unused gas and continue being indistinguishable to the caller.
+Status code `1` is used for both reverts coming from the callee frame and light failures encountered (see step 10. of Execution Semantics) in the execution of the instructions. The reason for combining them is keeping the semantics similar to the original CALLs - both scenarios preserve unused gas and continue being indistinguishable to the caller.
+
+Status code `2` signals an exceptional failure in the callee execution, meaning an error occurred that consumed all remaining gas in the callee frame.
 
 ### Parameter order
 
@@ -186,9 +187,9 @@ When existing `CALL` series operations encounter an address that does not fit in
 
 Smart contract developers should not rely on the operation reverting when such addresses are passed in. When a suitable proposal for the use of Address Space Extension is adopted it is expected that the `EXT*CALL` series of operations will adopt those changes.
 
-### New instructions undefined in legacy (only if this EIP is part of EOF)
+### New instructions undefined in legacy (this EIP is part of EOF only)
 
-There is an alternative scenario where, in case this EIP is included as part of the greater EOF upgrade, the four new instructions are **additionally** available in legacy EVM. There is, however, a preference to limit changes to legacy EVM in the fork where EOF is included as well as in subsequent ones.
+Initially an alternative scenario was considered to introduce these new instructions separately in the legacy EVM first to limit the scope of EOF change, but it was decided to include it as a part of the EOF upgrade and keep them undefined in the legacy EVM.
 
 ### `RETURNDATALOAD` and `RETURNDATACOPY` padding behavior
 
@@ -211,6 +212,8 @@ No existing instructions are changed and so we do not think any backwards compat
 It is expected that the attack surface will not grow. All of these operations can be modeled by existing operations with fixed gas (all available) and output range (zero length at zero memory).
 
 When implemented in EOF (where the GAS opcode and the original CALL operations are removed) existing out of gas attacks will be slightly more difficult, but not entirely prevented. Transactions can still pass in arbitrary gas values and clever contract construction can still result in specific gas values being passed to specific calls. It is expected the same surface will remain in EOF, but the ease of exploitation will be reduced.
+
+The legacy `*CALL` instructions allow to pass gas available for the callee. This ability is used to prevent reentrancy attack but in case of potential future gas repricing proposal this pattern does not give this guarantee any longer. Protecting against reentrancy should be resolved by using `TSTORE/TLOAD` instructions introduced in [EIP-1153](./eip-1153.md) or other solutions which do not rely on current gas schedule.       
 
 ## Copyright
 

--- a/EIPS/eip-7480.md
+++ b/EIPS/eip-7480.md
@@ -95,7 +95,7 @@ This change poses no risk to backwards compatibility, as it is introduced only f
 
 ## Security Considerations
 
-TBA
+Gas cost of these new opcodes is comparable to the legacy `CODECOPY` instruction. They must be carefully considered during the implementation of the EOF container validation algorithm.
 
 ## Copyright
 

--- a/EIPS/eip-7620.md
+++ b/EIPS/eip-7620.md
@@ -57,6 +57,8 @@ If the code is legacy bytecode, any of these instructions result in an *exceptio
     - deployment fails (returns 0 on the stack)
     - caller's nonce is not updated and gas for initcode execution is not consumed
 
+In the context of legacy bytecode execution any of these instructions (`EOFCREATE`, `RETURNCODE`) result in an *exceptional halt*. (*Note: This means no change to behaviour.*)
+
 #### Overview of the new contract creation flow
 
 In EOF EVM, new bytecode is introduced to the state by means of `InitcodeTransaction` delivering an EOF container (`initcontainer`). Such a container may include arbitrarily deeply nesting subcontainers. The `initcontainer` and its subcontainers are recursively validated according to all the validation rules applicable for the EOF version in question. Next, the 0th code section of the `initcontainer` is executed and may eventually call a `RETURNCODE` instruction, which will refer to a subcontainer to be finally deployed to an address.
@@ -86,7 +88,7 @@ Details on each instruction follow in the next sections.
     - can populate returndata if execution `REVERT`ed
 - a successful execution ends with initcode executing `RETURNCODE{deploy_container_index}(aux_data_offset, aux_data_size)` instruction (see below). After that:
     - load deploy EOF subcontainer at `deploy_container_index` in the container from which `RETURNCODE` is executed
-    - concatenate data section with `(aux_data_offset, aux_data_offset + aux_data_size)` memory segment and update data size in the header
+    - concatenate data section with `(aux_data_offset, aux_data_offset + aux_data_size)` memory segment and update data size in the header if needed.
     - if updated deploy container size exceeds `MAX_CODE_SIZE` instruction exceptionally aborts
     - set `state[new_address].code` to the updated deploy container
     - push `new_address` onto the stack


### PR DESCRIPTION
This PR improves and clarify spec of EOF EIPs. It also fills missing sections. Changes to each EIP has its separated commit.