### PR TITLE
Update EIP-615: removed dead link to SolidEtherPlas PDF

### DIFF
--- a/EIPS/eip-615.md
+++ b/EIPS/eip-615.md
@@ -508,7 +508,6 @@ There is a large and growing ecosystem of researchers, authors, teachers, audito
 * [A survey of attacks on Ethereum smart contracts](https://eprint.iacr.org/2016/1007.pdf)
 * [Defining the Ethereum Virtual Machine for Interactive Theorem Provers](https://www.google.com/url?q=http://fc17.ifca.ai/wtsc/Defining%2520the%2520Ethereum%2520Virtual%2520Machine%2520for%2520Interactive%2520Theorem%2520Provers.pdf)
 * [Ethereum 2.0 Specifications](https://github.com/ethereum/eth2.0-specs)
-* [Formal Verification of Smart Contracts](https://www.cs.umd.edu/~aseem/solidetherplas.pdf)
 * [JelloPaper: Human Readable Semantics of EVM in K](https://jellopaper.org/)
 * [KEVM: A Complete Semantics of the Ethereum Virtual Machine.](https://www.ideals.illinois.edu/items/102260)
 * [Making Smart Contracts Smarter](https://eprint.iacr.org/2016/633.pdf)


### PR DESCRIPTION
Removed the link to [SolidEtherPlas PDF](https://www.cs.umd.edu/~aseem/solidetherplas.pdf) since it’s 404 now. Keeping broken links can confuse people, so this cleans up the docs a bit.