### PR TITLE
Update EIP-7805: Separate full txs from IL

### DIFF
--- a/EIPS/eip-7805.md
+++ b/EIPS/eip-7805.md
@@ -1,7 +1,7 @@
 ---
 eip: 7805
 title: Fork-choice enforced Inclusion Lists (FOCIL)
-description:Allow a committee of validators to force-include a set of transaction hashes in every block, with full transactions provided as sidecars
+description: Allow a committee of validators to force-include a set of transaction hashes in every block, with full transactions provided as sidecars
 author: Thomas Thiery (@soispoke) <thomas.thiery@ethereum.org>, Francesco D'Amato <francesco.damato@ethereum.org>, Julian Ma <julian.ma@ethereum.org>, Barnabé Monnot <barnabe.monnot@ethereum.org>, Terence Tsao <ttsao@offchainlabs.com>, Jacob Kaufmann <jacob.kaufmann@ethereum.org>, Jihoon Song <jihoonsong.dev@gmail.com>
 discussions-to: https://ethereum-magicians.org/t/eip-7805-committee-based-fork-choice-enforced-inclusion-lists-focil/21578
 status: Draft
@@ -183,6 +183,7 @@ rlp([signed_inclusion_list, transactions])
 ```
 
 Where:
+
 - `signed_inclusion_list` - is the standard `SignedInclusionList` object containing transaction hashes
 - `transactions` - list of full `Transaction` objects corresponding to the hashes in the inclusion list
 


### PR DESCRIPTION
 ## Split transactions from inclusion lists into hash+full txs pattern

 This PR modifies FOCIL to use transaction hashes in the signed inclusion lists instead of full transactions, with full transaction data traveling attached.

 *Key changes:*
  - InclusionList container now contains transaction_hashes instead of transactions
  - Added networking section with RLP wrapper: rlp([signed_inclusion_list, transactions])
  - Updated validation rules to verify hash-to-transaction correspondence
  - Consensus layer only handles hashes, full transactions remain separate

*Why this matters:*
Proposers can now efficiently prove IL equivocation without needing access to complete transaction data - they only need the conflicting hash lists. This reduces bandwidth on the consensus layer while maintaining full transaction availability.