### PR TITLE
Update EIP-7495: fix typos and link formatting

### DIFF
--- a/EIPS/eip-7495.md
+++ b/EIPS/eip-7495.md
@@ -23,7 +23,7 @@ Further, if multiple versions of an SSZ container coexist at the same time, for 
 
 Progressive containers address these shortcomings by:
 
-- Using the [progressive Merkle tree](./eip-7916.md) structure to progressively grow to the actual field count with minimal overhead, ensuring provers remain valid as the field count chanages.
+- Using the [progressive Merkle tree](./eip-7916.md) structure to progressively grow to the actual field count with minimal overhead, ensuring provers remain valid as the field count changes.
 - Assigning stable gindices for each field across all versions by allowing gaps in the Merkle tree where a field is absent.
 - Serializing in a compact form where absent fields do not consume space.
 
@@ -119,7 +119,7 @@ The canonical [JSON mapping](https://github.com/ethereum/consensus-specs/blob/b5
 
 #### Merkleization
 
-The [SSZ Merkleization specification)](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/ssz/simple-serialize.md#merkleization) is extended with two helper functions:
+The [SSZ Merkleization specification](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/ssz/simple-serialize.md#merkleization) is extended with two helper functions:
 
 - `get_active_fields`: Given a `value` of type `ProgressiveContainer[active_fields]` return `value.__class__.active_fields`.
 - `mix_in_active_fields`: Given a Merkle root `root` and an `active_fields` bitlist return `hash(root, pack_bits(active_fields))`. Note that `active_fields` is restricted to ≤ 256 bits.


### PR DESCRIPTION

**Description:**  
This pull request corrects two minor issues in EIP-7495:
- Fixes a typo: `chanages` is replaced with `changes`.
- Removes an extra parenthesis in the Merkleization specification link.


