### PR TITLE
Update EIP-7928: change BAL retention period to WSP

### DIFF
--- a/EIPS/eip-7928.md
+++ b/EIPS/eip-7928.md
@@ -238,7 +238,7 @@ The execution layer provides the RLP-encoded `blockAccessList` to the consensus 
 - `engine_getBALsByHashV1`: Array of block hashes → Array of RLP-encoded BALs
 - `engine_getBALsByRangeV1`: Start block number, count → Array of RLP-encoded BALs
 
-The EL MUST retain BALs for at least the duration until the last finalized checkpoint to support synchronization from the latest finalized checkpoint performing re-execution on the EL.
+The EL MUST retain BALs for at least the duration the weak subjectivity period (`=3533 epochs`) to support synchronization with re-execution after being offline for less than the WSP.
 
 ### State Transition Function
 


### PR DESCRIPTION
As based on the discussion here, EL may store enough BAL to enable nodes that were offline for less than the WSP to catch up doing re-execution (for which BALs are needed):
https://discord.com/channels/595666850260713488/1364000387195076608/1450572627700617268