### PR TITLE
refactor(eip-6110): Remove unused MAX_DEPOSITS import

### DIFF
--- a/assets/eip-6110/eth2_ws_calc.py
+++ b/assets/eip-6110/eth2_ws_calc.py
@@ -5,7 +5,6 @@ This script calculates the Eth2 Weak Subjectivity period as defined by eth2.0-sp
 from eth2spec.phase0.mainnet import (
     uint64, Ether,
     ETH_TO_GWEI, 
-    MAX_DEPOSITS, 
     MAX_EFFECTIVE_BALANCE,  
     SLOTS_PER_EPOCH, 
     config, 


### PR DESCRIPTION
Removes unused `MAX_DEPOSITS` import from `eth2_ws_calc.py`.