### PR TITLE
Update EIP-7607: Remove EOF from Fusaka 

### DIFF
--- a/EIPS/eip-7607.md
+++ b/EIPS/eip-7607.md
@@ -24,6 +24,26 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion` and `Propo
 
 * [EIP-7594](./eip-7594.md): PeerDAS - Peer Data Availability Sampling
 * [EIP-7892](./eip-7892.md): Blob Parameter Only Hardforks
+
+
+#### Other EIPs
+
+* [EIP-7642](./eip-7642.md): eth/69 - Drop pre-merge fields
+    * Client teams MUST support this EIP by the activation of the Fusaka network upgrade.
+
+### Considered for Inclusion
+
+* [EIP-5920](./eip-5920.md): PAY opcode
+* RIP-7212: Precompile for secp256r1 Curve Support
+* [EIP-7762](./eip-7762.md): Increase MIN_BASE_FEE_PER_BLOB_GAS
+* [EIP-7823](./eip-7823.md): Set upper bounds for MODEXP
+* [EIP-7825](./eip-7825.md): Transaction Gas Limit Cap
+* [EIP-7883](./eip-7883.md): ModExp Gas Cost Increase
+* [EIP-7907](./eip-7907.md): Meter Contract Code Size And Increase Limit
+* [EIP-7917](./eip-7917.md): Deterministic proposer lookahead
+* [EIP-7918](./eip-7918.md): Blob base fee bounded by execution cost
+
+### Declined for Inclusion
 * EOF EIPs introduced in `eof-devnet-0` and `eof-devnet-1` in [EIP-7692](./eip-7692.md), namely:
     * [EIP-663](./eip-663.md): SWAPN, DUPN and EXCHANGE instructions
     * [EIP-3540](./eip-3540.md): EOF - EVM Object Format v1
@@ -37,30 +57,10 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion` and `Propo
     * [EIP-7620](./eip-7620.md): EOF Contract Creation
     * [EIP-7698](./eip-7698.md): EOF - Creation transaction
     * [EIP-7873](./eip-7873.md): EOF - TXCREATE and InitcodeTransaction type
-
-#### Other EIPs
-
-* [EIP-7642](./eip-7642.md): eth/69 - Drop pre-merge fields
-    * Client teams MUST support this EIP by the activation of the Fusaka network upgrade.
-
-### Considered for Inclusion
-
-* RIP-7212: Precompile for secp256r1 Curve Support
 * EOF EIPs introduced in `eof-devnet-2` in [EIP-7692](./eip-7692.md), namely:
     * [EIP-7834](./eip-7834.md): Separate Metadata Section for EOF
     * [EIP-7761](./eip-7761.md): EXTCODETYPE instruction
     * [EIP-7880](./eip-7880.md): EOF - EXTCODEADDRESS instruction
-    * [EIP-5920](./eip-5920.md): PAY opcode
-* [EIP-7762](./eip-7762.md): Increase MIN_BASE_FEE_PER_BLOB_GAS
-* [EIP-7823](./eip-7823.md): Set upper bounds for MODEXP
-* [EIP-7825](./eip-7825.md): Transaction Gas Limit Cap
-* [EIP-7883](./eip-7883.md): ModExp Gas Cost Increase
-* [EIP-7907](./eip-7907.md): Meter Contract Code Size And Increase Limit
-* [EIP-7917](./eip-7917.md): Deterministic proposer lookahead
-* [EIP-7918](./eip-7918.md): Blob base fee bounded by execution cost
-
-### Declined for Inclusion
-
 * [EIP-7666](./eip-7666.md): EVM-ify the identity precompile
 * [EIP-7668](./eip-7668.md): Remove bloom filters
 * [EIP-7688](./eip-7688.md): Forward compatible consensus data structures


### PR DESCRIPTION
On ["ACDT" 34](https://github.com/ethereum/pm/issues/1499), a decision was made to remove EOF from Fusaka. 

The process here was highly unusual. I encourage people to listen to the [full discussion](https://www.youtube.com/watch?v=M3DWaWbIB3s). Here are the reasons why I think this is the correct outcome, despite several client teams expressing support for EOF: 

1. **Risks to Fusaka timelines**: all client teams, ELs included, seem to agree that shipping PeerDAS ASAP is Ethereum's most important priority. While this wasn't a major topic of discussion on the call, it's worth acknowledging that debating variants of the EOF spec at this point affects our ability to ship. As we move towards Fusaka devnets, and coupling EL & CL changes, keeping EOF would increasingly become the default path. While there are ways to mitigate this risk, such as the modular EOF devnets proposed by the EIPs' champions, it is nevertheless a risk, and one we should only take if we feel the payoff is significant. Points (2) and (3) below make me question this.
2. **Technical uncertainty about impact**: while there seemed to be broad support on the call towards the Option D variant, midway through, some participants realized that they did not understand the implications of this variant. Reasoning about the implications of an EIP's semantic change should ideally happen much earlier in the process. Had another EIP with similar levels of open questions been proposed on today's call, ACD would have rejected it without hesitation. 
3. **Process considerations**: last but not least, I think the entire EOF inclusion debate has shown failures in ACD's prioritization process. While core devs originally agreed to ship EOF (many times), at each occasion, many prominent community members raised objections to it. While, individually considered, it didn't seem like any of these concerns warranted EOF's removal, zooming out, it's clear that ACD's feedback loops failed at addressing these concerns. 

Given the above, and the intention to [reconfigure AllCoreDevs](https://ethereum-magicians.org/t/reconfiguring-allcoredevs/23370) for Glamsterdam, it seems right to remove EOF from Fusaka while leaving the door for its champions to present a case for it in Glamsterdam, where hopefully the process begins by assessing what the highest impact changes for Ethereum as a whole are. 

My apologies to everyone who has sunk more time into this than they should have because of the process failures. I hope we can learn from this to improve how we plan upgrades going forward 🙏 ! 

---

Minor note: I left `PAY` as CFI'd as people expressed wanting to include it in Fusaka independent of EOF. If that's not the case, we can fix this on the next ACDE. 