### PR TITLE
Update EIP-7607: Move to Last Call

### DIFF
--- a/EIPS/eip-7607.md
+++ b/EIPS/eip-7607.md
@@ -4,7 +4,8 @@ title: Hardfork Meta - Fusaka
 description: EIPs included in the Fulu/Osaka Ethereum network upgrade.
 author: Tim Beiko (@timbeiko), Alex Stokes (@ralexstokes), Ansgar Dietrichs (@adietrichs)
 discussions-to: https://ethereum-magicians.org/t/eip-7607-fusaka-meta-eip/18439
-status: Review
+status: Last Call
+last-call-deadline: 2025-10-28
 type: Meta
 created: 2024-02-01
 requires: 7600


### PR DESCRIPTION
Move EIP-7607 from Review to Last Call with deadline matching the activation on Hoodi testnet (2025-10-28).

## Blocked by:

**Core EIPs:**
- [ ] #10400
- [ ] #10412
- [ ] #10413
- [ ] #10414
- [ ] #10415
- [ ] #10416
- [ ] #10417
- [ ] #10418
- [ ] #10419

**Other EIPs:**
- [ ] #10420
- [ ] #10421
- [ ] #10422

**Note:** EIP-7642 is already in Final status and does not need to move to Last Call.

**Type of change:** Status update

🤖 Generated with [Claude Code](https://claude.ai/code)