### PR TITLE
Update EIP-8071: Fix grammar errors

### DIFF
--- a/EIPS/eip-8071.md
+++ b/EIPS/eip-8071.md
@@ -66,7 +66,7 @@ def process_consolidation_request(
         return
 
     validator_pubkeys = [v.pubkey for v in state.validators]
-    # Verify pubkeys exists
+    # Verify pubkeys exist
     request_source_pubkey = consolidation_request.source_pubkey
     request_target_pubkey = consolidation_request.target_pubkey
     if request_source_pubkey not in validator_pubkeys:
@@ -108,7 +108,7 @@ def process_consolidation_request(
     if get_pending_balance_to_withdraw(state, source_index) > 0:
         return
 
-    # [New in EIP-8071]
+    # [New in EIPXXXX]
     # Verify that the consolidating balance will
     # end up as active balance, not as excess balance
     target_balance_after_consolidation = (
@@ -137,7 +137,7 @@ def process_consolidation_request(
 
 The new design introduces an iteration over pending consolidations which increases complexity of consolidation processing.
 
-This is done to handle the case when there are multiple consolidations with the same target and each of them doesn't exceed the max effective balance while all of them together does.
+This is done to handle the case when there are multiple consolidations with the same target and each of them doesn't exceed the max effective balance while all of them together do.
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
 Fixed two subject-verb agreement errors:
  - Line 69: `pubkeys exists` → `pubkeys exist`
  - Line 140: `all of them together does` → `all of them together do`