### PR TITLE
Update EIP-1014: Fix incomplete sentence in EIP-1014 Address formula section

### DIFF
--- a/EIPS/eip-1014.md
+++ b/EIPS/eip-1014.md
@@ -32,7 +32,7 @@ Allows interactions to (actually or counterfactually in channels) be made with a
 #### Address formula
 
 * Ensures that addresses created with this scheme cannot collide with addresses created using the traditional `keccak256(rlp([sender, nonce]))` formula, as `0xff` can only be a starting byte for RLP for data many petabytes long.
-* Ensures that the hash preimage has a fixed size,
+* Ensures that the hash preimage has a fixed size, which simplifies implementation and prevents variable-length input attacks.
 
 #### Gas cost
 


### PR DESCRIPTION
Complete the unfinished sentence in the "Address formula" section by adding 
the missing explanation about fixed size preimage benefits.

The sentence now properly explains that a fixed size preimage simplifies 
implementation and prevents variable-length input attacks, providing 
better context for the design rationale.