### PR TITLE
Update EIP-7928: clarify relationship between block_access_list_hash and BlockAccessList

### DIFF
--- a/EIPS/eip-7928.md
+++ b/EIPS/eip-7928.md
@@ -28,17 +28,17 @@ This proposal enforces access lists at the block level, enabling:
 
 ### Block Structure Modification
 
-We introduce a new field to the block header, `block_access_list_hash`, which contains the Keccak-256 hash of the RLP-encoded block access list. When no state changes are present, this field is the hash of an empty rlp list `0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347`, i.e. `keccak256(rlp.encode([]))`.
+We introduce a new field to the block header, `block_access_list_hash`, which contains the Keccak-256 hash of the RLP-encoded block access list stored in the block body (see below). When no state changes are present, this field is the hash of an empty RLP list `0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347`, i.e. `keccak256(rlp.encode([]))`.
 
 ```python
 class Header:
     # Existing fields
     ...
     
-    block_access_list_hash: Hash32 = keccak256(rlp.encode(block_access_list))
+    block_access_list_hash: Hash32 = keccak256(rlp.encode(block_access_list))  # Hash of BlockAccessList from block body
 ```
 
-The block body includes a `BlockAccessList` containing all account accesses and state changes. This field is RLP-encoded as a list of `AccountChanges`. When no state changes are present, this field is the empty RLP list `0xc0`, i.e. `rlp.encode([])`.
+The block body includes a `BlockAccessList` containing all account accesses and state changes. This field is RLP-encoded as a list of `AccountChanges`. When no state changes are present, this field is the empty RLP list `0xc0`, i.e. `rlp.encode([])`. The header's `block_access_list_hash` field contains `keccak256(rlp.encode(BlockAccessList))` of this field.
 
 ### RLP Data Structures
 


### PR DESCRIPTION
Adds cross-references between block_access_list_hash and BlockAccessList to clarify that the header contains keccak256 hash of the RLP-encoded list stored in the body, removing ambiguity about empty list representation.