### PR TITLE
Update EIP-7919: Minimize scope

### DIFF
--- a/EIPS/eip-7919.md
+++ b/EIPS/eip-7919.md
@@ -7,73 +7,69 @@ discussions-to: https://ethereum-magicians.org/t/eip-7919-pureth-meta/23273
 status: Draft
 type: Meta
 created: 2025-03-26
-requires: 6404, 6465, 6466, 6493, 7495, 7668, 7688, 7706, 7708, 7745, 7792, 7799, 7807, 7916
+requires: 6404, 6465, 6466, 7495, 7668, 7708, 7745, 7799, 7807, 7916
 ---
 
 ## Abstract
 
-This Meta EIP lists the EIPs which belong to the Pureth proposal.
+This Meta EIP bundles a set of improvements to make Ethereum data easier to access and verify without relying on trusted RPC providers or third-party indexers. The improvements achieve this by changing data structures for blocks, transactions, and receipts, so that efficient correctness (i.e., validity) and completion (i.e., nothing omitted) proofs can be added to the RPC responses.
 
 ## Motivation
 
-It is currently not feasible to consume Ethereum data for a given account to efficiently reconstruct the account activity, without relying on a trusted API gateway. This is a problem for:
+- **Security**: Today, most wallets and dApps consume data from very few large RPC providers, which exposes users to the risk of incorrect and incomplete data in case the RPC provider gets hacked, becomes malicious, or uses a faulty software version.
 
-- End users, through mobile or browser based wallets where a local full node is not viable
-- dApps that interact with Ethereum through JSON-RPC
-- L2 networks that read data from Ethereum through Merkle proofs
-- Portal network which aims to be a decentralized archive node
+- **Privacy**: Centralized infrastructure is subject to external data collection and privacy policies; users may be profiled across distinct wallets even when there is no on-chain link between them.
 
-Relying on a trusted API gateway exposes the application to external privacy policies and region-specific restrictions.
+- **Cost**: External indexers can be quite costly, however, are required for even basic wallet use cases. Reducing reliance on them helps lower-funded developers.
 
 ## Specification
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
 
-### PURGE: LOG Reform
+### Improve UX: ETH transfer logs
 
-Certain EVM operations can change the ETH balance, without an appropriate log being emitted. For example, a SELFDESTRUCT can send an arbitrary ETH balance to an arbitrary account, e.g., as part of a smart contract based wallet. To monitor such operations, the application would have to use tracing APIs on every single transaction of every single block. Adding logs for ETH transfers enables the use of existing `eth_getLogs` infrastructure to obtain a fully accurate account history.
+ETH transfers currently don't emit logs, and in many situations don't leave any on-chain record in neither transaction nor receipt that they took place. For example, SENDALL can send an arbitrary ETH balance to an arbitrary account as part of a smart contract based wallet. Or a new contract deployment may send ETH to a new account of which not even the address is known yet. This makes basic flows, such as detecting a user deposit onto an exchange, very tricky. Wallets, dApps etc. either have to use tracing debug APIs on every single transaction of every single block, or integrate an external trusted indexing service which can be costly.
 
 - [EIP-7708: ETH transfers emit a log](./eip-7708.md)
 - [EIP-7799: System logs](./eip-7799.md)
 
-While individual `eth_getLogs` results can be verified against the containing block when all block headers are available, it is not viable to verify exhaustiveness of the response, i.e., no logs were withheld, as the current Bloom based log filter suffers from false positives. Further, the per-receipt logs Bloom is essentially useless because it cannot be verified independently without also downloading the full receipt including all log data. This can be addressed by a better log index that allows enumerating all logs matching a query as well as looking up position information by hash for blocks, transactions, and logs.
+### Scale L1 / Improve UX: LOG reform
+
+The current 2048-bit Bloom filter has a high false positive rate, which grows further as more logs are packed into each block. Combined with the requirements to obtain all historical block headers to obtain a complete view of an account's history, the Bloom filter becomes practically irrelevant. A new on-chain 2D log index with bounded false positive rate and a historical accumulator is proposed that is highly efficient, further reducing the need for external indexing services for basic wallet use cases.
 
 - [EIP-7668: Remove bloom filters](./eip-7668.md)
-- [EIP-7745: Two dimensional log filter data structure](./eip-7745.md)
-- [EIP-7792: Verifiable logs](./eip-7792.md) (optional, uses ZK to store the filter commitment externally)
+- [EIP-7745: Light client and DHT friendly log index](./eip-7745.md)
+- [EIP-7792: Verifiable logs](./eip-7792.md) (alternative, with log index root provided via ZK instead of block header)
 
-The new log filter is based on SSZ to support proving individual parts of log data. This is useful for L2 smart contracts when processing potentially large fraud proofs where the entire receipt may be too large to fit into calldata.
+### Improve UX: Normalized transactions / receipts
 
-### PURGE: Remove old tx types
+There are various JSON-RPC fields that are missing on-chain and inefficient to prove:
 
-Moving logs to SSZ affects the receipts structure, which are defined by the various transaction types. Therefore, changing the receipts breaks backwards compatibility. By introducing a new transaction type, a new receipt type can be introduced. Basing that new transaction type on SSZ also enables proofs for individual parts of calldata.
+- **`from`, `contractAddress`, and `authority` addresses**: need to fetch transaction + use `ecrecover`
+- **`gasUsed`**: needs current and prior receipt, as on-chain data stores cumulative not individual gas used
+- **`logIndex`**: need to fetch all receipts in the block
+- **`txHash`**: the on-chain data is based on an MPT-prefixed hash, which is different from the RPC hash
 
-- [EIP-7706: Separate gas type for calldata](./eip-7706.md)
+Further, **`calldata` and log `data`** can be very large, but can only be verified by downloading the entire receipt / transaction data. This data is needed even if just basic items such as amount and destination are queried.
+
+Switching transactions and receipts to SSZ normalizes the format, changes to tree-based hash for more efficient proofs, and is also extensible for future transaction features such as multidimensional fees, CREATE2 deployment, and post-quantum signature types, without breaking verifiers that only check common fields.
+
 - [EIP-6404: SSZ transactions](./eip-6404.md)
 - [EIP-6466: SSZ receipts](./eip-6466.md)
 
-Existing RLP transactions continue to be supported in the mempool, but are converted to SSZ when bundled into an execution block. The conversion is lossless, so that full nodes can recover the original RLP representation when validating a block. Besides full nodes, no other client requires that original representation: The on-chain data follows a single SSZ format that's forward compatible across forks (`StableContainer`), and commitments to properties computed from the original RLP representation (`from` / `contract_address`) are included in the receipt data.
+### Improve UX: Serialization harmonization
 
-To enable native use of SSZ transactions without going through the conversion, a new signature scheme is proposed. New transaction features such as multidimensional fees, CREATE2 deployment, and post-quantum signature types, can be introduced without requiring introducing additional transaction types.
-
-- [EIP-6493: SSZ transaction signature scheme](./eip-6493.md) (optional)
-
-### PURGE: Serialization harmonization
-
-While the proposed changes do not affect applications that use a trusted API gateway via JSON-RPC, they represent breaking changes for applications that verify Ethereum data today. To avoid recurring breaking changes, the rest of the execution block is also transitioned to SSZ at the same time. This will likely require cooperating with popular applications that rely on assumptions about the block header layout.
+Changing the remainder of the EL to SSZ enables a switch to a binary API as an alternative to the dated JSON-RPC API. This is especially interesting for the engine API which currently encodes all blobs as ASCII hex-strings over JSON. That binary API would follow the same approach as beacon-APIs, be based on REST, SSZ, and Snappy compression, and support similar functionality as JSON-RPC, except that all response data now comes with a correctness and exhaustiveness proof. The SSZ objects are designed to efficiently serve API requests, often allowing to answer directly from the database without having to decompress stored data on the server and without having to consult auxiliary indices.
 
 - [EIP-6465: SSZ withdrawals root](./eip-6465.md)
 - [EIP-7807: SSZ execution blocks](./eip-7807.md)
 
-With all execution structures besides the state trie transitioned to SSZ, a secondary binary API can now be defined as an alternative to the dated JSON-RPC API and could also replace the engine API. That binary API would follow the same approach as beacon-APIs, be based on REST, SSZ, and Snappy compression, and support similar functionality as JSON-RPC, except that all response data now comes with a correctness and exhaustiveness proof. The SSZ objects are designed to efficiently serve API requests, often allowing to answer directly from the database without having to decompress stored data on the server and without having to consult auxiliary indices (e.g., to answer a `eth_getTransactionReceipt` query).
-
 ### Simple Serialize (SSZ) requirements
 
-The EIPs require adding production-grade Simple Serialize (SSZ) libraries to all execution client implementations. Further, new SSZ data types are required to achieve forward compatibility while maintaining reasonable efficiency.
+The EIPs require adding production-grade Simple Serialize (SSZ) libraries to all execution client implementations. Further, new SSZ data types are required to achieve forward compatibility while maintaining reasonable efficiency when using nested lists of large theoretical capacity.
 
 - [EIP-7916: SSZ ProgressiveList](./eip-7916.md)
-- [EIP-7495: SSZ StableContainer](./eip-7495.md)
-- [EIP-7688: Forward compatible consensus data structures](./eip-7688.md) (optional)
+- [EIP-7495: SSZ ProgressiveContainer](./eip-7495.md)
 
 ## Rationale
 


### PR DESCRIPTION
- Make motiviation clearer (no indexers for basic wallet use cases)
- Split ETH transfer emit logs and LOG reform sections
- Only keep multidimensional concept but don't introduce calldata fee
- Drop optional EIPs