### PR TITLE
Update EIP-5069: add concept of associate editors

### DIFF
--- a/EIPS/eip-5069.md
+++ b/EIPS/eip-5069.md
@@ -49,11 +49,13 @@ Documenting all of the things we would not do is impossible, and the above are j
 
 ### EIP Editors
 
-We, the Editors, consist of some number of EIP Editors and one Keeper of Consensus (or just Keeper for short) elected by and from the EIP Editors.
+We, the Editors, consist of some number of EIP Editors, some number of Associate EIP Editors, and one Keeper of Consensus (or just Keeper for short) elected by and from the EIP Editors.
 
-EIP Editors are responsible for governing the EIP process itself, electing a Keeper, and stewarding proposals.
+EIP Editors are responsible for governing and executing the EIP process, electing a Keeper, and stewarding proposals.
 
-The Keeper's two responsibilities (on top of their EIP Editor duties) are: to determine when rough consensus has been reached on a matter, and determine when/if it is appropriate to re-open an already settled matter.
+Associate Editors are responsible for executing the EIP process: reviewing proposals, approving pull requests, and moving EIPs through their lifecycle in accordance with EIP-1. Associate Editors have editorial discretion in these matters, but their decisions may be overridden by an EIP Editor. Associate Editors do not participate in governance.
+
+The Keeper's two responsibilities (on top of their EIP Editor duties) are: to determine when rough consensus has been reached on a matter, and determine when/if it is appropriate to re-open an already settled matter. The Keeper may also resolve disputes involving Associate Editors.
 
 ## Membership
 
@@ -66,6 +68,8 @@ Anyone may apply to join as an EIP Editor. Specific eligibility requirements are
 
 EIP Editors are expected to meet these requirements throughout their tenure, and not doing so is grounds for removal. Any member may delegate some or all of their responsibilities/powers to tools and/or to other people.
 
+Anyone may apply to join as an Associate Editor. The requirements are the same as for EIP Editors, except Associate Editors are not expected to participate in governance.
+
 ## Making Decisions
 
 ### Informally
@@ -74,7 +78,7 @@ For decisions that are unlikely to be controversial—especially for decisions a
 
 ### Formally
 
-Electing a Keeper, adding/removing EIP Editors, and any possibly-controversial decisions must all be made using variations of this formal process.
+Electing a Keeper, adding/removing EIP Editors, adding/removing Associate Editors, and any possibly-controversial decisions must all be made using variations of this formal process. Only EIP Editors participate in formal decision-making.
 
 #### Preparation
 
@@ -103,6 +107,14 @@ An EIP Editor is added once quorum is met, provided the candidate consents and n
 An EIP Editor is involuntarily retired once quorum is met, provided no current EIP Editor (aside from the one being removed) objects. An EIP Editor may voluntarily leave their position at any time.
 
 If the departing Editor was also the Keeper, an election for a new Keeper begins immediately.
+
+##### Adding an Associate Editor
+
+An Associate Editor is added once quorum is met, provided the candidate consents and no current EIP Editor objects.
+
+##### Removing an Associate Editor
+
+An Associate Editor is involuntarily retired once quorum is met, provided no current EIP Editor objects. An Associate Editor may voluntarily leave their position at any time.
 
 ##### Other Decisions
 


### PR DESCRIPTION
The biggest complaint I hear about the EIP process is how slow it can be to move through the process, get editor attention, etc. It would be great to bring more contributors into the fold, but as it stands today, EIP editors are in a very high trust position. We are tasked with governing the EIP process in a way that is effective and sustainable for the long term. Although we now have a better forcing function with Keeper, I still think adding more full EIP editors is not something we should do lightly.

With that said, I still want to address the timeliness of the EIP process and that's where I think Associate EIP Editors can come in. They will have the same powers and responsibilities that EIP Editors have for executing the day-to-day processes. They just won't be eligible for formally voting on governance matters. I think this strikes a good balance between opening up editing to allow for more contributors without putting the process in unnecessary risk.