### PR TITLE
Update EIP-8058: Add EIP-2929 to requires header

### DIFF
--- a/EIPS/eip-8058.md
+++ b/EIPS/eip-8058.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2025-10-22
-requires: 2930
+requires: 2929, 2930
 ---
 
 ## Abstract


### PR DESCRIPTION
Adds EIP-2929 to the requires header, as the specification explicitly uses EIP-2929's warm/cold state access rules and accessed_addresses mechanism for gas cost accounting in the deduplication check.