### PR TITLE
Add EIP: CREATE2 redeployment for delegation indicators

### DIFF
--- a/EIPS/eip-8200.md
+++ b/EIPS/eip-8200.md
@@ -1,0 +1,175 @@
+---
+eip: 8200
+title: CREATE2 redeployment for delegation indicators
+description: Allow CREATE2 to create and update EIP-7702 delegation indicators
+author: Chris Hunter (@chunter-cb) <chris.hunter@coinbase.com>
+discussions-to: https://ethereum-magicians.org/t/eip-8200-create2-redeployment-for-delegation-indicators/00000
+status: Draft
+type: Standards Track
+category: Core
+created: 2026-05-04
+requires: 684, 1014, 3541, 7610, 7702
+---
+
+## Abstract
+
+This EIP allows contract creation to deploy [EIP-7702](./eip-7702.md)-style delegation indicators, and allows `CREATE2` to replace an existing delegation indicator with another delegation indicator at the same address. This creates an opt-in upgrade path for accounts deployed as delegation indicators while preserving the immutability of all non-delegation contract code.
+
+## Motivation
+
+[EIP-7702](./eip-7702.md) introduced delegation indicators using the byte sequence `0xef0100 || address`. These indicators make an account execute code from another address while retaining the account's own address, balance, nonce, and storage.
+
+Delegation indicators are useful beyond externally owned accounts. A factory may want to deploy many accounts whose addresses are controlled by the existing `CREATE2` namespace, while keeping the implementation address upgradeable. Today this is not possible through contract creation:
+
+- [EIP-3541](./eip-3541.md) rejects new code beginning with `0xEF`.
+- [EIP-684](./eip-684.md) rejects creation when the destination account already has nonempty code or a nonzero nonce.
+- [EIP-7610](./eip-7610.md) rejects creation when the destination account has non-empty storage.
+- [EIP-1014](./eip-1014.md) derives `CREATE2` addresses from the deployer, salt, and init code hash, but does not permit the derived address to be reused.
+
+This EIP makes delegation indicators a redeployable subclass of `CREATE2` accounts. A factory can deploy an account as a delegation indicator, and later use the same `CREATE2` derivation to replace that indicator with a new delegation indicator. The exception is limited to delegation indicators: normal contract code remains immutable once deployed.
+
+## Specification
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119) and [RFC 8174](https://www.rfc-editor.org/rfc/rfc8174).
+
+### Parameters
+
+| Constant | Value |
+|----------|-------|
+| `DELEGATION_DESIGNATOR` | `0xef0100` |
+| `DELEGATION_INDICATOR_SIZE` | `23` |
+
+A byte sequence is a valid delegation indicator if and only if:
+
+1. its length is exactly `DELEGATION_INDICATOR_SIZE`, and
+2. its first three bytes are `DELEGATION_DESIGNATOR`.
+
+Equivalently, a valid delegation indicator is exactly:
+
+```
+0xef0100 || target
+```
+
+where `target` is a 20-byte address.
+
+### Contract creation code restriction
+
+The [EIP-3541](./eip-3541.md) restriction is modified as follows:
+
+After `block.number == FORK_BLOCK`, new contract creation via a create transaction, the `CREATE` opcode, or the `CREATE2` opcode MUST reject returned runtime code whose first byte is `0xEF`, unless the returned runtime code is a valid delegation indicator.
+
+Returned runtime code beginning with `0xEF` that is not a valid delegation indicator MUST continue to fail with the same exceptional abort behavior defined by EIP-3541.
+
+### CREATE2 collision exception
+
+The [EIP-684](./eip-684.md) collision rule, as amended by [EIP-7610](./eip-7610.md), is modified only for `CREATE2`.
+
+When executing `CREATE2`, clients compute the destination address using the existing [EIP-1014](./eip-1014.md) formula:
+
+```
+destination = keccak256(0xff || deployer || salt || keccak256(init_code))[12:]
+```
+
+If the destination account has nonempty code that is a valid delegation indicator, `CREATE2` MUST NOT fail solely because the destination account has nonempty code, a nonzero nonce, or non-empty storage.
+
+In this delegation replacement case:
+
+1. The `CREATE2` operation executes `init_code` using normal contract creation semantics.
+2. If `init_code` fails, reverts, or returns runtime code that is not a valid delegation indicator, the `CREATE2` operation MUST fail with normal contract creation failure semantics.
+3. If `init_code` returns a valid delegation indicator, the destination account's code MUST be replaced with the returned delegation indicator.
+4. The destination account's balance and storage MUST be preserved.
+5. The destination account's nonce behavior MUST follow normal contract creation semantics.
+
+If the destination account does not have nonempty code that is a valid delegation indicator, the EIP-684 collision rule, as amended by EIP-7610, is unchanged. In particular, `CREATE2` MUST fail when the destination account has nonempty non-delegation code, or when the destination account has empty code and a nonzero nonce or non-empty storage.
+
+The `CREATE` opcode and create transactions do not receive a collision exception under this EIP.
+
+### Delegation indicator behavior
+
+Delegation indicators deployed or replaced through this EIP behave identically to delegation indicators defined by [EIP-7702](./eip-7702.md).
+
+This EIP does not define a clearing operation. A `CREATE2` operation covered by this EIP writes the returned delegation indicator as account code, including the case where `target == address(0)`.
+
+## Rationale
+
+### Reusing CREATE2 authority
+
+`CREATE2` already defines a deployer-controlled namespace:
+
+```
+deployer, salt, init_code_hash
+```
+
+Allowing redeployment only when the existing and replacement code are both delegation indicators gives the original factory a natural upgrade authority without introducing a new opcode. The same factory and same `CREATE2` derivation that created the delegated account are required to update it.
+
+### Exact delegation indicators only
+
+The exception is limited to exact 23-byte delegation indicators. This preserves the reservation introduced by EIP-3541 for all other `0xEF`-prefixed code and avoids defining a general-purpose mutable code mechanism.
+
+### Preserving contract immutability
+
+EIP-684 protects the expectation that deployed contract code does not change. This EIP preserves that expectation for all non-delegation code. A delegation indicator is already an indirection to mutable behavior at another address; allowing the indicator target to change is consistent with the account's opt-in delegated form.
+
+### Target-independent init code
+
+The `CREATE2` address formula is unchanged. Therefore, redeployment to the same address requires the same deployer, salt, and init code hash.
+
+Factories that want to upgrade the delegation target while preserving the same account address should use target-independent init code. For example, the init code can obtain the current target from the factory during execution and return `0xef0100 || target`, while the bytes of the init code remain unchanged across upgrades.
+
+## Backwards Compatibility
+
+This EIP changes execution layer behavior and requires a hard fork.
+
+Existing contracts with non-delegation code remain immutable under the EIP-684 collision rule. Existing deployment flows that do not return a valid delegation indicator are unaffected except that valid delegation indicators become deployable runtime code.
+
+## Security Considerations
+
+### No arbitrary code replacement
+
+The collision exception applies only when the existing code is a valid delegation indicator and the replacement code is also a valid delegation indicator. A factory cannot use this EIP to replace a normal contract with new code, nor can it convert a delegated account into arbitrary runtime code.
+
+### Factory authority
+
+The factory that controls a `CREATE2` namespace controls future delegation replacements for accounts it deploys as delegation indicators. Users should treat the factory and its upgrade rules as part of the account's trust model.
+
+### Init code side effects
+
+During delegation replacement, `init_code` executes with normal contract creation semantics. Factory authors SHOULD keep replacement init code minimal and deterministic. Applications that rely on delegated accounts SHOULD document whether the factory can change the delegation target and under what conditions.
+
+### Delegation loops
+
+As in EIP-7702, clients do not resolve chains or loops of delegation indicators beyond the first delegation. Factories SHOULD avoid targets that are themselves delegation indicators unless this behavior is intended.
+
+## Test Cases
+
+### Deploying a delegation indicator
+
+Given init code that returns `0xef0100 || target`, where `target` is 20 bytes, creation via a create transaction, `CREATE`, or `CREATE2` succeeds if no collision rule is triggered.
+
+### Rejecting other 0xEF-prefixed runtime code
+
+Given init code that returns `0xef`, `0xef00`, `0xef0100`, or any other `0xEF`-prefixed runtime code that is not exactly 23 bytes beginning with `0xef0100`, creation fails with the EIP-3541 exceptional abort behavior.
+
+### Replacing a delegation indicator with CREATE2
+
+Given:
+
+1. a factory `F`,
+2. salt `S`,
+3. init code `I`,
+4. destination `D = keccak256(0xff || F || S || keccak256(I))[12:]`, and
+5. existing code at `D` equal to `0xef0100 || target_a`,
+
+then `CREATE2` from `F` using salt `S` and init code `I` succeeds if `I` returns `0xef0100 || target_b`. The code at `D` becomes `0xef0100 || target_b`.
+
+### Rejecting replacement with non-delegation code
+
+Using the same setup, if `I` returns runtime code that is not a valid delegation indicator, `CREATE2` fails and the code at `D` remains `0xef0100 || target_a`.
+
+### Rejecting replacement of non-delegation code
+
+If the code at `D` is nonempty and not a valid delegation indicator, `CREATE2` fails according to EIP-684, regardless of whether `I` returns a valid delegation indicator.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](../LICENSE.md).


### PR DESCRIPTION
## Summary
- Add a new Core EIP proposing deployment of EIP-7702-style delegation indicators through contract creation.
- Define a narrow CREATE2 collision exception allowing existing delegation indicators to be replaced only by new delegation indicators.
- Account for EIP-684 and EIP-7610 collision rules while preserving immutability for non-delegation code.