### PR TITLE
Update EIP-8007: Update EIP-8007 requires header

### DIFF
--- a/EIPS/eip-8007.md
+++ b/EIPS/eip-8007.md
@@ -7,7 +7,7 @@ discussions-to: https://ethereum-magicians.org/t/eip-8007-glamsterdam-gas-repric
 status: Draft
 type: Meta
 created: 2025-08-21
-requires: 2780, 2926, 7778, 7904, 7923, 7971, 7976, 7981, 8011, 8032, 8037, 8038, 8053, 8057, 8058, 8059
+requires: 2780, 2926, 7686, 7778, 7904, 7923, 7971, 7973, 7976, 7981, 8011, 8032, 8037, 8038, 8053, 8057, 8058, 8059
 ---
 
 ## Abstract


### PR DESCRIPTION
Adds missing EIPs to the `requires` header in EIP-8007.
EIP-7686 and EIP-7973 are explicitly listed in the EIP list table but were missing from the YAML header. 