### PR TITLE
Update EIP-7749: replace incorrect example signature; clarify 0x00 encoding and return format

### DIFF
--- a/EIPS/eip-7749.md
+++ b/EIPS/eip-7749.md
@@ -42,6 +42,14 @@ MUST calculate an Ethereum signature using `sign(keccak256("\x19\x00<intended va
 
 This method adds a prefix to the message to prevent malicious dApps from signing arbitrary data (e.g., a transaction) and using the signature to impersonate the victim.
 
+Implementations MUST follow these encoding rules when constructing the message to hash:
+
+- `\x19\x00` are the single-byte values `0x19` and `0x00` (not ASCII), prefixed exactly in this order.
+- `<intended validator address>` is the 20 raw bytes of the address. If provided as a hex string (e.g., `0x...`), strip the `0x` prefix and decode to bytes. Case of the hex characters is irrelevant; EIP-55 checksum is not applied to the bytes.
+- `<data to sign>` MUST be a hex string with `0x` prefix representing arbitrary bytes. Strip `0x` and decode to bytes before concatenation. Odd-length hex strings are invalid.
+- The preimage is the concatenation of: `0x19`, `0x00`, 20-byte validator address, then the raw bytes of `dataToSign`.
+- Compute `keccak256` over the entire preimage as defined above, then sign the resulting digest with the private key of `signerAddress`.
+
 #### Parameters
 
 ```js
@@ -59,7 +67,11 @@ interface WalletSignIntendedValidatorDataParams {
 
 #### Returns
 
-`Signature` - The Ethereum Signature generated.
+`Signature` - A hex-encoded 65-byte Ethereum signature (`0x`-prefixed) consisting of `r || s || v` in big-endian:
+
+- `r`: bytes `0..31`
+- `s`: bytes `32..63`
+- `v`: byte `64`, MUST be either `27` or `28` (or, optionally, `0` or `1` where supported). The `v` value MUST NOT include an EIP-155 chain id for this off-chain message signing scheme.
 
 ## Rationale
 
@@ -104,7 +116,7 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"wallet_signIntendedValidatorData
 {
   "jsonrpc": "2.0",
   "id": 1,
-  "result": "0x4355c47d63924e8a72e509b65029052eb6c299d53a04e167c5775fd466751c9d07299936d304c153f6443dfa05f40ff007d72911b6f72307f996231605b915621c"
+  "result": "0x<65-byte-signature-r|s|v>"
 }
 ```
 


### PR DESCRIPTION
The example result in EIP-7749 reused the canonical EIP-712 signature which is invalid for ERC-191 0x00, as the preimage and prefix differ; this caused a misleading, non-reproducible example. This change replaces the example signature with a neutral placeholder and adds explicit byte-level encoding rules for the 0x00 scheme, including how to interpret the validator address and data bytes. It also defines the return format precisely as a 65-byte r||s||v signature and clarifies v semantics without EIP-155 chain id for off-chain signing. These updates ensure the example cannot be mistaken for an EIP-712 signature and make the spec implementable and interoperable.