### PR TITLE
Update EIP-8070: correct grammar in continued sampling section

### DIFF
--- a/EIPS/eip-8070.md
+++ b/EIPS/eip-8070.md
@@ -75,7 +75,7 @@ Supernodes (nodes intending to fetch every blob payload in full) MUST load balan
 A sampler MAY drop a transaction if it has not observed sufficient network saturation (i.e., announcements from other peers for the same blob) within a defined period.
 
 **Continued sampling**
-Tenured transactions MAY be subject to resampling in other to test for liveness and confirm confidence of continued network-wide availability.
+Tenured transactions MAY be subject to resampling in order to test for liveness and confirm confidence of continued network-wide availability.
 
 ### Execution clients :: Local block builders
 


### PR DESCRIPTION
Fix typo "in other to" to "in order to" in the continued sampling specification