### PR TITLE
Update EIP-7708: Use EIP-8246 to simplify

### DIFF
--- a/EIPS/eip-7708.md
+++ b/EIPS/eip-7708.md
@@ -52,13 +52,11 @@ Withdrawals were also considered, but they are not attached to a transaction, wh
 
 Clients who wish to provide a unified view for consumers MAY expose a new aggregating RPC.
 
-### ETH burns via `SELFDESTRUCT`
-
-After EIP-8246, ETH can no longer be burned via `SELFDESTRUCT` to self or by sending ETH to an account marked for selfdestruction. Therefore, this EIP does not specify this edge-case.
-
 ## Backwards Compatibility
 
-No backward compatibility issues found.
+### ETH burns via `SELFDESTRUCT`
+
+After [EIP-8246](./eip-8246.md), ETH can no longer be burned via `SELFDESTRUCT` to self or by sending ETH to an account marked for selfdestruction. Therefore, this EIP does not specify this edge-case.
 
 ## Test Cases
 
@@ -67,7 +65,6 @@ No backward compatibility issues found.
 - Transfer logs for `CREATE` / `CREATE2` endowments, initcode behavior, and failure modes
 - Transfer logs for `SELFDESTRUCT` to self vs. a different beneficiary, including pre-existing and cross-tx contracts
 - Log ordering: Transfer logs appear before any EVM-emitted logs in a transaction, and nested-`CALL` Transfer logs appear in chronological call order
-- No transfer logs emitted for `SELFDESTRUCT` to self, either same-tx or pre-existing contract.
 - Negative cases where no log is emitted (zero-value, reverts, rolled-back inner calls, fee payments)
 - Transfers to special-purpose addresses (precompiles, the system address, the coinbase)
 - Fork transition behavior at the EIP-7708 activation boundary

--- a/EIPS/eip-7708.md
+++ b/EIPS/eip-7708.md
@@ -1,19 +1,19 @@
 ---
 eip: 7708
-title: ETH transfers and burns emit a log
-description: All ETH transfers and burns emit a log
+title: ETH transfers emit a log
+description: All ETH transfers emit a log
 author: Vitalik Buterin (@vbuterin), Peter Davies (@petertdavies), Etan Kissling (@etan-status), Gajinder Singh (@g11tech), Carson (@carsons-eels), Jared Wasinger (@jwasinger)
 discussions-to: https://ethereum-magicians.org/t/eip-7708-eth-transfers-emit-a-log/20034
 status: Draft
 type: Standards Track
 category: Core
 created: 2024-05-17
-requires: 1559, 4788, 6780
+requires: 1559, 4788, 6780, 8246
 ---
 
 ## Abstract
 
-All ETH transfers and burns emit a log.
+All ETH transfers emit a log.
 
 ## Motivation
 
@@ -40,22 +40,6 @@ A log, identical to a LOG3, is issued for:
 
 This matches the [ERC-20](./eip-20.md) Transfer event definition.
 
-### ETH burn logs
-
-A log, identical to a LOG2, is issued for:
-
-- Any nonzero-balance `SELFDESTRUCT` to self by a contract created in the same transaction, at the time the opcode is invoked
-- Any nonzero-balance account marked for deletion, at the time of removal during transaction finalization
-
-Burn logs are emitted after all other logs created by EVM execution and the payment of the [EIP-1559](./eip-1559.md) priority fee to the coinbase. When multiple accounts with nonzero balances are marked for deletion, burn logs are emitted in lexicographical order of account address.
-
-| Field | Value |
-| - | - |
-| `address` emitting log | `0xfffffffffffffffffffffffffffffffffffffffe` ([`SYSTEM_ADDRESS`](./eip-4788.md)) |
-| `topics[0]` | `0xcc16f5dbb4873280815c1ee09dbd06736cffcc184412cf7a71a0fdb75d397ca5` (`keccak256('Burn(address,uint256)')`) |
-| `topics[1]` | `address` (zero prefixed to fill uint256) |
-| `data` | `amount` in Wei (big endian uint256) |
-
 ## Rationale
 
 This is the simplest possible implementation that ensures that all ETH transfers are implemented in some kind of record that can be easily accessed through making RPC calls into a node, or through asking for a Merkle branch that is hashed into the block root. The log type is compatible with the ERC-20 token standard, but does not introduce any overly-specific ERC-20 features (eg. ABI encodings) into the specification.
@@ -68,6 +52,10 @@ Withdrawals were also considered, but they are not attached to a transaction, wh
 
 Clients who wish to provide a unified view for consumers MAY expose a new aggregating RPC.
 
+### ETH burns via `SELFDESTRUCT`
+
+After EIP-8246, ETH can no longer be burned via `SELFDESTRUCT` to self or by sending ETH to an account marked for selfdestruction. Therefore, this EIP does not specify this edge-case.
+
 ## Backwards Compatibility
 
 No backward compatibility issues found.
@@ -79,8 +67,7 @@ No backward compatibility issues found.
 - Transfer logs for `CREATE` / `CREATE2` endowments, initcode behavior, and failure modes
 - Transfer logs for `SELFDESTRUCT` to self vs. a different beneficiary, including pre-existing and cross-tx contracts
 - Log ordering: Transfer logs appear before any EVM-emitted logs in a transaction, and nested-`CALL` Transfer logs appear in chronological call order
-- Burn logs emitted for same-transaction `SELFDESTRUCT` to self
-- Burn logs emitted at transaction finalization, including lexicographic ordering and priority-fee interaction
+- No transfer logs emitted for `SELFDESTRUCT` to self, either same-tx or pre-existing contract.
 - Negative cases where no log is emitted (zero-value, reverts, rolled-back inner calls, fee payments)
 - Transfers to special-purpose addresses (precompiles, the system address, the coinbase)
 - Fork transition behavior at the EIP-7708 activation boundary


### PR DESCRIPTION
Adds EIP-8246 to EIP-7708 as a dependency to remove the ETH Burn logs edge-case completely.