### PR TITLE
Update EIP-7937: Add link to rust-evm reference implementation

### DIFF
--- a/EIPS/eip-7937.md
+++ b/EIPS/eip-7937.md
@@ -159,7 +159,7 @@ Test cases are orgnized as `[stack_item_1, stack_item_2] C0 opcode => [result_st
 
 ## Reference Implementation
 
-To be added.
+* [rust-evm](https://github.com/rust-ethereum/evm/tree/master/features/evm64)
 
 ## Security Considerations
 


### PR DESCRIPTION
**ATTENTION: ERC-RELATED PULL REQUESTS NOW OCCUR IN [ETHEREUM/ERCS](https://github.com/ethereum/ercs)**

--

When opening a pull request to submit a new EIP, please use the suggested template: https://github.com/ethereum/EIPs/blob/master/eip-template.md

We have a GitHub bot that automatically merges some PRs. It will merge yours immediately if certain criteria are met:

 - The PR edits only existing draft PRs.
 - The build passes.
 - Your GitHub username or email address is listed in the 'author' header of all affected PRs, inside <triangular brackets>.
 - If matching on email address, the email address is the one publicly listed on your GitHub profile.
