### PR TITLE
Update eip-7607: add EIP-7910 to fusaka scope as other EIP

### DIFF
--- a/EIPS/eip-7607.md
+++ b/EIPS/eip-7607.md
@@ -39,6 +39,8 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Proposed
 
 * [EIP-7642](./eip-7642.md): eth/69 - Drop pre-merge fields
     * Client teams MUST support this EIP by the activation of the Fusaka network upgrade.
+* [EIP-7910](./eip-7910.md): eth_config JSON-RPC Method
+    * Client teams MUST support this JSON RPC method by the activation of Fusaka network upgrade. 
 
 ### Declined for Inclusion
 


### PR DESCRIPTION
During ACDT on 7th of Jul 2025 we have agreed to have eth_config be part of the scope of fusaka.

**ATTENTION: ERC-RELATED PULL REQUESTS NOW OCCUR IN [ETHEREUM/ERCS](https://github.com/ethereum/ercs)**

--

When opening a pull request to submit a new EIP, please use the suggested template: https://github.com/ethereum/EIPs/blob/master/eip-template.md

We have a GitHub bot that automatically merges some PRs. It will merge yours immediately if certain criteria are met:

 - The PR edits only existing draft PRs.
 - The build passes.
 - Your GitHub username or email address is listed in the 'author' header of all affected PRs, inside <triangular brackets>.
 - If matching on email address, the email address is the one publicly listed on your GitHub profile.
