### PR TITLE
Move previously CFI'd Glamsterdam EIPs to PFI

### DIFF
--- a/EIPS/eip-7773.md
+++ b/EIPS/eip-7773.md
@@ -12,24 +12,23 @@ requires: 7607, 7723
 
 ## Abstract
 
-This Meta EIP lists the EIPs formally Proposed, Considered for & Scheduled for Inclusion in the Glamsterdam network upgrade.
+This Meta EIP lists the EIPs formally Proposed, Considered, Declined for & Scheduled for Inclusion in the Glamsterdam network upgrade.
 
 ## Specification
 
-Definitions for `Scheduled for Inclusion`, `Considered for Inclusion` and `Proposed for Inclusion` can be found in [EIP-7723](./eip-7723.md).
+Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Declined for Inclusion` and `Proposed for Inclusion` can be found in [EIP-7723](./eip-7723.md).
 
 ### EIPs Scheduled for Inclusion
 
 ### Considered for Inclusion
+
+### Proposed for Inclusion
 
 * [EIP-4762](./eip-4762.md): Statelessness gas cost changes
 * [EIP-6800](./eip-6800.md): Ethereum state using a unified verkle tree
 * [EIP-6873](./eip-6873.md): Preimage retention
 * [EIP-7545](./eip-7545.md): Verkle proof verification precompile
 * [EIP-7667](./eip-7667.md): Raise gas costs of hash functions
-
-### Proposed for Inclusion
-
 * [EIP-7793](./eip-7793.md): Conditional Transactions
 * [EIP-7843](./eip-7843.md): SLOTNUM opcode
 * [EIP-7919](./eip-7919.md): Pureth Meta


### PR DESCRIPTION
The decision to CFI EIPs for Glamsterdam early on was done before the recent changes to the fork scoping process. To reflect the latest process and EIP-7723 requirements, I propose moving these EIPs to PFI, and only moving them back to CFI if they are to be included in a fork devnet. 