### PR TITLE
Update EIP-7961: correct PUSH0 opcode to 0x5f in stack opcodes

### DIFF
--- a/EIPS/eip-7961.md
+++ b/EIPS/eip-7961.md
@@ -70,7 +70,7 @@ The gas cost for both opcodes is `G_VERYLOW64`. The memory resizing costs count 
 
 ### Stack opcodes
 
-`PUSH0` (0x59) to `PUSH8` (0x67) follows 0-byte to 8-byte literal. The literal is read little endian and pushed onto the stack. The gas cost for them is `G_VERYLOW64`.
+`PUSH0` (0x5f) to `PUSH8` (0x67) follows 0-byte to 8-byte literal. The literal is read little endian and pushed onto the stack. The gas cost for them is `G_VERYLOW64`.
 
 `POP`, `SWAPn` and `DUPn` are available in EVM64 mode, and their gas costs are the same as in "normal" EVM.
 


### PR DESCRIPTION
Problem: The spec listed PUSH0 as 0x59, which is actually MSIZE. PUSH0 was introduced by EIP-3855 and is 0x5f. Using 0x59 misleads implementers and tool authors, causing incorrect decoding/validation.
Fix: Updated the “Stack opcodes” section to use the correct byte: “PUSH0 (0x5f) to PUSH8 (0x67)”.