### PR TITLE
Update EIP-7773: remove duplicate EIP-8038 entry

### DIFF
--- a/EIPS/eip-7773.md
+++ b/EIPS/eip-7773.md
@@ -83,7 +83,6 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Declined
 1. [EIP-7997](./eip-7997.md): Deterministic Factory Predeploy
 1. [EIP-8032](./eip-8032.md): Size-Based Storage Gas Pricing
 1. [EIP-8037](./eip-8037.md): State Creation Gas Cost Increase
-1. [EIP-8038](./eip-8038.md): State-access gas cost increase
 1. [EIP-8051](./eip-8051.md): Precompile for ML-DSA signature verification 
 1. [EIP-8058](./eip-8058.md): Contract Bytecode Deduplication Discount
 1. [EIP-8061](./eip-8061.md): Increase exit and consolidation churn


### PR DESCRIPTION
Removes duplicate EIP-8038 from Proposed for Inclusion list, keeps it in Considered for Inclusion per ACDE 226.