### PR TITLE
Update EIP-8030: enforce integer low-s check per EIP-2

### DIFF
--- a/EIPS/eip-8030.md
+++ b/EIPS/eip-8030.md
@@ -39,7 +39,7 @@ def verify(signature_info: bytes, payload_hash: Hash32) -> Bytes:
     (r, s, x, y) = (signature_info[0:32], signature_info[32:64], signature_info[64:96], signature_info[96:128])
 
     # This is similar to [EIP-2](./eip-2.md)'s malleability verification.
-    assert(s <= N/2)
+    assert(int.from_bytes(s, "big") <= N // 2)
 
     # This is defined in [P256Verify Function](#p256verify-function)
     assert(P256Verify(payload_hash, r, s, x, y) == Bytes("0x0000000000000000000000000000000000000000000000000000000000000001"))


### PR DESCRIPTION
Replace assert(s <= N/2) with assert(int.from_bytes(s, "big") <= N // 2) in EIPS/eip-8030.md. s is a 32-byte slice; comparing bytes to a number is invalid.
Use integer conversion and floor division to avoid type errors and match EIP-2 low-s rule (<= n/2) for malleability mitigation.
This change corrects the verification logic without altering the intended semantics of the P-256 low-s requirement.