### PR TITLE
Update EIP-7932: Simplify calculate_penalty example in eip-7932.md

### DIFF
--- a/EIPS/eip-7932.md
+++ b/EIPS/eip-7932.md
@@ -170,8 +170,7 @@ as specified in the `calculate_penalty` function.
 
 def calculate_penalty(signature_info: bytes) -> int:
   gas_penalty_base = max(len(signature_info) - (SECP256K1_SIGNATURE_SIZE + 1), 0) * GAS_PER_ADDITIONAL_VERIFICATION_BYTE
-  total_gas_penalty = gas_penalty_base + ALGORITHMS[signature_info[0]].GAS_PENALTY
-  return total_gas_penalty
+  return gas_penalty_base + ALGORITHMS[signature_info[0]].GAS_PENALTY
 
 ```
 


### PR DESCRIPTION
Drop the redundant total_gas_penalty variable in the sample calculate_penalty function so the example returns the computed expression directly.
