### PR TITLE
Update EIP-8131: Rewrite EIP-8131 as Unified Transaction Content Floor

### DIFF
--- a/EIPS/eip-8131.md
+++ b/EIPS/eip-8131.md
@@ -1,186 +1,181 @@
 ---
 eip: 8131
-title: Add Auth Data to EIP-7623 Floor
-description: Add EIP-7702 authorization data to the EIP-7623 floor calculation
+title: Unified Transaction Content Floor
+description: Flat 64 gas per content byte at the floor, covering calldata, access-list entries, authorizations, and blob versioned hashes.
 author: Toni Wahrstätter (@nerolation)
 discussions-to: https://ethereum-magicians.org/t/eip-9999-add-auth-data-to-eip-7623-floor/12345
 status: Draft
 type: Standards Track
 category: Core
 created: 2025-01-21
-requires: 7623, 7702, 7976
+requires: 2028, 4844, 7623, 7702, 7976, 7981
 ---
 
 ## Abstract
 
-This EIP includes [EIP-7702](./eip-7702.md) authorization data in the [EIP-7623](./eip-7623.md) floor calculation, preventing circumvention of floor pricing through authorization lists. This effectively reduces the worst-case block size by ~16% with minimal user impact (~0.001% of mainnet transactions affected).
+Charge every user-controlled byte in a transaction (calldata, access-list entries, [EIP-7702](./eip-7702.md) auths, [EIP-4844](./eip-4844.md) blob hashes) at a flat 64 gas at the floor. One rule replaces [EIP-7623](./eip-7623.md)/[EIP-7976](./eip-7976.md) and [EIP-7981](./eip-7981.md) and closes the auth and blob hash floor gaps. Worst-case user-controlled tx content per block is bounded by `block_gas_limit / 64 ≈ 0.89 MB`. Fewer than 4% of mainnet transactions hit the new floor.
 
 ## Motivation
 
-[EIP-7702](./eip-7702.md) authorization tuples are priced for execution (`PER_EMPTY_ACCOUNT_COST = 25,000` gas per authorization) but do not contribute to the [EIP-7623](./eip-7623.md) floor calculation.
+[EIP-7623](./eip-7623.md) introduced a floor cost on calldata bytes to cap worst-case block size. [EIP-7976](./eip-7976.md) raised that floor to a uniform 64 gas per calldata byte, zero and non-zero alike (by treating every byte as 4 floor tokens at 16 gas each). [EIP-7981](./eip-7981.md) extended the same 64 gas/B rate to access-list bytes via a flat data-cost surcharge of 1,280 gas per address and 2,048 gas per storage key. The principle is consistent across both: every user-controlled content byte priced at 64 gas at the floor.
 
-Under [EIP-7976](./eip-7976.md) floor pricing, this enables circumventing the floor by combining all-non-zero calldata with authorization data at a 25%/75% (calldata/auths) gas split.
+[EIP-7702](./eip-7702.md) authorization tuples (up to 108 B each) and [EIP-4844](./eip-4844.md) blob versioned hashes (32 B each) were added without matching floor terms and still pay nothing at the floor.
+
+| Field | Floor rate | Source |
+|---|---|---|
+| Calldata byte (zero or non-zero) | 64 gas | EIP-7976 |
+| Access-list address (20 B) | 1,280 gas | EIP-7981 |
+| Access-list storage key (32 B) | 2,048 gas | EIP-7981 |
+| EIP-7702 authorization tuple (up to 108 B) | 0 | uncovered |
+| EIP-4844 blob versioned hash (32 B) | 0 | uncovered |
+
+Each per-component extension has needed its own EIP and its own constants. This EIP folds EIP-7976 and EIP-7981 into a single per-byte rule covering every user-controlled tx-content field, and pulls authorization tuples and blob versioned hashes into the same rule. The result is one formula that auto-prices any future variable-length tx field at the same rate, and a worst-case content bound provable from arithmetic.
 
 ## Specification
 
-| Parameter | Value | Source |
-|-----------|-------|--------|
-| `TOTAL_COST_FLOOR_PER_TOKEN` | `16` | [EIP-7976](./eip-7976.md) |
-| `FLOOR_COST_PER_AUTH` | `6464` | 101 bytes × 4 tokens × 16 gas |
-| `PER_EMPTY_ACCOUNT_COST` | `25000` | [EIP-7702](./eip-7702.md) |
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
 
-The [EIP-7623](./eip-7623.md) floor calculation is modified to include authorization data:
+### Constants
 
-```python
-tokens_in_calldata = zero_bytes_in_calldata + nonzero_bytes_in_calldata * 4
+```
+TX_BASE                        = 21000
+FLOOR_GAS_PER_BYTE             = 64    # per-byte floor rate established by EIP-7976 (calldata) and EIP-7981 (access lists)
+ACCESS_LIST_ADDRESS_BYTES      = 20
+ACCESS_LIST_STORAGE_KEY_BYTES  = 32
+AUTH_TUPLE_BYTES               = 108   # EIP-7702 authorization tuple worst-case RLP
+BLOB_VERSIONED_HASH_BYTES      = 32
+```
 
-floor_gas = (
-    TX_BASE_COST
-    + TOTAL_COST_FLOOR_PER_TOKEN * tokens_in_calldata
-    + FLOOR_COST_PER_AUTH * num_authorizations
+### Transaction floor
+
+```
+tx_floor = TX_BASE + FLOOR_GAS_PER_BYTE * (
+      len(tx.data)
+    + ACCESS_LIST_ADDRESS_BYTES      * num_access_list_addresses
+    + ACCESS_LIST_STORAGE_KEY_BYTES  * num_access_list_storage_keys
+    + AUTH_TUPLE_BYTES               * num_authorizations
+    + BLOB_VERSIONED_HASH_BYTES      * num_blob_versioned_hashes
 )
 ```
 
-The gas used calculation becomes:
+A field absent from a given transaction type contributes zero (the corresponding count is zero).
 
-```python
-tx.gasUsed = (
-    21000
-    +
-    max(
-        STANDARD_TOKEN_COST * tokens_in_calldata
-        + execution_gas_used
-        + isContractCreation * (32000 + INITCODE_WORD_COST * words(calldata))
-        + access_list_cost
-        + PER_EMPTY_ACCOUNT_COST * num_authorizations,
-        TOTAL_COST_FLOOR_PER_TOKEN * tokens_in_calldata
-        + FLOOR_COST_PER_AUTH * num_authorizations
-    )
-)
+### Charging
+
+```
+require tx.gas >= max(intrinsic, tx_floor)
+tx.gasUsed   =   max(execution_gas_used, tx_floor)
 ```
 
-A transaction is invalid if its `gas_limit` is less than `tx.gasUsed` evaluated with `execution_gas_used = 0`.
+Intrinsic gas is unchanged. The `max(intrinsic, floor)` shape of [EIP-7623](./eip-7623.md) is preserved.
 
 ## Rationale
 
-### Flat Cost Per Authorization
+### One per-byte rate
 
-Each authorization is charged a flat `FLOOR_COST_PER_AUTH = 6464` gas toward the floor, derived from:
+Pricing every content byte at the same `FLOOR_GAS_PER_BYTE` already used by [EIP-7976](./eip-7976.md) for calldata and by [EIP-7981](./eip-7981.md) for access-list bytes makes the worst case invariant to the attacker's choice of field or byte value: calldata, access-list entries, authorization tuples, and blob versioned hashes all yield `1/64` bytes per gas at the floor. The optimum collapses to `B = block_gas_limit / 64`. The bound holds independent of the network compressor, attacker strategy, or content composition.
 
-- 101 bytes per authorization tuple (as specified in [EIP-7702](./eip-7702.md))
-- 4 tokens per byte (treating all bytes as non-zero)
-- 16 gas per token (`TOTAL_COST_FLOOR_PER_TOKEN`)
+### Content-only, not full RLP
 
-This conservative approach avoids byte-level zero/non-zero accounting while ensuring authorization data is properly reflected in the floor calculation.
+Charging every encoded byte (envelope and signature included) would make legacy transactions strictly cheaper than equivalent [EIP-1559](./eip-1559.md) transactions for the same payload, because legacy has a smaller envelope. Content-only is type-symmetric: two transactions with identical content pay identical floor regardless of tx type.
 
-### Worst-Case Reduction
+### `TX_BASE` covers envelope
 
-At the floor under EIP-7976 every byte costs 64 gas regardless of value, so the optimal attacker uses all-non-zero calldata (incompressible under snappy) at the standard rate of 16 gas/byte and spends the remainder on auths. The break-even split is `(64 − 16) / 64 = 75%` on auths and `25%` on calldata. At a 60M gas limit:
+Envelope, signature, and type prefix total at most ~130 bytes for every transaction type defined to date. At `FLOOR_GAS_PER_BYTE` that is ~8,300 gas, well below `TX_BASE = 21,000`. Charging envelope explicitly would add ~5,000 gas to every bare ETH transfer; treating `TX_BASE` as covering it implicitly avoids the regression.
 
-```python
-# pre-EIP-8131 worst case (auth bypass, all-non-zero cd):
-(0.75 * 60_000_000 * 101 / 25_000 + 0.25 * 60_000_000 / 16) / 1024**2  ≈  1.067 MB
+### Standard intrinsic unchanged
 
-# post-EIP-8131 worst case (pure floor, all-non-zero cd):
-60_000_000 / 64 / 1024**2                                              ≈  0.894 MB
+The standard intrinsic per-byte rate ([EIP-2028](./eip-2028.md): 4 gas per zero, 16 gas per non-zero) is preserved. It prices EVM and state work per byte and is unrelated to the bandwidth-bound floor. Raising it would increase intrinsic cost for every transaction with non-zero data without improving the bandwidth-defense properties this EIP targets.
 
-# reduction: 1 − 0.894 / 1.067 ≈ 16%
-```
+### Per-auth term is a constant
 
-Empirical analysis over the last 6 months (2025-11-08 to 2026-05-08) ([impact report](../assets/eip-8131/impact_report.md)) shows that only 0.124% of type-4 transactions (0.001% of all mainnet) and 0.330% of type-4 senders would be affected by this EIP.
-
-### Floor-Only Modification
-
-Authorization costs are added to the floor calculation only, not to intrinsic gas. This differs from [EIP-7981](./eip-7981.md) (access lists) because:
-
-- Authorization execution cost (25,000 gas) far exceeds floor contribution (6,464 gas per auth)
-- Floor-only modification is sufficient to prevent bypass
-
-With this change:
-
-- Authorization data contributes to the floor path
-- High-execution transactions remain unaffected (execution exceeds floor)
-- Data-heavy transactions cannot use authorizations to bypass floor pricing
+`AUTH_TUPLE_BYTES = 108` is the maximum RLP size of an [EIP-7702](./eip-7702.md) authorization tuple (2 B list header + 9 B chain_id + 21 B address + 9 B nonce + 1 B y_parity + 33 B r + 33 B s). Using a constant rather than `len(rlp_encode(auth))` keeps the floor computable from counts alone; typical mainnet auths (chain_id 1, small nonce) over-pay by ~1,024 gas.
 
 ## Backwards Compatibility
 
-This is a backwards incompatible gas repricing that requires a scheduled network upgrade.
+Hard fork.
 
-Requires updates to gas estimation in wallets and nodes. Normal usage patterns remain largely unaffected since authorization execution cost typically dominates the floor contribution.
+Floor impact vs current mainnet baseline (EIP-7623 calldata floor, no floor term for access-list bytes, authorization tuples, or blob versioned hashes; mainnet sample 1,500 random blocks, 441,271 transactions, May 2026):
+
+| Type | Share | Avg content (B) | Floor today | Floor under EIP-8131 | Bind rate today | Bind rate under EIP-8131 |
+|---|---:|---:|---:|---:|---:|---:|
+| 0 Legacy | 10.66% | 164 | 26.3 k | 31.5 k | 0.85% | 1.32% |
+| 1 [EIP-2930](./eip-2930.md) | 0.09% | 486 | 33.9 k | 52.1 k | 0.00% | 0.00% |
+| 2 EIP-1559 | 87.51% | 421 | 34.9 k | 47.9 k | 1.30% | 2.98% |
+| 3 EIP-4844 | 0.44% | 992 | 69 k | 84 k | 60.05% | 60.05% |
+| 4 EIP-7702 | 1.29% | 8,768 | 240 k | 587 k | 0.04% | 20.63% |
+
+The "bind rate" is the share of transactions whose `tx_floor` exceeds intrinsic plus execution gas, i.e. transactions whose `tx.gasUsed` is set by the floor rather than by execution. Aggregate bind rate rises from 1.49% to 3.28%, and total network gas rises by 3.56%.
+
+The repricing concentrates exactly where this EIP intends:
+
+- **Type 4 (SetCode)**: bind rate jumps from 0.04% to 20.63% because authorization tuples (108 B × 64 gas = 6,912 gas per auth) are uncovered today and newly priced. Average type-4 floor rises from 240 k to 587 k.
+- **Type 3 (blob carriers, calldata-light)**: already 60% bind rate under today's floor, since blob-carrier transactions execute well below 7976-style calldata cost. This EIP raises the average floor from 69 k to 84 k as the 32-byte blob versioned hashes get priced.
+- **Legacy, [EIP-2930](./eip-2930.md), [EIP-1559](./eip-1559.md)** (98.3% of traffic): bind rate moves at most ~1.7 pp, driven by access-list bytes moving into the floor and by [EIP-7623](./eip-7623.md) zero-byte calldata catching up to the [EIP-7976](./eip-7976.md) / EIP-8131 rate.
+
+When does the floor bite? For calldata-only transactions:
+
+```
+tx_floor > gas_used  ⇔  calldata_bytes  >  (gas_used − TX_BASE) / FLOOR_GAS_PER_BYTE
+```
+
+A typical token transfer (68 B calldata, ~50 k gas) has `tx_floor = 25,352`, well under `gas_used`. A 50 k-gas tx needs more than 453 B of calldata before the floor bites.
+
+Wallets and `eth_estimateGas` MUST compute the new floor.
 
 ## Test Cases
 
-### Case 1: Transaction with Authorizations Only
+### Bare ETH transfer
 
-- Calldata: 0 bytes
-- Authorizations: 10
+`tx.to = recipient`, `tx.value = 1 ether`, `tx.data = b""`, no access list, no authorizations, no blob hashes.
 
-Old floor: 21,000 gas
-New floor: 21,000 + 10 × 6,464 = 85,640 gas
-Intrinsic: 21,000 + 10 × 25,000 = 271,000 gas
-Result: Pay intrinsic (271,000) — execution dominates, EIP-8131 has no effect
+- `tx_floor = TX_BASE = 21,000` gas. Unchanged.
 
-### Case 2: Bypass Attempt (Now Blocked)
+### Calldata-only transaction
 
-- Calldata: 100,000 non-zero bytes
-- Authorizations: 225
+10,000 calldata bytes, no other variable-length content.
 
-Old floor: 21,000 + 100,000 × 64                = 6,421,000 gas
-New floor: 21,000 + 100,000 × 64 + 225 × 6,464  = 7,875,400 gas
-Intrinsic: 21,000 + 100,000 × 16 + 225 × 25,000 = 7,246,000 gas
-Pre-EIP-8131:  max(7,246,000, 6,421,000) = 7,246,000 (intrinsic wins, floor bypassed)
-Post-EIP-8131: max(7,246,000, 7,875,400) = 7,875,400 (floor wins, bypass blocked)
+- `tx_floor = 21,000 + 64 × 10,000 = 661,000` gas. Identical across all transaction types carrying the same calldata.
 
-## Reference Implementation
+### Access-list entry: address with one storage key
 
-```python
-FLOOR_COST_PER_AUTH = 6464  # 101 bytes * 4 tokens/byte * 16 gas/token
+- `tx_floor = 21,000 + 64 × (20 + 32) = 24,328` gas.
 
+### EIP-7702 with one authorization
 
-def calculate_intrinsic_cost(tx: Transaction) -> Tuple[Uint, Uint]:
-    """
-    Calculate intrinsic gas cost and floor gas cost.
-    Returns (intrinsic_gas, floor_gas).
-    """
-    # Calldata tokens
-    calldata_zero = sum(1 for b in tx.data if b == 0)
-    tokens_in_calldata = Uint(calldata_zero + (len(tx.data) - calldata_zero) * 4)
+- `tx_floor = 21,000 + 64 × 108 = 27,912` gas.
 
-    # Authorization costs
-    num_authorizations = Uint(0)
-    auth_exec_cost = Uint(0)
-    if isinstance(tx, SetCodeTransaction):
-        num_authorizations = Uint(len(tx.authorizations))
-        auth_exec_cost = PER_EMPTY_ACCOUNT_COST * num_authorizations
+### EIP-4844 with six blob versioned hashes
 
-    # Floor: calldata + flat cost per authorization
-    floor_gas = (
-        TX_BASE_COST
-        + tokens_in_calldata * TOTAL_COST_FLOOR_PER_TOKEN
-        + num_authorizations * FLOOR_COST_PER_AUTH
-    )
-
-    # Intrinsic: calldata + create + access list + authorization execution cost
-    calldata_cost = tokens_in_calldata * STANDARD_TOKEN_COST
-    create_cost = TX_CREATE_COST + init_code_cost(tx.data) if is_create(tx) else 0
-    intrinsic_gas = (
-        TX_BASE_COST
-        + calldata_cost
-        + create_cost
-        + access_list_cost
-        + auth_exec_cost
-    )
-
-    return intrinsic_gas, floor_gas
-```
+- `tx_floor = 21,000 + 64 × (6 × 32) = 33,288` gas.
 
 ## Security Considerations
 
-This EIP closes a loophole that allows circumventing [EIP-7623](./eip-7623.md) floor pricing. Without this fix, adversaries can achieve larger blocks than intended by combining calldata with authorization data.
+### Block-size bound
 
-### Interaction with EIP-7981
+Every content byte the transaction contributes is paid at `FLOOR_GAS_PER_BYTE` via `tx_floor`. Implicit per-tx bytes (envelope, signature, type prefix) are covered by `TX_BASE`:
 
-If [EIP-7981](./eip-7981.md) is also adopted, both EIPs work together: access list tokens and authorization tokens are both included in the floor calculation. There are no conflicts.
+```
+content_bytes_per_tx * FLOOR_GAS_PER_BYTE  ≤  tx_floor  ≤  tx.gasUsed
+```
+
+Summing across user transactions:
+
+```
+sum(content_bytes) ≤ sum(tx.gasUsed) / 64 ≤ block_gas_limit / 64
+```
+
+At a 60M gas limit, the bound is `60,000,000 / 64 ≈ 0.89 MB` of attacker-controlled content per block. It is derived from arithmetic, requires no compression assumption, and survives a change of the network compressor.
+
+Envelope and signature contribute at most `~130 × (block_gas_limit / TX_BASE)` ≈ 372 KB at a 60M gas limit, well below `MAX_RLP_BLOCK_SIZE`.
+
+### Type symmetry
+
+Two transactions carrying identical content pay identical floor regardless of transaction type.
+
+### Gas estimation
+
+Wallets and `eth_estimateGas` MUST compute `tx_floor` alongside intrinsic gas. Without it, estimates for floor-bound transactions are too low and submissions will be rejected at validation.
 
 ## Copyright
 


### PR DESCRIPTION
Rewrite 8131 to prepare if for hegota:
* add blob versioned hashes too
* generalize it more as user-controlled bytes
* updating impact analysis