### PR TITLE
Update EIP-7748: fix grammar and variable bugs in pseudocode

### DIFF
--- a/EIPS/eip-7748.md
+++ b/EIPS/eip-7748.md
@@ -86,7 +86,7 @@ class CurrentConvertingAccount:
     phase : StoragePhase | AccountDataPhase
 ```
 
-These new structures allows `State` to track where we're in the conversion process.
+These new structures allow `State` to track where we're in the conversion process.
 
 Modify the `State` class by adding the following attributes:
 
@@ -152,8 +152,8 @@ def set_storage(
 ) -> None:
     # <new_code>
     if only_if_empty:
-        value = state._overlay_tree.get(get_tree_key_for_storage_slot(addr, key))
-        if value is not None:
+        existing_value = state._overlay_tree.get(get_tree_key_for_storage_slot(addr, key))
+        if existing_value is not None:
             return
     # </new_code>
     
@@ -206,7 +206,7 @@ def state_convert(state: State, stride: int):
             chunked_code = chunkify_code(account.code)
             
             for chunk_num in range(len(chunked_code)):
-                state_set_codechunk(state, address, chunk_num, chunked_code[chunk_num])
+                state_set_codechunk(state, curr_account.address, chunk_num, chunked_code[chunk_num])
                 
             # If the account data (i.e: nonce, balance, code-size, code-hash) lives in MPT, 
             # get_account will pull from MPT and then we write to the VKT. If the account 


### PR DESCRIPTION
Fix grammar error ("allows" → "allow"), rename shadowed variable `value` to `existing_value` in set_storage to avoid overwriting the parameter, and fix undefined `address` variable in state_set_codechunk call.