### PR TITLE
Update EIP-8142: rebase on top of 7732

### DIFF
--- a/EIPS/eip-8142.md
+++ b/EIPS/eip-8142.md
@@ -582,7 +582,7 @@ class ExecutionPayloadBid(Container):
 
 BiB reuses the existing blob networking mechanism. Nodes reconstruct the execution payload from the bid (header fields) and blobs (transactions, BAL).
 
-Payload-blobs will not have been propagated before block building, which may imply higher bandwidth requirements from builders.
+Unlike most type-3 blob transactions, payload-blobs will not have been propagated before block building, which may imply higher bandwidth requirements from builders.
 
 ### Fee Accounting
 


### PR DESCRIPTION
This PR rebases BiB on top of ePBS, deprecating the envelope and moving the necessary fields into the bid.