### PR TITLE
Website: fix broken mobile page margins

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -97,3 +97,70 @@ h1 a {
   }
 }
 
+// This will make ALL tables scrollable
+.page-content table {
+  display: inline-block;
+  width: auto !important;   /* shrink-to-fit its contents */
+  max-width: 100%; /* never exceed the width of its container */
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+// Fix text overflow in EIP content
+.home {
+  max-width: 100%;
+  overflow-x: hidden;
+  
+  // Target all content that could overflow
+  p, li, td, div {
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+    word-break: break-word;
+  }
+  
+  // Specifically handle URLs in links
+  a {
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+    word-break: break-all;
+    display: inline-block;
+    max-width: 100%;
+  }
+  
+  // Handle code blocks that might contain long strings
+  pre {
+    overflow-x: auto;
+    max-width: 100%;
+  }
+  
+  // Inline code should wrap
+  code {
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+  }
+}
+
+// Specifically target lists (where references usually are)
+.home ul, .home ol {
+  max-width: 100%;
+  padding-right: 20px; // Give some breathing room
+  
+  li {
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+    word-break: break-word;
+    
+    // Extra aggressive breaking for URLs
+    a {
+      word-break: break-all;
+      hyphens: auto;
+    }
+  }
+}
+
+// makes an exception to code inside tables allowing them to expand the table's width since it has overflow scrolling
+.page-content table code {
+  white-space: nowrap;
+  word-break: normal;
+  overflow-wrap: normal;
+}


### PR DESCRIPTION
## Description
On small screens, long text, links, code blocks and tables are overflowing past the right page margin and increasing the width of the entire page, breaking the overall page layout. Normally, overflowing content is contained (by wrapping or by isolated scrollable containers), not allowed to expand the entire page width. The problem affects at least 100+ pages including all category pages. This Closes #10357 , see that issue for a catalog of affected pages.

This fix ensures:
- Tables are scrollable within `.page-content` instead of extending beyond the right margin.
- Long words, links, and code blocks wrap correctly instead of extending beyond the right margin, including inside tables.
- Lists and inline code also wrap to avoid margin-breaking overflow.
- Expected element behaviors otherwise act as intended without side-effects.

**Only `style.scss` has been modified.**

**The entire catalog of affected pages should have the issues resolved with this fix.**

## Before and After Screenshots

**"All" Category page - Before**
![Image](https://github.com/user-attachments/assets/0028d06c-f957-4451-a850-7b8f291edb8d)

**"All" Category page - After**
![All-After](https://github.com/user-attachments/assets/980e1398-8751-43ee-b150-a517fd261c5b)

**ERC-721 - Before**
![Image](https://github.com/user-attachments/assets/2982c85c-3fdb-4407-b439-019fc09dfded)

**ERC-721 - After**
![ERC-721-After](https://github.com/user-attachments/assets/8f8e1041-7f2c-4796-9b24-db0d132a760f)

## Testing

I have tested the fix and reviewed pages on the following browsers in both desktop and mobile app versions:
-Chrome
-Edge
-Firefox

I also reviewed other pages not effected by the original issues to ensure there were no unintended side effects of the updated CSS and I did not find evidence of any. 

All pages' content should effectively behave as otherwise normally expected to.

Anyone is welcomed to check on a local build or the demo build I have up to see if the problems persist or if they note any side-effects.

### Demo
I have an EIPs demo to see how the layout fix looks at [eips.ritovision.com](https://eips.ritovision.com) (the mobile menu at the bottom is a separate unrelated component I am prototyping). The demo will remain up at least until the PR is resolved.
