### PR TITLE
Update EIP-8142: Make BiB modular

### DIFF
--- a/EIPS/eip-8142.md
+++ b/EIPS/eip-8142.md
@@ -98,9 +98,9 @@ These parameters are defined in EIP-4844 and related specs:
 
 **Summary:** The execution layer is modified in the following ways:
 
-- The ExecutionPayloadHeader now has a `payload_blob_count` field to track how many blobs are used for the execution payload data, enabling verification of the correct number of payload-blobs at the Engine API boundary.
-- `engine_getPayload` computes the payload-blobs when building a block, sets `payload_blob_count` in the ExecutionPayloadHeader, and returns the payload blobs (with their commitments and proofs) alongside type-3 transaction blobs in the response.
-- `engine_newPayload` takes the ExecutionPayload and before passing it to the EL STF, it computes the payload-blobs, checks that the amount of blobs needed is equal to the `payload_blob_count` value in the ExecutionPayloadHeader and verifies that the expected version hashes match.
+- The header now has a `payload_blob_count` field to track how many blobs are used for the execution payload data, enabling verification of the correct number of payload-blobs at the Engine API boundary.
+- `engine_getPayload` computes the payload-blobs when building a block, sets `payload_blob_count` in the header, and returns the payload blobs (with their commitments and proofs) alongside type-3 transaction blobs in the response.
+- `engine_newPayload` takes the ExecutionPayload and before passing it to the EL STF, it computes the payload-blobs, checks that the amount of blobs needed is equal to the `payload_blob_count` value in the header and verifies that the expected version hashes match.
 
 #### Referenced Helpers
 
@@ -222,9 +222,9 @@ def execution_payload_data_to_blobs(data: ExecutionPayloadData) -> List[Blob]:
 
     Encoding steps:
       1. bal_bytes = data.blockAccessList
-      2. transactions_bytes = RLP.encode(data.transactions)
+      2. txs_bytes = RLP.encode(data.transactions)
       3. Create 8-byte header: [4 bytes BAL length][4 bytes tx length]
-      4. payload_bytes = header + bal_bytes + transactions_bytes
+      4. payload_bytes = header + bal_bytes + txs_bytes
       5. return bytes_to_blobs(payload_bytes)
 
     The first blob will contain (in order):
@@ -238,15 +238,15 @@ def execution_payload_data_to_blobs(data: ExecutionPayloadData) -> List[Blob]:
     Note: blockAccessList is already RLP-encoded per EIP-7928. Transactions are RLP-encoded as a list.
     """
     bal_bytes = data.blockAccessList
-    transactions_bytes = RLP.encode(data.transactions)
+    txs_bytes = RLP.encode(data.transactions)
 
     # Create 8-byte header: [4 bytes BAL length][4 bytes tx length]
     bal_length = len(bal_bytes).to_bytes(4, 'little')
-    txs_length = len(transactions_bytes).to_bytes(4, 'little')
+    txs_length = len(txs_bytes).to_bytes(4, 'little')
     header = bal_length + txs_length
 
     # Combine header + data
-    payload_bytes = header + bal_bytes + transactions_bytes
+    payload_bytes = header + bal_bytes + txs_bytes
 
     return bytes_to_blobs(payload_bytes)
 ```
@@ -261,7 +261,7 @@ def blobs_to_execution_payload_data(blobs: List[Blob]) -> ExecutionPayloadData:
     Decoding steps:
       1. raw = blobs_to_bytes(blobs)
       2. Read 8-byte header: [4 bytes BAL length][4 bytes tx length]
-      3. Split into bal_bytes and transactions_bytes
+      3. Split into bal_bytes and txs_bytes
       4. return ExecutionPayloadData(blockAccessList, transactions)
     """
     # Extract raw bytes from blobs
@@ -273,10 +273,10 @@ def blobs_to_execution_payload_data(blobs: List[Blob]) -> ExecutionPayloadData:
 
     # Extract data portions
     bal_bytes = raw[8 : 8 + bal_length]
-    transactions_bytes = raw[8 + bal_length : 8 + bal_length + txs_length]
+    txs_bytes = raw[8 + bal_length : 8 + bal_length + txs_length]
 
     # Decode transactions
-    transactions = RLP.decode(transactions_bytes)
+    transactions = RLP.decode(txs_bytes)
 
     return ExecutionPayloadData(blockAccessList=bal_bytes, transactions=transactions)
 ```
@@ -321,11 +321,11 @@ class ExecutionPayloadData(Container):
 
 **Note:** This is not an SSZ Container - fields are RLP-encoded as described in the encoding functions. The `MAX_TRANSACTIONS_PER_PAYLOAD` bound is inherited from the ExecutionPayload field limit defined in the consensus specification.
 
-##### ExecutionPayloadHeader
+##### Header
 
-This EIP adds a new field to the `ExecutionPayloadHeader`:
+This EIP adds a new field to the header:
 
-- payload_blob_count : uint64
+- `payload_blob_count` : uint64
 
 Semantics:
 
@@ -368,24 +368,24 @@ def get_payload(payload_id: PayloadId) -> GetPayloadResponse:
     payload_blobs = execution_payload_data_to_blobs(payload_data)
     payload_blob_count = len(payload_blobs)
 
-    # 4. Set the count in the header
+    # 3. Set the count in the header
     payload.payload_blob_count = payload_blob_count
 
-    # 5. Compute blob commitments and cell proofs for payload blobs
+    # 4. Compute commitments and cell proofs for payload blobs
     payload_commitments = [blob_to_kzg_commitment(b) for b in payload_blobs]
     payload_versioned_hashes = [kzg_commitment_to_versioned_hash(c) for c in payload_commitments]
-    # Compute cells and cell proofs
+    # Cell proofs
     payload_cells_and_proofs = [compute_cells_and_kzg_proofs(b) for b in payload_blobs]
     payload_cell_proofs = [proofs for _, proofs in payload_cells_and_proofs]
 
-    # 6. Extract type-3 transaction blobs, commitments, and cell proofs
+    # 5. Extract type-3 transaction blobs, commitments, and cell proofs
     type3_blobs, type3_commitments, type3_cell_proofs = extract_data_from_type_3_tx(payload.transactions)
     type3_versioned_hashes = []
     for tx in payload.transactions:
         if tx.type == BLOB_TX_TYPE:
             type3_versioned_hashes.extend(tx.blob_versioned_hashes)
 
-    # 7. Combine: payload blobs first, then type-3 blobs
+    # 6. Combine: payload blobs first, then type-3 blobs
     all_blobs = payload_blobs + type3_blobs
     all_commitments = payload_commitments + type3_commitments
     all_cell_proofs = payload_cell_proofs + type3_cell_proofs
@@ -402,7 +402,7 @@ def get_payload(payload_id: PayloadId) -> GetPayloadResponse:
     )
 ```
 
-Note: The builder must account for payload blob usage when selecting type-3 transactions to ensure the total blob count does not exceed `MAX_BLOBS_PER_BLOCK`.
+**Note:** The builder must account for payload blob usage when selecting type-3 transactions to ensure the total blob count does not exceed `MAX_BLOBS_PER_BLOCK`.
 
 ##### engine_getPayload - zkEVM-Optimized Variant
 
@@ -420,10 +420,10 @@ def get_payload_zk(payload_id: PayloadId) -> GetPayloadResponse:
     payload_blobs = execution_payload_data_to_blobs(payload_data)
     payload_blob_count = len(payload_blobs)
 
-    # 4. Set the count in the header
+    # 3. Set the count in the header
     payload.payload_blob_count = payload_blob_count
 
-    # 5. Compute commitments, cell proofs, and random point proofs for payload blobs
+    # 4. Compute commitments, cell proofs, and random point proofs for payload blobs
     payload_commitments = [blob_to_kzg_commitment(b) for b in payload_blobs]
     payload_versioned_hashes = [kzg_commitment_to_versioned_hash(c) for c in payload_commitments]
     # Cell proofs
@@ -432,14 +432,14 @@ def get_payload_zk(payload_id: PayloadId) -> GetPayloadResponse:
     # Random point proofs for payload consistency verification
     payload_random_point_proofs = [compute_blob_kzg_proof(b, c) for b, c in zip(payload_blobs, payload_commitments)]
 
-    # 6. Extract type-3 transaction blobs, commitments, and cell proofs
+    # 5. Extract type-3 transaction blobs, commitments, and cell proofs
     type3_blobs, type3_commitments, type3_cell_proofs = extract_data_from_type_3_tx(payload.transactions)
     type3_versioned_hashes = []
     for tx in payload.transactions:
         if tx.type == BLOB_TX_TYPE:
             type3_versioned_hashes.extend(tx.blob_versioned_hashes)
 
-    # 7. Combine: payload blobs first, then type-3 blobs
+    # 6. Combine: payload blobs first, then type-3 blobs
     all_blobs = payload_blobs + type3_blobs
     all_commitments = payload_commitments + type3_commitments
     all_cell_proofs = payload_cell_proofs + type3_cell_proofs
@@ -456,7 +456,7 @@ def get_payload_zk(payload_id: PayloadId) -> GetPayloadResponse:
     )
 ```
 
-**Note for implementors:**
+**Note:**
 
 - The `payload_kzg_proofs` field contains KZG opening proofs for payload blobs only. It is used for payload consistency verification via `verify_blob_kzg_proof_batch`.
 - The builder/prover should extract the first `payload_blob_count` commitments from `all_commitments` (i.e., `all_commitments[:payload_blob_count]`). This corresponds to the `payload_kzg_commitments` parameter in the zkEVM variant of `engine_newPayload`.
@@ -469,7 +469,6 @@ def new_payload(
     expected_blob_versioned_hashes: List[VersionedHash],
     ...
 ) -> PayloadStatus:
-
     # 1. Derive payload blobs and commitments
     payload_data = get_execution_payload_data(payload)
     payload_blobs = execution_payload_data_to_blobs(payload_data)
@@ -500,7 +499,7 @@ def new_payload(
 This variant replaces the MSM in `blob_to_kzg_commitment` with polynomial opening proofs, which are cheaper to verify inside a zkEVM. The payload, commitments and KZG proofs are private inputs to the zkEVM circuit, while the corresponding versioned hashes (and payload header) are public inputs.
 
 ```python
-def new_payload(
+def new_payload_zk(
     payload: ExecutionPayload,
     expected_blob_versioned_hashes: List[VersionedHash], # public input
 
@@ -509,80 +508,87 @@ def new_payload(
     payload_kzg_proofs: List[KZGProof],            # private input
     ...
 ) -> PayloadStatus:
-
-    # 0. Declared payload blob count from the header
+    # 1. Declared payload blob count from the header
     n = payload.payload_blob_count
     assert len(payload_kzg_commitments) == n
     assert len(payload_kzg_proofs) == n
 
-    # 1. Construct payload blobs from execution-payload data
+    # 2. Derive payload blobs and versioned hashes
     payload_data = get_execution_payload_data(payload)
     payload_blobs = execution_payload_data_to_blobs(payload_data)
+    payload_versioned_hashes = [kzg_commitment_to_versioned_hash(c) for c in payload_kzg_commitments]
+
+    # 3. Verify payload blob count matches header
     assert len(payload_blobs) == n
 
-    # 2. Check the commitments correspond to the expected versioned hash prefix
-    payload_versioned_hashes = [
-        kzg_commitment_to_versioned_hash(c) for c in payload_kzg_commitments
-    ]
-    assert expected_blob_versioned_hashes[:n] == payload_versioned_hashes
+    # 4. Extract type-3 tx versioned hashes
+    type3_versioned_hashes = []
+    for tx in payload.transactions:
+        if tx.type == BLOB_TX_TYPE:
+            type3_versioned_hashes.extend(tx.blob_versioned_hashes)
 
-    # 3. Verify blob–commitment consistency using batch KZG proof verification
+    # 5. Verify versioned hashes: payload blobs first, then type-3
+    assert expected_blob_versioned_hashes == payload_versioned_hashes + type3_versioned_hashes
+
+    # 6. Verify blob–commitment consistency using batch KZG proof verification
     assert verify_blob_kzg_proof_batch(
         blobs=payload_blobs,
         commitments=payload_kzg_commitments,
         proofs=payload_kzg_proofs
     )
 
-    # 4. Proceed with standard EL payload validation / execution
+    # 7. Run EL STF
     return execute_payload(payload)
 ```
 
 ### Consensus Layer
 
-#### Validation
+#### Data structures
 
-The consensus layer does not introduce new blob specific validation rules for payload-blobs beyond what we have for EIP-4844/EIP-7594.
+##### ExecutionPayload
 
-The Consensus Layer relies on `payload_blob_count` in the ExecutionPayloadHeader to interpret the ordering of blob commitments, but otherwise treats payload blobs identically to other blobs for availability and networking.
-
-### Integration with EIP-7732 (ePBS)
-
-This EIP deprecates the `ExecutionPayloadEnvelope` from [EIP-7732](./eip-7732.md). Transactions and BAL are published in blobs; all other payload fields move to `ExecutionPayloadBid`:
+This EIP adds a new field to the `ExecutionPayload`:
 
 ```python
-class ExecutionPayloadBid(Container):
-    # Fields from EIP-7732 (unchanged)
-    parent_block_hash: Hash32
-    parent_block_root: Root
-    block_hash: Hash32
-    prev_randao: Bytes32
+class ExecutionPayload(Container):
+    parent_hash: Hash32
     fee_recipient: ExecutionAddress
-    gas_limit: uint64
-    builder_index: BuilderIndex
-    slot: Slot
-    value: Gwei
-    execution_payment: Gwei
-    blob_kzg_commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK]
-    # [New in BiB] Execution payload header fields
-    state_root: Root
-    receipts_root: Root
+    state_root: Bytes32
+    receipts_root: Bytes32
     logs_bloom: ByteVector[BYTES_PER_LOGS_BLOOM]
+    prev_randao: Bytes32
     block_number: uint64
+    gas_limit: uint64
     gas_used: uint64
     timestamp: uint64
     extra_data: ByteList[MAX_EXTRA_DATA_BYTES]
     base_fee_per_gas: uint256
+    block_hash: Hash32
+    transactions: List[Transaction, MAX_TRANSACTIONS_PER_PAYLOAD]
+    withdrawals: List[Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD]
+    blob_gas_used: uint64
     excess_blob_gas: uint64
+    # [New in EIP8142]
     payload_blob_count: uint64
-    # [New in BiB] For CL state transition
-    execution_requests: ExecutionRequests
 ```
+
+#### Validation
+
+The consensus layer does not introduce new blob specific validation rules for payload-blobs beyond what we have for EIP-4844/EIP-7594.
+
+The Consensus Layer relies on `payload_blob_count` in the `ExecutionPayload` to interpret the ordering of blob commitments, but otherwise treats payload blobs identically to other blobs for availability and networking.
 
 ### Networking
 
-BiB reuses the existing blob networking mechanism. Nodes reconstruct the execution payload from the bid (header fields) and blobs (transactions, BAL).
+BiB reuses the existing blob networking mechanism.
 
-Unlike most type-3 blob transactions, payload-blobs will not have been propagated before block building, which may imply higher bandwidth requirements from builders.
+We note the following for consideration:
+
+- Once proofs are made mandatory, a mechanism will be needed for execution payload retrieval. [EIP-7732](./eip-7732.md) introduces an `execution_payload` gossip topic that we can use for this purpose. However, in the context of mandatory proofs where a super majority of stake operates zk validators (which only listen to header topics), a malicious builder could publish only the payload in blobs and gossip the execution payload header without gossiping on the `execution_payload` topic. This would allow zk validators to attest, but other nodes depending on the full payload from the gossip topic would be unable to progress.
+
+- To mitigate this, nodes can implement a fallback mechanism: if they don't receive the payload on the `execution_payload` topic, they reconstruct it from the first `payload_blob_count` blobs and then seed the `execution_payload` topic themselves. This creates a resilient system where every node acts as a "bridge node" when needed, similar to how rollups use L2 gossip as a fast path but fall back to L1 data availability.
+
+- Unlike most type-3 blob transactions, payload-blobs will not have been propagated before block building, which may imply higher bandwidth requirements from builders.
 
 ### Fee Accounting
 


### PR DESCRIPTION
This PR makes BiB more precise, modular and forward-compatible with other zkEVM features. It aims to achieve the following:

1. Payload Deprecation.

Technically speaking, neither BiB nor mandatory proofs have to deprecate payload. It's a design decision. Not committing to a specific timeline for payload deprecation today gives us better flexibility for shipping zkEVM features.

2. `payload_blob_count` placement.

Gloas deprecates `ExecutionPayloadHeader`. While I think there is no problem with bringing it back when we introduce `NewPayloadRequestHeader`, BiB can stick to `ExecutionPayload`. In other words, BiB adds `payload_blob_count` to `ExecutionPayload`. This is a forward-compatible design decision because it naturally means that it also adds `payload_blob_count` to `ExecutionPayloadHeader` on the CL (when we bring it back) and to the header on the EL, respectively.

3. Some clean ups.

This PR does some nit pickings such as:
- using correct terminology such as the header in the EL instead of `ExecutionPayloadHeader`, which exists on the CL.
- making pseudocode for both native variant and zkEVM-optimized variant a bit more symmetric for enhanced readability.

In general, this PR aims to promote the synergy between zkEVM features.

P.S. With or after mandatory proofs, it seems payload deprecation would require us to propagate some more data on top of `NewPayloadRequestHeader`. For instance, `process_withdrawals(state, payload)` in CL's STF wants to access to `payload.withdrawals`. There are some subtleties but I believe we can figure it out down the road.