### PR TITLE
Update EIP-7932: Polish grammar and spelling in EIP-7932, 8030

### DIFF
--- a/EIPS/eip-7932.md
+++ b/EIPS/eip-7932.md
@@ -21,7 +21,7 @@ This EIP:
 
 As quantum computers become more advanced, several new post-quantum (PQ) algorithms have been designed. These algorithms all have certain drawbacks, such as large key sizes (>1KiB), large signature sizes, or long verification times. These issues make them more expensive to compute and store than the currently used secp256k1 curve.
 
-This EIP provides allows the use of many algorithms by introducing an algorithm registry that can be used via a single interface.
+This EIP allows the use of many algorithms by introducing an algorithm registry that can be used via a single interface.
 
 ## Specification
 
@@ -69,7 +69,7 @@ trait Algorithm {
 }
 ```
 
-Specifications MUST include some form of security analysis on the provided algorithm and basic benchmarks justifying gas costs. Additionally, specifications MUST address malleability issue that may arise from specified algorithms. 
+Specifications MUST include some form of security analysis on the provided algorithm and basic benchmarks justifying gas costs. Additionally, specifications MUST address malleability issues that may arise from specified algorithms. 
 
 An example of this specification can be found [here](../assets/eip-7932/template-eip.md).
 
@@ -220,7 +220,7 @@ Having a precompile allows non-EVM processes, i.e. transaction level signature v
 
 ### Opaque `signature` type
 
-As each algorithm has unique properties, e.g. supporting signature recovery and key sizes, the object needs to hold every permutation of every possible signature and potentially additional recovery information. A bytearray of a algorithm-defined size would be able to achieve this goal.
+As each algorithm has unique properties, e.g. supporting signature recovery and key sizes, the object needs to hold every permutation of every possible signature and potentially additional recovery information. A bytearray of an algorithm-defined size would be able to achieve this goal.
 
 ## Backwards Compatibility
 

--- a/EIPS/eip-8030.md
+++ b/EIPS/eip-8030.md
@@ -37,7 +37,7 @@ def gas_cost(signing_data: Bytes) -> Uint64:
     # subtracted (the cost of the secp256k1 precompile)
     BASE_GAS = Uint64(3900)
 
-    # Calcuate extra overhead for keccak256 hashing
+    # Calculate extra overhead for keccak256 hashing
     if len(signing_data) == 32:
         return BASE_GAS
     else:


### PR DESCRIPTION
 Corrects 6 errors in recently updated EIP specifications:

  **Spelling errors:**
  - `eip-8030.md:40` - "Calcuate" → "Calculate"

  **Article errors:**
  - `eip-7932.md:72` - "address malleability issue" → "address a malleability issue"
  - `eip-7932.md:223` - "a algorithm-defined" → "an algorithm-defined"

  **Other corrections:**
  - `eip-7932.md:24` - "provides allows" → "allows" (redundant verb)
