### PR TITLE
Update EIP-7657: Remove unused MAX_SYNC_COMMITTEE_SLASHINGS constant from EIP-7657

### DIFF
--- a/EIPS/eip-7657.md
+++ b/EIPS/eip-7657.md
@@ -36,7 +36,6 @@ Note: This still allows having contradictions between attestations/proposals and
 | `STATE_BLOCK_ROOTS_INDEX` | `get_generalized_index(BeaconState, 'block_roots')` (= 37) |
 | `STATE_HISTORICAL_ROOTS_INDEX` | `get_generalized_index(BeaconState, 'historical_roots')` (= 39) |
 | `HISTORICAL_BATCH_BLOCK_ROOTS_INDEX` | `get_generalized_index(HistoricalBatch, 'block_roots')` (= 2) |
-| `MAX_SYNC_COMMITTEE_SLASHINGS` | `2**0` (= 1) |
 
 ```python
 class SyncCommitteeSlashingEvidence(Container):


### PR DESCRIPTION
delete the MAX_SYNC_COMMITTEE_SLASHINGS entry from the constants table in EIP-7657 because the value is never referenced elsewhere in the specification.