### PR TITLE
Update EIP-7883: Move to Last Call

### DIFF
--- a/EIPS/eip-7883.md
+++ b/EIPS/eip-7883.md
@@ -4,7 +4,8 @@ title: ModExp Gas Cost Increase
 description: Increases cost of ModExp precompile
 author: Marcin Sobczak (@marcindsobczak), Marek Moraczyński (@MarekM25), Marcos Maceo (@stdevMac)
 discussions-to: https://ethereum-magicians.org/t/eip-7883-modexp-gas-cost-increase/22841
-status: Review
+status: Last Call
+last-call-deadline: 2025-10-28
 type: Standards Track
 category: Core
 created: 2025-02-11


### PR DESCRIPTION
Move EIP-7883 from Review to Last Call with deadline matching the activation on Hoodi testnet (2025-10-28).

This PR is part of moving EIP-7607 (Fusaka meta EIP) and its dependencies to Last Call status.

**Type of change:** Status update

🤖 Generated with [Claude Code](https://claude.ai/code)