### PR TITLE
Update EIP-8037: Clarify SSTORE restoration refund rollback semantics

### DIFF
--- a/EIPS/eip-8037.md
+++ b/EIPS/eip-8037.md
@@ -183,6 +183,8 @@ When a storage slot is set to a non-zero value and then restored to zero within 
 - State gas: `32 × cost_per_state_byte` is refunded directly to `state_gas_reservoir` (and `execution_state_gas_used` is decremented). The refund happens immediately at the X to 0 SSTORE, not via `refund_counter`. This ensures the full state gas amount is returned regardless of the 20% refund cap.
 - Regular gas: `GAS_STORAGE_UPDATE - GAS_COLD_SLOAD - GAS_WARM_ACCESS` is added to `refund_counter`, subject to the 20% cap.
 
+The state gas refund is scoped to the frame that executes the X to 0 SSTORE, and propagates to an ancestor frame only if all intervening frames return successfully. On **revert** or **exceptional halt** of the applying frame or of any ancestor frame the refund has reached, the refund's credit to `state_gas_reservoir` and its decrement of `execution_state_gas_used` are undone at that frame and are not inherited by its parent. As a result, whenever any frame in the chain experiences a **revert** or **exceptional halt**, the 0 to X to 0 refund contributes nothing to `state_gas_reservoir` or `execution_state_gas_used`, consistent with the principle that state gas is only refunded when no state was actually grown.
+
 The net cost after refund is `GAS_WARM_ACCESS`, consistent with pre-[EIP-8037](./eip-8037.md) `SSTORE` restoration behavior.
 
 ### State gas on frame failure


### PR DESCRIPTION
Adds one paragraph to the `SSTORE` refund for slot restoration section clarifying that the state gas refund is scoped to the executing frame and does not propagate to the parent on **revert** or **exceptional halt**.

### Motivation

The current text describes where and when the refund is applied (immediately at the X to 0 SSTORE, directly to `state_gas_reservoir`) but is silent on what happens if the frame that performed the X to 0 SSTORE subsequently fails. Two interpretations are consistent with the existing wording:

1. The credit to `state_gas_reservoir` is irrevocable once applied.
2. The credit is scoped to the frame and is undone on failure.

Only (2) is consistent with the EIP's own principle that state gas is only refunded when no state was actually grown, and with the rest of the document's treatment of reverted frames.

Under (1), a sub-call that performs 0 to X to 0 and then reverts leaves `state_gas_reservoir` inflated relative to its pre-call value, effectively converting parent `gas_left` into reservoir state gas via a reverted frame. This contradicts the net-state-growth-is-zero justification and is a consensus-split risk between clients that read the existing text differently.


### EELS Spec & Tests
ethereum/execution-specs#2698