### PR TITLE
Update EIP-8070: Prefix title with eth/72 protocol version

### DIFF
--- a/EIPS/eip-8070.md
+++ b/EIPS/eip-8070.md
@@ -1,6 +1,6 @@
 ---
 eip: 8070
-title: Sparse Blobpool
+title: eth/72 - Sparse Blobpool
 description: Introduce custody-aligned sampling in the EL blobpool to vacate bandwidth
 author: Raúl Kripalani (@raulk), Bosul Mun (@healthykim), Francesco D'Amato (@fradamt), Csaba Kiraly (@cskiraly), Felix Lange (@fjl), Marios Ioannou (@mariosioannou-create), Alex Stokes (@ralexstokes)
 discussions-to: https://ethereum-magicians.org/t/eip-8070-sparse-blobpool/26023


### PR DESCRIPTION
## Summary
- Prefixes the EIP-8070 title with the `eth/72` devp2p protocol version, aligning it with the naming convention used by other networking EIPs (e.g. EIP-8159 `eth/71 - Block Access List Exchange`, EIP-7975 `eth/70 - partial block receipt lists`, EIP-7642 `eth/69 - history expiry and simpler receipts`).

## Test plan
- [x] Title change only; no content modifications
- [x] Matches the `eth/XX - <description>` convention used by prior networking EIPs