### PR TITLE
Add EIP: Historical Ownership Extension for ERC-721

### DIFF
--- a/EIPS/eip-8042.md
+++ b/EIPS/eip-8042.md
@@ -2,8 +2,8 @@
 eip: 8042
 title: Historical Ownership Extension for ERC-721
 description: An extension to ERC-721 that preserves complete, on-chain ownership history through a three-layer model.
-author: Emiliano Solazzi https://github.com/emilianosolazzi/EIP-721H
-discussions-to: https://ethereum-magicians.org/t/erc-721h-historical-ownership-extension-for-erc-721/27682
+author: Emiliano Solazzi 
+discussions-to: https://ethereum-magicians.org/t/historical-ownership-extension-for-erc-721
 status: Draft
 type: Standards Track
 category: ERC
@@ -316,6 +316,7 @@ Exact costs vary with compiler version, optimizer settings, and storage warmth. 
 This standard is **fully backwards compatible** with [ERC-721](./eip-721.md). Every function defined in ERC-721 behaves identically. Wallets, marketplaces, and tooling that interact with ERC-721 will interact with tokens implementing this standard without modification.
 
 The historical extension is purely additive:
+
 - Existing ERC-721 contracts are **not** affected.
 - No changes to ERC-721 semantics are proposed.
 - Contracts that implement this standard also implement ERC-721 by definition.
@@ -349,6 +350,7 @@ Test files are provided in [`../assets/eip-XXXX/test/`](../assets/eip-XXXX/test/
 ## Reference Implementation
 
 A complete reference implementation is provided in:
+
 - [ERC-721H.sol](../assets/eip-XXXX/ERC-721H.sol) — Core contract (v2.0.0)
 - [IERC721H.sol](../assets/eip-XXXX/IERC721H.sol) — Core interface (10 functions, 3 events) + optional analytics interface (12 functions)
 - [ERC721HStorageLib.sol](../assets/eip-XXXX/ERC721HStorageLib.sol) — Low-level storage library
@@ -367,6 +369,7 @@ The reference implementation uses a two-library architecture:
 All library functions are `internal` — inlined at compile time for zero gas overhead.
 
 A companion `ERC721HFactory.sol` provides:
+
 - **`ERC721HCollection`** — Production wrapper: batch minting, supply cap, public mint with pricing/wallet limits, 5 batch historical query functions, configurable metadata URI.
 - **`ERC721HFactory`** — Permissionless CREATE2 deployer with deterministic cross-chain addresses and paginated registry.
 


### PR DESCRIPTION
Introduced EIP-721H, a historical ownership extension for ERC-721 that maintains complete on-chain ownership history through a three-layer model. This EIP aims to enhance the ERC-721 standard by providing immutable origin tracking, a historical trail of ownership, and current authority semantics.

**ATTENTION: ERC-RELATED PULL REQUESTS NOW OCCUR IN [ETHEREUM/ERCS](https://github.com/ethereum/ercs)**

--

When opening a pull request to submit a new EIP, please use the suggested template: https://github.com/ethereum/EIPs/blob/master/eip-template.md

We have a GitHub bot that automatically merges some PRs. It will merge yours immediately if certain criteria are met:

 - The PR edits only existing draft PRs.
 - The build passes.
 - Your GitHub username or email address is listed in the 'author' header of all affected PRs, inside <triangular brackets>.
 - If matching on email address, the email address is the one publicly listed on your GitHub profile.
