### PR TITLE
Update EIP-2539: Fix grammar and spelling errors in EIP-2539

### DIFF
--- a/EIPS/eip-2539.md
+++ b/EIPS/eip-2539.md
@@ -178,7 +178,7 @@ Error cases:
 
 #### ABI for mapping Fp element to G1 point
 
-Field-to-curve call expects `64` bytes an input that is interpreted as a an element of the base field. Output of this call is `128` bytes and is G1 point following respective encoding rules.
+Field-to-curve call expects `64` bytes as input that is interpreted as an element of the base field. Output of this call is `128` bytes and is G1 point following respective encoding rules.
 
 Error cases:
 	- Input has invalid length
@@ -186,7 +186,7 @@ Error cases:
 
 #### ABI for mapping Fp2 element to G2 point
 
-Field-to-curve call expects `128` bytes an input that is interpreted as a an element of the quadratic extension field. Output of this call is `256` bytes and is G2 point following respective encoding rules.
+Field-to-curve call expects `128` bytes as input that is interpreted as an element of the quadratic extension field. Output of this call is `256` bytes and is G2 point following respective encoding rules.
 
 Error cases:
 	- Input has invalid length
@@ -218,7 +218,7 @@ Assuming a constant `30 MGas/second` following prices are suggested.
 
 #### G1/G2 Multiexponentiation
 
-Multiexponentiations are expected to be performed by the Peppinger algorithm (we can also say that is **must** be performed by Peppinger algorithm to have a speedup that results in a discount over naive implementation by multiplying each pair separately and adding the results). For this case there was a table prepared for discount in case of `k <= 128` points in the multiexponentiation with a discount cup `max_discount` for `k > 128`.
+Multiexponentiations are expected to be performed by the Peppinger algorithm (we can also say that it **must** be performed by Peppinger algorithm to have a speedup that results in a discount over naive implementation by multiplying each pair separately and adding the results). For this case there was a table prepared for discount in case of `k <= 128` points in the multiexponentiation with a discount cap `max_discount` for `k > 128`.
 
 To avoid non-integer arithmetic call cost is calculated as `k * multiplication_cost * discount / multiplier` where `multiplier = 1000`, `k` is a number of (scalar, point) pairs for the call, `multiplication_cost` is a corresponding single multiplication call cost for G1/G2.
 


### PR DESCRIPTION

- Fixed duplicate article: `a an element` → `an element` 
- Fixed preposition: `bytes an input` → `bytes as input` 
- Fixed spelling: `discount cup` → `discount cap`
- Fixed grammar: `that is must` → `that it must`

