### PR TITLE
Update EIP-8141: fix typo

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -215,7 +215,7 @@ Then for each call frame:
    - If mode is `DEFAULT` or `VERIFY`:
        - Set the `caller` to `ENTRY_POINT`.
    - The `ORIGIN` opcode returns frame `caller` throughout all call depths.
-2. If frame has mode `VERIFY` and the frame did successfully call `APPROVE`, the transaction is invalid.
+2. If frame has mode `VERIFY` and the frame did not successfully call `APPROVE`, the transaction is invalid.
 
 After executing all frames, verify that `payer_approved == true`. If it is, refund any unpaid gas to the gas payer. If it is not, the whole transaction is invalid.
 


### PR DESCRIPTION
Should revert if `APPROVE` is _not_ called successfully.