### PR TITLE
Update EIP-8007: Sync descriptions with latest EIP-7976 and EIP-7981 drafts

### DIFF
--- a/EIPS/eip-8007.md
+++ b/EIPS/eip-8007.md
@@ -35,8 +35,8 @@ The following table lists all EIPs related to repricings that are being discusse
 | [EIP-2780](./eip-2780.md) | Reduce intrinsic transaction gas and charge 25k when a value transfer creates a new account. | Broad harmonization | Multi-resource | Decrease `TX_BASE_COST` (21k→4.5k); increase new-account surcharge (0→25k) |
 | [EIP-7778](./eip-7778.md) | Prevent Block Gas Limit Circumvention by Excluding Refunds from Block Gas Accounting. | Pricing extension | General Accounting | No opcode repricing; excludes gas refunds (e.g. `SSTORE` clearing) from block gas accounting |
 | [EIP-7904](./eip-7904.md) | Gas Cost Increase to reflect computational complexity and transaction throughput increase | Broad harmonization | Compute | All increase: `DIV`, `SDIV`, `MOD`, `MULMOD`, `KECCAK256`, precompiles (`BLAKE2F`, `BLS12_G1ADD`, `BLS12_G2ADD`, `ECADD`, `ECPAIRING`, `POINT_EVALUATION`) |
-| [EIP-7976](./eip-7976.md) | Further increase calldata cost to 15/60 gas per byte to reduce maximum block size. | Pricing extension | Data | Increase calldata floor cost (10/40 → 15/60 per byte) |
-| [EIP-7981](./eip-7981.md) | Introduce floor pricing for access lists to reduce maximum block size. | Pricing extension | Data | Increase: new floor charge on access list data (addresses + storage keys) |
+| [EIP-7976](./eip-7976.md) | Increase the calldata floor cost to 64/64 gas per byte to reduce maximum block size. | Pricing extension | Data | Increase calldata floor cost (10/40 → 64/64 per byte) |
+| [EIP-7981](./eip-7981.md) | Price access lists for data to reduce maximum block size. | Pricing extension | Data | Increase: new floor charge on access list data (addresses + storage keys) |
 | [EIP-8037](./eip-8037.md) | Harmonization, increase and separate metering of state creation gas costs to mitigate state growth and unblock scaling. | Broad harmonization | State | All increase (dynamic with gas limit): `GAS_CREATE`, `GAS_CODE_DEPOSIT`, `GAS_NEW_ACCOUNT`, `GAS_STORAGE_SET`, `PER_AUTH_BASE_COST` |
 | [EIP-8038](./eip-8038.md) | Increases the gas cost of state-access operations to reflect Ethereum's larger state. | Broad harmonization | State | All increase: cold storage write/access, cold account access, warm access, `EXTCODESIZE`/`EXTCODECOPY` extra read, access list costs |
 
@@ -118,7 +118,7 @@ At 60M gas limit, `cost_per_state_byte` (cpsb) = 662. Costs scale up with higher
 | --- | ---: | --- | --- | --- |
 | `TX_BASE_COST` | 21,000 | 4,500 | decrease | [2780](./eip-2780.md) |
 | New account surcharge (top-level value tx) | 0 | 25,000 | increase | [2780](./eip-2780.md) |
-| Calldata floor cost | 10/40 per byte | 15/60 per byte | increase | [7976](./eip-7976.md) |
+| Calldata floor cost | 10/40 per byte | 64/64 per byte | increase | [7976](./eip-7976.md) |
 | Access list data cost | 0 | `floor_token_cost` per token | increase (new) | [7981](./eip-7981.md) |
 
 ## Security Considerations


### PR DESCRIPTION

Update calldata floor cost from 15/60 to 64/64 per byte (EIP-7976) and revise EIP-7981 description to match current draft.