### PR TITLE
Update EIP-7773: Call and Return Opcodes for the EVM

### DIFF
--- a/EIPS/eip-7773.md
+++ b/EIPS/eip-7773.md
@@ -45,6 +45,7 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Declined
 * [EIP-7903](./eip-7903.md): Remove Initcode Size Limit
 * [EIP-7907](./eip-7907.md): Meter Contract Code Size And Increase Limit
 * [EIP-7923](./eip-7923.md): Linear, Page-Based Memory Costing
+* [EIP-7979](./eip-7979.md): Call and Return Opcodes for the EVM
 
 ### Activation
 


### PR DESCRIPTION
This is the smallest possible change to the EVM to support calls and returns.

This proposal introduces three new control-flow instructions to the EVM:

    CALLSUB destination transfers control to the destination``.
    ENTERSUB marks a CALLSUB destination.
    RETURNSUB returns to the PC after the most recent CALLSUB.

Code can also be prefixed with MAGIC bytes. The complete control flow of MAGIC code can be traversed in time and space linear in the size of the code, enabling better tools for validation, static analysis, and JIT and AOT compilers. Onchain, MAGIC code is validated at CREATE time to ensure that it will not execute invalid instructions, jump to invalid locations, underflow stack, or, in the absence of recursion, overflow stack.

These changes are backwards-compatible: the new instructions behave as specified whether or not they appear in MAGIC code.