### PR TITLE
Update EIP-7998: avoid pre-fork randao seed computation

### DIFF
--- a/EIPS/eip-7998.md
+++ b/EIPS/eip-7998.md
@@ -50,13 +50,13 @@ The logic for verifying `body.randao_reveal` within `process_randao` is updated 
 ```python
 def process_randao(state: BeaconState, body: BeaconBlockBody) -> None:
     epoch = get_current_epoch(state)
-    previous_epoch = get_previous_epoch(state)
-    previous_mix = get_randao_mix(state, previous_epoch)
     # Verify RANDAO reveal
     proposer = state.validators[get_beacon_proposer_index(state)]
     if epoch < FORK_EPOCH:
         signing_root = compute_signing_root(epoch, get_domain(state, DOMAIN_RANDAO))
     else:
+        previous_epoch = get_previous_epoch(state)
+        previous_mix = get_randao_mix(state, previous_epoch)
         seed = RandaoRevealSeed(previous_mix, state.slot)
         signing_root = compute_signing_root(seed, get_domain(state, DOMAIN_RANDAO))
     assert bls.Verify(proposer.pubkey, signing_root, body.randao_reveal)


### PR DESCRIPTION
Moved previous_epoch and previous_mix computation into the post-fork branch of process_randao so we only call get_previous_epoch and get_randao_mix when the new RandaoRevealSeed path is actually used. This removes unnecessary work before FORK_EPOCH without changing behavior and keeps the example closer to the phase0 consensus spec style.