### PR TITLE
Update EIP-7906: fix typos

### DIFF
--- a/EIPS/eip-7906.md
+++ b/EIPS/eip-7906.md
@@ -59,7 +59,7 @@ This code is executed in a static context and cannot modify the blockchain state
 
 ### Assertion Frame
 
-After the transaction execution frame is finished without reverting, the `RESTRICTED_EXECUTION_TX_TYPE` transactions MUST also successully execute a second execution frame. This frame runs in a static context and cannot modify storage or emit logs.
+After the transaction execution frame is finished without reverting, the `RESTRICTED_EXECUTION_TX_TYPE` transactions MUST also successfully execute a second execution frame. This frame runs in a static context and cannot modify storage or emit logs.
 
 The purpose of this frame is to execute the state change assertions as prescribed by the `asserter_address` and `asserter_data` parameters.
 
@@ -173,7 +173,7 @@ This proposal describes a new transaction type that should not affect the functi
 
 ### Correct Wallet UI presentation
 
-Successfull use of the `RESTRICTED_EXECUTION_TX_TYPE` transaction type requires the wallets to be abile to correctly understand and present the restrictions imposed on the transaction to the users.
+Successful use of the `RESTRICTED_EXECUTION_TX_TYPE` transaction type requires the wallets to be abile to correctly understand and present the restrictions imposed on the transaction to the users.
 
 Wallets will need to be able to understand the meaning of the state changes being permitted by the transaction. This requires wallets to be aware of all major ERC standards, such as [ERC-20](./eip-20.md) and [ERC-721](./eip-721.md). In many cases, this also requires the wallets to be able to fetch and analyze the source code of the executed contracts.
 


### PR DESCRIPTION
Corrected "successully" → "successfully"
Corrected "Successfull" → "Successful"