### PR TITLE
Update EIP-7898: add normative Specification details and RFC 2119 note

### DIFF
--- a/EIPS/eip-7898.md
+++ b/EIPS/eip-7898.md
@@ -12,9 +12,9 @@ created: 2025-03-01
 
 ## Abstract
 
-Currently, the beacon block in Ethereum Consensus embeds transactions within the `ExecutionPayload` field of `BeaconBlockBody`. This EIP proposes to replace `ExecutionPayload` with `ExecutionPayloadHeader` in `BeaconBlockBody` and to independently transmit `ExecutionPayloadWithInclusionProof`.
+Currently, the beacon block in Ethereum Consensus embeds transactions within the `ExecutionPayload` field of `BeaconBlockBody`. This EIP proposes to replace `ExecutionPayload` with `ExecutionPayloadHeader` in `BeaconBlockBody` and to independently transmit `ExecutionPayloadBundle`.
 
-However, this EIP makes no change to the block import mechanism, with the exception that block availability now includes waiting for the availability of `ExecutionPayloadWithInclusionProof`, making it different and simpler from proposals like ePBS/APS.
+However, this EIP makes no change to the block import mechanism, with the exception that block availability now includes waiting for the availability of `ExecutionPayloadBundle`, making it different and simpler from proposals like ePBS/APS.
 
 But this availability requirement can in fact be restricted to `gossip` import while allowing optimistic syncing of the execution layer (EL) on checkpoint/range sync as EL can pull full blocks from their peers in optimistic sync as they do now.
 
@@ -25,14 +25,14 @@ The Ethereum protocol has an ambitious goal to grow the `gasLimit` of the execut
 1. Higher latencies for the arrival of beacon blocks increase, requiring larger bandwidth resources to be made available for the beacon node.
 2. The greater number and size of transactions directly increase the merkelization compute time, increasing the import time of the block.
 
-We know from timing games that the block import latency greatly affects a client's performance to make correct head attestations. With this EIP, block transmission and block import processes will be decongested, allowing for greater flexibility in receiving a larger `ExecutionPayloadWithInclusionProof`, while the beacon block can simultaneously undergo processing. 
+We know from timing games that the block import latency greatly affects a client's performance to make correct head attestations. With this EIP, block transmission and block import processes will be decongested, allowing for greater flexibility in receiving a larger `ExecutionPayloadBundle`, while the beacon block can simultaneously undergo processing. 
 
 In addition, EL clients can also independently participate in forwarding and receiving larger execution blocks. That mechanism however can be independently developed and is out of scope for this EIP.
 
 Additional benefits obtained from this EIP:
 
 - Consensus clients don't need to store and serve blocks with transactions, providing greater efficiency and reduced resource requirements for running a beacon node.
-- The proposer-builder separation (PBS) pipeline becomes more efficient by the proposer transmitting the signed block directly to the p2p network, while submitting to the builder/relay for the independent reveal of the `ExecutionPayloadWithInclusionProof`.
+- The proposer-builder separation (PBS) pipeline becomes more efficient by the proposer transmitting the signed block directly to the p2p network, while submitting to the builder/relay for the independent reveal of the `ExecutionPayloadBundle`.
 - In the future with zero-knowledge (ZK) proof of the EL block execution, nodes could treat the transactions similarly to blobs which leverage data availability sampling (DAS) mechanisms for available data without requiring re-execution of transactions to establish validity. Hence the L1 execution could itself become a rollup by alleviating the need to import all transaction data by a node.
 
 Furthermore CL clients apis and code path will become cleaner and more maintainable because of collapse of blinded and full versions (like `BlindedBeaconBlock`, `BlindedBeaconBlockBody`) into same types.
@@ -40,8 +40,8 @@ Furthermore CL clients apis and code path will become cleaner and more maintaina
 ## Specification
 
 - `ExecutionPayload` in the `BeaconBlockBody` is replaced by `ExecutionPayloadHeader`
-- `ExecutionPayloadWithInclusionProof` is computed by the block proposer/builder and gossiped independently on a separate new topic. Also builder `submitBlindedBlock` api is modified to respond with `ExecutionPayloadWithInclusionProof` instead.
-- Data availability checks for block import into forkchoice now must wait for availability of the corresponding `ExecutionPayloadWithInclusionProof` but only for gossiped blocks
+- `ExecutionPayloadBundle` is computed by the block proposer/builder and gossiped independently on a separate new topic. Also builder `submitBlindedBlock` api is modified to respond with `ExecutionPayloadBundle` instead.
+- Data availability checks for block import into forkchoice now must wait for availability of the corresponding `ExecutionPayloadBundle` but only for gossiped blocks
 - `newPayloadHeader` engine api is introduced to augment the previous usage of `newPayload` in block processing when `ExecutionPayload` is not available for e.g. in processing range synced blocks signaling EL clients to optimistic sync those payloads from EL p2p network.
 
 ELs can optionally introduce a `getExecutionPayload` method (similar to `getBlobs`) to assist with faster recovery of execution payload from the EL's p2p network peers who could announce new payload hashes when they see new `VALID` payloads. However, as noted above, that mechanism could be independently specified and is out of scope for this EIP.
@@ -52,15 +52,17 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 - `ExecutionPayloadHeader` and `ExecutionPayload` refer to the canonical types in the consensus and execution specifications for the active fork. This EIP does not change the field set of either type.
 
-- `ExecutionPayloadWithInclusionProof` is defined for gossip and handoff purposes as:
+- Terminology note: this document previously referred to the bundle below as `ExecutionPayloadWithInclusionProof`. To avoid implying a cryptographic inclusion proof, it is renamed to `ExecutionPayloadBundle`. The bundle contains a header and full payload; consistency is established by recomputing the header from the payload, not by providing a separate Merkle proof.
+
+- `ExecutionPayloadBundle` is defined for gossip and handoff purposes as:
 
 ```
-class ExecutionPayloadWithInclusionProof(Container):
+class ExecutionPayloadBundle(Container):
     header: ExecutionPayloadHeader         # Header committed in the beacon block body
     payload: ExecutionPayload              # Full execution payload for the same block
 ```
 
-Validation rule for `ExecutionPayloadWithInclusionProof`:
+Validation rule for `ExecutionPayloadBundle`:
 
 - `derive_header(payload) == header` where `derive_header` deterministically computes all `ExecutionPayloadHeader` fields from `ExecutionPayload` (e.g., `transactions_root`, `receipts_root`, `state_root`, `withdrawals_root`, `base_fee_per_gas`, etc.). Nodes MUST recompute and compare for equality. No additional cryptographic proof is required beyond recomputation.
 
@@ -68,8 +70,8 @@ Implementations MAY additionally include per-field SSZ Merkle proofs for early f
 
 ### P2P gossip
 
-- A new global gossip topic is introduced for `ExecutionPayloadWithInclusionProof` messages corresponding to the current fork. Implementations MUST version this topic per-fork similarly to other consensus topics.
-- Gossip message payload is the SSZ serialization of `ExecutionPayloadWithInclusionProof`.
+- A new global gossip topic is introduced for `ExecutionPayloadBundle` messages corresponding to the current fork. Implementations MUST version this topic per-fork similarly to other consensus topics.
+- Gossip message payload is the SSZ serialization of `ExecutionPayloadBundle`.
 - Upon receiving a message, nodes MUST before re-gossiping:
   - Verify that `payload.block_hash` matches `header.block_hash` semantics for the active fork (i.e., the hash derived from `payload` equals `header.block_hash`).
   - Verify `derive_header(payload) == header`.
@@ -94,16 +96,16 @@ This EIP does not change existing `engine_forkchoiceUpdated` semantics. Implemen
 
 ### Forkchoice and availability
 
-- For blocks received via gossip, Consensus Layer clients MUST treat the beacon block as available for forkchoice only after the corresponding `ExecutionPayloadWithInclusionProof` has been received and validated per the rules above. Until then, the block MUST NOT be considered available for head selection.
+- For blocks received via gossip, Consensus Layer clients MUST treat the beacon block as available for forkchoice only after the corresponding `ExecutionPayloadBundle` has been received and validated per the rules above. Until then, the block MUST NOT be considered available for head selection.
 - For checkpoint or range sync, Consensus Layer clients MAY proceed optimistically by processing the beacon block with only `ExecutionPayloadHeader` and signaling the EL to recover bodies. In this mode, forkchoice participation MUST follow existing optimistic-sync safety constraints until bodies are validated.
 
 ### Builder/relay interaction (non-normative guidance)
 
-- Existing `submitBlindedBlock` style APIs SHOULD be extended to return `ExecutionPayloadWithInclusionProof` (or equivalently, a full `ExecutionPayload` together with the `ExecutionPayloadHeader` committed in the beacon block). Implementations SHOULD ensure the returned object satisfies the validation rule `derive_header(payload) == header`.
+- Existing `submitBlindedBlock` style APIs SHOULD be extended to return `ExecutionPayloadBundle` (or equivalently, a full `ExecutionPayload` together with the `ExecutionPayloadHeader` committed in the beacon block). Implementations SHOULD ensure the returned object satisfies the validation rule `derive_header(payload) == header`.
 
 ## Rationale
 
-There is another choice we could have made to go for `SignedExecutionPayload` instead of `ExecutionPayloadWithInclusionProof` and having a `SignedExecutionPayloadHeader` with builder signing these messages (validator is the builder in local block building). But without builder enshrinement tight gossip validation of `SignedExecutionPayload` would be an issue and could become a DOS vector.
+There is another choice we could have made to go for `SignedExecutionPayload` instead of `ExecutionPayloadBundle` and having a `SignedExecutionPayloadHeader` with builder signing these messages (validator is the builder in local block building). But without builder enshrinement tight gossip validation of `SignedExecutionPayload` would be an issue and could become a DOS vector.
 
 The benefit of `SignedExecutionPayload` design is that it could be transmitted ahead of even the `SignedExecutionPayloadHeader` inclusion in beacon block and is especially useful in PBS pipeline where the proposal to builder/relay latency can be reduced significantly.
 


### PR DESCRIPTION
- Insert RFC 2119/8174 terminology statement.
- Define ExecutionPayloadWithInclusionProof and header-derivation validation.
- Add P2P gossip topic and pre-gossip validation rules.
- Specify engine_newPayloadHeader and response semantics.
- Define forkchoice availability rules (gossip vs range sync).