### PR TITLE
Update EIP-8072: Fix specification inconsistencies in EIP-8072

### DIFF
--- a/EIPS/eip-8072.md
+++ b/EIPS/eip-8072.md
@@ -16,7 +16,7 @@ This EIP extends the existing `eth_subscribe` JSON-RPC method with a new subscri
 
 ## Motivation
 
-Current transaction submission workflows require separate calls to `eth_sendRawTransaction` followed by repeated polling of `eth_getTransactionReceipt`, creating unnecessary latency and network overhead. While [EIP-7966](eip-7966.md) proposes `eth_sendRawTransactionSync` to address this through a synchronous blocking approach, blocking HTTP connections presents significant drawbacks:
+Current transaction submission workflows require separate calls to `eth_sendRawTransaction` followed by repeated polling of `eth_getTransactionReceipt`, creating unnecessary latency and network overhead. While [EIP-7966](./eip-7966.md) proposes `eth_sendRawTransactionSync` to address this through a synchronous blocking approach, blocking HTTP connections presents significant drawbacks:
 
 - **Connection hogging**: Each transaction blocks one HTTP connection until confirmation or timeout
 - **Limited scalability**: Cannot efficiently monitor multiple transactions over a single connection
@@ -122,7 +122,7 @@ When the transaction status changes, the node MUST send a notification:
 The `status` field MAY be one of:
 
 - `"included"`: Transaction has been included in a block
-- `"finalized"`: Transaction's block has reached finality (only sent when `includeReorgs` is `false`)
+- `"finalized"`: Transaction's block has reached finality (only sent when `includeReorgs` is `true`)
 - `"reorged"`: Transaction was removed from the canonical chain (only sent if `includeReorgs` is `true`)
 
 The `receipt` field MUST contain the complete transaction receipt object as defined by `eth_getTransactionReceipt`.
@@ -159,7 +159,7 @@ The node MUST implement the following behavior:
    - The node SHOULD send an `eth_subscription` unsubscribe confirmation
 
 6. **Transaction Not Found**:
-   - If monitoring a transaction by `txHash` that doesn't exist in the mempool or chain, the subscription remains active
+   - If monitoring a transaction by `hash` that doesn't exist in the mempool or chain, the subscription remains active
    - The node SHOULD monitor for the transaction appearing in the future
    - Clients MAY manually unsubscribe if desired
 


### PR DESCRIPTION
 Fixed two specification inconsistencies in EIP-8072:

  1. **Line 125**: Corrected logic error where `"finalized"` status was documented as sent when `includeReorgs` is
  `false`, but according to the behavior specification (lines 147, 158), subscriptions with `includeReorgs: false`
  auto-unsubscribe after first inclusion and never reach finalization. Changed to `includeReorgs` is `true`, which
  matches the implementation flow in lines 154-155.

  2. **Line 162**: Fixed parameter name from `txHash` to `hash` to match the parameter definition in line 69 of the
  specification (`hash: DATA, 32 bytes`).