### PR TITLE
eip-4762: don't charge gas in syscalls

### DIFF
--- a/EIPS/eip-4762.md
+++ b/EIPS/eip-4762.md
@@ -41,8 +41,8 @@ Whenever the state is read, one or more of the access events of the form`(addres
 
 When:
 
- 1. a non-precompile which is also not a system contract is the target of a `*CALL`, `CALLCODE`, `SELFDESTRUCT`, `EXTCODESIZE`, or `EXTCODECOPY` opcode,
- 2. a non-precompile which is also not a system contract is the target address of a contract creation whose initcode starts execution,
+ 1. a non-precompile is the target of a `*CALL`, `CALLCODE`, `SELFDESTRUCT`, `EXTCODESIZE`, or `EXTCODECOPY` opcode,
+ 2. a non-precompile is the target address of a contract creation whose initcode starts execution,
  3. any address is the target of the `BALANCE` opcode
  4. a _deployed_ contract calls `CODECOPY`
 
@@ -52,7 +52,7 @@ process this access event:
 (address, 0, BASIC_DATA_LEAF_KEY)
 ```
 
-Note: a non-value-bearing `SELFDESTRUCT`, `*CALL` or `CALLCODE`, targeting a precompile or a system contract, will not cause the `BASIC_DATA_LEAF_KEY` to be added to the witness.
+Note: a non-value-bearing `SELFDESTRUCT`, `*CALL` or `CALLCODE`, targeting a precompile, will not cause the `BASIC_DATA_LEAF_KEY` to be added to the witness. Similarly, system calls will not add the basic data leaf to the witness.
 
 If a `*CALL`, `CALLCODE` or `SELFDESTRUCT` is value-bearing (ie. it transfers nonzero wei), whether or not the `callee` is a precompile or a system contract, process this additional access event:
 
@@ -68,7 +68,7 @@ When calling `EXTCODEHASH`, process the access event:
 (address, 0, CODEHASH_LEAF_KEY)
 ```
 
-Note that precompiles and system contracts are excluded, as their hashes are known to the client.
+Note that precompiles are excluded, as their hashes are known to the client.
 
 When a contract is created, process these access events:
 
@@ -249,7 +249,7 @@ are warm at the start of a transaction.
 
 ### System contracts
 
-When (and only when) calling a system contract either
+When (and only when) calling a system contract, either:
 
  * _via a system call_ or
  * _to resolve a precompile/opcode_,


### PR DESCRIPTION
This is the result of [a discussion with Felix during the Stateless Implementer's Call #38](https://stateless.fyi/development/sic-calls/history.html#2-eip-4762-witness-addition-rules): we decided to simplify the rules by saying that any access occurring during a syscall will not add anything to the witness.