### PR TITLE
Update EIP-7898: fix grammar and typos

### DIFF
--- a/EIPS/eip-7898.md
+++ b/EIPS/eip-7898.md
@@ -12,7 +12,7 @@ created: 2025-03-01
 
 ## Abstract
 
-Currently, the beacon block in Ethereum Consensus embed transactions within `ExecutionPayload` field of `BeaconBlockBody`. This EIP proposes to replace `ExecutionPayload` with `ExecutionPayloadHeader` in `BeaconBlockBody` and to independently transmit `ExecutionPayloadWithInclusionProof`.
+Currently, the beacon block in Ethereum Consensus embeds transactions within `ExecutionPayload` field of `BeaconBlockBody`. This EIP proposes to replace `ExecutionPayload` with `ExecutionPayloadHeader` in `BeaconBlockBody` and to independently transmit `ExecutionPayloadWithInclusionProof`.
 
 However, this EIP makes no change to the block import mechanism, with the exception that block availability now includes waiting for the availability of `ExecutionPayloadWithInclusionProof`, making it different and simpler from proposals like ePBS/APS.
 
@@ -42,7 +42,7 @@ Furthermore CL clients apis and code path will become cleaner and more maintaina
 - `ExecutionPayload` in the `BeaconBlockBody` is replaced by `ExecutionPayloadHeader`
 - `ExecutionPayloadWithInclusionProof` is computed by the block proposer/builder and gossiped independently on a separate new topic. Also builder `submitBlindedBlock` api is modified to respond with `ExecutionPayloadWithInclusionProof` instead.
 - Data availability checks for block import into forkchoice now must wait for availability of the corresponding `ExecutionPayloadWithInclusionProof` but only for gossiped blocks
-- `newPayloadHeader` engine api is introduced to augment the previous usage of `newPayload` in block processing when `ExecutionPayload` is not available for e.g. in processing range synced blocks signalling EL clients to optimistic sync those payloads from EL p2p network.
+- `newPayloadHeader` engine api is introduced to augment the previous usage of `newPayload` in block processing when `ExecutionPayload` is not available for e.g. in processing range synced blocks signaling EL clients to optimistic sync those payloads from EL p2p network.
 
 ELs can optionally introduce a `getExecutionPayload` method (similar to `getBlobs`) to assist with faster recovery of execution payload from the EL's p2p network peers who could announce new payload hashes when they see new `VALID` payloads. However, as noted above, that mechanism could be independently specified and is out of scope for this EIP.
 
@@ -50,7 +50,7 @@ ELs can optionally introduce a `getExecutionPayload` method (similar to `getBlob
 
 ## Rationale
 
-There is another choice we could have made to go for `SignedExecutionPayload` instead of `ExecutionPayloadWithInclusionProof` and having a `SignedExecutionPayloadHeader` with builder signing these messages (validator is the builder in local block building). But without builder enshrinment tight gossip validation of `SignedExecutionPayload` would be an issue and could become a DOS vector.
+There is another choice we could have made to go for `SignedExecutionPayload` instead of `ExecutionPayloadWithInclusionProof` and having a `SignedExecutionPayloadHeader` with builder signing these messages (validator is the builder in local block building). But without builder enshrinement tight gossip validation of `SignedExecutionPayload` would be an issue and could become a DOS vector.
 
 The benefit of `SignedExecutionPayload` design is that it could be transmitted ahead of even the `SignedExecutionPayloadHeader` inclusion in beacon block and is especially usedful in PBS pipeline where the proposal to builder/relay latency can be reduced significantly.
 


### PR DESCRIPTION
- Corrected verb form ("embed" → "embeds")
- Standardized spelling ("signalling" → "signaling")
- Fixed typo ("enshrinment" → "enshrinement")
