### PR TITLE
Update EIP-7708: Move to Draft

### DIFF
--- a/EIPS/eip-7708.md
+++ b/EIPS/eip-7708.md
@@ -2,9 +2,9 @@
 eip: 7708
 title: ETH transfers emit a log
 description: All ETH transfers emit a log
-author: Vitalik Buterin (@vbuterin), Peter Davies (@petertdavies)
+author: Vitalik Buterin (@vbuterin), Peter Davies (@petertdavies), Carson (@carsons-eels)
 discussions-to: https://ethereum-magicians.org/t/eip-7708-eth-transfers-emit-a-log/20034
-status: Stagnant
+status: Draft
 type: Standards Track
 category: Core
 created: 2024-05-17


### PR DESCRIPTION
7708 currently has no champion advancing it. The EIP has been Considered For Inclusion in the upcoming Amsterdam fork as well as included in [bal-devnet-2](https://notes.ethereum.org/OK4qGiy8Sy23LIoMRD7pmQ?view) which is scheduled for the 21st of January. 

7708 also suffers from under-specification and the [comments](https://ethereum-magicians.org/t/eip-7708-eth-transfers-emit-a-log/20034/42) from the Ethereum Magicians forum advance two refinements to the EIP, and two proposals for additional features. These need to be considered, reviewed, and either rejected or merged so that the implementation can likewise be updated.