### PR TITLE
Update EIP-7495: fix formatting of link

### DIFF
--- a/EIPS/eip-7495.md
+++ b/EIPS/eip-7495.md
@@ -31,7 +31,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ### `ProgressiveContainer(active_fields)`
 
-A new [SSZ composite types)](https://github.com/ethereum/consensus-specs/blob/ad36024441cf910d428d03f87f331fbbd2b3e5f1/ssz/simple-serialize.md#composite-types) is defined:
+A new [SSZ composite types](https://github.com/ethereum/consensus-specs/blob/ad36024441cf910d428d03f87f331fbbd2b3e5f1/ssz/simple-serialize.md#composite-types) is defined:
 
 - **progressive container**: ordered heterogeneous collection of values with stable Merkleization
   - python dataclass notation with key-type pairs, e.g.


### PR DESCRIPTION
<img width="1185" height="231" alt="image" src="https://github.com/user-attachments/assets/d99aedb1-ec2d-4576-a8c7-b655d501eebf" />

Looks like it should be without ')'