### PR TITLE
Update EIP-1: Correct GitHub brand capitalization in EIP-1

### DIFF
--- a/EIPS/eip-1.md
+++ b/EIPS/eip-1.md
@@ -172,7 +172,7 @@ At least one author must use a GitHub username, in order to get notified on chan
 
 While an EIP is a draft, a `discussions-to` header will indicate the URL where the EIP is being discussed.
 
-The preferred discussion URL is a topic on [Ethereum Magicians](https://ethereum-magicians.org/). The URL cannot point to Github pull requests, any URL which is ephemeral, and any URL which can get locked over time (i.e. Reddit topics).
+The preferred discussion URL is a topic on [Ethereum Magicians](https://ethereum-magicians.org/). The URL cannot point to GitHub pull requests, any URL which is ephemeral, and any URL which can get locked over time (i.e. Reddit topics).
 
 ### `type` header
 


### PR DESCRIPTION
This PR corrects the capitalization of "GitHub" in EIP-1 to match the official brand name styling.
