### PR TITLE
Update EIP-7981: increase the data cost for ALs

### DIFF
--- a/EIPS/eip-7981.md
+++ b/EIPS/eip-7981.md
@@ -13,7 +13,7 @@ requires: 2930
 
 ## Abstract
 
-This EIP charges access lists 16 gas per byte for their data footprint, closing a loophole that allows circumventing [EIP-7623](./eip-7623.md) floor pricing.
+This EIP charges access lists 40 gas per non-zero byte and 10 gas per zero byte for their data footprint, closing a loophole that allows circumventing [EIP-7623](./eip-7623.md) floor pricing.
 
 ## Motivation
 
@@ -21,13 +21,14 @@ Access lists can circumvent [EIP-7623](./eip-7623.md) by filling blocks with unc
 
 ## Specification
 
-| Parameter                              | Value |
-| -------------------------------------- | ----- |
-| `ACCESS_LIST_ADDRESS_COST`            | `2400` |
-| `ACCESS_LIST_STORAGE_KEY_COST`        | `1900` |
-| `ACCESS_LIST_DATA_COST_PER_BYTE`      | `16`   |
+| Parameter                              | Value | Source |
+| -------------------------------------- | ----- | ------ |
+| `ACCESS_LIST_ADDRESS_COST`            | `2400` | [EIP-2930](./eip-2930.md) |
+| `ACCESS_LIST_STORAGE_KEY_COST`        | `1900` | [EIP-2930](./eip-2930.md) |
+| `ACCESS_LIST_NONZERO_BYTE_COST`       | `40`   | **New in this EIP** |
+| `ACCESS_LIST_ZERO_BYTE_COST`          | `10`   | **New in this EIP** |
 
-Let `access_list_data_bytes = access_list_addresses * 20 + access_list_storage_keys * 32`.
+Let `access_list_nonzero_bytes` and `access_list_zero_bytes` be the count of non-zero and zero bytes respectively in the serialized access list data (addresses and storage keys).
 
 
 The current formula for access list costs in [EIP-2930](./eip-2930.md) is:
@@ -49,22 +50,25 @@ standard_access_list_cost = (
 )
 
 # Additional data cost for access list bytes
-access_list_data_cost = ACCESS_LIST_DATA_COST_PER_BYTE * access_list_data_bytes
+access_list_data_cost = (
+    ACCESS_LIST_NONZERO_BYTE_COST * access_list_nonzero_bytes
+    + ACCESS_LIST_ZERO_BYTE_COST * access_list_zero_bytes
+)
 
 # Total access list cost
 access_list_cost = standard_access_list_cost + access_list_data_cost
 ```
 
-Transactions pay both the existing [EIP-2930](./eip-2930.md) functionality costs plus 16 gas per byte for data.
+Transactions pay both the existing [EIP-2930](./eip-2930.md) functionality costs plus 40 gas per non-zero byte and 10 gas per zero byte for data.
 
 ## Rationale
 
-Adding 16 gas per byte ensures consistent pricing across all transaction data:
+Adding 40 gas per non-zero byte and 10 gas per zero byte ensures consistent pricing across all transaction data:
 
-- Address: 2720 gas (2400 + 320)
-- Storage key: 2412 gas (1900 + 512)
+- Address (20 bytes, typically mostly non-zero): ~3200 gas (2400 + 800 assuming all non-zero)
+- Storage key (32 bytes, typically mostly non-zero): ~3180 gas (1900 + 1280 assuming all non-zero)
 
-No threshold mechanism is used. The 16 gas per byte is always applied to maintain simplicity and prevent circumvention.
+No threshold mechanism is used. The per-byte costs are always applied to maintain simplicity and prevent circumvention.
 
 The additional cost makes EIP-2930 access lists economically irrational for gas optimization, effectively deprecating their use while maintaining compatibility.
 
@@ -74,9 +78,9 @@ Current pricing with 36M gas limit:
 
 - 1 address + 18,946 storage keys: 2400 + (18,946 × 1900) = 36,000,100 gas (~607 KB)
 
-With data pricing:
+With data pricing (assuming all non-zero bytes):
 
-- 1 address + 14,924 storage keys: 2720 + (14,924 × 2412) = 36,000,688 gas (~478 KB)
+- 1 address + 11,302 storage keys: 3200 + (11,302 × 3180) = 35,943,560 gas (~362 KB)
 
 ## Backwards Compatibility
 
@@ -89,27 +93,27 @@ Requires updates to gas estimation in wallets and nodes. Normal usage patterns r
 
 ### Case 1: Normal Transaction
 
-- Addresses: 5
-- Storage keys: 10  
+- Addresses: 5 (100 bytes, assume all non-zero)
+- Storage keys: 10 (320 bytes, assume all non-zero)
 - Old cost: 5 × 2400 + 10 × 1900 = 31,000 gas
-- New cost: 5 × 2720 + 10 × 2412 = 37,720 gas
-- Additional cost: 6,720 gas (21.7% increase)
+- New cost: 5 × 3200 + 10 × 3180 = 47,800 gas
+- Additional cost: 16,800 gas (54.2% increase)
 
 ### Case 2: Large Access List Transaction
 
-- Addresses: 1000
+- Addresses: 1000 (20,000 bytes, assume all non-zero)
 - Storage keys: 0
 - Old cost: 1000 × 2400 = 2,400,000 gas
-- New cost: 1000 × 2720 = 2,720,000 gas  
-- Additional cost: 320,000 gas (13.3% increase)
+- New cost: 1000 × 3200 = 3,200,000 gas  
+- Additional cost: 800,000 gas (33.3% increase)
 
 ### Case 3: Combined Access List + Calldata
 
-- Addresses: 500
+- Addresses: 500 (10,000 bytes, assume all non-zero)
 - Calldata: 5,000 bytes
 - Old access list cost: 500 × 2400 = 1,200,000 gas
 - Old calldata cost: 5,000 × 4 = 20,000 gas (standard rate, avoiding floor)
-- New access list cost: 500 × 2720 = 1,360,000 gas
+- New access list cost: 500 × 3200 = 1,600,000 gas
 - New calldata cost: Applied through [EIP-7623](./eip-7623.md) mechanism
 - Result: Can no longer circumvent [EIP-7623](./eip-7623.md) floor pricing
 


### PR DESCRIPTION
This aligns the eip with the 7623 floor price for calldata.