### PR TITLE
Update EIP-4762: formatting issues

### DIFF
--- a/EIPS/eip-4762.md
+++ b/EIPS/eip-4762.md
@@ -35,7 +35,7 @@ def get_storage_slot_tree_keys(storage_key: int) -> [int, int]:
 
 ### Access events
 
-Whenever the state is read, one or more of the access events of the form`(address, sub_key, leaf_key)` take place, determining what data is being accessed. We define access events as follows:
+Whenever the state is read, one or more of the access events of the form `(address, sub_key, leaf_key)` take place, determining what data is being accessed. We define access events as follows:
 
 #### Access events for account headers
 
@@ -214,7 +214,6 @@ When executing a transaction, maintain four sets:
  * `edited_subtrees: Set[Tuple[address, int]]`
  * `edited_leaves: Set[Tuple[address, int, int]]`
 
-
 When an **access** event of `(address, sub_key, leaf_key)` occurs, perform the following checks:
 
  * Perform the following steps unless event is a _Transaction access event_;
@@ -234,7 +233,7 @@ Note that values should only be added to the witness if there is sufficient gas 
 
 `CREATE*` and `*CALL` reserve 1/64th of the gas before the nested execution. In order to match the behavior of this charge with the pre-fork behavior of access lists: 
 
- * this minimum 1/64th gas reservation is checked **AFTER** charging the witness costs when performing a `CALL`, `CALLCODE`, `DELEGATECALL` or`STATICCALL`
+ * this minimum 1/64th gas reservation is checked **AFTER** charging the witness costs when performing a `CALL`, `CALLCODE`, `DELEGATECALL` or `STATICCALL`
  * this 1/64th of the gas is subtracted **BEFORE** charging the witness costs when performing a `CREATE` or `CREATE2`
 
 ### Block-level operations
@@ -270,7 +269,7 @@ Gas costs for reading storage and code are reformed to more closely reflect the 
 
 The main differences from gas costs in Berlin are:
 
- * 200 gas charged per 31 byte chunk of code. This has been estimated to increase average gas usage by ~6-12% suggesting 10-20% gas usage increases at a 350 gas per chunk level).
+ * 200 gas charged per 31 byte chunk of code. This has been estimated to increase average gas usage by ~6-12% (suggesting 10-20% gas usage increases at a 350 gas per chunk level).
  * Cost for accessing adjacent storage slots (`key1 // 256 == key2 // 256`) decreases from 2100 to 200 for all slots after the first in the group,
  * Cost for accessing storage slots 0…63 decreases from 2100 to 200, including the first storage slot. This is likely to significantly improve performance of many existing contracts, which use those storage slots for single persistent variables.
 
@@ -282,7 +281,7 @@ The precise specification of when access events take place, which makes up most 
 
 This EIP requires a hard fork, since it modifies consensus rules.
 
-The main backwards-compatibility-breaking changes is the gas costs for code chunk access making some applications less economically viable. It can be mitigated by increasing the gas limit at the same time as implementing this EIP, reducing the risk that applications will no longer work at all due to transaction gas usage rising above the block gas limit. 
+The main backwards-compatibility-breaking change is the gas costs for code chunk access making some applications less economically viable. It can be mitigated by increasing the gas limit at the same time as implementing this EIP, reducing the risk that applications will no longer work at all due to transaction gas usage rising above the block gas limit. 
 
 ## Security Considerations
 


### PR DESCRIPTION
Fixed formatting issues in EIP-4762:
- Added missing space before backtick in "form`(address" 
- Added missing space in "or`STATICCALL`"
- Fixed unclosed parenthesis in gas estimation sentence
- Fixed grammar: "changes is" -> "change is"
- Removed double blank line