### PR TITLE
Add EIP: Transaction Inclusion Subscription

### DIFF
--- a/EIPS/eip-8072.md
+++ b/EIPS/eip-8072.md
@@ -1,7 +1,7 @@
 ---
 eip: 8072
 title: Transaction Inclusion Subscription
-description:  Submit transactions and subscribe to transaction inclusion events using eth_subscribe
+description: Submit transactions and subscribe to transaction inclusion events using eth_subscribe
 author: Łukasz Rozmej (@LukaszRozmej)
 discussions-to: https://ethereum-magicians.org/t/eip-8072-transaction-inclusion-subscription/26431
 status: Draft
@@ -16,7 +16,7 @@ This EIP extends the existing `eth_subscribe` JSON-RPC method with a new subscri
 
 ## Motivation
 
-Current transaction submission workflows require separate calls to `eth_sendRawTransaction` followed by repeated polling of `eth_getTransactionReceipt`, creating unnecessary latency and network overhead. While [EIP-7966](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7966.md) proposes `eth_sendRawTransactionSync` to address this through a synchronous blocking approach, blocking HTTP connections presents significant drawbacks:
+Current transaction submission workflows require separate calls to `eth_sendRawTransaction` followed by repeated polling of `eth_getTransactionReceipt`, creating unnecessary latency and network overhead. While [EIP-7966](eip-7966.md) proposes `eth_sendRawTransactionSync` to address this through a synchronous blocking approach, blocking HTTP connections presents significant drawbacks:
 
 - **Connection hogging**: Each transaction blocks one HTTP connection until confirmation or timeout
 - **Limited scalability**: Cannot efficiently monitor multiple transactions over a single connection
@@ -120,6 +120,7 @@ When the transaction status changes, the node MUST send a notification:
 ```
 
 The `status` field MAY be one of:
+
 - `"included"`: Transaction has been included in a block
 - `"finalized"`: Transaction's block has reached finality (only sent when `includeReorgs` is `false`)
 - `"reorged"`: Transaction was removed from the canonical chain (only sent if `includeReorgs` is `true`)
@@ -202,6 +203,7 @@ Both modes auto-unsubscribe to prevent unbounded subscription accumulation and p
 - **`includeReorgs: true`**: Unsubscribes after finalization when reorgs are no longer possible, providing complete transaction lifecycle monitoring.
 
 The key difference is the level of guarantee:
+
 - `includeReorgs: false`: Fast notification, transaction is included (may still reorg)
 - `includeReorgs: true`: Complete lifecycle tracking until finality (cannot reorg)
 
@@ -214,6 +216,7 @@ This EIP is fully backwards compatible. It extends the existing `eth_subscribe` 
 ### Test Case 1: Submit and Monitor
 
 **Request:**
+
 ```json
 {
   "jsonrpc": "2.0",
@@ -226,6 +229,7 @@ This EIP is fully backwards compatible. It extends the existing `eth_subscribe` 
 ```
 
 **Expected Behavior:**
+
 1. Node submits transaction to network
 2. Node returns subscription ID
 3. When transaction is included, node sends notification with `"status": "included"` and receipt
@@ -234,6 +238,7 @@ This EIP is fully backwards compatible. It extends the existing `eth_subscribe` 
 ### Test Case 2: Monitor Existing Transaction
 
 **Request:**
+
 ```json
 {
   "jsonrpc": "2.0",
@@ -247,6 +252,7 @@ This EIP is fully backwards compatible. It extends the existing `eth_subscribe` 
 ```
 
 **Expected Behavior:**
+
 1. If transaction already included, immediately send notification with `"status": "included"`
 2. If transaction pending, wait and send notification upon inclusion
 3. Subscription automatically closes immediately after notification
@@ -254,6 +260,7 @@ This EIP is fully backwards compatible. It extends the existing `eth_subscribe` 
 ### Test Case 3: Reorg Monitoring
 
 **Request:**
+
 ```json
 {
   "jsonrpc": "2.0",
@@ -267,6 +274,7 @@ This EIP is fully backwards compatible. It extends the existing `eth_subscribe` 
 ```
 
 **Expected Behavior:**
+
 1. Send inclusion notification when transaction is included (with `"status": "included"`)
 2. Continue monitoring for reorgs
 3. If reorg occurs, send reorg notification (with `"status": "reorged"`)
@@ -277,6 +285,7 @@ This EIP is fully backwards compatible. It extends the existing `eth_subscribe` 
 ### Test Case 4: Invalid Parameters
 
 **Request:**
+
 ```json
 {
   "jsonrpc": "2.0",
@@ -289,6 +298,7 @@ This EIP is fully backwards compatible. It extends the existing `eth_subscribe` 
 ```
 
 **Expected Response:**
+
 ```json
 {
   "jsonrpc": "2.0",


### PR DESCRIPTION
### EIP-8072: Transaction Inclusion Subscription

This EIP proposes a new JSON-RPC `eth_subscribe` subscription `transactionInclusion` which reduces the latency between transaction submission and user confirmation by providing server side messages for transaction inclusion. For convenience this subscription allows for posting transactions. For safety this subscription allows to monitor the state of transaction (included/reorged/finalized). This method addresses the user experience gap in high-frequency applications by offering stronger delivery guarantees than `eth_sendRawTransaction`.