### PR TITLE
Update EIP-7981: Simplify spec

### DIFF
--- a/EIPS/eip-7981.md
+++ b/EIPS/eip-7981.md
@@ -31,46 +31,26 @@ Furthermore, access lists can circumvent the [EIP-7623](./eip-7623.md) floor pri
 
 Let `access_list_bytes` be the total byte count of addresses (20 bytes each) and storage keys (32 bytes each) in the access list.
 
-Let `floor_tokens_in_access_list = access_list_bytes * 4`.
+Let `access_list_data_cost = 64 * access_list_bytes` (i.e. `1280` gas per address and `2048` gas per storage key). The `64` gas-per-byte rate matches the [EIP-7976](./eip-7976.md) calldata floor.
 
-Equivalently, the access list data is charged `64` gas per byte, which amounts to `1280` gas per address (20 bytes × 64) and `2048` gas per storage key (32 bytes × 64). The token abstraction is retained only for consistency with [EIP-7623](./eip-7623.md) and [EIP-7976](./eip-7976.md).
-
-The access list cost formula changes from [EIP-2930](./eip-2930.md) to include data cost:
-
-```python
-access_list_cost = (
-    ACCESS_LIST_ADDRESS_COST * access_list_addresses
-    + ACCESS_LIST_STORAGE_KEY_COST * access_list_storage_keys
-    + TOTAL_COST_FLOOR_PER_TOKEN * floor_tokens_in_access_list
-)
-```
-
-The [EIP-7976](./eip-7976.md) floor calculation is modified to include access list tokens:
-
-```python
-floor_tokens_in_calldata = (zero_bytes_in_calldata + nonzero_bytes_in_calldata) * 4
-total_floor_data_tokens = floor_tokens_in_calldata + floor_tokens_in_access_list
-
-data_floor_gas_cost = TX_BASE_COST + TOTAL_COST_FLOOR_PER_TOKEN * total_floor_data_tokens
-```
-
-The gas used calculation becomes:
+The access list data cost is added as a flat surcharge to the gas used calculation, leaving the [EIP-2930](./eip-2930.md) `access_list_cost` and the [EIP-7976](./eip-7976.md) floor calculation unchanged:
 
 ```python
 tx.gasUsed = (
     21000
+    + access_list_data_cost
     +
     max(
         STANDARD_TOKEN_COST * tokens_in_calldata
         + execution_gas_used
         + isContractCreation * (32000 + INITCODE_WORD_COST * words(calldata))
         + access_list_cost,
-        TOTAL_COST_FLOOR_PER_TOKEN * total_floor_data_tokens
+        TOTAL_COST_FLOOR_PER_TOKEN * floor_tokens_in_calldata
     )
 )
 ```
 
-Any transaction with a gas limit below `21000 + TOTAL_COST_FLOOR_PER_TOKEN * total_floor_data_tokens` or below its intrinsic gas cost is considered invalid.
+Any transaction with a gas limit below `tx.gasUsed` evaluated with `execution_gas_used = 0` is considered invalid.
 
 ## Rationale
 


### PR DESCRIPTION
Original spec adds the same value to the both branches of max(). This is unnecessary complication and only confuses readers. Simplify it by extracting the term out of max().

Also simplify the formulation of tx.gas_limit check.

Behavior unchanged.