### PR TITLE
Update EIP-7545: correct function name typo in gas cost formula

### DIFF
--- a/EIPS/eip-7545.md
+++ b/EIPS/eip-7545.md
@@ -69,7 +69,7 @@ where:
  * `get_commitments` extracts the list of commitments in the proof, as encoded in `input`
  * `get_keys` extracts the list of keys in the proof, as encoded in `input`
  * `leaf_depth` returns the depth of the leaf in the tree
- * `get tree` reconstruct a stateless view of the tree from `input`
+ * `get_tree` reconstruct a stateless view of the tree from `input`
 
 ## Rationale
 


### PR DESCRIPTION
### What
Fixed typo in gas cost formula documentation: changed get tree to get_tree on line 72.
### Why
Maintains naming consistency with other helper functions (get_commitments, get_keys, leaf_depth) that use underscore notation.