### PR TITLE
Update EIP-8130: Add delegated account creation

### DIFF
--- a/EIPS/eip-8130.md
+++ b/EIPS/eip-8130.md
@@ -153,7 +153,7 @@ This proposal supports three paths for accounts to use AA transactions:
 |--------------|--------------|--------------|
 | **Existing Smart Contracts** | Already-deployed accounts (e.g., ERC-4337 wallets) register owners via the system contract (see [Smart Wallet Migration Path](#smart-wallet-migration-path)) | Wallet-defined |
 | **EOAs** | EOAs send AA transactions using their existing secp256k1 key via native ecrecover. If the account has no code, the protocol auto-delegates to `DEFAULT_ACCOUNT_ADDRESS` (see [Block Execution](#block-execution)). Accounts MAY override with a delegation entry in `account_changes` or a standard [EIP-7702](./eip-7702.md) transaction | Wallet-defined; EOA recoverable via 1559/7702 transaction flows |
-| **New Accounts (No EOA)** | Created via a create entry in `account_changes` with CREATE2 address derivation; runtime bytecode placed at address, owners + verifiers configured, `calls` handles initialization | Wallet-defined |
+| **New Accounts (No EOA)** | Created via a create entry in `account_changes`, either as a bytecode account (CREATE2 derivation, runtime bytecode placed at the address) or a delegated account ([EIP-7819](./eip-7819.md) derivation, `0xef0100 \|\| target` placed at the address); owners + verifiers configured, `calls` handles initialization | Wallet-defined |
 
 ### AA Transaction Type
 
@@ -216,7 +216,7 @@ The sender verifier runs first, and its metered cost is included in `gas_limit`.
 |-----------|-------|
 | `tx_payload_cost` | Standard per-byte cost over the entire RLP-serialized transaction: 16 gas per non-zero byte, 4 gas per zero byte, consistent with [EIP-2028](./eip-2028.md). Ensures all transaction fields (`account_changes`, `sender_auth`, `calls`, etc.) are charged for data availability |
 | `nonce_key_cost` | `NONCE_KEY_MAX`: 14,000 gas (replay protection state: 2 cold SLOADs + 1 warm SLOAD + 3 warm SSTORE resets). Otherwise: 22,100 gas for first use of a `nonce_key` (cold SLOAD + SSTORE set), 5,000 gas for existing keys (cold SLOAD + warm SSTORE reset) |
-| `bytecode_cost` | 0 if no create entry in `account_changes`. Otherwise: 32,000 (deployment base) + code deposit cost (200 gas per deployed byte). Byte costs for `code` are covered by `tx_payload_cost` |
+| `bytecode_cost` | 0 if no create entry in `account_changes`. For a bytecode account: 32,000 (deployment base) + code deposit cost (200 gas per deployed byte). For a delegated account: 25,000 (`EMPTY_ACCOUNT_COST` per [EIP-7819](./eip-7819.md), covering the 23-byte indicator). Byte costs for `code` are covered by `tx_payload_cost` |
 | `account_changes_cost` | Per applied config change entry: auth verification cost (same model as `sender_auth_cost`) + `num_operations` × 20,000 per SSTORE. Per applied delegation entry: code deposit cost (200 × 23 bytes for the delegation indicator). Per skipped config change entry (already applied): 2,100 (SLOAD to check sequence). 0 if no config change or delegation entries in `account_changes` |
 
 #### Signature Format
@@ -294,50 +294,61 @@ The `account_changes` field is an array of typed entries for account creation an
 
 | Type | Name | Description |
 |------|------|-------------|
-| `0x00` | Create | Deploy a new account with initial owners (must be first, at most one) |
+| `0x00` | Create | Deploy a new account (bytecode or delegated) with initial owners (must be first, at most one) |
 | `0x01` | Config change | Owner management: authorizeOwner, revokeOwner |
 | `0x02` | Delegation | Set code delegation via the delegation indicator (at most one per account) |
 
-Create and delegation entries are authorized by the transaction's `sender_auth` — there is no separate authorization field. The initial `ownerId`s for create entries are salt-committed to the derived address. Delegation requires the sender to be the account's implicit EOA owner with CONFIG scope. Config change entries carry their own `auth` and use a sequence counter for deterministic cross-chain ordering. Nodes SHOULD enforce a configurable per-transaction limit on the number of config change entries (mempool rule).
+Create and delegation entries are authorized by the transaction's `sender_auth` — there is no separate authorization field. The initial `ownerId`s for create entries are salt-committed to the derived address. Delegation updates are authorized under CONFIG scope (see [Delegation Entry](#delegation-entry)). Config change entries carry their own `auth` and use a sequence counter for deterministic cross-chain ordering. Nodes SHOULD enforce a configurable per-transaction limit on the number of config change entries (mempool rule).
 
 #### Create Entry
 
-New smart contract accounts can be created with pre-configured owners in a single transaction. The `code` is placed directly at the account address — it is not executed during deployment. The account's initialization logic runs via `calls` in the execution phase that follows:
+A create entry deploys a new account with pre-configured owners in a single transaction. The account body takes one of two forms, distinguished by `code`:
+
+- **Bytecode account**: `code` is runtime bytecode placed directly at the account address — it is not executed during deployment.
+- **Delegated account**: `code` is a delegation indicator (exactly `0xef0100 || target`, 23 bytes). The account is created as an [EIP-7702](./eip-7702.md)-style delegation to `target`, using the address derivation of [EIP-7819](./eip-7819.md).
+
+`code` is a delegation indicator if and only if it is exactly 23 bytes and begins with `0xef0100`; any other `code` is treated as bytecode and MUST NOT begin with `0xef` (consistent with [EIP-3541](./eip-3541.md)). The account's initialization logic runs via `calls` in the execution phase that follows.
 
 ```
 rlp([
   0x00,               // type: create
   user_salt,          // bytes32: User-chosen uniqueness factor
-  code,               // bytes: Runtime bytecode placed at account address
+  code,               // bytes: runtime bytecode, or a 23-byte delegation indicator (0xef0100 || target)
   initial_owners      // Array of [verifier, ownerId, scope] tuples
 ])
 ```
 
 Initial owners are registered with their specified scope. Wallet initialization code can lock the account via `calls` in the execution phase (e.g., calling `lock()` on the Account Configuration Contract).
 
-The `code` field contains runtime bytecode placed directly at the account address. For delegation, use a delegation entry (type `0x02`) in `account_changes` after account creation.
-
-```
-[0x00, user_salt, runtimeBytecode, initial_owners]
-```
-
 ##### Address Derivation
 
-Addresses are derived using the CREATE2 address formula with the Account Configuration Contract (`ACCOUNT_CONFIG_ADDRESS`) as the deployer. The `initial_owners` are sorted by `ownerId` before hashing to ensure address derivation is order-independent (the same set of owners always produces the same address regardless of the order specified):
+Both forms derive `ACCOUNT_CONFIG_ADDRESS` as the deployer and sort `initial_owners` by `ownerId` before hashing, so derivation is order-independent (the same set of owners always produces the same address regardless of the order specified):
 
 ```
 sorted_owners = sort(initial_owners, by: ownerId)
+owners_commitment = keccak256(ownerId_0 || verifier_0 || scope_0 || ... || ownerId_n || verifier_n || scope_n)
+```
 
-owners_commitment = keccak256(ownerId_0 || verifier_0 || scope_0 || ownerId_1 || verifier_1 || scope_1 || ... || ownerId_n || verifier_n || scope_n)
+The `owners_commitment` uses `ownerId || verifier || scope` (53 bytes) per owner — consistent with how the Account Configuration Contract identifies and configures owners.
 
+**Bytecode accounts** use the CREATE2 address formula:
+
+```
 effective_salt = keccak256(user_salt || owners_commitment)
 deployment_code = DEPLOYMENT_HEADER(len(code)) || code
 address = keccak256(0xff || ACCOUNT_CONFIG_ADDRESS || effective_salt || keccak256(deployment_code))[12:]
 ```
 
-The `owners_commitment` uses `ownerId || verifier || scope` (53 bytes) per owner — consistent with how the Account Configuration Contract identifies and configures owners.
+**Delegated accounts** use the [EIP-7819](./eip-7819.md) formula, binding `target` and `owners_commitment` into the salt:
 
-`DEPLOYMENT_HEADER(n)` is a fixed 14-byte EVM loader that returns the trailing code (see [Appendix: Deployment Header](#appendix-deployment-header) for the full opcode sequence). On non-8130 chains, `createAccount()` constructs `deployment_code` and passes it as init_code to CREATE2. On 8130 chains, the protocol constructs the same `deployment_code` for address derivation but places `code` directly (no execution). Both paths produce the same address — callers only provide `code`; the header is never user-facing.
+```
+delegate_salt = keccak256(user_salt || target || owners_commitment)
+address = keccak256(0xef0100 || ACCOUNT_CONFIG_ADDRESS || delegate_salt)[12:]
+```
+
+The two schemes use different pre-image lengths (85 vs 55 bytes), so a bytecode account and a delegated account can never derive the same address (see [EIP-7819](./eip-7819.md) Backwards Compatibility). Binding `target` into the delegate salt prevents front-running with a different implementation, and `owners_commitment` prevents front-running of owner assignment.
+
+`DEPLOYMENT_HEADER(n)` is a fixed 14-byte EVM loader that returns the trailing code (see [Appendix: Deployment Header](#appendix-deployment-header) for the full opcode sequence). It applies to bytecode accounts only. On non-8130 chains, `createAccount()` constructs `deployment_code` and passes it as init_code to CREATE2 for bytecode accounts, and uses [EIP-7819](./eip-7819.md)'s `SETDELEGATE` for delegated accounts. On 8130 chains, the protocol places `code` (bytecode) or the delegation indicator directly. Both paths produce the same address — callers only provide `code`; the header is never user-facing.
 
 Users can receive funds at counterfactual addresses before account creation.
 
@@ -348,14 +359,15 @@ When a create entry is present in `account_changes`:
 1. Parse `[0x00, user_salt, code, initial_owners]` where each entry is `[verifier, ownerId, scope]`
 2. Reject if any duplicate `ownerId` values exist
 3. Reject if `code` is empty
-4. Sort by ownerId: `sorted_owners = sort(initial_owners, by: ownerId)`
-5. Compute `owners_commitment = keccak256(ownerId_0 || verifier_0 || scope_0 || ... || ownerId_n || verifier_n || scope_n)`
-6. Compute `effective_salt = keccak256(user_salt || owners_commitment)`
-7. Compute `deployment_code = DEPLOYMENT_HEADER(len(code)) || code`
-8. Compute `expected = keccak256(0xff || ACCOUNT_CONFIG_ADDRESS || effective_salt || keccak256(deployment_code))[12:]`
-9. Require `sender == expected`
-10. Require `code_size(sender) == 0` (account not yet deployed)
-11. Validate `sender_auth` against one of `initial_owners` (ownerId resolved from auth must match an entry's ownerId)
+4. Determine the account form: if `code` is exactly 23 bytes and begins with `0xef0100`, it is a **delegated account** with `target = code[3:]` (reject if `target == address(0)`); otherwise it is a **bytecode account** (reject if `code` begins with `0xef`)
+5. Sort by ownerId: `sorted_owners = sort(initial_owners, by: ownerId)`
+6. Compute `owners_commitment = keccak256(ownerId_0 || verifier_0 || scope_0 || ... || ownerId_n || verifier_n || scope_n)`
+7. Compute `expected`:
+   - Bytecode: `effective_salt = keccak256(user_salt || owners_commitment)`; `deployment_code = DEPLOYMENT_HEADER(len(code)) || code`; `expected = keccak256(0xff || ACCOUNT_CONFIG_ADDRESS || effective_salt || keccak256(deployment_code))[12:]`
+   - Delegated: `delegate_salt = keccak256(user_salt || target || owners_commitment)`; `expected = keccak256(0xef0100 || ACCOUNT_CONFIG_ADDRESS || delegate_salt)[12:]`
+8. Require `sender == expected`
+9. Require `code_size(sender) == 0` (account not yet deployed)
+10. Validate `sender_auth` against one of `initial_owners` (ownerId resolved from auth must match an entry's ownerId)
 
 #### Config Change Entry
 
@@ -426,7 +438,10 @@ Both paths share the same signed owner changes and `change_sequence` counters. `
 
 #### Delegation Entry
 
-Delegation entries set [EIP-7702](./eip-7702.md)-style code delegation for the sender's account, replacing the need for an `authorization_list` in the transaction. Delegation is authorized by the transaction's `sender_auth` — no separate signature is required. The sender must be the account's implicit EOA owner (`ownerId == bytes32(bytes20(sender))`) with CONFIG scope.
+Delegation entries set [EIP-7702](./eip-7702.md)-style code delegation for the sender's account, replacing the need for an `authorization_list` in the transaction. Delegation is authorized by the transaction's `sender_auth` under CONFIG scope — no separate signature is required. The authorized owner depends on the account's implicit EOA slot `owner_config(sender, bytes32(bytes20(sender)))`:
+
+- **Empty or a real verifier** (an EOA, possibly already delegated): the sender MUST resolve to the implicit EOA owner (`ownerId == bytes32(bytes20(sender))`). This keeps delegation portable across non-8130 chains via standard [EIP-7702](./eip-7702.md) transactions.
+- **`REVOKED_VERIFIER`** (a delegate-created account, or an EOA that revoked its key): any owner with CONFIG scope MAY authorize the update, since no controlling EOA key exists.
 
 ##### Delegation Format
 
@@ -454,10 +469,10 @@ For 8130 transactions, successful delegation updates emit a protocol-injected `D
 
 `account_changes` entries are processed in order before call execution:
 
-1. **Create entry** (if present): Register `initial_owners` in Account Config storage for `sender` — for each `[verifier, ownerId, scope]` tuple, write `owner_config` (verifier address and scope byte). Initialize lock state to safe defaults: `locked = false`, `unlockDelay = 0`, `unlockRequestedAt = 0`.
+1. **Create entry** (if present): Register `initial_owners` in Account Config storage for `sender` — for each `[verifier, ownerId, scope]` tuple, write `owner_config` (verifier address and scope byte). For a **delegated account**, also write `REVOKED_VERIFIER` to the implicit EOA slot `owner_config(sender, bytes32(bytes20(sender)))`, since a 7819-derived address has no controlling key and MUST NOT be implicitly authorized. Initialize lock state to safe defaults: `locked = false`, `unlockDelay = 0`, `unlockRequestedAt = 0`.
 2. **Config change entries** (if any): Apply operations in entry order. Reject transaction if account is locked.
-3. **Delegation entries** (if any): Require the sender's resolved `ownerId == bytes32(bytes20(sender))` (EOA owner) with CONFIG scope. Reject if account is locked. For each entry, set `code(sender) = 0xef0100 || target` (or clear if `target` is `address(0)`). Reject if account has non-delegation bytecode.
-4. **Code placement** (if create entry present): Place `code` at `sender`. The runtime bytecode is placed directly — not executed.
+3. **Delegation entries** (if any): Authorize per the [Delegation Entry](#delegation-entry) rule. Reject if account is locked. For each entry, set `code(sender) = 0xef0100 || target` (or clear if `target` is `address(0)`). Reject if account has non-delegation bytecode.
+4. **Code placement** (if create entry present): For a **bytecode account**, place `code` at `sender` directly — not executed. For a **delegated account**, set `code(sender) = 0xef0100 || target` and, if `nonce(sender) == 0`, set `nonce(sender) = 1` (per [EIP-7819](./eip-7819.md), keeping the account out of the empty state).
 
 ### Execution
 
@@ -509,7 +524,7 @@ The system is split into storage and verification layers with different portabil
 |-----------|-------------|-----------------|
 | **Account Configuration Contract** | Protocol reads storage directly for validation; EVM interface available | Standard contract (ERC-4337 compatible factory) |
 | **Verifier Contracts** | Protocol calls verifiers via STATICCALL | Same onchain contracts callable by account config contract and wallets |
-| **Code Delegation** | Delegation entry in `account_changes` (EOA-only authorization in this version) | Standard [EIP-7702](./eip-7702.md) transactions (ECDSA authority) |
+| **Code Delegation** | Delegation entry in `account_changes` (EOA owner, or any CONFIG owner for keyless delegated accounts) | Standard [EIP-7702](./eip-7702.md) transactions (ECDSA authority) |
 | **Transaction Context** | Precompile at `TX_CONTEXT_ADDRESS` — protocol populates, verifiers read | No code at address; STATICCALL returns zero/default values |
 | **Nonce Manager** | Precompile at `NONCE_MANAGER_ADDRESS` | Not applicable; nonce management by existing systems (e.g., ERC-4337 EntryPoint) |
 
@@ -525,7 +540,7 @@ All contracts are deployed at deterministic CREATE2 addresses across chains.
    a. If create entry present in `account_changes`: verify address derivation, `code_size(sender) == 0`, use `initial_owners`
    b. Else: read from Account Config storage
 4. If config change or delegation entries present in `account_changes`: reject if account is locked (see [Account Lock](#account-lock)). For config change entries: simulate applying operations in sequence, skip already-applied entries. For delegation entries: verify `code_size(sender) == 0` or existing delegation designator.
-5. Validate `sender_auth` against resulting owner state (see [Validation](#validation)). Require SENDER scope on the resolved owner. If delegation entries are present, also require `ownerId == bytes32(bytes20(sender))` (EOA owner) and CONFIG scope.
+5. Validate `sender_auth` against resulting owner state (see [Validation](#validation)). Require SENDER scope on the resolved owner. If delegation entries are present, also apply the [Delegation Entry](#delegation-entry) authorization rule (CONFIG scope; EOA owner unless the implicit EOA slot is `REVOKED_VERIFIER`).
 6. Resolve payer from `payer` and `payer_auth`:
    - `payer` empty and `payer_auth` empty: self-pay. Payer is `sender`. Reject if balance insufficient.
    - `payer` = 20-byte address (sponsored): `payer_auth` uses any verifier. Validate `payer_auth` against the `payer` address's `owner_config`. Require PAYER scope on the resolved owner.
@@ -545,7 +560,7 @@ Nodes MAY apply higher pending transaction rate limits based on account lock sta
 
 #### Block Execution
 
-1. If `account_changes` contains config change or delegation entries, read lock state for `sender`. Reject transaction if account is locked. If delegation entries are present, require the sender's resolved `ownerId == bytes32(bytes20(sender))` (EOA owner) with CONFIG scope.
+1. If `account_changes` contains config change or delegation entries, read lock state for `sender`. Reject transaction if account is locked. If delegation entries are present, apply the [Delegation Entry](#delegation-entry) authorization rule.
 2. ETH gas deduction from payer (sponsor for sponsored, `sender` for self-pay). Transaction is invalid if payer has insufficient balance.
 3. If `nonce_key != NONCE_KEY_MAX`, increment nonce in Nonce Manager storage for `(sender, nonce_key)`. If `nonce_key == NONCE_KEY_MAX`, skip (nonce-free mode).
 4. If `code_size(sender) == 0` and no create entry and no delegation entry is present in `account_changes`, auto-delegate `sender` to `DEFAULT_ACCOUNT_ADDRESS` (set code to `0xef0100 || DEFAULT_ACCOUNT_ADDRESS`). This delegation persists.
@@ -648,7 +663,9 @@ Since every account has wallet bytecode (auto-delegation or explicit deployment)
 
 ### Why Delegation via Account Changes?
 
-[EIP-7702](./eip-7702.md) introduced `authorization_list` as a transaction-level field for code delegation, with ECDSA authority. This proposal moves delegation into `account_changes`, authorized by the transaction's `sender_auth`. Delegation is restricted to the account's implicit EOA owner (`ownerId == bytes32(bytes20(sender))`) so that code delegation remains portable across non-8130 chains via standard [EIP-7702](./eip-7702.md) transactions. Eventually this can be expanded to all verifier types.
+[EIP-7702](./eip-7702.md) introduced `authorization_list` as a transaction-level field for code delegation, with ECDSA authority. This proposal moves delegation into `account_changes`, authorized by the transaction's `sender_auth`. For accounts with a controlling EOA key, delegation is restricted to the implicit EOA owner (`ownerId == bytes32(bytes20(sender))`) so that code delegation remains portable across non-8130 chains via standard [EIP-7702](./eip-7702.md) transactions.
+
+A create entry can also deploy a **delegated account** directly: when `code` is a delegation indicator, the account is created as an [EIP-7702](./eip-7702.md) delegation using the [EIP-7819](./eip-7819.md) address derivation rather than as bytecode. This unifies account creation — a delegated account is the same object as an auto-delegated EOA (`0xef0100 || target` plus an owner set), only at a deterministic 7819-derived address instead of an EOA address. Because such an address has no controlling key, its implicit EOA owner is revoked at creation and subsequent delegation updates are authorized by any CONFIG-scoped owner rather than the (non-existent) EOA key. On non-8130 chains the same account is deployed by the Account Configuration Contract via [EIP-7819](./eip-7819.md)'s `SETDELEGATE`; where neither is supported, the address is still reserved for counterfactual funding.
 
 ### Why Account Lock?
 
@@ -694,7 +711,7 @@ No breaking changes. Existing EOAs and smart contracts function unchanged. Adopt
 
 - EOAs continue sending standard transactions
 - ERC-4337 infrastructure continues operating
-- Accounts gain AA capabilities by configuring owners. EOAs sending their first AA transaction are auto-delegated to `DEFAULT_ACCOUNT_ADDRESS` if they have no code. EOAs MAY override with a delegation entry in `account_changes` (EOA-only authorization), a standard [EIP-7702](./eip-7702.md) transaction, or use a create entry in `account_changes` for custom wallet implementations
+- Accounts gain AA capabilities by configuring owners. EOAs sending their first AA transaction are auto-delegated to `DEFAULT_ACCOUNT_ADDRESS` if they have no code. EOAs MAY override with a delegation entry in `account_changes`, a standard [EIP-7702](./eip-7702.md) transaction, or use a create entry in `account_changes` for custom wallet implementations (bytecode or delegated accounts)
 
 ## Reference Implementation
 
@@ -731,7 +748,8 @@ interface IAccountConfiguration {
     event AccountLocked(address indexed account, uint16 unlockDelay);
     event AccountUnlockInitiated(address indexed account, uint40 unlocksAt);
 
-    // Account creation (factory)
+    // Account creation (factory). `bytecode` is runtime code, or a 23-byte delegation
+    // indicator (0xef0100 || target) to create a delegated account per EIP-7819.
     function createAccount(bytes32 userSalt, bytes calldata bytecode, Owner[] calldata initialOwners) external returns (address);
     function computeAddress(bytes32 userSalt, bytes calldata bytecode, Owner[] calldata initialOwners) external view returns (address);
 


### PR DESCRIPTION
JUST A DRAFT FOR DISCUSSION 

## Summary

Extends the EIP-8130 create entry so a new account can be created as an [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) delegation in addition to placed bytecode — without adding a new account-changes entry type.

- The create body is a **bytecode account** (existing CREATE2 derivation) or a **delegated account** when `code` is exactly a 23-byte delegation indicator (`0xef0100 || target`). Detection keys on the full `0xef0100` prefix and 23-byte length, keeping it disjoint from EOF and from bytecode (which MUST NOT begin with `0xef`, per EIP-3541).
- Delegated accounts derive their address per [EIP-7819](https://eips.ethereum.org/EIPS/eip-7819) — a 55-byte pre-image, disjoint from CREATE2's 85-byte pre-image. `target` and `owners_commitment` are bound into the salt to prevent front-running.
- On create: the indicator is written, the nonce is bumped `0 -> 1` (EIP-7819 step 9), and the implicit EOA owner slot is set to `REVOKED_VERIFIER` (a 7819-derived address has no controlling key).
- Delegation-update authorization now depends on the implicit EOA slot: the EOA owner when present (portable to EIP-7702), or any CONFIG-scoped owner when the slot is `REVOKED_VERIFIER` (keyless delegated accounts).
- Gas: delegated accounts charge `25,000` (EIP-7819 `EMPTY_ACCOUNT_COST`) instead of the bytecode `32,000 +` per-byte deposit.
- A single rationale paragraph under "Why Delegation via Account Changes?" covers the unified create model and the EOA symmetry; spec sections stay mechanics-only.

This account type is controlled by the 8130 Account Configuration Contract, and the 8130 transaction path can upgrade its delegation via the top-level delegation entry.

## Notes

- Draft; references EIP-7819 (Draft) as a soft dependency (linked, not in `requires:`), consistent with how EIP-8130 references other proposals.
- Based on `master`; independent of the open owner-policies PR (both touch the Create entry, so whichever merges second will reconcile that overlap).
