### PR TITLE
Update EIP-8141: add support for atomic batching

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -287,7 +287,7 @@ Then for each call frame:
    - If a frame's execution reverts, its state changes are discarded. Additionally, if this frame has the atomic batch flag set, mark all subsequent frames in the same atomic group as skipped.
 3. If frame has mode `VERIFY` and the frame did not successfully call `APPROVE`, the transaction is invalid.
 
-##### Atomic Batching
+#### Atomic Batching
 
 Consecutive `SENDER` frames where all but the last have the atomic batch flag (bit 11) set form an **atomic batch**. Within a batch, if any frame reverts, all preceding frames in the batch are also reverted and all subsequent frames in the batch are skipped.
 


### PR DESCRIPTION
Add a `SENDER_ATOMIC` mode where consecutive `SENDER_ATOMIC` frames revert together.

This PR also adds the explicit requirement that `SENDER` and `SENDER_ATOMIC` frames can only be executed when `sender_approved` and `payer_approved` have been set to `true`, which essentially forbids `approve` from being called in `SENDER` and `SENDER_ATOMIC` modes (whereas previously it was allowed).  This is important because otherwise a `SENDER_ATOMIC` frame can `approve` gas payment, and then the payment frame may be reverted by other `SENDER_ATOMIC` frames, creating complexity for transaction validation.  Upon discussion with the coauthors, we decided that there were no valid use cases where calling `approve` in `SENDER/SENDER_ATOMIC` frames is necessary, so we now explicitly disallow that.