### PR TITLE
Update EIP-1051: correction

### DIFF
--- a/EIPS/eip-1051.md
+++ b/EIPS/eip-1051.md
@@ -25,12 +25,12 @@ The `ovf` flag is set in the following circumstances:
 
  - When an `ADD` (`0x01`) opcode, with both inputs treated as unsigned integers, produces an ideal output in excess of 2^256 - 1.
  - When a `SUB` (`0x03`) opcode, with both inputs treated as unsigned integers, produces an ideal output less than 0.
- - When a `MUL`(`0x02`) opcode, with both inputs treated as unsigned integers, produces an ideal output in excess of 2^256 - 1.
+ - When a `MUL` (`0x02`) opcode, with both inputs treated as unsigned integers, produces an ideal output in excess of 2^256 - 1.
 
 The `sovf` flag is set whenever the `ovf` flag is set, and additionally in the following circumstances:
 
  - When an `ADD` opcode with both inputs having the same MSB results in the output having a different MSB (eg, `(+a) + (+b) = (-c)` or `(-a) + (-b) = (+c)`).
- - When a `SUB` opcode occurs and the result has the same MSB as the subtracted (second argument) (eg, `(+a) - (-b) = (-c)` or `(-a) - (+b) = (+c)`.
+ - When a `SUB` opcode occurs and the result has the same MSB as the subtracted (second argument) (eg, `(+a) - (-b) = (-c)` or `(-a) - (+b) = (+c)`).
  - When a `MUL` opcode with both inputs being positive has a negative output.
  - When a `MUL` opcode with both inputs being negative has a negative output.
  - When a `MUL` opcode with one negative input and one positive input has a positive output.


### PR DESCRIPTION
Description:
- Add missing space between MUL and parenthesis in line 28
- Add missing closing parenthesis at end of example in line 33