### PR TITLE
Update EIP-8141: Spec cleanup and clarifications

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -76,15 +76,30 @@ Below are high-level definitions of each field in the transaction definition. De
 
 - `mode` -- the mode specifies the specific execution semantics the frame will execute with.
 - `flags` -- specifies optional frame / mode features.
-- `target` -- the destination or `to` address for the frame. Defaults to `tx.sender` if absent.
+- `target` -- the destination or `to` address for the frame.
 - `gas_limit` -- the maximum gas allowed to be execute in pursuit of the frame.
 - `value` -- the amount in wei that should transferred from the `sender` as part of the frame execution.
 - `data` -- the calldata provided to the top level call frame.
 
+###### Flags
+
+The `flags` field configures additional execution constraints. Bit positions are zero-based, with the least significant bit numbered `0`.
+
+| Flag bits | Meaning                      | Valid with  |
+|-----------|------------------------------| ----------- |
+| 0-1       | Approval scope               | Any mode    |
+| 2         | Atomic batch                 | Any mode    |
+| 3..       | reserved                     | No mode     |
+
+> The `Valid with` column indicates the mode under which the flag is valid. If a flag is not valid under the current mode, the transaction is invalid.
+
+- *Approval scope*: a bitmask with values defined in the `APPROVE` instruction section [Scope Operand](#scope-operand).
+- *Atomic batch*: flag indicates that the frame is in a batch with the following frame or frames. All frames in a batch must succeed, or all of them revert. We define `ATOMIC_BATCH_FLAG` constant with value `0x4`.
+
 ##### Signature object
 
 - `scheme` -- the verification scheme used to interpret the raw signature bytes.
-- `signer` -- scheme-dependent signer metadata; for `SECP256K1` and `P256`, this is a 20-byte address. Defaults to `tx.sender` if absent.
+- `signer` -- scheme-dependent signer metadata; for `SECP256K1` and `P256`, this is a 20-byte address.
 - `msg` -- either empty, indicating the canonical transaction signature hash, or an explicit 32-byte digest.
 - `signature` -- raw signature bytes interpreted according to `scheme`.
 
@@ -97,30 +112,6 @@ the purpose of the frame within the execution loop.
 | 1       | `VERIFY` mode  | Frame identifies as transaction validation |
 | 2       | `SENDER` mode  | Execute frame as `sender`                  |
 
-
-The `flags` field configures additional execution constraints. Bit positions are zero-based, with the least significant bit numbered `0`.
-
-| Flag bits | Meaning                      | Valid with  |
-|-----------|------------------------------| ----------- |
-| 0-1       | Approval scope               | Any mode    |
-| 2         | Atomic batch                 | Any mode    |
-| 3..       | reserved                     | No mode     |
-
-> The `Valid with` column indicates the mode under which the flag is valid. If a flag is not valid under the current mode, the transaction is invalid.
-
-The *Approval scope* is a bitmask. We define following constants:
-
-| name                          | value  | Meaning                                                                                                                       |
-|-------------------------------|--------|-------------------------------------------------------------------------------------------------------------------------------|
-| APPROVE_NONE                  | `0x0`  | No approval allowed - the current frame is not allowed to approve any scope.                                                  |
-| APPROVE_PAYMENT               | `0x1`  | Approval of payment - the target of current frame can approve paying the total gas cost for the transaction.                  |
-| APPROVE_EXECUTION             | `0x2`  | Approval of execution - the current frame must target sender's contract, and can approve future frames calling on its behalf. |
-| APPROVE_EXECUTION_AND_PAYMENT | `0x3`  | Approval of payment and/or execution.                                                                                         |
-| APPROVE_SCOPE_MASK            | `0x3`  | An alias for `APPROVE_EXECUTION_AND_PAYMENT`.                                                                                 |
-
-> Note that `APPROVE_EXECUTION` and `APPROVE_EXECUTION_AND_PAYMENT` are valid only when `frame.target` is `None` or equals `tx.sender`. See below.
-
-The *Atomic batch* flag indicates that the frame is in a batch with the following frame or frames. All frames in a batch must succeed, or all of them revert. We define `ATOMIC_BATCH_FLAG` constant with value `0x4`.
 
 #### Constraints
 
@@ -363,7 +354,7 @@ Then for each frame:
     - In the top-level frame call, `CALLVALUE` is `frame.value`.
         - As with an ordinary `CALL`, if the caller does not have sufficient balance to transfer `frame.value`, the frame reverts.
     - If `resolved_target` code hash is empty, i.e. `0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470`, execute the logic described in [default code](#default-code).
-        - Otherwise, if `resolved_target` uses an [EIP-7702](./eip-7702.md) delegation indicator, execute according to [EIP-7702](./eip-7702.md)'s delegated-code semantics.targettarget
+        - Otherwise, if `resolved_target` uses an [EIP-7702](./eip-7702.md) delegation indicator, execute according to [EIP-7702](./eip-7702.md)'s delegated-code semantics.
     - If a frame's execution reverts, its state changes are discarded. Additionally, if this frame has the atomic batch flag set, mark all subsequent frames in the same atomic group as skipped.
 1. If frame has mode `VERIFY` the following additional requirements are imposed:
     - Execute the frame as a `STATICCALL`, disallowing state manipulation.
@@ -464,9 +455,17 @@ The `APPROVE` instruction exits the current EVM call frame successfully and upda
 | `top - 1`  | `length`     |
 | `top - 2`  | `scope`      |
  
-#### Scope param
+#### Scope Operand
 
-The `scope` param is a bitmask, and it must be a **non-zero** subset of frame's *Approval scope* bitmap.
+The `scope` operand is a bitmask. Define the following constants:
+
+- `APPROVE_NONE` (`0x0`): No approval scope allowed - the current frame is not allowed to approve any scope.
+- `APPROVE_PAYMENT` (`0x1`): Approval of payment - the contract approves paying the total gas cost for the transaction.
+- `APPROVE_EXECUTION` (`0x2`): Approval of execution - the sender contract approves future frames calling on its behalf.
+    - Note this is only valid when `resolved_target` equals `tx.sender`.
+- `APPROVE_EXECUTION_AND_PAYMENT` (`0x3`): Approval of payment and execution.
+
+`APPROVE_SCOPE_MASK` is defined as an alias for `APPROVE_EXECUTION_AND_PAYMENT`.
 
 #### Behavior
 

--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -108,7 +108,7 @@ The `flags` field configures additional execution constraints. Bit positions are
 
 > The `Valid with` column indicates the mode under which the flag is valid. If a flag is not valid under the current mode, the transaction is invalid.
 
-The _Approval scope_ is a bitmask. We define following constants:
+The *Approval scope* is a bitmask. We define following constants:
 
 | name                          | value  | Meaning                                                                                                                       |
 |-------------------------------|--------|-------------------------------------------------------------------------------------------------------------------------------|
@@ -120,7 +120,7 @@ The _Approval scope_ is a bitmask. We define following constants:
 
 > Note that `APPROVE_EXECUTION` and `APPROVE_EXECUTION_AND_PAYMENT` are valid only when `frame.target` is `None` or equals `tx.sender`. See below.
 
-The _Atomic batch_ flag indicates that the frame is in a batch with the following frame or frames. All frames in a batch must succeed, or all of them revert. We define `ATOMIC_BATCH_FLAG` constant with value `0x4`.
+The *Atomic batch* flag indicates that the frame is in a batch with the following frame or frames. All frames in a batch must succeed, or all of them revert. We define `ATOMIC_BATCH_FLAG` constant with value `0x4`.
 
 #### Constraints
 
@@ -451,9 +451,7 @@ Frame transactions can be used by accounts who do not have deployed code, nor an
 - If `mode` is `SENDER` or `DEFAULT`:
   - Return successfully as if calling empty code.
 
-> TODO: Can we pass signature index as calldata?
-
-> TODO: Why don't we support P256 signature scheme as well?
+> TODO: Can we pass signature index as calldata? Why don't we support P256 signature scheme as well?
 
 ### `APPROVE` Instruction (`0xaa`)
 
@@ -469,7 +467,7 @@ The `APPROVE` instruction exits the current EVM call frame successfully and upda
  
 #### Scope param
 
-The `scope` param is a bitmask, and it must be a **non-zero** subset of frame's _Approval scope_ bitmap.
+The `scope` param is a bitmask, and it must be a **non-zero** subset of frame's *Approval scope* bitmap.
 
 #### Behavior
 
@@ -704,9 +702,7 @@ To be accepted into the public mempool, a frame transaction must satisfy the fol
 6. The sum of `gas_limit` values across the validation prefix, plus the intrinsic cost of validating `tx.signatures`, must not exceed `MAX_VERIFY_GAS`.
 7. Nodes should stop simulation immediately once `payer` has been set.
 
-> TODO: Should we force frame.flag to match expected APPROVE call. Meaning, `self_verify` should be `0x3`, `only_verify` should be `0x2` and `pay` should be `0x1`
-
-> TODO: Should we force "no VERIFY frames" after validation prefix? Because it there is VERIFY frame afterwards and reverts, entire tx is invalid.
+> TODO: Should we force frame.flag to match expected APPROVE call? Should we force "no VERIFY frames" after validation prefix (because it there is VERIFY frame afterwards and reverts, entire tx is invalid)?
 
 #### Expiry Verifier Frame
 

--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -382,9 +382,8 @@ After executing all frames, verify that `payer` has been set (i.e. `payer != Non
 A few cross-frame interactions to note:
 
 - For the purposes of gas accounting of warm / cold state status, the journal of such touches is shared across frames.
+- If a frame reverts, warm / cold status reverts to the state before the frame.
 - Discard the `TSTORE` and `TLOAD` transient storage between frames.
-
-> TODO: should we clarify whether warm status persist even if frames are reverted 
 
 ##### Gas Accounting
 
@@ -451,7 +450,7 @@ Frame transactions can be used by accounts who do not have deployed code, nor an
 - If `mode` is `SENDER` or `DEFAULT`:
   - Return successfully as if calling empty code.
 
-> TODO: Can we pass signature index as calldata? Why don't we support P256 signature scheme as well?
+> TODO: Can we pass signature index as calldata?
 
 ### `APPROVE` Instruction (`0xaa`)
 
@@ -635,15 +634,15 @@ Any dependency on third-party mutable state outside these categories must result
 
 While the frames are designed to be generic, we refine some frame modes for the purpose of specifying public mempool handling clearly.
 
-| Name  | Mode  | Description  |
-|---|---|---|
-| `self_verify`   | VERIFY  | Validates the transaction and approves both sender and payer |
-| `deploy`  | DEFAULT | Deploys a new smart account, typically via a deterministic factory such as the [EIP-7997](./eip-7997.md) predeploy |
-| `only_verify`  | VERIFY  | Validates the transaction and approves only the sender |
-| `pay`  | VERIFY | Validates the transaction and approves only the payer |
-| `expiry_verify` | VERIFY | Calls the expiry verifier contract (target = `EXPIRY_VERIFIER`) |
-| `user_op` | SENDER | Executes the intended user operation |
-| `post_op` | DEFAULT | Executes an optional post-op action as needed by the paymaster |
+| Name | Mode | Flags | Description |
+|---|---|---|---|
+| `self_verify` | VERIFY | `0x3` | Validates the transaction and approves both sender and payer |
+| `deploy` | DEFAULT | `0x0` | Deploys a new smart account, typically via a deterministic factory such as the [EIP-7997](./eip-7997.md) predeploy |
+| `only_verify` | VERIFY | `0x2` | Validates the transaction and approves only the sender |
+| `pay` | VERIFY | `0x1` | Validates the transaction and approves only the payer |
+| `expiry_verify` | VERIFY | `0x0` | Calls the expiry verifier contract (target = `EXPIRY_VERIFIER`) |
+| `user_op` | SENDER | any | Executes the intended user operation |
+| `post_op` | DEFAULT | any | Executes an optional post-op action as needed by the paymaster |
 
 
 #### Public Mempool-recognized Validation Prefixes
@@ -686,7 +685,7 @@ The public mempool recognizes four validation prefixes. Structural rules are enf
 +--------+-------------+-----+
 ```
 
-Frames after these prefixes are outside public mempool validation. For example, a transaction may continue with any number of `user_op`s and/or `post_op`s.
+Frames after these prefixes are outside public mempool validation. For example, a transaction may continue with any number of `user_op`s and/or `post_op`s. There must not be any `VERIFY` frame after these prefixes, otherwise their revert would make entire transaction invalid.
 
 #### Structural Rules
 
@@ -694,15 +693,14 @@ To be accepted into the public mempool, a frame transaction must satisfy the fol
 
 1. Its validation prefix must match one of the four recognized prefixes above.
 2. If present, `deploy` must be the first frame. This implies there can be at most one `deploy` frame in the validation prefix.
-3. `self_verify` and `only_verify` must execute in `VERIFY` mode, target `tx.sender` (either explicitly or via a null target), and must successfully call `APPROVE`.
+3. `self_verify` and `only_verify` must execute in `VERIFY` mode, target `tx.sender` (either explicitly or via a null target), must successfully call `APPROVE`, and `frame.flags` must match the scope of the `APPROVE` call.
     - `self_verify` must call `APPROVE(APPROVE_EXECUTION_AND_PAYMENT)`.
     - `only_verify` must call `APPROVE(APPROVE_EXECUTION)`.
-4. `pay` must execute in `VERIFY` mode and successfully call `APPROVE(APPROVE_PAYMENT)`.
+4. `pay` must execute in `VERIFY` mode, have flags set to `APPROVE_PAYMENT`, and must successfully call `APPROVE(APPROVE_PAYMENT)`
 5. No frame in the validation prefix may have the `ATOMIC_BATCH_FLAG` set.
 6. The sum of `gas_limit` values across the validation prefix, plus the intrinsic cost of validating `tx.signatures`, must not exceed `MAX_VERIFY_GAS`.
 7. Nodes should stop simulation immediately once `payer` has been set.
-
-> TODO: Should we force frame.flag to match expected APPROVE call? Should we force "no VERIFY frames" after validation prefix (because it there is VERIFY frame afterwards and reverts, entire tx is invalid)?
+8. There must not be `VERIFY` frame after validation prefix.
 
 #### Expiry Verifier Frame
 
@@ -849,10 +847,6 @@ The raw `signature` bytes of signatures with empty `msg` are elided from the can
 1. Signatures with explicit 32-byte `msg` values do not induce this circularity, so their raw bytes are currently committed by the transaction signature hash.
 1. In the future it may be desired to aggregate or otherwise externalize these signatures for data and compute efficiency reasons.
 
-The `data` of `VERIFY` frames, including expiry verifier deadlines, is not elided. Any validation data that is intended to be added after a sender signs should be represented as elided raw signature bytes in `tx.signatures`, rather than as mutable frame data.
-
-> TODO: Is last paragraph needed? First sentence feels not needed with the current spec, second sentence is invalid (raw signature bytes have to be valid signature of `sig.msg`).
-
 ### `APPROVE` calling convention
 
 Originally `APPROVE` was meant to extend the space of return statuses from 0 and 1 today to 0 to 4. However, this would mean smart accounts deployed today would not be able to modify their contract code to return with a different value at the top level. For this reason, we've chosen behavior above: `APPROVE` terminates the executing frame successfully like `RETURN`, but it actually updates the transaction scoped values `sender_approved` and `payer` during execution. It is still required that only the sender can toggle the `sender_approved` to `true`. Only the frame's resolved target can call `APPROVE` generally, because it can allow the transaction pool and other frames to better reason about `VERIFY` mode frames.
@@ -917,14 +911,12 @@ Note that users can use any EOA as a paymaster thanks to the [default code](#def
 
 ### Examples
 
-> TODO: I would reorder columns to: "Frame, Mode, Caller, Flags, Target, Value, Data". Mode and Flags should come earlier as they are the most interesting for people reading this EIP.
-
 #### Example 1: Simple Transaction
 
-| Frame | Caller      | Target        | Value | Flags                         | Data      | Mode   |
-| ----- | ----------- | ------------- | ----- | ----------------------------- | --------- | ------ |
-| 0     | ENTRY_POINT | Null (sender) | 0     | APPROVE_EXECUTION_AND_PAYMENT | Empty     | VERIFY |
-| 1     | Sender      | Target        | 0     | APPROVE_SCOPE_NONE            | Call data | SENDER |
+| Frame | Mode   | Caller      | Flags                         | Target        | Value | Data      |
+| ----- | ------ | ----------- | ----------------------------- | ------------- | ----- | --------- |
+| 0     | VERIFY | ENTRY_POINT | APPROVE_EXECUTION_AND_PAYMENT | Null (sender) | 0     | Empty     |
+| 1     | SENDER | Sender      | APPROVE_SCOPE_NONE            | Target        | 0     | Call data |
 
 Frame 0 uses a signature entry with empty `msg` for the sender and calls `APPROVE(APPROVE_EXECUTION_AND_PAYMENT)` to approve both payment and execution. Frame 1 executes and exits normally via `RETURN`.
 
@@ -935,20 +927,20 @@ The mempool can process this transaction with the following static validation an
 
 #### Example 1a: Simple ETH transfer
 
-| Frame | Caller      | Target        | Value  | Flags                         | Data      | Mode   |
-| ----- | ----------- | ------------- | ------ | ----------------------------- | --------- | ------ |
-| 0     | ENTRY_POINT | Null (sender) | 0      | APPROVE_EXECUTION_AND_PAYMENT | Empty     | VERIFY |
-| 1     | Sender      | Destination   | Amount | APPROVE_SCOPE_NONE            | Empty     | SENDER |
+| Frame | Mode   | Caller      | Flags                         | Target        | Value  | Data      |
+| ----- | ------ | ----------- | ----------------------------- | ------------- | ------ | --------- |
+| 0     | VERIFY | ENTRY_POINT | APPROVE_EXECUTION_AND_PAYMENT | Null (sender) | 0      | Empty     |
+| 1     | SENDER | Sender      | APPROVE_SCOPE_NONE            | Destination   | Amount | Empty     |
 
 A simple transfer is performed by setting the `SENDER` frame target to the destination account and the frame `value` to the transfer amount. This requires two frames for mempool compatibility, since the validation phase of the transaction has to be static.
 
 #### Example 1b: Simple account deployment
 
-| Frame | Caller      | Target        | Value  | Flags                         | Data           | Mode    |
-| ----- | ----------- | ------------- | ------ | ----------------------------- | -------------- | ------- |
-| 0     | ENTRY_POINT | Deployer      | 0      | APPROVE_SCOPE_NONE            | Initcode, Salt | DEFAULT |
-| 1     | ENTRY_POINT | Null (sender) | 0      | APPROVE_EXECUTION_AND_PAYMENT | Empty          | VERIFY  |
-| 2     | Sender      | Destination   | Amount | APPROVE_SCOPE_NONE            | Empty          | SENDER  |
+| Frame | Mode    | Caller      | Flags                         | Target        | Value  | Data           |
+| ----- | ------- | ----------- | ----------------------------- | ------------- | ------ | -------------- |
+| 0     | DEFAULT | ENTRY_POINT | APPROVE_SCOPE_NONE            | Deployer      | 0      | Initcode, Salt |
+| 1     | VERIFY  | ENTRY_POINT | APPROVE_EXECUTION_AND_PAYMENT | Null (sender) | 0      | Empty          |
+| 2     | SENDER  | Sender      | APPROVE_SCOPE_NONE            | Destination   | Amount | Empty          |
 
 This example illustrates the initial deployment flow for a smart account at the `sender` address. Since the address needs to have code in order to validate the transaction, the transaction must deploy the code before verification.
 
@@ -956,23 +948,23 @@ The first frame would call the [EIP-7997](./eip-7997.md) deterministic factory p
 
 #### Example 2: Atomic Approve + Swap
 
-| Frame | Caller      | Target        | Value | Flags                         | Data                 | Mode   |
-| ----- | ----------- | ------------- | ----- | ----------------------------- | -------------------- | ------ |
-| 0     | ENTRY_POINT | Null (sender) | 0     | APPROVE_EXECUTION_AND_PAYMENT | Empty                | VERIFY |
-| 1     | Sender      | ERC-20        | 0     | ATOMIC_BATCH_FLAG            | approve(DEX, amount) | SENDER |
-| 2     | Sender      | DEX           | 0     | APPROVE_SCOPE_NONE           | swap(...)            | SENDER |
+| Frame | Mode   | Caller      | Flags                         | Target        | Value | Data                 |
+| ----- | ------ | ----------- | ----------------------------- | ------------- | ----- | -------------------- |
+| 0     | VERIFY | ENTRY_POINT | APPROVE_EXECUTION_AND_PAYMENT | Null (sender) | 0     | Empty                |
+| 1     | SENDER | Sender      | ATOMIC_BATCH_FLAG             | ERC-20        | 0     | approve(DEX, amount) |
+| 2     | SENDER | Sender      | APPROVE_SCOPE_NONE            | DEX           | 0     | swap(...)            |
 
 Frame 0 uses a signature entry with empty `msg` and calls `APPROVE(APPROVE_EXECUTION_AND_PAYMENT)`. Frames 1 and 2 form an atomic batch: if the swap in frame 2 reverts, the ERC-20 approval from frame 1 is also reverted, preventing the account from being left with a dangling approval.
 
 #### Example 3: Sponsored Transaction (Fee Payment in ERC-20)
 
-| Frame | Caller      | Target        | Value | Flags              | Data                   | Mode    |
-| ----- | ----------- | ------------- | ----- | ------------------ | ---------------------- | ------- |
-| 0     | ENTRY_POINT | Null (sender) | 0     | APPROVE_EXECUTION  | Empty                  | VERIFY  |
-| 1     | ENTRY_POINT | Sponsor       | 0     | APPROVE_PAYMENT    | Sponsor data           | VERIFY  |
-| 2     | Sender      | ERC-20        | 0     | APPROVE_SCOPE_NONE | transfer(Sponsor,fees) | SENDER  |
-| 3     | Sender      | Target addr   | 0     | APPROVE_SCOPE_NONE | Call data              | SENDER  |
-| 4     | ENTRY_POINT | Sponsor       | 0     | APPROVE_SCOPE_NONE | Post op call           | DEFAULT |
+| Frame | Mode    | Caller      | Flags              | Target        | Value | Data                   |
+| ----- | ------- | ----------- | ------------------ | ------------- | ----- | ---------------------- |
+| 0     | VERIFY  | ENTRY_POINT | APPROVE_EXECUTION  | Null (sender) | 0     | Empty                  |
+| 1     | VERIFY  | ENTRY_POINT | APPROVE_PAYMENT    | Sponsor       | 0     | Sponsor data           |
+| 2     | SENDER  | Sender      | APPROVE_SCOPE_NONE | ERC-20        | 0     | transfer(Sponsor,fees) |
+| 3     | SENDER  | Sender      | APPROVE_SCOPE_NONE | Target addr   | 0     | Call data              |
+| 4     | DEFAULT | ENTRY_POINT | APPROVE_SCOPE_NONE | Sponsor       | 0     | Post op call           |
 
 - Frame 0: Uses the sender's signature entry with empty `msg` and calls `APPROVE(APPROVE_EXECUTION)` to authorize execution from sender.
 - Frame 1: Checks that the user has enough ERC-20 tokens, inspects signature metadata in `tx.signatures` if needed, and checks that the next frame is an ERC-20 send of the right size to the sponsor. Calls `APPROVE(APPROVE_PAYMENT)` to authorize payment.
@@ -980,7 +972,7 @@ Frame 0 uses a signature entry with empty `msg` and calls `APPROVE(APPROVE_EXECU
 - Frame 3: User's intended call.
 - Frame 4 (optional): Check unpaid gas, refund tokens, possibly convert tokens to ETH on an AMM.
 
-> TODO: Since Frame 1 checks that user has enough ERC-20 tokens, that means it can't be part of the public mempool. Should we highlight that here?
+> TODO: Since Frame 1 checks that user has enough ERC-20 tokens, that means it can't be part of the public mempool. Should we highlight that here? Alternatively, we can create it in such a way that it is accepted in public mempool (e.g remove ERC-20 balance check from Frame 1, put Frames 2-4 in the same atomic batch).
 
 ### Data Efficiency
 
@@ -1077,9 +1069,7 @@ Frame transactions introduce new denial-of-service vectors for transaction pools
 
 #### Example Attack
 
-> TODO: We now support this use case explicitly? Yes, it's split over multiple frames, but we support it. I think we should find different example.
-
-A simple example is transactions that check `block.timestamp`:
+A simple example is transactions that check `block.timestamp`, without using expiry verifier frame:
 
 ```solidity
 function validateTransaction() external {

--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -452,7 +452,7 @@ The `APPROVE` instruction exits the current EVM call frame successfully and upda
 | `top - 0`  | `offset`     |
 | `top - 1`  | `length`     |
 | `top - 2`  | `scope`      |
- 
+
 #### Scope Operand
 
 The `scope` operand is a bitmask. Define the following constants:

--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -964,16 +964,14 @@ Frame 0 uses a signature entry with empty `msg` and calls `APPROVE(APPROVE_EXECU
 | 4     | DEFAULT | ENTRY_POINT | APPROVE_SCOPE_NONE | Sponsor       | 0     | Post op call           |
 
 - Frame 0: Uses the sender's signature entry with empty `msg` and calls `APPROVE(APPROVE_EXECUTION)` to authorize execution from sender.
-- Frame 1: Checks that the user has enough ERC-20 tokens, inspects signature metadata in `tx.signatures` if needed, and checks that the next frame is an ERC-20 send of the right size to the sponsor. Calls `APPROVE(APPROVE_PAYMENT)` to authorize payment.
+- Frame 1: Inspects signature metadata in `tx.signatures` if needed, and checks that the next frame is an ERC-20 send of the right size to the sponsor. Calls `APPROVE(APPROVE_PAYMENT)` to authorize payment.
 - Frame 2: Sends tokens to sponsor.
 - Frame 3: User's intended call.
 - Frame 4 (optional): Check unpaid gas, refund tokens, possibly convert tokens to ETH on an AMM.
 
-> TODO: Since Frame 1 checks that user has enough ERC-20 tokens, that means it can't be part of the public mempool. Should we highlight that here? Alternatively, we can create it in such a way that it is accepted in public mempool (e.g remove ERC-20 balance check from Frame 1, put Frames 2-4 in the same atomic batch).
+Note: to be included in the public mempool under the current model, sponsors must accept some risk of frontrunning by the sponsee who can zero out their ERC-20 balance before the sponsored transaction lands on-chain.
 
 ### Data Efficiency
-
-> TODO: Are these RLP encoding bytes needed? I think several are wrong in that case (e.g. even if sig.msg or frame.data is empty, it still takes 1 byte of encoding), but error is not big. Do we care to have exact values or are small differences ok?
 
 **Basic transaction sending ETH from a smart account:**
 

--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -76,7 +76,7 @@ Below are high-level definitions of each field in the transaction definition. De
 
 - `mode` -- the mode specifies the specific execution semantics the frame will execute with.
 - `flags` -- specifies optional frame / mode features.
-- `target` -- the destination or `to` address for the frame.
+- `target` -- the destination or `to` address for the frame. Defaults to `tx.sender` if absent.
 - `gas_limit` -- the maximum gas allowed to be execute in pursuit of the frame.
 - `value` -- the amount in wei that should transferred from the `sender` as part of the frame execution.
 - `data` -- the calldata provided to the top level call frame.
@@ -84,7 +84,7 @@ Below are high-level definitions of each field in the transaction definition. De
 ##### Signature object
 
 - `scheme` -- the verification scheme used to interpret the raw signature bytes.
-- `signer` -- scheme-dependent signer metadata; for `SECP256K1` and `P256`, this is a 20-byte address.
+- `signer` -- scheme-dependent signer metadata; for `SECP256K1` and `P256`, this is a 20-byte address. Defaults to `tx.sender` if absent.
 - `msg` -- either empty, indicating the canonical transaction signature hash, or an explicit 32-byte digest.
 - `signature` -- raw signature bytes interpreted according to `scheme`.
 
@@ -104,8 +104,23 @@ The `flags` field configures additional execution constraints. Bit positions are
 |-----------|------------------------------| ----------- |
 | 0-1       | Approval scope               | Any mode    |
 | 2         | Atomic batch                 | Any mode    |
+| 3..       | reserved                     | No mode     |
 
-The `Valid with` column indicates the mode under which the flag is valid. If a flag is not valid under the current mode, the transaction is invalid.
+> The `Valid with` column indicates the mode under which the flag is valid. If a flag is not valid under the current mode, the transaction is invalid.
+
+The _Approval scope_ is a bitmask. We define following constants:
+
+| name                          | value  | Meaning                                                                                                                       |
+|-------------------------------|--------|-------------------------------------------------------------------------------------------------------------------------------|
+| APPROVE_NONE                  | `0x0`  | No approval allowed - the current frame is not allowed to approve any scope.                                                  |
+| APPROVE_PAYMENT               | `0x1`  | Approval of payment - the target of current frame can approve paying the total gas cost for the transaction.                  |
+| APPROVE_EXECUTION             | `0x2`  | Approval of execution - the current frame must target sender's contract, and can approve future frames calling on its behalf. |
+| APPROVE_EXECUTION_AND_PAYMENT | `0x3`  | Approval of payment and/or execution.                                                                                         |
+| APPROVE_SCOPE_MASK            | `0x3`  | An alias for `APPROVE_EXECUTION_AND_PAYMENT`.                                                                                 |
+
+> Note that `APPROVE_EXECUTION` and `APPROVE_EXECUTION_AND_PAYMENT` are valid only when `frame.target` is `None` or equals `tx.sender`. See below.
+
+The _Atomic batch_ flag indicates that the frame is in a batch with the following frame or frames. All frames in a batch must succeed, or all of them revert. We define `ATOMIC_BATCH_FLAG` constant with value `0x4`.
 
 #### Constraints
 
@@ -119,7 +134,7 @@ assert len(tx.sender) == 20
 
 for sig in tx.signatures:
     if sig.scheme in [SECP256K1, P256]:
-        assert len(sig.signer) == 20
+        assert len(sig.signer) == 0 or len(sig.signer) == 20
     elif sig.scheme == ARBITRARY:
         assert len(sig.signer) == 0
     else:
@@ -132,7 +147,7 @@ for sig in tx.signatures:
         invalid_transaction()
 
 total_frame_gas = 0
-for frame in tx.frames:
+for i, frame in enumerate(tx.frames):
     assert frame.mode < 3
     assert frame.flags < 8
     assert frame.target is None or len(frame.target) == 20
@@ -142,9 +157,13 @@ for frame in tx.frames:
     total_frame_gas += frame.gas_limit
     assert total_frame_gas <= 2**64 - 1
 
-    # Atomic batch flag (bit 2 of flags) requires a subsequent frame to batch with.
+    # Approval of execution is allowed only when target equals to None or tx.sender.
+    if frame.flags & APPROVE_EXECUTION:
+        assert frame.target is None or frame.target == tx.sender
+
+    # Atomic batch flag requires a subsequent frame to batch with.
     if frame.flags & ATOMIC_BATCH_FLAG:
-        assert i + 1 < len(tx.frames)                  # must not be last frame
+        assert i + 1 < len(tx.frames)    # must not be last frame
 ```
 
 #### Transaction Signatures
@@ -159,13 +178,13 @@ The `scheme` identifies how the raw `signature` bytes are interpreted.
 
 | `scheme`   | Name         | `signature` encoding                           | Gas cost |
 |------------|--------------|------------------------------------------------|----------|
-| 0x0        | `ARBITRARY`  | arbitrary bytes                               | 0        |
-| 0x1        | `SECP256K1`  | `v (1 byte) || r (32 bytes) || s (32 bytes)` | 2800     |
-| 0x2        | `P256`       | `r || s || qx || qy` (all 32 bytes)          | 6700     |
-| 0x3..255   | reserved     | reserved                                      | reserved |
+| 0x0        | `ARBITRARY`  | arbitrary bytes                                | 0        |
+| 0x1        | `SECP256K1`  | `v (1 byte) || r (32 bytes) || s (32 bytes)`   | 2800     |
+| 0x2        | `P256`       | `r || s || qx || qy` (32 bytes each)           | 6700     |
+| 0x3..255   | reserved     | reserved                                       | reserved |
 
-For `SECP256K1` and `P256`, the `signer` is a 20-byte Ethereum address.
-For `ARBITRARY`, `signer` MUST be empty. The protocol does not assign an effective signer address to `ARBITRARY` entries.
+For `SECP256K1` and `P256`, the `signer` is a 20-byte Ethereum address. If absent, `tx.sender` is used (for introspections as well).
+For `ARBITRARY`, `signer` MUST be empty. The protocol does not assign a resolved signer address to `ARBITRARY` entries.
 
 The `msg` field defines which message the signature authorizes:
 
@@ -209,18 +228,20 @@ ARBITRARY = 0x0
 SECP256K1 = 0x1
 P256      = 0x2
 
-def effective_signer(sig) -> Address:
-    if sig.scheme == ARBITRARY:
-        return Address(0)
-    return sig.signer
-
-def validate_signature(sig, tx, sig_hash) -> bool:
+def validate_signature(sig, tx_sender, sig_hash) -> bool:
     if len(sig.msg) == 0:
         msg = sig_hash
     elif len(sig.msg) == 32:
         if sig.msg == b"\x00" * 32:
             return False
         msg = sig.msg
+    else:
+        return False
+    
+    if len(sig.signer) == 0:
+        resolved_signer = tx_sender
+    elif len(sig.signer) == 20:
+        resolved_signer = sig.signer
     else:
         return False
 
@@ -230,7 +251,7 @@ def validate_signature(sig, tx, sig_hash) -> bool:
         v = sig.signature[0]
         r = sig.signature[1:33]
         s = sig.signature[33:65]
-        return sig.signer == ecrecover(msg, v, r, s)
+        return resolved_signer == ecrecover(msg, v, r, s)
 
     elif sig.scheme == P256:
         if len(sig.signature) != 128:
@@ -239,7 +260,7 @@ def validate_signature(sig, tx, sig_hash) -> bool:
         s  = sig.signature[32:64]
         qx = sig.signature[64:96]
         qy = sig.signature[96:128]
-        if sig.signer != keccak256(qx + qy)[12:]:
+        if resolved_signer != keccak256(qx + qy)[12:]:
             return False
         return P256VERIFY(msg, r, s, qx, qy)
 
@@ -310,7 +331,7 @@ if evm.timestamp > expiry_timestamp:
 stop()
 ```
 
-If the check passes, the frame succeeds with no return data and no logs. The frame consumes gas according to normal EVM execution rules. Although `TIMESTAMP` is generally banned during validation-prefix execution, it is permitted in this special `VERIFY` frame when executing the canonical expiry verifier runtime code at `EXPIRY_VERIFIER`.
+If the check passes, the frame succeeds with no return data and no logs. The frame consumes gas according to normal EVM execution rules.
 
 Clients may omit the explicit EVM execution and directly perform the expiry check above, provided the externally observable result is identical to executing the canonical contract. Note: While this is a valid optimization for Ethereum mainnet, it could be problematic on non-mainnet situations in case a different contract is used.
 
@@ -322,37 +343,37 @@ To begin processing a frame transaction:
 
 1. Ensure `tx.nonce == state[tx.sender].nonce`
 1. Compute the canonical transaction signature hash: `sig_hash = compute_sig_hash(tx)`.
-1. For each `sig` in `tx.signatures`, ensure `validate_signature(sig, tx, sig_hash) == true`.
+1. For each `sig` in `tx.signatures`, ensure `validate_signature(sig, tx.sender, sig_hash) == true`.
 1. Initialize transaction-scoped variables:
     - `payer = None`
     - `sender_approved = false`
-1. Let `resolved_target = frame.target if frame.target is not None else tx.sender`
-    - Unless otherwise stated, checks that refer to the target account during execution use the resolved target.
 
 Then for each frame:
 
-1. Execute a call with the specified `mode`, `flags`, `resolved_target`, `gas_limit`, `value`, and `data`.
-   - If mode is `SENDER`:
-       - `sender_approved` must be `true`. If not, the transaction is invalid.
-       - Set `caller` as `tx.sender`.
-   - If mode is `DEFAULT` or `VERIFY`:
-       - Set the `caller` to `ENTRY_POINT`.
-   - In the top-level frame call, `CALLVALUE` is `frame.value`.
-   - As with an ordinary `CALL`, if the caller does not have sufficient balance to transfer `frame.value`, the frame reverts.
-   - If `resolved_target` code hash is empty, i.e. `0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470`, execute the logic described in [default code](#default-code).
-   - Otherwise, if `resolved_target` uses an [EIP-7702](./eip-7702.md) delegation indicator, execute according to [EIP-7702](./eip-7702.md)'s delegated-code semantics.
-   - The `ORIGIN` opcode returns frame `caller` throughout all call depths.
-   - If a frame's execution reverts, its state changes are discarded. Additionally, if this frame has the atomic batch flag set, mark all subsequent frames in the same atomic group as skipped.
-2. If frame has mode `VERIFY` the following additional requirements are imposed:
+1. Execute a call with the specified `mode`, `flags`, `target`, `gas_limit`, `value`, and `data`.
+    - Let `resolved_target = frame.target if frame.target is not None else tx.sender`
+        - Unless otherwise stated, checks that refer to the target account during execution use the resolved target.
+    - Set frame's `caller`:
+        - If mode is `SENDER`:
+            - `sender_approved` must be `true`. If not, the transaction is invalid.
+            - Set `caller` to `tx.sender`.
+        - If mode is `DEFAULT` or `VERIFY`:
+            - Set `caller` to `ENTRY_POINT`.
+        - The `ORIGIN` opcode returns frame's `caller` throughout all call depths.
+    - In the top-level frame call, `CALLVALUE` is `frame.value`.
+        - As with an ordinary `CALL`, if the caller does not have sufficient balance to transfer `frame.value`, the frame reverts.
+    - If `resolved_target` code hash is empty, i.e. `0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470`, execute the logic described in [default code](#default-code).
+        - Otherwise, if `resolved_target` uses an [EIP-7702](./eip-7702.md) delegation indicator, execute according to [EIP-7702](./eip-7702.md)'s delegated-code semantics.targettarget
+    - If a frame's execution reverts, its state changes are discarded. Additionally, if this frame has the atomic batch flag set, mark all subsequent frames in the same atomic group as skipped.
+1. If frame has mode `VERIFY` the following additional requirements are imposed:
     - Execute the frame as a `STATICCALL`, disallowing state manipulation.
-      - Only `APPROVE` can modify the state or transaction context in `VERIFY`.
+        - Only `APPROVE` can modify the state or transaction context in `VERIFY`.
     - If the frame reverts, the transaction is invalid.
-3. If a frame is part of an atomic batch and it fails, unroll the associated atomic batch.
+1. If a frame is part of an atomic batch and it fails, unroll the associated atomic batch.
     - An **atomic batch** is a maximal contiguous sequence of frames `[i, j]` where `j > i`, frames `i` through `j - 1` have `ATOMIC_BATCH_FLAG` set, and frame `j` does not have `ATOMIC_BATCH_FLAG` set.
     - When a frame in the batch fails, the state must be rolled back to the condition it was immediately before the atomic batch began. All remaining frames in the atomic batch are skipped.
     - Since skipped frames are not executed, the gas value allotted to them is refunded at the end of the transaction.
-    - If the frame does not have an associated atomic batch, further special
-      handling is not needed, simple revert the individual frame.
+    - If the frame does not have an associated atomic batch, further special handling is not needed, simple revert the individual frame.
 
 After executing all frames, verify that `payer` has been set (i.e. `payer != None`). If `payer` is set, refund any unpaid gas to the payer. If it is not, the whole transaction is invalid.
 
@@ -363,11 +384,13 @@ A few cross-frame interactions to note:
 - For the purposes of gas accounting of warm / cold state status, the journal of such touches is shared across frames.
 - Discard the `TSTORE` and `TLOAD` transient storage between frames.
 
+> TODO: should we clarify whether warm status persist even if frames are reverted 
+
 ##### Gas Accounting
 
 The total gas limit of the transaction is:
 
-```
+```python
 def signature_gas(sig):
     if sig.scheme == SECP256K1:
         return 2800
@@ -399,7 +422,7 @@ Where `calldata_cost` is calculated per standard [EIP-7623](./eip-7623.md) rules
 
 The total fee is defined as:
 
-```
+```python
 tx_fee = tx_gas_limit * effective_gas_price + blob_fees
 blob_fees = len(blob_versioned_hashes) * GAS_PER_BLOB * blob_base_fee
 ```
@@ -410,8 +433,8 @@ Any `frame.value` transferred by `SENDER` frames is separate from `tx_fee` and f
 
 Each frame has its own `gas_limit` allocation. Unused gas from a frame is **not** available to subsequent frames. After all frames execute, the gas refund is calculated as:
 
-```
-refund = sum(frame.gas_limit for all frames) - total_gas_used
+```python
+refund = sum(frame.gas_limit for frame in tx.frames) - total_gas_used
 ```
 
 This refund is returned to the gas payer (the `resolved_target` that called `APPROVE(APPROVE_PAYMENT)` or `APPROVE(APPROVE_EXECUTION_AND_PAYMENT)`) and added back to the block gas pool.
@@ -421,12 +444,16 @@ This refund is returned to the gas payer (the `resolved_target` that called `APP
 Frame transactions can be used by accounts who do not have deployed code, nor an [EIP-7702](./eip-7702.md) delegation indicator via the "default code" mechanism. The behavior of the default code is defined below:
 
 - If `mode` is `VERIFY`:
-  - Read the allowed approval scope from the flags field: `allowed_scope = frame.flags & APPROVE_SCOPE_MASK`. If `allowed_scope == APPROVE_SCOPE_NONE`, revert.
-  - If `allowed_scope & APPROVE_EXECUTION != 0` and `resolved_target != tx.sender`, revert.
-  - If there is no `SECP256K1` signature `sig` such that `sig.signer == resolved_target` and `sig.msg == Bytes()`, revert.
+  - Read the allowed approval scope from the flags field: `allowed_scope = frame.flags & APPROVE_SCOPE_MASK`.
+  - If `allowed_scope == APPROVE_SCOPE_NONE`, revert.
+  - If there is no `SECP256K1` signature `sig` such that `resolved_signer == resolved_target` and `sig.msg == Bytes()`, revert.
   - Call `APPROVE(allowed_scope)`.
 - If `mode` is `SENDER` or `DEFAULT`:
   - Return successfully as if calling empty code.
+
+> TODO: Can we pass signature index as calldata?
+
+> TODO: Why don't we support P256 signature scheme as well?
 
 ### `APPROVE` Instruction (`0xaa`)
 
@@ -439,18 +466,10 @@ The `APPROVE` instruction exits the current EVM call frame successfully and upda
 | `top - 0`  | `offset`     |
 | `top - 1`  | `length`     |
 | `top - 2`  | `scope`      |
+ 
+#### Scope param
 
-#### Scope Operand
-
-The `scope` operand is a bitmask. Define the following constants:
-
-- `APPROVE_NONE` (`0x0`): No approval scope allowed - the current frame is not allowed to approve any scope.
-- `APPROVE_PAYMENT` (`0x1`): Approval of payment - the contract approves paying the total gas cost for the transaction.
-- `APPROVE_EXECUTION` (`0x2`): Approval of execution - the sender contract approves future frames calling on its behalf.
-   - Note this is only valid when `resolved_target` equals `tx.sender`.
-- `APPROVE_EXECUTION_AND_PAYMENT` (`0x3`): Approval of payment and execution.
-
-`APPROVE_SCOPE_MASK` is defined as an alias for `APPROVE_EXECUTION_AND_PAYMENT`.
+The `scope` param is a bitmask, and it must be a **non-zero** subset of frame's _Approval scope_ bitmap.
 
 #### Behavior
 
@@ -563,12 +582,12 @@ For `param` values `0x00` through `0x03`, the gas cost of this operation is `2`.
 
 For `param == 0x04`, this instruction copies bytes from an `ARBITRARY` signature's raw `signature` bytes into memory. Its gas cost is calculated exactly as for `CALLDATACOPY`, including the fixed cost of 3, the per-word copy cost, and the standard EVM memory expansion cost. It takes five values from the stack: `signatureIndex` on top, `param` second from top, followed by `length`, `dataOffset`, and `memOffset`. No stack output value is produced.
 
-| `param` | `signatureIndex` | Behavior                             |
-|---------|------------------|--------------------------------------|
-| 0x00    | signatureIndex   | returns effective signer address     |
-| 0x01    | signatureIndex   | returns `scheme`                     |
-| 0x02    | signatureIndex   | returns `msg`                        |
-| 0x03    | signatureIndex   | returns `len(signature)`             |
+| `param` | `signatureIndex` | Behavior                                     |
+|---------|------------------|----------------------------------------------|
+| 0x00    | signatureIndex   | returns `resolved_signer`                    |
+| 0x01    | signatureIndex   | returns `scheme`                             |
+| 0x02    | signatureIndex   | returns `msg`                                |
+| 0x03    | signatureIndex   | returns `len(signature)`                     |
 | 0x04    | signatureIndex   | copies `ARBITRARY` signature bytes to memory |
 
 Notes:
@@ -576,7 +595,7 @@ Notes:
 - Undefined `param` values result in an exceptional halt.
 - Out-of-bounds access for `signatureIndex` results in an exceptional halt.
 
-For `ARBITRARY` signature entries, requesting effective signer address results in exceptional halt
+For `ARBITRARY` signature entries, requesting `resolved_signer` results in exceptional halt
 
 For `param == 0x04`, if the referenced signature entry's `scheme` is not `ARBITRARY`, an exceptional halt occurs. The operation semantics match `CALLDATACOPY`, copying `length` bytes from the chosen signature's raw `signature` bytes, starting at the given byte `dataOffset`, into a memory region starting at `memOffset`. Bytes beyond the end of the signature are copied as zeroes.
 
@@ -685,13 +704,17 @@ To be accepted into the public mempool, a frame transaction must satisfy the fol
 6. The sum of `gas_limit` values across the validation prefix, plus the intrinsic cost of validating `tx.signatures`, must not exceed `MAX_VERIFY_GAS`.
 7. Nodes should stop simulation immediately once `payer` has been set.
 
+> TODO: Should we force frame.flag to match expected APPROVE call. Meaning, `self_verify` should be `0x3`, `only_verify` should be `0x2` and `pay` should be `0x1`
+
+> TODO: Should we force "no VERIFY frames" after validation prefix? Because it there is VERIFY frame afterwards and reverts, entire tx is invalid.
+
 #### Expiry Verifier Frame
 
-An `expiry_verify` frame MAY appear at any position in the frame list. For the purposes of matching the recognized validation-prefix shapes above, expiry verifier frames are skipped (e.g., `[expiry_verify, self_verify]` is recognized as `[self_verify]`).
+Although `TIMESTAMP` is generally banned during validation-prefix execution, it is permitted when executing the canonical expiry verifier runtime code at `EXPIRY_VERIFIER`; clients may optimize the frame by performing the same deadline check without explicit EVM execution.
+
+An `expiry_verify` frame MAY appear only as first frame in the frame list. For the purposes of matching the recognized validation-prefix shapes above, expiry verifier frame is skipped (e.g., `[expiry_verify, self_verify]` is recognized as `[self_verify]`).
 
 A node MUST drop a frame transaction from the public mempool if it contains an `expiry_verify` frame whose deadline is less than the node's view of the current block timestamp at any point.
-
-Expiry verifier frames are not subject to the validation trace rules, storage-dependency tracking, or `MAX_VERIFY_GAS`. The `TIMESTAMP` opcode is permitted only for the canonical expiry verifier runtime code at `EXPIRY_VERIFIER`; clients may optimize the frame by performing the same deadline check without explicit EVM execution.
 
 #### Canonical Paymaster Exception
 
@@ -827,10 +850,12 @@ Computing the signature hash in EVM is complicated and expensive. While using th
 The raw `signature` bytes of signatures with empty `msg` are elided from the canonical signature hash. This is done for three reasons:
 
 1. A signature over `compute_sig_hash(tx)` cannot commit to its own raw bytes.
-2. In the future it may be desired to aggregate or otherwise externalize these signatures for data and compute efficiency reasons.
-3. Signatures with explicit 32-byte `msg` values do not induce this circularity, so their raw bytes are currently committed by the transaction signature hash.
+1. Signatures with explicit 32-byte `msg` values do not induce this circularity, so their raw bytes are currently committed by the transaction signature hash.
+1. In the future it may be desired to aggregate or otherwise externalize these signatures for data and compute efficiency reasons.
 
 The `data` of `VERIFY` frames, including expiry verifier deadlines, is not elided. Any validation data that is intended to be added after a sender signs should be represented as elided raw signature bytes in `tx.signatures`, rather than as mutable frame data.
+
+> TODO: Is last paragraph needed? First sentence feels not needed with the current spec, second sentence is invalid (raw signature bytes have to be valid signature of `sig.msg`).
 
 ### `APPROVE` calling convention
 
@@ -896,6 +921,8 @@ Note that users can use any EOA as a paymaster thanks to the [default code](#def
 
 ### Examples
 
+> TODO: I would reorder columns to: "Frame, Mode, Caller, Flags, Target, Value, Data". Mode and Flags should come earlier as they are the most interesting for people reading this EIP.
+
 #### Example 1: Simple Transaction
 
 | Frame | Caller      | Target        | Value | Flags                         | Data      | Mode   |
@@ -957,7 +984,11 @@ Frame 0 uses a signature entry with empty `msg` and calls `APPROVE(APPROVE_EXECU
 - Frame 3: User's intended call.
 - Frame 4 (optional): Check unpaid gas, refund tokens, possibly convert tokens to ETH on an AMM.
 
+> TODO: Since Frame 1 checks that user has enough ERC-20 tokens, that means it can't be part of the public mempool. Should we highlight that here?
+
 ### Data Efficiency
+
+> TODO: Are these RLP encoding bytes needed? I think several are wrong in that case (e.g. even if sig.msg or frame.data is empty, it still takes 1 byte of encoding), but error is not big. Do we care to have exact values or are small differences ok?
 
 **Basic transaction sending ETH from a smart account:**
 
@@ -973,7 +1004,7 @@ Frame 0 uses a signature entry with empty `msg` and calls `APPROVE(APPROVE_EXECU
 | Blob versioned hashes (empty)     | 1     |
 | Signatures wrapper                | 1     |
 | Sender tx signature: scheme       | 1     |
-| Sender tx signature: signer       | 20    |
+| Sender tx signature: signer       | 1     |
 | Sender tx signature: msg          | 0     |
 | Sender tx signature: signature    | 65    |
 | Frames wrapper                    | 1     |
@@ -989,7 +1020,7 @@ Frame 0 uses a signature entry with empty `msg` and calls `APPROVE(APPROVE_EXECU
 | Execution frame: gas              | 1     |
 | Execution frame: value            | 5     |
 | Execution frame: data             | 0     |
-| **Total**                         | 158   |
+| **Total**                         | 139   |
 
 Notes: Nonce assumes < 65536 prior sends. Fees assume < 1099 gwei. Validation frame target is 1 byte because target is `tx.sender`. Validation gas assumes <= 65,536 gas. Validation frame value is zero. Execution frame target is encoded directly as the destination address. Execution frame value assumes a compact 5-byte encoding. The execution frame data is empty for a plain ETH transfer. The signature is a secp256k1 entry with empty `msg` using a 65-byte ECDSA signature. Blob fields assume no blobs (empty list, zero max fee).
 
@@ -1049,6 +1080,8 @@ The `ORIGIN` opcode behavior changes for frame transactions, returning the frame
 Frame transactions introduce new denial-of-service vectors for transaction pools that node operators must mitigate. Because validation logic is arbitrary EVM code, attackers can craft transactions that appear valid during initial validation but become invalid later. Without any additional policies, an attacker could submit many transactions whose validity depends on some shared state, then submit one transaction that modifies that state, and cause all other transactions to become invalid simultaneously. This wastes the computational resources nodes spent validating and storing these transactions.
 
 #### Example Attack
+
+> TODO: We now support this use case explicitly? Yes, it's split over multiple frames, but we support it. I think we should find different example.
 
 A simple example is transactions that check `block.timestamp`:
 

--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -436,12 +436,10 @@ Frame transactions can be used by accounts who do not have deployed code, nor an
 - If `mode` is `VERIFY`:
   - Read the allowed approval scope from the flags field: `allowed_scope = frame.flags & APPROVE_SCOPE_MASK`.
   - If `allowed_scope == APPROVE_SCOPE_NONE`, revert.
-  - If there is no `SECP256K1` signature `sig` such that `resolved_signer == resolved_target` and `sig.msg == Bytes()`, revert.
+  - If there is not a `SECP256K1` signature `sig` at index `0` such that `resolved_signer == resolved_target` and `sig.msg == Bytes()`, revert.
   - Call `APPROVE(allowed_scope)`.
 - If `mode` is `SENDER` or `DEFAULT`:
   - Return successfully as if calling empty code.
-
-> TODO: Can we pass signature index as calldata?
 
 ### `APPROVE` Instruction (`0xaa`)
 


### PR DESCRIPTION
Clean up of the EIP-8141 spec. Some highlighter changes:

- `sig.signer` can be empty and defaults to `tx.sender`
- raw `sig.signature` bytes are elided for all `sig_hash`
    - since all signatures need to be valid for tx to be valid -> committing to `sig.msg` indirectly commits to `sig.signatures` as well
    - if they are not elided, they can't be used for signature aggregation in the future
- Mempool
  - Expiry Verifier Frame can only be the first frame in the frame list
  - Each recognized frame type must use specific `frame.flags` value (corresponding to `APPROVE` call)
  - No `VERIFY` frames after validation prefix (otherwise they can invalidated entire transaction if they revert)
- Moved some content from one section to another where I though it would be more appropriate

> [!NOTE]
> I left several `TODO` in the code where I think we might want to change / clarify something. These should be resolved before merging.
