### PR TITLE
Website: remove redundant loop in `dependencies()` JS example

### DIFF
--- a/assets/eip-712/Example.js
+++ b/assets/eip-712/Example.js
@@ -57,11 +57,9 @@ function dependencies(primaryType, found = []) {
     }
     found.push(primaryType);
     for (let field of types[primaryType]) {
-        for (let dep of dependencies(field.type, found)) {
-            if (!found.includes(dep)) {
-                found.push(dep);
-            }
-        }
+        // `dependencies` mutates `found` in-place, so iterating and re-pushing
+        // the returned array is redundant.
+        dependencies(field.type, found);
     }
     return found;
 }


### PR DESCRIPTION

This PR simplifies `dependencies()` in `assets/eip-712/Example.js` by removing a redundant nested loop that never changes `found`.

