### PR TITLE
Update EIP-7701: Move to Withdrawn

### DIFF
--- a/EIPS/eip-7701.md
+++ b/EIPS/eip-7701.md
@@ -8,7 +8,7 @@ status: Withdrawn
 type: Standards Track
 category: Core
 created: 2024-05-01
-withdrawal-reason: Superseded by [EIP-8141: Frame Transaction](./eip-8141)
+withdrawal-reason: Superseded by [EIP-8141 Frame Transaction](./eip-8141)
 ---
 
 ## Abstract

--- a/EIPS/eip-7701.md
+++ b/EIPS/eip-7701.md
@@ -4,10 +4,11 @@ title: Native Account Abstraction
 description: Native Account Abstraction protocol, relying on a new transaction type and a family of opcodes
 author: Vitalik Buterin (@vbuterin), Yoav Weiss (@yoavw), Alex Forshtat (@forshtat), Dror Tirosh (@drortirosh), Shahaf Nacson (@shahafn)
 discussions-to: https://ethereum-magicians.org/t/eip-7701-native-account-abstraction/19893
-status: Stagnant
+status: Withdrawn
 type: Standards Track
 category: Core
 created: 2024-05-01
+withdrawal-reason: Superseded by [EIP-8141: Frame Transaction](./eip-8141)
 ---
 
 ## Abstract

--- a/EIPS/eip-7701.md
+++ b/EIPS/eip-7701.md
@@ -8,7 +8,7 @@ status: Withdrawn
 type: Standards Track
 category: Core
 created: 2024-05-01
-withdrawal-reason: Superseded by [EIP-8141 Frame Transaction](./eip-8141)
+withdrawal-reason: Superseded by EIP-8141
 ---
 
 ## Abstract


### PR DESCRIPTION
Updated the status of EIP-7701 to 'Withdrawn' and added a withdrawal reason.
