### PR TITLE
Update EIP-7819: fix inconsistent SETDELEGATE opcode naming

### DIFF
--- a/EIPS/eip-7819.md
+++ b/EIPS/eip-7819.md
@@ -102,9 +102,9 @@ Therefore, the cost of executing this instruction could be lower than EIP-7702. 
 
 The derivation of the `location` is designed not to conflict with contracts created using the `CREATE` or `CREATE2` opcodes. In particular, the pre-images used to hash the produced address have different lengths, preventing any collision:
 
-Contracts deployed using `CREATE2` have an address that is derived from a 85 bytes long pre-image, as opposed to 55 bytes for `SET_DELEGATE`. This observation alone remove the risk of pre-image collision.
+Contracts deployed using `CREATE2` have an address that is derived from a 85 bytes long pre-image, as opposed to 55 bytes for `SETDELEGATE`. This observation alone remove the risk of pre-image collision.
 
-Contracts deployed using `CREATE` have an address that is derived from the `RLP([address, nonce])`. For this pre-image to have a length 55 (like `SET_DELEGATE`), `nonce` must be 32 bytes long. In that case, the `RLP([address, nonce])` would be `0xf694<address>a0<nonce>` and would thus not start with the magic value used by `SETDELEGATE`. A smaller nonce could lead to the pre-image starting with `0xef`, but in that case the pre-image would be smaller than 55 bytes. Even in that case, the pre-image would start with `0xef94`, `0x94` encoding the `address` object (that is 20 bytes long).
+Contracts deployed using `CREATE` have an address that is derived from the `RLP([address, nonce])`. For this pre-image to have a length 55 (like `SETDELEGATE`), `nonce` must be 32 bytes long. In that case, the `RLP([address, nonce])` would be `0xf694<address>a0<nonce>` and would thus not start with the magic value used by `SETDELEGATE`. A smaller nonce could lead to the pre-image starting with `0xef`, but in that case the pre-image would be smaller than 55 bytes. Even in that case, the pre-image would start with `0xef94`, `0x94` encoding the `address` object (that is 20 bytes long).
 
 ## Security Considerations
 
@@ -120,7 +120,7 @@ Factories may want to protect against this risk by verifying that the `target` d
 
 ### Front running initialization
 
-Unlike EIP-7702 signature, which can be included in any transaction, and can thus lead to initialization front-running if the implementation doesn't check the authenticity of the initialization parameters, `CREATE_DELEGATE` is executed by a smart contract that can execute the initialization logic atomically, just after the delegation is created. This process is well-known to developers that initialize clones and proxies just after creation.
+Unlike EIP-7702 signature, which can be included in any transaction, and can thus lead to initialization front-running if the implementation doesn't check the authenticity of the initialization parameters, `SETDELEGATE` is executed by a smart contract that can execute the initialization logic atomically, just after the delegation is created. This process is well-known to developers that initialize clones and proxies just after creation.
 
 ### Multiple delegation changes within a single transaction.
 


### PR DESCRIPTION
Normalized the opcode name in EIP-7819 to SETDELEGATE everywhere, replacing leftover references to SET_DELEGATE and CREATE_DELEGATE. The goal is to match the canonical name used in the specification and the post-rename design discussed on Ethereum Magicians, and to avoid any ambiguity for implementers about which opcode is meant.