### PR TITLE
Update EIP-7778: clarify that user gas accounting remains unchanged

### DIFF
--- a/EIPS/eip-7778.md
+++ b/EIPS/eip-7778.md
@@ -30,12 +30,16 @@ This mechanism can be exploited to perform more operations in a block than the g
 
 ### Gas Accounting Changes
 
-1. **Block Gas Accounting (Modified):**
+1. **User Gas Accounting (Unchanged):**
+   - Users continue to receive gas refunds for operations that qualify (e.g., setting storage to zero)
+   - Transaction gas: `gas_spent = max(tx_gas_used - gas_refund, calldata_floor_gas_cost)`
+
+2. **Block Gas Accounting (Modified):**
    - When calculating gas for block gas limit enforcement, refunds are not subtracted
    - Block gas accounting becomes: `block.gas_used += max(tx_gas_used, calldata_floor_gas_cost)` (incorporating the calldata floor from [EIP-7623](./eip-7623.md))
    - Storage discounts that reflect actual reduced computational work (e.g., warm storage access, reverting to original values) remain applied to block gas accounting
 
-2. **Receipt Changes:**
+3. **Receipt Changes:**
    - `cumulative_gas_used`: Now uses gas before refunds, matching block gas accounting
    - New field `gas_spent`: Gas actually spent by the transaction after refunds (what the user pays)
 


### PR DESCRIPTION
Restore the user gas accounting section for clarity (removed in PR #11099).