### PR TITLE
Update EIP-6404: Fix RlpSetCodeTransaction payload type to RlpSetCodeTransactionPayload

### DIFF
--- a/EIPS/eip-6404.md
+++ b/EIPS/eip-6404.md
@@ -357,7 +357,7 @@ class RlpSetCodeTransactionPayload(
     authorization_list: ProgressiveList[RlpSetCodeAuthorization]
 
 class RlpSetCodeTransaction(Container):
-    payload: RlpAuthorization
+    payload: RlpSetCodeTransactionPayload
     signature: Secp256k1ExecutionSignature
 ```
 


### PR DESCRIPTION
Problem:
In EIP-6404’s EIP-7702 section, RlpSetCodeTransaction incorrectly declared payload: RlpAuthorization instead of payload: RlpSetCodeTransactionPayload. This contradicts the canonical SSZ type definitions used by the repo and leads to a type mismatch in the spec.

Evidence:
Canonical SSZ definition in the repo clearly shows the correct type:
assets/eip-6404/ssz_types.py
class RlpSetCodeTransaction(Container):
    payload: RlpSetCodeTransactionPayload
    signature: Secp256k1ExecutionSignature
    
The Markdown spec had the wrong type in the EIP-7702 section (now corrected):
class RlpSetCodeTransaction(Container):
    payload: RlpSetCodeTransactionPayload
    signature: Secp256k1ExecutionSignature