### PR TITLE
Update EIP-7928: Add Felipe, Rahul and Stefan as co-authors

### DIFF
--- a/EIPS/eip-7928.md
+++ b/EIPS/eip-7928.md
@@ -2,7 +2,7 @@
 eip: 7928
 title: Block-Level Access Lists
 description: Enforced block access lists with state locations and post-transaction state diffs
-author: Toni Wahrstätter (@nerolation), Dankrad Feist (@dankrad), Francesco D`Amato (@fradamt), Jochem Brouwer (@jochem-brouwer), Ignacio Hagopian (@jsign)
+author: Toni Wahrstätter (@nerolation), Dankrad Feist (@dankrad), Francesco D`Amato (@fradamt), Jochem Brouwer (@jochem-brouwer), Ignacio Hagopian (@jsign), Felipe Selmo (@fselmo), Rahul (@raxhvl), Stefan (@qu0b)
 discussions-to: https://ethereum-magicians.org/t/eip-7928-block-level-access-lists/23337
 status: Draft
 type: Standards Track


### PR DESCRIPTION
Felipe (@fselmo), Rahul (@raxhvl), and Stefan (@qu0b) have made significant contributions to EIP-7928's specification, testing, and devnet infrastructure. 
Adding them as co-authors recognizes their existing work and ongoing involvement in the proposal.