### PR TITLE
Update EIP-3416: fix minor typos

### DIFF
--- a/EIPS/eip-3416.md
+++ b/EIPS/eip-3416.md
@@ -25,7 +25,7 @@ Then there is a gas premium that is directly computed as 50% of (fee cap - base 
 
 We target the following goals:
 
-* Gas prices spikes are mathematically smoothed out. EIP1559 does not seems to really tackle gas premium volatility and UX.
+* Gas prices spikes are mathematically smoothed out. EIP1559 does not seem to really tackle gas premium volatility and UX.
 * Maintain gas price preference, i.e. transaction senders willing to pay extra in fees will be rewarded with early preferential inclusion in the blocks, because the miners want to maximize their profits and include transactions with higher fee caps first to maximize the median.
 * Final gas price paid by the sender is, most of the time, smaller than the maximum gas price specified by sender. 
 * Gas pricing is more robust to sender manipulation or miner manipulation.
@@ -60,7 +60,7 @@ This is a classic fork without a long migration time.
 * At `block.number == FORK_BLOCK_NUMBER` we set `BASE_FEE = INITIAL_BASE_FEE`
 * `BASE_FEE` is set, from `FORK_BLOCK_NUMBER + 1`, as follows
   * Let `GAS_DELTA = (PARENT_GAS_USED - PARENT_GAS_TARGET) // PARENT_GAS_TARGET` (possibly negative).
-  * Set `BASE_FEE = PARENT_BASE_FEE + GSA_DELTA * BASE_FEE_MAX_CHANGE`
+  * Set `BASE_FEE = PARENT_BASE_FEE + GAS_DELTA * BASE_FEE_MAX_CHANGE`
 * Transactions since `FORK_BLOCK_NUMBER` are encoded the same as the current ones `rlp([nonce, gasPrice, gasLimit, to, value, data, v, r, s])` where `v,r,s` is a signature of `rlp([nonce, gasPrice, gasLimit, to, value, data])` and `gasPrice` is the `FEE_CAP` specified by the sender according to this proposal.
 * To produce transactions since `FORK_BLOCK_NUMBER`, the new `FEE_CAP` field (maintaining legacy name of `gasPrice` in the transaction) is set as follows (and the `GAS_PREMIUM` is computed as specified):
   * `FEE_CAP`: `tx.gasPrice`, serves as the absolute maximum that the transaction sender is willing to pay.
@@ -75,7 +75,7 @@ The miners can still use a `greedy` strategy to include new transactions in the 
 
 ## Rationale 
 
-The rationale behind the premium being 50% of (fee cap - base fee) is that at any given point the average network sender has an average fee cap, and we assume that between base fee and fee cap the sender has no specific preference, as long as the transaction is included in some block. Then, the sender is happy with a median premium among this uniform range. Another justification can be that the user also knows that this new version of the pricing protocol for the complete block uses a median, then is fair for him to apply a median within his preferential range, assuming an uniform sampling there. Simulations ([here](https://hackmd.io/c6kyRNMuTnKf_SlolmevRg#An-improvement-for-the-premium)) with Ethereum gas data shows indeed that median one of the most robust metric.s
+The rationale behind the premium being 50% of (fee cap - base fee) is that at any given point the average network sender has an average fee cap, and we assume that between base fee and fee cap the sender has no specific preference, as long as the transaction is included in some block. Then, the sender is happy with a median premium among this uniform range. Another justification can be that the user also knows that this new version of the pricing protocol for the complete block uses a median, then is fair for him to apply a median within his preferential range, assuming an uniform sampling there. Simulations ([here](https://hackmd.io/c6kyRNMuTnKf_SlolmevRg#An-improvement-for-the-premium)) with Ethereum gas data shows indeed that median one of the most robust metrics.
 
 The 5% top outliers removal, not considered in the median, or similar number, is to give extra robustness against miner manipulation, because as current network utilization has been around 97% for the last 6 months the miners can include their own transactions on the empty 3% to try to manipulate and increase the median price (even this manipulation effect will be very small on the final price).
 
@@ -87,7 +87,7 @@ The rationale for the `BASE_FEE_MAX_CHANGE` being `1 // 8` is that the `BASE_FEE
 
 ## Backwards Compatibility
 
-The backward compatibility is very straightforward because there are no new fields added to the transactions. Pricing of the gas per block on the miner/validator side is still fast to compute but a little more complex. Changes only affect miners/validators. Wallets are no affected by this proposal.
+The backward compatibility is very straightforward because there are no new fields added to the transactions. Pricing of the gas per block on the miner/validator side is still fast to compute but a little more complex. Changes only affect miners/validators. Wallets are not affected by this proposal.
 
 ## Test Cases
 


### PR DESCRIPTION
spotted a few small typos while going through EIP-3416:

1. `metric.s` → `metrics`
2. `does not seems` → `does not seem`
3. `no affected` → `not affected`
4. `GSA_DELTA` → `GAS_DELTA`