### PR TITLE
Update EIP-7848: fix typos

### DIFF
--- a/EIPS/eip-7848.md
+++ b/EIPS/eip-7848.md
@@ -38,7 +38,7 @@ The **reference implementation hash** is the SHA-256 hash of the tarred source c
 
 Network participants shall study the reference implementation and decide whether they support an upgrade.
 
-Network participants shall study any specific software they will run and ensure it faithfully implements the behaviors consistent with that referennce implementation.
+Network participants shall study any specific software they will run and ensure it faithfully implements the behaviors consistent with that reference implementation.
 
 ### Upgrade
 
@@ -59,7 +59,7 @@ Blocks created from `VOTING_WINDOW_END` + 1 onward will use the new software beh
 
 For proof-of-work networks and other scenarios, it is possible that one fork activates the upgrade while another does not. In any case, blocks strictly greater than `VOTING_WINDOW_END` shall be created according to the behaviors of the software considering the outcome of the votes in the voting window which are the ancestors of that block.
 
-Note: Just because a upgrade was activated, this does not necessarily mean that the new software behaviors must generate block `VOTING_WINDOW_END` + 1 differently than the old software behaviors. Perhaps the new software behaviors will stipulate that only blocks at some later time will generate differently. Perhaps the new software behaviors include some other consensus change which does not change how blocks are created.
+Note: Just because an upgrade was activated, this does not necessarily mean that the new software behaviors must generate block `VOTING_WINDOW_END` + 1 differently than the old software behaviors. Perhaps the new software behaviors will stipulate that only blocks at some later time will generate differently. Perhaps the new software behaviors include some other consensus change which does not change how blocks are created.
 
 ## Rationale
 
@@ -83,7 +83,7 @@ Using a voting window to count votes provides real-time on-chain feedback about 
 
 ### Trademark
 
-The Ethereum Foundation (Stiftung Ethereum), Zug, Switzerland, owns the trademark “Ethereum.” As a result, if anybody publishes a proposed Ethereum Mainnet consensus client, the foundation may have the right to restrict marketing of that software as an “Ethereum” client. That also posess unique risks related to securities rules.
+The Ethereum Foundation (Stiftung Ethereum), Zug, Switzerland, owns the trademark “Ethereum.” As a result, if anybody publishes a proposed Ethereum Mainnet consensus client, the foundation may have the right to restrict marketing of that software as an “Ethereum” client. That also poses unique risks related to securities rules.
 
 ### EIP-2124
 


### PR DESCRIPTION


**Description:**  
This pull request corrects several typos in EIP-7848:
- "referennce" → "reference"
- "a upgrade" → "an upgrade"
- "posess" → "poses"

These changes improve the clarity and professionalism of the document.
