### PR TITLE
Update EIP-7928: Clarify block reward wording again

### DIFF
--- a/EIPS/eip-7928.md
+++ b/EIPS/eip-7928.md
@@ -164,7 +164,7 @@ This includes the following special cases where addresses **MUST** be included w
 - Zero-value transfer recipients
 - Calling a same-transaction SELFDESTRUCT on an address that had a zero pre-transaction balance
 
-Zero-value block reward recipients **MUST NOT** be included without changes. Zero-value block reward recipients **MUST** be included for blocks where rewards > 0. 
+Zero-value block reward recipients **MUST NOT** trigger a balance change in the block access list and **MUST NOT** cause the recipient address to be included as a read (e.g. without changes). Zero-value block reward recipients **MUST** only be included with a balance change in blocks where the reward is greater than zero.
 
 #### Code
 


### PR DESCRIPTION
I think this makes the block reward recipient handling very clear and should be good now.