### PR TITLE
Update EIP-8016: Link first references to EIP-7916 and EIP-7495

### DIFF
--- a/EIPS/eip-8016.md
+++ b/EIPS/eip-8016.md
@@ -56,9 +56,9 @@ The following types are considered [illegal](https://github.com/ethereum/consens
 - `Bitvector[N]` are compatible if they share the same capacity `N`.
 - `List[type, N]` are compatible if `type` is compatible and they share the same capacity `N`.
 - `Vector[type, N]` are compatible if `type` is compatible and they share the same capacity `N`.
-- `ProgressiveList[type]` are compatible if `type` is compatible.
+- [`ProgressiveList[type]`](./eip-7916.md) are compatible if `type` is compatible.
 - `Container` are compatible if they share the same field names in the same order, and all field types are compatible.
-- `ProgressiveContainer(active_fields)` are compatible if all `1` entries in both type's `active_fields` correspond to fields with shared names and compatible types, and no other field name is shared across both types.
+- [`ProgressiveContainer(active_fields)`](./eip-7495.md) are compatible if all `1` entries in both type's `active_fields` correspond to fields with shared names and compatible types, and no other field name is shared across both types.
 - `CompatibleUnion` are compatible with each other if all type options across both `CompatibleUnion` are compatible.
 - All other types are incompatible.
 


### PR DESCRIPTION
This change adds relative links to ./eip-7916.md and ./eip-7495.md on the first mentions of ProgressiveList[type] and ProgressiveContainer(active_fields) in the “Compatible Merkleization” list of EIP-8016. EIP-1 requires that the first reference to another EIP be linked with a relative path, and bringing these inline ensures editorial compliance, improves navigability for readers, and avoids ambiguity about the referenced definitions. The modification is strictly editorial and does not alter any normative content or semantics of the proposal.