### PR TITLE
Update EIP-8141: Add EIP-1559 to requires header

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2026-01-29
-requires: 2718, 4844
+requires: 1559, 2718, 4844
 ---
 
 ## Abstract


### PR DESCRIPTION
Adds EIP-1559 to the requires header, as the specification uses EIP-1559's max_priority_fee_per_gas and max_fee_per_gas fields in the transaction format and explicitly states that effective_gas_price is calculated per EIP-1559.