### PR TITLE
EIP-7928: Add statically inferrable nonce changes back

### DIFF
--- a/EIPS/eip-7928.md
+++ b/EIPS/eip-7928.md
@@ -144,7 +144,7 @@ Storage reads:
 
 Slots both read and written (with changed values) appear only in `storage_changes`.
 
-Balance changes record post-transaction balances (uint128`) for:
+Balance changes record post-transaction balances (`uint128`) for:
 
 - Transaction senders (gas + value)
 - Recipients
@@ -155,7 +155,7 @@ Zero-value transfers: NOT recorded in `balance_changes` but addresses MUST be in
 
 Code changes track post-transaction runtime bytecode for deployed/modified contracts.
 
-Nonce changes record post-transaction nonces for contracts that performed a successful `CREATE` or `CREATE2` operation.
+Nonce changes record post-transaction nonces for senders, contracts that performed a successful `CREATE` or `CREATE2` operation, deployed contracts and [EIP-7702](./eip-7792.md) authorities.
 
 ### Important Implementation Details
 
@@ -167,6 +167,7 @@ Nonce changes record post-transaction nonces for contracts that performed a succ
 - **Gas refunds**: Final balance of sender recorded after each transactions
 - **Block rewards**: Final balance of fee recipient recorded after each transactions
 - **STATICCALL/Read-only opcodes**: Include targets with empty changes
+- **Exceptional halts**: Final nonce and balance of sender and balance of fee recipient recorded after each transactions
 
 ### Concrete Example
 


### PR DESCRIPTION
Many nonce changes are statically inferrable by looking at the block, however, not including them into the BAL for reducing its size might not be worth the added complexity. This PR reverts those exceptions.