### PR TITLE
Update EIP-8037: more clarifcations for state gas accounting

### DIFF
--- a/EIPS/eip-8037.md
+++ b/EIPS/eip-8037.md
@@ -187,11 +187,15 @@ The net cost after refund is `GAS_WARM_ACCESS` (100), consistent with pre-[EIP-8
 
 ### Revert behavior for state gas
 
-State gas charged for account creation (`CREATE`, `CALL` to new account, and EOA delegation) is consumed even if the frame reverts — state changes are rolled back but gas is not refunded. This is consistent with pre-[EIP-8037](./eip-8037.md) behavior where `GAS_NEW_ACCOUNT` was consumed on revert.
+State gas charged for account creation (`CREATE`, `CALL` to new account, and EOA delegation) is consumed even if the immediate child frame created by the opcode reverts; state changes are rolled back but gas is not refunded. This applies only at the boundary between the opcode and its child frame. If the frame that executed the opcode itself later reverts, normal child frame state gas restoration applies. This is consistent with pre-[EIP-8037](./eip-8037.md) behavior where `GAS_NEW_ACCOUNT` was consumed on revert.
+
+The account-creation state gas charge is unconditional: it is consumed even when `CREATE`/`CREATE2` fails silently (insufficient balance, nonce overflow, stack depth limit, or address collision) without spawning a child frame. The charge is applied at the opcode level before the failure checks, consistent with the pay-before-execute model and pre-[EIP-8037](./eip-8037.md) behavior.
+
+When a contract is created and then destroyed via `SELFDESTRUCT` within the same transaction ([EIP-6780](./eip-6780.md)), the account-creation state gas is not refunded despite the net state change being zero. No `SELFDESTRUCT` gas refund mechanism exists post-London ([EIP-3529](./eip-3529.md)). A subsequent `CALL` with value to the destroyed address does not charge `GAS_NEW_ACCOUNT` because `is_account_alive` returns true during execution; actual account deletion is deferred to the end of the transaction.
 
 #### [EIP-2780](./eip-2780.md) authorizations
 
-For [EIP-7702](./eip-7702.md) authorizations, the intrinsic state gas assumes account creation for each authorization: `(112 + 23) × cost_per_state_byte` per authorization. When an authorization targets an existing account (no account creation needed), the `112 × cost_per_state_byte` portion is refunded to `state_gas_reservoir` and subtracted from `intrinsic_state_gas` during authorization processing, before state changes begin. The `intrinsic_state_gas` adjustment is required so that `tx_state_gas = intrinsic_state_gas + execution_state_gas_used` does not double count the refunded gas.
+For [EIP-7702](./eip-7702.md) authorizations, the intrinsic state gas assumes account creation for each authorization: `(112 + 23) × cost_per_state_byte` per authorization. When an authorization targets an existing account (no account creation needed), the `112 × cost_per_state_byte` portion is refunded to `state_gas_reservoir` and subtracted from `intrinsic_state_gas` during authorization processing, before state changes begin. The `intrinsic_state_gas` adjustment is required so that `tx_state_gas = intrinsic_state_gas + execution_state_gas_used` does not double count the refunded gas. Note that this mutates `intrinsic_state_gas` during execution, which is architecturally unusual as intrinsic gas is typically a static pre-execution value. This approach is chosen over the `refund_counter` pattern to avoid the 20% refund cap and to apply the refund immediately rather than deferring it to end-of-transaction accounting.
 
 #### Receipt semantics
 


### PR DESCRIPTION
## Summary

Consolidates points 3-6, from @misilva73's [state gas accounting review](https://github.com/misilva73/evm-gas-repricings/blob/main/reports/eip-8037/spec_review_state_gas_accounting.md). It would be good to align on these as we close devnet-3, leaving 1/2 discussions for devnet-4.

Note these are clarifactions to the EIP text of what the current spec in EELS does.

## Changes

**Point 3 (silent CREATE failures)**: Documents that the account-creation state gas charge is unconditional, consumed even on silent failures (insufficient balance, nonce overflow, stack depth, address collision) without spawning a child frame. Consistent with the pay-before-execute model.

**Point 4 (SELFDESTRUCT same-TX no refund)**: Documents that CREATE state gas is not refunded when the account is destroyed via SELFDESTRUCT in the same transaction (EIP-6780). No SELFDESTRUCT gas refund exists post-London (EIP-3529).

**Point 5 (CALL to self-destructed account)**: Documents that a CALL with value to a same-TX self-destructed account does not charge `GAS_NEW_ACCOUNT` where the actual deletion is deferred to end of transaction.

**Point 6 (mutable intrinsic_state_gas)**: Documents the EIP-7702 authorization `intrinsic_state_gas` mutation as a deliberate design choice over the `refund_counter` pattern, to avoid the 20% cap and apply the refund immediately.

Extra clarification: **Revert boundary clarification**: "the frame" now reads "the immediate child frame created by the opcode." If the frame that executed the opcode itself later reverts, normal child frame state gas restoration applies.

### Tests

Tests for these cases are all included here: ethereum/execution-specs#2639
Or already exist!

