### PR TITLE
Update EIP-7966: align receipt waiting semantics with reference impl

### DIFF
--- a/EIPS/eip-7966.md
+++ b/EIPS/eip-7966.md
@@ -196,14 +196,13 @@ This EIP introduces a new RPC method and does not modify or deprecate any existi
 
 ## Reference Implementation
 
-A minimal reference implementation can be realized by wrapping existing `eth_sendRawTransaction` submission with a polling loop that queries `eth_getTransactionReceipt` at short intervals until a receipt is found or a timeout occurs. Polling intervals and timeout values can be tuned by node implementations to optimize performance.
+A minimal reference implementation can be realized by wrapping existing `eth_sendRawTransaction` submission with logic that waits for the corresponding transaction receipt until a timeout elapses. Implementations MAY either rely on event-driven receipt-availability notifications or poll `eth_getTransactionReceipt` at short intervals until a receipt is found or a timeout occurs. Polling intervals or notification strategies and timeout values can be tuned by node implementations to optimize performance.
 
 For example, in `reth`, we can implement the handler for `eth_sendRawTransactionSync` as follows.
 
 ```rust
 async fn send_raw_transaction_sync(&self, tx: Bytes, timeout_duration: Option<Duration>) -> RpcResult<OpTransactionReceipt> {
     const DEFAULT_TIMEOUT: Duration = Duration::from_secs(2);
-    const POLL_INTERVAL: Duration = Duration::from_millis(1);
     
     // Validate the timeout parameter
     let timeout_duration = match timeout_duration {


### PR DESCRIPTION
Align the EIP-7966 reference implementation text with the actual event-driven receipt waiting used in the Rust example and allow both notification-based and polling-based approaches in the spec. Remove the unused POLL_INTERVAL constant from the snippet to avoid suggesting a polling loop that is not actually implemented. This makes the document internally consistent and clearer for client implementers.

