### PR TITLE
Update EIP-8037: improve EIP-7702 authorization gas accounting in EIP-8037

### DIFF
--- a/EIPS/eip-8037.md
+++ b/EIPS/eip-8037.md
@@ -173,6 +173,7 @@ Authorization processing follows 3 gas accounting rules:
 **2. Account-leaf refill.** If the authority's account leaf already exists in the **current state** (non-zero nonce, non-zero balance, or non-empty code), refill `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` to `state_gas_reservoir` and refund `ACCOUNT_WRITE` to the refund counter.
 
 **3. Delegation-indicator refill.**
+
 - If `authorization.address` is not `ZERO` (setting a delegation), refill `STATE_BYTES_PER_AUTH_BASE × CPSB` to `state_gas_reservoir` when `cur_delegated` or `pre_delegated` is `true`. In that case the 23-byte indicator slot is already occupied, so this authorization overwrites it without writing new bytes. Otherwise this authorization performs the net-new creation and its intrinsic charge stands.
 - If `authorization.address` is `ZERO` (clearing the delegation), refill `STATE_BYTES_PER_AUTH_BASE × CPSB` to `state_gas_reservoir`, since the clear writes no indicator. Additionally, when `cur_delegated` is `true` and `pre_delegated` is `false`, refill another `STATE_BYTES_PER_AUTH_BASE × CPSB`: the delegation being cleared was created by an earlier authorization in this same transaction, so the chain writes zero net delegation bytes and the earlier creation charge is no longer justified. This covers patterns such as `0->a->0`, where the creation by an earlier authorization is undone by a later clearing one in the same list.
 

--- a/EIPS/eip-8037.md
+++ b/EIPS/eip-8037.md
@@ -156,14 +156,28 @@ The same rules apply when the top-level call frame reverts or halts. Here, `stat
 
 ##### Gas accounting for [EIP-7702](./eip-7702.md) authorizations
 
-While computing the intrinsic gas cost, [EIP-7702](./eip-7702.md) authorizations are charged the worst-case cost for each delegation. Then, during authorization processing, the following gas adjustments are made for each processed authorization:
+Intrinsic gas charges the worst-case state-gas cost (`(STATE_BYTES_PER_NEW_ACCOUNT + STATE_BYTES_PER_AUTH_BASE) × CPSB`) for each authorization. Because both an authority's account leaf and its 23-byte delegation indicator are written at most once per transaction, even when the same authority appears in multiple authorizations. Adjustments are applied per authorization as the list is processed.
 
-- If the `authority`'s account leaf already exists (i.e., non-zero nonce, non-zero balance, or non-empty code), the `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` portion is refilled directly to `state_gas_reservoir` and the `ACCOUNT_WRITE` portion is refunded to the refund counter.
-- If the `authority`'s `codeHash` is not `emptyHash` (i.e., a prior authorization indicator already occupies the 23 bytes) or `authorization.address` is `ZERO` (the authorization is clearing the delegation), the `STATE_BYTES_PER_AUTH_BASE × CPSB` portion is also refilled directly to `state_gas_reservoir`.
+Processing maintains a per-tx set `billed` of authorities for which an auth-base creation has already been charged in this transaction. For each **valid** authorization processed in list order, two views of the authority's state are referenced:
 
-`execution_state_gas_used` decreases by the corresponding amount of state-gas refills.
+- **committed state**: the authority's state at the start of the transaction.
+- **in-flight state**: the authority's state after applying all prior authorizations in this transaction.
 
-Because `execution_state_gas_used` is initialized to `0`, this refill may bring it below zero before any execution-time charges. Implementations may equivalently track the refill separately and subtract it from `tx_state_gas` when accumulating `block_state_gas_used`.
+**1. Account-creation refill.** If the authority's account leaf already exists in the in-flight state (non-zero nonce, non-zero balance, or non-empty code), refill `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` to `state_gas_reservoir` and refund `ACCOUNT_WRITE` to the refund counter.
+
+**2. Auth-base refill.** Refill `STATE_BYTES_PER_AUTH_BASE × CPSB` to `state_gas_reservoir` if **any** of:
+
+- the authority was already delegated in the **committed** state
+- the authority is in `billed` (a prior authorization in this transaction has already been charged the auth-base creation for this authority)
+- `authorization.address` is `ZERO` (the authorization is clearing the delegation; no delegation bytes are written).
+
+Otherwise, add the authority to `billed`; this authorization is the one charged for the per-tx auth-base creation.
+
+**3. Cancel a prior auth-base creation.** If `authorization.address` is `ZERO` **and** the authority is in `billed`, additionally refill `STATE_BYTES_PER_AUTH_BASE × CPSB` to `state_gas_reservoir` and remove the authority from `billed`. The chain of authorizations for this authority now writes zero net delegation bytes, so the earlier creation charge is no longer justified. This covers patterns such as `0->a->0`, where the creation by an earlier authorization is undone by a later clearing one in the same list.
+
+Invalid authorizations are skipped without adjustment and their intrinsic state-gas remains consumed.
+
+`execution_state_gas_used` decreases by the total amount of these refills. Because it is initialized to `0`, this may bring it below zero before any execution-time charges. Implementations may equivalently track the refill separately and subtract it from `tx_state_gas` when accumulating `block_state_gas_used`.
 
 #### Pre-state and post-state gas validation
 

--- a/EIPS/eip-8037.md
+++ b/EIPS/eip-8037.md
@@ -158,28 +158,20 @@ The same rules apply when the top-level call frame reverts or halts. Here, `stat
 
 Intrinsic gas charges the worst-case state-gas cost (`(STATE_BYTES_PER_NEW_ACCOUNT + STATE_BYTES_PER_AUTH_BASE) × CPSB`) for each authorization. However, an authority's account leaf and its 23 byte delegation indicator can only be written once per transaction, even if the same authority appears in multiple authorizations. Therefore, per authorization adjustments are applied while processing the authorization list.
 
-Processing maintains two pieces of per-transaction bookkeeping:
+The adjustments enforce a single invariant: the `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` account-leaf portion is charged at most once per authority and only when the account did not exist before the transaction, and the `STATE_BYTES_PER_AUTH_BASE × CPSB` delegation-indicator portion is charged at most once per authority and only when the authority ends the transaction delegated having started it undelegated.
+Processing reads the account state at two points:
 
-- `billed`: tracks which authorities have already been charged for auth-base creation in the current transaction.
-- `account state`:
-    - **pre-transaction state**: the account state before transaction execution.
-    - **current state**: the account state while processing authorizations, updated after each authorization.
+- **pre-transaction state**: the account state before transaction execution.
+- **current state**: the account state while processing authorizations, updated after each authorization.
 
-Authorization processing follows 5 gas accounting rules:
+For each authorization, let `cur_delegated` be `true` when the authority has a non-empty delegation indicator in the **current state**, and `pre_delegated` be `true` when it had one in the **pre-transaction state**. 
 
-**1. Invalid authorizations.** Invalid authorizations are skipped without per-auth processing. Their entire intrinsic state-gas portion, `(STATE_BYTES_PER_NEW_ACCOUNT + STATE_BYTES_PER_AUTH_BASE) × CPSB`, is refilled to `state_gas_reservoir` and refund `ACCOUNT_WRITE` to the refund counter.
-
-**2. Account-creation refill.** If the authority's account leaf already exists in the **current state** (non-zero nonce, non-zero balance, or non-empty code), refill `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` to `state_gas_reservoir` and refund `ACCOUNT_WRITE` to the refund counter.
-
-**3. Auth-base refill.** Refill `STATE_BYTES_PER_AUTH_BASE × CPSB` to `state_gas_reservoir` if **any** of:
-
-- the authority was already delegated in the **pre-transaction state** state
-- the authority is in `billed` (a prior authorization in this transaction has already been charged the auth-base creation for this authority)
-- `authorization.address` is `ZERO` (the authorization is clearing the delegation)
-
-**4. First charge.** If the authorization does not meet the conditions of rule 1, 2 and 3, add the authority to `billed`; this authorization is the one charged for the per-tx auth-base creation. This charge was already included in the transaction's intrinsic cost.
-
-**5. Cancel a prior auth-base creation.** If `authorization.address` is `ZERO` **and** the authority is in `billed`, additionally refill `STATE_BYTES_PER_AUTH_BASE × CPSB` to `state_gas_reservoir` and remove the authority from `billed`. The chain of authorizations for this authority now writes zero net delegation bytes, so the earlier creation charge is no longer justified. This covers patterns such as `0->a->0`, where the creation by an earlier authorization is undone by a later clearing one in the same list.
+Authorization processing follows 3 gas accounting rules:
+**1. Invalid authorizations.** Invalid authorizations are skipped without per-auth processing. Their entire intrinsic state-gas portion, `(STATE_BYTES_PER_NEW_ACCOUNT + STATE_BYTES_PER_AUTH_BASE) × CPSB`, is refilled to `state_gas_reservoir` and `ACCOUNT_WRITE` is refunded to the refund counter.
+**2. Account-leaf refill.** If the authority's account leaf already exists in the **current state** (non-zero nonce, non-zero balance, or non-empty code), refill `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` to `state_gas_reservoir` and refund `ACCOUNT_WRITE` to the refund counter.
+**3. Delegation-indicator refill.**
+- If `authorization.address` is not `ZERO` (setting a delegation), refill `STATE_BYTES_PER_AUTH_BASE × CPSB` to `state_gas_reservoir` when `cur_delegated` or `pre_delegated` is `true`. In that case the 23-byte indicator slot is already occupied, so this authorization overwrites it without writing new bytes. Otherwise this authorization performs the net-new creation and its intrinsic charge stands.
+- If `authorization.address` is `ZERO` (clearing the delegation), refill `STATE_BYTES_PER_AUTH_BASE × CPSB` to `state_gas_reservoir`, since the clear writes no indicator. Additionally, when `cur_delegated` is `true` and `pre_delegated` is `false`, refill another `STATE_BYTES_PER_AUTH_BASE × CPSB`: the delegation being cleared was created by an earlier authorization in this same transaction, so the chain writes zero net delegation bytes and the earlier creation charge is no longer justified. This covers patterns such as `0->a->0`, where the creation by an earlier authorization is undone by a later clearing one in the same list.
 
 `execution_state_gas_used` decreases by the corresponding amount of state-gas refills. Because `execution_state_gas_used` is initialized to `0`, this refill may bring it below zero before any execution-time charges. Implementations may equivalently track the refill separately and subtract it from `tx_state_gas` when accumulating `block_state_gas_used`.
 

--- a/EIPS/eip-8037.md
+++ b/EIPS/eip-8037.md
@@ -167,8 +167,11 @@ Processing reads the account state at two points:
 For each authorization, let `cur_delegated` be `true` when the authority has a non-empty delegation indicator in the **current state**, and `pre_delegated` be `true` when it had one in the **pre-transaction state**. 
 
 Authorization processing follows 3 gas accounting rules:
+
 **1. Invalid authorizations.** Invalid authorizations are skipped without per-auth processing. Their entire intrinsic state-gas portion, `(STATE_BYTES_PER_NEW_ACCOUNT + STATE_BYTES_PER_AUTH_BASE) × CPSB`, is refilled to `state_gas_reservoir` and `ACCOUNT_WRITE` is refunded to the refund counter.
+
 **2. Account-leaf refill.** If the authority's account leaf already exists in the **current state** (non-zero nonce, non-zero balance, or non-empty code), refill `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` to `state_gas_reservoir` and refund `ACCOUNT_WRITE` to the refund counter.
+
 **3. Delegation-indicator refill.**
 - If `authorization.address` is not `ZERO` (setting a delegation), refill `STATE_BYTES_PER_AUTH_BASE × CPSB` to `state_gas_reservoir` when `cur_delegated` or `pre_delegated` is `true`. In that case the 23-byte indicator slot is already occupied, so this authorization overwrites it without writing new bytes. Otherwise this authorization performs the net-new creation and its intrinsic charge stands.
 - If `authorization.address` is `ZERO` (clearing the delegation), refill `STATE_BYTES_PER_AUTH_BASE × CPSB` to `state_gas_reservoir`, since the clear writes no indicator. Additionally, when `cur_delegated` is `true` and `pre_delegated` is `false`, refill another `STATE_BYTES_PER_AUTH_BASE × CPSB`: the delegation being cleared was created by an earlier authorization in this same transaction, so the chain writes zero net delegation bytes and the earlier creation charge is no longer justified. This covers patterns such as `0->a->0`, where the creation by an earlier authorization is undone by a later clearing one in the same list.

--- a/EIPS/eip-8037.md
+++ b/EIPS/eip-8037.md
@@ -175,7 +175,7 @@ Otherwise, add the authority to `billed`; this authorization is the one charged 
 
 **3. Cancel a prior auth-base creation.** If `authorization.address` is `ZERO` **and** the authority is in `billed`, additionally refill `STATE_BYTES_PER_AUTH_BASE × CPSB` to `state_gas_reservoir` and remove the authority from `billed`. The chain of authorizations for this authority now writes zero net delegation bytes, so the earlier creation charge is no longer justified. This covers patterns such as `0->a->0`, where the creation by an earlier authorization is undone by a later clearing one in the same list.
 
-Invalid authorizations are skipped without adjustment and their intrinsic state-gas remains consumed.
+Invalid authorizations are skipped without per-auth processing. Their entire intrinsic state-gas portion (`(STATE_BYTES_PER_NEW_ACCOUNT + STATE_BYTES_PER_AUTH_BASE) × CPSB`) is refilled to `state_gas_reservoir`, since no on-disk state is written. Their intrinsic regular-gas portion is **not** refunded, so each authorization still pays for the validation work performed (signature recovery, account access), preventing griefing via lists of invalid authorizations.
 
 `execution_state_gas_used` decreases by the total amount of these refills. Because it is initialized to `0`, this may bring it below zero before any execution-time charges. Implementations may equivalently track the refill separately and subtract it from `tx_state_gas` when accumulating `block_state_gas_used`.
 

--- a/EIPS/eip-8037.md
+++ b/EIPS/eip-8037.md
@@ -160,10 +160,10 @@ Intrinsic gas charges the worst-case state-gas cost (`(STATE_BYTES_PER_NEW_ACCOU
 
 Processing maintains two pieces of per-transaction bookkeeping:
 
-* `billed`: tracks which authorities have already been charged for auth-base creation in the current transaction.
-* `account state`:
-    * **pre-transaction state**: the account state before transaction execution.
-    * **current state**: the account state while processing authorizations, updated after each authorization.
+- `billed`: tracks which authorities have already been charged for auth-base creation in the current transaction.
+- `account state`:
+    - **pre-transaction state**: the account state before transaction execution.
+    - **current state**: the account state while processing authorizations, updated after each authorization.
 
 Authorization processing follows 5 gas accounting rules:
 

--- a/EIPS/eip-8037.md
+++ b/EIPS/eip-8037.md
@@ -156,28 +156,32 @@ The same rules apply when the top-level call frame reverts or halts. Here, `stat
 
 ##### Gas accounting for [EIP-7702](./eip-7702.md) authorizations
 
-Intrinsic gas charges the worst-case state-gas cost (`(STATE_BYTES_PER_NEW_ACCOUNT + STATE_BYTES_PER_AUTH_BASE) × CPSB`) for each authorization. Because both an authority's account leaf and its 23-byte delegation indicator are written at most once per transaction, even when the same authority appears in multiple authorizations. Adjustments are applied per authorization as the list is processed.
+Intrinsic gas charges the worst-case state-gas cost (`(STATE_BYTES_PER_NEW_ACCOUNT + STATE_BYTES_PER_AUTH_BASE) × CPSB`) for each authorization. However, an authority's account leaf and its 23 byte delegation indicator can only be written once per transaction, even if the same authority appears in multiple authorizations. Therefore, per authorization adjustments are applied while processing the authorization list.
 
-Processing maintains a per-tx set `billed` of authorities for which an auth-base creation has already been charged in this transaction. For each **valid** authorization processed in list order, two views of the authority's state are referenced:
+Processing maintains two pieces of per-transaction bookkeeping:
 
-- **committed state**: the authority's state at the start of the transaction.
-- **in-flight state**: the authority's state after applying all prior authorizations in this transaction.
+* `billed`: tracks which authorities have already been charged for auth-base creation in the current transaction.
+* `account state`:
+    * **pre-transaction state**: the account state before transaction execution.
+    * **current state**: the account state while processing authorizations, updated after each authorization.
 
-**1. Account-creation refill.** If the authority's account leaf already exists in the in-flight state (non-zero nonce, non-zero balance, or non-empty code), refill `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` to `state_gas_reservoir` and refund `ACCOUNT_WRITE` to the refund counter.
+Authorization processing follows 5 gas accounting rules:
 
-**2. Auth-base refill.** Refill `STATE_BYTES_PER_AUTH_BASE × CPSB` to `state_gas_reservoir` if **any** of:
+**1. Invalid authorizations.** Invalid authorizations are skipped without per-auth processing. Their entire intrinsic state-gas portion, `(STATE_BYTES_PER_NEW_ACCOUNT + STATE_BYTES_PER_AUTH_BASE) × CPSB`, is refilled to `state_gas_reservoir` and refund `ACCOUNT_WRITE` to the refund counter.
 
-- the authority was already delegated in the **committed** state
+**2. Account-creation refill.** If the authority's account leaf already exists in the **current state** (non-zero nonce, non-zero balance, or non-empty code), refill `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` to `state_gas_reservoir` and refund `ACCOUNT_WRITE` to the refund counter.
+
+**3. Auth-base refill.** Refill `STATE_BYTES_PER_AUTH_BASE × CPSB` to `state_gas_reservoir` if **any** of:
+
+- the authority was already delegated in the **pre-transaction state** state
 - the authority is in `billed` (a prior authorization in this transaction has already been charged the auth-base creation for this authority)
-- `authorization.address` is `ZERO` (the authorization is clearing the delegation; no delegation bytes are written).
+- `authorization.address` is `ZERO` (the authorization is clearing the delegation)
 
-Otherwise, add the authority to `billed`; this authorization is the one charged for the per-tx auth-base creation.
+**4. First charge.** If the authorization does not meet the conditions of rule 1, 2 and 3, add the authority to `billed`; this authorization is the one charged for the per-tx auth-base creation. This charge was already included in the transaction's intrinsic cost.
 
-**3. Cancel a prior auth-base creation.** If `authorization.address` is `ZERO` **and** the authority is in `billed`, additionally refill `STATE_BYTES_PER_AUTH_BASE × CPSB` to `state_gas_reservoir` and remove the authority from `billed`. The chain of authorizations for this authority now writes zero net delegation bytes, so the earlier creation charge is no longer justified. This covers patterns such as `0->a->0`, where the creation by an earlier authorization is undone by a later clearing one in the same list.
+**5. Cancel a prior auth-base creation.** If `authorization.address` is `ZERO` **and** the authority is in `billed`, additionally refill `STATE_BYTES_PER_AUTH_BASE × CPSB` to `state_gas_reservoir` and remove the authority from `billed`. The chain of authorizations for this authority now writes zero net delegation bytes, so the earlier creation charge is no longer justified. This covers patterns such as `0->a->0`, where the creation by an earlier authorization is undone by a later clearing one in the same list.
 
-Invalid authorizations are skipped without per-auth processing. Their entire intrinsic state-gas portion (`(STATE_BYTES_PER_NEW_ACCOUNT + STATE_BYTES_PER_AUTH_BASE) × CPSB`) is refilled to `state_gas_reservoir`, since no on-disk state is written. Their intrinsic regular-gas portion is **not** refunded, so each authorization still pays for the validation work performed (signature recovery, account access), preventing griefing via lists of invalid authorizations.
-
-`execution_state_gas_used` decreases by the total amount of these refills. Because it is initialized to `0`, this may bring it below zero before any execution-time charges. Implementations may equivalently track the refill separately and subtract it from `tx_state_gas` when accumulating `block_state_gas_used`.
+`execution_state_gas_used` decreases by the corresponding amount of state-gas refills. Because `execution_state_gas_used` is initialized to `0`, this refill may bring it below zero before any execution-time charges. Implementations may equivalently track the refill separately and subtract it from `tx_state_gas` when accumulating `block_state_gas_used`.
 
 #### Pre-state and post-state gas validation
 


### PR DESCRIPTION
This PR improves gas accounting for EIP-7702 authorizations, covering several corner cases such as authorization cancellation within the same transaction. 

State gas charging is now aligned with the net state changes introduced by authorizations, except for the case clearing a pre-existing authorization which is intentionally not refunded.