### PR TITLE
Remove stale issue/PR template exclusions from Jekyll config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -63,8 +63,6 @@ exclude:
   - vendor/gems/
   - vendor/ruby/
   - eip-template.md
-  - ISSUE_TEMPLATE.md
-  - PULL_REQUEST_TEMPLATE.md
   - README.md
   
 include:


### PR DESCRIPTION
drop ISSUE_TEMPLATE.md and PULL_REQUEST_TEMPLATE.md from the site exclude list, keep the Jekyll config aligned with the current file layout (templates live only under .github)