### PR TITLE
Update EIP-7863: Fix invalid set operations in block-level warming example

### DIFF
--- a/EIPS/eip-7863.md
+++ b/EIPS/eip-7863.md
@@ -75,8 +75,8 @@ def apply_body(...):
         
         # Process transaction and update block-level sets
         gas_used, accessed_addresses, accessed_storage_keys, logs, error = process_transaction(env, tx)
-        block_level_accessed_addresses += accessed_addresses
-        block_level_accessed_storage_keys += accessed_storage_keys
+        block_level_accessed_addresses.update(accessed_addresses)
+        block_level_accessed_storage_keys.update(accessed_storage_keys)
 ```
 
 This code shows how block-level slot warming is implemented at the execution layer. The `block_level_accessed_addresses` and `block_level_accessed_storage_keys` sets are maintained throughout the block's execution and passed to each transaction's environment.
@@ -85,12 +85,8 @@ This code shows how block-level slot warming is implemented at the execution lay
 
 ```python
 def process_transaction(env: vm.Environment, tx: Transaction) -> Tuple[Uint, Tuple[Log, ...], Optional[Exception]]:
-    preaccessed_addresses = set()
-    preaccessed_storage_keys = set()
-    
-    # Add block-level pre-accessed slots
-    preaccessed_addresses.add(env.block_level_accessed_addresses)
-    preaccessed_storage_keys.add(env.block_level_accessed_storage_keys)
+    preaccessed_addresses = set(env.block_level_accessed_addresses)
+    preaccessed_storage_keys = set(env.block_level_accessed_storage_keys)
     
     # Handle access lists from transaction
     ...


### PR DESCRIPTION
Replace the non-existent set += set usage with set.update(...) so the example no longer raises TypeError initialize the pre-accessed sets with set(env.block_level_accessed_...) instead of misusing add on whole sets keep the illustrative code runnable and aligned with real Python semantics