### PR TITLE
Update EIP-7904: simplify the proposal

### DIFF
--- a/EIPS/eip-7904.md
+++ b/EIPS/eip-7904.md
@@ -2,7 +2,7 @@
 eip: 7904
 title: General Repricing
 description: Gas Cost Repricing to reflect computational complexity and transaction throughput increase
-author: Jacek Glen (@JacekGlen), Lukasz Glen (@lukasz-glen)
+author: Jacek Glen (@JacekGlen), Lukasz Glen (@lukasz-glen), Maria Silva (@misilva73)
 discussions-to: https://ethereum-magicians.org/t/gas-cost-repricing-to-reflect-computational-complexity/23067
 status: Draft
 type: Standards Track
@@ -13,7 +13,7 @@ requires: 7883
 
 ## Abstract
 
-This proposal revises the gas cost schedule for opcodes, precompiles, memory expansion, and data access, prioritizing computational complexity, while excluding network-related costs such as state persistence. The adjustments aim to enhance gas cost accuracy and rebalance the cost structure.
+This proposal revises the gas cost schedule for opcodes and data access, prioritizing computational complexity, while excluding network-related costs such as state persistence. The adjustments aim to enhance gas cost accuracy and rebalance the cost structure.
 
 ## Motivation
 
@@ -53,17 +53,13 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ### Cost formulas
 
-| Name                  | Formula                                                          | Description                                                                                                                                                                  |
-| --------------------- | ---------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| data_size             | len(data)                                                        | The size of the data expressed as number of bytes                                                                                                                            |
-| data_word_size        | (len(data) + 31) / 32                                            | The size of the data expressed as number of words                                                                                                                            |
-| exponent_byte_size    | len(exponent)                                                    | The size in bytes of the exponent in the EXP opcode.                                                                                                                         |
-| sets_count            | len(data) / 192                                                  | The number of pair sets in the ECPAIRING precompile.                                                                                                                         |
-| memory_expansion_cost | memory_cost(current_word_size) - memory_cost(previous_word_size) | The cost of expanding memory to `current_word_size` words from `previous_word_size` words. In a single context memory cannot contract, so the formula is always non-negative |
-| memory_cost           | (memory_word_size \*\* 2) / 512                                  | The cost of memory for `data_word_size` words.                                                                                                                               |
-| memory_word_size      | (memory_size + 31) / 32                                          | The size of the allocated memory expressed as number of words                                                                                                                |
-| address_access_cost   | 5 (warm) \| 2600 (cold)                                          | The cost of accessing warm and cold address data.                                                                                                                            |
-| storage_access_cost   | 5 (warm) \| 2100 (cold)                                          | The cost of accessing warm and cold storage data.                                                                                                                            |
+| Name                | Formula                 | Description                                          |
+| ------------------- | ----------------------- | ---------------------------------------------------- |
+| data_size           | len(data)               | The size of the data expressed as number of bytes    |
+| data_word_size      | (len(data) + 31) / 32   | The size of the data expressed as number of words    |
+| exponent_byte_size  | len(exponent)           | The size in bytes of the exponent in the EXP opcode. |
+| address_access_cost | 5 (warm) \| 2600 (cold) | The cost of accessing warm and cold address data.    |
+| storage_access_cost | 5 (warm) \| 2100 (cold) | The cost of accessing warm and cold storage data.    |
 
 ### Opcode Costs
 
@@ -134,35 +130,25 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 | 0x80 - 0x8F | DUPx           |                                                                     3 |                                                                   BASE_OPCODE_COST |
 | 0x90 - 0x9F | SWAPx          |                                                                     3 |                                                                   BASE_OPCODE_COST |
 
-### Precompiles Costs
-
-| Precompile | Name       |                 Current Gas |              Proposed Gas |
-| ---------- | ---------- | --------------------------: | ------------------------: |
-| 0x07       | ECMUL      |                        6000 |                      2700 |
-| 0x08       | ECPAIRING  | 45000 + 34000 \* sets_count | 8000 + 7000 \* sets_count |
-| 0x0A       | POINTEVAL  |                       50000 |                     21000 |
-
-The calculated and rescaled cost of 0x06 (ECADD) is higher than the current cost. Still this cost is left unchanged to maintain compatibility with existing contracts.
-
-The remaining precompiles remains unchanged.
-
-Additionally, all precompiles benefit from the lowered cost of \*CALL opcodes (see below).
-
 ### Indirect changes
 
-The formula for these opcodes remains the same, but the total cost calculated is affected by changes to some components.
+The formula for these opcodes remains the same, but their gas cost is affected by changes to gas formula elements.
 
-| Opcode | Name         | Affected formula component                 |
-| ------ | ------------ | ------------------------------------------ |
-| 0x54   | SLOAD        | storage_access_cost                        |
-| 0x55   | SSTORE       | storage_access_cost                        |
-| 0xF0   | CREATE       | memory_expansion_cost                      |
-| 0xF5   | CREATE2      | memory_expansion_cost                      |
-| 0xF1   | CALL         | memory_expansion_cost, address_access_cost |
-| 0xFA   | STATICCALL   | memory_expansion_cost, address_access_cost |
-| 0xF4   | DELEGATECALL | memory_expansion_cost, address_access_cost |
-| 0xF3   | RETURN       | memory_expansion_cost                      |
-| 0xFD   | REVERT       | memory_expansion_cost                      |
+| Opcode | Name         | Affected formula component |
+| ------ | ------------ | -------------------------- |
+| 0x54   | SLOAD        | storage_access_cost        |
+| 0x55   | SSTORE       | storage_access_cost        |
+| 0xF1   | CALL         | address_access_cost        |
+| 0xFA   | STATICCALL   | address_access_cost        |
+| 0xF4   | DELEGATECALL | address_access_cost        |
+
+
+### Precompiles And Memory Costs
+
+All precompiles benefit from the lowered cost of \*CALL opcodes, as precompiles are always treated as warm address accesses.
+
+This proposal does not change the memory expansion cost formula.
+
 
 ## Rationale
 
@@ -178,7 +164,7 @@ Several initiatives have explored the real gas costs of EVM operations, providin
 
 - [EIP-7883](./eip-7883.md) - ModExp Gas Cost Increase: This EIP specifically analyzed the ModExp and proposed a revised pricing scheme. When adjusted with our `rescale factor`, its costs align with this proposal, requiring no further changes. This consistency validates our measuring approach.
 - Nethermind's Gas Benchmarks: This project takes a different approach to measuring gas costs. It uses standalone clients rather than isolated EVM implementations. Despite the methodological difference, its results mirror those of the Gas Cost Estimator, reinforcing our conclusions.
-- EVM Memory Analysis by @raxhvl: This project focuses on memory-related costs, providing valuable insights into the memory access and expansion costs. Our proposal incorporates these findings in the `memory_expansion_cost` formula.
+- EVM Memory Analysis by @raxhvl: This project focuses on memory-related costs, providing valuable insights into the memory access and expansion costs.
 
 These projects collectively affirm the need to reassess gas costs and demonstrate broad alignment with our approach.
 
@@ -204,34 +190,6 @@ Note that, it is safer to decrease because of Backwards Compatibility issues rel
 
 This EIP adopts a conservative strategy, prioritizing decreases for operations that empirical data show as overpriced, while ensuring no reductions compromise security. This approach aims to optimize efficiency without introducing new vulnerabilities.
 
-### Memory expansion cost
-
-This proposal introduces a simplified `memory_expansion_cost` formula. The current formula combines a constant cost per word and an additional quadratic cost. The latter is added to prevent attacks exploiting excessive memory usage. Our findings, supported by [related projects](../assets/eip-7904/raxhvl_memory_exp_100M.png), indicate the constant cost per word is negligible and already accounted for in opcodes that expand memory. Thus, the revised formula retains only the quadratic cost, preserving security while reducing overall gas costs. As a result, the first 22 words of memory incur no additional cost, as the quadratic penalty begins beyond this threshold.
-
-#### Estimated Maximum Memory Allocation
-
-The tables below compare the maximum memory allocations under the current and proposed gas schedules, showed for different block gas limits.
-
-**Single Opcode Memory Allocation:**
-This table shows the estimated maximum memory allocation achievable with a single opcode:
-
-| Block Gas Limit | Current Gas Schedule | Proposed Gas Schedule |
-| --------------- | -------------------- | --------------------- |
-| 30M             | 123,169 words        | 123,935 words         |
-| 36M             | 134,998 words        | 135,764 words         |
-| 60M             | 174,504 words        | 175,271 words         |
-
-**Multiple Calls Memory Allocation:**
-This table estimates the maximum memory allocation achievable with a transaction that repeatedly makes subcalls in a loop, until block gas limit is reached. Each subcall allocates memory in the most effective way balancing call costs and memory expansion costs. For the current gas schedule, it is 278 words per call, and for the proposed gas schedule, it is 93 words per call.
-
-| Block Gas Limit | Current Gas Schedule | Proposed Gas Schedule |
-| --------------- | -------------------- | --------------------- |
-| 30M             | 7,459,574 words      | 82,058,736 words      |
-| 36M             | 8,951,600 words      | 98,470,539 words      |
-| 60M             | 14,919,426 words     | 164,117,565 words     |
-
-Experiments with stack depth and recursive calls showed that the maximal total allocated memory at a single moment increases less than 10% comparing Current and Proposed Gas Schedule.
-
 ### Consideration of ZK-SNARK Proof Generation (EIP-7667)
 
 [EIP-7667](./eip-7667.md) proposes an alternative framework for measuring resource consumption, emphasizing the demands of generating ZK-SNARK proofs — an area  of growing importance for Ethereum. This includes hashing opcodes and precompiles, which are computationally intensive in ZK-SNARK contexts. Two motivations drive EIP-7667: first, the long-term vision of a ZK-SNARKed Ethereum Layer 1 (L1), where such operations will be critical; second, the immediate challenges faced by ZK-based Layer 2 (L2) solutions, which often limit hashing operations to manage costs. In contrast, this EIP uses a bare CPU as its reference point, focusing on general computational complexity rather than ZK-specific needs. The proposed changes are not expected to significantly alter the average case for ZK-based L2s but may impact worst-case scenarios. While acknowledging the relevance of ZK-SNARKs, this EIP argues that their systemic challenges require distinct solutions beyond the scope of this proposal. There are efforts and progress in the space, still the vision of a ZK-SNARKed L1 seems to be distant enough, to justify the focus on optimizing the current setup for broader network benefits.
@@ -248,27 +206,7 @@ By implementing the proposal, the overall computational cost will decrease, whil
 
 The proposal modifies two formulas for `address_access_cost` and `storage_access_cost`, but for the warm data only. This is because it can be estimated using the same methodology used here. The cold access cost is multi-layered, and depends on the blockchain state, its size and data structure. Accurate measurements would require to devise more suitable methodology.
 
-The two storage opcodes, SLOAD and STORE, are indirectly updated. Their cost formulas are complex and only the warm/cold data access cost ratio is modified. Similarly for CREATE and CREATE2. Only the memory expansion cost factor is modified, which is computational and is consistent with other opcodes that may expand memory.
-
-### Precompiles
-
-For the MODEXP precompile, this proposal assumes [EIP-7883](eip-7883.md) is adopted, and its gas cost remains unchanged. For ECPAIRING, the gas cost is reduced  by approximately a factor of 5, consistent with similar adjustments in this proposal. Precompiles such as ECRECOVER, IDENTITY, ECADD, ECMUL, BLAKE2F, and POINTEVAL either retain their current gas costs or see moderate reductions.
-
-Projects like Nethermind's Gas Benchmarks highlight a security concern: lowering the gas cost for ECRECOVER could lead to the worst-case scenario where the block computation time exceeds safety threshold. A similar issue applies to MODEXP. As the result, the `rescale factor` cannot be lower that the proposed `0.217391304` even though there is a room for further reduction. Note that the maximum number of operations in a block depends on the gas cost schedule and the block gas limit.
-
-The Gas Cost Estimator project suggests a slight increase in ECRECOVER’s gas cost, but this proposal avoids that change to maintain backward compatibility and because the impact would be minor.
-
-### Hashing
-
-The hashing operations, the precompiles SHA2-256, RIPEMD-160, BLAKE2F, and the KECCAK256 opcode, are not updated here deliberately. The examinations based on current Mainnet EVM implementations discovered settings that could and should be modified. Assuming changes proposed in this EIP as reference, the key findings include:
-
-- The gas cost for BLAKE2F should remain unchanged.
-- The per-word gas cost for KECCAK256 should stay the same, with the base cost lowered by a factor of 3.
-- For SHA2-256 and RIPEMD-160, the per-word gas cost should be reduced by a factor of 3.
-
-On the other hand, ZK based EVMs emerged for both Layer 2s recently and Mainnet in the future. And these solutions play important role in the ecosystem. Moreover, the situation is dynamic as there are efforts to optimize ZK proofs regarding the hashing operations. Changes in gas cost for these operations should be proposed in another EIP.
-
-Additionally, the potential changes revealed by the examinations might seem substantial, but would not worsen the edge cases outlined in [EIP-7667](./eip-7667.md) for instance - they are scenarios for generating ZK proofs in blocks filled entirely with hashing operations.
+The two storage opcodes, SLOAD and STORE, are indirectly updated. Their cost formulas are complex and only the warm/cold data access cost ratio is modified.
 
 ## Backwards Compatibility
 
@@ -277,7 +215,7 @@ The proposed changes to the gas cost schedule will require a hardfork due to the
 The changes have the following consequences:
 
 - Gas Cost Adjustments:
-  - The gas costs for a wide range of opcodes, precompiles, and other operations (such as memory expansion and access costs) will be modified.
+  - The gas costs for a wide range of opcodes, and other operations (such as access costs) will be modified.
   - These adjustments aim to better align gas pricing with the computational complexity of operations, but they will directly impact the cost of executing transactions and smart contracts.
 - Transaction Gas Cost Changes:
   - It is highly likely that the gas cost of any transaction that invokes a contract will change.
@@ -381,10 +319,6 @@ func memoryGasCost(mem *Memory, newMemSize uint64) (uint64, error) {
 ## Security Considerations
 
 The main risk associated with this proposal is the potential for DoS attacks. By reducing gas costs, the proposal could inadvertently make certain operations more affordable, enabling attackers to exploit them for malicious purposes. To mitigate this risk, the proposal focuses on decreasing the gas costs of overpriced operations, ensuring that the adjustments do not compromise network security. By maintaining the relative cost of operations, the proposal makes sure that the reduced prices do not create new vulnerabilities even in the worst-case scenarios.
-
-The reduced memory expansion cost still keeps the quadratic nature of the cost, which prevents attacks exploiting excessive memory usage. Any existing considerations are addressed by [EIP‑7825](./eip-7825.md).
-
-The proposal does not address concerns raised in [EIP-7667](./eip-7667.md), but it does not worsen the edge cases outlined in that EIP.
 
 ## Copyright
 


### PR DESCRIPTION
After lengthy discussions during EVM Resource Pricing workgroup meetings, we concluded that this EIP should focus on the core change only. Therefore, I've removed gas changes for:
- precompiles: this is being addressed by multiple other EIPs
- memory expansion costs: a separate EIP will be created just for this purpose.

Also, Maria has been added as a co-author.