### PR TITLE
Update EIP-7708: Add gas costs for system-emitted transfer and burn logs

### DIFF
--- a/EIPS/eip-7708.md
+++ b/EIPS/eip-7708.md
@@ -56,6 +56,48 @@ Burn logs are emitted after all other logs created by EVM execution and the paym
 | `topics[1]` | `address` (zero prefixed to fill uint256) |
 | `data` | `amount` in Wei (big endian uint256) |
 
+### Gas costs
+
+The system-emitted logs in this EIP are charged their `LOGn`-equivalent gas cost at each emission site:
+
+| Constant | Value | Derivation |
+| --- | --: | --- |
+| `TRANSFER_LOG_COST` | `1,756` | `LOG_GAS + 3 × LOG_TOPIC_GAS + 32 × LOG_DATA_GAS = 375 + 3×375 + 32×8` (LOG3 equivalent) |
+| `BURN_LOG_COST`     | `1,381` | `LOG_GAS + 2 × LOG_TOPIC_GAS + 32 × LOG_DATA_GAS = 375 + 2×375 + 32×8` (LOG2 equivalent) |
+
+These charges apply in addition to any existing [intrinsic-gas](./eip-2780.md) charge, `CALL` / `SELFDESTRUCT` base cost, and `CREATE` / `CREATE2` opcode base (`GAS_CREATE` plus init-code costs and, for `CREATE2`, the salt-hashing cost).
+
+#### Transfer log charges
+
+`TRANSFER_LOG_COST` is charged at each emission site listed in *ETH transfer logs*:
+
+| Emission site | Charged at |
+| --- | --- |
+| Top-level value-transferring transaction (including `CREATE` transactions with `value > 0`) | [Intrinsic gas](./eip-2780.md) computation, before EVM execution begins |
+| Value-moving `CALL` to a different account (`caller != to`) | Point of the value transfer |
+| Value-moving `SELFDESTRUCT` to a different account (`beneficiary != originator`, originator balance `> 0`) | Point of the value transfer |
+| `CREATE` / `CREATE2` with non-zero endowment | Point of the endowment transfer |
+
+The newly created account in `CREATE` / `CREATE2` is, by construction, distinct from the caller, so the self-transfer carve-out does not apply.
+
+#### Burn log charges
+
+`BURN_LOG_COST` is charged once at any `SELFDESTRUCT` whose originator (the contract executing the opcode) was created in the same transaction. This single charge covers both burn-log cases listed in *ETH burn logs*:
+
+- case (a): an immediate burn log emitted at `SELFDESTRUCT` when `beneficiary == originator` and the originator has non-zero balance.
+- case (b): a finalization-time burn log emitted when an account marked for deletion has non-zero balance at removal.
+
+The charge is applied at flagging time (the `SELFDESTRUCT` opcode), so all gas accounting completes before transaction finalization (which runs after EVM gas accounting closes). The charge is unconditional on burn-log emission: if no burn log actually emits (e.g. the originator's balance is zero at the `SELFDESTRUCT` and no further balance is sent to it), it is not refunded; the over-charge is bounded by `BURN_LOG_COST` per `SELFDESTRUCT`.
+
+A `SELFDESTRUCT`-flagged originator remains addressable until transaction finalization, so a subsequent value-transfer to it is possible. In the rare case where the originator self-destructs to itself (case (a) emits and burns the originator's then-current balance) and then receives further balance before finalization (case (b) emits at finalization for the new balance), both burn logs emit for the same `SELFDESTRUCT`. The spec accepts a bounded undercharge of one `BURN_LOG_COST` in this case.
+
+#### `SELFDESTRUCT` charge combinations
+
+A `SELFDESTRUCT` may pay 0, 1, or 2 of these log-cost charges. The two conditions are independent and both can hold on a single `SELFDESTRUCT`:
+
+- `TRANSFER_LOG_COST`: charged iff `beneficiary != originator` AND `originator_balance > 0` (transfer log at the `SELFDESTRUCT`).
+- `BURN_LOG_COST`: charged iff originator was created in the same transaction (burn log at the `SELFDESTRUCT` or at finalization).
+
 ## Rationale
 
 This is the simplest possible implementation that ensures that all ETH transfers are implemented in some kind of record that can be easily accessed through making RPC calls into a node, or through asking for a Merkle branch that is hashed into the block root. The log type is compatible with the ERC-20 token standard, but does not introduce any overly-specific ERC-20 features (eg. ABI encodings) into the specification.


### PR DESCRIPTION
Specifies `TRANSFER_LOG_COST = 1,756` (`LOG3` equivalent) and `BURN_LOG_COST = 1,381` (`LOG2` equivalent), the emission sites at which each is charged (top-level value-transferring tx incl. value-bearing `CREATE`, in-EVM `CALL`, `SELFDESTRUCT`, `CREATE` / `CREATE2`), the `BURN_LOG_COST` single-charge model for same-tx-created `SELFDESTRUCT`, and the 0/1/2 combination rules for `TRANSFER_LOG_COST` and `BURN_LOG_COST` on a single `SELFDESTRUCT`.

