### PR TITLE
Update EIP-8037: clarify regular gas costs for state creation operations

### DIFF
--- a/EIPS/eip-8037.md
+++ b/EIPS/eip-8037.md
@@ -51,9 +51,18 @@ Upon activation of this EIP, the following parameters of the gas model are updat
 | `GAS_STORAGE_SET` | 20,000 | 32 × `cpsb` | 2,900 (`GAS_STORAGE_UPDATE - GAS_COLD_SLOAD`) | `SSTORE` |
 | `PER_EMPTY_ACCOUNT_COST` | 25,000 | 112 × `cpsb` | — (included in `PER_AUTH_BASE_COST`) | EOA delegation |
 | `PER_AUTH_BASE_COST` | 12,500 | 23 × `cpsb` | 7,500 | EOA delegation |
-| ([EIP-2780](./eip-2780.md)) | — | 112 × `cpsb` | 5,000 (`GAS_STORAGE_UPDATE`) | Value tx to new account |
 
 Where `cpsb` = `cost_per_state_byte`.
+
+The `PER_AUTH_BASE_COST` regular gas of 7,500 is derived from [EIP-7702](./eip-7702.md)'s cost analysis, excluding the code deployment cost (now charged as state gas):
+
+- Calldata cost: ~1,616 (101 bytes × 16)
+- Recovering authority address (ecrecover): 3,000
+- Reading nonce and code of authority (cold access): 2,600
+- Storing values in already warm account: 200
+- ~~Code deployment cost: 4,600 (200 × 23)~~ → now in state gas
+
+Total regular gas: 1,616 + 3,000 + 2,600 + 200 ≈ 7,500
 
 In addition, `GAS_SELF_DESTRUCT_NEW_ACCOUNT` is removed and replaced by `GAS_NEW_ACCOUNT`.
 


### PR DESCRIPTION
Clarify how we split up gas costs in regular gas and state gas when they currently account both for state creation and for compute/IO. For example, we currently charge `GAS_STORAGE_SET` when for zero -> nonzero `SSTORE`, which accounts both for state creation and for the IO cost of writing to state (`= GAS_STORAGE_UPDATE - GAS_COLD_SLOAD (2900)`, which is what we charge for nonzero -> nonzero `SSTORE`). 

Leaving the regular gas for `CREATE` as tbd, as we need to discuss what exactly should be charged to properly account for the execution costs. 