### PR TITLE
Update EIP-7610: Clarify the relationship between the EIP-7610 and EIP-7702

### DIFF
--- a/EIPS/eip-7610.md
+++ b/EIPS/eip-7610.md
@@ -23,11 +23,11 @@ If a contract creation is attempted due to a creation transaction, the `CREATE` 
 
 This EIP amends [EIP-684](./eip-684.md) with one extra condition, requiring empty storage for contract deployment.
 
+This EIP will not affect [EIP-7702](./eip-7702.md), since the authority's nonce is always incremented after an authorization is applied, which conflicts with the condition required for contract deployment.
+
 ## Rationale
 
 EIP-684 defines two conditions for contract deployment: the destination address must have zero nonce and zero code length. Unfortunately, this is not sufficient. Before [EIP-161](./eip-161.md) was applied, the nonce of a newly deployed contract remained set to zero. Therefore, it was entirely possible to create a contract with a zero nonce and zero code length but with non-empty storage, if slots were set in the constructor. There exists 28 such contracts on Ethereum mainnet at this time.
-
-As one of the core tenets of smart contracts is that its code will not change, even if the code is zero length. The contract creation must be rejected in such instance.
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
This PR explicitly states that it does not affect [EIP-7702](https://github.com/ethereum/EIPs/pull/eip-7702.md), which enables code upgrades through authorization.

Additionally, one line has been removed, as EOAs can now have their code upgraded via EIP-7702.

**ATTENTION: ERC-RELATED PULL REQUESTS NOW OCCUR IN [ETHEREUM/ERCS](https://github.com/ethereum/ercs)**

--

When opening a pull request to submit a new EIP, please use the suggested template: https://github.com/ethereum/EIPs/blob/master/eip-template.md

We have a GitHub bot that automatically merges some PRs. It will merge yours immediately if certain criteria are met:

 - The PR edits only existing draft PRs.
 - The build passes.
 - Your GitHub username or email address is listed in the 'author' header of all affected PRs, inside <triangular brackets>.
 - If matching on email address, the email address is the one publicly listed on your GitHub profile.
