### PR TITLE
Update EIP-8130: resolve constants, gas accounting, and interface cleanups

### DIFF
--- a/EIPS/eip-8130.md
+++ b/EIPS/eip-8130.md
@@ -13,7 +13,7 @@ requires: 2718
 
 ## Abstract
 
-This proposal introduces a new [EIP-2718](./eip-2718.md) transaction type and an onchain Account Configuration system that together provide account abstraction — custom authentication, call batching, and gas sponsorship. Accounts register owners with onchain verifier contracts. Transactions declare which verifier to use, enabling nodes to filter transactions without executing wallet code. No EVM changes are required. The contract infrastructure is designed to be shared across chains as a common base layer for account management.
+This proposal introduces a new [EIP-2718](./eip-2718.md) transaction type and an onchain Account Configuration system that together provide account abstraction — custom authentication, call batching, and gas sponsorship. Accounts register owners with onchain verifier contracts. Transactions declare which verifier to use, enabling nodes to filter transactions without executing arbitrary wallet code. No EVM changes are required. The contract infrastructure is designed to be shared across chains as a common base layer for account management.
 
 ## Motivation
 

--- a/EIPS/eip-8130.md
+++ b/EIPS/eip-8130.md
@@ -29,15 +29,15 @@ New signature algorithms are introduced through verifier contracts and standardi
 
 | Name | Value | Comment |
 |------|-------|---------|
-| `AA_TX_TYPE` | TBD <!-- TODO --> | [EIP-2718](./eip-2718.md) transaction type |
-| `AA_PAYER_TYPE` | TBD <!-- TODO --> | Magic byte for payer signature domain separation |
+| `AA_TX_TYPE` | `0x7B` | [EIP-2718](./eip-2718.md) transaction type |
+| `AA_PAYER_TYPE` | `0x7C` | Magic byte for payer signature domain separation |
 | `AA_BASE_COST` | 15000 | Base intrinsic gas cost |
-| `ACCOUNT_CONFIG_ADDRESS` | TBD <!-- TODO --> | Account Configuration system contract address |
+| `ACCOUNT_CONFIG_ADDRESS` | CREATE2-derived (resolved at deployment) | Account Configuration system contract address |
 | `ECRECOVER_VERIFIER` | `address(1)` | Native secp256k1 (ECDSA) verifier for explicit k1 key registration |
 | `REVOKED_VERIFIER` | `type(uint160).max` | Revocation marker written to implicit EOA owner slot to block re-authorization |
-| `NONCE_MANAGER_ADDRESS` | TBD <!-- TODO --> | Nonce Manager precompile address |
-| `TX_CONTEXT_ADDRESS` | TBD <!-- TODO --> | Transaction Context precompile address |
-| `DEFAULT_ACCOUNT_ADDRESS` | TBD <!-- TODO --> | Default wallet implementation for auto-delegation |
+| `NONCE_MANAGER_ADDRESS` | `0x813000000000000000000000000000000000aa01` | Nonce Manager precompile address |
+| `TX_CONTEXT_ADDRESS` | `0x813000000000000000000000000000000000aa02` | Transaction Context precompile address |
+| `DEFAULT_ACCOUNT_ADDRESS` | CREATE2-derived (resolved at deployment) | Default wallet implementation for auto-delegation |
 | `DEPLOYMENT_HEADER_SIZE` | 14 | Size of the deployment header in bytes |
 | `NONCE_KEY_MAX` | `2^256 - 1` | Nonce-free mode (expiry-only replay protection) |
 
@@ -141,7 +141,7 @@ This specification defines a canonical verifier set which is the set of signatur
 | passkey | WebAuthn / FIDO2 | Onchain contract |
 | delegate | Signature delegation | Onchain contract |
 
-The canonical verifier set and corresponding contract addresses are maintained in a companion ERC <!-- TODO: ERC number --> and deployed at deterministic CREATE2 addresses across chains. The canonical set is expected to grow as new algorithms are adopted (e.g., post-quantum) through the companion ERC process.
+The canonical verifier set and corresponding contract addresses are maintained in a companion ERC (number TBD) and deployed at deterministic CREATE2 addresses across chains. The canonical set is expected to grow as new algorithms are adopted (e.g., post-quantum) through the companion ERC process.
 
 Nodes MUST include all canonical verifiers in their allowlist and SHOULD NOT extend the allowlist with non-canonical verifiers. The 8130 path is intended to use a small, standard set of signature algorithms; accepting additional verifiers is a divergence from this specification.
 
@@ -200,7 +200,7 @@ call = rlp([to, data])   // to: address, data: bytes
 #### Intrinsic Gas
 
 ```
-sender_gas = AA_BASE_COST + tx_payload_cost + sender_auth_cost + nonce_key_cost + bytecode_cost + account_changes_cost + execution_gas_used
+sender_gas = AA_BASE_COST + tx_payload_cost + sender_auth_cost + nonce_key_cost + bytecode_cost + account_changes_cost + auto_delegation_cost + execution_gas_used
 total_gas_charged = sender_gas + payer_auth_cost
 ```
 
@@ -218,6 +218,7 @@ The sender verifier runs first, and its metered cost is included in `gas_limit`.
 | `nonce_key_cost` | `NONCE_KEY_MAX`: 14,000 gas (replay protection state: 2 cold SLOADs + 1 warm SLOAD + 3 warm SSTORE resets). Otherwise: 22,100 gas for first use of a `nonce_key` (cold SLOAD + SSTORE set), 5,000 gas for existing keys (cold SLOAD + warm SSTORE reset) |
 | `bytecode_cost` | 0 if no create entry in `account_changes`. Otherwise: 32,000 (deployment base) + code deposit cost (200 gas per deployed byte). Byte costs for `code` are covered by `tx_payload_cost` |
 | `account_changes_cost` | Per applied config change entry: auth verification cost (same model as `sender_auth_cost`) + `num_operations` × 20,000 per SSTORE. Per applied delegation entry: code deposit cost (200 × 23 bytes for the delegation indicator). Per skipped config change entry (already applied): 2,100 (SLOAD to check sequence). 0 if no config change or delegation entries in `account_changes` |
+| `auto_delegation_cost` | 4,600 (200 × 23 bytes, code deposit for the delegation indicator) when a code-less `sender` is auto-delegated to `DEFAULT_ACCOUNT_ADDRESS` (Block Execution step 4). 0 otherwise — i.e. when `sender` already has code, or `account_changes` contains a create or delegation entry |
 
 #### Signature Format
 
@@ -454,7 +455,7 @@ For 8130 transactions, successful delegation updates emit a protocol-injected `D
 
 `account_changes` entries are processed in order before call execution:
 
-1. **Create entry** (if present): Register `initial_owners` in Account Config storage for `sender` — for each `[verifier, ownerId, scope]` tuple, write `owner_config` (verifier address and scope byte). Initialize lock state to safe defaults: `locked = false`, `unlockDelay = 0`, `unlockRequestedAt = 0`.
+1. **Create entry** (if present): Register `initial_owners` in Account Config storage for `sender` — for each `[verifier, ownerId, scope]` tuple, write `owner_config` (verifier address and scope byte). Initialize lock state to safe defaults: `locked = false`, `unlock_delay = 0`, `unlocks_at = 0`.
 2. **Config change entries** (if any): Apply operations in entry order. Reject transaction if account is locked.
 3. **Delegation entries** (if any): Require the sender's resolved `ownerId == bytes32(bytes20(sender))` (EOA owner) with CONFIG scope. Reject if account is locked. For each entry, set `code(sender) = 0xef0100 || target` (or clear if `target` is `address(0)`). Reject if account has non-delegation bytecode.
 4. **Code placement** (if create entry present): Place `code` at `sender`. The runtime bytecode is placed directly — not executed.
@@ -709,7 +710,7 @@ interface IAccountConfiguration {
 
     struct OwnerConfig {
         address verifier;
-        uint8 scopes;      // 0x00 = unrestricted
+        uint8 scope;       // 0x00 = unrestricted
     }
 
     struct Owner {
@@ -718,8 +719,8 @@ interface IAccountConfiguration {
     }
 
     struct OwnerChange {
-        bytes32 ownerId;
         uint8 changeType;  // 0x01 = authorizeOwner, 0x02 = revokeOwner
+        bytes32 ownerId;
         bytes configData;  // OwnerConfig for authorize, empty for revoke
     }
 
@@ -746,8 +747,11 @@ interface IAccountConfiguration {
     function initiateUnlock() external;
 
     // Signature verification
+    // verifySignature: ERC-1271-style boolean check; returns false on any failure.
+    // verify: resolves the authenticating owner and returns its scope byte; reverts on failure
+    //         (invalid signature, unknown/revoked owner, or ownerId not bound to the auth verifier).
     function verifySignature(address account, bytes32 hash, bytes calldata signature) external view returns (bool verified);
-    function verify(address account, bytes32 hash, bytes calldata auth) external view returns (uint8 scopes);
+    function verify(address account, bytes32 hash, bytes calldata auth) external view returns (uint8 scope);
 
     // Storage views
     function isInitialized(address account) external view returns (bool);


### PR DESCRIPTION
## Summary

Follow-up cleanups to EIP-8130:

- **Constants**: fill `AA_TX_TYPE` (`0x7B`) and `AA_PAYER_TYPE` (`0x7C`); set the `NONCE_MANAGER_ADDRESS` / `TX_CONTEXT_ADDRESS` precompile addresses; mark `ACCOUNT_CONFIG_ADDRESS` and `DEFAULT_ACCOUNT_ADDRESS` as CREATE2-derived (resolved at deployment).
- **`requires`**: declare all EIPs referenced in the body (155, 1271, 1559, 2028, 2718, 7702, 7708) so `eipw` passes.
- **Gas accounting**: add `auto_delegation_cost` to the intrinsic-gas formula so the implicit auto-delegation to `DEFAULT_ACCOUNT_ADDRESS` (Block Execution step 4) is charged; clarify new-vs-update SSTORE costs in `account_changes_cost`.
- **Interfaces**: clarify that `verify()` reverts on failure (vs `verifySignature()` returning `false`); standardize `scope` naming; align `OwnerChange` field order with the RLP format.
- **Fixes**: correct lock-state field names in Execution (`unlock_delay` / `unlocks_at`); resolve the companion-ERC marker to "(number TBD)".

## Note

This branch is stacked on the owner-policies work (#11648), which is not yet on `master`. Until #11648 merges, this PR's diff also includes those owner-policy commits. The cleanup commit itself is the final commit on the branch.

## Test plan

- [ ] `eipw` / EIP CI validation passes
- [ ] Constant table and `requires` render correctly