### PR TITLE
Update EIP-7799: correct eth_getLogs method name in Motivation

### DIFF
--- a/EIPS/eip-7799.md
+++ b/EIPS/eip-7799.md
@@ -17,7 +17,7 @@ This EIP defines an extension for eth_getLogs to provide logs for events that ar
 
 ## Motivation
 
-With [EIP-7708](./eip-7708.md) wallets gain the ability to use eth_getLogs to track changes to their ETH balance. However, the ETH balance may change without an explicit transaction, through block production and withdrawals. By having such operations emit block-level system logs, eth_Logs provides a complete picture of ETH balance changes.
+With [EIP-7708](./eip-7708.md) wallets gain the ability to use eth_getLogs to track changes to their ETH balance. However, the ETH balance may change without an explicit transaction, through block production and withdrawals. By having such operations emit block-level system logs, eth_getLogs provides a complete picture of ETH balance changes.
 
 ## Specification
 


### PR DESCRIPTION
 Replace erroneous “eth_Logs” with the correct JSON-RPC method “eth_getLogs” 