### PR TITLE
Update EIP-7942: correct Python syntax errors in pseudocode

### DIFF
--- a/EIPS/eip-7942.md
+++ b/EIPS/eip-7942.md
@@ -134,7 +134,7 @@ def get_head(store: Store) -> Root:
     # Get filtered block tree that only includes viable branches
     chains = get_filtered_block_tree(store)
     # Execute the longest stable chain fork choice
-    return max(chains, key=length).leaf
+    return max(chains, key=lambda c: c.length).leaf
 ```
 
 #### Modification 3
@@ -156,11 +156,11 @@ For the fork choice specification (fork_choice in consensus-specs):
 Modify `get_filtered_block_tree`. Only consider the chain that justifies the latest justified checkpoint.
 
 ```python
-def get_filtered_block_tree(store: Store) -> List(Chain) :
+def get_filtered_block_tree(store: Store) -> List[Chain]:
     chains = []
     for chain in store.chains:
         if is_equal(store.justified_checkpoint.root, chain.justified_checkpoint.root):
-            chains.add(chain)
+            chains.append(chain)
     return chains
 ```
 


### PR DESCRIPTION
Fixed three Python syntax errors in the pseudocode examples:
- `key=length` → `key=lambda c: c.length` (undefined variable)
- `List(Chain)` → `List[Chain]` (wrong type annotation syntax)
- `chains.add()` → `chains.append()` (lists don't have .add() method)