### PR TITLE
Website: Simplify non-ERC title branch in eip.html

### DIFF
--- a/_layouts/eip.html
+++ b/_layouts/eip.html
@@ -48,7 +48,7 @@ layout: default
   <h1 class="page-heading">
     {% if page.category == "ERC" %}
       ERC-{{ page.eip | xml_escape }}: {{ page.title | xml_escape }}
-    {% elsif page.category != "ERC" %}
+    {% else %}
       EIP-{{ page.eip | xml_escape }}: {{ page.title | xml_escape }}
     {% endif %}
     <a href="{{ page.discussions-to | uri_escape }}" class="no-underline">


### PR DESCRIPTION
Remove redundant elsif page.category != "ERC" in EIPs/_layouts/eip.html, rely on else for all non-ERC categories; behavior unchanged, keeps ERC branch intact; reduces dead conditional logic