### PR TITLE
Update EIP-7708: Add ETH burn logs and improve spec consistency

### DIFF
--- a/EIPS/eip-7708.md
+++ b/EIPS/eip-7708.md
@@ -1,7 +1,7 @@
 ---
 eip: 7708
-title: ETH transfers emit a log
-description: All ETH transfers emit a log
+title: ETH transfers and burns emit a log
+description: All ETH transfers and burns emit a log
 author: Vitalik Buterin (@vbuterin), Peter Davies (@petertdavies), Etan Kissling (@etan-status), Gajinder Singh (@g11tech), Carson (@carsons-eels), Jared Wasinger (@jwasinger)
 discussions-to: https://ethereum-magicians.org/t/eip-7708-eth-transfers-emit-a-log/20034
 status: Draft
@@ -13,7 +13,7 @@ requires: 1559, 4788, 6780
 
 ## Abstract
 
-All ETH-transfers, including transactions, `CALL` and `SELFDESTRUCT` emit a log.
+All ETH transfers and burns emit a log.
 
 ## Motivation
 
@@ -39,21 +39,21 @@ A log, identical to a LOG3, is issued for:
 
 This matches the [ERC-20](./eip-20.md) Transfer event definition.
 
-### Selfdestruct processing
+### ETH burn logs
 
 A log, identical to a LOG2, is issued for:
 
-- Any non-zero balance removal which occurs when a contract created in the same transaction invokes `SELFDESTRUCT` with itself as a target, at the time that the opcode is invoked.
-- Each account which has been marked for deletion and holds a balance at the time of removal during transaction finalization.  Burn logs are emitted after any other logs created by EVM execution and the payment of the [EIP-1559](./eip-1559.md) priority fee to the coinbase, in lexicographical order of account address
+- Any nonzero-balance `SELFDESTRUCT` to self by a contract created in the same transaction, at the time the opcode is invoked
+- Any nonzero-balance account marked for deletion, at the time of removal during transaction finalization
+
+Burn logs are emitted after all other logs created by EVM execution and the payment of the [EIP-1559](./eip-1559.md) priority fee to the coinbase. When multiple accounts are marked for deletion, burn logs are emitted in lexicographical order of account address.
 
 | Field | Value |
 | - | - |
 | `address` emitting log | `0xfffffffffffffffffffffffffffffffffffffffe` ([`SYSTEM_ADDRESS`](./eip-4788.md)) |
-| `topics[0]` | `0x4bfaba3443c1a1836cd362418edc679fc96cae8449cbefccb6457cdf2c943083` (`keccak256('Selfdestruct(address,uint256)')`) |
-| `topics[1]` | Closed `contract_address` (zero prefixed to fill uint256) |
-| `data` | `amount` in Wei (big endian uint256)
-
-The Selfdestruct log is emitted when (1) a `SELFDESTRUCT` to self is triggered, or when (2) a smart contract is closed after receiving more ETH after already flagged for `SELFDESTRUCT`.
+| `topics[0]` | `0xcc16f5dbb4873280815c1ee09dbd06736cffcc184412cf7a71a0fdb75d397ca5` (`keccak256('Burn(address,uint256)')`) |
+| `topics[1]` | `address` (zero prefixed to fill uint256) |
+| `data` | `amount` in Wei (big endian uint256) |
 
 ## Rationale
 


### PR DESCRIPTION
## Overview

ETH can be minted (added to circulation), transferred (moved between accounts), and burned (removed from circulation). Changes in circulation or ownership should be logged. The focus should be on *what* changed, not *how* it changed. 
This is done correctly for transfers, which emit a `Transfer` log. It does not specify how the transfer happened (`CALL` vs `SELFDESTRUCT`).

When ETH is burned, it should emit a `Burn(address,uint256)` log ("the what"), not a `SELFDESTRUCT(address,uint256)` log ("the how"). 

We are currently tracking a subset of changes. A consistent API allows for easier extensions. Logging ETH burns in other ways besides `SELFDESTRUCT`, for example.

## What changed
This PR:

  - Adds ETH burn logging alongside transfer logging for a consistency                                                                                                                                                    
  - Renames Selfdestruct event to Burn to describe what changed rather than how                                                                                                                                                                               
  - Restructures the specification for consistency between transfer and burn sections                                                                                                                                                                         
  - Fixes table formatting (missing delimiter)                                                                                                                                                                                                                
  - Updates title, description, and abstract to reflect both transfer and burn coverage  