### PR TITLE
Update EIP-7612: Fix variable names in set_storage function

### DIFF
--- a/EIPS/eip-7612.md
+++ b/EIPS/eip-7612.md
@@ -131,7 +131,7 @@ def get_storage(state: State, address: Address, key: Bytes) -> U256:
 def set_storage(
     state: State, address: Address, key: Bytes, value: U256
 ) -> None:
-    state._overlay_tree.set(get_tree_key_for_storage_slot(addr, slot), value)
+    state._overlay_tree.set(get_tree_key_for_storage_slot(address, key), value)
 ```
 
 Add the following function which is used when storing a contract in the tree:


### PR DESCRIPTION
Corrects undefined variable names `addr` and `slot` to match function parameters `address` and `key`, preventing NameError in the code example.