### PR TITLE
Add EIP: Cell-Level Deltas for Data Column Broadcast

### DIFF
--- a/EIPS/eip-8136.md
+++ b/EIPS/eip-8136.md
@@ -2,7 +2,7 @@
 eip: 8136
 title: Cell-Level Deltas for Data Column Broadcast
 description: Optimization for disseminating only previously unseen cells to the network for PeerDAS.
-author: Marco Munizaga (@MarcoPolo) <git@marcopolo.io>
+author: Marco Munizaga (@MarcoPolo) <git@marcopolo.io>, Daniel Knopik (@dknopik) <daniel@dknopik.de>, Sukun Tarachandani (@sukunrt) <sukunrt@gmail.com>
 discussions-to: https://ethereum-magicians.org/t/eip-8136-cell-level-deltas-for-data-column-broadcast/27675
 status: Draft
 type: Standards Track


### PR DESCRIPTION
Optimization for disseminating only previously unseen cells to the network for PeerDAS.

Related Discussions:
- https://github.com/ethereum/consensus-specs/pull/4558
- https://github.com/libp2p/specs/pull/685
- https://ethresear.ch/t/gossipsubs-partial-messages-extension-and-cell-level-dissemination/23017