### PR TITLE
Update EIP-8032: Transition changes and add clarity

### DIFF
--- a/EIPS/eip-8032.md
+++ b/EIPS/eip-8032.md
@@ -108,20 +108,20 @@ To compute `new` efficiently without scanning all storage every block, clients M
 For each storage slot `k` of account `A` that was written at least once in the block:
 
 ```python
-def calculate_storage_delta(v_0, v_1):
+def calculate_storage_delta(prestate_value, poststate_value):
     """
     Calculate the storage slot delta based on pre-state and post-state values.
     
     Args:
-        v_0: Pre-state value of the storage slot
-        v_1: Post-state value of the storage slot
+        prestate_value: Pre-state value of the storage slot
+        poststate_value: Post-state value of the storage slot
     
     Returns:
         int: Delta value (+1, -1, or 0)
     """
-    if v_0 == 0 and v_1 != 0:
+    if prestate_value == 0 and poststate_value != 0:
         return 1    # Slot created: empty to non-empty
-    elif v_0 != 0 and v_1 == 0:
+    elif prestate_value != 0 and poststate_value == 0:
         return -1   # Slot deleted: non-empty to empty
     else:
         return 0    # No change in slot occupancy
@@ -204,7 +204,7 @@ Under a unified tree, the per-write computational and I/O cost of `SSTORE` no lo
 
 ### Compatibility with EIP-2926
 
-Because [EIP-2926](./eip-2926.md) also requires an account transition, scheduling both EIPs in the same fork enables a single, combined transition. This removes duplicated work, reduces client complexity and the number of tree transitions in the future.
+Because [EIP-2926](./eip-2926.md) also requires an account transition to chunkify the bytecode and additional additional fields, scheduling both EIPs in the same fork enables a single, combined transition. This removes duplicated work, reduces client complexity and the number of tree transitions in the future.
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
#### 1. Count the slots for accounts with non-empty `storageRootHash` instead of non-empty `codeHash`
- It's possible for contracts to have non-empty `codeHash` and have empty `storageRootHash`. Therefore, it's more efficient to check for non-empty `storageRootHash` instead
- credits to @jochem-brouwer

#### 2. Iterate all accounts instead of just accounts with non-empty `storageRootHash`
- EL clients do not store accounts with non-empty `storageRootHash` separately. Therefore, the transition should involve iterating all accounts, and populate the `storageCount` field if it's an account with non-empty `storageRootHash`.

#### 3. Use python function for storage delta calculation
- The mathematical formula isn't rendered properly in the EIP page

#### 4. Added a subsection on compatibility with EIP-2926

