### PR TITLE
Update EIP-8080: Add test cases for EIP-8080

### DIFF
--- a/EIPS/eip-8080.md
+++ b/EIPS/eip-8080.md
@@ -88,7 +88,16 @@ This EIP introduces backwards-incompatible changes to the Consensus Layer and mu
 
 ## Test Cases
 
-<-- TODO -->
+Test cases should verify:
+
+1. **Basic routing**: When `earliest_exit_epoch > earliest_consolidation_epoch`, exits are correctly routed through the consolidation queue
+2. **Churn conversion**: The `2/3` conversion factor is correctly applied when routing exits through consolidation queue
+3. **Queue balance**: When consolidation queue is longer, exits continue to use the exit queue as before
+4. **Epoch transitions**: Correct behavior when queue lengths change across epoch boundaries
+5. **Large exits**: Exits requiring multiple epochs of churn are correctly processed through consolidation queue
+6. **Mixed operations**: Simultaneous exits and consolidations correctly share the consolidation queue
+7. **Churn limits**: Total churn consumed respects both exit and consolidation churn limits
+8. **Edge cases**: Behavior when queues are equal length, when churn is exhausted, and when validators have exactly 2048 ETH
 
 ## Security Considerations
 


### PR DESCRIPTION
Completes the Test Cases section for EIP-8080 by specifying 8 test scenarios covering the core functionality:

  - Queue routing logic (exits using consolidation queue when shorter)
  - The 2/3 churn conversion factor specified in the EIP
  - Edge cases including the 2048 ETH threshold mentioned in Motivation
  - Mixed operations and epoch transitions

  All test cases directly correspond to the specification's `compute_exit_epoch_and_update_churn` function and the weak subjectivity guarantees discussed in Security Considerations.

  Similar to the recent improvement in EIP-8024 (commit 05146bf), this fills a placeholder that was blocking the EIP's progression.