### PR TITLE
Update EIP-3014: Fix duplicate word repetitions

### DIFF
--- a/EIPS/eip-3014.md
+++ b/EIPS/eip-3014.md
@@ -39,7 +39,7 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"eth_symbol","params":[],"id":1}'
 ```
 
 ## Rationale
-This endpoint is similar to [EIP-695](./eip-695.md) but it provides the symbol instead of `chainId`. It provides functionality that is already there for [ERC-20](./eip-20.md) tokens, but not yet for the native coin of the network. Alternative naming of `eth_nativeCurrencySymbol` was considered, but the context and the fact that it just returns one value makes it clear that that it returns the symbol for the native coin of the network.
+This endpoint is similar to [EIP-695](./eip-695.md) but it provides the symbol instead of `chainId`. It provides functionality that is already there for [ERC-20](./eip-20.md) tokens, but not yet for the native coin of the network. Alternative naming of `eth_nativeCurrencySymbol` was considered, but the context and the fact that it just returns one value makes it clear that it returns the symbol for the native coin of the network.
 
 ## Security Considerations
 It is a read only endpoint. The information is only as trusted as the JSON-RPC node itself, it could supply wrong information and thereby trick the user in believing he/she is dealing with another native coin.

--- a/EIPS/eip-3298.md
+++ b/EIPS/eip-3298.md
@@ -45,7 +45,7 @@ The description above is sufficient to describe the change, but for the sake of 
 
 ## Rationale
 
-A full removal of refunds is the simplest way to solve the issues with refunds; any gains from partial retention of the refund mechanism are not worth the complexity that that would leave remaining in the Ethereum protocol.
+A full removal of refunds is the simplest way to solve the issues with refunds; any gains from partial retention of the refund mechanism are not worth the complexity that would leave remaining in the Ethereum protocol.
 
 ## Backwards Compatibility
 

--- a/EIPS/eip-3534.md
+++ b/EIPS/eip-3534.md
@@ -261,7 +261,7 @@ Four bytes, instead of the whole hash (32 bytes), was chosen only to reduce the 
 Using the whole hash would result in a "perfectly safe" implementation, and every additional byte reduces the chance of collision exponentially.
 
 The goal of the `ancestorId` is to disambiguate one chain segment from another, and in doing so, enable a transaction to define with adequate precision which chain it needs to be on.
-When a transaction's `ancestorId` references a block, we want to be pretty sure that that reference won't get confused with a different block than the one the author of the transaction had in mind.
+When a transaction's `ancestorId` references a block, we want to be pretty sure that the reference won't get confused with a different block than the one the author of the transaction had in mind.
 
 We assume the trait of collision resistance is uniformly applicable to all possible subsets of the block hash value, so our preference of using the _first_ 4 bytes is arbitrary and functionally equivalent to any other subset of equal length.
 

--- a/EIPS/eip-7329.md
+++ b/EIPS/eip-7329.md
@@ -160,7 +160,7 @@ subject to the same workflow as other groups.
 ### Alternative: Pain unrelated to process divergences
 
 This is a catch-all for a number of proposals, from allowing discord links in
-discussion-to to allowing more freedom in external links.
+discussion-to, to allowing more freedom in external links.
 
 While the theory that this may reduce the total amount of pain felt by users and
 editors, bringing the pain level down to a more acceptable level, this does not


### PR DESCRIPTION
Found 4 instances of duplicate words across EIP files:

  - `eip-3014.md:42` - "that that" → "that"
  - `eip-3298.md:48` - "that that" → "that"
  - `eip-3534.md:264` - "that that" → "the"
  - `eip-7329.md:163` - "discussion-to to" → "discussion-to, to"