### PR TITLE
Update EIP-7825: Move to Last Call

### DIFF
--- a/EIPS/eip-7825.md
+++ b/EIPS/eip-7825.md
@@ -4,7 +4,8 @@ title: Transaction Gas Limit Cap
 description: Introduce a protocol-level cap on the maximum gas used by a transaction to 16,777,216 (2^24).
 author: Giulio Rebuffo (@Giulio2002), Toni Wahrstätter (@nerolation)
 discussions-to: https://ethereum-magicians.org/t/eip-7825-transaction-gas-limit-cap/21848
-status: Review
+status: Last Call
+last-call-deadline: 2025-10-28
 type: Standards Track
 category: Core
 created: 2024-11-23


### PR DESCRIPTION
Move EIP-7825 from Review to Last Call with deadline matching the activation on Hoodi testnet (2025-10-28).

This PR is part of moving EIP-7607 (Fusaka meta EIP) and its dependencies to Last Call status.

**Type of change:** Status update

🤖 Generated with [Claude Code](https://claude.ai/code)