### PR TITLE
Update EIP-8141: Add EOA support

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -209,7 +209,7 @@ Initialize with transaction-scoped variables:
 
 Then for each call frame:
 
-1. Execute a call with the specified `mode`, `target`, `gas_limit`, `data`, and `value`.
+1. Execute a call with the specified `mode`, `target`, `gas_limit`, and `data`.
    - If `target` is null, set the call target to `tx.sender`.
    - If mode is `SENDER`:
        - `sender_approved` must be `true`. If not, the transaction is invalid.
@@ -231,19 +231,21 @@ Note:
 
 When using frame transactions with EOAs (accounts with no code), they are treated as if they have a "default code."  This spec describes only the behavior of the default code; clients are free to implement the default code however they want, so long as they correspond to the behavior specified here.
 
-- Read the second nibble of the first byte of `frame.data` as `mode`.
+- Retrieve the `mode` with `TXPARAMLOAD`.
 - If `mode` is `VERIFY`:
   - If `frame.target != tx.sender`, revert.
-  - Read the first nibble of the first byte as `scope`.
-  - Read the second byte as the `signature_type`.
-    - If `signature_type` is `0x0`:
+  - Read the first byte of `frame.data` as two nibbles:
+    - Read the first nibble as `scope`.
+    - Read the second nibble as `signature_type`.
+  - If `signature_type` is:
+    - `0x0`:
       - Read the rest of `frame.data` as `(v, r, s)`.
       - If `frame.target != ecrecover(hash, v, r, s)`, where `hash = keccak(sighash, data_with_out_signature)`, revert.
-    - Else if `signature_type` is `0x1`:
+    - `0x1`:
       - Read the rest of `frame.data` as `(r, s, qx, qy)`.
       - If `frame.target != keccak(qx|qy)[12:]`, revert.
       - If `P256VERIFY(hash, r, s, qx, qy) != true`, where `hash = keccak(sighash, data_with_out_signature)`, revert.
-    - Else revert.
+    - Otherwise revert.
   - Call `APPROVE(scope)`.
 - If `mode` is `SENDER`:
   - If the first nibble of the first byte is not `0x0`, revert.
@@ -270,37 +272,37 @@ SECP256K1 = 0x0
 P256      = 0x1
 
 def default_code(frame, tx):
-    first_byte = frame.data[0]
-    scope = (first_byte >> 4) & 0xF   # high nibble: APPROVE scope
-    mode  = first_byte & 0xF          # low nibble: operation mode
+    mode = frame.mode                     # equivalent to TXPARAMLOAD(0x14, TXPARAMLOAD(0x10))
 
     if mode == VERIFY:
         if frame.target != tx.sender:
             revert()
 
-        sig_hash       = compute_sig_hash(tx)   # equivalent to TXPARAMLOAD(0x08)
-        signature_type = frame.data[1]
+        first_byte     = frame.data[0]
+        scope          = (first_byte >> 4) & 0xF   # high nibble: APPROVE scope
+        signature_type = first_byte & 0xF          # low nibble: signature type
+        sig_hash       = compute_sig_hash(tx)      # equivalent to TXPARAMLOAD(0x08)
 
         if signature_type == SECP256K1:
-            # frame.data layout: [byte0, 0x00, v (1 byte), r (32 bytes), s (32 bytes)]
-            if len(frame.data) != 67:             # 2 header + 65 signature bytes
+            # frame.data layout: [byte0, v (1 byte), r (32 bytes), s (32 bytes)]
+            if len(frame.data) != 66:             # 1 header + 65 signature bytes
                 revert()
-            v                = frame.data[2]
-            r                = frame.data[3:35]
-            s                = frame.data[35:67]
+            v                = frame.data[1]
+            r                = frame.data[2:34]
+            s                = frame.data[34:66]
             data_without_sig = frame.data[:-65]   # prefix before (v, r, s)
             h                = keccak256(sig_hash + data_without_sig)
             if frame.target != ecrecover(h, v, r, s):
                 revert()
 
         elif signature_type == P256:
-            # frame.data layout: [byte0, 0x01, r (32 bytes), s (32 bytes), qx (32 bytes), qy (32 bytes)]
-            if len(frame.data) != 130:            # 2 header + 128 signature bytes
+            # frame.data layout: [byte0, r (32 bytes), s (32 bytes), qx (32 bytes), qy (32 bytes)]
+            if len(frame.data) != 129:            # 1 header + 128 signature bytes
                 revert()
-            r                = frame.data[2:34]
-            s                = frame.data[34:66]
-            qx               = frame.data[66:98]
-            qy               = frame.data[98:130]
+            r                = frame.data[1:33]
+            s                = frame.data[33:65]
+            qx               = frame.data[65:97]
+            qy               = frame.data[97:129]
             data_without_sig = frame.data[:-128]  # prefix before (r, s, qx, qy)
             h                = keccak256(sig_hash + data_without_sig)
             if frame.target != keccak256(qx + qy)[12:]:
@@ -314,8 +316,6 @@ def default_code(frame, tx):
         APPROVE(scope)
 
     elif mode == SENDER:
-        if scope != 0x0:
-            revert()
         if frame.target != tx.sender:
             revert()
 


### PR DESCRIPTION
Per discussion with @lightclient, proposing an update to make EIP-8141 support EOAs.

The PR should be self-explanatory, but in short, the idea is that:

- If a frame is in `VERIFY` mode and `frame.target` has no code, we read `frame.data` as `(scope, v, r, s)` and verify that `(v, r, s)` is a valid signature of `frame.target` over `(sighash, scope)`.
- Upon successful verification, the frame executes `APPROVE(scope)`.

We also add a `value` field to frames so that EOAs can send value with frame transactions.  Alternatively we could've encoded `value` as part of `data` too but we are slightly leaning towards this current proposal.