### PR TITLE
Update EIP-8080: Fix specification inconsistency in compute_exit_epoc…

### DIFF
--- a/EIPS/eip-8080.md
+++ b/EIPS/eip-8080.md
@@ -30,14 +30,17 @@ Starting from the beginning of the epoch when this EIP is activated, Consensus L
 
 ### Modified `compute_exit_epoch_and_update_churn`
 
-The only modification is this addition at the start of `compute_exit_epoch_and_update_churn`:
+The only modification is this addition at the start of `compute_exit_epoch_and_update_churn`, after computing the adjusted epoch values:
 
 ```python
-    if state.earliest_exit_epoch > state.earliest_consolidation_epoch:
+    activation_exit_epoch = compute_activation_exit_epoch(get_current_epoch(state))
+    earliest_exit_epoch = max(state.earliest_exit_epoch, activation_exit_epoch)
+    earliest_consolidation_epoch = max(state.earliest_consolidation_epoch, activation_exit_epoch)
+    if earliest_exit_epoch > earliest_consolidation_epoch:
         return compute_consolidation_epoch_and_update_churn(state, 2 * exit_balance // 3)
 ```
 
-In particular, we route exits through the consolidation queue whenever `state.earliest_exit_epoch > state.earliest_consolidation_epoch`, by using `compute_consolidation_epoch_and_update_churn`. Note that the `exit_balance` passed to the latter is only `2 * exit_balance // 3`, because each unit of exit churn corresponds to 2/3 units of consolidation churn from a weak subjectivity perspective. This way, we keep the weak subjectivity impact of the consolidation queue the same regardless of whether it is used by consolidations or by exits, maximizing the amount of operations we can process while keeping the same security guarantees.
+In particular, we route exits through the consolidation queue whenever the adjusted `earliest_exit_epoch > earliest_consolidation_epoch`, by using `compute_consolidation_epoch_and_update_churn`. Note that the `exit_balance` passed to the latter is only `2 * exit_balance // 3`, because each unit of exit churn corresponds to 2/3 units of consolidation churn from a weak subjectivity perspective. This way, we keep the weak subjectivity impact of the consolidation queue the same regardless of whether it is used by consolidations or by exits, maximizing the amount of operations we can process while keeping the same security guarantees.
 
 The full function is as follows:
 


### PR DESCRIPTION
 ## Summary
  Fixed inconsistency between the simplified modification description and the full implementation in the
  `compute_exit_epoch_and_update_churn` function.

  ## Changes
  - Updated the simplified modification (lines 35-41) to match the full implementation
  - Added missing variable computations (`activation_exit_epoch`, adjusted epoch values)
  - Clarified that the comparison uses adjusted epoch values, not raw state values
  - Added "adjusted" qualifier in the description to emphasize this distinction

  ## Rationale
  The previous simplified description compared `state.earliest_exit_epoch` with `state.earliest_consolidation_epoch`, but
  the full implementation compares the adjusted local variables after applying `max()`. This could mislead implementers
  who only read the simplified description.