### PR TITLE
Update EIP-7773: Update EIP-7773 with EIP status decisions from ACDE 225

### DIFF
--- a/EIPS/eip-7773.md
+++ b/EIPS/eip-7773.md
@@ -25,17 +25,33 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Declined
 
 ### Considered for Inclusion
 
+* [EIP-7708](./eip-7708.md): ETH transfers emit a log
+* [EIP-7778](./eip-7778.md): Block Gas Accounting without Refunds
 * [EIP-7805](./eip-7805.md): Fork-choice enforced Inclusion Lists (FOCIL)
+* [EIP-7843](./eip-7843.md): SLOTNUM opcode
+* [EIP-8024](./eip-8024.md): Backward compatible SWAPN, DUPN, EXCHANGE
 * [EIP-8045](./eip-8045.md): Exclude slashed validators from proposing
 
 ### Declined for Inclusion
 
+* [EIP-6404](./eip-6404.md): SSZ transactions
+* [EIP-6466](./eip-6466.md): SSZ receipts
 * [EIP-7692](./eip-7692.md): EVM Object Format (EOFv1) Meta
 * [EIP-7782](./eip-7782.md): Reduce Block Latency
+* [EIP-7791](./eip-7791.md): GAS2ETH opcode
+* [EIP-7819](./eip-7819.md): SETDELEGATE instruction
 * [EIP-7886](./eip-7886.md): Delayed execution
 * [EIP-7919](./eip-7919.md): Pureth Meta
+* [EIP-7932](./eip-7932.md): Secondary Signature Algorithms
 * [EIP-7937](./eip-7937.md): EVM64 - 64-bit mode EVM opcodes
 * [EIP-7942](./eip-7942.md): Available Attestation
+* [EIP-7979](./eip-7979.md): Call and Return Opcodes for the EVM
+* [EIP-8011](./eip-8011.md): Multidimensional Gas Metering
+* [EIP-8013](./eip-8013.md): Static relative jumps and calls for the EVM
+* [EIP-8030](./eip-8030.md): P256 transaction support
+* [EIP-8053](./eip-8053.md): Milli-gas for High-precision Gas Metering
+* [EIP-8057](./eip-8057.md): Inter-Block Temporal Locality Gas Discounts
+* [EIP-8059](./eip-8059.md): Gas Units Rebase for High-precision Metering
 * [EIP-8062](./eip-8062.md): Add sweep withdrawal fee for 0x01 validators
 * [EIP-8071](./eip-8071.md): Prevent using consolidations as withdrawals
 * [EIP-8068](./eip-8068.md): Neutral effective balance design
@@ -45,42 +61,26 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Declined
 1. [EIP-2780](./eip-2780.md): Reduce intrinsic transaction gas
 1. [EIP-2926](./eip-2926.md): Chunk-based code merkelization
 1. [EIP-5920](./eip-5920.md): PAY opcode
-1. [EIP-6404](./eip-6404.md): SSZ transactions
-1. [EIP-6466](./eip-6466.md): SSZ receipts
 1. [EIP-7610](./eip-7610.md): Revert creation in case of non-empty storage
 1. [EIP-7668](./eip-7668.md): Remove bloom filters
 1. [EIP-7686](./eip-7686.md): Linear EVM memory limits
 1. [EIP-7688](./eip-7688.md): Forward compatible consensus data structures
-1. [EIP-7708](./eip-7708.md): ETH transfers emit a log
 1. [EIP-7745](./eip-7745.md): Trustless log index
-1. [EIP-7778](./eip-7778.md): Block Gas Accounting without Refunds
-1. [EIP-7791](./eip-7791.md): GAS2ETH opcode
 1. [EIP-7793](./eip-7793.md): Conditional Transactions
-1. [EIP-7819](./eip-7819.md): SETDELEGATE instruction
-1. [EIP-7843](./eip-7843.md): SLOTNUM opcode
 1. [EIP-7872](./eip-7872.md): Max blob flag for local builders
 1. [EIP-7903](./eip-7903.md): Remove Initcode Size Limit
 1. [EIP-7904](./eip-7904.md): General Repricing
 1. [EIP-7907](./eip-7907.md): Meter Contract Code Size And Increase Limit
 1. [EIP-7923](./eip-7923.md): Linear, Page-Based Memory Costing
-1. [EIP-7932](./eip-7932.md): Secondary Signature Algorithms
 1. [EIP-7949](./eip-7949.md): Schema for `genesis.json` files
 1. [EIP-7973](./eip-7973.md): Warm Account Write Metering
 1. [EIP-7976](./eip-7976.md): Increase Calldata Floor Cost
-1. [EIP-7979](./eip-7979.md): Call and Return Opcodes for the EVM
 1. [EIP-7971](./eip-7971.md): Hard Limits for Transient Storage
 1. [EIP-7981](./eip-7981.md): Increase Access List Cost
 1. [EIP-7997](./eip-7997.md): Deterministic Factory Predeploy
-1. [EIP-8011](./eip-8011.md): Multidimensional Gas Metering
-1. [EIP-8013](./eip-8013.md): Static relative jumps and calls for the EVM
-1. [EIP-8024](./eip-8024.md): Backward compatible SWAPN, DUPN, EXCHANGE
-1. [EIP-8030](./eip-8030.md): P256 transaction support
 1. [EIP-8032](./eip-8032.md): Size-Based Storage Gas Pricing
 1. [EIP-8037](./eip-8037.md): State Creation Gas Cost Increase
 1. [EIP-8038](./eip-8038.md): State-access gas cost increase
-1. [EIP-8053](./eip-8053.md): Milli-gas for High-precision Gas Metering
-1. [EIP-8059](./eip-8059.md): Gas Units Rebase for High-precision Metering
-1. [EIP-8057](./eip-8057.md): Inter-Block Temporal Locality Gas Discounts
 1. [EIP-8058](./eip-8058.md): Contract Bytecode Deduplication Discount
 1. [EIP-8061](./eip-8061.md): Increase exit and consolidation churn
 1. [EIP-8070](./eip-8070.md): Sparse Blobpool


### PR DESCRIPTION
Moved EL EIPs to CFI or DFI based on decisions from #1808: https://forkcast.org/calls/acde/225#t=1627
→ CFI: 7708, 7778, 7843, 8024
→ DFI: 6406, 6466, 7619, 7791, 7819, 7932, 7979, 8011, 8013, 8030, 8053, 8057, 8059