### PR TITLE
Update EIP-7636: fix typos in EIP-7636

### DIFF
--- a/EIPS/eip-7636.md
+++ b/EIPS/eip-7636.md
@@ -66,13 +66,13 @@ and an ENR of
 enr:-MO4QBn4OF-y-dqULg4WOIlc8gQAt-arldNFe0_YQ4HNX28jDtg41xjDyKfCXGfZaPN97I-MCfogeK91TyqmWTpb0_AChmNsaWVudNqKTmV0aGVybWluZIYxLjkuNTOHN2ZjYjU2N4JpZIJ2NIJpcIR_AAABg2lwNpAAAAAAAAAAAAAAAAAAAAABiXNlY3AyNTZrMaECn-TTdCwfZP4XgJyq8Lxoj-SgEoIFgDLVBEUqQk4HnAqDdWRwgiMshHVkcDaCIyw
 ```
 
-which can be decoded to yield normal data such as `seq`, `siqnature`, `id` and `secp256k1`. Additionally, it would yield the client value of `["0x4e65746865726d696e64","0x312e392e3533","0x37666362353637"]` or `["Nethermind", "1.9.53", "7fcb567"]`
+which can be decoded to yield normal data such as `seq`, `signature`, `id` and `secp256k1`. Additionally, it would yield the client value of `["0x4e65746865726d696e64","0x312e392e3533","0x37666362353637"]` or `["Nethermind", "1.9.53", "7fcb567"]`
 
 ## Security Considerations
 
 Introducing identifiable client information could potentially be used for targeted attacks against specific versions or builds known to have vulnerabilities. It is crucial for clients implementing this EIP to consider the implications of disclosing their identity and version. Users or operators should have the ability to opt-out or anonymize this information if desired.
 
-Additionally, as this information is self proclaimed, this data ***MUST NOT*** be used for anything that requires it to be reliable.
+Additionally, as this information is self-proclaimed, this data ***MUST NOT*** be used for anything that requires it to be reliable.
 
 ## Copyright
 


### PR DESCRIPTION

Fixes two typos in `EIPS/eip-7636.md`:
- `siqnature` → `signature` 
- `self proclaimed` → `self-proclaimed` 

