### PR TITLE
Update eip-7773.md - rename to Glamsterdam

### DIFF
--- a/EIPS/eip-7773.md
+++ b/EIPS/eip-7773.md
@@ -1,9 +1,9 @@
 ---
 eip: 7773
-title: Hardfork Meta - Amsterdam
-description: EIPs included in the Amsterdam Ethereum network upgrade.
+title: Hardfork Meta - Glamsterdam
+description: EIPs included in the Gloas/Amsterdam Ethereum network upgrade.
 author: Tim Beiko (@timbeiko)
-discussions-to: https://ethereum-magicians.org/t/eip-7773-amsterdam-network-upgrade-meta-thread/21195
+discussions-to: https://ethereum-magicians.org/t/eip-7773-glamsterdam-network-upgrade-meta-thread/21195
 status: Stagnant
 type: Meta
 created: 2024-09-26
@@ -12,7 +12,7 @@ requires: 7607, 7723
 
 ## Abstract
 
-This Meta EIP lists the EIPs formally Proposed, Considered for & Scheduled for Inclusion in the Amsterdam network upgrade. 
+This Meta EIP lists the EIPs formally Proposed, Considered for & Scheduled for Inclusion in the Glamsterdam network upgrade. 
 
 ## Specification
 
@@ -42,7 +42,7 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion` and `Propo
 
 ## Rationale
 
-This Meta EIP provides a global view of all changes included in the Amsterdam network upgrade, as well as links to full specification. 
+This Meta EIP provides a global view of all changes included in the Glamsterdam network upgrade, as well as links to full specification. 
 
 ## Security Considerations
 


### PR DESCRIPTION
Gloas chosen as number for consensus layer upgrade after Fulu at ACDC #148   https://ethereum-magicians.org/t/all-core-devs-consensus-acdc-148-january-9-2025/22206