### PR TITLE
Update EIP-969: fix broken link to nonexistent Ethereum discussion

### DIFF
--- a/EIPS/eip-969.md
+++ b/EIPS/eip-969.md
@@ -2,7 +2,6 @@
 eip: 969
 title: Modifications to ethash to invalidate existing dedicated hardware implementations
 author: David Stanfill <david@airsquirrels.com>
-discussions-to: https://gitter.im/ethereum/topics/topic/5ac4d974109bb043328911ce/eip-969-discussion
 status: Stagnant
 type: Standards Track
 category: Core


### PR DESCRIPTION
This change removes the link to [[this Gitter topic](https://gitter.im/ethereum/topics/topic/5ac4d974109bb043328911ce/eip-969-discussion)](https://gitter.im/ethereum/topics/topic/5ac4d974109bb043328911ce/eip-969-discussion), which no longer exists. Previously, users clicking on it would encounter a 404 error, causing confusion and a poor user experience.

Removing the dead link ensures that all references in the documentation remain accurate and functional, improving overall reliability and trust in the content.