### PR TITLE
Update EIP-3155: `refund` should be `Number` not `Hex-Number`

### DIFF
--- a/EIPS/eip-3155.md
+++ b/EIPS/eip-3155.md
@@ -68,7 +68,7 @@ The CUT MUST output a `json` object for EACH operation.
 | `stack`      | Array of Hex-Numbers | Array of all values on the stack         |
 | `depth`      | Number               | Depth of the call stack                  |
 | `returnData` | Hex-String           | Data returned by function call           |
-| `refund`     | Hex-Number           | Amount of **global** gas refunded        |
+| `refund`     | Number               | Amount of **global** gas refunded        |
 
 #### Optional Fields
 


### PR DESCRIPTION
It correct in the test cases but wrong in the 'Required Fields' type column