### PR TITLE
Update EIP-7911: fix cosine similarity example

### DIFF
--- a/EIPS/eip-7911.md
+++ b/EIPS/eip-7911.md
@@ -78,7 +78,7 @@ sim_cos(xᵢ, xⱼ) = (xᵢ·xⱼ)/(‖xᵢ‖‖xⱼ‖)
 
 ![Vector Similarity Example](../assets/eip-7911/20250319_203500.png)
 
-Example: For vectors x₁ = [0.7, 0.8] and x₂ = [0.9, 0.4], the similarity is 0.89.
+Example: For vectors x₁ = [0.7, 0.8] and x₂ = [0.9, 0.4], the similarity is 0.91.
 
 ### 3. ZKP Proof Generation
 


### PR DESCRIPTION
Correct the numeric value in the cosine similarity example so that it matches the actual cosine similarity of the given vectors. The previous value 0.89 was inconsistent with the defined sim_cos formula.

Given: x₁ = [0.7, 0.8], x₂ = [0.9, 0.4], sim = 0.89 is claimed.
Calculation:
x₁·x₂ = 0.7*0.9 + 0.8*0.4 = 0.63 + 0.32 = 0.95
‖x₁‖ ≈ sqrt(0.49+0.64) = sqrt(1.13) ≈ 1.063
‖x₂‖ ≈ sqrt(0.81+0.16) = sqrt(0.97) ≈ 0.985
sim ≈ 0.95 / (1.063 * 0.985) ≈ 0.95 / 1.047 ≈ 0.91