### PR TITLE
Website: Remove deprecated IE meta tag from head template

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,6 +1,5 @@
 <head>
   <meta charset="utf-8" />
-  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   {% if page.layout == "eip" %}
     {% if page.category == "ERC" %}


### PR DESCRIPTION
Removes the obsolete `X-UA-Compatible` meta tag from `_includes/head.html`.