### PR TITLE
Update EIP-7823: correct RSA key size from 4196 to 4096 bits

### DIFF
--- a/EIPS/eip-7823.md
+++ b/EIPS/eip-7823.md
@@ -40,7 +40,7 @@ If any of these inputs are larger than the limit, the precompile execution stops
 
 This upper bound allows the existing use cases of MODEXP:
 
-1. RSA verification with up to 8192 bit keys. Commonly used ones are 1024/2048/4196 bits.
+1. RSA verification with up to 8192 bit keys. Commonly used ones are 1024/2048/4096 bits.
 2. Elliptic curve related use cases are usually less than 384 bits.
 
 ### EVMMAX


### PR DESCRIPTION
Fix typo in the Rationale section where RSA key sizes were incorrectly listed as 1024/2048/4196 bits. The correct standard RSA key sizes are 1024/2048/4096 bits.

This change ensures accuracy in the EIP documentation and aligns with standard RSA key size specifications.