### PR TITLE
Update EIP-4444: Fix typos in EIP-4444

### DIFF
--- a/EIPS/eip-4444.md
+++ b/EIPS/eip-4444.md
@@ -30,7 +30,7 @@ Finally, this change will result in less bandwidth usage on the network as clien
 
 Clients SHOULD NOT serve headers, block bodies, and receipts that are older than `HISTORY_PRUNE_EPOCHS` epochs on the p2p network.
 
-Clients MAY locally prune headers, block bodies, and receipts that is older than `HISTORY_PRUNE_EPOCHS` epochs.
+Clients MAY locally prune headers, block bodies, and receipts that are older than `HISTORY_PRUNE_EPOCHS` epochs.
 
 #### Bootstrapping and syncing
 
@@ -98,7 +98,7 @@ Furthermore, there is a risk that more dapps will rely on centralized services f
 
 ### Confusion with other proposals
 
-Because there are a number of alternative proposals for reducing the execution client's footprint on disk, we've decided to enforce a specific pronunciation of the EIP. When pronouncing the EIP number, it **MUST** be pronounced EIP "four fours". All other pronounciations are incorrect.
+Because there are a number of alternative proposals for reducing the execution client's footprint on disk, we've decided to enforce a specific pronunciation of the EIP. When pronouncing the EIP number, it **MUST** be pronounced EIP "four fours". All other pronunciation are incorrect.
 
 ## Copyright
 Copyright and related rights waived via [CC0](../LICENSE.md).


### PR DESCRIPTION
This pull request corrects minor grammatical issues and a typo in the text of EIP-4444, specifically:

- Corrected “receipts that is older” to “receipts that are older”.

- Fixed a typo in the word “pronounciations” → “pronunciation”.

