### PR TITLE
Website: add JSON-LD for site nav and breadcrumbs

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -39,6 +39,123 @@
       "@context": "https://schema.org"
     }
   </script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "SiteNavigationElement",
+  "name": "Main Navigation",
+  "url": "{{site.url}}",
+  "hasPart": [
+    {
+      "@type": "SiteNavigationElement", 
+      "name": "All EIPs",
+      "url": "{{site.url}}/all"
+    },
+    {
+      "@type": "SiteNavigationElement",
+      "name": "Core", 
+      "url": "{{site.url}}/core"
+    },
+    {
+      "@type": "SiteNavigationElement",
+      "name": "Networking",
+      "url": "{{site.url}}/networking"
+    },
+    {
+      "@type": "SiteNavigationElement",
+      "name": "Interface",
+      "url": "{{site.url}}/interface"
+    },
+    {
+      "@type": "SiteNavigationElement",
+      "name": "ERC",
+      "url": "{{site.url}}/erc"
+    },
+    {
+      "@type": "SiteNavigationElement",
+      "name": "Meta",
+      "url": "{{site.url}}/meta"
+    },
+    {
+      "@type": "SiteNavigationElement",
+      "name": "Informational",
+      "url": "{{site.url}}/informational"
+    }
+  ]
+}
+</script>
+{% if page.layout == "eip" %}
+<script type="application/ld+json">
+{
+  "@context":"https://schema.org",
+  "@type":"BreadcrumbList",
+  "itemListElement":[
+    {
+      "@type":"ListItem",
+      "position":1,
+      "name":"Ethereum Improvement Proposals",
+      "item":"{{ site.url }}"
+    },
+    {
+      "@type":"ListItem",
+      "position":2,
+      "name":"{% if page.category == 'ERC' %}ERC EIPs{% elsif page.category == 'Core' %}Core EIPs{% elsif page.category == 'Networking' %}Networking EIPs{% elsif page.category == 'Interface' %}Interface EIPs{% elsif page.type == 'Informational' %}Informational EIPs{% elsif page.type == 'Meta' %}Meta EIPs{% else %}All EIPs{% endif %}",
+      "item":"{% if page.category == 'ERC' %}{{ site.url }}/erc{% elsif page.category == 'Core' %}{{ site.url }}/core{% elsif page.category == 'Networking' %}{{ site.url }}/networking{% elsif page.category == 'Interface' %}{{ site.url }}/interface{% elsif page.type == 'Informational' %}{{ site.url }}/informational{% elsif page.type == 'Meta' %}{{ site.url }}/meta{% else %}{{ site.url }}/all{% endif %}"
+    },
+    {
+      "@type":"ListItem",
+      "position":3,
+      "name":"{% if page.category == 'ERC' %}ERC{% else %}EIP{% endif %}-{{ page.eip }}",
+      "item":"{{ site.url }}/EIPS/eip-{{ page.eip }}"
+    }
+  ]
+}
+</script>
+{% elsif page.url == "/" %}
+<script type="application/ld+json">
+{
+  "@context":"https://schema.org",
+  "@type":"BreadcrumbList",
+  "itemListElement":[
+    {
+      "@type":"ListItem",
+      "position":1,
+      "name":"{{ site.title }}",
+      "item":"{{ site.url }}"
+    }
+  ]
+}
+</script>
+{% elsif page.title == "All" or page.title == "ERC" or page.title == "Core"
+       or page.title == "Networking" or page.title == "Interface"
+       or page.title == "Meta" or page.title == "Informational" %}
+<script type="application/ld+json">
+{
+  "@context":"https://schema.org",
+  "@type":"CollectionPage",
+  "name":"{% if page.title == 'All' %}All EIPs{% else %}{{ page.title }}{% if page.title != 'Informational' and page.title != 'Meta' %} EIPs{% endif %}{% endif %}",
+  "description":"{% case page.title %}{% when 'All' %}Complete list of all Ethereum Improvement Proposals{% when 'ERC' %}Application-level standards and conventions{% when 'Core' %}Improvements requiring a consensus fork{% when 'Networking' %}Improvements around devp2p and Light Ethereum Subprotocol{% when 'Interface' %}Client API/RPC specifications and standards{% when 'Meta' %}Process proposals{% when 'Informational' %}Design issues and general guidelines{% endcase %}",
+  "url":"{{ site.url }}{{ page.url | remove: '.html' }}",
+  "breadcrumb":{
+    "@type":"BreadcrumbList",
+    "itemListElement":[
+      {
+        "@type":"ListItem",
+        "position":1,
+        "name":"Ethereum Improvement Proposals",
+        "item":"{{ site.url }}"
+      },
+      {
+        "@type":"ListItem",
+        "position":2,
+        "name":"{% if page.title == 'All' %}All EIPs{% else %}{{ page.title }}{% if page.title != 'Informational' and page.title != 'Meta' %} EIPs{% endif %}{% endif %}",
+        "item":"{{ site.url }}{{ page.url | remove: '.html' }}"
+      }
+    ]
+  }
+}
+</script>
+{% endif %}
   <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}" />
   {%- feed_meta -%}
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-4bw+/aepP/YC94hEpVNVgiZdgIC5+VKNBQNGCHeKRQN+PtmoHDEXuppvnDJzQIu9" crossorigin="anonymous">


### PR DESCRIPTION
## Summary
Implements machine-readable structured data (JSON-LD) to address accessibility barriers and improve SEO as outlined in [#10098](https://github.com/ethereum/EIPs/issues/10098).

## Changes
Added to `_includes/head.html`:
- `SiteNavigationElement`: Describes the main navigation structure on all pages
- Dynamic `BreadcrumbList`: Adapts based on page type using Jekyll conditionals
  - Homepage: Single-item breadcrumb
  - Category pages: Two-level breadcrumb + CollectionPage schema
  - EIP pages: Three-level breadcrumb with proper EIP category routing
- No new dependencies - uses existing Jekyll variables (`page.layout`, `page.category`, `page.type`)

## Testing
✅ Browser dev tools show proper JSON-LD injection in local build
✅ Live demo: https://eips.ritovision.com  
✅ Validated with [Schema.org](https://validator.schema.org/)
✅ All page types render correct breadcrumb depth and schema type

## Impact
- Meets accessibility best practices and addresses [WCAG 2.4.8 (Location)](https://www.w3.org/WAI/WCAG21/Understanding/location.html) guideline
- Enables assistive technologies to better understand site hierarchy
- Improves search engine understanding of content relationships

Fixes #10098