### PR TITLE
Update EIP-8141: Allow using precompiles for VERIFY frames

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -324,23 +324,21 @@ When using frame transactions with EOAs (accounts with no code), they are treate
 - Retrieve the `mode` with `TXPARAMLOAD`.
 - If `mode` is `VERIFY`:
   - If `frame.target != tx.sender`, revert.
-  - Read the first byte of `frame.data` as two nibbles:
-    - Read the first nibble as `scope`.
-    - Read the second nibble as `signature_type`.
+  - Read the approval scope from the mode bits: `scope = (frame.mode >> 8) & 3`. If `scope == 0`, revert.
+  - Read the first byte of `frame.data` as `signature_type`.
   - If `signature_type` is:
     - `0x0`:
       - Read the rest of `frame.data` as `(v, r, s)`.
-      - If `frame.target != ecrecover(hash, v, r, s)`, where `hash = keccak(sighash, data_with_out_signature)`, revert.
+      - If `frame.target != ecrecover(sig_hash, v, r, s)`, where `sig_hash = compute_sig_hash(tx)`, revert.
     - `0x1`:
       - Read the rest of `frame.data` as `(r, s, qx, qy)`.
       - If `frame.target != keccak(qx|qy)[12:]`, revert.
-      - If `P256VERIFY(hash, r, s, qx, qy) != true`, where `hash = keccak(sighash, data_with_out_signature)`, revert.
+      - If `P256VERIFY(sig_hash, r, s, qx, qy) != true`, where `sig_hash = compute_sig_hash(tx)`, revert.
     - Otherwise revert.
   - Call `APPROVE(scope)`.
 - If `mode` is `SENDER`:
-  - If the first nibble of the first byte is not `0x0`, revert.
   - If `frame.target != tx.sender`, revert.
-  - Read the rest of `frame.data` as RLP encoding of `calls = [[target, value, data]]`.
+  - Read `frame.data` as RLP encoding of `calls = [[target, value, data]]`.
   - For each call in `calls`, execute the call with `msg.sender = tx.sender`.
     - If any call reverts, revert the frame.
 - If `mode` is `DEFAULT`:
@@ -348,7 +346,6 @@ When using frame transactions with EOAs (accounts with no code), they are treate
 
 Notes:
 
-- `data_without_signature` means the portion of `frame.data` without the signature.  Note that since `signature` is always at the very end of `frame.data`, `data_without_signature` is always a prefix of `frame.data`.
 - It's implied that for the P256 (r1) signature type, the sender address must be `keccak(qx|qy)[12:]`.
 
 Here's the logic above implemented in Python:
@@ -365,36 +362,33 @@ def default_code(frame, tx):
     mode = frame.mode & 0xFF                 # equivalent to TXPARAMLOAD(0x14, TXPARAMLOAD(0x10))
 
     if mode == VERIFY:
-        first_byte     = frame.data[0]
-        scope          = (first_byte >> 4) & 0xF   # high nibble: APPROVE scope
-        signature_type = first_byte & 0xF          # low nibble: signature type
-        sig_hash       = compute_sig_hash(tx)      # equivalent to TXPARAMLOAD(0x08)
+        scope          = (frame.mode >> 8) & 3     # approval scope from mode bits
+        if scope == 0:
+            revert()
+        signature_type = frame.data[0]              # first byte: signature type
+        sig_hash       = compute_sig_hash(tx)       # equivalent to TXPARAMLOAD(0x08)
 
         if signature_type == SECP256K1:
-            # frame.data layout: [byte0, v (1 byte), r (32 bytes), s (32 bytes)]
-            if len(frame.data) != 66:             # 1 header + 65 signature bytes
+            # frame.data layout: [signature_type, v (1 byte), r (32 bytes), s (32 bytes)]
+            if len(frame.data) != 66:               # 1 header + 65 signature bytes
                 revert()
-            v                = frame.data[1]
-            r                = frame.data[2:34]
-            s                = frame.data[34:66]
-            data_without_sig = frame.data[:-65]   # prefix before (v, r, s)
-            h                = keccak256(sig_hash + data_without_sig)
-            if frame.target != ecrecover(h, v, r, s):
+            v = frame.data[1]
+            r = frame.data[2:34]
+            s = frame.data[34:66]
+            if frame.target != ecrecover(sig_hash, v, r, s):
                 revert()
 
         elif signature_type == P256:
-            # frame.data layout: [byte0, r (32 bytes), s (32 bytes), qx (32 bytes), qy (32 bytes)]
-            if len(frame.data) != 129:            # 1 header + 128 signature bytes
+            # frame.data layout: [signature_type, r (32 bytes), s (32 bytes), qx (32 bytes), qy (32 bytes)]
+            if len(frame.data) != 129:              # 1 header + 128 signature bytes
                 revert()
-            r                = frame.data[1:33]
-            s                = frame.data[33:65]
-            qx               = frame.data[65:97]
-            qy               = frame.data[97:129]
-            data_without_sig = frame.data[:-128]  # prefix before (r, s, qx, qy)
-            h                = keccak256(sig_hash + data_without_sig)
+            r  = frame.data[1:33]
+            s  = frame.data[33:65]
+            qx = frame.data[65:97]
+            qy = frame.data[97:129]
             if frame.target != keccak256(qx + qy)[12:]:
                 revert()
-            if not P256VERIFY(h, r, s, qx, qy):
+            if not P256VERIFY(sig_hash, r, s, qx, qy):
                 revert()
 
         else:
@@ -406,8 +400,8 @@ def default_code(frame, tx):
         if frame.target != tx.sender:
             revert()
 
-        # frame.data layout: [byte0, RLP-encoded [[target, value, data], ...]]
-        calls = rlp_decode(frame.data[1:])
+        # frame.data layout: RLP-encoded [[target, value, data], ...]
+        calls = rlp_decode(frame.data)
         for call_target, call_value, call_data in calls:
             result = evm_call(caller=tx.sender, to=call_target, value=call_value, data=call_data)
             if result.reverted:

--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -31,6 +31,7 @@ In doing so, it realizes the original vision of account abstraction: unlinking a
 | `FRAME_TX_INTRINSIC_COST` | `15000`         |
 | `ENTRY_POINT`             | `address(0xaa)` |
 | `MAX_FRAMES`              | `10^3`          |
+| `SIGNER_KEY_MAGIC`        | `0x1FCD`        |
 
 ### Opcodes
 
@@ -40,6 +41,15 @@ In doing so, it realizes the original vision of account abstraction: unlinking a
 | `TXPARAM`       | `0xb0` |
 | `FRAMEDATALOAD` | `0xb1` |
 | `FRAMEDATACOPY` | `0xb2` |
+
+#### Signature Precompiles
+
+The following precompiles are designated as **signature precompiles** that frame transactions [natively support](#signature-precompile-verification).  New signature precompiles (such as PQ precompiles) should be added to this list.
+
+| Name            | Address  |
+|-----------------|----------|
+| `ECRECOVER`     | `0x01`   |
+| `P256VERIFY`    | `0x0100` |
 
 ### New Transaction Type
 
@@ -76,9 +86,9 @@ Frame executes as regular call where the caller address is `ENTRY_POINT`.
 
 ##### `VERIFY` Mode
 
-Identifies the frame as a validation frame. Its purpose is to *verify* that a sender and/or payer authorized the transaction. It must call `APPROVE` during execution. Failure to do so will result in the whole transaction being invalid.
+Identifies the frame as a validation frame. Its purpose is to *verify* that a sender and/or payer authorized the transaction. It must call `APPROVE` during execution, or have the signature precompile flag (bit 12) set which triggers [signature precompile verification](#signature-precompile-verification) instead. Failure to result in a successful approval will cause the whole transaction to be invalid.
 
-The execution behaves the same as `STATICCALL`, state cannot be modified.
+The execution behaves the same as `STATICCALL`, state cannot be modified. When the signature precompile flag is set, the client executes the [signature precompile verification](#signature-precompile-verification) logic instead of a regular EVM call to `frame.target`.
 
 Frames in this mode will have their data elided from signature hash calculation and from introspection by other frames.
 
@@ -94,6 +104,7 @@ The upper bits (> 8) of `mode` configure the execution environment.
 |----------|------------------------------| ----------- |
 | 9-10     | Approval scope               | Any mode    |
 | 11       | Atomic batch                 | SENDER mode |
+| 12       | Signature precompile         | VERIFY mode |
 
 The `Valid with` column indicates the mode under which the flag is valid.  If a flag is not valid under the current mode, the transaction is invalid.
 
@@ -115,6 +126,11 @@ for i, frame in enumerate(tx.frames):
         assert (frame.mode & 0xFF) == 2               # must be SENDER
         assert i + 1 < len(tx.frames)                  # must not be last frame
         assert (tx.frames[i + 1].mode & 0xFF) == 2     # next frame must be SENDER
+
+# Signature precompile flag (bit 12) is only valid with VERIFY mode.
+for i, frame in enumerate(tx.frames):
+    if (frame.mode >> 11) & 1 == 1:
+        assert (frame.mode & 0xFF) == 1               # must be VERIFY
 ```
 
 #### Receipt
@@ -221,6 +237,7 @@ field to be extracted from the transaction. `in2` names a frame index.
 | 0x15    | frame index | `status` (exceptional halt if current/future)                               |
 | 0x16    | frame index | `scope` (bits 9/10 from `frame.mode`)                                       |
 | 0x17    | frame index | `atomic_batch` (bit 11 from `frame.mode`, returns 0 or 1)                   |
+| 0x18    | frame index | `sig_precompile` (bit 12 from `frame.mode`, returns 0 or 1)                 |
 
 Notes:
 
@@ -282,10 +299,11 @@ Then for each call frame:
        - Set `caller` as `tx.sender`.
    - If mode is `DEFAULT` or `VERIFY`:
        - Set the `caller` to `ENTRY_POINT`.
-   - If `frame.target` has no code, execute the logic described in [default code](#default-code).
+   - If mode is `VERIFY`:
+       - If the signature precompile bit flag is set, execute the [signature precompile verification](#signature-precompile-verification) logic instead of calling `frame.target`.
    - The `ORIGIN` opcode returns frame `caller` throughout all call depths.
    - If a frame's execution reverts, its state changes are discarded. Additionally, if this frame has the atomic batch flag set, mark all subsequent frames in the same atomic group as skipped.
-3. If frame has mode `VERIFY` and the frame did not successfully call `APPROVE`, the transaction is invalid.
+3. If frame has mode `VERIFY` and the frame did not result in a successful approval (via `APPROVE` or via signature precompile verification), the transaction is invalid.
 
 #### Atomic Batching
 
@@ -317,101 +335,140 @@ Note:
 
 - It is implied by the handling that the sender must approve the transaction *before* the payer and that once `sender_approved` or `payer_approved` become `true` they cannot be re-approved or reverted.
 
-#### Default code
+#### Signature Precompile Verification
 
-When using frame transactions with EOAs (accounts with no code), they are treated as if they have a "default code."  This spec describes only the behavior of the default code; clients are free to implement the default code however they want, so long as they correspond to the behavior specified here.
+When a `VERIFY` frame has the signature precompile bit flag set, the client executes the verification logic defined below instead of calling `frame.target` as a regular EVM call. The specific precompile is identified by the first 2 bytes of `frame.data`.
 
-- Retrieve the `mode` with `TXPARAMLOAD`.
-- If `mode` is `VERIFY`:
-  - If `frame.target != tx.sender`, revert.
-  - Read the approval scope from the mode bits: `scope = (frame.mode >> 8) & 3`. If `scope == 0`, revert.
-  - Read the first byte of `frame.data` as `signature_type`.
-  - If `signature_type` is:
-    - `0x0`:
-      - Read the rest of `frame.data` as `(v, r, s)`.
-      - If `frame.target != ecrecover(sig_hash, v, r, s)`, where `sig_hash = compute_sig_hash(tx)`, revert.
-    - `0x1`:
-      - Read the rest of `frame.data` as `(r, s, qx, qy)`.
-      - If `frame.target != keccak(qx|qy)[12:]`, revert.
-      - If `P256VERIFY(sig_hash, r, s, qx, qy) != true`, where `sig_hash = compute_sig_hash(tx)`, revert.
-    - Otherwise revert.
-  - Call `APPROVE(scope)`.
-- If `mode` is `SENDER`:
-  - If `frame.target != tx.sender`, revert.
-  - Read `frame.data` as RLP encoding of `calls = [[target, value, data]]`.
-  - For each call in `calls`, execute the call with `msg.sender = tx.sender`.
-    - If any call reverts, revert the frame.
-- If `mode` is `DEFAULT`:
-  - Revert the frame.
+##### Key Commitment
+
+An account may commit to a signing key by storing `keccak256(SIGNER_KEY_MAGIC || key_material)` in storage slot 0. This enables key rotation: updating slot 0 authorizes a new key and invalidates the previous one.  Note that EOAs can also set slot 0 via [EIP-7702](./eip-7702.md) delegation.
+
+The `key_material` depends on the precompile:
+
+- For `ECRECOVER`: the 20-byte Ethereum address recovered from the signature.
+- For `P256VERIFY`: the 64-byte public key `(qx || qy)`.
+
+##### Data Layout
+
+When the signature precompile flag is set, `frame.data` is structured as:
+
+```
+frame.data = [precompile_address (2 bytes, big-endian), signature_data...]
+```
+
+The `precompile_address` identifies which signature precompile to use. If the address does not correspond to a known [signature precompile](#signature-precompiles), the frame reverts.
+
+##### Verification Logic
+
+The verification proceeds in three phases: signature verification, authorization, and approval.
+
+**Phase 1: Signature Verification**
+
+Read the approval scope from the mode bits: `scope = (frame.mode >> 8) & 3`. If `scope == 0`, revert. Compute `sig_hash = compute_sig_hash(tx)`. Parse the first 2 bytes of `frame.data` as `precompile_address`.
+
+If `precompile_address` is `ECRECOVER`:
+
+- Parse the remaining `frame.data[2:]` as `[v, r, s]` (65 bytes: 1 + 32 + 32). If the length is not 67 total, revert.
+- Run `recovered_address = ecrecover(sig_hash, v, r, s)`. If recovery fails, revert.
+- Set `key_material = recovered_address` and `identity_address = recovered_address`.
+
+If `precompile_address` is `P256VERIFY`:
+
+- Parse the remaining `frame.data[2:]` as `[r, s, qx, qy]` (128 bytes: 32 + 32 + 32 + 32). If the length is not 130 total, revert.
+- Run `P256VERIFY(sig_hash, r, s, qx, qy)`. If verification fails, revert.
+- Set `key_material = qx || qy` and `identity_address = keccak256(qx || qy)[12:]`.
+
+Otherwise, revert.
+
+**Phase 2: Authorization**
+
+Read `slot0 = SLOAD(frame.target, 0)`.
+
+- If `slot0 == 0`: no key commitment exists (EOA fallback).
+    - Revert if `identity_address != frame.target`.
+- If `slot0 == 0` or `slot0 == keccak256(SIGNER_KEY_MAGIC || key_material)`:
+    - If `scope` includes execution approval (`0x1` or `0x3`), revert if `frame.target != tx.sender`.
+    - If `scope` includes payment approval (`0x2` or `0x3`), set `payer = frame.target`.
+- Else revert.
+
+**Phase 3: Approval**
+
+Set the approval context variables as if `APPROVE(scope)` was invoked, in accordance with the behavior defined for [the `APPROVE` opcode](#approve-opcode-0xaa).
 
 Notes:
 
-- It's implied that for the P256 (r1) signature type, the sender address must be `keccak(qx|qy)[12:]`.
+- For P256, the `identity_address` is derived as `keccak256(qx || qy)[12:]`, matching standard Ethereum address derivation from a public key.
+- The key committed to slot 0 has higher precedence over the root key (the key from which the EOA's address is derived), so if a EOA commits to a key via slot 0, the root key becomes invalid for frame transactions (unless and until slot 0 is set to 0 again), though note that a secp256k1 EOA may still use its root key for other transaction types.
 
 Here's the logic above implemented in Python:
 
 ```python
-DEFAULT   = 0
-VERIFY    = 1
-SENDER    = 2
+ECRECOVER_ADDRESS  = 0x01
+P256VERIFY_ADDRESS = 0x0100
 
-SECP256K1 = 0x0
-P256      = 0x1
-
-def default_code(frame, tx):
-    mode = frame.mode & 0xFF                 # equivalent to TXPARAMLOAD(0x14, TXPARAMLOAD(0x10))
-
-    if mode == VERIFY:
-        scope          = (frame.mode >> 8) & 3     # approval scope from mode bits
-        if scope == 0:
-            revert()
-        signature_type = frame.data[0]              # first byte: signature type
-        sig_hash       = compute_sig_hash(tx)       # equivalent to TXPARAMLOAD(0x08)
-
-        if signature_type == SECP256K1:
-            # frame.data layout: [signature_type, v (1 byte), r (32 bytes), s (32 bytes)]
-            if len(frame.data) != 66:               # 1 header + 65 signature bytes
-                revert()
-            v = frame.data[1]
-            r = frame.data[2:34]
-            s = frame.data[34:66]
-            if frame.target != ecrecover(sig_hash, v, r, s):
-                revert()
-
-        elif signature_type == P256:
-            # frame.data layout: [signature_type, r (32 bytes), s (32 bytes), qx (32 bytes), qy (32 bytes)]
-            if len(frame.data) != 129:              # 1 header + 128 signature bytes
-                revert()
-            r  = frame.data[1:33]
-            s  = frame.data[33:65]
-            qx = frame.data[65:97]
-            qy = frame.data[97:129]
-            if frame.target != keccak256(qx + qy)[12:]:
-                revert()
-            if not P256VERIFY(sig_hash, r, s, qx, qy):
-                revert()
-
-        else:
-            revert()
-
-        APPROVE(scope)
-
-    elif mode == SENDER:
-        if frame.target != tx.sender:
-            revert()
-
-        # frame.data layout: RLP-encoded [[target, value, data], ...]
-        calls = rlp_decode(frame.data)
-        for call_target, call_value, call_data in calls:
-            result = evm_call(caller=tx.sender, to=call_target, value=call_value, data=call_data)
-            if result.reverted:
-                revert()
-
-    elif mode == DEFAULT:
+def signature_precompile_verify(frame, tx):
+    scope = (frame.mode >> 8) & 3
+    if scope == 0:
         revert()
+
+    sig_hash = compute_sig_hash(tx)
+    subject = frame.target if frame.target is not None else tx.sender
+
+    # Parse precompile address from first 2 bytes of frame.data
+    if len(frame.data) < 2:
+        revert()
+    precompile_address = int.from_bytes(frame.data[0:2], 'big')
+    sig_data = frame.data[2:]
+
+    # Phase 1: Signature Verification
+    if precompile_address == ECRECOVER_ADDRESS:
+        # sig_data layout: [v (1 byte), r (32 bytes), s (32 bytes)]
+        if len(sig_data) != 65:
+            revert()
+        v = sig_data[0]
+        r = sig_data[1:33]
+        s = sig_data[33:65]
+        identity_address = ecrecover(sig_hash, v, r, s)
+        if identity_address is None:
+            revert()
+        key_material = identity_address
+
+    elif precompile_address == P256VERIFY_ADDRESS:
+        # sig_data layout: [r (32 bytes), s (32 bytes), qx (32 bytes), qy (32 bytes)]
+        if len(sig_data) != 128:
+            revert()
+        r  = sig_data[0:32]
+        s  = sig_data[32:64]
+        qx = sig_data[64:96]
+        qy = sig_data[96:128]
+        if not p256verify(sig_hash, r, s, qx, qy):
+            revert()
+        key_material = qx + qy
+        identity_address = keccak256(qx + qy)[12:]
 
     else:
         revert()
+
+    # Phase 2: Authorization
+    slot0 = sload(subject, 0)
+    commitment = keccak256(SIGNER_KEY_MAGIC + key_material)
+    payer = None
+
+    # EOA fallback: require signer identity matches the account
+    if slot0 == 0:
+        if identity_address != subject:
+            revert()
+
+    if slot0 == 0 or slot0 == commitment:
+        if scope in (0x2, 0x3):  # includes payment approval
+            payer = subject
+    else:
+        # Non-zero slot0 that doesn't match — unauthorized
+        revert()
+
+    # Phase 3: Approval
+    # Call APPROVE(scope) and charge payer accordingly
+    approve(scope, payer)
 ```
 
 #### Frame interactions
@@ -446,7 +503,7 @@ Each frame has its own `gas_limit` allocation. Unused gas from a frame is **not*
 refund = sum(frame.gas_limit for all frames) - total_gas_used
 ```
 
-This refund is returned to the gas payer (the `target` that called `APPROVE(0x2)` or `APPROVE(0x3)`) and added back to the block gas pool. *Note: This refund mechanism is separate from EIP-3529 storage refunds.*
+This refund is returned to the gas payer (the account determined by `APPROVE(0x2)`/`APPROVE(0x3)` or by [signature precompile verification](#signature-precompile-verification)) and added back to the block gas pool. *Note: This refund mechanism is separate from EIP-3529 storage refunds.*
 
 ### Mempool
 
@@ -557,12 +614,12 @@ The generic validation trace and opcode rules below apply to all frames in the v
 A public mempool node must simulate the validation prefix and reject the transaction if any of the following occurs before `payer_approved = true`:
 
 - a frame in the validation prefix reverts
-- a `VERIFY` frame in the validation prefix exits without the required `APPROVE`
+- a `VERIFY` frame in the validation prefix exits without the required `APPROVE`, except if the `VERIFY` frame uses [signature precompile verification](#signature-precompile-verification).
 - execution exceeds `MAX_VERIFY_GAS`
 - execution uses a banned opcode
 - execution performs a state write, except deterministic deployment performed by the first `deploy` frame through a known deployer
 - execution reads storage outside `tx.sender`
-- execution performs `CALL*` or `EXTCODE*` to an address that is neither an existing contract nor a precompile, or to an address that uses an EIP-7702 delegation, except for `tx.sender` default-code behavior
+- execution performs `CALL*` or `EXTCODE*` to an address that is neither an existing contract nor a precompile, or to an address that uses an EIP-7702 delegation
 - if a `deploy` frame is present, its execution does not result in non-empty, non-delegated code being installed at `tx.sender`
 
 ##### Banned Opcodes
@@ -700,17 +757,25 @@ Using a flag to indicate atomic batches saves us from having to introduce a new 
 
 It is not required because the account code can send value.
 
-### EOA support
+### Signature precompiles
 
-While we expect EOA users to migrate to smart accounts eventually, we recognize that most Ethereum users today are using EOAs, so we want to improve UX for them where we can.
+Using signature precompiles for verification has a number of upsides:
 
-With frame transactions, EOA wallets today can reap the key benefit of AA -- gas abstraction, including sending sponsored transactions, paying gas in ERC-20 tokens, and more.
+- **Protocol-guaranteed security**: When an account uses a precompile for signature verification, the security of the verification is guaranteed by the protocol and does not depend on smart contracts.
+
+- **EOA support**: Existing secp256k1 EOAs can send or sponsor frame transactions without any account upgrades by using the `ECRECOVER` precompile.  By supporting the `P256VERIFY` precompile, frame transactions also work with a new class of EOAs whose addresses are derived from secp256r1 keys.
+
+- **Key rotation**: since we read the key commitment from slot 0 when using signature precompiles, an account can rotate keys simply by overiding slot 0 with a new key.
+
+- **High-TPS mempools**: For EVM environments such as high-TPS L2s where the mempool nodes or sequencers need to validate  transactions with bounded validation cost, they can adopt a mempool strategy where only VERIFY frames using precompiles are allowed.
+
+- **Seperating verification from account logic**: Using precompiles for verification does not mean that the account cannot otherwise have code.  By offloading signature verification to precompiles, smart accounts (and EOAs with EIP-7702 delegations) can focus their contract code entirely on account-specific logic — such as execution logic for `SENDER` frames, session key management, spending limits, or multi-party approval flows — while delegating the core validation logic to the protocol.
 
 ### Non-canonical paymasters in the mempool
 
 The primary use case for non-canonical paymasters is to enable users to pay gas with a dedicated "gas account," so that their other accounts can transact without holding any ETH.  For example, a user might have a single account that holds some ETH, while other accounts only hold stablecoins and NFTs, and they can transact freely with these other accounts while using the gas account as the paymaster.
 
-Note that users can use any EOA as a paymaster thanks to the [default code](#default-code).
+Note that users can use any EOA as a gas payer by using [signature precompile verification](#signature-precompile-verification) in a `pay` `VERIFY` frame with the EOA as `frame.target`.
 
 ### Examples
 
@@ -779,14 +844,14 @@ Frame 0 verifies the signature and calls `APPROVE(0x3)`. Frames 1 and 2 form an 
 
 #### Example 4: EOA paying gas in ERC-20s
 
-| Frame | Caller      | Target        | Data                   | Mode    |
-| ----- | ----------- | ------------- | ---------------------- | ------- |
-| 0     | ENTRY_POINT | Null(sender)  | (0, v, r, s)           | VERIFY  |
-| 1     | ENTRY_POINT | Sponsor       | Sponsor signature      | VERIFY  |
-| 2     | Sender      | ERC-20        | transfer(Sponsor,fees) | SENDER  |
-| 3     | Sender      | Target addr   | Call data              | SENDER  |
+| Frame | Caller      | Target        | Data                   | Mode                                            |
+| ----- | ----------- | ------------- | ---------------------- | ----------------------------------------------- |
+| 0     | ENTRY_POINT | Null (sender) | (0x0001, v, r, s)     | VERIFY (with signature precompile flag and scope = 0x1) |
+| 1     | ENTRY_POINT | Sponsor       | Sponsor signature      | VERIFY (with scope = 0x2)                       |
+| 2     | Sender      | ERC-20        | transfer(Sponsor,fees) | SENDER                                          |
+| 3     | Sender      | Target addr   | Call data              | SENDER                                          |
 
-- Frame 0: Verify the sender with a EOA signature.  Upon verification, the frame calls `APPROVE(0x1)` to authorize execution.
+- Frame 0: Uses [signature precompile verification](#signature-precompile-verification) with `ECRECOVER` (precompile prefix `0x0001`) and scope `0x1`, setting `sender_approved`.
 - Frame 1: Checks that the user has enough ERC-20 tokens, and that the next frame is an ERC-20 send of the right size to the sponsor. Calls `APPROVE(0x2)` to authorize payment.
 - Frame 2: Sends tokens to sponsor.
 - Frame 3: User's intended call.
@@ -808,15 +873,15 @@ Frame 0 verifies the signature and calls `APPROVE(0x3)`. Frames 1 and 2 form an 
 | Frames wrapper                    | 1     |
 | Sender validation frame: target   | 1     |
 | Sender validation frame: gas      | 2     |
-| Sender validation frame: data     | 65    |
-| Sender validation frame: mode     | 1     |
+| Sender validation frame: data     | 67    |
+| Sender validation frame: mode     | 2     |
 | Execution frame: target           | 1     |
 | Execution frame: gas              | 1     |
 | Execution frame: data             | 20+5  |
 | Execution frame: mode             | 1     |
-| **Total**                         | 134   |
+| **Total**                         | 137   |
 
-Notes: Nonce assumes < 65536 prior sends. Fees assume < 1099 gwei. Validation frame target is 1 byte because target is `tx.sender`. Validation gas assumes <= 65,536 gas. Calldata is 65 bytes for ECDSA signature. Blob fields assume no blobs (empty list, zero max fee).
+Notes: Nonce assumes < 65536 prior sends. Fees assume < 1099 gwei. Validation frame target is 1 byte (null, defaults to sender). Validation mode is 2 bytes for VERIFY mode with scope and signature precompile flag. Data is 67 bytes: 2-byte precompile address prefix plus 65-byte ECDSA signature `(v, r, s)`. Validation gas assumes <= 65,536 gas. Blob fields assume no blobs (empty list, zero max fee).
 
 This is not much larger than an EIP-1559 transaction; the extra overhead is the need to specify the sender and amount in calldata explicitly.
 


### PR DESCRIPTION
This PR is still being worked on, but sharing it for wider feedback.  The goal is to allow VERIFY frames to use precompiles for verification.  This was already supported via the EOA default code, but with this proposed update, the same logic can be used for both EOAs and contract accounts.  This will allow a contract account to use precompiles for verification, while still having code that serves other purpose (e.g. for execution).

As a side benefit, this also enables key rotation, since the precompile reads the public key commitment from storage.  Refer to the "Rationale" section for a full list of benefits for this approach.