### PR TITLE
Update EIP-2780: precompile target and account-warming charge changes

### DIFF
--- a/EIPS/eip-2780.md
+++ b/EIPS/eip-2780.md
@@ -147,7 +147,7 @@ The intrinsic gas accounting defined here overrides [EIP-2929](./eip-2929.md)'s 
 
 A transaction’s intrinsic base is decomposed into explicit primitives, so warmth must be priced explicitly.
 
-- `tx.sender` is charged as a cold non-code account (`COLD_ACCOUNT_COST_NOCODE = 500`), representing the first access and coalesced account-leaf update.
+- `tx.sender` is charged as a cold non-code account (`COLD_ACCOUNT_COST_NOCODE = 500`), representing the first access and coalesced account-leaf update. It is always charged at the cold rate; access-list inclusion of `tx.sender` does not reduce its per-account cost.
 
 - `tx.to` is charged based on its type:
 
@@ -160,6 +160,8 @@ A transaction’s intrinsic base is decomposed into explicit primitives, so warm
   - if a [EIP-7702](./eip-7702.md) delegated account, use `COLD_ACCOUNT_COST_CODE = 2,600`. The delegation target incurs an additional `COLD_ACCOUNT_COST_CODE = 2,600`, always charged as cold regardless of access-list membership.
 
 - `tx.to` is always charged at the cold rate; access-list inclusion of `tx.to` (or, for a delegated target, the delegation target) does not reduce its per-account cost.
+
+- In summary, all three transaction-level accounts — `tx.sender`, `tx.to`, and any [EIP-7702](./eip-7702.md) delegation target — are always charged cold. There is no warm rate for these accounts and access-list membership never reduces their cost.
 
 This decomposition replaces the implicit warmth assumptions of [EIP-2929](./eip-2929.md) and makes the per-account cost explicit in the base or the execution phase as appropriate.
 
@@ -263,7 +265,8 @@ These changes refine execution-layer accounting to align with the primitives abo
 
 - **Warmth policy.**
 
-  - Access-list entries (charged via [EIP-2930](./eip-2930.md)) are warm at tx start.
+  - The transaction-level accounts — `tx.sender`, `tx.to`, and any [EIP-7702](./eip-7702.md) delegation target — are always charged cold. Access-list inclusion of these addresses does not warm them or reduce their per-account cost.
+  - Access-list entries (charged via [EIP-2930](./eip-2930.md)) warm only the *other* accounts touched during execution, not the transaction-level accounts above.
   - `CALL` warms its `to` after charging the appropriate cold cost if cold.
 
 - **Self-transfers.** If `from == to`, the value transfer is a no-op: the balance is unchanged, so no separate recipient leaf write or [EIP-7708](./eip-7708.md) transfer log is charged. The sender's nonce and balance update are coalesced into the single account-leaf write already included in `TX_BASE_COST`. (It is a NOP tx other than charging gas and incrementing nonce).
@@ -287,9 +290,9 @@ This aligns costs with actual state work rather than legacy flat surcharges.
 
 ### Edits and interactions with other EIPs
 
-- **[EIP-2930](./eip-2930.md) (Access List).** Intrinsic gas is `TX_BASE_COST` after `FORK_BLOCK`. Access lists keep their existing per-entry charges and warming semantics for execution-level account touches, but they no longer reduce the cold cost of the transaction target (`tx.to`).
+- **[EIP-2930](./eip-2930.md) (Access List).** Intrinsic gas is `TX_BASE_COST` after `FORK_BLOCK`. Access lists keep their existing per-entry charges and warming semantics for execution-level account touches, but they no longer reduce the cold cost of the transaction-level accounts (`tx.sender`, `tx.to`, or an [EIP-7702](./eip-7702.md) delegation target), which are always charged cold.
 - **[EIP-2929](./eip-2929.md) (Gas cost increases for state access).** Refined by this EIP to price non-code cold touches at `500` and code-account cold touches at `2,600`.
-- **[EIP-7702](./eip-7702.md) (Set EOA Code).** `TX_BASE_COST` remains `4,500` even if the sender temporarily assumes code for the transaction. Clients must not perform any disk code-load to determine sender type, since 7702 provides code inline. If the transaction executes code that reads or executes its own code, normal `COLD_ACCOUNT_COST_CODE` or `WARM_STATE_READ` costs apply at execution time as per the standard cold/warm model. When `tx.to` is a 7702-delegated account, it is charged `COLD_ACCOUNT_COST_CODE = 2,600` at the intrinsic level. Resolving the delegation requires loading code from the delegation target, which incurs its own `COLD_ACCOUNT_COST_CODE = 2,600`, always charged as cold for the transaction target regardless of access-list membership. For internal `CALL` to a delegated account, the standard cold/warm model applies per [EIP-2929](./eip-2929.md).
+- **[EIP-7702](./eip-7702.md) (Set EOA Code).** `TX_BASE_COST` remains `4,500` even if the sender temporarily assumes code for the transaction. When `tx.to` is a 7702-delegated account, it is charged `COLD_ACCOUNT_COST_CODE = 2,600` at the intrinsic level. Resolving the delegation requires loading code from the delegation target, which incurs its own `COLD_ACCOUNT_COST_CODE = 2,600`, it is always charged as cold for the transaction target regardless of access-list membership. For internal `CALL` to a delegated account, the standard cold/warm model applies per [EIP-2929](./eip-2929.md).
 - **[EIP-7708](./eip-7708.md) (ETH transfers emit a log).** EIP-7708 emits a LOG3-shaped transfer event on every non-zero-value ETH transfer to a different account, and a LOG2-shaped burn event when ETH leaves circulation. Under the legacy `21,000` intrinsic base, the LOG3 cost of a transfer event was implicitly absorbed; with `TX_BASE_COST` reduced to `4,500`, that subsidy disappears and each emission must be priced explicitly. This EIP charges `TRANSFER_LOG_COST = 1,756` (LOG3 equivalent: `375 + 3×375 + 32×8`) at intrinsic gas computation (see *Pseudocode*) for top-level value-transferring transactions, including `CREATE` transactions with `value > 0`. The corresponding in-EVM transfer-log and burn-log charges (`CALL`, `SELFDESTRUCT`, `CREATE` / `CREATE2`) are specified in [EIP-7708](./eip-7708.md).
 - **[EIP-7928](./eip-7928.md) (Block-Level Access Lists).** The two-tier cold-access model (`COLD_ACCOUNT_COST_NOCODE` vs `COLD_ACCOUNT_COST_CODE`) requires loading the account from disk before the correct charge can be determined. For cold accounts, at least `COLD_ACCOUNT_COST_NOCODE` gas must be available before account access is attempted; if unavailable, the operation fails with out-of-gas without accessing the account. Once an account access is attempted, the account is added to the transaction's accessed set for the BAL. Thereafter, if the account is found to have code, the account read remains in the BAL even if the available gas is less than `COLD_ACCOUNT_COST_CODE` and the call frame fails with out-of-gas.
 - **Calldata-pricing EIPs (e.g. [EIP-7623](./eip-7623.md)).** Unchanged. This EIP does not alter calldata pricing.
@@ -402,7 +405,7 @@ Add explicit test vectors (intrinsic gas only):
 1. `value > 0` to an empty EOA (non-existent per EIP-161): intrinsic `31,756` (4,500 base + 500 + 25,000 surcharge + 1,756 transfer log).
 2. `value = 0` to an empty address: intrinsic `4,500` (no creation, no surcharge).
 3. `CREATE` transaction: unchanged from prior rules.
-4. EIP-7702 transaction with and without access list: intrinsic uses `TX_BASE_COST` plus per-entry access-list costs; the `tx.to` cold cost is unchanged by access-list presence.
+4. EIP-7702 transaction with and without access list: intrinsic uses `TX_BASE_COST` plus per-entry access-list costs; the cold cost of `tx.sender`, `tx.to`, and the delegation target is unchanged by access-list presence (all always cold).
 5. Block of txs calling minimal gas contract execution with maximal contract size addresses (so VM is activated for every tx).
 6. 7702 interactions
     - 7702 tx where sender assumes code and calls nothing: intrinsic = 4,500, no extra cold-code cost.

--- a/EIPS/eip-2780.md
+++ b/EIPS/eip-2780.md
@@ -157,9 +157,9 @@ A transaction’s intrinsic base is decomposed into explicit primitives, so warm
 
   - if a contract, use `COLD_ACCOUNT_COST_CODE = 2,600`.
 
-  - if a [EIP-7702](./eip-7702.md) delegated account, use `COLD_ACCOUNT_COST_CODE = 2,600`. The delegation target incurs an additional `COLD_ACCOUNT_COST_CODE = 2,600` if cold, or `WARM_STATE_READ = 100` if already warm.
+  - if a [EIP-7702](./eip-7702.md) delegated account, use `COLD_ACCOUNT_COST_CODE = 2,600`. The delegation target incurs an additional `COLD_ACCOUNT_COST_CODE = 2,600`, always charged as cold regardless of access-list membership.
 
-- Warmth discovered through an access list still applies and overrides the cold cost.
+- `tx.to` is always charged at the cold rate; access-list inclusion of `tx.to` (or, for a delegated target, the delegation target) does not reduce its per-account cost.
 
 This decomposition replaces the implicit warmth assumptions of [EIP-2929](./eip-2929.md) and makes the per-account cost explicit in the base or the execution phase as appropriate.
 
@@ -282,9 +282,9 @@ This aligns costs with actual state work rather than legacy flat surcharges.
 
 ### Edits and interactions with other EIPs
 
-- **[EIP-2930](./eip-2930.md) (Access List).** Intrinsic gas is `TX_BASE_COST` after `FORK_BLOCK`. Access lists keep their existing per-entry charges and warming semantics.
+- **[EIP-2930](./eip-2930.md) (Access List).** Intrinsic gas is `TX_BASE_COST` after `FORK_BLOCK`. Access lists keep their existing per-entry charges and warming semantics for execution-level account touches, but they no longer reduce the cold cost of the transaction target (`tx.to`).
 - **[EIP-2929](./eip-2929.md) (Gas cost increases for state access).** Refined by this EIP to price non-code cold touches at `500` and code-account cold touches at `2,600`.
-- **[EIP-7702](./eip-7702.md) (Set EOA Code).** `TX_BASE_COST` remains `4,500` even if the sender temporarily assumes code for the transaction. Clients must not perform any disk code-load to determine sender type, since 7702 provides code inline. If the transaction executes code that reads or executes its own code, normal `COLD_ACCOUNT_COST_CODE` or `WARM_STATE_READ` costs apply at execution time as per the standard cold/warm model. When `tx.to` is a 7702-delegated account, it is charged `COLD_ACCOUNT_COST_CODE = 2,600` at the intrinsic level. Resolving the delegation requires loading code from the delegation target, which incurs its own `COLD_ACCOUNT_COST_CODE = 2,600` if the target is cold, or `WARM_STATE_READ = 100` if already warm. This also applies to calls made to delegated accounts.
+- **[EIP-7702](./eip-7702.md) (Set EOA Code).** `TX_BASE_COST` remains `4,500` even if the sender temporarily assumes code for the transaction. Clients must not perform any disk code-load to determine sender type, since 7702 provides code inline. If the transaction executes code that reads or executes its own code, normal `COLD_ACCOUNT_COST_CODE` or `WARM_STATE_READ` costs apply at execution time as per the standard cold/warm model. When `tx.to` is a 7702-delegated account, it is charged `COLD_ACCOUNT_COST_CODE = 2,600` at the intrinsic level. Resolving the delegation requires loading code from the delegation target, which incurs its own `COLD_ACCOUNT_COST_CODE = 2,600`, always charged as cold for the transaction target regardless of access-list membership. For internal `CALL` to a delegated account, the standard cold/warm model applies per [EIP-2929](./eip-2929.md).
 - **[EIP-7708](./eip-7708.md) (ETH transfers emit a log).** EIP-7708 emits a LOG3-shaped transfer event on every non-zero-value ETH transfer to a different account, and a LOG2-shaped burn event when ETH leaves circulation. Under the legacy `21,000` intrinsic base, the LOG3 cost of a transfer event was implicitly absorbed; with `TX_BASE_COST` reduced to `4,500`, that subsidy disappears and each emission must be priced explicitly. This EIP charges `TRANSFER_LOG_COST = 1,756` (LOG3 equivalent: `375 + 3×375 + 32×8`) at intrinsic gas computation (see *Pseudocode*) for top-level value-transferring transactions, including `CREATE` transactions with `value > 0`. The corresponding in-EVM transfer-log and burn-log charges (`CALL`, `SELFDESTRUCT`, `CREATE` / `CREATE2`) are specified in [EIP-7708](./eip-7708.md).
 - **[EIP-7928](./eip-7928.md) (Block-Level Access Lists).** The two-tier cold-access model (`COLD_ACCOUNT_COST_NOCODE` vs `COLD_ACCOUNT_COST_CODE`) requires loading the account from disk before the correct charge can be determined. For cold accounts, at least `COLD_ACCOUNT_COST_NOCODE` gas must be available before account access is attempted; if unavailable, the operation fails with out-of-gas without accessing the account. Once an account access is attempted, the account is added to the transaction's accessed set for the BAL. Thereafter, if the account is found to have code, the account read remains in the BAL even if the available gas is less than `COLD_ACCOUNT_COST_CODE` and the call frame fails with out-of-gas.
 - **Calldata-pricing EIPs (e.g. [EIP-7623](./eip-7623.md)).** Unchanged. This EIP does not alter calldata pricing.
@@ -397,21 +397,18 @@ Add explicit test vectors (intrinsic gas only):
 1. `value > 0` to an empty EOA (non-existent per EIP-161): intrinsic `31,756` (4,500 base + 500 + 25,000 surcharge + 1,756 transfer log).
 2. `value = 0` to an empty address: intrinsic `4,500` (no creation, no surcharge).
 3. `CREATE` transaction: unchanged from prior rules.
-4. EIP-7702 transaction with and without access list: intrinsic uses `TX_BASE_COST` plus unchanged access-list costs.
+4. EIP-7702 transaction with and without access list: intrinsic uses `TX_BASE_COST` plus per-entry access-list costs; the `tx.to` cold cost is unchanged by access-list presence.
 5. Block of txs calling minimal gas contract execution with maximal contract size addresses (so VM is activated for every tx).
-6. Warmth and access list interplay
-    - ETH transfer to existing EOA without access list: charge `COLD_ACCOUNT_COST_NOCODE = 500` for recipient lookup.
-    - Same transaction with recipient in access list: charge `WARM_STATE_READ = 100`.
-7. 7702 interactions
+6. 7702 interactions
     - 7702 tx where sender assumes code and calls nothing: intrinsic = 4,500, no extra cold-code cost.
     - 7702 tx where sender assumes code and executes self-code: charge `COLD_ACCOUNT_COST_CODE` when first loaded.
-8. Internal CALL repricing
+7. Internal CALL repricing
     - Internal `CALL` to existing EOA with value: `CALL_VALUE_COST = 3,756` plus cold/warm costs.
     - Internal `CALL` to EIP-161-empty: `CALL_VALUE_COST = 27,756`.
-9. Zero-value edge cases `value = 0` to empty address: intrinsic = `4,500`.
-10. Perfnet stress
+8. Zero-value edge cases `value = 0` to empty address: intrinsic = `4,500`.
+9. Perfnet stress
     - Fill block with minimal 4,500-gas tx and 7,756-gas ETH transfers; confirm gas vs byte-size binding per [EIP-7934](./eip-7934.md).
-11. SELFDESTRUCT test: Create-and-destroy in one tx; confirm normal value-transfer costs apply, no deletion repricing.
+10. SELFDESTRUCT test: Create-and-destroy in one tx; confirm normal value-transfer costs apply, no deletion repricing.
 
 ## Security Considerations
 

--- a/EIPS/eip-2780.md
+++ b/EIPS/eip-2780.md
@@ -22,7 +22,7 @@ This EIP does not change calldata or access-list metering. It also refines relat
 - Split cold-account touches into `COLD_ACCOUNT_COST_CODE = 2,600` and `COLD_ACCOUNT_COST_NOCODE = 500`.
 - Introduce `STATE_UPDATE = 1,000` as the price of a single account-leaf write.
 - Reprice value-moving calls as account-leaf writes, replacing `CALL_VALUE_COST = 9,000` with `CALL_VALUE_COST = 2 * STATE_UPDATE + TRANSFER_LOG_COST = 3,756`.
-- Charge `TRANSFER_LOG_COST = 1,756` for the [EIP-7708](./eip-7708.md) transfer log emitted on every nonzero-value transfer.
+- Charge `TRANSFER_LOG_COST = 1,756` for the [EIP-7708](./eip-7708.md) transfer log emitted on every nonzero-value transfer to a different account.
 
 Capacity impact (illustrative):
 
@@ -229,8 +229,9 @@ def CalculateIntrinsicGas(tx, state_at_start):
         gasCost += GasForAccessList(tx.access_list)     # per EIP-2930
 
     # Charge for the EIP-7708 transfer log emitted on the tx-level value
-    # transfer.
-    if tx.value > 0:
+    # transfer. EIP-7708 does not emit a log for self-transfers; CREATE
+    # transactions endow a freshly computed address distinct from sender.
+    if tx.value > 0 and (tx.is_create() or tx.sender != tx.to):
         gasCost += TRANSFER_LOG_COST                    # EIP-7708 transfer log
 
     if tx.is_create() == False
@@ -247,10 +248,11 @@ These changes refine execution-layer accounting to align with the primitives abo
 
 - **Value-moving calls.** Replace the legacy `CALL_VALUE_COST = 9,000` with:
 
-  - If recipient exists: `CALL_VALUE_COST = 2 * STATE_UPDATE + TRANSFER_LOG_COST = 3,756`.
-  - If recipient is EIP-161-empty: `CALL_VALUE_COST = STATE_UPDATE + GAS_NEW_ACCOUNT + TRANSFER_LOG_COST = 27,756`.
+  - If `caller == to` (self-call): `CALL_VALUE_COST = 0`. The balance is unchanged, so no account-leaf write is required, and [EIP-7708](./eip-7708.md) does not emit a transfer log for self-transfers.
+  - If recipient exists and `caller != to`: `CALL_VALUE_COST = 2 * STATE_UPDATE + TRANSFER_LOG_COST = 3,756`.
+  - If recipient is EIP-161-empty and `caller != to`: `CALL_VALUE_COST = STATE_UPDATE + GAS_NEW_ACCOUNT + TRANSFER_LOG_COST = 27,756`.
   - This charge is in addition to warm/cold account-touch costs per EIP-2929 and the existing `CALL` base cost. This EIP does not modify the `CALL` base cost.
-  - `TRANSFER_LOG_COST` covers the [EIP-7708](./eip-7708.md) transfer log emitted for every nonzero-value transfer.
+  - `TRANSFER_LOG_COST` covers the [EIP-7708](./eip-7708.md) transfer log emitted for every nonzero-value transfer to a different account.
 
   The `CALL_VALUE_COST` applies for all value-carrying calls, regardless of whether the callee's account has already been updated earlier in the same transaction. This ensures the 2300-gas stipend mechanism remains safe and consistent for simple value forwarding and does not retroactively depend on account-update history.
 
@@ -264,6 +266,8 @@ These changes refine execution-layer accounting to align with the primitives abo
   - Access-list entries (charged via [EIP-2930](./eip-2930.md)) are warm at tx start.
   - `CALL` warms its `to` after charging the appropriate cold cost if cold.
 
+- **Self-transfers.** If `from == to`, the value transfer is a no-op: the balance is unchanged, so no separate recipient leaf write or [EIP-7708](./eip-7708.md) transfer log is charged. The sender's nonce and balance update are coalesced into the single account-leaf write already included in `TX_BASE_COST`. (It is a NOP tx other than charging gas and incrementing nonce).
+
 
 ### Transaction reference cases
 
@@ -271,6 +275,7 @@ These changes refine execution-layer accounting to align with the primitives abo
 | ----------------------------------- | ---------------------------------------------------------------- | -------------------------:|
 | (NOP) No-transfer to EOA            | `TX_BASE_COST` + `COLD_ACCOUNT_COST_NOCODE`                      | 5,000                     |
 | (NOP) No-transfer to empty account  | `TX_BASE_COST` + `COLD_ACCOUNT_COST_NOCODE`                      | 5,000                     |
+| (NOP) ETH transfer to self          | `TX_BASE_COST`                                                   | 4,500                     |
 | ETH Transfer to existing EOA        | `TX_BASE_COST` + `COLD_ACCOUNT_COST_NOCODE` + `STATE_UPDATE` + `TRANSFER_LOG_COST` | 7,756                 |
 | No-transfer to contract             | `TX_BASE_COST` + `COLD_ACCOUNT_COST_CODE` + **execution**                | 7,100 + **execution**     |
 | ETH Transfer to contract            | `TX_BASE_COST` + `COLD_ACCOUNT_COST_CODE` + `STATE_UPDATE` + `TRANSFER_LOG_COST` + **execution** | 9,856 + **execution**     |
@@ -405,10 +410,12 @@ Add explicit test vectors (intrinsic gas only):
 7. Internal CALL repricing
     - Internal `CALL` to existing EOA with value: `CALL_VALUE_COST = 3,756` plus cold/warm costs.
     - Internal `CALL` to EIP-161-empty: `CALL_VALUE_COST = 27,756`.
-8. Zero-value edge cases `value = 0` to empty address: intrinsic = `4,500`.
-9. Perfnet stress
+    - Internal self-`CALL` with value (`caller == to`): `CALL_VALUE_COST = 0`; no transfer log charged.
+8. Self-transfer `from == to` with `value > 0`: intrinsic = `4,500`; no `STATE_UPDATE`, `COLD_ACCOUNT_COST`, or `TRANSFER_LOG_COST` for the recipient.
+9. Zero-value edge cases `value = 0` to empty address: intrinsic = `4,500`.
+10. Perfnet stress
     - Fill block with minimal 4,500-gas tx and 7,756-gas ETH transfers; confirm gas vs byte-size binding per [EIP-7934](./eip-7934.md).
-10. SELFDESTRUCT test: Create-and-destroy in one tx; confirm normal value-transfer costs apply, no deletion repricing.
+11. SELFDESTRUCT test: Create-and-destroy in one tx; confirm normal value-transfer costs apply, no deletion repricing.
 
 ## Security Considerations
 

--- a/EIPS/eip-2780.md
+++ b/EIPS/eip-2780.md
@@ -20,8 +20,8 @@ If a non-create transaction has `value > 0` and targets a non-existent account, 
 This EIP does not change calldata or access-list metering. It also refines related gas schedule items used in derivation and execution accounting:
 
 - Split cold-account touches into `COLD_ACCOUNT_COST_CODE = 2,600` and `COLD_ACCOUNT_COST_NOCODE = 500`.
-- Introduce `STATE_UPDATE = 1,000` as the price of a single account-leaf write. New state update is happening on value transfer on `to` account, caller account is already getting changes bcs of fee.
-- Reprice value-moving calls as account-leaf writes, replacing `CALL_VALUE_COST = 9,000` with `CALL_VALUE_COST = STATE_UPDATE + TRANSFER_LOG_COST = 3,756`.
+- Introduce `STATE_UPDATE = 1,000` as the price of a single account-leaf write.
+- Reprice value-moving calls as account-leaf writes, replacing `CALL_VALUE_COST = 9,000` with `CALL_VALUE_COST = 2 * STATE_UPDATE + TRANSFER_LOG_COST = 3,756`.
 - Charge `TRANSFER_LOG_COST = 1,756` for the [EIP-7708](./eip-7708.md) transfer log emitted on every nonzero-value transfer to a different account.
 
 Capacity impact (illustrative):

--- a/EIPS/eip-2780.md
+++ b/EIPS/eip-2780.md
@@ -22,7 +22,7 @@ This EIP does not change calldata or access-list metering. It also refines relat
 - Split cold-account touches into `COLD_ACCOUNT_COST_CODE = 2,600` and `COLD_ACCOUNT_COST_NOCODE = 500`.
 - Introduce `STATE_UPDATE = 1,000` as the price of a single account-leaf write.
 - Reprice value-moving calls as account-leaf writes, replacing `CALL_VALUE_COST = 9,000` with `CALL_VALUE_COST = 2 * STATE_UPDATE + TRANSFER_LOG_COST = 3,756`.
-- Charge `TRANSFER_LOG_COST = 1,756` for the [EIP-7708](./eip-7708.md) transfer log emitted on every nonzero-value transfer to a different account.
+- Charge `TRANSFER_LOG_COST = 1,756` for the [EIP-7708](./eip-7708.md) transfer log emitted on every nonzero-value transfer.
 
 Capacity impact (illustrative):
 
@@ -159,8 +159,6 @@ A transaction’s intrinsic base is decomposed into explicit primitives, so warm
 
   - if a [EIP-7702](./eip-7702.md) delegated account, use `COLD_ACCOUNT_COST_CODE = 2,600`. The delegation target incurs an additional `COLD_ACCOUNT_COST_CODE = 2,600` if cold, or `WARM_STATE_READ = 100` if already warm.
 
-  - if a precompile, it is warm at tx start and charged zero.
-
 - Warmth discovered through an access list still applies and overrides the cold cost.
 
 This decomposition replaces the implicit warmth assumptions of [EIP-2929](./eip-2929.md) and makes the per-account cost explicit in the base or the execution phase as appropriate.
@@ -190,8 +188,7 @@ Apply `GAS_NEW_ACCOUNT` when **all** are true:
 
 1. The transaction is not a `CREATE` transaction.
 2. `value > 0`.
-3. `to` is not a precompile.
-4. `to` is non-existent per [EIP-161](./eip-161.md) emptiness at the start of transaction execution.
+3. `to` is non-existent per [EIP-161](./eip-161.md) emptiness at the start of transaction execution.
 
 The `GAS_NEW_ACCOUNT = 25,000` charge covers state growth (new leaf creation and one `STATE_UPDATE`).
 An additional `COLD_ACCOUNT_COST_NOCODE = 500` applies for the initial lookup to determine that the account does not exist.
@@ -232,15 +229,12 @@ def CalculateIntrinsicGas(tx, state_at_start):
         gasCost += GasForAccessList(tx.access_list)     # per EIP-2930
 
     # Charge for the EIP-7708 transfer log emitted on the tx-level value
-    # transfer. CREATE transactions endow a freshly computed contract
-    # address that is, by construction, distinct from the sender, so the
-    # log applies whenever value > 0.
-    if tx.value > 0 and (tx.is_create() or tx.sender != tx.to):
+    # transfer.
+    if tx.value > 0:
         gasCost += TRANSFER_LOG_COST                    # EIP-7708 transfer log
 
     if tx.is_create() == False
        and tx.value > 0
-       and is_precompile(tx.to) == False
        and is_nonexistent_per_eip161(state_at_start, tx.to):
         gasCost += GAS_NEW_ACCOUNT
 
@@ -253,11 +247,10 @@ These changes refine execution-layer accounting to align with the primitives abo
 
 - **Value-moving calls.** Replace the legacy `CALL_VALUE_COST = 9,000` with:
 
-  - If `caller == to` (self-call): `CALL_VALUE_COST = STATE_UPDATE = 1,000`. No `TRANSFER_LOG_COST` is charged because [EIP-7708](./eip-7708.md) does not emit a transfer log for self-transfers.
-  - If recipient exists and `caller != to`: `CALL_VALUE_COST = 2 * STATE_UPDATE + TRANSFER_LOG_COST = 3,756`.
-  - If recipient is EIP-161-empty and `caller != to`: `CALL_VALUE_COST = STATE_UPDATE + GAS_NEW_ACCOUNT + TRANSFER_LOG_COST = 27,756`.
+  - If recipient exists: `CALL_VALUE_COST = 2 * STATE_UPDATE + TRANSFER_LOG_COST = 3,756`.
+  - If recipient is EIP-161-empty: `CALL_VALUE_COST = STATE_UPDATE + GAS_NEW_ACCOUNT + TRANSFER_LOG_COST = 27,756`.
   - This charge is in addition to warm/cold account-touch costs per EIP-2929 and the existing `CALL` base cost. This EIP does not modify the `CALL` base cost.
-  - `TRANSFER_LOG_COST` covers the [EIP-7708](./eip-7708.md) transfer log emitted for every nonzero-value transfer to a different account.
+  - `TRANSFER_LOG_COST` covers the [EIP-7708](./eip-7708.md) transfer log emitted for every nonzero-value transfer.
 
   The `CALL_VALUE_COST` applies for all value-carrying calls, regardless of whether the callee's account has already been updated earlier in the same transaction. This ensures the 2300-gas stipend mechanism remains safe and consistent for simple value forwarding and does not retroactively depend on account-update history.
 
@@ -268,10 +261,8 @@ These changes refine execution-layer accounting to align with the primitives abo
 
 - **Warmth policy.**
 
-  - Access-list entries (charged via [EIP-2930](./eip-2930.md)) and precompiles are warm at tx start.
+  - Access-list entries (charged via [EIP-2930](./eip-2930.md)) are warm at tx start.
   - `CALL` warms its `to` after charging the appropriate cold cost if cold.
-
-- **Self-transfers.** If `from == to`, only one `STATE_UPDATE` occurs. The sender's nonce and balance update are coalesced into the same leaf write. No recipient lookup or separate write is charged. (It is a NOP tx other than charging gas and incrementing nonce).
 
 
 ### Transaction reference cases
@@ -280,7 +271,6 @@ These changes refine execution-layer accounting to align with the primitives abo
 | ----------------------------------- | ---------------------------------------------------------------- | -------------------------:|
 | (NOP) No-transfer to EOA            | `TX_BASE_COST` + `COLD_ACCOUNT_COST_NOCODE`                      | 5,000                     |
 | (NOP) No-transfer to empty account  | `TX_BASE_COST` + `COLD_ACCOUNT_COST_NOCODE`                      | 5,000                     |
-| (NOP) ETH transfer to self          | `TX_BASE_COST`                                                   | 4,500                 |
 | ETH Transfer to existing EOA        | `TX_BASE_COST` + `COLD_ACCOUNT_COST_NOCODE` + `STATE_UPDATE` + `TRANSFER_LOG_COST` | 7,756                 |
 | No-transfer to contract             | `TX_BASE_COST` + `COLD_ACCOUNT_COST_CODE` + **execution**                | 7,100 + **execution**     |
 | ETH Transfer to contract            | `TX_BASE_COST` + `COLD_ACCOUNT_COST_CODE` + `STATE_UPDATE` + `TRANSFER_LOG_COST` + **execution** | 9,856 + **execution**     |
@@ -405,27 +395,23 @@ Tests should be created with blocks of just ETH transfers and tested on Perfnet 
 Add explicit test vectors (intrinsic gas only):
 
 1. `value > 0` to an empty EOA (non-existent per EIP-161): intrinsic `31,756` (4,500 base + 500 + 25,000 surcharge + 1,756 transfer log).
-2. `value > 0` to a precompile: intrinsic `6,256` (4,500 base + 1,756 transfer log; no surcharge; precompiles are warm at tx start).
-3. `value = 0` to an empty address: intrinsic `4,500` (no creation, no surcharge).
-4. `CREATE` transaction: unchanged from prior rules.
-5. EIP-7702 transaction with and without access list: intrinsic uses `TX_BASE_COST` plus unchanged access-list costs.
-6. Block of txs calling minimal gas contract execution with maximal contract size addresses (so VM is activated for every tx).
-7. Warmth and access list interplay
+2. `value = 0` to an empty address: intrinsic `4,500` (no creation, no surcharge).
+3. `CREATE` transaction: unchanged from prior rules.
+4. EIP-7702 transaction with and without access list: intrinsic uses `TX_BASE_COST` plus unchanged access-list costs.
+5. Block of txs calling minimal gas contract execution with maximal contract size addresses (so VM is activated for every tx).
+6. Warmth and access list interplay
     - ETH transfer to existing EOA without access list: charge `COLD_ACCOUNT_COST_NOCODE = 500` for recipient lookup.
     - Same transaction with recipient in access list: charge `WARM_STATE_READ = 100`.
-8. 7702 interactions
+7. 7702 interactions
     - 7702 tx where sender assumes code and calls nothing: intrinsic = 4,500, no extra cold-code cost.
     - 7702 tx where sender assumes code and executes self-code: charge `COLD_ACCOUNT_COST_CODE` when first loaded.
-9. Precompile transfers
-    - `value > 0` to `0x01`–`0x09`: intrinsic = 6,256 (4,500 base + 1,756 transfer log), no surcharge.
-10. Self-transfer `from == to`: total = 4,500.
-11. Internal CALL repricing
+8. Internal CALL repricing
     - Internal `CALL` to existing EOA with value: `CALL_VALUE_COST = 3,756` plus cold/warm costs.
     - Internal `CALL` to EIP-161-empty: `CALL_VALUE_COST = 27,756`.
-12. Zero-value edge cases `value = 0` to empty address: intrinsic = `4,500`.
-13. Perfnet stress
+9. Zero-value edge cases `value = 0` to empty address: intrinsic = `4,500`.
+10. Perfnet stress
     - Fill block with minimal 4,500-gas tx and 7,756-gas ETH transfers; confirm gas vs byte-size binding per [EIP-7934](./eip-7934.md).
-14. SELFDESTRUCT test: Create-and-destroy in one tx; confirm normal value-transfer costs apply, no deletion repricing.
+11. SELFDESTRUCT test: Create-and-destroy in one tx; confirm normal value-transfer costs apply, no deletion repricing.
 
 ## Security Considerations
 

--- a/EIPS/eip-2780.md
+++ b/EIPS/eip-2780.md
@@ -20,8 +20,8 @@ If a non-create transaction has `value > 0` and targets a non-existent account, 
 This EIP does not change calldata or access-list metering. It also refines related gas schedule items used in derivation and execution accounting:
 
 - Split cold-account touches into `COLD_ACCOUNT_COST_CODE = 2,600` and `COLD_ACCOUNT_COST_NOCODE = 500`.
-- Introduce `STATE_UPDATE = 1,000` as the price of a single account-leaf write.
-- Reprice value-moving calls as account-leaf writes, replacing `CALL_VALUE_COST = 9,000` with `CALL_VALUE_COST = 2 * STATE_UPDATE + TRANSFER_LOG_COST = 3,756`.
+- Introduce `STATE_UPDATE = 1,000` as the price of a single account-leaf write. New state update is happening on value transfer on `to` account, caller account is already getting changes bcs of fee.
+- Reprice value-moving calls as account-leaf writes, replacing `CALL_VALUE_COST = 9,000` with `CALL_VALUE_COST = STATE_UPDATE + TRANSFER_LOG_COST = 3,756`.
 - Charge `TRANSFER_LOG_COST = 1,756` for the [EIP-7708](./eip-7708.md) transfer log emitted on every nonzero-value transfer to a different account.
 
 Capacity impact (illustrative):
@@ -140,7 +140,6 @@ After `FORK_BLOCK`, set the following parameters and rules:
 | `STATE_UPDATE`             |  1,000 | One account-leaf write in the account trie (nonce and balance coalesce) |
 | `COLD_ACCOUNT_COST_CODE`   |  2,600 | Cold touch of an account with code                                      |
 | `COLD_ACCOUNT_COST_NOCODE` |    500 | Cold touch of an account known to have no code                          |
-| `WARM_STATE_READ`          |    100 | Touch of an already-warm account (same as `WARM_STORAGE_READ_COST`)     |
 | `TRANSFER_LOG_COST`        |  1,756 | [EIP-7708](./eip-7708.md) LOG3 transfer event (375 + 3×375 + 32×8). See [EIP-7708](./eip-7708.md) for the full set of emission sites and their charging points. |
 
 The intrinsic gas accounting defined here overrides [EIP-2929](./eip-2929.md)'s blanket "all tx addresses are warm" rule.
@@ -167,7 +166,7 @@ This decomposition replaces the implicit warmth assumptions of [EIP-2929](./eip-
 
 Notes:
 
-- `STATE_UPDATE` counts writes at the account-leaf granularity. If a single account's nonce and balance both change in one transition, charge one `STATE_UPDATE`.
+- `STATE_UPDATE` counts writes at the account-leaf granularity. If a single account's nonce or balance change in one transition, charge one `STATE_UPDATE`.
 - `COLD_ACCOUNT_COST_NOCODE` reflects that non-code accounts do not load code or a storage trie, so have a lower warming cost.
 - A regular ETH transfer additionally includes a cold touch of at least `COLD_ACCOUNT_COST_NOCODE`, a `STATE_UPDATE` of the `to` address, and a `TRANSFER_LOG_COST` for the [EIP-7708](./eip-7708.md) transfer log, so the effective minimal productive tx cost is `7,756`.
 - Not including the `to` cold warming and `STATE_UPDATE` in `TX_BASE_COST` means a contract-interaction transaction that does not transfer value does not unnecessarily pay these additional costs.

--- a/EIPS/eip-2780.md
+++ b/EIPS/eip-2780.md
@@ -22,7 +22,7 @@ This EIP does not change calldata or access-list metering. It also refines relat
 - Split cold-account touches into `COLD_ACCOUNT_COST_CODE = 2,600` and `COLD_ACCOUNT_COST_NOCODE = 500`.
 - Introduce `STATE_UPDATE = 1,000` as the price of a single account-leaf write.
 - Reprice value-moving calls as account-leaf writes, replacing `CALL_VALUE_COST = 9,000` with `CALL_VALUE_COST = 2 * STATE_UPDATE + TRANSFER_LOG_COST = 3,756`.
-- Charge `TRANSFER_LOG_COST = 1,756` for the [EIP-7708](./eip-7708.md) transfer log emitted on every nonzero-value transfer to a different account.
+- Charge `TRANSFER_LOG_COST = 1,756` for the [EIP-7708](./eip-7708.md) transfer log emitted on every nonzero-value transfer.
 
 Capacity impact (illustrative):
 
@@ -229,9 +229,8 @@ def CalculateIntrinsicGas(tx, state_at_start):
         gasCost += GasForAccessList(tx.access_list)     # per EIP-2930
 
     # Charge for the EIP-7708 transfer log emitted on the tx-level value
-    # transfer. EIP-7708 does not emit a log for self-transfers; CREATE
-    # transactions endow a freshly computed address distinct from sender.
-    if tx.value > 0 and (tx.is_create() or tx.sender != tx.to):
+    # transfer.
+    if tx.value > 0:
         gasCost += TRANSFER_LOG_COST                    # EIP-7708 transfer log
 
     if tx.is_create() == False
@@ -250,9 +249,8 @@ These changes refine execution-layer accounting to align with the primitives abo
 
   - If recipient exists: `CALL_VALUE_COST = 2 * STATE_UPDATE + TRANSFER_LOG_COST = 3,756`.
   - If recipient is EIP-161-empty: `CALL_VALUE_COST = STATE_UPDATE + GAS_NEW_ACCOUNT + TRANSFER_LOG_COST = 27,756`.
-  - When `caller == to`, omit `TRANSFER_LOG_COST` because [EIP-7708](./eip-7708.md) does not emit a transfer log for self-transfers.
   - This charge is in addition to warm/cold account-touch costs per EIP-2929 and the existing `CALL` base cost. This EIP does not modify the `CALL` base cost.
-  - `TRANSFER_LOG_COST` covers the [EIP-7708](./eip-7708.md) transfer log emitted for every nonzero-value transfer to a different account.
+  - `TRANSFER_LOG_COST` covers the [EIP-7708](./eip-7708.md) transfer log emitted for every nonzero-value transfer.
 
   The `CALL_VALUE_COST` applies for all value-carrying calls, regardless of whether the callee's account has already been updated earlier in the same transaction. This ensures the 2300-gas stipend mechanism remains safe and consistent for simple value forwarding and does not retroactively depend on account-update history.
 

--- a/EIPS/eip-2780.md
+++ b/EIPS/eip-2780.md
@@ -22,7 +22,7 @@ This EIP does not change calldata or access-list metering. It also refines relat
 - Split cold-account touches into `COLD_ACCOUNT_COST_CODE = 2,600` and `COLD_ACCOUNT_COST_NOCODE = 500`.
 - Introduce `STATE_UPDATE = 1,000` as the price of a single account-leaf write.
 - Reprice value-moving calls as account-leaf writes, replacing `CALL_VALUE_COST = 9,000` with `CALL_VALUE_COST = 2 * STATE_UPDATE + TRANSFER_LOG_COST = 3,756`.
-- Charge `TRANSFER_LOG_COST = 1,756` for the [EIP-7708](./eip-7708.md) transfer log emitted on every nonzero-value transfer.
+- Charge `TRANSFER_LOG_COST = 1,756` for the [EIP-7708](./eip-7708.md) transfer log emitted on every nonzero-value transfer to a different account.
 
 Capacity impact (illustrative):
 
@@ -229,8 +229,9 @@ def CalculateIntrinsicGas(tx, state_at_start):
         gasCost += GasForAccessList(tx.access_list)     # per EIP-2930
 
     # Charge for the EIP-7708 transfer log emitted on the tx-level value
-    # transfer.
-    if tx.value > 0:
+    # transfer. EIP-7708 does not emit a log for self-transfers; CREATE
+    # transactions endow a freshly computed address distinct from sender.
+    if tx.value > 0 and (tx.is_create() or tx.sender != tx.to):
         gasCost += TRANSFER_LOG_COST                    # EIP-7708 transfer log
 
     if tx.is_create() == False
@@ -249,8 +250,9 @@ These changes refine execution-layer accounting to align with the primitives abo
 
   - If recipient exists: `CALL_VALUE_COST = 2 * STATE_UPDATE + TRANSFER_LOG_COST = 3,756`.
   - If recipient is EIP-161-empty: `CALL_VALUE_COST = STATE_UPDATE + GAS_NEW_ACCOUNT + TRANSFER_LOG_COST = 27,756`.
+  - When `caller == to`, omit `TRANSFER_LOG_COST` because [EIP-7708](./eip-7708.md) does not emit a transfer log for self-transfers.
   - This charge is in addition to warm/cold account-touch costs per EIP-2929 and the existing `CALL` base cost. This EIP does not modify the `CALL` base cost.
-  - `TRANSFER_LOG_COST` covers the [EIP-7708](./eip-7708.md) transfer log emitted for every nonzero-value transfer.
+  - `TRANSFER_LOG_COST` covers the [EIP-7708](./eip-7708.md) transfer log emitted for every nonzero-value transfer to a different account.
 
   The `CALL_VALUE_COST` applies for all value-carrying calls, regardless of whether the callee's account has already been updated earlier in the same transaction. This ensures the 2300-gas stipend mechanism remains safe and consistent for simple value forwarding and does not retroactively depend on account-update history.
 


### PR DESCRIPTION
Refinements to EIP-2780's account-access and value-transfer accounting. All changes are confined to `EIPS/eip-2780.md`. They fall into four groups.

### 1. Precompile target normalization
A precompile `tx.to` is now metered like any other account — all precompile carve-outs were removed:
- Dropped the `to` "warm at tx start, charged zero" rule.
- Removed the new-account-surcharge precompile exclusion and the `is_precompile` check from the intrinsic-gas pseudocode.
- Removed the precompile mention from the warmth policy.
- Deleted the precompile-specific test vectors.

A value-bearing transaction to a precompile now follows the standard `tx.to` rules.

### 2. Transaction-level accounts always charged cold
`tx.sender`, `tx.to`, and any [EIP-7702](./eip-7702.md) delegation target are now **always** charged at the cold rate; access-list membership no longer warms them or reduces their per-account cost.
- Removed `WARM_STATE_READ = 100` from the gas table and the warm delegation-target reduction.
- Removed the "warmth discovered through an access list overrides the cold cost" rule; added an explicit summary that there is no warm rate for these three accounts.
- Updated the warmth policy and the EIP-2930 / EIP-7702 interaction notes to state access lists only warm *other* execution-level account touches.
- Updated the access-list test vector accordingly.

The general EIP-2929 cold/warm model still applies to other accounts touched during execution and to internal `CALL`s.

### 3. Self-transfer / self-`CALL` is a true no-op
A self-transfer (`from == to`) or self-`CALL` with value no longer requires any extra write:
- Self-`CALL` with value: `CALL_VALUE_COST = 0` (previously `STATE_UPDATE = 1,000`) — balance is unchanged, no leaf write, and EIP-7708 emits no transfer log.
- Self-transfer balance is unchanged; no recipient leaf write or transfer log is charged. The nonce/balance update coalesces into the single account-leaf write already in `TX_BASE_COST`.
- Added/updated test vectors for the self-transfer and internal self-`CALL` cases.

### 4. `CALL_VALUE_COST` / `STATE_UPDATE` clarifications
- Value-moving calls repriced as a single new account-leaf write on the `to` account (the caller's leaf already updates via the fee): `CALL_VALUE_COST = STATE_UPDATE + TRANSFER_LOG_COST`.
- Clarified that `STATE_UPDATE` is charged once when an account's nonce **or** balance changes in a transition.

---

Linters pass locally (`markdownlint-cli2` with repo config, `eipw` with `config/eipw.toml`).
