### PR TITLE
Update EIP-8051: align MLDSA precompile names

### DIFF
--- a/EIPS/eip-8051.md
+++ b/EIPS/eip-8051.md
@@ -22,8 +22,8 @@ This proposal adds precompiled contracts that perform signature verifications us
 
 Two precompile contracts are specified:
 
-* `VERIFY_MLDSA` — verifies a ML-DSA signature compliant to FIPS-204.
-* `VERIFY_MLDSA_ETH` — verifies a ML-DSA-ETH signature replacing SHAKE256 with a more efficient hash function, deviating from FIPS-204.
+* `MLDSA_VERIFY` — verifies a ML-DSA signature compliant to FIPS-204.
+* `MLDSA_VERIFY_ETH` — verifies a ML-DSA-ETH signature replacing SHAKE256 with a more efficient hash function, deviating from FIPS-204.
 
 ## Motivation
 
@@ -102,7 +102,7 @@ The values of the coefficients as well as the position in the coefficients list 
 Verifying a ML-DSA signature follows Algorithm 8 of FIPS-204, with `A_hat` of the public key stored in expanded format, and `t1` stored in the NTT domain.
 
 ```python
-def VERIFY_MLDSA(public_key, message, signature) -> bool:
+def MLDSA_VERIFY(public_key, message, signature) -> bool:
     A_hat, tr, t1 are decoded from public_key
     c_tilde, z, h are decoded from signature
     if h is not properly encoded, return False
@@ -127,7 +127,7 @@ The verification of ML-DSA-ETH signatures follows the same algorithm with anothe
 * A variant of `sample_in_ball` is defined using KeccakPRNG. The only difference from Algorithm 29 of FIPS-204 is that it requires a `flip()` between lines 3 and 4 so that it initializes the counter to `0` before starting squeezing. Note that this can be implemented in `absorb()` and `squeeze()` so that the same interface can be used as in SHAKE256.
 
 ```python
-def VERIFY_MLDSA_ETH(public_key, message, signature) -> bool:
+def MLDSA_VERIFY_ETH(public_key, message, signature) -> bool:
     A_hat, tr, t1 are decoded from public_key
     c_tilde, z, h are decoded from signature
     if h is not properly encoded, return False
@@ -154,7 +154,7 @@ def VERIFY_MLDSA_ETH(public_key, message, signature) -> bool:
 
 ### ML-DSA precompiled contract
 
-The precompiled contract VERIFY_MLDSA is proposed with the following input and outputs, which are big-endian values:
+The precompiled contract MLDSA_VERIFY is proposed with the following input and outputs, which are big-endian values:
 
 * **Input data**
     * 32 bytes for the message
@@ -175,7 +175,7 @@ The precompiled contract VERIFY_MLDSA is proposed with the following input and o
 
 ### ML-DSA-ETH precompiled contract
 
-The precompiled contract VERIFY_MLDSA_ETH is proposed with the following input and outputs, which are big-endian values:
+The precompiled contract MLDSA_VERIFY_ETH is proposed with the following input and outputs, which are big-endian values:
 
 * **Input data**
     * 32 bytes for the message
@@ -196,7 +196,7 @@ The precompiled contract VERIFY_MLDSA_ETH is proposed with the following input a
 
 ### Precompiled contract gas usage
 
-The cost of the **VERIFY_MLDSA** and **VERIFY_MLDSA_ETH** functions is dominated by the call to the NTTs, and the required hash calls for sampling in the ball (and for μ and the final check).
+The cost of the **MLDSA_VERIFY** and **MLDSA_VERIFY_ETH** functions is dominated by the call to the NTTs, and the required hash calls for sampling in the ball (and for μ and the final check).
 It represents in average 5 calls to the hash function. Taking linearly the cost of keccak256, and avoiding the context switching it represents 4500 gas.
 
 ### Compliance with EIP-7932
@@ -227,7 +227,7 @@ verify(signature_info: bytes, payload_hash: Hash32) -> Bytes:
     pubkey_hash  = signature_info[2421:2441]
     assert version == 0xD1
     pubkey = lookup_pubkey(pubkey_hash)
-    assert VERIFY_MLDSA(pubkey, payload_hash, signature)
+    assert MLDSA_VERIFY(pubkey, payload_hash, signature)
     return pubkey
 ```
 
@@ -241,7 +241,7 @@ verify(signature_info: bytes, payload_hash: Hash32) -> Bytes:
     pubkey_hash  = signature_info[2421:2441]
     assert version == 0xD2
     pubkey = lookup_pubkey(pubkey_hash)
-    assert VERIFY_MLDSA_ETH(pubkey, payload_hash, signature)
+    assert MLDSA_VERIFY_ETH(pubkey, payload_hash, signature)
     return pubkey
 ```
 


### PR DESCRIPTION
Previously the EIP-8051 spec mixed two naming styles for the same precompiles (MLDSA_VERIFY / MLDSA_VERIFY_ETH vs VERIFY_MLDSA / VERIFY_MLDSA_ETH), which could confuse implementers about the canonical identifiers.
This change makes the naming consistent by using MLDSA_VERIFY and MLDSA_VERIFY_ETH everywhere: in the precompile list, in the precompile specification text, in the verification pseudocode, and in the EIP-7932 integration examples.