### PR TITLE
Update EIP-7942: correct parent_root assignment in AA selection

### DIFF
--- a/EIPS/eip-7942.md
+++ b/EIPS/eip-7942.md
@@ -99,7 +99,7 @@ For the validator behavior specification (validator in consensus-specs):
 To propose, the validator selects a `BeaconBlock`, `parent` using this process:
 
 1. Compute AA blocks at the start of slot. Let `aa` be the later AA block and `aa_root` be the root of `aa`.
-Set `parent_root == aa_root`.
+Set `parent_root = aa_root`.
 2. If no AA block exists, compute fork choice's view of the head at the start of `slot`, after running
    `on_tick` and applying any queued attestations from `slot - 1`. Set `parent_root = get_head(store)`.
 3. Let `parent` be the block with `parent_root`.


### PR DESCRIPTION
The pseudocode used parent_root == aa_root, which is a comparison that has no effect and contradicts the surrounding “Set …” assignments. This made the step a no-op and broke the intended parent selection behavior.
Replaced the comparison operator with an assignment in the AA parent selection step to correctly set parent_root from aa_root.