### PR TITLE
Update EIP-7980: Fix broken LICENSE link in EIP-7980

### DIFF
--- a/EIPS/eip-7980.md
+++ b/EIPS/eip-7980.md
@@ -75,4 +75,4 @@ Needs discussion.
 
 ## Copyright
 
-Copyright and related rights waived via [CC0](../../LICENSE.md).
+Copyright and related rights waived via [CC0](../LICENSE.md).


### PR DESCRIPTION
Fixes broken relative path to LICENSE.md in EIP-7980.