### PR TITLE
Update EIP-8037: Update EIP-8037 requires header

### DIFF
--- a/EIPS/eip-8037.md
+++ b/EIPS/eip-8037.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2025-10-01
-requires: 2780
+requires: 2780, 7702, 7825, 8011
 ---
 
 ## Abstract


### PR DESCRIPTION
Adds EIP-7702, EIP-7825, and EIP-8011 to the requires header, as they are directly modified or used in the specification.