### PR TITLE
Update EIP-8130: allow expiry in initial actors at create and import

### DIFF
--- a/EIPS/eip-8130.md
+++ b/EIPS/eip-8130.md
@@ -177,7 +177,7 @@ This makes nonceless (`NONCE_KEY_MAX`) the default for every restricted (non-adm
 
 The protocol enforces one rule: an actor is **live** at `now` (the inclusion block timestamp) iff `expiry == 0 || now <= expiry` (see [Storage Layout](#storage-layout)), evaluated at inclusion. It checks only the acting key's own `expiry` and never walks authorizer lineage, so a live admin's authorization survives that admin's own later expiry or revocation; removal requires an explicit `revokeActor`.
 
-Note for wallets: `expiry` is set only by a config change (initial actors are always non-expiring), and SHOULD be placed only on non-admin actors, where a lapsed key simply stops working. Using it on an admin (`scope == 0x00`) can break valid change chains for cross-chain actor-change replay and account sync, so an admin SHOULD NOT expire unless the wallet owner deliberately plans for it and keeps a non-expiring owner in place.
+Note for wallets: `expiry` can be set at account creation and import (as part of each initial actor, committed to the derived address; see [Create Entry](#create-entry) and [Account Import](#account-import)) or later by a config change, and SHOULD be placed only on non-admin actors, where a lapsed key simply stops working. Using it on an admin (`scope == 0x00`) can break valid change chains for cross-chain actor-change replay and account sync, so an admin SHOULD NOT expire unless the wallet owner deliberately plans for it and keeps a non-expiring owner in place.
 
 #### Actor Policies
 
@@ -327,10 +327,10 @@ ACTOR_INITIALIZATION_TYPEHASH =
             "Actor(bytes32 actorId,ActorConfig config,bytes policyData)"
             "ActorConfig(address authenticator,uint8 scope,uint48 expiry)")
 
-// Per-actor. Imported actors carry scope and policyData like create; expiry is always 0
-// (expiry is added post-import via config changes). policyData follows authorizeActor's rule:
-// manager (20) || commitment (32) when POLICY is set, empty otherwise, and is hashed for real:
-configHash_i = keccak256(abi.encode(ACTORCONFIG_TYPEHASH, authenticator_i, scope_i, 0))
+// Per-actor. Imported actors carry scope, expiry, and policyData like create. policyData follows
+// authorizeActor's rule: manager (20) || commitment (32) when POLICY is set, empty otherwise,
+// and is hashed for real:
+configHash_i = keccak256(abi.encode(ACTORCONFIG_TYPEHASH, authenticator_i, scope_i, expiry_i))
 actorHash_i  = keccak256(abi.encode(ACTOR_TYPEHASH, actorId_i, configHash_i, keccak256(policyData_i)))
 
 digest = keccak256(abi.encode(
@@ -341,7 +341,7 @@ digest = keccak256(abi.encode(
 ))
 ```
 
-This digest is a typed (EIP-712-style) struct hash that intentionally omits the EIP-712 domain separator, which prevents phishing via standard wallet signing flows. The `salt` field is bound to the account address, and `chainId` binds the replay domain (matching `applySignedActorChanges`). This typed style is distinct from the packed style used for [Address Derivation](#address-derivation); that split is intentional. Imported actors are always non-expiring: implementations MUST hash `expiry = 0` into every `configHash_i` (as shown), and MUST NOT accept an actor-provided expiry at import. `policyData` is validated with `authorizeActor`'s frozen rule (well-formed `manager ‖ commitment` when `POLICY` is set, empty otherwise), written to `policy_manager`/`policy_commitment`, and hashed into `actorHash_i`; unlike create, `manager = account` is expressible here.
+This digest is a typed (EIP-712-style) struct hash that intentionally omits the EIP-712 domain separator, which prevents phishing via standard wallet signing flows. The `salt` field is bound to the account address, and `chainId` binds the replay domain (matching `applySignedActorChanges`). This typed style is distinct from the packed style used for [Address Derivation](#address-derivation); that split is intentional. Imported actors MAY carry an `expiry` (`uint48` Unix seconds; `0` = no expiry), hashed into `configHash_i` and written to the actor's config, exactly as at create. `policyData` is validated with `authorizeActor`'s frozen rule (well-formed `manager ‖ commitment` when `POLICY` is set, empty otherwise), written to `policy_manager`/`policy_commitment`, and hashed into `actorHash_i`; unlike create, `manager = account` is expressible here.
 
 On success, `importAccount` sets the `DEFAULT_EOA_REVOKED` flag (parity with `createAccount`), disabling the implicit native-secp256k1 owner. An owner who wants to keep using that key past import includes the self-actorId as a `K1_AUTHENTICATOR` entry in `initialActors` (lossless: still a full owner, now resolved through its inline default-EOA config, which clears the flag for the self).
 
@@ -434,7 +434,7 @@ execution_gas_available = gas_limit - sender_intrinsic_gas
 | `tx_payload_cost` | Standard per-byte cost over the entire RLP-serialized transaction: 16 gas per non-zero byte, 4 gas per zero byte, consistent with [EIP-2028](./eip-2028.md). Ensures all transaction fields (`account_changes`, `sender_auth`, `calls`, `metadata`, etc.) are charged for data availability |
 | `nonce_key_cost` | `NONCE_KEY_MAX`: 13,000 gas (ring-buffer replay state: 2 cold SLOADs + 1 warm SLOAD + 3 warm SSTORE resets; the ring pointer's SLOAD/SSTORE are amortized across the block). Otherwise: 22,100 gas for first use of a `nonce_key` (cold SLOAD + SSTORE set), 5,000 gas for existing keys (cold SLOAD + warm SSTORE reset) |
 | `bytecode_cost` | 0 if no create entry in `account_changes`. Otherwise: 32,000 (deployment base) + code deposit cost (200 gas per deployed byte). Byte costs for `code` are covered by `tx_payload_cost`; the create entry's initial-actor slot writes are covered by `account_changes_cost` |
-| `account_changes_cost` | Per applied create entry: one `actor_config` slot write per initial actor (22,100 gas each: cold SLOAD + SSTORE set). When an initial actor sets `POLICY`, its `policy_manager` and `policy_commitment` slots are also written (22,100 gas each), so a POLICY initial actor is 3 slot-sets (~66,300 gas) versus 1 (~22,100) for a non-policy actor; the extra `policyData` bytes are charged through `tx_payload_cost`. Expiry is not expressible at create. Per applied config change entry: auth authentication cost (same model as `sender_auth_cost`) + storage write costs for each mutated actor slot (`actor_config`; plus `policy_commitment` and `policy_manager` when `(scope & POLICY) != 0`). A config change that authorizes or revokes the **self-actor** mutates the packed account-state slot rather than an `actor_config` slot (the inline default-EOA `scope`/`expiry` and the `DEFAULT_EOA_REVOKED` bit) and, for the mutual-exclusion check between the inline secp256k1 self and a non-k1 self, additionally accesses the reserved `actor_config(self)` slot: +2,100 (cold SLOAD) for a `K1_AUTHENTICATOR` self change, or the normal `actor_config` write plus the account-state slot write for a non-secp256k1 self change. Per applied delegation entry: delegation indicator deposit (4,600 gas, 200 × 23 bytes). Per skipped config change entry (already applied): 2,100 (SLOAD to check sequence). 0 if no create, config change, or delegation entries in `account_changes` |
+| `account_changes_cost` | Per applied create entry: one `actor_config` slot write per initial actor (22,100 gas each: cold SLOAD + SSTORE set). When an initial actor sets `POLICY`, its `policy_manager` and `policy_commitment` slots are also written (22,100 gas each), so a POLICY initial actor is 3 slot-sets (~66,300 gas) versus 1 (~22,100) for a non-policy actor; the extra `policyData` bytes are charged through `tx_payload_cost`. Per applied config change entry: auth authentication cost (same model as `sender_auth_cost`) + storage write costs for each mutated actor slot (`actor_config`; plus `policy_commitment` and `policy_manager` when `(scope & POLICY) != 0`). A config change that authorizes or revokes the **self-actor** mutates the packed account-state slot rather than an `actor_config` slot (the inline default-EOA `scope`/`expiry` and the `DEFAULT_EOA_REVOKED` bit) and, for the mutual-exclusion check between the inline secp256k1 self and a non-k1 self, additionally accesses the reserved `actor_config(self)` slot: +2,100 (cold SLOAD) for a `K1_AUTHENTICATOR` self change, or the normal `actor_config` write plus the account-state slot write for a non-secp256k1 self change. Per applied delegation entry: delegation indicator deposit (4,600 gas, 200 × 23 bytes). Per skipped config change entry (already applied): 2,100 (SLOAD to check sequence). 0 if no create, config change, or delegation entries in `account_changes` |
 | `auto_delegation_cost` | Delegation indicator deposit: 4,600 gas (200 × 23 bytes for the `0xef0100 \|\| address` indicator) when a code-less `sender` is auto-delegated to `DEFAULT_ACCOUNT_ADDRESS` (Block Execution step 4). 0 otherwise. |
 
 #### Signature Format
@@ -534,11 +534,11 @@ rlp([
   0x00,               // type: create
   user_salt,          // bytes32: User-chosen uniqueness factor
   code,               // bytes: Runtime bytecode placed at account address
-  initial_actors      // Array of [actorId, authenticator, scope, policyData] tuples
+  initial_actors      // Array of [actorId, authenticator, scope, expiry, policyData] tuples
 ])
 ```
 
-Each initial actor carries an `actorId`, `authenticator`, `scope` (`uint8`; `0x00` = unrestricted admin), and `policyData` (empty, or `manager ‖ commitment` when `POLICY` is set), all committed to the derived address (see [Address Derivation](#address-derivation)) so the counterfactual address binds each initial actor's authority. Two things are **not** expressible here: `expiry`, and a self-referential `manager = account` (the account address is not yet known at commitment time). Both are added post-creation with a config change entry, which MAY accompany the create entry in the same `account_changes` array for atomic setup and, running after creation, resolves `manager = account` to a concrete address. For example, a subaccount is created with an admin actor (a delegate to the primary account, `scope = 0x00`) and a restricted app key (`SENDER | SELF_PAYER`, or `POLICY` with an external `manager` inline, or `manager = account` via an accompanying config change).
+Each initial actor carries an `actorId`, `authenticator`, `scope` (`uint8`; `0x00` = unrestricted admin), `expiry` (`uint48` Unix seconds; `0` = no expiry), and `policyData` (empty, or `manager ‖ commitment` when `POLICY` is set), all committed to the derived address (see [Address Derivation](#address-derivation)) so the counterfactual address binds each initial actor's authority. One thing is **not** expressible here: a self-referential `manager = account` (the account address is not yet known at commitment time). It is added post-creation with a config change entry, which MAY accompany the create entry in the same `account_changes` array for atomic setup and, running after creation, resolves `manager = account` to a concrete address. Wallets SHOULD keep at least one non-expiring admin among the initial actors (see the caution in [Actor Expiry](#actor-expiry)). For example, a subaccount is created with an admin actor (a delegate to the primary account, `scope = 0x00`) and a restricted app key (`SENDER | SELF_PAYER`, optionally with an `expiry`, or `POLICY` with an external `manager` inline, or `manager = account` via an accompanying config change).
 
 ##### Address Derivation
 
@@ -548,9 +548,9 @@ Addresses are derived using the CREATE2 address formula with the Account Configu
 // initial_actors MUST already be sorted by actorId (strictly ascending); reject otherwise
 
 actors_commitment = keccak256(
-    actorId_0 || authenticator_0 || scope_0 || policyData_0 ||
+    actorId_0 || authenticator_0 || scope_0 || expiry_0 || policyData_0 ||
     ...
-    actorId_n || authenticator_n || scope_n || policyData_n
+    actorId_n || authenticator_n || scope_n || expiry_n || policyData_n
 )
 
 effective_salt = keccak256(user_salt || actors_commitment)
@@ -558,7 +558,7 @@ deployment_code = DEPLOYMENT_HEADER(len(code)) || code
 address = keccak256(0xff || ACCOUNT_CONFIG_ADDRESS || effective_salt || keccak256(deployment_code))[12:]
 ```
 
-The per-actor contribution is `actorId || authenticator || scope || policyData`: the 32-byte `actorId`, 20-byte `authenticator`, 1-byte `scope`, and the `policyData` bytes (empty when `POLICY` is unset, or exactly 52 bytes — `manager (20) ‖ commitment (32)` — when `POLICY` is set). The per-actor length is fully determined by `scope`, so the concatenation remains unambiguous. Expiry does not participate. The required strictly-ascending `actorId` ordering makes the commitment canonical.
+The per-actor contribution is `actorId || authenticator || scope || expiry || policyData`: the 32-byte `actorId`, 20-byte `authenticator`, 1-byte `scope`, 6-byte `expiry` (`uint48`, big-endian; `0` = no expiry), and the `policyData` bytes (empty when `POLICY` is unset, or exactly 52 bytes — `manager (20) ‖ commitment (32)` — when `POLICY` is set). Every field except `policyData` is fixed-width and `policyData`'s length is fully determined by `scope`, so the concatenation remains unambiguous. Committing `expiry` binds each initial actor's time bound to the counterfactual address, so it cannot be altered by a front-runner. The required strictly-ascending `actorId` ordering makes the commitment canonical.
 
 `DEPLOYMENT_HEADER(n)` is a fixed 14-byte EVM loader that returns the trailing code (see [Appendix: Deployment Header](#appendix-deployment-header) for the full opcode sequence). On non-8130 chains, `createAccount()` constructs `deployment_code` and passes it as init_code to CREATE2. On 8130 chains, the protocol constructs the same `deployment_code` for address derivation but places `code` directly. Callers only provide `code`, the header is never user-facing.
 
@@ -566,7 +566,7 @@ The per-actor contribution is `actorId || authenticator || scope || policyData`:
 
 When a create entry is present in `account_changes`:
 
-1. Parse `[0x00, user_salt, code, initial_actors]` where each entry is `[actorId, authenticator, scope, policyData]`. `scope` is stored verbatim (unknown scope bits allowed, per [Actor Scope](#actor-scope)). Apply `authorizeActor`'s frozen `policyData` rule: reject unless `policyData` is exactly `manager (20) ‖ commitment (32)` when `scope & POLICY != 0`, or empty otherwise. `expiry` is not accepted in the create entry
+1. Parse `[0x00, user_salt, code, initial_actors]` where each entry is `[actorId, authenticator, scope, expiry, policyData]`. `scope` is stored verbatim (unknown scope bits allowed, per [Actor Scope](#actor-scope)). `expiry` is a `uint48` (`0` = no expiry) stored verbatim. Apply `authorizeActor`'s frozen `policyData` rule: reject unless `policyData` is exactly `manager (20) ‖ commitment (32)` when `scope & POLICY != 0`, or empty otherwise
 2. Require `initial_actors` are sorted by `actorId` in strictly ascending order; reject any unsorted set (strict ascending order also rejects duplicate `actorId` values).
 3. Reject if `code` is empty or `len(code) > MAX_CODE_SIZE` ([EIP-170](./eip-170.md): 24576 bytes), to keep the placed code within the EVM contract size limit that CREATE/CREATE2 would otherwise enforce
 4. Use `initial_actors` in the provided (sorted) order
@@ -672,7 +672,7 @@ For 8130 transactions, successful delegation updates emit a protocol-injected `D
 
 `account_changes` entries are processed in order before call execution:
 
-1. **Create entry** (if present): Register `initial_actors` in Account Config storage for `sender`, for each `[actorId, authenticator, scope, policyData]` tuple writing `actor_config` with the given `authenticator` and `scope` verbatim and `expiry = 0` (expiry is not expressible at create). When `scope & POLICY != 0`, also write `policy_manager`/`policy_commitment` from `policyData` (`manager ‖ commitment`); when unset there are no policy slots. A tuple naming the self-actorId (`actorId == bytes32(bytes20(sender))`) with `K1_AUTHENTICATOR` writes its `scope` into the inline default-EOA fields instead (`expiry = 0`). Mark the account initialized by setting its local change-sequence channel to `1` (see [Config Change Authorization](#config-change-authorization)). Initialize lock state to safe defaults: `LOCKED`/`UNLOCK_INITIATED` flags clear, `lock_union = 0`. Set the `DEFAULT_EOA_REVOKED` flag so a freshly created account does not leave a native secp256k1 owner live unless one is among `initial_actors`. Place `code` at `sender`.
+1. **Create entry** (if present): Register `initial_actors` in Account Config storage for `sender`, for each `[actorId, authenticator, scope, expiry, policyData]` tuple writing `actor_config` with the given `authenticator`, `scope`, and `expiry` verbatim. When `scope & POLICY != 0`, also write `policy_manager`/`policy_commitment` from `policyData` (`manager ‖ commitment`); when unset there are no policy slots. A tuple naming the self-actorId (`actorId == bytes32(bytes20(sender))`) with `K1_AUTHENTICATOR` writes its `scope` and `expiry` into the inline default-EOA fields instead. Mark the account initialized by setting its local change-sequence channel to `1` (see [Config Change Authorization](#config-change-authorization)). Initialize lock state to safe defaults: `LOCKED`/`UNLOCK_INITIATED` flags clear, `lock_union = 0`. Set the `DEFAULT_EOA_REVOKED` flag so a freshly created account does not leave a native secp256k1 owner live unless one is among `initial_actors`. Place `code` at `sender`.
 2. **Config change entries** (if any): Apply operations in entry order. Reject transaction if account is locked.
 3. **Delegation entries** (if any): Require admin EOA-actor delegation authority (see [Delegation Entry](#delegation-entry)). Reject if account is locked. For each entry, set `code(sender) = 0xef0100 || target` (or clear if `target` is `address(0)`). Reject if account has non-delegation bytecode.
 
@@ -957,14 +957,14 @@ interface IAccountConfiguration {
         uint48 expiry;      // Unix seconds; 0 = no expiry. Actor invalid once block.timestamp > expiry
     }
 
-    // Actor used for account creation and import. Carries scope and policyData
+    // Actor used for account creation and import. Carries scope, expiry, and policyData
     // (empty unless POLICY set, then manager[20] || commitment[32], per authorizeActor's rule).
-    // expiry is NOT expressible here and is added post-deployment via config changes
-    // (initial actors are always non-expiring).
+    // All fields are committed to the derived address at create and to the import digest.
     struct InitialActor {
         bytes32 actorId;
         address authenticator;
         uint8 scope;        // 0x00 = unrestricted (admin)
+        uint48 expiry;      // Unix seconds; 0 = no expiry
         bytes policyData;   // empty unless POLICY set; then manager[20] || commitment[32]
     }
 
@@ -1100,7 +1100,7 @@ All three cases resolve to the same `replay_id` (fee bumps included, since `repl
 
 **Cross-sender Payer Replay**: The payer signature hash binds to the resolved sender via the `sender` field (see [Signature Payload](#signature-payload)). In the EOA path where `sender` is empty in the wire format, the recovered sender address MUST be substituted into the `sender` position before computing the hash. Without this substitution, two different EOAs that construct otherwise identical transaction data (same `chain_id`, `nonce_key`, `nonce_sequence`, `expiry`, fees, `account_changes`, `calls`) would produce identical payer hashes, allowing a second EOA to reuse a payer signature originally issued for the first and drain the payer's gas deposit. The 2D nonce alone does not prevent this: `nonce_key` and `nonce_sequence` are fields in the transaction payload, so each attacker controls their own values. Substituting the recovered sender into the hash makes the payer's commitment per-sender and closes this replay path. The configured-actor path is unaffected because `sender` is non-empty by definition.
 
-**Account Creation Security**: `initial_actors` (`actorId`, `authenticator`, `scope`, and `policyData`; expiry is not expressible at create, per [Address Derivation](#address-derivation)) are salt-committed, preventing front-running of actor assignment. Wallet bytecode should be inert when uninitialized as it can be permissionlessly deployed. The create entry applies only to addresses that satisfy CREATE2 freshness. Without the nonce check, a create entry could be replayed against an EOA that has transaction history at the counterfactual address. Direct code placement also bypasses CREATE/CREATE2's [EIP-170](./eip-170.md) `MAX_CODE_SIZE` check, so the protocol enforces `len(code) <= MAX_CODE_SIZE` explicitly to keep the placed code within the EVM contract size limit.
+**Account Creation Security**: `initial_actors` (`actorId`, `authenticator`, `scope`, `expiry`, and `policyData`; see [Address Derivation](#address-derivation)) are salt-committed, preventing front-running of actor assignment or of an actor's time bound. Wallet bytecode should be inert when uninitialized as it can be permissionlessly deployed. The create entry applies only to addresses that satisfy CREATE2 freshness. Without the nonce check, a create entry could be replayed against an EOA that has transaction history at the counterfactual address. Direct code placement also bypasses CREATE/CREATE2's [EIP-170](./eip-170.md) `MAX_CODE_SIZE` check, so the protocol enforces `len(code) <= MAX_CODE_SIZE` explicitly to keep the placed code within the EVM contract size limit.
 
 ## Copyright
 


### PR DESCRIPTION
## Summary

Initial actors (via `createAccount` and `importAccount`) previously could **not** carry an `expiry` — a time bound was only settable after deployment through a config change. This PR adds an optional `uint48 expiry` to each initial actor for both paths, so a wallet can provision a time-bounded key atomically at account creation/import.

## What changed

- **`InitialActor` struct** (`IAccountConfiguration`): adds `uint48 expiry` (`0` = no expiry) between `scope` and `policyData`.
- **Create — address commitment**: `expiry` now participates in the per-actor contribution — `actorId || authenticator || scope || expiry || policyData` (6-byte big-endian). Committing it to the counterfactual address means an actor's time bound cannot be altered by a front-runner, matching how `scope` and `policyData` are already bound.
- **Create — execution/validation**: `expiry` is parsed and written to `actor_config` verbatim (or to the inline default-EOA fields for a `K1_AUTHENTICATOR` self-actor).
- **Import**: `expiry_i` is hashed into `configHash_i` of the `ActorInitialization` digest (the `ActorConfig` typehash already carried a `uint48 expiry` field, previously forced to `0`) and written to the actor's config.
- Updates gas notes, wallet guidance (Actor Expiry), and Security Considerations to reflect that `expiry` is now expressible at create/import.

## Design notes

- `expiry` is placed after `scope` to mirror the `actor_config` packing order (`authenticator | scope | expiry | reserved`).
- The existing caution stands: wallets SHOULD keep at least one non-expiring admin; an expiring sole admin can brick the account and break cross-chain reconstruction.
- The only thing still not expressible at create remains a self-referential `manager = account` (the account address is unknown at commitment time).

## Backwards compatibility

This changes the create address-derivation preimage and the import digest preimage (adds the `expiry` field to each initial actor). EIP-8130 is in Draft; there are no deployed accounts derived under the prior scheme to preserve.