### PR TITLE
Update EIP-7851: Move to Draft

### DIFF
--- a/EIPS/eip-7851.md
+++ b/EIPS/eip-7851.md
@@ -152,6 +152,7 @@ contract EIP7851KeyDeactivation {
     function status(address account) external view returns (uint8) {
         uint64 ts = finalizationTimestamp[account];
         if (ts == 0) return ACTIVE;
+        if (block.timestamp < ts) return PENDING;
         if (_has7702DelegationPrefix(account)) return DEACTIVATED;
         return DORMANT;
     }
@@ -167,7 +168,7 @@ contract EIP7851KeyDeactivation {
 
 ### Contracts Using ECDSA Signatures
 
-Deployed contracts using ECDSA signatures (e.g., `permit` of [ERC-2612](./eip-2612)) will not automatically respect deactivation. New or upgradeable contracts SHOULD call the system contract's `status()` and reject signatures from addresses in the **DEACTIVATED** state
+Deployed contracts using ECDSA signatures (e.g., `permit` of [ERC-2612](./eip-2612)) will not automatically respect deactivation. New or upgradeable contracts SHOULD call the system contract's `status()` and reject signatures from addresses in the **DEACTIVATED** state.
 
 For non-upgradeable contracts, the above method cannot be applied directly. The only clear path available, at the protocol level, is to modify `ecRecover` precompiled contract: if the private key of the recovered address is deactivated, the `ecRecover` precompiled contract could return a precompile contract error (or, if not adding an error return path, return a zero address or a collision-resistant address, such as `0x1`). This is complemented by a companion EIP that mitigates `ecRecover`-related risks by making the precompile aware of private key deactivation status.
 


### PR DESCRIPTION
Credit to @nconsigny for proposing the irreversible (no reactivation) design and the 7-day cancellation window.

### Summary of changes

- **Remove reactivation**: Deactivation is now irreversible to provide post-quantum security guarantees. Allowing ECDSA key reactivation would defeat this purpose.
- **7-day delay with cancellation**: Deactivation is no longer instant. A 7-day delay period allows the ECDSA key holder to `cancel()` before finalization, preventing accidental or unauthorized lockout.
- **Precompile → system contract**: The previous design avoided new per-account fields by encoding the deactivation status into the delegated code's trailing byte — a workable but hacky approach. With the introduction of the 7-day delay, a `finalizationTimestamp` must now be stored per account. Encoding a timestamp into the nonce or delegation designator would complicate their original validation logic, and adding an account-state field would require RLP encoding and p2p protocol changes. A precompile also lacks a natural storage mechanism. Given the need for new per-account state, a system contract (following the EIP-4788/EIP-2935/EIP-7002 pattern) is the cleanest fit — it consolidates deactivation, cancellation, and status queries into a single on-chain entry point with straightforward storage access.
