### PR TITLE
Update EIP-7708: clarify order of burn logs and coinbase transfer logs

### DIFF
--- a/EIPS/eip-7708.md
+++ b/EIPS/eip-7708.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2024-05-17
-requires: 4788, 1559, 6780
+requires: 1559, 4788, 6780
 ---
 
 ## Abstract


### PR DESCRIPTION
Payment to coinbase happens before selfdestructed accounts are removed in tx finalization.  The order of the logs that are emitted should reflect this.

