### PR TITLE
Update EIP-8052: Correct XOF extract usage

### DIFF
--- a/EIPS/eip-8052.md
+++ b/EIPS/eip-8052.md
@@ -204,7 +204,7 @@ def FALCON_HASH_TO_POINT_SHAKE256(message: bytes32, signature: bytes) -> bool:
     SHAKE256_inject(r+message)
     i = 0
     while i < n do
-        t = SHAKE256_extract(16)
+        t = SHAKE256_extract(2)
         if t < 61445 then
             c_i = t mod q
             i = i + 1
@@ -240,7 +240,7 @@ def FALCON_HASH_TO_POINT_KECCAKPRNG(message: bytes32, signature: bytes) -> bool:
     KeccakPRNG_inject(r+message)
     i = 0
     while i < n do
-        t = KeccakPRNG_extract(16)
+        t = KeccakPRNG_extract(2)
         if t < 61445 then
             c_i = t mod q
             i = i + 1


### PR DESCRIPTION
Falcon's H2P samples 16-*bit* values. The extract functions say they return "`length` bytes of output".