### PR TITLE
Update EIP-4762: Fix storage helper invocation in EIP-4762

### DIFF
--- a/EIPS/eip-4762.md
+++ b/EIPS/eip-4762.md
@@ -143,7 +143,7 @@ When a contract creation is initialized, process these write events:
 (address, tree_key, sub_key)
 ```
 
-Where `tree_key` and `sub_key` are computed as `tree_key, sub_key = get_storage_slot_tree_keys(address, key)`
+Where `tree_key` and `sub_key` are computed as `tree_key, sub_key = get_storage_slot_tree_keys(key)`
 
 #### Write events for code
 


### PR DESCRIPTION
align the write-event guidance with the helper definition of `get_storage_slot_tree_keys` remove the spurious `address` argument so implementers see the accurate call signature