### PR TITLE
Update EIP-7928: Change uint16 block access index to uint64 and clarify CL-side

### DIFF
--- a/EIPS/eip-7928.md
+++ b/EIPS/eip-7928.md
@@ -51,7 +51,7 @@ Address = bytes20  # 20-byte Ethereum address
 StorageKey = uint256  # Storage slot key
 StorageValue = uint256  # Storage value
 Bytecode = bytes  # Variable-length contract bytecode
-BlockAccessIndex = uint16  # Block access index (0 for pre-execution, 1..n for transactions, n+1 for post-execution)
+BlockAccessIndex = uint64  # Block access index (0 for pre-execution, 1..n for transactions, n+1 for post-execution)
 Balance = uint256  # Post-transaction balance in wei
 Nonce = uint64  # Account nonce
 
@@ -299,7 +299,7 @@ When processing a block:
 3. The EL executes the block and generates the actual BAL
 4. If the generated BAL doesn't match the provided BAL, the block is invalid (the hash in the header would be wrong)
 
-The execution layer provides the RLP-encoded `blockAccessList` to the consensus layer via the Engine API. The consensus layer then computes the SSZ `hash_tree_root` for storage in the `ExecutionPayload`.
+The execution layer provides the RLP-encoded `blockAccessList` to the consensus layer via the Engine API. The consensus layer stores it as a field in the SSZ `ExecutionPayload` container. For long-term storage, the full `blockAccessList` bytes MAY be pruned and replaced by the field's SSZ `hash_tree_root`, preserving the Merkle commitment within the `ExecutionPayload` tree.
 
 **Retrieval methods** for historical BALs:
 


### PR DESCRIPTION
Change BAL index from using `uint16` to using `uint64` to make it more future-proof for increasing gas limits and decreasing tx base cost / intrinsic costs.