### PR TITLE
Add EIP: eth/XX - announce transactions with nonce

### DIFF
--- a/EIPS/eip-8077.md
+++ b/EIPS/eip-8077.md
@@ -48,14 +48,23 @@ To solve the transaction propagation issues mentioned in the Motivation section,
 
 ### Overhead
 
-The modification adds a significant overhead to announcements by adding a B_20 and a variable size element to the existing B_32, size, and type elements. We think this overhead is worth
-the additional gain in protocol efficiency. Details TBD
+The modification adds a significant overhead to announcements by adding a B_20 and a variable size filed to the current B_32, size, and type fields. We think this overhead is worth
+the additional gain in protocol efficiency. Details TBD.
 
 ### Alternatives
 
-TBD: should we limit this mechanism to blob and/or large transactions?
+While the modification is relatively straightforward, there are several design variants to
+consider. First of all, small transactions are mostly propagating by the push mechanism, while
+announcement based pull is only used as recovery. We could choose to avoid the extra announcement overhead for these, however it would mean that filling nonce gaps remains difficult, only possible by trial-and-error.
 
-TBD: does it still make sense to announce to all our neighbors? Should we make that partial (e.g. proportional or to a fixed number of peers)?
+Another possibility similar to the previous one is to restrict the mechanism to blob transactions only. We choose not to restrict it in the proposal for the same reasons as in the previous point.
+
+If the traffic overhead from notifications is a concern, it is also worth considering how many nodes should announcements be sent to. While this is not mandated by the protocol, a typical
+implementation is to send announcements to all neighbors (except the ones that already signaled having it, and the ones to which the message is pushed). Should nodes send announcements to all peers, or only part of their peer set (e.g. proportional, or to a fixed number of peers)?
+
+Currently, for any given transaction, nodes receive announcements from many peers. About half of their peers, on average. Having the whole metadata (txhash, type, size, source, nonce) in all these is highly redundant. We could remove some of this overhead, e.g. by having a probabilistic choice between a simple announcement and a detailed announcement. The gain however seems marginal compared to the added complexity. 
+
+Finally, sending the source and the nonce opens up the possibility of a design variant where the transaction identifier in the announcements is based on these values, and not on the txhash. More specifically, a transaction could be identified by the source, the nonce, and an extra version number signaling the RBF (replace-by-fee) version in the given source/nonce scope. This variant would require deeper changes since the RBF version would need to be signed, so we prefer the simpler version that relies both the txhash and the source/nonce, without introducing an RBF version.
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
This EIP improves mempool propagation, extending the devp2p 'eth' protocol's `NewPooledTransactionHashes` message to also announce each transaction's source address and nonce together with the already announced hash, type, and size.