### PR TITLE
Add EIP: Token Gas Payments for EIP-8130

### DIFF
--- a/EIPS/eip-8140.md
+++ b/EIPS/eip-8140.md
@@ -8,12 +8,12 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2025-10-14
-requires: 8140
+requires: 8130
 ---
 
 ## Abstract
 
-This proposal extends [EIP-8130](./eip-8130.md) to enable gas payments using ERC-20 tokens. It defines the token payment format for EIP-8130's `fee_token` field, a Token Payment Registry for allowlisting tokens, permissionless payer configurations with oracle-based pricing, and an optional native payer system contract for chain-operated gas abstraction.
+This proposal extends [EIP-8130](./eip-8130.md) to enable gas payments using ERC-20 tokens. It defines the token payment format for EIP-8130's `fee_token` field, a Token Payment Registry for allowlisting tokens, and an optional native payer system contract for chain-operated gas abstraction with oracle-based pricing.
 
 ## Motivation
 
@@ -21,8 +21,8 @@ EIP-8130 provides account abstraction with ETH-based gas sponsorship. However, m
 
 - **Gasless UX**: Users transact with tokens they already hold
 - **Stablecoin payments**: Predictable transaction costs in USD-denominated tokens
-- **Competitive market**: Permissionless payers compete on exchange rates
-- **Chain flexibility**: Native payer option for chain-operated gas abstraction (ie. Native AMM)
+- **Competitive market**: Permissioned payers compete on exchange rates off-chain
+- **Chain flexibility**: Native payer option for chain-operated gas abstraction with oracle-based pricing
 - **Zero token changes**: Works with existing ERC-20 tokens using standard transfer logic—no upgrades or storage migrations required
 
 This proposal uses EIP-8130's `fee_token` field to add token payment capability without modifying the base transaction type.
@@ -34,57 +34,40 @@ This proposal uses EIP-8130's `fee_token` field to add token payment capability 
 | Name | Value | Comment |
 |------|-------|---------|
 | `TOKEN_PAYMENT_REGISTRY` | TBD | Token Payment Registry system contract address |
-| `TOKEN_TRANSFER_COST` | 500 (warm) / 5000 (cold) | Per SSTORE costs for balance slot writes |
+| `TOKEN_TRANSFER_COST` | 13000 | Token escrow/refund gas (see breakdown below) |
+| `DEACTIVATION_DELAY` | TBD | Blocks before token deactivation takes effect |
+| `PAUSE_COST` | TBD | ETH required to invoke emergency pause |
 | `NATIVE_PAYER` | TBD | (Optional) Native gas AMM payer system contract address |
 
 ### Fee Token Format
 
-Token payments use the EIP-8130 `fee_token` field with packed byte encoding. The format length determines payer consent:
+Token payments use the EIP-8130 `fee_token` field with packed byte encoding:
 
-| Length | Format | Payer Consent |
-|--------|--------|---------------|
+| Length | Format | Description |
+|--------|--------|-------------|
 | 0 bytes | `0x` (empty) | ETH payment only |
-| 52 bytes | `token (20) \|\| max_amount (32)` | Native payer or any permissioned payer |
-| 72 bytes | `token (20) \|\| max_amount (32) \|\| payer (20)` | Specific payer only |
-
-#### 52-byte Format (Flexible Payer)
+| 52 bytes | `token (20) \|\| max_exchange_rate (32)` | Token gas payment |
 
 ```
-fee_token = token_address || max_amount
+fee_token = token_address || max_exchange_rate
           = address (20 bytes) || uint256 (32 bytes)
           = 52 bytes total
 ```
 
-The sender signs over `token || max_amount` but does NOT commit to a specific payer. This allows:
-- **Native payer**: Empty `payer_auth` resolves to `NATIVE_PAYER`
-- **Any permissioned payer**: 65-byte `payer_auth` signature, payer recovered via ecrecover
-
-Permissionless payers (20-byte address in `payer_auth`) are **rejected** with this format because the sender did not consent to a specific payer.
-
-#### 72-byte Format (Specific Payer)
-
-```
-fee_token = token_address || max_amount || payer_address
-          = address (20 bytes) || uint256 (32 bytes) || address (20 bytes)
-          = 72 bytes total
-```
-
-The sender signs over `token || max_amount || payer`, explicitly committing to that payer. This allows:
-- **Specific permissioned payer**: 65-byte signature must recover to the committed payer
-- **Specific permissionless payer**: 20-byte address must match the committed payer
-- **Native payer**: Empty `payer_auth` if committed payer equals `NATIVE_PAYER`
-
 | Field | Type | Size | Description |
 |-------|------|------|-------------|
 | `token_address` | address | 20 bytes | ERC-20 token contract address |
-| `max_amount` | uint256 | 32 bytes | Maximum token amount sender will pay |
-| `payer_address` | address | 20 bytes | (Optional) Specific payer the sender consents to |
+| `max_exchange_rate` | uint256 | 32 bytes | Maximum tokens per ETH the sender will accept, in token's smallest unit (e.g., 2000 USDC/ETH = `2000 × 10^6`) |
+
+The `max_exchange_rate` is denominated in the token's native decimals per ETH, making it oracle-decimal-agnostic. The sender does NOT commit to a specific payer in `fee_token` — payer commitment uses EIP-8130's extended payer modes (see [Payer Modes with Token Payments](#payer-modes-with-token-payments)).
 
 When `fee_token` is non-empty, the transaction uses token-based gas payment instead of ETH.
 
 ### Token Payment Registry
 
 Tokens must be registered in the Token Payment Registry system contract at `TOKEN_PAYMENT_REGISTRY` before use for gas payment. Similar to EIP-8130's account configuration precompile, this is a protocol-level system contract with persistent storage. The registry stores token metadata required for protocol-level balance reads and transfers.
+
+The registry defines a single protocol-level interface that all wallets and payers integrate with. Its governance model for write access (token registration, pause, blocklist) is implementation-defined — chain-operated, permissionless, or hybrid — and can be extended by the deployer. The protocol reads from the registry identically regardless of governance model.
 
 #### Token Configuration Storage
 
@@ -97,138 +80,159 @@ Base slot: keccak256(token_address || TOKEN_PAYMENT_REGISTRY || "config")
 - base_slot + 1: packed config (uint256)
     - byte 0: token_decimals (uint8)
     - byte 1: active (bool)
-    - byte 2: highBitBlocklist (bool)
+    - byte 2: paused (bool)
     - bytes 3-31: reserved
+- base_slot + 2: deactivation_block (uint256) — 0 if no pending deactivation
 ```
 
 | Field | Description |
 |-------|-------------|
-| `balance_slot_index` | Storage slot index for token's `balanceOf` mapping. User balance at: `keccak256(user_address || balance_slot_index)` |
+| `balance_slot_index` | Storage slot index for token's balance mapping. User balance at: `keccak256(user_address \|\| balance_slot_index)` in the token contract |
 | `token_decimals` | Token decimal places (e.g., 6 for USDC, 18 for most tokens) |
 | `active` | Whether token is currently accepted for gas payments |
-| `highBitBlocklist` | If true, bit 255 of balance = 1 indicates account is blocklisted |
+| `paused` | Whether token is globally paused (emergency, instant) |
+| `deactivation_block` | Block number at which token becomes inactive. Set by `requestDeactivation`, takes effect after `DEACTIVATION_DELAY` blocks |
 
-#### Blocklist Storage
+#### Blocklist
 
-When `highBitBlocklist` is false, blocklist status is stored separately:
+Blocklist state is managed directly in the TOKEN_PAYMENT_REGISTRY rather than read from individual token contracts. This decouples the protocol from token storage internals and provides a single, predictable location for compliance checks:
 
 ```
 Blocklist slot: keccak256(token_address || account_address || TOKEN_PAYMENT_REGISTRY || "blocklist")
-Value: bool
+Value: bool (true = blocked)
 ```
 
-When `highBitBlocklist` is true, bit 255 of the token's balance slot indicates blocklist status—no separate storage read required. This optimization supports tokens like USDC that encode blocklist status in the balance.
+Token issuers or designated admins call `setBlocked(token, account, blocked)` on the registry to maintain the blocklist. For tokens like USDC, an admin or keeper bot monitors the token's native `Blacklisted` events and mirrors them to the registry. The number of blocklisted addresses is typically small (hundreds for major stablecoins — OFAC sanctions, stolen funds, etc.), making this approach practical.
+
+#### Deactivation and Emergency Pause
+
+Token removal and emergency pause use separate mechanisms:
+
+**Deactivation** (planned removal, timelocked): `requestDeactivation(token)` sets `deactivation_block = current_block + DEACTIVATION_DELAY`. The token remains active until that block, giving pending transactions time to clear. `cancelDeactivation(token)` resets the countdown. Activation via `activateToken(token)` takes effect immediately — enabling a token does not invalidate transactions.
+
+**Emergency pause** (instant, costs ETH): `setTokenPaused(token, true)` takes effect immediately and requires `msg.value >= PAUSE_COST`. The ETH cost discourages frivolous or spam pauses while preserving the ability to respond to genuine emergencies (e.g., a token exploit). Unpausing is free and immediate.
 
 ### Payer Modes with Token Payments
 
-This extension adds token payment capability to EIP-8130's payer modes. The `fee_token` length determines which payer modes are permitted:
+This extension leverages EIP-8130's payer marker in the sender signature hash to add token payment capability. EIP-8130 defines the marker as `0x80` (self-pay) or `0x00` (any sponsor). This EIP extends the marker to accept a 20-byte payer address, enabling the sender to commit to a specific payer without modifying `fee_token`:
 
-#### With 52-byte `fee_token` (Native or Permissioned)
+| Sender Signs (marker) | `payer_auth` (wire) | Gas Payer | Token Recipient | Description |
+|------------------------|---------------------|-----------|-----------------|-------------|
+| `0x80` (empty) | MUST be empty | `from` (ETH only) | — | Self-pay; `fee_token` MUST be empty |
+| `0x00` | 65-byte K1 signature | ecrecover(sig) | Payer | Any permissioned payer; payer signs tx |
+| `payer_address` (20 bytes) | 65-byte sig (must match) | Committed payer | Payer | Specific permissioned payer |
+| `NATIVE_PAYER` (20 bytes) | MUST be empty | `NATIVE_PAYER` | `NATIVE_PAYER` | Native payer (chain-operated) |
 
-| Mode | `payer_auth` | `fee_token` | Gas Payer | Token Recipient |
-|------|--------------|-------------|-----------|-----------------|
-| Native payer | Empty | `token \|\| max` | `NATIVE_PAYER` | `NATIVE_PAYER` |
-| Any permissioned | 65-byte signature | `token \|\| max` | ecrecover(sig) | Payer |
-| Permissionless | 20-byte address | `token \|\| max` | **REJECTED** | — |
+The RLP encoding naturally disambiguates: 0 bytes = self-pay, 1 byte (`0x00`) = any sponsor, 20 bytes = specific payer address.
 
-**Rationale**: Permissioned payers sign the transaction, demonstrating consent. Permissionless payers don't sign, so the sender must explicitly consent by using the 72-byte format.
+**Permissioned payers** sign each transaction, explicitly agreeing to the `max_exchange_rate`. They can use either `0x00` (any willing signer) or a 20-byte address (specific signer). The `NATIVE_PAYER` address is used directly as the marker for native payer mode. No permissionless (unsigned) third-party payers are supported — see [Security Considerations](#security-considerations) for rationale.
 
-#### With 72-byte `fee_token` (Specific Payer)
+**Updated sender signature hash** (extends [EIP-8130 Signature Payload](./eip-8130.md#signature-payload)):
 
-| Mode | `payer_auth` | `fee_token` | Gas Payer | Token Recipient |
-|------|--------------|-------------|-----------|-----------------|
-| Specific native | Empty | `token \|\| max \|\| NATIVE_PAYER` | `NATIVE_PAYER` | `NATIVE_PAYER` |
-| Specific permissioned | 65-byte signature | `token \|\| max \|\| payer` | Must match payer | Payer |
-| Specific permissionless | 20-byte address | `token \|\| max \|\| payer` | Must match payer | Payer |
+```
+// Self-pay (from pays ETH):
+keccak256(AA_TX_TYPE || rlp([..., fee_token, 0x80]))
 
-**Rationale**: Sender committed to a specific payer in `fee_token`, enabling permissionless mode safely.
+// Any permissioned sponsor:
+keccak256(AA_TX_TYPE || rlp([..., fee_token, 0x00]))
 
-### Permissionless Payer Configuration
+// Specific payer (permissioned or native):
+keccak256(AA_TX_TYPE || rlp([..., fee_token, payer_address]))
+```
 
-Permissionless payers register onchain to accept token payments without signing each transaction. Each payer specifies their own oracle per token, enabling a competitive gas market.
+### Native Payer
+
+The optional `NATIVE_PAYER` system contract provides chain-operated gas abstraction with oracle-based pricing. This is the only mechanism for unsigned (non-permissioned) token gas payments.
 
 #### Storage
 
 ```
-Base slot: keccak256(payer_address || TOKEN_PAYMENT_REGISTRY || "payer")
+Per-token oracle config:
+Token slot: keccak256(token_address || NATIVE_PAYER || "oracle")
 
-- base_slot + 0: active (bool)
-
-Per-token config:
-Token slot: keccak256(token_address || payer_address || TOKEN_PAYMENT_REGISTRY || "payer_token")
-
-- token_slot + 0: accepted (bool)
-- token_slot + 1: oracle_address (address)
-- token_slot + 2: oracle_slot (bytes32)
-- token_slot + 3: oracle_decimals (uint8)
+- token_slot + 0: oracle_address (address)
+- token_slot + 1: oracle_slot (bytes32)
+- token_slot + 2: oracle_decimals (uint8)
 ```
+
+Chain operators configure accepted tokens and their oracle feeds via the `NATIVE_PAYER` contract. Only tokens registered in the Token Payment Registry AND configured in the native payer can be used with native payer mode.
 
 #### Oracle-Based Pricing
 
-Each payer configures an oracle for each token they accept. The oracle value represents **tokens per ETH**, scaled by `10^oracle_decimals`:
+The native payer reads exchange rates from chain-operator-configured oracles. The oracle value represents **tokens per ETH**, scaled by `10^oracle_decimals`. The protocol normalizes the oracle value to the token's native units per ETH for comparison with `max_exchange_rate`:
 
 ```
-oracle_value = SLOAD(payer.oracle_address, payer.oracle_slot)
+oracle_value = SLOAD(native_payer.oracle_address, native_payer.oracle_slot)
 exchange_rate = oracle_value * 10^token_decimals / 10^oracle_decimals
 token_cost = ceil(gas_cost_wei * exchange_rate / 10^18)
 ```
 
+Both `exchange_rate` and `max_exchange_rate` are in the same units: token's smallest unit per ETH. Validation requires `exchange_rate <= max_exchange_rate`.
+
 **Example**: USDC payment for 0.001 ETH gas cost (1e15 wei), ETH at $2000:
-- `oracle_value` = 2000 × 10^8 (2000 USDC/ETH with 8 decimals, Chainlink standard)
-- `exchange_rate` = 2000e8 × 10^6 / 10^8 = 2000e6
-- `token_cost` = 1e15 × 2000e6 / 1e18 = 2e6 = 2 USDC 
+- `oracle_value` = 2000 × 10^8 (Chainlink 8-decimal standard)
+- `exchange_rate` = 2000e8 × 10^6 / 10^8 = 2000e6 (= 2000 USDC per ETH in USDC units)
+- `max_exchange_rate` = 2100e6 (sender accepts up to 2100 USDC/ETH)
+- `token_cost` = 1e15 × 2000e6 / 1e18 = 2e6 = 2 USDC
 
-If oracle returns 0, `token_cost` is 0 (payer assumes this risk).
+If oracle returns 0, `token_cost` is 0 (chain operator assumes this risk).
 
-#### Validation
+#### Oracle Maintenance
 
-Protocol verifies permissionless payers by checking:
-
-- Payer config is active
-- Payer accepts the specified token with valid oracle config
-- Payer has sufficient ETH for gas
-
-Payers can integrate any offchain logic to manage their position—sweeping accumulated tokens to ETH via DeFi protocols periodically.
-
-### Oracle Maintenance
-
-Oracle maintenance is external to this specification. Payers are responsible for maintaining accurate exchange rates. Common approaches:
+Oracle maintenance is the chain operator's responsibility. Common approaches:
 
 | Oracle Type | Description |
 |-------------|-------------|
 | **Chainlink feeds** | Decentralized price updates via established infrastructure |
-| **Keeper-updated** | Payer runs offchain updater with top-of-block updates |
-| **DeFi-integrated** | Permissionless contract queries configured DEX pool for current price |
+| **Internal feed** | Chain operator runs an updater service |
+| **DEX-integrated** | Oracle contract queries configured on-chain liquidity pool |
 
-The protocol reads `oracle_slot` at validation time. Stale prices are the payer's risk—they may overpay for gas or have transactions rejected via sender's `max_amount`. A recommended pattern is a non-upgradable oracle contract with a permissionless `update(token)` method that queries configured DEX pools.
-
-### Native Payer
-
-The optional `NATIVE_PAYER` system contract provides chain-operated gas abstraction.
+The oracle rate is read once and locked at the start of each AA transaction (see [Exchange Rate Resolution](#exchange-rate-resolution)). Stale prices are the chain operator's risk.
 
 #### Behavior
 
 - Uses the Token Payment Registry for token allowlisting and metadata
-- Chain operators define pricing mechanism and supported tokens (intentionally unspecified—enables AMMs, fixed rates, or custom curves)
-- Can be referenced explicitly (20-byte address in `payer_auth`) or implicitly (empty `payer_auth` with non-empty `fee_token`)
+- Chain operators define supported tokens and oracle feeds
+- Referenced via the sender's payer marker: sender signs `NATIVE_PAYER` address as the 20-byte marker, `payer_auth` is empty
+- Chain operators may implement custom pricing logic (AMMs, fixed rates, or custom curves) within the native payer contract
 
 ### Token Transfer Flow
 
-When `fee_token` is non-empty:
+Token transfers use a two-sided escrow/refund model. The exchange rate is resolved and locked once at the start of transaction execution — it does not change during the transaction.
 
-1. Parse `fee_token` to extract `token_address`, `max_amount`, and optionally `payer_address`
-2. Resolve payer from `payer_auth` (see [Validation Flow Updates](#validation-flow-updates))
-3. Read raw balance from token's `balance_slot_index` for sender
-4. Verify sender is not blocklisted (via high bit or blocklist storage)
-5. Determine `token_cost`:
-   - **Permissioned payer** (65-byte signature): `token_cost = max_amount × (gas_used / gas_limit)` — payer signed agreeing to max price, actual cost scales with gas used
-   - **Permissionless payer** (20-byte address, requires 72-byte `fee_token`): read exchange rate from payer's oracle config, compute `token_cost` based on actual `gas_used`, validate `token_cost <= max_amount`
-   - **Native payer**: compute from `NATIVE_PAYER` pricing based on actual `gas_used`, validate `token_cost <= max_amount`
-6. Validate `balance >= token_cost`
-7. Update balances: sender decreases, payer increases
-8. Emit `Transfer(from, payer, token_cost)` (implementation-defined)
+#### Exchange Rate Resolution
 
-Token transfers occur outside EVM execution. For permissioned payers, the initial transfer uses `max_amount` at transaction start; any refund based on actual gas usage occurs post-execution.
+The exchange rate is determined by payer type and locked at the start of AA transaction execution:
+
+| Payer Type | Exchange Rate Source | Meaning of `max_exchange_rate` |
+|------------|---------------------|-------------------------------|
+| **Permissioned** (65-byte sig) | `max_exchange_rate` directly | Mutually agreed rate (both parties signed over it) |
+| **Native** (`NATIVE_PAYER`) | Chain-operator oracle | Cap — oracle rate MUST NOT exceed `max_exchange_rate` |
+
+`max_exchange_rate` serves the same role for token pricing that `max_fee_per_gas` serves for ETH gas pricing — it is the sender's maximum willingness-to-pay. For native payer transactions, nodes SHOULD reject transactions where `max_exchange_rate < current_oracle_rate`, just as nodes reject transactions where `max_fee_per_gas < base_fee`. Wallets SHOULD set `max_exchange_rate` with a buffer above the current oracle rate (e.g., 10%) to avoid premature invalidation during normal price movement.
+
+#### Pre-Execution Escrow
+
+1. Parse `fee_token` to extract `token_address` and `max_exchange_rate`
+2. Resolve exchange rate (locked for the duration of this tx):
+   - Permissioned payer: `exchange_rate = max_exchange_rate` (mutually agreed)
+   - Native payer: `exchange_rate = oracle_rate`. If `oracle_rate > max_exchange_rate`, transaction fails
+3. Verify token is not paused (registry `paused` flag)
+4. Verify sender is not blocklisted (registry blocklist)
+5. Compute `max_token_cost = ceil(gas_limit × max_fee_per_gas × exchange_rate / 10^18)`
+6. **Token escrow**: Deduct `max_token_cost` from sender's token balance (sender tokens on hold)
+7. **ETH escrow**: Deduct `gas_limit × max_fee_per_gas` from payer's ETH balance (payer ETH on hold, per EIP-8130)
+
+#### Post-Execution Settlement
+
+After EVM execution completes (regardless of revert):
+
+1. Compute `actual_gas_cost = gas_used × effective_fee_per_gas`
+2. Compute `actual_token_cost = ceil(actual_gas_cost × exchange_rate / 10^18)`
+3. **Token settlement**: Transfer `actual_token_cost` from escrow to payer; refund `max_token_cost - actual_token_cost` back to sender
+4. **ETH settlement**: Refund `(gas_limit × max_fee_per_gas) - actual_gas_cost` back to payer (per EIP-8130)
+
+All token operations occur outside EVM execution via direct storage manipulation.
 
 ### Intrinsic Gas
 
@@ -238,42 +242,57 @@ When `fee_token` is non-empty, add to EIP-8130 intrinsic gas:
 intrinsic_gas = EIP8130_intrinsic_gas + TOKEN_TRANSFER_COST
 ```
 
+`TOKEN_TRANSFER_COST` (~13,000 gas) covers the protocol's direct storage operations for the escrow/refund flow:
+
+| Operation | Gas | Notes |
+|-----------|-----|-------|
+| Sender balance read (cold SLOAD) | 2,100 | From token contract storage |
+| Sender balance write (warm SSTORE) | 2,900 | Non-zero → non-zero |
+| Payer balance read (cold SLOAD) | 2,100 | From token contract storage |
+| Payer balance write (warm SSTORE) | 2,900 | Non-zero → non-zero |
+| Oracle read (cold SLOAD) | 2,100 | From oracle contract storage (native payer only; 0 for permissioned) |
+| Blocklist + pause check | ~200 | Registry storage (warm — same contract as token config reads) |
+| Post-execution refund (2× warm SSTORE) | ~800 | Both balance slots already warm |
+| **Total** | **~13,000** | |
+
 ### Validation Flow Updates
 
 Extend EIP-8130 mempool acceptance:
 
-1. (EIP-8130 steps 1-3)
-2. If `fee_token` is non-empty (52 or 72 bytes):
-   - Parse `fee_token`: extract `token_address`, `max_amount`, and optionally `payer_address`
+1. (EIP-8130 steps 1-6: signature, nonce, etc.)
+2. If `fee_token` is non-empty (52 bytes):
+   - Parse `fee_token`: extract `token_address`, `max_exchange_rate`
    - Verify token is registered and active in Token Payment Registry
-   - Verify sender is not blocklisted for this token
-   - Verify sender has sufficient token balance
-   - Resolve payer based on `fee_token` length:
-   
-   **52-byte format** (native or permissioned):
-   - Empty `payer_auth`: use `NATIVE_PAYER`
-   - 65-byte `payer_auth`: recover payer via ecrecover (any permissioned payer)
-   - 20-byte `payer_auth`: **REJECT** (sender did not consent to permissionless)
-   
-   **72-byte format** (specific payer):
-   - Extract `expected_payer` from `fee_token`
-   - Empty `payer_auth`: verify `expected_payer == NATIVE_PAYER`, use `NATIVE_PAYER`
-   - 65-byte `payer_auth`: recover payer via ecrecover, verify matches `expected_payer`
-   - 20-byte `payer_auth`: verify matches `expected_payer`, use as permissionless payer
-   
-   - For permissionless payers: verify payer accepts token, has valid oracle, sufficient ETH
-   - Verify `token_cost <= max_amount`
-3. (EIP-8130 steps 4-6)
+   - Verify token is not paused (registry `paused` flag)
+   - Verify sender is not blocklisted (registry blocklist)
+   - Resolve payer from sender's signed marker and `payer_auth`:
+     - Marker = empty (`0x80`): **REJECT** (self-pay not valid with token payments)
+     - Marker = `0x00`: recover payer via ecrecover from `payer_auth` (any permissioned payer)
+     - Marker = 20-byte address with 65-byte `payer_auth`: specific permissioned payer (ecrecover must match marker)
+     - Marker = `NATIVE_PAYER`: `payer_auth` MUST be empty; verify native payer has oracle config for token
+   - For native payer: read oracle exchange rate; **REJECT** if `max_exchange_rate < current_oracle_rate`
+   - For permissioned payer: use `max_exchange_rate` directly (mutually agreed rate)
+   - Compute `max_token_cost = ceil(gas_limit × max_fee_per_gas × exchange_rate / 10^18)`
+   - Verify sender token balance ≥ `max_token_cost`
+3. (EIP-8130 remaining steps: nonce, balance, expiry)
+
+Nodes SHOULD treat `max_exchange_rate` the same way they treat `max_fee_per_gas`: reject transactions where the cap is below the current rate. For native payer transactions, this means `max_exchange_rate >= current_oracle_rate`. Transactions that were valid but become invalid due to oracle rate increases are evicted from the mempool, the same as transactions evicted when `base_fee` rises above `max_fee_per_gas`.
 
 ### Block Execution Updates
 
 Extend EIP-8130 block execution:
 
-1. **Token transfer** (if `fee_token` is non-empty)
-2. ETH gas deduction from payer
-3. Process authorization_list (EIP-7702)
-4. Account initialization (if applicable)
-5. Deliver calldata to sender via self-call
+1. **Exchange rate lock** (if `fee_token` non-empty): Read and lock exchange rate for this tx
+2. **Token escrow** (if `fee_token` non-empty): Deduct `max_token_cost` from sender
+3. **ETH escrow**: Deduct `gas_limit × max_fee_per_gas` from payer (per EIP-8130)
+4. Process authorization_list (EIP-7702)
+5. Account initialization (if applicable)
+6. Apply key changes (if applicable)
+7. Deliver calldata to sender via self-call
+8. **Token settlement** (if `fee_token` non-empty): Transfer `actual_token_cost` to payer, refund excess to sender
+9. **ETH settlement**: Refund unused ETH gas to payer (per EIP-8130)
+
+Steps 1–6 and 8–9 are protocol-level direct state operations (no EVM execution). Step 7 is the single EVM execution frame. Token escrow (step 2) ensures the sender cannot move tokens during execution; settlement (step 8) transfers the actual cost. If step 7 reverts, token and ETH settlement still complete (consistent with EIP-8130's revert semantics).
 
 ### Transaction Context Extension
 
@@ -288,50 +307,35 @@ Returns the token address and amount transferred for gas payment. Returns `(addr
 
 ## Rationale
 
-### Why Length-Based Payer Consent?
+### Why `max_exchange_rate` Instead of `max_amount`?
 
-The `fee_token` field uses length to determine payer consent:
+The sender specifies a maximum exchange rate (tokens per ETH) rather than an absolute token amount:
 
-1. **52 bytes = flexible**: Sender allows native or any permissioned payer. Permissioned payers sign the transaction, demonstrating their consent. The sender trusts "anyone willing to sign."
+1. **Scales naturally**: The actual token cost scales with gas used — no over-escrow beyond what the gas limit requires
+2. **Rate-centric**: Users think in terms of "what rate am I paying?" not "what absolute amount might be deducted"
+3. **Oracle-comparable**: Directly comparable to the oracle's exchange rate without additional conversions
+4. **Simpler escrow**: `max_token_cost = gas_limit × max_fee_per_gas × max_exchange_rate / 10^18` — deterministic from tx fields
+5. **`max_fee_per_gas` analogy**: `max_exchange_rate` is to the oracle rate what `max_fee_per_gas` is to `base_fee` — a sender-specified ceiling that determines validity. Wallets set both with headroom above the current value; transactions become invalid when the underlying rate exceeds the cap. This is a familiar pattern for mempool nodes and wallet implementations.
 
-2. **72 bytes = specific**: Sender commits to a specific payer address. This enables permissionless payers safely because the sender explicitly chose that payer.
+### Why Payer Commitment via Signature Marker?
 
-This design prevents **payer attachment attacks** where an attacker could replace the intended payer with one offering worse rates. Without sender consent:
-- Attacker intercepts transaction with 52-byte `fee_token`
-- Attacker attaches a permissionless payer with unfavorable oracle rates
-- Sender pays more tokens than intended (up to `max_amount`)
+EIP-8130 already includes a payer marker in the sender's signature hash (`0x80` for self-pay, `0x00` for any sponsor). Extending this to accept a 20-byte payer address lets the sender commit to a specific payer without modifying `fee_token`. This prevents **payer attachment attacks** where an attacker replaces the intended payer with one offering worse rates. The sender's `max_exchange_rate` provides a hard cap, but the payer marker provides the primary protection by binding the sender's signature to a specific payer.
 
-By requiring 72-byte format for permissionless payers, the sender's signature binds to the specific payer they trust.
+### Why No Permissionless Third-Party Payers?
 
-### Why Permissionless Payers?
+Oracle-based pricing without a per-transaction signature creates a mass invalidation attack surface. A permissionless payer registers an oracle, and the mempool fills with transactions referencing that oracle. If the oracle price spikes (maliciously or organically), all pending transactions where `oracle_rate > max_exchange_rate` become invalid simultaneously. Worse, an attacker can register multiple Sybil payer identities pointing to the same oracle, circumventing per-payer pending limits and amplifying the blast radius.
 
-Permissionless payers create a competitive market for gas payment services:
+Oracle-based pricing is instead scoped to the **native payer** — a chain-operated system contract where the chain operator controls the oracle feed. This provides a single trusted operator with aligned incentives, no Sybil risk, and a simple invalidation model. Competitive pricing is achieved through **permissioned payers** who sign each transaction, agreeing to a specific `max_exchange_rate` — no oracle dependency in the mempool.
 
-1. **No gatekeeping**: Anyone can become a payer by registering
-2. **Price competition**: Payers compete on exchange rates
-3. **Decentralization**: No single entity controls gas payment pricing
-4. **Innovation**: Payers can experiment with pricing strategies
-
-### Why Per-Payer Oracles?
-
-Per-payer oracles rather than a global protocol oracle:
-
-1. **Market competition**: Payers compete on pricing—better oracles and tighter margins attract more transactions
-2. **No governance**: Avoids protocol-level debates about which oracle is canonical
-3. **Risk isolation**: A bad oracle only affects users of that payer
-4. **Flexibility**: Payers can use Chainlink, custom feeds, or promotional rates
-5. **Wallet-layer curation**: Discovery of reputable payers is handled by wallets, not protocol
-
-The `max_amount` field provides hard user protection—transactions fail if computed cost exceeds the user-specified limit.
-
-### Why Direct Storage Reads?
+### Why Direct Storage Reads for Balances?
 
 Reading token balances directly from storage slots rather than calling ERC-20 methods:
 
 1. **No token upgrades**: Existing tokens with standard `mapping(address => uint256)` balance storage work without modification—just register the balance slot index
 2. **No storage migrations**: Tokens don't need to move data or conform to new interfaces
-3. **Atomic execution**: Balance reads and transfers happen at protocol level, before EVM execution begins
-4. **Extensible**: The same approach can support other asset types that use balance-based storage patterns
+3. **Atomic execution**: Balance reads and transfers happen at protocol level, before and after EVM execution (escrow/refund model)
+
+Blocklist and pause state are managed in the TOKEN_PAYMENT_REGISTRY rather than read from token contracts. This decouples the protocol from token storage internals—each token's blocklist implementation is different (high-bit flags, separate mappings, struct fields), but the registry provides a single, predictable interface. Designated admins mirror token issuer blocklist events to the registry.
 
 ## Backwards Compatibility
 
@@ -343,55 +347,52 @@ This proposal extends EIP-8130. Nodes not supporting this EIP will reject transa
 
 ```solidity
 interface ITokenPaymentRegistry {
-    event TokenRegistered(address indexed token, uint256 balanceSlotIndex, uint8 tokenDecimals, bool highBitBlocklist);
-    event TokenStatusUpdated(address indexed token, bool active);
+    event TokenRegistered(address indexed token, uint256 balanceSlotIndex, uint8 tokenDecimals);
+    event TokenActivated(address indexed token);
+    event DeactivationRequested(address indexed token, uint256 effectiveBlock);
+    event DeactivationCancelled(address indexed token);
+    event TokenPaused(address indexed token, bool paused);
     event BlocklistUpdated(address indexed token, address indexed account, bool blocked);
-    event BlocklistManagerUpdated(address indexed token, address indexed manager, bool authorized);
+    event BlocklistAdminUpdated(address indexed token, address indexed admin, bool authorized);
     
-    // Token registration (token address or configured admin only)
-    function registerToken(address token, uint256 balanceSlotIndex, uint8 tokenDecimals, bool highBitBlocklist) external;
-    function setTokenActive(address token, bool active) external;
+    // Token registration — idempotent, calling on an already-registered token updates its config
+    function registerToken(address token, uint256 balanceSlotIndex, uint8 tokenDecimals) external;
     
-    // Blocklist management
-    function setBlocklistManager(address manager, bool authorized) external;
+    // Activation (immediate) and deactivation (timelocked by DEACTIVATION_DELAY)
+    function activateToken(address token) external;
+    function requestDeactivation(address token) external;
+    function cancelDeactivation(address token) external;
+    
+    // Emergency pause — pausing requires msg.value >= PAUSE_COST
+    function setTokenPaused(address token, bool paused) external payable;
+    
+    // Blocklist management (token admin or designated blocklist admin)
+    function setBlocklistAdmin(address token, address admin, bool authorized) external;
     function setBlocked(address token, address account, bool blocked) external;
     
-    // View functions
+    // View functions — isTokenActive returns false if paused or past deactivation_block
     function isTokenActive(address token) external view returns (bool);
     function isBlocked(address token, address account) external view returns (bool);
-    function isBlocklistManager(address token, address manager) external view returns (bool);
-    function getTokenDecimals(address token) external view returns (uint8);
-    function getBalanceSlotIndex(address token) external view returns (uint256);
-    function hasHighBitBlocklist(address token) external view returns (bool);
+    function getTokenConfig(address token) external view returns (
+        uint256 balanceSlotIndex, uint8 tokenDecimals, bool active, bool paused, uint256 deactivationBlock
+    );
 }
 ```
 
-### IPayerConfig
+### INativePayer
 
 ```solidity
-interface IPayerConfig {
-    struct TokenConfig {
-        bool accepted;
-        address oracleAddress;
-        bytes32 oracleSlot;
-        uint8 oracleDecimals;
-    }
+interface INativePayer {
+    event OracleConfigured(address indexed token, address oracleAddress, bytes32 oracleSlot, uint8 oracleDecimals);
+    event OracleRemoved(address indexed token);
     
-    event PayerUpdated(address indexed payer, bool active);
-    event PayerTokenConfigured(address indexed payer, address indexed token, address oracle, bytes32 oracleSlot, uint8 oracleDecimals);
-    event PayerTokenRemoved(address indexed payer, address indexed token);
-    
-    // Payer registration
-    function setPayerActive(bool active) external;
-    
-    // Token configuration
-    function configureToken(address token, address oracleAddress, bytes32 oracleSlot, uint8 oracleDecimals) external;
-    function removeToken(address token) external;
+    // Oracle configuration (chain operator only)
+    function configureOracle(address token, address oracleAddress, bytes32 oracleSlot, uint8 oracleDecimals) external;
+    function removeOracle(address token) external;
     
     // View functions
-    function isPayerActive(address payer) external view returns (bool);
-    function getTokenConfig(address payer, address token) external view returns (TokenConfig memory);
-    function getExchangeRate(address payer, address token) external view returns (uint256);
+    function getOracleConfig(address token) external view returns (address oracleAddress, bytes32 oracleSlot, uint8 oracleDecimals);
+    function getExchangeRate(address token) external view returns (uint256);
 }
 ```
 
@@ -399,25 +400,28 @@ interface IPayerConfig {
 
 **Token Spend Protection**: Token gas payments occur before wallet code executes, bypassing wallet-level spend limits. Mitigations:
 
-- **`max_amount` cap**: Hard limit on token spend per transaction
+- **`max_exchange_rate` cap**: Hard limit on the exchange rate per transaction; combined with `max_fee_per_gas` and `gas_limit`, this bounds maximum token spend
 - **`requiresSponsor` policy** (EIP-8130): Accounts can enable the `requiresSponsor` flag in their gas payment policy, which disables ALL self-paid gas (ETH and tokens). When enabled, transactions must have a sponsor signature in `payer_auth`. This completely eliminates the gas spend attack vector and is strongly recommended for accounts using EVM-layer multisig.
-- **Blocklist checks**: Protocol validates sender is not blocklisted before transfer
+- **Blocklist checks**: Protocol reads the registry-managed blocklist before escrow, ensuring blocklisted accounts cannot spend tokens on gas
 
-**Oracle Risks**: Per-payer oracles mean manipulation affects only that payer's users. Mitigations:
+**Escrow/Griefing Prevention**: The two-step escrow model (deduct `max_token_cost` pre-execution, refund excess post-execution) prevents the sender from transferring tokens away during EVM execution. Without escrow, the sender could drain their token balance in `calldata` execution, causing the post-execution token deduction to fail while the payer still pays ETH gas.
 
-- **Trusted payer lists**: Wallets curate lists of reputable payers
-- **`max_amount` field**: User-specified cap protects against price spikes
+**Oracle Risks**: Oracle-based pricing is restricted to the chain-operated native payer. The oracle rate is read once and locked at the start of AA transaction execution. If another transaction in the same block updates the oracle, the new rate is used — but the sender's `max_exchange_rate` cap protects against spikes. Stale oracle prices are the chain operator's risk.
 
-**Payer Security**: 
+**Payer Security**: Permissioned payers sign each transaction, explicitly agreeing to the `max_exchange_rate`. When the sender uses `0x00` (any sponsor), only permissioned payers who sign can attach. The native payer requires the sender to sign `NATIVE_PAYER` as the 20-byte marker. In all cases, `max_exchange_rate` provides a hard cap on token cost, preventing payer attachment attacks with worse rates.
 
-- **Permissioned**: Payer signs each transaction, explicitly agreeing to the token amount. Can be used with 52-byte or 72-byte `fee_token`.
-- **Permissionless**: Requires 72-byte `fee_token` format where sender commits to the specific payer address. This prevents payer attachment attacks where an attacker substitutes a payer with worse rates. Payers explicitly configure accepted tokens and oracles; protocol validates sender balance/blocklist before transfer.
+**Mass Invalidation Prevention**: Multiple layers protect against mass mempool invalidation:
 
-**Payer Attachment Attack Prevention**: The 52-byte format rejects permissionless payers because the sender didn't sign over a specific payer. An attacker cannot attach an arbitrary permissionless payer to steal value through unfavorable exchange rates. The `max_amount` field provides a hard cap, but the length-based consent model provides the primary protection.
+- **No permissionless third-party payers**: Oracle-based payers where anyone can register create a Sybil-amplified invalidation vector. Oracle pricing is restricted to the chain-operated native payer.
+- **Timelocked deactivation**: `requestDeactivation` starts a `DEACTIVATION_DELAY` countdown, giving pending transactions time to clear. Mempool nodes can stop accepting new transactions for a token with a pending deactivation.
+- **Paid emergency pause**: `setTokenPaused` requires a non-zero ETH payment (`PAUSE_COST`), making frivolous or spam pauses economically costly. Emergency pauses may still invalidate pending transactions, but the ETH cost bounds abuse.
+- **Permissioned payer rate lock**: Permissioned payers sign each transaction with an agreed `max_exchange_rate`, fixing the rate at signature time with no oracle dependency in the mempool.
 
 **Balance Manipulation**: Protocol reads token balances directly from storage slots. Tokens with non-standard balance storage (rebasing, fee-on-transfer) may behave unexpectedly. Only register well-understood tokens.
 
-**Token Slot Changes**: If a registered token upgrades and changes its balance storage slot, the registry configuration becomes invalid. The token must be deactivated; there is no migration path currently. This is intentional—tokens used for gas payment should have immutable storage layouts.
+**Balance Slot Changes**: If a registered token upgrades and changes its balance storage slot, the registry configuration becomes stale. The admin can call `registerToken` again to update the config atomically (no deactivation gap). However, tokens used for gas payment should have immutable balance storage layouts — frequent slot changes indicate an unstable token that should not be registered.
+
+**Blocklist Sync**: The registry-managed blocklist may lag behind a token issuer's native blocklist by a few blocks. In the worst case, a newly-blacklisted address could spend a small amount of tokens on gas before the registry is updated. This is an acceptable tradeoff for the simplicity of not coupling to each token's internal storage layout. Designated admins should monitor token blocklist events and mirror updates promptly.
 
 ## Copyright
 


### PR DESCRIPTION
## EIP: Token Gas Payments for EIP-8130

### Simple Summary

Enable gas payments using ERC-20 tokens for EIP-8130 account abstraction transactions via the extensions field.

Note EIP-8130 is still in PR: https://github.com/ethereum/EIPs/pull/11186 

### Abstract

This proposal extends EIP-8130 to enable gas payments using ERC-20 tokens. It defines the token payment extension format for EIP-8130's `extensions` field, a Token Payment Registry for allowlisting tokens, permissionless payer configurations with oracle-based pricing, and an optional native payer precompile for chain-operated gas abstraction.

### Motivation

EIP-8130 provides account abstraction with ETH-based gas sponsorship. However this enables native token transfers to enable token gas abstraction (ie ERC-20)

- **Gasless UX**: Users transact with tokens they already hold
- **Stablecoin payments**: Predictable transaction costs in USD-denominated tokens
- **Competitive market**: Permissionless payers compete on exchange rates
- **Chain flexibility**: Native payer option for chain-operated gas abstraction
- **Zero token changes**: Works with existing ERC-20 tokens using standard transfer logic—no upgrades or storage migrations required

### Key Features

- Token Payment Registry precompile for allowlisting tokens with balance slot metadata
- Blocklist support
- Three payer modes: permissioned (signature), permissionless (registered config), and native (chain-operated)
- Per-payer oracle configuration enabling competitive pricing markets
- Extensible to other asset types using balance-based storage patterns

### Dependencies

- Requires [EIP-8130](./eip-8130.md)