### PR TITLE
Update EIP-7980: Fix license link path in EIP-7980

### DIFF
--- a/EIPS/eip-7980.md
+++ b/EIPS/eip-7980.md
@@ -75,4 +75,4 @@ Needs discussion.
 
 ## Copyright
 
-Copyright and related rights waived via [CC0](../../LICENSE.md).
+Copyright and related rights waived via [CC0](../LICENSE.md).


### PR DESCRIPTION
Correct the CC0 license link in EIPS/eip-7980.md to point to the existing EIPs/LICENSE.md file. No other content or behavior changes; docs-only fix.