### PR TITLE
Update EIP-8011: Fix grammar and formatting

### DIFF
--- a/EIPS/eip-8011.md
+++ b/EIPS/eip-8011.md
@@ -24,7 +24,7 @@ There are four main benefits of the proposal:
 1. Throughput gains: By decoupling resource limits, blocks can carry transactions that stress distinct resources simultaneously, improving packing efficiency.
 2. Finer-grained control over excessive resource usage: metering gas costs independently for each resource allows us to tailor each operation's gas cost to the actual resource limits.
 3. Keeps UX identical: users still specify one `gas_limit` and see one `gas_used` value.
-4. Simplicity: This simpler metering change lays the groundwork for eventual multidimensional pricing  (such as [EIP-7999](./eip-7999.md)) without disrupting the current fee market and with minimal protocol changes.
+4. Simplicity: This simpler metering change lays the groundwork for eventual multidimensional pricing (such as [EIP-7999](./eip-7999.md)) without disrupting the current fee market and with minimal protocol changes.
 
 ## Specification
 
@@ -160,7 +160,7 @@ Additionally, state and history growth are not constrained at the block level, b
 
 ### Base fee manipulation
 
-Builders can manipulate the base fee by selectively including or excluding transactions to change the block's `max_gas_metered`. This behavior is already possible with EIP-1559. Yet, multidimensional gas metering compute the base fee on the bottleneck resource instead of the total gas consumed. This allows for blocks that yield the same total fees but with different `max_gas_metered` values. The extent of this concern is limited by the incentives to maximize fee revenue. While the expected gains of base fee manipulation are smaller than execution rewards, we won't observe these attacks.
+Builders can manipulate the base fee by selectively including or excluding transactions to change the block's `max_gas_metered`. This behavior is already possible with EIP-1559. Yet, multidimensional gas metering computes the base fee on the bottleneck resource instead of the total gas consumed. This allows for blocks that yield the same total fees but with different `max_gas_metered` values. The extent of this concern is limited by the incentives to maximize fee revenue. While the expected gains of base fee manipulation are smaller than execution rewards, we won't observe these attacks.
 
 ### Added complexity in block building
 


### PR DESCRIPTION
Fix two minor issues in EIP-8011:
- Fix subject-verb agreement: "metering compute" → "metering computes" (line 163)
- Remove extra space before parenthesis (line 27)