### PR TITLE
Update EIP-7773: PFI 7610 for Glamsterdam

### DIFF
--- a/EIPS/eip-7773.md
+++ b/EIPS/eip-7773.md
@@ -55,6 +55,7 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Declined
 1. [EIP-7778](./eip-7778.md): Block Gas Accounting without Refunds
 1. [EIP-7976](./eip-7976.md): Increase Calldata Floor Cost
 1. [EIP-2780](./eip-2780.md): Reduce intrinsic transaction gas
+1. [EIP-7610](./eip-7610.md): Revert creation in case of non-empty storage
 
 
 ### Activation


### PR DESCRIPTION
This adds an EIP which can be retroactively activated to Glamsterdam. I am not sure what the process here is. The EIP itself https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7610.md (Revert creation in case of non-empty storage) is currently in Last Call. I am not sure what the process was for these other retroactively EIPs (and which ones we have actually agreed on to be included or not - are those Final and thus included on Mainnet?)

Explicitly specifying that we also cannot deploy contracts to accounts which have non-empty storage helps (is necessary?) for BALs, because otherwise we have the situation where one can SELFDESTRUCT an account (in he same transaction as it is being created) which will delete all storage key/values. Since we do not have the preimage of the keys this operation is close to impossible to generate the correct block level access list (BAL) for.

Maybe also a nice moment to do something like https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7675.md to explicitly list which retroactively EIPs we have agreed on (this is not clear for me what we formally agreed on and is thus included in the clients).