### PR TITLE
Update EIP-8052: link first references to EIP-7932, EIP-1352, and EIP-7587

### DIFF
--- a/EIPS/eip-8052.md
+++ b/EIPS/eip-8052.md
@@ -420,9 +420,9 @@ The cost is interpolated using rule of thumb from SUPERCOPS signatures benchmark
 
 ## Backwards Compatibility
 
-In compliance with EIP-7932,  the necessary parameters and structure for its integration are provided. `ALG_TYPE = 0xFA`  uniquely identifies Falcon-512 transactions, set MAX_SIZE = 667 bytes to accommodate the fixed-length signature_info container (comprising a 1-byte version tag and a 666-byte Falcon signature), and recommend a `GAS_PENALTY` of approximately `3000` gas subject to benchmarking. The verification function follows the EIP-7932 model, parsing the signature_info, recovering the corresponding Falcon public key, verifying the signature against the transaction payload hash, and deriving the signer's Ethereum address as the last 20 bytes of keccak256(pubkey). This definition ensures that Falcon-512 can be cleanly adopted within the `AlgorithmicTransaction` container specified by EIP-7932.
+In compliance with [EIP-7932](./eip-7932.md),  the necessary parameters and structure for its integration are provided. `ALG_TYPE = 0xFA`  uniquely identifies Falcon-512 transactions, set MAX_SIZE = 667 bytes to accommodate the fixed-length signature_info container (comprising a 1-byte version tag and a 666-byte Falcon signature), and recommend a `GAS_PENALTY` of approximately `3000` gas subject to benchmarking. The verification function follows the EIP-7932 model, parsing the signature_info, recovering the corresponding Falcon public key, verifying the signature against the transaction payload hash, and deriving the signer's Ethereum address as the last 20 bytes of keccak256(pubkey). This definition ensures that Falcon-512 can be cleanly adopted within the `AlgorithmicTransaction` container specified by EIP-7932.
 
-As per EIP-7932, this EIP defines two Falcon algorithm types:
+As per [EIP-7932](./eip-7932.md), this EIP defines two Falcon algorithm types:
 
 * `ALG_TYPE = 0xFA` — Falcon-512 with SHAKE256 H2P
 * `ALG_TYPE = 0xFB` — Falcon-512 with Keccak-PRNG H2P
@@ -440,7 +440,7 @@ signature_info = Container[
 ]
 ```
 
-In the format of EIP-7932:
+In the format of [EIP-7932](./eip-7932.md):
 
 * For the NIST-compliant version:
 
@@ -471,7 +471,7 @@ In the format of EIP-7932:
 ### Addresses
 
 <!-- TODO: backward compatibility -->
-**TBD by ACD.** Final precompile addresses will be selected within the EIP-managed range of EIP-1352, explicitly **avoiding `0x0100–0x01FF` reserved for RIPs** by EIP-7587.
+**TBD by ACD.** Final precompile addresses will be selected within the EIP-managed range of [EIP-1352](./eip-1352.md), explicitly **avoiding `0x0100–0x01FF` reserved for RIPs** by [EIP-7587](./eip-7587.md).
 
 ## Test Cases
 


### PR DESCRIPTION
Adds markdown links to first mentions of related EIPs, improves cross-reference navigation.