### PR TITLE
Update EIP-7937: fix two minor typos

### DIFF
--- a/EIPS/eip-7937.md
+++ b/EIPS/eip-7937.md
@@ -30,7 +30,7 @@ If the second byte is not a valid 64-bit mode operation, then the interpreter MU
 
 ### General 64-bit mode behavior
 
-In 64-bit mode, all operations only work on the least significant 64-bit of each stack value. The most significant 192-bit is discarded. When a result value is pushed back onto the stack, then it MUST ensures that observable effects will see that the most significant 192-bit is zero. Note that here it's not necessary for an interpreter to reset the most significant 192-bit to zero every time -- if the next opcode is still in 64-bit mode, then the most significant 192-bit is still unobservable. We discuss the full details in the "rationale" section. The interpreter only needs to reproduce the full 256-bit value upon entering non-64-bit mode. If the full computational heavy part can be written in pure 64-bit mode, then this can result in noticeable performance gain.
+In 64-bit mode, all operations only work on the least significant 64-bit of each stack value. The most significant 192-bit is discarded. When a result value is pushed back onto the stack, then it MUST ensure that observable effects will see that the most significant 192-bit is zero. Note that here it's not necessary for an interpreter to reset the most significant 192-bit to zero every time -- if the next opcode is still in 64-bit mode, then the most significant 192-bit is still unobservable. We discuss the full details in the "rationale" section. The interpreter only needs to reproduce the full 256-bit value upon entering non-64-bit mode. If the full computational heavy part can be written in pure 64-bit mode, then this can result in noticeable performance gain.
 
 ### Gas cost constants
 
@@ -55,7 +55,7 @@ The 64-bit mode arithmetic opcodes are defined the same as non-64-bit mode, exce
 
 ### Comparison and bitwise opcodes
 
-The 64-bit mode comparison and bitwise opcodes are defined the same as non-64-bit mode, except that they only operates on the least significant 64 bits.
+The 64-bit mode comparison and bitwise opcodes are defined the same as non-64-bit mode, except that they only operate on the least significant 64 bits.
 
 * LT (`C010`), GT (`C011`), SLT (`C012`), SGT (`C013`), EQ (`C014`), AND (`C016`), OR (`C017`), XOR (`C018`): `a op b mod 2^64`, gas cost `G_VERYLOW64`
 * ISZERO (`C015`), NOT (`C019`): `op a mod 2^64`, gas cost `G_VERYLOW64`


### PR DESCRIPTION
then it MUST ensures -> then it MUST ensure
they only operates -> they only operate