### PR TITLE
Update eip-6110:Fix typos in eip-6110.md

### DIFF
--- a/EIPS/eip-6110.md
+++ b/EIPS/eip-6110.md
@@ -22,7 +22,7 @@ Validator deposits list supplied in a block is obtained by parsing deposit contr
 
 Validator deposits are a core component of the proof-of-stake consensus mechanism. This EIP allows for an in-protocol mechanism of deposit processing on the Consensus Layer and eliminates the proposer voting mechanism utilized currently. This proposed mechanism relaxes safety assumptions and reduces complexity of client software design, contributing to the security of the deposits flow. It also improves validator UX.
 
-Advantages of in-protocol deposit processing consist of but are not limit to the following:
+Advantages of in-protocol deposit processing consist of, but are not limited to, the following:
 
 * Significant increase of deposits security by supplanting proposer voting. With the proposed in-protocol mechanism, an honest online node can't be convinced to process fake deposits even when more than 2/3 portion of stake is adversarial.
 * Decrease of delay between submitting deposit transaction on Execution Layer and its processing on Consensus Layer. That is, ~13 minutes with in-protocol deposit processing compared to ~12 hours with the existing mechanism.
@@ -215,7 +215,7 @@ An optimistically syncing node may be susceptible to a more severe attack scenar
 
 ### Optimistic sync
 
-An optimistically syncing node have to rely on the honest majority assumption. That is, if adversary is powerful enough to finalize a deposit sequence, a syncing node will have to apply these deposits disregarding the validity of deposit requests with respect to the execution of a given block. Thus, an adversary that can finalize an invalid chain can also convince an honest node to accept fake deposits. The same is applicable to the validity of execution layer world state today and a new deposit processing design is within boundaries of the existing security model in that regard.
+An optimistically syncing node has to rely on the honest majority assumption. That is, if adversary is powerful enough to finalize a deposit sequence, a syncing node will have to apply these deposits disregarding the validity of deposit requests with respect to the execution of a given block. Thus, an adversary that can finalize an invalid chain can also convince an honest node to accept fake deposits. The same is applicable to the validity of execution layer world state today and a new deposit processing design is within boundaries of the existing security model in that regard.
 
 Online nodes can't be tricked into this situation because their execution layer validates supplied deposits with respect to the block execution.
 


### PR DESCRIPTION
### Fix typos in EIP-6110: subject-verb agreement and phrasing correction

This PR corrects two minor but important textual issues in [EIP-6110](https://eips.ethereum.org/EIPS/eip-6110) for improved clarity and grammatical accuracy:

#### 1. Subject-verb agreement fix
- **Before:**  
  `An optimistically syncing node have to rely...`  
- **After:**  
  `An optimistically syncing node has to rely...`

#### 2. Phrasing and grammar fix
- **Before:**  
  `...consist of but are not limit to the following...`  
- **After:**  
  `...consist of, but are not limited to, the following...`

Both changes improve the grammatical correctness of the EIP without affecting its technical meaning.
