### PR TITLE
Update EIP-7773: `Gloas/Amsterdam` → `Glamsterdam`

### DIFF
--- a/EIPS/eip-7773.md
+++ b/EIPS/eip-7773.md
@@ -1,7 +1,7 @@
 ---
 eip: 7773
 title: Hardfork Meta - Glamsterdam
-description: EIPs included in the Gloas/Amsterdam Ethereum network upgrade.
+description: EIPs included in the Glamsterdam Ethereum network upgrade.
 author: Tim Beiko (@timbeiko)
 discussions-to: https://ethereum-magicians.org/t/eip-7773-glamsterdam-network-upgrade-meta-thread/21195
 status: Draft


### PR DESCRIPTION


**Description:**  
This pull request corrects a typo in the EIP-7773 description, replacing "Gloas/Amsterdam" with the correct term "Glamsterdam" for clarity and consistency.
