### PR TITLE
Update EIP-7932: Add support for public key / signature separation

### DIFF
--- a/EIPS/eip-7932.md
+++ b/EIPS/eip-7932.md
@@ -66,6 +66,11 @@ trait Algorithm {
     // Take the signature and signing_data and return the
     // public key of the signer.
     fn verify(signature: Bytes, signing_data: Bytes) -> Bytes | Error;
+
+    // Given a public key and corresponding signature, merge them into
+    // a valid signature info container. This function MUST NOT check that
+    // the provided `public_key` matches the signature.
+    fn merge_detached_signature(detached_signature: Bytes, public_key: Bytes) -> Bytes | Error;
 }
 ```
 
@@ -93,6 +98,7 @@ class AlgorithmEntry():
     ALG_TYPE: uint8,
     SIZE: uint32,
     gas_cost: Callable[[Bytes], uint64],
+    merge_detached_signature: Callable[[Bytes, Bytes], Bytes],
     validate: Callable[[Bytes], None | Error],
     verify: Callable[[Bytes, Bytes], Bytes | Error]
 
@@ -175,6 +181,10 @@ def verify(signature: Bytes, signing_data: Bytes) -> Bytes | Error:
     public_key = PublicKey(ecdsa.ecdsa_recover(signing_data, recover_sig, raw=True))
     uncompressed = public_key.serialize(compressed=False)
     return uncompressed
+
+def merge_detached_signature(detached_signature: bytes, _public_key: bytes) -> bytes:
+    # Secp256k1 uses recoverable signatures, this is a no-op.
+    return detached_signature
 ```
 
 ### `sigrecover` precompile

--- a/EIPS/eip-7932.md
+++ b/EIPS/eip-7932.md
@@ -193,7 +193,7 @@ This EIP also introduces a new precompile located at `SIGRECOVER_PRECOMPILE_ADDR
 
 This precompile MUST charge `SIGRECOVER_PRECOMPILE_BASE_GAS` static gas before executing.
 
-The precompile MUST output the 20-byte address of the signer provided left padded to 32 bytes. Callers MUST assume all zero bytes as a failure. On failure, the precompile MUST return 32 `0x00` bytes.
+The precompile MUST output the 20-byte address of the signer provided left padded to 32 bytes. On failure, the precompile MUST NOT return any data.
 
 The precompile is defined as follows:
 

--- a/EIPS/eip-7932.md
+++ b/EIPS/eip-7932.md
@@ -84,8 +84,12 @@ The function below MUST be used when deriving an address from a public key:
 
 ```python
 def pubkey_to_address(public_key: Bytes, algorithm_id: uint8) -> ExecutionAddress:
-    if algorithm_id == 0xFF: # Compatibility shim to ensure backwards compatibility
+    if algorithm_id == 0x00: # Compatibility shim to ensure backwards compatibility
         return ExecutionAddress(keccak(public_key[1:])[12:])
+
+    if len(public_key) == 63:
+        # Prevent collisions with legacy secp256k1
+        return ExecutionAddress(keccak(algorithm_id || 0x00 || public_key)[12:])
 
     # with `||` being binary concatenation
     return ExecutionAddress(keccak(algorithm_id || public_key)[12:])
@@ -109,7 +113,7 @@ This EIP uses the `algorithm_registry` object to signify algorithms that have be
 
 A living EIP MAY be created on finalization of this EIP to track currently active algorithms across forks.
 
-The algorithm type is reserved `0xFE` as invalid / missing.
+The algorithm type is reserved `0x7F` as invalid / missing, algorithm types SHOULD be less than 127.
 
 ### Helper functions
 
@@ -142,7 +146,7 @@ def verify_signature(signing_data: Bytes, signature: Bytes) -> Bytes:
 
 
 ```python
-ALG_TYPE = 0xFF
+ALG_TYPE = 0x00
 SIZE = 66
 
 SECP256K1_SIGNATURE_SIZE = SIZE - 1

--- a/EIPS/eip-7932.md
+++ b/EIPS/eip-7932.md
@@ -113,7 +113,7 @@ This EIP uses the `algorithm_registry` object to signify algorithms that have be
 
 A living EIP MAY be created on finalization of this EIP to track currently active algorithms across forks.
 
-The algorithm type is reserved `0x7F` as invalid / missing, algorithm types SHOULD be less than 127.
+The algorithm type is reserved `0x7F` as invalid / missing, algorithm types MUST be less than 127.
 
 ### Helper functions
 

--- a/EIPS/eip-8030.md
+++ b/EIPS/eip-8030.md
@@ -63,10 +63,14 @@ def verify(signature: Bytes, signing_data: Bytes) -> Bytes | Error:
 
     # This is defined in [P256Verify Function](#p256verify-function)
     assert(P256Verify(signing_data, r, s, x, y) == Bytes("0x0000000000000000000000000000000000000000000000000000000000000001"))
-        
-    return x.to_bytes(32, "big") + y.to_bytes(32, "big")
-```
+    
+    # Return 64 byte public key
+    return x || y
 
+def merge_detached_signature(detached_signature: bytes, public_key: bytes) -> bytes:
+    # Concatenate r,s || x,y
+    return detached_signature + public_key
+```
 
 ### `P256Verify` Function
 

--- a/EIPS/eip-8030.md
+++ b/EIPS/eip-8030.md
@@ -1,7 +1,7 @@
 ---
 eip: 8030
 title: P256 algorithm support
-description: Adds an EIP-7932 algorithm type for P256 support of type `0x0`
+description: Adds an EIP-7932 algorithm type for P256 support of type `0x01`
 author: James Kempton (@SirSpudlington)
 discussions-to: https://ethereum-magicians.org/t/discussion-topic-for-eip-8030/25557
 status: Draft
@@ -13,7 +13,7 @@ requires: 7932, 7951
 
 ## Abstract
 
-This EIP adds a new [EIP-7932](./eip-7932.md) algorithm of type `0x0` for supporting P256 signatures.
+This EIP adds a new [EIP-7932](./eip-7932.md) algorithm of type `0x01` for supporting P256 signatures.
 
 ## Motivation
 
@@ -26,7 +26,7 @@ This EIP defines a new [EIP-7932](./eip-7932.md) algorithmic type with the follo
 
 | Constant | Value |
 | - | - |
-| `ALG_TYPE` | `Bytes1(0x0)` |
+| `ALG_TYPE` | `Bytes1(0x01)` |
 | `SIZE`| `129` |
 
 ```python

--- a/assets/eip-7932/algorithm_registry/helpers.py
+++ b/assets/eip-7932/algorithm_registry/helpers.py
@@ -11,8 +11,11 @@ class ExecutionAddress(ByteVector[20]):
 
 
 def pubkey_to_address(public_key: bytes, algorithm_id: uint8) -> ExecutionAddress:
-    if algorithm_id == 0xFF: # Compatibility shim to ensure backwards compatibility
+    if algorithm_id == 0x00: # Compatibility shim to ensure backwards compatibility
         return ExecutionAddress(keccak(public_key[1:])[12:])
+
+    if len(public_key) == 63:
+        return ExecutionAddress(keccak(algorithm_id + b"\x00" + public_key)[12:])
 
     return ExecutionAddress(keccak(algorithm_id.to_bytes(1, "big") + public_key)[12:])
 

--- a/assets/eip-7932/algorithm_registry/registry.py
+++ b/assets/eip-7932/algorithm_registry/registry.py
@@ -13,6 +13,7 @@ class AlgorithmEntry():
     ALG_TYPE: uint8
     SIZE: uint32
     gas_cost: Callable[[bytes], uint64]
+    merge_detached_signature: Callable[[bytes, bytes], bytes]
     validate: Callable[[bytes], None]
     verify: Callable[[bytes, bytes], bytes]
 
@@ -62,6 +63,10 @@ class Secp256k1(AlgorithmEntry):
         public_key = PublicKey(ecdsa.ecdsa_recover(signing_data, recover_sig, raw=True))
         uncompressed = public_key.serialize(compressed=False)
         return uncompressed
+    
+    def merge_detached_signature(detached_signature: bytes, _public_key: bytes) -> bytes:
+        # Secp256k1 uses recoverable signatures, this is a no-op.
+        return detached_signature
 
 
 algorithm_registry[Secp256k1.ALG_TYPE] = Secp256k1

--- a/assets/eip-7932/algorithm_registry/registry.py
+++ b/assets/eip-7932/algorithm_registry/registry.py
@@ -39,7 +39,7 @@ def secp256k1_validate(signature: ByteVector[SECP256K1_SIGNATURE_SIZE]):
 
 
 class Secp256k1(AlgorithmEntry):
-    ALG_TYPE = 0xFF
+    ALG_TYPE = 0x00
     SIZE = 66
 
     def gas_cost(signing_data: bytes) -> uint64:

--- a/assets/eip-7932/precompile.py
+++ b/assets/eip-7932/precompile.py
@@ -1,6 +1,6 @@
 from algorithm_registry import helpers, registry
 
-INVALID = b"\x00" * 32
+INVALID = b""
 SIGRECOVER_BASE_GAS = 3000
 
 # Modified sigrecover precompile to also return gas

--- a/assets/eip-7932/precompile_test_cases.py
+++ b/assets/eip-7932/precompile_test_cases.py
@@ -28,13 +28,13 @@ test_cases = [
     (b"", (INVALID, 3000)),
 
     # Invalid algorithm (without data)
-    (b"\xFE", (INVALID, 3000)),
+    (b"\x7F", (INVALID, 3000)),
 
     # Invalid algorithm (with data at secp256k1 size)
-    (b"\xFE" + b"\x01" * 65 + b"\x00" * 32, (INVALID, 3000)), 
+    (b"\x7F" + b"\x01" * 65 + b"\x00" * 32, (INVALID, 3000)), 
 
     # Invalid algorithm (with data greater than secp256k1 size)
-    (b"\xFE" + b"\x01" * 66 + b"\x00" * 32, (INVALID, 3000)),
+    (b"\x7F" + b"\x01" * 66 + b"\x00" * 32, (INVALID, 3000)),
 
     #
     # secp256k1

--- a/assets/eip-7932/precompile_test_cases.py
+++ b/assets/eip-7932/precompile_test_cases.py
@@ -3,7 +3,7 @@ import secp256k1
 from precompile import sigrecover_precompile
 from eth_hash.auto import keccak
 
-INVALID = b"\x00" * 32
+INVALID = b""
 
 secp256k1_test_key = bytes.fromhex("1f7627096fa44f0b850f5d9a859d271723ee856e526b947d0d4b011168bdcac1")
 address = b"\x00" * 12 + bytes.fromhex("d3eF791e8a9c9BD26787D262e66e673FE8E7262A")
@@ -41,25 +41,25 @@ test_cases = [
     # 
 
     # secp256k1 (without data)
-    (b"\xFF", (INVALID, 3000)),
+    (b"\x00", (INVALID, 3000)),
 
     # secp256k1 (too little data)
-    (b"\xFF" + b"\xFE" * 64 + b"\x00" * 32, (INVALID, 3036)),
+    (b"\x00" + b"\xFE" * 64 + b"\x00" * 32, (INVALID, 3036)),
 
     # secp256k1 (erroneous data)
-    (b"\xFF" + b"\xFE" * 67 + b"\x00" * 32, (INVALID, 3042)),
+    (b"\x00" + b"\xFE" * 67 + b"\x00" * 32, (INVALID, 3042)),
 
     # secp256k1 (invalid signature)
-    (b"\xFF" + b"\xFE" * 65 + b"\x00" * 32, (INVALID, 3000)),
+    (b"\x00" + b"\xFE" * 65 + b"\x00" * 32, (INVALID, 3000)),
 
     # secp256k1 (valid signature)
-    (b"\xFF" + zero_sig[0] + zero_sig[1].to_bytes(1, "big") + b"\x00" * 32, (address, 3000)),
+    (b"\x00" + zero_sig[0] + zero_sig[1].to_bytes(1, "big") + b"\x00" * 32, (address, 3000)),
 
     # secp256k1 (invalid signature + non 32 byte signing data size)
-    (b"\xFF" + b"\xFE" * 65 + b"\x00" * 30, (INVALID, 3036)),
+    (b"\x00" + b"\xFE" * 65 + b"\x00" * 30, (INVALID, 3036)),
 
     # secp256k1 (valid signature + non 32 byte signing data size)
-    (b"\xFF" + deadbeef_sig[0] + deadbeef_sig[1].to_bytes(1, "big") + bytes.fromhex("deadbeef"), (address, 3036)),
+    (b"\x00" + deadbeef_sig[0] + deadbeef_sig[1].to_bytes(1, "big") + bytes.fromhex("deadbeef"), (address, 3036)),
 ]
 
 
@@ -68,4 +68,6 @@ for (input, (address, gas)) in test_cases:
 
     assert(str(address) == str(o_address))
     assert(gas == o_gas)
+
+print("Test cases pass")
 

--- a/assets/eip-7932/template-eip.md
+++ b/assets/eip-7932/template-eip.md
@@ -38,6 +38,12 @@ def verify(signature: Bytes, signing_data: Bytes) -> Bytes | Error:
     # Complicated cryptography here
     # ...
     return public_key
+
+def merge_detached_signature(detached_signature: bytes, public_key: bytes) -> bytes:
+    # ...
+    # Either concatenation or a no-op here
+    # ...
+    return detached_signature + public_key
 ```
 
 ## Rationale


### PR DESCRIPTION
This PR:
- Changes secp256k1 to `0x0` from `0xff`
- Changes reserved / undefined to `0x7f` from `0xfe`
- Restricts algorithm types > 126
- Adds `merge_detached_signature` function to the Algorithm trait
- Fixes public key collision with secp256k1

After this change, I'll probably stop any significant changes to EIP-7932 unless a rather large bug comes up.