### PR TITLE
Add EIP: Composable Transaction

### DIFF
--- a/EIPS/eip-8175.md
+++ b/EIPS/eip-8175.md
@@ -156,7 +156,7 @@ A valid Composable transaction MUST satisfy the following:
 
 Each capability incurs intrinsic gas costs to account for both the size of the capability data and the cryptographic work required for signature verification. These costs are included in the transaction's intrinsic gas.
 
-TBD
+<-- TODO --> 
 
 ## Rationale
 


### PR DESCRIPTION
New EIP-2718 transaction type with extensible capability-based signatures and native transaction sponsorship.

A simpler alternative to EIP-8141 — no new opcodes, no execution frames, no per-frame gas accounting. The payer co-signs the transaction and their account is charged for gas.