### PR TITLE
SFI → Included

### DIFF
--- a/EIPS/eip-7600.md
+++ b/EIPS/eip-7600.md
@@ -12,7 +12,7 @@ requires: 2537, 2935, 6110, 7002, 7251, 7549, 7623, 7685, 7691, 7702
 
 ## Abstract
 
-This Meta EIP lists the EIPs formally Scheduled for Inclusion in the Prague/Electra network upgrade.
+This Meta EIP lists the EIPs Included in the Prague/Electra network upgrade.
 
 ## Specification
 


### PR DESCRIPTION
With the EIP Final, it should read "included", not "SFId"