### PR TITLE
Update EIP-8164: MD046 in footnote code block

### DIFF
--- a/EIPS/eip-8164.md
+++ b/EIPS/eip-8164.md
@@ -424,25 +424,25 @@ The crafted-signature method produces addresses that depend on `(chain_id, pk, r
 
 [^1]:
 
-    ```csl-json
-    {
-      "type": "standard",
-      "id": 1,
-      "author": [
-        {
-          "literal": "National Institute of Standards and Technology"
-        }
-      ],
-      "title": "Module-Lattice-Based Digital Signature Standard",
-      "DOI": "10.6028/NIST.FIPS.204",
-      "URL": "https://csrc.nist.gov/pubs/fips/204/final",
-      "original-date": {
-        "date-parts": [
-          [2024, 8, 13]
-        ]
+  ```csl-json
+  {
+    "type": "standard",
+    "id": 1,
+    "author": [
+      {
+        "literal": "National Institute of Standards and Technology"
       }
+    ],
+    "title": "Module-Lattice-Based Digital Signature Standard",
+    "DOI": "10.6028/NIST.FIPS.204",
+    "URL": "https://csrc.nist.gov/pubs/fips/204/final",
+    "original-date": {
+      "date-parts": [
+        [2024, 8, 13]
+      ]
     }
-    ```
+  }
+  ```
 
 ## Copyright
 


### PR DESCRIPTION
## Summary
- Use 2-space indent for DOI footnote body instead of 4-space, fixing MD046/code-block-style without suppressing the linter rule
- 4-space indent caused markdownlint to misidentify the fenced CSL-JSON block as an indented code block

Fixes the persistent Markdown Linter CI failure from #11511 and #11512.

## Test plan
- [x] `eipw --config ./config/eipw.toml EIPS/eip-8164.md` — 0 errors, 0 warnings
- [x] `npx markdownlint-cli2 --config config/.markdownlint.yaml EIPS/eip-8164.md` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)