### PR TITLE
Update EIP-7910: fix wording issues in `activationTime` and `forkId` sections

### DIFF
--- a/EIPS/eip-7910.md
+++ b/EIPS/eip-7910.md
@@ -63,7 +63,7 @@ Future forks may add, adjust, remove, or update members. The respective changes 
 
 The fork activation timestamp, represented as a JSON number in Unix epoch seconds (UTC). For the "current" configuration, this reflects the actual activation time; for "next" and "last", it is the scheduled time.
 
-Activation time is required. If a fork is activated at genesis the value `0` is used. If the fork is not scheduled to be activated or its activation time is unknown it should not be in the rpc results.
+Activation time is required. If a fork is activated at genesis the value `0` is used. If the fork is not scheduled to be activated or its activation time is unknown it should not be in the RPC results.
 
 #### `blobSchedule`
 
@@ -77,7 +77,7 @@ For purposes of canonicalization this value must always be a string.
 
 #### `forkId`
 
-The `FORK_HASH` value as specified in [EIP-6122](./eip-6122.md) of the specific fork, presented as an unsigned `0x`-prefixed hexadecimal numbers, with zeros left padded to a four byte length, in lower case.
+The `FORK_HASH` value as specified in [EIP-6122](./eip-6122.md) of the specific fork, presented as an unsigned `0x`-prefixed hexadecimal number, with zeros left padded to a four byte length, in lower case.
 
 #### `precompiles`
 


### PR DESCRIPTION
corrected a couple of minor wording issues:

* in the `activationTime` section, changed "rpc results" to "RPC results" for consistency.
* in the `forkId` section, corrected "numbers" to "number" to match the singular context.

these changes make the documentation more precise and clear.
