### PR TITLE
Website: Fix citation-js initialization to use global window.Cite instead of require()

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -70,7 +70,11 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/citation-js/0.6.7/citation.min.js" integrity="sha512-N+LDFMa9owHXGS+CyMrBvuxq2QuGl3fiB/7cys3aUEL7K6P1soHGqsS0sjHXZpwNd9Kz0m3R4IPy1HYRi6ROEQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script type="text/javascript">
     addEventListener('DOMContentLoaded', async () => {
-      const Cite = window.require('citation-js');
+      const Cite = window.Cite;
+      if (!Cite) {
+        console.warn('citation-js not available, skipping citation render');
+        return;
+      }
       const citationElements = document.querySelectorAll('.language-csl-json');
       for (let citationElement of citationElements) {
         try {


### PR DESCRIPTION
Fixes a JavaScript runtime error in citation rendering by using the correct global reference for the citation-js library loaded from CDN.