### PR TITLE
Update EIP-8130: minimize Transaction Context precompile to identity

### DIFF
--- a/EIPS/eip-8130.md
+++ b/EIPS/eip-8130.md
@@ -120,7 +120,7 @@ This proposal uses the same delegation indicator behavior as [EIP-7702](./eip-77
 
 ### Verifiers
 
-Each owner is associated with a verifier, a contract that performs signature verification. The verifier address is stored in `owner_config`. All verifiers implement `IVerifier.verify(hash, data)`. Stateful verifiers MAY read transaction context (sender address, calls, payer) from the Transaction Context precompile at `TX_CONTEXT_ADDRESS` (see [Transaction Context](#transaction-context)). The protocol validates the returned `ownerId` against `owner_config` and checks the owner's scope against the authentication context.
+Each owner is associated with a verifier, a contract that performs signature verification. The verifier address is stored in `owner_config`. All verifiers implement `IVerifier.verify(hash, data)`. Stateful verifiers MAY read identity context (sender, payer) from the Transaction Context precompile at `TX_CONTEXT_ADDRESS` (see [Transaction Context](#transaction-context)). The protocol validates the returned `ownerId` against `owner_config` and checks the owner's scope against the authentication context.
 
 Verifiers are executed via STATICCALL. Verifier addresses MUST NOT be delegated accounts — reject if the code at the verifier address starts with the delegation indicator (`0xef0100`). Execution is metered (see [Mempool Acceptance](#mempool-acceptance) for rules).
 
@@ -237,7 +237,7 @@ The first 20 bytes identify the verifier address. When the verifier is `ECRECOVE
 ##### Validation
 
 1. **Resolve sender**: If `sender` empty, ecrecover derives the sender address (EOA path) with `ownerId = bytes32(bytes20(sender))`. If `sender` set, read the first 20 bytes of `sender_auth` as the verifier address.
-2. **Set transaction context**: Populate the Transaction Context precompile with sender, payer, and calls (see [Transaction Context](#transaction-context)).
+2. **Set transaction context**: Populate the Transaction Context precompile with sender and payer; the sender's `ownerId` is set after authentication and is available during execution (see [Transaction Context](#transaction-context)).
 3. **Verify**: Route by verifier address. For the EOA path (`sender` empty), ecrecover was already performed in step 1. For `ECRECOVER_VERIFIER` (`address(1)`), the protocol natively ecrecovers from `data` (as `r || s || v`), returning `ownerId = bytes32(bytes20(recovered_address))`. For all other verifiers (`address(2+)`), call `verifier.verify(hash, data)` via STATICCALL, returning `ownerId` (or `bytes32(0)` for invalid). Reject `REVOKED_VERIFIER` as a verifier address.
 4. **Authorize**: SLOAD `owner_config(sender, ownerId)`. **Implicit EOA rule**: if the slot is empty, `ownerId == bytes32(bytes20(sender))`, and verification in step 3 used the native secp256k1 path (the EOA path or `ECRECOVER_VERIFIER`), treat as implicitly authorized with scope `0x00`. Otherwise, require that the stored verifier address matches the effective verifier and is not `REVOKED_VERIFIER`.
 5. **Check scope**: Read the scope byte from `owner_config` (or `0x00` for the implicit case). Determine the context bit: `0x02` (SENDER) for `sender_auth`, `0x04` (PAYER) for `payer_auth`, `0x01` (SIGNATURE) for `verifySignature()`, `0x08` (CONFIG) for config change `auth`. Require `scope == 0x00 || (scope & context_bit) != 0`.
@@ -487,18 +487,19 @@ Phases execute in order from a single gas pool (`gas_limit`). Within each phase,
 
 #### Transaction Context
 
-The Transaction Context precompile at `TX_CONTEXT_ADDRESS` provides read-only access to the current AA transaction's metadata. The precompile reads directly from the client's in-memory transaction state — protocol "writes" are effectively zero-cost. Gas is charged as a base cost plus 3 gas per 32 bytes of returned data, matching `CALLDATACOPY` pricing.
+The Transaction Context precompile at `TX_CONTEXT_ADDRESS` provides read-only access to the authenticated identity of the current transaction. The precompile reads directly from the client's in-memory transaction state — protocol "writes" are effectively zero-cost. Gas is charged as a base cost plus 3 gas per 32 bytes of returned data, matching `CALLDATACOPY` pricing.
 
 | Function | Returns | Available |
 |----------|---------|-----------|
-| `getSender()` | `address` — the account being validated (`sender`) | Validation + Execution |
-| `getPayer()` | `address` — gas payer (`sender` for self-pay, payer for sponsored) | Validation + Execution |
-| `getOwnerId()` | `bytes32` — authenticated owner's ownerId | Execution only |
-| `getCalls()` | `Call[][]` — full calls array | Validation + Execution |
-| `getMaxCost()` | `uint256` — `gas_limit * max_fee_per_gas`, excluding separately metered `payer_auth_cost` | Validation + Execution |
-| `getGasLimit()` | `uint256` — sender-side gas budget (`gas_limit`) before intrinsic costs and call execution | Validation + Execution |
+| `getTransactionSender()` | `address` — the account being validated (`sender`) | Validation + Execution |
+| `getTransactionPayer()` | `address` — gas payer (`sender` for self-pay, payer for sponsored) | Validation + Execution |
+| `getTransactionSenderOwnerId()` | `bytes32` — the `ownerId` that authenticated the sender | Execution only |
 
-If the wallet needs the verifier address or scope, it calls `getOwnerConfig(account, ownerId)` on the Account Configuration Contract.
+`getTransactionSenderOwnerId()` returns `bytes32(0)` during validation (the sender's owner is not yet authenticated) and the authenticated `ownerId` during execution. If the wallet needs the verifier address or scope, it calls `getOwnerConfig(account, ownerId)` on the Account Configuration Contract.
+
+The interface is intentionally minimal — only identity. Additional context (the `calls` array, `gas_limit * max_fee_per_gas`, `gas_limit`) is needed only by stateful payer verifiers that inspect the transaction; those fields MAY be added as new precompile functions if such verifiers are adopted, without changing the existing interface.
+
+**Population**: The precompile is populated for every transaction on an 8130 chain, not only `AA_TX_TYPE` transactions. For non-8130 transactions (e.g. legacy [EIP-1559](./eip-1559.md) or [EIP-7702](./eip-7702.md) transactions on an 8130 chain), there is no separate sender/payer authentication: `getTransactionSender()` and `getTransactionPayer()` both return `tx.origin`, and `getTransactionSenderOwnerId()` returns `bytes32(bytes20(tx.origin))` — the implicit EOA `ownerId` convention. This lets identity-aware contracts read the acting owner uniformly without branching on transaction type.
 
 **Non-8130 chains**: No code at `TX_CONTEXT_ADDRESS`; STATICCALL returns zero/default values.
 
@@ -551,7 +552,7 @@ Nodes MAY apply higher pending transaction rate limits based on account lock sta
 3. If `nonce_key != NONCE_KEY_MAX`, increment nonce in Nonce Manager storage for `(sender, nonce_key)`. If `nonce_key == NONCE_KEY_MAX`, skip (nonce-free mode).
 4. If `code_size(sender) == 0` and no create entry and no delegation entry is present in `account_changes`, auto-delegate `sender` to `DEFAULT_ACCOUNT_ADDRESS` (set code to `0xef0100 || DEFAULT_ACCOUNT_ADDRESS`). This delegation persists.
 5. Process `account_changes` entries in order (see [Execution (Account Changes)](#execution-account-changes)).
-6. Set transaction context on the Transaction Context precompile (sender, payer, ownerId, calls).
+6. Set transaction context on the Transaction Context precompile (sender, payer, ownerId).
 7. Execute `calls` per [Call Execution](#call-execution) semantics.
 
 Unused gas from `gas_limit` is refunded to the payer. Intrinsic gas, excluding separately metered `payer_auth_cost`, consumes `gas_limit` before call execution. For step 5, the protocol SHOULD inject log entries into the transaction receipt (e.g., `OwnerAuthorized`, `AccountCreated`, `DelegationApplied`) matching the events defined in the [IAccountConfiguration](#iaccountconfiguration) interface, following the protocol-injected log pattern established by [EIP-7708](./eip-7708.md). These protocol-injected logs are emitted only for 8130 transactions.
@@ -608,11 +609,13 @@ The Nonce Manager has no EVM-writable state and no portability requirement — a
 
 ### Why a Transaction Context Precompile?
 
-Transaction context (sender, payer, calls, gas) is immutable transaction metadata — it never changes during execution. `ownerId` is set after validation and available during execution only. A precompile is the natural fit:
+The precompile's purpose is to carry the authenticated sender identity — `sender`, `payer`, and the sender's `ownerId` — from validation into execution. The `ownerId` in particular cannot be recovered any other way during execution: the signature is already consumed, and calls dispatch with fixed parameters (`msg.sender == sender`, no owner identifier injected), so a wallet that applies per-owner logic in its own bytecode has no other channel to learn which key authorized the transaction. A precompile is the natural fit:
 
 - **Zero protocol write cost**: The precompile reads directly from the client's in-memory transaction struct — no HashMap insert, no journaling, no rollback tracking.
-- **Pull model**: Verifiers read only what they need. Pure verifiers pay nothing for context they don't use.
-- **Forward compatible**: New context fields are added as new precompile functions — no interface changes to `IVerifier` or existing verifier contracts.
+- **Pull model**: Callers read only what they need. Pure cryptographic verifiers, which authenticate solely from the signed hash, pay nothing for context they never read.
+- **Forward compatible**: Additional context fields can be added as new precompile functions later — no interface changes to `IVerifier` or existing verifier contracts.
+
+The initial interface is deliberately minimal — identity only. The `calls` array and gas bounds were dropped because their only consumers are stateful payer verifiers (which inspect the batch to price sponsorship) and protocol-level call inspection; with cryptographic verifiers and external policy managers (which authorize on their own terms rather than reading the 8130 `ownerId`), those fields have no consumer. They can be reintroduced as new functions if stateful payer verifiers are adopted.
 
 ### Why CREATE2 for Account Creation?
 
@@ -628,7 +631,7 @@ The create entry uses the CREATE2 address formula with `ACCOUNT_CONFIG_ADDRESS` 
 Existing ERC-4337 smart accounts migrate to native AA without redeployment:
 
 1. **Import account**: Call `importAccount()` on the Account Configuration Contract — this verifies via the account's `isValidSignature` ([ERC-1271](./eip-1271.md)) and registers initial owners. Existing ERC-4337 wallets already implement ERC-1271, so initial owner registration works without code changes.
-2. **Upgrade wallet logic**: Update contract to delegate `isValidSignature` to the Account Configuration Contract's `verifySignature()` function for owner and verifier infrastructure, and read `getOwnerId()` from the Transaction Context precompile during execution to identify which owner authorized the transaction
+2. **Upgrade wallet logic**: Update contract to delegate `isValidSignature` to the Account Configuration Contract's `verifySignature()` function for owner and verifier infrastructure, and read `getTransactionSenderOwnerId()` from the Transaction Context precompile during execution to identify which owner authorized the transaction
 3. **Backwards compatible**: Wallet can still accept ERC-4337 UserOps via EntryPoint alongside native AA transactions
 
 ### Why Call Phases?
@@ -637,7 +640,6 @@ Phases provide two atomic batching levels without per-call mode flags:
 
 - **Atomic batching**: One phase, all-or-nothing.
 - **Sponsor protection**: Payment in phase 0 persists even if user actions in phase 1 revert.
-- **Paymaster inspection**: Verifiers can inspect calls via the Transaction Context precompile to validate payment terms.
 
 ### Why Direct Dispatch?
 
@@ -774,23 +776,15 @@ interface IVerifier {
 }
 ```
 
-Stateful verifiers MAY read from the Transaction Context precompile or other state (see [Transaction Context](#transaction-context)). When called outside of an 8130 transaction (e.g., `verifySignature()` in a legacy transaction), the Transaction Context precompile returns zero/default values, so verifiers that depend on it naturally reject those calls.
+Stateful verifiers MAY read from the Transaction Context precompile or other state (see [Transaction Context](#transaction-context)). On chains without 8130 support, the precompile has no code and STATICCALL returns zero/default values, so verifiers that depend on it naturally reject in that environment. On an 8130 chain the precompile is populated for every transaction (identity defaults to `tx.origin` for non-8130 transactions), so a zero return cannot be used to distinguish an 8130 transaction from a legacy one; verifiers needing that distinction must rely on a dedicated 8130-only context field.
 
 ### ITxContext (Precompile)
 
 ```solidity
-struct Call {
-    address to;
-    bytes data;
-}
-
 interface ITxContext {
-    function getSender() external view returns (address);
-    function getPayer() external view returns (address);
-    function getOwnerId() external view returns (bytes32);
-    function getCalls() external view returns (Call[][] memory);
-    function getMaxCost() external view returns (uint256);
-    function getGasLimit() external view returns (uint256);
+    function getTransactionSender() external view returns (address);
+    function getTransactionPayer() external view returns (address);
+    function getTransactionSenderOwnerId() external view returns (bytes32);
 }
 ```
 


### PR DESCRIPTION
## Summary

Trims the Transaction Context precompile to a minimal, identity-only interface and renames the functions for clarity.

- `getSender()` → `getTransactionSender()`
- `getPayer()` → `getTransactionPayer()`
- `getOwnerId()` → `getTransactionSenderOwnerId()`

Drops `getCalls()`, `getMaxCost()`, and `getGasLimit()` (and the now-unused `Call` struct).

## Why

The only consumers of `calls`/`maxCost`/`gasLimit` were stateful payer verifiers that inspect the batch to price sponsorship. With cryptographic verifiers and external policy managers (e.g. `base/account-policies`, which authorize on their own terms — installed binding + executor signatures — rather than reading the 8130 `ownerId`), those fields have no consumer. The remaining justification for the precompile is carrying the authenticated sender identity, and especially the `ownerId`, from validation into execution: by execution time the signature is consumed and calls dispatch with fixed params, so a wallet doing per-owner logic in its own bytecode has no other channel to learn which key signed.

The dropped fields can be reintroduced as new functions later without an interface break.

## Changes

- Reduce `ITxContext` to the three identity functions and rename them.
- Define population for **every** transaction on an 8130 chain (not only `AA_TX_TYPE`): non-8130 transactions return `tx.origin` for sender/payer and `bytes32(bytes20(tx.origin))` for the sender owner id (implicit EOA convention), so identity-aware contracts read the acting owner without branching on transaction type.
- Update the *Why a Transaction Context Precompile?* rationale, the `IVerifier` legacy-context note, *Why Call Phases?*, and all cross-references.

## Notes

Populating identity in legacy context removes the prior "verifier sees zero → auto-rejects non-8130 calls" property; this is acceptable for cryptographic verifiers and documented. If stateful verifiers are reintroduced, a dedicated 8130-only context field should serve as that signal.