### PR TITLE
Update EIP-7939: Move to Last Call

### DIFF
--- a/EIPS/eip-7939.md
+++ b/EIPS/eip-7939.md
@@ -4,7 +4,8 @@ title: Count leading zeros (CLZ) opcode
 description: Opcode to count the number of leading zero bits in a 256-bit word
 author: Vectorized (@Vectorized), Georgios Konstantopoulos (@gakonst), Jochem Brouwer (@jochem-brouwer), Ben Adams (@benaadams), Giulio Rebuffo (@Giulio2002)
 discussions-to: https://ethereum-magicians.org/t/create-a-new-opcode-for-counting-leading-zeros-clz/10805
-status: Review
+status: Last Call
+last-call-deadline: 2025-10-28
 type: Standards Track
 category: Core
 created: 2025-04-28


### PR DESCRIPTION
Move EIP-7939 from Review to Last Call with deadline matching the activation on Hoodi testnet (2025-10-28).

This PR is part of moving EIP-7607 (Fusaka meta EIP) and its dependencies to Last Call status.

**Type of change:** Status update

🤖 Generated with [Claude Code](https://claude.ai/code)