### PR TITLE
Update EIP-7607: move 7917 to SFI in Fusaka

### DIFF
--- a/EIPS/eip-7607.md
+++ b/EIPS/eip-7607.md
@@ -27,6 +27,7 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Proposed
 * [EIP-7825](./eip-7825.md): Transaction Gas Limit Cap
 * [EIP-7883](./eip-7883.md): ModExp Gas Cost Increase
 * [EIP-7892](./eip-7892.md): Blob Parameter Only Hardforks
+* [EIP-7917](./eip-7917.md): Deterministic proposer lookahead
 * [EIP-7918](./eip-7918.md): Blob base fee bounded by execution cost
 * [EIP-7935](./eip-7935.md): Set default gas limit to XX0M
 
@@ -41,7 +42,6 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Proposed
 * [EIP-5920](./eip-5920.md): PAY opcode
 * RIP-7212: Precompile for secp256r1 Curve Support
 * [EIP-7907](./eip-7907.md): Meter Contract Code Size And Increase Limit
-* [EIP-7917](./eip-7917.md): Deterministic proposer lookahead
 * [EIP-7934](./eip-7934.md): RLP Execution Block Size Limit
 
 ### Declined for Inclusion


### PR DESCRIPTION
reflecting decisions from [ACDC #158](https://github.com/ethereum/pm/issues/1548)