### PR TITLE
Add EIP: Private Key Deactivation Aware ecRecover

### DIFF
--- a/EIPS/eip-8151.md
+++ b/EIPS/eip-8151.md
@@ -1,7 +1,7 @@
 ---
 eip: 8151
 title: Private Key Deactivation Aware ecRecover
-description: Modify ecRecover precompile to return zero address for keys deactivated per EIP-7851
+description: Modify ecRecover precompile to return 32 zero bytes for keys deactivated per EIP-7851
 author: Liyi Guo (@colinlyguo), Nicolas Consigny (@nconsigny)
 discussions-to: https://ethereum-magicians.org/t/eip-8151-private-key-deactivation-aware-ecrecover/27690
 status: Draft
@@ -13,7 +13,7 @@ requires: 7851
 
 ## Abstract
 
-This EIP modifies the `ecRecover` precompile at address `0x0000000000000000000000000000000000000001` to respect [EIP-7851](./eip-7851.md) key deactivation. After performing ECDSA public key recovery, the precompile checks whether the recovered address has a deactivated private key. If so, it returns the zero address instead of the recovered address.
+This EIP modifies the `ecRecover` precompile at address `0x0000000000000000000000000000000000000001` to respect [EIP-7851](./eip-7851.md) key deactivation. After performing ECDSA public key recovery, the precompile checks whether the recovered address has a deactivated private key. If so, it returns 32 zero bytes (the existing failure sentinel of `ecRecover`) instead of the recovered address.
 
 ## Motivation
 
@@ -23,16 +23,15 @@ This EIP modifies the `ecRecover` precompile at address `0x000000000000000000000
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119) and [RFC 8174](https://www.rfc-editor.org/rfc/rfc8174).
 
-| Constant | Value |
-|---|---|
-| `ECRECOVER_ADDRESS` | `0x0000000000000000000000000000000000000001` |
-| `COLD_ACCOUNT_ACCESS_COST` | 2600 |
-| `WARM_ACCOUNT_ACCESS_COST` | 100 |
-| `FORK_TIMESTAMP` | TBD |
+| Constant                   | Value                                        |
+|----------------------------|----------------------------------------------|
+| `ECRECOVER_ADDRESS`        | `0x0000000000000000000000000000000000000001` |
+| `COLD_ACCOUNT_ACCESS_COST` | 2600                                         |
+| `WARM_ACCOUNT_ACCESS_COST` | 100                                          |
 
 ### Modified `ecRecover` Behavior
 
-After `FORK_TIMESTAMP`, the `ecRecover` precompile at address `ECRECOVER_ADDRESS` MUST perform the following steps:
+Starting at the activation of this EIP, the `ecRecover` precompile at address `ECRECOVER_ADDRESS` MUST perform the following steps:
 
 1. Perform ECDSA public key recovery from the input `(hash, v, r, s)` as currently specified, yielding a `recovered_address`.
 2. If recovery fails, return 32 zero bytes and consume `3000` gas.
@@ -46,7 +45,7 @@ An address is considered to have a deactivated key if and only if its account co
 
 ```python
 code = state.get_code(recovered_address)
-is_deactivated = len(code) == 24 and code[:3] == bytes.fromhex("ef0100")
+is_deactivated = len(code) == 24 and code[:3] == bytes.fromhex("ef0100") and code[-1] == 0x00
 ```
 
 ### Gas Cost
@@ -67,9 +66,11 @@ When ECDSA recovery succeeds, the precompile MUST access the account of
 
 Modifying `ecRecover` at the protocol level is chosen because many deployed contracts that rely on `ecRecover` for signature-based authorization (e.g., ERC-20 `permit` implementations) are immutable and cannot be upgraded to incorporate deactivation checks. A protocol-level change ensures these existing contracts automatically benefit from key deactivation without requiring redeployment.
 
-### Returning Zero Address
+### Returning 32 Zero Bytes
 
-When a deactivated key is detected, the precompile returns the zero address rather than reverting. This preserves the existing interface of `ecRecover`, which never reverts but returns zero bytes on failure. Contracts that already check for a zero-address return will naturally reject deactivated keys without any code changes.
+When a deactivated key is detected, the precompile returns 32 zero bytes rather than triggering an execution failure (`success = 0`). Currently, malformed `v`, out of range `r`/`s`, and failed recovery all return 32 zero bytes with `success = 1`, and `ecRecover` has never used execution failure to signal invalid input. Treating a deactivated key as another form of "recovery failed" keeps this convention intact.
+
+Furthermore, introducing an execution failure path would break deployed contracts that wrap `ecRecover` with a low level `staticcall` and `require(success)`, turning a "signature not valid" result into an unexpected revert. Contracts that already check for a zero return will naturally reject deactivated keys without any code changes.
 
 ### EIP-2929 Gas Accounting
 
@@ -77,13 +78,13 @@ Since the precompile now reads account state, the additional gas cost follows th
 
 ## Backwards Compatibility
 
-For addresses whose private key has been deactivated under [EIP-7851](./eip-7851.md), `ecRecover` now returns the zero address where it previously returned the recovered address.
+For addresses whose private key has been deactivated under [EIP-7851](./eip-7851.md), `ecRecover` now returns 32 zero bytes where it previously returned the recovered address.
 
 On every successful ECDSA recovery, the precompile now performs an additional account access, adding either `WARM_ACCOUNT_ACCESS_COST` (100) or `COLD_ACCOUNT_ACCESS_COST` (2600) to the base cost of `3000`. Transactions that invoke `ecRecover` near their gas limit MAY fail with an out-of-gas error after activation.
 
 ## Test Cases
 
-To be added.
+<!-- TODO -->
 
 ## Reference Implementation
 
@@ -113,13 +114,27 @@ def ecrecover(state, hash: bytes, v: int, r: int, s: int) -> bytes:
 
     # Check EIP-7851 deactivation
     code = state.get_code(recovered_address)
-    if len(code) == DEACTIVATED_CODE_LEN and code[:3] == DELEGATED_CODE_PREFIX:
+    if len(code) == DEACTIVATED_CODE_LEN and code[:3] == DELEGATED_CODE_PREFIX and code[-1] == 0x00:
         return ZERO_BYTES32
 
     return recovered_address.rjust(32, b'\x00')
 ```
 
 ## Security Considerations
+
+### Contracts Not Checking for Zero Return
+
+Contracts that use `ecrecover` but do not verify the result is non-zero are already vulnerable to accepting invalid signatures. This EIP maps deactivated keys to the same failure sentinel (32 zero bytes) and therefore does not introduce a new class of vulnerability.
+
+### Application-Level ECDSA Verification
+
+This EIP only modifies the `ecrecover` precompile. Contracts that perform ECDSA recovery in application-level code (e.g., pure Solidity implementations) bypass the precompile and will not observe deactivation.
+
+### Cross-Domain / L2 Fault Proof Implications
+
+Some systems re-execute `ecrecover` in a different context (different chain, different layer, or asynchronously at a later time) and assume it is a pure function of `(hash, v, r, s)`. Because this EIP introduces a state read (the recovered address's account code), that assumption no longer holds.
+
+In particular, L2 fault proof systems that accelerate `ecrecover` by executing the L1 precompile and caching the result may become incorrect. Mitigations include removing such acceleration, or migrating to a pure recovery primitive (e.g., implementing secp256k1 recovery inside the fault-proof VM or via a new dedicated pure-recovery precompile in L1), so that the accelerated operation remains a pure function of its inputs.
 
 ### Multi-Chain Considerations
 


### PR DESCRIPTION
As discussed in the [EIP-7851 Magicians thread](https://ethereum-magicians.org/t/eip-7851-deactivate-reactivate-a-delegated-eoas-key/22344/14), immutable ERC-20 contracts that implement [ERC-2612](https://eips.ethereum.org/EIPS/eip-2612) `permit` (e.g., DAI) rely on the `ecRecover` precompile for signature verification. Other examples include [Uniswap Permit2](https://github.com/Uniswap/permit2), which is similarly immutable and non-upgradable. After a key is deactivated under EIP-7851, these contracts have no way to learn that the key is no longer valid. This EIP addresses the issue by making `ecRecover` itself aware of key deactivation status.

Note that this does **not** cover contracts that implement ECDSA signature verification in application-level code (e.g., pure-Solidity implemented recovery), as those bypass the precompile entirely.

Per discussion with @nconsigny, this is proposed as a standalone EIP rather than folded into EIP-7851 to keep the two concerns cleanly separated.