### PR TITLE
Add EIP: EOF - Extended types section

### DIFF
--- a/EIPS/eip-7960.md
+++ b/EIPS/eip-7960.md
@@ -1,5 +1,5 @@
 ---
-eip: 9834
+eip: 7960
 title: EOF - Extended types section
 description: Extend EOF container's types section with an extra type parameter.
 author: Wei Tang (@sorpaas)


### PR DESCRIPTION
This EIP extends the definition of `types_section` in EOF format with an additional `type` parameter.