### PR TITLE
Update EIP-8030: Add EIP-7951 to requires header

### DIFF
--- a/EIPS/eip-8030.md
+++ b/EIPS/eip-8030.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2025-09-20
-requires: 7932
+requires: 7932, 7951
 ---
 
 ## Abstract


### PR DESCRIPTION
Adds EIP-7951 to the requires header, as the P256Verify function logic from EIP-7951 is directly used in the specification.