### PR TITLE
Update EIP-8141: Add 2D nonces

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -32,6 +32,7 @@ In doing so, it realizes the original vision of account abstraction: unlinking a
 | `FRAME_TX_PER_FRAME_COST` | `475`           |
 | `ENTRY_POINT`             | `address(0xaa)` |
 | `MAX_FRAMES`              | `64`            |
+| `NONCE_MANAGER`           | `address(0x4E4F4E4345000000000000000000000000000000)` |
 
 `ENTRY_POINT` is a protocol-defined distinguished caller address used for `DEFAULT` and `VERIFY` frames. It is not specified as a deployed contract or precompile, and contracts MUST NOT assume anything about its code, balance, or caller type beyond address equality. Contracts called from `DEFAULT` or `VERIFY` frames therefore observe `CALLER = ENTRY_POINT` and `CALLVALUE = 0`, so heuristics that infer EOA-or-contract properties from `CALLER` may not behave as expected. Its numeric equality with the `APPROVE` opcode value has no semantic significance.
 
@@ -58,6 +59,13 @@ frames = [[mode, flags, target, gas_limit, value, data], ...]
 ```
 
 The pair `(nonce_key, nonce)` selects an independent nonce sequence for `tx.sender`. A sender may issue transactions on different `nonce_key`s in parallel; ordering is enforced only within a single key. `nonce_key = 0` is the legacy nonce sequence and shares state with pre-EIP-8141 transaction types.
+
+The accessor `state[tx.sender].nonce[tx.nonce_key]` resolves as follows:
+
+- `nonce_key == 0`: the existing account nonce field, `state[tx.sender].nonce`.
+- `nonce_key != 0`: the uint64 stored at storage slot `keccak256(abi.encode(tx.sender, tx.nonce_key))` of the `NONCE_MANAGER` system contract, i.e. `state[NONCE_MANAGER].storage[keccak256(abi.encode(tx.sender, tx.nonce_key))]`. Unset slots read as `0`.
+
+This keeps non-default nonce sequences inside ordinary contract storage, leaving the account state layout unchanged.
 
 If no blobs are included, `blob_versioned_hashes` must be an empty list and `max_fee_per_blob_gas` must be `0`.
 
@@ -776,6 +784,8 @@ The payer cannot be determined statically from a frame transaction and is releva
 ### 2D nonces
 
 Each transaction carries a `nonce_key` alongside the sequential `nonce`, indexing an independent nonce sequence per sender. This lets a sender (validators, relayers, automated agents, batched flows) issue non-conflicting transactions in parallel without serializing on a single counter, while still preserving replay protection within each key. `nonce_key = 0` aliases the legacy account nonce slot, so accounts that don't opt in continue to use a single sequence and remain interoperable with pre-EIP-8141 transaction types. Charging `nonce_key_cost` for non-zero keys prices the new storage slot under standard SSTORE semantics, preventing state-bloat abuse from transactions that scatter writes across many unused keys.
+
+Non-default sequences are kept in the storage of a single `NONCE_MANAGER` system contract rather than extending the account state, since adding a per-account nonce mapping would require changes to the account MPT layout. Reusing ordinary contract storage gives standard SSTORE pricing and lets the contract be optionally extended (e.g. with a getter for EVM introspection) without further protocol changes.
 
 ### No authorization list
 

--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -52,10 +52,12 @@ A new [EIP-2718](./eip-2718.md) transaction with type `FRAME_TX_TYPE` is introdu
 The payload is defined as the RLP serialization of the following:
 
 ```
-[chain_id, nonce, sender, frames, max_priority_fee_per_gas, max_fee_per_gas, max_fee_per_blob_gas, blob_versioned_hashes]
+[chain_id, nonce_key, nonce, sender, frames, max_priority_fee_per_gas, max_fee_per_gas, max_fee_per_blob_gas, blob_versioned_hashes]
 
 frames = [[mode, flags, target, gas_limit, value, data], ...]
 ```
+
+The pair `(nonce_key, nonce)` selects an independent nonce sequence for `tx.sender`. A sender may issue transactions on different `nonce_key`s in parallel; ordering is enforced only within a single key. `nonce_key = 0` is the legacy nonce sequence and shares state with pre-EIP-8141 transaction types.
 
 If no blobs are included, `blob_versioned_hashes` must be an empty list and `max_fee_per_blob_gas` must be `0`.
 
@@ -125,6 +127,7 @@ APPROVE_SCOPE_MASK = 0x03
 ATOMIC_BATCH_FLAG = 0x04
 
 assert tx.chain_id < 2**256
+assert tx.nonce_key < 2**256
 assert tx.nonce < 2**64
 assert len(tx.frames) > 0 and len(tx.frames) <= MAX_FRAMES
 assert len(tx.sender) == 20
@@ -229,11 +232,11 @@ The behavior of `APPROVE` is defined as follows:
     - `APPROVE_EXECUTION`: Set `sender_approved = true`.
         - If `sender_approved` was already set, revert the frame.
         - If `resolved_target` != `tx.sender`, revert the frame.
-    - `APPROVE_PAYMENT`: Increment the sender's nonce, collect the transaction's maximum cost (`TXPARAM(0x06)`) from `resolved_target`, and set `payer_approved = true`.
+    - `APPROVE_PAYMENT`: Increment the sender's nonce for `tx.nonce_key`, collect the transaction's maximum cost (`TXPARAM(0x06)`) from `resolved_target`, and set `payer_approved = true`.
         - If `payer_approved` was already set, revert the frame.
         - If `resolved_target` has insufficient balance, revert the frame.
         - If `sender_approved == false`, revert the frame.
-    - `APPROVE_PAYMENT_AND_EXECUTION`: Set `sender_approved = true`, increment the sender's nonce, collect the transaction's maximum cost (`TXPARAM(0x06)`) from `resolved_target`, and set `payer_approved = true`.
+    - `APPROVE_PAYMENT_AND_EXECUTION`: Set `sender_approved = true`, increment the sender's nonce for `tx.nonce_key`, collect the transaction's maximum cost (`TXPARAM(0x06)`) from `resolved_target`, and set `payer_approved = true`.
         - If `sender_approved` or `payer_approved` was already set, revert the frame.
         - If `resolved_target` != `tx.sender`, revert the frame.
         - If `resolved_target` has insufficient balance, revert the frame.
@@ -258,10 +261,10 @@ It takes one value from the stack, `param`. The `param` is the field to be extra
 | 0x08    | `compute_sig_hash(tx)`                                                      |
 | 0x09    | `len(frames)`                                                               |
 | 0x0A    | currently executing frame index                                             |
+| 0x0B    | `nonce_key`                                                                 |
 
 Notes:
 
-- `0x01` has a possible future extension to allow indices for multidimensional nonces.
 - `0x03` and `0x04` have a possible future extension to allow indices for multidimensional gas.
 - `0x06` covers only the maximum gas and blob fees. It does not include any `frame.value` transfers.
 - `0x07` returns only the number of blob versioned hashes. Individual blob versioned hashes remain accessible via the existing `BLOBHASH(index)` opcode.
@@ -328,7 +331,7 @@ When processing a frame transaction, perform the following steps.
 
 Perform stateful validation check:
 
-- Ensure `tx.nonce == state[tx.sender].nonce`
+- Ensure `tx.nonce == state[tx.sender].nonce[tx.nonce_key]`
 
 Initialize with transaction-scoped variables:
 
@@ -502,10 +505,12 @@ A few cross-frame interactions to note:
 The total gas limit of the transaction is:
 
 ```
-tx_gas_limit = FRAME_TX_INTRINSIC_COST + len(tx.frames) * FRAME_TX_PER_FRAME_COST + calldata_cost(rlp(tx.frames)) + sum(frame.gas_limit for all frames)
+tx_gas_limit = FRAME_TX_INTRINSIC_COST + len(tx.frames) * FRAME_TX_PER_FRAME_COST + calldata_cost(rlp(tx.frames)) + nonce_key_cost + sum(frame.gas_limit for all frames)
 ```
 
 Where `calldata_cost` is calculated per standard EVM rules (4 gas per zero byte, 16 gas per non-zero byte).
+
+`nonce_key_cost` charges for the per-key nonce write under standard storage-slot pricing: `0` if `tx.nonce_key == 0` (the legacy nonce slot, charged via the existing protocol nonce update), `22100` if `state[tx.sender].nonce[tx.nonce_key] == 0` (zero-to-non-zero transition), otherwise `5000`.
 
 The total fee is defined as:
 
@@ -731,7 +736,7 @@ available_paymaster_balance = state.balance(paymaster) - reserved_pending_cost(p
 3. The node simulates the validation prefix and enforces the structural and trace rules above, except that a `pay` frame whose target runtime code exactly matches the canonical paymaster implementation is handled via the canonical paymaster exception and the paymaster-specific rules below.
 4. The node records the sender storage slots read during validation. Calls into helper contracts do not create additional mutable-state dependencies unless they cause disallowed storage access under the trace rules above.
 5. If a canonical paymaster instance is used, the node verifies paymaster solvency using the reservation rule above.
-6. A node should keep at most one pending frame transaction per sender in the public mempool. A new transaction from the same sender MAY replace the existing one only if it uses the same nonce and satisfies the node's fee bump rules.
+6. A node should keep at most one pending frame transaction per `(sender, nonce_key)` pair in the public mempool. A new transaction with the same `(sender, nonce_key)` MAY replace the existing one only if it uses the same `nonce` and satisfies the node's fee bump rules.
 7. If all checks pass, the transaction may be accepted into the public mempool and propagated to peers.
 
 #### Revalidation
@@ -767,6 +772,10 @@ Because `DELEGATECALL` preserves `ADDRESS`, code executed via `DELEGATECALL` fro
 ### Payer in receipt
 
 The payer cannot be determined statically from a frame transaction and is relevant to users. The only way to provide this information safely and efficiently over the JSON-RPC is to record this data in the receipt object.
+
+### 2D nonces
+
+Each transaction carries a `nonce_key` alongside the sequential `nonce`, indexing an independent nonce sequence per sender. This lets a sender (validators, relayers, automated agents, batched flows) issue non-conflicting transactions in parallel without serializing on a single counter, while still preserving replay protection within each key. `nonce_key = 0` aliases the legacy account nonce slot, so accounts that don't opt in continue to use a single sequence and remain interoperable with pre-EIP-8141 transaction types. Charging `nonce_key_cost` for non-zero keys prices the new storage slot under standard SSTORE semantics, preventing state-bloat abuse from transactions that scatter writes across many unused keys.
 
 ### No authorization list
 
@@ -962,6 +971,8 @@ There is some inefficiency in the sponsor case, because the same sponsor address
 ## Backwards Compatibility
 
 The `ORIGIN` opcode behavior changes for frame transactions, returning the frame's caller rather than the traditional transaction origin. This is consistent with the precedent set by EIP-7702, which already modified `ORIGIN` semantics. Contracts that rely on `ORIGIN = CALLER` for security checks (a discouraged pattern) may behave differently under frame transactions.
+
+Per-account nonces are now indexed by `nonce_key`. A frame transaction with `nonce_key = 0` reads and increments the same nonce slot used by legacy transaction types, so a sender's existing nonce sequence continues uninterrupted when migrating to frame transactions. Non-zero `nonce_key`s introduce additional per-account storage but do not affect legacy transaction processing.
 
 ## Security Considerations
 


### PR DESCRIPTION
Add 2D nonces to EIP-8141.

* Add `nonce_key`; `(nonce_key, nonce)` selects per-sender nonce sequence
* Constraint: `tx.nonce_key < 2**256`
* Validation: `tx.nonce == state[tx.sender].nonce[tx.nonce_key]`
* `APPROVE_PAYMENT` / `APPROVE_PAYMENT_AND_EXECUTION` increment per-key nonce
* `TXPARAM 0x0B` returns `nonce_key`
* Gas: `nonce_key_cost` (0 / 5000 / 22100, SSTORE pricing) added to `tx_gas_limit` (to be updated)
* Mempool: one pending tx per `(sender, nonce_key)` enabling parallel sequences
* `nonce_key = 0` represents legacy nonce slot (backwards compatible)