### PR TITLE
Update EIP-7516: fix BLOBBASEFEE example bytecode to 0x4a00

### DIFF
--- a/EIPS/eip-7516.md
+++ b/EIPS/eip-7516.md
@@ -50,7 +50,7 @@ There are no known backward compatibility issues with this instruction.
 Assume calling `get_blob_gasprice(header)` (as defined in [EIP-4844 §Gas accounting](./eip-4844.md#gas-accounting)) on the current block's header returns `7 wei`:
 `BLOBBASEFEE` should push the value `7` (left padded byte32) to the stack.
 
-Bytecode: `0x4900` (`BLOBBASEFEE, STOP`)
+Bytecode: `0x4a00` (`BLOBBASEFEE, STOP`)
 
 | Pc | Op          | Cost | Stack | RStack |
 |----|-------------|------|-------|--------|


### PR DESCRIPTION
The example bytecode in EIP-7516 used 0x4900 for "BLOBBASEFEE, STOP".
However, 0x49 corresponds to BLOBHASH as defined in EIP-4844, while EIP-7516
assigns 0x4a to BLOBBASEFEE. This change updates the example to 0x4a00 to
match the specified opcode and ensure consistency with client implementations
and EIP-4844’s opcode map.