### PR TITLE
Update EIP-8141: relax requirement that APPROVE must be called by top level call frame

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -71,7 +71,7 @@ Frame executes as regular call where the caller address is `ENTRY_POINT`.
 
 ##### `VERIFY` Mode
 
-Identifies the frame as a validation frame. Its purpose is to *verify* that a sender and/or payer authorized the transaction. It must terminate execution with `APPROVE`. Any other result will cause the whole transaction to be invalid.
+Identifies the frame as a validation frame. Its purpose is to *verify* that a sender and/or payer authorized the transaction. It must call `APPROVE` during execution. Failure to do so will result in the whole transaction being invalid.
 
 The execution behaves the same as `STATICCALL`, state cannot be modified.
 
@@ -121,7 +121,7 @@ def compute_sig_hash(tx: FrameTx) -> Hash:
 
 #### `APPROVE` opcode (`0xaa`)
 
-The `APPROVE` opcode is like `RETURN (0xf3)`. It exits the current context successfully, but with a status code beyond the traditional `0` fail and `1` success via the `scope` operand.
+The `APPROVE` opcode is like `RETURN (0xf3)`. It exits the current context successfully and updates the transaction-scoped approval context based on the `scope` operand. It can only be called when `CALLER == frame.target`, otherwise it results in an exceptional halt.
 
 ##### Stack
 
@@ -141,19 +141,23 @@ The scope operand must be one of the following values:
 
 Any other value results in an exceptional halt.
 
-##### Status Code
+##### Behavior
 
-The status of a call returning with `APPROVE` has three new potential status codes.
+The behavior of `APPROVE` is defined as follows:
 
-| Code | Result               | Description                                      |
-| ---- | -------------------- | ------------------------------------------------ |
-| 0    | `FAIL`               | Call reverted                                    |
-| 1    | `SUCCESS`            | Call completed successfully                      |
-| 2    | `APPROVED_EXECUTION` | Call approved execution successfully             |
-| 3    | `APPROVED_PAYMENT`   | Call approved payment successfully               |
-| 4    | `APPROVED_BOTH`      | Call approved execution and payment successfully |
-
-*Note: codes `0` and `1` already exist today and are replicated here for completeness.*
+- If `APPROVE` is called when `CALLER != frame.target`, revert.
+- For scopes `0`,`1`, and `2`, execute the following:
+    - `0x0`: Set `sender_approved = true`.
+        - If `sender_approved` was already set, revert the frame.
+        - If `CALLER` != `tx.sender`, revert the frame.
+    - `0x1`: Increment the sender's nonce, collect the total gas cost of the transaction from the account, and set `payer_approved = true`.
+        - If payer_approved` was already set, revert the frame.
+        - If `frame.target` has insufficient balance, revert the frame.
+        - If `sender_approved == false`, revert the frame.
+   - `0x2`: `sender_approved = true`, increment the sender's nonce, collect the total gas cost of the transaction from `frame.target`, and set `payer_approved = true`.
+        - If `sender_approved` or `payer_approved` was already set, revert the frame.
+        - If `CALLER` != `tx.sender`, revert the frame.
+        - If `frame.target` has insufficient balance, revert the frame.
 
 #### `TXPARAM*` opcodes
 
@@ -211,15 +215,7 @@ Then for each call frame:
    - If mode is `DEFAULT` or `VERIFY`:
        - Set the `caller` to `ENTRY_POINT`.
    - The `ORIGIN` opcode returns frame `caller` throughout all call depths.
-2. If the frame exits with `1 < status < 5`, update approval state:
-   - `2` (execution approval): If `target = tx.sender`, set `sender_approved = true`.
-       - If `sender_approved` is already set, revert the frame.
-   - `3` (payment approval): If `payer_approved` is `false`, increment the sender's nonce, collect the total gas cost of the transaction from `target`, and set `payer_approved = true`.
-       - If `target` has insufficient balance, the transaction is invalid.
-       - If `sender_approved == false` and status is `3`, revert the frame.
-       - If `sender_approved == true` and status is `4`, revert the frame.
-   - `4` (both): Apply rule for status `2` then for status `3`.
-3. If frame has mode `VERIFY` and the frame did not terminate with status `1 < status < 5`, the transaction is not valid.
+2. If frame has mode `VERIFY` and the frame did successfully call `APPROVE`, the transaction is invalid.
 
 After executing all frames, verify that `payer_approved == true`. If it is, refund any unpaid gas to the gas payer. If it is not, the whole transaction is invalid.
 
@@ -271,7 +267,11 @@ The `frame.data` of `VERIFY` frames is elided from the signature hash. This is d
 
 1. It contains the signature so by definition it cannot be part of the signature hash.
 2. In the future it may be desired to aggregate the cryptographic operations for data and compute efficiency reasons. If the data was introspectable, it would not be possible to aggregate the verify frames in the future.
-3. For gas sponsoring workflows, we also recommend using a`VERIFY` frame to approve the gas payment. Here, the input data to the sponsor is intentionally left malleable so it can be added onto the transaction after the `sender` has made its signature. Notably, the `frame.target` of `VERIFY` frames is covered by the signature hash, i.e. the `sender` chooses the sponsor address explicitly.
+3. For gas sponsoring workflows, we also recommend using a `VERIFY` frame to approve the gas payment. Here, the input data to the sponsor is intentionally left malleable so it can be added onto the transaction after the `sender` has made its signature. Notably, the `frame.target` of `VERIFY` frames is covered by the signature hash, i.e. the `sender` chooses the sponsor address explicitly.
+
+### `APPROVE` calling convention
+
+Originally `APPROVE` was meant to extend the space of return statuses from 0 and j 1 today to 0 to 4. However, this would mean smart accounts deployed today would not beable to modify their contract code to return with a different value at the top level. For this reason, we've chosen behavior above: `APPROVE` terminates the executing frame successfully like `RETURN`, but it actually updates the transaction scoped values `sender_approved` and `payer_approved` during execution. It is still required that only the sender can toggle the `sender_approved` to `true`. Only the `frame.target` can call `APPROVE` generally, because it can allow the transaction pool and other frames to better reason about `VERIFY` mode frames.
 
 ### Payer in receipt
 
@@ -300,7 +300,7 @@ It is not required because the account code can send value.
 | 0     | ENTRY_POINT    | Null (sender) | Signature | VERIFY       |
 | 1     | Sender         | Target        | Call data | SENDER       |
 
-Frame 0 verifies the signature and exits with `APPROVE(0x2)` to approve both execution and payment. Frame 1 executes and exits normally via `RETURN`.
+Frame 0 verifies the signature and calls `APPROVE(0x2)` to approve both execution and payment. Frame 1 executes and exits normally via `RETURN`.
 
 The mempool can process this transaction with the following static validation and call:
 
@@ -340,8 +340,8 @@ The first frame would call a deployer contract, like EIP-7997. The deployer dete
 | 3     | Sender      | Target addr   | Call data              | SENDER  |
 | 4     | ENTRY_POINT | Sponsor       | Post op call           | DEFAULT |
 
-- Frame 0: Verifies signature and exits with `APPROVE(0x0)` to authorize execution from sender.
-- Frame 1: Checks that the user has enough ERC-20 tokens, and that the next frame is an ERC-20 send of the right size to the sponsor. Exits with `APPROVE(0x1)` to authorize payment.
+- Frame 0: Verifies signature and calls `APPROVE(0x0)` to authorize execution from sender.
+- Frame 1: Checks that the user has enough ERC-20 tokens, and that the next frame is an ERC-20 send of the right size to the sponsor. Calls `APPROVE(0x1)` to authorize payment.
 - Frame 2: Sends tokens to sponsor.
 - Frame 3: User's intended call.
 - Frame 4 (optional): Check unpaid gas, refund tokens, possibly convert tokens to ETH on an AMM.
@@ -438,7 +438,7 @@ Such transactions are valid when submitted but become invalid once the deadline 
 
 Node implementations should consider restricting which opcodes and storage slots validation frames can access, similar to ERC-7562. This isolates transactions from each other and limits mass invalidation vectors.
 
-It's recommended that to *validate* the transaction, a specific frame structure is enforced and the amount of gas that is expended executing the validation phase must be limited. Once the frame exits with `APPROVE(0x2)`, it can be included in the mempool and propagated to peers safely.
+It's recommended that to *validate* the transaction, a specific frame structure is enforced and the amount of gas that is expended executing the validation phase must be limited. Once the frame calls `APPROVE(0x2)`, it can be included in the mempool and propagated to peers safely.
 
 For deployment of the sender account in the first frame, the mempool must only allow specific and known deployer factory  contracts to be used as `frame.target`, to ensure deployment is deterministic and independent of chain state.
 


### PR DESCRIPTION
This is allows existing smart accounts to more easily adopt EIP-8141. Before, the requirement was that accounts must exit the top level frame with APPROVE. Since APPROVE only exists with 8141, not smart accounts today support it. More importantly, smart accounts who are deployed with proxies _can_ change their smart account implementations, but still not the outer proxy which won't understand `APPROVE`.