### PR TITLE
Update EIP-8037: Add quantization, reservoir model, and refine gas accounting

### DIFF
--- a/EIPS/eip-8037.md
+++ b/EIPS/eip-8037.md
@@ -32,15 +32,15 @@ The relationship we are seeing in this example is not linear as expected. This i
 | **Parameter** | **Value** |
 |:---:|:---:|
 | `TARGET_STATE_GROWTH_PER_YEAR` | 100 × 1024^3 bytes |
-| `CPSB_SIGNIFICANT_BITS` | 4 |
-| `CPSB_OFFSET` | 4451 |
+| `CPSB_SIGNIFICANT_BITS` | 5 |
+| `CPSB_OFFSET` | 9578 |
 
 Besides these fixed parameters, this EIP introduces a dynamic variable that controls the cost per byte of state created for a given block gas limit. The variable is `cost_per_state_byte` and is calculated as follows:
 
 ```python
 raw = ceil((gas_limit * 2_628_000) / (2 * TARGET_STATE_GROWTH_PER_YEAR))
 shifted = raw + CPSB_OFFSET
-shift = bit_length(shifted) - CPSB_SIGNIFICANT_BITS
+shift = max(bit_length(shifted) - CPSB_SIGNIFICANT_BITS, 0)
 cost_per_state_byte = max(((shifted >> shift) << shift) - CPSB_OFFSET, 1)
 ```
 
@@ -100,6 +100,7 @@ max(intrinsic_regular_gas, calldata_floor_gas_cost) > TX_MAX_GAS_LIMIT
 Since transactions have a single gas limit parameter (`tx.gas`), gas accounting is enforced through a **reservoir model**, in which `gas_left` and `state_gas_reservoir` are initialized as follows:
 
 ```python
+intrinsic_gas = intrinsic_regular_gas + intrinsic_state_gas
 execution_gas = tx.gas - intrinsic_gas
 regular_gas_budget = TX_MAX_GAS_LIMIT - intrinsic_regular_gas
 gas_left = min(regular_gas_budget, execution_gas)
@@ -226,33 +227,33 @@ With multidimensional metering, blocks can be filled up to 50% of the target for
 
 Without quantization, `cost_per_state_byte` changes by 1 for every ~81,715 change in gas limit, which is 0.13% of the current block gas limit of 60M gas units. This creates unnecessary churn for tooling and gas estimation, since the cost can change almost every block even when the gas limit is relatively stable.
 
-The quantization scheme retains the top 4 significant bits of `(raw + CPSB_OFFSET)`, zeroes the remaining bits, then subtracts `CPSB_OFFSET`. This is equivalent to binary floating-point rounding: each power-of-2 band has exactly 8 distinct levels, and the step size doubles at each band boundary while remaining perfectly uniform within a band.
+The quantization scheme retains the top 5 significant bits of `(raw + CPSB_OFFSET)`, zeroes the remaining bits, then subtracts `CPSB_OFFSET`. This is equivalent to binary floating-point rounding: each power-of-2 band has exactly 16 distinct levels, and the step size doubles at each band boundary while remaining perfectly uniform within a band.
 
-The offset (`CPSB_OFFSET = 4451`) shifts quantization boundaries away from common gas limit targets. It was chosen by brute-force search over 0–5000 to maximize the minimum distance from any quantization boundary to gas limits from 100M to 1000M (in 50M increments). This prevents `cost_per_state_byte` from flipping between adjacent values due to small gas limit fluctuations near popular targets. The following table shows the resulting boundary distances:
+The offset (`CPSB_OFFSET = 9578`) shifts quantization boundaries away from common gas limit targets. It was chosen by brute-force search over 0–10000 to maximize the minimum distance from any quantization boundary to gas limits from 100M to 1000M (in 50M increments). This prevents `cost_per_state_byte` from flipping between adjacent values due to small gas limit fluctuations near popular targets. The following table shows the resulting boundary distances:
 
 | Gas Limit | `cost_per_state_byte` | Distance to boundary | Blocks to boundary |
 | :---------: | :---------------------: | :--------------------: | :------------------: |
-| 100M | 1,181 | 3.58% | 36.6 |
-| 150M | 1,693 | 7.82% | 80.1 |
-| 200M | 2,205 | 9.95% | 101.9 |
-| 250M | 2,717 | 5.51% | 56.4 |
-| 300M | 3,229 | 1.87% | 19.2 |
-| 350M | 3,741 | 11.23% | 115.0 |
-| 400M | 4,765 | 2.68% | 27.4 |
-| 450M | 4,765 | 5.10% | 52.3 |
-| 500M | 5,789 | 5.41% | 55.4 |
-| 550M | 5,789 | 1.21% | 12.4 |
-| 600M | 6,813 | 6.72% | 68.8 |
-| 650M | 7,837 | 1.49% | 15.2 |
-| 700M | 7,837 | 3.43% | 35.1 |
-| 750M | 8,861 | 3.47% | 35.5 |
-| 800M | 8,861 | 0.96% | 9.8 |
-| 850M | 9,885 | 4.87% | 49.8 |
-| 900M | 10,909 | 0.96% | 9.8 |
-| 950M | 10,909 | 2.63% | 27.0 |
-| 1000M | 11,933 | 2.50% | 25.6 |
+| 100M | 1,174 | 4.15% | 42.5 |
+| 150M | 1,686 | 8.21% | 84.0 |
+| 200M | 2,198 | 10.24% | 104.8 |
+| 250M | 2,710 | 5.28% | 54.1 |
+| 300M | 3,222 | 1.68% | 17.2 |
+| 350M | 4,246 | 0.89% | 9.1 |
+| 400M | 4,758 | 2.82% | 28.9 |
+| 450M | 5,270 | 4.32% | 44.2 |
+| 500M | 5,782 | 2.85% | 29.2 |
+| 550M | 6,294 | 1.10% | 11.3 |
+| 600M | 6,806 | 6.63% | 67.8 |
+| 650M | 7,830 | 1.58% | 16.1 |
+| 700M | 7,830 | 3.35% | 34.3 |
+| 750M | 8,854 | 3.54% | 36.3 |
+| 800M | 8,854 | 0.89% | 9.1 |
+| 850M | 9,878 | 4.80% | 49.1 |
+| 900M | 10,902 | 1.02% | 10.5 |
+| 950M | 10,902 | 2.57% | 26.4 |
+| 1000M | 11,926 | 2.55% | 26.2 |
 
-The worst-case minimum distance is 0.96% of the gas limit (at 800M and 900M), corresponding to ~9.8 blocks of maximum-rate gas limit adjustment. Since the gas limit can deviate from its parent by at most 1/1024, `cost_per_state_byte` remains stable for at least ~10 consecutive blocks of same-direction gas limit changes at any gas limit in the 100M–1000M range.
+The worst-case minimum distance is 0.89% of the gas limit (at 350M and 800M). Since the gas limit can deviate from its parent by at most 1/1024, `cost_per_state_byte` remains stable for at least ~9 consecutive blocks of same-direction gas limit changes at any gas limit in the 100M–1000M range (in 50M increments).
 
 ### Harmonization across state creation
 
@@ -276,9 +277,9 @@ This proposal is consistent with [EIP-8011](./eip-8011.md). However, it only req
 
 #### EIP-7825 limit on contract size
 
-[EIP-7825](./eip-7825.md) introduces `TX_MAX_GAS_LIMIT` (16.7M) as the maximum gas for a single transaction, in particular stipulating `tx.gas < TX_MAX_GAS_LIMIT`as a validity condition. Were we to continue enforcing this validity condition, with a block limit of 60M gas units, this proposal would limit the maximum contract size that can be deployed to roughly 12kb ($\frac{16,777,216 - 21,000 - 5,000,000 - 112*980}{980} = 11,884$). This maximum size would only decrease as we increase the gas limit and the `cost_per_state_byte`.
+[EIP-7825](./eip-7825.md) introduces `TX_MAX_GAS_LIMIT` (16.7M) as the maximum gas for a single transaction, in particular stipulating `tx.gas < TX_MAX_GAS_LIMIT`as a validity condition. Were we to continue enforcing this validity condition, with a block limit of 100M gas units, this proposal would limit the maximum contract size that can be deployed to roughly 9.9kB ($\frac{16,777,216 - 21,000 - 5,000,000 - 112 \times 1174}{1174} = 9'902$). This maximum size would only decrease as we increase the gas limit and the `cost_per_state_byte`.
 
-To solve this issue, we only apply this gas limit to regular gas, not state gas. Doing so does not weaken the intended scaling effect of [EIP-7825](./eip-7825.md), because regular gas meters all resources that benefit from parallelization. In particular, state growth does not: growing the state always require writing to disk, a parallelizable operation, but crucially this part of the cost of a state growth operation has to be metered in regular gas, not state gas. In other words, any operation that grows the state should consume both regular gas and state gas, and the regular gas should fully account for all costs other than the long term effect of growing the state.
+To solve this issue, we only apply this gas limit to regular gas, not state gas. Doing so does not weaken the intended scaling effect of [EIP-7825](./eip-7825.md), because regular gas meters all resources that benefit from parallelization. In particular, state growth does not: growing the state always requires writing to disk, a parallelizable operation, but crucially this part of the cost of a state growth operation has to be metered in regular gas, not state gas. In other words, any operation that grows the state should consume both regular gas and state gas, and the regular gas should fully account for all costs other than the long term effect of growing the state.
 
 However, we cannot statically enforce a regular gas consumption of `TX_MAX_GAS_LIMIT`, while still allowing a higher state gas consumption, because transactions only have a single gas limit parameter, `tx.gas`. This is solved through a **reservoir model**: at transaction start, execution gas is split into `gas_left` (capped at `TX_MAX_GAS_LIMIT - intrinsic_regular_gas`) and a `state_gas_reservoir` (the overflow). State gas charges draw from the reservoir first, then from `gas_left` when the reservoir is empty. Regular gas charges draw from `gas_left` only. Exceeding the regular gas budget behaves identically to running out of gas — no special error is needed.
 
@@ -304,9 +305,10 @@ Users and dApp developers will experience an increase in transaction costs assoc
 | Case | cost_per_state_byte | Cost of a new account | Cost increase | Cost of a new slot | Cost increase | 24kB contract deployment | Cost increase |
 |:---:|:---:|---|---|---|---|---|---|
 | Current cost | NA | 25,000 | NA | 20,000 | NA | 4,947,200 | NA |
-| Proposed cost at 60M block limit | 669 | 74,928 | 3 | 21,408 | 1 | 16,520,880 | 3 |
-| Proposed cost at 100M block limit | 1,181 | 132,272 | 5 | 37,792 | 2 | 29,161,136 | 6 |
-| Proposed cost at 300M block limit | 3,229 | 361,648 | 14 | 103,328 | 5 | 79,722,160 | 16 |
+| Proposed cost at 60M block limit | 662 | 74,144 | 3 | 24,084 | 1 | 16,357,064 | 3 |
+| Proposed cost at 100M block limit | 1,174 | 131,488 | 5 | 40,468 | 2 | 28,997,320 | 6 |
+| Proposed cost at 200M block limit | 2,198 | 246,176 | 10 | 73,236 | 4 | 54,277,832 | 11 |
+| Proposed cost at 300M block limit | 3,222 | 360,864 | 14 | 106,004 | 5 | 79,558,344 | 16 |
 
 We should note that as the block limit increases, the base fee is expected to reduce due to the higher capacity of the network. This reduction in base fee will offset, in part, the costs from state creation operations. Some analysis is needed to quantify this effect.
 
@@ -316,9 +318,9 @@ Increasing the cost of state creation operations could impact the usability of c
 
 ### Mispricing with respect to ETH transfers
 
-One potential concern is the cost of creating a new account (212,800 gas units), compared to transferring ETH to a fresh account (21,000 gas units). With this mismatch, users wishing to create new account are incentivized to first send a normal transaction (costing 21k) to this account to create it, thus avoiding the `PER_EMPTY_ACCOUNT_COST` of 212,800 gas units.
+One potential concern is the cost of creating a new account (`112 × cost_per_state_byte` gas units, e.g., 131,488 at a 100M gas limit), compared to transferring ETH to a fresh account (21,000 gas units). With this mismatch, users wishing to create new account are incentivized to first send a normal transaction (costing 21k) to this account to create it, thus avoiding the `GAS_NEW_ACCOUNT` charge.
 
-[EIP-2780](./eip-2780.md) solves this mispricing by adding a new component to the intrinsic gas cost of transactions. For transactions the sending ETH that send ETH to a fresh account. If a non-create transaction has value > 0 and targets a non-existent account, the `GAS_NEW_ACCOUNT` is added to intrinsic cost.
+[EIP-2780](./eip-2780.md) solves this mispricing by adding a new component to the intrinsic gas cost of transactions. If a non-create transaction has value > 0 and targets a non-existent account, the `GAS_NEW_ACCOUNT` is added to intrinsic cost.
 
 ### Added complexity in block building
 

--- a/assets/eip-8037/quantization_analysis.ipynb
+++ b/assets/eip-8037/quantization_analysis.ipynb
@@ -1,0 +1,503 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4",
+   "metadata": {},
+   "source": [
+    "# EIP-8037: Quantization Analysis\n",
+    "\n",
+    "Test different values for `CPSB_SIGNIFICANT_BITS` and `CPSB_OFFSET` and reproduce the boundary distance table."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "c0b56adf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import math"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "e5f6a7b8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "def compute_cpsb(gas_limit, sig_bits, offset, target_state_growth_per_year):\n",
+    "    \"\"\"Compute cost_per_state_byte for a given gas limit and quantization parameters.\"\"\"\n",
+    "    raw = math.ceil((gas_limit * 2_628_000) / (2 * target_state_growth_per_year))\n",
+    "    shifted = raw + offset\n",
+    "    shift = max(0, shifted.bit_length() - sig_bits)\n",
+    "    cost = max(((shifted >> shift) << shift) - offset, 1)\n",
+    "    return cost\n",
+    "\n",
+    "\n",
+    "def find_boundary_distance(target_gl, sig_bits, offset, target_state_growth_per_year):\n",
+    "    \"\"\"Find the distance from target_gl to the nearest quantization boundary.\n",
+    "\n",
+    "    Returns (distance_pct, blocks_to_boundary, cpsb_value).\n",
+    "    \"\"\"\n",
+    "    p = 2_628_000\n",
+    "    q = 2 * target_state_growth_per_year\n",
+    "    # Calculate shifted, shift and cpsb\n",
+    "    raw = math.ceil(target_gl * p / q)\n",
+    "    shifted = raw + offset\n",
+    "    shift = max(0, shifted.bit_length() - sig_bits)\n",
+    "    cpsb_at_target = max(((shifted >> shift) << shift) - offset, 1)\n",
+    "    # Bucket boundaries in shifted-space\n",
+    "    lower_shifted = (shifted >> shift) << shift\n",
+    "    upper_shifted = lower_shifted + (1 << shift)\n",
+    "    # Smallest gl where ceil(gl * p/q) >= n is: (n-1) * q // p + 1\n",
+    "    gl_upper = (upper_shifted - offset - 1) * q // p + 1\n",
+    "    gl_lower = (lower_shifted - offset - 1) * q // p + 1\n",
+    "    # Compute metrics\n",
+    "    dist_up = gl_upper - target_gl\n",
+    "    dist_down = target_gl - gl_lower\n",
+    "    min_dist = min(dist_up, dist_down)\n",
+    "    max_change_per_block = target_gl / 1024\n",
+    "    return (\n",
+    "        min_dist / target_gl * 100,\n",
+    "        min_dist / max_change_per_block,\n",
+    "        cpsb_at_target,\n",
+    "    )\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "722c185a",
+   "metadata": {},
+   "source": [
+    "## Brute-force search for best offset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "8c0d6bcf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "TARGET_STATE_GROWTH_PER_YEAR = 100 * 1024**3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "5c6b6674",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Top 10 offsets for CPSB_SIGNIFICANT_BITS=4:\n",
+      "\n",
+      "Rank   Offset   Min dist   Worst GL   Blocks\n",
+      "--------------------------------------------\n",
+      "  #1      9746     1.386%      700M    14.2\n",
+      "  #2      7698     1.386%      700M    14.2\n",
+      "  #3      9745     1.377%      550M    14.1\n",
+      "  #4      7697     1.377%      550M    14.1\n",
+      "  #5      9747     1.374%      700M    14.1\n",
+      "  #6      7699     1.374%      700M    14.1\n",
+      "  #7      9748     1.362%      700M    13.9\n",
+      "  #8      7700     1.362%      700M    13.9\n",
+      "  #9      9744     1.362%      550M    13.9\n",
+      "  #10     7696     1.362%      550M    13.9\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Search range for offset\n",
+    "SEARCH_BITS = 4\n",
+    "SEARCH_MAX_OFFSET = 10000\n",
+    "SEARCH_GAS_LIMITS = [gl_m * 1_000_000 for gl_m in range(100, 1050, 50)]\n",
+    "\n",
+    "best = []\n",
+    "for offset in range(SEARCH_MAX_OFFSET + 1):\n",
+    "    min_frac = float(\"inf\")\n",
+    "    worst = 0\n",
+    "    for gl in SEARCH_GAS_LIMITS:\n",
+    "        frac, _, _ = find_boundary_distance(gl, SEARCH_BITS, offset, TARGET_STATE_GROWTH_PER_YEAR)\n",
+    "        if frac < min_frac:\n",
+    "            min_frac = frac\n",
+    "            worst = gl\n",
+    "    best.append((min_frac, offset, worst))\n",
+    "\n",
+    "best.sort(reverse=True)\n",
+    "\n",
+    "print(f\"Top 10 offsets for CPSB_SIGNIFICANT_BITS={SEARCH_BITS}:\")\n",
+    "print(\"\")\n",
+    "print(f\"{'Rank':>4} {'Offset':>8} {'Min dist':>10} {'Worst GL':>10} {'Blocks':>8}\")\n",
+    "print(\"-\" * 44)\n",
+    "for i, (frac, offset, worst_gl) in enumerate(best[:10]):\n",
+    "    _, blk, _ = find_boundary_distance(worst_gl, SEARCH_BITS, offset, TARGET_STATE_GROWTH_PER_YEAR)\n",
+    "    print(f\"  #{i+1:<2} {offset:>8} {frac:>9.3f}% {worst_gl//1_000_000:>8}M {blk:>7.1f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "314d2d39",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Top 10 offsets for CPSB_SIGNIFICANT_BITS=5:\n",
+      "\n",
+      "Rank   Offset   Min dist   Worst GL   Blocks\n",
+      "--------------------------------------------\n",
+      "  #1      9578     0.888%      800M     9.1\n",
+      "  #2      9579     0.878%      800M     9.0\n",
+      "  #3      9580     0.868%      800M     8.9\n",
+      "  #4      9577     0.867%      350M     8.9\n",
+      "  #5      9581     0.857%      800M     8.8\n",
+      "  #6      9582     0.847%      800M     8.7\n",
+      "  #7      9576     0.844%      350M     8.6\n",
+      "  #8      9583     0.837%      800M     8.6\n",
+      "  #9      9584     0.827%      800M     8.5\n",
+      "  #10     9575     0.821%      350M     8.4\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Search range for offset\n",
+    "SEARCH_BITS = 5\n",
+    "SEARCH_MAX_OFFSET = 10000\n",
+    "SEARCH_GAS_LIMITS = [gl_m * 1_000_000 for gl_m in range(100, 1050, 50)]\n",
+    "\n",
+    "best = []\n",
+    "for offset in range(SEARCH_MAX_OFFSET + 1):\n",
+    "    min_frac = float(\"inf\")\n",
+    "    worst = 0\n",
+    "    for gl in SEARCH_GAS_LIMITS:\n",
+    "        frac, _, _ = find_boundary_distance(gl, SEARCH_BITS, offset, TARGET_STATE_GROWTH_PER_YEAR)\n",
+    "        if frac < min_frac:\n",
+    "            min_frac = frac\n",
+    "            worst = gl\n",
+    "    best.append((min_frac, offset, worst))\n",
+    "\n",
+    "best.sort(reverse=True)\n",
+    "\n",
+    "print(f\"Top 10 offsets for CPSB_SIGNIFICANT_BITS={SEARCH_BITS}:\")\n",
+    "print(\"\")\n",
+    "print(f\"{'Rank':>4} {'Offset':>8} {'Min dist':>10} {'Worst GL':>10} {'Blocks':>8}\")\n",
+    "print(\"-\" * 44)\n",
+    "for i, (frac, offset, worst_gl) in enumerate(best[:10]):\n",
+    "    _, blk, _ = find_boundary_distance(worst_gl, SEARCH_BITS, offset, TARGET_STATE_GROWTH_PER_YEAR)\n",
+    "    print(f\"  #{i+1:<2} {offset:>8} {frac:>9.3f}% {worst_gl//1_000_000:>8}M {blk:>7.1f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c9d0e1f2",
+   "metadata": {},
+   "source": [
+    "## Configure parameters\n",
+    "\n",
+    "Change these values to test different quantization settings:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "a3b4c5d6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# === CHANGE THESE TO TEST DIFFERENT VALUES ===\n",
+    "CPSB_SIGNIFICANT_BITS = 5\n",
+    "CPSB_OFFSET = 9578\n",
+    "\n",
+    "# Gas limits to evaluate (in millions)\n",
+    "GAS_LIMITS_M = list(range(100, 1050, 50))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e7f8a9b0",
+   "metadata": {},
+   "source": [
+    "## Boundary distance table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "c1d2e3f4",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPSB_SIGNIFICANT_BITS = 5\n",
+      "CPSB_OFFSET = 9578\n",
+      "\n",
+      "   Gas Limit     cpsb   Distance   Blocks\n",
+      "------------------------------------------\n",
+      "      100M    1,174      4.15%    42.5\n",
+      "      150M    1,686      8.21%    84.0\n",
+      "      200M    2,198     10.24%   104.8\n",
+      "      250M    2,710      5.28%    54.1\n",
+      "      300M    3,222      1.68%    17.2\n",
+      "      350M    4,246      0.89%     9.1 <-- warning\n",
+      "      400M    4,758      2.82%    28.9\n",
+      "      450M    5,270      4.32%    44.2\n",
+      "      500M    5,782      2.85%    29.2\n",
+      "      550M    6,294      1.10%    11.3\n",
+      "      600M    6,806      6.63%    67.8\n",
+      "      650M    7,830      1.58%    16.1\n",
+      "      700M    7,830      3.35%    34.3\n",
+      "      750M    8,854      3.54%    36.3\n",
+      "      800M    8,854      0.89%     9.1 <-- warning\n",
+      "      850M    9,878      4.80%    49.1\n",
+      "      900M   10,902      1.02%    10.5\n",
+      "      950M   10,902      2.57%    26.4\n",
+      "     1000M   11,926      2.55%    26.2\n",
+      "\n",
+      "Worst case: 800M with 9.1 blocks to boundary\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"CPSB_SIGNIFICANT_BITS = {CPSB_SIGNIFICANT_BITS}\")\n",
+    "print(f\"CPSB_OFFSET = {CPSB_OFFSET}\")\n",
+    "print()\n",
+    "print(f\"{'Gas Limit':>12} {'cpsb':>8} {'Distance':>10} {'Blocks':>8}\")\n",
+    "print(\"-\" * 42)\n",
+    "\n",
+    "worst_blocks = float(\"inf\")\n",
+    "worst_gl = 0\n",
+    "\n",
+    "for gl_m in GAS_LIMITS_M:\n",
+    "    gl = gl_m * 1_000_000\n",
+    "    dist_pct, blocks, cpsb = find_boundary_distance(gl, CPSB_SIGNIFICANT_BITS, CPSB_OFFSET, TARGET_STATE_GROWTH_PER_YEAR)\n",
+    "    flag = \"\"\n",
+    "    if blocks < worst_blocks:\n",
+    "        worst_blocks = blocks\n",
+    "        worst_gl = gl_m\n",
+    "    if blocks < 10:\n",
+    "        flag = \" <-- warning\"\n",
+    "    print(f\"{gl_m:>9}M {cpsb:>8,} {dist_pct:>9.2f}% {blocks:>7.1f}{flag}\")\n",
+    "\n",
+    "print()\n",
+    "print(f\"Worst case: {worst_gl}M with {worst_blocks:.1f} blocks to boundary\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e1f2a3b4",
+   "metadata": {},
+   "source": [
+    "## Step size analysis\n",
+    "\n",
+    "Shows how much `cost_per_state_byte` jumps when crossing a quantization boundary."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "c5d6e7f8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPSB_SIGNIFICANT_BITS = 5\n",
+      "CPSB_OFFSET = 9578\n",
+      "\n",
+      "   Gas Limit     cpsb  Next cpsb     Step   Step %\n",
+      "--------------------------------------------------\n",
+      "      100M    1,174      1,686      512    43.6%\n",
+      "      150M    1,686      2,198      512    30.4%\n",
+      "      200M    2,198      2,710      512    23.3%\n",
+      "      250M    2,710      3,222      512    18.9%\n",
+      "      300M    3,222      3,734      512    15.9%\n",
+      "      350M    4,246      4,758      512    12.1%\n",
+      "      400M    4,758      5,270      512    10.8%\n",
+      "      450M    5,270      5,782      512     9.7%\n",
+      "      500M    5,782      6,294      512     8.9%\n",
+      "      550M    6,294      6,806      512     8.1%\n",
+      "      600M    6,806      7,830    1,024    15.0%\n",
+      "      650M    7,830      8,854    1,024    13.1%\n",
+      "      700M    7,830      8,854    1,024    13.1%\n",
+      "      750M    8,854      9,878    1,024    11.6%\n",
+      "      800M    8,854      9,878    1,024    11.6%\n",
+      "      850M    9,878     10,902    1,024    10.4%\n",
+      "      900M   10,902     11,926    1,024     9.4%\n",
+      "      950M   10,902     11,926    1,024     9.4%\n",
+      "     1000M   11,926     12,950    1,024     8.6%\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"CPSB_SIGNIFICANT_BITS = {CPSB_SIGNIFICANT_BITS}\")\n",
+    "print(f\"CPSB_OFFSET = {CPSB_OFFSET}\")\n",
+    "print()\n",
+    "print(f\"{'Gas Limit':>12} {'cpsb':>8} {'Next cpsb':>10} {'Step':>8} {'Step %':>8}\")\n",
+    "print(\"-\" * 50)\n",
+    "\n",
+    "for gl_m in GAS_LIMITS_M:\n",
+    "    gl = gl_m * 1_000_000\n",
+    "    cpsb = compute_cpsb(gl, CPSB_SIGNIFICANT_BITS, CPSB_OFFSET, TARGET_STATE_GROWTH_PER_YEAR)\n",
+    "    # Find next distinct cpsb value above\n",
+    "    gl_up = gl\n",
+    "    while compute_cpsb(gl_up, CPSB_SIGNIFICANT_BITS, CPSB_OFFSET, TARGET_STATE_GROWTH_PER_YEAR) == cpsb:\n",
+    "        gl_up += 1000\n",
+    "    next_cpsb = compute_cpsb(gl_up, CPSB_SIGNIFICANT_BITS, CPSB_OFFSET, TARGET_STATE_GROWTH_PER_YEAR)\n",
+    "    step = next_cpsb - cpsb\n",
+    "    step_pct = step / cpsb * 100\n",
+    "    print(f\"{gl_m:>9}M {cpsb:>8,} {next_cpsb:>10,} {step:>8,} {step_pct:>7.1f}%\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "08bdac75",
+   "metadata": {},
+   "source": [
+    "## Markdown tables (copy-paste into EIP)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "1fa5e182",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "| Gas Limit | `cost_per_state_byte` | Distance to boundary | Blocks to boundary |\n",
+      "| :---------: | :---------------------: | :--------------------: | :------------------: |\n",
+      "| 100M | 1,174 | 4.15% | 42.5 |\n",
+      "| 150M | 1,686 | 8.21% | 84.0 |\n",
+      "| 200M | 2,198 | 10.24% | 104.8 |\n",
+      "| 250M | 2,710 | 5.28% | 54.1 |\n",
+      "| 300M | 3,222 | 1.68% | 17.2 |\n",
+      "| 350M | 4,246 | 0.89% | 9.1 |\n",
+      "| 400M | 4,758 | 2.82% | 28.9 |\n",
+      "| 450M | 5,270 | 4.32% | 44.2 |\n",
+      "| 500M | 5,782 | 2.85% | 29.2 |\n",
+      "| 550M | 6,294 | 1.10% | 11.3 |\n",
+      "| 600M | 6,806 | 6.63% | 67.8 |\n",
+      "| 650M | 7,830 | 1.58% | 16.1 |\n",
+      "| 700M | 7,830 | 3.35% | 34.3 |\n",
+      "| 750M | 8,854 | 3.54% | 36.3 |\n",
+      "| 800M | 8,854 | 0.89% | 9.1 |\n",
+      "| 850M | 9,878 | 4.80% | 49.1 |\n",
+      "| 900M | 10,902 | 1.02% | 10.5 |\n",
+      "| 950M | 10,902 | 2.57% | 26.4 |\n",
+      "| 1000M | 11,926 | 2.55% | 26.2 |\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"| Gas Limit | `cost_per_state_byte` | Distance to boundary | Blocks to boundary |\")\n",
+    "print(\"| :---------: | :---------------------: | :--------------------: | :------------------: |\")\n",
+    "for gl_m in GAS_LIMITS_M:\n",
+    "    gl = gl_m * 1_000_000\n",
+    "    dist_pct, blocks, cpsb = find_boundary_distance(gl, CPSB_SIGNIFICANT_BITS, CPSB_OFFSET, TARGET_STATE_GROWTH_PER_YEAR)\n",
+    "    print(f\"| {gl_m}M | {cpsb:,} | {dist_pct:.2f}% | {blocks:.1f} |\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ff518748",
+   "metadata": {},
+   "source": [
+    "## Estimated price impacts at various block gas limits"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "tnjavbjrf0j",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "| Case | cost_per_state_byte | Cost of a new account | Cost increase | Cost of a new slot | Cost increase | 24kB contract deployment | Cost increase |\n",
+      "|:---:|:---:|---|---|---|---|---|---|\n",
+      "| Current cost | NA | 25,000 | NA | 20,000 | NA | 4,947,200 | NA |\n",
+      "| Proposed cost at 60M block limit | 662 | 74,144 | 3 | 24,084 | 1 | 16,357,064 | 3 |\n",
+      "| Proposed cost at 100M block limit | 1,174 | 131,488 | 5 | 40,468 | 2 | 28,997,320 | 6 |\n",
+      "| Proposed cost at 200M block limit | 2,198 | 246,176 | 10 | 73,236 | 4 | 54,277,832 | 11 |\n",
+      "| Proposed cost at 300M block limit | 3,222 | 360,864 | 14 | 106,004 | 5 | 79,558,344 | 16 |\n"
+     ]
+    }
+   ],
+   "source": [
+    "CURRENT_NEW_ACCOUNT = 25_000\n",
+    "CURRENT_NEW_SLOT = 20_000\n",
+    "CONTRACT_LEN = 24_576  # 24kB (EIP-170 limit)\n",
+    "CURRENT_DEPLOY = 32_000 + 200 * CONTRACT_LEN  # GAS_CREATE + GAS_CODE_DEPOSIT * L\n",
+    "ACCOUNT_BYTES = 112\n",
+    "SLOT_BYTES = 32\n",
+    "HASH_COST = 6 * math.ceil(CONTRACT_LEN / 32)\n",
+    "GAS_CREATE_REGULAR = 9_000\n",
+    "GAS_STORAGE_SET_REGULAR = 2_900  # GAS_STORAGE_UPDATE - GAS_COLD_SLOAD\n",
+    "\n",
+    "IMPACT_GAS_LIMITS_M = [60, 100, 200, 300]\n",
+    "\n",
+    "rows = []\n",
+    "rows.append(f\"| Current cost | NA | {CURRENT_NEW_ACCOUNT:,} | NA | {CURRENT_NEW_SLOT:,} | NA | {CURRENT_DEPLOY:,} | NA |\")\n",
+    "\n",
+    "for gl_m in IMPACT_GAS_LIMITS_M:\n",
+    "    gl = gl_m * 1_000_000\n",
+    "    cpsb = compute_cpsb(gl, CPSB_SIGNIFICANT_BITS, CPSB_OFFSET, TARGET_STATE_GROWTH_PER_YEAR)\n",
+    "    new_account = ACCOUNT_BYTES * cpsb\n",
+    "    new_slot = SLOT_BYTES * cpsb + GAS_STORAGE_SET_REGULAR\n",
+    "    deploy = cpsb * (ACCOUNT_BYTES + CONTRACT_LEN) + GAS_CREATE_REGULAR + HASH_COST\n",
+    "    inc_account = round(new_account / CURRENT_NEW_ACCOUNT)\n",
+    "    inc_slot = round(new_slot / CURRENT_NEW_SLOT)\n",
+    "    inc_deploy = round(deploy / CURRENT_DEPLOY)\n",
+    "    rows.append(\n",
+    "        f\"| Proposed cost at {gl_m}M block limit | {cpsb:,} \"\n",
+    "        f\"| {new_account:,} | {inc_account} \"\n",
+    "        f\"| {new_slot:,} | {inc_slot} \"\n",
+    "        f\"| {deploy:,} | {inc_deploy} |\"\n",
+    "    )\n",
+    "\n",
+    "header = \"| Case | cost_per_state_byte | Cost of a new account | Cost increase | Cost of a new slot | Cost increase | 24kB contract deployment | Cost increase |\"\n",
+    "sep = \"|:---:|:---:|---|---|---|---|---|---|\"\n",
+    "print(header)\n",
+    "print(sep)\n",
+    "for r in rows:\n",
+    "    print(r)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "evm-gas-simulator",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
- Add quantization scheme for `cost_per_state_byte` to avoid frequent small changes as the gas limit fluctuates, using top-4 significant bits with an optimized offset
- Replace revert-based `TX_MAX_GAS_LIMIT` enforcement with a **reservoir model** that splits execution gas into `gas_left` and `state_gas_reservoir`
- Expand multidimensional metering specification: transaction validation, block-level gas accounting, receipt semantics, and `SSTORE` refund/revert behavior
- Clarify `GAS_CREATE` and `GAS_NEW_ACCOUNT` regular gas values in the parameter table
- Update cost estimates to reflect the new quantized `cost_per_state_byte` values
