### PR TITLE
Update EIP-5792: Update CAIP-25 links in eip-5792.md to newest commit

### DIFF
--- a/EIPS/eip-5792.md
+++ b/EIPS/eip-5792.md
@@ -286,7 +286,7 @@ This method SHOULD return an `4100 Unauthorized` error if the user has not alrea
 
 We expect the community to align on the definition of additional capabilities in separate ERCs over time.
 
-Note that in addition to, or instead of, querying the wallet directly for capabilities, the same capability objects MAY be exposed out-of-band, such as in a `sessionProperty.capabilities` object persisted in a [CAIP-25](https://github.com/ChainAgnostic/CAIPs/blob/ad0cfebc45a4b8368628340bf22aefb2a5edcab7/CAIPs/caip-25.md)-conformant wallet provider interface, or in a well-known location (such as a URL derived from an [EIP-6963](./eip-6963.md) `rdns` identifier).
+Note that in addition to, or instead of, querying the wallet directly for capabilities, the same capability objects MAY be exposed out-of-band, such as in a [`sessionProperties.capabilities` and/or `scopedProperties.capabilities` objects](https://github.com/ChainAgnostic/namespaces/blob/1a91b0e13f02c199ce19bbacced0f69bcff50d64/eip155/caip25.md#examples) persisted in a [CAIP-25](https://github.com/ChainAgnostic/CAIPs/blob/c599f7601d0ce83e6dd9f350c6c21d158d56fd6d/CAIPs/caip-25.md)-conformant wallet provider interface, or in a well-known location (such as a URL derived from an [EIP-6963](./eip-6963.md) `rdns` identifier).
 Provider abstractions MAY also cache capabilities from previous requests or otherwise inject them from out-of-band to facilitate better user experience.
 If any of these supplemental expressions of capabilities are contradicted by capabilities expressed in live wallet RPC responses, these latter values SHOULD be taken as the canonical and current expression of capabilities.
 

--- a/EIPS/eip-5792.md
+++ b/EIPS/eip-5792.md
@@ -286,7 +286,7 @@ This method SHOULD return an `4100 Unauthorized` error if the user has not alrea
 
 We expect the community to align on the definition of additional capabilities in separate ERCs over time.
 
-Note that in addition to, or instead of, querying the wallet directly for capabilities, the same capability objects MAY be exposed out-of-band, such as in a [`sessionProperties.capabilities` and/or `scopedProperties.capabilities` objects](https://github.com/ChainAgnostic/namespaces/blob/1a91b0e13f02c199ce19bbacced0f69bcff50d64/eip155/caip25.md#examples) persisted in a [CAIP-25](https://github.com/ChainAgnostic/CAIPs/blob/c599f7601d0ce83e6dd9f350c6c21d158d56fd6d/CAIPs/caip-25.md)-conformant wallet provider interface, or in a well-known location (such as a URL derived from an [EIP-6963](./eip-6963.md) `rdns` identifier).
+Note that in addition to, or instead of, querying the wallet directly for capabilities, the same capability objects MAY be exposed out-of-band, such as in a `sessionProperties.capabilities` and/or `scopedProperties.capabilities` objects persisted in a [CAIP-25](https://github.com/ChainAgnostic/CAIPs/blob/c599f7601d0ce83e6dd9f350c6c21d158d56fd6d/CAIPs/caip-25.md)-conformant wallet provider interface (see eip155 profile for CAIP-25 for an example), or in some other a well-known location (such as a URL derived from an [EIP-6963](./eip-6963.md) `rdns` identifier).
 Provider abstractions MAY also cache capabilities from previous requests or otherwise inject them from out-of-band to facilitate better user experience.
 If any of these supplemental expressions of capabilities are contradicted by capabilities expressed in live wallet RPC responses, these latter values SHOULD be taken as the canonical and current expression of capabilities.
 

--- a/EIPS/eip-5792.md
+++ b/EIPS/eip-5792.md
@@ -286,7 +286,7 @@ This method SHOULD return an `4100 Unauthorized` error if the user has not alrea
 
 We expect the community to align on the definition of additional capabilities in separate ERCs over time.
 
-Note that in addition to, or instead of, querying the wallet directly for capabilities, the same capability objects MAY be exposed out-of-band, such as in a `sessionProperties.capabilities` and/or `scopedProperties.capabilities` objects persisted in a [CAIP-25](https://github.com/ChainAgnostic/CAIPs/blob/c599f7601d0ce83e6dd9f350c6c21d158d56fd6d/CAIPs/caip-25.md)-conformant wallet provider interface (see eip155 profile for CAIP-25 for an example), or in some other a well-known location (such as a URL derived from an [EIP-6963](./eip-6963.md) `rdns` identifier).
+Note that in addition to, or instead of, querying the wallet directly for capabilities, the same capability objects MAY be exposed out-of-band, such as in a `sessionProperties.capabilities` and/or `scopedProperties.capabilities` objects persisted in a [CAIP-25](https://github.com/ChainAgnostic/CAIPs/blob/c599f7601d0ce83e6dd9f350c6c21d158d56fd6d/CAIPs/caip-25.md)-conformant wallet provider interface (see the ethereum usage profile for CAIP-25 for an example request and response), or in some other a well-known location (such as a URL derived from an [EIP-6963](./eip-6963.md) `rdns` identifier).
 Provider abstractions MAY also cache capabilities from previous requests or otherwise inject them from out-of-band to facilitate better user experience.
 If any of these supplemental expressions of capabilities are contradicted by capabilities expressed in live wallet RPC responses, these latter values SHOULD be taken as the canonical and current expression of capabilities.
 


### PR DESCRIPTION
Not normative changes, just editorial/bibliographical ones. The newer commits in these links should less confusing to implementers trying to implement 5792 with Wallet Connect and/or MetaMask SDKs, as CASA updated the examples on that side to match the newest changes to chainId-specific (and evm-wide) capability declaration from a few weeks back.