### PR TITLE
chore(config): remove obsolete `include` directive

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -67,7 +67,4 @@ exclude:
   - PULL_REQUEST_TEMPLATE.md
   - README.md
   
-include:
-  - LICENSE
-
 markdown_ext: "markdown,mkdown,mkdn,mkd,md"


### PR DESCRIPTION
Removes the unused `include: [LICENSE]` directive from `_config.yml`.