### PR TITLE
fix: add missing gas parameter in TestDecLn

### DIFF
--- a/assets/eip-7543/decimal_float_test.go
+++ b/assets/eip-7543/decimal_float_test.go
@@ -300,7 +300,7 @@ func TestDecLn(t *testing.T) {
 		gas = 0
 		out.Ln(&tt.a, PRECISION, &tt.steps, &gas)
 
-		if !out.eq(&tt.b, PRECISION) {
+		if !out.eq(&tt.b, PRECISION, &gas) {
 			t.Fatal(tt.a, out, tt.b)
 		}
 	}


### PR DESCRIPTION
The eq() method requires 3 parameters but TestDecLn was calling itwith only 2. All other tests in the file correctly pass the gas parameter, this one was missing it.

This was a compilation error since Go doesn't support default parameters.