### PR TITLE
Update EIP-7961: Remove unused G_BASE64 gas constant

### DIFF
--- a/EIPS/eip-7961.md
+++ b/EIPS/eip-7961.md
@@ -33,7 +33,6 @@ During EOF validation, the validation function should enforce that only allowed 
 
 We define the following gas cost constants:
 
-* `G_BASE64`: 1
 * `G_VERYLOW64`: 2
 * `G_LOW64`: 3
 * `G_MID64`: 5


### PR DESCRIPTION
This change removes the G_BASE64 gas constant because it was never referenced by any opcode or rule in these specifications and had no usage elsewhere in the repository, which made it a dead/ambiguous constant