### PR TITLE
Update EIP-8061: correct get_exit_churn_limit docstring

### DIFF
--- a/EIPS/eip-8061.md
+++ b/EIPS/eip-8061.md
@@ -62,7 +62,7 @@ def get_activation_churn_limit(state: BeaconState) -> Gwei:
 
 def get_exit_churn_limit(state: BeaconState) -> Gwei:
     """
-    Per-epoch churn limit for activations, rounded to EFFECTIVE_BALANCE_INCREMENT.
+    Per-epoch churn limit for exits, rounded to EFFECTIVE_BALANCE_INCREMENT.
     """
     churn = max(
         MIN_PER_EPOCH_CHURN_LIMIT_ELECTRA,


### PR DESCRIPTION
The `get_exit_churn_limit` helper had a copy-pasted docstring that incorrectly described it as the per-epoch churn limit for activations, which contradicts both the function name and its usage for exits.
Updated the docstring of `get_exit_churn_limit` to state that it returns the per-epoch churn limit for exits, keeping the rest of the function logic intact.