### PR TITLE
Update EIP-7937: clarify 64-bit SIGNEXTEND semantics

### DIFF
--- a/EIPS/eip-7937.md
+++ b/EIPS/eip-7937.md
@@ -49,7 +49,8 @@ We define the following gas cost constants:
 The 64-bit mode arithmetic opcodes are defined the same as non-64-bit mode, except that it only operates on the least significant 64-bits. In the below definition, `a`, `b`, `N` is `a mod 2^64`, `b mod 2^64` and `N mod 2^64`.
 
 * ADD (`C001`) and SUB (`C003`): `a op b mod 2^64`, gas cost `G_VERYLOW64`.
-* MUL (`C002`), DIV (`C004`), SDIV (`C005`), MOD (`C006`), SMOD (`C007`), SIGNEXTEND (`C00B`): `a op b mod 2^64`, gas cost `G_LOW64`.
+* MUL (`C002`), DIV (`C004`), SDIV (`C005`), MOD (`C006`), SMOD (`C007`): `a op b mod 2^64`, gas cost `G_LOW64`.
+* SIGNEXTEND (`C00B`): same semantics as the base EVM `SIGNEXTEND`, but applied to `a mod 2^64` and `b mod 2^64`, with the result truncated to the least significant 64 bits. Gas cost `G_LOW64`.
 * ADDMOD (`C008`), MULMOD (`C009`): `a op b % N mod 2^64`, gas cost `G_MID64`.
 * EXP (`C00A`): `a EXP b mod 2^64`, gas cost `static_gas = G_EXP64_STATIC, dynamic_gas = G_EXP64_DYNAMIC * exponent_byte_size`.
 


### PR DESCRIPTION
The 64-bit mode arithmetic section was grouping SIGNEXTEND together with MUL/DIV/MOD and describing them all using the generic `a op b mod 2^64` formula. This is misleading for SIGNEXTEND, whose behavior is sign extension over a selected byte, not a simple binary operation on two operands.

This change moves SIGNEXTEND into its own bullet and describes it as having the same semantics as the base EVM SIGNEXTEND, applied to 64-bit truncated inputs with a 64-bit truncated result. This keeps EVM64 aligned with existing EVM semantics while making the spec unambiguous for implementers.