### PR TITLE
Update EIP-7723: Include primary point of contact in proposal

### DIFF
--- a/EIPS/eip-7723.md
+++ b/EIPS/eip-7723.md
@@ -40,13 +40,9 @@ When preparing a network upgrade, client developers typically implement EIPs fir
 
 Since client developers' ability to include EIPs in a network upgrade is constrained by what can be implemented and tested in these upgrade devnets, the [Considered for Inclusion](#considered-for-inclusion) and [Scheduled for Inclusion](#scheduled-for-inclusion) sections below propose aligning these statuses with EIPs' implementation status in upgrade devnets.
 
-### Champion
-
-A "Champion" is the designated primary point of contact for an EIP throughout its lifecycle within a network upgrade. This individual may represent the EIP on relevant calls, respond to questions from client and testing teams, and coordinate efforts to advance the proposal - or delegate these responsibilities as needed.
-
 ### Proposed for Inclusion
 
-To propose an EIP for inclusion, someone **MUST** open a pull request to add it to the `Proposed for Inclusion` section of the Upgrade Meta EIP. The Champion **SHOULD** open that pull request. Reasonable pull requests **SHOULD** be merged in a timely fashion by the Upgrade Meta EIP author.
+To propose an EIP for inclusion, someone **MUST** open a pull request to add it to the `Proposed for Inclusion` section of the Upgrade Meta EIP. The proposer of an EIP **SHOULD** serve as the primary point of contact for that EIP for the duration of the upgrade cycle or **SHOULD** designate another person to serve in that role. Reasonable pull requests **SHOULD** be merged in a timely fashion by the Upgrade Meta EIP author.
 
 At this stage, implementation teams **SHOULD** review the EIP. For Core EIPs, this should be in the context of including it in the next upgrade. For non-Core EIPs, this should be in the context of supporting the EIP before the network upgrade is activated. 
  

--- a/EIPS/eip-7723.md
+++ b/EIPS/eip-7723.md
@@ -40,9 +40,13 @@ When preparing a network upgrade, client developers typically implement EIPs fir
 
 Since client developers' ability to include EIPs in a network upgrade is constrained by what can be implemented and tested in these upgrade devnets, the [Considered for Inclusion](#considered-for-inclusion) and [Scheduled for Inclusion](#scheduled-for-inclusion) sections below propose aligning these statuses with EIPs' implementation status in upgrade devnets.
 
+### Champion
+
+A "Champion" is the designated primary point of contact for an EIP throughout its lifecycle within a network upgrade. This individual may represent the EIP on relevant calls, respond to questions from client and testing teams, and coordinate efforts to advance the proposal - or delegate these responsibilities as needed.
+
 ### Proposed for Inclusion
 
-To propose an EIP for inclusion, someone **MUST** open a pull request to add it to the `Proposed for Inclusion` section of the Upgrade Meta EIP. Reasonable pull requests **SHOULD** be merged in a timely fashion by the Upgrade Meta EIP author.  
+To propose an EIP for inclusion, someone **MUST** open a pull request to add it to the `Proposed for Inclusion` section of the Upgrade Meta EIP. A Champion **SHOULD** be included in the body of the pull request. Reasonable pull requests **SHOULD** be merged in a timely fashion by the Upgrade Meta EIP author.  
 
 At this stage, implementation teams **SHOULD** review the EIP. For Core EIPs, this should be in the context of including it in the next upgrade. For non-Core EIPs, this should be in the context of supporting the EIP before the network upgrade is activated. 
  

--- a/EIPS/eip-7723.md
+++ b/EIPS/eip-7723.md
@@ -46,7 +46,7 @@ A "Champion" is the designated primary point of contact for an EIP throughout it
 
 ### Proposed for Inclusion
 
-To propose an EIP for inclusion, someone **MUST** open a pull request to add it to the `Proposed for Inclusion` section of the Upgrade Meta EIP. A Champion **SHOULD** be included in the body of the pull request. Reasonable pull requests **SHOULD** be merged in a timely fashion by the Upgrade Meta EIP author.  
+To propose an EIP for inclusion, someone **MUST** open a pull request to add it to the `Proposed for Inclusion` section of the Upgrade Meta EIP. The Champion **SHOULD** open that pull request. Reasonable pull requests **SHOULD** be merged in a timely fashion by the Upgrade Meta EIP author.
 
 At this stage, implementation teams **SHOULD** review the EIP. For Core EIPs, this should be in the context of including it in the next upgrade. For non-Core EIPs, this should be in the context of supporting the EIP before the network upgrade is activated. 
  


### PR DESCRIPTION
This PR introduces a minimally invasive EIP Champion role for the duration of the EIPs lifecycle in a given network upgrade. In short, a Champion is the primary point of contact, but may delegate as much of the responsibility as needed.

The motivation is to establish clear communication channels out of the gate, so that call facilitators, client teams, and testers know exactly who to reach out to to progress an EIP through the upgrade. The lack of a Champion may also be healthy nudge early in the process to nominate one.

The change is backwards compatible, as a Champion is not a strict requirement.

Implementation considerations:
- If desirable, the Champion names could be displayed in the meta EIP for ease of reference.
- I've left it undefined, but rotating a Champion should be low fuss, e.g., have an author or current champion comment on the merged PR to specify the new Champion.

---

Oct 1 edit: "Champion" language has been removed to avoid overloading the term introduced in EIP-1. Just designating a primary point of contact is enough to satisfy the goal of this change.