### PR TITLE
Update EIP-7928: remove uint128 type inconsistency in balance_changes

### DIFF
--- a/EIPS/eip-7928.md
+++ b/EIPS/eip-7928.md
@@ -144,7 +144,7 @@ Note: Implementations MUST check the pre-transaction value to correctly distingu
 
 #### Balance (`balance_changes`)
 
-Record **post‑transaction** balances (`uint128`) for:
+Record **post‑transaction** balances for:
 
 - Transaction **senders** (gas + value).
 - Transaction **recipients** (only if `value > 0`).


### PR DESCRIPTION
The type definition correctly uses uint256 (line 54), so the semantic description now aligns with the type alias.