### PR TITLE
Update EIP-2926: Fix grammar error in First instruction offset section

### DIFF
--- a/EIPS/eip-2926.md
+++ b/EIPS/eip-2926.md
@@ -103,7 +103,7 @@ The current recommended chunk size of 31 bytes has been selected based on a few 
 
 ### First instruction offset
 
-The `firstInstructionOffset` field allows safe jumpdest analysis when a client doesn't have all the chunks, e.g. a stateless clients receiving block witnesses.
+The `firstInstructionOffset` field allows safe jumpdest analysis when a client doesn't have all the chunks, e.g. a stateless client receiving block witnesses.
 
 Note: there could be an edge case when computing FIO for the chunks where the data bytes at the end of a bytecode (last chunk) resemble a multi-byte instruction. This case can be safely ignored.
 


### PR DESCRIPTION
Fixed grammatical error in the Rationale section.
