### PR TITLE
Update EIP-7748: Fix set_storage guard to avoid clobbering incoming values

### DIFF
--- a/EIPS/eip-7748.md
+++ b/EIPS/eip-7748.md
@@ -152,8 +152,8 @@ def set_storage(
 ) -> None:
     # <new_code>
     if only_if_empty:
-        value = state._overlay_tree.get(get_tree_key_for_storage_slot(addr, key))
-        if value is not None:
+        existing_value = state._overlay_tree.get(get_tree_key_for_storage_slot(addr, key))
+        if existing_value is not None:
             return
     # </new_code>
     


### PR DESCRIPTION
load the existing slot value into a separate variable when only_if_empty is enabled return early if the slot is already populated, leaving the caller’s value untouched keep the original value argument intact so new data is written whenever the slot is empty