### PR TITLE
Update EIP-7749: fix typo in verifier address description

### DIFF
--- a/EIPS/eip-7749.md
+++ b/EIPS/eip-7749.md
@@ -75,7 +75,7 @@ No backward compatibility issues found.
 
 - Signer Address (`0x6aFbBC5e6AFcB251371711a6551E60ead2779Dc0`): This is the address of the account that will be used to sign the constructed message. We have access to the private key of this address, which allows us to generate the signature securely.
 
-- Verifier Address (`0x345B918b9E06fAa7B0e56bd71Ba418F31F47FED4`): This address represents the address verfying the signature, could be an EOA or a smart contract. For example, it could be a contract that performs specific actions based on the validity of the signature. By including this address in the data to be signed, we ensure that the signature cannot be reused by malicious actors for unintended purposes.
+- Verifier Address (`0x345B918b9E06fAa7B0e56bd71Ba418F31F47FED4`): This address represents the address verifying the signature, could be an EOA or smart contract. For example, it could be a contract that performs specific actions based on the validity of the signature. By including this address in the data to be signed, we ensure that the signature cannot be reused by malicious actors for unintended purposes.
 
 - Data to Sign (`0x59616d656e`): This is the hex-encoded string representing the actual content to be signed. In this example, it is the hex encoding for the ASCII string "Yamen". The data, combined with the verifier address, is hashed and signed to generate a unique signature that cannot be used for any other purpose.
 


### PR DESCRIPTION


**Description:**  
Corrected a typo ("verfying" → "verifying") and improved the wording in the verifier address example section for clarity and accuracy. 
