### PR TITLE
fix undefined variable `el` in Optional.value_byte_length() method

### DIFF
--- a/assets/eip-6475/optional.py
+++ b/assets/eip-6475/optional.py
@@ -67,7 +67,7 @@ class Optional(MonoSubtreeView):
             if elem_cls.is_fixed_byte_length():
                 return elem_cls.type_byte_length()
             else:
-                return cast(View, el).value_byte_length()
+                return cast(View, self.get(0)).value_byte_length()
 
     def get(self) -> PyOptional[View]:
         if self.length() == 0:


### PR DESCRIPTION
The variable `el` was undefined in the else branch of value_byte_length(). Replace it with `self.get(0)` to properly retrieve the Optional's value when length is non-zero.

This fixes a NameError that would occur when calling value_byte_length() on a non-empty Optional instance with variable-length elements.