### PR TITLE
Update EIP-7877: fix typos in EIP-7877

### DIFF
--- a/EIPS/eip-7877.md
+++ b/EIPS/eip-7877.md
@@ -21,7 +21,7 @@ instead of defaulting to returning from memory.
 With the introduction of transient storage, many smart contracts have begun to store data using the new transient opcodes to optimize for gas usage, whereby a callback
 involves returning the data previously stored transiently. However, the current `RETURN` opcode only allows for returning sequential bytes in memory. This requires
 developers to incur additional gas overhead by manually writing data from transient storage to memory before returning,
-incuring both an additional memory expansion and opcode cost from complicated for-loops. Similar
+incurring both an additional memory expansion and opcode cost from complicated for-loops. Similar
 inefficiencies already occur when attempting to return data already placed in storage. This EIP attempts to rectify
 this by allowing developers to optimize their code by deciding where to return data from directly, instead of requiring
 the intermediate step of first copying the data to memory.
@@ -38,7 +38,7 @@ RRETURN (0xf8)
 RETURN -> MRETURN (0xf3)
 ```
 
-The `MRETURN` opcode is a rename of `RETURN`, whereby sequential bytes in memory are returned. It will operate exactly as it currenty does as of the Cancun hard-fork, and its gas cost will remain the same.
+The `MRETURN` opcode is a rename of `RETURN`, whereby sequential bytes in memory are returned. It will operate exactly as it currently does as of the Cancun hard-fork, and its gas cost will remain the same.
 
 `RRETURN` operates similar to `MRETURN`. It pops two items off the stack, an offset to begin reading bytes from in the
 existing `RETURNDATA` buffer, and a number of bytes to return. Those bytes are used to overwrite the existing `RETURNDATA` buffer and then a return to the previous function is performed.


### PR DESCRIPTION
## Summary
Fixes two spelling errors in EIP-7877 documentation:
 `incuring` → `incurring` 
`currenty` → `currently`




