### PR TITLE
Update EIP-7636: error "siqnature" → "signature"

### DIFF
--- a/EIPS/eip-7636.md
+++ b/EIPS/eip-7636.md
@@ -66,7 +66,7 @@ and an ENR of
 enr:-MO4QBn4OF-y-dqULg4WOIlc8gQAt-arldNFe0_YQ4HNX28jDtg41xjDyKfCXGfZaPN97I-MCfogeK91TyqmWTpb0_AChmNsaWVudNqKTmV0aGVybWluZIYxLjkuNTOHN2ZjYjU2N4JpZIJ2NIJpcIR_AAABg2lwNpAAAAAAAAAAAAAAAAAAAAABiXNlY3AyNTZrMaECn-TTdCwfZP4XgJyq8Lxoj-SgEoIFgDLVBEUqQk4HnAqDdWRwgiMshHVkcDaCIyw
 ```
 
-which can be decoded to yield normal data such as `seq`, `siqnature`, `id` and `secp256k1`. Additionally, it would yield the client value of `["0x4e65746865726d696e64","0x312e392e3533","0x37666362353637"]` or `["Nethermind", "1.9.53", "7fcb567"]`
+which can be decoded to yield normal data such as `seq`, `signature`, `id` and `secp256k1`. Additionally, it would yield the client value of `["0x4e65746865726d696e64","0x312e392e3533","0x37666362353637"]` or `["Nethermind", "1.9.53", "7fcb567"]`
 
 ## Security Considerations
 


### PR DESCRIPTION
Corrected spelling error in line 69 where `siqnature` should be `signature` in the Test Cases section when describing ENR decoding output.
