### PR TITLE
Update EIP-8123: Remove EIP-1474 from requires header

### DIFF
--- a/EIPS/eip-8123.md
+++ b/EIPS/eip-8123.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: Interface
 created: 2026-01-11
-requires: 1474, 7825
+requires: 7825
 ---
 
 ## Abstract


### PR DESCRIPTION
EIP-8123 adds a single RPC method `eth_txGasLimitCap` to query the transaction gas limit cap introduced by EIP-7825. It does not depend on EIP-1474 (RPC specification, currently Stagnant) as a technical requirement—the method is self-contained and only requires EIP-7825 for the gas limit cap concept itself.

Removing the stagnant EIP-1474 dependency clarifies that EIP-8123 is simply extending the RPC interface, not rebuilding or depending on the entire RPC specification.