### PR TITLE
Update EIP-7942: Fix committee failure-probability notation

### DIFF
--- a/EIPS/eip-7942.md
+++ b/EIPS/eip-7942.md
@@ -59,9 +59,9 @@ Formally, we give the following definitions for AA:
 
 - (Stable chain) *The chain $c$ is a stable chain if the leaf block of $c$ is a stable block.*
 
-In practice, the validators are divided into 32 disjoint committees randomly. Since the committees are sampled pseudorandomly, the fraction of Byzantine validators in each committee follows a binomial distribution. We use $f$ as the number of total Byzantine validators and $f'$ as the number of Byzantine validators in each committee.
+In practice, the validators are divided into 32 disjoint committees randomly. Since the committees are sampled pseudorandomly, the number of Byzantine validators in each committee can be approximated by a binomial distribution. We use $f$ as the number of total Byzantine validators and $f'$ as the expected number of Byzantine validators in each committee.
 
-- We use $\vartheta$ to denote the number of Byzantine validators in each committee and $p$ as the desirable failure probability (i.e., the probability that the number of Byzantine validators in a committee is greater than $\vartheta$).
+- We use $\vartheta$ to denote a threshold on the number of Byzantine validators in each committee and $p$ as the desirable failure probability (i.e., the probability that the number of Byzantine validators in a committee is greater than $\vartheta$).
 
 Given the desired value $p$, the value of $\vartheta$ can be calculated using $\vartheta = \lfloor\mu + \sigma \cdot \Phi^{-1}(1 - p)\rfloor,$ where $\mu = f'$, $\sigma^2 = f'(1 - f/n)$, and $\Phi^{-1}$ is the inverse of the cumulative distribution function of the normal distribution. We show some concrete examples of the ratio of Byzantine validators in a committee.
 


### PR DESCRIPTION
Clarify the probabilistic model for committee composition so that the text matches the formulas used to derive the failure threshold. The updated wording makes it explicit that f' denotes the expected number of Byzantine validators per committee and that ϑ is a threshold on the number of Byzantine validators, with p defined as the probability that a committee exceeds this threshold. This removes the previous ambiguity where f' and ϑ were described as concrete committee counts while simultaneously serving as distribution parameters, without changing any formulas or protocol behavior.