### PR TITLE
Update EIP-8030: Remove redundant .to_bytes() conversion in signature verification

### DIFF
--- a/EIPS/eip-8030.md
+++ b/EIPS/eip-8030.md
@@ -46,7 +46,7 @@ def verify(signature_info: bytes, payload_hash: Hash32) -> Bytes:
     # This is defined in [P256Verify Function](#p256verify-function)
     assert(P256Verify(payload_hash, r, s, x, y) == Bytes("0x0000000000000000000000000000000000000000000000000000000000000001"))
         
-    return x.to_bytes(32, "big") + y.to_bytes(32, "big")
+    return x + y
 ```
 
 


### PR DESCRIPTION
Fixes a runtime error in the EIP-8030 reference implementation where `.to_bytes()` , was incorrectly called on bytes objects.