### PR TITLE
Update EIP-8081: Add EIP-7709 and EIP-8025

### DIFF
--- a/EIPS/eip-8081.md
+++ b/EIPS/eip-8081.md
@@ -30,7 +30,9 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Declined
 
 ### Proposed for Inclusion
 
+* [EIP-7709](./eip-7709.md): Read BLOCKHASH from storage and update cost
 * [EIP-7716](./eip-7716.md): Anti-correlation attestation penalties
+* [EIP-8025](./eip-8025.md): Optional Execution Proofs
 * [EIP-8205](./eip-8205.md): Withdrawal credentials preregistration
 
 ### Activation


### PR DESCRIPTION
Add EIP-7709 and EIP-8025 as PFI since they were presented in the last ACDE and ACDC, respectively.
