### PR TITLE
Update EIP-7934: Set MAX_RECEIPTS_MESSAGE_SIZE for GetReceipts in devp2p

### DIFF
--- a/EIPS/eip-7934.md
+++ b/EIPS/eip-7934.md
@@ -1,7 +1,7 @@
 ---
 eip: 7934
 title: RLP Execution Block Size Limit
-description: Introduce a protocol-level cap on the maximum RLP-encoded block size to 10 MiB, including a 512 KiB margin for beacon block size.
+description: Introduce a protocol-level cap on the maximum RLP-encoded block size to 10 MiB, including a 2 MiB margin for beacon block size.
 author: Giulio Rebuffo (@Giulio2002), Ben Adams (@benaadams), Storm Slivkoff (@sslivkoff)
 discussions-to: https://ethereum-magicians.org/t/eip-7934-add-bytesize-limit-to-blocks/23589
 status: Draft
@@ -12,7 +12,7 @@ created: 2025-04-16
 
 ## Abstract
 
-This proposal introduces a protocol-level cap on the maximum RLP-encoded execution block size to 10 megabytes (MiB), which includes a margin of 512 KiB to account for beacon block sizes.
+This proposal introduces a protocol-level cap on the maximum RLP-encoded execution block size to 10 megabytes (MiB), which includes a margin of 2 MiB to account for beacon block sizes.
 
 ## Motivation
 


### PR DESCRIPTION
**ATTENTION: ERC-RELATED PULL REQUESTS NOW OCCUR IN [ETHEREUM/ERCS](https://github.com/ethereum/ercs)**

--

When opening a pull request to submit a new EIP, please use the suggested template: https://github.com/ethereum/EIPs/blob/master/eip-template.md

We have a GitHub bot that automatically merges some PRs. It will merge yours immediately if certain criteria are met:

 - The PR edits only existing draft PRs.
 - The build passes.
 - Your GitHub username or email address is listed in the 'author' header of all affected PRs, inside <triangular brackets>.
 - If matching on email address, the email address is the one publicly listed on your GitHub profile.
