### PR TITLE
Update EIP-7892: harden the spec with p2p details.

### DIFF
--- a/EIPS/eip-7892.md
+++ b/EIPS/eip-7892.md
@@ -100,11 +100,13 @@ A new `BLOB_SCHEDULE` field is added to consensus layer configuration, containin
 
 ```yaml
 BLOB_SCHEDULE:
-  - EPOCH: 400000     ## A future anonymous BPO fork
+  - EPOCH: 380000     # FULU_FORK_EPOCH (illustrative)
+    MAX_BLOBS_PER_BLOCK: 12
+  - EPOCH: 400000     # A future anonymous BPO fork
     MAX_BLOBS_PER_BLOCK: 24
-  - EPOCH: 420000     ## A future anonymous BPO fork
+  - EPOCH: 420000     # A future anonymous BPO fork
     MAX_BLOBS_PER_BLOCK: 56
-  - EPOCH: 440000     ## GLOAS_FORK_EPOCH; a future named fork introducing blob parameter changes
+  - EPOCH: 440000     # GLOAS_FORK_EPOCH; a future named fork introducing blob parameter changes
     MAX_BLOBS_PER_BLOCK: 72
 ```
 
@@ -121,15 +123,16 @@ The parameters and schedules above are purely illustrative. Actual values and sc
 The `compute_fork_digest` helper is updated to account for BPO forks:
 
 ```python
-class BlobScheduleEntry(NamedTuple):
+@dataclass
+class BlobScheduleEntry:
    epoch: Epoch
-   max_blobs_per_block: int       # uint64, aligning with the type of MAX_BLOBS_PER_BLOCK.
+   max_blobs_per_block: uint64       # Aligning with the type of MAX_BLOBS_PER_BLOCK
 
 def compute_fork_digest(
-  current_version: Version,       # Unchanged. Refers to the baseline hardfork atop which the blob schedule is applied.
-  genesis_validators_root: Root,  # Unchanged.
-  current_epoch: Epoch,           # New.
-  blob_schedule: Sequence[BlobScheduleEntry]  # New.
+  current_version: Version,       # Unchanged; refers to the baseline hardfork atop which the blob schedule is applied
+  genesis_validators_root: Root,  # Unchanged
+  current_epoch: Epoch,           # New
+  blob_schedule: Sequence[BlobScheduleEntry]  # New
 ) -> ForkDigest:
     """
     Return the 4-byte fork digest for the ``current_version`` and ``genesis_validators_root``,
@@ -142,10 +145,11 @@ def compute_fork_digest(
 
     # Find the blob parameters applicable to this epoch.
     sorted_schedule = sorted(blob_schedule, key=lambda e: e.epoch, reverse=True)
-    blob_params = next(
-      (entry for entry in sorted_schedule if current_epoch >= entry.epoch),
-      None
-    )
+    blob_params = None
+    for entry in sorted_schedule:
+      if current_epoch >= entry.epoch:
+        blob_params = entry
+        break
 
     # This check enables us to roll out the BPO mechanism without a concurrent parameter change.
     if blob_params is None:
@@ -172,7 +176,7 @@ When discovering and interfacing with peers, nodes MUST evaluate `nfd` alongside
 
 #### `Status` req/resp
 
-No changes are needed in this interaction, but it is noted that it must correctly convey the updated `fork_digest`.
+No changes are needed in this interaction, but it is noted that the response payload must correctly contain the updated `fork_digest`.
 
 #### Gossip topics
 


### PR DESCRIPTION
Supersedes https://github.com/ethereum/EIPs/pull/9818.

Based on conclusions captured [in this comment](https://github.com/ethereum/consensus-specs/issues/4331#issuecomment-2917327652), confirmed in [ACDC #158](https://github.com/ethereum/pm/issues/1548).

---

To reconcile BPO forks at the p2p level, we make changes to:
- `compute_fork_digest`, to apply an XOR mask mixing in the currently-active `MAX_BLOBS_PER_BLOCK`.
- The ENR record to preserve its ability to accurately convey the next fork.

Furthermore, we require that all future blob parameter changes (even those happening at regular forks) be applied through the blob schedule. This is necessary to guarantee consistency and correct calculation of the updated `ForkDigest` in all circumstances.