### PR TITLE
Website: TOC link breakage when headings contain square brackets

### DIFF
--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -80,8 +80,9 @@
     {% endif %}
 
     {% capture heading_body %}{% if include.sanitize %}{{ header | strip_html }}{% else %}{{ header }}{% endif %}{% endcapture %}
+    {% comment %} Escape brackets in heading text to prevent Markdown link breakage in TOC {% endcomment %}
     {% capture my_toc %}{{ my_toc }}
-{{ space }}{{ listModifier }} {{ listItemClass }} [{{ heading_body | replace: "|", "\|" }}]({% if include.baseurl %}{{ include.baseurl }}{% endif %}#{{ html_id }}){% if include.anchor_class %}{:.{{ include.anchor_class }}}{% endif %}{% endcapture %}
+{{ space }}{{ listModifier }} {{ listItemClass }} [{{ heading_body | replace: "|", "\|" | replace: "[", "\[" | replace: "]", "\]" }}]({% if include.baseurl %}{{ include.baseurl }}{% endif %}#{{ html_id }}){% if include.anchor_class %}{:.{{ include.anchor_class }}}{% endif %}{% endcapture %}
 {% endfor %}
 
 {% if include.class and include.class != blank %}


### PR DESCRIPTION

## Problem
Table of Contents (TOC) links break when heading text contains square brackets `[` or `]`, causing malformed Markdown links and broken navigation.

## Solution
- Escape square brackets in heading text: `[` → `\[` and `]` → `\]`

## Files Changed
- `_includes/toc.html` - Enhanced bracket escaping in TOC link generation

