### PR TITLE
Update CONTRIBUTING.md: add rules regarding Smart Contract Code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,11 @@ The goal is to keep contributions consistent, transparent, and easy to review - 
 * Prefer SVG, but PNG is acceptable.
 * If possible, use [media queries](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Media_queries/Using) (specifically prefers-color-scheme) to support dark mode. If not, provide light-mode compatible images.
 
+#### Smart Contract Code
+
+* The Specification section must be self-contained: do not import external libraries in smart contract code (for example, `import { IExampleToken } from "@example-library/interfaces/IExampleToken.sol";` in Solidity). Instead, define any interfaces, types, or constants the specification depends on inline. External projects may change in ways that are not backward-compatible, or cease to exist entirely, which would make the specification ambiguous or impossible to interpret.
+* External library imports are acceptable in the Reference Implementation section, as it is illustrative rather than normative. Where practical, identify the library and the version used, so the import remains resolvable for future readers.
+
 #### Other
 
 * **Monitor feedback regularly**: Respond to comments or PRs that relate to your EIP, especially specification clarifications or typo fixes.


### PR DESCRIPTION
In [EIPIP#128](https://github.com/ethereum/pm/issues/2106#issuecomment-4871152430) we discussed (point 4) banning the use of external libraries in the Specifications section. This PR adds it to CONTRIBUTING.md. 

Note, it seems like CONTRIBUTING.md is a guideline for rules, not enforced (which is fine), but from an editorial point of view I think we should agree on some kind of rule basis to review future changes on. These "rules" should be concise and with proper motivation so it is clear why these rules exist. A good ruleset will improve the general quality of EIPs/ERCs/RIPs, which decreases the amount of time/energy spent in order to understand the relevant document: the "won" time can be spent on implementing these documents or improving them :smile: :+1: 