### PR TITLE
Update EIP-7748: align call site and prose to use state_convert()

### DIFF
--- a/EIPS/eip-7748.md
+++ b/EIPS/eip-7748.md
@@ -44,7 +44,7 @@ def apply_body(state: State, ...) -> Tuple[Uint, Root, Root, Bloom, State, Root]
     ...
     # <new_code>
     if block_time >= CONVERSION_START_TIMESTAMP and not state._conversion_finished:
-        block_state_conversion(state, CONVERSION_STRIDE)
+        state_convert(state, CONVERSION_STRIDE)
     # </new_code>
     
     for i, tx in enumerate(map(decode_transaction, transactions)):
@@ -52,7 +52,7 @@ def apply_body(state: State, ...) -> Tuple[Uint, Root, Root, Bloom, State, Root]
     ...
 ```
 
-Before executing txs, it calls `block_state_conversion(...)` (described below) which performs a state conversion step for this block.
+Before executing txs, it calls `state_convert(...)` (described below) which performs a state conversion step for this block.
 
 In `state.py`, add the following code:
 


### PR DESCRIPTION
Updated the apply_body(...) snippet and the accompanying prose in EIPS/eip-7748.md to reference state_convert(...) instead of block_state_conversion(...). The document defines only state_convert(state, stride) as the conversion routine; there is no block_state_conversion(...) function defined in the spec. Using state_convert(...) at the call site and in the text removes ambiguity for implementers and brings the snippet into alignment with the canonical function name found in the same section and in the upstream EIP rendering.