### PR TITLE
Update EIP-7932: Separate precompile & add Autonomous/Detached signature support

### DIFF
--- a/EIPS/eip-7932.md
+++ b/EIPS/eip-7932.md
@@ -15,7 +15,7 @@ created: 2025-04-12
 This EIP:
 
  - Creates a unified registry & standardized interface for introducing additional signature algorithms for the use of deriving account addresses.
- - Introduces a precompile at address `SIGRECOVER_PRECOMPILE_ADDRESS` for decoding these newly introduced algorithms.
+ - Introduces a three precompiles as an interface for the verification these newly introduced algorithms.
 
 ## Motivation
 
@@ -31,126 +31,168 @@ Unless explicitly noted, integer encoding MUST be in big-endian format.
 
 ### Parameters
 
+<!-- TODO: Finalize precompile address to known free values -->
 | Constant | Value |
 | - | - |
-| `SIGRECOVER_PRECOMPILE_ADDRESS`| `Bytes20(0x12)` |
-| `SIGRECOVER_PRECOMPILE_BASE_GAS` | `3000` |
+| `SIGADDRESS_PRECOMPILE_ADDRESS`| `Bytes20(0x20)` |
+| `SIGADDRESS_PRECOMPILE_BASE_GAS` | `3000` |
+| `SIGRECOVER_PRECOMPILE_ADDRESS`| `Bytes20(0x21)` |
+| `SIGRECOVER_PRECOMPILE_BASE_GAS` | `2500` |
+| `SIGVERIFY_PRECOMPILE_ADDRESS`| `Bytes20(0x22)` |
+| `SIGVERIFY_PRECOMPILE_BASE_GAS` | `2000` |
+| `SIGCOST_PRECOMPILE_ADDRESS`| `Bytes20(0x23)` |
+| `SIGCOST_PRECOMPILE_GAS`| `25` |
 
+
+### Defined objects
+
+This EIP defines the following object serializations:
+
+| Object | Serialization | Description |
+| - | - | - |
+| `AutonomousSignature(algorithm_id, data)`| `algorithm_id \|\| data` | Autonomous signatures are fully contained signatures that can be recovered into a public key, the underlying algorithm may not support recovery so public key data may be bundled into this signature type. |
+| `DetachedSignature(algorithm_id, data)`| `algorithm_id \|\| data` | Detached signatures cannot be verified without a corresponding public key |
+| `PublicKey(algorithm_id, data)`| `algorithm_id \|\| data` | An abstract public key type |
 
 ### Algorithm specification
 
-New algorithms beyond the `secp256k1` algorithm specified in this EIP MUST be specified via a distinct EIP.
+Algorithms beyond the `secp256k1` algorithm specified in this EIP MUST be specified via a distinct EIP.
 
 Each type of algorithm MUST specify the following fields:
 
 ```rust
 trait Algorithm {
     // The algorithm type byte
-    ALG_TYPE: uint8,
+    const ALG_TYPE: uint8,
 
-    // The size of signatures. Signatures MUST be padded
-    // to this size to be valid. Note that this does include
-    // the ALG_TYPE byte prefix
-    SIZE: uint32
+    // The size of a AutonomousSignature, DetachedSignature and PublicKey
+    // Signatures & public keys MUST be of this length to be valid.
+    // This includes the `algorithm_id` prefix.
+    const DETACHED_SIZE: uint32
+    const AUTONOMOUS_SIZE: uint32
+    const PUBLIC_KEY_SIZE: uint32
+    
 
-    // Get the gas cost of signing this data. This
+    // Get the gas cost of verifying the signature data. This
     // SHOULD include a reasonable minimum and MUST
     // be relative to secp256k1, i.e. 0 gas is secp256k1.
-    fn gas_cost(signing_data: Bytes) -> Uint64;
+    fn gas_cost(signing_data: Bytes) -> uint64;
 
-    // Check whether the signature is valid. For some
-    // algorithms, this may be a no-op. This function
-    // will always be called before `verify`.
-    fn validate(signature: Bytes) -> None | Error;
+    // Take either a autonomous or detached signature and verify
+    // that the signature is well-formed and that it could be valid
+    // for a corresponding public key.
+    fn validate_autonomous(signature: AutonomousSignature) -> None | Error;
+    fn validate_detached(signature: DetachedSignature) -> None | Error;
 
-    // Take the signature and signing_data and return the
-    // public key of the signer.
-    fn verify(signature: Bytes, signing_data: Bytes) -> Bytes | Error;
+    // Verify a autonomous signature with signing data and return
+    // the corresponding public key that signed the data.
+    fn verify_autonomous(
+        signing_data: Bytes,
+        signature: AutonomousSignature
+    ) -> PublicKey | Error;
 
-    // Given a public key and corresponding signature, merge them into
-    // a valid signature info container. This function MUST NOT check that
-    // the provided `public_key` matches the signature.
-    fn merge_detached_signature(detached_signature: Bytes, public_key: Bytes) -> Bytes | Error;
+    // Verify a detached signature with signing data against a specific
+    // public key returning None on success.
+    fn verify_detached(
+        signing_data: Bytes,
+        signature: DetachedSignature,
+        public_key: PublicKey
+    ) -> None | Error;
 }
 ```
 
-Specifications MUST include some form of security analysis on the provided algorithm and basic benchmarks justifying gas costs. Additionally, specifications MUST address malleability issues that may arise from specified algorithms. 
+Specifications MUST include some form of security analysis on the provided algorithm and basic benchmarks justifying gas costs. Additionally, specifications MUST ensure that malleability issues are correctly handled. 
 
 An example of this specification can be found [here](../assets/eip-7932/template-eip.md).
 
 ### Deriving address from public keys
 
-The function below MUST be used when deriving an address from a public key:
+Implementations MUST use the following mechanism for deriving an address from a public key:
 
 ```python
-def pubkey_to_address(public_key: Bytes, algorithm_id: uint8) -> ExecutionAddress:
-    if algorithm_id == 0x00: # Compatibility shim to ensure backwards compatibility
-        return ExecutionAddress(keccak(public_key[1:])[12:])
+def pubkey_to_address(public_key: PublicKey) -> ExecutionAddress:
+    # Compatibility shim to ensure backwards compatibility
+    if public_key.algorithm_id == 0x00:
+        return ExecutionAddress(keccak(public_key.data)[12:])
 
-    if len(public_key) == 63:
+    if len(public_key.data) == 63:
         # Prevent collisions with legacy secp256k1
-        return ExecutionAddress(keccak(algorithm_id || 0x00 || public_key)[12:])
+        return ExecutionAddress(keccak(
+            public_key.algorithm_id ||
+            0x00 ||
+            public_key.data
+        )[12:])
 
-    # with `||` being binary concatenation
-    return ExecutionAddress(keccak(algorithm_id || public_key)[12:])
+    return ExecutionAddress(keccak(public_key)[12:])
 ```
 
 ### Algorithm Registry
 
-```python
-class AlgorithmEntry():
-    ALG_TYPE: uint8,
-    SIZE: uint32,
-    gas_cost: Callable[[Bytes], uint64],
-    merge_detached_signature: Callable[[Bytes, Bytes], Bytes],
-    validate: Callable[[Bytes], None | Error],
-    verify: Callable[[Bytes, Bytes], Bytes | Error]
+This EIP uses the `algorithm_registry` object to signify algorithms that have been included within a hard fork, this object MAY be defined as `algorithm_registry: Dict[uint8, Algorithm]`.
 
-algorithm_registry: Dict[uint8, AlgorithmEntry]
-```
+The algorithm type is reserved `0x7F` as invalid / missing.
 
-This EIP uses the `algorithm_registry` object to signify algorithms that have been included within a hard fork.
-
-A living EIP MAY be created on finalization of this EIP to track currently active algorithms across forks.
-
-The algorithm type is reserved `0x7F` as invalid / missing, algorithm types MUST be less than 127.
+Newly defined algorithm types MUST be less than 127 (`0x7F`).
 
 ### Helper functions
 
 The following helper functions are defined for convenience:
 
 ```python
-def calculate_penalty(algorithm: uint8, signing_data: Bytes) -> uint:
+def gas_cost(algorithm: uint8, signing_data: Bytes) -> uint:
     assert algorithm in algorithm_registry
-
     algorithm = algorithm_registry[algorithm]
 
     return algorithm.gas_cost(signing_data)
 
-def validate_signature(signature: Bytes):
-    assert len(signature) > 0
-    assert signature[0] in algorithm_registry
+def validate_autonomous(signature: AutonomousSignature) -> None | Error:
+    assert signature.algorithm_id in algorithm_registry
+    return algorithm_registry[signature.algorithm_id].validate_autonomous(signature)
 
-    algorithm = algorithm_registry[signature[0]]
+def validate_detached(signature: DetachedSignature) -> None | Error:
+    assert signature.algorithm_id in algorithm_registry
+    return algorithm_registry[signature.algorithm_id].validate_detached(signature)
 
-    return algorithm.validate(signature)
+def verify_autonomous(
+    signing_data: Bytes,
+    signature: AutonomousSignature
+) -> PublicKey | Error:
+    assert signature.algorithm_id in algorithm_registry
+    return algorithm_registry[signature.algorithm_id].verify_autonomous(signing_data, signature)
 
-# This function cannot be called without prior calling `validate_signature(signature)`
-def verify_signature(signing_data: Bytes, signature: Bytes) -> Bytes:
-    algorithm = algorithm_registry[signature[0]]
-
-    return algorithm.verify(signature, signing_data)
+def verify_detached(
+    signing_data: Bytes,
+    signature: DetachedSignature,
+    public_key: PublicKey
+) -> None | Error:
+    assert signature.algorithm_id in algorithm_registry
+    assert signature.algorithm_id == public_key.algorithm_id
+    return algorithm_registry[signature.algorithm_id].verify_detached(
+        signing_data,
+        signature,
+        public_key
+    )
 ```
 
-### `secp256k1` algorithm
+### The `secp256k1` algorithm
 
 
 ```python
+# Internal constants
+
+SECP256K1_SIGNATURE_SIZE = 65
+SECP256K1_PUBKEY_SIZE = 64
+
+# Algorithm Constants
+
 ALG_TYPE = 0x00
-SIZE = 66
 
-SECP256K1_SIGNATURE_SIZE = SIZE - 1
+DETACHED_SIZE = SECP256K1_SIGNATURE_SIZE + 1
+AUTONOMOUS_SIZE = SECP256K1_SIGNATURE_SIZE + 1
+PUBLIC_KEY_SIZE = SECP256K1_PUBKEY_SIZE + 1
 
+# Internal Functions
+    
 def secp256k1_unpack(signature: ByteVector[SECP256K1_SIGNATURE_SIZE]) -> tuple[uint256, uint256, uint8]:
     r = uint256.from_bytes(signature[0:32], 'big')
     s = uint256.from_bytes(signature[32:64], 'big')
@@ -164,90 +206,229 @@ def secp256k1_validate(signature: ByteVector[SECP256K1_SIGNATURE_SIZE]):
     assert 0 < s <= SECP256K1N // 2
     assert y_parity in (0, 1)
 
-def gas_cost(signing_data: Bytes) -> Uint64:
+
+# Algorithm Functions
+
+def gas_cost(signing_data_len: uint64) -> uint64:
     # This is an adaptation from the KECCAK256 opcode
-    if len(signing_data) == 32:
-        return Uint64(0)
+    if signing_data_len == 32:
+        return uint64(0)
     else:
-        minimum_word_size = (len(signing_data) + 31) // 32
-        return Uint64(30 + (6 * minimum_word_size))
+        minimum_word_size = (signing_data_len + 31) // 32
+        return uint64(30 + (6 * minimum_word_size))
 
-def validate(signature: Bytes) -> None | Error:
-    secp256k1_validate(signature[1:])
+def validate_autonomous(signature: AutonomousSignature) -> None | Error:
+    secp256k1_validate(signature.data)
 
-def verify(signature: Bytes, signing_data: Bytes) -> Bytes | Error:
-    # Another compatibility shim to ensure passing a 32 byte hash still works.
-    if len(signing_data) != 32:
-        signing_data = keccak256(signing_data)
+def validate_detached(signature: DetachedSignature) -> None | Error:
+    # `DetachedSignature` == `AutonomousSignature` because
+    # secp256k1 can be recovered.
+    secp256k1_validate(signature.data)
 
+def verify_autonomous(
+    signing_data: Bytes,
+    signature: AutonomousSignature
+) -> PublicKey | Error:
     ecdsa = ECDSA()
     recover_sig = ecdsa.ecdsa_recoverable_deserialize(signature[1:65], signature[65])
     public_key = PublicKey(ecdsa.ecdsa_recover(signing_data, recover_sig, raw=True))
-    uncompressed = public_key.serialize(compressed=False)
-    return uncompressed
+    pubkey = public_key.serialize(compressed=False)
+    return ALG_TYPE || pubkey
 
-def merge_detached_signature(detached_signature: bytes, _public_key: bytes) -> bytes:
-    # Secp256k1 uses recoverable signatures, this is a no-op.
-    return detached_signature
+def verify_detached(
+    signing_data: Bytes,
+    signature: DetachedSignature,
+    public_key: PublicKey
+) -> None | Error:
+    recovered_key = verify_autonomous(
+        signing_data,
+        AutonomousSignature(
+            signature.algorithm_id,
+            signature.data,
+        )
+    )
+    assert(recovered_key == public_key)
 ```
 
-### `sigrecover` precompile
+### Precompiles
 
-This EIP also introduces a new precompile located at `SIGRECOVER_PRECOMPILE_ADDRESS`.
+#### `sigrecover`
 
-This precompile MUST charge `SIGRECOVER_PRECOMPILE_BASE_GAS` static gas before executing.
+The `sigrecover` precompile is located at `SIGRECOVER_PRECOMPILE_ADDRESS` and MUST charge `SIGRECOVER_PRECOMPILE_BASE_GAS` static gas before executing.
 
-The precompile MUST output the 20-byte address of the signer provided left padded to 32 bytes. On failure, the precompile MUST NOT return any data.
+The precompile MUST output the public key of the signer given an `AutonomousSignature` and signing data. On failure, the precompile MUST NOT return any data.
+
+The calldata format for this precompile is `AutonomousSignature || SignatureData: Bytes`.
 
 The precompile is defined as follows:
 
 ```python
 def sigrecover_precompile(input: Bytes) -> Bytes:
+    charge_gas(SIGRECOVER_PRECOMPILE_BASE_GAS)
+
     assert len(input) >= 1
     assert input[0] in algorithm_registry
 
-    size = algorithm_registry[input[0]].SIZE
+    algorithm: Algorithm = algorithm_registry[input[0]]
+    size = algorithm.AUTONOMOUS_SIZE
 
     assert len(input) > size
 
-    signature = input[:size]
-    signing_data = input[size:]
+    signature: AutonomousSignature = input[:size]
+    signing_data: Bytes = input[size:]
 
-    charge_gas(calculate_penalty(input[0], signing_data))
+    charge_gas(gas_cost(signature.algorithm_id, len(signing_data)))
 
     # Run validate/verify function
-    validate_signature(signature)
-    pubkey = verify_signature(signing_data, signature)
+    algorithm.validate_autonomous(signature)
+    pubkey = algorithm.verify_autonomous(signing_data, signature)
+
+    return pubkey
+```
+
+#### `sigaddress`
+
+The `sigaddress` precompile is located at `SIGADDRESS_PRECOMPILE_ADDRESS` and MUST charge `SIGADDRESS_PRECOMPILE_BASE_GAS` static gas before executing.
+
+The precompile MUST output the 20-byte address of the signer provided left padded to 32 bytes. On failure, the precompile MUST NOT return any data.
+
+The calldata format for this precompile is `AutonomousSignature || SignatureData: Bytes`.
+
+The precompile is defined as follows:
+
+```python
+def sigaddress_precompile(input: Bytes) -> Bytes:
+    charge_gas(SIGADDRESS_PRECOMPILE_BASE_GAS - SIGRECOVER_PRECOMPILE_BASE_GAS)
+
+    pubkey = sigrecover_precompile(input)
 
     # Return address left-padded to 32 bytes
-    return (b"\x00" * 12) + pubkey_to_address(pubkey, input[0])
+    return (b"\x00" * 12) + pubkey_to_address(pubkey)
 ```
+
+#### `sigverify`
+
+The `sigverify` precompile is located at `SIGVERIFY_PRECOMPILE_ADDRESS` and MUST charge `SIGVERIFY_PRECOMPILE_BASE_GAS` static gas before executing.
+
+The precompile MUST output a single `0x01` byte on success. On failure, the precompile MUST NOT return any data.
+
+The calldata format for this precompile is `DetachedSignature || PublicKey || SignatureData: Bytes`.
+
+The precompile is defined as follows:
+
+```python
+def sigverify_precompile(input: Bytes) -> Bytes:
+    charge_gas(SIGVERIFY_PRECOMPILE_BASE_GAS)
+    assert len(input) >= 2
+    assert input[0] in algorithm_registry
+
+    algorithm: Algorithm = algorithm_registry[input[0]]
+    sig_size = algorithm.DETACHED_SIZE
+    pubkey_size = algorithm.PUBLIC_KEY_SIZE
+
+    assert len(input) > (sig_size + pubkey_size)
+
+    signature: DetachedSignature = input[:sig_size]
+    public_key: PublicKey = input[sig_size: sig_size + pubkey_size]
+    signing_data: Bytes = input[sig_size + pubkey_size:]
+
+    charge_gas(gas_cost(signature.algorithm_id, len(signing_data)))
+
+    # Run validate/verify function
+    algorithm.validate_detached(signature)
+    algorithm.verify_detached(signing_data, signature, public_key)
+
+    return Bytes(0x01)
+```
+
+#### `sigcost`
+
+The `sigcost` precompile is located at `SIGCOST_PRECOMPILE_ADDRESS` and MUST charge `SIGCOST_PRECOMPILE_GAS` static gas before executing.
+
+The precompile MUST output the dynamic cost of verifying a given signature as a uint256. On failure, the precompile MUST NOT return any data.
+
+The calldata format for this precompile is `AlgorithmId: uint8 || signature_data_size: uint64`.
+
+The precompile is defined as follows:
+
+```python
+def sigcost_precompile(input: Bytes) -> Bytes:
+    charge_gas(SIGCOST_PRECOMPILE_GAS)
+    assert len(input) == 9
+    assert input[0] in algorithm_registry
+
+    signing_data_size = int.from_bytes(input[1:], 'big')
+
+    return gas_cost(input[0], signing_data_size).to_bytes(32, 'big')
+```
+
 
 ## Rationale
 
 ### ERC-4337 interoperability
 
-While initial drafts of this EIP were competing with ERC-4337, current versions of this EIP support it via the sigrecover precompile. This allows any ERC-4337 implementation to have the same signature verification logic and address derivation logic for any given private key. This also works agnostic of whatever algorithm derives the address.
+While initial drafts of this EIP were competing with ERC-4337, current versions of this EIP support it via the precompiles. This allows any ERC-4337 implementation to have the same signature verification logic and address derivation logic for any given private key.
 
-### Precompile over native EVM code
+
+### Opaque signature types
+
+Algorithms may use any number of encoding systems, attempting to handle or standardize all of them would result in significant overhead. Allowing algorithms to define encodings it allows them to be more adapted to preexisting standards such as NIST definitions.
+
+### Precompiles
+
+#### Precompiles over native EVM code
 
 Having a precompile allows non-EVM processes, i.e. transaction level signature verification, to access the registry *without* having to call into the EVM.
 
-### Opaque `signature` type
+#### Many precompiles
 
-As each algorithm has unique properties, e.g. supporting signature recovery and key sizes, the object needs to hold every permutation of every possible signature and potentially additional recovery information. A bytearray of an algorithm-defined size would be able to achieve this goal.
+Many precompiles have been introduced instead of one to prevent excessive edge cases, each precompile has a specific purpose which would make test cases, gas costs & usage easier. 
+
+
+#### Precompile addresses
+
+As this is a suite of precompiles, starting them at a single rounded address instead of at the next sequential address should be better for developer experience.
+
+#### sigaddress
+
+To maintain existing compatibility with ecrecover, sigaddress charges the same amount of gas for an secp256k1 signature with 32 bytes of signing data.
+
+### sigrecover
+
+Sigrecover is functionally identical to `sigaddress` minus the addition address derivation overhead. As such, sigrecover uses the gas cost of `sigaddress` subtract `500` for the additional address derivation.
+
+Sigrecover also returns a full public key, this prevents some of the confusion that `ecrecover` created when returning only an address.
+
+### sigverify
+
+Sigverify is designed for detached signature use cases such as account abstraction where the key is known before hand. The gas cost is only `2000` for this precompile as it does not produce *any* outputs other than a single byte and more gas will be charged with the additional public key data.
+
+### sigcost
+
+Sigcost is a purely static precompile for smart contracts to determine how much gas should be appended onto the base gas when verifying signatures. As this precompile does very little signature work it only charges `25` gas.
 
 ## Backwards Compatibility
 
 EIP-7932 does not modify any existing logic and does not pose any backwards compatibility issues.
 
+## Reference Implementation
+
+<!-- TODO: Update reference implementation -->
+
+The reference implementation may be found in the following files:
+
+- [eip-7932/algorithm_registry/helpers.py](../assets/eip-7932/algorithm_registry/helpers.py)
+- [eip-7932/algorithm_registry/registry.py](../assets/eip-7932/algorithm_registry/registry.py)
+- [eip-7932/precompile.py](../assets/eip-7932/precompile.py)
+
 ## Test Cases
 
+<!-- TODO: Update test cases -->
 Test cases for the `sigrecover` precompile may be found in the [precompile_test_cases.py](../assets/eip-7932/precompile_test_cases.py) file.
 
 ## Security Considerations
 
-Allowing more ways to derive addresses for a single account may decrease overall security for that specific account. However, this is partially mitigated by the increase in processing power required to trial all algorithms. Even still, adding additional algorithms may need further discussion to ensure that the security of the network would not be compromised.
+Allowing more ways to derive addresses for a single account may decrease overall security for that specific account. However, this is mitigated by the increase in processing power required to trial all algorithms. Even still, security discussions would still be required.
 
 ## Copyright
 

--- a/EIPS/eip-7932.md
+++ b/EIPS/eip-7932.md
@@ -411,20 +411,21 @@ Sigcost is a purely static precompile for smart contracts to determine how much 
 
 EIP-7932 does not modify any existing logic and does not pose any backwards compatibility issues.
 
+## Test Cases
+
+<!-- TODO: Update test cases -->
+Test cases for the `sigrecover` precompile may be found in the [precompile_test_cases.py](../assets/eip-7932/precompile_test_cases.py) file.
+
 ## Reference Implementation
 
 <!-- TODO: Update reference implementation -->
 
 The reference implementation may be found in the following files:
 
-- [eip-7932/algorithm_registry/helpers.py](../assets/eip-7932/algorithm_registry/helpers.py)
-- [eip-7932/algorithm_registry/registry.py](../assets/eip-7932/algorithm_registry/registry.py)
-- [eip-7932/precompile.py](../assets/eip-7932/precompile.py)
+- [algorithm_registry/helpers.py](../assets/eip-7932/algorithm_registry/helpers.py)
+- [algorithm_registry/registry.py](../assets/eip-7932/algorithm_registry/registry.py)
+- [precompile.py](../assets/eip-7932/precompile.py)
 
-## Test Cases
-
-<!-- TODO: Update test cases -->
-Test cases for the `sigrecover` precompile may be found in the [precompile_test_cases.py](../assets/eip-7932/precompile_test_cases.py) file.
 
 ## Security Considerations
 

--- a/EIPS/eip-8030.md
+++ b/EIPS/eip-8030.md
@@ -11,6 +11,8 @@ created: 2025-09-20
 requires: 7932, 7951
 ---
 
+<!-- TODO: This EIP needs to be updated to the latest version of the EIP-7932 spec -->
+
 ## Abstract
 
 This EIP adds a new [EIP-7932](./eip-7932.md) algorithm of type `0x01` for supporting P256 signatures.

--- a/assets/eip-7932/algorithm_registry/helpers.py
+++ b/assets/eip-7932/algorithm_registry/helpers.py
@@ -1,3 +1,5 @@
+# TODO: Update this impl, current git ref #7a2e7ad98
+
 from remerkleable.basic import uint8, uint
 from remerkleable.byte_arrays import ByteVector
 

--- a/assets/eip-7932/algorithm_registry/registry.py
+++ b/assets/eip-7932/algorithm_registry/registry.py
@@ -1,3 +1,5 @@
+# TODO: Update this impl, current git ref #7a2e7ad98
+
 from typing import Callable, Dict
 from remerkleable.byte_arrays import ByteVector
 from remerkleable.basic import uint8, uint32, uint64, uint256

--- a/assets/eip-7932/precompile.py
+++ b/assets/eip-7932/precompile.py
@@ -1,3 +1,5 @@
+# TODO: Update this impl, current git ref #7a2e7ad98
+
 from algorithm_registry import helpers, registry
 
 INVALID = b""

--- a/assets/eip-7932/precompile_test_cases.py
+++ b/assets/eip-7932/precompile_test_cases.py
@@ -1,3 +1,5 @@
+# TODO: Update this impl, current git ref #7a2e7ad98
+
 import secp256k1
 
 from precompile import sigrecover_precompile

--- a/assets/eip-7932/template-eip.md
+++ b/assets/eip-7932/template-eip.md
@@ -21,33 +21,53 @@ Generic algorithm has a good reason to be in Ethereum, therefore it should be.
 This EIP defines a new [EIP-7932](../../EIPS/eip-7932.md) algorithmic type with the following parameters.
 
 ```python
-ALG_TYPE = 0xFA
-SIZE = 128
+ALG_TYPE = 0x7E
 
-def gas_cost(signing_data: Bytes) -> Uint64:
-    return Uint64(128 + len(signing_data))
+DETACHED_SIZE = 64
+AUTONOMOUS_SIZE = 128
+PUBLIC_KEY_SIZE = 64
 
-def validate(signature: Bytes) -> None | Error:
+def gas_cost(signing_data_len: uint64) -> uint64:
+    # This is an adaptation from the KECCAK256 opcode
+    # as this algorithm requires exactly 32 signing bytes.
+    # If an algorithm can directly sign data such as ML-DSA,
+    # it should and this function should represent the
+    # internal cost of hashing + a base fee.
+
+    minimum_word_size = (signing_data_len + 31) // 32
+    return uint64(30 + (6 * minimum_word_size))
+
+def validate_autonomous(signature: AutonomousSignature) -> None | Error:
     # ...
     # Simple cryptography here
     # ...
-    return None
 
-def verify(signature: Bytes, signing_data: Bytes) -> Bytes | Error:
+def validate_detached(signature: DetachedSignature) -> None | Error:
+    # ...
+    # Simple cryptography here
+    # ...
+
+def verify_autonomous(
+    signing_data: Bytes,
+    signature: AutonomousSignature
+) -> PublicKey | Error:
     # ...
     # Complicated cryptography here
     # ...
-    return public_key
+    return algorithm_type || untagged_public_key
 
-def merge_detached_signature(detached_signature: bytes, public_key: bytes) -> bytes:
+def verify_detached(
+    signing_data: Bytes,
+    signature: DetachedSignature,
+    public_key: PublicKey
+) -> None | Error:
     # ...
-    # Either concatenation or a no-op here
+    # Complicated cryptography here
     # ...
-    return detached_signature + public_key
 ```
 
 ## Rationale
-Generic algorithm has a good reason to be in Ethereum, therefore it should be.
+Generic algorithm has a good reason to be used in the EVM, therefore it should be.
 
 ## Backwards Compatibility
 No backward compatibility issues found.


### PR DESCRIPTION
This PR refactors EIP-7932 to be more friendly to EIPs like [EIP-8141](https://eips.ethereum.org/EIPS/eip-8141) and [EIP-8164](https://eips.ethereum.org/EIPS/eip-8164).

The key changes are as follows:
- Formalize Autonomous/Detached signatures rather than signatures/detached_signatures
- Renames `sigrecover` -> `sigaddress`
- Introduces 3 new precompiles:
  - `sigrecover`: Similar to `sigaddress` but returns a tagged public key
  - `sigverify`: A precompile designed for AA use cases, takes a DetachedSignature and public key and only verifies them
  - `sigcosts`: Gets the cost of verifying a specific signature for staticcall gas calculation
  