### PR TITLE
Update EIP-8130: bind payer field into payer signature hash

### DIFF
--- a/EIPS/eip-8130.md
+++ b/EIPS/eip-8130.md
@@ -379,17 +379,18 @@ keccak256(AA_TX_TYPE || rlp([
 ]))
 ```
 
-**Payer signature hash** — all tx fields through `calls`, excluding `payer`, `sender_auth`, and `payer_auth`:
+**Payer signature hash** — all tx fields through `payer`, excluding `sender_auth` and `payer_auth`:
 
 ```
 keccak256(AA_PAYER_TYPE || rlp([
   chain_id, sender, nonce_key, nonce_sequence, expiry,
   max_priority_fee_per_gas, max_fee_per_gas, gas_limit,
-  account_changes, calls, metadata
+  account_changes, calls, metadata,
+  payer
 ]))
 ```
 
-The `sender` field in the payer signature hash MUST be the resolved sender address. In the EOA path (`sender` empty in the transaction wire format), the recovered sender address (from `sender_auth` ecrecover, see [Validation](#validation) step 1) MUST be substituted into the `sender` position before computing this hash; it MUST NOT be encoded as the empty wire-format value. This binds the payer's signature to the specific resolved sender and prevents cross-sender replay of payer signatures (see [Payer Security](#security-considerations)).
+The `sender` field in the payer signature hash MUST be the resolved sender address. In the EOA path (`sender` empty in the transaction wire format), the recovered sender address (from `sender_auth` ecrecover, see [Validation](#validation) step 1) MUST be substituted into the `sender` position before computing this hash; it MUST NOT be encoded as the empty wire-format value. This binds the payer's signature to the specific resolved sender and prevents cross-sender replay of payer signatures (see [Payer Security](#security-considerations)). The `payer` field MUST also be included so the payer's signature is bound to the account being charged; without it, a payer authorization could be redirected to any other account that authorizes the same actor with PAYER scope (e.g., via the [delegate authenticator](#delegate-authenticator)).
 
 #### Payer Modes
 


### PR DESCRIPTION
Adds `payer` to the **payer signature hash** (`AA_PAYER_TYPE` payload) in EIP-8130 so the payer's signature is bound to the account being charged.

Previously the payer hash excluded `payer`, so a payer authorization was only pinned to the transaction body and the resolved `sender` — not to which account funds it. Validation (`actor_config(payer, actorId)` + PAYER scope) succeeds for any account that authorizes the same actor, so a single payer signature could be redirected across accounts by swapping the `payer` field. The delegate authenticator makes this concrete: it authorizes one key across many accounts, and the nested vouching signature is taken over the payer hash, so the same signature validated against every account that delegated to that key.

Including `payer` mirrors the existing resolved-`sender` binding already used to prevent cross-sender payer replay.