### PR TITLE
Update EIP-7904: Fix text issues

### DIFF
--- a/assets/eip-7904/included_operations.md
+++ b/assets/eip-7904/included_operations.md
@@ -75,9 +75,9 @@ An important consideration for repricing is whether poor performance is isolated
 - Operations that genuinely need repricing (multiple clients struggle)
 - Operations where a specific client needs optimization (only one client struggles)
 
-The chart shows the number of tests in which each clietn was the worst performer. We can see that **Besu** is the worst performer in the majority of tests, followed by Erigon.
+The chart shows the number of tests in which each client was the worst performer. We can see that **Besu** is the worst performer in the majority of tests, followed by Erigon.
 
-![worst_client_countt](./figures/worst_client_count.png)
+![worst_client_count](./figures/worst_client_count.png)
 
 The next plot shows the distribution of the performance ratio between the worst client and second-worst client. Each boxplot shows this distribution by the client (i.e., when each client is the worst performer).
 
@@ -144,7 +144,7 @@ We also observed test performing at less than 20Mgas/s. Since there are likely i
 
 - `test_extcode_ops` in Geth and Erigon
 - `test_xcall` in Geth
-- `test_artimetic` in Besu (only `opcode_ADD`)
+- `test_arithmetic` in Besu (only `opcode_ADD`)
 - `test_selfbalance` in Besu (only `contract_balance_0`)
 - `test_call_frame_context_ops` in Besu (`opcode_ORIGIN`)
 


### PR DESCRIPTION
Fix three text issues in EIP-7904 asset file (included_operations.md):
- Fix "clietn" → "client" (line 78)
- Fix broken image link "worst_client_countt" → "worst_client_count" (line 80)
- Fix "test_artimetic" → "test_arithmetic" (line 147)

The broken image link was preventing the figure from rendering correctly.