### PR TITLE
Add EIP: Private ETH and ERC-20 Transfers

### DIFF
--- a/EIPS/eip-8182.md
+++ b/EIPS/eip-8182.md
@@ -125,7 +125,7 @@ This EIP uses Poseidon over the BN254 scalar field `p` (defined in Section 3.1) 
 * S-box: `x^5` (`α = 5`)
 * Full rounds: `R_F = 8`
 * Partial rounds: `R_P = 57`
-* Round constants and MDS matrix: TBD. The intended instantiation follows the Grassi–Khovratovich–Rechberger–Roy parameter generation for BN254 at 128-bit security. Exact constants and test vectors MUST be provided before Review.
+* Round constants and MDS matrix: TBD. <!-- TODO --> The intended instantiation follows the Grassi–Khovratovich–Rechberger–Roy parameter generation for BN254 at 128-bit security. Exact constants and test vectors MUST be provided before Review.
 
 This EIP uses a single 2-input Poseidon primitive, `hash_2(a, b)`, defined as one permutation on state `[0, a, b]` returning output element 0. All generic `poseidon(x_0, ..., x_{n-1})` expressions are defined as an arity-prefixed wrapper over that primitive: `poseidon(x_0, ..., x_{n-1}) = hash_2(n, tree(x_0, ..., x_{n-1}))`.
 
@@ -210,7 +210,9 @@ Users MUST maintain independent backups of `nullifierKey` and either `outputSecr
 
 #### 5.1 Deployment and Upgrade Model
 
-The shielded pool is deployed as a system contract at `SHIELDED_POOL_ADDRESS` (TBD), following the pattern established by [EIP-4788](./eip-4788.md) (beacon block root), [EIP-2935](./eip-2935.md) (historical block hashes), [EIP-7002](./eip-7002.md) (execution layer exits), and [EIP-7251](./eip-7251.md) (consolidations).
+The shielded pool is deployed as a system contract at `SHIELDED_POOL_ADDRESS` (TBD), following the pattern established by [EIP-4788](./eip-4788.md) (beacon block root), [EIP-2935](./eip-2935.md) (historical block hashes), [EIP-7002](./eip-7002.md) (execution layer exits), and [EIP-7251](./eip-7251.md) (consolidations). <!-- TODO -->
+
+<!-- TODO: Specify the exact system-contract runtime code and deployment mechanism, following the EIP-2935 pattern, before Review. -->
 
 * The code at `SHIELDED_POOL_ADDRESS` can only be replaced by a subsequent hard fork that sets new code as part of its state transition rules.
 * There is no proxy, no admin function, and no on-chain upgrade mechanism.
@@ -933,10 +935,10 @@ The verifier MUST reject any public input that is not a canonical field element 
 
 The precompile verifies proofs for the outer circuit (UltraHONK/BN254; to be pinned before Review). The verification key is fork-defined. Exact proof serialization and verification key formats MUST be pinned before Review.
 
-* Address: `PROOF_VERIFY_PRECOMPILE_ADDRESS` (TBD)
+* Address: `PROOF_VERIFY_PRECOMPILE_ADDRESS` (TBD) <!-- TODO -->
 * Input: `abi.encode(bytes proof, PublicInputs publicInputs)` — the struct fields are ABI-encoded as 19 consecutive `uint256` values in declaration order.
 * Output: 32 bytes — `uint256(1)` on success, empty on failure.
-* Gas: TBD (MUST be set before advancing to Review).
+* Gas: TBD <!-- TODO --> (MUST be set before advancing to Review).
 * Error: malformed input or verification failure returns empty.
 
 ### 12. Labels and Lineage
@@ -983,7 +985,7 @@ label = poseidon(
 | Canonical intent digest | `INTENT_DIGEST_DOMAIN, policyVersion, authorizingAddress, operationKind, poolAddress, tokenAddress, recipientAddress, amount, feeRecipientAddress, feeAmount, rawNonce, validUntilSeconds, executionChainId` | 13 |
 | Auth policy key (truncated to 160 bits) | `AUTH_POLICY_KEY_DOMAIN, authorizingAddress, innerVkHash` | 3 |
 | Auth policy leaf | `AUTH_POLICY_DOMAIN, authDataCommitment, policyVersion` | 3 |
-| Inner VK hash | `AUTH_VK_DOMAIN, vk_elem_0, ..., vk_elem_{n-1}` | TBD |
+| Inner VK hash | `AUTH_VK_DOMAIN, vk_elem_0, ..., vk_elem_{n-1}` | TBD <!-- TODO --> |
 | Deposit label | `LABEL_DOMAIN, executionChainId, depositorAddress, tokenAddress, publicAmountIn, intentNullifier` | 6 |
 | User registry leaf | `USER_REGISTRY_LEAF_DOMAIN, uint160(user), nullifierKeyHash, outputSecretHash` | 4 |
 | Merkle tree node | `left, right` | 2 |
@@ -1067,7 +1069,7 @@ This EIP introduces new functionality via a system contract and precompiles and 
 
 ## Test Cases
 
-TBD.
+TBD. <!-- TODO -->
 
 ## Security Considerations
 


### PR DESCRIPTION
Adds a draft EIP for a protocol-enshrined privacy pool system contract that defines a canonical validity layer for private asset transfers of ETH and ERC-20 tokens, with public deposits and withdrawals.

Scope:
- Fixed-address system contract with hard-fork-only upgrades (no admin/proxy keys)
- Canonical shared note tree, nullifier set, and registries
- Recursive proof architecture with a fork-managed outer circuit and permissionless inner auth circuits
- Proof-verification precompile for on-chain verification
- Per-note lineage commitment for future selective-disclosure schemes

Status: Draft. The spec intentionally leaves several values TBD before Review.

Discussions: https://ethereum-magicians.org/t/eip-8182-private-eth-and-erc-20-transfers/27889