### PR TITLE
Update EIP-7966: use hex format for QUANTITY timeout parameter in example

### DIFF
--- a/EIPS/eip-7966.md
+++ b/EIPS/eip-7966.md
@@ -97,7 +97,7 @@ Upon receiving an `eth_sendRawTransactionSync` request, the handler function per
   "method": "eth_sendRawTransactionSync",
   "params": [
     "0xf86c808504a817c80082520894ab... (signed tx hex)",
-    5000
+    "0x1388"
   ],
   "id": 1
 }


### PR DESCRIPTION
Update the timeout parameter in the example request to use hex-encoded
QUANTITY format ("0x1388") instead of decimal (5000) to comply with
EIP-1474 QUANTITY encoding standard.