### PR TITLE
Update EIP-7612: fix basicdata version byte to ensure 32-byte header

### DIFF
--- a/EIPS/eip-7612.md
+++ b/EIPS/eip-7612.md
@@ -45,7 +45,7 @@ def is_fork_block(block):
 # Write an account in the verkle tree
 def verkle_set_account(tree: VerkleTree, key: Bytes32, account: Optional[Account]):
     if account is not None:
-        basicdata = bytes(0) # Version
+        basicdata = b'\x00' # Version
         basicdata += bytes(4) # Reserved
         basicdata += len(account.code).to_bytes(3, 'big')
         basicdata += account.nonce.to_bytes(8, 'big')


### PR DESCRIPTION
Replace bytes(0) with a single zero byte for the account header version in verkle_set_account so that the assembled basicdata is exactly 32 bytes as specified in EIP-6800. The previous construction produced 31 bytes, shifting subsequent fields by one byte and breaking the documented offsets for code_size (5:8), nonce (8:16), and balance (16:32). Using b'\x00' restores the intended layout and keeps decoding in verkle_get_account consistent with the spec and with related documentation (EIP-6800 and the newer EIP-7864), without altering any other logic.