### PR TITLE
Update EIP-7928: Engine api clarification

### DIFF
--- a/EIPS/eip-7928.md
+++ b/EIPS/eip-7928.md
@@ -47,7 +47,7 @@ BALs use RLP encoding following the pattern: `address -> field -> block_access_i
 ```python
 # Type aliases for RLP encoding
 Address = bytes  # 20-byte Ethereum address
-StorageKey = bytes  # 32-byte storage slot key  
+StorageKey = bytes  # 32-byte storage slot key
 StorageValue = bytes  # 32-byte storage value
 CodeData = bytes  # Variable-length contract bytecode
 BlockAccessIndex = uint16  # Block access index (0 for pre-execution, 1..n for transactions, n+1 for post-execution)
@@ -219,7 +219,7 @@ The Engine API is extended with new structures and methods to support block-leve
 
 **engine_getPayloadV6** builds execution payloads:
 
-- Returns ExecutionPayloadV4 structure  
+- Returns ExecutionPayloadV4 structure
 - Collects all account accesses and state changes during transaction execution
 - Populates `blockAccessList` field with RLP-encoded access list
 


### PR DESCRIPTION
The engine api section was rather out of date while the execution specs had the latest changes implemented already.
This now aligns the eip's section on the engine api with the execution specs.

h/t  @jihoonsong for catching this.