### PR TITLE
Update EIP-7773: Add EIP-8189 to Glamsterdam CFI networking EIPs

### DIFF
--- a/EIPS/eip-7773.md
+++ b/EIPS/eip-7773.md
@@ -49,6 +49,7 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Declined
 * [EIP-8070](./eip-8070.md): eth/72 - Sparse Blobpool
 * [EIP-8136](./eip-8136.md): Cell-Level Deltas for Data Column Broadcast
 * [EIP-8159](./eip-8159.md): eth/71 - Block Access List Exchange
+* [EIP-8189](./eip-8189.md): snap/2 - BAL-Based State Healing
 
 ### Proposed for Inclusion
 


### PR DESCRIPTION
Adds [EIP-8189](https://eips.ethereum.org/EIPS/eip-8189) (snap/2 - BAL-Based State Healing) to the Networking EIPs subsection under Considered for Inclusion in the Glamsterdam hardfork meta EIP.

EIP-8189 builds on [EIP-7928](https://eips.ethereum.org/EIPS/eip-7928) (Block-Level Access Lists), which is already Scheduled for Inclusion in Glamsterdam.