### PR TITLE
Update EIP-7910: Move to Last Call

### DIFF
--- a/EIPS/eip-7910.md
+++ b/EIPS/eip-7910.md
@@ -4,7 +4,8 @@ title: eth_config JSON-RPC Method
 description: A JSON-RPC method that describes the configuration of the current and next fork
 author: Danno Ferrin (@shemnon)
 discussions-to: https://ethereum-magicians.org/t/eth-config-json-rpc-method/23183
-status: Review
+status: Last Call
+last-call-deadline: 2025-10-28
 type: Standards Track
 category: Interface
 created: 2025-03-18


### PR DESCRIPTION
Move EIP-7910 from Review to Last Call with deadline matching the activation on Hoodi testnet (2025-10-28).

This PR is part of moving EIP-7607 (Fusaka meta EIP) and its dependencies to Last Call status.

**Type of change:** Status update

🤖 Generated with [Claude Code](https://claude.ai/code)