### PR TITLE
Update EIP-7928: Fix contract creation wording

### DIFF
--- a/EIPS/eip-7928.md
+++ b/EIPS/eip-7928.md
@@ -99,7 +99,7 @@ It **MUST** include:
     - Targets of `BALANCE`, `EXTCODESIZE`, `EXTCODECOPY`, `EXTCODEHASH` opcodes
     - Targets of `CALL`, `CALLCODE`, `DELEGATECALL`, `STATICCALL` (even if they revert; see [Gas Validation Before State Access](#gas-validation-before-state-access) for inclusion conditions)
     - Target addresses of `CREATE`/`CREATE2` if the target account is accessed
-    - Deployed contract addresses from calls with initcode to empty addresses (e.g., calling `0x0` with initcode)
+    - Deployed contract addresses from creation transactions, i.e. transactions with an empty `to` field, which are always included since the deployment address is unconditionally accessed during transaction setup
     - Transaction sender and recipient addresses (even for zero-value transfers)
     - Beneficiary addresses for `SELFDESTRUCT`
     - System contract addresses accessed during pre/post-execution; the system caller address, `SYSTEM_ADDRESS` (`0xfffffffffffffffffffffffffffffffffffffffe`), MUST NOT be included unless it experiences state access itself


### PR DESCRIPTION
Fix the wrong wording in the EIP wrt contract creations using an empty `to` address.
h/t @rjl493456442