### PR TITLE
Update EIP-8130: authenticateActor returns scope, policyType, policyTarget

### DIFF
--- a/EIPS/eip-8130.md
+++ b/EIPS/eip-8130.md
@@ -863,10 +863,13 @@ interface IAccountConfiguration {
 
     // Signature verification and actor authentication
     // verifySignature: ERC-1271-style boolean check; returns false on any failure.
-    // authenticateActor: resolves the authenticating actor and returns its scope byte; reverts on failure
-    //              (invalid signature, unknown/revoked actor, or actorId not bound to the auth authenticator).
+    // authenticateActor: resolves the authenticating actor and returns its full authorization surface;
+    //              reverts on failure (invalid signature, unknown/revoked actor, or actorId not bound
+    //              to the auth authenticator). Returns the actor's scope byte, its policyType byte
+    //              (0x00 = ungated), and the resolved policyTarget (the policy manager, or address(0)
+    //              when ungated).
     function verifySignature(address account, bytes32 hash, bytes calldata signature) external view returns (bool verified);
-    function authenticateActor(address account, bytes32 hash, bytes calldata auth) external view returns (uint8 scope);
+    function authenticateActor(address account, bytes32 hash, bytes calldata auth) external view returns (uint8 scope, uint8 policyType, address policyTarget);
 
     // Storage views
     function isActor(address account, bytes32 actorId) external view returns (bool);

--- a/EIPS/eip-8130.md
+++ b/EIPS/eip-8130.md
@@ -863,11 +863,7 @@ interface IAccountConfiguration {
 
     // Signature verification and actor authentication
     // verifySignature: ERC-1271-style boolean check; returns false on any failure.
-    // authenticateActor: resolves the authenticating actor and returns its full authorization surface;
-    //              reverts on failure (invalid signature, unknown/revoked actor, or actorId not bound
-    //              to the auth authenticator). Returns the actor's scope byte, its policyType byte
-    //              (0x00 = ungated), and the resolved policyTarget (the policy manager, or address(0)
-    //              when ungated).
+    // authenticateActor: resolves the authenticating actor and returns its full authorization surface; reverts on failure.
     function verifySignature(address account, bytes32 hash, bytes calldata signature) external view returns (bool verified);
     function authenticateActor(address account, bytes32 hash, bytes calldata auth) external view returns (uint8 scope, uint8 policyType, address policyTarget);
 


### PR DESCRIPTION
Expands `IAccountConfiguration.authenticateActor` to return the actor's full authorization surface instead of only the scope byte.

**Before**
```solidity
function authenticateActor(address account, bytes32 hash, bytes calldata auth) external view returns (uint8 scope);
```

**After**
```solidity
function authenticateActor(address account, bytes32 hash, bytes calldata auth) external view returns (uint8 scope, uint8 policyType, address policyTarget);
```

This lets a single authentication call surface the resolved actor's `scope`, its `policyType` byte (`0x00` = ungated), and the resolved `policyTarget` (the policy manager, or `address(0)` when ungated). It enables callers (e.g. an ERC-4337 account validating a UserOp) to enforce scope and the single-target policy gate from one call rather than a follow-up `getPolicy` lookup. The `policyType` byte is surfaced and reserved for manager-defined sub-typing without changing the protocol gate semantics.

Documentation/interface-only change; no protocol behavior changes.