### PR TITLE
Update EIP-7937: fix grammar and wording

### DIFF
--- a/EIPS/eip-7937.md
+++ b/EIPS/eip-7937.md
@@ -30,7 +30,7 @@ If the second byte is not a valid 64-bit mode operation, then the interpreter MU
 
 ### General 64-bit mode behavior
 
-In 64-bit mode, all operations only work on the least significant 64-bit of each stack value. The most significant 192-bit is discarded. When a result value is pushed back onto the stack, then it MUST ensures that observable effects will see that the most significant 192-bit is zero. Note that here it's not necessary for an interpreter to reset the most significant 192-bit to zero every time -- if the next opcode is still in 64-bit mode, then the most significant 192-bit is still unobservable. We discuss the full details in the "rationale" section. The interpreter only needs to reproduce the full 256-bit value upon entering non-64-bit mode. If the full computational heavy part can be written in pure 64-bit mode, then this can result in noticeable performance gain.
+In 64-bit mode, all operations only work on the least significant 64-bit of each stack value. The most significant 192-bit is discarded. When a result value is pushed back onto the stack, then it MUST ensure that observable effects will see that the most significant 192-bit is zero. Note that here it's not necessary for an interpreter to reset the most significant 192-bit to zero every time -- if the next opcode is still in 64-bit mode, then the most significant 192-bit is still unobservable. We discuss the full details in the "rationale" section. The interpreter only needs to reproduce the full 256-bit value upon entering non-64-bit mode. If the full computational heavy part can be written in pure 64-bit mode, then this can result in noticeable performance gain.
 
 ### Gas cost constants
 
@@ -79,7 +79,7 @@ For flow operations JUMP and JUMPI, the behavior is as follows:
 
 When a smart contract uses the 64-bit mode, it's expected that once entered, it will want to stay in 64-bit mode, and only exit to non-64-bit mode when the computationally intensive function is finished. This EIP is designed particularly with this fact in mind.
 
-All 64-bit opcodes only operates on the 64-bit value. It totally discards the rest 192 bits. The interpreter only needs to ensure that when it exits into non-64-bit mode and next time when a value result is read, that value has the first 192 bits reset to zero. The EVM interpreter can therefore use a typed stack for optimization:
+All 64-bit opcodes only operate on the 64-bit value. It totally discards the rest 192 bits. The interpreter only needs to ensure that when it exits into non-64-bit mode and the next time a value result is read, that value has the first 192 bits reset to zero. The EVM interpreter can therefore use a typed stack for optimization:
 
 ```haskell
 type StackItem = Value U256 | Value64 U64
@@ -89,7 +89,7 @@ The typed stack can also be implemented as a bitmap for memory alignment.
 
 For all inputs of 64-bit opcodes, it will either read in a `Value`, when it'll only take the last 64 bits, or a `Value64`, which is what is needed. It then always outputs a `Value64`. After exiting into non-64-bit mode and upon a `Value64` is read, the interpreter then translate the value back to 256-bit `Value` by extending the first 192 bits with zero.
 
-The 64-bit mode does not contain any opcodes which depends on the value's endianness, therefore `Value64` can also be stored in the optimal endianness of the architecture.
+The 64-bit mode does not contain any opcodes which depend on the value's endianness, therefore `Value64` can also be stored in the optimal endianness of the architecture.
 
 The 64-bit mode will not save any memory usage.
 
@@ -101,11 +101,11 @@ This EIP also recommends that we reserve `C0`-`CF` for prefix (modes) opcodes. F
 
 #### Optimization assumptions
 
-This EIP assumes that the majority of EVM implementations target native little-endian 64-bit architectures (like `x86_64`, `arm64` and `riscv64`). A 256-bit stack item is stored efficiently internally as 4 items of 64-bit unsigned integer `[u64; 4]`. This EIP works best, in terms of optimizations, for those implementations. The opcodes simply operates on the last `u64`, instead of the whole `[u64; 4]`. There are basically no other changes.
+This EIP assumes that the majority of EVM implementations target native little-endian 64-bit architectures (like `x86_64`, `arm64` and `riscv64`). A 256-bit stack item is stored efficiently internally as 4 items of 64-bit unsigned integer `[u64; 4]`. This EIP works best, in terms of optimizations, for those implementations. The opcodes simply operate on the last `u64`, instead of the whole `[u64; 4]`. There are basically no other changes.
 
 #### Endianness
 
-In 64-bit mode, the principle of the specification is that the endianness should be kept strictly as an implementation detail. There should not be any opcodes that depends on endian. This is important, because on the one hand, we must enable easy and fast interop for 64-bit and non-64-bit opcodes. On the other hand, the interpreter should be able to do optimizations internally whether it uses little or big endian.
+In 64-bit mode, the principle of the specification is that the endianness should be kept strictly as an implementation detail. There should not be any opcodes that depend on endian. This is important, because on the one hand, we must enable easy and fast interop for 64-bit and non-64-bit opcodes. On the other hand, the interpreter should be able to do optimizations internally whether it uses little or big endian.
 
 Due to the issue of endianness, this EIP currently does not contain 64-bit mode `BYTE64`, memory opcodes `MLOAD64` and `MSTORE64`, and stack push opcodes `PUSH*64` (`PUSH1` to `PUSH8`).
 


### PR DESCRIPTION

Editorial clean-up of EIP-7937 to fix small grammar issues.

