### PR TITLE
Update EIP-7773: SFI 8 EL Amsterdam EIPs

### DIFF
--- a/EIPS/eip-7773.md
+++ b/EIPS/eip-7773.md
@@ -20,22 +20,22 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Declined
 
 ### EIPs Scheduled for Inclusion
 
+* [EIP-7708](./eip-7708.md): ETH transfers emit a log
 * [EIP-7732](./eip-7732.md): Enshrined Proposer-Builder Separation
+* [EIP-7778](./eip-7778.md): Block Gas Accounting without Refunds
+* [EIP-7843](./eip-7843.md): SLOTNUM opcode
 * [EIP-7928](./eip-7928.md): Block-Level Access Lists
+* [EIP-8024](./eip-8024.md): Backward compatible SWAPN, DUPN, EXCHANGE
 
 ### Considered for Inclusion
 
 * [EIP-2780](./eip-2780.md): Reduce intrinsic transaction gas
 * [EIP-7688](./eip-7688.md): Forward compatible consensus data structures
-* [EIP-7708](./eip-7708.md): ETH transfers emit a log
-* [EIP-7778](./eip-7778.md): Block Gas Accounting without Refunds
-* [EIP-7843](./eip-7843.md): SLOTNUM opcode
 * [EIP-7904](./eip-7904.md): General Repricing
-* [EIP-7954](./eip-7954.md): Increase Maxiumum Contract Size
+* [EIP-7954](./eip-7954.md): Increase Maximum Contract Size
 * [EIP-7976](./eip-7976.md): Increase Calldata Floor Cost
 * [EIP-7981](./eip-7981.md): Increase Access List Cost
 * [EIP-7997](./eip-7997.md): Deterministic Factory Predeploy
-* [EIP-8024](./eip-8024.md): Backward compatible SWAPN, DUPN, EXCHANGE
 * [EIP-8037](./eip-8037.md): State Creation Gas Cost Increase
 * [EIP-8038](./eip-8038.md): State-access gas cost increase
 * [EIP-8045](./eip-8045.md): Exclude slashed validators from proposing

--- a/EIPS/eip-7773.md
+++ b/EIPS/eip-7773.md
@@ -25,18 +25,18 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Declined
 * [EIP-7778](./eip-7778.md): Block Gas Accounting without Refunds
 * [EIP-7843](./eip-7843.md): SLOTNUM opcode
 * [EIP-7928](./eip-7928.md): Block-Level Access Lists
+* [EIP-7954](./eip-7954.md): Increase Maximum Contract Size
+* [EIP-7976](./eip-7976.md): Increase Calldata Floor Cost
+* [EIP-7981](./eip-7981.md): Increase Access List Cost
 * [EIP-8024](./eip-8024.md): Backward compatible SWAPN, DUPN, EXCHANGE
+* [EIP-8037](./eip-8037.md): State Creation Gas Cost Increase
 
 ### Considered for Inclusion
 
 * [EIP-2780](./eip-2780.md): Reduce intrinsic transaction gas
 * [EIP-7688](./eip-7688.md): Forward compatible consensus data structures
 * [EIP-7904](./eip-7904.md): General Repricing
-* [EIP-7954](./eip-7954.md): Increase Maximum Contract Size
-* [EIP-7976](./eip-7976.md): Increase Calldata Floor Cost
-* [EIP-7981](./eip-7981.md): Increase Access List Cost
 * [EIP-7997](./eip-7997.md): Deterministic Factory Predeploy
-* [EIP-8037](./eip-8037.md): State Creation Gas Cost Increase
 * [EIP-8038](./eip-8038.md): State-access gas cost increase
 * [EIP-8045](./eip-8045.md): Exclude slashed validators from proposing
 * [EIP-8061](./eip-8061.md): Increase exit and consolidation churn


### PR DESCRIPTION
Schedule for Inclusion the 8 EL EIPs included in Glamsterdam: EIP-7708, 7778, 7843, 7928, 7954, 7976, 7981, 8024, and 8037.

This PR aligns with the proposed SFI definition update in #11475, which formalizes the maturity criteria for moving EIPs to SFI with the following: 1 week devnet stability, spec close to final, minimal CFI interactions and adequate testing coverage.

EIP-8037 is the only EIP that does not meet this new criteria. Yet it is still added to this PR given the entensive efforts during the Soldogn interop on the EIP. It is incredibly unlikely to be DFI'd.
