### PR TITLE
Update EIP-7928: clarify selfdestruct in same transaction behavior

### DIFF
--- a/EIPS/eip-7928.md
+++ b/EIPS/eip-7928.md
@@ -164,7 +164,7 @@ Record **post‑transaction nonces** for:
 ### Edge Cases (Normative)
 
 - **SENDALL:** Beneficiary is recorded as a balance change.
-- **SELFDESTRUCT (in-transaction):** Accounts destroyed within a transaction **MUST** include a `NonceChange` with `new_nonce = 0` and a `BalanceChange` with `post_balance = 0` at that transaction’s `block_access_index`. This combination is the canonical signal of selfdestruct.
+- **SELFDESTRUCT (in-transaction):** Accounts destroyed within a transaction **MUST** include a `NonceChange` with `new_nonce = 0`, a `CodeChange` with `new_code = ''`, and a `BalanceChange` with `post_balance = 0` at that transaction’s `block_access_index`. This combination is the canonical signal of selfdestruct.
 - **Accessed but unchanged:** Include the address with empty changes (e.g., targets of `EXTCODEHASH`, `EXTCODESIZE`, `BALANCE`, `STATICCALL`, etc.).
 - **Zero‑value transfers:** Include the address; omit from `balance_changes`.
 - **Gas refunds:** Record the **final** balance of the sender after each transaction.


### PR DESCRIPTION
Add clarification for in-transaction selfdestructs: accounts now include a nonce change (0) and balance change (0) at the transaction’s block_access_index to signal deletion.