### PR TITLE
Remove unused MAX_DEPOSITS import from eth2_ws_calc.py

### DIFF
--- a/assets/eip-6110/eth2_ws_calc.py
+++ b/assets/eip-6110/eth2_ws_calc.py
@@ -4,10 +4,9 @@ This script calculates the Eth2 Weak Subjectivity period as defined by eth2.0-sp
 
 from eth2spec.phase0.mainnet import (
     uint64, Ether,
-    ETH_TO_GWEI, 
-    MAX_DEPOSITS, 
-    MAX_EFFECTIVE_BALANCE,  
-    SLOTS_PER_EPOCH, 
+    ETH_TO_GWEI,
+    MAX_EFFECTIVE_BALANCE,
+    SLOTS_PER_EPOCH,
     config, 
 )
 


### PR DESCRIPTION
Drop the unused MAX_DEPOSITS import from eth2_ws_calc.py.
The script already defines a local constant with the same name, so the external symbol was never referenced.
Keeps dependency usage minimal and avoids confusion for reviewers and static analyzers.
