### PR TITLE
[EIP-4762]: clarify EIP using python for spec, add atomicity, warm costs and 7702

### DIFF
--- a/EIPS/eip-4762.md
+++ b/EIPS/eip-4762.md
@@ -35,40 +35,99 @@ def get_storage_slot_tree_keys(storage_key: int) -> [int, int]:
 
 ### Access events
 
-Whenever the state is read, one or more of the access events of the form`(address, sub_key, leaf_key)` take place, determining what data is being accessed. We define access events as follows:
+Whenever the state is read or written to, one or more of the access events of the form`(address, sub_key, leaf_key)` take place, determining what data is being accessed. We define access events as follows:
+
+```python3
+def add_access_event(address: bytes20, sub_key: bytes31, leaf_key: byte, is_write: bool):
+  event = (address, sub_key_leaf_key)
+  if is_write:
+    tx.access_events.writes.append(event)
+  else:
+    tx.acess_events.reads.append(event)
+
+def add_write_access_events(address: bytes20, sub_key: bytes31, leaf_key: byte):
+  add_read_acess_events(address, sub_key, leaf_key)
+  add_access_event(address, sub_key, leaf_key, True)
+  
+def add_read_access_events(address: bytes20, sub_key: bytes31, leaf_key: byte):
+  add_access_event(address, sub_key, leaf_key, False)
+```
+
+The consequence of this model, is that it created group-locality in the state, with each "group" containing 256 contiguous leaves.
+
+An event will be triggered:
+
+ * Every time a group is accessed
+ * Every time a single leaf is accessed
+
+The model makes a distinction between read and write events. As we will see later, gas costs are associated to these events.
 
 #### Access events for account headers
 
-When:
+```python3
+# Emit all access events given an instruction. It is meant to be called before
+# the gas charging method for a given instruction is called, as these events
+# are subsequently used to process witness-related gas costs.
+def emit_access_events(opcode: int, stack: Stack, contract: Contract, new_contract: Optional[Contract]):
+  match opcode:
+    case OP_CALL | OP_DELEGATECALL | OP_STATICCALL | OP_CALLCODE | OP_SELFDESTRUCT:
+      address = stack.peek(1)
 
- 1. a non-precompile which is also not a system contract is the target of a `*CALL`, `CALLCODE`, `SELFDESTRUCT`, `EXTCODESIZE`, or `EXTCODECOPY` opcode,
- 2. a non-precompile which is also not a system contract is the target address of a contract creation whose initcode starts execution,
- 3. any address is the target of the `BALANCE` opcode
- 4. a _deployed_ contract calls `CODECOPY`
+      if value_bearing and op == OP_CALL:
+        add_write_access_event(contract.address, 0, BASIC_DATA_LEAF_KEY)
+        add_write_access_event(address, 0, BASIC_DATA_LEAF_KEY)
+      else:
+        if is_precompile(address) or is_system_contract(address):
+          # XXX charge warm costs
+        else:
+          add_read_access_event(address, 0, BASIC_DATA_LEAF_KEY)
+       
+      add_read_access_event(contract.address, 0, BASIC_DATA_LEAF_KEY)
 
-process this access event:
+    case OP_EXTCODECOPY | OP_EXTCODESIZE:
+      address = stack.peek(0)
+      add_read_access_event(address, 0, BASIC_DATA_LEAF_KEY)
 
+    case OP_BALANCE:
+      address = stack.peek(0)
+      add_read_access_event(address, 0, BASIC_DATA_LEAF_KEY)
+
+    case OP_CODECOPY:
+       if not contract.is_deployment:
+         add_read_access_event(contract.address, 0, BASIC_DATA_LEAF_KEY)
+
+    case OP_EXTCODEHASH:
+      address = stack.peek(0)
+      if not (is_precompile(address) or is_system_contract(address)):
+        add_read_access_event(address, 0, CODEHASH_LEAF_KEY)
+
+    case OP_SLOAD | OP_SSTORE:
+      address = stack.peek(0)
+      key = stack.peek(1)
+      read_access_for_storage(address, key)
+
+    case OP_CREATE | OP_CREATE2:
+      # This is to be called before the operation is created,
+      # XXX it makes no sense to do this here, it should be
+      # specified, in a way that reflects that this is created
+      # when either a tx creates a contract by setting to:null
+      # or when executing the CREATEn opcode. To be clear, this
+      # is incorrect because this is not part of the CREATE
+      # instruction's gas function at all, but of its execution.
+      if not (is_precompile(address) or not is_system_contract(address)):
+        add_read_access_event(new_contract.address, 0, BASIC_DATA_LEAF_KEY)
+        add_read_access_event(new_contract.address, 0, CODEHASH_LEAF_KEY)
+
+# This function is to be called right when it is known that the
+# account will be created.
+def emit_accesses_for_contract_creation_init(target_address):
+  add_write_access_event(address, 0, BASIC_DATA_LEAF_KEY)
+  add_write_access_event(address, 0, CODEHASH_LEAF_KEY)
+  
+def read_access_for_storage(contract_address: bytes20, storage_key: byte32):
+  index, suffix = get_storage_slot_key(contract_address, storage_key)
+  add_read_access_event(contract_address, index, suffix)
 ```
-(address, 0, BASIC_DATA_LEAF_KEY)
-```
-
-Note: a non-value-bearing `SELFDESTRUCT`, `*CALL` or `CALLCODE`, targeting a precompile or a system contract, will not cause the `BASIC_DATA_LEAF_KEY` to be added to the witness.
-
-If a `*CALL`, `CALLCODE` or `SELFDESTRUCT` is value-bearing (ie. it transfers nonzero wei), whether or not the `callee` is a precompile or a system contract, process this additional access event:
-
-```
-(caller, 0, BASIC_DATA_LEAF_KEY)
-```
-
-Note: when checking for the existence of the `callee`, the existence check is done by validating that there is an extension-and-suffix tree at the corresponding stem, and does not rely on `CODEHASH_LEAF_KEY`.
-
-When calling `EXTCODEHASH`, process the access event:
-
-```
-(address, 0, CODEHASH_LEAF_KEY)
-```
-
-Note that precompiles and system contracts are excluded, as their hashes are known to the client.
 
 When a contract is created, process these access events:
 
@@ -77,27 +136,98 @@ When a contract is created, process these access events:
 (contract_address, 0, CODEHASH_LEAF_KEY)
 ```
 
-#### Access events for storage
+##### Access events for delegation
 
-`SLOAD` and `SSTORE` opcodes with a given address and key process an access event of the form
+When `contract_address` is that of a delegating EoA, process the following events:
+
+ - For an `EXTCODEHASH`:
 
 ```
-(address, tree_key, sub_key)
+(delegated_address, 0, CODEHASH_LEAF_KEY)
 ```
 
-Where `tree_key` and `sub_key` are computed as `tree_key, sub_key = get_storage_slot_tree_keys(address, key)`
+ - For an `EXTCODESIZE`, or any other `*CALL`, `CALLCODE`:
+
+```
+(delegated_address, 0, BASIC_DATA_LEAF_KEY)
+```
 
 #### Access events for code
 
-In the conditions below, “chunk chunk_id is accessed” is understood to mean an access event of the form
+```python3
+def interpreter_loop(code: bytes, contract_address: bytes20):
+  pc = 0
 
-```
-(address, (chunk_id + 128) // 256, (chunk_id + 128) % 256)
+  # ...
+
+  while True:
+    if pc < len(code):
+      code_read_access_event(pc, code, contract_address)
+      # ... rest of the interpreter loop
+
+def code_read_access_event(pc: int, code: bytes, contract_address: Address):
+  chunk = pc // CHUNK_SIZE
+  # XXX this is what we do, but this isn't what is in the spec
+  if chunk > (len(code)+CHUNK_SIZE-1)/CHUNK_SIZE:
+    return # No access events for code beyond the last code chunk
+
+  opcode = OP_STOP # pad chunk with 0s
+  # if the code walks beyond the code size, it is not considered to be accessed.
+  # XXX I don't think that this is true on mainnet, even before the atomic stuff!
+  if pc < len(code):
+    opcode = code[pc]
+
+  add_read_access_event(contract_addresss, (chunk+128) // 256, (chunk + 128) % 256)
+
+  # add access events for immediates, if the instruction has them
+  match opcode:
+    case OP_JUMP:
+      dest = stack.peek(0)
+      if dest < len(code):
+        # The destination of a `JUMP` is considered to be accessed, even if the destination is not a jumpdest or is inside pushdata
+        add_read_access_event(dest)
+
+    case OP_JUMPI:
+      dest = stack.peek(0)
+      cond = stack.peek(1)
+      # if the code walks beyond the code size, it is not considered to be accessed.
+      if dest < len(code):
+        dest_chunk = dest // CHUNK_SIZE
+        # The destination of a positively evaluated `JUMPI` is considered to be accessed, even if the destination is not a jumpdest or is inside pushdata
+        # The destination of a `JUMPI` is not considered to be accessed if the jump conditional is `false`
+        if op == OP_JUMP or cond:
+          add_read_access_event(contract_address, (dest_chunk+128) // 256, (dest_chunk+128) % 256)
+
+    case OP_PUSH1 | OP_PUSH2 | ... | OP_PUSH32:
+      nbytes = opcode - OP_PUSH0 # determine the number of extra bytes to touch
+      for i in range(nbytes):
+        immediate_chunk = (pc+i) // CHUNK_SIZE
+        if immediate_chunk <= (len(code)+CHUNK_SIZE-1) // CHUNK_SIZE:
+          add_read_access_event(contract_address, (immediate_chunk+128) // 256, (immediate_chunk + 128) % 256)
+
+    case OP_CODECOPY | OP_EXTCODECOPY:
+      addr = contract_address
+      size = 0
+      offset = i0
+      if opcode == OP_EXTCODECOPY:
+        addr = stack.peek(0)
+        offset = stack.peek(2)
+        size = stack.peek(3)
+      else:
+        offset = stack.peek(1)
+        size = stack.peek(2)
+
+      for i in range(size):
+        copied_byte_chunk = (offset+i) // CHUNK_SIZE 
+        if copied_byte_chunk <= (len(code)+CHUNK_SIZE-1) // CHUNK_SIZE:
+          add_read_access_event(contract_address, (copied_byte_chunk+128) // 256, (copied_byte_chunk + 128) % 256)
+
+    case OP_CODESIZE | OP_EXTCODESIZE | OP_EXTCODEHAS:
+      # None of these operations access any chunk      
 ```
 
  * At each step of EVM execution, if and only if `PC < len(code)`, chunk `PC // CHUNK_SIZE` (where `PC` is the current program counter) of the callee is accessed. In particular, note the following corner cases:
-     * The destination of a `JUMP` (or positively evaluated `JUMPI`) is considered to be accessed, even if the destination is not a jumpdest or is inside pushdata
-     * The destination of a `JUMPI` is not considered to be accessed if the jump conditional is `false`.
+    # XXX ©a doit changer avec l'atomicité -> voir si c'est le cas
      * The destination of a jump is not considered to be accessed if the execution gets to the jump opcode but does not have enough gas to pay for the gas cost of executing the `JUMP` opcode (including chunk access cost if the `JUMP` is the first opcode in a not-yet-accessed chunk)
      * The destination of a jump is not considered to be accessed if it is beyond the code (`destination >= len(code)`)
      * If code stops execution by walking past the end of the code, `PC = len(code)` is not considered to be accessed
@@ -107,7 +237,16 @@ In the conditions below, “chunk chunk_id is accessed” is understood to mean 
      * Example 2: for a `CODECOPY` with start position 600, read size 0, no chunks are accessed
      * Example 3: for a `CODECOPY` with start position 1500, read size 2000, `code_size = 3100`, `x = 1500` and `y = 3099`
  * `CODESIZE`, `EXTCODESIZE` and `EXTCODEHASH` do NOT access any chunks.
-    When a contract is created, access chunks `0 ... (len(code)+30)//31`
+
+When a contract is created, access chunks `0 ... (len(code)+30)//31`:
+
+```python3
+def contract_creation_add_chunks(address: Address, code: bytes):
+  for i in range(code):
+    code_byte_chunk = (offset+i) // CHUNK_SIZE 
+    if code_byte_chunk <= (len(code)+CHUNK_SIZE-1) // CHUNK_SIZE:
+      add_write_access_event(contract_address, (code_byte_chunk+128) // 256, (code_byte_chunk + 128) % 256)
+```
 
 ### Write Events
 

--- a/EIPS/eip-4762.md
+++ b/EIPS/eip-4762.md
@@ -15,7 +15,7 @@ This EIP introduces changes in the gas schedule to reflect the costs of creating
 
 ## Motivation
 
-The introduction of Verkle trees into Ethereum requires fundamental changes and as a preparation, this EIP is targeting the fork coming right before the verkle tree fork, in order to incentivize Dapp developers to adopt the new storage model, and ample time to adjust to it. It also incentivizes client developers to migrate their database format ahead of the verkle fork.
+The introduction of Stateless Ethereum requires fundamental changes, and this EIP introduces changes to the gas schedule, reflectiong the new storage model, which seeks to disincentivize witness growth as well as state growth.
 
 ## Specification
 
@@ -62,6 +62,10 @@ An event will be triggered:
 
 The model makes a distinction between read and write events. As we will see later, gas costs are associated to these events.
 
+#### Atomicity
+
+The calls to `charge_gas()` are here to delimit the atomic boundaries of an operation. All the events emitted between two consecutive calls to `charge_gas` are charged together. If there isn't enough gas to pay for all events, none of the associated values are added to the witness.
+
 #### Access events for account headers
 
 ```python3
@@ -73,9 +77,16 @@ def emit_access_events(opcode: int, stack: Stack, contract: Contract, new_contra
     case OP_CALL | OP_DELEGATECALL | OP_STATICCALL | OP_CALLCODE | OP_SELFDESTRUCT:
       address = stack.peek(1)
 
-      if value_bearing and op == OP_CALL:
+      # XXX the previous version of the spec says OP_CALLCODE is concerned, but the geth
+      # code says it isn't.
+      if value_bearing and (op == OP_CALL or op == OP_SELFDESTRUCT or op == OP_CALLCODE):
         add_write_access_event(contract.address, 0, BASIC_DATA_LEAF_KEY)
         add_write_access_event(address, 0, BASIC_DATA_LEAF_KEY)
+
+        # If the operation triggers an account creation, charge the
+        # full cost of account creation
+        if not state.has_account(address):
+          add_write_access_event(address, 0, CODEHASH_LEAF_KEY)
       else:
         if is_precompile(address) or is_system_contract(address):
           # XXX charge warm costs
@@ -101,39 +112,41 @@ def emit_access_events(opcode: int, stack: Stack, contract: Contract, new_contra
       if not (is_precompile(address) or is_system_contract(address)):
         add_read_access_event(address, 0, CODEHASH_LEAF_KEY)
 
-    case OP_SLOAD | OP_SSTORE:
+    case OP_SLOAD:
       address = stack.peek(0)
       key = stack.peek(1)
       read_access_for_storage(address, key)
 
+    case OP_SSTORE:
+      address = stack.peek(0)
+      key = stack.peek(1)
+      write_access_for_storage(address, key)
+
     case OP_CREATE | OP_CREATE2:
-      # This is to be called before the operation is created,
-      # XXX it makes no sense to do this here, it should be
-      # specified, in a way that reflects that this is created
-      # when either a tx creates a contract by setting to:null
-      # or when executing the CREATEn opcode. To be clear, this
-      # is incorrect because this is not part of the CREATE
-      # instruction's gas function at all, but of its execution.
-      if not (is_precompile(address) or not is_system_contract(address)):
-        add_read_access_event(new_contract.address, 0, BASIC_DATA_LEAF_KEY)
-        add_read_access_event(new_contract.address, 0, CODEHASH_LEAF_KEY)
+      # Explitly specify that the witness costs for contract
+      # creation are not charged as part of the instruction,
+      # but as part of the creation execution it triggers.
+      # This means, among other things, that the subtraction
+      # of 1/64th of the gas is done before.
+
+  charge_gas()
 
 # This function is to be called right when it is known that the
 # account will be created.
-def emit_accesses_for_contract_creation_init(target_address):
+def emit_access_events_for_contract_creation_init(address: Address):
   add_write_access_event(address, 0, BASIC_DATA_LEAF_KEY)
   add_write_access_event(address, 0, CODEHASH_LEAF_KEY)
+  charge_gas()
+
+def emit_access_events_for_contract_creation_account_check(address: Address):
+  add_read_access_event(new_contract.address, 0, BASIC_DATA_LEAF_KEY)
+  add_read_access_event(new_contract.address, 0, CODEHASH_LEAF_KEY)
+  charge_gas()
   
 def read_access_for_storage(contract_address: bytes20, storage_key: byte32):
   index, suffix = get_storage_slot_key(contract_address, storage_key)
   add_read_access_event(contract_address, index, suffix)
-```
-
-When a contract is created, process these access events:
-
-```
-(contract_address, 0, BASIC_DATA_LEAF_KEY)
-(contract_address, 0, CODEHASH_LEAF_KEY)
+  charge_gas()
 ```
 
 ##### Access events for delegation
@@ -162,27 +175,29 @@ def interpreter_loop(code: bytes, contract_address: bytes20):
 
   while True:
     if pc < len(code):
-      code_read_access_event(pc, code, contract_address)
+      emit_code_access_events(pc, code, contract_address)
       # ... rest of the interpreter loop
 
-def code_read_access_event(pc: int, code: bytes, contract_address: Address):
-  chunk = pc // CHUNK_SIZE
-  # XXX this is what we do, but this isn't what is in the spec
-  if chunk > (len(code)+CHUNK_SIZE-1)/CHUNK_SIZE:
-    return # No access events for code beyond the last code chunk
-
+# Executed when decoding an instruction when running the interpreter loop
+def emit_code_access_events(pc: int, code: bytes, contract_address: Address):
   opcode = OP_STOP # pad chunk with 0s
   # if the code walks beyond the code size, it is not considered to be accessed.
   # XXX I don't think that this is true on mainnet, even before the atomic stuff!
-  if pc < len(code):
-    opcode = code[pc]
+  if pc >= len(code):
+    return
 
-  add_read_access_event(contract_addresss, (chunk+128) // 256, (chunk + 128) % 256)
+  opcode = code[pc]
+  chunk = pc // CHUNK_SIZE
+
+  add_read_access_event(contract_addresss, (chunk + CODE_OFFSET) // 256, (chunk + CODE_OFFSET) % 256)
+  charge_gas() # Note that the witness gas for instruction access is charged immediately,
+               # independently of access costs for its immediates.
 
   # add access events for immediates, if the instruction has them
   match opcode:
     case OP_JUMP:
       dest = stack.peek(0)
+      # The destination of a jump is not considered to be accessed if it is beyond the code
       if dest < len(code):
         # The destination of a `JUMP` is considered to be accessed, even if the destination is not a jumpdest or is inside pushdata
         add_read_access_event(dest)
@@ -190,20 +205,20 @@ def code_read_access_event(pc: int, code: bytes, contract_address: Address):
     case OP_JUMPI:
       dest = stack.peek(0)
       cond = stack.peek(1)
-      # if the code walks beyond the code size, it is not considered to be accessed.
+      # The destination of a jump is not considered to be accessed if it is beyond the code
       if dest < len(code):
         dest_chunk = dest // CHUNK_SIZE
         # The destination of a positively evaluated `JUMPI` is considered to be accessed, even if the destination is not a jumpdest or is inside pushdata
         # The destination of a `JUMPI` is not considered to be accessed if the jump conditional is `false`
         if op == OP_JUMP or cond:
-          add_read_access_event(contract_address, (dest_chunk+128) // 256, (dest_chunk+128) % 256)
+          add_read_access_event(contract_address, (dest_chunk + CODE_OFFSET) // 256, (dest_chunk + CODE_OFFSET) % 256)
 
     case OP_PUSH1 | OP_PUSH2 | ... | OP_PUSH32:
       nbytes = opcode - OP_PUSH0 # determine the number of extra bytes to touch
       for i in range(nbytes):
         immediate_chunk = (pc+i) // CHUNK_SIZE
         if immediate_chunk <= (len(code)+CHUNK_SIZE-1) // CHUNK_SIZE:
-          add_read_access_event(contract_address, (immediate_chunk+128) // 256, (immediate_chunk + 128) % 256)
+          add_read_access_event(contract_address, (immediate_chunk + CODE_OFFSET) // 256, (immediate_chunk + CODE_OFFSET) % 256)
 
     case OP_CODECOPY | OP_EXTCODECOPY:
       addr = contract_address
@@ -220,109 +235,66 @@ def code_read_access_event(pc: int, code: bytes, contract_address: Address):
       for i in range(size):
         copied_byte_chunk = (offset+i) // CHUNK_SIZE 
         if copied_byte_chunk <= (len(code)+CHUNK_SIZE-1) // CHUNK_SIZE:
-          add_read_access_event(contract_address, (copied_byte_chunk+128) // 256, (copied_byte_chunk + 128) % 256)
+          add_read_access_event(contract_address, (copied_byte_chunk + CODE_OFFSET) // 256, (copied_byte_chunk + CODE_OFFSET) % 256)
 
-    case OP_CODESIZE | OP_EXTCODESIZE | OP_EXTCODEHAS:
-      # None of these operations access any chunk      
+    case OP_CODESIZE | OP_EXTCODESIZE | OP_EXTCODEHASH:
+      # None of these operations access any chunk, it is
+      # explicitly documented here as a no-op.
+
+  charge_gas()
 ```
 
- * At each step of EVM execution, if and only if `PC < len(code)`, chunk `PC // CHUNK_SIZE` (where `PC` is the current program counter) of the callee is accessed. In particular, note the following corner cases:
-    # XXX ©a doit changer avec l'atomicité -> voir si c'est le cas
-     * The destination of a jump is not considered to be accessed if the execution gets to the jump opcode but does not have enough gas to pay for the gas cost of executing the `JUMP` opcode (including chunk access cost if the `JUMP` is the first opcode in a not-yet-accessed chunk)
-     * The destination of a jump is not considered to be accessed if it is beyond the code (`destination >= len(code)`)
-     * If code stops execution by walking past the end of the code, `PC = len(code)` is not considered to be accessed
- * If the current step of EVM execution is a `PUSH{n}`, all chunks `(PC // CHUNK_SIZE) <= chunk_index <= ((PC + n) // CHUNK_SIZE)` of the callee are accessed.
- * If a nonzero-read-size `CODECOPY` or `EXTCODECOPY` read bytes `x...y` inclusive, all chunks `(x // CHUNK_SIZE) <= chunk_index <= (min(y, code_size - 1) // CHUNK_SIZE)` of the accessed contract are accessed.
-     * Example 1: for a `CODECOPY` with start position 100, read size 50, `code_size = 200`, `x = 100` and `y = 149`
-     * Example 2: for a `CODECOPY` with start position 600, read size 0, no chunks are accessed
-     * Example 3: for a `CODECOPY` with start position 1500, read size 2000, `code_size = 3100`, `x = 1500` and `y = 3099`
- * `CODESIZE`, `EXTCODESIZE` and `EXTCODEHASH` do NOT access any chunks.
+Note: since no access list existed for code up until this EIP, note that no warm costs are charged for code accesses.
 
 When a contract is created, access chunks `0 ... (len(code)+30)//31`:
 
 ```python3
-def contract_creation_add_chunks(address: Address, code: bytes):
-  for i in range(code):
-    code_byte_chunk = (offset+i) // CHUNK_SIZE 
-    if code_byte_chunk <= (len(code)+CHUNK_SIZE-1) // CHUNK_SIZE:
-      add_write_access_event(contract_address, (code_byte_chunk+128) // 256, (code_byte_chunk + 128) % 256)
+def emit_code_write_access_events(address: Address, code: bytes):
+  last_chunk_num = (len(code) + CHUNK_SIZE - 1) // CHUNK_SIZE
+
+  for chunk_num in range(last_chunk_num):
+    add_write_access_event(contract_address, (chunk_num + CODE_OFFSET) // 256, (chunk_num + CODE_OFFSET) % 256)
+
+  charge_gas()
 ```
-
-### Write Events
-
-We define **write events** as follows. Note that when a write takes place, an access event also takes place (so the definition below should be a subset of the definition of access events). A write event is of the form `(address, sub_key, leaf_key)`, determining what data is being written to.
-
-#### Write events for account headers
-
-When a nonzero-balance-sending `CALL`, `CALLCODE` or `SELFDESTRUCT` with a given sender and recipient takes place, process these write events:
-
-```
-(caller, 0, BASIC_DATA_LEAF_KEY)
-(callee, 0, BASIC_DATA_LEAF_KEY)
-```
-
-if no account exists at `callee_address`, also process:
-
-```
-(callee, 0, CODEHASH_LEAF_KEY)
-```
-
-When a contract creation is initialized, process these write events:
-
-```
-(contract_address, 0, BASIC_DATA_LEAF_KEY)
-(contract_address, 0, CODEHASH_LEAF_KEY)
-```
-
-#### Write events for storage
-
-`SSTORE` opcodes with a given `address` and `key` process a write event of the form
-
-```
-(address, tree_key, sub_key)
-```
-
-Where `tree_key` and `sub_key` are computed as `tree_key, sub_key = get_storage_slot_tree_keys(address, key)`
-
-#### Write events for code
-
-When a contract is created, process the write events:
-
-```python
-(
-    address,
-    (CODE_OFFSET + i) // VERKLE_NODE_WIDTH,
-    (CODE_OFFSET + i) % VERKLE_NODE_WIDTH
-)
-```
-
-For `i` in `0 ... (len(code)+30)//31`.
-
-Note: since no access list existed for code up until this EIP, note that no warm costs are charged for code accesses.
 
 ### Transaction
 
-#### Access events
-
 For a transaction, make these access events:
 
-```
-(tx.origin, 0, BASIC_DATA_LEAF_KEY)
-(tx.origin, 0, CODEHASH_LEAF_KEY)
-(tx.target, 0, BASIC_DATA_LEAF_KEY)
-(tx.target, 0, CODEHASH_LEAF_KEY)
+```python3
+def emit_tx_prologue_events(from: Address, to: Address, value: int):
+  add_write_access_event(from, 0, BASIC_DATA_LEAF_KEY) # Note this is the only write, because of the nonce
+  add_read_access_event(from, 0, CODEHASH_LEAF_KEY)
+  add_read_access_event(to, 0, BASIC_DATA_LEAF_KEY)
+  add_read_access_event(to, 0, CODEHASH_LEAF_KEY)
+
+  if value != 0:
+    add_write_access_event(to, 0, BASIC_DATA_LEAF_KEY)
+
+    if not state.has_account(to)
+      add_write_access_event(to, 0, CODEHASH_LEAF_KEY)
+
+  # Note that gas isn't charged, as it's considered covered by
+  # the transaction's intrinsic gas.
 ```
 
-#### Write events
+For a contract-creating transaction, the emitted events are defined by:
 
-```
-(tx.origin, 0, BASIC_DATA_LEAF_KEY)
-```
+```python
+def contract_creation(address: Address, code: bytes):
+  # ...
+  # Just after increating the caller's nonce
+  emit_access_events_for_contract_creation_init(address)
 
-If `value` is non-zero:
+  # ...
+  # Just before creating the contract's account
+  emit_access_events_for_contract_creation_account_check(address)
 
-```
-(tx.target, 0, BASIC_DATA_LEAF_KEY)
+  # ...
+  # Just before setting the contract's code
+  emit_code_write_access_events(address, code)
+  
 ```
 
 ### Witness gas costs
@@ -399,7 +371,7 @@ Also corresponding witness costs need to be charged for _precompile/opcode resol
 
 ### Account abstraction
 
-TODO : still waiting on a final decision between 7702 and 3074
+TODO: complete spec update for 7702
 
 ## Rationale
 


### PR DESCRIPTION
This is the first draft of an attempt to rewrite eip-4762 in a more precise manner, as the complexity of its previous version is really difficult to grasp.

TODO:

 - [ ] pythonize eip 7702
 - [ ] add warm costs
 - [ ] address differences between spec and code (see `XXX` comments)