### PR TITLE
Update EIP-8141: add value field to frame

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -33,7 +33,7 @@ In doing so, it realizes the original vision of account abstraction: unlinking a
 | `ENTRY_POINT`             | `address(0xaa)` |
 | `MAX_FRAMES`              | `64`            |
 
-`ENTRY_POINT` is a protocol-defined distinguished caller address used for `DEFAULT` and `VERIFY` frames. It is not specified as a deployed contract or precompile, and contracts MUST NOT assume anything about its code, balance, or caller type beyond address equality. Contracts called from `DEFAULT` or `VERIFY` frames therefore observe `CALLER = ENTRY_POINT`, so heuristics that infer EOA-or-contract properties from `CALLER` may not behave as expected. Its numeric equality with the `APPROVE` opcode value has no semantic significance.
+`ENTRY_POINT` is a protocol-defined distinguished caller address used for `DEFAULT` and `VERIFY` frames. It is not specified as a deployed contract or precompile, and contracts MUST NOT assume anything about its code, balance, or caller type beyond address equality. Contracts called from `DEFAULT` or `VERIFY` frames therefore observe `CALLER = ENTRY_POINT` and `CALLVALUE = 0`, so heuristics that infer EOA-or-contract properties from `CALLER` may not behave as expected. Its numeric equality with the `APPROVE` opcode value has no semantic significance.
 
 ### Opcodes
 
@@ -54,7 +54,7 @@ The payload is defined as the RLP serialization of the following:
 ```
 [chain_id, nonce, sender, frames, max_priority_fee_per_gas, max_fee_per_gas, max_fee_per_blob_gas, blob_versioned_hashes]
 
-frames = [[mode, flags, target, gas_limit, data], ...]
+frames = [[mode, flags, target, gas_limit, value, data], ...]
 ```
 
 If no blobs are included, `blob_versioned_hashes` must be an empty list and `max_fee_per_blob_gas` must be `0`.
@@ -68,6 +68,8 @@ resolved_target = frame.target if frame.target is not None else tx.sender
 ```
 
 Unless otherwise stated, checks below that refer to the target account during execution use the resolved target.
+
+Each frame also has a `value` field, interpreted as the top-level call value in wei. A non-zero `value` is valid only in `SENDER` mode; `DEFAULT` and `VERIFY` frames must set `value = 0`.
 
 #### Frame Modes
 
@@ -95,7 +97,7 @@ Frames in this mode will have their data elided from signature hash calculation 
 
 ##### `SENDER` Mode
 
-Frame executes as regular call where the caller address is `sender`. This mode effectively acts on behalf of the transaction sender and can only be used after explicitly approved.
+Frame executes as regular call where the caller address is `sender`. This mode effectively acts on behalf of the transaction sender, can only be used after explicitly approved, and is the only mode that may send a non-zero `value`.
 
 ##### Frame Flags
 
@@ -132,8 +134,10 @@ for frame in tx.frames:
     assert frame.mode < 3
     assert frame.flags < 8
     assert frame.mode != VERIFY or (frame.flags & APPROVE_SCOPE_MASK) != 0  # VERIFY frames must permit a non-zero APPROVE scope
-    assert len(frame.target) == 20 or frame.target is None
+    assert frame.target is None or len(frame.target) == 20
     assert frame.gas_limit <= 2**63 - 1
+    assert frame.value < 2**256
+    assert frame.mode == SENDER or frame.value == 0
     total_frame_gas += frame.gas_limit
     assert total_frame_gas <= 2**63 - 1
 
@@ -259,6 +263,7 @@ Notes:
 
 - `0x01` has a possible future extension to allow indices for multidimensional nonces.
 - `0x03` and `0x04` have a possible future extension to allow indices for multidimensional gas.
+- `0x06` covers only the maximum gas and blob fees. It does not include any `frame.value` transfers.
 - `0x07` returns only the number of blob versioned hashes. Individual blob versioned hashes remain accessible via the existing `BLOBHASH(index)` opcode.
 - `0x08` returns the canonical signature hash. This value MUST be computed at most once per transaction and cached.
 - Invalid `param` values (not defined in the table above) result in an exceptional halt.
@@ -279,6 +284,7 @@ It takes two values from the stack, `param` and `frameIndex` (in this order). Th
 | 0x05    | frameIndex   | `status` (exceptional halt if current/future)             |
 | 0x06    | frameIndex   | `allowed_scope` (`frame.flags & APPROVE_SCOPE_MASK`)      |
 | 0x07    | frameIndex   | `atomic_batch` (`(frame.flags >> 2) & 0x01`, returns 0/1) |
+| 0x08    | frameIndex   | `value`                                                   |
 
 Notes:
 
@@ -331,12 +337,14 @@ Initialize with transaction-scoped variables:
 
 Then for each call frame:
 
-1. Let `resolved_target = frame.target if frame.target is not null else tx.sender`, then execute a call with the specified `mode`, `flags`, `resolved_target`, `gas_limit`, and `data`.
+1. Let `resolved_target = frame.target if frame.target is not null else tx.sender`, then execute a call with the specified `mode`, `flags`, `resolved_target`, `gas_limit`, `value`, and `data`.
    - If mode is `SENDER`:
        - `sender_approved` must be `true`. If not, the transaction is invalid.
        - Set `caller` as `tx.sender`.
    - If mode is `DEFAULT` or `VERIFY`:
        - Set the `caller` to `ENTRY_POINT`.
+   - In the top-level frame call, `CALLVALUE` is `frame.value`.
+   - As with an ordinary `CALL`, if the caller does not have sufficient balance to transfer `frame.value`, the frame reverts.
    - If `resolved_target` has neither code nor an [EIP-7702](./eip-7702.md) delegation indicator, execute the logic described in [default code](#default-code).
    - Otherwise, if `resolved_target` uses an [EIP-7702](./eip-7702.md) delegation indicator, execute according to [EIP-7702](./eip-7702.md)'s delegated-code semantics.
    - The `ORIGIN` opcode returns frame `caller` throughout all call depths.
@@ -398,8 +406,8 @@ When using frame transactions with EOAs that have neither code nor an [EIP-7702]
     - Otherwise revert.
   - Call `APPROVE(allowed_scope)`.
 - If `mode` is `SENDER`:
-  - If `resolved_target != tx.sender`, revert.
-  - Read `frame.data` as RLP encoding of `calls = [[target, value, data]]`.
+  - If `resolved_target != tx.sender`, return successfully with empty data. This matches a call to an empty-code account; any top-level `frame.value` transfer has already been applied by the frame call itself.
+  - Otherwise, read `frame.data` as RLP encoding of `calls = [[target, value, data]]`.
   - For each call in `calls`, execute the call with `msg.sender = tx.sender`.
     - If any call reverts, revert the frame.
 - If `mode` is `DEFAULT`:
@@ -477,7 +485,9 @@ def default_code(frame, tx):
 
     elif mode == SENDER:
         if resolved_target != tx.sender:
-            revert()
+            # Empty-code account behavior: succeed immediately. Any top-level
+            # frame.value transfer has already been applied by the frame call.
+            return
 
         # frame.data layout: RLP-encoded [[target, value, data], ...]
         calls = rlp_decode(frame.data)
@@ -518,6 +528,8 @@ blob_fees = len(blob_versioned_hashes) * GAS_PER_BLOB * blob_base_fee
 ```
 
 The `effective_gas_price` is calculated per EIP-1559 and `blob_fees` is calculated as per EIP-4844.
+
+Any `frame.value` transferred by `SENDER` frames is separate from `tx_fee` and follows ordinary `CALL` value-transfer semantics. The gas cost of sending `frame.value` is the same as for any ordinary `CALL` frame.
 
 Each frame has its own `gas_limit` allocation. Unused gas from a frame is **not** available to subsequent frames. After all frames execute, the gas refund is calculated as:
 
@@ -754,6 +766,9 @@ The `frame.data` of `VERIFY` frames is elided from the signature hash. This is d
 3. For gas sponsoring workflows, we also recommend using a `VERIFY` frame to approve the gas payment. Here, the input data to the sponsor is intentionally left malleable so it can be added onto the transaction after the `sender` has made its signature. Notably, the raw `frame.target` field of `VERIFY` frames is covered by the signature hash, i.e. the `sender` chooses the sponsor address explicitly.
 
 Implementations MUST NOT treat `VERIFY` frame `data` as sender-authenticated by the canonical signature hash. Any verifier or paymaster that depends on its input data, including sponsor parameters, exchange rates, fee terms, or custom account context, MUST authenticate that data independently. Replacing or mutating `VERIFY` frame `data` does not change the canonical signature hash.
+
+By contrast, non-`VERIFY` frame metadata, including a `SENDER` frame's `value`, remains covered by the canonical signature hash.
+
 Verification logic MUST NOT assign policy meaning to signature encodings or adjacent `VERIFY` frame data unless that meaning is independently authenticated.
 
 ### `APPROVE` calling convention
@@ -786,9 +801,11 @@ Using a flag to indicate atomic batches saves us from having to introduce a new 
 
 Each frame incurs a fixed CALL execution-context overhead (100) plus `G_log` (375) for the receipt sub-entry it produces, giving `FRAME_TX_PER_FRAME_COST = 475`. The execution-context component covers context setup, mode dispatch, and gas accounting at the frame boundary, analogous to the fixed overhead of a CALL. The `G_log` component covers the `[status, gas_used, logs]` receipt sub-entry that each frame adds to the transaction receipt, which must be serialized, hashed into the receipt trie, and proven by ZK-EVM implementations. Cold/warm access costs for the frame's target account are charged within the frame's own `gas_limit` through the normal EVM warm/cold accounting, not through the per-frame cost.
 
-### No value in frame
+### Per-frame value
 
-It is not required because the account code can send value.
+A design goal of the frame transaction is to provide a good experience out-of-the-box for users and to reduce the threat surface of smart contract wallets. Like batching, sending native value is a part of achieving that.
+
+Restricting non-zero `value` to `SENDER` frames keeps `VERIFY` and `DEFAULT` frames side-effect-free with respect to ETH transfer semantics, preserves the intended `STATICCALL`-like behavior of `VERIFY`, and avoids requiring the protocol-defined `ENTRY_POINT` caller to fund top-level ETH transfers.
 
 ### EOA support
 
@@ -806,10 +823,10 @@ Note that users can use any EOA as a paymaster thanks to the [default code](#def
 
 #### Example 1: Simple Transaction
 
-| Frame | Caller      | Target        | Flags                          | Data      | Mode   |
-| ----- | ----------- | ------------- | ------------------------------ | --------- | ------ |
-| 0     | ENTRY_POINT | Null (sender) | APPROVE_PAYMENT_AND_EXECUTION  | Signature | VERIFY |
-| 1     | Sender      | Target        | APPROVE_SCOPE_NONE             | Call data | SENDER |
+| Frame | Caller      | Target        | Value | Flags                         | Data      | Mode   |
+| ----- | ----------- | ------------- | ----- | ----------------------------- | --------- | ------ |
+| 0     | ENTRY_POINT | Null (sender) | 0     | APPROVE_PAYMENT_AND_EXECUTION | Signature | VERIFY |
+| 1     | Sender      | Target        | 0     | APPROVE_SCOPE_NONE            | Call data | SENDER |
 
 Frame 0 verifies the signature and calls `APPROVE(APPROVE_PAYMENT_AND_EXECUTION)` to approve both payment and execution. Frame 1 executes and exits normally via `RETURN`.
 
@@ -820,22 +837,20 @@ The mempool can process this transaction with the following static validation an
 
 #### Example 1a: Simple ETH transfer
 
-| Frame | Caller      | Target        | Flags                         | Data               | Mode   |
-| ----- | ----------- | ------------- | ----------------------------- | ------------------ | ------ |
-| 0     | ENTRY_POINT | Null (sender) | APPROVE_PAYMENT_AND_EXECUTION | Signature          | VERIFY |
-| 1     | Sender      | Null (sender) | APPROVE_SCOPE_NONE            | Destination/Amount | SENDER |
+| Frame | Caller      | Target        | Value  | Flags                         | Data      | Mode   |
+| ----- | ----------- | ------------- | ------ | ----------------------------- | --------- | ------ |
+| 0     | ENTRY_POINT | Null (sender) | 0      | APPROVE_PAYMENT_AND_EXECUTION | Signature | VERIFY |
+| 1     | Sender      | Destination   | Amount | APPROVE_SCOPE_NONE            | Empty     | SENDER |
 
-A simple transfer is performed by instructing the account to send ETH to the destination account. This requires two frames for mempool compatibility, since the validation phase of the transaction has to be static.
-
-This is listed here to illustrate why the transaction type has no built-in value field.
+A simple transfer is performed by setting the `SENDER` frame target to the destination account and the frame `value` to the transfer amount. This requires two frames for mempool compatibility, since the validation phase of the transaction has to be static.
 
 #### Example 1b: Simple account deployment
 
-| Frame | Caller      | Target        | Flags                         | Data               | Mode    |
-| ----- | ----------- | ------------- | ----------------------------- | ------------------ | ------- |
-| 0     | ENTRY_POINT | Deployer      | APPROVE_SCOPE_NONE            | Initcode, Salt     | DEFAULT |
-| 1     | ENTRY_POINT | Null (sender) | APPROVE_PAYMENT_AND_EXECUTION | Signature          | VERIFY  |
-| 2     | Sender      | Null (sender) | APPROVE_SCOPE_NONE            | Destination/Amount | SENDER  |
+| Frame | Caller      | Target        | Value  | Flags                         | Data           | Mode    |
+| ----- | ----------- | ------------- | ------ | ----------------------------- | -------------- | ------- |
+| 0     | ENTRY_POINT | Deployer      | 0      | APPROVE_SCOPE_NONE            | Initcode, Salt | DEFAULT |
+| 1     | ENTRY_POINT | Null (sender) | 0      | APPROVE_PAYMENT_AND_EXECUTION | Signature      | VERIFY  |
+| 2     | Sender      | Destination   | Amount | APPROVE_SCOPE_NONE            | Empty          | SENDER  |
 
 This example illustrates the initial deployment flow for a smart account at the `sender` address. Since the address needs to have code in order to validate the transaction, the transaction must deploy the code before verification.
 
@@ -843,23 +858,23 @@ The first frame would call the [EIP-7997](./eip-7997.md) deterministic factory p
 
 #### Example 2: Atomic Approve + Swap
 
-| Frame | Caller      | Target        | Flags                                    | Data                 | Mode   |
-| ----- | ----------- | ------------- | ---------------------------------------- | -------------------- | ------ |
-| 0     | ENTRY_POINT | Null (sender) | APPROVE_PAYMENT_AND_EXECUTION            | Signature            | VERIFY |
-| 1     | Sender      | ERC-20        | ATOMIC_BATCH_FLAG                        | approve(DEX, amount) | SENDER |
-| 2     | Sender      | DEX           | APPROVE_SCOPE_NONE                       | swap(...)            | SENDER |
+| Frame | Caller      | Target        | Value | Flags                         | Data                 | Mode   |
+| ----- | ----------- | ------------- | ----- | ----------------------------- | -------------------- | ------ |
+| 0     | ENTRY_POINT | Null (sender) | 0     | APPROVE_PAYMENT_AND_EXECUTION | Signature            | VERIFY |
+| 1     | Sender      | ERC-20        | 0     | ATOMIC_BATCH_FLAG            | approve(DEX, amount) | SENDER |
+| 2     | Sender      | DEX           | 0     | APPROVE_SCOPE_NONE           | swap(...)            | SENDER |
 
 Frame 0 verifies the signature and calls `APPROVE(APPROVE_PAYMENT_AND_EXECUTION)`. Frames 1 and 2 form an atomic batch: if the swap in frame 2 reverts, the ERC-20 approval from frame 1 is also reverted, preventing the account from being left with a dangling approval.
 
 #### Example 3: Sponsored Transaction (Fee Payment in ERC-20)
 
-| Frame | Caller      | Target        | Flags              | Data                   | Mode    |
-| ----- | ----------- | ------------- | ------------------ | ---------------------- | ------- |
-| 0     | ENTRY_POINT | Null (sender) | APPROVE_EXECUTION  | Signature              | VERIFY  |
-| 1     | ENTRY_POINT | Sponsor       | APPROVE_PAYMENT    | Sponsor data           | VERIFY  |
-| 2     | Sender      | ERC-20        | APPROVE_SCOPE_NONE | transfer(Sponsor,fees) | SENDER  |
-| 3     | Sender      | Target addr   | APPROVE_SCOPE_NONE | Call data              | SENDER  |
-| 4     | ENTRY_POINT | Sponsor       | APPROVE_SCOPE_NONE | Post op call           | DEFAULT |
+| Frame | Caller      | Target        | Value | Flags              | Data                   | Mode    |
+| ----- | ----------- | ------------- | ----- | ------------------ | ---------------------- | ------- |
+| 0     | ENTRY_POINT | Null (sender) | 0     | APPROVE_EXECUTION  | Signature              | VERIFY  |
+| 1     | ENTRY_POINT | Sponsor       | 0     | APPROVE_PAYMENT    | Sponsor data           | VERIFY  |
+| 2     | Sender      | ERC-20        | 0     | APPROVE_SCOPE_NONE | transfer(Sponsor,fees) | SENDER  |
+| 3     | Sender      | Target addr   | 0     | APPROVE_SCOPE_NONE | Call data              | SENDER  |
+| 4     | ENTRY_POINT | Sponsor       | 0     | APPROVE_SCOPE_NONE | Post op call           | DEFAULT |
 
 - Frame 0: Verifies signature and calls `APPROVE(APPROVE_EXECUTION)` to authorize execution from sender.
 - Frame 1: Checks that the user has enough ERC-20 tokens, and that the next frame is an ERC-20 send of the right size to the sponsor. Calls `APPROVE(APPROVE_PAYMENT)` to authorize payment.
@@ -869,12 +884,12 @@ Frame 0 verifies the signature and calls `APPROVE(APPROVE_PAYMENT_AND_EXECUTION)
 
 #### Example 4: EOA paying gas in ERC-20s
 
-| Frame | Caller      | Target       | Flags              | Data                   | Mode   |
-| ----- | ----------- | ------------ | ------------------ | ---------------------- | ------ |
-| 0     | ENTRY_POINT | Null(sender) | APPROVE_EXECUTION  | (0, v, r, s)          | VERIFY |
-| 1     | ENTRY_POINT | Sponsor      | APPROVE_PAYMENT    | Sponsor signature      | VERIFY |
-| 2     | Sender      | ERC-20       | APPROVE_SCOPE_NONE | transfer(Sponsor,fees) | SENDER |
-| 3     | Sender      | Target addr  | APPROVE_SCOPE_NONE | Call data              | SENDER |
+| Frame | Caller      | Target       | Value | Flags              | Data                   | Mode   |
+| ----- | ----------- | ------------ | ----- | ------------------ | ---------------------- | ------ |
+| 0     | ENTRY_POINT | Null(sender) | 0     | APPROVE_EXECUTION  | (0, v, r, s)           | VERIFY |
+| 1     | ENTRY_POINT | Sponsor      | 0     | APPROVE_PAYMENT    | Sponsor signature      | VERIFY |
+| 2     | Sender      | ERC-20       | 0     | APPROVE_SCOPE_NONE | transfer(Sponsor,fees) | SENDER |
+| 3     | Sender      | Target addr  | 0     | APPROVE_SCOPE_NONE | Call data              | SENDER |
 
 - Frame 0: Verify the sender with a EOA signature.  Upon verification, the frame calls `APPROVE(APPROVE_EXECUTION)` to authorize execution.
 - Frame 1: Checks that the user has enough ERC-20 tokens, and that the next frame is an ERC-20 send of the right size to the sponsor. Calls `APPROVE(APPROVE_PAYMENT)` to authorize payment.
@@ -900,17 +915,19 @@ Frame 0 verifies the signature and calls `APPROVE(APPROVE_PAYMENT_AND_EXECUTION)
 | Sender validation frame: flags    | 1     |
 | Sender validation frame: target   | 1     |
 | Sender validation frame: gas      | 2     |
+| Sender validation frame: value    | 1     |
 | Sender validation frame: data     | 65    |
 | Execution frame: mode             | 1     |
 | Execution frame: flags            | 1     |
-| Execution frame: target           | 1     |
+| Execution frame: target           | 20    |
 | Execution frame: gas              | 1     |
-| Execution frame: data             | 20+5  |
+| Execution frame: value            | 5     |
+| Execution frame: data             | 0     |
 | **Total**                         | 136   |
 
-Notes: Nonce assumes < 65536 prior sends. Fees assume < 1099 gwei. Validation frame target is 1 byte because target is `tx.sender`. Validation gas assumes <= 65,536 gas. Calldata is 65 bytes for ECDSA signature. Blob fields assume no blobs (empty list, zero max fee).
+Notes: Nonce assumes < 65536 prior sends. Fees assume < 1099 gwei. Validation frame target is 1 byte because target is `tx.sender`. Validation gas assumes <= 65,536 gas. Validation frame value is zero. Execution frame target is encoded directly as the destination address. Execution frame value assumes a compact 5-byte encoding. The execution frame data is empty for a plain ETH transfer. Validation data is 65 bytes for an ECDSA signature. Blob fields assume no blobs (empty list, zero max fee).
 
-This is not much larger than an EIP-1559 transaction; the extra overhead is the need to specify the sender and amount in calldata explicitly.
+This is not much larger than an EIP-1559 transaction; the extra overhead is mainly the need to specify the sender and the per-frame wrapper explicitly.
 
 **First transaction from an account (add deployment frame):**
 
@@ -920,8 +937,9 @@ This is not much larger than an EIP-1559 transaction; the extra overhead is the 
 | Deployment frame: flags    | 1     |
 | Deployment frame: target   | 20    |
 | Deployment frame: gas      | 3     |
+| Deployment frame: value    | 1     |
 | Deployment frame: data     | 100   |
-| **Total additional**       | 125   |
+| **Total additional**       | 126   |
 
 Notes: Gas assumes cost < 2^24. Calldata assumes small proxy.
 
@@ -933,18 +951,21 @@ Notes: Gas assumes cost < 2^24. Calldata assumes small proxy.
 | Sponsor validation frame: flags      | 1     |
 | Sponsor validation frame: target     | 20    |
 | Sponsor validation frame: gas        | 3     |
+| Sponsor validation frame: value      | 1     |
 | Sponsor validation frame: calldata   | 0     |
 | Send to sponsor frame: mode          | 1     |
 | Send to sponsor frame: flags         | 1     |
 | Send to sponsor frame: target        | 20    |
 | Send to sponsor frame: gas           | 3     |
+| Send to sponsor frame: value         | 1     |
 | Send to sponsor frame: calldata      | 68    |
 | Sponsor post op frame: mode          | 2     |
 | Sponsor post op frame: flags         | 1     |
 | Sponsor post op frame: target        | 20    |
 | Sponsor post op frame: gas           | 3     |
+| Sponsor post op frame: value         | 1     |
 | Sponsor post op frame: calldata      | 0     |
-| **Total additional**                 | 144   |
+| **Total additional**                 | 147   |
 
 Notes: Sponsor can read info from other fields. ERC-20 transfer call is 68 bytes.
 
@@ -985,7 +1006,7 @@ Because `tx.sender` is explicit in the transaction envelope, an attacker can sub
 
 #### Cross-Frame Data Visibility During Validation
 
-`FRAMEPARAM`, `FRAMEDATALOAD`, and `FRAMEDATACOPY` allow validation code to inspect other frames, including later `SENDER` frames. As a result, paymasters and other `VERIFY` frames can observe user operation parameters before approval and may condition their behavior on that information. Users should therefore treat non-`VERIFY` frame data as visible to validation logic and should not rely on untrusted paymasters or verifiers to keep such data private.
+`FRAMEPARAM`, `FRAMEDATALOAD`, and `FRAMEDATACOPY` allow validation code to inspect other frames, including later `SENDER` frames and their `value`s. As a result, paymasters and other `VERIFY` frames can observe user operation parameters before approval and may condition their behavior on that information. Users should therefore treat non-`VERIFY` frame parameters and data as visible to validation logic and should not rely on untrusted paymasters or verifiers to keep such information private.
 
 ##### Mitigations
 


### PR DESCRIPTION
It's been raised several times now that we frames should have `value` field. Originally I was against this because I preferred for the actual execution of the user's operation to be handled by their account, however, we are now focusing on having frames support a good out-of-the-box experience for users without needing wallets to implement things such as batching. In that world, `value` is a critical field for the `SENDER` frame.

To keep the frame object uniform, it is added for all modes, but it is only allowed to be non-zero in `SENDER` frames.