### PR TITLE
Update EIP-7932: Refine signature examples and terminology

### DIFF
--- a/EIPS/eip-7932.md
+++ b/EIPS/eip-7932.md
@@ -244,7 +244,7 @@ def sigrecover_precompile(input: Bytes) -> Bytes:
 
   # Run verify function
   try:
-    pubkey = alg(signature_info, hash)
+    pubkey = alg.verify(signature_info, hash)
     return pubkey_to_address(pubkey, algorithm_type)
   except:
     return ExecutionAddress(0x0)


### PR DESCRIPTION
Keep the sample code consistent with the registry description so implementers can follow it directly.