### PR TITLE
Update EIP-1559: standardize FORK_BLOCK_NUMBER naming

### DIFF
--- a/EIPS/eip-1559.md
+++ b/EIPS/eip-1559.md
@@ -150,7 +150,7 @@ class Account:
 	code_hash: int = 0
 
 INITIAL_BASE_FEE = 1000000000
-INITIAL_FORK_BLOCK_NUMBER = 10 # TBD
+FORK_BLOCK_NUMBER = 10 # TBD
 BASE_FEE_MAX_CHANGE_DENOMINATOR = 8
 ELASTICITY_MULTIPLIER = 2
 
@@ -161,7 +161,7 @@ class World(ABC):
 
 		# on the fork block, don't account for the ELASTICITY_MULTIPLIER to avoid
 		# unduly halving the gas target.
-		if INITIAL_FORK_BLOCK_NUMBER == block.number:
+		if FORK_BLOCK_NUMBER == block.number:
 			parent_gas_target = self.parent(block).gas_limit
 			parent_gas_limit = self.parent(block).gas_limit * ELASTICITY_MULTIPLIER 
 
@@ -180,7 +180,7 @@ class World(ABC):
 		assert block.gas_limit >= 5000
 
 		# check if the base fee is correct
-		if INITIAL_FORK_BLOCK_NUMBER == block.number:
+		if FORK_BLOCK_NUMBER == block.number:
 			expected_base_fee_per_gas = INITIAL_BASE_FEE
 		elif parent_gas_used == parent_gas_target:
 			expected_base_fee_per_gas = parent_base_fee_per_gas


### PR DESCRIPTION

What: Replace INITIAL_FORK_BLOCK_NUMBER with FORK_BLOCK_NUMBER in code
Why: Matches specification text and aligns with standard EIP naming conventions