### PR TITLE
Update EIP-8051: Fix undefined variable reference

### DIFF
--- a/EIPS/eip-8051.md
+++ b/EIPS/eip-8051.md
@@ -107,7 +107,7 @@ def VERIFY_MLDSA(public_key, message, signature) -> bool:
     c_tilde, z, h are decoded from signature
     if h is not properly encoded, return False
 
-    μ = shake_256(tr+m).extract(64)
+    μ = shake_256(tr+message).extract(64)
     c = sample_in_ball(c_tilde, τ)
     # computed in the NTT domain
     # three NTTs for c and z, and t1
@@ -132,7 +132,7 @@ def VERIFY_MLDSA_ETH(public_key, message, signature) -> bool:
     c_tilde, z, h are decoded from signature
     if h is not properly encoded, return False
 
-    μ = keccak_prng(tr+m).extract(64)
+    μ = keccak_prng(tr+message).extract(64)
     c = sample_in_ball_keccak_prng(c_tilde, τ)
     # computed in the NTT domain
     # two NTTs for c and z


### PR DESCRIPTION
Replace undefined variable `m` with parameter `message`, correcting variable reference in VERIFY_MLDSA and VERIFY_MLDSA_ETH functions.