### PR TITLE
Update EIP-8071: Fix typos and grammar in EIP-8071

### DIFF
--- a/EIPS/eip-8071.md
+++ b/EIPS/eip-8071.md
@@ -26,7 +26,7 @@ Even though this is a UX rather than security issue, consolidation queue was nev
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119) and [RFC 8174](https://www.rfc-editor.org/rfc/rfc8174).
 
-Starting from the beginning of the epoch when this EIP is activated, Consensus Layer client **MUST** use modified `process_consolidation_request` function which code is outlined below.
+Starting from the beginning of the epoch when this EIP is activated, Consensus Layer client **MUST** use the modified `process_consolidation_request` function which code is outlined below.
 
 ### New `get_pending_balance_to_consolidate`
 
@@ -42,7 +42,7 @@ def get_pending_balance_to_consolidate(state: BeaconState, target_index: Validat
 
 ### Modified `process_consolidation_request`
 
-*Note*: This function is extended with the check of the target's balance after consolidation and cancels consolidation request if the balance exceedes the max effective balance.
+*Note*: This function is extended with the check of the target's balance after consolidation and cancels consolidation request if the balance exceeds the max effective balance.
 
 ```python
 def process_consolidation_request(
@@ -133,7 +133,7 @@ def process_consolidation_request(
 
 ## Rationale
 
-### Iterating over pending consolidaitons
+### Iterating over pending consolidations
 
 The new design introduces an iteration over pending consolidations which increases complexity of consolidation processing.
 
@@ -158,8 +158,8 @@ All of the above test cases are implemented [here](../assets/eip-8071/test_proce
 
 ## Security Considerations
 
-When consolidation reuqest results in max effective balance exceed it is cancelled on the Consensus Layer,
-neither request fee nor transaction gast cost are refunded in this case.
+When consolidation request results in max effective balance exceeded, it is cancelled on the Consensus Layer,
+neither request fee nor transaction gas cost are refunded in this case.
 
 ## Copyright
 


### PR DESCRIPTION
### Description
This PR corrects multiple spelling errors (e.g., `consolidaitons`, `reuqest`, `gast`) and grammatical issues in EIP-8071.
 ### Motivation
The presence of typos and grammatical errors in a Standards Track EIP detracts from its professionalism and readability. Correcting these ensures the specification is polished and clear for implementers a reviewers.
 ### Changes
 *   Fixed typos: `consolidaitons` -> `consolidations`, `reuqest` -> `request`, `gast` -> `gas`.
 *   Corrected grammar: `exceed` -> `exceeded`, added missing articles.