### PR TITLE
Update EIP-7251: add iteration limit to fake_exponential function

### DIFF
--- a/EIPS/eip-7251.md
+++ b/EIPS/eip-7251.md
@@ -40,6 +40,7 @@ With the security model of the protocol no longer dependent on a low value for `
 | `TARGET_CONSOLIDATION_REQUESTS_PER_BLOCK` | `1` | |
 | `MIN_CONSOLIDATION_REQUEST_FEE` | `1` | |
 | `CONSOLIDATION_REQUEST_FEE_UPDATE_FRACTION` | `17` | |
+| `MAX_ITERATIONS` | `256` | Maximum iterations in fake_exponential to prevent infinite loops |
 | `EXCESS_INHIBITOR` | `2**256-1` | Excess value used to compute the fee before the first system call |
 
 #### Consensus layer
@@ -127,7 +128,7 @@ def fake_exponential(factor: int, numerator: int, denominator: int) -> int:
     i = 1
     output = 0
     numerator_accum = factor * denominator
-    while numerator_accum > 0:
+    while numerator_accum > 0 and i <= MAX_ITERATIONS:
         output += numerator_accum
         numerator_accum = (numerator_accum * numerator) // (denominator * i)
         i += 1


### PR DESCRIPTION
Add MAX_ITERATIONS constant to prevent potential infinite loops in fake_exponential when processing extreme excess values. 

The limit of 256 iterations is sufficient for normal convergence while providing safety against edge cases.