### PR TITLE
Update EIP-7805: reflect the latest engine APIs spec change

### DIFF
--- a/EIPS/eip-7805.md
+++ b/EIPS/eip-7805.md
@@ -101,7 +101,7 @@ For each transaction `T` in ILs, perform the following:
 
   - If `T` is invalid, then continue to the next transaction. 
   
-  - If `T` is valid, terminate process and return an `INVALID_INCLUSION_LIST` error.
+  - If `T` is valid, terminate process and return an `INCLUSION_LIST_UNSATISFIED` status.
 
 #### Engine API Changes
 
@@ -109,7 +109,7 @@ We make the following changes to the engine API:
 
 - Add `engine_getInclusionListV1` endpoint to retrieve an IL from the `ExecutionEngine`.
 - Add `engine_updatePayloadWithInclusionListV1` endpoint to update a payload with the IL that should be used to build the block. This takes as an argument an 8-byte `payloadId` of the ongoing payload build process, along with the IL itself.
-- Modify `engine_newPayload` endpoint to include a parameter for transactions in ILs determined by the IL committee member. If the IL is not satisfied an `INVALID_INCLUSION_LIST` error must be returned.
+- Modify `engine_newPayload` endpoint to include a parameter for transactions in ILs determined by the IL committee member. If the IL is not satisfied an `INCLUSION_LIST_UNSATISFIED` status must be returned.
 
 #### IL Building
 


### PR DESCRIPTION
This PR reflects the change introduced to the engine APIs spec in this [commit](https://github.com/ethereum/execution-apis/pull/609/commits/ae719c0587a66e8d8196bfebfb7c4eaa6bc3f6fb).