### PR TITLE
Update EIP-7688: Update eip-7688.md

### DIFF
--- a/EIPS/eip-7688.md
+++ b/EIPS/eip-7688.md
@@ -188,7 +188,7 @@ The `BeaconBlockHeader` is currently proposed to be kept as is. Updating the `Be
 
 #### `Validator`
 
-The `Validator` container is currently proposed to be kept as is. Updating the `Validator` to `ProgressiveContainer` would add an extra hash for each validator; validators are mostly immutable so rarely need to be re-hashed. With a conversion, implementations may have to incrementally construct the new `Validator` entries ahead of the fork when validator counts are high. It should be evaluated whether the hashing overhead is worth a clean transition to future fields, e.g., for holding postquantum keys. Also consider that that such a transition may also involve a new hash function, which is a breaking change to the Merkle proofs, so generalized indices do not have to be stable across that transition.
+The `Validator` container is currently proposed to be kept as is. Updating the `Validator` to `ProgressiveContainer` would add an extra hash for each validator; validators are mostly immutable so rarely need to be re-hashed. With a conversion, implementations may have to incrementally construct the new `Validator` entries ahead of the fork when validator counts are high. It should be evaluated whether the hashing overhead is worth a clean transition to future fields, e.g., for holding postquantum keys. Also consider that such a transition may also involve a new hash function, which is a breaking change to the Merkle proofs, so generalized indices do not have to be stable across that transition.
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
Removed redundant "that" in line 191 where "that that such a transition" should be "that such a transition"