### PR TITLE
Update EIP-2926: use 31-byte chunk size instead

### DIFF
--- a/EIPS/eip-2926.md
+++ b/EIPS/eip-2926.md
@@ -30,7 +30,7 @@ What follows is structured to have two sections:
 
 #### Constants
 
-- `CHUNK_SIZE`: 32 (bytes)
+- `CHUNK_SIZE`: 31 (bytes)
 - `VERSION_KEY`: `max(u256)`
 - `VERSION`: 0
 - `EMPTY_CODE_ROOT`: `0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470` (==`keccak256('')`)
@@ -95,7 +95,7 @@ The trie format is chosen to be the same as that of the account trie. If a tree 
 
 ### Chunk size
 
-The current recommended chunk size of 32 bytes has been selected based on a few observations. Smaller chunks are more efficient (i.e. have higher chunk utilization, but incur a larger hash overhead (i.e. number of hashes as part of the proof) due to a higher trie depth. Larger chunks are less efficient, but incur less hash overhead. We plan to run a larger experiment comparing various chunk sizes to arrive at a final recommendation.
+The current recommended chunk size of 31 bytes has been selected based on a few observations. Smaller chunks are more efficient (i.e. have higher chunk utilization, but incur a larger hash overhead (i.e. number of hashes as part of the proof) due to a higher trie depth. Larger chunks are less efficient, but incur less hash overhead. We plan to run a larger experiment comparing various chunk sizes to arrive at a final recommendation.
 
 ### First instruction offset
 


### PR DESCRIPTION
The EIP was meant to use 31-byte chunk size. That is, each chunk use 1 byte for push offset and 31 bytes of code, similar to the code chunking strategy in [EIP-6800](https://eips.ethereum.org/EIPS/eip-6800).