### PR TITLE
Update EIP-7851: Few tweaks to 7851 and 8151

### DIFF
--- a/EIPS/eip-7851.md
+++ b/EIPS/eip-7851.md
@@ -13,15 +13,13 @@ requires: 7702
 
 ## Abstract
 
-This EIP extends [EIP-7702](./eip-7702.md) with a magic address that changes an active delegation, `0xef0100 || delegate_address`, into a deactivated delegation, `0xef0101 || delegate_address`. The deactivated designation preserves delegated code execution while irreversibly disabling the authority's ECDSA transaction and [EIP-7702](./eip-7702.md) authorization capability.
+This EIP extends [EIP-7702](./eip-7702.md) with a magic address that changes a standard delegation, `0xef0100 || delegate_address`, into a permanent delegation, `0xef0101 || delegate_address`. The permanent delegation preserves delegated code behavior while irreversibly disabling the authority's ECDSA transaction and [EIP-7702](./eip-7702.md) authorization capability.
 
 ## Motivation
 
 [EIP-7702](./eip-7702.md) allows an EOA to delegate execution to wallet code, but the ECDSA key can still sign transactions and replace or clear the delegation. Users who have fully moved authority into delegated code need a small protocol-level mechanism to burn that residual ECDSA authority.
 
 ## Specification
-
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
 
 `||` denotes byte concatenation.
 
@@ -33,21 +31,21 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 This EIP introduces `0xef0101` as a new delegation prefix. Account code `0xef0101 || delegate_address` permanently locks the delegation to `delegate_address` and marks the authority's ECDSA authority as deactivated.
 
-Clients MUST treat the deactivated delegation as a delegation for code execution. Any operation that follows an [EIP-7702](./eip-7702.md) delegation MUST follow `0xef0101 || delegate_address` identically, loading code from `delegate_address` and executing it in the authority's context.
+Clients must treat the permanent delegation as a delegation for code execution. Any operation that follows an [EIP-7702](./eip-7702.md) delegation MUST follow `0xef0101 || delegate_address` identically, loading code from `delegate_address` and executing it in the authority's context.
 
-During [EIP-7702](./eip-7702.md) authorization processing, if `authority` currently has code equal to `0xef0101 || delegate_address`, any authorization signed by `authority` MUST be considered invalid and skipped.
+During [EIP-7702](./eip-7702.md) authorization processing, if `authority` currently has code equal to `0xef0101 || delegate_address`, any authorization signed by `authority` must be considered invalid and skipped.
 
-For other authorities, after a tuple has satisfied the normal [EIP-7702](./eip-7702.md) validation rules up to and including authority recovery and the authority nonce check, clients MUST apply the following rules:
+For other authorities, after a tuple has satisfied the normal [EIP-7702](./eip-7702.md) validation rules up to and including authority recovery and the authority nonce check, clients must apply the following rules:
 
-- If `address != DEACTIVATE_ADDRESS`, clients MUST process the tuple as a normal [EIP-7702](./eip-7702.md) authorization.
-- If `address == DEACTIVATE_ADDRESS` and `authority` currently has code exactly equal to `0xef0100 || delegate_address`, clients MUST write `0xef0101 || delegate_address`.
-- If `address == DEACTIVATE_ADDRESS` and `authority` does not currently have code exactly equal to `0xef0100 || delegate_address`, clients MUST skip this authorization without making any state changes.
+- If `address != DEACTIVATE_ADDRESS`, clients must process the tuple as a normal [EIP-7702](./eip-7702.md) authorization.
+- If `address == DEACTIVATE_ADDRESS` and `authority` currently has code exactly equal to `0xef0100 || delegate_address`, clients must write `0xef0101 || delegate_address`.
+- If `address == DEACTIVATE_ADDRESS` and `authority` does not currently have code exactly equal to `0xef0100 || delegate_address`, clients must skip this authorization without making any state changes.
 
 After a successful deactivation, clients MUST continue [EIP-7702](./eip-7702.md) authorization processing, including nonce increment and gas accounting, as if the tuple had written a normal delegation.
 
-An ECDSA-authenticated transaction whose recovered sender has code equal to `0xef0101 || delegate_address` MUST NOT be included in a block. Transaction pools MUST reject such transactions.
+An ECDSA-authenticated transaction whose recovered sender has code equal to `0xef0101 || delegate_address` MUST NOT be included in a block. Transaction pools must reject such transactions.
 
-The deactivated delegation is irreversible.
+The permanent delegation is irreversible.
 
 ## Rationale
 
@@ -65,7 +63,7 @@ Existing `0xef0100 || delegate_address` delegations are unchanged. Clients that 
 
 This EIP only invalidates protocol-level ECDSA-authenticated transactions and [EIP-7702](./eip-7702.md) authorizations. Contracts that verify ECDSA signatures directly, such as token `permit` functions, will not automatically reject signatures from a deactivated authority. For addressing the behavior of the ecrecover precompile with deactivated keys, see companion proposal [EIP-8151](./eip-8151.md).
 
-Deactivation also permanently locks the account to `delegate_address`. If that delegate contract is later found unsafe, the user cannot switch to a new delegate. Users should spend sufficient time using the active delegation first, and SHOULD deactivate only when the delegate has its own upgrade path.
+Deactivation also permanently locks the account to `delegate_address`. If that delegate contract is later found unsafe, the user cannot switch to a new delegate. Users should spend sufficient time using the standard delegation first, and SHOULD deactivate only when the delegate has its own upgrade path.
 
 [EIP-7702](./eip-7702.md) nonces and chain IDs provide replay protection for deactivation authorizations. A chain ID of `0` remains valid on any chain under [EIP-7702](./eip-7702.md), so users who want deactivation on only one chain should sign a chain-specific authorization.
 

--- a/EIPS/eip-8151.md
+++ b/EIPS/eip-8151.md
@@ -41,7 +41,7 @@ Starting at the activation of this EIP, the `ecRecover` precompile at address `E
 
 ### Deactivation Check
 
-An address is considered to have deactivated ECDSA authority if and only if its account code is exactly `0xef0101 || delegate_address`, consistent with the deactivated delegation prefix defined in [EIP-7851](./eip-7851.md):
+An address is considered to have deactivated ECDSA authority if and only if its account code is exactly `0xef0101 || delegate_address`, consistent with the permanent delegation prefix defined in [EIP-7851](./eip-7851.md):
 
 ```python
 code = state.get_code(recovered_address)


### PR DESCRIPTION
Notable changes:
- changed wording from "inactive delegation" to "permanent delegation"
- changed "active delegation" to "standard delegation"
- removed ugly RFC capital words