### PR TITLE
Update EIP-7745: Move to Draft

### DIFF
--- a/EIPS/eip-7745.md
+++ b/EIPS/eip-7745.md
@@ -1,10 +1,10 @@
 ---
 eip: 7745
-title: Light client and DHT friendly log index
+title: Trustless log index
 description: An efficient, light client and DHT friendly replacement for block header bloom filters
 author: Zsolt Felföldi (@zsfelfoldi)
 discussions-to: https://ethereum-magicians.org/t/eip-7745-two-dimensional-log-filter-data-structure/20580
-status: Stagnant
+status: Draft
 type: Standards Track
 category: Core
 created: 2024-07-17


### PR DESCRIPTION
Updated to latest working title "Trustless log index" and changed status back to "draft" as this is an active project.