### PR TITLE
Update EIP-5593: resolve MUST/SHOULD contradiction for third-party iframe blocking

### DIFF
--- a/EIPS/eip-5593.md
+++ b/EIPS/eip-5593.md
@@ -37,9 +37,9 @@ The provider objects, e.g. `window.ethereum`, are expected to only inject the Et
     - The User Agent implementation MAY also support configured [potentially trustworthy origins] that would normally not be considered trustworthy if the user configures their User Agent to do so. See section 7.2 titled "Development Environments" of W3C's Secure Contexts specification for additional details. For example, in Chromium based User Agents this is done via the `chrome://flags/#unsafely-treat-insecure-origin-as-secure` flag.
 - By default the Ethereum Provider APIs MUST NOT be exposed to third-party iframes.
 - `window.ethereum` MUST be `undefined` in an iframe where `window.isSecureContext` returns `false` in that iframe.
-- If the iframe is a third party to the top-level secure origin, it MUST be blocked.
+- If the iframe is a third party to the top-level secure origin, it SHOULD be blocked. Some implementations MAY provide a mechanism (e.g., via the `allow` attribute and Permissions API) for pages to request access, subject to user approval.
 - If the iframe is first-party to the top-level origin AND the `sandbox` attribute is set on the iframe, the provider object MUST be blocked. If the `sandbox` attribute is set to `sandbox="allow-same-origin"` it MUST be injected for a first party frame.
-    - Note `"allow-same-origin"` does nothing if the iframe is third-party. Third-party iframes MUST be blocked regardless of the `sandbox` attribute or any other configuration.
+    - Note `"allow-same-origin"` does nothing if the iframe is third-party. Third-party iframes SHOULD be blocked by default, but implementations MAY allow access through user-approved mechanisms such as the Permissions API.
 
 ## Rationale
 


### PR DESCRIPTION
Clarifies that third-party iframes MUST be blocked (not SHOULD) to align with the MUST NOT requirement for default exposure. 

Removes ambiguous reference to Permissions API and allow attribute mechanism that was never fully specified, replacing it with explicit blocking requirement regardless of configuration.