### PR TITLE
Update EIP-7658: add deterministic signature_slot tie-break

### DIFF
--- a/EIPS/eip-7658.md
+++ b/EIPS/eip-7658.md
@@ -132,9 +132,9 @@ def process_best_sync_data(state: BeaconState, block: BeaconBlock) -> None:
             is_better_sync_data = new_num_active_participants > old_num_active_participants
         elif new_has_sync_committee_finality != old_has_sync_committee_finality:
             is_better_sync_data = new_has_sync_committee_finality
-        else:
+        elif new_num_active_participants != old_num_active_participants:
             is_better_sync_data = new_num_active_participants > old_num_active_participants
-        if not is_better_sync_data and new_num_active_participants == old_num_active_participants:
+        else:
             is_better_sync_data = block.slot < state.current_best_sync_data.signature_slot
         if is_better_sync_data:
             state.current_best_sync_data = SyncData(


### PR DESCRIPTION
- Add explicit deterministic tie-break in process_best_sync_data: when participation and finality are equal, prefer the lower signature_slot; if equal, retain existing selection.
- Document the tie-break in the “How to rank SyncAggregate?” section.