### PR TITLE
Update EIP-7748: correct storage conversion phase handling

### DIFF
--- a/EIPS/eip-7748.md
+++ b/EIPS/eip-7748.md
@@ -177,7 +177,7 @@ def state_convert(state: State, stride: int):
             state._conversion_curr_account.phase = AccountDataPhase()
         
         # Account storage.
-        if curr_account.phase is StoragePhase:
+        if isinstance(curr_account.phase, StoragePhase):
             # Get the storage-slot from _storage_tries which is MPT data.
             trie = state._storage_tries.get(curr_account.address)
             
@@ -190,14 +190,14 @@ def state_convert(state: State, stride: int):
     
                 if next_key is not None:
                     # There're more storage-slots to be converted, continue in this phase.
-                    state.conversion_curr_account.phase.next_key = next_key
+                    curr_account.phase.next_key = next_key
                 else:
                     # No more storage-slots. Move to the account data migration.
-                    state.conversion_curr_account.phase = AccountDataPhase()
+                    curr_account.phase = AccountDataPhase()
             else:
                 # There's no storage trie for the account, move directly to
                 # migrating account's data and code (if any).
-                state.conversion_curr_account.phase = AccountDataPhase()
+                curr_account.phase = AccountDataPhase()
         # Account code and basic data.
         else:
             # Getting the code from the Overlay Tree is fine since it promises to return


### PR DESCRIPTION
The state_convert helper was never entering the storage migration branch because it compared the phase instance to the StoragePhase class object with “is” instead of checking the type. As a result, accounts started directly in the account data/code phase and skipped storage conversion entirely. In addition, the code was updating state.conversion_curr_account, which does not exist, instead of the tracked CurrentConvertingAccount instance. This change switches the phase check to isinstance(curr_account.phase, StoragePhase) and updates the phase and next_key fields through the current account object so that storage slots are migrated first and phase progress is actually persisted.