### PR TITLE
Update EIP-7910: fix missing 0 in nextHash example

### DIFF
--- a/EIPS/eip-7910.md
+++ b/EIPS/eip-7910.md
@@ -298,7 +298,7 @@ would return (after formatting):
         "WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS": "0x00000961ef480eb55e80d19ad83579a64c007002"
       }
     },
-    "nextHash": "0xd82a81f",
+    "nextHash": "0x0d82a81f",
     "nextForkId": "0x0929e24e",
     "last": {
       "activationTime": 1742999832,


### PR DESCRIPTION
follow up after https://github.com/ethereum/EIPs/pull/10039

there is a typo in `nextHash` - it should match the value of `lastHash` which has the correct value `0x0d82a81f`

@shemnon @rubo pls can you check