### PR TITLE
Update EIP-7932: add missing return statement in sigrecover_precompile function

### DIFF
--- a/EIPS/eip-7932.md
+++ b/EIPS/eip-7932.md
@@ -223,7 +223,7 @@ def sigrecover_precompile(input: Bytes) -> Bytes:
 
   # Run verify function
   try:
-    alg.verify(input[64:64 + sig_length], hash)
+    return alg.verify(input[64:64 + sig_length], hash)
   except:
     return ExecutionAddress(0x0)
   


### PR DESCRIPTION
Without this return, the precompile fails to output the signer address on successful verification, breaking core functionality