### PR TITLE
Add EIP: On-chain Proof Verification Standard

### DIFF
--- a/EIPS/eip-draft-on-chain-proof-verification.md
+++ b/EIPS/eip-draft-on-chain-proof-verification.md
@@ -3,7 +3,7 @@ eip: <to be assigned>
 title: On-chain Proof Verification Standard
 description: A minimal, proof-system-agnostic interface for on-chain verification of succinct zero-knowledge proofs (SNARKs/STARKs) and zkVM receipts, using field-aligned public inputs (bytes32[]).
 author: Walid Khemiri <walidelkhemiri@gmail.com>
-discussions-to: 
+discussions-to: https://ethereum-magicians.org/t/erc-on-chain-proof-verification-standardization/25612
 status: Draft
 type: Standards Track
 category: ERC


### PR DESCRIPTION
This PR proposes a minimal, proof-system-agnostic interface for on-chain verification of succinct zero-knowledge proofs. The interface standardizes a single entrypoint:

function isValidProof(
    bytes32 schema,
    bytes32[] calldata publicInputs,
    bytes calldata proof
) external view returns (bytes4 magicValue);


Callers pass field-aligned public inputs (bytes32[]) and an opaque proof; implementations return a magic value on success. All domain-separation fields (e.g., chainId, verifyingContract, nonce, expiry) are carried inside publicInputs and MUST be consumed as public signals by the underlying verifier. The draft includes simple adapters for a Groth16 circuit and a zkVM receipt (SNARK/STARK-backed), showing how to map bytes32[] lanes to the verifier’s uint256[] inputs. The scope is intentionally narrow: define the interface and a clear encoding discipline—no routing, registries, or key-management conventions.

What feedback I’m seeking

Is the verification interface sufficiently abstract—i.e., independent of specific proof systems and implementations?

Interface shape: Does schema + bytes32[] publicInputs + bytes proof cover your SNARK/STARK/zkVM/Recursion integration needs without extra parameters? 


Lane discipline: Any objections to requiring fixed lane order, big-endian numeric interpretation, and (if applicable) pre-reduction to the target field?

Domain separation: Are chainId, verifyingContract, nonce, expiry (or your equivalents) sufficient and practical as public signals?

zkVM receipts: Is exposing programId and journalHash as bytes32 lanes workable across existing zkVM toolchains?

Error semantics: Any concerns with “return magic value on success; otherwise any other value; do not revert on invalid proofs”?

Interoperability risks: Are there proof systems or popular verifier contracts that would struggle with bytes32[] lanes?

Versioning via schema: Is minting a new schema ID on layout change acceptable for ecosystem evolution?

