### PR TITLE
Update EIP-7607: Move to Final

### DIFF
--- a/EIPS/eip-7607.md
+++ b/EIPS/eip-7607.md
@@ -4,8 +4,7 @@ title: Hardfork Meta - Fusaka
 description: EIPs included in the Fulu/Osaka Ethereum network upgrade.
 author: Tim Beiko (@timbeiko), Alex Stokes (@ralexstokes), Ansgar Dietrichs (@adietrichs)
 discussions-to: https://ethereum-magicians.org/t/eip-7607-fusaka-meta-eip/18439
-status: Last Call
-last-call-deadline: 2025-10-28
+status: Final
 type: Meta
 created: 2024-02-01
 requires: 7600, 7723


### PR DESCRIPTION
Fusaka upgrade activated on mainnet December 3, last call period ended October 28.