### PR TITLE
Update EIP-8141: Support atomic batching with any frames

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -92,7 +92,7 @@ The `flags` field configures additional execution constraints. Bit positions are
 | Flag bits | Meaning                      | Valid with  |
 |-----------|------------------------------| ----------- |
 | 0-1       | Approval scope               | Any mode    |
-| 2         | Atomic batch                 | SENDER mode |
+| 2         | Atomic batch                 | Any mode    |
 
 The `Valid with` column indicates the mode under which the flag is valid. If a flag is not valid under the current mode, the transaction is invalid.
 
@@ -118,11 +118,9 @@ for frame in tx.frames:
     total_frame_gas += frame.gas_limit
     assert total_frame_gas <= 2**64 - 1
 
-    # Atomic batch flag (bit 2 of flags) is only valid with SENDER mode, and next frame must also be SENDER.
+    # Atomic batch flag (bit 2 of flags) requires a subsequent frame to batch with.
     if frame.flags & ATOMIC_BATCH_FLAG:
-        assert frame.mode == SENDER                    # must be SENDER
         assert i + 1 < len(tx.frames)                  # must not be last frame
-        assert tx.frames[i + 1].mode == SENDER         # next frame must be SENDER
 ```
 
 #### Receipt Encoding
@@ -179,8 +177,8 @@ Then for each frame:
     - Execute the frame as a `STATICCALL`, disallowing state manipulation.
       - Only `APPROVE` can modify the state or transaction context in `VERIFY`.
     - If the frame does not successfully call `APPROVE`, the transaction is invalid.
-3. If frame has mode `SENDER` and it fails, unroll associated atomic batch.
-    - An **atomic batch** is a maximal contiguous sequence of `SENDER` frames `[i, j]` where `j > i`, frames `i` through `j - 1` have `ATOMIC_BATCH_FLAG` set, and frame `j` does not have `ATOMIC_BATCH_FLAG` set.
+3. If a frame is part of an atomic batch and it fails, unroll the associated atomic batch.
+    - An **atomic batch** is a maximal contiguous sequence of frames `[i, j]` where `j > i`, frames `i` through `j - 1` have `ATOMIC_BATCH_FLAG` set, and frame `j` does not have `ATOMIC_BATCH_FLAG` set.
     - When a frame in the batch fails, the state must be rolled back to the condition it was immediately before the atomic batch began. All remaining frames in the atomic batch are skipped.
     - Since skipped frames are not executed, the gas value allotted to them is refunded at the end of the transaction.
     - If the frame does not have an associated atomic batch, further special
@@ -464,8 +462,9 @@ To be accepted into the public mempool, a frame transaction must satisfy the fol
     - `self_verify` must call `APPROVE(APPROVE_EXECUTION_AND_PAYMENT)`.
     - `only_verify` must call `APPROVE(APPROVE_EXECUTION)`.
 4. `pay` must execute in `VERIFY` mode and successfully call `APPROVE(APPROVE_PAYMENT)`.
-5. The sum of `gas_limit` values across the validation prefix must not exceed `MAX_VERIFY_GAS`.
-6. Nodes should stop simulation immediately once `payer` has been set.
+5. No frame in the validation prefix may have the `ATOMIC_BATCH_FLAG` set.
+6. The sum of `gas_limit` values across the validation prefix must not exceed `MAX_VERIFY_GAS`.
+7. Nodes should stop simulation immediately once `payer` has been set.
 
 #### Canonical Paymaster Exception
 
@@ -630,9 +629,9 @@ Future optimizations based on pre-announcing state elements a transaction will t
 
 ### Atomic batching
 
-Atomic batching allows multiple `SENDER` frames to be grouped into a single all-or-nothing unit. This is useful when a sequence of calls is only meaningful if all succeed together, such as an approval followed by a swap, or a series of interdependent state changes. Without this feature, a revert in one frame would leave the preceding frames' state changes applied, potentially leaving the account in an undesirable intermediate state.
+Atomic batching allows multiple frames to be grouped into a single all-or-nothing unit. This is useful when a sequence of calls is only meaningful if all succeed together, such as an approval followed by a swap, or a series of interdependent state changes. Without this feature, a revert in one frame would leave the preceding frames' state changes applied, potentially leaving the account in an undesirable intermediate state.
 
-Using a flag to indicate atomic batches saves us from having to introduce a new mode. Batches are identified purely by consecutive `SENDER` frames with the flag set, terminated by a `SENDER` frame without it. This design enables consecutive atomic batches since the batch boundary is clearly indicated by the `SENDER` frame without the flag.
+Using a flag to indicate atomic batches saves us from having to introduce a new mode. Batches are identified purely by consecutive frames with the flag set, terminated by a frame without it. This design enables consecutive atomic batches since the batch boundary is clearly indicated by the frame without the flag.
 
 ### Per-frame cost
 


### PR DESCRIPTION
Support atomic batching with any frames, while disallowing batching in validation prefixes for the public mempool.

Credits to @forshtat for the suggestion.