### PR TITLE
Update EIP-6493: fix/correct field name in ExecutionSigningData constructor

### DIFF
--- a/EIPS/eip-6493.md
+++ b/EIPS/eip-6493.md
@@ -43,7 +43,7 @@ class ExecutionSigningData(Container):
 def compute_ssz_sig_hash(payload: TransactionPayload) -> Hash32:
     return Hash32(ExecutionSigningData(
         object_root=payload.hash_tree_root(),
-        domain=DOMAIN_TX_SSZ,
+        domain_type=DOMAIN_TX_SSZ,
     ).hash_tree_root())
 
 def compute_ssz_tx_hash(tx: Transaction) -> Hash32:


### PR DESCRIPTION
Fix incorrect parameter name 'domain' to match the struct field name 'domain_type' in compute_ssz_sig_hash function within EIP-6493 specification