### PR TITLE
Update EIP-7999: add data and state resources, simplify gas accounting

### DIFF
--- a/EIPS/eip-7999.md
+++ b/EIPS/eip-7999.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2025-08-04
-requires: 1559, 2718, 4844, 7516, 7623, 7691, 7702, 7706, 7825, 7840, 7918, 7928, 8037, 8131, 8279
+requires: 1559, 2718, 2780, 4844, 7516, 7623, 7691, 7702, 7706, 7825, 7840, 7918, 7928, 8037, 8131, 8279
 ---
 
 ## Abstract
@@ -62,9 +62,9 @@ The [EIP-2718](./eip-2718.md) `TransactionPayload` for this transaction is
 [chain_id, nonce, gas_limit, to, value, data, access_list, blob_versioned_hashes, max_fee, max_priority_fee_per_gas, y_parity, r, s]
 ```
 
-We require `max_fee` to be a scalar integer from `0` to `2**128-1` and `max_priority_fee_per_gas` to be a list of integers from `0` to `2**64-1`, either of length 1 or with the same length as the number of resources (initially 4). The `gas_limit` is initially specified only for the main EVM gas, since other limits can be inferred from the transaction. To facilitate further expansion, the Python spec uses a list with a single element at index 0. Each added integer will range from `0` to `2**64-1`.
+We require `max_fee` to be a scalar integer from `0` to `2**128-1` and `max_priority_fee_per_gas` to be a list of integers from `0` to `2**64-1`, either of length 1 or with the same length as the number of resources (initially 4). The `gas_limit` is initially specified only for the main EVM gas. To facilitate further expansion, the Python spec uses a list with a single element at index 0. Each added integer will range from `0` to `2**64-1`.
 
-The intrinsic cost of the new transaction is inherited from EIP-4844, except that the calldata gas cost (16 per non-zero byte, 4 per zero byte) is removed.
+The intrinsic cost of the new transaction is inherited from [EIP-2780](./eip-2780.md), except that the calldata gas cost (16 per non-zero byte, 4 per zero byte) is removed.
 
 ### Block processing and transaction fees
 
@@ -123,37 +123,24 @@ def get_priority_fee(tx, gas: list[int], base_fees: list[int], remaining_fee: in
     return max_priority_fee
 ```
 
-The helper for calculating gas limits from EIP-7706 is adjusted to subtract data gas from the gas limit of old transactions and to widen the returned vector to four items, with a trailing `0` for the state dimension:
+The helper for calculating gas limits from EIP-7706 is adjusted to return the worst-case gas limit for each of the four resources. Intrinsic costs are ignored here as a simplification:
 
 ```python
 def get_gas_limits(tx: Transaction) -> list[int]:
-    data_gas = get_intrinsic_data_gas(tx)            # was get_calldata_gas(tx.data)
+    gas_limit = tx.gas_limit[0] if tx.type == MULTIDIM_TX_TYPE else tx.gas_limit
     blob_gas = len(getattr(tx, 'blob_versioned_hashes', [])) * GAS_PER_BLOB
-    if tx.type == MULTIDIM_TX_TYPE: # We use tx.gas_limit as is for new tx type
-        return [tx.gas_limit[0], blob_gas, data_gas, 0]
-    else: # Partition old tx.gas_limit into its execution and data components.
-        require(tx.gas_limit >= data_gas)
-        return [tx.gas_limit - data_gas, blob_gas, data_gas, 0]
+    execution_gas = min(TX_MAX_GAS_LIMIT, gas_limit)
+    data_gas = get_intrinsic_data_gas(tx) + MAX_BAL_DATA_PER_GAS * execution_gas
+    state_gas = gas_limit
+    return [execution_gas, blob_gas, data_gas, state_gas]
 ```
 
 The calculation for the *required* `max_fee` to process the transaction is done in a separate function for easy future expansion:
 
 ```python
-def get_required_max_fee(tx, base_fees, tx_gas_limits) -> int:
-    if len(base_fees) == len(tx_gas_limits):       # fully-specified vector limits
-        return sum(vector_mul(base_fees, tx_gas_limits))
-    intrinsic_exec_gas = get_intrinsic_exec_gas(tx)    # base tx cost, access lists, auth base
-    intrinsic_state_gas = get_intrinsic_state_gas(tx)  # worst-case intrinsic state
-    cost  = base_fees[0]*intrinsic_exec_gas + base_fees[3]*intrinsic_state_gas
-    cost += base_fees[2]*tx_gas_limits[2] + base_fees[1]*tx_gas_limits[1]
-    remaining_gas = tx_gas_limits[0] - intrinsic_exec_gas - intrinsic_state_gas
-    gas_left = min(TX_MAX_GAS_LIMIT - intrinsic_exec_gas, remaining_gas)
-    cost += gas_left * max(base_fees[i] for i in SHARED_GAS_INDICES)   # [0,2,3]
-    cost += (remaining_gas - gas_left) * base_fees[3]
-    return cost
+def get_required_max_fee(base_fees: list[int], tx_gas_limits: list[int]) -> int:
+    return sum(vector_mul(base_fees, tx_gas_limits))
 ```
-
-The `gas_left` budget is shared by execution, BAL data, and state, so it is priced at the highest of their base fees; the state-only reservoir is priced at the state base fee.
 
 **At the start of processing a block**:
 
@@ -163,12 +150,13 @@ The `gas_left` budget is shared by execution, BAL data, and state, so it is pric
 **At the start of processing a transaction**:
 
   * Derive basic properties of the tx: 
-    * `max_fee = get_max_fee(tx)`, 
-    * `tx_gas_limits = get_gas_limits(tx)`.
-    * `max_base = get_required_max_fee(tx, base_fees, tx_gas_limits)`
-  * Require that 
-    * the capacity check holds for indices `0..2` only (state has no block limit and is excluded). The reservation equals `tx_gas_limits` except that index `2` reserves the worst-case data gas `tx_max_data = get_intrinsic_data_gas(tx) + MAX_BAL_DATA_PER_GAS * gas_left`, so that `all_less_or_equal(vector_add(gas_used_so_far, reservation), gas_limits)` over those indices. The block's `gas_limits` are defined in the next subsection. We also require `MAX_BAL_DATA_PER_GAS * TX_MAX_GAS_LIMIT <= DATA_GAS_LIMIT` so that no single transaction is unincludable.
+    * `max_fee = get_max_fee(tx)`
+    * `tx_gas_limits = get_gas_limits(tx)`
+    * `max_base = get_required_max_fee(base_fees, tx_gas_limits)`
+  * Require that:
+    * `all_less_or_equal(vector_add(gas_used_so_far, tx_gas_limits), gas_limits)`. The block's `gas_limits` does not include the state resource as it does not have a block limit. This variable is defined in the next subsection
     * `max_base <= max_fee`
+    * The transaction’s intrinsic costs are not higher than [EIP-7825](./eip-7825.md)’s transaction cap.
   * Compute the fees to deduct initially:
     * `max_priority_fee = get_priority_fee(tx, tx_gas_limits, base_fees, max_fee - max_base)`
     * `fee_to_deduct = max_base + max_priority_fee`
@@ -199,14 +187,17 @@ def get_execution_data_gas(bal_data_bytes: int) -> int:
 
 Here `content_bytes(tx)` is the EIP-8131 user-controlled content byte count (calldata, access-list entries, [EIP-7702](./eip-7702.md) authorizations, EIP-4844 blob versioned hashes); envelope/signature/type-prefix bytes are not charged. The EIP-8279 BAL metering hook charges `DATA_GAS_PER_BAL_BYTE` per byte to the data dimension at the data base fee.
 
-### Shared gas budget and reservoir
+### Gas accounting
 
-State gas is metered with the [EIP-8037](./eip-8037.md) reservoir model but settled against its own base fee. Before execution, we deduct `intrinsic_exec_gas = get_intrinsic_exec_gas(tx)` (base transaction cost, access lists, authorization base) and `intrinsic_state_gas = get_intrinsic_state_gas(tx)` (worst-case intrinsic state for creations and authorizations) from `gas_limit`, then split the remainder into a shared budget and a state-only reservoir:
+State gas is metered with the [EIP-8037](./eip-8037.md) reservoir model but settled against its own base fee. Before execution, we deduct `intrinsic_exec_gas = get_intrinsic_exec_gas(tx)` (base transaction cost, access lists, authorization base), `intrinsic_data_gas = get_intrinsic_data_gas(tx)` (as defined above) and `intrinsic_state_gas = get_intrinsic_state_gas(tx)` (worst-case intrinsic state for creations and authorizations) from `gas_limit`, then split the remainder into a shared budget and a state-only reservoir:
 
 ```python
-remaining_gas = tx.gas_limit - intrinsic_exec_gas - intrinsic_state_gas
-gas_left = min(TX_MAX_GAS_LIMIT - intrinsic_exec_gas, remaining_gas)
-state_gas_reservoir = remaining_gas - gas_left
+intrinsic_regular_gas = intrinsic_exec_gas + intrinsic_data_gas
+intrinsic_gas = intrinsic_regular_gas + intrinsic_state_gas
+execution_gas = tx.gas - intrinsic_gas
+regular_gas_budget = TX_MAX_GAS_LIMIT - intrinsic_regular_gas
+gas_left = min(regular_gas_budget, execution_gas)
+state_gas_reservoir = execution_gas - gas_left
 ```
 
 During execution, execution gas draws `gas_left` at the execution base fee; state gas spends the reservoir first and then `gas_left` at the **state** base fee (the EIP-8037 LIFO refills are unchanged); BAL data always draws `gas_left`, settled at the data base fee:

--- a/EIPS/eip-7999.md
+++ b/EIPS/eip-7999.md
@@ -8,12 +8,12 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2025-08-04
-requires: 1559, 2718, 4844, 7516, 7691, 7840, 7918
+requires: 1559, 2718, 4844, 7516, 7623, 7691, 7702, 7706, 7825, 7840, 7918, 7928, 8037, 8131, 8279
 ---
 
 ## Abstract
 
-A unified multidimensional fee market is introduced, where each transaction specifies the maximum amount of ETH it is willing to pay for inclusion using a single `max_fee`. Upon inclusion, the protocol ensures that the transaction is able to pay the gas for all dimensions, treating the `max_fee` as fungible across resources. This enables a more efficient use of capital, and enshrines the same representation that users have when they interact with Ethereum. The fee market is further unified in terms of a single update fraction under a single fee update mechanism, generalized reserve pricing, and a gas normalization that retains current percentage ranges while keeping the price stable whenever a gas limit changes. Calldata is proposed as the first resource to be added, with avenues for facilitating gas fungibility for EVM resources considered for further expansion.
+A unified multidimensional fee market is introduced, where each transaction specifies the maximum amount of ETH it is willing to pay for inclusion using a single `max_fee`. Upon inclusion, the protocol ensures that the transaction is able to pay the gas for all dimensions, treating the `max_fee` as fungible across resources. This enables a more efficient use of capital, and enshrines the same representation that users have when they interact with Ethereum. The fee market is further unified in terms of a single update fraction under a single fee update mechanism, generalized reserve pricing, and a gas normalization that retains current percentage ranges while keeping the price stable whenever a gas limit changes. A data resource (transaction content bytes and block-access-list bytes) and a state-growth resource are added alongside execution and blob gas, with avenues for facilitating gas fungibility for EVM resources considered for further expansion.
 
 ## Motivation
 
@@ -35,15 +35,22 @@ The specification inherits its logic from [EIP-7706](./eip-7706.md), incorporati
 | :--- | :--- | :--- |
 | `MULTIDIM_TX_TYPE` | `TBD` <!-- TODO --> | Identifier for the new transaction type |
 | `EVM_LIMIT_TARGET_RATIO` | `2` | Ratio of EVM gas target to EVM gas limit |
-| `CALLDATA_GAS_PER_TOKEN` | `4` | Gas cost per token for calldata |
-| `TOKENS_PER_NONZERO_BYTE` | `4` | Tokens per non-zero byte of calldata |
-| `CALLDATA_GAS_LIMIT_RATIO` | `4` | Ratio of calldata limit to gas limit |
-| `CALLDATA_LIMIT_TARGET_RATIO` | `4` | Ratio of calldata target to calldata limit |
-| `GAS_RESERVE_FACTOR` | `[0, 16, 12]` | Factor by which the base fee can be below the baseline |
-| `GAS_RESERVE_INDEX` | `[0, 0, 1]` | Index of the base fee to compare against |
+| `DATA_GAS_PER_CONTENT_BYTE` | `16` | Data gas charged per content byte (counted per [EIP-8131](./eip-8131.md)) |
+| `DATA_GAS_PER_BAL_BYTE` | `TBD` <!-- TODO --> | Data gas charged per block-access-list byte (metered per [EIP-8279](./eip-8279.md)) |
+| `MAX_BAL_DATA_PER_GAS` | `TBD` <!-- TODO --> | Maximum BAL data gas per unit of shared gas (`< 1`) |
+| `DATA_GAS_LIMIT` | `60_000_000` | Per-block data gas limit |
+| `DATA_LIMIT_TARGET_RATIO` | `TBD` <!-- TODO --> | Ratio of data target to data limit |
+| `SHARED_GAS_INDICES` | `[0, 2, 3]` | Resource indices that draw from the shared gas budget |
+| `TX_MAX_GAS_LIMIT` | `16_777_216` | Maximum execution gas per transaction (from [EIP-7825](./eip-7825.md)) |
+| `STATE_GAS_TARGET` | `TBD` <!-- TODO --> | Per-block state gas target (state has no block limit) |
+| `CPSB` | `1530` | State gas charged per state byte (from [EIP-8037](./eip-8037.md)) |
+| `GAS_RESERVE_FACTOR` | `[0, 16, 12, 0]` | Factor by which the base fee can be below the baseline |
+| `GAS_RESERVE_INDEX` | `[0, 0, 1, 0]` | Index of the base fee to compare against |
 | `MIN_BASE_FEE_PER_GAS` | `1` | Minimum base fee per gas unit |
 | `GAS_NORMALIZATION_FACTOR` | `10**9` | Normalization factor for the delta excess gas |
 | `BASE_FEE_UPDATE_FRACTION` | `4_245_093_508` | ≈ `GAS_NORMALIZATION_FACTOR / (2 * ln(1.125))` |
+
+The EIP-8037 state-byte constants and per-operation state-gas charges are inherited unchanged; only the base fee they settle against changes.
 
 ### New transaction type
 
@@ -55,7 +62,7 @@ The [EIP-2718](./eip-2718.md) `TransactionPayload` for this transaction is
 [chain_id, nonce, gas_limit, to, value, data, access_list, blob_versioned_hashes, max_fee, max_priority_fee_per_gas, y_parity, r, s]
 ```
 
-We require `max_fee` to be a scalar integer from `0` to `2**128-1` and `max_priority_fee_per_gas` to be a list of integers from `0` to `2**64-1`, either of length 1 or with the same length as the number of resources (initially 3). The `gas_limit` is initially specified only for the main EVM gas, since other limits can be inferred from the transaction. To facilitate further expansion, the Python spec uses a list with a single element at index 0. Each added integer will range from `0` to `2**64-1`.
+We require `max_fee` to be a scalar integer from `0` to `2**128-1` and `max_priority_fee_per_gas` to be a list of integers from `0` to `2**64-1`, either of length 1 or with the same length as the number of resources (initially 4). The `gas_limit` is initially specified only for the main EVM gas, since other limits can be inferred from the transaction. To facilitate further expansion, the Python spec uses a list with a single element at index 0. Each added integer will range from `0` to `2**64-1`.
 
 The intrinsic cost of the new transaction is inherited from EIP-4844, except that the calldata gas cost (16 per non-zero byte, 4 per zero byte) is removed.
 
@@ -92,7 +99,7 @@ def get_max_fee(tx: Transaction) -> int:
 ```python
 def get_priority_fee(tx, gas: list[int], base_fees: list[int], remaining_fee: int) -> int:
     # Precalculate total gas and fees for non-blob resources
-    tip_indices = [0, 2]
+    tip_indices = [0, 2, 3]
     tgas = sum(gas[i] for i in tip_indices)
     tfee = sum(gas[i] * base_fees[i] for i in tip_indices)
 
@@ -116,38 +123,41 @@ def get_priority_fee(tx, gas: list[int], base_fees: list[int], remaining_fee: in
     return max_priority_fee
 ```
 
-The calldata resource pricing under this EIP follows previous gas per byte constants but deprecates the floor pricing specified in [EIP-7623](./eip-7623.md):
-
-```python
-def get_calldata_gas(calldata: bytes) -> int:
-    tokens = calldata.count(0) + (len(calldata) - calldata.count(0)) * TOKENS_PER_NONZERO_BYTE
-    return tokens * CALLDATA_GAS_PER_TOKEN
-```
-
-The helper for calculating gas limits from EIP-7706 is adjusted to subtract calldata gas from the gas limit of old transactions:
+The helper for calculating gas limits from EIP-7706 is adjusted to subtract data gas from the gas limit of old transactions and to widen the returned vector to four items, with a trailing `0` for the state dimension:
 
 ```python
 def get_gas_limits(tx: Transaction) -> list[int]:
-    calldata_gas = get_calldata_gas(tx.data)
+    data_gas = get_intrinsic_data_gas(tx)            # was get_calldata_gas(tx.data)
     blob_gas = len(getattr(tx, 'blob_versioned_hashes', [])) * GAS_PER_BLOB
     if tx.type == MULTIDIM_TX_TYPE: # We use tx.gas_limit as is for new tx type
-        return [tx.gas_limit, blob_gas, calldata_gas]
-    else: # Partition old tx.gas_limit into its execution and calldata components.
-        require(tx.gas_limit >= calldata_gas)  
-        execution_gas = tx.gas_limit - calldata_gas
-        return [execution_gas, blob_gas, calldata_gas]
+        return [tx.gas_limit[0], blob_gas, data_gas, 0]
+    else: # Partition old tx.gas_limit into its execution and data components.
+        require(tx.gas_limit >= data_gas)
+        return [tx.gas_limit - data_gas, blob_gas, data_gas, 0]
 ```
 
 The calculation for the *required* `max_fee` to process the transaction is done in a separate function for easy future expansion:
 
 ```python
-def get_required_max_fee(base_fees: list[int], tx_gas_limits: list[int]) -> int:
-    return sum(vector_mul(base_fees, tx_gas_limits))
+def get_required_max_fee(tx, base_fees, tx_gas_limits) -> int:
+    if len(base_fees) == len(tx_gas_limits):       # fully-specified vector limits
+        return sum(vector_mul(base_fees, tx_gas_limits))
+    intrinsic_exec_gas = get_intrinsic_exec_gas(tx)    # base tx cost, access lists, auth base
+    intrinsic_state_gas = get_intrinsic_state_gas(tx)  # worst-case intrinsic state
+    cost  = base_fees[0]*intrinsic_exec_gas + base_fees[3]*intrinsic_state_gas
+    cost += base_fees[2]*tx_gas_limits[2] + base_fees[1]*tx_gas_limits[1]
+    remaining_gas = tx_gas_limits[0] - intrinsic_exec_gas - intrinsic_state_gas
+    gas_left = min(TX_MAX_GAS_LIMIT - intrinsic_exec_gas, remaining_gas)
+    cost += gas_left * max(base_fees[i] for i in SHARED_GAS_INDICES)   # [0,2,3]
+    cost += (remaining_gas - gas_left) * base_fees[3]
+    return cost
 ```
+
+The `gas_left` budget is shared by execution, BAL data, and state, so it is priced at the highest of their base fees; the state-only reservoir is priced at the state base fee.
 
 **At the start of processing a block**:
 
-  * initialize a vector `gas_used_so_far` to `[0, 0, 0]`,
+  * initialize a vector `gas_used_so_far` to `[0, 0, 0, 0]`,
   * derive the base fee `base_fees = get_block_base_fees(block.parent)`.
 
 **At the start of processing a transaction**:
@@ -155,9 +165,9 @@ def get_required_max_fee(base_fees: list[int], tx_gas_limits: list[int]) -> int:
   * Derive basic properties of the tx: 
     * `max_fee = get_max_fee(tx)`, 
     * `tx_gas_limits = get_gas_limits(tx)`.
-    * `max_base = get_required_max_fee(base_fees, tx_gas_limits)`
+    * `max_base = get_required_max_fee(tx, base_fees, tx_gas_limits)`
   * Require that 
-    * `all_less_or_equal(vector_add(gas_used_so_far, tx_gas_limits), gas_limits)`. The block's `gas_limits` are defined in the next subsection.
+    * the capacity check holds for indices `0..2` only (state has no block limit and is excluded). The reservation equals `tx_gas_limits` except that index `2` reserves the worst-case data gas `tx_max_data = get_intrinsic_data_gas(tx) + MAX_BAL_DATA_PER_GAS * gas_left`, so that `all_less_or_equal(vector_add(gas_used_so_far, reservation), gas_limits)` over those indices. The block's `gas_limits` are defined in the next subsection. We also require `MAX_BAL_DATA_PER_GAS * TX_MAX_GAS_LIMIT <= DATA_GAS_LIMIT` so that no single transaction is unincludable.
     * `max_base <= max_fee`
   * Compute the fees to deduct initially:
     * `max_priority_fee = get_priority_fee(tx, tx_gas_limits, base_fees, max_fee - max_base)`
@@ -166,7 +176,7 @@ def get_required_max_fee(base_fees: list[int], tx_gas_limits: list[int]) -> int:
 
 **At the end of processing a transaction**:
 
-  * Compute `tx_gas_consumed` as a three-item vector, where the first item is the amount of execution gas actually consumed, and the second and third items are the blob and calldata gas amounts, which are equal to their limits from `tx_gas_limits`.
+  * Compute `tx_gas_consumed` as a four-item vector: item `0` is the execution gas actually consumed, item `1` is the blob gas (equal to its limit from `tx_gas_limits`), item `2` is the data gas actually consumed (`get_intrinsic_data_gas(tx)` plus the execution data gas metered for BAL bytes, not its reserved limit), and item `3` is the state gas actually consumed (net of EIP-8037 refills).
   * Burn `base_fee_paid = sum(vector_mul(base_fees, tx_gas_consumed))`.
   * Transfer to the coinbase `priority_fee_paid = get_priority_fee(tx, tx_gas_consumed, base_fees, fee_to_deduct - base_fee_paid)`
   * Refund the sender `fee_to_deduct - base_fee_paid - priority_fee_paid`.
@@ -175,36 +185,68 @@ def get_required_max_fee(base_fees: list[int], tx_gas_limits: list[int]) -> int:
 **At the end of processing a block**:
 
   * Require each element of `block.gas_used` (a vector field in the header) to equal the corresponding element in `gas_used_so_far`.
+  
+### The new data resource
+
+The data resource is priced from two sources and deprecates the floor pricing specified in [EIP-7623](./eip-7623.md): transaction content bytes counted deterministically per [EIP-8131](./eip-8131.md), and block-access-list (BAL) bytes metered at runtime per [EIP-8279](./eip-8279.md):
+
+```python
+def get_intrinsic_data_gas(tx) -> int:
+    return content_bytes(tx) * DATA_GAS_PER_CONTENT_BYTE   # EIP-8131 content count
+def get_execution_data_gas(bal_data_bytes: int) -> int:
+    return bal_data_bytes * DATA_GAS_PER_BAL_BYTE          # EIP-8279 counter
+```
+
+Here `content_bytes(tx)` is the EIP-8131 user-controlled content byte count (calldata, access-list entries, [EIP-7702](./eip-7702.md) authorizations, EIP-4844 blob versioned hashes); envelope/signature/type-prefix bytes are not charged. The EIP-8279 BAL metering hook charges `DATA_GAS_PER_BAL_BYTE` per byte to the data dimension at the data base fee.
+
+### Shared gas budget and reservoir
+
+State gas is metered with the [EIP-8037](./eip-8037.md) reservoir model but settled against its own base fee. Before execution, we deduct `intrinsic_exec_gas = get_intrinsic_exec_gas(tx)` (base transaction cost, access lists, authorization base) and `intrinsic_state_gas = get_intrinsic_state_gas(tx)` (worst-case intrinsic state for creations and authorizations) from `gas_limit`, then split the remainder into a shared budget and a state-only reservoir:
+
+```python
+remaining_gas = tx.gas_limit - intrinsic_exec_gas - intrinsic_state_gas
+gas_left = min(TX_MAX_GAS_LIMIT - intrinsic_exec_gas, remaining_gas)
+state_gas_reservoir = remaining_gas - gas_left
+```
+
+During execution, execution gas draws `gas_left` at the execution base fee; state gas spends the reservoir first and then `gas_left` at the **state** base fee (the EIP-8037 LIFO refills are unchanged); BAL data always draws `gas_left`, settled at the data base fee:
+
+```python
+def charge_bal_data_gas(amount):   # gas, via DATA_GAS_PER_BAL_BYTE
+    charge_gas_left(amount); execution_data_gas_used += amount
+```
 
 ### Block structure
 
-The `BlockHeader` is updated to remove the `blob_gas_used`, `gas_used`, `base_fee_per_gas`, `gas_limit` and `excess_blob_gas` fields, and the following new fields are added, all of the `[int, int, int]` type: `gas_limits`, `gas_used`, `excess_gas`. The header sequence of the new fields is `[..., withdrawals_root, gas_limits, gas_used, excess_gas]`.
+The `BlockHeader` is updated to remove the `blob_gas_used`, `gas_used`, `base_fee_per_gas`, `gas_limit` and `excess_blob_gas` fields, and the following new fields are added: `gas_limits` of the `[int, int, int]` type, and `gas_used` and `excess_gas` of the `[int, int, int, int]` type (the data and state dimensions track usage but state has no block limit). The header sequence of the new fields is `[..., withdrawals_root, gas_limits, gas_used, excess_gas]`.
 
 We define the `gas_limits`
 
   * `gas_limits[0]` follows the existing adjustment formula based on the parent `gas_limits[0]`.
   * `gas_limits[1]` must equal `blobSchedule.max * GAS_PER_BLOB`
-  * `gas_limits[2]` must equal `gas_limits[0] // CALLDATA_GAS_LIMIT_RATIO`.
+  * `gas_limits[2]` must equal `DATA_GAS_LIMIT`.
 
 and the `gas_targets`
 
   * `gas_targets[0]` must equal `gas_limits[0] // EVM_LIMIT_TARGET_RATIO`.
   * `gas_targets[1]` must equal `blobSchedule.target * GAS_PER_BLOB`.
-  * `gas_targets[2]` must equal `gas_limits[2] // CALLDATA_LIMIT_TARGET_RATIO`.
+  * `gas_targets[2]` must equal `gas_limits[2] // DATA_LIMIT_TARGET_RATIO`.
+  * `gas_targets[3]` must equal `STATE_GAS_TARGET`.
 
-The blobSchedule for referencing target and max blobs was introduced in [EIP-7840](./eip-7840.md).
+State has no per-block limit; it equilibrates around `STATE_GAS_TARGET`, which corresponds to `STATE_GAS_TARGET / CPSB` state bytes per block. The blobSchedule for referencing target and max blobs was introduced in [EIP-7840](./eip-7840.md).
 
 ### Gas accounting
 
-We incorporate EIP-7918 to establish a dynamic reserve price for blob and calldata gas. When the market price for a resource drops below its reserve price, the mechanism for reducing its `excess_gas` (and thus lowering its base fee) is disabled. This leads the base fee to rise with usage until it meets the reserve price.
+We incorporate EIP-7918 to establish a dynamic reserve price for blob and data gas. When the market price for a resource drops below its reserve price, the mechanism for reducing its `excess_gas` (and thus lowering its base fee) is disabled. This leads the base fee to rise with usage until it meets the reserve price. State has no EIP-7918 anchor (`GAS_RESERVE_FACTOR[3] = 0`), so it never enters the reserve path.
 
-We normalize the running excess gas so that all resources operate at the same scale with the same `BASE_FEE_UPDATE_FRACTION`, which also provides a smoother response when any limit is adjusted. Division by `gas_limits[i]` upholds the same price changes stipulated in EIP-4844 and [EIP-7691](./eip-7691.md).
+We normalize the running excess gas so that all resources operate at the same scale with the same `BASE_FEE_UPDATE_FRACTION`, which also provides a smoother response when any limit is adjusted. Division by `norm[i]` upholds the same price changes stipulated in EIP-4844 and [EIP-7691](./eip-7691.md); since state has no block limit, it normalizes by its target instead.
 
 ```python
 def calc_excess_gas(parent: Header) -> list[int]:
     base_fees = get_block_base_fees(parent)
     limits = parent.gas_limits
     targets = get_block_gas_targets(parent)
+    norm = limits + [targets[3]]  # state has no limit, so it normalizes by its target
 
     new_excess = []
     for i in range(len(parent.excess_gas)):
@@ -216,10 +258,10 @@ def calc_excess_gas(parent: Header) -> list[int]:
         else:  # Regular path. Excess gas rises and falls with usage as normal
             if parent.gas_used[i] >= targets[i]: # Add
                 delta = parent.gas_used[i] - targets[i]
-                excess = parent.excess_gas[i] + delta * GAS_NORMALIZATION_FACTOR // limits[i]
+                excess = parent.excess_gas[i] + delta * GAS_NORMALIZATION_FACTOR // norm[i]
             else: # ..or subtract
                 delta = targets[i] - parent.gas_used[i]
-                deltan = delta * GAS_NORMALIZATION_FACTOR // limits[i]
+                deltan = delta * GAS_NORMALIZATION_FACTOR // norm[i]
                 excess = 0 if parent.excess_gas[i] < deltan else parent.excess_gas[i] - deltan
         new_excess.append(excess)  
     return new_excess
@@ -237,13 +279,14 @@ def get_block_base_fees(parent: Header) -> list[int]:
     ]
 ```
 
-### CALLDATABASEFEE instruction
+### DATABASEFEE and STATEBASEFEE instructions
 
-We add a `CALLDATABASEFEE (0x4b)` instruction that returns the calldata base fee of the current block, following the same principles as specified in [EIP-7516](./eip-7516.md) for the blob base fee. 
+We add a `DATABASEFEE (0x4b)` instruction that returns the data base fee of the current block, and a `STATEBASEFEE (0x4c)` instruction that returns the state base fee of the current block. Both follow the same principles as specified in [EIP-7516](./eip-7516.md) for the blob base fee. 
 
 | Op   | Input | Output | Cost |
 |------|-------|--------|------|
 | 0x4b | 0     | 1      | 2    |
+| 0x4c | 0     | 1      | 2    |
 
 ### Censorship resistance
 
@@ -253,7 +296,7 @@ In EIP-7805, *includers* propose inclusion-list (IL) transactions that the block
 * *Unconditional resource* – An IL transaction consuming this resource *must be included* as long as sufficient capacity remains for all *conditional* resources it also uses. A lack of available capacity in the unconditional resource itself is *not* a valid reason for exclusion.
 * *Deconditional resource* – An IL transaction consuming this resource *can always be excluded*, regardless of available capacity. For this reason, there is no incentive for includers to list such a transaction.
 
-If EIP-7805 is implemented, it must: (i) continue to treat EVM gas as a conditional resource; (ii) continue to treat blob gas as a deconditional resource; (iii) treat calldata gas as an unconditional resource. Any transaction listed in an IL that consumes calldata and is excluded from the block, despite there being sufficient capacity in all conditional resources it uses, MUST produce an `INVALID_INCLUSION_LIST`.
+If EIP-7805 is implemented, it must: (i) continue to treat EVM gas as a conditional resource; (ii) continue to treat blob gas as a deconditional resource; (iii) treat data gas as an unconditional resource; (iv) treat state gas as an unconditional resource. State is unconditional because it has no block limit and therefore can never be full; a state-using IL transaction must be included as long as its conditional resources (execution, and the conditional space for data) have room. Any transaction listed in an IL that consumes data or state and is excluded from the block, despite there being sufficient capacity in all conditional resources it uses, MUST produce an `INVALID_INCLUSION_LIST`.
 
 ## Rationale
 
@@ -315,7 +358,7 @@ It should here be noted that the required priority fee per gas for some resource
 
 Ethereum currently uses two separate fee mechanisms, one for execution gas (EIP-1559) and one for blob gas (EIP-4844). This EIP unifies these mechanisms under the EIP-4844 standard, similar to EIP-7706 but with a few additions. We normalize the excess gas delta by dividing by the gas limit in `calc_excess_gas`, thus enabling all resources to operate under the same `BASE_FEE_UPDATE_FRACTION` while also keeping each fee fixed during a hard fork whenever a limit changes.
 
-The reserve pricing mechanism from EIP-7918 is also generalized such that it can be applied to any resource, using another resource as an anchor. The mechanism imposes that if the base fee multiplied by `GAS_RESERVE_FACTOR` is less than the anchor base fee, the base fee cannot fall any further. Calldata uses blob data as an anchor to ensure that we do not charge less for calldata than blob data (see the separate section on the calldata resource for further details).
+The reserve pricing mechanism from EIP-7918 is also generalized such that it can be applied to any resource, using another resource as an anchor. The mechanism imposes that if the base fee multiplied by `GAS_RESERVE_FACTOR` is less than the anchor base fee, the base fee cannot fall any further. Data uses blob data as an anchor to ensure that we do not charge less for data than blob data (see the separate section on the data resource for further details). State has no anchor (`GAS_RESERVE_FACTOR[3] = 0`) and is excluded from the reserve path.
 
 ### Wallet fee estimation logic
 
@@ -326,13 +369,13 @@ To suggest a `max_fee`, the wallet first simulates the transaction to obtain an 
 
 Historical data show that around 90% of blocks are below the gas limit. It is only when blocks are full that the builder is constrained in its block construction (disregarding timing games). Furthermore, a multidimensional knapsack problem only manifests in the event that a block is simultaneously full in multiple dimensions. Ignoring blobs, this is expected to be rare with the proposal, since calldata is assigned a limit four times above the target, which is already set higher than current consumption. The calldata limit is thus unlikely to be reached frequently. The blob dimension is a special case, in that this dimension already exists today, and the number of blob-carrying transactions is fairly low. Generally, the impact on revenue from sophisticated packing algorithms will likely be dwarfed by more significant MEV factors such as transaction ordering and private order flow.
 
-### The calldata resource
+### The data resource
 
 #### Byte sizes
 
-Calldata is separated into its own resource. With the proposed constants, at 60M execution gas, each block will on average contain `60M/(CALLDATA_GAS_LIMIT_RATIO * CALLDATA_LIMIT_TARGET_RATIO) = 3.75M` gas of calldata. Focusing on non-zero bytes that cannot be Snappy-compressed, this gas corresponds to around `3.75M/16 = 234kB`. The average block size has been around `90kB` at a 36M gas limit, which would expand to `150kB` at a 60M gas limit if the proportion of calldata in the block remains the same. Using basic assumptions, this proposal thus increases the amount of calldata that will be consumed by over 50%, from `150kB` to `234kB` at 60M gas. As pointed out in EIP-7706, this will serve to decrease the cost of calldata for our users. 
+Data is separated into its own resource, priced from two sources: transaction content bytes counted deterministically per EIP-8131, and block-access-list (BAL) bytes metered at runtime per EIP-8279. Both sources are charged in the same data dimension, settled at the data base fee. With `DATA_GAS_PER_CONTENT_BYTE = 16` and `DATA_GAS_LIMIT = 60_000_000`, the per-block data limit corresponds to a worst case of around `60M/16 = 3.75M` bytes ≈ `3.75 MB`. The block equilibrates around its target `DATA_GAS_LIMIT / DATA_LIMIT_TARGET_RATIO`. As pointed out in EIP-7706, separating data into its own resource serves to decrease its cost for our users.
 
-The limit is `60M/CALLDATA_GAS_LIMIT_RATIO = 15M` gas of calldata, corresponding to around `15M/16 = 938kB`. This is well below the limit under the current specification incorporating EIP‑7623, which is `60M/40 = 1.5MB` at 60M gas. Since calldata gas is also no longer accounted for as execution gas, the implied "aggregate" gas limit expands to `75M` gas, without materially affecting the maximum workload in terms of execution. In conclusion, the separation of calldata into its own resource increases calldata throughput while reducing costs. It furthermore facilitates scaling by allowing for faster payload propagation in the worst case and keeping all EVM gas available for other operations.
+The floor pricing specified in EIP-7623 is dropped, since metering data at the block level controls worst-case block sizes directly without varying the price with a transaction's execution usage. Since data gas is also no longer accounted for as execution gas, the implied "aggregate" gas limit expands without materially affecting the maximum workload in terms of execution. In conclusion, the separation of data into its own resource increases data throughput while reducing costs. It furthermore facilitates scaling by allowing for faster payload propagation in the worst case and keeping all EVM gas available for other operations.
 
 #### Censorship resistance
 
@@ -340,23 +383,29 @@ For censorship resistance (CR) purposes, under the currently proposed CR impleme
 
 When resources have separate limits, the block is treated as "full" already when any single conditional resource reaches its limit. Transactions that use that resource can then be excluded, even if they were surfaced by an IL. This makes it potentially cheaper to "stuff the block" to censor transactions. Specifically, a builder can create dummy transactions consuming a single resource to fill that dimension, ensuring that the block is treated as "full" when evaluating IL transactions. When resources have separate base fees, the builder may target a resource with a lower base fee, at a cost of roughly $b_i \cdot \Delta g_i$, where $\Delta g_i$ is the additional gas in resource $i$ required to reach its limit.
 
-The good news is that calldata has properties allowing the builder to extract MEV while at the same time unconditionally adhering to its gas limit under EIP-7805. This means that this EIP does not impede censorship resistance. Specifically, in the case where all ILs are filled with disjoint transactions, the aggregate size of included transactions can still be at most `8KiB*16 = 131kB`. This leaves at the very minimum `938kB - 131kB = 807kB` of calldata for the builder to use as it sees fit when extracting MEV, which is sufficient according to the usage patterns we know.
+The good news is that data has properties allowing the builder to extract MEV while at the same time unconditionally adhering to its gas limit under EIP-7805. This means that this EIP does not impede censorship resistance. Specifically, in the case where all ILs are filled with disjoint transactions, the aggregate size of included transactions can still be at most `8KiB*16 = 131kB`. This leaves at the very minimum `3.75MB - 131kB ≈ 3.62MB` of data for the builder to use as it sees fit when extracting MEV, which is sufficient according to the usage patterns we know.
 
-Accordingly, calldata is treated as an "unconditional" resource, as defined in the specification. An includer MUST therefore signal `INVALID_INCLUSION_LIST` if—and only if—a calldata‑using IL transaction is omitted despite sufficient capacity remaining in all conditional resources it uses. When considering expansion into further resources with tighter conditional limits, it may be necessary to adopt a version of FOCIL with ranked transactions (FOCILR).
+Accordingly, data is treated as an "unconditional" resource, as defined in the specification. An includer MUST therefore signal `INVALID_INCLUSION_LIST` if—and only if—a data‑using IL transaction is omitted despite sufficient capacity remaining in all conditional resources it uses. When considering expansion into further resources with tighter conditional limits, it may be necessary to adopt a version of FOCIL with ranked transactions (FOCILR).
 
 #### Reserve price
 
-An EIP-7918 reserve price is used for calldata just as for blobs. This ensures that the equilibrium price does not fall to levels where the fee market update mechanism stops working satisfactorily. Furthermore, the expiry window for blobs is much shorter than the planned rolling expiry window for calldata, making a modest relative reserve price motivated from a resource preservation perspective. Finally, without a reserve price on calldata, it could become cheaper than blob data (particularly below the blob reserve price), and thus a rational choice for L2s. 
+An EIP-7918 reserve price is used for data just as for blobs. This ensures that the equilibrium price does not fall to levels where the fee market update mechanism stops working satisfactorily. Furthermore, the expiry window for blobs is much shorter than the planned rolling expiry window for data, making a modest relative reserve price motivated from a resource preservation perspective. Finally, without a reserve price on data, it could become cheaper than blob data (particularly below the blob reserve price), and thus a rational choice for L2s. 
 
-The latter rationale also motivates the specific parameterization chosen. The EIP-7918 reserve price per byte for calldata is set 1/3 above the price per byte for blob data. This is achieved by tying the EIP-7918 if clause to the *blob base fee*. The gas per byte is 16 for calldata and 1 for blob data, and the price floor is triggered when `base_fees[1] > GAS_RESERVE_FACTOR[2] * base_fees[2]`. Given `GAS_RESERVE_FACTOR[2] = 12`, the EIP-7918 condition activates when the blob base fee is more than `12` times higher than the calldata base fee, at which point calldata costs less than `16/12 = 1+1/3` of the blob price per byte. The calldata base fee is then imposed to not fall further.
+The latter rationale also motivates the specific parameterization chosen. The EIP-7918 reserve price per byte for data is set 1/3 above the price per byte for blob data. This is achieved by tying the EIP-7918 if clause to the *blob base fee*. The gas per byte is 16 for data and 1 for blob data, and the price floor is triggered when `base_fees[1] > GAS_RESERVE_FACTOR[2] * base_fees[2]`. Given `GAS_RESERVE_FACTOR[2] = 12`, the EIP-7918 condition activates when the blob base fee is more than `12` times higher than the data base fee, at which point data costs less than `16/12 = 1+1/3` of the blob price per byte. The data base fee is then imposed to not fall further.
 
 #### Relationship to previous EIPs and other resources
 
 We acknowledge that calldata already has been limited by EIP-7623, with further repricings proposed in [EIP-7976](./eip-7976.md). These EIPs limit worst-case block sizes by metering and conditionally pricing calldata at the transaction level as opposed to at the block level, having the calldata price vary with a transaction's execution usage. This may lead to secondary markets if users wish to combine different transactions to take advantage of the "rebate" on calldata when consumed together with EVM gas. Treating calldata as a separate resource with a price based on block usage would allow for a more precise control over usage, and transactors would not need to interact with a secondary market to achieve the best price. 
 
-Given that the EIP-7623 design already achieves calldata moderation, it must be remembered that an individual fee market for calldata would merely be a first step toward a multidimensional fee market. Calldata is not an endgame. It is likely best to transition over several hard forks, and the options available at the present must then be considered, which leads to a focus on calldata. Another present consideration is block level access lists (BALs) and their interaction. 
+Given that the EIP-7623 design already achieves calldata moderation, it must be remembered that an individual fee market for calldata would merely be a first step toward a multidimensional fee market. Calldata is not an endgame. It is likely best to transition over several hard forks, and the options available at the present must then be considered, which leads to a focus on calldata. Another present consideration is block level access lists (BALs, [EIP-7928](./eip-7928.md)) and their interaction, now metered in the data dimension per EIP-8279. 
 
-A resource such as state is more attractive to separate than calldata. We could achieve exact control over state growth, while allowing temporary spikes many times above current gas limits. However, an expansion into other resources requires a multidimensional gas repricing, which has currently not yet been completed. The next section will further discuss remaining complexities of multidimensional EVM gas, and the strategies available for overcoming them.
+State is also separated into its own resource in this EIP, achieving exact control over state growth while allowing temporary spikes many times above current gas limits. State is metered with the EIP-8037 reservoir model but settled against its own base fee (see the section on the state resource). A further expansion into multiple separately priced EVM gas resources requires a multidimensional gas repricing, which has currently not yet been completed. The next section will further discuss remaining complexities of multidimensional EVM gas, and the strategies available for overcoming them.
+
+### The state resource
+
+State growth is added as a priced resource with its own base fee. The per-operation state-gas charges and state-byte metering are inherited unchanged from EIP-8037; only the base fee they settle against changes—state gas is no longer paid at the execution base fee, but at a dedicated state base fee that equilibrates around `STATE_GAS_TARGET`. This gives exact long-run control over state growth (`STATE_GAS_TARGET / CPSB` state bytes per block on average) while letting individual blocks spike well above the target when demand is high.
+
+State differs from the other resources in two ways. First, it has no per-block limit: there is only a target, so the dimension can absorb temporary spikes and is treated as a long-run rate control rather than a hard cap. Because `calc_excess_gas` cannot divide by a non-existent limit, the state dimension normalizes its excess-gas delta by `STATE_GAS_TARGET` instead. Second, state has no EIP-7918 anchor (`GAS_RESERVE_FACTOR[3] = 0`); there is no other resource it must remain more expensive than, so the reserve path never applies to it.
 
 ### Expansion paths for multiple EVM resources
 
@@ -391,7 +440,7 @@ else: # The joint EVM gas limit is expanded to cover all block resources
 
 #### Multidimensional gas metering
 
-An existing proposal by Inês Silva and Crapis is *Multidimensional gas metering* (not yet submitted as an EIP), which prices gas in one dimension, but applies limits at the block level across several dimensions when updating the (single) EVM base fee. The EVM will thus track multidimensional gas consumption, but perform the limit check on the aggregate, which is also passed on in subcalls. The proposed EIP could be combined with Multidimensional gas metering, for example by using a single EVM gas and calculating metered block gas usage separately, before submitting the outcome as a single resource dimension to the revamped `calc_excess_gas()`.
+An existing proposal is [EIP-8011](./eip-8011.md), which prices gas in one dimension, but applies limits at the block level across several dimensions when updating the (single) EVM base fee. The EVM will thus track multidimensional gas consumption, but perform the limit check on the aggregate, which is also passed on in subcalls. The proposed EIP could be combined with Multidimensional gas metering, for example by using a single EVM gas and calculating metered block gas usage separately, before submitting the outcome as a single resource dimension to the revamped `calc_excess_gas()`.
 
 #### Multidimensional fee market with aggregate EVM gas
 
@@ -459,9 +508,13 @@ The `max_fee_per_gas` of the EIP-1559 and EIP-4844 transaction types are convert
 
 Backward compatibility for contracts that rely on gas introspection can be resolved by giving users the ability to rely on aggregated EVM gas, while still potentially pricing EVM resources separately. Wallets must be updated to handle multidimensional gas accounting with several base fees.
 
+State-gas charges now settle at a dedicated state base fee rather than the execution base fee. The EIP-8037 metering—its per-operation state-gas charges and state-byte accounting—is reused unchanged, so contract behavior with respect to state usage is unaffected beyond the price the state gas settles against. There is no per-block state limit; the state dimension is a long-run rate control around `STATE_GAS_TARGET` rather than a hard cap, and individual blocks may exceed the target.
+
 ## Security Considerations
 
-One concern is the risk of increasing builder centralization due to increased revenue from sophisticated packing algorithms. While the builder is constrained in its block construction when blocks are full, it is only when several limits are reached at the same time that packing complexity markedly changes from today. Given that around 90% of blocks are below the gas limit, and the calldata limit is set to be very permissive, we argue that this will happen very rarely.
+One concern is the risk of increasing builder centralization due to increased revenue from sophisticated packing algorithms. While the builder is constrained in its block construction when blocks are full, it is only when several limits are reached at the same time that packing complexity markedly changes from today. Given that around 90% of blocks are below the gas limit, and the data limit is set to be very permissive, we argue that this will happen very rarely.
+
+BAL bytes are priced in the data dimension, which preserves the EIP-8279 worst-case block-size bound: every BAL byte is metered before insertion and charged at least `MIN_BASE_FEE_PER_GAS`, so the data dimension cannot be inflated for free. The EIP-7623 floor treatment of BAL bytes is removed, since block-level data metering already bounds worst-case sizes and the floor is no longer needed for this purpose.
 
 One reason for using `max_priority_fee_per_gas` instead of `max_priority_fee` is to establish the priority fee as always having a non-aggregate representation. We could possibly otherwise imagine a scenario where a user in the old transaction format manually submits an aggregate `max_fee` and `max_priority_fee`, causing loss of funds.
 


### PR DESCRIPTION
## Summary

Expands EIP-7999 from three resource dimensions to four, adding a **data** resource and a **state-growth** resource alongside execution and blob gas.

## Changes

- **Data resource** (replaces standalone calldata): priced from EIP-8131 content bytes (`DATA_GAS_PER_CONTENT_BYTE = 16`) and EIP-8279 BAL bytes; flat `DATA_GAS_LIMIT = 60M`; drops EIP-7623 floor pricing; renames `CALLDATABASEFEE` → `DATABASEFEE (0x4b)`.
- **State resource**: new separately-priced dimension reusing EIP-8037 metering with its own base fee; no per-block limit (target only), no EIP-7918 anchor; adds `STATEBASEFEE (0x4c)`.
- **Gas accounting**: extends gas vectors 3→4 dims; reworks `get_gas_limits`; adopts EIP-2780 intrinsic basis and EIP-7825 per-tx cap; data & state treated as unconditional under EIP-7805.
- **Header**: `requires` adds EIP-2780, 7623, 7702, 7706, 7825, 7928, 8037, 8131, 8279.

Several constants remain `TBD`.