### PR TITLE
Update EIP-7937: Fix Typos and Improve Clarity in EIP-7937 Specification

### DIFF
--- a/EIPS/eip-7937.md
+++ b/EIPS/eip-7937.md
@@ -30,7 +30,7 @@ If the second byte is not a valid 64-bit mode operation, then the interpreter MU
 
 ### General 64-bit mode behavior
 
-In 64-bit mode, all operations only work on the least significant 64-bit of each stack value. The most significant 192-bit is discarded. When a result value is pushed back onto the stack, then it MUST ensures that observable effects will see that the most significant 192-bit is zero. Note that here it's not necessary for an interpreter to reset the most significant 192-bit to zero every time -- if the next opcode is still in 64-bit mode, then the most significant 192-bit is still unobservable. We discuss the full details in the "rationale" section. The interpreter only needs to reproduce the full 256-bit value upon entering non-64-bit mode. If the full computational heavy part can be written in pure 64-bit mode, then this can result in noticable performance gain.
+In 64-bit mode, all operations only work on the least significant 64-bit of each stack value. The most significant 192-bit is discarded. When a result value is pushed back onto the stack, then it MUST ensures that observable effects will see that the most significant 192-bit is zero. Note that here it's not necessary for an interpreter to reset the most significant 192-bit to zero every time -- if the next opcode is still in 64-bit mode, then the most significant 192-bit is still unobservable. We discuss the full details in the "rationale" section. The interpreter only needs to reproduce the full 256-bit value upon entering non-64-bit mode. If the full computational heavy part can be written in pure 64-bit mode, then this can result in noticeable performance gain.
 
 ### Gas cost constants
 
@@ -79,7 +79,7 @@ For flow operations JUMP and JUMPI, the behavior is as follows:
 
 When a smart contract uses the 64-bit mode, it's expected that once entered, it will want to stay in 64-bit mode, and only exit to non-64-bit mode when the computationally intensive function is finished. This EIP is designed particularly with this fact in mind.
 
-All 64-bit opcodes only operates on the 64-bit value. It totally discards the rest 192 bits. The interpreter only needs to ensure that when it exits into non-64-bit mode and next time when a value result is read, that value has the first 192 bits reset to zero. The EVM interpreter can therefore use a typed stack for optmization:
+All 64-bit opcodes only operates on the 64-bit value. It totally discards the rest 192 bits. The interpreter only needs to ensure that when it exits into non-64-bit mode and next time when a value result is read, that value has the first 192 bits reset to zero. The EVM interpreter can therefore use a typed stack for optimization:
 
 ```haskell
 type StackItem = Value U256 | Value64 U64
@@ -115,14 +115,14 @@ It is possible to extend EVM64 where "64-bit mode" is instead defined as "little
 * `MLOAD64` and `MSTORE64` loads and store little-endian 64-bit values in memory.
 * `PUSH*64` (`PUSH1` to `PUSH8`) accepts literal little-endian bytes.
 
-In specification there is no issue with the design, but this can bring signficant confusions to developers. So the author advise caution.
+In specification there is no issue with the design, but this can bring significant confusions to developers. So the author advise caution.
 
 #### `POP`, `DUP*`, `SWAP*`
 
 There is no explicit 64-bit mode for stack operations:
 
 * `POP` is "automatically 64-bit" because it only removes values from the stack.
-* `DUP*` and `SWAP*` will copy or swap stack items optimized for 64-bit as is. They are kept optimized, so there's no need for seperate 64-bit mode for those opcodes.
+* `DUP*` and `SWAP*` will copy or swap stack items optimized for 64-bit as is. They are kept optimized, so there's no need for separate 64-bit mode for those opcodes.
 
 #### Drawbacks
 


### PR DESCRIPTION


# Description:  
1. Corrected `noticable` → `noticeable`
2. Corrected `optmization` → `optimization`
3. Corrected `signficant` → `significant`
4. Corrected `seperate` → `separate`

