### PR TITLE
Update EIP-7708: Soldøgn Interop Breakout Decisions

### DIFF
--- a/EIPS/eip-7708.md
+++ b/EIPS/eip-7708.md
@@ -47,7 +47,7 @@ A log, identical to a LOG2, is issued for:
 - Any nonzero-balance `SELFDESTRUCT` to self by a contract created in the same transaction, at the time the opcode is invoked
 - Any nonzero-balance account marked for deletion, at the time of removal during transaction finalization
 
-Burn logs are emitted after all other logs created by EVM execution and the payment of the [EIP-1559](./eip-1559.md) priority fee to the coinbase. When multiple accounts with non-zero balances are marked for deletion, burn logs are emitted in lexicographical order of account address.
+Burn logs are emitted after all other logs created by EVM execution and the payment of the [EIP-1559](./eip-1559.md) priority fee to the coinbase. When multiple accounts with nonzero balances are marked for deletion, burn logs are emitted in lexicographical order of account address.
 
 | Field | Value |
 | - | - |
@@ -60,11 +60,13 @@ Burn logs are emitted after all other logs created by EVM execution and the paym
 
 This is the simplest possible implementation that ensures that all ETH transfers are implemented in some kind of record that can be easily accessed through making RPC calls into a node, or through asking for a Merkle branch that is hashed into the block root. The log type is compatible with the ERC-20 token standard, but does not introduce any overly-specific ERC-20 features (eg. ABI encodings) into the specification.
 
-### Open questions
+The `SYSTEM_ADDRESS` is reused as the log emitter for consistency with other protocol-originated operations (e.g. [EIP-4788](./eip-4788.md)) and to distinguish these protocol-generated logs from logs emitted by user contracts.
 
-1. Magic value used for `address`? For address: (a) `0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee` (same as `eth_simulateV1`), (b) `0xfffffffffffffffffffffffffffffffffffffffe` ([`SYSTEM_ADDRESS`](./eip-4788.md)), (c) zero address
-2. Should fee payments trigger a log? It would ensure "completeness", in the sense that you can compute the exact current balance table by watching logs, but it would greatly increase the number of logs, perhaps to an unacceptably high amount.
-3. Should withdrawals also trigger a log? They are not associated with transactions.
+Fee payment logs for priority fees paid to the coinbase were considered. However, they are a distinct category from transfers, and adding these logs to this EIP would explode the log volume in a way that raises the intrinsic cost of transfer logs (and therefore transactions), putting an unreasonable load on the network. Clients can already compute these fee amounts from the block header and transaction receipt, so it is unnecessary to log them. The base fee burn is excluded for the same reason: the burned amount is already derivable from the block header.
+
+Withdrawals were also considered, but they are not attached to a transaction, which means there is no natural emission point. Additionally, they are already easily derivable from block information. Adding these kinds of logs would duplicate data already available to clients.
+
+Clients who wish to provide a unified view for consumers MAY expose a new aggregating RPC.
 
 ## Backwards Compatibility
 
@@ -72,7 +74,18 @@ No backward compatibility issues found.
 
 ## Test Cases
 
-TODO
+- Transfer log emission for plain transactions, EOAs, delegated EOAs, and across all transaction types
+- Transfer logs across the `CALL` family and how the executing context attributes the sender
+- Transfer logs for `CREATE` / `CREATE2` endowments, initcode behavior, and failure modes
+- Transfer logs for `SELFDESTRUCT` to self vs. a different beneficiary, including pre-existing and cross-tx contracts
+- Log ordering: Transfer logs appear before any EVM-emitted logs in a transaction, and nested-`CALL` Transfer logs appear in chronological call order
+- Burn logs emitted for same-transaction `SELFDESTRUCT` to self
+- Burn logs emitted at transaction finalization, including lexicographic ordering and priority-fee interaction
+- Negative cases where no log is emitted (zero-value, reverts, rolled-back inner calls, fee payments)
+- Transfers to special-purpose addresses (precompiles, the system address, the coinbase)
+- Fork transition behavior at the EIP-7708 activation boundary
+
+Test cases for this EIP can be found in the Execution Layer Specification suite [`eip7708_eth_transfer_logs`](https://github.com/ethereum/execution-specs/tree/155c3e136d81dcd5c61086c9d832595b7641db4a/tests/amsterdam/eip7708_eth_transfer_logs).
 
 ## Security Considerations
 


### PR DESCRIPTION
# Remove Existing Open Questions & Document Rationale

These were decided at [Soldøgn Interop](https://blog.ethereum.org/2026/05/02/soldogn-interop-recap). We will not expand 7708 to cover priority fees, base fee burn, or withdrawals. We will document the rationale so as not to re-hash this again.