### PR TITLE
Update EIP-7979: Support call elimination via JUMP to ENTERSUB

### DIFF
--- a/EIPS/eip-7979.md
+++ b/EIPS/eip-7979.md
@@ -18,7 +18,7 @@ This is a minimal change to the EVM to support calls and returns.
 This proposal introduces three new control-flow instructions to the EVM:
 
 * `CALLSUB` transfers control to the *destination* on the *data stack*.
-* `ENTERSUB` marks a `CALLSUB` destination.
+* `ENTERSUB` marks a subroutine entry: the destination of a `CALLSUB`, or of a `JUMP` that eliminates a call.
 * `RETURNSUB` returns to the *PC* after the most recent `CALLSUB`.
 
 Code can also be prefixed with `MAGIC` bytes.  `MAGIC` code is validated at `CREATE` time to ensure that it cannot execute invalid instructions, jump to invalid locations, underflow stack, or, in the absence of recursion, overflow stack.
@@ -66,6 +66,11 @@ The gas cost is *mid* (8).
 Marks a destination for `CALLSUB`.  Like `JUMPDEST`, it is otherwise a
 no-op: execution falls through.  The *destination* of every `CALLSUB` MUST
 be an `ENTERSUB`.
+
+An `ENTERSUB` is also, like a `JUMPDEST`, a valid destination for `JUMP`
+and `JUMPI`.  Jumping to an `ENTERSUB` enters the subroutine without
+pushing to the *return stack*, so the subroutine's `RETURNSUB` returns to
+the original caller.
 
 The gas cost is *jumpdest* (1).
 
@@ -129,9 +134,9 @@ data, and are ignored.
   pops the return address it pushed.  Frames nest; execution begins in an
   implicit outermost frame.
 
-* ***entry***: an `ENTERSUB`.  Every *frame* begun by a `CALLSUB` starts at
-  an entry; an entry may also be reached by falling through from the
-  preceding instruction, so subroutines may have multiple entry points.
+* ***entry***: an `ENTERSUB`.  Every *frame* begun by a `CALLSUB` starts
+  at an entry; an entry may also be entered without a call — by falling
+  through, or by jump — so subroutines may have multiple entry points.
 
 * ***region***: the reachable instructions governed by a given *entry* —
   those whose most recent `ENTERSUB` within their *frame* is that entry;
@@ -165,8 +170,9 @@ decidable in a single linear pass.
    * the `INVALID` opcode is *valid*.
 
 2. Every reachable `JUMP` and `JUMPI` MUST be immediately preceded by a
-   `PUSH`, whose immediate value is the destination.  The destination MUST be
-   a `JUMPDEST` instruction — immediate data is not an instruction.
+   `PUSH`, whose immediate value is the destination.  The destination MUST
+   be a `JUMPDEST` or an `ENTERSUB` instruction — immediate data is not an
+   instruction.  A jump to an `ENTERSUB` enters the subroutine.
 
 3. Every reachable `CALLSUB` MUST be immediately preceded by a `PUSH`, whose
    immediate value is the destination.  The destination MUST be an `ENTERSUB`
@@ -211,7 +217,7 @@ The above is a purely *semantic* specification, placing no constraints on the *s
 
 Rather than enforce semantic constraints via syntax — as is done by higher-level languages — this proposal enforces them via validation: `MAGIC` code is proven *valid* at `CREATE` time.
 
-With no syntactic constraints and minimal semantic constraints, we maximize opportunities for optimizations, including tail call elimination, multiple-entry calls, efficient register allocation, and inter-procedural optimizations.  Since we want to support online compilation of EVM code to native code, it is crucial that the EVM code be as well optimized as possible by high-level-language compilers — upfront and offline.
+With no syntactic constraints and minimal semantic constraints, we maximize opportunities for optimizations, including call elimination, multiple-entry calls, efficient register allocation, and inter-procedural optimizations.  Since we want to support online compilation of EVM code to native code, it is crucial that the EVM code be as well optimized as possible by high-level-language compilers — upfront and offline.
 
 ## Rationale
 
@@ -248,6 +254,8 @@ Primarily **backwards compatibility**.  We need `MAGIC` code to run unaltered in
 
 Constraint 2 requires that `JUMP` and `JUMPI` in `MAGIC` code be immediately preceded by a `PUSH` instruction, making their destinations compile-time constants.  This converts them from dynamic to static jumps, preserving their use for intra-subroutine branching — loops, conditionals — while ensuring that all control flow in `MAGIC` code is statically resolvable in a single linear pass.
 
+The destination may be a `JUMPDEST` or an `ENTERSUB`.  A jump to an `ENTERSUB` enters the subroutine without a call: where a `CALLSUB` would be the last action before a `RETURNSUB`, the jump does the same work with no return address pushed — the call is eliminated.  This makes `ENTERSUB` a safe cross-region label: within a *region*, jumps go to `JUMPDEST`s; between regions, control enters at an *entry*, by call or by jump.  Call elimination in this form supports tail recursion, mutual recursion and state machines, shared epilogues, and the outlining of repeated code — the transformations optimizing compilers rely on — while leaving computed dispatch out: destinations remain compile-time constants, so the path-explosion door stays shut.  Jumping into the middle of another *region* remains invalid; the one-byte `ENTERSUB` is the price of making a point enterable, and it keeps every cross-region transfer visible to one-pass analysis.
+
 ### How can dynamic jumps explode control flow analysis?
 
 Recovering a program's control flow is a fundamental first step for many analyses.  When all jumps are static, the number of analysis steps is linear in the number of instructions: a fixed number of paths must be explored for each jump.  With dynamic jumps, every possible destination must be explored at every jump.  Intuitively, the number of possible paths through code just explodes.  At worst, the number of paths in the control flow can go up as the square of the number of instructions, and symbolic execution of the paths can go up exponentially.  See [EIP-8173](./eip-8173.md) for a more detailed explanation and example exploit.
@@ -256,7 +264,7 @@ This behavior is not merely a theoretical concern.  For Ethereum, it represents 
 
 ### Why these three instructions?
 
-This proposal aims to be a minimal change to the EVM.  We introduce two abstract operations — call and return — implemented by three instructions: `CALLSUB`, `ENTERSUB`, and `RETURNSUB`.  These suffice to eliminate the need for dynamic jumps.  *(Note: `ENTERSUB` and `JUMPDEST` are technically unnecessary, but their presence makes it easier to recover function and block boundaries in the control flow, so we leave deliberation on whether to remove them to a later EIP.)*
+This proposal aims to be a minimal change to the EVM.  We introduce two abstract operations — call and return — implemented by three instructions: `CALLSUB`, `ENTERSUB`, and `RETURNSUB`.  These suffice to eliminate the need for dynamic jumps.  *(Note: `ENTERSUB` and `JUMPDEST` are not mere conveniences.  The two kinds of label make every destination self-describing: a `JUMPDEST` marks a branch target within a *region*, while an `ENTERSUB` marks an *entry*, where the *baseline* resets and a jump eliminates a call.  Without the distinction, the validator could not tell a merge from an entrance.)*
 
 ### Why the return-stack mechanism for calls and returns?
 
@@ -520,6 +528,15 @@ small vectors; the algorithm is independent of the limit.*
 | recursion, no base case      | `0x6004B000B16004B0B2` | yes   |
 | recursion eats caller stack  | `0x6004B000B1506004B0` | no    |
 
+**Jumps to an `ENTERSUB` (call elimination)**
+
+| Test                          | Bytecode                         | Valid |
+|-------------------------------|----------------------------------|-------|
+| jump to an `ENTERSUB`         | `0x6004B000B15F600956B150B2`     | yes   |
+| conditional jump to an `ENTERSUB` | `0x6004B000B136600A57B2B1B2` | yes   |
+| jump to an `ENTERSUB`, net effects disagree | `0x6004B000B15F36600B57B2B150B2` | no |
+| unframed jump to a called subroutine | `0x6006B0600656B1B2`      | no    |
+
 **Overflow (run with `STACK_LIMIT` = 16)**
 
 | Test                                  | Bytecode                             | Valid |
@@ -576,10 +593,10 @@ the validator computes per *entry*.
 The three subroutine instructions receive specific handling:
 
 * `ENTERSUB` resets the *baseline*: it is always visited in the canonical
-  state — *stack offset* 0, itself the *entry*.  An arrival by fall-through
-  at offset d records a *fall edge*: the arriving *entry*'s *net effect* is
-  d plus this *entry*'s, composing *net effects* across multiple entry
-  points, and its *inputs* are at least this *entry*'s *inputs* minus d.
+  state — *stack offset* 0, itself the *entry*.  An arrival without a call
+  — by fall-through or by jump — at offset d records an *enter edge*: the arriving *entry*'s *net effect* is d plus this
+  *entry*'s, composing *net effects* across multiple entry points, and its
+  *inputs* are at least this *entry*'s *inputs* minus d.
 
 * `CALLSUB` records a *call edge* (for the *summaries*, likewise) and seeds
   the callee in its canonical state, *framed*.  The return point — the next
@@ -593,15 +610,15 @@ The three subroutine instructions receive specific handling:
   It resolves its *entry*'s *net effect* as the current *stack offset*, or
   checks agreement with the already-resolved value (Constraint 5).
   Resolving an *entry* releases its pending return points and, in
-  cascade, resolves the entries that fall into it.
+  cascade, resolves the entries that enter it without a call.
 
 A subroutine that never returns leaves its callers' return points pending
 forever: they are unreachable, and correctly never validated.
 
 After the traversal, the *summaries* propagate over the recorded edges
 from *child* to *parent* — the child being the callee of a *call edge*, or
-the entry fallen into by a *fall edge*; the parent, the *region* that
-called or fell into it: *inputs*(parent) ≥ *inputs*(child) − offset at the
+the entry entered by an *enter edge*; the parent, the *region* that called
+or entered it: *inputs*(parent) ≥ *inputs*(child) − offset at the
 edge; *stack growth*(parent) ≥ offset + *stack growth*(child);
 *call depth*(parent) ≥ *call depth*(child), plus one *frame* per call edge.
 The *entry graph* — the *regions*, connected by these edges — is sorted
@@ -626,7 +643,8 @@ continuations and records at most one edge or pending return point, and
 each *entry* resolves once, so the traversal runs in time and space linear
 in code size.  The propagation of the *summaries* is a topological pass,
 one relaxation per edge; under recursion the *inputs* relaxation re-visits
-an *entry* only when its *inputs* strictly increase, at most 1024 times — a
+an
+*entry* only when its *inputs* strictly increase, at most 1024 times — a
 protocol constant — so the whole validation is linear in code size, worst
 case.
 
@@ -676,8 +694,10 @@ MAX_EDGES: constant(uint256) = MAX_WORKLIST
 INPUTS_WORK_BOUND: constant(uint256) = ENTRY_SLOTS * 1027
 
 # Required destination type tags, stored in required_at[].
+# LABEL requires a JUMPDEST or an ENTERSUB (a jump destination);
+# ENTERSUB requires an ENTERSUB (a call destination).
 REQUIRE_NONE:     constant(uint8) = 0
-REQUIRE_JUMPDEST: constant(uint8) = 1
+REQUIRE_LABEL:    constant(uint8) = 1
 REQUIRE_ENTERSUB: constant(uint8) = 2
 
 # ---------------------------------------------------------------------------
@@ -769,16 +789,16 @@ def validate(code: Bytes[MAX_CODE_SIZE]) -> bool:
     pend_framed: bool[MAX_PENDING]    = empty(bool[MAX_PENDING])
     pend_count:  uint256 = 0
 
-    # Call and fall edges, a linked list per child entry — the callee
-    # of a CALLSUB, or the entry fallen into.  The inputs, growth, and
-    # call_depth summaries flow from child to parent over every edge;
-    # net effects flow only over fall edges.  List indices are stored
-    # plus one; zero means empty.
+    # Call and enter edges, a linked list per child entry — the callee
+    # of a CALLSUB, or the entry entered without a call.  The inputs,
+    # growth, and call_depth summaries flow from child to parent over
+    # every edge; net effects flow only over enter edges.  List indices
+    # are stored plus one; zero means empty.
     edge_head:   uint256[ENTRY_SLOTS] = empty(uint256[ENTRY_SLOTS])
     edge_next:   uint256[MAX_EDGES]   = empty(uint256[MAX_EDGES])
     edge_parent: uint256[MAX_EDGES]   = empty(uint256[MAX_EDGES])
     edge_off:    int256[MAX_EDGES]    = empty(int256[MAX_EDGES])
-    edge_fall:   bool[MAX_EDGES]      = empty(bool[MAX_EDGES])
+    edge_enter:  bool[MAX_EDGES]      = empty(bool[MAX_EDGES])
     edge_count:  uint256 = 0
 
     # Entries whose net effect has just resolved, awaiting cascade.
@@ -802,7 +822,7 @@ def validate(code: Bytes[MAX_CODE_SIZE]) -> bool:
 
     for _step: uint256 in range(MAX_STEPS):
         # Cascade resolutions: flush each newly resolved entry's pending
-        # return points, and propagate net effects to fall-edge parents.
+        # return points, and propagate net effects to enter-edge parents.
         for _c: uint256 in range(ENTRY_SLOTS):
             if res_top == 0:
                 break
@@ -832,7 +852,7 @@ def validate(code: Bytes[MAX_CODE_SIZE]) -> bool:
                 if ecur == 0:
                     break
                 eidx: uint256 = ecur - 1
-                if edge_fall[eidx]:
+                if edge_enter[eidx]:
                     parent: uint256 = edge_parent[eidx]
                     candidate: int256 = edge_off[eidx] + resolved_net
                     if net_resolved[parent]:
@@ -872,9 +892,10 @@ def validate(code: Bytes[MAX_CODE_SIZE]) -> bool:
         if size == 0:
             return False
 
-        # ENTERSUB resets the offset baseline.  A fall-through arrival at
-        # offset d records a fall edge — the arriving entry's net effect
-        # is d plus this entry's — then the state is normalized to the
+        # ENTERSUB resets the offset baseline.  An arrival without a
+        # call — by fall-through or by jump — at offset d records an
+        # enter edge: the arriving entry's net effect is d plus this
+        # entry's.  The state is then normalized to the
         # canonical (offset 0, this entry) before the join check.
         if op == OPCODE_ENTERSUB:
             if entry != pc or offset != 0:
@@ -883,7 +904,7 @@ def validate(code: Bytes[MAX_CODE_SIZE]) -> bool:
                 edge_next[edge_count]   = edge_head[pc]
                 edge_parent[edge_count] = entry
                 edge_off[edge_count]    = offset
-                edge_fall[edge_count]   = True
+                edge_enter[edge_count]   = True
                 edge_head[pc] = edge_count + 1
                 edge_count += 1
                 if net_resolved[pc]:
@@ -913,8 +934,9 @@ def validate(code: Bytes[MAX_CODE_SIZE]) -> bool:
         visited_framed[pc] = framed
 
         # Destination-type requirement recorded for this PC, if any.
-        if required_at[pc] == REQUIRE_JUMPDEST and op != OPCODE_JUMPDEST:
-            return False
+        if required_at[pc] == REQUIRE_LABEL:
+            if op != OPCODE_JUMPDEST and op != OPCODE_ENTERSUB:
+                return False
         if required_at[pc] == REQUIRE_ENTERSUB and op != OPCODE_ENTERSUB:
             return False
 
@@ -971,16 +993,15 @@ def validate(code: Bytes[MAX_CODE_SIZE]) -> bool:
                 dest_op: uint8 = convert(convert(slice(code, dest, 1), bytes1), uint8)
                 if dest_op != OPCODE_ENTERSUB:
                     return False
-            if required_at[dest] != REQUIRE_NONE and required_at[dest] != REQUIRE_ENTERSUB:
-                return False
+            # A LABEL requirement upgrades to ENTERSUB: both can hold.
             required_at[dest] = REQUIRE_ENTERSUB
-            # Call edge: need flows from the callee to this region.
+            # Call edge: the summaries flow from the callee to this region.
             if edge_count >= MAX_EDGES:
                 return False
             edge_next[edge_count]   = edge_head[dest]
             edge_parent[edge_count] = entry
             edge_off[edge_count]    = new_offset
-            edge_fall[edge_count]   = False
+            edge_enter[edge_count]   = False
             edge_head[dest] = edge_count + 1
             edge_count += 1
             # Seed the callee in its canonical state, framed.
@@ -1044,11 +1065,10 @@ def validate(code: Bytes[MAX_CODE_SIZE]) -> bool:
                 # Already visited: dest is a known instruction boundary,
                 # so its opcode can be checked directly.
                 dest_op: uint8 = convert(convert(slice(code, dest, 1), bytes1), uint8)
-                if dest_op != OPCODE_JUMPDEST:
+                if dest_op != OPCODE_JUMPDEST and dest_op != OPCODE_ENTERSUB:
                     return False
-            if required_at[dest] != REQUIRE_NONE and required_at[dest] != REQUIRE_JUMPDEST:
-                return False
-            required_at[dest] = REQUIRE_JUMPDEST
+            if required_at[dest] == REQUIRE_NONE:
+                required_at[dest] = REQUIRE_LABEL
             if wl_tail >= MAX_WORKLIST:
                 return False
             worklist[wl_tail] = Continuation(
@@ -1069,11 +1089,10 @@ def validate(code: Bytes[MAX_CODE_SIZE]) -> bool:
                 # Already visited: dest is a known instruction boundary,
                 # so its opcode can be checked directly.
                 dest_op: uint8 = convert(convert(slice(code, dest, 1), bytes1), uint8)
-                if dest_op != OPCODE_JUMPDEST:
+                if dest_op != OPCODE_JUMPDEST and dest_op != OPCODE_ENTERSUB:
                     return False
-            if required_at[dest] != REQUIRE_NONE and required_at[dest] != REQUIRE_JUMPDEST:
-                return False
-            required_at[dest] = REQUIRE_JUMPDEST
+            if required_at[dest] == REQUIRE_NONE:
+                required_at[dest] = REQUIRE_LABEL
             # Branch target:
             if wl_tail >= MAX_WORKLIST:
                 return False
@@ -1167,7 +1186,7 @@ def validate(code: Bytes[MAX_CODE_SIZE]) -> bool:
             if parent_growth > growth[par]:
                 growth[par] = parent_growth
             parent_depth: int256 = call_depth[node]
-            if not edge_fall[ei]:
+            if not edge_enter[ei]:
                 parent_depth += 1
             if parent_depth > call_depth[par]:
                 call_depth[par] = parent_depth
@@ -1299,7 +1318,7 @@ Validated contracts are more secure than ordinary contracts: they cannot execute
 
 The canonical validation contract is consensus-critical, and correcting a faulty validator is hard: invalid contracts it admitted are already on the blockchain and cannot be removed.  A mechanism to retroactively invalidate them may be needed; like the header layout, it is deferred.  (Fork-driven changes to validity — see Validation — need no such mechanism: contracts validated under earlier forks simply remain deployed.)
 
-Validation is linear in the size of the code and its gas is paid by the creator, so it cannot be used as a denial of service attack.
+Validation is linear in the size of the code and its gas is paid by the creator, so it cannot be used to amplify work.
 
 ## Copyright
 


### PR DESCRIPTION
Clarify the role of `ENTERSUB` in control flow and update related explanations throughout the document.
