### PR TITLE
Update EIP-5593: fix spacing and grammar in author section

### DIFF
--- a/EIPS/eip-5593.md
+++ b/EIPS/eip-5593.md
@@ -2,7 +2,7 @@
 eip: 5593
 title: Restrict Ethereum Provider API Injection
 description: Wallet guidance for restricting Ethereum Provider API access to secure contexts for improved privacy and security for wallet users.
-author: Yan Zhu (@diracdeltas), Brian R. Bondy (@bbondy), Andrea  Brancaleoni (@thypon), Kyle Den Hartog (@kdenhartog)
+author: Yan Zhu (@diracdeltas), Brian R. Bondy (@bbondy), Andrea Brancaleoni (@thypon), Kyle Den Hartog (@kdenhartog)
 discussions-to: https://ethereum-magicians.org/t/rfc-limiting-provider-object-injection-to-secure-contexts/10670
 status: Stagnant
 type: Standards Track
@@ -17,7 +17,7 @@ Historically the web platform has had a notion of “powerful” APIs like those
 
 ### Author's Note
 
-Unfortunately, because of a difference in interpretations by EIP editors of RFC 2119 terminology around linking in [EIP-1](./eip-1.md), the authors cannot directly link to other W3C specifications which this EIP builds upon. The author's attempted to provide as much context as possible within the text while complying with the editor bot in order to get this merged. If this policy is updated or further clarified before this EIP reaches final call in the future this EIP will be updated with links.
+Unfortunately, because of a difference in interpretations by EIP editors of RFC 2119 terminology around linking in [EIP-1](./eip-1.md), the authors cannot directly link to other W3C specifications which this EIP builds upon. The authors attempted to provide as much context as possible within the text while complying with the editor bot in order to get this merged. If this policy is updated or further clarified before this EIP reaches final call in the future this EIP will be updated with links.
 
 ## Motivation
 


### PR DESCRIPTION
Removed extra space in author name "Andrea Brancaleoni"
Changed "author's attempted" to "authors attempted" (possessive → plural)