### PR TITLE
Update EIP-7607: Move to Final

### DIFF
--- a/EIPS/eip-7607.md
+++ b/EIPS/eip-7607.md
@@ -4,8 +4,7 @@ title: Hardfork Meta - Fusaka
 description: EIPs included in the Fulu/Osaka Ethereum network upgrade.
 author: Tim Beiko (@timbeiko), Alex Stokes (@ralexstokes), Ansgar Dietrichs (@adietrichs)
 discussions-to: https://ethereum-magicians.org/t/eip-7607-fusaka-meta-eip/18439
-status: Last Call
-last-call-deadline: 2025-10-28
+status: Final
 type: Meta
 created: 2024-02-01
 requires: 7600, 7723
@@ -17,9 +16,9 @@ This Meta EIP lists the EIPs formally Scheduled for Inclusion in the Fulu/Osaka 
 
 ## Specification
 
-Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Proposed for Inclusion` and `Declined for Inclusion` can be found in [EIP-7723](./eip-7723.md).
+Definitions for `Included`, `Considered for Inclusion`, `Proposed for Inclusion` and `Declined for Inclusion` can be found in [EIP-7723](./eip-7723.md).
 
-### EIPs Scheduled for Inclusion
+### EIPs Included
 
 #### Core EIPs
 


### PR DESCRIPTION
With Fusaka activated on mainnet on December 3, 2025, this Meta EIP should be moved to Final.

This PR also updates "Scheduled for Inclusion" → "Included" per [EIP-7723](https://eips.ethereum.org/EIPS/eip-7723).

All included EIPs must be moved to Final first:

### Core EIPs

- [ ] [EIP-7594](./eip-7594.md): PeerDAS - Peer Data Availability Sampling
- [ ] [EIP-7823](./eip-7823.md): Set upper bounds for MODEXP
- [ ] [EIP-7825](./eip-7825.md): Transaction Gas Limit Cap
- [ ] [EIP-7883](./eip-7883.md): ModExp Gas Cost Increase
- [ ] [EIP-7917](./eip-7917.md): Deterministic proposer lookahead
- [ ] [EIP-7918](./eip-7918.md): Blob base fee bounded by execution cost
- [ ] [EIP-7934](./eip-7934.md): RLP Execution Block Size Limit
- [ ] [EIP-7939](./eip-7939.md): Count leading zeros (CLZ) opcode
- [ ] [EIP-7951](./eip-7951.md): Precompile for secp256r1 Curve Support

### Other EIPs

- [ ] [EIP-7892](./eip-7892.md): Blob Parameter Only Hardforks
- [ ] [EIP-7642](./eip-7642.md): eth/69 - Drop pre-merge fields
- [ ] [EIP-7910](./eip-7910.md): eth_config JSON-RPC Method
- [ ] [EIP-7935](./eip-7935.md): Set default gas limit to 60M