### PR TITLE
Update EIP-7935: fix discussion URL

### DIFF
--- a/EIPS/eip-7935.md
+++ b/EIPS/eip-7935.md
@@ -3,7 +3,7 @@ eip: 7935
 title: Set default gas limit to 60M
 description: Recommend a new gas limit value for Fusaka and update execution layer client default configs
 author: Sophia Gold (@sophia-gold), Parithosh Jayanthi (@parithoshj), Toni Wahrstätter (@nerolation), Carl Beekhuizen (@CarlBeek), Ansgar Dietrichs (@adietrichs), Dankrad Feist (@dankrad), Alex Stokes (@ralexstokes), Josh Rudolph (@jrudolph), Giulio Rebuffo (@Giulio2002), Storm Slivkoff (@sslivkoff), Kamil Chodoła (@kamilchodola)
-discussions-to: https://ethereum-magicians.org/t/eip-7935-set-default-gas-limit-to-xx0m/23789
+discussions-to: https://ethereum-magicians.org/t/eip-7935-set-default-gas-limit-to-60m/23789
 status: Last Call
 last-call-deadline: 2025-10-28
 type: Informational


### PR DESCRIPTION
Updated the `discussions-to` link by replacing the `xx0m` placeholder with the correct value `60m`.