### PR TITLE
Update EIP-8130: prevent cross-sender payer signature replay

### DIFF
--- a/EIPS/eip-8130.md
+++ b/EIPS/eip-8130.md
@@ -250,6 +250,8 @@ keccak256(AA_PAYER_TYPE || rlp([
 ]))
 ```
 
+The `from` field in the payer signature hash MUST be the resolved sender address. In the EOA path (`from` empty in the transaction wire format), the recovered sender address (from `sender_auth` ecrecover, see [Validation](#validation) step 1) MUST be substituted into the `from` position before computing this hash; it MUST NOT be encoded as the empty wire-format value. This binds the payer's signature to the specific resolved sender and prevents cross-sender replay of payer signatures (see [Payer Security](#security-considerations)).
+
 #### Payer Modes
 
 Gas payment and sponsorship are controlled by two independent fields:
@@ -793,6 +795,8 @@ Read-only. The protocol manages nonce storage directly; there are no state-modif
 **ownerId Binding**: The protocol checks that the verifier's returned `ownerId` maps back to that verifier in `owner_config` — preventing a malicious verifier from claiming ownership of another verifier's owners.
 
 **Payer Security**: `AA_TX_TYPE` vs `AA_PAYER_TYPE` domain separation prevents signature reuse between sender and payer roles. The `payer` field in the sender's signed hash binds to a specific payer address. Scope enforcement adds a second layer — PAYER-only owners cannot be used as `sender_auth`, and vice versa.
+
+**Cross-sender Payer Replay**: The payer signature hash binds to the resolved sender via the `from` field (see [Signature Payload](#signature-payload)). In the EOA path where `from` is empty in the wire format, the recovered sender address MUST be substituted into the `from` position before computing the hash. Without this substitution, two different EOAs that construct otherwise identical transaction data (same `chain_id`, `nonce_key`, `nonce_sequence`, `expiry`, fees, `account_changes`, `calls`) would produce identical payer hashes, allowing a second EOA to reuse a payer signature originally issued for the first and drain the payer's gas deposit. The 2D nonce alone does not prevent this: `nonce_key` and `nonce_sequence` are fields in the transaction payload, so each attacker controls their own values. Substituting the recovered sender into the hash makes the payer's commitment per-sender and closes this replay path. The configured-owner path is unaffected because `from` is non-empty by definition.
 
 **Account Creation Security**: `initial_owners` (verifier + ownerId + scope tuples) are salt-committed, preventing front-running of owner assignment. Wallet bytecode should be inert when uninitialized as it can be permissionlessly deployed.
 


### PR DESCRIPTION
The payer signature hash includes a `from` field, but the spec did not say what to put there in the EOA path where `from` is empty in the wire format. If `from` were encoded as empty, two different EOAs with otherwise identical tx data would produce identical payer hashes, letting a second EOA reuse a payer signature meant for the first and drain the payer's gas deposit. Require substituting the recovered sender address into the `from` position before hashing, and document the threat in Security Considerations.

**ATTENTION: ERC-RELATED PULL REQUESTS NOW OCCUR IN [ETHEREUM/ERCS](https://github.com/ethereum/ercs)**

--

When opening a pull request to submit a new EIP, please use the suggested template: https://github.com/ethereum/EIPs/blob/master/eip-template.md

We have a GitHub bot that automatically merges some PRs. It will merge yours immediately if certain criteria are met:

 - The PR edits only existing draft PRs.
 - The build passes.
 - Your GitHub username or email address is listed in the 'author' header of all affected PRs, inside <triangular brackets>.
 - If matching on email address, the email address is the one publicly listed on your GitHub profile.
