### PR TITLE
Update EIP-7864: fix typo in EIP-7864

### DIFF
--- a/EIPS/eip-7864.md
+++ b/EIPS/eip-7864.md
@@ -30,7 +30,7 @@ Apart from requiring a state tree design that is friendly for block validity pro
 
 Regarding these regular Merkle proofs in an MPT, since it's a hexary tree, their size is quite big on average and in worst-case scenarios. Given a 2^32 size tree, the expected size for proving a single branch is `15 * 32 * log_16(2^32) = 3840`. From a worst-case block perspective, if 30M gas is used to access only a single byte of different account codes since this code isn't chunkified, we'd need `30M/2400*(5*480+24k)=330MB`.
 
-A binary tree has a good balance between out-of-circuit and in-circuit proving. Since the tree arity is two, this reduces the size of regular Merkle proofs (i.e., `# sibilings * log_arity(N)` for arity 2 is better than for arity 16). Moreover, we propose switching from Keccak to a more proving-friendly hash function, which would be more amenable to modern proving systems.
+A binary tree has a good balance between out-of-circuit and in-circuit proving. Since the tree arity is two, this reduces the size of regular Merkle proofs (i.e., `# siblings * log_arity(N)` for arity 2 is better than for arity 16). Moreover, we propose switching from Keccak to a more proving-friendly hash function, which would be more amenable to modern proving systems.
 
 ## Specification
 


### PR DESCRIPTION

Fixes a typo in the Merkle proofs explanation section.

`sibilings` → `siblings`

