### PR TITLE
Update EIP-6810: add dependency determination algorithm for cascading revert

### DIFF
--- a/EIPS/eip-6810.md
+++ b/EIPS/eip-6810.md
@@ -54,7 +54,14 @@ Otherwise, the remainder of the budget after all transactions are reverted is pa
 The state is rolled back to the start of the transaction specified by `revertNonce`.
 An access list is initialized empty.
 Any state previously modified by a reverted transaction is added to the access list.
-Any subsequent transaction reading or using state included in the access list must also be reverted.
+
+**Dependency determination algorithm:**
+1. For each reverted transaction, collect all state modifications (ether balance changes, storage writes, code deployments, nonce increments)
+2. For each subsequent transaction in the block, check if it accesses any state included in the access list
+3. State access includes: `SLOAD`, `SSTORE`, `BALANCE`, `*CALL` opcodes, `EXT*` opcodes, and direct ether transfers
+4. If a transaction accesses any state from the access list, it must be reverted and its state modifications added to the access list
+5. Repeat step 2-4 for all newly reverted transactions until no more dependencies are found
+
 This operation cascades forward until the current block.
 
 State includes:


### PR DESCRIPTION
Adds a detailed step-by-step algorithm for determining transaction dependencies in the cascading revert mechanism. 

Specifies which EVM operations create dependencies and describes the iterative process for identifying all affected transactions.