### PR TITLE
Update EIP-7834: use max_stack_increase in types_section grammar

### DIFF
--- a/EIPS/eip-7834.md
+++ b/EIPS/eip-7834.md
@@ -49,7 +49,7 @@ header :=
     kind_data, data_size,
     terminator
 body := types_section, code_section+, container_section*, [metadata_section], data_section
-types_section := (inputs, outputs, max_stack_height)+
+types_section := (inputs, outputs, max_stack_increase)+
 ```
 
 ### Header


### PR DESCRIPTION
Replace max_stack_height with max_stack_increase in types_section grammar.
Reason: EIP-3540 defines the third tuple element as max_stack_increase, and other EOF EIPs reference this field name for validation and runtime checks. Using max_stack_height here was inconsistent and could mislead implementers.