### PR TITLE
Update EIP-8141: 8141 nits

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -379,19 +379,23 @@ def signature_gas(sig):
 
 signature_verification_cost = sum(signature_gas(sig) for sig in tx.signatures)
 
+frame_data_cost = sum(calldata_cost(frame.data) for frame in tx.frames)
+signature_data_cost = sum(
+    calldata_cost(sig.signer) + calldata_cost(sig.msg) + calldata_cost(sig.signature)
+    for sig in tx.signatures
+)
+
 tx_gas_limit = (
     FRAME_TX_INTRINSIC_COST
     + len(tx.frames) * FRAME_TX_PER_FRAME_COST
-    + calldata_cost(rlp(tx.signatures))
-    + calldata_cost(rlp(tx.frames))
+    + frame_data_cost
+    + signature_data_cost
     + signature_verification_cost
     + sum(frame.gas_limit for all frames)
 )
 ```
 
 Where `calldata_cost` is calculated per standard [EIP-7623](./eip-7623.md) rules.
-
-The calldata cost for `rlp(tx.signatures)` is charged over the signature objects exactly as included in the transaction, including the scheme-dependent `signer` bytes.
 
 The total fee is defined as:
 

--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -452,6 +452,7 @@ The `scope` operand is a bitmask. Define the following constants:
 
 The behavior of `APPROVE` is defined as follows:
 
+- If the current transaction is not a frame transaction, an exceptional halt occurs.
 - If `ADDRESS != resolved_target`, revert.
 - Ensure that `scope` is one of the caller's allowed scopes in `frame.flags`, otherwise revert.
     - To check this, evaluate that `scope != 0` and `scope & ~(frame.flags & APPROVE_SCOPE_MASK) == 0`.
@@ -474,6 +475,8 @@ The behavior of `APPROVE` is defined as follows:
 ### Introspection
 
 The instructions in this section provide the needed introspection capabilities of the new frame transaction type and the frame objects themselves, including some runtime information like the execution result status.
+
+The instructions in this section are defined only during the execution of a frame transaction. Executing any of them in the context of any other transaction type results in an exceptional halt.
 
 #### `TXPARAM` Instruction `(0xb0)`
 


### PR DESCRIPTION
- note that exceptional halt occurs when frame-related ops are called outside frame tx context.
- charge for actual data, not rlp encoded