### PR TITLE
Update EIP-225: remove trailing comma and correct Go struct field syntax

### DIFF
--- a/EIPS/eip-225.md
+++ b/EIPS/eip-225.md
@@ -451,7 +451,7 @@ tests := []struct {
   }, {
     // An authorized signer that signed recently should not be able to sign again
     signers: []string{"A", "B"},
-  blocks []block{
+    blocks: []block{
       {signer: "A"},
       {signer: "A"},
     },
@@ -467,7 +467,7 @@ tests := []struct {
       {signer: "A"},
     },
     failure: errRecentlySigned,
-  },,
+  },
 }
 ```
 


### PR DESCRIPTION
- Removed an extraneous trailing comma after the last test case in the test cases array to ensure proper syntax.
- Fixed the Go struct initialization in the test cases by adding a missing colon in the blocks: []block{ field, replacing the incorrect blocks []block{ syntax.
- These changes improve the accuracy and validity of the code examples in the EIP-225 specification.