### PR TITLE
Update EIP-7732: update to latest CL-spec version

### DIFF
--- a/EIPS/eip-7732.md
+++ b/EIPS/eip-7732.md
@@ -12,7 +12,7 @@ created: 2024-06-28
 
 ## Abstract
 
-This EIP fundamentally changes the way an Ethereum block is validated by decoupling the execution validation from the consensus validation both logically as well as temporally. It does so by introducing a new optional attribution (being a *builder*) and a new duty (submitting *payload timeliness attestations*) to Ethereum validators. The `ExecutionPayload` field of the `BeaconBlockBody` is removed and instead it is replaced by a signed commitment (a `SignedExecutionPayloadHeader` object) from a builder to later reveal the corresponding execution payload. This commitment specifies in particular the blockhash of the execution block and a *value* to be paid to the beacon block proposer. When processing the `BeaconBlock`, the committed value is deducted from the builder's beacon chain balance and credited to the beacon block proposer. A subset of validators in the beacon committee is assigned to the *Payload Timeliness Committee* (PTC), these validators are tasked to attest (by broadcasting a `PayloadAttestationMessage`) to whether the corresponding builder has revealed the committed execution payload (with the right blockhash) in a timely fashion. PTC members are not required to validate the execution payload, execution validation is thus deferred until the next beacon block validation. 
+This EIP fundamentally changes the way an Ethereum block is validated by decoupling the execution validation from the consensus validation both logically as well as temporally. It does so by introducing a new optional attribution (being a *builder*) and a new duty (submitting *payload timeliness attestations*) to Ethereum validators. The `ExecutionPayload` field of the `BeaconBlockBody` is removed and instead it is replaced by a signed commitment (a `SignedExecutionPayloadHeader` object) from a builder to later reveal the corresponding execution payload. This commitment specifies in particular the blockhash of the execution block and a *value* to be paid to the beacon block proposer. When processing the `BeaconBlock`, the committed value is deducted from the builder's beacon chain balance and later a withdrawal is placed to an address, of the proposer's choosing, in the execution layer. A subset of validators in the beacon committee is assigned to the *Payload Timeliness Committee* (PTC), these validators are tasked to attest (by broadcasting a `PayloadAttestationMessage`) to whether the corresponding builder has revealed the committed execution payload (with the right blockhash) in a timely fashion and whether the correspoding blob data was available according to their view. PTC members are not required to validate the execution payload, execution validation is thus deferred until the next beacon block validation. 
 
 ## Motivation
 
@@ -35,12 +35,12 @@ No changes are required.
 
 The full consensus changes can be found in the consensus-specs Github repository. They are split between: 
 
-- [Beacon Chain](https://github.com/ethereum/consensus-specs/blob/8f8ab03acf1656c54f3a81ef18878f853a1cc4c6/specs/_features/eip7732/beacon-chain.md) changes.
-- [Fork choice](https://github.com/ethereum/consensus-specs/blob/8f8ab03acf1656c54f3a81ef18878f853a1cc4c6/specs/_features/eip7732/fork-choice.md) changes.
-- [P2P](https://github.com/ethereum/consensus-specs/blob/8f8ab03acf1656c54f3a81ef18878f853a1cc4c6/specs/_features/eip7732/p2p-interface.md) changes.
-- [Honest validator guide](https://github.com/ethereum/consensus-specs/blob/8f8ab03acf1656c54f3a81ef18878f853a1cc4c6/specs/_features/eip7732/validator.md) changes.
-- A new [honest builder](https://github.com/ethereum/consensus-specs/blob/8f8ab03acf1656c54f3a81ef18878f853a1cc4c6/specs/_features/eip7732/builder.md) guide. 
-- [Fork logic](https://github.com/ethereum/consensus-specs/blob/8f8ab03acf1656c54f3a81ef18878f853a1cc4c6/specs/_features/eip7732/fork.md) changes. 
+- [Beacon Chain](https://github.com/ethereum/consensus-specs/blob/9e2dc0bcf9aa17b549e1df4712b16a5709d74119/specs/_features/eip7732/beacon-chain.md) changes.
+- [Fork choice](https://github.com/ethereum/consensus-specs/blob/9e2dc0bcf9aa17b549e1df4712b16a5709d74119/specs/_features/eip7732/fork-choice.md) changes.
+- [P2P](https://github.com/ethereum/consensus-specs/blob/9e2dc0bcf9aa17b549e1df4712b16a5709d74119/specs/_features/eip7732/p2p-interface.md) changes.
+- [Honest validator guide](https://github.com/ethereum/consensus-specs/blob/9e2dc0bcf9aa17b549e1df4712b16a5709d74119/specs/_features/eip7732/validator.md) changes.
+- A new [honest builder](https://github.com/ethereum/consensus-specs/blob/9e2dc0bcf9aa17b549e1df4712b16a5709d74119/specs/_features/eip7732/builder.md) guide. 
+- [Fork logic](https://github.com/ethereum/consensus-specs/blob/9e2dc0bcf9aa17b549e1df4712b16a5709d74119/specs/_features/eip7732/fork.md) changes. 
 
 A summary of the main changes is included below, the [Rationale](#rationale) section contains explanation for most of the design decisions around these changes. 
 
@@ -50,27 +50,41 @@ A summary of the main changes is included below, the [Rationale](#rationale) sec
 
 | Name | Value | 
 | - | - | 
-| `PAYLOAD_ABSENT` | `uint8(0)` |
-| `PAYLOAD_PRESENT` | `uint8(1)` | 
-| `PAYLOAD_WITHHELD` | `uint8(2)` | 
-| `PAYLOAD_INVALID_STATUS` | `uint8(3)` |
+| `DOMAIN_BEACON_BUILDER`     | `DomainType('0x1B000000')` |
+| `DOMAIN_PTC_ATTESTER`       | `DomainType('0x0C000000')` |
+
 
 ##### Presets
 
 | Name | Value | 
 | - | - | 
 | `PTC_SIZE` | `uint64(2**9)` (=512) |
-| `DOMAIN_BEACON_BUILDER`     | `DomainType('0x1B000000')` |
-| `DOMAIN_PTC_ATTESTER`       | `DomainType('0x0C000000')` |
 | `MAX_PAYLOAD_ATTESTATIONS` | `2**2` (= 4) |
- 
+| `BUILDER_PEDING_WITHDRAWALS_LIMIT` | `uint64(2**20)` (=1,048,576) | 
+| `BUILDER_WITHDRAWAL_PREFIX` | `Bytes1('0X03')` | 
+
 ##### Containers
+
+```python
+class BuilderPendingPayment(Container):
+    weight: Gwei
+    withdrawal: BuilderPendingWithdrawal
+```
+
+```python
+class BuilderPendingWithdrawal(Container):
+    fee_recipient: ExecutionAddress
+    amount: Gwei
+    builder_index: ValidatorIndex
+    withdrawable_epoch: Epoch
+```
 
 ```python
 class PayloadAttestationData(Container):
     beacon_block_root: Root
     slot: Slot
-    payload_status: uint8
+    payload_present: boolean
+    blob_data_available: boolean
 ```
 
 ```python
@@ -103,8 +117,10 @@ class SignedExecutionPayloadHeader(Container):
 ```python
 class ExecutionPayloadEnvelope(Container):
     payload: ExecutionPayload
+    execution_requests: ExecutionRequests
     builder_index: ValidatorIndex
     beacon_block_root: Root
+    slot: Slot
     blob_kzg_commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK]
     payload_withheld: boolean
     state_root: Root
@@ -118,8 +134,10 @@ class SignedExecutionPayloadEnvelope(Container):
 
 The `BeaconState` container is modified with the addition of:
 
+- `execution_payload_availability`, of type `Bitvector[SLOTS_PER_HISTORICAL_ROOT]` to track the presence of execution payloads on the canonical chain. 
+- `builder_pending_payments`, of type `Vector[BuilderPendingPayment, 2 * SLOTS_PER_EPOCH]` to track pending payments from builders to proposers before the execution payload has been processed. 
+- `builder_pending_withdrawals`, of type `List[BuilderPendingWithdrawal, BUILDER_PENDING_WITHDRAWALS_LIMIT]` to track pending withdrawals to the execution layer with the builders' payments. 
 - `latest_block_hash`, of type `Hash32`, to track the blockhash of the last execution payload in the blockchain. 
-- `latest_full_slot`, of type `Slot`, to track the latest slot in which an execution payload was included. 
 - `latest_withdrawals_root` of type `Root` to track the hash tree root of the latest withdrawals deducted in the beacon chain when processing a `SignedBeaconBlock`. 
 
 The `BeaconBlockBody` is modified with the addition of:
@@ -132,14 +150,16 @@ The `ExecutionPayloadHeader` object is changed to only track the minimum informa
 State transition logic is modified by: 
 
 - A new beacon state getter `get_ptc` returns the PTC members for a given slot. 
-- `get_attesting_indices` is modified to not return the beacon committee members that are included in the PTC.
 - `process_withdrawals` is modified as follows. Withdrawals are obtained directly from the beacon state instead of the execution payload. They are deducted from the beacon chain. The beacon state `latest_withdrawals_root` is updated with the HTR of this list. The next execution payload MUST include withdrawals matching the `state.latest_withdrawals_root`. 
-- `process_execution_payload` is removed from `process_block`. Instead a new function `process_execution_payload_header` is included, this function validates the `SignedExecutionPayloadHeader` included in the `BeaconBlockBody` and transfers the payment from the builder's balance to the proposer. 
+- `process_execution_payload` is removed from `process_block`. Instead a new function `process_execution_payload_header` is included, this function validates the `SignedExecutionPayloadHeader` included in the `BeaconBlockBody`, deducts the payment from the builder's balance and adds a `BuilderPendingPayment` object to the beacon state.
 - `process_deposit_request` is removed from `process_operations` and deferred until `process_execution_payload`. 
 - `process_withdrawal_request` is removed from `process_operations` and deferred until `process_execution_payload`. 
 - `process_consolidation_request` is removed from `process_operations` and deferred until `process_execution_payload`. 
 - A new `process_payload_attestation` is added to `process_operations`, this function validates the payload timeliness attestations broadcast by the PTC members. 
-- `process_execution_payload` is now called as a separate helper when receiving a `SignedExecutionPayloadEnvelope` on the P2P layer. This function in particular checks that the HTR of the resulting beacon state coincides with the committed one in the payload envelope. 
+- `process_execution_payload` is now called as a separate helper when receiving a `SignedExecutionPayloadEnvelope` on the P2P layer. This function in particular checks that the HTR of the resulting beacon state coincides with the committed one in the payload envelope. On sucessful processing of the execution payload, the corresponding `BuilderPendingPayment` is removed from the beacon state and a `BuilderPendingWithdrawal` is queued. 
+
+Epoch processing is modified by addition of a new helper function `process_builder_pending_payments`, that processes the builder pending payments from those payloads that were not included in the canonical chain. 
+Although there is no change in the `AttestationData` object, the `index` field which is unused since the Electra fork, is now repurposed to signal payload availability. The value of `0` is used when attesting to the current beacon block or a past beacon block without a payload present, and the value of `1` is used to attest to a past beacon block with a payload present. 
 
 #### Fork choice changes
 
@@ -148,37 +168,34 @@ State transition logic is modified by:
 | Name                 | Value       |
 | -------------------- | ----------- |
 | `PAYLOAD_TIMELY_THRESHOLD` | `PTC_SIZE/2` (=`uint64(256)`) | 
-| `INTERVALS_PER_SLOT` | `4` |
-| `PROPOSER_SCORE_BOOST` | `20` | 
-| `PAYLOAD_WITHHOLD_BOOST` | `40` | 
-| `PAYLOAD_REVEAL_BOOST` | `40` | 
+| `PAYLOAD_STATUS_PENDING`   | `PayloadStatus(0)`      |
+| `PAYLOAD_STATUS_EMPTY`     | `PayloadStatus(1)`      |
+| `PAYLOAD_STATUS_FULL`      | `PayloadStatus(2)`      |
+
 
 ##### Containers
 
 ```python
-class ChildNode(Container):
+class ForkChoiceNode(Container):
     root: Root
-    slot: Slot
-    is_payload_present: bool
+    payload_status: PayloadStatus  # One of PAYLOAD_STATUS_* values
 ```
 
-The class `LatestMessage` is modified to track the slot instead of an epoch:
+The class `LatestMessage` is modified to track the slot instead of an epoch and the addition of a boolean `payload_present` to signal the payload content of the attestation. 
 
 ```python
 @dataclass(eq=True, frozen=True)
 class LatestMessage(object):
     slot: Slot
     root: Root
+    payload_present: boolean
 ```
 
 The class `Store` is modified to track the following fields:
 
 ```python
     execution_payload_states: Dict[Root, BeaconState] = field(default_factory=dict)
-    ptc_vote: Dict[Root, Vector[uint8, PTC_SIZE]] = field(default_factory=dict)
-    payload_withhold_boost_root: Root
-    payload_withhold_boost_full: bool
-    payload_reveal_boost_root: Root
+    ptc_vote: Dict[Root, Vector[boolean, PTC_SIZE]] = field(default_factory=dict)
 ```
 
 - A new handler `on_payload_attestation_message` is called when receiving a `PayloadAttestationMessage` from the P2P network. 
@@ -197,14 +214,14 @@ No changes needed.
 
 ### Staked builders
 
-Being a builder is a new attribution of validators. As such builders are staked in the beacon chain. This allows for in-protocol trustless enforcement of the builder's payment to the proposer. Alternatively, payment could be enforced in the Execution Layer (EL) at the cost of adding the corresponding EL consensus-changing logic. Payments in the EL have the advantage of not requiring the builder to periodically submit deposit transactions to replenish their validator balance. Both systems require availability of funds before the payload is revealed: in the Consensus Layer (CL) this is done by getting builders to stake. In the EL this is done with a balance check and a payment transaction. This transaction can be checked without executing the payload only if it the first transaction of the block. 
+Being a builder is a new attribution of validators. As such builders are staked in the beacon chain and they have their own withdrawal credential prefix. This allows for in-protocol trustless enforcement of the builder's payment to the proposer. Alternatively, payment could be enforced in the Execution Layer (EL) at the cost of adding the corresponding EL consensus-changing logic. Payments in the EL have the advantage of not requiring the builder to periodically submit deposit transactions to replenish their validator balance. Both systems require availability of funds before the payload is revealed: in the Consensus Layer (CL) this is done by getting builders to stake. In the EL this is done with a balance check and a payment transaction. This transaction can be checked without executing the payload only if it the first transaction of the block. 
 
 ### Delayed validation
 
 The Payload Timeliness Committee members do not need to validate the execution payload before attesting to it. They perform basic checks such as verifying the builder's signature, and the correct blockhash is included. This takes away the full execution payload validation from the hot path of validation of an Ethereum block, giving the next proposer 6 seconds (`SECONDS_PER_SLOT * 2 // INTERVALS_PER_SLOT`) to validate the payload and every other validator 9 seconds (`SECONDS_PER_SLOT * 3 // INTERVALS_PER_SLOT`). From a user UX perspective, a transaction included in slot `N` by the builder is not widely validated until the proposer of slot `N+1` releases their beacon block on top of block `N` first and the attesters of slot `N+1` vote on this beacon block as the head of the chain.
 
 
-### (Block, Slot, Payload) - Fork choice
+### Fork choice
 
 The following features of fork choice are guaranteed under specified margins of security: 
 
@@ -220,19 +237,11 @@ Proposer unconditional payment refers to the following. An Ethereum slot can be 
 
 Proposer unconditional payment refers to the fact that in the third scenario the beacon block proposer received payment from the corresponding builder.
 
-Builder reveal safety refers to the fact that if the builder acted honestly and revealed a payload in a timely fashion (as attested by the PTC) then the revealed payload will be included on-chain. This is enforced by the addition of a new `BUILDER_REVEAL_BOOST` to the LMD weight of the fork choice node that contains the payload. 
+Builder reveal safety refers to the fact that if the builder acted honestly and revealed a payload in a timely fashion (as attested by the PTC) then the revealed payload will be included on-chain.
 
-Builder withhold safety refers to the fact that if some beacon block containing a builder's commitment is withheld and revealed late, then that beacon block root **will not** be the canonical head of the blockchain in the view of honest validators. 
+Builder withhold safety refers to the fact that if some beacon block containing a builder's commitment is withheld and revealed late, the builder will not be charged the value of the bid. In particular, the payload does not even need to be revealed in this case. 
 
-In order to enforce this, any attestation on a given slot `N` for a block from a previous slot, not only does not support the block of slot `N`, but actually counts against it. This is the content of `(Block, Slot)` voting. Similarly, if a consensus for slot `N+1` has the consensus block for slot `N` as parent beacon block, but the execution payload revealed in `N-1` as parent execution block (thus ignoring the execution payload that may have been revealed during slot `N`), then any attestation for this consensus block `N+1` **does not** support a chain that descends from the execution payload committed in consensus block `N`, that is, from the *full slot* `N`. This is the content of `(Block, Slot, Payload)` voting. 
-
-### Builder timeliness boosts
-
-When a builder reveals an expected payload and the PTC achieved consensus that it was timely, that is, when at least `PAYLOAD_TIMELY_THRESHOLD` votes have been received for `PAYLOAD_PRESENT`, the forkchoice node containing the full slot (that is the consensus block together with its payload present) receives a boost equivalent to 40% of the beacon committee. 
-
-Similarly, when a builder reveals a *payload withheld* message and the PTC achieved consensus by having at least `PAYLOAD_TIMELY_THRESHOLD` votes for `PAYLOAD_WITHHELD`, then the parent consensus block receives a boost equivalent to 40% of the beacon committee. Given the `(Block, Slot)` nature of fork choice voting, this boost counts **against** the consensus block containing the builder's commitment. 
-
-Both these boosts are present to guarantee the Builder's reveal and withhold safety under the parameters described in the [Security Considerations](#security-considerations) section. 
+The precise method by which these safety mechanisms are enforced is by allowing attestations to also signal their view of the slot as in either of the above options *Full*, *Skipped* or *Empty*. For this, the `index` field in the `AttestationData` is used as explained above. 
 
 ### PTC equivocations
 
@@ -261,7 +270,7 @@ The current EIP adds an extra state transition function to the block processing 
 
 #### Inclusion lists
 
-This EIP is fully compatible with forward inclusion lists as specified in [EIP-7547](./eip-7547.md) or similar.
+This EIP is fully compatible with forkchoice enforced inclusion lists as specified in [EIP-7805](./eip-7805.md) or similar.
 
 #### Slot auctions
 
@@ -277,10 +286,6 @@ A simple change to this EIP is to remove the blockhash commitment from the `Sign
 This EIP introduces backward incompatible changes to the block validation rule set on the consensus layer and must be accompanied by a hard fork. 
 
 ## Security Considerations
-
-### Reorg resistance 
-
-`PROPOSER_SCORE_BOOST` is reduced from 40 to 20. This does not allow however a ex-ante reorg by a proposer with 20% of the total stake as the attacker's payload will also not be included. Proposers are protected against *1-slot sandwich* reorgs by a colluding set of validators and builders controlling more than 20% of the total stake.
 
 ### Builder safety
 


### PR DESCRIPTION
- Updates the links to the latest CL spec snapshot. 
- Removes mentions of payload boosts
- Adds bid payment processing mechanism by withdrawals
- Updates to latest structures

Still needs to update to dual deadline PTC and the rebase on Fulu. 