### PR TITLE
Remove unused DEPOSIT_CONTRACT_DEPTH import from deposit snapshot tests

### DIFF
--- a/assets/eip-4881/test_deposit_snapshot.py
+++ b/assets/eip-4881/test_deposit_snapshot.py
@@ -3,7 +3,7 @@ import pytest
 import yaml
 from dataclasses import dataclass
 from deposit_snapshot import DepositTree,DepositTreeSnapshot
-from eip_4881 import DepositData,DEPOSIT_CONTRACT_DEPTH,Eth1Data,Hash32,sha256,uint64,zerohashes
+from eip_4881 import DepositData,Eth1Data,Hash32,sha256,uint64,zerohashes
 
 @dataclass
 class DepositTestCase:


### PR DESCRIPTION
remove the unused DEPOSIT_CONTRACT_DEPTH import from assets/eip-4881/test_deposit_snapshot.py to keep the test module dependency list clean and silence linter warnings.
