### PR TITLE
Update EIP-7773: add 6404 to 7773

### DIFF
--- a/EIPS/eip-7773.md
+++ b/EIPS/eip-7773.md
@@ -41,6 +41,7 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Declined
 1. [EIP-2780](./eip-2780.md): Reduce intrinsic transaction gas
 1. [EIP-2926](./eip-2926.md): Chunk-based code merkelization
 1. [EIP-5920](./eip-5920.md): PAY opcode
+1. [EIP-6404](./eip-6404.md): SSZ transactions
 1. [EIP-6466](./eip-6466.md): SSZ receipts
 1. [EIP-6873](./eip-6873.md): Preimage retention
 1. [EIP-7610](./eip-7610.md): Revert creation in case of non-empty storage


### PR DESCRIPTION
6404 is a dependency for 6466 (as noted in #10543) - for the sake of completeness, it should be listed on 7773 as proposed. it is already on forkcast