### PR TITLE
Update EIP-8024: bytecode is missing one 0x6000 to match test case + description

### DIFF
--- a/EIPS/eip-8024.md
+++ b/EIPS/eip-8024.md
@@ -180,7 +180,7 @@ This has no effect on contracts that would never attempt to execute the opcodes 
 - `600160008080808080808080808080808080806002e700` results in 18 stack items, the top of the stack valued 1, the bottom of the stack valued 2, the rest valued 0
   - `600160008080808080808080808080808080806002e7` at the end of the code is equivalent to above
 - `600060016002e801` results in 3 stack items, from top to bottom: [2, 0, 1]
-- `600060006000600060006000600060006000600060006000600060006000600060006000600060006000600060006000600060006000600060016002e8` results in 30 stack items, the top of the stack valued 2, the bottom of the stack valued 1, the rest valued 0
+- `60006000600060006000600060006000600060006000600060006000600060006000600060006000600060006000600060006000600060006000600060016002e8` results in 30 stack items, the top of the stack valued 2, the bottom of the stack valued 1, the rest valued 0
 - `e75b` reverts 
 - `600456e65b` executes successfully (`PUSH 04 JUMP INVALID_DUPN JUMPDEST`)
 - `600060006000e80115` results in 3 stack items, the top of the stack valued 1, the rest valued 0


### PR DESCRIPTION
In writing a test case for this, the bytecode here seemed off. Is this what was meant [here](https://github.com/ethereum/EIPs/pull/11095) @jrhea ? 👀

edit: looking into this further tomorrow... closing for now