### PR TITLE
Update EIP-7954: Raise contract code size to 64KiB

### DIFF
--- a/EIPS/eip-7954.md
+++ b/EIPS/eip-7954.md
@@ -1,7 +1,7 @@
 ---
 eip: 7954
 title: Increase Maximum Contract Size
-description: Raise the maximum contract code size from 24KiB to 32KiB and initcode size from 48KiB to 64KiB.
+description: Raise the maximum contract code size from 24KiB to 64KiB and initcode size from 48KiB to 128KiB.
 author: Giulio Rebuffo (@Giulio2002), Ben Adams (@benaadams)
 discussions-to: https://ethereum-magicians.org/t/increase-maximum-contract-size-to-48kb/24509
 status: Draft
@@ -13,16 +13,16 @@ requires: 170, 3860
 
 ## Abstract
 
-This EIP proposes to raise the maximum allowed size for contract code deployed on Ethereum from 24,576 bytes to 32,768 bytes.
+This EIP proposes to raise the maximum allowed size for contract code deployed on Ethereum from 24,576 bytes to 65,536 bytes, and to raise the initcode size limit from 49,152 bytes to 131,072 bytes.
 
 ## Motivation
 
-The current 24KiB contract size limit can be restrictive for complex contracts and applications. Increasing the limit to 32KiB allows for more feature-rich contracts while maintaining reasonable constraints on block and state growth.
+The current 24KiB contract size limit can be restrictive for complex contracts and applications. Increasing the limit to 64KiB allows for more feature-rich contracts while maintaining reasonable constraints on block and state growth.
 
 ## Specification
 
-1. Update the [EIP-170](./eip-170.md) contract code size limit of 24KiB (`0x6000` bytes) to 32KiB (`0x8000` bytes).
-2. Update the [EIP-3860](./eip-3860.md) initcode size limit of 48KiB (`0xC000` bytes) to 64KiB (`0x10000` bytes).
+1. Update the [EIP-170](./eip-170.md) contract code size limit of 24KiB (`0x6000` bytes) to 64KiB (`0x10000` bytes).
+2. Update the [EIP-3860](./eip-3860.md) initcode size limit of 48KiB (`0xC000` bytes) to 128KiB (`0x20000` bytes).
 
 ## Rationale
 
@@ -32,7 +32,7 @@ The current 24KiB contract size limit can be restrictive for complex contracts a
 
 ## Backwards Compatibility
 
-This change is not backwards compatible and must be activated via a network upgrade (hard fork). Contracts larger than 24KiB, up to 32KiB, will be deployable after activation.
+This change is not backwards compatible and must be activated via a network upgrade (hard fork). Contracts larger than 24KiB, up to 64KiB, will be deployable after activation.
 
 ## Security Considerations
 


### PR DESCRIPTION
This updates EIP-7954 to raise deployed contract code size from 24KiB to 64KiB.

To keep the proposal internally consistent, it also raises the EIP-3860 initcode limit from 48KiB to 128KiB.

Requested by Giulio.