### PR TITLE
Update EIP-6888: fix typos in EIP-6888

### DIFF
--- a/EIPS/eip-6888.md
+++ b/EIPS/eip-6888.md
@@ -47,7 +47,7 @@ From this point forward  `a`, `b` and `c` references the arguments in a math ope
 
 The function `sign(x)` is defined in the set of `uint256 -> {NEGATIVE, ZERO, POSITIVE}`
 
-### Contidions
+### Conditions
 
 The `carry` flag MUST be set in the following circumstances:
 
@@ -80,7 +80,7 @@ Clears both flags. `carry = overflow = false`
 #### `JUMPO`
 
 Consumes one argument from the stack, the possible pc dest,
-Conditionally alter the program counter depending on the `ovewflow` flag. `J_JUMPO = carry ? µ_s[0] : µ_pc + 1` 
+Conditionally alter the program counter depending on the `overflow` flag. `J_JUMPO = carry ? µ_s[0] : µ_pc + 1` 
 Clears both flags. `carry = overflow = false`
 
 ### gas


### PR DESCRIPTION


**Description:**  
This pull request corrects minor typos in EIP-6888:
- Fixes the section header from "Contidions" to "Conditions".
- Updates the JUMPO opcode logic to reference the correct `overflow` flag.

