### PR TITLE
Website: show withdrawn reason

### DIFF
--- a/_includes/eiptable.html
+++ b/_includes/eiptable.html
@@ -29,6 +29,8 @@
           <td class="eipnum"><a href="{{page.url|relative_url}}">{{page.eip|xml_escape}}</a></td>
           {% if status == "Last Call" and page.last-call-deadline != undefined %}
             <td class="date">{{ page.last-call-deadline | xml_escape }}</td>
+          {% elsif status == "Withdrawn" %}
+            <td class="withdrawn-reason">{{ page.withdrawal-reason | xml_escape }}</td>
           {% endif %}
           <td class="title">{{page.title|xml_escape}}</td>
           <td class="author">{% include authorlist.html authors=page.author %}</td>


### PR DESCRIPTION
This PR fixes this problem on the site:

<img width="1083" height="270" alt="image" src="https://github.com/user-attachments/assets/5a6ecb1d-390e-4c9e-94b2-24cdeca1c44a" />

There seems to be a column missing and the data in the column is misaligned (withdrawal reason is not there)

After the PR:

<img width="1105" height="683" alt="image" src="https://github.com/user-attachments/assets/bb585a29-48fa-4c4e-8e97-946d121dc2ae" />
