### PR TITLE
Update EIP-2780: Minor wording fix

### DIFF
--- a/EIPS/eip-2780.md
+++ b/EIPS/eip-2780.md
@@ -304,7 +304,7 @@ This EIP composes cleanly with calldata-pricing proposals such as [EIP-7623](./e
 
 ### Why not charge full tx data as calldata?
 
-- **Intrinsic coupling to signed fields.** Pricing full-transaction bytes would make intrinsic gas depend on `gas_limit` and variable-length signature elements, creating fixed-point estimation issues and incentives for signature-length selection as well as iteration unstablity as `gas_limit` depends on signiture which contains `gas_limit`.
+- **Intrinsic coupling to signed fields.** Pricing full-transaction bytes would make intrinsic gas depend on `gas_limit` and variable-length signature elements, creating fixed-point estimation issues and incentives for signature-length selection as well as iteration unstablity as `gas_limit` depends on signature which contains `gas_limit`.
 
 - **Serialization neutrality.** A fee rule keyed to RLP size couples costs to one encoding and weakens [EIP-2718](./eip-2718.md) type neutrality and future formats such as SSZ. Calldata is treated as opaque bytes so it avoids this coupling.
 


### PR DESCRIPTION
This PR improves the wording in **EIP-2780** to clarify the explanation around intrinsic gas coupling to signed fields.