### PR TITLE
Update EIP-7804: add explicit credential type field

### DIFF
--- a/EIPS/eip-7804.md
+++ b/EIPS/eip-7804.md
@@ -99,6 +99,7 @@ with type `0x03` and consists of the following fields:
 1. `pubkey`: `Bytes48`
 2. `old_address`: `Bytes20`
 3. `new_address`: `Bytes20`
+4. `new_credential_type`: `Bytes1`
 
 The [EIP-7685](./eip-7685.md) encoding of a withdrawal credential update request is computed as follows.
 
@@ -112,7 +113,7 @@ request_data = read_withdrawal_credential_update_requests()
 The contract is similar to other execution requests contracts for Deposits, Withdrawals and Consolidation.
 The contract has three different code paths, which can be summarized at a high level as follows:
 
-1. Add request - requires a `68` byte input, the validator's public key concatenated with the new address for withdrawal credentials.
+1. Add request - requires a `69` byte input, the validator's public key, the new address for withdrawal credentials, and the new withdrawal credential type.
 2. Excess requests getter - if the input length is zero, return the current excess requests count.
 3. System process - if called by system address, pop off the withdrawal credential update requests for the current block from the queue.
 
@@ -142,6 +143,7 @@ class WithdrawalCredentialUpdateRequest(Container):
     validator_pubkey: BLSPubkey
     old_address: ExecutionAddress  # request contract will set this to msg.caller
     new_address: ExecutionAddress
+    new_credential_type: Bytes1
 ```
 
 ```python
@@ -162,7 +164,7 @@ def process_withdrawal_credential_update_request(state: BeaconState, withdrawal_
     if not (has_correct_credential and is_correct_old_address):
         return
 
-    credential_type = withdrawal_credentials_update_requests.type
+    credential_type = withdrawal_credentials_update_requests.new_credential_type
     is_eth1_type = credential_type == ETH1_ADDRESS_WITHDRAWAL_PREFIX
     is_compounding_type = credential_type == COMPOUNDING_WITHDRAWAL_PREFIX
     # Verify valid type


### PR DESCRIPTION
The request handler referenced a type field that did not exist in the request payload or container, so the new withdrawal credential prefix could not be validated at all.

Added an explicit new_credential_type field to the request definition, contract calldata description, and CL processing logic to make the type check well-defined.