### PR TITLE
Update EIP-7976: Add EIP-3860 to requires header

### DIFF
--- a/EIPS/eip-7976.md
+++ b/EIPS/eip-7976.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2025-06-18
-requires: 7623
+requires: 3860, 7623
 ---
 
 ## Abstract


### PR DESCRIPTION
Adds EIP-3860 to the requires header, as EIP-7976 directly references the INITCODE_WORD_COST constant defined in EIP-3860.