### PR TITLE
Update EIP-7805: update engine API changes

### DIFF
--- a/EIPS/eip-7805.md
+++ b/EIPS/eip-7805.md
@@ -108,7 +108,7 @@ For each transaction `T` in ILs, perform the following:
 We make the following changes to the engine API:
 
 - Add `engine_getInclusionListV1` endpoint to retrieve an IL from the `ExecutionEngine`.
-- Add `engine_updatePayloadWithInclusionListV1` endpoint to update a payload with the IL that should be used to build the block. This takes as an argument an 8-byte `payloadId` of the ongoing payload build process, along with the IL itself.
+- Modify `engine_forkchoiceUpdated` endpoint to update a payload with the IL that should be used to build the block. `payloadAttributes` is extended to include the IL.
 - Modify `engine_newPayload` endpoint to include a parameter for transactions in ILs determined by the IL committee member. If the IL is not satisfied an `INCLUSION_LIST_UNSATISFIED` status must be returned.
 
 #### IL Building


### PR DESCRIPTION
This PR updates the engine API changes section of EIP-7805 according to the spec changes.