### PR TITLE
Update EIP-2780: account for EIP-7623 calldata floor base

### DIFF
--- a/EIPS/eip-2780.md
+++ b/EIPS/eip-2780.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2020-07-11
-requires: 2718, 2929, 2930, 6780, 7523, 7702, 7708, 7904, 7928, 8037, 8038
+requires: 2718, 2929, 2930, 6780, 7523, 7623, 7702, 7708, 7904, 7928, 8037, 8038
 ---
 
 ## Abstract
@@ -107,6 +107,7 @@ Costs are split into regular gas and state gas, per [EIP-8037](./eip-8037.md). "
 
 - **[EIP-2929](./eip-2929.md) (warm/cold accounting).** The transaction-level `tx.sender`, `tx.to`, and delegation-target charges are always cold and are not reduced by an access list. The standard EIP-2929 warm/cold model still applies to execution-level account touches, including internal `CALL`s.
 - **[EIP-2930](./eip-2930.md) (access lists).** Access lists keep their existing per-entry charges and warming semantics for execution-level touches.
+- **[EIP-7623](./eip-7623.md) (calldata floor).** EIP-7623 floors a transaction's cost at `21,000 + TOTAL_COST_FLOOR_PER_TOKEN × tokens_in_calldata`, where the flat `21,000` is the intrinsic base this EIP decomposes. With this EIP active, that base term is replaced by the transaction's decomposed regular-gas intrinsic — the sum of the regular-gas primitives charged above (`TX_BASE_COST + COLD_ACCOUNT_ACCESS + TX_VALUE_COST + TRANSFER_LOG_COST` for value transfers, `TX_BASE_COST + CREATE_ACCESS` for contract creation) — so the floor and the floor's validity check rest on the same per-transaction base as the rest of intrinsic gas rather than a stale constant. The calldata schedule itself is unchanged; only the base the floor sits on moves. The new-account state-gas charge is metered in the separate `state_gas_reservoir` per [EIP-8037](./eip-8037.md) and does not enter the calldata floor.
 - **[EIP-7702](./eip-7702.md) (set EOA code).** `TX_BASE_COST` is unchanged even when the sender temporarily assumes code; clients must not perform a disk code load to classify the sender, since EIP-7702 provides the code inline. When `tx.to` is a delegated account, resolving the delegation loads the target's code, charged `COLD_ACCOUNT_ACCESS` on first touch or warm thereafter, following the standard EIP-2929 `accessed_addresses` model. Setting a delegation (writing the 23-byte pointer) is distinct from resolving one (reading the target's code); the resolution charge is genuine work and is not prepaid by the authorization.
 - **[EIP-7708](./eip-7708.md) (ETH transfers emit a log).** Every non-zero-value transfer to a different account emits a transfer log, priced explicitly as `TRANSFER_LOG_COST` rather than absorbed into the base.
 - **[EIP-7928](./eip-7928.md) (block-level access lists).** Intrinsic costs already account for accessing `tx.sender` and `tx.to`, so these accounts are included in the BAL even when the transaction reverts.


### PR DESCRIPTION
EIP-7623's calldata floor rests on the flat 21,000 that EIP-2780 decomposes. This adds 7623 to `requires` and an interactions bullet specifying the floor's base is now the decomposed regular-gas intrinsic (state-gas charge stays out).
