### PR TITLE
Update EIP-7745: Remove dead max_row_length recomputation

### DIFF
--- a/EIPS/eip-7745.md
+++ b/EIPS/eip-7745.md
@@ -276,7 +276,6 @@ def add_log_value(log_index, log_value):
         if len(row) < max_row_length * bytes_per_column:
             break
         layer_index += 1
-        max_row_length = MIN(max_row_length * LAYER_COMMON_RATIO, MAX_BASE_ROW_LENGTH * MAPS_PER_EPOCH)
     row.append(to_binary32(column_index)[:bytes_per_column])
     log_index.next_index += 1
 
@@ -319,7 +318,6 @@ def get_potential_matches(log_index, map_index, log_value):
         if len(row) < max_row_length * bytes_per_column:
             break
         layer_index += 1
-        max_row_length = MIN(max_row_length * LAYER_COMMON_RATIO, MAX_BASE_ROW_LENGTH * MAPS_PER_EPOCH)
     return matches
 ```
 


### PR DESCRIPTION
The recomputation of max_row_length after incrementing layer_index inside both add_log_value and get_potential_matches was redundant. Each loop recalculates max_row_length from layer_index at the start of the next iteration, so the in-loop update had no effect. Removing it eliminates dead code and avoids confusion about semantics