### PR TITLE
Update EIP-7657: correct field names in sync committee slashing validation

### DIFF
--- a/EIPS/eip-7657.md
+++ b/EIPS/eip-7657.md
@@ -245,7 +245,7 @@ def process_sync_committee_slashing(state: BeaconState, sync_committee_slashing:
         rooted_in_canonical = (
             recent_finalized_slot < state.slot <= recent_finalized_slot + SLOTS_PER_HISTORICAL_ROOT
             and recent_finalized_slot <= compute_start_slot_at_epoch(state.finalized_checkpoint.epoch)
-            and recent_finalized_block_root == state.state_roots[recent_finalized_slot % SLOTS_PER_HISTORICAL_ROOT]
+            and recent_finalized_block_root == state.block_roots[recent_finalized_slot % SLOTS_PER_HISTORICAL_ROOT]
         )
         assert rooted_in_evidence_1 or rooted_in_evidence_2 or rooted_in_canonical
         is_slashable = True
@@ -284,13 +284,13 @@ def process_sync_committee_slashing(state: BeaconState, sync_committee_slashing:
         evidence_1,
         recent_finalized_block_root,
         recent_finalized_slot,
-        state.genesis_validator_root,
+        state.genesis_validators_root,
     )
     assert is_valid_sync_committee_slashing_evidence(
         evidence_2,
         recent_finalized_block_root,
         recent_finalized_slot,
-        state.genesis_validator_root,
+        state.genesis_validators_root,
     )
 
     # Perform slashing


### PR DESCRIPTION
1. Fix genesis_validator_root -> genesis_validators_root (lines 287, 293)
   - Corrected field name to match Ethereum consensus spec BeaconState structure
   - The field stores root of all genesis validators (plural form is correct)

2. Fix state.state_roots -> state.block_roots (line 248) 
   - Changed from state roots array to block roots array for block validation
   - Logic requires block root lookup for recent_finalized_block_root verification
   - state.block_roots contains block roots, state.state_roots contains state roots
