### PR TITLE
Update EIP-7904: Align WarmStorageReadCost with spec (5 gas)

### DIFF
--- a/EIPS/eip-7904.md
+++ b/EIPS/eip-7904.md
@@ -266,7 +266,7 @@ const (
   RepricedGasMidStep          uint64 = 3
 
   //overrides
-  WarmStorageReadCost uint64 = 100 // WARM_STORAGE_READ_COST
+  WarmStorageReadCost uint64 = 5 // WARM_STORAGE_READ_COST
   ExpGas              uint64 = 2  // Once per EXP instruction
   ExpByteGas          uint64 = 4  // One per byte of the EXP exponent
   CopyGas             uint64 = 1  // One per word of the copied code


### PR DESCRIPTION
The EIP-7904 spec sets WARM_STORAGE_READ_COST to 5 and ties TLOAD/TSTORE to this constant in the opcode table, but the Go reference snippet still defined WarmStorageReadCost as 100, which is the current mainnet value from EIP-2929/EIP-1153 rather than the repriced value proposed here. This change updates WarmStorageReadCost to 5 so that TLOAD and TSTORE map to the intended repriced warm access cost, making the reference code consistent with the Parameters section and the opcode table.