### PR TITLE
Add contribution guidelines for EIP repository

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,7 @@ TBA.
 ### Do’s
 
 * **Check ownership and status.**  
-   * Authors, co-authors & champion can request status changes (Draft - Review - Last Call - Final). 
+   * Authors, co-authors & champion can request status changes. 
    * Confirm that non-author edits are non-semantic and author-approved if applicable.
 * **Enforce structure and format.**  
    * Confirm all required header fields match [EIP-1](https://eips.ethereum.org/EIPS/eip-1).  


### PR DESCRIPTION
As per the [EIPIP meeting 121](https://ethereum-magicians.org/t/eipip-meeting-121-oct-15-2025/25803/2),  this document has guidelines for authors, editors, and other contributors.   

It also contains [@SamWilsn 's Rules for EIPs](https://hackmd.io/@SamWilsn/B11QmJoq6) which new authors can reference while documenting EIP's text and diagrams.

Associated [PR](https://github.com/ethereum/EIPs/pull/11125) to Update EIP-1
