### PR TITLE
Update EIP-8037: Clarify gas accounting for contract deployment

### DIFF
--- a/EIPS/eip-8037.md
+++ b/EIPS/eip-8037.md
@@ -13,7 +13,7 @@ requires: 2780
 
 ## Abstract
 
-This proposal increases the cost of state creation operations, thus avoiding excessive state growth under increased block gas limits. It sets a unit cost per new state byte that targets an average state growth of 60 GiB per year at a block gas limit of 300M gas units and an average gas utilization for state growth of 30%. Contract deployments get a 10x cost increase while new accounts get a 8.5x increase. Deployments of duplicated do not pay deposit costs. To avoid limiting the maximum contract size that can be deployed, it also introduces an independent metering for code deposit costs.
+This proposal increases the cost of state creation operations, thus avoiding excessive state growth under increased block gas limits. It sets a unit cost per new state byte that targets an average state growth of 60 GiB per year at a block gas limit of 300M gas units and an average gas utilization for state growth of 30%. Contract deployments get a 10x cost increase while new accounts get a 8.5x increase. To avoid limiting the maximum contract size that can be deployed, it also introduces an independent metering for code deposit costs.
 
 ## Motivation
 
@@ -31,15 +31,15 @@ The relationship we are seeing in this example is not linear as expected. This i
 
 Upon activation of this EIP, the following parameters of the gas model are updated:
 
-| **Parameter** | **Current value** | **New value** | **Increase** | **Operations affected** |
-|:---:|:---:|:---:|:---:|:---:|
-| `GAS_CREATE` | 32,000 | 212,800 | 6.7x | `CREATE`, `CREATE2`, contract creation txs |
-| `GAS_CODE_DEPOSIT` | 200 | 1,900 | 9.5x | `CREATE`, `CREATE2`, contract creation txs |
-| `GAS_NEW_ACCOUNT` | 25,000 | 212,800 | 8.5x | New EOA funding |
-| `GAS_SELF_DESTRUCT_NEW_ACCOUNT` | 25,000 | 212,800 | 8.5x | `SELF_DESTRUCT` |
-| `GAS_STORAGE_SET` | 20,000 | 60,800 | 3x | `SSTORE` |
-| `PER_EMPTY_ACCOUNT_COST` | 25,000 | 212,800 | 8.5x | EOA delegation |
-| `PER_AUTH_BASE_COST` | 12,500 | 43,700 | 3.5x | EOA delegation |
+|          **Parameter**          | **Current value** | **New value** | **Increase** |          **Operations affected**           |
+| :-----------------------------: | :---------------: | :-----------: | :----------: | :----------------------------------------: |
+|          `GAS_CREATE`           |      32,000       |    212,800    |     6.7x     | `CREATE`, `CREATE2`, contract creation txs |
+|       `GAS_CODE_DEPOSIT`        |        200        |     1,900     |     9.5x     | `CREATE`, `CREATE2`, contract creation txs |
+|        `GAS_NEW_ACCOUNT`        |      25,000       |    212,800    |     8.5x     |              New EOA funding               |
+| `GAS_SELF_DESTRUCT_NEW_ACCOUNT` |      25,000       |    212,800    |     8.5x     |              `SELF_DESTRUCT`               |
+|        `GAS_STORAGE_SET`        |      20,000       |    60,800     |      3x      |                  `SSTORE`                  |
+|    `PER_EMPTY_ACCOUNT_COST`     |      25,000       |    212,800    |     8.5x     |               EOA delegation               |
+|      `PER_AUTH_BASE_COST`       |      12,500       |    43,700     |     3.5x     |               EOA delegation               |
 
 ### Multidimensional metering for code deposit gas
 
@@ -47,16 +47,43 @@ Besides the parameter changes, this proposal introduces an independent metering 
 
 ### Contract deployment cost calculation
 
-This proposal further changes how contract deployment cost are computed. When a contract creation returns a runtime bytecode `R` (length `L`), first check whether the code already exists in the state trie. Then:
+This proposal clarifies how gas is charged during contract deployment, ensuring that post-execution costs (account creation, hashing, code deposit) are only charged when the deployment succeeds.
 
-- If `CodeExists(keccak256(R), live_state) == false`, charge `code_deposit_cost=GAS_CODE_DEPOSIT*L` and store `R` under its code hash.
-- If `CodeExists(...) == true`, do not charge code-deposit storage gas (`code_deposit_gas=0`); simply link the new account's `codeHash` to the existing code object.
+#### Success vs Failure Gas Accounting
 
-In addition, contract creation is also charged a `storage_access_cost = GAS_WARM_ACCESS (if warm) | GAS_COLD_SLOAD (if cold)` and a `hash_cost = GAS_KECCAK256_WORD * code_data_words`, where `code_data_words = ceil(L / 32)`. This accounts for the added execution cost of accessing and verifying for duplicated code.
+When a contract creation transaction or opcode (`CREATE`/`CREATE2`) is executed, gas is charged differently based on whether the deployment succeeds or fails. Given bytecode `B` (length `L`) returned by initcode and `H = keccak256(B)`:
+
+1. **When opcode execution starts:** Always charge `GAS_CREATE` (212,800 gas)
+2. **During initcode execution:** Charge the actual gas consumed by the initcode execution
+3. **Success path** (no error, not reverted, and `L ≤ MAX_CODE_SIZE`):
+   - If the target account is new, charge `GAS_NEW_ACCOUNT` (212,800 gas)
+   - Charge `GAS_CODE_DEPOSIT * L` and persist `B` under `H`, then link `codeHash` to `H`
+   - Charge `HASH_COST(L)` where `HASH_COST(L) = 6 × ceil(L / 32)` to compute `H`
+4. **Failure paths** (REVERT, OOG/invalid during initcode, OOG during code deposit, or `L > MAX_CODE_SIZE`):
+   - Do NOT charge `GAS_NEW_ACCOUNT`, `GAS_CODE_DEPOSIT * L`, or `HASH_COST(L)`
+   - No code is stored; no `codeHash` is linked to the account
+   - The account remains unchanged or non-existent
+
+**Important:** The gas for code deposit (`GAS_CODE_DEPOSIT * L`) is checked before hash computation. This means that if a deployment runs out of gas, it will fail during the deposit gas check before the hash is computed. This maintains consistency with post-Homestead behavior where any deployment failure (including OOG) reverts all state changes - no account is created and no gas is charged beyond `GAS_CREATE` and the actual initcode execution cost consumed.
+
+**Total gas formulas:**
+
+```
+SUCCESS_PATH_TOTAL_GAS =
+    GAS_CREATE
+  + initcode_execution_cost
+  + (GAS_NEW_ACCOUNT if account is new else 0)
+  + GAS_CODE_DEPOSIT * L
+  + HASH_COST(L)
+
+FAILURE_PATH_TOTAL_GAS =
+    GAS_CREATE
+  + initcode_execution_cost
+```
 
 #### `CREATE` vs `CREATE2`
 
-`CREATE2` already charges for hashing the init code when deriving the address. That cost remains. Runtime-code deduplication hash (`keccak256(R)`) is separate: even with `CREATE2`, the runtime hash must be computed to determine whether the code is new or already stored.
+`CREATE2` already charges for hashing the init code when deriving the address. That cost remains unchanged. The bytecode hash (`keccak256(B)`) must be computed on success to store the code, incurring `HASH_COST(L)` as specified above.
 
 ## Rationale
 
@@ -64,13 +91,13 @@ In addition, contract creation is also charged a `storage_access_cost = GAS_WARM
 
 With the current pricing, the gas cost of creating 1 byte of state varies depending on the method used. The following table shows the various methods and their gas cost per byte. The calculation ignores the transaction intrinsic cost (21k gas units) and the costs of additional opcodes and scaffolding needed to execute such a transaction.
 
-| Method | What is written | Intrinsic gas | Bytes → state | Gas / byte |
-|---|---|---|---|---|
-| Deploy 24kB contract ([EIP-170](./eip-170.md) limit) | Runtime code + account trie node | 32,000 CREATE + 25,000 new account + 200 × 24,576 code deposit = 4,972,200 gas | 24,576 B | ~202 gas |
-| Fund fresh EOA with 1 wei | Updated account leaf | 25,000 new account | ~112 B | ~223 gas |
-| Add delegate flag to funded EOA ([EIP-7702](./eip-7702.md)) | 23 B (0xef0100‖address) + updated account leaf | 25,000 PER_EMPTY_ACCOUNT + 12,500 PER_AUTH_BASE + 1,616 calldata - 7,823 refund = ~31,300 gas | ~135 B | ~232 gas |
-| [EIP-7702](./eip-7702.md) authorization to empty address | 23 B (0xef0100‖address) + updated account leaf | 25,000 PER_EMPTY_ACCOUNT + 12,500 PER_AUTH_BASE + 1,616 calldata = 39,116 gas | ~135 B | ~289 gas |
-| Fill new storage slots (SSTORE 0→x) | Slot in storage trie | 20,000 gas/slot | 32 B | 625 gas |
+| Method                                                      | What is written                                | Intrinsic gas                                                                                 | Bytes → state | Gas / byte |
+| ----------------------------------------------------------- | ---------------------------------------------- | --------------------------------------------------------------------------------------------- | ------------- | ---------- |
+| Deploy 24kB contract ([EIP-170](./eip-170.md) limit)        | Runtime code + account trie node               | 32,000 CREATE + 25,000 new account + 200 × 24,576 code deposit = 4,972,200 gas                | 24,576 B      | ~202 gas   |
+| Fund fresh EOA with 1 wei                                   | Updated account leaf                           | 25,000 new account                                                                            | ~112 B        | ~223 gas   |
+| Add delegate flag to funded EOA ([EIP-7702](./eip-7702.md)) | 23 B (0xef0100‖address) + updated account leaf | 25,000 PER_EMPTY_ACCOUNT + 12,500 PER_AUTH_BASE + 1,616 calldata - 7,823 refund = ~31,300 gas | ~135 B        | ~232 gas   |
+| [EIP-7702](./eip-7702.md) authorization to empty address    | 23 B (0xef0100‖address) + updated account leaf | 25,000 PER_EMPTY_ACCOUNT + 12,500 PER_AUTH_BASE + 1,616 calldata = 39,116 gas                 | ~135 B        | ~289 gas   |
+| Fill new storage slots (SSTORE 0→x)                         | Slot in storage trie                           | 20,000 gas/slot                                                                               | 32 B          | 625 gas    |
 
 To harmonize costs, we first set the gas cost of a single state byte, `cost_per_state_byte`. **This cost targets an average growth of 60 GiB per year at a block gas limit of 300M gas units and an average gas utilization for state growth of 30%**. A [recent empirical analysis](../assets/eip-8011/multidim_empirical_analysis.md) has shown that, at current gas prices, state creation accounts for approximately 30% of all gas consumed. ** Additionally, on average, blocks use half of the entire available gas in the block. Thus, we are setting the unit gas cost of state creation based on the average case. Finally, we are targeting a 300M block limit to account for scaling optimizations expected in the short to medium term.
 
@@ -96,12 +123,6 @@ An independent metering of the code deposit costs allows to lift this limit for 
 
 This proposal is consistent with the multidimensional gas metering introduced in [EIP-8011](./eip-8011.md). However, it only requires two dimensions, namely, `gas` and `code_deposit_gas`. If [EIP-8011](./eip-8011.md) is not implemented, a two-dimensional version of [EIP-8011](./eip-8011.md) is still required.
 
-### Duplicated bytecode discount
-
-- Ordering & same-block deployments: Sequential transaction execution ensures that a deployment storing new code makes it visible to later transactions in the same block. First transaction paying `code_deposit_cost`; subsequent transactions see the code as present and pay only lookup + hash costs.
-- Hashing cost is necessary: Always charge `hash_cost` for runtime code. Protects against abuse with large constructor outputs.
-- What counts as “same code”? Exact runtime bytecode. Even minor differences produce distinct hashes.
-- Empty code handling: Clients can treat empty code as a special case with a hard-coded hash lookup (`EMPTY_CODE_HASH`), making it effectively free.
 
 ## Backwards Compatibility
 
@@ -128,17 +149,12 @@ New slot:
 - OLD: 0.5 Gwei x 20,000 x 4,000 USD = 0.04 USD
 - NEW: 0.5 Gwei x 60,800 x 4,000 USD = 0.122 USD
 
-24kB contract deployment:
+24kB contract deployment (new account):
 
-- OLD: 0.5 Gwei x (32,000 + 200 × 24,576) x 4,000 USD = 9.8944 USD
-- NEW: 0.5 Gwei x (212,800 + 2100 + 6 * 768 + 1,900 × 24,576) x 4,000 USD = 93.828 USD
+- OLD: 0.5 Gwei x (32,000 + 25,000 + 200 × 24,576) x 4,000 USD = 9.9584 USD
+- NEW: 0.5 Gwei x (212,800 + 212,800 + 4,608 + 1,900 × 24,576) x 4,000 USD = 94.254 USD
 
-24kB contract deployment with duplicated bytecode:
-
-- OLD: 0.5 Gwei x (32,000 + 200 × 24,576) x 4,000 USD = 9.8944 USD
-- NEW: 0.5 Gwei x (212,800 + 2100 + 6 * 768) x 4,000 USD = 0.439 USD
-
-Note that we are ignoring transaction intrinsic costs (21k gas units), call data costs, and the costs of additional opcodes and scaffolding needed to execute such transactions.
+Note: The NEW calculation includes `GAS_CREATE` (212,800), `GAS_NEW_ACCOUNT` (212,800), `HASH_COST` (6 × 768 = 4,608 for 24,576 bytes), and `GAS_CODE_DEPOSIT` (1,900 × 24,576). We ignore transaction intrinsic costs (21k gas units), call data costs, and the costs of additional opcodes and scaffolding needed to execute such transactions.
 
 ## Security Considerations
 


### PR DESCRIPTION
…ss/failure paths

This update clarifies how gas is charged during contract creation, addressing review feedback about the proper ordering of gas charges and failure behavior.

Key clarifications:
- Explicitly define success vs failure gas accounting paths
- Specify that GAS_CODE_DEPOSIT is charged before HASH_COST
- Clarify that any failure (REVERT, OOG, L > MAX_CODE_SIZE) reverts all state changes, maintaining post-Homestead behavior
- Document that only GAS_CREATE + initcode execution costs are charged on failure
- Add HASH_COST(L) = 6 × ceil(L / 32) for bytecode hash computation

This change removes the bytecode deduplication mechanism (deferred to future PR) and focuses solely on clarifying the gas accounting behavior for the base proposal.