### PR TITLE
Cleanup unused import in weak subjectivity calc

### DIFF
--- a/assets/eip-6110/eth2_ws_calc.py
+++ b/assets/eip-6110/eth2_ws_calc.py
@@ -5,7 +5,6 @@ This script calculates the Eth2 Weak Subjectivity period as defined by eth2.0-sp
 from eth2spec.phase0.mainnet import (
     uint64, Ether,
     ETH_TO_GWEI, 
-    MAX_DEPOSITS, 
     MAX_EFFECTIVE_BALANCE,  
     SLOTS_PER_EPOCH, 
     config, 


### PR DESCRIPTION
Dropped the unused MAX_DEPOSITS import from assets/eip-6110/eth2_ws_calc.py, relying on the local constant that already provides the needed value. No behavioral changes expected.