### PR TITLE
Config: fix malformed regex pattern in mlc_config.json

### DIFF
--- a/config/mlc_config.json
+++ b/config/mlc_config.json
@@ -1,6 +1,7 @@
 {
   "ignorePatterns": [
-    "[`]*csl-json"
+    // Escaping ']' to avoid malformed character class in regex; matches optional backticks before 'csl-json'
+    "[`\]]*csl-json"
   ],
   "replacementPatterns": [
     {


### PR DESCRIPTION


**Problem**: The regex pattern `"[`]*csl-json"` in `config/mlc_config.json` contains an unescaped closing bracket `]` within a character class, which can cause incorrect pattern matching behavior.

**Solution**: Escape the closing bracket to ensure proper regex parsing:
- **Before**: `"[`]*csl-json"`  
- **After**: `"[`\]]*csl-json"`



---
