### PR TITLE
Update EIP-7864: encode offset as big endian

### DIFF
--- a/EIPS/eip-7864.md
+++ b/EIPS/eip-7864.md
@@ -237,7 +237,7 @@ def tree_hash(inp: bytes) -> bytes32:
 
 def get_tree_key(address: Address32, tree_index: int, sub_index: int):
     # Assumes STEM_SUBTREE_WIDTH = 256
-    return tree_hash(address + tree_index.to_bytes(32, "little"))[:31] + bytes(
+    return tree_hash(address + tree_index.to_bytes(32, "big"))[:31] + bytes(
         [sub_index]
     )
 


### PR DESCRIPTION
This was discussed during [SIC #49]() : the slot number is currently serialized as a _little_ endian, which is the opposite order to how the components of how the address is saved. See the middle part of the diagram below:

<img width="861" height="599" alt="image" src="https://github.com/user-attachments/assets/54091e42-e45b-4c19-9296-188c6859c57d" />

This PR changes the spec to serialize the tree index as a _big_ endian number, so that it's less confusing, and also doesn't require to swap the endianness of that number, since it's based on a slot number, which is a 32 byte big endian number (see the bottom part of the diagram).