### PR TITLE
Update EIP-7898: Remove leftover TODO placeholders from EIP-7898

### DIFF
--- a/EIPS/eip-7898.md
+++ b/EIPS/eip-7898.md
@@ -46,8 +46,6 @@ Furthermore CL clients apis and code path will become cleaner and more maintaina
 
 ELs can optionally introduce a `getExecutionPayload` method (similar to `getBlobs`) to assist with faster recovery of execution payload from the EL's p2p network peers who could announce new payload hashes when they see new `VALID` payloads. However, as noted above, that mechanism could be independently specified and is out of scope for this EIP.
 
-<-- TODO: add spec details -->
-
 ## Rationale
 
 There is another choice we could have made to go for `SignedExecutionPayload` instead of `ExecutionPayloadWithInclusionProof` and having a `SignedExecutionPayloadHeader` with builder signing these messages (validator is the builder in local block building). But without builder enshrinement tight gossip validation of `SignedExecutionPayload` would be an issue and could become a DOS vector.
@@ -60,15 +58,9 @@ This change isn't backward compatible and a new hardfork is required to activate
 
 ## Test Cases
 
-<-- TODO -->
-
 ## Reference Implementation
 
-<-- TODO -->
-
 ## Security Considerations
-
-<-- TODO -->
 
 Needs discussion.
 


### PR DESCRIPTION
drop the remaining <!-- TODO --> markers from EIPs/EIPS/eip-7898.md, leave the section headings intact so the document reads as a clean draft for reviewers