### PR TITLE
Add EIP: eth/71 - Block Access List Exchange

### DIFF
--- a/EIPS/eip-8159.md
+++ b/EIPS/eip-8159.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: Networking
 created: 2026-02-12
-requires: 7928
+requires: 7928, 7975
 ---
 
 ## Abstract


### PR DESCRIPTION
This is the EIP for eth/71, which introduces Block-level Access Lists support to the eth protocol.

Related discussion:
https://github.com/ethereum/devp2p/pull/264