### PR TITLE
Update EIP-7778: Clarify interaction with calldata floor cost

### DIFF
--- a/EIPS/eip-7778.md
+++ b/EIPS/eip-7778.md
@@ -37,7 +37,7 @@ This mechanism can be exploited to perform more operations in a block than the g
 
 2. **Block Gas Accounting (Modified):**
    - When calculating gas for block gas limit enforcement, refunds are not subtracted
-   - Block gas accounting becomes: `block.gas_used += gas_used` (without subtracting refunds)
+   - Block gas accounting becomes: `block.gas_used += max(tx_gas_used_before_refund, calldata_floor_gas_cost)` (without subtracting refunds, incorporating the calldata floor from [EIP-7623](./eip-7623.md))
    - Storage discounts that reflect actual reduced computational work (e.g., warm storage access, reverting to original values) remain applied to block gas accounting
 
 ### Block Gas Limit Enforcement


### PR DESCRIPTION
This clarifies that block gas accounting uses max(tx_gas_used_before_refund, calldata_floor_gas_cost) and adds a reference to EIP-7623 which defines the calldata floor gas cost mechanism.
