### PR TITLE
Update EIP-7002: Amount endianness

### DIFF
--- a/EIPS/eip-7002.md
+++ b/EIPS/eip-7002.md
@@ -63,7 +63,7 @@ with type `0x01` and consists of the following fields:
 3. `amount`: `uint64`
 
 The [EIP-7685](./eip-7685.md) encoding of a withdrawal request is computed as follows.
-Note that `amount` is returned by the contract little-endian, and must be encoded as such.
+Note that `amount` is stored as big-endian in storage, but is returned by the contract little-endian, and must be encoded as such.
 
 ```python
 request_type = WITHDRAWAL_REQUEST_TYPE
@@ -108,7 +108,7 @@ def add_withdrawal_request(Bytes48: validator_pubkey, uint64: amount):
     queue_storage_slot = WITHDRAWAL_REQUEST_QUEUE_STORAGE_OFFSET + queue_tail_index * 3
     sstore(WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS, queue_storage_slot, msg.sender)
     sstore(WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS, queue_storage_slot + 1, validator_pubkey[0:32])
-    sstore(WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS, queue_storage_slot + 2, validator_pubkey[32:48] ++ uint64_to_little_endian(amount))
+    sstore(WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS, queue_storage_slot + 2, (validator_pubkey[32:48] ++ amount).ljust(32, b"\x00"))
     sstore(WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS, WITHDRAWAL_REQUEST_QUEUE_TAIL_STORAGE_SLOT, queue_tail_index + 1)
 ```
 
@@ -201,7 +201,7 @@ def dequeue_withdrawal_requests():
         validator_pubkey = (
             sload(WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS, queue_storage_slot + 1)[0:32] + sload(WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS, queue_storage_slot + 2)[0:16]
         )
-        amount = little_endian_to_uint64(sload(WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS, queue_storage_slot + 2)[16:24])
+        amount = uint64(int.from_bytes(sload(WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS, queue_storage_slot + 2)[16:24], 'big'))
         req = ValidatorWithdrawalRequest(
             source_address=Bytes20(source_address),
             validator_pubkey=Bytes48(validator_pubkey),

--- a/EIPS/eip-7002.md
+++ b/EIPS/eip-7002.md
@@ -108,7 +108,7 @@ def add_withdrawal_request(Bytes48: validator_pubkey, uint64: amount):
     queue_storage_slot = WITHDRAWAL_REQUEST_QUEUE_STORAGE_OFFSET + queue_tail_index * 3
     sstore(WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS, queue_storage_slot, msg.sender)
     sstore(WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS, queue_storage_slot + 1, validator_pubkey[0:32])
-    sstore(WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS, queue_storage_slot + 2, (validator_pubkey[32:48] ++ amount).ljust(32, b"\x00"))
+    sstore(WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS, queue_storage_slot + 2, (validator_pubkey[32:48] + amount).ljust(32, b"\x00"))
     sstore(WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS, WITHDRAWAL_REQUEST_QUEUE_TAIL_STORAGE_SLOT, queue_tail_index + 1)
 ```
 

--- a/EIPS/eip-7002.md
+++ b/EIPS/eip-7002.md
@@ -90,7 +90,7 @@ If call data input to the contract is exactly `56` bytes, perform the following:
 Specifically, the functionality is defined in pseudocode as the function `add_withdrawal_request()`:
 
 ```python
-def add_withdrawal_request(Bytes48: validator_pubkey, uint64: amount):
+def add_withdrawal_request(calldata: Bytes56):
     """
     Add withdrawal request adds new request to the withdrawal request queue, so long as a sufficient fee is provided.
     """
@@ -98,6 +98,10 @@ def add_withdrawal_request(Bytes48: validator_pubkey, uint64: amount):
     # Verify sufficient fee was provided.
     fee = get_fee()
     require(msg.value >= fee, 'Insufficient value for fee')
+
+    # Parse calldata
+    validator_pubkey = calldata[:48]
+    amount = calldata[48:56]
 
     # Increment withdrawal request count.
     count = sload(WITHDRAWAL_REQUEST_PREDEPLOY_ADDRESS, WITHDRAWAL_REQUEST_COUNT_STORAGE_SLOT)


### PR DESCRIPTION
The PR fixes the pseudocode to correctly specify the big endian amount stored in the system contract storage.

h/t @marioevz @jochem-brouwer @fselmo 