### PR TITLE
Website: Fix citation-js initialization for CSL blocks

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -70,9 +70,12 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/citation-js/0.6.7/citation.min.js" integrity="sha512-N+LDFMa9owHXGS+CyMrBvuxq2QuGl3fiB/7cys3aUEL7K6P1soHGqsS0sjHXZpwNd9Kz0m3R4IPy1HYRi6ROEQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script type="text/javascript">
     addEventListener('DOMContentLoaded', async () => {
-      const Cite = window.require('citation-js');
+      const Cite = window.Cite;
+      if (!Cite) {
+        return;
+      }
       const citationElements = document.querySelectorAll('.language-csl-json');
-      for (let citationElement of citationElements) {
+      for (const citationElement of citationElements) {
         try {
           const citation = await Cite.async(citationElement);
           const template = document.createElement('template');


### PR DESCRIPTION
reference the global `window.Cite` exposed by the CDN build instead of calling window.require, exit early when the library is absent so the rest of the page never breaks, leave the rendering loop otherwise unchanged