### PR TITLE
Update EIP-8046: Add EIP-1559 and EIP-2718 to requires header

### DIFF
--- a/EIPS/eip-8046.md
+++ b/EIPS/eip-8046.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2025-10-16
-requires: 7805
+requires: 1559, 2718, 7805
 ---
 
 ## Abstract


### PR DESCRIPTION
Adds EIP-1559 and EIP-2718 to the requires header, as the specification defines a new EIP-2718 transaction type (RANK_TX_TYPE) and modifies EIP-1559 transaction processing logic for the uniform price auction mechanism.