### PR TITLE
Update EIP-7864: fix grammar and spelling corrections

### DIFF
--- a/EIPS/eip-7864.md
+++ b/EIPS/eip-7864.md
@@ -34,7 +34,7 @@ A binary tree has a good balance between out-of-circuit and in-circuit proving. 
 
 ## Specification
 
-The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", https://ethereum-magicians.org/t/eip-8015-remove-legacy-deposit-and-eth1data-fields/25401"MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
+The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
 
 ### Notable changes from the hexary structure
 


### PR DESCRIPTION
- Corrected preposition `friendly for` to `friendly to`  
- Fixed awkward phrasing `allows to have in single stem branch`
- Added missing article `the usual` instead of `usual`
- Improved clarity of `same size range` to `same range of size` 
- Fixed plural form `experts estimations` to `expert estimations`
- Corrected verb form `suggests stop using` to `suggests stopping the use of`
- Added missing article and verb in `in middle of paths` and `might not worth it`
- Fixed preposition `field the StemNode` to `field to the StemNode`