### PR TITLE
Update EIP-8081: move FOCIL to SFI

### DIFF
--- a/EIPS/eip-8081.md
+++ b/EIPS/eip-8081.md
@@ -20,9 +20,9 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Declined
 
 ### EIPs Scheduled for Inclusion
 
-### Considered for Inclusion
-
 * [EIP-7805](./eip-7805.md): Fork-choice enforced Inclusion Lists (FOCIL)
+
+### Considered for Inclusion
 
 ### Declined for Inclusion
 


### PR DESCRIPTION
## Summary
- Move EIP-7805 (FOCIL) from Considered for Inclusion to Scheduled for Inclusion in the Hegotá meta EIP

following https://github.com/ethereum/pm/issues/1930

🤖 Generated with [Claude Code](https://claude.com/claude-code)