### PR TITLE
Update EIP-7997: replace 'nonce' with 'salt' in Input validation

### DIFF
--- a/EIPS/eip-7997.md
+++ b/EIPS/eip-7997.md
@@ -115,7 +115,7 @@ The address `0x0b` (`0x000000000000000000000000000000000000000b`) is chosen as t
 
 ### Input validation
 
-The factory reverts if the input is smaller than 32 bytes, the minimum size that contains a nonce, to provide an explicit error when the factory is not correctly invoked.
+The factory reverts if the input is smaller than 32 bytes, the minimum size that contains the salt, to provide an explicit error when the factory is not correctly invoked.
 
 ### No frontrunning protection
 


### PR DESCRIPTION
The Input validation section incorrectly referred to the first 32 bytes as a "nonce".
For CREATE2, the first 32 bytes are the salt (stack arg 4), as specified in EIP-1014:
"salt is always 32 bytes" and the address formula uses salt.

This change aligns the terminology with the spec and the earlier sentence in this EIP that already states the salt is the first 32 bytes of calldata.