### PR TITLE
chore: remove non-existent LICENSE entry from Jekyll config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -68,6 +68,4 @@ exclude:
   - README.md
   
 include:
-  - LICENSE
-
 markdown_ext: "markdown,mkdown,mkdn,mkd,md"


### PR DESCRIPTION
Removes the obsolete `- LICENSE` entry from the `include:` section in `_config.yml`.