### PR TITLE
Update EIP-7928: Add first-accessed indices to BAL

### DIFF
--- a/EIPS/eip-7928.md
+++ b/EIPS/eip-7928.md
@@ -59,6 +59,10 @@ Nonce = uint64  # Account nonce
 # StorageChange: [block_access_index, new_value]
 StorageChange = [BlockAccessIndex, StorageValue]
 
+# StorageRead: [block_access_index, slot]
+# Records when a storage slot was first accessed
+StorageRead = [BlockAccessIndex, StorageKey]
+
 # BalanceChange: [block_access_index, post_balance]
 BalanceChange = [BlockAccessIndex, Balance]
 
@@ -72,12 +76,13 @@ CodeChange = [BlockAccessIndex, Bytecode]
 # All changes to a single storage slot
 SlotChanges = [StorageKey, List[StorageChange]]
 
-# AccountChanges: [address, storage_changes, storage_reads, balance_changes, nonce_changes, code_changes]
+# AccountChanges: [address, first_access_index, storage_changes, storage_reads, balance_changes, nonce_changes, code_changes]
 # All changes for a single account, grouped by field type
 AccountChanges = [
     Address,                    # address
+    BlockAccessIndex,           # first_access_index (when account was first accessed)
     List[SlotChanges],          # storage_changes (slot -> [block_access_index -> new_value])
-    List[StorageKey],           # storage_reads (read-only storage keys)
+    List[StorageRead],          # storage_reads ([block_access_index, slot] for read-only slots)
     List[BalanceChange],        # balance_changes ([block_access_index -> post_balance])
     List[NonceChange],          # nonce_changes ([block_access_index -> new_nonce])
     List[CodeChange]            # code_changes ([block_access_index -> new_code])
@@ -166,6 +171,8 @@ The following ordering rules **MUST** apply:
 - **storage_changes**: Slots lexicographic by storage key; within each slot, changes by block access index (ascending)
 - **storage_reads**: Lexicographic by storage key
 - **balance_changes, nonce_changes, code_changes**: By block access index (ascending)
+
+The `first_access_index` field records the block access index of the first transaction (or system call) that accessed the account. For storage reads, the `block_access_index` within each `StorageRead` indicates when that slot was first accessed.
 
 ### BlockAccessIndex Assignment
 
@@ -331,24 +338,26 @@ def track_state_changes(tx, accesses, block_access_index):
     for addr in get_touched_addresses(tx):
         if addr not in accesses:
             accesses[addr] = {
+                'first_access_index': block_access_index,  # Record first access
                 'storage_writes': {},  # slot -> [(index, value)]
-                'storage_reads': set(),
+                'storage_reads': {},   # slot -> first_access_index
                 'balance_changes': [],
                 'nonce_changes': [],
                 'code_changes': []
             }
-        
+
         # Track storage changes
         for slot, value in get_storage_writes(addr).items():
             if slot not in accesses[addr]['storage_writes']:
                 accesses[addr]['storage_writes'][slot] = []
             accesses[addr]['storage_writes'][slot].append((block_access_index, value))
-        
-        # Track reads (slots accessed but not written)
+
+        # Track reads (slots accessed but not written) with first access index
         for slot in get_storage_reads(addr):
             if slot not in accesses[addr]['storage_writes']:
-                accesses[addr]['storage_reads'].add(slot)
-        
+                if slot not in accesses[addr]['storage_reads']:
+                    accesses[addr]['storage_reads'][slot] = block_access_index
+
         # Track balance, nonce, code changes
         if balance_changed(addr):
             accesses[addr]['balance_changes'].append((block_access_index, get_balance(addr)))
@@ -362,21 +371,25 @@ def build_bal(accesses):
     bal = []
     for addr in sorted(accesses.keys()):  # Sort addresses lexicographically
         data = accesses[addr]
-        
+
         # Format storage changes: [slot, [[index, value], ...]]
-        storage_changes = [[slot, sorted(changes)] 
+        storage_changes = [[slot, sorted(changes)]
                           for slot, changes in sorted(data['storage_writes'].items())]
-        
-        # Account entry: [address, storage_changes, reads, balance_changes, nonce_changes, code_changes]
+
+        # Format storage reads: [[first_access_index, slot], ...] sorted by slot
+        storage_reads = [[idx, slot] for slot, idx in sorted(data['storage_reads'].items())]
+
+        # Account entry: [address, first_access_index, storage_changes, reads, balance_changes, nonce_changes, code_changes]
         bal.append([
             addr,
+            data['first_access_index'],
             storage_changes,
-            sorted(list(data['storage_reads'])),
+            storage_reads,
             sorted(data['balance_changes']),
             sorted(data['nonce_changes']),
             sorted(data['code_changes'])
         ])
-    
+
     return bal
 ```
 
@@ -414,6 +427,7 @@ Resulting BAL (RLP structure):
     # Addresses are sorted lexicographically
     [ # AccountChanges for 0x0000F90827F1C53a10cb7A02335B175320002935 (Block hash contract)
         0x0000F90827F1C53a10cb7A02335B175320002935,
+        0,   # first_access_index: pre-execution
         [ # storage_changes
             [b'\x00...\x0f\xa0', [[0, b'...']]]  # slot, [[block_access_index, parent_hash]]
         ],
@@ -424,14 +438,16 @@ Resulting BAL (RLP structure):
     ],
     [ # AccountChanges for 0x2222... (Address checked by Alice)
         0x2222...,
+        1,   # first_access_index: first accessed in tx 1
         [],  # storage_changes
         [],  # storage_reads
         [],  # balance_changes (no change, just checked)
         [],  # nonce_changes
         []   # code_changes
     ],
-    [ # AccountChanges for 0xaaaa... (Alice - sender tx 0)
+    [ # AccountChanges for 0xaaaa... (Alice - sender tx 1)
         0xaaaa...,
+        1,   # first_access_index
         [],  # storage_changes
         [],  # storage_reads
         [[1, 0x...29a241a]],  # balance_changes: [[block_access_index, post_balance]]
@@ -440,22 +456,25 @@ Resulting BAL (RLP structure):
     ],
     [ # AccountChanges for 0xabcd... (Eve - withdrawal recipient)
         0xabcd...,
+        3,   # first_access_index: post-execution
         [],  # storage_changes
         [],  # storage_reads
         [[3, 0x...5f5e100]],  # balance_changes: 100 ETH withdrawal
         [],  # nonce_changes
         []   # code_changes
     ],
-    [ # AccountChanges for 0xbbbb... (Bob - recipient tx 0)
+    [ # AccountChanges for 0xbbbb... (Bob - recipient tx 1)
         0xbbbb...,
+        1,   # first_access_index
         [],  # storage_changes
         [],  # storage_reads
         [[1, 0x...b9aca00]],  # balance_changes: +1 ETH
         [],  # nonce_changes
         []   # code_changes
     ],
-    [ # AccountChanges for 0xcccc... (Charlie - sender tx 1)
+    [ # AccountChanges for 0xcccc... (Charlie - sender tx 2)
         0xcccc...,
+        2,   # first_access_index
         [],  # storage_changes
         [],  # storage_reads
         [[2, 0x...bc16d67]],  # balance_changes: after gas
@@ -464,6 +483,7 @@ Resulting BAL (RLP structure):
     ],
     [ # AccountChanges for 0xdddd... (Deployed contract)
         0xdddd...,
+        2,   # first_access_index
         [],  # storage_changes
         [],  # storage_reads
         [],  # balance_changes
@@ -472,6 +492,7 @@ Resulting BAL (RLP structure):
     ],
     [ # AccountChanges for 0xeeee... (COINBASE)
         0xeeee...,
+        1,   # first_access_index: first accessed when receiving tx 1 fees
         [],  # storage_changes
         [],  # storage_reads
         [[1, 0x...05f5e1], [2, 0x...0bebc2]],  # balance_changes: after tx fees
@@ -480,6 +501,7 @@ Resulting BAL (RLP structure):
     ],
     [ # AccountChanges for 0xffff... (Factory contract)
         0xffff...,
+        2,   # first_access_index
         [ # storage_changes
             [b'\x00...\x01', [[2, b'\x00...\xdd\xdd...']]]  # slot 1, deployed address
         ],
@@ -508,6 +530,8 @@ This design variant was chosen for several key reasons:
 4. **Transaction independence**: 60-80% of transactions access disjoint storage slots, enabling effective parallelization. The remaining 20-40% can be parallelized by having post-transaction state diffs.
 
 5. **RLP encoding**: Native Ethereum encoding format, maintains compatibility with existing infrastructure.
+
+6. **First-access indices**: Each account and storage read includes the transaction index of first access. This enables to invalidate blocks during execution—clients can detect invalid BALs at transaction boundaries rather than waiting until block completion. Without these indices, storage reads provide no benefit for parallel execution since adversarial BALs could declare arbitrary reads that are never accessed.
 
 ### BAL Size Considerations (60m block gas limit)
 


### PR DESCRIPTION
## Add first-access indices to accounts and storage reads

This PR adds **first-access transaction indices** to the Block Access List (BAL) format.

### Changes

* **AccountChanges**: added `first_access_index`, recording when an account is first accessed
* **StorageRead**: changed from a bare `StorageKey` to a `(BlockAccessIndex, StorageKey)` pair

### Rationale

First-access indices enable **progressive invalid block detection** during block execution.

Without mapping state reads to the transaction that accessed them, clients cannot detect invalid BALs until after full execution. An adversarial block could declare arbitrary storage reads that are never actually accessed, forcing worst-case execution equivalent to parallel execution without having batch I/O from the state locations.

With first-access indices, clients can validate state access at transaction boundaries and reject invalid BALs early.

### Size Impact

Analysis of 50 mainnet blocks shows:

* **+4.0%** compressed size overhead (~3.7 KB per block on average)
* ~**1.5 bytes per account** for `first_access_index`
* ~**2.8 bytes per storage read** for the `block_access_index` prefix
