### PR TITLE
Update EIP-7886: Move from "coinbase fronting" to "payload reversion" mechanism

### DIFF
--- a/EIPS/eip-7886.md
+++ b/EIPS/eip-7886.md
@@ -286,26 +286,19 @@ During block execution:
 1. Clients MUST create a block-level snapshot before any transaction execution occurs. This happens after handling the system contracts from [EIP-4788](./eip-4788) and [EIP-2935](./eip-2935).
 
 2. Maximum fees MUST be deducted from sender balances upfront by:
-   ```python
-   def deduct_max_tx_fee_from_sender_balance(block_env, tx):
-       effective_gas_price = calculate_effective_gas_price(tx, block_env.base_fee_per_gas)
-       blob_gas_price = calculate_blob_gas_price(block_env.excess_blob_gas)
-       blob_gas_used = calculate_total_blob_gas(tx)
-       max_gas_fee = tx.gas * effective_gas_price + blob_gas_used * blob_gas_price
-       sender = recover_sender(block_env.chain_id, tx)
-       sender_account = get_account(block_env.state, sender)
-       set_account_balance(block_env.state, sender, sender_account.balance - U256(max_gas_fee))
-   ```
+
+```python
+def deduct_max_tx_fee_from_sender_balance(block_env, tx):
+    effective_gas_price = calculate_effective_gas_price(tx, block_env.base_fee_per_gas)
+    blob_gas_price = calculate_blob_gas_price(block_env.excess_blob_gas)
+    blob_gas_used = calculate_total_blob_gas(tx)
+    max_gas_fee = tx.gas * effective_gas_price + blob_gas_used * blob_gas_price
+    sender = recover_sender(block_env.chain_id, tx)
+    sender_account = get_account(block_env.state, sender)
+    set_account_balance(block_env.state, sender, sender_account.balance - U256(max_gas_fee))
+```
 
 3. Transactions are executed sequentially until executing a transaction would cause the block to exceed the gas limit.
-
-   ```python
-  def process_transaction(...)
-      if block_output.block_gas_used + tx.gas > block_env.block_gas_limit:
-            block_output.execution_reverted = True
-            return
-      ...
-   ```
 
 4. After execution, clients MUST verify that the total gas used matches the declared `gas_used` in the block header.
 
@@ -321,7 +314,15 @@ During block execution:
 
 8. The execution outputs (`last_transactions_root`, `last_receipt_root`, `last_block_logs_bloom`, `last_requests_hash`, `last_execution_reverted`) are updated in the chain state based on the execution results, and will be verified in subsequent blocks.
 
+Execution SHALL be stopped and the payload reverted after exceeding the block gas limit:
 
+```python
+def process_transaction(...)
+  if block_output.block_gas_used + tx.gas > block_env.block_gas_limit:
+        block_output.execution_reverted = True
+        return
+  ...
+```
 
 ## Rationale
 

--- a/EIPS/eip-7886.md
+++ b/EIPS/eip-7886.md
@@ -62,6 +62,7 @@ class Header:
 ```
 
 The key changes are:
+
 1. `pre_state_root`: Represents the state root before execution (checked against the post-execution state of the parent block)
 2. `parent_receipt_root`: Receipt root from the parent block (deferred execution output)
 3. `parent_bloom`: Logs bloom from the parent block (deferred execution output)
@@ -343,12 +344,14 @@ By tracking sender balances and nonces during validation, the protocol can enfor
 The block-level snapshot mechanism builds upon the existing transaction snapshot system to provide an efficient way to revert execution when necessary. This approach allows clients to roll back the entire block's execution if the actual gas used does not match the declared gas in the header, without invalidating the block structure itself.
 
 This provides two key benefits:
+
 1. It allows validators to attest to blocks before execution is complete
 2. It ensures execution is eventually performed correctly, with economic penalties for incorrect gas declarations
 
 ### EIP-7623 Integration
 
 The implementation integrates [EIP-7623](./eip-7623.md) calldata gas floor by:
+
 1. Using the maximum of intrinsic gas and calldata floor cost during validation
 2. Checking that total inclusion gas (including floor-adjusted costs) doesn't exceed the declared gas_used
 3. Maintaining backward compatibility with existing transaction formats
@@ -358,6 +361,7 @@ This ensures that sufficient gas is always allocated for calldata processing reg
 ### Execution Reversion Handling
 
 When a block's execution is reverted due to gas mismatch:
+
 1. The block itself remains valid and part of the canonical chain
 2. The `last_execution_reverted` flag is set to `True` in chain state
 3. The next block must include this flag as `parent_execution_reverted`

--- a/EIPS/eip-7886.md
+++ b/EIPS/eip-7886.md
@@ -1,170 +1,105 @@
 ---
 eip: 7886
 title: Delayed execution
-description: Make blocks statically verifiable by charging coinbase for inclusion costs upfront
-author: Francesco D`Amato (@fradamt), Toni Wahrstätter (@nerolation)
+description: Separate block validation from execution
+author: Francesco D'Amato (@fradamt), Toni Wahrstätter (@nerolation)
 discussions-to: https://ethereum-magicians.org/t/eip-7886-delayed-execution/22890
 status: Draft
 type: Standards Track
 category: Core
 created: 2025-02-18
+requires: 1559, 2930, 4844, 7623, 7702
 ---
 
 ## Abstract
 
-This proposal makes (execution) blocks statically verifiable through minimal checks that only require the previous state, but no execution of the block's transactions, allowing validators attest to a block's validity without completing its execution. We allow transactions to be skipped when invalid at execution time, without invalidating the whole block. To ensure that even skipped transactions pay for their resources, the `COINBASE` pays for all inclusion costs upfront (base cost, calldata and blobs), and recovers the costs only when transactions are successfully executed.
+This proposal introduces a mechanism to make execution blocks statically verifiable through minimal checks that only require the previous state, without requiring execution of the block's transactions. This enables validators to attest to a block's validity without completing its execution.
 
 ## Motivation
 
-A key advantage of this proposal is that it enables **asynchronous block validation**. Currently, blocks must be fully executed before validators can attest to their validity. This requirement creates a bottleneck in the consensus process, as attestors must wait for execution results before committing their votes.
+The primary advantage of this proposal is **asynchronous block validation**. In the current Ethereum protocol, blocks must be fully executed before validators can attest to them. This requirement creates a bottleneck in the consensus process, as attestors must wait for execution results before committing their votes, limiting the network's throughput potential.
 
-By introducing a mechanism where invalid transactions are skipped rather than invalidating the entire block, execution is no longer an immediate requirement for validation. Instead, a block’s validity can be determined based on its structural correctness and the upfront payment of inclusion costs by the `COINBASE`. This allows attestation to happen earlier, independent of execution, potentially enabling higher block gas limits.
+By introducing a mechanism where execution payloads can be reverted rather than invalidating the entire block, execution is no longer an immediate requirement for validation. Instead, a block's validity can be determined based on its structural correctness and the upfront payment of transaction fees by senders. This allows attestation to happen earlier in the slot, independent of execution, potentially enabling higher block gas limits and significant throughput improvements across the network.
 
 ## Specification
 
-### Change to the header structure
+### Header Changes
 
-#### Deferred fields 
-
-In order to be verifiable before execution, the header cannot commit to any execution output. In particular, we need to defer these fields: `state_root, receipt_root, bloom, gas_used, requests_hash`. We replace them with the equivalent execution outputs from the parent block. 
-
-#### Coinbase signature over the header
-
-We include a signature from `COINBASE` over the rest of the header in the header , so that the `COINBASE` address can authorize the upfront payment of inclusion costs.
-
-The final header structure then is: 
+The block header structure is extended to support delayed execution:
 
 ```python
+@dataclass
 class Header:
+    # Existing fields
     parent_hash: Hash32
     ommers_hash: Hash32
     coinbase: Address
-    pre_state_root: Root # Deferred
-    transactions_root: Root
-    parent_receipt_root: Root # Deferred
-    parent_bloom: Bloom # Deferred
+
+    # Pre-execution state root - this is the state root before executing transactions
+    pre_state_root: Root  
+
+    # Deferred execution outputs from parent block
+    parent_transactions_root: Root    # Transaction root from parent block
+    parent_receipt_root: Root         # Receipt root from parent block
+    parent_bloom: Bloom               # Logs bloom from parent block
+    parent_requests_hash: Hash32      # Hash of requests from the parent block
+    parent_execution_reverted: bool   # Indicates if parent block's execution was reverted
+
+    # Other existing fields
     difficulty: Uint
     number: Uint
     gas_limit: Uint
-    parent_gas_used: Uint
+    gas_used: Uint                   # Declared gas used by txs, validated post-execution
     timestamp: U256
     extra_data: Bytes
     prev_randao: Bytes32
     nonce: Bytes8
     base_fee_per_gas: Uint
     withdrawals_root: Root
-    blob_gas_used: U64
+    blob_gas_used: U64               # Total blob gas used by transactions
     excess_blob_gas: U64
     parent_beacon_block_root: Root
-    parent_requests_hash: Hash32 # Deferred
-    # Signature over the header
-    y_parity: U256
-    r: U256
-    s: U256
 ```
 
-The following function is used to recover the signer’s address, intended to be `COINBASE`, from the signed block header:
+The key changes are:
+1. `pre_state_root`: Represents the state root before execution (checked against the post-execution state of the parent block)
+2. `parent_receipt_root`: Receipt root from the parent block (deferred execution output)
+3. `parent_bloom`: Logs bloom from the parent block (deferred execution output)
+4. `parent_requests_hash`: Hash of requests from the parent block (deferred execution output)
+5. `parent_execution_reverted`: Indicates whether the parent block's execution was reverted
+
+A block header MUST include all these fields to be considered valid under this EIP. The `pre_state_root` MUST match the state root after applying the parent block's execution. The parent execution outputs MUST accurately reflect the previous block's execution results to maintain chain integrity.
+
+### Chain State Tracking
+
+The blockchain object is extended to track execution outputs for verification in subsequent blocks:
 
 ```python
-def recover_header_signer(
-    chain_id: U64,
-    header: Header,
-) -> Address:
-    signing_hash = keccak256(
-        b"0x06"
-        + rlp.encode(
-            (
-                chain_id,
-                header.parent_hash,
-                header.ommers_hash,
-                header.coinbase,
-                header.pre_state_root,
-                header.transactions_root,
-                header.parent_receipt_root,
-                header.parent_bloom,
-                header.difficulty,
-                header.number,
-                header.gas_limit,
-                header.parent_gas_used,
-                header.timestamp,
-                header.extra_data,
-                header.prev_randao,
-                header.nonce,
-                header.base_fee_per_gas,
-                header.withdrawals_root,
-                header.blob_gas_used,
-                header.excess_blob_gas,
-                header.parent_beacon_block_root,
-                header.parent_requests_hash,
-            )
-        )
-    )
+@dataclass
+class BlockChain:
+    blocks: List[Block]
+    state: State
+    chain_id: U64
+    last_transactions_root: Root    # Transaction root from the last executed block
+    last_receipt_root: Root         # Receipt root from last executed block
+    last_block_logs_bloom: Bloom    # Logs bloom from last executed block
+    last_requests_hash: Bytes       # Requests hash from last executed block
+    last_execution_reverted: bool   # Indicates if the last block's execution was reverted
 ```
 
-If `COINBASE != header_signer`, the block MUST be considered invalid.
+These additional fields are used to verify the deferred execution outputs claimed in subsequent blocks. The `last_transactions_root`, `last_receipt_root`, `last_block_logs_bloom`, `last_requests_hash`, and `last_execution_reverted` act as critical chain state references that MUST be updated after each block execution to ensure proper state progression. When a block's execution is reverted due to a gas mismatch, the `last_execution_reverted` field is set to `True`, which affects the base fee calculation of subsequent blocks.
+
+### Block Validation
+
+Static validation is performed separately from execution. In this phase, all checks that can be done without executing transactions are performed:
 
 ```python
-header_signer = recover_header_signer(
-    chain.chain_id,
-    block.header,
-)
-if coinbase != header_signer:
-    raise InvalidBlock
-```
+def validate_block(chain: BlockChain, block: Block) -> None:
+    # Validate header against parent
+    validate_header(chain, block.header)
 
-### Static block validation
-
-We split up a block's validation from its execution. In the ethereum/execution-specs, static validation is done in `[validate_block](https://github.com/ethereum/execution-specs/blob/ae2c77989cb83e5d5e5eb1f51d9da840a337d5b0/src/ethereum/prague/fork.py#L480)`, after which a block is guaranteed to be valid and can be attested to, while execution remains within `[apply_body](https://github.com/ethereum/execution-specs/blob/ae2c77989cb83e5d5e5eb1f51d9da840a337d5b0/src/ethereum/prague/fork.py#L696)`. In `validate_block`, we do some formal checks, as well as:
-
-* validate all deferred header fields (`pre_state_root`, `parent_gas_used`, `parent_receipts_root`, `parent_bloom`, `parent_receipts_hash`, `parent_requests_hash`) against the output from execution *of the parent block*.
-* validate all statically verifiable header fields:
-    * check that `transactions_root` and `withdrawals_root` are correct, by building the respective tries, but *without yet processing either the transactions or the withdrawals*
-    * check that `blob_gas_used` is correct
-* validate the header signature of the `COINBASE`.
-* do static checks for each transaction in `[check_transaction_static](https://github.com/ethereum/execution-specs/blob/ae2c77989cb83e5d5e5eb1f51d9da840a337d5b0/src/ethereum/prague/fork.py#L443)`:
-    * verify the transaction's signature
-    * verify that the gas prices are sufficient for the current basefees
-* determine the inclusion costs of all transactions, and check that `COINBASE` can pay for the total inclusion cost
-* check that neither the total inclusion gas nor the total blob gas go over the limits
-
-In other words, we validate everything that we can validate without doing any execution.
-
-```python
-def check_transaction_static(
-    tx: Transaction,
-    chain_id: U64,
-) -> Address:
-    
-    ... 
-    
-    if isinstance(tx, (FeeMarketTransaction, BlobTransaction, SetCodeTransaction)):
-    if tx.max_fee_per_gas < tx.max_priority_fee_per_gas:
-        raise InvalidBlock
-    if tx.max_fee_per_gas < base_fee_per_gas:
-        raise InvalidBlock
-else:
-    if tx.gas_price < base_fee_per_gas:
-        raise InvalidBlock
-        
-    if isinstance(tx, BlobTransaction):
-        ...
-        if Uint(tx.max_fee_per_blob_gas) < blob_gas_price:
-            raise InvalidBlock       
-    ...
-    
-    return recover_sender(chain_id, tx)
-
-
-def validate_block(
-    chain: BlockChain,
-    block: Block,
-) -> List[Address]:
-    
-    parent_header = chain.blocks[-1].header
-    validate_header(block.header, parent_header)
-
-    # validate deferred execution outputs from the parent
-    if block.header.parent_gas_used != chain.last_block_gas_used:
+    # Validate deferred execution outputs from the parent
+    if block.header.parent_transactions_root != chain.last_transactions_root:
         raise InvalidBlock
     if block.header.parent_receipt_root != chain.last_receipt_root:
         raise InvalidBlock
@@ -174,225 +109,290 @@ def validate_block(
         raise InvalidBlock
     if block.header.pre_state_root != state_root(chain.state):
         raise InvalidBlock
-
-    if block.ommers != ():
+    if block.header.parent_execution_reverted != chain.last_execution_reverted:
         raise InvalidBlock
 
-    # Validate coinbase's signature over the header
-    coinbase = block.header.coinbase
-    header_signer = recover_header_signer(
-        chain.chain_id,
-        block.header,
-    )
-    if coinbase != header_signer:
-        raise InvalidBlock
-    
-    sender_addresses = []
+    ...
+
+    # Process all transactions trie and validate transactions
+    total_inclusion_gas = Uint(0)
+    total_blob_gas_used = Uint(0)
+    withdrawals_trie = Trie(secured=False, default=None)
+
+    # Track sender balances and nonces by address
+    sender_balances = {}
+    sender_nonces = {}
+
+    # Calculate blob gas price based on excess blob gas
+    blob_gas_price = calculate_blob_gas_price(block.header.excess_blob_gas)
+
+    # Validate each transaction
     for i, tx in enumerate(map(decode_transaction, block.transactions)):
-        sender_address = check_transaction_static(tx, chain.chain_id)
-        sender_addresses.append(sender_address)
-        _, inclusion_gas = calculate_inclusion_gas_cost(tx)
+        # Validate transaction parameters (signature, fees, etc.)
+        validate_transaction(tx, block.header.base_fee_per_gas, block.header.excess_blob_gas)
+
+        # Recover sender
+        sender_address = recover_sender(chain.chain_id, tx)
+
+        # Calculate gas costs (both EIP-7623 intrinsic cost and floor cost)
+        intrinsic_gas, calldata_floor_gas_cost = calculate_intrinsic_cost(tx)
         blob_gas_used = calculate_total_blob_gas(tx)
-        
-        total_inclusion_gas += inclusion_gas
+
+        # Track total gas usage (using the maximum of intrinsic gas and floor cost)
+        total_inclusion_gas += max(intrinsic_gas, calldata_floor_gas_cost)
         total_blob_gas_used += blob_gas_used
 
-        trie_set(
-            transactions_trie, rlp.encode(Uint(i)), encode_transaction(tx)
-        )
+        # Calculate maximum gas fee (including blob fees)
+        effective_gas_price = calculate_effective_gas_price(tx, block.header.base_fee_per_gas)
+        max_gas_fee = tx.gas * effective_gas_price + blob_gas_used * blob_gas_price
 
-    # Check that inclusion resources are within the limits
-    if total_inclusion_gas > block.header.gas_limit:
+        # Verify sender is an EOA or has delegation support
+        if sender_address not in sender_balances:
+            account = get_account(chain.state, sender_address)
+            is_sender_eoa = (
+                account.code == bytearray()
+                or is_valid_delegation(account.code)
+            )
+            if not is_sender_eoa:
+                raise InvalidBlock
+            sender_balances[sender_address] = account.balance
+            sender_nonces[sender_address] = account.nonce
+
+        # Verify sender has sufficient balance
+        if sender_balances[sender_address] < max_gas_fee + Uint(tx.value):
+            raise InvalidBlock
+
+        # Verify correct nonce
+        if sender_nonces[sender_address] != tx.nonce:
+            raise InvalidBlock
+
+        # Track balance and nonce changes
+        sender_balances[sender_address] -= max_gas_fee + Uint(tx.value)
+        sender_nonces[sender_address] += 1
+
+    # Validate gas constraints
+    if total_inclusion_gas > block.header.gas_used:
         raise InvalidBlock
-    if total_blob_gas_used > MAX_BLOB_GAS_PER_BLOCK:
+    if total_blob_gas_used != block.header.blob_gas_used:
         raise InvalidBlock
 
-    blob_gas_price = calculate_blob_gas_price(block.header.excess_blob_gas)
-    inclusion_cost = (
-        total_inclusion_gas * block.header.base_fee_per_gas
-        + total_blob_gas_used * blob_gas_price
-    )
-    
-    # Check that coinbase can pay for inclusion costs
-    coinbase_account = get_account(chain.state, coinbase)
-    if Uint(coinbase_account.balance) < inclusion_cost:
-        raise InvalidBlock
-
+    # Validate withdrawals trie
     for i, wd in enumerate(block.withdrawals):
         trie_set(withdrawals_trie, rlp.encode(Uint(i)), rlp.encode(wd))
 
-    if block.header.transactions_root != root(transactions_trie):
-        raise InvalidBlock
     if block.header.withdrawals_root != root(withdrawals_trie):
         raise InvalidBlock
-    if block.header.blob_gas_used != blob_gas_used:
-        raise InvalidBlock
-    
-    return sender_addresses
 ```
 
-### Block execution
+This validation function enforces several requirements:
 
-This logic is implemented into the ethereum/execution-specs, in `[apply_body](https://github.com/ethereum/execution-specs/blob/ae2c77989cb83e5d5e5eb1f51d9da840a337d5b0/src/ethereum/prague/fork.py#L696)`.
+1. Clients MUST validate that the block's parent execution outputs match the chain's tracked last execution outputs.
+2. The `pre_state_root` MUST match the current state root to ensure proper state transition.
+3. All transactions MUST be statically validated for signature correctness and transaction type-specific requirements ([EIP-1559](./eip-1559.md), [EIP-4844](./eip-4844.md), etc.).
+4. Sender accounts MUST be externally owned accounts (EOAs) or have valid delegation support ([EIP-7702](./eip-7702.md)).
+5. Senders MUST have sufficient balance to cover maximum possible gas fees plus transaction value.
+6. Transaction nonces MUST be correct and sequential per sender.
+7. Total inclusion gas (using the maximum of intrinsic gas and EIP-7623 floor cost plus calldata) MUST not exceed the block's declared gas_used.
+8. Total blob gas MUST match the declared blob_gas_used.
+9. Transaction and withdrawal trie roots MUST match their respective header fields.
 
-#### Coinbase Pays Inclusion Cost Upfront
+When calculating inclusion gas, the implementation uses the maximum of the regular intrinsic gas cost and the EIP-7623 calldata floor cost, which ensures proper accounting for calldata gas regardless of execution outcome.
 
-   * The block's `COINBASE` is charged `inclusion_cost = 21000 + max_calldata_fee + blob_fee` for each transaction at the start of block execution. The `inclusion_cost` is determined by adding up the blob fee and the floor cost of [EIP-7623](./eip-7623.md), itself comprising the 21k base cost and the calldata cost charged at `TOTAL_COST_FLOOR_PER_TOKEN`.
-   * If the transaction is skipped, **the `COINBASE` loses** these inclusion fees and thereby pays for DA and other base costs like signature verification.
+### Block Execution with State Snapshots
 
-```python
-# The inclusion gas consists of the base cost + the calldata cost
-def calculate_inclusion_gas_cost(tx: Transaction) -> Uint:
-    tokens_in_calldata = zero_bytes + (len(tx.data) - zero_bytes) * 4
-    calldata_floor_gas_cost = tokens_in_calldata * FLOOR_CALLDATA_COST
-    return TX_BASE_COST + calldata_floor_gas_cost
-
-def apply_body(
-    ...
-) -> ApplyBodyOutput:
-    
-    ...
-    total_inclusion_gas = sum(calculate_inclusion_gas_cost(tx) for tx in decoded_transactions)
-    total_blob_gas_used = sum(calculate_total_blob_gas(tx) for tx in decoded_transactions)
-    inclusion_cost = (
-        total_inclusion_gas * base_fee_per_gas
-        + total_blob_gas_used * blob_gas_price
-    )
-    coinbase_account = get_account(state, coinbase)
-    coinbase_balance_after_inclusion_cost = (
-        Uint(coinbase_account.balance) - inclusion_cost
-    )
-    # Charge coinbase for inclusion costs
-    set_account_balance(
-        env.state,
-        env.coinbase,
-        U256(coinbase_balance_after_inclusion_cost),
-    )
-    ...
-```
-
-Besides deducting the inclusion costs from the`COINBASE`'s balance, we deduct the `inclusion_gas` from `gas_available` upfront, since this gas is going to be consumed regardless of how execution goes. When executing a transaction, we do the following:
-
-* We initially add its inclusion gas to `gas_available`, making it available for the transaction to consume.
-* If the transaction is skipped, the inclusion gas is deducted from the `gas_available`
-* For transactions that are not skipped (c.f. *executed*), we deduct the actual `gas_used` from `gas_available`.
+After a block passes static validation, execution proceeds with the pre-charged transaction senders:
 
 ```python
 def apply_body(
-    ...
-) -> ApplyBodyOutput:
-    ...
-    
-    total_inclusion_gas = sum(calculate_inclusion_gas_cost(tx) for tx in decoded_transactions)
-    ...
-    
-    gas_available = block_gas_limit - total_inclusion_gas
-    ...
-    
-    for i, tx in enumerate(txs):
-        ...
-        inclusion_gas = calculate_inclusion_gas_cost(tx)
-        gas_available += inclusion_gas
-        (
-            is_transaction_skipped,
-            effective_gas_price,
-            blob_versioned_hashes,
-        ) = check_transaction(
-            state,
-            tx,
-            sender_address,
-            gas_available,
+    block_env: vm.BlockEnvironment,
+    transactions: Tuple[Union[LegacyTransaction, Bytes], ...],
+    withdrawals: Tuple[Withdrawal, ...],
+) -> vm.BlockOutput:
+    block_output = vm.BlockOutput()
+
+    # Process system transactions first (beacon roots, history storage)
+    process_system_transaction(
+        block_env=block_env,
+        target_address=BEACON_ROOTS_ADDRESS,
+        data=block_env.parent_beacon_block_root,
+    )
+
+    process_system_transaction(
+        block_env=block_env,
+        target_address=HISTORY_STORAGE_ADDRESS,
+        data=block_env.block_hashes[-1],  # The parent hash
+    )
+
+    # Process user transactions
+    process_transactions(block_env, block_output, transactions)
+
+    # Process withdrawals only if execution wasn't reverted
+    if not block_output.execution_reverted:
+        process_withdrawals(block_env, block_output, withdrawals)
+
+        # Process requests (deposits, withdrawals, consolidations)
+        process_general_purpose_requests(
+            block_env=block_env,
+            block_output=block_output,
         )
 
-        
-        if is_transaction_skipped:
-            gas_available -= inclusion_gas
-        else:
-            
-            ...
+    return block_output
 
-            gas_used, logs, error = process_transaction(env, tx)
-            gas_available -= gas_used
-            
-            ...
-    ...
+def process_transactions(
+    block_env: vm.BlockEnvironment,
+    block_output: vm.BlockOutput,
+    transactions: Tuple[Union[LegacyTransaction, Bytes], ...],
+) -> None:
+    # Take a block-level snapshot of the state before transaction execution
+    begin_transaction(block_env.state)
+
+    # Decode transactions
+    decoded_transactions = [decode_transaction(tx) for tx in transactions]
+
+    # Pre-charge senders for maximum possible gas fees upfront
+    for tx in decoded_transactions:
+        deduct_max_tx_fee_from_sender_balance(block_env, tx)
+
+    # Execute each transaction
+    for i, tx in enumerate(decoded_transactions):
+        process_transaction(block_env, block_output, tx, Uint(i))
+        # Stop processing if execution is already reverted
+        if block_output.execution_reverted:
+            break
+
+    # Validate declared gas used against actual gas used
+    block_output.execution_reverted = (
+        block_output.execution_reverted
+        or block_output.block_gas_used != block_env.block_gas_used
+    )
+
+    # If execution is reverted, reset all outputs and rollback the state
+    if block_output.execution_reverted:
+        rollback_transaction(block_env.state)
+        block_output.block_gas_used = Uint(0)
+        block_output.transactions_trie = Trie(secured=False, default=None)
+        block_output.receipts_trie = Trie(secured=False, default=None)
+        block_output.receipt_keys = ()
+        block_output.block_logs = ()
+        block_output.requests = []
+        block_output.execution_reverted = True
+    else:
+        # Commit the state if execution is valid
+        commit_transaction(block_env.state)
 ```
 
-#### Skipped Transactions
+During block execution:
 
-**Definition**: A "skipped transaction" is a transaction that:
+1. Clients MUST create a block-level snapshot before any transaction execution occurs. This happens after handling the system contracts from [EIP-4788](./eip-4788) and [EIP-2935](./eip-2935).
 
-* Is included in the block (part of the transactions list)
-* Is not executed during block execution
-* Consumes no gas beyond its inclusion cost, which the block's `COINBASE` pays and **does not get refunded** if the transaction is ultimately skipped.
+2. Maximum fees MUST be deducted from sender balances upfront by:
+   ```python
+   def deduct_max_tx_fee_from_sender_balance(block_env, tx):
+       effective_gas_price = calculate_effective_gas_price(tx, block_env.base_fee_per_gas)
+       blob_gas_price = calculate_blob_gas_price(block_env.excess_blob_gas)
+       blob_gas_used = calculate_total_blob_gas(tx)
+       max_gas_fee = tx.gas * effective_gas_price + blob_gas_used * blob_gas_price
+       sender = recover_sender(block_env.chain_id, tx)
+       sender_account = get_account(block_env.state, sender)
+       set_account_balance(block_env.state, sender, sender_account.balance - U256(max_gas_fee))
+   ```
 
-Skipping might occur because:
+3. Transactions are executed sequentially until executing a transaction would cause the block to exceed the gas limit.
 
-1. The transaction is underfunded, meaning that the sender cannot cover the maximum transaction costs plus `tx.value` 
-2. There is not enough gas available in the block
-3. The sender's nonce does not match
-4. The sender is not an EOA
+   ```python
+  def process_transaction(...)
+      if block_output.block_gas_used + tx.gas > block_env.block_gas_limit:
+            block_output.execution_reverted = True
+            return
+      ...
+   ```
 
-More precisely, this is how we determine if a transaction should be skipped: 
+4. After execution, clients MUST verify that the total gas used matches the declared `gas_used` in the block header.
 
-```python
-    is_sender_eoa = (
-        sender_account.code == bytearray() 
-        or is_valid_delegation(sender_account.code)
-    )
-    is_transaction_skipped = (
-        tx.gas > gas_available
-        or Uint(sender_account.balance) < max_gas_fee + Uint(tx.value)
-        or sender_account.nonce != tx.nonce
-        or not is_sender_eoa
-    )
-```
+5. If the actual gas used doesn't match the declared value, clients MUST:
+   - Set `execution_reverted` to `True`
+   - Roll back to the snapshot taken before execution
+   - Reset all execution outputs (receipts, logs, etc.)
+   - Return zero gas used
 
-Note that signature verification and other checks *that do not depend on execution* are done in advance, when statically checking the block's validity. If those fail, the block is invalid. A transaction is skipped only when an *execution-dependent* check fails, in a block that's already been determined to be valid.
+6. The block itself remains valid, but execution outputs are not applied to the state.
 
-#### Transaction execution
+7. General purpose requests as defined in [EIP-7685](./eip-7685.md) are skipped when execution is reverted.
 
-When a transaction is executed, rather than skipped, the only change from the previous behavior is that `COINBASE` receives not only the priority fees, but also a refund of the inclusion costs. From the transaction sender's perspective, there is no change at all: the transaction executes in the same way, and the same exact fees are paid. From the protocol's perspective, there is also no difference, because the extra fees collected by `COINBASE` are exactly those that it had paid upfront at the beginning of the block's execution.
+8. The execution outputs (`last_transactions_root`, `last_receipt_root`, `last_block_logs_bloom`, `last_requests_hash`, `last_execution_reverted`) are updated in the chain state based on the execution results, and will be verified in subsequent blocks.
 
-```python
-def process_transaction(
-   ...
-    inclusion_cost_refund = (
-    inclusion_gas * base_fee_per_gas
-    + blob_gas_used * blob_gas_price
-    )
-    
-    # transfer priority fees and refund inclusion cost
-    coinbase_balance_after_transaction = (
-        coinbase_account.balance 
-        + priority_fee
-        + inclusion_cost_refund
-    )
-   ...
-```
+
 
 ## Rationale
 
-### Overview
+### Deferred Execution Outputs
 
-Enabling delayed execution by making the block's validity statically verifiable requires two things:
+The core innovation of deferring execution outputs to the next block enables static verification without requiring immediate execution. The `pre_state_root` provides a cryptographically verifiable starting point for validation, while parent execution outputs create a chain of deferred execution results that maintains the integrity of the blockchain state.
 
-1. **Deferred execution outputs**: all header fields that commit to execution outputs are deferred by one slot. For example `state_root` and `receipt_root` become `pre_state_root`, `parent_receipt_root` the root of the state and receipt trie obtained after executing the block's parent. The same applies to the General Purpose Execution Layer Requests from [EIP-7685](./eip-7685.md): the requests are deferred by one slot and the requests in the CL must correspond to the `parent_requests_hash` in the EL header. However, this alone would only defer the computation of these execution outputs (mainly of the state root) rather than the actual execution, because verifying transaction validity would still require executing. 
-2. **Upfront payment of inclusion costs by `COINBASE`**: in addition, we need to be able to skip (no-op) invalid transactions without invalidating the whole block. Right now, this is not possible because of the free-DA problem: as soon as we include a transaction into a block, it must pay for its data footprint. By charging the inclusion cost of all transactions upfront from the block's `COINBASE`, it is possible to skip transactions that are found to be invalid at execution time, because the protocol has already been compensated for the inclusion.
+This approach eliminates the execution bottleneck in the validation pipeline by allowing validators to attest to a block's validity based on its structure and the pre-charged transaction fees, without waiting for execution results.
 
-### Coinbase signature over the header
+### Pre-Charging Mechanism
 
-By signing over the header, the `COINBASE` address explicitly accepts responsibility for the upfront inclusion costs *of this block*. Therefore, the recovered address MUST equal the block's `COINBASE`. The `COINBASE`'s commitment is protected from replay attacks, because the header is a commitment to the block, so the signature only serves as an authorization for the exact block for which the `COINBASE` has agreed to take responsibility.
+Pre-charging senders with the maximum possible fees before execution provides a crucial guarantee that transactions have sufficient balance to be included in the block. This mechanism is compatible with existing fee models, including [EIP-1559](./eip-1559.md) dynamic fee transactions and [EIP-4844](./eip-4844.md) blob transactions.
+
+By tracking sender balances and nonces during validation, the protocol can enforce transaction validity without execution, enabling earlier block attestation.
+
+### State Snapshot Architecture
+
+The block-level snapshot mechanism builds upon the existing transaction snapshot system to provide an efficient way to revert execution when necessary. This approach allows clients to roll back the entire block's execution if the actual gas used does not match the declared gas in the header, without invalidating the block structure itself.
+
+This provides two key benefits:
+1. It allows validators to attest to blocks before execution is complete
+2. It ensures execution is eventually performed correctly, with economic penalties for incorrect gas declarations
+
+### EIP-7623 Integration
+
+The implementation integrates [EIP-7623](./eip-7623.md) calldata gas floor by:
+1. Using the maximum of intrinsic gas and calldata floor cost during validation
+2. Checking that total inclusion gas (including floor-adjusted costs) doesn't exceed the declared gas_used
+3. Maintaining backward compatibility with existing transaction formats
+
+This ensures that sufficient gas is always allocated for calldata processing regardless of execution outcome, improving DoS protection.
+
+### Execution Reversion Handling
+
+When a block's execution is reverted due to gas mismatch:
+1. The block itself remains valid and part of the canonical chain
+2. The `last_execution_reverted` flag is set to `True` in chain state
+3. The next block must include this flag as `parent_execution_reverted`
+4. Base fee calculations for subsequent blocks use 0 as parent gas used when parent execution was reverted
 
 ## Backwards Compatibility
 
-This change is not backward compatible and requires a hard fork activation. 
+This EIP requires a hard fork, as it alters the block validation and execution process.
 
 ## Security Considerations
 
-### Coinbase funding
+### Execution Correctness Guarantees
 
-At the time of block creation, the `COINBASE` must be sufficiently funded to cover up to `block.gas_limit * base_fee_per_gas` + `blob_gas_price * max_blob_gas_per_block` to be able to cover the maximum possible inclusion cost. For instance, with a base fee of 100 gwei and a 36 million gas limit, the `COINBASE` would need to hold 3.6 ETH to front this cost (ignoring the blob fees) for a worst-case block. This requirement could introduce additional liquidity constraints for block proposers, especially under high base fee conditions. However, the inclusion costs under normal conditions (lower base fee, inclusion gas much below the gas limit) are significantly lower. Over a one year period of blocks from ~19.1M to ~21.7M, the average inclusion costs would have been ~5.5M gas per block, or ~0.55 ETH even at 100 gwei.
+The protocol ensures execution correctness through these primary mechanisms:
+
+1. Deferred execution outputs MUST match in subsequent blocks, creating a chain of verifiable execution results.
+2. State rollback MUST occur if the actual gas used doesn't match the declared value, providing an economic incentive for correct gas declaration.
+3. The `parent_execution_reverted` flag ensures that blocks acknowledge when parent execution has been reverted, maintaining chain integrity.
+4. Static validation guarantees that all transactions are properly authorized and senders have sufficient funds for maximum fees.
+
+### Base Fee Dynamics with Reverted Execution
+
+When a block's execution is reverted, the next block's base fee calculation treats the parent's gas used as zero, regardless of what was declared in the header. This ensures that base fee adjustments remain responsive to actual chain usage, and prevents manipulation of the fee market through incorrect gas declarations.
+
+### Data Availability and Economic Incentives
+
+Block proposers MUST declare correct gas usage or lose transaction fees when execution is reverted. This aligns incentives for correct gas declaration and ensures execution integrity.
+
+Even when a block's execution is reverted due to incorrect gas declaration, the transaction data (calldata, [EIP-2930](./eip-2930.md) access lists, and blob data) MUST still be stored by all nodes for syncing and block validation purposes. This requirement creates a potential attack vector where malicious actors could attempt to place large amounts of data on-chain at a reduced cost by intentionally invalidating blocks through incorrect gas declarations.
+
+However, this attack is not economically sustainable for several reasons:
+
+1. Block proposers who invalidate blocks through incorrect gas declarations lose all execution layer rewards associated with the block.
+2. The attack requires control of block production, which is a scarce resource in the consensus layer.
+
+The economic costs of forgoing block rewards significantly outweigh any potential benefits, making such attacks financially impractical under normal network conditions.
 
 ## Copyright
 


### PR DESCRIPTION
We've transitioned from the coinbase-fronted inclusion cost model to a mechanism where transaction senders are pre-charged for their declared gas usage upfront. If any transaction turns out to be invalid during execution, the entire EL payload is treated as a no-op, reverting to the pre-state. This avoids complex fork-choice changes and maintains compatibility with related protocol proposals such as FOCIL. It keeps the UX stable—gas refunds are still possible—while mitigating builder exploits around free DA. Critically, the declared gas usage must match actual gas used, or the block becomes invalid.