### PR TITLE
Update EIP-7928: clarify coinbase + upper limit constants

### DIFF
--- a/EIPS/eip-7928.md
+++ b/EIPS/eip-7928.md
@@ -54,13 +54,6 @@ BlockAccessIndex = uint16  # Block access index (0 for pre-execution, 1..n for t
 Balance = uint256  # Post-transaction balance in wei
 Nonce = uint64  # Account nonce
 
-# Constants; chosen to support a 630m block gas limit
-MAX_TXS = 30_000
-MAX_SLOTS = 300_000
-MAX_ACCOUNTS = 300_000
-MAX_CODE_SIZE = 24_576  # Maximum contract bytecode size in bytes as defined in EIP-170
-MAX_CODE_CHANGES = 1
-
 # Core change structures (RLP encoded as lists)
 # StorageChange: [block_access_index, new_value]
 StorageChange = [BlockAccessIndex, StorageValue]
@@ -170,7 +163,8 @@ This includes the following special cases where addresses **MUST** be included w
 
 - Zero-value transfer recipients
 - Calling a same-transaction SELFDESTRUCT on an address that had a zero pre-transaction balance
-- Zero-value block reward recipients
+
+Zero-value block reward recipients **MUST NOT** be included without changes. Zero-value block reward recipients **MUST** be included for blocks where rewards > 0. 
 
 #### Code
 


### PR DESCRIPTION
This change ensures clarity around coinbase tracking and removes the SSZ upper-bounds we needed earlier before moving to RLP:
https://discord.com/channels/595666850260713488/1364000387195076608/1428343933653483571