### PR TITLE
Update EIP-7928: Fix analysis

### DIFF
--- a/assets/eip-7928/bal_size_analysis_60m.md
+++ b/assets/eip-7928/bal_size_analysis_60m.md
@@ -1,4 +1,4 @@
-# EIP-7928 Component Size - 1000 Blocks
+# EIP-7928 Component Size & Compression Analysis - 1000 Blocks
 
 ## Dataset
 - **Blocks Analyzed**: 1000 blocks (23,991,474 to 23,992,473)
@@ -14,7 +14,7 @@
 | Balance Changes | 6.8 | 6.6 | 6.7 | 6.5 | 1.02x | 1.00x |
 | Nonce Changes | 1.1 | 1.0 | 1.1 | 1.0 | 0.99x | 1.00x |
 | Code Changes | 2.1 | 0.2 | 1.2 | 0.2 | 1.37x | 1.16x |
-| **Full BAL** | **74.3** | **70.9** | **49.4** | **47.9** | **1.50x** | **1.48x** |
+| **Full BAL** | **110.8** | **106.0** | **72.4** | **70.5** | **1.52x** | **1.52x** |
 
 ## Component Size Distribution (KiB)
 
@@ -25,7 +25,7 @@
 | Balance Changes | 0.7 | 22.4 | 2.8 | 0.7 | 22.4 | 2.7 |
 | Nonce Changes | 0.1 | 4.4 | 0.5 | 0.1 | 4.5 | 0.5 |
 | Code Changes | 0.0 | 72.6 | 5.6 | 0.0 | 25.3 | 2.9 |
-| **Full BAL** | **8.4** | **223.5** | **30.7** | **6.8** | **141.8** | **19.5** |
+| **Full BAL** | **10.9** | **301.9** | **45.5** | **8.6** | **191.4** | **28.8** |
 
 ## Compression Ratio Distribution
 
@@ -36,13 +36,13 @@
 | Balance Changes | 1.00x | 1.50x | 0.04x | 1.00x | 1.03x |
 | Nonce Changes | 0.97x | 1.07x | 0.00x | 0.99x | 1.00x |
 | Code Changes | 0.93x | 8.67x | 0.65x | 0.99x | 1.56x |
-| **Full BAL** | **1.20x** | **2.23x** | **0.10x** | **1.44x** | **1.53x** |
+| **Full BAL** | **1.19x** | **1.98x** | **0.09x** | **1.47x** | **1.56x** |
 
 ## Block Activity Metrics (per block)
 
 | Metric | Average | Median | Min | Max |
 |--------|---------|--------|-----|-----|
-| Total Accounts | 432 | 428 | 67 | 1124 |
+| Total Accounts | 603 | 600 | 98 | 1474 |
 | Storage Writes Count | 700 | 667 | 65 | 2521 |
 | Storage Reads Count | 982 | 922 | 36 | 3279 |
 | Balance Changes Count | 612 | 598 | 62 | 1812 |
@@ -52,11 +52,11 @@
 
 | Component | % of Raw Size | % of Compressed Size |
 |-----------|---------------|---------------------|
-| Storage Writes | 70.7% | 59.1% |
-| Balance Changes | 9.2% | 13.5% |
-| Nonce Changes | 1.5% | 2.2% |
-| Code Changes | 2.8% | 2.4% |
+| Storage Writes | 47.5% | 40.3% |
 | Storage Reads | 28.6% | 25.8% |
+| Balance Changes | 6.2% | 9.2% |
+| Nonce Changes | 1.0% | 1.5% |
+| Code Changes | 1.9% | 1.6% |
 
 ## BAL vs Block Size Comparison
 
@@ -64,24 +64,24 @@ Comparison using compressed block average of **71.71 KiB**:
 
 | Metric | BAL Size (KiB) | Block Size (KiB) | Ratio (BAL/Block) | Size Difference |
 |--------|---------------|------------------|-------------------|------------------|
-| **WITHOUT reads** | 49.4 | 71.7 | 0.69x | -22.3 KiB |
-| **WITH reads** | 72.4 | 71.7 | 1.01x | +0.7 KiB |
+| **Full BAL (with reads)** | 72.4 | 71.7 | 1.01x | +0.7 KiB |
+| **BAL without reads** | 49.4 | 71.7 | 0.69x | -22.3 KiB |
 
 ### Key Insights:
+- Full BAL **with reads** is 1.01x the size of a compressed block
 - BAL **without reads** is 0.69x the size of a compressed block
-- BAL **with reads** is 1.01x the size of a compressed block
 - Storage reads add **23.0 KiB** (46.6%) to BAL size
-- BAL overhead vs blocks: **-31.1%** (without reads), **+1.0%** (with reads)
+- BAL overhead vs blocks: **+1.0%** (with reads), **-31.1%** (without reads)
 
 ## Storage Reads Impact Analysis
 
-- **WITH reads**: 72.4 KiB compressed
+- **WITH reads** (Full BAL): 72.4 KiB compressed
 - **WITHOUT reads**: 49.4 KiB compressed
 - **Storage reads overhead**: 23.0 KiB (46.6%)
 
 ## Summary
 
-1. **Component dominance**: Storage writes are 70.7% of raw BAL size
-2. **Compression efficiency**: Overall 1.50x compression ratio
-3. **Size variability**: BAL sizes vary from 6.8 to 141.8 KiB compressed
-4. **Block size ratio**: BALs are 0.69x compressed block size (without reads)
+1. **Component dominance**: Storage writes are 47.5% of raw BAL size
+2. **Compression efficiency**: Overall 1.52x compression ratio
+3. **Size variability**: BAL sizes vary from 8.6 to 191.4 KiB compressed
+4. **Block size ratio**: Full BALs are 1.01x compressed block size


### PR DESCRIPTION
The previous analysis didn't include the read values in the BAL properly