### PR TITLE
Update EIP-7612: Update broken Verkle reference links

### DIFF
--- a/EIPS/eip-7612.md
+++ b/EIPS/eip-7612.md
@@ -166,7 +166,7 @@ No backward compatibility issues found.
 
 ## Reference Implementation
 
- * `transition-post-genesis` branch in `github.com/gballet/go-ethereum` implements this when setting `--override.overlay-stride=0` on the command line.
+ * `beverly-hills-just-after-pbss` branch in `github.com/gballet/go-ethereum` implements this when setting `--override.overlay-stride=0` on the command line.
 
 ## Security Considerations
 

--- a/EIPS/eip-7748.md
+++ b/EIPS/eip-7748.md
@@ -290,7 +290,7 @@ TODO: currently described in an external document.
 
 ## Reference Implementation
 
-- `transition-post-genesis` branch in `github.com/gballet/go-ethereum` implements this when setting `--override.overlay-stride` to a non-zero value on the command line.
+- `beverly-hills-just-after-pbss` branch in `github.com/gballet/go-ethereum` implements this when setting `--override.overlay-stride` to a non-zero value on the command line.
 
 ## Security Considerations
 


### PR DESCRIPTION
The `transition-post-genesis` branch referenced in EIP-7612 and EIP-7748 does not exist anymore.
This PR updates the Reference Implementation links to point to the active `beverly-hills-just-after-pbss` branch in `gballet/go-ethereum`. 