### PR TITLE
Update EIP-7607: Fix Fusaka SFI Changes

### DIFF
--- a/EIPS/eip-7607.md
+++ b/EIPS/eip-7607.md
@@ -24,8 +24,7 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion` and `Propo
 
 * [EIP-7594](./eip-7594.md): PeerDAS - Peer Data Availability Sampling
 * [EIP-7823](./eip-7823.md): Set upper bounds for MODEXP
-* [EIP-7892](./eip-7892.md): Blob Parameter Only Hardforks
-* [EIP-7823](./eip-7823.md): Set upper bounds for MODEXP
+* [EIP-7883](./eip-7883.md): ModExp Gas Cost Increase
 * [EIP-7892](./eip-7892.md): Blob Parameter Only Hardforks
 * [EIP-7935](./eip-7935.md): Set default gas limit to XX0M
 
@@ -40,9 +39,7 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion` and `Propo
 * [EIP-5920](./eip-5920.md): PAY opcode
 * RIP-7212: Precompile for secp256r1 Curve Support
 * [EIP-7762](./eip-7762.md): Increase MIN_BASE_FEE_PER_BLOB_GAS
-* [EIP-7823](./eip-7823.md): Set upper bounds for MODEXP
 * [EIP-7825](./eip-7825.md): Transaction Gas Limit Cap
-* [EIP-7883](./eip-7883.md): ModExp Gas Cost Increase
 * [EIP-7907](./eip-7907.md): Meter Contract Code Size And Increase Limit
 * [EIP-7917](./eip-7917.md): Deterministic proposer lookahead
 * [EIP-7918](./eip-7918.md): Blob base fee bounded by execution cost


### PR DESCRIPTION
I messed up the copy/paste in the [previous PR](https://github.com/ethereum/EIPs/pull/9772) 😅 

On [ACDT#36](https://ethereum-magicians.org/t/all-core-devs-testing-acdt-36-may-12-2025/24076), we SFI'd EIP 7883, to be included along with the other SFI'd EIPs in devnet-1. The Meta EIP now reflect this, and removes all SFI'd EIP from the CFI section. 