### PR TITLE
Update EIP-8068: fix typos in EIP-8068

### DIFF
--- a/EIPS/eip-8068.md
+++ b/EIPS/eip-8068.md
@@ -101,7 +101,7 @@ def process_effective_balance_updates(state: BeaconState) -> None:
             state.temporary_upward_threshold[index] = 0
 ```
 
-When processing partial withdrawal, the flag for reseting the EB is set.
+When processing partial withdrawal, the flag for resetting the EB is set.
 
 ```python
 def process_withdrawals(state: BeaconState, payload: ExecutionPayload) -> None:
@@ -120,7 +120,7 @@ def process_withdrawals(state: BeaconState, payload: ExecutionPayload) -> None:
 
 ### Relative change in staking yield
 
-The figure shows the impact of the current EB bands and hysteresis design on validator yields for different validator configuations. The relative change in staking yield is plotted against a baseline 0 which corresponds to what compounding `0x02` validators would earn if $E=b$, as in the neutral effective balance design. Note that these are relative changes, so a validator at -0.01 under a CL yield of 3% would earn $0.99 \times 3 = 2.97$% in yield.
+The figure shows the impact of the current EB bands and hysteresis design on validator yields for different validator configurations. The relative change in staking yield is plotted against a baseline 0 which corresponds to what compounding `0x02` validators would earn if $E=b$, as in the neutral effective balance design. Note that these are relative changes, so a validator at -0.01 under a CL yield of 3% would earn $0.99 \times 3 = 2.97$% in yield.
 
 ![Figure 1](../assets/eip-8068/1.png)
 
@@ -192,7 +192,7 @@ def process_effective_balance_updates(state: BeaconState) -> None:
 
 ## Security Considerations
 
-This EIP would trigger a mass upward change of EBs at the specific hardfork boundary. The effect of this should be analyzed furher.
+This EIP would trigger a mass upward change of EBs at the specific hardfork boundary. The effect of this should be analyzed further.
 
 ## Copyright
 


### PR DESCRIPTION


**Description:**
- Correct spelling in partial withdrawal flag handling (resetting EB).
- Fix “configurations” wording in validator yield discussion.
- Clarify text on analyzing hardfork EB changes (“further”).
