### PR TITLE
Update EIP-8070: Fix typos in EIP-8070 sampling section

### DIFF
--- a/EIPS/eip-8070.md
+++ b/EIPS/eip-8070.md
@@ -38,7 +38,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 We introduce a new devp2p protocol version, `eth/71` extending the existing `eth/70` protocol (TODO: spec for eth/70 missing).
 
 **Modify `NewPooledTransactionHashes` (`0x08`) message.**
-Add a new field `cell_mask` of type `B_16` (`uint128`). This field MUST be interpreted as a bitarray of length `CELLS_PER_EXT_BLOB`, carrying `1` in the indices of colums the announcer has available for **all type 3 txs announced within the message**. This field MUST be set to `nil` when no transactions of such type are announced. (TODO: this approach is not expressive enough if the node wants to offer randomly sampled columns, nor if it wants to announce transactions with full and partial availability in a single message).
+Add a new field `cell_mask` of type `B_16` (`uint128`). This field MUST be interpreted as a bitarray of length `CELLS_PER_EXT_BLOB`, carrying `1` in the indices of columns the announcer has available for **all type 3 txs announced within the message**. This field MUST be set to `nil` when no transactions of such type are announced. (TODO: this approach is not expressive enough if the node wants to offer randomly sampled columns, nor if it wants to announce transactions with full and partial availability in a single message).
 
 - old schema (`eth/70`): `[types: B, [size_0: P, size_1: P, ...], [hash_0: B_32, hash_1: B_32, ...]]`
 - new schema (`eth/71`): `[types: B, [size_0: P, size_1: P, ...], [hash_0: B_32, hash_1: B_32, ...], cell_mask: B_16]`
@@ -75,7 +75,7 @@ Supernodes (nodes intending to fetch every blob payload in full) MUST load balan
 A sampler MAY drop a transaction if it has not observed sufficient network saturation (i.e., announcements from other peers for the same blob) within a defined period.
 
 **Continued sampling**
-Tenured transactions MAY be subject to resampling in other to test for liveness and confirm confidence of continued network-wide availability.
+Tenured transactions MAY be subject to resampling in order to test for liveness and confirm confidence of continued network-wide availability.
 
 ### Execution clients :: Local block builders
 


### PR DESCRIPTION
correct the spelling of “columns” in the devp2p protocol description
replace the incorrect phrase “in other to” with “in order to” in the continued sampling paragraph
