### PR TITLE
Update EIP-8052: Add EIP-7932 to requires header

### DIFF
--- a/EIPS/eip-8052.md
+++ b/EIPS/eip-8052.md
@@ -8,6 +8,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2025-10-17
+requires: 7932
 ---
 
 ## Abstract


### PR DESCRIPTION
Adds EIP-7932 to the requires header, as EIP-8052 directly uses the AlgorithmicTransaction container and verification model defined in EIP-7932.