### PR TITLE
Update EIP-8096: Fix grammar and clarify pricing logic

### DIFF
--- a/EIPS/eip-8096.md
+++ b/EIPS/eip-8096.md
@@ -13,11 +13,11 @@ requires: 4844
 
 ## Abstract
 
-This EIP modifies the gas cost of `point evaluation` precompile introduced in [EIP-4844](./eip-4844.md).
+This EIP modifies the gas cost of the `point evaluation` precompile introduced in [EIP-4844](./eip-4844.md).
 
 ## Motivation
 
-Currently the `point evaluation` precompile is underpriced relative to its resource consumption. This EIP aims to address these discrepancies by adjusting the gas cost and making `point evaluation` precompile sufficiently efficient to enable potential further increases in the block gas limit.
+Currently the `point evaluation` precompile is underpriced relative to its resource consumption. This EIP aims to address this discrepancy by adjusting the gas cost and making the `point evaluation` precompile accurately priced to enable potential further increases in the block gas limit.
 
 ## Specification
 
@@ -25,7 +25,7 @@ Upon activation of this EIP, the gas cost of calling the precompile at address `
 
 ## Rationale
 
-Benchmarking the `point evaluation` precompile revealed that its gas cost is significantly underestimated. This modification aim to ensure that the `point evaluation` precompile's performance no longer impedes potential increases to the block gas limit.
+Benchmarking the `point evaluation` precompile revealed that its gas cost is significantly underestimated. This modification aims to ensure that the `point evaluation` precompile's performance no longer impedes potential increases to the block gas limit.
 
 ## Backwards Compatibility
 
@@ -33,7 +33,7 @@ This EIP introduces a backwards-incompatible change. However, similar gas repric
 
 ## Security Considerations
 
-This EIP does not introduce any new functionality or make existing operations cheaper, therefore there are no direct security concerns related to new attack vectors or reduced cost.
+This EIP does not introduce any new functionality or make existing operations cheaper; therefore, there are no direct security concerns related to new attack vectors or reduced cost.
 
 ## Copyright
 


### PR DESCRIPTION
Corrected grammatical errors including missing articles and subject-verb agreement, and refined the motivation to accurately state that the goal is accurate pricing rather than efficiency.