### PR TITLE
Update EIP-7723: Update EIP-7723 with clearer SFI criteria

### DIFF
--- a/EIPS/eip-7723.md
+++ b/EIPS/eip-7723.md
@@ -70,15 +70,15 @@ At any time during the network upgrade planning process, client developers **MAY
 
 ### Scheduled for Inclusion 
 
-When client teams agree to implement a Core EIP in the **next** Upgrade Devnet, the EIP **SHOULD** move to the `Scheduled for Inclusion` stage, and the Upgrade Meta EIP **SHOULD** be updated to reflect this. Non-Core EIPs **SHOULD** move to `Scheduled for Inclusion` when client teams agree to immediately prioritize their implementation. 
+An EIP **MAY** be moved to `Scheduled for Inclusion` when:
+1. The EIP has been included in at least one upgrade devnet, **AND**
+2. Client developers agree there are no remaining implementation complexity or testing surface concerns or unknowns.
 
-An EIP **MUST** have a Python implementation accompanied by tests in [execution-specs](https://github.com/ethereum/execution-specs/blob/78fb726158c69d8fa164e28f195fabf6ab59b915/README.md), submitted as an open PR or merged to the `devnets/upgradeName/version` branch of the repository. Client developers **MAY** decide to allow an EIP to be moved to `Scheduled for Inclusion` without an [execution-specs](https://github.com/ethereum/execution-specs/blob/78fb726158c69d8fa164e28f195fabf6ab59b915/README.md) implementation, but the tests are strictly mandatory.
+Devnet scoping decisions inclusion alone does not constitute SFI. SFI decisions **SHOULD** be made on ACDE or ACDC.
 
-Any updates to an EIP that is already at this stage **MUST** be accompanied by appropriate updates to its implementation and tests in [execution-specs](https://github.com/ethereum/execution-specs/blob/78fb726158c69d8fa164e28f195fabf6ab59b915/README.md) if deemed necessary by client developers.
+An EIP **MUST** have a Python implementation accompanied by tests in [execution-specs](https://github.com/ethereum/execution-specs), submitted as an open PR or merged to the `devnets/upgradeName/version` branch of the repository. Client developers **MAY** decide to allow an EIP to be moved to `Scheduled for Inclusion` without an [execution-specs](https://github.com/ethereum/execution-specs) implementation, but the tests are strictly mandatory. Any updates to an EIP at this stage **MUST** be accompanied by appropriate updates to its implementation and tests if deemed necessary by client developers.
 
-`Scheduled for Inclusion` signals that implementation and testing work are underway. The EIP **SHOULD** be included in the network upgrade if no issues arise. The latest Upgrade Devnet must contain all `Scheduled for Inclusion` Core EIPs.
-
-An EIP **MAY** be moved from `Scheduled for Inclusion` to `Declined for Inclusion` if client teams are against including the EIP in the network upgrade. An EIP **MAY** also be moved from `Scheduled for Inclusion` to `Considered for Inclusion` if client teams are in favor of including the EIP in the network upgrade but cannot commit to including it in the **next** Upgrade Devnet.
+`Scheduled for Inclusion` signals that implementation and testing have demonstrated stability. The EIP **SHOULD** be included in the network upgrade if no issues arise. The latest upgrade devnet **MUST** contain all `Scheduled for Inclusion` Core EIPs. An EIP **MAY** be moved from `Scheduled for Inclusion` to `Declined for Inclusion` if issues arise during continued testing or if upgrade scope constraints require it.
 
 ### Included
 


### PR DESCRIPTION
testing and devnet scoping should follow a priority list set by ACD{C/E} but ACDT should have flexibility in choosing from those priorities, depending on testing realities

the current definition creates ambiguity about whether or not these scoping decisions constitute "SFI" status. this removes that ambiguity without needlessly constraining ACDT to decisions that should be made on Thursday calls

this should be accompanied by development of a predictable process for creating that priority list with sign-off by ACD{C/E}