### PR TITLE
Update EIP-7708: Clarify CALL to self does not emit transfer log

### DIFF
--- a/EIPS/eip-7708.md
+++ b/EIPS/eip-7708.md
@@ -25,7 +25,7 @@ Logs are often used to track when balance changes of assets on Ethereum. Logs wo
 A log, identical to a LOG3, is issued for:
 
 - Any nonzero-value-transferring transaction, before any other logs created by EVM execution
-- Any nonzero-value-transferring `CALL`, at the time that the value transfer executes
+- Any nonzero-value-transferring `CALL` to a different account, at the time that the value transfer executes
 - Any nonzero-value-transferring `SELFDESTRUCT` to a different account, at the time that the value transfer executes
 
 | Field | Value |


### PR DESCRIPTION
## Summary
- Adds "to a different account" clause for `CALL` instructions to match the existing `SELFDESTRUCT` behavior
- Makes it explicit that self-calls with value do not emit a transfer log

## Test plan
- Review the change is consistent with SELFDESTRUCT handling in the same specification