### PR TITLE
Update EIP-7997: remove specification of nonce

### DIFF
--- a/EIPS/eip-7997.md
+++ b/EIPS/eip-7997.md
@@ -34,13 +34,13 @@ Keyless transactions have been the most successful approach. However, since such
 
 * `FACTORY_ADDRESS` = `0x4e59b44847b379578588920cA78FbF26c0B4956C`
 
-The chain's state MUST include `FACTORY_ADDRESS` with nonce 1 and this runtime code:
+The chain's state MUST include `FACTORY_ADDRESS` with this runtime code:
 
 ```
 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf3
 ```
 
-A chain may satisfy this requirement by any means that results in the account above: deploying the factory with an ordinary transaction (for example, its keyless creation transaction) where the chain's gas parameters permit it, including the account in the genesis state, or inserting it via an irregular state transition. Regardless of the method used, the resulting `FACTORY_ADDRESS` account MUST have the nonce and runtime code specified above.
+A chain may satisfy this requirement by any means that results in the account above: deploying the factory with an ordinary transaction (for example, its keyless creation transaction) where the chain's gas parameters permit it, including the account in the genesis state, or inserting it via an irregular state transition. Regardless of the method used, the resulting `FACTORY_ADDRESS` account MUST have the runtime code specified above. If deployed using an irregular state transition, the nonce SHOULD be set to 1.
 
 This is a contract that invokes the `CREATE2` instruction ([EIP-1014](./eip-1014.md)) with a salt equal to the first 32 bytes of the call's input data, init code equal to the remaining data, and value equal to the call's value. If input data is smaller than 32 bytes, the contract will attempt to copy close to 2^256 bytes of calldata and should revert as a result. If contract creation fails (`CREATE2` outputs `0`), the call reverts with empty return data. When successful, the address is returned in exactly 20 bytes of data with no padding.
 


### PR DESCRIPTION
Since the factory contract's nonce will increase on every use, it is silly to specify that it MUST exist with nonce 1.
