### PR TITLE
Update EIP-7708: Clarify transaction transfer to different account

### DIFF
--- a/EIPS/eip-7708.md
+++ b/EIPS/eip-7708.md
@@ -24,7 +24,7 @@ Logs are often used to track when balance changes of assets on Ethereum. Logs wo
 
 A log, identical to a LOG3, is issued for:
 
-- Any nonzero-value-transferring transaction, before any other logs created by EVM execution
+- Any nonzero-value-transferring transaction to a different account, before any other logs created by EVM execution
 - Any nonzero-value-transferring `CALL` to a different account, at the time that the value transfer executes
 - Any nonzero-value-transferring `SELFDESTRUCT` to a different account, at the time that the value transfer executes
 


### PR DESCRIPTION
## Summary
Clarifies that a transfer log is only emitted for transactions when transferring to a different account.

This aligns with the existing behavior for `CALL` and `SELFDESTRUCT` which already specify "to a different account".