### PR TITLE
Update EIP-8130: Simplify for initial EIP

### DIFF
--- a/EIPS/eip-8130.md
+++ b/EIPS/eip-8130.md
@@ -534,7 +534,7 @@ Enables permissionless extension of signature algorithms — deploy a new verifi
 
 ### Why a Nonce Precompile?
 
-Nonce state is isolated in a dedicated precompile (`NONCE_MANAGER_ADDRESS`) rather than stored alongside owners in the Account Configuration Contract. This separation is motivated by their fundamentally different access patterns and portability requirements:
+Nonce state is isolated in a dedicated precompile (`NONCE_MANAGER_ADDRESS`). This separation is motivated by their fundamentally different access patterns and portability requirements:
 
 | Property | Owner Config | Nonces |
 |----------|-----------|--------|
@@ -592,7 +592,7 @@ All owner data fits in a single 32-byte storage slot — just the verifier addre
 Public keys are not stored in the Account Configuration Contract. Instead, owners are identified by `ownerId` (bytes32) and public key material is provided at signing time in the verifier-specific `data` portion of the signature. This design is motivated by three factors:
 
 - **State growth**: Public key storage is permanent state growth. For PQ keys (1,000+ bytes), this means 40+ storage slots per owner. Calldata goes to data availability (temporary); storage is permanent. The trend is toward higher SLOAD costs and cheaper DA.
-- **Gas efficiency**: Calldata is cheaper than cold SLOADs for all key sizes. P256: ~2,048 gas calldata vs ~6,300 gas cold SLOADs. PQ: ~21,000 gas calldata vs ~88,000 gas cold SLOADs. With K1 recovery, the cost is zero — no public key in calldata or storage.
+- **Gas efficiency**: Calldata is cheaper than cold SLOADs for all key sizes. P256: ~2,048 gas calldata vs ~6,300 gas cold SLOADs. PQ: ~21,000 gas calldata vs ~88,000 gas cold SLOADs.
 - **Simplicity**: One storage slot per owner (`owner_config`). No variable-length public key encoding, no multi-slot reads, no length fields. Registration is a single SSTORE.
 
 The verifier handles `ownerId` derivation and public-key-to-`ownerId` binding — the protocol never needs to know how any algorithm works.
@@ -692,7 +692,7 @@ Read-only. The protocol manages nonce storage directly; there are no state-modif
 
 **Replay Protection**: Transactions include `chain_id`, 2D nonce, and `expiry`.
 
-**Owner Management**: All authorized owners are equal — every owner has full authority over the account. Owner modifications require cryptographic authorization — either a signed config change in `account_changes` or direct verification via `owner_config` (with `isValidSignature` fallback for migration). The EOA owner is implicitly authorized by default; revocable via portable config change. Accounts SHOULD have at least one configured owner before revoking the EOA owner. Nodes enforce a configurable per-transaction limit on config change entries as a mempool rule.
+**Owner Management**: All authorized owners are equal — every owner has full authority over the account. Owner modifications require cryptographic authorization — either a signed config change in `account_changes` or direct verification via `owner_config` (with `isValidSignature` fallback for migration). The EOA owner is implicitly authorized by default; revocable via portable config change. Nodes enforce a configurable per-transaction limit on config change entries as a mempool rule.
 
 **ownerId Binding**: Each verifier is responsible for deriving the `ownerId` from the provided signature data and ensuring it corresponds to the authenticated public key. The protocol checks that the verifier's returned `ownerId` maps back to that verifier in `owner_config` — a self-consistency check that prevents a malicious verifier from claiming ownership of another verifier's owners. Registering an `ownerId` that doesn't correspond to any public key the user controls renders the owner unusable — this is self-inflicted and has no security impact on the account.
 
@@ -700,7 +700,7 @@ Read-only. The protocol manages nonce storage directly; there are no state-modif
 
 **Payer Security**: `AA_TX_TYPE` vs `AA_PAYER_TYPE` domain separation prevents signature reuse between sender and payer roles. The `payer` field in the sender's signed hash binds to a specific payer address. The payer's auth mechanism is independent of the sender's.
 
-**Account Creation Security**: `initial_owners` (verifier + ownerId tuples) are salt-committed, preventing front-running of owner assignment. Initial owners and account policy use hardcoded safe defaults to prevent front-running and bad-state attacks. Permissionless deployment via `createAccount()` is safe — even if front-run, the account is created with the user's `ownerId`s and safe defaults. Wallet bytecode should be inert when uninitialized.
+**Account Creation Security**: `initial_owners` (verifier + ownerId tuples) are salt-committed, preventing front-running of owner assignment. Wallet bytecode should be inert when uninitialized as can permissionlessly deployed. 
 
 ## Copyright
 


### PR DESCRIPTION
AA model that is highly performant and can run a performant mempool in a safe way.

**Storage required**:
The World State (Balances, Nonces, CodeHashes, StateHashes) 
Contract Code Storage (can be limited to trusted verifiers + canonical addresses)
Account Config Contract State
Canonical Nonce State

Later we can add a new verifier type that receives the call_phases array in its calldata, and has access to any state.  a permissionless paymaster system, session key policies etc can be added by adding a new verifier type if we choose to. 

The account configuration contract is extensible singleton contract for future account protocol configurations that can be upgraded through hard forks.

