### PR TITLE
Update EIP-7917: Move to Last Call

### DIFF
--- a/EIPS/eip-7917.md
+++ b/EIPS/eip-7917.md
@@ -4,7 +4,8 @@ title: Deterministic proposer lookahead
 description: Pre-calculate and store a deterministic proposer lookahead in the beacon state at the start of every epoch
 author: Lin Oshitani (@linoscope) <lin@nethermind.io>, Justin Drake (@JustinDrake) <justin@ethereum.org>
 discussions-to: https://ethereum-magicians.org/t/eip-7917-deterministic-proposer-lookahead/23259
-status: Review
+status: Last Call
+last-call-deadline: 2025-10-28
 type: Standards Track
 category: Core
 created: 2025-03-24


### PR DESCRIPTION
Move EIP-7917 from Review to Last Call with deadline matching the activation on Hoodi testnet (2025-10-28).

This PR is part of moving EIP-7607 (Fusaka meta EIP) and its dependencies to Last Call status.

**Type of change:** Status update

🤖 Generated with [Claude Code](https://claude.ai/code)