### PR TITLE
Update EIP-8130: Tighten verifier allowlist language

### DIFF
--- a/EIPS/eip-8130.md
+++ b/EIPS/eip-8130.md
@@ -21,7 +21,7 @@ Account abstraction proposals that delegate validation to wallet code force node
 
 This proposal separates verification from account logic. Each transaction explicitly declares its verifier — a contract that takes a hash and signature data and returns the authenticated owner. This makes validation predictable: wallets know the rules, and nodes can see exactly what computation a transaction requires before executing it. Nodes may optionally filter on verifier identity, accepting only known verifiers (ECDSA, P256, WebAuthn, multisig, post-quantum) and rejecting the rest without execution.
 
-New signature algorithms deploy as verifier contracts and are adopted by nodes independently with no protocol upgrade required.
+New signature algorithms are introduced through verifier contracts and standardized through the canonical verifier set.
 
 ## Specification
 
@@ -124,7 +124,7 @@ Each owner is associated with a verifier, a contract that performs signature ver
 
 Verifiers are executed via STATICCALL. Verifier addresses MUST NOT be delegated accounts — reject if the code at the verifier address starts with the delegation indicator (`0xef0100`). Execution is metered (see [Mempool Acceptance](#mempool-acceptance) for rules).
 
-Nodes MAY implement equivalent verification logic natively for well-known verifier addresses, bypassing EVM execution. The native implementation MUST produce identical results to the onchain contract. Native implementations avoid EVM interpreter overhead, have deterministic gas costs, and introduce no external state dependencies — improving mempool validation throughput.
+On the 8130 path, nodes MAY enshrine canonical verifier execution and charge standard gas targets for those verifiers. Enshrined execution MUST produce identical results to the corresponding verifier contract.
 
 `ECRECOVER_VERIFIER` (`address(1)`) is a protocol-reserved address for native secp256k1 verification. When the protocol encounters this address as a verifier in auth data, it performs ecrecover directly rather than making a STATICCALL. The `data` portion is interpreted as raw ECDSA `(r || s || v)`, and the returned `ownerId` is `bytes32(bytes20(recovered_address))`. Owners can be explicitly registered with `ECRECOVER_VERIFIER` to use native ecrecover with a custom scope, without requiring a deployed verifier contract.
 
@@ -132,7 +132,7 @@ Any contract implementing `IVerifier` can be permissionlessly deployed and regis
 
 #### Canonical Verifier Set
 
-This specification defines a canonical verifier set — the minimum signature algorithms that compliant nodes MUST accept. The initial canonical set includes:
+This specification defines a canonical verifier set which is the set of signature algorithms that compliant nodes MUST accept. The initial canonical set includes:
 
 | Name | Algorithm | Verifier |
 |------|-----------|----------|
@@ -143,7 +143,7 @@ This specification defines a canonical verifier set — the minimum signature al
 
 The canonical verifier set and corresponding contract addresses are maintained in a companion ERC <!-- TODO: ERC number --> and deployed at deterministic CREATE2 addresses across chains. The canonical set is expected to grow as new algorithms are adopted (e.g., post-quantum) through the companion ERC process.
 
-Nodes MUST include all canonical verifiers in their allowlist. Transactions using canonical verifiers are guaranteed acceptance by any compliant node. Nodes MAY extend their allowlist with additional non-canonical verifiers; transactions using non-canonical verifiers are valid but are not guaranteed acceptance across the network.
+Nodes MUST include all canonical verifiers in their allowlist and SHOULD NOT extend the allowlist with non-canonical verifiers. The 8130 path is intended to use a small, standard set of signature algorithms; accepting additional verifiers is a divergence from this specification.
 
 ### Account Types
 
@@ -533,9 +533,9 @@ All contracts are deployed at deterministic CREATE2 addresses across chains.
    - **Nonce-free key** (`nonce_key == NONCE_KEY_MAX`): skip nonce check, require `nonce_sequence == 0`, require non-zero `expiry`, and nodes SHOULD reject if `expiry` exceeds a short window (e.g., 10 seconds). Deduplicate by transaction hash.
 8. Mempool threshold: gas payer's pending count below node-configured limits.
 
-Nodes MUST maintain a verifier allowlist that includes, at minimum, all verifiers in the canonical verifier set (see [Canonical Verifier Set](#canonical-verifier-set)). Allowlisted verifiers have known gas bounds and no external state dependencies, enabling validation with no tracing and minimal state requirements — only `owner_config` and the verifier code itself.
+Nodes MUST maintain a verifier allowlist that includes all verifiers in the canonical verifier set (see [Canonical Verifier Set](#canonical-verifier-set)).
 
-Nodes MAY extend their allowlist with additional non-canonical verifiers. Nodes MAY also accept transactions with unknown verifiers by enforcing a gas cap and applying validation scope tracing to restrict opcodes and track state dependencies for invalidation.
+Nodes SHOULD NOT extend their allowlist with additional non-canonical verifiers.
 
 Nodes MAY apply higher pending transaction rate limits based on account lock state:
 
@@ -564,8 +564,6 @@ Unused execution gas (from `gas_limit`) is refunded to the payer. Intrinsic gas 
 - `status` (uint8): `0x01` = all phases succeeded (or `calls` was empty), `0x00` = one or more phases reverted. Existing tools checking `status == 1` remain correct for the success path.
 - `phaseStatuses` (uint8[]): Per-phase status array. Each entry is `0x01` (success) or `0x00` (reverted). Phases after a revert are not executed and reported as `0x00`. Empty if `calls` was empty.
 
-**`eth_getAcceptedVerifiers`**: Returns the node's verifier acceptance policy. The response includes a top-level `acceptsUnknownVerifiers` boolean indicating whether the node accepts transactions with verifiers not on its allowlist. The `verifiers` array lists each accepted verifier with its `address`, whether the node has a `native` implementation, whether it is `canonical` (part of the canonical verifier set), and `maxAuthCost` — the maximum gas the node will allow for that verifier's auth execution. Compliant nodes MUST include all canonical verifiers in the response.
-
 ### Appendix: Storage Layout
 
 The protocol reads storage directly from the Account Configuration Contract (`ACCOUNT_CONFIG_ADDRESS`) and Nonce Manager (`NONCE_MANAGER_ADDRESS`). The storage layout is defined by the deployed contract bytecode — slot derivation follows from the contract's Solidity storage declarations. The final deployed contract source serves as the canonical reference for slot locations.
@@ -592,7 +590,7 @@ The create entry only supports runtime bytecode. Delegation is set via delegatio
 
 ### Why Verifier Contracts?
 
-Enables permissionless extension — deploy a new verifier contract, nodes update their allowlist, no protocol upgrade required. The verifier returns the `ownerId` rather than accepting it as input, so the protocol never needs algorithm-specific logic — routing, derivation, and validation are all handled by the verifier. All verifiers share a single `verify(hash, data)` interface with no type-based dispatch. Owner scope provides protocol-enforced role separation without verifier cooperation.
+Enables signature-algorithm extension through verifier contracts. The verifier returns the `ownerId` rather than accepting it as input, so the protocol never needs algorithm-specific logic — routing, derivation, and validation are all handled by the verifier. All verifiers share a single `verify(hash, data)` interface with no type-based dispatch. Owner scope provides protocol-enforced role separation without verifier cooperation.
 
 ### Why 2D Nonce + `NONCE_KEY_MAX`?
 
@@ -667,9 +665,9 @@ The `0x00` = unrestricted default ensures backward compatibility.
 
 ### Why a Canonical Verifier Set?
 
-Without a required minimum set, nodes would have no obligation to accept any particular verifier beyond `ECRECOVER_VERIFIER`. Wallets would face a fragmented network where each node accepts a different combination of algorithms, making it impossible to guarantee transaction delivery for non-k1 signature types.
+Without a required verifier set, nodes could diverge on which signature algorithms they accept beyond `ECRECOVER_VERIFIER`. Wallets would face a fragmented network where each node accepts a different combination of algorithms, making it impossible to guarantee transaction delivery for non-k1 signature types.
 
-The canonical set establishes a shared baseline: wallets that use canonical verifiers know their transactions will be accepted by any compliant node. New algorithms graduate into the canonical set through the companion ERC process as they gain adoption — providing a clear path for ecosystem growth without requiring protocol upgrades. Non-canonical verifiers remain fully functional for use cases where universal node acceptance is not required.
+The canonical set establishes a shared baseline: wallets that use canonical verifiers know their transactions will be accepted by any compliant node. The set is expected to remain small, with new algorithms added through the companion ERC process as they gain broad adoption.
 
 ### Why No Public Key Storage?
 

--- a/EIPS/eip-8130.md
+++ b/EIPS/eip-8130.md
@@ -590,7 +590,7 @@ The create entry only supports runtime bytecode. Delegation is set via delegatio
 
 ### Why Verifier Contracts?
 
-Enables signature-algorithm extension through verifier contracts. The verifier returns the `ownerId` rather than accepting it as input, so the protocol never needs algorithm-specific logic — routing, derivation, and validation are all handled by the verifier. All verifiers share a single `verify(hash, data)` interface with no type-based dispatch. Owner scope provides protocol-enforced role separation without verifier cooperation.
+Enables signature-algorithm extension through verifier contracts. The verifier returns the `ownerId` rather than accepting it as input, so the protocol never needs algorithm-specific logic. All verifiers share a single `verify(hash, data)` interface with no type-based dispatch. Owner scope provides protocol-enforced role separation without verifier cooperation.
 
 ### Why 2D Nonce + `NONCE_KEY_MAX`?
 


### PR DESCRIPTION
## Summary
- Frames the canonical verifier set as the intended small set of signature algorithms for compliant nodes.
- Changes allowlist guidance so nodes SHOULD NOT include non-canonical verifiers.
- Removes `eth_getAcceptedVerifiers` and the prior native/client/no-hard-fork framing.

## Test plan
- `git diff --check`
- Checked editor diagnostics for `EIPS/eip-8130.md`


Made with [Cursor](https://cursor.com)