### PR TITLE
Update EIP-2: unify fork parameter name to HOMESTEAD_FORK_BLKNUM

### DIFF
--- a/EIPS/eip-2.md
+++ b/EIPS/eip-2.md
@@ -14,11 +14,11 @@ created: 2015-11-15
 
 ### Parameters
 
-|   FORK_BLKNUM   | CHAIN_NAME  |
-|-----------------|-------------|
-|    1,150,000    | Main net    |
-|   494,000       | Morden      |
-|    0            | Future testnets    |
+| HOMESTEAD_FORK_BLKNUM | CHAIN_NAME       |
+|-----------------------|------------------|
+| 1,150,000             | Main net         |
+| 494,000               | Morden           |
+| 0                     | Future testnets  |
 
 # Specification
 


### PR DESCRIPTION
Replace the Parameters table column header from FORK_BLKNUM to HOMESTEAD_FORK_BLKNUM to match the name used in the Specification section. This removes an internal inconsistency and aligns with repository conventions where fork-specific constants use fork-scoped names (e.g., CONSTANTINOPLE_FORK_BLKNUM).