### PR TITLE
Update EIP-4863: Remove leftover TODO note from EIP-4863 spec

### DIFF
--- a/EIPS/eip-4863.md
+++ b/EIPS/eip-4863.md
@@ -55,7 +55,6 @@ This balance change is unconditional and **MUST** not fail.
 
 This transaction type has no associated gas costs.
 
-TODO: add logs?
 
 ## Rationale
 


### PR DESCRIPTION
remove the editorial TODO line from `EIPs/eip-4863.md`, leave the transaction processing section free of unfinished notes