### PR TITLE
Update EIP-7981: use 7976 reference, update eip name

### DIFF
--- a/EIPS/eip-7981.md
+++ b/EIPS/eip-7981.md
@@ -1,25 +1,25 @@
 ---
 eip: 7981
-title: Increase access list cost
-description: Price access lists for data footpring to reduce maximum block size
+title: Increase Access List Cost
+description: Price access lists for data to reduce maximum block size
 author: Toni Wahrstätter (@nerolation)
 discussions-to: https://ethereum-magicians.org/t/eip-7981-increase-access-list-cost/24680
 status: Draft
 type: Standards Track
 category: Core
 created: 2024-12-27
-requires: 2930
+requires: 2930, 7976
 ---
 
 ## Abstract
 
-This EIP charges access lists for their data footprint, closing a loophole that allows circumventing [EIP-7623](./eip-7623.md) floor pricing. This effectively reduces the worst-case block size by ~21% with minimal impact on users.
+This EIP charges access lists for their data footprint, preventing the circumvention of the [EIP-7623](./eip-7623.md) floor pricing. This effectively reduces the worst-case block size by ~21% with minimal impact on users.
 
 ## Motivation
 
 Access lists are only priced for storage but not for their data.
 
-Furthermore, access lists can circumvent the [EIP-7623](./eip-7623.md) floor pricing by contributing to EVM gas while still leaving a non-negligible data footprint. This enables to achieve the maximal possible block size by combining access lists with calldata at a certain ratio.
+Furthermore, access lists can circumvent the [EIP-7976](./eip-7976.md) floor pricing by contributing to EVM gas while still leaving a non-negligible data footprint. This enables to achieve the maximal possible block size by combining access lists with calldata at a certain ratio.
 
 ## Specification
 
@@ -27,7 +27,7 @@ Furthermore, access lists can circumvent the [EIP-7623](./eip-7623.md) floor pri
 | -------------------------------------- | ----- | ------ |
 | `ACCESS_LIST_ADDRESS_COST`            | `2400` | [EIP-2930](./eip-2930.md) |
 | `ACCESS_LIST_STORAGE_KEY_COST`        | `1900` | [EIP-2930](./eip-2930.md) |
-| `TOTAL_COST_FLOOR_PER_TOKEN`          | `10`   | [EIP-7623](./eip-7623.md) |
+| `TOTAL_COST_FLOOR_PER_TOKEN`          | `15`   | [EIP-7976](./eip-7976.md) |
 
 Let `access_list_nonzero_bytes` and `access_list_zero_bytes` be the count of non-zero and zero bytes respectively in the addresses (20 bytes each) and storage keys (32 bytes each) contained within the access list.
 
@@ -58,14 +58,14 @@ access_list_data_cost = access_list_tokens * TOTAL_COST_FLOOR_PER_TOKEN
 access_list_cost = standard_access_list_cost + access_list_data_cost
 ```
 
-Transactions pay both the existing [EIP-2930](./eip-2930.md) functionality costs plus 40 gas per non-zero byte and 10 gas per zero byte counted across all addresses and storage keys in the access list.
+Transactions pay both the existing [EIP-2930](./eip-2930.md) functionality costs plus 60 gas per non-zero byte and 15 gas per zero byte counted across all addresses and storage keys in the access list.
 
 ## Rationale
 
-Adding 40 gas per non-zero byte and 10 gas per zero byte ensures consistent pricing across all transaction data:
+Adding 60 gas per non-zero byte and 15 gas per zero byte ensures consistent pricing across all transaction data:
 
-- Address (20 bytes, typically mostly non-zero): ~3200 gas (2400 + 800 assuming all non-zero)
-- Storage key (32 bytes, typically mostly non-zero): ~3180 gas (1900 + 1280 assuming all non-zero)
+- Address (20 bytes, typically mostly non-zero): ~3600 gas (2400 + 1200 assuming all non-zero)
+- Storage key (32 bytes, typically mostly non-zero): ~3820 gas (1900 + 1920 assuming all non-zero)
 
 No threshold mechanism is used. The per-byte costs are always applied to maintain simplicity and prevent circumvention.
 
@@ -79,14 +79,14 @@ At a gas limit of 60M:
 
 With data pricing (assuming all non-zero bytes):
 
-- 1 address + 18,866 storage keys: 3200 + (18,866 × 3180) = 59,998,280 gas (~604 KB)
+- 1 address + 15,705 storage keys: 3600 + (15,705 × 3820) = 59,996,700 gas (~491 KB)
 
 
 ### Maximum Block Size Impact
 
-The maximum possible Snappy compressed block size can be achieved by using access lists and calldata together at a ratio were the transaction keeps paying the lower calldata price.
+The maximum possible Snappy compressed block size can be achieved by using access lists and calldata together at a ratio where the transaction keeps paying the lower calldata price.
 
-At a gas limit of 60M, the maximum possible compressed block size will be reduced from 2.71 MiB to 2.13 MiB.
+At a gas limit of 60M, the maximum possible compressed block size will be reduced from 2.71 MiB to approximately 1.7 MiB.
 
 ## Backwards Compatibility
 
@@ -101,16 +101,16 @@ Requires updates to gas estimation in wallets and nodes. Normal usage patterns r
 - Addresses: 5 (100 bytes, assume all non-zero)
 - Storage keys: 10 (320 bytes, assume all non-zero)
 - Old cost: 5 × 2400 + 10 × 1900 = 31,000 gas
-- New cost: 5 × 3200 + 10 × 3180 = 47,800 gas
-- Additional cost: 16,800 gas (54.2% increase)
+- New cost: 5 × 3600 + 10 × 3820 = 56,200 gas
+- Additional cost: 25,200 gas (81.3% increase)
 
 ### Case 2: Large Access List Transaction
 
 - Addresses: 1000 (20,000 bytes, assume all non-zero)
 - Storage keys: 0
 - Old cost: 1000 × 2400 = 2,400,000 gas
-- New cost: 1000 × 3200 = 3,200,000 gas  
-- Additional cost: 800,000 gas (33.3% increase)
+- New cost: 1000 × 3600 = 3,600,000 gas
+- Additional cost: 1,200,000 gas (50% increase)
 
 ### Case 3: Combined Access List + Calldata
 
@@ -118,9 +118,9 @@ Requires updates to gas estimation in wallets and nodes. Normal usage patterns r
 - Calldata: 5,000 bytes
 - Old access list cost: 500 × 2400 = 1,200,000 gas
 - Old calldata cost: 5,000 × 4 = 20,000 gas (standard rate, avoiding floor)
-- New access list cost: 500 × 3200 = 1,600,000 gas
-- New calldata cost: Applied through [EIP-7623](./eip-7623.md) mechanism
-- Result: Can no longer circumvent [EIP-7623](./eip-7623.md) floor pricing
+- New access list cost: 500 × 3600 = 1,800,000 gas
+- New calldata cost: Applied through [EIP-7976](./eip-7976.md) mechanism
+- Result: Can no longer circumvent [EIP-7976](./eip-7976.md) floor pricing
 
 
 ## Reference Implementation
@@ -128,8 +128,8 @@ Requires updates to gas estimation in wallets and nodes. Normal usage patterns r
 The following is the EELS (Ethereum Execution Layer Specification) implementation:
 
 ```python
-TX_ACCESS_LIST_NONZERO_BYTE_COST = Uint(40)
-TX_ACCESS_LIST_ZERO_BYTE_COST = Uint(10)
+TX_ACCESS_LIST_NONZERO_BYTE_COST = Uint(60)
+TX_ACCESS_LIST_ZERO_BYTE_COST = Uint(15)
 
 def count_access_list_bytes(access_list: Tuple[Access, ...]) -> Tuple[int, int]:
     """


### PR DESCRIPTION
Since this EIP is likely to arrive together with EIP-7976, I incorporated the constants of EIP-7976 into this EIP.