### PR TITLE
Update EIP-1571: Fix spelling and grammar errors

### DIFF
--- a/EIPS/eip-1571.md
+++ b/EIPS/eip-1571.md
@@ -16,16 +16,16 @@ This draft contains the guidelines to define a new standard for the Stratum prot
 ### Conventions
 
 The key words `MUST`, `MUST NOT`, `REQUIRED`, `SHALL`, `SHALL NOT`, `SHOULD`, `SHOULD NOT`, `RECOMMENDED`, `MAY`, and `OPTIONAL` in this document are to be interpreted as described in [RFC 2119](https://tools.ietf.org/html/rfc2119).
-The definition `mining pool server`, and it's plural form, is to be interpreted as `work provider` and later in this document can be shortened as `pool` or `server`.
-The definition `miner(s)`, and it's plural form, is to be interpreted as `work receiver/processor` and later in this document can be shortened as `miner` or `client`.
+The definition `mining pool server`, and its plural form, is to be interpreted as `work provider` and later in this document can be shortened as `pool` or `server`.
+The definition `miner(s)`, and its plural form, is to be interpreted as `work receiver/processor` and later in this document can be shortened as `miner` or `client`.
 
 ### Rationale
 
-Ethereum does not have an official Stratum implementation yet. It officially supports only getWork which requires miners to constantly pool the work provider. Only recently go-ethereum have implemented a [push mechanism](https://github.com/ethereum/go-ethereum/pull/17347) to notify clients for mining work, but whereas the vast majority of miners do not run a node, it's main purpose is to facilitate mining pools rather than miners.
+Ethereum does not have an official Stratum implementation yet. It officially supports only getWork which requires miners to constantly pool the work provider. Only recently go-ethereum have implemented a [push mechanism](https://github.com/ethereum/go-ethereum/pull/17347) to notify clients for mining work, but whereas the vast majority of miners do not run a node, its main purpose is to facilitate mining pools rather than miners.
 The Stratum protocol on the other hand relies on a standard stateful TCP connection which allows two-way exchange of line-based messages. Each line contains the string representation of a JSON object following the rules of either [JSON-RPC 1.0](https://www.jsonrpc.org/specification_v1) or [JSON-RPC 2.0](https://www.jsonrpc.org/specification).
-Unfortunately, in absence of a well defined standard, various flavours of Stratum have bloomed for Ethereum mining as a derivative work for different mining pools implementations. The only attempt to define a standard was made by NiceHash with their [EthereumStratum/1.0.0](https://github.com/nicehash/Specifications/blob/master/EthereumStratum_NiceHash_v1.0.0.txt) implementation which is the main source this work inspires from.
-Mining activity, thus the interaction among pools and miners, is at it's basics very simple, and can be summarized with "_please find a number (nonce) which coupled to this data as input for a given hashing algorithm produces, as output, a result which is below a certain target_". Other messages which may or have to be exchanged among parties during a session are needed to support this basic concept.
-Due to the simplicity of the subject, the proponent, means to stick with JSON formatted objects rather than investigating more verbose solutions, like for example  [Google's Protocol Buffers](https://developers.google.com/protocol-buffers/docs/overview) which carry the load of strict object definition.
+Unfortunately, in the absence of a well defined standard, various flavours of Stratum have bloomed for Ethereum mining as a derivative work for different mining pools implementations. The only attempt to define a standard was made by NiceHash with their [EthereumStratum/1.0.0](https://github.com/nicehash/Specifications/blob/master/EthereumStratum_NiceHash_v1.0.0.txt) implementation which is the main source this work inspires from.
+Mining activity, thus the interaction among pools and miners, is at its basics very simple, and can be summarized with "_please find a number (nonce) which coupled to this data as input for a given hashing algorithm produces, as output, a result which is below a certain target_". Other messages which may or have to be exchanged among parties during a session are needed to support this basic concept.
+Due to the simplicity of the subject, the proponent means to stick with JSON formatted objects rather than investigating more verbose solutions, like for example  [Google's Protocol Buffers](https://developers.google.com/protocol-buffers/docs/overview) which carry the load of strict object definition.
 
 ### Stratum design flaws
 
@@ -65,8 +65,8 @@ In order to get the most concise messages among parties of a session/conversatio
 
 ## Conventions
 
-- The representation of a JSON object is, at it's base, a string 
-- The conversation among the client and the server is made of strings. Each string ending with a LF (ASCII char 10) denotes a `line`. Each line **MUST** contain only one JSON root object. Eventually the root object **MAY** contain additional JSON objects in it's members.
+- The representation of a JSON object is, at its base, a string 
+- The conversation among the client and the server is made of strings. Each string ending with a LF (ASCII char 10) denotes a `line`. Each line **MUST** contain only one JSON root object. Eventually the root object **MAY** contain additional JSON objects in its members.
 - Aside the `LF` delimiter each `line` **MUST** be made of printable ASCII chars in the range 32..126
 - It's implicit and mandatory that each line message corresponds to a well formatted JSON object: see [JSON documentation](https://www.json.org/)
 - JSON objects are made of `members` which can be of type : primitive of string/number, JSON object, JSON arrays
@@ -77,7 +77,7 @@ In order to get the most concise messages among parties of a session/conversatio
 - JSON values `strings` : any string value **MUST** be composed of printable ASCII chars only in the ASCII range 32..126. Each string is delimited by a `"` (ASCII 34) at the beginning and at the end. Should the string value contain a `"` this must be escaped as `\"`
 - Hex values : a Hexadecimal representation of a number is actually a string data type. As a convention, and to reduce the number of transmitted bytes, the prefix "0x" **MUST** always be omitted. In addition any hex number **MUST** be transferred only for their significant part i.e. the non significant zeroes **MUST** be omitted (example : the decimal `456` must be represented as `"1c8"` and not as `"01c8"` although the conversion produces the same decimal value). This directive **DOES NOT APPLY** to hashes and extranonces
 - Hex values casing : all letters in Hexadecimal values **MUST** be lower case. (example : the decimal `456` must be represented as `"1c8"` and not as `"1C8"` although the conversion produces the same decimal value). This directive **DOES NOT APPLY** to hashes.
-- Numbers : any non-fractional number **MUST** be transferred by it's hexadecimal representation
+- Numbers : any non-fractional number **MUST** be transferred by its hexadecimal representation
 
 ### Requests
 
@@ -92,7 +92,7 @@ The JSON representation of `request` object is made of these parts:
 The JSON representation of `response` object is made of these parts:
 
 - mandatory `id` member of type Integer : the identifier of the request this response corresponds to
-- optional `error` member : whether an error occurred during the parsing of the method or during it's execution this member **MUST** be present and valued. If no errors occurred this member **MUST NOT** be present. For a detailed structure of the `error` member see below.
+- optional `error` member : whether an error occurred during the parsing of the method or during its execution this member **MUST** be present and valued. If no errors occurred this member **MUST NOT** be present. For a detailed structure of the `error` member see below.
 - optional `result` member : This has to be set, if the corresponding request requires a result from the user. If no errors occurred by invoking the corresponding function, this member **MUST** be present even if one or more information are null. The type can be of Object or single type Array or Primitive string/number. If no data is meant back for the issuer (the method is void on the receiver) or an error occurred this member **MUST NOT** be present.
 
 You'll notice here some differences with standard JSON-RPC-2.0. Namely the result member is not always required. Basically a response like this:
@@ -114,7 +114,7 @@ This response syntax leaves room to many interpretations: is it an error? is `fa
 For this reason responses, we reiterate, **MUST BE** of two types:
 
 - success responses : no error occurred during the processing, the request was legit, syntactically correct, and the receiver had no issues processing it. This kind of responses **MUST NOT** have the `error` member and **MAY** have the `result` member if a value is expected back to the issuer.
-- failure responses : something wrong with the request, it's syntax, it's validity scope, or server processing problems. This kind of responses **MUST HAVE** the `error` member and **MAY** have the `result` member.
+- failure responses : something wrong with the request, its syntax, its validity scope, or server processing problems. This kind of responses **MUST HAVE** the `error` member and **MAY** have the `result` member.
 
 The latter deserves a better explanation: failure responses can be distinguished by a severity degree. 
 Example 1 : a client submits a solution and server rejects it cause it's not below target. Server **MUST** respond like this; 
@@ -181,7 +181,7 @@ As seen above a `response` **MAY** contain an `error` member. When present this 
 - Client advertises and request protocol compatibility
 - Server confirms compatibility and declares ready
 - Client starts/resumes a session
-- Client sends request for authorization for each of it's workers
+- Client sends request for authorization for each of its workers
 - Server replies back with responses for each authorization
 - Server sends `mining.set` for constant values to be adopted for following mining jobs
 - Server sends `mining.notify` with minimal job info
@@ -253,7 +253,7 @@ Where the `result` is an object made of 5 mandatory members
 When the server replies back with `"encoding" : "gzip"` to the client, both parties **MUST** gzip compress all next messages. In case the client is not capable of compression it **MUST** close the connection immediately.
 Should the server, after this reply, receive other messages as plain text, it **MUST** close the connection.
 
-Eventually the client will continue with `mining.subscribe` (further on descripted)
+Eventually the client will continue with `mining.subscribe` (further described)
 
 Otherwise, in case of errors or rejection to start the conversation, the server **MAY** reply back with an error giving the other party useful information or, at server's maintainers discretion, abruptly close the connection.
 
@@ -296,7 +296,7 @@ Disconnection are not gracefully handled in Stratum. Client disconnections from 
 }
 ```
 
-The party receiving this message aknowledges the other party wants to stop the conversation and closes the socket. The issuer will close too. The explicit issuance of this notification implies the session gets abandoned so no session resuming will be possible even on server which support session-resuming. Client reconnecting to the same server which implements session resuming **SHOULD** expect a new session id and **MUST** re-authorize all their workers.
+The party receiving this message acknowledges the other party wants to stop the conversation and closes the socket. The issuer will close too. The explicit issuance of this notification implies the session gets abandoned so no session resuming will be possible even on servers which support session-resuming. Client reconnecting to the same server which implements session resuming **SHOULD** expect a new session id and **MUST** re-authorize all their workers.
 
 ### Session Handling - Session Subscription
 
@@ -335,8 +335,8 @@ A server receiving a client session subscription **MUST** reply back with
 A server receiving a subscription request with `params` being a string holding the session id. This cases may apply
 
 - If session resuming is not supported `result` will hold a new session Id which **MUST** be a different value from the `session` member issued by client in previous `mining.subscribe` method 
-- If session resuming is supported it will retrieve working values from cache and `result` will have the same id requested by the client. This means a session is "resumed": as a consequence the server **CAN** start pushing jobs omitting to precede them with `mining.set` (see below) and the client **MUST** continue to use values lastly received within the same session scope. In addition the client **CAN** omit to re-authorize all it's workers.
-- If session resuming is supported but the requested session has expired or it's cache values have been purged `result` will hold a new session Id which **MUST** be a different value from the `session` member issued by client in previous `mining.subscribe` method. As a consequence the server **MUST** wait for client to request authorization for it's workers and **MUST** send `mining.set` values before pushing jobs. The client **MUST** prepare for a new session discarding all previously cached values (if any).
+- If session resuming is supported it will retrieve working values from cache and `result` will have the same id requested by the client. This means a session is "resumed": as a consequence the server **CAN** start pushing jobs omitting to precede them with `mining.set` (see below) and the client **MUST** continue to use values lastly received within the same session scope. In addition the client **CAN** omit to re-authorize all its workers.
+- If session resuming is supported but the requested session has expired or its cache values have been purged `result` will hold a new session Id which **MUST** be a different value from the `session` member issued by client in previous `mining.subscribe` method. As a consequence the server **MUST** wait for client to request authorization for its workers and **MUST** send `mining.set` values before pushing jobs. The client **MUST** prepare for a new session discarding all previously cached values (if any).
 
 A server implementing session-resuming **MUST** cache:
 
@@ -345,9 +345,9 @@ A server implementing session-resuming **MUST** cache:
 - The extraNonce
 - Any authorized worker
 
-Servers **MAY** drop entries from the cache on their own schedule. It's up to server to enforce session validation for same agent and/or ip.
+Servers **MAY** drop entries from the cache on their own schedule. It's up to the server to enforce session validation for same agent and/or ip.
 
-A client which successfully subscribes and resumes session (the `session` value in server response is identical to `session` value requested by client on `mining.subscribe`) **CAN** omit to issue the authorization request for it's workers.
+A client which successfully subscribes and resumes session (the `session` value in server response is identical to `session` value requested by client on `mining.subscribe`) **CAN** omit to issue the authorization request for its workers.
 
 ### Session Handling - Noop
 
@@ -407,7 +407,7 @@ The server **MUST** reply back either with an error or, in case of success, with
 
 Where the `result` member is a string which holds an unique - within the scope of the `session` - token which identifies the authorized worker. For every further request issued by the client, and related to a Worker action, the client **MUST** use the token given by the server in response to an `mining.authorize` request. This reduces the number of bytes transferred for solution and /or hashrate submission.
 
-If client is resuming a previous session it **CAN** omit the authorization request for it's workers and, in this case, **MUST** use the tokens assigned in the originating session. It's up to the server to keep the correct map between tokens and workers.
+If client is resuming a previous session it **CAN** omit the authorization request for its workers and, in this case, **MUST** use the tokens assigned in the originating session. It's up to the server to keep the correct map between tokens and workers.
 The server receiving an authorization request where the credentials match previously authorized ones within the same session **MUST** reply back with the previously generated unique token.
 
 ### Prepare for mining
@@ -437,12 +437,12 @@ At the beginning of each `session` the server **MUST** send this notification be
 Whenever the server detects that one, or two, or three or four values change within the session, the server will issue a notification with one, or two or three or four members in the `param` object. For this reason on each **new** session the server **MUST** pass all four members. As a consequence the miner is instructed to adapt those values on **next** job which gets notified.
 The new `algo` member is defined to be prepared for possible presence of algorithm variants to ethash, namely ethash1a or ProgPow.
 Pools providing multicoin switching will take care to send a new `mining.set` to miners before pushing any job after a switch.
-The client which can't support the data provided in the `mining.set` notification **MAY** close connection or stay idle till new values satisfy it's configuration (see `mining.noop`).
+The client which can't support the data provided in the `mining.set` notification **MAY** close connection or stay idle till new values satisfy its configuration (see `mining.noop`).
 All client's implementations **MUST** be prepared to accept new extranonces during the session: unlike in EthereumStratum/1.0.0 the optional client advertisement `mining.extranonce.subscribe` is now implicit and mandatory.
 
 The miner receiving the `extranonce` **MUST** initialize the search segment for next job resizing the extranonce to a hex of 16 bytes thus appending as many zeroes as needed.
 Extranonce "af4c" means "_search segment of next jobs starts from 0xaf4c000000000000_"
-If `extranonce` is valued to an empty string, or it's never been set within the session scope, the client is free pick any starting point of it's own search segment on subsequent `mining.notify` jobs.
+If `extranonce` is valued to an empty string, or it's never been set within the session scope, the client is free to pick any starting point of its own search segment on subsequent `mining.notify` jobs.
 
 ### A detail of "extranonce"
 
@@ -471,8 +471,8 @@ Giving the above assumptions we can depict a nonce as any number in the hex rang
 
 _the prefix 0x is voluntarily inserted here only to give a better visual representation_.
 
-The `extranonce` is, at it's basics, the message of the server saying the client "_I give you the first number to start search from_". More in detail the `extranonce` is the leftmost part of that number.
-Assume a pool notifies the client the usage of extranonce `ab5d` this means the client will see it's search segment narrowed as
+The `extranonce` is, at its basics, the message of the server saying the client "_I give you the first number to start search from_". In more detail the `extranonce` is the leftmost part of that number.
+Assume a pool notifies the client the usage of extranonce `ab5d` this means the client will see its search segment narrowed as
  
 ```
   Min 0xab5d000000000000
@@ -574,7 +574,7 @@ Most pools offer statistic information, in form of graphs or by API calls, about
 In this document we propose an official implementation of the `mining.hashrate` request.
 This method behaves differently when issued from client or from server.
 
-#### Client communicates it's hashrate to server.
+#### Client communicates its hashrate to server.
 
 ```json
 {
@@ -587,14 +587,14 @@ This method behaves differently when issued from client or from server.
 }
 ```
 
-where `params` is an array made of two elements: the first is a hexadecimal string representation (32 bytes) of the hashrate the miner reads on it's devices and the latter is the authorization token issued to worker this hashrate is refers to (see above for `mining.authorization`).
-Server **MUST** respond back with either an aknowledgment message
+where `params` is an array made of two elements: the first is a hexadecimal string representation (32 bytes) of the hashrate the miner reads on its devices and the latter is the authorization token issued to worker this hashrate refers to (see above for `mining.authorization`).
+Server **MUST** respond back with either an acknowledgment message
 
 ```json
 {"id": 16 }
 ```
 
-Optionally the server can reply back reporting it's findings about calculated hashrate **for the same worker**.
+Optionally the server can reply back reporting its findings about calculated hashrate **for the same worker**.
 
 ```json
 {
@@ -620,7 +620,7 @@ In case of errors - for example when the client submits too frequently - with
 
 #### Server communicates hashrate to client
 
-Optionally the server can **notify** client about it's overall performance (according to schedule set on server) with a `mining.hashrate` notification composed like this
+Optionally the server can **notify** client about its overall performance (according to schedule set on server) with a `mining.hashrate` notification composed like this
 
 ```json
 {
@@ -641,7 +641,7 @@ Where `params` is an object which holds these members for values of the **whole 
 - `accepted` is an array of two number elements : the first is the overall count of accepted shares and the second is the number of stale shares. The array must be interpreted as "total accepted of which x are stale"
 - `rejected` (number) the overall number of rejected shares
 
-The client will eventually take internal actions to reset/restart it's workers.
+The client will eventually take internal actions to reset/restart its workers.
 
 ## Copyright
 


### PR DESCRIPTION


- Fixed spelling: `aknowledges` → `acknowledges`
- Fixed spelling: `aknowledgment` → `acknowledgment`
- Fixed grammar: `further on descripted` → `further described`
- Fixed grammar: `this hashrate is refers to` → `this hashrate refers to`
- Fixed grammar: `even on server which support` → `even on servers which support`
- Fixed punctuation: removed unnecessary comma in `the proponent, means` → `the proponent means`

