### PR TITLE
Update EIP-7607: Update eip-7607.md

### DIFF
--- a/EIPS/eip-7607.md
+++ b/EIPS/eip-7607.md
@@ -23,6 +23,9 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion` and `Propo
 #### Core EIPs
 
 * [EIP-7594](./eip-7594.md): PeerDAS - Peer Data Availability Sampling
+* [EIP-7823](./eip-7823.md): Set upper bounds for MODEXP
+* [EIP-7892](./eip-7892.md): Blob Parameter Only Hardforks
+* [EIP-7823](./eip-7823.md): Set upper bounds for MODEXP
 * [EIP-7892](./eip-7892.md): Blob Parameter Only Hardforks
 * [EIP-7935](./eip-7935.md): Set default gas limit to XX0M
 


### PR DESCRIPTION
Moving the two EIPs included in `fusaka-devnet-0` from CFI to SFI as decided on [ACDT#36](https://ethereum-magicians.org/t/all-core-devs-testing-acdt-36-may-12-2025/24076)