### PR TITLE
Update EIP-7898: fix missing articles

### DIFF
--- a/EIPS/eip-7898.md
+++ b/EIPS/eip-7898.md
@@ -12,7 +12,7 @@ created: 2025-03-01
 
 ## Abstract
 
-Currently, the beacon block in Ethereum Consensus embeds transactions within `ExecutionPayload` field of `BeaconBlockBody`. This EIP proposes to replace `ExecutionPayload` with `ExecutionPayloadHeader` in `BeaconBlockBody` and to independently transmit `ExecutionPayloadWithInclusionProof`.
+Currently, the beacon block in Ethereum Consensus embeds transactions within the `ExecutionPayload` field of `BeaconBlockBody`. This EIP proposes to replace `ExecutionPayload` with `ExecutionPayloadHeader` in `BeaconBlockBody` and to independently transmit `ExecutionPayloadWithInclusionProof`.
 
 However, this EIP makes no change to the block import mechanism, with the exception that block availability now includes waiting for the availability of `ExecutionPayloadWithInclusionProof`, making it different and simpler from proposals like ePBS/APS.
 
@@ -20,7 +20,7 @@ But this availability requirement can in fact be restricted to `gossip` import w
 
 ## Motivation
 
-Ethereum protocol has an ambitious goal to grow the `gasLimit` of the execution payloads (possibly by 10X). This leads to larger messages, negatively affecting the networking and block processing pipelines of the consensus layer (CL) clients leading to following issues:
+The Ethereum protocol has an ambitious goal to grow the `gasLimit` of the execution payloads (possibly by 10X). This leads to larger messages, negatively affecting the networking and block processing pipelines of the consensus layer (CL) clients leading to following issues:
 
 1. Higher latencies for the arrival of beacon blocks increase, requiring larger bandwidth resources to be made available for the beacon node.
 2. The greater number and size of transactions directly increase the merkelization compute time, increasing the import time of the block.


### PR DESCRIPTION
Added missing definite articles "the" and "The" to improve grammatical accuracy in the Abstract and Motivation sections of the EIP document