### PR TITLE
Update EIP-7907: Account for large contracts as tx entry point

### DIFF
--- a/EIPS/eip-7907.md
+++ b/EIPS/eip-7907.md
@@ -39,6 +39,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 `COLD_ACCOUNT_ACCESS_COST` and `WARM_STORAGE_READ_COST` are defined in [EIP-2929](./eip-2929.md#parameters).
 
 3. Update the [EIP-3860](./eip-3860.md) contract initcode size limit of 48KB (`0xc000` bytes) to 512KB (`0x80000` bytes).
+4. If a large contract is the entry point of a transaction, the cost calculated in (2) is charged before the execution of any opcode and contract code becomes warm immediately. The execution can run out-of-gas at this point if not enough gas was provided with the transaction to pay for this extra cost.
 
 ## Rationale
 

--- a/EIPS/eip-7907.md
+++ b/EIPS/eip-7907.md
@@ -39,7 +39,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 `COLD_ACCOUNT_ACCESS_COST` and `WARM_STORAGE_READ_COST` are defined in [EIP-2929](./eip-2929.md#parameters).
 
 3. Update the [EIP-3860](./eip-3860.md) contract initcode size limit of 48KB (`0xc000` bytes) to 512KB (`0x80000` bytes).
-4. If a large contract is the entry point of a transaction, the cost calculated in (2) is charged before the execution of any opcode and contract code becomes warm immediately. The execution can run out-of-gas at this point if not enough gas was provided with the transaction to pay for this extra cost.
+4. If a large contract is the entry point of a transaction, the cost calculated in (2) is charged before the execution and contract code is marked as warm. This fee is not calculated towards the initial gas fee. In case of out-of-gas halt, execution will stop and the balance will not be transferred.
 
 ## Rationale
 


### PR DESCRIPTION
Clarify behavior when a large contract is the entry point of a transaction.