### PR TITLE
Update EIP-2938: Removed Link to Nonexistent Quilt Tests Repository

### DIFF
--- a/EIPS/eip-2938.md
+++ b/EIPS/eip-2938.md
@@ -264,9 +264,6 @@ Badly-designed single-tenant AA contracts will break the transaction non-malleab
 
 AA contracts may not have replay protection unless they build it in explicitly; this can be done with the `CHAINID (0x46)` opcode introduced in [EIP 1344](./eip-1344.md).
 
-## Test Cases
-See: [https://github.com/quilt/tests/tree/account-abstraction](https://github.com/quilt/tests/tree/account-abstraction)
-
 ## Implementation
 See: [https://github.com/quilt/go-ethereum/tree/account-abstraction](https://github.com/quilt/go-ethereum/tree/account-abstraction)
 


### PR DESCRIPTION
This change removes the link to the Quilt tests repository (https://github.com/quilt/tests), which is no longer available.