### PR TITLE
Add EIP: Builder generalized consolidation requests

### DIFF
--- a/EIPS/eip-8014.md
+++ b/EIPS/eip-8014.md
@@ -1,19 +1,19 @@
 ---
-eip: 99999
-title: Builder generalized consolidation requests.
+eip: 8014
+title: Builder generalized consolidation requests
 description: Adds a new generalized consolidation requests to create builders.
 author: Potuz (@potuz)
-discussions-to: https://ethereum-magicians.org/t/eip-99999-generalized-consolidation-requests/11111
+discussions-to: https://ethereum-magicians.org/t/eip-8014-builder-generalized-consolidation-requests/25265
 status: Draft
 type: Standards Track
 category: Core
 created: 2025-08-22
-requires: 7732, 9999
+requires: 7732, 8012
 ---
 
 ## Abstract
 
-This EIP adds a new [EIP-9999](./EIP/9999.md)-type generalized consolidation request allowing any active validator to become a builder.
+This EIP adds a new [EIP-8012](./EIP/eip-8012.md)-type generalized consolidation request allowing any active validator to become a builder.
 
 ## Motivation
 
@@ -35,7 +35,7 @@ No changes are expected.
 
 ### Consensus Layer
 
-This EIP adds a new handler for the [EIP-9999](./eip-9999.md) type generalized consolidation request, with `CALL_TYPE` of value `BUILDER_CONSOLIDATION_CALL_NUMBER`. and `ARG_NUMBER` of value `0`. The consensus layer, after verifying that the `target_pubkey` field of the respective `ConsolidationRequest` object conforms to EIP-9999 and having validated the correct signature by the execution withdrawal credentials for the validator with `source_pubkey`, converts the withdrawal prefix of said validator to a `BUILDER_WITHDRAWAL_PREFIX`.
+This EIP adds a new handler for the [EIP-8012](./eip-8012.md) type generalized consolidation request, with `CALL_TYPE` of value `BUILDER_CONSOLIDATION_CALL_NUMBER`. and `ARG_NUMBER` of value `0`. The consensus layer, after verifying that the `target_pubkey` field of the respective `ConsolidationRequest` object conforms to EIP-9999 and having validated the correct signature by the execution withdrawal credentials for the validator with `source_pubkey`, converts the withdrawal prefix of said validator to a `BUILDER_WITHDRAWAL_PREFIX`.
 
 ### Engine API
 

--- a/EIPS/eip-99999.md
+++ b/EIPS/eip-99999.md
@@ -1,0 +1,57 @@
+---
+eip: 99999
+title: Builder generalized consolidation requests.
+description: Adds a new generalized consolidation requests to create builders.
+author: Potuz (@potuz)
+discussions-to: https://ethereum-magicians.org/t/eip-99999-generalized-consolidation-requests/11111
+status: Draft
+type: Standards Track
+category: Core
+created: 2025-08-22
+requires: 7732, 9999
+---
+
+## Abstract
+
+This EIP adds a new [EIP-9999](./EIP/9999.md)-type generalized consolidation request allowing any active validator to become a builder.
+
+## Motivation
+
+[EIP-7732](./eip-7732.md) introduces new validator attributions in the consensus layer. Validators whose withdrawal credentials start with a `BUILDER_WITHDRAWAL_PREFIX` are allowed to build execution payloads to be included in other validators proposed beacon blocks. Without this EIP, any active validator that whishes to become a builder would have to withdraw their validator and redeposit with the new withdrawal credential. This EIP allows any active validator with execution withdrawal credentials to be able to convert their validator to a builder.
+
+## Specification
+
+### Constants
+
+#### Consensus Layer
+
+| Name | Value |
+| - | - |
+| `BUILDER_CONSOLIDATION_CALL_NUMBER` | `uint32(3)` |
+
+### Execution Layer
+
+No changes are expected.
+
+### Consensus Layer
+
+This EIP adds a new handler for the [EIP-9999](./eip-9999.md) type generalized consolidation request, with `CALL_TYPE` of value `BUILDER_CONSOLIDATION_CALL_NUMBER`. and `ARG_NUMBER` of value `0`. The consensus layer, after verifying that the `target_pubkey` field of the respective `ConsolidationRequest` object conforms to EIP-9999 and having validated the correct signature by the execution withdrawal credentials for the validator with `source_pubkey`, converts the withdrawal prefix of said validator to a `BUILDER_WITHDRAWAL_PREFIX`.
+
+### Engine API
+
+No changes needed.
+
+## Rationale
+This EIP enables any active validator to become a builder without affecting neither the withdrawal/exit queue nor the deposit queue. Allowing thus for a better user experience and strengthening the decentralization of the builder market.
+
+## Security Considerations
+
+No known security impacts.
+
+### Backwards compatibility
+
+This EIP introduces backward incompatible changes to the block validation rule set on the consensus layer and must be accompanied by a hard fork.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](../LICENSE.md).


### PR DESCRIPTION
This EIP adds a generalized consolidation type as specified in https://github.com/ethereum/EIPs/pull/10218 to handle active validators becoming builders as per EIP-7732. 

The consensus counterpart is in https://github.com/ethereum/consensus-specs/pull/4522