### PR TITLE
Update EIP-8077: Fix typo

### DIFF
--- a/EIPS/eip-8077.md
+++ b/EIPS/eip-8077.md
@@ -17,12 +17,12 @@ This EIP improves mempool propagation, extending the devp2p 'eth' protocol's `Ne
 
 ## Motivation
 
-Transactions are propagated in the Mempool using the devp2p protocol in two modalities. Eager push is only used for small transactions, and only towards a few nodes, while the rest of nodes receive only announcements. For large transactions and for type 3 transactions, only announcements are sent. This announcement is made using the `NewPooledTransactionHashes` message, which only contains the hash, the type and the size of each transaction. As it is now, the receiver of the announcement does not have enough information to make intelligent scheduling choices. This crates several issues:
+Transactions are propagated in the Mempool using the devp2p protocol in two modalities. Eager push is only used for small transactions, and only towards a few nodes, while the rest of nodes receive only announcements. For large transactions and for type 3 transactions, only announcements are sent. This announcement is made using the `NewPooledTransactionHashes` message, which only contains the hash, the type and the size of each transaction. As it is now, the receiver of the announcement does not have enough information to make intelligent scheduling choices. This creates several issues:
 
-- the receiver of the announcement can only base its logic on the order of announcements, but if it schedules requests to different peers, it can easily end up pulling transactions that leave a nonce gap in it's own view of the mempool, making the pulled transaction non-includable,
+- the receiver of the announcement can only base its logic on the order of announcements, but if it schedules requests to different peers, it can easily end up pulling transactions that leave a nonce gap in its own view of the mempool, making the pulled transaction non-includable,
 - filling existing gaps is hard, since in the absence of sender/nonce information it can only be done with trial and error, requesting more transactions of missing hashes,
 - to filter out old transaction announcements, the node has to keep a cache of all transaction hashes on chain, instead of simply checking the nonce against current chain state,
-- receivers have no way to selectively request transactions with specific source addresses, which would be important UX and L2s. 
+- receivers have no way to selectively request transactions with specific source addresses, which would be important for UX and L2s. 
 
 Moreover, as we are increasing the throughput of block building, it is more and more probable that we end up in a state where nodes can't fetch all transactions. This extension allows nodes to do selective fetching and gap filling while keeping a consistent state of their own view of the mempool without nonce gaps.
 
@@ -44,11 +44,11 @@ At the receiver side of `NewPooledTransactionHashes` messages the extra informat
 
 ## Rationale
 
-To solve the transaction propagation issues mentioned in the Motivation section, nodes require more information about a transaction then its hash, size, and type. By adding the source and the nonce, the receiver has enough information to make better fetch decisions.
+To solve the transaction propagation issues mentioned in the Motivation section, nodes require more information about a transaction than its hash, size, and type. By adding the source and the nonce, the receiver has enough information to make better fetch decisions.
 
 ### Overhead
 
-The modification adds a significant overhead to announcements by adding a B_20 and a variable size filed to the current B_32, size, and type fields. We think this overhead is worth
+The modification adds a significant overhead to announcements by adding a B_20 and a variable size field to the current B_32, size, and type fields. We think this overhead is worth
 the additional gain in protocol efficiency. Details TBD.
 
 ### Alternatives
@@ -64,7 +64,7 @@ implementation is to send announcements to all neighbors (except the ones that a
 
 Currently, for any given transaction, nodes receive announcements from many peers. About half of their peers, on average. Having the whole metadata (txhash, type, size, source, nonce) in all these is highly redundant. We could remove some of this overhead, e.g. by having a probabilistic choice between a simple announcement and a detailed announcement. The gain however seems marginal compared to the added complexity. 
 
-Finally, sending the source and the nonce opens up the possibility of a design variant where the transaction identifier in the announcements is based on these values, and not on the txhash. More specifically, a transaction could be identified by the source, the nonce, and an extra version number signaling the RBF (replace-by-fee) version in the given source/nonce scope. This variant would require deeper changes since the RBF version would need to be signed, so we prefer the simpler version that relies both the txhash and the source/nonce, without introducing an RBF version.
+Finally, sending the source and the nonce opens up the possibility of a design variant where the transaction identifier in the announcements is based on these values, and not on the txhash. More specifically, a transaction could be identified by the source, the nonce, and an extra version number signaling the RBF (replace-by-fee) version in the given source/nonce scope. This variant would require deeper changes since the RBF version would need to be signed, so we prefer the simpler version that relies on both the txhash and the source/nonce, without introducing an RBF version.
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
 ### Description
This pull request introduces minor textual revisions to EIP-8077 to improve its clarity and grammatical correctness.
 
 ### Motivation
 Accurate and precise language is crucial for technical specifications. The identified issues, including typos and grammatical inconsistencies, could potentially lead to misinterpretations or diminish the document's professional standing. This update ensures the EIP is presented clearly and effectively.
 ### Changes
   *   Corrected typos (`crates` to `creates`, `filed` to `field`).
   *   Addressed grammatical errors (e.g., `it's` to `its`, `then` to `than` for comparisons, preposition usage).

### Impact
These changes enhance the readability and professionalism of EIP-8077 without altering its technical content or specification.