### PR TITLE
Update EIP-7939: Change gas cost from 3 to 5

### DIFF
--- a/EIPS/eip-7939.md
+++ b/EIPS/eip-7939.md
@@ -108,7 +108,7 @@ inline uint32_t clz(uint32_t x[8]) {
 }
 ```
 
-The cost of the opcode is 3, the same as `ADD`.
+The cost of the opcode is 5, matching MUL (raised from 3 to avoid under-pricing DoS risk).
 
 ## Rationale
 


### PR DESCRIPTION
Increases the gas cost of CLZ from 3 to 5. This gives us a very conservative upper bound that is very unlikely to be under priced and abused.

We could wait for benchmarking results over the next week to determine a more precise value or validate the current value, but personally as I lean on the side of finalizing Fusaka ASAP I'd rather increase now then re-assess in Glamsterdam. 

