### PR TITLE
Update EIP-1485: fix grammar errors

### DIFF
--- a/EIPS/eip-1485.md
+++ b/EIPS/eip-1485.md
@@ -13,7 +13,7 @@ created: 2018-11-01
 This EIP modifies ethash in order to break ASIC miners specialized for the current ethash mining algorithm.
 
 ## Abstract
-This EIP pursue "obsolete current ASIC miners" by modifying PoW algorithm in a very low risk manner and update to latest hash algorithm from deprecated FNV Hash algorithms.
+This EIP pursues "obsolete current ASIC miners" by modifying PoW algorithm in a very low risk manner and update to latest hash algorithm from deprecated FNV Hash algorithms.
 
 Following TEthashV1 algorithm suggests safe transition of PoW algorithms and secure the FNV Algorithm in MIX Parts.
 
@@ -59,7 +59,7 @@ Provide original Ethash proof of work verification with minimal set of changes b
    hash = 0
    for each byte_of_data to be hashed
    	hash = hash × FNV_prime
-   	hash = hash XOR octet_of_data
+   	hash = hash XOR byte_of_data
    return hash
   ```
 
@@ -93,7 +93,7 @@ and make dispersion boundary condition (0, even number, ..) by using of Prime Nu
 
 Consider real computation resources, in TEthashV1 uses hash byte_of_data to 4bytes aligned data.
 
-In TETHashV1, Adapts fully follow the FNV1A implementation.
+In TETHashV1, it fully follows the FNV1A implementation.
 
   - TETHASHV1 FNV1A implementation
 
@@ -193,7 +193,7 @@ genoil ethminer (2015) -> ethereum-mining/ethminer (2017) [2year]
 
 ## Test Results::
 
-Tethash miner has 2~3% of hashrate degrade on GPU, due to more core computation time.
+Tethash miner has 2~3% of hashrate degradation on GPU, due to more core computation time.
 
 ## Copyright
 


### PR DESCRIPTION
Fix grammar errors in EIP-1485: "pursue" → "pursues", "octet_of_data" → "byte_of_data" for consistency with surrounding code, "Adapts fully follow" → "it fully follows", "hashrate degrade" → "hashrate degradation".