### PR TITLE
Add EIP: EVM64 - EOF code section

### DIFF
--- a/EIPS/eip-7961.md
+++ b/EIPS/eip-7961.md
@@ -21,7 +21,7 @@ EIP-7937 has maximum compatibility with existing EVM. It implements EVM64 simply
 
 ## Specification
 
-Define `0x02` as an allowed `type` in `types_section`, as defined in EIP-9834. This denotes an EVM64 code section.
+Define `0x02` as an allowed `type` in `types_section`, as defined in EIP-7960. This denotes an EVM64 code section.
 
 ### EOF function execution
 


### PR DESCRIPTION
An alternative specification to EIP-7937. Depends on #9834.