### PR TITLE
Update EIP-7773: status updates from ACDE227

### DIFF
--- a/EIPS/eip-7773.md
+++ b/EIPS/eip-7773.md
@@ -33,6 +33,7 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Declined
 * [EIP-7904](./eip-7904.md): General Repricing
 * [EIP-7976](./eip-7976.md): Increase Calldata Floor Cost
 * [EIP-7981](./eip-7981.md): Increase Access List Cost
+* [EIP-7997](./eip-7997.md): Deterministic Factory Predeploy
 * [EIP-8024](./eip-8024.md): Backward compatible SWAPN, DUPN, EXCHANGE
 * [EIP-8038](./eip-8038.md): State-access gas cost increase
 * [EIP-8045](./eip-8045.md): Exclude slashed validators from proposing
@@ -45,8 +46,10 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Declined
 * [EIP-6404](./eip-6404.md): SSZ transactions
 * [EIP-6466](./eip-6466.md): SSZ receipts
 * [EIP-7619](./eip-7619.md): Precompile Falcon512 generic verifier
+* [EIP-7668](./eip-7668.md): Remove bloom filters
 * [EIP-7686](./eip-7686.md): Linear EVM memory limits
 * [EIP-7692](./eip-7692.md): EVM Object Format (EOFv1) Meta
+* [EIP-7745](./eip-7745.md): Trustless log index
 * [EIP-7782](./eip-7782.md): Reduce Block Latency
 * [EIP-7791](./eip-7791.md): GAS2ETH opcode
 * [EIP-7805](./eip-7805.md): Fork-choice enforced Inclusion Lists (FOCIL)
@@ -64,6 +67,7 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Declined
 * [EIP-8030](./eip-8030.md): P256 transaction support
 * [EIP-8053](./eip-8053.md): Milli-gas for High-precision Gas Metering
 * [EIP-8057](./eip-8057.md): Inter-Block Temporal Locality Gas Discounts
+* [EIP-8058](./eip-8058.md): Contract Bytecode Deduplication Discount
 * [EIP-8059](./eip-8059.md): Gas Units Rebase for High-precision Metering
 * [EIP-8062](./eip-8062.md): Add sweep withdrawal fee for 0x01 validators
 * [EIP-8071](./eip-8071.md): Prevent using consolidations as withdrawals
@@ -72,23 +76,18 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Declined
 ### Proposed for Inclusion
 
 
-1. [EIP-5920](./eip-5920.md): PAY opcode
-1. [EIP-7610](./eip-7610.md): Revert creation in case of non-empty storage
-1. [EIP-7668](./eip-7668.md): Remove bloom filters
-1. [EIP-7745](./eip-7745.md): Trustless log index
-1. [EIP-7793](./eip-7793.md): Conditional Transactions
-1. [EIP-7872](./eip-7872.md): Max blob flag for local builders
-1. [EIP-7903](./eip-7903.md): Remove Initcode Size Limit
-1. [EIP-7907](./eip-7907.md): Meter Contract Code Size And Increase Limit
-1. [EIP-7949](./eip-7949.md): Schema for `genesis.json` files
-1. [EIP-7971](./eip-7971.md): Hard Limits for Transient Storage
-1. [EIP-7997](./eip-7997.md): Deterministic Factory Predeploy
-1. [EIP-8032](./eip-8032.md): Size-Based Storage Gas Pricing
-1. [EIP-8037](./eip-8037.md): State Creation Gas Cost Increase
-1. [EIP-8038](./eip-8038.md): State-access gas cost increase
-1. [EIP-8051](./eip-8051.md): Precompile for ML-DSA signature verification
-1. [EIP-8058](./eip-8058.md): Contract Bytecode Deduplication Discount
-1. [EIP-8070](./eip-8070.md): Sparse Blobpool
+* [EIP-5920](./eip-5920.md): PAY opcode
+* [EIP-7610](./eip-7610.md): Revert creation in case of non-empty storage
+* [EIP-7793](./eip-7793.md): Conditional Transactions
+* [EIP-7872](./eip-7872.md): Max blob flag for local builders
+* [EIP-7903](./eip-7903.md): Remove Initcode Size Limit
+* [EIP-7907](./eip-7907.md): Meter Contract Code Size And Increase Limit
+* [EIP-7949](./eip-7949.md): Schema for `genesis.json` files
+* [EIP-7971](./eip-7971.md): Hard Limits for Transient Storage
+* [EIP-8032](./eip-8032.md): Size-Based Storage Gas Pricing
+* [EIP-8037](./eip-8037.md): State Creation Gas Cost Increase
+* [EIP-8051](./eip-8051.md): Precompile for ML-DSA signature verification
+* [EIP-8070](./eip-8070.md): Sparse Blobpool
 
 ### Activation
 


### PR DESCRIPTION
1. reflect decisions from [ACDE227](https://forkcast.org/calls/acde/227/): 
- EIP-7997 → CFI
- EIP-8058 → DFI
- EIP-7668 → DFI
- EIP-7745 → DFI

2. fix bullet point types cuz it's annoying to move EIPs to new statuses with different styles

3. remove EIP-8038 from PFI (was already duplicated into CFI but wasn't removed from PFI)