### PR TITLE
Update EIP-7883: Fix broken table rendering

### DIFF
--- a/assets/eip-7883/call_analysis.md
+++ b/assets/eip-7883/call_analysis.md
@@ -34,6 +34,7 @@ The EIP-7883 specification introduces three key changes:
 ### Input Size Distributions
 
 **Statistical Summary:**
+
 | Parameter | Min | Max | Mean | Median | Std Dev |
 |-----------|-----|-----|------|--------|---------|
 | Bsize | 32 | 385 | 32.0 | 32.0 | 2.7 |
@@ -41,6 +42,7 @@ The EIP-7883 specification introduces three key changes:
 | Msize | 32 | 384 | 32.0 | 32.0 | 2.7 |
 
 **Common Size Combinations:**
+
 | Base Size | Exponent Size | Modulus Size | Count | Percentage |
 |-----------|---------------|--------------|-------|------------|
 | 32 | 32 | 32 | 304,225 | 100.0% |
@@ -55,6 +57,7 @@ The EIP-7883 specification introduces three key changes:
 **Fermat Prime Usage**: 1,351 calls (0.4%)
 
 **Most Common Exponent Values:**
+
 | Rank | Exponent | Count | Percentage |
 |------|----------|-------|------------|
 | 1 | 0x30644e72... | 66,115 | 21.73% |


### PR DESCRIPTION
Take a look at https://eips.ethereum.org/assets/eip-7883/call_analysis. Some tables do not render well.

In kramdown (used in Jekyll), a blank line is needed before the table. Otherwise, it will not render.
Though github renders it well, it shows a mess in the https://eips.ethereum.org/ website.