### PR TITLE
Update EIP-7807: align ExecutionPayload text to use requests_hash instead of requests_root

### DIFF
--- a/EIPS/eip-7807.md
+++ b/EIPS/eip-7807.md
@@ -84,7 +84,7 @@ For new blocks, the execution block hash is changed to be based on `hash_tree_ro
 
 Usages of `ExecutionPayloadHeader` are replaced with `ExecutionBlockHeader`.
 
-Usages of `ExecutionPayload` are updated to share `hash_tree_root` with `ExecutionBlockHeader`. `transactions_root`, `withdrawals_root` and `requests_root` are expanded to their full list contents.
+Usages of `ExecutionPayload` are updated to share `hash_tree_root` with `ExecutionBlockHeader`. `transactions_root`, `withdrawals_root` and `requests_hash` are expanded to their full list contents.
 
 ```python
 class ExecutionPayload(


### PR DESCRIPTION
Replace a stray reference to requests_root with requests_hash in EIP-7807 to match the header field name and EIP-7685 terminology. No semantic changes; this corrects a naming inconsistency in the explanatory text.