### PR TITLE
fix: correct RSS feed self-reference and remove redundant Last Call filter in nonerc.xml

### DIFF
--- a/rss/nonerc.xml
+++ b/rss/nonerc.xml
@@ -7,14 +7,13 @@ layout: null
     <title>Ethereum EIPs</title>
     <description>All EIPs that are not ERCs</description>
     <link>{{ site.url }}</link>
-    <atom:link href="{{ site.url }}/rss/last-call.xml" rel="self" type="application/rss+xml" />
+    <atom:link href="{{ site.url }}/rss/nonerc.xml" rel="self" type="application/rss+xml" />
     <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
     {% assign eips = site.pages | sort: 'eip' %}
     {% for eip in eips %}
       {% unless eip.category == "ERC" %}
-      {% if eip.status == "Last Call" %}
       {% capture description %}
-        <p><strong>EIP #{{ eip.eip }} - {{eip.title }}</strong> is in Last Call status. It is authored by {{ eip.author }} and was originally created {{ eip.created }}. It is in the {{ eip.category }} category of type {{ eip.type }}. Please review and note any changes that should block acceptance.</p>
+        <p><strong>EIP #{{ eip.eip }} - {{eip.title }}</strong> is in the {{ eip.category }} category of type {{ eip.type }} and was just updated.</p>
         {% if eip.discussions-to %}
           <p>The author has requested that discussions happen at the following URL: <a href="{{ eip.discussions-to }}">{{ eip.discussions-to }}</a></p>
         {% endif %}
@@ -28,7 +27,6 @@ layout: null
         <link>{{ site.url }}/{{ eip.url }}</link>
         <guid isPermaLink="true">{{ site.url }}/{{ eip.url }}</guid>
       </item>
-      {% endif %}
       {% endunless %}
     {% endfor %}
   </channel>


### PR DESCRIPTION
Fixes incorrect self-reference link and redundant filtering logic in the non-ERC RSS feed.