### PR TITLE
Update EIP-2780: clarify OOG handling for top-level gas charges

### DIFF
--- a/EIPS/eip-2780.md
+++ b/EIPS/eip-2780.md
@@ -82,6 +82,8 @@ During execution, before any opcode is executed, the recipient account is loaded
 
 Per [EIP-7523](./eip-7523.md), a post-merge state contains no empty accounts, so only a non-existent recipient creates a new account. These charges are evaluated **after** [EIP-7702](./eip-7702.md) authorizations are applied. A `tx.to` whose account is materialized by an authorization in the same transaction is therefore no longer non-existent when this phase runs, so the new-account state charge does not fire; that account's creation is already priced by the authorization's `PER_EMPTY_ACCOUNT_COST`.
 
+These top-level charges are applied during execution, after the transaction has already been validated and its [EIP-7702](./eip-7702.md) authorizations applied. If the remaining gas is insufficient to cover them — the new-account state-gas charge when the recipient is non-existent and `tx.value > 0`, or the additional `COLD_ACCOUNT_ACCESS` when the recipient is delegated — the transaction is **not** invalidated. It is instead treated as an exceptional halt (out-of-gas): the transaction is included, the sender pays for all gas consumed, and its state changes are reverted, exactly as for any out-of-gas condition during execution. Transaction validity is decided entirely by the intrinsic gas check, which requires no state access; these charges, which do require state access (resolving recipient existence and delegation only after authorizations are applied), can therefore never retroactively invalidate an already-validated transaction.
+
 If a contract-creation transaction's initcode reverts, the transaction remains valid. In that case `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` is not charged and is refilled to the `state_gas_reservoir`, per [EIP-8037](./eip-8037.md). A plain value transfer to a new account executes no code and so cannot revert; its new-account state charge is therefore never rolled back this way.
 
 ### Transaction reference cases
@@ -172,6 +174,7 @@ Intrinsic and top-level gas, by case:
 7. Contract-creation transaction, `value > 0`: `24,756` regular, `183,600` state.
 8. EIP-7702 transaction: `TX_BASE_COST` is unchanged even when the sender assumes code; access-list and authorization costs are unchanged.
 9. Contract-creation transaction whose initcode reverts (value-bearing or not): the transaction remains valid; the `183,600` new-account state-gas charge is refilled to the reservoir.
+10. Transaction whose gas suffices for intrinsic cost but not for the top-level charge (a value transfer to a non-existent recipient lacking gas for the new-account state charge, or a transfer to a delegated account lacking gas for the extra `COLD_ACCOUNT_ACCESS`): the transaction is valid and included, halts out-of-gas, and its state changes are reverted; it is **not** invalidated.
 
 Blocks of pure ETH transfers should be tested across all EL clients (e.g. on Perfnet) to confirm the pricing matches measured runtimes at the chosen throughput anchor.
 


### PR DESCRIPTION
Specifies what happens when a transaction has enough gas for intrinsic cost but not for the top-level charges applied during execution (new-account state charge or the extra `COLD_ACCOUNT_ACCESS` for a delegated recipient).

Since these charges are evaluated after EIP-7702 authorizations and require state access, insufficient gas is treated as an exceptional halt (out-of-gas) — the transaction is included and reverted, **not** invalidated. Transaction validity stays decidable from the intrinsic gas check alone, with no further state access.

Also adds a matching test case.

