### PR TITLE
Update EIP-7906: correct CALL opcode value from 0xFA to 0xF1

### DIFF
--- a/EIPS/eip-7906.md
+++ b/EIPS/eip-7906.md
@@ -135,7 +135,7 @@ Including all opcodes called during a transaction execution in the stack trace i
 * `DELEGATECALL` (`0xF4`)
 * `CALLCODE` (`0xF2`)
 * `STATICCALL` (`0xFA`)
-* `CALL` (`0xFA`)
+* `CALL` (`0xF1`)
 * `LOG` (`0xA0`)
 * `LOG1` (`0xA1`)
 * `LOG2` (`0xA2`)


### PR DESCRIPTION
Fix incorrect CALL opcode value. It was listed as 0xFA (STATICCALL) instead of 0xF1.