### PR TITLE
Update EIP-7799: Validate systemLogsRoot in engine_newPayloadVx instead of forkchoiceUpdated

### DIFF
--- a/EIPS/eip-7799.md
+++ b/EIPS/eip-7799.md
@@ -93,7 +93,7 @@ In the engine API, the `ExecutionPayload` for versions corresponding to forks ad
 
 - `systemLogsRoot`: `DATA`, 32 Bytes
 
-As part of `engine_forkchoiceUpdated`, Execution Layer implementations SHALL verify that `systemLogsRoot` for each block matches the actual value computed from local processing. This extends on top of existing `receiptsRoot` validation.
+As part of `engine_newPayloadVx`, Execution Layer implementations SHALL verify that the submitted payload's `systemLogsRoot` matches the value computed from local processing; if it does not, the payload MUST be rejected (e.g., with `INVALID`). This extends on top of existing `receiptsRoot` validation performed at payload acceptance time.
 
 ### Consensus `ExecutionPayload` changes
 


### PR DESCRIPTION
- Problem: The spec incorrectly required validating systemLogsRoot during engine_forkchoiceUpdated. Engine API payload field validations (e.g., receiptsRoot, withdrawals_root) occur at payload acceptance in engine_newPayloadVx, not during fork choice updates.
- Change: Moved the validation requirement to engine_newPayloadVx and specified rejection of invalid payloads (e.g., INVALID).
- Impact: Aligns with established Engine API semantics, prevents transient acceptance of invalid payloads, and matches how clients validate new payloads.