### PR TITLE
Update EIP-7742: specify header RLP encoding and placement of target_blobs_per_block

### DIFF
--- a/EIPS/eip-7742.md
+++ b/EIPS/eip-7742.md
@@ -68,13 +68,44 @@ additional 64-bit field: the `target_blobs_per_block`. This value is set to the 
 is modified along with this EIP to provide the `target_blobs_per_block` with each payload and implementations can use this
 value to correctly set the block header field.
 
+#### Header RLP encoding
+
+The resulting RLP encoding of the header is therefore:
+
+```python
+rlp([
+    parent_hash,
+    0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347, # ommers hash
+    coinbase,
+    state_root,
+    txs_root,
+    receipts_root,
+    logs_bloom,
+    0, # difficulty
+    number,
+    gas_limit,
+    gas_used,
+    timestamp,
+    extradata,
+    prev_randao,
+    0x0000000000000000, # nonce
+    base_fee_per_gas,
+    withdrawals_root,
+    blob_gas_used,
+    excess_blob_gas,
+    parent_beacon_block_root,
+    target_blobs_per_block,  # new 64-bit unsigned
+])
+```
+
+The `target_blobs_per_block` is a 64-bit unsigned integer encoded in RLP using the minimal big-endian representation (consistent with other 64-bit header fields).
+
 Validity of the `target_blobs_per_block` is guaranteed from the consensus layer, much like how withdrawals are handled.
 
 When verifying a block, execution clients **MUST** ensure the target blob count in the block header matches the one
 provided by the consensus client.
 
-For a genesis block with no existing parent, the value should be set according to the agreed specification for the
-target blob count given by that genesis block's protocol rule set.
+For the first post-fork block, `parent.blob_gas_used` and `parent.excess_blob_gas` are evaluated as `0` as in EIP-4844, and the parent’s `target_blobs_per_block` is provided by the consensus layer and committed in the parent header per the RLP encoding above.
 
 ### Block processing
 
@@ -100,6 +131,8 @@ Otherwise, the specification of EIP-4844 is not changed. For example, blob base 
 The Engine API is extended to provide both the `target_blobs_per_block` and the `max_blobs_per_block` when the CL requests the EL to construct a payload for proposal.
 
 These values should be used to ensure the correct number of blobs are included in any constructed payload, and to ensure that the blob base fee accounting is correctly computed.
+
+Additionally, `ExecutionPayload`/`ExecutionPayloadHeader` are extended to include `target_blobs_per_block`. Consensus clients **MUST** provide this value to execution clients via Engine API, and execution clients **MUST** set and serialize it at the end of the header per the RLP encoding above.
 
 ## Rationale
 


### PR DESCRIPTION
This change specifies the exact RLP encoding of the execution header when introducing target_blobs_per_block, placing the new uint64 field at the end of the header after parent_beacon_block_root in line with how other EIPs extend the header (e.g., EIP-4788, EIP-7591). It clarifies the type and minimal big-endian RLP encoding, aligns “first post-fork block” terminology with EIP-4844 initialization rules, and states the Engine API/serialization invariant that consensus clients must provide target_blobs_per_block and execution clients must serialize it per the defined RLP layout. These additions remove ambiguity for implementers and ensure deterministic serialization and cross-client compatibility.