### PR TITLE
Update EIP-7883: Triple price

### DIFF
--- a/EIPS/eip-7883.md
+++ b/EIPS/eip-7883.md
@@ -112,6 +112,7 @@ This EIP introduces a backwards-incompatible change. However, similar gas repric
 
 ## Test Cases
 
+The most common usages (approximately 99.69% of historical `Modexp` calls as of January 4th, 2025) will experience either a 150% increase (from 200 to 500 gas) or a 200% increase (tripling from approximately 1360 gas).
 No changes are made to the underlying interface or arithmetic algorithms, allowing existing test vectors to be reused. The table below presents the updated gas costs for these test vectors:
 
 | Test Case                    | [EIP-2565](./eip-2565.md) Pricing | EIP-7883 Pricing | Increase |
@@ -145,7 +146,6 @@ No changes are made to the underlying interface or arithmetic algorithms, allowi
 | modexp_marcin_3_base_heavy   | 677 | 2032 | 200% |
 | modexp_marcin_3_exp_heavy    | 765 | 4080 | 433% |
 | modexp_marcin_3_balanced     | 1360 | 4080 | 200% |
-
 
 ## Security Considerations
 


### PR DESCRIPTION
Tripling the price for ModExp calls.

Moving worst-performing ModExp test case from 18 to about 31MGas/s.