### PR TITLE
Update EIP-6493: fix typos in spec text

### DIFF
--- a/EIPS/eip-6493.md
+++ b/EIPS/eip-6493.md
@@ -33,7 +33,7 @@ Additional information is mixed into `sig_hash` to uniquely identify the underly
 
 | Name | Value | Description |
 | - | - | - |
-| `DOMAIN_TX_SSZ` | `DomainType('0x00000080)` | [`DomainType`](https://github.com/ethereum/consensus-specs/blob/b3e83f6691c61e5b35136000146015653b22ed38/specs/phase0/beacon-chain.md#custom-types) for signing native SSZ transactions compatible with this EIP |
+| `DOMAIN_TX_SSZ` | `DomainType('0x00000080')` | [`DomainType`](https://github.com/ethereum/consensus-specs/blob/b3e83f6691c61e5b35136000146015653b22ed38/specs/phase0/beacon-chain.md#custom-types) for signing native SSZ transactions compatible with this EIP |
 
 ```python
 class ExecutionSigningData(Container):
@@ -141,7 +141,7 @@ SSZ signatures MUST NOT collide with RLP transaction and message hashes.
 
 As RLP messages are hashed using keccak256, and all SSZ objects are hashed using SHA256. These two hashing algorithms are both considered cryptographically secure and are based on fundamentally different approaches, minimizing the risk of hash collision between those two hashing algorithms.
 
-Furthermore, RLP messages are hashed linearly across their serialization, while SSZ objects are hashed using a recursive Merkle tree. Having a different mechanism further reduce the risk of hash collisions.
+Furthermore, RLP messages are hashed linearly across their serialization, while SSZ objects are hashed using a recursive Merkle tree. Having a different mechanism further reduces the risk of hash collisions.
 
 ## Copyright
 


### PR DESCRIPTION
- Added missing quote in DOMAIN_TX_SSZ value.
- Corrected grammar in hash collision explanation.