### PR TITLE
Update EIP-8016: expand deserialization error handling for CompatibleUnion

### DIFF
--- a/EIPS/eip-8016.md
+++ b/EIPS/eip-8016.md
@@ -79,6 +79,9 @@ The deserialization logic is updated:
 The following invalid input needs to be hardened against:
 
 - An out-of-bounds type selector in a `CompatibleUnion`
+- Incomplete data (less than 1 byte for selector)
+- Corrupted or malformed serialized data
+- Invalid serialization of inner types (delegated to inner type deserialization)
 
 #### JSON mapping
 


### PR DESCRIPTION
Added missing error cases to CompatibleUnion deserialization specification. 

Now covers incomplete data, corrupted input, and inner type validation failures. 

This ensures implementers have clear guidance on all error scenarios that need handling.