### PR TITLE
Update EIP-8061: remove the overlap with EIP-8080

### DIFF
--- a/EIPS/eip-8061.md
+++ b/EIPS/eip-8061.md
@@ -1,7 +1,7 @@
 ---
 eip: 8061
 title: Increase exit and consolidation churn
-description: Increase the exit and consolidation churn, let exits use consolidation churn and create a separate consolidation churn limit parameter.
+description: Increase the exit and consolidation churn and create a separate consolidation churn limit parameter.
 author: Francesco D'Amato (@fradamt), Anders Elowsson (@anderselowsson)
 discussions-to: https://ethereum-magicians.org/t/eip-8061-increase-churn-limits/25991
 status: Draft
@@ -13,12 +13,12 @@ requires: 7521
 
 ## Abstract
 
-This EIP roughly doubles the consolidation churn, as well as quadrupling the exit churn and restoring its proportionality to total stake (though maintaining the existing cap on activations). Moreover, it routes exits through the consolidation queue when it is shorter than the exit queue (but not viceversa!), increasing the maximum exit throughput by another 75%. The choice of parameters balances maintaining a sufficiently long weak subjectivity period (~7 days, roughly halving the current period) with achieving two goals: allowing for faster consolidation of the validator set, in turn accelerating the timeline to faster finality, and relieving exit queue congestion, improving staking liquidity.
+This EIP roughly doubles the consolidation churn, as well as quadrupling the exit churn and restoring its proportionality to total stake (though maintaining the existing cap on activations). The choice of parameters balances maintaining a sufficiently long weak subjectivity period (~7 days, roughly halving the current period) with achieving two goals: allowing for faster consolidation of the validator set, in turn accelerating the timeline to faster finality, and relieving exit queue congestion, improving staking liquidity.
 
 ## Motivation
 
 [EIP-7514](./eip-7514.md) introduced an activation cap of 8 validators per epoch (now 256 ETH per epoch) to prevent overly rapid validator set growth. [EIP-7251](./eip-7251.md) extended this cap to exits, to make room for the newly introduced consolidation operations, without increasing the weak subjectivity period. However, the fixed cap prevents the exit churn limit from being proportional to total stake, which, all else being equal, leads to longer queues as stake grows. Moreover, the 
-`CHURN_LIMIT_QUOTIENT` is set quite conservatively in the first place, requiring more than 3 months for 1/3 of the validator set to exit, a time which is now be more than doubled due to the cap. Recent episodes have stressed for more headroom to improve liquidity and staking user experience, as the exit queue has stretched beyond forty days as a consequence of the mass exit of Kiln validators. Long queues degrade user experience, and slow operator response to market or operational events. They also reduce the network’s ability to reconfigure stake more quickly after adverse events, for example to regain finality by having a large amount of stake exit (a double-edged sword, as preventing double finality is the reason these queues exist in the first place, as discussed in the security section). Finally, solo stakers are arguably the participants that suffer the most from a lack of liquidity today, as they do not have the ability to issue a liquid staking token or maintain liquidity reserves.
+`CHURN_LIMIT_QUOTIENT` is set quite conservatively in the first place, requiring more than 3 months for 1/3 of the validator set to exit, a time which is now be more than doubled due to the cap. Recent episodes have stressed for more headroom to improve liquidity and staking user experience, as the exit queue has stretched beyond forty days as a consequence of the mass exit of Kiln validators. Long queues degrade user experience, and slow operator response to market or operational events. They also reduce the network’s ability to reconfigure stake more quickly after adverse events, for example to regain finality by having a large amount of stake exit (a double-edged sword, as preventing double finality is the reason these queues exist in the first place, as discussed in the security section). Finally, centralized forms of staking are those that (in relative terms) benefit the most from a lack of liquidity today, as they have the ability to issue a liquid staking token, maintain liquidity reserves or more generally build products that get around the limitations of the protocol.
 
 The conservative setting of the `CHURN_LIMIT_QUOTIENT` affects consolidations as well. Increasing the consolidation churn limit can shorten the path to a smaller validator set and, in turn, the path to a protocol with much faster finality. Under today’s parameters, even the best-case timelines are long: using only activations and exits, fully saturated around the clock, shrinking the roughly 32M ETH of 0x01 stake would take on the order of ~1.5 years; a fully saturated consolidation queue would still take ~1.3 years. Moreover, deposit capacity is also needed for new stake and is thus far from guaranteed to be available for consolidations, as evidenced by the recent inflow of > 1M ETH, fully occupying the queue for ~20 days.
 
@@ -27,7 +27,6 @@ The EIP proposes to address these issues by:
 - removing the cap on exits, restoring the proportionality of exit churn limit to total stake
 - increasing the churn limit on exits
 - introducing a separate consolidation churn limit, since there is no more "excess churn" from having an exit cap, and increase it compared to the current (implicitly defined) one. This also lets us more independently adjust it in the future, for example to increase it if we want to allow for faster consolidation of the validator set or decrease it when this process has already run its course.
-- allowing exits to use the consolidation queue whenever `earliest_consolidation_epoch < earliest_exit_epoch`, so that the consolidation churn is not wasted even when consolidations are not much in use. This lets us use the allocated churn more efficiently, greatly increasing the maximum exit throughput, while not harming the cause of shrinking the validator set size, since exits do that too. Moreover, it is already possible to route exits through the consolidation queue, due to a a loophole in the consolidation logic, which [EIP-8071](./eip-8071.md) proposes to fix. Democratizing this feature is useful and arguably even simpler than EIP-8071.
 
  The EIP does *not* propose to lift the cap on the deposit churn, as part of the motivation for introducing it in [EIP-7514](./eip-7514.md) still holds today: though *active validator set* growth is mostly solved by [EIP-7251](./eip-7251.md), the *validator array in the BeaconState* (including inactive validators) is very large and still growing, and too rapid *stake* growth continues to be a concern as well.
 
@@ -47,7 +46,7 @@ The `CHURN_LIMIT_QUOTIENT` is halved, from `2**16` to `2**15`, and fully dedicat
 
 ### Churn computations
 
-Due to the intended asymmetry in activation and exit churn, we replace `get_activation_exit_churn_limit` with `get_activation_churn_limit`, capped at  `MAX_PER_EPOCH_ACTIVATION_CHURN_LIMIT`, and `get_exit_churn_limit`, uncapped. `get_consolidation_churn_limit` uses the new `CONSOLIDATION_CHURN_LIMIT_QUOTIENT`, without either a minimum or a maximum value. 
+Due to the intended asymmetry in activation and exit churn, we replace `get_activation_exit_churn_limit` with `get_activation_churn_limit`, capped at  `MAX_PER_EPOCH_ACTIVATION_CHURN_LIMIT`, and `get_exit_churn_limit`, uncapped. `get_consolidation_churn_limit` uses the new `CONSOLIDATION_CHURN_LIMIT_QUOTIENT`, without either a minimum or a maximum value.
 
 ```python
 def get_activation_churn_limit(state: BeaconState) -> Gwei:
@@ -73,8 +72,7 @@ def get_exit_churn_limit(state: BeaconState) -> Gwei:
 
 def get_consolidation_churn_limit(state: BeaconState) -> Gwei:
     """
-    Per-epoch churn limit for consolidations (EIP-7521), rounded to
-    EFFECTIVE_BALANCE_INCREMENT. Can also be used by exits.
+    Per-epoch churn limit for consolidations (EIP-7521), rounded to EFFECTIVE_BALANCE_INCREMENT.
     """
     churn = get_total_active_balance(state) // CONSOLIDATION_CHURN_LIMIT_QUOTIENT
     return churn - churn % EFFECTIVE_BALANCE_INCREMENT
@@ -91,7 +89,7 @@ def compute_weak_subjectivity_period(state: BeaconState) -> uint64:
     """
     t = get_total_active_balance(state)
     delta = (
-        2 * get_activation_exit_churn_limit(state) // 3 # effect of exit churn
+        2 * get_exit_churn_limit(state) // 3 # effect of exit churn
         + get_activation_churn_limit(state) // 3 # effect of activation churn
         + get_consolidation_churn_limit(state) # effect of consolidation churn
     )
@@ -165,17 +163,15 @@ def process_pending_deposits(state: BeaconState) -> None:
 
 ### Exit processing
 
-We replace `get_activation_exit_churn_limit` with `get_exit_churn_limit`. Moreover, we route exits through the consolidation queue whenever `state.earliest_exit_epoch > state.earliest_consolidation_epoch`, by using `compute_consolidation_epoch_and_update_churn`. Note that the `exit_balance` passed to the latter is `2 * exit_balance // 3`, because each unit of exit churn corresponds to 2/3 units of consolidation churn from a weak subjectivity perspective. This way, we keep the weak subjectivity impact of the consolidation queue the same regardless of whether it is used by consolidations or by exits.
+We replace `get_activation_exit_churn_limit` with `get_exit_churn_limit`.
 
 ```python
 def compute_exit_epoch_and_update_churn(state: BeaconState, exit_balance: Gwei) -> Epoch:
-    if state.earliest_exit_epoch > state.earliest_consolidation_epoch:
-        return compute_consolidation_epoch_and_update_churn(state, 2 * exit_balance // 3)
-
     earliest_exit_epoch = max(
         state.earliest_exit_epoch,
         compute_activation_exit_epoch(get_current_epoch(state))
     )
+    # [Modified in Gloas:EIP-8061]
     per_epoch_churn = get_exit_churn_limit(state)
     # New epoch for exits.
     if state.earliest_exit_epoch < earliest_exit_epoch:
@@ -202,8 +198,7 @@ def compute_exit_epoch_and_update_churn(state: BeaconState, exit_balance: Gwei) 
 - **Independent parameters:** a separate churn consolidation is easy to independently tune, in particular adjusted upward if we want to speed up the consolidation process further, and later downward, when the primary wave of validator set consolidation has already happened and the consolidation operation becomes less crucial. 
 - **Scaling with stake**: the exit churn regains proportionality to the total stake, and the consolidation churn maintains it.
 - **Preserving the activation cap**: the activation churn limit maintains the cap from [EIP-7514](./eip-7514.md)
-- **Efficient consolidation churn utilization**: allowing exits to use the consolidation queue when it is shorter than the exit queue ensures that consolidation churn is not wasted when consolidations are not in high demand. With the current parameters, this increases the maximum exit throughput by 75% beyond the base increase, while not impeding the goal of shrinking the validator set size. The conversion factor of $2/3$ preserves the weak subjectivity impact regardless of whether the consolidation queue is used by consolidations or exits.
-- **Balancing security and functionality**: the exit churn limit is increased by ~4x compared to the current cap, and exactly 2x compared to previous uncapped version, while the consolidation churn limit is increased by ~2x. Moreover, the maximum exit throughput increases by a further 75% when we include routing through the consolidation queue, for a total increase of ~7x. Activations remain capped at the existing limit. As we see later in more detail, accounting for the asymmetric impact of exits and activations on safety degradation, this results in a decrease of the weak subjectivity period from ~15.7 days to ~7 days (see detailed calculations below), or ~6 days if we were to later remove the activation cap, in either case still on the order of a week. Moreover, were consolidations to be removed later, the weak subjectivity period would go up to ~11 days, or ~8.4 days without the activation cap.
+- **Balancing security and functionality**: the exit churn limit is increased by ~4x compared to the current cap, and exactly 2x compared to previous uncapped version, while the consolidation churn limit is increased by ~2x. Activations remain capped at the existing limit. As we see later in more detail, accounting for the asymmetric impact of exits and activations on safety degradation, this results in a decrease of the weak subjectivity period from ~15.7 days to ~7 days (see detailed calculations below), or ~6 days if we were to later remove the activation cap, in either case still on the order of a week. Moreover, were consolidations to be removed later, the weak subjectivity period would go up to ~11 days, or ~8.4 days without the activation cap.
 
 ## Backwards Compatibility
 
@@ -256,9 +251,6 @@ Other possible future scenarios are:
 - Consolidations disabled and activation cap removed: $\textbf{WS} \approx \mathbf{8.4\ \text{days}}$ ($\text{WS}_{\text{epochs}} \approx 1894$)
 
 Note that removing the activation cap only reduces the weak subjectivity period by one day, and leaves it on the order of a week. The current parameters might then also be considered acceptable in a future where it is decided to remove the activation cap.
-
-
-
 
 ## Copyright
 


### PR DESCRIPTION
Removes the feature of allowing exits to use the consolidation queue, which has been pulled out into EIP-8080