### PR TITLE
Update EIP-7928: Further clarify balance changes for in-transaction self-destruct

### DIFF
--- a/EIPS/eip-7928.md
+++ b/EIPS/eip-7928.md
@@ -178,7 +178,7 @@ Record **post‑transaction nonces** for:
 
 - **Precompiled contracts:** Precompiles **MUST** be included when accessed. If a precompile receives value, it is recorded with a balance change. Otherwise, it is included with empty change lists.
 - **SENDALL:** For positive-value selfdestructs, the sender and beneficiary are recorded with a balance change.
-- **SELFDESTRUCT (in-transaction):** Accounts destroyed within a transaction **MUST** be included in `AccountChanges` without code changes. However, if the account had a positive balance pre-transaction, the balance change to zero **MUST** be recorded. Storage keys within the self-destructed contracts that were modified or read **MUST** be included as a `storage_read`. 
+- **SELFDESTRUCT (in-transaction):** Accounts destroyed within a transaction **MUST** be included in `AccountChanges` without nonce or code changes. However, if the account had a positive balance pre-transaction, the balance change to zero **MUST** be recorded. Storage keys within the self-destructed contracts that were modified or read **MUST** be included as a `storage_read`. 
 - **Accessed but unchanged:** Include the address with empty changes (e.g., targets of `EXTCODEHASH`, `EXTCODESIZE`, `BALANCE`, `STATICCALL`, etc.).
 - **Zero‑value transfers:** Include the address; omit from `balance_changes`.
 - **Gas refunds:** Record the **final** balance of the sender after each transaction.


### PR DESCRIPTION
This clarifies: In case an account that does an in-transaction self-destruct and had a positive balance pre-tx, then the balance change to 0 must be included in the BAL.