### PR TITLE
Update EIP-7928: Clarify gas accounting sequence for BALs

### DIFF
--- a/EIPS/eip-7928.md
+++ b/EIPS/eip-7928.md
@@ -97,6 +97,7 @@ It **MUST** include:
   
     - Targets of `BALANCE`, `EXTCODESIZE`, `EXTCODECOPY`, `EXTCODEHASH` opcodes
     - Targets of `CALL`, `CALLCODE`, `DELEGATECALL`, `STATICCALL` (even if they revert)
+    - Note: For call operations (`CALL`, `CALLCODE`, `DELEGATECALL`, `STATICCALL`), the target address is only included in the BAL if gas checks (memory expansion, access cost, transfer cost) pass; if gas shortage causes the operation to fail before state access, the target address MUST NOT be included.
     - Target addresses of `CREATE`/`CREATE2` (even when creation fails)
     - Transaction sender and recipient addresses (even for zero-value transfers)
     - COINBASE address when receiving transaction fees


### PR DESCRIPTION
The clarification defines when call-operation target addresses (CALL, CALLCODE, DELEGATECALL, STATICCALL) should be added to the Block Access List. Target addresses are included only if all gas checks - memory expansion, access cost, and transfer cost - succeed. If the call fails due to insufficient gas before any state access occurs, the address must not be added.

This resolves discrepancies observed during testing, where clients differed on whether to insert addresses into the BAL when calls failed early. Some implementations accessed state (and thus added the address) before performing gas checks, while others evaluated gas first. The clarification enforces a consistent rule: gas checks must be performed before any state access, ensuring that an address is never added to the BAL when gas shortage prevents the call from reaching a state access.

Related discussion:
https://discord.com/channels/595666850260713488/1445508120972628079/1445508124890103849