### PR TITLE
Update EIP-1829: Correct "Sappling" to "Sapling" in EIP-1829

### DIFF
--- a/EIPS/eip-1829.md
+++ b/EIPS/eip-1829.md
@@ -118,7 +118,7 @@ The BN254 (aka alt_bn8) multiplication operation introduced by the [EIP-196][EIP
 
 **256-bit modulus.** This EIP is for field moduli less than `2^{256}`. This covers many of the popular curves while still having all parameters fit in a single EVM word.
 
-TODO: Consider a double-word version. 512 bits would cover all known curves except E-521. In particular it will cover the NIST P-384 curve used by the Estonian e-Identity and the BLS12-381 curve used by [ZCash Sappling][sappling].
+TODO: Consider a double-word version. 512 bits would cover all known curves except E-521. In particular it will cover the NIST P-384 curve used by the Estonian e-Identity and the BLS12-381 curve used by [ZCash Sapling][sappling].
 
 [sappling]: https://z.cash/blog/new-snark-curve/
 


### PR DESCRIPTION
Fixes a spelling error in the EIP-1829 specification document where the ZCash upgrade name was misspelled.