### PR TITLE
Update EIP-8125: fix transient opcode name

### DIFF
--- a/EIPS/eip-8125.md
+++ b/EIPS/eip-8125.md
@@ -119,7 +119,7 @@ The call rules should follow `SSTORE` and `SLOAD`.
 
 The gas rules should follow the conventions in [EIP-2929](./eip-2929.md) and [EIP-2200](./eip-2200.md) referencing `SSTORE` and `SLOAD`, except that:
 
-- The gas costs should be much lower than `SSTORE` and `SLOAD`, but higher than `TSLOAD` and `TSTORE`
+- The gas costs should be much lower than `SSTORE` and `SLOAD`, but higher than `TLOAD` and `TSTORE`
 - No refunds are given for clearing temporary storage
 - `TMPLOAD` MAY perform up to 2 storage reads (current then previous). Gas MUST account for this behaviour.
 - Deletion in `TMPSTORE` is more expensive than creation/modification as the storage root of both system accounts are updated. Gas MUST account for this behaviour.


### PR DESCRIPTION
The EIP-8125 gas rules referred to a non-existent opcode TSLOAD instead of the standardized transient storage opcode TLOAD from EIP-1153, making the spec inconsistent with the rest of the repo and the wider ecosystem.