### PR TITLE
Update EIP-7932: fix SSZ active_fields count in AlgorithmicTransaction

### DIFF
--- a/EIPS/eip-7932.md
+++ b/EIPS/eip-7932.md
@@ -111,7 +111,7 @@ class SignableData(ProgressiveContainer(active_fields=[1,1,1])):
   additional_signatures: List[AdditionalSignature, MAX_ADDITIONAL_INFO]
 
 
-class AlgorithmicTransaction(ProgressiveContainer(active_fields=[1,1,1,1])):
+class AlgorithmicTransaction(ProgressiveContainer(active_fields=[1,1,1,1,1])):
   # The selector for which algorithm is to be used.
   algorithm_type: uint8,
 


### PR DESCRIPTION
Reason:
- EIP-7495 (ProgressiveContainer) requires the number of '1' bits in active_fields  to equal the number of fields defined in the class, and the bitvector must not end in 0.
- AlgorithmicTransaction defines five fields (algorithm_type, signature_info, payload,  chain_id, additional_signatures); previously only four bits were set, violating the rule.
- The update makes the container serialization/merkleization compliant and consistent  with patterns used across EIP-6404 and related SSZ container definitions.