### PR TITLE
Update EIP-4762: Clarify storage slot helper usage in eip-4762

### DIFF
--- a/EIPS/eip-4762.md
+++ b/EIPS/eip-4762.md
@@ -85,7 +85,7 @@ When a contract is created, process these access events:
 (address, tree_key, sub_key)
 ```
 
-Where `tree_key` and `sub_key` are computed as `tree_key, sub_key = get_storage_slot_tree_keys(address, key)`
+Where `tree_key` and `sub_key` are computed as `tree_key, sub_key = get_storage_slot_tree_keys(key)`
 
 #### Access events for code
 


### PR DESCRIPTION
Align both call sites in the spec with the actual signature of `get_storage_slot_tree_keys`, removing the non-existent `address` parameter