### PR TITLE
Update EIP-5656: resolve gas calculation inconsistency in EIP-5656

### DIFF
--- a/EIPS/eip-5656.md
+++ b/EIPS/eip-5656.md
@@ -75,8 +75,8 @@ Per yellow paper terminology, it should be considered part of the `W_copy` group
 ```
 words_copied = (length + 31) // 32
 g_verylow    = 3
-g_copy       = 3 * words_copied + memory_expansion_cost
-gas_cost     = g_verylow + g_copy
+g_copy       = 3 * words_copied
+gas_cost     = g_verylow + g_copy + memory_expansion_cost
 ```
 
 ### Output stack
@@ -90,7 +90,7 @@ Copying takes place as if an intermediate buffer was used, allowing the destinat
 
 If `length > 0` and (`src + length` or `dst + length`) is beyond the current memory length, the memory is extended with respective gas cost applied.
 
-The gas cost of this instruction mirrors that of other `Wcopy` instructions and is `Gverylow + Gcopy * ceil(length / 32)`.
+The gas cost of this instruction mirrors that of other `Wcopy` instructions and is `Gverylow + Gcopy * ceil(length / 32) + memory_expansion_cost`.
 
 ## Rationale
 


### PR DESCRIPTION
Fixes conflicting gas cost formulas in MCOPY specification:
- First formula included memory_expansion_cost
- Second formula excluded memory_expansion_cost

This inconsistency could lead to incorrect implementations where memory expansion costs are not properly accounted for.