### PR TITLE
Update EIP-712: Expand `encodeType` example to clarify sorting

### DIFF
--- a/EIPS/eip-712.md
+++ b/EIPS/eip-712.md
@@ -89,7 +89,7 @@ The `hashStruct` function is defined as
 
 The type of a struct is encoded as `name ‖ "(" ‖ member₁ ‖ "," ‖ member₂ ‖ "," ‖ … ‖ memberₙ ")"` where each member is written as `type ‖ " " ‖ name`. For example, the above `Mail` struct is encoded as `Mail(address from,address to,string contents)`.
 
-If the struct type references other struct types (and these in turn reference even more struct types), then the set of referenced struct types is collected, sorted by name and appended to the encoding. An example encoding is `Transaction(Person from,Person to,Asset tx)Asset(address token,uint256 amount)Person(address wallet,string name)`.
+If the struct type references other struct types (and these in turn reference even more struct types), then the set of transitively referenced struct types is collected, sorted by name and appended to the encoding. An example encoding is `Shipment(Person from,Person to,LineItem[] contents)LineItem(string gtin,uint256 count)Location(string locode,string localAddress)Person(string name,Location location)`.
 
 ### Definition of `encodeData`
 


### PR DESCRIPTION
Ref https://github.com/ethereum/EIPs/issues/4643

Replace the example two-level struct type hierarchy [Transaction→Person, Transaction→Asset] with the three-level [Shipment→Person, Shipment→LineItem, Person→Location] to demonstrate that sorting applies to the transitive closure of non-entry-point referenced struct types rather than e.g. independently at each node of a depth- or breadth-first traversal.

This example is consistent with reference code at https://eips.ethereum.org/assets/eip-712/Example.js.