### PR TITLE
Update EIP-2926: refine transition description and refer to 8032

### DIFF
--- a/EIPS/eip-2926.md
+++ b/EIPS/eip-2926.md
@@ -73,7 +73,7 @@ The transition process involves reading all contracts in the state and applying 
 
 Note that:
 
- - Because multiple accounts can share the same code hash, the whole account tree needs to be iterated over to convert each account. Only iterating over the bycodes isn't enough.
+ - Because multiple accounts can share the same code hash, the whole account tree needs to be iterated over to convert each account. Only iterating over the bytecodes isn't enough.
  - Nonetheless, the conversion process should take a few hours, instead of days for a full tree change.
 
 At `HF_TIMESTAMP` the EIP gets activated:
@@ -87,7 +87,7 @@ At `HF_TIMESTAMP` the EIP gets activated:
 
 The value for `ITERATOR_STRIDE` has been chosen to be safe while ensuring the transition process does not last too long. At the current state size and block time, this represents about 10000 blocks, which is about one and a half day.
 
-Following the transition process described in [EIP-8032](./eip-8032.md), the transition process uses a system contract to store its progress pointers. The transition process has been designed in such a way that if both EIPs are activated at the same, time, their transition process can be meged. Refer to that EIP for more details.
+Following the transition process described in [EIP-8032](./eip-8032.md), the transition process uses a system contract to store its progress pointers. The transition process has been designed in such a way that if both EIPs are activated at the same time, their transition process can be merged. Refer to that EIP for more details.
 
 Note that for a bytecode used by multiple contracts, the chunking need happen only once. Such contract only need to update their code size and code root, which MAY be cached during the transition process.
 


### PR DESCRIPTION
Clarify some aspects of the conversion in 2926, and also remark that it is mergeable with the one described in 8032.