### PR TITLE
Update EIP-8061: fix function docstring and typo

### DIFF
--- a/EIPS/eip-8061.md
+++ b/EIPS/eip-8061.md
@@ -62,7 +62,7 @@ def get_activation_churn_limit(state: BeaconState) -> Gwei:
 
 def get_exit_churn_limit(state: BeaconState) -> Gwei:
     """
-    Per-epoch churn limit for activations, rounded to EFFECTIVE_BALANCE_INCREMENT.
+    Per-epoch churn limit for exits, rounded to EFFECTIVE_BALANCE_INCREMENT.
     """
     churn = max(
         MIN_PER_EPOCH_CHURN_LIMIT_ELECTRA,
@@ -99,7 +99,7 @@ def compute_weak_subjectivity_period(state: BeaconState) -> uint64:
 
 ### Deposit processing
 
-The only modification is replacing `get_activation_exit_churn_limit` with `get_activation_churn_limit`, maintaing the current cap on deposit churn respects, while removing the cap from exits. This reverts to the pre-Electra status quo, when activations were capped but exits were not.
+The only modification is replacing `get_activation_exit_churn_limit` with `get_activation_churn_limit`, maintaining the current cap on deposit churn, while removing the cap from exits. This reverts to the pre-Electra status quo, when activations were capped but exits were not.
 
 ```python
 def process_pending_deposits(state: BeaconState) -> None:


### PR DESCRIPTION
Corrects `get_exit_churn_limit` docstring from "activations" to "exits", fixes spelling error "maintaing" to "maintaining"