### PR TITLE
Update EIP-8311: clarify scope of TOTAL_COST_FLOOR_PER_TOKEN change

### DIFF
--- a/EIPS/eip-8311.md
+++ b/EIPS/eip-8311.md
@@ -39,6 +39,8 @@ Upon activation, the floor cost for calldata is increased to 96/96 gas per byte.
 
 Recall that `floor_tokens_in_calldata = (zero_bytes_in_calldata + nonzero_bytes_in_calldata) * 4`. The floor cost is `96` gas per calldata byte (both zero and non-zero), since `TOTAL_COST_FLOOR_PER_TOKEN * 4 = 96`. The token abstraction is retained only for consistency with [EIP-7623](./eip-7623.md) and [EIP-7976](./eip-7976.md).
 
+Only `TOTAL_COST_FLOOR_PER_TOKEN` changes, from 16 to 24; the EIP-7976 `gasUsed` formula and transaction-validity rule are otherwise unchanged.
+
 ## Rationale
 
 ### Deriving the anchor density


### PR DESCRIPTION
Adds a clarifying sentence to EIP-8311 (Increase Calldata Floor Cost to 96)
noting that only `TOTAL_COST_FLOOR_PER_TOKEN` changes (from 16 to 24), while
the EIP-7976 `gasUsed` formula and the transaction-validity rule are otherwise
unchanged.

This is an editorial clarification only — no change to the specified behavior.