### PR TITLE
Update EIP-7981: Align with EIP-7976 updates

### DIFF
--- a/EIPS/eip-7981.md
+++ b/EIPS/eip-7981.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2024-12-27
-requires: 2930, 7623
+requires: 2930, 7623, 7976
 ---
 
 ## Abstract
@@ -27,11 +27,11 @@ Furthermore, access lists can circumvent the [EIP-7623](./eip-7623.md) floor pri
 | -------------------------------------- | ----- | ------ |
 | `ACCESS_LIST_ADDRESS_COST`            | `2400` | [EIP-2930](./eip-2930.md) |
 | `ACCESS_LIST_STORAGE_KEY_COST`        | `1900` | [EIP-2930](./eip-2930.md) |
-| `TOTAL_COST_FLOOR_PER_TOKEN`          | `10`   | [EIP-7623](./eip-7623.md) |
+| `TOTAL_COST_FLOOR_PER_TOKEN`          | `16`   | [EIP-7976](./eip-7976.md) |
 
-Let `access_list_nonzero_bytes` and `access_list_zero_bytes` be the count of non-zero and zero bytes respectively in the addresses (20 bytes each) and storage keys (32 bytes each) contained within the access list.
+Let `access_list_bytes` be the total byte count of addresses (20 bytes each) and storage keys (32 bytes each) in the access list.
 
-Let `tokens_in_access_list = access_list_zero_bytes + access_list_nonzero_bytes * 4`.
+Let `floor_tokens_in_access_list = access_list_bytes * 4`.
 
 The access list cost formula changes from [EIP-2930](./eip-2930.md) to include data cost:
 
@@ -39,17 +39,17 @@ The access list cost formula changes from [EIP-2930](./eip-2930.md) to include d
 access_list_cost = (
     ACCESS_LIST_ADDRESS_COST * access_list_addresses
     + ACCESS_LIST_STORAGE_KEY_COST * access_list_storage_keys
-    + TOTAL_COST_FLOOR_PER_TOKEN * tokens_in_access_list
+    + TOTAL_COST_FLOOR_PER_TOKEN * floor_tokens_in_access_list
 )
 ```
 
-The [EIP-7623](./eip-7623.md) floor calculation is modified to include access list tokens:
+The [EIP-7976](./eip-7976.md) floor calculation is modified to include access list tokens:
 
 ```python
-tokens_in_calldata = zero_bytes_in_calldata + nonzero_bytes_in_calldata * 4
-total_data_tokens = tokens_in_calldata + tokens_in_access_list
+floor_tokens_in_calldata = (zero_bytes_in_calldata + nonzero_bytes_in_calldata) * 4
+total_floor_data_tokens = floor_tokens_in_calldata + floor_tokens_in_access_list
 
-data_floor_gas_cost = TX_BASE_COST + TOTAL_COST_FLOOR_PER_TOKEN * total_data_tokens
+data_floor_gas_cost = TX_BASE_COST + TOTAL_COST_FLOOR_PER_TOKEN * total_floor_data_tokens
 ```
 
 The gas used calculation becomes:
@@ -63,12 +63,12 @@ tx.gasUsed = (
         + execution_gas_used
         + isContractCreation * (32000 + INITCODE_WORD_COST * words(calldata))
         + access_list_cost,
-        TOTAL_COST_FLOOR_PER_TOKEN * total_data_tokens
+        TOTAL_COST_FLOOR_PER_TOKEN * total_floor_data_tokens
     )
 )
 ```
 
-Any transaction with a gas limit below `21000 + TOTAL_COST_FLOOR_PER_TOKEN * total_data_tokens` or below its intrinsic gas cost is considered invalid.
+Any transaction with a gas limit below `21000 + TOTAL_COST_FLOOR_PER_TOKEN * total_floor_data_tokens` or below its intrinsic gas cost is considered invalid.
 
 ## Rationale
 
@@ -87,25 +87,16 @@ Requires updates to gas estimation in wallets and nodes. Normal usage patterns r
 ## Reference Implementation
 
 ```python
-def calculate_access_list_tokens(access_list: Tuple[Access, ...]) -> Uint:
-    """Count data tokens in access list addresses and storage keys."""
-    zero_bytes = Uint(0)
-    nonzero_bytes = Uint(0)
+def calculate_access_list_floor_tokens(access_list: Tuple[Access, ...]) -> Uint:
+    """Count floor data tokens in access list addresses and storage keys."""
+    total_bytes = Uint(0)
 
     for access in access_list:
-        for byte in access.account:
-            if byte == 0:
-                zero_bytes += Uint(1)
-            else:
-                nonzero_bytes += Uint(1)
+        total_bytes += ulen(access.account)
         for slot in access.slots:
-            for byte in slot:
-                if byte == 0:
-                    zero_bytes += Uint(1)
-                else:
-                    nonzero_bytes += Uint(1)
+            total_bytes += ulen(slot)
 
-    return zero_bytes + nonzero_bytes * Uint(4)
+    return total_bytes * Uint(4)
 
 
 def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
@@ -113,29 +104,33 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
     Calculate intrinsic gas cost and floor gas cost.
     Returns (intrinsic_gas, floor_gas).
     """
-    # Calldata tokens
+    # Calldata tokens (EIP-7976)
     calldata_zero_bytes = Uint(0)
     for byte in tx.data:
         if byte == 0:
             calldata_zero_bytes += Uint(1)
+    calldata_nonzero_bytes = ulen(tx.data) - calldata_zero_bytes
     tokens_in_calldata = (
-        calldata_zero_bytes + (ulen(tx.data) - calldata_zero_bytes) * Uint(4)
+        calldata_zero_bytes + calldata_nonzero_bytes * Uint(4)
+    )
+    floor_tokens_in_calldata = (
+        (calldata_zero_bytes + calldata_nonzero_bytes) * Uint(4)
     )
 
-    # Access list tokens and cost
-    tokens_in_access_list = Uint(0)
+    # Access list floor tokens and cost
+    floor_tokens_in_access_list = Uint(0)
     access_list_cost = Uint(0)
     if has_access_list(tx):
-        tokens_in_access_list = calculate_access_list_tokens(tx.access_list)
+        floor_tokens_in_access_list = calculate_access_list_floor_tokens(tx.access_list)
         for access in tx.access_list:
             access_list_cost += TX_ACCESS_LIST_ADDRESS_COST
             access_list_cost += ulen(access.slots) * TX_ACCESS_LIST_STORAGE_KEY_COST
         # EIP-7981: Always charge data cost
-        access_list_cost += tokens_in_access_list * TOTAL_COST_FLOOR_PER_TOKEN
+        access_list_cost += floor_tokens_in_access_list * TOTAL_COST_FLOOR_PER_TOKEN
 
-    # EIP-7981: Floor includes all data tokens
-    total_data_tokens = tokens_in_calldata + tokens_in_access_list
-    floor_gas = TX_BASE_COST + total_data_tokens * TOTAL_COST_FLOOR_PER_TOKEN
+    # EIP-7981: Floor includes all floor data tokens
+    total_floor_data_tokens = floor_tokens_in_calldata + floor_tokens_in_access_list
+    floor_gas = TX_BASE_COST + total_floor_data_tokens * TOTAL_COST_FLOOR_PER_TOKEN
 
     # Intrinsic gas
     calldata_cost = tokens_in_calldata * STANDARD_TOKEN_COST


### PR DESCRIPTION
Updated EIP-7981 to align with EIP-7976's floor token model: TOTAL_COST_FLOOR_PER_TOKEN updated to 16, access list and calldata floor tokens now use uniform 4x byte weighting, and all formulas/reference implementation updated accordingly.