### PR TITLE
Update EIP-7949: Fix typos and formatting

### DIFF
--- a/EIPS/eip-7949.md
+++ b/EIPS/eip-7949.md
@@ -68,7 +68,7 @@ The `alloc` field defines the initial state at genesis. It maps addresses (as lo
 
 
 
-JSON Schema
+### JSON Schema
 
 
 ```json
@@ -86,7 +86,7 @@ JSON Schema
     },
     "address": {
       "type": "string",
-      "pattern":  "^0x[0-9a-fA-F]{40}$"
+      "pattern": "^0x[0-9a-fA-F]{40}$"
     },
     "hash": {
       "type": "string",
@@ -104,7 +104,7 @@ JSON Schema
         "homesteadBlock": { "type": "integer" },
         "daoForkBlock": { "type": "integer" },
         "eip150Block": { "type": "integer" },
-        "tangerineWhistleBlock": {"type":  "integer"},
+        "tangerineWhistleBlock": {"type": "integer"},
         "eip155Block": { "type": "integer" },
         "spuriousDragonBlock": {"type": "integer"},
         "byzantiumBlock": { "type": "integer" },
@@ -129,7 +129,7 @@ JSON Schema
             "type": "object",
             "properties": {
               "target": { "type": "integer" },
-              "max": { "type" : "integer" },
+              "max": { "type": "integer" },
               "baseFeeUpdateFraction": { "type" : "integer" }
             }
           }
@@ -170,7 +170,7 @@ JSON Schema
         },
         "additionalProperties": false
       },
-      "additionalProperties":false
+      "additionalProperties": false
     }
   },
   "additionalProperties": true
@@ -184,7 +184,7 @@ There are a growing number of EIPs that propose improvements to how a network is
 
 [Add Blob Schedule to EL Config File](eip-7840)
 
-[Blob Paramter Only Hardforks](eip-7892)
+[Blob Parameter Only Hardforks](eip-7892)
 
 [eth_config JSON-RPC method](eip-7910)
 


### PR DESCRIPTION


This PR corrects several typos and formatting issues in EIP-7949:

###  Changes Made
- **Header formatting**: Added proper markdown heading for "JSON Schema" section
- **Typo fix**: Corrected "Paramter" → "Parameter" in line 188  
- **JSON formatting**: Cleaned up spacing inconsistencies in schema definition
  - Removed extra spaces in `pattern` properties
  - Standardized spacing in `type` declarations
  - Fixed `additionalProperties` formatting

### Impact
- Improves document readability and consistency
- Ensures proper markdown rendering
- Maintains JSON schema validity

