### PR TITLE
Update EIP-7928: add GAS_COPY to EXTCODECOPY

### DIFF
--- a/EIPS/eip-7928.md
+++ b/EIPS/eip-7928.md
@@ -144,7 +144,7 @@ The following table specifies pre-state validation costs in addition to the base
 | `SELFBALANCE` | None (accesses current contract, always warm) |
 | `EXTCODESIZE` | `access_cost` |
 | `EXTCODEHASH` | `access_cost` |
-| `EXTCODECOPY` | `access_cost` + `memory_expansion` |
+| `EXTCODECOPY` | `access_cost` + `memory_expansion` + `GAS_COPY` |
 | `CALL` | `access_cost` + `memory_expansion` + `GAS_CALL_VALUE` (if value > 0) |
 | `CALLCODE` | `access_cost` + `memory_expansion` + `GAS_CALL_VALUE` (if value > 0) |
 | `DELEGATECALL` | `access_cost` + `memory_expansion` |


### PR DESCRIPTION
There was a missing GAS_COPY for EXTCODECOPY.

This issue was reported by Ömer Faruk Irmak [here](https://discord.com/channels/595666850260713488/1364000387195076608/1506952443681050715).

Clients passing the tests need no changes as the test `test_bal_extcodecopy_and_oog::oog_at_memory_boundary` already covers that case.

I also confirmed that the specs had it right, verified in environment.py:384-398:

```python
if address in evm.accessed_addresses:
    access_gas_cost = GasCosts.WARM_ACCESS
else:
    evm.accessed_addresses.add(address)  # only EVM-local set
    access_gas_cost = GasCosts.COLD_ACCOUNT_ACCESS

total_gas_cost = (
    access_gas_cost
    + copy_gas_cost
    + extend_memory.cost
)

charge_gas(evm, total_gas_cost)  # OOG raises here

# OPERATION (only reached after charge succeeds)
...
code_hash = get_account(tx_state, address).code_hash  # adds to tx_state.account_reads
```