### PR TITLE
Update EIP-8081: Propose EIP-7851 and EIP-8151 for inclusion in Hegotá

### DIFF
--- a/EIPS/eip-8081.md
+++ b/EIPS/eip-8081.md
@@ -28,6 +28,9 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Declined
 
 ### Proposed for Inclusion
 
+* [EIP-7851](./eip-7851.md): Deactivate a Delegated EOA's Key
+* [EIP-8151](./eip-8151.md): Private Key Deactivation Aware ecRecover
+
 ### Activation
 
 | Network Name | Activation Epoch | Activation Timestamp |


### PR DESCRIPTION
## Summary
- Propose [EIP-7851](https://eips.ethereum.org/EIPS/eip-7851) (Deactivate a Delegated EOA's Key) for inclusion in Hegotá
- Propose [EIP-8151](https://eips.ethereum.org/EIPS/eip-8151) (Private Key Deactivation Aware ecRecover) for inclusion in Hegotá

These two EIPs are complementary: EIP-7851 introduces a precompiled contract for EOAs with delegated code to permanently deactivate private keys, and EIP-8151 extends ecRecover to be aware of key deactivation status.