### PR TITLE
Update EIP-7685: Move to Final

### DIFF
--- a/EIPS/eip-7685.md
+++ b/EIPS/eip-7685.md
@@ -4,7 +4,7 @@ title: General purpose execution layer requests
 description: A general purpose bus for sharing EL triggered requests with the CL
 author: lightclient (@lightclient), Felix Lange (@fjl)
 discussions-to: https://ethereum-magicians.org/t/eip-7685-general-purpose-execution-layer-requests/19668
-status: Last Call
+status: Final
 last-call-deadline: 2025-02-21
 type: Standards Track
 category: Core

--- a/EIPS/eip-7685.md
+++ b/EIPS/eip-7685.md
@@ -5,7 +5,6 @@ description: A general purpose bus for sharing EL triggered requests with the CL
 author: lightclient (@lightclient), Felix Lange (@fjl)
 discussions-to: https://ethereum-magicians.org/t/eip-7685-general-purpose-execution-layer-requests/19668
 status: Final
-last-call-deadline: 2025-02-21
 type: Standards Track
 category: Core
 created: 2024-04-14


### PR DESCRIPTION
move status to final now that 7600 is final (https://github.com/ethereum/EIPs/pull/9740)