### PR TITLE
Update EIP-7932: Fix undefined variable reference

### DIFF
--- a/EIPS/eip-7932.md
+++ b/EIPS/eip-7932.md
@@ -205,7 +205,7 @@ def sigrecover_precompile(input: Bytes) -> Bytes:
     validate_signature(signature)
     pubkey = verify_signature(signing_data, signature)
 
-    return pubkey_to_address(pubkey, algorithm_type)
+    return pubkey_to_address(pubkey, input[0])
 ```
 
 ## Rationale


### PR DESCRIPTION
Line 208 used undefined variable `algorithm_type`, changed to `input[0]` to match the rest of the function.