### PR TITLE
Update EIP-7976: Increase floor data cost to 64/64

### DIFF
--- a/EIPS/eip-7976.md
+++ b/EIPS/eip-7976.md
@@ -1,7 +1,7 @@
 ---
 eip: 7976
 title: Increase Calldata Floor Cost
-description: Increase the calldata floor cost to 15/60 gas per byte to reduce maximum block size
+description: Increase the calldata floor cost to 64/64 gas per byte to reduce maximum block size
 author: Toni Wahrstätter (@nerolation)
 discussions-to: https://ethereum-magicians.org/t/eip-7976-further-increase-calldata-cost/24597
 status: Draft
@@ -13,13 +13,13 @@ requires: 7623
 
 ## Abstract
 
-This EIP proposes an adjustment to calldata pricing by raising the floor cost from 10/40 to 15/60 gas per zero/non-zero calldata byte. This reduces the worst-case block size by ~33% with minimal impact.
+This EIP proposes an adjustment to calldata pricing by raising the floor cost from 10/40 to 64/64 gas per calldata byte. This reduces the worst-case block size by ~37% with minimal impact.
 
 ## Motivation
 
-While [EIP-7623](./eip-7623.md) successfully reduced the maximum possible block size by introducing a floor cost of 10/40 gas per byte for data-heavy transactions, continued increases in gas limit demands further optimization. The current floor cost still permits relatively large data-heavy payloads that contribute to block size variance.
+While [EIP-7623](./eip-7623.md) successfully reduced the maximum possible block size by introducing a floor cost of 10/40 gas per byte for data-heavy transactions, continued increases in gas limit demands further optimization. The current floor cost still permits relatively large data-heavy payloads that contribute to block size variance. With 64/64 pricing, a 10 MiB uncompressed execution payload would require ~671M gas instead of ~105M gas under 10/40 pricing, providing significant headroom for gas limit increases.
 
-By increasing the floor cost to 15/60 gas per byte, this proposal aims to:
+By increasing the floor cost to 64/64 gas per byte, this proposal aims to:
 
 - Further reduce the maximum possible block size for data-heavy transactions
 - Create additional headroom for potential block gas limit increases
@@ -31,9 +31,11 @@ By increasing the floor cost to 15/60 gas per byte, this proposal aims to:
 | Parameter                    | Value |
 | ---------------------------- | ----- |
 | `STANDARD_TOKEN_COST`        | `4`   |
-| `TOTAL_COST_FLOOR_PER_TOKEN` | `15`  |
+| `TOTAL_COST_FLOOR_PER_TOKEN` | `16`  |
 
 Let `tokens_in_calldata = zero_bytes_in_calldata + nonzero_bytes_in_calldata * 4`.
+
+Let `floor_tokens_in_calldata = (zero_bytes_in_calldata + nonzero_bytes_in_calldata) * 4`.
 
 Let `isContractCreation` be a boolean indicating the respective event.
 
@@ -51,20 +53,20 @@ tx.gasUsed = (
         STANDARD_TOKEN_COST * tokens_in_calldata
         + execution_gas_used
         + isContractCreation * (32000 + INITCODE_WORD_COST * words(calldata)),
-        TOTAL_COST_FLOOR_PER_TOKEN * tokens_in_calldata
+        TOTAL_COST_FLOOR_PER_TOKEN * floor_tokens_in_calldata
     )
 )
 ```
 
-Any transaction with a gas limit below `21000 + TOTAL_COST_FLOOR_PER_TOKEN * tokens_in_calldata` or below its intrinsic gas cost (take the maximum of these two calculations) is considered invalid. This limitation exists because transactions must cover the floor price of their calldata without relying on the execution of the transaction. There are valid cases where `gasUsed` will be below this floor price, but the floor price needs to be reserved in the transaction gas limit.
+Any transaction with a gas limit below `21000 + TOTAL_COST_FLOOR_PER_TOKEN * floor_tokens_in_calldata` or below its intrinsic gas cost (take the maximum of these two calculations) is considered invalid. This limitation exists because transactions must cover the floor price of their calldata without relying on the execution of the transaction. There are valid cases where `gasUsed` will be below this floor price, but the floor price needs to be reserved in the transaction gas limit.
 
 ## Rationale
 
-With [EIP-7623](./eip-7623.md)'s implementation, data-heavy transactions cost 10/40 gas per zero/non-zero byte, reducing the maximum possible EL payload size to approximately 1.07 MB (`45s_000_000/40`). This EIP further reduces this to approximately 0.72 MB (`45_000_000/60`) for non zero bytes and maintains proportional costs for non-zero bytes.
+With [EIP-7623](./eip-7623.md)'s implementation, data-heavy transactions cost 10/40 gas per zero/non-zero byte, reducing the maximum possible EL payload size to approximately 1.07 MB (`45_000_000/40`). This EIP further reduces this to approximately 0.67 MB (`45_000_000/64`).
 
-By increasing calldata costs from 10/40 to 15/60 gas per byte for data-heavy transactions, this EIP provides:
+By increasing calldata costs from 10/40 to 64/64 gas per byte for data-heavy transactions, this EIP provides:
 
-- **Enhanced block size reduction**: Maximum data-heavy payload size drops by ~33%.
+- **Enhanced block size reduction**: Maximum data-heavy payload size drops by ~37%.
 - **Maintained user experience**: Regular users engaging in DeFi, token transfers, and other EVM-heavy operations remain unaffected
 - **Better blob incentivization**: Higher calldata costs further encourage migration to blob usage for data availability
 
@@ -80,7 +82,7 @@ This is a backwards incompatible gas repricing that requires a scheduled network
 
 Wallet developers and node operators MUST update gas estimation handling to accommodate the new calldata cost rules. Specifically:
 
-1. **Wallets**: Wallets using `eth_estimateGas` MUST be updated to ensure that they correctly account for the updated `TOTAL_COST_FLOOR_PER_TOKEN` parameter of 15. Failure to do so could result in underestimating gas, leading to failed transactions.
+1. **Wallets**: Wallets using `eth_estimateGas` MUST be updated to ensure that they correctly account for the updated `TOTAL_COST_FLOOR_PER_TOKEN` parameter of 16. Failure to do so could result in underestimating gas, leading to failed transactions.
 
 2. **Node Software**: RPC methods such as `eth_estimateGas` MUST incorporate the updated formula for gas calculation with the new floor cost values.
 
@@ -88,9 +90,9 @@ Users can maintain their usual workflows without modification, as wallet and RPC
 
 ## Test Cases
 
-Testing for this EIP should verify the correct application of the new calldata cost floor of 15/60 gas per zero/non-zero byte:
+Testing for this EIP should verify the correct application of the new calldata cost floor of 64/64 gas per byte:
 
-1. **Data-heavy transactions**: Verify transactions with minimal EVM execution pay the floor cost of 15 gas per calldata token
+1. **Data-heavy transactions**: Verify transactions with minimal EVM execution pay the floor cost of 64 gas per calldata byte
 2. **EVM-heavy transactions**: Confirm transactions with significant computation continue using standard 4/16 gas per byte
 3. **Edge cases**: Test transactions at the boundary where execution gas equals or exceeds the floor cost
 4. **Gas estimation**: Validate that `eth_estimateGas` correctly accounts for the new `TOTAL_COST_FLOOR_PER_TOKEN` value


### PR DESCRIPTION
Update EIP-7976 calldata floor pricing from 15/60 to 64/64 gas per byte, increasing the gas required for a 10 MiB payload from ~105M to ~671M gas.