### PR TITLE
Update EIP-8159: Correct empty bal response to 0x80 empty string

### DIFF
--- a/EIPS/eip-8159.md
+++ b/EIPS/eip-8159.md
@@ -97,7 +97,7 @@ BALs are only available for blocks after [EIP-7928](./eip-7928.md) activation an
 [request-id: P, [block-access-list₁, block-access-list₂, ...]]
 ```
 
-Response to `GetBlockAccessLists`. Each element corresponds to a block hash from the request, in order. Empty BALs (RLP-encoded empty list `0xc0`) are returned for blocks where the BAL is unavailable.
+Response to `GetBlockAccessLists`. Each element corresponds to a block hash from the request, in order. The RLP empty string (`0x80`) is returned for blocks where the BAL is unavailable.
 
 The recommended soft limit for `BlockAccessLists` responses is 2 MiB.
 


### PR DESCRIPTION
Changed `0xc0` (empty list) to `0x80` (empty string) on line 100 of EIP-8159 matching EIP-8189 and the snap/1 `ByteCodes`/`TrieNodes` convention.
On a chain without system contracts, `0xc0` would collide with a empty BALs, thus using `0x80` is cleaner.