### PR TITLE
Update EIP-7927: EIP 7927 - remove leftover TODO item

### DIFF
--- a/EIPS/eip-7927.md
+++ b/EIPS/eip-7927.md
@@ -43,7 +43,7 @@ Testing of history expiry will occur on the Sepolia testnet. Execution clients m
 
 ### Devnet Activation
 
-Execution clients may test dropping of history on devnets for all history prior to block `TODO-WHAT-BLOCK-NUMBER?`.
+Execution clients may test dropping of history on devnets.
 
 
 ## Rationale


### PR DESCRIPTION
Remove the TODO item that was left in the EIP and is no longer needed.