### PR TITLE
Update EIP-8051: Fix precompile naming in specification table

### DIFF
--- a/EIPS/eip-8051.md
+++ b/EIPS/eip-8051.md
@@ -49,7 +49,7 @@ The following specification provides two precompiled contracts:
 
 |**Precompiled contract**|**1**|**2**|
 |-|-|-|
-|**Name**|`MLDSA_VERIFY`|`MLDSA_VERIFY_ETH`|
+|**Name**|`VERIFY_MLDSA`|`VERIFY_MLDSA_ETH`|
 |**Address**| 0x12| 0x13|
 |**Gas cost**|  4500| 4500|
 


### PR DESCRIPTION
The specification table (line 52) incorrectly names the precompiles as `MLDSA_VERIFY` and `MLDSA_VERIFY_ETH`, while the rest of the document consistently uses `VERIFY_MLDSA` and `VERIFY_MLDSA_ETH`:

  - Abstract (lines 25-26): defines them as `VERIFY_MLDSA` and `VERIFY_MLDSA_ETH`
  - Function definitions (lines 105, 130): `def VERIFY_MLDSA(` and `def VERIFY_MLDSA_ETH(`
  - Code examples (lines 230, 244): `assert VERIFY_MLDSA(` and `assert VERIFY_MLDSA_ETH(`
  - Section headers (lines 157, 178): reference `VERIFY_MLDSA` and `VERIFY_MLDSA_ETH`