### PR TITLE
EIP-7928: Clarify BAL for precompiles

### DIFF
--- a/EIPS/eip-7928.md
+++ b/EIPS/eip-7928.md
@@ -163,6 +163,7 @@ Record **post‑transaction nonces** for:
 
 ### Edge Cases (Normative)
 
+- **Precompiled contracts:** Precompiles **MUST** be included when accessed. If a precompile receives value, it is recorded with a balance change. Otherwise, it is included with empty change lists.
 - **SENDALL:** For positive-value selfdestructs, the sender and beneficiary are recorded with a balance change.
 - **SELFDESTRUCT (in-transaction):** Accounts destroyed within a transaction **MUST** be included in `AccountChanges` without balance, nonce or code changes. Storage keys within the self-destructed contracts that were modified or read **MUST** be included as a `storage_read`.
 - **Accessed but unchanged:** Include the address with empty changes (e.g., targets of `EXTCODEHASH`, `EXTCODESIZE`, `BALANCE`, `STATICCALL`, etc.).


### PR DESCRIPTION
As discussed in the EIP-7928 Breakout Call Nr. 3, precompiles are included in the BAL if accessed.
Additionally, if they received value, this must be included as a balance change.