### PR TITLE
Update EIP-7928: clarify spurious entry detection and fix typos

### DIFF
--- a/EIPS/eip-7928.md
+++ b/EIPS/eip-7928.md
@@ -117,7 +117,7 @@ Entries from an [EIP-2930](./eip-2930.md) access list **MUST NOT** be included a
 The following ordering rules **MUST** apply:
 
 - **Accounts**: Lexicographic by address
-- **storage_changes**: Slots lexicographic by storage key; within each slot, changes by block access index index (ascending)
+- **storage_changes**: Slots lexicographic by storage key; within each slot, changes by block access index (ascending)
 - **storage_reads**: Lexicographic by storage key
 - **balance_changes, nonce_changes, code_changes**: By block access index (ascending)
 
@@ -238,7 +238,7 @@ The execution layer provides the RLP-encoded `blockAccessList` to the consensus 
 - `engine_getBALsByHashV1`: Array of block hashes → Array of RLP-encoded BALs
 - `engine_getBALsByRangeV1`: Start block number, count → Array of RLP-encoded BALs
 
-The EL MUST retain BALs for at least the duration the weak subjectivity period (`=3533 epochs`) to support synchronization with re-execution after being offline for less than the WSP.
+The EL MUST retain BALs for at least the duration of the weak subjectivity period (`=3533 epochs`) to support synchronization with re-execution after being offline for less than the WSP.
 
 ### State Transition Function
 
@@ -332,7 +332,7 @@ def build_bal(accesses):
     return bal
 ```
 
-The BAL MUST be complete and accurate. Missing or spurious entries invalidate the block.
+The BAL MUST be complete and accurate. Missing or spurious entries invalidate the block. Spurious entries MAY be detected by validating BAL indices, which MUST never be higher than `len(transactions) + 1`.
 
 Clients MAY invalidate immediately if any transaction exceeds declared state.
 


### PR DESCRIPTION
- Add clarification that spurious BAL entries MAY be detected by validating indices, which MUST not exceed len(transactions) + 1

+ some typo fixes
