### PR TITLE
Update EIP-2926: Move to Draft

### DIFF
--- a/EIPS/eip-2926.md
+++ b/EIPS/eip-2926.md
@@ -44,6 +44,8 @@ What follows is structured to have two sections:
 
 For an account record `A` with code `C`, two extra optional fields are added: `A.codeSize` and `A.codeRoot`. `A.codeHash` is retained to serve `EXTCODEHASH`.
 
+If `C` is empty, i.e. in the case of an EoA, `A.codeRoot` and `A.codeSize` are omitted from the account's RLP. This is intended to limit the size overhead of this change.
+
 If `C` is not empty:
 
  - `A.codeSize = len(code)`
@@ -59,8 +61,6 @@ The `i`th element of `chunks` is stored in `codeTrie` with:
 
 - Key: `BE(i, 4)`
 - Value: `BE(FIO_i, 1) || code_i`, where `||` stands for byte-wise concatenation
-
-If `C` is empty, `A.codeRoot` and `A.codeSize` are omitted from the account's RLP. This is intended to limit the size overhead of this change.
 
 #### Contract creation gas cost
 
@@ -133,10 +133,6 @@ Show the `codeRoot` for the following cases:
 1. `code=''`
 2. `code='PUSH1(0) DUP1 REVERT'`
 3. `code='PUSH32(-1)'` (data passing through a chunk boundary)
-
-## Implementation
-
-The implementation for the previous version of this EIP, i.e. the chunking and merkleization logic in Typescript can be found [here](https://github.com/ewasm/biturbo/blob/merklize-mainnet-blocks/src/relayer/bytecode.ts#L172), and in Python [here](https://github.com/hugo-dc/code-chunks/). Please note neither of these examples currently use a binary tree.
 
 ## Security Considerations
 

--- a/EIPS/eip-2926.md
+++ b/EIPS/eip-2926.md
@@ -71,6 +71,7 @@ As of now there is a charge of 200 gas per byte of the code stored in state by c
 The transition process involves reading all contracts in the state and applying the above procedure to them. A process simliar to [EIP-7612](./eip-7612.md) is to be used, as the total code size at the time of this EIP edit is >10GB and can not be processed in a single block.
 
 Note that:
+
  - Because multiple accounts can share the same code hash, the whole account tree needs to be iterated over to convert each account.
  - Nonetheless, the conversion process should take a few hours, instead of days for a full tree change.
 

--- a/EIPS/eip-2926.md
+++ b/EIPS/eip-2926.md
@@ -34,7 +34,7 @@ What follows is structured to have two sections:
 - `VERSION`: 0
 - `EMPTY_CODE_ROOT`: `0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470` (==`keccak256('')`)
 - `HF_TIMESTAMP`: to be defined
-- `ITERATOR_STRIDE`: `50_000`
+- `ITERATOR_STRIDE`: `TBC` but based on verkle numbers, first devnets should use `50_000`
 
 #### Definitions
 
@@ -42,9 +42,11 @@ What follows is structured to have two sections:
 
 ### Code merkleization
 
-For an account record `A` with code `C`, two extra optional fields are added: `A.codeSize` and `A.codeRoot`. If `C` is not empty:
+For an account record `A` with code `C`, two extra optional fields are added: `A.codeSize` and `A.codeRoot`. `A.codeHash` is retained to serve `EXTCODEHASH`.
 
- - `A.codeSize = BE()`
+If `C` is not empty:
+
+ - `A.codeSize = len(code)`
  - `A.codeRoot` contains the root of `codeTrie`, a trie with the following leaves:
    - Key: `VERSION_KEY`, value: `BE(VERSION, 1)`
    - A list of code `chunks = [(FIO_0, code_0), ..., (FIO_n, code_n)]` which are derived from `C` as follows:
@@ -58,19 +60,28 @@ The `i`th element of `chunks` is stored in `codeTrie` with:
 - Key: `BE(i, 4)`
 - Value: `BE(FIO_i, 1) || code_i`, where `||` stands for byte-wise concatenation
 
+If `C` is empty, `A.codeRoot` and `A.codeSize` are omitted from the account's RLP. This is intended to limit the size overhead of this change.
+
 #### Contract creation gas cost
 
 As of now there is a charge of 200 gas per byte of the code stored in state by contract creation operations, be it initiated via `CREATE`, `CREATE2`, or an external transaction. This per byte cost is to be increased from `200` to `500` to account for the chunking and merkleization costs. This number is inherited from [EIP-4762](./eip-4762.md) and is picked for forward-compatibility.
 
 ### Updating existing code (transition process)
 
-The transition process involves reading all contracts in the state and applying the above procedure to them. A process simiar to [EIP-7612](./eip-7612.md) is to be used, as the total code size at the time of this EIP edit is >10GB and can not be processed in a single block. Nonetheless, the conversion process should take minutes instead of days for a full tree conversion.
+The transition process involves reading all contracts in the state and applying the above procedure to them. A process simliar to [EIP-7612](./eip-7612.md) is to be used, as the total code size at the time of this EIP edit is >10GB and can not be processed in a single block.
+
+Note that:
+ - Because multiple accounts can share the same code hash, the whole account tree needs to be iterated over to convert each account.
+ - Nonetheless, the conversion process should take a few hours, instead of days for a full tree change.
 
 At `HF_TIMESTAMP` the EIP gets activated:
 
- - any contract creationi and 7702 delegation updates must use the new format.
-   - for 7702 accounts, the code size is set to `23`, and any call checking the code size/hash are forwarded to the delegated account.
- - after executing any transaction, the client must convert `ITERATOR_STRIDE` accounts in the tree.
+ - any contract creation and 7702 delegation updates must use the new format.
+   - for 7702 accounts, the code size is set to `23`, and `CODESIZE`/`CODECOPY` are forwarded to the delegated account. `EXTCODESIZE`/`EXTCODEHASH`/`EXTCODECOPY` behave the same as they did before the activation of this EIP.
+   - accounts are NOT converted in case of a balance or nonce update
+ - after executing any transaction, the client iteraters over `ITERATOR_STRIDE` accounts in the tree, and for each account:
+   - if the account is an EoA or is a contract using the new format, leave that account untouched,
+   - if the account is a "legacy" contract, convert it and write it back to the tree
 
 The value for `ITERATOR_STRIDE` has been chosen to be safe while ensuring the transition process does not last too long. At the current state size and block time, this represents about 10000 blocks, which is about one and a half day.
 
@@ -78,7 +89,7 @@ The value for `ITERATOR_STRIDE` has been chosen to be safe while ensuring the tr
 
 ### Hexary vs binary trie
 
-The trie format is chosen to be the same as that of the account trie. If a tree conversion happens at a later stage, the chunk tree will have to be converted as well, e.g. the way it is in [EIP-6800](./eip-6800.md) or [EIP-76i84](./eip-7684.md).
+The trie format is chosen to be the same as that of the account trie. If a tree conversion happens at a later stage, the chunk tree will have to be converted as well, e.g. the way it is in [EIP-6800](./eip-6800.md) or [EIP-7864](./eip-7864.md).
 
 ### Chunk size
 
@@ -92,7 +103,7 @@ Note: there could be an edge case when computing FIO for the chunks where the da
 
 ### Gas cost of code-accessing opcodes
 
-Details of how the code is stored, is left to the client implementers. However, to reflect the removal of the max code limit and the fact that larger codes will be more expensive to load, a uniform read access cost of 200 warming read cost and an extra 500 write costs are being charged.
+Details of how the code is stored, is left to the client implementers. However, to reflect the removal of the max code limit and the fact that larger codes will be more expensive to load, reading a non-accessed chunk will incur a 200 warming cost, and chunks written beyond the 24kb limit will cost 500 gas instead of 200.
 
 ### Different chunking logic
 
@@ -105,10 +116,6 @@ This approach has downsides compared to the one specified:
 3) Calculating the number of chunks is not trivial and would have to be stored explicitly in the metadata.
 
 Additionally we have reviewed many other options (basic block based, Solidity subroutines (requires determining the control flow), EIP-2315 subroutines). This EIP however only focuses on the chunk-based option.
-
-### RLP and SSZ
-
-To remain consistent with the binary transition proposal we avoid using RLP for serializing the leaf values. We have furthermore considered SSZ for both serializing data and merkleization and remain open to adopting it, but decided to use the binary trie format for simplicity.
 
 ## Backwards Compatibility
 

--- a/EIPS/eip-2926.md
+++ b/EIPS/eip-2926.md
@@ -68,9 +68,9 @@ The transition process involves reading all contracts in the state and applying 
 
 At `HF_TIMESTAMP` the EIP gets activated:
 
- * any contract creationi and 7702 delegation updates must use the new format.
-   * for 7702 accounts, the code size is set to `23`, and any call checking the code size/hash are forwarded to the delegated account.
- * after executing any transaction, the client must convert `ITERATOR_STRIDE` accounts in the tree.
+ - any contract creationi and 7702 delegation updates must use the new format.
+   - for 7702 accounts, the code size is set to `23`, and any call checking the code size/hash are forwarded to the delegated account.
+ - after executing any transaction, the client must convert `ITERATOR_STRIDE` accounts in the tree.
 
 The value for `ITERATOR_STRIDE` has been chosen to be safe while ensuring the transition process does not last too long. At the current state size and block time, this represents about 10000 blocks, which is about one and a half day.
 
@@ -99,6 +99,7 @@ Details of how the code is stored, is left to the client implementers. However, 
 We have considered an alternative option to package chunks, where each chunk is prepended with its `chunkLength` and would only contain complete opcodes (i.e. any multi-byte opcode not fitting the `CHUNK_SIZE` would be deferred to the next chunk).
 
 This approach has downsides compared to the one specified:
+
 1) Requires a larger `CHUNK_SIZE` -- at least 33 bytes to accommodate the `PUSH32` instruction.
 2) It is more wasteful. For example, `DUP1 PUSH32 <32-byte payload>` would be encoded as two chunks, the first chunk contains only `DUP1`, and the second contains only the `PUSH32` instruction with its payload.
 3) Calculating the number of chunks is not trivial and would have to be stored explicitly in the metadata.
@@ -134,4 +135,5 @@ The implementation for the previous version of this EIP, i.e. the chunking and m
 TBA
 
 ## Copyright
+
 Copyright and related rights waived via [CC0](../LICENSE.md).

--- a/EIPS/eip-2926.md
+++ b/EIPS/eip-2926.md
@@ -3,7 +3,7 @@ eip: 2926
 title: Chunk-Based Code Merkleization
 author: Sina Mahmoodi (@s1na), Alex Beregszaszi (@axic), Guillaume Ballet (@gballet), Jochem Brouwer (@jochem-brouwer), Ignacio Hagopian (@jsign)
 discussions-to: https://ethereum-magicians.org/t/eip-2926-chunk-based-code-merkleization/4555
-status: Stagnant
+status: Draft
 type: Standards Track
 category: Core
 created: 2020-08-25

--- a/EIPS/eip-2926.md
+++ b/EIPS/eip-2926.md
@@ -79,8 +79,8 @@ At `HF_TIMESTAMP` the EIP gets activated:
  - any contract creation and 7702 delegation updates must use the new format.
    - for 7702 accounts, the code size is set to `23`, and `CODESIZE`/`CODECOPY` are forwarded to the delegated account. `EXTCODESIZE`/`EXTCODEHASH`/`EXTCODECOPY` behave the same as they did before the activation of this EIP.
    - accounts are NOT converted in case of a balance or nonce update
- - after executing any transaction, the client iteraters over `ITERATOR_STRIDE` accounts in the tree, and for each account:
-   - if the account is an EoA or is a contract using the new format, leave that account untouched,
+ - at the end of block processing, and after all transactions have been executed, the client iterates over `ITERATOR_STRIDE` accounts in the tree, and for each account:
+   - if the account has empty code, or is a contract using the new format, leave that account untouched,
    - if the account is a "legacy" contract, convert it and write it back to the tree
 
 The value for `ITERATOR_STRIDE` has been chosen to be safe while ensuring the transition process does not last too long. At the current state size and block time, this represents about 10000 blocks, which is about one and a half day.

--- a/EIPS/eip-2926.md
+++ b/EIPS/eip-2926.md
@@ -1,13 +1,13 @@
 ---
 eip: 2926
 title: Chunk-Based Code Merkleization
-author: Sina Mahmoodi (@s1na), Alex Beregszaszi (@axic)
+author: Sina Mahmoodi (@s1na), Alex Beregszaszi (@axic), Guillaume Ballet (@gballet), Tomasz Stanczak (@tkstanczak)
 discussions-to: https://ethereum-magicians.org/t/eip-2926-chunk-based-code-merkleization/4555
 status: Stagnant
 type: Standards Track
 category: Core
 created: 2020-08-25
-requires: 161, 170, 2584
+requires: 161, 170
 ---
 
 ## Abstract
@@ -20,7 +20,7 @@ Bytecode is currently the [second contributor](https://github.com/mandrigin/ethe
 
 ## Specification
 
-This specification assumes that [EIP-2584](./eip-2584.md) is deployed, and the merkleization rules and gas costs are proposed accordingly. What follows is structured to have two sections:
+What follows is structured to have two sections:
 
 1. How a given contract code is split into chunks and then merkleized
 2. How to merkleize all existing contract codes during a hardfork
@@ -30,14 +30,11 @@ This specification assumes that [EIP-2584](./eip-2584.md) is deployed, and the m
 #### Constants
 
 - `CHUNK_SIZE`: 32 (bytes)
-- `KEY_LENGTH`: 2 (bytes)
-- `MAX_CHUNK_COUNT`: `0xfffc`
-- `VERSION_KEY`: `0xfffd`
-- `CODELEN_KEY`: `0xfffe`
-- `CODEHASH_KEY`: `0xffff`
+- `VERSION_KEY`: `max(u256)`
 - `VERSION`: 0
 - `EMPTY_CODE_ROOT`: `0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470` (==`keccak256('')`)
-- `HF_BLOCK_NUMBER`: to be defined
+- `HF_TIMESTAMP`: to be defined
+- `ITERATOR_STRIDE`: `50_000`
 
 #### Definitions
 
@@ -45,42 +42,43 @@ This specification assumes that [EIP-2584](./eip-2584.md) is deployed, and the m
 
 ### Code merkleization
 
-For an account record `A` with code `C`, the field `A.codeHash` is replaced with `codeRoot`. `codeRoot` is `EMPTY_CODE_ROOT` if `C` is empty. Otherwise it contains the root of `codeTrie`, a [binary trie](https://hackmd.io/uCWOpSrUQaytBgcO0MVkTQ) with the following leaves:
+For an account record `A` with code `C`, two extra optional fields are added: `A.codeSize` and `A.codeRoot`. If `C` is not empty:
 
-- Key: `VERSION_KEY`, value: `BE(VERSION, 1)`
-- Key: `CODELEN_KEY`, value: `BE(length(C), 4)`
-- Key: `CODEHASH_KEY`, value: `keccak256(C)`
-
-In addition to the above, `codeTrie` commits to a list of code `chunks = [(FIO_0, code_0), ..., (FIO_n, code_n)]` which are derived from `C` in a way that:
-
-- `n < MAX_CHUNK_COUNT`.
-- `code_0 || ... || code_n == C`.
-- `length(code_i) == CHUNK_SIZE` where `0 <= i < n`.
-- `length(code_n) <= CHUNK_SIZE`.
-- `FIO_i` is the offset of the first instruction within the chunk. It should only be greater than zero if the last instruction in `code_i-1` is a multi-byte instruction (like `PUSHN`) crossing the chunk boundary. It is set to `CHUNK_SIZE` in the case where all bytes of a chunk are data.
+ - `A.codeSize = BE()`
+ - `A.codeRoot` contains the root of `codeTrie`, a trie with the following leaves:
+   - Key: `VERSION_KEY`, value: `BE(VERSION, 1)`
+   - A list of code `chunks = [(FIO_0, code_0), ..., (FIO_n, code_n)]` which are derived from `C` as follows:
+     - `code_0 || ... || code_n == C`.
+     - `length(code_i) == CHUNK_SIZE` where `0 <= i < n`.
+     - `length(code_n) <= CHUNK_SIZE`.
+     - `FIO_i` is the offset of the first instruction within the chunk. It should only be greater than zero if the last instruction in `code_i-1` is a multi-byte instruction (like `PUSHN`) crossing the chunk boundary. It is set to `CHUNK_SIZE` in the case where all bytes of a chunk are data.
 
 The `i`th element of `chunks` is stored in `codeTrie` with:
 
-- Key: `BE(i, KEY_LENGTH)`
+- Key: `BE(i, 4)`
 - Value: `BE(FIO_i, 1) || code_i`, where `||` stands for byte-wise concatenation
 
 #### Contract creation gas cost
 
-As of now there is a charge of 200 gas per byte of the code stored in state by contract creation operations, be it initiated via `CREATE`, `CREATE2`, or an external transaction. This per byte cost is to be increased from `200` to `TBD` to account for the chunking and merkleization costs.
+As of now there is a charge of 200 gas per byte of the code stored in state by contract creation operations, be it initiated via `CREATE`, `CREATE2`, or an external transaction. This per byte cost is to be increased from `200` to `500` to account for the chunking and merkleization costs. This number is inherited from [EIP-4762](./eip-4762.md) and is picked for forward-compatibility.
 
 ### Updating existing code (transition process)
 
-The transition process involves reading all contracts in the state and applying the above procedure to them. A benchmark showing how long this process will take is still pending, but intuitively it should take longer than the time between two blocks (in the order of hours). Hence we recommend clients to pre-process the changes before the EIP is activated.
+The transition process involves reading all contracts in the state and applying the above procedure to them. A process simiar to [EIP-7612](./eip-7612.md) is to be used, as the total code size at the time of this EIP edit is >10GB and can not be processed in a single block. Nonetheless, the conversion process should take minutes instead of days for a full tree conversion.
 
-Code has the nice property that it is (mostly) static. Therefore clients can maintain a mapping of `[accountAddress -> codeRoot]` which stores the results for the contracts they have already merkleized. During this pre-computation phase, whenever a new contract is created its `codeRoot` is computed, and added to the mapping. Whenever a contract self-destructs, its corresponding entry is removed.
+At `HF_TIMESTAMP` the EIP gets activated:
 
-At block `HF_BLOCK_NUMBER` when the EIP gets activated, before executing any transaction the client must update the account record for all contracts with non-empty code in the state to replace the `codeHash` field with the pre-computed `codeRoot`. EoA accounts will keep their `codeHash` value as `codeRoot`. *Accounts with empty code will keep their `codeHash` value as `codeRoot`.*
+ * any contract creationi and 7702 delegation updates must use the new format.
+   * for 7702 accounts, the code size is set to `23`, and any call checking the code size/hash are forwarded to the delegated account.
+ * after executing any transaction, the client must convert `ITERATOR_STRIDE` accounts in the tree.
+
+The value for `ITERATOR_STRIDE` has been chosen to be safe while ensuring the transition process does not last too long. At the current state size and block time, this represents about 10000 blocks, which is about one and a half day.
 
 ## Rationale
 
 ### Hexary vs binary trie
 
-The Ethereum mainnet state is encoded as of now in a hexary Merkle Patricia Tree. As part of the Eth1x roadmap, a transition to a [binary trie](https://ethresear.ch/t/binary-trie-format/7621) has been [investigated](https://medium.com/@mandrigin/stateless-ethereum-binary-tries-experiment-b2c035497768) with the goal of reducing witness sizes. Because code chunks are also stored in the trie, this EIP would benefit from the witness size reduction offered by the binarification. Therefore we have decided to explicitly state [EIP-2584](./eip-2584.md) to be a requirement of this change. Note that if code merkleization is included in a hard-fork beforehand, then all code must be re-merkleized after the binary transition.
+The trie format is chosen to be the same as that of the account trie. If a tree conversion happens at a later stage, the chunk tree will have to be converted as well, e.g. the way it is in [EIP-6800](./eip-6800.md) or [EIP-76i84](./eip-7684.md).
 
 ### Chunk size
 
@@ -94,9 +92,7 @@ Note: there could be an edge case when computing FIO for the chunks where the da
 
 ### Gas cost of code-accessing opcodes
 
-How merkleized code is stored in the client database affects the performance of code-accessing opcodes, i.e: CALL, CALLCODE, DELEGATECALL, STATICCALL, EXTCODESIZE, EXTCODEHASH, and EXTCODECOPY. Storing the code trie with all intermediate nodes in the database implies multiple look-ups to fetch the code of the callee, which is more than the current one look-up (excluding the trie traversal to get the account) required. Note CODECOPY and CODESIZE are not affected since the code for the current contract has already been loaded to memory.
-
-The gas cost analysis in this section assumes a specific way of storing it. In this approach clients only merkleize code once during creation to compute `codeRoot`, but then discard the chunks. They instead store the full bytecode as well as the metadata fields in the database. We believe per-chunk metering for calls would be more easily solvable by witness metering in the stateless model.
+Details of how the code is stored, is left to the client implementers. However, to reflect the removal of the max code limit and the fact that larger codes will be more expensive to load, a uniform read access cost of 200 warming read cost and an extra 500 write costs are being charged.
 
 ### Different chunking logic
 
@@ -112,26 +108,6 @@ Additionally we have reviewed many other options (basic block based, Solidity su
 ### RLP and SSZ
 
 To remain consistent with the binary transition proposal we avoid using RLP for serializing the leaf values. We have furthermore considered SSZ for both serializing data and merkleization and remain open to adopting it, but decided to use the binary trie format for simplicity.
-
-### Metadata fields
-
-The metadata fields `version`, `codeLen` and `codeHash` are added mostly to facilitate a cheaper implementation of `EXTCODESIZE` and `EXTCODEHASH` in a stateless paradigm. The version field allows for differentiating between bytecode types (e.g. [EVM1.5/EIP-615](./eip-615.md), [EIP-2315](./eip-2315.md), etc.) or code merkleization schemes (or merkleization settings, such as larger `CHUNK_SIZE`) in future.
-
-Instead of encoding `codeHash` and `codeSize` in the metadata, they could be made part of the account. In our opinion, the metadata is a more concise option, because EoAs do not need these fields, resulting in either additional logic (to omit those fields in the accounts) or calculation (to include them in merkleizing the account).
-
-An alternative option to the version field would be to add an account-level field: either following [EIP-1702](./eip-1702.md), or by adding an `accountKind` field (with potential options: `eoa`, `merkleized_evm_chunk32`, `merkleized_eip2315_chunk64`, etc.) as the first member of the account. One benefit this could provide is omitting `codeHash` for EoAs.
-
-### The keys in the code trie (and `KEY_LENGTH`)
-
-As explained in the specification above, the keys in the code trie are indices of the `chunks` array. Having a key length of 2 bytes means the trie can address 65536 - 3 (minus metadata fields) chunks, which corresponds to ~2Mb code size. That allows for roughly ~85x increase in the code size limit in future without requiring a change in merkleization.
-
-### Alternate values of codeRoot for EoAs
-
-This proposal changes the meaning of the fourth field (`codeHash`) of the account. Prior to this change, that field represents the Keccak-256 hash of the bytecode, which is logically hash of an empty input for EoAs.
-
-Since `codeHash` is replaced with `codeRoot`, the root hash of the code trie, the value would be different for EoAs under the new rules: the root of the `codeTrie(metadata=[codeHash=keccak256(''), codeSize=0])`. An alternative would be simply using the hash of an empty trie. Or to avoid introducing yet another constant (the result of the above), one could also consider using `codeRoot = 0` for EoAs.
-
-However, we wanted to maintain compatibility with [EIP-1052](./eip-1052.md) and decided to keep matters simple by using the hash of empty input (`c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470`) for EoAs.
 
 ## Backwards Compatibility
 
@@ -151,7 +127,7 @@ Show the `codeRoot` for the following cases:
 
 ## Implementation
 
-The implementation of the chunking and merkleization logic in Typescript can be found [here](https://github.com/ewasm/biturbo/blob/merklize-mainnet-blocks/src/relayer/bytecode.ts#L172), and in Python [here](https://github.com/hugo-dc/code-chunks/). Please note neither of these examples currently use a binary tree.
+The implementation for the previous version of this EIP, i.e. the chunking and merkleization logic in Typescript can be found [here](https://github.com/ewasm/biturbo/blob/merklize-mainnet-blocks/src/relayer/bytecode.ts#L172), and in Python [here](https://github.com/hugo-dc/code-chunks/). Please note neither of these examples currently use a binary tree.
 
 ## Security Considerations
 

--- a/EIPS/eip-2926.md
+++ b/EIPS/eip-2926.md
@@ -1,7 +1,7 @@
 ---
 eip: 2926
 title: Chunk-Based Code Merkleization
-author: Sina Mahmoodi (@s1na), Alex Beregszaszi (@axic), Guillaume Ballet (@gballet), Tomasz Stanczak (@tkstanczak)
+author: Sina Mahmoodi (@s1na), Alex Beregszaszi (@axic), Guillaume Ballet (@gballet), Jochem Brouwer (@jochem-brouwer), Ignacio Hagopian (@jsign), Tomasz Stanczak (@tkstanczak)
 discussions-to: https://ethereum-magicians.org/t/eip-2926-chunk-based-code-merkleization/4555
 status: Stagnant
 type: Standards Track

--- a/EIPS/eip-2926.md
+++ b/EIPS/eip-2926.md
@@ -1,7 +1,7 @@
 ---
 eip: 2926
 title: Chunk-Based Code Merkleization
-author: Sina Mahmoodi (@s1na), Alex Beregszaszi (@axic), Guillaume Ballet (@gballet), Jochem Brouwer (@jochem-brouwer), Ignacio Hagopian (@jsign), Tomasz Stanczak (@tkstanczak)
+author: Sina Mahmoodi (@s1na), Alex Beregszaszi (@axic), Guillaume Ballet (@gballet), Jochem Brouwer (@jochem-brouwer), Ignacio Hagopian (@jsign)
 discussions-to: https://ethereum-magicians.org/t/eip-2926-chunk-based-code-merkleization/4555
 status: Stagnant
 type: Standards Track

--- a/EIPS/eip-2926.md
+++ b/EIPS/eip-2926.md
@@ -1,6 +1,7 @@
 ---
 eip: 2926
 title: Chunk-Based Code Merkleization
+description: Introduce code-chunking in an MPT context.
 author: Sina Mahmoodi (@s1na), Alex Beregszaszi (@axic), Guillaume Ballet (@gballet), Jochem Brouwer (@jochem-brouwer), Ignacio Hagopian (@jsign)
 discussions-to: https://ethereum-magicians.org/t/eip-2926-chunk-based-code-merkleization/4555
 status: Draft
@@ -16,7 +17,7 @@ Code merkleization, along with binarification of the trie and gas cost bump of s
 
 ## Motivation
 
-Bytecode is currently the [second contributor](https://github.com/mandrigin/ethereum-mainnet-bin-tries-data) to block witness size, after the proof hashes. Transitioning the trie from hexary to binary reduces the hash section of the witness by 3x, thereby making code the first contributor. By breaking contract code into chunks and committing to those chunks in a merkle tree, stateless clients would only need the chunks that were touched during a given transaction to execute it.
+Bytecode is currently the second contributor to block witness size, after the proof hashes. Transitioning the trie from hexary to binary reduces the hash section of the witness by 3x, thereby making code the first contributor. By breaking contract code into chunks and committing to those chunks in a merkle tree, stateless clients would only need the chunks that were touched during a given transaction to execute it.
 
 ## Specification
 
@@ -94,7 +95,7 @@ The trie format is chosen to be the same as that of the account trie. If a tree 
 
 ### Chunk size
 
-The current recommended chunk size of 32 bytes has been selected based on a few observations. Smaller chunks are more efficient (i.e. have higher [chunk utilization](https://ethresear.ch/t/some-quick-numbers-on-code-merkelization/7260/3)), but incur a larger hash overhead (i.e. number of hashes as part of the proof) due to a higher trie depth. Larger chunks are less efficient, but incur less hash overhead. We plan to run a larger experiment comparing various chunk sizes to arrive at a final recommendation.
+The current recommended chunk size of 32 bytes has been selected based on a few observations. Smaller chunks are more efficient (i.e. have higher chunk utilization, but incur a larger hash overhead (i.e. number of hashes as part of the proof) due to a higher trie depth. Larger chunks are less efficient, but incur less hash overhead. We plan to run a larger experiment comparing various chunk sizes to arrive at a final recommendation.
 
 ### First instruction offset
 


### PR DESCRIPTION
This PR revives eip 2926 based on a conversation that happened during the Berlin interop. The idea is to strip the verkle/binary/tree EIPs down to the most valuable piece for the medium-term Ethereum roadmap: code chunking.

There is a significant overhaul of this EIP:

 * Code size and hash are stored at the account level, not in the tree. A new field for the code chunk root hash is added.
 * Only the version is stored in the tree, alongside the code chunks
 * Tree is expected to be MPT, to be later replaced with a single tree version, e.g. in eip-7864
 * It doesn't restrict the depth of the tree, so that code length can go beyond 2MB
 * It adapts the conversion from eip 7612 to this new version