### PR TITLE
Update EIP-1474: Update Parity Ethereum blog URL

### DIFF
--- a/EIPS/eip-1474.md
+++ b/EIPS/eip-1474.md
@@ -2246,7 +2246,7 @@ The current generation of Ethereum clients includes several implementations that
 |Client Name|Language|Homepage|
 |-|-|-|
 |Geth|Go|[geth.ethereum.org](https://geth.ethereum.org)|
-|Parity|Rust|[parity.io/ethereum](https://parity.io/ethereum)|
+|Parity|Rust|[parity.io/ethereum](https://www.parity.io/blog/category/ethereum)|
 |Aleth|C++|[cpp-ethereum.org](https://cpp-ethereum.org)|
 
 ## Copyright


### PR DESCRIPTION
Updated the Parity Ethereum documentation link as the old URL (parity.io/ethereum) is no longer accessible. Replaced with the current blog category URL (www.parity.io/blog/category/ethereum) to ensure users can access up-to-date Parity documentation.
