### PR TITLE
Update EIP-7748: remove leftover diff markers from eip-7748 examples

### DIFF
--- a/EIPS/eip-7748.md
+++ b/EIPS/eip-7748.md
@@ -42,10 +42,8 @@ Include the following code in the existing `apply_body(...)` function:
 ```python
 def apply_body(state: State, ...) -> Tuple[Uint, Root, Root, Bloom, State, Root]:
     ...
-    # <new_code>
     if block_time >= CONVERSION_START_TIMESTAMP and not state._conversion_finished:
         block_state_conversion(state, CONVERSION_STRIDE)
-    # </new_code>
     
     for i, tx in enumerate(map(decode_transaction, transactions)):
         ...
@@ -93,10 +91,8 @@ Modify the `State` class by adding the following attributes:
 ```python
 @dataclass
 class State:
-    # <new_code>
     _conversion_curr_account: Optional[CurrentConvertingAccount] = None
     _conversion_finished: bool = False
-    # </new_code>
     ...
     
 ```
@@ -150,12 +146,10 @@ def conversion_move_to_next_account(state: State):
 def set_storage(
     state: State, addr: Address, key: Bytes, value: U256, only_if_empty: bool = True
 ) -> None:
-    # <new_code>
     if only_if_empty:
         value = state._overlay_tree.get(get_tree_key_for_storage_slot(addr, key))
         if value is not None:
             return
-    # </new_code>
     
     state._overlay_tree.set(get_tree_key_for_storage_slot(addr, key), value)
 ```


### PR DESCRIPTION
drop the `# <new_code>` / `# </new_code>` placeholders from the `apply_body`, `State`, and `set_storage` snippets in `EIPS/eip-7748.md`, keep the examples focused on the actual code that should appear in implementations