### PR TITLE
Add EIP: Multi KZG Point Evaluation Precompile

### DIFF
--- a/EIPS/eip-8149.md
+++ b/EIPS/eip-8149.md
@@ -21,6 +21,8 @@ Add a precompile that verifies multiple KZG openings `(z_i, y_i)` for a single [
 
 ## Specification
 
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119) and [RFC 8174](https://www.rfc-editor.org/rfc/rfc8174).
+
 ### Constants
 
 | Name | Value | Comment |


### PR DESCRIPTION
### Summary

The precompile verifies multiple KZG openings `(z_i, y_i)` for a single EIP-4844 blob commitment in one call by doing a bls12381 pairing check 