### PR TITLE
Update EIP-7873: Handling of EOF containers in existing TX types.

### DIFF
--- a/EIPS/eip-7873.md
+++ b/EIPS/eip-7873.md
@@ -81,7 +81,7 @@ tx.gasUsed = (
 
 Under transaction validation rules `initcodes` are not validated for conforming to the EOF specification. They are only validated when accessed via `TXCREATE`. This avoids potential DoS attacks of the mempool. If during the execution of an `InitcodeTransaction` no `TXCREATE` instruction is called, such transaction is still valid.
 
-Legacy creation transactions (any transactions with empty `to`) that start with the two bytes `EF00` will be invalid. They will not be parsed into EOF containers and they will not be executed as legacy bytecode.
+Other creation transactions that support contract creation (specifically type 0 "Frontier," type 1 "AccessList," type 2 "FeeMarket" transactions with an empty `to` field) will not attempt to parse EOF containers in their `input` field and will execute the code as non-EOF code. This will result in immediately executing the `INVALID`(`0xEF`) instruction (see [EIP-141](./eip-141.md)) and halting.
 
 
 #### RLP and signature
@@ -175,7 +175,7 @@ This change poses no risk to backwards compatibility, as it is introduced at the
 
 The transactions of the new type are invalid until this change activates.
 
-Contract creation options do not change for legacy bytecode.
+Contract creation options do not change for legacy bytecode, including how existing transactions behave when encountering code that may look like an EOF container.
 
 ## Security Considerations
 


### PR DESCRIPTION
Revise the spec so that the behavior of Type 0, 1, and 2 transactions
remains unchanged when the input data starts with EF or contains a valid
 EOF container. (Do not parse and execute the EF instruction).

