### PR TITLE
Add EIP: Non-Transferable Token Standard

### DIFF
--- a/EIPS/eip-xxxx.md
+++ b/EIPS/eip-xxxx.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: ERC
 created: 2026-01-19
-requires: [165, 721]
+requires: 165, 721
 ---
 
 ## Abstract


### PR DESCRIPTION
**ATTENTION: ERC-RELATED PULL REQUESTS NOW OCCUR IN [ETHEREUM/ERCS](https://github.com/ethereum/ercs)**

--
## Summary

This PR proposes EIP-XXXX: Non-Transferable Token Standard - a minimal standard for tokens that are permanently bound to an address.

## Description

Introduces a dedicated interface for non-transferable (Soulbound) tokens that eliminates transfer functionality by design, rather than extending ERC-721 and blocking transfers. The standard:

- Defines tokens as non-transferable through interface design (no transfer functions)
- Reduces bytecode bloat by ~80% compared to ERC-721 extensions
- Provides semantic clarity - tokens that cannot be transferred vs tokens that block transfers
- Includes only essential operations: `mint()`, `burn()`, `ownerOf()`
- Requires ERC-721 Metadata interface for wallet/indexer compatibility

This approach addresses architectural mismatches in existing Soulbound implementations (ERC-5192, ERC-4973, ERC-5484) that inherit unused transfer infrastructure.