### PR TITLE
Update EIP-7702: Remove trie concept from the vm specification

### DIFF
--- a/EIPS/eip-7702.md
+++ b/EIPS/eip-7702.md
@@ -112,9 +112,8 @@ following:
 4. Add `authority` to `accessed_addresses`, as defined in [EIP-2929](./eip-2929.md).
 5. Verify the code of `authority` is empty or already delegated.
 6. Verify the nonce of `authority` is equal to `nonce`.
-   * If `authority` does not exist in the trie, verify `nonce` is equal to `0`.
 7. Add `PER_EMPTY_ACCOUNT_COST - PER_AUTH_BASE_COST` gas to the global refund
-   counter if `authority` exists in the trie.
+   counter if `authority` is not empty.
 8. Set the code of `authority` to be `0xef0100 || address`. This is a delegation
    indicator.
     * If `address` is `0x0000000000000000000000000000000000000000`, do not write


### PR DESCRIPTION
## Motivation
- Remove concept of trie from the EVM specification in EIP-7702 and replace it with "emptiness" for simplicity.

## Rationale
- I think it would be good to abstract the EVM from the trie implementation. The EVM should just know if an account is empty or not. This simplification has been done almost 9 years ago and we should stick to it. For clients that don't implement forks older than Tangerine Whistle it adds unnecessary complexity because they'd need to track if an account is empty but still exists in the trie, something that's not possible in these scenarios.

From [EIP-158](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-158.md)
"Whenever the EVM checks if an account exists, emptiness is treated as equivalent to nonexistence. Particularly, note that this implies that, once this change is enabled, there is no longer a meaningful difference between emptiness and nonexistence from the point of view of EVM execution."

## Possible Counter Argument:
The only counter argument that I can think of for this is that in the case of some clients it may happen that there are empty accounts in the trie but I still think it is better to treat those as non-existent in the EVM.