### PR TITLE
Update EIP-3026: fix input size specification in G2 multiexponentiation ABI

### DIFF
--- a/EIPS/eip-3026.md
+++ b/EIPS/eip-3026.md
@@ -159,15 +159,14 @@ Error cases:
 - Field elements encoding rules apply (obviously)
 - Input has invalid length
 
-#### ABI for G2 multiexponentiation
+#### ABI for G2 multiexponentiation  
 
-G2 multiplication call expects `240*k` bytes as an input that is interpreted as byte concatenation of `k` slices each of them being a byte concatenation of encoding of G2 point (`192` bytes) and encoding of a scalar value (`48` bytes). Output is an encoding of multiexponentiation operation result.
+G2 multiexponentiation call expects `256*k` bytes as an input that is interpreted as byte concatenation of `k` slices, each of them being a byte concatenation of encoding of G2 point (`192` bytes) and encoding of a scalar value (`64` bytes). Output is an encoding of multiexponentiation operation result.  
 
-Error cases:
-
-- Any of G2 points being not on the curve must result in error
-- Field elements encoding rules apply (obviously)
-- Input has invalid length
+Error cases:  
+- Any of G2 points being not on the curve must result in error  
+- Field elements encoding rules apply (obviously)  
+- Input length must be a multiple of `256`  
 
 #### ABI for pairing
 


### PR DESCRIPTION
corrected an error in the *ABI for G2 multiexponentiation* section. It previously stated that the call expects `240*k` bytes, but this contradicts the encoding sizes defined elsewhere (192 bytes for a G2 point + 64 bytes for a scalar = 256 bytes per slice). updated it to `256*k` for consistency with the rest of the spec and the gas cost calculation logic.  

also clarified the input length validation rule to explicitly require a multiple of 256.