### PR TITLE
Update EIP-7910: require addresses and forkids to be in lowecase hex.

### DIFF
--- a/EIPS/eip-7910.md
+++ b/EIPS/eip-7910.md
@@ -83,7 +83,7 @@ The blob configuration parameters for the specific fork, as defined in the genes
 
 #### `chainId`
 
-The chain ID of the current network, presented as a string with an unsigned `0x`-prefixed hexadecimal number, with all leading zeros removed. This specification does not support chains without a chain ID or with a chain ID of zero.
+The chain ID of the current network, presented as a string with an unsigned `0x`-prefixed hexadecimal number, with all leading zeros removed, in lower case. This specification does not support chains without a chain ID or with a chain ID of zero.
 
 For purposes of canonicalization this value must always be a string.
 
@@ -91,7 +91,7 @@ For purposes of canonicalization this value must always be a string.
 
 A representation of the active precompile contracts for the fork. If a precompile is replaced by an on-chain contract, or removed, then it is not included.
 
-This is a JSON object where the members are the 20-byte `0x`-prefixed hexadecimal addresses of the precompiles (with zeros preserved), and the values are agreed-upon names for each contract, typically specified in the EIP defining that contract.
+This is a JSON object where the members are the 20-byte `0x`-prefixed hexadecimal addresses of the precompiles (with zeros preserved), in lower case, and the values are agreed-upon names for each contract, typically specified in the EIP defining that contract.
 
 For Cancun, the contract names are (in order): `ECREC`, `SHA256`, `RIPEMD160`, `ID`, `MODEXP`, `BN254_ADD`, `BN254_MUL`, `BN254_PAIRING`, `BLAKE2F`, `KZG_POINT_EVALUATION`.
 
@@ -99,7 +99,7 @@ For Prague, the added contracts are (in order): `BLS12_G1ADD`, `BLS12_G1MSM`,`BL
 
 #### `systemContracts`
 
-A JSON object representing system-level contracts relevant to the fork, as introduced in their defining EIPs. Keys are the contract names (e.g., `BEACON_ROOTS_ADDRESS`) from the first EIP where they appeared, sorted alphabetically. Values are 20-byte addresses in `0x`-prefixed hexadecimal form, with leading zeros preserved. Omitted for forks before Cancun.
+A JSON object representing system-level contracts relevant to the fork, as introduced in their defining EIPs. Keys are the contract names (e.g., `BEACON_ROOTS_ADDRESS`) from the first EIP where they appeared, sorted alphabetically. Values are 20-byte addresses in `0x`-prefixed hexadecimal form, with leading zeros preserved, in lower case. Omitted for forks before Cancun.
 
 For Cancun the only system contract is `BEACON_ROOTS_ADDRESS`.
 


### PR DESCRIPTION
Some impls have good EIP-55 support, but that (a) breaks canonical form and (b) is hard to hand-edit. So all hex values must be lower case.