### PR TITLE
Update EIP-8198: Use SLOT_SCHEDULE for slot-time-dependent constants

### DIFF
--- a/EIPS/eip-8198.md
+++ b/EIPS/eip-8198.md
@@ -57,20 +57,26 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 All arithmetic in this specification uses integer division (truncating toward zero). Formulas are written with the multiply performed before the divide to preserve precision.
 
-### Parameters
+### Slot Schedule
 
-At `<FORK_EPOCH>`, the following constants take effect. All consensus layer timing derivations MUST use the fork-activated values from the fork epoch onward. Functions that compute wall-clock time from slot numbers, such as `compute_time_at_slot(...)`, MUST account for the duration change at the fork boundary.
+This EIP introduces a `SLOT_SCHEDULE`, a consensus layer configuration analogous to the `BLOB_SCHEDULE` defined in [EIP-7892](./eip-7892.md). Each entry is keyed by epoch and specifies `SLOT_DURATION_MS` along with all constants that must scale with slot duration. Clients MUST look up the active entry (highest epoch ≤ current epoch) to determine the current parameter set.
 
-| Constant | Current | New |
-| -------- | ------- | --- |
-| `SLOT_DURATION_MS` | 12,000 | 8,000 |
-| `BASE_REWARD_FACTOR` | 64 | 42 |
-| `INACTIVITY_PENALTY_QUOTIENT_BELLATRIX` | 16,777,216 | 37,748,736 |
-| `MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS` | 4,096 | 6,144 |
-| `MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS` | 4,096 | 6,144 |
-| `CHURN_LIMIT_QUOTIENT` | 65,536 | 98,304 |
-| `MIN_PER_EPOCH_CHURN_LIMIT_ELECTRA` | 128,000,000,000 | 85,333,333,333 |
-| `MAX_PER_EPOCH_ACTIVATION_EXIT_CHURN_LIMIT` | 256,000,000,000 | 170,666,666,666 |
+```yaml
+SLOT_SCHEDULE:
+  - EPOCH: <FORK_EPOCH>
+    SLOT_DURATION_MS: 8000
+    BASE_REWARD_FACTOR: 42
+    INACTIVITY_PENALTY_QUOTIENT_BELLATRIX: 37748736
+    MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS: 6144
+    MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS: 6144
+    CHURN_LIMIT_QUOTIENT: 98304
+    MIN_PER_EPOCH_CHURN_LIMIT_ELECTRA: 85333333333
+    MAX_PER_EPOCH_ACTIVATION_EXIT_CHURN_LIMIT: 170666666666
+```
+
+All consensus layer timing derivations MUST use the values from the active `SLOT_SCHEDULE` entry. Functions that compute wall-clock time from slot numbers, such as `compute_time_at_slot(...)`, MUST account for duration changes at schedule boundaries.
+
+Future slot duration changes — whether from a regular hard fork or a slot-parameter-only fork — are deployed by appending a new entry to the `SLOT_SCHEDULE` with the target epoch and updated parameters. This requires no client code changes, only a configuration update.
 
 ### Gas limit adjustment
 
@@ -96,7 +102,11 @@ where `old_max_blobs` is the `MAX_BLOBS_PER_BLOCK` from the most recent precedin
 
 ### Why infrastructure first
 
-The bottleneck is not picking a number. It is the hardcoded twelve-second assumption spread across every consensus and execution client. Delivering this change as a fork forces client teams to audit and remove these assumptions — once that work is done, future slot duration changes become straightforward fork-activated parameter updates rather than invasive refactors. The infrastructure work compounds across future upgrades.
+The bottleneck is not picking a number. It is the hardcoded twelve-second assumption spread across every consensus and execution client. Delivering this change as a fork forces client teams to audit and remove these assumptions — once that work is done, future slot duration changes become straightforward parameter updates rather than invasive refactors. The infrastructure work compounds across future upgrades.
+
+### Why a schedule
+
+The `SLOT_SCHEDULE` follows the precedent set by `BLOB_SCHEDULE` ([EIP-7892](./eip-7892.md)): a configuration-driven mechanism that allows parameter changes at specific epochs without client code changes. Since this EIP envisions iterative slot time reductions based on Phase 2 performance characterization, a schedule-based approach means each subsequent reduction is a config-only update — append a new entry with the target epoch, updated `SLOT_DURATION_MS`, and scaled constants. This delivers on the stated goal that "future slot duration changes become configuration updates rather than contentious protocol upgrades."
 
 ### Why eight seconds
 


### PR DESCRIPTION
Since EIP-8198 envisions iterative slot time reductions, this replaces the hardcoded parameter table with a SLOT_SCHEDULE config keyed by epoch — same pattern as BLOB_SCHEDULE from EIP-7892. That way future reductions can ship as config updates instead of needing new EIPs with manually recomputed constant tables each time.