### PR TITLE
Update EIP-7793: Clarify TXINDEX stack encoding and uint64 sentinel semantics

### DIFF
--- a/EIPS/eip-7793.md
+++ b/EIPS/eip-7793.md
@@ -39,7 +39,7 @@ We introduce a new type of [EIP-2718](./eip-2718.md) transaction, "conditional t
 
 The fields `chain_id`, `nonce`, `max_priority_fee_per_gas`, `max_fee_per_gas`, `gas_limit`, `to`, `value`, `data`, `access_list`, `max_fee_per_blob_gas` follow the same semantics as [EIP-4844](./eip-4844.md). The field `blob_versioned_hashes` is the same except that the list may be empty for a conditional transaction.
 
-The fields `conditional_slot` and `conditional_tx_index` are both `uint64` and specify the slot and transaction index in which this transaction should be considered valid respectively. In order to verify that `conditional_slot` is correct, [EIP-7843](./eip-7843.md) is a dependency, as this adds the slot number to the header. For both fields `-1` is used as a sentinel value for which the slot or transaction index check will not take place.
+The fields `conditional_slot` and `conditional_tx_index` are both `uint64` and specify the slot and transaction index in which this transaction should be considered valid respectively. In order to verify that `conditional_slot` is correct, [EIP-7843](./eip-7843.md) is a dependency, as this adds the slot number to the header. For both fields, the sentinel value is `0xffffffffffffffff` (`2^64 - 1`). When interpreted on the EVM stack or by EVM opcodes (e.g., via `TXINDEX`), this 64-bit sentinel value MUST be zero-extended to a 256-bit stack word. If a field equals this sentinel, the corresponding check (slot or transaction index) MUST NOT take place.
 
 #### Signature
 
@@ -53,7 +53,7 @@ A new opcode `TXINDEX` is introduced at `TXINDEX_OPCODE_BYTE`.
 
 #### Output
 
-One element `TransactionIndex` is added to the stack. `TransactionIndex` is a `uint64` in big endian encoding. It is equal to `conditional_tx_index` if the current transaction is a conditional transaction, and `-1` otherwise.
+One element `TransactionIndex` is pushed to the EVM stack as a 256-bit word. The numeric value is a 64-bit unsigned integer encoded in big-endian and zero-extended to 256 bits (left-padded with zeros to 32 bytes). If the current transaction is a conditional transaction, the value equals `conditional_tx_index`. Otherwise, the value equals the 64-bit sentinel `0xffffffffffffffff` (`2^64 - 1`), zero-extended to 256 bits.
 
 #### Gas Cost
 


### PR DESCRIPTION
This commit removes ambiguity in EIP-7793 around the TXINDEX opcode result and the sentinel value used by uint64 fields:

- Define that TXINDEX pushes a 256-bit stack word with a 64-bit big-endian value  zero-extended to 256 bits (left-padded to 32 bytes).
- Specify that the sentinel -1 for uint64 fields is the concrete value  0xffffffffffffffff (2^64 - 1), and when surfaced in EVM (e.g., via TXINDEX),  it MUST be zero-extended to a 256-bit stack word.

Rationale:
- EVM stack items are always 256-bit words. Stating "uint64 in big endian" without  explicit zero-extension leaves room for divergent implementations.
- Similar recent EIPs (e.g., SLOTNUM) use uint64, but explicit padding rules ensure  consistent client behavior and avoid misinterpretation.