### PR TITLE
Update EIP-8131: Clarify worst-case block size reduction, align 7976

### DIFF
--- a/EIPS/eip-8131.md
+++ b/EIPS/eip-8131.md
@@ -8,25 +8,25 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2025-01-21
-requires: 7623, 7702
+requires: 7623, 7702, 7976
 ---
 
 ## Abstract
 
-This EIP includes [EIP-7702](./eip-7702.md) authorization data in the [EIP-7623](./eip-7623.md) floor calculation, preventing circumvention of floor pricing through authorization lists.
+This EIP includes [EIP-7702](./eip-7702.md) authorization data in the [EIP-7623](./eip-7623.md) floor calculation, preventing circumvention of floor pricing through authorization lists. This effectively reduces the worst-case block size by ~16%.
 
 ## Motivation
 
 [EIP-7702](./eip-7702.md) authorization tuples are priced for execution (`PER_EMPTY_ACCOUNT_COST = 25,000` gas per authorization) but do not contribute to the [EIP-7623](./eip-7623.md) floor calculation.
 
-This enables achieving ~9% larger blocks than intended by combining calldata with authorization data at an optimal ratio, circumventing the floor pricing mechanism.
+Under [EIP-7976](./eip-7976.md) floor pricing, this enables circumventing the floor by combining all-non-zero calldata with authorization data at a 25%/75% (calldata/auths) gas split.
 
 ## Specification
 
 | Parameter | Value | Source |
 |-----------|-------|--------|
-| `TOTAL_COST_FLOOR_PER_TOKEN` | `10` | [EIP-7623](./eip-7623.md) |
-| `FLOOR_COST_PER_AUTH` | `4040` | 101 bytes × 4 tokens × 10 gas |
+| `TOTAL_COST_FLOOR_PER_TOKEN` | `16` | [EIP-7976](./eip-7976.md) |
+| `FLOOR_COST_PER_AUTH` | `6464` | 101 bytes × 4 tokens × 16 gas |
 | `PER_EMPTY_ACCOUNT_COST` | `25000` | [EIP-7702](./eip-7702.md) |
 
 The [EIP-7623](./eip-7623.md) floor calculation is modified to include authorization data:
@@ -59,25 +59,39 @@ tx.gasUsed = (
 )
 ```
 
-Any transaction with a gas limit below `floor_gas` or below its intrinsic gas cost is considered invalid.
+A transaction is invalid if its `gas_limit` is less than `tx.gasUsed` evaluated with `execution_gas_used = 0`.
 
 ## Rationale
 
 ### Flat Cost Per Authorization
 
-Each authorization is charged a flat `FLOOR_COST_PER_AUTH = 4040` gas toward the floor, derived from:
+Each authorization is charged a flat `FLOOR_COST_PER_AUTH = 6464` gas toward the floor, derived from:
 
 - 101 bytes per authorization tuple (as specified in [EIP-7702](./eip-7702.md))
 - 4 tokens per byte (treating all bytes as non-zero)
-- 10 gas per token (`TOTAL_COST_FLOOR_PER_TOKEN`)
+- 16 gas per token (`TOTAL_COST_FLOOR_PER_TOKEN`)
 
 This conservative approach avoids byte-level zero/non-zero accounting while ensuring authorization data is properly reflected in the floor calculation.
+
+### Worst-Case Reduction
+
+At the floor under EIP-7976 every byte costs 64 gas regardless of value, so the optimal attacker uses all-non-zero calldata (incompressible under snappy) at the standard rate of 16 gas/byte and spends the remainder on auths. The break-even split is `(64 − 16) / 64 = 75%` on auths and `25%` on calldata. At a 60M gas limit:
+
+```python
+# pre-EIP-8131 worst case (auth bypass, all-non-zero cd):
+(0.75 * 60_000_000 * 101 / 25_000 + 0.25 * 60_000_000 / 16) / 1024**2  ≈  1.067 MB
+
+# post-EIP-8131 worst case (pure floor, all-non-zero cd):
+60_000_000 / 64 / 1024**2                                              ≈  0.894 MB
+
+# reduction: 1 − 0.894 / 1.067 ≈ 16%
+```
 
 ### Floor-Only Modification
 
 Authorization costs are added to the floor calculation only, not to intrinsic gas. This differs from [EIP-7981](./eip-7981.md) (access lists) because:
 
-- Authorization execution cost (25,000 gas) far exceeds floor contribution (4,040 gas per auth)
+- Authorization execution cost (25,000 gas) far exceeds floor contribution (6,464 gas per auth)
 - Floor-only modification is sufficient to prevent bypass
 
 With this change:
@@ -100,24 +114,25 @@ Requires updates to gas estimation in wallets and nodes. Normal usage patterns r
 - Authorizations: 10
 
 Old floor: 21,000 gas
-New floor: 21,000 + 10 × 4,040 = 61,400 gas
-Execution: 10 × 25,000 = 250,000 gas
-Result: Pay execution (250,000) - unchanged, execution dominates
+New floor: 21,000 + 10 × 6,464 = 85,640 gas
+Intrinsic: 21,000 + 10 × 25,000 = 271,000 gas
+Result: Pay intrinsic (271,000) — execution dominates, EIP-8131 has no effect
 
 ### Case 2: Bypass Attempt (Now Blocked)
 
-- Calldata: 100,000 bytes (400,000 tokens)
-- Authorizations: 100
+- Calldata: 100,000 non-zero bytes
+- Authorizations: 225
 
-Old floor: 21,000 + 400,000 × 10 = 4,021,000 gas
-New floor: 21,000 + 400,000 × 10 + 100 × 4,040 = 4,425,000 gas
-Execution: 21,000 + 1,600,000 + 2,500,000 = 4,121,000 gas
-Result: Pay new floor (4,425,000) - bypass blocked
+Old floor: 21,000 + 100,000 × 64                = 6,421,000 gas
+New floor: 21,000 + 100,000 × 64 + 225 × 6,464  = 7,875,400 gas
+Intrinsic: 21,000 + 100,000 × 16 + 225 × 25,000 = 7,246,000 gas
+Pre-EIP-8131:  max(7,246,000, 6,421,000) = 7,246,000 (intrinsic wins, floor bypassed)
+Post-EIP-8131: max(7,246,000, 7,875,400) = 7,875,400 (floor wins, bypass blocked)
 
 ## Reference Implementation
 
 ```python
-FLOOR_COST_PER_AUTH = 4040  # 101 bytes * 4 tokens/byte * 10 gas/token
+FLOOR_COST_PER_AUTH = 6464  # 101 bytes * 4 tokens/byte * 16 gas/token
 
 
 def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
@@ -143,16 +158,23 @@ def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
         + num_authorizations * FLOOR_COST_PER_AUTH
     )
 
-    # Intrinsic: calldata + authorization execution cost
+    # Intrinsic: calldata + create + access list + authorization execution cost
     calldata_cost = tokens_in_calldata * STANDARD_TOKEN_COST
-    intrinsic_gas = TX_BASE_COST + calldata_cost + access_list_cost + auth_exec_cost
+    create_cost = TX_CREATE_COST + init_code_cost(tx.data) if is_create(tx) else 0
+    intrinsic_gas = (
+        TX_BASE_COST
+        + calldata_cost
+        + create_cost
+        + access_list_cost
+        + auth_exec_cost
+    )
 
     return intrinsic_gas, floor_gas
 ```
 
 ## Security Considerations
 
-This EIP closes a loophole that allows circumventing [EIP-7623](./eip-7623.md) floor pricing. Without this fix, adversaries can achieve ~9% larger blocks by combining calldata with authorization data.
+This EIP closes a loophole that allows circumventing [EIP-7623](./eip-7623.md) floor pricing. Without this fix, adversaries can achieve larger blocks than intended by combining calldata with authorization data.
 
 ### Interaction with EIP-7981
 


### PR DESCRIPTION
Clarify the worst-case block size reduction achieved through this EIP and align it with changes of EIP-7976.