### PR TITLE
Update EIP-8130: define signature-invariant nonce-free replay identifier

### DIFF
--- a/EIPS/eip-8130.md
+++ b/EIPS/eip-8130.md
@@ -92,7 +92,24 @@ The transaction carries two nonce fields: `nonce_key` (`uint256`) selects the no
 
 When `nonce_key == NONCE_KEY_MAX`, the protocol does not read or increment nonce state. `nonce_sequence` MUST be `0`. Replay protection relies on `expiry`, which MUST be non-zero.
 
-Nodes SHOULD reject `NONCE_KEY_MAX` transactions from the mempool if `expiry` exceeds a short window (e.g., 10 seconds from current time). Replay protection is handled by transaction hash.
+Nodes SHOULD reject `NONCE_KEY_MAX` transactions from the mempool if `expiry` exceeds a short window (e.g., 10 seconds from current time). Replay protection is handled by the **nonce-free replay identifier** defined below.
+
+###### Nonce-Free Replay Identifier
+
+Nonce-free deduplication and replay protection MUST key on a **signature-invariant** identifier rather than the [EIP-2718](./eip-2718.md) transaction hash:
+
+```
+replay_id = keccak256(resolved_sender || sender_signature_hash)
+```
+
+where `sender_signature_hash` is defined in [Signature Payload](#signature-payload) and `resolved_sender` is the sender address recovered via ecrecover (EOA path, where `sender` is empty in the wire format) or taken directly from the `sender` field (configured-owner path). Binding `resolved_sender` keeps the identifier unique per sender on the EOA path, where two distinct EOAs can sign identical transaction bodies.
+
+The full transaction hash MUST NOT be used for nonce-free deduplication. The transaction hash commits to `sender_auth` and `payer_auth` (the authorization blobs), whereas `replay_id` excludes both. Keying on the transaction hash would allow trivial duplication of a single logical transaction:
+
+- **Re-signed `payer_auth`**: the sender signs over the `payer` *address* but not the payer's signature bytes, so a sponsor can produce a different `payer_auth` for the same sender body, yielding a different transaction hash for the same logical transaction.
+- **`sender_auth` malleability**: ECDSA signatures are malleable, so an EOA `sender_auth` can be re-encoded into a distinct-but-valid form, again yielding a different transaction hash.
+
+Both variants resolve to the same `replay_id`, so deduplicating on it collapses them to a single mempool slot and a single includable transaction.
 
 #### Account Lock
 
@@ -532,7 +549,7 @@ All contracts are deployed at deterministic CREATE2 addresses across chains.
    - `payer` = 20-byte address (sponsored): `payer_auth` uses any verifier. Validate `payer_auth` against the `payer` address's `owner_config`. Require PAYER scope on the resolved owner.
 7. Verify nonce, payer ETH balance, and expiry:
    - **Standard keys** (`nonce_key != NONCE_KEY_MAX`): require `nonce_sequence == current_sequence(sender, nonce_key)`.
-   - **Nonce-free key** (`nonce_key == NONCE_KEY_MAX`): skip nonce check, require `nonce_sequence == 0`, require non-zero `expiry`, and nodes SHOULD reject if `expiry` exceeds a short window (e.g., 10 seconds). Deduplicate by transaction hash.
+   - **Nonce-free key** (`nonce_key == NONCE_KEY_MAX`): skip nonce check, require `nonce_sequence == 0`, require non-zero `expiry`, and nodes SHOULD reject if `expiry` exceeds a short window (e.g., 10 seconds). Deduplicate by the [Nonce-Free Replay Identifier](#nonce-free-replay-identifier) (`replay_id`), not the full transaction hash.
 8. Mempool threshold: gas payer's pending count below node-configured limits.
 
 Nodes MUST maintain a verifier allowlist that includes all verifiers in the canonical verifier set (see [Canonical Verifier Set](#canonical-verifier-set)).
@@ -598,7 +615,7 @@ Enables signature-algorithm extension through verifier contracts. The verifier r
 
 Additional `nonce_key` values allow parallel transaction lanes without nonce contention between independent workflows.
 
-`NONCE_KEY_MAX` enables nonce-free transactions where replay protection comes from short-lived `expiry` and node-level replay protection by transaction hash. This is useful for operations where nonce ordering coordination is undesirable.
+`NONCE_KEY_MAX` enables nonce-free transactions where replay protection comes from short-lived `expiry` and node-level deduplication by the signature-invariant [Nonce-Free Replay Identifier](#nonce-free-replay-identifier). This is useful for operations where nonce ordering coordination is undesirable.
 
 ### Why a Nonce Precompile?
 
@@ -810,7 +827,7 @@ Read-only. The protocol manages nonce storage directly; there are no state-modif
 
 **Validation Surface**: For pure verifiers, invalidators are `owner_config` revocation and nonce consumption. Stateful verifiers additionally depend on traced state; invalidation tracking is a mempool concern.
 
-**Replay Protection**: Transactions include `chain_id`, 2D nonce (`nonce_key`, `nonce_sequence`), and `expiry`. For `NONCE_KEY_MAX` (nonce-free mode), replay protection relies on short-lived `expiry` and transaction-hash deduplication. The mempool enforces a tight expiry window (e.g., 10-30 seconds) to bound the window. Block builders MUST NOT include duplicate `NONCE_KEY_MAX` transactions with the same hash.
+**Replay Protection**: Transactions include `chain_id`, 2D nonce (`nonce_key`, `nonce_sequence`), and `expiry`. For `NONCE_KEY_MAX` (nonce-free mode), replay protection relies on short-lived `expiry` and deduplication by the signature-invariant [Nonce-Free Replay Identifier](#nonce-free-replay-identifier) (`replay_id`). The mempool enforces a tight expiry window (e.g., 10-30 seconds) to bound the window. Block builders MUST NOT include two `NONCE_KEY_MAX` transactions with the same `replay_id`. The identifier deliberately excludes `sender_auth` and `payer_auth`: keying on the full transaction hash would let a sponsor re-sign `payer_auth`, or an attacker exploit `sender_auth` malleability, to admit or include duplicates of one logical transaction (see [Nonce-Free Replay Identifier](#nonce-free-replay-identifier)).
 
 **Owner Scope**: Protocol-enforced after verifier execution — a verifier cannot bypass scope checking.
 


### PR DESCRIPTION
## Summary

Clarifies how `NONCE_KEY_MAX` (nonce-free mode) transactions are deduplicated / replay-protected. The spec currently says only "deduplicate by transaction hash" in three places without defining the hash. By the standard [EIP-2718](./eip-2718.md) convention, "the transaction hash" commits to `sender_auth` and `payer_auth`, which **does not** achieve the intended one-logical-transaction-per-window guarantee.

This PR defines a signature-invariant **Nonce-Free Replay Identifier**:

```
replay_id = keccak256(resolved_sender || sender_signature_hash)
```

and updates the Nonce-Free Mode, Mempool Acceptance, Rationale, and Security Considerations sections to reference it.

## Why

Because the transaction hash commits to the authorization blobs, keying dedup on it lets a single logical transaction be duplicated:

- **Re-signed `payer_auth`** — the sender signs over the `payer` *address* but not the payer's signature bytes, so a sponsor can produce a different `payer_auth` for the same sender body → different transaction hash, same logical transaction.
- **`sender_auth` malleability** — ECDSA signatures are malleable, so an EOA `sender_auth` can be re-encoded into a distinct-but-valid form → different transaction hash.

Both defeat same-hash deduplication and allow duplicate mempool admission / duplicate inclusion. `replay_id` excludes both authorization fields and binds the resolved sender, collapsing all such variants to one identifier (and matching the per-sender binding already required for the payer signature hash).

## Changes

- Add a **Nonce-Free Replay Identifier** sub-section defining `replay_id`.
- Mempool Acceptance step 7: deduplicate by `replay_id`, not the full transaction hash.
- Rationale (Why 2D Nonce) and Security Considerations (Replay Protection): reference `replay_id` and the rationale for excluding the auth fields.

No normative change to non-nonce-free paths.