### PR TITLE
ACDE#213 changes

### DIFF
--- a/EIPS/eip-7607.md
+++ b/EIPS/eip-7607.md
@@ -39,7 +39,6 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Proposed
 
 ### Considered for Inclusion
 
-* [EIP-5920](./eip-5920.md): PAY opcode
 * RIP-7212: Precompile for secp256r1 Curve Support
 * [EIP-7907](./eip-7907.md): Meter Contract Code Size And Increase Limit
 * [EIP-7934](./eip-7934.md): RLP Execution Block Size Limit
@@ -63,6 +62,7 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Proposed
     * [EIP-7834](./eip-7834.md): Separate Metadata Section for EOF
     * [EIP-7761](./eip-7761.md): EXTCODETYPE instruction
     * [EIP-7880](./eip-7880.md): EOF - EXTCODEADDRESS instruction
+* [EIP-5920](./eip-5920.md): PAY opcode
 * [EIP-7762](./eip-7762.md): Increase MIN_BASE_FEE_PER_BLOB_GAS
 * [EIP-7666](./eip-7666.md): EVM-ify the identity precompile
 * [EIP-7668](./eip-7668.md): Remove bloom filters


### PR DESCRIPTION
The following EIPs are tentatively being scheduled for `devnet-2`, which is the last devnet during which we plan to grow the Fusaka scope: 

* RIP-7212: Precompile for secp256r1 Curve Support
* [EIP-7907](./eip-7907.md): Meter Contract Code Size And Increase Limit
* [EIP-7934](./eip-7934.md): RLP Execution Block Size Limit

EIP-5920 was DFI'd from Fusaka, and RIP-7212 will be replaced by EIP-7951 once merged. 