### PR TITLE
Update EIP-1186: fix broken links

### DIFF
--- a/EIPS/eip-1186.md
+++ b/EIPS/eip-1186.md
@@ -40,16 +40,16 @@ Returns the account- and storage-values of the specified account including the M
 ##### Parameters
 
 1. `DATA`, 20 Bytes - address of the account.
-2. `ARRAY`, 32 Bytes - array of storage-keys which should be proofed and included. See [`eth_getStorageAt`](https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_getstorageat)  
-3. `QUANTITY|TAG` - integer block number, or the string `"latest"` or `"earliest"`, see the [default block parameter](https://github.com/ethereum/wiki/wiki/JSON-RPC#the-default-block-parameter)
+2. `ARRAY`, 32 Bytes - array of storage-keys which should be proofed and included. See [`eth_getStorageAt`](https://ethereum.org/uk/developers/docs/apis/json-rpc/#eth_getstorageat)  
+3. `QUANTITY|TAG` - integer block number, or the string `"latest"` or `"earliest"`, see the [default block parameter](https://ethereum.org/uk/developers/docs/apis/json-rpc/#block-parameter)
 
 ##### Returns
 
 `Object` - A account object:
 
-  - `balance`: `QUANTITY` - the balance of the account. See [`eth_getBalance`](https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_getbalance) 
+  - `balance`: `QUANTITY` - the balance of the account. See [`eth_getBalance`](https://ethereum.org/uk/developers/docs/apis/json-rpc/#eth_getbalance) 
   - `codeHash`: `DATA`, 32 Bytes - hash of the code of the account. For a simple Account without code it will return `"0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"` 
-  - `nonce`: `QUANTITY`, - nonce of the account. See [`eth_getTransactionCount`](https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_gettransactioncount) 
+  - `nonce`: `QUANTITY`, - nonce of the account. See [`eth_getTransactionCount`](https://ethereum.org/uk/developers/docs/apis/json-rpc/#eth_gettransactioncount) 
   - `storageHash`: `DATA`, 32 Bytes - SHA3 of the StorageRoot. All storage will deliver a MerkleProof starting with this rootHash.
   - `accountProof`: `ARRAY` - Array of rlp-serialized MerkleTree-Nodes, starting with the stateRoot-Node, following the path of the SHA3 (address) as key. 
   - `storageProof`: `ARRAY` - Array of storage-entries as requested. Each entry is an object with these properties:


### PR DESCRIPTION
https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_getstorageat
https://github.com/ethereum/wiki/wiki/JSON-RPC#the-default-block-parameter
https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_getbalance

https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_gettransactioncount - brooooken

https://ethereum.org/uk/developers/docs/apis/json-rpc/#eth_getstorageat
https://ethereum.org/uk/developers/docs/apis/json-rpc/#block-parameter
https://ethereum.org/uk/developers/docs/apis/json-rpc/#eth_getbalance
https://ethereum.org/uk/developers/docs/apis/json-rpc/#eth_gettransactioncount - work