### PR TITLE
Update EIP-7928: exclude the recipient when a runtime halt precedes i…

### DIFF
--- a/EIPS/eip-7928.md
+++ b/EIPS/eip-7928.md
@@ -100,7 +100,7 @@ It MUST include:
     - Targets of `CALL`, `CALLCODE`, `DELEGATECALL`, `STATICCALL` (even if they revert; see [Gas Validation Before State Access](#gas-validation-before-state-access) for inclusion conditions)
     - Target addresses of `CREATE`/`CREATE2` only once the EVM accesses the computed address: on post-access out-of-gas, on creation collision, or when creation setup increments the new account's nonce; not on address computation alone, nor when creation fails before access (e.g. insufficient sender balance for the endowment, nonce overflow, or call stack depth limit)
     - Deployed contract addresses from creation transactions, i.e. transactions with an empty `to` field, which are always included since the deployment address is unconditionally accessed during transaction setup
-    - Transaction sender and recipient addresses (even for zero-value transfers)
+    - Transaction sender and recipient addresses (even for zero-value transfers), unless the transaction halts before the recipient is loaded (see **Exceptional halts**)
     - Beneficiary addresses for `SELFDESTRUCT`
     - System contract addresses accessed during pre/post-execution; the system caller address, `SYSTEM_ADDRESS` (`0xfffffffffffffffffffffffffffffffffffffffe`), MUST NOT be included unless it experiences state access itself
     - Withdrawal recipient addresses, regardless of whether the withdrawal amount is non-zero
@@ -229,7 +229,7 @@ Record **post‑transaction** balances (`uint256`) for:
 
 For unaltered account balances:
 
-If an account’s balance changes during a transaction, but its post-transaction balance is equal to its pre-transaction balance, then the change MUST NOT be recorded in `balance_changes`. The sender and recipient address MUST be included in `AccountChanges`.
+If an account’s balance changes during a transaction, but its post-transaction balance is equal to its pre-transaction balance, then the change MUST NOT be recorded in `balance_changes`. The sender and recipient address MUST still be included in `AccountChanges`.
 
 The following special cases require addresses to be included with empty changes if no other state changes occur:
 
@@ -261,7 +261,7 @@ Record **post‑transaction nonces** for:
 - **Zero‑value transfers / Unchanged balance in transaction:** Include the address; omit from `balance_changes`.
 - **Gas refunds:** Record the **final** balance of the sender after each transaction.
 - **Block rewards:** Record the **final** balance of the fee recipient after each transaction.
-- **Exceptional halts:** Record the **final** nonce and balance of the sender, and the **final** balance of the fee recipient after each transaction. State changes from the reverted call are discarded, but all accessed addresses MUST be included. If no changes remain, addresses are included with empty lists; if storage was read, the corresponding keys MUST appear in `storage_reads`.
+- **Exceptional halts:** Record the **final** nonce and balance of the sender, and the **final** balance of the fee recipient after each transaction. State changes from the reverted call are discarded, but all accessed addresses MUST be included. If no changes remain, addresses are included with empty lists; if storage was read, the corresponding keys MUST appear in `storage_reads`. A transaction can halt on a runtime gas charge before the recipient is loaded (e.g., during [EIP-7702](./eip-7702.md) authorization processing); the recipient is then never accessed and MUST NOT be included unless accessed for another reason.
 - **Pre‑execution system contract calls:** All state changes MUST use `block_access_index = 0`.
 - **Post‑execution system contract calls:** All state changes MUST use `block_access_index = len(transactions) + 1`.
 - **EIP-7702 Delegations:** The authority address MUST be included with nonce and code changes after any successful delegation set, update, or clear. If authorization fails after the authority address has been loaded and added to `accessed_addresses` (per [EIP-2929](./eip-2929.md)), it MUST still be included with an empty change set; if authorization fails before the authority is loaded, it MUST NOT be included. The delegation target MUST NOT be included during delegation creation or modification and MUST only be included once it is actually loaded as an execution target (e.g., via `CALL`/`CALLCODE`/`DELEGATECALL`/`STATICCALL` under authority execution).


### PR DESCRIPTION
With EIP-2780, a runtime halt during authorization processing can precede the recipient load. Unaccessed recipients stay out of the BAL.
This is based on a discussion [here](https://discord.com/channels/1359927674746835211/1524359372791218227).