### PR TITLE
Add dark mode toggle to nav

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -39,6 +39,48 @@
       "@context": "https://schema.org"
     }
   </script>
+  
+  <!-- theme detection and immediate apply to prevent FOUC -->
+  <script>
+    (function() {
+      'use strict';
+      
+      const THEME_KEY = 'eips-theme-preference';
+      const THEME_AUTO = 'auto';
+      const THEME_LIGHT = 'light';
+      const THEME_DARK = 'dark';
+      
+      function getStoredTheme() {
+        try {
+          const stored = localStorage.getItem(THEME_KEY);
+          if (stored && [THEME_AUTO, THEME_LIGHT, THEME_DARK].includes(stored)) {
+            return stored;
+          }
+        } catch (e) {
+          // if localStorage is not available due to browser settings, use auto
+        }
+        return THEME_AUTO;
+      }
+      
+      function getSystemPreference() {
+        return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? THEME_DARK : THEME_LIGHT;
+      }
+      
+      function applyThemeImmediately() {
+        const storedTheme = getStoredTheme();
+        const effectiveTheme = storedTheme === THEME_AUTO ? getSystemPreference() : storedTheme;
+        
+        document.documentElement.setAttribute('data-theme', effectiveTheme);
+        
+        const metaThemeColor = document.createElement('meta');
+        metaThemeColor.name = 'theme-color';
+        metaThemeColor.content = effectiveTheme === THEME_DARK ? '#212529' : '#ffffff';
+        document.head.appendChild(metaThemeColor);
+      }
+      
+      applyThemeImmediately();
+    })();
+  </script>
   <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}" />
   <link rel="icon" type="image/png" href="{{ '/assets/images/favicon.png' | relative_url }}" />
   {%- feed_meta -%}
@@ -67,6 +109,7 @@
     };
   </script>
   <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3.0.1/es5/tex-mml-chtml.js" integrity="sha384-/1zmJ1mBdfKIOnwPxpdG6yaRrxP6qu3eVYm0cz2nOx+AcL4d3AqEFrwcqGZVVroG" crossorigin="anonymous"></script>
+  <script src="{{ '/assets/js/theme-toggle.js' | relative_url }}" defer></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/citation-js/0.6.7/citation.min.js" integrity="sha512-N+LDFMa9owHXGS+CyMrBvuxq2QuGl3fiB/7cys3aUEL7K6P1soHGqsS0sjHXZpwNd9Kz0m3R4IPy1HYRi6ROEQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script type="text/javascript">
     addEventListener('DOMContentLoaded', async () => {

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -2,28 +2,58 @@
   <div class="wrapper">
     {%- assign default_paths = site.pages | map: "path" -%}
     {%- assign page_paths = site.header_pages | default: default_paths -%}
-    <a class="site-title" rel="author" href="{{ "/" | relative_url }}">{{ site.title | escape }}</a>
+    
+    <div class="header-content">
+      <a class="site-title" rel="author" href="{{ "/" | relative_url }}">{{ site.title | escape }}</a>
+      
+      <div class="header-actions">
+        
 
-    {%- if page_paths -%}
-      <nav class="site-nav d-flex">
-        <input type="checkbox" id="nav-trigger" class="nav-trigger" />
-        <label for="nav-trigger">
-          <span class="menu-icon">
-            <svg viewBox="0 0 18 15" width="18px" height="15px">
-              <path d="M18,1.484c0,0.82-0.665,1.484-1.484,1.484H1.484C0.665,2.969,0,2.304,0,1.484l0,0C0,0.665,0.665,0,1.484,0 h15.032C17.335,0,18,0.665,18,1.484L18,1.484z M18,7.516C18,8.335,17.335,9,16.516,9H1.484C0.665,9,0,8.335,0,7.516l0,0 c0-0.82,0.665-1.484,1.484-1.484h15.032C17.335,6.031,18,6.696,18,7.516L18,7.516z M18,13.516C18,14.335,17.335,15,16.516,15H1.484 C0.665,15,0,14.335,0,13.516l0,0c0-0.82,0.665-1.483,1.484-1.483h15.032C17.335,12.031,18,12.695,18,13.516L18,13.516z"/>
+        {%- if page_paths -%}
+          <nav class="site-nav d-flex">
+            <input type="checkbox" id="nav-trigger" class="nav-trigger" />
+            <label for="nav-trigger">
+              <span class="menu-icon">
+                <svg viewBox="0 0 18 15" width="18px" height="15px">
+                  <path d="M18,1.484c0,0.82-0.665,1.484-1.484,1.484H1.484C0.665,2.969,0,2.304,0,1.484l0,0C0,0.665,0.665,0,1.484,0 h15.032C17.335,0,18,0.665,18,1.484L18,1.484z M18,7.516C18,8.335,17.335,9,16.516,9H1.484C0.665,9,0,8.335,0,7.516l0,0 c0-0.82,0.665-1.484,1.484-1.484h15.032C17.335,6.031,18,6.696,18,7.516L18,7.516z M18,13.516C18,14.335,17.335,15,16.516,15H1.484 C0.665,15,0,14.335,0,13.516l0,0c0-0.82,0.665-1.483,1.484-1.483h15.032C17.335,12.031,18,12.695,18,13.516L18,13.516z"/>
+                </svg>
+              </span>
+            </label>
+
+            <div class="trigger row p-2">
+              <div class="theme-toggle-wrapper theme-toggle-mobile col-12">
+                <button id="theme-toggle-mobile" class="theme-toggle-btn theme-toggle-mobile-btn" aria-label="Toggle dark mode" title="Toggle dark mode">
+                  <svg id="theme-icon-light-mobile" class="theme-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+                    <path d="M12 2.25a.75.75 0 01.75.75v2.25a.75.75 0 01-1.5 0V3a.75.75 0 01.75-.75zM7.5 12a4.5 4.5 0 119 0 4.5 4.5 0 01-9 0zM18.894 6.166a.75.75 0 00-1.06-1.06l-1.591 1.59a.75.75 0 101.06 1.061l1.591-1.59zM21.75 12a.75.75 0 01-.75.75h-2.25a.75.75 0 010-1.5H21a.75.75 0 01.75.75zM17.834 18.894a.75.75 0 001.06-1.06l-1.59-1.591a.75.75 0 10-1.061 1.06l1.59 1.591zM12 18a.75.75 0 01.75.75V21a.75.75 0 01-1.5 0v-2.25A.75.75 0 0112 18zM7.758 17.303a.75.75 0 00-1.061-1.06l-1.591 1.59a.75.75 0 001.06 1.061l1.591-1.59zM6 12a.75.75 0 01-.75.75H3a.75.75 0 010-1.5h2.25A.75.75 0 016 12zM6.697 7.757a.75.75 0 001.06-1.06l-1.59-1.591a.75.75 0 00-1.061 1.06l1.59 1.591z" />
+                  </svg>
+                  <svg id="theme-icon-dark-mobile" class="theme-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" style="display: none;">
+                    <path fill-rule="evenodd" d="M9.528 1.718a.75.75 0 01.162.819A8.97 8.97 0 009 6a9 9 0 009 9 8.97 8.97 0 003.463-.69.75.75 0 01.981.98 10.503 10.503 0 01-9.694 6.46c-5.799 0-10.5-4.701-10.5-10.5 0-4.368 2.667-8.112 6.46-9.694a.75.75 0 01.818.162z" clip-rule="evenodd" />
+                  </svg>
+                  <span class="theme-toggle-label">Dark Mode</span>
+                </button>
+              </div>
+              
+              {%- for path in page_paths -%}
+                {%- assign my_page = site.pages | where: "path", path | first -%}
+                {%- if my_page.title -%}
+                <a class="page-link col" href="{{ my_page.url | relative_url }}">{{ my_page.title | escape }}</a>
+                {%- endif -%}
+              {%- endfor -%}
+            </div>
+          </nav>
+        {%- endif -%}
+
+        <div class="theme-toggle-wrapper theme-toggle-desktop">
+          <button id="theme-toggle" class="theme-toggle-btn" aria-label="Toggle dark mode" title="Toggle dark mode">
+            <svg id="theme-icon-light" class="theme-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+              <path d="M12 2.25a.75.75 0 01.75.75v2.25a.75.75 0 01-1.5 0V3a.75.75 0 01.75-.75zM7.5 12a4.5 4.5 0 119 0 4.5 4.5 0 01-9 0zM18.894 6.166a.75.75 0 00-1.06-1.06l-1.591 1.59a.75.75 0 101.06 1.061l1.591-1.59zM21.75 12a.75.75 0 01-.75.75h-2.25a.75.75 0 010-1.5H21a.75.75 0 01.75.75zM17.834 18.894a.75.75 0 001.06-1.06l-1.59-1.591a.75.75 0 10-1.061 1.06l1.59 1.591zM12 18a.75.75 0 01.75.75V21a.75.75 0 01-1.5 0v-2.25A.75.75 0 0112 18zM7.758 17.303a.75.75 0 00-1.061-1.06l-1.591 1.59a.75.75 0 001.06 1.061l1.591-1.59zM6 12a.75.75 0 01-.75.75H3a.75.75 0 010-1.5h2.25A.75.75 0 016 12zM6.697 7.757a.75.75 0 001.06-1.06l-1.59-1.591a.75.75 0 00-1.061 1.06l1.59 1.591z" />
             </svg>
-          </span>
-        </label>
-
-        <div class="trigger row p-2">
-          {%- for path in page_paths -%}
-            {%- assign my_page = site.pages | where: "path", path | first -%}
-            {%- if my_page.title -%}
-            <a class="page-link col" href="{{ my_page.url | relative_url }}">{{ my_page.title | escape }}</a>
-            {%- endif -%}
-          {%- endfor -%}
+            <svg id="theme-icon-dark" class="theme-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" style="display: none;">
+              <path fill-rule="evenodd" d="M9.528 1.718a.75.75 0 01.162.819A8.97 8.97 0 009 6a9 9 0 009 9 8.97 8.97 0 003.463-.69.75.75 0 01.981.98 10.503 10.503 0 01-9.694 6.46c-5.799 0-10.5-4.701-10.5-10.5 0-4.368 2.667-8.112 6.46-9.694a.75.75 0 01.818.162z" clip-rule="evenodd" />
+            </svg>
+          </button>
         </div>
-      </nav>
-    {%- endif -%}
+      </div>
+    </div>
   </div>
 </header>

--- a/assets/css/override.css
+++ b/assets/css/override.css
@@ -78,3 +78,194 @@
     --bs-form-invalid-border-color: #ea868f;
   }
 }
+
+.header-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-top: 0.5rem;
+}
+
+.theme-toggle-wrapper {
+  display: flex;
+  align-items: center;
+}
+
+.theme-toggle-btn {
+  background: none;
+  border: 2px solid var(--bs-border-color, #dee2e6);
+  border-radius: 50%;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: var(--bs-body-color);
+}
+
+.theme-toggle-btn:hover {
+  background-color: var(--bs-tertiary-bg, #f8f9fa);
+  border-color: var(--bs-primary, #0d6efd);
+  transform: rotate(15deg);
+}
+
+.theme-toggle-btn:focus {
+  outline: 2px solid var(--bs-primary, #0d6efd);
+  outline-offset: 2px;
+}
+
+/* Theme Transitions - Only apply after page has loaded to prevent FOUC */
+body.loaded * {
+  transition: background-color 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+
+
+.theme-toggle-btn {
+  transition: all 0.2s ease;
+}
+
+.theme-icon {
+  transition: opacity 0.15s ease;
+}
+
+[data-theme="dark"] {
+  color-scheme: dark;
+  --bs-body-color: #dee2e6;
+  --bs-body-color-rgb: 222,226,230;
+  --bs-body-bg: #212529;
+  --bs-body-bg-rgb: 33,37,41;
+  --bs-emphasis-color: #fff;
+  --bs-emphasis-color-rgb: 255,255,255;
+  --bs-secondary-color: rgba(222, 226, 230, 0.75);
+  --bs-secondary-color-rgb: 222,226,230;
+  --bs-secondary-bg: #343a40;
+  --bs-secondary-bg-rgb: 52,58,64;
+  --bs-tertiary-color: rgba(222, 226, 230, 0.5);
+  --bs-tertiary-color-rgb: 222,226,230;
+  --bs-tertiary-bg: #2b3035;
+  --bs-tertiary-bg-rgb: 43,48,53;
+  --bs-primary-text-emphasis: #6ea8fe;
+  --bs-secondary-text-emphasis: #a7acb1;
+  --bs-success-text-emphasis: #75b798;
+  --bs-info-text-emphasis: #6edff6;
+  --bs-warning-text-emphasis: #ffda6a;
+  --bs-danger-text-emphasis: #ea868f;
+  --bs-light-text-emphasis: #f8f9fa;
+  --bs-dark-text-emphasis: #dee2e6;
+  --bs-primary-bg-subtle: #031633;
+  --bs-secondary-bg-subtle: #161719;
+  --bs-success-bg-subtle: #051b11;
+  --bs-info-bg-subtle: #032830;
+  --bs-warning-bg-subtle: #332701;
+  --bs-danger-bg-subtle: #2c0b0e;
+  --bs-light-bg-subtle: #343a40;
+  --bs-dark-bg-subtle: #1a1d20;
+  --bs-primary-border-subtle: #084298;
+  --bs-secondary-border-subtle: #41464b;
+  --bs-success-border-subtle: #0f5132;
+  --bs-info-border-subtle: #087990;
+  --bs-warning-border-subtle: #997404;
+  --bs-danger-border-subtle: #842029;
+  --bs-light-border-subtle: #495057;
+  --bs-dark-border-subtle: #343a40;
+  --bs-heading-color: inherit;
+  --bs-link-color: #6ea8fe;
+  --bs-link-hover-color: #8bb9fe;
+  --bs-link-color-rgb: 110,168,254;
+  --bs-link-hover-color-rgb: 139,185,254;
+  --bs-code-color: #e685b5;
+  --bs-border-color: #495057;
+  --bs-border-color-translucent: rgba(255, 255, 255, 0.15);
+  --bs-form-valid-color: #75b798;
+  --bs-form-valid-border-color: #75b798;
+  --bs-form-invalid-color: #ea868f;
+  --bs-form-invalid-border-color: #ea868f;
+}
+
+[data-theme="dark"] table th {
+  background-color: #0f0f0f;
+}
+
+[data-theme="dark"] table tr:nth-child(2n) {
+  background-color: #080808;
+}
+
+[data-theme="dark"] .site-title,
+[data-theme="dark"] .site-title:visited {
+  color: #bdbdbd;
+}
+
+[data-theme="dark"] .highlighter-rouge .highlight,
+[data-theme="dark"] pre,
+[data-theme="dark"] code {
+  background-color: #111100;
+}
+
+[data-theme="light"] {
+  color-scheme: light;
+}
+
+.theme-toggle-mobile {
+  display: none;
+}
+
+.theme-toggle-mobile-btn {
+  width: 100%;
+  border-radius: 8px;
+  padding: 12px 16px;
+  justify-content: flex-start;
+  gap: 12px;
+  margin-bottom: 8px;
+  border: 1px solid var(--bs-border-color, #dee2e6);
+}
+
+.theme-toggle-label {
+  font-size: 16px;
+  font-weight: 500;
+  color: var(--bs-body-color);
+}
+
+@media (max-width: 768px) {
+  .header-actions {
+    gap: 0.5rem;
+  }
+  
+  .theme-toggle-desktop {
+    display: none;
+  }
+  
+  .theme-toggle-mobile {
+    display: block;
+  }
+  
+  .theme-toggle-mobile-btn:hover {
+    background-color: var(--bs-tertiary-bg, #f8f9fa);
+    transform: none;
+  }
+}
+
+@media (min-width: 769px) {
+  .theme-toggle-mobile {
+    display: none !important;
+  }
+  
+  .theme-toggle-desktop {
+    display: flex;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body.loaded *,
+  .theme-toggle-btn,
+  .theme-icon {
+    transition: none !important;
+  }
+}

--- a/assets/js/theme-toggle.js
+++ b/assets/js/theme-toggle.js
@@ -1,0 +1,247 @@
+(function () {
+  "use strict";
+
+  const THEME_KEY = "eips-theme-preference";
+  const THEME_AUTO = "auto";
+  const THEME_LIGHT = "light";
+  const THEME_DARK = "dark";
+
+  class ThemeManager {
+    constructor() {
+      this.toggleBtn = null;
+      this.lightIcon = null;
+      this.darkIcon = null;
+      this.currentTheme = this.getStoredTheme();
+      this.systemPrefersDark = window.matchMedia(
+        "(prefers-color-scheme: dark)"
+      );
+
+      this.init();
+    }
+
+    init() {
+      this.bindElements();
+      this.bindEvents();
+      this.syncWithCurrentTheme();
+      this.updateUI();
+      this.enableTransitions();
+    }
+
+    enableTransitions() {
+      document.body.classList.add("loaded");
+    }
+
+    syncWithCurrentTheme() {
+      const currentDataTheme =
+        document.documentElement.getAttribute("data-theme");
+      if (currentDataTheme && currentDataTheme !== this.getEffectiveTheme()) {
+        if (
+          currentDataTheme === "dark" &&
+          this.currentTheme === THEME_AUTO &&
+          !this.systemPrefersDark.matches
+        ) {
+          this.currentTheme = THEME_DARK;
+        } else if (
+          currentDataTheme === "light" &&
+          this.currentTheme === THEME_AUTO &&
+          this.systemPrefersDark.matches
+        ) {
+          this.currentTheme = THEME_LIGHT;
+        }
+      }
+    }
+
+    bindElements() {
+      this.toggleBtn = document.getElementById("theme-toggle");
+      this.lightIcon = document.getElementById("theme-icon-light");
+      this.darkIcon = document.getElementById("theme-icon-dark");
+
+      this.toggleBtnMobile = document.getElementById("theme-toggle-mobile");
+      this.lightIconMobile = document.getElementById("theme-icon-light-mobile");
+      this.darkIconMobile = document.getElementById("theme-icon-dark-mobile");
+
+      if (!this.toggleBtn && !this.toggleBtnMobile) {
+        console.warn("Theme toggle buttons not found");
+        return;
+      }
+    }
+
+    bindEvents() {
+      if (this.toggleBtn) {
+        this.toggleBtn.addEventListener("click", () => this.toggleTheme());
+
+        this.toggleBtn.addEventListener("keydown", (e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            this.toggleTheme();
+          }
+        });
+      }
+
+      if (this.toggleBtnMobile) {
+        this.toggleBtnMobile.addEventListener("click", () =>
+          this.toggleTheme()
+        );
+
+        this.toggleBtnMobile.addEventListener("keydown", (e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            this.toggleTheme();
+          }
+        });
+      }
+
+      this.systemPrefersDark.addEventListener("change", () => {
+        if (this.currentTheme === THEME_AUTO) {
+          this.updateUI();
+          this.applySystemTheme();
+        }
+      });
+    }
+
+    getStoredTheme() {
+      const stored = localStorage.getItem(THEME_KEY);
+      if (stored && [THEME_AUTO, THEME_LIGHT, THEME_DARK].includes(stored)) {
+        return stored;
+      }
+      return THEME_AUTO;
+    }
+
+    setStoredTheme(theme) {
+      localStorage.setItem(THEME_KEY, theme);
+      this.currentTheme = theme;
+    }
+
+    getEffectiveTheme() {
+      if (this.currentTheme === THEME_AUTO) {
+        return this.systemPrefersDark.matches ? THEME_DARK : THEME_LIGHT;
+      }
+      return this.currentTheme;
+    }
+
+    applyTheme(theme) {
+      const effectiveTheme =
+        theme === THEME_AUTO
+          ? this.systemPrefersDark.matches
+            ? THEME_DARK
+            : THEME_LIGHT
+          : theme;
+
+      document.documentElement.setAttribute("data-theme", effectiveTheme);
+
+      this.updateThemeColor(effectiveTheme);
+    }
+
+    applySystemTheme() {
+      if (this.currentTheme === THEME_AUTO) {
+        const effectiveTheme = this.systemPrefersDark.matches
+          ? THEME_DARK
+          : THEME_LIGHT;
+        document.documentElement.setAttribute("data-theme", effectiveTheme);
+        this.updateThemeColor(effectiveTheme);
+      }
+    }
+
+    updateThemeColor(theme) {
+      let metaThemeColor = document.querySelector('meta[name="theme-color"]');
+      if (!metaThemeColor) {
+        metaThemeColor = document.createElement("meta");
+        metaThemeColor.name = "theme-color";
+        document.getElementsByTagName("head")[0].appendChild(metaThemeColor);
+      }
+
+      metaThemeColor.content = theme === THEME_DARK ? "#212529" : "#ffffff";
+    }
+
+    updateUI() {
+      const effectiveTheme = this.getEffectiveTheme();
+      const isDark = effectiveTheme === THEME_DARK;
+      const label = isDark ? "Switch to light mode" : "Switch to dark mode";
+
+      if (this.toggleBtn && this.lightIcon && this.darkIcon) {
+        this.lightIcon.style.display = isDark ? "none" : "block";
+        this.darkIcon.style.display = isDark ? "block" : "none";
+        this.toggleBtn.setAttribute("aria-label", label);
+        this.toggleBtn.setAttribute("title", label);
+        this.toggleBtn.classList.toggle("theme-dark", isDark);
+      }
+
+      if (this.toggleBtnMobile && this.lightIconMobile && this.darkIconMobile) {
+        this.lightIconMobile.style.display = isDark ? "none" : "block";
+        this.darkIconMobile.style.display = isDark ? "block" : "none";
+        this.toggleBtnMobile.setAttribute("aria-label", label);
+        this.toggleBtnMobile.setAttribute("title", label);
+        this.toggleBtnMobile.classList.toggle("theme-dark", isDark);
+      }
+    }
+
+    toggleTheme() {
+      let nextTheme;
+
+      switch (this.currentTheme) {
+        case THEME_AUTO:
+          nextTheme = this.systemPrefersDark.matches ? THEME_LIGHT : THEME_DARK;
+          break;
+        case THEME_LIGHT:
+          nextTheme = THEME_DARK;
+          break;
+        case THEME_DARK:
+          nextTheme = THEME_LIGHT;
+          break;
+        default:
+          nextTheme = THEME_AUTO;
+      }
+
+      this.setStoredTheme(nextTheme);
+      this.applyTheme(nextTheme);
+      this.updateUI();
+
+      this.announceThemeChange(nextTheme);
+    }
+
+    announceThemeChange(theme) {
+      const effectiveTheme =
+        theme === THEME_AUTO
+          ? this.systemPrefersDark.matches
+            ? "dark (auto)"
+            : "light (auto)"
+          : theme;
+
+      const announcement = `Theme switched to ${effectiveTheme} mode`;
+
+      const announcer = document.createElement("div");
+      announcer.setAttribute("aria-live", "polite");
+      announcer.setAttribute("aria-atomic", "true");
+      announcer.style.position = "absolute";
+      announcer.style.left = "-10000px";
+      announcer.style.width = "1px";
+      announcer.style.height = "1px";
+      announcer.style.overflow = "hidden";
+
+      document.body.appendChild(announcer);
+      announcer.textContent = announcement;
+
+      setTimeout(() => {
+        document.body.removeChild(announcer);
+      }, 1000);
+    }
+
+    getThemeInfo() {
+      return {
+        stored: this.currentTheme,
+        effective: this.getEffectiveTheme(),
+        systemPreference: this.systemPrefersDark.matches
+          ? THEME_DARK
+          : THEME_LIGHT,
+      };
+    }
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", () => {
+      window.eipsThemeManager = new ThemeManager();
+    });
+  } else {
+    window.eipsThemeManager = new ThemeManager();
+  }
+})();


### PR DESCRIPTION
## Description
Adds dark mode with light, dark, and auto (system) theme options. User preference is saved and persists across sessions.


### Changes

- New theme manager in assets/js/theme-toggle.js
- Three theme modes with localStorage persistence
- Auto mode detects and follows system preference
- Accessible with screen reader announcements

### Testing

- Use theme toggle button in header
- Click to cycle through light → dark 
- Refresh page to verify persistence
