### PR TITLE
Update EIP-7966: add client-configured timeout and improve specs

### DIFF
--- a/EIPS/eip-7966.md
+++ b/EIPS/eip-7966.md
@@ -39,33 +39,50 @@ _In a low-latency blockchain, transaction receipts are often available right aft
 
 ### Parameters
 
-The parameters of this method MUST be identical to the `eth_sendRawTransaction` method, which contain a signed transaction data.
+| Position | Type       | Description                       | Required |
+|----------|------------|-----------------------------------|----------|
+| 1        | `DATA`     | The signed transaction data       | Yes      |
+| 2        | `QUANTITY` | Maximum wait time in milliseconds | No       |
 
-- `DATA`. The signed transaction data.
+#### Parameter Validation Rules
+
+- **Transaction Data**. MUST be a valid hex-encoded, RLP-encoded signed transaction (same as in `eth_sendRawTransaction`).
+- **Timeout**. MUST be a positive integer between 1 and the node-configured maximum timeout.
 
 ### Returns
 
-- **On success**. Clients MUST return the transaction receipt object as defined by the `eth_getTransactionReceipt` method.
-- **On timeout error**. Clients MUST return an error code `-32002` with a timeout message.
-- **On standard error**. Clients MUST return a JSON-RPC error object consistent with existing RPC error formats.
+On success, node implementations MUST return the transaction receipt object as defined by the `eth_getTransactionReceipt` method.
 
-### Timeout Configuration
+### Error Codes
 
-- The handler function of this RPC MUST incorporate a configurable timeout when waiting for receipts (RECOMMENDED: 2 seconds).
-- Implementations MUST provide a way to configure the timeout duration.
+The next table describes error codes incorporated with the RPC, following [EIP-1474](./eip-1474) standards.
+
+| Code   | Message              | Meaning                                                       | Data Fields            |
+|--------|----------------------|---------------------------------------------------------------|------------------------|
+| -32000 | Invalid request      | Standard JSON-RPC invalid request                             | Standard JSON-RPC data |
+| -32001 | Method not supported | Method is not implemented                                     | `supportedMethods`     |
+| -32002 | Transaction timeout  | Transaction submitted but not processed within timeout        | `transactionHash`      |
+| -32602 | Invalid params       | Standard JSON-RPC invalid params & invalid timeout parameters | `maxTimeout`           |
+
+### Node-Configured Timeouts
+
+- The handler function of this RPC SHOULD incorporate a configurable timeout when waiting for receipts (RECOMMENDED: 2 seconds).
+- Node implementations SHOULD provide a way to configure the timeout duration.
 - Node operators MAY implement dynamic timeout adjustment based on real-time network conditions.
 
 ### Behavior
 
 Upon receiving an `eth_sendRawTransactionSync` request, the handler function performs the following tasks.
 
+- If timeout parameter is provided, the handler function MUST validate its validity.
+    - If the timeout is invalid, the handler function MUST return an error code `-32602` with current limits.
 - The handler function MUST submit the signed transaction to the network as per the existing `eth_sendRawTransaction` semantics.
 - The handler function MUST wait for the transaction receipt until the timeout elapses.
 - If the receipt is found within the specified timeout, the handler function MUST return it immediately.
-- If the timeout expires without obtaining a receipt, the handler function MUST return an error message with a timeout message.
-- If the transaction submission fails (e.g., due to invalid transaction data), the handler function MUST return an error immediately.
+- If the timeout expires without obtaining a receipt, the handler function MUST return an error code `-32002` with a timeout message.
+- If the transaction submission fails (e.g., due to invalid transaction data), the handler function MUST return an error (following the `eth_sendRawTransaction` definition) immediately.
 
-### Example Request
+### Example Request (No Timeout)
 
 ```json
 {
@@ -73,6 +90,20 @@ Upon receiving an `eth_sendRawTransactionSync` request, the handler function per
   "method": "eth_sendRawTransactionSync",
   "params": [
     "0xf86c808504a817c80082520894ab... (signed tx hex)"
+  ],
+  "id": 1
+}
+```
+
+### Example Request (With Timeout)
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "eth_sendRawTransactionSync",
+  "params": [
+    "0xf86c808504a817c80082520894ab... (signed tx hex)",
+    5000
   ],
   "id": 1
 }
@@ -111,7 +142,23 @@ Upon receiving an `eth_sendRawTransactionSync` request, the handler function per
 }
 ```
 
-### Example Response (Error)
+### Example Response (Invalid Timeout Parameter)
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "error": {
+    "code": -32602,
+    "message": "Invalid params: maximum timeout exceeded",
+    "data": {
+      "maxTimeout": 2000
+    }
+  }
+}
+```
+
+### Example Response (Standard Error)
 
 ```json
 {
@@ -130,13 +177,19 @@ Upon receiving an `eth_sendRawTransactionSync` request, the handler function per
 
 Modifying `eth_sendRawTransaction` to support this behavior would risk compatibility issues and ambiguity. A separate method makes the semantics explicit and opt-in.
 
-### Blocking Behavior and Timeouts
+### Node-Configured Timeouts
 
-Clients SHOULD allow configuration of the timeout period, defaulting to 2 seconds (depending on the implementation). This balances responsiveness and propagation guarantees without creating excessive overhead in node clients.
+Node implementations SHOULD allow configuration of the timeout period, defaulting to 2 seconds (depending on the implementation). This balances responsiveness and propagation guarantees without creating excessive overhead in node clients.
+
+### User-Configured Timeouts
+
+The optional timeout parameter allows clients to specify their preferred maximum wait time for transaction processing.
+- Applications can adjust timeouts based on their specific latency requirements.
+- The optional timeout prevents the RPC call from blocking indefinitely.
 
 ### Optionality
 
-This method is optional and does not replace or change existing asynchronous transaction submission methods. Clients and servers that do not implement this method will continue to operate normally using the standard asynchronous RPC methods.
+This method is optional and does not replace or change existing asynchronous transaction submission methods. Nodes that do not implement this method will continue to operate normally using the standard asynchronous RPC methods.
 
 This RPC method is particularly suitable for EVM-compatible blockchains or L2 solutions with fast block times and low network latency, where synchronous receipt retrieval can significantly improve responsiveness. On high-latency or slower blockchains (e.g., Ethereum mainnet pre-sharding), the synchronous wait may cause longer RPC call durations or timeouts, making the method less practical.
 
@@ -146,23 +199,38 @@ The synchronous receipt retrieval reduces the complexity of client applications 
 
 ## Backwards Compatibility
 
-This EIP introduces a new RPC method and does not modify or deprecate any existing methods. Clients and servers that do not implement this method will continue operating normally. Existing applications using `eth_sendRawTransaction` are unaffected. Clients that do not support the method will simply return `method not found`.
+This EIP introduces a new RPC method and does not modify or deprecate any existing methods. Nodes that do not implement this method will continue operating normally. Existing applications using `eth_sendRawTransaction` are unaffected. Node implementations that do not support the method will simply return `method not found`.
 
 ## Reference Implementation
 
-A minimal reference implementation can be realized by wrapping existing `eth_sendRawTransaction` submission with a polling loop that queries `eth_getTransactionReceipt` at short intervals until a receipt is found or a timeout occurs. Polling intervals and timeout values can be tuned by client implementations to optimize performance.
+A minimal reference implementation can be realized by wrapping existing `eth_sendRawTransaction` submission with a polling loop that queries `eth_getTransactionReceipt` at short intervals until a receipt is found or a timeout occurs. Polling intervals and timeout values can be tuned by node implementations to optimize performance.
 
 For example, in `reth`, we can implement the handler for `eth_sendRawTransactionSync` as follows.
 
 ```rust
-async fn send_raw_transaction_sync(&self, tx: Bytes) -> RpcResult<OpTransactionReceipt> {
-    const TIMEOUT_DURATION: Duration = Duration::from_secs(2);
+async fn send_raw_transaction_sync(&self, tx: Bytes, timeout_duration: Option<Duration>) -> RpcResult<OpTransactionReceipt> {
+    const DEFAULT_TIMEOUT: Duration = Duration::from_secs(2);
     const POLL_INTERVAL: Duration = Duration::from_millis(1);
+    
+    // Validate the timeout parameter
+    let timeout_duration = timeout_duration.unwrap_or(DEFAULT_TIMEOUT);
+    if timeout_duration > DEFAULT_TIMEOUT {
+        return Err(ErrorObject::owned(
+            -32602,
+            format!(
+                "Invalid timeout: requested timeout {:?} exceeds maximum allowed {:?}",
+                timeout_duration, DEFAULT_TIMEOUT
+            ),
+            Some(json!({
+                        "maxTimeout": DEFAULT_TIMEOUT,
+            }))
+        ));
+    }
 
     let hash = self.inner.send_raw_transaction(tx).await?;
 
     let start = Instant::now();
-    while start.elapsed() < TIMEOUT_DURATION {
+    while start.elapsed() < timeout_duration {
         if let Some(receipt) = self.pending_block.get_receipt(hash) {
             return Ok(receipt);
         }
@@ -172,7 +240,7 @@ async fn send_raw_transaction_sync(&self, tx: Bytes) -> RpcResult<OpTransactionR
     Err(ErrorObject::owned(
         -32002,
         format!(
-            "The transaction was added to the mempool but wasn't processed in {TIMEOUT_DURATION:?}."
+            "The transaction was added to the mempool but wasn't processed in {timeout_duration:?}."
         ),
         Some(hash),
     ))
@@ -184,9 +252,9 @@ Other implementations such as `go-ethereum` can utilize a channel to signify rec
 ## Security Considerations
 
 - This method does not introduce new security risks beyond those inherent in transaction submission.
-- The timeout prevents indefinite blocking of RPC calls, protecting clients and servers from hanging requests.
-- Clients should handle timeout responses gracefully and continue monitoring transaction status as needed.
-- Servers must ensure that the implementation does not degrade node performance or cause denial-of-service.
+- The node-configured timeout prevents indefinite blocking of RPC calls, protecting nodes from hanging requests.
+- Node implementations should handle timeout responses gracefully and continue monitoring transaction status as needed.
+- Nodes must ensure that the implementation does not degrade performance or cause denial-of-service.
 
 ## Copyright
 

--- a/EIPS/eip-7966.md
+++ b/EIPS/eip-7966.md
@@ -184,6 +184,7 @@ Node implementations SHOULD allow configuration of the timeout period, defaultin
 ### User-Configured Timeouts
 
 The optional timeout parameter allows clients to specify their preferred maximum wait time for transaction processing.
+
 - Applications can adjust timeouts based on their specific latency requirements.
 - The optional timeout prevents the RPC call from blocking indefinitely.
 


### PR DESCRIPTION
- Add optional client-configured timeout parameter
- Define error codes for timeout and invalid parameter scenarios (following EIP-1474 and JSON error code standards)
- Change node-configured timeouts from MUST to SHOULD
- Improve specs

**ATTENTION: ERC-RELATED PULL REQUESTS NOW OCCUR IN [ETHEREUM/ERCS](https://github.com/ethereum/ercs)**

--

When opening a pull request to submit a new EIP, please use the suggested template: https://github.com/ethereum/EIPs/blob/master/eip-template.md

We have a GitHub bot that automatically merges some PRs. It will merge yours immediately if certain criteria are met:

 - The PR edits only existing draft PRs.
 - The build passes.
 - Your GitHub username or email address is listed in the 'author' header of all affected PRs, inside <triangular brackets>.
 - If matching on email address, the email address is the one publicly listed on your GitHub profile.
