### PR TITLE
Update EIP-8038: Fix grammar errors

### DIFF
--- a/EIPS/eip-8038.md
+++ b/EIPS/eip-8038.md
@@ -32,7 +32,7 @@ Upon activation of this EIP, the following parameters of the gas model are renam
 | `GAS_STORAGE_UPDATE` | `GAS_COLD_STORAGE_WRITE` |
 | `GAS_COLD_SLOAD` | `GAS_COLD_STORAGE_ACCESS` |
 
-The following parameters of the gas model updated:
+The following parameters of the gas model are updated:
 
 | **Parameter** | **Current value** | **New value** | **Increase** |**Operations affected** |
 |:---:|:---:|:---:|:---:|:---:|
@@ -68,7 +68,7 @@ This proposal does not yet have finalized numbers. To achieve this, we require s
 
 ### Special case for `EXTCODESIZE` and `EXTCODECOPY`
 
-Differently from other account read operations, `EXTCODESIZE` and `EXTCODECOPY` make two reads to the database. The first read is the same, where the object of the target account is loaded. This object includes the account's `nonce`, `balance`, `codeHash` and `storageRoot`. Then, these operations do another read to collect either the code size of the bytecode of the account. This second read is to an already warmed account, and thus we propose to price it as `GAS_WARM_ACCESS` for consistency.
+Differently from other account read operations, `EXTCODESIZE` and `EXTCODECOPY` make two reads to the database. The first read is the same, where the object of the target account is loaded. This object includes the account's `nonce`, `balance`, `codeHash` and `storageRoot`. Then, these operations do another read to collect either the code size or the bytecode of the account. This second read is to an already warmed account, and thus we propose to price it as `GAS_WARM_ACCESS` for consistency.
 
 ### Interaction with [EIP-8032](eip-8032.md)
 


### PR DESCRIPTION
Corrects missing verb and conjunction in EIP-8038, fixing "gas model updated" to "gas model are updated" and "code size of the bytecode" to "code size or the bytecode"