### PR TITLE
Update EIP-7892: Move to Review

### DIFF
--- a/EIPS/eip-7892.md
+++ b/EIPS/eip-7892.md
@@ -4,7 +4,7 @@ title: Blob Parameter Only Hardforks
 description: Defines a mechanism for scaling Ethereum’s blob capacity via specialized hard forks that modify only blob-related parameters.
 author: Mark Mackey (@ethDreamer), Raúl Kripalani (@raulk)
 discussions-to: https://ethereum-magicians.org/t/eip-7892-blob-parameter-only-hardforks/23018
-status: Draft
+status: Review
 type: Informational
 created: 2025-02-28
 requires: 7840


### PR DESCRIPTION
## Summary
- Updates EIP-7892 status from Draft to Review

## Motivation
This change is required to unblock PR #10337 which updates EIP-7607 to Review status. The EIP validator requires all referenced EIPs to be in a stable status before allowing the meta-EIP to move to Review.

## Blocking
- Blocks: ethereum/EIPs#10337

🤖 Generated with [Claude Code](https://claude.ai/code)