### PR TITLE
Update EIP-7997: Normalize factory address casing

### DIFF
--- a/EIPS/eip-7997.md
+++ b/EIPS/eip-7997.md
@@ -38,7 +38,7 @@ This EIP aims to coordinate a widely available multi-chain `CREATE2` factory wit
 
 ### Parameters
 
-* `FACTORY_ADDRESS` = `0x0B`
+* `FACTORY_ADDRESS` = `0x0b`
 
 ### Factory Contract
 


### PR DESCRIPTION
I changed the factory address to lowercase so the spec uses the same hex style everywhere and reads more cleanly.