### PR TITLE
Update EIP-2780: fix typos and improve wording

### DIFF
--- a/EIPS/eip-2780.md
+++ b/EIPS/eip-2780.md
@@ -13,7 +13,7 @@ requires: 1559, 2718, 2929, 2930
 
 ## Abstract
 
-Reduce the intrinsic cost `TX_BASE_COST` from `21,000` to `4,500` and define a consistent gas accounting model based on actual state operations. This more granular approach makes a simple ETH transfer `6,000` from additional costs related to the `to` account.
+Reduce the intrinsic cost `TX_BASE_COST` from `21,000` to `4,500` and define a consistent gas accounting model based on actual state operations. This more granular approach makes a simple ETH transfer `6,000` due to additional costs related to the `to` account.
 
 If a non-create transaction has `value > 0` and targets a non-existent account, charge `GAS_NEW_ACCOUNT = 25,000` to align with `CALL` account creation and price in state growth. When this surcharge applies, the recipient pays exactly one cold non-code touch; no code-load cost applies.
 
@@ -32,7 +32,7 @@ Capacity impact (illustrative):
 | Max (ETH transfers)         | 10,000 tx / block |   +250% | 6,000-gas ETH transfers per 60 M block                       |
 | Throughput (minimal txs)    |        ~1,111 TPS |   +367% | 4,500-gas minimal transactions per 60 M block per 12sec      |
 | Throughput (ETH transfers)  |          ~833 TPS |   +250% | 6,000-gas ETH transfers per 60 M block per 12sec             |
-| Equivalent gas-limit uplift |          ≈ +20.8% |       - | Effective throughput gain for ave tx usage (e.g., 60 M => ~72.5 M) |
+| Equivalent gas-limit uplift |          ≈ +20.8% |       - | Effective throughput gain for avg tx usage (e.g., 60 M => ~72.5 M) |
 
 ## Motivation
 
@@ -42,7 +42,7 @@ Money has three basic functions: a unit of account, a medium of exchange, and a 
 
 ETH underpins most onchain liquidity. Pairs are denominated in it, and gas is paid in it - a de-facto tax base that anchors value. Bitcoin's monetary role now runs mainly through exchange pairs, hence its drift in focus to store-of-value rather than medium-of-exchange. ETH still clears real activity onchain, yet outside NFTs few people think in ETH terms. In that niche ETH already functions as both unit and medium, but only for high-value items.
 
-For ETH to operate fully as money, it must also handle small transactions. That was impractical when gas sat at 300 gwei, or even 90 gwei on quiet weekends. Post-4844, blobs absorb L2's "pay at any price" data and higher gaslimits ease congestion; cost, not capacity, is the bottleneck.
+For ETH to operate fully as money, it must also handle small transactions. That was impractical when gas sat at 300 gwei, or even 90 gwei on quiet weekends. Post-4844, blobs absorb L2's "pay at any price" data and higher gas limits ease congestion; cost, not capacity, is the bottleneck.
 
 EIP-2780 lowers that fixed cost. By aligning the base gas with the real work of a transaction and by correcting `CALL` value pricing, it removes the legacy penalty on simple payments. Small transfers become viable again without subsidising calldata or storage. The same logic charges properly for new-account creation, so state growth remains priced in.
 
@@ -259,7 +259,7 @@ These changes refine execution-layer accounting to align with the primitives abo
   - `CALL` warms its `to` after charging the appropriate cold cost if cold.
   - A `PAY`-style pure value-move primitive, if present, does not warm its recipient and never loads code. It pays `WARM_STATE_READ = 100` if warm for unrelated reasons, else `COLD_ACCOUNT_COST_NOCODE = 500`, plus the value-write cost above.
 
-- **Self-transfers.** If `from == to`, only one `STATE_UPDATE` occurs. The sender's nonce and balance update are coalesced into the same leaf write. No recipient lookup or separate write is charged. (Is a NOP tx other than charging gas and incrementing nonce).
+- **Self-transfers.** If `from == to`, only one `STATE_UPDATE` occurs. The sender's nonce and balance update are coalesced into the same leaf write. No recipient lookup or separate write is charged. (It is a NOP tx other than charging gas and incrementing nonce).
 
 ### Transaction reference cases
 
@@ -412,9 +412,9 @@ Add explicit test vectors (intrinsic gas only):
 
 ## Security Considerations
 
-As this significantly increases the max tx per block this carries risk.
+As this significantly increases the max tx per block, this carries risk.
 
-However this pricing should be the same as performing the component changes inside the transaction; and it factors in the additional costs from state growth which were not originally in the transaction base price.
+However, this pricing should be the same as performing the component changes inside the transaction; and it factors in the additional costs from state growth which were not originally in the transaction base price.
 
 Current gaslimit testing mostly uses a block with a single transaction; so this should not cause unexpected load compared to what is already being tested.
 


### PR DESCRIPTION

- Fix minor typos and grammatical issues in EIP-2780.
- Clarify the abstract sentence about the 6,000-gas simple ETH transfer.
- Improve consistency in terminology (e.g., “gas limits”, “avg tx usage”) and punctuation.

