### PR TITLE
Update EIP-8071: Fix balance type inconsistency in consolidation check

### DIFF
--- a/EIPS/eip-8071.md
+++ b/EIPS/eip-8071.md
@@ -35,8 +35,8 @@ def get_pending_balance_to_consolidate(state: BeaconState, target_index: Validat
     pending_balance_to_consolidate = Gwei(0)
     for pending_consolidation in state.pending_consolidations:
         if pending_consolidation.target_index == target_index:
-            source_validator = state.validators[pending_consolidation.source_index]
-            pending_balance_to_consolidate += source_validator.effective_balance
+            source_index = pending_consolidation.source_index
+            pending_balance_to_consolidate += state.balances[source_index]
     return pending_balance_to_consolidate
 ```
 
@@ -108,12 +108,12 @@ def process_consolidation_request(
     if get_pending_balance_to_withdraw(state, source_index) > 0:
         return
 
-    # [New in EIPXXXX]
+    # [New in EIP-8071]
     # Verify that the consolidating balance will
     # end up as active balance, not as excess balance
     target_balance_after_consolidation = (
         get_pending_balance_to_consolidate(state, target_index)
-        + source_validator.effective_balance
+        + state.balances[source_index]
         + state.balances[target_index]
     )
     if target_balance_after_consolidation > get_max_effective_balance(target_validator):


### PR DESCRIPTION
Fixed balance type inconsistency where the consolidation check mixed `effective_balance` and actual `balance`, leading
  to inaccurate calculations.

  ## Changes
  1. Modified `get_pending_balance_to_consolidate()` to return actual balance instead of effective balance
  2. Updated consolidation check to use `state.balances[source_index]` instead of `source_validator.effective_balance`
  3. Fixed placeholder `EIPXXXX` → `EIP-8071`

  ## Rationale
  When consolidations are processed, the full actual balance (not just effective balance) is transferred. To accurately
  prevent consolidations from being used as withdrawals, the check must sum all actual balances. Mixing balance types
  could underestimate the post-consolidation balance and allow excess balance to be withdrawn.