### PR TITLE
Update EIP-8053: Fix variable logic error

### DIFF
--- a/EIPS/eip-8053.md
+++ b/EIPS/eip-8053.md
@@ -12,7 +12,7 @@ created: 2025-10-17
 
 ## Abstract
 
-This proposal introduces the `milli-gas` counter as the EVM’s internal gas accounting. Gas costs are defined in `milli_gas` and internal EVM gas accounting is entirely carried out in `milli_gas`. At the end of transaction execution,`milli_gas` is rounded up to `gas`. Gas limits and transaction fees are still computed and verified using the current `gas_used` counter. This new counter enables a more precise accounting of cheap compute without impacting UX.
+This proposal introduces the `milli-gas` counter as the EVM's internal gas accounting. Gas costs are defined in `milli_gas` and internal EVM gas accounting is entirely carried out in `milli_gas`. At the end of transaction execution, `milli_gas` is rounded up to `gas`. Gas limits and transaction fees are still computed and verified using the current `gas_used` counter. This new counter enables a more precise accounting of cheap compute without impacting UX.
 
 ## Motivation
 
@@ -74,7 +74,7 @@ At the end of each transaction execution, the gas left in the transaction output
 tx_output.gas_left = ceil(evm.milli_gas_left / 1000)
 ```
 
-At the same time, after the transaction is executed, `evm.milli_gas_left` is rounded up to `evm.milli_gas_used = ceil(evm.milli_gas_used / 1000)`.
+At the same time, after the transaction is executed, `evm.milli_gas_used` is rounded up to `evm.gas_used = ceil(evm.milli_gas_used / 1000)`.
 
 ### Opcode costs
 


### PR DESCRIPTION
`milli_gas_left` was incorrectly used instead of `milli_gas_used`, and fixes circular assignment  `milli_gas_used = ceil(milli_gas_used / 1000)` to proper conversion `gas_used = ceil(milli_gas_used / 1000)`, consistent with the conversion pattern.