### PR TITLE
Update EIP-7928: Revert 7702 tracking

### DIFF
--- a/EIPS/eip-7928.md
+++ b/EIPS/eip-7928.md
@@ -164,13 +164,7 @@ Post-state costs (e.g., `GAS_NEW_ACCOUNT` for calls to empty accounts, `GAS_SELF
 
 #### EIP-7702 Delegation
 
-When a call target has an [EIP-7702](./eip-7702.md) delegation, the target is accessed to resolve the delegation. The delegated address is loaded, and MUST appear in the BAL, only if **all** of the following hold:
-
-- Sufficient gas remains to cover the delegated address's own `access_cost`.
-- For value-transferring `CALL` or `CALLCODE`, the sender's balance covers the value transfer (`sender_balance >= value`).
-- The call stack depth limit is not violated.
-
-If any of these checks fails, the delegated address is not loaded and MUST NOT appear in the BAL. The original call target is still included, having been accessed to resolve the delegation.
+When a call target has an [EIP-7702](./eip-7702.md) delegation, the target is accessed to resolve the delegation, which also accesses the delegated address. The delegated address requires its own `access_cost` check before being accessed; if that gas check fails, the delegated address MUST NOT appear in the BAL. Otherwise both the original call target and the delegated address MUST appear in the BAL, including when the call subsequently fails its sender-balance (`sender_balance >= value`) or call-stack-depth check, since the delegation is resolved before those checks.
 
 Note: Delegated accounts cannot be empty, so `GAS_NEW_ACCOUNT` never applies when resolving delegations.
 


### PR DESCRIPTION
Based on [discord discussions](https://discord.com/channels/595666850260713488/1517173399695261868), this reverts the eip back to "option 1":
doing the checks after warming; delegate read during resolution -> everything stays in.