### PR TITLE
Update EIP-7980: fix Ed25519 signature parsing

### DIFF
--- a/EIPS/eip-7980.md
+++ b/EIPS/eip-7980.md
@@ -33,10 +33,13 @@ This EIP defines a new [EIP-7932](../../EIPS/eip-7932.md) algorithmic type with 
 
 ```python
 def verify(signature_info: bytes, payload_hash: Hash32) -> ExecutionAddress:
-  assert(len(signature_info) == 96)
+  assert(len(signature_info) == (MAX_SIZE + 1))
 
-  signature = signature_info[:64]
-  public_key = signature_info[64:]
+  algorithm_id = signature_info[0]
+  assert(algorithm_id == 0x0)
+
+  signature = signature_info[1:65]
+  public_key = signature_info[65:]
   
   # This is the `Verify` function described in [RFC 8032 Section 5.1.7](https://datatracker.ietf.org/doc/html/rfc8032#section-5.1.7),
   # This MUST be processed as raw `Ed25519` and not `Ed25519ctx` or `Ed25519ph`


### PR DESCRIPTION
We were slicing the Ed25519 signature blob as if it didn’t contain the algorithm selector byte, so the verify code was feeding the wrong 64-byte region into ed25519_verify. Updated the check and slicing to account for the 0x0 selector so signature and public key land on the right offsets.