### PR TITLE
Update EIP-2711: fix minor typos

### DIFF
--- a/EIPS/eip-2711.md
+++ b/EIPS/eip-2711.md
@@ -23,7 +23,7 @@ An EIP-2718 transaction with the type number `2` is a new type of transaction th
 ### Sponsored Transactions
 With the advent of tokens and especially stable coins, it has become common for users to not hold ETH in an account while they may have other assets of value in that account.  Some users don't want to be exposed to the perceived volatility of ETH and instead would prefer to transact using other assets.  Unfortunately, since gas **MUST** be paid for with ETH, this prevents the user from transacting with their assets without first acquiring some ETH using some other means, and then using that ETH to pay fees.
 
-This EIP proposes a mechanism by which we can allow people to transact without ever having to own any ETH by allowing someone else to cover gas costs.  The arrangements that enable the covering of gas costs is out of scope for this EIP but it could be an extra-protocol monthly subscription, payment could occur as part of the transaction being submitted, the recpient may be willing to cover gas costs, or it could be a free service offered as a value-add by a company that you are working with.
+This EIP proposes a mechanism by which we can allow people to transact without ever having to own any ETH by allowing someone else to cover gas costs.  The arrangements that enable the covering of gas costs is out of scope for this EIP but it could be an extra-protocol monthly subscription, payment could occur as part of the transaction being submitted, the recipient may be willing to cover gas costs, or it could be a free service offered as a value-add by a company that you are working with.
 
 While it is possible to implement these sort of mechanisms at the individual contract layer, such solutions require integration by just about every contract and those solutions also end up depending on gas costs being stable with time in order to appropriately bake them into contracts without putting either party at risk of malicious participants in the system.  For this reason, it is believed that separating out `GAS_PAYER` from `msg.sender` at the protocol layer is valuable.
 
@@ -121,7 +121,7 @@ For the dust-account clearing usecase,
 - The unix time is generally available in most settings, even on a computer which is offline. This means that even a setup where blockchain information is unavailable, the party signing a transaction can generate a transaction with the desired properties. 
 - The correlation between time and block number is not fixed; even though a 13s blocktime is 'desired', this varies due to both network hashrate and difficulty bomb progression. 
 - The block number is even more unreliable as a timestamp for testnets and private networks.
-- unix time is more user-friendly, a user can more easily decide on reasonable end-date for a transaction, rather than a suitalbe number of valid blocks.
+- unix time is more user-friendly, a user can more easily decide on reasonable end-date for a transaction, rather than a suitable number of valid blocks.
 
 ## Backwards Compatibility
 No known issues.


### PR DESCRIPTION
spotted a few small typos while going through EIP-2711:

* `recpient` → `recipient`
* `suitalbe` → `suitable`