### PR TITLE
Update EIP-7973: fix constant name inconsistencies

### DIFF
--- a/EIPS/eip-7973.md
+++ b/EIPS/eip-7973.md
@@ -37,8 +37,8 @@ The parameters `GAS_CALL_VALUE` and `GAS_STORAGE_UPDATE` are removed, and the fo
 
 On the account-updating opcodes `CREATE`, `CREATE2`, and `*CALL`, instead of charging `GAS_CALL_VALUE`:
 
-- `GAS_COLD_ACCOUNT_WRITE_COST` is charged if the account fields **are equal** to the transaction start values (i.e., they have not yet been updated by the transaction), or
-- `GAS_WARM_ACCOUNT_WRITE_COST` is charged if the account fields **are not equal** to the transaction start values (i.e., they have already been updated before by the transaction).
+- `GAS_COLD_ACCOUNT_WRITE` is charged if the account fields **are equal** to the transaction start values (i.e., they have not yet been updated by the transaction), or
+- `GAS_WARM_WRITE` is charged if the account fields **are not equal** to the transaction start values (i.e., they have already been updated before by the transaction).
 
 `SSTORE` is also subjected to warm account metering. That is, this EIP splits the cost of `SSTORE` into two components, the cost to update the account tuple, and the cost to update the state trie. Note that if the state trie has already been updated once in a transaction, the account tuple is already dirty, and so we can amortize the cost of updating the account tuple again. Thus, the gas cost of `SSTORE` and its refund logic is updated to:
 
@@ -59,9 +59,9 @@ gas_cost = Uint(0)
 
 # Charge account write cost
 if account != original_account:
-    gas_cost += GAS_WARM_ACCOUNT_WRITE_COST
+    gas_cost += GAS_WARM_WRITE
 else:
-    gas_cost += GAS_COLD_ACCOUNT_WRITE_COST
+    gas_cost += GAS_COLD_ACCOUNT_WRITE
 
 # Charge slot-specific costs
 if (evm.message.current_target, key) not in evm.accessed_storage_keys:
@@ -98,7 +98,7 @@ if current_value != new_value:
                 )
         # Refund account writting cost (only if cold)
         if account == original_account:
-            evm.refund_counter += GAS_COLD_ACCOUNT_WRITE_COST
+            evm.refund_counter += GAS_COLD_ACCOUNT_WRITE
 
 ```
 


### PR DESCRIPTION
Align constant usage with definitions by removing `_COST` suffix from lines 40, 62, 64, 101, changing `GAS_COLD_ACCOUNT_WRITE_COST` to `GAS_COLD_ACCOUNT_WRITE` and `GAS_WARM_ACCOUNT_WRITE_COST` to `GAS_WARM_WRITE` to match the constants defined in the specification table.