### PR TITLE
Update EIP-8012: fix typo in rationale section

### DIFF
--- a/EIPS/eip-8012.md
+++ b/EIPS/eip-8012.md
@@ -52,7 +52,7 @@ No changes needed.
 
 ## Rationale
 
-The proposed reinterpretation of the existing contract enables new implementations in the consensus layer without requireing a hard fork in the execution layer.
+The proposed reinterpretation of the existing contract enables new implementations in the consensus layer without requiring a hard fork in the execution layer.
 
 ## Backwards Compatibility
 


### PR DESCRIPTION


### Description
- Corrects a typo: `requireing` → `requiring` in `EIPS/eip-8012.md`.


