### PR TITLE
Update eip-3584: fix article in spec text

### DIFF
--- a/EIPS/eip-3584.md
+++ b/EIPS/eip-3584.md
@@ -112,7 +112,7 @@ access_list := Set[
     Set  [ AccessedInBlockTransactionNumber, List [ AccessedStorageKeys ] ]
 ]
 ```
-and then get to define the a canonical specification for building the fingerprint.
+and then get to define a canonical specification for building the fingerprint.
 This will allow an incremental path to partial or full statelessness, where it would be easy to bundle/request **witnesses** using this `access_list`.
 
 ## Backwards Compatibility


### PR DESCRIPTION
then get to define the a canonical specification for building the fingerprint. ->
then get to define a canonical specification for building the fingerprint.