### PR TITLE
Update EIP-8141: Tighten spec

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2026-01-29
-requires: 1559, 2718, 4844
+requires: 1559, 2718, 4844, 7997
 ---
 
 ## Abstract
@@ -29,8 +29,11 @@ In doing so, it realizes the original vision of account abstraction: unlinking a
 |---------------------------|-----------------|
 | `FRAME_TX_TYPE`           | `0x06`          |
 | `FRAME_TX_INTRINSIC_COST` | `15000`         |
+| `FRAME_TX_PER_FRAME_COST` | `1000`          |
 | `ENTRY_POINT`             | `address(0xaa)` |
-| `MAX_FRAMES`              | `10^3`          |
+| `MAX_FRAMES`              | `64`            |
+
+`ENTRY_POINT` is a protocol-defined distinguished caller address used for `DEFAULT` and `VERIFY` frames. It is not specified as a deployed contract or precompile, and contracts MUST NOT assume anything about its code, balance, or caller type beyond address equality. Contracts called from `DEFAULT` or `VERIFY` frames therefore observe `CALLER = ENTRY_POINT`, so heuristics that infer EOA-or-contract properties from `CALLER` may not behave as expected. Its numeric equality with the `APPROVE` opcode value has no semantic significance.
 
 ### Opcodes
 
@@ -40,6 +43,7 @@ In doing so, it realizes the original vision of account abstraction: unlinking a
 | `TXPARAM`       | `0xb0` |
 | `FRAMEDATALOAD` | `0xb1` |
 | `FRAMEDATACOPY` | `0xb2` |
+| `FRAMEINFO`     | `0xb3` |
 
 ### New Transaction Type
 
@@ -50,25 +54,32 @@ The payload is defined as the RLP serialization of the following:
 ```
 [chain_id, nonce, sender, frames, max_priority_fee_per_gas, max_fee_per_gas, max_fee_per_blob_gas, blob_versioned_hashes]
 
-frames = [[mode, target, gas_limit, data], ...]
+frames = [[mode, flags, target, gas_limit, data], ...]
 ```
 
 If no blobs are included, `blob_versioned_hashes` must be an empty list and `max_fee_per_blob_gas` must be `0`.
+
+Frame transactions do not include an [EIP-7702](./eip-7702.md) authorization list and do not set, clear, or otherwise modify EIP-7702 delegation indicators.
+
+For execution semantics, each frame has a **resolved target**:
+
+```python
+resolved_target = frame.target if frame.target is not None else tx.sender
+```
+
+Unless otherwise stated, checks below that refer to the target account during execution use the resolved target.
 
 #### Frame Modes
 
 The `mode` of each frame sets the context of execution. It allows the protocol to identify
 the purpose of the frame within the execution loop.
 
-The execution mode of a frame is identified by the lower bits (<= 8) of the `mode` field.
-The modes are explained in detail below.
-
-| `mode & 0xFF` | Name           | Summary                                    |
-|---------------|----------------|--------------------------------------------|
-| 0             | `DEFAULT` mode | Execute frame as `ENTRY_POINT`             |
-| 1             | `VERIFY` mode  | Frame identifies as transaction validation |
-| 2             | `SENDER` mode  | Execute frame as `sender`                  |
-| 3..255        | reserved       |
+| `mode`  | Name           | Summary                                    |
+|---------|----------------|--------------------------------------------|
+| 0       | `DEFAULT` mode | Execute frame as `ENTRY_POINT`             |
+| 1       | `VERIFY` mode  | Frame identifies as transaction validation |
+| 2       | `SENDER` mode  | Execute frame as `sender`                  |
+| 3..255  | reserved       |
 
 ##### `DEFAULT` Mode
 
@@ -78,7 +89,7 @@ Frame executes as regular call where the caller address is `ENTRY_POINT`.
 
 Identifies the frame as a validation frame. Its purpose is to *verify* that a sender and/or payer authorized the transaction. It must call `APPROVE` during execution. Failure to do so will result in the whole transaction being invalid.
 
-The execution behaves the same as `STATICCALL`, state cannot be modified.
+The execution behaves the same as `STATICCALL` for user code: state cannot otherwise be modified. The `APPROVE` opcode is the only exception and applies its protocol-defined effects, including approval updates and, for payment scopes, nonce increment and gas-charge collection.
 
 Frames in this mode will have their data elided from signature hash calculation and from introspection by other frames.
 
@@ -86,14 +97,17 @@ Frames in this mode will have their data elided from signature hash calculation 
 
 Frame executes as regular call where the caller address is `sender`. This mode effectively acts on behalf of the transaction sender and can only be used after explicitly approved.
 
-##### Mode Flags
+##### Frame Flags
 
-The upper bits (> 8) of `mode` configure the execution environment.
+The `flags` field configures additional execution constraints.
 
-| Mode bit | Meaning                      | Valid with  |
-|----------|------------------------------| ----------- |
-| 9-10     | Approval scope               | Any mode    |
-| 11       | Atomic batch                 | SENDER mode |
+Bit positions in this specification are zero-based, with the least significant bit numbered `0`.
+
+| Flag bits | Meaning                      | Valid with  |
+|-----------|------------------------------| ----------- |
+| 0-1       | Approval scope               | Any mode    |
+| 2         | Atomic batch                 | SENDER mode |
+| 3-7       | reserved, must be zero       |             |
 
 The `Valid with` column indicates the mode under which the flag is valid.  If a flag is not valid under the current mode, the transaction is invalid.
 
@@ -106,15 +120,23 @@ assert tx.chain_id < 2**256
 assert tx.nonce < 2**64
 assert len(tx.frames) > 0 and len(tx.frames) <= MAX_FRAMES
 assert len(tx.sender) == 20
-assert (tx.frames[n].mode & 0xFF)  < 3
-assert len(tx.frames[n].target) == 20 or tx.frames[n].target is None
+assert tx.sender != bytes(20)
+total_frame_gas = 0
+for frame in tx.frames:
+    assert frame.mode < 3
+    assert frame.flags < 8
+    assert frame.mode != 1 or (frame.flags & 0x03) != 0  # VERIFY frames must permit a non-zero APPROVE scope
+    assert len(frame.target) == 20 or frame.target is None
+    assert frame.gas_limit <= 2**63 - 1
+    total_frame_gas += frame.gas_limit
+    assert total_frame_gas <= 2**63 - 1
 
-# Atomic batch flag (bit 11) is only valid with SENDER mode, and next frame must also be SENDER.
+# Atomic batch flag (bit 2 of flags) is only valid with SENDER mode, and next frame must also be SENDER.
 for i, frame in enumerate(tx.frames):
-    if (frame.mode >> 10) & 1 == 1:
-        assert (frame.mode & 0xFF) == 2               # must be SENDER
+    if frame.flags & 0x04 == 0x04:
+        assert frame.mode == 2                        # must be SENDER
         assert i + 1 < len(tx.frames)                  # must not be last frame
-        assert (tx.frames[i + 1].mode & 0xFF) == 2     # next frame must be SENDER
+        assert tx.frames[i + 1].mode == 2             # next frame must be SENDER
 ```
 
 #### Receipt
@@ -135,7 +157,7 @@ With the frame transaction, the signature may be at an arbitrary location in the
 ```python
 def compute_sig_hash(tx: FrameTx) -> Hash:
     for i, frame in enumerate(tx.frames):
-        if (frame.mode & 0xFF) == VERIFY:
+        if frame.mode == VERIFY:
             tx.frames[i].data = Bytes()
     return keccak(rlp(tx))
 ```
@@ -146,7 +168,7 @@ def compute_sig_hash(tx: FrameTx) -> Hash:
 
 The `APPROVE` opcode is like `RETURN (0xf3)`. It exits the current context successfully and updates the transaction-scoped approval context based on the `scope` operand.
 
-If the currently executing account is not `frame.target` (i.e. if `ADDRESS != frame.target`), `APPROVE` reverts.
+If the currently executing account is not the frame's resolved target (i.e. if `ADDRESS != resolved_target`), `APPROVE` reverts.
 
 ##### Stack
 
@@ -158,79 +180,104 @@ If the currently executing account is not `frame.target` (i.e. if `ADDRESS != fr
 
 ##### Scope Operand
 
-The `scope` operand must be one of the following values:
+The `scope` operand is a bitmask. Define the following constants:
 
-1. `0x1`: Approval of execution - the sender contract approves future frames calling on its behalf.
-   - Note this is only valid when `frame.target` equals `tx.sender`.
-2. `0x2`: Approval of payment - the contract approves paying the total gas cost for the transaction.
-3. `0x3`: Approval of execution and payment - combines both `0x1` and `0x2`.
+1. `APPROVE_SCOPE_NONE = 0x0`
+2. `APPROVE_PAYMENT = 0x1`
+3. `APPROVE_EXECUTION = 0x2`
+4. `APPROVE_PAYMENT_AND_EXECUTION = APPROVE_PAYMENT | APPROVE_EXECUTION`
+5. `APPROVE_SCOPE_MASK = APPROVE_PAYMENT_AND_EXECUTION`
 
-Any other value results in an exceptional halt.
+The `scope` operand must be a non-zero subset of `APPROVE_SCOPE_MASK`, i.e. one of the following values:
 
-Usable `scope` operands are constrained by bits 9 and 10 of the `frame.mode`, and using
-a non-allowed scope also results in an exceptional halt.
+1. `APPROVE_PAYMENT` (`0x1`): Approval of payment - the contract approves paying the total gas cost for the transaction.
+2. `APPROVE_EXECUTION` (`0x2`): Approval of execution - the sender contract approves future frames calling on its behalf.
+   - Note this is only valid when `resolved_target` equals `tx.sender`.
+3. `APPROVE_PAYMENT_AND_EXECUTION` (`0x3`): Approval of payment and execution.
 
-- If `(frame.mode>>8) & 3 == 0`, any scope can be used.
-- If `(frame.mode>>8) & 3 == 1`, only scope `0x1` can be used.
-- If `(frame.mode>>8) & 3 == 2`, only scope `0x2` can be used.
-- If `(frame.mode>>8) & 3 == 3`, only scope `0x3` can be used.
+Any other value, including `APPROVE_SCOPE_NONE`, results in an exceptional halt.
+
+`APPROVE_PAYMENT_AND_EXECUTION` is processed atomically within a single `APPROVE` and is not equivalent to invoking `APPROVE` twice.
+
+The frame's allowed approval scope is `allowed_scope = frame.flags & APPROVE_SCOPE_MASK`. These flag bits use the same bit assignments as the `scope` operand. A `scope` that is not a non-zero subset of `allowed_scope` results in an exceptional halt.
+
+`allowed_scope` is caller-supplied policy input and may restrict a verifier's intended `APPROVE` call. Verification logic SHOULD authenticate any approval scope it relies on and MUST NOT treat `allowed_scope` as trusted unless it is covered by that logic.
+
+- If `allowed_scope == APPROVE_SCOPE_NONE`, no `APPROVE` scope is allowed.
+- If `allowed_scope == APPROVE_EXECUTION`, only `APPROVE_EXECUTION` is allowed.
+- If `allowed_scope == APPROVE_PAYMENT`, only `APPROVE_PAYMENT` is allowed.
+- If `allowed_scope == APPROVE_PAYMENT_AND_EXECUTION`, `APPROVE_EXECUTION`, `APPROVE_PAYMENT`, or `APPROVE_PAYMENT_AND_EXECUTION` are allowed.
 
 ##### Behavior
 
 The behavior of `APPROVE` is defined as follows:
 
-- If `ADDRESS != frame.target`, revert.
-- For scopes `1`,`2`, and `3`, execute the following:
-    - `0x1`: Set `sender_approved = true`.
+- If `ADDRESS != resolved_target`, revert.
+- For scopes `APPROVE_EXECUTION`, `APPROVE_PAYMENT`, and `APPROVE_PAYMENT_AND_EXECUTION`, execute the following:
+    - `APPROVE_EXECUTION`: Set `sender_approved = true`.
         - If `sender_approved` was already set, revert the frame.
-        - If `frame.target` != `tx.sender`, revert the frame.
-    - `0x2`: Increment the sender's nonce, collect the total gas cost of the transaction from the account, and set `payer_approved = true`.
+        - If `resolved_target` != `tx.sender`, revert the frame.
+    - `APPROVE_PAYMENT`: Increment the sender's nonce, collect the transaction's maximum cost (`TXPARAM(0x06)`) from `resolved_target`, and set `payer_approved = true`.
         - If `payer_approved` was already set, revert the frame.
-        - If `frame.target` has insufficient balance, revert the frame.
+        - If `resolved_target` has insufficient balance, revert the frame.
         - If `sender_approved == false`, revert the frame.
-    - `0x3`: Set `sender_approved = true`, increment the sender's nonce, collect the total gas cost of the transaction from `frame.target`, and set `payer_approved = true`.
+    - `APPROVE_PAYMENT_AND_EXECUTION`: Set `sender_approved = true`, increment the sender's nonce, collect the transaction's maximum cost (`TXPARAM(0x06)`) from `resolved_target`, and set `payer_approved = true`.
         - If `sender_approved` or `payer_approved` was already set, revert the frame.
-        - If `frame.target` != `tx.sender`, revert the frame.
-        - If `frame.target` has insufficient balance, revert the frame.
+        - If `resolved_target` != `tx.sender`, revert the frame.
+        - If `resolved_target` has insufficient balance, revert the frame.
 
 #### `TXPARAM` opcode
 
-This opcode gives access to information from the transaction header and/or frames. The gas
+This opcode gives access to transaction-scoped information. The gas
 cost of this operation is `2`.
 
-It takes two values from the stack, `param` and `in2` (in this order). The `param` is the
-field to be extracted from the transaction. `in2` names a frame index.
+It takes one value from the stack, `param`. The `param` is the field to be extracted from the transaction.
 
-| `param` | `in2`       | Return value                                                                |
-|---------|-------------|-----------------------------------------------------------------------------|
-| 0x00    | must be 0   | current transaction type                                                    |
-| 0x01    | must be 0   | `nonce`                                                                     |
-| 0x02    | must be 0   | `sender`                                                                    |
-| 0x03    | must be 0   | `max_priority_fee_per_gas`                                                  |
-| 0x04    | must be 0   | `max_fee_per_gas`                                                           |
-| 0x05    | must be 0   | `max_fee_per_blob_gas`                                                      |
-| 0x06    | must be 0   | max cost (basefee=max, all gas used, includes blob cost and intrinsic cost) |
-| 0x07    | must be 0   | `len(blob_versioned_hashes)`                                                |
-| 0x08    | must be 0   | `compute_sig_hash(tx)`                                                      |
-| 0x09    | must be 0   | `len(frames)` (can be zero)                                                 |
-| 0x10    | must be 0   | currently executing frame index                                             |
-| 0x11    | frame index | `target`                                                                    |
-| 0x12    | frame index | `gas_limit`                                                                 |
-| 0x13    | frame index | `mode` (the lower 8 bits of `frame.mode`)                                                                     |
-| 0x14    | frame index | `len(data)`                                                                 |
-| 0x15    | frame index | `status` (exceptional halt if current/future)                               |
-| 0x16    | frame index | `scope` (bits 9/10 from `frame.mode`)                                       |
-| 0x17    | frame index | `atomic_batch` (bit 11 from `frame.mode`, returns 0 or 1)                   |
+| `param` | Return value                                                                |
+|---------|-----------------------------------------------------------------------------|
+| 0x00    | current transaction type                                                    |
+| 0x01    | `nonce`                                                                     |
+| 0x02    | `sender`                                                                    |
+| 0x03    | `max_priority_fee_per_gas`                                                  |
+| 0x04    | `max_fee_per_gas`                                                           |
+| 0x05    | `max_fee_per_blob_gas`                                                      |
+| 0x06    | max cost (basefee=max, all gas used, includes blob cost and intrinsic cost) |
+| 0x07    | `len(blob_versioned_hashes)`                                                |
+| 0x08    | `compute_sig_hash(tx)`                                                      |
+| 0x09    | `len(frames)`                                                               |
+| 0x0A    | currently executing frame index                                             |
 
 Notes:
 
 - `0x01` has a possible future extension to allow indices for multidimensional nonces.
 - `0x03` and `0x04` have a possible future extension to allow indices for multidimensional gas.
-- The `status` field (0x15) returns `0` for failure or `1` for success.
+- `0x07` returns only the number of blob versioned hashes. Individual blob versioned hashes remain accessible via the existing `BLOBHASH(index)` opcode.
 - Invalid `param` values (not defined in the table above) result in an exceptional halt.
-- Out-of-bounds access for frame index (`>= len(frames)`) results in an exceptional halt.
+
+#### `FRAMEINFO` opcode
+
+This opcode gives access to frame-scoped information. The gas cost of this operation is `2`.
+
+It takes two values from the stack, `param` and `frameIndex` (in this order). The `frameIndex` is zero-based, so `0` refers to the first frame.
+
+| `param` | `frameIndex` | Return value                                            |
+|---------|--------------|---------------------------------------------------------|
+| 0x00    | frameIndex   | `target`                                                |
+| 0x01    | frameIndex   | `gas_limit`                                             |
+| 0x02    | frameIndex   | `mode`                                                  |
+| 0x03    | frameIndex   | `flags`                                                 |
+| 0x04    | frameIndex   | `len(data)`                                             |
+| 0x05    | frameIndex   | `status` (exceptional halt if current/future)           |
+| 0x06    | frameIndex   | `allowed_scope` (`frame.flags & APPROVE_SCOPE_MASK`)    |
+| 0x07    | frameIndex   | `atomic_batch` (`frame.flags & 0x04`, returns 0/1)      |
+
+Notes:
+
+- The `status` field (0x05) returns `0` for failure or `1` for success.
+- Invalid `param` values (not defined in the table above) result in an exceptional halt.
+- Out-of-bounds access for `frameIndex` (`>= len(frames)`) results in an exceptional halt.
 - Attempting to access the return `status` of the current frame or a subsequent frame results in an exceptional halt.
-- `len(data)` field (0x14) returns size 0 value when called on a frame with `VERIFY` set.
+- `len(data)` returns size 0 when called on a frame with `VERIFY` set.
 
 #### `FRAMEDATALOAD` opcode
 
@@ -247,9 +294,9 @@ mode, the returned data is always zero.
 
 #### `FRAMEDATACOPY` opcode
 
-This opcode copies data frame input into the contract's memory.The gas cost matches
-CALLDATACOPY, i.e. the operation has a fixed cost of 3 and a variable cost that accounts
-for the memory expansion and copying.
+This opcode copies data frame input into the contract's memory. Its gas cost is calculated
+exactly as for `CALLDATACOPY`, including the fixed cost of 3, the per-word copy cost, and
+the standard EVM memory expansion cost.
 
 It takes four values from the stack: `memOffset`, `dataOffset`, `length` and `frameIndex`.
 No stack output value is produced.
@@ -275,21 +322,21 @@ Initialize with transaction-scoped variables:
 
 Then for each call frame:
 
-2. Execute a call with the specified `mode`, `target`, `gas_limit`, and `data`.
-   - If `target` is null, set the call target to `tx.sender`.
+1. Let `resolved_target = frame.target if frame.target is not null else tx.sender`, then execute a call with the specified `mode`, `flags`, `resolved_target`, `gas_limit`, and `data`.
    - If mode is `SENDER`:
        - `sender_approved` must be `true`. If not, the transaction is invalid.
        - Set `caller` as `tx.sender`.
    - If mode is `DEFAULT` or `VERIFY`:
        - Set the `caller` to `ENTRY_POINT`.
-   - If `frame.target` has no code, execute the logic described in [default code](#default-code).
+   - If `resolved_target` has neither code nor an [EIP-7702](./eip-7702.md) delegation indicator, execute the logic described in [default code](#default-code).
+   - Otherwise, if `resolved_target` uses an [EIP-7702](./eip-7702.md) delegation indicator, execute according to [EIP-7702](./eip-7702.md)'s delegated-code semantics.
    - The `ORIGIN` opcode returns frame `caller` throughout all call depths.
    - If a frame's execution reverts, its state changes are discarded. Additionally, if this frame has the atomic batch flag set, mark all subsequent frames in the same atomic group as skipped.
-3. If frame has mode `VERIFY` and the frame did not successfully call `APPROVE`, the transaction is invalid.
+2. If frame has mode `VERIFY` and the frame did not successfully call `APPROVE`, the transaction is invalid.
 
 #### Atomic Batching
 
-Consecutive `SENDER` frames where all but the last have the atomic batch flag (bit 11) set form an **atomic batch**. Within a batch, if any frame reverts, all preceding frames in the batch are also reverted and all subsequent frames in the batch are skipped.
+Consecutive `SENDER` frames where all but the last have the atomic batch flag (bit 2 of `flags`) set form an **atomic batch**. Within a batch, if any frame reverts, all preceding frames in the batch are also reverted and all subsequent frames in the batch are skipped.
 
 More precisely, execution of an atomic batch proceeds as follows:
 
@@ -319,25 +366,30 @@ Note:
 
 #### Default code
 
-When using frame transactions with EOAs (accounts with no code), they are treated as if they have a "default code."  This spec describes only the behavior of the default code; clients are free to implement the default code however they want, so long as they correspond to the behavior specified here.
+When using frame transactions with EOAs that have neither code nor an [EIP-7702](./eip-7702.md) delegation indicator, they are treated as if they have a "default code." Accounts with code, including [EIP-7702](./eip-7702.md) delegated accounts, do not use the default code path. This spec describes only the behavior of the default code; clients are free to implement the default code however they want, so long as they correspond to the behavior specified here.
 
-- Retrieve the `mode` with `TXPARAMLOAD`.
+- Let `resolved_target = frame.target if frame.target is not null else tx.sender`.
+- Retrieve the current frame's `mode` with `FRAMEINFO`.
 - If `mode` is `VERIFY`:
-  - If `frame.target != tx.sender`, revert.
-  - Read the approval scope from the mode bits: `scope = (frame.mode >> 8) & 3`. If `scope == 0`, revert.
+  - Read the allowed approval scope from the flags field: `allowed_scope = frame.flags & APPROVE_SCOPE_MASK`. If `allowed_scope == APPROVE_SCOPE_NONE`, revert.
+  - If `allowed_scope & APPROVE_EXECUTION != 0` and `resolved_target != tx.sender`, revert.
   - Read the first byte of `frame.data` as `signature_type`.
   - If `signature_type` is:
     - `0x0`:
       - Read the rest of `frame.data` as `(v, r, s)`.
-      - If `frame.target != ecrecover(sig_hash, v, r, s)`, where `sig_hash = compute_sig_hash(tx)`, revert.
+      - If `s > secp256k1n / 2`, revert.
+      - Let `recovered = ecrecover(sig_hash, v, r, s)`, where `sig_hash = compute_sig_hash(tx)`.
+      - If `recovered == address(0)`, revert.
+      - If `resolved_target != recovered`, revert.
     - `0x1`:
       - Read the rest of `frame.data` as `(r, s, qx, qy)`.
-      - If `frame.target != keccak(qx|qy)[12:]`, revert.
+      - Let `p256_address = keccak(P256_ADDRESS_DOMAIN|qx|qy)[12:]`.
+      - If `resolved_target != p256_address`, revert.
       - If `P256VERIFY(sig_hash, r, s, qx, qy) != true`, where `sig_hash = compute_sig_hash(tx)`, revert.
     - Otherwise revert.
-  - Call `APPROVE(scope)`.
+  - Call `APPROVE(allowed_scope)`.
 - If `mode` is `SENDER`:
-  - If `frame.target != tx.sender`, revert.
+  - If `resolved_target != tx.sender`, revert.
   - Read `frame.data` as RLP encoding of `calls = [[target, value, data]]`.
   - For each call in `calls`, execute the call with `msg.sender = tx.sender`.
     - If any call reverts, revert the frame.
@@ -346,7 +398,8 @@ When using frame transactions with EOAs (accounts with no code), they are treate
 
 Notes:
 
-- It's implied that for the P256 (r1) signature type, the sender address must be `keccak(qx|qy)[12:]`.
+- `P256VERIFY` must reject invalid public keys, including points that are not on the P256 curve.
+- For the P256 (r1) signature type, the sender address is `keccak(P256_ADDRESS_DOMAIN|qx|qy)[12:]`.
 
 Here's the logic above implemented in Python:
 
@@ -354,19 +407,30 @@ Here's the logic above implemented in Python:
 DEFAULT   = 0
 VERIFY    = 1
 SENDER    = 2
+APPROVE_SCOPE_NONE = 0x00
+APPROVE_PAYMENT = 0x01
+APPROVE_EXECUTION = 0x02
+APPROVE_PAYMENT_AND_EXECUTION = APPROVE_PAYMENT | APPROVE_EXECUTION
+APPROVE_SCOPE_MASK = APPROVE_PAYMENT_AND_EXECUTION
+ATOMIC_BATCH_FLAG = 0x04
 
 SECP256K1 = 0x0
 P256      = 0x1
+P256_ADDRESS_DOMAIN = b"\x01"
+SECP256K1N_DIV_2 = 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0
 
 def default_code(frame, tx):
-    mode = frame.mode & 0xFF                 # equivalent to TXPARAMLOAD(0x14, TXPARAMLOAD(0x10))
+    mode = frame.mode                        # equivalent to FRAMEINFO(0x02, TXPARAM(0x0A))
+    resolved_target = frame.target if frame.target is not None else tx.sender
 
     if mode == VERIFY:
-        scope          = (frame.mode >> 8) & 3     # approval scope from mode bits
-        if scope == 0:
+        allowed_scope  = frame.flags & APPROVE_SCOPE_MASK  # allowed approval scope from flags field
+        if allowed_scope == APPROVE_SCOPE_NONE:
+            revert()
+        if allowed_scope & APPROVE_EXECUTION != 0 and resolved_target != tx.sender:
             revert()
         signature_type = frame.data[0]              # first byte: signature type
-        sig_hash       = compute_sig_hash(tx)       # equivalent to TXPARAMLOAD(0x08)
+        sig_hash       = compute_sig_hash(tx)       # equivalent to TXPARAM(0x08)
 
         if signature_type == SECP256K1:
             # frame.data layout: [signature_type, v (1 byte), r (32 bytes), s (32 bytes)]
@@ -375,7 +439,13 @@ def default_code(frame, tx):
             v = frame.data[1]
             r = frame.data[2:34]
             s = frame.data[34:66]
-            if frame.target != ecrecover(sig_hash, v, r, s):
+            # Reject high-s signatures so each authorization has a single canonical encoding.
+            if int.from_bytes(s, "big") > SECP256K1N_DIV_2:
+                revert()
+            recovered = ecrecover(sig_hash, v, r, s)
+            if recovered == bytes(20):
+                revert()
+            if resolved_target != recovered:
                 revert()
 
         elif signature_type == P256:
@@ -386,7 +456,7 @@ def default_code(frame, tx):
             s  = frame.data[33:65]
             qx = frame.data[65:97]
             qy = frame.data[97:129]
-            if frame.target != keccak256(qx + qy)[12:]:
+            if resolved_target != keccak256(P256_ADDRESS_DOMAIN + qx + qy)[12:]:
                 revert()
             if not P256VERIFY(sig_hash, r, s, qx, qy):
                 revert()
@@ -394,10 +464,10 @@ def default_code(frame, tx):
         else:
             revert()
 
-        APPROVE(scope)
+        APPROVE(allowed_scope)
 
     elif mode == SENDER:
-        if frame.target != tx.sender:
+        if resolved_target != tx.sender:
             revert()
 
         # frame.data layout: RLP-encoded [[target, value, data], ...]
@@ -426,7 +496,7 @@ A few cross-frame interactions to note:
 The total gas limit of the transaction is:
 
 ```
-tx_gas_limit = FRAME_TX_INTRINSIC_COST + calldata_cost(rlp(tx.frames)) + sum(frame.gas_limit for all frames)
+tx_gas_limit = FRAME_TX_INTRINSIC_COST + len(tx.frames) * FRAME_TX_PER_FRAME_COST + calldata_cost(rlp(tx.frames)) + sum(frame.gas_limit for all frames)
 ```
 
 Where `calldata_cost` is calculated per standard EVM rules (4 gas per zero byte, 16 gas per non-zero byte).
@@ -446,7 +516,7 @@ Each frame has its own `gas_limit` allocation. Unused gas from a frame is **not*
 refund = sum(frame.gas_limit for all frames) - total_gas_used
 ```
 
-This refund is returned to the gas payer (the `target` that called `APPROVE(0x2)` or `APPROVE(0x3)`) and added back to the block gas pool. *Note: This refund mechanism is separate from EIP-3529 storage refunds.*
+This refund is returned to the gas payer (the `target` that called `APPROVE(APPROVE_PAYMENT)` or `APPROVE(APPROVE_PAYMENT_AND_EXECUTION)`) and added back to the block gas pool. *Note: This refund mechanism is separate from EIP-3529 storage refunds.*
 
 ### Mempool
 
@@ -473,7 +543,7 @@ A frame transaction is eligible for public mempool propagation only if its valid
 
 1. transaction fields, including the canonical signature hash,
 2. the sender's nonce, code, and storage,
-3. a known deterministic deployer contract, if a deployment frame is present,
+3. the [EIP-7997](./eip-7997.md) deterministic factory predeploy, if a deployment frame is present,
 4. if a paymaster frame is present, either a canonical paymaster instance together with explicit paymaster balance reservation, or a non-canonical paymaster being used by less than `MAX_PENDING_TXS_USING_NON_CANONICAL_PAYMASTER` pending transactions,
 5. the code of any other existing non-delegated contracts reached during validation via `CALL*` or `EXTCODE*`, provided the resulting trace does not access disallowed mutable state.
 
@@ -486,7 +556,7 @@ While the frames are designed to be generic, we refine some frame modes for the 
 | Name  | Mode  | Description  |
 |---|---|---|
 | `self_verify`   | VERIFY  | Validates the transaction and approves both sender and payer |
-| `deploy`  | DEFAULT | Deploys a new smart account using a known deterministic deployer |
+| `deploy`  | DEFAULT | Deploys a new smart account using the [EIP-7997](./eip-7997.md) deterministic factory predeploy |
 | `only_verify`  | VERIFY  | Validates the transaction and approves only the sender |
 | `pay`  | VERIFY | Validates the transaction and approves only the payer |
 | `user_op` | SENDER | Executes the intended user operation |
@@ -542,15 +612,15 @@ To be accepted into the public mempool, a frame transaction must satisfy the fol
 1. Its validation prefix must match one of the four recognized prefixes above.
 2. If present, `deploy` must be the first frame. This implies there can be at most one `deploy` frame in the validation prefix.
 3. `self_verify` and `only_verify` must execute in `VERIFY` mode, target `tx.sender` (either explicitly or via a null target), and must successfully call `APPROVE`.
-    - `self_verify` must call `APPROVE(0x2)`.
-    - `only_verify` must call `APPROVE(0x0)`.
-4. `pay` must execute in `VERIFY` mode and successfully call `APPROVE(0x1)`.
+    - `self_verify` must call `APPROVE(APPROVE_PAYMENT_AND_EXECUTION)`.
+    - `only_verify` must call `APPROVE(APPROVE_EXECUTION)`.
+4. `pay` must execute in `VERIFY` mode and successfully call `APPROVE(APPROVE_PAYMENT)`.
 5. The sum of `gas_limit` values across the validation prefix must not exceed `MAX_VERIFY_GAS`.
 6. Nodes should stop simulation immediately once `payer_approved = true` has been observed.
 
 #### Canonical Paymaster Exception
 
-The generic validation trace and opcode rules below apply to all frames in the validation prefix except a `pay` frame whose target runtime code exactly matches the canonical paymaster implementation. The canonical paymaster implementation is explicitly designed to be safe for public mempool use and is therefore admitted by code match, successful `APPROVE(0x1)`, and the paymaster accounting rules in this section, rather than by requiring it to satisfy each generic validation rule individually.
+The generic validation trace and opcode rules below apply to all frames in the validation prefix except a `pay` frame whose target runtime code exactly matches the canonical paymaster implementation. The canonical paymaster implementation is explicitly designed to be safe for public mempool use and is therefore admitted by code match, successful `APPROVE(APPROVE_PAYMENT)`, and the paymaster accounting rules in this section, rather than by requiring it to satisfy each generic validation rule individually.
 
 #### Validation Trace Rules
 
@@ -567,7 +637,7 @@ A public mempool node must simulate the validation prefix and reject the transac
 
 ##### Banned Opcodes
 
-The following opcodes are banned during the validation prefix, with a few caveats:
+For `VERIFY` frames, the usual `STATICCALL` restrictions apply except for the protocol-defined effects of `APPROVE`. In addition, the following opcodes are banned during the validation prefix, with a few caveats:
 
 - ORIGIN (0x32)
 - GASPRICE (0x3A)
@@ -584,7 +654,7 @@ The following opcodes are banned during the validation prefix, with a few caveat
     - Except when followed immediately by a `*CALL` instruction. This is the standard method of passing gas to a child call and does not create an additional public mempool dependency.
 - CREATE (0xF0)
 - CREATE2 (0xF5)
-    - Except inside the first `deploy` frame when targeting a known deterministic deployer.
+    - Except inside the first `deploy` frame when targeting the [EIP-7997](./eip-7997.md) deterministic factory predeploy.
 - INVALID (0xFE)
 - SELFDESTRUCT (0xFF)
 - BALANCE (0x31)
@@ -612,6 +682,8 @@ We address this conflict in two ways:
 
 The canonical paymaster is not a singleton deployment. Many instances may be deployed. For public mempool purposes, a paymaster instance is considered canonical if and only if the runtime code at the `pay` frame target exactly matches the canonical paymaster implementation.
 
+The canonical paymaster in this draft authorizes with a single secp256k1 signer via `ecrecover`, does not support contract-signature schemes, and may change in later specifications, in which case a new canonical implementation version would be required.
+
 Because the canonical paymaster implementation is explicitly standardized to be safe for public mempool use, nodes do not need to apply the generic validation trace and opcode rules to that `pay` frame. Instead, they identify it by runtime code match and apply the paymaster-specific accounting and revalidation rules in this section.
 
 A transaction using a paymaster is eligible for public mempool propagation only if the `pay` frame targets a canonical paymaster instance and the node can reserve the maximum transaction cost against that paymaster.
@@ -624,9 +696,9 @@ available_paymaster_balance = state.balance(paymaster) - reserved_pending_cost(p
 
 Where `pending_withdrawal_amount(paymaster)` is the currently pending delayed withdrawal amount of the canonical paymaster instance, or zero if no delayed withdrawal is pending.
 
-A node must reject a paymaster transaction if `available_paymaster_balance` is less than the transaction's maximum cost (`TXPARAM(0x06, 0)`).
+A node must reject a paymaster transaction if `available_paymaster_balance` is less than the transaction's maximum cost (`TXPARAM(0x06)`).
 
-On admission, the node increments `reserved_pending_cost(paymaster)` by the transaction's maximum cost (`TXPARAM(0x06, 0)`). On eviction, replacement, inclusion, or reorg removal, the node decrements it accordingly.
+On admission, the node increments `reserved_pending_cost(paymaster)` by the transaction's maximum cost (`TXPARAM(0x06)`). On eviction, replacement, inclusion, or reorg removal, the node decrements it accordingly.
 
 ##### Non-canonical paymaster
 
@@ -662,19 +734,24 @@ When a new canonical block is accepted, the node removes any included frame tran
 
 ### Canonical signature hash
 
-The canonical signature hash is provided in `TXPARAMLOAD` to simplify the development of smart accounts.
+The canonical signature hash is provided in `TXPARAM` to simplify the development of smart accounts.
 
 Computing the signature hash in EVM is complicated and expensive. While using the canonical signature hash is not mandatory, it is strongly recommended. Creating a bespoke signature requires precise commitment to the underlying transaction data. Without this, it's possible that some elements can be manipulated in-the-air while the transaction is pending and have unexpected effects. This is known as transaction malleability. Using the canonical signature hash avoids malleability of the frames other than `VERIFY`.
 
-The `frame.data` of `VERIFY` frames is elided from the signature hash. This is done for two reasons:
+The `frame.data` of `VERIFY` frames is elided from the signature hash. This is done for three reasons:
 
 1. It contains the signature so by definition it cannot be part of the signature hash.
 2. In the future it may be desired to aggregate the cryptographic operations for data and compute efficiency reasons. If the data was introspectable, it would not be possible to aggregate the verify frames in the future.
-3. For gas sponsoring workflows, we also recommend using a `VERIFY` frame to approve the gas payment. Here, the input data to the sponsor is intentionally left malleable so it can be added onto the transaction after the `sender` has made its signature. Notably, the `frame.target` of `VERIFY` frames is covered by the signature hash, i.e. the `sender` chooses the sponsor address explicitly.
+3. For gas sponsoring workflows, we also recommend using a `VERIFY` frame to approve the gas payment. Here, the input data to the sponsor is intentionally left malleable so it can be added onto the transaction after the `sender` has made its signature. Notably, the raw `frame.target` field of `VERIFY` frames is covered by the signature hash, i.e. the `sender` chooses the sponsor address explicitly.
+
+Implementations MUST NOT treat `VERIFY` frame `data` as sender-authenticated by the canonical signature hash. Any verifier or paymaster that depends on its input data, including sponsor parameters, exchange rates, fee terms, or custom account context, MUST authenticate that data independently. Replacing or mutating `VERIFY` frame `data` does not change the canonical signature hash.
+Verification logic MUST NOT assign policy meaning to signature encodings or adjacent `VERIFY` frame data unless that meaning is independently authenticated.
 
 ### `APPROVE` calling convention
 
-Originally `APPROVE` was meant to extend the space of return statuses from 0 and 1 today to 0 to 4. However, this would mean smart accounts deployed today would not be able to modify their contract code to return with a different value at the top level. For this reason, we've chosen behavior above: `APPROVE` terminates the executing frame successfully like `RETURN`, but it actually updates the transaction scoped values `sender_approved` and `payer_approved` during execution. It is still required that only the sender can toggle the `sender_approved` to `true`. Only the `frame.target` can call `APPROVE` generally, because it can allow the transaction pool and other frames to better reason about `VERIFY` mode frames.
+Originally `APPROVE` was meant to extend the space of return statuses from 0 and 1 today to 0 to 4. However, this would mean smart accounts deployed today would not be able to modify their contract code to return with a different value at the top level. For this reason, we've chosen behavior above: `APPROVE` terminates the executing frame successfully like `RETURN`, but it actually updates the transaction scoped values `sender_approved` and `payer_approved` during execution. It is still required that only the sender can toggle the `sender_approved` to `true`. Only the frame's resolved target can call `APPROVE` generally, because it can allow the transaction pool and other frames to better reason about `VERIFY` mode frames.
+
+Because `DELEGATECALL` preserves `ADDRESS`, code executed via `DELEGATECALL` from the resolved target may also execute `APPROVE` successfully. Contracts that rely on `APPROVE` should therefore treat delegatecalled libraries as fully trusted.
 
 ### Payer in receipt
 
@@ -721,7 +798,7 @@ Note that users can use any EOA as a paymaster thanks to the [default code](#def
 | 0     | ENTRY_POINT    | Null (sender) | Signature | VERIFY       |
 | 1     | Sender         | Target        | Call data | SENDER       |
 
-Frame 0 verifies the signature and calls `APPROVE(0x3)` to approve both execution and payment. Frame 1 executes and exits normally via `RETURN`.
+Frame 0 verifies the signature and calls `APPROVE(APPROVE_PAYMENT_AND_EXECUTION)` to approve both payment and execution. Frame 1 executes and exits normally via `RETURN`.
 
 The mempool can process this transaction with the following static validation and call:
 
@@ -749,7 +826,7 @@ This is listed here to illustrate why the transaction type has no built-in value
 
 This example illustrates the initial deployment flow for a smart account at the `sender` address. Since the address needs to have code in order to validate the transaction, the transaction must deploy the code before verification.
 
-The first frame would call a deployer contract, like EIP-7997. The deployer determines the address in a deterministic way, such as by hashing the initcode and salt. However, since the transaction sender is not authenticated at this point, the user must choose an initcode which is safe to deploy by anyone.
+The first frame would call the [EIP-7997](./eip-7997.md) deterministic factory predeploy. The deployer determines the address in a deterministic way from the salt and initcode. However, since the transaction sender is not authenticated at this point, the user must choose an initcode which is safe to deploy by anyone.
 
 #### Example 2: Atomic Approve + Swap
 
@@ -759,7 +836,7 @@ The first frame would call a deployer contract, like EIP-7997. The deployer dete
 | 1     | Sender      | ERC-20        | approve(DEX, amount)  | SENDER | set          |
 | 2     | Sender      | DEX           | swap(...)                | SENDER | not set      |
 
-Frame 0 verifies the signature and calls `APPROVE(0x3)`. Frames 1 and 2 form an atomic batch: if the swap in frame 2 reverts, the ERC-20 approval from frame 1 is also reverted, preventing the account from being left with a dangling approval.
+Frame 0 verifies the signature and calls `APPROVE(APPROVE_PAYMENT_AND_EXECUTION)`. Frames 1 and 2 form an atomic batch: if the swap in frame 2 reverts, the ERC-20 approval from frame 1 is also reverted, preventing the account from being left with a dangling approval.
 
 #### Example 3: Sponsored Transaction (Fee Payment in ERC-20)
 
@@ -771,8 +848,8 @@ Frame 0 verifies the signature and calls `APPROVE(0x3)`. Frames 1 and 2 form an 
 | 3     | Sender      | Target addr   | Call data              | SENDER  |
 | 4     | ENTRY_POINT | Sponsor       | Post op call           | DEFAULT |
 
-- Frame 0: Verifies signature and calls `APPROVE(0x1)` to authorize execution from sender.
-- Frame 1: Checks that the user has enough ERC-20 tokens, and that the next frame is an ERC-20 send of the right size to the sponsor. Calls `APPROVE(0x2)` to authorize payment.
+- Frame 0: Verifies signature and calls `APPROVE(APPROVE_EXECUTION)` to authorize execution from sender.
+- Frame 1: Checks that the user has enough ERC-20 tokens, and that the next frame is an ERC-20 send of the right size to the sponsor. Calls `APPROVE(APPROVE_PAYMENT)` to authorize payment.
 - Frame 2: Sends tokens to sponsor.
 - Frame 3: User's intended call.
 - Frame 4 (optional): Check unpaid gas, refund tokens, possibly convert tokens to ETH on an AMM.
@@ -786,8 +863,8 @@ Frame 0 verifies the signature and calls `APPROVE(0x3)`. Frames 1 and 2 form an 
 | 2     | Sender      | ERC-20        | transfer(Sponsor,fees) | SENDER  |
 | 3     | Sender      | Target addr   | Call data              | SENDER  |
 
-- Frame 0: Verify the sender with a EOA signature.  Upon verification, the frame calls `APPROVE(0x1)` to authorize execution.
-- Frame 1: Checks that the user has enough ERC-20 tokens, and that the next frame is an ERC-20 send of the right size to the sponsor. Calls `APPROVE(0x2)` to authorize payment.
+- Frame 0: Verify the sender with a EOA signature.  Upon verification, the frame calls `APPROVE(APPROVE_EXECUTION)` to authorize execution.
+- Frame 1: Checks that the user has enough ERC-20 tokens, and that the next frame is an ERC-20 send of the right size to the sponsor. Calls `APPROVE(APPROVE_PAYMENT)` to authorize payment.
 - Frame 2: Sends tokens to sponsor.
 - Frame 3: User's intended call.
 
@@ -873,19 +950,31 @@ A simple example is transactions that check `block.timestamp`:
 function validateTransaction() external {
     require(block.timestamp < SOME_DEADLINE, "expired");
     // ... rest of validation
-    APPROVE(0x3);
+    APPROVE(APPROVE_PAYMENT_AND_EXECUTION);
 }
 ```
 
 Such transactions are valid when submitted but become invalid once the deadline passes, without any on-chain action required from the attacker.
 
+#### Deploy Frame Front-Running
+
+If a transaction uses a `deploy` frame, that frame executes before the sender is authenticated. An observer can front-run the same deterministic deployment and cause the `deploy` frame to fail because code is already present at `tx.sender`. Accordingly, initcode used with `deploy` frames must be safe to deploy by any party, and wallets should expect resubmission without the `deploy` frame once deployment has already occurred.
+
+#### Explicit Sender State-Read Amplification
+
+Because `tx.sender` is explicit in the transaction envelope, an attacker can submit many invalid frame transactions that name arbitrary sender addresses and force nodes to read sender state, including the nonce check required before execution. Public mempool implementations should therefore perform all available structural and stateless checks before sender-state access and should consider peer-level rate limiting or other DoS mitigations for repeated invalid transactions that vary `tx.sender`.
+
+#### Cross-Frame Data Visibility During Validation
+
+`FRAMEINFO`, `FRAMEDATALOAD`, and `FRAMEDATACOPY` allow validation code to inspect other frames, including later `SENDER` frames. As a result, paymasters and other `VERIFY` frames can observe user operation parameters before approval and may condition their behavior on that information. Users should therefore treat non-`VERIFY` frame data as visible to validation logic and should not rely on untrusted paymasters or verifiers to keep such data private.
+
 ##### Mitigations
 
 Node implementations should consider restricting which opcodes and storage slots validation frames can access, similar to ERC-7562. This isolates transactions from each other and limits mass invalidation vectors.
 
-It's recommended that to *validate* the transaction, a specific frame structure is enforced and the amount of gas that is expended executing the validation phase must be limited. Once the frame calls `APPROVE(0x2)`, it can be included in the mempool and propagated to peers safely.
+It's recommended that to *validate* the transaction, a specific frame structure is enforced and the amount of gas that is expended executing the validation phase must be limited. Once the validation prefix reaches payer approval via `APPROVE(APPROVE_PAYMENT)` or `APPROVE(APPROVE_PAYMENT_AND_EXECUTION)`, the transaction can be included in the mempool and propagated to peers safely.
 
-For deployment of the sender account in the first frame, the mempool must only allow specific and known deployer factory  contracts to be used as `frame.target`, to ensure deployment is deterministic and independent of chain state.
+For deployment of the sender account in the first frame, the mempool must only allow the [EIP-7997](./eip-7997.md) deterministic factory predeploy as `frame.target`, to ensure deployment is deterministic and independent of chain state.
 
 In general, it can be assumed that handling of frame transactions imposes similar restrictions as EIP-7702 on mempool relay, i.e. only a single transaction can be pending for an account that uses frame transactions.
 

--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -116,6 +116,12 @@ The `Valid with` column indicates the mode under which the flag is valid.  If a 
 Some validity constraints can be determined statically. They are outlined below:
 
 ```python
+# Constants (see Default Code section for full definitions)
+VERIFY = 1
+SENDER = 2
+APPROVE_SCOPE_MASK = 0x03
+ATOMIC_BATCH_FLAG = 0x04
+
 assert tx.chain_id < 2**256
 assert tx.nonce < 2**64
 assert len(tx.frames) > 0 and len(tx.frames) <= MAX_FRAMES
@@ -125,7 +131,7 @@ total_frame_gas = 0
 for frame in tx.frames:
     assert frame.mode < 3
     assert frame.flags < 8
-    assert frame.mode != 1 or (frame.flags & 0x03) != 0  # VERIFY frames must permit a non-zero APPROVE scope
+    assert frame.mode != VERIFY or (frame.flags & APPROVE_SCOPE_MASK) != 0  # VERIFY frames must permit a non-zero APPROVE scope
     assert len(frame.target) == 20 or frame.target is None
     assert frame.gas_limit <= 2**63 - 1
     total_frame_gas += frame.gas_limit
@@ -133,10 +139,10 @@ for frame in tx.frames:
 
 # Atomic batch flag (bit 2 of flags) is only valid with SENDER mode, and next frame must also be SENDER.
 for i, frame in enumerate(tx.frames):
-    if frame.flags & 0x04 == 0x04:
-        assert frame.mode == 2                        # must be SENDER
+    if frame.flags & ATOMIC_BATCH_FLAG:
+        assert frame.mode == SENDER                    # must be SENDER
         assert i + 1 < len(tx.frames)                  # must not be last frame
-        assert tx.frames[i + 1].mode == 2             # next frame must be SENDER
+        assert tx.frames[i + 1].mode == SENDER         # next frame must be SENDER
 ```
 
 #### Receipt
@@ -156,10 +162,12 @@ With the frame transaction, the signature may be at an arbitrary location in the
 
 ```python
 def compute_sig_hash(tx: FrameTx) -> Hash:
-    for i, frame in enumerate(tx.frames):
+    # Operate on a copy; the original transaction object is not modified.
+    tx_copy = deep_copy(tx)
+    for i, frame in enumerate(tx_copy.frames):
         if frame.mode == VERIFY:
-            tx.frames[i].data = Bytes()
-    return keccak(rlp(tx))
+            tx_copy.frames[i].data = Bytes()
+    return keccak(rlp(tx_copy))
 ```
 
 ### New Opcodes
@@ -260,16 +268,16 @@ This opcode gives access to frame-scoped information. The gas cost of this opera
 
 It takes two values from the stack, `param` and `frameIndex` (in this order). The `frameIndex` is zero-based, so `0` refers to the first frame.
 
-| `param` | `frameIndex` | Return value                                            |
-|---------|--------------|---------------------------------------------------------|
-| 0x00    | frameIndex   | `target`                                                |
-| 0x01    | frameIndex   | `gas_limit`                                             |
-| 0x02    | frameIndex   | `mode`                                                  |
-| 0x03    | frameIndex   | `flags`                                                 |
-| 0x04    | frameIndex   | `len(data)`                                             |
-| 0x05    | frameIndex   | `status` (exceptional halt if current/future)           |
-| 0x06    | frameIndex   | `allowed_scope` (`frame.flags & APPROVE_SCOPE_MASK`)    |
-| 0x07    | frameIndex   | `atomic_batch` (`frame.flags & 0x04`, returns 0/1)      |
+| `param` | `frameIndex` | Return value                                              |
+|---------|--------------|-----------------------------------------------------------|
+| 0x00    | frameIndex   | `target`                                                  |
+| 0x01    | frameIndex   | `gas_limit`                                               |
+| 0x02    | frameIndex   | `mode`                                                    |
+| 0x03    | frameIndex   | `flags`                                                   |
+| 0x04    | frameIndex   | `len(data)`                                               |
+| 0x05    | frameIndex   | `status` (exceptional halt if current/future)             |
+| 0x06    | frameIndex   | `allowed_scope` (`frame.flags & APPROVE_SCOPE_MASK`)      |
+| 0x07    | frameIndex   | `atomic_batch` (`(frame.flags >> 2) & 0x01`, returns 0/1) |
 
 Notes:
 
@@ -781,7 +789,7 @@ It is not required because the account code can send value.
 
 While we expect EOA users to migrate to smart accounts eventually, we recognize that most Ethereum users today are using EOAs, so we want to improve UX for them where we can.
 
-With frame transactions, EOA wallets today can reap the key benefit of AA -- gas abstraction, including sending sponsored transactions, paying gas in ERC-20 tokens, and more.
+With frame transactions, EOA wallets today can reap the key benefit of AA - gas abstraction, including sending sponsored transactions, paying gas in ERC-20 tokens, and more.
 
 ### Non-canonical paymasters in the mempool
 
@@ -793,10 +801,10 @@ Note that users can use any EOA as a paymaster thanks to the [default code](#def
 
 #### Example 1: Simple Transaction
 
-| Frame | Caller         | Target        | Data      | Mode         |
-| ----- | -------------- | ------------- | --------- | ------------ |
-| 0     | ENTRY_POINT    | Null (sender) | Signature | VERIFY       |
-| 1     | Sender         | Target        | Call data | SENDER       |
+| Frame | Caller         | Target        | Flags | Data      | Mode         |
+| ----- | -------------- | ------------- | ----- | --------- | ------------ |
+| 0     | ENTRY_POINT    | Null (sender) | 0x03  | Signature | VERIFY       |
+| 1     | Sender         | Target        | 0x00  | Call data | SENDER       |
 
 Frame 0 verifies the signature and calls `APPROVE(APPROVE_PAYMENT_AND_EXECUTION)` to approve both payment and execution. Frame 1 executes and exits normally via `RETURN`.
 
@@ -807,10 +815,10 @@ The mempool can process this transaction with the following static validation an
 
 #### Example 1a: Simple ETH transfer
 
-| Frame | Caller         | Target        | Data               | Mode         |
-| ----- | -------------- | ------------- | ------------------ | ------------ |
-| 0     | ENTRY_POINT    | Null (sender) | Signature          | VERIFY       |
-| 1     | Sender         | Null (sender) | Destination/Amount | SENDER       |
+| Frame | Caller         | Target        | Flags | Data               | Mode         |
+| ----- | -------------- | ------------- | ----- | ------------------ | ------------ |
+| 0     | ENTRY_POINT    | Null (sender) | 0x03  | Signature          | VERIFY       |
+| 1     | Sender         | Null (sender) | 0x00  | Destination/Amount | SENDER       |
 
 A simple transfer is performed by instructing the account to send ETH to the destination account. This requires two frames for mempool compatibility, since the validation phase of the transaction has to be static.
 
@@ -818,11 +826,11 @@ This is listed here to illustrate why the transaction type has no built-in value
 
 #### Example 1b: Simple account deployment
 
-| Frame | Caller       | Target        | Data               | Mode    |
-| ----- | ------------ | ------------- | ------------------ | ------- |
-| 0     | ENTRY_POINT  | Deployer      | Initcode, Salt     | DEFAULT |
-| 1     | ENTRY_POINT  | Null (sender) | Signature          | VERIFY  |
-| 2     | Sender       | Null (sender) | Destination/Amount | SENDER  |
+| Frame | Caller       | Target        | Flags | Data               | Mode    |
+| ----- | ------------ | ------------- | ----- | ------------------ | ------- |
+| 0     | ENTRY_POINT  | Deployer      | 0x00  | Initcode, Salt     | DEFAULT |
+| 1     | ENTRY_POINT  | Null (sender) | 0x03  | Signature          | VERIFY  |
+| 2     | Sender       | Null (sender) | 0x00  | Destination/Amount | SENDER  |
 
 This example illustrates the initial deployment flow for a smart account at the `sender` address. Since the address needs to have code in order to validate the transaction, the transaction must deploy the code before verification.
 
@@ -830,23 +838,23 @@ The first frame would call the [EIP-7997](./eip-7997.md) deterministic factory p
 
 #### Example 2: Atomic Approve + Swap
 
-| Frame | Caller      | Target        | Data                     | Mode   | Atomic Batch |
-| ----- | ----------- | ------------- | ------------------------ | ------ | ------------ |
-| 0     | ENTRY_POINT | Null (sender) | Signature                | VERIFY | -            |
-| 1     | Sender      | ERC-20        | approve(DEX, amount)  | SENDER | set          |
-| 2     | Sender      | DEX           | swap(...)                | SENDER | not set      |
+| Frame | Caller      | Target        | Flags | Data                  | Mode   | Atomic Batch |
+| ----- | ----------- | ------------- | ----- | --------------------- | ------ | ------------ |
+| 0     | ENTRY_POINT | Null (sender) | 0x03  | Signature             | VERIFY | -            |
+| 1     | Sender      | ERC-20        | 0x04  | approve(DEX, amount)  | SENDER | set          |
+| 2     | Sender      | DEX           | 0x00  | swap(...)             | SENDER | not set      |
 
 Frame 0 verifies the signature and calls `APPROVE(APPROVE_PAYMENT_AND_EXECUTION)`. Frames 1 and 2 form an atomic batch: if the swap in frame 2 reverts, the ERC-20 approval from frame 1 is also reverted, preventing the account from being left with a dangling approval.
 
 #### Example 3: Sponsored Transaction (Fee Payment in ERC-20)
 
-| Frame | Caller      | Target        | Data                   | Mode    |
-| ----- | ----------- | ------------- | ---------------------- | ------- |
-| 0     | ENTRY_POINT | Null (sender) | Signature              | VERIFY  |
-| 1     | ENTRY_POINT | Sponsor       | Sponsor data           | VERIFY  |
-| 2     | Sender      | ERC-20        | transfer(Sponsor,fees) | SENDER  |
-| 3     | Sender      | Target addr   | Call data              | SENDER  |
-| 4     | ENTRY_POINT | Sponsor       | Post op call           | DEFAULT |
+| Frame | Caller      | Target        | Flags | Data                   | Mode    |
+| ----- | ----------- | ------------- | ----- | ---------------------- | ------- |
+| 0     | ENTRY_POINT | Null (sender) | 0x02  | Signature              | VERIFY  |
+| 1     | ENTRY_POINT | Sponsor       | 0x01  | Sponsor data           | VERIFY  |
+| 2     | Sender      | ERC-20        | 0x00  | transfer(Sponsor,fees) | SENDER  |
+| 3     | Sender      | Target addr   | 0x00  | Call data              | SENDER  |
+| 4     | ENTRY_POINT | Sponsor       | 0x00  | Post op call           | DEFAULT |
 
 - Frame 0: Verifies signature and calls `APPROVE(APPROVE_EXECUTION)` to authorize execution from sender.
 - Frame 1: Checks that the user has enough ERC-20 tokens, and that the next frame is an ERC-20 send of the right size to the sponsor. Calls `APPROVE(APPROVE_PAYMENT)` to authorize payment.
@@ -856,12 +864,12 @@ Frame 0 verifies the signature and calls `APPROVE(APPROVE_PAYMENT_AND_EXECUTION)
 
 #### Example 4: EOA paying gas in ERC-20s
 
-| Frame | Caller      | Target        | Data                   | Mode    |
-| ----- | ----------- | ------------- | ---------------------- | ------- |
-| 0     | ENTRY_POINT | Null(sender)  | (0, v, r, s)           | VERIFY  |
-| 1     | ENTRY_POINT | Sponsor       | Sponsor signature      | VERIFY  |
-| 2     | Sender      | ERC-20        | transfer(Sponsor,fees) | SENDER  |
-| 3     | Sender      | Target addr   | Call data              | SENDER  |
+| Frame | Caller      | Target        | Flags | Data                   | Mode    |
+| ----- | ----------- | ------------- | ----- | ---------------------- | ------- |
+| 0     | ENTRY_POINT | Null(sender)  | 0x02  | (0, v, r, s)           | VERIFY  |
+| 1     | ENTRY_POINT | Sponsor       | 0x01  | Sponsor signature      | VERIFY  |
+| 2     | Sender      | ERC-20        | 0x00  | transfer(Sponsor,fees) | SENDER  |
+| 3     | Sender      | Target addr   | 0x00  | Call data              | SENDER  |
 
 - Frame 0: Verify the sender with a EOA signature.  Upon verification, the frame calls `APPROVE(APPROVE_EXECUTION)` to authorize execution.
 - Frame 1: Checks that the user has enough ERC-20 tokens, and that the next frame is an ERC-20 send of the right size to the sponsor. Calls `APPROVE(APPROVE_PAYMENT)` to authorize payment.
@@ -883,15 +891,17 @@ Frame 0 verifies the signature and calls `APPROVE(APPROVE_PAYMENT_AND_EXECUTION)
 | Max fee per blob gas              | 1     |
 | Blob versioned hashes (empty)     | 1     |
 | Frames wrapper                    | 1     |
+| Sender validation frame: mode     | 1     |
+| Sender validation frame: flags    | 1     |
 | Sender validation frame: target   | 1     |
 | Sender validation frame: gas      | 2     |
 | Sender validation frame: data     | 65    |
-| Sender validation frame: mode     | 1     |
+| Execution frame: mode             | 1     |
+| Execution frame: flags            | 1     |
 | Execution frame: target           | 1     |
 | Execution frame: gas              | 1     |
 | Execution frame: data             | 20+5  |
-| Execution frame: mode             | 1     |
-| **Total**                         | 134   |
+| **Total**                         | 136   |
 
 Notes: Nonce assumes < 65536 prior sends. Fees assume < 1099 gwei. Validation frame target is 1 byte because target is `tx.sender`. Validation gas assumes <= 65,536 gas. Calldata is 65 bytes for ECDSA signature. Blob fields assume no blobs (empty list, zero max fee).
 
@@ -901,11 +911,12 @@ This is not much larger than an EIP-1559 transaction; the extra overhead is the 
 
 | Field                      | Bytes |
 | -------------------------- | ----- |
+| Deployment frame: mode     | 1     |
+| Deployment frame: flags    | 1     |
 | Deployment frame: target   | 20    |
 | Deployment frame: gas      | 3     |
 | Deployment frame: data     | 100   |
-| Deployment frame: mode     | 1     |
-| **Total additional**       | 124   |
+| **Total additional**       | 125   |
 
 Notes: Gas assumes cost < 2^24. Calldata assumes small proxy.
 
@@ -913,19 +924,22 @@ Notes: Gas assumes cost < 2^24. Calldata assumes small proxy.
 
 | Field                                | Bytes |
 | ------------------------------------ | ----- |
-| Sponsor validation frame: target   | 20    |
-| Sponsor validation frame: gas      | 3     |
-| Sponsor validation frame: calldata | 0     |
-| Sponsor validation frame: mode     | 1     |
-| Send to sponsor frame: target      | 20    |
-| Send to sponsor frame: gas         | 3     |
-| Send to sponsor frame: calldata    | 68    |
-| Send to sponsor frame: mode        | 1     |
-| Sponsor post op frame: target      | 20    |
-| Sponsor post op frame: gas         | 3     |
-| Sponsor post op frame: calldata    | 0     |
-| Sponsor post op frame: mode        | 2     |
-| **Total additional**               | 141   |
+| Sponsor validation frame: mode       | 1     |
+| Sponsor validation frame: flags      | 1     |
+| Sponsor validation frame: target     | 20    |
+| Sponsor validation frame: gas        | 3     |
+| Sponsor validation frame: calldata   | 0     |
+| Send to sponsor frame: mode          | 1     |
+| Send to sponsor frame: flags         | 1     |
+| Send to sponsor frame: target        | 20    |
+| Send to sponsor frame: gas           | 3     |
+| Send to sponsor frame: calldata      | 68    |
+| Sponsor post op frame: mode          | 2     |
+| Sponsor post op frame: flags         | 1     |
+| Sponsor post op frame: target        | 20    |
+| Sponsor post op frame: gas           | 3     |
+| Sponsor post op frame: calldata      | 0     |
+| **Total additional**                 | 144   |
 
 Notes: Sponsor can read info from other fields. ERC-20 transfer call is 68 bytes.
 

--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -806,10 +806,10 @@ Note that users can use any EOA as a paymaster thanks to the [default code](#def
 
 #### Example 1: Simple Transaction
 
-| Frame | Caller         | Target        | Flags | Data      | Mode         |
-| ----- | -------------- | ------------- | ----- | --------- | ------------ |
-| 0     | ENTRY_POINT    | Null (sender) | 0x03  | Signature | VERIFY       |
-| 1     | Sender         | Target        | 0x00  | Call data | SENDER       |
+| Frame | Caller      | Target        | Flags                          | Data      | Mode   |
+| ----- | ----------- | ------------- | ------------------------------ | --------- | ------ |
+| 0     | ENTRY_POINT | Null (sender) | APPROVE_PAYMENT_AND_EXECUTION  | Signature | VERIFY |
+| 1     | Sender      | Target        | APPROVE_SCOPE_NONE             | Call data | SENDER |
 
 Frame 0 verifies the signature and calls `APPROVE(APPROVE_PAYMENT_AND_EXECUTION)` to approve both payment and execution. Frame 1 executes and exits normally via `RETURN`.
 
@@ -820,10 +820,10 @@ The mempool can process this transaction with the following static validation an
 
 #### Example 1a: Simple ETH transfer
 
-| Frame | Caller         | Target        | Flags | Data               | Mode         |
-| ----- | -------------- | ------------- | ----- | ------------------ | ------------ |
-| 0     | ENTRY_POINT    | Null (sender) | 0x03  | Signature          | VERIFY       |
-| 1     | Sender         | Null (sender) | 0x00  | Destination/Amount | SENDER       |
+| Frame | Caller      | Target        | Flags                         | Data               | Mode   |
+| ----- | ----------- | ------------- | ----------------------------- | ------------------ | ------ |
+| 0     | ENTRY_POINT | Null (sender) | APPROVE_PAYMENT_AND_EXECUTION | Signature          | VERIFY |
+| 1     | Sender      | Null (sender) | APPROVE_SCOPE_NONE            | Destination/Amount | SENDER |
 
 A simple transfer is performed by instructing the account to send ETH to the destination account. This requires two frames for mempool compatibility, since the validation phase of the transaction has to be static.
 
@@ -831,11 +831,11 @@ This is listed here to illustrate why the transaction type has no built-in value
 
 #### Example 1b: Simple account deployment
 
-| Frame | Caller       | Target        | Flags | Data               | Mode    |
-| ----- | ------------ | ------------- | ----- | ------------------ | ------- |
-| 0     | ENTRY_POINT  | Deployer      | 0x00  | Initcode, Salt     | DEFAULT |
-| 1     | ENTRY_POINT  | Null (sender) | 0x03  | Signature          | VERIFY  |
-| 2     | Sender       | Null (sender) | 0x00  | Destination/Amount | SENDER  |
+| Frame | Caller      | Target        | Flags                         | Data               | Mode    |
+| ----- | ----------- | ------------- | ----------------------------- | ------------------ | ------- |
+| 0     | ENTRY_POINT | Deployer      | APPROVE_SCOPE_NONE            | Initcode, Salt     | DEFAULT |
+| 1     | ENTRY_POINT | Null (sender) | APPROVE_PAYMENT_AND_EXECUTION | Signature          | VERIFY  |
+| 2     | Sender      | Null (sender) | APPROVE_SCOPE_NONE            | Destination/Amount | SENDER  |
 
 This example illustrates the initial deployment flow for a smart account at the `sender` address. Since the address needs to have code in order to validate the transaction, the transaction must deploy the code before verification.
 
@@ -843,23 +843,23 @@ The first frame would call the [EIP-7997](./eip-7997.md) deterministic factory p
 
 #### Example 2: Atomic Approve + Swap
 
-| Frame | Caller      | Target        | Flags | Data                  | Mode   | Atomic Batch |
-| ----- | ----------- | ------------- | ----- | --------------------- | ------ | ------------ |
-| 0     | ENTRY_POINT | Null (sender) | 0x03  | Signature             | VERIFY | -            |
-| 1     | Sender      | ERC-20        | 0x04  | approve(DEX, amount)  | SENDER | set          |
-| 2     | Sender      | DEX           | 0x00  | swap(...)             | SENDER | not set      |
+| Frame | Caller      | Target        | Flags                                    | Data                 | Mode   |
+| ----- | ----------- | ------------- | ---------------------------------------- | -------------------- | ------ |
+| 0     | ENTRY_POINT | Null (sender) | APPROVE_PAYMENT_AND_EXECUTION            | Signature            | VERIFY |
+| 1     | Sender      | ERC-20        | ATOMIC_BATCH_FLAG                        | approve(DEX, amount) | SENDER |
+| 2     | Sender      | DEX           | APPROVE_SCOPE_NONE                       | swap(...)            | SENDER |
 
 Frame 0 verifies the signature and calls `APPROVE(APPROVE_PAYMENT_AND_EXECUTION)`. Frames 1 and 2 form an atomic batch: if the swap in frame 2 reverts, the ERC-20 approval from frame 1 is also reverted, preventing the account from being left with a dangling approval.
 
 #### Example 3: Sponsored Transaction (Fee Payment in ERC-20)
 
-| Frame | Caller      | Target        | Flags | Data                   | Mode    |
-| ----- | ----------- | ------------- | ----- | ---------------------- | ------- |
-| 0     | ENTRY_POINT | Null (sender) | 0x02  | Signature              | VERIFY  |
-| 1     | ENTRY_POINT | Sponsor       | 0x01  | Sponsor data           | VERIFY  |
-| 2     | Sender      | ERC-20        | 0x00  | transfer(Sponsor,fees) | SENDER  |
-| 3     | Sender      | Target addr   | 0x00  | Call data              | SENDER  |
-| 4     | ENTRY_POINT | Sponsor       | 0x00  | Post op call           | DEFAULT |
+| Frame | Caller      | Target        | Flags              | Data                   | Mode    |
+| ----- | ----------- | ------------- | ------------------ | ---------------------- | ------- |
+| 0     | ENTRY_POINT | Null (sender) | APPROVE_EXECUTION  | Signature              | VERIFY  |
+| 1     | ENTRY_POINT | Sponsor       | APPROVE_PAYMENT    | Sponsor data           | VERIFY  |
+| 2     | Sender      | ERC-20        | APPROVE_SCOPE_NONE | transfer(Sponsor,fees) | SENDER  |
+| 3     | Sender      | Target addr   | APPROVE_SCOPE_NONE | Call data              | SENDER  |
+| 4     | ENTRY_POINT | Sponsor       | APPROVE_SCOPE_NONE | Post op call           | DEFAULT |
 
 - Frame 0: Verifies signature and calls `APPROVE(APPROVE_EXECUTION)` to authorize execution from sender.
 - Frame 1: Checks that the user has enough ERC-20 tokens, and that the next frame is an ERC-20 send of the right size to the sponsor. Calls `APPROVE(APPROVE_PAYMENT)` to authorize payment.
@@ -869,12 +869,12 @@ Frame 0 verifies the signature and calls `APPROVE(APPROVE_PAYMENT_AND_EXECUTION)
 
 #### Example 4: EOA paying gas in ERC-20s
 
-| Frame | Caller      | Target        | Flags | Data                   | Mode    |
-| ----- | ----------- | ------------- | ----- | ---------------------- | ------- |
-| 0     | ENTRY_POINT | Null(sender)  | 0x02  | (0, v, r, s)           | VERIFY  |
-| 1     | ENTRY_POINT | Sponsor       | 0x01  | Sponsor signature      | VERIFY  |
-| 2     | Sender      | ERC-20        | 0x00  | transfer(Sponsor,fees) | SENDER  |
-| 3     | Sender      | Target addr   | 0x00  | Call data              | SENDER  |
+| Frame | Caller      | Target       | Flags              | Data                   | Mode   |
+| ----- | ----------- | ------------ | ------------------ | ---------------------- | ------ |
+| 0     | ENTRY_POINT | Null(sender) | APPROVE_EXECUTION  | (0, v, r, s)          | VERIFY |
+| 1     | ENTRY_POINT | Sponsor      | APPROVE_PAYMENT    | Sponsor signature      | VERIFY |
+| 2     | Sender      | ERC-20       | APPROVE_SCOPE_NONE | transfer(Sponsor,fees) | SENDER |
+| 3     | Sender      | Target addr  | APPROVE_SCOPE_NONE | Call data              | SENDER |
 
 - Frame 0: Verify the sender with a EOA signature.  Upon verification, the frame calls `APPROVE(APPROVE_EXECUTION)` to authorize execution.
 - Frame 1: Checks that the user has enough ERC-20 tokens, and that the next frame is an ERC-20 send of the right size to the sponsor. Calls `APPROVE(APPROVE_PAYMENT)` to authorize payment.

--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -29,7 +29,7 @@ In doing so, it realizes the original vision of account abstraction: unlinking a
 |---------------------------|-----------------|
 | `FRAME_TX_TYPE`           | `0x06`          |
 | `FRAME_TX_INTRINSIC_COST` | `15000`         |
-| `FRAME_TX_PER_FRAME_COST` | `1000`          |
+| `FRAME_TX_PER_FRAME_COST` | `475`           |
 | `ENTRY_POINT`             | `address(0xaa)` |
 | `MAX_FRAMES`              | `64`            |
 
@@ -43,7 +43,7 @@ In doing so, it realizes the original vision of account abstraction: unlinking a
 | `TXPARAM`       | `0xb0` |
 | `FRAMEDATALOAD` | `0xb1` |
 | `FRAMEDATACOPY` | `0xb2` |
-| `FRAMEINFO`     | `0xb3` |
+| `FRAMEPARAM`    | `0xb3` |
 
 ### New Transaction Type
 
@@ -262,7 +262,7 @@ Notes:
 - `0x07` returns only the number of blob versioned hashes. Individual blob versioned hashes remain accessible via the existing `BLOBHASH(index)` opcode.
 - Invalid `param` values (not defined in the table above) result in an exceptional halt.
 
-#### `FRAMEINFO` opcode
+#### `FRAMEPARAM` opcode
 
 This opcode gives access to frame-scoped information. The gas cost of this operation is `2`.
 
@@ -377,7 +377,7 @@ Note:
 When using frame transactions with EOAs that have neither code nor an [EIP-7702](./eip-7702.md) delegation indicator, they are treated as if they have a "default code." Accounts with code, including [EIP-7702](./eip-7702.md) delegated accounts, do not use the default code path. This spec describes only the behavior of the default code; clients are free to implement the default code however they want, so long as they correspond to the behavior specified here.
 
 - Let `resolved_target = frame.target if frame.target is not null else tx.sender`.
-- Retrieve the current frame's `mode` with `FRAMEINFO`.
+- Retrieve the current frame's `mode` with `FRAMEPARAM`.
 - If `mode` is `VERIFY`:
   - Read the allowed approval scope from the flags field: `allowed_scope = frame.flags & APPROVE_SCOPE_MASK`. If `allowed_scope == APPROVE_SCOPE_NONE`, revert.
   - If `allowed_scope & APPROVE_EXECUTION != 0` and `resolved_target != tx.sender`, revert.
@@ -428,7 +428,7 @@ P256_ADDRESS_DOMAIN = b"\x01"
 SECP256K1N_DIV_2 = 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0
 
 def default_code(frame, tx):
-    mode = frame.mode                        # equivalent to FRAMEINFO(0x02, TXPARAM(0x0A))
+    mode = frame.mode                        # equivalent to FRAMEPARAM(0x02, TXPARAM(0x0A))
     resolved_target = frame.target if frame.target is not None else tx.sender
 
     if mode == VERIFY:
@@ -781,6 +781,10 @@ Atomic batching allows multiple `SENDER` frames to be grouped into a single all-
 
 Using a flag to indicate atomic batches saves us from having to introduce a new mode. Batches are identified purely by consecutive `SENDER` frames with the flag set, terminated by a `SENDER` frame without it. This design enables consecutive atomic batches since the batch boundary is clearly indicated by the `SENDER` frame without the flag.
 
+### Per-frame cost
+
+Each frame incurs a fixed CALL execution-context overhead (100) plus `G_log` (375) for the receipt sub-entry it produces, giving `FRAME_TX_PER_FRAME_COST = 475`. The execution-context component covers context setup, mode dispatch, and gas accounting at the frame boundary, analogous to the fixed overhead of a CALL. The `G_log` component covers the `[status, gas_used, logs]` receipt sub-entry that each frame adds to the transaction receipt, which must be serialized, hashed into the receipt trie, and proven by ZK-EVM implementations. Cold/warm access costs for the frame's target account are charged within the frame's own `gas_limit` through the normal EVM warm/cold accounting, not through the per-frame cost.
+
 ### No value in frame
 
 It is not required because the account code can send value.
@@ -980,7 +984,7 @@ Because `tx.sender` is explicit in the transaction envelope, an attacker can sub
 
 #### Cross-Frame Data Visibility During Validation
 
-`FRAMEINFO`, `FRAMEDATALOAD`, and `FRAMEDATACOPY` allow validation code to inspect other frames, including later `SENDER` frames. As a result, paymasters and other `VERIFY` frames can observe user operation parameters before approval and may condition their behavior on that information. Users should therefore treat non-`VERIFY` frame data as visible to validation logic and should not rely on untrusted paymasters or verifiers to keep such data private.
+`FRAMEPARAM`, `FRAMEDATALOAD`, and `FRAMEDATACOPY` allow validation code to inspect other frames, including later `SENDER` frames. As a result, paymasters and other `VERIFY` frames can observe user operation parameters before approval and may condition their behavior on that information. Users should therefore treat non-`VERIFY` frame data as visible to validation logic and should not rely on untrusted paymasters or verifiers to keep such data private.
 
 ##### Mitigations
 

--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -260,6 +260,7 @@ Notes:
 - `0x01` has a possible future extension to allow indices for multidimensional nonces.
 - `0x03` and `0x04` have a possible future extension to allow indices for multidimensional gas.
 - `0x07` returns only the number of blob versioned hashes. Individual blob versioned hashes remain accessible via the existing `BLOBHASH(index)` opcode.
+- `0x08` returns the canonical signature hash. This value MUST be computed at most once per transaction and cached.
 - Invalid `param` values (not defined in the table above) result in an exceptional halt.
 
 #### `FRAMEPARAM` opcode

--- a/assets/eip-8141/CanonicalPaymaster.sol
+++ b/assets/eip-8141/CanonicalPaymaster.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.24;
 /// @dev VERIFY frame calldata is expected to be exactly:
 ///      r (32 bytes) || s (32 bytes) || v (1 byte)
 ///      The signature is checked against TXPARAM(0x08), i.e. the canonical tx sig hash.
-///      On success, the contract calls APPROVE(0x1) to approve payment.
+///      On success, the contract calls APPROVE with scope=0x1 and offset/length=0 to approve payment.
 ///      This implementation supports only a single secp256k1 signer recovered via ecrecover.
 ///      ERC-1271 and other contract-signature schemes are not supported.
 contract CanonicalPaymaster {

--- a/assets/eip-8141/CanonicalPaymaster.sol
+++ b/assets/eip-8141/CanonicalPaymaster.sol
@@ -4,8 +4,10 @@ pragma solidity ^0.8.24;
 /// @notice Minimal canonical paymaster for EIP-8141-style frame transactions.
 /// @dev VERIFY frame calldata is expected to be exactly:
 ///      r (32 bytes) || s (32 bytes) || v (1 byte)
-///      The signature is checked against TXPARAM(0x08, 0), i.e. the canonical tx sig hash.
+///      The signature is checked against TXPARAM(0x08), i.e. the canonical tx sig hash.
 ///      On success, the contract calls APPROVE(0x1) to approve payment.
+///      This implementation supports only a single secp256k1 signer recovered via ecrecover.
+///      ERC-1271 and other contract-signature schemes are not supported.
 contract CanonicalPaymaster {
     uint256 public constant WITHDRAWAL_DELAY = 12 hours;
 
@@ -15,6 +17,7 @@ contract CanonicalPaymaster {
 
     // Stored in contract storage instead of immutable so the deployed runtime code
     // is identical across all instances and can be recognized canonically by code match.
+    // This is the authorized secp256k1 signer address, not a generic contract-signature authority.
     address public owner;
 
     address payable public pendingWithdrawalTo;
@@ -96,8 +99,8 @@ contract CanonicalPaymaster {
 
     function _txSigHash() internal returns (bytes32 sigHash) {
         assembly {
-            // TXPARAM(0x08, 0) -> canonical frame transaction signature hash
-            sigHash := verbatim_0i_1o(hex"60006008b0")
+            // TXPARAM(0x08) -> canonical frame transaction signature hash
+            sigHash := verbatim_0i_1o(hex"6008b0")
         }
     }
 


### PR DESCRIPTION
## Summary
This PR tightens `EIP-8141` spec. It focuses on making the frame model, approval semantics, default-code behavior, and public-mempool rules more explicit and internally consistent.

## Main changes
- Split the packed frame `mode` field into `mode` + `flags`, add `FRAMEPARAM`, and introduce an explicit `resolved_target` used consistently throughout execution.
- Fix `APPROVE`/`VERIFY` semantics: define approval scopes as a bitmask, align the public-mempool prefixes, make the `VERIFY`/`STATICCALL` carve-out explicit, clarify that payment scopes collect `TXPARAM(0x06)`, and allow third-party EOA paymasters in the default-code path.
- Harden the default secp256k1 and P256 paths: low-`s` enforcement, reject failed `ecrecover`, add P256 address-domain separation, and require `P256VERIFY` to reject invalid public keys.
- Tighten limits and accounting: reduce `MAX_FRAMES` to `64`, add `FRAME_TX_PER_FRAME_COST`, bound frame gas totals, and clarify gas semantics for `FRAMEDATACOPY` and `TXPARAM`/blob access.
- Lock deterministic deployment to `EIP-7997` and make the `EIP-7702` interaction explicit.
- Add stronger warnings around `VERIFY`-data malleability, `DELEGATECALL` + `APPROVE`, deploy-frame front-running, explicit-sender state-read amplification, and validation-time cross-frame data visibility.
- Update the canonical paymaster helper to use `TXPARAM(0x08)` and clarify that the current canonical implementation is single-signer secp256k1 only.

## Files
- `EIPS/eip-8141.md`
- `assets/eip-8141/CanonicalPaymaster.sol`