### PR TITLE
Update EIP-7778: Clarify receipts gas_used

### DIFF
--- a/EIPS/eip-7778.md
+++ b/EIPS/eip-7778.md
@@ -33,7 +33,7 @@ This mechanism can be exploited to perform more operations in a block than the g
 1. **User Gas Costs (Unchanged):**
    - Users continue to receive gas refunds for operations that qualify (e.g., setting storage to zero)
    - The transaction gas cost remains: `tx.gas_used = gas_used - gas_refund`
-   - Note: Since receipts store the post-refund gas_used value, validating block gas limits using receipts requires tracking refunds during transaction execution and adding them back to each transaction's gas_used when computing cumulative block gas usage
+   - Note: Since receipts store the post-refund `gas_used` value, validating block gas limits using receipts requires tracking refunds during transaction execution and adding them back to each transaction's `gas_used` when computing cumulative block gas usage
 
 2. **Block Gas Accounting (Modified):**
    - When calculating gas for block gas limit enforcement, refunds are not subtracted


### PR DESCRIPTION
The `gas_used` in receipts is the value after applying the refund.