### PR TITLE
Update EIP-695: fix typo in specification text

### DIFF
--- a/EIPS/eip-695.md
+++ b/EIPS/eip-695.md
@@ -68,7 +68,7 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"eth_chainId","params":[],"id":83
 
 An ETH/ETC client can accidentally connect to an ETC/ETH RPC
 endpoint without knowing it unless it tries to sign a transaction or
-it fetch a transaction that is known to have signed with a chain
+it fetches a transaction that is known to have signed with a chain
 ID. This has since caused trouble for application developers, such as
 MetaMask, to add multi-chain support.
 


### PR DESCRIPTION
- Corrected "it fetch" → "it fetches" in EIP-695
