### PR TITLE
Update EIP-7892: Move to Last Call

### DIFF
--- a/EIPS/eip-7892.md
+++ b/EIPS/eip-7892.md
@@ -4,7 +4,8 @@ title: Blob Parameter Only Hardforks
 description: Defines a mechanism for scaling Ethereum’s blob capacity via specialized hard forks that modify only blob-related parameters.
 author: Mark Mackey (@ethDreamer), Raúl Kripalani (@raulk)
 discussions-to: https://ethereum-magicians.org/t/eip-7892-blob-parameter-only-hardforks/23018
-status: Review
+status: Last Call
+last-call-deadline: 2025-10-28
 type: Informational
 created: 2025-02-28
 requires: 7840


### PR DESCRIPTION
Move EIP-7892 from Review to Last Call with deadline matching the activation on Hoodi testnet (2025-10-28).

This PR is part of moving EIP-7607 (Fusaka meta EIP) and its dependencies to Last Call status.

**Type of change:** Status update

🤖 Generated with [Claude Code](https://claude.ai/code)