### PR TITLE
Update EIP-8037: Add explanation of 101 byte count in `REGULAR_PER_AUTH_BASE_COST`

### DIFF
--- a/EIPS/eip-8037.md
+++ b/EIPS/eip-8037.md
@@ -52,7 +52,7 @@ Upon activation of this EIP, the following parameters of the gas model are updat
 
 The `REGULAR_PER_AUTH_BASE_COST` is defined as the sum of:
 
-- Calldata cost: 1,616 (101 bytes × 16)
+- Calldata cost: 1,616 (101 bytes × 16), where 101 is the byte size of an [EIP-7702](./eip-7702.md) authorization tuple (`chain_id` 8 + `address` 20 + `nonce` 8 + `y_parity` 1 + `r` 32 + `s` 32). This is a representative size, not a worst case, since `chain_id` is a `uint256` and may exceed 8 bytes.
 - Recovering authority address (ecRecover): `PRECOMPILE_ECRECOVER` (is updated by [EIP-7904](./eip-7904.md))
 - Reading nonce and code of authority (cold access): `COLD_ACCOUNT_ACCESS` (is updated by [EIP-8038](./eip-8038.md))
 - Storing values in an already warm account: 2 x `WARM_ACCESS`

--- a/EIPS/eip-8038.md
+++ b/EIPS/eip-8038.md
@@ -123,7 +123,7 @@ The cases for account-related operations and their corresponding costs are summa
 
 `REGULAR_PER_AUTH_BASE_COST` is defined in [EIP-8037](./eip-8037.md) as the sum of:
 
-- Calldata cost: 1,616 (101 bytes × 16)
+- Calldata cost: 1,616 (101 bytes × 16), where 101 is the byte size of an [EIP-7702](./eip-7702.md) authorization tuple (`chain_id` 8 + `address` 20 + `nonce` 8 + `y_parity` 1 + `r` 32 + `s` 32). This is a representative size, not a worst case, since `chain_id` is a `uint256` and may exceed 8 bytes.
 - Recovering authority address (ecRecover): `PRECOMPILE_ECRECOVER` (updated by [EIP-7904](./eip-7904.md))
 - Reading nonce and code of authority (cold access): `COLD_ACCOUNT_ACCESS` (updated by this EIP)
 - Storing values in already warm account: 2 x `WARM_ACCESS`


### PR DESCRIPTION
The 101 magic number raised questions during the 8038 EELS implementation, cf https://github.com/ethereum/execution-specs/pull/2972#discussion_r3436672182; this PR adds a short explanation of the byte count to both 8037 and 8038.

