### PR TITLE
Update EIP-1355: fix broken Ethash Main Loop link to official Ethereum documentation

### DIFF
--- a/EIPS/eip-1355.md
+++ b/EIPS/eip-1355.md
@@ -22,7 +22,7 @@ Provide minimal set of changes to Ethash algorithm to hinder and delay the adopt
    ```
    where `FNV1A_PRIME` is 16777499 or 16777639.
 2. Change the hash function that determines the DAG item index in Ethash algorithm from `fnv()` to new `fnv1a()`.
-   In [Main Loop](https://ethereum.org/en/developers/docs/consensus-mechanisms/pow/mining/mining-algorithms/ethash/#main-loop) change
+   In [Main Loop](https://github.com/ethereum/execution-specs/blob/forks/osaka/src/ethereum/ethash.py) change
    ```python
    p = fnv(i ^ s[0], mix[i % w]) % (n // mixhashes) * mixhashes
    ```


### PR DESCRIPTION
Replaced the outdated link to the Ethash "Main Loop" section (previously pointing to the archived GitHub wiki) with an up-to-date link to the official Ethereum documentation. This ensures that readers have access to a maintained and accurate description of the Ethash main loop.