### PR TITLE
Update EIP-8130: renumber AA transaction types and add eth_call/eth_estimateGas RPC extension

### DIFF
--- a/EIPS/eip-8130.md
+++ b/EIPS/eip-8130.md
@@ -585,7 +585,7 @@ The delegation is only permitted when:
 - `code_size(sender) == 0` (empty account), or
 - `code(sender)` starts with the delegation designator `0xef0100` (updating an existing delegation)
 
-It will **not** replace non-delegation bytecode.
+It will not replace non-delegation bytecode.
 
 When `target` is `address(0)`, the delegation indicator is cleared and the account's code hash is reset to the empty code hash.
 

--- a/EIPS/eip-8130.md
+++ b/EIPS/eip-8130.md
@@ -712,7 +712,7 @@ Unused gas from `gas_limit` is refunded to the payer. For step 5, the protocol S
 - `status` (uint8): `0x01` = all phases succeeded (or `calls` was empty), `0x00` = one or more phases reverted. Existing tools checking `status == 1` remain correct for the success path.
 - `phaseStatuses` (uint8[]): Per-phase status array. Each entry is `0x01` (success) or `0x00` (reverted). Phases after a revert are not executed and reported as `0x00`. Empty if `calls` was empty.
 
-**`eth_estimateGas`** / **`eth_call`**: Accept the AA transaction fields (`sender`, `nonceKey`, `accountChanges`, `calls`, `expiry`, `metadata`, `payer`, `senderAuth`, `payerAuth`) alongside the standard request object and price the request as an `AA_TX_TYPE` transaction. Because authentication gas is determined by the auth blob's *shape* rather than a valid signature (see [Intrinsic Gas](#intrinsic-gas)), the request is priced from an **unsigned** representative blob; no signature is produced or verified. The sender is taken from `sender` or the standard `from` (equivalently); if both are present they MUST be equal.
+**`eth_estimateGas`** / **`eth_call`**: Accept the AA transaction fields (`sender`, `nonceKey`, `accountChanges`, `calls`, `expiry`, `metadata`, `payer`, `senderAuth`, `payerAuth`) alongside the standard request object and price the request as an `AA_TX_TYPE` transaction. Because authentication gas is determined by the auth blob's *shape* rather than a valid signature (see [Intrinsic Gas](#intrinsic-gas)), the request is priced from an **unsigned** representative blob; no signature is produced or verified. The sender is taken from `sender` or the standard `from` (equivalently) and if both are present they MUST be equal. 
 
 ### Constants
 

--- a/EIPS/eip-8130.md
+++ b/EIPS/eip-8130.md
@@ -712,12 +712,14 @@ Unused gas from `gas_limit` is refunded to the payer. For step 5, the protocol S
 - `status` (uint8): `0x01` = all phases succeeded (or `calls` was empty), `0x00` = one or more phases reverted. Existing tools checking `status == 1` remain correct for the success path.
 - `phaseStatuses` (uint8[]): Per-phase status array. Each entry is `0x01` (success) or `0x00` (reverted). Phases after a revert are not executed and reported as `0x00`. Empty if `calls` was empty.
 
+**`eth_estimateGas`** / **`eth_call`**: Accept the AA transaction fields (`sender`, `nonceKey`, `accountChanges`, `calls`, `expiry`, `metadata`, `payer`, `senderAuth`, `payerAuth`) alongside the standard request object and price the request as an `AA_TX_TYPE` transaction. Because authentication gas is determined by the auth blob's *shape* rather than a valid signature (see [Intrinsic Gas](#intrinsic-gas)), the request is priced from an **unsigned** representative blob; no signature is produced or verified. The sender is taken from `sender` or the standard `from` (equivalently); if both are present they MUST be equal.
+
 ### Constants
 
 | Name | Value | Comment |
 |------|-------|---------|
-| `AA_TX_TYPE` | `0x7B` | [EIP-2718](./eip-2718.md) transaction type |
-| `AA_PAYER_TYPE` | `0x7C` | Magic byte for payer signature domain separation |
+| `AA_TX_TYPE` | `0x79` | [EIP-2718](./eip-2718.md) transaction type |
+| `AA_PAYER_TYPE` | `0x7A` | Magic byte for payer signature domain separation |
 | `AA_BASE_COST` | 15000 | Base intrinsic gas cost |
 | `ACCOUNT_CONFIG_ADDRESS` | CREATE2-derived (resolved at deployment) | Account Configuration system contract address |
 | `K1_AUTHENTICATOR` | `address(1)` | Native secp256k1 (ECDSA) authenticator (implicit default EOA and explicitly registered k1 actors) |


### PR DESCRIPTION
## Summary

- Renumber the transaction-type constants: `AA_TX_TYPE` `0x7B → 0x79` and `AA_PAYER_TYPE` `0x7C → 0x7A`.
- Add an `eth_call` / `eth_estimateGas` RPC extension: accept the AA transaction fields (`sender`, `nonceKey`, `accountChanges`, `calls`, `expiry`, `metadata`, `payer`, `senderAuth`, `payerAuth`) and price the request as an `AA_TX_TYPE` transaction. Since authentication gas depends on the auth blob's *shape* rather than a valid signature, the request is priced from an unsigned representative blob; no signature is produced or verified.

## Test plan

- [ ] EIP validator / eipw passes
- [ ] Author review of wording