### PR TITLE
Update EIP-712: fix assembly code

### DIFF
--- a/EIPS/eip-712.md
+++ b/EIPS/eip-712.md
@@ -304,7 +304,7 @@ function hashStruct(Mail memory mail) pure returns (bytes32 hash) {
     assembly {
         // Back up select memory
         let temp1 := mload(sub(mail, 32))
-        let temp2 := mload(add(mail, 128))
+        let temp2 := mload(add(mail, 64))
 
         // Write typeHash and sub-hashes
         mstore(sub(mail, 32), typeHash)


### PR DESCRIPTION
EIP-712 provides code for an efficient in-place implementation of `hashStruct` in Solidity.
This implementation is intended to read some locations in memory, overwrite them, and finally restore them to the original value.
What ends up happening, likely because of a typo, is that the output of this function is correct but the `Mail` struct isn't restored correctly and becomes corrupted in memory. Actually using this code in production would be a security risk.

Note that no change is needed to the EIP-712 assets since they don't include this in-place implementation.

<details><summary>Example test code</summary>

Instructions: using Foundry, run `forge init`, add the following file to the `tests/` directory, and run `forge test`.

```solidity
// SPDX-License-Identifier: UNLICENSED
pragma solidity ^0.8;

import {Test, stdError} from "forge-std/Test.sol";

contract Eip712 {
    struct Mail {
        address from;
        address to;
        string contents;
    }

    bytes32 constant EIP712DOMAIN_TYPEHASH =
        keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");

    bytes32 constant MAIL_TYPEHASH = keccak256("Mail(address from,address to,string contents)");

    function hashStruct(Mail memory mail) external pure returns (bytes32 hash) {
        return keccak256(abi.encode(MAIL_TYPEHASH, mail.from, mail.to, keccak256(bytes(mail.contents))));
    }

    function hashStructInPlaceUpdated(Mail memory mail) external pure returns (bytes32 hash, Mail memory mailOut) {
        // Compute sub-hashes
        bytes32 typeHash = MAIL_TYPEHASH;
        bytes32 contentsHash = keccak256(bytes(mail.contents));

        assembly {
            // Back up select memory
            let temp1 := mload(sub(mail, 32))
            let temp2 := mload(add(mail, 64))

            // Write typeHash and sub-hashes
            mstore(sub(mail, 32), typeHash)
            mstore(add(mail, 64), contentsHash)

            // Compute hash
            hash := keccak256(sub(mail, 32), 128)

            // Restore memory
            mstore(sub(mail, 32), temp1)
            mstore(add(mail, 64), temp2)
        }
        mailOut = mail;
    }

    function hashStructInPlaceFromEip(Mail memory mail) external pure returns (bytes32 hash, Mail memory mailOut) {
        // Compute sub-hashes
        bytes32 typeHash = MAIL_TYPEHASH;
        bytes32 contentsHash = keccak256(bytes(mail.contents));

        assembly {
            // Back up select memory
            let temp1 := mload(sub(mail, 32))
            let temp2 := mload(add(mail, 128))

            // Write typeHash and sub-hashes
            mstore(sub(mail, 32), typeHash)
            mstore(add(mail, 64), contentsHash)

            // Compute hash
            hash := keccak256(sub(mail, 32), 128)

            // Restore memory
            mstore(sub(mail, 32), temp1)
            mstore(add(mail, 64), temp2)
        }
        mailOut = mail;
    }
}

contract Eip712Test is Test {
    Eip712 public eip712;

    function setUp() public {
        eip712 = new Eip712();
    }

    function test_UpdateNoChange(Eip712.Mail memory mail) public view {
        (bytes32 hash, Eip712.Mail memory out) = eip712.hashStructInPlaceUpdated(mail);
        assertEq(hash, eip712.hashStruct(mail));
        assertEq(abi.encode(out), abi.encode(mail));
    }

    function test_StructChanges() public {
        Eip712.Mail memory mail = Eip712.Mail(address(1337), address(42), "c0ded");
        vm.expectRevert(new bytes(0));
        eip712.hashStructInPlaceFromEip(mail);
    }
}
```
</details>