### PR TITLE
Update EIP-7928: clarify stf without BAL

### DIFF
--- a/EIPS/eip-7928.md
+++ b/EIPS/eip-7928.md
@@ -292,7 +292,7 @@ The EL MUST retain BALs for at least the duration of the weak subjectivity perio
 
 The state transition function must validate that the provided BAL matches the actual state accesses.
 
-**Implementation Note:** The BAL itself does not need to enter the state transition function. Implementations MAY validate by: (1) including the `block_access_list_hash` in the block header, (2) generating a virtual BAL during transaction execution, (3) hashing the virtual BAL and comparing against the header hash. This is the approach used in the execution-specs reference implementation.
+**Implementation Note:** The BAL itself does not need to enter the state transition function. Implementations MAY validate by generating a virtual BAL during execution, hashing it, and comparing against the `block_access_list_hash` in the header. This is the approach used in the execution-specs reference implementation.
 
 ```python 
 def validate_block(execution_payload, block_header):


### PR DESCRIPTION
Clarify that BAL validation can occur via hash comparison of a virtual BAL generated during execution, matching the execution-specs approach.
