### PR TITLE
Update EIP-6122: Add missing testcase field to code examples

### DIFF
--- a/EIPS/eip-6122.md
+++ b/EIPS/eip-6122.md
@@ -65,6 +65,7 @@ Here's a suite of tests with mainnet config and withdrawals enabled at time `166
 ```go
 type testcase struct {
 	head uint64
+	time uint64
 	want ID
 }
 tests := []struct {
@@ -114,6 +115,7 @@ tests := []struct {
 ```go
 tests := []struct {
 	head uint64
+	time uint64
 	id   ID
 	err  error
 }{


### PR DESCRIPTION
Updates the code examples shown to add a missing field