### PR TITLE
Update EIP-7692: Sync EOF Meta Headers

### DIFF
--- a/EIPS/eip-7692.md
+++ b/EIPS/eip-7692.md
@@ -7,7 +7,7 @@ discussions-to: https://ethereum-magicians.org/t/eip-7692-evm-object-format-eof-
 status: Stagnant
 type: Meta
 created: 2024-04-17
-requires: 663, 3540, 3670, 4200, 4750, 5450, 6206, 7069, 7480, 7620, 7698
+requires: 663, 3540, 3670, 4200, 4750, 5450, 5920, 6206, 7069, 7480, 7620, 7698, 7761, 7834, 7873, 7880
 ---
 
 ## Abstract


### PR DESCRIPTION
Syncs the `requires` header with the latest EIP list in the specification body. Several EIPs (e.g., 7834, 7761, 7880) are listed in the text as part of recent devnets but were missing from the metadata.This ensures the Meta EIP accurately links to all components of the EOF v1 proposal.