### PR TITLE
Update EIP-1186: Fix broken Merkle Tree link in EIP-1186 abstract

### DIFF
--- a/EIPS/eip-1186.md
+++ b/EIPS/eip-1186.md
@@ -16,7 +16,7 @@ One of the great features of Ethereum is the fact, that you can verify all data 
 
 ## Abstract
 
-Ethereum uses a [Merkle Tree](https://github.com/ethereum/wiki/wiki/Patricia-Tree) to store the state of accounts and their storage. This allows verification of each value by simply creating a Merkle Proof. But currently, the standard RPC-Interface does not give you access to these proofs. This EIP suggests an additional RPC-Method, which creates Merkle Proofs for Accounts and Storage Values. 
+Ethereum uses a [Merkle Tree](https://github.com/ethereum/eth-wiki/blob/master/fundamentals/patricia-tree.md) to store the state of accounts and their storage. This allows verification of each value by simply creating a Merkle Proof. But currently, the standard RPC-Interface does not give you access to these proofs. This EIP suggests an additional RPC-Method, which creates Merkle Proofs for Accounts and Storage Values. 
 
 Combined with a stateRoot (from the blockheader) it enables offline verification of any account or storage-value. This allows especially IOT-Devices or even mobile apps which are not able to run a light client to verify responses from an untrusted source only given a trusted blockhash.
 


### PR DESCRIPTION
Replaced a deprecated GitHub Wiki link with the updated Merkle Tree documentation in the eth-wiki repo.