### PR TITLE
Update EIP-7658: Use constant sync committee size for supermajority checks

### DIFF
--- a/EIPS/eip-7658.md
+++ b/EIPS/eip-7658.md
@@ -121,11 +121,10 @@ def process_best_sync_data(state: BeaconState, block: BeaconBlock) -> None:
 
     # Track best sync data
     if attested_period == signature_period:
-        max_active_participants = len(block.body.sync_aggregate.sync_committee_bits)
         new_num_active_participants = sum(block.body.sync_aggregate.sync_committee_bits)
         old_num_active_participants = sum(state.current_best_sync_data.sync_aggregate.sync_committee_bits)
-        new_has_supermajority = new_num_active_participants * 3 >= max_active_participants * 2
-        old_has_supermajority = old_num_active_participants * 3 >= max_active_participants * 2
+        new_has_supermajority = new_num_active_participants * 3 >= SYNC_COMMITTEE_SIZE * 2
+        old_has_supermajority = old_num_active_participants * 3 >= SYNC_COMMITTEE_SIZE * 2
         if new_has_supermajority != old_has_supermajority:
             is_better_sync_data = new_has_supermajority
         elif not new_has_supermajority and new_num_active_participants != old_num_active_participants:


### PR DESCRIPTION
replace the redundant len(sync_committee_bits) calculation with the existing SYNC_COMMITTEE_SIZE constant when computing supermajority thresholds, keep the logic identical while avoiding repeated list length evaluation