### PR TITLE
Update EIP-8030: correct Python function definition syntax

### DIFF
--- a/EIPS/eip-8030.md
+++ b/EIPS/eip-8030.md
@@ -44,11 +44,11 @@ def gas_cost(signing_data: Bytes) -> Uint64:
         minimum_word_size = (len(signing_data) + 31) // 32
         return BASE_GAS + Uint64(30 + (6 * minimum_word_size))
 
-def validate(signature: Bytes) -> None | Error;
+def validate(signature: Bytes) -> None | Error:
     # This function is a noop as there is no
     # exposed function defined in [EIP-7951](./eip-7951.md)
 
-def verify(signature: Bytes, signing_data: Bytes) -> Bytes | Error;
+def verify(signature: Bytes, signing_data: Bytes) -> Bytes | Error:
     if len(signing_data) != 32:
         # Hash if non-standard size
         signing_data = keccak256(signing_data)


### PR DESCRIPTION
Change semicolons to colons in function definitions on lines 47 and 51, as Python function definitions require colons not semicolons.