### PR TITLE
Update EIP-7932: fix undefined SIZE in EIP-7932

### DIFF
--- a/EIPS/eip-7932.md
+++ b/EIPS/eip-7932.md
@@ -69,7 +69,7 @@ trait Algorithm {
 }
 ```
 
-Specifications MUST include some form of security analysis on the provided algorithm and basic benchmarks justifying gas costs. Additionally, specifications MUST address malleability issue that may arrise from specified algorithms. 
+Specifications MUST include some form of security analysis on the provided algorithm and basic benchmarks justifying gas costs. Additionally, specifications MUST address malleability issue that may arise from specified algorithms. 
 
 An example of this specification can be found [here](../assets/eip-7932/template-eip.md).
 
@@ -137,7 +137,7 @@ def verify_signature(signing_data: Bytes, signature: Bytes) -> Bytes:
 
 ```python
 ALG_TYPE = 0xFF
-SIZE = 
+SIZE = 66
 
 SECP256K1_SIGNATURE_SIZE = SIZE - 1
 


### PR DESCRIPTION
Corrected spelling 'arrise' to 'arise', set missing SIZE value to 66 for secp256k1 algorithm signature structure.