### PR TITLE
Update EIP-7807: Remove EIP-7706 from requires header

### DIFF
--- a/EIPS/eip-7807.md
+++ b/EIPS/eip-7807.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2024-10-28
-requires: 6404, 6465, 6466, 7495, 7706, 7799
+requires: 6404, 6465, 6466, 7495, 7799
 ---
 
 ## Abstract


### PR DESCRIPTION
 EIP-7807 migrates execution blocks to SSZ format. It depends on EIP-6404 (SSZ transactions), EIP-6466 (SSZ receipts), EIP-6465 (SSZ withdrawals), EIP-7495 (SSZ ProgressiveContainer), and EIP-7799 (System logs).

  EIP-7706 (Separate gas type for calldata) is not referenced anywhere in the specification and is not a technical dependency for SSZ block migration. The EIP already handles gas through the `GasAmounts` structure which supports regular and blob gas, without requiring a separate calldata gas type.

  Removing EIP-7706 (currently Stagnant) clarifies the actual dependencies for SSZ execution blocks.