### PR TITLE
Update EIP-7607: Fix JSON-RPC format inconsistency

### DIFF
--- a/EIPS/eip-7607.md
+++ b/EIPS/eip-7607.md
@@ -39,7 +39,7 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Proposed
 * [EIP-7642](./eip-7642.md): eth/69 - Drop pre-merge fields
     * Client teams MUST support this EIP by the activation of the Fusaka network upgrade.
 * [EIP-7910](./eip-7910.md): eth_config JSON-RPC Method
-    * Client teams MUST support this JSON RPC method by the activation of Fusaka network upgrade. 
+    * Client teams MUST support this JSON-RPC method by the activation of Fusaka network upgrade. 
 * [EIP-7935](./eip-7935.md): Set default gas limit to 60M
 
 ### Activation


### PR DESCRIPTION
Changed `JSON RPC` to `JSON-RPC` on line 42 to match official specification and maintain consistency with line 41.