### PR TITLE
Update EIP-7907: Consider empty code as always warm

### DIFF
--- a/EIPS/eip-7907.md
+++ b/EIPS/eip-7907.md
@@ -51,7 +51,7 @@ def excess_code_size(n: int) -> int:
 3. The cost for `EXTCODESIZE` is updated to acknowlege the potential for two database reads: once for the account (making it warm) and second for code size if bytecode is marked as cold. Bytecode will not be marked as warm as only codesize is read. In addition to the current pricing scheme defined under [EIP-2929](./eip-2929.md), the instruction will also be subject to the `COLD_SLOAD_COST=2100` if code is cold.
 4. Update the [EIP-3860](./eip-3860.md) contract initcode size limit of 48KB (`0xc000` bytes) to 96KB (`0x18000` bytes).
 5. If a large contract is the entry point of a transaction, the cost calculated in (2) is charged before the execution and contract code is marked as warm. This fee is not calculated towards the initial gas fee. In case of out-of-gas halt, execution will stop and the balance will not be transferred.
-6. Empty code ( with `keccak([])` hash) is always considered warm.
+6. Empty code ( with `keccak("") = "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"`) is always considered warm.
 
 | Contract                | Gas changes (only opcodes that load code)                          | How?                                                                                                                       |
 | ----------------------- | ------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------- |

--- a/EIPS/eip-7907.md
+++ b/EIPS/eip-7907.md
@@ -51,6 +51,7 @@ def excess_code_size(n: int) -> int:
 3. The cost for `EXTCODESIZE` is updated to acknowlege the potential for two database reads: once for the account (making it warm) and second for code size if bytecode is marked as cold. Bytecode will not be marked as warm as only codesize is read. In addition to the current pricing scheme defined under [EIP-2929](./eip-2929.md), the instruction will also be subject to the `COLD_SLOAD_COST=2100` if code is cold.
 4. Update the [EIP-3860](./eip-3860.md) contract initcode size limit of 48KB (`0xc000` bytes) to 96KB (`0x18000` bytes).
 5. If a large contract is the entry point of a transaction, the cost calculated in (2) is charged before the execution and contract code is marked as warm. This fee is not calculated towards the initial gas fee. In case of out-of-gas halt, execution will stop and the balance will not be transferred.
+6. Empty code ( with `keccak([])` hash) is always considered warm.
 
 | Contract                | Gas changes (only opcodes that load code)                          | How?                                                                                                                       |
 | ----------------------- | ------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
Empty code (code with `keccak([])`) is something we can check from the account, so we can consider this code as warm

Making this as draft, hope that the bot is not going to merge it.