### PR TITLE
Update EIP-7773: Add EIP-7975 and EIP-8159 to the CFI list

### DIFF
--- a/EIPS/eip-7773.md
+++ b/EIPS/eip-7773.md
@@ -42,6 +42,8 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Declined
 * [EIP-8061](./eip-8061.md): Increase exit and consolidation churn
 * [EIP-8070](./eip-8070.md): Sparse Blobpool
 * [EIP-8080](./eip-8080.md): Let exits use the consolidation queue
+* [EIP-7975](./eip-7975.md): eth/70 - partial block receipt lists
+* [EIP-8159](./eip-8159.md): eth/71 - Block Access List Exchange
 
 ### Declined for Inclusion
 


### PR DESCRIPTION
As discussed in ACD 230, this adds the 2 devp2p upgrades to the CFI list.