### PR TITLE
Update EIP-7557: unify constant name to CODE_CHUNK_ACCESS_COST

### DIFF
--- a/EIPS/eip-7557.md
+++ b/EIPS/eip-7557.md
@@ -334,10 +334,10 @@ In such case the changes are reflected in the reimbursement function as well, wh
 in order to redistribute the shared cost of accessing the same code chunk in multiple transactions:
 
 ```typescript
-const reimbursementsFromCoinbase = calculatePriorityFeeReimbursements(sortedCodeChunkAccessDetails, CHUNK_ACCESS_COST)
+const reimbursementsFromCoinbase = calculatePriorityFeeReimbursements(sortedCodeChunkAccessDetails, CODE_CHUNK_ACCESS_COST)
 for (let i = 0; i < sortedAccessDetails.length; i++) {
   const reimbursement = reimbursements.get(accessor.sender)
-  reimbursement.reimbursementFromBurn += CHUNK_ACCESS_COST * block.baseFeePerGas * reimbursementPercent
+  reimbursement.reimbursementFromBurn += CODE_CHUNK_ACCESS_COST * block.baseFeePerGas * reimbursementPercent
   reimbursement.reimbursementFromCoinbase += reimbursementsFromCoinbase[i]
 }
 ```


### PR DESCRIPTION
Replaced CHUNK_ACCESS_COST with CODE_CHUNK_ACCESS_COST in the EIP-6800 reimbursement pseudocode to align with the surrounding text that introduces the per-code-chunk gas as CODE_CHUNK_ACCESS_COST.
This removes an internal inconsistency and avoids ambiguity with other “chunk” cost terms used in EIP-6800 (e.g., witness-related costs).