### PR TITLE
Update EIP-2926: clarify transition process description

### DIFF
--- a/EIPS/eip-2926.md
+++ b/EIPS/eip-2926.md
@@ -69,7 +69,7 @@ As of now there is a charge of 200 gas per byte of the code stored in state by c
 
 ### Updating existing code (transition process)
 
-The transition process involves reading all contracts in the state and applying the above procedure to them. A process simliar to [EIP-7612](./eip-7612.md) is to be used, as the total code size at the time of this EIP edit is >10GB and can not be processed in a single block.
+The transition process involves reading all contracts in the state and applying the above procedure to them. A process similar to [EIP-7612](./eip-7612.md) is to be used, as the total code size at the time of this EIP edit is >10GB and can not be processed in a single block.
 
 Note that:
 


### PR DESCRIPTION


**Description:**  
Corrected `simliar` → `similar`
