### PR TITLE
Update EIP-2780: align with recent EIP-2780 changes

### DIFF
--- a/EIPS/eip-2780.md
+++ b/EIPS/eip-2780.md
@@ -8,21 +8,14 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2020-07-11
-requires: 2718, 2929, 2930, 6780, 7523, 7623, 7702, 7708, 7904, 7928, 8037, 8038
+requires: 2718, 2929, 2930, 6780, 7523, 7623, 7702, 7708, 7928, 8037, 8038
 ---
 
 ## Abstract
 
-This EIP decomposes the flat `21,000` intrinsic transaction cost into explicit primitives, each priced to match the resources a transaction actually consumes:
+This EIP decomposes the flat `21,000` intrinsic transaction cost into explicit primitives, each priced to match the resources a transaction actually consumes. The costs of plain ETH transfers and contract creation transactions remain equal, while ETH transfers to new accounts and [7702](./eip-7702.md)-related transactions
 
-- `TX_BASE_COST = 12,000` — ECDSA recovery, the sender account's access and write, and the inclusion of the transaction in the block (which is transient and expires with history).
-- `COLD_ACCOUNT_ACCESS = 3,000` — the recipient account touch, per [EIP-8038](./eip-8038.md).
-- `TX_VALUE_COST = 4,244` — the recipient balance write performed by a value transfer.
-- `TRANSFER_LOG_COST = 1,756` — the [EIP-7708](./eip-7708.md) transfer log.
-
-A plain ETH transfer to an existing account still costs `12,000 + 3,000 + 4,244 + 1,756 = 21,000` gas. The headline number is unchanged, but it is now built from measured components rather than a single legacy constant, so each transaction pays for the work it does and nothing it does not.
-
-The gas charging is split across two phases. **Intrinsic gas** is the state-independent cost of including the transaction in a block and is the sole input to the transaction-validity check; top-level account accesses whose warmth cannot be known without state — the recipient touch and the [EIP-7702](./eip-7702.md) authority access — are charged here at the cold rate unconditionally. **Runtime gas** covers the state-dependent charges — new-account creation and delegation resolution — charged as the first frame is entered, metered in same way as inside the frame. Running out of gas in runtime does not invalidate the transaction. Instead, the transaction is included, execution is skipped, and all state changes are reverted, as for any out-of-gas halt inside a frame.
+In addition, the new primitives are split into intrinsic gas and runtime gas. **Intrinsic gas** is the state-independent cost of including the transaction in a block and is the sole input to the transaction-validity check. **Runtime gas** covers the state-dependent charges, such as new account creation and delegation resolution. Runtime gas is charged as the first frame is entered, metered in same way as inside the frame. Running out of gas in runtime does not invalidate the transaction. Instead, the transaction is included, execution is skipped, and all state changes are reverted, as for any out-of-gas halt inside a frame.
 
 This EIP does not change calldata or access-list metering.
 
@@ -35,9 +28,7 @@ This EIP replaces the constant with a decomposition into named primitives, each 
 - **Accuracy.** Signature recovery, account accesses, account writes, the transfer log, and state creation are billed separately, so cost tracks usage.
 - **State growth is internalized.** A value transfer that creates an account, like a contract-creation transaction, pays `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` in state gas. This aligns top-level value transfers with internal `CALL`-based account creation, which already pays for the new leaf, and prices the durable state cost the flat base ignored.
 - **Composability.** Pricing intrinsic cost as a sum of the same primitives used elsewhere in the gas schedule lets future repricings (e.g. of cold-account access in [EIP-8038](./eip-8038.md), or of state bytes in [EIP-8037](./eip-8037.md)) flow through automatically, without re-deriving a bespoke constant.
-
-Transaction costs fall into two groups. Some can be computed from the transaction's fields alone, such as signature recovery, the sender's account access and write, the transaction's bytes in the block, and the recipient and authority touches — charged at the cold rate, since a top-level account is loaded from cold state once per transaction. Others require reading state, such as creating a new account or resolving a delegation. This EIP splits the two: intrinsic gas is reduced to the minimum needed to include the transaction in a block and remains the sole input to the validity check, while state-dependent costs are charged at runtime, using the same metering as inside a frame. This removes the overcharging of the flat worst-case reservation, since a transaction pays a state-dependent cost only when it actually incurs it. It also allows halting in the pre-execution phase: a transaction whose gas covers inclusion but not a state-dependent charge is included, charged for the gas consumed, and reverted, exactly like an out-of-gas inside a call frame.
-
+- **No worst-case reservation.** State-dependent costs, such as new account creation and delegation resolution, are charged at runtime only when a transaction incurs them, rather than reserved up front. Intrinsic gas covers only inclusion and remains the sole validity input, so a transaction that funds inclusion but not a runtime charge is included, charged for the gas consumed, and reverted, exactly like an out-of-gas halt inside a call frame.
 
 ## Specification
 
@@ -57,7 +48,7 @@ The remaining values are defined in other EIPs and referenced here:
 | `WARM_ACCESS` | 100 | [EIP-8038](./eip-8038.md) | Warm account touch |
 | `ACCOUNT_WRITE` | 8,000 | [EIP-8038](./eip-8038.md) | First write to an account leaf |
 | `CREATE_ACCESS` | 11,000 | [EIP-8038](./eip-8038.md) | Contract-deployment account access and write |
-| `REGULAR_PER_AUTH_BASE_COST` | 7,816 | [EIP-8037](./eip-8037.md) | Per-authorization base: calldata, ECDSA recovery (per [EIP-7904](./eip-7904.md)), cold authority access, and warm writes |
+| `REGULAR_PER_AUTH_BASE_COST` | 7,816 | [EIP-8037](./eip-8037.md) | Per-authorization base: calldata, ECDSA recovery, cold authority access, and warm writes |
 | `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` | 183,600 | [EIP-8037](./eip-8037.md) | State gas for one new account leaf |
 | `STATE_BYTES_PER_AUTH_BASE × CPSB` | 35,190 | [EIP-8037](./eip-8037.md) | State gas for one 23-byte delegation indicator |
 
@@ -71,22 +62,42 @@ A transaction's intrinsic base cost is decomposed into the following explicit pr
 - `tx.to` is charged based on its type:
   - if self-transfer (`tx.sender == tx.to`), there are no charges;
   - if `None` (contract-creation transaction), charge `CREATE_ACCESS` in regular gas; the new-account state charge depends on whether the deployment target exists and is charged at runtime;
-  - otherwise, charge `COLD_ACCOUNT_ACCESS` in regular gas — the recipient touch, charged at the cold rate unconditionally.
+  - otherwise, charge `COLD_ACCOUNT_ACCESS` in regular gas (covering the recipient touch, charged at the cold rate unconditionally).
 - `tx.value` is charged based on its value:
   - if zero, there are no charges;
   - if non-zero and self-transfer, there are no charges;
   - if non-zero and contract creation, charge `TRANSFER_LOG_COST` in regular gas;
   - otherwise, charge `TRANSFER_LOG_COST + TX_VALUE_COST` in regular gas.
 - each [EIP-7702](./eip-7702.md) authorization is charged `REGULAR_PER_AUTH_BASE_COST` in regular gas.
-- calldata and access-list costs are unchanged.
 
-The recipient touch and the authority access (inside `REGULAR_PER_AUTH_BASE_COST`) are charged at the cold rate every time, even if the account would be warm — for example via an access list — keeping intrinsic gas computable without any state read. These charges replace the legacy contract-creation transaction charges and EIP-7702's flat `PER_EMPTY_ACCOUNT_COST × authorization_list_length` intrinsic charge. Calldata and access-list metering remain unchanged.
+The recipient touch and the authority access (inside `REGULAR_PER_AUTH_BASE_COST`) are charged at the cold rate every time, even if the account would be warm (for example, via an access list) keeping intrinsic gas computable without any state read. =
+
+These charges replace the legacy contract-creation transaction charges and EIP-7702's flat `PER_EMPTY_ACCOUNT_COST × authorization_list_length` intrinsic charge.
+
+Calldata and access-list metering remain unchanged.
 
 ### Runtime gas costs
 
-Once the transaction passes the intrinsic gas check, the state-dependent charges are applied at runtime — as the first frame is entered — drawing from the same gas the transaction supplies. Like every charge in this EIP, each runtime charge is split into regular gas and state gas per [EIP-8037](./eip-8037.md): account accesses and writes are regular gas, while durable state growth (new account leaves and net-new delegation bytes) is state gas. This mirrors how a `CALL` frame is metered: accesses, account creation, and writes are charged as state is touched, not up front. Because these charges require state access, they are evaluated only after [EIP-7702](./eip-7702.md) authorizations are applied.
+Once the transaction passes the intrinsic gas check, the state-dependent gas costs (i.e., runtime costs) are applied. The runtime charges happen in a distinct window — the pre-execution phase — after the transaction is already deemed valid but before the first EVM frame is entered. This phase includes the following action, by order:
 
-While processing each valid authorization — the per-authority rules of [EIP-8037](./eip-8037.md) ensure each charge below is applied at most once per authority:
+1. The available gas is split into `gas_left` and `state_gas_reservoir`, and all the gas accounting counters are initialized, per [EIP-8037](./eip-8037.md);
+2. [EIP-7702](./eip-7702.md) authorizations are processed;
+3. The recipient account is added to the [EIP-7928](./eip-7928.md)'s Block-Level Access List (its access was already charged at the cold rate at the intrinsic phase, and it is warm from transaction start);
+4. The remaining account creation and access costs are applied.
+
+Like every charge in this EIP, each runtime charge is split into regular gas and state gas per [EIP-8037](./eip-8037.md): account accesses and writes are regular gas, while durable state growth (new account leaves and net-new delegation bytes) is state gas. This mirrors how a `CALL` frame is metered: accesses, account creation, and writes are charged as state is touched, not up front.
+
+Running out of gas during these runtime charges does **not** invalidate the transaction. Validity is decided solely by the intrinsic gas check.
+
+If the transaction goes out-of-gas in this pre-execution phase, the sender pays for all gas consumed, and all state changes are reverted, including any [EIP-7702](./eip-7702.md) delegations. By contrast, if the transaction goes out-of-gas after entering the first EVM frame, the already applied delegations during pre-execution phase stay in place, per [EIP-7702](./eip-7702.md), and all runtime charges remain consumed.
+
+If a contract-creation transaction's initcode reverts, the transaction remains valid and any state gas charged at runtime is refilled in last-in, first-out (LIFO) order, per [EIP-8037](./eip-8037.md): the portion the charge drew from `gas_left` is credited back to `gas_left`, and only the remainder returns to the `state_gas_reservoir`.
+
+On an exceptional halt, the same LIFO refill applies. A plain value transfer to a new account executes no code and so cannot revert. Its new-account state charge is therefore never rolled back this way. The exception is a transfer to an empty precompile, which does execute and can fail, though on mainnet all precompiles are already prefunded.
+
+#### [EIP-7702](./eip-7702.md) authorization processing
+
+While processing each valid authorization, the following charges are applied **at most once per authority**:
 
 - if the authority account does not already exist, charge `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` in state gas for the new account leaf;
 - if this is the first write to the authority within the transaction, charge `ACCOUNT_WRITE` in regular gas; the charge is skipped when the write is already paid for, namely when the authority:
@@ -95,20 +106,16 @@ While processing each valid authorization — the per-authority rules of [EIP-80
   - is `tx.to` of a value-bearing transaction, covered by `TX_VALUE_COST`;
 - if the authorization writes the 23-byte delegation indicator into a previously empty slot (net-new delegation bytes), charge `STATE_BYTES_PER_AUTH_BASE × CPSB` in state gas.
 
-`REGULAR_PER_AUTH_BASE_COST` already prices the authority access at the cold rate at the intrinsic phase, so no account-access charge is added at runtime for the authority; the authority is added to `accessed_addresses`, per [EIP-7702](./eip-7702.md).
+For each authorization, after the gas charges of that authorization are processed, the authority is added to `accessed_addresses`, per [EIP-7702](./eip-7702.md).
 
-Then the recipient account is added to the BAL — its access was already charged at the cold rate at the intrinsic phase, and it is warm from transaction start — and unless the transaction is a self-transfer or a contract creation:
+#### Account creation and access charges
+
+If the transaction is not a self-transfer nor a contract creation, then the following charges are applied:
 
 - if the recipient is non-existent and `tx.value > 0`, charge `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` in state gas;
-- if the recipient is an [EIP-7702](./eip-7702.md) delegated account, additionally charge the delegation-target access in regular gas — `COLD_ACCOUNT_ACCESS` if cold, `WARM_ACCESS` if warm.
+- if the recipient is an [EIP-7702](./eip-7702.md) delegated account, additionally charge the delegation-target access in regular gas: `COLD_ACCOUNT_ACCESS` if cold, `WARM_ACCESS` if warm.
 
-For a contract-creation transaction, the account at the deployment address is loaded instead; if it does not already exist, per the existence rule of [EIP-8037](./eip-8037.md), charge `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` in state gas. Whether the target exists can only be determined by reading state, so the check is part of the runtime phase.
-
-The first frame is then entered with the gas remaining after these runtime charges.
-
-Running out of runtime gas does **not** invalidate the transaction. Validity is decided solely by the intrinsic gas check, which needs no state access; the runtime charges, which do, can never retroactively invalidate an already-validated transaction. On out-of-gas in this pre-execution phase the transaction is included, halts before the first frame is entered, the sender pays for all gas consumed, and all state changes are reverted — including any [EIP-7702](./eip-7702.md) delegations. An out-of-gas *inside* the frame, by contrast, leaves the applied delegations in place, per [EIP-7702](./eip-7702.md), and their runtime charges remain consumed.
-
-If a contract-creation transaction's initcode reverts, the transaction remains valid and any `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` charged at runtime is refilled in last-in, first-out (LIFO) order, per [EIP-8037](./eip-8037.md): the portion the charge drew from `gas_left` is credited back to `gas_left`, and only the remainder returns to the `state_gas_reservoir`. On an exceptional halt the same LIFO refill applies. A plain value transfer to a new account executes no code and so cannot revert; its new-account state charge is therefore never rolled back this way. The exception is a transfer to an empty precompile, which does execute and can fail — though on mainnet all precompiles are already prefunded.
+For a contract-creation transaction, if the deployment address does not already exist, per the existence rule of [EIP-8037](./eip-8037.md), charge `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` in state gas.
 
 ### Transaction reference cases
 

--- a/EIPS/eip-8037.md
+++ b/EIPS/eip-8037.md
@@ -71,37 +71,31 @@ At the block level, only the gas used in the bottleneck resource is considered w
 
 Before transaction execution, inclusion of a transaction in a block requires that:
 
-1. The transaction's **intrinsic costs are not higher than [EIP-7825](./eip-7825.md)'s transaction cap**. Concretely, `max(intrinsic_regular_gas, calldata_floor_gas_cost) <= TX_MAX_GAS_LIMIT`, where `intrinsic_regular_gas` includes all the intrinsic costs not associated with state created (i.e., base transaction cost, calldata, access lists, authorization base costs).
+1. The transaction's **intrinsic gas is not higher than [EIP-7825](./eip-7825.md)'s transaction cap**. Concretely, `max(intrinsic_gas, calldata_floor_gas_cost) <= TX_MAX_GAS_LIMIT`. Under [EIP-2780](./eip-2780.md), `intrinsic_gas` is state-independent and charged entirely in regular-gas; there is no intrinsic state-gas component.
 2. For each gas dimension, the **cumulative gas used of all previous transactions added to the transaction's contribution does not exceed the block gas limit**. Concretely, `min(TX_MAX_GAS_LIMIT, tx.gas) <= regular_gas_available` and `tx.gas <= state_gas_available`, where `regular_gas_available = block_env.block_gas_limit - block_output.block_regular_gas_used` and `state_gas_available = block_env.block_gas_limit - block_output.block_state_gas_used`.
 
 This check is performed before transaction inclusion in a block.
 
-`intrinsic_regular_gas` is the sum of:
+`intrinsic_gas` is the state-independent intrinsic cost defined by [EIP-2780](./eip-2780.md), charged entirely in regular-gas (base transaction cost, calldata, access lists, the recipient touch, value costs, and per-authorization base costs). It is the sole input to the transaction-validity check.
 
-- Transaction base cost
-- Calldata cost
-- Access list gas cost
-- Authorizations regular gas cost (`ACCOUNT_WRITE` + `REGULAR_PER_AUTH_BASE_COST` per authorization)
-- Create transaction regular gas cost (`CREATE_ACCESS` if it is a create tx)
-
-`intrinsic_state_gas` is the sum of:
-
-- Authorizations state gas cost ((`STATE_BYTES_PER_NEW_ACCOUNT` + `STATE_BYTES_PER_AUTH_BASE`) x `CPSB` per authorization)
-- Create transaction state gas (`STATE_BYTES_PER_NEW_ACCOUNT` x `CPSB` if it is a create tx)
+All state-dependent charges — new account creation and [EIP-7702](./eip-7702.md) delegation costs — are no longer part of intrinsic gas. Per [EIP-2780](./eip-2780.md), they are **runtime charges** applied in the pre-execution phase, after the transaction is deemed valid but before the first EVM frame is entered.
 
 #### Transaction-level gas accounting (reservoir model)
 
-Since transactions have a single gas limit parameter (`tx.gas`), gas accounting is enforced through a **reservoir model**, in which `gas_left` and `state_gas_reservoir` are initialized as follows:
+Since transactions have a single gas limit parameter (`tx.gas`), gas accounting is enforced through a **reservoir model**. The gas is split into `gas_left` and `state_gas_reservoir`, and all gas counters are initialized, during the pre-execution phase defined by [EIP-2780](./eip-2780.md). This phase occurs after the transaction has passed the intrinsic gas check but before the first EVM frame is entered.
+
+This EIP defines how the split and the counters are computed. The remaining accounting rules of the pre-execution phase (authorization processing, recipient warming, and the runtime account-creation and access charges) is specified in [EIP-2780](./eip-2780.md).
+
+`gas_left` and `state_gas_reservoir` are initialized as follows:
 
 ```python
-intrinsic_gas = intrinsic_regular_gas + intrinsic_state_gas
 execution_gas = tx.gas - intrinsic_gas
-regular_gas_budget = TX_MAX_GAS_LIMIT - intrinsic_regular_gas
+regular_gas_budget = TX_MAX_GAS_LIMIT - intrinsic_gas
 gas_left = min(regular_gas_budget, execution_gas)
-state_gas_reservoir = execution_gas - gas_left + create_state_gas
+state_gas_reservoir = execution_gas - gas_left
 ```
 
-Here `create_state_gas` is the contract-creation component of `intrinsic_state_gas` (`STATE_BYTES_PER_NEW_ACCOUNT × CPSB` for contract-creation transactions, `0` otherwise). It is counted in `intrinsic_gas` for transaction validation, but it is seeded into the reservoir rather than pre-consumed: the corresponding charge is applied conditionally at execution time (see [Gas accounting for new accounts](#gas-accounting-for-new-accounts)).
+Because [EIP-2780](./eip-2780.md) makes intrinsic gas state-independent, no state-gas component is subtracted from `tx.gas` here and none is seeded into the reservoir. The state-dependent costs are applied as runtime charges — later in the pre-execution phase and during execution — drawing from `state_gas_reservoir` first and from `gas_left` once the reservoir is exhausted.
 
 This means that the `state_gas_reservoir` holds gas that exceeds [EIP-7825](./eip-7825.md)'s budget. Additionally, three new counters are introduced:
 
@@ -154,7 +148,7 @@ State-gas accounting for `CALL*` and `CREATE`/`CREATE2` operations is performed 
 
 The code-deposit portion (`L × CPSB`) is unaffected by this rule and is charged at code-deposit time as usual.
 
-The same conditional rule applies to top-level contract-creation transactions. The `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` create component of `intrinsic_state_gas` participates in transaction validation unchanged — the transaction must be able to afford the worst case without any state access — but it is not pre-consumed: it is seeded into `state_gas_reservoir` (see the reservoir model above), and the charge is applied when transaction setup accesses the deployment address (an access [EIP-7928](./eip-7928.md) always records), only if the destination does not already exist. The seeding guarantees the charge can always be covered, so transaction validity is unaffected. If the transaction reverts or halts (including an address collision), any charged portion is refilled by the rules below, and the unspent reservoir is returned to the sender by the normal end-of-transaction settlement.
+The same conditional rule applies to top-level contract-creation transactions. Under [EIP-2780](./eip-2780.md) the `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` account-creation charge is not part of intrinsic gas and is not reserved up front; it is applied as a runtime charge in the pre-execution phase, when transaction setup accesses the deployment address (an access [EIP-7928](./eip-7928.md) always records), only if the destination does not already exist. Like any other state charge, it draws from `state_gas_reservoir` first and from `gas_left` once the reservoir is exhausted. If the transaction reverts or halts (including an address collision), any charged portion is refilled by the rules below, and the unspent reservoir is returned to the sender by the normal end-of-transaction settlement.
 
 Charges for account creation with `SELFDESTRUCT` are charged at the point where it executes.
 
@@ -178,28 +172,7 @@ The same rules apply when the top-level call frame reverts or halts, treating th
 
 ##### Gas accounting for [EIP-7702](./eip-7702.md) authorizations
 
-Intrinsic gas charges the worst-case state-gas cost (`(STATE_BYTES_PER_NEW_ACCOUNT + STATE_BYTES_PER_AUTH_BASE) × CPSB`) for each authorization. However, an authority's account leaf and its 23 byte delegation indicator can only be written once per transaction, even if the same authority appears in multiple authorizations. Therefore, per authorization adjustments are applied while processing the authorization list.
-
-The adjustments enforce a single invariant: the `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` account-leaf portion is charged at most once per authority and only when the account did not exist before the transaction, and the `STATE_BYTES_PER_AUTH_BASE × CPSB` delegation-indicator portion is charged at most once per authority and only when the authority ends the transaction delegated having started it undelegated.
-Processing reads the account state at two points:
-
-- **pre-transaction state**: the account state before transaction execution.
-- **current state**: the account state while processing authorizations, updated after each authorization.
-
-For each authorization, let `cur_delegated` be `true` when the authority has a non-empty delegation indicator in the **current state**, and `pre_delegated` be `true` when it had one in the **pre-transaction state**. 
-
-Authorization processing follows 3 gas accounting rules:
-
-**1. Invalid authorizations.** Invalid authorizations are skipped without per-auth processing. Their entire intrinsic state-gas portion, `(STATE_BYTES_PER_NEW_ACCOUNT + STATE_BYTES_PER_AUTH_BASE) × CPSB`, is refilled to `state_gas_reservoir` and `ACCOUNT_WRITE` is refunded to the refund counter.
-
-**2. Account-leaf refill.** If the authority's account leaf already exists in the **current state** (non-zero nonce, non-zero balance, or non-empty code), refill `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` to `state_gas_reservoir` and refund `ACCOUNT_WRITE` to the refund counter.
-
-**3. Delegation-indicator refill.**
-
-- If `authorization.address` is not `ZERO` (setting a delegation), refill `STATE_BYTES_PER_AUTH_BASE × CPSB` to `state_gas_reservoir` when `cur_delegated` or `pre_delegated` is `true`. In that case the 23-byte indicator slot is already occupied, so this authorization overwrites it without writing new bytes. Otherwise this authorization performs the net-new creation and its intrinsic charge stands.
-- If `authorization.address` is `ZERO` (clearing the delegation), refill `STATE_BYTES_PER_AUTH_BASE × CPSB` to `state_gas_reservoir`, since the clear writes no indicator. Additionally, when `cur_delegated` is `true` and `pre_delegated` is `false`, refill another `STATE_BYTES_PER_AUTH_BASE × CPSB`: the delegation being cleared was created by an earlier authorization in this same transaction, so the chain writes zero net delegation bytes and the earlier creation charge is no longer justified. This covers patterns such as `0->a->0`, where the creation by an earlier authorization is undone by a later clearing one in the same list.
-
-`execution_state_gas_used` decreases by the corresponding amount of state-gas refills. Because `execution_state_gas_used` is initialized to `0`, this refill may bring it below zero before any execution-time charges. Implementations may equivalently track the refill separately and subtract it from `tx_state_gas` when accumulating `block_state_gas_used`.
+Gas charges for [EIP-7702](./eip-7702.md) authorizations follow the specification in [EIP-2780](./eip-2780.md).
 
 #### Pre-state and post-state gas validation
 
@@ -225,12 +198,14 @@ The refund cap remains at 20% of gas used. `tx_gas_used` applies the [EIP-7623](
 At block level, instead of tracking a single `gas_used` counter, we keep track of two counters, one for `state-gas` and one for `regular-gas`:
 
 ```python
-tx_state_gas = intrinsic_state_gas - create_state_gas + tx_output.execution_state_gas_used
+tx_state_gas = tx_output.execution_state_gas_used
 tx_regular_gas = tx_gas_used_after_refund - tx_state_gas
 
 block_output.block_regular_gas_used += tx_regular_gas
 block_output.block_state_gas_used += tx_state_gas
 ```
+
+Since all state-gas charges are now applied as runtime or execution-time charges (per [EIP-2780](./eip-2780.md)), the transaction's total state-gas is fully captured by `execution_state_gas_used`; there is no separate intrinsic state-gas term to add.
 
 Note: `tx_gas_used` applies the [EIP-7623](./eip-7623.md) calldata floor after refunds, so the floor can effectively negate part of a refund when `calldata_floor_gas_cost > tx_gas_used_after_refund`. The receipt `cumulative_gas_used` uses this post-floor value.
 
@@ -257,7 +232,7 @@ gas_used_delta = parent.gas_used - parent.gas_target
 [EIP-7778](./eip-7778.md) excludes transactions refunds from the block gas accounting. If implemented together with [EIP-7778](./eip-7778.md), the block level would be updated to:
 
 ```python
-tx_state_gas = intrinsic_state_gas - create_state_gas + tx_output.execution_state_gas_used
+tx_state_gas = tx_output.execution_state_gas_used
 tx_regular_gas = tx_gas_used_before_refund - tx_state_gas
 
 block_output.block_regular_gas_used += tx_regular_gas
@@ -393,9 +368,9 @@ These figures account only for the leaf payload and its keccak256 key. They do n
 
 To solve this issue, we only apply this gas limit to regular gas, not state gas. Doing so does not weaken the intended scaling effect of [EIP-7825](./eip-7825.md), because regular gas meters all resources that benefit from parallelization. In particular, state growth does not: growing the state always requires writing to disk, a parallelizable operation, but crucially this part of the cost of a state growth operation has to be metered in regular gas, not state gas. In other words, any operation that grows the state should consume both regular gas and state gas, and the regular gas should fully account for all costs other than the long term effect of growing the state.
 
-However, we cannot statically enforce a regular gas consumption of `TX_MAX_GAS_LIMIT`, while still allowing a higher state gas consumption, because transactions only have a single gas limit parameter, `tx.gas`. This is solved through a **reservoir model**: at transaction start, execution gas is split into `gas_left` (capped at `TX_MAX_GAS_LIMIT - intrinsic_regular_gas`) and a `state_gas_reservoir` (the overflow). State gas charges draw from the reservoir first, then from `gas_left` when the reservoir is empty. Regular gas charges draw from `gas_left` only. Exceeding the regular gas budget behaves identically to running out of gas — no special error is needed.
+However, we cannot statically enforce a regular gas consumption of `TX_MAX_GAS_LIMIT`, while still allowing a higher state gas consumption, because transactions only have a single gas limit parameter, `tx.gas`. This is solved through a **reservoir model**: at transaction start, execution gas is split into `gas_left` (capped at `TX_MAX_GAS_LIMIT - intrinsic_gas`) and a `state_gas_reservoir` (the overflow). State gas charges draw from the reservoir first, then from `gas_left` when the reservoir is empty. Regular gas charges draw from `gas_left` only. Exceeding the regular gas budget behaves identically to running out of gas — no special error is needed.
 
-State-gas refills are applied in last-in, first-out (LIFO) order: because charges draw from the reservoir first and from `gas_left` last, refills credit `gas_left` first (up to the gas it borrowed, tracked by the frame-local `state_gas_from_gas_left` counter), then the reservoir. Undoing a state creation therefore restores the exact pools the charge drew from, so the two pools never drift into one another — `gas_left` is never inflated beyond `TX_MAX_GAS_LIMIT - intrinsic_regular_gas`, and regular gas is never permanently stranded in the state-only reservoir. This LIFO refill also subsumes the exceptional-halt case: refilling into a child's `gas_left` and then consuming that `gas_left` leaves the reservoir at exactly its start-of-frame value, so no dedicated reservoir-reset rule is needed (see [Gas accounting for halts and reverts](#gas-accounting-for-halts-and-reverts)).
+State-gas refills are applied in last-in, first-out (LIFO) order: because charges draw from the reservoir first and from `gas_left` last, refills credit `gas_left` first (up to the gas it borrowed, tracked by the frame-local `state_gas_from_gas_left` counter), then the reservoir. Undoing a state creation therefore restores the exact pools the charge drew from, so the two pools never drift into one another — `gas_left` is never inflated beyond `TX_MAX_GAS_LIMIT - intrinsic_gas`, and regular gas is never permanently stranded in the state-only reservoir. This LIFO refill also subsumes the exceptional-halt case: refilling into a child's `gas_left` and then consuming that `gas_left` leaves the reservoir at exactly its start-of-frame value, so no dedicated reservoir-reset rule is needed (see [Gas accounting for halts and reverts](#gas-accounting-for-halts-and-reverts)).
 
 #### Higher throughput
 
@@ -407,7 +382,7 @@ Another advantage of metering contract creation separately is that increasing th
 
 The conditional account-creation charge is compatible with this by construction. The existence read that decides the charge is the *same single access* that performs the [EIP-7610](./eip-7610.md) collision check, and it happens after the pre-access failure checks — exactly the access [EIP-7928](./eip-7928.md) already sanctions and records. Creations that fail before access charge nothing and appear nowhere in the block access list; creations that reach the access point are recorded and pay exactly for the state they are about to create. The recorded access set is identical to that of an unconditional-charge design: the charge decision introduces no additional read.
 
-An earlier revision of this EIP instead charged the account-creation portion unconditionally before the create frame (before the balance, nonce, and depth checks) and refilled it on frame exit when the destination pre-existed or creation failed. The conditional model was adopted because it removes the pre-existing-destination refill and the pre-access-failure refills (nothing was charged), aligns `CREATE`/`CREATE2` with the `CALL*` family (state-dependent charges are applied when the state is read, conditionally on what is actually created), and avoids temporarily under-budgeting the create frame of a deployment onto a pre-existing account (e.g., a pre-funded deterministic-deployment address). The remaining refill — on failure of the create frame — is shared with `CALL*`. At the transaction level the worst-case charge stays in `intrinsic_state_gas`, so transaction validity remains decidable without any state access; only the moment the gas is actually consumed changes.
+An earlier revision of this EIP instead charged the account-creation portion unconditionally before the create frame (before the balance, nonce, and depth checks) and refilled it on frame exit when the destination pre-existed or creation failed. The conditional model was adopted because it removes the pre-existing-destination refill and the pre-access-failure refills (nothing was charged), aligns `CREATE`/`CREATE2` with the `CALL*` family (state-dependent charges are applied when the state is read, conditionally on what is actually created), and avoids temporarily under-budgeting the create frame of a deployment onto a pre-existing account (e.g., a pre-funded deterministic-deployment address). The remaining refill — on failure of the create frame — is shared with `CALL*`. At the transaction level the account-creation charge is not part of intrinsic gas at all: per [EIP-2780](./eip-2780.md) it is a runtime charge, so transaction validity remains decidable without any state access while the charge is metered only when the state is actually accessed.
 
 Placement of the charge among the remaining alternatives:
 

--- a/EIPS/eip-8038.md
+++ b/EIPS/eip-8038.md
@@ -115,24 +115,6 @@ The cases for account-related operations and their corresponding costs are summa
 | `SELFDESTRUCT` | `COLD_ACCOUNT_ACCESS` or `WARM_ACCESS` | when a positive balance is sent to an empty account | — |
 | `BALANCE` / `EXTCODEHASH` | `COLD_ACCOUNT_ACCESS` or `WARM_ACCESS` | never | — |
 | `EXTCODESIZE` / `EXTCODECOPY` | `COLD_ACCOUNT_ACCESS` or `WARM_ACCESS` | never | `WARM_ACCESS` (second database read) |
-| EOA delegation ([EIP-7702](./eip-7702.md)) | `COLD_ACCOUNT_ACCESS` or `WARM_ACCESS` per authority | per authorization (intrinsic cost) | see authorizations table below |
-
-### [EIP-7702](./eip-7702.md) authorizations pricing
-
-[EIP-7702](./eip-7702.md) authorizations have two separate gas costs - intrinsic costs and access costs. Intrinsic costs are computed during transaction validation, while access costs are charged during code execution. The following table summarizes these costs:
-
-| Charge type | Regular-gas charges/refunds | State-gas charges/refills |
-| :---: | :---: | :---: |
-| Intrinsic costs (per authorization) | `ACCOUNT_WRITE` + `REGULAR_PER_AUTH_BASE_COST` charged | (`STATE_BYTES_PER_NEW_ACCOUNT` + `STATE_BYTES_PER_AUTH_BASE`) x `CPSB` charged |
-| Access costs (per warm authority) | `WARM_ACCESS` | no state-gas updates |
-| Access costs (per cold authority) | `COLD_ACCOUNT_ACCESS` | State-gas charges/refills |
-
-`REGULAR_PER_AUTH_BASE_COST` is defined in [EIP-8037](./eip-8037.md) as the sum of:
-
-- Calldata cost: 1,616 (101 bytes × 16), where 101 is the byte size of an [EIP-7702](./eip-7702.md) authorization tuple (`chain_id` 8 + `address` 20 + `nonce` 8 + `y_parity` 1 + `r` 32 + `s` 32). This is a representative size, not a worst case, since `chain_id` is a `uint256` and may exceed 8 bytes.
-- Recovering authority address (ecRecover): `PRECOMPILE_ECRECOVER` (updated by [EIP-7904](./eip-7904.md))
-- Reading nonce and code of authority (cold access): `COLD_ACCOUNT_ACCESS` (updated by this EIP)
-- Storing values in already warm account: 2 x `WARM_ACCESS`
 
 ## Rationale
 


### PR DESCRIPTION
Aligns EIP-8037 and EIP-8038 with the recent EIP-2780 changes that made intrinsic
gas state-independent, and improves the readability of EIP-2780. No spec changes.

- **EIP-2780**: editorial improvements to the abstract and intrinsic-cost breakdown
  for readability. No normative change.
- **EIP-8037**: updates the wording and accounting description to match EIP-2780 —
  a single state-independent `intrinsic_gas`, no seeded `create_state_gas` in the
  reservoir, and state-gas captured via `execution_state_gas_used`. Removes the
  EIP-7702 authorization accounting detail that now lives in EIP-2780.
- **EIP-8038**: removes the EIP-7702 authorization pricing table, now specified in
  EIP-2780.

These are alignment and editorial changes only; the specified behavior is unchanged.

