### PR TITLE
Update EIP-7934: Bump safety margin to 2MiB.

### DIFF
--- a/EIPS/eip-7934.md
+++ b/EIPS/eip-7934.md
@@ -23,7 +23,7 @@ Currently, Ethereum does not enforce a strict upper limit on the encoded size of
 
 Additionally, blocks exceeding 10 MiB are not propagated by the consensus layer's (CL) gossip protocol, potentially causing network fragmentation or denial-of-service (DoS) conditions.
 
-By imposing a protocol-level limit on the RLP-encoded block size, Ethereum can ensure enhanced resilience against targeted attacks on block validation times. Adding an additional margin of 512 KiB explicitly accommodates beacon block sizes, ensuring compatibility across network components.
+By imposing a protocol-level limit on the RLP-encoded block size, Ethereum can ensure enhanced resilience against targeted attacks on block validation times. Adding an additional margin of 2MiB explicitly accommodates beacon block sizes, ensuring compatibility across network components.
 
 ## Specification
 
@@ -31,7 +31,7 @@ By imposing a protocol-level limit on the RLP-encoded block size, Ethereum can e
 
 - Introduce constants:
   - `MAX_BLOCK_SIZE` set to **10 MiB (10,485,760 bytes)**
-  - `SAFETY_MARGIN` set to **512 KiB (524,288 bytes)**
+  - `SAFETY_MARGIN` set to **2MiB (2,097,152  bytes)**
   - `MAX_RLP_BLOCK_SIZE` calculated as `MAX_BLOCK_SIZE - MARGIN`
 - Any RLP-encoded block exceeding `MAX_RLP_BLOCK_SIZE` must be considered invalid.
 
@@ -39,7 +39,7 @@ Thus add the following check to the Ethereum protocol:
 
 ```python
 MAX_BLOCK_SIZE = 10_485_760  # 10 MiB
-SAFETY_MARGIN = 524_288  # 512 KiB
+SAFETY_MARGIN = 2_097_152  # 2 KiB
 MAX_RLP_BLOCK_SIZE = MAX_BLOCK_SIZE - SAFETY_MARGIN
 
 # if true, the block is invalid and should be rejected/not get built
@@ -61,7 +61,7 @@ def exceed_max_rlp_block_size(block: Block) -> bool:
 
 ### Why 10 MiB?
 
-A cap of 10 MiB aligns with the gossip protocol constraint in Ethereum's consensus layer (CL). An additional 512 KiB margin explicitly accounts for beacon block sizes, ensuring compatibility and consistent block propagation across the network. Blocks significantly larger than 10 MiB will not be broadcast by the CL, potentially leading to network fragmentation or denial-of-service scenarios.
+A cap of 10 MiB aligns with the gossip protocol constraint in Ethereum's consensus layer (CL). An additional 2MiB margin explicitly accounts for beacon block sizes, ensuring compatibility and consistent block propagation across the network. Blocks significantly larger than 10 MiB will not be broadcast by the CL, potentially leading to network fragmentation or denial-of-service scenarios.
 
 ## Backwards Compatibility
 

--- a/EIPS/eip-7934.md
+++ b/EIPS/eip-7934.md
@@ -39,7 +39,7 @@ Thus add the following check to the Ethereum protocol:
 
 ```python
 MAX_BLOCK_SIZE = 10_485_760  # 10 MiB
-SAFETY_MARGIN = 2_097_152  # 2 KiB
+SAFETY_MARGIN = 2_097_152  # 2 MiB
 MAX_RLP_BLOCK_SIZE = MAX_BLOCK_SIZE - SAFETY_MARGIN
 
 # if true, the block is invalid and should be rejected/not get built


### PR DESCRIPTION
As title.

From Pari:
> MARGIN needs to be atleast 890kib with todays validator set size. You likely want to set the value to 1mib or more to account for future validator set growth.