### PR TITLE
Update EIP-7928: specify nonce diffs as post-tx nonces for contract accounts which modified their nonce

### DIFF
--- a/EIPS/eip-7928.md
+++ b/EIPS/eip-7928.md
@@ -154,7 +154,7 @@ def state_transition(block):
         for address, nonce in nonce_info:
             if address not in computed_nonce_diffs:
                 computed_nonce_diffs[address] = []
-            computed_nonce_diffs.push((idx, nonce))
+            computed_nonce_diffs[address].push((idx, nonce))
 
         # Execute transaction and collect state accesses and diffs
         accessed, balances, codes = execute_transaction(tx)

--- a/EIPS/eip-7928.md
+++ b/EIPS/eip-7928.md
@@ -43,7 +43,7 @@ We introduce three new components in the block body:
 1. A Block Access List (BAL) that maps transactions to accessed storage locations and post-execution values for writes.
 2. Balance Diffs that track every address touched by value transfers along with the balance deltas.
 3. Code Diffs that track every address and the deployed code to it.
-4. Nonce Diffs that record the pre-block nonces of contracts using `CREATE` or `CREATE2` within the block.
+4. Nonce Diffs that record the post-transaction nonces of accounts which invoke `CREATE` or `CREATE2`.
 
 ### SSZ Data Structures
 
@@ -104,7 +104,7 @@ CodeDiffs = List[AccountCodeDiff, MAX_ACCOUNTS]
 # Nonce Diff structures
 class TxNonceDiff(Container):
     tx_index: TxIndex
-    nonce_before: Nonce # nonce value before transaction execution
+    nonce_after: Nonce # nonce value after transaction execution
 
 class AccountNonceDiff(Container):
     address: Address
@@ -135,7 +135,7 @@ Each entry MUST include the transaction index and the signed balance delta per a
 The `CodeDiff` structure tracks every deployed/changed contract with it's post-transaction runtime byte code.
 Each entry MUST include the transaction index and the contract bytecode for each transaction with a contract deployment.
 
-The `NonceDiffs` structure MUST record the pre-transaction nonce values for all `CREATE` and `CREATE2` deployer accounts and the deployed contracts in the block. This includes nonce increases that occur at the deployer contract even when deployments using `CREATE` or `CREATE2` revert, as specified in [EIP-7610](./eip-7610.md).
+The `NonceDiffs` structure MUST record the post-transaction nonce values for all accounts whose nonces were increased as a result of a successful `CREATE`/`CREATE2` invocation.
 
 ### State Transition Function
 
@@ -153,7 +153,8 @@ def state_transition(block):
         nonce_info = get_nonce_info(tx)
         for address, nonce in nonce_info:
             if address not in computed_nonce_diffs:
-                computed_nonce_diffs[address] = nonce
+                computed_nonce_diffs[address] = []
+            computed_nonce_diffs.push((idx, nonce))
 
         # Execute transaction and collect state accesses and diffs
         accessed, balances, codes = execute_transaction(tx)


### PR DESCRIPTION
In order to parallelize block transaction execution and state root calculation, we need post-tx nonce values for contract accounts which created other contracts.  If we only have prestate nonces, we would need to execute the final block transaction before being able to calculate the state root.

Also, I don't see a need to include the nonce values for contracts which invoked a `CREATE`/`CREATE2` that reverted.  It's not information that needs to be known in order to execute subsequent txs in the block.