### PR TITLE
Update EIP-7807: correct grammar in Engine API section

### DIFF
--- a/EIPS/eip-7807.md
+++ b/EIPS/eip-7807.md
@@ -119,7 +119,7 @@ This transition completes the transition to SSZ for everything except the execut
   - The CL would insert the extra logs for minting ([EIP-7799](./eip-7799.md)) and could fetch the ones relevant for withdrawing (deposits, requests, consolidations). That mechanism would be more generic than [EIP-7685](./eip-7685.md) and would drop requiring the EL to special case requests, including `compute_requests_hash`.
   - For client applications and smart contracts, it would streamline transaction history verification based on [EIP-7792](./eip-7792.md).
 
-- Engine API should be updated with (1) possible withdrawals/requests refactoring as above, (2) dropping the `block_hash` field so that `ExecutionPayload` is replaced with to `ExecutionBlockHeader`, (3) binary encoding based on `ForkDigest`-context (through HTTP header or interleaved, similar to beacon-API). This reduces encoding overhead and also simplifies sharing data structures in combined CL/EL in-process implementations.
+- Engine API should be updated with (1) possible withdrawals/requests refactoring as above, (2) dropping the `block_hash` field so that `ExecutionPayload` is replaced with `ExecutionBlockHeader`, (3) binary encoding based on `ForkDigest`-context (through HTTP header or interleaved, similar to beacon-API). This reduces encoding overhead and also simplifies sharing data structures in combined CL/EL in-process implementations.
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
Unnecessary 'to'
replaced with `ExecutionBlockHeader` - correct