### PR TITLE
Update EIP-8007: Add gas cost summaries

### DIFF
--- a/EIPS/eip-8007.md
+++ b/EIPS/eip-8007.md
@@ -28,34 +28,98 @@ The following table lists all EIPs related to repricings that are being discusse
 2. **Pricing extension**. These EIPs make targeted changes to a specific opcode or component of the gas model, usually coupled with a new mechanism.
 3. **Supporting**. These EIPs are not directly doing a repricing, but instead introduce a change that support other repricing EIPs or enhance the scalability potential of repricings.
 
-This list will continue to be updated as more gas repricing EIPs are proposed.
+### Considered for Inclusion
 
-### EIP list
+| EIP | Description | Type | Resource class | Gas change overview |
+|:---:|---|---|:---:|---|
+| [EIP-2780](./eip-2780.md) | Reduce intrinsic transaction gas and charge 25k when a value transfer creates a new account. | Broad harmonization | Multi-resource | Decrease `TX_BASE_COST` (21k→4.5k); increase new-account surcharge (0→25k) |
+| [EIP-7778](./eip-7778.md) | Prevent Block Gas Limit Circumvention by Excluding Refunds from Block Gas Accounting. | Pricing extension | General Accounting | No opcode repricing; excludes gas refunds (e.g. `SSTORE` clearing) from block gas accounting |
+| [EIP-7904](./eip-7904.md) | Gas Cost Increase to reflect computational complexity and transaction throughput increase | Broad harmonization | Compute | All increase: `DIV`, `SDIV`, `MOD`, `MULMOD`, `KECCAK256`, precompiles (`BLAKE2F`, `BLS12_G1ADD`, `BLS12_G2ADD`, `ECADD`, `ECPAIRING`, `POINT_EVALUATION`) |
+| [EIP-7976](./eip-7976.md) | Further increase calldata cost to 15/60 gas per byte to reduce maximum block size. | Pricing extension | Data | Increase calldata floor cost (10/40 → 15/60 per byte) |
+| [EIP-7981](./eip-7981.md) | Introduce floor pricing for access lists to reduce maximum block size. | Pricing extension | Data | Increase: new floor charge on access list data (addresses + storage keys) |
+| [EIP-8037](./eip-8037.md) | Harmonization, increase and separate metering of state creation gas costs to mitigate state growth and unblock scaling. | Broad harmonization | State | All increase (dynamic with gas limit): `GAS_CREATE`, `GAS_CODE_DEPOSIT`, `GAS_NEW_ACCOUNT`, `GAS_STORAGE_SET`, `PER_AUTH_BASE_COST` |
+| [EIP-8038](./eip-8038.md) | Increases the gas cost of state-access operations to reflect Ethereum's larger state. | Broad harmonization | State | All increase: cold storage write/access, cold account access, warm access, `EXTCODESIZE`/`EXTCODECOPY` extra read, access list costs |
 
-| EIP | Description | Type | Resource class | Status |
-|:---:|---|---|:---:|:---:|
-| [EIP-2780](./eip-2780.md) | Reduce intrinsic transaction gas and charge 25k when a value transfer creates a new account. | Broad harmonization | Multi-resource | Considered for Inclusion |
-| [EIP-2926](./eip-2926.md) | Introduce code-chunking in an MPT context. | Pricing extension | State | Declined for Inclusion |
-| [EIP-7686](./eip-7686.md) | Adjust memory limits and gas limits of sub-calls to create a clear linear bound on how much total memory an EVM execution can consume. | Pricing extension | Memory | Declined for Inclusion |
-| [EIP-7778](./eip-7778.md) | Prevent Block Gas Limit Circumvention by Excluding Refunds from Block Gas Accounting. | Pricing extension | General Accounting | Considered for Inclusion |
-| [EIP-7904](./eip-7904.md) | Gas Cost Repricing to reflect computational complexity and transaction throughput increase | Broad harmonization | Compute | Considered for Inclusion |
-| [EIP-7923](./eip-7923.md) | Linearize Memory Costing and replace the current quadratic formula with a page-based cost model. | Pricing extension | Memory | Declined for Inclusion |
-| [EIP-7971](./eip-7971.md) | Decrease costs for `TLOAD` and `TSTORE` with a transaction-global limit. | Pricing extension | Memory | Declined for Inclusion |
-| [EIP-7973](./eip-7973.md) | Introduce warm account writes, decreasing the cost of writing to an account after the first write. | Pricing extension | State | Declined for Inclusion |
-| [EIP-7976](./eip-7976.md) | Further increase calldata cost to 15/60 gas per byte to reduce maximum block size. | Pricing extension | Data | Considered for Inclusion |
-| [EIP-7981](./eip-7981.md) | Introduce floor pricing for access lists to reduce maximum block size. | Pricing extension | Data | Considered for Inclusion |
-| [EIP-8011](./eip-8011.md) | Gas accounting by EVM resource, increasing throughput and improving resource usage controls, with minimal changes to the protocol and UX. | Supporting | NA | Declined for Inclusion |
-| [EIP-8032](./eip-8032.md) | Makes `SSTORE` gas cost scale with a contract's storage size to discourage state bloat. | Pricing extension | State | Declined for Inclusion |
-| [EIP-8037](./eip-8037.md) | Harmonization and increase of state creation gas costs to mitigate state growth and unblock scaling. | Broad harmonization | State | Considered for Inclusion |
-| [EIP-8038](./eip-8038.md) | Increases the gas cost of state-access operations to reflect Ethereum’s larger state. | Broad harmonization | State | Considered for Inclusion |
-| [EIP-8053](./eip-8053.md) | Adds `milli-gas` as the EVM’s internal gas accounting unit, reducing rounding errors without impacting UX. | Supporting | NA | Declined for Inclusion |
-| [EIP-8057](./eip-8057.md) | Multi‑block temporal locality discounts for state and account access. | Pricing extension | State | Declined for Inclusion |
-| [EIP-8058](./eip-8058.md) | Reduces gas costs for deploying duplicate contract bytecode via access-list based mechanism. | Pricing extension | State | Declined for Inclusion |
-| [EIP-8059](./eip-8059.md) | Gas parameters and variables are increased to a factor of `REBASE_FACTOR` to reduce rounding errors without major changes to the EVM. | Supporting | NA | Declined for Inclusion |
+### Declined for Inclusion
+
+| EIP | Description | Type | Resource class |
+|:---:|---|---|:---:|
+| [EIP-2926](./eip-2926.md) | Introduce code-chunking in an MPT context. | Pricing extension | State |
+| [EIP-7686](./eip-7686.md) | Adjust memory limits and gas limits of sub-calls to create a clear linear bound on how much total memory an EVM execution can consume. | Pricing extension | Memory |
+| [EIP-7923](./eip-7923.md) | Linearize Memory Costing and replace the current quadratic formula with a page-based cost model. | Pricing extension | Memory |
+| [EIP-7971](./eip-7971.md) | Decrease costs for `TLOAD` and `TSTORE` with a transaction-global limit. | Pricing extension | Memory |
+| [EIP-7973](./eip-7973.md) | Introduce warm account writes, decreasing the cost of writing to an account after the first write. | Pricing extension | State |
+| [EIP-8011](./eip-8011.md) | Gas accounting by EVM resource, increasing throughput and improving resource usage controls, with minimal changes to the protocol and UX. | Supporting | NA |
+| [EIP-8032](./eip-8032.md) | Makes `SSTORE` gas cost scale with a contract's storage size to discourage state bloat. | Pricing extension | State |
+| [EIP-8053](./eip-8053.md) | Adds `milli-gas` as the EVM's internal gas accounting unit, reducing rounding errors without impacting UX. | Supporting | NA |
+| [EIP-8057](./eip-8057.md) | Multi‑block temporal locality discounts for state and account access. | Pricing extension | State |
+| [EIP-8058](./eip-8058.md) | Reduces gas costs for deploying duplicate contract bytecode via access-list based mechanism. | Pricing extension | State |
+| [EIP-8059](./eip-8059.md) | Gas parameters and variables are increased to a factor of `REBASE_FACTOR` to reduce rounding errors without major changes to the EVM. | Supporting | NA |
 
 ## Rationale
 
-Discussed in the individual EIPs.
+### Gas cost changes by operation
+
+The following tables summarize the preliminary gas cost changes. Numbers are not yet finalized and will be subject to change.
+
+#### Compute Opcodes — [EIP-7904](./eip-7904.md) (all increase)
+
+| Opcode | Name | Current | New | Direction |
+| --- | --- | ---: | ---: | --- |
+| 0x04 | `DIV` | 5 | 15 | increase |
+| 0x05 | `SDIV` | 5 | 20 | increase |
+| 0x06 | `MOD` | 5 | 12 | increase |
+| 0x09 | `MULMOD` | 8 | 11 | increase |
+| 0x20 | `KECCAK256` (base) | 30 | 45 | increase |
+
+`KECCAK256` per-word cost stays at 6. `ADDMOD`, `SMOD`, and `ECRECOVER` are unchanged.
+
+#### Precompiles — [EIP-7904](./eip-7904.md) (all increase)
+
+| Precompile | Current | New | Direction |
+| --- | ---: | ---: | --- |
+| `BLAKE2F` (base) | 0 | 170 | increase |
+| `BLAKE2F` (per round) | 1 | 2 | increase |
+| `BLS12_G1ADD` | 375 | 643 | increase |
+| `BLS12_G2ADD` | 600 | 765 | increase |
+| `ECADD` | 150 | 314 | increase |
+| `ECPAIRING` (per pair) | 34,000 | 34,103 | increase (slight) |
+| `POINT_EVALUATION` | 50,000 | 89,363 | increase |
+
+#### State Access — [EIP-8038](./eip-8038.md) (all increase, values TBD)
+
+| Opcode(s) | Component | Current | New | Direction |
+| --- | --- | ---: | --- | --- |
+| `SSTORE` | `GAS_COLD_STORAGE_WRITE` | 5,000 | TBD | increase |
+| `SSTORE`, `SLOAD` | `GAS_COLD_STORAGE_ACCESS` | 2,100 | TBD | increase |
+| `CALL`, `STATICCALL`, `DELEGATECALL`, `BALANCE`, `EXT*`, `SELFDESTRUCT` | `GAS_COLD_ACCOUNT_ACCESS` | 2,600 | TBD | increase |
+| All state ops (warm) | `GAS_WARM_ACCESS` | 100 | TBD | increase |
+| `EXTCODESIZE` | Extra warm read for 2nd DB lookup | 0 | +`GAS_WARM_ACCESS` | increase (new) |
+| `EXTCODECOPY` | Extra warm read for 2nd DB lookup | 0 | +`GAS_WARM_ACCESS` | increase (new) |
+| `SSTORE`, `SLOAD` (access list) | `ACCESS_LIST_STORAGE_KEY_COST` | 1,900 | TBD | increase |
+| `CALL` etc. (access list) | `ACCESS_LIST_ADDRESS_COST` | 2,400 | TBD | increase |
+
+#### State Creation — [EIP-8037](./eip-8037.md) (all increase, dynamic with gas limit)
+
+At 60M gas limit, `cost_per_state_byte` (cpsb) = 662. Costs scale up with higher gas limits.
+
+| Operation | Opcodes Affected | Current | New (at 60M) | Direction |
+| --- | --- | ---: | ---: | --- |
+| `GAS_CREATE` | `CREATE`, `CREATE2`, create txs | 32,000 | 112 x cpsb + 9,000 (~83k) | increase |
+| `GAS_CODE_DEPOSIT` | `CREATE`, `CREATE2`, create txs | 200/byte | cpsb/byte + hash (~662/byte) | increase |
+| `GAS_NEW_ACCOUNT` | `CALL*` to new accounts | 25,000 | 112 x cpsb (~74k) | increase |
+| `GAS_STORAGE_SET` | `SSTORE` (0 -> non-zero) | 20,000 | 32 x cpsb + 2,900 (~24k) | increase |
+| `PER_AUTH_BASE_COST` | EIP-7702 auth | 12,500 | 23 x cpsb + 7,500 (~22.7k) | increase |
+| `PER_EMPTY_ACCOUNT_COST` | EIP-7702 auth | 25,000 | 112 x cpsb (~74k) | increase |
+
+#### Transaction-Level Costs
+
+| Parameter | Current | New | Direction | EIP |
+| --- | ---: | --- | --- | --- |
+| `TX_BASE_COST` | 21,000 | 4,500 | decrease | [2780](./eip-2780.md) |
+| New account surcharge (top-level value tx) | 0 | 25,000 | increase | [2780](./eip-2780.md) |
+| Calldata floor cost | 10/40 per byte | 15/60 per byte | increase | [7976](./eip-7976.md) |
+| Access list data cost | 0 | `floor_token_cost` per token | increase (new) | [7981](./eip-7981.md) |
 
 ## Security Considerations
 


### PR DESCRIPTION
- Splits the single EIP table into separate "Considered for Inclusion" and "Declined for Inclusion" sections, adding a Gas change overview column to the CFI table
- Added detailed Gas cost changes by operation tables in the Rationale section, covering compute opcodes, precompiles (EIP-7904), state access (EIP-8038), state creation (EIP-8037), and transaction-level costs (EIPs 2780, 7976, 7981)