### PR TITLE
Update EIP-1702: update broken link

### DIFF
--- a/EIPS/eip-1702.md
+++ b/EIPS/eip-1702.md
@@ -143,9 +143,9 @@ purpose. When "enabling EIP-1702", those extensions should not be
 enabled unless the extension specification is also included.
 
 * [44-VERTXN: Account Versioning Extension for Contract Creation
-  Transaction](https://specs.corepaper.org/44-vertxn/)
+  Transaction](https://corepaper.org/ethereum/compatibility/versioning/#extensions-for-state-based-account-versioning)
 * [45-VEROP: Account Versioning Extension for CREATE and
-  CREATE2](https://specs.corepaper.org/45-verop/)
+  CREATE2](https://corepaper.org/ethereum/compatibility/versioning/#create-and-create2-extension)
 
 ## Usage Template
 
@@ -192,7 +192,7 @@ together), then this will requires extensions such as 44-VERTXN and
 
 Alternatively, account versioning can also be done through:
 
-* **[26-VER](https://specs.corepaper.org/26-ver/)** and
+* **[26-VER](https://corepaper.org/ethereum/compatibility/versioning/#prefix-based-account-versioning)** and
   **[40-UNUSED](https://corepaper.org/ethereum/compatibility/forward/)**: This makes an
   account's versioning solely dependent on its code header prefix. If
   with only 26-VER, it is not possible to certify any code is valid,
@@ -234,7 +234,7 @@ To be added.
 ## References
 
 The source of this specification can be found at
-[43-VER](https://specs.corepaper.org/43-ver/).
+[43-VER](https://corepaper.org/ethereum/compatibility/versioning/#state-based-account-versioning).
 
 ## Copyright
 

--- a/EIPS/eip-1702.md
+++ b/EIPS/eip-1702.md
@@ -193,7 +193,7 @@ together), then this will requires extensions such as 44-VERTXN and
 Alternatively, account versioning can also be done through:
 
 * **[26-VER](https://specs.corepaper.org/26-ver/)** and
-  **[40-UNUSED](https://specs.corepaper.org/40-unused/)**: This makes an
+  **[40-UNUSED](https://corepaper.org/ethereum/compatibility/forward/)**: This makes an
   account's versioning solely dependent on its code header prefix. If
   with only 26-VER, it is not possible to certify any code is valid,
   because current VM allows treating code as data. This can be fixed


### PR DESCRIPTION
https://specs.corepaper.org/40-unused/ - broken
https://corepaper.org/ethereum/compatibility/forward/ - correct