### PR TITLE
Update EIP-7867: Fix typos and JSON syntax

### DIFF
--- a/EIPS/eip-7867.md
+++ b/EIPS/eip-7867.md
@@ -224,7 +224,7 @@ These requirements defined in EIP-5792 are removed:
 > * MUST NOT await for any calls to be finalized to complete the batch
 > * MUST submit multiple calls as an atomic unit in a single transaction
 > * MAY revert all calls if any call fails
-> * MUST not execute any further calls after a failed call
+> * MUST NOT execute any further calls after a failed call
 > * MAY reject the request if one or more calls in the batch is expected to
 >   fail, when simulated sequentially
 
@@ -485,7 +485,7 @@ transaction atomicity. In this example, the wallet only offers the
 {
     "0x1": {
         "flowControl": {
-            "none": [ "continue" ]
+            "none": [ "continue" ],
             "loose": [ "rollback", "halt", "continue" ]
         }
     }


### PR DESCRIPTION
- Correct "MUST not" to "MUST NOT" for RFC 2119 compliance
- Fix missing comma in JSON example for valid syntax