### PR TITLE
Update EIP-8096: change reprice to double

### DIFF
--- a/EIPS/eip-8007.md
+++ b/EIPS/eip-8007.md
@@ -7,7 +7,7 @@ discussions-to: https://ethereum-magicians.org/t/eip-8007-glamsterdam-gas-repric
 status: Draft
 type: Meta
 created: 2025-08-21
-requires: 2780, 2926, 7778, 7904, 7923, 7971, 7976, 7981, 8011, 8032, 8037, 8038, 8053, 8057, 8058, 8059, 8096
+requires: 2780, 2926, 7778, 7904, 7923, 7971, 7976, 7981, 8011, 8032, 8037, 8038, 8053, 8057, 8058, 8059
 ---
 
 ## Abstract
@@ -52,7 +52,6 @@ This list will continue to be updated as more gas repricing EIPs are proposed.
 | [EIP-8057](./eip-8057.md) | Multi‑block temporal locality discounts for state and account access. | Pricing extension | State | Proposed for Inclusion |
 | [EIP-8058](./eip-8058.md) | Reduces gas costs for deploying duplicate contract bytecode via access-list based mechanism. | Pricing extension | State | Proposed for Inclusion |
 | [EIP-8059](./eip-8059.md) | Gas parameters and variables are increased to a factor of `REBASE_FACTOR` to reduce rounding errors without major changes to the EVM. | Supporting | NA | Proposed for Inclusion |
-| [EIP-8096](./eip-8096.md) | Increases cost of point evaluation precompile. | Pricing extension | Compute | Proposed for Inclusion |
 
 ## Rationale
 


### PR DESCRIPTION
We are targeting performance of 60MGas/s on a reference machine for Glamsterdam, so doubling the price will be enough