### PR TITLE
Update EIP-8038: reverse SSTORE clear refund to prevent net-profitable round trips

### DIFF
--- a/EIPS/eip-8038.md
+++ b/EIPS/eip-8038.md
@@ -53,10 +53,13 @@ In addition, the `SSTORE` cost formula is updated to include the following indep
 2. Write cost: additionally charge `STORAGE_WRITE` if the new value is different from the present value and the present value equals the original value (First time change).
 3. State creation cost: additionally charge `GAS_STORAGE_SET` (per [EIP-8037](./eip-8037.md)) if the original value is zero, the current value is zero, and the new value is non-zero.
 
-Refunds are also updated as follows:
+Refunds are also updated as follows. Each rule is an adjustment to the transaction's refund counter and is evaluated on every `SSTORE`:
 
-1. `STORAGE_CLEAR_REFUND` is refunded if the original value is non-zero, the current value is non-zero and the new value is zero.
-2. `STORAGE_WRITE` is refunded if the original value is the same as the new value.
+1. `STORAGE_CLEAR_REFUND` is added if the original value is non-zero, the current value is non-zero and the new value is zero (a slot is cleared).
+2. `STORAGE_CLEAR_REFUND` is subtracted if the original value is non-zero, the current value is zero and the new value is non-zero (a slot that was cleared earlier in the same transaction is restored). This reverses the refund granted by rule 1, so that clearing and then restoring a slot within the same transaction is never net-profitable.
+3. `STORAGE_WRITE` is refunded if the new value equals the original value and differs from the current value (a first-time change made earlier in the same transaction is reset back to its original value).
+
+Rules 2 and 3 mirror the refund accounting of [EIP-2200](./eip-2200.md) and [EIP-3529](./eip-3529.md) for slots that are modified more than once within a transaction: a `STORAGE_WRITE` charge or `STORAGE_CLEAR_REFUND` granted on an earlier `SSTORE` to the same slot is undone when a later `SSTORE` returns the slot to its original value. Without these reversals, a round trip such as `x → 0 → x` would yield a net refund even though the slot ends the transaction unchanged.
 
 These refunds go to the transaction's refund counter and are capped to 20% of the total gas used by the transaction, as per the current refund mechanism.
 
@@ -68,12 +71,15 @@ Cases and their corresponding costs are detailed in the table below:
 | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
 | 0 | 0 | x | Cold | New slot | `COLD_STORAGE_ACCESS` + `STORAGE_WRITE` charged | `GAS_STORAGE_SET` charged |
 | 0 | 0 | x | Warm | New slot | `WARM_ACCESS` + `STORAGE_WRITE` charged | `GAS_STORAGE_SET` charged |
-| 0 | x | 0 | Warm | Cleared slot, zero at transaction start | `WARM_ACCESS` charged, `STORAGE_WRITE` refunded | `GAS_STORAGE_SET` refilled |
-| x | x | 0 | Warm | Cleared slot, non-zero at transaction start | `WARM_ACCESS` charged, `STORAGE_CLEAR_REFUND` refunded | no state-gas adjustments |
-| x | x | y | Cold | Existing slot, updated to new value | `COLD_STORAGE_ACCESS` + `STORAGE_WRITE` charged | no state-gas adjustments |
-| x | x | y | Warm | Existing slot, updated to new value | `WARM_ACCESS` + `STORAGE_WRITE` charged | no state-gas adjustments |
-| x | y | z | Warm | Existing slot, written to again | `WARM_ACCESS` charged | no state-gas adjustments |
-| x | y | x | Warm | Existing slot, value reset | `WARM_ACCESS` charged, `STORAGE_WRITE` refunded | no state-gas adjustments |
+| x | x | y | Cold | Existing slot, first change | `COLD_STORAGE_ACCESS` + `STORAGE_WRITE` charged | no state-gas adjustments |
+| x | x | y | Warm | Existing slot, first change | `WARM_ACCESS` + `STORAGE_WRITE` charged | no state-gas adjustments |
+| x | x | 0 | Cold | Cleared slot, non-zero at transaction start | `COLD_STORAGE_ACCESS` + `STORAGE_WRITE` charged, `STORAGE_CLEAR_REFUND` refunded | no state-gas adjustments |
+| x | x | 0 | Warm | Cleared slot, non-zero at transaction start | `WARM_ACCESS` + `STORAGE_WRITE` charged, `STORAGE_CLEAR_REFUND` refunded | no state-gas adjustments |
+| 0 | x | 0 | Warm | Set slot reset to zero (zero at transaction start) | `WARM_ACCESS` charged, `STORAGE_WRITE` refunded | `GAS_STORAGE_SET` refilled |
+| x | y | x | Warm | Previously-modified slot reset to original value | `WARM_ACCESS` charged, `STORAGE_WRITE` refunded | no state-gas adjustments |
+| x | 0 | x | Warm | Cleared slot restored to original value | `WARM_ACCESS` charged, `STORAGE_WRITE` refunded, `STORAGE_CLEAR_REFUND` reversed | no state-gas adjustments |
+| x | 0 | y | Warm | Cleared slot written to a new non-zero value | `WARM_ACCESS` charged, `STORAGE_CLEAR_REFUND` reversed | no state-gas adjustments |
+| x | y | z | Warm | Previously-modified slot written to again | `WARM_ACCESS` charged | no state-gas adjustments |
 
 ### Account access pricing
 


### PR DESCRIPTION
## Summary

Fixes a refund bug in EIP-8038's `SSTORE` pricing: returning a slot to its original value within one transaction (e.g. `x → 0 → x`) could yield a net refund despite zero net state change.

## Problem

For `x → 0 → x`, the `STORAGE_CLEAR_REFUND` granted on the clear is never reversed when the slot is restored, leaving a net profit of `STORAGE_CLEAR_REFUND − COLD_STORAGE_ACCESS − WARM_ACCESS` = 9,380 gas. The refund rules dropped the reversal logic from [EIP-2200](https://eips.ethereum.org/EIPS/eip-2200) / [EIP-3529](https://eips.ethereum.org/EIPS/eip-3529), and the cases table was inconsistent with the prose.

## Changes

- Subtract `STORAGE_CLEAR_REFUND` when a previously-cleared slot is restored.
- Guard the `STORAGE_WRITE` reset refund with `new ≠ current`, closing a no-op `SSTORE` refund loophole.
- Fix the cases table to match the prose and add the missing clear/restore rows.

After the fix, `x → 0 → x` nets to a cost, not a profit.
