### PR TITLE
Update EIP-7851: use code-controlled delegation

### DIFF
--- a/EIPS/eip-7851.md
+++ b/EIPS/eip-7851.md
@@ -1,9 +1,9 @@
 ---
 eip: 7851
-title: Disable ECDSA Authority for Delegated EOAs
-description: Irreversibly disable ECDSA transaction and authorization capability for EIP-7702 delegated EOAs.
+title: Code-Controlled EOA Delegation
+description: Allow EIP-7702 delegated EOAs to update delegation through code while permanently disabling residual ECDSA authority.
 author: Liyi Guo (@colinlyguo), Nicolas Consigny (@nconsigny)
-discussions-to: https://ethereum-magicians.org/t/eip-7851-disable-ecdsa-authority-for-delegated-eoas/22344
+discussions-to: https://ethereum-magicians.org/t/eip-7851-code-controlled-eoa-delegation/22344
 status: Draft
 type: Standards Track
 category: Core
@@ -13,63 +13,92 @@ requires: 7702
 
 ## Abstract
 
-This EIP extends [EIP-7702](./eip-7702.md) with a magic address that changes a standard delegation, `0xef0100 || delegate_address`, into a permanent delegation, `0xef0101 || delegate_address`. The permanent delegation preserves delegated code behavior while irreversibly disabling the authority's ECDSA transaction and [EIP-7702](./eip-7702.md) authorization capability.
+This EIP extends [EIP-7702](./eip-7702.md) with an ECDSA-disabled delegation prefix `0xef0101` and a self-only opcode `SETSELFDELEGATE`. EIP-7702 bootstraps delegation by writing `0xef0100 || delegate_address` through the original EOA key. Delegated wallet code can then call `SETSELFDELEGATE` to write `0xef0101 || delegate_address`, permanently disabling residual ECDSA authority while preserving code-controlled delegate updates.
 
 ## Motivation
 
-[EIP-7702](./eip-7702.md) allows an EOA to delegate execution to wallet code, but the ECDSA key can still sign transactions and replace or clear the delegation. Users who have fully moved authority into delegated code need a small protocol-level mechanism to burn that residual ECDSA authority.
+[EIP-7702](./eip-7702.md) bootstraps delegation with the original EOA key, but after control has moved into wallet code, users may operate the account through the wallet code itself. This EIP lets wallet code control the delegation lifecycle and burn residual ECDSA authority.
 
 ## Specification
 
 `||` denotes byte concatenation.
 
+`0xef0100 || delegate_address` is an ECDSA-enabled delegation, and `0xef0101 || delegate_address` is an ECDSA-disabled delegation. ECDSA-disabled means the original ECDSA key can no longer authorize transactions or [EIP-7702](./eip-7702.md) delegation changes. It does not mean the delegate target is frozen forever: wallet code is capable of updating the delegate while staying ECDSA-disabled. The irreversible invariant is that once ECDSA authority is disabled, it can never be restored.
+
 ### Parameters
 
 | Parameter | Value |
 | --- | --- |
-| `DEACTIVATE_ADDRESS` | `0x0000000000000000000000000000000000007851` |
+| `SETSELFDELEGATE_OPCODE` | `TBD` |
+| `SETSELFDELEGATE_GAS` | `9500` |
 
-This EIP introduces `0xef0101` as a new delegation prefix. Account code `0xef0101 || delegate_address` permanently locks the delegation to `delegate_address` and marks the authority's ECDSA authority as deactivated.
+### Delegated Code Execution
 
-Clients must treat the permanent delegation as a delegation for code execution. Any operation that follows an [EIP-7702](./eip-7702.md) delegation MUST follow `0xef0101 || delegate_address` identically, loading code from `delegate_address` and executing it in the authority's context.
+Clients must treat `0xef0101 || delegate_address` identically to `0xef0100 || delegate_address` for delegated code execution.
 
-During [EIP-7702](./eip-7702.md) authorization processing, if `authority` currently has code equal to `0xef0101 || delegate_address`, any authorization signed by `authority` must be considered invalid and skipped.
+### SETSELFDELEGATE
 
-For other authorities, after a tuple has satisfied the normal [EIP-7702](./eip-7702.md) validation rules up to and including authority recovery and the authority nonce check, clients must apply the following rules:
+`SETSELFDELEGATE(delegate_address)` takes one stack item. The low 160 bits of the stack item are interpreted as `delegate_address`.
 
-- If `address != DEACTIVATE_ADDRESS`, clients must process the tuple as a normal [EIP-7702](./eip-7702.md) authorization.
-- If `address == DEACTIVATE_ADDRESS` and `authority` currently has code exactly equal to `0xef0100 || delegate_address`, clients must write `0xef0101 || delegate_address`.
-- If `address == DEACTIVATE_ADDRESS` and `authority` does not currently have code exactly equal to `0xef0100 || delegate_address`, clients must skip this authorization without making any state changes.
+Before execution:
 
-After a successful deactivation, clients MUST continue [EIP-7702](./eip-7702.md) authorization processing, including nonce increment and gas accounting, as if the tuple had written a normal delegation.
+```text
+[..., delegate_address]
+```
 
-An ECDSA-authenticated transaction whose recovered sender has code equal to `0xef0101 || delegate_address` MUST NOT be included in a block. Transaction pools must reject such transactions.
+After execution:
 
-The permanent delegation is irreversible.
+```text
+[..., success]
+```
+
+`success` is `1` on success and `0` when no state change is made.
+
+The opcode costs `SETSELFDELEGATE_GAS` for each execution attempt.
+
+If executed in a static context, `SETSELFDELEGATE` must cause an exceptional halt.
+
+Let `authority` be the current execution-context address. Let `code` be the raw account code stored in state for `authority`, not the resolved delegated code currently being executed. A successful update affects only future delegated-code resolution; it does not change the code executing in the current frame.
+
+`SETSELFDELEGATE` is self-only. It must not accept a target account and must not modify any account other than `authority`.
+
+State changes made by `SETSELFDELEGATE` follow normal EVM revert semantics. If the frame or transaction reverts, the delegation update reverts.
+
+Execution proceeds as follows:
+
+1. If `delegate_address == address(0)`, push `0` and make no state change.
+2. If `code` is exactly 23 bytes long and starts with either `0xef0100` or `0xef0101`, set `code(authority) = 0xef0101 || delegate_address` and push `1`.
+3. Otherwise, push `0` and make no state change.
+
+Calling `SETSELFDELEGATE` from an ECDSA-enabled delegation disables ECDSA authority and sets the delegate. Calling it from an ECDSA-disabled delegation redelegates while keeping ECDSA authority disabled.
+
+### Validation
+
+During [EIP-7702](./eip-7702.md) authorization processing, if `authority` currently has code that is exactly 23 bytes long and starts with `0xef0101`, any authorization signed by `authority` must be considered invalid and skipped.
+
+An ECDSA-authenticated transaction whose recovered sender has code that is exactly 23 bytes long and starts with `0xef0101` must not be included in a block. Transaction pools must reject such transactions.
 
 ## Rationale
 
-Using a magic address makes the deactivation intent explicit in the authorization payload without changing [EIP-7702](./eip-7702.md)'s payload format. `DEACTIVATE_ADDRESS` is a reserved operation marker, not an ordinary delegate target. A payload-level deactivation flag is not used because it would add implementation complexity and plumbing across transaction encoding, signing, and validation.
+[EIP-7702](./eip-7702.md) bootstraps delegation with the original EOA key. After bootstrap, the account may be controlled through wallet code, passkeys, multisig, social recovery, or modules. The ECDSA-disabled lifecycle should therefore be available from the delegated account's execution path.
 
-Using a same-delegate authorization as the deactivation trigger is not used because it is unintuitive and consumes the normal meaning of reauthorizing the same delegate address. With `DEACTIVATE_ADDRESS`, a pending deactivation authorization can be invalidated by consuming the authority nonce with any normal transaction or [EIP-7702](./eip-7702.md) authorization, including reauthorizing the same delegate address.
+`SETSELFDELEGATE` moves this decision into wallet code. The first successful call permanently disables residual ECDSA authority. Later calls may update the delegate, but always remain ECDSA-disabled. The permanent property is not that the delegate target is frozen forever; the permanent property is that residual ECDSA authority is disabled forever.
 
-Using `nonce == 2**64 - 1` as a special deactivation operation is not used because the authorization would no longer bind to the authority's current nonce in the normal [EIP-7702](./eip-7702.md) way. Such a signature could remain valid indefinitely.
+`SETSELFDELEGATE_GAS` is `9500`, equal to `PER_AUTH_BASE_COST` from [EIP-7702](./eip-7702.md) minus the `3000` gas attributed to recovering the authority address. The opcode writes one 23-byte delegation indicator for the current execution-context account after delegation has already resolved, and does not verify a signature, process an authorization tuple, increment the account nonce, or touch another account.
 
 ## Backwards Compatibility
 
-Existing `0xef0100 || delegate_address` delegations are unchanged. Clients that implement this EIP must recognize `0xef0101 || delegate_address` as a delegation for execution and as a deactivated ECDSA authority for validation.
+Existing `0xef0100 || delegate_address` delegations are unchanged. Clients that implement this EIP must recognize `0xef0101 || delegate_address` as a delegation for execution and as an ECDSA-disabled authority for validation.
 
 ## Security Considerations
 
-This EIP only invalidates protocol-level ECDSA-authenticated transactions and [EIP-7702](./eip-7702.md) authorizations. Contracts that verify ECDSA signatures directly, such as token `permit` functions, will not automatically reject signatures from a deactivated authority. For addressing the behavior of the ecrecover precompile with deactivated keys, see companion proposal [EIP-8151](./eip-8151.md).
+Entering ECDSA-disabled delegation is irreversible with respect to ECDSA authority. The original EOA key can never restore ECDSA authority after `0xef0101` is set.
 
-Deactivation also permanently locks the account to `delegate_address`. If that delegate contract is later found unsafe, the user cannot switch to a new delegate. Users should spend sufficient time using the standard delegation first, and SHOULD deactivate only when the delegate has its own upgrade path.
+Wallet code can still update the delegate while remaining ECDSA-disabled. Wallets should expose `SETSELFDELEGATE` only after explicit user confirmation and treat it as the highest privilege.
 
-[EIP-7702](./eip-7702.md) nonces and chain IDs provide replay protection for deactivation authorizations. A chain ID of `0` remains valid on any chain under [EIP-7702](./eip-7702.md), so users who want deactivation on only one chain should sign a chain-specific authorization.
+The execution load change is small. Execution paths that already resolve delegated code can reuse the existing delegation-code lookup. Transaction pools may need one additional account-code read for the sender to reject ECDSA-authenticated transactions from ECDSA-disabled authorities.
 
-The execution load change is small. Execution paths that already resolve delegated code can reuse the existing delegation-code lookup. Transaction pools that proactively reject ECDSA-authenticated transactions from deactivated authorities may need one additional account-code read for the sender.
-
-Wallets and SDKs that expose EIP-7702 authorization signing should display `DEACTIVATE_ADDRESS` as an irreversible ECDSA-authority deactivation operation, not as a delegation target.
+This EIP only invalidates protocol-level ECDSA-authenticated transactions and [EIP-7702](./eip-7702.md) authorizations. Contracts that verify ECDSA signatures directly, such as token `permit` functions, will not automatically reject signatures from an ECDSA-disabled authority. For addressing the behavior of the `ecrecover` precompile with ECDSA-disabled authorities, see companion proposal [EIP-8151](./eip-8151.md).
 
 ## Copyright
 

--- a/EIPS/eip-8151.md
+++ b/EIPS/eip-8151.md
@@ -21,8 +21,6 @@ This EIP modifies the `ecRecover` precompile at address `0x000000000000000000000
 
 ## Specification
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119) and [RFC 8174](https://www.rfc-editor.org/rfc/rfc8174).
-
 | Constant                   | Value                                        |
 |----------------------------|----------------------------------------------|
 | `ECRECOVER_ADDRESS`        | `0x0000000000000000000000000000000000000001` |
@@ -31,7 +29,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ### Modified `ecRecover` Behavior
 
-Starting at the activation of this EIP, the `ecRecover` precompile at address `ECRECOVER_ADDRESS` MUST perform the following steps:
+Starting at the activation of this EIP, the `ecRecover` precompile at address `ECRECOVER_ADDRESS` must perform the following steps:
 
 1. Perform ECDSA public key recovery from the input `(hash, v, r, s)` as currently specified, yielding a `recovered_address`.
 2. If recovery fails, return 32 zero bytes and consume `3000` gas.
@@ -41,7 +39,7 @@ Starting at the activation of this EIP, the `ecRecover` precompile at address `E
 
 ### Deactivation Check
 
-An address is considered to have deactivated ECDSA authority if and only if its account code is exactly `0xef0101 || delegate_address`, consistent with the permanent delegation prefix defined in [EIP-7851](./eip-7851.md):
+An address is considered to have deactivated ECDSA authority if and only if its account code is exactly `0xef0101 || delegate_address`, consistent with the ECDSA-disabled delegation prefix defined in [EIP-7851](./eip-7851.md):
 
 ```python
 code = state.get_code(recovered_address)
@@ -53,12 +51,12 @@ is_deactivated = len(code) == 23 and code[:3] == bytes.fromhex("ef0101")
 When ECDSA recovery fails, no state access is performed and the gas cost
 remains `3000`.
 
-When ECDSA recovery succeeds, the precompile MUST access the account of
-`recovered_address` to read its code. This access MUST follow the
+When ECDSA recovery succeeds, the precompile must access the account of
+`recovered_address` to read its code. This access must follow the
 [EIP-2929](./eip-2929.md) warm/cold rules:
 
 - If `recovered_address` is already in the transaction's `accessed_addresses` set, the additional cost is `WARM_ACCOUNT_ACCESS_COST` (100).
-- Otherwise, the additional cost is `COLD_ACCOUNT_ACCESS_COST` (2600), and `recovered_address` MUST be added to the `accessed_addresses` set, making it warm for subsequent operations within the same transaction.
+- Otherwise, the additional cost is `COLD_ACCOUNT_ACCESS_COST` (2600), and `recovered_address` must be added to the `accessed_addresses` set, making it warm for subsequent operations within the same transaction.
 
 ## Rationale
 
@@ -80,7 +78,7 @@ Since the precompile now reads account state, the additional gas cost follows th
 
 For addresses whose ECDSA authority has been deactivated under [EIP-7851](./eip-7851.md), `ecRecover` now returns 32 zero bytes where it previously returned the recovered address.
 
-On every successful ECDSA recovery, the precompile now performs an additional account access, adding either `WARM_ACCOUNT_ACCESS_COST` (100) or `COLD_ACCOUNT_ACCESS_COST` (2600) to the base cost of `3000`. Transactions that invoke `ecRecover` near their gas limit MAY fail with an out-of-gas error after activation.
+On every successful ECDSA recovery, the precompile now performs an additional account access, adding either `WARM_ACCOUNT_ACCESS_COST` (100) or `COLD_ACCOUNT_ACCESS_COST` (2600) to the base cost of `3000`. Transactions that invoke `ecRecover` near their gas limit may fail with an out-of-gas error after activation.
 
 ## Reference Implementation
 


### PR DESCRIPTION
After absorbing some nice considerations, I updated EIP-7851 away from the EIP-7702 authorization-marker path.

The key issue: once control has moved into delegated wallet code, requiring the original EOA key again to disable residual ECDSA authority does not follow the "let the code decide" model.

For example, after delegation, the old EOA key may no longer be used by the wallet. It may be unavailable, or intentionally "generated-and-discarded" after setup, but historical signatures can still make it crackable in a post-quantum world.

The new design introduces `SETSELFDELEGATE(delegate_address)`, a self-only opcode that lets delegated wallet code write `0xef0101 || delegate_address`.

This permanently disables residual ECDSA authority while still allowing wallet code to update the delegate in ECDSA-disabled mode.

