### PR TITLE
Update EIP-7773: Add scheduled EIPs to requires header

### DIFF
--- a/EIPS/eip-7773.md
+++ b/EIPS/eip-7773.md
@@ -7,7 +7,7 @@ discussions-to: https://ethereum-magicians.org/t/eip-7773-glamsterdam-network-up
 status: Draft
 type: Meta
 created: 2024-09-26
-requires: 7607, 7723
+requires: 7607, 7723, 7732, 7928
 ---
 
 ## Abstract


### PR DESCRIPTION
EIP-7773 is the Meta EIP for the Glamsterdam hardfork. The requires header was incomplete—it only listed EIP-7607 (Fusaka) and EIP-7723 (Meta EIP process), but didn't include the EIPs scheduled for inclusion in Glamsterdam.
  This PR adds the EIPs listed in the "EIPs Scheduled for Inclusion" section to the requires header: 7732 (Enshrined Proposer-Builder Separation) and 7928 (Block-Level Access Lists).
  