### PR TITLE
Update EIP-6493: replace SSZ StableContainer with SSZ ProgressiveContainer

### DIFF
--- a/EIPS/eip-6493.md
+++ b/EIPS/eip-6493.md
@@ -17,7 +17,7 @@ This EIP defines a signature scheme for native [Simple Serialize (SSZ)](https://
 
 ## Motivation
 
-[EIP-6404](./eip-6404.md) introduces SSZ transactions by converting from RLP transactions. Defining a signature scheme for native SSZ transactions further reduces required conversions and unlocks the forward compatibility benefits of SSZ [`StableContainer`](./eip-7495.md).
+[EIP-6404](./eip-6404.md) introduces SSZ transactions by converting from RLP transactions. Defining a signature scheme for native SSZ transactions further reduces required conversions and unlocks the forward compatibility benefits of SSZ [`ProgressiveContainer`](./eip-7495.md).
 
 ## Specification
 


### PR DESCRIPTION
Replace outdated term “SSZ StableContainer” with the official “SSZ ProgressiveContainer” per EIP-7495.
Proof (in-repo): 
eip-7485.md
title: SSZ ProgressiveContainer

eip-6465.md
New withdrawals use a normalized SSZ representation. The existing consensus `Withdrawal` SSZ container is migrated to [EIP-7495 `ProgressiveContainer`](./eip-7495.md).
class Withdrawal(ProgressiveContainer(active_fields=[1, 1, 1, 1])):
