### PR TITLE
Update EIP-3220: Correct wording in blockchain identifier documentation

### DIFF
--- a/EIPS/eip-3220.md
+++ b/EIPS/eip-3220.md
@@ -44,7 +44,7 @@ Hence there is need for a more robust blockchain identifier that will overcome t
 
 | Name          | Size(bytes) | Description |
 |---------------|-------------|-------------|
-| Truncated Block Hash | 16 | This is the block hash of the genesis block or the block hash of of the block immediate prior to the fork for a fork of a blockchain. The 16 bytes is the 16 least significant bytes, assuming network byte order.|
+| Truncated Block Hash | 16 | This is the block hash of the genesis block or the block hash of the block immediate prior to the fork for a fork of a blockchain. The 16 bytes is the 16 least significant bytes, assuming network byte order.|
 |Native Chain ID| 8 | This is the **Chain Id** value that should be used with the blockchain when signing transactions. For blockchains that do not have a concept of **Chain Id**, this value is zero.|
 |Chain Type| 2 |  Reserve 0x00 as undefined chaintype. 0x01 as mainnet type. 0x1[0-A]: testnet, 0x2[0-A]: private development network|
 | Governance Identifier | 2 |  For new blockchains, a governance_identifier can be specified to identify an original **owner** of a blockchain, to help settle forked / main chain disputes. For all existing blockchains and for blockchains that do not have the concept of an **owner**, this field is zero. |


### PR DESCRIPTION


## Description
This pull request fixes a typographical error in the EIP-3220 Crosschain Identifier Specification document. The phrase "block hash of of the block" contained a duplicate word "of" which has been removed to improve readability and correctness of the specification.


