### PR TITLE
Update EIP-7620: Handling of EOF containers in CREATE/CREATE2

### DIFF
--- a/EIPS/eip-7620.md
+++ b/EIPS/eip-7620.md
@@ -53,9 +53,9 @@ If the code is legacy bytecode, any of these instructions result in an *exceptio
 ### Execution Semantics
 
 - The instructions `CREATE`, `CREATE2` are made obsolete and rejected by validation in EOF contracts. They are only available in legacy contracts.
-- If instructions `CREATE` and `CREATE2` have EOF code as initcode (starting with `EF00` magic)
-    - deployment fails (returns 0 on the stack)
-    - caller's nonce is not updated and gas for initcode execution is not consumed
+- If instructions `CREATE` and `CREATE2` have EOF code as initcode (starting with `EF00` magic), maintain current behavior:
+    - do not attempt to parse EOF containers
+    - execute the code as non-EOF code, resulting in immediately executing the undefined `0xEF` instruction and halting.
 
 #### Overview of the new contract creation flow
 
@@ -175,11 +175,19 @@ Leaving the `keccak256(initcontainer)` out of the `new_address` hash has also th
 
 `EXT*CALL` instructions from [EIP-7069](./eip-7069.md) have had their stack argument order changed, as compared to that of legacy instructions `*CALL`. We follow the same change to have `EOFCREATE` stack arg order match those of `EXTCALL`.
 
+### Handling of `0xEF00` prefixed initcode in `CREATE` / `CREATE2` instruction execution.
+
+Two legacy opcodes (`CREATE` and `CREATE2`) accept code as part of their input data. This code can start with `EF`.
+
+One possible way of handling potential EOF containers in these that input is to make them fail "lightly" (not bump nonce and not consume all initcode execution gas) if they are attempting to execute an EOF container as initcode. This would have the advantage of blocking improper EOF execution early on and not punishing users who attempt to do that too severly.
+
+However, since in [EIP-7873](./eip-7873.md), analogous type 0/1/2 transactions with `to: nil` and EOF containers in the data were decided to *not be* invalid but halt on executing of the initial undefined `0xEF` instruction, `CREATE` and `CREATE2` logic should remain analogous and halt on `0xEF`. See [EIP-7873](./eip-7873.md) for the rationale on the decision concerning transactions.
+
 ## Backwards Compatibility
 
 This change poses no risk to backwards compatibility, as it is introduced at the same time EIP-3540 is. The new instructions are not introduced for legacy bytecode (code which is not EOF formatted), and the contract creation options do not change for legacy bytecode.
 
-`CREATE` and `CREATE2` calls with `EF00` initcode fail early without executing the initcode. Previously, in both cases the initcode execution would begin and fail on the first undefined instruction `EF`.
+`CREATE` and `CREATE2` calls with `EF00` initcode fail by executing the initcode's first instruction `0xEF`, which means no change to behavior.
 
 ## Test Cases
 
@@ -190,9 +198,9 @@ Creation transaction, `CREATE` and `CREATE2` cannot have its *code* starting wit
 | `0xEF` | initcode starts execution and fails |
 | `0xEF01` | initcode starts execution and fails |
 | `0xEF5f` | initcode starts execution and fails |
-| `0xEF00` | `CREATE` / `CREATE2` fails early, returns 0 and keeps sender nonce intact |
-| `0xEF0001` | as above |
-| valid EOFv1 container | as above |
+| `0xEF00` | initcode starts execution and fails |
+| `0xEF0001` | initcode starts execution and fails |
+| valid EOFv1 container | initcode starts execution and fails |
 
 ## Security Considerations
 


### PR DESCRIPTION
This is a mirror to the [update to EIP-7873](https://github.com/ethereum/EIPs/pull/9669) where legacy creation txs with EOF initcode are not treated specially anymore. Here CREATE/CREATE2 attempts to deploy from EOF initcontainers stops to be treated specially.