### PR TITLE
Update EIP-3030: fix broken link to Prysmatic Labs Web3Signer documentation

### DIFF
--- a/EIPS/eip-3030.md
+++ b/EIPS/eip-3030.md
@@ -337,7 +337,7 @@ Repository Url | Language | Organization | Commentary
 --- | --- | --- | ---
 [BLS Remote Signer](https://github.com/sigp/rust-bls-remote-signer) | Rust | Sigma Prime | Supports proposed specification.
 [Web3signer](https://github.com/PegaSysEng/web3signer) | Java | PegaSys | Supports proposed specification, although with [slightly different methods](https://pegasyseng.github.io/web3signer/web3signer-eth2.html):<br>{`/sign` => `/api/v1/eth2/sign`, `/publicKeys` => `/api/v1/eth2/publicKeys`}.
-[Remote Signing Wallet](https://docs.prylabs.network/docs/wallet/remote/) | Golang | Prysmatics Labs | Supports both gRPC and JSON over HTTP.
+[Remote Signing Wallet](https://docs.prylabs.network/docs/wallet/web3signer/) | Golang | Prysmatics Labs | Supports both gRPC and JSON over HTTP.
 
 ## Security Considerations
 


### PR DESCRIPTION
I've updated the broken link in EIP-3030.md. The new link now points to the Web3Signer documentation on the Prysm website, which is the current recommended way to handle remote signing with Prysm.
This change reflects that Prysmatic Labs has moved from their own remote signer implementation (which is now archived on GitHub) to recommending Web3Signer for remote signing capabilities.