### PR TITLE
Update EIP-8268: remove redundant storage roots validation

### DIFF
--- a/EIPS/eip-8268.md
+++ b/EIPS/eip-8268.md
@@ -51,8 +51,7 @@ Entries that describe accessed-but-unchanged accounts (every change list empty) 
 
 A block is invalid if, for any `AccountChanges` carrying `storage_root`:
 
-- the post-block storage trie is non-empty and `storage_root` is not its 32-byte storage trie root produced by executing the block; or
-- the post-block storage trie is empty and `storage_root` is not the empty byte string.
+- if the `block_access_list_hash` for the BAL generated during block execution donot match the `block_access_list_hash` in header.
 
 Equivalently, every empty storage trie MUST be encoded as the empty byte string and every non-empty storage trie as its 32-byte root, so each block has exactly one valid encoding.
 

--- a/EIPS/eip-8268.md
+++ b/EIPS/eip-8268.md
@@ -49,9 +49,7 @@ Entries that describe accessed-but-unchanged accounts (every change list empty) 
 
 ### Validation
 
-A block is invalid if, for any `AccountChanges` carrying `storage_root`:
-
-- if the `block_access_list_hash` for the BAL generated during block execution donot match the `block_access_list_hash` in header.
+A block is invalid if the `block_access_list_hash` for the BAL generated during block execution do not match the `block_access_list_hash` in header.
 
 Equivalently, every empty storage trie MUST be encoded as the empty byte string and every non-empty storage trie as its 32-byte root, so each block has exactly one valid encoding.
 


### PR DESCRIPTION
We can probably skip validating `storage_root` for each `AccountChanges`, since validation of `block_access_list_hash`  from BAL built during execution against one in block header  should essentially take care of it.
