### PR TITLE
Update EIP-225: fix typos

### DIFF
--- a/EIPS/eip-225.md
+++ b/EIPS/eip-225.md
@@ -192,7 +192,7 @@ This list may be expired after a certain number of blocks / epochs, but it's imp
 ## Test Cases
 
 ```go
-// block represents a single block signed by a parcitular account, where
+// block represents a single block signed by a particular account, where
 // the account may or may not have cast a Clique vote.
 type block struct {
   signer     string   // Account that signed this particular block

--- a/EIPS/eip-627.md
+++ b/EIPS/eip-627.md
@@ -153,7 +153,7 @@ Data field contains encrypted message of the Envelope. In case of symmetric encr
 
 Those unable to decrypt the message data are also unable to access the signature. The signature, if provided, is the ECDSA signature of the Keccak-256 hash of the unencrypted data using the secret key of the originator identity. The signature is serialised as the concatenation of the `R`, `S` and `V` parameters of the SECP-256k1 ECDSA signature, in that order. `R` and `S` are both big-endian encoded, fixed-width 256-bit unsigned. `V` is an 8-bit big-endian encoded, non-normalised and should be either 27 or 28.
 
-The padding field was introduced in order to align the message size, since message size alone might reveal important metainformation. Padding can be arbitrary size. However, it is recommended that the size of Data Field (excuding the Salt) before encryption (i.e. plain text) should be factor of 256 bytes.
+The padding field was introduced in order to align the message size, since message size alone might reveal important metainformation. Padding can be arbitrary size. However, it is recommended that the size of Data Field (excluding the Salt) before encryption (i.e. plain text) should be factor of 256 bytes.
 
 ### Payload Encryption
 


### PR DESCRIPTION
[EIP-225.md] fix from 'parcitular' -> 'particular'
[EIP-627.md] correct from 'excuding' -> 'excluding'