### PR TITLE
Update EIP-7928: Remove BAL from EL block and further specify engine api interaction

### DIFF
--- a/EIPS/eip-7928.md
+++ b/EIPS/eip-7928.md
@@ -1,7 +1,7 @@
 ---
 eip: 7928
 title: Block-Level Access Lists
-description: Enforced block access lists with storage locations and post-transaction state diffs
+description: Enforced block access lists with state locations and post-transaction state diffs
 author: Toni Wahrstätter (@nerolation), Dankrad Feist (@dankrad), Francesco D`Amato (@fradamt), Jochem Brouwer (@jochem-brouwer), Ignacio Hagopian (@jsign)
 discussions-to: https://ethereum-magicians.org/t/eip-7928-block-level-access-lists/23337
 status: Draft
@@ -12,7 +12,7 @@ created: 2025-03-31
 
 ## Abstract
 
-This EIP introduces Block-Level Access Lists (BALs) that record all accounts and storage locations accessed during block execution, along with their post-execution values. BALs enable parallel disk reads, parallel transaction validation, and executionless state updates.
+This EIP introduces Block-Level Access Lists (BALs) that record all accounts and storage locations accessed during block execution, along with their post-execution values. BALs enable parallel disk reads, parallel transaction validation, parallel state root computation and executionless state updates.
 
 ## Motivation
 
@@ -21,6 +21,7 @@ Transaction execution cannot be parallelized without knowing in advance which ad
 This proposal enforces access lists at the block level, enabling:
 
 - Parallel disk reads and transaction execution
+- Parallel post-state root calculation
 - State reconstruction without executing transactions
 - Reduced execution time to `parallel IO + parallel EVM`
 
@@ -38,7 +39,7 @@ class Header:
     block_access_list_hash: Hash32 = keccak256(rlp.encode(block_access_list))
 ```
 
-The block body includes a `BlockAccessList` containing all account accesses and state changes. This field is RLP-encoded as a list of `AccountChanges`. When no state changes are present, this field is the empty RLP list `0xc0`, i.e. `rlp.encode([])`.
+The `BlockAccessList` is not included in the block body. The EL stores BALs separately and transmits them as a field in the `ExecutionPayload` via the engine API. The BAL is RLP-encoded as a list of `AccountChanges`. When no state changes are present, this field is the empty RLP list `0xc0`, i.e. `rlp.encode([])`.
 
 ### RLP Data Structures
 
@@ -211,35 +212,47 @@ The Engine API is extended with new structures and methods to support block-leve
 
 **engine_newPayloadV5** validates execution payloads:
 
-- Accepts ExecutionPayloadV4 structure
+- Accepts `ExecutionPayloadV4` structure
 - Validates that computed access list matches provided `blockAccessList`
 - Returns `INVALID` if access list is malformed or doesn't match
 
 **engine_getPayloadV6** builds execution payloads:
 
-- Returns ExecutionPayloadV4 structure
+- Returns `ExecutionPayloadV4` structure
 - Collects all account accesses and state changes during transaction execution
 - Populates `blockAccessList` field with RLP-encoded access list
 
-The execution layer provides the RLP-encoded `blockAccessList` to the consensus layer via the Engine API. The consensus layer then computes the SSZ `hash_tree_root` for storage in the `ExecutionPayloadHeader`.
+**Block processing flow:**
+
+When processing a block:
+1. The EL receives the BAL in the ExecutionPayload
+2. The EL computes `block_access_list_hash = keccak256(blockAccessList)` and includes it in the block header
+3. The EL executes the block and generates the actual BAL
+4. If the generated BAL doesn't match the provided BAL, the block is invalid (the hash in the header would be wrong)
+
+The execution layer provides the RLP-encoded `blockAccessList` to the consensus layer via the Engine API. The consensus layer then computes the SSZ `hash_tree_root` for storage in the `ExecutionPayload`.
+
+**Retrieval methods** for historical BALs (similar to `engine_getPayloadBodiesByHashV1`):
+- `engine_getBALsByHashV1`: Array of block hashes → Array of RLP-encoded BALs
+- `engine_getBALsByRangeV1`: Start block number, count → Array of RLP-encoded BALs
+
+The EL MUST retain BALs for at least the duration until the last finalized checkpoint to support synchronization from the latest finalized checkpoint performing re-execution on the EL.
 
 ### State Transition Function
 
 The state transition function must validate that the provided BAL matches the actual state accesses:
 
 ```python 
-def validate_block(block):
-    # 1. Verify provided BAL matches header hash
-    import rlp
-    provided_bal_hash = keccak256(rlp.encode(block.block_access_list))
-    assert provided_bal_hash == block.header.block_access_list_hash
+def validate_block(execution_payload, block_header):
+    # 1. Compute hash from received BAL and set in header
+    block_header.block_access_list_hash = keccak(execution_payload.blockAccessList)
     
     # 2. Execute block and collect actual accesses
-    actual_bal = execute_and_collect_accesses(block)
+    actual_bal = execute_and_collect_accesses(execution_payload)
     
     # 3. Verify actual execution matches provided BAL
-    actual_bal_hash = keccak256(rlp.encode(actual_bal))
-    assert actual_bal_hash == block.header.block_access_list_hash
+    # If this fails, the block is invalid (the hash in the header would be wrong)
+    assert rlp.encode(actual_bal) == execution_payload.blockAccessList
 
 def execute_and_collect_accesses(block):
     """Execute block and collect all state accesses into BAL format"""
@@ -319,9 +332,9 @@ def build_bal(accesses):
 
 The BAL MUST be complete and accurate. Missing or spurious entries invalidate the block.
 
-Clients MAY validate by comparing execution-gathered accesses with the BAL.
-
 Clients MAY invalidate immediately if any transaction exceeds declared state.
+
+Clients MUST store BALs separately from blocks and make them available via the engine API.
 
 ### Concrete Example
 
@@ -329,7 +342,7 @@ Example block:
 
 **Pre-execution:**
 
-- EIP-2935: Store parent hash at block hash contract (0x0000F90827F1C53a10cb7A02335B175320002935)
+- EIP-2935: Store parent hash at block hash contract (`0x0000F90827F1C53a10cb7A02335B175320002935`)
 - EIP-7002: Omitted for simplicity.
 
 **Transactions:**
@@ -440,7 +453,7 @@ This design variant was chosen for several key reasons:
 
 2. **Storage values for writes**: Post-execution values enable state reconstruction during sync without individual proofs against state root.
 
-3. **Overhead analysis**: Historical data shows ~45 KiB average BAL size.
+3. **Overhead analysis**: Historical data shows ~70 KiB average BAL size.
 
 4. **Transaction independence**: 60-80% of transactions access disjoint storage slots, enabling effective parallelization. The remaining 20-40% can be parallelized by having post-transaction state diffs.
 
@@ -448,7 +461,7 @@ This design variant was chosen for several key reasons:
 
 ### Block Size Considerations
 
-Block size impact (historical analysis):
+Block size impact (historical analysis at 36 million block gas limit):
 
 - Average: ~40 KiB (compressed)
 - Balance diffs: ~4.5 KiB (compressed)
@@ -468,7 +481,7 @@ BAL verification occurs alongside parallel IO and EVM operations without delayin
 
 ## Backwards Compatibility
 
-This proposal requires changes to the block structure that are not backwards compatible and require a hard fork.
+This proposal requires changes to the block structure and engine API that are not backwards compatible and require a hard fork.
 
 ## Security Considerations
 
@@ -478,7 +491,7 @@ Validating access lists and balance diffs adds validation overhead but is essent
 
 ### Block Size
 
-Increased block size impacts propagation but overhead (~40 KiB average) is reasonable for performance gains.
+Increased block size impacts propagation but overhead (~70 KiB average) is reasonable for performance gains.
 
 ## Copyright
 


### PR DESCRIPTION
* BALs are not in the EL block body anymore; they’re stored separately and sent via the `ExecutionPayload`.
* The header only commits to the BAL hash.
* Added explicit BAL retrieval RPCs and a minimum retention rule (until last finalized checkpoint).
* Updated BAL size estimates to ~70 KiB (compressed), analysis attached in the assets folder (prev PR).