### PR TITLE
Add EIP: Transaction Gas Limit Cap at 16,777,216

### DIFF
--- a/EIPS/eip-7987.md
+++ b/EIPS/eip-7987.md
@@ -1,5 +1,5 @@
 ---
-eip: 7983
+eip: 7987
 title: Transaction Gas Limit Cap at 16,777,216
 description: Introduce a protocol-level cap on the maximum gas used by a transaction to 16,777,216
 author: Toni Wahrstätter (@nerolation), Vitalik Buterin (@vbuterin)


### PR DESCRIPTION
Add EIP, a continuation of 7825. 