### PR TITLE
Website: eliminate duplicate draft suffix logic in EIP layout template

### DIFF
--- a/_layouts/eip.html
+++ b/_layouts/eip.html
@@ -18,6 +18,11 @@ layout: default
 </svg>
 
 <div class="home">
+  {% assign draft_statuses = "Draft,Stagnant,Withdrawn,Review,Last Call" | split: "," %}
+  {% assign draft_suffix = "" %}
+  {% if draft_statuses contains page.status %}
+    {% assign draft_suffix = " [DRAFT]" %}
+  {% endif %}
   <span class="h5">
     {% if page.status == "Stagnant" %}
       <span class="badge text-light bg-danger" data-bs-toggle="tooltip" data-bs-title="This EIP had no activity for at least 6 months. This EIP should not be used.">🚧 Stagnant</span>
@@ -119,7 +124,7 @@ layout: default
   IEEE specification for reference formatting:
   https://ieee-dataport.org/sites/default/files/analysis/27/IEEE%20Citation%20Guidelines.pdf
   {% endcomment %}
-  <p>{% include authorlist.html authors=page.author %}, "{% if page.category == "ERC" %}ERC{% else %}EIP{% endif %}-{{ page.eip | xml_escape }}: {{ page.title | xml_escape }}{% if page.status == "Draft" or page.status == "Stagnant" or page.status == "Withdrawn" or page.status == "Review" or page.status == "Last Call" %} [DRAFT]{% endif %}," <em>Ethereum Improvement Proposals</em>, no. {{ page.eip | xml_escape }}, {{ page.created | date: "%B %Y" }}. [Online serial]. Available: https://eips.ethereum.org/EIPS/eip-{{ page.eip | xml_escape }}.</p>
+  <p>{% include authorlist.html authors=page.author %}, "{% if page.category == "ERC" %}ERC{% else %}EIP{% endif %}-{{ page.eip | xml_escape }}: {{ page.title | xml_escape }}{{ draft_suffix }}," <em>Ethereum Improvement Proposals</em>, no. {{ page.eip | xml_escape }}, {{ page.created | date: "%B %Y" }}. [Online serial]. Available: https://eips.ethereum.org/EIPS/eip-{{ page.eip | xml_escape }}.</p>
 </div>
 {% comment %}
 Article schema specification:


### PR DESCRIPTION
Removes code duplication in _layouts/eip.html by computing the [DRAFT] suffix once and reusing it in both citation and JSON-LD metadata sections.