### PR TITLE
Update EIP-8141: Fix some issues with EIP-8141

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -123,7 +123,7 @@ def compute_sig_hash(tx: FrameTx) -> Hash:
 
 The `APPROVE` opcode is like `RETURN (0xf3)`. It exits the current context successfully and updates the transaction-scoped approval context based on the `scope` operand.
 
-`APPROVE` can only be executed when `ADDRESS == frame.target` and only if the frame mode is `VERIFY`.
+If the currently executing account is not `frame.target` (i.e. if `ADDRESS != frame.target`), `APPROVE` reverts.
 
 ##### Stack
 
@@ -147,7 +147,7 @@ Any other value results in an exceptional halt.
 
 The behavior of `APPROVE` is defined as follows:
 
-- If `ADDRESS != frame.target` or the current frame is not `VERIFY`, revert.
+- If `ADDRESS != frame.target`, revert.
 - For scopes `0`,`1`, and `2`, execute the following:
     - `0x0`: Set `sender_approved = true`.
         - If `sender_approved` was already set, revert the frame.
@@ -156,7 +156,7 @@ The behavior of `APPROVE` is defined as follows:
         - If `payer_approved` was already set, revert the frame.
         - If `frame.target` has insufficient balance, revert the frame.
         - If `sender_approved == false`, revert the frame.
-    - `0x2`: `sender_approved = true`, increment the sender's nonce, collect the total gas cost of the transaction from `frame.target`, and set `payer_approved = true`.
+    - `0x2`: Set `sender_approved = true`, increment the sender's nonce, collect the total gas cost of the transaction from `frame.target`, and set `payer_approved = true`.
         - If `sender_approved` or `payer_approved` was already set, revert the frame.
         - If `frame.target` != `tx.sender`, revert the frame.
         - If `frame.target` has insufficient balance, revert the frame.


### PR DESCRIPTION
- Remove several references to how `APPROVE` requires `CALLER == frame.target` which doesn't make sense since a typical `VERIFY` frame will have `CALLER == ENTRY_POINT` and `frame.target == tx.sender`, as seen from the examples.  I believe the real intention is that `APPROVE` should be called by `frame.target` (or more precisely `ADDRESS == frame.target`), so I updated the language accordingly.

- Restrict `APPROVE` to `VERIFY` frames.  I believe this is the intention since `APPROVE` cannot be called from `SENDER` frames and it's not clear why it should ever be called from a `DEFAULT` frame since `DEFAULT` frames can modify state.

- Clarify that frame reverts don't affect subsequent frames.

- Fix some minor typos.