### PR TITLE
Update EIP-7266: grammar tweak: “gone” → “went”

### DIFF
--- a/EIPS/eip-7266.md
+++ b/EIPS/eip-7266.md
@@ -19,7 +19,7 @@ This EIP removes the [`blake2f`](./eip-152.md) (`0x09`) precompile by changing t
 [EIP-152](./eip-152.md) has never capitalised on a real-world use case. This fact is clearly reflected in the number of times the address `0x09` has been invoked (numbers from the date this EIP was created):
 
 - The most recent call took place on 6 October 2022.
-- Since its gone live as part of the Istanbul network upgrade on December 7 2019 (block number 9,069,000), `0x09` has been called only 22,131 times.
+- Since its went live as part of the Istanbul network upgrade on December 7 2019 (block number 9,069,000), `0x09` has been called only 22,131 times.
 
 One of the reasons why [EIP-152](./eip-152.md) has failed is that the envisioned use cases were not validated before inclusion.
 


### PR DESCRIPTION
just fixed a tiny grammar slip in the network upgrade note.
changed *“gone live”* to *“went live”* after *“since”* so it reads correctly.