### PR TITLE
Update EIP-4736: expand CLWP acronym in security considerations

### DIFF
--- a/EIPS/eip-4736.md
+++ b/EIPS/eip-4736.md
@@ -99,7 +99,7 @@ A claim will be considered contested if a claim arrives where the verifiable con
 * User A: Controls the CL keys and the EL key used for the deposit
 * User B: Controls the CL keys, but does not control the EL key for the deposit
 
-User A signs and submits a claim to the CLWP repository, clients load User A message into the "`BLSToExecutionChange` Broadcast" file. At the time of the first epoch support `BLSToExecutionChange`, many (not all) nodes begin to broadcast the message. User B also tries to submit a different but valid `BLSToExecutionChange` to an address that does not match the signature in the claim. This message is successfully received via REST API, but some (not all) nodes begin to silently drop this message as the signature does not match the signature in the "`BLSToExecutionChange` Broadcast" file. As such, these nodes do not replicate this message via P2P.  
+User A signs and submits a claim to the CLWP (Consensus Layer Withdrawal Protection) repository, clients load User A message into the "`BLSToExecutionChange` Broadcast" file. At the time of the first epoch support `BLSToExecutionChange`, many (not all) nodes begin to broadcast the message. User B also tries to submit a different but valid `BLSToExecutionChange` to an address that does not match the signature in the claim. This message is successfully received via REST API, but some (not all) nodes begin to silently drop this message as the signature does not match the signature in the "`BLSToExecutionChange` Broadcast" file. As such, these nodes do not replicate this message via P2P.  
 
 ### 2: Attacker has both EL deposit key and CL keys, uncontested claim
 


### PR DESCRIPTION
Adds expansion of CLWP acronym (Consensus Layer Withdrawal Protection) when first mentioned in the Security Considerations section. 

This clarifies the term for readers who may not be familiar with the abbreviation.