### PR TITLE
Update EIP-8071: replace EIPXXXX placeholder with actual EIP number

### DIFF
--- a/EIPS/eip-8071.md
+++ b/EIPS/eip-8071.md
@@ -108,7 +108,7 @@ def process_consolidation_request(
     if get_pending_balance_to_withdraw(state, source_index) > 0:
         return
 
-    # [New in EIPXXXX]
+    # [New in EIP-8071]
     # Verify that the consolidating balance will
     # end up as active balance, not as excess balance
     target_balance_after_consolidation = (


### PR DESCRIPTION
Replace forgotten `EIPXXXX` placeholder with `EIP-8071` in the code comment.