### PR TITLE
Update EIP-7825: Move to Review

### DIFF
--- a/EIPS/eip-7825.md
+++ b/EIPS/eip-7825.md
@@ -4,7 +4,7 @@ title: Transaction Gas Limit Cap
 description: Introduce a protocol-level cap on the maximum gas used by a transaction to 16,777,216 (2^24).
 author: Giulio Rebuffo (@Giulio2002), Toni Wahrstätter (@nerolation)
 discussions-to: https://ethereum-magicians.org/t/eip-7825-transaction-gas-limit-cap/21848
-status: Draft
+status: Review
 type: Standards Track
 category: Core
 created: 2024-11-23


### PR DESCRIPTION
## Summary
- Updates EIP-7825 status from Draft to Review

## Motivation
This change is required to unblock PR #10337 which updates EIP-7607 to Review status. The EIP validator requires all referenced EIPs to be in a stable status before allowing the meta-EIP to move to Review.

## Blocking
- Blocks: ethereum/EIPs#10337

🤖 Generated with [Claude Code](https://claude.ai/code)