### PR TITLE
Update EIP-7883: Move to Review

### DIFF
--- a/EIPS/eip-7883.md
+++ b/EIPS/eip-7883.md
@@ -4,7 +4,7 @@ title: ModExp Gas Cost Increase
 description: Increases cost of ModExp precompile
 author: Marcin Sobczak (@marcindsobczak), Marek Moraczyński (@MarekM25), Marcos Maceo (@stdevMac)
 discussions-to: https://ethereum-magicians.org/t/eip-7883-modexp-gas-cost-increase/22841
-status: Draft
+status: Review
 type: Standards Track
 category: Core
 created: 2025-02-11


### PR DESCRIPTION
## Summary
- Updates EIP-7883 status from Draft to Review

## Motivation
This change is required to unblock PR #10337 which updates EIP-7607 to Review status. The EIP validator requires all referenced EIPs to be in a stable status before allowing the meta-EIP to move to Review.

## Blocking
- Blocks: ethereum/EIPs#10337

🤖 Generated with [Claude Code](https://claude.ai/code)