### PR TITLE
Update EIP-8094: Add EIP-4844 to requires header

### DIFF
--- a/EIPS/eip-8094.md
+++ b/EIPS/eip-8094.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: Networking
 created: 2025-11-29
-requires: 7642
+requires: 4844, 7642
 ---
 
 ## Abstract


### PR DESCRIPTION
Adds EIP-4844 to the requires header, as the specification modifies EIP-4844's blob transaction propagation rules and relies on EIP-4844 concepts including type 3 transactions, sidecars, and vhashes.