### PR TITLE
Update EIP-8051: define ML-DSA beta norm bound

### DIFF
--- a/EIPS/eip-8051.md
+++ b/EIPS/eip-8051.md
@@ -60,10 +60,10 @@ For the two variants of ML-DSA of this EIP, the following parameters are fixed:
 * Polynomial degree: `n = 256`,
 * Field modulus: `q = 8380417`,
 * Matrix dimensions: `k=4`, `l=4`,
-* Bounds of rejection: `γ_1 = 2¹⁷`, `γ_2 = (q-1)/88`,
+* Bounds of rejection: `γ_1 = 2¹⁷`, `γ_2 = (q-1)/88`, `β = 78`,
 * Additional parameters: `η = 2`, `τ = 39`, `d = 13`.
 
-These parameters strictly follow NIST. More precisely, `q`, `n`, `k`, `l` and `η` are chosen in order to ensure a hard MLWE related problem, and the remaining parameters are chosen for the hardness of MSIS as well as for the efficiency of the scheme.
+These parameters strictly follow NIST. More precisely, `q`, `n`, `k`, `l` and `η` are chosen in order to ensure a hard MLWE related problem, and the remaining parameters are chosen for the hardness of MSIS as well as for the efficiency of the scheme. The parameter `β = τ * η = 78` is the norm bound used in the rejection condition `||z||_∞ < γ_1 - β` for the ML-DSA-44 parameter set in FIPS-204.
 
 In terms of storage, ML-DSA public key can be derived by the verifier, making the overall public key of 1312 bytes. However, this increases the verifier cost, making the on-chain verification too expensive from a practical point of view. In this EIP, the verification algorithm takes the public key in raw format, meaning that the storage for the public key is:
 


### PR DESCRIPTION
Defined the beta parameter used in the ML-DSA norm bound, setting β = 78 for the ML-DSA-44 (Dilithium2) parameter set. The value is derived as β = τ * η = 39 * 2 and is consistent with FIPS-204.

By adding β to the fixed parameter list and tying it to the condition ||z||_∞ < γ_1 - β, the EIP removes an ambiguity that prevented implementers from knowing the exact acceptance bound for z while still keeping the algorithmic pseudocode unchanged.