### PR TITLE
Remove unused MAX_DEPOSITS import in Eth2 weak subjectivity calculator

### DIFF
--- a/assets/eip-6110/eth2_ws_calc.py
+++ b/assets/eip-6110/eth2_ws_calc.py
@@ -4,11 +4,10 @@ This script calculates the Eth2 Weak Subjectivity period as defined by eth2.0-sp
 
 from eth2spec.phase0.mainnet import (
     uint64, Ether,
-    ETH_TO_GWEI, 
-    MAX_DEPOSITS, 
-    MAX_EFFECTIVE_BALANCE,  
-    SLOTS_PER_EPOCH, 
-    config, 
+    ETH_TO_GWEI,
+    MAX_EFFECTIVE_BALANCE,
+    SLOTS_PER_EPOCH,
+    config,
 )
 
 MIN_VALIDATOR_WITHDRAWABILITY_DELAY = config.MIN_VALIDATOR_WITHDRAWABILITY_DELAY


### PR DESCRIPTION
Drop the dead MAX_DEPOSITS import so the script no longer shadows it with the local constant keep the local definition as the single source of truth and avoid misleading reviewers about which value is used