### PR TITLE
Update EIP-7594: Fix upper bound probability

### DIFF
--- a/EIPS/eip-7594.md
+++ b/EIPS/eip-7594.md
@@ -118,7 +118,7 @@ For mainnet parameters given in the specs and assuming 10,000 nodes on the netwo
 
 | $\epsilon$ | $n\epsilon$ (target nodes) | Upper bound on $\mathbb{P}$ |
 |:----------:|:-------------------:|:---------------------------:|
-| 0.01        | 100                | $10^{38.36}$                |
+| 0.01        | 100                | $1$                         |
 | 0.02        | 200                | $10^{-20.04}$               |
 | 0.03        | 300                | $10^{-101.55}$              |
 | 0.04        | 400                | $10^{-198.24}$              |


### PR DESCRIPTION
Just set it the first case to 1 instead of a useless upper bound > 1