### PR TITLE
Update EIP-8077: Fix grammar and spelling errors

### DIFF
--- a/EIPS/eip-8077.md
+++ b/EIPS/eip-8077.md
@@ -48,7 +48,7 @@ To solve the transaction propagation issues mentioned in the Motivation section,
 
 ### Overhead
 
-The modification adds a significant overhead to announcements by adding a B_20 and a variable size filed to the current B_32, size, and type fields. We think this overhead is worth
+The modification adds a significant overhead to announcements by adding a B_20 and a variable size field to the current B_32, size, and type fields. We think this overhead is worth
 the additional gain in protocol efficiency. Details TBD <-- TODO --> .
 
 ### Alternatives

--- a/EIPS/eip-8096.md
+++ b/EIPS/eip-8096.md
@@ -25,7 +25,7 @@ Upon activation of this EIP, the gas cost of calling the precompile at address `
 
 ## Rationale
 
-Benchmarking the `point evaluation` precompile revealed that its gas cost is significantly underestimated. This modification aim to ensure that the `point evaluation` precompile's performance no longer impedes potential increases to the block gas limit.
+Benchmarking the `point evaluation` precompile revealed that its gas cost is significantly underestimated. This modification aims to ensure that the `point evaluation` precompile's performance no longer impedes potential increases to the block gas limit.
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
Fixed 2 grammatical and spelling errors in recent EIPs:

  - `eip-8096.md:28` - "modification aim" → "modification aims" (subject-verb agreement)
  - `eip-8077.md:51` - "filed" → "field" (typo)