### PR TITLE
Update EIP-8130: add actor call policies and per-actor expiry

### DIFF
--- a/EIPS/eip-8130.md
+++ b/EIPS/eip-8130.md
@@ -51,15 +51,26 @@ Actors are identified by their `actorId`, a 32-byte identifier derived by the ve
 
 #### Storage Layout
 
-Each actor occupies a single `actor_config` slot containing the verifier address (20 bytes) and a scope byte (1 byte) with 11 bytes reserved. The scope byte controls which authentication contexts the actor is valid for (see [Actor Scope](#actor-scope)). Non-EOA actors are revoked by deleting the `actor_config` slot. The implicit EOA actor (`actorId == bytes32(bytes20(account))`) is revoked by overwriting the slot with `verifier = REVOKED_VERIFIER` (`type(uint160).max`), making it distinguishable from an empty (implicitly authorized) slot.
+Each actor occupies a single `actor_config` slot containing the verifier address, scope byte, policy type, and an optional expiry. When `policyType != 0x00`, the actor also carries a signed policy commitment and a manager address in the separate policy slots `policy_commitment`/`policy_manager` (see [Actor Policies](#actor-policies)). Non-EOA actors are revoked by deleting the `actor_config` slot. The implicit EOA actor (`actorId == bytes32(bytes20(account))`) is revoked by overwriting the slot with `verifier = REVOKED_VERIFIER` (`type(uint160).max`), making it distinguishable from an empty (implicitly authorized) slot.
 
 | Field | Bytes | Description |
 |-------|-------|-------------|
 | `verifier` | 0–19 | Verifier contract address |
-| `scope` | 20 | Permission bitmask (`0x00` = unrestricted) |
-| reserved | 21–31 | Reserved for future use (must be zero) |
+| `scope` | 20 | Permission bitmask (`0x00` = unrestricted; see [Actor Scope](#actor-scope)) |
+| `expiry` | 21–26 | `uint48` Unix timestamp (seconds); the actor is invalid once `block.timestamp > expiry`. `0` = no expiry |
+| `policyType` | 27 | Policy selector: `0x00` = no policy; any non-zero value gates the actor to its stored `policy_manager`. The specific non-zero value is interpreted by the manager, not the protocol (see [Actor Policies](#actor-policies)) |
+| reserved | 28–31 | Reserved for future use (must be zero) |
 
-**Implicit EOA authorization**: An unregistered actor (`actor_config` slot is empty) is implicitly authorized if `actorId == bytes32(bytes20(account))`. The empty slot's scope byte is `0x00` (unrestricted), granting full permissions by default. This allows every existing EOA to send AA transactions immediately without prior registration. When the implicit rule applies, the protocol verifies using native ecrecover rather than calling an external verifier contract. The implicit authorization is revoked by writing `REVOKED_VERIFIER` (`type(uint160).max`) to the verifier field, making the slot non-empty and blocking re-authorization. The EOA actor can also be explicitly registered with `ECRECOVER_VERIFIER` (`address(1)`) to set a custom scope while retaining native ecrecover verification.
+When `policyType != 0x00`, the actor's policy is held in two additional slots:
+
+```
+policy_commitment(account, actorId) → bytes32   // set when policyType != 0x00
+policy_manager(account, actorId)    → address   // set when policyType != 0x00
+```
+
+These slots are read only during execution (see [Actor Policies](#actor-policies)); validity is still decided by the single `actor_config` SLOAD.
+
+**Implicit EOA authorization**: An unregistered actor (`actor_config` slot is empty) is implicitly authorized if `actorId == bytes32(bytes20(account))`. The empty slot's scope byte and `policyType` are both `0x00`, and `expiry` is `0` (never expires), granting unrestricted, non-expiring permissions and no protocol-enforced policy by default. This allows every existing EOA to send AA transactions immediately without prior registration. When the implicit rule applies, the protocol verifies using native ecrecover rather than calling an external verifier contract. The implicit authorization is revoked by writing `REVOKED_VERIFIER` (`type(uint160).max`) to the verifier field, making the slot non-empty and blocking re-authorization. The EOA actor can also be explicitly registered with `ECRECOVER_VERIFIER` (`address(1)`) to set a custom scope or `policyType` while retaining native ecrecover verification.
 
 #### Actor Scope
 
@@ -74,7 +85,35 @@ The scope byte in `actor_config` is a permission bitmask that restricts which au
 
 The protocol checks scope after verifier execution: `scope == 0x00 || (scope & context_bit) != 0`.
 
-The protocol validates signatures by reading `actor_config` directly and delegating authentication to [Verifiers](#verifiers) — see [Validation](#validation) for the full flow. Actor enumeration is performed off-chain via `ActorAuthorized` / `ActorRevoked` event logs. No actor count is enforced on-chain — gas costs naturally bound actor creation.
+The protocol validates signatures by reading `actor_config` directly and delegating authentication to [Verifiers](#verifiers) — see [Validation](#validation) for the full flow. Actor enumeration is performed off-chain via `ActorAuthorized` and `ActorRevoked` event logs. No actor counts are enforced on-chain — gas costs naturally bound them.
+
+#### Actor Policies
+
+The `policyType` byte selects whether an actor is gated. `0x00` means no policy; any non-zero value gates the actor to a stored `manager` and carries an opaque 32-byte **commitment** (`keccak256` of the policy parameters). The protocol gates identically on every non-zero value and never interprets the specific byte; it is carried in `actor_config` for the `manager` to read as a sub-type if useful.
+
+| `policyType` | Gate: `call.to` MUST equal | `policyData` |
+|--------------|----------------------------|---------------|
+| `0x00` | (no gate) | — |
+| non-zero | the actor's `manager` | `manager` (20 bytes) ‖ `commitment` (32 bytes) |
+
+A policy-bearing actor (typically a session key) may call exactly one target: its configured `manager`. The contract at that target reads the actor's `commitment` (via [`getPolicy`](#iaccountconfiguration)), validates the presented policy parameters against it (`keccak256(params) == commitment`), enforces *what* the call may do, and carries out the approved action. The protocol's only responsibility is the single-target gate; how the target enforces the commitment and how it acts on behalf of the account are out of scope for this specification.
+
+A key that should be enforced by the account's own code rather than a separate contract sets `manager = account`.
+
+**Scope.** The policy gate constrains only SENDER-context calls, so a policy-bearing actor MUST be authorized with a restricted `scope` that is neither unrestricted (`0x00`) nor includes CONFIG (`0x08`): a CONFIG-scoped key could authorize new, unrestricted actors and escape its policy entirely. PAYER and SIGNATURE scopes are permitted but are not policy-constrained — a policy-bearing actor with PAYER scope can sponsor gas up to the transaction's limits, and with SIGNATURE scope can produce ERC-1271 signatures the policy never sees — so wallets SHOULD grant a restricted key only the scopes it needs, typically SENDER alone.
+
+**Reference flow** (non-normative). A session-key policy with a custom manager:
+
+1. The account authorizes the key with a non-zero `policyType`, a `manager`, and `commitment = keccak256(params)`.
+2. The account installs `params` at the manager, which checks that `getPolicy(account, actorId)` resolves to itself with a matching `commitment`.
+3. On each use, the protocol gate routes the key's call to the manager; the manager re-reads `getPolicy(account, actorId)`, requires `keccak256(presented params) == commitment`, enforces them, and acts for the account.
+4. `revokeActor` (or `expiry`) clears the slots, so step 3 then fails for that key.
+
+**The commitment is signed, opaque, and protocol-stored.** Because it is part of the signed actor change, one signature fully describes the key's authority (its manager and exact policy) and travels with the portable, multichain actor-change path. Because it is opaque (one word), the protocol stays agnostic to the policy vocabulary: new policy behaviors are new target logic, requiring no protocol change.
+
+**Enforcement is at execution, not validation.** The protocol does not read `policy_commitment` or `policy_manager` when checking transaction validity; the gate is applied later, during [Call Execution](#call-execution).
+
+**Lifecycle.** Policy state is keyed by `(account, actorId)`; clearing on revocation and target-held parameters are covered under [Policy State on Revocation](#security-considerations).
 
 #### 2D Nonce Storage
 
@@ -137,7 +176,7 @@ This proposal uses the same delegation indicator behavior as [EIP-7702](./eip-77
 
 ### Verifiers
 
-Each actor is associated with a verifier, a contract that performs signature verification. The verifier address is stored in `actor_config`. All verifiers implement `IVerifier.verify(hash, data)`. Stateful verifiers MAY read transaction context (sender address, calls, payer) from the Transaction Context precompile at `TX_CONTEXT_ADDRESS` (see [Transaction Context](#transaction-context)). The protocol validates the returned `actorId` against `actor_config` and checks the actor's scope against the authentication context.
+Each actor is associated with a verifier, a contract that performs signature verification. The verifier address is stored in `actor_config`. All verifiers implement `IVerifier.verify(hash, data)`. Stateful verifiers MAY read transaction context (sender address, calls, payer) from the Transaction Context precompile at `TX_CONTEXT_ADDRESS` (see [Transaction Context](#transaction-context)). The protocol validates the returned `actorId` against `actor_config` and checks the actor's scope against the authentication context; the policy gate (`policyType != 0x00`) is enforced later, during execution.
 
 Verifiers are executed via STATICCALL. Verifier addresses MUST NOT be delegated accounts — reject if the code at the verifier address starts with the delegation indicator (`0xef0100`). Execution is metered (see [Mempool Acceptance](#mempool-acceptance) for rules).
 
@@ -234,7 +273,7 @@ The sender verifier runs first, and its metered cost is included in `gas_limit`.
 | `tx_payload_cost` | Standard per-byte cost over the entire RLP-serialized transaction: 16 gas per non-zero byte, 4 gas per zero byte, consistent with [EIP-2028](./eip-2028.md). Ensures all transaction fields (`account_changes`, `sender_auth`, `calls`, etc.) are charged for data availability |
 | `nonce_key_cost` | `NONCE_KEY_MAX`: 14,000 gas (replay protection state: 2 cold SLOADs + 1 warm SLOAD + 3 warm SSTORE resets). Otherwise: 22,100 gas for first use of a `nonce_key` (cold SLOAD + SSTORE set), 5,000 gas for existing keys (cold SLOAD + warm SSTORE reset) |
 | `bytecode_cost` | 0 if no create entry in `account_changes`. Otherwise: 32,000 (deployment base) + code deposit cost (200 gas per deployed byte). Byte costs for `code` are covered by `tx_payload_cost` |
-| `account_changes_cost` | Per applied config change entry: auth verification cost (same model as `sender_auth_cost`) + `num_operations` × 20,000 per SSTORE. Per applied delegation entry: code deposit cost (200 × 23 bytes for the delegation indicator). Per skipped config change entry (already applied): 2,100 (SLOAD to check sequence). 0 if no config change or delegation entries in `account_changes` |
+| `account_changes_cost` | Per applied config change entry: auth verification cost (same model as `sender_auth_cost`) + storage write costs for each mutated actor slot (`actor_config`; plus `policy_commitment` and `policy_manager` when `policyType != 0x00`). Per applied delegation entry: code deposit cost (200 × 23 bytes for the delegation indicator). Per skipped config change entry (already applied): 2,100 (SLOAD to check sequence). 0 if no config change or delegation entries in `account_changes` |
 | `auto_delegation_cost` | 4,600 (200 × 23 bytes, code deposit for the delegation indicator) when a code-less `sender` is auto-delegated to `DEFAULT_ACCOUNT_ADDRESS` (Block Execution step 4). 0 otherwise — i.e. when `sender` already has code, or `account_changes` contains a create or delegation entry |
 
 #### Signature Format
@@ -256,7 +295,7 @@ The first 20 bytes identify the verifier address. When the verifier is `ECRECOVE
 1. **Resolve sender**: If `sender` empty, ecrecover derives the sender address (EOA path) with `actorId = bytes32(bytes20(sender))`. If `sender` set, read the first 20 bytes of `sender_auth` as the verifier address.
 2. **Set transaction context**: Populate the Transaction Context precompile with sender, payer, and calls (see [Transaction Context](#transaction-context)).
 3. **Verify**: Route by verifier address. For the EOA path (`sender` empty), ecrecover was already performed in step 1. For `ECRECOVER_VERIFIER` (`address(1)`), the protocol natively ecrecovers from `data` (as `r || s || v`), returning `actorId = bytes32(bytes20(recovered_address))`. For all other verifiers (`address(2+)`), call `verifier.verify(hash, data)` via STATICCALL, returning `actorId` (or `bytes32(0)` for invalid). Reject `REVOKED_VERIFIER` as a verifier address.
-4. **Authorize**: SLOAD `actor_config(sender, actorId)`. **Implicit EOA rule**: if the slot is empty, `actorId == bytes32(bytes20(sender))`, and verification in step 3 used the native secp256k1 path (the EOA path or `ECRECOVER_VERIFIER`), treat as implicitly authorized with scope `0x00`. Otherwise, require that the stored verifier address matches the effective verifier and is not `REVOKED_VERIFIER`.
+4. **Authorize**: SLOAD `actor_config(sender, actorId)`. **Implicit EOA rule**: if the slot is empty, `actorId == bytes32(bytes20(sender))`, and verification in step 3 used the native secp256k1 path (the EOA path or `ECRECOVER_VERIFIER`), treat as implicitly authorized with `scope = 0x00` and `policyType = 0x00`. Otherwise, require that the stored verifier address matches the effective verifier and is not `REVOKED_VERIFIER`. If the stored `expiry` is non-zero, also require `block.timestamp <= expiry`; an expired actor fails authentication. `expiry` is read from the same `actor_config` slot, adding no extra SLOAD.
 5. **Check scope**: Read the scope byte from `actor_config` (or `0x00` for the implicit case). Determine the context bit: `0x02` (SENDER) for `sender_auth`, `0x04` (PAYER) for `payer_auth`, `0x01` (SIGNATURE) for `verifySignature()`, `0x08` (CONFIG) for config change `auth`. Require `scope == 0x00 || (scope & context_bit) != 0`.
 
 #### Signature Payload
@@ -327,17 +366,13 @@ rlp([
   0x00,               // type: create
   user_salt,          // bytes32: User-chosen uniqueness factor
   code,               // bytes: Runtime bytecode placed at account address
-  initial_actors      // Array of [verifier, actorId, scope] tuples
+  initial_actors      // Array of [verifier, actorId, scope, expiry, policyType, policyData] tuples
 ])
 ```
 
-Initial actors are registered with their specified scope. Wallet initialization code can lock the account via `calls` in the execution phase (e.g., calling `lock()` on the Account Configuration Contract).
+Initial actors are registered with their specified scope, `expiry` (`0` = no expiry), and `policyType`. The `policyData` field carries the actor's policy and is sliced by `policyType` into `policy_commitment`/`policy_manager` exactly as for [`authorizeActor`](#actor-policies). Wallet initialization code can lock the account via `calls` in the execution phase (e.g., calling `lock()` on the Account Configuration Contract).
 
 The `code` field contains runtime bytecode placed directly at the account address. For delegation, use a delegation entry (type `0x02`) in `account_changes` after account creation.
-
-```
-[0x00, user_salt, runtimeBytecode, initial_actors]
-```
 
 ##### Address Derivation
 
@@ -346,14 +381,18 @@ Addresses are derived using the CREATE2 address formula with the Account Configu
 ```
 sorted_actors = sort(initial_actors, by: actorId)
 
-actors_commitment = keccak256(actorId_0 || verifier_0 || scope_0 || actorId_1 || verifier_1 || scope_1 || ... || actorId_n || verifier_n || scope_n)
+actors_commitment = keccak256(
+    actorId_0 || verifier_0 || scope_0 || expiry_0 || policyType_0 || manager_0 || commitment_0 ||
+    ...
+    actorId_n || verifier_n || scope_n || expiry_n || policyType_n || manager_n || commitment_n
+)
 
 effective_salt = keccak256(user_salt || actors_commitment)
 deployment_code = DEPLOYMENT_HEADER(len(code)) || code
 address = keccak256(0xff || ACCOUNT_CONFIG_ADDRESS || effective_salt || keccak256(deployment_code))[12:]
 ```
 
-The `actors_commitment` uses `actorId || verifier || scope` (53 bytes) per actor — consistent with how the Account Configuration Contract identifies and configures actors.
+The per-actor contribution is `actorId || verifier || scope || expiry || policyType || manager || commitment` (112 bytes; `expiry` is the 6-byte `uint48`, `manager` the 20-byte address, and `commitment` the 32-byte value, with both `manager` and `commitment` zero unless `policyType != 0x00`). Sorting actors by `actorId` makes the commitment order-independent.
 
 `DEPLOYMENT_HEADER(n)` is a fixed 14-byte EVM loader that returns the trailing code (see [Appendix: Deployment Header](#appendix-deployment-header) for the full opcode sequence). On non-8130 chains, `createAccount()` constructs `deployment_code` and passes it as init_code to CREATE2. On 8130 chains, the protocol constructs the same `deployment_code` for address derivation but places `code` directly (no execution). Both paths produce the same address — callers only provide `code`; the header is never user-facing.
 
@@ -363,17 +402,18 @@ Users can receive funds at counterfactual addresses before account creation.
 
 When a create entry is present in `account_changes`:
 
-1. Parse `[0x00, user_salt, code, initial_actors]` where each entry is `[verifier, actorId, scope]`
+1. Parse `[0x00, user_salt, code, initial_actors]` where each entry is `[verifier, actorId, scope, expiry, policyType, policyData]`
 2. Reject if any duplicate `actorId` values exist
 3. Reject if `code` is empty or `len(code) > MAX_CODE_SIZE` ([EIP-170](./eip-170.md): 24576 bytes), to keep the placed code within the EVM contract size limit that CREATE/CREATE2 would otherwise enforce
-4. Sort by actorId: `sorted_actors = sort(initial_actors, by: actorId)`
-5. Compute `actors_commitment = keccak256(actorId_0 || verifier_0 || scope_0 || ... || actorId_n || verifier_n || scope_n)`
-6. Compute `effective_salt = keccak256(user_salt || actors_commitment)`
-7. Compute `deployment_code = DEPLOYMENT_HEADER(len(code)) || code`
-8. Compute `expected = keccak256(0xff || ACCOUNT_CONFIG_ADDRESS || effective_salt || keccak256(deployment_code))[12:]`
-9. Require `sender == expected`
-10. Require the destination matches CREATE2 freshness: `code_size(sender) == 0` and `nonce(sender) == 0` (matching the conditions under which CREATE2 would be permitted to deploy)
-11. Validate `sender_auth` against one of `initial_actors` (actorId resolved from auth must match an entry's actorId)
+4. Reject any actor whose `len(policyData)` does not match its `policyType` (`0` for `0x00`, `52` for non-zero), or any policy-bearing actor (`policyType != 0x00`) whose `scope` is unrestricted (`0x00`) or includes CONFIG (`0x08`)
+5. Sort actors by `actorId`
+6. Compute `actors_commitment` per [Address Derivation](#address-derivation)
+7. Compute `effective_salt = keccak256(user_salt || actors_commitment)`
+8. Compute `deployment_code = DEPLOYMENT_HEADER(len(code)) || code`
+9. Compute `expected = keccak256(0xff || ACCOUNT_CONFIG_ADDRESS || effective_salt || keccak256(deployment_code))[12:]`
+10. Require `sender == expected`
+11. Require the destination matches CREATE2 freshness: `code_size(sender) == 0` and `nonce(sender) == 0` (matching the conditions under which CREATE2 would be permitted to deploy)
+12. Validate `sender_auth` against one of `initial_actors` (actorId resolved from auth must match an entry's actorId and the auth verifier must match that entry's verifier)
 
 #### Config Change Entry
 
@@ -392,18 +432,17 @@ rlp([
 
 actor_change = rlp([
   change_type,          // uint8: operation type (see below)
-  verifier,             // address: verifier contract (authorizeActor only)
   actorId,              // bytes32: actor identifier
-  scope                 // uint8: permission bitmask (authorizeActor only, 0x00 = unrestricted)
+  data                  // bytes: operation-specific (see below)
 ])
 ```
 
 **Operation types**:
 
-| change_type | Name | Description | Fields Used |
-|-------------|------|-------------|-------------|
-| `0x01` | `authorizeActor` | Authorize a new actor with scope | `verifier`, `actorId`, `scope` |
-| `0x02` | `revokeActor` | Revoke an existing actor — deletes the slot for non-EOA actors; for the implicit EOA actor (`actorId == bytes32(bytes20(account))`), overwrites with `verifier = REVOKED_VERIFIER` (`type(uint160).max`) to prevent implicit re-authorization | `actorId` |
+| change_type | Name | `data` | Description |
+|-------------|------|--------|-------------|
+| `0x01` | `authorizeActor` | `rlp([verifier, scope, expiry, policyType, policyData])` | Authorize a new actor. Writes `actor_config` with `verifier`, `scope`, `expiry` (`0` = no expiry), and `policyType`. Slices `policyData` into `policy_commitment`/`policy_manager`: empty for `0x00`, `manager ‖ commitment` when non-zero (see [Actor Policies](#actor-policies)); rejects mismatched `len(policyData)`, and rejects a policy-bearing actor whose `scope` is unrestricted (`0x00`) or includes CONFIG (`0x08`). Emits `ActorAuthorized`. |
+| `0x02` | `revokeActor` | `rlp([])` | Revoke an existing actor. Deletes `actor_config` (and `policy_commitment`/`policy_manager`) for non-EOA actors; for the implicit EOA actor (`actorId == bytes32(bytes20(account))`), overwrites with `verifier = REVOKED_VERIFIER` (`type(uint160).max`) to prevent implicit re-authorization. Emits `ActorRevoked`. |
 
 #### Config Change Authorization
 
@@ -416,9 +455,9 @@ The sequence number is scoped by `chain_id`: `0` uses the multichain sequence ch
 Entry signatures use ABI-encoded type hashing. Operations within an entry are individually ABI-encoded and hashed into an array digest:
 
 ```
-TYPEHASH = keccak256("SignedActorChanges(address account,uint64 chainId,uint64 sequence,ActorChange[] actorChanges)ActorChange(uint8 changeType,address verifier,bytes32 actorId,uint8 scope)")
+TYPEHASH = keccak256("SignedActorChanges(address account,uint64 chainId,uint64 sequence,ActorChange[] actorChanges)ActorChange(uint8 changeType,bytes32 actorId,bytes data)")
 
-actorChangeHashes = [keccak256(abi.encode(changeType, verifier, actorId, scope)) for each actorChange]
+actorChangeHashes = [keccak256(abi.encode(changeType, actorId, keccak256(data))) for each actorChange]
 actorChangesHash = keccak256(abi.encodePacked(actorChangeHashes))
 
 digest = keccak256(abi.encode(TYPEHASH, account, chainId, sequence, actorChangesHash))
@@ -440,7 +479,7 @@ Actors can be modified through two portable paths:
 | Sequence | Increments channel's `change_sequence` | Increments channel's `change_sequence` |
 | When processed | Before code deployment (8130 only) | During EVM execution (any chain) |
 
-Both paths share the same signed actor changes and `change_sequence` counters. `applySignedActorChanges()` parses the verifier address from `auth`, calls the verifier to get the `actorId`, and checks `actor_config`. Anyone can call these functions; authorization comes from the signed operation, not the caller. All actor modification paths are blocked when the account is locked (see [Account Lock](#account-lock)).
+Both paths share the same signed actor changes and `change_sequence` counters. `applySignedActorChanges()` parses the verifier address from `auth`, calls the verifier to get the `actorId`, and checks `actor_config`. `authorizeActor` writes `actor_config` and, for policy-bearing actors (`policyType != 0x00`), the `policy_commitment` and `policy_manager` slots; `revokeActor` clears them all. Anyone can call these functions; authorization comes from the signed operation, not the caller. All actor modification paths are blocked when the account is locked (see [Account Lock](#account-lock)).
 
 #### Delegation Entry
 
@@ -472,7 +511,7 @@ For 8130 transactions, successful delegation updates emit a protocol-injected `D
 
 `account_changes` entries are processed in order before call execution:
 
-1. **Create entry** (if present): Register `initial_actors` in Account Config storage for `sender` — for each `[verifier, actorId, scope]` tuple, write `actor_config` (verifier address and scope byte). Initialize lock state to safe defaults: `locked = false`, `unlock_delay = 0`, `unlocks_at = 0`.
+1. **Create entry** (if present): Register `initial_actors` in Account Config storage for `sender` — for each `[verifier, actorId, scope, expiry, policyType, policyData]` tuple, write `actor_config` (verifier address, scope byte, `expiry`, and `policyType`) and the policy slots from `policyData` (see [Actor Policies](#actor-policies)). Initialize lock state to safe defaults: `locked = false`, `unlock_delay = 0`, `unlocks_at = 0`.
 2. **Config change entries** (if any): Apply operations in entry order. Reject transaction if account is locked.
 3. **Delegation entries** (if any): Require the sender's resolved `actorId == bytes32(bytes20(sender))` (EOA actor) with CONFIG scope. Reject if account is locked. For each entry, set `code(sender) = 0xef0100 || target` (or clear if `target` is `address(0)`). Reject if account has non-delegation bytecode.
 4. **Code placement** (if create entry present): Place `code` at `sender`. The runtime bytecode is placed directly — not executed.
@@ -496,6 +535,14 @@ Calls carry no ETH value. ETH transfers are initiated by the account's wallet by
 
 Phases execute in order from a single gas pool (`gas_limit`). Within each phase, calls execute in order and are **atomic** — if any call in a phase reverts, all state changes for that phase are discarded and remaining phases are **skipped**. Completed phases **persist** — their state changes are committed and survive later phase reverts.
 
+**Policy gate**: When the transaction's authenticating actor has `policyType != 0x00` (SENDER scope), each call is gated before dispatch. The protocol resolves the actor's allowed target — `policy_manager(sender, actorId)` — and if `call.to` is not that address, the call is **not dispatched** and fails deterministically with the protocol revert `PolicyViolation(bytes32 actorId, address target)`:
+
+```solidity
+error PolicyViolation(bytes32 actorId, address target);
+```
+
+The frame's return data is `abi.encodeWithSelector(PolicyViolation.selector, actorId, call.to)`. This is a consensus-level result, not a validity error, so standard atomicity applies: the enclosing phase's state changes roll back, later phases are skipped, and the phase is reported as failed in `phaseStatuses`. Only work already performed is charged (intrinsic gas plus the one `policy_manager` SLOAD); the undispatched call body costs nothing and the transaction is still included with its nonce consumed.
+
 **Common patterns**:
 
 - **Simple call**: `[[{to, data}]]` — one phase, one call
@@ -515,7 +562,7 @@ The Transaction Context precompile at `TX_CONTEXT_ADDRESS` provides read-only ac
 | `getTransactionMaxCost()` | `uint256` — `gas_limit * max_fee_per_gas`, excluding separately metered `payer_auth_cost` | Validation + Execution |
 | `getTransactionGasLimit()` | `uint256` — sender-side gas budget (`gas_limit`) before intrinsic costs and call execution | Validation + Execution |
 
-If the wallet needs the verifier address or scope, it calls `getActorConfig(account, actorId)` on the Account Configuration Contract.
+If the wallet needs the verifier address or scope, it calls `getActorConfig(account, actorId)` on the Account Configuration Contract. A policy target reached as a `call.to` identifies which key it is acting for by combining `getTransactionSender()` and the authenticated `getTransactionSenderActorId()` from this precompile, then reads the actor's signed `commitment` via `getPolicy(account, actorId)` and validates the presented policy parameters against it. The commitment lives in Account Configuration storage (where it is written and revoked), not the precompile, keeping the precompile to immutable transaction context.
 
 **Non-8130 chains**: No code at `TX_CONTEXT_ADDRESS`; STATICCALL returns zero/default values.
 
@@ -571,7 +618,7 @@ Nodes MAY apply higher pending transaction rate limits based on account lock sta
 6. Set transaction context on the Transaction Context precompile (sender, payer, actorId, calls).
 7. Execute `calls` per [Call Execution](#call-execution) semantics.
 
-Unused gas from `gas_limit` is refunded to the payer. Intrinsic gas, excluding separately metered `payer_auth_cost`, consumes `gas_limit` before call execution. For step 5, the protocol SHOULD inject log entries into the transaction receipt (e.g., `ActorAuthorized`, `AccountCreated`, `DelegationApplied`) matching the events defined in the [IAccountConfiguration](#iaccountconfiguration) interface, following the protocol-injected log pattern established by [EIP-7708](./eip-7708.md). These protocol-injected logs are emitted only for 8130 transactions.
+Unused gas from `gas_limit` is refunded to the payer. Intrinsic gas, excluding separately metered `payer_auth_cost`, consumes `gas_limit` before call execution. For step 5, the protocol SHOULD inject log entries into the transaction receipt (e.g., `ActorAuthorized`, `ActorRevoked`, `AccountCreated`, `DelegationApplied`) matching the events defined in the [IAccountConfiguration](#iaccountconfiguration) interface, following the protocol-injected log pattern established by [EIP-7708](./eip-7708.md). These protocol-injected logs are emitted only for 8130 transactions.
 
 ### RPC Extensions
 
@@ -609,7 +656,7 @@ The create entry only supports runtime bytecode. Delegation is set via delegatio
 
 ### Why Verifier Contracts?
 
-Enables signature-algorithm extension through verifier contracts. The verifier returns the `actorId` rather than accepting it as input, so the protocol never needs algorithm-specific logic. All verifiers share a single `verify(hash, data)` interface with no type-based dispatch. Actor scope provides protocol-enforced role separation without verifier cooperation.
+Enables signature-algorithm extension through verifier contracts. The verifier returns the `actorId` rather than accepting it as input, so the protocol never needs algorithm-specific logic. All verifiers share a single `verify(hash, data)` interface with no type-based dispatch. Actor scope and policy provide protocol-enforced role separation without verifier cooperation.
 
 ### Why 2D Nonce + `NONCE_KEY_MAX`?
 
@@ -674,7 +721,30 @@ Locked accounts have a frozen actor set, so the primary state that can invalidat
 
 ### Why One Slot Per Actor?
 
-The protocol reads everything it needs for authorization and scope checking in one SLOAD. Reserved bytes provide an extension path for future protocol-level actor policy.
+The protocol reads everything it needs to decide transaction validity — verifier binding, scope, and policy selection — in one SLOAD on `actor_config`. The policy commitment and manager are kept in separate slots (`policy_commitment`, `policy_manager`) read only during execution, so policy adds nothing to the validity surface: actors with `policyType == 0x00` pay nothing; policy-bearing actors pay their two policy SLOADs at execution time when authenticating as SENDER (see [Why Policy Types?](#why-policy-types)).
+
+### Why Policy Types?
+
+Session keys and gas-payer hot wallets often need narrow authority: only this token, only this much per day, only this action. `policyType` expresses that by gating a restricted key to a single call target and binding it to a signed, opaque **commitment** that the target enforces. The protocol's only policy responsibility is the single-target gate plus storing the commitment; what the target does with the call, and how it ultimately effects actions for the account, is left to the application.
+
+The protocol distinguishes only no policy from a policy:
+
+| `policyType` | Target | Protocol slots | Policy SLOADs |
+|--------------|--------|----------------|---------------|
+| `0x00` (none) | — | 0 | 0 |
+| non-zero | stored `manager` | 2 (`commitment` + `manager`) | 2 |
+
+A policy-bearing actor stores both a `commitment` and a `manager`: the gate resolves the target with one `policy_manager` SLOAD and the target reads the `commitment` with another. Collapsing every policy to this single shape, rather than carving out a cheaper "self" type, keeps the consensus gate branch-free and loses no expressiveness: a key enforced by the account's own code is just `manager = account`, trading one SLOAD for the account's own address against a separate mode every integrator must understand.
+
+Because the Account Configuration Contract is a single immutable deployment, it can never grow new handling for specific `policyType` values, so it reserves none and gates on any non-zero value, leaving the byte for a `manager` to interpret. New policy behaviors are new manager logic, not new protocol values.
+
+**Why an opaque commitment rather than a consensus-level policy vocabulary?** Encoding policy primitives (selector lists, recipient allowlists, spend limits) into consensus would freeze the vocabulary, requiring a fork and lockstep adoption per new primitive. A single opaque commitment keeps the protocol agnostic (new policy behaviors are new target logic, shippable permissionlessly) while still riding the signed, portable actor-change path so one signature fully describes a key's authority.
+
+**Why not a per-target allowlist?** An earlier design let a restricted key carry an array of authorized targets, each with its own commitment. Keying policy by `(account, actorId)` is strictly better on the axes the protocol cares about: bounded, enumerable-free revocation (see [Policy State on Revocation](#security-considerations)) and a single gate resolution rather than one SLOAD per distinct `call.to`. Multi-target composition (token + lending) moves into the single target's own logic, where it belongs.
+
+### Why Actor Expiry?
+
+Session keys are intended to be short-lived, but revocation requires a transaction, and a forgotten key lingers indefinitely. The per-actor `expiry` lets a wallet provision a key that lapses automatically at a chosen time, with no revoke transaction and no lingering authority. Because `expiry` is packed into the same `actor_config` slot the protocol already reads for validity, enforcement costs nothing extra and happens at validation: an expired actor's transactions are rejected before execution rather than reverting. For policy-bearing keys it also caps how long the key can reach its target: once expired, the key can no longer act even if the policy parameters held by the target are never explicitly uninstalled. A value of `0` preserves the existing always-valid behavior for actors that should not expire.
 
 ### Why Actor Scope?
 
@@ -694,7 +764,7 @@ Public keys are not stored in the Account Configuration Contract. Instead, actor
 
 - **State growth**: Public key storage is permanent state growth. For PQ keys (1,000+ bytes), this means 40+ storage slots per actor. Calldata goes to data availability (temporary); storage is permanent. The trend is toward higher SLOAD costs and cheaper DA.
 - **Gas efficiency**: Calldata is cheaper than cold SLOADs for all key sizes. P256: ~2,048 gas calldata vs ~6,300 gas cold SLOADs. PQ: ~21,000 gas calldata vs ~88,000 gas cold SLOADs.
-- **Simplicity**: One storage slot per actor (`actor_config`). No variable-length public key encoding, no multi-slot reads, no length fields. Registration is a single SSTORE.
+- **Simplicity**: One primary storage slot per actor (`actor_config`). No variable-length public key encoding, no multi-slot public key reads, no length fields. Registration is a single SSTORE in the common case, with two extra SSTOREs (`policy_commitment` and `policy_manager`) when an actor carries a policy.
 
 The protocol never needs to know how any algorithm works.
 
@@ -728,20 +798,23 @@ interface IAccountConfiguration {
     struct ActorConfig {
         address verifier;
         uint8 scope;       // 0x00 = unrestricted
+        uint48 expiry;     // Unix seconds; 0 = no expiry. Actor invalid once block.timestamp > expiry
+        uint8 policyType;  // 0x00 = none; any non-zero = gated to stored manager (value interpreted by the manager)
     }
 
     struct Actor {
         bytes32 actorId;
         ActorConfig config;
+        bytes policyData;  // sliced by policyType: empty (0x00); manager[20] || commitment[32] (non-zero)
     }
 
     struct ActorChange {
         uint8 changeType;  // 0x01 = authorizeActor, 0x02 = revokeActor
         bytes32 actorId;
-        bytes configData;  // ActorConfig for authorize, empty for revoke
+        bytes data;        // operation-specific (see Config Change Format)
     }
 
-    event ActorAuthorized(address indexed account, bytes32 indexed actorId, ActorConfig config);
+    event ActorAuthorized(address indexed account, bytes32 indexed actorId, ActorConfig config, address policyManager, bytes32 policyCommitment);
     event ActorRevoked(address indexed account, bytes32 indexed actorId);
     event AccountCreated(address indexed account, bytes32 userSalt, bytes32 codeHash);
     event AccountImported(address indexed account);
@@ -774,6 +847,9 @@ interface IAccountConfiguration {
     function isInitialized(address account) external view returns (bool);
     function isActor(address account, bytes32 actorId) external view returns (bool);
     function getActorConfig(address account, bytes32 actorId) external view returns (ActorConfig memory);
+    // Resolves the policy gate target and signed commitment:
+    //   0x00 -> (address(0), bytes32(0)); non-zero -> (manager, commitment)
+    function getPolicy(address account, bytes32 actorId) external view returns (address target, bytes32 commitment);
     function getChangeSequences(address account) external view returns (ChangeSequences memory);
     function isLocked(address account) external view returns (bool);
     function getLockStatus(address account) external view returns (bool locked, bool hasInitiatedUnlock, uint40 unlocksAt, uint16 unlockDelay);
@@ -825,11 +901,15 @@ Read-only. The protocol manages nonce storage directly; there are no state-modif
 
 ## Security Considerations
 
-**Validation Surface**: For pure verifiers, invalidators are `actor_config` revocation and nonce consumption. Stateful verifiers additionally depend on traced state; invalidation tracking is a mempool concern.
+**Validation Surface**: For pure verifiers, invalidators are `actor_config` changes and nonce consumption. Stateful verifiers additionally depend on traced state; invalidation tracking is a mempool concern.
 
 **Replay Protection**: Transactions include `chain_id`, 2D nonce (`nonce_key`, `nonce_sequence`), and `expiry`. For `NONCE_KEY_MAX` (nonce-free mode), replay protection relies on short-lived `expiry` and deduplication by the signature-invariant [Nonce-Free Replay Identifier](#nonce-free-replay-identifier) (`replay_id`). The mempool enforces a tight expiry window (e.g., 10-30 seconds) to bound the window. Block builders MUST NOT include two `NONCE_KEY_MAX` transactions with the same `replay_id`. The identifier deliberately excludes `sender_auth` and `payer_auth`: keying on the full transaction hash would let a sponsor re-sign `payer_auth`, or an attacker exploit `sender_auth` malleability, to admit or include duplicates of one logical transaction (see [Nonce-Free Replay Identifier](#nonce-free-replay-identifier)).
 
-**Actor Scope**: Protocol-enforced after verifier execution — a verifier cannot bypass scope checking.
+**Actor Scope and Policy**: Scope is protocol-enforced after verifier execution during validation — a verifier cannot bypass it. The policy gate is protocol-enforced during execution (a `call.to` other than the resolved target reverts with `PolicyViolation`) and is likewise outside verifier control; because it is an execution-time gate rather than a validity input, it is not a mempool filter for compromised keys (see [Why Policy Types?](#why-policy-types)). The gate covers only SENDER-context calls, so a policy-bearing actor is barred at authorization from unrestricted (`0x00`) and CONFIG scope — a CONFIG-scoped key could authorize new actors and escape its policy — while any PAYER or SIGNATURE scope it holds is not policy-constrained (see [Actor Policies](#actor-policies)).
+
+**Policy Target as Trust Anchor**: For a policy-bearing actor, the resolved target is fully trusted to enforce the committed limits; the key can only reach that target, which decides what happens next. A buggy or malicious manager can do anything its own authority over the account allows. Accounts SHOULD point restricted keys only at audited managers and treat installing one with the same care as granting that contract authority over the account. A manager (and any policy it enforces) SHOULD be non-upgradeable: an upgradeable manager lets whoever controls the upgrade rewrite enforcement, which is equivalent to granting that party root access over everything the manager can do for the account. The committed parameters and any target-held state are the target's own authorization surface; checking that `keccak256(params)` matches the stored commitment is the target's responsibility, not the protocol's. How the target obtains authority to act for the account is out of scope for this specification.
+
+**Policy State on Revocation**: `revokeActor` clears `actor_config`, `policy_commitment`, and `policy_manager` — all keyed by `(account, actorId)` — which immediately stops the key from reaching its target; there are no per-target protocol entries to enumerate or resurrect, and storage is fully reclaimed. Any parameters a target keeps in its own storage are not protocol state and are not auto-cleared; wallets uninstall them through the target when retiring a key, and an `expiry` bounds the window during which a not-yet-uninstalled key could otherwise be used.
 
 **Actor Management**: Config change authorization requires CONFIG scope. The EOA actor is implicitly authorized with unrestricted scope; revocable via portable config change. All actor modification paths are blocked when the account is locked.
 
@@ -841,7 +921,7 @@ Read-only. The protocol manages nonce storage directly; there are no state-modif
 
 **Cross-sender Payer Replay**: The payer signature hash binds to the resolved sender via the `sender` field (see [Signature Payload](#signature-payload)). In the EOA path where `sender` is empty in the wire format, the recovered sender address MUST be substituted into the `sender` position before computing the hash. Without this substitution, two different EOAs that construct otherwise identical transaction data (same `chain_id`, `nonce_key`, `nonce_sequence`, `expiry`, fees, `account_changes`, `calls`) would produce identical payer hashes, allowing a second EOA to reuse a payer signature originally issued for the first and drain the payer's gas deposit. The 2D nonce alone does not prevent this: `nonce_key` and `nonce_sequence` are fields in the transaction payload, so each attacker controls their own values. Substituting the recovered sender into the hash makes the payer's commitment per-sender and closes this replay path. The configured-actor path is unaffected because `sender` is non-empty by definition.
 
-**Account Creation Security**: `initial_actors` (verifier + actorId + scope tuples) are salt-committed, preventing front-running of actor assignment. Wallet bytecode should be inert when uninitialized as it can be permissionlessly deployed. The create entry applies only to addresses that satisfy CREATE2 freshness. Without the nonce check, a create entry could be replayed against an EOA that has transaction history at the counterfactual address. Direct code placement also bypasses CREATE/CREATE2's [EIP-170](./eip-170.md) `MAX_CODE_SIZE` check, so the protocol enforces `len(code) <= MAX_CODE_SIZE` explicitly to keep the placed code within the EVM contract size limit.
+**Account Creation Security**: `initial_actors` (verifier + actorId + scope + policyType + expiry + manager + commitment, per [Address Derivation](#address-derivation)) are salt-committed, preventing front-running of actor assignment or the initial policy binding. Wallet bytecode should be inert when uninitialized as it can be permissionlessly deployed. The create entry applies only to addresses that satisfy CREATE2 freshness. Without the nonce check, a create entry could be replayed against an EOA that has transaction history at the counterfactual address. Direct code placement also bypasses CREATE/CREATE2's [EIP-170](./eip-170.md) `MAX_CODE_SIZE` check, so the protocol enforces `len(code) <= MAX_CODE_SIZE` explicitly to keep the placed code within the EVM contract size limit.
 
 ## Copyright
 


### PR DESCRIPTION
## Summary

Rebased replacement for #11648, which had become unmergeable due to some eth-bot bug.

* Adds an optional per-actor call policy selected by a `policyType` byte in `actor_config`, with a signed `commitment` and `manager` in separate policy slots keyed by `(account, actorId)`.
* Enforcement is at execution, not validation: the protocol never reads the policy slots when deciding validity, so policy stays off the mempool validity surface and a single `actor_config` SLOAD still decides validity. Calls under a `policyType != 0x00` actor are gated to the stored manager (a non-matching `call.to` reverts with `PolicyViolation`).
* Adds a `uint48` per-actor `expiry` enforced at validation from the same SLOAD (`0` = no expiry), threaded through create tuples, the creation commitment preimage, `authorizeActor` data, and the `ActorConfig` struct.
* Restricts policy-bearing actor scope (neither unrestricted nor CONFIG) and notes managers/policies should be non-upgradeable.

## Test plan

* `git diff --check`
* Verified the diff against `master` contains only the intended policy/expiry additions in `actor` terminology (no stray `owner` references, finalized precompile/interface names preserved).