### PR TITLE
Update EIP-7607: ACDE#214 changes

### DIFF
--- a/EIPS/eip-7607.md
+++ b/EIPS/eip-7607.md
@@ -82,7 +82,7 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Proposed
 | Network Name     | Activation Epoch | Activation Timestamp |
 |------------------|------------------|----------------------|
 | Sepolia          |                  |                      |
-| Holešky          |                  |                      |
+| Holešky          |                  |                       |
 | Mainnet          |                  |                      |
 
 **Note**: rows in the table above will be filled as activation times are decided by client teams.

--- a/EIPS/eip-7607.md
+++ b/EIPS/eip-7607.md
@@ -27,21 +27,18 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Proposed
 * [EIP-7825](./eip-7825.md): Transaction Gas Limit Cap
 * [EIP-7883](./eip-7883.md): ModExp Gas Cost Increase
 * [EIP-7892](./eip-7892.md): Blob Parameter Only Hardforks
+* [EIP-7907](./eip-7907.md): Meter Contract Code Size And Increase Limit
 * [EIP-7917](./eip-7917.md): Deterministic proposer lookahead
 * [EIP-7918](./eip-7918.md): Blob base fee bounded by execution cost
+* [EIP-7934](./eip-7934.md): RLP Execution Block Size Limit
 * [EIP-7935](./eip-7935.md): Set default gas limit to XX0M
-
+* [EIP-7939](./eip-7939.md): Count leading zeros (CLZ) opcode
+* [EIP-7951](./eip-7951.md): Precompile for secp256r1 Curve Support
 
 #### Other EIPs
 
 * [EIP-7642](./eip-7642.md): eth/69 - Drop pre-merge fields
     * Client teams MUST support this EIP by the activation of the Fusaka network upgrade.
-
-### Considered for Inclusion
-
-* RIP-7212: Precompile for secp256r1 Curve Support
-* [EIP-7907](./eip-7907.md): Meter Contract Code Size And Increase Limit
-* [EIP-7934](./eip-7934.md): RLP Execution Block Size Limit
 
 ### Declined for Inclusion
 


### PR DESCRIPTION
EIPs 7907, 7934, 7939 and 7951 were SFI'd on [ACDE#214](https://github.com/ethereum/pm/issues/1569). 

This PR is blocked on https://github.com/ethereum/EIPs/pull/9833