### PR TITLE
Update EIP-7917: Change proposer_lookahead type from List to Vector

### DIFF
--- a/EIPS/eip-7917.md
+++ b/EIPS/eip-7917.md
@@ -30,12 +30,12 @@ With this change, it will no longer be possible for validators to grind effectiv
 
 ## Specification
 
-The `BeaconState` container is extended with a `proposer_lookahead` field, which is a list of validator indices covering the full visible lookahead period, starting from the beginning of the current epoch to the next `MIN_SEED_LOOKAHEAD` epochs.
+The `BeaconState` container is extended with a `proposer_lookahead` field, which is a vector of validator indices covering the full visible lookahead period, starting from the beginning of the current epoch to the next `MIN_SEED_LOOKAHEAD` epochs.
 
 ```python
 class BeaconState:
     ...
-    proposer_lookahead: List[ValidatorIndex, (MIN_SEED_LOOKAHEAD + 1) * SLOTS_PER_EPOCH]
+    proposer_lookahead: Vector[ValidatorIndex, (MIN_SEED_LOOKAHEAD + 1) * SLOTS_PER_EPOCH]
 ```
 
 For example, `proposer_lookahead[0]` is the validator index for the first proposer in the current epoch, `proposer_lookahead[SLOTS_PER_EPOCH + 4]` is the validator index for the fifth proposer in the next epoch, and so forth.


### PR DESCRIPTION
Update EIP based on [latest specs](https://github.com/ethereum/consensus-specs/blob/dev/specs/fulu/beacon-chain.md#beaconstate).
