### PR TITLE
Update EIP-7642: Corrected Spelling and Grammar

### DIFF
--- a/EIPS/eip-7642.md
+++ b/EIPS/eip-7642.md
@@ -34,7 +34,7 @@ We recently discovered that none of the clients store the `Bloom` field of the r
 it can be recomputed on demand. However the networking spec requires the `Bloom` field to
 be sent over the network. Thus a syncing node will ask for the Bloom filters for all
 receipts. The serving node will regenerate roughly 530GB of bloom filters (2.3B txs * 256
-byte). These 530GBs are sent over the network to the syncing peer, the syncing peer will
+byte). These 530GBs are send over the network to the syncing peer, the syncing peer will
 verify them and not store them either. This adds an additional 530GB of unnecessary
 bandwidth to every sync.
 

--- a/EIPS/eip-7642.md
+++ b/EIPS/eip-7642.md
@@ -16,7 +16,7 @@ requires: 5793
 This EIP modifies the 'eth' p2p protocol to announce the historical block range served by
 the node. We also simplify the handshake to remove total difficulty information, which
 isn't used anymore after the merge. Additionally we propose to remove the `Bloom` field
-from receipts transfered over the protocol.
+from receipts transferred over the protocol.
 
 ## Motivation
 
@@ -34,7 +34,7 @@ We recently discovered that none of the clients store the `Bloom` field of the r
 it can be recomputed on demand. However the networking spec requires the `Bloom` field to
 be sent over the network. Thus a syncing node will ask for the Bloom filters for all
 receipts. The serving node will regenerate roughly 530GB of bloom filters (2.3B txs * 256
-byte). These 530GBs are send over the network to the syncing peer, the syncing peer will
+byte). These 530GBs are sent over the network to the syncing peer, the syncing peer will
 verify them and not store them either. This adds an additional 530GB of unnecessary
 bandwidth to every sync.
 
@@ -97,7 +97,7 @@ The new `earliestBlock` field is technically not required for history expiry, bu
 are a couple reasons why adding it can help:
 
 - It improves peer finding for clients that still want to sync history from p2p after the
-  agreed-upon removal of pre merge history has taken place. Without `earliestBlock`, the
+  agreed-upon removal of pre-merge history has taken place. Without `earliestBlock`, the
   client would have to perform a request for history to check if the earlier range exists,
   and assume that a failed request means it's not there.
 - The new field can be used for census in a specialized crawler. We will be able to see


### PR DESCRIPTION


**Description:**  
This pull request fixes several minor typos and grammatical errors in EIP-7642, including corrections for "transfered" → "transferred", "send" → "sent", and "pre merge" → "pre-merge". 