### PR TITLE
Update EIP-1702: fix typos

### DIFF
--- a/EIPS/eip-1702.md
+++ b/EIPS/eip-1702.md
@@ -87,7 +87,7 @@ is empty.
 
 ### Validation
 
-A new phrase, *validation* is added to contract deployment (by
+A new phase, *validation* is added to contract deployment (by
 `CREATE` / `CREATE2` opcodes, or by contract creation
 transaction). When `version` is `0`, the phrase does nothing and
 always succeeds. Future VM versions can define additional validation
@@ -187,7 +187,7 @@ state. The design above gets account versioning by making the contract
 needed to be provided by contract creation transaction, and there is
 no restrictions on formats of code for any version. If we want to
 support multiple newest VMs (for example, EVM and WebAssembly running
-together), then this will requires extensions such as 44-VERTXN and
+together), then this will require extensions such as 44-VERTXN and
 45-VEROP.
 
 Alternatively, account versioning can also be done through:
@@ -214,7 +214,7 @@ change how current contracts are executed.
 
 ### Performance
 
-Currently nearly all full node implementations uses config parameters
+Currently nearly all full node implementations use config parameters
 to decide which virtual machine version to use. Switching virtual
 machine version is simply an operation that changes a pointer using a
 different set of config parameters. As a result, this scheme has


### PR DESCRIPTION
Corrected "will requires" → "will require" in Account Versioning section

Corrected "implementations uses" → "implementations use" in Performance section