### PR TITLE
Add EIP: snap/2 - BAL-Based State Healing

### DIFF
--- a/EIPS/eip-8189.md
+++ b/EIPS/eip-8189.md
@@ -59,7 +59,7 @@ Notes:
 
 Response to `GetBlockAccessLists`. Each element corresponds positionally to a block hash from the request. Empty BALs (zero-length byte slice) are returned for blocks where the BAL is unavailable.
 
-The recommended soft limit for `BlockAccessLists` responses is 10 MiB.
+The recommended soft limit for `BlockAccessLists` responses is 2 MiB.
 
 ### Unchanged Messages
 
@@ -103,7 +103,7 @@ Message IDs are scoped to the protocol version and negotiated during the RLPx ca
 
 ## Backwards Compatibility
 
-This EIP requires rolling out a new protocol version, snap/2. Older clients continue using snap/1. snap/2 is only meaningful for post-Amsterdam blocks, since the `block-access-list-hash` header field ([EIP-7928](./eip-7928.md)) is absent for earlier blocks. snap/2 peers **must** also run eth/71 or later, as `snap` is a dependent satellite of `eth`.
+This EIP requires rolling out a new protocol version, snap/2. Older clients continue using snap/1. snap/2 is only meaningful for post-Amsterdam blocks, since the `block-access-list-hash` header field ([EIP-7928](./eip-7928.md)) is absent for earlier blocks.
 
 For a node synchronizing data, if both snap/1 and snap/2 are supported, it should use either snap/1 or snap/2 for state sync; running both simultaneously is not recommended. Once the synchronization phase is complete, the node can serve requests for both protocols.
 
@@ -111,7 +111,7 @@ For a node synchronizing data, if both snap/1 and snap/2 are supported, it shoul
 
 ### Amplification
 
-A `GetBlockAccessLists` request can trigger responses significantly larger than the request. Implementations **should** apply rate limiting and respect the 10 MiB soft response limit.
+A `GetBlockAccessLists` request can trigger responses significantly larger than the request. Implementations **should** apply rate limiting and respect the 2 MiB soft response limit.
 
 ### Unavailable Data
 


### PR DESCRIPTION
This EIP defines snap v2, which uses [EIP-7928](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7928.md)'s block-level access lists for the healing phase in snap sync.

Duplicating BAL exchange in [eth/71](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-8159.md) and snap/2 keeps sync self-contained in a satellite protocol and allows snap to evolve independently, for example, serving only state diffs instead of full BALs in a future version, without requiring changes to eth.