### PR TITLE
Update EIP-7928: convert contract code field from union type to list of bytes

### DIFF
--- a/EIPS/eip-7928.md
+++ b/EIPS/eip-7928.md
@@ -64,7 +64,7 @@ class SlotAccess(Container):
 class AccountAccess(Container):
     address: Address
     accesses: List[SlotAccess, MAX_SLOTS]
-    code: Union[ByteVector(MAX_CODE_SIZE), None]  # Optional field for contract bytecode
+    code: List[byte, MAX_CODE_SIZE]  # field for contract bytecode
 
 BlockAccessList = List[AccountAccess, MAX_ACCOUNTS]
 


### PR DESCRIPTION
Unions are not present in the spec, and AFAICT they are not supported by production-grade SSZ implementations.  We can use a byte list here, with empty list signaling no code in the account.