### PR TITLE
Add EIP: State-access gas cost increase

### DIFF
--- a/EIPS/eip-8038.md
+++ b/EIPS/eip-8038.md
@@ -1,6 +1,6 @@
 ---
 eip: 8038
-title: Further increase in state access costs
+title: State-access gas cost increase
 description: Increases the gas cost of state-access operations to reflect Ethereum’s larger state
 author: Maria Silva (@misilva73), Wei Han Ng (@weiihann), Ansgar Dietrichs (@adietrichs)
 discussions-to: https://ethereum-magicians.org/t/eip-8038-further-increase-in-state-access-costs/25693
@@ -8,6 +8,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2025-10-03
+requires: 2926, 7928, 8032
 ---
 
 ## Abstract
@@ -16,7 +17,7 @@ This EIP updates the gas cost of state-access operations to reflect Ethereum’s
 
 ## Motivation
 
-The gas price of accessing state has not been updated for quite some time. EIP-2929 was included in the Berlin fork in March 2021 and raised the costs of state-accessing opcodes. Yet, since then, Ethereum's state has grown significantly, thus deteriorating the performance of these operations. This proposal further raises state access costs to better align them with the current performance of state access operations, in relation to other operations.
+The gas price of accessing state has not been updated for quite some time. [EIP-2929](eip-2929.md) was included in the Berlin fork in March 2021 and raised the costs of state-accessing opcodes. Yet, since then, Ethereum's state has grown significantly, thus deteriorating the performance of these operations. This proposal further raises state access costs to better align them with the current performance of state access operations, in relation to other operations.
 
 Additionally, `EXTCODESIZE` and `EXTCODECOPY` have the same access cost as `BALANCE` and `EXTCODEHASH`. However, `EXTCODESIZE` and `EXTCODECOPY` require two database reads - first to load the account object (which includes the `nonce`, `balance`, `codeHash` and `storageRoot`), and second to collect the required information (the code size and bytecode respectively). Therefore, the access cost of `EXTCODESIZE` and `EXTCODECOPY` should be higher when compared with the other account read operations.
 
@@ -30,6 +31,8 @@ Upon activation of this EIP, the following parameters of the gas model are updat
 | `GAS_COLD_SLOAD` | 2,100 | TBD | TBD | `SSTORE` and `SLOAD` |
 | `GAS_COLD_ACCOUNT_ACCESS` | 2,600 | TBD | TBD | `*CALL` opcodes, `BALANCE`, `SELFDESTRUCT` and `EXT*` opcodes |
 | `GAS_WARM_ACCESS` | 100 | TBD | TBD | `SSTORE`, `SLOAD`, `*CALL` opcodes, `BALANCE` and `EXT*` opcodes |
+
+<-- TODO -->
 
 Besides these parameter changes, the gas cost formula for `EXTCODESIZE` and `EXTCODECOPY` is updated to include an additional `GAS_WARM_ACCESS`:
 
@@ -46,6 +49,8 @@ else:
 ### Benchmarking
 
 This proposal does not yet have finalized numbers. To achieve this, we require stateful benchmarks, which are currently in development. Once we collect that data, we will set the final numbers.
+
+<-- TODO -->
 
 ### Special case for `EXTCODESIZE` and `EXTCODECOPY`
 


### PR DESCRIPTION
EIP-8038: State-access gas cost increase

Increases the gas cost of state-access operations to reflect Ethereum’s larger state
