### PR TITLE
Update EIP-8011: correct return type annotation syntax

### DIFF
--- a/EIPS/eip-8011.md
+++ b/EIPS/eip-8011.md
@@ -76,7 +76,7 @@ At the transaction level, everything remains the same. A transaction still has t
 The key change is the introduction of `gas_used_vector` as a new variable that tracks the gas used by each resource at the transaction level. This variable is returned by the `execute_transaction` function, in addition to `gas_used`:
 
 ```python
-def execute_transaction(self, transaction: NormalizedTransaction, effective_gas_price: int) -> int, narray: pass
+def execute_transaction(self, transaction: NormalizedTransaction, effective_gas_price: int) -> tuple[int, list]: pass
 ```
 
 ### Block header extension


### PR DESCRIPTION
Fix invalid return type annotation on line 79, changing `-> int, narray:` to `-> tuple[int, list]:` to match proper Python type hint syntax.