### PR TITLE
Update EIP-695: Update JSON-RPC hex value encoding reference to ethereum.org

### DIFF
--- a/EIPS/eip-695.md
+++ b/EIPS/eip-695.md
@@ -90,7 +90,7 @@ Implementers should take care to implement `eth_chainId` correctly and promote i
 
 ## Reference
 
-Return value `QUANTITY` adheres to standard JSON RPC hex value encoding, as documented in the [Ethereum.org documentation](https://ethereum.org/en/developers/docs/apis/json-rpc/#hex-value-encoding).
+Return value `QUANTITY` adheres to standard JSON RPC hex value encoding, as documented in the [Ethereum.org documentation](https://ethereum.org/en/developers/docs/apis/json-rpc/#hex-encoding).
 
 ## Copyright
 


### PR DESCRIPTION
Replaced the outdated link to the Ethereum Wiki for JSON-RPC hex value encoding in EIP-695 with the current and maintained documentation on ethereum.org. This ensures that readers are directed to an up-to-date and reliable source for the encoding specification. No other content was changed.