### PR TITLE
Add EIP: AI Agent Identity and Threat Registry

### DIFF
--- a/EIPS/eip-8259.md
+++ b/EIPS/eip-8259.md
@@ -1,0 +1,408 @@
+---
+title: AI Agent Identity and Threat Registry
+description: A standard interface for decentralized identity management, dynamic reputation scoring, and trustless threat intelligence sharing for autonomous AI agents on EVM networks.
+author: Ibonon (@ibonon)
+discussions-to: https://ethereum-magicians.org/t/erc-8259-ai-agent-identity-threat-registry/28473
+status: Draft
+type: Standards Track
+category: ERC
+created: 2026-05-07
+requires: 165
+---
+
+## Abstract
+
+This proposal defines a standard interface for autonomous AI agents operating on EVM-compatible
+networks to register a Decentralized Identifier (DID), accumulate a portable reputation score,
+and participate in collaborative on-chain threat intelligence sharing. Three composable interfaces
+are introduced: `IAgentIdentity`, `IAgentReputation`, and `IThreatRegistry`. Together they enable
+DeFi protocols, agent frameworks, and infrastructure providers to programmatically assess the
+trustworthiness of an AI agent before granting execution privileges, without relying on
+off-chain oracles or centralized databases.
+
+## Motivation
+
+The Agentic Economy is not a future concept—it is live. As of 2026, over 400,000 ElizaOS-based
+agents hold real wallets and execute real on-chain transactions. Virtuals Protocol has tokenized
+thousands of AI agents that interact with DeFi protocols autonomously. Autonolas (OLAS) runs
+over 500 autonomous on-chain services managing real funds.
+
+Current Ethereum standards are insufficient to secure this new class of actors:
+
+- **ERC-725** (Identity) provides key management but no behavioral reputation.
+- **ERC-4337** (Account Abstraction) abstracts transaction validation but carries no risk semantics.
+- **ERC-734/735** (Claims) lack the high-frequency, verifiable scoring mechanics required for
+  real-time Agent-to-Agent (A2A) risk assessment.
+
+The absence of a portable trust layer creates four compounding problems:
+
+1. **Identity Fragmentation**: An agent that burns its wallet after an attack can re-register
+   anywhere with a clean record.
+2. **Reputation Silos**: Behavioral history is trapped per protocol and cannot be queried
+   cross-protocol without trusted intermediaries.
+3. **Threat Intelligence Gaps**: A drain-star attack detected by Protocol A is invisible to
+   Protocol B until after damage is done.
+4. **Credit Inaccessibility**: DeFi lending protocols cannot issue credit lines to AI agents
+   because there is no standard solvency signal—blocking a multi-trillion-dollar market.
+
+This standard bridges these gaps by providing a minimal, composable registry that any
+protocol can read in a single `staticcall`.
+
+## Specification
+
+The key words MUST, MUST NOT, REQUIRED, SHALL, SHALL NOT, SHOULD, SHOULD NOT, RECOMMENDED,
+NOT RECOMMENDED, MAY, and OPTIONAL in this document are to be used as interpreted in RFC 2119
+and RFC 8174.
+
+### Definitions
+
+- **AI Agent**: An autonomous software entity that signs and submits transactions without
+  continuous human intervention.
+- **DID**: A Decentralized Identifier following the W3C DID Core specification
+  (format: `did:erc8259:<chainId>:<address>`).
+- **Reputation Score**: An unsigned integer in the range `[0, 1000]` representing an agent's
+  normalized behavioral trustworthiness. `1000` is maximum trust, `0` is untrusted.
+- **Verification Tier**: An ordinal in `{0, 1, 2, 3, 4}` representing escalating levels of
+  identity assurance (None, Bronze, Silver, Gold, Platinum).
+- **Threat Pattern**: A `bytes32` value computed as
+  `keccak256(abi.encodePacked(actionType, destinationAddress, amountBucket))` representing
+  a standardized suspicious behavior fingerprint.
+
+---
+
+### Interface 1 — `IAgentIdentity`
+
+Handles DID registration and resolution.
+
+```solidity
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.20;
+
+interface IAgentIdentity {
+
+    struct AgentIdentity {
+        string  did;                    // "did:erc8259:<chainId>:<address>"
+        bytes32 publicKeyHash;          // keccak256 of Ed25519 or secp256k1 public key
+        uint8   verificationTier;       // 0=None 1=Bronze 2=Silver 3=Gold 4=Platinum
+        uint16  reputationScore;        // 0–1000
+        uint64  registrationTime;       // block.timestamp at registration
+        uint64  lastUpdate;             // block.timestamp of last mutation
+        string  metadataURI;            // IPFS CID or HTTPS URI for off-chain metadata
+        bool    isActive;
+    }
+
+    /// @notice Emitted when a new agent DID is registered.
+    event AgentRegistered(
+        string  indexed did,
+        address indexed agentAddress,
+        uint8           verificationTier,
+        uint64          registrationTime
+    );
+
+    /// @notice Emitted when an agent's reputation score changes.
+    event ReputationUpdated(
+        string  indexed did,
+        uint16          oldScore,
+        uint16          newScore,
+        string          reason
+    );
+
+    /// @notice Register a new AI agent identity.
+    /// @dev    MUST revert if `did` is already registered.
+    ///         MUST emit `AgentRegistered`.
+    /// @param  did             W3C DID string.
+    /// @param  publicKeyHash   Hash of the agent's signing key.
+    /// @param  verificationTier Initial tier (callers MAY pass 0 for self-registration).
+    /// @param  metadataURI     Off-chain metadata pointer.
+    /// @return agentId         Unique monotonically increasing identifier.
+    function registerAgent(
+        string  calldata did,
+        bytes32          publicKeyHash,
+        uint8            verificationTier,
+        string  calldata metadataURI
+    ) external payable returns (uint256 agentId);
+
+    /// @notice Resolve a DID to an Ethereum address.
+    /// @return The registered address, or address(0) if not found.
+    function getAgentByDID(string calldata did)
+        external view returns (address);
+
+    /// @notice Retrieve full identity data for an agent address.
+    function getAgentIdentity(address agentAddress)
+        external view returns (AgentIdentity memory);
+
+    /// @notice Returns true if the agent is registered and has verificationTier > 0.
+    function isVerified(address agentAddress)
+        external view returns (bool);
+}
+```
+
+---
+
+### Interface 2 — `IAgentReputation`
+
+Handles mutable reputation scoring. Score updates MUST be restricted to authorized oracles
+or governance-controlled addresses.
+
+```solidity
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.20;
+
+interface IAgentReputation {
+
+    /// @notice Update the reputation score of a registered agent.
+    /// @dev    MUST revert if caller is not an authorized oracle.
+    ///         Score MUST be clamped to [0, 1000].
+    ///         MUST emit `ReputationUpdated` on IAgentIdentity.
+    /// @param  agentAddress  The agent whose score is being updated.
+    /// @param  newScore      New score value (0–1000).
+    /// @param  reason        Human-readable justification (stored off-chain via event).
+    function updateReputationScore(
+        address agentAddress,
+        uint16  newScore,
+        string  calldata reason
+    ) external;
+
+    /// @notice Upgrade or downgrade the verification tier of an agent.
+    /// @dev    MUST revert if caller is not an authorized verifier.
+    function updateVerificationTier(
+        address agentAddress,
+        uint8   newTier
+    ) external payable;
+
+    /// @notice Compute a normalized trust score combining tier and raw reputation.
+    /// @return A value in [0, 1000].
+    function calculateTrustScore(address agentAddress)
+        external view returns (uint16);
+}
+```
+
+Reference scoring formula (implementations MAY vary but MUST be documented):
+
+```
+trustScore = clamp(
+    (reputationScore × tierMultiplier(verificationTier)) / 100,
+    0,
+    1000
+)
+
+tierMultiplier:
+    None     →  50   (0.5×)
+    Bronze   → 100   (1.0×)
+    Silver   → 150   (1.5×)
+    Gold     → 200   (2.0×)
+    Platinum → 300   (3.0×)
+```
+
+---
+
+### Interface 3 — `IThreatRegistry`
+
+Enables cross-protocol threat intelligence sharing.
+
+```solidity
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.20;
+
+interface IThreatRegistry {
+
+    struct AttackRecord {
+        address agentAddress;    // Agent wallet at time of attack
+        bytes32 patternHash;     // keccak256(actionType ‖ destination ‖ amountBucket)
+        uint256 amountUSDC6;     // Amount in 6-decimal USDC units
+        uint32  riskMilli;       // Risk score × 1000 (0–1_000_000)
+        uint8   layer;           // 1=Behavior 2=Splitting 3=Service 4=Contract
+        uint64  blockedAt;       // block.timestamp
+    }
+
+    /// @notice Emitted when an attack is recorded.
+    event AttackBlocked(
+        uint256 indexed recordId,
+        address indexed agentAddress,
+        bytes32 indexed patternHash,
+        uint256         amountUSDC6,
+        uint32          riskMilli,
+        uint8           layer
+    );
+
+    /// @notice Emitted when a new threat pattern is broadcast.
+    event ThreatPatternShared(
+        bytes32 indexed patternHash,
+        address indexed reporter,
+        uint32          riskScore,
+        string          description
+    );
+
+    /// @notice Record a blocked attack for future cross-protocol queries.
+    /// @dev    MUST revert if caller is not an authorized security oracle.
+    ///         MUST emit `AttackBlocked`.
+    function recordAttack(
+        address agentAddress,
+        bytes32 patternHash,
+        uint256 amountUSDC6,
+        uint32  riskMilli,
+        uint8   layer
+    ) external returns (uint256 recordId);
+
+    /// @notice Broadcast a new threat pattern to the network.
+    /// @dev    Any caller MAY invoke this; governance SHOULD rate-limit submissions.
+    function shareThreatPattern(
+        bytes32 patternHash,
+        uint32  riskScore,
+        string  calldata description
+    ) external;
+
+    /// @notice Returns true if the agent has at least one recorded attack.
+    function isKnownAttacker(address agentAddress)
+        external view returns (bool);
+
+    /// @notice Returns the total number of recorded attacks and cumulative blocked amount
+    ///         for a given agent.
+    function getAgentAttackHistory(address agentAddress)
+        external view returns (uint256 attackCount, uint256 totalBlockedUSDC6);
+
+    /// @notice Compute a risk score for a pending transaction.
+    /// @param  agentAddress   The agent initiating the transaction.
+    /// @param  amountUSDC6    Amount in 6-decimal USDC.
+    /// @param  actionHash     keccak256 of the action type string.
+    /// @return riskScore      A value in [0, 1000].
+    function assessTransactionRisk(
+        address agentAddress,
+        uint256 amountUSDC6,
+        bytes32 actionHash
+    ) external view returns (uint256 riskScore);
+}
+```
+
+### Threat Pattern Computation
+
+Implementations MUST compute threat patterns as follows to ensure cross-protocol
+interoperability:
+
+```solidity
+bytes32 patternHash = keccak256(abi.encodePacked(
+    actionType,      // string: "DRAIN_STAR" | "MIXING_CHAIN" | "COORDINATED_CLUSTER"
+    destination,     // address: target contract
+    amountBucket     // uint256: floor(amount / 1000e6) — bucket by $1,000 USDC
+));
+```
+
+### ERC-165 Support
+
+Compliant implementations MUST implement ERC-165 and return `true` for the following
+interface IDs:
+
+| Interface | ID |
+|---|---|
+| `IAgentIdentity` | `0x4d5f3ed2` |
+| `IAgentReputation` | `0x9a8f3c11` |
+| `IThreatRegistry` | `0xb72f4e07` |
+
+### Verification Tier Requirements
+
+| Tier | Name | Minimum Requirements | Validity |
+|---|---|---|---|
+| 0 | None | DID self-registration | Indefinite |
+| 1 | Bronze | Social proof (GitHub/Twitter) | 90 days |
+| 2 | Silver | KYC + 1,000 token stake | 180 days |
+| 3 | Gold | Enhanced KYC + 10,000 token stake | 365 days |
+| 4 | Platinum | Third-party audit + 50,000 token stake | 730 days |
+
+Implementations MAY substitute alternative verification mechanisms, provided they are
+documented in the contract's metadata and the requirements are at least as stringent.
+
+## Rationale
+
+### Why not extend ERC-725?
+
+ERC-725 provides a generic key-value store for identity claims. It does not define
+reputation semantics, threat pattern structures, or cross-protocol sharing interfaces.
+Extending ERC-725 would impose a proxy architecture that is incompatible with many
+existing DeFi integrations. ERC-8259 is designed to be a thin, read-optimized oracle
+that existing contracts can query with a single `staticcall`.
+
+### Why `bytes32` for threat patterns rather than structured types?
+
+`bytes32` hashes are gas-efficient to store, index, and compare on-chain. The
+deterministic hash formula specified above ensures that independently computed patterns
+are identical across implementations, enabling cross-protocol correlation without
+requiring shared storage.
+
+### Why capped at 1,000?
+
+A range of `[0, 1000]` maps directly to basis points (BPS), the standard unit for
+DeFi fee and risk calculations. This allows integrating protocols to express
+thresholds such as "require score ≥ 700 BPS for uncollateralized lending" without
+additional conversion.
+
+### Why three separate interfaces?
+
+Composability. A lightweight L2 deployment MAY implement only `IAgentIdentity`. A full
+security oracle MAY implement all three. DeFi protocols can selectively integrate the
+interfaces relevant to their risk model.
+
+## Backwards Compatibility
+
+This standard introduces new interfaces and does not modify any existing ERC. It is
+fully additive. Existing contracts that do not implement `IAgentIdentity` will simply
+return `address(0)` from `getAgentByDID`, which integrating protocols MUST handle
+gracefully.
+
+ERC-165 support allows runtime detection of which interfaces a given registry exposes.
+
+## Reference Implementation
+
+A reference implementation is available at:
+`https://github.com/ibonon/Sigui`
+
+The deployed contract on Ethereum Sepolia testnet is located at:
+`0x3806aeb76eDD2E22D3cF66A163113c4b24243b29`
+
+Key files:
+
+- `contracts/AgentRegistry.sol` — Reference implementation of all three interfaces
+- `sdk/python/sigui/` — Python SDK (`pip install sigui`)
+- `modules/identity/` — Off-chain agent DID management
+
+## Security Considerations
+
+### Oracle Authorization
+
+Implementations MUST restrict calls to `updateReputationScore`, `updateVerificationTier`,
+and `recordAttack` to explicitly authorized addresses. A compromised oracle can set all
+agent scores to 0 or whitelist malicious agents. Implementations SHOULD use a
+multi-oracle consensus (e.g., 2-of-3 threshold) before committing score mutations.
+
+### Sybil Resistance
+
+An adversary can create a new agent address to reset their score to the default (500).
+Mitigations include:
+
+- Requiring a staking deposit proportional to the initial tier requested.
+- Linking DID registration to an ERC-721 soul-bound token (SBT) tied to a real-world
+  identity claim.
+- Implementing a registration cooldown per originating EOA.
+
+### False Positive Risk
+
+An incorrectly blocked agent suffers economic harm. Implementations MUST provide an
+on-chain appeal mechanism that routes disputes to governance or a designated arbitrator.
+The `AttackRecord` SHOULD be soft-deletable pending appeal resolution.
+
+### Front-Running of `recordAttack`
+
+An attacker monitoring the mempool may detect a pending `recordAttack` call and
+front-run it to transfer funds before the block is mined. Implementations SHOULD
+combine `recordAttack` with `pauseAgent` in a single atomic transaction, or use
+commit-reveal schemes for sensitive threat submissions.
+
+### Privacy
+
+Agent DIDs and attack records are public by design. Agents that require confidentiality
+for their transaction strategies SHOULD use Zero-Knowledge proofs to attest compliance
+with threat pattern absence without revealing transaction content. This is outside the
+scope of this standard but is compatible with the interface design.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](../LICENSE.md).


### PR DESCRIPTION
## Summary

This PR proposes **ERC-8259**, a minimal, composable standard for autonomous AI agents operating on EVM-compatible networks. It defines three orthogonal interfaces — `IAgentIdentity`, `IAgentReputation`, and `IThreatRegistry` — that together form a portable trust and threat intelligence layer, queryable by any smart contract via a single `staticcall`.

## Problem

The Agentic Economy is not a future concept. As of 2026:

- **ElizaOS** has deployed over 400,000 agents with real Ethereum wallets executing on-chain transactions autonomously
- **Virtuals Protocol** has tokenized thousands of AI agents that interact directly with DeFi protocols
- **Autonolas (OLAS)** runs 500+ autonomous on-chain services managing real capital

Yet no Ethereum standard addresses the fundamental trust problem these agents create. Existing standards fall short:

| Standard | Gap |
|---|---|
| **ERC-725** (Identity) | Key management only — no behavioral reputation, no threat semantics |
| **ERC-4337** (Account Abstraction) | Transaction validation — no risk scoring, no cross-protocol memory |
| **ERC-734/735** (Claims) | Static attestations — no high-frequency real-time risk signaling |

Without a portable reputation layer, a malicious agent can drain Protocol A, burn its wallet, and re-register at Protocol B with a clean record in seconds. This is not theoretical — coordinated AI agent drain attacks are an active and growing threat vector.

## Solution

ERC-8259 introduces three composable interfaces:

**`IAgentIdentity`** — DID registration (`did:erc8259:<chainId>:<address>`) and resolution. Maps an agent's execution wallet to a persistent, cross-protocol Decentralized Identifier.

**`IAgentReputation`** — Mutable trust score (`uint16`, range 0–1000, expressed in basis points). Score updates are restricted to authorized oracles. The scoring formula is: