### PR TITLE
Update EIP-7778: Revert back to not having a receipt field

### DIFF
--- a/EIPS/eip-7778.md
+++ b/EIPS/eip-7778.md
@@ -31,17 +31,15 @@ This mechanism can be exploited to perform more operations in a block than the g
 ### Gas Accounting Changes
 
 1. **User Gas Accounting (Unchanged):**
+
    - Users continue to receive gas refunds for operations that qualify (e.g., setting storage to zero)
    - Transaction gas: `gas_spent = max(tx_gas_used - gas_refund, calldata_floor_gas_cost)`
 
 2. **Block Gas Accounting (Modified):**
+
    - When calculating gas for block gas limit enforcement, refunds are not subtracted
    - Block gas accounting becomes: `block.gas_used += max(tx_gas_used, calldata_floor_gas_cost)` (incorporating the calldata floor from [EIP-7623](./eip-7623.md))
    - Storage discounts that reflect actual reduced computational work (e.g., warm storage access, reverting to original values) remain applied to block gas accounting
-
-3. **Receipt Changes:**
-   - `cumulative_gas_used`: Now uses gas before refunds, matching block gas accounting
-   - New field `gas_spent`: Gas actually spent by the transaction after refunds (what the user pays)
 
 ## Rationale
 
@@ -56,7 +54,7 @@ Users still receive gas refunds, maintaining incentives for efficient state mana
 ## Backwards Compatibility
 
 - This change is not backwards compatible and requires a hard fork
-- Receipt structure changes: `cumulative_gas_used` semantics change and new `gas_spent` field is added
+- User and developer experience for individual transactions remains unchanged
 - Block producers need to adjust their transaction selection algorithms to account for the new gas accounting rules
 
 ## Test Cases
@@ -69,9 +67,9 @@ Users still receive gas refunds, maintaining incentives for efficient state mana
    - Construct blocks with varying amounts of refundable operations
    - Ensure blocks cannot exceed gas limits through refund mechanisms
 
-3. **Receipt Fields:**
-   - Verify `cumulative_gas_used` reflects gas before refunds
-   - Verify `gas_spent` reflects gas after refunds (user cost)
+3. **Transaction Gas vs Block Gas:**
+   - Verify that transaction costs for users remain unchanged
+   - Confirm block gas accounting properly excludes refunds
 
 ## Security Considerations
 


### PR DESCRIPTION
Reverting back to:
* not having i new receipt field
* using the gas used after refund for cumulative gas used in receipt

Relevant discussion:
https://discord.com/channels/595666850260713488/1460715235437580369/1466028329768456246

