### PR TITLE
Update EIP-7919: correct EIP-7792 description in eip-7919 LOG reform section

### DIFF
--- a/EIPS/eip-7919.md
+++ b/EIPS/eip-7919.md
@@ -39,7 +39,7 @@ The current 2048-bit Bloom filter has a high false positive rate, which grows fu
 
 - [EIP-7668: Remove bloom filters](./eip-7668.md)
 - [EIP-7745: Light client and DHT friendly log index](./eip-7745.md)
-- [EIP-7792: Verifiable logs](./eip-7792.md) (alternative, with log index root provided via ZK instead of block header)
+- [EIP-7792: Verifiable logs](./eip-7792.md) (alternative: verifiability via state-based log accumulators validated with eth_getProof; zk/off-protocol accumulator is an optional future optimization)
 
 ### Improve UX: Normalized transactions / receipts
 


### PR DESCRIPTION
- The line describing EIP-7792 claimed it is an “alternative, with log index root provided via ZK instead of block header,” which is incorrect.
- EIP-7792 does not introduce a “log index root” in the block header and is not a “ZK replacement” for EIP-7745. It uses state-based log accumulators validated via eth_getProof; zk/off-protocol accumulator is only mentioned as a possible future optimization.