### PR TITLE
Update EIP-7973: document access gas parameters

### DIFF
--- a/EIPS/eip-7973.md
+++ b/EIPS/eip-7973.md
@@ -32,6 +32,9 @@ The parameters `GAS_CALL_VALUE` and `GAS_STORAGE_UPDATE` are removed, and the fo
 | `GAS_COLD_STORAGE_WRITE` | TBD | Cost of a single update to the storage trie |
 | `GAS_COLD_ACCOUNT_WRITE` | TBD | Cost of a single update to the account trie |
 | `GAS_WARM_WRITE` | TBD | Cost of a warm update to a trie (i.e. does not trigger a new state root calculation) |
+| `GAS_COLD_STORAGE_ACCESS` | existing | Base cost of a cold access to the storage trie, as defined in the Execution Layer spec and [EIP-8038](eip-8038.md) |
+| `GAS_COLD_ACCOUNT_ACCESS` | existing | Base cost of a cold access to the account trie, as defined in the Execution Layer spec and [EIP-8038](eip-8038.md) |
+| `GAS_WARM_ACCESS` | existing | Base cost of a warm access to already-loaded state, as defined in the Execution Layer spec and [EIP-8038](eip-8038.md) |
 
 <-- TODO -->
 


### PR DESCRIPTION
Extend the gas parameter table in the Specification section to include `GAS_COLD_STORAGE_ACCESS`, `GAS_COLD_ACCOUNT_ACCESS`, and `GAS_WARM_ACCESS`, referencing the Execution Layer spec and EIP-8038. This makes the previously used access parameters explicit in the document and clarifies how they relate to the new _WRITE parameters, removing ambiguity about their origin and meaning.