### PR TITLE
Update EIP-7981: add access list cost to eip-7623 floor formula

### DIFF
--- a/EIPS/eip-7981.md
+++ b/EIPS/eip-7981.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2024-12-27
-requires: 2930, 7976
+requires: 2930, 7623
 ---
 
 ## Abstract
@@ -19,7 +19,7 @@ This EIP charges access lists for their data footprint, preventing the circumven
 
 Access lists are only priced for storage but not for their data.
 
-Furthermore, access lists can circumvent the [EIP-7976](./eip-7976.md) floor pricing by contributing to EVM gas while still leaving a non-negligible data footprint. This enables to achieve the maximal possible block size by combining access lists with calldata at a certain ratio.
+Furthermore, access lists can circumvent the [EIP-7623](./eip-7623.md) floor pricing by contributing to EVM gas while still leaving a non-negligible data footprint. This enables achieving the maximal possible block size by combining access lists with calldata at a certain ratio.
 
 ## Specification
 
@@ -27,66 +27,56 @@ Furthermore, access lists can circumvent the [EIP-7976](./eip-7976.md) floor pri
 | -------------------------------------- | ----- | ------ |
 | `ACCESS_LIST_ADDRESS_COST`            | `2400` | [EIP-2930](./eip-2930.md) |
 | `ACCESS_LIST_STORAGE_KEY_COST`        | `1900` | [EIP-2930](./eip-2930.md) |
-| `TOTAL_COST_FLOOR_PER_TOKEN`          | `15`   | [EIP-7976](./eip-7976.md) |
+| `TOTAL_COST_FLOOR_PER_TOKEN`          | `10`   | [EIP-7623](./eip-7623.md) |
 
 Let `access_list_nonzero_bytes` and `access_list_zero_bytes` be the count of non-zero and zero bytes respectively in the addresses (20 bytes each) and storage keys (32 bytes each) contained within the access list.
 
+Let `tokens_in_access_list = access_list_zero_bytes + access_list_nonzero_bytes * 4`.
 
-The current formula for access list costs in [EIP-2930](./eip-2930.md) is:
+The access list cost formula changes from [EIP-2930](./eip-2930.md) to include data cost:
 
 ```python
 access_list_cost = (
     ACCESS_LIST_ADDRESS_COST * access_list_addresses
     + ACCESS_LIST_STORAGE_KEY_COST * access_list_storage_keys
+    + TOTAL_COST_FLOOR_PER_TOKEN * tokens_in_access_list
 )
 ```
 
-The formula for access list costs changes to:
+The [EIP-7623](./eip-7623.md) floor calculation is modified to include access list tokens:
 
 ```python
-# Standard access list functionality cost
-standard_access_list_cost = (
-    ACCESS_LIST_ADDRESS_COST * access_list_addresses
-    + ACCESS_LIST_STORAGE_KEY_COST * access_list_storage_keys
-)
+tokens_in_calldata = zero_bytes_in_calldata + nonzero_bytes_in_calldata * 4
+total_data_tokens = tokens_in_calldata + tokens_in_access_list
 
-# Additional data cost for access list bytes
-access_list_tokens = access_list_nonzero_bytes * 4 + access_list_zero_bytes
-access_list_data_cost = access_list_tokens * TOTAL_COST_FLOOR_PER_TOKEN
-
-# Total access list cost
-access_list_cost = standard_access_list_cost + access_list_data_cost
+data_floor_gas_cost = TX_BASE_COST + TOTAL_COST_FLOOR_PER_TOKEN * total_data_tokens
 ```
 
-Transactions pay both the existing [EIP-2930](./eip-2930.md) functionality costs plus 60 gas per non-zero byte and 15 gas per zero byte counted across all addresses and storage keys in the access list.
+The gas used calculation becomes:
+
+```python
+tx.gasUsed = (
+    21000
+    +
+    max(
+        STANDARD_TOKEN_COST * tokens_in_calldata
+        + execution_gas_used
+        + isContractCreation * (32000 + INITCODE_WORD_COST * words(calldata))
+        + access_list_cost,
+        TOTAL_COST_FLOOR_PER_TOKEN * total_data_tokens
+    )
+)
+```
+
+Any transaction with a gas limit below `21000 + TOTAL_COST_FLOOR_PER_TOKEN * total_data_tokens` or below its intrinsic gas cost is considered invalid.
 
 ## Rationale
 
-Adding 60 gas per non-zero byte and 15 gas per zero byte ensures consistent pricing across all transaction data:
+Access list data is always charged at floor rate (added to `access_list_cost`), and access list tokens are included in the floor calculation. This ensures:
 
-- Address (20 bytes, typically mostly non-zero): ~3600 gas (2400 + 1200 assuming all non-zero)
-- Storage key (32 bytes, typically mostly non-zero): ~3820 gas (1900 + 1920 assuming all non-zero)
-
-No threshold mechanism is used. The per-byte costs are always applied to maintain simplicity and prevent circumvention.
-
-The additional cost makes [EIP-2930](./eip-2930.md) access lists economically irrational for gas optimization, effectively deprecating their use while maintaining compatibility.
-
-### Access List Size Impact
-
-At a gas limit of 60M:
-
-- 1 address + 31,578 storage keys: 2400 + (31,578 × 1900) = 59,998,200 gas (~1,012 KB)
-
-With data pricing (assuming all non-zero bytes):
-
-- 1 address + 15,705 storage keys: 3600 + (15,705 × 3820) = 59,996,700 gas (~491 KB)
-
-
-### Maximum Block Size Impact
-
-The maximum possible Snappy compressed block size can be achieved by using access lists and calldata together at a ratio where the transaction keeps paying the lower calldata price.
-
-At a gas limit of 60M, the maximum possible compressed block size will be reduced from 2.71 MiB to approximately 1.7 MiB.
+- Access list data always pays floor rate regardless of execution level
+- Access lists cannot be used to bypass the calldata floor pricing
+- Consistent pricing across all transaction data sources
 
 ## Backwards Compatibility
 
@@ -94,111 +84,71 @@ This is a backwards incompatible gas repricing that requires a scheduled network
 
 Requires updates to gas estimation in wallets and nodes. Normal usage patterns remain largely unaffected.
 
-## Test Cases
-
-### Case 1: Normal Transaction
-
-- Addresses: 5 (100 bytes, assume all non-zero)
-- Storage keys: 10 (320 bytes, assume all non-zero)
-- Old cost: 5 × 2400 + 10 × 1900 = 31,000 gas
-- New cost: 5 × 3600 + 10 × 3820 = 56,200 gas
-- Additional cost: 25,200 gas (81.3% increase)
-
-### Case 2: Large Access List Transaction
-
-- Addresses: 1000 (20,000 bytes, assume all non-zero)
-- Storage keys: 0
-- Old cost: 1000 × 2400 = 2,400,000 gas
-- New cost: 1000 × 3600 = 3,600,000 gas
-- Additional cost: 1,200,000 gas (50% increase)
-
-### Case 3: Combined Access List + Calldata
-
-- Addresses: 500 (10,000 bytes, assume all non-zero)
-- Calldata: 5,000 bytes
-- Old access list cost: 500 × 2400 = 1,200,000 gas
-- Old calldata cost: 5,000 × 4 = 20,000 gas (standard rate, avoiding floor)
-- New access list cost: 500 × 3600 = 1,800,000 gas
-- New calldata cost: Applied through [EIP-7976](./eip-7976.md) mechanism
-- Result: Can no longer circumvent [EIP-7976](./eip-7976.md) floor pricing
-
-
 ## Reference Implementation
 
-The following is the EELS (Ethereum Execution Layer Specification) implementation:
-
 ```python
-TX_ACCESS_LIST_NONZERO_BYTE_COST = Uint(60)
-TX_ACCESS_LIST_ZERO_BYTE_COST = Uint(15)
+def calculate_access_list_tokens(access_list: Tuple[Access, ...]) -> Uint:
+    """Count data tokens in access list addresses and storage keys."""
+    zero_bytes = Uint(0)
+    nonzero_bytes = Uint(0)
 
-def count_access_list_bytes(access_list: Tuple[Access, ...]) -> Tuple[int, int]:
-    """
-    Count zero and non-zero bytes in access list addresses and storage keys.
-    
-    Returns a tuple of (zero_bytes, nonzero_bytes).
-    """
-    zero_bytes = 0
-    nonzero_bytes = 0
-    
     for access in access_list:
-        # Count bytes in address (20 bytes)
         for byte in access.account:
             if byte == 0:
-                zero_bytes += 1
+                zero_bytes += Uint(1)
             else:
-                nonzero_bytes += 1
-        
-        # Count bytes in storage keys (32 bytes each)
+                nonzero_bytes += Uint(1)
         for slot in access.slots:
             for byte in slot:
                 if byte == 0:
-                    zero_bytes += 1
+                    zero_bytes += Uint(1)
                 else:
-                    nonzero_bytes += 1
-    
-    return zero_bytes, nonzero_bytes
+                    nonzero_bytes += Uint(1)
+
+    return zero_bytes + nonzero_bytes * Uint(4)
+
 
 def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     """
-    Calculates the gas that is charged before execution is started.
+    Calculate intrinsic gas cost and floor gas cost.
+    Returns (intrinsic_gas, floor_gas).
     """
-    # ... existing calldata and base cost calculations ...
-    
+    # Calldata tokens
+    calldata_zero_bytes = Uint(0)
+    for byte in tx.data:
+        if byte == 0:
+            calldata_zero_bytes += Uint(1)
+    tokens_in_calldata = (
+        calldata_zero_bytes + (ulen(tx.data) - calldata_zero_bytes) * Uint(4)
+    )
+
+    # Access list tokens and cost
+    tokens_in_access_list = Uint(0)
     access_list_cost = Uint(0)
-    access_list_data_cost = Uint(0)
-    
-    if isinstance(tx, (AccessListTransaction, FeeMarketTransaction, 
-                      BlobTransaction, SetCodeTransaction)):
-        # Standard EIP-2930 access list functionality costs
+    if has_access_list(tx):
+        tokens_in_access_list = calculate_access_list_tokens(tx.access_list)
         for access in tx.access_list:
             access_list_cost += TX_ACCESS_LIST_ADDRESS_COST
-            access_list_cost += (
-                ulen(access.slots) * TX_ACCESS_LIST_STORAGE_KEY_COST
-            )
-        
-        # EIP-7981: Additional data cost for access list bytes
-        zero_bytes, nonzero_bytes = count_access_list_bytes(tx.access_list)
-        access_list_data_cost = (
-            Uint(zero_bytes) * TX_ACCESS_LIST_ZERO_BYTE_COST +
-            Uint(nonzero_bytes) * TX_ACCESS_LIST_NONZERO_BYTE_COST
-        )
-    
-    return (
-        Uint(
-            TX_BASE_COST
-            + data_cost
-            + create_cost
-            + access_list_cost
-            + access_list_data_cost  # Added by EIP-7981
-            + auth_cost
-        ),
-        calldata_floor_gas_cost,
-    )
+            access_list_cost += ulen(access.slots) * TX_ACCESS_LIST_STORAGE_KEY_COST
+        # EIP-7981: Always charge data cost
+        access_list_cost += tokens_in_access_list * TOTAL_COST_FLOOR_PER_TOKEN
+
+    # EIP-7981: Floor includes all data tokens
+    total_data_tokens = tokens_in_calldata + tokens_in_access_list
+    floor_gas = TX_BASE_COST + total_data_tokens * TOTAL_COST_FLOOR_PER_TOKEN
+
+    # Intrinsic gas
+    calldata_cost = tokens_in_calldata * STANDARD_TOKEN_COST
+    create_cost = TX_CREATE_COST + init_code_cost(tx.data) if is_create(tx) else Uint(0)
+
+    intrinsic_gas = TX_BASE_COST + calldata_cost + create_cost + access_list_cost
+
+    return intrinsic_gas, floor_gas
 ```
 
 ## Security Considerations
 
-Reduces maximum block size from access lists, improving network stability. The additional cost is proportional to data usage while maintaining access list utility for backwards compatibility.
+This EIP closes a loophole that allows circumventing [EIP-7623](./eip-7623.md) floor pricing. Without this fix, attackers can achieve larger blocks than intended by combining access lists with calldata. All transaction data sources now contribute to the floor calculation consistently.
 
 ## Copyright
 


### PR DESCRIPTION
Add access list data cost to intrinsic gas and include access list tokens in floor calculation to prevent bypass of EIP-7623 calldata floor pricing.