### PR TITLE
Update EIP-7906: fix CALL opcode value

### DIFF
--- a/EIPS/eip-7906.md
+++ b/EIPS/eip-7906.md
@@ -135,7 +135,7 @@ Including all opcodes called during a transaction execution in the stack trace i
 * `DELEGATECALL` (`0xF4`)
 * `CALLCODE` (`0xF2`)
 * `STATICCALL` (`0xFA`)
-* `CALL` (`0xFA`)
+* `CALL` (`0xF1`)
 * `LOG` (`0xA0`)
 * `LOG1` (`0xA1`)
 * `LOG2` (`0xA2`)


### PR DESCRIPTION
The traced opcodes list in EIP-7906 incorrectly documented CALL as 0xFA, which conflicts with the canonical EVM opcode table and EIP-214 where 0xFA is STATICCALL and 0xF1 is CALL. This change corrects the CALL opcode to 0xF1 to align the specification with the established EVM semantics and other EIPs in this repository.