### PR TITLE
Update EIP-8070: Rename protocol version to eth/72 and fix typos

### DIFF
--- a/EIPS/eip-8070.md
+++ b/EIPS/eip-8070.md
@@ -50,7 +50,7 @@ Responses now elide blob payloads for type 3 transactions requested via this RPC
 
 - `eth/72`: `[[hash_0: B_32, hash_1: B_32, ...], cell_mask: B_16]`
 
-**New message type `Cells` (`0x13`).** Used to respond to a `GetCells` requests.
+**New message type `Cells` (`0x15`).** Used to respond to a `GetCells` requests.
 
 - `eth/72`: `[[hash_0: B_32, hash_1: B_32, ...], cells: [[cell_0_0: B_2048, cell_0_1: B_2048, ...], [cell_1_0: B_2048, cell_1_1: B_2048, ...]], cell_mask: B_16]`
 

--- a/EIPS/eip-8070.md
+++ b/EIPS/eip-8070.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: Networking
 created: 2025-10-29
-requires: 4844, 7594, 7870
+requires: 4844, 7594, 7870, 8159
 ---
 
 ## Abstract

--- a/EIPS/eip-8070.md
+++ b/EIPS/eip-8070.md
@@ -46,7 +46,7 @@ Add a new field `cell_mask` of type `B_16` (`uint128`). This field MUST be inter
 **Modify `GetPooledTransactions` (`0x09`) / `PooledTransactions` (`0x10`) behaviour.**
 Responses now elide blob payloads for type 3 transactions requested via this RPC. This is performed by setting an RLP `nil` literal in the list position corresponding to the transaction's blob data. Cell proofs and commitments are unaffected and continue to be sent.
 
-**New message type `GetCells` (`0x12`).** Used to request cells for type 3 transactions. It specifies the transaction hashes being requested, along with a `cell_mask` specifying which cell indices are needed, with syntax identical as `cell_mask` in `NewPooledTransactionHashes`.
+**New message type `GetCells` (`0x14`).** Used to request cells for type 3 transactions. It specifies the transaction hashes being requested, along with a `cell_mask` specifying which cell indices are needed, with syntax identical as `cell_mask` in `NewPooledTransactionHashes`.
 
 - `eth/72`: `[[hash_0: B_32, hash_1: B_32, ...], cell_mask: B_16]`
 

--- a/EIPS/eip-8070.md
+++ b/EIPS/eip-8070.md
@@ -35,24 +35,24 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ### Execution clients :: devp2p changes
 
-We introduce a new devp2p protocol version, `eth/71` extending the existing `eth/70` protocol (TODO: spec for eth/70 missing).
+We introduce a new devp2p protocol version, `eth/72` extending the existing `eth/70` protocol (TODO: spec for eth/70 missing).
 
 **Modify `NewPooledTransactionHashes` (`0x08`) message.**
-Add a new field `cell_mask` of type `B_16` (`uint128`). This field MUST be interpreted as a bitarray of length `CELLS_PER_EXT_BLOB`, carrying `1` in the indices of colums the announcer has available for **all type 3 txs announced within the message**. This field MUST be set to `nil` when no transactions of such type are announced. (TODO: this approach is not expressive enough if the node wants to offer randomly sampled columns, nor if it wants to announce transactions with full and partial availability in a single message).
+Add a new field `cell_mask` of type `B_16` (`uint128`). This field MUST be interpreted as a bitarray of length `CELLS_PER_EXT_BLOB`, carrying `1` in the indices of columns the announcer has available for **all type 3 txs announced within the message**. This field MUST be set to `nil` when no transactions of such type are announced. (TODO: this approach is not expressive enough if the node wants to offer randomly sampled columns, nor if it wants to announce transactions with full and partial availability in a single message).
 
 - old schema (`eth/70`): `[types: B, [size_0: P, size_1: P, ...], [hash_0: B_32, hash_1: B_32, ...]]`
-- new schema (`eth/71`): `[types: B, [size_0: P, size_1: P, ...], [hash_0: B_32, hash_1: B_32, ...], cell_mask: B_16]`
+- new schema (`eth/72`): `[types: B, [size_0: P, size_1: P, ...], [hash_0: B_32, hash_1: B_32, ...], cell_mask: B_16]`
 
 **Modify `GetPooledTransactions` (`0x09`) / `PooledTransactions` (`0x10`) behaviour.**
 Responses now elide blob payloads for type 3 transactions requested via this RPC. This is performed by setting an RLP `nil` literal in the list position corresponding to the transaction's blob data. Cell proofs and commitments are unaffected and continue to be sent.
 
 **New message type `GetCells` (`0x12`).** Used to request cells for type 3 transactions. It specifies the transaction hashes being requested, along with a `cell_mask` specifying which cell indices are needed, with syntax identical as `cell_mask` in `NewPooledTransactionHashes`.
 
-- `eth/71`: `[[hash_0: B_32, hash_1: B_32, ...], cell_mask: B_16]`
+- `eth/72`: `[[hash_0: B_32, hash_1: B_32, ...], cell_mask: B_16]`
 
 **New message type `Cells` (`0x13`).** Used to respond to a `GetCells` requests.
 
-- `eth/71`: `[[hash_0: B_32, hash_1: B_32, ...], cells: [[cell_0_0: B_2048, cell_0_1: B_2048, ...], [cell_1_0: B_2048, cell_1_1: B_2048, ...]], cell_mask: B_16]`
+- `eth/72`: `[[hash_0: B_32, hash_1: B_32, ...], cells: [[cell_0_0: B_2048, cell_0_1: B_2048, ...], [cell_1_0: B_2048, cell_1_1: B_2048, ...]], cell_mask: B_16]`
 
 ### Execution clients :: Blobpool behavior
 
@@ -75,7 +75,7 @@ Supernodes (nodes intending to fetch every blob payload in full) MUST load balan
 A sampler MAY drop a transaction if it has not observed sufficient network saturation (i.e., announcements from other peers for the same blob) within a defined period.
 
 **Continued sampling**
-Tenured transactions MAY be subject to resampling in other to test for liveness and confirm confidence of continued network-wide availability.
+Tenured transactions MAY be subject to resampling in order to test for liveness and confirm confidence of continued network-wide availability.
 
 ### Execution clients :: Local block builders
 
@@ -192,7 +192,7 @@ Evaluating for sensible values of $p$ and $k$ yields, where $D=50$ (Geth's defau
 
 ## Backwards Compatibility
 
-This EIP changes the `eth` protocol and requires rolling out a new version, `eth/71`. Supporting multiple versions of a wire protocol is possible. Rolling out a new version does not break older clients immediately, since they can keep using protocol version `eth/70`.
+This EIP changes the `eth` protocol and requires rolling out a new version, `eth/72`. Supporting multiple versions of a wire protocol is possible. Rolling out a new version does not break older clients immediately, since they can keep using protocol version `eth/70`.
 
 This EIP does not change consensus rules and does not strictly require a hard fork. We are assessing the gradual rollout possibilities. In the meantime, it is RECOMMENDED that this EIP be deployed within the context of a hard fork.
 
@@ -224,7 +224,7 @@ This simple mechanism reinforces key model assumptions (a provider is truly a pr
 
 ### No normative peer scoring
 
-An earlier design considered a peer scoring system to grade peers by tracking their statistical ratio of requests to announcements (leechiness vs. helpfulness). After careful consideration, we deemed this approached brittle and dropped the feature. Our rationale was that such mechanism would strongly encode assumptions and confine the system to conform to some modellic behaviour, thus reducing flexibility and resilience in the face of environmental changes, shocks, or unexpected/improbable events (properties that are crucial in open and permissionless systems). Instead, we defer to implementations to define their own local heuristics for peer disconnection, if any.
+An earlier design considered a peer scoring system to grade peers by tracking their statistical ratio of requests to announcements (leechiness vs. helpfulness). After careful consideration, we deemed this approach brittle and dropped the feature. Our rationale was that such mechanism would strongly encode assumptions and confine the system to conform to some modellic behaviour, thus reducing flexibility and resilience in the face of environmental changes, shocks, or unexpected/improbable events (properties that are crucial in open and permissionless systems). Instead, we defer to implementations to define their own local heuristics for peer disconnection, if any.
 
 ### devp2p message schema choices
 

--- a/EIPS/eip-8070.md
+++ b/EIPS/eip-8070.md
@@ -35,12 +35,12 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ### Execution clients :: devp2p changes
 
-We introduce a new devp2p protocol version, `eth/72` extending the existing `eth/70` protocol (TODO: spec for eth/70 missing).
+We introduce a new devp2p protocol version, `eth/72` extending the existing `eth/71` protocol.
 
 **Modify `NewPooledTransactionHashes` (`0x08`) message.**
 Add a new field `cell_mask` of type `B_16` (`uint128`). This field MUST be interpreted as a bitarray of length `CELLS_PER_EXT_BLOB`, carrying `1` in the indices of columns the announcer has available for **all type 3 txs announced within the message**. This field MUST be set to `nil` when no transactions of such type are announced. (TODO: this approach is not expressive enough if the node wants to offer randomly sampled columns, nor if it wants to announce transactions with full and partial availability in a single message).
 
-- old schema (`eth/70`): `[types: B, [size_0: P, size_1: P, ...], [hash_0: B_32, hash_1: B_32, ...]]`
+- old schema (`eth/71`): `[types: B, [size_0: P, size_1: P, ...], [hash_0: B_32, hash_1: B_32, ...]]`
 - new schema (`eth/72`): `[types: B, [size_0: P, size_1: P, ...], [hash_0: B_32, hash_1: B_32, ...], cell_mask: B_16]`
 
 **Modify `GetPooledTransactions` (`0x09`) / `PooledTransactions` (`0x10`) behaviour.**
@@ -192,7 +192,7 @@ Evaluating for sensible values of $p$ and $k$ yields, where $D=50$ (Geth's defau
 
 ## Backwards Compatibility
 
-This EIP changes the `eth` protocol and requires rolling out a new version, `eth/72`. Supporting multiple versions of a wire protocol is possible. Rolling out a new version does not break older clients immediately, since they can keep using protocol version `eth/70`.
+This EIP changes the `eth` protocol and requires rolling out a new version, `eth/72`. Supporting multiple versions of a wire protocol is possible. Rolling out a new version does not break older clients immediately, since they can keep using protocol version `eth/71`.
 
 This EIP does not change consensus rules and does not strictly require a hard fork. We are assessing the gradual rollout possibilities. In the meantime, it is RECOMMENDED that this EIP be deployed within the context of a hard fork.
 


### PR DESCRIPTION
## Summary

- Renames the new devp2p protocol version introduced by EIP-8070 from `eth/71` to `eth/72`. `eth/71` is already claimed by [EIP-8159](./eip-8159.md) (Block Access List Exchange), so EIP-8070 needs to bump to the next version to avoid a collision.
- Updates references to the predecessor protocol from `eth/70` to `eth/71` so the version sequence reads naturally (eth/71 → eth/72) instead of appearing to skip eth/71.
- Folds in typo fixes from the currently open typo PRs against EIP-8070:
  - `colums` → `columns`
  - `in other to` → `in order to`
  - `approached` → `approach`

## Supersedes

This PR rolls up the fixes from the following open PRs, which can now be closed:

- #10702 — Update EIP-8070: correct grammar in continued sampling section
- #10723 — Update EIP-8070: Fix typos
- #10731 — Update EIP-8070: Fix typos in EIP-8070 sampling section
- #11304 — Update EIP-8070: fix typo

## Test plan

- [ ] CI passes (EIP linter / markdown checks)
- [ ] No remaining `eth/71` references in eip-8070.md for the new protocol version
- [ ] Typo fixes from the four open PRs are all present

🤖 Generated with [Claude Code](https://claude.com/claude-code)