### PR TITLE
Update EIP-7864: Fix TODO typo in EIP-7864

### DIFF
--- a/EIPS/eip-7864.md
+++ b/EIPS/eip-7864.md
@@ -433,7 +433,7 @@ Python reference implementation (`github.com/jsign/binary-tree-spec`).
 
 ## Security Considerations
 
-Needs discussion. <!-- TOOD -->
+Needs discussion. <!-- TODO -->
 
 ## Copyright
 


### PR DESCRIPTION
correct the inline comment typo (“TOOD” → “TODO”) in the Security Considerations section
