### PR TITLE
Website: Reuse cached Standards Track page collection in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,19 +33,20 @@ title: Home
 
 <p>EIPs are separated into a number of types, and each has its own list of EIPs.</p>
 
-<h3>Standards Track ({{site.pages|where:"type","Standards Track"|size}})</h3>
+{% assign standards_track_pages = site.pages | where: "type", "Standards Track" %}
+<h3>Standards Track ({{ standards_track_pages | size }})</h3>
 <p>Describes any change that affects most or all Ethereum implementations, such as a change to the network protocol, a change in block or transaction validity rules, proposed application standards/conventions, or any change or addition that affects the interoperability of applications using Ethereum. Furthermore Standard EIPs can be broken down into the following categories.</p>
 
-<h4><a href="{{"core"|relative_url}}">Core</a> ({{site.pages|where:"type","Standards Track"|where:"category","Core"|size}})</h4>
+<h4><a href="{{"core"|relative_url}}">Core</a> ({{ standards_track_pages | where: "category", "Core" | size }})</h4>
 <p>Improvements requiring a consensus fork (e.g. <a href="./EIPS/eip-5">EIP-5</a>, <a href="./EIPS/eip-211">EIP-211</a>), as well as changes that are not necessarily consensus critical but may be relevant to “core dev” discussions (for example, the PoA algorithm for testnets described in <a href="./EIPS/eip-225">EIP-225</a>).</p>
 
-<h4><a href="{{"networking"|relative_url}}">Networking</a> ({{site.pages|where:"type","Standards Track"|where:"category","Networking"|size}})</h4>
+<h4><a href="{{"networking"|relative_url}}">Networking</a> ({{ standards_track_pages | where: "category", "Networking" | size }})</h4>
 <p>Includes improvements around devp2p (<a href="./EIPS/eip-8">EIP-8</a>) and Light Ethereum Subprotocol, as well as proposed improvements to network protocol specifications of whisper and swarm.</p>
 
-<h4><a href="{{"interface"|relative_url}}">Interface</a> ({{site.pages|where:"type","Standards Track"|where:"category","Interface"|size}})</h4>
+<h4><a href="{{"interface"|relative_url}}">Interface</a> ({{ standards_track_pages | where: "category", "Interface" | size }})</h4>
 <p>Includes improvements around client API/RPC specifications and standards, and also certain language-level standards like method names (<a href="./EIPS/eip-6">EIP-6</a>) and contract ABIs. The label “interface” aligns with the interfaces repo and discussion should primarily occur in that repository before an EIP is submitted to the EIPs repository.</p>
 
-<h4><a href="{{"erc"|relative_url}}">ERC</a> ({{site.pages|where:"type","Standards Track"|where:"category","ERC"|size}})</h4>
+<h4><a href="{{"erc"|relative_url}}">ERC</a> ({{ standards_track_pages | where: "category", "ERC" | size }})</h4>
 <p>Application-level standards and conventions, including contract standards such as token standards (<a href="./EIPS/eip-20">EIP-20</a>), name registries (<a href="./EIPS/eip-137">EIP-137</a>), URI schemes (<a href="./EIPS/eip-681">EIP-681</a>), library/package formats (<a href="./EIPS/eip-190">EIP-190</a>), and account abstraction (<a href="./EIPS/eip-4337">EIP-4337</a>).</p>
 
 <h3><a href="{{"meta"|relative_url}}">Meta</a> ({{site.pages|where:"type","Meta"|size}})</h3>


### PR DESCRIPTION
Assign the result of site.pages | where: "type", "Standards Track" once and reuse it when rendering the Standards Track subsections. Eliminate four redundant Liquid filter passes while keeping the rendered counts identical.