### PR TITLE
Remove unused helper from deposit snapshot tests 

### DIFF
--- a/assets/eip-4881/test_deposit_snapshot.py
+++ b/assets/eip-4881/test_deposit_snapshot.py
@@ -13,9 +13,6 @@ class DepositTestCase:
     block_height: uint64
     snapshot: DepositTreeSnapshot
 
-def get_hex(some_bytes) -> str:
-    return "0x{}".format(some_bytes.hex())
-
 def get_bytes(hexstr) -> bytes:
     return bytes.fromhex(hexstr.replace("0x",""))
 


### PR DESCRIPTION
Delete the unused get_hex function from assets/eip-4881/test_deposit_snapshot.py to eliminate dead code without changing test behavior.