### PR TITLE
Update EIP-7732: Update EIP-7732 Gloas summary

### DIFF
--- a/EIPS/eip-7732.md
+++ b/EIPS/eip-7732.md
@@ -113,14 +113,6 @@ A summary of the main changes is included below, the [Rationale](#rationale) sec
 
 ##### Configuration
 
-###### Validator cycle
-
-| Name                                         | Value                                    |
-| -------------------------------------------- | ---------------------------------------- |
-| `CHURN_LIMIT_QUOTIENT_GLOAS`                 | `uint64(2**15)` (= 32,768)               |
-| `CONSOLIDATION_CHURN_LIMIT_QUOTIENT`         | `uint64(2**16)` (= 65,536)               |
-| `MAX_PER_EPOCH_ACTIVATION_CHURN_LIMIT_GLOAS` | `Gwei(2**8 * 10**9)` (= 256,000,000,000) |
-
 ###### Time parameters
 
 | Name                                | Value                      |  Unit  |

--- a/EIPS/eip-7732.md
+++ b/EIPS/eip-7732.md
@@ -338,6 +338,7 @@ The `BeaconState` container is modified with the addition of:
 - `builder_pending_payments`, of type `Vector[BuilderPendingPayment, 2 * SLOTS_PER_EPOCH]` to track pending payments from builders to proposers before the execution payload has been processed. 
 - `builder_pending_withdrawals`, of type `List[BuilderPendingWithdrawal, BUILDER_PENDING_WITHDRAWALS_LIMIT]` to track pending withdrawals to the execution layer with the builders' payments. 
 - `latest_block_hash`, of type `Hash32`, to track the blockhash of the last execution payload in the blockchain. 
+- `latest_execution_payload_bid`, of type `ExecutionPayloadBid`, to track the latest accepted builder bid. This bid is used to verify the corresponding execution payload envelope and to process the parent execution payload before the next block's bid overwrites it.
 - `payload_expected_withdrawals` of type `List[Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD]` to track the latest withdrawals that were deducted in the consensus layer and need to still be honored in the Execution Layer.
 - `ptc_window`, of type `Vector[Vector[ValidatorIndex, PTC_SIZE], (2 + MIN_SEED_LOOKAHEAD) * SLOTS_PER_EPOCH]` to cache the PTC assignments in the lookahead window.
 

--- a/EIPS/eip-7732.md
+++ b/EIPS/eip-7732.md
@@ -35,12 +35,15 @@ No changes are required.
 
 The full consensus changes can be found in the consensus-specs Github repository. They are split between: 
 
-- [Beacon Chain](https://github.com/ethereum/consensus-specs/blob/c94138e73e0e70eb4b27f9be4d4e9325fa1aebf7/specs/gloas/beacon-chain.md) changes.
-- [Fork choice](https://github.com/ethereum/consensus-specs/blob/c94138e73e0e70eb4b27f9be4d4e9325fa1aebf7/specs/gloas/fork-choice.md) changes.
-- [P2P](https://github.com/ethereum/consensus-specs/blob/c94138e73e0e70eb4b27f9be4d4e9325fa1aebf7/specs/gloas/p2p-interface.md) changes.
-- [Honest validator guide](https://github.com/ethereum/consensus-specs/blob/c94138e73e0e70eb4b27f9be4d4e9325fa1aebf7/specs/gloas/validator.md) changes.
-- A new [honest builder](https://github.com/ethereum/consensus-specs/blob/c94138e73e0e70eb4b27f9be4d4e9325fa1aebf7/specs/gloas/builder.md) guide. 
-- [Fork logic](https://github.com/ethereum/consensus-specs/blob/c94138e73e0e70eb4b27f9be4d4e9325fa1aebf7/specs/gloas/fork.md) changes. 
+- [Beacon Chain](https://github.com/ethereum/consensus-specs/blob/267e007f0e5e9f29f2e0325afc9ae5523171fc19/specs/gloas/beacon-chain.md) changes.
+- [Fork choice](https://github.com/ethereum/consensus-specs/blob/267e007f0e5e9f29f2e0325afc9ae5523171fc19/specs/gloas/fork-choice.md) changes.
+- [P2P](https://github.com/ethereum/consensus-specs/blob/267e007f0e5e9f29f2e0325afc9ae5523171fc19/specs/gloas/p2p-interface.md) changes.
+- [Honest validator guide](https://github.com/ethereum/consensus-specs/blob/267e007f0e5e9f29f2e0325afc9ae5523171fc19/specs/gloas/validator.md) changes.
+- A new [honest builder](https://github.com/ethereum/consensus-specs/blob/267e007f0e5e9f29f2e0325afc9ae5523171fc19/specs/gloas/builder.md) guide.
+- [Fork logic](https://github.com/ethereum/consensus-specs/blob/267e007f0e5e9f29f2e0325afc9ae5523171fc19/specs/gloas/fork.md) changes.
+- [Light client](https://github.com/ethereum/consensus-specs/tree/267e007f0e5e9f29f2e0325afc9ae5523171fc19/specs/gloas/light-client) changes.
+- [Partial column sidecar](https://github.com/ethereum/consensus-specs/blob/267e007f0e5e9f29f2e0325afc9ae5523171fc19/specs/gloas/partial-columns/p2p-interface.md) changes.
+- [Weak subjectivity](https://github.com/ethereum/consensus-specs/blob/267e007f0e5e9f29f2e0325afc9ae5523171fc19/specs/gloas/weak-subjectivity.md) changes.
 
 A summary of the main changes is included below, the [Rationale](#rationale) section contains explanation for most of the design decisions around these changes. 
 
@@ -111,11 +114,19 @@ A summary of the main changes is included below, the [Rationale](#rationale) sec
 
 ##### Configuration
 
+###### Validator cycle
+
+| Name                                         | Value                                    |
+| -------------------------------------------- | ---------------------------------------- |
+| `CHURN_LIMIT_QUOTIENT_GLOAS`                 | `uint64(2**15)` (= 32,768)               |
+| `CONSOLIDATION_CHURN_LIMIT_QUOTIENT`         | `uint64(2**16)` (= 65,536)               |
+| `MAX_PER_EPOCH_ACTIVATION_CHURN_LIMIT_GLOAS` | `Gwei(2**8 * 10**9)` (= 256,000,000,000) |
+
 ###### Time parameters
 
-| Name                                | Value                 |  Unit  |
-| ----------------------------------- | --------------------- | :----: |
-| `MIN_BUILDER_WITHDRAWABILITY_DELAY` | `uint64(2**6)` (= 64) | epochs |
+| Name                                | Value                      |  Unit  |
+| ----------------------------------- | -------------------------- | :----: |
+| `MIN_BUILDER_WITHDRAWABILITY_DELAY` | `uint64(2**13)` (= 8,192) | epochs |
 
 ##### Containers
 
@@ -202,6 +213,7 @@ class ExecutionPayloadBid(Container):
     value: Gwei
     execution_payment: Gwei
     blob_kzg_commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK]
+    execution_requests_root: Root
 ```
 
 ###### `SignedExecutionPayloadBid`
@@ -220,8 +232,7 @@ class ExecutionPayloadEnvelope(Container):
     execution_requests: ExecutionRequests
     builder_index: BuilderIndex
     beacon_block_root: Root
-    slot: Slot
-    state_root: Root
+    parent_beacon_block_root: Root
 ```
 
 ###### `SignedExecutionPayloadEnvelope`
@@ -261,6 +272,8 @@ class BeaconBlockBody(Container):
     signed_execution_payload_bid: SignedExecutionPayloadBid
     # [New in Gloas:EIP7732]
     payload_attestations: List[PayloadAttestation, MAX_PAYLOAD_ATTESTATIONS]
+    # [New in Gloas:EIP7732]
+    parent_execution_requests: ExecutionRequests
 ```
 
 ###### `BeaconState`
@@ -294,7 +307,7 @@ class BeaconState(Container):
     # [Modified in Gloas:EIP7732]
     # Removed `latest_execution_payload_header`
     # [New in Gloas:EIP7732]
-    latest_execution_payload_bid: ExecutionPayloadBid
+    latest_block_hash: Hash32
     next_withdrawal_index: WithdrawalIndex
     next_withdrawal_validator_index: ValidatorIndex
     historical_summaries: List[HistoricalSummary, HISTORICAL_ROOTS_LIMIT]
@@ -319,9 +332,11 @@ class BeaconState(Container):
     # [New in Gloas:EIP7732]
     builder_pending_withdrawals: List[BuilderPendingWithdrawal, BUILDER_PENDING_WITHDRAWALS_LIMIT]
     # [New in Gloas:EIP7732]
-    latest_block_hash: Hash32
+    latest_execution_payload_bid: ExecutionPayloadBid
     # [New in Gloas:EIP7732]
     payload_expected_withdrawals: List[Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD]
+    # [New in Gloas:EIP7732]
+    ptc_window: Vector[Vector[ValidatorIndex, PTC_SIZE], (2 + MIN_SEED_LOOKAHEAD) * SLOTS_PER_EPOCH]
 ```
 
 The `BeaconState` container is modified with the addition of:
@@ -333,24 +348,28 @@ The `BeaconState` container is modified with the addition of:
 - `builder_pending_withdrawals`, of type `List[BuilderPendingWithdrawal, BUILDER_PENDING_WITHDRAWALS_LIMIT]` to track pending withdrawals to the execution layer with the builders' payments. 
 - `latest_block_hash`, of type `Hash32`, to track the blockhash of the last execution payload in the blockchain. 
 - `payload_expected_withdrawals` of type `List[Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD]` to track the latest withdrawals that were deducted in the consensus layer and need to still be honored in the Execution Layer.
+- `ptc_window`, of type `Vector[Vector[ValidatorIndex, PTC_SIZE], (2 + MIN_SEED_LOOKAHEAD) * SLOTS_PER_EPOCH]` to cache the PTC assignments in the lookahead window.
 
 The `BeaconBlockBody` is modified with the addition of:
 
 - `signed_execution_payload_bid` of type `SignedExecutionPayloadBid` with the builder's commitment.
 - `payload_attestations` of type `List[PayloadAttestation, MAX_PAYLOAD_ATTESTATIONS]` a list of PTC attestations from the previous slot.
+- `parent_execution_requests` of type `ExecutionRequests` to carry the execution requests from the parent's payload when the block builds on the full parent.
 
 The `ExecutionPayloadHeader` object is changed (and renamed to `ExecutionPayloadBid`) to only track the minimum information needed to commit to a builder's payload.
 
 State transition logic is modified by: 
 
-- A new beacon state getter `get_ptc` returns the PTC members for a given slot. 
-- `process_withdrawals` is modified as follows. Withdrawals are obtained directly from the beacon state instead of the execution payload. They are deducted from the beacon chain. The beacon state `latest_withdrawals_root` is updated with the HTR of this list. The next execution payload MUST include withdrawals matching the `state.latest_withdrawals_root`. 
+- A new beacon state getter `get_ptc` returns the PTC members for a given slot, using the cached `ptc_window`.
+- A new `process_ptc_window` helper updates the cached PTC assignments during epoch processing.
+- `process_parent_execution_payload` is called before `process_execution_payload_bid`. It checks whether the parent was full, verifies `parent_execution_requests` against the parent's `execution_requests_root`, and applies those execution requests before the new bid overwrites `state.latest_execution_payload_bid`.
+- `process_withdrawals` is modified as follows. Withdrawals are obtained directly from the beacon state instead of the execution payload. They are deducted from the beacon chain and stored in `payload_expected_withdrawals`. The next execution payload that uses the corresponding block as its parent is required to honor these withdrawals in the execution layer.
 - `process_execution_payload` is removed from `process_block`. Instead a new function `process_execution_payload_bid` is included, this function validates the `SignedExecutionPayloadBid` included in the `BeaconBlockBody`, ensures the payment from the builder's balance can be deducted and adds a `BuilderPendingPayment` object to the beacon state.
-- `process_deposit_request` is removed from `process_operations` and deferred until `process_execution_payload`. Special care is added for deposit requests from new validator pubkeys, with withdrawal credentials starting with the prefix `BUILDER_WITHDRAWAL_PREFIX`. These deposits are immediately added to the beacon chain and processed as new builders. 
-- `process_withdrawal_request` is removed from `process_operations` and deferred until `process_execution_payload`.
-- `process_consolidation_request` is removed from `process_operations` and deferred until `process_execution_payload`. 
+- `process_deposit_request` is removed from `process_operations` and deferred until the parent execution payload is applied. Special care is added for deposit requests from new validator pubkeys, with withdrawal credentials starting with the prefix `BUILDER_WITHDRAWAL_PREFIX`. These deposits are immediately added to the beacon chain and processed as new builders.
+- `process_withdrawal_request` is removed from `process_operations` and deferred until the parent execution payload is applied.
+- `process_consolidation_request` is removed from `process_operations` and deferred until the parent execution payload is applied.
 - A new `process_payload_attestation` is added to `process_operations`, this function validates the payload timeliness attestations broadcast by the PTC members. 
-- `process_execution_payload` is now called as a separate helper when receiving a `SignedExecutionPayloadEnvelope` on the P2P layer. This function in particular checks that the HTR of the resulting beacon state coincides with the committed one in the payload envelope. On sucessful processing of the execution payload, the corresponding `BuilderPendingPayment` is removed from the beacon state and a `BuilderPendingWithdrawal` is queued. 
+- `process_execution_payload` is replaced by `verify_execution_payload_envelope`, a pure verification helper called when receiving a `SignedExecutionPayloadEnvelope` on the P2P layer. Payload processing is deferred to the next beacon block through `process_parent_execution_payload`.
 
 Epoch processing is modified by addition of a new helper function `process_builder_pending_payments`, that processes the builder pending payments from those payloads that were not included in the canonical chain. 
 Although there is no change in the `AttestationData` object, the `index` field which is unused since the Electra fork, is now repurposed to signal payload availability. The value of `0` is used when attesting to the current beacon block or a past beacon block without a payload present, and the value of `1` is used to attest to a past beacon block with a payload present. 
@@ -364,7 +383,7 @@ Forkchoice is changed substantially to deal with the fact that forkchoice nodes 
 
 - A new global topic for broadcasting `SignedExecutionPayloadBid` messages (builder bids).
 - A new global topic for broadcasting `PayloadAttestationMessage` objects. 
-- A new global topic for broadcasting `ProposerPreferences` objects.
+- A new global topic for broadcasting `SignedProposerPreferences` objects. These messages carry a `dependent_root`, `proposal_slot`, `validator_index`, `fee_recipient`, and `target_gas_limit`. Builder bids are matched to proposer preferences by slot and dependent root, and their gas limit is checked for compatibility with the target gas limit under the EIP-1559 gas limit adjustment rule.
 
 ### Engine API
 
@@ -420,11 +439,11 @@ Withdrawals from the beacon chain are complex in nature, they involve removing f
 - The set of withdrawals just deducted is committed to the beacon state `post_state`.  
 - When processing any execution payload whose parent beacon state is `post_state`, the payload is deemed invalid if it doesn't include precisely the list of withdrawals committed to `post_state`. 
 
-This asynchronous mechanism has some consequences as slots may be *empty* as defined above. In these cases, the consensus layer does not process any more withdrawals until an execution payload has fulfilled the outstanding ones. An alternative design would be to defer all of withdrawal processing to the execution payload validation phase (ie. `process_execution_payload`). This has the advantage of not needing to track the fulfilled withdrawals on the beacon chain. The logic changes when several payloads are missing, in which case balances on the beacon chain change and therefore a withdrawal that would be possible with the former mechanism may be different, or even impossible with the latter.
+This asynchronous mechanism has some consequences as slots may be *empty* as defined above. In these cases, the consensus layer does not process any more withdrawals until an execution payload has fulfilled the outstanding ones. An alternative design would be to defer all of withdrawal processing until the parent execution payload is applied. This has the advantage of not needing to track the fulfilled withdrawals on the beacon chain. The logic changes when several payloads are missing, in which case balances on the beacon chain change and therefore a withdrawal that would be possible with the former mechanism may be different, or even impossible with the latter.
 
-### Three state transition functions
+### Deferred payload processing
 
-The current EIP adds an extra state transition function to the block processing in Ethereum. Processing a `SignedBeaconBlock` changes the consensus layer `BeaconState`. A `SignedExecutionPayloadEnvelope` changes both the execution layer state and the consensus layer one. As such, the envelope commits to the consensus layer post-state-transition beacon state root. 
+The current EIP adds an extra verification path for the execution payload envelope. Processing a `SignedBeaconBlock` changes the consensus layer `BeaconState`. A `SignedExecutionPayloadEnvelope` is verified when it is received on the P2P layer, while its execution requests are processed by the next beacon block when the chain builds on the full parent payload.
 
 ### Compatible designs 
 

--- a/EIPS/eip-7732.md
+++ b/EIPS/eip-7732.md
@@ -375,7 +375,7 @@ Forkchoice is changed substantially to deal with the fact that forkchoice nodes 
 
 - A new global topic for broadcasting `SignedExecutionPayloadBid` messages (builder bids).
 - A new global topic for broadcasting `PayloadAttestationMessage` objects. 
-- A new global topic for broadcasting `SignedProposerPreferences` objects. These messages carry a `dependent_root`, `proposal_slot`, `validator_index`, `fee_recipient`, and `target_gas_limit`. Builder bids are matched to proposer preferences by slot and dependent root, and their gas limit is checked for compatibility with the target gas limit under the EIP-1559 gas limit adjustment rule.
+- A new global topic for broadcasting `SignedProposerPreferences` objects. The signed message contains a `dependent_root`, `proposal_slot`, `validator_index`, `fee_recipient`, and `target_gas_limit`. Builder bids are matched to proposer preferences by proposal slot and by the proposer-dependent root computed from the bid's parent block. The bid gas limit is checked for compatibility with the proposer's `target_gas_limit` under the EIP-1559 gas limit adjustment rule.
 
 ### Engine API
 
@@ -433,9 +433,9 @@ Withdrawals from the beacon chain are complex in nature, they involve removing f
 
 This asynchronous mechanism has some consequences as slots may be *empty* as defined above. In these cases, the consensus layer does not process any more withdrawals until an execution payload has fulfilled the outstanding ones. An alternative design would be to defer all of withdrawal processing until the parent execution payload is applied. This has the advantage of not needing to track the fulfilled withdrawals on the beacon chain. The logic changes when several payloads are missing, in which case balances on the beacon chain change and therefore a withdrawal that would be possible with the former mechanism may be different, or even impossible with the latter.
 
-### Deferred payload processing
+### Deferred execution payload processing
 
-The current EIP adds an extra verification path for the execution payload envelope. Processing a `SignedBeaconBlock` changes the consensus layer `BeaconState`. A `SignedExecutionPayloadEnvelope` is verified when it is received on the P2P layer, while its execution requests are processed by the next beacon block when the chain builds on the full parent payload.
+The current EIP adds a separate verification path for the execution payload envelope. Processing a `SignedBeaconBlock` changes the consensus layer `BeaconState`. A `SignedExecutionPayloadEnvelope` is verified when it is received on the P2P layer, while its execution requests are processed by the next beacon block when the chain builds on the full parent payload.
 
 ### Compatible designs 
 

--- a/EIPS/eip-7732.md
+++ b/EIPS/eip-7732.md
@@ -43,7 +43,6 @@ The full consensus changes can be found in the consensus-specs Github repository
 - [Fork logic](https://github.com/ethereum/consensus-specs/blob/267e007f0e5e9f29f2e0325afc9ae5523171fc19/specs/gloas/fork.md) changes.
 - [Light client](https://github.com/ethereum/consensus-specs/tree/267e007f0e5e9f29f2e0325afc9ae5523171fc19/specs/gloas/light-client) changes.
 - [Partial column sidecar](https://github.com/ethereum/consensus-specs/blob/267e007f0e5e9f29f2e0325afc9ae5523171fc19/specs/gloas/partial-columns/p2p-interface.md) changes.
-- [Weak subjectivity](https://github.com/ethereum/consensus-specs/blob/267e007f0e5e9f29f2e0325afc9ae5523171fc19/specs/gloas/weak-subjectivity.md) changes.
 
 A summary of the main changes is included below, the [Rationale](#rationale) section contains explanation for most of the design decisions around these changes. 
 


### PR DESCRIPTION
This updates the EIP-7732 Gloas summary to match the current consensus-specs Gloas files.

The EIP still pointed at an older consensus-specs snapshot, and several parts of the summary had drifted from the current spec. The PR updates the linked spec snapshot, updates the builder withdrawal delay, aligns the bid and envelope containers with the current deferred payload flow, and updates the P2P summary for proposer preferences.