### PR TITLE
Update EIP-7906: correct CALL opcode

### DIFF
--- a/EIPS/eip-7906.md
+++ b/EIPS/eip-7906.md
@@ -135,7 +135,7 @@ Including all opcodes called during a transaction execution in the stack trace i
 * `DELEGATECALL` (`0xF4`)
 * `CALLCODE` (`0xF2`)
 * `STATICCALL` (`0xFA`)
-* `CALL` (`0xFA`)
+* `CALL` (`0xF1`)
 * `LOG` (`0xA0`)
 * `LOG1` (`0xA1`)
 * `LOG2` (`0xA2`)


### PR DESCRIPTION
The Opcodes Traced section incorrectly documented CALL as 0xFA, which is the opcode of STATICCALL. This change updates CALL to 0xF1 according to the canonical EVM specification