### PR TITLE
Update EIP-7788: fix typos

### DIFF
--- a/EIPS/eip-7788.md
+++ b/EIPS/eip-7788.md
@@ -2,7 +2,7 @@
 eip: 7788
 title: Dynamic target blob count
 description: Target blob count changes dynamically to aim for constant blob costs
-author: Vitaly Hrynkiv (@vtjl10)
+author: Marc Harvey-Hill (@Marchhill)
 discussions-to: https://ethereum-magicians.org/t/eip-7788-dynamic-target-blob-count/21399
 status: Withdrawn
 type: Standards Track


### PR DESCRIPTION
## Summary

This pull request fixes a typo in `EIPS/eip-7788.md`:

- Replaces `consisent` with `consistent` on line 24.

