### PR TITLE
Update EIP-8024: Switch encoding to push-postfix

### DIFF
--- a/EIPS/eip-8024.md
+++ b/EIPS/eip-8024.md
@@ -164,6 +164,8 @@ This has no effect on contracts that would never attempt to execute the opcodes 
 - `e86012` is `[EXCHANGE 2 3]`
 - `e860d0` is `[EXCHANGE 1 19]`
 - `e850` is `[INVALID_EXCHANGE, POP]`
+- `e6` at end of code is `[INVALID_DUPN]`
+- `e660` at end of code is `[DUPN 17]`
 
 ### Execution
 


### PR DESCRIPTION
For consideration by ACD, this would change the EIP from Option 2.2.1 to 2.2.3 as defined in https://ethereum-magicians.org/t/evm-immediates/25605