### PR TITLE
Update EIP-7732: fix constant name

### DIFF
--- a/EIPS/eip-7732.md
+++ b/EIPS/eip-7732.md
@@ -60,7 +60,7 @@ A summary of the main changes is included below, the [Rationale](#rationale) sec
 | - | - | 
 | `PTC_SIZE` | `uint64(2**9)` (=512) |
 | `MAX_PAYLOAD_ATTESTATIONS` | `2**2` (= 4) |
-| `BUILDER_PEDING_WITHDRAWALS_LIMIT` | `uint64(2**20)` (=1,048,576) | 
+| `BUILDER_PENDING_WITHDRAWALS_LIMIT` | `uint64(2**20)` (=1,048,576) | 
 | `BUILDER_WITHDRAWAL_PREFIX` | `Bytes1('0X03')` | 
 
 ##### Containers


### PR DESCRIPTION
Correct the preset constant name from BUILDER_PEDING_WITHDRAWALS_LIMIT to BUILDER_PENDING_WITHDRAWALS_LIMIT