### PR TITLE
Update EIP-7723: remove contradictory Last Call requirement in Rationale

### DIFF
--- a/EIPS/eip-7723.md
+++ b/EIPS/eip-7723.md
@@ -92,7 +92,7 @@ Formalizing the `Proposed for Inclusion`, `Considered for Inclusion`, `Scheduled
 
 The specification tries to minimize steps which **MUST** be followed to align with Ethereum's "rough consensus" governance model. 
 
-Assuming it is adopted, the process outlined in this EIP should be used for at least one full network upgrade cycle before moving to `Last Call` and at least two full network upgrades cycles before moving to `Final`. This way, the EIP can be updated to reflect changes made to the process over time. 
+This process is intended to be adopted for future network upgrades. Before this EIP moves to `Final`, the process should be validated through at least two full network upgrade cycles to allow for refinement based on practical experience. 
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
## Problem

The Rationale section contained a logical contradiction: it stated that the process should be used for at least one full network upgrade cycle before moving to `Last Call`, but EIP-7723 is already in `Last Call` status. This created confusion about whether the requirement was met or violated.

## Solution

Updated the Rationale section to clarify that the process is intended for future network upgrades. The text now specifies that validation through at least two full network upgrade cycles should occur before this EIP moves to `Final` status, removing the contradictory requirement about `Last Call`.