### PR TITLE
Update EIP-7807: fix typo

### DIFF
--- a/EIPS/eip-7807.md
+++ b/EIPS/eip-7807.md
@@ -84,7 +84,7 @@ For new blocks, the execution block hash is changed to be based on `hash_tree_ro
 
 Usages of `ExecutionPayloadHeader` are replaced with `ExecutionBlockHeader`.
 
-Usages of `ExecutionPayload` are updated to share `hash_tree_root` with `ExxecutionBlockHeader`. `transactions_root`, `withdrawals_root` and `requests_root` are expanded to their full list contents.
+Usages of `ExecutionPayload` are updated to share `hash_tree_root` with `ExecutionBlockHeader`. `transactions_root`, `withdrawals_root` and `requests_root` are expanded to their full list contents.
 
 ```python
 class ExecutionPayload(


### PR DESCRIPTION
fix `ExxecutionBlockHeader` to `ExecutionBlockHeader`

(two xx)