### PR TITLE
Update EIP-7762: correct doubling rate

### DIFF
--- a/EIPS/eip-7762.md
+++ b/EIPS/eip-7762.md
@@ -62,7 +62,7 @@ def validate_block(block: Block) -> None:
 
 The current MIN_BASE_FEE_PER_BLOB_GAS is 1 wei. This is many orders of magnitude lower than the prevailing price of blobs when blobs enter price discovery. Whenever demand for blobs exceeds supply, blobs enter price discovery, but traversing the 8 orders of magnitude between 1 wei and the point where elasticity of demand starts to decrease takes a long time.
 
-The blob base fee can at most double every $\log_{1.125}(10) = 5.885$ blocks when blocks use all available blob space. When blobs enter price discovery, they must climb many factors of 2 to reach the prevailing price.
+The blob base fee can at most double every $\log_{1.125}(2) \approx 5.886$ blocks when blocks use all available blob space. When blobs enter price discovery, they must climb many factors of 2 to reach the prevailing price.
 
 To set the parameter appropriately, one approach is to look at the cost of simple transfers when base fees are low. The cost of a simple transfer when the base fee is 1 GWEI  is ~5 cents USD at today's prices (2,445.77$ ETH/USDC). We can try to peg the minimum price of a blob to that. Today, to reach this price, it requires an excess blob gas of `63070646`. When you calculate how long this would take to reach from 0 excess blob gas, you get:
 


### PR DESCRIPTION
The text said “double every log_{1.125}(10) = 5.885 blocks”, which mixed doubling (×2) with a log argument for ×10. The 5.885 value actually corresponds to log_{1.125}(2). Updated the statement to “double every log_{1.125}(2) ≈ 5.886 blocks,” consistent with EIP-4844’s per-block growth cap (~1.125×) and the surrounding rationale that discusses climbing in factors of 2.