### PR TITLE
Updare EIP-1283: fix grammatical issues

### DIFF
--- a/EIPS/eip-1283.md
+++ b/EIPS/eip-1283.md
@@ -13,7 +13,7 @@ created: 2018-08-01
 
 This EIP proposes net gas metering changes for `SSTORE` opcode, enabling
 new usages for contract storage, and reducing excessive gas costs
-where it doesn't match how most implementation works.
+where it doesn't match how most implementations work.
 
 This acts as an alternative for EIP-1087, where it tries to be
 friendlier to implementations that use different optimization
@@ -23,7 +23,7 @@ strategies for storage change caches.
 
 This EIP proposes a way for gas metering on SSTORE (as an alternative
 for EIP-1087 and EIP-1153), using information that is more universally
-available to most implementations, and require as little change in
+available to most implementations, and requires as little change in
 implementation structures as possible.
 
 * *Storage slot's original value*.
@@ -207,7 +207,7 @@ anticipated, and many contracts will see gas reduction.
 Below we provide 17 test cases. 15 of them covering consecutive two
 `SSTORE` operations are based on work [by
 @chfast](https://github.com/ethereum/tests/issues/483). Two additional
-case with three `SSTORE` operations is used to test the case when a
+cases with three `SSTORE` operations is used to test the case when a
 slot is reset and then set again.
 
 | Code                               | Used Gas | Refund | Original | 1st | 2nd | 3rd |


### PR DESCRIPTION
how most implementation works. ->  how most implementations work.
(a way) require -> (a way) requires
Two additional case -> Two additional cases