### PR TITLE
Update EIP-7906: TXDIFF EIP-2929 gas pricing, remove duplicate paragraph

### DIFF
--- a/EIPS/eip-7906.md
+++ b/EIPS/eip-7906.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2025-02-21
-requires: 8141
+requires: 2929, 8141
 ---
 
 ## Abstract
@@ -31,7 +31,6 @@ By providing the Wallets and dApps with the ability to observe and restrict the 
 
 | Name                   | Value |
 |------------------------|-------|
-| TXDIFF_GAS_COST        | TBD   |
 | TXTRACE_GAS_COST       | TBD   |
 | EVENTDATACOPY_GAS_COST | TBD   |
 | `POST_TX`              | `3`   |
@@ -114,6 +113,15 @@ We introduce an additional `TXDIFF` opcode for this purpose, complementing `TXTR
 | 0x05    | address | must be 0        | `codehash_after`    |
 
 If the queried key `address`/`(address, slot)` was never modified during the transaction, `TXDIFF` returns the current live value for both the `before` and `after` variant of that param.
+
+#### Gas Cost
+
+`TXDIFF` uses the [EIP-2929](./eip-2929.md) access list to determine its cost:
+
+- Storage slot params (`0x00`, `0x01`): `COLD_SLOAD_COST` (2100) if the `(address, slot)` pair is not in the accessed storage list; `WARM_STORAGE_READ_COST` (100) otherwise.
+- Balance and codehash params (`0x02`–`0x05`): `COLD_ACCOUNT_ACCESS_COST` (2600) if the address is not in the accessed addresses set; `WARM_STORAGE_READ_COST` (100) otherwise.
+
+The accessed slot or address is added to the respective access list after the call.
 
 `codehash_before` is equal to the empty-code hash for undeployed contracts.
 
@@ -218,8 +226,6 @@ Events can use emission order because each event is a distinct, non-collapsed en
 `TXTRACE`, `EVENTDATACOPY`, and `TXDIFF` occupy previously unused opcode slots. No changes are made to existing opcodes, transaction types, or precompiles, so existing contracts and tooling are unaffected.
 
 This proposal has a hard dependency on [EIP-8141](./eip-8141.md) (`requires: 8141`): `TXTRACE`, `EVENTDATACOPY`, and `TXDIFF` can only execute inside an EIP-8141 `POST_TX` frame, as defined under [The `POST_TX` Frame Mode](#the-post_tx-frame-mode). Legacy transactions, [EIP-1559](./eip-1559.md) transactions, and any other EIP-8141 frame mode cannot use any of these opcodes.
-
-This proposal has a hard dependency on [EIP-8141](./eip-8141.md) (`requires: 8141`): `TXTRACE` and `EVENTDATACOPY` can only execute inside an EIP-8141 `POST_TX` frame, as defined under [The `POST_TX` Frame Mode](#the-post_tx-frame-mode). Legacy transactions, [EIP-1559](./eip-1559.md) transactions, and any other EIP-8141 frame mode cannot use either opcode.
 
 ## Security Considerations
 


### PR DESCRIPTION
## Summary

- Specifies `TXDIFF` gas cost using [EIP-2929](./eip-2929.md) access list rules: `COLD_SLOAD_COST`/`WARM_STORAGE_READ_COST` for storage slot params, `COLD_ACCOUNT_ACCESS_COST`/`WARM_STORAGE_READ_COST` for balance and codehash params.
- Removes the flat `TXDIFF_GAS_COST` TBD constant (replaced by the warm/cold access rule).
- Adds EIP-2929 as a normative dependency in the `requires:` frontmatter and links it properly in the spec text.
- Removes a duplicate paragraph in the Backwards Compatibility section (older version missing `TXDIFF`).

## Test plan

- [ ] Verify EIP linter passes (requires field, link format)
- [ ] Confirm gas cost section is consistent with EIP-2929 definitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)