### PR TITLE
Update EIP-7937: Fix malformed test case

### DIFF
--- a/EIPS/eip-7937.md
+++ b/EIPS/eip-7937.md
@@ -138,7 +138,7 @@ This EIP introduces a new (prefix) opcode `C0`. `C0` was previously an invalid o
 
 Test cases are organized as `[stack_item_1, stack_item_2] C0 opcode => [result_stack_item_1, result_stack_item_2]`.
 
-* `[ff00000000000000 000000000000000 0000000000000ff 000000000000001, ff0000000000000 000000000000000 0000000000000ff f0000000000000f] C0 SHR => [<0> 780000000000007]`
+* `[ff00000000000000, 0000000000000004] C01C => [0ff0000000000000]`
 
 ## Reference Implementation
 


### PR DESCRIPTION
The test case had hex values split by spaces instead of being proper 256-bit stack items, and used "C0 SHR" notation instead of the actual two-byte opcode C01C. This made it impossible to parse or execute. Replaced it with a valid example that demonstrates SHR (C01C) shifting ff00000000000000 right by 4 bits.