### PR TITLE
Update EIP-8053: correct HTML comment syntax

### DIFF
--- a/EIPS/eip-8053.md
+++ b/EIPS/eip-8053.md
@@ -123,7 +123,7 @@ Deployed bytecode that compares `gas_left` to constants or that uses explicit ga
 
 ## Security Considerations
 
-<-- TODO -->
+<!-- TODO -->
 
 ## Copyright
 


### PR DESCRIPTION
Fix invalid HTML comment syntax in EIP-8053.

Changed `<-- TODO -->` to `<!-- TODO -->` in the Security Considerations section.