### PR TITLE
Update EIP-7932: Fix broken table rendering

### DIFF
--- a/EIPS/eip-7932.md
+++ b/EIPS/eip-7932.md
@@ -120,6 +120,7 @@ def identify_transaction_profile(tx: Transaction) -> Type[Profile]:
 Further algorithms MUST be specified via a distinct EIP.
 
 Each type of algorithm MUST specify the following fields:
+
 | Field Name | Description |
 |-|-|
 |`ALG_TYPE`| The uint8 of the algorithm unique ID |


### PR DESCRIPTION
Take a look at https://eips.ethereum.org/EIPS/eip-7932. The table below `Algorithm specification` does not render well.

In kramdown (used in Jekyll), a blank line is needed before the table. Otherwise, it will not render.
Though github renders it well, it shows a mess in the https://eips.ethereum.org/ website.