### PR TITLE
Update EIP-2780: Fix minor text issues

### DIFF
--- a/EIPS/eip-2780.md
+++ b/EIPS/eip-2780.md
@@ -190,7 +190,7 @@ Apply `GAS_NEW_ACCOUNT` when **all** are true:
 3. `to` is not a precompile.
 4. `to` is non-existent per [EIP-161](./eip-161.md) emptiness at the start of transaction execution.
 
-The `GAS_NEW_ACCOUNT = 25,000`charge covers state growth (new leaf creation and one `STATE_UPDATE`).
+The `GAS_NEW_ACCOUNT = 25,000` charge covers state growth (new leaf creation and one `STATE_UPDATE`).
 An additional `COLD_ACCOUNT_COST_NOCODE = 500` applies for the initial lookup to determine that the account does not exist.
 
 Thus, the **total** intrinsic gas for a value-transferring transaction to a new account is `30,000` (`4,500 base + 500 lookup + 25,000 new-account surcharge`).
@@ -304,7 +304,7 @@ This EIP composes cleanly with calldata-pricing proposals such as [EIP-7623](./e
 
 ### Why not charge full tx data as calldata?
 
-- **Intrinsic coupling to signed fields.** Pricing full-transaction bytes would make intrinsic gas depend on `gas_limit` and variable-length signature elements, creating fixed-point estimation issues and incentives for signature-length selection as well as iteration unstablity as `gas_limit` depends on signature which contains `gas_limit`.
+- **Intrinsic coupling to signed fields.** Pricing full-transaction bytes would make intrinsic gas depend on `gas_limit` and variable-length signature elements, creating fixed-point estimation issues and incentives for signature-length selection as well as iteration instability as `gas_limit` depends on signature which contains `gas_limit`.
 
 - **Serialization neutrality.** A fee rule keyed to RLP size couples costs to one encoding and weakens [EIP-2718](./eip-2718.md) type neutrality and future formats such as SSZ. Calldata is treated as opaque bytes so it avoids this coupling.
 


### PR DESCRIPTION
Fix two minor text issues in EIP-2780:
- Add missing space after `25,000` in line 193
- Fix "unstablity" → "instability" in line 307

I have thoroughly reviewed the entire EIP for similar issues - these are the only remaining corrections.