### PR TITLE
Update EIP-8038: fix grammar issues

### DIFF
--- a/EIPS/eip-8038.md
+++ b/EIPS/eip-8038.md
@@ -32,7 +32,7 @@ Upon activation of this EIP, the following parameters of the gas model are renam
 | `GAS_STORAGE_UPDATE` | `GAS_COLD_STORAGE_WRITE` |
 | `GAS_COLD_SLOAD` | `GAS_COLD_STORAGE_ACCESS` |
 
-The following parameters of the gas model updated:
+The following parameters of the gas model are updated:
 
 | **Parameter** | **Current value** | **New value** | **Increase** |**Operations affected** |
 |:---:|:---:|:---:|:---:|:---:|
@@ -79,7 +79,7 @@ Differently from other account read operations, `EXTCODESIZE` and `EXTCODECOPY` 
 
 ### Interaction with [EIP-2926](eip-2926.md)
 
-[EIP-2926](eip-2926.md) proposes to change how code is store in the state trie. One of the changes of this proposal is to include the code size as a new field in the account object (`codeSize`). With this change, the code size can be directly accessed with a single read to the database and thus `EXTCODESIZE` should maintain its previous cost formula, without including the additional `GAS_WARM_ACCESS`.
+[EIP-2926](eip-2926.md) proposes to change how code is stored in the state trie. One of the changes of this proposal is to include the code size as a new field in the account object (`codeSize`). With this change, the code size can be directly accessed with a single read to the database and thus `EXTCODESIZE` should maintain its previous cost formula, without including the additional `GAS_WARM_ACCESS`.
 
 ### Interaction with [EIP-7928](eip-7928.md)
 


### PR DESCRIPTION
## Description

Fix grammar issues:
 - `updated` → `are updated`
 - `store` → `stored`