### PR TITLE
Update EIP-7932: fix typo and remove unnecessary whitespace

### DIFF
--- a/EIPS/eip-7932.md
+++ b/EIPS/eip-7932.md
@@ -46,7 +46,7 @@ If not explicitly noted, integer encoding is always big-endian.
 ### Algorithmic Transaction
 
 
-New  Profile definitions are introduced to represent native SSZ transactions:
+New Profile definitions are introduced to represent native SSZ transactions:
 
 This EIP introduces a new [EIP-7495](./eip-7495.md) transaction profile of SSZ type `AlgorithmicTransaction` defined below:
 
@@ -225,7 +225,7 @@ def sigrecover_precompile(input: Bytes) -> Bytes:
 
 ### Opaque `signature_info` type
 
-As each algorithm has unique properties, i.e. signature recovery and key sizes, a object is needed to hold every permutation of every possible key and signature. A bytearray of dynamic size would be able to achieve this goal, this does lead to a DoS vector which the [Gas penalties](#gas-penalties) section solves along with the `MAX_SIZE` parameter.
+As each algorithm has unique properties, i.e. signature recovery and key sizes, an object is needed to hold every permutation of every possible key and signature. A bytearray of dynamic size would be able to achieve this goal, this does lead to a DoS vector which the [Gas penalties](#gas-penalties) section solves along with the `MAX_SIZE` parameter.
 
 ### Gas penalties
 


### PR DESCRIPTION
a object -> an object
New  Profile definitions -> New Profile definitions ( remove whitespace between New and Profile )