### PR TITLE
CI: skip auto-review trigger for non-retrigger comments

### DIFF
--- a/.github/workflows/auto-review-trigger.yml
+++ b/.github/workflows/auto-review-trigger.yml
@@ -20,6 +20,9 @@ jobs:
   trigger:
     runs-on: ubuntu-latest
     name: Trigger
+    if: >-
+      github.event_name != 'issue_comment'
+      || (github.event.issue.pull_request && contains(github.event.comment.body, '@eth-bot rerun'))
     steps:
       - name: Write PR Number - PR Target
         run: echo $PR_NUMBER > pr-number.txt


### PR DESCRIPTION
## Summary

- The Auto Review Bot Trigger workflow fires on every `issue_comment` event, but only produces the `pr-number` artifact when the comment contains `@eth-bot rerun` on a PR
- Non-matching comments (i.e. normal PR discussion) cause the downstream Auto Review Bot to fail with "no artifacts found", sending spurious failure email notifications to contributors
- Adds a job-level `if` condition to skip the trigger job entirely for `issue_comment` events that don't match the retrigger pattern

## Test plan

- [ ] Verify `@eth-bot rerun` comments on PRs still trigger the auto-review bot
- [ ] Verify normal PR comments no longer trigger a failing workflow run

🤖 Generated with [Claude Code](https://claude.com/claude-code)