### PR TITLE
Website: add security attributes to external link

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@ title: Home
   <a href="rss/nonerc.xml"><img src="https://img.shields.io/badge/rss-All except ERC-red.svg" alt="RSS"></a>
   <a href="https://eepurl.com/ikqNIP"><img src="https://img.shields.io/badge/-email%20alerts-red.svg" alt="RSS"></a>
 </h1>
-<p>Ethereum Improvement Proposals (EIPs) describe standards for the Ethereum platform, including core protocol specifications, client APIs, and contract standards. Network upgrades are discussed separately in the <a target="_blank" href="https://github.com/ethereum/pm/">Ethereum Project Management</a> repository.</p>
+<p>Ethereum Improvement Proposals (EIPs) describe standards for the Ethereum platform, including core protocol specifications, client APIs, and contract standards. Network upgrades are discussed separately in the <!-- Prevent reverse-tabnabbing --> <a target="_blank" rel="noopener noreferrer" href="https://github.com/ethereum/pm/">Ethereum Project Management</a> repository.</p>
 
 <h2>Contributing</h2>
 <p>First review <a href="EIPS/eip-1">EIP-1</a>. Then clone the repository and add your EIP to it. There is a <a href="https://github.com/ethereum/EIPs/blob/master/eip-template.md?plain=1">template EIP here</a>. Then submit a Pull Request to Ethereum's <a href="https://github.com/ethereum/EIPs">EIPs repository</a>.</p>


### PR DESCRIPTION


**Problem:** External link with `target="_blank"` lacks `rel="noopener noreferrer"` attributes, creating a potential reverse-tabnabbing vulnerability.

**Solution:** Added `rel="noopener noreferrer"` to the Ethereum Project Management repository link in `index.html` to prevent the opened page from accessing `window.opener`.

