### PR TITLE
Update EIP-4762: Remove outdated Account Abstraction TODO from EIP-4762

### DIFF
--- a/EIPS/eip-4762.md
+++ b/EIPS/eip-4762.md
@@ -258,10 +258,6 @@ When (and only when) calling a system contract either
 
 Also corresponding witness costs need to be charged for _precompile/opcode resolution_ but are not charged in the _system call_.
 
-### Account abstraction
-
-TODO : still waiting on a final decision between 7702 and 3074
-
 ## Rationale
 
 ### Gas reform


### PR DESCRIPTION
Removes obsolete TODO section regarding Account Abstraction decision between EIP-7702 and EIP-3074 from EIP-4762 specification.