### PR TITLE
Update EIP-7928: Clarify anti-dos measure for invalid, bloated BALs

### DIFF
--- a/EIPS/eip-7928.md
+++ b/EIPS/eip-7928.md
@@ -556,10 +556,10 @@ To mitigate this, clients SHOULD enforce a gas-budget feasibility check at trans
 The following invariant must hold:
 
 ```
-G_remaining >= R_remaining * 2100
+G_remaining >= R_remaining * 2000
 ```
 
-Where 2100 is the minimum gas cost for a cold `SLOAD`. If this check fails, the block can be rejected immediately as invalid, since insufficient gas remains to access the declared reads. This check SHOULD be performed periodically (e.g., every 8 transactions) to enable early rejection without impacting parallel execution.
+Where 2000 is the minimum gas cost for a storage read (via [EIP-2930](./eip-2930.md) access lists: 1900 upfront + 100 warm read). If this check fails, the block can be rejected immediately as invalid, since insufficient gas remains to access the declared reads. This check SHOULD be performed periodically (e.g., every 8 transactions) to enable early rejection without impacting parallel execution.
 
 ## Copyright
 


### PR DESCRIPTION
Adds a non-consensus security consideration to protect clients from DoS via inflated BALs.

Problem: Since storage_reads aren't mapped to transaction indices, a malicious proposer can declare phantom storage reads that are never accessed. This forces clients into unnecessary I/O prefetching and significant data download, with the block only rejectable after full execution.

Solution: Clients should enforce a gas-budget feasibility check at transaction boundaries:
`G_remaining >= R_remaining * 2000`

If remaining gas cannot cover the minimum cost of accessing remaining declared reads, the block is immediately invalid. This enables early rejection without impacting parallel execution.
