### PR TITLE
CI: Deactivate Jekyll Page Deployment for Forks

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -31,6 +31,7 @@ concurrency:
 jobs:
   # Build job
   build:
+    if: github.repository == 'ethereum/EIPs'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout EIPs
@@ -60,6 +61,7 @@ jobs:
 
   # Deployment job
   deploy:
+    if: github.repository == 'ethereum/EIPs'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
Since I have forked the EIP repo a couple of weeks ago I get failure notes every 15 min (!) due to the cronjob in the [jekyll.yml](https://github.com/ethereum/EIPs/blob/master/.github/workflows/jekyll.yml) workflow definition since page deployment is failing (and does not make sense in the first place 🙂).

<img width="857" height="40" alt="grafik" src="https://github.com/user-attachments/assets/7884d718-500f-4b6d-8fe8-989700301445" />

Can we therefore limit this job to only run on the main repo? This is otherwise annoying, also not so contributor-friendly since it bears the risk that people delete their forks just for the sake of a quick "silence solution".