### PR TITLE
Update EIP-7773: Remove EIP-7904 from considered EIPs

### DIFF
--- a/EIPS/eip-7773.md
+++ b/EIPS/eip-7773.md
@@ -35,7 +35,6 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Declined
 
 * [EIP-2780](./eip-2780.md): Reduce intrinsic transaction gas
 * [EIP-7688](./eip-7688.md): Forward compatible consensus data structures
-* [EIP-7904](./eip-7904.md): General Repricing
 * [EIP-7997](./eip-7997.md): Deterministic Factory Predeploy
 * [EIP-8038](./eip-8038.md): State-access gas cost increase
 * [EIP-8045](./eip-8045.md): Exclude slashed validators from proposing


### PR DESCRIPTION
Removed EIP-7904 from the considered for inclusion list. This would need to be mentioned on an ACDE call to be considered official / mergeable.