### PR TITLE
Update EIP-7594: Fix typo in PeerDAS rationale

### DIFF
--- a/EIPS/eip-7594.md
+++ b/EIPS/eip-7594.md
@@ -71,7 +71,7 @@ PeerDAS is a DAS scheme that requires nodes to only download a small constant fr
 
 ### What does peer sampling provide?
 
-PeerDAS takes the set of peers of a node on the network as a primitive to build a DAS scheme around. A focus on peers allows for redundancy in the mechanism (as a node generally has many peers, and peer count can also be cheaply increased) which both helps with theoretical security as detailed in the "Security Considerations" section, but also pratical security of the implementation (e.g. if a single peer fails, a node can likely use another peer for the same sampling task).
+PeerDAS takes the set of peers of a node on the network as a primitive to build a DAS scheme around. A focus on peers allows for redundancy in the mechanism (as a node generally has many peers, and peer count can also be cheaply increased) which both helps with theoretical security as detailed in the "Security Considerations" section, but also practical security of the implementation (e.g. if a single peer fails, a node can likely use another peer for the same sampling task).
 
 PeerDAS also has the nice property that any given node may voluntarily custody more of the data than the bare minimum which increases the performance of the mechanism. Alternative schemes do not readily support this "transparent" scaling property.
 


### PR DESCRIPTION
correct a spelling mistake ("pratical" → "practical") in the PeerDAS rationale section
