### PR TITLE
Update EIP-7922: Fix undefined constant and variable references in EIP-7922

### DIFF
--- a/EIPS/eip-7922.md
+++ b/EIPS/eip-7922.md
@@ -119,14 +119,14 @@ def process_historical_exit_churn_vector(state: BeaconState) -> None:
     # Update the vector if switching over to the next generation.
     if next_epoch_generation > current_epoch_generation:
         lookahead_generation = next_epoch_generation + GENERATIONS_PER_EXIT_CHURN_LOOKAHEAD
-        lookahead_generation_index = lookahead_generation % GENERATIONS_PER_HISTORICAL_CHURN_VECTOR
+        lookahead_generation_index = lookahead_generation % GENERATIONS_PER_EXIT_CHURN_VECTOR
         if earliest_exit_epoch_generation < lookahead_generation:
             # If earliest_exit_epoch is earlier than the lookahead generation,
             # reset its churn usage to 0,
             state.exit_churn_vector[lookahead_generation_index] = uint64(0)
         else:
             # otherwise, mark the lookahead generation churn as fully consumed.
-            state.historical_exit_churn_vector[lookahead_generation_index] = UINT64_MAX
+            state.exit_churn_vector[lookahead_generation_index] = UINT64_MAX
 ```
 
 *Design note*: This function resets the lookahead generation churn upon switching to the next generation. If `state.earliest_exit_epoch` falls into the generation earlier than the lookahead, the lookahead generation churn usage is reset. Otherwise, it is marked as fully used.
@@ -198,13 +198,13 @@ def compute_exit_epoch_and_update_churn(state: BeaconState, exit_balance: Gwei) 
     # New in [EIP-XXXX]
     current_epoch_generation = current_epoch // EPOCHS_PER_CHURN_GENERATION
     exit_epoch_generation = state.earliest_exit_epoch // EPOCHS_PER_CHURN_GENERATION
-    current_generation_index = current_epoch_generation % GENERATIONS_PER_HISTORICAL_CHURN_VECTOR
+    current_generation_index = current_epoch_generation % GENERATIONS_PER_EXIT_CHURN_VECTOR
     # Record churn usage only if exit falls into the lookahead period
     # and the exit epoch generation churn isn't fully used.
     lookahead_generation = current_epoch_generation + GENERATIONS_PER_EXIT_CHURN_LOOKAHEAD
     exit_epoch_generation_index = exit_epoch_generation % GENERATIONS_PER_EXIT_CHURN_VECTOR
     if (exit_epoch_generation <= lookahead_generation
-        and state.historical_exit_churn_vector[exit_epoch_generation_index] < UINT64_MAX):
+        and state.exit_churn_vector[exit_epoch_generation_index] < UINT64_MAX):
         state.exit_churn_vector[exit_epoch_generation_index] += exit_balance
 
     return state.earliest_exit_epoch


### PR DESCRIPTION
The code references `GENERATIONS_PER_HISTORICAL_CHURN_VECTOR` and `state.historical_exit_churn_vector` which are never defined.

  The actual definitions are:
  - Line 74: `GENERATIONS_PER_EXIT_CHURN_VECTOR`
  - Line 83: `exit_churn_vector`

  This PR fixes 4 incorrect references (lines 122, 129, 201, 207) to match the actual variable names.