### PR TITLE
Update EIP-7702: Clarify precompile behavior for external transactions

### DIFF
--- a/EIPS/eip-7702.md
+++ b/EIPS/eip-7702.md
@@ -162,9 +162,9 @@ authority.*
 ###### Precompiles
 
 When a precompile address is the target of a delegation, the retrieved code is
-considered empty and `CALL`, `CALLCODE`, `STATICCALL`, `DELEGATECALL`
-instructions targeting this account will execute empty code, and therefore
-succeed with no execution when given enough gas to initiate the call.
+considered empty and any transaction—internal or external—targeting this 
+account will execute empty code, and therefore succeed with no execution when 
+given enough gas to initiate the call.
 
 ###### Loops
 


### PR DESCRIPTION
**Motivation**
- Clarify that the behavior of executing empty bytecode not only happens when xCALL opcodes are called but also happens with external transactions. 

If reasoned this may be obvious but I just thought it was important to add that this happens in both external and internal transactions. It's just a suggestion based on what I felt when I read the EIP for the first time but it isn't very relevant though. Feel free to dismiss it.
Also, I removed the opcodes names because I believe EVM developers already know what internal and external transactions are, so I thought there was no need for clarifying the opcodes names, but I may be wrong.