### PR TITLE
Update EIP-6690: unify active_ctx variable naming in EIP-6690

### DIFF
--- a/EIPS/eip-6690.md
+++ b/EIPS/eip-6690.md
@@ -173,9 +173,9 @@ Note: serialization format for values in EVM memory: big-endian padded to `activ
 * Assert that the range `[source, source + count]` falls within the active field context's zero-indexed value space.
 * Assert that the range `[dest, dest + count * active_ctx.element_size]` falls entirely within EVM memory.
 * If modulus is a power of two:
-    * charge `(active_ctxt.element_size + 31) // 32 * 3` gas (the same as the memory copying component for the `MCOPY` opcode)
+    * charge `(active_ctx.element_size + 31) // 32 * 3` gas (the same as the memory copying component for the `MCOPY` opcode)
 * If modulus is odd:
-    * charge `count * operation_cost` gas, where `operation_cost` is looked up from the multiplication cost table, given `active_ctxt.element_size`.
+    * charge `count * operation_cost` gas, where `operation_cost` is looked up from the multiplication cost table, given `active_ctx.element_size`.
 * copy virtual register values `[source, source + count]` to memory `[dest, dest + count * active_ctx.element_size]`.
 
 ##### `STOREX(0xc2)`
@@ -193,8 +193,8 @@ Note: serialization format for values in EVM memory: big-endian padded to `activ
 * If modulus of the active context is a power of two:
     * charge `cost_mem_copy(count * active_ctx.element_size)` (TBD: deliberately didn't choose `mcopy` gas model to see if this can consider a cheaper one).
 * Else if modulus of the active context is odd:
-    * charge `count * operation_cost` gas, where `operation_cost` is looked up from the multiplication cost table, given `active_ctxt.element_size`.
-* Assert that `[source, source + count * active_context.element_size]` falls entirely within EVM memory.  Interpret it as `count` number of values, asserting that each is less than the modulus and storing them in the registers `[dest, dest + count]`.
+    * charge `count * operation_cost` gas, where `operation_cost` is looked up from the multiplication cost table, given `active_ctx.element_size`.
+* Assert that `[source, source + count * active_ctx.element_size]` falls entirely within EVM memory.  Interpret it as `count` number of values, asserting that each is less than the modulus and storing them in the registers `[dest, dest + count]`.
 
 ### EVM Memory Expansion Cost Modification
 


### PR DESCRIPTION
Fixed inconsistent variable naming in gas cost calculations. 

Replaced  active_ctxt and active_context with active_ctx to match the variable definition in the specification. 