### PR TITLE
Update EIP-8116: correct logIndex reconstruction formula in EIP-8116

### DIFF
--- a/EIPS/eip-8116.md
+++ b/EIPS/eip-8116.md
@@ -44,7 +44,7 @@ This EIP is a step towards aligning on-chain data with the RPC data actually bei
 
 Applications using verified `gasUsed` / `cumulativeGasUsed` values need to adapt to the new on-chain data semantics.
 
-Applications relying on the per block `logIndex` need adaptation, as `logIndex` now refers to an index per receipt. Note that this is solely an RPC change. Relative log ordering can be emulated by estimating `logIndex` as `transactionIndex * 4 + logIndex` (guaranteed to have same order as before, but absolute index values may be higher than before).
+Applications relying on the per block `logIndex` need adaptation, as `logIndex` now refers to an index per receipt. Note that this is solely an RPC change. To reconstruct the global block-level `logIndex`, applications need to sum the number of logs from all previous transactions in the block: `globalLogIndex = sum(logs_count[0..transactionIndex-1]) + logIndex`. This requires access to all receipts in the block, which contradicts the goal of making receipts independent. Applications should migrate to using per-receipt `logIndex` values instead.
 
 ## Security Considerations
 


### PR DESCRIPTION
Remove incorrect formula with magic number 4 that could cause collisions when transactions have more than 4 logs. Replace with accurate formula that sums logs from previous transactions, noting the contradiction with receipt independence goals. Recommend migration to per-receipt logIndex.