### PR TITLE
fix typo

### DIFF
--- a/EIPS/eip-7834.md
+++ b/EIPS/eip-7834.md
@@ -71,7 +71,7 @@ types_section := (inputs, outputs, max_stack_height)+
 | metadata_section | variable | n/a   | arbitrary sequence of bytes |
 | data_section     | variable | n/a   | arbitrary sequence of bytes |
 
-The strucure and the encoding of the `metadata_section` is not defined by this EIP. It is left to the compilers, tooling, or the contract developers to define the encoding and the content. The current practice by the Solidity and Vyper compilers is to use CBOR encoding.
+The structure and the encoding of the `metadata_section` is not defined by this EIP. It is left to the compilers, tooling, or the contract developers to define the encoding and the content. The current practice by the Solidity and Vyper compilers is to use CBOR encoding.
 
 ## Rationale
 


### PR DESCRIPTION

Fixed a typo in the EIP-7834 specification document where `strucure` was incorrectly spelled instead of `structure`

- Corrected `strucure` to `structure` in the Body section description

