### PR TITLE
Update EIP-7778: Clarify gas accounting for receipts

### DIFF
--- a/EIPS/eip-7778.md
+++ b/EIPS/eip-7778.md
@@ -30,23 +30,14 @@ This mechanism can be exploited to perform more operations in a block than the g
 
 ### Gas Accounting Changes
 
-1. **User Gas Costs (Unchanged):**
+1. **User and Receipt Gas Accounting (Unchanged):**
    - Users continue to receive gas refunds for operations that qualify (e.g., setting storage to zero)
-   - The transaction gas cost remains: `tx.gas_used = gas_used - gas_refund`
+   - Transaction and receipt gas: `gas_used = max(tx_gas_used - gas_refund, calldata_floor_gas_cost)`
 
 2. **Block Gas Accounting (Modified):**
    - When calculating gas for block gas limit enforcement, refunds are not subtracted
-   - Block gas accounting becomes: `block.gas_used += max(tx_gas_used_before_refund, calldata_floor_gas_cost)` (without subtracting refunds, incorporating the calldata floor from [EIP-7623](./eip-7623.md))
+   - Block gas accounting becomes: `block.gas_used += max(tx_gas_used, calldata_floor_gas_cost)` (incorporating the calldata floor from [EIP-7623](./eip-7623.md))
    - Storage discounts that reflect actual reduced computational work (e.g., warm storage access, reverting to original values) remain applied to block gas accounting
-
-### Block Gas Limit Enforcement
-
-The sum of gas used before refunds by all transactions must not exceed the block gas limit. This ensures the block gas limit accurately reflects the computational and storage workload
-
-### Receipt Gas Accounting
-
-- Receipt gas accounting becomes: `cumulative_gas_used += max(tx_gas_used_after_refund, calldata_floor_gas_cost)`, representing the gas the user paid
-- Block gas limit enforcement uses the block header's `gas_used` field, which stores the sum of gas used before refunds
 
 ## Rationale
 


### PR DESCRIPTION
Clarify that `cumulative_gas_used` in receipts stores pre-refund gas for block gas limit enforcement.