### PR TITLE
Update EIP-8024: Fix pair encoding to match intent

### DIFF
--- a/EIPS/eip-8024.md
+++ b/EIPS/eip-8024.md
@@ -130,7 +130,7 @@ A previous formulation of `EXCHANGE` allowed swapping stack elements only if the
 
 In addition, the exact formulation was chosen to make `decode_pair` a simple function using only basic arithmetic, bitwise operations (division by 16), and few branches. A small trade-off in the number of addressable pairs was made to reduce the number of necessary branches; this implies some of the immediate range is not allocated, and it could be used to add a dozen more addressable pairs at the cost of more decoding complexity, potentially in a future network upgrade.
 
-Finally, note that the operands in the assembly instruction `EXCHANGE n m` apper "off by one", i.e. it operates on the stack elements at depths `n + 1` and `m + 1`. These offsets were chosen to match the `SWAP` and `SWAPN` opcodes such that `EXCHANGE n m` has an effect equivalent to the sequence `SWAP{n} SWAP{m} SWAP{n}`.
+Finally, note that the operands in the assembly instruction `EXCHANGE n m` appear "off by one", i.e. it operates on the stack elements at depths `n + 1` and `m + 1`. These offsets were chosen to match the `SWAP` and `SWAPN` opcodes such that `EXCHANGE n m` has an effect equivalent to the sequence `SWAP{n} SWAP{m} SWAP{n}`.
 
 ### Size of immediate operand
 


### PR DESCRIPTION
One of the examples didn't match the spec. The example was more accurately reflecting my original intent (explained now in rationale), so I've modified the decoding/encoding functions to match that. 