### PR TITLE
docs: fix grammar

### DIFF
--- a/EIPS/eip-7840.md
+++ b/EIPS/eip-7840.md
@@ -1,7 +1,7 @@
 ---
 eip: 7840
 title: Add blob schedule to EL config files
-description: Include a per-fork blob parameters in client configuration files
+description: Include per-fork blob parameters in client configuration files
 author: lightclient (@lightclient)
 discussions-to: https://ethereum-magicians.org/t/add-blob-schedule-to-execution-client-configuration-files/22182
 status: Final


### PR DESCRIPTION
removed the extra "a" before "parameters" so it reads correctly: "Include per-fork blob parameters." 