### PR TITLE
Update EIP-6914: fix typo in AttesterSlashing participants description

### DIFF
--- a/EIPS/eip-6914.md
+++ b/EIPS/eip-6914.md
@@ -55,7 +55,7 @@ Validator indices cannot be immediately reused but instead must wait `SAFE_EPOCH
 The attestation poisoning attack hinges upon two facts:
 
 * the reuse of a validator index overwrites the previous validator's pubkey from the beacon state.
-* `AttesterSlashing`s include validator indices to reconstruct signature pariticipants.
+* `AttesterSlashing`s include validator indices to reconstruct signature participants.
 
 ### Details of attack
 


### PR DESCRIPTION


**Description:**  
This pull request corrects a typo in the EIP-6914 documentation, changing "pariticipants" to "participants" for improved clarity and accuracy. 