### PR TITLE
Add EIP: Block Access List Sidecars

### DIFF
--- a/EIPS/eip-8146.md
+++ b/EIPS/eip-8146.md
@@ -1,9 +1,9 @@
 ---
-eip: 8143
+eip: 8146
 title: Block Access List Sidecars
 description: Decouple block access list propagation from execution payload envelopes
 author: Toni Wahrstätter (@nerolation), Raúl Kripalani (@raulk)
-discussions-to: https://ethereum-magicians.org/t/eip-8143-block-access-list-sidecars/
+discussions-to: https://ethereum-magicians.org/t/eip-8146-block-access-list-sidecars/27757
 status: Draft
 type: Standards Track
 category: Core
@@ -310,7 +310,7 @@ BAL availability is tracked as a dedicated `block_access_list_present` boolean i
 
 ### Dedicated Engine API Method
 
-The BAL is delivered to the EL exclusively via `engine_notifyBlockAccessListV1`, separate from `engine_newPayloadV5`. This enables early delivery: the BAL sidecar typically arrives before the execution payload envelope, so the EL can begin prefetching storage slots immediately, or start calculcating the post-state root. When the payload arrives later, `engine_newPayloadV5` proceeds without the BAL -- the EL already has it, matched by `blockHash`.
+The BAL is delivered to the EL exclusively via `engine_notifyBlockAccessListV1`, separate from `engine_newPayloadV5`. This enables early delivery: the BAL sidecar typically arrives before the execution payload envelope, so the EL can begin prefetching storage slots immediately, or start calculating the post-state root. When the payload arrives later, `engine_newPayloadV5` proceeds without the BAL -- the EL already has it, matched by `blockHash`.
 
 ### Data Retention
 


### PR DESCRIPTION
This PR adds a proposal for separating the BAL from the ExecutionPayload, allowing it to travel over the wire independently from the payload.
The BAL can be useful for prefetching or calculating the post-state root, even before the payload arrives, thus, having functionality to enable passing the BAL to the EL independently from the payload makes sense.

This also prepares BALs to be put into blobs at a later stage.