### PR TITLE
Update EIP-1474: removed dead parity.io/ethereum link

### DIFF
--- a/EIPS/eip-1474.md
+++ b/EIPS/eip-1474.md
@@ -2246,7 +2246,6 @@ The current generation of Ethereum clients includes several implementations that
 |Client Name|Language|Homepage|
 |-|-|-|
 |Geth|Go|[geth.ethereum.org](https://geth.ethereum.org)|
-|Parity|Rust|[parity.io/ethereum](https://parity.io/ethereum)|
 |Aleth|C++|[cpp-ethereum.org](https://cpp-ethereum.org)|
 
 ## Copyright


### PR DESCRIPTION
the old link was 404, so I took it out to keep things clean.
