### PR TITLE
Update EIP-7934: Move to Review

### DIFF
--- a/EIPS/eip-7934.md
+++ b/EIPS/eip-7934.md
@@ -4,7 +4,7 @@ title: RLP Execution Block Size Limit
 description: Introduce a protocol-level cap on the maximum RLP-encoded block size to 10 MiB, including a 2 MiB margin for beacon block size.
 author: Giulio Rebuffo (@Giulio2002), Ben Adams (@benaadams), Storm Slivkoff (@sslivkoff)
 discussions-to: https://ethereum-magicians.org/t/eip-7934-add-bytesize-limit-to-blocks/23589
-status: Draft
+status: Review
 type: Standards Track
 category: Core
 created: 2025-04-16


### PR DESCRIPTION
## Summary
- Updates EIP-7934 status from Draft to Review

## Motivation
This change is required to unblock PR #10337 which updates EIP-7607 to Review status. The EIP validator requires all referenced EIPs to be in a stable status before allowing the meta-EIP to move to Review.

## Blocking
- Blocks: ethereum/EIPs#10337

🤖 Generated with [Claude Code](https://claude.ai/code)