### PR TITLE
Update EIP-7851: tweak wording based on forum discussions

### DIFF
--- a/EIPS/eip-7851.md
+++ b/EIPS/eip-7851.md
@@ -38,7 +38,9 @@ Clients must treat `0xef0101 || delegate_address` identically to `0xef0100 || de
 
 ### SETSELFDELEGATE
 
-`SETSELFDELEGATE(delegate_address)` takes one stack item. The low 160 bits of the stack item are interpreted as `delegate_address`.
+`SETSELFDELEGATE(delegate_address)` is self-only. Define `authority` as the current execution-context address. The opcode updates only `authority`.
+
+The opcode takes one stack item. The low 160 bits of the stack item are interpreted as `delegate_address`.
 
 Before execution:
 
@@ -58,11 +60,9 @@ The opcode costs `SETSELFDELEGATE_GAS` for each execution attempt.
 
 If executed in a static context, `SETSELFDELEGATE` must cause an exceptional halt.
 
-Let `authority` be the current execution-context address. Let `code` be the raw account code stored in state for `authority`, not the resolved delegated code currently being executed. A successful update affects only future delegated-code resolution; it does not change the code executing in the current frame.
-
-`SETSELFDELEGATE` is self-only. It must not accept a target account and must not modify any account other than `authority`.
-
 State changes made by `SETSELFDELEGATE` follow normal EVM revert semantics. If the frame or transaction reverts, the delegation update reverts.
+
+The `code` checked by this opcode is the raw account code stored in state for `authority`, not the code obtained by following the delegation indicator for the current frame.
 
 Execution proceeds as follows:
 
@@ -70,19 +70,23 @@ Execution proceeds as follows:
 2. If `code` is exactly 23 bytes long and starts with either `0xef0100` or `0xef0101`, set `code(authority) = 0xef0101 || delegate_address` and push `1`.
 3. Otherwise, push `0` and make no state change.
 
+After a successful update, later code-executing operations targeting `authority` follow the updated delegation indicator to obtain the code to execute.
+
+More specifically, the effect is frame-local. Frames that have already obtained code continue executing that code. A re-entrant call to `authority` later in the same transaction is a later code-executing operation and therefore loads code through the updated delegation indicator.
+
 Calling `SETSELFDELEGATE` from an ECDSA-enabled delegation disables ECDSA authority and sets the delegate. Calling it from an ECDSA-disabled delegation redelegates while keeping ECDSA authority disabled.
 
 ### Validation
 
 During [EIP-7702](./eip-7702.md) authorization processing, if `authority` currently has code that is exactly 23 bytes long and starts with `0xef0101`, any authorization signed by `authority` must be considered invalid and skipped.
 
-An ECDSA-authenticated transaction whose recovered sender has code that is exactly 23 bytes long and starts with `0xef0101` must not be included in a block. Transaction pools must reject such transactions.
+An ECDSA-authenticated transaction whose recovered sender has code that is exactly 23 bytes long and starts with `0xef0101` in the current state is invalid and must not be included in a block. Transaction pools must reject such transactions.
 
 ## Rationale
 
 [EIP-7702](./eip-7702.md) bootstraps delegation with the original EOA key. After bootstrap, the account may be controlled through wallet code, passkeys, multisig, social recovery, or modules. The ECDSA-disabled lifecycle should therefore be available from the delegated account's execution path.
 
-`SETSELFDELEGATE` moves this decision into wallet code. The first successful call permanently disables residual ECDSA authority. Later calls may update the delegate, but always remain ECDSA-disabled. The permanent property is not that the delegate target is frozen forever; the permanent property is that residual ECDSA authority is disabled forever.
+`SETSELFDELEGATE` moves this decision into wallet code. The first successful call permanently disables residual ECDSA authority. Later calls may update the delegate, but ECDSA remains disabled.
 
 `SETSELFDELEGATE_GAS` is `9500`, equal to `PER_AUTH_BASE_COST` from [EIP-7702](./eip-7702.md) minus the `3000` gas attributed to recovering the authority address. The opcode writes one 23-byte delegation indicator for the current execution-context account after delegation has already resolved, and does not verify a signature, process an authorization tuple, increment the account nonce, or touch another account.
 


### PR DESCRIPTION
This PR tweaks EIP-7851 wording based on forum discussions, clarifying frame-local execution semantics and transaction validity wording.
