### PR TITLE
Update EIP-7916: fixing markdown link

### DIFF
--- a/EIPS/eip-7916.md
+++ b/EIPS/eip-7916.md
@@ -36,7 +36,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ### Progressive Merkle tree
 
-The [SSZ Merkleization specification)](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/ssz/simple-serialize.md#merkleization) is extended with a helper function:
+The [SSZ Merkleization specification](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/ssz/simple-serialize.md#merkleization) is extended with a helper function:
 
 - `merkleize_progressive(chunks, num_leaves=1)`: Given ordered `BYTES_PER_CHUNK`-byte chunks:
   - The merkleization depends on the number of input chunks and is defined recursively:
@@ -81,7 +81,7 @@ This results in a 0-terminated sequence of binary subtrees with increasing leaf 
 
 ### `ProgressiveList[type]` and `ProgressiveBitlist`
 
-Two new [SSZ composite types)](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/ssz/simple-serialize.md#composite-types) are defined:
+Two new [SSZ composite types](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/ssz/simple-serialize.md#composite-types) are defined:
 
 - **progressive list**: ordered variable-length homogeneous collection, without limit
   - notation `ProgressiveList[type]`, e.g. `ProgressiveList[uint64]`


### PR DESCRIPTION
Remove the stray closing parentheses from the SSZ reference links