### PR TITLE
Update EIP-7906: correct CALL opcode

### DIFF
--- a/EIPS/eip-7906.md
+++ b/EIPS/eip-7906.md
@@ -135,7 +135,7 @@ Including all opcodes called during a transaction execution in the stack trace i
 * `DELEGATECALL` (`0xF4`)
 * `CALLCODE` (`0xF2`)
 * `STATICCALL` (`0xFA`)
-* `CALL` (`0xFA`)
+* `CALL` (`0xF1`)
 * `LOG` (`0xA0`)
 * `LOG1` (`0xA1`)
 * `LOG2` (`0xA2`)


### PR DESCRIPTION
Previously the CALL opcode was documented as 0xFA, which is the value of STATICCALL in the EVM. This could mislead implementers of the trace precompile and cause incorrect handling of CALL vs STATICCALL.

This change updates the Opcodes Traced list in EIP-7906 so that CALL is listed with the correct opcode 0xF1 and leaves all other opcode values unchanged.