### PR TITLE
Update EIP-7910: add P256 precompile for Osaka

### DIFF
--- a/EIPS/eip-7910.md
+++ b/EIPS/eip-7910.md
@@ -89,6 +89,8 @@ For Cancun, the contract names are (in order): `ECREC`, `SHA256`, `RIPEMD160`, `
 
 For Prague, the added contracts are (in order): `BLS12_G1ADD`, `BLS12_G1MSM`, `BLS12_G2ADD`, `BLS12_G2MSM`, `BLS12_PAIRING_CHECK`, `BLS12_MAP_FP_TO_G1`, `BLS12_MAP_FP2_TO_G2`.
 
+For Osaka, the added contract is: `P256VERIFY`.
+
 #### `systemContracts`
 
 A JSON object representing system-level contracts relevant to the fork, as introduced in their defining EIPs. Keys are the contract names (e.g., `BEACON_ROOTS_ADDRESS`) from the first EIP where they appeared, sorted alphabetically. Values are 20-byte addresses in `0x`-prefixed hexadecimal form, with leading zeros preserved, in lower case. Omitted for forks before Cancun.


### PR DESCRIPTION
The EIP is missing the `P256` precompile introduced in Osaka. As such, some clients (like [Reth](https://github.com/paradigmxyz/reth/pull/18744)) introduced such a precompile under the name `P256_VERIFY` while other clients used `P256VERIFY`. This inconsistency could introduce issues when automated tools check that the config among all clients are the same, so this PR.