### PR TITLE
Update EIP-7749: clarify `wallet_signIntendedValidatorData` params format

### DIFF
--- a/EIPS/eip-7749.md
+++ b/EIPS/eip-7749.md
@@ -52,6 +52,8 @@ interface WalletSignIntendedValidatorDataParams {
 }
 ```
 
+The `wallet_signIntendedValidatorData` JSON-RPC method MUST be called with `params` as an array of three items in the following order: `[signerAddress, validatorAddress, dataToSign]`. Implementations MUST NOT treat the parameters as a single object.
+
 
 1. `signerAddress` - 20-byte account address: The address signing the constructed message.
 2. `validatorAddress` - 20-byte account address: The intended validator address included in the message to sign.


### PR DESCRIPTION
Previously the specification defined a `WalletSignIntendedValidatorDataParams` interface, which looks like a single object parameter, while the JSON-RPC example used a positional `params` array. This ambiguity could lead implementers to send an object instead of the required array and produce incompatible implementations.