### PR TITLE
Website: DRY up EIP/ERC prefix and draft suffix logic in layout template

### DIFF
--- a/_layouts/eip.html
+++ b/_layouts/eip.html
@@ -18,6 +18,10 @@ layout: default
 </svg>
 
 <div class="home">
+  {% assign doc_prefix = "EIP" %}
+  {% if page.category == "ERC" %}
+    {% assign doc_prefix = "ERC" %}
+  {% endif %}
   <span class="h5">
     {% if page.status == "Stagnant" %}
       <span class="badge text-light bg-danger" data-bs-toggle="tooltip" data-bs-title="This EIP had no activity for at least 6 months. This EIP should not be used.">🚧 Stagnant</span>
@@ -46,11 +50,7 @@ layout: default
     {% endif %}
   </span>
   <h1 class="page-heading">
-    {% if page.category == "ERC" %}
-      ERC-{{ page.eip | xml_escape }}: {{ page.title | xml_escape }}
-    {% elsif page.category != "ERC" %}
-      EIP-{{ page.eip | xml_escape }}: {{ page.title | xml_escape }}
-    {% endif %}
+    {{ doc_prefix }}-{{ page.eip | xml_escape }}: {{ page.title | xml_escape }}
     <a href="{{ page.discussions-to | uri_escape }}" class="no-underline">
       <svg role="img" aria-label="Discuss" class="inline-svg" xmlns="https://www.w3.org/2000/svg" viewBox="0 0 16 16">
         <use xlink:href="#bi-chat"/>
@@ -125,17 +125,20 @@ layout: default
 Article schema specification:
 https://schema.org/TechArticle
 {% endcomment %}
+{% assign draft_suffix = "" %}
+{% if page.status == "Draft" or page.status == "Stagnant" or page.status == "Withdrawn" or page.status == "Review" or page.status == "Last Call" %}
+  {% assign draft_suffix = " [DRAFT]" %}
+{% endif %}
+{% capture doc_title %}
+  {{ doc_prefix }}-{{ page.eip | xml_escape }}: {{ page.title | xml_escape }}{{ draft_suffix }}
+{% endcapture %}
+{% assign doc_title = doc_title | strip %}
 <script type="application/ld+json">
   {
     "@context": "http://schema.org",
     "@type": "TechArticle",
-    {% if page.category == "ERC" %}
-    "headline": "ERC-{{ page.eip | xml_escape }}: {{ page.title | xml_escape }}{% if page.status == "Draft" or page.status == "Stagnant" or page.status == "Withdrawn" or page.status == "Review" or page.status == "Last Call" %} [DRAFT]{% endif %}",
-    "name": "ERC-{{ page.eip | xml_escape }}: {{ page.title | xml_escape }}{% if page.status == "Draft" or page.status == "Stagnant" or page.status == "Withdrawn" or page.status == "Review" or page.status == "Last Call" %} [DRAFT]{% endif %}",
-    {% else %}
-    "headline": "EIP-{{ page.eip | xml_escape }}: {{ page.title | xml_escape }}{% if page.status == "Draft" or page.status == "Stagnant" or page.status == "Withdrawn" or page.status == "Review" or page.status == "Last Call" %} [DRAFT]{% endif %}",
-    "name": "EIP-{{ page.eip | xml_escape }}: {{ page.title | xml_escape }}{% if page.status == "Draft" or page.status == "Stagnant" or page.status == "Withdrawn" or page.status == "Review" or page.status == "Last Call" %} [DRAFT]{% endif %}",
-    {% endif %}
+    "headline": "{{ doc_title }}",
+    "name": "{{ doc_title }}",
     "author": "{{ page.author }}",
     "dateCreated": "{{ page.created | date: "%Y-%m-%d" }}",
     "datePublished": "{{ page.created | date: "%Y-%m-%d" }}",


### PR DESCRIPTION
Refactors _layouts/eip.html to eliminate code duplication by computing the document prefix (EIP/ERC) and draft suffix once, then reusing these values across the page heading and JSON-LD structured data.