### PR TITLE
Update EIP-7928: inconsistencies in SSZ structures

### DIFF
--- a/EIPS/eip-7928.md
+++ b/EIPS/eip-7928.md
@@ -97,7 +97,7 @@ class CodeChange(Container):
 
 class AccountCodeDiff(Container):
     address: Address
-    changes: CodeChange
+    change: CodeChange
 
 CodeDiffs = List[AccountCodeDiff, MAX_ACCOUNTS]
 
@@ -106,7 +106,7 @@ class AccountNonce(Container):
     address: Address  # account address
     nonce_before: Nonce  # nonce value before block execution
 
-NonceDiffs = List[AccountNonceDiff, MAX_TXS]
+NonceDiffs = List[AccountNonce, MAX_TXS]
 
 # Block-level Access List structure
 class BlockAccessList(Container):


### PR DESCRIPTION
## Description

Fix inconsistencies in SSZ data structures.

`AccountCodeDiff.changes` -> `AccountCodeDiff.change` - as it represents a single code change

`NonceDiffs = List[AccountNonceDiff, MAX_TXS]` -> `NonceDiffs = List[AccountNonce, MAX_TXS]`