### PR TITLE
Update EIP-7928: Fix mistake in tx_index of system contracts

### DIFF
--- a/EIPS/eip-7928.md
+++ b/EIPS/eip-7928.md
@@ -175,7 +175,7 @@ Nonce changes record post-transaction nonces for EOA senders, contracts that per
 - **System contracts**: All state changes from system contracts use tx_index = len(transactions)
 - **EIP-7002 withdrawals**: System contract storage diffs of the storage slots 0-3 (4 slots) after dequeuing call
 - **EIP-7251 consolidations**: System contract storage diffs of the storage slots 0-3 (4 slots) after dequeuing call
-- **EIP-2935 block hash**: ` BLOCKHASH_STORAGE_ADDRESS` storage containing new parent_hash
+- **EIP-2935 block hash**: `BLOCKHASH_STORAGE_ADDRESS` storage containing new parent_hash
 - **EIP-4788 beacon root**: `BEACON_ROOTS_ADDRESS` storage containing new parent_beacon_root
 
 ### Concrete Example

--- a/EIPS/eip-7928.md
+++ b/EIPS/eip-7928.md
@@ -156,7 +156,7 @@ Balance changes record post-transaction balances (`uint128`) for:
 
 Zero-value transfers: NOT recorded in `balance_changes` but addresses MUST be included with empty `AccountChanges`.
 
-Code changes track post-transaction runtime bytecode for deployed/modified contracts.
+Code changes track post-transaction runtime bytecode for deployed/modified contracts and delegation indicators from [EIP-7702](./eip-7702.md).
 
 Nonce changes record post-transaction nonces for EOA senders, contracts that performed a successful `CREATE` or `CREATE2` operation, deployed contracts and [EIP-7702](./eip-7792.md) authorities.
 

--- a/EIPS/eip-7928.md
+++ b/EIPS/eip-7928.md
@@ -172,7 +172,7 @@ Nonce changes record post-transaction nonces for EOA senders, contracts that per
 - **STATICCALL/Read-only opcodes**: Include targets with empty changes
 - **Exceptional halts**: Final nonce and balance of sender and balance of fee recipient recorded after each transactions
 - **Consensus layer withdrawals**: Recipients recorded with final balance after withdrawal
-- **System contracts**: All state changes from system contracts use tx_index = len(transactions) + 1
+- **System contracts**: All state changes from system contracts use tx_index = len(transactions)
 - **EIP-7002 withdrawals**: System contract storage diffs of the storage slots 0-3 (4 slots) after dequeuing call
 - **EIP-7251 consolidations**: System contract storage diffs of the storage slots 0-3 (4 slots) after dequeuing call
 - **EIP-2935 block hash**: ` BLOCKHASH_STORAGE_ADDRESS` storage containing new parent_hash
@@ -186,7 +186,7 @@ Example block:
 2. Charlie (0xcccc...) calls factory (0xffff...) deploying contract at 0xdddd...
 3. System contracts: parent hash storage, beacon root storage, withdrawal to Eve (0xeeee...)
 
-Note: System contract state changes use tx_index = 3 (len(transactions) + 1)
+Note: System contract state changes use tx_index = 2 (len(transactions))
 
 Resulting BAL:
 
@@ -273,7 +273,7 @@ BlockAccessList(
                 SlotChanges(
                     slot=b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x0f\xa0',  # slot = (block.number - 1) % 8191
                     changes=[
-                        StorageChange(tx_index=3, new_value=b'...')  # Parent block hash
+                        StorageChange(tx_index=2, new_value=b'...')  # Parent block hash
                     ]
                 )
             ],
@@ -288,7 +288,7 @@ BlockAccessList(
                 SlotChanges(
                     slot=b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x30\x39',
                     changes=[
-                        StorageChange(tx_index=3, new_value=b'...')  # System tx_index
+                        StorageChange(tx_index=2, new_value=b'...')  # System tx_index
                     ]
                 )
             ],
@@ -301,7 +301,7 @@ BlockAccessList(
             address=0xabcd...,  # Eve (withdrawal recipient)
             storage_changes=[],
             storage_reads=[],
-            balance_changes=[BalanceChange(tx_index=3, post_balance=0x0000000000000005f5e100)],  # 100 ETH withdrawal
+            balance_changes=[BalanceChange(tx_index=2, post_balance=0x0000000000000005f5e100)],  # 100 ETH withdrawal
             nonce_changes=[],
             code_changes=[]
         )
@@ -321,7 +321,7 @@ def validate_bal(block):
     collected_accesses = {}
     
     # Process pre-execution system contracts (parent hashes, beacon roots)
-    system_tx_index = len(block.transactions) + 1
+    system_tx_index = len(block.transactions)
     process_system_contracts_pre(block, collected_accesses, system_tx_index)
     
     # Execute transactions and track all state accesses
@@ -476,7 +476,7 @@ This design variant was chosen for several key reasons:
 
 2. **Storage values for writes**: Post-execution values enable state reconstruction during sync without individual proofs against state root.
 
-3. **Overhead analysis**: Historical data shows ~40 KiB average BAL size with ~4.5 KiB for balance diffs - reasonable for performance gains.
+3. **Overhead analysis**: Historical data shows ~40 KiB average BAL size.
 
 4. **Transaction independence**: 60-80% of transactions access disjoint storage slots, enabling effective parallelization.
 


### PR DESCRIPTION
System contract must be mapped to tx_index `len(transactions)` instead of `len(transactions) +1`