### PR TITLE
chore: Remove redundant minima gem dependency from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,9 +7,6 @@ source "https://rubygems.org"
 #     bundle exec jekyll serve
 #
 
-# This is the default theme for new Jekyll sites. You may change this to anything you like.
-gem "minima", "~> 2.0"
-
 # If you have any plugins, put them here!
 group :jekyll_plugins do
   gem "github-pages", "228"


### PR DESCRIPTION
Removes explicit `minima` gem declaration from Gemfile as it's already included in the `github-pages` dependency.