### PR TITLE
Update EIP-7928: make explicit that the BAL is its own field in the block, remove SSZ encoding as a requirement for BAL verification

### DIFF
--- a/EIPS/eip-7928.md
+++ b/EIPS/eip-7928.md
@@ -65,7 +65,7 @@ class AccountAccess(Container):
     address: Address
     accesses: List[SlotAccess, MAX_SLOTS]
 
-BlockAccessList = List[AccountAccess, MAX_ACCOUNTS]
+AccountAccessList = List[AccountAccess, MAX_ACCOUNTS]
 
 # Balance Diff structures
 BalanceDelta = ByteVector(12)  # signed, two's complement encoding
@@ -97,6 +97,12 @@ class AccountNonce(Container):
     nonce_before: Nonce  # nonce value before block execution
 
 NonceDiffs = List[AccountNonceDiff, MAX_TXS]
+
+class BlockAccessList(Container):
+    account_accesses: AccountAccessList
+    balance_diffs: BalanceDiffs
+    code_diffs: AccountCodeDiffs
+    nonce_diffs: NonceDiffs
 ```
 
 The `BlockAccessList` is a deduplicated list of accessed addresses. For each address, it MUST contain a list of accessed storage keys. 
@@ -148,10 +154,10 @@ def state_transition(block):
             computed_code_diffs.setdefault(addr, []).append((idx, code))
 
     # Validate block data
-    assert block.block_access_list == encode_ssz_access_list(computed_access_list, computed_code_diffs)
-    assert block.balance_diffs == encode_ssz_balance_diffs(computed_balance_diffs)
-    assert block.code_diffs == encode_ssz_code_diffs(computed_code_diffs)
-    assert block.nonce_diffs == encode_ssz_nonce_diffs(computed_nonce_diffs)
+    assert block.access_list.block_access_list == computed_access_list
+    assert block.access_list.balance_diffs == computed_balance_diffs
+    assert block.access_list.code_diffs == computed_code_diffs
+    assert block.access_list.nonce_diffs == computed_nonce_diffs
 ```
 
 The BAL MUST be complete and accurate. It MUST NOT contain too few entries (missing accesses) or too many entries (spurious accesses). Any missing or extra entries in the access list, balance diffs, or nonce diffs MUST result in block invalidation.


### PR DESCRIPTION
> make explicit that the BAL is its own field in the block

I think this was already assumed, so I'm making it explicit here.

> remove SSZ encoding as a requirement for BAL verification

Comparing the output of the ssz encoding of the computed BAL in verification incurs unnecessary overhead.  We can just compare the header BAL vs computed value directly (field-by-field).