### PR TITLE
Update EIP-7937: Replace “MUST OOG” with “MUST halt with an invalid instruction exception”

### DIFF
--- a/EIPS/eip-7937.md
+++ b/EIPS/eip-7937.md
@@ -26,7 +26,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 This EIP uses the prefix opcode `C0`, and it only occupies this single EVM opcode space. Upon the interpreter encountering opcode `C0`, it MUST continue to seek the next byte in code. It then executes things in "64-bit mode", based on the second byte, described below. If the execution is successful, then the interpreter MUST increase `PC` by 2 (instead of 1).
 
-If the second byte is not a valid 64-bit mode operation, then the interpreter MUST OOG.
+If the second byte is not a valid 64-bit mode operation, the interpreter MUST halt with an invalid instruction exception.
 
 ### General 64-bit mode behavior
 
@@ -73,7 +73,7 @@ For flow operations JUMP and JUMPI, the behavior is as follows:
 
 * `JUMP` will only read the last 64 bits from the stack value. The rest 192 bits are discarded without reading. Gas cost is `G_MID64`.
 * `JUMPI` will only read the last 64 bits from the stack as destination, and the condition check will only read the last 64 bits. Gas cost is `G_HIGH64`.
-* In `JUMPDEST` validation phrase, `C0` is considered a standalone "mode" opcode and if the next byte followed is `JUMPDEST`, it continues to mark a valid `JUMPDEST` destination. Note that because there's no 64-bit `JUMPDEST`, during execution, `C0 JUMPDEST` would result in OOG.
+* In `JUMPDEST` validation phrase, `C0` is considered a standalone "mode" opcode and if the next byte followed is `JUMPDEST`, it continues to mark a valid `JUMPDEST` destination. Note that because there's no 64-bit `JUMPDEST`, during execution `C0 JUMPDEST` MUST halt with an invalid instruction exception.
 
 ## Rationale
 


### PR DESCRIPTION
- Problem: The spec incorrectly stated “MUST OOG” for two invalid-instruction cases: (1) when the second byte after the C0 prefix is not a valid 64-bit opcode, and (2) when executing C0 JUMPDEST. In EVM semantics, these are invalid instruction halts, not out-of-gas.
- What was wrong: Misuse of OOG terminology for invalid opcode scenarios, conflicting with the Yellow Paper and established - EIPs.
- Fix: Updated wording to “MUST halt with an invalid instruction exception” at both locations (invalid C0 xx; C0 JUMPDEST) to align with EVM behavior.