### PR TITLE
Update EIP-7942: Standardize unstable block reference field as unstable_root

### DIFF
--- a/EIPS/eip-7942.md
+++ b/EIPS/eip-7942.md
@@ -84,7 +84,7 @@ We make three main changes:
 
 2. **Replace HLMD-GHOST with Longest Stable Chain fork choice rule.** We replace the HLMD GHOST with the longest chain as the fork choice rule. Our longest chain fork choice rule is very simple: it outputs the head of the chain with the most stable blocks. In case of a tie, the longest chain fork choice rule chooses the chain such that the leaf block has the largest slot number.
 
-3. **Blocks carry a reference `u` to recent unstable blocks to preserve transaction continuity.** We additionally include a field `u` in a block b. Each proposer sets its `u` field as the hash of an unstable block. If there is no such unstable block, set `u` as None. The transactions in the unstable blocks should not conflict with the transactions in the longest chain. The transactions in `u` can also be finalized once block b (that includes `u`) is finalized.
+3. **Blocks carry a reference `unstable_root` to recent unstable blocks to preserve transaction continuity.** We additionally include a field `unstable_root` in a block b. Each proposer sets its `unstable_root` field as the hash of an unstable block. If there is no such unstable block, set `unstable_root` as None. The transactions in the unstable blocks should not conflict with the transactions in the longest chain. The transactions in `unstable_root` can also be finalized once block b (that includes `unstable_root`) is finalized.
 
 4. **Simplify the filtering rule and the justification process.** We simplify the filtering rule as it only considers the chain that justifies the last justified checkpoint. Additionally, the justification process only updates when a chain crosses the epoch boundary.
 
@@ -145,9 +145,9 @@ Modify `Preparing for a BeaconBlock`
 
 To construct a `BeaconBlockBody`, a `block` (`BeaconBlock`) is defined with the necessary context for a block proposal:
 
-##### unstable
+##### unstable_root
 
-Set `block.unstable` as the hash of the latest unstable block if such block exists. If none exists, set `unstable = None`. The transactions in `unstable` must not conflict with the stable chain and will be finalized once `block` is finalized.
+Set `block.unstable_root` as the hash of the latest unstable block if such block exists. If none exists, set `block.unstable_root = None`. The transactions in `unstable_root` must not conflict with the stable chain and will be finalized once `block` is finalized.
 
 #### Modification 4
 


### PR DESCRIPTION
Standardized the field naming for the unstable block reference to align with consensus-spec conventions and remove internal inconsistencies. The prose previously introduced a single-letter field u while the pseudocode used block.unstable; single-letter fields are atypical in the consensus specs and the value stored is a block root, so the descriptive name unstable_root is preferable. Updated Protocol Changes item 3 to use unstable_root consistently and corrected the pseudocode to set block.unstable_root = None, ensuring the name, semantics, and assignment target match throughout the document.