### PR TITLE
Update EIP-7607: Add all Fusaka EIPs to requires header

### DIFF
--- a/EIPS/eip-7607.md
+++ b/EIPS/eip-7607.md
@@ -8,7 +8,7 @@ status: Last Call
 last-call-deadline: 2025-10-28
 type: Meta
 created: 2024-02-01
-requires: 7600, 7723
+requires: 7594, 7600, 7642, 7723, 7823, 7825, 7883, 7892, 7910, 7917, 7918, 7934, 7935, 7939, 7951
 ---
 
 ## Abstract


### PR DESCRIPTION
 EIP-7607 is the Meta EIP for the Fusaka hardfork. The requires header was incomplete—it only listed EIP-7600 (Pectra) and EIP-7723 (Meta EIP process), but didn't include the actual EIPs scheduled for inclusion in Fusaka.

  This PR adds all EIPs listed in the "EIPs Scheduled for Inclusion" section to the requires header: 7594, 7642, 7823, 7825, 7883, 7892, 7910, 7917, 7918, 7934, 7935, 7939, 7951.

  This aligns the requires header with the actual content of the Meta EIP.