### PR TITLE
Update EIP-8061: remove fork name from constant

### DIFF
--- a/EIPS/eip-8061.md
+++ b/EIPS/eip-8061.md
@@ -40,7 +40,7 @@ The `CHURN_LIMIT_QUOTIENT` is halved, from `2**16` to `2**15`, and fully dedicat
 
 | Name                                   | Value                      |
 | -------------------------------------- | -------------------------- |
-| `CHURN_LIMIT_QUOTIENT_GLOAS`           | `uint64(2**15)` (= 32,768) |
+| `CHURN_LIMIT_QUOTIENT`                 | `uint64(2**15)` (= 32,768) |
 | `CONSOLIDATION_CHURN_LIMIT_QUOTIENT`   | `uint64(2**16)` (= 65,536) |
 | `MAX_PER_EPOCH_ACTIVATION_CHURN_LIMIT` | `uint64(2**8)`  (=256)     |
 
@@ -55,7 +55,7 @@ def get_activation_churn_limit(state: BeaconState) -> Gwei:
     """
     churn = max(
         MIN_PER_EPOCH_CHURN_LIMIT_ELECTRA,
-        get_total_active_balance(state) // CHURN_LIMIT_QUOTIENT_GLOAS
+        get_total_active_balance(state) // CHURN_LIMIT_QUOTIENT
     )
     churn = churn - churn % EFFECTIVE_BALANCE_INCREMENT
     return min(MAX_PER_EPOCH_ACTIVATION_CHURN_LIMIT, churn)
@@ -66,7 +66,7 @@ def get_exit_churn_limit(state: BeaconState) -> Gwei:
     """
     churn = max(
         MIN_PER_EPOCH_CHURN_LIMIT_ELECTRA,
-        get_total_active_balance(state) // CHURN_LIMIT_QUOTIENT_GLOAS
+        get_total_active_balance(state) // CHURN_LIMIT_QUOTIENT
     )
     return churn - churn % EFFECTIVE_BALANCE_INCREMENT
 


### PR DESCRIPTION
Remove `_GLOAS` suffix from `CHURN_LIMIT_QUOTIENT` on lines 43, 58, 69, as the constant definition should not include fork-specific naming per EIP conventions.