### PR TITLE
Update EIP-7910: Add Fork Id to response, spec BPOs, add "last"

### DIFF
--- a/EIPS/eip-7910.md
+++ b/EIPS/eip-7910.md
@@ -57,6 +57,8 @@ The "current" and "next" members contain the configuration object currently in e
 
 The "currentHash" and "nextHash" members contain the hash of the current configuration and the next configuration, respectively, or null if the next configuration is also null.
 
+The "currentForkId" and "nextForkId" members contain the `FORK_HASH` value as specified in [EIP-6122](./eip-6122.md) of the current configuration and the next configuration, respectively, or null if the next configuration is also null.
+
 ### Converting a Fork Configuration to a Hash
 
 To generate a fork hash, the JSON object representing the fork configuration is converted into canonical form as per [RFC-8785](https://www.rfc-editor.org/rfc/rfc8785) (in short no whitespace, sorted keys, and numeric values in their simplest form). The result is then hashed using CRC-32.
@@ -135,7 +137,7 @@ JSON was chosen for its ubiquity, machine and human readability, and the existen
 
 ### CRC-32 as Hash Format
 
-The reasons for using CRC-32 instead of a cryptographic hash are the same as those in [EIP-2124](./eip-2124#why-use-ieee-crc32-as-the-checksum-instead-of-keccak256), incorporated by reference. In brief, nodes can lie, the 4-byte reduction is for convenience rather than security, and CRC-32 is widely implemented.
+The reasons for using CRC-32 instead of a cryptographic hash are the same as those in [EIP-2124](./eip-2124.md#why-use-ieee-crc32-as-the-checksum-instead-of-keccak256), incorporated by reference. In brief, nodes can lie, the 4-byte reduction is for convenience rather than security, and CRC-32 is widely implemented.
 
 ## Backwards Compatibility
 
@@ -256,6 +258,7 @@ would return (after formatting):
       }
     },
     "currentHash": "243c27d1",
+    "currentForkId": "bef71d30",
     "next": {
       "activationTime": 1742999832,
       "blobSchedule": {
@@ -291,7 +294,8 @@ would return (after formatting):
         "WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS": "0x00000961ef480eb55e80d19ad83579a64c007002"
       }
     },
-    "nextHash": "10368496"
+    "nextHash": "10368496",
+    "nextForkId": "0929e24e"
   }
 }
 ```

--- a/EIPS/eip-7910.md
+++ b/EIPS/eip-7910.md
@@ -109,7 +109,7 @@ Future forks MUST define the list of system contracts in their meta-EIPs.
 
 ### Blob Parameter Only Forks
 
-BPO forks specified in [EIP-7892](https://eips.ethereum.org/EIPS/eip-7892) should be interpreted as new forks, taking the parent fork as base and updating only the appropriate values in the `blobsSchedule` object to produce the new fork configuration.
+BPO forks specified in [EIP-7892](./eip-7892.md) should be interpreted as new forks, taking the parent fork as base and updating only the appropriate values in the `blobsSchedule` object to produce the new fork configuration.
 
 ## Rationale
 

--- a/EIPS/eip-7910.md
+++ b/EIPS/eip-7910.md
@@ -99,13 +99,17 @@ For Prague, the added contracts are (in order): `BLS12_G1ADD`, `BLS12_G1MSM`,`BL
 
 #### `systemContracts`
 
-A JSON object representing system-level contracts relevant to the fork, as introduced in their defining EIPs. Keys are the contract names (e.g., `BEACON_ROOTS_ADDRESS`) from the first EIP where they appeared, sorted alphabetically. Values are 20-byte addresses in `0x`-prefixed hexadecimal form, with leading zeros preserved. Omitted for forks before Cancun.
+A JSON object representing system-level contracts relevant to the fork, as introduced in their defining EIPs. Keys are 20-byte addresses in `0x`-prefixed hexadecimal form, with leading zeros preserved, sorted alphabetically. Omitted for forks before Cancun. Values are the contract names (e.g., `BEACON_ROOTS_ADDRESS`) from the first EIP where they appeared.
 
 For Cancun the only system contract is `BEACON_ROOTS_ADDRESS`.
 
 For Prague the system contracts are (in order) `BEACON_ROOTS_ADDRESS`, `CONSOLIDATION_REQUEST_PREDEPLOY_ADDRESS`, `DEPOSIT_CONTRACT_ADDRESS`, `HISTORY_STORAGE_ADDRESS`, and `WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS`.
 
 Future forks MUST define the list of system contracts in their meta-EIPs.
+
+### Blob Parameter Only Forks
+
+BPO forks specified in [EIP-7892](https://eips.ethereum.org/EIPS/eip-7892) should be interpreted as new forks, taking the parent fork as base and updating only the appropriate values in the `blobsSchedule` object to produce the new fork configuration.
 
 ## Rationale
 
@@ -180,11 +184,11 @@ Hoodi Prague Config
     "0x0000000000000000000000000000000000000011": "BLS12_MAP_FP2_TO_G2"
   },
   "systemContracts": {
-    "BEACON_ROOTS_ADDRESS": "0x000f3df6d732807ef1319fb7b8bb8522d0beac02",
-    "CONSOLIDATION_REQUEST_PREDEPLOY_ADDRESS": "0x0000bbddc7ce488642fb579f8b00f3a590007251",
-    "DEPOSIT_CONTRACT_ADDRESS": "0x00000000219ab540356cbb839cbe05303d7705fa",
-    "HISTORY_STORAGE_ADDRESS": "0x0000f90827f1c53a10cb7a02335b175320002935",
-    "WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS": "0x00000961ef480eb55e80d19ad83579a64c007002"
+    "0x00000000219ab540356cbb839cbe05303d7705fa": "DEPOSIT_CONTRACT_ADDRESS",
+    "0x00000961ef480eb55e80d19ad83579a64c007002": "WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS",
+    "0x0000bbddc7ce488642fb579f8b00f3a590007251": "CONSOLIDATION_REQUEST_PREDEPLOY_ADDRESS",
+    "0x0000f90827f1c53a10cb7a02335b175320002935": "HISTORY_STORAGE_ADDRESS",
+    "0x000f3df6d732807ef1319fb7b8bb8522d0beac02": "BEACON_ROOTS_ADDRESS"
   }
 }
 ```
@@ -213,7 +217,7 @@ Hoodi Cancun Config
     "0x000000000000000000000000000000000000000a": "KZG_POINT_EVALUATION"
   },
   "systemContracts": {
-    "BEACON_ROOTS_ADDRESS": "0x000f3df6d732807ef1319fb7b8bb8522d0beac02"
+    "0x000f3df6d732807ef1319fb7b8bb8522d0beac02": "BEACON_ROOTS_ADDRESS"
   }
 }
 ```
@@ -254,11 +258,11 @@ would return (after formatting):
         "0x000000000000000000000000000000000000000a": "KZG_POINT_EVALUATION"
       },
       "systemContracts": {
-        "BEACON_ROOTS_ADDRESS": "0x000f3df6d732807ef1319fb7b8bb8522d0beac02"
+        "0x000f3df6d732807ef1319fb7b8bb8522d0beac02": "BEACON_ROOTS_ADDRESS"
       }
     },
-    "currentHash": "243c27d1",
-    "currentForkId": "bef71d30",
+    "currentHash": "0xfe6aefa8",
+    "currentForkId": "0xbef71d30",
     "next": {
       "activationTime": 1742999832,
       "blobSchedule": {
@@ -287,15 +291,15 @@ would return (after formatting):
         "0x0000000000000000000000000000000000000011": "BLS12_MAP_FP2_TO_G2"
       },
       "systemContracts": {
-        "BEACON_ROOTS_ADDRESS": "0x000f3df6d732807ef1319fb7b8bb8522d0beac02",
-        "CONSOLIDATION_REQUEST_PREDEPLOY_ADDRESS": "0x0000bbddc7ce488642fb579f8b00f3a590007251",
-        "DEPOSIT_CONTRACT_ADDRESS": "0x00000000219ab540356cbb839cbe05303d7705fa",
-        "HISTORY_STORAGE_ADDRESS": "0x0000f90827f1c53a10cb7a02335b175320002935",
-        "WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS": "0x00000961ef480eb55e80d19ad83579a64c007002"
+        "0x00000000219ab540356cbb839cbe05303d7705fa": "DEPOSIT_CONTRACT_ADDRESS",
+        "0x00000961ef480eb55e80d19ad83579a64c007002": "WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS",
+        "0x0000bbddc7ce488642fb579f8b00f3a590007251": "CONSOLIDATION_REQUEST_PREDEPLOY_ADDRESS",
+        "0x0000f90827f1c53a10cb7a02335b175320002935": "HISTORY_STORAGE_ADDRESS",
+        "0x000f3df6d732807ef1319fb7b8bb8522d0beac02": "BEACON_ROOTS_ADDRESS"
       }
     },
-    "nextHash": "10368496",
-    "nextForkId": "0929e24e"
+    "nextHash": "0xfc6b6ba3",
+    "nextForkId": "0x0929e24e"
   }
 }
 ```

--- a/EIPS/eip-7910.md
+++ b/EIPS/eip-7910.md
@@ -12,7 +12,7 @@ created: 2025-03-18
 
 ## Abstract
 
-This document describes an RPC method that provides node-relevant configuration data for the current and next fork.
+This document describes an RPC method that provides node-relevant configuration data for the current, next and last known forks.
 
 ## Motivation
 
@@ -41,7 +41,7 @@ Clients MAY also expose this method through the Engine API.
 
 Clients MAY use these configuration objects to manage their per-fork configurations, though they SHOULD NOT simply return unprocessed configuration data.
 
-When reporting the current and next configurations, clients MUST include every configuration parameter specified in this EIP.
+When reporting the current, next and last configurations, clients MUST include every configuration parameter specified in this EIP.
 
 Clients MUST return up-to-date configuration values, reflecting the most recent block header they provide. If clients cache the configuration, they MUST ensure such caches are purged when fork boundaries are crossed.
 
@@ -53,11 +53,11 @@ A new JSON-RPC API, `eth_config`, is introduced. It takes no parameters and retu
 
 The RPC response contains four members of two types:
 
-The "current" and "next" members contain the configuration object currently in effect and the next configuration, respectively, or null if the client is not configured to support a future fork.
+The "current", "next" and "last" members contain the configuration object currently in effect, the next configuration and the last known configuration, respectively, or null if the client is not configured to support a future fork. "next" and "last" members will contain the same configuration in the case the next configured fork is also the last configured fork.
 
-The "currentHash" and "nextHash" members contain the hash of the current configuration and the next configuration, respectively, or null if the next configuration is also null.
+The "currentHash", "nextHash" and "lastHash" members contain the hash of the current configuration, the next configuration and the last configuration, respectively, or null if the next configuration is also null.
 
-The "currentForkId" and "nextForkId" members contain the `FORK_HASH` value as specified in [EIP-6122](./eip-6122.md) of the current configuration and the next configuration, respectively, or null if the next configuration is also null.
+The "currentForkId", "nextForkId" and "lastForkId" members contain the `FORK_HASH` value as specified in [EIP-6122](./eip-6122.md) of the current configuration, the next configuration and the last configuration, respectively, or null if the next configuration is also null.
 
 ### Converting a Fork Configuration to a Hash
 
@@ -73,7 +73,7 @@ Future forks may add, adjust, remove, or update fields. The respective changes M
 
 #### `activationTime`
 
-The fork activation timestamp, represented as a JSON number in Unix epoch seconds (UTC). For the "current" configuration, this reflects the actual activation time; for "next," it is the scheduled time.
+The fork activation timestamp, represented as a JSON number in Unix epoch seconds (UTC). For the "current" configuration, this reflects the actual activation time; for "next" and "last", it is the scheduled time.
 
 Activation time is required. If a fork is activated at genesis the value `0` is used. If the fork is not scheduled to be activated or its activation time is unknown it should not be in the rpc results.
 
@@ -99,7 +99,7 @@ For Prague, the added contracts are (in order): `BLS12_G1ADD`, `BLS12_G1MSM`,`BL
 
 #### `systemContracts`
 
-A JSON object representing system-level contracts relevant to the fork, as introduced in their defining EIPs. Keys are 20-byte addresses in `0x`-prefixed hexadecimal form, with leading zeros preserved, sorted alphabetically. Omitted for forks before Cancun. Values are the contract names (e.g., `BEACON_ROOTS_ADDRESS`) from the first EIP where they appeared.
+A JSON object representing system-level contracts relevant to the fork, as introduced in their defining EIPs. Keys are the contract names (e.g., `BEACON_ROOTS_ADDRESS`) from the first EIP where they appeared, sorted alphabetically. Values are 20-byte addresses in `0x`-prefixed hexadecimal form, with leading zeros preserved. Omitted for forks before Cancun.
 
 For Cancun the only system contract is `BEACON_ROOTS_ADDRESS`.
 
@@ -109,7 +109,7 @@ Future forks MUST define the list of system contracts in their meta-EIPs.
 
 ### Blob Parameter Only Forks
 
-BPO forks specified in [EIP-7892](./eip-7892.md) should be interpreted as new forks, taking the parent fork as base and updating only the appropriate values in the `blobsSchedule` object to produce the new fork configuration.
+BPO forks specified in [EIP-7892](./eip-7892.md) should be interpreted as new forks, taking the parent fork as base (recursively, if the parent fork is also a BPO) and updating only the appropriate values in the `blobsSchedule` object to produce the new fork configuration.
 
 ## Rationale
 
@@ -184,11 +184,11 @@ Hoodi Prague Config
     "0x0000000000000000000000000000000000000011": "BLS12_MAP_FP2_TO_G2"
   },
   "systemContracts": {
-    "0x00000000219ab540356cbb839cbe05303d7705fa": "DEPOSIT_CONTRACT_ADDRESS",
-    "0x00000961ef480eb55e80d19ad83579a64c007002": "WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS",
-    "0x0000bbddc7ce488642fb579f8b00f3a590007251": "CONSOLIDATION_REQUEST_PREDEPLOY_ADDRESS",
-    "0x0000f90827f1c53a10cb7a02335b175320002935": "HISTORY_STORAGE_ADDRESS",
-    "0x000f3df6d732807ef1319fb7b8bb8522d0beac02": "BEACON_ROOTS_ADDRESS"
+    "BEACON_ROOTS_ADDRESS": "0x000f3df6d732807ef1319fb7b8bb8522d0beac02",
+    "CONSOLIDATION_REQUEST_PREDEPLOY_ADDRESS": "0x0000bbddc7ce488642fb579f8b00f3a590007251",
+    "DEPOSIT_CONTRACT_ADDRESS": "0x00000000219ab540356cbb839cbe05303d7705fa",
+    "HISTORY_STORAGE_ADDRESS": "0x0000f90827f1c53a10cb7a02335b175320002935",
+    "WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS": "0x00000961ef480eb55e80d19ad83579a64c007002"
   }
 }
 ```
@@ -217,7 +217,7 @@ Hoodi Cancun Config
     "0x000000000000000000000000000000000000000a": "KZG_POINT_EVALUATION"
   },
   "systemContracts": {
-    "0x000f3df6d732807ef1319fb7b8bb8522d0beac02": "BEACON_ROOTS_ADDRESS"
+    "BEACON_ROOTS_ADDRESS": "0x000f3df6d732807ef1319fb7b8bb8522d0beac02"
   }
 }
 ```
@@ -258,10 +258,10 @@ would return (after formatting):
         "0x000000000000000000000000000000000000000a": "KZG_POINT_EVALUATION"
       },
       "systemContracts": {
-        "0x000f3df6d732807ef1319fb7b8bb8522d0beac02": "BEACON_ROOTS_ADDRESS"
+        "BEACON_ROOTS_ADDRESS": "0x000f3df6d732807ef1319fb7b8bb8522d0beac02"
       }
     },
-    "currentHash": "0xfe6aefa8",
+    "currentHash": "0x243c27d1",
     "currentForkId": "0xbef71d30",
     "next": {
       "activationTime": 1742999832,
@@ -291,15 +291,52 @@ would return (after formatting):
         "0x0000000000000000000000000000000000000011": "BLS12_MAP_FP2_TO_G2"
       },
       "systemContracts": {
-        "0x00000000219ab540356cbb839cbe05303d7705fa": "DEPOSIT_CONTRACT_ADDRESS",
-        "0x00000961ef480eb55e80d19ad83579a64c007002": "WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS",
-        "0x0000bbddc7ce488642fb579f8b00f3a590007251": "CONSOLIDATION_REQUEST_PREDEPLOY_ADDRESS",
-        "0x0000f90827f1c53a10cb7a02335b175320002935": "HISTORY_STORAGE_ADDRESS",
-        "0x000f3df6d732807ef1319fb7b8bb8522d0beac02": "BEACON_ROOTS_ADDRESS"
+        "BEACON_ROOTS_ADDRESS": "0x000f3df6d732807ef1319fb7b8bb8522d0beac02",
+        "CONSOLIDATION_REQUEST_PREDEPLOY_ADDRESS": "0x0000bbddc7ce488642fb579f8b00f3a590007251",
+        "DEPOSIT_CONTRACT_ADDRESS": "0x00000000219ab540356cbb839cbe05303d7705fa",
+        "HISTORY_STORAGE_ADDRESS": "0x0000f90827f1c53a10cb7a02335b175320002935",
+        "WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS": "0x00000961ef480eb55e80d19ad83579a64c007002"
       }
     },
-    "nextHash": "0xfc6b6ba3",
-    "nextForkId": "0x0929e24e"
+    "nextHash": "0x10368496",
+    "nextForkId": "0x0929e24e",
+    "last": {
+      "activationTime": 1742999832,
+      "blobSchedule": {
+        "baseFeeUpdateFraction": 5007716,
+        "max": 9,
+        "target": 6
+      },
+      "chainId": "0x88bb0",
+      "precompiles": {
+        "0x0000000000000000000000000000000000000001": "ECREC",
+        "0x0000000000000000000000000000000000000002": "SHA256",
+        "0x0000000000000000000000000000000000000003": "RIPEMD160",
+        "0x0000000000000000000000000000000000000004": "ID",
+        "0x0000000000000000000000000000000000000005": "MODEXP",
+        "0x0000000000000000000000000000000000000006": "BN256_ADD",
+        "0x0000000000000000000000000000000000000007": "BN256_MUL",
+        "0x0000000000000000000000000000000000000008": "BN256_PAIRING",
+        "0x0000000000000000000000000000000000000009": "BLAKE2F",
+        "0x000000000000000000000000000000000000000a": "KZG_POINT_EVALUATION",
+        "0x000000000000000000000000000000000000000b": "BLS12_G1ADD",
+        "0x000000000000000000000000000000000000000c": "BLS12_G1MSM",
+        "0x000000000000000000000000000000000000000d": "BLS12_G2ADD",
+        "0x000000000000000000000000000000000000000e": "BLS12_G2MSM",
+        "0x000000000000000000000000000000000000000f": "BLS12_PAIRING_CHECK",
+        "0x0000000000000000000000000000000000000010": "BLS12_MAP_FP_TO_G1",
+        "0x0000000000000000000000000000000000000011": "BLS12_MAP_FP2_TO_G2"
+      },
+      "systemContracts": {
+        "BEACON_ROOTS_ADDRESS": "0x000f3df6d732807ef1319fb7b8bb8522d0beac02",
+        "CONSOLIDATION_REQUEST_PREDEPLOY_ADDRESS": "0x0000bbddc7ce488642fb579f8b00f3a590007251",
+        "DEPOSIT_CONTRACT_ADDRESS": "0x00000000219ab540356cbb839cbe05303d7705fa",
+        "HISTORY_STORAGE_ADDRESS": "0x0000f90827f1c53a10cb7a02335b175320002935",
+        "WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS": "0x00000961ef480eb55e80d19ad83579a64c007002"
+      }
+    },
+    "lastHash": "0x10368496",
+    "lastForkId": "0x0929e24e"
   }
 }
 ```


### PR DESCRIPTION
### Fork ID
Adds Fork Id as members `currentForkId` and `nextForkId` to the `eth_config` response, as specified in EIP-6122.

Note that EIP-6122 only mentions `FORK_HASH` as the current configured fork's Id, and the block/timestamp number as the sole piece of information for the next fork, but, in this PR, `FORK_HASH` is also calculated for the next fork in order to catch fork ID issues early.

### Blob Parameter Only Forks

BPO forks are now specified in the EIP.

### `last` member

Adds `last`, `lastHash` and `lastForkId` members to represent the last configured fork know by the client.