### PR TITLE
Update EIP-8311: Apply refund for calldata floor gas

### DIFF
--- a/EIPS/eip-8311.md
+++ b/EIPS/eip-8311.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2026-06-20
-requires: 3860, 7623, 7976
+requires: 3529, 3860, 7623, 7778, 7976
 ---
 
 ## Abstract
@@ -37,9 +37,46 @@ Upon activation, the floor cost for calldata is increased to 96/96 gas per byte.
 | `STANDARD_TOKEN_COST`        | `4`   |
 | `TOTAL_COST_FLOOR_PER_TOKEN` | `24`  |
 
-Recall that `floor_tokens_in_calldata = (zero_bytes_in_calldata + nonzero_bytes_in_calldata) * 4`. The floor cost is `96` gas per calldata byte (both zero and non-zero), since `TOTAL_COST_FLOOR_PER_TOKEN * 4 = 96`. The token abstraction is retained only for consistency with [EIP-7623](./eip-7623.md) and [EIP-7976](./eip-7976.md).
+Let `tokens_in_calldata = zero_bytes_in_calldata + nonzero_bytes_in_calldata * 4`.
 
-Only `TOTAL_COST_FLOOR_PER_TOKEN` changes, from 16 to 24; the EIP-7976 `gasUsed` formula and transaction-validity rule are otherwise unchanged.
+Let `floor_tokens_in_calldata = (zero_bytes_in_calldata + nonzero_bytes_in_calldata) * 4`.
+
+Equivalently, the floor cost is `96` gas per calldata byte (both zero and non-zero), since `TOTAL_COST_FLOOR_PER_TOKEN * 4 = 96`. The token abstraction is retained only for consistency with [EIP-7623](./eip-7623.md) and [EIP-7976](./eip-7976.md).
+
+Let `isContractCreation` be a boolean indicating the respective event.
+
+Let `total_refund_gas` be the gas refund computed according to [EIP-3529](./eip-3529.md).
+
+Let `tx_gas_used` be the total amount of gas consumed by the transaction.
+
+Let `execution_gas_used` be the gas used for EVM execution after applying `total_refund_gas`.
+
+Let `INITCODE_WORD_COST` be 2 as defined in [EIP-3860](./eip-3860.md).
+
+The formula for determining the gas used per transaction changes from [EIP-7976](./eip-7976.md)'s implementation to:
+
+```python
+calldata_floor_gas = TOTAL_COST_FLOOR_PER_TOKEN * floor_tokens_in_calldata
+
+calldata_floor_gas_after_refund = calldata_floor_gas - min(floor(calldata_floor_gas // 5), total_refund_gas)
+
+tx.gasUsed = (
+    21000
+    +
+    max(
+        STANDARD_TOKEN_COST * tokens_in_calldata
+        + execution_gas_used
+        + isContractCreation * (32000 + INITCODE_WORD_COST * words(calldata)),
+        calldata_floor_gas_after_refund
+    )
+)
+```
+
+Any transaction with a gas limit below `21000 + calldata_floor_gas_after_refund` or below its intrinsic gas cost (take the maximum of these two calculations) is considered invalid.
+
+Per [EIP-7778](./eip-7778.md), block gas accounting remains `block_gas_used += max(tx_gas_used, calldata_floor_gas)`.
+
+The only behavioral change introduced by this proposal is that the calldata floor cost now follows the same gas refund rules defined in [EIP-3529](./eip-3529.md). This preserves the effectiveness of execution gas refunds under a higher calldata floor while maintaining network safety, since refunds continue to have no effect on block-level gas accounting. Consequently, the amount of calldata that can be included in a block remains bounded by the intended upper limit.
 
 ## Rationale
 


### PR DESCRIPTION
The only behavioral change introduced by this proposal is that the calldata floor cost now follows the same gas refund rules defined in [EIP-3529](./eip-3529.md). This preserves the effectiveness of execution gas refunds under a higher calldata floor while maintaining network safety, since refunds continue to have no effect on block-level gas accounting. Consequently, the amount of calldata that can be included in a block remains bounded by the intended upper limit.