### PR TITLE
Update EIP-8037: Clarify SELFDESTRUCT charges

### DIFF
--- a/EIPS/eip-8037.md
+++ b/EIPS/eip-8037.md
@@ -50,6 +50,8 @@ Upon activation of this EIP, the following parameters of the gas model are updat
 | `PER_EMPTY_ACCOUNT_COST` | 25,000 | `STATE_BYTES_PER_NEW_ACCOUNT x CPSB` | 0 (included in `PER_AUTH_BASE_COST`) | EOA delegation |
 | `PER_AUTH_BASE_COST` | 12,500 | `STATE_BYTES_PER_AUTH_BASE x CPSB` | 7,500 | EOA delegation |
 
+`SELFDESTRUCT_NEW_ACCOUNT` is removed and replaced by `GAS_NEW_ACCOUNT`.
+
 The values assigned to regular gas will be updated based on [EIP-8038](./eip-8038.md).
 
 The `PER_AUTH_BASE_COST` regular gas of 7,500 is derived from [EIP-7702](./eip-7702.md)'s cost analysis, excluding the code deployment cost (now charged as state gas):

--- a/EIPS/eip-8037.md
+++ b/EIPS/eip-8037.md
@@ -45,7 +45,7 @@ Upon activation of this EIP, the following parameters of the gas model are updat
 |---|---|---|---|---|
 | `GAS_CREATE` | 32,000 | `STATE_BYTES_PER_NEW_ACCOUNT x CPSB` | 9,000 (assuming same as `GAS_CALL_VALUE`)  | `CREATE`, `CREATE2`, contract creation txs |
 | `GAS_CODE_DEPOSIT` | 200/byte | `CPSB` per byte | `6 × ceil(len/32)` (hash cost) | `CREATE`, `CREATE2`, contract creation txs |
-| `GAS_NEW_ACCOUNT` | 25,000 | `STATE_BYTES_PER_NEW_ACCOUNT x CPSB` | 0 (already has `GAS_CALL_VALUE` 9,000) | `CALL*` |
+| `GAS_NEW_ACCOUNT` | 25,000 | `STATE_BYTES_PER_NEW_ACCOUNT x CPSB` | 0 (already has `GAS_CALL_VALUE` 9,000) | `CALL*`, `SELFDESTRUCT` |
 | `GAS_STORAGE_SET` | 20,000 | `STATE_BYTES_PER_STORAGE_SET x CPSB` | 2,900 (`GAS_STORAGE_UPDATE - GAS_COLD_SLOAD`) | `SSTORE` |
 | `PER_EMPTY_ACCOUNT_COST` | 25,000 | `STATE_BYTES_PER_NEW_ACCOUNT x CPSB` | 0 (included in `PER_AUTH_BASE_COST`) | EOA delegation |
 | `PER_AUTH_BASE_COST` | 12,500 | `STATE_BYTES_PER_AUTH_BASE x CPSB` | 7,500 | EOA delegation |

--- a/EIPS/eip-8037.md
+++ b/EIPS/eip-8037.md
@@ -135,12 +135,15 @@ State-gas accounting for `SSTORE` is performed at the end of the opcode executio
 |---|---|
 | `CALL*` with value to non-existent account | `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` charged |
 | `CREATE`/`CREATE2` with bytecode size of `L` | `(STATE_BYTES_PER_NEW_ACCOUNT + L) × CPSB` charged |
+| `SELFDESTRUCT` where balance transfer creates a new account | `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` charged |
 
 State-gas accounting for `CALL*` and `CREATE`/`CREATE2` operations is performed at the end of successful call frames. The respective call frame reverts or halts exceptionally, no state-gas is charged for the new account.
 
-##### Gas accounting for `SELFDESTRUCT`
+Charges for account creation with `SELFDESTRUCT` are charged at the point where it executes.
 
-`SELFDESTRUCT` does not produce a state-gas effect at the point in which it executes. Its accounting is deferred to the end of the transaction. For each account that was created during the transaction, `SELFDESTRUCT`ed, and is now being removed:
+##### State gas refills for `SELFDESTRUCT`
+
+`SELFDESTRUCT` does not produce a state-gas refills at the point in which it executes. Its accounting is deferred to the end of the transaction. For each account that was created during the transaction, `SELFDESTRUCT`ed, and is now being removed:
 
 - The state gas previously charged for the account creation (`STATE_BYTES_PER_NEW_ACCOUNT × CPSB`), the code deposit (`L × CPSB` where `L` is the deployed code length), and every storage slot that was charged as new on that account during the transaction (`STATE_BYTES_PER_STORAGE_SET × CPSB` per slot) is refunded directly to `state_gas_reservoir` and the `execution_state_gas_used` decreases by the same amount.
 - These refunds are not subject to the 20% refund cap.


### PR DESCRIPTION
- Adds a new row to the charges table for `SELFDESTRUCT` when its balance transfer creates a new account (`STATE_BYTES_PER_NEW_ACCOUNT × CPSB`, charged at execution time)
- Renames the deferred-accounting section from "Gas accounting for `SELFDESTRUCT`" to "State gas refills for `SELFDESTRUCT`" to scope it to refills only
- Clarifies that account-creation charges from `SELFDESTRUCT` happen at execution, while refills remain deferred to end-of-transaction