### PR TITLE
Update EIP-7928: fix misleading link

### DIFF
--- a/EIPS/eip-7928.md
+++ b/EIPS/eip-7928.md
@@ -157,7 +157,7 @@ Zero-value transfers: MUST NOT be recorded in `balance_changes` but addresses MU
 
 Code changes track post-transaction runtime bytecode for deployed/modified contracts and delegation indicators from [EIP-7702](./eip-7702.md).
 
-Nonce changes record post-transaction nonces for EOA senders, contracts that performed a successful `CREATE` or `CREATE2` operation, deployed contracts and [EIP-7702](./eip-7792.md) authorities.
+Nonce changes record post-transaction nonces for EOA senders, contracts that performed a successful `CREATE` or `CREATE2` operation, deployed contracts and [EIP-7702](./eip-7702.md) authorities.
 
 ### Important Implementation Details
 


### PR DESCRIPTION
from [EIP-7702](./eip-7792.md)
to [EIP-7702](./eip-7702.md)
it seems the links was intent to be /eip-7702.md