### PR TITLE
Update EIP-7773: Move EIPs 7732, 7782, and 7805 from PFI to CFI

### DIFF
--- a/EIPS/eip-7773.md
+++ b/EIPS/eip-7773.md
@@ -22,6 +22,10 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Declined
 
 ### Considered for Inclusion
 
+* [EIP-7732](./eip-7732.md): Enshrined Proposer-Builder Separation
+* [EIP-7782](./eip-7782.md): Reduce Block Latency
+* [EIP-7805](./eip-7805.md): Fork-choice enforced Inclusion Lists (FOCIL)
+
 ### Proposed for Inclusion
 
 * [EIP-6873](./eip-6873.md): Preimage retention


### PR DESCRIPTION
## Summary
- Moved EIP-7732 (Enshrined Proposer-Builder Separation) from Proposed for Inclusion to Considered for Inclusion
- Moved EIP-7782 (Reduce Block Latency) from Proposed for Inclusion to Considered for Inclusion  
- Moved EIP-7805 (Fork-choice enforced Inclusion Lists (FOCIL)) from Proposed for Inclusion to Considered for Inclusion
- Corrected EIP titles to match their actual titles in the repository

## Changes
This PR updates the Glamsterdam hardfork meta EIP (EIP-7773) to reflect the updated status of these three EIPs.

🤖 Generated with [Claude Code](https://claude.ai/code)