### PR TITLE
Update EIP-8096: fix wording and grammar

### DIFF
--- a/EIPS/eip-8096.md
+++ b/EIPS/eip-8096.md
@@ -25,7 +25,7 @@ Upon activation of this EIP, the gas cost of calling the precompile at address `
 
 ## Rationale
 
-Benchmarking the `point evaluation` precompile revealed that its gas cost is significantly underestimated. This modification aim to ensure that the `point evaluation` precompile's performance no longer impedes potential increases to the block gas limit.
+Benchmarking the `point evaluation` precompile revealed that its gas cost is significantly underestimated. This modification aims to ensure that the `point evaluation` precompile's performance no longer impedes potential increases to the block gas limit.
 
 ## Backwards Compatibility
 


### PR DESCRIPTION

This PR makes small editorial improvements to EIP-8096 to clarify the text and fix minor grammatical issues.

- Corrected verb agreement and wording in the rationale (e.g. “modification aims to ensure…”).
