### PR TITLE
Update EIP-7928: Cite eip 170

### DIFF
--- a/EIPS/eip-7928.md
+++ b/EIPS/eip-7928.md
@@ -58,7 +58,7 @@ Nonce = uint64  # Account nonce
 MAX_TXS = 30_000
 MAX_SLOTS = 300_000
 MAX_ACCOUNTS = 300_000
-MAX_CODE_SIZE = 24_576  # Maximum contract bytecode size in bytes
+MAX_CODE_SIZE = 24_576  # Maximum contract bytecode size in bytes as defined in EIP-170
 MAX_CODE_CHANGES = 1
 
 # Core change structures (RLP encoded as lists)


### PR DESCRIPTION
Since EIP-7928 doesn't change the current code size limit, I added a citation for EIP-170, making it clear that this number is still defined in 170 and not updated in 7928.