### PR TITLE
Update EIP-8130: rename owners to actors and finalize Transaction Context naming

### DIFF
--- a/EIPS/eip-8130.md
+++ b/EIPS/eip-8130.md
@@ -13,13 +13,13 @@ requires: 170, 2718
 
 ## Abstract
 
-This proposal introduces a new [EIP-2718](./eip-2718.md) transaction type and an onchain Account Configuration system that together provide account abstraction — custom authentication, call batching, and gas sponsorship. Accounts register owners with onchain verifier contracts. Transactions declare which verifier to use, enabling nodes to filter transactions without executing arbitrary wallet code. No EVM changes are required. The contract infrastructure is designed to be shared across chains as a common base layer for account management.
+This proposal introduces a new [EIP-2718](./eip-2718.md) transaction type and an onchain Account Configuration system that together provide account abstraction — custom authentication, call batching, and gas sponsorship. Accounts register actors with onchain verifier contracts. Transactions declare which verifier to use, enabling nodes to filter transactions without executing arbitrary wallet code. No EVM changes are required. The contract infrastructure is designed to be shared across chains as a common base layer for account management.
 
 ## Motivation
 
 Account abstraction proposals that delegate validation to wallet code force nodes to simulate arbitrary EVM before accepting a transaction. This requires full state access, tracing infrastructure, and reputation systems to bound the cost of invalid submissions.
 
-This proposal separates verification from account logic. Each transaction explicitly declares its verifier — a contract that takes a hash and signature data and returns the authenticated owner. This makes validation predictable: wallets know the rules, and nodes can see exactly what computation a transaction requires before executing it. Nodes may optionally filter on verifier identity, accepting only known verifiers (ECDSA, P256, WebAuthn, multisig, post-quantum) and rejecting the rest without execution.
+This proposal separates verification from account logic. Each transaction explicitly declares its verifier — a contract that takes a hash and signature data and returns the authenticated actor. This makes validation predictable: wallets know the rules, and nodes can see exactly what computation a transaction requires before executing it. Nodes may optionally filter on verifier identity, accepting only known verifiers (ECDSA, P256, WebAuthn, multisig, post-quantum) and rejecting the rest without execution.
 
 New signature algorithms are introduced through verifier contracts and standardized through the canonical verifier set.
 
@@ -34,7 +34,7 @@ New signature algorithms are introduced through verifier contracts and standardi
 | `AA_BASE_COST` | 15000 | Base intrinsic gas cost |
 | `ACCOUNT_CONFIG_ADDRESS` | CREATE2-derived (resolved at deployment) | Account Configuration system contract address |
 | `ECRECOVER_VERIFIER` | `address(1)` | Native secp256k1 (ECDSA) verifier for explicit k1 key registration |
-| `REVOKED_VERIFIER` | `type(uint160).max` | Revocation marker written to implicit EOA owner slot to block re-authorization |
+| `REVOKED_VERIFIER` | `type(uint160).max` | Revocation marker written to implicit EOA actor slot to block re-authorization |
 | `NONCE_MANAGER_ADDRESS` | `0x813000000000000000000000000000000000aa01` | Nonce Manager precompile address |
 | `TX_CONTEXT_ADDRESS` | `0x813000000000000000000000000000000000aa02` | Transaction Context precompile address |
 | `DEFAULT_ACCOUNT_ADDRESS` | CREATE2-derived (resolved at deployment) | Default wallet implementation for auto-delegation |
@@ -43,15 +43,15 @@ New signature algorithms are introduced through verifier contracts and standardi
 
 ### Account Configuration
 
-Each account can authorize a set of owners through the Account Configuration Contract at `ACCOUNT_CONFIG_ADDRESS`. This contract handles owner authorization, account creation, change sequencing, and delegates signature verification to onchain [Verifiers](#verifiers).
+Each account can authorize a set of actors through the Account Configuration Contract at `ACCOUNT_CONFIG_ADDRESS`. This contract handles actor authorization, account creation, change sequencing, and delegates signature verification to onchain [Verifiers](#verifiers).
 
-Owners are identified by their `ownerId`, a 32-byte identifier derived by the verifier from public key material. The protocol does not enforce a derivation algorithm — each verifier defines its own convention (see [ownerId Conventions](#ownerid-conventions)). Owners can be modified via calls within EVM execution by calling the authenticated config change functions.
+Actors are identified by their `actorId`, a 32-byte identifier derived by the verifier from public key material. The protocol does not enforce a derivation algorithm — each verifier defines its own convention (see [actorId Conventions](#actorid-conventions)). Actors can be modified via calls within EVM execution by calling the authenticated config change functions.
 
-**Default behavior**: The EOA owner is implicitly authorized by default but can be revoked on the contract.
+**Default behavior**: The EOA actor is implicitly authorized by default but can be revoked on the contract.
 
 #### Storage Layout
 
-Each owner occupies a single `owner_config` slot containing the verifier address (20 bytes) and a scope byte (1 byte) with 11 bytes reserved. The scope byte controls which authentication contexts the owner is valid for (see [Owner Scope](#owner-scope)). Non-EOA owners are revoked by deleting the `owner_config` slot. The implicit EOA owner (`ownerId == bytes32(bytes20(account))`) is revoked by overwriting the slot with `verifier = REVOKED_VERIFIER` (`type(uint160).max`), making it distinguishable from an empty (implicitly authorized) slot.
+Each actor occupies a single `actor_config` slot containing the verifier address (20 bytes) and a scope byte (1 byte) with 11 bytes reserved. The scope byte controls which authentication contexts the actor is valid for (see [Actor Scope](#actor-scope)). Non-EOA actors are revoked by deleting the `actor_config` slot. The implicit EOA actor (`actorId == bytes32(bytes20(account))`) is revoked by overwriting the slot with `verifier = REVOKED_VERIFIER` (`type(uint160).max`), making it distinguishable from an empty (implicitly authorized) slot.
 
 | Field | Bytes | Description |
 |-------|-------|-------------|
@@ -59,11 +59,11 @@ Each owner occupies a single `owner_config` slot containing the verifier address
 | `scope` | 20 | Permission bitmask (`0x00` = unrestricted) |
 | reserved | 21–31 | Reserved for future use (must be zero) |
 
-**Implicit EOA authorization**: An unregistered owner (`owner_config` slot is empty) is implicitly authorized if `ownerId == bytes32(bytes20(account))`. The empty slot's scope byte is `0x00` (unrestricted), granting full permissions by default. This allows every existing EOA to send AA transactions immediately without prior registration. When the implicit rule applies, the protocol verifies using native ecrecover rather than calling an external verifier contract. The implicit authorization is revoked by writing `REVOKED_VERIFIER` (`type(uint160).max`) to the verifier field, making the slot non-empty and blocking re-authorization. The EOA owner can also be explicitly registered with `ECRECOVER_VERIFIER` (`address(1)`) to set a custom scope while retaining native ecrecover verification.
+**Implicit EOA authorization**: An unregistered actor (`actor_config` slot is empty) is implicitly authorized if `actorId == bytes32(bytes20(account))`. The empty slot's scope byte is `0x00` (unrestricted), granting full permissions by default. This allows every existing EOA to send AA transactions immediately without prior registration. When the implicit rule applies, the protocol verifies using native ecrecover rather than calling an external verifier contract. The implicit authorization is revoked by writing `REVOKED_VERIFIER` (`type(uint160).max`) to the verifier field, making the slot non-empty and blocking re-authorization. The EOA actor can also be explicitly registered with `ECRECOVER_VERIFIER` (`address(1)`) to set a custom scope while retaining native ecrecover verification.
 
-#### Owner Scope
+#### Actor Scope
 
-The scope byte in `owner_config` is a permission bitmask that restricts which authentication contexts an owner can be used in. A value of `0x00` means unrestricted — the owner is valid in all contexts. Any non-zero value restricts the owner to contexts where the corresponding bit is set.
+The scope byte in `actor_config` is a permission bitmask that restricts which authentication contexts an actor can be used in. A value of `0x00` means unrestricted — the actor is valid in all contexts. Any non-zero value restricts the actor to contexts where the corresponding bit is set.
 
 | Bit | Value | Name | Context |
 |-----|-------|------|---------|
@@ -74,7 +74,7 @@ The scope byte in `owner_config` is a permission bitmask that restricts which au
 
 The protocol checks scope after verifier execution: `scope == 0x00 || (scope & context_bit) != 0`.
 
-The protocol validates signatures by reading `owner_config` directly and delegating authentication to [Verifiers](#verifiers) — see [Validation](#validation) for the full flow. Owner enumeration is performed off-chain via `OwnerAuthorized` / `OwnerRevoked` event logs. No owner count is enforced on-chain — gas costs naturally bound owner creation.
+The protocol validates signatures by reading `actor_config` directly and delegating authentication to [Verifiers](#verifiers) — see [Validation](#validation) for the full flow. Actor enumeration is performed off-chain via `ActorAuthorized` / `ActorRevoked` event logs. No actor count is enforced on-chain — gas costs naturally bound actor creation.
 
 #### 2D Nonce Storage
 
@@ -102,7 +102,7 @@ Nonce-free deduplication and replay protection MUST key on a **signature-invaria
 replay_id = keccak256(resolved_sender || sender_signature_hash)
 ```
 
-where `sender_signature_hash` is defined in [Signature Payload](#signature-payload) and `resolved_sender` is the sender address recovered via ecrecover (EOA path, where `sender` is empty in the wire format) or taken directly from the `sender` field (configured-owner path). Binding `resolved_sender` keeps the identifier unique per sender on the EOA path, where two distinct EOAs can sign identical transaction bodies.
+where `sender_signature_hash` is defined in [Signature Payload](#signature-payload) and `resolved_sender` is the sender address recovered via ecrecover (EOA path, where `sender` is empty in the wire format) or taken directly from the `sender` field (configured-actor path). Binding `resolved_sender` keeps the identifier unique per sender on the EOA path, where two distinct EOAs can sign identical transaction bodies.
 
 The full transaction hash MUST NOT be used for nonce-free deduplication. The transaction hash commits to `sender_auth` and `payer_auth` (the authorization blobs), whereas `replay_id` excludes both. Keying on the transaction hash would allow trivial duplication of a single logical transaction:
 
@@ -117,11 +117,11 @@ Account lock state is stored in a single packed 32-byte slot:
 
 | Field | Description |
 |-------|-------------|
-| `locked` | Owner configuration is frozen — config changes rejected |
+| `locked` | Actor configuration is frozen — config changes rejected |
 | `unlock_delay` | Seconds required between initiating unlock and becoming unlocked (`uint16`) |
 | `unlocks_at` | Timestamp when unlock takes effect (`uint40`, 0 = no unlock initiated) |
 
-When `locked` is set, all config changes are rejected — both config change entries in `account_changes` and `applySignedOwnerChanges()` via EVM. The lock cannot be removed without a timelock delay.
+When `locked` is set, all config changes are rejected — both config change entries in `account_changes` and `applySignedActorChanges()` via EVM. The lock cannot be removed without a timelock delay.
 
 Lock operations are called directly by the account (`msg.sender`) on the Account Configuration Contract.
 
@@ -137,15 +137,15 @@ This proposal uses the same delegation indicator behavior as [EIP-7702](./eip-77
 
 ### Verifiers
 
-Each owner is associated with a verifier, a contract that performs signature verification. The verifier address is stored in `owner_config`. All verifiers implement `IVerifier.verify(hash, data)`. Stateful verifiers MAY read transaction context (sender address, calls, payer) from the Transaction Context precompile at `TX_CONTEXT_ADDRESS` (see [Transaction Context](#transaction-context)). The protocol validates the returned `ownerId` against `owner_config` and checks the owner's scope against the authentication context.
+Each actor is associated with a verifier, a contract that performs signature verification. The verifier address is stored in `actor_config`. All verifiers implement `IVerifier.verify(hash, data)`. Stateful verifiers MAY read transaction context (sender address, calls, payer) from the Transaction Context precompile at `TX_CONTEXT_ADDRESS` (see [Transaction Context](#transaction-context)). The protocol validates the returned `actorId` against `actor_config` and checks the actor's scope against the authentication context.
 
 Verifiers are executed via STATICCALL. Verifier addresses MUST NOT be delegated accounts — reject if the code at the verifier address starts with the delegation indicator (`0xef0100`). Execution is metered (see [Mempool Acceptance](#mempool-acceptance) for rules).
 
 On the 8130 path, nodes MAY enshrine canonical verifier execution and charge standard gas targets for those verifiers. Enshrined execution MUST produce identical results to the corresponding verifier contract.
 
-`ECRECOVER_VERIFIER` (`address(1)`) is a protocol-reserved address for native secp256k1 verification. When the protocol encounters this address as a verifier in auth data, it performs ecrecover directly rather than making a STATICCALL. The `data` portion is interpreted as raw ECDSA `(r || s || v)`, and the returned `ownerId` is `bytes32(bytes20(recovered_address))`. Owners can be explicitly registered with `ECRECOVER_VERIFIER` to use native ecrecover with a custom scope, without requiring a deployed verifier contract.
+`ECRECOVER_VERIFIER` (`address(1)`) is a protocol-reserved address for native secp256k1 verification. When the protocol encounters this address as a verifier in auth data, it performs ecrecover directly rather than making a STATICCALL. The `data` portion is interpreted as raw ECDSA `(r || s || v)`, and the returned `actorId` is `bytes32(bytes20(recovered_address))`. Actors can be explicitly registered with `ECRECOVER_VERIFIER` to use native ecrecover with a custom scope, without requiring a deployed verifier contract.
 
-Any contract implementing `IVerifier` can be permissionlessly deployed and registered as an owner's verifier.
+Any contract implementing `IVerifier` can be permissionlessly deployed and registered as an actor's verifier.
 
 #### Canonical Verifier Set
 
@@ -168,9 +168,9 @@ This proposal supports three paths for accounts to use AA transactions:
 
 | Account Type | How It Works | Key Recovery |
 |--------------|--------------|--------------|
-| **Existing Smart Contracts** | Already-deployed accounts (e.g., ERC-4337 wallets) register owners via the system contract (see [Smart Wallet Migration Path](#smart-wallet-migration-path)) | Wallet-defined |
+| **Existing Smart Contracts** | Already-deployed accounts (e.g., ERC-4337 wallets) register actors via the system contract (see [Smart Wallet Migration Path](#smart-wallet-migration-path)) | Wallet-defined |
 | **EOAs** | EOAs send AA transactions using their existing secp256k1 key via native ecrecover. If the account has no code, the protocol auto-delegates to `DEFAULT_ACCOUNT_ADDRESS` (see [Block Execution](#block-execution)). Accounts MAY override with a delegation entry in `account_changes` or a standard [EIP-7702](./eip-7702.md) transaction | Wallet-defined; EOA recoverable via 1559/7702 transaction flows |
-| **New Accounts (No EOA)** | Created via a create entry in `account_changes` with CREATE2 address derivation; runtime bytecode placed at address, owners + verifiers configured, `calls` handles initialization | Wallet-defined |
+| **New Accounts (No EOA)** | Created via a create entry in `account_changes` with CREATE2 address derivation; runtime bytecode placed at address, actors + verifiers configured, `calls` handles initialization | Wallet-defined |
 
 ### AA Transaction Type
 
@@ -201,14 +201,14 @@ call = rlp([to, data])   // to: address, data: bytes
 | Field | Description |
 |-------|-------------|
 | `chain_id` | Chain ID per [EIP-155](./eip-155.md) |
-| `sender` | Sending account address. **Required** (non-empty) for configured owner signatures. **Empty** for EOA signatures—address recovered via ecrecover. The presence or absence of `sender` is the sole distinguisher between EOA and configured owner signatures. |
+| `sender` | Sending account address. **Required** (non-empty) for configured actor signatures. **Empty** for EOA signatures—address recovered via ecrecover. The presence or absence of `sender` is the sole distinguisher between EOA and configured actor signatures. |
 | `nonce_key` | `uint256` nonce channel selector. `0` for standard sequential ordering, `1` through `NONCE_KEY_MAX - 1` for parallel channels, `NONCE_KEY_MAX` for nonce-free mode. |
 | `nonce_sequence` | `uint64` expected sequence number within `nonce_key`. Must match current sequence for `(sender, nonce_key)`. Incremented after inclusion regardless of execution outcome. Must be `0` when `nonce_key == NONCE_KEY_MAX`. |
 | `expiry` | Unix timestamp (seconds since epoch). Transaction invalid when `block.timestamp > expiry`. A value of `0` means no expiry. Must be non-zero when `nonce_key == NONCE_KEY_MAX`. |
 | `max_priority_fee_per_gas` | Priority fee per gas unit ([EIP-1559](./eip-1559.md)) |
 | `max_fee_per_gas` | Maximum fee per gas unit ([EIP-1559](./eip-1559.md)) |
 | `gas_limit` | Maximum gas budget for intrinsic costs, sender authentication, account changes, and call execution (see [Intrinsic Gas](#intrinsic-gas)). Payer authentication is metered separately. |
-| `account_changes` | **Empty**: No account changes. **Non-empty**: Array of typed entries — create (type `0x00`) for account deployment, config change (type `0x01`) for owner management, and delegation (type `0x02`) for code delegation. See [Account Changes](#account-changes) |
+| `account_changes` | **Empty**: No account changes. **Non-empty**: Array of typed entries — create (type `0x00`) for account deployment, config change (type `0x01`) for actor management, and delegation (type `0x02`) for code delegation. See [Account Changes](#account-changes) |
 | `calls` | **Empty**: No calls. **Non-empty**: Array of call phases — see [Call Execution](#call-execution) |
 | `payer` | Gas payer identity. **Empty**: Sender pays. **20-byte address**: This specific payer required. See [Payer Modes](#payer-modes) |
 | `sender_auth` | See [Signature Format](#signature-format) |
@@ -225,7 +225,7 @@ All `sender_gas` components consume `gas_limit`; intrinsic costs are charged bef
 
 The sender verifier runs first, and its metered cost is included in `gas_limit`. This lets the payer sign a single maximum sender-side gas exposure without committing to the sender's verifier choice. Payer authentication is chosen by the payer and metered separately.
 
-**`sender_auth_cost`**: For EOA signatures (`sender` empty) or `ECRECOVER_VERIFIER` (`address(1)`) signatures: 6,000 gas (ecrecover + 1 SLOAD + overhead). For other configured owner signatures (`sender` set, `address(2+)` verifier): 1 SLOAD (`owner_config`) + cold code access + actual gas consumed by verifier execution.
+**`sender_auth_cost`**: For EOA signatures (`sender` empty) or `ECRECOVER_VERIFIER` (`address(1)`) signatures: 6,000 gas (ecrecover + 1 SLOAD + overhead). For other configured actor signatures (`sender` set, `address(2+)` verifier): 1 SLOAD (`actor_config`) + cold code access + actual gas consumed by verifier execution.
 
 **`payer_auth_cost`**: 0 for self-pay (`payer` empty). Otherwise, the same `sender_auth_cost` model applies to the payer's verifier.
 
@@ -243,7 +243,7 @@ Signature format is determined by the `sender` field:
 
 **EOA signature** (`sender` empty): Raw 65-byte ECDSA signature `(r || s || v)`. The sender address is recovered via ecrecover.
 
-**Configured owner signature** (`sender` set):
+**Configured actor signature** (`sender` set):
 
 ```
 verifier (20 bytes) || data
@@ -253,11 +253,11 @@ The first 20 bytes identify the verifier address. When the verifier is `ECRECOVE
 
 ##### Validation
 
-1. **Resolve sender**: If `sender` empty, ecrecover derives the sender address (EOA path) with `ownerId = bytes32(bytes20(sender))`. If `sender` set, read the first 20 bytes of `sender_auth` as the verifier address.
+1. **Resolve sender**: If `sender` empty, ecrecover derives the sender address (EOA path) with `actorId = bytes32(bytes20(sender))`. If `sender` set, read the first 20 bytes of `sender_auth` as the verifier address.
 2. **Set transaction context**: Populate the Transaction Context precompile with sender, payer, and calls (see [Transaction Context](#transaction-context)).
-3. **Verify**: Route by verifier address. For the EOA path (`sender` empty), ecrecover was already performed in step 1. For `ECRECOVER_VERIFIER` (`address(1)`), the protocol natively ecrecovers from `data` (as `r || s || v`), returning `ownerId = bytes32(bytes20(recovered_address))`. For all other verifiers (`address(2+)`), call `verifier.verify(hash, data)` via STATICCALL, returning `ownerId` (or `bytes32(0)` for invalid). Reject `REVOKED_VERIFIER` as a verifier address.
-4. **Authorize**: SLOAD `owner_config(sender, ownerId)`. **Implicit EOA rule**: if the slot is empty, `ownerId == bytes32(bytes20(sender))`, and verification in step 3 used the native secp256k1 path (the EOA path or `ECRECOVER_VERIFIER`), treat as implicitly authorized with scope `0x00`. Otherwise, require that the stored verifier address matches the effective verifier and is not `REVOKED_VERIFIER`.
-5. **Check scope**: Read the scope byte from `owner_config` (or `0x00` for the implicit case). Determine the context bit: `0x02` (SENDER) for `sender_auth`, `0x04` (PAYER) for `payer_auth`, `0x01` (SIGNATURE) for `verifySignature()`, `0x08` (CONFIG) for config change `auth`. Require `scope == 0x00 || (scope & context_bit) != 0`.
+3. **Verify**: Route by verifier address. For the EOA path (`sender` empty), ecrecover was already performed in step 1. For `ECRECOVER_VERIFIER` (`address(1)`), the protocol natively ecrecovers from `data` (as `r || s || v`), returning `actorId = bytes32(bytes20(recovered_address))`. For all other verifiers (`address(2+)`), call `verifier.verify(hash, data)` via STATICCALL, returning `actorId` (or `bytes32(0)` for invalid). Reject `REVOKED_VERIFIER` as a verifier address.
+4. **Authorize**: SLOAD `actor_config(sender, actorId)`. **Implicit EOA rule**: if the slot is empty, `actorId == bytes32(bytes20(sender))`, and verification in step 3 used the native secp256k1 path (the EOA path or `ECRECOVER_VERIFIER`), treat as implicitly authorized with scope `0x00`. Otherwise, require that the stored verifier address matches the effective verifier and is not `REVOKED_VERIFIER`.
+5. **Check scope**: Read the scope byte from `actor_config` (or `0x00` for the implicit case). Determine the context bit: `0x02` (SENDER) for `sender_auth`, `0x04` (PAYER) for `payer_auth`, `0x01` (SIGNATURE) for `verifySignature()`, `0x08` (CONFIG) for config change `auth`. Require `scope == 0x00 || (scope & context_bit) != 0`.
 
 #### Signature Payload
 
@@ -302,58 +302,58 @@ Gas payment and sponsorship are controlled by two independent fields:
 | `payer` | `payer_auth` | Payer Address | Validation |
 |---------|-------------|---------------|------------|
 | empty | empty | `sender` | Self-pay — no payer validation |
-| address | `verifier (20) \|\| data` | `payer` field | Sponsored — any verifier. Reads payer's `owner_config`, validates against `payer` address |
+| address | `verifier (20) \|\| data` | `payer` field | Sponsored — any verifier. Reads payer's `actor_config`, validates against `payer` address |
 
-Any authorized owner with SENDER scope can sign self-pay transactions.
+Any authorized actor with SENDER scope can sign self-pay transactions.
 
 ### Account Changes
 
-The `account_changes` field is an array of typed entries for account creation and owner management:
+The `account_changes` field is an array of typed entries for account creation and actor management:
 
 | Type | Name | Description |
 |------|------|-------------|
-| `0x00` | Create | Deploy a new account with initial owners (must be first, at most one) |
-| `0x01` | Config change | Owner management: authorizeOwner, revokeOwner |
+| `0x00` | Create | Deploy a new account with initial actors (must be first, at most one) |
+| `0x01` | Config change | Actor management: authorizeActor, revokeActor |
 | `0x02` | Delegation | Set code delegation via the delegation indicator (at most one per account) |
 
-Create and delegation entries are authorized by the transaction's `sender_auth` — there is no separate authorization field. The initial `ownerId`s for create entries are salt-committed to the derived address. Delegation requires the sender to be the account's implicit EOA owner with CONFIG scope. Config change entries carry their own `auth` and use a sequence counter for deterministic cross-chain ordering. Nodes SHOULD enforce a configurable per-transaction limit on the number of config change entries (mempool rule).
+Create and delegation entries are authorized by the transaction's `sender_auth` — there is no separate authorization field. The initial `actorId`s for create entries are salt-committed to the derived address. Delegation requires the sender to be the account's implicit EOA actor with CONFIG scope. Config change entries carry their own `auth` and use a sequence counter for deterministic cross-chain ordering. Nodes SHOULD enforce a configurable per-transaction limit on the number of config change entries (mempool rule).
 
 #### Create Entry
 
-New smart contract accounts can be created with pre-configured owners in a single transaction. The `code` is placed directly at the account address — it is not executed during deployment. The account's initialization logic runs via `calls` in the execution phase that follows:
+New smart contract accounts can be created with pre-configured actors in a single transaction. The `code` is placed directly at the account address — it is not executed during deployment. The account's initialization logic runs via `calls` in the execution phase that follows:
 
 ```
 rlp([
   0x00,               // type: create
   user_salt,          // bytes32: User-chosen uniqueness factor
   code,               // bytes: Runtime bytecode placed at account address
-  initial_owners      // Array of [verifier, ownerId, scope] tuples
+  initial_actors      // Array of [verifier, actorId, scope] tuples
 ])
 ```
 
-Initial owners are registered with their specified scope. Wallet initialization code can lock the account via `calls` in the execution phase (e.g., calling `lock()` on the Account Configuration Contract).
+Initial actors are registered with their specified scope. Wallet initialization code can lock the account via `calls` in the execution phase (e.g., calling `lock()` on the Account Configuration Contract).
 
 The `code` field contains runtime bytecode placed directly at the account address. For delegation, use a delegation entry (type `0x02`) in `account_changes` after account creation.
 
 ```
-[0x00, user_salt, runtimeBytecode, initial_owners]
+[0x00, user_salt, runtimeBytecode, initial_actors]
 ```
 
 ##### Address Derivation
 
-Addresses are derived using the CREATE2 address formula with the Account Configuration Contract (`ACCOUNT_CONFIG_ADDRESS`) as the deployer. The `initial_owners` are sorted by `ownerId` before hashing to ensure address derivation is order-independent (the same set of owners always produces the same address regardless of the order specified):
+Addresses are derived using the CREATE2 address formula with the Account Configuration Contract (`ACCOUNT_CONFIG_ADDRESS`) as the deployer. The `initial_actors` are sorted by `actorId` before hashing to ensure address derivation is order-independent (the same set of actors always produces the same address regardless of the order specified):
 
 ```
-sorted_owners = sort(initial_owners, by: ownerId)
+sorted_actors = sort(initial_actors, by: actorId)
 
-owners_commitment = keccak256(ownerId_0 || verifier_0 || scope_0 || ownerId_1 || verifier_1 || scope_1 || ... || ownerId_n || verifier_n || scope_n)
+actors_commitment = keccak256(actorId_0 || verifier_0 || scope_0 || actorId_1 || verifier_1 || scope_1 || ... || actorId_n || verifier_n || scope_n)
 
-effective_salt = keccak256(user_salt || owners_commitment)
+effective_salt = keccak256(user_salt || actors_commitment)
 deployment_code = DEPLOYMENT_HEADER(len(code)) || code
 address = keccak256(0xff || ACCOUNT_CONFIG_ADDRESS || effective_salt || keccak256(deployment_code))[12:]
 ```
 
-The `owners_commitment` uses `ownerId || verifier || scope` (53 bytes) per owner — consistent with how the Account Configuration Contract identifies and configures owners.
+The `actors_commitment` uses `actorId || verifier || scope` (53 bytes) per actor — consistent with how the Account Configuration Contract identifies and configures actors.
 
 `DEPLOYMENT_HEADER(n)` is a fixed 14-byte EVM loader that returns the trailing code (see [Appendix: Deployment Header](#appendix-deployment-header) for the full opcode sequence). On non-8130 chains, `createAccount()` constructs `deployment_code` and passes it as init_code to CREATE2. On 8130 chains, the protocol constructs the same `deployment_code` for address derivation but places `code` directly (no execution). Both paths produce the same address — callers only provide `code`; the header is never user-facing.
 
@@ -363,21 +363,21 @@ Users can receive funds at counterfactual addresses before account creation.
 
 When a create entry is present in `account_changes`:
 
-1. Parse `[0x00, user_salt, code, initial_owners]` where each entry is `[verifier, ownerId, scope]`
-2. Reject if any duplicate `ownerId` values exist
+1. Parse `[0x00, user_salt, code, initial_actors]` where each entry is `[verifier, actorId, scope]`
+2. Reject if any duplicate `actorId` values exist
 3. Reject if `code` is empty or `len(code) > MAX_CODE_SIZE` ([EIP-170](./eip-170.md): 24576 bytes), to keep the placed code within the EVM contract size limit that CREATE/CREATE2 would otherwise enforce
-4. Sort by ownerId: `sorted_owners = sort(initial_owners, by: ownerId)`
-5. Compute `owners_commitment = keccak256(ownerId_0 || verifier_0 || scope_0 || ... || ownerId_n || verifier_n || scope_n)`
-6. Compute `effective_salt = keccak256(user_salt || owners_commitment)`
+4. Sort by actorId: `sorted_actors = sort(initial_actors, by: actorId)`
+5. Compute `actors_commitment = keccak256(actorId_0 || verifier_0 || scope_0 || ... || actorId_n || verifier_n || scope_n)`
+6. Compute `effective_salt = keccak256(user_salt || actors_commitment)`
 7. Compute `deployment_code = DEPLOYMENT_HEADER(len(code)) || code`
 8. Compute `expected = keccak256(0xff || ACCOUNT_CONFIG_ADDRESS || effective_salt || keccak256(deployment_code))[12:]`
 9. Require `sender == expected`
 10. Require the destination matches CREATE2 freshness: `code_size(sender) == 0` and `nonce(sender) == 0` (matching the conditions under which CREATE2 would be permitted to deploy)
-11. Validate `sender_auth` against one of `initial_owners` (ownerId resolved from auth must match an entry's ownerId)
+11. Validate `sender_auth` against one of `initial_actors` (actorId resolved from auth must match an entry's actorId)
 
 #### Config Change Entry
 
-Config change entries manage the account's owners. Each entry includes a `chain_id` field where `0` means valid on any chain, allowing replay across chains to synchronize owner state.
+Config change entries manage the account's actors. Each entry includes a `chain_id` field where `0` means valid on any chain, allowing replay across chains to synchronize actor state.
 
 ##### Config Change Format
 
@@ -386,15 +386,15 @@ rlp([
   0x01,               // type: config change
   chain_id,           // uint64: 0 = valid on any chain
   sequence,           // uint64: monotonic ordering
-  owner_changes,      // Array of owner changes
-  auth                // Signature from an owner valid at this sequence
+  actor_changes,      // Array of actor changes
+  auth                // Signature from an actor valid at this sequence
 ])
 
-owner_change = rlp([
+actor_change = rlp([
   change_type,          // uint8: operation type (see below)
-  verifier,             // address: verifier contract (authorizeOwner only)
-  ownerId,              // bytes32: owner identifier
-  scope                 // uint8: permission bitmask (authorizeOwner only, 0x00 = unrestricted)
+  verifier,             // address: verifier contract (authorizeActor only)
+  actorId,              // bytes32: actor identifier
+  scope                 // uint8: permission bitmask (authorizeActor only, 0x00 = unrestricted)
 ])
 ```
 
@@ -402,12 +402,12 @@ owner_change = rlp([
 
 | change_type | Name | Description | Fields Used |
 |-------------|------|-------------|-------------|
-| `0x01` | `authorizeOwner` | Authorize a new owner with scope | `verifier`, `ownerId`, `scope` |
-| `0x02` | `revokeOwner` | Revoke an existing owner — deletes the slot for non-EOA owners; for the implicit EOA owner (`ownerId == bytes32(bytes20(account))`), overwrites with `verifier = REVOKED_VERIFIER` (`type(uint160).max`) to prevent implicit re-authorization | `ownerId` |
+| `0x01` | `authorizeActor` | Authorize a new actor with scope | `verifier`, `actorId`, `scope` |
+| `0x02` | `revokeActor` | Revoke an existing actor — deletes the slot for non-EOA actors; for the implicit EOA actor (`actorId == bytes32(bytes20(account))`), overwrites with `verifier = REVOKED_VERIFIER` (`type(uint160).max`) to prevent implicit re-authorization | `actorId` |
 
 #### Config Change Authorization
 
-Each config change entry represents a set of operations authorized at a specific sequence number. The `auth` must be valid against the account's owner configuration *at the point after all previous entries in the list have been applied*. The authorizing owner must have CONFIG scope (see [Owner Scope](#owner-scope)).
+Each config change entry represents a set of operations authorized at a specific sequence number. The `auth` must be valid against the account's actor configuration *at the point after all previous entries in the list have been applied*. The authorizing actor must have CONFIG scope (see [Actor Scope](#actor-scope)).
 
 The sequence number is scoped by `chain_id`: `0` uses the multichain sequence channel (valid on any chain), while a specific `chain_id` uses that chain's local channel.
 
@@ -416,35 +416,35 @@ The sequence number is scoped by `chain_id`: `0` uses the multichain sequence ch
 Entry signatures use ABI-encoded type hashing. Operations within an entry are individually ABI-encoded and hashed into an array digest:
 
 ```
-TYPEHASH = keccak256("SignedOwnerChanges(address account,uint64 chainId,uint64 sequence,OwnerChange[] ownerChanges)OwnerChange(uint8 changeType,address verifier,bytes32 ownerId,uint8 scope)")
+TYPEHASH = keccak256("SignedActorChanges(address account,uint64 chainId,uint64 sequence,ActorChange[] actorChanges)ActorChange(uint8 changeType,address verifier,bytes32 actorId,uint8 scope)")
 
-ownerChangeHashes = [keccak256(abi.encode(changeType, verifier, ownerId, scope)) for each ownerChange]
-ownerChangesHash = keccak256(abi.encodePacked(ownerChangeHashes))
+actorChangeHashes = [keccak256(abi.encode(changeType, verifier, actorId, scope)) for each actorChange]
+actorChangesHash = keccak256(abi.encodePacked(actorChangeHashes))
 
-digest = keccak256(abi.encode(TYPEHASH, account, chainId, sequence, ownerChangesHash))
+digest = keccak256(abi.encode(TYPEHASH, account, chainId, sequence, actorChangesHash))
 ```
 
 Domain separation from transaction signatures (`AA_TX_TYPE`, `AA_PAYER_TYPE`) is structural — transaction hashes use `keccak256(type_byte || rlp([...]))`, which cannot produce the same prefix as `abi.encode(TYPEHASH, ...)`.
 
-The `auth` follows the same [Signature Format](#signature-format) as `sender_auth` (`verifier || data`), validated against the account's owner state at that point in the sequence.
+The `auth` follows the same [Signature Format](#signature-format) as `sender_auth` (`verifier || data`), validated against the account's actor state at that point in the sequence.
 
 ##### Account Config Change Paths
 
-Owners can be modified through two portable paths:
+Actors can be modified through two portable paths:
 
-| | `account_changes` (tx field) | `applySignedOwnerChanges()` (EVM) |
+| | `account_changes` (tx field) | `applySignedActorChanges()` (EVM) |
 |--|---|---|
-| Authorization | Signed operation (any verifier) | Direct verification via verifier + `owner_config` |
+| Authorization | Signed operation (any verifier) | Direct verification via verifier + `actor_config` |
 | Availability | Always (8130 chains) | Always (any chain) |
 | Portability | Cross-chain (chain_id 0) or chain-specific | Cross-chain (chain_id 0) or chain-specific |
 | Sequence | Increments channel's `change_sequence` | Increments channel's `change_sequence` |
 | When processed | Before code deployment (8130 only) | During EVM execution (any chain) |
 
-Both paths share the same signed owner changes and `change_sequence` counters. `applySignedOwnerChanges()` parses the verifier address from `auth`, calls the verifier to get the `ownerId`, and checks `owner_config`. Anyone can call these functions; authorization comes from the signed operation, not the caller. All owner modification paths are blocked when the account is locked (see [Account Lock](#account-lock)).
+Both paths share the same signed actor changes and `change_sequence` counters. `applySignedActorChanges()` parses the verifier address from `auth`, calls the verifier to get the `actorId`, and checks `actor_config`. Anyone can call these functions; authorization comes from the signed operation, not the caller. All actor modification paths are blocked when the account is locked (see [Account Lock](#account-lock)).
 
 #### Delegation Entry
 
-Delegation entries set [EIP-7702](./eip-7702.md)-style code delegation for the sender's account, replacing the need for an `authorization_list` in the transaction. Delegation is authorized by the transaction's `sender_auth` — no separate signature is required. The sender must be the account's implicit EOA owner (`ownerId == bytes32(bytes20(sender))`) with CONFIG scope.
+Delegation entries set [EIP-7702](./eip-7702.md)-style code delegation for the sender's account, replacing the need for an `authorization_list` in the transaction. Delegation is authorized by the transaction's `sender_auth` — no separate signature is required. The sender must be the account's implicit EOA actor (`actorId == bytes32(bytes20(sender))`) with CONFIG scope.
 
 ##### Delegation Format
 
@@ -472,9 +472,9 @@ For 8130 transactions, successful delegation updates emit a protocol-injected `D
 
 `account_changes` entries are processed in order before call execution:
 
-1. **Create entry** (if present): Register `initial_owners` in Account Config storage for `sender` — for each `[verifier, ownerId, scope]` tuple, write `owner_config` (verifier address and scope byte). Initialize lock state to safe defaults: `locked = false`, `unlock_delay = 0`, `unlocks_at = 0`.
+1. **Create entry** (if present): Register `initial_actors` in Account Config storage for `sender` — for each `[verifier, actorId, scope]` tuple, write `actor_config` (verifier address and scope byte). Initialize lock state to safe defaults: `locked = false`, `unlock_delay = 0`, `unlocks_at = 0`.
 2. **Config change entries** (if any): Apply operations in entry order. Reject transaction if account is locked.
-3. **Delegation entries** (if any): Require the sender's resolved `ownerId == bytes32(bytes20(sender))` (EOA owner) with CONFIG scope. Reject if account is locked. For each entry, set `code(sender) = 0xef0100 || target` (or clear if `target` is `address(0)`). Reject if account has non-delegation bytecode.
+3. **Delegation entries** (if any): Require the sender's resolved `actorId == bytes32(bytes20(sender))` (EOA actor) with CONFIG scope. Reject if account is locked. For each entry, set `code(sender) = 0xef0100 || target` (or clear if `target` is `address(0)`). Reject if account has non-delegation bytecode.
 4. **Code placement** (if create entry present): Place `code` at `sender`. The runtime bytecode is placed directly — not executed.
 
 ### Execution
@@ -508,14 +508,14 @@ The Transaction Context precompile at `TX_CONTEXT_ADDRESS` provides read-only ac
 
 | Function | Returns | Available |
 |----------|---------|-----------|
-| `getSender()` | `address` — the account being validated (`sender`) | Validation + Execution |
-| `getPayer()` | `address` — gas payer (`sender` for self-pay, payer for sponsored) | Validation + Execution |
-| `getOwnerId()` | `bytes32` — authenticated owner's ownerId | Execution only |
-| `getCalls()` | `Call[][]` — full calls array | Validation + Execution |
-| `getMaxCost()` | `uint256` — `gas_limit * max_fee_per_gas`, excluding separately metered `payer_auth_cost` | Validation + Execution |
-| `getGasLimit()` | `uint256` — sender-side gas budget (`gas_limit`) before intrinsic costs and call execution | Validation + Execution |
+| `getTransactionSender()` | `address` — the account being validated (`sender`) | Validation + Execution |
+| `getTransactionPayer()` | `address` — gas payer (`sender` for self-pay, payer for sponsored) | Validation + Execution |
+| `getTransactionSenderActorId()` | `bytes32` — authenticated actor's actorId | Execution only |
+| `getTransactionCalls()` | `Call[][]` — full calls array | Validation + Execution |
+| `getTransactionMaxCost()` | `uint256` — `gas_limit * max_fee_per_gas`, excluding separately metered `payer_auth_cost` | Validation + Execution |
+| `getTransactionGasLimit()` | `uint256` — sender-side gas budget (`gas_limit`) before intrinsic costs and call execution | Validation + Execution |
 
-If the wallet needs the verifier address or scope, it calls `getOwnerConfig(account, ownerId)` on the Account Configuration Contract.
+If the wallet needs the verifier address or scope, it calls `getActorConfig(account, actorId)` on the Account Configuration Contract.
 
 **Non-8130 chains**: No code at `TX_CONTEXT_ADDRESS`; STATICCALL returns zero/default values.
 
@@ -539,14 +539,14 @@ All contracts are deployed at deterministic CREATE2 addresses across chains.
 
 1. Parse and structurally validate `sender_auth`. Verify `account_changes` contains at most one create entry (type `0x00`, must be first) and at most one delegation entry (type `0x02`). Nodes SHOULD enforce a configurable limit on the number of config change entries (type `0x01`).
 2. Resolve sender: if `sender` set, use it; if empty, ecrecover from `sender_auth`
-3. Determine effective owner state:
-   a. If create entry present in `account_changes`: verify address derivation, `code_size(sender) == 0`, use `initial_owners`
+3. Determine effective actor state:
+   a. If create entry present in `account_changes`: verify address derivation, `code_size(sender) == 0`, use `initial_actors`
    b. Else: read from Account Config storage
 4. If config change or delegation entries present in `account_changes`: reject if account is locked (see [Account Lock](#account-lock)). For config change entries: simulate applying operations in sequence, skip already-applied entries. For delegation entries: verify `code_size(sender) == 0` or existing delegation designator.
-5. Validate `sender_auth` against resulting owner state (see [Validation](#validation)). Require SENDER scope on the resolved owner. If delegation entries are present, also require `ownerId == bytes32(bytes20(sender))` (EOA owner) and CONFIG scope.
+5. Validate `sender_auth` against resulting actor state (see [Validation](#validation)). Require SENDER scope on the resolved actor. If delegation entries are present, also require `actorId == bytes32(bytes20(sender))` (EOA actor) and CONFIG scope.
 6. Resolve payer from `payer` and `payer_auth`:
    - `payer` empty and `payer_auth` empty: self-pay. Payer is `sender`. Reject if balance insufficient.
-   - `payer` = 20-byte address (sponsored): `payer_auth` uses any verifier. Validate `payer_auth` against the `payer` address's `owner_config`. Require PAYER scope on the resolved owner.
+   - `payer` = 20-byte address (sponsored): `payer_auth` uses any verifier. Validate `payer_auth` against the `payer` address's `actor_config`. Require PAYER scope on the resolved actor.
 7. Verify nonce, payer ETH balance, and expiry:
    - **Standard keys** (`nonce_key != NONCE_KEY_MAX`): require `nonce_sequence == current_sequence(sender, nonce_key)`.
    - **Nonce-free key** (`nonce_key == NONCE_KEY_MAX`): skip nonce check, require `nonce_sequence == 0`, require non-zero `expiry`, and nodes SHOULD reject if `expiry` exceeds a short window (e.g., 10 seconds). Deduplicate by the [Nonce-Free Replay Identifier](#nonce-free-replay-identifier) (`replay_id`), not the full transaction hash.
@@ -563,15 +563,15 @@ Nodes MAY apply higher pending transaction rate limits based on account lock sta
 
 #### Block Execution
 
-1. If `account_changes` contains config change or delegation entries, read lock state for `sender`. Reject transaction if account is locked. If delegation entries are present, require the sender's resolved `ownerId == bytes32(bytes20(sender))` (EOA owner) with CONFIG scope.
+1. If `account_changes` contains config change or delegation entries, read lock state for `sender`. Reject transaction if account is locked. If delegation entries are present, require the sender's resolved `actorId == bytes32(bytes20(sender))` (EOA actor) with CONFIG scope.
 2. ETH gas deduction from payer (sponsor for sponsored, `sender` for self-pay). Transaction is invalid if payer has insufficient balance.
 3. If `nonce_key != NONCE_KEY_MAX`, increment nonce in Nonce Manager storage for `(sender, nonce_key)`. If `nonce_key == NONCE_KEY_MAX`, skip (nonce-free mode).
 4. If `code_size(sender) == 0` and no create entry and no delegation entry is present in `account_changes`, auto-delegate `sender` to `DEFAULT_ACCOUNT_ADDRESS` (set code to `0xef0100 || DEFAULT_ACCOUNT_ADDRESS`). This delegation persists.
 5. Process `account_changes` entries in order (see [Execution (Account Changes)](#execution-account-changes)).
-6. Set transaction context on the Transaction Context precompile (sender, payer, ownerId, calls).
+6. Set transaction context on the Transaction Context precompile (sender, payer, actorId, calls).
 7. Execute `calls` per [Call Execution](#call-execution) semantics.
 
-Unused gas from `gas_limit` is refunded to the payer. Intrinsic gas, excluding separately metered `payer_auth_cost`, consumes `gas_limit` before call execution. For step 5, the protocol SHOULD inject log entries into the transaction receipt (e.g., `OwnerAuthorized`, `AccountCreated`, `DelegationApplied`) matching the events defined in the [IAccountConfiguration](#iaccountconfiguration) interface, following the protocol-injected log pattern established by [EIP-7708](./eip-7708.md). These protocol-injected logs are emitted only for 8130 transactions.
+Unused gas from `gas_limit` is refunded to the payer. Intrinsic gas, excluding separately metered `payer_auth_cost`, consumes `gas_limit` before call execution. For step 5, the protocol SHOULD inject log entries into the transaction receipt (e.g., `ActorAuthorized`, `AccountCreated`, `DelegationApplied`) matching the events defined in the [IAccountConfiguration](#iaccountconfiguration) interface, following the protocol-injected log pattern established by [EIP-7708](./eip-7708.md). These protocol-injected logs are emitted only for 8130 transactions.
 
 ### RPC Extensions
 
@@ -609,7 +609,7 @@ The create entry only supports runtime bytecode. Delegation is set via delegatio
 
 ### Why Verifier Contracts?
 
-Enables signature-algorithm extension through verifier contracts. The verifier returns the `ownerId` rather than accepting it as input, so the protocol never needs algorithm-specific logic. All verifiers share a single `verify(hash, data)` interface with no type-based dispatch. Owner scope provides protocol-enforced role separation without verifier cooperation.
+Enables signature-algorithm extension through verifier contracts. The verifier returns the `actorId` rather than accepting it as input, so the protocol never needs algorithm-specific logic. All verifiers share a single `verify(hash, data)` interface with no type-based dispatch. Actor scope provides protocol-enforced role separation without verifier cooperation.
 
 ### Why 2D Nonce + `NONCE_KEY_MAX`?
 
@@ -619,13 +619,13 @@ Additional `nonce_key` values allow parallel transaction lanes without nonce con
 
 ### Why a Nonce Precompile?
 
-Nonce state is isolated in a dedicated precompile (`NONCE_MANAGER_ADDRESS`) because nonce writes occur on nearly every AA transaction, while owner config writes are relatively infrequent.
+Nonce state is isolated in a dedicated precompile (`NONCE_MANAGER_ADDRESS`) because nonce writes occur on nearly every AA transaction, while actor config writes are relatively infrequent.
 
 The Nonce Manager has no EVM-writable state and no portability requirement — a precompile is simpler than exposing nonce mutation through the account config contract.
 
 ### Why a Transaction Context Precompile?
 
-Transaction context (sender, payer, calls, gas) is immutable transaction metadata — it never changes during execution. `ownerId` is set after validation and available during execution only. A precompile is the natural fit:
+Transaction context (sender, payer, calls, gas) is immutable transaction metadata — it never changes during execution. `actorId` is set after validation and available during execution only. A precompile is the natural fit:
 
 - **Zero protocol write cost**: The precompile reads directly from the client's in-memory transaction struct — no HashMap insert, no journaling, no rollback tracking.
 - **Pull model**: Verifiers read only what they need. Pure verifiers pay nothing for context they don't use.
@@ -635,17 +635,17 @@ Transaction context (sender, payer, calls, gas) is immutable transaction metadat
 
 The create entry uses the CREATE2 address formula with `ACCOUNT_CONFIG_ADDRESS` as the deployer address for cross-chain portability:
 
-1. **Deterministic addresses**: Same `user_salt + code + initial_owners` produces the same address on any chain
+1. **Deterministic addresses**: Same `user_salt + code + initial_actors` produces the same address on any chain
 2. **Pre-deployment funding**: Users can receive funds at counterfactual addresses before account creation
 3. **Portability**: Same `deployment_code` produces the same address on both 8130 and non-8130 chains (see [Address Derivation](#address-derivation))
-4. **Front-running prevention**: `initial_owners` in the salt prevents attackers from deploying with different owners (see [Create Entry](#create-entry))
+4. **Front-running prevention**: `initial_actors` in the salt prevents attackers from deploying with different actors (see [Create Entry](#create-entry))
 
 ### Smart Wallet Migration Path
 
 Existing ERC-4337 smart accounts migrate to native AA without redeployment:
 
-1. **Import account**: Call `importAccount()` on the Account Configuration Contract — this verifies via the account's `isValidSignature` ([ERC-1271](./eip-1271.md)) and registers initial owners. Existing ERC-4337 wallets already implement ERC-1271, so initial owner registration works without code changes.
-2. **Upgrade wallet logic**: Update contract to delegate `isValidSignature` to the Account Configuration Contract's `verifySignature()` function for owner and verifier infrastructure, and read `getOwnerId()` from the Transaction Context precompile during execution to identify which owner authorized the transaction
+1. **Import account**: Call `importAccount()` on the Account Configuration Contract — this verifies via the account's `isValidSignature` ([ERC-1271](./eip-1271.md)) and registers initial actors. Existing ERC-4337 wallets already implement ERC-1271, so initial actor registration works without code changes.
+2. **Upgrade wallet logic**: Update contract to delegate `isValidSignature` to the Account Configuration Contract's `verifySignature()` function for actor and verifier infrastructure, and read `getTransactionSenderActorId()` from the Transaction Context precompile during execution to identify which actor authorized the transaction
 3. **Backwards compatible**: Wallet can still accept ERC-4337 UserOps via EntryPoint alongside native AA transactions
 
 ### Why Call Phases?
@@ -658,7 +658,7 @@ Phases provide two atomic batching levels without per-call mode flags:
 
 ### Why Direct Dispatch?
 
-The protocol dispatches each call directly to the specified `to` address with `msg.sender = sender`. Owners with SENDER scope are authorized to send transactions at the protocol level. Every account has wallet bytecode (via auto-delegation or explicit deployment), so calls route through the wallet for ETH-carrying operations.
+The protocol dispatches each call directly to the specified `to` address with `msg.sender = sender`. Actors with SENDER scope are authorized to send transactions at the protocol level. Every account has wallet bytecode (via auto-delegation or explicit deployment), so calls route through the wallet for ETH-carrying operations.
 
 ### Why No Value in Calls?
 
@@ -666,19 +666,19 @@ Since every account has wallet bytecode (auto-delegation or explicit deployment)
 
 ### Why Delegation via Account Changes?
 
-[EIP-7702](./eip-7702.md) introduced `authorization_list` as a transaction-level field for code delegation, with ECDSA authority. This proposal moves delegation into `account_changes`, authorized by the transaction's `sender_auth`. Delegation is restricted to the account's implicit EOA owner (`ownerId == bytes32(bytes20(sender))`) so that code delegation remains portable across non-8130 chains via standard [EIP-7702](./eip-7702.md) transactions. Eventually this can be expanded to all verifier types.
+[EIP-7702](./eip-7702.md) introduced `authorization_list` as a transaction-level field for code delegation, with ECDSA authority. This proposal moves delegation into `account_changes`, authorized by the transaction's `sender_auth`. Delegation is restricted to the account's implicit EOA actor (`actorId == bytes32(bytes20(sender))`) so that code delegation remains portable across non-8130 chains via standard [EIP-7702](./eip-7702.md) transactions. Eventually this can be expanded to all verifier types.
 
 ### Why Account Lock?
 
-Locked accounts have a frozen owner set, so the primary state that can invalidate a validated transaction is nonce consumption. This can enable nodes to cache owner state and apply higher mempool rate limits (see [Mempool Acceptance](#mempool-acceptance)). A per-owner lock alternative was considered but adds mempool tracking complexity — rate limits per `(address, ownerId)` pair rather than per address.
+Locked accounts have a frozen actor set, so the primary state that can invalidate a validated transaction is nonce consumption. This can enable nodes to cache actor state and apply higher mempool rate limits (see [Mempool Acceptance](#mempool-acceptance)). A per-actor lock alternative was considered but adds mempool tracking complexity — rate limits per `(address, actorId)` pair rather than per address.
 
-### Why One Slot Per Owner?
+### Why One Slot Per Actor?
 
-The protocol reads everything it needs for authorization and scope checking in one SLOAD. Reserved bytes provide an extension path for future protocol-level owner policy.
+The protocol reads everything it needs for authorization and scope checking in one SLOAD. Reserved bytes provide an extension path for future protocol-level actor policy.
 
-### Why Owner Scope?
+### Why Actor Scope?
 
-Without scope, all owners have equal authority — any owner can sign as sender, approve gas payment, appear through ERC-1271, and authorize config changes. This is insufficient when accounts have owners serving different roles, like for example running a payer for ERC-20 tokens.
+Without scope, all actors have equal authority — any actor can sign as sender, approve gas payment, appear through ERC-1271, and authorize config changes. This is insufficient when accounts have actors serving different roles, like for example running a payer for ERC-20 tokens.
 
 The `0x00` = unrestricted default ensures backward compatibility.
 
@@ -690,21 +690,21 @@ The canonical set establishes a shared baseline: wallets that use canonical veri
 
 ### Why No Public Key Storage?
 
-Public keys are not stored in the Account Configuration Contract. Instead, owners are identified by `ownerId` (bytes32) and public key material is provided at signing time in the verifier-specific `data` portion of the signature. This design is motivated by three factors:
+Public keys are not stored in the Account Configuration Contract. Instead, actors are identified by `actorId` (bytes32) and public key material is provided at signing time in the verifier-specific `data` portion of the signature. This design is motivated by three factors:
 
-- **State growth**: Public key storage is permanent state growth. For PQ keys (1,000+ bytes), this means 40+ storage slots per owner. Calldata goes to data availability (temporary); storage is permanent. The trend is toward higher SLOAD costs and cheaper DA.
+- **State growth**: Public key storage is permanent state growth. For PQ keys (1,000+ bytes), this means 40+ storage slots per actor. Calldata goes to data availability (temporary); storage is permanent. The trend is toward higher SLOAD costs and cheaper DA.
 - **Gas efficiency**: Calldata is cheaper than cold SLOADs for all key sizes. P256: ~2,048 gas calldata vs ~6,300 gas cold SLOADs. PQ: ~21,000 gas calldata vs ~88,000 gas cold SLOADs.
-- **Simplicity**: One storage slot per owner (`owner_config`). No variable-length public key encoding, no multi-slot reads, no length fields. Registration is a single SSTORE.
+- **Simplicity**: One storage slot per actor (`actor_config`). No variable-length public key encoding, no multi-slot reads, no length fields. Registration is a single SSTORE.
 
 The protocol never needs to know how any algorithm works.
 
-### Why bytes32 ownerId?
+### Why bytes32 actorId?
 
 The full 32-byte keccak256 output provides ~2^85 quantum collision resistance (vs ~2^53 for bytes20 via BHT), which is adequate for post-quantum keys. It also fits a single storage slot and aligns with keccak256 output without truncation.
 
-#### ownerId Conventions
+#### actorId Conventions
 
-Each verifier defines how it derives `ownerId` from signature data.
+Each verifier defines how it derives `actorId` from signature data.
 
 ## Backwards Compatibility
 
@@ -712,7 +712,7 @@ No breaking changes. Existing EOAs and smart contracts function unchanged. Adopt
 
 - EOAs continue sending standard transactions
 - ERC-4337 infrastructure continues operating
-- Accounts gain AA capabilities by configuring owners. EOAs sending their first AA transaction are auto-delegated to `DEFAULT_ACCOUNT_ADDRESS` if they have no code. EOAs MAY override with a delegation entry in `account_changes` (EOA-only authorization), a standard [EIP-7702](./eip-7702.md) transaction, or use a create entry in `account_changes` for custom wallet implementations
+- Accounts gain AA capabilities by configuring actors. EOAs sending their first AA transaction are auto-delegated to `DEFAULT_ACCOUNT_ADDRESS` if they have no code. EOAs MAY override with a delegation entry in `account_changes` (EOA-only authorization), a standard [EIP-7702](./eip-7702.md) transaction, or use a create entry in `account_changes` for custom wallet implementations
 
 ## Reference Implementation
 
@@ -725,24 +725,24 @@ interface IAccountConfiguration {
         uint64 local;      // chain_id == block.chainid
     }
 
-    struct OwnerConfig {
+    struct ActorConfig {
         address verifier;
         uint8 scope;       // 0x00 = unrestricted
     }
 
-    struct Owner {
-        bytes32 ownerId;
-        OwnerConfig config;
+    struct Actor {
+        bytes32 actorId;
+        ActorConfig config;
     }
 
-    struct OwnerChange {
-        uint8 changeType;  // 0x01 = authorizeOwner, 0x02 = revokeOwner
-        bytes32 ownerId;
-        bytes configData;  // OwnerConfig for authorize, empty for revoke
+    struct ActorChange {
+        uint8 changeType;  // 0x01 = authorizeActor, 0x02 = revokeActor
+        bytes32 actorId;
+        bytes configData;  // ActorConfig for authorize, empty for revoke
     }
 
-    event OwnerAuthorized(address indexed account, bytes32 indexed ownerId, OwnerConfig config);
-    event OwnerRevoked(address indexed account, bytes32 indexed ownerId);
+    event ActorAuthorized(address indexed account, bytes32 indexed actorId, ActorConfig config);
+    event ActorRevoked(address indexed account, bytes32 indexed actorId);
     event AccountCreated(address indexed account, bytes32 userSalt, bytes32 codeHash);
     event AccountImported(address indexed account);
     event DelegationApplied(address indexed account, address target);
@@ -750,14 +750,14 @@ interface IAccountConfiguration {
     event AccountUnlockInitiated(address indexed account, uint40 unlocksAt);
 
     // Account creation (factory)
-    function createAccount(bytes32 userSalt, bytes calldata bytecode, Owner[] calldata initialOwners) external returns (address);
-    function computeAddress(bytes32 userSalt, bytes calldata bytecode, Owner[] calldata initialOwners) external view returns (address);
+    function createAccount(bytes32 userSalt, bytes calldata bytecode, Actor[] calldata initialActors) external returns (address);
+    function computeAddress(bytes32 userSalt, bytes calldata bytecode, Actor[] calldata initialActors) external view returns (address);
 
-    // Import existing account (ERC-1271 verification for initial owner registration)
-    function importAccount(address account, Owner[] calldata initialOwners, bytes calldata signature) external;
+    // Import existing account (ERC-1271 verification for initial actor registration)
+    function importAccount(address account, Actor[] calldata initialActors, bytes calldata signature) external;
 
-    // Portable owner changes (direct verification via verifier + owner_config)
-    function applySignedOwnerChanges(address account, uint64 chainId, OwnerChange[] calldata ownerChanges, bytes calldata auth) external;
+    // Portable actor changes (direct verification via verifier + actor_config)
+    function applySignedActorChanges(address account, uint64 chainId, ActorChange[] calldata actorChanges, bytes calldata auth) external;
 
     // Account lock (called by the account directly)
     function lock(uint16 unlockDelay) external;
@@ -765,15 +765,15 @@ interface IAccountConfiguration {
 
     // Signature verification
     // verifySignature: ERC-1271-style boolean check; returns false on any failure.
-    // verify: resolves the authenticating owner and returns its scope byte; reverts on failure
-    //         (invalid signature, unknown/revoked owner, or ownerId not bound to the auth verifier).
+    // verify: resolves the authenticating actor and returns its scope byte; reverts on failure
+    //         (invalid signature, unknown/revoked actor, or actorId not bound to the auth verifier).
     function verifySignature(address account, bytes32 hash, bytes calldata signature) external view returns (bool verified);
     function verify(address account, bytes32 hash, bytes calldata auth) external view returns (uint8 scope);
 
     // Storage views
     function isInitialized(address account) external view returns (bool);
-    function isOwner(address account, bytes32 ownerId) external view returns (bool);
-    function getOwnerConfig(address account, bytes32 ownerId) external view returns (OwnerConfig memory);
+    function isActor(address account, bytes32 actorId) external view returns (bool);
+    function getActorConfig(address account, bytes32 actorId) external view returns (ActorConfig memory);
     function getChangeSequences(address account) external view returns (ChangeSequences memory);
     function isLocked(address account) external view returns (bool);
     function getLockStatus(address account) external view returns (bool locked, bool hasInitiatedUnlock, uint40 unlocksAt, uint16 unlockDelay);
@@ -787,13 +787,13 @@ interface IVerifier {
     function verify(
         bytes32 hash,
         bytes calldata data
-    ) external view returns (bytes32 ownerId);
+    ) external view returns (bytes32 actorId);
 }
 ```
 
 Stateful verifiers MAY read from the Transaction Context precompile or other state (see [Transaction Context](#transaction-context)). When called outside of an 8130 transaction (e.g., `verifySignature()` in a legacy transaction), the Transaction Context precompile returns zero/default values, so verifiers that depend on it naturally reject those calls.
 
-### ITxContext (Precompile)
+### ITransactionContext (Precompile)
 
 ```solidity
 struct Call {
@@ -801,13 +801,13 @@ struct Call {
     bytes data;
 }
 
-interface ITxContext {
-    function getSender() external view returns (address);
-    function getPayer() external view returns (address);
-    function getOwnerId() external view returns (bytes32);
-    function getCalls() external view returns (Call[][] memory);
-    function getMaxCost() external view returns (uint256);
-    function getGasLimit() external view returns (uint256);
+interface ITransactionContext {
+    function getTransactionSender() external view returns (address);
+    function getTransactionPayer() external view returns (address);
+    function getTransactionSenderActorId() external view returns (bytes32);
+    function getTransactionCalls() external view returns (Call[][] memory);
+    function getTransactionMaxCost() external view returns (uint256);
+    function getTransactionGasLimit() external view returns (uint256);
 }
 ```
 
@@ -825,23 +825,23 @@ Read-only. The protocol manages nonce storage directly; there are no state-modif
 
 ## Security Considerations
 
-**Validation Surface**: For pure verifiers, invalidators are `owner_config` revocation and nonce consumption. Stateful verifiers additionally depend on traced state; invalidation tracking is a mempool concern.
+**Validation Surface**: For pure verifiers, invalidators are `actor_config` revocation and nonce consumption. Stateful verifiers additionally depend on traced state; invalidation tracking is a mempool concern.
 
 **Replay Protection**: Transactions include `chain_id`, 2D nonce (`nonce_key`, `nonce_sequence`), and `expiry`. For `NONCE_KEY_MAX` (nonce-free mode), replay protection relies on short-lived `expiry` and deduplication by the signature-invariant [Nonce-Free Replay Identifier](#nonce-free-replay-identifier) (`replay_id`). The mempool enforces a tight expiry window (e.g., 10-30 seconds) to bound the window. Block builders MUST NOT include two `NONCE_KEY_MAX` transactions with the same `replay_id`. The identifier deliberately excludes `sender_auth` and `payer_auth`: keying on the full transaction hash would let a sponsor re-sign `payer_auth`, or an attacker exploit `sender_auth` malleability, to admit or include duplicates of one logical transaction (see [Nonce-Free Replay Identifier](#nonce-free-replay-identifier)).
 
-**Owner Scope**: Protocol-enforced after verifier execution — a verifier cannot bypass scope checking.
+**Actor Scope**: Protocol-enforced after verifier execution — a verifier cannot bypass scope checking.
 
-**Owner Management**: Config change authorization requires CONFIG scope. The EOA owner is implicitly authorized with unrestricted scope; revocable via portable config change. All owner modification paths are blocked when the account is locked.
+**Actor Management**: Config change authorization requires CONFIG scope. The EOA actor is implicitly authorized with unrestricted scope; revocable via portable config change. All actor modification paths are blocked when the account is locked.
 
-**Implicit EOA Rule Scoping**: The implicit EOA authorization rule only applies when authentication used the native secp256k1 path — either the EOA path (`sender` empty) or `ECRECOVER_VERIFIER`. Generic verifier contracts MUST NOT satisfy the implicit branch even if they return `bytes32(bytes20(sender))`, otherwise an arbitrary verifier could authenticate as any EOA whose implicit owner slot has never been written.
+**Implicit EOA Rule Scoping**: The implicit EOA authorization rule only applies when authentication used the native secp256k1 path — either the EOA path (`sender` empty) or `ECRECOVER_VERIFIER`. Generic verifier contracts MUST NOT satisfy the implicit branch even if they return `bytes32(bytes20(sender))`, otherwise an arbitrary verifier could authenticate as any EOA whose implicit actor slot has never been written.
 
-**ownerId Binding**: The protocol checks that the verifier's returned `ownerId` maps back to that verifier in `owner_config` — preventing a malicious verifier from claiming ownership of another verifier's owners.
+**actorId Binding**: The protocol checks that the verifier's returned `actorId` maps back to that verifier in `actor_config` — preventing a malicious verifier from claiming control of another verifier's actors.
 
-**Payer Security**: `AA_TX_TYPE` vs `AA_PAYER_TYPE` domain separation prevents signature reuse between sender and payer roles. The `payer` field in the sender's signed hash binds to a specific payer address. Scope enforcement adds a second layer — PAYER-only owners cannot be used as `sender_auth`, and vice versa. The payer's exposure to sender-controlled gas is bounded by signed fee fields because `gas_limit` includes sender authentication, intrinsic costs, account changes, and call execution. Payer authentication uses the payer's chosen verifier, is validated under PAYER scope, and is metered separately so the payer's verifier choice cannot reduce gas available to `calls`.
+**Payer Security**: `AA_TX_TYPE` vs `AA_PAYER_TYPE` domain separation prevents signature reuse between sender and payer roles. The `payer` field in the sender's signed hash binds to a specific payer address. Scope enforcement adds a second layer — PAYER-only actors cannot be used as `sender_auth`, and vice versa. The payer's exposure to sender-controlled gas is bounded by signed fee fields because `gas_limit` includes sender authentication, intrinsic costs, account changes, and call execution. Payer authentication uses the payer's chosen verifier, is validated under PAYER scope, and is metered separately so the payer's verifier choice cannot reduce gas available to `calls`.
 
-**Cross-sender Payer Replay**: The payer signature hash binds to the resolved sender via the `sender` field (see [Signature Payload](#signature-payload)). In the EOA path where `sender` is empty in the wire format, the recovered sender address MUST be substituted into the `sender` position before computing the hash. Without this substitution, two different EOAs that construct otherwise identical transaction data (same `chain_id`, `nonce_key`, `nonce_sequence`, `expiry`, fees, `account_changes`, `calls`) would produce identical payer hashes, allowing a second EOA to reuse a payer signature originally issued for the first and drain the payer's gas deposit. The 2D nonce alone does not prevent this: `nonce_key` and `nonce_sequence` are fields in the transaction payload, so each attacker controls their own values. Substituting the recovered sender into the hash makes the payer's commitment per-sender and closes this replay path. The configured-owner path is unaffected because `sender` is non-empty by definition.
+**Cross-sender Payer Replay**: The payer signature hash binds to the resolved sender via the `sender` field (see [Signature Payload](#signature-payload)). In the EOA path where `sender` is empty in the wire format, the recovered sender address MUST be substituted into the `sender` position before computing the hash. Without this substitution, two different EOAs that construct otherwise identical transaction data (same `chain_id`, `nonce_key`, `nonce_sequence`, `expiry`, fees, `account_changes`, `calls`) would produce identical payer hashes, allowing a second EOA to reuse a payer signature originally issued for the first and drain the payer's gas deposit. The 2D nonce alone does not prevent this: `nonce_key` and `nonce_sequence` are fields in the transaction payload, so each attacker controls their own values. Substituting the recovered sender into the hash makes the payer's commitment per-sender and closes this replay path. The configured-actor path is unaffected because `sender` is non-empty by definition.
 
-**Account Creation Security**: `initial_owners` (verifier + ownerId + scope tuples) are salt-committed, preventing front-running of owner assignment. Wallet bytecode should be inert when uninitialized as it can be permissionlessly deployed. The create entry applies only to addresses that satisfy CREATE2 freshness. Without the nonce check, a create entry could be replayed against an EOA that has transaction history at the counterfactual address. Direct code placement also bypasses CREATE/CREATE2's [EIP-170](./eip-170.md) `MAX_CODE_SIZE` check, so the protocol enforces `len(code) <= MAX_CODE_SIZE` explicitly to keep the placed code within the EVM contract size limit.
+**Account Creation Security**: `initial_actors` (verifier + actorId + scope tuples) are salt-committed, preventing front-running of actor assignment. Wallet bytecode should be inert when uninitialized as it can be permissionlessly deployed. The create entry applies only to addresses that satisfy CREATE2 freshness. Without the nonce check, a create entry could be replayed against an EOA that has transaction history at the counterfactual address. Direct code placement also bypasses CREATE/CREATE2's [EIP-170](./eip-170.md) `MAX_CODE_SIZE` check, so the protocol enforces `len(code) <= MAX_CODE_SIZE` explicitly to keep the placed code within the EVM contract size limit.
 
 ## Copyright
 


### PR DESCRIPTION
## Summary

A naming-finalization pass over EIP-8130. Two changes:

1. **Rename `owner` → `actor` throughout.** Many of these entities are scoped credentials (PAYER-only, SIGNATURE-only, session-style keys), so "owner" overstated their authority; "actor" describes a scoped signing entity more accurately. This covers `ownerId → actorId`, `owner_config → actor_config`, the `OwnerConfig`/`Owner`/`OwnerChange` structs, `authorizeOwner`/`revokeOwner`, the `OwnerAuthorized`/`OwnerRevoked` events, `applySignedOwnerChanges → applySignedActorChanges`, `getOwnerConfig → getActorConfig`, `isOwner → isActor`, the `SignedActorChanges` TYPEHASH string, and all related headings/anchors.

2. **Finalize Transaction Context precompile naming.** Adopt the getter renames from #11758 and extend the `getTransaction*` convention consistently:
   - `getSender() → getTransactionSender()`
   - `getPayer() → getTransactionPayer()`
   - `getOwnerId() → getTransactionSenderActorId()`
   - `getCalls() → getTransactionCalls()`
   - `getMaxCost() → getTransactionMaxCost()`
   - `getGasLimit() → getTransactionGasLimit()`
   - `ITxContext → ITransactionContext` (the `Tx` abbreviation was inconsistent with the prose and the `getTransaction*` getters)

## Relationship to #11758

This keeps the **renames** from #11758 but **drops its removals**. The full Transaction Context precompile interface is retained — `getTransactionCalls`/`getTransactionMaxCost`/`getTransactionGasLimit` and the `Call` struct remain, and the original rationale (including paymaster/calls inspection and the immutable-metadata framing) is preserved. This is a pure renaming change with no semantic/behavioral edits.

## Notes

- The `SignedActorChanges` / `ActorChange` TYPEHASH string changes, which alters the config-change signing digest — acceptable while the EIP is in Draft.
- No other EIP references `eip-8130`, so the rename is self-contained. Internal anchor links were updated to match the renamed headings.