### PR TITLE
Update EIP-7896: Fix JSON syntax in EIP-7896 ABI example

### DIFF
--- a/EIPS/eip-7896.md
+++ b/EIPS/eip-7896.md
@@ -85,6 +85,7 @@ Wallets SHOULD use the provided interface specs to decode the `data` of each cal
           "version": "abi-v1",
           "spec": [
             {
+              "type": "function"
               "name": "transfer",
               "stateMutability": "nonpayable",
               "inputs": [


### PR DESCRIPTION
 drop the trailing comma after the `"outputs": []` array so the snippet becomes valid JSON