### PR TITLE
Update EIP-8037: add per-dimension block gas limit check

### DIFF
--- a/EIPS/eip-8037.md
+++ b/EIPS/eip-8037.md
@@ -93,6 +93,20 @@ max(intrinsic_regular_gas, calldata_floor_gas_cost) > TX_MAX_GAS_LIMIT
 
 `validate_transaction` also returns `intrinsic_regular_gas`, `intrinsic_state_gas`, and `calldata_floor_gas_cost`.
 
+After this check, inclusion of a transaction in a block additionally requires that, for each gas dimension, the cumulative gas used of all previous transactions added to the transaction's contribution must not exceed the block gas limit. This contribution is assumed as the worst case for each dimension, before actually executing the transaction. Specifically, `check_transaction` is updated to:
+
+```python
+regular_gas_available = block_env.block_gas_limit - block_output.block_regular_gas_used
+state_gas_available = block_env.block_gas_limit - block_output.block_state_gas_used
+# ...
+if min(TX_MAX_GAS_LIMIT, tx.gas - intrinsic_state_gas) > regular_gas_available:
+    raise GasUsedExceedsLimitError("gas used exceeds limit")
+if tx.gas - intrinsic_regular_gas > state_gas_available:
+    raise GasUsedExceedsLimitError("gas used exceeds limit")
+```
+
+`intrinsic_regular_gas` and `intrinsic_state_gas` must be passed to `check_transaction` to perform the regular gas availability check.
+
 #### Transaction-level gas accounting (reservoir model)
 
 Since transactions have a single gas limit parameter (`tx.gas`), gas accounting is enforced through a **reservoir model**, in which `gas_left` and `state_gas_reservoir` are initialized as follows:
@@ -118,7 +132,7 @@ The two counters are returned by the transaction output. Besides the two counter
 
 #### Pre-state and post-state gas validation
 
-[EIP-7928](./eip-7928.md) defines two-phase gas validation for state-accessing opcodes: pre-state costs (determinable without state access) and post-state costs (requiring state access). Pre-state validation must pass before any state access occurs. Under the reservoir model, both regular and state gas portions of pre-state costs must be satisfiable; regular gas is checked against `gas_left`, state gas against `state_gas_reservoir` (then `gas_left`). If either check fails, the state access does not occur.
+During execution, [EIP-7928](./eip-7928.md) defines two-phase gas validation for state-accessing opcodes: pre-state costs (determinable without state access) and post-state costs (requiring state access). Pre-state validation must pass before any state access occurs. Under the reservoir model, both regular and state gas portions of pre-state costs must be satisfiable; regular gas is checked against `gas_left`, state gas against `state_gas_reservoir` (then `gas_left`). If either check fails, the state access does not occur.
 
 The cost parameters introduced by this EIP map to validation phases as follows:
 


### PR DESCRIPTION
- Specifies how block gas limits are enforced per dimension (regular, state) before execution, with updated check_transaction pseudocode.
- Minor wording fix scoping EIP-7928 two-phase validation to execution time

Aims to replace #11503