### PR TITLE
Update EIP-7773: propose eip 2926 for inclusion in Glamsterdam

### DIFF
--- a/EIPS/eip-7773.md
+++ b/EIPS/eip-7773.md
@@ -28,6 +28,7 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Declined
 
 ### Proposed for Inclusion
 
+* [EIP-2926](./eip-2926.md): Chunk-based code merkelization
 * [EIP-6873](./eip-6873.md): Preimage retention
 * [EIP-7667](./eip-7667.md): Raise gas costs of hash functions
 * [EIP-7793](./eip-7793.md): Conditional Transactions


### PR DESCRIPTION
As requested in https://ethereum-magicians.org/t/eip-7773-glamsterdam-network-upgrade-meta-thread/21195, I am creating a PR to propose 2926 in Glamsterdam.