### PR TITLE
Update EIP-6404: Use SSZ `ProgressiveContainer` / `Union`

### DIFF
--- a/EIPS/eip-6404.md
+++ b/EIPS/eip-6404.md
@@ -8,12 +8,12 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2023-01-30
-requires: 155, 1559, 2718, 2930, 4844, 5793, 7495, 7702
+requires: 155, 1559, 2718, 2930, 4844, 7495, 7702, 7916
 ---
 
 ## Abstract
 
-This EIP defines a migration process of [EIP-2718](./eip-2718.md) Recursive-Length Prefix (RLP) transactions to [Simple Serialize (SSZ)](https://github.com/ethereum/consensus-specs/blob/b3e83f6691c61e5b35136000146015653b22ed38/ssz/simple-serialize.md).
+This EIP defines a migration process of [EIP-2718](./eip-2718.md) Recursive-Length Prefix (RLP) transactions to [Simple Serialize (SSZ)](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/ssz/simple-serialize.md).
 
 ## Motivation
 
@@ -25,13 +25,11 @@ RLP transactions have a number of shortcomings:
 
 3. **Incompatible representation:** As part of the consensus `ExecutionPayload`, the RLP serialization of transactions is hashed using SSZ merkleization. These SSZ hashes are incompatible with both the `tx_hash` and the MPT `transactions_root`.
 
-4. **No extensibility:** Transaction types cannot be extended with optional features. Hypothetically, if [EIP-4844](./eip-4844.md) blob transactions existed from the start, new features such as [EIP-2930](./eip-2930.md) access lists and [EIP-1559](./eip-1559.md) priority fees would have required two new transaction types each to extend both the basic and blob transaction types.
+4. **Technical debt:** All client applications and smart contracts handling RLP transactions have to correctly deal with caveats such as `LegacyTransaction` lacking a prefix byte, the inconsistent `chain_id` and `v` / `y_parity` semantics, and the introduction of `max_priority_fee_per_gas` between other fields instead of at the end. As existing transaction types tend to remain valid perpetually, this technical debt builds up over time.
 
-5. **Technical debt:** All client applications and smart contracts handling RLP transactions have to correctly deal with caveats such as `LegacyTransaction` lacking a prefix byte, the inconsistent `chain_id` and `v` / `y_parity` semantics, and the introduction of `max_priority_fee_per_gas` between other fields instead of at the end. As existing transaction types tend to remain valid perpetually, this technical debt builds up over time.
+5. **Inappropriate opaqueness:** The Consensus Layer treats RLP transaction data as opaque, but requires validation of consensus `blob_kzg_commitments` against transaction `blob_versioned_hashes`, resulting in a more complex than necessary engine API.
 
-6. **Inappropriate opaqueness:** The Consensus Layer treats RLP transaction data as opaque, but requires validation of consensus `blob_kzg_commitments` against transaction `blob_versioned_hashes`, resulting in a more complex than necessary engine API.
-
-This EIP defines a lossless conversion mechanism to normalize transaction representation across both Consensus Layer and Execution Layer while retaining support for processing RLP transaction types.
+This EIP addresses these by defining a lossless conversion mechanism to normalize transaction representation across both Consensus Layer and Execution Layer while retaining support for processing RLP transaction types.
 
 ## Specification
 
@@ -43,34 +41,28 @@ Definitions from existing specifications that are used throughout this document 
 
 | Name | Value |
 | - | - |
-| [`MAX_TRANSACTIONS_PER_PAYLOAD`](https://github.com/ethereum/consensus-specs/blob/b3e83f6691c61e5b35136000146015653b22ed38/specs/bellatrix/beacon-chain.md#execution) | `uint64(2**20)` (= 1,048,576) |
-| [`BYTES_PER_FIELD_ELEMENT`](https://github.com/ethereum/consensus-specs/blob/b3e83f6691c61e5b35136000146015653b22ed38/specs/deneb/polynomial-commitments.md#constants) | `uint64(32)` |
-| [`FIELD_ELEMENTS_PER_BLOB`](https://github.com/ethereum/consensus-specs/blob/b3e83f6691c61e5b35136000146015653b22ed38/specs/deneb/polynomial-commitments.md#blob) | `uint64(4096)` |
-| [`MAX_BLOB_COMMITMENTS_PER_BLOCK`](https://github.com/ethereum/consensus-specs/blob/b3e83f6691c61e5b35136000146015653b22ed38/specs/deneb/beacon-chain.md#execution) | `uint64(2**12)` (= 4,096) |
+| [`BYTES_PER_FIELD_ELEMENT`](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/specs/deneb/polynomial-commitments.md#constants) | `uint64(32)` |
+| [`FIELD_ELEMENTS_PER_BLOB`](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/specs/deneb/polynomial-commitments.md#blob) | `uint64(4096)` |
 
 | Name | SSZ equivalent |
 | - | - |
-| [`Hash32`](https://github.com/ethereum/consensus-specs/blob/b3e83f6691c61e5b35136000146015653b22ed38/specs/phase0/beacon-chain.md#custom-types) | `Bytes32` |
-| [`ExecutionAddress`](https://github.com/ethereum/consensus-specs/blob/b3e83f6691c61e5b35136000146015653b22ed38/specs/bellatrix/beacon-chain.md#custom-types) | `Bytes20` |
-| [`VersionedHash`](https://github.com/ethereum/consensus-specs/blob/b3e83f6691c61e5b35136000146015653b22ed38/specs/deneb/beacon-chain.md#custom-types) | `Bytes32` |
-| [`KZGCommitment`](https://github.com/ethereum/consensus-specs/blob/b3e83f6691c61e5b35136000146015653b22ed38/specs/deneb/polynomial-commitments.md#custom-types) | `Bytes48` |
-| [`KZGProof`](https://github.com/ethereum/consensus-specs/blob/b3e83f6691c61e5b35136000146015653b22ed38/specs/deneb/polynomial-commitments.md#custom-types) | `Bytes48` |
-| [`Blob`](https://github.com/ethereum/consensus-specs/blob/b3e83f6691c61e5b35136000146015653b22ed38/specs/deneb/polynomial-commitments.md#custom-types) | `ByteVector[BYTES_PER_FIELD_ELEMENT * FIELD_ELEMENTS_PER_BLOB]` |
+| [`Hash32`](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/specs/phase0/beacon-chain.md#custom-types) | `Bytes32` |
+| [`ExecutionAddress`](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/specs/bellatrix/beacon-chain.md#custom-types) | `Bytes20` |
+| [`VersionedHash`](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/specs/deneb/beacon-chain.md#custom-types) | `Bytes32` |
+| [`KZGCommitment`](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/specs/deneb/polynomial-commitments.md#custom-types) | `Bytes48` |
+| [`KZGProof`](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/specs/deneb/polynomial-commitments.md#custom-types) | `Bytes48` |
+| [`Blob`](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/specs/deneb/polynomial-commitments.md#custom-types) | `ByteVector[BYTES_PER_FIELD_ELEMENT * FIELD_ELEMENTS_PER_BLOB]` |
 
-### `ExecutionSignature` container
+### Signatures
 
-Signatures use their native, opaque representation, and are extended with an on-chain commitment to the signing address.
+Transaction signatures are represented by their native, opaque representation. ECDSA signatures are no longer split up into `r`, `s`, and `y_parity` components.
 
 | Name | Value | Description |
 | - | - | - |
 | `SECP256K1_SIGNATURE_SIZE` | `32 + 32 + 1` (= 65) | Byte length of a secp256k1 ECDSA signature |
-| `MAX_EXECUTION_SIGNATURE_FIELDS` | `uint64(2**3)` (= 8) | Maximum number of fields to which `ExecutionSignature` can ever grow in the future |
 
 ```python
-class ExecutionSignature(StableContainer[MAX_EXECUTION_SIGNATURE_FIELDS]):
-    secp256k1: Optional[ByteVector[SECP256K1_SIGNATURE_SIZE]]
-
-class Secp256k1ExecutionSignature(Profile[ExecutionSignature]):
+class Secp256k1ExecutionSignature(ProgressiveContainer[active_fields=[1]]):
     secp256k1: ByteVector[SECP256K1_SIGNATURE_SIZE]
 
 def secp256k1_pack(r: uint256, s: uint256, y_parity: uint8) -> ByteVector[SECP256K1_SIGNATURE_SIZE]:
@@ -98,232 +90,283 @@ def secp256k1_recover_signer(signature: ByteVector[SECP256K1_SIGNATURE_SIZE],
     return ExecutionAddress(keccak(uncompressed[1:])[12:])
 ```
 
-### `Transaction` container
+### Gas fees
 
-All transactions are represented as a single, normalized SSZ container. The definition uses the `StableContainer[N]` SSZ type and `Optional[T]` as defined in [EIP-7495](./eip-7495.md).
+The different kinds of gas fees are combined into a single structure.
 
-| Name | Value | Description |
+| Name | SSZ equivalent | Description |
 | - | - | - |
-| `MAX_FEES_PER_GAS_FIELDS` | `uint64(2**4)` (= 16) | Maximum number of fields to which `FeesPerGas` can ever grow in the future |
-| `MAX_CALLDATA_SIZE` | `uint64(2**24)` (= 16,777,216) | Maximum `input` calldata byte length for a transaction |
-| `MAX_ACCESS_LIST_STORAGE_KEYS` | `uint64(2**19)` (= 524,288) | Maximum number of storage keys within an access tuple |
-| `MAX_ACCESS_LIST_SIZE` | `uint64(2**19)` (= 524,288) | Maximum number of access tuples within an `access_list` |
-| `MAX_AUTHORIZATION_PAYLOAD_FIELDS` | `uint64(2**4)` (= 16) | Maximum number of fields to which `AuthorizationPayload` can ever grow in the future |
-| `MAX_AUTHORIZATION_LIST_SIZE` | `uint64(2**16)` (= 65,536) | Maximum number of authorizations within an `authorization_list` |
-| `MAX_TRANSACTION_PAYLOAD_FIELDS` | `uint64(2**5)` (= 32) | Maximum number of fields to which `TransactionPayload` can ever grow in the future |
+| `FeePerGas` | `uint256` | Fee per unit of gas |
+
+```python
+class BasicFeesPerGas(ProgressiveContainer[active_fields=[1]]):
+    regular: FeePerGas
+
+class BlobFeesPerGas(ProgressiveContainer[active_fields=[1, 1]]):
+    regular: FeePerGas
+    blob: FeePerGas
+```
+
+### Normalized transactions
+
+RLP transactions are converted to a normalized SSZ representation. Their original RLP `TransactionType` is retained to enable recovery of their original RLP representation and associated `sig_hash` and historical `tx_hash` values.
+
+```python
+class Transaction(CompatibleUnion[
+    RlpTransaction,
+]):
+    pass
+
+class RlpTransaction(CompatibleUnion[
+    RlpLegacyReplayableBasicTransaction,
+    RlpLegacyReplayableCreateTransaction,
+    RlpLegacyBasicTransaction,
+    RlpLegacyCreateTransaction,
+    RlpAccessListBasicTransaction,
+    RlpAccessListCreateTransaction,
+    RlpBasicTransaction,
+    RlpCreateTransaction,
+    RlpBlobTransaction,
+    RlpSetCodeTransaction,
+]):
+    pass
+```
 
 | Name | SSZ equivalent | Description |
 | - | - | - |
 | `TransactionType` | `uint8` | [EIP-2718](./eip-2718.md) transaction type, range `[0x00, 0x7F]` |
-| `ChainId` | `uint64` | [EIP-155](./eip-155.md) chain ID |
-| `FeePerGas` | `uint256` | Fee per unit of gas |
+| `ChainId` | `uint256` | [EIP-155](./eip-155.md) chain ID |
 | `GasAmount` | `uint64` | Amount in units of gas |
 
+#### Replayable legacy transactions
+
+The original RLP representation of these transactions is replayable across networks with different chain ID.
+
 ```python
-class FeesPerGas(StableContainer[MAX_FEES_PER_GAS_FIELDS]):
-    regular: Optional[FeePerGas]
+class RlpLegacyReplayableBasicTransactionPayload(
+    ProgressiveContainer[active_fields=[1, 0, 1, 1, 1, 1, 1, 1]]
+):
+    type_: TransactionType  # 0x00
+    nonce: uint64
+    max_fees_per_gas: BasicFeesPerGas
+    gas: GasAmount
+    to: ExecutionAddress
+    value: uint256
+    input_: ProgressiveByteList
 
-    # EIP-4844
-    blob: Optional[FeePerGas]
+class RlpLegacyReplayableBasicTransaction(Container):
+    payload: RlpLegacyReplayableBasicTransactionPayload
+    signature: Secp256k1ExecutionSignature
 
-class AccessTuple(Container):
-    address: ExecutionAddress
-    storage_keys: List[Hash32, MAX_ACCESS_LIST_STORAGE_KEYS]
+class RlpLegacyReplayableCreateTransactionPayload(
+    ProgressiveContainer[active_fields=[1, 0, 1, 1, 1, 0, 1, 1]]
+):
+    type_: TransactionType  # 0x00
+    nonce: uint64
+    max_fees_per_gas: BasicFeesPerGas
+    gas: GasAmount
+    value: uint256
+    input_: ProgressiveByteList
 
-class AuthorizationPayload(StableContainer[MAX_AUTHORIZATION_PAYLOAD_FIELDS]):
-    magic: Optional[TransactionType]
-    chain_id: Optional[ChainId]
-    address: Optional[ExecutionAddress]
-    nonce: Optional[uint64]
-
-class Authorization(Container):
-    payload: AuthorizationPayload
-    signature: ExecutionSignature
-
-class TransactionPayload(StableContainer[MAX_TRANSACTION_PAYLOAD_FIELDS]):
-    # EIP-2718
-    type_: Optional[TransactionType]
-
-    # EIP-155
-    chain_id: Optional[ChainId]
-
-    nonce: Optional[uint64]
-    max_fees_per_gas: Optional[FeesPerGas]
-    gas: Optional[GasAmount]
-    to: Optional[ExecutionAddress]
-    value: Optional[uint256]
-    input_: Optional[ByteList[MAX_CALLDATA_SIZE]]
-
-    # EIP-2930
-    access_list: Optional[List[AccessTuple, MAX_ACCESS_LIST_SIZE]]
-
-    # EIP-1559
-    max_priority_fees_per_gas: Optional[FeesPerGas]
-
-    # EIP-4844
-    blob_versioned_hashes: Optional[List[VersionedHash, MAX_BLOB_COMMITMENTS_PER_BLOCK]]
-
-    # EIP-7702
-    authorization_list: Optional[List[Authorization, MAX_AUTHORIZATION_LIST_SIZE]]
-
-class Transaction(Container):
-    payload: TransactionPayload
-    signature: ExecutionSignature
+class RlpLegacyReplayableCreateTransaction(Container):
+    payload: RlpLegacyReplayableCreateTransactionPayload
+    signature: Secp256k1ExecutionSignature
 ```
 
-### `Transaction` profiles
+#### EIP-155 legacy transactions
 
-[EIP-7495](./eip-7495.md) `Profile` definitions provide type safety for valid transactions. Their original RLP `TransactionType` is retained to enable recovery of their original RLP representation and associated `sig_hash` and `tx_hash` values where necessary.
+These transactions are locked to a single [EIP-155](./eip-155.md) chain ID.
 
 ```python
-class BasicFeesPerGas(Profile[FeesPerGas]):
-    regular: FeePerGas
-
-class BlobFeesPerGas(Profile[FeesPerGas]):
-    regular: FeePerGas
-    blob: FeePerGas
-
-class RlpLegacyTransactionPayload(Profile[TransactionPayload]):
-    type_: TransactionType
-    chain_id: Optional[ChainId]
-    nonce: uint64
-    max_fees_per_gas: BasicFeesPerGas
-    gas: GasAmount
-    to: Optional[ExecutionAddress]
-    value: uint256
-    input_: ByteList[MAX_CALLDATA_SIZE]
-
-class RlpLegacyTransaction(Container):
-    payload: RlpLegacyTransactionPayload
-    signature: Secp256k1ExecutionSignature
-
-class RlpAccessListTransactionPayload(Profile[TransactionPayload]):
-    type_: TransactionType
+class RlpLegacyBasicTransactionPayload(
+    ProgressiveContainer[active_fields=[1, 1, 1, 1, 1, 1, 1, 1]]
+):
+    type_: TransactionType  # 0x00
     chain_id: ChainId
     nonce: uint64
     max_fees_per_gas: BasicFeesPerGas
     gas: GasAmount
-    to: Optional[ExecutionAddress]
+    to: ExecutionAddress
     value: uint256
-    input_: ByteList[MAX_CALLDATA_SIZE]
-    access_list: List[AccessTuple, MAX_ACCESS_LIST_SIZE]
+    input_: ProgressiveByteList
 
-class RlpAccessListTransaction(Container):
-    payload: RlpAccessListTransactionPayload
+class RlpLegacyBasicTransaction(Container):
+    payload: RlpLegacyBasicTransactionPayload
     signature: Secp256k1ExecutionSignature
 
-class RlpFeeMarketTransactionPayload(Profile[TransactionPayload]):
-    type_: TransactionType
+class RlpLegacyCreateTransactionPayload(
+    ProgressiveContainer[active_fields=[1, 1, 1, 1, 1, 0, 1, 1]]
+):
+    type_: TransactionType  # 0x00
     chain_id: ChainId
     nonce: uint64
     max_fees_per_gas: BasicFeesPerGas
     gas: GasAmount
-    to: Optional[ExecutionAddress]
     value: uint256
-    input_: ByteList[MAX_CALLDATA_SIZE]
-    access_list: List[AccessTuple, MAX_ACCESS_LIST_SIZE]
+    input_: ProgressiveByteList
+
+class RlpLegacyCreateTransaction(Container):
+    payload: RlpLegacyCreateTransactionPayload
+    signature: Secp256k1ExecutionSignature
+```
+
+#### EIP-2930 access list transactions
+
+These transactions support specifying an [EIP-2930](./eip-2930.md) access list.
+
+```python
+class AccessTuple(Container):
+    address: ExecutionAddress
+    storage_keys: ProgressiveList[Hash32]
+
+class RlpAccessListBasicTransactionPayload(
+    ProgressiveContainer[active_fields=[1, 1, 1, 1, 1, 1, 1, 1, 1]]
+):
+    type_: TransactionType  # 0x01
+    chain_id: ChainId
+    nonce: uint64
+    max_fees_per_gas: BasicFeesPerGas
+    gas: GasAmount
+    to: ExecutionAddress
+    value: uint256
+    input_: ProgressiveByteList
+    access_list: ProgressiveList[AccessTuple]
+
+class RlpAccessListBasicTransaction(Container):
+    payload: RlpAccessListBasicTransactionPayload
+    signature: Secp256k1ExecutionSignature
+
+class RlpAccessListCreateTransactionPayload(
+    ProgressiveContainer[active_fields=[1, 1, 1, 1, 1, 0, 1, 1, 1]]
+):
+    type_: TransactionType  # 0x01
+    chain_id: ChainId
+    nonce: uint64
+    max_fees_per_gas: BasicFeesPerGas
+    gas: GasAmount
+    value: uint256
+    input_: ProgressiveByteList
+    access_list: ProgressiveList[AccessTuple]
+
+class RlpAccessListCreateTransaction(Container):
+    payload: RlpAccessListCreateTransactionPayload
+    signature: Secp256k1ExecutionSignature
+```
+
+#### EIP-1559 fee market transactions
+
+These transactions support specifying [EIP-1559](./eip-1559.md) priority fees.
+
+```python
+class RlpBasicTransactionPayload(
+    ProgressiveContainer[active_fields=[1, 1, 1, 1, 1, 1, 1, 1, 1, 1]]
+):
+    type_: TransactionType  # 0x02
+    chain_id: ChainId
+    nonce: uint64
+    max_fees_per_gas: BasicFeesPerGas
+    gas: GasAmount
+    to: ExecutionAddress
+    value: uint256
+    input_: ProgressiveByteList
+    access_list: ProgressiveList[AccessTuple]
     max_priority_fees_per_gas: BasicFeesPerGas
 
-class RlpFeeMarketTransaction(Container):
-    payload: RlpFeeMarketTransactionPayload
+class RlpBasicTransaction(Container):
+    payload: RlpBasicTransactionPayload
     signature: Secp256k1ExecutionSignature
 
-class RlpBlobTransactionPayload(Profile[TransactionPayload]):
-    type_: TransactionType
+class RlpCreateTransactionPayload(
+    ProgressiveContainer[active_fields=[1, 1, 1, 1, 1, 0, 1, 1, 1, 1]]
+):
+    type_: TransactionType  # 0x02
+    chain_id: ChainId
+    nonce: uint64
+    max_fees_per_gas: BasicFeesPerGas
+    gas: GasAmount
+    value: uint256
+    input_: ProgressiveByteList
+    access_list: ProgressiveList[AccessTuple]
+    max_priority_fees_per_gas: BasicFeesPerGas
+
+class RlpCreateTransaction(Container):
+    payload: RlpCreateTransactionPayload
+    signature: Secp256k1ExecutionSignature
+```
+
+#### EIP-4844 blob transactions
+
+These transactions support specifying [EIP-4844](./eip-4844.md) blobs.
+
+```python
+class RlpBlobTransactionPayload(
+    ProgressiveContainer[active_fields=[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]]
+):
+    type_: TransactionType  # 0x03
     chain_id: ChainId
     nonce: uint64
     max_fees_per_gas: BlobFeesPerGas
     gas: GasAmount
     to: ExecutionAddress
     value: uint256
-    input_: ByteList[MAX_CALLDATA_SIZE]
-    access_list: List[AccessTuple, MAX_ACCESS_LIST_SIZE]
-    max_priority_fees_per_gas: BlobFeesPerGas
-    blob_versioned_hashes: List[VersionedHash, MAX_BLOB_COMMITMENTS_PER_BLOCK]
+    input_: ProgressiveByteList
+    access_list: ProgressiveList[AccessTuple]
+    max_priority_fees_per_gas: BasicFeesPerGas
+    blob_versioned_hashes: ProgressiveList[VersionedHash]
 
 class RlpBlobTransaction(Container):
     payload: RlpBlobTransactionPayload
     signature: Secp256k1ExecutionSignature
+```
 
-class RlpSetCodeAuthorizationPayload(Profile[AuthorizationPayload]):
-    magic: TransactionType
-    chain_id: Optional[ChainId]
+#### EIP-7702 set code transactions
+
+These transactions support specifying an [EIP-7702](./eip-7702.md) authorization list.
+
+```python
+class RlpAuthorization(CompatibleUnion[
+    RlpReplayableBasicAuthorizationPayload,
+    RlpBasicAuthorizationPayload,
+]):
+    pass
+
+class RlpReplayableBasicAuthorizationPayload(ProgressiveContainer[active_fields=[1, 0, 1, 1]]):
+    magic: TransactionType  # 0x05
     address: ExecutionAddress
     nonce: uint64
 
-class RlpSetCodeAuthorization(Container):
-    payload: RlpSetCodeAuthorizationPayload
-    signature: Secp256k1ExecutionSignature
+class RlpBasicAuthorizationPayload(ProgressiveContainer[active_fields=[1, 1, 1, 1]]):
+    magic: TransactionType  # 0x05
+    chain_id: ChainId
+    address: ExecutionAddress
+    nonce: uint64
 
-class RlpSetCodeTransactionPayload(Profile[TransactionPayload]):
-    type_: TransactionType
+class RlpSetCodeTransactionPayload(
+    ProgressiveContainer[active_fields=[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]]
+):
+    type_: TransactionType  # 0x04
     chain_id: ChainId
     nonce: uint64
     max_fees_per_gas: BasicFeesPerGas
     gas: GasAmount
     to: ExecutionAddress
     value: uint256
-    input_: ByteList[MAX_CALLDATA_SIZE]
-    access_list: List[AccessTuple, MAX_ACCESS_LIST_SIZE]
+    input_: ProgressiveByteList
+    access_list: ProgressiveList[AccessTuple]
     max_priority_fees_per_gas: BasicFeesPerGas
-    authorization_list: List[RlpSetCodeAuthorization, MAX_AUTHORIZATION_LIST_SIZE]
+    authorization_list: ProgressiveList[RlpSetCodeAuthorization]
 
 class RlpSetCodeTransaction(Container):
-    payload: RlpSetCodeTransactionPayload
+    payload: RlpAuthorization
     signature: Secp256k1ExecutionSignature
 ```
 
-Helpers are provided to identify the [EIP-7495](./eip-7495.md) `Profile` of a normalized `Transaction`. The type system ensures that all required fields of the `Profile` are present and that excluded fields are absent.
-
-```python
-LEGACY_TX_TYPE = TransactionType(0x00)
-ACCESS_LIST_TX_TYPE = TransactionType(0x01)
-FEE_MARKET_TX_TYPE = TransactionType(0x02)
-BLOB_TX_TYPE = TransactionType(0x03)
-SET_CODE_TX_TYPE = TransactionType(0x04)
-SET_CODE_TX_MAGIC = TransactionType(0x05)
-
-def identify_authorization_profile(auth: Authorization) -> Type[Profile]:
-    if auth.payload.magic == SET_CODE_TX_MAGIC:
-        if auth.payload.chain_id == 0:
-            raise Exception(f'Unsupported chain ID in Set Code RLP authorization: {auth}')
-        return RlpSetCodeAuthorization
-
-    raise Exception(f'Unsupported authorization: {auth}')
-
-def identify_transaction_profile(tx: Transaction) -> Type[Profile]:
-    if tx.payload.type_ == SET_CODE_TX_TYPE:
-        for auth in tx.payload.authorization_list or []:
-            auth = identify_authorization_profile(auth).from_base(auth)
-            if not isinstance(auth, RlpSetCodeAuthorization):
-                raise Exception(f'Unsupported authorization in Set Code RLP transaction: {tx}')
-        return RlpSetCodeTransaction
-
-    if tx.payload.type_ == BLOB_TX_TYPE:
-        if (tx.payload.max_priority_fees_per_gas or FeesPerGas()).blob != 0:
-            raise Exception(f'Unsupported blob priority fee in Blob RLP transaction: {tx}')
-        return RlpBlobTransaction
-
-    if tx.payload.type_ == FEE_MARKET_TX_TYPE:
-        return RlpFeeMarketTransaction
-
-    if tx.payload.type_ == ACCESS_LIST_TX_TYPE:
-        return RlpAccessListTransaction
-
-    if tx.payload.type_ == LEGACY_TX_TYPE:
-        return RlpLegacyTransaction
-
-    raise Exception(f'Unsupported transaction: {tx}')
-```
-
-To obtain a transaction's `from` address, its identifier, or an authorization's `authority` address, see [EIP assets](../assets/eip-6404/tx_hashes.py) for a definition of `compute_sig_hash`, `compute_tx_hash`, and `compute_auth_hash` that account for the various transaction types.
-
 ### Execution block header changes
 
-The [execution block header's `txs-root`](https://github.com/ethereum/devp2p/blob/5713591d0366da78a913a811c7502d9ca91d29a8/caps/eth.md#block-encoding-and-validity) is transitioned from MPT to SSZ.
+The [execution block header's `txs-root`](https://github.com/ethereum/devp2p/blob/bc76b9809a30e6dc5c8dcda996273f0f9bcf7108/caps/eth.md#block-encoding-and-validity) is transitioned from MPT to SSZ.
 
 ```python
-transactions = List[Transaction, MAX_TRANSACTIONS_PER_PAYLOAD](
+transactions = ProgressiveList[Transaction](
     tx_0, tx_1, tx_2, ...)
 
 block_header.transactions_root = transactions.hash_tree_root()
@@ -331,120 +374,42 @@ block_header.transactions_root = transactions.hash_tree_root()
 
 ### Engine API
 
-In the engine API, the structure of the `transactions` field in `ExecutionPayload` versions adopting this EIP is changed from `Array of DATA` to `Array of TransactionV1`.
+In the engine API, the semantics of the `transactions` field in `ExecutionPayload` versions adopting this EIP are changed to emit transactions using SSZ serialization.
 
-`TransactionV1` is defined to map onto the SSZ `Transaction` type, as follows:
-
-- `payload`: `TransactionPayloadV1` - An `OBJECT` containing the fields of a `TransactionPayloadV1` structure
-- `signature`: `ExecutionSignatureV1` - An `OBJECT` containing the fields of an `ExecutionSignatureV1` structure
-
-`TransactionPayloadV1` is defined to map onto the SSZ `TransactionPayload` `StableContainer`, as follows:
-
-- `type`: `QUANTITY|null`, 8 Bits or `null`
-- `chainId`: `QUANTITY|null`, 256 Bits or `null`
-- `nonce`: `QUANTITY|null`, 64 Bits or `null`
-- `maxFeesPerGas`: `FeesPerGasV1|null` - An `OBJECT` containing the fields of a `FeesPerGasV1` structure or `null`
-- `gas`: `QUANTITY|null`, 64 Bits or `null`
-- `to`: `DATA|null`, 20 Bytes or `null`
-- `value`: `QUANTITY|null`, 256 Bits or `null`
-- `input`: `DATA|null`, 0 through `MAX_CALLDATA_SIZE` bytes or `null`
-- `accessList`: `Array of AccessTupleV1` - 0 through `MAX_ACCESS_LIST_SIZE` `OBJECT` entries each containing the fields of an `AccessTupleV1` structure, or `null`
-- `maxPriorityFeesPerGas`: `FeesPerGasV1|null` - An `OBJECT` containing the fields of a `FeesPerGasV1` structure or `null`
-- `blobVersionedHashes`: `Array of DATA|null` - 0 through `MAX_BLOB_COMMITMENTS_PER_BLOCK` `DATA` entries each containing 32 Bytes, or `null`
-- `authorizationList`: `Array of AuthorizationV1` - 0 through `MAX_AUTHORIZATION_LIST_SIZE` `OBJECT` entries each containing the fields of an `AuthorizationV1` structure, or `null`
-
-`FeesPerGasV1` is defined to map onto the SSZ `FeesPerGas` `StableContainer`, as follows:
-
-- `regular`: `QUANTITY|null`, 256 Bits or `null`
-- `blob`: `QUANTITY|null`, 256 Bits or `null`
-
-`AccessTupleV1` is defined to map onto the SSZ `AccessTuple` `Container`, as follows:
-
-- `address`: `DATA`, 20 Bytes
-- `storageKeys`: `Array of DATA` - 0 through `MAX_ACCESS_LIST_STORAGE_KEYS` `DATA` entries each containing 32 Bytes
-
-`AuthorizationV1` is defined to map onto the SSZ `Authorization` `Container`, as follows:
-
-- `payload`: `AuthorizationPayloadV1` - An `OBJECT` containing the fields of an `AuthorizationPayloadV1` structure
-- `signature`: `ExecutionSignatureV1` - An `OBJECT` containing the fields of an `ExecutionSignatureV1` structure
-
-`AuthorizationPayloadV1` is defined to map onto the SSZ `AuthorizationPayload` `StableContainer`, as follows:
-
-- `magic`: `QUANTITY|null`, 8 Bits or `null`
-- `chainId`: `QUANTITY|null`, 256 Bits or `null`
-- `address`: `DATA|null`, 20 Bytes or `null`
-- `nonce`: `QUANTITY|null`, 64 Bits or `null`
-
-`ExecutionSignatureV1` is defined to map onto the SSZ `ExecutionSignature` `StableContainer`, as follows:
-
-- `secp256k1`: `DATA|null`, 65 Bytes or `null`
+- `transactions` - `Array` of `DATA` - Array of transaction objects, each object is a byte list (`DATA`) representing `ssz.serialize(tx)`
 
 ### Consensus `ExecutionPayload` changes
 
-When building a consensus `ExecutionPayload`, the [`transactions`](https://github.com/ethereum/consensus-specs/blob/b3e83f6691c61e5b35136000146015653b22ed38/specs/deneb/beacon-chain.md#executionpayload) list is no longer opaque and uses the new `Transaction` type.
+When building a consensus `ExecutionPayload`, the [`transactions`](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/specs/deneb/beacon-chain.md#executionpayload) list is no longer opaque and uses the new `Transaction` type, aligning the `transactions_root` across execution blocks and execution payloads.
 
 ```python
 class ExecutionPayload(Container):
     ...
-    transactions: List[Transaction, MAX_TRANSACTIONS_PER_PAYLOAD]
+    transactions: ProgressiveList[Transaction]
     ...
 ```
 
-### SSZ `PooledTransaction` container
-
-During transaction gossip responses ([`PooledTransactions`](https://github.com/ethereum/devp2p/blob/5713591d0366da78a913a811c7502d9ca91d29a8/caps/eth.md#pooledtransactions-0x0a)), each `Transaction` is wrapped into a `PooledTransaction`.
-
-| Name | Value | Description |
-| - | - | - |
-| `MAX_POOLED_TRANSACTION_FIELDS` | `uint64(2**3)` (= 8) | Maximum number of fields to which `PooledTransaction` can ever grow in the future |
-
-```python
-class BlobData(Container):
-    blobs: List[Blob, MAX_BLOB_COMMITMENTS_PER_BLOCK]
-    commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK]
-    proofs: List[KZGProof, MAX_BLOB_COMMITMENTS_PER_BLOCK]
-
-class PooledTransaction(StableContainer[MAX_POOLED_TRANSACTION_FIELDS]):
-    tx: Optional[Transaction]
-    blob_data: Optional[BlobData]
-```
-
-The additional validation constraints defined in [EIP-4844](./eip-4844.md) also apply to transactions that define `tx.payload.blob_versioned_hashes` or `blob_data`.
-
-### Transaction gossip announcements
-
-The semantics of the [`types` element](./eip-5793.md) in transaction gossip announcements ([`NewPooledTransactionHashes`](https://github.com/ethereum/devp2p/blob/5713591d0366da78a913a811c7502d9ca91d29a8/caps/eth.md#newpooledtransactionhashes-0x08)) are changed to match `ssz(PooledTransaction.active_fields())`. The separate control flow for fetching blob transactions compared to basic transactions is retained.
-
-Note that this change maps `active_fields` for `PooledTransaction` with `blob_data` to `0x03`, which coincides with the previous [`BLOB_TX_TYPE`](./eip-4844.md) prefix of blob RLP transactions.
-
-### Networking
-
-When exchanging SSZ transactions via the [Ethereum Wire Protocol](https://github.com/ethereum/devp2p/blob/5713591d0366da78a913a811c7502d9ca91d29a8/caps/eth.md), the following [EIP-2718](./eip-2718.md) compatible envelopes are used:
-
-| Name | Value | Description |
-| - | - | - |
-| `SSZ_TX_TYPE` | `TransactionType(0x1f)` | Endpoint specific SSZ object |
-
-- `Transaction`: `SSZ_TX_TYPE || snappyFramed(ssz(Transaction))`
-- `PooledTransaction`: `SSZ_TX_TYPE || snappyFramed(ssz(PooledTransaction))`
-
-Objects are encoded using [SSZ](https://github.com/ethereum/consensus-specs/blob/b3e83f6691c61e5b35136000146015653b22ed38/ssz/simple-serialize.md) and compressed using the Snappy framing format, matching the encoding of consensus objects as defined in the [consensus networking specification](https://github.com/ethereum/consensus-specs/blob/b3e83f6691c61e5b35136000146015653b22ed38/specs/phase0/p2p-interface.md#ssz-snappy-encoding-strategy). As part of the encoding, the uncompressed object length is emitted; the RECOMMENDED limit to enforce per object is [`MAX_CHUNK_SIZE`](https://github.com/ethereum/consensus-specs/blob/e3a939e439d6c05356c9c29c5cd347384180bc01/specs/phase0/p2p-interface.md#configuration) bytes.
-
-Implementations SHOULD continue to support accepting RLP transactions into their transaction pool. However, such transactions MUST be converted to SSZ for inclusion into an `ExecutionPayload`. See [EIP assets](../assets/eip-6404/convert.py) for a reference implementation to convert from RLP to SSZ, as well as corresponding [test cases](../assets/eip-6404/convert_tests.py). The original `sig_hash` and `tx_hash` are retained throughout the conversion process.
-
 ## Rationale
 
-Switching to a single, unified and forward compatible transaction format within execution blocks reduces implementation complexity for client applications and smart contracts. Future use cases such as transaction inclusion proofs or submitting individual verifiable chunks of calldata to a smart contract become easier to implement with SSZ.
+### Forward compatibility
 
-Various protocol inefficiencies are also addressed. While the transaction data is hashed several times under the RLP system, including (1) `sig_hash`, (2) `tx_hash`, (3) MPT internal hash, and (4) SSZ internal hash, the normalized representation reduces the hash count. Furthermore, Consensus Layer implementations may drop invalid blocks early if consensus `blob_kzg_commitments` do not validate against transaction `blob_versioned_hashes` and no longer need to query the Execution Layer for block hash validation.
+The proposed transaction design is extensible with new fee types, new signature types, and entirely new transaction features (e.g., CREATE2), while retaining compatibility with the proposed transactions.
+
+### Verifier improvements
+
+Future RPC could expose an SSZ based `tx_root` on top of the `tx_hash`, against which proofs can be validated. The `transactions_root` can now be reconstructed from the list of `tx_root`. Further, partial data becomes provable, such as destination / amount without requiring the full calldata. This can reduce gas cost or zk proving cost when verifying L2 chain data in an L1 smart contract.
+
+### Consensus client improvements
+
+Consensus Layer implementations may drop invalid blocks early if consensus `blob_kzg_commitments` do not validate against transaction `blob_versioned_hashes` and no longer need to query the Execution Layer for that validation. Future versions of the engine API could be simplified to drop the transfers of `blob_kzg_commitments` to the EL.
 
 ## Backwards Compatibility
 
 Applications that rely on the replaced MPT `transactions_root` in the block header require migration to the SSZ `transactions_root`.
 
-While there is no on-chain commitment of the `tx_hash`, it is widely used in JSON-RPC and the [Ethereum Wire Protocol](https://github.com/ethereum/devp2p/blob/5713591d0366da78a913a811c7502d9ca91d29a8/caps/eth.md) to uniquely identify transactions. The `tx_hash` remains stable across the conversion from RLP to SSZ.
+While there is no on-chain commitment of the `tx_hash`, it is widely used in JSON-RPC and the [Ethereum Wire Protocol](https://github.com/ethereum/devp2p/blob/bc76b9809a30e6dc5c8dcda996273f0f9bcf7108/caps/eth.md) to uniquely identify transactions. The conversion from RLP transactions to SSZ is lossless. The original RLP `sig_hash` and `tx_hash` can be recovered from the SSZ representation.
 
-The conversion from RLP transactions to SSZ is lossless. The original RLP `sig_hash` and `tx_hash` can be recovered from the SSZ representation.
+RLP and SSZ transactions may clash when encoded. It is essential to use only a single format within one channel.
 
 ## Security Considerations
 

--- a/EIPS/eip-6465.md
+++ b/EIPS/eip-6465.md
@@ -41,7 +41,6 @@ Definitions from existing specifications that are used throughout this document 
 | Name | Value |
 | - | - |
 | [`MAX_WITHDRAWALS_PER_PAYLOAD`](https://github.com/ethereum/consensus-specs/blob/b3e83f6691c61e5b35136000146015653b22ed38/specs/capella/beacon-chain.md#execution) | `uint64(2**4)` (= 16) |
-| [`SSZ_TX_TYPE`](./eip-6404.md#networking) | `0x1f` |
 
 ### SSZ `Withdrawal` container
 
@@ -66,39 +65,6 @@ withdrawals = List[Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD](
 block_header.withdrawals_root == withdrawals.hash_tree_root()
 ```
 
-### Typed withdrawal envelope
-
-A typed withdrawal envelope similar to [EIP-2718](./eip-2718.md) is introduced for exchanging withdrawals via the [Ethereum Wire Protocol](https://github.com/ethereum/devp2p/blob/5713591d0366da78a913a811c7502d9ca91d29a8/caps/eth.md).
-
-```
-withdrawal = {legacy-withdrawal, typed-withdrawal}
-```
-
-Untyped, legacy withdrawals are given as an RLP list as defined in [EIP-4895](./eip-4895.md).
-
-```
-legacy-withdrawal = [
-    index: P,
-    validator-index: P,
-    address: B_20,
-    amount: P,
-]
-```
-
-Typed withdrawals are encoded as RLP byte arrays where the first byte is a withdrawal type (`withdrawal-type`) and the remaining bytes are opaque type-specific data.
-
-```
-typed-withdrawal = withdrawal-type || withdrawal-data
-```
-
-### Networking
-
-When exchanging SSZ withdrawals via the [Ethereum Wire Protocol](https://github.com/ethereum/devp2p/blob/5713591d0366da78a913a811c7502d9ca91d29a8/caps/eth.md), the following withdrawal envelope is used:
-
-- `Withdrawal`: `SSZ_TX_TYPE || snappyFramed(ssz(Withdrawal))`
-
-Objects are encoded using [SSZ](https://github.com/ethereum/consensus-specs/blob/b3e83f6691c61e5b35136000146015653b22ed38/ssz/simple-serialize.md) and compressed using the Snappy framing format, matching the encoding of consensus objects as defined in the [consensus networking specification](https://github.com/ethereum/consensus-specs/blob/b3e83f6691c61e5b35136000146015653b22ed38/specs/phase0/p2p-interface.md#ssz-snappy-encoding-strategy). As part of the encoding, the uncompressed object length is emitted; the RECOMMENDED limit to enforce per object is `8 + 8 + 20 + 8` (= 44) bytes.
-
 ## Rationale
 
 This change was originally a candidate for inclusion in Shanghai, but was postponed to accelerate the rollout of withdrawals.
@@ -110,8 +76,6 @@ The RLPx serialization layer may not be aware of the fork schedule and the block
 ## Backwards Compatibility
 
 Applications that rely on the replaced MPT `withdrawals_root` in the block header require migration to the SSZ `withdrawals_root`.
-
-Clients can differentiate between the legacy withdrawals and typed withdrawals by looking at the first byte. If it starts with a value in the range `[0, 0x7f]` then it is a new withdrawal type, if it starts with a value in the range `[0xc0, 0xfe]` then it is a legacy withdrawal type. `0xff` is not realistic for an RLP encoded withdrawal, so it is reserved for future use as an extension sentinel value.
 
 ## Security Considerations
 

--- a/EIPS/eip-6466.md
+++ b/EIPS/eip-6466.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2023-02-08
-requires: 658, 2718, 6404, 7702
+requires: 658, 2718, 6404, 7495, 7702, 7919
 ---
 
 ## Abstract
@@ -37,17 +37,11 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 Definitions from existing specifications that are used throughout this document are replicated here for reference.
 
-| Name | Value |
-| - | - |
-| [`MAX_TRANSACTIONS_PER_PAYLOAD`](https://github.com/ethereum/consensus-specs/blob/b3e83f6691c61e5b35136000146015653b22ed38/specs/bellatrix/beacon-chain.md#execution) | `uint64(2**20)` (= 1,048,576) |
-| [`MAX_AUTHORIZATION_LIST_SIZE`](./eip-6404.md#transaction-container) | `uint64(2**16)` (= 65,536) |
-| [`SSZ_TX_TYPE`](./eip-6404.md#networking) | `0x1f` |
-
 | Name | SSZ equivalent |
 | - | - |
 | [`Root`](https://github.com/ethereum/consensus-specs/blob/b3e83f6691c61e5b35136000146015653b22ed38/specs/phase0/beacon-chain.md#custom-types) | `Bytes32` |
 | [`ExecutionAddress`](https://github.com/ethereum/consensus-specs/blob/b3e83f6691c61e5b35136000146015653b22ed38/specs/bellatrix/beacon-chain.md#custom-types) | `Bytes20` |
-| [`GasAmount`](./eip-6404.md#transaction-container) | `uint64` |
+| [`GasAmount`](./eip-6404.md#normalized-transactions) | `uint64` |
 
 ### `Receipt` container
 
@@ -56,39 +50,37 @@ All receipts are represented as a single, normalized SSZ container. The definiti
 | Name | Value | Description |
 | - | - | - |
 | `MAX_TOPICS_PER_LOG` | `4` | `LOG0` through `LOG4` opcodes allow 0-4 topics per log |
-| `MAX_LOG_DATA_SIZE` | `uint64(2**24)` (= 16,777,216) | Maximum `data` byte length for a log |
-| `MAX_LOGS_PER_RECEIPT` | `uint64(2**21)` (= 2,097,152) | Maximum number of entries within `logs` |
 | `MAX_RECEIPT_FIELDS` | `uint64(2**5)` (= 32) | Maximum number of fields to which `Receipt` can ever grow in the future |
 
 ```python
 class Log(Container):
     address: ExecutionAddress
     topics: List[Bytes32, MAX_TOPICS_PER_LOG]
-    data: ByteList[MAX_LOG_DATA_SIZE]
+    data: ProgressiveByteList
 
 class StableReceipt(StableContainer[MAX_RECEIPT_FIELDS]):
     from_: Optional[ExecutionAddress]
     gas_used: Optional[GasAmount]
     contract_address: Optional[ExecutionAddress]
-    logs: Optional[List[Log, MAX_LOGS_PER_RECEIPT]]
+    logs: Optional[ProgressiveList[Log]]
 
     # EIP-658
     status: Optional[boolean]
 
     # EIP-7702
-    authorities: Optional[List[ExecutionAddress, MAX_AUTHORIZATION_LIST_SIZE]]
+    authorities: Optional[ProgressiveList[ExecutionAddress]]
 
 class Receipt(Profile[StableReceipt]):
     from_: ExecutionAddress
     gas_used: GasAmount
     contract_address: Optional[ExecutionAddress]
-    logs: List[Log, MAX_LOGS_PER_RECEIPT]
+    logs: ProgressiveList[Log]
 
     # EIP-658
     status: boolean
 
     # EIP-7702
-    authorities: Optional[List[ExecutionAddress, MAX_AUTHORIZATION_LIST_SIZE]]
+    authorities: Optional[ProgressiveList[ExecutionAddress]]
 ```
 
 ### `Receipt` construction
@@ -111,7 +103,7 @@ The `logs_bloom` and intermediate state `root` (Homestead scheme) are not presen
 The [execution block header's `receipts-root`](https://github.com/ethereum/devp2p/blob/5713591d0366da78a913a811c7502d9ca91d29a8/caps/eth.md#block-encoding-and-validity) is transitioned from MPT to SSZ.
 
 ```python
-receipts = List[Receipt, MAX_TRANSACTIONS_PER_PAYLOAD](
+receipts = ProgressiveList[Receipt](
     receipt_0, receipt_1, receipt_2, ...)
 
 block_header.receipts_root = receipts.hash_tree_root()
@@ -121,7 +113,9 @@ block_header.receipts_root = receipts.hash_tree_root()
 
 Transaction receipt objects in the context of the JSON-RPC API are extended to include:
 
-- `authorities`: `Array of DATA|null` - 0 through `MAX_AUTHORIZATION_LIST_SIZE` `DATA` entries each containing 20 Bytes, corresponding to the receipt's `authorities` field
+- `authorities`: `Array of DATA|null` - Array of `DATA` entries each containing 20 Bytes, corresponding to the receipt's `authorities` field
+
+Within `logs`, the `logIndex` field is removed as it cannot be efficiently validated. This includes responses pertaining to historical logs.
 
 The `logsBloom` field is no longer returned for new receipts. It continues to be returned for historical receipts conforming to earlier schemes.
 
@@ -147,14 +141,6 @@ class ExecutionPayloadHeader(Container):
 payload_header.receipts_root = payload.receipts_root
 ```
 
-### Networking
-
-When exchanging SSZ receipts via the [Ethereum Wire Protocol](https://github.com/ethereum/devp2p/blob/6b259a7003b4bfb18365ba690f4b00ba8a26393b/caps/eth.md), the following [EIP-2718](./eip-2718.md) compatible envelope is used:
-
-- `Receipt`: `SSZ_TX_TYPE || snappyFramed(ssz(Receipt))`
-
-Objects are encoded using [SSZ](https://github.com/ethereum/consensus-specs/blob/b3e83f6691c61e5b35136000146015653b22ed38/ssz/simple-serialize.md) and compressed using the Snappy framing format, matching the encoding of consensus objects as defined in the [consensus networking specification](https://github.com/ethereum/consensus-specs/blob/b3e83f6691c61e5b35136000146015653b22ed38/specs/phase0/p2p-interface.md#ssz-snappy-encoding-strategy). As part of the encoding, the uncompressed object length is emitted; the RECOMMENDED limit to enforce per object is [`MAX_CHUNK_SIZE`](https://github.com/ethereum/consensus-specs/blob/e3a939e439d6c05356c9c29c5cd347384180bc01/specs/phase0/p2p-interface.md#configuration) bytes.
-
 ## Rationale
 
 Switching to a single, unified and forward compatible receipt format within execution blocks reduces implementation complexity for client applications and smart contracts. Individual chunks of receipt data can now be verified, simplifying implementation of bridges.
@@ -170,6 +156,10 @@ Applications that rely on the replaced MPT `receipts_root` in the block header r
 Applications using verified `cumulativeGasUsed` values have to compute the value from prior receipts.
 
 Applications relying on the `logsBloom` will have to swap to an out-of-protocol mechanism for filtering logs, or fall back to processing the complete set of receipts. As the `logsBloom` mechanism was prohibitively inefficient for light clients, its removal is unlikely to have a significant impact.
+
+Applications relying on the `logIndex` have to compute this value from the full receipt data. Note that verifying applications already have to do this.
+
+RLP and SSZ receipts may clash when encoded. It is essential to use only a single format within one channel.
 
 ## Security Considerations
 

--- a/EIPS/eip-6493.md
+++ b/EIPS/eip-6493.md
@@ -53,9 +53,13 @@ def compute_ssz_tx_hash(tx: Transaction) -> Hash32:
 
 ### JSON-RPC
 
+| Name | Value | Description |
+| - | - | - |
+| `SSZ_TX_TYPE` | `TransactionType(0x1f)` | Endpoint specific SSZ object |
+
 Certain JSON-RPC endpoints such as `eth_getTransactionByHash` indicate the corresponding [EIP-2718](./eip-2718.md) envelope type prefix in a `type` field.
 
-When representing native SSZ transactions on such endpoints, `SSZ_TX_TYPE` SHOULD be indicated as their `type`, as defined in [EIP-6404](./eip-6404.md#networking). Omitting the `type` is NOT RECOMMENDED as certain client applications could confuse the omission with untyped `LegacyTransaction`.
+When representing native SSZ transactions on such endpoints, `SSZ_TX_TYPE` SHOULD be indicated as their `type`. Omitting the `type` is NOT RECOMMENDED as certain client applications could confuse the omission with untyped `LegacyTransaction`.
 
 ### `Transaction` profiles
 

--- a/EIPS/eip-7792.md
+++ b/EIPS/eip-7792.md
@@ -109,7 +109,7 @@ Making the `eth_getLogs` response verifiable adds the necessary security attribu
 
 ### Gas cost
 
-The gas cost produced by this scheme is significantly higher than what `LOG#` opcodes produce as of Prague, primarily due to the additional `SLOAD` / `SSTORE` requirement and the double cost of `SHA256` opcodes compared to `KECCAK256` opcodes. The gas cost increases outweigh the savings from dropping logs blooms.
+The gas cost produced by this scheme is significantly higher than what `LOG#` opcodes produce as of Prague, primarily due to the additional `SLOAD` / `SSTORE` and the double cost of `SHA256` opcodes compared to `KECCAK256` opcodes. The gas cost increases outweigh the savings from dropping logs blooms.
 
 If the mechanism turns out to be prohibitively expensive even when optimized, it may be necessary to move the log accumulators to a separate optimized data structure (not in `state_root`), or to an out-of-protocol zk system. Even then, the gas cost for logs should still reflect the actual overall cost to update a typical out-of-protocol accumulator to deter against log spamming.
 

--- a/EIPS/eip-7807.md
+++ b/EIPS/eip-7807.md
@@ -108,8 +108,6 @@ In the initial draft, only the requests hash and block hash are changed to be SS
 
 - Engine API should be updated with (1) possible withdrawals/requests refactoring as above, (2) dropping the `block_hash` field so that `ExecutionPayload` is replaced with to `ExecutionBlockHeader`, (3) binary encoding based on `ForkDigest`-context (through HTTP header or interleaved, similar to beacon-API). This reduces encoding overhead and also simplifies sharing data structures in combined CL/EL in-process implementations.
 
-- Networking should be updated to be SSZ based, using similar format as [EIP-6404](./eip-6404.md#networking) with a type prefix followed by a potentially SSZ snappy compressed payload.
-
 ## Backwards Compatibility
 
 This breaks compatibility of smart contracts that depend on the previous block header binary format, including for "generic" implementations that assume a common prefix and run the entire data through a linear keccak256 hash.


### PR DESCRIPTION
- Adopt latest EIP-7495: no optionals / profiles / field capacities
- Adopt EIP-7916 ProgressiveList: no capacities
- Update engine API to be based on `ssz.serialize`
- Drop networking changes, such efforts can be adopted separately
