### PR TITLE
Update EIP-7877: Fix typos

### DIFF
--- a/EIPS/eip-7877.md
+++ b/EIPS/eip-7877.md
@@ -21,7 +21,7 @@ instead of defaulting to returning from memory.
 With the introduction of transient storage, many smart contracts have begun to store data using the new transient opcodes to optimize for gas usage, whereby a callback
 involves returning the data previously stored transiently. However, the current `RETURN` opcode only allows for returning sequential bytes in memory. This requires
 developers to incur additional gas overhead by manually writing data from transient storage to memory before returning,
-incuring both an additional memory expansion and opcode cost from complicated for-loops. Similar
+incurring both an additional memory expansion and opcode cost from complicated for-loops. Similar
 inefficiencies already occur when attempting to return data already placed in storage. This EIP attempts to rectify
 this by allowing developers to optimize their code by deciding where to return data from directly, instead of requiring
 the intermediate step of first copying the data to memory.
@@ -38,7 +38,7 @@ RRETURN (0xf8)
 RETURN -> MRETURN (0xf3)
 ```
 
-The `MRETURN` opcode is a rename of `RETURN`, whereby sequential bytes in memory are returned. It will operate exactly as it currenty does as of the Cancun hard-fork, and its gas cost will remain the same.
+The `MRETURN` opcode is a rename of `RETURN`, whereby sequential bytes in memory are returned. It will operate exactly as it currently does as of the Cancun hard-fork, and its gas cost will remain the same.
 
 `RRETURN` operates similar to `MRETURN`. It pops two items off the stack, an offset to begin reading bytes from in the
 existing `RETURNDATA` buffer, and a number of bytes to return. Those bytes are used to overwrite the existing `RETURNDATA` buffer and then a return to the previous function is performed.
@@ -51,7 +51,7 @@ If the length parameter is a zero, then only the initial slot value should be re
 The cost for these opcodes should be similar to the cost of accessing data now.
 
 ```
-SRETURN = (number_of_cold_slots) * 2100 + (numer_of_warm_slots * 100)
+SRETURN = (number_of_cold_slots) * 2100 + (number_of_warm_slots * 100)
 TRETURN = number_of_slots * 100
 
 RRETURN = cost of RETURNDATACOPY without memory_expansion cost


### PR DESCRIPTION


##  Changes
- Fixed `incuring` → `incurring` (line 26)
- Fixed `currenty` → `currently` (line 38) 
- Fixed `numer_of_warm_slots` → `number_of_warm_slots` (line 54)

