### PR TITLE
Update EIP-2780: fix typo

### DIFF
--- a/EIPS/eip-2780.md
+++ b/EIPS/eip-2780.md
@@ -30,8 +30,8 @@ Capacity impact (illustrative):
 | --------------------------- | ----------------: | ------: |------------------------------------------------------------- |
 | Max (minimal txs)           | 13,333 tx / block |   +367% | 4,500-gas minimal transactions per 60 M block                |
 | Max (ETH transfers)         | 10,000 tx / block |   +250% | 6,000-gas ETH transfers per 60 M block                       |
-| Thoughput (minimal txs)     |        ~1,111 TPS |   +367% | 4,500-gas minimal transactions per 60 M block per 12sec      |
-| Thoughput (ETH transfers)   |          ~833 TPS |   +250% | 6,000-gas ETH transfers per 60 M block per 12sec             |
+| Throughput (minimal txs)    |        ~1,111 TPS |   +367% | 4,500-gas minimal transactions per 60 M block per 12sec      |
+| Throughput (ETH transfers)  |          ~833 TPS |   +250% | 6,000-gas ETH transfers per 60 M block per 12sec             |
 | Equivalent gas-limit uplift |          ≈ +20.8% |       - | Effective throughput gain for ave tx usage (e.g., 60 M => ~72.5 M) |
 
 ## Motivation


### PR DESCRIPTION
Corrected `Thoughput` to `Throughput`