### PR TITLE
Update EIP-7612: Remove the redundant article and fix the typo

### DIFF
--- a/EIPS/eip-2539.md
+++ b/EIPS/eip-2539.md
@@ -178,7 +178,7 @@ Error cases:
 
 #### ABI for mapping Fp element to G1 point
 
-Field-to-curve call expects `64` bytes an input that is interpreted as a an element of the base field. Output of this call is `128` bytes and is G1 point following respective encoding rules.
+Field-to-curve call expects `64` bytes an input that is interpreted as an element of the base field. Output of this call is `128` bytes and is G1 point following respective encoding rules.
 
 Error cases:
 	- Input has invalid length
@@ -186,7 +186,7 @@ Error cases:
 
 #### ABI for mapping Fp2 element to G2 point
 
-Field-to-curve call expects `128` bytes an input that is interpreted as a an element of the quadratic extension field. Output of this call is `256` bytes and is G2 point following respective encoding rules.
+Field-to-curve call expects `128` bytes an input that is interpreted as an element of the quadratic extension field. Output of this call is `256` bytes and is G2 point following respective encoding rules.
 
 Error cases:
 	- Input has invalid length
@@ -248,7 +248,7 @@ Motivation section covers a total motivation to have operations over BLS12-377 c
 
 ### Multiexponentiation as a separate call
 
-Explicit separate multiexponentiation operation that allows one to save execution time (so gas) by both the algorithm used (namely Peppinger algorithm) and (usually forgotten) by the fact that `CALL` operation in Ethereum is expensive (at the time of writing), so one would have to pay non-negigible overhead if e.g. for multiexponentiation of `100` points would have to call the multipication precompile `100` times and addition for `99` times (roughly `138600` would be saved).
+Explicit separate multiexponentiation operation that allows one to save execution time (so gas) by both the algorithm used (namely Peppinger algorithm) and (usually forgotten) by the fact that `CALL` operation in Ethereum is expensive (at the time of writing), so one would have to pay non-negigible overhead if e.g. for multiexponentiation of `100` points would have to call the multiplication precompile `100` times and addition for `99` times (roughly `138600` would be saved).
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
Remove the redundant article and fix the typo