### PR TITLE
Update EIP-7942: correct protocol changes count to four

### DIFF
--- a/EIPS/eip-7942.md
+++ b/EIPS/eip-7942.md
@@ -78,7 +78,7 @@ Ethereum now has approximately $2^{20}$ validators. The maximum desirable probab
 
 ### Protocol Changes
 
-We make three main changes:
+We make four main changes:
 
 1. **Modify the selection rule of parent.** As mentioned in the overview, we require that a block $b$ in slot $t$ must include $\vartheta+1$ attestations to prove that the parent of block $b$ is a valid output in slot $t-1$. Therefore, the parent of block $b$ is the $AA_{t-1}$. Such a block is a stable block. If no $AA_{t-1}$ exists, the parent of block $b$ is the output of the fork choice rule. Such a block is an unstable block.
 


### PR DESCRIPTION
The section “Protocol Changes” stated there were three changes but listed four. Updated the lead-in to “four” to align with the enumerated items and avoid confusion for reviewers and implementers.