### PR TITLE
Update EIP-2242: Removed dead Ethereum RLP link

### DIFF
--- a/EIPS/eip-2242.md
+++ b/EIPS/eip-2242.md
@@ -34,7 +34,7 @@ An additional optional field, `postdata`, is added to transactions. Serialized t
 "nonce": uint256,
 ["postdata": bytes],
 ```
-with witnesses signing over the [RLP encoding](https://github.com/ethereum/wiki/wiki/RLP) of the above. `postdata` is data that is posted on-chain, for later historical retrieval by layer-2 systems.
+with witnesses signing over the RLP encoding of the above. `postdata` is data that is posted on-chain, for later historical retrieval by layer-2 systems.
 
 `postdata` is an RLP-encoded twople `(version: uint64, data: bytes)`.
 1. `version` is `0`.


### PR DESCRIPTION
Deleted the broken link to Ethereum RLP (`https://github.com/ethereum/wiki/wiki/RLP`) since the page and repo no longer exist. This keeps the docs clean and avoids confusing anyone trying to follow it.