### PR TITLE
Update EIP-684: Clarify activation scope for contract creation collision revert

### DIFF
--- a/EIPS/eip-684.md
+++ b/EIPS/eip-684.md
@@ -18,7 +18,7 @@ This EIP causes contract creation to throw an error when attempted at an address
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
 
-If a contract creation is attempted due to a creation transaction, the `CREATE` opcode, the `CREATE2` opcode, or any other reason, and the destination address already has either a nonzero nonce, or a nonzero code length, then the creation MUST throw as if the first byte in the init code were an invalid opcode. This change MUST apply retroactively for all existing blocks.
+If a contract creation is attempted due to a creation transaction, the `CREATE` opcode, the `CREATE2` opcode, or any other reason, and the destination address already has either a nonzero nonce, or a nonzero code length, then the creation MUST throw as if the first byte in the init code were an invalid opcode. This change MUST apply to all contract creation attempts in blocks with block.number greater than or equal to the activation block of the hard fork.
 
 ## Rationale
 


### PR DESCRIPTION
Replaced the phrase "This change MUST apply retroactively for all existing blocks." with "This change MUST apply to all contract creation attempts in blocks with block.number greater than or equal to the activation block of the hard fork." in the Specification section.
This change was made to accurately reflect standard Ethereum upgrade practices: consensus changes are never applied retroactively to existing blocks, but only from the activation block of the relevant hard fork. This clarification prevents ambiguity and ensures the EIP is implementable in real-world networks.