### PR TITLE
Update EIP-7928: cap max items in BAL

### DIFF
--- a/EIPS/eip-7928.md
+++ b/EIPS/eip-7928.md
@@ -126,7 +126,7 @@ Where:
 - `available_gas = block_gas_limit - tx_count * TX_BASE_COST`
 - `system_allowance = (15 + 3 * (MAX_WITHDRAWAL_REQUESTS_PER_BLOCK + MAX_CONSOLIDATION_REQUESTS_PER_BLOCK)) * ITEM_COST`
 
-The `storage_reads` is the total number of storage accesses across all accounts, and `addresses` is the total number of unique addresses accessed in the block. The `system_allowance` term accounts for system contract accesses that occur outside of user transactions.
+The `storage_reads` is the total number of storage accesses across all accounts, and `addresses` is the total number of unique addresses accessed in the block. The `system_allowance` term accounts for system contract accesses that occur outside of user transactions. `MAX_WITHDRAWAL_REQUESTS_PER_BLOCK` is defined in [EIP-7002](./eip-7002.md) and `MAX_CONSOLIDATION_REQUESTS_PER_BLOCK` is defined in [EIP-7251](./eip-7251.md).
 
 ### Gas Validation Before State Access
 


### PR DESCRIPTION
Setting a cap on what the BAL can realistically contain helps wrt DoS.

Execution Specs:
https://github.com/ethereum/execution-specs/pull/2109