### PR TITLE
Website: reveal heading anchor links on hover

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -15,13 +15,20 @@ $content-width: 1152px;
 }
 
 .page-content {
-  a.anchor-link {
-    width: 16px;
-    height: 16px;
-    display: inline-block;
-    margin-left: -22px;
-    &:hover {
+  h2, h3, h4, h5, h6 {
+    a.anchor-link {
+      width: 16px;
+      height: 16px;
+      display: inline-block;
+      margin-left: -22px;
+      visibility: hidden;
       background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' class='anchor-link-icon' viewBox='0 0 16 16' version='1.1' width='16' height='16' aria-hidden='true'%3E%3Cpath fill-rule='evenodd' d='M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z'%3E%3C/path%3E%3C/svg%3E");
+      background-repeat: no-repeat;
+    }
+
+    &:hover a.anchor-link,
+    a.anchor-link:focus {
+      visibility: visible;
     }
   }
 }


### PR DESCRIPTION
## Summary

Headings in EIP content are already wrapped in `<a class=\"anchor-link\" href=\"#…\">` by the `anchor_headings.html` include, but the link icon is only painted while the cursor is inside an invisible 16×16 patch in the left margin — so the anchor feature has been effectively undiscoverable. This PR scopes the rule to `h2`–`h6` inside `.page-content`, hides the anchor by default, and reveals it on heading hover (GitHub-style) or anchor focus (keyboard accessibility).

- `h1` is skipped intentionally — the page-title `<h1 class=\"page-heading\">` already carries Discuss/Source icons, so adding a third icon on that line would just clutter it
- Layout space is reserved with `visibility: hidden` rather than `display: none`, so headings don't shift when the icon appears
- Pure CSS change, no markup or include changes

## Test plan

- [ ] Hover an `##`/`###` heading in any EIP page (e.g. https://eips.ethereum.org/EIPS/eip-1) — the link icon appears to the left of the heading text
- [ ] Move cursor away — icon hides
- [ ] Click the icon — URL updates to `#section-id`
- [ ] Tab through the page — anchor link receives focus and becomes visible
- [ ] Page-title `<h1>` is unchanged (still shows Discuss/Source icons only)