### PR TITLE
Update EIP-8079: Fix formatting

### DIFF
--- a/EIPS/eip-8079.md
+++ b/EIPS/eip-8079.md
@@ -146,6 +146,7 @@ While Ethereum burns the base fee, most rollups collect it for themselves, which
 ### Re-execution vs ZK proofs
 
 <!-- TODO -->
+TBD
 
 ## Backwards Compatibility
 
@@ -154,14 +155,17 @@ Existing rollups can more or less easily migrate to being native based on their 
 ## Test Cases
 
 <!-- TODO -->
+TBD
 
 ## Reference Implementation
 
 <!-- TODO -->
+TBD
 
 ## Security Considerations
 
 <!-- TODO -->
+TBD
 
 ## Copyright
 


### PR DESCRIPTION
Currently broken:

<img width="1298" height="189" alt="image" src="https://github.com/user-attachments/assets/681513fa-eeaf-4467-af87-a8268504b24c" />
