### PR TITLE
Add EIP: Contract Bytecode Deduplication Discount

### DIFF
--- a/EIPS/eip-8058.md
+++ b/EIPS/eip-8058.md
@@ -2,7 +2,7 @@
 eip: 8058
 title: Contract Bytecode Deduplication Discount
 description: Reduces gas costs for deploying duplicate contract bytecode via access-list based mechanism
-author: Carlos Perez (@CPerezz), Wei-Han (@weiihann), Guillaume Ballet (@gballet)
+author: Carlos Perez (@CPerezz), Wei Han Ng (@weiihann), Guillaume Ballet (@gballet)
 discussions-to: https://ethereum-magicians.org/t/eip-8058-contract-bytecode-deduplication-discount/25933
 status: Draft
 type: Standards Track
@@ -28,7 +28,7 @@ A naive "check if code exists in database" approach would break consensus becaus
 
 Empirical analysis reveals that approximately 27,869 bytecodes existed in full-synced node databases with no live account pointing to them (as of the Cancun fork). A database lookup `CodeExists(hash)` would yield different results on different nodes, causing different gas costs and breaking consensus.
 
-This proposal solves the problem by making deduplication checks explicit and deterministic through access lists, ensuring all nodes compute identical gas costs regardless of their database state. (Notice here that even if fully-synced clients have more codes, there are no accounts whose codeHash actually is referencing them. Thus, users can't profit from such discounts which keeps consensus safe).
+This proposal solves the problem by making deduplication checks implicit and deterministic through access lists, ensuring all nodes compute identical gas costs regardless of their database state. (Notice here that even if fully-synced clients have more codes, there are no accounts whose codeHash actually is referencing them. Thus, users can't profit from such discounts which keeps consensus safe).
 
 ## Specification
 
@@ -122,7 +122,7 @@ If two transactions in the same block both deploy identical new bytecode and nei
 This is acceptable because:
 
 - The first deployment cannot be known at transaction construction time
-- Deduplication requires explicit opt-in via access list
+- Deduplication requires implicit opt-in via access list
 - This scenario is extremely rare in practice
 - The complexity of special handling is not worth the minimal benefit
 


### PR DESCRIPTION
This proposal introduces a gas discount for contract deployments when the bytecode being deployed already exists in the state. The mechanism extends EIP-2930 access lists with an optional checkCodeHash flag to enable deterministic deduplication checks without breaking consensus.

Key features:
- Access-list based deduplication via checkCodeHash flag
- Avoids GAS_CODE_DEPOSIT * L costs for duplicate deployments
- Solves database divergence issues across different sync modes
- Becomes particularly relevant with EIP-8037's increased gas costs

This EIP is extracted from the original EIP-8037 proposal to allow independent review and adoption.

This EIP doesn't modify any interaction between users and the chain if not used. Meaning, users will get discounts if they use the EIP. They'll pay the same exact price as they do now if they don't use this EIP.