### PR TITLE
Update EIP-7917: Move to Final

### DIFF
--- a/EIPS/eip-7917.md
+++ b/EIPS/eip-7917.md
@@ -4,8 +4,7 @@ title: Deterministic proposer lookahead
 description: Pre-calculate and store a deterministic proposer lookahead in the beacon state at the start of every epoch
 author: Lin Oshitani (@linoscope) <lin@nethermind.io>, Justin Drake (@JustinDrake) <justin@ethereum.org>
 discussions-to: https://ethereum-magicians.org/t/eip-7917-deterministic-proposer-lookahead/23259
-status: Last Call
-last-call-deadline: 2025-10-28
+status: Final
 type: Standards Track
 category: Core
 created: 2025-03-24


### PR DESCRIPTION
Move EIP-7917 to Final as it was deployed to mainnet https://eips.ethereum.org/EIPS/eip-7607
