### PR TITLE
Update EIP-7961: fix minor typos

### DIFF
--- a/EIPS/eip-7961.md
+++ b/EIPS/eip-7961.md
@@ -25,7 +25,7 @@ Define `0x02` as an allowed `type` in `types_section`, as defined in EIP-7960. T
 
 ### EOF function execution
 
-When entering an EOF code section (either at the beginning of the contract call, or through `CALLF`), it enters "pure EVM64 mode". Unless defined below, no other opcodes are allowed. Those opcodes all only operates on the least significant 64-bit, in little endian.
+When entering an EOF code section (either at the beginning of the contract call, or through `CALLF`), it enters "pure EVM64 mode". Unless defined below, no other opcodes are allowed. Those opcodes all only operate on the least significant 64-bit, in little endian.
 
 During EOF validation, the validation function should enforce that only allowed opcodes exist.
 
@@ -53,7 +53,7 @@ The 64-bit mode arithmetic opcodes are defined the same as non-64-bit mode, exce
 
 ### Comparison and bitwise opcodes
 
-The 64-bit mode comparison and bitwise opcodes are defined the same as non-64-bit mode, except that they only operates on the least significant 64 bits.
+The 64-bit mode comparison and bitwise opcodes are defined the same as non-64-bit mode, except that they only operate on the least significant 64 bits.
 
 * LT (`10`), GT (`11`), SLT (`12`), SGT (`13`), EQ (`14`), AND (`16`), OR (`17`), XOR (`18`): `a op b mod 2^64`, gas cost `G_VERYLOW64`
 * ISZERO (`15`), NOT (`19`): `op a mod 2^64`, gas cost `G_VERYLOW64`
@@ -97,7 +97,7 @@ For flow operations RJUMPI and RJUMPV, the 64-bit mode has following changes:
 
 ### Discussions
 
-This alternative definition (compared with EIP-7937) has the advantage that the code size is now shorter (because no multibyte opcodes are needed). It however will only work with EOF contract but not "legacy" EVM. The interaction between EVM64 and "system calls" (those calls that reads Ethereum block values, addresses, balances and storages) will be more difficult. It's not "seamless" like EIP-7937 where one can enter/exit 64-bit mode at ease. Depending on how the 64-bit optimization works out, this may be an advantage or an disadvantage.
+This alternative definition (compared with EIP-7937) has the advantage that the code size is now shorter (because no multibyte opcodes are needed). It however will only work with EOF contract but not "legacy" EVM. The interaction between EVM64 and "system calls" (those calls that reads Ethereum block values, addresses, balances and storages) will be more difficult. It's not "seamless" like EIP-7937 where one can enter/exit 64-bit mode at ease. Depending on how the 64-bit optimization works out, this may be an advantage or a disadvantage.
 
 The memory is, as usual, still shared during the entire execution. So in EVM64, the contract can always use the memory to push/fetch data.
 


### PR DESCRIPTION
Those opcodes all only operates -> Those opcodes all only operate
they only operates -> they only operate
an disadvantage -> a disadvantage