### PR TITLE
Update EIP-7773: move PFI above DFI

### DIFF
--- a/EIPS/eip-7773.md
+++ b/EIPS/eip-7773.md
@@ -50,6 +50,12 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Declined
 * [EIP-8136](./eip-8136.md): Cell-Level Deltas for Data Column Broadcast
 * [EIP-8159](./eip-8159.md): eth/71 - Block Access List Exchange
 
+### Proposed for Inclusion
+
+* [EIP-7610](./eip-7610.md): Revert creation in case of non-empty storage
+* [EIP-7979](./eip-7979.md): Call and Return Opcodes for the EVM
+* [EIP-8163](./eip-8163.md): Reserve `EXTENSION (0xae)` opcode
+
 ### Declined for Inclusion
 
 * [EIP-2926](./eip-2926.md): Chunk-based code merkelization
@@ -91,12 +97,6 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Declined
 * [EIP-8062](./eip-8062.md): Add sweep withdrawal fee for 0x01 validators
 * [EIP-8068](./eip-8068.md): Neutral effective balance design
 * [EIP-8071](./eip-8071.md): Prevent using consolidations as withdrawals
-
-### Proposed for Inclusion
-
-* [EIP-7610](./eip-7610.md): Revert creation in case of non-empty storage
-* [EIP-7979](./eip-7979.md): Call and Return Opcodes for the EVM
-* [EIP-8163](./eip-8163.md): Reserve `EXTENSION (0xae)` opcode
 
 ### Activation
 


### PR DESCRIPTION
these EIPs are still in play and may be CFI'd at some point. they should be above the DFI section for clarity & ease of reading