### PR TITLE
Update EIP-7773: PFI EIP-7778 Block Gas Accounting without Refunds

### DIFF
--- a/EIPS/eip-7773.md
+++ b/EIPS/eip-7773.md
@@ -51,6 +51,7 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Declined
 1. [EIP-7979](./eip-7979.md): Call and Return Opcodes for the EVM
 1. [EIP-7997](./eip-7997.md): Deterministic Factory Predeploy
 1. [EIP-7999](./eip-7999.md): Unified multidimensional fee market
+1. [EIP-7778](./eip-7778.md): Block Gas Accounting without Refunds
 
 ### Activation
 


### PR DESCRIPTION
This adds https://eips.ethereum.org/EIPS/eip-7778 to the PFId EIPs of Glamsterdam.

I believe the current mechanics of the refunds are bugged. We want to give people incentive to clean up state (the only refund we now give is setting nonzero storage values to zero, deleting them from the MPT thus cleaning up nodes). This is fine. But we do not want to discount this refund from the "execution gas", since this measures how much computation was used. If we cleanup space, we want to get some ETH back, but we do not want to also remove this from the execution gas, since the execution time has clearly been used and not sent to some void which rollbacks time :smile: :+1: 

CC @benaadams @nerolation