### PR TITLE
Update EIP-615: Fix EIP-615 dead paper references

### DIFF
--- a/EIPS/eip-615.md
+++ b/EIPS/eip-615.md
@@ -503,10 +503,10 @@ There is a large and growing ecosystem of researchers, authors, teachers, audito
 
 #### Some Papers
 
-* [A Formal Verification Tool for Ethereum VM Bytecode](https://www.google.com/url?q=http://fsl.cs.illinois.edu/FSL/papers/2018/park-zhang-saxena-daian-rosu-2018-fse/park-zhang-saxena-daian-rosu-2018-fse-public.pdf)
+* [A Formal Verification Tool for Ethereum VM Bytecode](https://doi.org/10.1145/3236024.3264591)
 * [A Lem formalization of EVM and some Isabelle/HOL proofs](https://github.com/pirapira/eth-isabelle)
 * [A survey of attacks on Ethereum smart contracts](https://eprint.iacr.org/2016/1007.pdf)
-* [Defining the Ethereum Virtual Machine for Interactive Theorem Provers](https://www.google.com/url?q=http://fc17.ifca.ai/wtsc/Defining%2520the%2520Ethereum%2520Virtual%2520Machine%2520for%2520Interactive%2520Theorem%2520Provers.pdf)
+* [Defining the Ethereum Virtual Machine for Interactive Theorem Provers](https://fc17.ifca.ai/wtsc/Defining%20the%20Ethereum%20Virtual%20Machine%20for%20Interactive%20Theorem%20Provers.pdf)
 * [Ethereum 2.0 Specifications](https://github.com/ethereum/eth2.0-specs)
 * [Formal Verification of Smart Contracts](https://www.cs.umd.edu/~aseem/solidetherplas.pdf)
 * [JelloPaper: Human Readable Semantics of EVM in K](https://jellopaper.org/)


### PR DESCRIPTION
**Replaced dead link**: The link for "A Formal Verification Tool for Ethereum VM Bytecode" (`fsl.cs.illinois.edu`) is 404. It has been replaced with its persistent **DOI** link (`10.1145/3236024.3264591`).