### PR TITLE
Update EIP-7723: update SFI definition based on ACDT#74

### DIFF
--- a/EIPS/eip-7723.md
+++ b/EIPS/eip-7723.md
@@ -40,7 +40,7 @@ When preparing a network upgrade, client developers typically implement EIPs fir
 
 Since client developers' ability to include EIPs in a network upgrade is constrained by what can be implemented and tested in these upgrade devnets, the [Considered for Inclusion](#considered-for-inclusion) and [Scheduled for Inclusion](#scheduled-for-inclusion) sections below propose aligning these statuses with EIPs' implementation status in upgrade devnets.
 
-### Proposed for Inclusion (PFI)
+### Proposed for Inclusion <span>(PFI)</span>
 
 To propose an EIP for inclusion, someone **MUST** open a pull request to add it to the `Proposed for Inclusion` section of the Upgrade Meta EIP. The proposer of an EIP **SHOULD** serve as the primary point of contact for that EIP for the duration of the upgrade cycle or **SHOULD** designate another person to serve in that role. Reasonable pull requests **SHOULD** be merged in a timely fashion by the Upgrade Meta EIP author.
 
@@ -48,7 +48,7 @@ At this stage, implementation teams **SHOULD** review the EIP. For Core EIPs, th
  
 Note that EIPs must be `Proposed for Inclusion` for each network upgrade. In other words, proposals do not "carry over" to the next upgrade if an EIP is not included in the one it was first proposed for. 
 
-### Considered for Inclusion (CFI)
+### Considered for Inclusion <span>(CFI)</span>
 
 Once client developers have reviewed an EIP which was `Proposed for Inclusion`, they **MAY** move it to the `Considered for Inclusion` stage. Once a decision is made by client teams to move an EIP to `Considered for Inclusion`, the Upgrade Meta EIP **SHOULD** be updated to reflect this. 
 
@@ -64,15 +64,16 @@ An EIP **SHOULD** have a Python implementation accompanied by tests in [executio
 
 Any updates to an EIP that is already at this stage **SHOULD** be accompanied by the appropriate updates to its implementation and tests in [execution-specs](https://github.com/ethereum/execution-specs/blob/78fb726158c69d8fa164e28f195fabf6ab59b915/README.md) if deemed necessary by client developers.
 
-### Declined for Inclusion (DFI)
+### Declined for Inclusion <span>(DFI)</span>
 
 At any time during the network upgrade planning process, client developers **MAY** move EIPs from any other stage to the `Declined for Inclusion` stage if client teams are against including the EIP in the network upgrade. Once a decision is made by client teams to move an EIP to `Declined for Inclusion`, the Upgrade Meta EIP **SHOULD** be updated to reflect this.
 
 `Declined for Inclusion` signals that client developers wish to exclude the EIP from the current network upgrade and stop discussing its potential inclusion or implementation status in relation to this upgrade. An EIP which was `Declined for Inclusion` in a particular upgrade **MAY** still be `Proposed for Inclusion` in a subsequent upgrade. In exceptional circumstances, client developers **MAY** choose to move an EIP from `Declined for Inclusion` to `Considered for Inclusion` or `Scheduled for Inclusion`. 
 
-### Scheduled for Inclusion (SFI)
+### Scheduled for Inclusion <span>(SFI)</span>
 
 An EIP can be moved to SFI when core developers:
+
 1. Agree upon a strong intent to include the EIP in the next network upgrade.
 2. Agree that an EIP's specifications and implementations have reached a certain level of maturity.
 

--- a/EIPS/eip-7723.md
+++ b/EIPS/eip-7723.md
@@ -40,17 +40,17 @@ When preparing a network upgrade, client developers typically implement EIPs fir
 
 Since client developers' ability to include EIPs in a network upgrade is constrained by what can be implemented and tested in these upgrade devnets, the [Considered for Inclusion](#considered-for-inclusion) and [Scheduled for Inclusion](#scheduled-for-inclusion) sections below propose aligning these statuses with EIPs' implementation status in upgrade devnets.
 
-### Proposed for Inclusion <span>(PFI)</span>
+### Proposed for Inclusion
 
-To propose an EIP for inclusion, someone **MUST** open a pull request to add it to the `Proposed for Inclusion` section of the Upgrade Meta EIP. The proposer of an EIP **SHOULD** serve as the primary point of contact for that EIP for the duration of the upgrade cycle or **SHOULD** designate another person to serve in that role. Reasonable pull requests **SHOULD** be merged in a timely fashion by the Upgrade Meta EIP author.
+To propose an EIP for inclusion, someone **MUST** open a pull request to add it to the `Proposed for Inclusion` (PFI) section of the Upgrade Meta EIP. The proposer of an EIP **SHOULD** serve as the primary point of contact for that EIP for the duration of the upgrade cycle or **SHOULD** designate another person to serve in that role. Reasonable pull requests **SHOULD** be merged in a timely fashion by the Upgrade Meta EIP author.
 
 At this stage, implementation teams **SHOULD** review the EIP. For Core EIPs, this should be in the context of including it in the next upgrade. For non-Core EIPs, this should be in the context of supporting the EIP before the network upgrade is activated. 
  
 Note that EIPs must be `Proposed for Inclusion` for each network upgrade. In other words, proposals do not "carry over" to the next upgrade if an EIP is not included in the one it was first proposed for. 
 
-### Considered for Inclusion <span>(CFI)</span>
+### Considered for Inclusion
 
-Once client developers have reviewed an EIP which was `Proposed for Inclusion`, they **MAY** move it to the `Considered for Inclusion` stage. Once a decision is made by client teams to move an EIP to `Considered for Inclusion`, the Upgrade Meta EIP **SHOULD** be updated to reflect this. 
+Once client developers have reviewed an EIP which was `Proposed for Inclusion`, they **MAY** move it to the `Considered for Inclusion` (CFI) stage. Once a decision is made by client teams to move an EIP to `Considered for Inclusion`, the Upgrade Meta EIP **SHOULD** be updated to reflect this. 
 
 `Considered for Inclusion` signals that client developers intend to attempt to include the EIP in devnets. The All Core Devs Execution (ACDE) and Consensus (ACDC) call facilitators should work with the testing teams to propose a priority ordering of CFI EIPs to be reviewed by client developers, and then reflect this prioritization in the Meta EIP. This prioritization should inform which EIPs should be included in upcoming devnets, with some flexibility if circumstances change.
 
@@ -64,15 +64,15 @@ An EIP **SHOULD** have a Python implementation accompanied by tests in [executio
 
 Any updates to an EIP that is already at this stage **SHOULD** be accompanied by the appropriate updates to its implementation and tests in [execution-specs](https://github.com/ethereum/execution-specs/blob/78fb726158c69d8fa164e28f195fabf6ab59b915/README.md) if deemed necessary by client developers.
 
-### Declined for Inclusion <span>(DFI)</span>
+### Declined for Inclusion
 
-At any time during the network upgrade planning process, client developers **MAY** move EIPs from any other stage to the `Declined for Inclusion` stage if client teams are against including the EIP in the network upgrade. Once a decision is made by client teams to move an EIP to `Declined for Inclusion`, the Upgrade Meta EIP **SHOULD** be updated to reflect this.
+At any time during the network upgrade planning process, client developers **MAY** move EIPs from any other stage to the `Declined for Inclusion` (DFI) stage if client teams are against including the EIP in the network upgrade. Once a decision is made by client teams to move an EIP to `Declined for Inclusion`, the Upgrade Meta EIP **SHOULD** be updated to reflect this.
 
 `Declined for Inclusion` signals that client developers wish to exclude the EIP from the current network upgrade and stop discussing its potential inclusion or implementation status in relation to this upgrade. An EIP which was `Declined for Inclusion` in a particular upgrade **MAY** still be `Proposed for Inclusion` in a subsequent upgrade. In exceptional circumstances, client developers **MAY** choose to move an EIP from `Declined for Inclusion` to `Considered for Inclusion` or `Scheduled for Inclusion`. 
 
-### Scheduled for Inclusion <span>(SFI)</span>
+### Scheduled for Inclusion
 
-An EIP can be moved to SFI when core developers:
+An EIP can be moved to Scheduled for Inclusion (SFI) when core developers:
 
 1. Agree upon a strong intent to include the EIP in the next network upgrade.
 2. Agree that an EIP's specifications and implementations have reached a certain level of maturity.

--- a/EIPS/eip-7723.md
+++ b/EIPS/eip-7723.md
@@ -72,12 +72,18 @@ At any time during the network upgrade planning process, client developers **MAY
 
 ### Scheduled for Inclusion (SFI)
 
-An EIP should move to SFI when:
+An EIP can be moved to SFI when core developers:
+1. Agree upon a strong intent to include the EIP in the next network upgrade.
+2. Agree that an EIP's specifications and implementations have reached a certain level of maturity.
 
-- It has been included in a devnet that has demonstrated stability (e.g., high participation, no critical bugs for ≥1 week)
-- The EIP specification is finalized (no placeholder values or pending design decisions)
-- It has minimal interactions with other CFI EIPs, OR those interactions have been tested in the same devnet
-- Testing coverage is adequate (hive/EEST passing, no known divergence across clients)
+I.e., an SFI status signals that the EIP is on track for inclusion barring unforeseen issues.
+
+The following critieria can be applied to ascertain whether an EIP is mature (stable) enough to move to SFI:
+
+- It has been included in a devnet that has demonstrated stability (e.g., high participation, no critical bugs for ≥1 week).
+- The EIP specification is deemed close to final (no placeholder values or pending design decisions).
+- It has minimal interactions with other CFI EIPs, OR those interactions have been tested in the same devnet.
+- Testing coverage is adequate (clients pass consensus tests, no known divergence across clients).
 
 All Core Devs Testing (ACDT) calls may review EIPs to determine SFI eligibility. Status changes will then be ratified on ACDE or ACDC before assigning SFI status.
 
@@ -85,9 +91,9 @@ All Core Devs Testing (ACDT) calls may review EIPs to determine SFI eligibility.
 
 An EIP **MAY** be moved from `Scheduled for Inclusion` to `Declined for Inclusion` if circumstances necessitate removal, as agreed by client teams. An EIP **MAY** also be moved from `Scheduled for Inclusion` to `Considered for Inclusion` if client teams remain in favor of including the EIP in the network upgrade but cannot commit to including it in the **next** Upgrade Devnet.
 
-An EIP **MUST** have a Python implementation accompanied by tests in [execution-specs](https://github.com/ethereum/execution-specs/blob/78fb726158c69d8fa164e28f195fabf6ab59b915/README.md), submitted as an open PR or merged to the `devnets/upgradeName/version` branch of the repository. Client developers **MAY** decide to allow an EIP to be moved to `Scheduled for Inclusion` without an [execution-specs](https://github.com/ethereum/execution-specs/blob/78fb726158c69d8fa164e28f195fabf6ab59b915/README.md) implementation, but the tests are strictly mandatory.
+An EIP **MUST** have a Python implementation accompanied by tests in [execution-specs](https://github.com/ethereum/execution-specs/blob/5cdb055e069e246a877c8aa018079eb0b9093f57/README.md), submitted as an open PR or merged to the `devnets/upgradeName/version` branch of the repository. Client developers **MAY** decide to allow an EIP to be moved to `Scheduled for Inclusion` without an [execution-specs](https://github.com/ethereum/execution-specs/blob/5cdb055e069e246a877c8aa018079eb0b9093f57/README.md) implementation, but the tests are strictly mandatory.
 
-Any updates to an EIP that is already at this stage **MUST** be accompanied by appropriate updates to its implementation and tests in [execution-specs](https://github.com/ethereum/execution-specs/blob/78fb726158c69d8fa164e28f195fabf6ab59b915/README.md) if deemed necessary by client developers.
+Any updates to an EIP that is already at this stage **MUST** be accompanied by appropriate updates to its implementation and tests in [execution-specs](https://github.com/ethereum/execution-specs/blob/5cdb055e069e246a877c8aa018079eb0b9093f57/README.md) if deemed necessary by client developers.
 
 ### Included
 

--- a/EIPS/eip-7723.md
+++ b/EIPS/eip-7723.md
@@ -40,7 +40,7 @@ When preparing a network upgrade, client developers typically implement EIPs fir
 
 Since client developers' ability to include EIPs in a network upgrade is constrained by what can be implemented and tested in these upgrade devnets, the [Considered for Inclusion](#considered-for-inclusion) and [Scheduled for Inclusion](#scheduled-for-inclusion) sections below propose aligning these statuses with EIPs' implementation status in upgrade devnets.
 
-### Proposed for Inclusion
+### Proposed for Inclusion (PFI)
 
 To propose an EIP for inclusion, someone **MUST** open a pull request to add it to the `Proposed for Inclusion` section of the Upgrade Meta EIP. The proposer of an EIP **SHOULD** serve as the primary point of contact for that EIP for the duration of the upgrade cycle or **SHOULD** designate another person to serve in that role. Reasonable pull requests **SHOULD** be merged in a timely fashion by the Upgrade Meta EIP author.
 
@@ -48,11 +48,13 @@ At this stage, implementation teams **SHOULD** review the EIP. For Core EIPs, th
  
 Note that EIPs must be `Proposed for Inclusion` for each network upgrade. In other words, proposals do not "carry over" to the next upgrade if an EIP is not included in the one it was first proposed for. 
 
-### Considered for Inclusion 
+### Considered for Inclusion (CFI)
 
 Once client developers have reviewed an EIP which was `Proposed for Inclusion`, they **MAY** move it to the `Considered for Inclusion` stage. Once a decision is made by client teams to move an EIP to `Considered for Inclusion`, the Upgrade Meta EIP **SHOULD** be updated to reflect this. 
 
-`Considered for Inclusion` signals that client developers are positive towards the EIP. A Core EIP that is `Considered for Inclusion`  **SHOULD** be implemented in future Upgrade Devnets. Assuming it meets all the requirements for mainnet deployment it **MAY** be included in the network upgrade. This stage is similar to "concept ACK" in other open source projects, and is not sufficient to result in deployment to mainnet. 
+`Considered for Inclusion` signals that client developers intend to attempt to include the EIP in devnets. The All Core Devs Execution (ACDE) and Consensus (ACDC) call facilitators should work with the testing teams to propose a priority ordering of CFI EIPs to be reviewed by client developers, and then reflect this prioritization in the Meta EIP. This prioritization should inform which EIPs should be included in upcoming devnets, with some flexibility if circumstances change.
+
+Assuming it meets all the requirements for mainnet deployment it **MAY** be included in the network upgrade. This stage is similar to "concept ACK" in other open source projects, and is not sufficient to result in deployment to mainnet. 
 
 Non-Core EIPs that are `Considered for Inclusion` **SHOULD** be supported prior to the network upgrade being activated. 
 
@@ -62,13 +64,13 @@ An EIP **SHOULD** have a Python implementation accompanied by tests in [executio
 
 Any updates to an EIP that is already at this stage **SHOULD** be accompanied by the appropriate updates to its implementation and tests in [execution-specs](https://github.com/ethereum/execution-specs/blob/78fb726158c69d8fa164e28f195fabf6ab59b915/README.md) if deemed necessary by client developers.
 
-### Declined for Inclusion
+### Declined for Inclusion (DFI)
 
 At any time during the network upgrade planning process, client developers **MAY** move EIPs from any other stage to the `Declined for Inclusion` stage if client teams are against including the EIP in the network upgrade. Once a decision is made by client teams to move an EIP to `Declined for Inclusion`, the Upgrade Meta EIP **SHOULD** be updated to reflect this.
 
 `Declined for Inclusion` signals that client developers wish to exclude the EIP from the current network upgrade and stop discussing its potential inclusion or implementation status in relation to this upgrade. An EIP which was `Declined for Inclusion` in a particular upgrade **MAY** still be `Proposed for Inclusion` in a subsequent upgrade. In exceptional circumstances, client developers **MAY** choose to move an EIP from `Declined for Inclusion` to `Considered for Inclusion` or `Scheduled for Inclusion`. 
 
-### Scheduled for Inclusion 
+### Scheduled for Inclusion (SFI)
 
 An EIP should move to SFI when:
 
@@ -76,6 +78,8 @@ An EIP should move to SFI when:
 - The EIP specification is finalized (no placeholder values or pending design decisions)
 - It has minimal interactions with other CFI EIPs, OR those interactions have been tested in the same devnet
 - Testing coverage is adequate (hive/EEST passing, no known divergence across clients)
+
+All Core Devs Testing (ACDT) calls may review EIPs to determine SFI eligibility. Status changes will then be ratified on ACDE or ACDC before assigning SFI status.
 
 `Scheduled for Inclusion` signals that the EIP is on track for inclusion barring unforeseen issues. EIPs with incomplete specs or untested interactions should remain CFI until these conditions are met. The latest Upgrade Devnet must contain all `Scheduled for Inclusion` Core EIPs.
 

--- a/EIPS/eip-7723.md
+++ b/EIPS/eip-7723.md
@@ -70,15 +70,20 @@ At any time during the network upgrade planning process, client developers **MAY
 
 ### Scheduled for Inclusion 
 
-When client teams agree to implement a Core EIP in the **next** Upgrade Devnet, the EIP **SHOULD** move to the `Scheduled for Inclusion` stage, and the Upgrade Meta EIP **SHOULD** be updated to reflect this. Non-Core EIPs **SHOULD** move to `Scheduled for Inclusion` when client teams agree to immediately prioritize their implementation. 
+An EIP should move to SFI when:
+
+- It has been included in a devnet that has demonstrated stability (e.g., high participation, no critical bugs for ≥1 week)
+- The EIP specification is finalized (no placeholder values or pending design decisions)
+- It has minimal interactions with other CFI EIPs, OR those interactions have been tested in the same devnet
+- Testing coverage is adequate (hive/EEST passing, no known divergence across clients)
+
+`Scheduled for Inclusion` signals that the EIP is on track for inclusion barring unforeseen issues. EIPs with incomplete specs or untested interactions should remain CFI until these conditions are met. The latest Upgrade Devnet must contain all `Scheduled for Inclusion` Core EIPs.
+
+An EIP **MAY** be moved from `Scheduled for Inclusion` to `Declined for Inclusion` if circumstances necessitate removal, as agreed by client teams. An EIP **MAY** also be moved from `Scheduled for Inclusion` to `Considered for Inclusion` if client teams remain in favor of including the EIP in the network upgrade but cannot commit to including it in the **next** Upgrade Devnet.
 
 An EIP **MUST** have a Python implementation accompanied by tests in [execution-specs](https://github.com/ethereum/execution-specs/blob/78fb726158c69d8fa164e28f195fabf6ab59b915/README.md), submitted as an open PR or merged to the `devnets/upgradeName/version` branch of the repository. Client developers **MAY** decide to allow an EIP to be moved to `Scheduled for Inclusion` without an [execution-specs](https://github.com/ethereum/execution-specs/blob/78fb726158c69d8fa164e28f195fabf6ab59b915/README.md) implementation, but the tests are strictly mandatory.
 
 Any updates to an EIP that is already at this stage **MUST** be accompanied by appropriate updates to its implementation and tests in [execution-specs](https://github.com/ethereum/execution-specs/blob/78fb726158c69d8fa164e28f195fabf6ab59b915/README.md) if deemed necessary by client developers.
-
-`Scheduled for Inclusion` signals that implementation and testing work are underway. The EIP **SHOULD** be included in the network upgrade if no issues arise. The latest Upgrade Devnet must contain all `Scheduled for Inclusion` Core EIPs.
-
-An EIP **MAY** be moved from `Scheduled for Inclusion` to `Declined for Inclusion` if client teams are against including the EIP in the network upgrade. An EIP **MAY** also be moved from `Scheduled for Inclusion` to `Considered for Inclusion` if client teams are in favor of including the EIP in the network upgrade but cannot commit to including it in the **next** Upgrade Devnet.
 
 ### Included
 

--- a/EIPS/eip-7723.md
+++ b/EIPS/eip-7723.md
@@ -81,7 +81,7 @@ I.e., an SFI status signals that the EIP is on track for inclusion barring unfor
 The following critieria can be applied to ascertain whether an EIP is mature (stable) enough to move to SFI:
 
 - It has been included in a devnet that has demonstrated stability (e.g., high participation, no critical bugs for ≥1 week).
-- The EIP specification is deemed close to final (no placeholder values or pending design decisions).
+- The EIP specification is close to final (no placeholder values or pending design decisions).
 - It has minimal interactions with other CFI EIPs, OR those interactions have been tested in the same devnet.
 - Testing coverage is adequate (clients pass consensus tests, no known divergence across clients).
 


### PR DESCRIPTION
SFI currently has a simple definition of "being included in a devnet" - this is not playing out in reality as there are often reasons not to SFI an EIP even though it's being planned for a devnet and it's resulting in failing to SFI EIPs because the current definition doesn't fit very well so results in it not being clear when an EIP should actually be SFI'd
 
This proposed definition is based on conversation from ACDT #74: https://forkcast.org/calls/acdt/074#t=1002 and subsequent discussion at Svalbard interop

Caveat #&#8203;1: "1 week" is somewhat arbitrary but gives good time between ACDs for SFI decisions
Caveat #&#8203;2: This pretty explicitly carves out CFI/SFI as more "descriptive" than a forcing function. This should come with clarification on a "priority list" process where, after non-headliners are chosen, a devnet priority list is created for the full list of EIPs

cc @spencer-tb 