### PR TITLE
Update EIP-8012: Fix typos in EIP-8012

### DIFF
--- a/EIPS/eip-8012.md
+++ b/EIPS/eip-8012.md
@@ -36,7 +36,7 @@ No changes are expected
 
 ### Consensus Layer
 
-This EIP does not establish any changes on the consensus layer, but rather standardizes how consolidation requests are to be treated in the future. When receiving a `ConsolidationRequest` type object on the consensus layer, the `target_pubkey` field is to be treated differently. If it coincides with the BLS publick key of an existing active validator in the beacon chain, then it is to be interpreted as such. Otherwise, the 48 bytes are to be interpreted as a concatenation of the following fields
+This EIP does not establish any changes on the consensus layer, but rather standardizes how consolidation requests are to be treated in the future. When receiving a `ConsolidationRequest` type object on the consensus layer, the `target_pubkey` field is to be treated differently. If it coincides with the BLS public key of an existing active validator in the beacon chain, then it is to be interpreted as such. Otherwise, the 48 bytes are to be interpreted as a concatenation of the following fields
 
 ```
 |MAGIC_PREFIX | CALL_TYPE | ARG_NUMBER | ARG1 | ARG2 | ARG3 | ARG4 | ARG5 |
@@ -52,7 +52,7 @@ No changes needed.
 
 ## Rationale
 
-The proposed reinterpretation of the existing contract enables new implementations in the consensus layer without requireing a hard fork in the execution layer.
+The proposed reinterpretation of the existing contract enables new implementations in the consensus layer without requiring a hard fork in the execution layer.
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
Fixes two typos in EIP-8012:

- `publick key` → `public key` (line 39)
- `requireing` → `requiring` (line 55)