### PR TITLE
Update EIP-7778: Block Gas Accounting without Refunds and Route Refunds

### DIFF
--- a/EIPS/eip-7778.md
+++ b/EIPS/eip-7778.md
@@ -1,7 +1,7 @@
 ---
 eip: 7778
 title: Block Gas Accounting without Refunds
-description: Prevent Block Gas Limit Circumvention by Excluding Refunds from Block Gas Accounting
+description: Prevent Block Gas Limit Circumvention by Excluding Refunds from Block Gas Accounting and Introduce Refund Routing based on Their Origin
 author: Ben Adams (@benaadams), Toni Wahrstätter (@nerolation)
 discussions-to: https://ethereum-magicians.org/t/eip-7778-prevent-block-gas-smuggling/21234
 status: Draft
@@ -12,7 +12,9 @@ created: 2024-10-01
 
 ## Abstract
 
-This EIP modifies the block gas accounting mechanism to prevent the circumvention of block gas limits. It proposes that gas refunds, particularly those from SSTORE operations setting storage slots to zero, should not reduce the gas counted toward the block gas limit, while still being applied to transaction gas costs for users.
+This EIP modifies the block gas accounting mechanism to prevent the circumvention of block gas limits. It proposes that gas refunds, particularly those from `SSTORE` operations setting storage slots to zero, should not reduce the gas counted toward the block gas limit, while still being applied to transaction gas costs for users.
+
+Additionally, this EIP introduces refund routing based on the origin of refunds in order to further improve gas accounting. These rules apply retroactively to existing gas refunds but do not modify the value of any refund mechanism.
 
 ## Motivation
 
@@ -25,6 +27,8 @@ This mechanism can be exploited to perform more operations in a block than the g
 1. Network instability due to oversized blocks
 2. Denial-of-service vectors
 3. Computational loads exceeding the intended block gas limit
+
+Furthermore, existing refunds (for example, the authorization refunds introduced by [EIP-7702](./eip-7702.md) are routed through the single refund counter retained after [EIP-3529](./eip-3529.md). As a result, refunded gas remains unavailable until the end of the transaction and is subject to the 20% refund cap. Separating these refunds according to their origin improves gas accounting and can reduce transaction costs by making refunded gas available through more appropriate accounting mechanisms.
 
 ## Specification
 
@@ -41,6 +45,17 @@ This mechanism can be exploited to perform more operations in a block than the g
    - Block gas accounting becomes: `block.gas_used += max(tx_gas_used, calldata_floor_gas_cost)` (incorporating the calldata floor from [EIP-7623](./eip-7623.md))
    - Storage discounts that reflect actual reduced computational work (e.g., warm storage access, reverting to original values) remain applied to block gas accounting
 
+### Refund Routing
+
+This EIP defines two categories of gas refunds according to their origin:
+
+- `external refund`: a refund originating from state changes performed by previous transactions. For example, transaction A creates a storage slot and transaction B subsequently clears it.
+- `internal refund`: a refund originating from state changes or overcharges within the same transaction. For example, refunds resulting from the overcharging of [EIP-7702](./eip-7702.md) authorizations.
+
+The refund counter only accepts refunds belonging to the `external refund` category.
+
+Refunds belonging to the `internal refund` category MUST NOT be added to the refund counter and instead MUST be accounted for using alternative mechanisms, such as dedicated refund reservoirs or counters.
+
 ## Rationale
 
 ### Aligning Gas Limits with Computational Work
@@ -50,6 +65,10 @@ The block gas limit is designed to constrain the computational load per block. G
 ### Preserving User Incentives
 
 Users still receive gas refunds, maintaining incentives for efficient state management. Only the accounting for block-level constraints changes, not the economics for individual users
+
+### Refund Routing
+
+Separating refunds according to their origin further improves gas accounting while preserving the existing refund mechanisms. This proposal changes how refunds are accounted for but does not alter the economic value of existing refunds.
 
 ## Backwards Compatibility
 
@@ -71,12 +90,15 @@ Users still receive gas refunds, maintaining incentives for efficient state mana
    - Verify that transaction costs for users remain unchanged
    - Confirm block gas accounting properly excludes refunds
 
+4. **Refund Routing:**
+   - Verify that only `external refunds` are added to the refund counter
+
 ## Security Considerations
 
 - Eliminates potential denial-of-service vectors that exploit gas refunds to exceed block computational limits
 - Improves predictability of block processing times by enforcing stricter limits on computational work
 - Prevents miners/validators from including transactions that collectively contain more computational work than intended
 
-## Copyright
+## Copyright 
 
 Copyright and related rights waived via [CC0](../LICENSE.md).


### PR DESCRIPTION
Continuing the previous discussion in #11824 to fix the error caused by overlapping branches, the `description` has been changed from `Implement` to `Introduce`. The rest remains the same as the previous PR.