### PR TITLE
Config: remove deprecated 'event' field from citation schema

### DIFF
--- a/config/eipw.toml
+++ b/config/eipw.toml
@@ -484,10 +484,6 @@ additional_schemas = [[
       \"edition\": {
         \"type\": [\"string\", \"number\"]
       },
-      \"event\": {
-        \"description\": \"[Deprecated - use 'event-title' instead. Will be removed in 1.1]\",
-        \"type\": \"string\"
-      },
       \"event-title\": {
         \"type\": \"string\"
       },


### PR DESCRIPTION
Removes the deprecated `"event"` field from the citation schema in `config/eipw.toml`.