### PR TITLE
Update EIP-6690: correct typo in Montgomery multiplication function parameter

### DIFF
--- a/EIPS/eip-6690.md
+++ b/EIPS/eip-6690.md
@@ -257,7 +257,7 @@ Note that normal modular addition and subtraction algorithms work for Montgomery
 # output:
 #  (x * y * pow(R, -1, mod)) % mod
 #
-def mulmont(x: int, y: int, mod: int, monst_const: int, R: int) -> int:
+def mulmont(x: int, y: int, mod: int, mont_const: int, R: int) -> int:
     t = x * y
     m = ((t % R) * mont_const) % R
     t = t + m * mod


### PR DESCRIPTION
The typo was causing a mismatch between the parameter name in the function definition and its usage in the function body, which would result in a NameError at runtime. This fix ensures the Montgomery multiplication algorithm implementation is syntactically correct and consistent with the documented variable naming convention.