### PR TITLE
Update EIP-7928: Clarify COINBASE tracking in BAL

### DIFF
--- a/EIPS/eip-7928.md
+++ b/EIPS/eip-7928.md
@@ -181,7 +181,7 @@ Record **post‑transaction nonces** for:
 
 ### Edge Cases (Normative)
 
-- **COINBASE / Fee Recipient:** The COINBASE address **MUST** be included if it experiences state change. It **MUST NOT** be included for blocks with no transactions, provided there are no other state changes (e.g., from [EIP-4895](./eip-4895.md) withdrawals). If the COINBASE reward is zero, the COINBASE address **MUST** be included as a *read*.
+- **COINBASE / Fee Recipient:** The COINBASE address **MUST** be included if it experiences any state change. It **MUST NOT** be included for blocks with no transactions, provided there are no other state changes (e.g., from [EIP-4895](./eip-4895.md) withdrawals). If the COINBASE reward is zero, the COINBASE address **MUST** be included as a *read*.
 - **Precompiled contracts:** Precompiles **MUST** be included when accessed. If a precompile receives value, it is recorded with a balance change. Otherwise, it is included with empty change lists.
 - **SENDALL:** For positive-value selfdestructs, the sender and beneficiary are recorded with a balance change.
 - **SELFDESTRUCT (in-transaction):** Accounts destroyed within a transaction **MUST** be included in `AccountChanges` without nonce or code changes. However, if the account had a positive balance pre-transaction, the balance change to zero **MUST** be recorded. Storage keys within the self-destructed contracts that were modified or read **MUST** be included as a `storage_read`. 


### PR DESCRIPTION
This clarifies how the COINBASE address is tracked, aligned with the outcome of the discussion of EIP-7928 breakout call nr 5:
https://github.com/ethereum/pm/issues/1771