### PR TITLE
Update EIP-7932: 

### DIFF
--- a/EIPS/eip-7932.md
+++ b/EIPS/eip-7932.md
@@ -136,7 +136,7 @@ The signing hash of the payload MUST be calculated using the `compute_ssz_sig_ha
 def compute_ssz_sig_hash(payload: SignableData) -> Hash32:
     return Hash32(ExecutionSigningData(
         object_root=payload.hash_tree_root(),
-        domain=DOMAIN_TX_SSZ,
+        domain_type=DOMAIN_TX_SSZ,
     ).hash_tree_root())
 
 ```


### PR DESCRIPTION
Replace field name domain with domain_type in compute_ssz_sig_hash. EIP-7932 requires EIP-6493, which defines ExecutionSigningData with domain_type and uses it across examples. This change ensures type correctness and consistency with the canonical SSZ transaction signing scheme.