### PR TITLE
Update EIP-6465: Fix withdrawals_root assignment example in EIP-6465

### DIFF
--- a/EIPS/eip-6465.md
+++ b/EIPS/eip-6465.md
@@ -58,7 +58,7 @@ The [execution block header's `withdrawals-root`](https://github.com/ethereum/de
 withdrawals = ProgressiveList[Withdrawal](
     withdrawal_0, withdrawal_1, withdrawal_2, ...)
 
-block_header.withdrawals_root == withdrawals.hash_tree_root()
+block_header.withdrawals_root = withdrawals.hash_tree_root()
 ```
 
 ### Consensus `ExecutionPayload` changes


### PR DESCRIPTION
Replace the equality comparison with an assignment in the SSZ withdrawals example ensure the block header update matches the intent of the migration text