### PR TITLE
Add EIP: Binary SSZ Transport for the Engine API

### DIFF
--- a/EIPS/eip-8178.md
+++ b/EIPS/eip-8178.md
@@ -30,7 +30,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ### Transport
 
-The binary SSZ transport uses resource-oriented REST over HTTP. Endpoints are organized by resource type (payloads, forkchoice, blobs) with per-endpoint versioning, following the same conventions as the [Beacon API](https://github.com/ethereum/beacon-APIs).
+The binary SSZ transport uses resource-oriented REST over HTTP. Endpoints are organized by resource type (payloads, forkchoice, blobs) with per-endpoint versioning, following the same conventions as the Beacon API.
 
 #### Base URL
 


### PR DESCRIPTION
Defines the `ssz_rest` communication channel for the Engine API. Each `engine_*` JSON-RPC method is mapped to a REST endpoint using SSZ-encoded request and response bodies with `application/octet-stream` content type.
