### PR TITLE
fix: correct RFC reference from 8170 to 8174 in eip-template.md

### DIFF
--- a/eip-template.md
+++ b/eip-template.md
@@ -47,7 +47,7 @@ requires: <EIP number(s)> # Only required when you reference an EIP in the `Spec
 <!--
   The Specification section should describe the syntax and semantics of any new feature. The specification should be detailed enough to allow competing, interoperable implementations for any of the current Ethereum platforms (besu, erigon, ethereumjs, go-ethereum, nethermind, or others).
 
-  It is recommended to follow RFC 2119 and RFC 8170. Do not remove the key word definitions if RFC 2119 and RFC 8170 are followed.
+  It is recommended to follow RFC 2119 and RFC 8174. Do not remove the key word definitions if RFC 2119 and RFC 8174 are followed.
 
   TODO: Remove this comment before submitting
 -->


### PR DESCRIPTION
- Change RFC 8170 to RFC 8174 in the Specification section comment
- Aligns template with EIP-1 specification and existing EIP documents
- RFC 8174 is the correct standard for terminology alongside RFC 2119
- All existing EIPs use RFC 8174, making this consistent with the codebase