### PR TITLE
Update EIP-8038: correct HTML comment syntax

### DIFF
--- a/EIPS/eip-8038.md
+++ b/EIPS/eip-8038.md
@@ -43,7 +43,7 @@ The following parameters of the gas model are updated:
 | `ACCESS_LIST_STORAGE_KEY_COST` | 1,900 | TBD | TBD | `SSTORE` and `SLOAD`|
 | `ACCESS_LIST_ADDRESS_COST` | 2,400 | TBD | TBD | `*CALL` opcodes, `BALANCE`, `SELFDESTRUCT` and `EXT*` opcodes |
 
-<-- TODO -->
+<!-- TODO -->
 
 ### `EXT*` family update
 
@@ -63,7 +63,7 @@ else:
 
 This proposal does not yet have finalized numbers. To achieve this, we require stateful benchmarks, which are currently in development. Once we collect that data, we will set the final numbers.
 
-<-- TODO -->
+<!-- TODO -->
 
 ### Special case for `EXTCODESIZE` and `EXTCODECOPY`
 


### PR DESCRIPTION
Fix invalid HTML comment syntax in EIP-8038.

Changed `<-- TODO -->` to `<!-- TODO -->` (two occurrences).


If this has already been addressed in another PR, please close this one.