### PR TITLE
Update EIP-7702 gas refund as per canonical implementation

### DIFF
--- a/EIPS/eip-7702.md
+++ b/EIPS/eip-7702.md
@@ -114,7 +114,8 @@ following:
 5. Verify the code of `authority` is empty or already delegated.
 6. Verify the nonce of `authority` is equal to `nonce`.
 7. Add `PER_EMPTY_ACCOUNT_COST - PER_AUTH_BASE_COST` gas to the global refund
-   counter if `authority` is not empty.
+   counter if `authority` existed in the state trie at the start of the
+   transaction, regardless of its `code_hash`.
 8. Set the code of `authority` to be `0xef0100 || address`. This is a delegation
    indicator.
     * If `address` is `0x0000000000000000000000000000000000000000`, do not write


### PR DESCRIPTION
Update EIP-7702 to match the canonical implementation after OP fork. 
OP Lab's post mortem: https://oplabs.notion.site/Incident-Post-Mortem-op-geth-op-reth-Gas-Refund-Mismatch-209f153ee16280729366e9134e91455f
