### PR TITLE
Update EIP-8032: use S_pre in SSTORE gas formula

### DIFF
--- a/EIPS/eip-8032.md
+++ b/EIPS/eip-8032.md
@@ -146,7 +146,7 @@ If `storage_count(A)` is absent at block start, clients MUST treat `S_pre(A) = 0
 The gas cost of an `SSTORE` is computed as such:
 
 ```python=
-constant_sstore_gas(addr, slot) + LIN_FACTOR * ceil_log16(account.storage_count) // ACTIVATION_THRESHOLD
+constant_sstore_gas(addr, slot) + LIN_FACTOR * ceil_log16(S_pre(addr)) // ACTIVATION_THRESHOLD
 ```
 
 ### Impact on state size


### PR DESCRIPTION
The SSTORE gas cost section defines S_pre(A) as the storage_count(A) taken from the parent state and mandates that implementations MUST use this pre-state value for all SSTOREs in a block. However, the formula still referenced account.storage_count, which is not clearly tied to S_pre and makes it ambiguous whether a live or pre-state value is used. This change updates the formula to use S_pre(addr) explicitly, aligning the pseudocode with the normative text and making it clear that the gas calculation is based on the per-account storage count from the parent state, held constant for the duration of the block.