### PR TITLE
Update EIP-7904: correct opcode table order and reference implementat…

### DIFF
--- a/EIPS/eip-7904.md
+++ b/EIPS/eip-7904.md
@@ -121,9 +121,9 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 | 0x58        | PC             |                                                                     2 |                                                                   BASE_OPCODE_COST |
 | 0x59        | MSIZE          |                                                                     2 |                                                                   BASE_OPCODE_COST |
 | 0x5A        | GAS            |                                                                     2 |                                                                   BASE_OPCODE_COST |
+| 0x5B        | JUMPDEST       |                                                                     1 |                                                                   BASE_OPCODE_COST |
 | 0x5C        | TLOAD          |                                                                   100 |                                                             WARM_STORAGE_READ_COST |
 | 0x5D        | TSTORE         |                                                                   100 |                                                             WARM_STORAGE_READ_COST |
-| 0x5B        | JUMPDEST       |                                                                     1 |                                                                   BASE_OPCODE_COST |
 | 0x5E        | MCOPY          |                       3 + 3 \* data_word_size + memory_expansion_cost |    BASE_OPCODE_COST + COPY_PER_WORD_COST \* data_word_size + memory_expansion_cost |
 | 0x5F        | PUSH0          |                                                                     2 |                                                                   BASE_OPCODE_COST |
 | 0x60 - 0x7F | PUSHx          |                                                                     3 |                                                                   BASE_OPCODE_COST |
@@ -289,7 +289,7 @@ func newRepricedInstructionSet() JumpTable {
   instructionSet[TSTORE].constantGas = WarmStorageReadCost
 
   validateAndFillMaxStack(&instructionSet)
- return instructionSet
+  return instructionSet
 }
 
 func memoryGasCost(mem *Memory, newMemSize uint64) (uint64, error) {


### PR DESCRIPTION
- Reorder JUMPDEST (0x5B) to its correct position in the opcode table (was placed after 0x5D instead of after 0x5A)
- Fix indentation of `return` statement in Go reference implementation