### PR TITLE
Update EIP-8038: correct terminology in EIP-8038 backwards compatibility section

### DIFF
--- a/EIPS/eip-8038.md
+++ b/EIPS/eip-8038.md
@@ -75,10 +75,10 @@ Differently from other account read operations, `EXTCODESIZE` and `EXTCODECOPY` 
 
 This is a backwards-incompatible gas repricing that requires a scheduled network upgrade.
 
-Wallet developers and node operators MUST update gas estimation handling to accommodate the new calldata cost rules. Specifically:
+Wallet developers and node operators MUST update gas estimation handling to accommodate the new state access cost rules. Specifically:
 
 - Wallets: Wallets using `eth_estimateGas` MUST be updated to ensure that they correctly account for the updated gas parameters. Failure to do so could result in underestimating gas, leading to failed transactions.
-- Node Software: RPC methods such as `eth_estimateGas` MUST incorporate the updated formula for gas calculation with the new floor cost values.
+- Node Software: RPC methods such as `eth_estimateGas` MUST incorporate the updated formula for gas calculation with the new state access cost values.
 
 Users can maintain their usual workflows without modification, as wallet and RPC updates will handle these changes.
 


### PR DESCRIPTION
Fixed incorrect reference to "calldata cost rules" in the backwards compatibility section. EIP-8038 deals with state access operations, not calldata operations. 