### PR TITLE
Update EIP-1962: fix duplicate

### DIFF
--- a/EIPS/eip-1962.md
+++ b/EIPS/eip-1962.md
@@ -34,7 +34,7 @@ Full functionality of the precompile is described below in `Specification` secti
 - There is a pending proposal to implement base elliptic curve arithmetic is covered by [EIP-1829](./eip-1829.md) and will allow to implement various privacy-preserving protocols with a reasonable gas costs per operation.
 - Pairings are an important extension for basic arithmetic and so this new precompile is proposed with the following benefits:
     - Extended set of curves will be available to allow Ethereum users to choose their security parameters and required functionality.
-    - Generic approach of this precompile will allow Ethereum users to experiment with newly found curves of their choice and new constructions constructions without waiting for new forks.
+    - Generic approach of this precompile will allow Ethereum users to experiment with newly found curves of their choice and new constructions without waiting for new forks.
     - EC arithmetic is indeed re-implemented in this precompile, but it's strictly required. Most of the pairing-based protocols still need to perform standard EC multiplications or additions and thus such operations must be available on generic set of curves.
 - Gas costs - this EIP is designed to estimate gas-cost of performed operation as early as possible during the call and base if solely on specified parameters and operation type. This is a strict requirement for any precompile to allow Ethereum nodes to efficiently reject transactions and operations as early as possible.
 


### PR DESCRIPTION
`constructions constructions` - `constructions` 