### PR TITLE
EIP-7928: Add note about linear scaling of BAL size w.r.t. `block.gasLimit`

### DIFF
--- a/EIPS/eip-7928.md
+++ b/EIPS/eip-7928.md
@@ -205,6 +205,8 @@ Validating access lists and balance diffs adds validation overhead but is essent
 
 Including comprehensive access lists, balance diffs and nonce values increases block size, potentially impacting network propagation times. However, as noted in the rationale section, the overhead is reasonable given the performance benefits, with typical BALs averaging around 67 KiB in total.
 
+The worst-case size of the BAL grows linearly with respect to the block gas limit. Each item of the BAL is either a read or write to the chain state relevant to that entry. The gas costs to perform such action is constant in the worst case (in this case, thus the cheapest cost). Since this is cost is nonzero, the count of actions is given a block gas limit thus has an upper bound. The size of the added items to the BAL is also constant. Therefore, the BAL grows linearly in the worst case. Note that in the case of contract code deposits, the cost is charged as constant nonzero gas per byte. Therefore, in case of code deposits, the BAL also has an upper bound in size which scales linearly with the gas limit.
+
 ## Copyright
 
 Copyright and related rights waived via [CC0](../LICENSE.md).


### PR DESCRIPTION
Keeping as draft, likely want to add more notes/considerations.