### PR TITLE
Update EIP-7928: Fix BAL type definition

### DIFF
--- a/EIPS/eip-7928.md
+++ b/EIPS/eip-7928.md
@@ -110,13 +110,13 @@ class AccountNonceDiff(Container):
     address: Address
     changes: List[TxNonceDiff, MAX_TXS]
 
-NonceDiffs = List[AccountNonceDiff, MAX_TXS]
+NonceDiffs = List[AccountNonceDiff, MAX_ACCOUNTS]
 
 # Block-level Access List structure
 class BlockAccessList(Container):
     account_accesses: AccountAccessList
     balance_diffs: BalanceDiffs
-    code_diffs: AccountCodeDiffs
+    code_diffs: CodeDiffs
     nonce_diffs: NonceDiffs
 ```
 
@@ -154,7 +154,7 @@ def state_transition(block):
         for address, nonce in nonce_info:
             if address not in computed_nonce_diffs:
                 computed_nonce_diffs[address] = []
-            computed_nonce_diffs[address].push((idx, nonce))
+            computed_nonce_diffs[address].append((idx, nonce))
 
         # Execute transaction and collect state accesses and diffs
         accessed, balances, codes = execute_transaction(tx)


### PR DESCRIPTION
This PR fixes two issues with BAL type definition:
1. `code_diffs` should be of type `CodeDiffs`.
2.  `NonceDiffs` is defined as `List[AccountNonceDiff, MAX_TXS]` but should be `List[AccountNonceDiff, MAX_ACCOUNTS]`
  since it's tracking accounts, not transactions.

Additionally it fixes a small python syntax error:
1. `.push()` should be `.append()`