### PR TITLE
Update EIP-8045: misssed "it"

### DIFF
--- a/EIPS/eip-8045.md
+++ b/EIPS/eip-8045.md
@@ -63,7 +63,7 @@ Test cases should verify that:
 
 ## Security Considerations
 
-Slashed validators are already prevented from successfully proposing blocks through the state transition validation, for good reason, as they are considered to be unreliable participants (malicious or faulty). However, they have historically still been eligible to be selected as proposers in order to ensure stability of the proposer selection mechanism, because excluding them would have severely impacted the stability of the proposer selection mechanism. In fact, any slashing processed on chain would have caused the sequence of future proposers to completely change, even within the lookahead window. However, with [EIP-7917](./eip-7917.md), the proposer selection is fixed in advance by storing in the Beacon state, so it would not be affected by slashings processed after the fact.
+Slashed validators are already prevented from successfully proposing blocks through the state transition validation, for good reason, as they are considered to be unreliable participants (malicious or faulty). However, they have historically still been eligible to be selected as proposers in order to ensure stability of the proposer selection mechanism, because excluding them would have severely impacted the stability of the proposer selection mechanism. In fact, any slashing processed on chain would have caused the sequence of future proposers to completely change, even within the lookahead window. However, with [EIP-7917](./eip-7917.md), the proposer selection is fixed in advance by storing it in the Beacon state, so it would not be affected by slashings processed after the fact.
 
 ### Impact on proposer selection distribution
 


### PR DESCRIPTION
Clarified the explanation of slashed validators and their impact on proposer selection, emphasizing the changes introduced by EIP-7917.

