### PR TITLE
Update EIP-8130: Clarify actor policies and simplify metadata field

### DIFF
--- a/EIPS/eip-8130.md
+++ b/EIPS/eip-8130.md
@@ -13,7 +13,7 @@ requires: 170, 2718
 
 ## Abstract
 
-This proposal introduces a new [EIP-2718](./eip-2718.md) transaction type and an onchain Account Configuration system that together provide account abstraction — custom authentication, call batching, and gas sponsorship. Accounts register actors with onchain authenticator contracts. Transactions declare which authenticator to use, enabling nodes to filter transactions without executing arbitrary wallet code. No EVM changes are required. The contract infrastructure is designed to be shared across chains as a common base layer for account management.
+This proposal introduces a new [EIP-2718](./eip-2718.md) transaction type and an onchain Account Configuration system that together provide account abstraction: custom authentication, call batching, and gas sponsorship. Accounts register actors with onchain authenticator contracts. Transactions declare which authenticator to use, enabling nodes to filter transactions without executing arbitrary wallet code. No EVM changes are required. The contract infrastructure is designed to be shared across chains as a common base layer for account management.
 
 ## Motivation
 
@@ -33,10 +33,10 @@ A new [EIP-2718](./eip-2718.md) transaction type (`AA_TX_TYPE`) names the authen
 
 The specification is organized around four pieces:
 
-- **Actors and Authenticators** — the authentication and authorization model(see [Authenticators](#authenticators)).
-- **Account Configuration** — onchain management of account and it's actors (see [Account Configuration](#account-configuration)).
-- **AA Transaction Type** — the wire format, signature payloads, and gas accounting (see [AA Transaction Type](#aa-transaction-type)).
-- **Account Changes** — how accounts are created and how actors are added, revoked, or delegated (see [Account Changes](#account-changes)).
+- **Actors and Authenticators**: the authentication and authorization model (see [Authenticators](#authenticators)).
+- **Account Configuration**: onchain management of account and it's actors (see [Account Configuration](#account-configuration)).
+- **AA Transaction Type**: the wire format, signature payloads, and gas accounting (see [AA Transaction Type](#aa-transaction-type)).
+- **Account Changes**: how accounts are created and how actors are added, revoked, or delegated (see [Account Changes](#account-changes)).
 
 Note that the accounts are portable to any EVM and the system is able to work on all chains. If a chain does not support 8130, an alternative AA mechanism such as ERC-4337 can be used with the same account, provided the account code allows support. 
 
@@ -54,13 +54,13 @@ This proposal supports three paths for accounts to use AA transactions:
 
 Each actor is associated with an authenticator, a contract that performs signature authentication. In the protocol's terms, the authenticator *authenticates* the actor (it returns the actor's `actorId`); scope and policy then *authorize* what that authenticated actor may do. The authenticator address is stored in `actor_config` (see [Account Configuration](#account-configuration)). All authenticators implement `IAuthenticator.authenticate(hash, data)`. After the authenticator authenticates the signature, the protocol validates the returned `actorId` against `actor_config` and authorizes the actor by checking its scope against the authorization context; the policy gate (`policyType != 0x00`) is enforced later, during execution.
 
-Authenticators are executed via STATICCALL. Authenticator addresses MUST NOT be delegated accounts — reject if the code at the authenticator address starts with the delegation indicator (`0xef0100`).
+Authenticators are executed via STATICCALL. Authenticator addresses MUST NOT be delegated accounts; reject if the code at the authenticator address starts with the delegation indicator (`0xef0100`).
 
 Chains choose how authenticator execution is priced. A chain MAY meter authenticator execution as ordinary EVM execution (see [Mempool Acceptance](#mempool-acceptance) for rules), or it MAY enshrine canonical authenticators and charge a fixed, standard gas cost per enshrined authenticator instead of metering. When an authenticator is enshrined, its execution MUST produce identical results to the corresponding authenticator contract.
 
 `K1_AUTHENTICATOR` (`address(1)`) is a protocol-reserved address for native secp256k1 authentication. When the protocol encounters this address as an authenticator in auth data, it performs ecrecover directly rather than making a STATICCALL. The `data` portion is interpreted as raw ECDSA `(r || s || v)`, and the returned `actorId` is `bytes32(bytes20(recovered_address))`. The same identity serves both the implicit default EOA and any explicitly registered k1 actor; the `actor_config` slot alone distinguishes a full-owner EOA from a scoped key, so actors can be explicitly registered with `K1_AUTHENTICATOR` to use native ecrecover with a custom scope, without requiring a deployed authenticator contract. `address(0)` is considered empty.
 
-Any contract implementing `IAuthenticator` can be permissionlessly deployed and registered as an actor's authenticator. However, registration does not make an authenticator usable on the 8130 path: only canonical authenticators in the node allowlist are accepted for block-level AA authentication (see [Canonical Authenticator Set](#canonical-authenticator-set)). Non-canonical authenticators remain fully usable within EVM execution — for example, an account can authenticate an actor against an arbitrary `IAuthenticator` via a config change call, enabling use cases such as wallet-defined recovery methods. Such actors simply cannot authenticate transactions directly over the 8130 path and they operate through ordinary EVM execution.
+Any contract implementing `IAuthenticator` can be permissionlessly deployed and registered as an actor's authenticator. However, registration does not make an authenticator usable on the 8130 path: only canonical authenticators in the node allowlist are accepted for block-level AA authentication (see [Canonical Authenticator Set](#canonical-authenticator-set)). Non-canonical authenticators remain fully usable within EVM execution; for example, an account can authenticate an actor against an arbitrary `IAuthenticator` via a config change call, enabling use cases such as wallet-defined recovery methods. Such actors simply cannot authenticate transactions directly over the 8130 path and they operate through ordinary EVM execution.
 
 #### Canonical Authenticator Set
 
@@ -71,7 +71,7 @@ This specification defines a canonical authenticator set which is the set of sig
 | k1 | secp256k1 | `K1_AUTHENTICATOR` (native sentinel) | `bytes32(bytes20(recovered_address))` |
 | p256 | P-256 | Onchain contract | `keccak256(abi.encodePacked(x, y))` |
 | passkey | WebAuthn / FIDO2 | Onchain contract | `keccak256(abi.encodePacked(x, y))` |
-| delegate | Signature delegation | Onchain contract | `bytes32(bytes20(delegated_address))` — signatures from `delegated_address` are valid for the registering account (see [Delegate Authenticator](#delegate-authenticator)) |
+| delegate | Signature delegation | Onchain contract | `bytes32(bytes20(delegated_address))`: signatures from `delegated_address` are valid for the registering account (see [Delegate Authenticator](#delegate-authenticator)) |
 
 The canonical authenticator set and corresponding contract addresses are maintained in a companion ERC (number TBD) and deployed at deterministic CREATE2 addresses across chains. The canonical set is expected to grow as new algorithms are adopted (e.g., post-quantum) through the companion ERC process.
 
@@ -87,7 +87,7 @@ The delegate authenticator lets one account act on behalf of another. An account
 
 ```
 data = delegated_account (20 bytes)   // B
-    || nested_auth                     // authenticator (20 bytes) || data — a normal auth blob for B
+    || nested_auth                     // authenticator (20 bytes) || data, a normal auth blob for B
 ```
 
 **Constraints**:
@@ -104,7 +104,7 @@ Actors are identified by their `actorId`, a 32-byte identifier derived by the au
 
 #### Storage Layout
 
-Each actor occupies a single `actor_config` slot containing the authenticator address, scope byte, policy type, and an optional expiry. When `policyType != 0x00`, the actor also carries a signed policy commitment and a manager address in the separate policy slots `policy_commitment`/`policy_manager` (see [Actor Policies](#actor-policies)). Actors are revoked by deleting the `actor_config` slot. The self-actor (`actorId == bytes32(bytes20(account))`) is the one exception: its native secp256k1 config is held **inline in the packed account-state slot** — the default-EOA `scope`/`policyType`/`expiry` fields plus the `DEFAULT_EOA_REVOKED` bit (see [Account Lock](#account-lock)) — so the account's own key resolves in a single SLOAD, including the scoped-self case. Its `actor_config` slot is instead reserved for a *non-secp256k1* self authenticator (e.g. a authenticator that returns the self-actorId); the inline secp256k1 self and a non-k1 self are mutually exclusive (registering one clears the other). Revoking the self-actor writes the account-state slot and leaves the `actor_config` slot empty and reusable.
+Each actor occupies a single `actor_config` slot containing the authenticator address, scope byte, policy type, and an optional expiry. When `policyType != 0x00`, the actor also carries a signed policy commitment and a manager address in the separate policy slots `policy_commitment`/`policy_manager` (see [Actor Policies](#actor-policies)). Actors are revoked by deleting the `actor_config` slot. The self-actor (`actorId == bytes32(bytes20(account))`) is the one exception: its native secp256k1 config is held **inline in the packed account-state slot**, the default-EOA `scope`/`policyType`/`expiry` fields plus the `DEFAULT_EOA_REVOKED` bit (see [Account Lock](#account-lock)), so the account's own key resolves in a single SLOAD, including the scoped-self case. Its `actor_config` slot is instead reserved for a *non-secp256k1* self authenticator (e.g. a authenticator that returns the self-actorId); the inline secp256k1 self and a non-k1 self are mutually exclusive (registering one clears the other). Revoking the self-actor writes the account-state slot and leaves the `actor_config` slot empty and reusable.
 
 | Field | Bytes | Description |
 |-------|-------|-------------|
@@ -135,12 +135,12 @@ The scope byte in `actor_config` is a permission bitmask that restricts which au
 |-----|-------|------|---------|
 | 0 | `0x01` | SIGNATURE | ERC-1271 via `verifySignature()` |
 | 1 | `0x02` | SENDER | `sender_auth` validation, can originate transactions |
-| 2 | `0x04` | PAYER | Gas payment — `payer_auth` validation (sponsored) and the sender's own gas (self-pay) |
+| 2 | `0x04` | PAYER | Gas payment: `payer_auth` validation (sponsored) and the sender's own gas (self-pay) |
 | 3 | `0x08` | CONFIG | Config change `auth` |
 
-Scope authorization is applied only after an authenticator authenticates the signature and returns an `actorId`: the protocol loads that actor's `scope` and checks it against the context being authorized — `sender_auth` (SENDER), gas payment by either the sender or a sponsor (PAYER), `verifySignature()` (SIGNATURE), or config change `auth` (CONFIG). The actor is authorized for that context when it is unrestricted (`scope == 0x00`) or the context's bit is set (`(scope & context_bit) != 0`); otherwise the actor is not authorized and the request is rejected.
+Scope authorization is applied only after an authenticator authenticates the signature and returns an `actorId`: the protocol loads that actor's `scope` and checks it against the context being authorized: `sender_auth` (SENDER), gas payment by either the sender or a sponsor (PAYER), `verifySignature()` (SIGNATURE), or config change `auth` (CONFIG). The actor is authorized for that context when it is unrestricted (`scope == 0x00`) or the context's bit is set (`(scope & context_bit) != 0`); otherwise the actor is not authorized and the request is rejected.
 
-The protocol validates signatures by reading `actor_config` directly and delegating authentication to [Authenticators](#authenticators) — see [Validation](#validation) for the full flow. Actor enumeration is performed off-chain via `ActorAuthorized` and `ActorRevoked` event logs. 
+The protocol validates signatures by reading `actor_config` directly and delegating authentication to [Authenticators](#authenticators); see [Validation](#validation) for the full flow. Actor enumeration is performed off-chain via `ActorAuthorized` and `ActorRevoked` event logs. 
 
 #### Actor Policies
 
@@ -157,7 +157,7 @@ A policy-bearing actor (typically a session key) may call exactly one target: it
 
 A key that should be enforced by the account's own code rather than a separate contract sets `manager = account`. 
 
-**Scope.** The policy gate constrains only SENDER-context calls, so a policy-bearing actor MUST be authorized with a restricted `scope` that is neither unrestricted (`0x00`) nor includes CONFIG (`0x08`): a CONFIG-scoped key could authorize new, unrestricted actors and escape its policy entirely. PAYER and SIGNATURE scopes are permitted but are not policy-constrained — a policy-bearing actor with PAYER scope can sponsor gas up to the transaction's limits, and with SIGNATURE scope can produce ERC-1271 signatures the policy never sees, so wallets SHOULD grant a restricted key only the scopes it needs, typically SENDER alone.
+**Scope.** The policy gate constrains only SENDER-context calls, so a policy-bearing actor MUST be authorized with a restricted `scope` that is neither unrestricted (`0x00`) nor includes CONFIG (`0x08`): a CONFIG-scoped key could authorize new, unrestricted actors and escape its policy entirely. PAYER and SIGNATURE scopes are permitted but are not policy-constrained: a policy-bearing actor with PAYER scope can sponsor gas up to the transaction's limits, and with SIGNATURE scope can produce ERC-1271 signatures the policy never sees, so wallets SHOULD grant a restricted key only the scopes it needs, typically SENDER alone.
 
 **Reference flow** (non-normative). One construction of a session-key policy:
 
@@ -212,7 +212,7 @@ Account lock state is stored in a single packed 32-byte account-state slot that 
 |-------|-------------|
 | `multichain_sequence` | Change-sequence counter for `chain_id 0` (`uint64`) |
 | `local_sequence` | Change-sequence counter for the local chain (`uint64`); `> 0` doubles as the initialized flag |
-| `locked` | Actor configuration is frozen — config changes rejected |
+| `locked` | Actor configuration is frozen; config changes rejected |
 | `unlock_delay` | Seconds required between initiating unlock and becoming unlocked (`uint16`) |
 | `unlocks_at` | Timestamp when unlock takes effect (`uint40`, 0 = no unlock initiated) |
 | `flags` | Account flags byte; bit 0 (`DEFAULT_EOA_REVOKED`) disables the secp256k1 self-actor |
@@ -222,7 +222,7 @@ Account lock state is stored in a single packed 32-byte account-state slot that 
 
 The packed slot is exactly 32 bytes, so the inline self-actor config costs no extra SLOAD/SSTORE beyond the account-state access already performed for the change-sequence and lock fields.
 
-When `locked` is set, all config changes are rejected — both config change entries in `account_changes` and `applySignedActorChanges()` via EVM. The lock cannot be removed without a timelock delay.
+When `locked` is set, all config changes are rejected: both config change entries in `account_changes` and `applySignedActorChanges()` via EVM. The lock cannot be removed without a timelock delay.
 
 Lock operations are called directly by the account (`msg.sender`) on the Account Configuration Contract.
 
@@ -230,13 +230,13 @@ Lock operations are called directly by the account (`msg.sender`) on the Account
 
 1. **Lock**: Call `lock(unlockDelay)`. Sets `locked = true` with the specified `unlockDelay` (seconds).
 2. **Initiate unlock**: Call `initiateUnlock()`. Sets `unlocks_at = block.timestamp + unlock_delay`.
-3. **Effective unlock**: Once `block.timestamp >= unlocks_at`, the account is effectively unlocked — config changes are permitted.
+3. **Effective unlock**: Once `block.timestamp >= unlocks_at`, the account is effectively unlocked; config changes are permitted.
 
 #### Account Import
 
 `importAccount(address account, InitialActor[] calldata initialActors, bytes calldata signature)` is a one-time call that registers an already-deployed account into the Account Configuration Contract with an initial actor set. The call is rejected when:
 
-- The account already has 8130 state — **either** change-sequence channel is non-zero. Import is a one-time bootstrap, so it requires both the local and multichain channels empty.
+- The account already has 8130 state: **either** change-sequence channel is non-zero. Import is a one-time bootstrap, so it requires both the local and multichain channels empty.
 - The account is locked. Locking is keyed on `msg.sender` and does not require initialization, so a locked account is not necessarily initialized; this check is independent (see [Account Lock](#account-lock)).
 
 The `signature` is validated against the account via [ERC-1271](./eip-1271.md) `isValidSignature(digest, signature)`, binding the initial actor set to the account's existing authorization logic. `digest` is a typed `ActorInitialization` struct hash:
@@ -307,25 +307,25 @@ call = rlp([to, data])   // to: address, data: bytes
 | Field | Description |
 |-------|-------------|
 | `chain_id` | Chain ID per [EIP-155](./eip-155.md) |
-| `sender` | Sending account address. **Required** (non-empty) for configured actor signatures. **Empty** for EOA signatures—address recovered via ecrecover. The presence or absence of `sender` is the sole distinguisher between EOA and configured actor signatures. |
+| `sender` | Sending account address. **Required** (non-empty) for configured actor signatures. **Empty** for EOA signatures; address recovered via ecrecover. The presence or absence of `sender` is the sole distinguisher between EOA and configured actor signatures. |
 | `nonce_key` | `uint256` nonce channel selector. `0` for standard sequential ordering, `1` through `NONCE_KEY_MAX - 1` for parallel channels, `NONCE_KEY_MAX` for nonce-free mode. |
 | `nonce_sequence` | `uint64` expected sequence number within `nonce_key`. Must match current sequence for `(sender, nonce_key)`. Incremented after inclusion regardless of execution outcome. Must be `0` when `nonce_key == NONCE_KEY_MAX`. |
 | `expiry` | Unix timestamp (seconds since epoch). Transaction invalid when `block.timestamp > expiry`. A value of `0` means no expiry. Must be non-zero when `nonce_key == NONCE_KEY_MAX`. |
 | `max_priority_fee_per_gas` | Priority fee per gas unit ([EIP-1559](./eip-1559.md)) |
 | `max_fee_per_gas` | Maximum fee per gas unit ([EIP-1559](./eip-1559.md)) |
 | `gas_limit` | Maximum gas budget for sender-intrinsic gas (intrinsic gas excluding payer authentication) and call execution (see [Intrinsic Gas](#intrinsic-gas)). Payer authentication is metered separately and does not draw from `gas_limit` |
-| `account_changes` | **Empty**: No account changes. **Non-empty**: Array of typed entries — create (type `0x00`) for account deployment, config change (type `0x01`) for actor management, and delegation (type `0x02`) for code delegation. See [Account Changes](#account-changes) |
-| `calls` | **Empty**: No calls. **Non-empty**: Array of call phases — see [Call Execution](#call-execution) |
+| `account_changes` | **Empty**: No account changes. **Non-empty**: Array of typed entries: create (type `0x00`) for account deployment, config change (type `0x01`) for actor management, and delegation (type `0x02`) for code delegation. See [Account Changes](#account-changes) |
+| `calls` | **Empty**: No calls. **Non-empty**: Array of call phases; see [Call Execution](#call-execution) |
 | `metadata` | **Empty**: No metadata. **Non-empty**: Opaque bytes carrying attribution or annotation data. The protocol does not interpret or execute it. See [Transaction Metadata](#transaction-metadata) |
 | `payer` | Gas payer identity. **Empty**: Sender pays. **20-byte address**: This specific payer required. See [Payer Modes](#payer-modes) |
 | `sender_auth` | See [Signature Format](#signature-format) |
-| `payer_auth` | Payer authorization. **Empty**: self-pay. **Non-empty**: `authenticator || data` — same format as `sender_auth`. See [Payer Modes](#payer-modes) |
+| `payer_auth` | Payer authorization. **Empty**: self-pay. **Non-empty**: `authenticator || data`, same format as `sender_auth`. See [Payer Modes](#payer-modes) |
 
 #### Intrinsic Gas
 
 **Intrinsic gas** follows the standard Ethereum meaning: the total cost to include the transaction. As in standard transactions it accounts for signature authentication, here both the sender's authentication (`sender_auth_cost`) and the payer's (`payer_auth_cost`) are included.
 
-The specific per-component gas *values* in this section are a **recommended schedule** that reflects the EVM access and data-availability costs ([EIP-2929](./eip-2929.md) / [EIP-2028](./eip-2028.md)) at the time of writing. They are a reference, not protocol constants: just as a chain may choose how it prices authenticator execution (see [Authenticators](#authenticators)), a chain MAY adopt a different intrinsic-gas schedule — for example to track a future EVM repricing or a local cost model. The formula's structure (its components and what each one accounts for) is the normative part; the absolute numbers below are the recommended values for a chain that mirrors current EVM costs.
+The specific per-component gas *values* in this section are a **recommended schedule** that reflects the EVM access and data-availability costs ([EIP-2929](./eip-2929.md) / [EIP-2028](./eip-2028.md)) at the time of writing. They are a reference, not protocol constants: just as a chain may choose how it prices authenticator execution (see [Authenticators](#authenticators)), a chain MAY adopt a different intrinsic-gas schedule, for example to track a future EVM repricing or a local cost model. The formula's structure (its components and what each one accounts for) is the normative part; the absolute numbers below are the recommended values for a chain that mirrors current EVM costs.
 
 ```
 intrinsic_gas = AA_BASE_COST + tx_payload_cost + nonce_key_cost + bytecode_cost + account_changes_cost + auto_delegation_cost + sender_auth_cost + payer_auth_cost
@@ -372,20 +372,20 @@ Signature format is determined by the `sender` field:
 authenticator (20 bytes) || data
 ```
 
-The first 20 bytes identify the authenticator address. When the authenticator is `K1_AUTHENTICATOR`, `data` is raw ECDSA `(r || s || v)` and the protocol handles ecrecover natively. For all other authenticators, `data` is authenticator-specific — each authenticator defines its own wire format.
+The first 20 bytes identify the authenticator address. When the authenticator is `K1_AUTHENTICATOR`, `data` is raw ECDSA `(r || s || v)` and the protocol handles ecrecover natively. For all other authenticators, `data` is authenticator-specific; each authenticator defines its own wire format.
 
 ##### Validation
 
 1. **Resolve sender**: If `sender` empty, ecrecover derives the sender address (EOA path) with `actorId = bytes32(bytes20(sender))`. If `sender` set, read the first 20 bytes of `sender_auth` as the authenticator address.
 2. **Authenticate**: Route by authenticator address. For the EOA path (`sender` empty), ecrecover was already performed in step 1. For `K1_AUTHENTICATOR` (`address(1)`), the protocol natively ecrecovers from `data` (as `r || s || v`), returning `actorId = bytes32(bytes20(recovered_address))`. For all other authenticators, call `authenticator.authenticate(hash, data)` via STATICCALL, returning `actorId` (or `bytes32(0)` for invalid). `address(0)` is never a valid authenticator selector (it is the empty `actor_config` sentinel).
-3. **Authorize**: **Self-actor (native secp256k1) rule**: if authentication in step 2 used the native secp256k1 path (the EOA path or `K1_AUTHENTICATOR`) and `actorId == bytes32(bytes20(sender))`, resolve the self-actor from the inline default-EOA config in the packed account-state slot — reject if `DEFAULT_EOA_REVOKED` is set; otherwise take `scope`, `policyType`, and `expiry` from the inline fields (all-zero = unrestricted, non-expiring full owner). Otherwise SLOAD `actor_config(sender, actorId)` and require that the stored authenticator address matches the effective authenticator (this covers every other actor, including a non-secp256k1 self). In either case, if the resolved `expiry` is non-zero, also require `block.timestamp <= expiry`; an expired actor is rejected.
+3. **Authorize**: **Self-actor (native secp256k1) rule**: if authentication in step 2 used the native secp256k1 path (the EOA path or `K1_AUTHENTICATOR`) and `actorId == bytes32(bytes20(sender))`, resolve the self-actor from the inline default-EOA config in the packed account-state slot: reject if `DEFAULT_EOA_REVOKED` is set; otherwise take `scope`, `policyType`, and `expiry` from the inline fields (all-zero = unrestricted, non-expiring full owner). Otherwise SLOAD `actor_config(sender, actorId)` and require that the stored authenticator address matches the effective authenticator (this covers every other actor, including a non-secp256k1 self). In either case, if the resolved `expiry` is non-zero, also require `block.timestamp <= expiry`; an expired actor is rejected.
 4. **Check scope**: Read the resolved `scope` byte (from the inline default-EOA config for the secp256k1 self-actor, or `actor_config` otherwise). Determine the context bit: `0x02` (SENDER) for `sender_auth`, `0x04` (PAYER) for `payer_auth`, `0x01` (SIGNATURE) for `verifySignature()`, `0x08` (CONFIG) for config change `auth`. Require `scope == 0x00 || (scope & context_bit) != 0`. In self-pay (no `payer_auth`), the sender's own actor is the gas payer, so additionally require PAYER scope on the resolved sender actor (`scope == 0x00 || (scope & 0x04) != 0`).
 
 #### Signature Payload
 
 Sender and payer use different type bytes for domain separation, preventing signature reuse attacks:
 
-**Sender signature hash** — all tx fields through `payer`, excluding `sender_auth` and `payer_auth`:
+**Sender signature hash**, all tx fields through `payer`, excluding `sender_auth` and `payer_auth`:
 
 ```
 keccak256(AA_TX_TYPE || rlp([
@@ -396,7 +396,7 @@ keccak256(AA_TX_TYPE || rlp([
 ]))
 ```
 
-**Payer signature hash** — all tx fields through `payer`, excluding `sender_auth` and `payer_auth`:
+**Payer signature hash**, all tx fields through `payer`, excluding `sender_auth` and `payer_auth`:
 
 ```
 keccak256(AA_PAYER_TYPE || rlp([
@@ -413,19 +413,19 @@ The `sender` field in the payer signature hash MUST be the resolved sender addre
 
 Gas payment and sponsorship are controlled by two independent fields:
 
-**`payer`** — the sender's commitment regarding the gas payer, included in the sender's signed hash:
+**`payer`**, the sender's commitment regarding the gas payer, included in the sender's signed hash:
 
 | Value | Mode | Description |
 |-------|------|-------------|
 | empty | Self-pay | Sender pays their own gas |
 | `payer_address` (20 bytes) | Sponsored | Sender binds tx to a specific sponsor |
 
-**`payer_auth`** — uses the same `authenticator || data` format as `sender_auth`:
+**`payer_auth`** uses the same `authenticator || data` format as `sender_auth`:
 
 | `payer` | `payer_auth` | Payer Address | Validation |
 |---------|-------------|---------------|------------|
-| empty | empty | `sender` | Self-pay — no separate `payer_auth`; the resolved sender actor MUST have PAYER scope |
-| address | `authenticator (20) \|\| data` | `payer` field | Sponsored — any authenticator. Reads payer's `actor_config`, validates against `payer` address, and requires PAYER scope |
+| empty | empty | `sender` | Self-pay: no separate `payer_auth`; the resolved sender actor MUST have PAYER scope |
+| address | `authenticator (20) \|\| data` | `payer` field | Sponsored: any authenticator. Reads payer's `actor_config`, validates against `payer` address, and requires PAYER scope |
 
 
 ### Transaction Metadata
@@ -554,7 +554,7 @@ actorChangesHash = keccak256(abi.encodePacked(actorChangeHashes))
 digest = keccak256(abi.encode(TYPEHASH, account, chainId, sequence, actorChangesHash))
 ```
 
-Domain separation from transaction signatures (`AA_TX_TYPE`, `AA_PAYER_TYPE`) is structural — transaction hashes use `keccak256(type_byte || rlp([...]))`, which cannot produce the same prefix as `abi.encode(TYPEHASH, ...)`.
+Domain separation from transaction signatures (`AA_TX_TYPE`, `AA_PAYER_TYPE`) is structural; transaction hashes use `keccak256(type_byte || rlp([...]))`, which cannot produce the same prefix as `abi.encode(TYPEHASH, ...)`.
 
 The `auth` follows the same [Signature Format](#signature-format) as `sender_auth` (`authenticator || data`), validated against the account's actor state at that point in the sequence.
 
@@ -562,8 +562,8 @@ The `auth` follows the same [Signature Format](#signature-format) as `sender_aut
 
 The same signed actor change can be applied through two paths:
 
-- **`account_changes` (tx field)** — processed by the protocol before code deployment on 8130 chains.
-- **`applySignedActorChanges()` (EVM)** — applied during EVM execution on any chain, including non-8130 chains and ERC-4337 deployments.
+- **`account_changes` (tx field)**: processed by the protocol before code deployment on 8130 chains.
+- **`applySignedActorChanges()` (EVM)**: applied during EVM execution on any chain, including non-8130 chains and ERC-4337 deployments.
 
 Both paths carry the same signed actor changes, share the same `change_sequence` counters, and are equally portable (`chain_id 0` for cross-chain or a specific `chain_id` for chain-local). They differ only in transport: the protocol consumes the signed change directly on 8130 chains, while everywhere else the EVM function does. `applySignedActorChanges()` parses the authenticator address from `auth`, calls the authenticator to get the `actorId`, and checks `actor_config`. `authorizeActor` writes `actor_config` and, for policy-bearing actors (`policyType != 0x00`), the `policy_commitment` and `policy_manager` slots; `revokeActor` clears them all. Anyone can call these functions; authorization comes from the signed operation, not the caller. All actor modification paths are blocked when the account is locked (see [Account Lock](#account-lock)).
 
@@ -595,7 +595,7 @@ For 8130 transactions, successful delegation updates emit a protocol-injected `D
 
 `account_changes` entries are processed in order before call execution:
 
-1. **Create entry** (if present): Register `initial_actors` in Account Config storage for `sender` — for each `[actorId, authenticator]` tuple, write `actor_config` as an unrestricted owner (the `authenticator` address with `scope = 0x00`, `expiry = 0`, `policyType = 0x00`; no policy slots). Mark the account initialized by setting its local change-sequence channel to `1` (see [Config Change Authorization](#config-change-authorization)). Initialize lock state to safe defaults: `locked = false`, `unlock_delay = 0`, `unlocks_at = 0`. Set the `DEFAULT_EOA_REVOKED` flag so a freshly created account does not leave a native secp256k1 owner live unless one is among `initial_actors`. Place `code` at `sender`.
+1. **Create entry** (if present): Register `initial_actors` in Account Config storage for `sender`, for each `[actorId, authenticator]` tuple writing `actor_config` as an unrestricted owner (the `authenticator` address with `scope = 0x00`, `expiry = 0`, `policyType = 0x00`; no policy slots). Mark the account initialized by setting its local change-sequence channel to `1` (see [Config Change Authorization](#config-change-authorization)). Initialize lock state to safe defaults: `locked = false`, `unlock_delay = 0`, `unlocks_at = 0`. Set the `DEFAULT_EOA_REVOKED` flag so a freshly created account does not leave a native secp256k1 owner live unless one is among `initial_actors`. Place `code` at `sender`.
 2. **Config change entries** (if any): Apply operations in entry order. Reject transaction if account is locked.
 3. **Delegation entries** (if any): Require the sender's resolved `actorId == bytes32(bytes20(sender))` (EOA actor only) with CONFIG scope (unrestricted `0x00` also satisfies this). Reject if account is locked. For each entry, set `code(sender) = 0xef0100 || target` (or clear if `target` is `address(0)`). Reject if account has non-delegation bytecode.
 
@@ -618,11 +618,11 @@ Calls carry no ETH value. ETH transfers are initiated by the account's wallet by
 
 ##### Call Phases
 
-`calls` is a two-level structure: an ordered array of **phases**, where each phase is an ordered array of individual calls (`[[call, ...], [call, ...]]`). This gives two levels of atomicity — calls grouped within a phase are all-or-nothing, while phases commit independently in sequence (see [Why Call Phases?](#why-call-phases)).
+`calls` is a two-level structure: an ordered array of **phases**, where each phase is an ordered array of individual calls (`[[call, ...], [call, ...]]`). This gives two levels of atomicity where calls grouped within a phase are all-or-nothing, while phases commit independently in sequence (see [Why Call Phases?](#why-call-phases)).
 
 Phases execute in order from a single gas pool (`gas_limit`). Within each phase, calls execute in order and are **atomic** so if any call in a phase reverts, all state changes for that phase are discarded and remaining phases are **skipped**. Completed phases **persist** and their state changes are committed and survive later phase reverts.
 
-**Policy gate**: When the transaction's authenticating actor has `policyType != 0x00`, each call is gated before dispatch. The protocol resolves the actor's allowed target — `policy_manager(sender, actorId)` — once at the start of `calls` execution, and that snapshot gates every call in every phase; a config change applied by an earlier call does not retarget the gate for later calls. If `call.to` is not that address, the call is **not dispatched** and fails deterministically with the protocol revert `ActorPolicyViolation(bytes32 actorId, address target)`:
+**Policy gate**: When the transaction's authenticating actor has `policyType != 0x00`, each call is gated before dispatch. The protocol resolves the actor's allowed target (`policy_manager(sender, actorId)`) once at the start of `calls` execution, and that snapshot gates every call in every phase; a config change applied by an earlier call does not retarget the gate for later calls. If `call.to` is not that address, the call is **not dispatched** and fails deterministically with the protocol revert `ActorPolicyViolation(bytes32 actorId, address target)`:
 
 ```solidity
 error ActorPolicyViolation(bytes32 actorId, address target);
@@ -632,19 +632,19 @@ The frame's return data is `abi.encodeWithSelector(ActorPolicyViolation.selector
 
 **Common patterns**:
 
-- **Simple call**: `[[{to, data}]]` — one phase, one call
-- **Atomic batch**: `[[call_a, call_b, call_c]]` — one phase, all-or-nothing
-- **Sponsor + user**: `[[sponsor_payment], [user_action_a, user_action_b]]` — sponsor in phase 0 (committed), user actions in phase 1 (atomic, skipped if sponsor fails)
+- **Simple call**: `[[{to, data}]]`, one phase, one call
+- **Atomic batch**: `[[call_a, call_b, call_c]]`, one phase, all-or-nothing
+- **Sponsor + user**: `[[sponsor_payment], [user_action_a, user_action_b]]`, sponsor in phase 0 (committed), user actions in phase 1 (atomic, skipped if sponsor fails)
 
 #### Transaction Context
 
-The Transaction Context precompile at `TX_CONTEXT_ADDRESS` provides read-only access to the current AA transaction's metadata during call execution. The precompile is populated only while the protocol is dispatching the transaction's `calls`; validation and account-change processing do not populate it. It reads directly from the client's in-memory transaction state — protocol "writes" are effectively zero-cost. Gas is charged as a base cost plus 3 gas per 32 bytes of returned data, matching `CALLDATACOPY` pricing.
+The Transaction Context precompile at `TX_CONTEXT_ADDRESS` provides read-only access to the current AA transaction's metadata during call execution. The precompile is populated only while the protocol is dispatching the transaction's `calls`; validation and account-change processing do not populate it. It reads directly from the client's in-memory transaction state; protocol "writes" are effectively zero-cost. Gas is charged as a base cost plus 3 gas per 32 bytes of returned data, matching `CALLDATACOPY` pricing.
 
 | Function | Returns | Available |
 |----------|---------|-----------|
-| `getTransactionSender()` | `address` — the account executing calls (`sender`) | Execution only |
-| `getTransactionPayer()` | `address` — gas payer (`sender` for self-pay, payer for sponsored) | Execution only |
-| `getTransactionSenderActorId()` | `bytes32` — authenticated actor's actorId | Execution only |
+| `getTransactionSender()` | `address`, the account executing calls (`sender`) | Execution only |
+| `getTransactionPayer()` | `address`, gas payer (`sender` for self-pay, payer for sponsored) | Execution only |
+| `getTransactionSenderActorId()` | `bytes32`, authenticated actor's actorId | Execution only |
 
 If the wallet needs the authenticator address or scope, it calls `getActorConfig(account, actorId)` on the Account Configuration Contract. A policy target reached as a `call.to` identifies which key it is acting for by combining `getTransactionSender()` and the authenticated `getTransactionSenderActorId()` from this precompile, then reads the actor's policy sub-type, gate target, and signed `commitment` via `getPolicy(account, actorId)` in one call and validates the presented policy parameters against the commitment. The commitment lives in Account Configuration storage (where it is written and revoked), not the precompile, keeping the precompile to immutable transaction context.
 
@@ -659,7 +659,7 @@ The system is split into storage and authentication layers with different portab
 | **Account Configuration Contract** | Protocol reads storage directly for validation; EVM interface available | Standard contract (ERC-4337 compatible factory) |
 | **Authenticator Contracts** | Protocol calls authenticators via STATICCALL | Same onchain contracts callable by account config contract and wallets |
 | **Code Delegation** | Delegation entry in `account_changes` (EOA-only authorization in this version) | Standard [EIP-7702](./eip-7702.md) transactions (ECDSA authority) |
-| **Transaction Context** | Precompile at `TX_CONTEXT_ADDRESS` — protocol populates, authenticators read | No code at address; STATICCALL returns zero/default values |
+| **Transaction Context** | Precompile at `TX_CONTEXT_ADDRESS`; protocol populates, authenticators read | No code at address; STATICCALL returns zero/default values |
 | **Nonce Manager** | Precompile at `NONCE_MANAGER_ADDRESS` | Not applicable; nonce management by existing systems (e.g., ERC-4337 EntryPoint) |
 
 All contracts are deployed at deterministic CREATE2 addresses across chains.
@@ -729,7 +729,7 @@ Unused gas from `gas_limit` is refunded to the payer. For step 5, the protocol S
 
 ### Appendix: Storage Layout
 
-The protocol reads storage directly from the Account Configuration Contract (`ACCOUNT_CONFIG_ADDRESS`). The storage layout is defined by the deployed contract bytecode — slot derivation follows from the contract's Solidity storage declarations. The final deployed contract source serves as the canonical reference for slot locations.
+The protocol reads storage directly from the Account Configuration Contract (`ACCOUNT_CONFIG_ADDRESS`). The storage layout is defined by the deployed contract bytecode; slot derivation follows from the contract's Solidity storage declarations. The final deployed contract source serves as the canonical reference for slot locations.
 
 ### Appendix: Deployment Header
 
@@ -775,7 +775,7 @@ The protocol never needs to know how any algorithm works.
 
 Session keys and gas-payer hot wallets often need narrow authority: only this token, only this much per day, only this action. `policyType` expresses that by gating a restricted key to a single call target and binding it to a signed, opaque **commitment** that the target enforces. The protocol's only policy responsibility is the single-target gate plus storing the commitment; what the target does with the call, and how it ultimately effects actions for the account, is left to the application.
 
-Because the Account Configuration Contract is a single immutable deployment, it reserves no specific `policyType` values and gates on any non-zero value, leaving the byte for a `manager` to interpret. New policy behaviors are new manager logic, not new protocol values. Encoding policy primitives (selector lists, allowlists, spend limits) into consensus would freeze the vocabulary and require a fork per new primitive — an opaque commitment keeps the protocol agnostic and new behaviors shippable permissionlessly.
+Because the Account Configuration Contract is a single immutable deployment, it reserves no specific `policyType` values and gates on any non-zero value, leaving the byte for a `manager` to interpret. New policy behaviors are new manager logic, not new protocol values. Encoding policy primitives (selector lists, allowlists, spend limits) into consensus would freeze the vocabulary and require a fork per new primitive; an opaque commitment keeps the protocol agnostic and new behaviors shippable permissionlessly.
 
 ### Why Actor Expiry?
 
@@ -789,7 +789,7 @@ Additional `nonce_key` values allow parallel transaction lanes without nonce con
 
 ### Why Account Lock?
 
-Locked accounts have a frozen actor set, so the primary state that can invalidate a validated transaction is nonce consumption. This can enable nodes to cache actor state and apply higher mempool rate limits (see [Mempool Acceptance](#mempool-acceptance)). A locked payer running a canonical account implementation that restricts ETH movement while locked further bounds balance changes to gas fees, letting nodes raise payer rate limits — useful for high-throughput payer/sponsor services. 
+Locked accounts have a frozen actor set, so the primary state that can invalidate a validated transaction is nonce consumption. This can enable nodes to cache actor state and apply higher mempool rate limits (see [Mempool Acceptance](#mempool-acceptance)). A locked payer running a canonical account implementation that restricts ETH movement while locked further bounds balance changes to gas fees, letting nodes raise payer rate limits, useful for high-throughput payer/sponsor services. 
 
 ### Why CREATE2 for Account Creation?
 
@@ -817,15 +817,15 @@ Attribution and annotation data (builder/app codes, payment references, off-chai
 
 ### Why No Value in Calls?
 
-The protocol dispatches each call directly to the specified `to` address with `msg.sender = sender`. Since every account has wallet bytecode (via auto-delegation or explicit deployment), ETH transfers route through wallet code via the CALL opcode — no capability is lost. Removing protocol-level value from calls means the protocol never moves ETH on behalf of the sender.
+The protocol dispatches each call directly to the specified `to` address with `msg.sender = sender`. Since every account has wallet bytecode (via auto-delegation or explicit deployment), ETH transfers route through wallet code via the CALL opcode; no capability is lost. Removing protocol-level value from calls means the protocol never moves ETH on behalf of the sender.
 
 ### Why a Transaction Context Precompile?
 
-Transaction context (sender, payer, calls, gas) is immutable transaction metadata — it never changes during execution. `actorId` is set after validation and available during execution only. A precompile is the natural fit:
+Transaction context (sender, payer, calls, gas) is immutable transaction metadata; it never changes during execution. `actorId` is set after validation and available during execution only. A precompile is the natural fit:
 
-- **Zero protocol write cost**: The precompile reads directly from the client's in-memory transaction struct — no HashMap insert, no journaling, no rollback tracking.
-- **Pull model**: Consumers read only what they need — policies read `actorId` to enforce per-actor limits, and accounts may inspect `payer` for fee reimbursement or access logic.
-- **Forward compatible**: New context fields are added as new precompile functions — no interface changes to `IAuthenticator` or existing authenticator contracts.
+- **Zero protocol write cost**: The precompile reads directly from the client's in-memory transaction struct: no HashMap insert, no journaling, no rollback tracking.
+- **Pull model**: Consumers read only what they need: policies read `actorId` to enforce per-actor limits, and accounts may inspect `payer` for fee reimbursement or access logic.
+- **Forward compatible**: New context fields are added as new precompile functions, with no interface changes to `IAuthenticator` or existing authenticator contracts.
 
 ## Backwards Compatibility
 
@@ -958,19 +958,19 @@ The full transaction hash MUST NOT be used for nonce-free deduplication. The tra
 
 Both variants resolve to the same `replay_id`, so deduplicating on it collapses them to a single mempool slot and a single includable transaction.
 
-**Actor Scope and Policy**: Scope is protocol-enforced after authenticator execution during validation. The policy gate is protocol-enforced during execution (a `call.to` other than the resolved target reverts with `ActorPolicyViolation`). Because it is an execution-time gate rather than a validity input, it is not a mempool filter for compromised keys (see [Why Policy Types?](#why-policy-types)). The gate covers only SENDER-context calls, so a policy-bearing actor cannot hold unrestricted (`0x00`) or CONFIG scope — a CONFIG-scoped key could authorize new actors and escape its policy — while any PAYER or SIGNATURE scope it holds is not policy-constrained (see [Actor Policies](#actor-policies)).
+**Actor Scope and Policy**: Scope is protocol-enforced after authenticator execution during validation. The policy gate is protocol-enforced during execution (a `call.to` other than the resolved target reverts with `ActorPolicyViolation`). Because it is an execution-time gate rather than a validity input, it is not a mempool filter for compromised keys (see [Why Policy Types?](#why-policy-types)). The gate covers only SENDER-context calls, so a policy-bearing actor cannot hold unrestricted (`0x00`) or CONFIG scope (a CONFIG-scoped key could authorize new actors and escape its policy), while any PAYER or SIGNATURE scope it holds is not policy-constrained (see [Actor Policies](#actor-policies)).
 
 **Policy Target as Trust Anchor**: For a policy-bearing actor, the resolved target is fully trusted to enforce the committed limits; the key can only reach that target, which decides what happens next. A buggy or malicious manager can do anything its own authority over the account allows. Accounts SHOULD point restricted keys only at audited managers and treat installing one with the same care as granting that contract authority over the account. A manager (and any policy it enforces) SHOULD be non-upgradeable: an upgradeable manager lets whoever controls the upgrade rewrite enforcement, which is equivalent to granting that party root access over everything the manager can do for the account. The committed parameters and any target-held state are the target's own authorization surface; checking that `keccak256(params)` matches the stored commitment is the target's responsibility, not the protocol's. How the target obtains authority to act for the account is out of scope for this specification.
 
-**Policy State on Revocation**: `revokeActor` clears `actor_config`, `policy_commitment`, and `policy_manager` — all keyed by `(account, actorId)` — which immediately stops the key from reaching its target; there are no per-target protocol entries to enumerate or resurrect, and storage is fully reclaimed. Any parameters a target keeps in its own storage are not protocol state and are not auto-cleared; wallets uninstall them through the target when retiring a key, and an `expiry` bounds the window during which a not-yet-uninstalled key could otherwise be used.
+**Policy State on Revocation**: `revokeActor` clears `actor_config`, `policy_commitment`, and `policy_manager` (all keyed by `(account, actorId)`), which immediately stops the key from reaching its target; there are no per-target protocol entries to enumerate or resurrect, and storage is fully reclaimed. Any parameters a target keeps in its own storage are not protocol state and are not auto-cleared; wallets uninstall them through the target when retiring a key, and an `expiry` bounds the window during which a not-yet-uninstalled key could otherwise be used.
 
 **Actor Management**: Config change authorization requires CONFIG scope (satisfied by an unrestricted `0x00` scope or the CONFIG bit `0x08`). The EOA actor is implicitly authorized with unrestricted scope; revocable via portable config change. All actor modification paths are blocked when the account is locked.
 
-**Implicit EOA Rule Scoping**: The implicit EOA authorization rule only applies when authentication used the native secp256k1 path — either the EOA path (`sender` empty) or `K1_AUTHENTICATOR` — and the account's `DEFAULT_EOA_REVOKED` flag is unset. Generic authenticator contracts MUST NOT satisfy the implicit branch even if they return `bytes32(bytes20(sender))`, otherwise an arbitrary authenticator could authenticate as any EOA whose implicit actor slot has never been written.
+**Implicit EOA Rule Scoping**: The implicit EOA authorization rule only applies when authentication used the native secp256k1 path, either the EOA path (`sender` empty) or `K1_AUTHENTICATOR`, and the account's `DEFAULT_EOA_REVOKED` flag is unset. Generic authenticator contracts MUST NOT satisfy the implicit branch even if they return `bytes32(bytes20(sender))`, otherwise an arbitrary authenticator could authenticate as any EOA whose implicit actor slot has never been written.
 
-**actorId Binding**: The protocol checks that the authenticator's returned `actorId` maps back to that authenticator in `actor_config` — preventing a malicious authenticator from claiming control of another authenticator's actors.
+**actorId Binding**: The protocol checks that the authenticator's returned `actorId` maps back to that authenticator in `actor_config`, preventing a malicious authenticator from claiming control of another authenticator's actors.
 
-**Payer Security**: `AA_TX_TYPE` vs `AA_PAYER_TYPE` domain separation prevents signature reuse between sender and payer roles. The `payer` field in the sender's signed hash binds to a specific payer address. Scope enforcement adds a second layer — PAYER-only actors cannot be used as `sender_auth`, and vice versa. The payer's exposure to sender-controlled gas is bounded by signed fee fields because `gas_limit` includes sender authentication, intrinsic costs, account changes, and call execution. Payer authentication uses the payer's chosen authenticator, is validated under PAYER scope, and is metered separately so the payer's authenticator choice cannot reduce gas available to `calls` or otherwise affect execution behavior.
+**Payer Security**: `AA_TX_TYPE` vs `AA_PAYER_TYPE` domain separation prevents signature reuse between sender and payer roles. The `payer` field in the sender's signed hash binds to a specific payer address. Scope enforcement adds a second layer: PAYER-only actors cannot be used as `sender_auth`, and vice versa. The payer's exposure to sender-controlled gas is bounded by signed fee fields because `gas_limit` includes sender authentication, intrinsic costs, account changes, and call execution. Payer authentication uses the payer's chosen authenticator, is validated under PAYER scope, and is metered separately so the payer's authenticator choice cannot reduce gas available to `calls` or otherwise affect execution behavior.
 
 **Cross-sender Payer Replay**: The payer signature hash binds to the resolved sender via the `sender` field (see [Signature Payload](#signature-payload)). In the EOA path where `sender` is empty in the wire format, the recovered sender address MUST be substituted into the `sender` position before computing the hash. Without this substitution, two different EOAs that construct otherwise identical transaction data (same `chain_id`, `nonce_key`, `nonce_sequence`, `expiry`, fees, `account_changes`, `calls`) would produce identical payer hashes, allowing a second EOA to reuse a payer signature originally issued for the first and drain the payer's gas deposit. The 2D nonce alone does not prevent this: `nonce_key` and `nonce_sequence` are fields in the transaction payload, so each attacker controls their own values. Substituting the recovered sender into the hash makes the payer's commitment per-sender and closes this replay path. The configured-actor path is unaffected because `sender` is non-empty by definition.
 

--- a/EIPS/eip-8130.md
+++ b/EIPS/eip-8130.md
@@ -144,25 +144,29 @@ The protocol validates signatures by reading `actor_config` directly and delegat
 
 #### Actor Policies
 
-The `policyType` byte selects whether an actor is gated. `0x00` means no policy; any non-zero value gates the actor to a stored `manager` and carries an opaque 32-byte **commitment** (`keccak256` of the policy parameters). The protocol gates identically on every non-zero value and never interprets the specific byte; it is carried in `actor_config` for the `manager` to read as a sub-type if useful.
+Policies let an account issue a **restricted key**, typically a session key, that carries only narrow authority, such as "spend at most 5 USDC per month" or "only call these two contracts." The protocol enforces just one thing: the key can call exactly one contract, its **manager**. The manager holds the actual rules and drives the account. This keeps policy logic out of consensus, so new policy behaviors ship as new manager contracts rather than protocol changes (see [Why Policy Types?](#why-policy-types)).
+
+An account authorizes such a key by storing three fields in its config: a non-zero `policyType`, the `manager` address, and an opaque 32-byte **commitment**. The protocol interprets none of them beyond the gate. Any non-zero `policyType` forces every call to the `manager`; it gates identically on all non-zero values, leaving the byte as an optional sub-type the manager may read. The `commitment` is simply 32 bytes the protocol stores and exposes back to the manager, with a meaning the manager alone defines. A common convention is `commitment = keccak256(policy params)`, which commits to a policy without publishing it, but the protocol neither requires nor inspects this. `0x00` means no policy.
 
 | `policyType` | Gate: `call.to` MUST equal | `policyData` |
 |--------------|----------------------------|---------------|
 | `0x00` | (no gate) | — |
 | non-zero | the actor's `manager` | `manager` (20 bytes) ‖ `commitment` (32 bytes) |
 
-A policy-bearing actor (typically a session key) may call exactly one target: its configured `manager`. The contract at that target reads the actor's `commitment` (via [`getPolicy`](#iaccountconfiguration)), validates the presented policy parameters against it (`keccak256(params) == commitment`), enforces *what* the call may do, and carries out the approved action. The protocol's only responsibility is the single-target gate; how the target enforces the commitment and how it acts on behalf of the account are out of scope for this specification.
+The protocol's only responsibility is this single-target gate plus storing and exposing the commitment (via [`getPolicy`](#iaccountconfiguration)). What the commitment means, what the `manager` allows, and how it acts for the account are entirely up to the `manager` and out of scope for this specification. The reference flow below is one common way to use the gate; the only protocol guarantee is that a non-zero `policyType` confines the key's calls to its `manager`.
 
 A key that should be enforced by the account's own code rather than a separate contract sets `manager = account`. 
 
 **Scope.** The policy gate constrains only SENDER-context calls, so a policy-bearing actor MUST be authorized with a restricted `scope` that is neither unrestricted (`0x00`) nor includes CONFIG (`0x08`): a CONFIG-scoped key could authorize new, unrestricted actors and escape its policy entirely. PAYER and SIGNATURE scopes are permitted but are not policy-constrained — a policy-bearing actor with PAYER scope can sponsor gas up to the transaction's limits, and with SIGNATURE scope can produce ERC-1271 signatures the policy never sees, so wallets SHOULD grant a restricted key only the scopes it needs, typically SENDER alone.
 
-**Reference flow** (non-normative). A session-key policy with a custom manager:
+**Reference flow** (non-normative). One common way to build a session-key policy on top of the gate; other designs work equally well, since the protocol only guarantees the single-target gate:
 
-1. The account authorizes the key with a non-zero `policyType`, a `manager`, and `commitment = keccak256(params)`.
-2. The account installs `params` at the manager, which checks that `getPolicy(account, actorId)` resolves to itself with a matching `commitment`.
-3. On each use, the protocol gate routes the key's call to the manager; the manager re-reads `getPolicy(account, actorId)`, requires `keccak256(presented params) == commitment`, enforces them, and acts for the account.
-4. `revokeActor` (or `expiry`) clears the slots, so step 3 then fails for that key.
+1. **Authorize.** The account authorizes the key with a non-zero `policyType`, SENDER scope, the `manager`, and a `commitment` (here `keccak256(params)`). The key holds no authority of its own, only the gate to its `manager`.
+2. **Install (once).** The `params` are installed at the `manager`. Installation is permissionless because it is gated by the signed commitment, not the caller: the account, the key, or a third party can submit it. The `manager` recomputes `keccak256(params)`, confirms `getPolicy(account, actorId)` resolves to itself with that commitment, and stores `params` keyed by the commitment. This is typically bundled into the key's first transaction.
+3. **Use (each call).** The protocol gate routes the key's call to the `manager`; the `manager` loads the installed `params` via the live `commitment` from `getPolicy(account, actorId)`, enforces them against the requested action (decrement the allowance, check the target and selector), and drives the account. Later calls repeat this step against the running state, with no re-install.
+4. **Retire.** `revokeActor` (or `expiry`) zeroes the commitment, so step 3 fails immediately for that key.
+
+**Example** (non-normative). A subscription session key limited to **5 USDC per 30-day period** with a **two-target allowlist**: USDC (`transfer` only) and one application contract, encoded as the key's `params`. The wallet authorizes the key with SENDER scope only, so it gets no PAYER or CONFIG scope and cannot pay its own gas or widen its own authority; a sponsor covers gas via `payer`/`payer_auth`. The key's **first transaction** installs the `params` at the manager and makes its first call in the same flow (steps 2 and 3); **later transactions** go straight to step 3, drawing down the same monthly counter. A `transfer` over the remaining budget, a call to any other target, or any call after the key expires or is revoked is rejected.
 
 **The commitment is signed, opaque, and protocol-stored.** Because it is part of the signed actor change, one signature fully describes the key's authority (its manager and exact policy) and travels with the portable, multichain actor-change path. Because it is opaque (one word), the protocol stays agnostic to the policy vocabulary: new policy behaviors are new target logic, requiring no protocol change.
 
@@ -430,7 +434,7 @@ The `metadata` field is optional opaque bytes for attaching attribution or annot
 
 `metadata` does not affect validation or execution: the protocol never parses, dispatches, or otherwise interprets it. It is part of the signed transaction (covered by both the [sender and payer signature payloads](#signature-payload)) and is charged per byte through `tx_payload_cost` like any other transaction bytes. Off-chain consumers (indexers, explorers) read it directly from the transaction.
 
-The byte layout of `metadata` is not constrained by this specification; producers MAY use any encoding, and MAY treat the field as wholly opaque bytes. A companion specification defines a recommended structured encoding so that off-chain consumers can index metadata interoperably.
+The byte layout of `metadata` is not constrained by this specification; producers MAY use any encoding, and MAY treat the field as wholly opaque bytes.
 
 ### Account Changes
 
@@ -809,7 +813,7 @@ Phases provide two atomic batching levels without per-call mode flags:
 
 ### Why a Metadata Field?
 
-Attribution and annotation data (builder/app codes, payment references, off-chain commitments) traditionally ride as a trailing "data suffix" on `tx.input`. The structured `calls` array has no such trailing location, so a dedicated optional `metadata` field gives this data a first-class, signed home without overloading a call. Keeping it opaque and out of execution means the protocol stays agnostic to its contents: annotation formats are defined by companion specifications, not by protocol changes. Binding it into both signature payloads makes it tamper-evident, unlike a mutable trailing suffix.
+Attribution and annotation data (builder/app codes, payment references, off-chain commitments) traditionally ride as a trailing "data suffix" on `tx.input`. The structured `calls` array has no such trailing location, so a dedicated optional `metadata` field gives this data a first-class, signed home without overloading a call. Keeping it opaque and out of execution means the protocol stays agnostic to its contents. Binding it into both signature payloads makes it tamper-evident, unlike a mutable trailing suffix.
 
 ### Why No Value in Calls?
 

--- a/EIPS/eip-8130.md
+++ b/EIPS/eip-8130.md
@@ -144,22 +144,22 @@ The protocol validates signatures by reading `actor_config` directly and delegat
 
 #### Actor Policies
 
-Policies let an account issue a **restricted key**, typically a session key, that carries only narrow authority, such as "spend at most 5 USDC per month" or "only call these two contracts." The protocol enforces just one thing: the key can call exactly one contract, its **manager**. The manager holds the actual rules and drives the account. This keeps policy logic out of consensus, so new policy behaviors ship as new manager contracts rather than protocol changes (see [Why Policy Types?](#why-policy-types)).
+Actor policies gate a key to a single `manager` contract that enforces application-defined authority on the account's behalf, for example a session key limited to a spend cap or a small set of targets (see [Why Policy Types?](#why-policy-types)).
 
-An account authorizes such a key by storing three fields in its config: a non-zero `policyType`, the `manager` address, and an opaque 32-byte **commitment**. The protocol interprets none of them beyond the gate. Any non-zero `policyType` forces every call to the `manager`; it gates identically on all non-zero values, leaving the byte as an optional sub-type the manager may read. The `commitment` is simply 32 bytes the protocol stores and exposes back to the manager, with a meaning the manager alone defines. A common convention is `commitment = keccak256(policy params)`, which commits to a policy without publishing it, but the protocol neither requires nor inspects this. `0x00` means no policy.
+The `policyType` byte selects whether an actor is gated. `0x00` means no policy; any non-zero value gates the actor to a stored `manager` and carries an opaque 32-byte **commitment** whose meaning is defined by the `manager` (commonly `keccak256` of the policy parameters). The protocol gates identically on every non-zero value and never interprets the specific byte; it is carried in `actor_config` for the `manager` to read as a sub-type if useful.
 
 | `policyType` | Gate: `call.to` MUST equal | `policyData` |
 |--------------|----------------------------|---------------|
 | `0x00` | (no gate) | — |
 | non-zero | the actor's `manager` | `manager` (20 bytes) ‖ `commitment` (32 bytes) |
 
-The protocol's only responsibility is this single-target gate plus storing and exposing the commitment (via [`getPolicy`](#iaccountconfiguration)). What the commitment means, what the `manager` allows, and how it acts for the account are entirely up to the `manager` and out of scope for this specification. The reference flow below is one common way to use the gate; the only protocol guarantee is that a non-zero `policyType` confines the key's calls to its `manager`.
+A policy-bearing actor (typically a session key) may call exactly one target: its configured `manager`. The contract at that target reads the actor's `commitment` (via [`getPolicy`](#iaccountconfiguration)), validates the presented policy parameters against it (typically `keccak256(params) == commitment`), enforces *what* the call may do, and carries out the approved action. The protocol's only responsibility is the single-target gate; how the target interprets the commitment and acts on behalf of the account are out of scope for this specification.
 
 A key that should be enforced by the account's own code rather than a separate contract sets `manager = account`. 
 
 **Scope.** The policy gate constrains only SENDER-context calls, so a policy-bearing actor MUST be authorized with a restricted `scope` that is neither unrestricted (`0x00`) nor includes CONFIG (`0x08`): a CONFIG-scoped key could authorize new, unrestricted actors and escape its policy entirely. PAYER and SIGNATURE scopes are permitted but are not policy-constrained — a policy-bearing actor with PAYER scope can sponsor gas up to the transaction's limits, and with SIGNATURE scope can produce ERC-1271 signatures the policy never sees, so wallets SHOULD grant a restricted key only the scopes it needs, typically SENDER alone.
 
-**Reference flow** (non-normative). One common way to build a session-key policy on top of the gate; other designs work equally well, since the protocol only guarantees the single-target gate:
+**Reference flow** (non-normative). One construction of a session-key policy:
 
 1. **Authorize.** The account authorizes the key with a non-zero `policyType`, SENDER scope, the `manager`, and a `commitment` (here `keccak256(params)`). The key holds no authority of its own, only the gate to its `manager`.
 2. **Install (once).** The `params` are installed at the `manager`. Installation is permissionless because it is gated by the signed commitment, not the caller: the account, the key, or a third party can submit it. The `manager` recomputes `keccak256(params)`, confirms `getPolicy(account, actorId)` resolves to itself with that commitment, and stores `params` keyed by the commitment. This is typically bundled into the key's first transaction.


### PR DESCRIPTION
## Summary

Clarifies the actor policy model and simplifies the transaction metadata section in EIP-8130. No normative behavior changes.

- **Actor Policies**: rewritten for clarity. Removes duplicated explanations of the single-target gate, and states the one protocol guarantee plainly — a non-zero `policyType` confines the key's calls to its `manager`. The 32-byte `commitment` is described as fully opaque (meaning defined by the manager); `keccak256(params)` is presented as a common convention, not a requirement. Adds a labeled reference flow (Authorize / Install / Use / Retire) framed as one pattern among many, plus a concrete non-normative subscription session-key example (USDC spend limit + two-target allowlist, SENDER-scope-only with sponsored gas).
- **Transaction Metadata**: drops the reference to a recommended structured encoding / companion specification. The field stands on its own as opaque, signed, protocol-agnostic bytes; a metadata encoding spec can be referenced later once one exists.

## Test plan

- [ ] EIP validation / linting passes in CI
- [ ] Rendered Markdown reads cleanly (Actor Policies section, Transaction Metadata section)