### PR TITLE
Update EIP-2780: Rework as resource-based intrinsic transaction gas

### DIFF
--- a/EIPS/eip-2780.md
+++ b/EIPS/eip-2780.md
@@ -48,7 +48,7 @@ This EIP replaces the constant with a decomposition into named primitives, each 
 
 The following values are referenced from other EIPs and are not final:
 
-- `COLD_ACCOUNT_ACCESS = 3,000` and `CREATE_ACCESS = 8,800`, per [EIP-8038](./eip-8038.md).
+- `COLD_ACCOUNT_ACCESS = 3,000` and `CREATE_ACCESS = 11,000`, per [EIP-8038](./eip-8038.md).
 - `STATE_BYTES_PER_NEW_ACCOUNT × CPSB = 183,600`, per [EIP-8037](./eip-8037.md). This value changes whenever a fork changes `CPSB`.
 
 Regular-gas and state-gas semantics are defined by [EIP-8037](./eip-8037.md).
@@ -98,8 +98,8 @@ Costs are split into regular gas and state gas, per [EIP-8037](./eip-8037.md). "
 | No-transfer to 7702 delegated | `TX_BASE_COST + 2 × COLD_ACCOUNT_ACCESS` + execution | 0 | 18,000 + execution | 0 |
 | ETH transfer to 7702 delegated | `TX_BASE_COST + 2 × COLD_ACCOUNT_ACCESS + TX_VALUE_COST + TRANSFER_LOG_COST` + execution | 0 | 24,000 + execution | 0 |
 | ETH transfer creating new account | `TX_BASE_COST + COLD_ACCOUNT_ACCESS + TX_VALUE_COST + TRANSFER_LOG_COST` | `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` | 21,000 | 183,600 |
-| Create transaction, `tx.value` = 0 | `TX_BASE_COST + CREATE_ACCESS` | `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` | 20,800 | 183,600 |
-| Create transaction, `tx.value` > 0 | `TX_BASE_COST + CREATE_ACCESS + TRANSFER_LOG_COST` | `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` | 22,556 | 183,600 |
+| Create transaction, `tx.value` = 0 | `TX_BASE_COST + CREATE_ACCESS` | `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` | 23,000 | 183,600 |
+| Create transaction, `tx.value` > 0 | `TX_BASE_COST + CREATE_ACCESS + TRANSFER_LOG_COST` | `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` | 24,756 | 183,600 |
 
 ### Interactions with other EIPs
 
@@ -168,8 +168,8 @@ Intrinsic and top-level gas, by case:
 3. Value transfer to an existing EOA: `21,000` regular, `0` state.
 4. Value transfer creating a new account (empty per EIP-161): `21,000` regular, `183,600` state.
 5. Value transfer to a 7702-delegated account: `24,000` regular plus execution.
-6. Contract-creation transaction, `value = 0`: `20,800` regular, `183,600` state.
-7. Contract-creation transaction, `value > 0`: `22,556` regular, `183,600` state.
+6. Contract-creation transaction, `value = 0`: `23,000` regular, `183,600` state.
+7. Contract-creation transaction, `value > 0`: `24,756` regular, `183,600` state.
 8. EIP-7702 transaction: `TX_BASE_COST` is unchanged even when the sender assumes code; access-list and authorization costs are unchanged.
 9. Reverting value transfer to a new account: transaction is valid; the `183,600` state-gas charge is refilled to the reservoir.
 

--- a/EIPS/eip-2780.md
+++ b/EIPS/eip-2780.md
@@ -136,59 +136,63 @@ Upon activation of this EIP, the following parameters of the gas model are updat
 | Name | Definition | Value | Description |
 | :----: | :----: | :----: | :----: |
 | `TX_BASE_COST` | `GAS_PRECOMPILE_ECRECOVER` + `COLD_ACCOUNT_ACCESS` + `ACCOUNT_WRITE` | 12,300 | Base cost of any transaction |
-| `TRANSFER_LOG_COST` | `GAS_LOG` + 3 x `GAS_LOG_TOPIC` + 8 x `GAS_LOG_DATA_PER_BYTE` | 1,756 | Transfer log emitted for every nonzero-value transfer to a different account per [EIP-7708](./eip-7708.md) |
+| `TRANSFER_LOG_COST` | `GAS_LOG` + 3 x `GAS_LOG_TOPIC` + 32 x `GAS_LOG_DATA_PER_BYTE` | 1,756 | Transfer log emitted for every nonzero-value transfer to a different account per [EIP-7708](./eip-7708.md) |
 
-`COLD_ACCOUNT_ACCESS = 2,600` and `ACCOUNT_WRITE = 6,700` are updated in [EIP-8038](eip-8038.md). The current numbers are not yet final.
+`COLD_ACCOUNT_ACCESS = 2,600` and `ACCOUNT_WRITE = 6,700` are updated in [EIP-8038](./eip-8038.md). The current numbers are not yet final.
 
 ### Intrinsic gas costs
 
-A transaction’s intrinsic base cost is decomposed into following explicit primitives:
+A transaction’s intrinsic base cost is decomposed into the following explicit primitives:
 
 - `tx.sender` is charged `TX_BASE_COST` in regular gas, accounting for one ECDSA recovery and the `sender`'s state access + write cost.
 - `tx.to` is charged based on its type:
   - if self-transfer (`tx.sender` = `tx.to`), there are no charges;
   - if a precompile, there are no charges;
+  - if `None` (contract creation transaction), charge `ACCOUNT_WRITE` in regular gas and `STATE_BYTES_PER_NEW_ACCOUNT x CPSB` in state gas;
   - otherwise, charge `COLD_ACCOUNT_ACCESS` in regular gas.
 - `tx.value` is charged based on its value:
   - if zero, there are no charges;
   - if non-zero and self-transfer, there are no charges;
-  - if non-zero and `tx.sender` != `tx.to`, charge `TRANSFER_LOG_COST` + `ACCOUNT_WRITE` in regular gas.
+  - if non-zero and contract creation, charge `TRANSFER_LOG_COST` in regular gas;
+  - otherwise, charge `TRANSFER_LOG_COST` + `ACCOUNT_WRITE` in regular gas.
 
-These charges replace the cost for contract creation (`GAS_CREATE`). All other intrinsic costs (calldata, access list, and authorizations) remain unchanged.
+`ACCOUNT_WRITE = 6,700`, per [EIP-8038](./eip-8038.md). This number is not yet final.
 
-Regular gas semantics are derived from [EIP-8037](eip-8037.md).
+`STATE_BYTES_PER_NEW_ACCOUNT x CPSB` is set to `183,600`, per [EIP-8037](./eip-8037.md). This value can be updated by a fork when changing `CPSB`.
+
+Regular gas and state gas semantics are derived from [EIP-8037](./eip-8037.md).
+
+These charges replace the contract creation transaction charges. All other intrinsic costs (calldata, access list, and authorizations) remain unchanged.
 
 ### Transaction's top-level gas costs
 
 During EVM execution, before any opcode is executed, the recipient account is loaded and the following gas costs are charged:
 
-- if `tx.to` is empty (`tx.to == Bytes0(b"")`) and `tx.value > 0`:
-  - charge `CALL_VALUE` in regular gas, and
-  - charge `STATE_BYTES_PER_NEW_ACCOUNT x CPSB` in state gas;
+- If recipient is empty per [EIP-161](./eip-161.md) and `tx.value > 0`, charge `STATE_BYTES_PER_NEW_ACCOUNT x CPSB` in state gas;
+- if recipient is an [EIP-7702](./eip-7702.md) delegated account, charge `COLD_ACCOUNT_ACCESS` in regular gas;
 - otherwise, there are no charges.
 
-`CALL_VALUE` is defined as `ACCOUNT_WRITE + CALL_STIPEND = 9000`, per [EIP-8038](eip-8038.md). This number is not yet final.
+`STATE_BYTES_PER_NEW_ACCOUNT x CPSB` is set to `183,600`, per [EIP-8037](./eip-8037.md). This value can be updated by a fork when changing `CPSB`. Regular gas and state gas semantics are derived from [EIP-8037](./eip-8037.md).
 
-`STATE_BYTES_PER_NEW_ACCOUNT x CPSB` is set to `183,600`, per [EIP-8037](eip-8037.md). This value can be updated by a fork when changing `CPSB`. Regular gas and state gas semantics are derived from [EIP-8037](eip-8037.md).
-
-If the transaction reverts at this point, it is still valid. In this case, `STATE_BYTES_PER_NEW_ACCOUNT x CPSB` is not charged and refilled back to the `state_gas_reservoir`, per [EIP-8037](eip-8037.md).
+If the transaction reverts at this point, it is still valid. In this case, `STATE_BYTES_PER_NEW_ACCOUNT x CPSB` is not charged and refilled back to the `state_gas_reservoir`, per [EIP-8037](./eip-8037.md). This is valid for both contract creation transactions and ETH transfers with value to new accounts.
 
 ### Transaction reference cases
 
 | Case | Formula | Total Cost |
 | :----: | :----: | :----: |
 | ETH transfer to self | `TX_BASE_COST` | 12,300 |
-| ETH transfer to precompile | `TX_BASE_COST` | 12,300 |
+| No-transfer to precompile | `TX_BASE_COST` | 12,300 |
+| ETH transfer to precompile | `TX_BASE_COST` + `ACCOUNT_WRITE` + `TRANSFER_LOG_COST` | 20,756 |
 | No-transfer to EOA | `TX_BASE_COST` + `COLD_ACCOUNT_ACCESS` | 14,900 |
 | No-transfer to empty account | `TX_BASE_COST` + `COLD_ACCOUNT_ACCESS` | 14,900 |
 | ETH Transfer to existing EOA | `TX_BASE_COST` + `COLD_ACCOUNT_ACCESS` + `ACCOUNT_WRITE` + `TRANSFER_LOG_COST` | 23,356 |
 | No-transfer to contract | `TX_BASE_COST` + `COLD_ACCOUNT_ACCESS` + **execution** | 14,900 + **execution** |
 | ETH Transfer to contract | `TX_BASE_COST` + `COLD_ACCOUNT_ACCESS` + `ACCOUNT_WRITE` + `TRANSFER_LOG_COST` + **execution** | 23,356 + **execution** |
-| No-transfer to 7702 delegated | `TX_BASE_COST` + `COLD_ACCOUNT_ACCESS` + **execution** | 14,900 + **execution** |
-| ETH Transfer to 7702 delegated | `TX_BASE_COST` + `COLD_ACCOUNT_ACCESS` + `ACCOUNT_WRITE` + `TRANSFER_LOG_COST` + **execution** | 23,356 + **execution** |
-| ETH Transfer creating new account | `TX_BASE_COST` + `COLD_ACCOUNT_ACCESS` + `ACCOUNT_WRITE` + `GAS_NEW_ACCOUNT` + `TRANSFER_LOG_COST` | 206,956 |
-
-Note that in ETH transfers that create new account, an additional `CALL_STIPEND = 2300` is charged before entering the `CREATE` frame and added to the call's `gas_left`. This amount in not considered as cost as it can be spent inside the call frame and returned in case it is not used.
+| No-transfer to 7702 delegated | `TX_BASE_COST` + 2 x `COLD_ACCOUNT_ACCESS` + **execution** | 17,500 + **execution** |
+| ETH Transfer to 7702 delegated | `TX_BASE_COST` + 2 x `COLD_ACCOUNT_ACCESS` + `ACCOUNT_WRITE` + `TRANSFER_LOG_COST` + **execution** | 25,956 + **execution** |
+| Create transaction with `tx.value` = 0 | `TX_BASE_COST` + `ACCOUNT_WRITE` + `STATE_BYTES_PER_NEW_ACCOUNT x CPSB` | 202,600 |
+| Create transaction with `tx.value` > 0 | `TX_BASE_COST` + `ACCOUNT_WRITE` + `STATE_BYTES_PER_NEW_ACCOUNT x CPSB` + `TRANSFER_LOG_COST` | 204,356 |
+| ETH Transfer creating new account | `TX_BASE_COST` + `COLD_ACCOUNT_ACCESS` + `ACCOUNT_WRITE` + `STATE_BYTES_PER_NEW_ACCOUNT x CPSB` + `TRANSFER_LOG_COST` | 206,956 |
 
 ### Edits and interactions with other EIPs
 
@@ -196,7 +200,7 @@ Note that in ETH transfers that create new account, an additional `CALL_STIPEND 
 - **Calldata-pricing EIPs (e.g. [EIP-7623](./eip-7623.md)).** Unchanged. This EIP does not alter calldata pricing.
 - **[EIP-7702](./eip-7702.md) (Set EOA Code).** `TX_BASE_COST` remains `12,300` even if the sender temporarily assumes code for the transaction. Clients must not perform any disk code-load to determine sender type, since 7702 provides code inline. If the transaction executes code that reads or executes its own code, normal `COLD_ACCOUNT_ACCESS` or `WARM_ACCESS` costs apply at execution time as per the standard cold/warm model. When `tx.to` is a 7702-delegated account, it is charged `COLD_ACCOUNT_ACCESS` at the intrinsic level. Resolving the delegation requires loading code from the delegation target, which incurs its own `COLD_ACCOUNT_ACCESS` if the target is cold, or `WARM_ACCESS` if already warm. This also applies to calls made to delegated accounts.
 - **[EIP-7708](./eip-7708.md) (ETH transfers emit a log).** EIP-7708 emits a LOG3-shaped transfer event on every non-zero-value ETH transfer to a different account, and a LOG2-shaped burn event when ETH leaves circulation. Under the legacy `21,000` intrinsic base, the LOG3 cost of a transfer event was implicitly absorbed; with `TX_BASE_COST` reduced to `12,300`, that subsidy disappears, and each emission must be priced explicitly. This EIP charges `TRANSFER_LOG_COST = 1,756` (LOG3 equivalent: `375 + 3×375 + 32×8`) at intrinsic gas computation for top-level value-transferring transactions.
-- **[EIP-7928](./eip-7928.md) (Block-Level Access Lists).** The intrinsic costs already account for accessing the sender and recipient accounts. Thefore, these accounts should be included in the BAL even in cases where the transaction reverts.
+- **[EIP-7928](./eip-7928.md) (Block-Level Access Lists).** The intrinsic costs already account for accessing the sender and recipient accounts. Therefore, these accounts should be included in the BAL even in cases where the transaction reverts.
 
 ## Rationale
 

--- a/EIPS/eip-2780.md
+++ b/EIPS/eip-2780.md
@@ -82,7 +82,7 @@ During execution, before any opcode is executed, the recipient account is loaded
 
 These charges are evaluated **after** [EIP-7702](./eip-7702.md) authorizations are applied. A `tx.to` whose account is materialized by an authorization in the same transaction is therefore no longer EIP-161-empty when this phase runs, so the new-account state charge does not fire; that account's creation is already priced by the authorization's `PER_EMPTY_ACCOUNT_COST`.
 
-If the transaction reverts at this point, it remains valid. In that case `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` is not charged and is refilled to the `state_gas_reservoir`, per [EIP-8037](./eip-8037.md). This applies to both contract-creation transactions and value transfers to new accounts.
+If a contract-creation transaction's initcode reverts, the transaction remains valid. In that case `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` is not charged and is refilled to the `state_gas_reservoir`, per [EIP-8037](./eip-8037.md). A plain value transfer to a new account executes no code and so cannot revert; its new-account state charge is therefore never rolled back this way.
 
 ### Transaction reference cases
 
@@ -171,7 +171,7 @@ Intrinsic and top-level gas, by case:
 6. Contract-creation transaction, `value = 0`: `23,000` regular, `183,600` state.
 7. Contract-creation transaction, `value > 0`: `24,756` regular, `183,600` state.
 8. EIP-7702 transaction: `TX_BASE_COST` is unchanged even when the sender assumes code; access-list and authorization costs are unchanged.
-9. Reverting value transfer to a new account: transaction is valid; the `183,600` state-gas charge is refilled to the reservoir.
+9. Contract-creation transaction whose initcode reverts (value-bearing or not): the transaction remains valid; the `183,600` new-account state-gas charge is refilled to the reservoir.
 
 Blocks of pure ETH transfers should be tested across all EL clients (e.g. on Perfnet) to confirm the pricing matches measured runtimes at the chosen throughput anchor.
 

--- a/EIPS/eip-2780.md
+++ b/EIPS/eip-2780.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2020-07-11
-requires: 1559, 2718, 2929, 2930, 7904, 7708, 8037, 8038
+requires: 1559, 2718, 2929, 2930, 7708, 7904, 8037, 8038
 ---
 
 ## Abstract

--- a/EIPS/eip-2780.md
+++ b/EIPS/eip-2780.md
@@ -1,344 +1,185 @@
 ---
 eip: 2780
-title: Reduce intrinsic transaction gas
-description: Reduce intrinsic transaction gas and charge 25k when a value transfer creates a new account
+title: Resource-based intrinsic transaction gas
+description: Decompose the flat intrinsic transaction cost into explicit primitives priced to match the resources a transaction actually consumes
 author: Matt Garnett (@lightclient), Uri Klarman (@uriklarman), Ben Adams (@benaadams), Maria Inês Silva (@misilva73), Anders Elowsson (@anderselowsson), Anthony Sassano (@sassal)
 discussions-to: https://ethereum-magicians.org/t/eip-2780-reduce-intrinsic-cost-of-transactions/4413
 status: Draft
 type: Standards Track
 category: Core
 created: 2020-07-11
-requires: 1559, 2718, 2929, 2930, 7708, 7904, 8037, 8038
+requires: 161, 2718, 2929, 2930, 6780, 7702, 7708, 7904, 7928, 8037, 8038
 ---
 
 ## Abstract
 
-Reduce the intrinsic cost `TX_BASE_COST` from `21,000` to `4,500` and define a consistent gas accounting model based on actual state operations. This more granular approach makes a simple ETH transfer `7,756` due to additional costs related to the `to` account and the [EIP-7708](./eip-7708.md) transfer log.
+This EIP decomposes the flat `21,000` intrinsic transaction cost into explicit primitives, each priced to match the resources a transaction actually consumes:
 
-If a non-create transaction has `value > 0` and targets a non-existent account, charge `GAS_NEW_ACCOUNT = 25,000` to align with `CALL` account creation and price in state growth. When this surcharge applies, the recipient pays exactly one cold non-code touch; no code-load cost applies.
+- `TX_BASE_COST = 12,000` — ECDSA recovery plus the sender account's access and write.
+- `COLD_ACCOUNT_ACCESS = 3,000` — the recipient account touch, per [EIP-8038](./eip-8038.md).
+- `TX_VALUE_COST = 4,244` — the recipient balance write performed by a value transfer.
+- `TRANSFER_LOG_COST = 1,756` — the [EIP-7708](./eip-7708.md) transfer log.
 
-This EIP does not change calldata or access-list metering. It also refines related gas schedule items used in derivation and execution accounting:
+A plain ETH transfer to an existing account still costs `12,000 + 3,000 + 4,244 + 1,756 = 21,000` gas. The headline number is unchanged, but it is now built from measured components rather than a single legacy constant, so each transaction pays for the work it does and nothing it does not.
 
-- Split cold-account touches into `COLD_ACCOUNT_COST_CODE = 2,600` and `COLD_ACCOUNT_COST_NOCODE = 500`.
-- Introduce `STATE_UPDATE = 1,000` as the price of a single account-leaf write.
-- Reprice value-moving calls as account-leaf writes, replacing `CALL_VALUE_COST = 9,000` with `CALL_VALUE_COST = 2 * STATE_UPDATE + TRANSFER_LOG_COST = 3,756`.
-- Charge `TRANSFER_LOG_COST = 1,756` for the [EIP-7708](./eip-7708.md) transfer log emitted on every nonzero-value transfer to a different account.
+Transactions that grow the state — value transfers that create a new account and contract-creation transactions — additionally pay `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` in state gas, per [EIP-8037](./eip-8037.md). These transactions therefore cost more than `21,000`, internalizing the cost of state growth that the flat base previously left unpriced.
 
-Capacity impact (illustrative):
-
-| Metric                      |            Result |  Change | Description                                                  |
-| --------------------------- | ----------------: | ------: |------------------------------------------------------------- |
-| Max (minimal txs)           | 13,333 tx / block |   +367% | 4,500-gas minimal transactions per 60 M block                |
-| Max (ETH transfers)         |  7,735 tx / block |   +171% | 7,756-gas ETH transfers per 60 M block                       |
-| Throughput (minimal txs)    |        ~1,111 TPS |   +367% | 4,500-gas minimal transactions per 60 M block per 12sec      |
-| Throughput (ETH transfers)  |          ~645 TPS |   +171% | 7,756-gas ETH transfers per 60 M block per 12sec             |
-| Equivalent gas-limit uplift |          ≈ +20.8% |       - | Effective throughput gain for avg tx usage (e.g., 60 M => ~72.5 M) |
+This EIP does not change calldata, access-list, or authorization metering.
 
 ## Motivation
 
-**Monetary Context**
+The flat `21,000` intrinsic cost charges every transaction the same amount regardless of what it does. A zero-value transaction to an existing account and a value transfer that creates a new account both pay `21,000`, even though the latter touches an extra account, writes an extra balance, emits a log, and permanently grows the state. The single constant both over-prices the simplest paths and under-prices the ones that consume real, lasting resources.
 
-Money has three basic functions: a unit of account, a medium of exchange, and a store of value. ETH already meets the last two by design. It carries value without an issuer and settles with finality. Where it falls short is in everyday exchange - the friction of use rather than the nature of the asset.
+This EIP replaces the constant with a decomposition into named primitives, each priced to the resource it represents. The goal is to make every transaction's intrinsic cost reflect its actual work:
 
-ETH underpins most onchain liquidity. Pairs are denominated in it, and gas is paid in it - a de-facto tax base that anchors value. Bitcoin's monetary role now runs mainly through exchange pairs, hence its drift in focus to store-of-value rather than medium-of-exchange. ETH still clears real activity onchain, yet outside NFTs few people think in ETH terms. In that niche ETH already functions as both unit and medium, but only for high-value items.
-
-For ETH to operate fully as money, it must also handle small transactions. That was impractical when gas sat at 300 gwei, or even 90 gwei on quiet weekends. Post-4844, blobs absorb L2's "pay at any price" data and higher gas limits ease congestion; cost, not capacity, is the bottleneck.
-
-EIP-2780 lowers that fixed cost. By aligning the base gas with the real work of a transaction and by correcting `CALL` value pricing, it removes the legacy penalty on simple payments. Small transfers become viable again without subsidising calldata or storage. The same logic charges properly for new-account creation, so state growth remains priced in.
-
-- **Unit of account:** When transfers are cheap and regular, people price in ETH because they use it directly. This proposal turns that habit into equilibrium rather than idealism.
-
-- **Medium of exchange:** Reducing `TX_BASE_COST` eliminates the old friction that slowed native circulation. Settlement becomes frequent, not occasional.
-
-- **Store of value:** Honest pricing reinforces confidence that ETH's cost structure is grounded in real computation, not arbitrary constants.
-
-- **Velocity:** Lower friction raises the rate of final settlement; more frequent, smaller clears in native ETH, without altering calldata or storage economics.
-
-- **Monetary competition:** Stablecoins and LSTs are welcome, but they compete for onchain "moneyness". Making native ETH easy to spend keeps it central; not just the fuel, but the money of the system.
-
-**Note:** This proposal doesn't target ETH specifically, the lower base cost applies to every transaction type. However since `TX_BASE_COST` makes up nearly all of an ETH transfer's gas, while it's only a small fraction of contract calls, ETH loses the most friction and gains the most velocity.
-
-**Specifics**
-
-The legacy `21,000` base no longer matches the universal work path under warm/cold accounting. Decomposed into signature recovery, one account-leaf write for the sender (nonce + balance coalesced), and one cold non-code touch (sender), the universal path totals `4,500` gas.
-
-State growth is underpriced for top-level value transfers that create accounts, while `CALL` pays explicit creation. Charging `25,000` when a transfer creates an account aligns entry points and internalizes state growth.
-
-A lower base removes the distortion that over-incentivized batching solely to dodge `TX_BASE_COST`, without subsidizing calldata or storage. The refinement of value-transfer costs and cold-account pricing makes execution charges proportional to actual state work: account touches and leaf writes.
-
-We intentionally do **not** charge per-byte gas for the transaction envelope (`nonce`, `gas*`, `to`, `value`, `v`, `r`, `s`). Calldata pricing applies only to `tx.data`. A plain ETH payment has empty `tx.data`, so it pays zero calldata gas. Lowering `TX_BASE_COST` to the universal work path makes ETH payments cheaper without subsidizing arbitrary calldata.
-
-### Throughput, payload, and basefee dynamics
-
-This EIP affects three independent levers:
-
-1. **Gas-limit equivalence:** Reducing the base cost from `21,000` to `4,500` increases transaction capacity at a fixed block gaslimit by approximately +20.8%.
-
-2. **Payload-size bounds:** Per [EIP-7934](./eip-7934.md) the execution payload cap is `MAX_RLP_BLOCK_SIZE = 10,485,760 - 2,097,152 = 8,388,608` bytes. Payload size, not gas, may become the dominant block-size constraint at high gaslimits.
-
-3. **Basefee market dynamics:** Lower intrinsic gas reduces the average gas per tx, temporarily increasing utilisation and causing short-term downward adjustment in basefee. Over time, equilibrium restores as inclusion policies adapt.
-
-These levers are independent; this proposal changes only intrinsic gas, not calldata metering or access-list pricing.
-
-### Monetary Effects
-
-Reducing ETH transfer cost from `21,000` => `7,756` gas increases both transaction frequency and viable payment granularity. At a fixed basefee, smaller payments become economical, raising the **velocity of money** - how often ETH changes hands on L1.
-
-Let $g$ be gas per transaction, $b$ the basefee (in gwei), and $r$ the user's tolerated fee share of payment value.
-
-$v_{\text{min}} = \frac{g \times b \times 10^{-9}}{r}$
-
-Since $g$ drops from $21,000$ to $7,756$:
-
-$\frac{v_{\text{min,new}}}{v_{\text{min,old}}} = \frac{7{,}756}{21{,}000} \approx 0.37$
-
-The minimum economical L1 payment falls by about **63 %**, allowing more, smaller transfers to clear directly in ETH.
-
-From the quantity relation $M V = P Q$, with $M$ and $P$ roughly constant over short periods:
-
-$V_{\text{new}} / V_{\text{old}} \approx Q_{\text{new}} / Q_{\text{old}}$
-
-Pure ETH-transfer capacity rises roughly **2.7x** (+171 %), and the lower $v_{\text{min}}$ further increases $Q$ as more small-value payments become viable.
-
-Together these effects lift $V$, more frequent, smaller, native settlements without changing monetary supply.
-
-ETH thus gains moneyness:
-
-- **Medium of exchange:** direct use becomes routine, not exceptional.
-- **Unit of account:** frequent native settlement encourages ETH-denominated pricing.
-- **Store of value:** workload-based fees reinforce trust in cost realism.
-
-Price volatility may still lead users to prefer stablecoins for predictability, but this change removes unnecessary friction, restoring ETH’s competitiveness wherever volatility is tolerable.
-
-The `25,000` surcharge for new-account creation continues to price state growth honestly while everyday transfers become cheaper and faster.
-
-### Equivalent gas-limit increase
-
-Lowering `TX_BASE_COST` from `21,000` to `4,500` removes up to `16,500` gas per transaction. Using recent totals of 163 Ggas/day and 1.7 M tx/day:
-
-| Metric                       | Calculation     | Result          | Change    |
-| ---------------------------- | ---------------:| ---------------:| ---------:|
-| Avg gas per tx               | 163Bn / 1.7M    | ≈ 95,882 gas    | -         |
-| New avg gas per tx           | 95,882 − 16,500 | ≈ 79,382 gas    | -         |
-| Throughput at fixed gaslimit | 95,882 / 79,382 | ≈ x1.208        | +20.08%   |
-| Daily tx at same gas usage   | 1.7M × 1.208    | ≈ 2.053M tx/day | +340k/day |
-
-Perfnet measurements show EL clients handle >300 MGas/s for pure ETH transfers. Expressed under a 4.5k base this corresponds to `300 * (4.5/21) ~ 64.3 MGas/s`, i.e. `~771 MGas` per 12 s slot. This indicates sufficient headroom and that the current base is significantly overcharged, so no extra engineering is required to improve performance to support this change.
-
-Net effect equals raising a 45 M gas limit to ~54.4 M at unchanged calldata and access-list metering. This directly advances Scaling L1.
+- **Accuracy.** Signature recovery, account accesses, account writes, the transfer log, and state creation are billed separately, so cost tracks usage.
+- **State growth is internalized.** A value transfer that creates an account, like a contract-creation transaction, pays `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` in state gas. This aligns top-level value transfers with internal `CALL`-based account creation, which already pays for the new leaf, and prices the durable state cost the flat base ignored.
+- **Composability.** Pricing intrinsic cost as a sum of the same primitives used elsewhere in the gas schedule lets future repricings (e.g. of cold-account access in [EIP-8038](./eip-8038.md), or of state bytes in [EIP-8037](./eip-8037.md)) flow through automatically, without re-deriving a bespoke constant.
 
 ## Specification
 
-### Parameter changes
+### Parameters
 
-Upon activation of this EIP, the following parameters of the gas model are updated:
+| Name | Value | Definition |
+| :----: | :----: | :---- |
+| `TX_BASE_COST` | 12,000 | Sender cost: ECDSA recovery, the sender's account access, and the sender's account write |
+| `TX_VALUE_COST` | 4,244 | Recipient balance write performed by a value transfer |
+| `TRANSFER_LOG_COST` | 1,756 | [EIP-7708](./eip-7708.md) transfer log: `GAS_LOG + 3 × GAS_LOG_TOPIC + 32 × GAS_LOG_DATA_PER_BYTE` |
 
-| Name | Definition | Value | Description |
-| :----: | :----: | :----: | :----: |
-| `TX_BASE_COST` | `GAS_PRECOMPILE_ECRECOVER` + `COLD_ACCOUNT_ACCESS` + `ACCOUNT_WRITE` | 12,300 | Base cost of any transaction |
-| `TRANSFER_LOG_COST` | `GAS_LOG` + 3 x `GAS_LOG_TOPIC` + 32 x `GAS_LOG_DATA_PER_BYTE` | 1,756 | Transfer log emitted for every nonzero-value transfer to a different account per [EIP-7708](./eip-7708.md) |
+The following values are referenced from other EIPs and are not final:
 
-`COLD_ACCOUNT_ACCESS = 2,600` and `ACCOUNT_WRITE = 6,700` are updated in [EIP-8038](./eip-8038.md). The current numbers are not yet final.
+- `COLD_ACCOUNT_ACCESS = 3,000` and `CREATE_ACCESS = 8,800`, per [EIP-8038](./eip-8038.md).
+- `STATE_BYTES_PER_NEW_ACCOUNT × CPSB = 183,600`, per [EIP-8037](./eip-8037.md). This value changes whenever a fork changes `CPSB`.
+
+Regular-gas and state-gas semantics are defined by [EIP-8037](./eip-8037.md).
 
 ### Intrinsic gas costs
 
-A transaction’s intrinsic base cost is decomposed into the following explicit primitives:
+A transaction's intrinsic base cost is decomposed into the following explicit primitives:
 
-- `tx.sender` is charged `TX_BASE_COST` in regular gas, accounting for one ECDSA recovery and the `sender`'s state access + write cost.
+- `tx.sender` is charged `TX_BASE_COST` in regular gas, accounting for one ECDSA recovery and the sender's account access and write.
 - `tx.to` is charged based on its type:
-  - if self-transfer (`tx.sender` = `tx.to`), there are no charges;
-  - if a precompile, there are no charges;
-  - if `None` (contract creation transaction), charge `CREATE_ACCESS` in regular gas and `STATE_BYTES_PER_NEW_ACCOUNT x CPSB` in state gas;
+  - if self-transfer (`tx.sender == tx.to`), there are no charges;
+  - if `None` (contract-creation transaction), charge `CREATE_ACCESS` in regular gas and `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` in state gas;
   - otherwise, charge `COLD_ACCOUNT_ACCESS` in regular gas.
 - `tx.value` is charged based on its value:
   - if zero, there are no charges;
   - if non-zero and self-transfer, there are no charges;
   - if non-zero and contract creation, charge `TRANSFER_LOG_COST` in regular gas;
-  - otherwise, charge `TRANSFER_LOG_COST` + `ACCOUNT_WRITE` in regular gas.
+  - otherwise, charge `TRANSFER_LOG_COST + TX_VALUE_COST` in regular gas.
 
-`ACCOUNT_WRITE = 6,700` and `CREATE_ACCESS = 9,300`, per [EIP-8038](./eip-8038.md). These numbers are not yet final.
+The `tx.sender`, `tx.to`, and (where applicable) delegation-target charges above are always at the cold rate. Access lists do not warm these transaction-level accounts; access-list warming applies only to subsequent execution-level touches.
 
-`STATE_BYTES_PER_NEW_ACCOUNT x CPSB` is set to `183,600`, per [EIP-8037](./eip-8037.md). This value can be updated by a fork when changing `CPSB`.
-
-Regular gas and state gas semantics are derived from [EIP-8037](./eip-8037.md).
-
-These charges replace the contract creation transaction charges. All other intrinsic costs (calldata, access list, and authorizations) remain unchanged.
+These charges replace the contract-creation transaction charges. All other intrinsic costs (calldata, access list, and authorizations) remain unchanged.
 
 ### Transaction's top-level gas costs
 
-During EVM execution, before any opcode is executed, the recipient account is loaded and the following gas costs are charged:
+During execution, before any opcode is executed, the recipient account is loaded and the following gas costs are charged:
 
-- If recipient is empty per [EIP-161](./eip-161.md) and `tx.value > 0`, charge `STATE_BYTES_PER_NEW_ACCOUNT x CPSB` in state gas;
-- if recipient is an [EIP-7702](./eip-7702.md) delegated account, charge an additional `COLD_ACCOUNT_ACCESS` in regular gas;
+- if the recipient is empty per [EIP-161](./eip-161.md) and `tx.value > 0`, charge `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` in state gas;
+- if the recipient is an [EIP-7702](./eip-7702.md) delegated account, charge an additional `COLD_ACCOUNT_ACCESS` in regular gas;
 - otherwise, there are no charges.
 
-`STATE_BYTES_PER_NEW_ACCOUNT x CPSB` is set to `183,600`, per [EIP-8037](./eip-8037.md). This value can be updated by a fork when changing `CPSB`. Regular gas and state gas semantics are derived from [EIP-8037](./eip-8037.md).
+These charges are evaluated **after** [EIP-7702](./eip-7702.md) authorizations are applied. A `tx.to` whose account is materialized by an authorization in the same transaction is therefore no longer EIP-161-empty when this phase runs, so the new-account state charge does not fire; that account's creation is already priced by the authorization's `PER_EMPTY_ACCOUNT_COST`.
 
-If the transaction reverts at this point, it is still valid. In this case, `STATE_BYTES_PER_NEW_ACCOUNT x CPSB` is not charged and refilled back to the `state_gas_reservoir`, per [EIP-8037](./eip-8037.md). This is valid for both contract creation transactions and ETH transfers with value to new accounts.
+If the transaction reverts at this point, it remains valid. In that case `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` is not charged and is refilled to the `state_gas_reservoir`, per [EIP-8037](./eip-8037.md). This applies to both contract-creation transactions and value transfers to new accounts.
 
 ### Transaction reference cases
 
-| Case | Formula | Total Cost |
-| :----: | :----: | :----: |
-| ETH transfer to self | `TX_BASE_COST` | 12,300 |
-| No-transfer to precompile | `TX_BASE_COST` | 12,300 |
-| ETH transfer to precompile | `TX_BASE_COST` + `ACCOUNT_WRITE` + `TRANSFER_LOG_COST` | 20,756 |
-| No-transfer to EOA | `TX_BASE_COST` + `COLD_ACCOUNT_ACCESS` | 14,900 |
-| No-transfer to empty account | `TX_BASE_COST` + `COLD_ACCOUNT_ACCESS` | 14,900 |
-| ETH Transfer to existing EOA | `TX_BASE_COST` + `COLD_ACCOUNT_ACCESS` + `ACCOUNT_WRITE` + `TRANSFER_LOG_COST` | 23,356 |
-| No-transfer to contract | `TX_BASE_COST` + `COLD_ACCOUNT_ACCESS` + **execution** | 14,900 + **execution** |
-| ETH Transfer to contract | `TX_BASE_COST` + `COLD_ACCOUNT_ACCESS` + `ACCOUNT_WRITE` + `TRANSFER_LOG_COST` + **execution** | 23,356 + **execution** |
-| No-transfer to 7702 delegated | `TX_BASE_COST` + 2 x `COLD_ACCOUNT_ACCESS` + **execution** | 17,500 + **execution** |
-| ETH Transfer to 7702 delegated | `TX_BASE_COST` + 2 x `COLD_ACCOUNT_ACCESS` + `ACCOUNT_WRITE` + `TRANSFER_LOG_COST` + **execution** | 25,956 + **execution** |
-| Create transaction with `tx.value` = 0 | `TX_BASE_COST` + `CREATE_ACCESS` + `STATE_BYTES_PER_NEW_ACCOUNT x CPSB` | 205,200 |
-| Create transaction with `tx.value` > 0 | `TX_BASE_COST` + `CREATE_ACCESS` + `STATE_BYTES_PER_NEW_ACCOUNT x CPSB` + `TRANSFER_LOG_COST` | 206,956 |
-| ETH Transfer creating new account | `TX_BASE_COST` + `COLD_ACCOUNT_ACCESS` + `ACCOUNT_WRITE` + `STATE_BYTES_PER_NEW_ACCOUNT x CPSB` + `TRANSFER_LOG_COST` | 206,956 |
+Costs are split into regular gas and state gas, per [EIP-8037](./eip-8037.md). "execution" denotes contract execution charged at the standard schedule.
 
-### Edits and interactions with other EIPs
+| Case | Regular gas | State gas | Regular gas value | State gas value |
+| :---- | :---- | :---- | :----: | :----: |
+| ETH transfer to self | `TX_BASE_COST` | 0 | 12,000 | 0 |
+| No-transfer to EOA / empty account | `TX_BASE_COST + COLD_ACCOUNT_ACCESS` | 0 | 15,000 | 0 |
+| No-transfer to contract | `TX_BASE_COST + COLD_ACCOUNT_ACCESS` + execution | 0 | 15,000 + execution | 0 |
+| ETH transfer to existing EOA | `TX_BASE_COST + COLD_ACCOUNT_ACCESS + TX_VALUE_COST + TRANSFER_LOG_COST` | 0 | 21,000 | 0 |
+| ETH transfer to contract | `TX_BASE_COST + COLD_ACCOUNT_ACCESS + TX_VALUE_COST + TRANSFER_LOG_COST` + execution | 0 | 21,000 + execution | 0 |
+| No-transfer to 7702 delegated | `TX_BASE_COST + 2 × COLD_ACCOUNT_ACCESS` + execution | 0 | 18,000 + execution | 0 |
+| ETH transfer to 7702 delegated | `TX_BASE_COST + 2 × COLD_ACCOUNT_ACCESS + TX_VALUE_COST + TRANSFER_LOG_COST` + execution | 0 | 24,000 + execution | 0 |
+| ETH transfer creating new account | `TX_BASE_COST + COLD_ACCOUNT_ACCESS + TX_VALUE_COST + TRANSFER_LOG_COST` | `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` | 21,000 | 183,600 |
+| Create transaction, `tx.value` = 0 | `TX_BASE_COST + CREATE_ACCESS` | `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` | 20,800 | 183,600 |
+| Create transaction, `tx.value` > 0 | `TX_BASE_COST + CREATE_ACCESS + TRANSFER_LOG_COST` | `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` | 22,556 | 183,600 |
 
-- **[EIP-2930](./eip-2930.md) (Access List).** Access lists keep their existing per-entry charges and warming semantics.
-- **Calldata-pricing EIPs (e.g. [EIP-7623](./eip-7623.md)).** Unchanged. This EIP does not alter calldata pricing.
-- **[EIP-7702](./eip-7702.md) (Set EOA Code).** `TX_BASE_COST` remains `12,300` even if the sender temporarily assumes code for the transaction. Clients must not perform any disk code-load to determine sender type, since 7702 provides code inline. If the transaction executes code that reads or executes its own code, normal `COLD_ACCOUNT_ACCESS` or `WARM_ACCESS` costs apply at execution time as per the standard cold/warm model. When `tx.to` is a 7702-delegated account, it is charged `COLD_ACCOUNT_ACCESS` at the intrinsic level. Resolving the delegation requires loading code from the delegation target, which incurs its own `COLD_ACCOUNT_ACCESS` if the target is cold, or `WARM_ACCESS` if already warm. This also applies to calls made to delegated accounts.
-- **[EIP-7708](./eip-7708.md) (ETH transfers emit a log).** EIP-7708 emits a LOG3-shaped transfer event on every non-zero-value ETH transfer to a different account, and a LOG2-shaped burn event when ETH leaves circulation. Under the legacy `21,000` intrinsic base, the LOG3 cost of a transfer event was implicitly absorbed; with `TX_BASE_COST` reduced to `12,300`, that subsidy disappears, and each emission must be priced explicitly. This EIP charges `TRANSFER_LOG_COST = 1,756` (LOG3 equivalent: `375 + 3×375 + 32×8`) at intrinsic gas computation for top-level value-transferring transactions.
-- **[EIP-7928](./eip-7928.md) (Block-Level Access Lists).** The intrinsic costs already account for accessing the sender and recipient accounts. Therefore, these accounts should be included in the BAL even in cases where the transaction reverts.
+### Interactions with other EIPs
+
+- **[EIP-2929](./eip-2929.md) (warm/cold accounting).** The transaction-level `tx.sender`, `tx.to`, and delegation-target charges are always cold and are not reduced by an access list. The standard EIP-2929 warm/cold model still applies to execution-level account touches, including internal `CALL`s.
+- **[EIP-2930](./eip-2930.md) (access lists).** Access lists keep their existing per-entry charges and warming semantics for execution-level touches.
+- **[EIP-7702](./eip-7702.md) (set EOA code).** `TX_BASE_COST` is unchanged even when the sender temporarily assumes code; clients must not perform a disk code load to classify the sender, since EIP-7702 provides the code inline. When `tx.to` is a delegated account, resolving the delegation loads the target's code, charged `COLD_ACCOUNT_ACCESS` on first touch or warm thereafter, following the standard EIP-2929 `accessed_addresses` model. Setting a delegation (writing the 23-byte pointer) is distinct from resolving one (reading the target's code); the resolution charge is genuine work and is not prepaid by the authorization.
+- **[EIP-7708](./eip-7708.md) (ETH transfers emit a log).** Every non-zero-value transfer to a different account emits a transfer log, priced explicitly as `TRANSFER_LOG_COST` rather than absorbed into the base.
+- **[EIP-7928](./eip-7928.md) (block-level access lists).** Intrinsic costs already account for accessing `tx.sender` and `tx.to`, so these accounts are included in the BAL even when the transaction reverts.
 
 ## Rationale
 
-Price only what every transaction always does: ECDSA recovery, warming `sender` and `to`, and one account-leaf write for the sender (nonce + balance change). That sums to `4,500` gas. Anything not universal should be metered separately.
+### Pricing only the work each transaction does
 
-Calldata remains metered per byte. No calldata allowance is folded into the base. This reinforces ETH as money and payments: a plain ETH transfer carries no calldata, executes no bytecode, and touches no contract storage slots. It adds exactly one recipient touch (when not a smart contract), one recipient leaf write, and one [EIP-7708](./eip-7708.md) transfer log, so its total is `7,756`.
+The decomposition charges each primitive once, where the resource is consumed: signature recovery and the sender's access and write in `TX_BASE_COST`; the recipient touch in `COLD_ACCOUNT_ACCESS`; the recipient balance write in `TX_VALUE_COST`; the transfer log in `TRANSFER_LOG_COST`; and durable state creation in `STATE_BYTES_PER_NEW_ACCOUNT × CPSB`. A zero-value transaction pays only for the touches it makes, while a value transfer that creates an account pays for the new leaf it adds. This removes the cross-subsidy in the flat base, where simple transactions overpaid and state-creating ones underpaid.
 
-The `GAS_NEW_ACCOUNT` surcharge does not apply to `CREATE`/`CREATE2`: the `GAS_CREATE = 32,000` opcode base already prices account creation, and top-level `CREATE` transactions are not charged `GAS_CREATE` at all. Top-level `CREATE` transactions with `value > 0` do pay `TRANSFER_LOG_COST` for the [EIP-7708](./eip-7708.md) transfer log. Access-list pricing is unchanged.
+The new-account state charge does not apply to `CREATE`/`CREATE2`: the `GAS_CREATE` opcode base already prices internal account creation, and top-level contract-creation transactions pay `CREATE_ACCESS` plus the same state-gas charge directly. Charging the state-growth cost on top-level value transfers that create accounts aligns them with the `CALL`-based creation path, which has always paid for the new leaf.
 
-Legacy pricing undercharged top-level ETH transfers that created new accounts relative to internal `CALL`-based creations. This EIP corrects that by charging `GAS_NEW_ACCOUNT = 25,000`, identical to the `CALL` account-creation surcharge, ensuring consistent pricing for state growth regardless of entry path.
+### Deriving the decomposition from client runtimes
 
-This removes cross-subsidies, aligns charges with resources, and keeps costs equal across paths that perform the same state growth.
+The values of `TX_BASE_COST` and `TX_VALUE_COST` are not set by intuition; they are derived from measured client execution times, using the same approach as [EIP-8038](./eip-8038.md).
 
-Do not fold any calldata allowance into the base. The envelope RLP (`nonce`, `gas*`, `to`, `value`, `v`, `r`, `s`) is not charged as calldata and remains unmetered per byte. Only `tx.data` bytes are metered at the existing calldata schedule, and access lists keep their per-entry costs. A vanilla ETH transfer executes no bytecode and touches no contract storage slots; it performs signature recovery, warms the sender, and updates sender and recipient accounts. It therefore receives the base discount and pays only the additional recipient costs.
+The derivation uses the EELS `test_ether_transfers_onchain_receivers` benchmark, executed across all major execution-layer clients (Besu, Erigon, Geth, Nethermind, Reth). The benchmark fills blocks with ether transfers to four kinds of receiver, each exercising a different work path:
 
-Bundling multiple transfers into a single contract call avoids repeated `TX_BASE_COST`, but those transfers then execute serially inside one EVM context. That blocks parallel execution. With a lower per-tx base cost, users have less incentive to bundle, so more transfers remain independent transactions. Independent transactions can be scheduled across threads, which improves parallelism at the client and execution-layer level.
+- transfers to a contract with shared code, where the code lookup is cached across transactions;
+- transfers to a contract with unique 24 KiB code, forcing a fresh code read and JUMPDEST analysis on every transaction (the heaviest path);
+- transfers to an existing EOA;
+- transfers to a non-existent EOA, where the client must create a new account.
 
-Thus, reducing `TX_BASE_COST` not only corrects mispricing but also increases the share of transactions that are naturally parallelizable.
+For each `(client, receiver)` pair, a non-negative least-squares (NNLS) model fits measured block runtime as a linear function of the number of transfers and the number of value-bearing transfers. The two fitted coefficients are the per-transfer base runtime and the additional runtime of moving value. Each coefficient is converted to gas at a fixed throughput anchor of 100 Mgas/s (`gas = ceil(100,000 × runtime_ms)`).
 
-This EIP composes cleanly with calldata-pricing proposals such as [EIP-7623](./eip-7623.md) and [EIP-7976](./eip-7976.md). Those EIPs affect `tx.data` metering, while this EIP adjusts only transaction-level intrinsic accounting. There is no overlapping scope.
+For any candidate target, the analysis surfaces each client's worst case across receiver types, separating clients that already meet the target from those that must optimize to reach it. The proposed `TX_BASE_COST` and `TX_VALUE_COST` are set as such targets: they align intrinsic cost with the resource usage of well-optimized clients while leaving slower clients a defined optimization goal.
 
-### Why not charge full tx data as calldata?
+The two empirical coefficients map onto the decomposition as follows:
 
-- **Intrinsic coupling to signed fields.** Pricing full-transaction bytes would make intrinsic gas depend on `gas_limit` and variable-length signature elements, creating fixed-point estimation issues and incentives for signature-length selection as well as iteration instability as `gas_limit` depends on signature which contains `gas_limit`.
+- the per-transfer base runtime covers signature recovery, the sender's access and write, and the recipient touch → `TX_BASE_COST + COLD_ACCOUNT_ACCESS`;
+- the value increment covers the recipient balance write and the transfer log → `TX_VALUE_COST + TRANSFER_LOG_COST`.
 
-- **Serialization neutrality.** A fee rule keyed to RLP size couples costs to one encoding and weakens [EIP-2718](./eip-2718.md) type neutrality and future formats such as SSZ. Calldata is treated as opaque bytes so it avoids this coupling.
+`COLD_ACCOUNT_ACCESS` is taken directly from [EIP-8038](./eip-8038.md), since the recipient touch is the same cold-account access priced there, and `TRANSFER_LOG_COST` is fixed by the [EIP-7708](./eip-7708.md) log shape (see [Transfer log cost](#transfer-log-cost)). `TX_BASE_COST` and `TX_VALUE_COST` are the residual parameters this EIP introduces.
 
-- **Policy targeting and market floor.** Calldata floors (for example [EIP-7623](./eip-7623.md) or [EIP-7976](./eip-7976.md)) price bytes in `tx.data` to bound EL payload and steer data to blobs; envelope bytes are control-plane. The `TX_BASE_COST` is the smallest tx size, and having a low encoding-agnostic intrinsic base keeps the minimum inclusion price coupled to the basefee market, without opening a DoS vector.
+As in [EIP-8038](./eip-8038.md), these numbers are provisional. At the 100 Mgas/s anchor some clients are currently slower than the target on the heaviest paths and must optimize to meet it; the values will be refined as client optimizations land and the benchmarks mature.
 
-- **Native settlement and unit-of-account.** Even though all transactions receive the same absolute gas reduction, it proportionally improves pristine ETH transfers more. With an ETH transfer at ~7,756 gas vs a permissioned ERC-20/LST/stablecoin transfer at ~48,000 gas, you get ~6x higher payment throughput per unit gas, which reinforces ETH as the settlement asset and reduces reliance on contract-based money (which carries smart contract risk, operator risk, governance risk and censorship risks via smart contract operator).
+### Transfer log cost
 
-![Figure 1](../assets/eip-2780/1.png)
+`TRANSFER_LOG_COST` assumes a 32-byte log data payload because that is exactly the [EIP-7708](./eip-7708.md) transfer-log shape, not an arbitrary choice. The log is `LOG3`-shaped: three indexed topics (`keccak256("Transfer(address,address,uint256)")`, `from`, `to`) and a `data` field carrying a single `uint256` wei amount. Indexed topics do not count as data bytes, so the only data payload is the 32-byte amount — always a full word, never variable length. Hence:
 
-### Effects on transactions per block
+`TRANSFER_LOG_COST = GAS_LOG + 3 × GAS_LOG_TOPIC + 32 × GAS_LOG_DATA_PER_BYTE = 375 + 3 × 375 + 32 × 8 = 1,756`
 
-For execution-payload size, use [EIP-7934](./eip-7934.md)’s 8 MiB uncompressed cap: `8,388,608 bytes`. A typical EIP-1559 ETH transfer encodes at roughly `~110 bytes`, yielding a size cap of `floor(8,388,608 / 110) = 76,260 tx` per block when size, not gas, is the binding constraint.
+### Not metering the transaction envelope as calldata
 
-There are two useful ceilings to consider:
+Only `tx.data` bytes are metered at the calldata schedule; the envelope RLP (`nonce`, `gas*`, `to`, `value`, `v`, `r`, `s`) is not. Pricing full-transaction bytes would make intrinsic gas depend on `gas_limit` and variable-length signature elements — creating a fixed-point estimation problem, since `gas_limit` would depend on the signature, which itself encodes `gas_limit` — and would couple the fee to one serialization, weakening [EIP-2718](./eip-2718.md) type neutrality and future encodings. Treating calldata as opaque bytes avoids both issues. A plain ETH transfer carries empty `tx.data` and so pays zero calldata gas regardless.
 
-- Minimal transaction with no value and no execution: `TX_BASE_COST = 4,500` gas.
-- Minimal ETH payment to an existing EOA: `7,756` gas (`TX_BASE_COST + COLD_ACCOUNT_COST_NOCODE + STATE_UPDATE + TRANSFER_LOG_COST`).
+### Self-transfers
 
-Counts below are `floor(gaslimit / per-tx-gas)`, then capped by `76,260` when the 8 MiB size limit binds. TPS figures round to the nearest integer.
-
-#### Scenario A: minimal txs at 4,500 gas
-
-Binding point for size-cap dominance: `76,260 * 4,500 = 343,170,000` gas. At gaslimits above ~343.17 M, block size, not gas, limits the tx count for 4,500-gas transactions.
-
-| Block gaslimit | Old tx/bk (21k) | New tx/bk (4.5k) | TPS @ 12s | TPS @ 6s | TPS @ 3s | TPS @ 1.5s |
-| -------------: | --------------: | ---------------: | --------: | -------: | -------: | ---------: |
-|           45 M |           2,142 |           10,000 |       833 |    1,667 |    3,333 |      6,667 |
-|           60 M |           2,857 |           13,333 |     1,111 |    2,222 |    4,444 |      8,889 |
-|          100 M |           4,761 |           22,222 |     1,852 |    3,704 |    7,407 |     14,815 |
-|          200 M |           9,523 |           44,444 |     3,704 |    7,407 |   14,815 |     29,629 |
-|          450 M |          21,428 |          †76,260 |     6,355 |   12,710 |   25,420 |     50,840 |
-
-  † Size cap binds at 450 M because 450 M > 343.17 M.
-
-#### Scenario B: ETH transfers at 7,756 gas
-
-Binding point for size-cap dominance: `76,260 * 7,756 = 591,472,560` gas. At gaslimits below ~591.47 M, gas limits tx count; above it, the 8 MiB size cap dominates.
-
-| Block gaslimit | Old tx/bk (21k) | New tx/bk (7,756) | TPS @ 12s | TPS @ 6s | TPS @ 3s | TPS @ 1.5s |
-| -------------: | --------------: | ----------------: | --------: | -------: | -------: | ---------: |
-|           45 M |           2,142 |             5,801 |       483 |      967 |    1,934 |      3,867 |
-|           60 M |           2,857 |             7,735 |       644 |    1,289 |    2,578 |      5,157 |
-|          100 M |           4,761 |            12,893 |     1,074 |    2,149 |    4,298 |      8,595 |
-|          200 M |           9,523 |            25,786 |     2,149 |    4,298 |    8,595 |     17,191 |
-|          450 M |          21,428 |            58,019 |     4,835 |    9,670 |   19,340 |     38,680 |
-
-#### Changes for common types of txs
-
-| Transaction Type                   | Old Cost | New Cost | Change |
-| ---------------------------------- | -------: | -------: | -----: |
-| Simple ETH transfer (existing EOA) |   21,000 |    7,756 |  −63 % |
-| ETH transfer creating new EOA      |   21,000 |   31,756 |  +51 % |
-| ERC-20 transfer (typical)          |   63,200 |   48,200 |  −24 % |
-| ERC-20 transfer (Solady)           |   33,400 |   18,400 |  −45 % |
-| Uniswap v3 swap                    |  184,500 |  169,500 |   −8 % |
-| Uniswap v3 add-liquidity           |  216,900 |  201,900 |   −7 % |
-
-
-#### Reference MGas/s for gaslimit vs slot time
-
-| Block gaslimit | MGas/s @ 12s | MGas/s @ 6s | MGas/s @ 3s | MGas/s @ 1.5s |
-| -------------: | -----------: | ----------: | ----------: | ------------: |
-|           45 M |         3.75 |        7.50 |       15.00 |         30.00 |
-|           60 M |         5.00 |       10.00 |       20.00 |         40.00 |
-|          100 M |         8.33 |       16.67 |       33.33 |         66.67 |
-|          200 M |        16.67 |       33.33 |       66.67 |        133.33 |
-|          450 M |        37.50 |       75.00 |      150.00 |        300.00 |
+A self-transfer (`tx.sender == tx.to`) charges neither the recipient touch nor the value cost: the account is already accessed and written as the sender, and EIP-7708 emits no transfer log when sender and recipient coincide. Only `TX_BASE_COST` applies.
 
 ## Backwards Compatibility
 
-This EIP is **not** backward compatible. It is a consensus gas repricing that must be activated at `FORK_BLOCK`.
-
-Wallets, RPCs, gas estimators, and any logic that assumes a `21,000` base must update.
+This EIP is **not** backward compatible. It is a consensus gas repricing that must be activated at a network upgrade. Wallets, RPCs, gas estimators, and any logic that assumes a flat `21,000` intrinsic base must update, particularly to account for the state-gas charge on transactions that create new accounts.
 
 ## Test Cases
 
-While the benefits of reducing transactions' intrinsic cost are apparent, such a change should be applied if it imposes no negative externalities, or if such effects are negligible.
+Intrinsic and top-level gas, by case:
 
-Tests should be created with blocks of just ETH transfers and tested on Perfnet across all EL clients to ensure the pricing is correct.
+1. Self-transfer (`from == to`): `12,000`.
+2. Zero-value transaction to any address (existing, empty, or contract): `15,000` regular (`12,000 + COLD_ACCOUNT_ACCESS`), `0` state. A self-target is `12,000`.
+3. Value transfer to an existing EOA: `21,000` regular, `0` state.
+4. Value transfer creating a new account (empty per EIP-161): `21,000` regular, `183,600` state.
+5. Value transfer to a 7702-delegated account: `24,000` regular plus execution.
+6. Contract-creation transaction, `value = 0`: `20,800` regular, `183,600` state.
+7. Contract-creation transaction, `value > 0`: `22,556` regular, `183,600` state.
+8. EIP-7702 transaction: `TX_BASE_COST` is unchanged even when the sender assumes code; access-list and authorization costs are unchanged.
+9. Reverting value transfer to a new account: transaction is valid; the `183,600` state-gas charge is refilled to the reservoir.
 
-Add explicit test vectors (intrinsic gas only):
-
-1. `value > 0` to an empty EOA (non-existent per EIP-161): intrinsic `31,756` (4,500 base + 500 + 25,000 surcharge + 1,756 transfer log).
-2. `value > 0` to a precompile: intrinsic `6,256` (4,500 base + 1,756 transfer log; no surcharge; precompiles are warm at tx start).
-3. `value = 0` to an empty address: intrinsic `4,500` (no creation, no surcharge).
-4. `CREATE` transaction: unchanged from prior rules.
-5. EIP-7702 transaction with and without access list: intrinsic uses `TX_BASE_COST` plus unchanged access-list costs.
-6. Block of txs calling minimal gas contract execution with maximal contract size addresses (so VM is activated for every tx).
-7. Warmth and access list interplay
-    - ETH transfer to existing EOA without access list: charge `COLD_ACCOUNT_COST_NOCODE = 500` for recipient lookup.
-    - Same transaction with recipient in access list: charge `WARM_STATE_READ = 100`.
-8. 7702 interactions
-    - 7702 tx where sender assumes code and calls nothing: intrinsic = 4,500, no extra cold-code cost.
-    - 7702 tx where sender assumes code and executes self-code: charge `COLD_ACCOUNT_COST_CODE` when first loaded.
-9. Precompile transfers
-    - `value > 0` to `0x01`–`0x09`: intrinsic = 6,256 (4,500 base + 1,756 transfer log), no surcharge.
-10. Self-transfer `from == to`: total = 4,500.
-11. Internal CALL repricing
-    - Internal `CALL` to existing EOA with value: `CALL_VALUE_COST = 3,756` plus cold/warm costs.
-    - Internal `CALL` to EIP-161-empty: `CALL_VALUE_COST = 27,756`.
-12. Zero-value edge cases `value = 0` to empty address: intrinsic = `4,500`.
-13. Perfnet stress
-    - Fill block with minimal 4,500-gas tx and 7,756-gas ETH transfers; confirm gas vs byte-size binding per [EIP-7934](./eip-7934.md).
-14. SELFDESTRUCT test: Create-and-destroy in one tx; confirm normal value-transfer costs apply, no deletion repricing.
+Blocks of pure ETH transfers should be tested across all EL clients (e.g. on Perfnet) to confirm the pricing matches measured runtimes at the chosen throughput anchor.
 
 ## Security Considerations
 
-As this significantly increases the max tx per block, this carries risk.
+The decomposed charges sum to at least the legacy `21,000` for any transaction that moves value to a distinct account, and add state gas for transactions that grow the state. No path is cheaper than under the flat base in a way that increases per-block resource consumption; the change reallocates cost to match resources and prices state growth that was previously unpriced.
 
-However, this pricing should be the same as performing the component changes inside the transaction; and it factors in the additional costs from state growth which were not originally in the transaction base price.
-
-Current gaslimit testing mostly uses a block with a single transaction; so this should not cause unexpected load compared to what is already being tested.
-
-The semantics of `SELFDESTRUCT` remain unchanged. Following [EIP-6780](./eip-6780.md), only contracts created within the same transaction may be fully deleted. This EIP does not reprice or modify any `SELFDESTRUCT` side-effects.
+The semantics of `SELFDESTRUCT` are unchanged. Per [EIP-6780](./eip-6780.md), only contracts created within the same transaction may be fully deleted; this EIP does not reprice or modify any `SELFDESTRUCT` side effects.
 
 ## Copyright
 

--- a/EIPS/eip-2780.md
+++ b/EIPS/eip-2780.md
@@ -148,7 +148,7 @@ A transaction’s intrinsic base cost is decomposed into the following explicit 
 - `tx.to` is charged based on its type:
   - if self-transfer (`tx.sender` = `tx.to`), there are no charges;
   - if a precompile, there are no charges;
-  - if `None` (contract creation transaction), charge `ACCOUNT_WRITE` in regular gas and `STATE_BYTES_PER_NEW_ACCOUNT x CPSB` in state gas;
+  - if `None` (contract creation transaction), charge `CREATE_ACCESS` in regular gas and `STATE_BYTES_PER_NEW_ACCOUNT x CPSB` in state gas;
   - otherwise, charge `COLD_ACCOUNT_ACCESS` in regular gas.
 - `tx.value` is charged based on its value:
   - if zero, there are no charges;
@@ -156,7 +156,7 @@ A transaction’s intrinsic base cost is decomposed into the following explicit 
   - if non-zero and contract creation, charge `TRANSFER_LOG_COST` in regular gas;
   - otherwise, charge `TRANSFER_LOG_COST` + `ACCOUNT_WRITE` in regular gas.
 
-`ACCOUNT_WRITE = 6,700`, per [EIP-8038](./eip-8038.md). This number is not yet final.
+`ACCOUNT_WRITE = 6,700` and `CREATE_ACCESS = 9,300`, per [EIP-8038](./eip-8038.md). These numbers are not yet final.
 
 `STATE_BYTES_PER_NEW_ACCOUNT x CPSB` is set to `183,600`, per [EIP-8037](./eip-8037.md). This value can be updated by a fork when changing `CPSB`.
 
@@ -169,7 +169,7 @@ These charges replace the contract creation transaction charges. All other intri
 During EVM execution, before any opcode is executed, the recipient account is loaded and the following gas costs are charged:
 
 - If recipient is empty per [EIP-161](./eip-161.md) and `tx.value > 0`, charge `STATE_BYTES_PER_NEW_ACCOUNT x CPSB` in state gas;
-- if recipient is an [EIP-7702](./eip-7702.md) delegated account, charge `COLD_ACCOUNT_ACCESS` in regular gas;
+- if recipient is an [EIP-7702](./eip-7702.md) delegated account, charge an additional `COLD_ACCOUNT_ACCESS` in regular gas;
 - otherwise, there are no charges.
 
 `STATE_BYTES_PER_NEW_ACCOUNT x CPSB` is set to `183,600`, per [EIP-8037](./eip-8037.md). This value can be updated by a fork when changing `CPSB`. Regular gas and state gas semantics are derived from [EIP-8037](./eip-8037.md).
@@ -190,8 +190,8 @@ If the transaction reverts at this point, it is still valid. In this case, `STAT
 | ETH Transfer to contract | `TX_BASE_COST` + `COLD_ACCOUNT_ACCESS` + `ACCOUNT_WRITE` + `TRANSFER_LOG_COST` + **execution** | 23,356 + **execution** |
 | No-transfer to 7702 delegated | `TX_BASE_COST` + 2 x `COLD_ACCOUNT_ACCESS` + **execution** | 17,500 + **execution** |
 | ETH Transfer to 7702 delegated | `TX_BASE_COST` + 2 x `COLD_ACCOUNT_ACCESS` + `ACCOUNT_WRITE` + `TRANSFER_LOG_COST` + **execution** | 25,956 + **execution** |
-| Create transaction with `tx.value` = 0 | `TX_BASE_COST` + `ACCOUNT_WRITE` + `STATE_BYTES_PER_NEW_ACCOUNT x CPSB` | 202,600 |
-| Create transaction with `tx.value` > 0 | `TX_BASE_COST` + `ACCOUNT_WRITE` + `STATE_BYTES_PER_NEW_ACCOUNT x CPSB` + `TRANSFER_LOG_COST` | 204,356 |
+| Create transaction with `tx.value` = 0 | `TX_BASE_COST` + `CREATE_ACCESS` + `STATE_BYTES_PER_NEW_ACCOUNT x CPSB` | 205,200 |
+| Create transaction with `tx.value` > 0 | `TX_BASE_COST` + `CREATE_ACCESS` + `STATE_BYTES_PER_NEW_ACCOUNT x CPSB` + `TRANSFER_LOG_COST` | 206,956 |
 | ETH Transfer creating new account | `TX_BASE_COST` + `COLD_ACCOUNT_ACCESS` + `ACCOUNT_WRITE` + `STATE_BYTES_PER_NEW_ACCOUNT x CPSB` + `TRANSFER_LOG_COST` | 206,956 |
 
 ### Edits and interactions with other EIPs

--- a/EIPS/eip-2780.md
+++ b/EIPS/eip-2780.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2020-07-11
-requires: 1559, 2718, 2929, 2930, 7708
+requires: 1559, 2718, 2929, 2930, 7904, 7708, 8037, 8038
 ---
 
 ## Abstract
@@ -129,175 +129,74 @@ Net effect equals raising a 45 M gas limit to ~54.4 M at unchanged calldata and 
 
 ## Specification
 
-After `FORK_BLOCK`, set the following parameters and rules:
+### Parameter changes
 
-### Parameters
+Upon activation of this EIP, the following parameters of the gas model are updated:
 
-| Name                       |  Value | Description                                                             |
-| -------------------------- | -----: | ----------------------------------------------------------------------- |
-| `TX_BASE_COST`             |  4,500 | Base cost of any transaction                                            |
-| `GAS_NEW_ACCOUNT`          | 25,000 | Surcharge when a value-transferring transaction creates a new account   |
-| `STATE_UPDATE`             |  1,000 | One account-leaf write in the account trie (nonce and balance coalesce) |
-| `COLD_ACCOUNT_COST_CODE`   |  2,600 | Cold touch of an account with code                                      |
-| `COLD_ACCOUNT_COST_NOCODE` |    500 | Cold touch of an account known to have no code                          |
-| `WARM_STATE_READ`          |    100 | Touch of an already-warm account (same as `WARM_STORAGE_READ_COST`)     |
-| `TRANSFER_LOG_COST`        |  1,756 | [EIP-7708](./eip-7708.md) LOG3 transfer event (375 + 3×375 + 32×8). See [EIP-7708](./eip-7708.md) for the full set of emission sites and their charging points. |
+| Name | Definition | Value | Description |
+| :----: | :----: | :----: | :----: |
+| `TX_BASE_COST` | `GAS_PRECOMPILE_ECRECOVER` + `COLD_ACCOUNT_ACCESS` + `ACCOUNT_WRITE` | 12,300 | Base cost of any transaction |
+| `TRANSFER_LOG_COST` | `GAS_LOG` + 3 x `GAS_LOG_TOPIC` + 8 x `GAS_LOG_DATA_PER_BYTE` | 1,756 | Transfer log emitted for every nonzero-value transfer to a different account per [EIP-7708](./eip-7708.md) |
 
-The intrinsic gas accounting defined here overrides [EIP-2929](./eip-2929.md)'s blanket "all tx addresses are warm" rule.
+`COLD_ACCOUNT_ACCESS = 2,600` and `ACCOUNT_WRITE = 6,700` are updated in [EIP-8038](eip-8038.md). The current numbers are not yet final.
 
-A transaction’s intrinsic base is decomposed into explicit primitives, so warmth must be priced explicitly.
+### Intrinsic gas costs
 
-- `tx.sender` is charged as a cold non-code account (`COLD_ACCOUNT_COST_NOCODE = 500`), representing the first access and coalesced account-leaf update.
+A transaction’s intrinsic base cost is decomposed into following explicit primitives:
 
+- `tx.sender` is charged `TX_BASE_COST` in regular gas, accounting for one ECDSA recovery and the `sender`'s state access + write cost.
 - `tx.to` is charged based on its type:
+  - if self-transfer (`tx.sender` = `tx.to`), there are no charges;
+  - if a precompile, there are no charges;
+  - otherwise, charge `COLD_ACCOUNT_ACCESS` in regular gas.
+- `tx.value` is charged based on its value:
+  - if zero, there are no charges;
+  - if non-zero and self-transfer, there are no charges;
+  - if non-zero and `tx.sender` != `tx.to`, charge `TRANSFER_LOG_COST` + `ACCOUNT_WRITE` in regular gas.
 
-  - if a contract create, charge under those rules.
+These charges replace the cost for contract creation (`GAS_CREATE`). All other intrinsic costs (calldata, access list, and authorizations) remain unchanged.
 
-  - if an EOA or an empty account, use `COLD_ACCOUNT_COST_NOCODE = 500`.
+Regular gas semantics are derived from [EIP-8037](eip-8037.md).
 
-  - if a contract, use `COLD_ACCOUNT_COST_CODE = 2,600`.
+### Transaction's top-level gas costs
 
-  - if a [EIP-7702](./eip-7702.md) delegated account, use `COLD_ACCOUNT_COST_CODE = 2,600`. The delegation target incurs an additional `COLD_ACCOUNT_COST_CODE = 2,600` if cold, or `WARM_STATE_READ = 100` if already warm.
+During EVM execution, before any opcode is executed, the recipient account is loaded and the following gas costs are charged:
 
-  - if a precompile, it is warm at tx start and charged zero.
+- if `tx.to` is empty (`tx.to == Bytes0(b"")`) and `tx.value > 0`:
+  - charge `CALL_VALUE` in regular gas, and
+  - charge `STATE_BYTES_PER_NEW_ACCOUNT x CPSB` in state gas;
+- otherwise, there are no charges.
 
-- Warmth discovered through an access list still applies and overrides the cold cost.
+`CALL_VALUE` is defined as `ACCOUNT_WRITE + CALL_STIPEND = 9000`, per [EIP-8038](eip-8038.md). This number is not yet final.
 
-This decomposition replaces the implicit warmth assumptions of [EIP-2929](./eip-2929.md) and makes the per-account cost explicit in the base or the execution phase as appropriate.
+`STATE_BYTES_PER_NEW_ACCOUNT x CPSB` is set to `183,600`, per [EIP-8037](eip-8037.md). This value can be updated by a fork when changing `CPSB`. Regular gas and state gas semantics are derived from [EIP-8037](eip-8037.md).
 
-Notes:
-
-- `STATE_UPDATE` counts writes at the account-leaf granularity. If a single account's nonce and balance both change in one transition, charge one `STATE_UPDATE`.
-- `COLD_ACCOUNT_COST_NOCODE` reflects that non-code accounts do not load code or a storage trie, so have a lower warming cost.
-- A regular ETH transfer additionally includes a cold touch of at least `COLD_ACCOUNT_COST_NOCODE`, a `STATE_UPDATE` of the `to` address, and a `TRANSFER_LOG_COST` for the [EIP-7708](./eip-7708.md) transfer log, so the effective minimal productive tx cost is `7,756`.
-- Not including the `to` cold warming and `STATE_UPDATE` in `TX_BASE_COST` means a contract-interaction transaction that does not transfer value does not unnecessarily pay these additional costs.
-
-### Derivation (non-normative)
-
-Decomposition of the base cost into universal primitives:
-
-| Component                |      Cost | Notes                                              |
-| ------------------------ | --------: | -------------------------------------------------- |
-| ECRECOVER                |     3,000 | Elliptic curve signature recovery                  |
-| STATE_UPDATE             |     1,000 | One account-leaf write (nonce + balance coalesced) |
-| COLD_ACCOUNT_COST_NOCODE |       500 | Sender is cold and has no code                     |
-| **TX_BASE_COST**         | **4,500** | Sum of above (3,000 + 1,000 + 500)                 |
-
-
-### New-account surcharge
-
-Apply `GAS_NEW_ACCOUNT` when **all** are true:
-
-1. The transaction is not a `CREATE` transaction.
-2. `value > 0`.
-3. `to` is not a precompile.
-4. `to` is non-existent per [EIP-161](./eip-161.md) emptiness at the start of transaction execution.
-
-The `GAS_NEW_ACCOUNT = 25,000` charge covers state growth (new leaf creation and one `STATE_UPDATE`).
-An additional `COLD_ACCOUNT_COST_NOCODE = 500` applies for the initial lookup to determine that the account does not exist.
-
-Thus, the **total** intrinsic gas for a value-transferring transaction to a new account is `31,756` (`4,500 base + 500 lookup + 25,000 new-account surcharge + 1,756 transfer log`).
-
-For reference, the **total** charges for such transfers change from 21,000 to 31,756.
-
-| Component                |     Cost   | Notes                                    |
-| ------------------------ | ----------:| ---------------------------------------- |
-| TX_BASE_COST             |     4,500  | Base transaction cost                    |
-| COLD_ACCOUNT_COST_NOCODE |       500  | Recipient cold lookup (execution charge) |
-| GAS_NEW_ACCOUNT          |    25,000  | Account creation, includes leaf write    |
-| TRANSFER_LOG_COST        |     1,756  | EIP-7708 transfer log                    |
-| **Total**                | **31,756** | Sum of above (4,500 + 500 + 25,000 + 1,756) |
-
-Notes:
-
-- If `value = 0` and `to` is empty per [EIP-161](./eip-161.md), no account is created and no surcharge applies.
-- Top-level `CREATE` transactions with `value > 0` (see *Pseudocode*) pay  `TRANSFER_LOG_COST` for the [EIP-7708](./eip-7708.md) transfer log emitted on the endowment transfer.
-
-### Intrinsic gas computation
-
-Clients compute intrinsic gas as today for each typed transaction **except**:
-
-- Replace any hardcoded `21,000` with `TX_BASE_COST = 4,500`.
-- Add `GAS_NEW_ACCOUNT` when the *New-account surcharge* conditions hold.
-
-### Pseudocode (normative):
-
-```python
-def CalculateIntrinsicGas(tx, state_at_start):
-    gasCost = TX_BASE_COST
-
-    # Existing rules for calldata and access lists remain unchanged by this EIP.
-    gasCost += GasForCalldata(tx.data)                  # per active calldata pricing EIPs
-    if tx.has_access_list():
-        gasCost += GasForAccessList(tx.access_list)     # per EIP-2930
-
-    # Charge for the EIP-7708 transfer log emitted on the tx-level value
-    # transfer. CREATE transactions endow a freshly computed contract
-    # address that is, by construction, distinct from the sender, so the
-    # log applies whenever value > 0.
-    if tx.value > 0 and (tx.is_create() or tx.sender != tx.to):
-        gasCost += TRANSFER_LOG_COST                    # EIP-7708 transfer log
-
-    if tx.is_create() == False
-       and tx.value > 0
-       and is_precompile(tx.to) == False
-       and is_nonexistent_per_eip161(state_at_start, tx.to):
-        gasCost += GAS_NEW_ACCOUNT
-
-    return gasCost
-```
-
-### EVM gas schedule adjustments
-
-These changes refine execution-layer accounting to align with the primitives above.
-
-- **Value-moving calls.** Replace the legacy `CALL_VALUE_COST = 9,000` with:
-
-  - If `caller == to` (self-call): `CALL_VALUE_COST = STATE_UPDATE = 1,000`. No `TRANSFER_LOG_COST` is charged because [EIP-7708](./eip-7708.md) does not emit a transfer log for self-transfers.
-  - If recipient exists and `caller != to`: `CALL_VALUE_COST = 2 * STATE_UPDATE + TRANSFER_LOG_COST = 3,756`.
-  - If recipient is EIP-161-empty and `caller != to`: `CALL_VALUE_COST = STATE_UPDATE + GAS_NEW_ACCOUNT + TRANSFER_LOG_COST = 27,756`.
-  - This charge is in addition to warm/cold account-touch costs per EIP-2929 and the existing `CALL` base cost. This EIP does not modify the `CALL` base cost.
-  - `TRANSFER_LOG_COST` covers the [EIP-7708](./eip-7708.md) transfer log emitted for every nonzero-value transfer to a different account.
-
-  The `CALL_VALUE_COST` applies for all value-carrying calls, regardless of whether the callee's account has already been updated earlier in the same transaction. This ensures the 2300-gas stipend mechanism remains safe and consistent for simple value forwarding and does not retroactively depend on account-update history.
-
-- **Cold-account touches.**
-
-  - Use `COLD_ACCOUNT_COST_CODE = 2,600` when touching an account with code.
-  - Use `COLD_ACCOUNT_COST_NOCODE = 500` when touching an account known to have no code.
-
-- **Warmth policy.**
-
-  - Access-list entries (charged via [EIP-2930](./eip-2930.md)) and precompiles are warm at tx start.
-  - `CALL` warms its `to` after charging the appropriate cold cost if cold.
-
-- **Self-transfers.** If `from == to`, only one `STATE_UPDATE` occurs. The sender's nonce and balance update are coalesced into the same leaf write. No recipient lookup or separate write is charged. (It is a NOP tx other than charging gas and incrementing nonce).
-
+If the transaction reverts at this point, it is still valid. In this case, `STATE_BYTES_PER_NEW_ACCOUNT x CPSB` is not charged and refilled back to the `state_gas_reservoir`, per [EIP-8037](eip-8037.md).
 
 ### Transaction reference cases
 
-| Case                                | Formula                                                          | Total Cost                |
-| ----------------------------------- | ---------------------------------------------------------------- | -------------------------:|
-| (NOP) No-transfer to EOA            | `TX_BASE_COST` + `COLD_ACCOUNT_COST_NOCODE`                      | 5,000                     |
-| (NOP) No-transfer to empty account  | `TX_BASE_COST` + `COLD_ACCOUNT_COST_NOCODE`                      | 5,000                     |
-| (NOP) ETH transfer to self          | `TX_BASE_COST`                                                   | 4,500                 |
-| ETH Transfer to existing EOA        | `TX_BASE_COST` + `COLD_ACCOUNT_COST_NOCODE` + `STATE_UPDATE` + `TRANSFER_LOG_COST` | 7,756                 |
-| No-transfer to contract             | `TX_BASE_COST` + `COLD_ACCOUNT_COST_CODE` + **execution**                | 7,100 + **execution**     |
-| ETH Transfer to contract            | `TX_BASE_COST` + `COLD_ACCOUNT_COST_CODE` + `STATE_UPDATE` + `TRANSFER_LOG_COST` + **execution** | 9,856 + **execution**     |
-| No-transfer to 7702 delegated       | `TX_BASE_COST` + `2 * COLD_ACCOUNT_COST_CODE` + **execution**    | 9,700 + **execution**     |
-| ETH Transfer to 7702 delegated      | `TX_BASE_COST` + `2 * COLD_ACCOUNT_COST_CODE` + `STATE_UPDATE` + `TRANSFER_LOG_COST` + **execution** | 12,456 + **execution**    |
-| ETH Transfer creating new account   | `TX_BASE_COST` + `COLD_ACCOUNT_COST_NOCODE` + `GAS_NEW_ACCOUNT` + `TRANSFER_LOG_COST` | 31,756                |
+| Case | Formula | Total Cost |
+| :----: | :----: | :----: |
+| ETH transfer to self | `TX_BASE_COST` | 12,300 |
+| ETH transfer to precompile | `TX_BASE_COST` | 12,300 |
+| No-transfer to EOA | `TX_BASE_COST` + `COLD_ACCOUNT_ACCESS` | 14,900 |
+| No-transfer to empty account | `TX_BASE_COST` + `COLD_ACCOUNT_ACCESS` | 14,900 |
+| ETH Transfer to existing EOA | `TX_BASE_COST` + `COLD_ACCOUNT_ACCESS` + `ACCOUNT_WRITE` + `TRANSFER_LOG_COST` | 23,356 |
+| No-transfer to contract | `TX_BASE_COST` + `COLD_ACCOUNT_ACCESS` + **execution** | 14,900 + **execution** |
+| ETH Transfer to contract | `TX_BASE_COST` + `COLD_ACCOUNT_ACCESS` + `ACCOUNT_WRITE` + `TRANSFER_LOG_COST` + **execution** | 23,356 + **execution** |
+| No-transfer to 7702 delegated | `TX_BASE_COST` + `COLD_ACCOUNT_ACCESS` + **execution** | 14,900 + **execution** |
+| ETH Transfer to 7702 delegated | `TX_BASE_COST` + `COLD_ACCOUNT_ACCESS` + `ACCOUNT_WRITE` + `TRANSFER_LOG_COST` + **execution** | 23,356 + **execution** |
+| ETH Transfer creating new account | `TX_BASE_COST` + `COLD_ACCOUNT_ACCESS` + `ACCOUNT_WRITE` + `GAS_NEW_ACCOUNT` + `TRANSFER_LOG_COST` | 206,956 |
 
-This aligns costs with actual state work rather than legacy flat surcharges.
+Note that in ETH transfers that create new account, an additional `CALL_STIPEND = 2300` is charged before entering the `CREATE` frame and added to the call's `gas_left`. This amount in not considered as cost as it can be spent inside the call frame and returned in case it is not used.
 
 ### Edits and interactions with other EIPs
 
-- **[EIP-2930](./eip-2930.md) (Access List).** Intrinsic gas is `TX_BASE_COST` after `FORK_BLOCK`. Access lists keep their existing per-entry charges and warming semantics.
-- **[EIP-2929](./eip-2929.md) (Gas cost increases for state access).** Refined by this EIP to price non-code cold touches at `500` and code-account cold touches at `2,600`.
-- **[EIP-7702](./eip-7702.md) (Set EOA Code).** `TX_BASE_COST` remains `4,500` even if the sender temporarily assumes code for the transaction. Clients must not perform any disk code-load to determine sender type, since 7702 provides code inline. If the transaction executes code that reads or executes its own code, normal `COLD_ACCOUNT_COST_CODE` or `WARM_STATE_READ` costs apply at execution time as per the standard cold/warm model. When `tx.to` is a 7702-delegated account, it is charged `COLD_ACCOUNT_COST_CODE = 2,600` at the intrinsic level. Resolving the delegation requires loading code from the delegation target, which incurs its own `COLD_ACCOUNT_COST_CODE = 2,600` if the target is cold, or `WARM_STATE_READ = 100` if already warm. This also applies to calls made to delegated accounts.
-- **[EIP-7708](./eip-7708.md) (ETH transfers emit a log).** EIP-7708 emits a LOG3-shaped transfer event on every non-zero-value ETH transfer to a different account, and a LOG2-shaped burn event when ETH leaves circulation. Under the legacy `21,000` intrinsic base, the LOG3 cost of a transfer event was implicitly absorbed; with `TX_BASE_COST` reduced to `4,500`, that subsidy disappears and each emission must be priced explicitly. This EIP charges `TRANSFER_LOG_COST = 1,756` (LOG3 equivalent: `375 + 3×375 + 32×8`) at intrinsic gas computation (see *Pseudocode*) for top-level value-transferring transactions, including `CREATE` transactions with `value > 0`. The corresponding in-EVM transfer-log and burn-log charges (`CALL`, `SELFDESTRUCT`, `CREATE` / `CREATE2`) are specified in [EIP-7708](./eip-7708.md).
-- **[EIP-7928](./eip-7928.md) (Block-Level Access Lists).** The two-tier cold-access model (`COLD_ACCOUNT_COST_NOCODE` vs `COLD_ACCOUNT_COST_CODE`) requires loading the account from disk before the correct charge can be determined. For cold accounts, at least `COLD_ACCOUNT_COST_NOCODE` gas must be available before account access is attempted; if unavailable, the operation fails with out-of-gas without accessing the account. Once an account access is attempted, the account is added to the transaction's accessed set for the BAL. Thereafter, if the account is found to have code, the account read remains in the BAL even if the available gas is less than `COLD_ACCOUNT_COST_CODE` and the call frame fails with out-of-gas.
+- **[EIP-2930](./eip-2930.md) (Access List).** Access lists keep their existing per-entry charges and warming semantics.
 - **Calldata-pricing EIPs (e.g. [EIP-7623](./eip-7623.md)).** Unchanged. This EIP does not alter calldata pricing.
+- **[EIP-7702](./eip-7702.md) (Set EOA Code).** `TX_BASE_COST` remains `12,300` even if the sender temporarily assumes code for the transaction. Clients must not perform any disk code-load to determine sender type, since 7702 provides code inline. If the transaction executes code that reads or executes its own code, normal `COLD_ACCOUNT_ACCESS` or `WARM_ACCESS` costs apply at execution time as per the standard cold/warm model. When `tx.to` is a 7702-delegated account, it is charged `COLD_ACCOUNT_ACCESS` at the intrinsic level. Resolving the delegation requires loading code from the delegation target, which incurs its own `COLD_ACCOUNT_ACCESS` if the target is cold, or `WARM_ACCESS` if already warm. This also applies to calls made to delegated accounts.
+- **[EIP-7708](./eip-7708.md) (ETH transfers emit a log).** EIP-7708 emits a LOG3-shaped transfer event on every non-zero-value ETH transfer to a different account, and a LOG2-shaped burn event when ETH leaves circulation. Under the legacy `21,000` intrinsic base, the LOG3 cost of a transfer event was implicitly absorbed; with `TX_BASE_COST` reduced to `12,300`, that subsidy disappears, and each emission must be priced explicitly. This EIP charges `TRANSFER_LOG_COST = 1,756` (LOG3 equivalent: `375 + 3×375 + 32×8`) at intrinsic gas computation for top-level value-transferring transactions.
+- **[EIP-7928](./eip-7928.md) (Block-Level Access Lists).** The intrinsic costs already account for accessing the sender and recipient accounts. Thefore, these accounts should be included in the BAL even in cases where the transaction reverts.
 
 ## Rationale
 


### PR DESCRIPTION
Reworks EIP-2780 from *reducing* the intrinsic cost into a **resource-based decomposition** of the `21,000` base. The headline number is unchanged — it's just rebuilt from explicit primitives, each priced to the resource a transaction actually consumes (`TX_BASE_COST + COLD_ACCOUNT_ACCESS + TX_VALUE_COST + TRANSFER_LOG_COST = 21,000` for a standard value transfer).

### What changed

- **Reframed around preserving 21,000, not reducing it.** Title and abstract updated to match.
- **State growth internalized.** New-account value transfers and contract-creation transactions now pay `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` in state gas (EIP-8037).
- **Parameters derived from client runtimes.** `TX_BASE_COST` and `TX_VALUE_COST` fitted from the EELS ether-transfer benchmark across all major ELs, per EIP-8038's method.
- **Motivation and Rationale written** (previously flagged as missing).
- **Reference cases and test cases rewritten** to split regular vs. state gas.
- **Dependencies updated:** requires 161, 2718, 2929, 2930, 6780, 7702, 7708, 7904, 7928, 8037, 8038.
