### PR TITLE
CI: remove redundant jekyll build step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,16 +54,14 @@ jobs:
           ruby-version: '3.1' # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 0 # Increment this number if you need to re-download cached gems
-      - name: Build with Jekyll
-        run: bundle exec jekyll build
-        env:
-          JEKYLL_ENV: production
-
+      
       - name: Build Website
         run: |
           bundle exec jekyll doctor
           bundle exec jekyll build
-
+        env:
+          JEKYLL_ENV: production
+          
       - name: HTML Proofer
         run: bundle exec htmlproofer --allow-missing-href --disable-external --assume-extension '.html' --log-level=:info --cache='{"timeframe":{"external":"6w"}}' --checks 'Links,Images,Scripts,OpenGraph' --no-check-sri --ignore-empty-alt --no-enforce_https ./_site
       - name: DNS Validator


### PR DESCRIPTION
drop the duplicate `bundle exec jekyll build` invocation from the HTMLProofer job, keep the remaining build running with `JEKYLL_ENV=production` after `jekyll doctor`