### PR TITLE
Update EIP-7980: fix issues

### DIFF
--- a/EIPS/eip-7980.md
+++ b/EIPS/eip-7980.md
@@ -1,7 +1,7 @@
 ---
 eip: 7980
 title: Ed25519 transaction support
-description: Adds a EIP-7932 algorithm type for Ed25519 support of type `0x0`
+description: Adds an EIP-7932 algorithm type for Ed25519 support of type `0x0`
 author: James Kempton (@SirSpudlington)
 discussions-to: https://ethereum-magicians.org/t/eip-7980-adding-ed25519-as-a-signature-scheme-to-test-eip-7932/24663
 status: Draft
@@ -48,7 +48,7 @@ def verify(signature_info: bytes, payload_hash: Hash32) -> ExecutionAddress:
 
 ### Additional 1000 gas penalty
 
-The gas penalty discourages people attempting to migrate off current secp256k1 accounts, and also covers the additional overhead (in regards to hashing) that the ed25519 curve applies.
+The gas penalty discourages people from attempting to migrate off current secp256k1 accounts, and also covers the additional overhead (in regards to hashing) that the ed25519 curve applies.
 
 ### Why Ed25519?
 


### PR DESCRIPTION
Fix article usage: "Adds a EIP-7932" → "Adds an EIP-7932"
Add missing preposition: "discourages people attempting" → "discourages people from attempting"