### PR TITLE
Update EIP-7266: clarify blake2f precompile removal behavior

### DIFF
--- a/EIPS/eip-7266.md
+++ b/EIPS/eip-7266.md
@@ -27,7 +27,7 @@ One of the reasons why [EIP-152](./eip-152.md) has failed is that the envisioned
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
 
-All `CALL`, `CALLCODE`, `DELEGATECALL`, and `STATICCALL` invocations to the `blake2f` precompile address `0x09` MUST result in an exceptional abort that consumes all provided gas and reverts execution without returning any data.
+All `CALL`, `CALLCODE`, `DELEGATECALL`, and `STATICCALL` invocations to the `blake2f` precompile address `0x09` MUST result in an exceptional halting state that consumes all supplied gas and returns no data.
 
 ## Rationale
 


### PR DESCRIPTION
Specify that blake2f precompile calls must consume all gas and revert without data. 