### PR TITLE
Update EIP-8130: Add canonical verifier set

### DIFF
--- a/EIPS/eip-8130.md
+++ b/EIPS/eip-8130.md
@@ -130,6 +130,21 @@ Nodes MAY implement equivalent verification logic natively for well-known verifi
 
 Any contract implementing `IVerifier` can be permissionlessly deployed and registered as an owner's verifier.
 
+#### Canonical Verifier Set
+
+This specification defines a canonical verifier set — the minimum signature algorithms that compliant nodes MUST accept. The initial canonical set includes:
+
+| Name | Algorithm | Verifier |
+|------|-----------|----------|
+| k1 | secp256k1 | `ECRECOVER_VERIFIER` (native sentinel) |
+| p256 | P-256 | Onchain contract |
+| passkey | WebAuthn / FIDO2 | Onchain contract |
+| delegate | Signature delegation | Onchain contract |
+
+The canonical verifier set and corresponding contract addresses are maintained in a companion ERC <!-- TODO: ERC number --> and deployed at deterministic CREATE2 addresses across chains. The canonical set is expected to grow as new algorithms are adopted (e.g., post-quantum) through the companion ERC process.
+
+Nodes MUST include all canonical verifiers in their allowlist. Transactions using canonical verifiers are guaranteed acceptance by any compliant node. Nodes MAY extend their allowlist with additional non-canonical verifiers; transactions using non-canonical verifiers are valid but are not guaranteed acceptance across the network.
+
 ### Account Types
 
 This proposal supports three paths for accounts to use AA transactions:
@@ -518,9 +533,9 @@ All contracts are deployed at deterministic CREATE2 addresses across chains.
    - **Nonce-free key** (`nonce_key == NONCE_KEY_MAX`): skip nonce check, require `nonce_sequence == 0`, require non-zero `expiry`, and nodes SHOULD reject if `expiry` exceeds a short window (e.g., 10 seconds). Deduplicate by transaction hash.
 8. Mempool threshold: gas payer's pending count below node-configured limits.
 
-Nodes SHOULD maintain a verifier allowlist of trusted verifiers. Allowlisted verifiers have known gas bounds and no external state dependencies, enabling validation with no tracing and minimal state requirements — only `owner_config` and the verifier code itself.
+Nodes MUST maintain a verifier allowlist that includes, at minimum, all verifiers in the canonical verifier set (see [Canonical Verifier Set](#canonical-verifier-set)). Allowlisted verifiers have known gas bounds and no external state dependencies, enabling validation with no tracing and minimal state requirements — only `owner_config` and the verifier code itself.
 
-Nodes MAY accept transactions with unknown verifiers by enforcing a gas cap and applying validation scope tracing to restrict opcodes and track state dependencies for invalidation.
+Nodes MAY extend their allowlist with additional non-canonical verifiers. Nodes MAY also accept transactions with unknown verifiers by enforcing a gas cap and applying validation scope tracing to restrict opcodes and track state dependencies for invalidation.
 
 Nodes MAY apply higher pending transaction rate limits based on account lock state:
 
@@ -549,7 +564,7 @@ Unused execution gas (from `gas_limit`) is refunded to the payer. Intrinsic gas 
 - `status` (uint8): `0x01` = all phases succeeded (or `calls` was empty), `0x00` = one or more phases reverted. Existing tools checking `status == 1` remain correct for the success path.
 - `phaseStatuses` (uint8[]): Per-phase status array. Each entry is `0x01` (success) or `0x00` (reverted). Phases after a revert are not executed and reported as `0x00`. Empty if `calls` was empty.
 
-**`eth_getAcceptedVerifiers`**: Returns the node's verifier acceptance policy. The response includes a top-level `acceptsUnknownVerifiers` boolean indicating whether the node accepts transactions with verifiers not on its allowlist. The `verifiers` array lists each accepted verifier with its `address`, whether the node has a `native` implementation, and `maxAuthCost` — the maximum gas the node will allow for that verifier's auth execution.
+**`eth_getAcceptedVerifiers`**: Returns the node's verifier acceptance policy. The response includes a top-level `acceptsUnknownVerifiers` boolean indicating whether the node accepts transactions with verifiers not on its allowlist. The `verifiers` array lists each accepted verifier with its `address`, whether the node has a `native` implementation, whether it is `canonical` (part of the canonical verifier set), and `maxAuthCost` — the maximum gas the node will allow for that verifier's auth execution. Compliant nodes MUST include all canonical verifiers in the response.
 
 ### Appendix: Storage Layout
 
@@ -649,6 +664,12 @@ The protocol reads everything it needs for authorization and scope checking in o
 Without scope, all owners have equal authority — any owner can sign as sender, approve gas payment, appear through ERC-1271, and authorize config changes. This is insufficient when accounts have owners serving different roles, like for example running a payer for ERC-20 tokens.
 
 The `0x00` = unrestricted default ensures backward compatibility.
+
+### Why a Canonical Verifier Set?
+
+Without a required minimum set, nodes would have no obligation to accept any particular verifier beyond `ECRECOVER_VERIFIER`. Wallets would face a fragmented network where each node accepts a different combination of algorithms, making it impossible to guarantee transaction delivery for non-k1 signature types.
+
+The canonical set establishes a shared baseline: wallets that use canonical verifiers know their transactions will be accepted by any compliant node. New algorithms graduate into the canonical set through the companion ERC process as they gain adoption — providing a clear path for ecosystem growth without requiring protocol upgrades. Non-canonical verifiers remain fully functional for use cases where universal node acceptance is not required.
 
 ### Why No Public Key Storage?
 


### PR DESCRIPTION
## Summary
- Defines a canonical verifier set for EIP-8130 as the minimum verifier baseline compliant nodes must accept.
- Updates mempool acceptance and `eth_getAcceptedVerifiers` to expose canonical verifier requirements.
- Adds rationale for why wallets need a shared verifier acceptance baseline.

## Test plan
- `git diff --check`
- Checked editor diagnostics for `EIPS/eip-8130.md`


Made with [Cursor](https://cursor.com)