### PR TITLE
Update EIP-7928: Clarify expectations when no state changes are present

### DIFF
--- a/EIPS/eip-7928.md
+++ b/EIPS/eip-7928.md
@@ -99,8 +99,8 @@ BlockAccessList = List[AccountChanges]
 
 It **MUST** include:
 
-* Addresses with state changes (storage, balance, nonce, or code).
-* Addresses accessed without state changes (e.g., `STATICCALL` targets, `BALANCE` opcode targets).
+- Addresses with state changes (storage, balance, nonce, or code).
+- Addresses accessed without state changes (e.g., `STATICCALL` targets, `BALANCE` opcode targets).
 
 Addresses with no state changes **MUST** still be present with empty change lists.
 
@@ -110,41 +110,41 @@ Entries from an [EIP-2930](./eip-2930.md) access list **MUST NOT** be included a
 
 The following ordering rules **MUST** apply:
 
-* **Addresses:** lexicographic (bytewise).
-* **Storage keys:** lexicographic within each account.
-* **Block access indices:** ascending within each change list.
+- **Addresses:** lexicographic (bytewise).
+- **Storage keys:** lexicographic within each account.
+- **Block access indices:** ascending within each change list.
 
 ### BlockAccessIndex Assignment
 
 `BlockAccessIndex` values **MUST** be assigned as follows:
 
-* `0` for **pre‑execution** system contract calls.
-* `1 … n` for transactions (in block order).
-* `n + 1` for **post‑execution** system contract calls.
+- `0` for **pre‑execution** system contract calls.
+- `1 … n` for transactions (in block order).
+- `n + 1` for **post‑execution** system contract calls.
 
 ### Recording Semantics by Change Type
 
 #### Storage
 
-* **Writes include:**
+- **Writes include:**
 
-  * Any value change (post‑value ≠ pre‑value).
-  * **Zeroing** a slot (pre‑value exists, post‑value is zero).
+  - Any value change (post‑value ≠ pre‑value).
+  - **Zeroing** a slot (pre‑value exists, post‑value is zero).
   
-* **Reads include:**
+- **Reads include:**
 
-  * Slots accessed via `SLOAD` that are not written.
-  * Slots written with unchanged values (i.e., `SSTORE` that re‑stores the same value).
+  - Slots accessed via `SLOAD` that are not written.
+  - Slots written with unchanged values (i.e., `SSTORE` that re‑stores the same value).
 
 #### Balance (`balance_changes`)
 
 Record **post‑transaction** balances (`uint128`) for:
 
-* Transaction **senders** (gas + value).
-* Transaction **recipients** (only if `value > 0`).
-* **Coinbase** (rewards + fees).
-* **SELFDESTRUCT/SENDALL** beneficiaries.
-* **Withdrawal recipients** (system withdrawals, [EIP-4895](./eip-4895.md)).
+- Transaction **senders** (gas + value).
+- Transaction **recipients** (only if `value > 0`).
+- **Coinbase** (rewards + fees).
+- **SELFDESTRUCT/SENDALL** beneficiaries.
+- **Withdrawal recipients** (system withdrawals, [EIP-4895](./eip-4895.md)).
 
 **Zero‑value transfers:** **MUST NOT** be recorded in `balance_changes`, but the corresponding addresses **MUST** still be included with empty `AccountChanges`.
 
@@ -156,26 +156,26 @@ Track **post‑transaction runtime bytecode** for deployed or modified contracts
 
 Record **post‑transaction nonces** for:
 
-* EOA senders.
-* Contracts that performed a successful `CREATE` or `CREATE2`.
-* Deployed contracts.
-* [EIP-7702](./eip-7702.md) authorities.
+- EOA senders.
+- Contracts that performed a successful `CREATE` or `CREATE2`.
+- Deployed contracts.
+- [EIP-7702](./eip-7702.md) authorities.
 
 ### Edge Cases (Normative)
 
-* **SELFDESTRUCT/SENDALL:** Beneficiary is recorded as a balance change.
-* **Accessed but unchanged:** Include the address with empty changes (e.g., targets of `EXTCODEHASH`, `EXTCODESIZE`, `BALANCE`, `STATICCALL`, etc.).
-* **Zero‑value transfers:** Include the address; omit from `balance_changes`.
-* **Gas refunds:** Record the **final** balance of the sender after each transaction.
-* **Block rewards:** Record the **final** balance of the fee recipient after each transaction.
-* **Exceptional halts:** Record the **final** nonce and balance of the sender, and the **final** balance of the fee recipient after each transaction.
-* **Pre‑execution system contract calls:** All state changes **MUST** use `block_access_index = 0`.
-* **Post‑execution system contract calls:** All state changes **MUST** use `block_access_index = len(transactions) + 1`.
-* **EIP‑4895 (Consensus layer withdrawals):** Recipients are recorded with their final balance after the withdrawal.
-* **EIP‑2935 (block hash):** Record system contract storage diffs of the **single** updated storage slot in the ring buffer.
-* **EIP‑4788 (beacon root):** Record system contract storage diffs of the **two** updated storage slots in the ring buffer.
-* **EIP‑7002 (withdrawals):** Record system contract storage diffs of storage slots **0–3** (4 slots) after the dequeuing call.
-* **EIP‑7251 (consolidations):** Record system contract storage diffs of storage slots **0–3** (4 slots) after the dequeuing call.
+- **SELFDESTRUCT/SENDALL:** Beneficiary is recorded as a balance change.
+- **Accessed but unchanged:** Include the address with empty changes (e.g., targets of `EXTCODEHASH`, `EXTCODESIZE`, `BALANCE`, `STATICCALL`, etc.).
+- **Zero‑value transfers:** Include the address; omit from `balance_changes`.
+- **Gas refunds:** Record the **final** balance of the sender after each transaction.
+- **Block rewards:** Record the **final** balance of the fee recipient after each transaction.
+- **Exceptional halts:** Record the **final** nonce and balance of the sender, and the **final** balance of the fee recipient after each transaction.
+- **Pre‑execution system contract calls:** All state changes **MUST** use `block_access_index = 0`.
+- **Post‑execution system contract calls:** All state changes **MUST** use `block_access_index = len(transactions) + 1`.
+- **EIP‑4895 (Consensus layer withdrawals):** Recipients are recorded with their final balance after the withdrawal.
+- **EIP‑2935 (block hash):** Record system contract storage diffs of the **single** updated storage slot in the ring buffer.
+- **EIP‑4788 (beacon root):** Record system contract storage diffs of the **two** updated storage slots in the ring buffer.
+- **EIP‑7002 (withdrawals):** Record system contract storage diffs of storage slots **0–3** (4 slots) after the dequeuing call.
+- **EIP‑7251 (consolidations):** Record system contract storage diffs of storage slots **0–3** (4 slots) after the dequeuing call.
 
 ### Engine API
 


### PR DESCRIPTION
In implementing the tests, I see this seems implicit but feels under-specified. I am seeing differing implementations in clients using `nil` instead. We should clarify what empty state expectations are. Does this feel concise enough and in the appropriate places?

cc: @nerolation