### PR TITLE
Update EIP-7886: Fixed broken link to EIP-2935 and EIP-4788 in eip-7886.md

### DIFF
--- a/EIPS/eip-7886.md
+++ b/EIPS/eip-7886.md
@@ -282,7 +282,7 @@ def process_transactions(
 
 During block execution:
 
-1. Clients MUST create a block-level snapshot before any transaction execution occurs. This happens after handling the system contracts from [EIP-4788](./eip-4788) and [EIP-2935](./eip-2935).
+1. Clients MUST create a block-level snapshot before any transaction execution occurs. This happens after handling the system contracts from [EIP-4788](./eip-4788.md) and [EIP-2935](./eip-2935.md).
 
 2. Maximum fees MUST be deducted from sender balances upfront by:
 


### PR DESCRIPTION
Updated the Markdown link to EIP-2935 and EIP-4788 in EIPS/eip-7886.md from [EIP-2935](./eip-2935) , [EIP-4788](./eip-4788) to the correct [EIP-2935](./eip-2935.md) , [EIP-4788](./eip-4788.md) so that the link works correctly in the repository and when viewing the documentation.