### PR TITLE
Update EIP-8016: fix errors

### DIFF
--- a/EIPS/eip-8016.md
+++ b/EIPS/eip-8016.md
@@ -44,9 +44,9 @@ The [default value](https://github.com/ethereum/consensus-specs/blob/ad36024441c
 
 The following types are considered [illegal](https://github.com/ethereum/consensus-specs/blob/ad36024441cf910d428d03f87f331fbbd2b3e5f1/ssz/simple-serialize.md#illegal-types):
 
-- `CompatibleUnion({})` without any type options is illegal.
-- `CompatibleUnion({selector: type})` with a selector outside `uint8(1)` through `uint8(127)` is illegal.
-- `CompatibleUnion({selector: type})` with a type option that has incompatible Merkleization with another type option is illegal.
+- `CompatibleUnion({})` without any type options are illegal.
+- `CompatibleUnion({selector: type})` with a selector outside `uint8(1)` through `uint8(127)` are illegal.
+- `CompatibleUnion({selector: type})` with a type option that has incompatible Merkleization with another type option are illegal.
 
 #### Compatible Merkleization
 


### PR DESCRIPTION
Fixed 4 grammatical errors related to subject-verb agreement:
- Line 32: `composite types` → `composite type` (singular after `A new`)
