### PR TITLE
Update EIP-7732: Add Nico Flaig as coauthor

### DIFF
--- a/EIPS/eip-7732.md
+++ b/EIPS/eip-7732.md
@@ -2,7 +2,7 @@
 eip: 7732
 title: Enshrined Proposer-Builder Separation
 description: Separates the ethereum block in consensus and execution parts, adds a mechanism for the consensus proposer to choose the execution proposer.
-author: Francesco D'Amato <francesco.damato@ethereum.org>, Barnabé Monnot <barnabe.monnot@ethereum.org>, Michael Neuder <michael.neuder@ethereum.org>, Potuz (@potuz), Justin Traglia <jtraglia@ethereum.org>, Terence Tsao <ttsao@offchainlabs.com>
+author: Francesco D'Amato <francesco.damato@ethereum.org>, Nico Flaig <nflaig@protonmail.com>, Barnabé Monnot <barnabe.monnot@ethereum.org>, Michael Neuder <michael.neuder@ethereum.org>, Potuz (@potuz), Justin Traglia <jtraglia@ethereum.org>, Terence Tsao <ttsao@offchainlabs.com>
 discussions-to: https://ethereum-magicians.org/t/eip-7732-enshrined-proposer-builder-separation-epbs/19634
 status: Draft
 type: Standards Track


### PR DESCRIPTION
Nico has done extensive study of the EIP and merged https://github.com/ethereum/consensus-specs/pull/5094 which is a considerable contribution.
