### PR TITLE
Update EIP-7928: Code change

### DIFF
--- a/EIPS/eip-7928.md
+++ b/EIPS/eip-7928.md
@@ -64,7 +64,6 @@ class SlotAccess(Container):
 class AccountAccess(Container):
     address: Address
     accesses: List[SlotAccess, MAX_SLOTS]
-    code: List[byte, MAX_CODE_SIZE]  # field for contract bytecode
 
 BlockAccessList = List[AccountAccess, MAX_ACCOUNTS]
 
@@ -84,7 +83,7 @@ BalanceDiffs = List[AccountBalanceDiff, MAX_ACCOUNTS]
 # Code Diff structures
 class CodeChange(Container):
     tx_index: TxIndex
-    new_code: CodeData
+    new_code: CodeData # runtime bytecode of newly deployed contract
 
 class AccountCodeDiff(Container):
     address: Address
@@ -92,7 +91,7 @@ class AccountCodeDiff(Container):
 
 CodeDiffs = List[AccountCodeDiff, MAX_ACCOUNTS]
 
-# Pre-transaction nonce structures
+# Nonce Diff structures
 class AccountNonce(Container):
     address: Address  # account address
     nonce_before: Nonce  # nonce value before block execution

--- a/EIPS/eip-7928.md
+++ b/EIPS/eip-7928.md
@@ -87,7 +87,7 @@ class CodeChange(Container):
 
 class AccountCodeDiff(Container):
     address: Address
-    changes: List[CodeChange, MAX_TXS]
+    changes: CodeChange
 
 CodeDiffs = List[AccountCodeDiff, MAX_ACCOUNTS]
 


### PR DESCRIPTION
Since code can only change once per tx/address, we can remove the list as suggested by @jochem-brouwer in this PR:
https://github.com/ethereum/EIPs/pull/9864#event-18019983159