### PR TITLE
Update EIP-8045: Move to Review

### DIFF
--- a/EIPS/eip-8045.md
+++ b/EIPS/eip-8045.md
@@ -4,7 +4,7 @@ title: Exclude slashed validators from proposing
 description: Modify proposer selection to exclude slashed validators, improving network resilience and performance after mass slashings
 author: Francesco D'Amato (@fradamt), Barnabas Busa (@barnabasbusa)
 discussions-to: https://ethereum-magicians.org/t/eip-8045-exclude-slashed-validators-from-proposing/25850
-status: Draft
+status: Review
 type: Standards Track
 category: Core
 created: 2025-10-16


### PR DESCRIPTION
This proposal is CFI for Glamsterdam per [EIP-7773](https://eips.ethereum.org/EIPS/eip-7773) and is therefore being promoted to `Review` status

