### PR TITLE
Update EIP-7688: Fix field naming and wording

### DIFF
--- a/EIPS/eip-7688.md
+++ b/EIPS/eip-7688.md
@@ -74,7 +74,7 @@ The following types SHALL be converted to `ProgressiveContainer`:
   - The `transactions` and `withdrawals` fields are redefined to use `ProgressiveList`
   - The `MAX_TRANSACTIONS_PER_PAYLOAD` (1M) limit is no longer enforced (the limit is unreachable with `MAX_PAYLOAD_SIZE` 10 MB)
 - [`ExecutionRequests`](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/specs/electra/beacon-chain.md#executionrequests)
-  - The `deposits`, `withdrawals` and `consolidation` fields are redefined to use `ProgressiveList`
+  - The `deposits`, `withdrawals` and `consolidations` fields are redefined to use `ProgressiveList`
 - [`BeaconBlockBody`](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/specs/electra/beacon-chain.md#beaconblockbody)
   - The `proposer_slashings`, `attester_slashings`, `attestations`, `deposits`, `voluntary_exits` and `bls_to_execution_changes` fields are redefined to use `ProgressiveList`
 - [`BeaconState`](https://github.com/ethereum/consensus-specs/blob/b5c3b619887c7850a8c1d3540b471092be73ad84/specs/electra/beacon-chain.md#beaconstate)
@@ -184,7 +184,7 @@ For other requests (withdrawal / consolidation requests), a shared total limit b
 
 #### `BeaconBlockHeader`
 
-The `BeaconBlockHeader` is currently proposed to be kept as is. Updating the `BeaconBlockHeader` to `ProgressiveContainer` is tricky as is breaks `hash_tree_root(latest_block_header)` in the `BeaconState`. One option could be to store `latest_block_header_root` separately, possibly also incorporating the block proposer signature into the hash to avoid proposer signature checks while backfilling historical blocks.
+The `BeaconBlockHeader` is currently proposed to be kept as is. Updating the `BeaconBlockHeader` to `ProgressiveContainer` is tricky as it breaks `hash_tree_root(latest_block_header)` in the `BeaconState`. One option could be to store `latest_block_header_root` separately, possibly also incorporating the block proposer signature into the hash to avoid proposer signature checks while backfilling historical blocks.
 
 #### `Validator`
 


### PR DESCRIPTION
- Line 77: `consolidation` → `consolidations` (matches deposits, withdrawals pattern)
- Line 187: `as is breaks` → `as it breaks` (correct sentence structure)