### PR TITLE
Update EIP-7768: correct grammatical errors

### DIFF
--- a/EIPS/eip-7768.md
+++ b/EIPS/eip-7768.md
@@ -15,18 +15,18 @@ A technique is introduced where an externally-owned account having no Ether can 
 
 ## Motivation
 
-There is much interest in third-party-pay transactions on Ethereum and competing networks.
+There is much interest in third-party-paid transactions on Ethereum and competing networks.
 
 Other proposals require changes to the Ethereum client, that transactions be sent to the network (i.e. `tx.origin`) using a separate account and/or other additional things.
 
-In contrast, this proposal introduces and standardizes a solution to this problem that works only with existing client and technology, and which preserves the `tx.origin` of the originator of a transaction.
+In contrast, this proposal introduces and standardizes a solution to this problem that works only with existing clients and technologies, and which preserves the `tx.origin` of the originator of a transaction.
 
 ## Specification
 
 ### End user process
 
 1. An end user who controls an externally-owned account, say Alice, will prepare transaction(s) she would like to execute and she signs this (series of) transactions.
-2. If Alice will like to provide consideration for executing these transactions, she will ensure that a well-known address on the network, "the free-for-all bucket" will control tokens (such as 20, 721, 1155 tokens) at the end of her series of transactions.
+2. If Alice would like to provide consideration for executing these transactions, she will ensure that a well-known address on the network, "the free-for-all bucket" will control tokens (such as 20, 721, 1155 tokens) at the end of her series of transactions.
 3. Alice orders her transaction nonces carefully considering that what will eventually be executed may be:
    1. None of them;
    2. Only the first;
@@ -79,7 +79,7 @@ interface FreeForAll {
 
 This approach can be useful for end users who do not want to or are not able to add Ether to their account.
 
-This approach allows to use the correct `origin.tx` which may be required for important transactions like ERC-721 `setApprovalForAll`. 
+This approach allows using the correct `origin.tx` which may be required for important transactions like ERC-721 `setApprovalForAll`. 
 
 This approach may use more gas than other approaches where the consensus client is changed or where transactions can execute from (`origin.tx`) a different account.
 


### PR DESCRIPTION

* "third-party-pay" → "third-party-paid" transactions
* "existing client and technology" → "existing clients and technologies"  
* "will like" → "would like" in conditional clause
* "allows to use" → "allows using" proper infinitive construction