### PR TITLE
Update EIP-7928: Disallow empty change set for storage slot

### DIFF
--- a/EIPS/eip-7928.md
+++ b/EIPS/eip-7928.md
@@ -194,6 +194,7 @@ The following uniqueness constraints **MUST** hold:
 - Each storage key **MUST** appear at most once in `storage_reads` per account.
 - A storage key **MUST NOT** appear in both `storage_changes` and `storage_reads` for the same account.
 - Each `block_access_index` **MUST** appear at most once per change list (`balance_changes`, `nonce_changes`, `code_changes`, and per-slot `StorageChange` list).
+- Each `SlotChanges` entry **MUST** contain at least one `StorageChange`.
 
 ### BlockAccessIndex Assignment
 


### PR DESCRIPTION
Disallow storage slot with empty changes:

```json
"storage_changes": [
      {
        "slot": "0x02",
        "slot_changes": []          // empty inner list
      }
    ]
```
This is meaningless and can be potentially ambiguous.