### PR TITLE
Update EIP-7915: fix typos

### DIFF
--- a/EIPS/eip-7915.md
+++ b/EIPS/eip-7915.md
@@ -135,7 +135,7 @@ $$
 
 The mechanism only applies mean reversion when $f_g < \bar{f}_ g.$ While there can be benefits from mean reversion in both directions, the case when $f_g<\bar{f}_ g$ is far more important to address. Furthermore, the update schedule from [EIP-7691](./eip-7691.md), applied when $f_g \geq \bar{f}_g$, already decreases more with 0 blobs than it increases with the maximum.
 
-A symmetrical update schedule at ratios around 1 was initially considered since the target from Pectra is not centered at `MAX_BLOB_GAS_PER_BLOCK/2`. However, a well-formed symmetrical fee update schedule will likely not achieve a `TARGET_BLOB_GAS_PER_BLOCK` throughput, even though it responds to a target gas consumption by keeping the fee fixed. The reason is that the fee update for blocks $x$ blobs above the target and $x$ blobs below the target will not be reciprocal. Equilibrium would therefore settle at slightly lower throughput than `TARGET_BLOB_GAS_PER_BLOCK`, at a slightly higher price than when relying on the assymetrical update schedule with an identical target. The proposed fee update schedule instead intermediately transitions to a symmetrical schedule as the fee ratio falls (see Figure 2).
+A symmetrical update schedule at ratios around 1 was initially considered since the target from Pectra is not centered at `MAX_BLOB_GAS_PER_BLOCK/2`. However, a well-formed symmetrical fee update schedule will likely not achieve a `TARGET_BLOB_GAS_PER_BLOCK` throughput, even though it responds to a target gas consumption by keeping the fee fixed. The reason is that the fee update for blocks $x$ blobs above the target and $x$ blobs below the target will not be reciprocal. Equilibrium would therefore settle at slightly lower throughput than `TARGET_BLOB_GAS_PER_BLOCK`, at a slightly higher price than when relying on the asymmetrical update schedule with an identical target. The proposed fee update schedule instead intermediately transitions to a symmetrical schedule as the fee ratio falls (see Figure 2).
 
 ### Computing the long-run average base fee
 
@@ -157,7 +157,7 @@ The EMA is computed in the linear domain to preserve additivity and maintain int
 
 ### Alternative approach
 
-One alternative way to structure the adaptive mean reversion was referenced in the previous subsection and will be described here. It differs in that that the protocol would rely on and store a log-domain representation of `base_fee_per_blob_gas_ema`: `excess_blob_gas_ema`. The EMA computation would still be performed in the linear domain, but `get_base_fee_per_blob_gas()` and its inverse—relying on a new `fake_log()` function—would be applied during computations to first go to the linear domain and then return to the log-domain
+One alternative way to structure the adaptive mean reversion was referenced in the previous subsection and will be described here. It differs in that the protocol would rely on and store a log-domain representation of `base_fee_per_blob_gas_ema`: `excess_blob_gas_ema`. The EMA computation would still be performed in the linear domain, but `get_base_fee_per_blob_gas()` and its inverse—relying on a new `fake_log()` function—would be applied during computations to first go to the linear domain and then return to the log-domain
 
 $$
 \bar{e}_ {g(n)} = \log\Biggl[\exp\bigl(\bar{e}_ {g(n-1)}\bigr) + \frac{\exp\bigl(e_ {g(n-1)}\bigr) - \exp\bigl(\bar{e}_ {g(n-1)}\bigr)}{m}\Biggr].


### PR DESCRIPTION


**Description:**  
This pull request corrects two minor typographical errors in EIP-7915:
- Replaces `assymetrical` with the correct spelling `asymmetrical`
- Removes a duplicate `that` in the `Alternative approach` section


