### PR TITLE
Update EIP-7377: clarify storage tuple processing in EIP-7377

### DIFF
--- a/EIPS/eip-7377.md
+++ b/EIPS/eip-7377.md
@@ -73,7 +73,7 @@ Executing a migration transaction has two parts.
 
 Unlike standard contract deployment, a migration transaction directly specifies what `code` value the sender's account should be set to.
 
-As the first step of processing the transaction, set the sender's `code` to `state[tx.codeAddr].code`. Next, for each tuple in `tx.storage` and the sender's storage trie, set `storage[t.first] = t.second`.
+As the first step of processing the transaction, set the sender's `code` to `state[tx.codeAddr].code`. Next, for each tuple `(slot, value)` in `tx.storage`, set the sender's storage slot `slot` to `value`.
 
 ##### Transaction Execution
 


### PR DESCRIPTION
## Fix

Clarifies ambiguous wording in the storage tuple processing specification that could be misinterpreted.

## Changes

- Replaces "for each tuple in `tx.storage` and the sender's storage trie" with explicit "for each tuple `(slot, value)` in `tx.storage`"
- Removes non-standard `t.first`/`t.second` notation in favor of descriptive tuple structure `(slot, value)`
- Makes it clear that only tuples from `tx.storage` are processed, not the existing storage trie