### PR TITLE
Update EIP-7880: fix typos in EIP-7880

### DIFF
--- a/EIPS/eip-7880.md
+++ b/EIPS/eip-7880.md
@@ -21,9 +21,9 @@ EOFv1 as scoped in [EIP-7692] removes code introspection capabilities from the E
 
 One example is a managed proxy contract. Such a contract may want to ensure security by not allowing the proxy to be updated to a delegated address. There are also safety concerns with pointing to a delegation, as the contract may be updated to non EOF code and `EXTDELEGATECALL` will no longer be able to call the contract, due to changes outside the control of the managed proxy contract.
 
-Another example are contracts that need to ensure that the delegation has not changed over a limited scope of time, such as sponsorships. This will prevent a transaction from receiving gas sponsorship, changing the delegation, and performing an act different than what was approved. Sponsors can encode the delegation into the transaction data and verify wih this instruction.
+Another example are contracts that need to ensure that the delegation has not changed over a limited scope of time, such as sponsorships. This will prevent a transaction from receiving gas sponsorship, changing the delegation, and performing an act different than what was approved. Sponsors can encode the delegation into the transaction data and verify with this instruction.
 
-Finally, there is the case where contracts may want to de-escalate risks and only accept a small number of delegations for any given contract. To enable this validation contracts will need to be able to resolve the actual address of delegtion, not just know that one exists.
+Finally, there is the case where contracts may want to de-escalate risks and only accept a small number of delegations for any given contract. To enable this validation contracts will need to be able to resolve the actual address of delegation, not just know that one exists.
 
 To address this the essential task of the designation parsing is moved into a new opcode `EXTCODEADDRESS`, where the task of calculating the delegated address will be performed. For non-delegated accounts or empty accounts the address will be the same as the queried address.
 


### PR DESCRIPTION
**Fixes two typos in EIPS/eip-7880.md:**

`wih` → `with`
`delegtion` → `delegation`