### PR TITLE
Add EIP: EVM64 - EOF support

### DIFF
--- a/EIPS/eip-7957.md
+++ b/EIPS/eip-7957.md
@@ -25,7 +25,9 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 We define the following gas cost constant:
 
-* `G_RJUMPIV64`: 3
+| Name | Gas |
+|------|-----|
+| `G_RJUMPIV64` | `3` |
 
 At EOF contract creation time as defined in [EIP-3670](./eip-3670.md), if the opcode `C0` is encountered and it is not part of PUSH opcode's data, then the interpreter MUST validate that:
 


### PR DESCRIPTION
This splits EIP-7937 (Core document for EVM64) to have EOF support (code validation, `RJUMPI` and `RJUMPV` opcodes) defined separately.
