### PR TITLE
Website: resolve Liquid syntax warnings in eip.html layout

### DIFF
--- a/_layouts/eip.html
+++ b/_layouts/eip.html
@@ -23,7 +23,11 @@ layout: default
   {% else %}
     {% assign doc_prefix = "EIP" %}
   {% endif %}
-  {% assign is_draft_stage = page.status == "Draft" or page.status == "Stagnant" or page.status == "Withdrawn" or page.status == "Review" or page.status == "Last Call" %}
+  {% if page.status == "Draft" or page.status == "Stagnant" or page.status == "Withdrawn" or page.status == "Review" or page.status == "Last Call" %}
+    {% assign is_draft_stage = true %}
+  {% else %}
+    {% assign is_draft_stage = false %}
+  {% endif %}
   {% capture doc_title %}
     {{ doc_prefix }}-{{ page.eip | xml_escape }}: {{ page.title | xml_escape }}{% if is_draft_stage %} [DRAFT]{% endif %}
   {% endcapture %}


### PR DESCRIPTION
## Summary
- The `{% assign %}` tag in Liquid doesn't support compound boolean expressions with `or`, causing 1000+ "Expected end_of_string but found comparison" warnings during every Jekyll build
- Replace the invalid `assign` with an `if/else` block to evaluate the condition and assign the result

## Test plan
- [x] Run `bundle exec jekyll build` and confirm zero Liquid syntax warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)