### PR TITLE
Update EIP-2035: EIP-2035 typo corrections

### DIFF
--- a/EIPS/eip-2035.md
+++ b/EIPS/eip-2035.md
@@ -10,10 +10,12 @@ created: 2019-05-16
 ---
 
 ## Simple Summary
+
 The gas cost of EVM opcodes `SLOAD` and `SSTORE` increases in order to accommodate extra bandwidth required to propagate block proof together with the block
 headers and block bodies, as explained [here](https://medium.com/@akhounov/data-from-the-ethereum-stateless-prototype-8c69479c8abc).
 
 ## Abstract
+
 It is part of the State Rent roadmap. This particular change prepares Ethereum for introduction of the block proofs (current understanding is that they
 can be introduced without a hard fork). The introduction of the block proofs allows any Ethereum node that wishes to receive them, to process transactions
 in the blocks without needing to access the Ethereum state. All necessary information for the execution (and the proof of validity) is continued in the
@@ -24,6 +26,7 @@ but block proofs will make it optional to have access to contract storage for ex
 affected.
 
 ## Motivation
+
 There is [empirical analysis](https://github.com/holiman/vmstats/blob/master/README.md) showing that `SLOAD` opcode is currently underpriced in terms
 of execution latency it adds to the block processing. The hypothesis is that it is due to the latency of the database accesses. In the same
 analysis, `SSTORE` is not considered, because its effect on the database accesses can be (and are in many implementations) delayed until the end of
@@ -33,12 +36,14 @@ at most 1 kB to the block proofs. At the current cost of data transmission (68 g
 operations by 69k gas. However, in light of proposal in [EIP-2028](./eip-2028.md), the increase can be made much smaller.
 
 ## Specification
+
 Not very formal at the moment, but will be formalised with more research and prototyping. Gas of operations `SLOAD` and `SSTORE` increases by `X` gas when the storage slots accessed (read by `SLOAD` or written by `SSTORE`) were not previously accessed (by another `SLOAD` or `SSTORE`) during the same transaction.
 
 Future variant (will be possible after the implementation of the *Gross contract size accounting*) is researched, where the increase is varied
 depending on the size of the contract storage, i.e. `SLOAD` and `SSTORE` for smaller contracts will be cheaper.
 
 ## Rationale
+
 [EIP-1884](./eip-1884.md) seeks to increase the gas cost of `SLOAD` but using a different justification
 (latency of the execution as described in the Motivation). This EIP is likely to increase the cost of `SLOAD` by a larger amount, therefore partially
 (because EIP-1884 also proposed other increases) supersedes EIP-1884.
@@ -51,6 +56,7 @@ vulnerability problem, and so far the solution seems to be in redesigning and re
 However, this approach is likely to be very expensive on the non-technical (ecosystem) level.
 
 ## Backwards Compatibility
+
 This change is not backwards compatible and requires hard fork to be activated.
 There might also be an adverse effect of this change on the already deployed contract. It is expected that after this EIP and
 [EIP-2026](./eip-2026.md) (rent prepayment for accounts), the recommendation will be made to raise the gas limit. This can somewhat dampen the
@@ -61,11 +67,14 @@ adverse effect of the rent proportional to the contract storage size. However, m
 analyse the potentially impacted contracts.
 
 ## Test Cases
+
 Tests cases will be generated out of a reference implementation.
 
 ## Implementation
+
 There will be proof of concept implementation to refine and clarify the specification.
 
 ## Copyright
+
 Copyright and related rights waived via [CC0](../LICENSE.md).
 


### PR DESCRIPTION




### Changes Made:
- `introuced` → `introduced`
- `emprical` → `empirical` 
- `acccounting` → `accounting`

