### PR TITLE
Update EIP-8030: fix Python type errors

### DIFF
--- a/EIPS/eip-8030.md
+++ b/EIPS/eip-8030.md
@@ -59,12 +59,12 @@ def verify(signature: Bytes, signing_data: Bytes) -> Bytes | Error:
     (r, s, x, y) = (signature[0:32], signature[32:64], signature[64:96], signature[96:128])
 
     # This is similar to [EIP-2](./eip-2.md)'s malleability verification.
-    assert(s <= N/2)
+    assert(int.from_bytes(s, "big") <= N//2)
 
     # This is defined in [P256Verify Function](#p256verify-function)
     assert(P256Verify(signing_data, r, s, x, y) == Bytes("0x0000000000000000000000000000000000000000000000000000000000000001"))
-        
-    return x.to_bytes(32, "big") + y.to_bytes(32, "big")
+
+    return x + y
 ```
 
 


### PR DESCRIPTION
Fixes type conversion for bytes comparison and removes invalid method call, correcting Python syntax errors in the verify function.