### PR TITLE
Update EIP-7979: Fix typos in EIP-7979 and EIP-8012

### DIFF
--- a/EIPS/eip-7979.md
+++ b/EIPS/eip-7979.md
@@ -252,7 +252,7 @@ This would of course break the promise of "the smallest possible change."  [EIP-
 
 ### Why no code sections?
 
-Again, this would break the promise of "the smallest possible change," and [EIP-3540: EOF - EVM Object Format](./eip-3540) remains available. But note that restricting jumps to code sections impedes important optimizations, which EOF supported by adding special opcodes.  So if we want restricted code sections this becomes a much bigger change, and we should consider [EOF - Functions](./eip-4750) and related EIPs separately.  This proposal uses the same return-stack mechanism and poses no forwards compatability issues with EOF.
+Again, this would break the promise of "the smallest possible change," and [EIP-3540: EOF - EVM Object Format](./eip-3540) remains available. But note that restricting jumps to code sections impedes important optimizations, which EOF supported by adding special opcodes.  So if we want restricted code sections this becomes a much bigger change, and we should consider [EOF - Functions](./eip-4750) and related EIPs separately.  This proposal uses the same return-stack mechanism and poses no forwards compatibility issues with EOF.
 
 ### Why the return-stack mechanism?
 

--- a/EIPS/eip-8012.md
+++ b/EIPS/eip-8012.md
@@ -42,7 +42,7 @@ This EIP does not establish any changes on the consensus layer, but rather stand
 |MAGIC_PREFIX | CALL_TYPE | ARG_NUMBER | ARG1 | ARG2 | ARG3 | ARG4 | ARG5 |
 ```
 
-Where `MAGIC_PREFIX` is the 3 byte constant that prefixes all generalized consolidation requests. `CALL_TYPE` are 4 bytes to be interpretted as a little Endian `uint32` and identifies the function type. `ARG_NUMBER` is a 1 byte to be interpretted as a `uint8` that encodes the number of arguments that are being passed to the generalized consolidation request handler. And each `ARG1, ARG2, ARG3, ARG4, ARG5` are all interpretted as little Endian `uint64`.
+Where `MAGIC_PREFIX` is the 3 byte constant that prefixes all generalized consolidation requests. `CALL_TYPE` are 4 bytes to be interpreted as a little Endian `uint32` and identifies the function type. `ARG_NUMBER` is a 1 byte to be interpreted as a `uint8` that encodes the number of arguments that are being passed to the generalized consolidation request handler. And each `ARG1, ARG2, ARG3, ARG4, ARG5` are all interpreted as little Endian `uint64`.
 
 For each addition of a new `CALL_TYPE`, the consensus layer must add a handler appropriately called from within `process_consolidation_requests`.
 


### PR DESCRIPTION
Fixes spelling errors in EIP-7979 and EIP-8012 

Corrections include:
- EIP-7979: `compatability` → `compatibility`
- EIP-8012: `interpretted` → `interpreted` (3 occurrences)