### PR TITLE
Update EIP-8141: Fix broken relative link to EIP-2718 in EIP-8141

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -305,7 +305,7 @@ Frame 0 verifies the signature and calls `APPROVE(0x2)` to approve both executio
 The mempool can process this transaction with the following static validation and call:
 
 - Verify that the first frame is a `VERIFY` frame.
-- Verify that the call of frame 0 succeeds, and does not violate the mempool rules (similar to [ERC-7562](./eip-7562.md)).
+- Verify that the call of frame 0 succeeds, and does not violate the mempool rules (similar to ERC-7562).
 
 #### Example 1a: Simple ETH transfer
 


### PR DESCRIPTION
Fixes a broken relative link reference to EIP-2718 in the EIP-8141 specification.
