### PR TITLE
Fix DepositTreeSnapshot finalized type annotation

### DIFF
--- a/assets/eip-4881/deposit_snapshot.py
+++ b/assets/eip-4881/deposit_snapshot.py
@@ -7,7 +7,7 @@ from eip_4881 import DEPOSIT_CONTRACT_DEPTH,Hash32,sha256,to_le_bytes,zerohashes
 
 @dataclass
 class DepositTreeSnapshot:
-    finalized: List[Hash32, DEPOSIT_CONTRACT_DEPTH]
+    finalized: List[Hash32]
     deposit_root: Hash32
     deposit_count: uint64
     execution_block_hash: Hash32


### PR DESCRIPTION
remove the illegal second generic argument from DepositTreeSnapshot.finalized, keep the field typed as List[Hash32] so static analyzers stop erroring