### PR TITLE
Update EIP-7916: Tree grows left / Added ProgressiveBitlist

### DIFF
--- a/EIPS/eip-7916.md
+++ b/EIPS/eip-7916.md
@@ -1,7 +1,7 @@
 ---
 eip: 7916
 title: SSZ ProgressiveList
-description: New SSZ type to improve efficiency for short lists
+description: SSZ types for efficiently hashing short lists
 author: Zsolt Felföldi (@zsfelfoldi), Cayman (@wemeetagain), Etan Kissling (@etan-status)
 discussions-to: https://ethereum-magicians.org/t/eip-7916-ssz-progressivebytelist/23254
 status: Draft
@@ -12,132 +12,118 @@ created: 2025-03-24
 
 ## Abstract
 
-This EIP introduces a new [Simple Serialize (SSZ)](https://github.com/ethereum/consensus-specs/blob/0cd5dcd26327e49b726e66ca51802c4cd65be889/ssz/simple-serialize.md) type, `ProgressiveList[T]`, to represent lists of arbitrary length with stable merkleization. Unlike the existing `List[T, N]` type, which imposes a fixed capacity `N`, `ProgressiveList[T]` supports unbounded growth using a recursive tree structure during merkleization to efficiently handle lists of any size while maintaining stable [generalized indices (gindices)](https://github.com/ethereum/consensus-specs/blob/0cd5dcd26327e49b726e66ca51802c4cd65be889/ssz/merkle-proofs.md#generalized-merkle-tree-index) for individual elements. This enables reduced hash overhead for small lists and avoids arbitrary predefined limits.
+This EIP introduces a new Merkle tree shape for [Simple Serialize (SSZ)](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/ssz/simple-serialize.md) types that results in fewer hashes when only a small number of leaves is used. The new tree shape grows progressively with increased leaf count and no longer has a bounded capacity. It also offers forward compatibility: a given chunk index is always assigned the same stable [generalized index (gindex)](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/ssz/merkle-proofs.md#generalized-merkle-tree-index) regardless of leaf count.
+
+New types are defined to use the progressive Merkle tree shape: `ProgressiveList[type]` and `ProgressiveBitlist`. These new types represent lists of arbitrary length with stable merkleization, reducing hashing overhead for small lists and avoiding arbitrary capacity limits.
 
 ## Motivation
 
-Current SSZ `List[T, N]` types require a predefined capacity `N`, which leads to several issues:
+Current SSZ `List[type, N]` types require a predefined capacity `N`, which leads to several issues:
 
-- Inefficient hashing: Lists often contain far fewer elements than their maximum capacity (e.g., [`Transaction`](https://github.com/ethereum/consensus-specs/blob/3c028dc73f5d93defc9bfd38c44784573a0bc70a/specs/bellatrix/beacon-chain.md#custom-types)), resulting in unnecessary zero-padding and dozens of extra hash computations.
-- Arbitrary Limits: Fixed limits such as `N` are often chosen arbitrarily (e.g., [`MAX_BYTES_PER_TRANSACTION`](https://github.com/ethereum/consensus-specs/blob/3c028dc73f5d93defc9bfd38c44784573a0bc70a/specs/bellatrix/beacon-chain.md#execution), [`MAX_TRANSACTIONS_PER_PAYLOAD`](https://github.com/ethereum/consensus-specs/blob/3c028dc73f5d93defc9bfd38c44784573a0bc70a/specs/bellatrix/beacon-chain.md#execution)), introducing unnecessary bound checks and restricting design flexibility for future state transitions.
-- Unstable proofs: Modifying `N` across forks (e.g., [`MAX_ATTESTER_SLASHINGS_ELECTRA`](https://github.com/ethereum/consensus-specs/blob/3c028dc73f5d93defc9bfd38c44784573a0bc70a/specs/electra/beacon-chain.md#max-operations-per-block), [`MAX_ATTESTATIONS_ELECTRA`](https://github.com/ethereum/consensus-specs/blob/3c028dc73f5d93defc9bfd38c44784573a0bc70a/specs/electra/beacon-chain.md#max-operations-per-block)) alters gindices, breaking downstream verifiers.
+- Inefficient hashing: Lists often contain far fewer elements than their maximum capacity (e.g., [`Transaction`](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/specs/bellatrix/beacon-chain.md#custom-types)), resulting in unnecessary zero-padding and dozens of extra hash computations. This is exacerbated when nesting `List[type, N]`, e.g., in a design where each of up to `X` transactions has up to `Y` access lists, each with up to `Z` storage slots.
+- Arbitrary Limits: The capacity `N` is often chosen arbitrarily (e.g., [`MAX_BYTES_PER_TRANSACTION`](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/specs/bellatrix/beacon-chain.md#execution), [`MAX_TRANSACTIONS_PER_PAYLOAD`](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/specs/bellatrix/beacon-chain.md#execution)) and set to an artificially large value to anticipate future design space which are not always correct.
+- Unstable proofs: Modifying `N` across forks (e.g., [`MAX_ATTESTER_SLASHINGS_ELECTRA`](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/specs/electra/beacon-chain.md#max-operations-per-block), [`MAX_ATTESTATIONS_ELECTRA`](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/specs/electra/beacon-chain.md#max-operations-per-block)) alters gindices, breaking downstream verifiers.
 
-`ProgressiveList[T]` addresses these by:
+The progressive Merkle tree shape addresses these by:
 
-- Using a recursive structure where each subtree has a fixed size, with larger lists extending into additional subtrees, reducing hash overhead for small lists.
-- Eliminating the need for an explicit upper bound, relying instead on practical limits (e.g., SSZ's 4 GB variable offset cap, network payload limits, gas limits, bounds on number of signatures).
-- Maintaining stable gindices for elements, ensuring provers remain valid as the list grows.
-
-This is particularly valuable for execution-layer (EL) data like receipt logs and calldata, where list sizes vary widely, and for consensus-layer (CL) structures where unbounded growth avoids artificial caps.
+- Using a recursive tree structure that progressively grows to the actual leaf count with minimal overhead
+- Dropping the notion of a maximum capacity, relying instead on practical limits, e.g., SSZ's 4 GB variable offset cap, network payload limits, gas limits, bounds on number of signatures.
+- Maintaining stable gindices for each element, ensuring provers remain valid as the leaf count changes.
 
 ## Specification
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
 
-### `ProgressiveList[T]`
+### Progressive Merkle tree
 
-`ProgressiveList[T]` defines an ordered, homogeneous collection of elements of type `T`, where `T` is any valid SSZ type (e.g., `uint64`, `Container`, etc.).
+The [SSZ Merkleization specification)](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/ssz/simple-serialize.md#merkleization) is extended with a helper function:
+
+- `merkleize_progressive(chunks, num_leaves=1)`: Given ordered `BYTES_PER_CHUNK`-byte chunks:
+  - The merkleization depends on the number of input chunks and is defined recursively:
+    - If `len(chunks) == 0`: the root is a zero value, `Bytes32()`.
+    - Otherwise: compute the root using `hash(a, b)`
+      - `a`: Recursively merkleize chunks beyond `num_leaves` using `merkleize_progressive(chunks[num_leaves:], num_leaves * 4)`.
+      - `b`: Merkleize the first up to `num_leaves` chunks as a binary tree using `merkleize(chunks[:num_leaves], num_leaves)`.
+
+This results in a 0-terminated sequence of binary subtrees with increasing leaf count. The deepest subtree is padded with zeroed chunks (virtually for memory efficiency).
+
+```
+        root
+         /\
+        /  \
+       /\   1: chunks[0 ..< 1]
+      /  \
+     /\   4: chunks[1 ..< 5]
+    /  \
+   /\  16: chunks[5 ..< 21]
+  /  \
+ 0   64: chunks[21 ..< 85]
+```
+
+| Depth | Added chunks | Total chunks | Total capacity (bytes) |
+| -: | -: | -: | -: |
+| 0 | 0 | 0 | 0 |
+| 1 | 1 | 1 | 32 |
+| 2 | 4 | 5 | 160 |
+| 3 | 16 | 21 | 672 |
+| 4 | 64 | 85 | 2'720 |
+| 5 | 256 | 341 | 10'912 |
+| 6 | 1'024 | 1'365 | 43'680 |
+| 7 | 4'096 | 5'461 | 174'752 |
+| 8 | 16'384 | 21'845 | 699'040 |
+| 9 | 65'536 | 87'381 | 2'796'192 |
+| 10 | 262'144 | 349'525 | 11'184'800 |
+| 11 | 1'048'576 | 1'398'101 | 44'739'232 |
+| 12 | 4'194'304 | 5'592'405 | 178'956'960 |
+| 13 | 16'777'216 | 22'369'621 | 715'827'872 |
+| 14 | 67'108'864 | 89'478'485 | 2'863'311'520 |
+| 15 | 268'435'456 | 357'913'941 | 11'453'246'112 |
+
+### `ProgressiveList[type]` and `ProgressiveBitlist`
+
+Two new [SSZ composite types)](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/ssz/simple-serialize.md#composite-types) are defined:
+
+- **progressive list**: ordered variable-length homogeneous collection
+  - notation `ProgressiveList[type]`, e.g. `ProgressiveList[uint64]`
+- **progressive bitlist**: ordered variable-length collection of `boolean` values
+  - notation `ProgressiveBitlist`
+
+The new types are considered ["variable-size"](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/ssz/simple-serialize.md#variable-size-and-fixed-size).
+
+For convenience we [alias](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/ssz/simple-serialize.md#aliases):
+
+- `ProgressiveByteList` to `ProgressiveList[byte]`
+
+The [default value](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/ssz/simple-serialize.md#default-values) is defined as:
+
+| Type                    | Default Value |
+| ----------------------- | ------------- |
+| `ProgressiveList[type]` | `[]`          |
+| `ProgressiveBitlist`    | `[]`          |
 
 #### Serialization
 
-Serialization of `ProgressiveList[T]` is identical to `List[T, N]`.
+Serialization, deserialization, and JSON mapping of `ProgressiveBitlist` are identical to [`Bitlist[N]`](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/ssz/simple-serialize.md#bitlistn).
+
+Serialization, deserialization, and JSON mapping of `ProgressiveList[type]` are identical to [`List[type, N]`](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/ssz/simple-serialize.md#vectors-containers-lists).
 
 #### Merkleization
 
-`ProgressiveList[T]` is represented as a recursive Merkle tree following this process:
+The [Merkleization](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/ssz/simple-serialize.md#merkleization) definitions are extended.
 
-- Pack the list into chunks, either by `pack` or by `hash_tree_root` of its elements, depending on whether the element type is basic or composite. (This matches packing behavior of `List`)
-- Merkleize the chunks into subtrees. This process repeats as needed, with each subsequent subtree’s size being the previous size multiplied by the scaling factor. E.g., the first subtree has 1 chunk, next has 4, then 16, 64, etc.
-- Each subtree is a fixed-size `Vector` of chunks, with the next subtree’s root mixed in if present. The last subtree is padded to size with zeros, with a zero mixed in.
-- The final root has the total length of the list mixed in.
-
-```
-ProgressiveList[T]
-
-       V4   0 (terminator)
-        \  /
-     V3  \/
-      \  /
-   V2  \/
-    \  /
- V1  \/
-  \  /
-   \/  LEN
-    \  /
-     \/
-    ROOT
-
-V1: Vector[T, 1]  # Assuming `T` with a 32-byte chunk size; otherwise vectors are scaled accordingly
-V2: Vector[T, 4]
-V3: Vector[T, 16]
-V4: Vector[T, 64]
-```
-
-- `mix_in_length(merkleize_progressive_list(pack(value)), len(value))` if `value` is a `ProgressiveList[T]` of basic objects
-- `mix_in_length(merkleize_progressive_list([hash_tree_root(element) for element in value]), len(value))` if `value` is a `ProgressiveList[T]` of composite objects
-
-```python
-def merkleize_progressive_list(chunks, base_size=1, scaling_factor=4):
-    if len(chunks) <= base_size:
-        return mix_in_aux(merkleize(chunks + [Bytes32()] * (base_size - len(chunks))), Bytes32())
-    else:
-        next_size = base_size * scaling_factor
-        subtree = chunks[:base_size]
-        successor = chunks[base_size:]
-        subtree_root = merkleize(subtree)
-        successor_root = merkleize_progressive_list(successor, next_size, scaling_factor)
-        return mix_in_aux(subtree_root, successor_root)
-```
-
-| # | Layer size (chunks) | Total capacity (chunks) |
-| -: | -: | -: |
-| 1 | 1 | 1 |
-| 2 | 4 | 5 |
-| 3 | 16 | 21 |
-| 4 | 64 | 85 |
-| 5 | 256 | 341 |
-| 6 | 1'024 | 1'365 |
-| 7 | 4'096 | 5'461 |
-| 8 | 16'384 | 21'845 |
-| 9 | 65'536 | 87'381 |
-| 10 | 262'144 | 349'525 |
-| 11 | 1'048'576 | 1'398'101 |
-| 12 | 4'194'304 | 5'592'405 |
-| 13 | 16'777'216 | 22'369'621 |
-| 14 | 67'108'864 | 89'478'485 |
-| 15 | 268'435'456 | 357'913'941 |
-
-### `ProgressiveByteList`
-
-For convenience `ProgressiveByteList` is defined as an alias to `ProgressiveList[byte]`.
-
-| # | Layer size (bytes) | Total capacity (bytes) |
-| -: | -: | -: |
-| 1 | 32 | 32 |
-| 2 | 128 | 160 |
-| 3 | 512 | 672 |
-| 4 | 2'048 | 2'720 |
-| 5 | 8'192 | 10'912 |
-| 6 | 32'768 | 43'680 |
-| 7 | 131'072 | 174'752 |
-| 8 | 524'288 | 699'040 |
-| 9 | 2'097'152 | 2'796'192 |
-| 10 | 8'388'608 | 11'184'800 |
-| 11 | 33'554'432 | 44'739'232 |
-| 12 | 134'217'728 | 178'956'960 |
-| 13 | 536'870'912 | 715'827'872 |
-| 14 | 2'147'483'648 | 2'863'311'520 |
-| 15 | 8'589'934'592 | 11'453'246'112 |
+- `mix_in_length(merkleize_progressive(pack(value)), len(value))` if `value` is a progressive list of basic objects.
+- `mix_in_length(merkleize_progressive(pack_bits(value)), len(value))` if `value` is a progressive bitlist.
+- `mix_in_length(merkleize_progressive([hash_tree_root(element) for element in value]), len(value))` if `value` is a progressive list of composite objects.
 
 ## Rationale
 
-### Why a Recursive Structure?
+### Why a recursive structure?
 
-- Efficiency: Small lists use fewer hashes (e.g., a 3-item list in a 16-element subtree wastes fewer hashes than a 1024-element `List[T, N]`).
+- Efficiency: Small lists use fewer hashes (e.g., a 3-item list in a 16-element subtree wastes fewer hashes than a 1024-element `List[type, N]`).
 - Stability: Fixed subtree sizes ensure stable gindices, avoiding the need for dynamic depth adjustments or multiple queries.
 - Scalability: Recursive subtrees allow arbitrary growth without a hardcoded limit, constrained only by practical limits (e.g., network payload limit, validation rules).
 
-### Why Not Dynamic Depth?
+### Why not dynamic depth?
 
 Dynamic-depth Merkleization destabilizes gindices:
 
@@ -146,24 +132,24 @@ Dynamic-depth Merkleization destabilizes gindices:
 
 Mixing in successor subtrees ensures predictable gindices and proof sizes.
 
-### Why Not Fixed-Capacity Lists?
+### Why not fixed-capacity lists?
 
-`List[T, N]`:
+`List[type, N]`:
 
 - Imposes arbitrary limits, hindering scalability.
 - Breaks stability when redefined.
 - Wastes hashes with padding (e.g., 1024-element capacity for a 1-item list). (only log(N) wasted hashes)
 
-`ProgressiveList[T]` offers a scalable, efficient alternative.
+`ProgressiveList[type]` offers a scalable, efficient alternative.
 
-### Why Are Base Size and Scaling Factors Not Exposed Parameters?
+### Why are initial leaf count and scaling factors not exposed parameters?
 
-- Simplicity: Fixed values (base size 1, scaling factor 4) provide a sensible default that balances efficiency and usability, aligning with SSZ’s goal of simplicity.
+- Simplicity: Fixed values (initial leaf count 1, scaling factor 4) provide a sensible default that balances efficiency and usability, aligning with SSZ’s goal of simplicity.
 - Future Extensibility: If specific use cases demand different values, a future EIP could introduce parameterization. For now, fixed values reduce adoption barriers and align with the principle of "good enough" defaults.
 
 ## Backwards Compatibility
 
-`ProgressiveList[T]` is a new SSZ type, coexisting with `List[T, N]` and other types without conflict. Its `List`-equivalent serialization ensures compatibility with existing serializers.
+The new SSZ types coexist with existing types without conflict and share their serialization logic.
 
 ## Test Cases
 
@@ -175,8 +161,8 @@ See [EIP assets](../assets/eip-7916/progressive.py), based on `protolambda/remer
 
 ## Security Considerations
 
-- Resource limits: The `uint32` limit for variable-length offsets essentially introduces a ~4GB cap when including a `ProgressiveList[T]` within another complex type, but practical limits (e.g., 10MB libp2p messages) apply. Implementations SHOULD enforce context-specific bounds.
-- Variable proof size: Recursive traversal may increase proof sizes for large indices, though logarithmic in list size due to scaling.
+- Resource limits: The `uint32` limit for variable-length offsets essentially introduces a ~4GB cap when including a `ProgressiveList[type]` or `ProgressiveBitlist` within another complex type, but practical limits (e.g., 10MB libp2p messages) apply. Implementations SHOULD enforce context-specific bounds.
+- Variable proof size: Recursive traversal may increase proof sizes for large indices, though logarithmic in list size due to the scaling factor.
 
 ## Copyright
 


### PR DESCRIPTION
- Added `ProgressiveBitlist`
- Tree now grows to left instead of right
- Fixed incorrect `Bitvector` notion in graphic: Unused chunks are padded with 0 chunks instead of default(T) chunks.
- Simplified Merkleization code
