### PR TITLE
Update EIP-1014: Complete address formula rationale explanation

### DIFF
--- a/EIPS/eip-1014.md
+++ b/EIPS/eip-1014.md
@@ -32,7 +32,7 @@ Allows interactions to (actually or counterfactually in channels) be made with a
 #### Address formula
 
 * Ensures that addresses created with this scheme cannot collide with addresses created using the traditional `keccak256(rlp([sender, nonce]))` formula, as `0xff` can only be a starting byte for RLP for data many petabytes long.
-* Ensures that the hash preimage has a fixed size,
+* Ensures that the hash preimage has a fixed size, which provides predictable gas costs and prevents potential DoS attacks through variable-length inputs.
 
 #### Gas cost
 


### PR DESCRIPTION
Add missing explanation for fixed-size hash preimage benefits in CREATE2
Address formula section. Clarifies that fixed size provides predictable
gas costs and DoS protection.