### PR TITLE
Update EIP-8094: clarify blob validation tracking mechanism

### DIFF
--- a/EIPS/eip-8094.md
+++ b/EIPS/eip-8094.md
@@ -55,7 +55,7 @@ This is the response to GetPooledBlobs, returning the requested blobs. The items
 >
 > It is important to include all cell proofs to keep reconstruction CPU-efficient.
 
-The blobs must be in the same order as in the request, but it is OK to skip blobs which are not available. Since the recipient have to check that transmitted blob hashes correspond to the requested vhashes anyway, we can avoid sending the list of vhashes as part of this message. If some blobs are unavailable, the recipient may request them from other peers or wait for them to become available before considering the transaction complete.
+The blobs must be in the same order as in the request, but it is OK to skip blobs which are not available. Since the recipient have to check that transmitted blob hashes correspond to the requested vhashes anyway, we can avoid sending the list of vhashes as part of this message. If some blobs are unavailable, the recipient may request them from other peers. It is expected that nodes keep announced transactions and blobs around for a while, so such "skips" should not be frequent.
 
 > Note: Optionally, we could extend this message with a bitmap of sent/unsent blobs from the request, or with the list of vhashes sent. This information is redundant, but it can simplify processing on the receiver side.
 
@@ -67,7 +67,7 @@ EIP-4844 introduced the following:
 
 The above should be changed as follows:
 
-    Nodes MUST send (broadcast or send in NewPooledTransactionHashes) blob transaction **without** sidecars to their peers. Peers can then request blob content using `GetPooledBlobs` messages. Nodes MUST determine the expected number of blobs from the transaction's `blob_versioned_hashes` field and track received blobs by comparing received vhashes against this list. Nodes MUST NOT forward blob transactions before receiving and validating all blobs referenced in the transaction's `blob_versioned_hashes` field.
+    When a blob transaction is sent as part of a `Transactions` or `PooledTransactions` message, it MUST be sent without sidecar. Peers can then determine the list of referenced blobs from the transaction's `blob_versioned_hashes` field, and request blob content using `GetPooledBlobs` messages. Nodes MUST NOT forward (`Transactions` message) or announce (`NewPooledTransactionHashes` message) blob transactions before receiving and validating all their respective blobs.
 
 ## Rationale
 


### PR DESCRIPTION
### Fix
Clarifies how nodes track blob completion before forwarding blob transactions.
### Changes
- Nodes must use the transaction's blob_versioned_hashes field to determine expected blob count and track received blobs by comparing vhashes
- Added guidance for handling partially available blobs: recipients may request missing blobs from other peers or wait before considering the transaction complete