### PR TITLE
Update EIP-1108: correct typo in EIP-1108 rationale section

### DIFF
--- a/EIPS/eip-1108.md
+++ b/EIPS/eip-1108.md
@@ -150,7 +150,7 @@ Fast elliptic curve cryptography is a keystone of a growing number of protocols 
     }
     ```
 
-These are all technologies that have been, or are in the process of being, deployed to main-net. There protocols would all benefit from reducing the gas cost of the precompiles.  
+These are all technologies that have been, or are in the process of being, deployed to main-net. These protocols would all benefit from reducing the gas cost of the precompiles.  
 
 To give a concrete example, it currently costs `820,000` gas to validate the cryptography in a typical AZTEC confidential transaction. If the gas schedule for the precompiles correctly reflected their load on the Ethereum network, this cost would be `197,000` gas. This significantly increases the potential use cases for private assets on Ethereum. AZTEC is planning to deploy several cryptographic protocols Ethereum, but these are at the limits of what is practical given the current precompile costs:  
 


### PR DESCRIPTION
Fix grammatical error in EIP-1108.md

- Change "There protocols" to "These protocols" for proper grammar
