### PR TITLE
Update EIP-8081: add newly PFId EIPs

### DIFF
--- a/EIPS/eip-8081.md
+++ b/EIPS/eip-8081.md
@@ -33,10 +33,18 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Declined
 * [EIP-4758](./eip-4758.md): Deactivate SELFDESTRUCT
 * [EIP-7709](./eip-7709.md): Read BLOCKHASH from storage and update cost
 * [EIP-7716](./eip-7716.md): Anti-correlation attestation penalties
+* [EIP-7851](./eip-7851.md): Code-Controlled EOA Delegation
+* [EIP-7979](./eip-7979.md): Call and Return Opcodes for the EVM
 * [EIP-8025](./eip-8025.md): Optional Execution Proofs
+* [EIP-8131](./eip-8131.md): Add Auth Data to EIP-7623 Floor
 * [EIP-8148](./eip-8148.md): Custom sweep threshold for validators.
+* [EIP-8151](./eip-8151.md): ECDSA Authority Deactivation Aware ecRecover
+* [EIP-8163](./eip-8163.md): Reserve `EXTENSION (0xae)` opcode
+* [EIP-8173](./eip-8173.md): Foundations of EVM Control Flow
+* [EIP-8182](./eip-8182.md): Private ETH and ERC-20 Transfers
 * [EIP-8188](./eip-8188.md): State Tiering by Write Age
 * [EIP-8205](./eip-8205.md): Withdrawal credentials preregistration
+* [EIP-8237](./eip-8237.md): Independent CL/EL Sync
 * [EIP-8253](./eip-8253.md): Bump nonce of zero-nonce storage accounts
 
 ### Activation


### PR DESCRIPTION
Add to Hegotá PFIs:
- EIP-7851: Code-controlled EOA Delegation, proposed by @lightclient on [ACDE 238](https://forkcast.org/calls/acde/238#t=3929)
- EIP-7979: Call and Return Opcodes for the EVM, proposed by @gcolvin on [ACDE 235](https://forkcast.org/calls/acde/235#t=4081)
- EIP-8131: Add Auth Data to EIP-7623 Floor, proposed by @nerolation on [ACDE 238](https://forkcast.org/calls/acde/238#t=1477)
- EIP-8151: ECDSA Authority Deactivation Aware ecRecover, proposed by @lightclient on [ACDE 238](https://forkcast.org/calls/acde/238#t=3929)
- EIP-8163: Reserve `EXTENSION (0xae)` opcode, proposed by @pdobacz on [ACDE 235](https://forkcast.org/calls/acde/235#t=4081)
- EIP-8173: Foundations of EVM Control Flow, proposed by @gcolvin on [ACDE 238](https://forkcast.org/calls/acde/238#t=2164)
- EIP-8237: Independent CL/EL Sync, proposed by @potuz on [ACDE 235](https://forkcast.org/calls/acde/235#t=1921)
- EIP-8182: Private ETH and ERC-20 Transfer, proposed by @RogerPodacter on [ACDE 237](https://forkcast.org/calls/acde/237#t=2172)
- EIP-8279: Block Access Byte Floor, proposed by @nerolation on [ACDE 238](https://forkcast.org/calls/acde/238#t=1477)

Addresses 
https://github.com/ethereum/EIPs/pull/11615 (can't close, still 2 open EIPs there)

Closes
https://github.com/ethereum/EIPs/pull/11506
https://github.com/ethereum/EIPs/pull/11561
https://github.com/ethereum/EIPs/pull/11568