### PR TITLE
Update EIP-3540: Suggest version range reservation

### DIFF
--- a/EIPS/eip-3540.md
+++ b/EIPS/eip-3540.md
@@ -214,6 +214,10 @@ The alternative is to have execution time validation for EOF. This is performed 
 The version number 0 will never be used in EOF, so we can call legacy code *EOF0*.
 Also, implementations may use APIs where 0 version number denotes legacy code.
 
+### Version range reservation
+
+Consider reserving versions `0x02`–`0xFE` for future EOF versions and `0xFF` for extensions or escape sequences.
+
 ### Section structure
 
 We have considered different questions for the sections:


### PR DESCRIPTION
Suggests reserving versions 0x02–0xFE for future EOF versions and 0xFF for extensions.