### PR TITLE
Update EIP-8075: use tx variable inside validate_block loop

### DIFF
--- a/EIPS/eip-8075.md
+++ b/EIPS/eip-8075.md
@@ -143,9 +143,9 @@ def validate_block(block: Block) -> None:
         ...
 
         # Transaction execution returns a gas_used vector and refund_vector
-        gas_used, regular_gas_used, state_bytes = self.execute_transaction(transaction, effective_gas_price)
+        gas_used, regular_gas_used, state_bytes = self.execute_transaction(tx, effective_gas_price)
         # The gas refund stays the same, the transaction gas counter only counts regular gas without refunds
-        gas_refund = transaction.gas_limit - gas_used
+        gas_refund = tx.gas_limit - gas_used
         cumulative_transaction_gas_used += regular_gas_used
         # Update the total state bytes created and cleared in the block
         state_bytes_created += state_bytes[0]


### PR DESCRIPTION
The pseudocode used an undefined variable name (transaction) inside the for tx in block.transactions: loop. This causes a scope/name error and diverges from the convention used in EIP-4844. Replace transaction with tx in the execute_transaction call and gas_refund computation to keep naming consistent and make the snippet implementable.