### PR TITLE
Update EIP-8037: clarify spillover state gas still increments execution_state_gas_used

### DIFF
--- a/EIPS/eip-8037.md
+++ b/EIPS/eip-8037.md
@@ -108,7 +108,7 @@ state_gas_reservoir = execution_gas - gas_left
 The `state_gas_reservoir` holds gas that exceeds the [EIP-7825](./eip-7825.md)'s budget. The two counters operate as follows:
 
 - **Regular gas** charges deduct from `gas_left` only.
-- **State gas** charges deduct from `state_gas_reservoir` first; when the reservoir is exhausted, from `gas_left`.
+- **State gas** charges deduct from `state_gas_reservoir` first; when the reservoir is exhausted, from `gas_left`. The charge increments `execution_state_gas_used` by its full amount regardless of whether it was satisfied from the reservoir, from `gas_left`, or partially from both; a state gas charge never increments `execution_regular_gas_used`.
 - When an opcode requires both regular and state gas, the regular gas charge MUST be applied first. If the regular gas charge triggers an out-of-gas error, the state gas charge is not applied.
 - The `GAS` opcode returns `gas_left` only (excluding the reservoir).
 - The reservoir is passed **in full** to child frames (no 63/64 rule). On child success, the remaining `state_gas_reservoir` is returned to the parent. On child **revert** or **exceptional halt**, all state gas consumed by the child, both from the reservoir and any that spilled into `gas_left`, is restored to the parent's reservoir. On child **exceptional halt**, only `gas_left` is consumed (zeroed). State gas is fully preserved on failure because state changes are reverted, so no state was actually grown.


### PR DESCRIPTION
## Summary

Clarify that when a state gas charge exceeds `state_gas_reservoir` and spills into `gas_left`, the charge still increments `execution_state_gas_used` in full — it does **not** increment `execution_regular_gas_used`. Counter classification is by cost type, not funding source.

## Motivation

Discovered during bal-devnet-3 debugging. Three EL clients diverged on the same block because they disagreed on which counter a spilled state-gas charge increments:

- geth: increments `execution_state_gas_used` (matches EELS `charge_state_gas` in `forks/amsterdam/vm/gas.py`).
- erigon / reth / nethermind: incremented `execution_regular_gas_used` (read line 117 as "costs that were paid from the regular budget count toward regular gas").

Since `block_gas_used = max(cum_regular_gas_used, cum_state_gas_used)`, the two interpretations produce block totals that differ by exactly the spilled amount (e.g. `131,488` = `112 × cpsb` for a single `GAS_NEW_ACCOUNT` at 100M gas limit), splitting the chain.

The current paragraph at line 117 already implies the EELS / geth behaviour but does not state it explicitly. Adding one sentence at line 111, where spillover is introduced, removes the ambiguity at the point readers are most likely to lose the invariant.

## Scope

Purely a clarification — no semantic change. Disjoint from:

- #11468 / #11476 — restoration behaviour on frame failure (touch line 114, leave line 111 untouched).
- #11503 — tx inclusion validity condition.
- merged #11328 / #11421 / #11414 — reservoir mechanics, regular-first ordering, EIP-7928 phase alignment (none introduced the spillover-classification rule).

EELS already implements this behaviour in `charge_state_gas` (`src/ethereum/forks/amsterdam/vm/gas.py`):

```python
if evm.state_gas_left >= amount:
    evm.state_gas_left -= amount
elif evm.state_gas_left + evm.gas_left >= amount:
    remainder = amount - evm.state_gas_left
    evm.state_gas_left = Uint(0)
    evm.gas_left -= remainder
else:
    raise OutOfGasError

evm.state_gas_used += amount  # full amount, regardless of source
```

This PR brings the EIP text in line with the reference implementation.