### PR TITLE
Update EIP-6800: Remove unused stem aggregation in compute_verkle_root

### DIFF
--- a/EIPS/eip-6800.md
+++ b/EIPS/eip-6800.md
@@ -81,14 +81,6 @@ def compute_main_tree_root(data: Dict[bytes32, int],
         return group_to_scalar_field(compute_commitment_root(sub_commitments))
 
 def compute_verkle_root(data: Dict[bytes32, bytes32]) -> Point:
-    stems = set(key[:-1] for key in data.keys())
-    data_as_stems = {}
-    for stem in stems:
-        commitment_data = Dict[byte, bytes32]()
-        for i in range(VERKLE_NODE_WIDTH):
-            if stem + bytes([i]) in data:
-                commitment_data[i] = data[stem + bytes([i])]
-        data_as_stems[stem] = extension_and_suffix_tree(stem, commitment_data)
     sub_commitments = [
         compute_main_tree_root({
                 key: value for key, value in data.items() if


### PR DESCRIPTION
eliminate the unused data_as_stems construction in compute_verkle_root keep the function’s behaviour intact while avoiding redundant iteration and allocations