### PR TITLE
Update EIP-712: typo, reference ERC spec correctly and formats

### DIFF
--- a/EIPS/eip-712.md
+++ b/EIPS/eip-712.md
@@ -15,13 +15,13 @@ requires: 155, 191
 
 This is a standard for hashing and signing of typed structured data as opposed to just bytestrings. It includes a
 
-*   theoretical framework for correctness of encoding functions,
-*   specification of structured data similar to and compatible with Solidity structs,
-*   safe hashing algorithm for instances of those structures,
-*   safe inclusion of those instances in the set of signable messages,
-*   an extensible mechanism for domain separation,
-*   new RPC call `eth_signTypedData`, and
-*   an optimized implementation of the hashing algorithm in EVM.
+* theoretical framework for correctness of encoding functions,
+* specification of structured data similar to and compatible with Solidity structs,
+* safe hashing algorithm for instances of those structures,
+* safe inclusion of those instances in the set of signable messages,
+* an extensible mechanism for domain separation,
+* new RPC call `eth_signTypedData`, and
+* an optimized implementation of the hashing algorithm in EVM.
 
 It does not include replay protection.
 
@@ -42,15 +42,16 @@ Here we outline a scheme to encode data along with its structure which allows it
 ## Specification
 
 The set of signable messages is extended from transactions and bytestrings `𝕋 ∪ 𝔹⁸ⁿ` to also include structured data `𝕊`. The new set of signable messages is thus `𝕋 ∪ 𝔹⁸ⁿ ∪ 𝕊`. They are encoded to bytestrings suitable for hashing and signing as follows:
-*   `encode(transaction : 𝕋) = RLP_encode(transaction)`
-*   `encode(message : 𝔹⁸ⁿ) = "\x19Ethereum Signed Message:\n" ‖ len(message) ‖ message` where `len(message)` is the _non-zero-padded_ ascii-decimal encoding of the number of bytes in `message`.
-*   `encode(domainSeparator : 𝔹²⁵⁶, message : 𝕊) = "\x19\x01" ‖ domainSeparator ‖ hashStruct(message)` where `domainSeparator` and `hashStruct(message)` are defined below.
+
+* `encode(transaction : 𝕋) = RLP_encode(transaction)`
+* `encode(message : 𝔹⁸ⁿ) = "\x19Ethereum Signed Message:\n" ‖ len(message) ‖ message` where `len(message)` is the _non-zero-padded_ ascii-decimal encoding of the number of bytes in `message`.
+* `encode(domainSeparator : 𝔹²⁵⁶, message : 𝕊) = "\x19\x01" ‖ domainSeparator ‖ hashStruct(message)` where `domainSeparator` and `hashStruct(message)` are defined below.
 
 This encoding is deterministic because the individual components are. The encoding is injective because the three cases always differ in first byte. (`RLP_encode(transaction)` does not start with `\x19`.)
 
-The encoding is compliant with [EIP-191][EIP-191]. The 'version byte' is fixed to `0x01`, the 'version specific data' is the 32-byte domain separator `domainSeparator` and the 'data to sign' is the 32-byte `hashStruct(message)`.
+The encoding is compliant with [ERC-191][ERC-191]. The 'version byte' is fixed to `0x01`, the 'version specific data' is the 32-byte domain separator `domainSeparator` and the 'data to sign' is the 32-byte `hashStruct(message)`.
 
-[EIP-191]: ./eip-191.md
+[ERC-191]: ./eip-191.md
 
 ### Definition of typed structured data `𝕊`
 
@@ -80,7 +81,7 @@ struct Mail {
 
 The `hashStruct` function is defined as
 
-*   `hashStruct(s : 𝕊) = keccak256(typeHash ‖ encodeData(s))` where `typeHash = keccak256(encodeType(typeOf(s)))`
+* `hashStruct(s : 𝕊) = keccak256(typeHash ‖ encodeData(s))` where `typeHash = keccak256(encodeType(typeOf(s)))`
 
 **Note**: The `typeHash` is a constant for a given struct type and does not need to be runtime computed.
 
@@ -111,11 +112,11 @@ domainSeparator = hashStruct(eip712Domain)
 
 where the type of `eip712Domain` is a struct named `EIP712Domain` with one or more of the below fields. Protocol designers only need to include the fields that make sense for their signing domain. Unused fields are left out of the struct type.
 
-*   `string name` the user readable name of signing domain, i.e. the name of the DApp or the protocol.
-*   `string version` the current major version of the signing domain. Signatures from different versions are not compatible.
-*   `uint256 chainId` the [EIP-155][EIP-155] chain id. The user-agent *should* refuse signing if it does not match the currently active chain.
-*   `address verifyingContract` the address of the contract that will verify the signature. The user-agent *may* do contract specific phishing prevention.
-*   `bytes32 salt` a disambiguating salt for the protocol. This can be used as a domain separator of last resort.
+* `string name` the user readable name of signing domain, i.e. the name of the DApp or the protocol.
+* `string version` the current major version of the signing domain. Signatures from different versions are not compatible.
+* `uint256 chainId` the [EIP-155][EIP-155] chain id. The user-agent _should_ refuse signing if it does not match the currently active chain.
+* `address verifyingContract` the address of the contract that will verify the signature. The user-agent _may_ do contract specific phishing prevention.
+* `bytes32 salt` a disambiguating salt for the protocol. This can be used as a domain separator of last resort.
 
 [EIP-155]: ./eip-155.md
 
@@ -135,8 +136,8 @@ The sign method calculates an Ethereum specific signature with: `sign(keccak256(
 
 ##### Parameters
 
-1.  `Address` - 20 Bytes - Address of the account that will sign the messages.
-2.  `TypedData` - Typed structured data to be signed.
+1. `Address` - 20 Bytes - Address of the account that will sign the messages.
+2. `TypedData` - Typed structured data to be signed.
 
 Typed data is a JSON object containing type information, domain separator parameters and the message object. Below is the json-schema definition for `TypedData` param.
 
@@ -174,16 +175,16 @@ Typed data is a JSON object containing type information, domain separator parame
 
 `DATA`: Signature. As in `eth_sign` it is a hex encoded 65 byte array starting with `0x`. It encodes the `r`, `s` and `v` parameters from appendix F of the yellow paper in big-endian format. Bytes 0...32 contain the `r` parameter, bytes 32...64 the `s` parameter and the last byte the `v` parameter. Note that the `v` parameter includes the chain id as specified in [EIP-155][eip-155].
 
-[eip-155]: ./eip-155.md
-
 ##### Example
 
 Request:
+
 ```shell
 curl -X POST --data '{"jsonrpc":"2.0","method":"eth_signTypedData","params":["0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826", {"types":{"EIP712Domain":[{"name":"name","type":"string"},{"name":"version","type":"string"},{"name":"chainId","type":"uint256"},{"name":"verifyingContract","type":"address"}],"Person":[{"name":"name","type":"string"},{"name":"wallet","type":"address"}],"Mail":[{"name":"from","type":"Person"},{"name":"to","type":"Person"},{"name":"contents","type":"string"}]},"primaryType":"Mail","domain":{"name":"Ether Mail","version":"1","chainId":1,"verifyingContract":"0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"},"message":{"from":{"name":"Cow","wallet":"0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826"},"to":{"name":"Bob","wallet":"0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"},"contents":"Hello, Bob!"}}],"id":1}'
 ```
 
 Result:
+
 ```JavaScript
 {
   "id":1,
@@ -267,12 +268,12 @@ For the type hash several alternatives were considered and rejected for the reas
 
 **Alternative 2**: Use ABIv2 function signatures. `bytes4` is not enough to be collision resistant. Unlike function signatures, there is negligible runtime cost incurred by using longer hashes.
 
-**Alternative 3**: ABIv2 function signatures modified to be 256-bit. While this captures type info, it does not capture any of the semantics other than the function. This is already causing a practical collision between [EIP-20]'s and [EIP-721]'s `transfer(address,uint256)`, where in the former the `uint256` refers to an amount and the latter to a unique id. In general ABIv2 favors compatibility where a hashing standard should prefer incompatibility.
+**Alternative 3**: ABIv2 function signatures modified to be 256-bit. While this captures type info, it does not capture any of the semantics other than the function. This is already causing a practical collision between [ERC-20]'s and [ERC-721]'s `transfer(address,uint256)`, where in the former the `uint256` refers to an amount and the latter to a unique id. In general ABIv2 favors compatibility where a hashing standard should prefer incompatibility.
 
-[EIP-20]: ./eip-20.md
-[EIP-721]: ./eip-721.md
+[ERC-20]: ./eip-20.md
+[ERC-721]: ./eip-721.md
 
-**Alternative 4**: 256-bit ABIv2 signatures extended with parameter names and struct names. The `Mail` example from a above would be encoded as `Mail(Person(string name,address wallet) from,Person(string name,address wallet) to,string contents)`. This is longer than the proposed solution. And indeed, the length of the string can grow exponentially in the length of the input (consider `struct A{B a;B b;}; struct B {C a;C b;}; …`). It also does not allow a recursive struct type (consider `struct List {uint256 value; List next;}`).
+**Alternative 4**: 256-bit ABIv2 signatures extended with parameter names and struct names. The `Mail` example from above would be encoded as `Mail(Person(string name,address wallet) from,Person(string name,address wallet) to,string contents)`. This is longer than the proposed solution. And indeed, the length of the string can grow exponentially in the length of the input (consider `struct A{B a;B b;}; struct B {C a;C b;}; …`). It also does not allow a recursive struct type (consider `struct List {uint256 value; List next;}`).
 
 **Alternative 5**: Include natspec documentation. This would include even more semantic information in the schemaHash and further reduces chances of collision. It makes extending and amending documentation a breaking changes, which contradicts common assumptions. It also makes the schemaHash mechanism very verbose.
 


### PR DESCRIPTION
Originally just to update a tiny typo (`a above` to `above`) in existing EIP-712, then the bot gave a bunch of errors relating to format... so here is it