### PR TITLE
Update EIP-7928: Clarify 7702 delegation indicators

### DIFF
--- a/EIPS/eip-7928.md
+++ b/EIPS/eip-7928.md
@@ -156,7 +156,7 @@ Balance changes record post-transaction balances (`uint128`) for:
 
 Zero-value transfers: NOT recorded in `balance_changes` but addresses MUST be included with empty `AccountChanges`.
 
-Code changes track post-transaction runtime bytecode for deployed/modified contracts.
+Code changes track post-transaction runtime bytecode for deployed/modified contracts and delegation indicators from [EIP-7702](./eip-7702.md).
 
 Nonce changes record post-transaction nonces for EOA senders, contracts that performed a successful `CREATE` or `CREATE2` operation, deployed contracts and [EIP-7702](./eip-7792.md) authorities.
 


### PR DESCRIPTION
Clarify that we add the delegation indicator as a code diff (has already been handled correctly in the exec specs).