### PR TITLE
Update EIP-6800: Remove unused hash_point_to_bytes helper from eip-6800 spec

### DIFF
--- a/EIPS/eip-6800.md
+++ b/EIPS/eip-6800.md
@@ -136,9 +136,6 @@ def old_style_address_to_address32(address: Address) -> Address32:
 These are the positions in the tree at which block header fields of an account are stored.
 
 ```
-def hash_point_to_bytes(point: Point) -> int:
-    return group_to_scalar_field(point).to_bytes(32, 'little')
-
 def pedersen_hash(inp: bytes) -> bytes32:
     assert len(inp) <= 255 * 16
     # Interpret input as list of 128 bit (16 byte) integers


### PR DESCRIPTION
drop the unused hash_point_to_bytes helper from the eip-6800 spec example keep the specification snippet focused on callable helpers only