### PR TITLE
Update EIP-7773: Add EIP-8058 to Glamsterdam PFI list

### DIFF
--- a/EIPS/eip-7773.md
+++ b/EIPS/eip-7773.md
@@ -75,15 +75,16 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Declined
 1. [EIP-8038](./eip-8038.md): State-access gas cost increase
 1. [EIP-8045](./eip-8045.md): Exclude slashed validators from proposing
 1. [EIP-8057](./eip-8057.md): Inter-Block Temporal Locality Gas Discounts
+1. [EIP-8058](./eip-8058.md): Contract Bytecode Deduplication Discount
 1. [EIP-8061](./eip-8061.md): Increase churn limits
 
 ### Activation
 
-| Network Name     | Activation Epoch | Activation Timestamp |
-|------------------|------------------|----------------------|
-| Sepolia          |                  |                      |
-| Holešky          |                  |                      |
-| Mainnet          |                  |                      |
+| Network Name | Activation Epoch | Activation Timestamp |
+| ------------ | ---------------- | -------------------- |
+| Sepolia      |                  |                      |
+| Holešky      |                  |                      |
+| Mainnet      |                  |                      |
 
 **Note**: rows in the table above will be filled as activation times are decided by client teams.
 


### PR DESCRIPTION
## Summary

Adds EIP-8058 (Contract Bytecode Deduplication Discount) to the Glamsterdam - PFI list in EIP-7773.

EIP-8058 introduces a gas discount for contract deployments when the bytecode being deployed already exists in state, leveraging EIP-2930 access lists for implicit deduplication.