### PR TITLE
Update EIP-7688: Correct ProgressiveContainer reference

### DIFF
--- a/EIPS/eip-7688.md
+++ b/EIPS/eip-7688.md
@@ -133,7 +133,7 @@ Applying this EIP breaks `hash_tree_root` and Merkle tree verifiers a single tim
 
 ### Can this be applied retroactively?
 
-While `Profile` serializes in the same way as the legacy `Container`, the merkleization and `hash_tree_root` of affected data structures changes. Therefore, verifiers that wish to process Merkle proofs of legacy variants still need to support the corresponding legacy schemes.
+While `ProgressiveContainer` serializes in the same way as the legacy `Container`, the merkleization and `hash_tree_root` of affected data structures changes. Therefore, verifiers that wish to process Merkle proofs of legacy variants still need to support the corresponding legacy schemes.
 
 ### Immutability
 


### PR DESCRIPTION
Replace the stray `Profile` reference with `ProgressiveContainer`; it’s a typo because there is no Profile type in the spec and the paragraph is clearly about ProgressiveContainer serialization.