### PR TITLE
CI: Update actions/configure-pages to v5

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -64,7 +64,7 @@ jobs:
           cache-version: 0 # Increment this number if you need to re-download cached gems
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"


### PR DESCRIPTION


Updates actions/configure-pages from v3 to v5 in GitHub Pages workflow configurations.

Changes:
- Updates `actions/configure-pages@v3` to `actions/configure-pages@v5` in the Jekyll workflow file
- Ensures compatibility with latest GitHub Pages features and improvements
- Improves static site generator configurations

Reference:
Latest version: https://github.com/actions/configure-pages/releases/tag/v5

This update ensures we're using the most recent stable version of the GitHub Pages configuration action, providing better support for static site generation and improved Pages metadata handling.
