### PR TITLE
Update EIP-8130: Fix four critical authorization and replay issues

### DIFF
--- a/EIPS/eip-8130.md
+++ b/EIPS/eip-8130.md
@@ -47,7 +47,7 @@ Each account can authorize a set of owners through the Account Configuration Con
 
 Owners are identified by their `ownerId`, a 32-byte identifier derived by the verifier from public key material. The protocol does not enforce a derivation algorithm — each verifier defines its own convention (see [ownerId Conventions](#ownerid-conventions)). Owners can be modified via calls within EVM execution by calling the authenticated config change functions.
 
-**Default behavior**: The EOA owner is implicitly authorized by default but can be revoked on the contract.
+**Default behavior**: The EOA owner is implicitly authorized by default. It can be revoked explicitly via a config change, and is auto-revoked when the account first delegates to a wallet contract via a delegation entry (see [Execution (Account Changes)](#execution-account-changes)) so that the wallet's authentication logic is not silently bypassed by the EOA key.
 
 #### Storage Layout
 
@@ -222,7 +222,7 @@ The first 20 bytes identify the verifier address. When the verifier is `ECRECOVE
 1. **Resolve sender**: If `from` empty, ecrecover derives the sender address (EOA path) with `ownerId = bytes32(bytes20(sender))`. If `from` set, read the first 20 bytes of `sender_auth` as the verifier address.
 2. **Set transaction context**: Populate the Transaction Context precompile with sender, payer, and calls (see [Transaction Context](#transaction-context)).
 3. **Verify**: Route by verifier address. For the EOA path (`from` empty), ecrecover was already performed in step 1. For `ECRECOVER_VERIFIER` (`address(1)`), the protocol natively ecrecovers from `data` (as `r || s || v`), returning `ownerId = bytes32(bytes20(recovered_address))`. For all other verifiers (`address(2+)`), call `verifier.verify(hash, data)` via STATICCALL, returning `ownerId` (or `bytes32(0)` for invalid). Reject `REVOKED_VERIFIER` as a verifier address.
-4. **Authorize**: SLOAD `owner_config(from, ownerId)`. **Implicit EOA rule**: if the slot is empty and `ownerId == bytes32(bytes20(from))`, treat as implicitly authorized with scope `0x00`. Otherwise, require that the stored verifier address matches the effective verifier and is not `REVOKED_VERIFIER`.
+4. **Authorize**: SLOAD `owner_config(from, ownerId)`. **Implicit EOA rule**: if the slot is empty, `ownerId == bytes32(bytes20(from))`, **and** the verification in step 3 was performed via the native secp256k1 path (either the EOA path with `from` empty, or `ECRECOVER_VERIFIER` (`address(1)`)), treat as implicitly authorized with scope `0x00`. The implicit rule MUST NOT apply when step 3 dispatched to a generic verifier contract (`address(2+)`) — otherwise a malicious verifier returning `bytes32(bytes20(from))` could satisfy the implicit branch for any EOA whose implicit slot has not yet been written. Otherwise, require that the stored verifier address matches the effective verifier and is not `REVOKED_VERIFIER`.
 5. **Check scope**: Read the scope byte from `owner_config` (or `0x00` for the implicit case). Determine the context bit: `0x02` (SENDER) for `sender_auth`, `0x04` (PAYER) for `payer_auth`, `0x01` (SIGNATURE) for `verifySignature()`, `0x08` (CONFIG) for config change `auth`. Require `scope == 0x00 || (scope & context_bit) != 0`.
 
 #### Signature Payload
@@ -240,17 +240,20 @@ keccak256(AA_TX_TYPE || rlp([
 ]))
 ```
 
-**Payer signature hash** — all tx fields through `calls`, excluding `payer`, `sender_auth`, and `payer_auth`:
+**Payer signature hash** — all tx fields through `calls`, excluding `payer`, `sender_auth`, and `payer_auth`, plus the sender's verifier address (the first 20 bytes of `sender_auth`, or `address(1)` for the EOA path where `sender_auth` carries no verifier prefix):
 
 ```
 keccak256(AA_PAYER_TYPE || rlp([
   chain_id, from, nonce_key, nonce_sequence, expiry,
   max_priority_fee_per_gas, max_fee_per_gas, gas_limit,
-  account_changes, calls
+  account_changes, calls,
+  sender_verifier
 ]))
 ```
 
 The `from` field in the payer signature hash MUST be the resolved sender address. In the EOA path (`from` empty in the transaction wire format), the recovered sender address (from `sender_auth` ecrecover, see [Validation](#validation) step 1) MUST be substituted into the `from` position before computing this hash; it MUST NOT be encoded as the empty wire-format value. This binds the payer's signature to the specific resolved sender and prevents cross-sender replay of payer signatures (see [Payer Security](#security-considerations)).
+
+The `sender_verifier` field binds the payer's signature to the specific verifier the sender authenticates with. For the EOA path it is `address(1)` (`ECRECOVER_VERIFIER`); for the configured-owner path it is the first 20 bytes of `sender_auth`. Without this binding, the payer is charged for `sender_auth_cost` (see [Intrinsic Gas](#intrinsic-gas)) — which includes the verifier's actual EVM execution cost — but never commits to which verifier runs, allowing a sender that owns multiple owners to swap a cheap verifier shown to the sponsor for an arbitrarily expensive one at submission time and drain the payer's gas. Binding the verifier address makes the choice part of the payer's commitment.
 
 #### Payer Modes
 
@@ -352,6 +355,7 @@ rlp([
   0x01,               // type: config change
   chain_id,           // uint64: 0 = valid on any chain
   sequence,           // uint64: monotonic ordering
+  expiry,             // uint64: Unix timestamp (seconds). Entry invalid when block.timestamp > expiry. MUST be non-zero.
   owner_changes,      // Array of owner changes
   auth                // Signature from an owner valid at this sequence
 ])
@@ -363,6 +367,8 @@ owner_change = rlp([
   scope                 // uint8: permission bitmask (authorizeOwner only, 0x00 = unrestricted)
 ])
 ```
+
+Entries with `block.timestamp > expiry` MUST be rejected before signature verification on both the `account_changes` path and the `applySignedOwnerChanges()` EVM path. `expiry == 0` is reserved and MUST be rejected — every entry MUST commit to a finite validity window. This bounds the lifetime of `chain_id == 0` (multichain) signatures, which would otherwise be replayable on any future chain that deploys `ACCOUNT_CONFIG_ADDRESS` (the per-chain `change_sequence` starts at `0`, so a leaked or stale multichain signature could authorize unintended changes on chains the user has never used).
 
 **Operation types**:
 
@@ -382,13 +388,15 @@ The sequence number is scoped by `chain_id`: `0` uses the multichain sequence ch
 Entry signatures use ABI-encoded type hashing. Operations within an entry are individually ABI-encoded and hashed into an array digest:
 
 ```
-TYPEHASH = keccak256("SignedOwnerChanges(address account,uint64 chainId,uint64 sequence,OwnerChange[] ownerChanges)OwnerChange(uint8 changeType,address verifier,bytes32 ownerId,uint8 scope)")
+TYPEHASH = keccak256("SignedOwnerChanges(address account,uint64 chainId,uint64 sequence,uint64 expiry,OwnerChange[] ownerChanges)OwnerChange(uint8 changeType,address verifier,bytes32 ownerId,uint8 scope)")
 
 ownerChangeHashes = [keccak256(abi.encode(changeType, verifier, ownerId, scope)) for each ownerChange]
 ownerChangesHash = keccak256(abi.encodePacked(ownerChangeHashes))
 
-digest = keccak256(abi.encode(TYPEHASH, account, chainId, sequence, ownerChangesHash))
+digest = keccak256(abi.encode(TYPEHASH, account, chainId, sequence, expiry, ownerChangesHash))
 ```
+
+`expiry` is an absolute Unix timestamp (seconds since epoch), not a block number, so the bound is consistent across chains regardless of block time differences.
 
 Domain separation from transaction signatures (`AA_TX_TYPE`, `AA_PAYER_TYPE`) is structural — transaction hashes use `keccak256(type_byte || rlp([...]))`, which cannot produce the same prefix as `abi.encode(TYPEHASH, ...)`.
 
@@ -440,7 +448,7 @@ For 8130 transactions, successful delegation updates emit a protocol-injected `D
 
 1. **Create entry** (if present): Register `initial_owners` in Account Config storage for `from` — for each `[verifier, ownerId, scope]` tuple, write `owner_config` (verifier address and scope byte). Initialize lock state to safe defaults: `locked = false`, `unlockDelay = 0`, `unlockRequestedAt = 0`.
 2. **Config change entries** (if any): Apply operations in entry order. Reject transaction if account is locked.
-3. **Delegation entries** (if any): Require the sender's resolved `ownerId == bytes32(bytes20(from))` (EOA owner) with CONFIG scope. Reject if account is locked. For each entry, set `code(from) = 0xef0100 || target` (or clear if `target` is `address(0)`). Reject if account has non-delegation bytecode.
+3. **Delegation entries** (if any): Require the sender's resolved `ownerId == bytes32(bytes20(from))` (EOA owner) with CONFIG scope. Reject if account is locked. For each entry, set `code(from) = 0xef0100 || target` (or clear if `target` is `address(0)`). Reject if account has non-delegation bytecode. **Auto-revoke implicit EOA owner**: when `target != address(0)` and the implicit EOA slot at `owner_config(from, bytes32(bytes20(from)))` is empty (i.e., the implicit owner has never been explicitly written), the protocol MUST overwrite that slot with `verifier = REVOKED_VERIFIER` as part of the same step. Without this, the implicit EOA rule (see [Validation](#validation) step 4) continues to authorize raw ECDSA signatures from the EOA's secp256k1 key, completely bypassing the authentication logic of the newly delegated wallet contract — a multisig or social-recovery wallet receives delegated code, but a single leaked secp256k1 key can still authorize transactions as `msg.sender = from` without ever invoking the wallet's `isValidSignature`. Wallets that explicitly want the EOA key to remain authorized after delegation MUST follow the delegation entry with a config change (or `applySignedOwnerChanges()` call) that re-registers the EOA owner via `ECRECOVER_VERIFIER` with the desired scope; opting back in is an explicit action.
 4. **Code placement** (if create entry present): Place `code` at `from`. The runtime bytecode is placed directly — not executed.
 
 ### Execution
@@ -790,11 +798,15 @@ Read-only. The protocol manages nonce storage directly; there are no state-modif
 
 **Owner Scope**: Protocol-enforced after verifier execution — a verifier cannot bypass scope checking.
 
-**Owner Management**: Config change authorization requires CONFIG scope. The EOA owner is implicitly authorized with unrestricted scope; revocable via portable config change. All owner modification paths are blocked when the account is locked.
+**Owner Management**: Config change authorization requires CONFIG scope. The EOA owner is implicitly authorized with unrestricted scope; revocable via portable config change, and auto-revoked on first delegation (see below). All owner modification paths are blocked when the account is locked. Config change entries are bound to a finite `expiry` (Unix timestamp); `chain_id == 0` (multichain) signatures without an `expiry` would otherwise be replayable on any future chain that deploys `ACCOUNT_CONFIG_ADDRESS` since the per-chain `change_sequence` starts at `0`.
+
+**Implicit EOA Rule Scoping**: The implicit EOA authorization (see [Validation](#validation) step 4) only applies when authentication ran through the native secp256k1 path — either the EOA path (`from` empty) or `ECRECOVER_VERIFIER` (`address(1)`). It MUST NOT apply when a generic verifier contract executed in step 3. Without this restriction, anyone could deploy a verifier whose `verify()` returns `bytes32(bytes20(victim))` for any input and use it to authenticate as any EOA whose implicit slot has never been written — i.e., effectively every existing EOA on chain.
+
+**Implicit EOA Auto-Revocation on Delegation**: When an account first delegates to a wallet contract, the protocol overwrites the implicit EOA slot with `REVOKED_VERIFIER` (see [Execution (Account Changes)](#execution-account-changes)). Otherwise the EOA's raw secp256k1 key remains a permanent backdoor that authenticates as `msg.sender = from` without ever invoking the delegated wallet's `isValidSignature` — a single compromised key would defeat any multisig, social-recovery, or session-key policy implemented in the delegated wallet. Wallets that explicitly want the EOA key to coexist with delegation re-register it via `ECRECOVER_VERIFIER` after delegation; opting back in is explicit.
 
 **ownerId Binding**: The protocol checks that the verifier's returned `ownerId` maps back to that verifier in `owner_config` — preventing a malicious verifier from claiming ownership of another verifier's owners.
 
-**Payer Security**: `AA_TX_TYPE` vs `AA_PAYER_TYPE` domain separation prevents signature reuse between sender and payer roles. The `payer` field in the sender's signed hash binds to a specific payer address. Scope enforcement adds a second layer — PAYER-only owners cannot be used as `sender_auth`, and vice versa.
+**Payer Security**: `AA_TX_TYPE` vs `AA_PAYER_TYPE` domain separation prevents signature reuse between sender and payer roles. The `payer` field in the sender's signed hash binds to a specific payer address. Scope enforcement adds a second layer — PAYER-only owners cannot be used as `sender_auth`, and vice versa. The payer signature hash also binds to the sender's verifier address (see [Signature Payload](#signature-payload)) so that a sender owning multiple owners cannot show a sponsor a transaction signed with a cheap verifier and submit one signed with a far more expensive verifier — `sender_auth_cost` includes the verifier's actual EVM execution cost and is charged to the payer, so unbound verifier choice would let the sender drain the payer's gas budget.
 
 **Cross-sender Payer Replay**: The payer signature hash binds to the resolved sender via the `from` field (see [Signature Payload](#signature-payload)). In the EOA path where `from` is empty in the wire format, the recovered sender address MUST be substituted into the `from` position before computing the hash. Without this substitution, two different EOAs that construct otherwise identical transaction data (same `chain_id`, `nonce_key`, `nonce_sequence`, `expiry`, fees, `account_changes`, `calls`) would produce identical payer hashes, allowing a second EOA to reuse a payer signature originally issued for the first and drain the payer's gas deposit. The 2D nonce alone does not prevent this: `nonce_key` and `nonce_sequence` are fields in the transaction payload, so each attacker controls their own values. Substituting the recovered sender into the hash makes the payer's commitment per-sender and closes this replay path. The configured-owner path is unaffected because `from` is non-empty by definition.
 


### PR DESCRIPTION
C1 — Implicit EOA rule scoping: restrict the implicit-authorization branch in Validation step 4 to the native secp256k1 path (EOA path or `ECRECOVER_VERIFIER`). A literal reading of the prior text let a generic verifier returning `bytes32(bytes20(from))` satisfy the implicit branch for any unwritten EOA slot — i.e., almost every existing EOA.

C2 — Bind `sender_verifier` into the payer signature hash. `sender_auth_cost` includes the verifier's actual EVM execution cost and is charged to the payer, but the payer hash previously did not commit to which verifier the sender uses. A sender with multiple registered owners could show the sponsor a cheap verifier and submit with an expensive one to drain gas.

C3 — Add uint64 `expiry` to `SignedOwnerChanges` TYPEHASH and the config change entry format; reject when `block.timestamp > expiry`, and reject expiry == 0. Without an expiry, chain_id == 0 (multichain) signatures were replayable on any future chain that deploys `ACCOUNT_CONFIG_ADDRESS`, because each chain's change_sequence starts at 0.

C4 — Auto-revoke the implicit EOA owner on first delegation: when a delegation entry sets non-zero target, write `REVOKED_VERIFIER` to the implicit EOA slot if still empty. Otherwise the EOA's secp256k1 key remains a permanent backdoor around the delegated wallet's auth logic (multisig, social recovery, session keys). Wallets that want the EOA key to coexist with delegation re-register it explicitly via ECRECOVER_VERIFIER.

Security Considerations updated to document each rule.

**ATTENTION: ERC-RELATED PULL REQUESTS NOW OCCUR IN [ETHEREUM/ERCS](https://github.com/ethereum/ercs)**

--

When opening a pull request to submit a new EIP, please use the suggested template: https://github.com/ethereum/EIPs/blob/master/eip-template.md

We have a GitHub bot that automatically merges some PRs. It will merge yours immediately if certain criteria are met:

 - The PR edits only existing draft PRs.
 - The build passes.
 - Your GitHub username or email address is listed in the 'author' header of all affected PRs, inside <triangular brackets>.
 - If matching on email address, the email address is the one publicly listed on your GitHub profile.
