### PR TITLE
Update EIP-8011: Add EIP-1559 to requires header

### DIFF
--- a/EIPS/eip-8011.md
+++ b/EIPS/eip-8011.md
@@ -8,6 +8,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2025-08-22
+requires: 1559
 ---
 
 ## Abstract


### PR DESCRIPTION
Adds EIP-1559 to the requires header, as EIP-8011 directly modifies the base fee update mechanism defined in EIP-1559.