### PR TITLE
Update EIP-8141: remove the rlp call batch for default account

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -406,10 +406,7 @@ When using frame transactions with EOAs that have neither code nor an [EIP-7702]
     - Otherwise revert.
   - Call `APPROVE(allowed_scope)`.
 - If `mode` is `SENDER`:
-  - If `resolved_target != tx.sender`, return successfully with empty data. This matches a call to an empty-code account; any top-level `frame.value` transfer has already been applied by the frame call itself.
-  - Otherwise, read `frame.data` as RLP encoding of `calls = [[target, value, data]]`.
-  - For each call in `calls`, execute the call with `msg.sender = tx.sender`.
-    - If any call reverts, revert the frame.
+  - Revert the frame.
 - If `mode` is `DEFAULT`:
   - Revert the frame.
 
@@ -484,17 +481,7 @@ def default_code(frame, tx):
         APPROVE(allowed_scope)
 
     elif mode == SENDER:
-        if resolved_target != tx.sender:
-            # Empty-code account behavior: succeed immediately. Any top-level
-            # frame.value transfer has already been applied by the frame call.
-            return
-
-        # frame.data layout: RLP-encoded [[target, value, data], ...]
-        calls = rlp_decode(frame.data)
-        for call_target, call_value, call_data in calls:
-            result = evm_call(caller=tx.sender, to=call_target, value=call_value, data=call_data)
-            if result.reverted:
-                revert()
+        revert()
 
     elif mode == DEFAULT:
         revert()


### PR DESCRIPTION
With the addition of frame batching, we no longer need RLP call batches in the default account.