### PR TITLE
Update EIP-8279: Fix 24 -> 32 in optimum expression

### DIFF
--- a/EIPS/eip-8279.md
+++ b/EIPS/eip-8279.md
@@ -121,7 +121,7 @@ System-contract calls ([EIP-2935](./eip-2935.md), [EIP-4788](./eip-4788.md), [EI
 
 Raising opcode intrinsic costs would penalise every user, including ones who never bypass. Charging on the floor only bites when execution is too cheap to cover the floor, which is exactly the bypass case.
 
-A pure intrinsic surcharge also fails to cap the block at `gas_limit / 64`: for any added per-`SLOAD` cost `X`, the optimum bypass still yields `B = gas_limit / 64 + 24 · gas_limit / (2100 + X)` bytes, with the residual only vanishing as `X` grows large. Floor-side charging gives a closed bound directly.
+A pure intrinsic surcharge also fails to cap the block at `gas_limit / 64`: for any added per-`SLOAD` cost `X`, the optimum bypass still yields `B = gas_limit / 64 + 32 · gas_limit / (2100 + X)` bytes, with the residual only vanishing as `X` grows large. Floor-side charging gives a closed bound directly.
 
 ### Runtime extensions cannot make the floor bind on their own
 


### PR DESCRIPTION
In the Rationale section of this EIP, the optimization expression `B = gas_limit / 64 + 24 · gas_limit / (2100 + X)` is given, but the number `24` in this expression is unclear, possibly a calculation error. This value is replaced with `32` to accurately reflect the number of BALs bytes added by cold `SLOAD`