### PR TITLE
Update EIP-2780: require EIP-7523 instead of EIP-161

### DIFF
--- a/EIPS/eip-2780.md
+++ b/EIPS/eip-2780.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2020-07-11
-requires: 161, 2718, 2929, 2930, 6780, 7702, 7708, 7904, 7928, 8037, 8038
+requires: 2718, 2929, 2930, 6780, 7523, 7702, 7708, 7904, 7928, 8037, 8038
 ---
 
 ## Abstract
@@ -76,11 +76,11 @@ These charges replace the contract-creation transaction charges. All other intri
 
 During execution, before any opcode is executed, the recipient account is loaded and the following gas costs are charged:
 
-- if the recipient is empty per [EIP-161](./eip-161.md) and `tx.value > 0`, charge `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` in state gas;
+- if the recipient is non-existent and `tx.value > 0`, charge `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` in state gas;
 - if the recipient is an [EIP-7702](./eip-7702.md) delegated account, charge an additional `COLD_ACCOUNT_ACCESS` in regular gas;
 - otherwise, there are no charges.
 
-These charges are evaluated **after** [EIP-7702](./eip-7702.md) authorizations are applied. A `tx.to` whose account is materialized by an authorization in the same transaction is therefore no longer EIP-161-empty when this phase runs, so the new-account state charge does not fire; that account's creation is already priced by the authorization's `PER_EMPTY_ACCOUNT_COST`.
+Per [EIP-7523](./eip-7523.md), a post-merge state contains no empty accounts, so only a non-existent recipient creates a new account. These charges are evaluated **after** [EIP-7702](./eip-7702.md) authorizations are applied. A `tx.to` whose account is materialized by an authorization in the same transaction is therefore no longer non-existent when this phase runs, so the new-account state charge does not fire; that account's creation is already priced by the authorization's `PER_EMPTY_ACCOUNT_COST`.
 
 If a contract-creation transaction's initcode reverts, the transaction remains valid. In that case `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` is not charged and is refilled to the `state_gas_reservoir`, per [EIP-8037](./eip-8037.md). A plain value transfer to a new account executes no code and so cannot revert; its new-account state charge is therefore never rolled back this way.
 
@@ -166,7 +166,7 @@ Intrinsic and top-level gas, by case:
 1. Self-transfer (`from == to`): `12,000`.
 2. Zero-value transaction to any address (existing, empty, or contract): `15,000` regular (`12,000 + COLD_ACCOUNT_ACCESS`), `0` state. A self-target is `12,000`.
 3. Value transfer to an existing EOA: `21,000` regular, `0` state.
-4. Value transfer creating a new account (empty per EIP-161): `21,000` regular, `183,600` state.
+4. Value transfer creating a new account (recipient non-existent): `21,000` regular, `183,600` state.
 5. Value transfer to a 7702-delegated account: `24,000` regular plus execution.
 6. Contract-creation transaction, `value = 0`: `23,000` regular, `183,600` state.
 7. Contract-creation transaction, `value > 0`: `24,756` regular, `183,600` state.


### PR DESCRIPTION
Require EIP-7523 so the top-level new-account charge must be defined for non-existent recipients only.

The top-level new-account state charge was specified for a recipient "empty per EIP-161", but "empty per EIP-161" excludes a non-existent account, while the dominant case (the "Value transfer creating a new account" reference row at 183,600 state gas) is a transfer to a non-existent recipient.

Require EIP-7523 (post-merge states contain no empty accounts) in place of EIP-161. With no empty accounts, a recipient is either non-existent or alive, so the charge condition is simply "non-existent". Reword the normative bullet, the post-authorization note, and the reference-case list accordingly. This matches the reference implementation, which fires the charge whenever the recipient is not alive.