### PR TITLE
Update EIP-8: Replace incorrect HMAC-256 reference with Keccak-256 MAC in EIP-8

### DIFF
--- a/EIPS/eip-8.md
+++ b/EIPS/eip-8.md
@@ -66,7 +66,7 @@ sha3(MESSAGE)
 ecies.encrypt(PUBKEY, MESSAGE, AUTHDATA)
     is the asymmetric authenticated encryption function as used by RLPx.
     AUTHDATA is authenticated data which is not part of the resulting ciphertext,
-    but written to HMAC-256 before generating the message tag.
+    but written to the Keccak-256 MAC before generating the message tag.
 ```
 
 ### Motivation


### PR DESCRIPTION
Update EIPS/eip-8.md to replace “HMAC-256” with “Keccak-256 MAC” in the ECIES description. Rationale:
RLPx uses a Keccak-256–based MAC (maintaining keccak states for ingress/egress MAC), not HMAC-SHA256.
The same file already defines sha3(MESSAGE) as Keccak256, so “HMAC-256” is inconsistent with the documented primitives.
Official devp2p RLPx documentation specifies Keccak-256 for MAC/tag computation and does not use HMAC. See:
devp2p RLPx spec: https://github.com/ethereum/devp2p/blob/master/rlpx.md (sections on MAC/keccak states and tag generation).