### PR TITLE
Update EIP-8130: Add metadata sink

### DIFF
--- a/EIPS/eip-8130.md
+++ b/EIPS/eip-8130.md
@@ -37,6 +37,7 @@ New signature algorithms are introduced through verifier contracts and standardi
 | `REVOKED_VERIFIER` | `type(uint160).max` | Revocation marker written to implicit EOA owner slot to block re-authorization |
 | `NONCE_MANAGER_ADDRESS` | TBD <!-- TODO --> | Nonce Manager precompile address |
 | `TX_CONTEXT_ADDRESS` | TBD <!-- TODO --> | Transaction Context precompile address |
+| `METADATA_SINK_ADDRESS` | TBD <!-- TODO --> | Protocol no-op call target for transaction-level metadata |
 | `DEFAULT_ACCOUNT_ADDRESS` | TBD <!-- TODO --> | Default wallet implementation for auto-delegation |
 | `DEPLOYMENT_HEADER_SIZE` | 14 | Size of the deployment header in bytes |
 | `NONCE_KEY_MAX` | `2^256 - 1` | Nonce-free mode (expiry-only replay protection) |
@@ -478,11 +479,18 @@ Calls carry no ETH value. ETH transfers are initiated by the account's wallet by
 
 Phases execute in order from a single gas pool (`gas_limit`). Within each phase, calls execute in order and are **atomic** — if any call in a phase reverts, all state changes for that phase are discarded and remaining phases are **skipped**. Completed phases **persist** — their state changes are committed and survive later phase reverts.
 
+##### Metadata Sink
+
+When `call.to == METADATA_SINK_ADDRESS`, the call is a protocol no-op used for transaction-level metadata (for example, wallet `dataSuffix` attribution bytes). The protocol MUST treat the call as successful without account access, code lookup, EVM dispatch, call frame creation, log emission, or state changes. The bytes in `call.data` are not dispatched as execution calldata; indexers that understand the convention read them directly from the transaction's `calls` array.
+
+Metadata sink calls are signed naturally because `calls` is included in both the sender and payer signature hashes. They are charged through `tx_payload_cost` like all other transaction bytes. Because the protocol skips execution for `METADATA_SINK_ADDRESS`, no additional execution gas is charged for the metadata sink call itself.
+
 **Common patterns**:
 
 - **Simple call**: `[[{to, data}]]` — one phase, one call
 - **Atomic batch**: `[[call_a, call_b, call_c]]` — one phase, all-or-nothing
 - **Sponsor + user**: `[[sponsor_payment], [user_action_a, user_action_b]]` — sponsor in phase 0 (committed), user actions in phase 1 (atomic, skipped if sponsor fails)
+- **Metadata suffix**: append `{to: METADATA_SINK_ADDRESS, data: metadata}` as a final call for tx-level attribution or indexer metadata
 
 #### Transaction Context
 
@@ -649,6 +657,12 @@ Since every account has wallet bytecode (auto-delegation or explicit deployment)
 ### Why Delegation via Account Changes?
 
 [EIP-7702](./eip-7702.md) introduced `authorization_list` as a transaction-level field for code delegation, with ECDSA authority. This proposal moves delegation into `account_changes`, authorized by the transaction's `sender_auth`. Delegation is restricted to the account's implicit EOA owner (`ownerId == bytes32(bytes20(sender))`) so that code delegation remains portable across non-8130 chains via standard [EIP-7702](./eip-7702.md) transactions. Eventually this can be expanded to all verifier types.
+
+### Why a Metadata Sink?
+
+Some wallet APIs support tx-level metadata suffixes for attribution and indexing. Legacy transactions have a single top-level `input` byte string, but this proposal moves execution calldata into the `calls` array. A protocol no-op metadata sink keeps metadata in the existing call model instead of adding a second top-level input field with no execution semantics.
+
+Using a reserved sink address also avoids appending bytes to arbitrary application calldata, which could change contract behavior or break strict decoders. Since the sink is skipped by the protocol, wallets can add metadata as a normal signed call while indexers scan for calls to `METADATA_SINK_ADDRESS`.
 
 ### Why Account Lock?
 

--- a/EIPS/eip-8130.md
+++ b/EIPS/eip-8130.md
@@ -37,7 +37,7 @@ New signature algorithms are introduced through verifier contracts and standardi
 | `REVOKED_VERIFIER` | `type(uint160).max` | Revocation marker written to implicit EOA owner slot to block re-authorization |
 | `NONCE_MANAGER_ADDRESS` | TBD <!-- TODO --> | Nonce Manager precompile address |
 | `TX_CONTEXT_ADDRESS` | TBD <!-- TODO --> | Transaction Context precompile address |
-| `METADATA_SINK_ADDRESS` | TBD <!-- TODO --> | Protocol no-op call target for transaction-level metadata |
+| `METADATA_SINK_ADDRESS` | TBD <!-- TODO --> | Protocol no-op call target for signed call metadata |
 | `DEFAULT_ACCOUNT_ADDRESS` | TBD <!-- TODO --> | Default wallet implementation for auto-delegation |
 | `DEPLOYMENT_HEADER_SIZE` | 14 | Size of the deployment header in bytes |
 | `NONCE_KEY_MAX` | `2^256 - 1` | Nonce-free mode (expiry-only replay protection) |
@@ -481,16 +481,18 @@ Phases execute in order from a single gas pool (`gas_limit`). Within each phase,
 
 ##### Metadata Sink
 
-When `call.to == METADATA_SINK_ADDRESS`, the call is a protocol no-op used for transaction-level metadata (for example, wallet `dataSuffix` attribution bytes). The protocol MUST treat the call as successful without account access, code lookup, EVM dispatch, call frame creation, log emission, or state changes. The bytes in `call.data` are not dispatched as execution calldata; indexers that understand the convention read them directly from the transaction's `calls` array.
+When `call.to == METADATA_SINK_ADDRESS`, the call is protocol-recognized metadata (for example, wallet `dataSuffix` attribution bytes). The protocol MUST treat the call as successful without account access, code lookup, EVM dispatch, call frame creation, log emission, or state changes. The bytes in `call.data` are not dispatched as execution calldata; indexers that understand the convention read them directly from the transaction's `calls` array.
 
 Metadata sink calls are signed naturally because `calls` is included in both the sender and payer signature hashes. They are charged through `tx_payload_cost` like all other transaction bytes. Because the protocol skips execution for `METADATA_SINK_ADDRESS`, no additional execution gas is charged for the metadata sink call itself.
+
+Metadata can be scoped by placement. For example, wallets can append a single final sink call for transaction-level metadata, or include sink calls in each phase such as `[[action_1, metadata_1], [action_2, metadata_2]]` to associate metadata with specific actions.
 
 **Common patterns**:
 
 - **Simple call**: `[[{to, data}]]` — one phase, one call
 - **Atomic batch**: `[[call_a, call_b, call_c]]` — one phase, all-or-nothing
 - **Sponsor + user**: `[[sponsor_payment], [user_action_a, user_action_b]]` — sponsor in phase 0 (committed), user actions in phase 1 (atomic, skipped if sponsor fails)
-- **Metadata suffix**: append `{to: METADATA_SINK_ADDRESS, data: metadata}` as a final call for tx-level attribution or indexer metadata
+- **Metadata suffix**: append `{to: METADATA_SINK_ADDRESS, data: metadata}` as a final call or phase-local companion call for attribution or indexer metadata
 
 #### Transaction Context
 
@@ -660,9 +662,9 @@ Since every account has wallet bytecode (auto-delegation or explicit deployment)
 
 ### Why a Metadata Sink?
 
-Some wallet APIs support tx-level metadata suffixes for attribution and indexing. Legacy transactions have a single top-level `input` byte string, but this proposal moves execution calldata into the `calls` array. A protocol no-op metadata sink keeps metadata in the existing call model instead of adding a second top-level input field with no execution semantics.
+Some wallet APIs support metadata suffixes for attribution and indexing. Legacy transactions have a single top-level `input` byte string, but this proposal moves execution calldata into the `calls` array. A protocol-recognized metadata sink keeps metadata in the existing call model instead of adding a second top-level input field with no execution semantics.
 
-Using a reserved sink address also avoids appending bytes to arbitrary application calldata, which could change contract behavior or break strict decoders. Since the sink is skipped by the protocol, wallets can add metadata as a normal signed call while indexers scan for calls to `METADATA_SINK_ADDRESS`.
+Using a reserved sink address also avoids appending bytes to arbitrary application calldata, which could change contract behavior or break strict decoders. Since the sink is skipped by the protocol, wallets can add metadata as a normal signed call while indexers scan for calls to `METADATA_SINK_ADDRESS`. Placement in the `calls` array lets metadata describe the whole transaction or sit next to a specific phase/action.
 
 ### Why Account Lock?
 


### PR DESCRIPTION

DO NOT MERGE (just for discussion)

## Summary

For discussion vs https://github.com/ethereum/EIPs/pull/11578 and doing nothing.

dataSuffix is represented as a final METADATA_SINK_ADDRESS call containing the suffix bytes.

- Add `METADATA_SINK_ADDRESS` as a protocol-recognized no-op call target for signed metadata such as wallet `dataSuffix` attribution bytes.
- Keep metadata in the existing `calls` model instead of adding a new top-level `input`/`opaque_input` field.
- Allow metadata placement to compose with phases, e.g. `[[action_1, metadata_1], [action_2, metadata_2]]`, or as one final transaction-level sink call.
- Let indexers scan `calls` for `to == METADATA_SINK_ADDRESS` and read metadata from `call.data`.
- Clarify gas accounting: metadata bytes are charged through `tx_payload_cost`; the sink call is skipped by protocol and adds no account access, EVM dispatch, log emission, or execution gas.