### PR TITLE
Update EIP-7937: fix typos

### DIFF
--- a/EIPS/eip-7937.md
+++ b/EIPS/eip-7937.md
@@ -73,7 +73,7 @@ For flow operations JUMP and JUMPI, the behavior is as follows:
 
 * `JUMP` will only read the last 64 bits from the stack value. The rest 192 bits are discarded without reading. Gas cost is `G_MID64`.
 * `JUMPI` will only read the last 64 bits from the stack as destination, and the condition check will only read the last 64 bits. Gas cost is `G_HIGH64`.
-* In `JUMPDEST` validation phrase, `C0` is considered a standalone "mode" opcode and if the next byte followed is `JUMPDEST`, it continues to mark a valid `JUMPDEST` destination. Note that because there's no 64-bit `JUMPDEST`, during execution, `C0 JUMPDEST` would result in OOG.
+* In `JUMPDEST` validation phase, `C0` is considered a standalone "mode" opcode and if the next byte followed is `JUMPDEST`, it continues to mark a valid `JUMPDEST` destination. Note that because there's no 64-bit `JUMPDEST`, during execution, `C0 JUMPDEST` would result in OOG.
 
 ## Rationale
 
@@ -105,7 +105,7 @@ This EIP assumes that the majority of EVM implementations target native little-e
 
 #### Endianness
 
-In 64-bit mode, the principle of the specification is that the endianness should be kept strictly as an implementation detail. There should not be any opcodes that depends on endian. This is important, because on the one hand, we must enable easy and fast interop for 64-bit and non-64-bit opcodes. On the other hand, the interpreter should be able to do optimizations internally whether it uses little or big endian.
+In 64-bit mode, the principle of the specification is that the endianness should be kept strictly as an implementation detail. There should not be any opcodes that depend on endian. This is important, because on the one hand, we must enable easy and fast interop for 64-bit and non-64-bit opcodes. On the other hand, the interpreter should be able to do optimizations internally whether it uses little or big endian.
 
 Due to the issue of endianness, this EIP currently does not contain 64-bit mode `BYTE64`, memory opcodes `MLOAD64` and `MSTORE64`, and stack push opcodes `PUSH*64` (`PUSH1` to `PUSH8`).
 
@@ -115,7 +115,7 @@ It is possible to extend EVM64 where "64-bit mode" is instead defined as "little
 * `MLOAD64` and `MSTORE64` loads and store little-endian 64-bit values in memory.
 * `PUSH*64` (`PUSH1` to `PUSH8`) accepts literal little-endian bytes.
 
-In specification there is no issue with the design, but this can bring significant confusions to developers. So the author advise caution.
+In specification there is no issue with the design, but this can bring significant confusions to developers. So the author advises caution.
 
 #### `POP`, `DUP*`, `SWAP*`
 


### PR DESCRIPTION
validation phrase -> validation phase
opcodes that depends -> opcodes that depend
So the author advise caution -> So the author advises caution