### PR TITLE
Update EIP-7928: Update `CodeData` to use `Bytecode`

### DIFF
--- a/EIPS/eip-7928.md
+++ b/EIPS/eip-7928.md
@@ -65,7 +65,7 @@ BalanceChange = [BlockAccessIndex, Balance]
 NonceChange = [BlockAccessIndex, Nonce]
 
 # CodeChange: [block_access_index, new_code]
-CodeChange = [BlockAccessIndex, CodeData]
+CodeChange = [BlockAccessIndex, Bytecode]
 
 # SlotChanges: [slot, [changes]]
 # All changes to a single storage slot


### PR DESCRIPTION
This PR replaces `CodeData` with `Bytecode`, which is a missing change from this [PR](https://github.com/ethereum/EIPs/pull/10634#issuecomment-3466394502).