### PR TITLE
Update EIP-7935: Move to Last Call

### DIFF
--- a/EIPS/eip-7935.md
+++ b/EIPS/eip-7935.md
@@ -4,7 +4,8 @@ title: Set default gas limit to 60M
 description: Recommend a new gas limit value for Fusaka and update execution layer client default configs
 author: Sophia Gold (@sophia-gold), Parithosh Jayanthi (@parithoshj), Toni Wahrstätter (@nerolation), Carl Beekhuizen (@CarlBeek), Ansgar Dietrichs (@adietrichs), Dankrad Feist (@dankrad), Alex Stokes (@ralexstokes), Josh Rudolph (@jrudolph), Giulio Rebuffo (@Giulio2002), Storm Slivkoff (@sslivkoff)
 discussions-to: https://ethereum-magicians.org/t/eip-7935-set-default-gas-limit-to-xx0m/23789
-status: Review
+status: Last Call
+last-call-deadline: 2025-10-28
 type: Informational
 created: 2025-04-22
 ---


### PR DESCRIPTION
Move EIP-7935 from Review to Last Call with deadline matching the activation on Hoodi testnet (2025-10-28).

This PR is part of moving EIP-7607 (Fusaka meta EIP) and its dependencies to Last Call status.

**Type of change:** Status update

🤖 Generated with [Claude Code](https://claude.ai/code)