### PR TITLE
Update EIP-8282: set predeploy addresses from current reference bytecode

### DIFF
--- a/EIPS/eip-8282.md
+++ b/EIPS/eip-8282.md
@@ -42,8 +42,8 @@ The `0x03`/`0x04` request types MUST be unique across **all** active [EIP-7685](
 
 | Name | Value | Comment |
 | --- | --- | --- |
-| `BUILDER_DEPOSIT_CONTRACT_ADDRESS` | `0x0000000000000000000000000000000001008282` <!-- placeholder --> | Predeploy address of the builder deposit contract |
-| `BUILDER_EXIT_CONTRACT_ADDRESS` | `0x0000000000000000000000000000000002008282` <!-- placeholder --> | Predeploy address of the builder exit contract |
+| `BUILDER_DEPOSIT_CONTRACT_ADDRESS` | `0x0000bFF46984e3725691FA540a8C7589300D8282` | Predeploy address of the builder deposit contract |
+| `BUILDER_EXIT_CONTRACT_ADDRESS` | `0x000064D678505ad48F8cCb093BC65613800E8282` | Predeploy address of the builder exit contract |
 | `BUILDER_DEPOSIT_REQUEST_TYPE` | `0x03` | [EIP-7685](./eip-7685.md) request-type byte for builder deposits |
 | `BUILDER_EXIT_REQUEST_TYPE` | `0x04` | [EIP-7685](./eip-7685.md) request-type byte for builder exits  |
 | `SYSTEM_ADDRESS` | `0xfffffffffffffffffffffffffffffffffffffffe` | Address that invokes the end-of-block system call (as in [EIP-7002](./eip-7002.md)) |
@@ -60,7 +60,7 @@ The `0x03`/`0x04` request types MUST be unique across **all** active [EIP-7685](
 
 ### Deployment
 
-Each predeploy is deployed exactly as the [EIP-7002](./eip-7002.md) and [EIP-7251](./eip-7251.md) request contracts are: by a one-time presigned transaction from a single-use deployer account (the Nick's-method scheme), so that `BUILDER_DEPOSIT_CONTRACT_ADDRESS` and `BUILDER_EXIT_CONTRACT_ADDRESS` are the addresses cryptographically derived from those transactions. Each contract's init code sets its `excess` slot to `EXCESS_INHIBITOR`, so no request can be enqueued until the inhibitor is cleared (see [Request fee](#request-fee)). The concrete transactions — and therefore the final addresses — will be fixed once the runtime bytecode is audited and frozen (see [Reference Implementation](#reference-implementation)).
+Each predeploy is deployed exactly as the [EIP-7002](./eip-7002.md) and [EIP-7251](./eip-7251.md) request contracts are: by a one-time presigned transaction from a single-use deployer account (the Nick's-method scheme), so that `BUILDER_DEPOSIT_CONTRACT_ADDRESS` and `BUILDER_EXIT_CONTRACT_ADDRESS` are the addresses cryptographically derived from those transactions. Each contract's init code sets its `excess` slot to `EXCESS_INHIBITOR`, so no request can be enqueued until the inhibitor is cleared (see [Request fee](#request-fee)). The addresses above are derived from the presigned deployment transactions for the current reference bytecode; they will change if the runtime bytecode changes before it is audited and frozen (see [Reference Implementation](#reference-implementation)).
 
 The deployment transactions MUST be included before the fork that activates this EIP. If there is no code at either predeploy address once the EIP is active, every block from activation onward MUST be invalid — the same handling [EIP-7002](./eip-7002.md) and [EIP-7251](./eip-7251.md) specify for their predeploys.
 


### PR DESCRIPTION
Replaces the placeholder `BUILDER_DEPOSIT_CONTRACT_ADDRESS` / `BUILDER_EXIT_CONTRACT_ADDRESS` values with the addresses derived from the presigned Nick's-method deployment transactions for the current sys-asm bytecode (post ethereum/sys-asm#52):

- deposit: `0x0000bFF46984e3725691FA540a8C7589300D8282`
- exit: `0x000064D678505ad48F8cCb093BC65613800E8282`

These are the addresses deployed on glamsterdam-devnet-7 genesis (ethereum-genesis-generator >= 6.1.3). The Deployment section note is adjusted to say the addresses track the current reference bytecode and change if it changes before audit/freeze.