### PR TITLE
Update EIP-8141: Fix spec inconsistencies in APPROVE scopes, default code, and added verify frame count check

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -110,11 +110,16 @@ assert (tx.frames[n].mode & 0xFF)  < 3
 assert len(tx.frames[n].target) == 20 or tx.frames[n].target is None
 
 # Atomic batch flag (bit 11) is only valid with SENDER mode, and next frame must also be SENDER.
+# At most 2 VERIFY frames: each APPROVE flag (sender_approved, payer_approved) is one-shot.
+verify_count = 0
 for i, frame in enumerate(tx.frames):
+    if (frame.mode & 0xFF) == 1:
+        verify_count += 1
     if (frame.mode >> 10) & 1 == 1:
         assert (frame.mode & 0xFF) == 2               # must be SENDER
         assert i + 1 < len(tx.frames)                  # must not be last frame
         assert (tx.frames[i + 1].mode & 0xFF) == 2     # next frame must be SENDER
+assert verify_count <= 2
 ```
 
 #### Receipt
@@ -323,7 +328,6 @@ When using frame transactions with EOAs (accounts with no code), they are treate
 
 - Retrieve the `mode` with `TXPARAMLOAD`.
 - If `mode` is `VERIFY`:
-  - If `frame.target != tx.sender`, revert.
   - Read the approval scope from the mode bits: `scope = (frame.mode >> 8) & 3`. If `scope == 0`, revert.
   - Read the first byte of `frame.data` as `signature_type`.
   - If `signature_type` is:
@@ -542,9 +546,9 @@ To be accepted into the public mempool, a frame transaction must satisfy the fol
 1. Its validation prefix must match one of the four recognized prefixes above.
 2. If present, `deploy` must be the first frame. This implies there can be at most one `deploy` frame in the validation prefix.
 3. `self_verify` and `only_verify` must execute in `VERIFY` mode, target `tx.sender` (either explicitly or via a null target), and must successfully call `APPROVE`.
-    - `self_verify` must call `APPROVE(0x2)`.
-    - `only_verify` must call `APPROVE(0x0)`.
-4. `pay` must execute in `VERIFY` mode and successfully call `APPROVE(0x1)`.
+    - `self_verify` must call `APPROVE(0x3)`.
+    - `only_verify` must call `APPROVE(0x1)`.
+4. `pay` must execute in `VERIFY` mode and successfully call `APPROVE(0x2)`.
 5. The sum of `gas_limit` values across the validation prefix must not exceed `MAX_VERIFY_GAS`.
 6. Nodes should stop simulation immediately once `payer_approved = true` has been observed.
 


### PR DESCRIPTION
- Add static VERIFY frame count check (`<= 2`) to constraints, since `sender_approved` and `payer_approved` are one-shot flags
- Fix stale APPROVE scope values in structural rules: `self_verify` ->`APPROVE(0x3)`, `only_verify` ->  `APPROVE(0x1)`, `pay` -> `APPROVE(0x2)`
- Remove `frame.target != tx.sender` check from default VERIFY code to allow any EOA as paymaster (Already fixed in the python code but wasn't in the spec)