### PR TITLE
Update EIP-7782: Move to Draft

### DIFF
--- a/EIPS/eip-7782.md
+++ b/EIPS/eip-7782.md
@@ -38,6 +38,19 @@ SLOT_SCHEDULE:
 
 The parameters and schedules above are purely illustrative. Actual values and schedules are beyond the scope of this specification.
 
+### Adjustment to gas and blob limits
+
+The first execution block after the fork needs to specify half the previous gas limit. With this fork, all gas limit settings are reinterpreted as "gas per 12 seconds". I.e., if the user configuration or otherwise default gas limit vote was 36,000,000, the client should now vote for 18,000,000. All values are rounded down to integers.
+
+The blob target and limit are also halved, rounded down to the nearest integer.
+
+### Attestation deadlines
+
+All clients need to be reconfigured so that deadlines can be configured in milliseconds for finer granularity. Currently the slot is split into three equal intervals, with proposal happening at time 0, and attestations and aggregations being sent at one thirds and two thirds of the slot time. We change this to a new uneven schedule, in order to give sufficient time for block propagation, which takes the most time:
+ * Block proposal at 0 ms
+ * Attestations at 3000 ms
+ * Aggregates at 4500 ms
+
 ## Rationale
 
 This proposal balances user experience, economic efficiency, and network stability:

--- a/EIPS/eip-7782.md
+++ b/EIPS/eip-7782.md
@@ -3,7 +3,7 @@ eip: 7782
 title: Reduce Block Latency
 description: Reduce Ethereum's slot time from 12s to 6s to decrease latency by 50%, distribute bandwidth usage, and improve UX.
 author: Ben Adams (@benaadams), Dankrad Feist (@dankrad)
-discussions-to: https://ethereum-magicians.org/t/eip-7782-reduce-slot-time-for-lower-peak-bandwidth/21271
+discussions-to: https://ethereum-magicians.org/t/eip-7782-reduce-block-latency/21271
 status: Draft
 type: Standards Track
 category: Core
@@ -17,6 +17,7 @@ Reduce Ethereum's slot time from 12 s to 6 s, halving on‑chain latency and
 
 ## Motivation
 
+- **Protocol Carrying Capacity** It is impractical to increase block sizes beyond 10MiB without substaintial networking changes. However it is practical to decrease slot time to achieve similar effect while also improving the UX at same time.
 - **Enhanced UX**: Confirmations now arrive in ~6 s instead of 12 s.
 - **Faster Finality**: Epochs shrink from 384 s (32 × 12 s) to 192 s (32 × 6 s), accelerating Casper‑FFG finality.
 - **L2 Interoperability**: Layer 2 rollups see half the settlement delay on L1, improving throughput and reducing reorg risk period.
@@ -47,9 +48,10 @@ The blob target and limit are also halved, rounded down to the nearest integer.
 ### Attestation deadlines
 
 All clients need to be reconfigured so that deadlines can be configured in milliseconds for finer granularity. Currently the slot is split into three equal intervals, with proposal happening at time 0, and attestations and aggregations being sent at one thirds and two thirds of the slot time. We change this to a new uneven schedule, in order to give sufficient time for block propagation, which takes the most time:
- * Block proposal at 0 ms
- * Attestations at 3000 ms
- * Aggregates at 4500 ms
+
+- Block proposal at 0 ms
+- Attestations at 3000 ms
+- Aggregates at 4500 ms
 
 ## Rationale
 
@@ -61,7 +63,7 @@ This proposal balances user experience, economic efficiency, and network stabili
 
 - L2 & Based Rollups Synergy: Layer 2 rollups, especially based rollups, benefit from reduced L1 settlement delays, enhancing throughput and user-perceived performance in rollup ecosystems.
 
-- Network Stability: Maintaining existing block and blob limits smooths bandwidth usage over time, avoiding peak-load spikes and preserving accessibility for nodes with diverse bandwidth capacities.
+- Network Stability: Maintaining existing p2p network maximum smooths bandwidth usage over time, avoiding peak-load spikes and preserving accessibility for nodes with diverse bandwidth capacities.
 
 ## Backwards Compatibility
 

--- a/EIPS/eip-7782.md
+++ b/EIPS/eip-7782.md
@@ -1,8 +1,8 @@
 ---
 eip: 7782
-title: Reduce Slot Time for Improved UX and Economic Efficiency
+title: Halve Slot Time for Faster UX & Efficiency
 description: Reduce Ethereum's slot time from 12s to 6s to decrease latency by 50%, distribute bandwidth usage, and improve UX.
-authors: Ben Adams (@benaadams), Dankrad Feist (@dankrad)
+author: Ben Adams (@benaadams), Dankrad Feist (@dankrad)
 discussions-to: https://ethereum-magicians.org/t/eip-7782-reduce-slot-time-for-lower-peak-bandwidth/21271
 status: Draft
 type: Standards Track

--- a/EIPS/eip-7782.md
+++ b/EIPS/eip-7782.md
@@ -21,7 +21,7 @@ Reduce Ethereum's slot time from 12 s to 6 s, halving on‑chain latency and
 - **Faster Finality**: Epochs shrink from 384 s (32 × 12 s) to 192 s (32 × 6 s), accelerating Casper‑FFG finality.
 - **L2 Interoperability**: Layer 2 rollups see half the settlement delay on L1, improving throughput and reducing reorg risk period.
 - **Based rollups**: Based rollup sequencing is tied to L1 block time so faster blocks directly improves based rollups.
-- **DEX Economics**: More frequent blocks narrow price spreads, reduce slippage, and lower arbitrage friction.
+- **DEX Economics**: More frequent blocks decrease LVR (Loss Versus Rebalancing), which improves the economics for liquidity providers. More liquidity means lower spreads (reduced slippage).
 - **Bandwidth Smoothing**: Doubling slot rate distributes bandwidth evenly without increasing peak block size; nodes with modest capacity remain supported.
 
 ## Specification

--- a/EIPS/eip-7782.md
+++ b/EIPS/eip-7782.md
@@ -29,7 +29,7 @@ Reduce Ethereum's slot time from 12 s to 6 s, halving on‑chain latency and
 On the consensus layer, a new parameter is added to the configuration:
 
 ```
-BLOB_SCHEDULE:
+SLOT_SCHEDULE:
   - EPOCH: 348618
     SECONDS_PER_SLOT: 12
   - EPOCH: 355368

--- a/EIPS/eip-7782.md
+++ b/EIPS/eip-7782.md
@@ -1,6 +1,6 @@
 ---
 eip: 7782
-title: Halve Slot Time for Faster UX & Efficiency
+title: Reduce Block Latency
 description: Reduce Ethereum's slot time from 12s to 6s to decrease latency by 50%, distribute bandwidth usage, and improve UX.
 author: Ben Adams (@benaadams), Dankrad Feist (@dankrad)
 discussions-to: https://ethereum-magicians.org/t/eip-7782-reduce-slot-time-for-lower-peak-bandwidth/21271

--- a/EIPS/eip-7782.md
+++ b/EIPS/eip-7782.md
@@ -1,173 +1,58 @@
 ---
 eip: 7782
-title: Reduce Slot Time for Lower Peak Bandwidth
-description: Reduce Ethereum's slot time from 12s to 8s to increase throughput by ~33%, distribute bandwidth usage, and improve rollup latency.
-author: Ben Adams (@benaadams)
+title: Reduce Slot Time for Improved UX and Economic Efficiency
+description: Reduce Ethereum's slot time from 12s to 6s to decrease latency by 50%, distribute bandwidth usage, and improve UX.
+authors: Ben Adams (@benaadams), Dankrad Feist (@dankrad)
 discussions-to: https://ethereum-magicians.org/t/eip-7782-reduce-slot-time-for-lower-peak-bandwidth/21271
-status: Stagnant
+status: Draft
 type: Standards Track
 category: Core
 created: 2024-10-05
 requires: 7623, 7778
 ---
 
-Propose reducing Ethereum's slot time from 12 seconds to 8 seconds to increase transaction throughput by one-third. This approach distributes bandwidth usage over time, lowering peak bandwidth requirements without increasing individual block or blob counts. It requires [EIP-7623](./eip-7623) and [EIP-7778](./eip-7778) to ensure network stability and efficiency with the higher block rate.
-
 ## Abstract
 
-This EIP suggests decreasing the slot time in Ethereum's Proof-of-Stake (PoS) consensus mechanism from 12 seconds to 8 seconds. The reduction increases the number of slots per unit time, boosting the network's transaction processing capacity by approximately 33%. 
-
-Unlike directly increasing the gas limit or blob limit; which would raise peak bandwidth demands, this proposal distributes the increased bandwidth evenly over time, preventing spikes in network load and preserving node accessibility for participants with varying bandwidth capacities.
-
-This change requires the implementation of [EIP-7623](./eip-7623) to adjust calldata costs accordingly and [EIP-7778](./eip-7778) to remove gas smuggling via refunds to maintain network performance.
+Reduce Ethereum's slot time from 12 s to 6 s, halving on‑chain latency and epoch duration. This doubles slot throughput while keeping block and blob sizes unchanged, smoothing bandwidth usage. The change delivers better user experience, faster Layer 2 interaction, tighter DEX pricing, reduced MEV, and quicker finality.
 
 ## Motivation
 
-### Distributing Bandwidth and Reducing Peak Usage
-
-- **Avoiding Peak Bandwidth Increases**: Increasing the gas limit from 30 million to 40 million or the blob limit from 6 to 8 directly raises the size of individual blocks or blobs, leading to higher peak bandwidth requirements that can strain network resources and disadvantage nodes with limited bandwidth.
-
-- **Distributing Bandwidth Over Time**: Reducing the slot time increases the frequency of blocks, spreading bandwidth usage more evenly and avoiding sudden peaks in network load.
-
-- **Throughput Enhancement**: A reduction from 12 seconds to 8 seconds per slot equates to a one-third decrease in time, resulting in a one-third increase in slots per unit time. This mirrors the throughput gains from increasing the gas limit or blob limit by one-third.
-
-### Complementing EIP-7623
-
-- **EIP-7623 Alignment**: EIP-7623 increases calldata costs to reduce maximum block size and variance. Implementing it alongside the slot time reduction ensures that blocks remain manageable in size and that the network can handle the increased block frequency without compromising security or efficiency.
+- **Enhanced UX**: Confirmations now arrive in ~6 s instead of 12 s.
+- **Faster Finality**: Epochs shrink from 384 s (32 × 12 s) to 192 s (32 × 6 s), accelerating Casper‑FFG finality.
+- **L2 Interoperability**: Layer 2 rollups see half the settlement delay on L1, improving throughput and reducing reorg risk period.
+- **Based rollups**: Based rollup sequencing is tied to L1 block time so faster blocks directly improves based rollups.
+- **DEX Economics**: More frequent blocks narrow price spreads, reduce slippage, and lower arbitrage friction.
+- **Bandwidth Smoothing**: Doubling slot rate distributes bandwidth evenly without increasing peak block size; nodes with modest capacity remain supported.
 
 ## Specification
 
-### Slot Time Reduction
+On the consensus layer, a new parameter is added to the configuration:
 
-- **Change the Slot Time Parameter**: Modify the slot time (`SECONDS_PER_SLOT`) from **12 seconds** to **8 seconds** in the Ethereum consensus specifications.
+```
+BLOB_SCHEDULE:
+  - EPOCH: 348618
+    SECONDS_PER_SLOT: 12
+  - EPOCH: 355368
+    SECONDS_PER_SLOT: 6
+```
 
-### Adjustments to Timing Parameters
-
-- **Epoch Length**:
-
-  - **Slots per Epoch**: Maintain the current number of slots per epoch (32 slots).
-  - **Epoch Duration**: With a 8-second slot time, each epoch would last 256 seconds (4.267 minutes) if the number of slots per epoch remains unchanged.
-
-- **Timeouts and Deadlines**:
-
-  - **Attestation Deadlines**: Adjust attestation aggregation and broadcast deadlines to align with the new slot duration.
-  - **Proposer Deadlines**: Update block proposal timing to ensure proposers have sufficient time to prepare and broadcast blocks.
-
-- **Synchronization Protocols**:
-
-  - **Networking Parameters**: Update networking protocols to account for increased message frequency and ensure timely block and attestation propagation.
-
-### Validator Operations
-
-- **Increased Frequency**:
-
-  - **Block Proposals**: Validators will propose blocks more frequently due to shorter slots.
-  - **Attestations**: Validators will need to perform attestation duties at shorter intervals.
-
-- **Resource Management**:
-
-  - **Client Performance**: Optimize validator clients to handle increased operational demands without excessive resource consumption.
-  - **Bandwidth Usage**: Ensure that validators with lower bandwidth capacities can handle the increased frequency of messages.
+The parameters and schedules above are purely illustrative. Actual values and schedules are beyond the scope of this specification.
 
 ## Rationale
 
-### Based Rollup Latency
+This proposal balances user experience, economic efficiency, and network stability:
 
-- Reducing the slot time from 12 seconds to 8 seconds significantly improves the latency for based-rollup Layer 2 solutions as they are directly effected by L1 latency.
+- UX & Finality: Halving slot time directly reduces confirmation latency and halves epoch duration, delivering faster feedback to users and speeding up Casper-FFG finality.
 
-### Throughput Increase Without Raising Peak Bandwidth
+- Economic Efficiency: Increased block frequency tightens DEX price spreads, lowers slippage, and diminishes arbitrage and MEV opportunities, improving on-chain trading conditions.
 
-- **Maintaining Individual Block Sizes**: By keeping block and blob sizes unchanged, we avoid increasing peak bandwidth requirements.
+- L2 & Based Rollups Synergy: Layer 2 rollups, especially based rollups, benefit from reduced L1 settlement delays, enhancing throughput and user-perceived performance in rollup ecosystems.
 
-- **Distributing Workload**: More frequent blocks distribute the network's workload over time, leading to smoother operation and reduced risk of congestion.
+- Network Stability: Maintaining existing block and blob limits smooths bandwidth usage over time, avoiding peak-load spikes and preserving accessibility for nodes with diverse bandwidth capacities.
 
-### Complementing EIP-7623
+## Backwards Compatibility
 
-- **Managing Block Sizes**: EIP-7623 increases calldata costs for DA-heavy transactions, reducing the maximum possible block size. This is essential when reducing slot time to prevent oversized blocks from causing propagation delays.
-
-- **Network Efficiency**: Together, the proposals ensure that the network can handle increased throughput without compromising on security or decentralization.
-
-### Validator Capability
-
-- **Operational Feasibility**: Validators are expected to handle the increased frequency, as the computational workload per block remains consistent. There is enough performance in the network for ELs to process at higher rates (as the L2s run the same EL clients at far higher rates). There is also enough time for consenus to be reached as there is enough network slack to play timing games.
-
-- **Resource Optimization**: Client software can be optimized to manage resources effectively under the new conditions.
-
-### Alternative to Increasing Block Size or Blob Count
-
-- **Avoiding Drawbacks**: Larger blocks or more blobs can lead to longer verification times and propagation delays, potentially centralizing the network. Reducing slot time circumvents these issues.
-
-### Backwards Compatibility
-
-- **Network Upgrade Required**: This change is backward-incompatible and necessitates a hard fork.
-
-- **Client Updates**: All Ethereum clients must update to accommodate the new slot time and related protocol adjustments.
-
-- **Smart Contracts and DApps**:
-
-  - **Block Timing**: Applications relying on block timestamps or assuming a 12-second slot time may need adjustments.
-  - **Event Timing**: Event-driven applications should be tested to ensure proper functionality with increased block frequency.
-
-### Test Cases
-
-- **Simulation of Network Conditions**:
-
-  - **Latency Scenarios**: Test the network under various latency conditions to assess block propagation success rates.
-  - **Bandwidth Constraints**: Evaluate performance with nodes of varying bandwidth capacities.
-
-- **Validator Performance Metrics**:
-
-  - **Resource Utilization**: Monitor CPU, memory, and network usage of validators.
-  - **Duty Compliance**: Ensure validators can meet attestation and block proposal deadlines.
-
-- **Consensus Stability Tests**:
-
-  - **Fork Scenarios**: Simulate potential fork conditions to detect any consensus vulnerabilities.
-  - **Finality Assurance**: Verify that the network reaches finality consistently.
-
-### Network Propagation Considerations
-
-- **Latency and Bandwidth**:
-
-  - **Propagation Speed**: Assess and optimize the network's ability to propagate blocks and attestations within the reduced slot time.
-  - **Gossip Protocol Enhancements**: Implement improvements to the gossip network to facilitate faster dissemination of consensus messages.
-
-- **Optimizations**:
-
-  - **Block and Attestation Compression**: Use efficient serialization and compression techniques to reduce message sizes.
-  - **Peer Selection Strategies**: Optimize peer selection to prioritize connections that enhance propagation speed.
-
-### Consensus Adjustments
-
-- **Fork Choice Rule**:
-
-  - **LMD GHOST Adjustments**: Verify that the Latest Message Driven Greediest Heaviest Observed SubTree (LMD GHOST) fork choice algorithm operates correctly with increased block frequency.
-
-- **Finality Mechanism**:
-
-  - **Casper FFG Stability**: Ensure that the Casper Friendly Finality Gadget (FFG) finality mechanism remains stable and reliable under the new timing conditions.
-
-### Implementation
-
-- **Client Modifications**:
-
-  - **Update Slot Time**: Change the `SECONDS_PER_SLOT` constant to 8 seconds.
-  - **Adjust Timing Parameters**: Modify all time-dependent logic, including epochs, timeouts, and scheduling.
-
-- **Protocol Specification Updates**:
-
-  - **Consensus Specs**: Update the Ethereum consensus specifications to reflect the new slot duration and any related parameter changes.
-  - **Networking Protocols**: Adjust networking specifications to handle increased message frequency.
-
-- **Deployment Plan**:
-
-  - **Testnets**: Implement the changes on test networks (e.g. Sepolia, et al) for extensive testing.
-  - **Monitoring**: Use monitoring tools to observe network performance and identify issues.
-
-- **Community Coordination**:
-
-  - **Communication**: Inform all stakeholders, including node operators, validators, exchanges, and DApp developers.
-  - **Support and Resources**: Provide documentation and support for updating client software and applications.
+No backwards compatibility concerns.
 
 ## Security Considerations
 


### PR DESCRIPTION
## Reduce Block Latency

### Reduce Ethereum's slot time from 12s to 6s to decrease latency by 50%, distribute bandwidth usage, and improve UX.

#### Authors: Ben Adams (@benaadams), Dankrad Feist (@dankrad)
