### PR TITLE
Update EIP-7918: Move to Last Call

### DIFF
--- a/EIPS/eip-7918.md
+++ b/EIPS/eip-7918.md
@@ -4,7 +4,8 @@ title: Blob base fee bounded by execution cost
 description: Imposes that the price of GAS_PER_BLOB blob gas is greater than the price of BLOB_BASE_COST execution gas.
 author: Anders Elowsson (@anderselowsson), Ben Adams (@benaadams), Francesco D'Amato (@fradamt)
 discussions-to: https://ethereum-magicians.org/t/eip-blob-base-fee-bounded-by-price-of-blob-carrying-transaction/23271
-status: Review
+status: Last Call
+last-call-deadline: 2025-10-28
 type: Standards Track
 category: Core
 created: 2025-03-25


### PR DESCRIPTION
Move EIP-7918 from Review to Last Call with deadline matching the activation on Hoodi testnet (2025-10-28).

This PR is part of moving EIP-7607 (Fusaka meta EIP) and its dependencies to Last Call status.

**Type of change:** Status update

🤖 Generated with [Claude Code](https://claude.ai/code)