### PR TITLE
Update EIP-8037: Add access-list based deduplication and success/failure cases

### DIFF
--- a/EIPS/eip-8037.md
+++ b/EIPS/eip-8037.md
@@ -13,7 +13,7 @@ requires: 2780
 
 ## Abstract
 
-This proposal increases the cost of state creation operations, thus avoiding excessive state growth under increased block gas limits. It sets a unit cost per new state byte that targets an average state growth of 60 GiB per year at a block gas limit of 300M gas units and an average gas utilization for state growth of 30%. Contract deployments get a 10x cost increase while new accounts get a 8.5x increase. Deployments of duplicated do not pay deposit costs. To avoid limiting the maximum contract size that can be deployed, it also introduces an independent metering for code deposit costs.
+This proposal increases the cost of state creation operations, thus avoiding excessive state growth under increased block gas limits. It sets a unit cost per new state byte that targets an average state growth of 60 GiB per year at a block gas limit of 300M gas units and an average gas utilization for state growth of 30%. Contract deployments get a 10x cost increase while new accounts get a 8.5x increase. Deployments of duplicated bytecode do not pay deposit costs when the duplicate is identified through an access-list based mechanism. To avoid limiting the maximum contract size that can be deployed, it also introduces an independent metering for code deposit costs.
 
 ## Motivation
 
@@ -31,15 +31,16 @@ The relationship we are seeing in this example is not linear as expected. This i
 
 Upon activation of this EIP, the following parameters of the gas model are updated:
 
-| **Parameter** | **Current value** | **New value** | **Increase** | **Operations affected** |
-|:---:|:---:|:---:|:---:|:---:|
-| `GAS_CREATE` | 32,000 | 212,800 | 6.7x | `CREATE`, `CREATE2`, contract creation txs |
-| `GAS_CODE_DEPOSIT` | 200 | 1,900 | 9.5x | `CREATE`, `CREATE2`, contract creation txs |
-| `GAS_NEW_ACCOUNT` | 25,000 | 212,800 | 8.5x | New EOA funding |
-| `GAS_SELF_DESTRUCT_NEW_ACCOUNT` | 25,000 | 212,800 | 8.5x | `SELF_DESTRUCT` |
-| `GAS_STORAGE_SET` | 20,000 | 60,800 | 3x | `SSTORE` |
-| `PER_EMPTY_ACCOUNT_COST` | 25,000 | 212,800 | 8.5x | EOA delegation |
-| `PER_AUTH_BASE_COST` | 12,500 | 43,700 | 3.5x | EOA delegation |
+|          **Parameter**          | **Current value** | **New value** | **Increase** |          **Operations affected**           |
+| :-----------------------------: | :---------------: | :-----------: | :----------: | :----------------------------------------: |
+|       `CREATE_FIXED_COST`       |      32,000       |    212,800    |     6.7x     | `CREATE`, `CREATE2`, contract creation txs |
+|       `CODE_DEPOSIT_GAS`        |        200        |     1,900     |     9.5x     | `CREATE`, `CREATE2`, contract creation txs |
+|     `ACCOUNT_CREATION_COST`     |      25,000       |    212,800    |     8.5x     |  New account creation (EOA and contracts)  |
+| `GAS_SELF_DESTRUCT_NEW_ACCOUNT` |      25,000       |    212,800    |     8.5x     |              `SELF_DESTRUCT`               |
+|        `GAS_STORAGE_SET`        |      20,000       |    60,800     |      3x      |                  `SSTORE`                  |
+|    `PER_EMPTY_ACCOUNT_COST`     |      25,000       |    212,800    |     8.5x     |               EOA delegation               |
+|      `PER_AUTH_BASE_COST`       |      12,500       |    43,700     |     3.5x     |               EOA delegation               |
+|           `HASH_GAS`            |         -         |  6 per word   |      -       |   Runtime code hashing for deduplication   |
 
 ### Multidimensional metering for code deposit gas
 
@@ -47,16 +48,85 @@ Besides the parameter changes, this proposal introduces an independent metering 
 
 ### Contract deployment cost calculation
 
-This proposal further changes how contract deployment cost are computed. When a contract creation returns a runtime bytecode `R` (length `L`), first check whether the code already exists in the state trie. Then:
+This proposal fundamentally changes how contract deployment costs are computed to properly account for success and failure paths, ensuring that post-execution costs are only charged when deployment succeeds.
 
-- If `CodeExists(keccak256(R), live_state) == false`, charge `code_deposit_cost=GAS_CODE_DEPOSIT*L` and store `R` under its code hash.
-- If `CodeExists(...) == true`, do not charge code-deposit storage gas (`code_deposit_gas=0`); simply link the new account's `codeHash` to the existing code object.
+#### Success vs Failure Gas Accounting
 
-In addition, contract creation is also charged a `storage_access_cost = GAS_WARM_ACCESS (if warm) | GAS_COLD_SLOAD (if cold)` and a `hash_cost = GAS_KECCAK256_WORD * code_data_words`, where `code_data_words = ceil(L / 32)`. This accounts for the added execution cost of accessing and verifying for duplicated code.
+When a contract creation transaction or opcode (`CREATE`/`CREATE2`) is executed, gas is charged differently based on whether the deployment succeeds or fails. Given runtime bytecode `R` (length `L`) returned by initcode and `H = keccak256(R)`:
+
+1. **On opcode entry:** Always charge `CREATE_FIXED_COST` (212,800 gas)
+2. **During initcode execution:** Charge `EXECUTION_GAS` equal to gas consumed by the initcode
+3. **Success path** (no error, not reverted, and `L ≤ MAX_CODE_SIZE`):
+   - If the target account is new, charge `ACCOUNT_CREATION_COST` (212,800 gas)
+   - Charge `HASH_GAS(L)` where `HASH_GAS(L) = 6 × ceil(L / 32)` to compute `H`
+   - Perform deduplication check (see Access-List CodeHash section below):
+     - If duplicate: do NOT charge `CODE_DEPOSIT_GAS(L)`; link `codeHash` to `H`
+     - If not duplicate: charge `CODE_DEPOSIT_GAS(L)` where `CODE_DEPOSIT_GAS(L) = 1,900 × L` and persist `R` under `H`, then link
+4. **Failure paths** (REVERT, OOG/invalid during initcode, OOG during code deposit, or `L > MAX_CODE_SIZE`):
+   - Do NOT charge `ACCOUNT_CREATION_COST`, `HASH_GAS(L)`, or `CODE_DEPOSIT_GAS(L)`
+   - No code is stored; no `codeHash` is linked to the account
+   - The account remains unchanged or non-existent
+
+**Total gas formulas:**
+
+```
+SUCCESS_PATH_TOTAL_GAS =
+    CREATE_FIXED_COST
+  + EXECUTION_GAS
+  + (ACCOUNT_CREATION_COST if account is new else 0)
+  + HASH_GAS(L)
+  + (CODE_DEPOSIT_GAS(L) if not deduped else 0)
+
+FAILURE_PATH_TOTAL_GAS =
+    CREATE_FIXED_COST
+  + EXECUTION_GAS
+```
+
+#### Access-List CodeHash Deduplication
+
+To determine whether bytecode is duplicated, this EIP introduces an access-list based mechanism that avoids consensus-breaking database lookups. The approach extends EIP-2930 access lists with an optional `checkCodeHash` flag:
+
+```json
+{
+  "address": "0x...",
+  "storageKeys": ["0x..."],
+  "checkCodeHash": true
+}
+```
+
+**Consensus semantics:**
+
+- Before transaction execution, build a set `W` containing the `codeHash` of every access-listed address where `checkCodeHash == true`
+- On successful contract creation, if `H = keccak256(R)` is in `W`, the bytecode is considered a duplicate
+- Duplicate bytecode does not incur `CODE_DEPOSIT_GAS(L)` charges
+- The cost of reading `codeHash` for access-listed addresses is already covered by EIP-2929/2930 access costs
+
+**Implementation:**
+
+```text
+// Before execution:
+W := ∅
+for each tuple t in tx.access_list:
+  warm(t.Address)           // per EIP-2930/EIP-2929 rules
+  if t.CheckCodeHash == true:
+    acc := load_account(t.Address)
+    W.insert(acc.codeHash)
+
+// On successful CREATE/CREATE2:
+H := keccak256(R)
+if (H in W) {
+  // duplicate: no deposit gas
+  link_codehash(new_account, H)
+} else {
+  charge CODE_DEPOSIT_GAS(len(R))
+  persist_code(H, R)
+  link_codehash(new_account, H)
+}
+```
 
 #### `CREATE` vs `CREATE2`
 
-`CREATE2` already charges for hashing the init code when deriving the address. That cost remains. Runtime-code deduplication hash (`keccak256(R)`) is separate: even with `CREATE2`, the runtime hash must be computed to determine whether the code is new or already stored.
+`CREATE2` already charges for hashing the init code when deriving the address. That cost remains unchanged. The runtime-code deduplication hash (`keccak256(R)`) is separate: even with `CREATE2`, the runtime hash must be computed on success to determine whether the code is new or already stored.
 
 ## Rationale
 
@@ -64,13 +134,13 @@ In addition, contract creation is also charged a `storage_access_cost = GAS_WARM
 
 With the current pricing, the gas cost of creating 1 byte of state varies depending on the method used. The following table shows the various methods and their gas cost per byte. The calculation ignores the transaction intrinsic cost (21k gas units) and the costs of additional opcodes and scaffolding needed to execute such a transaction.
 
-| Method | What is written | Intrinsic gas | Bytes → state | Gas / byte |
-|---|---|---|---|---|
-| Deploy 24kB contract ([EIP-170](./eip-170.md) limit) | Runtime code + account trie node | 32,000 CREATE + 25,000 new account + 200 × 24,576 code deposit = 4,972,200 gas | 24,576 B | ~202 gas |
-| Fund fresh EOA with 1 wei | Updated account leaf | 25,000 new account | ~112 B | ~223 gas |
-| Add delegate flag to funded EOA ([EIP-7702](./eip-7702.md)) | 23 B (0xef0100‖address) + updated account leaf | 25,000 PER_EMPTY_ACCOUNT + 12,500 PER_AUTH_BASE + 1,616 calldata - 7,823 refund = ~31,300 gas | ~135 B | ~232 gas |
-| [EIP-7702](./eip-7702.md) authorization to empty address | 23 B (0xef0100‖address) + updated account leaf | 25,000 PER_EMPTY_ACCOUNT + 12,500 PER_AUTH_BASE + 1,616 calldata = 39,116 gas | ~135 B | ~289 gas |
-| Fill new storage slots (SSTORE 0→x) | Slot in storage trie | 20,000 gas/slot | 32 B | 625 gas |
+| Method                                                      | What is written                                | Intrinsic gas                                                                                 | Bytes → state | Gas / byte |
+| ----------------------------------------------------------- | ---------------------------------------------- | --------------------------------------------------------------------------------------------- | ------------- | ---------- |
+| Deploy 24kB contract ([EIP-170](./eip-170.md) limit)        | Runtime code + account trie node               | 32,000 CREATE + 25,000 new account + 200 × 24,576 code deposit = 4,972,200 gas                | 24,576 B      | ~202 gas   |
+| Fund fresh EOA with 1 wei                                   | Updated account leaf                           | 25,000 new account                                                                            | ~112 B        | ~223 gas   |
+| Add delegate flag to funded EOA ([EIP-7702](./eip-7702.md)) | 23 B (0xef0100‖address) + updated account leaf | 25,000 PER_EMPTY_ACCOUNT + 12,500 PER_AUTH_BASE + 1,616 calldata - 7,823 refund = ~31,300 gas | ~135 B        | ~232 gas   |
+| [EIP-7702](./eip-7702.md) authorization to empty address    | 23 B (0xef0100‖address) + updated account leaf | 25,000 PER_EMPTY_ACCOUNT + 12,500 PER_AUTH_BASE + 1,616 calldata = 39,116 gas                 | ~135 B        | ~289 gas   |
+| Fill new storage slots (SSTORE 0→x)                         | Slot in storage trie                           | 20,000 gas/slot                                                                               | 32 B          | 625 gas    |
 
 To harmonize costs, we first set the gas cost of a single state byte, `cost_per_state_byte`. **This cost targets an average growth of 60 GiB per year at a block gas limit of 300M gas units and an average gas utilization for state growth of 30%**. A [recent empirical analysis](../assets/eip-8011/multidim_empirical_analysis.md) has shown that, at current gas prices, state creation accounts for approximately 30% of all gas consumed. ** Additionally, on average, blocks use half of the entire available gas in the block. Thus, we are setting the unit gas cost of state creation based on the average case. Finally, we are targeting a 300M block limit to account for scaling optimizations expected in the short to medium term.
 
@@ -78,15 +148,16 @@ This capacity corresponds to an average of $\frac{60 \times 1024^3}{365} = 176,5
 
 Now that we have a standardized cost per byte, we can derive the various costs parameters by multiplying the unit cost by the increase in bytes any given operation creates in the database (i.e., 32 bytes per slot, 112 bytes per account and 23 bytes per authorization):
 
-- `GAS_CREATE` = 112 x `cost_per_state_byte`= 212,800
-- `GAS_CODE_DEPOSIT` = `cost_per_state_byte` = 1,900
+- `CREATE_FIXED_COST` = 112 x `cost_per_state_byte`= 212,800
+- `CODE_DEPOSIT_GAS` = `cost_per_state_byte` = 1,900
 - `GAS_STORAGE_SET` = 32 x `cost_per_state_byte` = 60,800
-- `GAS_NEW_ACCOUNT` = 112 x `cost_per_state_byte`= 212,800
+- `ACCOUNT_CREATION_COST` = 112 x `cost_per_state_byte`= 212,800
 - `GAS_SELF_DESTRUCT_NEW_ACCOUNT` = 112 x `cost_per_state_byte` = 212,800
 - `PER_EMPTY_ACCOUNT_COST` = 112 x `cost_per_state_byte` = 212,800
 - `PER_AUTH_BASE_COST` = 23 x `cost_per_state_byte` = 43,700
+- `HASH_GAS` = 6 gas per word (consistent with existing `KECCAK256` pricing)
 
-Note that the fixed cost `GAS_CREATE` for contract deployments assumes the same cost as a new account creation.
+Note that the fixed cost `CREATE_FIXED_COST` for contract deployments assumes the same cost as a new account creation.
 
 ### Multidimensional metering
 
@@ -102,6 +173,76 @@ This proposal is consistent with the multidimensional gas metering introduced in
 - Hashing cost is necessary: Always charge `hash_cost` for runtime code. Protects against abuse with large constructor outputs.
 - What counts as “same code”? Exact runtime bytecode. Even minor differences produce distinct hashes.
 - Empty code handling: Clients can treat empty code as a special case with a hard-coded hash lookup (`EMPTY_CODE_HASH`), making it effectively free.
+
+#### Access-List CodeHash Deduplication Rationale (Solving the existing-bytecode lookup issues)
+
+The access-list based deduplication mechanism addresses a critical consensus issue that arises from database divergence across different node implementations and sync modes:
+
+##### The Database Divergence Problem
+
+Empirical analysis reveals that approximately **27,869 bytecodes** exist in full-synced node databases with no live account pointing to them (as of the time of writing this EIP). These orphaned codes arise from:
+
+1. Chain reorganizations: Code blobs persist in the database even when the blocks containing their creation are reorganized away
+2. Sync mode differences:
+   - Full-sync nodes: Retain all historical code, including from reverted/reorged transactions
+   - Snap-sync nodes: Only store code reachable from the current state trie
+   - Archive nodes: May have different retention policies
+
+This divergence means that a naive "database contains hash?" check would yield **different gas costs on different nodes for the same transaction**, breaking consensus.
+
+##### Why Access-List Based Solution
+
+The access-list approach solves the bytecode duplication check problem by:
+
+1. Deterministic behavior: Only code hashes explicitly included in the transaction's access list are considered for deduplication. This makes the result independent of local database state.
+2. No reverse index requirement: Unlike other approaches, this doesn't require maintaining a `codeHash → account` reverse index, which would add significant complexity and storage overhead.
+3. Leverages existing infrastructure: Builds on EIP-2930 access lists and EIP-2929 access costs, requiring minimal protocol changes.
+4. Explicit opt-in: Transactions must explicitly indicate which addresses to check, preventing unexpected behavior and giving users control over gas optimization.
+5. Forward compatibility: Older clients that don't implement the feature simply never grant the discount, maintaining compatibility while newer clients can optimize. Same will happen with Wallet providers and TX builders.
+
+#### Access-List Extension Specification
+
+For developers implementing this feature, the access list structure is extended as follows:
+
+```go
+// Geth-style struct (JSON/RPC; optional field)
+type AccessTuple struct {
+    Address       common.Address `json:"address"`
+    StorageKeys   []common.Hash  `json:"storageKeys"`
+    CheckCodeHash bool           `json:"checkCodeHash,omitempty"`
+}
+```
+
+**Consensus semantics:**
+
+- The transaction's **CodeHash Access-Set** is $W = \{ \text{codeHash}(a) \mid a \text{ is in access list and } a.\text{CheckCodeHash} = \text{true} \}$.
+- **Deduplication rule:** On success, if $H \in W$ $\rightarrow$ **no** `CODE_DEPOSIT_GAS(L)`; else $\rightarrow$ **charge** `CODE_DEPOSIT_GAS(L)` and persist.
+- **Gas costs:** The cost of reading $\text{codeHash}(a)$ is already covered by EIP-2929/2930 access costs (intrinsic access-list cost and cold→warm charging). No additional lookup cost is introduced.
+- **Backwards compatibility:** The `checkCodeHash` field is optional. Transactions without this field behave as they do today (no deduplication discount).
+
+**Example transaction with access list:**
+
+```json
+{
+  "from": "0x...",
+  "to": null,
+  "data": "0x...",
+  "accessList": [
+    {
+      "address": "0x1234...5678",
+      "storageKeys": [],
+      "checkCodeHash": true
+    },
+    {
+      "address": "0xabcd...ef00",
+      "storageKeys": ["0x..."],
+      "checkCodeHash": false
+    }
+  ]
+}
+```
+
+In this example, if the deployed contract's runtime bytecode hash matches the `codeHash` of address `0x1234...5678`, the deployment receives the deduplication discount and skips `CODE_DEPOSIT_GAS`.
 
 ## Backwards Compatibility
 

--- a/EIPS/eip-8037.md
+++ b/EIPS/eip-8037.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2025-10-01
-requires: 2780
+requires: 2780, 2930
 ---
 
 ## Abstract
@@ -31,16 +31,15 @@ The relationship we are seeing in this example is not linear as expected. This i
 
 Upon activation of this EIP, the following parameters of the gas model are updated:
 
-|          **Parameter**          | **Current value** | **New value** | **Increase** |          **Operations affected**           |
-| :-----------------------------: | :---------------: | :-----------: | :----------: | :----------------------------------------: |
-|       `CREATE_FIXED_COST`       |      32,000       |    212,800    |     6.7x     | `CREATE`, `CREATE2`, contract creation txs |
-|       `CODE_DEPOSIT_GAS`        |        200        |     1,900     |     9.5x     | `CREATE`, `CREATE2`, contract creation txs |
-|     `ACCOUNT_CREATION_COST`     |      25,000       |    212,800    |     8.5x     |  New account creation (EOA and contracts)  |
-| `GAS_SELF_DESTRUCT_NEW_ACCOUNT` |      25,000       |    212,800    |     8.5x     |              `SELF_DESTRUCT`               |
-|        `GAS_STORAGE_SET`        |      20,000       |    60,800     |      3x      |                  `SSTORE`                  |
-|    `PER_EMPTY_ACCOUNT_COST`     |      25,000       |    212,800    |     8.5x     |               EOA delegation               |
-|      `PER_AUTH_BASE_COST`       |      12,500       |    43,700     |     3.5x     |               EOA delegation               |
-|           `HASH_GAS`            |         -         |  6 per word   |      -       |   Runtime code hashing for deduplication   |
+| **Parameter** | **Current value** | **New value** | **Increase** | **Operations affected** |
+|:---:|:---:|:---:|:---:|:---:|
+| `GAS_CREATE` | 32,000 | 212,800 | 6.7x | `CREATE`, `CREATE2`, contract creation txs |
+| `GAS_CODE_DEPOSIT` | 200 | 1,900 | 9.5x | `CREATE`, `CREATE2`, contract creation txs |
+| `GAS_NEW_ACCOUNT` | 25,000 | 212,800 | 8.5x | New EOA funding |
+| `GAS_SELF_DESTRUCT_NEW_ACCOUNT` | 25,000 | 212,800 | 8.5x | `SELF_DESTRUCT` |
+| `GAS_STORAGE_SET` | 20,000 | 60,800 | 3x | `SSTORE` |
+| `PER_EMPTY_ACCOUNT_COST` | 25,000 | 212,800 | 8.5x | EOA delegation |
+| `PER_AUTH_BASE_COST` | 12,500 | 43,700 | 3.5x | EOA delegation |
 
 ### Multidimensional metering for code deposit gas
 
@@ -48,22 +47,22 @@ Besides the parameter changes, this proposal introduces an independent metering 
 
 ### Contract deployment cost calculation
 
-This proposal fundamentally changes how contract deployment costs are computed to properly account for success and failure paths, ensuring that post-execution costs are only charged when deployment succeeds.
+This proposal introduces a discount for contract deployment of duplicated bytecode. To account for the added work of checking bytecode duplication, it additionally charges a storage access cost and a hashing cost, while properly accounting for success and failure paths and ensuring that post-execution costs are only charged when deployment succeeds.
 
 #### Success vs Failure Gas Accounting
 
 When a contract creation transaction or opcode (`CREATE`/`CREATE2`) is executed, gas is charged differently based on whether the deployment succeeds or fails. Given runtime bytecode `R` (length `L`) returned by initcode and `H = keccak256(R)`:
 
-1. **On opcode entry:** Always charge `CREATE_FIXED_COST` (212,800 gas)
+1. **On opcode entry:** Always charge `GAS_CREATE` (212,800 gas)
 2. **During initcode execution:** Charge `EXECUTION_GAS` equal to gas consumed by the initcode
 3. **Success path** (no error, not reverted, and `L ≤ MAX_CODE_SIZE`):
-   - If the target account is new, charge `ACCOUNT_CREATION_COST` (212,800 gas)
-   - Charge `HASH_GAS(L)` where `HASH_GAS(L) = 6 × ceil(L / 32)` to compute `H`
+   - If the target account is new, charge `GAS_NEW_ACCOUNT` (212,800 gas)
+   - Charge `HASH_COST(L)` where `HASH_COST(L) = 6 × ceil(L / 32)` to compute `H`
    - Perform deduplication check (see Access-List CodeHash section below):
-     - If duplicate: do NOT charge `CODE_DEPOSIT_GAS(L)`; link `codeHash` to `H`
-     - If not duplicate: charge `CODE_DEPOSIT_GAS(L)` where `CODE_DEPOSIT_GAS(L) = 1,900 × L` and persist `R` under `H`, then link
+     - If duplicate: do NOT charge `GAS_CODE_DEPOSIT * L`; link `codeHash` to `H`
+     - If not duplicate: charge `GAS_CODE_DEPOSIT * L` (1,900 × L) and persist `R` under `H`, then link
 4. **Failure paths** (REVERT, OOG/invalid during initcode, OOG during code deposit, or `L > MAX_CODE_SIZE`):
-   - Do NOT charge `ACCOUNT_CREATION_COST`, `HASH_GAS(L)`, or `CODE_DEPOSIT_GAS(L)`
+   - Do NOT charge `GAS_NEW_ACCOUNT`, `HASH_COST(L)`, or `GAS_CODE_DEPOSIT * L`
    - No code is stored; no `codeHash` is linked to the account
    - The account remains unchanged or non-existent
 
@@ -71,14 +70,14 @@ When a contract creation transaction or opcode (`CREATE`/`CREATE2`) is executed,
 
 ```
 SUCCESS_PATH_TOTAL_GAS =
-    CREATE_FIXED_COST
+    GAS_CREATE
   + EXECUTION_GAS
-  + (ACCOUNT_CREATION_COST if account is new else 0)
-  + HASH_GAS(L)
-  + (CODE_DEPOSIT_GAS(L) if not deduped else 0)
+  + (GAS_NEW_ACCOUNT if account is new else 0)
+  + HASH_COST(L)
+  + (GAS_CODE_DEPOSIT * L if not deduped else 0)
 
 FAILURE_PATH_TOTAL_GAS =
-    CREATE_FIXED_COST
+    GAS_CREATE
   + EXECUTION_GAS
 ```
 
@@ -96,10 +95,20 @@ To determine whether bytecode is duplicated, this EIP introduces an access-list 
 
 **Consensus semantics:**
 
-- Before transaction execution, build a set `W` containing the `codeHash` of every access-listed address where `checkCodeHash == true`
+- Before transaction execution, build a set `W` containing the `codeHash` of every **existing** access-listed address where `checkCodeHash == true`. **Important:** `W` is built from state at the start of transaction execution. Only addresses that already exist with deployed code contribute to `W`.
 - On successful contract creation, if `H = keccak256(R)` is in `W`, the bytecode is considered a duplicate
-- Duplicate bytecode does not incur `CODE_DEPOSIT_GAS(L)` charges
+- Duplicate bytecode does not incur `GAS_CODE_DEPOSIT * L` charges
 - The cost of reading `codeHash` for access-listed addresses is already covered by EIP-2929/2930 access costs
+
+**How deduplication works:**
+
+1. **Transaction T_A** deploys a contract at address `X` with bytecode `B`. This pays full `GAS_CODE_DEPOSIT * L` cost (no prior contract has this bytecode).
+2. **Later transaction T_B** (in a later block or later in the same block) wants to deploy the same bytecode `B`:
+   - T_B must include address `X` in its access list with `checkCodeHash: true`
+   - When T_B starts execution, it builds `W` from current state. Since `X` now exists from T_A's deployment, `W` contains `codeHash(B)`
+   - T_B's deployment gets the discount and skips `GAS_CODE_DEPOSIT * L`
+
+**Important edge case:** If two transactions in the same block both deploy identical new bytecode and neither references an existing contract with that bytecode in their access lists, both will pay full `GAS_CODE_DEPOSIT * L`. The first deployment cannot be known at transaction construction time. However, this scenario is extremely rare and not worth the complexity of special handling.
 
 **Implementation:**
 
@@ -118,7 +127,7 @@ if (H in W) {
   // duplicate: no deposit gas
   link_codehash(new_account, H)
 } else {
-  charge CODE_DEPOSIT_GAS(len(R))
+  charge GAS_CODE_DEPOSIT * len(R)
   persist_code(H, R)
   link_codehash(new_account, H)
 }
@@ -148,16 +157,15 @@ This capacity corresponds to an average of $\frac{60 \times 1024^3}{365} = 176,5
 
 Now that we have a standardized cost per byte, we can derive the various costs parameters by multiplying the unit cost by the increase in bytes any given operation creates in the database (i.e., 32 bytes per slot, 112 bytes per account and 23 bytes per authorization):
 
-- `CREATE_FIXED_COST` = 112 x `cost_per_state_byte`= 212,800
-- `CODE_DEPOSIT_GAS` = `cost_per_state_byte` = 1,900
+- `GAS_CREATE` = 112 x `cost_per_state_byte`= 212,800
+- `GAS_CODE_DEPOSIT` = `cost_per_state_byte` = 1,900
 - `GAS_STORAGE_SET` = 32 x `cost_per_state_byte` = 60,800
-- `ACCOUNT_CREATION_COST` = 112 x `cost_per_state_byte`= 212,800
+- `GAS_NEW_ACCOUNT` = 112 x `cost_per_state_byte`= 212,800
 - `GAS_SELF_DESTRUCT_NEW_ACCOUNT` = 112 x `cost_per_state_byte` = 212,800
 - `PER_EMPTY_ACCOUNT_COST` = 112 x `cost_per_state_byte` = 212,800
 - `PER_AUTH_BASE_COST` = 23 x `cost_per_state_byte` = 43,700
-- `HASH_GAS` = 6 gas per word (consistent with existing `KECCAK256` pricing)
 
-Note that the fixed cost `CREATE_FIXED_COST` for contract deployments assumes the same cost as a new account creation.
+Note that the fixed cost `GAS_CREATE` for contract deployments assumes the same cost as a new account creation.
 
 ### Multidimensional metering
 
@@ -198,51 +206,7 @@ The access-list approach solves the bytecode duplication check problem by:
 2. No reverse index requirement: Unlike other approaches, this doesn't require maintaining a `codeHash → account` reverse index, which would add significant complexity and storage overhead.
 3. Leverages existing infrastructure: Builds on EIP-2930 access lists and EIP-2929 access costs, requiring minimal protocol changes.
 4. Explicit opt-in: Transactions must explicitly indicate which addresses to check, preventing unexpected behavior and giving users control over gas optimization.
-5. Forward compatibility: Older clients that don't implement the feature simply never grant the discount, maintaining compatibility while newer clients can optimize. Same will happen with Wallet providers and TX builders.
-
-#### Access-List Extension Specification
-
-For developers implementing this feature, the access list structure is extended as follows:
-
-```go
-// Geth-style struct (JSON/RPC; optional field)
-type AccessTuple struct {
-    Address       common.Address `json:"address"`
-    StorageKeys   []common.Hash  `json:"storageKeys"`
-    CheckCodeHash bool           `json:"checkCodeHash,omitempty"`
-}
-```
-
-**Consensus semantics:**
-
-- The transaction's **CodeHash Access-Set** is $W = \{ \text{codeHash}(a) \mid a \text{ is in access list and } a.\text{CheckCodeHash} = \text{true} \}$.
-- **Deduplication rule:** On success, if $H \in W$ $\rightarrow$ **no** `CODE_DEPOSIT_GAS(L)`; else $\rightarrow$ **charge** `CODE_DEPOSIT_GAS(L)` and persist.
-- **Gas costs:** The cost of reading $\text{codeHash}(a)$ is already covered by EIP-2929/2930 access costs (intrinsic access-list cost and cold→warm charging). No additional lookup cost is introduced.
-- **Backwards compatibility:** The `checkCodeHash` field is optional. Transactions without this field behave as they do today (no deduplication discount).
-
-**Example transaction with access list:**
-
-```json
-{
-  "from": "0x...",
-  "to": null,
-  "data": "0x...",
-  "accessList": [
-    {
-      "address": "0x1234...5678",
-      "storageKeys": [],
-      "checkCodeHash": true
-    },
-    {
-      "address": "0xabcd...ef00",
-      "storageKeys": ["0x..."],
-      "checkCodeHash": false
-    }
-  ]
-}
-```
-
-In this example, if the deployed contract's runtime bytecode hash matches the `codeHash` of address `0x1234...5678`, the deployment receives the deduplication discount and skips `CODE_DEPOSIT_GAS`.
+5. Forward compatibility: This mechanism provides smooth upgrade paths. Pre-fork, nodes ignore the `checkCodeHash` field and never grant discounts. Post-fork, all consensus clients MUST enforce identical behavior. Wallet providers and transaction builders can optionally add the field to optimize gas costs, but its absence doesn't invalidate transactions.
 
 ## Backwards Compatibility
 
@@ -294,6 +258,53 @@ One potential concern is the cost of creating a new account (212,800 gas units),
 ### Independent metering for code deposit costs
 
 Contract creation now introduces a cost that is not accounted for in the traditional gas metering and thus doesn't contribute to the block gas limit or the individual transaction limit. This could potentially be exploited by an attacker to create very large contracts that would stress the network. More benchmarking and analysis is needed to understand the potential risks and to determine if additional mitigations are necessary.
+
+## Reference Implementation
+
+### Access-List Extension
+
+For developers implementing this feature, the access list structure is extended as follows:
+
+```go
+// Geth-style struct (JSON/RPC; optional field)
+type AccessTuple struct {
+    Address       common.Address `json:"address"`
+    StorageKeys   []common.Hash  `json:"storageKeys"`
+    CheckCodeHash bool           `json:"checkCodeHash,omitempty"`
+}
+```
+
+**Consensus semantics:**
+
+- The transaction's **CodeHash Access-Set** is $W = \{ \text{codeHash}(a) \mid a \text{ is in access list and } a.\text{CheckCodeHash} = \text{true} \text{ and } a \text{ exists in state} \}$.
+- `W` is built from state at the start of transaction execution. Only existing addresses with deployed code contribute.
+- **Deduplication rule:** On success, if $H \in W$ $\rightarrow$ **no** `GAS_CODE_DEPOSIT * L`; else $\rightarrow$ **charge** `GAS_CODE_DEPOSIT * L` and persist.
+- **Gas costs:** The cost of reading $\text{codeHash}(a)$ is already covered by EIP-2929/2930 access costs (intrinsic access-list cost and cold→warm charging). No additional lookup cost is introduced.
+- **Backwards compatibility:** The `checkCodeHash` field is optional. Transactions without this field behave as they do today (no deduplication discount).
+
+**Example transaction with access list:**
+
+```json
+{
+  "from": "0x...",
+  "to": null,
+  "data": "0x...",
+  "accessList": [
+    {
+      "address": "0x1234...5678",
+      "storageKeys": [],
+      "checkCodeHash": true
+    },
+    {
+      "address": "0xabcd...ef00",
+      "storageKeys": ["0x..."],
+      "checkCodeHash": false
+    }
+  ]
+}
+```
+
+In this example, if the deployed contract's runtime bytecode hash matches the `codeHash` of address `0x1234...5678`, the deployment receives the deduplication discount and skips `GAS_CODE_DEPOSIT * L`.
 
 ## Copyright
 


### PR DESCRIPTION
Adding 2 important fixes/clarifications to EIP-8037:

1. Success/Failure Gas Accounting: Properly distinguishes between successful and failed contract deployments. Post-execution costs (ACCOUNT_CREATION_COST, HASH_GAS, CODE_DEPOSIT_GAS) are now only charged on success, aligning with Ethereum's principle that gas should reflect actual resource consumption.

2. Access-List CodeHash Deduplication: Replaces database lookup mechanism with an access-list based approach to solve consensus divergence between different sync modes (full-sync vs snap-sync). Approximately 27,869 orphaned bytecodes exist in full-sync nodes with no live account links, making DB lookups non-deterministic.

Changes include:
- Explicit success/failure gas formulas with detailed rationale
- AccessTuple extension with checkCodeHash field
- Comprehensive rationale explaining sync-mode divergence problem
- Developer-facing specification with Go struct and JSON example
- Updated gas cost examples for all scenarios
- LaTeX formatting for mathematical notation
