### PR TITLE
Update EIP-8159: clarify resp size cap (10MiB -> 2MiB soft cap)

### DIFF
--- a/EIPS/eip-8159.md
+++ b/EIPS/eip-8159.md
@@ -99,7 +99,7 @@ BALs are only available for blocks after [EIP-7928](./eip-7928.md) activation an
 
 Response to `GetBlockAccessLists`. Each element corresponds to a block hash from the request, in order. Empty BALs (RLP-encoded empty list `0xc0`) are returned for blocks where the BAL is unavailable.
 
-The recommended soft limit for `BlockAccessLists` responses is 10 MiB.
+The recommended soft limit for `BlockAccessLists` responses is 2 MiB.
 
 ### Validation
 
@@ -121,7 +121,7 @@ Message IDs 0x12 and 0x13 follow sequentially from the existing eth/69 messages 
 
 ### Response Size Limit
 
-The 10 MiB soft limit aligns with existing protocol conventions and accommodates multiple BALs per response while remaining within typical message size constraints.
+The 2 MiB soft limit is consistent with other eth protocol responses (blocks, receipts, headers) and accommodates multiple BALs per response. Responses containing a single BAL that exceeds 2 MiB are still valid, as the soft limit governs when to stop appending additional items, not the maximum size of an individual item.
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
Changes and clarifies the response size cap:
* The soft cap is set at 2MiB, consistent with the caps used for other responses