### PR TITLE
Update EIP-7928: Add updated BAL size analysis for 60M gas

### DIFF
--- a/EIPS/eip-7928.md
+++ b/EIPS/eip-7928.md
@@ -459,7 +459,7 @@ Block size impact (historical analysis):
 
 Smaller than current worst-case calldata blocks.
 
-An empirical analysis has been done [here](../assets/eip-7928/bal_size_analysis.md). An updated analysis for a 60 million block gas limit can be found [here](../ssets/eip-7928/bal_size_analysis_60m.md)
+An empirical analysis has been done [here](../assets/eip-7928/bal_size_analysis.md). An updated analysis for a 60 million block gas limit can be found [here](../assets/eip-7928/bal_size_analysis_60m.md)
 
 ### Asynchronous Validation
 

--- a/assets/eip-7928/bal_size_analysis_60m.md
+++ b/assets/eip-7928/bal_size_analysis_60m.md
@@ -65,24 +65,3 @@ Additional:
 | Per Hour (50 blocks) | 4.49 MB | 3.01 MB | 1.48 MB |
 | Per Day | 107.8 MB | 72.3 MB | 35.5 MB |
 | Per Year | 38.4 GB | 25.8 GB | 12.6 GB |
-
-### 4.2 Storage at Scale
-
-| TPS | WITH Reads | WITHOUT Reads | Savings |
-|-----|------------|---------------|---------|
-| 15 TPS | 38.4 GB | 25.8 GB | 12.6 GB |
-| 100 TPS | 256 GB | 172 GB | 84 GB |
-| 1,000 TPS | 2.56 TB | 1.72 TB | 840 GB |
-
-## 5. Reduction Patterns
-
-| Metric | Raw | Compressed |
-|--------|------|------------|
-| Mean | 34.5% | 32.7% |
-| Median | 34.8% | 32.8% |
-| Min | 21.5% | 19.1% |
-| Max | 47.0% | 46.0% |
-
-Notes:
-- Reductions are stable across blocks.
-- Reads compress slightly worse (1.81x vs 1.94x).


### PR DESCRIPTION
This adds an updated analysis using https://github.com/nerolation/eth-bal-analysis/tree/main for a 60m block gas limit.