### PR TITLE
Update EIP-7749: Fix ERC-191 v0x00 terminology to "intended validator address"

### DIFF
--- a/EIPS/eip-7749.md
+++ b/EIPS/eip-7749.md
@@ -38,7 +38,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ### `wallet_signIntendedValidatorData`
 
-MUST calculate an Ethereum signature using `sign(keccak256("\x19\x00<signature validator address><data to sign>"))`.
+MUST calculate an Ethereum signature using `sign(keccak256("\x19\x00<intended validator address><data to sign>"))`.
 
 This method adds a prefix to the message to prevent malicious dApps from signing arbitrary data (e.g., a transaction) and using the signature to impersonate the victim.
 


### PR DESCRIPTION
Replace "<signature validator address>" with "<intended validator address>" in the ERC-191 v0x00 hashing formula for wallet_signIntendedValidatorData.

Reason:
- ERC-191 (Final) specifies version 0x00 as: 0x19 <0x00> <intended validator address> <data to sign>.
- Aligns with the Abstract and the rest of this EIP which already use "intended validator address".
- Removes ambiguity and ensures spec correctness and interoperability.

Scope:
- Single-line doc fix in EIPS/eip-7749.md; no functional changes.