### PR TITLE
Update EIP-6465: Fix inconsistent terminology

### DIFF
--- a/EIPS/eip-6465.md
+++ b/EIPS/eip-6465.md
@@ -13,15 +13,15 @@ requires: 2718, 4895, 6404, 7495, 7916
 
 ## Abstract
 
-This EIP defines a migration process of the existing Merkle-Patricia Trie (MPT) commitment for withdrawals to [Simple Serialize (SSZ)](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/ssz/simple-serialize.md).
+This EIP defines a migration process of the existing Merkle Patricia Trie (MPT) commitment for withdrawals to [Simple Serialize (SSZ)](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/ssz/simple-serialize.md).
 
 ## Motivation
 
 While the consensus `ExecutionPayloadHeader` and the execution block header map to each other conceptually, they are encoded differently. This EIP aims to align the encoding of the `withdrawals_root`, taking advantage of the more modern SSZ format. This brings several advantages:
 
-1. **Reducing complexity:** The proposed design reduces the number of use cases that require support for Merkle-Patricia Trie (MPT).
+1. **Reducing complexity:** The proposed design reduces the number of use cases that require support for Merkle Patricia Trie (MPT).
 
-2. **Reducing ambiguity:** The name `withdrawals_root` is currently used to refer to different roots. While the execution block header refers to a Merkle-Patricia Trie (MPT) root, the consensus `ExecutionPayloadHeader` instead refers to an SSZ root. With these changes, `withdrawals_root` consistently refers to the same SSZ root.
+2. **Reducing ambiguity:** The name `withdrawals_root` is currently used to refer to different roots. While the execution block header refers to a Merkle Patricia Trie (MPT) root, the consensus `ExecutionPayloadHeader` instead refers to an SSZ root. With these changes, `withdrawals_root` consistently refers to the same SSZ root.
 
 ## Specification
 


### PR DESCRIPTION
Document used "Merkle-Patricia Trie" (with hyphen) in two places but "Merkle Patricia Trie" (without hyphen) in line 24. Added hyphen to line 24 to maintain consistent terminology throughout the specification.