### PR TITLE
Update EIP-7928: Update StorageKey and StorageValue type definitions

### DIFF
--- a/EIPS/eip-7928.md
+++ b/EIPS/eip-7928.md
@@ -47,8 +47,8 @@ BALs use RLP encoding following the pattern: `address -> field -> block_access_i
 ```python
 # Type aliases for RLP encoding
 Address = bytes20  # 20-byte Ethereum address
-StorageKey = bytes32  # 32-byte storage slot key
-StorageValue = bytes32  # 32-byte storage value
+StorageKey = uint256  # Storage slot key
+StorageValue = uint256  # Storage value
 Bytecode = bytes  # Variable-length contract bytecode
 BlockAccessIndex = uint16  # Block access index (0 for pre-execution, 1..n for transactions, n+1 for post-execution)
 Balance = uint256  # Post-transaction balance in wei


### PR DESCRIPTION
This updates the StorageKey and StorageValue block access list type definitions to uint256. 

The reasoning for this change is to reduce the size of the rlp encoded BALs. The rlp encoding of small slots takes less space when encoded as a number than when encoded as bytes32. For example the uint256 rlp encoding of slot 1 takes a single byte while the bytes32 rlp encoding takes 33 bytes due to the leading zeros which can/should be excluded to save space.