### PR TITLE
Update EIP-6110: ensure ints are decoded as uints

### DIFF
--- a/EIPS/eip-6110.md
+++ b/EIPS/eip-6110.md
@@ -89,11 +89,11 @@ def is_valid_deposit_event_data(deposit_event_data: bytes) -> bool:
     if len(deposit_event_data) != 576:
         return False
 
-    pubkey_offset = int.from_bytes(deposit_event_data[0:32], byteorder='big')
-    withdrawal_credentials_offset = int.from_bytes(deposit_event_data[32:64], byteorder='big')
-    amount_offset = int.from_bytes(deposit_event_data[64:96], byteorder='big')
-    signature_offset = int.from_bytes(deposit_event_data[96:128], byteorder='big')
-    index_offset = int.from_bytes(deposit_event_data[128:160], byteorder='big')
+    pubkey_offset = int.from_bytes(deposit_event_data[0:32], byteorder='big', signed=False)
+    withdrawal_credentials_offset = int.from_bytes(deposit_event_data[32:64], byteorder='big', signed=False)
+    amount_offset = int.from_bytes(deposit_event_data[64:96], byteorder='big', signed=False)
+    signature_offset = int.from_bytes(deposit_event_data[96:128], byteorder='big', signed=False)
+    index_offset = int.from_bytes(deposit_event_data[128:160], byteorder='big', signed=False)
 
     if (
         pubkey_offset != 160
@@ -105,11 +105,11 @@ def is_valid_deposit_event_data(deposit_event_data: bytes) -> bool:
         return False
 
     # These sizes are the sizes of the relevant data
-    pubkey_size = int.from_bytes(deposit_event_data[pubkey_offset:pubkey_offset+32], byteorder='big')
-    withdrawal_credentials_size = int.from_bytes(deposit_event_data[withdrawal_credentials_offset:withdrawal_credentials_offset+32], byteorder='big')
-    amount_size = int.from_bytes(deposit_event_data[amount_offset:amount_offset+32], byteorder='big')
-    signature_size = int.from_bytes(deposit_event_data[signature_offset:signature_offset+32], byteorder='big')
-    index_size = int.from_bytes(deposit_event_data[index_offset:index_offset+32], byteorder='big')
+    pubkey_size = int.from_bytes(deposit_event_data[pubkey_offset:pubkey_offset+32], byteorder='big', signed=False)
+    withdrawal_credentials_size = int.from_bytes(deposit_event_data[withdrawal_credentials_offset:withdrawal_credentials_offset+32], byteorder='big', signed=False)
+    amount_size = int.from_bytes(deposit_event_data[amount_offset:amount_offset+32], byteorder='big', signed=False)
+    signature_size = int.from_bytes(deposit_event_data[signature_offset:signature_offset+32], byteorder='big', signed=False)
+    index_size = int.from_bytes(deposit_event_data[index_offset:index_offset+32], byteorder='big', signed=False)
 
     return (
         pubkey_size == 48


### PR DESCRIPTION
This change clarifies that the python `int.from_bytes` should use `signed=False`. Therefore, it will never return a negative number. Note, that `signed=False` is the default setting for `int.from_bytes`. This is thus a clarification to avoid decoding it as signed int. It is now thus decoded as `uint`.