### PR TITLE
Update EIP-8141: Small tweaks to default code to be 7392 compatible

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -328,11 +328,11 @@ When using frame transactions with EOAs (accounts with no code), they are treate
   - Read the first byte of `frame.data` as `signature_type`.
   - If `signature_type` is:
     - `0x0`:
-      - Read the rest of `frame.data` as `(v, r, s)`.
+      - Read the rest of `frame.data` as `(r, s, v)`.
       - If `frame.target != ecrecover(sig_hash, v, r, s)`, where `sig_hash = compute_sig_hash(tx)`, revert.
     - `0x1`:
       - Read the rest of `frame.data` as `(r, s, qx, qy)`.
-      - If `frame.target != keccak(qx|qy)[12:]`, revert.
+      - If `frame.target != keccak(0x01|qx|qy)[12:]`, revert.
       - If `P256VERIFY(sig_hash, r, s, qx, qy) != true`, where `sig_hash = compute_sig_hash(tx)`, revert.
     - Otherwise revert.
   - Call `APPROVE(scope)`.
@@ -346,7 +346,7 @@ When using frame transactions with EOAs (accounts with no code), they are treate
 
 Notes:
 
-- It's implied that for the P256 (r1) signature type, the sender address must be `keccak(qx|qy)[12:]`.
+- It's implied that for the P256 (r1) signature type, the sender address must be `keccak(0x01|qx|qy)[12:]`.
 
 Here's the logic above implemented in Python:
 
@@ -372,9 +372,11 @@ def default_code(frame, tx):
             # frame.data layout: [signature_type, v (1 byte), r (32 bytes), s (32 bytes)]
             if len(frame.data) != 66:               # 1 header + 65 signature bytes
                 revert()
-            v = frame.data[1]
-            r = frame.data[2:34]
-            s = frame.data[34:66]
+            
+            r = frame.data[1:33]
+            s = frame.data[33:65]
+            v = frame.data[65]
+            
             if frame.target != ecrecover(sig_hash, v, r, s):
                 revert()
 
@@ -386,7 +388,7 @@ def default_code(frame, tx):
             s  = frame.data[33:65]
             qx = frame.data[65:97]
             qy = frame.data[97:129]
-            if frame.target != keccak256(qx + qy)[12:]:
+            if frame.target != keccak256(b"\x01" + qx + qy)[12:]:
                 revert()
             if not P256VERIFY(sig_hash, r, s, qx, qy):
                 revert()

--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -376,7 +376,7 @@ def default_code(frame, tx):
             r = frame.data[1:33]
             s = frame.data[33:65]
             v = frame.data[65]
-            
+
             if frame.target != ecrecover(sig_hash, v, r, s):
                 revert()
 
@@ -783,7 +783,7 @@ Frame 0 verifies the signature and calls `APPROVE(0x3)`. Frames 1 and 2 form an 
 
 | Frame | Caller      | Target        | Data                   | Mode    |
 | ----- | ----------- | ------------- | ---------------------- | ------- |
-| 0     | ENTRY_POINT | Null(sender)  | (0, v, r, s)           | VERIFY  |
+| 0     | ENTRY_POINT | Null(sender)  | (0, r, s, v)           | VERIFY  |
 | 1     | ENTRY_POINT | Sponsor       | Sponsor signature      | VERIFY  |
 | 2     | Sender      | ERC-20        | transfer(Sponsor,fees) | SENDER  |
 | 3     | Sender      | Target addr   | Call data              | SENDER  |


### PR DESCRIPTION
This is the spiritual successor to https://github.com/ethereum/EIPs/pull/11408, where the is **no dependency introduced**. It just makes the values interoperable.