### PR TITLE
Update EIP-6404: correct type mismatches in RlpSetCodeTransaction definition

### DIFF
--- a/EIPS/eip-6404.md
+++ b/EIPS/eip-6404.md
@@ -354,7 +354,7 @@ class RlpSetCodeTransactionPayload(
     input_: ProgressiveByteList
     access_list: ProgressiveList[AccessTuple]
     max_priority_fees_per_gas: BasicFeesPerGas
-    authorization_list: ProgressiveList[RlpAuthorization]
+    authorization_list: ProgressiveList[RlpSetCodeAuthorization]
 
 class RlpSetCodeTransaction(Container):
     payload: RlpSetCodeTransactionPayload


### PR DESCRIPTION
fixed two type inconsistencies in the EIP-6404 specification:

fixed `authorization_list` type from undefined `RlpSetCodeAuthorization` to `RlpAuthorization` 
fixed `payload` type from `RlpAuthorization` to `RlpSetCodeTransactionPayload` to match naming convention used by all other transaction classes

