### PR TITLE
Website: remove redundant count variable in eiptable.html

### DIFF
--- a/_includes/eiptable.html
+++ b/_includes/eiptable.html
@@ -9,8 +9,7 @@
 </style>
 {% for status in site.data.statuses %}
   {% assign eips = include.eips|where:"status",status|sort:"eip" %}
-  {% assign count = eips|size %}
-  {% if count > 0 %}
+  {% if eips.size > 0 %}
     <h2 id="{{status|slugify}}">{{status}}</h2>
     <table class="eiptable">
       <thead>


### PR DESCRIPTION
Removed unnecessary intermediate variable `count` in `_includes/eiptable.html`.