### PR TITLE
Update EIP-8030: Remove stale TODO marker from EIP-8030

### DIFF
--- a/EIPS/eip-8030.md
+++ b/EIPS/eip-8030.md
@@ -71,7 +71,6 @@ No backward compatibility issues found.
 ## Security Considerations
 
 Needs discussion.
-<!-- TODO -->
 
 ## Copyright
 


### PR DESCRIPTION
delete the leftover <!-- TODO --> placeholder in EIPs/EIPS/eip-8030.md keep the Security Considerations section concise and free of unfinished markup