### PR TITLE
Update EIP-8037: fixed CPSB + frame accounting

### DIFF
--- a/EIPS/eip-8037.md
+++ b/EIPS/eip-8037.md
@@ -8,12 +8,12 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2025-10-01
-requires: 2780, 7702, 7825, 8038
+requires: 161, 2780, 7702, 7825, 8038
 ---
 
 ## Abstract
 
-This proposal increases the cost of state creation operations, thus avoiding excessive state growth under increased block gas limits. It sets the unit cost per new state byte by targeting an average state growth of 96 GiB per year and a gas limit of 100M gas units. It also introduces an independent metering for state creation costs, thus allowing for increased throughput and for larger contract deployments without being limited by the single transaction gas limit.
+This proposal increases the cost of state creation operations, thus avoiding excessive state growth under increased block gas limits. It sets the unit cost per new state byte by targeting an average state growth of 100 GiB per year at a reference block gas limit of 96M gas units. It also introduces an independent metering for state creation costs, thus allowing for increased throughput and for larger contract deployments without being limited by the single transaction gas limit.
 
 ## Motivation
 
@@ -23,7 +23,7 @@ Additionally, state growth will become a bottleneck for scaling under higher blo
 
 ![new_state_added](../assets/eip-8037/new_state_added.png)
 
-The relationship we are seeing in this example is not linear as expected. This is likely due to other factors impacting user behavior. However, all else being equal, we expect a proportional increase in the number of new states created as gas limits increase. At a 60M gas limit (and a proportional increase in new state per day of 1.7x), we would see a daily state growth of ~349 MiB and a yearly state growth of ~124 GiB. Similarly, at a 100M gas limit, the state would grow at a rate of ~553 MiB per day and 197 GiB per year. This level of state growth would give us less than 2.5 years until the size of the state database exceeds the threshold of 650 GiB, at which point nodes will begin experiencing a degradation in performance.
+The state-growth response we observe is not linear in the gas limit increase: a 1.2x bump (30M → 36M) produced a roughly 2x jump in daily new state, suggesting a one-off shift in user behavior rather than a steady-state ratio. Treating the post-bump rate as the new baseline and extrapolating proportionally to the new gas limit, at a 60M gas limit we would see a daily state growth of ~349 MiB and a yearly state growth of ~124 GiB. Similarly, at a 100M gas limit, the state would grow at a rate of ~553 MiB per day and ~197 GiB per year. Starting from 340 GiB, this rate would breach the 650 GiB threshold (at which point nodes begin experiencing performance degradation) in under 1.6 years.
 
 ## Specification
 
@@ -62,7 +62,7 @@ The `PER_AUTH_BASE_COST` regular gas of 7,500 is derived from [EIP-7702](./eip-7
 
 Total regular gas: 1,616 + 3,000 + 2,600 + 200 ≈ 7,500
 
-In addition, `GAS_SELF_DESTRUCT_NEW_ACCOUNT` is removed and replaced by `GAS_NEW_ACCOUNT`.
+In addition, `GAS_SELF_DESTRUCT_NEW_ACCOUNT` is removed and replaced by `GAS_NEW_ACCOUNT`. This unifies the new-account charge across all paths that can create one (including `SELFDESTRUCT` transferring balance to a non-existent beneficiary) under a single parameter; the resulting cost is identical to that of any other new account creation.
 
 ### Multidimensional metering for state creation costs
 
@@ -70,7 +70,7 @@ Besides the parameter changes, this proposal introduces an independent metering 
 
 At transaction level, the user pays for both regular-gas and state-gas. The total gas cost of a transaction is the sum of both dimensions. In addition, the transaction gas limit set in [EIP-7825](./eip-7825.md) only applies to regular-gas, while state-gas is only capped by `tx.gas`.
 
-At the block level, only the gas used in the bottleneck resource is considered when checking if the block is full and when updating the base fee for the next block. This gives a new meaning to the block’s gas limit and the block’s gas target, which now corresponds to the maximum gas that can be metered in the bottleneck resource.
+At the block level, only the gas used in the bottleneck resource is considered when checking if the block is full and when updating the base fee for the next block. This gives a new meaning to the block's gas limit and the block's gas target: each now bounds the bottleneck resource (the dimension with the highest cumulative gas used) rather than a single combined gas counter.
 
 #### Transaction validation
 
@@ -91,7 +91,7 @@ gas_left = min(regular_gas_budget, execution_gas)
 state_gas_reservoir = execution_gas - gas_left
 ```
 
-This means that The `state_gas_reservoir` holds gas that exceeds the [EIP-7825](./eip-7825.md)'s budget.. Additionally, two new counters are introduced:
+This means that the `state_gas_reservoir` holds gas that exceeds [EIP-7825](./eip-7825.md)'s budget. Additionally, two new counters are introduced:
 
 - `execution_regular_gas_used` encodes the total regular-gas used by the transaction, and it is initialized as `execution_regular_gas_used = intrinsic_regular_gas`.
 - `execution_state_gas_used` encodes the total state-gas used by the transaction, and it is initialized as `execution_state_gas_used = intrinsic_state_gas`.
@@ -113,7 +113,7 @@ When a frame returns successfully, the EVM derives its state-gas charges and ref
 For each storage slot whose value differs between the frame's entry and exit states, the frame is charged or refunded as follows:
 
 - **New slot.** The slot's frame-exit value is non-zero and its transaction-entry value was zero. Charge `STATE_BYTES_PER_STORAGE_SET × CPSB` of state gas and increase `execution_state_gas_used` by the same amount.
-- **Cleared slot, zero at transaction start.** The slot's frame-exit value is zero, its frame-entry value was non-zero, and its transaction-entry value was zero (the slot was created earlier in the same transaction and is now being cleared). Refund `STATE_BYTES_PER_STORAGE_SET × CPSB` directly to `state_gas_reservoir` and decrease `execution_state_gas_used` by the same amount. This refund is not subject to the 20% refund cap, since the corresponding charge was incurred in the same transaction.
+- **Cleared slot, zero at transaction start.** The slot's frame-exit value is zero, its frame-entry value was non-zero, and its transaction-entry value was zero (the slot was created earlier in the same transaction and is now being cleared). Refund `STATE_BYTES_PER_STORAGE_SET × CPSB` directly to `state_gas_reservoir` and decrease `execution_state_gas_used` by the same amount; this state-gas refund is not subject to the 20% refund cap, since the corresponding charge was incurred in the same transaction. Additionally, `GAS_STORAGE_UPDATE - GAS_COLD_SLOAD - GAS_WARM_ACCESS` is added to `refund_counter`, subject to the 20% refund cap, refunding the regular-gas portion of the original `SSTORE_SET` charge and preserving the current EVM refund behavior (i.e., a residual of `GAS_WARM_ACCESS` per round-trip).
 - **Cleared slot, non-zero at transaction start.** The slot's frame-exit value is zero, its frame-entry value was non-zero, and its transaction-entry value was non-zero (a pre-existing slot is being cleared). No state-gas adjustment; instead, `GAS_STORAGE_UPDATE - GAS_COLD_SLOAD - GAS_WARM_ACCESS` is added to `refund_counter`, subject to the 20% refund cap. No changes to `execution_state_gas_used`
 - **Other transitions** (e.g., between two non-zero values, or transient changes that net to no change between frame entry and frame exit): no state-gas charge or refund.
 
@@ -194,7 +194,7 @@ gas_used_delta = parent.gas_used - parent.gas_target
 
 #### [EIP-7702](./eip-7702.md) authorizations
 
-For [EIP-7702](./eip-7702.md) authorizations, the intrinsic state gas assumes account creation for each authorization: `(STATE_BYTES_PER_NEW_ACCOUNT + STATE_BYTES_PER_AUTH_BASE) × CPSB` per authorization. When an authorization targets an existing account (no account creation needed), the `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` portion is refunded directly to `state_gas_reservoir` during authorization processing. `execution_state_gas_used` decreases by the corresponding amount.
+For [EIP-7702](./eip-7702.md) authorizations, the intrinsic state gas assumes account creation for each authorization: `(STATE_BYTES_PER_NEW_ACCOUNT + STATE_BYTES_PER_AUTH_BASE) × CPSB` per authorization. This mirrors [EIP-7702](./eip-7702.md)'s own intrinsic charge of `PER_EMPTY_ACCOUNT_COST` per authorization, which assumes the authority is empty. When the `authority` is not empty (using the same definition as [EIP-7702](./eip-7702.md) step 7, i.e., per [EIP-161](./eip-161.md): non-zero nonce, non-zero balance, or non-empty code) and therefore no account creation is needed, the `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` portion is refunded directly to `state_gas_reservoir` during authorization processing, in parallel with [EIP-7702](./eip-7702.md)'s `PER_EMPTY_ACCOUNT_COST - PER_AUTH_BASE_COST` regular-gas refund. `execution_state_gas_used` decreases by the corresponding amount.
 
 `intrinsic_state_gas` is immutable after transaction validation and is not modified by this refund. Block accounting uses the original worst-case `intrinsic_state_gas`; the refunded gas is reflected in the final `state_gas_reservoir` rather than in a mutated intrinsic value.
 
@@ -204,13 +204,11 @@ Receipt `cumulative_gas_used` tracks the cumulative sum of `tx_gas_used_after_re
 
 #### `CREATE` vs `CREATE2`
 
-`CREATE2` already charges for hashing the init code when deriving the address. That cost remains unchanged. The bytecode hash (`keccak256(B)`) must be computed on success to store the code, incurring `HASH_COST(L)` as specified above.
+`CREATE2` already charges for hashing the init code when deriving the address. That cost remains unchanged. The bytecode hash (`keccak256(B)`) must be computed on success to store the code, incurring the regular-gas hashing cost `6 × ⌈L/32⌉` defined above for `GAS_CODE_DEPOSIT`.
 
 ### System contracts and system transactions
 
-The calls to system contracts at the start of every block have their gas limit updated from 30M to:
-
-The gas limit of system contracts (e.g., [EIP-2935](./eip-2935.md), [EIP-4788](./eip-4788.md), [EIP-7002](./eip-7002.md), [EIP-7251](./eip-7251.md)) that are invoked at the start of every block via a system call is updated to:
+The gas limit of system contracts (e.g., [EIP-2935](./eip-2935.md), [EIP-4788](./eip-4788.md), [EIP-7002](./eip-7002.md), [EIP-7251](./eip-7251.md)) that are invoked at the start of every block via a system call is updated from 30M to:
 
 ```python
 SYSTEM_CALL_GAS_LIMIT = 30_000_000 + STATE_BYTES_PER_STORAGE_SET × CPSB × SYSTEM_MAX_SSTORES_PER_CALL
@@ -276,7 +274,7 @@ This proposal is consistent with [EIP-8011](./eip-8011.md). However, it only req
 
 #### EIP-7825 limit on contract size
 
-[EIP-7825](./eip-7825.md) introduces `TX_MAX_GAS_LIMIT` (16.7M) as the maximum gas for a single transaction, in particular stipulating `tx.gas < TX_MAX_GAS_LIMIT`as a validity condition. Were we to continue enforcing this validity condition, with a block limit of 100M gas units, this proposal would limit the maximum contract size that can be deployed to roughly 9.9kB ($\frac{16,777,216 - 21,000 - 5,000,000 - 112 \times 1174}{1174} = 9'902$). This maximum size would only decrease as we increase the gas limit and the `CPSB`.
+[EIP-7825](./eip-7825.md) introduces `TX_MAX_GAS_LIMIT` (16.7M) as the maximum gas for a single transaction, in particular stipulating `tx.gas < TX_MAX_GAS_LIMIT`as a validity condition. Were we to continue enforcing this validity condition, with a block limit of 100M gas units, this proposal would limit the maximum contract size that can be deployed to roughly 9.9kB. Assuming a representative constructor execution budget of 5M regular gas on top of the 21,000 base transaction cost and the `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` account-creation cost, the remaining budget for code-deposit state gas yields $\frac{16,777,216 - 21,000 - 5,000,000 - 112 \times 1174}{1174} \approx 9{,}902$ bytes. This maximum size would only decrease as we increase the gas limit and the `CPSB`.
 
 To solve this issue, we only apply this gas limit to regular gas, not state gas. Doing so does not weaken the intended scaling effect of [EIP-7825](./eip-7825.md), because regular gas meters all resources that benefit from parallelization. In particular, state growth does not: growing the state always requires writing to disk, a parallelizable operation, but crucially this part of the cost of a state growth operation has to be metered in regular gas, not state gas. In other words, any operation that grows the state should consume both regular gas and state gas, and the regular gas should fully account for all costs other than the long term effect of growing the state.
 
@@ -290,10 +288,10 @@ Another advantage of metering contract creation separately is that increasing th
 
 This is a backwards-incompatible gas repricing that requires a scheduled network upgrade.
 
-Wallet developers and node operators MUST update gas estimation handling to accommodate the new calldata cost rules. Specifically:
+Wallet developers and node operators MUST update gas estimation handling to accommodate the new state creation costs and the two-dimensional metering model. Specifically:
 
-- Wallets: Wallets using `eth_estimateGas` MUST be updated to ensure that they correctly account for the updated gas parameters. Failure to do so could result in underestimating gas, leading to failed transactions.
-- Node Software: RPC methods such as `eth_estimateGas` MUST incorporate the updated formula for gas calculation with the new floor cost values.
+- Wallets: Wallets using `eth_estimateGas` MUST be updated to ensure they correctly account for the updated state creation costs and report `tx.gas` covering both the regular-gas and state-gas dimensions. Failure to do so could result in underestimating gas, leading to failed transactions.
+- Node Software: RPC methods such as `eth_estimateGas` MUST incorporate the new state-gas charges, the reservoir-model accounting, and the two-dimensional block accounting when computing gas estimates.
 
 Users can maintain their usual workflows without modification, as wallet and RPC updates will handle these changes.
 

--- a/EIPS/eip-8037.md
+++ b/EIPS/eip-8037.md
@@ -8,12 +8,12 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2025-10-01
-requires: 2780, 7702, 7825, 8011
+requires: 2780, 7702, 7825, 8038
 ---
 
 ## Abstract
 
-This proposal increases the cost of state creation operations, thus avoiding excessive state growth under increased block gas limits. It dynamically sets the unit cost per new state byte at a given block gas limit, by targeting an average state growth of 100 GiB per year based on current network usage. It also introduces an independent metering for state creation costs, thus allowing for increased throughput and for larger contract deployments without being limited by the single transaction gas limit.
+This proposal increases the cost of state creation operations, thus avoiding excessive state growth under increased block gas limits. It sets the unit cost per new state byte by targeting an average state growth of 100 GiB per year based on current network usage and a gas limit of 100M gas units. It also introduces an independent metering for state creation costs, thus allowing for increased throughput and for larger contract deployments without being limited by the single transaction gas limit.
 
 ## Motivation
 
@@ -31,35 +31,26 @@ The relationship we are seeing in this example is not linear as expected. This i
 
 | **Parameter** | **Value** |
 |:---:|:---:|
-| `TARGET_STATE_GROWTH_PER_YEAR` | 100 × 1024^3 bytes |
-| `CPSB_SIGNIFICANT_BITS` | 5 |
-| `CPSB_OFFSET` | 9578 |
+| `CPSB` | 1174 |
+| `STATE_BYTES_PER_STORAGE_SET` | 32 |
+| `STATE_BYTES_PER_NEW_ACCOUNT` | 112 |
 
-Besides these fixed parameters, this EIP introduces a dynamic variable that controls the cost per byte of state created for a given block gas limit. The variable is `cost_per_state_byte` and is calculated as follows:
-
-```python
-raw = ceil((gas_limit * 2_628_000) / (2 * TARGET_STATE_GROWTH_PER_YEAR))
-shifted = raw + CPSB_OFFSET
-shift = max(bit_length(shifted) - CPSB_SIGNIFICANT_BITS, 0)
-cost_per_state_byte = max(((shifted >> shift) << shift) - CPSB_OFFSET, 1)
-```
-
-The raw value is the unquantized cost derived from targeting `TARGET_STATE_GROWTH_PER_YEAR` at 50% average gas utilization (see [Deriving the cost per byte](#deriving-the-cost-per-byte)). Quantization retains the top `CPSB_SIGNIFICANT_BITS` significant bits after applying `CPSB_OFFSET`, producing a stepped function that avoids frequent small changes as the gas limit fluctuates (see [Quantization](#quantization-of-cost_per_state_byte)).
+<!-- TODO -->
 
 ### Parameter changes
 
-Upon activation of this EIP, the following parameters of the gas model are updated. The "New State Gas" column shows the state gas cost (charged to the `state_gas` dimension), while the "New Regular Gas" column shows additional regular gas costs that accompany the state gas charge.
+Upon activation of this EIP, the following parameters of the gas model are updated. The "New State Gas" column shows the state gas cost (charged to the state-gas dimension), while the "New Regular Gas" column shows additional regular gas costs that accompany the state gas charge.
 
 | **Parameter** | **Current** | **New State Gas** | **New Regular Gas** | **Operations affected** |
 |---|---|---|---|---|
-| `GAS_CREATE` | 32,000 | 112 × `cpsb` | 9,000 (assuming same as `GAS_CALL_VALUE`)  | `CREATE`, `CREATE2`, contract creation txs |
-| `GAS_CODE_DEPOSIT` | 200/byte | `cpsb` per byte | `6 × ceil(len/32)` (hash cost) | `CREATE`, `CREATE2`, contract creation txs |
-| `GAS_NEW_ACCOUNT` | 25,000 | 112 × `cpsb` | 0 (already has `GAS_CALL_VALUE` 9,000) | `CALL*` |
-| `GAS_STORAGE_SET` | 20,000 | 32 × `cpsb` | 2,900 (`GAS_STORAGE_UPDATE - GAS_COLD_SLOAD`) | `SSTORE` |
-| `PER_EMPTY_ACCOUNT_COST` | 25,000 | 112 × `cpsb` | 0 (included in `PER_AUTH_BASE_COST`) | EOA delegation |
-| `PER_AUTH_BASE_COST` | 12,500 | 23 × `cpsb` | 7,500 | EOA delegation |
+| `GAS_CREATE` | 32,000 | `STATE_BYTES_PER_NEW_ACCOUNT x CPSB` | 9,000 (assuming same as `GAS_CALL_VALUE`)  | `CREATE`, `CREATE2`, contract creation txs |
+| `GAS_CODE_DEPOSIT` | 200/byte | `CPSB` per byte | `6 × ceil(len/32)` (hash cost) | `CREATE`, `CREATE2`, contract creation txs |
+| `GAS_NEW_ACCOUNT` | 25,000 | `STATE_BYTES_PER_NEW_ACCOUNT x CPSB` | 0 (already has `GAS_CALL_VALUE` 9,000) | `CALL*` |
+| `GAS_STORAGE_SET` | 20,000 | `STATE_BYTES_PER_STORAGE_SET x CPSB` | 2,900 (`GAS_STORAGE_UPDATE - GAS_COLD_SLOAD`) | `SSTORE` |
+| `PER_EMPTY_ACCOUNT_COST` | 25,000 | `STATE_BYTES_PER_NEW_ACCOUNT x CPSB` | 0 (included in `PER_AUTH_BASE_COST`) | EOA delegation |
+| `PER_AUTH_BASE_COST` | 12,500 | 23 × `CPSB` | 7,500 | EOA delegation |
 
-Where `cpsb` = `cost_per_state_byte`. The values assigned to regular gas will be updated based on [EIP-8038](./eip-8038.md).
+The values assigned to regular gas will be updated based on [EIP-8038](./eip-8038.md).
 
 The `PER_AUTH_BASE_COST` regular gas of 7,500 is derived from [EIP-7702](./eip-7702.md)'s cost analysis, excluding the code deployment cost (now charged as state gas):
 
@@ -75,37 +66,18 @@ In addition, `GAS_SELF_DESTRUCT_NEW_ACCOUNT` is removed and replaced by `GAS_NEW
 
 ### Multidimensional metering for state creation costs
 
-Besides the parameter changes, this proposal introduces an independent metering for state creation costs. The specification is derived from [EIP-8011](./eip-8011.md). However, it only requires two dimensions, namely, `regular_gas` and `state_gas`. For state creation operations, the "new state costs" are charged to `state_gas`, while the "new regular costs" are charged to `regular_gas`. The costs of all other operations are also charged to `regular_gas`.
+Besides the parameter changes, this proposal introduces an independent metering for state creation costs. Two gas dimensions are introduced, regular-gas and state-gas. For state creation operations, the "new state costs" are charged to state-gas, while the "new regular costs" are charged to regular-gas. The costs of all other operations are also charged to regular-gas.
 
-At transaction level, the user pays for both `regular_gas` and `state_gas`. The total gas cost of a transaction is the sum of both dimensions. In addition, the transaction gas limit set in [EIP-7825](./eip-7825.md) only applies to `regular_gas`, while `state_gas` is only capped by `tx.gas`.
+At transaction level, the user pays for both regular-gas and state-gas. The total gas cost of a transaction is the sum of both dimensions. In addition, the transaction gas limit set in [EIP-7825](./eip-7825.md) only applies to regular-gas, while state-gas is only capped by `tx.gas`.
 
 At the block level, only the gas used in the bottleneck resource is considered when checking if the block is full and when updating the base fee for the next block. This gives a new meaning to the block’s gas limit and the block’s gas target, which now corresponds to the maximum gas that can be metered in the bottleneck resource.
 
 #### Transaction validation
 
-Before transaction execution, `calculate_intrinsic_cost` returns three values: `intrinsic_regular_gas`, `intrinsic_state_gas`, and `calldata_floor_gas_cost`. State gas components of intrinsic cost (e.g., account creation for contract deployment transactions, [EIP-2780](./eip-2780.md) charges, [EIP-7702](./eip-7702.md) authorization charges) are included in `intrinsic_state_gas`. All other intrinsic costs (base transaction cost, calldata, access lists, authorization base costs) are included in `intrinsic_regular_gas`.
+Before transaction execution, inclusion of a transaction in a block requires that:
 
-`validate_transaction` rejects transactions where:
-
-```python
-max(intrinsic_regular_gas, calldata_floor_gas_cost) > TX_MAX_GAS_LIMIT
-```
-
-`validate_transaction` also returns `intrinsic_regular_gas`, `intrinsic_state_gas`, and `calldata_floor_gas_cost`.
-
-After this check, inclusion of a transaction in a block additionally requires that, for each gas dimension, the cumulative gas used of all previous transactions added to the transaction's contribution must not exceed the block gas limit. This contribution is assumed as the worst case for each dimension, before actually executing the transaction. Specifically, `check_transaction` is updated to:
-
-```python
-regular_gas_available = block_env.block_gas_limit - block_output.block_regular_gas_used
-state_gas_available = block_env.block_gas_limit - block_output.block_state_gas_used
-# ...
-if min(TX_MAX_GAS_LIMIT, tx.gas - intrinsic_state_gas) > regular_gas_available:
-    raise GasUsedExceedsLimitError("gas used exceeds limit")
-if tx.gas - intrinsic_regular_gas > state_gas_available:
-    raise GasUsedExceedsLimitError("gas used exceeds limit")
-```
-
-`intrinsic_regular_gas` and `intrinsic_state_gas` must be passed to `check_transaction` to perform the regular gas availability check.
+1. The transaction's **intrinsic costs are not higher than [EIP-7825](./eip-7825.md)'s transaction cap**. Concretely, `max(intrinsic_regular_gas, calldata_floor_gas_cost) <= TX_MAX_GAS_LIMIT`, where `intrinsic_regular_gas` includes all the intrinsic costs not associated with state created (i.e., base transaction cost, calldata, access lists, authorization base costs).
+2. For each gas dimension, the **cumulative gas used of all previous transactions added to the transaction's contribution does not exceed the block gas limit**. Concretely, `min(TX_MAX_GAS_LIMIT, tx.gas) <= regular_gas_available` and `tx.gas <= state_gas_available`, where `regular_gas_available = block_env.block_gas_limit - block_output.block_regular_gas_used` and `state_gas_available = block_env.block_gas_limit - block_output.block_state_gas_used`.
 
 #### Transaction-level gas accounting (reservoir model)
 
@@ -121,27 +93,67 @@ state_gas_reservoir = execution_gas - gas_left
 
 The `state_gas_reservoir` holds gas that exceeds the [EIP-7825](./eip-7825.md)'s budget. The two counters operate as follows:
 
-- **Regular gas** charges deduct from `gas_left` only.
-- **State gas** charges deduct from `state_gas_reservoir` first; when the reservoir is exhausted, from `gas_left`. The charge increments `execution_state_gas_used` by its full amount regardless of whether it was satisfied from the reservoir, from `gas_left`, or partially from both; a state gas charge never increments `execution_regular_gas_used`.
-- When an opcode requires both regular and state gas, the regular gas charge MUST be applied first. If the regular gas charge triggers an out-of-gas error, the state gas charge is not applied.
+- regular-gas charges deduct from `gas_left` only.
+- state-gas charges deduct from `state_gas_reservoir` first. When the reservoir is exhausted, state gas charges deduct from `gas_left`.
 - The `GAS` opcode returns `gas_left` only (excluding the reservoir).
-- The reservoir is passed **in full** to child frames (no 63/64 rule). On child success, the remaining `state_gas_reservoir` is returned to the parent and the child's `execution_state_gas_used` is added to the parent's `execution_state_gas_used`. On child **revert** or **exceptional halt**, all state gas consumed by the child, both from the reservoir and any that spilled into `gas_left`, is restored to the parent's `state_gas_reservoir`; the child's `execution_state_gas_used` is **not** added to the parent's `execution_state_gas_used`, because state changes are rolled back and no state was actually grown. On child **exceptional halt**, the child's `gas_left` is additionally consumed (zeroed).
-- On **revert** or **exceptional halt** at the top level (no parent frame), all state gas consumed during execution — both from the `state_gas_reservoir` and any that spilled into `gas_left` — is restored to the `state_gas_reservoir`, and `execution_state_gas_used` is reset to zero, because state changes are fully reverted and no state was actually grown. This mirrors the child frame restoration: the sender is refunded the full execution state gas via the reservoir. On **exceptional halt** specifically, remaining `gas_left` is additionally set to zero (all regular gas consumed), consistent with existing EVM out-of-gas semantics. System transactions are not subject to the `TX_MAX_GAS_LIMIT` cap, their entire `execution_gas` is placed in `gas_left` with `state_gas_reservoir = 0`.
+- state-gas is metered at call-frame boundaries and at the end of the transaction, not at individual state-mutating opcodes. Each frame's state-gas cost is derived from the state diff it accumulated since the call-frame began — the changes between its entry state and exit state — categorized against the **transaction-entry state** (the state at the start of the transaction) to determine which storage slot writes and account creations count as new.
 
-The two counters are returned by the transaction output. Besides the two counters, the EVM also keeps track of `execution_state_gas_used` and `execution_regular_gas_used` during transaction execution. `state_gas` costs are added to `execution_state_gas_used` while `regular_gas` costs are added to `execution_regular_gas_used`. These two counters are also returned by the transaction output.
+##### Frame-end state-gas accounting
+
+When a frame returns successfully, the EVM derives its state-gas charges and refunds from the changes the frame caused that have not already been accounted for by a successful descendant frame. Two reference points are used:
+
+- the **transaction-entry value** of each storage slot or account, used to determine whether a write counts as a new slot or a new account; and
+- the **frame-entry value**, used to determine the changes attributable to the frame (a frame is not charged for state that already existed when its execution began).
+
+For each storage slot whose value differs between the frame's entry and exit states, the frame is charged or refunded as follows:
+
+- **New slot.** The slot's frame-exit value is non-zero and its transaction-entry value was zero. Charge `STATE_BYTES_PER_STORAGE_SET × cost_per_state_byte` of state gas.
+- **Cleared slot, zero at transaction start.** The slot's frame-exit value is zero, its frame-entry value was non-zero, and its transaction-entry value was zero (the slot was created earlier in the same transaction and is now being cleared). Refund `STATE_BYTES_PER_STORAGE_SET × cost_per_state_byte` directly to `state_gas_reservoir` and decrement `execution_state_gas_used` by the same amount. This refund is not subject to the 20% refund cap, since the corresponding charge was incurred in the same transaction.
+- **Cleared slot, non-zero at transaction start.** The slot's frame-exit value is zero, its frame-entry value was non-zero, and its transaction-entry value was non-zero (a pre-existing slot is being cleared). No state-gas adjustment; instead, `GAS_STORAGE_UPDATE - GAS_COLD_SLOAD - GAS_WARM_ACCESS` is added to `refund_counter`, subject to the 20% refund cap.
+- **Other transitions** (e.g., between two non-zero values, or transient changes that net to no change between frame entry and frame exit): no state-gas charge or refund.
+
+For each account:
+
+- **New account.** The account exists at the frame's exit state, did not exist at the start of the transaction, and was not already accounted for by a successful descendant frame. Charge `STATE_BYTES_PER_NEW_ACCOUNT × cost_per_state_byte` of state gas.
+- **Code deposit on creation.** For a newly created account with bytecode `B` of length `L`, additionally charge `L × cost_per_state_byte` of state gas plus `6 × ⌈L/32⌉` of regular gas (the bytecode hashing cost).
+
+`SELFDESTRUCT` does not produce a state-gas effect at the frame in which it executes; its accounting is deferred to the end of the transaction (see [Top-level frame end](#top-level-frame-end-transaction-end) below).
+
+Each storage slot or account that is created or cleared in the transaction is charged or refunded exactly once across the call stack: once a successful descendant frame has accounted for a state change, ancestor frames do not re-account for it.
+
+##### Reservoir propagation across frames
+
+The reservoir is passed **in full** to child frames (no 63/64 rule). When a child returns successfully, the remaining `state_gas_reservoir` is returned to the parent, and the child's `execution_state_gas_used` is added to the parent's `execution_state_gas_used`. The frame-end accounting above is what populates the child's contribution.
+
+When a child **reverts** or **halts exceptionally**, all of its state changes are rolled back. Because state-gas accounting is performed only at the boundary of a successful frame, a reverted or halted child contributes nothing to the parent's `execution_state_gas_used` and produces no debits or credits to the parent's `state_gas_reservoir`. On exceptional halt, the child's `gas_left` is additionally consumed (zeroed), consistent with existing EVM semantics.
+
+On **revert** or **exceptional halt** of the top-level frame, all state changes are reverted and no state gas is charged. On exceptional halt specifically, remaining `gas_left` is set to zero. System transactions are not subject to the `TX_MAX_GAS_LIMIT` cap; their entire `execution_gas` is placed in `gas_left` with `state_gas_reservoir = 0`.
+
+##### Top-level frame end (transaction end)
+
+At the end of a successful transaction, the top-level frame applies the frame-end accounting above and additionally performs deferred `SELFDESTRUCT` processing. [EIP-6780](./eip-6780.md) defers actual account removal to the end of the transaction for accounts that were created and self-destructed in the same transaction; the corresponding state-gas effect is therefore also computed only at this point.
+
+For each account that was created during the transaction, `SELFDESTRUCT`ed, and is now being removed:
+
+- The state gas previously charged for the account creation (`STATE_BYTES_PER_NEW_ACCOUNT × cost_per_state_byte`), the code deposit (`L × cost_per_state_byte` where `L` is the deployed code length), and every storage slot that was charged as new on that account during the transaction (`STATE_BYTES_PER_STORAGE_SET × cost_per_state_byte` per slot) is refunded directly to `state_gas_reservoir`, and `execution_state_gas_used` is decremented by the same amount.
+- These refunds are not subject to the 20% refund cap.
+
+For an account that existed before the transaction, `SELFDESTRUCT` only transferred its balance and the account is not removed; no state-gas refund applies.
+
+The two counters `gas_left` and `state_gas_reservoir`, along with `execution_state_gas_used` and `execution_regular_gas_used`, are returned by the transaction output. `state-gas` costs are accumulated into `execution_state_gas_used` and `regular-gas` costs into `execution_regular_gas_used` during transaction execution.
 
 #### Pre-state and post-state gas validation
 
-During execution, [EIP-7928](./eip-7928.md) defines two-phase gas validation for state-accessing opcodes: pre-state costs (determinable without state access) and post-state costs (requiring state access). Pre-state validation must pass before any state access occurs. Under the reservoir model, both regular and state gas portions of pre-state costs must be satisfiable; regular gas is checked against `gas_left`, state gas against `state_gas_reservoir` (then `gas_left`). If either check fails, the state access does not occur.
+[EIP-7928](./eip-7928.md) defines two-phase gas validation for state-accessing opcodes: pre-state costs (determinable without state access) and post-state costs (requiring state access). Under this EIP, the regular-gas portion of these opcodes follows the [EIP-7928](./eip-7928.md) rules unchanged and is charged at opcode time against `gas_left`. The state-gas portion is **not** charged at the opcode level; it is computed and deducted at frame-end accounting (see [Frame-end state-gas accounting](#frame-end-state-gas-accounting)), drawing first from `state_gas_reservoir` and then from `gas_left`.
 
-The cost parameters introduced by this EIP map to validation phases as follows:
+The cost parameters introduced by this EIP map as follows:
 
-| Cost Parameter | Validation Phase | State Gas | Regular Gas |
+| Cost Parameter | When the state-gas component is charged | State Gas | Regular Gas (charged at opcode) |
 |---|---|---|---|
-| `GAS_CREATE` | Pre-state | 112 × `cpsb` | 9,000 |
-| `GAS_CODE_DEPOSIT` | Post-state (on deployment success) | `cpsb` × L | 6 × ⌈L/32⌉ |
-| `GAS_NEW_ACCOUNT` | Post-state (requires account existence check) | 112 × `cpsb` | 0 |
-| `GAS_STORAGE_SET` | Post-state (requires reading current value) | 32 × `cpsb` | 2,900 |
+| `GAS_CREATE` | Frame end of the creating frame, if a new account persists | `STATE_BYTES_PER_NEW_ACCOUNT × cpsb` | 9,000 |
+| `GAS_CODE_DEPOSIT` | Frame end of the creating frame, if code is deployed | `cpsb × L` | `6 × ⌈L/32⌉` |
+| `GAS_NEW_ACCOUNT` | Frame end of the calling frame, if a new account persists | `STATE_BYTES_PER_NEW_ACCOUNT × cpsb` | 0 |
+| `GAS_STORAGE_SET` | Frame end of the writing frame, if a new slot persists | `STATE_BYTES_PER_STORAGE_SET × cpsb` | 2,900 |
 
 For `SSTORE`, the `GAS_CALL_STIPEND` pre-state check ([EIP-7928](./eip-7928.md)) applies to `gas_left` only, excluding the `state_gas_reservoir`.
 
@@ -159,7 +171,7 @@ The refund cap remains at 20% of gas used.
 
 #### Block-level gas accounting
 
-At block level, instead of tracking a single `gas_used` counter, we keep track of two counters, one for `state_gas` and one for `regular_gas`:
+At block level, instead of tracking a single `gas_used` counter, we keep track of two counters, one for `state-gas` and one for `regular-gas`:
 
 ```python
 tx_regular_gas = intrinsic_regular_gas + tx_output.execution_regular_gas_used
@@ -190,40 +202,22 @@ The base fee update rule is also modified accordingly:
 gas_used_delta = parent.gas_used - parent.gas_target
 ```
 
-### `SSTORE` refund for slot restoration
+### Worked example: `SSTORE` slot restoration
 
-When a storage slot is set to a non-zero value and then restored to zero within the same transaction (0 to X to 0 pattern), the state gas and regular gas refunds are handled separately:
+The 0 → X → 0 pattern (a storage slot is set to a non-zero value and then restored to zero within the same transaction) is fully captured by [Frame-end state-gas accounting](#frame-end-state-gas-accounting). For a slot whose transaction-entry value was zero:
 
-- State gas: `32 × cost_per_state_byte` is refunded directly to `state_gas_reservoir` (and `execution_state_gas_used` is decremented). The refund happens immediately at the X to 0 SSTORE, not via `refund_counter`. This ensures the full state gas amount is returned regardless of the 20% refund cap.
-- Regular gas: `GAS_STORAGE_UPDATE - GAS_COLD_SLOAD - GAS_WARM_ACCESS` is added to `refund_counter`, subject to the 20% cap.
+- If the entire 0 → X → 0 sequence happens inside a single frame, the frame's exit value equals its entry value (zero) and the slot does not appear in any frame-end charge or refund. No state gas is paid; no refund is needed.
+- If the 0 → X is committed by a successful descendant frame and the X → 0 is performed in an ancestor frame, the descendant's frame end charges `STATE_BYTES_PER_STORAGE_SET × cost_per_state_byte` of state gas, and the ancestor's frame end refunds the same amount directly to `state_gas_reservoir` (decrementing `execution_state_gas_used`), not subject to the 20% cap.
 
-The state gas refund is scoped to the frame that executes the X to 0 SSTORE, and propagates to an ancestor frame only if all intervening frames return successfully. On **revert** or **exceptional halt** of the applying frame or of any ancestor frame the refund has reached, the refund's credit to `state_gas_reservoir` and its decrement of `execution_state_gas_used` are undone at that frame and are not inherited by its parent. As a result, whenever any frame in the chain experiences a **revert** or **exceptional halt**, the 0 to X to 0 refund contributes nothing to `state_gas_reservoir` or `execution_state_gas_used`, consistent with the principle that state gas is only refunded when no state was actually grown.
+In both cases, the regular-gas refund-counter contribution from the cleared SSTORE is `GAS_STORAGE_UPDATE - GAS_COLD_SLOAD - GAS_WARM_ACCESS`, subject to the 20% cap, and the net cost after refund is consistent with pre-[EIP-8037](./eip-8037.md) `SSTORE` restoration behavior.
 
-The net cost after refund is `GAS_WARM_ACCESS`, consistent with pre-[EIP-8037](./eip-8037.md) `SSTORE` restoration behavior.
+If any frame in the call chain reverts or halts before the cleared-slot observation reaches a successful frame boundary, both the 0 → X charge and the X → 0 refund are rolled back along with the underlying state changes, and neither contributes to `execution_state_gas_used` or `state_gas_reservoir`.
 
-### State gas on frame failure
+### `CALL` with value to a self-destructed account in the same transaction
 
-State gas is deducted at the point of the operation (`CREATE`, `CALL` to new account, EOA delegation). If the frame subsequently reverts or halts, the deduction is not undone within that frame — but the parent reclaims the child's consumed state gas via the reservoir restoration described above. At the top level, the same restoration applies: all consumed execution state gas (from the reservoir and any spillover from `gas_left`) is moved back into the `state_gas_reservoir`, and `execution_state_gas_used` is reset to zero. In both cases, state gas is refunded because state changes are reverted and no state was actually grown. This departs from pre-[EIP-8037](./eip-8037.md) behavior where `GAS_NEW_ACCOUNT` was consumed on revert, but is more consistent with the principle that state gas exclusively pays for long-term state growth.
+When an account is created and then self-destructed in the same transaction ([EIP-6780](./eip-6780.md)), deletion is deferred to the end of the transaction. During the transaction the account is still present in state with a nonce of 1 from the `CREATE`, and is therefore neither empty nor nonexistent. A subsequent `CALL` with value to that address does **not** create a new account at the frame-end accounting step, because the account already exists at the calling frame's exit state.
 
-### State gas refund on CREATE failure
-
-`CREATE`/`CREATE2` charges `112 × cost_per_state_byte` upfront (pay-before-execute). If the creation fails at the opcode level before a child frame is entered — silent failures such as insufficient balance, nonce overflow, stack depth limit, or address collision — the account creation state gas is refunded to `state_gas_reservoir` (and `execution_state_gas_used` is decremented). No account was created, so no state gas should be paid. This preserves the pay-before-execute model while ensuring state gas is only consumed when state is actually created. Child frame revert and exceptional halt are handled by the general frame failure rule above.
-
-### State gas refund on same-tx SELFDESTRUCT
-
-When an account is created and self-destructed in the same transaction ([EIP-6780](./eip-6780.md)), the state does not persist. At the end of the transaction, when the actual account and storage removal occurs, all state gas for that account is refunded to `state_gas_reservoir` (and `execution_state_gas_used` is decremented). The refund scope includes:
-
-- Account creation: `112 × cost_per_state_byte`
-- Created storage slots: `32 × cost_per_state_byte` per non-zero slot
-- Code deposit: `len(code) × cost_per_state_byte`
-
-This refund must be applied before `tx_gas_used_before_refund` is computed so the sender is not charged for state that was destroyed. Storage slots that were restored to zero during execution (0 to X to 0) already have a final value of 0 and are not counted, avoiding a double refund with the SSTORE restoration refund.
-
-### CALL with value to the selfdestructed account in the same transaction
-
-When an account is created and then selfdestructed in the same transaction ([EIP-6780](./eip-6780.md)), deletion is deferred to the end of the transaction. During the transaction the account is still present in the state with a nonce of 1 from the CREATE, and is therefore neither empty nor nonexistent. A subsequent `CALL` with value to that address does **not** trigger a new account creation and therefore does **not** charge `GAS_NEW_ACCOUNT` state gas.
-
-The end of the transaction destruction still removes the account regardless of any value received after the SELFDESTRUCT, so no persisted state results from the CALL. Any value transferred is burned when the account is destroyed. Combined with the same transaction SELFDESTRUCT refund above, the net state gas across the CREATE, SELFDESTRUCT, and CALL with value lifecycle is zero, matching the zero persisted state.
+End-of-transaction destruction still removes the account regardless of any value received after the `SELFDESTRUCT`, so no persisted state results from the `CALL`. Any value transferred is burned when the account is destroyed. Combined with the deferred `SELFDESTRUCT` refund described in [Top-level frame end](#top-level-frame-end-transaction-end), the net state gas across the `CREATE`, `SELFDESTRUCT`, and `CALL`-with-value lifecycle is zero, matching the zero persisted state.
 
 #### [EIP-7702](./eip-7702.md) authorizations
 
@@ -239,35 +233,40 @@ Receipt `cumulative_gas_used` tracks the cumulative sum of `tx_gas_used_after_re
 
 When a contract creation transaction or opcode (`CREATE`/`CREATE2`) is executed, gas is charged differently based on whether the deployment succeeds or fails. Given bytecode `B` (length `L`) returned by initcode and `H = keccak256(B)`:
 
-1. **When opcode execution starts:** Always charge `GAS_CREATE`
-2. **During initcode execution:** Charge the actual gas consumed by the initcode execution
+1. **When opcode execution starts:** Charge the regular-gas portion of `GAS_CREATE` (9,000) against `gas_left`. The state-gas portion (`STATE_BYTES_PER_NEW_ACCOUNT × cost_per_state_byte`) is **not** charged here; it is computed at frame end if the new account persists.
+2. **During initcode execution:** Charge the actual gas consumed by the initcode execution.
 3. **Success path** (no error, not reverted, and `L ≤ MAX_CODE_SIZE`):
-   - Charge `GAS_CODE_DEPOSIT * L` and persist `B` under `H`, then link `codeHash` to `H`
-   - Charge `HASH_COST(L)` where `HASH_COST(L) = 6 × ceil(L / 32)` to compute `H`
+   - Charge `HASH_COST(L) = 6 × ⌈L/32⌉` regular gas to compute `H`, persist `B` under `H`, then link `codeHash` to `H`.
+   - At frame end, the creating frame is charged the state-gas portion of `GAS_CREATE` (`STATE_BYTES_PER_NEW_ACCOUNT × cost_per_state_byte`) plus the state-gas portion of `GAS_CODE_DEPOSIT` (`L × cost_per_state_byte`).
 4. **Failure paths** (REVERT, OOG/invalid during initcode, OOG during code deposit, or `L > MAX_CODE_SIZE`):
-   - Do NOT charge `GAS_CODE_DEPOSIT * L` or `HASH_COST(L)`
-   - No code is stored; no `codeHash` is linked to the account
-   - The account remains unchanged or non-existent
+   - No code is stored; no `codeHash` is linked to the account.
+   - The account remains unchanged or non-existent.
+   - Because state gas is only computed at successful frame ends, no state gas is charged for any of these failure modes — there is no charge to refund and no upfront deduction to reverse. Silent pre-frame failures (insufficient balance, nonce overflow, stack depth limit, address collision) likewise produce no state-gas charge, since the parent's frame end observes no new account.
 
-**Important:** The gas for code deposit (`GAS_CODE_DEPOSIT * L`) is checked before hash computation. This means that if a deployment runs out of gas, it will fail during the deposit gas check before the hash is computed. This maintains consistency with post-Homestead behavior where any deployment failure (including OOG) reverts all state changes - no account is created, and no gas is charged beyond `GAS_CREATE` and the actual initcode execution cost consumed.
+**Important:** The hash computation cost is paid in regular gas after a successful initcode return; if the creating frame runs out of regular gas there, the deployment fails and falls back to the failure path above, with no state created and no state gas charged.
 
-**Total gas formulas:**
+**Total gas formulas** (combining regular and state components):
 
 ```
 SUCCESS_PATH_TOTAL_GAS =
-    GAS_CREATE
+    9_000                                            # GAS_CREATE regular
+  + STATE_BYTES_PER_NEW_ACCOUNT × cost_per_state_byte  # GAS_CREATE state, charged at frame end
   + initcode_execution_cost
-  + GAS_CODE_DEPOSIT * L
-  + HASH_COST(L)
+  + L × cost_per_state_byte                          # GAS_CODE_DEPOSIT state, charged at frame end
+  + HASH_COST(L)                                     # GAS_CODE_DEPOSIT regular
 
 FAILURE_PATH_TOTAL_GAS =
-    GAS_CREATE
+    9_000                                            # GAS_CREATE regular
   + initcode_execution_cost
 ```
 
 ### `CREATE` vs `CREATE2`
 
 `CREATE2` already charges for hashing the init code when deriving the address. That cost remains unchanged. The bytecode hash (`keccak256(B)`) must be computed on success to store the code, incurring `HASH_COST(L)` as specified above.
+
+### System contracts
+
+`30M + 32 * cpsb * MAX_SSTORES`
 
 ## Rationale
 
@@ -327,7 +326,7 @@ Note that the fixed cost `GAS_CREATE` for contract deployments assumes the same 
 
 ### Multidimensional metering
 
-This proposal is consistent with [EIP-8011](./eip-8011.md). However, it only requires two dimensions, namely, `regular_gas` and `state_gas`. If [EIP-8011](./eip-8011.md) is not implemented, a two-dimensional version of [EIP-8011](./eip-8011.md) is still required.
+This proposal is consistent with [EIP-8011](./eip-8011.md). However, it only requires two dimensions, namely, `regular-gas` and `state-gas`. If [EIP-8011](./eip-8011.md) is not implemented, a two-dimensional version of [EIP-8011](./eip-8011.md) is still required.
 
 #### EIP-7825 limit on contract size
 

--- a/EIPS/eip-8037.md
+++ b/EIPS/eip-8037.md
@@ -13,7 +13,7 @@ requires: 2780, 7702, 7825, 8038
 
 ## Abstract
 
-This proposal increases the cost of state creation operations, thus avoiding excessive state growth under increased block gas limits. It sets the unit cost per new state byte by targeting an average state growth of 100 GiB per year based on current network usage and a gas limit of 100M gas units. It also introduces an independent metering for state creation costs, thus allowing for increased throughput and for larger contract deployments without being limited by the single transaction gas limit.
+This proposal increases the cost of state creation operations, thus avoiding excessive state growth under increased block gas limits. It sets the unit cost per new state byte by targeting an average state growth of 96 GiB per year and a gas limit of 100M gas units. It also introduces an independent metering for state creation costs, thus allowing for increased throughput and for larger contract deployments without being limited by the single transaction gas limit.
 
 ## Motivation
 
@@ -34,6 +34,7 @@ The relationship we are seeing in this example is not linear as expected. This i
 | `CPSB` | 1174 |
 | `STATE_BYTES_PER_STORAGE_SET` | 32 |
 | `STATE_BYTES_PER_NEW_ACCOUNT` | 112 |
+| `STATE_BYTES_PER_AUTH_BASE` | 23 |
 
 <!-- TODO -->
 
@@ -48,7 +49,7 @@ Upon activation of this EIP, the following parameters of the gas model are updat
 | `GAS_NEW_ACCOUNT` | 25,000 | `STATE_BYTES_PER_NEW_ACCOUNT x CPSB` | 0 (already has `GAS_CALL_VALUE` 9,000) | `CALL*` |
 | `GAS_STORAGE_SET` | 20,000 | `STATE_BYTES_PER_STORAGE_SET x CPSB` | 2,900 (`GAS_STORAGE_UPDATE - GAS_COLD_SLOAD`) | `SSTORE` |
 | `PER_EMPTY_ACCOUNT_COST` | 25,000 | `STATE_BYTES_PER_NEW_ACCOUNT x CPSB` | 0 (included in `PER_AUTH_BASE_COST`) | EOA delegation |
-| `PER_AUTH_BASE_COST` | 12,500 | 23 × `CPSB` | 7,500 | EOA delegation |
+| `PER_AUTH_BASE_COST` | 12,500 | `STATE_BYTES_PER_AUTH_BASE x CPSB` | 7,500 | EOA delegation |
 
 The values assigned to regular gas will be updated based on [EIP-8038](./eip-8038.md).
 
@@ -96,7 +97,7 @@ The `state_gas_reservoir` holds gas that exceeds the [EIP-7825](./eip-7825.md)'s
 - regular-gas charges deduct from `gas_left` only.
 - state-gas charges deduct from `state_gas_reservoir` first. When the reservoir is exhausted, state gas charges deduct from `gas_left`.
 - The `GAS` opcode returns `gas_left` only (excluding the reservoir).
-- state-gas is metered at call-frame boundaries and at the end of the transaction, not at individual state-mutating opcodes. Each frame's state-gas cost is derived from the state diff it accumulated since the call-frame began — the changes between its entry state and exit state — categorized against the **transaction-entry state** (the state at the start of the transaction) to determine which storage slot writes and account creations count as new.
+- state-gas is metered at call-frame boundaries and at the end of the transaction, not at individual state-mutating opcodes. Each frame's state-gas cost is derived from the state diff it accumulated since the call-frame began (i.e., the changes between its entry state and exit state).
 
 ##### Frame-end state-gas accounting
 
@@ -107,27 +108,25 @@ When a frame returns successfully, the EVM derives its state-gas charges and ref
 
 For each storage slot whose value differs between the frame's entry and exit states, the frame is charged or refunded as follows:
 
-- **New slot.** The slot's frame-exit value is non-zero and its transaction-entry value was zero. Charge `STATE_BYTES_PER_STORAGE_SET × cost_per_state_byte` of state gas.
-- **Cleared slot, zero at transaction start.** The slot's frame-exit value is zero, its frame-entry value was non-zero, and its transaction-entry value was zero (the slot was created earlier in the same transaction and is now being cleared). Refund `STATE_BYTES_PER_STORAGE_SET × cost_per_state_byte` directly to `state_gas_reservoir` and decrement `execution_state_gas_used` by the same amount. This refund is not subject to the 20% refund cap, since the corresponding charge was incurred in the same transaction.
+- **New slot.** The slot's frame-exit value is non-zero and its transaction-entry value was zero. Charge `STATE_BYTES_PER_STORAGE_SET × CPSB` of state gas.
+- **Cleared slot, zero at transaction start.** The slot's frame-exit value is zero, its frame-entry value was non-zero, and its transaction-entry value was zero (the slot was created earlier in the same transaction and is now being cleared). Refund `STATE_BYTES_PER_STORAGE_SET × CPSB` directly to `state_gas_reservoir`. This refund is not subject to the 20% refund cap, since the corresponding charge was incurred in the same transaction.
 - **Cleared slot, non-zero at transaction start.** The slot's frame-exit value is zero, its frame-entry value was non-zero, and its transaction-entry value was non-zero (a pre-existing slot is being cleared). No state-gas adjustment; instead, `GAS_STORAGE_UPDATE - GAS_COLD_SLOAD - GAS_WARM_ACCESS` is added to `refund_counter`, subject to the 20% refund cap.
 - **Other transitions** (e.g., between two non-zero values, or transient changes that net to no change between frame entry and frame exit): no state-gas charge or refund.
 
 For each account:
 
-- **New account.** The account exists at the frame's exit state, did not exist at the start of the transaction, and was not already accounted for by a successful descendant frame. Charge `STATE_BYTES_PER_NEW_ACCOUNT × cost_per_state_byte` of state gas.
-- **Code deposit on creation.** For a newly created account with bytecode `B` of length `L`, additionally charge `L × cost_per_state_byte` of state gas plus `6 × ⌈L/32⌉` of regular gas (the bytecode hashing cost).
+- **New account.** The account exists at the frame's exit state, did not exist at the start of the transaction, and was not already accounted for by a successful descendant frame. Charge `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` of state gas.
+- **Code deposit on creation.** For a newly created account with bytecode `B` of length `L`, additionally charge `L × CPSB` of state gas plus `6 × ⌈L/32⌉` of regular gas (the bytecode hashing cost).
 
 `SELFDESTRUCT` does not produce a state-gas effect at the frame in which it executes; its accounting is deferred to the end of the transaction (see [Top-level frame end](#top-level-frame-end-transaction-end) below).
 
 Each storage slot or account that is created or cleared in the transaction is charged or refunded exactly once across the call stack: once a successful descendant frame has accounted for a state change, ancestor frames do not re-account for it.
 
-##### Reservoir propagation across frames
+When a child **reverts** or **halts exceptionally**, all of its state changes are rolled back. Because state-gas accounting is performed only at the boundary of a successful frame, a reverted or halted child produces no debits or credits to the parent's `state_gas_reservoir`. On exceptional halt, the child's `gas_left` is additionally consumed (zeroed), consistent with existing EVM semantics.
 
-The reservoir is passed **in full** to child frames (no 63/64 rule). When a child returns successfully, the remaining `state_gas_reservoir` is returned to the parent, and the child's `execution_state_gas_used` is added to the parent's `execution_state_gas_used`. The frame-end accounting above is what populates the child's contribution.
+On **revert** or **exceptional halt** of the top-level frame, all state changes are reverted and no state gas is charged. On exceptional halt specifically, remaining `gas_left` is set to zero.
 
-When a child **reverts** or **halts exceptionally**, all of its state changes are rolled back. Because state-gas accounting is performed only at the boundary of a successful frame, a reverted or halted child contributes nothing to the parent's `execution_state_gas_used` and produces no debits or credits to the parent's `state_gas_reservoir`. On exceptional halt, the child's `gas_left` is additionally consumed (zeroed), consistent with existing EVM semantics.
-
-On **revert** or **exceptional halt** of the top-level frame, all state changes are reverted and no state gas is charged. On exceptional halt specifically, remaining `gas_left` is set to zero. System transactions are not subject to the `TX_MAX_GAS_LIMIT` cap; their entire `execution_gas` is placed in `gas_left` with `state_gas_reservoir = 0`.
+System transactions are not subject to the `TX_MAX_GAS_LIMIT` cap; their entire `execution_gas` is placed in `gas_left` with `state_gas_reservoir = 0`.
 
 ##### Top-level frame end (transaction end)
 
@@ -135,25 +134,14 @@ At the end of a successful transaction, the top-level frame applies the frame-en
 
 For each account that was created during the transaction, `SELFDESTRUCT`ed, and is now being removed:
 
-- The state gas previously charged for the account creation (`STATE_BYTES_PER_NEW_ACCOUNT × cost_per_state_byte`), the code deposit (`L × cost_per_state_byte` where `L` is the deployed code length), and every storage slot that was charged as new on that account during the transaction (`STATE_BYTES_PER_STORAGE_SET × cost_per_state_byte` per slot) is refunded directly to `state_gas_reservoir`, and `execution_state_gas_used` is decremented by the same amount.
+- The state gas previously charged for the account creation (`STATE_BYTES_PER_NEW_ACCOUNT × CPSB`), the code deposit (`L × CPSB` where `L` is the deployed code length), and every storage slot that was charged as new on that account during the transaction (`STATE_BYTES_PER_STORAGE_SET × CPSB` per slot) is refunded directly to `state_gas_reservoir`.
 - These refunds are not subject to the 20% refund cap.
 
 For an account that existed before the transaction, `SELFDESTRUCT` only transferred its balance and the account is not removed; no state-gas refund applies.
 
-The two counters `gas_left` and `state_gas_reservoir`, along with `execution_state_gas_used` and `execution_regular_gas_used`, are returned by the transaction output. `state-gas` costs are accumulated into `execution_state_gas_used` and `regular-gas` costs into `execution_regular_gas_used` during transaction execution.
-
 #### Pre-state and post-state gas validation
 
 [EIP-7928](./eip-7928.md) defines two-phase gas validation for state-accessing opcodes: pre-state costs (determinable without state access) and post-state costs (requiring state access). Under this EIP, the regular-gas portion of these opcodes follows the [EIP-7928](./eip-7928.md) rules unchanged and is charged at opcode time against `gas_left`. The state-gas portion is **not** charged at the opcode level; it is computed and deducted at frame-end accounting (see [Frame-end state-gas accounting](#frame-end-state-gas-accounting)), drawing first from `state_gas_reservoir` and then from `gas_left`.
-
-The cost parameters introduced by this EIP map as follows:
-
-| Cost Parameter | When the state-gas component is charged | State Gas | Regular Gas (charged at opcode) |
-|---|---|---|---|
-| `GAS_CREATE` | Frame end of the creating frame, if a new account persists | `STATE_BYTES_PER_NEW_ACCOUNT × cpsb` | 9,000 |
-| `GAS_CODE_DEPOSIT` | Frame end of the creating frame, if code is deployed | `cpsb × L` | `6 × ⌈L/32⌉` |
-| `GAS_NEW_ACCOUNT` | Frame end of the calling frame, if a new account persists | `STATE_BYTES_PER_NEW_ACCOUNT × cpsb` | 0 |
-| `GAS_STORAGE_SET` | Frame end of the writing frame, if a new slot persists | `STATE_BYTES_PER_STORAGE_SET × cpsb` | 2,900 |
 
 For `SSTORE`, the `GAS_CALL_STIPEND` pre-state check ([EIP-7928](./eip-7928.md)) applies to `gas_left` only, excluding the `state_gas_reservoir`.
 
@@ -202,26 +190,9 @@ The base fee update rule is also modified accordingly:
 gas_used_delta = parent.gas_used - parent.gas_target
 ```
 
-### Worked example: `SSTORE` slot restoration
-
-The 0 → X → 0 pattern (a storage slot is set to a non-zero value and then restored to zero within the same transaction) is fully captured by [Frame-end state-gas accounting](#frame-end-state-gas-accounting). For a slot whose transaction-entry value was zero:
-
-- If the entire 0 → X → 0 sequence happens inside a single frame, the frame's exit value equals its entry value (zero) and the slot does not appear in any frame-end charge or refund. No state gas is paid; no refund is needed.
-- If the 0 → X is committed by a successful descendant frame and the X → 0 is performed in an ancestor frame, the descendant's frame end charges `STATE_BYTES_PER_STORAGE_SET × cost_per_state_byte` of state gas, and the ancestor's frame end refunds the same amount directly to `state_gas_reservoir` (decrementing `execution_state_gas_used`), not subject to the 20% cap.
-
-In both cases, the regular-gas refund-counter contribution from the cleared SSTORE is `GAS_STORAGE_UPDATE - GAS_COLD_SLOAD - GAS_WARM_ACCESS`, subject to the 20% cap, and the net cost after refund is consistent with pre-[EIP-8037](./eip-8037.md) `SSTORE` restoration behavior.
-
-If any frame in the call chain reverts or halts before the cleared-slot observation reaches a successful frame boundary, both the 0 → X charge and the X → 0 refund are rolled back along with the underlying state changes, and neither contributes to `execution_state_gas_used` or `state_gas_reservoir`.
-
-### `CALL` with value to a self-destructed account in the same transaction
-
-When an account is created and then self-destructed in the same transaction ([EIP-6780](./eip-6780.md)), deletion is deferred to the end of the transaction. During the transaction the account is still present in state with a nonce of 1 from the `CREATE`, and is therefore neither empty nor nonexistent. A subsequent `CALL` with value to that address does **not** create a new account at the frame-end accounting step, because the account already exists at the calling frame's exit state.
-
-End-of-transaction destruction still removes the account regardless of any value received after the `SELFDESTRUCT`, so no persisted state results from the `CALL`. Any value transferred is burned when the account is destroyed. Combined with the deferred `SELFDESTRUCT` refund described in [Top-level frame end](#top-level-frame-end-transaction-end), the net state gas across the `CREATE`, `SELFDESTRUCT`, and `CALL`-with-value lifecycle is zero, matching the zero persisted state.
-
 #### [EIP-7702](./eip-7702.md) authorizations
 
-For [EIP-7702](./eip-7702.md) authorizations, the intrinsic state gas assumes account creation for each authorization: `(112 + 23) × cost_per_state_byte` per authorization. When an authorization targets an existing account (no account creation needed), the `112 × cost_per_state_byte` portion is refunded directly to `state_gas_reservoir` during authorization processing.
+For [EIP-7702](./eip-7702.md) authorizations, the intrinsic state gas assumes account creation for each authorization: `(STATE_BYTES_PER_NEW_ACCOUNT + STATE_BYTES_PER_AUTH_BASE) × CPSB` per authorization. When an authorization targets an existing account (no account creation needed), the `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` portion is refunded directly to `state_gas_reservoir` during authorization processing.
 
 `intrinsic_state_gas` is immutable after transaction validation and is not modified by this refund. Block accounting uses the original worst-case `intrinsic_state_gas`; the refunded gas is reflected in the final `state_gas_reservoir` rather than in a mutated intrinsic value.
 
@@ -229,38 +200,7 @@ For [EIP-7702](./eip-7702.md) authorizations, the intrinsic state gas assumes ac
 
 Receipt `cumulative_gas_used` tracks the cumulative sum of `tx_gas_used_after_refund` (post-refund, post-floor) across transactions, instead of the block's `gas_used`. This means `receipt[i].cumulative_gas_used - receipt[i-1].cumulative_gas_used` equals the gas paid by transaction `i`.
 
-### Contract deployment cost calculation
-
-When a contract creation transaction or opcode (`CREATE`/`CREATE2`) is executed, gas is charged differently based on whether the deployment succeeds or fails. Given bytecode `B` (length `L`) returned by initcode and `H = keccak256(B)`:
-
-1. **When opcode execution starts:** Charge the regular-gas portion of `GAS_CREATE` (9,000) against `gas_left`. The state-gas portion (`STATE_BYTES_PER_NEW_ACCOUNT × cost_per_state_byte`) is **not** charged here; it is computed at frame end if the new account persists.
-2. **During initcode execution:** Charge the actual gas consumed by the initcode execution.
-3. **Success path** (no error, not reverted, and `L ≤ MAX_CODE_SIZE`):
-   - Charge `HASH_COST(L) = 6 × ⌈L/32⌉` regular gas to compute `H`, persist `B` under `H`, then link `codeHash` to `H`.
-   - At frame end, the creating frame is charged the state-gas portion of `GAS_CREATE` (`STATE_BYTES_PER_NEW_ACCOUNT × cost_per_state_byte`) plus the state-gas portion of `GAS_CODE_DEPOSIT` (`L × cost_per_state_byte`).
-4. **Failure paths** (REVERT, OOG/invalid during initcode, OOG during code deposit, or `L > MAX_CODE_SIZE`):
-   - No code is stored; no `codeHash` is linked to the account.
-   - The account remains unchanged or non-existent.
-   - Because state gas is only computed at successful frame ends, no state gas is charged for any of these failure modes — there is no charge to refund and no upfront deduction to reverse. Silent pre-frame failures (insufficient balance, nonce overflow, stack depth limit, address collision) likewise produce no state-gas charge, since the parent's frame end observes no new account.
-
-**Important:** The hash computation cost is paid in regular gas after a successful initcode return; if the creating frame runs out of regular gas there, the deployment fails and falls back to the failure path above, with no state created and no state gas charged.
-
-**Total gas formulas** (combining regular and state components):
-
-```
-SUCCESS_PATH_TOTAL_GAS =
-    9_000                                            # GAS_CREATE regular
-  + STATE_BYTES_PER_NEW_ACCOUNT × cost_per_state_byte  # GAS_CREATE state, charged at frame end
-  + initcode_execution_cost
-  + L × cost_per_state_byte                          # GAS_CODE_DEPOSIT state, charged at frame end
-  + HASH_COST(L)                                     # GAS_CODE_DEPOSIT regular
-
-FAILURE_PATH_TOTAL_GAS =
-    9_000                                            # GAS_CREATE regular
-  + initcode_execution_cost
-```
-
-### `CREATE` vs `CREATE2`
+#### `CREATE` vs `CREATE2`
 
 `CREATE2` already charges for hashing the init code when deriving the address. That cost remains unchanged. The bytecode hash (`keccak256(B)`) must be computed on success to store the code, incurring `HASH_COST(L)` as specified above.
 
@@ -268,45 +208,39 @@ FAILURE_PATH_TOTAL_GAS =
 
 `30M + 32 * cpsb * MAX_SSTORES`
 
+<!-- TODO -->
+
 ## Rationale
 
-### Deriving the cost per byte
+### Deriving the cost per state byte (CPSB)
 
-The variable `cost_per_state_byte` is a dynamic parameter that depends on the block gas limit. The idea is to have a cost that scales as the block gas limit increases, thus avoiding excessive state growth. To compute this variable, we target a specific state growth per year, which we set to 100 GiB. Then, we assume this growth rate is achieved at an average gas utilization.
+`CPSB` is a derived parameter that depends on the block gas limit. The idea is to have a cost that scales as the block gas limit increases, thus avoiding excessive state growth. The derivation pins the cost so that, under expected average utilization, total state growth stays at the target rate.
 
-With multidimensional metering, blocks can be filled up to 50% of the target for both regular gas and state gas. Thus, we consider that on average, blocks can use half of the entire available gas in the block for state creation. This leads to a total of `(gas_limit/2) * 7200 * 365` gas units used for state creation in a year. Dividing this by the target state growth per year gives us the cost per byte of state created.
+#### Inputs
 
-### Quantization of `cost_per_state_byte`
+- **Target state growth**: 100 GiB per year, i.e., `100 × 2^30 = 107,374,182,400` bytes.
+- **Reference block gas limit**: 96M gas units.
+- **Slot time**: 12 seconds, giving `86400 / 12 = 7,200` blocks per day and `7,200 × 365 = 2,628,000` blocks per year.
+- **Average state-gas utilization**: 50% of the block gas limit. Under multidimensional metering, the base fee equilibrates around the target, which is half of the gas limit. On average, half of each block's gas budget can therefore be consumed by state-gas charges before the base fee starts pushing back.
 
-Without quantization, `cost_per_state_byte` changes by 1 for every ~81,715 change in gas limit, which is 0.13% of the current block gas limit of 60M gas units. This creates unnecessary churn for tooling and gas estimation, since the cost can change almost every block even when the gas limit is relatively stable.
+#### Derivation
 
-The quantization scheme retains the top 5 significant bits of `(raw + CPSB_OFFSET)`, zeroes the remaining bits, then subtracts `CPSB_OFFSET`. This is equivalent to binary floating-point rounding: each power-of-2 band has exactly 16 distinct levels, and the step size doubles at each band boundary while remaining perfectly uniform within a band.
+The total state gas available for state creation in a year is:
 
-The offset (`CPSB_OFFSET = 9578`) shifts quantization boundaries away from common gas limit targets. It was chosen by brute-force search over 0–10000 to maximize the minimum distance from any quantization boundary to gas limits from 100M to 1000M (in 50M increments). This prevents `cost_per_state_byte` from flipping between adjacent values due to small gas limit fluctuations near popular targets. The following table shows the resulting boundary distances:
+```text
+total_state_gas_per_year = (gas_limit / 2) × blocks_per_year
+                         = (96,000,000 / 2) × 2,628,000
+                         = 48,000,000 × 2,628,000
+                         = 1.26144 × 10^14 gas
+```
 
-| Gas Limit | `cost_per_state_byte` | Distance to boundary | Blocks to boundary |
-| :---------: | :---------------------: | :--------------------: | :------------------: |
-| 100M | 1,174 | 4.15% | 42.5 |
-| 150M | 1,686 | 8.21% | 84.0 |
-| 200M | 2,198 | 10.24% | 104.8 |
-| 250M | 2,710 | 5.28% | 54.1 |
-| 300M | 3,222 | 1.68% | 17.2 |
-| 350M | 4,246 | 0.89% | 9.1 |
-| 400M | 4,758 | 2.82% | 28.9 |
-| 450M | 5,270 | 4.32% | 44.2 |
-| 500M | 5,782 | 2.85% | 29.2 |
-| 550M | 6,294 | 1.10% | 11.3 |
-| 600M | 6,806 | 6.63% | 67.8 |
-| 650M | 7,830 | 1.58% | 16.1 |
-| 700M | 7,830 | 3.35% | 34.3 |
-| 750M | 8,854 | 3.54% | 36.3 |
-| 800M | 8,854 | 0.89% | 9.1 |
-| 850M | 9,878 | 4.80% | 49.1 |
-| 900M | 10,902 | 1.02% | 10.5 |
-| 950M | 10,902 | 2.57% | 26.4 |
-| 1000M | 11,926 | 2.55% | 26.2 |
+Dividing by the target byte count gives the cost per state byte:
 
-The worst-case minimum distance is 0.89% of the gas limit (at 350M and 800M). Since the gas limit can deviate from its parent by at most 1/1024, `cost_per_state_byte` remains stable for at least ~9 consecutive blocks of same-direction gas limit changes at any gas limit in the 100M–1000M range (in 50M increments).
+```text
+CPSB = total_state_gas_per_year / target_state_growth
+     = 1.26144 × 10^14 / 107,374,182,400
+     ≈ 1174 gas/byte
+```
 
 ### Harmonization across state creation
 
@@ -320,7 +254,7 @@ With the current pricing, the gas cost of creating 1 byte of state varies depend
 | [EIP-7702](./eip-7702.md) authorization to empty address    | 23 B (0xef0100‖address) + updated account leaf | 25,000 PER_EMPTY_ACCOUNT + 12,500 PER_AUTH_BASE + 1,616 calldata = 39,116 gas                 | ~135 B        | ~289 gas   |
 | Fill new storage slots (SSTORE 0→x)                         | Slot in storage trie                           | 20,000 gas/slot                                                                               | 32 B          | 625 gas    |
 
-To harmonize costs, we first set the gas cost of a single state byte, `cost_per_state_byte`, as explained above. This is a dynamic parameter that depends on the block gas limit. Now that we have a standardized cost per byte, we can derive the various costs parameters by multiplying the unit cost by the increase in bytes any given operation creates in the database (i.e., 32 bytes per slot, 112 bytes per account and 23 bytes per authorization).
+To harmonize costs, we first set the gas cost of a single state byte, `CPSB`, as explained above. This is a dynamic parameter that depends on the block gas limit. Now that we have a standardized cost per byte, we can derive the various costs parameters by multiplying the unit cost by the increase in bytes any given operation creates in the database (i.e., 32 bytes per slot, 112 bytes per account and 23 bytes per authorization).
 
 Note that the fixed cost `GAS_CREATE` for contract deployments assumes the same cost as a new account creation.
 
@@ -330,7 +264,7 @@ This proposal is consistent with [EIP-8011](./eip-8011.md). However, it only req
 
 #### EIP-7825 limit on contract size
 
-[EIP-7825](./eip-7825.md) introduces `TX_MAX_GAS_LIMIT` (16.7M) as the maximum gas for a single transaction, in particular stipulating `tx.gas < TX_MAX_GAS_LIMIT`as a validity condition. Were we to continue enforcing this validity condition, with a block limit of 100M gas units, this proposal would limit the maximum contract size that can be deployed to roughly 9.9kB ($\frac{16,777,216 - 21,000 - 5,000,000 - 112 \times 1174}{1174} = 9'902$). This maximum size would only decrease as we increase the gas limit and the `cost_per_state_byte`.
+[EIP-7825](./eip-7825.md) introduces `TX_MAX_GAS_LIMIT` (16.7M) as the maximum gas for a single transaction, in particular stipulating `tx.gas < TX_MAX_GAS_LIMIT`as a validity condition. Were we to continue enforcing this validity condition, with a block limit of 100M gas units, this proposal would limit the maximum contract size that can be deployed to roughly 9.9kB ($\frac{16,777,216 - 21,000 - 5,000,000 - 112 \times 1174}{1174} = 9'902$). This maximum size would only decrease as we increase the gas limit and the `CPSB`.
 
 To solve this issue, we only apply this gas limit to regular gas, not state gas. Doing so does not weaken the intended scaling effect of [EIP-7825](./eip-7825.md), because regular gas meters all resources that benefit from parallelization. In particular, state growth does not: growing the state always requires writing to disk, a parallelizable operation, but crucially this part of the cost of a state growth operation has to be metered in regular gas, not state gas. In other words, any operation that grows the state should consume both regular gas and state gas, and the regular gas should fully account for all costs other than the long term effect of growing the state.
 
@@ -351,19 +285,14 @@ Wallet developers and node operators MUST update gas estimation handling to acco
 
 Users can maintain their usual workflows without modification, as wallet and RPC updates will handle these changes.
 
-### Estimated price impacts at various block gas limits
+### Estimated price impacts
 
-Users and dApp developers will experience an increase in transaction costs associated with creating a new state. The next table summarizes the state creation costs for common operations at different block gas limits.
+Users and dApp developers will experience an increase in transaction costs associated with creating a new state. The next table summarizes the state creation costs for common operations under the proposed `CPSB` of 1,174.
 
-| Case | cost_per_state_byte | Cost of a new account | Cost increase | Cost of a new slot | Cost increase | 24kB contract deployment | Cost increase |
-|:---:|:---:|---|---|---|---|---|---|
-| Current cost | NA | 25,000 | NA | 20,000 | NA | 4,947,200 | NA |
-| Proposed cost at 60M block limit | 662 | 74,144 | 3 | 24,084 | 1 | 16,357,064 | 3 |
-| Proposed cost at 100M block limit | 1,174 | 131,488 | 5 | 40,468 | 2 | 28,997,320 | 6 |
-| Proposed cost at 200M block limit | 2,198 | 246,176 | 10 | 73,236 | 4 | 54,277,832 | 11 |
-| Proposed cost at 300M block limit | 3,222 | 360,864 | 14 | 106,004 | 5 | 79,558,344 | 16 |
-
-We should note that as the block limit increases, the base fee is expected to reduce due to the higher capacity of the network. This reduction in base fee will offset, in part, the costs from state creation operations. Some analysis is needed to quantify this effect.
+| Case | Cost of a new account | Cost increase | Cost of a new slot | Cost increase | 24kB contract deployment | Cost increase |
+|:---:|---|---|---|---|---|---|
+| Current cost | 25,000 | NA | 20,000 | NA | 4,947,200 | NA |
+| Proposed cost | 131,488 | 5 | 40,468 | 2 | 28,997,320 | 6 |
 
 ## Security Considerations
 
@@ -371,7 +300,7 @@ Increasing the cost of state creation operations could impact the usability of c
 
 ### Mispricing with respect to ETH transfers
 
-One potential concern is the cost of creating a new account (`112 × cost_per_state_byte` gas units, e.g., 131,488 at a 100M gas limit), compared to transferring ETH to a fresh account (21,000 gas units). With this mismatch, users wishing to create new account are incentivized to first send a normal transaction (costing 21k) to this account to create it, thus avoiding the `GAS_NEW_ACCOUNT` charge.
+One potential concern is the cost of creating a new account (`STATE_BYTES_PER_NEW_ACCOUNT × CPSB` gas units, e.g., 131,488 at a 100M gas limit), compared to transferring ETH to a fresh account (21,000 gas units). With this mismatch, users wishing to create new account are incentivized to first send a normal transaction (costing 21k) to this account to create it, thus avoiding the `GAS_NEW_ACCOUNT` charge.
 
 [EIP-2780](./eip-2780.md) solves this mispricing by adding a new component to the intrinsic gas cost of transactions. If a non-create transaction has value > 0 and targets a non-existent account, the `GAS_NEW_ACCOUNT` is added to intrinsic cost.
 

--- a/EIPS/eip-8037.md
+++ b/EIPS/eip-8037.md
@@ -13,7 +13,7 @@ requires: 2780, 6780, 7702, 7825, 7976, 7981, 8038
 
 ## Abstract
 
-This proposal increases the cost of state creation operations, thus avoiding excessive state growth under increased block gas limits. It sets the unit cost per new state byte by targeting an average state growth of 100 GiB per year at a reference block gas limit of 96M gas units. It also introduces an independent metering for state creation costs, thus allowing for increased throughput and for larger contract deployments without being limited by the single transaction gas limit.
+This proposal increases the cost of state creation operations, thus avoiding excessive state growth under increased block gas limits. It introduces a new variable,`CPSB` (cost per state byte), and sets this unit of gas costs per new state byte by targeting an average state growth of 100 GiB per year at a reference block gas limit of 96M gas units. It also introduces an independent metering for state creation costs, thus allowing for increased throughput and for larger contract deployments without being limited by the single transaction gas limit.
 
 ## Motivation
 
@@ -317,6 +317,10 @@ One potential concern is the cost of creating a new account (`STATE_BYTES_PER_NE
 ### Added complexity in block building
 
 Optimal block construction becomes more complex, since builders must now balance resource usage across multiple dimensions rather than a single gas metric. Sophisticated builders may gain an advantage by applying advanced optimization techniques, raising concerns about further builder centralization. However, practical heuristics (e.g., greedily filling blocks until one resource dimension saturates) remain effective for most use cases. These heuristics limit centralization pressure by keeping block construction feasible for local and less sophisticated builders.
+
+### Interaction with [EIP-4337](./eip-4337.md) bundles
+
+The `GAS` opcode returns `gas_left` only and cannot observe `state_gas_reservoir`. Bundling protocols that meter sub-call consumption via `gasleft()` deltas (e.g., the [EIP-4337](./eip-4337.md) `EntryPoint`) therefore cannot accurately attribute state-gas usage when it is funded by the reservoir. Because all user operations in a bundle share the transaction's reservoir, one user operation's state-gas refunds can subsidize another's state-gas charges without appearing in either's `gasleft()` delta. Bundlers and `EntryPoint` implementations MUST account for state-gas charges and refunds explicitly rather than relying on `gasleft()` differences alone.
 
 ## Copyright
 

--- a/EIPS/eip-8037.md
+++ b/EIPS/eip-8037.md
@@ -35,8 +35,7 @@ The relationship we are seeing in this example is not linear as expected. This i
 | `STATE_BYTES_PER_STORAGE_SET` | 32 |
 | `STATE_BYTES_PER_NEW_ACCOUNT` | 112 |
 | `STATE_BYTES_PER_AUTH_BASE` | 23 |
-
-<!-- TODO -->
+| `SYSTEM_MAX_SSTORES_PER_CALL` | 16 |
 
 ### Parameter changes
 
@@ -126,8 +125,6 @@ When a child **reverts** or **halts exceptionally**, all of its state changes ar
 
 On **revert** or **exceptional halt** of the top-level frame, all state changes are reverted and no state gas is charged. On exceptional halt specifically, remaining `gas_left` is set to zero.
 
-System transactions are not subject to the `TX_MAX_GAS_LIMIT` cap; their entire `execution_gas` is placed in `gas_left` with `state_gas_reservoir = 0`.
-
 ##### Top-level frame end (transaction end)
 
 At the end of a successful transaction, the top-level frame applies the frame-end accounting above and additionally performs deferred `SELFDESTRUCT` processing. [EIP-6780](./eip-6780.md) defers actual account removal to the end of the transaction for accounts that were created and self-destructed in the same transaction; the corresponding state-gas effect is therefore also computed only at this point.
@@ -204,11 +201,21 @@ Receipt `cumulative_gas_used` tracks the cumulative sum of `tx_gas_used_after_re
 
 `CREATE2` already charges for hashing the init code when deriving the address. That cost remains unchanged. The bytecode hash (`keccak256(B)`) must be computed on success to store the code, incurring `HASH_COST(L)` as specified above.
 
-### System contracts
+### System contracts and system transactions
 
-`30M + 32 * cpsb * MAX_SSTORES`
+The calls to system contracts at the start of every block have their gas limit updated from 30M to:
 
-<!-- TODO -->
+The gas limit of system contracts (e.g., [EIP-2935](./eip-2935.md), [EIP-4788](./eip-4788.md), [EIP-7002](./eip-7002.md), [EIP-7251](./eip-7251.md)) that are invoked at the start of every block via a system call is updated to:
+
+```python
+SYSTEM_CALL_GAS_LIMIT = 30_000_000 + STATE_BYTES_PER_STORAGE_SET × CPSB × SYSTEM_MAX_SSTORES_PER_CALL
+```
+
+This ensures preservation of the existing execution margin for system contracts under higher state creation costs.
+
+Here, `SYSTEM_MAX_SSTORES_PER_CALL = 16` is the upper bound on the number of new storage slots a single system call is expected to write. This value matches `MAX_WITHDRAWAL_REQUESTS_PER_BLOCK` ([EIP-7002](./eip-7002.md)), the largest per-block bound across the existing system contracts.
+
+The additional `STATE_BYTES_PER_STORAGE_SET × CPSB × SYSTEM_MAX_SSTORES_PER_CALL` is placed in `state_gas_reservoir` while the rest of the system call's execution gas is placed in `gas_left`. System calls remain not subject to the [EIP-7825](./eip-7825.md) `TX_MAX_GAS_LIMIT` cap, do not count against the block gas limit, and do not contribute to either `block_regular_gas_used` or `block_state_gas_used`.
 
 ## Rationale
 

--- a/EIPS/eip-8037.md
+++ b/EIPS/eip-8037.md
@@ -93,8 +93,8 @@ state_gas_reservoir = execution_gas - gas_left
 
 This means that the `state_gas_reservoir` holds gas that exceeds [EIP-7825](./eip-7825.md)'s budget. Additionally, two new counters are introduced:
 
-- `execution_regular_gas_used` encodes the total regular-gas used by the transaction, and it is initialized as `execution_regular_gas_used = intrinsic_regular_gas`.
-- `execution_state_gas_used` encodes the total state-gas used by the transaction, and it is initialized as `execution_state_gas_used = intrinsic_state_gas`.
+- `execution_regular_gas_used` encodes the total regular-gas used by the transaction, and it is initialized as `execution_regular_gas_used = 0`.
+- `execution_state_gas_used` encodes the total state-gas used by the transaction, and it is initialized as `execution_state_gas_used = 0`.
 
 The gas counters operate as follows:
 

--- a/EIPS/eip-8037.md
+++ b/EIPS/eip-8037.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2025-10-01
-requires: 161, 2780, 7702, 7825, 8038
+requires: 2780, 6780, 7702, 7825, 7976, 7981, 8038
 ---
 
 ## Abstract
@@ -60,9 +60,7 @@ The `PER_AUTH_BASE_COST` regular gas of 7,500 is derived from [EIP-7702](./eip-7
 - Storing values in already warm account: 200
 - ~~Code deployment cost: 4,600 (200 × 23)~~ → now in state gas
 
-Total regular gas: 1,616 + 3,000 + 2,600 + 200 ≈ 7,500
-
-In addition, `GAS_SELF_DESTRUCT_NEW_ACCOUNT` is removed and replaced by `GAS_NEW_ACCOUNT`. This unifies the new-account charge across all paths that can create one (including `SELFDESTRUCT` transferring balance to a non-existent beneficiary) under a single parameter; the resulting cost is identical to that of any other new account creation.
+Total regular gas: 1,616 + 3,000 + 2,600 + 200 ≈ 7,500s
 
 ### Multidimensional metering for state creation costs
 
@@ -78,6 +76,8 @@ Before transaction execution, inclusion of a transaction in a block requires tha
 
 1. The transaction's **intrinsic costs are not higher than [EIP-7825](./eip-7825.md)'s transaction cap**. Concretely, `max(intrinsic_regular_gas, calldata_floor_gas_cost) <= TX_MAX_GAS_LIMIT`, where `intrinsic_regular_gas` includes all the intrinsic costs not associated with state created (i.e., base transaction cost, calldata, access lists, authorization base costs).
 2. For each gas dimension, the **cumulative gas used of all previous transactions added to the transaction's contribution does not exceed the block gas limit**. Concretely, `min(TX_MAX_GAS_LIMIT, tx.gas) <= regular_gas_available` and `tx.gas <= state_gas_available`, where `regular_gas_available = block_env.block_gas_limit - block_output.block_regular_gas_used` and `state_gas_available = block_env.block_gas_limit - block_output.block_state_gas_used`.
+
+This check is performed before transaction inclusion in a block.
 
 #### Transaction-level gas accounting (reservoir model)
 
@@ -139,7 +139,7 @@ For each account that was created during the transaction, `SELFDESTRUCT`ed, and 
 - The state gas previously charged for the account creation (`STATE_BYTES_PER_NEW_ACCOUNT × CPSB`), the code deposit (`L × CPSB` where `L` is the deployed code length), and every storage slot that was charged as new on that account during the transaction (`STATE_BYTES_PER_STORAGE_SET × CPSB` per slot) is refunded directly to `state_gas_reservoir` and the `execution_state_gas_used` decreases by the same amount.
 - These refunds are not subject to the 20% refund cap.
 
-For an account that existed before the transaction, `SELFDESTRUCT` only transferred its balance and the account is not removed; no state-gas refund applies and no changes to `execution_state_gas_used`.
+For an account that existed before the transaction, `SELFDESTRUCT` only transferred its balance and the account is not removed; no state-gas refund applies and no changes to `execution_state_gas_used`. this is consistent with the behavior of [EIP-6780](./eip-6780.md)
 
 #### Pre-state and post-state gas validation
 

--- a/EIPS/eip-8037.md
+++ b/EIPS/eip-8037.md
@@ -66,7 +66,7 @@ In addition, `GAS_SELF_DESTRUCT_NEW_ACCOUNT` is removed and replaced by `GAS_NEW
 
 ### Multidimensional metering for state creation costs
 
-Besides the parameter changes, this proposal introduces an independent metering for state creation costs. Two gas dimensions are introduced, regular-gas and state-gas. For state creation operations, the "new state costs" are charged to state-gas, while the "new regular costs" are charged to regular-gas. The costs of all other operations are also charged to regular-gas.
+Besides the parameter changes, this proposal introduces an independent metering for state creation costs. Two gas dimensions are introduced, regular-gas and state-gas. For state creation operations, the "new state costs" are charged to state-gas, while the "new regular costs" are charged to regular-gas. The costs of all other operations are charged to regular-gas.
 
 At transaction level, the user pays for both regular-gas and state-gas. The total gas cost of a transaction is the sum of both dimensions. In addition, the transaction gas limit set in [EIP-7825](./eip-7825.md) only applies to regular-gas, while state-gas is only capped by `tx.gas`.
 

--- a/EIPS/eip-8037.md
+++ b/EIPS/eip-8037.md
@@ -79,6 +79,19 @@ Before transaction execution, inclusion of a transaction in a block requires tha
 
 This check is performed before transaction inclusion in a block.
 
+`intrinsic_regular_gas` is the sum of:
+
+- Transaction base cost
+- Calldata cost
+- Access list gas cost
+- Authorizations regular gas cost (the regular gas portion of `PER_AUTH_BASE_COST`)
+- Create transaction regular gas cost (the regular gas portion of `GAS_CREATE`)
+
+`intrinsic_state_gas` is the sum of:
+
+- Authorizations state gas cost (`PER_EMPTY_ACCOUNT_COST` + the state gas portion of `PER_AUTH_BASE_COST`)
+- Create transaction state gas (the state gas portion of `GAS_CREATE`)
+
 #### Transaction-level gas accounting (reservoir model)
 
 Since transactions have a single gas limit parameter (`tx.gas`), gas accounting is enforced through a **reservoir model**, in which `gas_left` and `state_gas_reservoir` are initialized as follows:
@@ -98,52 +111,51 @@ This means that the `state_gas_reservoir` holds gas that exceeds [EIP-7825](./ei
 
 The gas counters operate as follows:
 
-- regular-gas charges deduct from `gas_left` only and increment `execution_regular_gas_used`.
-- state-gas charges deduct from `state_gas_reservoir` first. When the reservoir is exhausted, state gas charges deduct from `gas_left`. state-gas charges increment `execution_state_gas_used`.
+- Regular-gas charges deduct from `gas_left` only and increment `execution_regular_gas_used`.
+- State-gas charges deduct from `state_gas_reservoir` first. When the reservoir is exhausted, state-gas charges deduct from `gas_left`. State-gas charges increment `execution_state_gas_used`.
+- If a state creation is undone during execution, the corresponding amount of state-gas is refilled back to the reservoir. State-gas refills decrement it `execution_state_gas_used`.
 - The `GAS` opcode returns `gas_left` only (excluding the reservoir).
-- state-gas is metered at call-frame boundaries and at the end of the transaction, not at individual state-mutating opcodes. Each frame's state-gas cost is derived from the state diff it accumulated since the call-frame began (i.e., the changes between its entry state and exit state).
+- State-gas is metered at the end of all state-mutating opcodes, call-frame boundaries (in case of exceptional halts and reverts) and at the end of the transaction.
 
-##### Frame-end state-gas accounting
+##### Gas accounting for SSTORE (opcode-level)
 
-When a frame returns successfully, the EVM derives its state-gas charges and refunds from the changes the frame caused that have not already been accounted for by a successful descendant frame. Two reference points are used:
+|Original value| current value | New value | Description | State-gas charges/refills |
+|---|---|---|---|---|
+| 0 | x | 0 | Cleared slot, zero at transaction start | `STATE_BYTES_PER_STORAGE_SET × CPSB` refilled |
+| 0 | 0 | x | New slot | `STATE_BYTES_PER_STORAGE_SET × CPSB` charged |
+| x | x | 0 | Cleared slot, non-zero at transaction start | no state-gas adjustments |
+| x | 0 | x | Existing slot, written to again | no state-gas adjustments |
+| x or 0 | y | z | Existing slot, written to again | no state-gas adjustments |
 
-- the **transaction-entry value** of each storage slot or account, used to determine whether a write counts as a new slot or a new account; and
-- the **frame-entry value**, used to determine the changes attributable to the frame (a frame is not charged for state that already existed when its execution began).
+State-gas accounting for `SSTORE` is performed at the end of the opcode execution.
 
-For each storage slot whose value differs between the frame's entry and exit states, the frame is charged or refunded as follows:
+##### Gas accounting for new accounts
 
-- **New slot.** The slot's frame-exit value is non-zero and its transaction-entry value was zero. Charge `STATE_BYTES_PER_STORAGE_SET × CPSB` of state gas and increase `execution_state_gas_used` by the same amount.
-- **Cleared slot, zero at transaction start.** The slot's frame-exit value is zero, its frame-entry value was non-zero, and its transaction-entry value was zero (the slot was created earlier in the same transaction and is now being cleared). Refund `STATE_BYTES_PER_STORAGE_SET × CPSB` directly to `state_gas_reservoir` and decrease `execution_state_gas_used` by the same amount; this state-gas refund is not subject to the 20% refund cap, since the corresponding charge was incurred in the same transaction. Additionally, `GAS_STORAGE_UPDATE - GAS_COLD_SLOAD - GAS_WARM_ACCESS` is added to `refund_counter`, subject to the 20% refund cap.
-- **Cleared slot, non-zero at transaction start.** The slot's frame-exit value is zero, its frame-entry value was non-zero, and its transaction-entry value was non-zero (a pre-existing slot is being cleared). No state-gas adjustment; instead, `SSTORE_CLEARS_SCHEDULE` is added to `refund_counter`, subject to the 20% refund cap. No changes to `execution_state_gas_used`
-- **Other transitions** (e.g., between two non-zero values, or transient changes that net to no change between frame entry and frame exit): no state-gas charge or refund.
+| Operation | State-gas charges/refills |
+|---|---|
+| `CALL*` with value to non-existent account | `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` charged |
+| `CREATE`/`CREATE2` with bytecode size of `L` | `(STATE_BYTES_PER_NEW_ACCOUNT + L) × CPSB` charged |
 
-For each account:
+State-gas accounting for `CALL*` and `CREATE`/`CREATE2` operations is performed at the end of successful call frames. The respective call frame reverts or halts exceptionally, no state-gas is charged for the new account.
 
-- **New account.** The account exists at the frame's exit state, did not exist at the start of the transaction, and was not already accounted for by a successful descendant frame. Charge `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` of state gas and increase `execution_state_gas_used` by the same amount.
-- **Code deposit on creation.** For a newly created account with bytecode `B` of length `L`, additionally charge `L × CPSB` of state gas plus `6 × ⌈L/32⌉` of regular gas (the bytecode hashing cost). Increase `execution_state_gas_used` and `execution_regular_gas_used` by the respective amounts
+##### Gas accounting for `SELFDESTRUCT`
 
-`SELFDESTRUCT` does not produce a state-gas effect at the frame in which it executes; its accounting is deferred to the end of the transaction (see [Top-level frame end](#top-level-frame-end-transaction-end) below).
-
-Each storage slot or account that is created or cleared in the transaction is charged or refunded exactly once across the call stack: once a successful descendant frame has accounted for a state change, ancestor frames do not re-account for it.
-
-When a child **reverts** or **halts exceptionally**, all of its state changes are rolled back. Because state-gas accounting is performed only at the boundary of a successful frame, a reverted or halted child produces no debits or credits to the parent's `state_gas_reservoir`. On exceptional halt, the child's `gas_left` is additionally consumed (zeroed), consistent with existing EVM semantics. `execution_regular_gas_used` is increased consistently.
-
-On **revert** or **exceptional halt** of the top-level frame, all state changes are reverted and no state gas is charged. On exceptional halt specifically, remaining `gas_left` is set to zero and `execution_regular_gas_used` is increased consistently.
-
-##### Top-level frame end (transaction end)
-
-At the end of a successful transaction, the top-level frame applies the frame-end accounting above and additionally performs deferred `SELFDESTRUCT` processing. [EIP-6780](./eip-6780.md) defers actual account removal to the end of the transaction for accounts that were created and self-destructed in the same transaction; the corresponding state-gas effect is therefore also computed only at this point.
-
-For each account that was created during the transaction, `SELFDESTRUCT`ed, and is now being removed:
+`SELFDESTRUCT` does not produce a state-gas effect at the point in which it executes. Its accounting is deferred to the end of the transaction. For each account that was created during the transaction, `SELFDESTRUCT`ed, and is now being removed:
 
 - The state gas previously charged for the account creation (`STATE_BYTES_PER_NEW_ACCOUNT × CPSB`), the code deposit (`L × CPSB` where `L` is the deployed code length), and every storage slot that was charged as new on that account during the transaction (`STATE_BYTES_PER_STORAGE_SET × CPSB` per slot) is refunded directly to `state_gas_reservoir` and the `execution_state_gas_used` decreases by the same amount.
 - These refunds are not subject to the 20% refund cap.
 
-For an account that existed before the transaction, `SELFDESTRUCT` only transferred its balance and the account is not removed; no state-gas refund applies and no changes to `execution_state_gas_used`. this is consistent with the behavior of [EIP-6780](./eip-6780.md)
+For an account that existed before the transaction, `SELFDESTRUCT` only transferred its balance and the account is not removed; no state-gas refund applies and no changes to `execution_state_gas_used`. This is consistent with the behavior of [EIP-6780](./eip-6780.md)
+
+##### Gas accounting for halts and reverts
+
+After a revert, all state changes performed on the child frame are rolled back and all state-gas charged on the child frame is refunded to the parent frame's `state_gas_reservoir` and the remaining `gas_left` of the child frame is given back to the parent frame (added to `gas_left`), consistent with existing EVM semantics. `execution_state_gas_used` is decreased consistently, while `execution_regular_gas_used` is updated according to the regular gas consumed by the child frame before the revert.
+
+After an exceptional halt, `state_gas_reservoir` is reset back to its value at the start of the child frame (i.e., all state-gas charges on the child frame are refunded to the parent frame) and the `gas_left` initially given to the child is consumed (set to zero), consistent with existing EVM semantics. `execution_state_gas_used` and `execution_regular_gas_used` are updated accordingly.
 
 #### Pre-state and post-state gas validation
 
-[EIP-7928](./eip-7928.md) defines two-phase gas validation for state-accessing opcodes: pre-state costs (determinable without state access) and post-state costs (requiring state access). Under this EIP, the regular-gas portion of these opcodes follows the [EIP-7928](./eip-7928.md) rules unchanged and is charged at opcode time against `gas_left`. The state-gas portion is **not** charged at the opcode level; it is computed and deducted at frame-end accounting (see [Frame-end state-gas accounting](#frame-end-state-gas-accounting)), drawing first from `state_gas_reservoir` and then from `gas_left`.
+[EIP-7928](./eip-7928.md) defines two-phase gas validation for state-accessing opcodes: pre-state costs (determinable without state access) and post-state costs (requiring state access). Under this EIP, the regular-gas portion of these opcodes follows the [EIP-7928](./eip-7928.md) rules unchanged and is charged at opcode time against `gas_left`. The state-gas portion is also charged at the opcode level; it is computed and deducted at the end of the opcode execution, drawing first from `state_gas_reservoir` and then from `gas_left`.
 
 For `SSTORE`, the `GAS_CALL_STIPEND` pre-state check ([EIP-7928](./eip-7928.md)) applies to `gas_left` only, excluding the `state_gas_reservoir`.
 
@@ -194,17 +206,11 @@ gas_used_delta = parent.gas_used - parent.gas_target
 
 #### [EIP-7702](./eip-7702.md) authorizations
 
-For [EIP-7702](./eip-7702.md) authorizations, the intrinsic state gas assumes account creation for each authorization: `(STATE_BYTES_PER_NEW_ACCOUNT + STATE_BYTES_PER_AUTH_BASE) × CPSB` per authorization. This mirrors [EIP-7702](./eip-7702.md)'s own intrinsic charge of `PER_EMPTY_ACCOUNT_COST` per authorization, which assumes the authority is empty. When the `authority` is not empty (using the same definition as [EIP-7702](./eip-7702.md) step 7, i.e., per [EIP-161](./eip-161.md): non-zero nonce, non-zero balance, or non-empty code) and therefore no account creation is needed, the `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` portion is refunded directly to `state_gas_reservoir` during authorization processing, in parallel with [EIP-7702](./eip-7702.md)'s `PER_EMPTY_ACCOUNT_COST - PER_AUTH_BASE_COST` regular-gas refund. `execution_state_gas_used` decreases by the corresponding amount.
-
-`intrinsic_state_gas` is immutable after transaction validation and is not modified by this refund. Block accounting uses the original worst-case `intrinsic_state_gas`; the refunded gas is reflected in the final `state_gas_reservoir` rather than in a mutated intrinsic value.
+For [EIP-7702](./eip-7702.md) authorizations, the intrinsic state-gas assumes account creation for each authorization: `(STATE_BYTES_PER_NEW_ACCOUNT + STATE_BYTES_PER_AUTH_BASE) × CPSB` per authorization. This mirrors [EIP-7702](./eip-7702.md)'s own intrinsic charge of `PER_EMPTY_ACCOUNT_COST` per authorization, which assumes the authority is empty. When the `authority` is not empty (i.e., non-zero nonce, non-zero balance, or non-empty code), the `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` portion is refunded directly to `state_gas_reservoir` during authorization processing. `execution_state_gas_used` decreases by the corresponding amount.
 
 #### Receipt semantics
 
 Receipt `cumulative_gas_used` tracks the cumulative sum of `tx_gas_used` (post-refund, post-floor) across transactions, instead of the block's `gas_used`. This means `receipt[i].cumulative_gas_used - receipt[i-1].cumulative_gas_used` equals the gas paid by transaction `i`.
-
-#### `CREATE` vs `CREATE2`
-
-`CREATE2` already charges for hashing the init code when deriving the address. That cost remains unchanged. The bytecode hash (`keccak256(B)`) must be computed on success to store the code, incurring the regular-gas hashing cost `6 × ⌈L/32⌉` defined above for `GAS_CODE_DEPOSIT`.
 
 ### System contracts and system transactions
 
@@ -269,8 +275,6 @@ To harmonize costs, we first set the gas cost of a single state byte, `CPSB`, as
 Note that the fixed cost `GAS_CREATE` for contract deployments assumes the same cost as a new account creation.
 
 ### Multidimensional metering
-
-This proposal is consistent with [EIP-8011](./eip-8011.md). However, it only requires two dimensions, namely, `regular-gas` and `state-gas`. If [EIP-8011](./eip-8011.md) is not implemented, a two-dimensional version of [EIP-8011](./eip-8011.md) is still required.
 
 #### EIP-7825 limit on contract size
 

--- a/EIPS/eip-8037.md
+++ b/EIPS/eip-8037.md
@@ -322,9 +322,9 @@ One potential concern is the cost of creating a new account (`STATE_BYTES_PER_NE
 
 Optimal block construction becomes more complex, since builders must now balance resource usage across multiple dimensions rather than a single gas metric. Sophisticated builders may gain an advantage by applying advanced optimization techniques, raising concerns about further builder centralization. However, practical heuristics (e.g., greedily filling blocks until one resource dimension saturates) remain effective for most use cases. These heuristics limit centralization pressure by keeping block construction feasible for local and less sophisticated builders.
 
-### Interaction with [EIP-4337](./eip-4337.md) bundles
+### Interaction with [ERC-4337](./eip-4337.md) bundles
 
-The `GAS` opcode returns `gas_left` only and cannot observe `state_gas_reservoir`. Bundling protocols that meter sub-call consumption via `gasleft()` deltas (e.g., the [EIP-4337](./eip-4337.md) `EntryPoint`) therefore cannot accurately attribute state-gas usage when it is funded by the reservoir. Because all user operations in a bundle share the transaction's reservoir, one user operation's state-gas refunds can subsidize another's state-gas charges without appearing in either's `gasleft()` delta. Bundlers and `EntryPoint` implementations MUST account for state-gas charges and refunds explicitly rather than relying on `gasleft()` differences alone.
+The `GAS` opcode returns `gas_left` only and cannot observe `state_gas_reservoir`. Bundling protocols that meter sub-call consumption via `gasleft()` deltas (e.g., the [ERC-4337](./eip-4337.md) `EntryPoint`) therefore cannot accurately attribute state-gas usage when it is funded by the reservoir. Because all user operations in a bundle share the transaction's reservoir, one user operation's state-gas refunds can subsidize another's state-gas charges without appearing in either's `gasleft()` delta. Bundlers and `EntryPoint` implementations MUST account for state-gas charges and refunds explicitly rather than relying on `gasleft()` differences alone.
 
 ## Copyright
 

--- a/EIPS/eip-8037.md
+++ b/EIPS/eip-8037.md
@@ -91,10 +91,15 @@ gas_left = min(regular_gas_budget, execution_gas)
 state_gas_reservoir = execution_gas - gas_left
 ```
 
-The `state_gas_reservoir` holds gas that exceeds the [EIP-7825](./eip-7825.md)'s budget. The two counters operate as follows:
+This means that The `state_gas_reservoir` holds gas that exceeds the [EIP-7825](./eip-7825.md)'s budget.. Additionally, two new counters are introduced:
 
-- regular-gas charges deduct from `gas_left` only.
-- state-gas charges deduct from `state_gas_reservoir` first. When the reservoir is exhausted, state gas charges deduct from `gas_left`.
+- `execution_regular_gas_used` encodes the total regular-gas used by the transaction, and it is initialized as `execution_regular_gas_used = intrinsic_regular_gas`.
+- `execution_state_gas_used` encodes the total state-gas used by the transaction, and it is initialized as `execution_state_gas_used = intrinsic_state_gas`.
+
+The gas counters operate as follows:
+
+- regular-gas charges deduct from `gas_left` only and increment `execution_regular_gas_used`.
+- state-gas charges deduct from `state_gas_reservoir` first. When the reservoir is exhausted, state gas charges deduct from `gas_left`. state-gas charges increment `execution_state_gas_used`.
 - The `GAS` opcode returns `gas_left` only (excluding the reservoir).
 - state-gas is metered at call-frame boundaries and at the end of the transaction, not at individual state-mutating opcodes. Each frame's state-gas cost is derived from the state diff it accumulated since the call-frame began (i.e., the changes between its entry state and exit state).
 
@@ -107,23 +112,23 @@ When a frame returns successfully, the EVM derives its state-gas charges and ref
 
 For each storage slot whose value differs between the frame's entry and exit states, the frame is charged or refunded as follows:
 
-- **New slot.** The slot's frame-exit value is non-zero and its transaction-entry value was zero. Charge `STATE_BYTES_PER_STORAGE_SET × CPSB` of state gas.
-- **Cleared slot, zero at transaction start.** The slot's frame-exit value is zero, its frame-entry value was non-zero, and its transaction-entry value was zero (the slot was created earlier in the same transaction and is now being cleared). Refund `STATE_BYTES_PER_STORAGE_SET × CPSB` directly to `state_gas_reservoir`. This refund is not subject to the 20% refund cap, since the corresponding charge was incurred in the same transaction.
-- **Cleared slot, non-zero at transaction start.** The slot's frame-exit value is zero, its frame-entry value was non-zero, and its transaction-entry value was non-zero (a pre-existing slot is being cleared). No state-gas adjustment; instead, `GAS_STORAGE_UPDATE - GAS_COLD_SLOAD - GAS_WARM_ACCESS` is added to `refund_counter`, subject to the 20% refund cap.
+- **New slot.** The slot's frame-exit value is non-zero and its transaction-entry value was zero. Charge `STATE_BYTES_PER_STORAGE_SET × CPSB` of state gas and increase `execution_state_gas_used` by the same amount.
+- **Cleared slot, zero at transaction start.** The slot's frame-exit value is zero, its frame-entry value was non-zero, and its transaction-entry value was zero (the slot was created earlier in the same transaction and is now being cleared). Refund `STATE_BYTES_PER_STORAGE_SET × CPSB` directly to `state_gas_reservoir` and decrease `execution_state_gas_used` by the same amount. This refund is not subject to the 20% refund cap, since the corresponding charge was incurred in the same transaction.
+- **Cleared slot, non-zero at transaction start.** The slot's frame-exit value is zero, its frame-entry value was non-zero, and its transaction-entry value was non-zero (a pre-existing slot is being cleared). No state-gas adjustment; instead, `GAS_STORAGE_UPDATE - GAS_COLD_SLOAD - GAS_WARM_ACCESS` is added to `refund_counter`, subject to the 20% refund cap. No changes to `execution_state_gas_used`
 - **Other transitions** (e.g., between two non-zero values, or transient changes that net to no change between frame entry and frame exit): no state-gas charge or refund.
 
 For each account:
 
-- **New account.** The account exists at the frame's exit state, did not exist at the start of the transaction, and was not already accounted for by a successful descendant frame. Charge `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` of state gas.
-- **Code deposit on creation.** For a newly created account with bytecode `B` of length `L`, additionally charge `L × CPSB` of state gas plus `6 × ⌈L/32⌉` of regular gas (the bytecode hashing cost).
+- **New account.** The account exists at the frame's exit state, did not exist at the start of the transaction, and was not already accounted for by a successful descendant frame. Charge `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` of state gas and increase `execution_state_gas_used` by the same amount.
+- **Code deposit on creation.** For a newly created account with bytecode `B` of length `L`, additionally charge `L × CPSB` of state gas plus `6 × ⌈L/32⌉` of regular gas (the bytecode hashing cost). Increase `execution_state_gas_used` and `execution_regular_gas_used` by the respective amounts
 
 `SELFDESTRUCT` does not produce a state-gas effect at the frame in which it executes; its accounting is deferred to the end of the transaction (see [Top-level frame end](#top-level-frame-end-transaction-end) below).
 
 Each storage slot or account that is created or cleared in the transaction is charged or refunded exactly once across the call stack: once a successful descendant frame has accounted for a state change, ancestor frames do not re-account for it.
 
-When a child **reverts** or **halts exceptionally**, all of its state changes are rolled back. Because state-gas accounting is performed only at the boundary of a successful frame, a reverted or halted child produces no debits or credits to the parent's `state_gas_reservoir`. On exceptional halt, the child's `gas_left` is additionally consumed (zeroed), consistent with existing EVM semantics.
+When a child **reverts** or **halts exceptionally**, all of its state changes are rolled back. Because state-gas accounting is performed only at the boundary of a successful frame, a reverted or halted child produces no debits or credits to the parent's `state_gas_reservoir`. On exceptional halt, the child's `gas_left` is additionally consumed (zeroed), consistent with existing EVM semantics. `execution_regular_gas_used` is increased consistently.
 
-On **revert** or **exceptional halt** of the top-level frame, all state changes are reverted and no state gas is charged. On exceptional halt specifically, remaining `gas_left` is set to zero.
+On **revert** or **exceptional halt** of the top-level frame, all state changes are reverted and no state gas is charged. On exceptional halt specifically, remaining `gas_left` is set to zero and `execution_regular_gas_used` is increased consistently.
 
 ##### Top-level frame end (transaction end)
 
@@ -131,10 +136,10 @@ At the end of a successful transaction, the top-level frame applies the frame-en
 
 For each account that was created during the transaction, `SELFDESTRUCT`ed, and is now being removed:
 
-- The state gas previously charged for the account creation (`STATE_BYTES_PER_NEW_ACCOUNT × CPSB`), the code deposit (`L × CPSB` where `L` is the deployed code length), and every storage slot that was charged as new on that account during the transaction (`STATE_BYTES_PER_STORAGE_SET × CPSB` per slot) is refunded directly to `state_gas_reservoir`.
+- The state gas previously charged for the account creation (`STATE_BYTES_PER_NEW_ACCOUNT × CPSB`), the code deposit (`L × CPSB` where `L` is the deployed code length), and every storage slot that was charged as new on that account during the transaction (`STATE_BYTES_PER_STORAGE_SET × CPSB` per slot) is refunded directly to `state_gas_reservoir` and the `execution_state_gas_used` decreases by the same amount.
 - These refunds are not subject to the 20% refund cap.
 
-For an account that existed before the transaction, `SELFDESTRUCT` only transferred its balance and the account is not removed; no state-gas refund applies.
+For an account that existed before the transaction, `SELFDESTRUCT` only transferred its balance and the account is not removed; no state-gas refund applies and no changes to `execution_state_gas_used`.
 
 #### Pre-state and post-state gas validation
 
@@ -189,7 +194,7 @@ gas_used_delta = parent.gas_used - parent.gas_target
 
 #### [EIP-7702](./eip-7702.md) authorizations
 
-For [EIP-7702](./eip-7702.md) authorizations, the intrinsic state gas assumes account creation for each authorization: `(STATE_BYTES_PER_NEW_ACCOUNT + STATE_BYTES_PER_AUTH_BASE) × CPSB` per authorization. When an authorization targets an existing account (no account creation needed), the `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` portion is refunded directly to `state_gas_reservoir` during authorization processing.
+For [EIP-7702](./eip-7702.md) authorizations, the intrinsic state gas assumes account creation for each authorization: `(STATE_BYTES_PER_NEW_ACCOUNT + STATE_BYTES_PER_AUTH_BASE) × CPSB` per authorization. When an authorization targets an existing account (no account creation needed), the `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` portion is refunded directly to `state_gas_reservoir` during authorization processing. `execution_state_gas_used` decreases by the corresponding amount.
 
 `intrinsic_state_gas` is immutable after transaction validation and is not modified by this refund. Block accounting uses the original worst-case `intrinsic_state_gas`; the refunded gas is reflected in the final `state_gas_reservoir` rather than in a mutated intrinsic value.
 

--- a/EIPS/eip-8037.md
+++ b/EIPS/eip-8037.md
@@ -113,8 +113,8 @@ When a frame returns successfully, the EVM derives its state-gas charges and ref
 For each storage slot whose value differs between the frame's entry and exit states, the frame is charged or refunded as follows:
 
 - **New slot.** The slot's frame-exit value is non-zero and its transaction-entry value was zero. Charge `STATE_BYTES_PER_STORAGE_SET × CPSB` of state gas and increase `execution_state_gas_used` by the same amount.
-- **Cleared slot, zero at transaction start.** The slot's frame-exit value is zero, its frame-entry value was non-zero, and its transaction-entry value was zero (the slot was created earlier in the same transaction and is now being cleared). Refund `STATE_BYTES_PER_STORAGE_SET × CPSB` directly to `state_gas_reservoir` and decrease `execution_state_gas_used` by the same amount; this state-gas refund is not subject to the 20% refund cap, since the corresponding charge was incurred in the same transaction. Additionally, `GAS_STORAGE_UPDATE - GAS_COLD_SLOAD - GAS_WARM_ACCESS` is added to `refund_counter`, subject to the 20% refund cap, refunding the regular-gas portion of the original `SSTORE_SET` charge and preserving the current EVM refund behavior (i.e., a residual of `GAS_WARM_ACCESS` per round-trip).
-- **Cleared slot, non-zero at transaction start.** The slot's frame-exit value is zero, its frame-entry value was non-zero, and its transaction-entry value was non-zero (a pre-existing slot is being cleared). No state-gas adjustment; instead, `GAS_STORAGE_UPDATE - GAS_COLD_SLOAD - GAS_WARM_ACCESS` is added to `refund_counter`, subject to the 20% refund cap. No changes to `execution_state_gas_used`
+- **Cleared slot, zero at transaction start.** The slot's frame-exit value is zero, its frame-entry value was non-zero, and its transaction-entry value was zero (the slot was created earlier in the same transaction and is now being cleared). Refund `STATE_BYTES_PER_STORAGE_SET × CPSB` directly to `state_gas_reservoir` and decrease `execution_state_gas_used` by the same amount; this state-gas refund is not subject to the 20% refund cap, since the corresponding charge was incurred in the same transaction. Additionally, `GAS_STORAGE_UPDATE - GAS_COLD_SLOAD - GAS_WARM_ACCESS` is added to `refund_counter`, subject to the 20% refund cap.
+- **Cleared slot, non-zero at transaction start.** The slot's frame-exit value is zero, its frame-entry value was non-zero, and its transaction-entry value was non-zero (a pre-existing slot is being cleared). No state-gas adjustment; instead, `SSTORE_CLEARS_SCHEDULE` is added to `refund_counter`, subject to the 20% refund cap. No changes to `execution_state_gas_used`
 - **Other transitions** (e.g., between two non-zero values, or transient changes that net to no change between frame entry and frame exit): no state-gas charge or refund.
 
 For each account:
@@ -200,7 +200,7 @@ For [EIP-7702](./eip-7702.md) authorizations, the intrinsic state gas assumes ac
 
 #### Receipt semantics
 
-Receipt `cumulative_gas_used` tracks the cumulative sum of `tx_gas_used_after_refund` (post-refund, post-floor) across transactions, instead of the block's `gas_used`. This means `receipt[i].cumulative_gas_used - receipt[i-1].cumulative_gas_used` equals the gas paid by transaction `i`.
+Receipt `cumulative_gas_used` tracks the cumulative sum of `tx_gas_used` (post-refund, post-floor) across transactions, instead of the block's `gas_used`. This means `receipt[i].cumulative_gas_used - receipt[i-1].cumulative_gas_used` equals the gas paid by transaction `i`.
 
 #### `CREATE` vs `CREATE2`
 
@@ -224,7 +224,7 @@ The additional `STATE_BYTES_PER_STORAGE_SET × CPSB × SYSTEM_MAX_SSTORES_PER_CA
 
 ### Deriving the cost per state byte (CPSB)
 
-`CPSB` is a derived parameter that depends on the block gas limit. The idea is to have a cost that scales as the block gas limit increases, thus avoiding excessive state growth. The derivation pins the cost so that, under expected average utilization, total state growth stays at the target rate.
+`CPSB` is a fixed parameter derived from a reference block gas limit. The derivation pins the cost so that, at the reference block gas limit and under expected average utilization, total state growth stays at the target rate. If a future block gas limit increase materially changes the expected state growth rate, `CPSB` can be re-derived in a subsequent EIP.
 
 #### Inputs
 
@@ -264,7 +264,7 @@ With the current pricing, the gas cost of creating 1 byte of state varies depend
 | [EIP-7702](./eip-7702.md) authorization to empty address    | 23 B (0xef0100‖address) + updated account leaf | 25,000 PER_EMPTY_ACCOUNT + 12,500 PER_AUTH_BASE + 1,616 calldata = 39,116 gas                 | ~135 B        | ~289 gas   |
 | Fill new storage slots (SSTORE 0→x)                         | Slot in storage trie                           | 20,000 gas/slot                                                                               | 32 B          | 625 gas    |
 
-To harmonize costs, we first set the gas cost of a single state byte, `CPSB`, as explained above. This is a dynamic parameter that depends on the block gas limit. Now that we have a standardized cost per byte, we can derive the various costs parameters by multiplying the unit cost by the increase in bytes any given operation creates in the database (i.e., 32 bytes per slot, 112 bytes per account and 23 bytes per authorization).
+To harmonize costs, we first set the gas cost of a single state byte, `CPSB`, as explained above. Now that we have a standardized cost per byte, we can derive the various costs parameters by multiplying the unit cost by the increase in bytes any given operation creates in the database (i.e., 32 bytes per slot, 112 bytes per account and 23 bytes per authorization).
 
 Note that the fixed cost `GAS_CREATE` for contract deployments assumes the same cost as a new account creation.
 
@@ -274,7 +274,7 @@ This proposal is consistent with [EIP-8011](./eip-8011.md). However, it only req
 
 #### EIP-7825 limit on contract size
 
-[EIP-7825](./eip-7825.md) introduces `TX_MAX_GAS_LIMIT` (16.7M) as the maximum gas for a single transaction, in particular stipulating `tx.gas < TX_MAX_GAS_LIMIT`as a validity condition. Were we to continue enforcing this validity condition, with a block limit of 100M gas units, this proposal would limit the maximum contract size that can be deployed to roughly 9.9kB. Assuming a representative constructor execution budget of 5M regular gas on top of the 21,000 base transaction cost and the `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` account-creation cost, the remaining budget for code-deposit state gas yields $\frac{16,777,216 - 21,000 - 5,000,000 - 112 \times 1174}{1174} \approx 9{,}902$ bytes. This maximum size would only decrease as we increase the gas limit and the `CPSB`.
+[EIP-7825](./eip-7825.md) introduces `TX_MAX_GAS_LIMIT` (16.7M) as the maximum gas for a single transaction, in particular stipulating `tx.gas < TX_MAX_GAS_LIMIT`as a validity condition. Were we to continue enforcing this validity condition, with `CPSB = 1174`, this proposal would limit the maximum contract size that can be deployed to roughly 9.9kB. Assuming a representative constructor execution budget of 5M regular gas on top of the 21,000 base transaction cost and the `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` account-creation cost, the remaining budget for code-deposit state gas yields $\frac{16,777,216 - 21,000 - 5,000,000 - 112 \times 1174}{1174} \approx 9{,}902$ bytes. This maximum size would only decrease if `CPSB` is re-derived upward in a future EIP.
 
 To solve this issue, we only apply this gas limit to regular gas, not state gas. Doing so does not weaken the intended scaling effect of [EIP-7825](./eip-7825.md), because regular gas meters all resources that benefit from parallelization. In particular, state growth does not: growing the state always requires writing to disk, a parallelizable operation, but crucially this part of the cost of a state growth operation has to be metered in regular gas, not state gas. In other words, any operation that grows the state should consume both regular gas and state gas, and the regular gas should fully account for all costs other than the long term effect of growing the state.
 
@@ -317,10 +317,6 @@ One potential concern is the cost of creating a new account (`STATE_BYTES_PER_NE
 ### Added complexity in block building
 
 Optimal block construction becomes more complex, since builders must now balance resource usage across multiple dimensions rather than a single gas metric. Sophisticated builders may gain an advantage by applying advanced optimization techniques, raising concerns about further builder centralization. However, practical heuristics (e.g., greedily filling blocks until one resource dimension saturates) remain effective for most use cases. These heuristics limit centralization pressure by keeping block construction feasible for local and less sophisticated builders.
-
-### Testing requirements for increasing block limits
-
-With a dynamic cost per byte, every time the block gas limit is increased, clients and testing frameworks need to test for backward compatibility issues. This changes the testing framework for increasing the block limit. A way to mitigate this is to introduce a max cost per byte and do the analysis once on the impact of this max cost.
 
 ## Copyright
 


### PR DESCRIPTION
### Cost-per-state-byte: dynamic → fixed

- Replaces the dynamic, quantized `cost_per_state_byte` with a single constant `CPSB = 1174`, derived from a 100 GiB/year target at a 96M-gas reference limit.
- Removes `TARGET_STATE_GROWTH_PER_YEAR`, `CPSB_SIGNIFICANT_BITS`, `CPSB_OFFSET`, and the entire quantization section.
- Adds named byte-count constants: `STATE_BYTES_PER_STORAGE_SET`, `STATE_BYTES_PER_NEW_ACCOUNT`, `STATE_BYTES_PER_AUTH_BASE`.

### State-gas accounting rules (opcode-level)

- `SSTORE`: charged/refilled at end of opcode based on original/current/new value (handles the 0→x→0 case directly without a separate refund section).
- `CALL*` / `CREATE` / `CREATE2`: state-gas charged at end of successful call frame; reverted or exceptionally-halted frames produce no debit.
- `SELFDESTRUCT`: accounting deferred to end of transaction; refunds the account, code, and per-slot state-gas for accounts both created and destroyed in the same tx (per [EIP-6780](./eip-6780.md)), bypassing the 20% refund cap.
- Removes the now-subsumed sections on SSTORE 0→x→0 refund, frame-failure handling, CREATE-failure refund, same-tx SELFDESTRUCT refund, CALL-with-value to selfdestructed accounts, and the detailed contract-deployment gas formulas.

### System contracts and system transactions

- Adds a new section adjusting `SYSTEM_CALL_GAS_LIMIT` to `30M + STATE_BYTES_PER_STORAGE_SET × CPSB × SYSTEM_MAX_SSTORES_PER_CALL` so existing system contracts retain their execution margin under the higher state-creation cost.