### PR TITLE
Update EIP-7932: Remove redundant argument to `sigrecover`

### DIFF
--- a/EIPS/eip-7932.md
+++ b/EIPS/eip-7932.md
@@ -204,26 +204,25 @@ The precompile logic contains the following logic:
 ```python
 
 def sigrecover_precompile(input: Bytes) -> Bytes:
-  # Recover signature length and type
-  assert(len(input) >= 64)
+  # Recover signature, hash and type
+  assert(len(input) >= 33)
   hash: Hash32 = input[:32]
   algorithm_type: uint8 = input[32]
-  sig_length: uint248 = int.from_bytes(input[33:64], "big")
+  signature: Bytes = input[33:]
 
-  # Ensure the algorithm exists and signature is correct size
+  # Ensure the algorithm exists
   if algorithm_type not in Algorithms:
     return ExecutionAddress(0x0)
 
   alg = Algorithms[algorithm_type]
 
-  # Sig length must be smaller than alg.MAX_SIZE and
-  # equal to the remaining call data
-  if sig_length > alg.MAX_SIZE or sig_length != (len(input) - 64):
+  # Check sig is smaller than the maximum
+  if len(signature) > alg.MAX_SIZE:
     return ExecutionAddress(0x0)
 
   # Run verify function
   try:
-    return alg.verify(input[64:64 + sig_length], hash)
+    return alg.verify(signature, hash)
   except:
     return ExecutionAddress(0x0)
   


### PR DESCRIPTION
Thank you @Amxx for pointing this out