### PR TITLE
Update EIP-7906: Add per-address TXDIFF views and account change flags

### DIFF
--- a/EIPS/eip-7906.md
+++ b/EIPS/eip-7906.md
@@ -105,25 +105,58 @@ We introduce an additional `TXDIFF` opcode for this purpose, complementing `TXTR
 
 #### Params
 
-| `param` | `in2`   | `in3`            | Return value        |
-|---------|---------|------------------|---------------------|
-| 0x00    | address | `slot_key` value | `slot_value_before` |
-| 0x01    | address | `slot_key` value | `slot_value_after`  |
-| 0x02    | address | must be 0        | `balance_before`    |
-| 0x03    | address | must be 0        | `balance_after`     |
-| 0x04    | address | must be 0        | `codehash_before`   |
-| 0x05    | address | must be 0        | `codehash_after`    |
+| `param` | `in2`   | `in3`            | Return value           |
+|---------|---------|------------------|------------------------|
+| 0x00    | address | `slot_key` value | `slot_value_before`    |
+| 0x01    | address | `slot_key` value | `slot_value_after`     |
+| 0x02    | address | must be 0        | `balance_before`       |
+| 0x03    | address | must be 0        | `balance_after`        |
+| 0x04    | address | must be 0        | `codehash_before`      |
+| 0x05    | address | must be 0        | `codehash_after`       |
+| 0x06    | address | must be 0        | `address_slots_count`  |
+| 0x07    | address | index `k`        | `address_slot_index`   |
+| 0x08    | address | must be 0        | `address_events_count` |
+| 0x09    | address | index `k`        | `address_event_index`  |
+| 0x0A    | address | must be 0        | `account_change_flags` |
 
-If the queried key `address`/`(address, slot)` was never modified during the transaction, `TXDIFF` returns the current live value for both the `before` and `after` variant of that param.
+If the queried key `address`/`(address, slot)` was never modified during the transaction, `TXDIFF` (params `0x00`–`0x05`) returns the current live value for both the `before` and `after` variant of that param.
+
+#### Per-Address Views
+
+Params `0x06`–`0x09` expose per-address filtered views over the two `TXTRACE` enumeration tables that carry an address column: `slots_changed` and events.
+
+The view for an `address` is the subsequence of the global table consisting of the entries belonging to that address, in the same order as the global enumeration.
+
+The count params (`0x06`, `0x08`) return the size of this view, returning `0` for an address with no entries.
+
+The index params (`0x07`, `0x09`) map a view-local index `k`, passed as `in3`, to the entry's global index in the corresponding table. The returned global index can be used directly with the per-entry `TXTRACE` params and with `EVENTDATACOPY`. If `k` is greater than or equal to the view's count, an exceptional halt occurs.
+
+#### Account Change Flags
+
+Param `0x0A` returns a bitmask summarizing all net changes to the account's state. The bits follow the field order of the account tuple `(nonce, balance, storage_root, code_hash)`:
+
+| Bit | Value | Set when                                                                                     |
+|-----|-------|----------------------------------------------------------------------------------------------|
+| 0   | `0x1` | the account nonce differs from its transaction prestate value                                |
+| 1   | `0x2` | `balance_after != balance_before`                                                            |
+| 2   | `0x4` | any storage slot of the account differs from its prestate value (`address_slots_count > 0`)  |
+| 3   | `0x8` | `codehash_after != codehash_before`                                                          |
+
+All higher bits are zero. As with all state difference semantics, a bit reflects a net difference between the transaction prestate and the state as of the opcode call: values that were modified and later restored within the transaction do not set a bit.
+
+`account_change_flags == 0` if and only if the account's state, including its entire storage, is identical to the transaction prestate.
+
+The nonce is not otherwise observable through `TXTRACE` or `TXDIFF`. Accounts whose nonce is incremented by the transaction itself, such as the sender, or by executing `CREATE`/`CREATE2`, will have bit 0 set.
 
 #### Gas Cost
 
-`TXDIFF` uses the [EIP-2929](./eip-2929.md) access list to determine its cost:
+`TXDIFF` params that may fall back to reading live state use the [EIP-2929](./eip-2929.md) access lists to determine their cost:
 
 - Storage slot params (`0x00`, `0x01`): `COLD_SLOAD_COST` (2100) if the `(address, slot)` pair is not in the accessed storage list; `WARM_STORAGE_READ_COST` (100) otherwise.
 - Balance and codehash params (`0x02`–`0x05`): `COLD_ACCOUNT_ACCESS_COST` (2600) if the address is not in the accessed addresses set; `WARM_STORAGE_READ_COST` (100) otherwise.
+- Per-address view and flags params (`0x06`–`0x0A`): a flat cost of `TXTRACE_GAS_COST`. These params are answered entirely from the transaction-local state diff and never read the live state.
 
-The accessed slot or address is added to the respective access list after the call.
+For params `0x00`–`0x05`, the accessed slot or address is added to the respective access list after the call. Params `0x06`–`0x0A` do not interact with the [EIP-2929](./eip-2929.md) access lists.
 
 `codehash_before` is equal to the empty-code hash for undeployed contracts.
 
@@ -184,6 +217,28 @@ An assertion contract would have to implement its own search over the sorted enu
 A point lookup over storage needs both an `address` and a `slot` to be unambiguous, not fitting the `TXTRACE`'s existing 2-argument `(param, in2)` shape.
 
 Balance and codehash are keyed only by `address`.
+
+### Per-Address Views
+
+Assertion contracts frequently need per-contract answers: "did this contract's storage change at all", "did this contract emit any event", "check every slot this contract changed".
+
+For storage, the address-sorted `slots_changed` enumeration makes an address's entries contiguous, so these questions are answerable with a binary search over `TXTRACE` — but every assertion author would then hand-roll that search in exactly the code where an implementation bug is as dangerous as no assertion at all.
+
+For events, no efficient workaround exists: events are enumerated in emission order, so finding one contract's events requires a linear scan over every event in the transaction. The number of unrelated events is attacker-controlled — a malicious dApp can pad a transaction with cheap logs, inflating the assertion's gas cost until it exceeds its stipend. An assertion's cost must not scale with attacker-controlled padding; per-address views make the cost proportional only to the activity of the contracts the assertion actually inspects.
+
+Both tables get the same primitive — a count and an `(address, k)` to global index mapping — rather than, for example, a "first index" param that would only suit the contiguous storage table. The view preserves the global enumeration order, so for storage `address_slot_index(address, k)` always equals `address_slot_index(address, 0) + k` as a consequence of [Results Ordering](#results-ordering), while for events `k` follows the contract's own emission order. Contracts do not need to know which table happens to be contiguous.
+
+Returning global indices, rather than duplicating every per-entry accessor in an address-keyed variant, keeps the parameter space small: one conversion call plugs into all existing `TXTRACE` params and `EVENTDATACOPY`.
+
+These params are keyed by address and take a second scalar input, matching `TXDIFF`'s `(param, address, in3)` shape, which `TXTRACE`'s two-input shape cannot express. They are therefore placed on `TXDIFF` even though their return values are indices into the `TXTRACE` enumeration space.
+
+### Account Change Flags as a Shield Assertion
+
+A common assertion is expected to be a "shield": asserting that a given account was **not** affected by the transaction. Without the flags param this requires three separate lookups — balance, codehash, and storage count — and still leaves the nonce unobserved. `account_change_flags` collapses the entire check into a single opcode call: `flags == 0` guarantees the account's state, including its full storage, is identical to the transaction prestate.
+
+Only bit 0 (nonce) adds a new observable to the diff model; the remaining bits are conjunctions of existing params. The bit ordering follows the account tuple `(nonce, balance, storage_root, code_hash)` so that the encoding is derived from the account structure rather than being arbitrary.
+
+Events are deliberately excluded from the bitmask: an emitted event is not a change to the account's state. A "the contract stayed silent" check is available separately as `address_events_count == 0`.
 
 ### Receipt Representation and Anti-DoS
 
@@ -254,8 +309,16 @@ Asserting over them will require a significant amount of gas in the worst-case.
 Assertion contracts should defend against assertion gas related issues by reading the total entry counts and ensuring these are below a safe limit.
 The framework layer calling the assertion must forward a gas stipend proportional to the entry counts it expects to process.
 
+Assertions concerned with specific contracts should use the per-address `TXDIFF` views instead of enumerating the global tables, making their gas cost independent of unrelated — and potentially attacker-controlled — entries.
+
 An assertion that runs out of gas before completing its enumeration loop has not verified the full outcome.
 Any framework built on `TXTRACE` must ensure that assertion OOG is treated as an explicit assertion revert.
+
+### Client-Side Query Cost
+
+The per-address view and flags params are flat-priced, so client implementations must answer them in constant time. A naive implementation that rescans an account's touched slots on every call could be forced into amplified work by a loop of flat-priced queries over an account with many net-restored slots.
+
+Clients should maintain incremental per-address structures alongside the existing write journal: a net-changed-slot counter (the comparison of each `SSTORE` against the slot's original value is already required for gas metering and refunds) and a per-address list of event indices. Both are constant-time per write and bounded by work the transaction has already paid for.
 
 ### The `POST_TX` Frame Mode Not Reverting Validation Prefix
 

--- a/EIPS/eip-7906.md
+++ b/EIPS/eip-7906.md
@@ -105,48 +105,51 @@ We introduce an additional `TXDIFF` opcode for this purpose, complementing `TXTR
 
 #### Params
 
-| `param` | `in2`   | `in3`            | Return value           |
-|---------|---------|------------------|------------------------|
-| 0x00    | address | `slot_key` value | `slot_value_before`    |
-| 0x01    | address | `slot_key` value | `slot_value_after`     |
-| 0x02    | address | must be 0        | `balance_before`       |
-| 0x03    | address | must be 0        | `balance_after`        |
-| 0x04    | address | must be 0        | `codehash_before`      |
-| 0x05    | address | must be 0        | `codehash_after`       |
-| 0x06    | address | must be 0        | `address_slots_count`  |
-| 0x07    | address | index `k`        | `address_slot_index`   |
-| 0x08    | address | must be 0        | `address_events_count` |
-| 0x09    | address | index `k`        | `address_event_index`  |
-| 0x0A    | address | must be 0        | `account_change_flags` |
+| `param` | `in2`   | `in3`                           | Return value                        |
+|---------|---------|---------------------------------|-------------------------------------|
+| 0x00    | address | `slot_key` value                | `slot_value_before`                 |
+| 0x01    | address | `slot_key` value                | `slot_value_after`                  |
+| 0x02    | address | must be 0                       | `balance_before`                    |
+| 0x03    | address | must be 0                       | `balance_after`                     |
+| 0x04    | address | must be 0                       | `codehash_before`                   |
+| 0x05    | address | must be 0                       | `codehash_after`                    |
+| 0x06    | address | must be 0                       | `address_slots_count`               |
+| 0x07    | address | index in `address_slots_count`  | `TXTRACE` index for `slots_changed` |
+| 0x08    | address | must be 0                       | `address_events_count`              |
+| 0x09    | address | index in `address_events_count` | `TXTRACE` index for `events_count`  |
+| 0x0A    | address | must be 0                       | `account_change_flags`              |
 
 If the queried key `address`/`(address, slot)` was never modified during the transaction, `TXDIFF` (params `0x00`–`0x05`) returns the current live value for both the `before` and `after` variant of that param.
 
-#### Per-Address Views
+#### Per-Address Remapping
 
-Params `0x06`–`0x09` expose per-address filtered views over the two `TXTRACE` enumeration tables that carry an address column: `slots_changed` and events.
-
-The view for an `address` is the subsequence of the global table consisting of the entries belonging to that address, in the same order as the global enumeration.
+Params queryalbe with `TXDIFF` `0x06`, `0x07`, `0x08`, and `0x09` expose per-address filtered views over the storage slots and events exposed via enumeration by the  `TXTRACE` opcode.
 
 The count params (`0x06`, `0x08`) return the size of this view, returning `0` for an address with no entries.
 
-The index params (`0x07`, `0x09`) map a view-local index `k`, passed as `in3`, to the entry's global index in the corresponding table. The returned global index can be used directly with the per-entry `TXTRACE` params and with `EVENTDATACOPY`. If `k` is greater than or equal to the view's count, an exceptional halt occurs.
+The index params (`0x07`, `0x09`) map a per-address, local index, passed as `in3`, to the entry's global index in the corresponding table. The returned global index can be used directly with the per-entry `TXTRACE` params and with `EVENTDATACOPY`.
+
+If `TXDIFF` recevied an invalid local index, i.e. value greater than or equal to the view's count, an exceptional halt occurs.
 
 #### Account Change Flags
 
 Param `0x0A` returns a bitmask summarizing all net changes to the account's state. The bits follow the field order of the account tuple `(nonce, balance, storage_root, code_hash)`:
 
-| Bit | Value | Set when                                                                                     |
-|-----|-------|----------------------------------------------------------------------------------------------|
-| 0   | `0x1` | the account nonce differs from its transaction prestate value                                |
-| 1   | `0x2` | `balance_after != balance_before`                                                            |
-| 2   | `0x4` | any storage slot of the account differs from its prestate value (`address_slots_count > 0`)  |
-| 3   | `0x8` | `codehash_after != codehash_before`                                                          |
+| Binary | Set when                                                                                    |
+|--------|---------------------------------------------------------------------------------------------|
+| 0b0001 | the account nonce differs from its transaction prestate value                               |
+| 0b0010 | `balance_after != balance_before`                                                           |
+| 0b0100 | any storage slot of the account differs from its prestate value (`address_slots_count > 0`) |
+| 0b1000 | `codehash_after != codehash_before`                                                         |
 
-All higher bits are zero. As with all state difference semantics, a bit reflects a net difference between the transaction prestate and the state as of the opcode call: values that were modified and later restored within the transaction do not set a bit.
+All higher bits are set to zero.
 
-`account_change_flags == 0` if and only if the account's state, including its entire storage, is identical to the transaction prestate.
+A set bit reflects a net difference between the transaction prestate and the state as of the opcode call.
+Values that were modified and later restored within the transaction do not set a bit.
 
-The nonce is not otherwise observable through `TXTRACE` or `TXDIFF`. Accounts whose nonce is incremented by the transaction itself, such as the sender, or by executing `CREATE`/`CREATE2`, will have bit 0 set.
+`account_change_flags == 0` if and only if the account's internal state, including its entire storage, is identical to the transaction prestate.
+
+The actual nonce value is not observable through `TXTRACE` or `TXDIFF`.
 
 #### Gas Cost
 
@@ -222,21 +225,15 @@ Balance and codehash are keyed only by `address`.
 
 Assertion contracts frequently need per-contract answers: "did this contract's storage change at all", "did this contract emit any event", "check every slot this contract changed".
 
-For storage, the address-sorted `slots_changed` enumeration makes an address's entries contiguous, so these questions are answerable with a binary search over `TXTRACE` — but every assertion author would then hand-roll that search in exactly the code where an implementation bug is as dangerous as no assertion at all.
+For events, no efficient workaround exists: events are enumerated in emission order, so finding one contract's events requires a linear scan over every event in the transaction. The number of unrelated events is attacker-controlled — a malicious dApp can pad a transaction with cheap logs, inflating the assertion's gas cost until it exceeds its stipend.
+ 
+The per-address views make the cost proportional only to the activity of the contracts the assertion actually inspects.
 
-For events, no efficient workaround exists: events are enumerated in emission order, so finding one contract's events requires a linear scan over every event in the transaction. The number of unrelated events is attacker-controlled — a malicious dApp can pad a transaction with cheap logs, inflating the assertion's gas cost until it exceeds its stipend. An assertion's cost must not scale with attacker-controlled padding; per-address views make the cost proportional only to the activity of the contracts the assertion actually inspects.
-
-Both tables get the same primitive — a count and an `(address, k)` to global index mapping — rather than, for example, a "first index" param that would only suit the contiguous storage table. The view preserves the global enumeration order, so for storage `address_slot_index(address, k)` always equals `address_slot_index(address, 0) + k` as a consequence of [Results Ordering](#results-ordering), while for events `k` follows the contract's own emission order. Contracts do not need to know which table happens to be contiguous.
-
-Returning global indices, rather than duplicating every per-entry accessor in an address-keyed variant, keeps the parameter space small: one conversion call plugs into all existing `TXTRACE` params and `EVENTDATACOPY`.
-
-These params are keyed by address and take a second scalar input, matching `TXDIFF`'s `(param, address, in3)` shape, which `TXTRACE`'s two-input shape cannot express. They are therefore placed on `TXDIFF` even though their return values are indices into the `TXTRACE` enumeration space.
+Returning global indices keeps the parameter space small, as one conversion call plugs into all existing `TXTRACE` params and `EVENTDATACOPY`.
 
 ### Account Change Flags as a Shield Assertion
 
 A common assertion is expected to be a "shield": asserting that a given account was **not** affected by the transaction. Without the flags param this requires three separate lookups — balance, codehash, and storage count — and still leaves the nonce unobserved. `account_change_flags` collapses the entire check into a single opcode call: `flags == 0` guarantees the account's state, including its full storage, is identical to the transaction prestate.
-
-Only bit 0 (nonce) adds a new observable to the diff model; the remaining bits are conjunctions of existing params. The bit ordering follows the account tuple `(nonce, balance, storage_root, code_hash)` so that the encoding is derived from the account structure rather than being arbitrary.
 
 Events are deliberately excluded from the bitmask: an emitted event is not a change to the account's state. A "the contract stayed silent" check is available separately as `address_events_count == 0`.
 
@@ -313,12 +310,6 @@ Assertions concerned with specific contracts should use the per-address `TXDIFF`
 
 An assertion that runs out of gas before completing its enumeration loop has not verified the full outcome.
 Any framework built on `TXTRACE` must ensure that assertion OOG is treated as an explicit assertion revert.
-
-### Client-Side Query Cost
-
-The per-address view and flags params are flat-priced, so client implementations must answer them in constant time. A naive implementation that rescans an account's touched slots on every call could be forced into amplified work by a loop of flat-priced queries over an account with many net-restored slots.
-
-Clients should maintain incremental per-address structures alongside the existing write journal: a net-changed-slot counter (the comparison of each `SSTORE` against the slot's original value is already required for gas metering and refunds) and a per-address list of event indices. Both are constant-time per write and bounded by work the transaction has already paid for.
 
 ### The `POST_TX` Frame Mode Not Reverting Validation Prefix
 

--- a/EIPS/eip-7906.md
+++ b/EIPS/eip-7906.md
@@ -226,7 +226,6 @@ Balance and codehash are keyed only by `address`.
 Assertion contracts frequently need per-contract answers: "did this contract's storage change at all", "did this contract emit any event", "check every slot this contract changed".
 
 For events, no efficient workaround exists: events are enumerated in emission order, so finding one contract's events requires a linear scan over every event in the transaction. The number of unrelated events is attacker-controlled — a malicious dApp can pad a transaction with cheap logs, inflating the assertion's gas cost until it exceeds its stipend.
- 
 The per-address views make the cost proportional only to the activity of the contracts the assertion actually inspects.
 
 Returning global indices keeps the parameter space small, as one conversion call plugs into all existing `TXTRACE` params and `EVENTDATACOPY`.


### PR DESCRIPTION
Thanks @drortirosh for the suggestion

## Summary

Extends the `TXDIFF` opcode with params `0x06`–`0x0A`, following a suggestion by @drortirosh to make per-contract questions ("did it change?", "did it emit?") answerable directly.

### Per-address views (`0x06`–`0x09`)

A single primitive defined identically for both enumerable tables that carry an address column (`slots_changed` and events): a per-address **count**, and an **`(address, k)` → global index** mapping into the corresponding `TXTRACE` table. The view preserves global enumeration order, so the returned index plugs directly into the existing per-entry `TXTRACE` params and `EVENTDATACOPY`.

The `(address, k)` shape was chosen over a "first index" param because events are enumerated in emission order, not sorted by address — a first-index only skips a prefix there. For storage, contiguity (`index(a, k) = index(a, 0) + k`) falls out of Results Ordering as a consequence, so contracts never need to know which table happens to be contiguous.

The events half fills a real gap: without it, "did contract X emit anything" requires a linear scan over every event in the transaction (~42,600 worst case), and that padding is attacker-controlled — a griefing vector against protective assertions, since assertion OOG must revert the transaction. The Rationale now records the underlying principle: **assertion gas cost must not scale with attacker-controlled padding.**

### Account change flags (`0x0A`)

A one-call "shield" assertion: a bitmask whose bits follow the account tuple order (`nonce`, `balance`, `storage_root`, `code_hash`), with the guarantee that `flags == 0` iff the account's state, including its entire storage, is identical to the transaction prestate. The nonce bit is the only new observable added to the diff model; events are deliberately excluded (not account state — use `address_events_count == 0` for "stayed silent").

### Gas and client impact

The new params read only transaction-local diff data, so they are flat-priced at `TXTRACE_GAS_COST` and do not interact with the EIP-2929 access lists. A new Security Considerations section requires clients to answer them in O(1) via incremental per-address structures (the `SSTORE`-vs-original comparison already exists for gas metering), preventing amplification through loops of flat-priced queries over accounts with many net-restored slots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
