### PR TITLE
Update EIP-5792: add missing 6xx category for status code 600

### DIFF
--- a/EIPS/eip-5792.md
+++ b/EIPS/eip-5792.md
@@ -208,6 +208,7 @@ Status codes follow these categories:
 * 2xx: Confirmed states
 * 4xx: Offchain failures
 * 5xx: Chain rules failures
+* 6xx: Partial chain rules failures
 
 | Code | Description                                                                                                                       |
 |------|-----------------------------------------------------------------------------------------------------------------------------------|


### PR DESCRIPTION
Adds 6xx category for status code 600. The code was already used but its category wasn't listed, so this fixes the mismatch.