### PR TITLE
Update EIP-7607: Move to Final

### DIFF
--- a/EIPS/eip-7607.md
+++ b/EIPS/eip-7607.md
@@ -7,7 +7,7 @@ discussions-to: https://ethereum-magicians.org/t/eip-7607-fusaka-meta-eip/18439
 status: Final
 type: Meta
 created: 2024-02-01
-requires: 7600, 7723
+requires: 7600
 ---
 
 ## Abstract

--- a/EIPS/eip-7607.md
+++ b/EIPS/eip-7607.md
@@ -4,8 +4,7 @@ title: Hardfork Meta - Fusaka
 description: EIPs included in the Fulu/Osaka Ethereum network upgrade.
 author: Tim Beiko (@timbeiko), Alex Stokes (@ralexstokes), Ansgar Dietrichs (@adietrichs)
 discussions-to: https://ethereum-magicians.org/t/eip-7607-fusaka-meta-eip/18439
-status: Last Call
-last-call-deadline: 2025-10-28
+status: Final
 type: Meta
 created: 2024-02-01
 requires: 7600, 7723
@@ -13,13 +12,11 @@ requires: 7600, 7723
 
 ## Abstract
 
-This Meta EIP lists the EIPs formally Scheduled for Inclusion in the Fulu/Osaka network upgrade. It follows the Pectra upgrade, documented in [EIP-7600](./eip-7600.md)
+This Meta EIP lists the EIPs included in the Fulu/Osaka network upgrade. It follows the Pectra upgrade, documented in [EIP-7600](./eip-7600.md).
 
 ## Specification
 
-Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Proposed for Inclusion` and `Declined for Inclusion` can be found in [EIP-7723](./eip-7723.md).
-
-### EIPs Scheduled for Inclusion
+### Included EIPs
 
 #### Core EIPs
 

--- a/EIPS/eip-7607.md
+++ b/EIPS/eip-7607.md
@@ -7,7 +7,7 @@ discussions-to: https://ethereum-magicians.org/t/eip-7607-fusaka-meta-eip/18439
 status: Final
 type: Meta
 created: 2024-02-01
-requires: 7600
+requires: 7594, 7600, 7642, 7823, 7825, 7883, 7910, 7917, 7918, 7934, 7935, 7939, 7951, 7892
 ---
 
 ## Abstract

--- a/EIPS/eip-7607.md
+++ b/EIPS/eip-7607.md
@@ -7,7 +7,7 @@ discussions-to: https://ethereum-magicians.org/t/eip-7607-fusaka-meta-eip/18439
 status: Final
 type: Meta
 created: 2024-02-01
-requires: 7594, 7600, 7642, 7823, 7825, 7883, 7910, 7917, 7918, 7934, 7935, 7939, 7951, 7892
+requires: 7594, 7600, 7642, 7823, 7825, 7883, 7892, 7910, 7917, 7918, 7934, 7935, 7939, 7951
 ---
 
 ## Abstract


### PR DESCRIPTION
Fusaka is live, its Meta EIP should be moved to FInal

- Status: Last Call → Final
- Removed `last-call-deadline` header
- "formally Scheduled for Inclusion" → "included"
- Removed definitions line (CFI/PFI/DFI reference to EIP-7723)
- Section header: "EIPs Included" → "Included EIPs" (matches Pectra/Dencun format)

Most EIPs have already been moved to Final, with the exception of PeerDAS, [7918](https://eips.ethereum.org/EIPS/eip-7918)~~, and 7723~~. Will use this PR to track.

### Dependencies
- ~[ ] [EIP-7723](https://eips.ethereum.org/EIPS/eip-7723): Network Upgrade Inclusion Stages [ [PR](https://github.com/ethereum/EIPs/pull/11239) ]~ 
  - removed from requirements list as it's an entirely procedural EIP not in Living or Final and with open questions

### Core EIPs
- [x] [EIP-7594](https://eips.ethereum.org/EIPS/eip-7594): PeerDAS [ [PR](https://github.com/ethereum/EIPs/pull/10935) ]
  - ~~potentially blocked by #10736~~ 
  - edit: solved by https://github.com/ethereum/EIPs/pull/11238
- [x] [EIP-7823](https://eips.ethereum.org/EIPS/eip-7823): Set upper bounds for MODEXP [ [PR](https://github.com/ethereum/EIPs/pull/11113) ]
- [x] [EIP-7825](https://eips.ethereum.org/EIPS/eip-7825): Transaction Gas Limit Cap [ [PR](https://github.com/ethereum/EIPs/pull/11113) ]
- [x] [EIP-7883](https://eips.ethereum.org/EIPS/eip-7883): ModExp Gas Cost Increase [ [PR](https://github.com/ethereum/EIPs/pull/11113) ]
- [x] [EIP-7917](https://eips.ethereum.org/EIPS/eip-7917): Deterministic proposer lookahead [ [PR](github.com/ethereum/EIPs/pull/10915) ]
- [x] [EIP-7918](https://eips.ethereum.org/EIPS/eip-7918): Blob base fee bounded by execution cost [ [PR](https://github.com/ethereum/EIPs/pull/10891) ]
  - blocked by PeerDAS PR #10935
- [x] [EIP-7934](https://eips.ethereum.org/EIPS/eip-7934): RLP Execution Block Size Limit [ [PR](https://github.com/ethereum/EIPs/pull/11112) ]
- [x] [EIP-7939](https://eips.ethereum.org/EIPS/eip-7939): Count leading zeros (CLZ) opcode [ [PR](https://github.com/ethereum/EIPs/pull/11113) ]
- [x] [EIP-7951](https://eips.ethereum.org/EIPS/eip-7951): Precompile for secp256r1 Curve Support [ [PR](https://github.com/ethereum/EIPs/pull/11113) ]

### Other EIPs
- [x] [EIP-7892](https://eips.ethereum.org/EIPS/eip-7892): Blob Parameter Only Hardforks [ [PR](https://github.com/ethereum/EIPs/pull/11152) ]
- [x] [EIP-7642](https://eips.ethereum.org/EIPS/eip-7642): eth/69 - Drop pre-merge fields [ [PR](https://github.com/ethereum/EIPs/pull/9857) ]
- [x] [EIP-7910](https://eips.ethereum.org/EIPS/eip-7910): eth_config JSON-RPC Method [ [PR](https://github.com/ethereum/EIPs/pull/11135) ]
- [x] [EIP-7935](https://eips.ethereum.org/EIPS/eip-7935): Set default gas limit to 60M [ [PR](https://github.com/ethereum/EIPs/pull/11134) ]

Supersedes #11153 (thank you @MrEeeeet111 !)