### PR TITLE
Update EIP-8130: rename IAccountConfiguration.verify to verifyActor

### DIFF
--- a/EIPS/eip-8130.md
+++ b/EIPS/eip-8130.md
@@ -765,10 +765,10 @@ interface IAccountConfiguration {
 
     // Signature verification
     // verifySignature: ERC-1271-style boolean check; returns false on any failure.
-    // verify: resolves the authenticating actor and returns its scope byte; reverts on failure
-    //         (invalid signature, unknown/revoked actor, or actorId not bound to the auth verifier).
+    // verifyActor: resolves the authenticating actor and returns its scope byte; reverts on failure
+    //              (invalid signature, unknown/revoked actor, or actorId not bound to the auth verifier).
     function verifySignature(address account, bytes32 hash, bytes calldata signature) external view returns (bool verified);
-    function verify(address account, bytes32 hash, bytes calldata auth) external view returns (uint8 scope);
+    function verifyActor(address account, bytes32 hash, bytes calldata auth) external view returns (uint8 scope);
 
     // Storage views
     function isInitialized(address account) external view returns (bool);


### PR DESCRIPTION
## Summary

Follow-up to #11764 (which merged before this rename was pushed).

Renames `IAccountConfiguration.verify` → `verifyActor`. This:
- Disambiguates it from `IVerifier.verify`, which has different semantics (returns the `actorId`, not the scope).
- Makes the scope-returning, reverting authentication entrypoint self-describing, consistent with the `actor` terminology adopted in #11764.

`verifySignature` (the ERC-1271-style boolean check) is unchanged. Pure rename, no behavioral change.