### PR TITLE
Update EIP-7940: Fix term length constraint

### DIFF
--- a/EIPS/eip-7940.md
+++ b/EIPS/eip-7940.md
@@ -37,7 +37,7 @@ The Shah SHOULD explicitly call out blockers, communications breakdowns, and whe
 
 The Shah SHOULD NOT report to the Ethereum Foundation. The Shah's position would be paid directly from the most credibly "Ethereum" source of funding, which has received its budget from a diverse set of Ethereum community members: The Protocol Guild. 
 
-The Shah SHOULD have an expiration date for their role set at the time of election, that does exceed 2 years.
+The Shah SHOULD have an expiration date for their role set at the time of election, that does not exceed 2 years.
 
 The Shah SHOULD be able to step down willingly before the end of their 2 year term. 
 


### PR DESCRIPTION
Insert “not” to ensure the Shah’s term expiration “does not exceed 2 years,” correcting a logical inversion in the specification.