### PR TITLE
Update EIP-7801: align etha handshake with eth/69 Status and append blockBitmask

### DIFF
--- a/EIPS/eip-7801.md
+++ b/EIPS/eip-7801.md
@@ -29,9 +29,9 @@ By introducing a separate subprotocol, `etha`, nodes can exchange this informati
 
 - Introduce a new subprotocol named `etha`.
 - Define the handshake message for the `etha` subprotocol as follows:
-  - Handshake packet: `[version: P, networkid: P, blockhash: B_32, genesis: B_32, forkid, blockBitmask]`
+  - Handshake packet: `[version: P, networkid: P, genesis: B_32, forkid, earliestBlock: P, latestBlock: P, latestBlockHash: B_32, blockBitmask]`
+  - The first seven elements are identical to `eth/69` `Status (0x00)`: `[version: P, networkid: P, genesis: B_32, forkid, earliestBlock: P, latestBlock: P, latestBlockHash: B_32]`. `blockBitmask` is appended as an additional field for `etha`.
   - `blockBitmask` is a 10-bit bitmask, with each bit representing a 106_496-block range per 1_064_960 blocks of history.
-  - the rest of the elements are as defined in eth/69
 
 ### Supported Messages
 


### PR DESCRIPTION
Align the etha handshake tuple with eth/69 Status (0x00) per EIP-7642 by:
- Replacing blockhash with latestBlockHash.
- Adding earliestBlock and latestBlock.
- Preserving the eth/69 field order: [version, networkid, genesis, forkid, earliestBlock, latestBlock, latestBlockHash].

Append blockBitmask as an etha-specific field and clarify the mapping in the spec text.

The previous handshake contradicted eth/69 while claiming alignment and omitted required fields, risking interoperability issues given requires: 7642.