### PR TITLE
Update EIP-5920: Minor spelling corrections in EIP-5920 documentation

### DIFF
--- a/EIPS/eip-5920.md
+++ b/EIPS/eip-5920.md
@@ -23,7 +23,7 @@ Currently, to send ether to an address requires you to call into that address, w
   - In practice, when calling into another account and sending ether, 2300 gas (the "gas stipend") is always available "for free" in the newly created call frame. Although it is currently not possible to make storage state changes with the 2300 gas stipend (see the last minute rejection of [EIP-1283](./eip-1283.md) from Constantinople to be replaced with the "gas stipend safe" [EIP-2200](./eip-2200.md) version in Istanbul), it is possible to do this with transient storage ([EIP-1153](./eip-1153.md)). This is a security risk where potentially the transient storage gets changed unintentionally. The goal is to send ether, and not have to consider these potential unintuitive security problems.
 - Secondly, it opens a DoS vector. Contracts wanting to send ether must be cognizant of the possibility that the recipient will run out of gas or revert.
 - Future potential call-like opcodes may not provide a way to restrict the amount of gas being forwarded to the recipient, so the meager mitigation against unintended side effects in use today (gas limit) is not guaranteed to be available.
-- The `CALL` and `EXTCALL` opcodes will execute code on the receipient, which is unintended when wanting to send ether and which could lead to unintentional operations. The code execution also has to be paid for in gas, even when the intention is to only send ether, which is thus an unnecessary waste of gas.
+- The `CALL` and `EXTCALL` opcodes will execute code on the recipient, which is unintended when wanting to send ether and which could lead to unintentional operations. The code execution also has to be paid for in gas, even when the intention is to only send ether, which is thus an unnecessary waste of gas.
 - Finally, [EIP-7702](./eip-7702.md) allows to delegate externally owned accounts (EOAs) to other accounts, which breaks the invariant that EOAs cannot contain code. Therefore, calling such EOA with the intention to send ether will thus also execute code and cost unnecessary gas.
 
 Having a dedicated opcode for ether transfers solves all of these issues, and would be a useful addition to the EVM.
@@ -52,7 +52,7 @@ A new opcode is introduced: `PAY` (`0xfc`), which:
 - Charges the gas cost detailed below.
 - Marks `addr` as warm (adding `addr` to `accessed_addresses`).
 - Transfers `val` wei from the current address to the address `addr`, only if the current address has a balance greater than or equal to `val`.
-- Push `1` on the stack if the `PAY` operation was succesful, or `0` if it failed.
+- Push `1` on the stack if the `PAY` operation was successful, or `0` if it failed.
   - Currently only insufficient balance would produce a `0` return value.
 
 ### Gas Cost


### PR DESCRIPTION
**Description:**  
This PR fixes minor spelling mistakes in the EIP-5920 document, replacing "receipient" with "recipient" and "succesful" with "successful" for improved clarity and professionalism.