### PR TITLE
Update EIP-7748: Fix Verkle conversion storage writes losing migrated values

### DIFF
--- a/EIPS/eip-7748.md
+++ b/EIPS/eip-7748.md
@@ -151,10 +151,8 @@ def set_storage(
     state: State, addr: Address, key: Bytes, value: U256, only_if_empty: bool = True
 ) -> None:
     # <new_code>
-    if only_if_empty:
-        value = state._overlay_tree.get(get_tree_key_for_storage_slot(addr, key))
-        if value is not None:
-            return
+    if only_if_empty and state._overlay_tree.get(get_tree_key_for_storage_slot(addr, key)) is not None:
+        return
     # </new_code>
     
     state._overlay_tree.set(get_tree_key_for_storage_slot(addr, key), value)


### PR DESCRIPTION
Keep the incoming value untouched in set_storage when only_if_empty is true. Return early only if the overlay already contains data for the slot, preserving the original storage value for migration