### PR TITLE
Update EIP-7907: correct parameter reference in excess_code_size function

### DIFF
--- a/EIPS/eip-7907.md
+++ b/EIPS/eip-7907.md
@@ -41,7 +41,7 @@ def ceil32(n: int) -> int:
     return ((n + 31) // 32) * 32
 
 def excess_code_size(n: int) -> int:
-    return max(0, contract_size - 0x6000)
+    return max(0, n - 0x6000)
 ```
 
 ### Behavior


### PR DESCRIPTION
Use function parameter `n` instead of undefined variable `contract_size` in the excess_code_size helper function
