### PR TITLE
Remove unused assignments in deposit snapshot tests

### DIFF
--- a/assets/eip-4881/test_deposit_snapshot.py
+++ b/assets/eip-4881/test_deposit_snapshot.py
@@ -150,11 +150,11 @@ def test_snapshot_cases():
 def test_empty_tree_snapshot():
     with pytest.raises(AssertionError):
         # can't get snapshot from tree that hasn't been finalized
-        snapshot = DepositTree.new().get_snapshot()
+        DepositTree.new().get_snapshot()
 
 def test_invalid_snapshot():
     with pytest.raises(AssertionError):
         # invalid snapshot (deposit root doesn't match)
         invalid_snapshot = DepositTreeSnapshot([], zerohashes[0], 0, zerohashes[0], 0)
-        tree = DepositTree.from_snapshot(invalid_snapshot)
+        DepositTree.from_snapshot(invalid_snapshot)
 


### PR DESCRIPTION
Drop the unused locals inside the pytest.raises blocks so the negative tests stay the same but no longer define dead variables.
