### PR TITLE
Update EIP-7971: Hard Limits for Transient Storage

### DIFF
--- a/EIPS/eip-7971.md
+++ b/EIPS/eip-7971.md
@@ -72,6 +72,7 @@ This EIP implements constant pricing with a hard limit for several reasons:
 
 - `GAS_TLOAD` (5 gas): Transient storage reads require only memory access without disk I/O.
 - `GAS_TSTORE` (12 gas): Transient storage writes require memory allocation and journaling for revert support.
+- `GAS_TSTORE_ALLOCATE` (24 gas): Writes to fresh slots require memory allocation, which is more expensive than writing to an existing slot.
 
 `TSTORE` currently has a fixed cost. However, writing to fresh slots requires memory allocation, which is more expensive than writing to an existing slot. Therefore, we may consider introducing charging more for the first slot allocation through the parameter `GAS_TSTORE_ALLOCATE`. However, we would also need to introduce a mechanism to check for the first slot allocation versus subsequent allocations.
 


### PR DESCRIPTION
- Removes the warm `SLOAD` reprice since this parameter is updated in EIP-8038
- Adds a benchmarking note
- Updates wording
- Updates authors