### PR TITLE
Update EIP-7807: Fix ProgressiveContainer syntax in GasAmounts

### DIFF
--- a/EIPS/eip-7807.md
+++ b/EIPS/eip-7807.md
@@ -40,7 +40,7 @@ The different kinds of gas amounts are combined into a single structure, mirrori
 | [`GasAmount`](./eip-6404.md#normalized-transactions) | `uint64` |
 
 ```python
-class GasAmounts(ProgressiveContainer((active_fields=[1, 1]))):
+class GasAmounts(ProgressiveContainer(active_fields=[1, 1])):
     regular: GasAmount
     blob: GasAmount
 ```


### PR DESCRIPTION
Remove redundant parentheses in ProgressiveContainer constructor call.

Changed `ProgressiveContainer((active_fields=[1, 1]))` to `ProgressiveContainer(active_fields=[1, 1])` to match the correct syntax used in ExecutionBlockHeader and ExecutionPayload classes.