### PR TITLE
Update EIP-4760: fix typo in EIP-4760

### DIFF
--- a/EIPS/eip-4760.md
+++ b/EIPS/eip-4760.md
@@ -57,8 +57,8 @@ The following applications of `SELFDESTRUCT` will be broken and applications tha
 1. Any use where `SELFDESTRUCT` is used to burn non-ETH token balances, such as ERC20, inside a contract. We do not know of any such use (since it can easily be done by sending to a burn address this seems an unlikely way to use `SELFDESTRUCT`)
 2. Where `CREATE2` is used to redeploy a contract in the same place. There are two ways in which this can fail:
 
-    - The destruction prevents the contract from being used outside of a certain context. For example, the contract allows anyone to withdraw funds, but `SELFDESTRUCT` is used at the end of an operation to prevent others from doing this. This type of operation can easily be modified to not depend on `SELFDESTRUCT`.
-    - The `SELFDESTRUCT` operation is used in order to make a contract upgradable. This is not supported anymore and delegates should be used.
+    * The destruction prevents the contract from being used outside of a certain context. For example, the contract allows anyone to withdraw funds, but `SELFDESTRUCT` is used at the end of an operation to prevent others from doing this. This type of operation can easily be modified to not depend on `SELFDESTRUCT`.
+    * The `SELFDESTRUCT` operation is used in order to make a contract upgradable. This is not supported anymore and delegates should be used.
 
 ## Copyright
 


### PR DESCRIPTION
This pull request corrects a minor but important typo in `EIPS/eip-4760.md`.

**Changes:**
- Replaced all instances of the misspelled `SELFDESCRUCT` with the correct `SELFDESTRUCT` opcode name.