### PR TITLE
Update EIP-7713: Cleanup TODO markers in EIP-7713 rationale and security sections

### DIFF
--- a/EIPS/eip-7713.md
+++ b/EIPS/eip-7713.md
@@ -127,11 +127,11 @@ For example, a message for the `Envelope` type above may be represented as:
 
 ## Rationale
 
-TBD <!-- TODO -->
+TBD
 
 ## Security Considerations
 
-Needs discussion. <!-- TODO -->
+Needs discussion.
 
 ## Copyright
 


### PR DESCRIPTION
Remove leftover <!-- TODO --> comments from the Rationale section remove the same comments from the Security Considerations section keep the existing placeholders (TBD, Needs discussion.) so the sections remain consistent