### PR TITLE
Update EIP-7773: Fix EIP ordering

### DIFF
--- a/EIPS/eip-7773.md
+++ b/EIPS/eip-7773.md
@@ -54,8 +54,8 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Declined
 * [EIP-8057](./eip-8057.md): Inter-Block Temporal Locality Gas Discounts
 * [EIP-8059](./eip-8059.md): Gas Units Rebase for High-precision Metering
 * [EIP-8062](./eip-8062.md): Add sweep withdrawal fee for 0x01 validators
-* [EIP-8071](./eip-8071.md): Prevent using consolidations as withdrawals
 * [EIP-8068](./eip-8068.md): Neutral effective balance design
+* [EIP-8071](./eip-8071.md): Prevent using consolidations as withdrawals
 
 ### Proposed for Inclusion
 
@@ -75,14 +75,14 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Declined
 1. [EIP-7923](./eip-7923.md): Linear, Page-Based Memory Costing
 1. [EIP-7949](./eip-7949.md): Schema for `genesis.json` files
 1. [EIP-7973](./eip-7973.md): Warm Account Write Metering
-1. [EIP-7976](./eip-7976.md): Increase Calldata Floor Cost
 1. [EIP-7971](./eip-7971.md): Hard Limits for Transient Storage
+1. [EIP-7976](./eip-7976.md): Increase Calldata Floor Cost
 1. [EIP-7981](./eip-7981.md): Increase Access List Cost
 1. [EIP-7997](./eip-7997.md): Deterministic Factory Predeploy
 1. [EIP-8032](./eip-8032.md): Size-Based Storage Gas Pricing
 1. [EIP-8037](./eip-8037.md): State Creation Gas Cost Increase
 1. [EIP-8038](./eip-8038.md): State-access gas cost increase
-1. [EIP-8051](./eip-8051.md): Precompile for ML-DSA signature verification 
+1. [EIP-8051](./eip-8051.md): Precompile for ML-DSA signature verification
 1. [EIP-8058](./eip-8058.md): Contract Bytecode Deduplication Discount
 1. [EIP-8061](./eip-8061.md): Increase exit and consolidation churn
 1. [EIP-8070](./eip-8070.md): Sparse Blobpool


### PR DESCRIPTION
Corrected numerical order of EIPs 8068/8071 and 7971/7976, removed trailing whitespace.