### PR TITLE
Add EIP: Increase Gas Cost of Point Evaluation

### DIFF
--- a/EIPS/eip-8096.md
+++ b/EIPS/eip-8096.md
@@ -21,11 +21,7 @@ Currently the `point evaluation` precompile is underpriced relative to its resou
 
 ## Specification
 
-Upon activation of this EIP, the gas cost of calling the precompile at address `0x000000000000000000000000000000000000000A` will be doubled from `50_000` gas to `100_000` gas.
-
-Important notice: while increasing the gas cost of `point evaluation` precompile is necessary for enabling potential increases in the block gas limit, new cost equal `100_000` is not a final value and can be adjusted based on new pricings of other opcodes and precompiles.
-
-<-- TODO -->
+Upon activation of this EIP, the gas cost of calling the precompile at address `0x000000000000000000000000000000000000000A` will be tripled from `50_000` gas to `150_000` gas.
 
 ## Rationale
 


### PR DESCRIPTION
This EIP is modifying the gas cost of point evaluation precompile introduced in [EIP-4844](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-4844.md).

Currently the `point evaluation` precompile is underpriced relative to its resource consumption. This EIP aims to address these discrepancies by adjusting the gas cost and making `point evaluation` precompile sufficiently efficient to enable potential further increases in the block gas limit.