### PR TITLE
Add EIP: Further increase calldata cost

### DIFF
--- a/EIPS/eip-7976.md
+++ b/EIPS/eip-7976.md
@@ -20,6 +20,7 @@ Following the implementation of [EIP-7623](./eip-7623.md), this EIP proposes a f
 While [EIP-7623](./eip-7623.md) successfully reduced the maximum possible block size by introducing a floor cost of 10/40 gas per byte for data-heavy transactions, continued increases in gas limit demands further optimization. The current floor cost still permits relatively large data-heavy payloads that contribute to block size variance.
 
 By increasing the floor cost to 15/60 gas per byte, this proposal aims to:
+
 - Further reduce the maximum possible block size for data-heavy transactions
 - Create additional headroom for potential block gas limit increases
 - Maintain the same exemption for transactions with significant EVM computation
@@ -61,6 +62,7 @@ Any transaction with a gas limit below `21000 + TOTAL_COST_FLOOR_PER_TOKEN * tok
 With [EIP-7623](./eip-7623.md)'s implementation, data-heavy transactions cost 10/40 gas per zero/non-zero byte, reducing the maximum possible EL payload size to approximately 0.72 MB (`30_000_000/40`). This EIP further reduces this to approximately 0.47 MB (`30_000_000/60`) for zero bytes and maintains proportional costs for non-zero bytes.
 
 By increasing calldata costs from 10/40 to 15/60 gas per byte for data-heavy transactions, this EIP provides:
+
 - **Enhanced block size reduction**: Maximum data-heavy payload size drops to ~0.47 MB
 - **Maintained user experience**: Regular users engaging in DeFi, token transfers, and other EVM-heavy operations remain unaffected
 - **Better blob incentivization**: Higher calldata costs further encourage migration to blob usage for data availability
@@ -94,6 +96,7 @@ Testing for this EIP should verify the correct application of the new calldata c
 As the maximum possible block size is further reduced compared to [EIP-7623](./eip-7623.md), no additional security concerns are introduced beyond those already addressed in the original proposal.
 
 The same transaction bundling considerations from [EIP-7623](./eip-7623.md) apply:
+
 1. Transaction bundling was already possible and remains so
 2. Bundling does not compromise the block size reduction objectives
 3. Practical limitations (trust, coordination) continue to limit widespread bundling

--- a/EIPS/eip-7976.md
+++ b/EIPS/eip-7976.md
@@ -1,9 +1,9 @@
 ---
-eip: XXXX
+eip: 7976
 title: Further increase calldata cost
 description: Further increase calldata cost to 15/60 gas per byte to reduce maximum block size
 author: Toni Wahrstätter (@nerolation)
-discussions-to: https://ethereum-magicians.org/t/eip-xxxx-further-increase-calldata-cost/24597
+discussions-to: https://ethereum-magicians.org/t/eip-7976-further-increase-calldata-cost/24597
 status: Draft
 type: Standards Track
 category: Core

--- a/EIPS/eip-xxxx.md
+++ b/EIPS/eip-xxxx.md
@@ -3,7 +3,7 @@ eip: XXXX
 title: Further increase calldata cost
 description: Further increase calldata cost to 15/60 gas per byte to reduce maximum block size
 author: Toni Wahrstätter (@nerolation)
-discussions-to: https://ethereum-magicians.org/t/eip-xxxx-further-increase-calldata-cost/XXXXX
+discussions-to: https://ethereum-magicians.org/t/eip-xxxx-further-increase-calldata-cost/24597
 status: Draft
 type: Standards Track
 category: Core

--- a/EIPS/eip-xxxx.md
+++ b/EIPS/eip-xxxx.md
@@ -79,6 +79,16 @@ Wallet developers and node operators MUST update gas estimation handling to acco
 
 Users can maintain their usual workflows without modification, as wallet and RPC updates will handle these changes.
 
+## Test Cases
+
+Testing for this EIP should verify the correct application of the new calldata cost floor of 15/60 gas per zero/non-zero byte:
+
+1. **Data-heavy transactions**: Verify transactions with minimal EVM execution pay the floor cost of 15 gas per calldata token
+2. **EVM-heavy transactions**: Confirm transactions with significant computation continue using standard 4/16 gas per byte
+3. **Edge cases**: Test transactions at the boundary where execution gas equals or exceeds the floor cost
+4. **Gas estimation**: Validate that `eth_estimateGas` correctly accounts for the new `TOTAL_COST_FLOOR_PER_TOKEN` value
+5. **Invalid transactions**: Ensure transactions with insufficient gas limits are properly rejected
+
 ## Security Considerations
 
 As the maximum possible block size is further reduced compared to [EIP-7623](./eip-7623.md), no additional security concerns are introduced beyond those already addressed in the original proposal.

--- a/EIPS/eip-xxxx.md
+++ b/EIPS/eip-xxxx.md
@@ -1,0 +1,95 @@
+---
+eip: XXXX
+title: Further increase calldata cost
+description: Further increase calldata cost to 15/60 gas per byte to reduce maximum block size
+author: Toni Wahrstätter (@nerolation)
+discussions-to: https://ethereum-magicians.org/t/eip-xxxx-further-increase-calldata-cost/XXXXX
+status: Draft
+type: Standards Track
+category: Core
+created: 2025-06-18
+requires: 7623
+---
+
+## Abstract
+
+Following the implementation of [EIP-7623](./eip-7623.md), this EIP proposes a further adjustment to calldata pricing by raising the floor cost from 10/40 to 15/60 gas per zero/non-zero byte. This change aims to provide additional reduction in maximum block size and variance while maintaining compatibility with regular user transactions that involve significant EVM computation.
+
+## Motivation
+
+While [EIP-7623](./eip-7623.md) successfully reduced the maximum possible block size by introducing a floor cost of 10/40 gas per byte for data-heavy transactions, continued increases in gas limit demands further optimization. The current floor cost still permits relatively large data-heavy payloads that contribute to block size variance.
+
+By increasing the floor cost to 15/60 gas per byte, this proposal aims to:
+- Further reduce the maximum possible block size for data-heavy transactions
+- Create additional headroom for potential block gas limit increases
+- Maintain the same exemption for transactions with significant EVM computation
+
+## Specification
+
+| Parameter                    | Value |
+| ---------------------------- | ----- |
+| `STANDARD_TOKEN_COST`        | `4`   |
+| `TOTAL_COST_FLOOR_PER_TOKEN` | `15`  |
+
+Let `tokens_in_calldata = zero_bytes_in_calldata + nonzero_bytes_in_calldata * 4`.
+
+Let `isContractCreation` be a boolean indicating the respective event.
+
+Let `execution_gas_used` be the gas used for EVM execution with the gas refund subtracted.
+
+Let `INITCODE_WORD_COST` be 2 as defined in [EIP-3860](./eip-3860.md).
+
+The formula for determining the gas used per transaction changes from [EIP-7623](./eip-7623.md)'s implementation to:
+
+```python
+tx.gasUsed = (
+    21000
+    +
+    max(
+        STANDARD_TOKEN_COST * tokens_in_calldata
+        + execution_gas_used
+        + isContractCreation * (32000 + INITCODE_WORD_COST * words(calldata)),
+        TOTAL_COST_FLOOR_PER_TOKEN * tokens_in_calldata
+    )
+)
+```
+
+Any transaction with a gas limit below `21000 + TOTAL_COST_FLOOR_PER_TOKEN * tokens_in_calldata` or below its intrinsic gas cost (take the maximum of these two calculations) is considered invalid. This limitation exists because transactions must cover the floor price of their calldata without relying on the execution of the transaction. There are valid cases where `gasUsed` will be below this floor price, but the floor price needs to be reserved in the transaction gas limit.
+
+## Rationale
+
+With [EIP-7623](./eip-7623.md)'s implementation, data-heavy transactions cost 10/40 gas per zero/non-zero byte, reducing the maximum possible EL payload size to approximately 0.72 MB (`30_000_000/40`). This EIP further reduces this to approximately 0.47 MB (`30_000_000/60`) for zero bytes and maintains proportional costs for non-zero bytes.
+
+By increasing calldata costs from 10/40 to 15/60 gas per byte for data-heavy transactions, this EIP provides:
+- **Enhanced block size reduction**: Maximum data-heavy payload size drops to ~0.47 MB
+- **Maintained user experience**: Regular users engaging in DeFi, token transfers, and other EVM-heavy operations remain unaffected
+- **Better blob incentivization**: Higher calldata costs further encourage migration to blob usage for data availability
+
+The floor cost mechanism ensures that transactions involving significant EVM computation continue to pay the standard 4/16 gas per byte for calldata, preserving the user experience for regular Ethereum operations.
+
+## Backwards Compatibility
+
+This is a backwards incompatible gas repricing that requires a scheduled network upgrade.
+
+Wallet developers and node operators MUST update gas estimation handling to accommodate the new calldata cost rules. Specifically:
+
+1. **Wallets**: Wallets using `eth_estimateGas` MUST be updated to ensure that they correctly account for the updated `TOTAL_COST_FLOOR_PER_TOKEN` parameter of 15. Failure to do so could result in underestimating gas, leading to failed transactions.
+
+2. **Node Software**: RPC methods such as `eth_estimateGas` MUST incorporate the updated formula for gas calculation with the new floor cost values.
+
+Users can maintain their usual workflows without modification, as wallet and RPC updates will handle these changes.
+
+## Security Considerations
+
+As the maximum possible block size is further reduced compared to [EIP-7623](./eip-7623.md), no additional security concerns are introduced beyond those already addressed in the original proposal.
+
+The same transaction bundling considerations from [EIP-7623](./eip-7623.md) apply:
+1. Transaction bundling was already possible and remains so
+2. Bundling does not compromise the block size reduction objectives
+3. Practical limitations (trust, coordination) continue to limit widespread bundling
+
+The increased floor cost strengthens the incentive structure for appropriate data availability method selection without introducing new attack vectors.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](../LICENSE.md).


### PR DESCRIPTION
Raise calldata floor cost to 15/60 gas to reduce max block size