### PR TITLE
Update EIP-7979: Fix Python syntax errors in validate_code function

### DIFF
--- a/EIPS/eip-7979.md
+++ b/EIPS/eip-7979.md
@@ -382,17 +382,17 @@ We assume that instruction validation and destination analysis has been done, an
             # check stack height and return if we have been here before
             stack_depth = sp - bp
             max_depth = max + stack_depth
-            if max_depth > 1024
+            if max_depth > 1024:
                 return max_depth, false
-            if stack_depths[pc] {
+            if stack_depths[pc]:
                 if stack_depth != stack_depths[pc]:
                     return 0, false
                 if opcode == ENTERSUB:
                     return max_depths[pc], true
-                else
-                    return max_depth, true
                 else:
-                    stack_depths[pc] = stack_depth
+                    return max_depth, true
+            else:
+                stack_depths[pc] = stack_depth
 
             if is_terminator(opcode):
                 return max_depth, true
@@ -405,9 +405,9 @@ We assume that instruction validation and destination analysis has been done, an
 
                 # validate and track maximum height
                 max_depth, valid = validate_code(jumpdest, 0, sp - bp, max)
-                if !valid:
+                if not valid:
                    return max_depth, false
-                max_depths[jumpdest] = max_depth;
+                max_depths[jumpdest] = max_depth
 
             elif opcode == RETURNSUB:
 
@@ -427,20 +427,20 @@ We assume that instruction validation and destination analysis has been done, an
 
                 # recurse to validate true side of conditional
                 max_depth, valid = validate_code(jumpdest, sp, bp)
-                if !valid:
+                if not valid:
                     return max_depth, false
 
             # apply instructions to stack
             sp -= removed_items(opcode)
-            if sp < 0
-                return so, false
+            if sp < 0:
+                return sp, false
             sp += added_items(opcode)
 
             # Skip opcode and any immediate data
             pc += 1 + immediate_size(opcode)
 
         max_depth = max + stack_depth
-        if (max_depth > 1024)
+        if (max_depth > 1024):
             return max_depth, false
         return max_depth, true
 ```


### PR DESCRIPTION
Fixes multiple Python syntax errors in the validate_code pseudocode that would prevent the code from running, including missing colons, incorrect operators, duplicate else statements, and a variable name typo.