### PR TITLE
Update EIP-7934: Move to Last Call

### DIFF
--- a/EIPS/eip-7934.md
+++ b/EIPS/eip-7934.md
@@ -4,7 +4,8 @@ title: RLP Execution Block Size Limit
 description: Introduce a protocol-level cap on the maximum RLP-encoded block size to 10 MiB, including a 2 MiB margin for beacon block size.
 author: Giulio Rebuffo (@Giulio2002), Ben Adams (@benaadams), Storm Slivkoff (@sslivkoff)
 discussions-to: https://ethereum-magicians.org/t/eip-7934-add-bytesize-limit-to-blocks/23589
-status: Review
+status: Last Call
+last-call-deadline: 2025-10-28
 type: Standards Track
 category: Core
 created: 2025-04-16


### PR DESCRIPTION
Move EIP-7934 from Review to Last Call with deadline matching the activation on Hoodi testnet (2025-10-28).

This PR is part of moving EIP-7607 (Fusaka meta EIP) and its dependencies to Last Call status.

**Type of change:** Status update

🤖 Generated with [Claude Code](https://claude.ai/code)