### PR TITLE
Update EIP-7937: explicitly assign C056/C057 to JUMP/JUMPI

### DIFF
--- a/EIPS/eip-7937.md
+++ b/EIPS/eip-7937.md
@@ -71,8 +71,8 @@ Note that:
 
 For flow operations JUMP and JUMPI, the behavior is as follows:
 
-* `JUMP` will only read the last 64 bits from the stack value. The rest 192 bits are discarded without reading. Gas cost is `G_MID64`.
-* `JUMPI` will only read the last 64 bits from the stack as destination, and the condition check will only read the last 64 bits. Gas cost is `G_HIGH64`.
+* `JUMP` (`C056`) will only read the last 64 bits from the stack value. The rest 192 bits are discarded without reading. Gas cost is `G_MID64`.
+* `JUMPI` (`C057`) will only read the last 64 bits from the stack as destination, and the condition check will only read the last 64 bits. Gas cost is `G_HIGH64`.
 * In `JUMPDEST` validation phrase, `C0` is considered a standalone "mode" opcode and if the next byte followed is `JUMPDEST`, it continues to mark a valid `JUMPDEST` destination. Note that because there's no 64-bit `JUMPDEST`, during execution, `C0 JUMPDEST` would result in OOG.
 
 ## Rationale


### PR DESCRIPTION
Align spec with Abstract and related EIPs by explicitly mapping JUMP (C056) and JUMPI (C057) in the “JUMP, JUMPI” section.
Resolves a discrepancy where the Abstract declared flow opcodes C056/C057 but the Specification omitted the exact opcode bytes.
Matches expectations from the EOF-support EVM64 doc (EIP-7957), which presumes JUMP64/JUMPI64 exist in EIP-7937.