### PR TITLE
chore: remove dead `include` directive from Jekyll config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -63,11 +63,6 @@ exclude:
   - vendor/gems/
   - vendor/ruby/
   - eip-template.md
-  - ISSUE_TEMPLATE.md
-  - PULL_REQUEST_TEMPLATE.md
   - README.md
-  
-include:
-  - LICENSE
 
 markdown_ext: "markdown,mkdown,mkdn,mkd,md"


### PR DESCRIPTION
Removes redundant `include` section from `_config.yml` that references non-existent or already-excluded files.