### PR TITLE
Update EIP-7790: minor grammar improvements

### DIFF
--- a/EIPS/eip-7790.md
+++ b/EIPS/eip-7790.md
@@ -33,7 +33,7 @@ The parameters for the controlled gas limit increase strategy are:
   The initial gas limit at `blockNumStart` represents the current default gas limit of the Ethereum network, set to 30 million gas.
 
 - **Rate of Increase (`r`)**: `6`  
-  The gas limit will increase by 6 gas per block. This results in a slow growth rate culminating to reaching the cap in approximately 694 days.
+  The gas limit will increase by 6 gas per block. This results in a slow growth rate culminating in reaching the cap in approximately 694 days.
 
 - **Gas Limit Cap (`gasLimitCap`)**: `60_000_000`  
   The maximum gas limit is capped at 60 million gas, ensuring that the gas limit will not increase indefinitely and will prevent the network from being overwhelmed by excessively large blocks.
@@ -42,7 +42,7 @@ The parameters for the controlled gas limit increase strategy are:
 
 ### **Starting Block Number**
 
-The chosen block number (`21792420`) provides ample time to discuss and implement the gas limit increase strategy, additionally, it allows to happen with or slightly before the pectra hard fork.
+The chosen block number (`21792420`) provides ample time to discuss and implement the gas limit increase strategy, additionally, it allows it to happen with or slightly before the pectra hard fork.
   
 ### **Initial Gas Limit**
 


### PR DESCRIPTION
These changes were made because the original phrases used incorrect verb–preposition and verb–object constructions. 

In English, the verb “culminate” correctly takes the preposition “in” (not “to”), and the verb “allow” requires an explicit object (“it”) before an infinitive, so the corrections make the sentences grammatically correct and natural.