### PR TITLE
Update EIP-7799: Add EIP-4788 to requires

### DIFF
--- a/EIPS/eip-7799.md
+++ b/EIPS/eip-7799.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2024-10-29
-requires: 1559, 4895, 6466, 7708, 7916
+requires: 1559, 4788, 4895, 6466, 7708, 7916
 ---
 
 ## Abstract


### PR DESCRIPTION
- EIP-7799 references SYSTEM_ADDRESS via a parenthetical link to EIP-4788 in multiple tables.
- To keep the reference normative and unambiguous, explicitly list EIP-4788 in the requires field.
- This aligns with the document’s current usage (linking to 4788 as the source of SYSTEM_ADDRESS) and avoids ambiguity about the constant’s origin without duplicating its definition locally.