### PR TITLE
Update EIP-7973: Initialize key and new_value in SSTORE pseudocode

### DIFF
--- a/EIPS/eip-7973.md
+++ b/EIPS/eip-7973.md
@@ -43,6 +43,10 @@ On the account-updating opcodes `CREATE`, `CREATE2`, and `*CALL`, instead of cha
 `SSTORE` is also subjected to warm account metering. That is, this EIP splits the cost of `SSTORE` into two components, the cost to update the account tuple, and the cost to update the state trie. Note that if the state trie has already been updated once in a transaction, the account tuple is already dirty, and so we can amortize the cost of updating the account tuple again. Thus, the gas cost of `SSTORE` and its refund logic is updated to:
 
 ```python
+# get SSTORE operands (slot key and value to write)
+key = get_sstore_key(evm)
+new_value = get_sstore_value(evm)
+
 # get original_value and current_value
 state = evm.message.block_env.state
 original_value = get_storage_original(


### PR DESCRIPTION
Make the SSTORE pseudocode self-contained by explicitly initializing the slot key and the new value to be written. While EIP-1283/EIP-2200 define these terms conceptually, this document uses procedural pseudocode with explicit assignments for other variables. Without defining key/new_value, the block was internally inconsistent and ambiguous for implementers.