### PR TITLE
Update EIP-8016: Fix JSON mapping selector type

### DIFF
--- a/EIPS/eip-8016.md
+++ b/EIPS/eip-8016.md
@@ -89,7 +89,7 @@ The canonical [JSON mapping](https://github.com/ethereum/consensus-specs/blob/ad
 
 | SSZ                                 | JSON            | Example                                |
 | ----------------------------------- | --------------- | -------------------------------------- |
-| `CompatibleUnion({selector: type})` | selector-object | `{ "selector": string, "data": type }` |
+| `CompatibleUnion({selector: type})` | selector-object | `{ "selector": number, "data": type }` |
 
 `CompatibleUnion` is encoded as an object with a `selector` and `data` field, where the contents of `data` change according to the selector.
 


### PR DESCRIPTION
Fix JSON mapping for CompatibleUnion selector type to align with base SSZ specification.

The selector field was incorrectly specified as "string" type in the JSON mapping, while the base SSZ specification (simple-serialize.md) defines Union selector as "number" type. Since CompatibleUnion extends Union semantics, it should follow
the same JSON mapping conventions.

Changed: `{ "selector": string, "data": type }` 
To:      `{ "selector": number, "data": type }`

This ensures consistency with the canonical SSZ JSON mapping specification.