### PR TITLE
Update EIP-7937: fix typo in test cases section

### DIFF
--- a/EIPS/eip-7937.md
+++ b/EIPS/eip-7937.md
@@ -136,7 +136,7 @@ This EIP introduces a new (prefix) opcode `C0`. `C0` was previously an invalid o
 
 ## Test Cases
 
-Test cases are orgnized as `[stack_item_1, stack_item_2] C0 opcode => [result_stack_item_1, result_stack_item_2]`.
+Test cases are organized as `[stack_item_1, stack_item_2] C0 opcode => [result_stack_item_1, result_stack_item_2]`.
 
 * `[ff00000000000000 000000000000000 0000000000000ff 000000000000001, ff0000000000000 000000000000000 0000000000000ff f0000000000000f] C0 SHR => [<0> 780000000000007]`
 


### PR DESCRIPTION


**Description:**  
Corrected a typo in the `Test Cases` section of EIP-7937:  
- Changed `orgnized` to `organized` for improved clarity and professionalism.
