### PR TITLE
Update EIP-7928: clarify degelation resolution in 7928

### DIFF
--- a/EIPS/eip-7928.md
+++ b/EIPS/eip-7928.md
@@ -166,6 +166,8 @@ Post-state costs (e.g., `GAS_NEW_ACCOUNT` for calls to empty accounts, `GAS_SELF
 
 When a call target has an [EIP-7702](./eip-7702.md) delegation, the target is accessed to resolve the delegation, which also accesses the delegated address. The delegated address requires its own `access_cost` check before being accessed; if that gas check fails, the delegated address MUST NOT appear in the BAL. Otherwise both the original call target and the delegated address MUST appear in the BAL, including when the call subsequently fails its sender-balance (`sender_balance >= value`) or call-stack-depth check, since the delegation is resolved before those checks.
 
+The same rule applies to the topmost call frame: when `tx.to` has a delegation, the delegated address's access is charged at runtime per [EIP-2780](./eip-2780.md). If gas cannot cover this charge, the delegated address MUST NOT appear in the BAL; otherwise it MUST appear.
+
 Note: Delegated accounts cannot be empty, so `GAS_NEW_ACCOUNT` never applies when resolving delegations.
 
 #### SSTORE
@@ -264,7 +266,7 @@ Record **post‑transaction nonces** for:
 - **Exceptional halts:** Record the **final** nonce and balance of the sender, and the **final** balance of the fee recipient after each transaction. State changes from the reverted call are discarded, but all accessed addresses MUST be included. If no changes remain, addresses are included with empty lists; if storage was read, the corresponding keys MUST appear in `storage_reads`.
 - **Pre‑execution system contract calls:** All state changes MUST use `block_access_index = 0`.
 - **Post‑execution system contract calls:** All state changes MUST use `block_access_index = len(transactions) + 1`.
-- **EIP-7702 Delegations:** The authority address MUST be included with nonce and code changes after any successful delegation set, update, or clear. If authorization fails after the authority address has been loaded and added to `accessed_addresses` (per [EIP-2929](./eip-2929.md)), it MUST still be included with an empty change set; if authorization fails before the authority is loaded, it MUST NOT be included. The delegation target MUST NOT be included during delegation creation or modification and MUST only be included once it is actually loaded as an execution target (e.g., via `CALL`/`CALLCODE`/`DELEGATECALL`/`STATICCALL` under authority execution).
+- **EIP-7702 Delegations:** The authority address MUST be included with nonce and code changes after any successful delegation set, update, or clear. If authorization fails after the authority address has been loaded and added to `accessed_addresses` (per [EIP-2929](./eip-2929.md)), it MUST still be included with an empty change set; if authorization fails before the authority is loaded, it MUST NOT be included. The delegation target MUST NOT be included during delegation creation or modification and MUST only be included once it is actually loaded as an execution target (via `CALL`/`CALLCODE`/`DELEGATECALL`/`STATICCALL`, or the topmost call frame when `tx.to` has a delegation; see [EIP-7702 Delegation](#eip-7702-delegation)).
 - **EIP‑4895 (Consensus layer withdrawals):** Recipients are recorded with their final balance after the withdrawal.
 - **EIP‑2935 (block hash):** Record system contract storage diffs of the **single** updated storage slot in the ring buffer.
 - **EIP‑4788 (beacon root):** Record system contract storage diffs of the **two** updated storage slots in the ring buffer.


### PR DESCRIPTION
This PR clarifies an edge case, that for top-most call frame, if the tx.to has a delegation, after EIP-2780 runtime gas charging, the delegated address itself must be included in the BAL.