### PR TITLE
Update EIP-7980: remove redundant EIP-7932 link from EIP-7980

### DIFF
--- a/EIPS/eip-7980.md
+++ b/EIPS/eip-7980.md
@@ -24,7 +24,7 @@ cases against during the implementation phase of [EIP-7932](./eip-7932.md).
 
 ## Specification
 
-This EIP defines a new [EIP-7932](../../EIPS/eip-7932.md) algorithmic type with the following parameters:
+This EIP defines a new algorithmic type with the following parameters:
 | Constant | Value |
 | - | - |
 | `ALG_TYPE` | `Bytes1(0x0)` |


### PR DESCRIPTION
drop the second link to EIP-7932 in EIP-7980’s specification section, keep the wording intact while avoiding duplicate cross-references