### PR TITLE
Update EIP-7600: Move to Final

### DIFF
--- a/EIPS/eip-7600.md
+++ b/EIPS/eip-7600.md
@@ -7,7 +7,7 @@ discussions-to: https://ethereum-magicians.org/t/eip-7600-hardfork-meta-prague-e
 status: Final
 type: Meta
 created: 2024-01-18
-requires: 2537, 2935, 6110, 7002, 7251, 7549, 7623, 7685, 7691, 7702, 7840
+requires: 2537, 2935, 6110, 7002, 7251, 7549, 7623, 7685, 7691, 7702
 ---
 
 ## Abstract

--- a/EIPS/eip-7600.md
+++ b/EIPS/eip-7600.md
@@ -4,8 +4,7 @@ title: Hardfork Meta - Pectra
 description: EIPs included in the Prague/Electra Ethereum network upgrade.
 author: Tim Beiko (@timbeiko)
 discussions-to: https://ethereum-magicians.org/t/eip-7600-hardfork-meta-prague-electra/18205
-status: Last Call
-last-call-deadline: 2025-04-01
+status: Final
 type: Meta
 created: 2024-01-18
 requires: 2537, 2935, 6110, 7002, 7251, 7549, 7623, 7685, 7691, 7702, 7840
@@ -17,9 +16,9 @@ This Meta EIP lists the EIPs formally Scheduled for Inclusion in the Prague/Elec
 
 ## Specification
 
-A formal definition for `Scheduled for Inclusion` can be found in [EIP-7723](./eip-7723.md).
+A formal definition for `Included` can be found in [EIP-7723](./eip-7723.md).
 
-### EIPs Scheduled for Inclusion  
+### Included EIPs
 
 #### Core EIPs
 
@@ -33,7 +32,6 @@ A formal definition for `Scheduled for Inclusion` can be found in [EIP-7723](./e
 * [EIP-7685](./eip-7685.md): General purpose execution layer requests 
 * [EIP-7691](./eip-7691.md): Blob throughput increase
 * [EIP-7702](./eip-7702.md): Set EOA account code
-
 
 #### Other EIPs
 
@@ -60,12 +58,9 @@ EIP-2537, EIP-2935, EIP-6110, EIP-7002, EIP-7623, EIP-7685, EIP-7702 and EIP-784
 | Hoodi            |    `2048`        |     `1742999832`     |
 | Mainnet          |   `364032`       |     `1746612311`     |
 
-**Note**: rows in the table above will be filled as activation times are decided by client teams. 
-
 ## Rationale
 
 This Meta EIP provides a global view of all changes included in the Prague/Electra network upgrade, as well as links to the full specification. 
-
 ## Security Considerations
 
 None.

--- a/EIPS/eip-7600.md
+++ b/EIPS/eip-7600.md
@@ -59,6 +59,7 @@ EIP-2537, EIP-2935, EIP-6110, EIP-7002, EIP-7623, EIP-7685, EIP-7702 and EIP-784
 ## Rationale
 
 This Meta EIP provides a global view of all changes included in the Prague/Electra network upgrade, as well as links to the full specification. 
+
 ## Security Considerations
 
 None.

--- a/EIPS/eip-7600.md
+++ b/EIPS/eip-7600.md
@@ -16,8 +16,6 @@ This Meta EIP lists the EIPs formally Scheduled for Inclusion in the Prague/Elec
 
 ## Specification
 
-A formal definition for `Included` can be found in [EIP-7723](./eip-7723.md).
-
 ### Included EIPs
 
 #### Core EIPs


### PR DESCRIPTION
With Pectra live on mainnet, the Meta EIP should be moved to Final. Note that this will require all included EIPs to be moved to final: 

- [x] [EIP-2537](./eip-2537.md): Precompile for BLS12-381 curve operations  
- [x] [EIP-2935](./eip-2935.md): Save historical block hashes in state  
- [x] [EIP-6110](./eip-6110.md): Supply validator deposits on chain  
- [x] [EIP-7002](./eip-7002.md): Execution layer triggerable exits  
- [x] [EIP-7251](./eip-7251.md): Increase the MAX_EFFECTIVE_BALANCE  
- [x] [EIP-7549](./eip-7549.md): Move committee index outside Attestation  
- [x] [EIP-7623](./eip-7623.md): Increase calldata cost  
- [x] [EIP-7685](./eip-7685.md): General purpose execution layer requests  
- [x] [EIP-7691](./eip-7691.md): Blob throughput increase  
- [x] [EIP-7702](./eip-7702.md): Set EOA account code  
- [x] [EIP-7840](./eip-7840.md): Add blob schedule to EL config files (Informational)  
- [x] [EIP-7642](./eip-7642.md): eth/69 - Drop pre-merge fields (Networking)  