### PR TITLE
Update EIP-7976: clarify token abstraction

### DIFF
--- a/EIPS/eip-7976.md
+++ b/EIPS/eip-7976.md
@@ -37,6 +37,8 @@ Let `tokens_in_calldata = zero_bytes_in_calldata + nonzero_bytes_in_calldata * 4
 
 Let `floor_tokens_in_calldata = (zero_bytes_in_calldata + nonzero_bytes_in_calldata) * 4`.
 
+Equivalently, the floor cost is `64` gas per calldata byte (both zero and non-zero), since `TOTAL_COST_FLOOR_PER_TOKEN * 4 = 64`. The token abstraction is retained only for consistency with [EIP-7623](./eip-7623.md).
+
 Let `isContractCreation` be a boolean indicating the respective event.
 
 Let `execution_gas_used` be the gas used for EVM execution with the gas refund subtracted.

--- a/EIPS/eip-7981.md
+++ b/EIPS/eip-7981.md
@@ -33,6 +33,8 @@ Let `access_list_bytes` be the total byte count of addresses (20 bytes each) and
 
 Let `floor_tokens_in_access_list = access_list_bytes * 4`.
 
+Equivalently, the access list data is charged `64` gas per byte, which amounts to `1280` gas per address (20 bytes × 64) and `2048` gas per storage key (32 bytes × 64). The token abstraction is retained only for consistency with [EIP-7623](./eip-7623.md) and [EIP-7976](./eip-7976.md).
+
 The access list cost formula changes from [EIP-2930](./eip-2930.md) to include data cost:
 
 ```python


### PR DESCRIPTION
Clarify EIP-7976 and EIP-7981 by making the floor cost explicit as 64 gas per calldata/access-list byte (1280 gas per address, 2048 gas per storage key), noting the token abstraction is retained only for consistency with EIP-7623.