### PR TITLE
Update EIP-7702: Clarify read ops

### DIFF
--- a/EIPS/eip-7702.md
+++ b/EIPS/eip-7702.md
@@ -149,11 +149,11 @@ The affected executing operations are:
 * any transaction where `destination` points to an address with a delegation
 indicator present
 
-For code reading, only `CODESIZE` and `CODECOPY` instructions are affected
-reading. They operate directly on the executing code instead of the delegation.
-For example, when executing a delegated account `EXTCODESIZE` returns `23` (the
-size of `0xef0100 || address`) whereas `CODESIZE` returns the size of the code
-residing at `address`.
+For code reading, only `CODESIZE` and `CODECOPY` instructions are affected. They
+operate directly on the executing code instead of the delegation. For example,
+when executing a delegated account `EXTCODESIZE` returns `23` (the size of
+`0xef0100 || address`) whereas `CODESIZE` returns the size of the code residing
+at `address`.
 
 *Note, this means during delegated execution `CODESIZE` and `CODECOPY` produce a
 different result compared to calling `EXTCODESIZE` and `EXTCODECOPY` on the
@@ -183,7 +183,7 @@ authorization list length`.
 The transaction sender will pay for all authorization tuples, regardless of
 validity or duplication.
 
-If a code reading instruction accesses a cold account during the resolution of
+If a code executing instruction accesses a cold account during the resolution of
 delegated code, add an additional [EIP-2929](eip-2929.md)
 `COLD_ACCOUNT_READ_COST` cost of `2600` gas to the normal cost and add the
 account to `accessed_addresses`. Otherwise, assess a `WARM_STORAGE_READ_COST`


### PR DESCRIPTION
@wjmelements noted that the current text is very confusing re: the gas costs of code reading instructions.