### PR TITLE
Update EIP-7918: finalize BLOB_BASE_COST

### DIFF
--- a/EIPS/eip-7918.md
+++ b/EIPS/eip-7918.md
@@ -36,7 +36,7 @@ The reserve price also fulfills a second important function. Nodes must cryptogr
 
 | Constant | Value 
 | - | - |
-| `BLOB_BASE_COST` | `2**14` |
+| `BLOB_BASE_COST` | `2**13` |
 
 ### Functions
 
@@ -79,13 +79,13 @@ b_r = BLOB_BASE_COST * base_fee_per_gas / GAS_PER_BLOB
 
 As long as $b_r$ is a relevant fraction of $c$, the fee update mechanism will always be able to regulate demand by increasing the blob base fee whenever there is contention for blobspace, alleviating spikiness in resource consumption. The blob fee's share of the total price ($b+c$) will with the reserve price always be at least 
 
-$\frac{b_r}{b_r+c}.$
+$\frac{b_r}{b_r+c}$, which simplifies to `BLOB_BASE_COST / (BLOB_BASE_COST + execution_cost)`.
 
-This is why the equilibrium under the reserve price (dashed line in Figure 1) is situated a constant fraction $16384/(16384+10500)$ below the black demand curve formed under a 0 execution base fee.
+This is why the equilibrium under the reserve price (dashed line in Figure 1) is situated a constant fraction $2^{13}/(2^{13}+10500)$ below the black demand curve formed under a 0 execution base fee.
 
 The demand curve could potentially be somewhat inelastic even under zero execution costs. This would however just be another reason to move forward with this proposal. Regardless of the exact shape of the demand curve—which of course will remain unknown and can vary going forward—the proposal is based on something tangible affecting blob consumers. This makes it a justified neutral bound on the blob base fee.
 
-The ratio between the reserve price for the blob base fee and the execution base fee is fixed: `BLOB_BASE_COST / GAS_PER_BLOB`, which is 1/8 with the proposed constant. The relationship follows from the new `if`-clause in `calc_excess_blob_gas()`.
+The ratio between the reserve price for the blob base fee and the execution base fee is fixed: `BLOB_BASE_COST / GAS_PER_BLOB`, which is 1/16 with the proposed constant. The relationship follows from the new `if`-clause in `calc_excess_blob_gas()`.
 
 ### Blob KZG proof verification cost
 
@@ -115,7 +115,7 @@ There is a specific reflexivity that is important to understand in this analysis
 
 For this reason, fixed thresholds not relating to blob quantity or the execution fee may not be sustainable. In a scenario where Ethereum sells more blobs per block, the equilibrium blob base fee should ideally have a relatively lower floor. Any fixed threshold (not relating to execution base fee or blob quantity) would need to be gradually readjusted to retain the same relative impact.
 
-There are approximately 8 blobs per million blob gas. A target of 30M execution gas (i.e., gas limit 60M) and 240 blobs is thus equal in terms of gas. In a scenario with such a distribution, Ethereum would need to derive an at least 1/9th of its income from blob gas, given the fixed reserve price on the blob base fee of (1/8) of the execution fee. It seems desirable to strive for a fee market under which blobs are not all sold at reserve price, and it might be optimistic to assume that Ethereum can derive as much income from blob gas as execution gas. Assumptions around income potential and scaling of execution and blobs are therefore important to consider. If it is believed that blob gas will scale faster than execution gas, a slightly lower `BLOB_BASE_COST` would likely be reasonable.
+There are approximately 8 blobs per 1M blob gas. A target of 30M execution gas (i.e., gas limit 60M) and 240 blobs is thus equal in terms of gas. In a scenario with such a distribution, Ethereum would need to derive an at least 1/17th of its income from blob gas, given the fixed reserve price on the blob base fee of (1/16) of the execution fee. It seems desirable to strive for a fee market under which blobs are not all sold at reserve price, and it might be optimistic to assume that Ethereum can derive as much income from blob gas as execution gas. Assumptions around income potential and scaling of execution and blobs are therefore important to consider. If it is believed that blob gas will scale faster than execution gas, a slightly lower `BLOB_BASE_COST` would likely be reasonable.
 
 
 ### Delayed response during a quick rise in execution fees


### PR DESCRIPTION
Update with the change agreed upon on [ACDE 214](https://ethereum-magicians.org/t/all-core-devs-execution-acde-214-june-19-2025/24508/2), i.e. finalize `BLOB_BASE_COST` to `2**13`. Figures to be updated in a separate PR later.
