### PR TITLE
Update EIP-8030: Remove invalid byte conversion in EIP-8030 verify example

### DIFF
--- a/EIPS/eip-8030.md
+++ b/EIPS/eip-8030.md
@@ -46,7 +46,7 @@ def verify(signature_info: bytes, payload_hash: Hash32) -> Bytes:
     # This is defined in [P256Verify Function](#p256verify-function)
     assert(P256Verify(payload_hash, r, s, x, y) == Bytes("0x0000000000000000000000000000000000000000000000000000000000000001"))
         
-    return x.to_bytes(32, "big") + y.to_bytes(32, "big")
+    return x + y
 ```
 
 


### PR DESCRIPTION
replace the incorrect x.to_bytes(...) / y.to_bytes(...) calls with direct concatenation of the sliced byte values in verify ensure the documentation example returns the expected 64-byte public key without triggering an AttributeError