### PR TITLE
Update EIP-8146: Update BAL sidecare spec, align with ePBS

### DIFF
--- a/EIPS/eip-8146.md
+++ b/EIPS/eip-8146.md
@@ -324,11 +324,11 @@ When constructing a bid, the builder:
 3. After the beacon block is published, broadcasts the `BlockAccessListSidecar` on the `block_access_list_sidecar` gossip topic.
 4. Broadcasts the `SignedExecutionPayloadEnvelope` (which no longer contains the BAL).
 
-Builders SHOULD broadcast the BAL sidecar as early as possible to enable prefetching by the next block's builder.
+Builders SHOULD broadcast the BAL sidecar as early as possible, well before the envelope, to give the network's ELs a prefetch window. See [BAL publication timing](#bal-publication-timing) for the safety argument and worst-case discussion.
 
 #### PTC Members
 
-PTC members set `block_access_list_present = True` in their `PayloadAttestationData` if they have received a valid `BlockAccessListSidecar` for the block (i.e., the sidecar passes gossip validation including the `hash_tree_root` commitment check).
+PTC members set `block_access_list_present = True` in their `PayloadAttestationData` only if a valid `BlockAccessListSidecar` for the block was received locally at least 1 second before the payload attestation deadline. The sidecar must pass gossip validation including the `keccak256` commitment check.
 
 PTC members set `payload_present` and `blob_data_available` per [EIP-7732](./eip-7732.md) rules, independently of `block_access_list_present`.
 
@@ -349,6 +349,14 @@ BAL availability is tracked as a dedicated `block_access_list_present` boolean i
 ### PTC Deadline Independence
 
 [EIP-7732](./eip-7732.md) applies a variable PTC deadline to the execution payload based on payload size. Since the BAL travels as an independent sidecar, and its size scales inversely with the payload size, this variable deadline does not apply to it.
+
+### BAL publication timing
+
+In ePBS, builders generally delay publishing the execution payload envelope until close to the attestation deadline. Releasing the payload too early exposes its transactions to same-slot unbundling: a malicious proposer could see the payload contents and replace them with a competing block that extracts the same MEV.
+
+The BAL is not exposed to this risk. It carries post-state values and access lists but contains no independently-signed items: the transactions are not in the BAL, the sidecar itself has no signature, and the keccak commitment inside the signed bid binds the BAL to the builder so it cannot equivocate between BALs. A proposer who sees the BAL early learns coarse activity (which pools were touched, which balances moved) but cannot lift transactions into a competing block.
+
+To guarantee a minimum prefetch window for the worst case (BAL arriving with or after the envelope), PTC members vote `block_access_list_present = True` only if the sidecar was received at least 1 second before the payload attestation deadline. This 1-second gap is the protocol-enforced lower bound on the prefetch window the EL gets before execution begins. Builders SHOULD publish well before this deadline; they have no economic reason to delay.
 
 ### Dedicated Engine API Method
 

--- a/EIPS/eip-8146.md
+++ b/EIPS/eip-8146.md
@@ -272,11 +272,42 @@ def on_execution_payload_envelope(
 
 ### Engine API
 
-`engine_getPayloadV6` returns the BAL as a separate `blockAccessList` field (RLP-encoded bytes) outside the `ExecutionPayload`. The builder computes `block_access_list_hash = keccak256(blockAccessList)` for inclusion in the bid. This is the same value the EL writes into the EL header per [EIP-7928](./eip-7928.md), so no additional hashing is required.
+EIP-8146 splits BAL delivery and payload delivery into two engine calls so the EL can start work on the BAL while the payload envelope is still in flight. The CL forwards the BAL the instant the sidecar passes gossip validation, without waiting for the envelope. This is the operational core of the EIP.
 
-`engine_notifyBlockAccessListV1` is a new method that delivers the BAL to the EL independently of the execution payload. It accepts `blockAccessList` (RLP-encoded bytes) and `blockHash` (to associate the BAL with the corresponding payload). The EL stores the BAL and begins prefetching the referenced state. The CL calls this method when the BAL sidecar is received (in `on_block_access_list_sidecar`).
+#### `engine_getPayloadV6`
 
-`engine_newPayloadV5` is unchanged from [EIP-7732](./eip-7732.md). It does not include the BAL. The EL uses the BAL previously delivered via `engine_notifyBlockAccessListV1`, matching by `blockHash`.
+Returns the BAL as a separate `blockAccessList` field (RLP-encoded bytes) alongside the `ExecutionPayload`. The builder computes `block_access_list_hash = keccak256(blockAccessList)` for inclusion in the bid; this is the same value the EL writes into the EL header per [EIP-7928](./eip-7928.md), so no additional hashing is required.
+
+#### New `engine_notifyBlockAccessListV1`
+
+Delivers the BAL to the EL independently of the execution payload.
+
+Parameters:
+
+- `blockAccessList`: RLP-encoded BAL bytes.
+- `blockHash`: ties the BAL to a specific payload.
+
+On receipt the EL:
+
+1. Stores the BAL keyed by `blockHash`.
+2. Begins **prefetching** the accounts and storage slots the BAL declares will be touched, warming the state cache.
+3. MAY begin **parallel post-state root computation** using the BAL's post-values.
+
+The CL MUST call this method from `on_block_access_list_sidecar` immediately after the keccak check against `bid.block_access_list_hash` passes. The CL MUST NOT wait for the payload envelope.
+
+#### `engine_newPayloadV5`
+
+Unchanged from [EIP-7732](./eip-7732.md). It does not carry the BAL. The EL pairs the incoming payload with the previously delivered BAL by `blockHash` and runs execution against the warmed state. If the BAL has not yet arrived (out-of-order receipt), the EL MAY queue the payload until `engine_notifyBlockAccessListV1` is called for the same `blockHash`.
+
+#### Best-case sequencing
+
+```
+t0:  CL --engine_notifyBlockAccessListV1--> EL    (BAL arrives; EL prefetches state, MAY precompute post-state root)
+t1:  CL --engine_newPayloadV5-------------> EL    (envelope arrives; EL executes against warm cache)
+t2:  CL <----------- {status: VALID} ------ EL
+```
+
+The `t1 - t0` gap is the head start the EIP creates. With the BAL inside the envelope (pre-EIP-8146), `t0 = t1` and the head start is zero.
 
 ### Execution Layer
 

--- a/EIPS/eip-8146.md
+++ b/EIPS/eip-8146.md
@@ -13,7 +13,7 @@ requires: 7732, 7928
 
 ## Abstract
 
-This EIP removes the block access list (BAL) from the `ExecutionPayloadEnvelope` and propagates it as an independent sidecar on a dedicated gossip topic. Builders commit to the BAL root in their `ExecutionPayloadBid`. Sidecar verification uses this commitment; no separate signature is required. The Payload Timeliness Committee (PTC) enforces BAL availability at the attestation deadline.
+This EIP removes the block access list (BAL) from the `ExecutionPayloadEnvelope` and propagates it as an independent sidecar on a dedicated gossip topic. Builders commit to the BAL exactly once, by including `keccak256(rlp(BAL))` (the same 32-byte value already defined as `block_access_list_hash` in the EL block header by [EIP-7928](./eip-7928.md)) in their `ExecutionPayloadBid`. Sidecar verification uses this commitment; the consensus layer treats the BAL as opaque bytes and never needs to RLP-decode it. No separate sidecar signature is required. The Payload Timeliness Committee (PTC) enforces BAL availability at the attestation deadline.
 
 ## Motivation
 
@@ -65,13 +65,13 @@ class ExecutionPayload(Container):
     withdrawals: List[Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD]
     blob_gas_used: uint64
     excess_blob_gas: uint64
-    # [Removed in EIP-8143]
+    # [Removed in EIP-8146]
     # block_access_list: BlockAccessList
 ```
 
 ##### `ExecutionPayloadBid`
 
-A `block_access_list_root` field is added:
+A `block_access_list_hash` field is added. Its value is identical to the EL header field of the same name defined by [EIP-7928](./eip-7928.md), i.e. `keccak256(rlp(BlockAccessList))`. Using the EL's canonical commitment avoids introducing a second hashing scheme on the CL side.
 
 ```python
 class ExecutionPayloadBid(Container):
@@ -86,8 +86,8 @@ class ExecutionPayloadBid(Container):
     value: Gwei
     execution_payment: Gwei
     blob_kzg_commitments: List[KZGCommitment, MAX_BLOB_COMMITMENTS_PER_BLOCK]
-    # [New in EIP-8143]
-    block_access_list_root: Root
+    # [New in EIP-8146]
+    block_access_list_hash: Bytes32
 ```
 
 ##### `PayloadAttestationData`
@@ -100,7 +100,7 @@ class PayloadAttestationData(Container):
     slot: Slot
     payload_present: boolean
     blob_data_available: boolean
-    # [New in EIP-8143]
+    # [New in EIP-8146]
     block_access_list_present: boolean
 ```
 
@@ -133,7 +133,7 @@ Let `block` be the beacon block with root `sidecar.beacon_block_root`. Let `bid`
 
 - _[REJECT]_ `block` passes validation.
 - _[REJECT]_ `sidecar.slot == block.slot`.
-- _[REJECT]_ `hash_tree_root(sidecar.block_access_list) == bid.block_access_list_root`.
+- _[REJECT]_ `keccak256(sidecar.block_access_list) == bid.block_access_list_hash`. The CL treats `sidecar.block_access_list` as opaque bytes; no RLP decoding is performed.
 
 #### Req/Resp
 
@@ -184,10 +184,12 @@ Returns sidecars matching the requested beacon block roots.
 @dataclass
 class Store(object):
     # ... existing fields ...
-    # [New in EIP-8143]
+    # [New in EIP-8146]
     block_access_lists: Dict[Root, BlockAccessList] = field(default_factory=dict)
-    # [New in EIP-8143]
-    ptc_block_access_list_vote: Dict[Root, Vector[boolean, PTC_SIZE]] = field(default_factory=dict)
+    # [New in EIP-8146]
+    block_access_list_availability_vote: Dict[Root, list[Optional[boolean]]] = field(
+        default_factory=dict
+    )
 ```
 
 #### Modified `on_block`
@@ -195,8 +197,8 @@ class Store(object):
 When a new block is added to the store, initialize the BAL PTC vote tracker (alongside the existing `ptc_vote` initialization):
 
 ```python
-# [New in EIP-8143] Add a new PTC BAL voting for this block to the store
-store.ptc_block_access_list_vote[block_root] = [False] * PTC_SIZE
+# [New in EIP-8146] Add a new PTC BAL voting for this block to the store
+store.block_access_list_availability_vote[block_root] = [None] * PTC_SIZE
 ```
 
 #### Modified `on_payload_attestation_message`
@@ -209,9 +211,10 @@ def on_payload_attestation_message(
 ) -> None:
     # ... existing validation and payload_present recording ...
 
-    # [New in EIP-8143] Update the BAL vote for the block
-    ptc_block_access_list_vote = store.ptc_block_access_list_vote[data.beacon_block_root]
-    ptc_block_access_list_vote[ptc_index] = data.block_access_list_present
+    # [New in EIP-8146] Update the BAL vote for the block
+    store.block_access_list_availability_vote[data.beacon_block_root][ptc_index] = (
+        data.block_access_list_present
+    )
 ```
 
 #### Modified `notify_ptc_messages`
@@ -229,9 +232,9 @@ def on_block_access_list_sidecar(store: Store, sidecar: BlockAccessListSidecar) 
     # Verify slot consistency
     assert sidecar.slot == block.slot
 
-    # Verify BAL matches commitment in bid
+    # Verify BAL matches commitment in bid (CL operates on opaque bytes; no RLP)
     bid = block.body.signed_execution_payload_bid.message
-    assert hash_tree_root(sidecar.block_access_list) == bid.block_access_list_root
+    assert keccak256(sidecar.block_access_list) == bid.block_access_list_hash
 
     # Store BAL
     store.block_access_lists[sidecar.beacon_block_root] = sidecar.block_access_list
@@ -240,12 +243,14 @@ def on_block_access_list_sidecar(store: Store, sidecar: BlockAccessListSidecar) 
     EXECUTION_ENGINE.notify_block_access_list(sidecar.block_access_list, bid.block_hash)
 ```
 
-#### Modified `on_execution_payload`
+#### Modified `on_execution_payload_envelope`
 
-BAL availability is required before processing the execution payload. The BAL has already been delivered to the EL via `engine_notifyBlockAccessListV1` when the sidecar was received; `process_execution_payload` itself is unchanged.
+BAL availability is required before processing the execution payload. The BAL has already been delivered to the EL via `engine_notifyBlockAccessListV1` when the sidecar was received; `verify_execution_payload_envelope` itself is unchanged.
 
 ```python
-def on_execution_payload(store: Store, signed_envelope: SignedExecutionPayloadEnvelope) -> None:
+def on_execution_payload_envelope(
+    store: Store, signed_envelope: SignedExecutionPayloadEnvelope
+) -> None:
     envelope = signed_envelope.message
     # The corresponding beacon block root needs to be known
     assert envelope.beacon_block_root in store.block_states
@@ -253,19 +258,21 @@ def on_execution_payload(store: Store, signed_envelope: SignedExecutionPayloadEn
     # Check if blob data is available
     assert is_data_available(envelope.beacon_block_root)
 
-    # Make a copy of the state to avoid mutability issues
-    state = copy(store.block_states[envelope.beacon_block_root])
+    # [New in EIP-8146] Check if the BAL has been received locally
+    assert envelope.beacon_block_root in store.block_access_lists
 
-    # Process the execution payload (unchanged)
-    process_execution_payload(state, signed_envelope, EXECUTION_ENGINE)
+    state = store.block_states[envelope.beacon_block_root]
 
-    # Add new state for this payload to the store
-    store.execution_payload_states[envelope.beacon_block_root] = state
+    # Verify the execution payload envelope (unchanged)
+    verify_execution_payload_envelope(state, signed_envelope, EXECUTION_ENGINE)
+
+    # Add execution payload envelope to the store
+    store.payloads[envelope.beacon_block_root] = envelope
 ```
 
 ### Engine API
 
-`engine_getPayloadV6` returns the BAL as a separate `blockAccessList` field (RLP-encoded bytes) outside the `ExecutionPayload`. The builder computes `block_access_list_root = hash_tree_root(ByteList(blockAccessList))` for inclusion in the bid.
+`engine_getPayloadV6` returns the BAL as a separate `blockAccessList` field (RLP-encoded bytes) outside the `ExecutionPayload`. The builder computes `block_access_list_hash = keccak256(blockAccessList)` for inclusion in the bid. This is the same value the EL writes into the EL header per [EIP-7928](./eip-7928.md), so no additional hashing is required.
 
 `engine_notifyBlockAccessListV1` is a new method that delivers the BAL to the EL independently of the execution payload. It accepts `blockAccessList` (RLP-encoded bytes) and `blockHash` (to associate the BAL with the corresponding payload). The EL stores the BAL and begins prefetching the referenced state. The CL calls this method when the BAL sidecar is received (in `on_block_access_list_sidecar`).
 
@@ -282,7 +289,7 @@ The execution block header field `block_access_list_hash` (keccak256 of RLP-enco
 When constructing a bid, the builder:
 
 1. Obtains the BAL from `engine_getPayloadV6`.
-2. Computes `block_access_list_root = hash_tree_root(ByteList(blockAccessList))` and includes it in the `ExecutionPayloadBid`.
+2. Computes `block_access_list_hash = keccak256(blockAccessList)` and includes it in the `ExecutionPayloadBid`.
 3. After the beacon block is published, broadcasts the `BlockAccessListSidecar` on the `block_access_list_sidecar` gossip topic.
 4. Broadcasts the `SignedExecutionPayloadEnvelope` (which no longer contains the BAL).
 
@@ -296,13 +303,17 @@ PTC members set `payload_present` and `blob_data_available` per [EIP-7732](./eip
 
 ## Rationale
 
+### Single Commitment, Shared Across Layers
+
+[EIP-7928](./eip-7928.md) already commits the BAL into the EL header as `block_access_list_hash = keccak256(rlp(BAL))`. Carrying the same 32 bytes in the bid gives the CL everything it needs to authenticate a sidecar without introducing a second hashing scheme. The CL holds the BAL only as opaque bytes; RLP decoding remains an EL concern. A builder cannot equivocate: `bid.block_hash` transitively commits to the EL header, so if `bid.block_access_list_hash` disagrees with the revealed payload, either `payload.block_hash != bid.block_hash` (envelope rejected) or the EL recomputes a BAL that does not match its own header (payload rejected per EIP-7928).
+
 ### No Separate Signature
 
-The BAL sidecar requires no BLS signature. The builder commits to `block_access_list_root` in the signed `ExecutionPayloadBid`; verification is `hash_tree_root(sidecar.block_access_list) == bid.block_access_list_root`. This mirrors `DataColumnSidecar` verification via KZG proofs against commitments in the bid.
+The BAL sidecar requires no BLS signature. The builder commits to `block_access_list_hash` in the signed `ExecutionPayloadBid`; sidecar verification is `keccak256(sidecar.block_access_list) == bid.block_access_list_hash`. This mirrors `DataColumnSidecar` verification via KZG commitments in the bid.
 
 ### Separate PTC Field
 
-BAL availability is tracked as a dedicated `block_access_list_present` boolean in `PayloadAttestationData`, following the same pattern as `blob_data_available`. This keeps concerns separated: `payload_present` signals envelope timeliness, `blob_data_available` signals blob availability, and `block_access_list_present` signals BAL availability. The fork choice `on_execution_payload` handler independently gates on local BAL availability (`assert root in store.block_access_lists`), ensuring execution validation cannot proceed without the BAL regardless of PTC votes.
+BAL availability is tracked as a dedicated `block_access_list_present` boolean in `PayloadAttestationData`, following the same pattern as `blob_data_available`. This keeps concerns separated: `payload_present` signals envelope timeliness, `blob_data_available` signals blob availability, and `block_access_list_present` signals BAL availability. The fork choice `on_execution_payload_envelope` handler independently gates on local BAL availability (`assert root in store.block_access_lists`), ensuring execution validation cannot proceed without the BAL regardless of PTC votes.
 
 ### PTC Deadline Independence
 
@@ -322,11 +333,11 @@ This EIP requires a hard fork. It modifies the `ExecutionPayload` and `Execution
 
 ## Security Considerations
 
-**Withholding**: A builder can withhold the BAL sidecar. PTC members will vote `block_access_list_present = False`, providing network-wide visibility. The fork choice `on_execution_payload` handler gates on local BAL availability, so the payload cannot be validated without the BAL. The builder withhold safety properties from [EIP-7732](./eip-7732.md) apply: if the beacon block was not timely, the builder is not charged.
+**Withholding**: A builder can withhold the BAL sidecar. PTC members will vote `block_access_list_present = False`, providing network-wide visibility. The fork choice `on_execution_payload_envelope` handler gates on local BAL availability, so the payload cannot be validated without the BAL. The builder withhold safety properties from [EIP-7732](./eip-7732.md) apply: if the beacon block was not timely, the builder is not charged.
 
 **Network overhead**: The BAL sidecar adds ~70 KiB average per slot to gossip traffic, equal to the current overhead when BAL is inside the envelope. Total network load is unchanged; it is redistributed across topics.
 
-**Verification cost**: Sidecar verification requires one `hash_tree_root` computation on up to 1 MiB. This is negligible compared to execution validation.
+**Verification cost**: Sidecar verification requires one `keccak256` computation on up to `MAX_BLOCK_ACCESS_LIST_SIZE` bytes. This is negligible compared to execution validation. CL implementations gain a `keccak256` dependency, satisfied by well-tested off-the-shelf libraries.
 
 ## Copyright
 


### PR DESCRIPTION
this updates the wrong eip number referred to in the eip, replaces the mpt root with the BAL hash (CL needs to do a keccak), integrate bal sidecar into ptc, 1s earlier bal deadline.