### PR TITLE
Update EIP-1355: Fix Ethash documentation reference in EIP-1355

### DIFF
--- a/EIPS/eip-1355.md
+++ b/EIPS/eip-1355.md
@@ -22,7 +22,7 @@ Provide minimal set of changes to Ethash algorithm to hinder and delay the adopt
    ```
    where `FNV1A_PRIME` is 16777499 or 16777639.
 2. Change the hash function that determines the DAG item index in Ethash algorithm from `fnv()` to new `fnv1a()`.
-   In [Main Loop](https://github.com/ethereum/wiki/wiki/Ethash#main-loop) change
+   In [Main Loop](https://github.com/ethereum/eth-wiki/blob/master/concepts/ethash/ethash.md#main-loop) change
    ```python
    p = fnv(i ^ s[0], mix[i % w]) % (n // mixhashes) * mixhashes
    ```


### PR DESCRIPTION
Redirected wiki link to the current documentation location in eth-wiki. Updated reference from /wiki/wiki/Ethash#main-loop to /eth-wiki/blob/master/concepts/ethash/ethash.md#main-loop to reflect repository restructuring.