### PR TITLE
Update EIP-8135: Move to Last Call

### DIFF
--- a/EIPS/eip-8135.md
+++ b/EIPS/eip-8135.md
@@ -4,7 +4,8 @@ title: Hardfork Meta - BPO2
 description: Blob parameter changes with BPO2 on Ethereum mainnet.
 author: Pooja Ranjan (@poojaranjan)
 discussions-to: https://ethereum-magicians.org/t/eip-8135-hardfork-meta-bpo2/27605
-status: Review
+status: Last Call
+last-call-deadline: 2026-03-31
 type: Meta
 created: 2026-01-24
 requires: 7892, 8134


### PR DESCRIPTION
The upgrade has been completed. Moving the Meta EIP to `Last Call` to progress its status.