### PR TITLE
Update EIP-7727: fix grammar and add missing constant

### DIFF
--- a/EIPS/eip-7727.md
+++ b/EIPS/eip-7727.md
@@ -38,6 +38,7 @@ Currently, a single block builder has unrestricted control over the final sequen
 | BUNDLE_TX_TYPE | 0x06 |
 | BUNDLE_BASE_GAS_COST | TBD <!-- TODO --> |
 | BUNDLE_SIGNER_OPCODE_NUMBER | TBD <!-- TODO --> |
+| CALLDATA_COST | TBD <!-- TODO --> |
 
 ### New Transaction Payload Types
 
@@ -86,7 +87,7 @@ For the `BUNDLE_TX_TYPE`, the transaction payload should be interpreted as:
 
 Where the `transactionList` element is a list of syntactically valid transactions of either type `DELEGATED_TX_TYPE` or `BUNDLE_TX_TYPE`. At least one transaction must be in the list.
 
-An example would of the `transactionList` would be:
+An example of the `transactionList` would be:
 
 ```go
 [
@@ -102,7 +103,7 @@ The `signatureYParity`, `signatureR`, `signatureS` elements of the `BUNDLE_TX_
 keccak256(0x06 || rlp([bundleSigner, blockNumber, chainId, nonce, gasPrice, transactionList]))
 ```
 
-We’ll refer to address resolved by this signature the bundle transaction’s signer. 
+We'll refer to the address resolved by this signature the bundle transaction's signer. 
 
 ### `BUNDLE_SIGNER` Opcode
 
@@ -136,7 +137,7 @@ The formula is calculated as follows:
 
 ```go
 BUNDLE_BASE_GAS_COST +
-    (CALL_DATA_TOKEN_COST * transaction_list_invalid_tx_byte_length)
+    (CALLDATA_COST * transaction_list_invalid_tx_byte_length)
 
 ```
 
@@ -148,7 +149,7 @@ The `DELEGATED_TX_TYPE` follows typical gas costing rules.
 
 `DELEGATED_TX_TYPE` execute normally with the `BUNDLE_SIGNER` opcode returning the `bundleSigner` payload variable.
 
-`BUNDLE_TX_TYPE` do not start execution contexts. The`BUNDLE_TX_TYPE`'s `NONCE` must be incremented before the start of any `transactionList` execution.
+`BUNDLE_TX_TYPE` do not start execution contexts. The `BUNDLE_TX_TYPE`'s `NONCE` must be incremented before the start of any `transactionList` execution.
 
 ### ReceiptPayload Definitions
 
@@ -168,7 +169,7 @@ rlp([statusArray, cumulativeGasUsed])
 
 Where the `statusArray` is a list of status results for the inner `transactionList`'s transactions. The list must be the same length as the `transactionList` and report the statuses in the same order. The status type `0x3` should be used to report invalid transactions.
 
-The `cumulateGasUsed` is the amount of gas spent by the `BUNDLE_TX_TYPE`'s signer on the `BUNDLE_TX_TYPE` transaction costs post `CALLDATA` refund. 
+The `cumulativeGasUsed` is the amount of gas spent by the `BUNDLE_TX_TYPE`'s signer on the `BUNDLE_TX_TYPE` transaction costs post `CALLDATA` refund. 
 
 ## Rationale
 


### PR DESCRIPTION
Corrects grammar errors and spelling inconsistency, adds missing CALLDATA_COST constant definition and updates its usage.