### PR TITLE
Update EIP-8012: fix some typos

### DIFF
--- a/EIPS/eip-8012.md
+++ b/EIPS/eip-8012.md
@@ -36,13 +36,13 @@ No changes are expected
 
 ### Consensus Layer
 
-This EIP does not establish any changes on the consensus layer, but rather standardizes how consolidation requests are to be treated in the future. When receiving a `ConsolidationRequest` type object on the consensus layer, the `target_pubkey` field is to be treated differently. If it coincides with the BLS publick key of an existing active validator in the beacon chain, then it is to be interpreted as such. Otherwise, the 48 bytes are to be interpreted as a concatenation of the following fields
+This EIP does not establish any changes on the consensus layer, but rather standardizes how consolidation requests are to be treated in the future. When receiving a `ConsolidationRequest` type object on the consensus layer, the `target_pubkey` field is to be treated differently. If it coincides with the BLS public key of an existing active validator in the beacon chain, then it is to be interpreted as such. Otherwise, the 48 bytes are to be interpreted as a concatenation of the following fields
 
 ```
 |MAGIC_PREFIX | CALL_TYPE | ARG_NUMBER | ARG1 | ARG2 | ARG3 | ARG4 | ARG5 |
 ```
 
-Where `MAGIC_PREFIX` is the 3 byte constant that prefixes all generalized consolidation requests. `CALL_TYPE` are 4 bytes to be interpretted as a little Endian `uint32` and identifies the function type. `ARG_NUMBER` is a 1 byte to be interpretted as a `uint8` that encodes the number of arguments that are being passed to the generalized consolidation request handler. And each `ARG1, ARG2, ARG3, ARG4, ARG5` are all interpretted as little Endian `uint64`.
+Where `MAGIC_PREFIX` is the 3 byte constant that prefixes all generalized consolidation requests. `CALL_TYPE` are 4 bytes to be interpreted as a little Endian `uint32` and identifies the function type. `ARG_NUMBER` is a 1 byte to be interpreted as a `uint8` that encodes the number of arguments that are being passed to the generalized consolidation request handler. And each `ARG1, ARG2, ARG3, ARG4, ARG5` are all interpreted as little Endian `uint64`.
 
 For each addition of a new `CALL_TYPE`, the consensus layer must add a handler appropriately called from within `process_consolidation_requests`.
 
@@ -52,7 +52,7 @@ No changes needed.
 
 ## Rationale
 
-The proposed reinterpretation of the existing contract enables new implementations in the consensus layer without requireing a hard fork in the execution layer.
+The proposed reinterpretation of the existing contract enables new implementations in the consensus layer without requiring a hard fork in the execution layer.
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
Corrected some typos:

- `publick` → `public`
- `interpretted` → `interpreted`
- `requireing` → `requiring`