### PR TITLE
Update EIP-8148: correct `MAX_REQUESTS_PER_BLOCK` in bytecode from 2 to 16

### DIFF
--- a/EIPS/eip-8148.md
+++ b/EIPS/eip-8148.md
@@ -380,13 +380,13 @@ dup1
 dup3
 sub
 dup1
-push1 0x02
+push1 0x10
 gt
 push1 0xdf
 jumpi
 
 pop
-push1 0x02
+push1 0x10
 
 jumpdest
 push0


### PR DESCRIPTION
<!-- Why was this wrong? -->
The bytecode contained `push1 0x02` (2 requests) instead of `push1 0x10` (16 requests), contradicting the constant `MAX_SET_SWEEP_THRESHOLD_REQUESTS_PER_BLOCK = 16` defined in the specification table. This reduced throughput by 8x and caused queue congestion.

<!-- What changed? -->
Fixed two occurrences in the system call bytecode to use `0x10` (16), matching EIP-7002's implementation and the documented constant.