### PR TITLE
Update eip-7549.md

### DIFF
--- a/EIPS/eip-7549.md
+++ b/EIPS/eip-7549.md
@@ -27,7 +27,7 @@ On a beacon chain network with at least 262144 active indices, it's necessary to
 
 Signing over the 3rd item causes tuples of equal votes to produce different signing roots. If the committee index is moved outside of the Attestation message the minimum number of attestations to verify to reach a 2/3 threshold is reduced to `ceil(32 * 2/3) = 22` (a factor of 62).
 
-On-chain attestations can now be packed more space-efficiently into beacon blocks. This proposal allows to include up to 8 slots worth of votes into a block, compared to 2 today. In order words, a chain with only 1/8 online proposers can still potentially include all votes on-chain.
+On-chain attestations can now be packed more space-efficiently into beacon blocks. This proposal allows to include up to 8 slots worth of votes into a block, compared to 2 today. In other words, a chain with only 1/8 online proposers can still potentially include all votes on-chain.
 
 ## Specification
 


### PR DESCRIPTION
### PR Description

Fixes a minor typo in the Motivation section of EIP-7549.

#### Change
- Replaced **"In order words"** with **"In other words"**

#### Rationale
This corrects a typographical error to improve clarity and maintain the professional tone of the EIP document.

_No changes to technical content._
