### PR TITLE
Update EIP-8052: Fix array indexing in hash-to-point functions

### DIFF
--- a/EIPS/eip-8052.md
+++ b/EIPS/eip-8052.md
@@ -206,7 +206,7 @@ def FALCON_HASH_TO_POINT_SHAKE256(message: bytes32, signature: bytes) -> bool:
     while i < n do
         t = SHAKE256_extract(16)
         if t < 61445 then
-            c_i = t mod q
+            c[i] = t mod q
             i = i + 1
     return c
 ```
@@ -242,7 +242,7 @@ def FALCON_HASH_TO_POINT_KECCAKPRNG(message: bytes32, signature: bytes) -> bool:
     while i < n do
         t = KeccakPRNG_extract(16)
         if t < 61445 then
-            c_i = t mod q
+            c[i] = t mod q
             i = i + 1
     return c
 ```


### PR DESCRIPTION
Corrects array assignment from c_i to c[i] in both SHAKE256 and KeccakPRNG hash-to-point pseudocode, ensuring values are properly stored in the array rather than creating new variables. 