### PR TITLE
Update EIP-7793: clarify conditional tx sentinel and index base

### DIFF
--- a/EIPS/eip-7793.md
+++ b/EIPS/eip-7793.md
@@ -39,7 +39,7 @@ We introduce a new type of [EIP-2718](./eip-2718.md) transaction, "conditional t
 
 The fields `chain_id`, `nonce`, `max_priority_fee_per_gas`, `max_fee_per_gas`, `gas_limit`, `to`, `value`, `data`, `access_list`, `max_fee_per_blob_gas` follow the same semantics as [EIP-4844](./eip-4844.md). The field `blob_versioned_hashes` is the same except that the list may be empty for a conditional transaction.
 
-The fields `conditional_slot` and `conditional_tx_index` are both `uint64` and specify the slot and transaction index in which this transaction should be considered valid respectively. In order to verify that `conditional_slot` is correct, [EIP-7843](./eip-7843.md) is a dependency, as this adds the slot number to the header. For both fields `-1` is used as a sentinel value for which the slot or transaction index check will not take place.
+The fields `conditional_slot` and `conditional_tx_index` are both `uint64` and specify the slot and transaction index in which this transaction should be considered valid respectively; `conditional_tx_index` is a 0-based index into the block's transaction list. In order to verify that `conditional_slot` is correct, [EIP-7843](./eip-7843.md) is a dependency, as this adds the slot number to the header. For both fields the sentinel value is the maximum `uint64` value `2**64 - 1` (encoded as `0xffffffffffffffff`), for which the slot or transaction index check MUST NOT take place.
 
 #### Signature
 
@@ -53,7 +53,7 @@ A new opcode `TXINDEX` is introduced at `TXINDEX_OPCODE_BYTE`.
 
 #### Output
 
-One element `TransactionIndex` is added to the stack. `TransactionIndex` is a `uint64` in big endian encoding. It is equal to `conditional_tx_index` if the current transaction is a conditional transaction, and `-1` otherwise.
+One element `TransactionIndex` is added to the stack. `TransactionIndex` is a `uint64` in big endian encoding. It is equal to `conditional_tx_index` if the current transaction is a conditional transaction, and `2**64 - 1` (i.e. `0xffffffffffffffff`) otherwise.
 
 #### Gas Cost
 


### PR DESCRIPTION
Clarify that conditional_tx_index is a 0-based index into the block's transaction list and replace the ambiguous -1 sentinel with the explicit uint64 maximum value (2**64 - 1 / 0xffffffffffffffff) for conditional_slot and conditional_tx_index, including TXINDEX output. This removes type/sign ambiguity around uint64 fields and ensures consistent consensus behavior across client implementations.