### PR TITLE
Update EIP-8081: Fix grammar in Abstract

### DIFF
--- a/EIPS/eip-8081.md
+++ b/EIPS/eip-8081.md
@@ -12,7 +12,7 @@ requires: 7723, 7773
 
 ## Abstract
 
-This Meta EIP lists the EIPs formally Proposed, Considered, Declined for & Scheduled for Inclusion in the Hegotá network upgrade.
+This Meta EIP lists the EIPs formally Proposed, Considered, Declined, and Scheduled for Inclusion in the Hegotá network upgrade.
 
 ## Specification
 


### PR DESCRIPTION
Fixes grammatical error in Abstract section, replaces incorrect "Declined for &" with proper list format "Declined, and" .