### PR TITLE
Update EIP-7807: Adopt `ProgressiveContainer`

### DIFF
--- a/EIPS/eip-7807.md
+++ b/EIPS/eip-7807.md
@@ -8,66 +8,55 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2024-10-28
-requires: 6404, 6465, 6466, 7706, 7799
+requires: 6404, 6465, 6466, 7495, 7706, 7799
 ---
 
 ## Abstract
 
-This EIP defines a migration process of execution blocks to [Simple Serialize (SSZ)](https://github.com/ethereum/consensus-specs/blob/b3e83f6691c61e5b35136000146015653b22ed38/ssz/simple-serialize.md).
+This EIP defines a migration process of execution blocks to [Simple Serialize (SSZ)](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/ssz/simple-serialize.md).
 
 ## Motivation
 
-With [EIP-6404](./eip-6404.md) SSZ transactions, [EIP-6466](./eip-6466.md) SSZ receipts, and [EIP-6465](./eip-6465.md) SSZ withdrawals, all Merkle-Patricia Trie (MPT) besides the state trie are converted to SSZ. This enables the surrounding data structure, in this case, the execution block itself, to also convert to SSZ, achieving a unified block representation across both Consensus Layer and Execution Layer.
+With [EIP-6404](./eip-6404.md) SSZ transactions, [EIP-6466](./eip-6466.md) SSZ receipts, and [EIP-6465](./eip-6465.md) SSZ withdrawals, all Merkle-Patricia Trie (MPT) besides the state trie are converted to SSZ. This enables the surrounding data structure, the execution block itself, to also convert to SSZ, achieving a unified block representation across both Consensus Layer and Execution Layer.
 
-1. **Normalized block hash:** The Consensus Layer can compute the block hash autonomously, enabling it to process all consistency checks that currently require asynchronous communication with the Execution Layer ([`verify_and_notify_new_payload`](https://github.com/ethereum/consensus-specs/blob/b3e83f6691c61e5b35136000146015653b22ed38/specs/electra/beacon-chain.md#modified-verify_and_notify_new_payload)). This allows early rejection of inconsistent blocks and dropping the requirement to wait for engine API interactions while syncing.
+1. **Normalized block hash:** The Consensus Layer can compute the block hash autonomously, enabling it to process all consistency checks that currently require asynchronous communication with the Execution Layer ([`verify_and_notify_new_payload`](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/specs/electra/beacon-chain.md#modified-verify_and_notify_new_payload)). This allows early rejection of inconsistent blocks and dropping the requirement to wait for engine API interactions while syncing.
 
 2. **Optimized engine API:** With all exchanged data supporting SSZ, the engine API can be changed from the textual JSON encoding to binary SSZ encoding, reducing exchanged data size by ~50% and significantly improving encoding/parsing efficiency.
 
-3. **Proving support:** With SSZ, individual fields of the execution block header become provable without requiring full block headers to be present. With [EIP-7495](./eip-7495.md) SSZ `StableContainer`, proofs are forward compatible as long as underlying semantics of individual fields are unchanged, reducing maintenance requirements for smart contracts and verifying client applications.
+3. **Proving support:** With SSZ, individual fields of the execution block header become provable without requiring full block headers to be present. With [EIP-7495](./eip-7495.md) SSZ `ProgressiveContainer`, proofs are forward compatible as long as underlying semantics of individual fields are unchanged, reducing maintenance requirements for smart contracts and verifying client applications.
 
-4. **Cleanup opportunity:** The conversion to SSZ allows dropping historical fields from the PoW era and the inefficient logs bloom mechanism, and allows introducing the concept of [EIP-7706](./eip-7706.md) multi-dimensional gas.
+4. **Cleanup opportunity:** The conversion to SSZ allows dropping historical fields from the PoW era and the inefficient logs bloom mechanism.
 
 ## Specification
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
 
-### `ExecutionBlockHeader` container
+### Gas amounts
 
-Execution blocks are represented as a single, normalized SSZ container. The definition uses the `StableContainer[N]` SSZ type and `Optional[T]` as defined in [EIP-7495](./eip-7495.md).
+The different kinds of gas amounts are combined into a single structure, mirroring the [EIP-6404 gas fees](./eip-6404.md#gas-fees).
 
-| Name | Value | Description |
-| - | - | - |
-| `MAX_EXECUTION_BLOCK_FIELDS` | `uint64(2**6)` (= 64) | Maximum number of fields to which `StableExecutionBlock` can ever grow in the future |
+| Name | SSZ equivalent |
+| - | - |
+| [`GasAmount`](./eip-6404.md#normalized-transactions) | `uint64` |
 
 ```python
-class StableGasAmounts(StableContainer[MAX_FEES_PER_GAS_FIELDS]):
-    regular: Optional[GasAmount]
-    blob: Optional[GasAmount]
-
-class GasAmounts(Profile[StableGasAmounts]):
+class GasAmounts(ProgressiveContainer([active_fields=[1, 1]])):
     regular: GasAmount
     blob: GasAmount
+```
 
-class StableExecutionBlockHeader(StableContainer[MAX_EXECUTION_BLOCK_FIELDS]):
-    parent_hash: Optional[Root]
-    miner: Optional[ExecutionAddress]
-    state_root: Optional[Bytes32]
-    transactions_root: Optional[Root]
-    receipts_root: Optional[Root]
-    number: Optional[uint64]
-    gas_limits: Optional[StableGasAmounts]
-    gas_used: Optional[StableGasAmounts]
-    timestamp: Optional[uint64]
-    extra_data: Optional[ByteList[MAX_EXTRA_DATA_BYTES]]
-    mix_hash: Optional[Bytes32]
-    base_fees_per_gas: Optional[FeesPerGas]
-    withdrawals_root: Optional[Root]
-    excess_gas: Optional[StableGasAmounts]
-    parent_beacon_block_root: Optional[Root]
-    requests_hash: Optional[Bytes32]
-    system_logs_root: Optional[Root]
+### Requests hash computation
 
-class ExecutionBlockHeader(Profile[StableExecutionBlockHeader]):
+`requests_hash` is changed to `ExecutionRequests.hash_tree_root()` using the same structure as in the Consensus Layer `BeaconBlockBody`.
+
+### Execution block headers
+
+New execution block headers use a normalized SSZ representation.
+
+```python
+class ExecutionBlockHeader(
+    ProgressiveContainer[active_fields=[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]]
+):
     parent_hash: Root
     miner: ExecutionAddress
     state_root: Bytes32
@@ -83,28 +72,52 @@ class ExecutionBlockHeader(Profile[StableExecutionBlockHeader]):
     withdrawals_root: Root  # EIP-6465 withdrawals.hash_tree_root()
     excess_gas: GasAmounts
     parent_beacon_block_root: Root
-    requests_hash: Bytes32  # EIP-6110 `ExecutionRequests`.hash_tree_root()
-    system_logs_root: Root
+    requests_hash: Bytes32  # EIP-6110 execution_requests.hash_tree_root()
+    system_logs_root: Root  # EIP-7799 system_logs.hash_tree_root()
 ```
-
-### Requests hash computation
-
-`requests_hash` is changed to `ExecutionRequests.hash_tree_root()` using the same structure as in the Consensus Layer `BeaconBlockBody`.
 
 ### Execution block hash computation
 
-The execution block hash is changed to be based on `hash_tree_root` in all contexts, including (1) the BLOCKHASH opcode, (2) engine API interactions (`blockHash` field), (3) JSON-RPC API interactions, (4) devp2p networking.
+For new blocks, the execution block hash is changed to be based on `hash_tree_root` in all contexts, including (1) the `BLOCKHASH` opcode, (2) JSON-RPC API interactions (`blockHash` field), (3) devp2p networking.
+
+### Consensus `ExecutionPayload` changes
+
+Usages of `ExecutionPayloadHeader` are replaced with `ExecutionBlockHeader`.
+
+Usages of `ExecutionPayload` are updated to share `hash_tree_root` with `ExxecutionBlockHeader`. `transactions_root`, `withdrawals_root` and `requests_root` are expanded to their full list contents.
+
+```python
+class ExecutionPayload(
+    ProgressiveContainer[active_fields=[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]]
+):
+    parent_hash: Root
+    miner: ExecutionAddress
+    state_root: Bytes32
+    transactions: ProgressiveList[Transaction]
+    receipts_root: Root
+    number: uint64
+    gas_limits: GasAmounts
+    gas_used: GasAmounts
+    timestamp: uint64
+    extra_data: ByteList[MAX_EXTRA_DATA_BYTES]
+    mix_hash: Bytes32
+    base_fees_per_gas: BlobFeesPerGas
+    withdrawals: ProgressiveList[Withdrawal]
+    excess_gas: GasAmounts
+    parent_beacon_block_root: Root
+    requests: ExecutionRequests
+    system_logs_root: Root
+```
 
 ## Rationale
 
-In the initial draft, only the requests hash and block hash are changed to be SSZ `hash_tree_root()` based. No Consensus Layer changes are required.
+This transition completes the transition to SSZ for everything except the execution state trie.
 
 ### Future
 
 - With SSZ `Log`, the withdrawals mechanism and validator requests could be redefined to be based on logs (similar to deposits, originally, but without the delay), possibly removing the need for `withdrawals_root` and `requests_hash`.
   - The CL would insert the extra logs for minting ([EIP-7799](./eip-7799.md)) and could fetch the ones relevant for withdrawing (deposits, requests, consolidations). That mechanism would be more generic than [EIP-7685](./eip-7685.md) and would drop requiring the EL to special case requests, including `compute_requests_hash`.
   - For client applications and smart contracts, it would streamline transaction history verification based on [EIP-7792](./eip-7792.md).
-  - The extra fee market for withdrawal and consolidation requests could be integrated into the multidimensional fee system, allowing to drop the extra queueing in the corresponding contract storage and reducing gas fees. The corresponding contracts may need to be updated with an irregular state transition or be replaced.
 
 - Engine API should be updated with (1) possible withdrawals/requests refactoring as above, (2) dropping the `block_hash` field so that `ExecutionPayload` is replaced with to `ExecutionBlockHeader`, (3) binary encoding based on `ForkDigest`-context (through HTTP header or interleaved, similar to beacon-API). This reduces encoding overhead and also simplifies sharing data structures in combined CL/EL in-process implementations.
 


### PR DESCRIPTION
- Use EIP-7495 ProgressiveContainer for latest forward compatibility changes
- Replicate changes to ExecutionPayload / Header to avoid separate `block_hash` field / use hash_tree_root everywhere
