### PR TITLE
Update EIP-7594: Move to Last Call

### DIFF
--- a/EIPS/eip-7594.md
+++ b/EIPS/eip-7594.md
@@ -4,7 +4,8 @@ title: PeerDAS - Peer Data Availability Sampling
 description: Introducing simple DAS utilizing gossip distribution and peer requests
 author: Danny Ryan (@djrtwo), Dankrad Feist (@dankrad), Francesco D'Amato (@fradamt), Hsiao-Wei Wang (@hwwhww), Alex Stokes (@ralexstokes)
 discussions-to: https://ethereum-magicians.org/t/eip-7594-peerdas-peer-data-availability-sampling/18215
-status: Review
+status: Last Call
+last-call-deadline: 2025-10-28
 type: Standards Track
 category: Core
 created: 2024-01-12


### PR DESCRIPTION
Move EIP-7594 from Review to Last Call with deadline matching the activation on Hoodi testnet (2025-10-28).

This PR is part of moving EIP-7607 (Fusaka meta EIP) and its dependencies to Last Call status.

**Type of change:** Status update

🤖 Generated with [Claude Code](https://claude.ai/code)