### PR TITLE
Update EIP-7778: add new receipt field for gas_spent

### DIFF
--- a/EIPS/eip-7778.md
+++ b/EIPS/eip-7778.md
@@ -30,14 +30,14 @@ This mechanism can be exploited to perform more operations in a block than the g
 
 ### Gas Accounting Changes
 
-1. **User and Receipt Gas Accounting (Unchanged):**
-   - Users continue to receive gas refunds for operations that qualify (e.g., setting storage to zero)
-   - Transaction and receipt gas: `gas_used = max(tx_gas_used - gas_refund, calldata_floor_gas_cost)`
-
-2. **Block Gas Accounting (Modified):**
+1. **Block Gas Accounting (Modified):**
    - When calculating gas for block gas limit enforcement, refunds are not subtracted
    - Block gas accounting becomes: `block.gas_used += max(tx_gas_used, calldata_floor_gas_cost)` (incorporating the calldata floor from [EIP-7623](./eip-7623.md))
    - Storage discounts that reflect actual reduced computational work (e.g., warm storage access, reverting to original values) remain applied to block gas accounting
+
+2. **Receipt Changes:**
+   - `cumulative_gas_used`: Now uses gas before refunds, matching block gas accounting
+   - New field `gas_spent`: Gas actually spent by the transaction after refunds (what the user pays)
 
 ## Rationale
 
@@ -52,7 +52,7 @@ Users still receive gas refunds, maintaining incentives for efficient state mana
 ## Backwards Compatibility
 
 - This change is not backwards compatible and requires a hard fork
-- User and developer experience for individual transactions remains unchanged
+- Receipt structure changes: `cumulative_gas_used` semantics change and new `gas_spent` field is added
 - Block producers need to adjust their transaction selection algorithms to account for the new gas accounting rules
 
 ## Test Cases
@@ -65,9 +65,9 @@ Users still receive gas refunds, maintaining incentives for efficient state mana
    - Construct blocks with varying amounts of refundable operations
    - Ensure blocks cannot exceed gas limits through refund mechanisms
 
-3. **Transaction Gas vs Block Gas:**
-   - Verify that transaction costs for users remain unchanged
-   - Confirm block gas accounting properly excludes refunds
+3. **Receipt Fields:**
+   - Verify `cumulative_gas_used` reflects gas before refunds
+   - Verify `gas_spent` reflects gas after refunds (user cost)
 
 ## Security Considerations
 


### PR DESCRIPTION
This PR reverts EIP-7778 back to using the gas used before refunds for the cumulative gas used in receipts, and adds a new field, gas_spent, to the receipt (which is needed to populate the `gas_used` in `eth_getTransactionReceipt`.

Discussion:
https://discord.com/channels/595666850260713488/688075293562503241/1461678093289656524

Execution specs:
https://github.com/ethereum/execution-specs/pull/1401