### PR TITLE
Update EIP-7807: type requests_hash as Root

### DIFF
--- a/EIPS/eip-7807.md
+++ b/EIPS/eip-7807.md
@@ -72,7 +72,7 @@ class ExecutionBlockHeader(
     withdrawals_root: Root  # EIP-6465 withdrawals.hash_tree_root()
     excess_gas: GasAmounts
     parent_beacon_block_root: Root
-    requests_hash: Bytes32  # EIP-6110 execution_requests.hash_tree_root()
+    requests_hash: Root  # EIP-6110 ExecutionRequests.hash_tree_root()
     system_logs_root: Root  # EIP-7799 system_logs.hash_tree_root()
 ```
 


### PR DESCRIPTION
Change requests_hash type from Bytes32 to Root in ExecutionBlockHeader to reflect that it is computed via ExecutionRequests.hash_tree_root() (SSZ merkle root). This aligns the field with other SSZ roots in the header (transactions_root, receipts_root, withdrawals_root, system_logs_root), avoids ambiguity of a generic Bytes32, and matches the prose in this EIP and CL semantics (BeaconBlockBody). Reason: ensure semantic correctness and consistency after migrating requests commitment from a generic hash to SSZ.