### PR TITLE
Fix type annotation and variable shadowing in EIP-4881 assets

### DIFF
--- a/assets/eip-4881/deposit_snapshot.py
+++ b/assets/eip-4881/deposit_snapshot.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 from typing import List, Optional, Tuple
 from dataclasses import dataclass
 from abc import abstractmethod
-from eip_4881 import DEPOSIT_CONTRACT_DEPTH,Hash32,sha256,to_le_bytes,zerohashes
+from eip_4881 import DEPOSIT_CONTRACT_DEPTH,Eth1Data,Hash32,sha256,to_le_bytes,uint64,zerohashes
 
 @dataclass
 class DepositTreeSnapshot:
-    finalized: List[Hash32, DEPOSIT_CONTRACT_DEPTH]
+    finalized: List[Hash32]
     deposit_root: Hash32
     deposit_count: uint64
     execution_block_hash: Hash32

--- a/assets/eip-4881/test_deposit_snapshot.py
+++ b/assets/eip-4881/test_deposit_snapshot.py
@@ -60,12 +60,12 @@ def read_test_cases(filename):
 
 def merkle_root_from_branch(leaf, branch, index) -> Hash32:
     root = leaf
-    for (i, leaf) in enumerate(branch):
+    for (i, sibling) in enumerate(branch):
         ith_bit = (index >> i) & 0x1
         if ith_bit == 1:
-            root = sha256(leaf + root)
+            root = sha256(sibling + root)
         else:
-            root = sha256(root + leaf)
+            root = sha256(root + sibling)
     return root
 
 def check_proof(tree, index):


### PR DESCRIPTION
1. `deposit_snapshot.py`: `List[Hash32, DEPOSIT_CONTRACT_DEPTH]` is invalid Python - `List` only accepts one type argument. Changed to `List[Hash32]`. Also added missing imports (`Eth1Data`, `uint64`) that are used in type hints.

2. `test_deposit_snapshot.py`: The loop variable `leaf` was shadowing the function parameter with the same name in `merkle_root_from_branch()`. Renamed to `sibling` which is also more accurate terminology for Merkle proofs.