### PR TITLE
Update EIP-7702: Fixing minor typos

### DIFF
--- a/EIPS/eip-7702.md
+++ b/EIPS/eip-7702.md
@@ -16,7 +16,7 @@ requires: 2, 161, 1052, 2718, 2929, 2930, 3541, 3607, 4844
 
 Add a new [EIP-2718](./eip-2718.md) transaction type that allows Externally
 Owned Accounts (EOAs) to set the code in their account. This is done by
-attaching a list of authorization tuples -- individually formated as `[chain_id,
+attaching a list of authorization tuples -- individually formatted as `[chain_id,
 address, nonce, y_parity, r, s]` -- to the transaction. For each tuple, a
 delegation indicator `(0xef0100 || address)` is written to the authorizing
 account's code. All code executing operations must load and execute the code
@@ -119,7 +119,7 @@ following:
 8. Set the code of `authority` to be `0xef0100 || address`. This is a delegation
    indicator.
     * If `address` is `0x0000000000000000000000000000000000000000`, do not write
-    the delegation indicator. Clear the account's code by reseting the account's
+    the delegation indicator. Clear the account's code by resetting the account's
     code hash to the empty code hash
     `0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470`.
 9. Increase the nonce of `authority` by one.
@@ -404,7 +404,7 @@ however because this EIP allows EOAs to spend value intra-transaction, the
 concern with bumping the nonce intra-transaction and invalidating pending
 transactions is not significant.
 
-#### Protection from mallebility cross-chain
+#### Protection from malleability cross-chain
 
 One consideration when signing a code pointer is what code that address points
 to on another chain. While it is possible to create a deterministic deployment,
@@ -574,7 +574,7 @@ system.
 ### Transaction propagation
 
 Allowing EOAs to behave as smart contracts via the delegation indicator poses
-some challenges for transaction propagation. Traditionally, EOAs have only be
+some challenges for transaction propagation. Traditionally, EOAs have only been
 able to send value via a transaction. This invariant allows nodes to statically
 determine the validity of transactions for that account. In other words, a
 single transaction has only been able to invalidate transactions pending from
@@ -583,7 +583,7 @@ the sender's account.
 With this EIP, it becomes possible to cause transactions from other accounts to
 become stale. This is due to the fact that once an EOA has delegated to code,
 that code can be called by anyone at any point in a transaction. It becomes
-impossible to know if the balance of the account has been sweeped in a static
+impossible to know if the balance of the account has been swept in a static
 manner.
 
 While there are a few mitigations for this, the authors recommend that clients
@@ -597,7 +597,7 @@ behave as the delegated code *only* for EIP-7702 transactions which include them
 in such a list, thus returning to clients the ability to statically analyze and
 reason about pending transactions.
 
-A related issue is that an EOA's nonce maybe incremented more than once per
+A related issue is that an EOA's nonce may be incremented more than once per
 transaction. Because clients already need to be robust in a worse scenario
 (described above), it isn't a major concern. However, clients should be aware
 this behavior is possible and design their transaction propagation accordingly.


### PR DESCRIPTION
**Typographical & Grammar Fixes**

- "formated" → "formatted" in the Abstract section.

- "reseting" → "resetting" in the Specification section.

- "sweeped" → "swept" in the Security Considerations (Transaction propagation) section.

- "maybe" → "may be" (space added) in the last paragraph under Transaction Propagation.

- "be able to" → "been able to" for proper tense in the Transaction Propagation section.