### PR TITLE
Update EIP-8051: align EIP-8051 signature_info length with ML-DSA container

### DIFF
--- a/EIPS/eip-8051.md
+++ b/EIPS/eip-8051.md
@@ -201,7 +201,7 @@ It represents in average 5 calls to the hash function. Taking linearly the cost 
 
 ### Compliance with EIP-7932
 
-In compliance with [EIP-7932](./eip-7932.md),  the necessary parameters and structure for its integration are provided. `ALG_TYPE = 0xD1`  uniquely identifies ML-DSA transactions, set MAX_SIZE = 2420 bytes to accommodate the fixed-length signature_info container, and recommend a `GAS_PENALTY` of approximately `3000` gas subject to benchmarking. The verification function follows the EIP-7932 model, parsing the signature_info, recovering the corresponding Dilithium public key, verifying the signature against the transaction payload hash, and deriving the signer's Ethereum address as the last 20 bytes of keccak256(pubkey). This definition ensures that ML-DSA can be cleanly adopted within the `AlgorithmicTransaction` container specified by EIP-7932.
+In compliance with [EIP-7932](./eip-7932.md),  the necessary parameters and structure for its integration are provided. `ALG_TYPE = 0xD1`  uniquely identifies ML-DSA transactions, set MAX_SIZE = 2441 bytes to accommodate the fixed-length signature_info container, and recommend a `GAS_PENALTY` of approximately `3000` gas subject to benchmarking. The verification function follows the EIP-7932 model, parsing the signature_info, recovering the corresponding Dilithium public key, verifying the signature against the transaction payload hash, and deriving the signer's Ethereum address as the last 20 bytes of keccak256(pubkey). This definition ensures that ML-DSA can be cleanly adopted within the `AlgorithmicTransaction` container specified by EIP-7932.
 
 ```python
 signature_info = Container[
@@ -221,7 +221,7 @@ In the format of EIP-7932:
 
 ```python
 verify(signature_info: bytes, payload_hash: Hash32) -> Bytes:
-    assert len(signature_info) == 699
+    assert len(signature_info) == 2441
     version      = signature_info[0]
     signature    = signature_info[1:2421]
     pubkey_hash  = signature_info[2421:2441]
@@ -235,7 +235,7 @@ verify(signature_info: bytes, payload_hash: Hash32) -> Bytes:
 
 ```python
 verify(signature_info: bytes, payload_hash: Hash32) -> Bytes:
-    assert len(signature_info) == 699
+    assert len(signature_info) == 2441
     version      = signature_info[0]
     signature    = signature_info[1:2421]
     pubkey_hash  = signature_info[2421:2441]


### PR DESCRIPTION
The EIP-8051 EIP-7932 integration described a signature_info container as (version: uint8, signature: ByteVector[2420], pubkey_hash: ByteVector[20]), which implies a 2441-byte payload. However, the text still used MAX_SIZE = 2420 and both verify() helpers asserted len(signature_info) == 699, a leftover from an earlier Falcon-style container. Updated MAX_SIZE to 2441 and adjusts both verify() functions to assert len(signature_info) == 2441 so that the checks match the declared ML-DSA container layout and the internal slicing logic (1:2421, 2421:2441).