### PR TITLE
Update EIP-7883: Assume minimal base/mod length of 32

### DIFF
--- a/EIPS/eip-7883.md
+++ b/EIPS/eip-7883.md
@@ -27,9 +27,8 @@ Upon activation of this EIP, the gas cost of calling the precompile at address `
 def calculate_multiplication_complexity(base_length, modulus_length):
     max_length = max(base_length, modulus_length)
     words = math.ceil(max_length / 8)
-    multiplication_complexity = 0
-    if max_length <= 32: multiplication_complexity = words**2
-    elif max_length > 32: multiplication_complexity = 2 * words**2
+    multiplication_complexity = 16
+    if max_length > 32: multiplication_complexity = 2 * words**2
     return multiplication_complexity
 
 def calculate_iteration_count(exponent_length, exponent):
@@ -49,7 +48,7 @@ Changes (with algorithm from [EIP-2565](./eip-2565.md)):
 
 ### 1. Increase minimal price from 200 to 500
 
-This part of equation:
+This part of the equation:
 
 ```
     return max(200, math.floor(multiplication_complexity * iteration_count / 3))
@@ -63,7 +62,7 @@ Is replaced by this:
 
 ### 2. Increase cost when exponent is larger than 32 bytes
 
-This part of equation:
+This part of the equation:
 
 ```
     elif exponent_length > 32: iteration_count = (8 * (exponent_length - 32)) + ((exponent & (2**256 - 1)).bit_length() - 1)
@@ -77,9 +76,9 @@ Is replaced by this:
 
 Multiplier 8 is replaced by 16.
 
-### 3. Increase cost when base or modulus is larger than 32 bytes
+### 3. Assume the minimal base / modulus length to be 32 and increase the cost when it is larger than 32 bytes
 
-This part of equation:
+This part of the equation:
 
 ```
 def calculate_multiplication_complexity(base_length, modulus_length):
@@ -94,9 +93,8 @@ Is replaced by this:
 def calculate_multiplication_complexity(base_length, modulus_length):
     max_length = max(base_length, modulus_length)
     words = math.ceil(max_length / 8)
-    multiplication_complexity = 0
-    if max_length <= 32: multiplication_complexity = words**2
-    elif max_length > 32: multiplication_complexity = 2 * words**2
+    multiplication_complexity = 16
+    if max_length > 32: multiplication_complexity = 2 * words**2
     return multiplication_complexity
 ```
 


### PR DESCRIPTION
From the performance analysis of the modexp precompile after EIP-7883, the increase minimal cost of 500 don't fully cover the worst case of small base/modulus. E.g. the case of the smallest base/modulus of 8 bytes the maximum exponent within the 500 gas cost budget has 880 bits. This case performs significantly worst than the average case (modulus 32 bytes).

We propose to eliminate the pathological cases of base/modulus smaller than 32 bytes by computing the gas cost as if they had 32 byte length. By the [Mainnet usage data of the modexp](https://github.com/hugo-dc/modexp_analysis/blob/master/modexp.ipynb), a modulus smaller than 32 bytes had never been used.

Additional context in the EIP discussion: https://ethereum-magicians.org/t/eip-7883-modexp-gas-cost-increase/22841/6.

The below graphs (of different zoom levels) visualize the proposed changes. They show:
- EIP-2565 common (modulus 32 bytes) gas curve,
- EIP-7883 gas curves for modulus 8, 16, 24, 32 bytes long,
- The proposed gas cost collapsing moduli <= 32 bytes into single curve.

You can notice how slowly rises the `EIP-7883 mod=8b` curve.

![EIP-7883 gas cost analysis 500](https://github.com/user-attachments/assets/8f857e1e-4546-46f5-bb20-706d71a3b003)

![EIP-7883 gas cost analysis 1500](https://github.com/user-attachments/assets/9b0d53f5-ee22-49fa-a4a2-b444c61369e2)

