### PR TITLE
Update EIP-8141: add signatures list to outer tx

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -13,7 +13,7 @@ requires: 1559, 2718, 3607, 4844, 7623, 7702
 
 ## Abstract
 
-Adds a new transaction whose validity and gas payment can be defined abstractly. This is achieved by decomposing the transaction into a sequence of *frames* which are contract calls that validate the transaction, approve gas payment, and execute standard user operations.
+Adds a new transaction whose validity and gas payment can be defined abstractly. This is achieved by decomposing the transaction into a sequence of *frames* which are contract calls that validate the transaction, approve gas payment, and execute standard user operations. The transaction can also carry a reusable list of signatures that may be referenced by `VERIFY` frames and by ordinary EVM execution.
 
 ## Motivation
 
@@ -50,9 +50,10 @@ A new [EIP-2718](./eip-2718.md) transaction with type `FRAME_TX_TYPE` is introdu
 The payload is defined as the RLP serialization of the following:
 
 ```
-[chain_id, nonce, sender, frames, max_priority_fee_per_gas, max_fee_per_gas, max_fee_per_blob_gas, blob_versioned_hashes]
+[chain_id, nonce, sender, frames, signatures, max_priority_fee_per_gas, max_fee_per_gas, max_fee_per_blob_gas, blob_versioned_hashes]
 
 frames = [[mode, flags, target, gas_limit, value, data], ...]
+signatures = [[scheme, signer, msg, signature], ...]
 ```
 
 #### Field Definitions
@@ -65,6 +66,7 @@ Below are high-level definitions of each field in the transaction definition. De
 - `nonce` -- nonce of the sender to prevent replays.
 - `sender` -- the address of the intended sender of the transaction.
 - `frames` -- list of frames to execute.
+- `signatures` -- list of validated signatures available to the transaction.
 - `max_priority_fee_per_gas` -- the EIP-1559 priority fee per gas the transaction will pay.
 - `max_fee_per_gas` -- the maximum EIP-1559 fee the transaction is willing to pay, per gas.
 - `max_fee_per_blob_gas` -- the maximum EIP-4844 fee per blob gas the transaction is willing to pay. Must be `0` if `blob_versioned_hashes` is empty.
@@ -78,6 +80,13 @@ Below are high-level definitions of each field in the transaction definition. De
 - `gas_limit` -- the maximum gas allowed to be execute in pursuit of the frame.
 - `value` -- the amount in wei that should transferred from the `sender` as part of the frame execution.
 - `data` -- the calldata provided to the top level call frame.
+
+##### Signature object
+
+- `scheme` -- the verification scheme used to interpret the raw signature bytes.
+- `signer` -- the address that authorized the message.
+- `msg` -- either empty, indicating the canonical transaction signature hash, or an explicit 32-byte digest.
+- `signature` -- raw signature bytes interpreted according to `scheme`.
 
 The `mode` of each frame sets the context of execution. It allows the protocol to identify
 the purpose of the frame within the execution loop.
@@ -108,6 +117,15 @@ assert tx.nonce < 2**64
 assert len(tx.frames) > 0 and len(tx.frames) <= MAX_FRAMES
 assert len(tx.sender) == 20
 
+for sig in tx.signatures:
+    assert len(sig.signer) == 20
+    if len(sig.msg) == 0:
+        assert sig.msg == Bytes()
+    elif len(sig.msg) == 32:
+        assert sig.msg != b"\x00" * 32
+    else:
+        invalid_transaction()
+
 total_frame_gas = 0
 for frame in tx.frames:
     assert frame.mode < 3
@@ -124,6 +142,35 @@ for frame in tx.frames:
         assert i + 1 < len(tx.frames)                  # must not be last frame
 ```
 
+#### Transaction Signatures
+
+The `signatures` list contains signatures that may be referenced by `VERIFY` frames and by ordinary EVM execution. Every signature in this list must validate successfully before any frame is executed. If any signature is malformed or invalid, the whole transaction is invalid.
+
+The `signatures` list is optional. Contracts may still ignore it entirely and perform bespoke signature verification inside frame execution.
+
+The raw `signature` byte strings are intentionally not introspectable by EVM code to allow future aggregation schemes. Contracts can inspect only the metadata of the signature list through transaction introspection.
+
+The `scheme` identifies how the raw `signature` bytes are interpreted.
+
+| `scheme` | Name        | `signature` encoding                           | Gas cost |
+|----------|-------------|------------------------------------------------|----------|
+| 0x0      | `Arbitrary` | ``                                             | 2800     |
+| 0x1      | `SECP256K1` | `v (1 byte) || r (32 bytes) || s (32 bytes)` | 2800     |
+| 0x2      | `P256`      | `r || s || qx || qy` (all 32 bytes)          | 6700     |
+| 0x3..255 | reserved    | reserved                                       | reserved |
+
+The `signer` is the 20-byte Ethereum address that authorized the `msg`.
+
+The `msg` determines which message the signature authorizes:
+
+- if `len(msg) == 0`, the signature is signed over `compute_sig_hash(tx)`
+- if `len(msg) == 32`, the signature is signed over the explicit 32-byte digest `msg`
+- any other `msg` length is invalid
+
+The explicit 32-byte zero digest is invalid. This reserves the zero stack value as the EVM-visible representation of the transaction signing hash case.
+
+For `P256`, the signer address must be `keccak256(qx || qy)[12:]`.
+
 #### Receipt Encoding
 
 The `ReceiptPayload` is defined as:
@@ -137,14 +184,61 @@ frame_receipt = [status, gas_used, logs]
 
 #### Signature Hash
 
-With the frame transaction, the signature may be at an arbitrary location in the frame list. In the canonical signature hash any frame with mode `VERIFY` will have its data elided, except for [expiry verifier frames](#expiry-verifier-frame), whose `data` is the deadline and is covered by the signature:
+The canonical signature hash is defined such that any signature with empty `msg` will have its raw `signature` bytes elided:
 
 ```python
 def compute_sig_hash(tx: FrameTx) -> Hash:
-    for i, frame in enumerate(tx.frames):
-        if frame.mode == VERIFY and frame.target != EXPIRY_VERIFIER:
-            tx.frames[i].data = Bytes()
+    for i, sig in enumerate(tx.signatures):
+        if len(sig.msg) == 0:
+            tx.signatures[i].signature = Bytes()
     return keccak(bytes([FRAME_TX_TYPE]) + rlp(tx))
+```
+
+#### Signature Validation
+
+Every signature in the outer transaction object is validated before frame execution. The validation rules are:
+
+```python
+ARBITRARY = 0x0
+SECP256K1 = 0x1
+P256      = 0x2
+
+def validate_signature(sig, tx, sig_hash) -> bool:
+    if len(sig.msg) == 0:
+        msg = sig_hash
+    elif len(sig.msg) == 32:
+        if sig.msg == b"\x00" * 32:
+            return False
+        msg = sig.msg
+    else:
+        return False
+
+    if sig.scheme == ARBITRARY:
+        # Reserved for contracts that want to attest to arbitrary metadata through
+        # the signature list; the protocol does not interpret `signature`.
+        return True
+
+    elif sig.scheme == SECP256K1:
+        if len(sig.signature) != 65:
+            return False
+        v = sig.signature[0]
+        r = sig.signature[1:33]
+        s = sig.signature[33:65]
+        return sig.signer == ecrecover(msg, v, r, s)
+
+    elif sig.scheme == P256:
+        if len(sig.signature) != 128:
+            return False
+        r  = sig.signature[0:32]
+        s  = sig.signature[32:64]
+        qx = sig.signature[64:96]
+        qy = sig.signature[96:128]
+        if sig.signer != keccak256(qx + qy)[12:]:
+            return False
+        return P256VERIFY(msg, r, s, qx, qy)
+
+    else:
+        return False
 ```
 
 #### Expiry Verifier Frame
@@ -218,6 +312,8 @@ When processing a frame transaction, perform the following steps.
 To begin processing a frame transaction:
 
 1. Ensure `tx.nonce == state[tx.sender].nonce`
+1. Compute the canonical transaction signature hash: `sig_hash = compute_sig_hash(tx)`.
+1. For each `sig` in `tx.signatures`, ensure `validate_signature(sig, tx, sig_hash) == true`.
 1. Initialize transaction-scoped variables:
     - `payer = None`
     - `sender_approved = false`
@@ -263,7 +359,25 @@ A few cross-frame interactions to note:
 The total gas limit of the transaction is:
 
 ```
-tx_gas_limit = FRAME_TX_INTRINSIC_COST + len(tx.frames) * FRAME_TX_PER_FRAME_COST + calldata_cost(rlp(tx.frames)) + sum(frame.gas_limit for all frames)
+def signature_gas(sig):
+    if sig.scheme == SECP256K1:
+        return 2800
+    if sig.scheme == P256:
+        return 6700
+    if sig.scheme == ARBITRARY:
+        return 2800
+    invalid_transaction()
+
+signature_verification_cost = sum(signature_gas(sig) for sig in tx.signatures)
+
+tx_gas_limit = (
+    FRAME_TX_INTRINSIC_COST
+    + len(tx.frames) * FRAME_TX_PER_FRAME_COST
+    + calldata_cost(rlp(tx.signatures))
+    + calldata_cost(rlp(tx.frames))
+    + signature_verification_cost
+    + sum(frame.gas_limit for all frames)
+)
 ```
 
 Where `calldata_cost` is calculated per standard [EIP-7623](./eip-7623.md) rules.
@@ -294,14 +408,7 @@ Frame transactions can be used by accounts who do not have deployed code, nor an
 - If `mode` is `VERIFY`:
   - Read the allowed approval scope from the flags field: `allowed_scope = frame.flags & APPROVE_SCOPE_MASK`. If `allowed_scope == APPROVE_SCOPE_NONE`, revert.
   - If `allowed_scope & APPROVE_EXECUTION != 0` and `resolved_target != tx.sender`, revert.
-  - Read the first byte of `frame.data` as `signature_type`.
-  - If `signature_type` is:
-    - `0x0`:
-      - Read the rest of `frame.data` as `(v, r, s)`.
-      - If `s > secp256k1n / 2`, revert.
-      - Let `recovered = ecrecover(sig_hash, v, r, s)`, where `sig_hash = compute_sig_hash(tx)`.
-      - If `recovered == address(0)` or `resolved_target != recovered`, revert.
-    - Otherwise revert.
+  - If there is no non-arbitrary signature `sig` such that `sig.signer == resolved_target` and `sig.msg == Bytes()`, revert.
   - Call `APPROVE(allowed_scope)`.
 - If `mode` is `SENDER` or `DEFAULT`:
   - Return successfully as if calling empty code.
@@ -346,11 +453,12 @@ This instruction gives access to transaction-scoped information. The gas cost of
 | 0x03    | `max_priority_fee_per_gas`                                                  |
 | 0x04    | `max_fee_per_gas`                                                           |
 | 0x05    | `max_fee_per_blob_gas`                                                      |
-| 0x06    | max cost (basefee=max, all gas used, includes blob cost, and intrinsic cost) |
+| 0x06    | max cost (basefee=max, all gas used, includes blob cost, intrinsic cost, and signature verification cost) |
 | 0x07    | `len(blob_versioned_hashes)`                                                |
 | 0x08    | `compute_sig_hash(tx)`                                                      |
 | 0x09    | `len(frames)`                                                               |
 | 0x0A    | currently executing frame index                                             |
+| 0x0B    | `len(signatures)`                                                           |
 
 
 Undefined `param` values result in an exceptional halt.
@@ -365,8 +473,7 @@ It places the retrieved data on the stack.
 When the `frameIndex` is out-of-bounds, an exceptional halt occurs.
 
 The operation semantics match CALLDATALOAD, returning a word of data from the chosen
-frame's `data`, starting at the given byte `offset`. When targeting a frame in `VERIFY`
-mode, the returned data is always zero.
+frame's `data`, starting at the given byte `offset`.
 
 #### `FRAMEDATACOPY` Instruction (`0xb2`)
 
@@ -381,7 +488,7 @@ When the `frameIndex` is out-of-bounds, an exceptional halt occurs.
 
 The operation semantics match CALLDATACOPY, copying `length` bytes from the chosen frame's
 `data`, starting at the given byte `dataOffset`, into a memory region starting at
-`memOffset`. When targeting a frame in `VERIFY` mode, no data is copied.
+`memOffset`.
 
 #### `FRAMEPARAM` Instruction (`0xb3`)
 
@@ -405,7 +512,23 @@ Notes:
 - Undefined `param` values result in an exceptional halt.
 - Out-of-bounds access for `frameIndex` results in an exceptional halt.
 - Attempting to access the return `status` of the current frame or a subsequent frame results in an exceptional halt.
-- `len(data)` returns size 0 when called on a frame with `VERIFY` set.
+
+
+#### `SIGPARAM` Instruction (`0xb4`)
+
+This instruction gives access to signature-scoped metadata. The raw `signature` bytes are intentionally not accessible from the EVM. The gas cost of this operation is `2`. It takes two values from the stack, `signatureIndex` on top and `param` second from top.
+
+| `param` | `signatureIndex` | Return value       |
+|---------|------------------|--------------------|
+| 0x00    | signatureIndex   | `signer`           |
+| 0x01    | signatureIndex   | `scheme`           |
+| 0x02    | signatureIndex   | `msg`              |
+| 0x03    | signatureIndex   | `len(signature)`   |
+
+Notes:
+
+- Undefined `param` values result in an exceptional halt.
+- Out-of-bounds access for `signatureIndex` results in an exceptional halt.
 
 ### Mempool
 
@@ -417,7 +540,7 @@ This policy is inspired by [ERC-7562](./eip-7562.md), but removes staking and re
 
 | Name  | Value  | Description  |
 |---|---|---|
-| `MAX_VERIFY_GAS`   | `100_000`  | Maximum amount of gas a node should expend simulating the validation prefix |
+| `MAX_VERIFY_GAS`   | `100_000`  | Maximum amount of gas a node should expend validating signatures and simulating the validation prefix |
 | `MAX_PENDING_TXS_USING_NON_CANONICAL_PAYMASTER`   | `1`  | Maximum amount of pending transactions that can be using any given non-canonical paymaster |
 
 #### Validation Prefix
@@ -425,6 +548,8 @@ This policy is inspired by [ERC-7562](./eip-7562.md), but removes staking and re
 The **validation prefix** of a frame transaction is the shortest prefix of frames whose successful execution sets `payer`.
 
 Public mempool rules apply only to the validation prefix. Once `payer` has been set, subsequent frames are outside public mempool validation and may be arbitrary. In particular, `user_op` and `post_op` occur after payment approval and are therefore not subject to the public mempool restrictions below.
+
+For public mempool accounting, signature validation is treated as part of the transaction intrinsic cost and counts against `MAX_VERIFY_GAS`.
 
 #### Policy Summary
 
@@ -507,7 +632,7 @@ To be accepted into the public mempool, a frame transaction must satisfy the fol
     - `only_verify` must call `APPROVE(APPROVE_EXECUTION)`.
 4. `pay` must execute in `VERIFY` mode and successfully call `APPROVE(APPROVE_PAYMENT)`.
 5. No frame in the validation prefix may have the `ATOMIC_BATCH_FLAG` set.
-6. The sum of `gas_limit` values across the validation prefix must not exceed `MAX_VERIFY_GAS`.
+6. The sum of `gas_limit` values across the validation prefix, plus the intrinsic cost of validating `tx.signatures`, must not exceed `MAX_VERIFY_GAS`.
 7. Nodes should stop simulation immediately once `payer` has been set.
 
 #### Expiry Verifier Frame
@@ -528,7 +653,7 @@ A public mempool node must simulate the validation prefix and reject the transac
 
 - a frame in the validation prefix reverts
 - a `self_verify`, `only_verify`, or `pay` frame exits without its required `APPROVE`
-- execution exceeds `MAX_VERIFY_GAS`
+- total public-mempool validation work, including signature validation, exceeds `MAX_VERIFY_GAS`
 - execution uses a banned opcode
 - execution performs a state write, except inside the first `deploy` frame for (a) `CREATE`, `CREATE2`, or `SETDELEGATE` operations that install code at `tx.sender`, or (b) `SSTORE`s to `tx.sender`'s storage
 - execution reads storage outside `tx.sender`
@@ -623,12 +748,13 @@ available_paymaster_balance = state.balance(paymaster) - reserved_pending_cost(p
 #### Acceptance Algorithm
 
 1. A transaction is received over the wire and the node decides whether to accept or reject it.
-2. The node analyzes the frame structure and determines the validation prefix. If the prefix is not one of the recognized prefixes, reject.
-3. The node simulates the validation prefix and enforces the structural and trace rules above, except that a `pay` frame whose target runtime code exactly matches the canonical paymaster implementation is handled via the canonical paymaster exception and the paymaster-specific rules below.
-4. The node records the sender storage slots read during validation. Calls into helper contracts do not create additional mutable-state dependencies unless they cause disallowed storage access under the trace rules above.
-5. If a canonical paymaster instance is used, the node verifies paymaster solvency using the reservation rule above.
-6. A node should keep at most one pending frame transaction per sender in the public mempool. A new transaction from the same sender MAY replace the existing one only if it uses the same nonce and satisfies the node's fee bump rules.
-7. If all checks pass, the transaction may be accepted into the public mempool and propagated to peers.
+2. The node validates all signatures. If any signature is malformed or invalid, reject.
+3. The node analyzes the frame structure and determines the validation prefix. If the prefix is not one of the recognized prefixes, reject.
+4. The node simulates the validation prefix and enforces the structural and trace rules above, except that a `pay` frame whose target runtime code exactly matches the canonical paymaster implementation is handled via the canonical paymaster exception and the paymaster-specific rules below.
+5. The node records the sender storage slots read during validation. Calls into helper contracts do not create additional mutable-state dependencies unless they cause disallowed storage access under the trace rules above.
+6. If a canonical paymaster instance is used, the node verifies paymaster solvency using the reservation rule above.
+7. A node should keep at most one pending frame transaction per sender in the public mempool. A new transaction from the same sender MAY replace the existing one only if it uses the same nonce and satisfies the node's fee bump rules.
+8. If all checks pass, the transaction may be accepted into the public mempool and propagated to peers.
 
 #### Revalidation
 
@@ -646,21 +772,15 @@ Validation logic for other transaction types remains unchanged, i.e. the transac
 
 The canonical signature hash is provided in `TXPARAM` to simplify the development of smart accounts.
 
-Computing the signature hash in EVM is complicated and expensive. While using the canonical signature hash is not mandatory, it is strongly recommended. Creating a bespoke signature requires precise commitment to the underlying transaction data. Without this, it's possible that some elements can be manipulated in-the-air while the transaction is pending and have unexpected effects. This is known as transaction malleability. Using the canonical signature hash avoids malleability of the frames other than `VERIFY`.
+Computing the signature hash in EVM is complicated and expensive. While using the canonical signature hash is not mandatory, it is strongly recommended. Creating a bespoke signature requires precise commitment to the underlying transaction data. Without this, it's possible that some elements can be manipulated in-the-air while the transaction is pending and have unexpected effects. This is known as transaction malleability. Using the canonical signature hash avoids malleability of the frames.
 
-The `frame.data` of `VERIFY` frames is elided from the signature hash. This is done for three reasons:
+The raw `signature` bytes of signatures with empty `msg` are elided from the canonical signature hash. This is done for three reasons:
 
-1. It contains the signature so by definition it cannot be part of the signature hash.
-2. In the future it may be desired to aggregate the cryptographic operations for data and compute efficiency reasons. If the data was introspectable, it would not be possible to aggregate the verify frames in the future.
-3. For gas sponsoring workflows, we also recommend using a `VERIFY` frame to approve the gas payment. Here, the input data to the sponsor is intentionally left malleable so it can be added onto the transaction after the `sender` has made its signature. Notably, the raw `frame.target` field of `VERIFY` frames is covered by the signature hash, i.e. the `sender` chooses the sponsor address explicitly.
+1. A signature over `compute_sig_hash(tx)` cannot commit to its own raw bytes.
+2. In the future it may be desired to aggregate or otherwise externalize these signatures for data and compute efficiency reasons.
+3. Signatures with explicit 32-byte `msg` values do not induce this circularity, so their raw bytes are currently committed by the transaction signature hash.
 
-[Expiry verifier frames](#expiry-verifier-frame) are an exception: their `data` is the deadline, a sender-authored commitment that must not be malleable in transit, so it is included in the signature hash.
-
-Implementations MUST NOT treat `VERIFY` frame `data` as sender-authenticated by the canonical signature hash. Any verifier or paymaster that depends on its input data, including sponsor parameters, exchange rates, fee terms, or custom account context, MUST authenticate that data independently. Replacing or mutating `VERIFY` frame `data` does not change the canonical signature hash.
-
-By contrast, non-`VERIFY` frame metadata, including a `SENDER` frame's `value`, remains covered by the canonical signature hash.
-
-Verification logic MUST NOT assign policy meaning to signature encodings or adjacent `VERIFY` frame data unless that meaning is independently authenticated.
+The `data` of `VERIFY` frames, including expiry verifier deadlines, is not elided. Any validation data that is intended to be added after a sender signs should be represented as elided raw signature bytes in `tx.signatures`, rather than as mutable frame data.
 
 ### `APPROVE` calling convention
 
@@ -716,10 +836,10 @@ Note that users can use any EOA as a paymaster thanks to the [default code](#def
 
 | Frame | Caller      | Target        | Value | Flags                         | Data      | Mode   |
 | ----- | ----------- | ------------- | ----- | ----------------------------- | --------- | ------ |
-| 0     | ENTRY_POINT | Null (sender) | 0     | APPROVE_EXECUTION_AND_PAYMENT | Signature | VERIFY |
+| 0     | ENTRY_POINT | Null (sender) | 0     | APPROVE_EXECUTION_AND_PAYMENT | Empty     | VERIFY |
 | 1     | Sender      | Target        | 0     | APPROVE_SCOPE_NONE            | Call data | SENDER |
 
-Frame 0 verifies the signature and calls `APPROVE(APPROVE_EXECUTION_AND_PAYMENT)` to approve both payment and execution. Frame 1 executes and exits normally via `RETURN`.
+Frame 0 uses a signature entry with empty `msg` for the sender and calls `APPROVE(APPROVE_EXECUTION_AND_PAYMENT)` to approve both payment and execution. Frame 1 executes and exits normally via `RETURN`.
 
 The mempool can process this transaction with the following static validation and call:
 
@@ -730,7 +850,7 @@ The mempool can process this transaction with the following static validation an
 
 | Frame | Caller      | Target        | Value  | Flags                         | Data      | Mode   |
 | ----- | ----------- | ------------- | ------ | ----------------------------- | --------- | ------ |
-| 0     | ENTRY_POINT | Null (sender) | 0      | APPROVE_EXECUTION_AND_PAYMENT | Signature | VERIFY |
+| 0     | ENTRY_POINT | Null (sender) | 0      | APPROVE_EXECUTION_AND_PAYMENT | Empty     | VERIFY |
 | 1     | Sender      | Destination   | Amount | APPROVE_SCOPE_NONE            | Empty     | SENDER |
 
 A simple transfer is performed by setting the `SENDER` frame target to the destination account and the frame `value` to the transfer amount. This requires two frames for mempool compatibility, since the validation phase of the transaction has to be static.
@@ -740,7 +860,7 @@ A simple transfer is performed by setting the `SENDER` frame target to the desti
 | Frame | Caller      | Target        | Value  | Flags                         | Data           | Mode    |
 | ----- | ----------- | ------------- | ------ | ----------------------------- | -------------- | ------- |
 | 0     | ENTRY_POINT | Deployer      | 0      | APPROVE_SCOPE_NONE            | Initcode, Salt | DEFAULT |
-| 1     | ENTRY_POINT | Null (sender) | 0      | APPROVE_EXECUTION_AND_PAYMENT | Signature      | VERIFY  |
+| 1     | ENTRY_POINT | Null (sender) | 0      | APPROVE_EXECUTION_AND_PAYMENT | Empty          | VERIFY  |
 | 2     | Sender      | Destination   | Amount | APPROVE_SCOPE_NONE            | Empty          | SENDER  |
 
 This example illustrates the initial deployment flow for a smart account at the `sender` address. Since the address needs to have code in order to validate the transaction, the transaction must deploy the code before verification.
@@ -751,24 +871,24 @@ The first frame would call the [EIP-7997](./eip-7997.md) deterministic factory p
 
 | Frame | Caller      | Target        | Value | Flags                         | Data                 | Mode   |
 | ----- | ----------- | ------------- | ----- | ----------------------------- | -------------------- | ------ |
-| 0     | ENTRY_POINT | Null (sender) | 0     | APPROVE_EXECUTION_AND_PAYMENT | Signature            | VERIFY |
+| 0     | ENTRY_POINT | Null (sender) | 0     | APPROVE_EXECUTION_AND_PAYMENT | Empty                | VERIFY |
 | 1     | Sender      | ERC-20        | 0     | ATOMIC_BATCH_FLAG            | approve(DEX, amount) | SENDER |
 | 2     | Sender      | DEX           | 0     | APPROVE_SCOPE_NONE           | swap(...)            | SENDER |
 
-Frame 0 verifies the signature and calls `APPROVE(APPROVE_EXECUTION_AND_PAYMENT)`. Frames 1 and 2 form an atomic batch: if the swap in frame 2 reverts, the ERC-20 approval from frame 1 is also reverted, preventing the account from being left with a dangling approval.
+Frame 0 uses a signature entry with empty `msg` and calls `APPROVE(APPROVE_EXECUTION_AND_PAYMENT)`. Frames 1 and 2 form an atomic batch: if the swap in frame 2 reverts, the ERC-20 approval from frame 1 is also reverted, preventing the account from being left with a dangling approval.
 
 #### Example 3: Sponsored Transaction (Fee Payment in ERC-20)
 
 | Frame | Caller      | Target        | Value | Flags              | Data                   | Mode    |
 | ----- | ----------- | ------------- | ----- | ------------------ | ---------------------- | ------- |
-| 0     | ENTRY_POINT | Null (sender) | 0     | APPROVE_EXECUTION  | Signature              | VERIFY  |
+| 0     | ENTRY_POINT | Null (sender) | 0     | APPROVE_EXECUTION  | Empty                  | VERIFY  |
 | 1     | ENTRY_POINT | Sponsor       | 0     | APPROVE_PAYMENT    | Sponsor data           | VERIFY  |
 | 2     | Sender      | ERC-20        | 0     | APPROVE_SCOPE_NONE | transfer(Sponsor,fees) | SENDER  |
 | 3     | Sender      | Target addr   | 0     | APPROVE_SCOPE_NONE | Call data              | SENDER  |
 | 4     | ENTRY_POINT | Sponsor       | 0     | APPROVE_SCOPE_NONE | Post op call           | DEFAULT |
 
-- Frame 0: Verifies signature and calls `APPROVE(APPROVE_EXECUTION)` to authorize execution from sender.
-- Frame 1: Checks that the user has enough ERC-20 tokens, and that the next frame is an ERC-20 send of the right size to the sponsor. Calls `APPROVE(APPROVE_PAYMENT)` to authorize payment.
+- Frame 0: Uses the sender's signature entry with empty `msg` and calls `APPROVE(APPROVE_EXECUTION)` to authorize execution from sender.
+- Frame 1: Checks that the user has enough ERC-20 tokens, inspects signature metadata in `tx.signatures` if needed, and checks that the next frame is an ERC-20 send of the right size to the sponsor. Calls `APPROVE(APPROVE_PAYMENT)` to authorize payment.
 - Frame 2: Sends tokens to sponsor.
 - Frame 3: User's intended call.
 - Frame 4 (optional): Check unpaid gas, refund tokens, possibly convert tokens to ETH on an AMM.
@@ -787,22 +907,27 @@ Frame 0 verifies the signature and calls `APPROVE(APPROVE_EXECUTION_AND_PAYMENT)
 | Max fee                           | 5     |
 | Max fee per blob gas              | 1     |
 | Blob versioned hashes (empty)     | 1     |
+| Signatures wrapper                | 1     |
+| Sender tx signature: scheme       | 1     |
+| Sender tx signature: signer       | 20    |
+| Sender tx signature: msg          | 0     |
+| Sender tx signature: signature    | 65    |
 | Frames wrapper                    | 1     |
 | Sender validation frame: mode     | 1     |
 | Sender validation frame: flags    | 1     |
 | Sender validation frame: target   | 1     |
 | Sender validation frame: gas      | 2     |
 | Sender validation frame: value    | 1     |
-| Sender validation frame: data     | 65    |
+| Sender validation frame: data     | 0     |
 | Execution frame: mode             | 1     |
 | Execution frame: flags            | 1     |
 | Execution frame: target           | 20    |
 | Execution frame: gas              | 1     |
 | Execution frame: value            | 5     |
 | Execution frame: data             | 0     |
-| **Total**                         | 136   |
+| **Total**                         | 158   |
 
-Notes: Nonce assumes < 65536 prior sends. Fees assume < 1099 gwei. Validation frame target is 1 byte because target is `tx.sender`. Validation gas assumes <= 65,536 gas. Validation frame value is zero. Execution frame target is encoded directly as the destination address. Execution frame value assumes a compact 5-byte encoding. The execution frame data is empty for a plain ETH transfer. Validation data is 65 bytes for an ECDSA signature. Blob fields assume no blobs (empty list, zero max fee).
+Notes: Nonce assumes < 65536 prior sends. Fees assume < 1099 gwei. Validation frame target is 1 byte because target is `tx.sender`. Validation gas assumes <= 65,536 gas. Validation frame value is zero. Execution frame target is encoded directly as the destination address. Execution frame value assumes a compact 5-byte encoding. The execution frame data is empty for a plain ETH transfer. The signature is a secp256k1 entry with empty `msg` using a 65-byte ECDSA signature. Blob fields assume no blobs (empty list, zero max fee).
 
 This is not much larger than an EIP-1559 transaction; the extra overhead is mainly the need to specify the sender and the per-frame wrapper explicitly.
 

--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -13,7 +13,7 @@ requires: 1559, 2718, 3607, 4844, 7623, 7702
 
 ## Abstract
 
-Adds a new transaction whose validity and gas payment can be defined abstractly. This is achieved by decomposing the transaction into a sequence of *frames* which are contract calls that validate the transaction, approve gas payment, and execute standard user operations. The transaction can also carry a reusable list of signatures that may be referenced by `VERIFY` frames and by ordinary EVM execution.
+Adds a new transaction whose validity and gas payment can be defined abstractly. This is achieved by decomposing the transaction into a sequence of *frames* which are contract calls that validate the transaction, approve gas payment, and execute standard user operations.
 
 ## Motivation
 
@@ -31,15 +31,20 @@ Ultimately, frame transactions realize the original vision of account abstractio
 
 ### Constants
 
-| Name                      | Value           |
-|---------------------------|-----------------|
-| `FRAME_TX_TYPE`           | `0x06`          |
-| `FRAME_TX_INTRINSIC_COST` | `15000`         |
-| `FRAME_TX_PER_FRAME_COST` | `475`           |
-| `ENTRY_POINT`             | `address(0xaa)` |
-| `EXPIRY_VERIFIER`         | `address(0x8141)` |
-| `EXPIRY_DATA_LENGTH`      | `8`             |
-| `MAX_FRAMES`              | `64`            |
+| Name                       | Value             |
+|----------------------------|-------------------|
+| `FRAME_TX_TYPE`            | `0x06`            |
+| `FRAME_TX_INTRINSIC_COST`  | `15000`           |
+| `FRAME_TX_PER_FRAME_COST`  | `475`             |
+| `ENTRY_POINT`              | `address(0xaa)`   |
+| `EXPIRY_VERIFIER`          | `address(0x8141)` |
+| `EXPIRY_DATA_LENGTH`       | `8`               |
+| `MAX_FRAMES`               | `64`              |
+| `PUBLIC_KEY_ALIAS_PREFIX`  | `0xef02`          |
+| `PUBLIC_KEY_ALIAS_VERSION` | `0x00`            |
+| `BLS12_381_G1_PUBLIC_KEY`  | `0x00`            |
+| `BLS12_381_SIGNING_DOMAIN` | `b"EIP8141_BLS12_381_V0"` |
+| `BLS12_381_SIGNATURE_GAS`  | `TBD`             |
 
 ### Frame Transaction
 
@@ -84,7 +89,7 @@ Below are high-level definitions of each field in the transaction definition. De
 ##### Signature object
 
 - `scheme` -- the verification scheme used to interpret the raw signature bytes.
-- `signer` -- the address that authorized the message.
+- `signer` -- the signer's address, inline public key, or alias to public key.
 - `msg` -- either empty, indicating the canonical transaction signature hash, or an explicit 32-byte digest.
 - `signature` -- raw signature bytes interpreted according to `scheme`.
 
@@ -118,7 +123,14 @@ assert len(tx.frames) > 0 and len(tx.frames) <= MAX_FRAMES
 assert len(tx.sender) == 20
 
 for sig in tx.signatures:
-    assert len(sig.signer) == 20
+    if sig.scheme == ARBITRARY:
+        pass
+    elif sig.scheme in [SECP256K1, P256]:
+        assert len(sig.signer) == 20
+    elif sig.scheme == BLS12_381:
+        assert len(sig.signer) in [20, 48]
+    else:
+        invalid_transaction()
     if len(sig.msg) == 0:
         assert sig.msg == Bytes()
     elif len(sig.msg) == 32:
@@ -152,24 +164,85 @@ The raw `signature` byte strings are intentionally not introspectable by EVM cod
 
 The `scheme` identifies how the raw `signature` bytes are interpreted.
 
-| `scheme` | Name        | `signature` encoding                           | Gas cost |
-|----------|-------------|------------------------------------------------|----------|
-| 0x0      | `Arbitrary` | ``                                             | 2800     |
-| 0x1      | `SECP256K1` | `v (1 byte) || r (32 bytes) || s (32 bytes)` | 2800     |
-| 0x2      | `P256`      | `r || s || qx || qy` (all 32 bytes)          | 6700     |
-| 0x3..255 | reserved    | reserved                                       | reserved |
+| `scheme` | Name         | `signature` encoding                           | Gas cost |
+|----------|--------------|------------------------------------------------|----------|
+| 0x0      | `Arbitrary`  | arbitrary bytes                               | 2800     |
+| 0x1      | `SECP256K1`  | `v (1 byte) || r (32 bytes) || s (32 bytes)` | 2800     |
+| 0x2      | `P256`       | `r || s || qx || qy` (all 32 bytes)          | 6700     |
+| 0x3      | `BLS12_381`  | compressed G2 signature (96 bytes)            | `BLS12_381_SIGNATURE_GAS` |
+| 0x4..255 | reserved     | reserved                                       | reserved |
 
-The `signer` is the 20-byte Ethereum address that authorized the `msg`.
+For `SECP256K1` and `P256`, the `signer` is a 20-byte Ethereum address.
 
-The `msg` determines which message the signature authorizes:
+For `Arbitrary`, both `signer` and `signature` have no fixed length and are not interpreted by the protocol. If `len(signer) == 20`, `signer` is treated as an alias address. Otherwise, `signer` is treated as arbitrary inline data and its effective signer address is `keccak256(signer)[12:]`.
+
+For `BLS12_381`, the `signer` can either be an inline public key or an alias to
+a public key:
+
+- if `len(signer) == 20`, `signer` is a public key alias address whose code contains the public key;
+- if `len(signer) == 48`, `signer` is an inline compressed BLS12-381 G1 public key.
+
+The effective signer address of a `BLS12_381` signature is:
+
+```python
+if len(sig.signer) == 20:
+    effective_signer = sig.signer
+elif len(sig.signer) == 48:
+    effective_signer = keccak256(bytes([BLS12_381_G1_PUBLIC_KEY]) + (48).to_bytes(2, "big") + sig.signer)[12:]
+else:
+    invalid_transaction()
+```
+
+The `msg` which message the signature authorizes:
 
 - if `len(msg) == 0`, the signature is signed over `compute_sig_hash(tx)`
-- if `len(msg) == 32`, the signature is signed over the explicit 32-byte digest `msg`
+- if `len(msg) == 32`, the signature is signed the explicit 32-byte digest `msg`
 - any other `msg` length is invalid
 
 The explicit 32-byte zero digest is invalid. This reserves the zero stack value as the EVM-visible representation of the transaction signing hash case.
 
 For `P256`, the signer address must be `keccak256(qx || qy)[12:]`.
+
+For `BLS12_381`, verification uses the BLS signature functions defined by the [Ethereum consensus specifications](https://github.com/ethereum/consensus-specs/blob/4a4937bea332d72a55a76aaebcb97fbcdc189f69/specs/phase0/beacon-chain.md#bls-signatures), which reference the IETF BLS signature ciphersuite `BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_`. Public keys are 48-byte compressed G1 points and signatures are 96-byte compressed G2 points. Public keys and signatures must be canonical encodings, must not be the point at infinity, and must pass subgroup checks. The BLS message verified by the signature is:
+
+```python
+bls_message = keccak256(BLS12_381_SIGNING_DOMAIN + bytes([sig.scheme]) + effective_signer(sig) + msg)
+```
+
+where `msg` is resolved according to the rules above.
+
+The BLS ciphersuite hash-to-curve procedure and domain separation tag are the ones defined by the Ethereum consensus specifications. EIP-8141-specific domain separation is provided by the `BLS12_381_SIGNING_DOMAIN` bytes included in `bls_message`.
+
+#### Public Key Aliases
+
+A public key alias is a 20-byte address that names a public key stored in state. It allows signature schemes to refer to public keys by address instead of carrying the full key in every transaction. This is useful for `BLS12_381` and is intended to be reusable by future cryptographic schemes with large public key sizes.
+
+A public key alias account contains a canonical public key object as code. The code is not executable EVM bytecode. Each `key_type` defines the cryptosystem, public key encoding, valid public key lengths, and key validation rules for the `pubkey` bytes.
+
+Public key alias code has the following format:
+
+```text
+0xef || 0x02 || version || key_type || pubkey_len || pubkey
+```
+
+where `version` is one byte, `key_type` is one byte, `pubkey_len` is a two-byte unsigned big-endian integer, and `pubkey` is `pubkey_len` bytes. The initial version is `PUBLIC_KEY_ALIAS_VERSION` (`0x00`).
+
+The initial key types are:
+
+| `key_type` | Name                     | `pubkey` encoding                    |
+|------------|--------------------------|--------------------------------------|
+| 0x00       | `BLS12_381_G1_PUBLIC_KEY` | compressed BLS12-381 G1 point, 48 bytes |
+| 0x01..255  | reserved                 | reserved                             |
+
+For BLS12-381 public keys, the key object is:
+
+```text
+0xef || 0x02 || 0x00 || BLS12_381_G1_PUBLIC_KEY || 0x0030 || compressed_g1_pubkey
+```
+
+When a `BLS12_381` signature uses a 20-byte `signer`, validation loads the code at that address and requires it to be a public key alias with `version == 0x00`, `key_type == BLS12_381_G1_PUBLIC_KEY`, `pubkey_len == 48`, and a valid compressed BLS12-381 G1 public key.
+
+Because transaction signatures are validated before any frame executes, a public key alias referenced by a transaction signature must already exist in the pre-transaction state. Users who have not published an alias can use the inline public key form.
 
 #### Receipt Encoding
 
@@ -202,6 +275,34 @@ Every signature in the outer transaction object is validated before frame execut
 ARBITRARY = 0x0
 SECP256K1 = 0x1
 P256      = 0x2
+BLS12_381 = 0x3
+
+def effective_signer(sig) -> Address:
+    if sig.scheme == ARBITRARY:
+        if len(sig.signer) == 20:
+            return sig.signer
+        return keccak256(sig.signer)[12:]
+    if sig.scheme == BLS12_381:
+        if len(sig.signer) == 20:
+            return sig.signer
+        if len(sig.signer) == 48:
+            return keccak256(bytes([BLS12_381_G1_PUBLIC_KEY]) + (48).to_bytes(2, "big") + sig.signer)[12:]
+        invalid_transaction()
+    return sig.signer
+
+def load_public_key_alias(alias: Address, key_type: int) -> Bytes:
+    code = state.code(alias)
+    if len(code) < 6 or code[0:2] != b"\xef\x02":
+        invalid_transaction()
+    version = code[2]
+    actual_key_type = code[3]
+    pubkey_len = int.from_bytes(code[4:6], "big")
+    pubkey = code[6:]
+    if version != PUBLIC_KEY_ALIAS_VERSION or actual_key_type != key_type:
+        invalid_transaction()
+    if len(pubkey) != pubkey_len:
+        invalid_transaction()
+    return pubkey
 
 def validate_signature(sig, tx, sig_hash) -> bool:
     if len(sig.msg) == 0:
@@ -236,6 +337,22 @@ def validate_signature(sig, tx, sig_hash) -> bool:
         if sig.signer != keccak256(qx + qy)[12:]:
             return False
         return P256VERIFY(msg, r, s, qx, qy)
+
+    elif sig.scheme == BLS12_381:
+        if len(sig.signature) != 96:
+            return False
+        if len(sig.signer) == 20:
+            pubkey = load_public_key_alias(sig.signer, BLS12_381_G1_PUBLIC_KEY)
+        elif len(sig.signer) == 48:
+            pubkey = sig.signer
+        else:
+            return False
+        if len(pubkey) != 48 or not BLS_VALID_G1_PUBKEY(pubkey):
+            return False
+        if not BLS_VALID_G2_SIGNATURE(sig.signature):
+            return False
+        bls_message = keccak256(BLS12_381_SIGNING_DOMAIN + bytes([sig.scheme]) + effective_signer(sig) + msg)
+        return BLS_VERIFY(pubkey, bls_message, sig.signature)
 
     else:
         return False
@@ -364,6 +481,8 @@ def signature_gas(sig):
         return 2800
     if sig.scheme == P256:
         return 6700
+    if sig.scheme == BLS12_381:
+        return BLS12_381_SIGNATURE_GAS
     if sig.scheme == ARBITRARY:
         return 2800
     invalid_transaction()
@@ -381,6 +500,8 @@ tx_gas_limit = (
 ```
 
 Where `calldata_cost` is calculated per standard [EIP-7623](./eip-7623.md) rules.
+
+The calldata cost for `rlp(tx.signatures)` is charged over the signature objects exactly as included in the transaction, including the scheme-dependent `signer` bytes. For example, a `BLS12_381` signature using an inline 48-byte public key pays calldata cost for that inline public key, while a `BLS12_381` signature using a public key alias pays calldata cost only for the 20-byte alias address. `Arbitrary` inline signer data is charged in the same way.
 
 The total fee is defined as:
 
@@ -408,7 +529,7 @@ Frame transactions can be used by accounts who do not have deployed code, nor an
 - If `mode` is `VERIFY`:
   - Read the allowed approval scope from the flags field: `allowed_scope = frame.flags & APPROVE_SCOPE_MASK`. If `allowed_scope == APPROVE_SCOPE_NONE`, revert.
   - If `allowed_scope & APPROVE_EXECUTION != 0` and `resolved_target != tx.sender`, revert.
-  - If there is no non-arbitrary signature `sig` such that `sig.signer == resolved_target` and `sig.msg == Bytes()`, revert.
+  - If there is no `SECP256K1` signature `sig` such that `sig.signer == resolved_target` and `sig.msg == Bytes()`, revert.
   - Call `APPROVE(allowed_scope)`.
 - If `mode` is `SENDER` or `DEFAULT`:
   - Return successfully as if calling empty code.
@@ -436,6 +557,44 @@ The `scope` operand is a bitmask. Define the following constants:
 - `APPROVE_EXECUTION_AND_PAYMENT` (`0x3`): Approval of payment and execution.
 
 `APPROVE_SCOPE_MASK` is defined as an alias for `APPROVE_EXECUTION_AND_PAYMENT`.
+
+### `PUBLISHPK` Instruction (`0xab`)
+
+The `PUBLISHPK` instruction publishes a public key alias for any recognized `key_type`. It reads a public key from memory, validates it according to the selected `key_type`, wraps it in the canonical public key alias code format, derives the alias address, and installs the alias code at that address.
+
+#### Stack
+
+| Stack      | Value        |
+| ---------- | ------------ |
+| `top - 0`  | `offset`     |
+| `top - 1`  | `length`     |
+| `top - 2`  | `key_type`   |
+
+`PUBLISHPK` pops these three values and pushes the 20-byte `alias_address` as a stack value on success.
+
+#### Behavior
+
+Let `pubkey = memory[offset:offset + length]`. `key_type` must fit in one byte and `length` must fit in two bytes. `key_type` must be a public key type recognized by the protocol, and `pubkey` must satisfy that key type's length, encoding, and validity rules. For `BLS12_381_G1_PUBLIC_KEY`, `length` must equal `48` and `pubkey` must be a valid compressed BLS12-381 G1 public key.
+
+The alias code is:
+
+```python
+alias_code = b"\xef\x02" + bytes([PUBLIC_KEY_ALIAS_VERSION]) + bytes([key_type]) + length.to_bytes(2, "big") + pubkey
+```
+
+The alias address is derived as:
+
+```python
+alias_address = keccak256(b"EIP8141_PUBLISHPK" + ADDRESS + alias_code)[12:]
+```
+
+where `ADDRESS` is the current execution address, i.e. the value returned by the `ADDRESS` opcode in the current call frame.
+
+If `alias_address` is not empty execution results in an exceptional halt. Otherwise, create the account using normal contract-creation account initialization semantics and set its code to `alias_code`.
+
+`PUBLISHPK` is state-modifying and results in an exceptional halt in a static context.
+
+The gas cost is the memory expansion cost for reading `pubkey`, plus `G_create`, plus `G_codedeposit * len(alias_code)`, plus `G_sha3word * ceil((len(b"EIP8141_PUBLISHPK") + 20 + len(alias_code)) / 32)`.
 
 ### Introspection
 
@@ -520,7 +679,7 @@ This instruction gives access to signature-scoped metadata. The raw `signature` 
 
 | `param` | `signatureIndex` | Return value       |
 |---------|------------------|--------------------|
-| 0x00    | signatureIndex   | `signer`           |
+| 0x00    | signatureIndex   | effective signer address |
 | 0x01    | signatureIndex   | `scheme`           |
 | 0x02    | signatureIndex   | `msg`              |
 | 0x03    | signatureIndex   | `len(signature)`   |
@@ -529,6 +688,8 @@ Notes:
 
 - Undefined `param` values result in an exceptional halt.
 - Out-of-bounds access for `signatureIndex` results in an exceptional halt.
+- For `Arbitrary`, the effective signer address is `signer` when `len(signer) == 20`, or `keccak256(signer)[12:]` otherwise.
+- For `BLS12_381`, the effective signer address is the 20-byte public key alias address when `len(signer) == 20`, or `keccak256(key_type || pubkey_len || pubkey)[12:]` when `len(signer) == 48`.
 
 ### Mempool
 
@@ -556,11 +717,12 @@ For public mempool accounting, signature validation is treated as part of the tr
 A frame transaction is eligible for public mempool propagation only if its validation prefix depends exclusively on:
 
 1. transaction fields, including the canonical signature hash,
-2. the block timestamp as read by an expiry verifier frame,
-3. the sender's nonce, code, and storage,
-4. if a deploy frame is present, the code of the factory targeted by that frame (subject to the deploy-frame trace rules below),
-5. if a paymaster frame is present, either a canonical paymaster instance together with explicit paymaster balance reservation, or a non-canonical paymaster being used by less than `MAX_PENDING_TXS_USING_NON_CANONICAL_PAYMASTER` pending transactions,
-6. the code of any other existing non-delegated contracts reached during validation via `CALL*` or `EXTCODE*`, provided the resulting trace does not access disallowed mutable state.
+2. public key alias code referenced by `BLS12_381` signatures,
+3. the block timestamp as read by an expiry verifier frame,
+4. the sender's nonce, code, and storage,
+5. if a deploy frame is present, the code of the factory targeted by that frame (subject to the deploy-frame trace rules below),
+6. if a paymaster frame is present, either a canonical paymaster instance together with explicit paymaster balance reservation, or a non-canonical paymaster being used by less than `MAX_PENDING_TXS_USING_NON_CANONICAL_PAYMASTER` pending transactions,
+7. the code of any other existing non-delegated contracts reached during validation via `CALL*` or `EXTCODE*`, provided the resulting trace does not access disallowed mutable state.
 
 Any dependency on third-party mutable state outside these categories must result in rejection by the public mempool.
 
@@ -678,6 +840,7 @@ For `VERIFY` frames, the usual `STATICCALL` restrictions apply except for the pr
 - BLOBBASEFEE (0x4A)
 - GAS (0x5A)
     - Except when followed immediately by a `*CALL` instruction. This is the standard method of passing gas to a child call and does not create an additional public mempool dependency.
+- PUBLISHPK (0xAB)
 - CREATE (0xF0)
     - Except inside the first `deploy` frame.
 - CREATE2 (0xF5)

--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -118,9 +118,7 @@ assert len(tx.frames) > 0 and len(tx.frames) <= MAX_FRAMES
 assert len(tx.sender) == 20
 
 for sig in tx.signatures:
-    if sig.scheme == ARBITRARY:
-        pass
-    elif sig.scheme in [SECP256K1, P256]:
+    if sig.scheme in [SECP256K1, P256]:
         assert len(sig.signer) == 20
     else:
         invalid_transaction()
@@ -157,16 +155,13 @@ The raw `signature` byte strings are intentionally not introspectable by EVM cod
 
 The `scheme` identifies how the raw `signature` bytes are interpreted.
 
-| `scheme`   | Name         | `signature` encoding                             | Gas cost |
-|----------|--------------|------------------------------------------------|----------|
-| 0x0      | `Arbitrary`  | arbitrary bytes                                  | normal calldata cost for `signer` and `signature`  |
-| 0x1      | `SECP256K1`  | `v (1 byte) || r (32 bytes) || s (32 bytes)`     | 2800     |
-| 0x2      | `P256`       | `r || s || qx || qy` (all 32 bytes)              | 6700     |
-| 0x3..255 | reserved     | reserved                                       | reserved |
+| `scheme`   | Name         | `signature` encoding                           | Gas cost |
+|------------|--------------|------------------------------------------------|----------|
+| 0x0        | `SECP256K1`  | `v (1 byte) || r (32 bytes) || s (32 bytes)` | 2800     |
+| 0x1        | `P256`       | `r || s || qx || qy` (all 32 bytes)          | 6700     |
+| 0x2..255   | reserved     | reserved                                       | reserved |
 
 For `SECP256K1` and `P256`, the `signer` is a 20-byte Ethereum address.
-
-For `Arbitrary`, both `signer` and `signature` have no fixed length and are not interpreted by the protocol. If `len(signer) == 20`, `signer` is used directly as the effective signer address. Otherwise, `signer` is treated as arbitrary inline data and its effective signer address is `keccak256(signer)[12:]`.
 
 The `msg` which message the signature authorizes:
 
@@ -206,15 +201,10 @@ def compute_sig_hash(tx: FrameTx) -> Hash:
 Every signature in the outer transaction object is validated before frame execution. The validation rules are:
 
 ```python
-ARBITRARY = 0x0
-SECP256K1 = 0x1
-P256      = 0x2
+SECP256K1 = 0x0
+P256      = 0x1
 
 def effective_signer(sig) -> Address:
-    if sig.scheme == ARBITRARY:
-        if len(sig.signer) == 20:
-            return sig.signer
-        return keccak256(sig.signer)[12:]
     return sig.signer
 
 def validate_signature(sig, tx, sig_hash) -> bool:
@@ -227,12 +217,7 @@ def validate_signature(sig, tx, sig_hash) -> bool:
     else:
         return False
 
-    if sig.scheme == ARBITRARY:
-        # Reserved for contracts that want to attest to arbitrary metadata through
-        # the signature list; the protocol does not interpret `signature`.
-        return True
-
-    elif sig.scheme == SECP256K1:
+    if sig.scheme == SECP256K1:
         if len(sig.signature) != 65:
             return False
         v = sig.signature[0]
@@ -378,8 +363,6 @@ def signature_gas(sig):
         return 2800
     if sig.scheme == P256:
         return 6700
-    if sig.scheme == ARBITRARY:
-        return 2800
     invalid_transaction()
 
 signature_verification_cost = sum(signature_gas(sig) for sig in tx.signatures)
@@ -396,7 +379,7 @@ tx_gas_limit = (
 
 Where `calldata_cost` is calculated per standard [EIP-7623](./eip-7623.md) rules.
 
-The calldata cost for `rlp(tx.signatures)` is charged over the signature objects exactly as included in the transaction, including the scheme-dependent `signer` bytes. `Arbitrary` inline signer data is charged in the same way.
+The calldata cost for `rlp(tx.signatures)` is charged over the signature objects exactly as included in the transaction, including the scheme-dependent `signer` bytes.
 
 The total fee is defined as:
 
@@ -545,7 +528,6 @@ Notes:
 
 - Undefined `param` values result in an exceptional halt.
 - Out-of-bounds access for `signatureIndex` results in an exceptional halt.
-- For `Arbitrary`, the effective signer address is `signer` when `len(signer) == 20`, or `keccak256(signer)[12:]` otherwise.
 
 ### Mempool
 

--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -40,11 +40,6 @@ Ultimately, frame transactions realize the original vision of account abstractio
 | `EXPIRY_VERIFIER`          | `address(0x8141)` |
 | `EXPIRY_DATA_LENGTH`       | `8`               |
 | `MAX_FRAMES`               | `64`              |
-| `PUBLIC_KEY_ALIAS_PREFIX`  | `0xef02`          |
-| `PUBLIC_KEY_ALIAS_VERSION` | `0x00`            |
-| `BLS12_381_G1_PUBLIC_KEY`  | `0x00`            |
-| `BLS12_381_SIGNING_DOMAIN` | `b"EIP8141_BLS12_381_V0"` |
-| `BLS12_381_SIGNATURE_GAS`  | `TBD`             |
 
 ### Frame Transaction
 
@@ -89,7 +84,7 @@ Below are high-level definitions of each field in the transaction definition. De
 ##### Signature object
 
 - `scheme` -- the verification scheme used to interpret the raw signature bytes.
-- `signer` -- the signer's address, inline public key, or alias to public key.
+- `signer` -- scheme-dependent signer metadata; for `SECP256K1` and `P256`, this is a 20-byte address.
 - `msg` -- either empty, indicating the canonical transaction signature hash, or an explicit 32-byte digest.
 - `signature` -- raw signature bytes interpreted according to `scheme`.
 
@@ -127,8 +122,6 @@ for sig in tx.signatures:
         pass
     elif sig.scheme in [SECP256K1, P256]:
         assert len(sig.signer) == 20
-    elif sig.scheme == BLS12_381:
-        assert len(sig.signer) in [20, 48]
     else:
         invalid_transaction()
     if len(sig.msg) == 0:
@@ -169,29 +162,11 @@ The `scheme` identifies how the raw `signature` bytes are interpreted.
 | 0x0      | `Arbitrary`  | arbitrary bytes                               | 2800     |
 | 0x1      | `SECP256K1`  | `v (1 byte) || r (32 bytes) || s (32 bytes)` | 2800     |
 | 0x2      | `P256`       | `r || s || qx || qy` (all 32 bytes)          | 6700     |
-| 0x3      | `BLS12_381`  | compressed G2 signature (96 bytes)            | `BLS12_381_SIGNATURE_GAS` |
-| 0x4..255 | reserved     | reserved                                       | reserved |
+| 0x3..255 | reserved     | reserved                                       | reserved |
 
 For `SECP256K1` and `P256`, the `signer` is a 20-byte Ethereum address.
 
-For `Arbitrary`, both `signer` and `signature` have no fixed length and are not interpreted by the protocol. If `len(signer) == 20`, `signer` is treated as an alias address. Otherwise, `signer` is treated as arbitrary inline data and its effective signer address is `keccak256(signer)[12:]`.
-
-For `BLS12_381`, the `signer` can either be an inline public key or an alias to
-a public key:
-
-- if `len(signer) == 20`, `signer` is a public key alias address whose code contains the public key;
-- if `len(signer) == 48`, `signer` is an inline compressed BLS12-381 G1 public key.
-
-The effective signer address of a `BLS12_381` signature is:
-
-```python
-if len(sig.signer) == 20:
-    effective_signer = sig.signer
-elif len(sig.signer) == 48:
-    effective_signer = keccak256(bytes([BLS12_381_G1_PUBLIC_KEY]) + (48).to_bytes(2, "big") + sig.signer)[12:]
-else:
-    invalid_transaction()
-```
+For `Arbitrary`, both `signer` and `signature` have no fixed length and are not interpreted by the protocol. If `len(signer) == 20`, `signer` is used directly as the effective signer address. Otherwise, `signer` is treated as arbitrary inline data and its effective signer address is `keccak256(signer)[12:]`.
 
 The `msg` which message the signature authorizes:
 
@@ -202,47 +177,6 @@ The `msg` which message the signature authorizes:
 The explicit 32-byte zero digest is invalid. This reserves the zero stack value as the EVM-visible representation of the transaction signing hash case.
 
 For `P256`, the signer address must be `keccak256(qx || qy)[12:]`.
-
-For `BLS12_381`, verification uses the BLS signature functions defined by the [Ethereum consensus specifications](https://github.com/ethereum/consensus-specs/blob/4a4937bea332d72a55a76aaebcb97fbcdc189f69/specs/phase0/beacon-chain.md#bls-signatures), which reference the IETF BLS signature ciphersuite `BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_`. Public keys are 48-byte compressed G1 points and signatures are 96-byte compressed G2 points. Public keys and signatures must be canonical encodings, must not be the point at infinity, and must pass subgroup checks. The BLS message verified by the signature is:
-
-```python
-bls_message = keccak256(BLS12_381_SIGNING_DOMAIN + bytes([sig.scheme]) + effective_signer(sig) + msg)
-```
-
-where `msg` is resolved according to the rules above.
-
-The BLS ciphersuite hash-to-curve procedure and domain separation tag are the ones defined by the Ethereum consensus specifications. EIP-8141-specific domain separation is provided by the `BLS12_381_SIGNING_DOMAIN` bytes included in `bls_message`.
-
-#### Public Key Aliases
-
-A public key alias is a 20-byte address that names a public key stored in state. It allows signature schemes to refer to public keys by address instead of carrying the full key in every transaction. This is useful for `BLS12_381` and is intended to be reusable by future cryptographic schemes with large public key sizes.
-
-A public key alias account contains a canonical public key object as code. The code is not executable EVM bytecode. Each `key_type` defines the cryptosystem, public key encoding, valid public key lengths, and key validation rules for the `pubkey` bytes.
-
-Public key alias code has the following format:
-
-```text
-0xef || 0x02 || version || key_type || pubkey_len || pubkey
-```
-
-where `version` is one byte, `key_type` is one byte, `pubkey_len` is a two-byte unsigned big-endian integer, and `pubkey` is `pubkey_len` bytes. The initial version is `PUBLIC_KEY_ALIAS_VERSION` (`0x00`).
-
-The initial key types are:
-
-| `key_type` | Name                     | `pubkey` encoding                    |
-|------------|--------------------------|--------------------------------------|
-| 0x00       | `BLS12_381_G1_PUBLIC_KEY` | compressed BLS12-381 G1 point, 48 bytes |
-| 0x01..255  | reserved                 | reserved                             |
-
-For BLS12-381 public keys, the key object is:
-
-```text
-0xef || 0x02 || 0x00 || BLS12_381_G1_PUBLIC_KEY || 0x0030 || compressed_g1_pubkey
-```
-
-When a `BLS12_381` signature uses a 20-byte `signer`, validation loads the code at that address and requires it to be a public key alias with `version == 0x00`, `key_type == BLS12_381_G1_PUBLIC_KEY`, `pubkey_len == 48`, and a valid compressed BLS12-381 G1 public key.
-
-Because transaction signatures are validated before any frame executes, a public key alias referenced by a transaction signature must already exist in the pre-transaction state. Users who have not published an alias can use the inline public key form.
 
 #### Receipt Encoding
 
@@ -275,34 +209,13 @@ Every signature in the outer transaction object is validated before frame execut
 ARBITRARY = 0x0
 SECP256K1 = 0x1
 P256      = 0x2
-BLS12_381 = 0x3
 
 def effective_signer(sig) -> Address:
     if sig.scheme == ARBITRARY:
         if len(sig.signer) == 20:
             return sig.signer
         return keccak256(sig.signer)[12:]
-    if sig.scheme == BLS12_381:
-        if len(sig.signer) == 20:
-            return sig.signer
-        if len(sig.signer) == 48:
-            return keccak256(bytes([BLS12_381_G1_PUBLIC_KEY]) + (48).to_bytes(2, "big") + sig.signer)[12:]
-        invalid_transaction()
     return sig.signer
-
-def load_public_key_alias(alias: Address, key_type: int) -> Bytes:
-    code = state.code(alias)
-    if len(code) < 6 or code[0:2] != b"\xef\x02":
-        invalid_transaction()
-    version = code[2]
-    actual_key_type = code[3]
-    pubkey_len = int.from_bytes(code[4:6], "big")
-    pubkey = code[6:]
-    if version != PUBLIC_KEY_ALIAS_VERSION or actual_key_type != key_type:
-        invalid_transaction()
-    if len(pubkey) != pubkey_len:
-        invalid_transaction()
-    return pubkey
 
 def validate_signature(sig, tx, sig_hash) -> bool:
     if len(sig.msg) == 0:
@@ -337,22 +250,6 @@ def validate_signature(sig, tx, sig_hash) -> bool:
         if sig.signer != keccak256(qx + qy)[12:]:
             return False
         return P256VERIFY(msg, r, s, qx, qy)
-
-    elif sig.scheme == BLS12_381:
-        if len(sig.signature) != 96:
-            return False
-        if len(sig.signer) == 20:
-            pubkey = load_public_key_alias(sig.signer, BLS12_381_G1_PUBLIC_KEY)
-        elif len(sig.signer) == 48:
-            pubkey = sig.signer
-        else:
-            return False
-        if len(pubkey) != 48 or not BLS_VALID_G1_PUBKEY(pubkey):
-            return False
-        if not BLS_VALID_G2_SIGNATURE(sig.signature):
-            return False
-        bls_message = keccak256(BLS12_381_SIGNING_DOMAIN + bytes([sig.scheme]) + effective_signer(sig) + msg)
-        return BLS_VERIFY(pubkey, bls_message, sig.signature)
 
     else:
         return False
@@ -481,8 +378,6 @@ def signature_gas(sig):
         return 2800
     if sig.scheme == P256:
         return 6700
-    if sig.scheme == BLS12_381:
-        return BLS12_381_SIGNATURE_GAS
     if sig.scheme == ARBITRARY:
         return 2800
     invalid_transaction()
@@ -501,7 +396,7 @@ tx_gas_limit = (
 
 Where `calldata_cost` is calculated per standard [EIP-7623](./eip-7623.md) rules.
 
-The calldata cost for `rlp(tx.signatures)` is charged over the signature objects exactly as included in the transaction, including the scheme-dependent `signer` bytes. For example, a `BLS12_381` signature using an inline 48-byte public key pays calldata cost for that inline public key, while a `BLS12_381` signature using a public key alias pays calldata cost only for the 20-byte alias address. `Arbitrary` inline signer data is charged in the same way.
+The calldata cost for `rlp(tx.signatures)` is charged over the signature objects exactly as included in the transaction, including the scheme-dependent `signer` bytes. `Arbitrary` inline signer data is charged in the same way.
 
 The total fee is defined as:
 
@@ -557,44 +452,6 @@ The `scope` operand is a bitmask. Define the following constants:
 - `APPROVE_EXECUTION_AND_PAYMENT` (`0x3`): Approval of payment and execution.
 
 `APPROVE_SCOPE_MASK` is defined as an alias for `APPROVE_EXECUTION_AND_PAYMENT`.
-
-### `PUBLISHPK` Instruction (`0xab`)
-
-The `PUBLISHPK` instruction publishes a public key alias for any recognized `key_type`. It reads a public key from memory, validates it according to the selected `key_type`, wraps it in the canonical public key alias code format, derives the alias address, and installs the alias code at that address.
-
-#### Stack
-
-| Stack      | Value        |
-| ---------- | ------------ |
-| `top - 0`  | `offset`     |
-| `top - 1`  | `length`     |
-| `top - 2`  | `key_type`   |
-
-`PUBLISHPK` pops these three values and pushes the 20-byte `alias_address` as a stack value on success.
-
-#### Behavior
-
-Let `pubkey = memory[offset:offset + length]`. `key_type` must fit in one byte and `length` must fit in two bytes. `key_type` must be a public key type recognized by the protocol, and `pubkey` must satisfy that key type's length, encoding, and validity rules. For `BLS12_381_G1_PUBLIC_KEY`, `length` must equal `48` and `pubkey` must be a valid compressed BLS12-381 G1 public key.
-
-The alias code is:
-
-```python
-alias_code = b"\xef\x02" + bytes([PUBLIC_KEY_ALIAS_VERSION]) + bytes([key_type]) + length.to_bytes(2, "big") + pubkey
-```
-
-The alias address is derived as:
-
-```python
-alias_address = keccak256(b"EIP8141_PUBLISHPK" + ADDRESS + alias_code)[12:]
-```
-
-where `ADDRESS` is the current execution address, i.e. the value returned by the `ADDRESS` opcode in the current call frame.
-
-If `alias_address` is not empty execution results in an exceptional halt. Otherwise, create the account using normal contract-creation account initialization semantics and set its code to `alias_code`.
-
-`PUBLISHPK` is state-modifying and results in an exceptional halt in a static context.
-
-The gas cost is the memory expansion cost for reading `pubkey`, plus `G_create`, plus `G_codedeposit * len(alias_code)`, plus `G_sha3word * ceil((len(b"EIP8141_PUBLISHPK") + 20 + len(alias_code)) / 32)`.
 
 ### Introspection
 
@@ -689,7 +546,6 @@ Notes:
 - Undefined `param` values result in an exceptional halt.
 - Out-of-bounds access for `signatureIndex` results in an exceptional halt.
 - For `Arbitrary`, the effective signer address is `signer` when `len(signer) == 20`, or `keccak256(signer)[12:]` otherwise.
-- For `BLS12_381`, the effective signer address is the 20-byte public key alias address when `len(signer) == 20`, or `keccak256(key_type || pubkey_len || pubkey)[12:]` when `len(signer) == 48`.
 
 ### Mempool
 
@@ -717,12 +573,11 @@ For public mempool accounting, signature validation is treated as part of the tr
 A frame transaction is eligible for public mempool propagation only if its validation prefix depends exclusively on:
 
 1. transaction fields, including the canonical signature hash,
-2. public key alias code referenced by `BLS12_381` signatures,
-3. the block timestamp as read by an expiry verifier frame,
-4. the sender's nonce, code, and storage,
-5. if a deploy frame is present, the code of the factory targeted by that frame (subject to the deploy-frame trace rules below),
-6. if a paymaster frame is present, either a canonical paymaster instance together with explicit paymaster balance reservation, or a non-canonical paymaster being used by less than `MAX_PENDING_TXS_USING_NON_CANONICAL_PAYMASTER` pending transactions,
-7. the code of any other existing non-delegated contracts reached during validation via `CALL*` or `EXTCODE*`, provided the resulting trace does not access disallowed mutable state.
+2. the block timestamp as read by an expiry verifier frame,
+3. the sender's nonce, code, and storage,
+4. if a deploy frame is present, the code of the factory targeted by that frame (subject to the deploy-frame trace rules below),
+5. if a paymaster frame is present, either a canonical paymaster instance together with explicit paymaster balance reservation, or a non-canonical paymaster being used by less than `MAX_PENDING_TXS_USING_NON_CANONICAL_PAYMASTER` pending transactions,
+6. the code of any other existing non-delegated contracts reached during validation via `CALL*` or `EXTCODE*`, provided the resulting trace does not access disallowed mutable state.
 
 Any dependency on third-party mutable state outside these categories must result in rejection by the public mempool.
 
@@ -840,7 +695,6 @@ For `VERIFY` frames, the usual `STATICCALL` restrictions apply except for the pr
 - BLOBBASEFEE (0x4A)
 - GAS (0x5A)
     - Except when followed immediately by a `*CALL` instruction. This is the standard method of passing gas to a child call and does not create an additional public mempool dependency.
-- PUBLISHPK (0xAB)
 - CREATE (0xF0)
     - Except inside the first `deploy` frame.
 - CREATE2 (0xF5)
@@ -980,6 +834,20 @@ Each frame incurs a fixed CALL execution-context overhead (100) plus `G_log` (37
 A design goal of the frame transaction is to provide a good experience out-of-the-box for users and to reduce the threat surface of smart contract wallets. Like batching, sending native value is a part of achieving that.
 
 Restricting non-zero `value` to `SENDER` frames keeps `VERIFY` and `DEFAULT` frames side-effect-free with respect to ETH transfer semantics, preserves the intended `STATICCALL`-like behavior of `VERIFY`, and avoids requiring the protocol-defined `ENTRY_POINT` caller to fund top-level ETH transfers.
+
+### Public Key Aliases
+
+Future signature schemes with large public keys may benefit from a state-backed alias mechanism. Such an alias could be a 20-byte address that identifies a public key stored in state, allowing transactions to reference the address instead of carrying the full public key each time.
+
+A future extension could represent the alias account as non-executable code containing a canonical public key object, for example:
+
+```text
+0xef02 || version || key_type || pubkey_len || pubkey
+```
+
+where `key_type` defines the cryptosystem, public key encoding, valid lengths, and validation rules for `pubkey`.
+
+That extension could also define a `PUBLISHPK` instruction to validate a public key, wrap it in the canonical alias-code format, derive the alias address, and install the alias code.
 
 ### Externally Owned Account (EOA) support
 

--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -157,11 +157,11 @@ The raw `signature` byte strings are intentionally not introspectable by EVM cod
 
 The `scheme` identifies how the raw `signature` bytes are interpreted.
 
-| `scheme` | Name         | `signature` encoding                           | Gas cost |
+| `scheme`   | Name         | `signature` encoding                             | Gas cost |
 |----------|--------------|------------------------------------------------|----------|
-| 0x0      | `Arbitrary`  | arbitrary bytes                               | 2800     |
-| 0x1      | `SECP256K1`  | `v (1 byte) || r (32 bytes) || s (32 bytes)` | 2800     |
-| 0x2      | `P256`       | `r || s || qx || qy` (all 32 bytes)          | 6700     |
+| 0x0      | `Arbitrary`  | arbitrary bytes                                  | normal calldata cost for `signer` and `signature`  |
+| 0x1      | `SECP256K1`  | `v (1 byte) || r (32 bytes) || s (32 bytes)`     | 2800     |
+| 0x2      | `P256`       | `r || s || qx || qy` (all 32 bytes)              | 6700     |
 | 0x3..255 | reserved     | reserved                                       | reserved |
 
 For `SECP256K1` and `P256`, the `signer` is a 20-byte Ethereum address.


### PR DESCRIPTION
Any important goal of 8141 is to be forward compatible with signature aggregation techniques, especially with respect to PQ signatures. As those signatures are quite large, aggregating them may become very important as many users begin migrating.

For this reason, I'm proposing we add a new field `signatures` to the outer transaction object. The is a list of signature objects which include both the signature itself as well as metadata for the signature, such as the algorithm, the message, and the signer. The signatures are verified before the execution of the frames. This means during execution, introspection of the signature message and signer can already be assumed to be valid and it simply up to the smart contract to ensure the signature has sufficient authority.

In the future, the block may be extended with an aggregated witness and the individual signatures can be easily elided from block serialization.