### PR TITLE
Update EIP-8125: "surchage" → "surcharge"

### DIFF
--- a/EIPS/eip-8125.md
+++ b/EIPS/eip-8125.md
@@ -47,7 +47,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 | `TEMP_STORAGE_SYSTEM_ADDRESS_0` | TBD | First reserved address used to store temporary storage |
 | `TEMP_STORAGE_SYSTEM_ADDRESS_1` | TBD | Second reserved address used to store temporary storage |
 | `TMPLOAD_GAS` | TBD | The gas cost of a warm read at temporary storage slot |
-| `COLD_TMPLOAD_COST` | TBD | The gas cost surchage of a cold access at the temporary storage |
+| `COLD_TMPLOAD_COST` | TBD | The gas cost surcharge of a cold access at the temporary storage |
 | `TMPSTORE_SET_GAS` | TBD | The gas cost of setting a slot from zero to non-zero at the temporary storage |
 | `TMPSTORE_RESET_GAS` | TBD | The gas cost of changing a non-zero slot to another value at the temporary storage |
 


### PR DESCRIPTION
Fixed a spelling error in EIP-8125 specification document.
