### PR TITLE
Website: Update head.html

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -47,9 +47,12 @@
   <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.6/dist/umd/popper.min.js" integrity="sha384-oBqDVmMz9ATKxIep9tiCxS/Z9fNfEXiDAYTujMAeBAsjFuCZSmKbSSUnQlmh/jp3" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.min.js" integrity="sha384-Rx+T1VzGupg4BHQYs2gCW9It+akI2MM/mndMCy36UVfodzcJcF0GGLxZIzObiEfa" crossorigin="anonymous"></script>
   <script type="text/javascript">
-    document.addEventListener("DOMContentLoaded", (event) => {
+    document.addEventListener("DOMContentLoaded", () => {
       const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]')
-      const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl))
+      Array.prototype.forEach.call(
+        tooltipTriggerList,
+        tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl)
+      )
     });
   </script>
   <script type="text/javascript">
@@ -70,7 +73,10 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/citation-js/0.6.7/citation.min.js" integrity="sha512-N+LDFMa9owHXGS+CyMrBvuxq2QuGl3fiB/7cys3aUEL7K6P1soHGqsS0sjHXZpwNd9Kz0m3R4IPy1HYRi6ROEQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script type="text/javascript">
     addEventListener('DOMContentLoaded', async () => {
-      const Cite = window.require('citation-js');
+      const Cite = window.Cite;
+      if (!Cite) {
+        return;
+      }
       const citationElements = document.querySelectorAll('.language-csl-json');
       for (let citationElement of citationElements) {
         try {


### PR DESCRIPTION
drop the unused DOMContentLoaded callback argument in EIPs/_includes/head.html,iterate tooltip triggers in place instead of creating a throwaway array, rely on window.Cite and short-circuit if citation-js failed to load, preventing runtime errors