### PR TITLE
Update EIP-7928: clarify CREATE inclusion and storage no-op handling

### DIFF
--- a/EIPS/eip-7928.md
+++ b/EIPS/eip-7928.md
@@ -98,7 +98,7 @@ It **MUST** include:
   
     - Targets of `BALANCE`, `EXTCODESIZE`, `EXTCODECOPY`, `EXTCODEHASH` opcodes
     - Targets of `CALL`, `CALLCODE`, `DELEGATECALL`, `STATICCALL` (even if they revert; see [Gas Validation Before State Access](#gas-validation-before-state-access) for inclusion conditions)
-    - Target addresses of `CREATE`/`CREATE2` only once the creation target is accessed: after post-pre-state-validation for the computed address (including post-target out-of-gas), on creation collision, or when creation setup increments the new account's nonce; not on address computation alone nor when creation fails earlier (e.g. insufficient sender balance for the endowment)
+    - Target addresses of `CREATE`/`CREATE2` only once the EVM accesses the computed address: on post-access out-of-gas, on creation collision, or when creation setup increments the new account's nonce; not on address computation alone, nor when creation fails before access (e.g. insufficient sender balance for the endowment, nonce overflow, or call stack depth limit)
     - Deployed contract addresses from creation transactions, i.e. transactions with an empty `to` field, which are always included since the deployment address is unconditionally accessed during transaction setup
     - Transaction sender and recipient addresses (even for zero-value transfers)
     - Beneficiary addresses for `SELFDESTRUCT`
@@ -217,7 +217,7 @@ The following uniqueness constraints **MUST** hold:
   - Slots accessed via `SLOAD` that are not written.
   - Slots written with unchanged values (i.e., `SSTORE` where post-value equals pre-value, also known as "no-op writes").
 
-Note: Implementations MUST check the pre-transaction value at the current `block_access_index` to correctly distinguish between actual writes and no-op writes. A no-op write MUST NOT remove `storage_changes` entries from earlier indices for the same slot.
+Note: Implementations MUST compare each write against the storage value as of immediately before the current `block_access_index` (i.e., the cumulative state from all prior indices, falling back to the pre-block state) to correctly distinguish between actual writes and no-op writes. A no-op write MUST NOT remove `storage_changes` entries from earlier indices for the same slot.
 
 #### Balance (`balance_changes`)
 

--- a/EIPS/eip-7928.md
+++ b/EIPS/eip-7928.md
@@ -98,7 +98,7 @@ It **MUST** include:
   
     - Targets of `BALANCE`, `EXTCODESIZE`, `EXTCODECOPY`, `EXTCODEHASH` opcodes
     - Targets of `CALL`, `CALLCODE`, `DELEGATECALL`, `STATICCALL` (even if they revert; see [Gas Validation Before State Access](#gas-validation-before-state-access) for inclusion conditions)
-    - Target addresses of `CREATE`/`CREATE2` if the target account is accessed
+    - Target addresses of `CREATE`/`CREATE2` only once the creation target is accessed: after post-pre-state-validation for the computed address (including post-target out-of-gas), on creation collision, or when creation setup increments the new account's nonce; not on address computation alone nor when creation fails earlier (e.g. insufficient sender balance for the endowment)
     - Deployed contract addresses from creation transactions, i.e. transactions with an empty `to` field, which are always included since the deployment address is unconditionally accessed during transaction setup
     - Transaction sender and recipient addresses (even for zero-value transfers)
     - Beneficiary addresses for `SELFDESTRUCT`
@@ -217,7 +217,7 @@ The following uniqueness constraints **MUST** hold:
   - Slots accessed via `SLOAD` that are not written.
   - Slots written with unchanged values (i.e., `SSTORE` where post-value equals pre-value, also known as "no-op writes").
 
-Note: Implementations MUST check the pre-transaction value to correctly distinguish between actual writes and no-op writes.
+Note: Implementations MUST check the pre-transaction value at the current `block_access_index` to correctly distinguish between actual writes and no-op writes. A no-op write MUST NOT remove `storage_changes` entries from earlier indices for the same slot.
 
 #### Balance (`balance_changes`)
 


### PR DESCRIPTION
## Summary

Two small clarifications aligned with existing execution-spec tests ([v7.1.0](https://github.com/ethereum/execution-spec-tests/releases/tag/bal%40v7.1.0), should go for v7.1.1 as well):

- **CREATE/CREATE2:** spell out when the computed creation address is included in the BAL (post-target gas validation, collision, or nonce increment) and when it is not (e.g. insufficient endowment before setup completes).
- **Storage no-op SSTORE:** no-op writes are evaluated per `block_access_index` and must not remove `storage_changes` from earlier indices on the same slot.

No intended semantic change for conforming implementations.

## Test/review plan

- Review against `bal_create_early_failure` and `bal_create2_selfdestruct_then_recreate_same_block` fixtures