### PR TITLE
CI: upgrade to Node.js 24

### DIFF
--- a/.github/workflows/auto-stagnate-bot.yml
+++ b/.github/workflows/auto-stagnate-bot.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node.js Environment
         uses: actions/setup-node@d98fa1113850e562f83c7fc3a89c0ecd7a87fbed
         with:
-          node-version: '14'
+          node-version: '24'
       - name: auto-stagnant-bot
         uses: ethereum/EIP-Bot@b3ac0ba3600aea27157fc68d1e36c08cc5a6db77 # mark-eips-stale
         id: auto-stagnant-bot


### PR DESCRIPTION
This PR updates the GitHub Actions workflow to use Node.js 24 instead of 14.

Node.js 24 includes updated V8, npm 11, and other performance and compatibility improvements.
No other changes were required. CI and lint checks run successfully under the new version.

Reference:https://github.com/nodejs/node/releases/tag/v24.4.1