### PR TITLE
Add EIP: Engine API Communication Channels

### DIFF
--- a/EIPS/eip-8177.md
+++ b/EIPS/eip-8177.md
@@ -56,8 +56,8 @@ This method extends `engine_exchangeCapabilities` (V1) by adding a `supportedPro
 #### Response
 
 * result: `object`
-    - `capabilities`: `Array of string` — Array of strings, each string is a name of a method supported by the execution layer client software.
-    - `supportedProtocols`: `Array of CommunicationChannel` — List of communication protocols the EL supports.
+    * `capabilities`: `Array of string` — Array of strings, each string is a name of a method supported by the execution layer client software.
+    * `supportedProtocols`: `Array of CommunicationChannel` — List of communication protocols the EL supports.
 
 ```json
 {
@@ -105,9 +105,9 @@ This EIP defines one protocol identifier:
 
 Follow-up EIPs can define additional identifiers. Some examples:
 
-- `ssz_rest` — SSZ-encoded payloads over REST using `application/octet-stream`.
-- `grpc` — gRPC with Protocol Buffers or SSZ serialization.
-- `ssz_websocket` — SSZ-encoded payloads over WebSocket.
+* `ssz_rest` — SSZ-encoded payloads over REST using `application/octet-stream`.
+* `grpc` — gRPC with Protocol Buffers or SSZ serialization.
+* `ssz_websocket` — SSZ-encoded payloads over WebSocket.
 
 #### Behavior
 


### PR DESCRIPTION
## Description

Adds a new Engine API method `engine_getClientCommunicationChannelsV1` that returns a list of supported communication protocols and their endpoints.

This lets the CL discover what the EL supports (JSON-RPC, SSZ-REST, gRPC, etc.) and pick whatever works best. No hard fork required — purely a client-side change.

Serves as a foundation for a smooth SSZ transition: EL clients can advertise SSZ endpoints alongside JSON-RPC, and CL clients can switch at their own pace.