### PR TITLE
Update EIP-7935: 60M gas limit

### DIFF
--- a/EIPS/eip-7935.md
+++ b/EIPS/eip-7935.md
@@ -1,9 +1,9 @@
 ---
 eip: 7935
-title: Set default gas limit to XX0M
+title: Set default gas limit to 60M
 description: Recommend a new gas limit value for Fusaka and update execution layer client default configs
 author: Sophia Gold (@sophia-gold), Parithosh Jayanthi (@parithoshj), Toni Wahrstätter (@nerolation), Carl Beekhuizen (@CarlBeek), Ansgar Dietrichs (@adietrichs), Dankrad Feist (@dankrad), Alex Stokes (@ralexstokes), Josh Rudolph (@jrudolph), Giulio Rebuffo (@Giulio2002), Storm Slivkoff (@sslivkoff)
-discussions-to: https://ethereum-magicians.org/t/eip-7935-set-default-gas-limit-to-xx0m/23789
+discussions-to: https://ethereum-magicians.org/t/eip-7935-set-default-gas-limit-to-60m/23789
 status: Draft
 type: Informational
 created: 2025-04-22
@@ -11,8 +11,7 @@ created: 2025-04-22
 
 ## Abstract
 
-<!--TODO: Fill in recommended gas limit-->
-The gas limit on mainnet is currently 36M. This should be significantly increased to XX0Mby the time Fusaka is released by execution layer clients updating their default configurations.
+The gas limit on mainnet is currently 36M. This should be significantly increased to 60M by the time Fusaka is released by execution layer clients updating their default configurations.
 
 ## Motivation
 
@@ -20,7 +19,7 @@ There is currently great interest in scaling L1 execution. This can likely be do
 
 ## Specification
 
-Execution layer clients have different configuration formats. They should all update the gas limit value generated in their default configurations to XX0M.
+Execution layer clients have different configuration formats. They should all update the gas limit value generated in their default configurations to 60M.
 
 ## Rationale
 


### PR DESCRIPTION
Fills in the gas limit as 60M based on discussion with EL client teams.
