### PR TITLE
Update EIP-7591: Correct spelling and function naming

### DIFF
--- a/EIPS/eip-7591.md
+++ b/EIPS/eip-7591.md
@@ -102,12 +102,12 @@ The messages signed via BLS are distinct (no hash collisions on the txhash), thu
 The public keys are not distinct which is not a problem in BLS.
 
 We assume that keccak256 and ECDSA and BLS are working as intended. 
-Suppose we have two addresses `address_1 = keccak256(pk_ecdsa)` and `address_2 = keccak(pk_bls)` with `address_1 == address_2`.
-We know that `pk_ecdsa` must be equal to `pk_bls` (follows from keccak).
+Suppose we have two addresses `address_1 = keccak256(pk_ecdsa)` and `address_2 = keccak256(pk_bls)` with `address_1 == address_2`.
+We know that `pk_ecdsa` must be equal to `pk_bls` (follows from keccak256).
 This would mean that we would either be able to find `x` with `g_bls^x = y` for a given `y` (violates the security of BLS)
 or find `z` with `d_ecdsa^z = y` (violates the security of ECDSA).
 
-Thus it would be impossible (with greater than negligble probability) to find two private keys, one in ECDSA and one in BLS that control the same account.
+Thus it would be impossible (with greater than negligible probability) to find two private keys, one in ECDSA and one in BLS that control the same account.
 
 ## Copyright
 


### PR DESCRIPTION


### Description

This PR fixes several typos found in EIP-7591:

- **Line 98, 99**: `keccak(pk_bls)` → `keccak256(pk_bls)` and `follows from keccak` → `follows from keccak256`
- **Line 103**: `negligble` → `negligible`

These corrections ensure consistency in function naming and fix a spelling error in the Security Considerations section.

### Changes
-  Fixed incomplete function name references
-  Corrected spelling error
