### PR TITLE
Update EIP-8130: clarify the intrinsic-gas schedule is a recommendation

### DIFF
--- a/EIPS/eip-8130.md
+++ b/EIPS/eip-8130.md
@@ -309,6 +309,8 @@ call = rlp([to, data])   // to: address, data: bytes
 
 **Intrinsic gas** follows the standard Ethereum meaning: the total cost to include the transaction. As in standard transactions it accounts for signature authentication, here both the sender's authentication (`sender_auth_cost`) and the payer's (`payer_auth_cost`) are included.
 
+The specific per-component gas *values* in this section are a **recommended schedule** that reflects the EVM access and data-availability costs ([EIP-2929](./eip-2929.md) / [EIP-2028](./eip-2028.md)) at the time of writing. They are a reference, not protocol constants: just as a chain may choose how it prices authenticator execution (see [Authenticators](#authenticators)), a chain MAY adopt a different intrinsic-gas schedule — for example to track a future EVM repricing or a local cost model. The formula's structure (its components and what each one accounts for) is the normative part; the absolute numbers below are the recommended values for a chain that mirrors current EVM costs.
+
 ```
 intrinsic_gas = AA_BASE_COST + tx_payload_cost + nonce_key_cost + bytecode_cost + account_changes_cost + auto_delegation_cost + sender_auth_cost + payer_auth_cost
 ```


### PR DESCRIPTION
## Summary

Clarifies that the per-component gas **values** in the Intrinsic Gas section are a *recommended schedule*, not fixed protocol constants.

The section currently reads as if every number (`AA_BASE_COST`, the `nonce_key_cost` table, the 16/4 calldata costs, slot-write costs, etc.) is normative. In practice they reflect the current EIP-2929/EIP-2028 EVM access and data-availability costs, and exactly as the spec already allows for authenticator-execution pricing ("Chains choose how authenticator execution is priced") a chain may reasonably adopt a different intrinsic-gas schedule (e.g. to track a future EVM repricing such as EIP-7623, or a local cost model).

## Change

Adds one paragraph at the top of the Intrinsic Gas section stating:

- The per-component values are a recommended schedule reflecting current EVM costs (EIP-2929 / EIP-2028) at the time of writing.
- They are a reference, not protocol constants; a chain MAY adopt a different schedule, consistent with the existing authenticator-pricing flexibility.
- The **formula's structure** (its components and what each accounts for) is the normative part; the absolute numbers are recommended values for a chain that mirrors current EVM costs.

No values are changed. Documentation/wording only.