### PR TITLE
Update EIP-7923: Move to Draft

### DIFF
--- a/EIPS/eip-7923.md
+++ b/EIPS/eip-7923.md
@@ -4,7 +4,7 @@ title: Linear, Page-Based Memory Costing
 description: Linearize Memory Costing and replace the current quadratic formula with a page-based cost model.
 author: Charles Cooper (@charles-cooper), Qi Zhou (@qizhou)
 discussions-to: https://ethereum-magicians.org/t/eip-linearize-memory-costing/23290
-status: Stagnant
+status: Draft
 type: Standards Track
 category: Core
 created: 2025-03-27


### PR DESCRIPTION
Page 0 is free since the CALL overhead already pays for initial page allocation. This also improves backwards compatibility by keeping the cost for any access within the first page the same or lower than current pricing.