### PR TITLE
Update EIP-8016: fix typos

### DIFF
--- a/EIPS/eip-8016.md
+++ b/EIPS/eip-8016.md
@@ -29,7 +29,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ### `CompatibleUnion({selector: type})`
 
-A new [SSZ composite types)](https://github.com/ethereum/consensus-specs/blob/ad36024441cf910d428d03f87f331fbbd2b3e5f1/ssz/simple-serialize.md#composite-types) is defined:
+A new [SSZ composite types](https://github.com/ethereum/consensus-specs/blob/ad36024441cf910d428d03f87f331fbbd2b3e5f1/ssz/simple-serialize.md#composite-types) is defined:
 
 - **compatible union**: union type containing one of the given subtypes with compatible Merkleization
   - notation `CompatibleUnion({selector: type})`, e.g. `CompatibleUnion({1: Square, 2: Circle})`
@@ -116,7 +116,7 @@ An alternative design was explored where the `active_fields` bitvector was emitt
 
 With `CompatibleUnion`, a tag is emitted that tells the parser early on what to expect, including for nested fields.
 
-Note that wrapping a field in a `CompatibleUnion` is not a backwards compatible operation. However, new options can be introduced, and existing options dropped, without breaking verifiers. Therefore, `CompatibleUnion` has to be introduced earlyon wherever future design extensions are anticipated, even when only a single type option is used.
+Note that wrapping a field in a `CompatibleUnion` is not a backwards compatible operation. However, new options can be introduced, and existing options dropped, without breaking verifiers. Therefore, `CompatibleUnion` has to be introduced early on wherever future design extensions are anticipated, even when only a single type option is used.
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
fix formatting link ( unnecessary ')' ) and typo earlyon -> early on