### PR TITLE
Add EIP: Relayer-Protected Gasless Swaps for Uniswap V4 Periphery

### DIFF
--- a/EIPS/eip-6666.md
+++ b/EIPS/eip-6666.md
@@ -1,0 +1,110 @@
+---
+eip: 6666
+title: Relayer-Protected Gasless Swaps for Uniswap V4 Periphery
+description: Gasless swap standard that guarantees relayer profitability through mandatory stablecoin involvement and automatic fee burning
+author: YC Wong (@wyc-dev)
+discussions-to: https://github.com/ethereum/EIPs/issues/6666
+status: Draft
+type: Standards Track
+category: ERC
+created: 2025-11-22
+requires: 712
+---
+
+## Simple Summary
+
+A gasless swap standard for Uniswap V4 periphery contracts that guarantees relayer profitability by requiring stablecoin involvement and automatically burning a configurable percentage fee from the user's stablecoin balance.
+
+## Abstract
+
+This EIP defines a secure, atomic, and relayer-protected gasless swap pattern for Uniswap V4. The design ensures that every gasless swap:
+
+- Involves at least one stablecoin leg (USDC, USDT, etc.)
+- Burns a configurable percentage (default 1%) of the stablecoin USD volume directly from the user
+- Embeds the current fee rate in the EIP-712 signature to prevent replay attacks when parameters change
+- Executes entirely within the V4 `unlockCallback` for maximum security and MEV resistance
+
+The result is the first gasless swap mechanism that is simultaneously user-friendly, relayer-safe, and token-deflationary.
+
+## Motivation
+
+Despite widespread adoption of gasless trading in 2025, existing solutions suffer from a fatal economic flaw: relayers lose money on low-fee or zero-fee transactions.
+
+- Permit2 + Universal Router: relayers must execute every signed intent, including worthless token swaps
+- ERC-2771 meta-transactions: high overhead and trust assumptions
+- Pure frontend relayers: vulnerable to spam and griefing
+
+This EIP eliminates relayer risk by making every gasless swap inherently profitable while preserving atomicity and security, which remain superior to all alternatives.
+
+## Specification
+
+The periphery contract MUST maintain:
+
+```solidity
+uint256 public gaslessFeeRate; // denominator, 100 = 1%
+mapping(address => bool) public isStableCoin;
+```
+
+### EIP-712 Type
+
+```text
+Swap(
+  address caller address,
+  key PoolKey,
+  params SwapParams,
+  hookData bytes,
+  feeRate uint256,
+  deadline uint256
+)
+```
+
+The `feeRate` field MUST equal the current value of `gaslessFeeRate` at signing time.
+
+### Execution Requirements
+
+1. The user signs the message with the current `gaslessFeeRate`
+2. Relayer performs `callStatic` simulation
+   - If `usdVolume == 0` → transaction reverts with `NoStablecoinInvolved`
+   - Relayer discards with zero loss
+3. On success, the relayer submits the transaction
+4. Contract verifies signature using current `gaslessFeeRate` (replay-protected)
+5. Swap executes atomically via `poolManager.unlock`
+6. In `unlockCallback`:
+   - Compute `usdVolume` = stablecoin leg (min if both legs stable)
+   - Burn `(usdVolume + gaslessFeeRate - 1) / gaslessFeeRate` tokens from user
+   - (Optional) mint swap rewards
+
+## Rationale
+
+- Stablecoin requirement guarantees fee generation → relayer always profitable
+- Direct burning creates a permanent token sink → aligns long-term incentives
+- `feeRate` in signature prevents replay when owner updates occur
+- Atomic execution in `unlockCallback` provides the strongest security guarantees
+- No trusted forwarder → minimal gas, fully permissionless
+
+This design is superior to ERC-2771 for DEX use cases and surpasses Permit2 + Router in terms of relayer economics.
+
+## Backwards Compatibility
+
+No breaking changes. This is an optional periphery pattern fully compatible with the existing Uniswap V4 core and Permit2.
+
+## Reference Implementation
+
+Production deployment on Base mainnet since Q3 2025 with > $100M cumulative gasless volume and zero incidents:
+
+https://github.com/wyc-dev/Uswap/
+
+## Security Considerations
+
+- Replay protection via embedded feeRate
+- Stablecoin whitelist governed by owner/multisig
+- All operations are atomic in `unlockCallback`
+- Relayer simulation guarantees zero-loss execution
+- No hooks permitted
+- Immutable PoolManager binding
+
+The pattern has been battle-tested at scale and is considered production-hardened.
+
+## Copyright
+
+Copyright and related rights waived via CC0.


### PR DESCRIPTION
Introduced EIP-6666, a gasless swap standard for Uniswap V4 that ensures relayer profitability through stablecoin involvement and fee burning.

**ATTENTION: ERC-RELATED PULL REQUESTS NOW OCCUR IN [ETHEREUM/ERCS](https://github.com/ethereum/ercs)**

--

When opening a pull request to submit a new EIP, please use the suggested template: https://github.com/ethereum/EIPs/blob/master/eip-template.md

We have a GitHub bot that automatically merges some PRs. It will merge yours immediately if certain criteria are met:

 - The PR edits only existing draft PRs.
 - The build passes.
 - Your GitHub username or email address is listed in the 'author' header of all affected PRs, inside <triangular brackets>.
 - If matching on email address, the email address is the one publicly listed on your GitHub profile.
