### PR TITLE
Add EIP: MLOAD8 and CALLDATALOAD8 Opcodes

### DIFF
--- a/EIPS/eip-8120.md
+++ b/EIPS/eip-8120.md
@@ -45,6 +45,8 @@ Memory expansion rules apply in the same way as for `MSTORE8` (extending memory 
 
 ### CALLDATALOAD8 (TBD)
 
+<!-- TODO: Replace TBD with assigned opcode value -->
+
 - **Stack input**: `offset`
 - **Stack output**: `value`
 


### PR DESCRIPTION
This PR introduces a draft EIP proposing two new EVM opcodes, `MLOAD8` and `CALLDATALOAD8`, which allow efficient single-byte access to memory and calldata.

A discussion thread has been opened on Ethereum Magicians: https://ethereum-magicians.org/t/eip-xxxx-mload8-and-calldataload8-opcodes/27396