### PR TITLE
Update EIP-8030: Fix grammar and formatting

### DIFF
--- a/EIPS/eip-8030.md
+++ b/EIPS/eip-8030.md
@@ -52,7 +52,7 @@ def verify(signature_info: bytes, payload_hash: Hash32) -> Bytes:
 
 ### `P256Verify` Function
 
-The `P256Verify` function is logic of the precompile defined in [EIP-7951](./eip-7951.md), the only exception is that this function MUST not charge any gas.
+The `P256Verify` function is the logic of the precompile defined in [EIP-7951](./eip-7951.md), the only exception is that this function MUST NOT charge any gas.
 
 ## Rationale
 
@@ -75,4 +75,4 @@ Needs discussion.
 
 ## Copyright
 
-Copyright and related rights waived via [CC0](../../LICENSE.md).
+Copyright and related rights waived via [CC0](../LICENSE.md).


### PR DESCRIPTION
 - Adds missing article `the`.
 - Fixes RFC 2119 keyword format from `MUST not` to `MUST NOT` per specification equirements
 - Corrects LICENSE path from `../../LICENSE.md` to `../LICENSE.md` to match repository structure. 