### PR TITLE
Add EIP: Upgrade Mascots

### DIFF
--- a/EIPS/eip-8066.md
+++ b/EIPS/eip-8066.md
@@ -49,6 +49,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 The Mascot Wrestler **SHALL** conduct selection using one or more community-appropriate mechanisms.
 
 The process **MUST**:
+
 - Run for a minimum of 7 days.
 - Present at least 2 candidates.
 - Rank finalists by popularity.
@@ -65,6 +66,7 @@ All uses **MUST** respect the network upgrade mascot's cute, non-offensive natur
 This specification balances creativity with guardrails to prevent mascot drift (e.g., unrelated or edgy choices). Emoji-based representation ensures accessibility across digital platforms, while the animal/cute mandate aligns with Ethereum's community ethos of approachability. The self-selected Mascot Wrestler role decentralizes coordination, leveraging vetoes for accountability. Selection flexibility accommodates Ethereum's decentralized governance evolution.
 
 Alternatives considered:
+
 - Fully onchain mandates: Too rigid for creative processes.
 - No formal process: Risks ad-hoc or absent mascots.
 - Non-animal options: Animals evoke universality and whimsy.


### PR DESCRIPTION
Meta EIP to formalize mascots for network upgrades.

:owl: Shapella (Shanghai + Capella)
:blowfish: Dencun (Cancun + Deneb)
:giraffe: Pectra (Prague + Electra)
:zebra: Fusaka (Fulu + Osaka)