### PR TITLE
CI: correct typo in CI workflow job name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
           skip: .git,Gemfile.lock,**/*.png,**/*.gif,**/*.jpg,**/*.svg,.codespell-whitelist,vendor,_site,_config.yml,style.css
 
   eipw-validator:
-    name: EIP Walidator
+    name: EIP Validator
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Fix typo "EIP Walidator" to "EIP Validator" in the eipw-validator job name in the continuous integration workflow. This improves the professional appearance of the CI pipeline without affecting any functionality.