### PR TITLE
Update EIP-7863: "messured" → "measured" in eip-7863.md

### DIFF
--- a/EIPS/eip-7863.md
+++ b/EIPS/eip-7863.md
@@ -22,7 +22,7 @@ Currently, the EVM's storage slot warming mechanism operates at the transaction 
 2. Better align gas costs with actual computational overhead
 3. Improve overall network throughput without compromising security.
 
-As of Jan. 2025, the empirically messured efficiency gains are around 5%.
+As of Jan. 2025, the empirically measured efficiency gains are around 5%.
 
 
 ## Specification


### PR DESCRIPTION
Fixes a spelling error in `EIPS/eip-7863.md` where "messured" was incorrectly used instead of "measured".