### PR TITLE
Update EIP-8037: Calldata floor accounting alignment & call-frame refill clarification

### DIFF
--- a/EIPS/eip-8037.md
+++ b/EIPS/eip-8037.md
@@ -374,6 +374,12 @@ Wallet developers and node operators MUST update gas estimation handling to acco
 
 Users can maintain their usual workflows without modification, as wallet and RPC updates will handle these changes.
 
+### Deterministic deployment factories
+
+Some well-known deterministic deployment factories are deployed via presigned transactions with a hardcoded gas limit. The classic Nick's method factory, for instance, uses a presigned transaction with a 100k gas limit. Under this EIP, the state creation cost of deploying these factories increases beyond their hardcoded gas limit, so the original presigned deployment transactions will no longer execute successfully. The same applies to other deterministic deployers such as ERC-2470, Create2Deployer, ImmutableCreate2Factory, and CreateX.
+
+This does not affect existing networks where these factories are already deployed, including mainnet and L2s (which maintain their own gas schedules). The impact is limited to new networks (e.g., devnets and testnets) that activate this EIP from genesis and have not yet deployed these factories. On such networks, the presigned deployment transactions must be regenerated with an updated gas limit, or the factories must be pre-deployed at genesis. Tooling that relies on these factories being available at their canonical addresses SHOULD ensure they are deployed before use.
+
 ### Estimated price impacts
 
 Users and dApp developers will experience an increase in transaction costs associated with creating a new state. The next table summarizes the state-gas portion of state creation costs for common operations under the proposed `CPSB` of 1,530. Additional regular-gas charges (e.g., `ACCOUNT_WRITE`, `STORAGE_WRITE`, hash cost) defined in [EIP-8038](./eip-8038.md) apply on top.

--- a/EIPS/eip-8037.md
+++ b/EIPS/eip-8037.md
@@ -379,9 +379,9 @@ Users can maintain their usual workflows without modification, as wallet and RPC
 
 ### Deterministic deployment factories
 
-Well-known deterministic deployment factories (e.g., Nick's method factory, ERC-2470, Create2Deployer, ImmutableCreate2Factory, CreateX) are deployed via presigned transactions with hardcoded gas limits. Under this EIP, their state creation costs exceed those limits, so the original deployment transactions will no longer execute successfully.
+Some well-known deterministic deployment factories are deployed via presigned transactions with a hardcoded gas limit. The classic Nick's method factory, for instance, uses a presigned transaction with a 100k gas limit. Under this EIP, the state creation cost of deploying these factories increases beyond their hardcoded gas limit, so the original presigned deployment transactions will no longer execute successfully. The same applies to other deterministic deployers such as ERC-2470, Create2Deployer, ImmutableCreate2Factory, and CreateX.
 
-This affects only new networks (e.g., devnets and testnets) that activate this EIP from genesis, not existing networks where these factories are already deployed (mainnet, L2s). On affected networks, the presigned transactions must be regenerated with an updated gas limit, or the factories pre-deployed at genesis.
+This does not affect existing networks where these factories are already deployed, including mainnet and L2s (which maintain their own gas schedules). The impact is limited to new networks (e.g., devnets and testnets) that activate this EIP from genesis and have not yet deployed these factories. On such networks, the presigned deployment transactions must be regenerated with an updated gas limit, or the factories must be pre-deployed at genesis. Tooling that relies on these factories being available at their canonical addresses SHOULD ensure they are deployed before use.
 
 ### Estimated price impacts
 

--- a/EIPS/eip-8037.md
+++ b/EIPS/eip-8037.md
@@ -2,7 +2,7 @@
 eip: 8037
 title: State Creation Gas Cost Increase
 description: Harmonization, increase and separate metering of state creation gas costs to mitigate state growth and unblock scaling
-author: Maria Silva (@misilva73), Carlos Perez (@CPerezz), Jochem Brouwer (@jochem-brouwer), Ansgar Dietrichs (@adietrichs), Łukasz Rozmej (@LukaszRozmej), Anders Elowsson (@anderselowsson), Francesco D'Amato (@fradamt)
+author: Maria Silva (@misilva73), Carlos Perez (@CPerezz), Jochem Brouwer (@jochem-brouwer), Ansgar Dietrichs (@adietrichs), Łukasz Rozmej (@LukaszRozmej), Anders Elowsson (@anderselowsson), Francesco D'Amato (@fradamt), Dragan Rakita (@rakita)
 discussions-to: https://ethereum-magicians.org/t/eip-8037-state-creation-gas-cost-increase/25694
 status: Draft
 type: Standards Track

--- a/EIPS/eip-8037.md
+++ b/EIPS/eip-8037.md
@@ -134,7 +134,7 @@ State-gas accounting for `SSTORE` is performed at the end of the opcode executio
 | `CREATE`/`CREATE2` with bytecode size of `L` | `(STATE_BYTES_PER_NEW_ACCOUNT + L) × CPSB` charged |
 | `SELFDESTRUCT` where balance transfer creates a new account | `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` charged |
 
-State-gas accounting for `CALL*` and `CREATE`/`CREATE2` operations is performed right before the respective call frame. If the respective call frame reverts or halts exceptionally, the charged state-gas is refilled back to the `state_gas_reservoir` and `execution_state_gas_used` decreases by the same amount.
+State-gas accounting for `CALL*` and `CREATE`/`CREATE2` operations is performed right before the respective call frame. If the respective call frame reverts or halts exceptionally or if the operation is unsuccessful before entering the call frame (e.g., due to insuficient balance or due to the stack depth), the charged state-gas is refilled back to the `state_gas_reservoir` and `execution_state_gas_used` decreases by the same amount.
 
 The same applies to top-level contract-creation transactions. If the transaction reverts or halts, the `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` portion of `intrinsic_state_gas` is refilled back to `state_gas_reservoir` and `execution_state_gas_used` decreases by the same amount.
 

--- a/EIPS/eip-8037.md
+++ b/EIPS/eip-8037.md
@@ -134,7 +134,7 @@ State-gas accounting for `SSTORE` is performed at the end of the opcode executio
 | `CREATE`/`CREATE2` with bytecode size of `L` | `(STATE_BYTES_PER_NEW_ACCOUNT + L) × CPSB` charged |
 | `SELFDESTRUCT` where balance transfer creates a new account | `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` charged |
 
-State-gas accounting for `CALL*` and `CREATE`/`CREATE2` operations is performed right before the respective call frame. If the respective call frame reverts or halts exceptionally or if the operation is unsuccessful before entering the call frame (e.g., due to insuficient balance or due to the stack depth), the charged state-gas is refilled back to the `state_gas_reservoir` and `execution_state_gas_used` decreases by the same amount.
+State-gas accounting for `CALL*` and `CREATE`/`CREATE2` operations is performed right before the respective call frame. If the respective call frame reverts or halts exceptionally or if the operation is unsuccessful before entering the call frame (e.g., due to insufficient balance or due to the stack depth), the charged state-gas is refilled back to the `state_gas_reservoir` and `execution_state_gas_used` decreases by the same amount.
 
 The same applies to top-level contract-creation transactions. If the transaction reverts or halts, the `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` portion of `intrinsic_state_gas` is refilled back to `state_gas_reservoir` and `execution_state_gas_used` decreases by the same amount.
 

--- a/EIPS/eip-8037.md
+++ b/EIPS/eip-8037.md
@@ -190,7 +190,7 @@ At block level, instead of tracking a single `gas_used` counter, we keep track o
 
 ```python
 tx_state_gas = intrinsic_state_gas + tx_output.execution_state_gas_used
-tx_regular_gas = tx_gas_used - tx_state_gas
+tx_regular_gas = tx_gas_used_after_refund - tx_state_gas
 
 block_output.block_regular_gas_used += tx_regular_gas
 block_output.block_state_gas_used += tx_state_gas
@@ -222,13 +222,9 @@ gas_used_delta = parent.gas_used - parent.gas_target
 
 ```python
 tx_state_gas = intrinsic_state_gas + tx_output.execution_state_gas_used
+tx_regular_gas = tx_gas_used_before_refund - tx_state_gas
 
-if calldata_floor_gas_cost >= tx_gas_used_after_refund:
-     tx_regular_gas = tx_gas_used - tx_state_gas
-else:
-     tx_regular_gas = tx_gas_used - tx_state_gas + tx_gas_refund
-
-block_output.block_regular_gas_used += tx_regular_gas
+block_output.block_regular_gas_used += tx_state_gas
 block_output.block_state_gas_used += tx_state_gas
 ```
 

--- a/EIPS/eip-8037.md
+++ b/EIPS/eip-8037.md
@@ -131,8 +131,11 @@ State-gas accounting for `SSTORE` is performed at the end of the opcode executio
 | Operation | State-gas charges/refills |
 |---|---|
 | `CALL*` with value to non-existent account | `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` charged |
-| `CREATE`/`CREATE2` with bytecode size of `L` | `(STATE_BYTES_PER_NEW_ACCOUNT + L) × CPSB` charged |
+| `CREATE`/`CREATE2` with bytecode size of `L` to existent account | `L × CPSB` charged |
+| `CREATE`/`CREATE2` with bytecode size of `L` to non-existent account | `(STATE_BYTES_PER_NEW_ACCOUNT + L) × CPSB` charged |
 | `SELFDESTRUCT` where balance transfer creates a new account | `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` charged |
+
+Here, an account is *existent* if it already has a leaf in the state trie, i.e., it has a nonzero balance, a nonzero nonce, or non-empty code (per [EIP-161](./eip-161.md)). In particular, an address that holds a balance but has no code and a zero nonce is existent and is a valid `CREATE`/`CREATE2` target under [EIP-684](./eip-684.md). Creating a contract at such an address updates the existing leaf rather than adding a new one, so only the code-deposit cost (`L × CPSB`) applies and the `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` account-creation charge does not.
 
 State-gas accounting for `CALL*` and `CREATE`/`CREATE2` operations is performed right before the respective call frame. If the respective call frame reverts or halts exceptionally or if the operation is unsuccessful before entering the call frame (e.g., due to insufficient balance or due to the stack depth), the charged state-gas is refilled back to the `state_gas_reservoir` and `execution_state_gas_used` decreases by the same amount.
 
@@ -376,9 +379,9 @@ Users can maintain their usual workflows without modification, as wallet and RPC
 
 ### Deterministic deployment factories
 
-Some well-known deterministic deployment factories are deployed via presigned transactions with a hardcoded gas limit. The classic Nick's method factory, for instance, uses a presigned transaction with a 100k gas limit. Under this EIP, the state creation cost of deploying these factories increases beyond their hardcoded gas limit, so the original presigned deployment transactions will no longer execute successfully. The same applies to other deterministic deployers such as ERC-2470, Create2Deployer, ImmutableCreate2Factory, and CreateX.
+Well-known deterministic deployment factories (e.g., Nick's method factory, ERC-2470, Create2Deployer, ImmutableCreate2Factory, CreateX) are deployed via presigned transactions with hardcoded gas limits. Under this EIP, their state creation costs exceed those limits, so the original deployment transactions will no longer execute successfully.
 
-This does not affect existing networks where these factories are already deployed, including mainnet and L2s (which maintain their own gas schedules). The impact is limited to new networks (e.g., devnets and testnets) that activate this EIP from genesis and have not yet deployed these factories. On such networks, the presigned deployment transactions must be regenerated with an updated gas limit, or the factories must be pre-deployed at genesis. Tooling that relies on these factories being available at their canonical addresses SHOULD ensure they are deployed before use.
+This affects only new networks (e.g., devnets and testnets) that activate this EIP from genesis, not existing networks where these factories are already deployed (mainnet, L2s). On affected networks, the presigned transactions must be regenerated with an updated gas limit, or the factories pre-deployed at genesis.
 
 ### Estimated price impacts
 

--- a/EIPS/eip-8037.md
+++ b/EIPS/eip-8037.md
@@ -179,20 +179,20 @@ At the end of transaction execution, the gas used before and after refunds is de
 tx_gas_used_before_refund = tx.gas - tx_output.gas_left - tx_output.state_gas_reservoir
 tx_gas_refund = min(tx_gas_used_before_refund // 5, tx_output.refund_counter)
 tx_gas_used_after_refund = tx_gas_used_before_refund - tx_gas_refund
+tx_gas_used = max(tx_gas_used_after_refund, calldata_floor_gas_cost) 
 ```
 
-The refund cap remains at 20% of gas used.
+The refund cap remains at 20% of gas used. `tx_gas_used` applies the [EIP-7623](./eip-7623.md) calldata floor after refunds, so the floor can effectively negate part of a refund when `calldata_floor_gas_cost > tx_gas_used_after_refund`. The receipt `cumulative_gas_used` uses this post-floor value.
 
 #### Block-level gas accounting
 
 At block level, instead of tracking a single `gas_used` counter, we keep track of two counters, one for `state-gas` and one for `regular-gas`:
 
 ```python
-tx_regular_gas = intrinsic_regular_gas + tx_output.execution_regular_gas_used
 tx_state_gas = intrinsic_state_gas + tx_output.execution_state_gas_used
+tx_regular_gas = tx_gas_used - tx_state_gas
 
-tx_gas_used = max(tx_gas_used_after_refund, calldata_floor_gas_cost)
-block_output.block_regular_gas_used += max(tx_regular_gas, calldata_floor_gas_cost)
+block_output.block_regular_gas_used += tx_regular_gas
 block_output.block_state_gas_used += tx_state_gas
 ```
 
@@ -214,6 +214,22 @@ The base fee update rule is also modified accordingly:
 
 ```python
 gas_used_delta = parent.gas_used - parent.gas_target
+```
+
+##### Integration with [EIP-7778](./eip-7778.md)
+
+[EIP-7778](./eip-7778.md) excludes transactions refunds from the block gas accounting. If implemented together with [EIP-7778](./eip-7778.md), the block level would be updated to:
+
+```python
+tx_state_gas = intrinsic_state_gas + tx_output.execution_state_gas_used
+
+if calldata_floor_gas_cost >= tx_gas_used_after_refund:
+     tx_regular_gas = tx_gas_used - tx_state_gas
+else:
+     tx_regular_gas = tx_gas_used - tx_state_gas + tx_gas_refund
+
+block_output.block_regular_gas_used += tx_regular_gas
+block_output.block_state_gas_used += tx_state_gas
 ```
 
 #### Receipt semantics


### PR DESCRIPTION
Updates to EIP-8037 covering four changes:

1. **Calldata floor gas accounting** — aligns block- and transaction-level gas accounting by applying the EIP-7623 calldata floor at the transaction level (deriving regular gas from the post-refund value), clarifies floor/refund interaction and receipt accounting, and adds an "Integration with EIP-7778" subsection.
2. **Call refill clarification** — extend the state-gas refill rule for `CALL*`/`CREATE`/`CREATE2` to cover cases where the operation is unsuccessful before entering the call frame (e.g., insufficient balance, stack depth limit), not only revert/exceptional halt inside the frame.
3. **Deterministic deployment factories caveat** — adds a caveat that deterministic deployment factories (Nick's method, ERC-2470, CreateX, etc.) won't deploy via their presigned transactions on new networks activating from genesis, since state creation costs exceed the hardcoded gas limits.
4. **CREATE/CREATE2 clarification** — clarifies that CREATE/CREATE2 to a balance-only (codeless, zero-nonce) account skips the account-creation charge.
5. **Authors** — add Dragan Rakita (@rakita) to the author list.
