### PR TITLE
Update EIP-7773: remove EIPs 6873 & 7667 (withdrawn 23 Oct, ACDE #223)

### DIFF
--- a/EIPS/eip-7773.md
+++ b/EIPS/eip-7773.md
@@ -42,9 +42,7 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Declined
 1. [EIP-2926](./eip-2926.md): Chunk-based code merkelization
 1. [EIP-5920](./eip-5920.md): PAY opcode
 1. [EIP-6466](./eip-6466.md): SSZ receipts
-1. [EIP-6873](./eip-6873.md): Preimage retention
 1. [EIP-7610](./eip-7610.md): Revert creation in case of non-empty storage
-1. [EIP-7667](./eip-7667.md): Raise gas costs of hash functions
 1. [EIP-7668](./eip-7668.md): Remove bloom filters
 1. [EIP-7686](./eip-7686.md): Linear EVM memory limits
 1. [EIP-7688](./eip-7688.md): Forward compatible consensus data structures


### PR DESCRIPTION
both of these EIPs were withdrawn on ACDE #223 on 23 Oct, just PR'ing to reflect those changes: https://forkcast.org/calls/acde/223#t=4202