### PR TITLE
Update EIP-7867: Cleanup EIP-7867 boilerplate

### DIFF
--- a/EIPS/eip-7867.md
+++ b/EIPS/eip-7867.md
@@ -526,7 +526,7 @@ as if they requested `strict`. Even though the batches will work, the
 
   The current placeholder is acceptable for a draft.
 
-  TODO: Remove this comment before submitting
+
 -->
 
 TBD
@@ -541,7 +541,7 @@ TBD
 
   The current placeholder is acceptable for a draft.
 
-  TODO: Remove this comment before submitting
+
 -->
 
 No backward compatibility issues found.


### PR DESCRIPTION
Removes leftover template comments ("TODO: Remove this comment before submitting") from [eip-7867.md](cci:7://file:///d:/friendly-project/EIPs/EIPS/eip-7867.md:0:0-0:0).

These lines are explicit instructions to the author to remove them, serving as clear evidence that they are unintentional artifacts of the drafting process and should simply be deleted.