### PR TITLE
Update EIP-7736: complete incomplete comment of validation function

### DIFF
--- a/EIPS/eip-7736.md
+++ b/EIPS/eip-7736.md
@@ -125,7 +125,7 @@ def validate_subtrees(tree, tx, current_epoch) -> bool:
 
 def validate_subtree(tree, stem, values, last_epoch, current_epoch) -> bool:
     # Compute the commitment to the expired
-    # tree, get the 
+    # tree, get the keepsake
     expired_C = extension_and_suffix_tree(stem, values, last_epoch)
     expired = tree.get_keepsake(stem)
     if keepsake.C != expired_C:


### PR DESCRIPTION
Fix incomplete comment on line 95 in the validate_subtree function.
The comment now properly describes what the function is doing:
"Compute the commitment to the expired tree, get the keepsake"