### PR TITLE
Update EIP-7773: DFI unselected headliners

### DIFF
--- a/EIPS/eip-7773.md
+++ b/EIPS/eip-7773.md
@@ -29,7 +29,12 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Declined
 
 ### Declined for Inclusion
 
+* [EIP-7692](./eip-7692.md): EVM Object Format (EOFv1) Meta
 * [EIP-7782](./eip-7782.md): Reduce Block Latency
+* [EIP-7886](./eip-7886.md): Delayed execution
+* [EIP-7919](./eip-7919.md): Pureth Meta
+* [EIP-7937](./eip-7937.md): EVM64 - 64-bit mode EVM opcodes
+* [EIP-7942](./eip-7942.md): Available Attestation
 
 ### Proposed for Inclusion
 
@@ -40,7 +45,6 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Declined
 1. [EIP-7793](./eip-7793.md): Conditional Transactions
 1. [EIP-7819](./eip-7819.md): SETDELEGATE instruction
 1. [EIP-7843](./eip-7843.md): SLOTNUM opcode
-1. [EIP-7919](./eip-7919.md): Pureth Meta
 1. [EIP-5920](./eip-5920.md): PAY opcode
 1. [EIP-7791](./eip-7791.md): GAS2ETH opcode
 1. [EIP-7903](./eip-7903.md): Remove Initcode Size Limit


### PR DESCRIPTION
of the headliner proposals:
- 7732 and 7928 were moved to SFI
- 7805 was moved to CFI
- the rest of the headliners [should be DFI'd](https://ethereum-magicians.org/t/community-consensus-fork-headliners-acd-working-groups/24088)

authors + ACD can decide whether or not these features can be re-proposed with reduced scope