### PR TITLE
Update EIP-8072: fix parameter name

### DIFF
--- a/EIPS/eip-8072.md
+++ b/EIPS/eip-8072.md
@@ -314,7 +314,7 @@ This EIP is fully backwards compatible. It extends the existing `eth_subscribe` 
 
 A minimal reference implementation can be realized by:
 
-1. For `signedTransaction` parameter: Call internal `eth_sendRawTransaction` logic and capture the transaction hash
+1. For `transaction` parameter: Call internal `eth_sendRawTransaction` logic and capture the transaction hash
 2. Register the transaction hash in a subscription manager
 3. Monitor the transaction pool and canonical chain for the transaction
 4. When the transaction is included in a block, query the receipt and send notification


### PR DESCRIPTION
Align parameter naming with the Parameters section and examples. The spec and pseudocode consistently use `transaction`