### PR TITLE
remove redundant `TARGET_BLOB_GAS_PER_BLOCK`

### DIFF
--- a/EIPS/eip-7918.md
+++ b/EIPS/eip-7918.md
@@ -13,11 +13,11 @@ requires: 4844, 7840
 
 ## Abstract
 
-This EIP assigns a reserve price `BLOB_BASE_COST * base_fee_per_gas` to blobs by introducing an `if`-clause in `calc_excess_blob_gas()`. Specifically, when the reserve price is higher than `GAS_PER_BLOB * base_fee_per_blob_gas`, the function will not subtract `TARGET_BLOB_GAS_PER_BLOCK` from `excess_blob_gas`, instead imposing `excess_blob_gas` to increase according to `blob_gas_used`, but rebalanced to maintain the same maximum increase. The proposal ensures that the blob fee market can function properly and that blob consumers pay at least a relevant fraction of the market rate for the compute they request from nodes.
+This EIP assigns a reserve price `BLOB_BASE_COST * base_fee_per_gas` to blobs by introducing an `if`-clause in `calc_excess_blob_gas()`. Specifically, when the reserve price is higher than `GAS_PER_BLOB * base_fee_per_blob_gas`, the function will not subtract `target_blob_gas` from `excess_blob_gas`, instead imposing `excess_blob_gas` to increase according to `blob_gas_used`, but rebalanced to maintain the same maximum increase. The proposal ensures that the blob fee market can function properly and that blob consumers pay at least a relevant fraction of the market rate for the compute they request from nodes.
 
 ## Motivation
 
-Ethereum deploys a dynamic pricing auction to set the blob base fee, lowering the fee if less gas is consumed than `TARGET_BLOB_GAS_PER_BLOCK` and raising the fee if more gas is consumed. Such an auction can function well when the blob base fee represents the price signal, allowing the mechanism to control the real price facing the consumer. However, when a rollup's L1 costs are dominated by execution gas, e.g., for executing blob-carrying transactions (including priority fees) and ZK proof verification, the price signal is lost. The blob base fee no longer represents a significant component of the total cost facing the consumer, and the protocol can no longer rely on the blob base fee to control the equilibrium quantity of blobs consumed. The current mechanism can therefore end up repeatedly lowering the blob base fee until it eventually settles at 1 wei. A change in the blob base fee of 10% may under such circumstances shift the total cost of utilizing blobspace by just 0.0000001%. Whenever demand picks up, over an hour of near-full blocks is required to restore a market-clearing equilibrium fee, with the mechanism intermittently resorting to a first-price auction, considered a worse UX by blob consumers. The resulting spikiness in resource consumption is suboptimal for scaling blobspace. 
+Ethereum deploys a dynamic pricing auction to set the blob base fee, lowering the fee if less gas is consumed than `target_blob_gas = GAS_PER_BLOB * blob_schedule.target` and raising the fee if more gas is consumed. Such an auction can function well when the blob base fee represents the price signal, allowing the mechanism to control the real price facing the consumer. However, when a rollup's L1 costs are dominated by execution gas, e.g., for executing blob-carrying transactions (including priority fees) and ZK proof verification, the price signal is lost. The blob base fee no longer represents a significant component of the total cost facing the consumer, and the protocol can no longer rely on the blob base fee to control the equilibrium quantity of blobs consumed. The current mechanism can therefore end up repeatedly lowering the blob base fee until it eventually settles at 1 wei. A change in the blob base fee of 10% may under such circumstances shift the total cost of utilizing blobspace by just 0.0000001%. Whenever demand picks up, over an hour of near-full blocks is required to restore a market-clearing equilibrium fee, with the mechanism intermittently resorting to a first-price auction, considered a worse UX by blob consumers. The resulting spikiness in resource consumption is suboptimal for scaling blobspace. 
 
 Figure 1 shows how execution costs make the real demand curve inelastic, such that relatively small shifts in organic demand or execution base fee (arrows) can lead to dramatic shifts in the equilibrium blob base fee. To alleviate this, the proposal imposes a reserve price, that reflects execution costs, through a simple `if`-clause in `calc_excess_blob_gas()`. The equilibrium (squares) must then form somewhere along the edge of the upper-left quadrant, bounded by the blue supply curve and the dashed curve representing possible reserve price equilibria under real demand (see rationale for a further elaboration).
 
@@ -40,24 +40,25 @@ The reserve price also fulfills a second important function. Nodes must cryptogr
 
 ### Functions
 
-An `if`-clause is added to `calc_excess_blob_gas()` from [EIP-4844](./eip-4844.md). The function no longer subtracts `TARGET_BLOB_GAS_PER_BLOCK` when updating `excess_blob_gas`, if the price of a `blob` is below the price of `BLOB_BASE_COST` execution gas. The blobSchedule for referencing target and max blobs was introduced in [EIP-7840](./eip-7840.md).
+An `if`-clause is added to `calc_excess_blob_gas()` from [EIP-4844](./eip-4844.md). The function no longer subtracts `target_blob_gas` when updating `excess_blob_gas`, if the price of a `blob` is below the price of `BLOB_BASE_COST` execution gas. The blobSchedule for referencing target and max blobs was introduced in [EIP-7840](./eip-7840.md).
 
 ```python
 def calc_excess_blob_gas(parent: Header) -> int:
-    if parent.excess_blob_gas + parent.blob_gas_used < TARGET_BLOB_GAS_PER_BLOCK:
+    target_blob_gas = GAS_PER_BLOB * blob_schedule.target
+    if parent.excess_blob_gas + parent.blob_gas_used < target_blob_gas:
         return 0
 
     if BLOB_BASE_COST * parent.base_fee_per_gas > GAS_PER_BLOB * get_base_fee_per_blob_gas(parent):
         return parent.excess_blob_gas + parent.blob_gas_used * (blobSchedule.max - blobSchedule.target) // blobSchedule.max
     else:
-        return parent.excess_blob_gas + parent.blob_gas_used - TARGET_BLOB_GAS_PER_BLOCK
+        return parent.excess_blob_gas + parent.blob_gas_used - target_blob_gas
 ```
 
 ## Rationale
 
 ### Fee-inelasticity and reserve price
 
-This proposal alleviates idiosyncrasies in the blob base fee auction. The fee update mechanism is unaware of the full price of the goods that it regulates the price for and therefore fails to converge on equilibrium in a timely manner. To resolve this, a link to the price of execution gas is required. A relatively high cost of execution gas renders changes to the blob base fee less effective in controlling quantity demanded—it is then ultimately the execution cost that determines equilibrium formation. Given that the protocol stipulates a long-run perfectly inelastic supply curve (vertical blue line in Figure 1), the blob base fee will simply fall to the boundary of 1 wei whenever the execution cost is too high for consumers to achieve equilibrium formation at `TARGET_BLOB_GAS_PER_BLOCK`. Thus, in the regime where execution fees dominate, the demand curve is *blob fee-inelastic*, and whenever the blob fees dominate, the demand curve is *execution fee-inelastic*. Figure 1 illustrates the real demand function
+This proposal alleviates idiosyncrasies in the blob base fee auction. The fee update mechanism is unaware of the full price of the goods that it regulates the price for and therefore fails to converge on equilibrium in a timely manner. To resolve this, a link to the price of execution gas is required. A relatively high cost of execution gas renders changes to the blob base fee less effective in controlling quantity demanded—it is then ultimately the execution cost that determines equilibrium formation. Given that the protocol stipulates a long-run perfectly inelastic supply curve (vertical blue line in Figure 1), the blob base fee will simply fall to the boundary of 1 wei whenever the execution cost is too high for consumers to achieve equilibrium formation at `target_blog_gas`. Thus, in the regime where execution fees dominate, the demand curve is *blob fee-inelastic*, and whenever the blob fees dominate, the demand curve is *execution fee-inelastic*. Figure 1 illustrates the real demand function
 
 $Q(b + c),$
 
@@ -120,7 +121,7 @@ There are approximately 8 blobs per 1M blob gas. A target of 30M execution gas (
 
 ### Delayed response during a quick rise in execution fees
 
-When the `if` statement concludes that Ethereum operates in the execution-fee-led pricing regime, the blob base fee rises in accordance with `blob_gas_used * (max - target) // max`, without subtracting `TARGET_BLOB_GAS_PER_BLOCK`. This is an intuitive way to return to the blob-fee-led pricing regime, retaining the same maximum fee increase while not allowing for a decrease. If the execution base fee rises quickly, there may be a few blocks before the blob base fee catches up (during which `TARGET_BLOB_GAS_PER_BLOCK` will never be subtracted. This is arguably not an issue, and the smooth response in the blob base fee under these circumstances may even be seen as a benefit.
+When the `if` statement concludes that Ethereum operates in the execution-fee-led pricing regime, the blob base fee rises in accordance with `blob_gas_used * (max - target) // max`, without subtracting `target_blob_gas`. This is an intuitive way to return to the blob-fee-led pricing regime, retaining the same maximum fee increase while not allowing for a decrease. If the execution base fee rises quickly, there may be a few blocks before the blob base fee catches up (during which `target_blob_gas` will never be subtracted. This is arguably not an issue, and the smooth response in the blob base fee under these circumstances may even be seen as a benefit.
 
 ### Empirical analysis
 


### PR DESCRIPTION
The blob gas target is now just expressed as `GAS_PER_BLOB * blob_schedule.target`