### PR TITLE
Update EIP-6466: clarify contract_address field presence in receipt types

### DIFF
--- a/EIPS/eip-6466.md
+++ b/EIPS/eip-6466.md
@@ -136,7 +136,7 @@ Receipts are constructed as follows.
 | - | - |
 | `from` | The transaction sender's address |
 | `gas_used` | How much gas this individual transaction used. Replaces `cumulative_gas_used` |
-| `contract_address` | For transactions deploying a contract, the new contract address |
+| `contract_address` | For transactions deploying a contract, the new contract address. Present only in `CreateReceipt` |
 | `logs` | Logs emitted during transaction execution |
 | `status` | [EIP-658](./eip-658.md) transaction status code |
 | `authorities` | For transactions with an authorization list, the list of [EIP-7702](./eip-7702.md) `authority` addresses. Non-successful authorizations are represented with an all-zero address |
@@ -164,7 +164,7 @@ Within `logs`, the `logIndex` field is changed to indicate the log index positio
 
 The `logsBloom` field is no longer returned for new receipts. It continues to be returned for historical receipts conforming to earlier schemes.
 
-`from`, `gasUsed`, and `contractAddress` are already provided via JSON-RPC and are left unchanged.
+`from`, `gasUsed`, and `contractAddress` are already provided via JSON-RPC and are left unchanged. For `BasicReceipt` and `SetCodeReceipt`, `contractAddress` will be `null` as these receipt types do not contain the `contract_address` field.
 
 ### Consensus `ExecutionPayload` changes
 


### PR DESCRIPTION
Specifies that contract_address is only present in CreateReceipt.

Adds note that contractAddress will be null for BasicReceipt and SetCodeReceipt in JSON-RPC responses.