### PR TITLE
Update EIP-2025: fix typos

### DIFF
--- a/EIPS/eip-2025.md
+++ b/EIPS/eip-2025.md
@@ -181,7 +181,7 @@ I do not aim to change Ethereum governance. Because this EIP has hardcoded value
 
 This EIP is not about governance reform.
 
-## Why not allow current client implementors fund this work? (EF, Consensys, Parity, etc...) 
+### Why not allow current client implementors fund this work? (EF, Consensys, Parity, etc...) 
 
 Historically there has been a precedent that the Ethereum Foundation is solely responsible for funding the development of Ethereum. This process has evolved as the development has become more distributed. Aya Miyaguchi observed in a recent [Coindesk article](https://www.coindesk.com/ethereum-foundation-director-sets-new-vision-for-blockchain-non-profit), “it really is not only Ethereum Foundation people who are building [Ethereum]”. Yes, we could rely on the Ethereum Foundation to fund Eth1.X. But, why should we? This is a call for the network to come together and fund its own development. Ethereum *the network* is not owned by any one organization or group of people. We are lucky to have the EF and I consider this EIP in support of their coordination efforts.
 


### PR DESCRIPTION



**Description:**  
This pull request corrects several typographical errors in EIP-2025:
- `Etheruem` → `Ethereum`
- `us a smart contract` → `use a smart contract`
- `ecosytem` → `ecosystem`



