### PR TITLE
Update EIP-7805: Use `MAX_TRANSACTIONS_PER_PAYLOAD` for the max length of IL transactions

### DIFF
--- a/EIPS/eip-7805.md
+++ b/EIPS/eip-7805.md
@@ -141,7 +141,7 @@ class InclusionList(Container):
     slot: Slot
     validator_index: ValidatorIndex
     inclusion_list_committee_root: Root
-    transactions: List[Transaction, MAX_TRANSACTIONS_PER_INCLUSION_LIST]
+    transactions: List[Transaction, MAX_TRANSACTIONS_PER_PAYLOAD]
 ```
 
 ```python


### PR DESCRIPTION
*Description*:
The max length of inclusion list transactions should be `MAX_TRANSACTIONS_PER_PAYLOAD`. The EIP was using `MAX_TRANSACTIONS_PER_INCLUSION_LIST` for historical reason and has to be updated.

Thanks to @GrapeBaBa for spotting this out.

Relevant discussion: https://discord.com/channels/595666850260713488/1210529202458071050/1332367822390693981