### PR TITLE
Update EIP-7966: validate timeout against node-configured maximum instead of default

### DIFF
--- a/EIPS/eip-7966.md
+++ b/EIPS/eip-7966.md
@@ -59,8 +59,9 @@ _In a low-latency blockchain, transaction receipts are often available right aft
 
 ### Node-Configured Timeouts
 
-- The handler function of this RPC SHOULD incorporate a configurable timeout when waiting for receipts (RECOMMENDED: 2 seconds).
-- Node implementations SHOULD provide a way to configure the timeout duration.
+- The handler function of this RPC SHOULD incorporate a configurable timeout when waiting for receipts (RECOMMENDED: 2 seconds as the default).
+- Node implementations SHOULD provide a way to configure both the default timeout and the maximum allowed timeout (node-configured maximum timeout).
+- The node-configured maximum timeout defines the upper bound for user-provided timeout values and SHOULD be configurable by node operators.
 - Node operators MAY implement dynamic timeout adjustment based on real-time network conditions.
 
 ### Behavior
@@ -68,7 +69,8 @@ _In a low-latency blockchain, transaction receipts are often available right aft
 Upon receiving an `eth_sendRawTransactionSync` request, the handler function performs the following tasks.
 
 - If timeout parameter is provided, the handler function MUST validate its validity.
-    - If the timeout is invalid, the handler function MUST use the default node-configure timeout.
+    - The timeout MUST be a positive integer not greater than the node-configured maximum timeout.
+    - If the timeout is invalid or exceeds the maximum, the handler function MUST use the default node-configured timeout.
 - The handler function MUST submit the signed transaction to the network as per the existing `eth_sendRawTransaction` semantics.
 - The handler function MUST wait for the transaction receipt until the timeout elapses.
 - If the transaction is not ready to be processed, the handler function SHOULD return an error code `5` with an error message.
@@ -203,11 +205,13 @@ For example, in `reth`, we can implement the handler for `eth_sendRawTransaction
 ```rust
 async fn send_raw_transaction_sync(&self, tx: Bytes, timeout_duration: Option<Duration>) -> RpcResult<OpTransactionReceipt> {
     const DEFAULT_TIMEOUT: Duration = Duration::from_secs(2);
+    const MAX_TIMEOUT: Duration = Duration::from_secs(10); // Node-configured maximum timeout
     
     // Validate the timeout parameter
     let timeout_duration = match timeout_duration {
-        Some(t) if t <= DEFAULT_TIMEOUT => t,
-        _ => DEFAULT_TIMEOUT,
+        Some(t) if t > Duration::ZERO && t <= MAX_TIMEOUT => t,
+        Some(_) => DEFAULT_TIMEOUT, // Invalid timeout, use default
+        None => DEFAULT_TIMEOUT,
     };
     
     // is_ready indicates if the processing node is ready to process the transaction (likely in L2 sequencers).


### PR DESCRIPTION
The example request uses 5000ms timeout, but the code was only checking against the default 2s timeout, which breaks the spec. Updated validation to check against the node-configured maximum timeout instead, so clients can use values up to the node's limit. Also fixed the "node-configure" typo and clarified what the maximum timeout means in the spec.

