### PR TITLE
Update EIP-8164: markdownlint MD046 for footnote code block

### DIFF
--- a/EIPS/eip-8164.md
+++ b/EIPS/eip-8164.md
@@ -422,6 +422,9 @@ Native-key accounts share the same transaction pool challenges as EIP-7702 deleg
 
 The crafted-signature method produces addresses that depend on `(chain_id, pk, r, s, y_parity)`. Users should use the recommended deterministic `r` construction to ensure addresses are publicly reproducible. Non-deterministic `r` values are not unsafe but prevent third-party verification that the account is provably rootless.
 
+<!-- markdownlint-capture -->
+<!-- markdownlint-disable code-block-style -->
+
 [^1]:
 
     ```csl-json
@@ -443,6 +446,8 @@ The crafted-signature method produces addresses that depend on `(chain_id, pk, r
       }
     }
     ```
+
+<!-- markdownlint-restore -->
 
 ## Copyright
 


### PR DESCRIPTION
## Summary
- Add `markdownlint-capture`/`markdownlint-disable code-block-style`/`markdownlint-restore` around the DOI footnote CSL-JSON block
- Matches the pattern used in EIP-1 itself (line ~472)
- Fixes the MD046/code-block-style CI failure that persisted through #11511 and #11512

## Test plan
- [x] `eipw --config ./config/eipw.toml EIPS/eip-8164.md` passes (warnings only, acceptable for Draft)
- [x] `npx markdownlint-cli2 --config config/.markdownlint.yaml EIPS/eip-8164.md` passes with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)