### PR TITLE
Update EIP-7999: correct Python type

### DIFF
--- a/EIPS/eip-7999.md
+++ b/EIPS/eip-7999.md
@@ -120,7 +120,7 @@ The calldata resource pricing under this EIP follows previous gas per byte const
 
 ```python
 def get_calldata_gas(calldata: bytes) -> int:
-    tokens = calldata.count(0) + (len(calldata) - calldata.count(0)) * TOKENS_PER_NONZERO_BYTE
+    tokens = calldata.count(b'\x00') + (len(calldata) - calldata.count(b'\x00')) * TOKENS_PER_NONZERO_BYTE
     return tokens * CALLDATA_GAS_PER_TOKEN
 ```
 


### PR DESCRIPTION
Fixes a type error in the gas calculation logic, passing a bytes object to the count method instead of an integer.