### PR TITLE
Update EIP-1186: Fix broken link Merkle Tree Patricia

### DIFF
--- a/EIPS/eip-1186.md
+++ b/EIPS/eip-1186.md
@@ -16,7 +16,7 @@ One of the great features of Ethereum is the fact, that you can verify all data 
 
 ## Abstract
 
-Ethereum uses a [Merkle Tree](https://github.com/ethereum/wiki/wiki/Patricia-Tree) to store the state of accounts and their storage. This allows verification of each value by simply creating a Merkle Proof. But currently, the standard RPC-Interface does not give you access to these proofs. This EIP suggests an additional RPC-Method, which creates Merkle Proofs for Accounts and Storage Values. 
+Ethereum uses a [Merkle Tree](https://ethereum.org/en/developers/docs/data-structures-and-encoding/patricia-merkle-trie/) to store the state of accounts and their storage. This allows verification of each value by simply creating a Merkle Proof. But currently, the standard RPC-Interface does not give you access to these proofs. This EIP suggests an additional RPC-Method, which creates Merkle Proofs for Accounts and Storage Values. 
 
 Combined with a stateRoot (from the blockheader) it enables offline verification of any account or storage-value. This allows especially IOT-Devices or even mobile apps which are not able to run a light client to verify responses from an untrusted source only given a trusted blockhash.
 


### PR DESCRIPTION
Replaced the outdated link to the Ethereum Patricia Tree (Merkle Tree) specification with the current official documentation on ethereum.org. This ensures that readers have access to up-to-date and authoritative information about the Merkle Patricia Trie data structure used in Ethereum. No other content was changed.