### PR TITLE
PFI Remove bloom filters Glamsterdam

### DIFF
--- a/EIPS/eip-7773.md
+++ b/EIPS/eip-7773.md
@@ -56,7 +56,7 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Declined
 1. [EIP-7976](./eip-7976.md): Increase Calldata Floor Cost
 1. [EIP-2780](./eip-2780.md): Reduce intrinsic transaction gas
 1. [EIP-7610](./eip-7610.md): Revert creation in case of non-empty storage
-
+1. [EIP-7668](./eip-7668.md): Remove bloom filters
 
 ### Activation
 


### PR DESCRIPTION
Bloom filters use space, have to be calculated, and are often full and near-useless. Let's remove it.