### PR TITLE
Update EIP-7907: Minor clarifications for readability

### DIFF
--- a/EIPS/eip-7907.md
+++ b/EIPS/eip-7907.md
@@ -54,11 +54,11 @@ def excess_code_size(n: int) -> int:
 
 ### Behavior
 
-1. Update the [EIP-170](./eip-170.md) introduced `MAX_CODE_SIZE` constant of 24KB (`0x6000` bytes) to 64KB (`0x10000` bytes).
-2. Introduces a new cold/warm state for contract code. Specifically, change the gas schedule of operations that load code, e.g. the opcodes `CALL`, `STATICCALL`, `DELEGATECALL`, `CALLCODE` and `EXTCODECOPY` are modified so that dynamic `EXCESS_CODE_COST= ceil32(excess_code_size(len(code))) * GAS_PER_CODE_WORD // 32` gas are added to the access cost if the code is cold. When the code is an [EIP-7702](./eip-7702.md) delegation to another account, if target account code is cold add additional gas should be accounted. Warming of the contract code is subjected to the journaling and can be reverted similar to other state warming in [EIP-2930](./eip-2930.md).
-3. Update the [EIP-3860](./eip-3860.md) introduced `MAX_INITCODE_SIZE` limit of 48KB (`0xc000` bytes) to 128KB (`0x10000` bytes).
+1. Update the [EIP-170](./eip-170.md) `MAX_CODE_SIZE` constant of 24KB (`0x6000` bytes) to 64KB (`0x10000` bytes).
+2. Introduces a new cold/warm state for contract code. Specifically, change the gas schedule of operations that load code, e.g. the opcodes `CALL`, `STATICCALL`, `DELEGATECALL`, `CALLCODE` and `EXTCODECOPY` are modified so that dynamic `EXCESS_CODE_COST = ceil32(excess_code_size(len(code))) * GAS_PER_CODE_WORD // 32` gas are added to the access cost if the code is cold. When the code is an [EIP-7702](./eip-7702.md) delegation to another account and the target account’s code is cold, additional gas MUST be charged. Warming of the contract code is subject to journaling and can be reverted similar to other state warming in [EIP-2930](./eip-2930.md).
+3. Update the [EIP-3860](./eip-3860.md) `MAX_INITCODE_SIZE` limit of 48KB (`0xc000` bytes) to 128KB (`0x20000` bytes).
 4. If a large contract is the entry point of a transaction, the cost calculated in (2) is charged before the execution and contract code is marked as warm. This fee is not calculated towards the initial gas fee. In case of out-of-gas halt, execution will stop and the balance will not be transferred.
-6. Empty code ( with `keccak("") = "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"`) is always considered warm.
+5. Empty code ( with `keccak("") = "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"`) is always considered warm.
 
 | Contract                | Gas changes (only opcodes that load code)                          | How?                                                                                                                       |
 | ----------------------- | ------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
Clarifying some sentences, fixing some areas, while reviewing the EIP. Happy to ignore some of these but I think it helps with readability.

- 128 KB had `0x10000` (possibly copied from `64KB (0x10000 bytes)`). Should be `0x20000`.
- List had 1, 2, 3, 4, 6... should be 1, 2, 3, 4, 5.
- Remove `introduced`. I feel like this would be hyphenated "Update the EIP-170-introduced constant...". But we don't need the `introduced` here. We can say "Update the EIP-170 constant".
- Some clarification in delegation sentence / just rephrasing.