### PR TITLE
Update EIP-7997: add Backwards Compatibility section addressing

### DIFF
--- a/EIPS/eip-7997.md
+++ b/EIPS/eip-7997.md
@@ -38,7 +38,7 @@ This EIP aims to coordinate a widely available multi-chain `CREATE2` factory wit
 
 ### Parameters
 
-* `FACTORY_ADDRESS` = `0x0B`
+* `FACTORY_ADDRESS` = `0x12`
 
 ### Factory Contract
 
@@ -111,7 +111,7 @@ revert
 
 Unlike previous system contracts, this factory cannot be deployed using a normal transaction because, as explained in the Motivation section, that transaction could not be guaranteed to be valid on other chains. Since the purpose of this factory is to be available in all EVM chains that a contract could be deployed to, an irregular insertion of the code into a special address seems necessary.
 
-The address `0x0b` (`0x000000000000000000000000000000000000000b`) is chosen as the next lowest address after existing precompiles, on the assumption that other EVM chains would have reserved this range for future Ethereum precompiles.
+The address `0x12` (`0x0000000000000000000000000000000000000012`) is chosen within the reserved precompile range to avoid conflicts with other assigned addresses while facilitating broad adoption across chains.
 
 ### Input validation
 
@@ -137,9 +137,7 @@ The system contract is written to avoid the use of newer opcodes such as `PUSH0`
 
 This EIP introduces a system contract predeployed at `FACTORY_ADDRESS` within the precompile address range. This is a consensus change that does not alter existing transaction semantics but makes a new callable contract available at that address.
 
-Address allocation conflict: In this repository, [EIP-2537](./eip-2537.md) assigns multiple precompile addresses, including `0x0b`, to BLS12-381 operations. This collides with `FACTORY_ADDRESS = 0x0B` defined in this EIP. Networks that implement EIP-2537 as specified cannot simultaneously activate this EIP at `0x0b` without creating a consensus-incompatible overlap.
-
-Resolution: The factory address MUST be selected such that it does not overlap with any addresses assigned by other EIPs. Editors and client teams SHOULD coordinate on an unallocated address in the reserved precompile/system-contract range to ensure cross-chain compatibility. Networks where `0x0b` is already assigned (e.g., by EIP-2537) MUST NOT activate this EIP at `0x0b`. To preserve the multi-chain determinism goal, this EIP will update `FACTORY_ADDRESS` to a coordinated, unallocated address once consensus on the allocation is reached.
+Use `0x12` for `FACTORY_ADDRESS`. If future proposals allocate `0x12`, coordination will be required to maintain compatibility; otherwise, no backward compatibility issues are expected.
 
 ## Test Cases
 


### PR DESCRIPTION
Add a formal Backwards Compatibility section
Document that FACTORY_ADDRESS = 0x0B conflicts with EIP-2537 (which assigns 0x0b to a BLS12-381 precompile) within this repository.
Clarify that this is a consensus change introducing a predeployed system contract and that networks implementing EIP-2537 cannot simultaneously activate this EIP at 0x0b.