### PR TITLE
Update EIP-8077: Fix grammar and spelling errors

### DIFF
--- a/EIPS/eip-8077.md
+++ b/EIPS/eip-8077.md
@@ -17,12 +17,12 @@ This EIP improves mempool propagation, extending the devp2p 'eth' protocol's `Ne
 
 ## Motivation
 
-Transactions are propagated in the Mempool using the devp2p protocol in two modalities. Eager push is only used for small transactions, and only towards a few nodes, while the rest of nodes receive only announcements. For large transactions and for type 3 transactions, only announcements are sent. This announcement is made using the `NewPooledTransactionHashes` message, which only contains the hash, the type and the size of each transaction. As it is now, the receiver of the announcement does not have enough information to make intelligent scheduling choices. This crates several issues:
+Transactions are propagated in the Mempool using the devp2p protocol in two modalities. Eager push is only used for small transactions, and only towards a few nodes, while the rest of nodes receive only announcements. For large transactions and for type 3 transactions, only announcements are sent. This announcement is made using the `NewPooledTransactionHashes` message, which only contains the hash, the type and the size of each transaction. As it is now, the receiver of the announcement does not have enough information to make intelligent scheduling choices. This creates several issues:
 
 - the receiver of the announcement can only base its logic on the order of announcements, but if it schedules requests to different peers, it can easily end up pulling transactions that leave a nonce gap in it's own view of the mempool, making the pulled transaction non-includable,
 - filling existing gaps is hard, since in the absence of sender/nonce information it can only be done with trial and error, requesting more transactions of missing hashes,
 - to filter out old transaction announcements, the node has to keep a cache of all transaction hashes on chain, instead of simply checking the nonce against current chain state,
-- receivers have no way to selectively request transactions with specific source addresses, which would be important UX and L2s. 
+- receivers have no way to selectively request transactions with specific source addresses, which would be important for UX and L2s. 
 
 Moreover, as we are increasing the throughput of block building, it is more and more probable that we end up in a state where nodes can't fetch all transactions. This extension allows nodes to do selective fetching and gap filling while keeping a consistent state of their own view of the mempool without nonce gaps.
 
@@ -44,22 +44,22 @@ At the receiver side of `NewPooledTransactionHashes` messages the extra informat
 
 ## Rationale
 
-To solve the transaction propagation issues mentioned in the Motivation section, nodes require more information about a transaction then its hash, size, and type. By adding the source and the nonce, the receiver has enough information to make better fetch decisions.
+To solve the transaction propagation issues mentioned in the Motivation section, nodes require more information about a transaction than its hash, size, and type. By adding the source and the nonce, the receiver has enough information to make better fetch decisions.
 
 ### Overhead
 
-The modification adds a significant overhead to announcements by adding a B_20 and a variable size filed to the current B_32, size, and type fields. We think this overhead is worth
+The modification adds a significant overhead to announcements by adding a B_20 and a variable size field to the current B_32, size, and type fields. We think this overhead is worth
 the additional gain in protocol efficiency. Details TBD <-- TODO --> .
 
 ### Alternatives
 
 While the modification is relatively straightforward, there are several design variants to
-consider. First of all, small transactions are mostly propagating by the push mechanism, while
+consider. First of all, small transactions are mostly propagated by the push mechanism, while
 announcement based pull is only used as recovery. We could choose to avoid the extra announcement overhead for these, however it would mean that filling nonce gaps remains difficult, only possible by trial-and-error.
 
 Another possibility similar to the previous one is to restrict the mechanism to blob transactions only. We choose not to restrict it in the proposal for the same reasons as in the previous point.
 
-If the traffic overhead from notifications is a concern, it is also worth considering how many nodes should announcements be sent to. While this is not mandated by the protocol, a typical implementation is to send announcements to all neighbors (except the ones that already signaled having it, and the ones to which the message is pushed). Should nodes send announcements to all peers, or only part of their peer set (e.g. proportional, or to a fixed number of peers)? The protocol allows to only part, and in case of bandwidth constraints it seems better to send more metadata (addresses and nonces) to fewer peers.
+If the traffic overhead from notifications is a concern, it is also worth considering how many nodes should announcements be sent to. While this is not mandated by the protocol, a typical implementation is to send announcements to all neighbors (except the ones that already signaled having it, and the ones to which the message is pushed). Should nodes send announcements to all peers, or only part of their peer set (e.g. proportional, or to a fixed number of peers)? The protocol allows sending to only part, and in case of bandwidth constraints it seems better to send more metadata (addresses and nonces) to fewer peers.
 
 Currently, for any given transaction, nodes receive announcements from many peers. About half of their peers, on average. Having the whole metadata (txhash, type, size, source, nonce) in all these is highly redundant. We could remove some of this overhead, e.g. by having a probabilistic choice between a simple announcement and a detailed announcement. The gain however seems marginal compared to the added complexity.
 
@@ -81,4 +81,4 @@ A mismatch between the announced <txhash,type,size,address,nonce> tuple and a re
 
 ## Copyright
 
-Copyright and related rights waived via CC0.
+Copyright and related rights waived via [CC0](../LICENSE.md).


### PR DESCRIPTION
Fixes multiple grammar and spelling errors: corrects typo 'crates' to 'creates', adds missing preposition 'for' before 'UX', changes 'then' to 'than' for comparison, fixes typo 'filed' to 'field', corrects verb tense 'propagating' to 'propagated', adds missing verb 'sending' in 'allows sending to', and updates copyright format to match EIP-1 standard with proper `CC0` link.