### PR TITLE
Update EIP-7612: use code_size from basicdata; remove unused CODE_SIZE_LEAF_KEY read

### DIFF
--- a/EIPS/eip-7612.md
+++ b/EIPS/eip-7612.md
@@ -59,16 +59,13 @@ def verkle_set_account(tree: VerkleTree, key: Bytes32, account: Optional[Account
 def verkle_get_account(tree: VerkleTree, key: Bytes32) -> Optional[Account]:
     basicdata_leaf = tree.get(key)
     if basicdata_leaf is not None:
-        cs = int.from_bytes(basicdata_leaf[5:8], 'big')
+        code_size = int.from_bytes(basicdata_leaf[5:8], 'big')
         nonce = int.from_bytes(basicdata_leaf[8:16], 'big')
         balance = int.from_bytes(basicdata_leaf[16:32], 'big')
         ckkey = key
         ckkey[31] = CODEHASH_LEAF_KEY
         ck = tree.get(ckkey)
-        cskey = key
-        cskey[31] = CODE_SIZE_LEAF_KEY
-        cs = tree.get(cskey)
-        account = Account(0, balance, nonce, ck, cs)
+        account = Account(0, balance, nonce, ck, code_size)
 
     return account
 ```


### PR DESCRIPTION
Replace overwritten variable usage in verkle_get_account: read code_size from basicdata_leaf[5:8] and pass it to Account, removing the erroneous read of a non-specified CODE_SIZE_LEAF_KEY. This aligns with EIP-6800, where code_size is part of the basic account data, and eliminates dead code and potential type inconsistencies.