### PR TITLE
Clarify blob schedule usage in base fee computations

### DIFF
--- a/EIPS/eip-7892.md
+++ b/EIPS/eip-7892.md
@@ -94,6 +94,27 @@ To facilitate these changes on the execution layer, each fork in the `blobSchedu
 "bpo2Time": 1767387784,
 ```
 
+### Blob base fee computations
+
+We modify the functions `get_base_fee_per_blob_gas` and `calc_excess_blob_gas` defined in [EIP-4844](./eip-4844.md) to explicitly use the blob schedule.
+In line with how updating `BLOB_BASE_FEE_UPDATE_FRACTION` was handled in [EIP-7691](./eip-7691.md), the functions use the *current* block's blob schedule.
+
+```python
+ def calc_excess_blob_gas(parent: Header) -> int:
+    target_blob_gas = GAS_PER_BLOB * blobSchedule.target
+    if parent.excess_blob_gas + parent.blob_gas_used < target_blob_gas :
+        return 0
+    else:
+        return parent.excess_blob_gas + parent.blob_gas_used - target_blob_gas
+
+def get_base_fee_per_blob_gas(header: Header) -> int:
+    return fake_exponential(
+        MIN_BASE_FEE_PER_BLOB_GAS,
+        header.excess_blob_gas,
+        blobSchedule.baseFeeUpdateFraction
+    )
+```
+
 ### Consensus layer configuration
 
 A new `BLOB_SCHEDULE` field is added to consensus layer configuration, containing a sequence of entries representing blob parameter changes **after** `ELECTRA_FORK_EPOCH`. There exists one entry per fork that changes blob parameters, whether it is a regular or a Blob-Parameter-Only fork.


### PR DESCRIPTION
Attempts to clarify the behavior that caused a network split in devnet-4, i.e., whether to use the current blob schedule values in blob base fee computations at the fork boundary.