### PR TITLE
Update EIP-8130: add opaque_input bytes field

### DIFF
--- a/EIPS/eip-8130.md
+++ b/EIPS/eip-8130.md
@@ -158,7 +158,8 @@ AA_TX_TYPE || rlp([
   calls,              // [[{to, data}, ...], ...] | empty
   payer,              // empty = sender-paid, payer_address = specific payer
   sender_auth,
-  payer_auth          // empty = sender-pay, verifier || data = sponsored (same format as sender_auth)
+  payer_auth,         // empty = sender-pay, verifier || data = sponsored (same format as sender_auth)
+  opaque_input        // bytes: tx-level metadata, opaque to the protocol; not call input
 ])
 
 call = rlp([to, data])   // to: address, data: bytes
@@ -181,6 +182,16 @@ call = rlp([to, data])   // to: address, data: bytes
 | `payer` | Gas payer identity. **Empty**: Sender pays. **20-byte address**: This specific payer required. See [Payer Modes](#payer-modes) |
 | `sender_auth` | See [Signature Format](#signature-format) |
 | `payer_auth` | Payer authorization. **Empty**: self-pay. **Non-empty**: `verifier || data` — same format as `sender_auth`. See [Payer Modes](#payer-modes) |
+| `opaque_input` | Arbitrary tx-level metadata bytes. Opaque to the protocol — **never** dispatched to the EVM, **never** loaded as calldata, and **never** mutated by execution. May be empty. See [Opaque Input](#opaque-input) |
+
+#### Opaque Input
+
+`opaque_input` is a free-form `bytes` field reserved for tx-level metadata (e.g., attribution suffixes, indexer hints) that is opaque to the protocol.
+
+- **Not executed.** Never dispatched to the EVM, never placed on any frame's calldata, never exposed by any opcode. The sole source of execution calldata is `call.data` (see [Call Execution](#call-execution)).
+- **Signed by sender and payer.** MUST be included in both the [sender and payer signature hashes](#signature-payload), preventing intermediaries from substituting metadata after signing.
+- **Priced as calldata.** Charged at the [EIP-2028](./eip-2028.md) per-byte rate via [`tx_payload_cost`](#intrinsic-gas) — no separate cost component.
+- **Validity.** MUST be a valid RLP byte string. No protocol-level length cap; nodes MAY apply mempool size policy. Empty (`0x80`) is the default.
 
 #### Intrinsic Gas
 
@@ -198,7 +209,7 @@ The sender verifier runs first. By the time the payer verifier executes, all int
 
 | Component | Value |
 |-----------|-------|
-| `tx_payload_cost` | Standard per-byte cost over the entire RLP-serialized transaction: 16 gas per non-zero byte, 4 gas per zero byte, consistent with [EIP-2028](./eip-2028.md). Ensures all transaction fields (`account_changes`, `sender_auth`, `calls`, etc.) are charged for data availability |
+| `tx_payload_cost` | Standard per-byte cost over the entire RLP-serialized transaction: 16 gas per non-zero byte, 4 gas per zero byte, consistent with [EIP-2028](./eip-2028.md). Ensures all transaction fields (`account_changes`, `sender_auth`, `calls`, `opaque_input`, etc.) are charged for data availability |
 | `nonce_key_cost` | `NONCE_KEY_MAX`: 14,000 gas (replay protection state: 2 cold SLOADs + 1 warm SLOAD + 3 warm SSTORE resets). Otherwise: 22,100 gas for first use of a `nonce_key` (cold SLOAD + SSTORE set), 5,000 gas for existing keys (cold SLOAD + warm SSTORE reset) |
 | `bytecode_cost` | 0 if no create entry in `account_changes`. Otherwise: 32,000 (deployment base) + code deposit cost (200 gas per deployed byte). Byte costs for `code` are covered by `tx_payload_cost` |
 | `account_changes_cost` | Per applied config change entry: auth verification cost (same model as `sender_auth_cost`) + `num_operations` × 20,000 per SSTORE. Per applied delegation entry: code deposit cost (200 × 23 bytes for the delegation indicator). Per skipped config change entry (already applied): 2,100 (SLOAD to check sequence). 0 if no config change or delegation entries in `account_changes` |
@@ -229,26 +240,30 @@ The first 20 bytes identify the verifier address. When the verifier is `ECRECOVE
 
 Sender and payer use different type bytes for domain separation, preventing signature reuse attacks:
 
-**Sender signature hash** — all tx fields through `payer`, excluding `sender_auth` and `payer_auth`:
+**Sender signature hash** — all tx fields through `payer` plus `opaque_input`, excluding `sender_auth` and `payer_auth`:
 
 ```
 keccak256(AA_TX_TYPE || rlp([
   chain_id, from, nonce_key, nonce_sequence, expiry,
   max_priority_fee_per_gas, max_fee_per_gas, gas_limit,
   account_changes, calls,
-  payer
+  payer,
+  opaque_input
 ]))
 ```
 
-**Payer signature hash** — all tx fields through `calls`, excluding `payer`, `sender_auth`, and `payer_auth`:
+**Payer signature hash** — all tx fields through `calls` plus `opaque_input`, excluding `payer`, `sender_auth`, and `payer_auth`:
 
 ```
 keccak256(AA_PAYER_TYPE || rlp([
   chain_id, from, nonce_key, nonce_sequence, expiry,
   max_priority_fee_per_gas, max_fee_per_gas, gas_limit,
-  account_changes, calls
+  account_changes, calls,
+  opaque_input
 ]))
 ```
+
+Both the sender and the payer commit to the **same** `opaque_input` bytes. This prevents a relayer, bundler, or block builder from substituting attribution metadata between signing and inclusion: any modification of `opaque_input` invalidates both signatures.
 
 #### Payer Modes
 
@@ -634,6 +649,10 @@ Since every account has wallet bytecode (auto-delegation or explicit deployment)
 
 [EIP-7702](./eip-7702.md) introduced `authorization_list` as a transaction-level field for code delegation, with ECDSA authority. This proposal moves delegation into `account_changes`, authorized by the transaction's `sender_auth`. Delegation is restricted to the account's implicit EOA owner (`ownerId == bytes32(bytes20(from))`) so that code delegation remains portable across non-8130 chains via standard [EIP-7702](./eip-7702.md) transactions. Eventually this can be expanded to all verifier types.
 
+### Why `opaque_input`?
+
+The legacy top-level `input` field doubled as EVM calldata and as a signed tx-level byte string that indexers and attribution systems (e.g., the ERC-8021 suffix) parse. With a 2D `calls` array, the calldata role moves to per-call `call.data`; `opaque_input` keeps the metadata role as a single tx-level field, avoiding per-call duplication and wallet-shape-dependent placement.
+
 ### Why Account Lock?
 
 Locked accounts have a frozen owner set, so the primary state that can invalidate a validated transaction is nonce consumption. This can enable nodes to cache owner state and apply higher mempool rate limits (see [Mempool Acceptance](#mempool-acceptance)). A per-owner lock alternative was considered but adds mempool tracking complexity — rate limits per `(address, ownerId)` pair rather than per address.
@@ -673,6 +692,7 @@ No breaking changes. Existing EOAs and smart contracts function unchanged. Adopt
 - EOAs continue sending standard transactions
 - ERC-4337 infrastructure continues operating
 - Accounts gain AA capabilities by configuring owners. EOAs sending their first AA transaction are auto-delegated to `DEFAULT_ACCOUNT_ADDRESS` if they have no code. EOAs MAY override with a delegation entry in `account_changes` (EOA-only authorization), a standard [EIP-7702](./eip-7702.md) transaction, or use a create entry in `account_changes` for custom wallet implementations
+- Tooling that depends on a tx-level metadata field (e.g., the legacy `input` field of pre-AA transactions, used by attribution/indexer conventions such as the ERC-8021 suffix) reads the AA transaction's `opaque_input` field.
 
 ## Reference Implementation
 


### PR DESCRIPTION
Append `opaque_input` (bytes) to the AA_TX_TYPE RLP payload to restore the tx-level metadata role that the legacy top-level `input` field played for pre-AA transactions (e.g., ERC-8021 attribution suffixes).

Specified semantics:
- Not part of EVM dispatch; `call.data` remains the sole execution calldata. The protocol never forwards `opaque_input` to any frame.
- MUST be included in both the sender and payer signature hashes, preventing relayers/builders from substituting metadata after signing.
- Charged via `tx_payload_cost` at the standard EIP-2028 per-byte rate; no separate cost component is introduced.
- JSON-RPC exposes it as `opaqueInput`; clients MAY mirror it under `input` for tooling compatibility, with an explicit note that for AA transactions `input` is not EVM execution calldata.

**ATTENTION: ERC-RELATED PULL REQUESTS NOW OCCUR IN [ETHEREUM/ERCS](https://github.com/ethereum/ercs)**

--

When opening a pull request to submit a new EIP, please use the suggested template: https://github.com/ethereum/EIPs/blob/master/eip-template.md

We have a GitHub bot that automatically merges some PRs. It will merge yours immediately if certain criteria are met:

 - The PR edits only existing draft PRs.
 - The build passes.
 - Your GitHub username or email address is listed in the 'author' header of all affected PRs, inside <triangular brackets>.
 - If matching on email address, the email address is the one publicly listed on your GitHub profile.
