### PR TITLE
Update EIP-1485: Removed Broken Ethereum Wiki Link from Documentation

### DIFF
--- a/EIPS/eip-1485.md
+++ b/EIPS/eip-1485.md
@@ -26,7 +26,7 @@ Provide original Ethash proof of work verification with minimal set of changes b
 
 #### Where FNV Applied on ETHASH
 
-- In ETHASH , FNV Hash is used on
+- In [ETHASH](https://web.archive.org/web/20200505215203/https://github.com/ethereum/wiki/wiki/Ethash), FNV Hash is used on
   * 1) On data aggregation function, MIX parts.
   
   * Ethash Algorithm 


### PR DESCRIPTION
This update removes the outdated link to the Ethereum Wiki (https://github.com/ethereum/wiki/wiki/Ethash), as both the page and repository no longer exist.