### PR TITLE
Update EIP-7594: correct sign in probability table for ε=0.01

### DIFF
--- a/EIPS/eip-7594.md
+++ b/EIPS/eip-7594.md
@@ -118,7 +118,7 @@ For mainnet parameters given in the specs and assuming 10,000 nodes on the netwo
 
 | $\epsilon$ | $n\epsilon$ (nodes) | Upper bound on $\mathbb{P}$ |
 |:----------:|:-------------------:|:---------------------------:|
-| 0.01        | 100                | $10^{38.36}$                |
+| 0.01        | 100                | $10^{-38.36}$               |
 | 0.02        | 200                | $10^{-20.04}$               |
 | 0.03        | 300                | $10^{-101.55}$              |
 | 0.04        | 400                | $10^{-198.24}$              |


### PR DESCRIPTION
Corrects a typographical error in EIPS/eip-7594.md under Security Considerations where the upper bound probability for ε=0.01 was listed as 10^{38.36}, which exceeds 1 and is physically impossible for a probability. Updated to 10^{-38.36} to align with the pattern of other rows and with the expected negligible upper bounds.