### PR TITLE
Update EIP-7495: Use progressive tree shape / Drop optionals

### DIFF
--- a/EIPS/eip-7495.md
+++ b/EIPS/eip-7495.md
@@ -48,28 +48,28 @@ Two new [SSZ composite types)](https://github.com/ethereum/consensus-specs/blob/
       color: uint8  # Merkleized at field index #2 (location of second 1 in `active_fields`)
   ```
 
-- **union**: union type containing one of the given subtypes with compatible Merkleization
-  - notation `Union[type_0, type_1, ...]`, e.g. `Union[Square, Circle]`
+- **compatible union**: union type containing one of the given subtypes with compatible Merkleization
+  - notation `CompatibleUnion[type_0, type_1, ...]`, e.g. `CompatibleUnion[Square, Circle]`
 
-Unions are always considered ["variable-size"](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/ssz/simple-serialize.md#variable-size-and-fixed-size), even when all type options share the same fixed length.
+Compatible unions are always considered ["variable-size"](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/ssz/simple-serialize.md#variable-size-and-fixed-size), even when all type options share the same fixed length.
 
 The [default value](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/ssz/simple-serialize.md#default-values) is defined as:
 
-| Type                                  | Default Value                                              |
-| ------------------------------------- | ---------------------------------------------------------- |
-| `ProgressiveContainer[active_fields]` | `[default(type) for type in progressive_container]`        |
-| `Union[type_0, type_1, ...]`          | `default(type_0) if type_0.active_fields == [] else error` |
+| Type                                   | Default Value                                              |
+| -------------------------------------- | ---------------------------------------------------------- |
+| `ProgressiveContainer[active_fields]`  | `[default(type) for type in progressive_container]`        |
+| `CompatibleUnion[type_0, type_1, ...]` | `default(type_0) if type_0.active_fields == [] else error` |
 
 The following types are considered [illegal](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/ssz/simple-serialize.md#illegal-types):
 
 - `ProgressiveContainer` with an `active_fields` list ending in `0` are illegal.
 - `ProgressiveContainer` with an `active_fields` list of more than 256 entries are illegal.
 - `ProgressiveContainer` with an `active_fields` list with a different count of `1` than fields are illegal.
-- `Union[type_0, type_1, ...]` without any type options are illegal.
-- `Union[type_0, type_1, ...]` without a `ProgressiveContainer[active_fields=[]]` type option and more than 127 type options are illegal.
-- `Union[type_0, type_1, ...]` with a `ProgressiveContainer[active_fields=[]]` type option and more than 128 type options are illegal.
-- `Union[type_0, type_1, ...]` with a `ProgressiveContainer[active_fields=[]]` type option at a position other than `type_0` are illegal.
-- `Union[type_0, type_1, ...]` with a type option that has incompatible Merkleization with another type option are illegal.
+- `CompatibleUnion[type_0, type_1, ...]` without any type options are illegal.
+- `CompatibleUnion[type_0, type_1, ...]` without a `ProgressiveContainer[active_fields=[]]` type option and more than 127 type options are illegal.
+- `CompatibleUnion[type_0, type_1, ...]` with a `ProgressiveContainer[active_fields=[]]` type option and more than 128 type options are illegal.
+- `CompatibleUnion[type_0, type_1, ...]` with a `ProgressiveContainer[active_fields=[]]` type option at a position other than `type_0` are illegal.
+- `CompatibleUnion[type_0, type_1, ...]` with a type option that has incompatible Merkleization with another type option are illegal.
 
 #### Compatible Merkleization
 
@@ -80,15 +80,15 @@ The following types are considered [illegal](https://github.com/ethereum/consens
 - `ProgressiveList[type]` are compatible if `type` is compatible.
 - `Container` are compatible if they share the same field names in the same order, and all field types are compatible.
 - `ProgressiveContainer[active_fields]` are compatible if all `1` entries in both type's `active_fields` correspond to fields with shared names and compatible types, and no other field name is shared across both types.
-- `Union[type_0, type_1, ...]` and any of the type options `type_0`, `type_1`, ... are compatible and vice versa.
-- `Union` are compatible with each other if all type options across both `Union` are compatible.
+- `CompatibleUnion[type_0, type_1, ...]` and any of the type options `type_0`, `type_1`, ... are compatible and vice versa.
+- `CompatibleUnion` are compatible with each other if all type options across both `CompatibleUnion` are compatible.
 - All other types are incompatible.
 
 #### Serialization
 
 Serialization of `ProgressiveContainer[active_fields]` are identical to [`Container`](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/ssz/simple-serialize.md#vectors-containers-lists).
 
-A `value` as `Union[T...]` type has properties `value.data` with the contained value, and `value.selector` which indexes the selected `Union` type option `T`. The index is based at 0 if a `ProgressiveContainer[active_fields=[]]` type option is present. Otherwise, it is based at 1.
+A `value` as `CompatibleUnion[T...]` type has properties `value.data` with the contained value, and `value.selector` which indexes the selected `CompatibleUnion` type option `T`. The index is based at 0 if a `ProgressiveContainer[active_fields=[]]` type option is present. Otherwise, it is based at 1.
 
 ```python
 return value.selector.to_bytes(1, "little") + serialize(value.data)
@@ -98,24 +98,24 @@ return value.selector.to_bytes(1, "little") + serialize(value.data)
 
 Deserialization of `ProgressiveContainer[active_fields]` is identical to [`Container`](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/ssz/simple-serialize.md#deserialization).
 
-For `Union`, the deserialization logic is updated:
+For `CompatibleUnion`, the deserialization logic is updated:
 
-- In the case of unions, the first byte of the deserialization scope is deserialized as type selector, the remainder of the scope is deserialized as the selected type.
+- In the case of compatible unions, the first byte of the deserialization scope is deserialized as type selector, the remainder of the scope is deserialized as the selected type.
 
 The following invalid input needs to be hardened against:
 
-- An out-of-bounds type selector in a `Union`
+- An out-of-bounds type selector in a `CompatibleUnion`
 
 #### JSON mapping
 
 The canonical [JSON mapping](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/ssz/simple-serialize.md#json-mapping) is updated:
 
-| SSZ                                   | JSON            | Example                                  |
-| ------------------------------------- | --------------- | ---------------------------------------- |
-| `ProgressiveContainer[active_fields]` | object          | `{ "field": ... }`                       |
-| `Union[type_0, type_1, ...]`          | selector-object | `{ "selector": number, "data": type_N }` |
+| SSZ                                    | JSON            | Example                                  |
+| -------------------------------------- | --------------- | ---------------------------------------- |
+| `ProgressiveContainer[active_fields]`  | object          | `{ "field": ... }`                       |
+| `CompatibleUnion[type_0, type_1, ...]` | selector-object | `{ "selector": number, "data": type_N }` |
 
-`Union` is encoded as an object with a `selector` and `data` field, where the contents of `data` change according to the selector.
+`CompatibleUnion` is encoded as an object with a `selector` and `data` field, where the contents of `data` change according to the selector.
 
 #### Merkleization
 
@@ -127,7 +127,7 @@ The [SSZ Merkleization specification)](https://github.com/ethereum/consensus-spe
 The Merkleization definitions are extended.
 
 - `mix_in_active_fields(merkleize_progressive([hash_tree_root(element) for element in value]), get_active_fields(value))` if `value` is a progressive container.
-- `hash_tree_root(value.data)` if `value` is of union type. Note that the selector is only used for serialization, it is not mixed in when Merkleizing.
+- `hash_tree_root(value.data)` if `value` is of compatible union type. Note that the selector is only used for serialization, it is not mixed in when Merkleizing.
 
 ## Rationale
 
@@ -135,27 +135,27 @@ The Merkleization definitions are extended.
 
 `active_fields` conceptually creates a single Merkle tree shape across all prior, current, and future versions, where each field (as identified by its name) is assigned a stable gindex and can either be present or absent. This allows appending new fields or dropping existing fields as the data type evolves without impacting `hash_tree_root`, reducing the maintenance burden for provers and verifiers of partial data.
 
-### Why `Union`?
+### Why `CompatibleUnion`?
 
-SSZ does not allow skipping of unknown fields when deserializing data, requiring the full schema to be known and preventing a forward compatible serialization format. Each specification version only allows select combinations of `active_fields` at any time. Using `Union` reduces serialization overhead (especially when nesting is involved), and decreases the number of deserialization error conditions.
+SSZ does not allow skipping of unknown fields when deserializing data, requiring the full schema to be known and preventing a forward compatible serialization format. Each specification version only allows select combinations of `active_fields` at any time. Using `CompatibleUnion` reduces serialization overhead (especially when nesting is involved), and decreases the number of deserialization error conditions.
 
 Note that `hash_tree_root` is unaffected by any given serialization. For Merkleization and proof verification, `active_fields` models the underlying data as a `Container` full of optional fields. When only partial data is desired (e.g., a staking pool that wishes to verify if a validator got slashed), a forward compatible proof format can be designed on a per application basis.
 
-Further note that `Union` is solely a serialization optimization. The `Union` selector is not mixed into `hash_tree_root`. Instead, the underlying `active_fields` are mixed in.
+Further note that `CompatibleUnion` is solely a serialization optimization. The `CompatibleUnion` selector is not mixed into `hash_tree_root`. Instead, the underlying `active_fields` are mixed in.
 
 ### Why not `Optional[type]`?
 
 Introducing `Optional` is not required by any current functionality, and would trigger serialization overhead by requiring "variable-size" encoding for all enclosing types.
 
-If `Optional` support becomes desirable, and it is not feasible to model the valid field combinations as a `Union`, the `active_fields` concept should be reused by updating `get_active_fields` to only emit `1` for fields that are always required as well as for optional fields that are present, and emit `0` for fields that are always excluded as well as for optional fields that are absent, retaining compatibility across the proposed `ProgressiveContainer[active_fields]` type. As for serialization, a `BitVector[O]` with `O` being the number of optional fields would be prepended to the value to indicate presence or absence of optional fields. The concept can also be combined with `Union`, with individual type options having optional fields.
+If `Optional` support becomes desirable, and it is not feasible to model the valid field combinations as a `CompatibleUnion`, the `active_fields` concept should be reused by updating `get_active_fields` to only emit `1` for fields that are always required as well as for optional fields that are present, and emit `0` for fields that are always excluded as well as for optional fields that are absent, retaining compatibility across the proposed `ProgressiveContainer[active_fields]` type. As for serialization, a `BitVector[O]` with `O` being the number of optional fields would be prepended to the value to indicate presence or absence of optional fields. The concept can also be combined with `CompatibleUnion`, with individual type options having optional fields.
 
-`Optional[type]` should _not_ be represented as a `Union[ProgressiveContainer[active_fields=[]], type]` because of Merkleization and serialization overhead over the proposed update.
+`Optional[type]` should _not_ be represented as a `CompatibleUnion[ProgressiveContainer[active_fields=[]], type]` because of Merkleization and serialization overhead over the proposed update.
 
 ## Backwards Compatibility
 
 `ProgressiveContainer[active_fields]` is a new SSZ type and does not conflict with existing types.
 
-`Union[type_0, type_1, ...]` conflicts with an [earlier union proposal](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/ssz/simple-serialize.md#composite-types). However, it has only been used in [deprecated specifications](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/specs/_deprecated/sharding/beacon-chain.md). Portal network also uses a union concept for network types, but does not use `hash_tree_root` for unions, and could transition to the new union proposal with a new networking version.
+`CompatibleUnion[type_0, type_1, ...]` conflicts with an [earlier union proposal](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/ssz/simple-serialize.md#composite-types). However, it has only been used in [deprecated specifications](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/specs/_deprecated/sharding/beacon-chain.md). Portal network also uses a union concept for network types, but does not use `hash_tree_root` on them, and could transition to the new compatible union proposal with a new networking version.
 
 ## Test Cases
 


### PR DESCRIPTION
- StableContainer becomes pure mental model for assigning field indices
- Profile becomes ProgressiveContainer
- Drop optionals support from ProgressiveContainer
- Compact encoding as union, as deserialization needs type info anyway
- Leave partial data encoding up to applications
