### PR TITLE
Update EIP-2780: fix pseudocode syntax

### DIFF
--- a/EIPS/eip-2780.md
+++ b/EIPS/eip-2780.md
@@ -218,18 +218,18 @@ Clients compute intrinsic gas as today for each typed transaction **except**:
 
 ### Pseudocode (normative):
 
-```text
-function CalculateIntrinsicGas(tx, state_at_start):
+```python
+def CalculateIntrinsicGas(tx, state_at_start):
     gasCost = TX_BASE_COST
 
-    // Existing rules for calldata and access lists remain unchanged by this EIP.
-    gasCost += GasForCalldata(tx.data)                  // per active calldata pricing EIPs
+    # Existing rules for calldata and access lists remain unchanged by this EIP.
+    gasCost += GasForCalldata(tx.data)                  # per active calldata pricing EIPs
     if tx.has_access_list():
-        gasCost += GasForAccessList(tx.access_list)     // per EIP-2930
+        gasCost += GasForAccessList(tx.access_list)     # per EIP-2930
 
-    if tx.is_create() == false
+    if tx.is_create() == False
        and tx.value > 0
-       and is_precompile(tx.to) == false
+       and is_precompile(tx.to) == False
        and is_nonexistent_per_eip161(state_at_start, tx.to):
         gasCost += GAS_NEW_ACCOUNT
 


### PR DESCRIPTION
Converts normative pseudocode to valid Python, fixing function definitions and boolean literals.