### PR TITLE
Update EIP-7773: Move EIP-7732 and EIP-7928 to SFI

### DIFF
--- a/EIPS/eip-7773.md
+++ b/EIPS/eip-7773.md
@@ -20,12 +20,13 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Declined
 
 ### EIPs Scheduled for Inclusion
 
+* [EIP-7732](./eip-7732.md): Enshrined Proposer-Builder Separation
+* [EIP-7928](./eip-7928.md): Block-Level Access Lists
+
 ### Considered for Inclusion
 
-* [EIP-7732](./eip-7732.md): Enshrined Proposer-Builder Separation
 * [EIP-7782](./eip-7782.md): Reduce Block Latency
 * [EIP-7805](./eip-7805.md): Fork-choice enforced Inclusion Lists (FOCIL)
-* [EIP-7928](./eip-7928.md): Block-Level Access Lists
 
 ### Proposed for Inclusion
 


### PR DESCRIPTION
## Summary
- Move EIP-7732 (Enshrined Proposer-Builder Separation) from "Considered for Inclusion" to "Scheduled for Inclusion"
- Move EIP-7928 (Block-Level Access Lists) from "Considered for Inclusion" to "Scheduled for Inclusion"

These changes reflect the updated status of these EIPs for the Glamsterdam network upgrade.

🤖 Generated with [Claude Code](https://claude.ai/code)