### PR TITLE
Update EIP-7773: Add EIP-7872 (Max Blobs flag) to Glamsterdam PFI list

### DIFF
--- a/EIPS/eip-7773.md
+++ b/EIPS/eip-7773.md
@@ -53,6 +53,7 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Declined
 1. [EIP-7793](./eip-7793.md): Conditional Transactions
 1. [EIP-7819](./eip-7819.md): SETDELEGATE instruction
 1. [EIP-7843](./eip-7843.md): SLOTNUM opcode
+1. [EIP-7872](./eip-7872.md): Max blob flag for local builders
 1. [EIP-7903](./eip-7903.md): Remove Initcode Size Limit
 1. [EIP-7904](./eip-7904.md): General Repricing
 1. [EIP-7907](./eip-7907.md): Meter Contract Code Size And Increase Limit


### PR DESCRIPTION
This does not require a hard fork, included here as a formality.

CC @parithosh for visibility since you wrote an blog post on max blobs