### PR TITLE
Update EIP-2935: Fix Ring Buffer Size in Description

### DIFF
--- a/EIPS/eip-2935.md
+++ b/EIPS/eip-2935.md
@@ -1,7 +1,7 @@
 ---
 eip: 2935
 title: Serve historical block hashes from state
-description: Store and serve last 8192 block hashes as storage slots of a system contract to allow for stateless execution
+description: Store and serve last 8191 block hashes as storage slots of a system contract to allow for stateless execution
 author: Vitalik Buterin (@vbuterin), Tomasz Stanczak (@tkstanczak), Guillaume Ballet (@gballet), Gajinder Singh (@g11tech), Tanishq Jasoria (@tanishqjasoria), Ignacio Hagopian (@jsign), Jochem Brouwer (@jochem-brouwer), Sina Mahmoodi (@s1na)
 discussions-to: https://ethereum-magicians.org/t/eip-2935-save-historical-block-hashes-in-state/4565
 status: Last Call


### PR DESCRIPTION
The specs say:
> The ring buffer data structure is sized to hold 8191 hashes.

Also, https://github.com/ethereum/sys-asm/blob/f1c13e285b6aeef2b19793995e00861bf0f32c9a/src/execution_hash/main.eas#L17

```eas
;; BUFLEN returns the HISTORY_BUFFER_LENGTH as defined in the EIP.
#define BUFLEN = 8191
```