### PR TITLE
Website: eliminate duplicate EIP/ERC prefix logic in eip.html

### DIFF
--- a/_layouts/eip.html
+++ b/_layouts/eip.html
@@ -18,6 +18,12 @@ layout: default
 </svg>
 
 <div class="home">
+  {% if page.category == "ERC" %}
+    {% assign spec_prefix = "ERC" %}
+  {% else %}
+    {% assign spec_prefix = "EIP" %}
+  {% endif %}
+  {% assign draftish = page.status == "Draft" or page.status == "Stagnant" or page.status == "Withdrawn" or page.status == "Review" or page.status == "Last Call" %}
   <span class="h5">
     {% if page.status == "Stagnant" %}
       <span class="badge text-light bg-danger" data-bs-toggle="tooltip" data-bs-title="This EIP had no activity for at least 6 months. This EIP should not be used.">🚧 Stagnant</span>
@@ -46,11 +52,7 @@ layout: default
     {% endif %}
   </span>
   <h1 class="page-heading">
-    {% if page.category == "ERC" %}
-      ERC-{{ page.eip | xml_escape }}: {{ page.title | xml_escape }}
-    {% elsif page.category != "ERC" %}
-      EIP-{{ page.eip | xml_escape }}: {{ page.title | xml_escape }}
-    {% endif %}
+    {{ spec_prefix }}-{{ page.eip | xml_escape }}: {{ page.title | xml_escape }}
     <a href="{{ page.discussions-to | uri_escape }}" class="no-underline">
       <svg role="img" aria-label="Discuss" class="inline-svg" xmlns="https://www.w3.org/2000/svg" viewBox="0 0 16 16">
         <use xlink:href="#bi-chat"/>
@@ -119,7 +121,7 @@ layout: default
   IEEE specification for reference formatting:
   https://ieee-dataport.org/sites/default/files/analysis/27/IEEE%20Citation%20Guidelines.pdf
   {% endcomment %}
-  <p>{% include authorlist.html authors=page.author %}, "{% if page.category == "ERC" %}ERC{% else %}EIP{% endif %}-{{ page.eip | xml_escape }}: {{ page.title | xml_escape }}{% if page.status == "Draft" or page.status == "Stagnant" or page.status == "Withdrawn" or page.status == "Review" or page.status == "Last Call" %} [DRAFT]{% endif %}," <em>Ethereum Improvement Proposals</em>, no. {{ page.eip | xml_escape }}, {{ page.created | date: "%B %Y" }}. [Online serial]. Available: https://eips.ethereum.org/EIPS/eip-{{ page.eip | xml_escape }}.</p>
+  <p>{% include authorlist.html authors=page.author %}, "{{ spec_prefix }}-{{ page.eip | xml_escape }}: {{ page.title | xml_escape }}{% if draftish %} [DRAFT]{% endif %}," <em>Ethereum Improvement Proposals</em>, no. {{ page.eip | xml_escape }}, {{ page.created | date: "%B %Y" }}. [Online serial]. Available: https://eips.ethereum.org/EIPS/eip-{{ page.eip | xml_escape }}.</p>
 </div>
 {% comment %}
 Article schema specification:
@@ -129,13 +131,8 @@ https://schema.org/TechArticle
   {
     "@context": "http://schema.org",
     "@type": "TechArticle",
-    {% if page.category == "ERC" %}
-    "headline": "ERC-{{ page.eip | xml_escape }}: {{ page.title | xml_escape }}{% if page.status == "Draft" or page.status == "Stagnant" or page.status == "Withdrawn" or page.status == "Review" or page.status == "Last Call" %} [DRAFT]{% endif %}",
-    "name": "ERC-{{ page.eip | xml_escape }}: {{ page.title | xml_escape }}{% if page.status == "Draft" or page.status == "Stagnant" or page.status == "Withdrawn" or page.status == "Review" or page.status == "Last Call" %} [DRAFT]{% endif %}",
-    {% else %}
-    "headline": "EIP-{{ page.eip | xml_escape }}: {{ page.title | xml_escape }}{% if page.status == "Draft" or page.status == "Stagnant" or page.status == "Withdrawn" or page.status == "Review" or page.status == "Last Call" %} [DRAFT]{% endif %}",
-    "name": "EIP-{{ page.eip | xml_escape }}: {{ page.title | xml_escape }}{% if page.status == "Draft" or page.status == "Stagnant" or page.status == "Withdrawn" or page.status == "Review" or page.status == "Last Call" %} [DRAFT]{% endif %}",
-    {% endif %}
+    "headline": "{{ spec_prefix }}-{{ page.eip | xml_escape }}: {{ page.title | xml_escape }}{% if draftish %} [DRAFT]{% endif %}",
+    "name": "{{ spec_prefix }}-{{ page.eip | xml_escape }}: {{ page.title | xml_escape }}{% if draftish %} [DRAFT]{% endif %}",
     "author": "{{ page.author }}",
     "dateCreated": "{{ page.created | date: "%Y-%m-%d" }}",
     "datePublished": "{{ page.created | date: "%Y-%m-%d" }}",


### PR DESCRIPTION
Reduces template redundancy by computing `spec_prefix` and `draftish` once at render time instead of re-evaluating the same conditions in multiple locations.