### PR TITLE
Update EIP-8141: allow payer to approve before sender

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -89,11 +89,11 @@ Frame executes as regular call where the caller address is `ENTRY_POINT`.
 
 ##### `VERIFY` Mode
 
-Identifies the frame as a validation frame. Its purpose is to *verify* that a sender and/or payer authorized the transaction. It must call `APPROVE` during execution. Failure to do so will result in the whole transaction being invalid.
+Identifies the frame as a validation frame. Its purpose is to *verify* that a sender and/or payer authorized the transaction. It must call `APPROVE` during execution. Failure to do so before payment has been approved will result in the whole transaction being invalid after payment has been approved, the frame is treated as a paid failure.
 
-The execution behaves the same as `STATICCALL` for user code: state cannot otherwise be modified. The `APPROVE` opcode is the only exception and applies its protocol-defined effects, including approval updates and, for payment scopes, nonce increment and gas-charge collection.
+The execution behaves the same as `STATICCALL` for user code: state cannot otherwise be modified. The `APPROVE` opcode is the only exception and applies its protocol-defined effects, including approval updates, gas-charge collection for payment scopes, and sender nonce increment for execution scopes.
 
-Frames in this mode will have their data elided from signature hash calculation and from introspection by other frames.
+Frames in this mode will have their data elided from the canonical signature hash and from introspection by other frames. Their data is included in the current-frame signature hash computed by other frames, and elided only when the `VERIFY` frame itself is the currently executing frame.
 
 ##### `SENDER` Mode
 
@@ -162,7 +162,7 @@ frame_receipt = [status, gas_used, logs]
 
 #### Signature Hash
 
-With the frame transaction, the signature may be at an arbitrary location in the frame list. In the canonical signature hash any frame with mode `VERIFY` will have its data elided:
+With the frame transaction, the signature may be at an arbitrary location in the frame list. In the canonical signature hash, any `VERIFY` frame will have their data elided:
 
 ```python
 def compute_sig_hash(tx: FrameTx) -> Hash:
@@ -173,6 +173,19 @@ def compute_sig_hash(tx: FrameTx) -> Hash:
             tx_copy.frames[i].data = Bytes()
     return keccak(bytes([FRAME_TX_TYPE]) + rlp(tx_copy))
 ```
+
+A second signature hash is available for frame-local authorizations. It elides only the data of the currently executing frame and commits to all other frame data, including the data of other `VERIFY` frames:
+
+```python
+def compute_frame_sig_hash(tx: FrameTx, current_frame_index: int) -> Hash:
+    assert current_frame_index < len(tx.frames)
+    # Operate on a copy; the original transaction object is not modified.
+    tx_copy = deep_copy(tx)
+    tx_copy.frames[current_frame_index].data = Bytes()
+    return keccak(bytes([FRAME_TX_TYPE]) + rlp(tx_copy))
+```
+
+This hash is intended for authorizations whose signature or nonce material is carried in the current frame but which must bind to the exact data of other validation frames, such as a payer signature produced after the sender's validation data has been assembled.
 
 ### New Opcodes
 
@@ -226,16 +239,17 @@ The behavior of `APPROVE` is defined as follows:
 
 - If `ADDRESS != resolved_target`, revert.
 - For scopes `APPROVE_EXECUTION`, `APPROVE_PAYMENT`, and `APPROVE_PAYMENT_AND_EXECUTION`, execute the following:
-    - `APPROVE_EXECUTION`: Set `sender_approved = true`.
+    - `APPROVE_EXECUTION`: Increment the sender's nonce and set `sender_approved = true`.
         - If `sender_approved` was already set, revert the frame.
         - If `resolved_target` != `tx.sender`, revert the frame.
-    - `APPROVE_PAYMENT`: Increment the sender's nonce, collect the transaction's maximum cost (`TXPARAM(0x06)`) from `resolved_target`, and set `payer_approved = true`.
+        - If `state[tx.sender].nonce != tx.nonce`, revert the frame.
+    - `APPROVE_PAYMENT`: Collect the transaction's maximum cost (`TXPARAM(0x06)`) from `resolved_target`, set `payer = resolved_target`, and set `payer_approved = true`.
         - If `payer_approved` was already set, revert the frame.
         - If `resolved_target` has insufficient balance, revert the frame.
-        - If `sender_approved == false`, revert the frame.
-    - `APPROVE_PAYMENT_AND_EXECUTION`: Set `sender_approved = true`, increment the sender's nonce, collect the transaction's maximum cost (`TXPARAM(0x06)`) from `resolved_target`, and set `payer_approved = true`.
+    - `APPROVE_PAYMENT_AND_EXECUTION`: Increment the sender's nonce, collect the transaction's maximum cost (`TXPARAM(0x06)`) from `resolved_target`, set `payer = resolved_target`, set `sender_approved = true`, and set `payer_approved = true`.
         - If `sender_approved` or `payer_approved` was already set, revert the frame.
         - If `resolved_target` != `tx.sender`, revert the frame.
+        - If `state[tx.sender].nonce != tx.nonce`, revert the frame.
         - If `resolved_target` has insufficient balance, revert the frame.
 
 #### `TXPARAM` opcode
@@ -258,6 +272,7 @@ It takes one value from the stack, `param`. The `param` is the field to be extra
 | 0x08    | `compute_sig_hash(tx)`                                                      |
 | 0x09    | `len(frames)`                                                               |
 | 0x0A    | currently executing frame index                                             |
+| 0x0B    | `compute_frame_sig_hash(tx, TXPARAM(0x0A))`                                 |
 
 Notes:
 
@@ -266,6 +281,7 @@ Notes:
 - `0x06` covers only the maximum gas and blob fees. It does not include any `frame.value` transfers.
 - `0x07` returns only the number of blob versioned hashes. Individual blob versioned hashes remain accessible via the existing `BLOBHASH(index)` opcode.
 - `0x08` returns the canonical signature hash. This value MUST be computed at most once per transaction and cached.
+- `0x0B` returns the current-frame signature hash. This value MUST be computed at most once per frame index and cached.
 - Invalid `param` values (not defined in the table above) result in an exceptional halt.
 
 #### `FRAMEPARAM` opcode
@@ -334,13 +350,15 @@ Initialize with transaction-scoped variables:
 
 - `payer_approved = false`
 - `sender_approved = false`
+- `payer = None`
 
 Then for each call frame:
 
 1. Let `resolved_target = frame.target if frame.target is not null else tx.sender`, then execute a call with the specified `mode`, `flags`, `resolved_target`, `gas_limit`, `value`, and `data`.
    - If mode is `SENDER`:
-       - `sender_approved` must be `true`. If not, the transaction is invalid.
-       - Set `caller` as `tx.sender`.
+       - If `sender_approved` is `true`, set `caller` as `tx.sender`.
+       - If `sender_approved` is `false` and `payer_approved` is `false`, the transaction is invalid.
+       - If `sender_approved` is `false` and `payer_approved` is `true`, do not execute the frame and mark it as failed.
    - If mode is `DEFAULT` or `VERIFY`:
        - Set the `caller` to `ENTRY_POINT`.
    - In the top-level frame call, `CALLVALUE` is `frame.value`.
@@ -349,7 +367,9 @@ Then for each call frame:
    - Otherwise, if `resolved_target` uses an [EIP-7702](./eip-7702.md) delegation indicator, execute according to [EIP-7702](./eip-7702.md)'s delegated-code semantics.
    - The `ORIGIN` opcode returns frame `caller` throughout all call depths.
    - If a frame's execution reverts, its state changes are discarded. Additionally, if this frame has the atomic batch flag set, mark all subsequent frames in the same atomic group as skipped.
-2. If frame has mode `VERIFY` and the frame did not successfully call `APPROVE`, the transaction is invalid.
+2. If frame has mode `VERIFY` and the frame did not successfully call `APPROVE`:
+   - If `payer_approved` is `false`, the transaction is invalid.
+   - If `payer_approved` is `true`, mark the frame as failed and continue to the next frame.
 
 #### Atomic Batching
 
@@ -379,7 +399,9 @@ After executing all frames, verify that `payer_approved == true`. If it is, refu
 
 Note:
 
-- It is implied by the handling that the sender must approve the transaction *before* the payer and that once `sender_approved` or `payer_approved` become `true` they cannot be re-approved or reverted.
+- Payment approval and execution approval may occur in either order. A transaction is valid once payment has been approved, even if execution approval never succeeds. `SENDER` frames still require `sender_approved = true` before they can execute.
+- The sender nonce is consumed only by `APPROVE_EXECUTION` or `APPROVE_PAYMENT_AND_EXECUTION`. A payer that approves payment before sender approval cannot rely on the sender nonce for replay protection.
+- Once `sender_approved` or `payer_approved` become `true` they cannot be re-approved or reverted.
 
 #### Default code
 
@@ -417,6 +439,7 @@ Notes:
 
 - `P256VERIFY` must reject invalid public keys, including points that are not on the P256 curve.
 - For the P256 (r1) signature type, the sender address is `keccak(P256_ADDRESS_DOMAIN|qx|qy)[12:]`.
+- The default-code payment path does not maintain payer-specific replay protection. A default-code account that approves payment before sender execution approval is replay-safe only if the same transaction later consumes the sender nonce, or if the payer accepts replay risk through some external mechanism.
 
 Here's the logic above implemented in Python:
 
@@ -562,7 +585,7 @@ Public mempool rules apply only to the validation prefix. Once `payer_approved =
 
 A frame transaction is eligible for public mempool propagation only if its validation prefix depends exclusively on:
 
-1. transaction fields, including the canonical signature hash,
+1. transaction fields, including the canonical signature hash and the current-frame signature hash,
 2. the sender's nonce, code, and storage,
 3. the [EIP-7997](./eip-7997.md) deterministic factory predeploy, if a deployment frame is present,
 4. if a paymaster frame is present, either a canonical paymaster instance together with explicit paymaster balance reservation, or a non-canonical paymaster being used by less than `MAX_PENDING_TXS_USING_NON_CANONICAL_PAYMASTER` pending transactions,
@@ -579,14 +602,14 @@ While the frames are designed to be generic, we refine some frame modes for the 
 | `self_verify`   | VERIFY  | Validates the transaction and approves both sender and payer |
 | `deploy`  | DEFAULT | Deploys a new smart account using the [EIP-7997](./eip-7997.md) deterministic factory predeploy |
 | `only_verify`  | VERIFY  | Validates the transaction and approves only the sender |
-| `pay`  | VERIFY | Validates the transaction and approves only the payer |
+| `pay`  | VERIFY or DEFAULT | Validates the transaction and approves only the payer |
 | `user_op` | SENDER | Executes the intended user operation |
 | `post_op` | DEFAULT | Executes an optional post-op action as needed by the paymaster |
 
 
 #### Public Mempool-recognized Validation Prefixes
 
-The public mempool recognizes four validation prefixes. Structural rules are enforced only up to and including the frame that sets `payer_approved = true`.
+The public mempool recognizes the following validation prefixes. Structural rules are enforced only up to and including the frame that sets `payer_approved = true`.
 
 ##### Self Relay
 
@@ -606,7 +629,7 @@ The public mempool recognizes four validation prefixes. Structural rules are enf
 +--------+-------------+
 ```
 
-##### Canonical Paymaster
+##### Paymaster, sender-first
 
 ###### Basic Transaction
 
@@ -624,24 +647,44 @@ The public mempool recognizes four validation prefixes. Structural rules are enf
 +--------+-------------+-----+
 ```
 
-Frames after these prefixes are outside public mempool validation. For example, a transaction may continue with any number of `user_op`s and/or `post_op`s.
+##### Non-canonical paymaster, payer-first
+
+###### Basic Transaction
+
+```
++-----+
+| pay |
++-----+
+```
+
+###### Deploy New Account
+
+```
++--------+-----+
+| deploy | pay |
++--------+-----+
+```
+
+Frames after these prefixes are outside public mempool validation. For example, a payer-first transaction may continue with `only_verify`, any number of `user_op`s, and/or `post_op`s after `pay`. The payer-first prefixes are not available to the canonical paymaster.
 
 #### Structural Rules
 
 To be accepted into the public mempool, a frame transaction must satisfy the following:
 
-1. Its validation prefix must match one of the four recognized prefixes above.
+1. Its validation prefix must match one of the recognized prefixes above.
 2. If present, `deploy` must be the first frame. This implies there can be at most one `deploy` frame in the validation prefix.
-3. `self_verify` and `only_verify` must execute in `VERIFY` mode, target `tx.sender` (either explicitly or via a null target), and must successfully call `APPROVE`.
+3. `self_verify` and `only_verify`, if present in the validation prefix, must execute in `VERIFY` mode, target `tx.sender` (either explicitly or via a null target), and must successfully call `APPROVE`.
     - `self_verify` must call `APPROVE(APPROVE_PAYMENT_AND_EXECUTION)`.
     - `only_verify` must call `APPROVE(APPROVE_EXECUTION)`.
-4. `pay` must execute in `VERIFY` mode and successfully call `APPROVE(APPROVE_PAYMENT)`.
+4. `pay` must execute in `VERIFY` or `DEFAULT` mode and successfully call `APPROVE(APPROVE_PAYMENT)`.
+    - If `pay` targets a canonical paymaster instance, the validation prefix must be a sender-first paymaster prefix and `pay` must execute in `VERIFY` mode.
+    - If `pay` appears in a payer-first prefix, it must not target a canonical paymaster instance.
 5. The sum of `gas_limit` values across the validation prefix must not exceed `MAX_VERIFY_GAS`.
 6. Nodes should stop simulation immediately once `payer_approved = true` has been observed.
 
 #### Canonical Paymaster Exception
 
-The generic validation trace and opcode rules below apply to all frames in the validation prefix except a `pay` frame whose target runtime code exactly matches the canonical paymaster implementation. The canonical paymaster implementation is explicitly designed to be safe for public mempool use and is therefore admitted by code match, successful `APPROVE(APPROVE_PAYMENT)`, and the paymaster accounting rules in this section, rather than by requiring it to satisfy each generic validation rule individually.
+The generic validation trace and opcode rules below apply to all frames in the validation prefix except a sender-first `pay` frame whose target runtime code exactly matches the canonical paymaster implementation. The canonical paymaster implementation is explicitly designed to be safe for public mempool use in the sender-first flow and is therefore admitted by code match, successful `APPROVE(APPROVE_PAYMENT)`, and the paymaster accounting rules in this section, rather than by requiring it to satisfy each generic validation rule individually.
 
 #### Validation Trace Rules
 
@@ -651,8 +694,8 @@ A public mempool node must simulate the validation prefix and reject the transac
 - a `VERIFY` frame in the validation prefix exits without the required `APPROVE`
 - execution exceeds `MAX_VERIFY_GAS`
 - execution uses a banned opcode
-- execution performs a state write, except deterministic deployment performed by the first `deploy` frame through a known deployer
-- execution reads storage outside `tx.sender`
+- execution performs a state write, except deterministic deployment performed by the first `deploy` frame through a known deployer, or payer-owned replay-protection writes performed by an admitted `pay` frame
+- execution reads storage outside `tx.sender`, except payer-owned storage read by an admitted `pay` frame for payment authentication and replay protection
 - execution performs `CALL*` or `EXTCODE*` to an address that is neither an existing contract nor a precompile, or to an address that uses an EIP-7702 delegation, except for `tx.sender` default-code behavior
 - if a `deploy` frame is present, its execution does not result in non-empty, non-delegated code being installed at `tx.sender`
 
@@ -681,10 +724,11 @@ For `VERIFY` frames, the usual `STATICCALL` restrictions apply except for the pr
 - BALANCE (0x31)
 - SELFBALANCE (0x47)
 - SSTORE (0x55)
+    - Except for payer-owned replay-protection writes performed by an admitted `pay` frame.
 - TLOAD (0x5C)
 - TSTORE (0x5D)
 
-`SLOAD` can be used only to access `tx.sender` storage, including when reached transitively via `CALL*` or `DELEGATECALL`.
+`SLOAD` can be used only to access `tx.sender` storage, including when reached transitively via `CALL*` or `DELEGATECALL`. A `pay` frame admitted under the paymaster rules may additionally read the paymaster's own storage needed to authenticate and replay-protect payment.
 
 `CALL*` and `EXTCODE*` may target any existing contract or precompile, provided the resulting trace still satisfies the storage, opcode, and EIP-7702 restrictions above. This permits helper contracts and libraries during validation, including via `DELEGATECALL`, so long as they do not introduce additional mutable-state dependencies.
 
@@ -699,15 +743,25 @@ We address this conflict in two ways:
   b. after a delay period.
 2. If a paymaster sponsors gas for a small number of accounts simultaneously (no more than `MAX_PENDING_TXS_USING_NON_CANONICAL_PAYMASTER`), it may be any paymaster contract.
 
+##### Payer replay protection
+
+The protocol does not provide a payer nonce. A payer that approves payment before execution approval might pay for a transaction that does not consume the sender nonce, because `APPROVE_EXECUTION` may fail or may not be present. Such a payer must implement replay protection in its own account logic if it does not intend the same payment authorization to be reusable.
+
+A payer authorization should use the current-frame signature hash (`TXPARAM(0x0B)`) rather than the canonical signature hash (`TXPARAM(0x08)`) when the payer wants to bind to the exact calldata of other validation frames. The payer's signed message should also include payer-specific replay data, such as a nonce or replay key, and any policy terms that appear in the payer frame's own calldata, because the current frame's calldata is excluded from `TXPARAM(0x0B)`.
+
+A `pay` frame that consumes payer-owned replay state generally executes in `DEFAULT` mode, because `VERIFY` mode is `STATICCALL`-like and cannot otherwise modify storage. A `DEFAULT` `pay` frame uses a non-zero approval scope, so its calldata is elided from the canonical signature hash while remaining visible to other frames.
+
 ##### Canonical paymaster
 
 The canonical paymaster is not a singleton deployment. Many instances may be deployed. For public mempool purposes, a paymaster instance is considered canonical if and only if the runtime code at the `pay` frame target exactly matches the canonical paymaster implementation.
 
 The canonical paymaster in this draft authorizes with a single secp256k1 signer via `ecrecover`, does not support contract-signature schemes, and may change in later specifications, in which case a new canonical implementation version would be required.
 
-Because the canonical paymaster implementation is explicitly standardized to be safe for public mempool use, nodes do not need to apply the generic validation trace and opcode rules to that `pay` frame. Instead, they identify it by runtime code match and apply the paymaster-specific accounting and revalidation rules in this section.
+The canonical paymaster is sender-first only for public mempool purposes. Its `pay` frame executes in `VERIFY` mode after an `only_verify` frame has approved execution. Its calldata is `r || s || v`, where `r` and `s` are 32 bytes each and `v` is one byte. The canonical paymaster signature is checked against the canonical signature hash (`TXPARAM(0x08)`). It does not maintain payer-owned replay protection; replay protection for the canonical sender-first flow comes from the sender nonce consumed by the preceding execution approval.
 
-A transaction using a paymaster is eligible for public mempool propagation only if the `pay` frame targets a canonical paymaster instance and the node can reserve the maximum transaction cost against that paymaster.
+Because the canonical paymaster implementation is explicitly standardized to be safe for public mempool use in the sender-first flow, nodes do not need to apply the generic validation trace and opcode rules to that `pay` frame. Instead, they identify it by runtime code match and apply the paymaster-specific accounting and revalidation rules in this section.
+
+A transaction using a canonical paymaster is eligible for public mempool propagation only if the `pay` frame targets a canonical paymaster instance, appears in a sender-first validation prefix, and the node can reserve the maximum transaction cost against that paymaster.
 
 For public mempool purposes, each node maintains a local accounting value `reserved_pending_cost(paymaster)` and computes:
 
@@ -723,7 +777,7 @@ On admission, the node increments `reserved_pending_cost(paymaster)` by the tran
 
 ##### Non-canonical paymaster
 
-For non-canonical paymasters, `pending_withdrawal_amount` is not meaningful since they may not support timelocked withdrawals.  Instead, we keep the mempool safe by enforcing that each non-canonical paymaster can only be used with no more than `MAX_PENDING_TXS_USING_NON_CANONICAL_PAYMASTER` pending transactions.
+For non-canonical paymasters, `pending_withdrawal_amount` is not meaningful since they may not support timelocked withdrawals.  Instead, we keep the mempool safe by enforcing that each non-canonical paymaster can only be used with no more than `MAX_PENDING_TXS_USING_NON_CANONICAL_PAYMASTER` pending transactions. This limit also bounds the effect of non-canonical paymaster replay-state dependencies.
 
 Therefore we perform two checks:
 
@@ -741,15 +795,15 @@ available_paymaster_balance = state.balance(paymaster) - reserved_pending_cost(p
 
 1. A transaction is received over the wire and the node decides whether to accept or reject it.
 2. The node analyzes the frame structure and determines the validation prefix. If the prefix is not one of the recognized prefixes, reject.
-3. The node simulates the validation prefix and enforces the structural and trace rules above, except that a `pay` frame whose target runtime code exactly matches the canonical paymaster implementation is handled via the canonical paymaster exception and the paymaster-specific rules below.
-4. The node records the sender storage slots read during validation. Calls into helper contracts do not create additional mutable-state dependencies unless they cause disallowed storage access under the trace rules above.
+3. The node simulates the validation prefix and enforces the structural and trace rules above, except that a sender-first `pay` frame whose target runtime code exactly matches the canonical paymaster implementation is handled via the canonical paymaster exception and the paymaster-specific rules below.
+4. The node records the sender storage slots and admitted paymaster storage slots read during validation. Calls into helper contracts do not create additional mutable-state dependencies unless they cause disallowed storage access under the trace rules above.
 5. If a canonical paymaster instance is used, the node verifies paymaster solvency using the reservation rule above.
 6. A node should keep at most one pending frame transaction per sender in the public mempool. A new transaction from the same sender MAY replace the existing one only if it uses the same nonce and satisfies the node's fee bump rules.
 7. If all checks pass, the transaction may be accepted into the public mempool and propagated to peers.
 
 #### Revalidation
 
-When a new canonical block is accepted, the node removes any included frame transactions from the public mempool, updates paymaster reservations accordingly, and identifies the remaining pending transactions whose tracked dependencies were touched by the block. This includes at least transactions for the same sender, transactions whose recorded sender storage slots changed, and transactions that reference a canonical paymaster instance whose balance, code, or delayed-withdrawal state changed. The node then re-simulates the validation prefix of only those affected transactions against the new head and evicts any transaction that no longer satisfies the public mempool rules.
+When a new canonical block is accepted, the node removes any included frame transactions from the public mempool, updates paymaster reservations accordingly, and identifies the remaining pending transactions whose tracked dependencies were touched by the block. This includes at least transactions for the same sender, transactions whose recorded sender storage slots changed, and transactions that reference a paymaster whose balance, code, delayed-withdrawal state, or admitted replay-protection storage changed. The node then re-simulates the validation prefix of only those affected transactions against the new head and evicts any transaction that no longer satisfies the public mempool rules.
 
 ## Rationale
 
@@ -757,23 +811,31 @@ When a new canonical block is accepted, the node removes any included frame tran
 
 The canonical signature hash is provided in `TXPARAM` to simplify the development of smart accounts.
 
-Computing the signature hash in EVM is complicated and expensive. While using the canonical signature hash is not mandatory, it is strongly recommended. Creating a bespoke signature requires precise commitment to the underlying transaction data. Without this, it's possible that some elements can be manipulated in-the-air while the transaction is pending and have unexpected effects. This is known as transaction malleability. Using the canonical signature hash avoids malleability of the frames other than `VERIFY`.
+Computing the signature hash in EVM is complicated and expensive. While using the canonical signature hash is not mandatory, it is strongly recommended. Creating a bespoke signature requires precise commitment to the underlying transaction data. Without this, it's possible that some elements can be manipulated in-the-air while the transaction is pending and have unexpected effects. This is known as transaction malleability. Using the canonical signature hash avoids malleability of non-elided frame data.
 
-The `frame.data` of `VERIFY` frames is elided from the signature hash. This is done for three reasons:
+The `frame.data` of `VERIFY` frames and `DEFAULT` frames with a non-zero approval scope is elided from the canonical signature hash. This is done for three reasons:
 
 1. It contains the signature so by definition it cannot be part of the signature hash.
 2. In the future it may be desired to aggregate the cryptographic operations for data and compute efficiency reasons. If the data was introspectable, it would not be possible to aggregate the verify frames in the future.
-3. For gas sponsoring workflows, we also recommend using a `VERIFY` frame to approve the gas payment. Here, the input data to the sponsor is intentionally left malleable so it can be added onto the transaction after the `sender` has made its signature. Notably, the raw `frame.target` field of `VERIFY` frames is covered by the signature hash, i.e. the `sender` chooses the sponsor address explicitly.
+3. For gas sponsoring workflows that use the canonical signature hash, an approval frame can approve gas payment while leaving the sponsor input data malleable so it can be added onto the transaction after the `sender` has made its signature. Notably, the raw `frame.target` field of approval frames is covered by the canonical signature hash, i.e. the `sender` chooses the sponsor address explicitly.
 
-Implementations MUST NOT treat `VERIFY` frame `data` as sender-authenticated by the canonical signature hash. Any verifier or paymaster that depends on its input data, including sponsor parameters, exchange rates, fee terms, or custom account context, MUST authenticate that data independently. Replacing or mutating `VERIFY` frame `data` does not change the canonical signature hash.
+Implementations MUST NOT treat elided frame `data` as sender-authenticated by the canonical signature hash. Any verifier or paymaster that depends on its input data, including sponsor parameters, exchange rates, fee terms, or custom account context, MUST authenticate that data independently. Replacing or mutating elided frame `data` does not change the canonical signature hash.
 
-By contrast, non-`VERIFY` frame metadata, including a `SENDER` frame's `value`, remains covered by the canonical signature hash.
+By contrast, non-elided frame data and frame metadata, including a `SENDER` frame's `value`, remain covered by the canonical signature hash.
 
-Verification logic MUST NOT assign policy meaning to signature encodings or adjacent `VERIFY` frame data unless that meaning is independently authenticated.
+Verification logic MUST NOT assign policy meaning to signature encodings or adjacent elided frame data unless that meaning is independently authenticated.
+
+### Current-frame signature hash
+
+The current-frame signature hash is provided for authorizations that need to bind to validation calldata outside the authorizing frame. This is especially useful for payer-first flows: the payer can sign after the sender's validation data is known, while still placing the payer signature and payer nonce or replay key inside the payer frame itself without creating a circular hash dependency.
+
+Because the current frame's data is elided, payer-specific nonces, replay keys, expiries, exchange rates, or other terms carried in the payer frame data MUST be authenticated by the payer's own signed message. Signing only `TXPARAM(0x0B)` does not authenticate those current-frame fields.
 
 ### `APPROVE` calling convention
 
 Originally `APPROVE` was meant to extend the space of return statuses from 0 and 1 today to 0 to 4. However, this would mean smart accounts deployed today would not be able to modify their contract code to return with a different value at the top level. For this reason, we've chosen behavior above: `APPROVE` terminates the executing frame successfully like `RETURN`, but it actually updates the transaction scoped values `sender_approved` and `payer_approved` during execution. It is still required that only the sender can toggle the `sender_approved` to `true`. Only the frame's resolved target can call `APPROVE` generally, because it can allow the transaction pool and other frames to better reason about `VERIFY` mode frames.
+
+Payment approval intentionally does not require prior execution approval. This allows a payer to pay unconditionally for later computation, including later sender-verification failure and paymaster post-operation logic. To prevent a payer from consuming sender nonces without sender authorization, the sender nonce is consumed by execution approval (`APPROVE_EXECUTION` or `APPROVE_PAYMENT_AND_EXECUTION`), not by payment-only approval (`APPROVE_PAYMENT`).
 
 Because `DELEGATECALL` preserves `ADDRESS`, code executed via `DELEGATECALL` from the resolved target may also execute `APPROVE` successfully. Contracts that rely on `APPROVE` should therefore treat delegatecalled libraries as fully trusted.
 
@@ -817,7 +879,7 @@ With frame transactions, EOA wallets today can reap the key benefit of AA - gas 
 
 The primary use case for non-canonical paymasters is to enable users to pay gas with a dedicated "gas account," so that their other accounts can transact without holding any ETH.  For example, a user might have a single account that holds some ETH, while other accounts only hold stablecoins and NFTs, and they can transact freely with these other accounts while using the gas account as the paymaster.
 
-Note that users can use any EOA as a paymaster thanks to the [default code](#default-code).
+Users can use any EOA as a paymaster thanks to the [default code](#default-code). However, default-code payers do not have payer-owned replay protection. They should only be used for payment-first flows when the transaction is expected to consume the sender nonce, or when replay of the payment authorization is otherwise acceptable.
 
 ### Examples
 
@@ -868,33 +930,33 @@ Frame 0 verifies the signature and calls `APPROVE(APPROVE_PAYMENT_AND_EXECUTION)
 
 #### Example 3: Sponsored Transaction (Fee Payment in ERC-20)
 
-| Frame | Caller      | Target        | Value | Flags              | Data                   | Mode    |
-| ----- | ----------- | ------------- | ----- | ------------------ | ---------------------- | ------- |
-| 0     | ENTRY_POINT | Null (sender) | 0     | APPROVE_EXECUTION  | Signature              | VERIFY  |
-| 1     | ENTRY_POINT | Sponsor       | 0     | APPROVE_PAYMENT    | Sponsor data           | VERIFY  |
-| 2     | Sender      | ERC-20        | 0     | APPROVE_SCOPE_NONE | transfer(Sponsor,fees) | SENDER  |
-| 3     | Sender      | Target addr   | 0     | APPROVE_SCOPE_NONE | Call data              | SENDER  |
-| 4     | ENTRY_POINT | Sponsor       | 0     | APPROVE_SCOPE_NONE | Post op call           | DEFAULT |
+| Frame | Caller      | Target        | Value | Flags              | Data                         | Mode    |
+| ----- | ----------- | ------------- | ----- | ------------------ | ---------------------------- | ------- |
+| 0     | ENTRY_POINT | Sponsor       | 0     | APPROVE_PAYMENT    | Sponsor replay key/signature | DEFAULT |
+| 1     | ENTRY_POINT | Null (sender) | 0     | APPROVE_EXECUTION  | Signature                    | VERIFY  |
+| 2     | Sender      | ERC-20        | 0     | APPROVE_SCOPE_NONE | transfer(Sponsor,fees)       | SENDER  |
+| 3     | Sender      | Target addr   | 0     | APPROVE_SCOPE_NONE | Call data                    | SENDER  |
+| 4     | ENTRY_POINT | Sponsor       | 0     | APPROVE_SCOPE_NONE | Post op call                 | DEFAULT |
 
-- Frame 0: Verifies signature and calls `APPROVE(APPROVE_EXECUTION)` to authorize execution from sender.
-- Frame 1: Checks that the user has enough ERC-20 tokens, and that the next frame is an ERC-20 send of the right size to the sponsor. Calls `APPROVE(APPROVE_PAYMENT)` to authorize payment.
-- Frame 2: Sends tokens to sponsor.
-- Frame 3: User's intended call.
-- Frame 4 (optional): Check unpaid gas, refund tokens, possibly convert tokens to ETH on an AMM.
+- Frame 0: Verifies the sponsor authorization, consumes sponsor-owned replay protection, and calls `APPROVE(APPROVE_PAYMENT)` to authorize payment. The sponsor signs the current-frame signature hash (`TXPARAM(0x0B)`) plus its replay key and policy terms, binding the payment to the sender validation data in frame 1.
+- Frame 1: Verifies the sender signature and calls `APPROVE(APPROVE_EXECUTION)` to authorize execution from sender. The sender can sign before the sponsor calldata is finalized because frame 0 has a non-zero approval scope and its calldata is elided from the canonical signature hash.
+- Frame 2: Sends tokens to sponsor if frame 1 succeeded.
+- Frame 3: User's intended call if frame 1 succeeded.
+- Frame 4 (optional): Check unpaid gas, refund tokens, possibly convert tokens to ETH on an AMM. This frame may run even if frame 1 failed, because payment was already approved.
 
 #### Example 4: EOA paying gas in ERC-20s
 
-| Frame | Caller      | Target       | Value | Flags              | Data                   | Mode   |
-| ----- | ----------- | ------------ | ----- | ------------------ | ---------------------- | ------ |
-| 0     | ENTRY_POINT | Null(sender) | 0     | APPROVE_EXECUTION  | (0, v, r, s)           | VERIFY |
-| 1     | ENTRY_POINT | Sponsor      | 0     | APPROVE_PAYMENT    | Sponsor signature      | VERIFY |
-| 2     | Sender      | ERC-20       | 0     | APPROVE_SCOPE_NONE | transfer(Sponsor,fees) | SENDER |
-| 3     | Sender      | Target addr  | 0     | APPROVE_SCOPE_NONE | Call data              | SENDER |
+| Frame | Caller      | Target       | Value | Flags              | Data                         | Mode    |
+| ----- | ----------- | ------------ | ----- | ------------------ | ---------------------------- | ------- |
+| 0     | ENTRY_POINT | Sponsor      | 0     | APPROVE_PAYMENT    | Sponsor replay key/signature | DEFAULT |
+| 1     | ENTRY_POINT | Null(sender) | 0     | APPROVE_EXECUTION  | (0, v, r, s)                 | VERIFY  |
+| 2     | Sender      | ERC-20       | 0     | APPROVE_SCOPE_NONE | transfer(Sponsor,fees)       | SENDER  |
+| 3     | Sender      | Target addr  | 0     | APPROVE_SCOPE_NONE | Call data                    | SENDER  |
 
-- Frame 0: Verify the sender with a EOA signature.  Upon verification, the frame calls `APPROVE(APPROVE_EXECUTION)` to authorize execution.
-- Frame 1: Checks that the user has enough ERC-20 tokens, and that the next frame is an ERC-20 send of the right size to the sponsor. Calls `APPROVE(APPROVE_PAYMENT)` to authorize payment.
-- Frame 2: Sends tokens to sponsor.
-- Frame 3: User's intended call.
+- Frame 0: Verifies the sponsor authorization, consumes sponsor-owned replay protection, and calls `APPROVE(APPROVE_PAYMENT)` to authorize payment.
+- Frame 1: Verifies the sender with an EOA signature. Upon verification, the frame calls `APPROVE(APPROVE_EXECUTION)` to authorize execution. The sender can sign before the sponsor calldata is finalized because frame 0 has a non-zero approval scope and its calldata is elided from the canonical signature hash.
+- Frame 2: Sends tokens to sponsor if frame 1 succeeded.
+- Frame 3: User's intended call if frame 1 succeeded.
 
 ### Data Efficiency
 
@@ -947,12 +1009,12 @@ Notes: Gas assumes cost < 2^24. Calldata assumes small proxy.
 
 | Field                                | Bytes |
 | ------------------------------------ | ----- |
-| Sponsor validation frame: mode       | 1     |
-| Sponsor validation frame: flags      | 1     |
-| Sponsor validation frame: target     | 20    |
-| Sponsor validation frame: gas        | 3     |
-| Sponsor validation frame: value      | 1     |
-| Sponsor validation frame: calldata   | 0     |
+| Sponsor payment frame: mode          | 1     |
+| Sponsor payment frame: flags         | 1     |
+| Sponsor payment frame: target        | 20    |
+| Sponsor payment frame: gas           | 3     |
+| Sponsor payment frame: value         | 1     |
+| Sponsor payment frame: calldata      | 97    |
 | Send to sponsor frame: mode          | 1     |
 | Send to sponsor frame: flags         | 1     |
 | Send to sponsor frame: target        | 20    |
@@ -965,9 +1027,9 @@ Notes: Gas assumes cost < 2^24. Calldata assumes small proxy.
 | Sponsor post op frame: gas           | 3     |
 | Sponsor post op frame: value         | 1     |
 | Sponsor post op frame: calldata      | 0     |
-| **Total additional**                 | 147   |
+| **Total additional**                 | 244   |
 
-Notes: Sponsor can read info from other fields. ERC-20 transfer call is 68 bytes.
+Notes: Sponsor can read info from other fields. Sponsor calldata assumes a 32-byte replay key and 65-byte secp256k1 signature. ERC-20 transfer call is 68 bytes.
 
 There is some inefficiency in the sponsor case, because the same sponsor address must appear in three places (sponsor validation, send to sponsor inside ERC-20 calldata, post op frame), and the ABI is inefficient (~12 + 24 bytes wasted on zeroes). This is difficult to mitigate in a "clean" way, because one of the duplicates is inside the ERC-20 call, "opaque" to the protocol. However, it is much less inefficient than ERC-4337, because not all of the data takes the hit of the 32-byte-per-field ABI overhead.
 
@@ -1008,11 +1070,17 @@ Because `tx.sender` is explicit in the transaction envelope, an attacker can sub
 
 `FRAMEPARAM`, `FRAMEDATALOAD`, and `FRAMEDATACOPY` allow validation code to inspect other frames, including later `SENDER` frames and their `value`s. As a result, paymasters and other `VERIFY` frames can observe user operation parameters before approval and may condition their behavior on that information. Users should therefore treat non-`VERIFY` frame parameters and data as visible to validation logic and should not rely on untrusted paymasters or verifiers to keep such information private.
 
+#### Payer-First Replay Protection
+
+A transaction can be valid with `payer_approved = true` even if `sender_approved` never becomes true. In that case the sender nonce is not consumed, and the same transaction envelope can remain valid at the same sender nonce. Payers that approve payment before execution approval MUST implement their own replay protection, such as a nonce or replay key in the payer contract, unless they intentionally authorize reusable payment.
+
+Payer signatures SHOULD use `TXPARAM(0x0B)` when they need to commit to other validation frames' calldata. They MUST separately authenticate any payer nonce, replay key, or policy terms carried in the payer frame's own calldata because that calldata is excluded from `TXPARAM(0x0B)`.
+
 ##### Mitigations
 
 Node implementations should consider restricting which opcodes and storage slots validation frames can access, similar to ERC-7562. This isolates transactions from each other and limits mass invalidation vectors.
 
-It's recommended that to *validate* the transaction, a specific frame structure is enforced and the amount of gas that is expended executing the validation phase must be limited. Once the validation prefix reaches payer approval via `APPROVE(APPROVE_PAYMENT)` or `APPROVE(APPROVE_PAYMENT_AND_EXECUTION)`, the transaction can be included in the mempool and propagated to peers safely.
+It's recommended that to *validate* the transaction, a specific frame structure is enforced and the amount of gas that is expended executing the validation phase must be limited. Once the validation prefix reaches payer approval via `APPROVE(APPROVE_PAYMENT)` or `APPROVE(APPROVE_PAYMENT_AND_EXECUTION)`, and any required payer replay-protection and reservation checks have passed, the transaction can be included in the mempool and propagated to peers safely.
 
 For deployment of the sender account in the first frame, the mempool must only allow the [EIP-7997](./eip-7997.md) deterministic factory predeploy as `frame.target`, to ensure deployment is deterministic and independent of chain state.
 


### PR DESCRIPTION
Alternative to #11555 

I think it is simpler to just allow the payer to approve before the sender instead of adding the full guarantor role.