### PR TITLE
Update EIP-7723: Move to Living

### DIFF
--- a/EIPS/eip-7723.md
+++ b/EIPS/eip-7723.md
@@ -4,8 +4,7 @@ title: Network Upgrade Inclusion Stages
 description: Overview of the various stages Core EIPs go through before their activation in network upgrades.
 author: Tim Beiko (@timbeiko), Alex Stokes (@ralexstokes)
 discussions-to: https://ethereum-magicians.org/t/eip-7723-network-upgrade-inclusion-stages/20281
-status: Last Call
-last-call-deadline: 2025-04-01
+status: Living
 type: Meta
 created: 2024-06-12
 ---


### PR DESCRIPTION
EIP-7723 was listed as a requirement for EIP-7607, so it will need either Living or Final status in order for the Fusaka Meta to be [moved to Final](https://github.com/ethereum/EIPs/pull/11237)

Living makes sense as a process doc and to match EIP-1