### PR TITLE
Update EIP-7002: fix variable name typo in withdrawal requests dequeue function

### DIFF
--- a/EIPS/eip-7002.md
+++ b/EIPS/eip-7002.md
@@ -196,7 +196,7 @@ def dequeue_withdrawal_requests():
     num_dequeued = min(num_in_queue, MAX_WITHDRAWAL_REQUESTS_PER_BLOCK)
 
     reqs = []
-    for i in range(num_dequeue):
+    for i in range(num_dequeued):
         queue_storage_slot = WITHDRAWAL_REQUEST_QUEUE_STORAGE_OFFSET + (queue_head_index + i) * 3
         source_address = address(sload(WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS, queue_storage_slot)[0:20])
         validator_pubkey = (


### PR DESCRIPTION
## Description

This PR fixes a variable name inconsistency in the `dequeue_withdrawal_requests` function. The variable was assigned as `num_dequeued` but then referenced as `num_dequeue` in the for loop, which would cause an undefined variable reference.

## Changes

- Changed `for i in range(num_dequeue):` to `for i in range(num_dequeued):` to correctly reference the previously defined variable
- This ensures the code correctly iterates through the intended number of withdrawal requests to be dequeued

## Testing

The fix maintains the intended functionality of the withdrawal request system while preventing potential errors during execution.
