### PR TITLE
Update EIP-7708: Tighten definition of Selfdestruct logs to comply with EIP-6780

### DIFF
--- a/EIPS/eip-7708.md
+++ b/EIPS/eip-7708.md
@@ -42,7 +42,7 @@ This matches the [ERC-20](./eip-20.md) Transfer event definition.
 
 A log, identical to a LOG2, is issued for:
 
-- Any nonzero-value-transferring `SELFDESTRUCT` to self, at the time that the value subtraction executes
+- Any nonzero-value-transferring `SELFDESTRUCT` to self for all ephemeral contracts (contracts created and destroyed within the same transaction burning the ETH as per [EIP-6780](https://eips.ethereum.org/EIPS/eip-6780)), at the time that the value subtraction executes
 - Any nonzero-value-holding account closure, after any other logs created by EVM execution, but before charging the [EIP-1559](./eip-1559.md) priority fee, in lexicographical order of closed account address
 
 | Field | Value |


### PR DESCRIPTION
**ATTENTION: ERC-RELATED PULL REQUESTS NOW OCCUR IN [ETHEREUM/ERCS](https://github.com/ethereum/ercs)**

--

When opening a pull request to submit a new EIP, please use the suggested template: https://github.com/ethereum/EIPs/blob/master/eip-template.md

We have a GitHub bot that automatically merges some PRs. It will merge yours immediately if certain criteria are met:

 - The PR edits only existing draft PRs.
 - The build passes.
 - Your GitHub username or email address is listed in the 'author' header of all affected PRs, inside <triangular brackets>.
 - If matching on email address, the email address is the one publicly listed on your GitHub profile.
