### PR TITLE
Update EIP-7979: fix test comments to use ENTERSUB

### DIFF
--- a/EIPS/eip-7979.md
+++ b/EIPS/eip-7979.md
@@ -271,7 +271,7 @@ _(Note: these tests are known to be outdated and incorrect.)_
 
 This should jump into a subroutine, back out and stop.
 
-Bytecode: `0x60045e005c5d` (`PUSH1 0x04, CALLSUB, STOP, BEGINSUB, RETURNSUB`)
+Bytecode: `0x60045e005c5d` (`PUSH1 0x04, CALLSUB, STOP, ENTERSUB, RETURNSUB`)
 
 |  Pc   |      Op     | Cost |   Stack   |   RStack  |
 |-------|-------------|------|-----------|-----------|
@@ -287,7 +287,7 @@ Consumed gas: `18`
 
 This should execute fine, going into one two depths of subroutines
 
-Bytecode: `0x6800000000000000000c5e005c60115e5d5c5d` (`PUSH9 0x00000000000000000c, CALLSUB, STOP, BEGINSUB, PUSH1 0x11, CALLSUB, RETURNSUB, BEGINSUB, RETURNSUB`)
+Bytecode: `0x6800000000000000000c5e005c60115e5d5c5d` (`PUSH9 0x00000000000000000c, CALLSUB, STOP, ENTERSUB, PUSH1 0x11, CALLSUB, RETURNSUB, ENTERSUB, RETURNSUB`)
 
 |  Pc   |      Op     | Cost |   Stack   |   RStack  |
 |-------|-------------|------|-----------|-----------|
@@ -306,7 +306,7 @@ Consumed gas: `36`
 This should fail, since the given location is outside of the code-range. The code is the same as previous example,
 except that the pushed location is `0x01000000000000000c` instead of `0x0c`.
 
-Bytecode: `0x6801000000000000000c5e005c60115e5d5c5d` (`PUSH9 0x01000000000000000c, CALLSUB, STOP, BEGINSUB, PUSH1 0x11, CALLSUB, RETURNSUB, BEGINSUB, RETURNSUB`)
+Bytecode: `0x6801000000000000000c5e005c60115e5d5c5d` (`PUSH9 0x01000000000000000c, CALLSUB, STOP, ENTERSUB, PUSH1 0x11, CALLSUB, RETURNSUB, ENTERSUB, RETURNSUB`)
 
 |  Pc   |      Op     | Cost |   Stack   |   RStack  |
 |-------|-------------|------|-----------|-----------|
@@ -335,7 +335,7 @@ Error: at pc=0, op=RETURNSUB: invalid retsub
 
 In this example. the CALLSUB is on the last byte of code. When the subroutine returns, it should hit the 'virtual stop' _after_ the bytecode, and not exit with error
 
-Bytecode: `0x6005565c5d5b60035e` (`PUSH1 0x05, JUMP, BEGINSUB, RETURNSUB, JUMPDEST, PUSH1 0x03, CALLSUB`)
+Bytecode: `0x6005565c5d5b60035e` (`PUSH1 0x05, JUMP, ENTERSUB, RETURNSUB, JUMPDEST, PUSH1 0x03, CALLSUB`)
 
 |  Pc   |      Op     | Cost |   Stack   |   RStack  |
 |-------|-------------|------|-----------|-----------|


### PR DESCRIPTION
The EIP-7979 specification and EIP-8013 consistently define the subroutine entry opcode as ENTERSUB, but the test bytecode comments still referred to BEGINSUB, inherited from older subroutine proposals (e.g. EIP-615). This patch updates the human-readable test comments to use ENTERSUB so that the examples match the normative specification and related EIPs