### PR TITLE
Update EIP-747: Fix TypeScript interface syntax errors in EIP-747

### DIFF
--- a/EIPS/eip-747.md
+++ b/EIPS/eip-747.md
@@ -58,10 +58,8 @@ The format of the options field is:
 
 ```typescript
 interface ERC1046WatchAssetOptions {
-{
     address: string; // The hexadecimal address of the token contract
     chainId?: number; // The chain ID of the asset. If empty, defaults to the current chain ID.
-  };
 }
 ```
 
@@ -83,10 +81,8 @@ The format of the options field is:
 
 ```typescript
 interface ERC20WatchAssetOptions {
-{
     address: string; // The hexadecimal address of the token contract
     chainId?: number; // The chain ID of the asset. If empty, defaults to the current chain ID.
-  };
 }
 ```
 


### PR DESCRIPTION
## Summary
Fixed syntax errors in TypeScript interface definitions within the EIP-747 specification document. 
## Changes Made
- ERC1046WatchAssetOptions interface: Removed extra opening brace { and semicolon ; after interface declaration
- ERC20WatchAssetOptions interface: Removed extra opening brace { and semicolon ; after interface declaration


