### PR TITLE
Update EIP-7997: remove stray TODO marker from eip-7997 test cases

### DIFF
--- a/EIPS/eip-7997.md
+++ b/EIPS/eip-7997.md
@@ -139,7 +139,6 @@ The system contract is written to avoid the use of newer opcodes such as `PUSH0`
 
 ## Test Cases
 
-<!-- TODO -->
 TBD
 
 ## Security Considerations


### PR DESCRIPTION
drop the redundant <!-- TODO --> comment in the Test Cases section of eip-7997.md