### PR TITLE
Update EIP-7619: fix duplicated phrase and typo

### DIFF
--- a/EIPS/eip-7619.md
+++ b/EIPS/eip-7619.md
@@ -85,7 +85,7 @@ The precompile can be wrapped in Solidity to provide a more development-friendly
 Since data size is variable, each operation to execute the precompiled call will require:
 
 - 1465 base units of gas for each operation.
-- 6 units of gas for each for each word contained in the payload.
+- 6 units of gas for each word contained in the payload.
   These values are based on results presented at the [benchmarks](#benchmarks) section.
 
 ## Rationale
@@ -100,7 +100,7 @@ The following table shows a summary of the typical values for keys and the appro
 | Falcon512   |      27933.0 |                 897 |                 666 |
 
 
-Falcon uses shake256 under the hood, an implementation made in solidity showed it is not viable to implement this algorithm at that layer, on the other hand the implementation of falcon-512 by using precompiles turned to be the best approach since the gas cost (as show in the previous section) is relatively low.
+Falcon uses shake256 under the hood, an implementation made in solidity showed it is not viable to implement this algorithm at that layer, on the other hand the implementation of falcon-512 by using precompiles turned to be the best approach since the gas cost (as shown in the previous section) is relatively low.
 
 Implementing just the signature verification is sufficiently enough to open a wide range of use cases at the smart contract level. To give an example, this method can perfectly work with the Account Abstraction concept, where the authentication process would rely on Falcon and the account is a smart contract.
 


### PR DESCRIPTION
This commit fixes two textual issues in EIP-7619:

- Gas costs (line 88): remove duplicated phrase "for each for each" → "for each".
- Rationale (line 103): correct "as show" → "as shown".
