### PR TITLE
Update EIP-7823: Move to Review

### DIFF
--- a/EIPS/eip-7823.md
+++ b/EIPS/eip-7823.md
@@ -4,7 +4,7 @@ title: Set upper bounds for MODEXP
 description: Each input field is restricted to a maximum of 8192 bits
 author: Alex Beregszaszi (@axic), Radoslaw Zagorowicz (@rodiazet)
 discussions-to: https://ethereum-magicians.org/t/eip-7823-set-upper-bounds-for-modexp/21798
-status: Final
+status: Review
 type: Standards Track
 category: Core
 created: 2024-11-11


### PR DESCRIPTION
EIP-7823 (upper bounds for modexp) had been moved to `stagnant` by bot in #10086, changing over from `review` status:

---

<img width="894" height="506" alt="grafik" src="https://github.com/user-attachments/assets/b10afa4b-e7c0-4c59-a5a6-64585ba9577d" />

---

This was likely accidentally following the respective rules from EIP-1:

> Stagnant - Any EIP in Draft or Review or Last Call if inactive for a period of 6 months or greater is moved to Stagnant. An EIP may be resurrected from this state by Authors or EIP Editors through moving it back to Draft or its earlier status. If not resurrected, a proposal may stay forever in this status.

---

This is irritating, given that the EIP is scheduled for Fusaka. ~Can we take the occasion and move to `Final`?~

As mentioned below, I have downscaled this to simply move back to `Review` for easy merge.
