### PR TITLE
remove redundant function

### DIFF
--- a/EIPS/eip-7701.md
+++ b/EIPS/eip-7701.md
@@ -399,19 +399,6 @@ def execute_code_with_role(args):
 # get the current contract code at the given address
 def get_code(target_address):
     pass
-
-
-# pre-charge the entire maximum gas cost of the transaction
-def buy_gas(tx, block):
-    max_gas = tx.sender_validation_gas_limit + tx.paymaster_validation_gas_limit + tx.sender_execution_gas_limit + tx.paymaster_post_op_gas_limit
-    gas_price = min(tx.max_fee_per_gas, block.base_fee_per_gas + tx.max_priority_fee_per_gas)
-    total_max_cost = max_gas * gas_price
-    if tx.paymaster is None:
-        balances[tx.paymaster] -= total_max_cost
-    else:
-        balances[tx.sender] -= total_max_cost
-
-
 ```
 
 #### Block transition function


### PR DESCRIPTION
`buy_gas` is not used anywhere. It should either be removed or used at the beginning of the state transition, instead of the explicit code that's currently there
