### PR TITLE
Update EIP-8038: Remove incorrect requires header

### DIFF
--- a/EIPS/eip-8038.md
+++ b/EIPS/eip-8038.md
@@ -8,7 +8,6 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2025-10-03
-requires: 2926, 7928, 8032
 ---
 
 ## Abstract


### PR DESCRIPTION
Removes EIP-2926, EIP-7928, and EIP-8032 from the requires header, as they are interaction notes rather than implementation dependencies.