### PR TITLE
Update EIP-7883: Fix typo in pricing of one test case

### DIFF
--- a/EIPS/eip-7883.md
+++ b/EIPS/eip-7883.md
@@ -131,7 +131,7 @@ No changes are made to the underlying interface or arithmetic algorithms, allowi
 | modexp_nagydani_4_pow0x10001 | 21845 | 131072 | 500% |
 | modexp_nagydani_5_square     | 5461 | 32768 | 500% |
 | modexp_nagydani_5_qube       | 5461 | 32768 | 500% |
-| modexp_nagydani_5_pow0x10001 | 87381 | 525288 | 500% |
+| modexp_nagydani_5_pow0x10001 | 87381 | 524288 | 500% |
 | modexp_marius_1_even         | 2057 | 45296 | 2102% |
 | modexp_guido_1_even          | 2298 | 51136 | 2125% |
 | modexp_guido_2_even          | 2300 | 51152 | 2124% |


### PR DESCRIPTION
Fixing a typo in gas pricing of test case `modexp_nagydani_5_pow0x10001`