### PR TITLE
Update EIP-7980: Fix broken relative license link in EIP-7980

### DIFF
--- a/EIPS/eip-7980.md
+++ b/EIPS/eip-7980.md
@@ -75,4 +75,4 @@ Needs discussion.
 
 ## Copyright
 
-Copyright and related rights waived via [CC0](../../LICENSE.md).
+Copyright and related rights waived via [CC0](../LICENSE.md).


### PR DESCRIPTION
Fixes a broken relative link to the license file in [EIPS/eip-7980.md](cci:7://file:///d:/friendly-project/EIPs/EIPS/eip-7980.md:0:0-0:0).

The file currently uses `../../LICENSE.md`, which incorrectly attempts to traverse two levels up from the `EIPS/` directory. Since `LICENSE.md` resides in the repository root and [eip-7980.md](cci:7://file:///d:/friendly-project/EIPs/EIPS/eip-7980.md:0:0-0:0) is directly inside `EIPS/`, the correct relative path is `../LICENSE.md`. 