### PR TITLE
Update EIP-8037: unfair allocation of EIP-7702 overcharges

### DIFF
--- a/EIPS/eip-8037.md
+++ b/EIPS/eip-8037.md
@@ -159,28 +159,27 @@ The same rules apply when the top-level call frame reverts or halts. Here, `stat
 
 ##### Gas accounting for [EIP-7702](./eip-7702.md) authorizations
 
-Intrinsic gas charges the worst-case state-gas cost (`(STATE_BYTES_PER_NEW_ACCOUNT + STATE_BYTES_PER_AUTH_BASE) × CPSB`) for each authorization. However, an authority's account leaf and its 23 byte delegation indicator can only be written once per transaction, even if the same authority appears in multiple authorizations. Therefore, per authorization adjustments are applied while processing the authorization list.
+Intrinsic gas charges the worst-case gas cost for each authorization, and this worst-case amount is included in `intrinsic_state_gas` and `intrinsic_regular_gas`. An authority's account leaf and its 23 byte delegation indicator can only be written once per transaction, even if the same authority appears in multiple authorizations, thus, per authorization adjustments must be applied while processing the authorization list.
 
-The adjustments enforce a single invariant: the `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` account-leaf portion is charged at most once per authority and only when the account did not exist before the transaction, and the `STATE_BYTES_PER_AUTH_BASE × CPSB` delegation-indicator portion is charged at most once per authority and only when the authority ends the transaction delegated having started it undelegated.
+The adjustments enforce a single invariant: the `STATE_BYTES_PER_NEW_ACCOUNT × CPSB + ACCOUNT_WRITE` account-leaf portion is charged at most once per authority and only when the account did not exist before the transaction, and the `STATE_BYTES_PER_AUTH_BASE × CPSB` delegation-indicator portion is charged at most once per authority and only when the authority ends the transaction delegated having started it undelegated.
+
 Processing reads the account state at two points:
 
 - **pre-transaction state**: the account state before transaction execution.
 - **current state**: the account state while processing authorizations, updated after each authorization.
 
-For each authorization, let `cur_delegated` be `true` when the authority has a non-empty delegation indicator in the **current state**, and `pre_delegated` be `true` when it had one in the **pre-transaction state**. 
+For each authorization, let `cur_delegated` be `true` when the authority has a non-empty delegation indicator in the **current state**, and `pre_delegated` be `true` when it had one in the **pre-transaction state**.
 
 Authorization processing follows 3 gas accounting rules:
 
-**1. Invalid authorizations.** Invalid authorizations are skipped without per-auth processing. Their entire intrinsic state-gas portion, `(STATE_BYTES_PER_NEW_ACCOUNT + STATE_BYTES_PER_AUTH_BASE) × CPSB`, is refilled to `state_gas_reservoir` and `ACCOUNT_WRITE` is refunded to the refund counter.
+**1. Invalid authorizations.** Invalid authorizations are skipped without per-auth processing. The `(STATE_BYTES_PER_NEW_ACCOUNT + STATE_BYTES_PER_AUTH_BASE) × CPSB` portion is credited back to `intrinsic_state_gas` and the `ACCOUNT_WRITE` portion is credited back to `intrinsic_regular_gas`.
 
-**2. Account-leaf refill.** If the authority's account leaf already exists in the **current state** (non-zero nonce, non-zero balance, or non-empty code), refill `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` to `state_gas_reservoir` and refund `ACCOUNT_WRITE` to the refund counter.
+**2. Account-leaf refill.** If the authority's account leaf already exists in the **current state** (non-zero nonce, non-zero balance, or non-empty code), the `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` portion is credited back to `intrinsic_state_gas` and the `ACCOUNT_WRITE` portion is credited back to `intrinsic_regular_gas`.
 
 **3. Delegation-indicator refill.**
 
-- If `authorization.address` is not `ZERO` (setting a delegation), refill `STATE_BYTES_PER_AUTH_BASE × CPSB` to `state_gas_reservoir` when `cur_delegated` or `pre_delegated` is `true`. In that case the 23-byte indicator slot is already occupied, so this authorization overwrites it without writing new bytes. Otherwise this authorization performs the net-new creation and its intrinsic charge stands.
-- If `authorization.address` is `ZERO` (clearing the delegation), refill `STATE_BYTES_PER_AUTH_BASE × CPSB` to `state_gas_reservoir`, since the clear writes no indicator. Additionally, when `cur_delegated` is `true` and `pre_delegated` is `false`, refill another `STATE_BYTES_PER_AUTH_BASE × CPSB`: the delegation being cleared was created by an earlier authorization in this same transaction, so the chain writes zero net delegation bytes and the earlier creation charge is no longer justified. This covers patterns such as `0->a->0`, where the creation by an earlier authorization is undone by a later clearing one in the same list.
-
-`execution_state_gas_used` decreases by the corresponding amount of state-gas refills. Because `execution_state_gas_used` is initialized to `0`, this refill may bring it below zero before any execution-time charges. Implementations may equivalently track the refill separately and subtract it from `tx_state_gas` when accumulating `block_state_gas_used`.
+- If `authorization.address` is not `ZERO` (setting a delegation), the `STATE_BYTES_PER_AUTH_BASE × CPSB` portion is credited back to `intrinsic_state_gas` when `cur_delegated` or `pre_delegated` is `true`. In that case the 23-byte indicator slot is already occupied, so this authorization overwrites it without writing new bytes. Otherwise this authorization performs the net-new creation and its intrinsic charge stands.
+- If `authorization.address` is `ZERO` (clearing the delegation), the `STATE_BYTES_PER_AUTH_BASE × CPSB` portion is credited back to `intrinsic_state_gas`, since the clear writes no indicator. Additionally, when `cur_delegated` is `true` and `pre_delegated` is `false`, credit back another `STATE_BYTES_PER_AUTH_BASE × CPSB` to the `intrinsic_state_gas`: the delegation being cleared was created by an earlier authorization in this same transaction, so the chain writes zero net delegation bytes and the earlier creation charge is no longer justified. This covers patterns such as `0->a->0`, where the creation by an earlier authorization is undone by a later clearing one in the same list.
 
 #### Pre-state and post-state gas validation
 


### PR DESCRIPTION
In EIP-8037 worst cases are charged for EIP-7702 authorization processing before actually processing them, so the user has to commit a lot more gas even if their authorization list does not incur the worst case. This is fine as it prevents compute grieving attacks.
These overcharges are later corrected while processing the delegations but they are allocated to the state gas pool or refund counter, e.g., they cannot be used for compute any longer. This doesn't feel like an efficient allocation of gas for the transaction and plays against what the user initially set.

My main point here is that these are overcharges and should be corrected inline (against `intrinsic_*_gas`), not thrown into the state reservoir of refund counter. As a simple example, If a user has supplied a `gas limit < TX_MAX_GAS_LIMIT + EIP-7702` worst case meaning that it intends to mostly do compute, it will see some of the gas available for compute move into the state reservoir if a non worst case authorization list is supplied. This is the normal, happy path, while updating delegations, not some sort of edge case.

https://hackmd.io/@yLS7PKbzTHyB7H_THgC9Cg/ByN9odTgMg