### PR TITLE
Update EIP-7773: EIP-8070 decision from ACDC172

### DIFF
--- a/EIPS/eip-7773.md
+++ b/EIPS/eip-7773.md
@@ -38,6 +38,7 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Declined
 * [EIP-8038](./eip-8038.md): State-access gas cost increase
 * [EIP-8045](./eip-8045.md): Exclude slashed validators from proposing
 * [EIP-8061](./eip-8061.md): Increase exit and consolidation churn
+* [EIP-8070](./eip-8070.md): Sparse Blobpool
 * [EIP-8080](./eip-8080.md): Let exits use the consolidation queue
 
 ### Declined for Inclusion
@@ -70,11 +71,10 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Declined
 * [EIP-8058](./eip-8058.md): Contract Bytecode Deduplication Discount
 * [EIP-8059](./eip-8059.md): Gas Units Rebase for High-precision Metering
 * [EIP-8062](./eip-8062.md): Add sweep withdrawal fee for 0x01 validators
-* [EIP-8071](./eip-8071.md): Prevent using consolidations as withdrawals
 * [EIP-8068](./eip-8068.md): Neutral effective balance design
+* [EIP-8071](./eip-8071.md): Prevent using consolidations as withdrawals
 
 ### Proposed for Inclusion
-
 
 * [EIP-5920](./eip-5920.md): PAY opcode
 * [EIP-7610](./eip-7610.md): Revert creation in case of non-empty storage
@@ -87,7 +87,6 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Declined
 * [EIP-8032](./eip-8032.md): Size-Based Storage Gas Pricing
 * [EIP-8037](./eip-8037.md): State Creation Gas Cost Increase
 * [EIP-8051](./eip-8051.md): Precompile for ML-DSA signature verification
-* [EIP-8070](./eip-8070.md): Sparse Blobpool
 
 ### Activation
 


### PR DESCRIPTION
Move EIP-8070 from PFI → CFI based on [decision from ACDC#172](https://forkcast.org/calls/acdc/172#t=809)

(plus some other minor formatting nits)
