### PR TITLE
Update EIP-7979: fix typo and formatting errors

### DIFF
--- a/EIPS/eip-7979.md
+++ b/EIPS/eip-7979.md
@@ -53,7 +53,7 @@ In 1950 Alan Turing answered "Lady Lovelace's Objection" with a question of his 
 
 Call and return facilities of various levels of complexity — from Burroughs' baroque ALGOL support to RISC-V's subtly dynamic `JAL` and  `JALR` — have proven their worth across a long line of important machines over the last 80 years.  This includes most all of the machines we have programmed or implemented: physical machines including the Burroughs 5000, CDC 7600, IBM 360, PDP-11, VAX, Motorola 68000, Sun SPARC, Intel x86s, and others, as well as virtual machines for Scheme, Forth, Pascal, Java, Wasm, .NET and others.
 
-Especially relevant to the EVM's design are the Jave, Wasm, and .NET VMs.  They share some important features:  their programs are all represented with a portable bytecode, the bytecode can be directly interpreted, and the bytecode can also be translated to machine code with a one-pass JIT.
+Especially relevant to the EVM's design are the Java, Wasm, and .NET VMs.  They share some important features:  their programs are all represented with a portable bytecode, the bytecode can be directly interpreted, and the bytecode can also be translated to machine code with a one-pass JIT.
 
 ### The EVM control-flow facility
 
@@ -212,7 +212,7 @@ The difference these instructions make can be seen in this very simple code for 
 
 SQUARE:                           |       SQUARE:
     jumpdest       ; 1 gas        |           entersub       ; 1 gas
-    dup            ; 3 gas        |           dup            : 5 gas
+    dup            ; 3 gas        |           dup            ; 5 gas
     mul            ; 5 gas        |           mul            ; 5 gas
     swap1          ; 3 gas        |           returnsub      ; 5 gas
     jump           ; 8 gas        |
@@ -464,7 +464,7 @@ These changes introduce new flow control instructions.  They do not introduce an
        }
      ],
      "DOI": "arXiv:2101.05735",
-     "title": "The Good, the Bad and the Ugly: Pitfalls and Best Practices in Automated Sound Static Analysis of Ethereum Smart Contracts.,
+     "title": "The Good, the Bad and the Ugly: Pitfalls and Best Practices in Automated Sound Static Analysis of Ethereum Smart Contracts.",
      "original-date": {
        "date-parts": [
          [2021, 1, 14]
@@ -485,7 +485,7 @@ These changes introduce new flow control instructions.  They do not introduce an
        }
      ],
      "DOI": "arXiv:2004.14437",
-     "title": "Analyzing Smart Contracts: From EVM to a sound Control-Flow Graph.,
+     "title": "Analyzing Smart Contracts: From EVM to a sound Control-Flow Graph.",
      "original-date": {
        "date-parts": [
          [2020, 4, 29]


### PR DESCRIPTION
Corrects typo "Jave" to "Java" and comment syntax inconsistency, fixes missing quotation marks in JSON bibliography entries.