### PR TITLE
Update EIP-7928: Clarify bal entry ordering

### DIFF
--- a/EIPS/eip-7928.md
+++ b/EIPS/eip-7928.md
@@ -120,9 +120,10 @@ Entries from an [EIP-2930](./eip-2930.md) access list **MUST NOT** be included a
 
 The following ordering rules **MUST** apply:
 
-- **Addresses:** lexicographic (bytewise).
-- **Storage keys:** lexicographic within each account.
-- **Block access indices:** ascending within each change list.
+- **Accounts**: Lexicographic by address
+- **storage_changes**: Slots lexicographic by storage key; within each slot, changes by block access index index (ascending)
+- **storage_reads**: Lexicographic by storage key
+- **balance_changes, nonce_changes, code_changes**: By block access index (ascending)
 
 ### BlockAccessIndex Assignment
 


### PR DESCRIPTION
Further clarifying the ordering section from the EIP to make it clearer how things are ordered in the final bal.