### PR TITLE
Typo fix in eip-5022.md

### DIFF
--- a/EIPS/eip-5022.md
+++ b/EIPS/eip-5022.md
@@ -39,7 +39,7 @@ Whereas solutions like state rent, or state expiry have been researched for a lo
 
 The current pricing was made off a naive approach of benchmarking opcodes in a laptop. Not only it did not consider the long term problem of having the same price for a resource that costs more over time, the benchmark itself was wrong. This price is closer to what the naive original benchmark should have been. It could go higher, but that may be too disruptive.
 
-### Is this too distruptive?
+### Is this too disruptive?
 
 This change will severely impact the gas cost of many applications. The network does not have to subsidize state growth at the expense of more expensive regular transactions, so even if it is too disruptive, it will increase the health of the network.
 


### PR DESCRIPTION
Hey just noticed a typo in this section.

"Is this too distruptive?"
Typo: “distruptive” should be “disruptive”
Fix: “Is this too disruptive?”