### PR TITLE
CI: update actions/configure-pages from v3 to v5

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -64,7 +64,7 @@ jobs:
           cache-version: 0 # Increment this number if you need to re-download cached gems
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"


### PR DESCRIPTION
Update GitHub Actions dependency to use the latest version of configure-pages action, improving security and ensuring compatibility with other v5 actions in the workflow