### PR TITLE
Update EIP-6466: Adopt `ProgressiveContainer`

### DIFF
--- a/EIPS/eip-6466.md
+++ b/EIPS/eip-6466.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2023-02-08
-requires: 658, 2718, 6404, 7495, 7702, 7919
+requires: 658, 2718, 6404, 7495, 7702, 7916
 ---
 
 ## Abstract
@@ -21,7 +21,7 @@ RLP receipts have a number of shortcomings:
 
 1. **Limited proving support:** Due to receipt data being linearly hashed as part of the `receipts_root` Merkle-Patricia Trie (MPT), it is not possible to efficiently proof individual parts of receipts, such as logs. Requiring the full receipt data to be present can be prohibitive for smart contract based applications such as L2 fraud proofs or client applications verifying log data.
 
-2. **Unnecessary statefulness:** [EIP-658](./eip-658.md) replaced the intermediate post-state `root` from receipts with a boolean `status` code. However, `cumulativeGasUsed` is similarly stateful, unnecessarily complicating efforts to execute transactions in parallel. Furthermore, multiple receipts are required to verify the effective gas used by an individual transaction.
+2. **Unnecessary statefulness:** [EIP-658](./eip-658.md) replaced the intermediate post-state `root` from receipts with a boolean `status` code. However, `cumulativeGasUsed` and `logIndex` are similarly stateful, unnecessarily complicating efforts to execute transactions in parallel. Further, `gasUsed` verification requires computation from `cumulativeGasUsed` across multiple receipts.
 
 3. **Incomplete data:** JSON-RPC provides `from`, `gasUsed`, and `contractAddress` fields for receipts, but the on-chain receipt does not contain the required information to verify them.
 
@@ -43,44 +43,89 @@ Definitions from existing specifications that are used throughout this document 
 | [`ExecutionAddress`](https://github.com/ethereum/consensus-specs/blob/b3e83f6691c61e5b35136000146015653b22ed38/specs/bellatrix/beacon-chain.md#custom-types) | `Bytes20` |
 | [`GasAmount`](./eip-6404.md#normalized-transactions) | `uint64` |
 
-### `Receipt` container
+### Logs
 
-All receipts are represented as a single, normalized SSZ container. The definition uses the `StableContainer[N]` SSZ type and `Optional[T]` as defined in [EIP-7495](./eip-7495.md).
+Logs are represented as an SSZ `Container`.
 
 | Name | Value | Description |
 | - | - | - |
 | `MAX_TOPICS_PER_LOG` | `4` | `LOG0` through `LOG4` opcodes allow 0-4 topics per log |
-| `MAX_RECEIPT_FIELDS` | `uint64(2**5)` (= 32) | Maximum number of fields to which `Receipt` can ever grow in the future |
 
 ```python
 class Log(Container):
     address: ExecutionAddress
     topics: List[Bytes32, MAX_TOPICS_PER_LOG]
     data: ProgressiveByteList
+```
 
-class StableReceipt(StableContainer[MAX_RECEIPT_FIELDS]):
-    from_: Optional[ExecutionAddress]
-    gas_used: Optional[GasAmount]
-    contract_address: Optional[ExecutionAddress]
-    logs: Optional[ProgressiveList[Log]]
+### Receipts
 
-    # EIP-658
-    status: Optional[boolean]
+New receipts use a normalized SSZ representation.
 
-    # EIP-7702
-    authorities: Optional[ProgressiveList[ExecutionAddress]]
+```python
+class Receipt(CompatibleUnion[
+    BasicReceipt,
+    CreateReceipt,
+    SetCodeReceipt,
+]):
+    pass
+```
 
-class Receipt(Profile[StableReceipt]):
+#### Basic receipts
+
+This receipt is emitted for these transactions:
+
+- [`RlpLegacyReplayableBasicTransaction`](./eip-6404.md#normalized-transactions)
+- [`RlpLegacyBasicTransaction`](./eip-6404.md#normalized-transactions)
+- [`RlpAccessListBasicTransaction`](./eip-6404.md#normalized-transactions)
+- [`RlpBasicTransaction`](./eip-6404.md#normalized-transactions)
+- [`RlpBlobTransaction`](./eip-6404.md#normalized-transactions)
+
+```python
+class BasicReceipt(
+    ProgressiveContainer[active_fields=[1, 1, 0, 1, 1]]
+):
     from_: ExecutionAddress
     gas_used: GasAmount
-    contract_address: Optional[ExecutionAddress]
     logs: ProgressiveList[Log]
-
-    # EIP-658
     status: boolean
+```
 
-    # EIP-7702
-    authorities: Optional[ProgressiveList[ExecutionAddress]]
+#### Create receipts
+
+This receipt is emitted for these transactions:
+
+- [`RlpLegacyReplayableCreateTransaction`](./eip-6404.md#normalized-transactions)
+- [`RlpLegacyCreateTransaction`](./eip-6404.md#normalized-transactions)
+- [`RlpAccessListCreateTransaction`](./eip-6404.md#normalized-transactions)
+- [`RlpCreateTransaction`](./eip-6404.md#normalized-transactions)
+
+```python
+class CreateReceipt(
+    ProgressiveContainer[active_fields=[1, 1, 1, 1, 1]]
+):
+    from_: ExecutionAddress
+    gas_used: GasAmount
+    contract_address: ExecutionAddress
+    logs: ProgressiveList[Log]
+    status: boolean
+```
+
+#### EIP-7702 set code receipts
+
+This receipt is emitted for these transactions:
+
+- [`RlpSetCodeTransaction`](./eip-6404.md#normalized-transactions)
+
+```python
+class SetCodeReceipt(
+    ProgressiveContainer[active_fields=[1, 1, 0, 1, 1, 1]]
+):
+    from_: ExecutionAddress
+    gas_used: GasAmount
+    logs: ProgressiveList[Log]
+    status: boolean
+    authorities: ProgressiveList[ExecutionAddress]
 ```
 
 ### `Receipt` construction
@@ -100,7 +145,7 @@ The `logs_bloom` and intermediate state `root` (Homestead scheme) are not presen
 
 ### Execution block header changes
 
-The [execution block header's `receipts-root`](https://github.com/ethereum/devp2p/blob/5713591d0366da78a913a811c7502d9ca91d29a8/caps/eth.md#block-encoding-and-validity) is transitioned from MPT to SSZ.
+The [execution block header's `receipts-root`](https://github.com/ethereum/devp2p/blob/bc76b9809a30e6dc5c8dcda996273f0f9bcf7108/caps/eth.md#block-encoding-and-validity) is transitioned from MPT to SSZ.
 
 ```python
 receipts = ProgressiveList[Receipt](
@@ -115,7 +160,7 @@ Transaction receipt objects in the context of the JSON-RPC API are extended to i
 
 - `authorities`: `Array of DATA|null` - Array of `DATA` entries each containing 20 Bytes, corresponding to the receipt's `authorities` field
 
-Within `logs`, the `logIndex` field is removed as it cannot be efficiently validated. This includes responses pertaining to historical logs.
+Within `logs`, the `logIndex` field is changed to indicate the log index position in the individual receipt, rather than in the entire block.
 
 The `logsBloom` field is no longer returned for new receipts. It continues to be returned for historical receipts conforming to earlier schemes.
 
@@ -126,12 +171,12 @@ The `logsBloom` field is no longer returned for new receipts. It continues to be
 When building a consensus `ExecutionPayload`, the [`receipts_root`](https://github.com/ethereum/consensus-specs/blob/b3e83f6691c61e5b35136000146015653b22ed38/specs/deneb/beacon-chain.md#executionpayload) is now based on the `Receipt` type, changing the type of `receipts_root` from an MPT [`Hash32`](https://github.com/ethereum/consensus-specs/blob/b3e83f6691c61e5b35136000146015653b22ed38/specs/phase0/beacon-chain.md#custom-types) to an SSZ [`Root`](https://github.com/ethereum/consensus-specs/blob/b3e83f6691c61e5b35136000146015653b22ed38/specs/phase0/beacon-chain.md#custom-types).
 
 ```python
-class ExecutionPayload(Container):
+class ExecutionPayload(...):
     ...
     receipts_root: Root
     ...
 
-class ExecutionPayloadHeader(Container):
+class ExecutionPayloadHeader(...):
     ...
     receipts_root: Root
     ...
@@ -143,11 +188,17 @@ payload_header.receipts_root = payload.receipts_root
 
 ## Rationale
 
-Switching to a single, unified and forward compatible receipt format within execution blocks reduces implementation complexity for client applications and smart contracts. Individual chunks of receipt data can now be verified, simplifying implementation of bridges.
+### Forward compatibility
 
-Light clients can now efficiently verify a receipt's `from`, `gas_used`, and `authorities`, which previously required obtaining the corresponding transaction data and additional receipts. Execution layer implementations no longer have to compute signer addresses using the expensive `ecrecover` mechanism when backfilling / serving historical receipt data.
+All receipts share the same Merkle tree shape with a stable [generalized index (gindex)](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/ssz/merkle-proofs.md#generalized-merkle-tree-index) assigned to each field. Future transaction features can introduce additional receipt fields or drop existing fields without breaking verifiers.
 
-Removal of `logs_bloom` reduces storage cost for receipts by 259 bytes per receipt.
+### Verifier improvements
+
+Committing to `from`, `contract_address` and `authorities` in the receipt allows efficient verification without the expensive `ecrecover` mechanism. This allows future EIPs to change how these addresses are computed without breaking verifiers, e.g., when future signature schemes are introduced.
+
+### Execution client improvements
+
+Execution Layer implementations no longer need access to the transaction and additional indices when serving receipts based on SSZ.
 
 ## Backwards Compatibility
 
@@ -157,9 +208,9 @@ Applications using verified `cumulativeGasUsed` values have to compute the value
 
 Applications relying on the `logsBloom` will have to swap to an out-of-protocol mechanism for filtering logs, or fall back to processing the complete set of receipts. As the `logsBloom` mechanism was prohibitively inefficient for light clients, its removal is unlikely to have a significant impact.
 
-Applications relying on the `logIndex` have to compute this value from the full receipt data. Note that verifying applications already have to do this.
+Applications relying on the per block `logIndex` now have to compute this data, as `logIndex` now refers to an index per receipt.
 
-RLP and SSZ receipts may clash when encoded. It is essential to use only a single format within one channel.
+RLP and SSZ receipts may clash when encoded. It is essential to use only a single format within one channel. When requesting receipts by hash over the network, the block header corresponding to the containing receipts root can be consulted to identify the underlying fork.
 
 ## Security Considerations
 


### PR DESCRIPTION
- `logIndex` now based per receipt rather than entire block
- Switch to `ProgressiveContainer` / `CompatibleUnion` based design
