### PR TITLE
Update EIP-5450: align JUMPF validation formula with EIP-6206

### DIFF
--- a/EIPS/eip-5450.md
+++ b/EIPS/eip-5450.md
@@ -27,7 +27,7 @@ and preventing the execution and deployment of any invalid code.
 The operand stack validation provides several benefits:
 
 - removes the run-time stack underflow check for all instructions,
-- removes the run-time stack overflow check for all instructions except `CALLF` and `JUMPF` (`JUMPF` introduced in a separate EIP) ,
+- removes the run-time stack overflow check for all instructions except `CALLF` and `JUMPF` (`JUMPF` introduced in [EIP-6206](./eip-6206.md)),
 - ensures that execution terminates with one of the terminating instructions,
 - prevents deployment of code with unreachable instructions, thereby discouraging the use of code sections for data storage.
 
@@ -61,7 +61,7 @@ In the second validation phase control-flow analysis is performed on the code.
 - ending function execution: `RETF`, `JUMPF`, or
 - ending call frame execution: `STOP`, `RETURN`, `RETURNCODE`, `REVERT`, `INVALID`.
 
-*note: `JUMPF` and `RETURNCODE` are introduced in separate EIPs.*
+*note: `JUMPF` is introduced in [EIP-6206](./eip-6206.md) and `RETURNCODE` is introduced in [EIP-7620](./eip-7620.md).*
 
 *Forward jump* refers to any of `RJUMP`/`RJUMPI`/`RJUMPV` instruction with relative offset greater than or equal to 0. *Backwards jump* refers to any of `RJUMP`/`RJUMPI`/`RJUMPV` instruction with relative offset less than 0, including jumps to the same jump instruction.
 
@@ -77,7 +77,7 @@ For each instruction:
    1. **Check** if the recorded stack height bounds satisfy the instruction requirements. Specifically:
       - for `CALLF` instruction the recorded stack height lower bound must be at least the number of inputs of the called function according to its type defined in the type section,
       - for `RETF` instruction both the recorded lower and upper bound must be equal and must be exactly the number of outputs of the function matching the code,
-      - for `JUMPF` into returning function both the recorded lower and upper bound must equal exactly `type[current_section_index].outputs + type[target_section_index].inputs - type[target_section_index].outputs`,
+      - for `JUMPF` into returning function both the recorded lower and upper bound must equal exactly `type[current_section_index].outputs - type[target_section_index].outputs + type[target_section_index].inputs`,
       - for `JUMPF` into non-returning function the recorded stack height lower bound must be at least the number of inputs of the target function according to its type defined in the type section,
       - for any other instruction the recorded stack height lower bound must be at least the number of inputs required by instruction,
       - there is no additional check for terminating instructions other than `RETF` and `JUMPF`, this implies that extra items left on stack at instruction ending EVM execution are allowed.


### PR DESCRIPTION
## Fix

Aligns JUMPF validation formula with EIP-6206 and adds explicit EIP references.

## Changes

- Reorder JUMPF validation formula terms to match EIP-6206
- Replace "separate EIPs" with direct links to EIP-6206 and EIP-7620