### PR TITLE
Update EIP-7951: Move to Last Call

### DIFF
--- a/EIPS/eip-7951.md
+++ b/EIPS/eip-7951.md
@@ -4,7 +4,8 @@ title: Precompile for secp256r1 Curve Support
 description: Add precompiled contract for secp256r1 ECDSA signature verification with proper security checks
 author: Carl Beekhuizen (@carlbeek), Ulaş Erdoğan (@ulerdogan), Doğan Alpaslan (@doganalpaslan)
 discussions-to: https://ethereum-magicians.org/t/eip-7951-precompile-for-secp256r1-curve-support/24360
-status: Review
+status: Last Call
+last-call-deadline: 2025-10-28
 type: Standards Track
 category: Core
 created: 2025-05-27


### PR DESCRIPTION
Move EIP-7951 from Review to Last Call with deadline matching the activation on Hoodi testnet (2025-10-28).

This PR is part of moving EIP-7607 (Fusaka meta EIP) and its dependencies to Last Call status.

**Type of change:** Status update

🤖 Generated with [Claude Code](https://claude.ai/code)