### PR TITLE
Update EIP-7642: Move to Last Call

### DIFF
--- a/EIPS/eip-7823.md
+++ b/EIPS/eip-7823.md
@@ -4,7 +4,8 @@ title: Set upper bounds for MODEXP
 description: Each input field is restricted to a maximum of 8192 bits
 author: Alex Beregszaszi (@axic), Radoslaw Zagorowicz (@rodiazet)
 discussions-to: https://ethereum-magicians.org/t/eip-7823-set-upper-bounds-for-modexp/21798
-status: Review
+status: Last Call
+last-call-deadline: 2025-10-28
 type: Standards Track
 category: Core
 created: 2024-11-11


### PR DESCRIPTION
Move EIP-7642 from Review to Last Call with deadline matching the activation on Hoodi testnet (2025-10-28).

This PR is part of moving EIP-7607 (Fusaka meta EIP) and its dependencies to Last Call status.

**Type of change:** Status update

🤖 Generated with [Claude Code](https://claude.ai/code)