### PR TITLE
Update EIP-7612: align account code size leaf with spec

### DIFF
--- a/EIPS/eip-7612.md
+++ b/EIPS/eip-7612.md
@@ -54,12 +54,15 @@ def verkle_set_account(tree: VerkleTree, key: Bytes32, account: Optional[Account
         ckkey = key
         ckkey[31] = CODEHASH_LEAF_KEY
         tree.set(ckkey, account.code_hash)
+        cskey = key
+        cskey[31] = CODE_SIZE_LEAF_KEY
+        tree.set(cskey, len(account.code).to_bytes(3, 'big'))
 
 # Reads an account from the verkle tree
 def verkle_get_account(tree: VerkleTree, key: Bytes32) -> Optional[Account]:
     basicdata_leaf = tree.get(key)
+    account = None
     if basicdata_leaf is not None:
-        cs = int.from_bytes(basicdata_leaf[5:8], 'big')
         nonce = int.from_bytes(basicdata_leaf[8:16], 'big')
         balance = int.from_bytes(basicdata_leaf[16:32], 'big')
         ckkey = key


### PR DESCRIPTION
Fixed the verkle_get_account helper in EIP-7612 and makes the account encoding consistent with the Verkle account layout.

The previous version decoded cs from the basicdata blob and then immediately overwrote it by reading from the CODE_SIZE_LEAF_KEY leaf, leaving a dead assignment and relying on a leaf that was never actually written. It also returned account without guaranteeing that the variable was initialized when the basicdata leaf was missing.

The updated version writes the code size into a dedicated CODE_SIZE_LEAF_KEY leaf in verkle_set_account, removes the unused cs read from basicdata, and initializes account to None before decoding. This makes the code size handling explicit and consistent with the Verkle account scheme, and avoids returning an undefined value.