### PR TITLE
Update EIP-7928: simplify capping of block-level access list

### DIFF
--- a/EIPS/eip-7928.md
+++ b/EIPS/eip-7928.md
@@ -260,8 +260,8 @@ Record **post‑transaction nonces** for:
 - **EIP‑4895 (Consensus layer withdrawals):** Recipients are recorded with their final balance after the withdrawal.
 - **EIP‑2935 (block hash):** Record system contract storage diffs of the **single** updated storage slot in the ring buffer.
 - **EIP‑4788 (beacon root):** Record system contract storage diffs of the **two** updated storage slots in the ring buffer.
-- **EIP‑7002 (withdrawals):** Record system contract storage diffs of storage slots **0–3** (4 slots) after the dequeuing call.
-- **EIP‑7251 (consolidations):** Record system contract storage diffs of storage slots **0–3** (4 slots) after the dequeuing call.
+- **EIP‑7002 (withdrawals):** Record system contract storage diffs of storage slots **0–3** (4 slots) after the dequeuing call. The dequeue also reads up to 3 × `MAX_WITHDRAWAL_REQUESTS_PER_BLOCK` queue data slots (from slot 4 onward), which appear as storage_reads.
+- **EIP‑7251 (consolidations):** Record system contract storage diffs of storage slots **0–3** (4 slots) after the dequeuing call. The dequeue also reads up to 4 × `MAX_CONSOLIDATION_REQUESTS_PER_BLOCK` queue data slots (from slot 4 onward), which appear as storage_reads.
 
 ### Engine API
 


### PR DESCRIPTION
Simplifies the BAL size constraint from

`bal_items * ITEM_COST <= available_gas + system_allowance`

, which required and CL-coupled constants (`MAX_WITHDRAWAL_REQUESTS_PER_BLOCK` and `MAX_CONSOLIDATION_REQUESTS_PER_BLOCK`)

to

`bal_items <= block_gas_limit // 2000`.

With EIP-7981, the true minimum cost per BAL item is `COLD_SLOAD_COST` (2100); using 2000 implicitly creates ~`gas_limit / 42,000` items of buffer (~857 at 36M gas) that absorbs the ~87 BAL entries from system contracts and withdrawals without referencing any external constants.