### PR TITLE
Update EIP-7928: move BAL into response engine_getPayloadBodiesV2

### DIFF
--- a/EIPS/eip-7928.md
+++ b/EIPS/eip-7928.md
@@ -233,10 +233,12 @@ When processing a block:
 
 The execution layer provides the RLP-encoded `blockAccessList` to the consensus layer via the Engine API. The consensus layer then computes the SSZ `hash_tree_root` for storage in the `ExecutionPayload`.
 
-**Retrieval methods** for historical BALs (similar to `engine_getPayloadBodiesByHashV1`):
+**Retrieval methods** for historical BALs:
 
-- `engine_getBALsByHashV1`: Array of block hashes → Array of RLP-encoded BALs
-- `engine_getBALsByRangeV1`: Start block number, count → Array of RLP-encoded BALs
+- `engine_getPayloadBodiesByHashV2`: Returns `ExecutionPayloadBodyV2` objects containing transactions, withdrawals, and `blockAccessList`
+- `engine_getPayloadBodiesByRangeV2`: Returns `ExecutionPayloadBodyV2` objects containing transactions, withdrawals, and `blockAccessList`
+
+The `blockAccessList` field contains the RLP-encoded BAL or `null` for pre-Amsterdam blocks or when data has been pruned.
 
 The EL MUST retain BALs for at least the duration of the weak subjectivity period (`=3533 epochs`) to support synchronization with re-execution after being offline for less than the WSP.
 


### PR DESCRIPTION
This PR puts the BAL back into the PayloadBody; related discussion at https://github.com/ethereum/execution-apis/pull/727