### PR TITLE
Update EIP-7799: Adopt `ProgressiveList`

### DIFF
--- a/EIPS/eip-7799.md
+++ b/EIPS/eip-7799.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2024-10-29
-requires: 1559, 4895, 6466, 7708
+requires: 1559, 4895, 6466, 7708, 7916
 ---
 
 ## Abstract
@@ -28,7 +28,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 A new list is introduced to track all block level logs emitted from system interactions. The definition uses the `Log` SSZ type from [EIP-6466](./eip-6466.md).
 
 ```python
-system_logs = List[Log, MAX_LOGS_PER_RECEIPT](
+system_logs = ProgressiveList[Log](
     log_0, log_1, log_2, ...)
 ```
 
@@ -100,7 +100,7 @@ As part of `engine_forkchoiceUpdated`, Execution Layer implementations SHALL ver
 The consensus `ExecutionPayload` type is extended with a new field to store the system logs root.
 
 ```python
-class ExecutionPayload(Container):
+class ExecutionPayload(...):
     ...
     system_logs_root: Root
 ```


### PR DESCRIPTION
Use `ProgressiveList` to avoid `MAX_LOGS_PER_RECEIPT` bound.
