### PR TITLE
Update EIP-7898: Fix typos in EIP-7898

### DIFF
--- a/EIPS/eip-7898.md
+++ b/EIPS/eip-7898.md
@@ -16,7 +16,7 @@ Currently, the beacon block in Ethereum Consensus embed transactions within `Exe
 
 However, this EIP makes no change to the block import mechanism, with the exception that block availability now includes waiting for the availability of `ExecutionPayloadWithInclusionProof`, making it different and simpler from proposals like ePBS/APS.
 
-But this availability requirement can infact be restricted to `gossip` import while allowing optimistic syncing of the execution layer (EL) on checkpoint/range sync as EL can pull full blocks from their peers in optimistic sync as they do now.
+But this availability requirement can in fact be restricted to `gossip` import while allowing optimistic syncing of the execution layer (EL) on checkpoint/range sync as EL can pull full blocks from their peers in optimistic sync as they do now.
 
 ## Motivation
 
@@ -42,9 +42,9 @@ Furthermore CL clients apis and code path will become cleaner and more maintaina
 - `ExecutionPayload` in the `BeaconBlockBody` is replaced by `ExecutionPayloadHeader`
 - `ExecutionPayloadWithInclusionProof` is computed by the block proposer/builder and gossiped independently on a separate new topic. Also builder `submitBlindedBlock` api is modified to respond with `ExecutionPayloadWithInclusionProof` instead.
 - Data availability checks for block import into forkchoice now must wait for availability of the corresponding `ExecutionPayloadWithInclusionProof` but only for gossiped blocks
-- `newPayloadHeader` engine api is introduced to augument the previous usage of `newPayload` in block processing when `ExecutionPayload` is not available for e.g. in processing range synced blocks signalling EL clients to optimistic sync those payloads from EL p2p network.
+- `newPayloadHeader` engine api is introduced to argument the previous usage of `newPayload` in block processing when `ExecutionPayload` is not available for e.g. in processing range synced blocks signalling EL clients to optimistic sync those payloads from EL p2p network.
 
-ELs can optionally introduce a `getExecutionPayload` method (similar to `getBlobs`) to assist with faster recovery of execution payload from the EL's p2p network peers who could annouce new payload hashes when they see new `VALID` payloads. However, as noted above, that mechanism could be independently specified and is out of scope for this EIP.
+ELs can optionally introduce a `getExecutionPayload` method (similar to `getBlobs`) to assist with faster recovery of execution payload from the EL's p2p network peers who could announce new payload hashes when they see new `VALID` payloads. However, as noted above, that mechanism could be independently specified and is out of scope for this EIP.
 
 <-- TODO: add spec details -->
 

--- a/EIPS/eip-7898.md
+++ b/EIPS/eip-7898.md
@@ -42,7 +42,7 @@ Furthermore CL clients apis and code path will become cleaner and more maintaina
 - `ExecutionPayload` in the `BeaconBlockBody` is replaced by `ExecutionPayloadHeader`
 - `ExecutionPayloadWithInclusionProof` is computed by the block proposer/builder and gossiped independently on a separate new topic. Also builder `submitBlindedBlock` api is modified to respond with `ExecutionPayloadWithInclusionProof` instead.
 - Data availability checks for block import into forkchoice now must wait for availability of the corresponding `ExecutionPayloadWithInclusionProof` but only for gossiped blocks
-- `newPayloadHeader` engine api is introduced to argument the previous usage of `newPayload` in block processing when `ExecutionPayload` is not available for e.g. in processing range synced blocks signalling EL clients to optimistic sync those payloads from EL p2p network.
+- `newPayloadHeader` engine api is introduced to augment the previous usage of `newPayload` in block processing when `ExecutionPayload` is not available for e.g. in processing range synced blocks signalling EL clients to optimistic sync those payloads from EL p2p network.
 
 ELs can optionally introduce a `getExecutionPayload` method (similar to `getBlobs`) to assist with faster recovery of execution payload from the EL's p2p network peers who could announce new payload hashes when they see new `VALID` payloads. However, as noted above, that mechanism could be independently specified and is out of scope for this EIP.
 


### PR DESCRIPTION


**Description:**

This PR corrects a few typos in the EIP-7898 specification.

Changes:
*   `infact` → `in fact`
*   `augument` → `augment`
*   `annouce` → `announce`

