### PR TITLE
Update EIP-8038: remove circular EIP-8037 dependency, reuse canonical gas symbols

### DIFF
--- a/EIPS/eip-8038.md
+++ b/EIPS/eip-8038.md
@@ -8,12 +8,12 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2025-10-03
-requires: 7904, 8037
+requires: 7904
 ---
 
 ## Abstract
 
-This EIP updates the gas cost of state-access operations to reflect Ethereum's larger state and the consequent slowdown of these operations. It raises the base costs for `STORAGE_WRITE`, `COLD_STORAGE_ACCESS`, and `COLD_ACCOUNT_ACCESS` and updates the access cost for `EXTCODESIZE` and `EXTCODECOPY`.
+This EIP updates the gas cost of state-access operations to reflect Ethereum's larger state and the consequent slowdown of these operations. It raises the base costs for `STORAGE_WRITE`, `COLD_SLOAD_COST`, and `COLD_ACCOUNT_ACCESS_COST` and updates the access cost for `EXTCODESIZE` and `EXTCODECOPY`.
 
 ## Motivation
 
@@ -29,61 +29,62 @@ Upon activation of this EIP, the following parameters of the gas model are intro
 
 | **Parameter** | **Description** | **Current value** | **New value** | **Increase** | **Operations affected** |
 | :---: | :---: | :---: | :---: | :---: | :---: |
-| `COLD_ACCOUNT_ACCESS` | Cold touch of an account | 2,600 | 3,000 | +15% | `*CALL` opcodes, `BALANCE`, `SELFDESTRUCT`, `EXT*` opcodes, EOA delegations, contract creation txs and ETH transfers |
+| `COLD_ACCOUNT_ACCESS_COST` | Cold touch of an account | 2,600 | 3,000 | +15% | `*CALL` opcodes, `BALANCE`, `SELFDESTRUCT`, `EXT*` opcodes, EOA delegations, contract creation txs and ETH transfers |
 | `ACCOUNT_WRITE` | Surcharge for when writing to an account changes one account leaf value for the first time | 6,700¹ | 8,000 | +19% | `*CALL` opcodes, `SELFDESTRUCT`, EOA delegations and ETH transfers |
-| `COLD_STORAGE_ACCESS` | Cold touch of a storage slot | 2,100 | 3,000 | +43% | `SSTORE` and `SLOAD` |
+| `COLD_SLOAD_COST` | Cold touch of a storage slot | 2,100 | 3,000 | +43% | `SSTORE` and `SLOAD` |
 | `STORAGE_WRITE` | Surcharge for when writing to a storage slot changes its value for the first time | 2,800² | 10,000 | +257% | `SSTORE` |
-| `WARM_ACCESS` | Touch of an already-warm account or storage slot | 100 | 100 | +0% | `SSTORE`, `SLOAD`, `*CALL` opcodes, `BALANCE` and `EXT*` opcodes |
-| `STORAGE_CLEAR_REFUND` | Refund for clearing a storage slot | 4,800 | 12,480 | +160% | `SSTORE` |
+| `WARM_STORAGE_READ_COST` | Touch of an already-warm account or storage slot | 100 | 100 | +0% | `SSTORE`, `SLOAD`, `*CALL` opcodes, `BALANCE` and `EXT*` opcodes |
+| `SSTORE_CLEARS_SCHEDULE` | Refund for clearing a storage slot | 4,800 | 12,480 | +160% | `SSTORE` |
 | `CREATE_ACCESS` | State access costs for contract deployment (include account cold access and account write) | 7,000³ | 11,000 | +57% | `CREATE`/ `CREATE2` |
 | `ACCESS_LIST_STORAGE_KEY_COST` | Gas charged per storage key included in a transaction's access list | 1,900 | 3,000 | +58% | `SSTORE` and `SLOAD` |
 | `ACCESS_LIST_ADDRESS_COST` | Gas charged per address included in a transaction's access list | 2,400 | 3,000 | +25% | `*CALL` opcodes, `BALANCE`, `SELFDESTRUCT` and `EXT*` opcodes |
 
 ¹: 6,700 = `CALL_VALUE` (9,000) - `CALL_STIPEND`(2,300)
 
-²: 2,800 = `GAS_STORAGE_UPDATE` (5,000) - `GAS_COLD_SLOAD` (2,100) - `GAS_WARM_ACCESS` (100)
+²: 2,800 = `SSTORE_RESET_GAS` (5,000) - `COLD_SLOAD_COST` (2,100) - `WARM_STORAGE_READ_COST` (100)
 
 ³: 7,000 = `GAS_CREATE` (32,000) - `GAS_NEW_ACCOUNT` (25,000)
 
+This EIP updates existing parameters where possible, keeping their established names: `COLD_ACCOUNT_ACCESS_COST`, `COLD_SLOAD_COST` and `WARM_STORAGE_READ_COST` are defined in [EIP-2929](./eip-2929.md), `SSTORE_CLEARS_SCHEDULE` in [EIP-2200](./eip-2200.md) (current value set by [EIP-3529](./eip-3529.md)), and `ACCESS_LIST_ADDRESS_COST` and `ACCESS_LIST_STORAGE_KEY_COST` in [EIP-2930](./eip-2930.md). `ACCOUNT_WRITE`, `STORAGE_WRITE` and `CREATE_ACCESS` are new parameters introduced by this EIP; they have no pre-existing counterpart, and their "current value" column shows the equivalent cost derived from the pre-existing schedule per the footnotes above.
+
 ### `SSTORE` pricing
 
-In addition, the `SSTORE` cost formula is updated to include the following independent costs:
+The `SSTORE` charging and refund rules of [EIP-2200](./eip-2200.md) and [EIP-2929](./eip-2929.md) are replaced by the rules below. The complete `SSTORE` charge is the sum of the following independent costs:
 
-1. Access costs: `COLD_STORAGE_ACCESS` or `WARM_ACCESS`, depending on whether the storage slot is cold or warm.
-2. Write cost: additionally charge `STORAGE_WRITE` if the new value is different from the present value and the present value equals the original value (First time change).
-3. State creation cost: additionally charge `GAS_STORAGE_SET` (per [EIP-8037](./eip-8037.md)) if the original value is zero, the current value is zero, and the new value is non-zero.
+1. Access costs: `COLD_SLOAD_COST` or `WARM_STORAGE_READ_COST`, depending on whether the storage slot is cold or warm.
+2. Write cost: additionally charge `STORAGE_WRITE` if the new value is different from the current value and the current value equals the original value (First time change).
+3. State creation cost: additionally charge `SSTORE_SET_GAS` if the original value is zero, the current value is zero, and the new value is non-zero. `SSTORE_SET_GAS` (20,000) is defined in [EIP-2200](./eip-2200.md) and is not repriced by this EIP; its refund is given by rule 4 below.
 
 Refunds are also updated as follows. Each rule is an adjustment to the transaction's refund counter and is evaluated on every `SSTORE`:
 
-1. `STORAGE_CLEAR_REFUND` is added if the original value is non-zero, the current value is non-zero and the new value is zero (a slot is cleared).
-2. `STORAGE_CLEAR_REFUND` is subtracted if the original value is non-zero, the current value is zero and the new value is non-zero (a slot that was cleared earlier in the same transaction is restored). This reverses the refund granted by rule 1, so that clearing and then restoring a slot within the same transaction is never net-profitable.
+1. `SSTORE_CLEARS_SCHEDULE` is added if the original value is non-zero, the current value is non-zero and the new value is zero (a slot is cleared).
+2. `SSTORE_CLEARS_SCHEDULE` is subtracted if the original value is non-zero, the current value is zero and the new value is non-zero (a slot that was cleared earlier in the same transaction is restored). This reverses the refund granted by rule 1, so that clearing and then restoring a slot within the same transaction is never net-profitable.
 3. `STORAGE_WRITE` is refunded if the new value equals the original value and differs from the current value (a first-time change made earlier in the same transaction is reset back to its original value).
+4. `SSTORE_SET_GAS` is refunded in full if the original value is zero, the current value is non-zero and the new value is zero (a slot set earlier in the same transaction is reset to zero).
 
-Rules 2 and 3 mirror the refund accounting of [EIP-2200](./eip-2200.md) and [EIP-3529](./eip-3529.md) for slots that are modified more than once within a transaction: a `STORAGE_WRITE` charge or `STORAGE_CLEAR_REFUND` granted on an earlier `SSTORE` to the same slot is undone when a later `SSTORE` returns the slot to its original value. Without these reversals, a round trip such as `x → 0 → x` would yield a net refund even though the slot ends the transaction unchanged.
+Rules 2–4 mirror the refund accounting of [EIP-2200](./eip-2200.md) and [EIP-3529](./eip-3529.md) for slots that are modified more than once within a transaction: a `STORAGE_WRITE` or `SSTORE_SET_GAS` charge, or a `SSTORE_CLEARS_SCHEDULE` grant, from an earlier `SSTORE` to the same slot is undone when a later `SSTORE` returns the slot to its original value. Without these reversals, a round trip such as `x → 0 → x` would yield a net refund even though the slot ends the transaction unchanged. Rule 4 refunds the full `SSTORE_SET_GAS` where [EIP-2200](./eip-2200.md) refunded `SSTORE_SET_GAS` minus a read cost: since access is now charged explicitly and separately in every case, the round trip `0 → x → 0` nets to exactly its access costs.
 
 These refunds go to the transaction's refund counter and are capped to 20% of the total gas used by the transaction, as per the current refund mechanism.
 
-The rules for state creation cost charges and refills are addressed in [EIP-8037](./eip-8037.md).
-
 Cases and their corresponding costs are detailed in the table below:
 
-| Original value | Current value | New value | Access status | Description | Regular-gas charges/refunds | State-gas charges/refills |
+| Original value | Current value | New value | Access status | Description | Charges/refunds | `SSTORE_SET_GAS` charges/refunds |
 | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
-| 0 | 0 | x | Cold | New slot | `COLD_STORAGE_ACCESS` + `STORAGE_WRITE` charged | `GAS_STORAGE_SET` charged |
-| 0 | 0 | x | Warm | New slot | `WARM_ACCESS` + `STORAGE_WRITE` charged | `GAS_STORAGE_SET` charged |
-| x | x | y | Cold | Existing slot, first change | `COLD_STORAGE_ACCESS` + `STORAGE_WRITE` charged | no state-gas adjustments |
-| x | x | y | Warm | Existing slot, first change | `WARM_ACCESS` + `STORAGE_WRITE` charged | no state-gas adjustments |
-| x | x | 0 | Cold | Cleared slot, non-zero at transaction start | `COLD_STORAGE_ACCESS` + `STORAGE_WRITE` charged, `STORAGE_CLEAR_REFUND` refunded | no state-gas adjustments |
-| x | x | 0 | Warm | Cleared slot, non-zero at transaction start | `WARM_ACCESS` + `STORAGE_WRITE` charged, `STORAGE_CLEAR_REFUND` refunded | no state-gas adjustments |
-| 0 | x | 0 | Warm | Set slot reset to zero (zero at transaction start) | `WARM_ACCESS` charged, `STORAGE_WRITE` refunded | `GAS_STORAGE_SET` refilled |
-| x | y | x | Warm | Previously-modified slot reset to original value | `WARM_ACCESS` charged, `STORAGE_WRITE` refunded | no state-gas adjustments |
-| x | 0 | x | Warm | Cleared slot restored to original value | `WARM_ACCESS` charged, `STORAGE_WRITE` refunded, `STORAGE_CLEAR_REFUND` reversed | no state-gas adjustments |
-| x | 0 | y | Warm | Cleared slot written to a new non-zero value | `WARM_ACCESS` charged, `STORAGE_CLEAR_REFUND` reversed | no state-gas adjustments |
-| x | y | z | Warm | Previously-modified slot written to again | `WARM_ACCESS` charged | no state-gas adjustments |
+| 0 | 0 | x | Cold | New slot | `COLD_SLOAD_COST` + `STORAGE_WRITE` charged | `SSTORE_SET_GAS` charged |
+| 0 | 0 | x | Warm | New slot | `WARM_STORAGE_READ_COST` + `STORAGE_WRITE` charged | `SSTORE_SET_GAS` charged |
+| x | x | y | Cold | Existing slot, first change | `COLD_SLOAD_COST` + `STORAGE_WRITE` charged | no adjustments |
+| x | x | y | Warm | Existing slot, first change | `WARM_STORAGE_READ_COST` + `STORAGE_WRITE` charged | no adjustments |
+| x | x | 0 | Cold | Cleared slot, non-zero at transaction start | `COLD_SLOAD_COST` + `STORAGE_WRITE` charged, `SSTORE_CLEARS_SCHEDULE` refunded | no adjustments |
+| x | x | 0 | Warm | Cleared slot, non-zero at transaction start | `WARM_STORAGE_READ_COST` + `STORAGE_WRITE` charged, `SSTORE_CLEARS_SCHEDULE` refunded | no adjustments |
+| 0 | x | 0 | Warm | Set slot reset to zero (zero at transaction start) | `WARM_STORAGE_READ_COST` charged, `STORAGE_WRITE` refunded | `SSTORE_SET_GAS` refunded |
+| x | y | x | Warm | Previously-modified slot reset to original value | `WARM_STORAGE_READ_COST` charged, `STORAGE_WRITE` refunded | no adjustments |
+| x | 0 | x | Warm | Cleared slot restored to original value | `WARM_STORAGE_READ_COST` charged, `STORAGE_WRITE` refunded, `SSTORE_CLEARS_SCHEDULE` reversed | no adjustments |
+| x | 0 | y | Warm | Cleared slot written to a new non-zero value | `WARM_STORAGE_READ_COST` charged, `SSTORE_CLEARS_SCHEDULE` reversed | no adjustments |
+| x | y | z | Warm | Previously-modified slot written to again | `WARM_STORAGE_READ_COST` charged | no adjustments |
 
 ### Account access pricing
 
-The rules that determine when `COLD_ACCOUNT_ACCESS` and `WARM_ACCESS` are charged for account-related operations are unchanged; only the parameter values themselves are updated.
+The rules that determine when `COLD_ACCOUNT_ACCESS_COST` and `WARM_STORAGE_READ_COST` are charged for account-related operations are unchanged; only the parameter values themselves are updated.
 
 #### `CALL`/`CALLCODE`
 
@@ -91,7 +92,7 @@ For `CALL` and `CALLCODE` operations, `CALL_VALUE` is set to `ACCOUNT_WRITE + CA
 
 #### `CREATE`/`CREATE2`
 
-`CREATE` and `CREATE2` operations don't have explicit warm/cold pricing. Instead, they are charged `CREATE_ACCESS` in regular-gas and `GAS_NEW_ACCOUNT` in state-gas (per [EIP-8037](./eip-8037.md)). `CREATE_ACCESS` is defined as `ACCOUNT_WRITE` + `COLD_STORAGE_ACCESS`.
+`CREATE` and `CREATE2` operations don't have explicit warm/cold pricing. Instead, they are charged `CREATE_ACCESS` plus the account-creation charge `GAS_NEW_ACCOUNT`, an existing constant of the gas schedule (the Yellow Paper's `G_newaccount`, 25,000; it predates the EIP process) that is not repriced by this EIP. `CREATE_ACCESS` is defined as `ACCOUNT_WRITE` + `COLD_SLOAD_COST`.
 
 Note: this definition does not exactly match the legacy decomposition shown in footnote ³ of the Parameters table (`GAS_CREATE` - `GAS_NEW_ACCOUNT` = 7,000). The pre-existing accounting in the protocol is not internally consistent here, and this EIP keeps the discrepancy rather than attempting to reconcile it.
 
@@ -101,7 +102,7 @@ For `SELFDESTRUCT`, an additional charge of `ACCOUNT_WRITE` is added if a positi
 
 #### `EXT*` family update
 
-Besides the current access costs, `EXTCODESIZE` and `EXTCODECOPY` are charged an additional `WARM_ACCESS`.
+Besides the current access costs, `EXTCODESIZE` and `EXTCODECOPY` are charged an additional `WARM_STORAGE_READ_COST`.
 
 #### Overview
 
@@ -109,12 +110,12 @@ The cases for account-related operations and their corresponding costs are summa
 
 | Operation | Access charge | `ACCOUNT_WRITE` charged | Additional charge |
 | :--- | :---: | :--- | :--- |
-| `CALL` / `CALLCODE` | `COLD_ACCOUNT_ACCESS` or `WARM_ACCESS` | when value is transferred (via `CALL_VALUE` = `ACCOUNT_WRITE` + `CALL_STIPEND`) | — |
-| `DELEGATECALL` / `STATICCALL` | `COLD_ACCOUNT_ACCESS` or `WARM_ACCESS` | never (no value transfer) | — |
-| `CREATE` / `CREATE2` | `CREATE_ACCESS` (= `ACCOUNT_WRITE` + `COLD_STORAGE_ACCESS`) | always (folded into `CREATE_ACCESS`) | `GAS_NEW_ACCOUNT` in state-gas (per [EIP-8037](./eip-8037.md)) |
-| `SELFDESTRUCT` | `COLD_ACCOUNT_ACCESS` or `WARM_ACCESS` | when a positive balance is sent to an empty account | — |
-| `BALANCE` / `EXTCODEHASH` | `COLD_ACCOUNT_ACCESS` or `WARM_ACCESS` | never | — |
-| `EXTCODESIZE` / `EXTCODECOPY` | `COLD_ACCOUNT_ACCESS` or `WARM_ACCESS` | never | `WARM_ACCESS` (second database read) |
+| `CALL` / `CALLCODE` | `COLD_ACCOUNT_ACCESS_COST` or `WARM_STORAGE_READ_COST` | when value is transferred (via `CALL_VALUE` = `ACCOUNT_WRITE` + `CALL_STIPEND`) | — |
+| `DELEGATECALL` / `STATICCALL` | `COLD_ACCOUNT_ACCESS_COST` or `WARM_STORAGE_READ_COST` | never (no value transfer) | — |
+| `CREATE` / `CREATE2` | `CREATE_ACCESS` (= `ACCOUNT_WRITE` + `COLD_SLOAD_COST`) | always (folded into `CREATE_ACCESS`) | `GAS_NEW_ACCOUNT` |
+| `SELFDESTRUCT` | `COLD_ACCOUNT_ACCESS_COST` or `WARM_STORAGE_READ_COST` | when a positive balance is sent to an empty account | — |
+| `BALANCE` / `EXTCODEHASH` | `COLD_ACCOUNT_ACCESS_COST` or `WARM_STORAGE_READ_COST` | never | — |
+| `EXTCODESIZE` / `EXTCODECOPY` | `COLD_ACCOUNT_ACCESS_COST` or `WARM_STORAGE_READ_COST` | never | `WARM_STORAGE_READ_COST` (second database read) |
 
 ## Rationale
 
@@ -177,11 +178,11 @@ The following table lists the directly estimated parameters and their mapping to
 
 | Test name | Configuration | Model | Parameter mapping |
 | :---: | :---: | :---: | :---: |
-| `test_account_access` | CacheStrategy = NO_CACHE | runtime = intercept + slope × operation_count + update × value_sent x operation_count | `slope` → `COLD_ACCOUNT_ACCESS`; `update` → `ACCOUNT_WRITE` |
-| `test_sload_bloated` | CacheStrategy = NO_CACHE | runtime = intercept + slope × operation_count | `slope` → `COLD_STORAGE_ACCESS` |
-| `test_sstore_bloated` | CacheStrategy = NO_CACHE | runtime = intercept + slope × operation_count + update × write_new_value x operation_count | `slope` → `COLD_STORAGE_ACCESS`; `update` → `STORAGE_WRITE` |
-| `test_storage_sload_same_key_benchmark` | NA | runtime = intercept + slope × operation_count | `slope` → `WARM_ACCESS` |
-| `test_ext_account_query_warm` | NA | runtime = intercept + slope × operation_count | `slope` → `WARM_ACCESS` |
+| `test_account_access` | CacheStrategy = NO_CACHE | runtime = intercept + slope × operation_count + update × value_sent x operation_count | `slope` → `COLD_ACCOUNT_ACCESS_COST`; `update` → `ACCOUNT_WRITE` |
+| `test_sload_bloated` | CacheStrategy = NO_CACHE | runtime = intercept + slope × operation_count | `slope` → `COLD_SLOAD_COST` |
+| `test_sstore_bloated` | CacheStrategy = NO_CACHE | runtime = intercept + slope × operation_count + update × write_new_value x operation_count | `slope` → `COLD_SLOAD_COST`; `update` → `STORAGE_WRITE` |
+| `test_storage_sload_same_key_benchmark` | NA | runtime = intercept + slope × operation_count | `slope` → `WARM_STORAGE_READ_COST` |
+| `test_ext_account_query_warm` | NA | runtime = intercept + slope × operation_count | `slope` → `WARM_STORAGE_READ_COST` |
 
 `test_sstore_bloated` and `test_sload_bloated` targeted a bespoke contract with a storage size of 10GB, which is the size of the largest mainnet contract.
 
@@ -202,10 +203,10 @@ Where:
 **Derived parameters** are computed from the directly estimated ones:
 
 ```
-STORAGE_CLEAR_REFUND         = (STORAGE_WRITE + COLD_STORAGE_ACCESS) * (4800/5000)
-ACCESS_LIST_STORAGE_KEY_COST = COLD_STORAGE_ACCESS
-ACCESS_LIST_ADDRESS_COST     = COLD_ACCOUNT_ACCESS
-CREATE_ACCESS                = ACCOUNT_WRITE + COLD_STORAGE_ACCESS
+SSTORE_CLEARS_SCHEDULE         = (STORAGE_WRITE + COLD_SLOAD_COST) * (4800/5000)
+ACCESS_LIST_STORAGE_KEY_COST = COLD_SLOAD_COST
+ACCESS_LIST_ADDRESS_COST     = COLD_ACCOUNT_ACCESS_COST
+CREATE_ACCESS                = ACCOUNT_WRITE + COLD_SLOAD_COST
 ```
 
 ### Interaction with [EIP-7928](./eip-7928.md)
@@ -214,18 +215,18 @@ CREATE_ACCESS                = ACCOUNT_WRITE + COLD_STORAGE_ACCESS
 
 ### Special case for `EXTCODESIZE` and `EXTCODECOPY`
 
-Differently from other account read operations, `EXTCODESIZE` and `EXTCODECOPY` make two reads to the database. The first read is the same, where the object of the target account is loaded. This object includes the account's `nonce`, `balance`, `codeHash` and `storageRoot`. Then, these operations do another read to collect either the code size or the bytecode of the account. This second read is to an already warmed account, and thus we propose to price it as `WARM_ACCESS` for consistency.
+Differently from other account read operations, `EXTCODESIZE` and `EXTCODECOPY` make two reads to the database. The first read is the same, where the object of the target account is loaded. This object includes the account's `nonce`, `balance`, `codeHash` and `storageRoot`. Then, these operations do another read to collect either the code size or the bytecode of the account. This second read is to an already warmed account, and thus we propose to price it as `WARM_STORAGE_READ_COST` for consistency.
 
 ### Interaction with [EIP-8032](./eip-8032.md)
 
-[EIP-8032](./eip-8032.md) proposes modifying the `SSTORE` cost formula to account for the storage size of a contract. This is a more accurate method for pricing storage writes. It allows writes to smaller contracts to be cheaper than writes to large contracts, which helps with scaling and is fairer to users. However, [EIP-8032](./eip-8032.md) is not yet scheduled for inclusion in a fork, and, as such, this proposal considers two cases for setting the values of `STORAGE_WRITE` and `COLD_STORAGE_ACCESS`:
+[EIP-8032](./eip-8032.md) proposes modifying the `SSTORE` cost formula to account for the storage size of a contract. This is a more accurate method for pricing storage writes. It allows writes to smaller contracts to be cheaper than writes to large contracts, which helps with scaling and is fairer to users. However, [EIP-8032](./eip-8032.md) is not yet scheduled for inclusion in a fork, and, as such, this proposal considers two cases for setting the values of `STORAGE_WRITE` and `COLD_SLOAD_COST`:
 
 1. Before [EIP-8032](./eip-8032.md). In this case, we set the parameters assuming a worst-case contract size, which makes state-accessing operations more expensive, independently of the contract size.
 2. After [EIP-8032](./eip-8032.md). In this case, we set the parameters assuming the worst-case until `ACTIVATION_THRESHOLD`, which is the parameter in [EIP-8032](./eip-8032.md) that triggers the depth-based cost. This means that contract sizes below the threshold have the same access costs, while contracts above the threshold get exponentially more expensive with increasing size.
 
 ### Interaction with [EIP-2926](./eip-2926.md)
 
-[EIP-2926](./eip-2926.md) proposes to change how code is stored in the state trie. One of the changes of this proposal is to include the code size as a new field in the account object (`codeSize`). With this change, the code size can be directly accessed with a single read to the database and thus `EXTCODESIZE` should maintain its previous cost formula, without including the additional `WARM_ACCESS`.
+[EIP-2926](./eip-2926.md) proposes to change how code is stored in the state trie. One of the changes of this proposal is to include the code size as a new field in the account object (`codeSize`). With this change, the code size can be directly accessed with a single read to the database and thus `EXTCODESIZE` should maintain its previous cost formula, without including the additional `WARM_STORAGE_READ_COST`.
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
Note: one of many, will keep this draft until I also finish updating EIP-8037 and EIP-2780.

## What this PR does

This PR makes EIP-8038 a self-contained regular-gas repricing with no reference to
EIP-8037. It changes **no charge value, condition, timing, or refund behavior** — the
composed Glamsterdam semantics (8038 + 8037 together) are exactly as before. Alongside
the untangling, it renames constants back to their established names where the EIP only
changes a value, and tightens the SSTORE section so the EIP is implementable from its
own text.

## Why

EIP-2780, EIP-8037 and EIP-8038 currently form the only dependency cycle among the
Glamsterdam EIPs: 2780 ⇄ 8037, 8037 ⇄ 8038, and the 3-cycle 8038 → 8037 → 2780 → 8038.
Circular `requires:` means neither document can be read or implemented first, and it
blocks the move to Review (eipw requires an EIP's `requires:` targets — and its body
links — to be at the same or a later status, so a cycle admits no valid move order).
Breaking the 8038 → 8037 edge is one of the two removals needed; with it, 8038 can move
to Review first, then 2780, then 8037.

The guiding rule: 8037 *requires* 8038 (it builds the state-gas dimension on top of
8038's regular-gas schedule), so 8038 must be fully specifiable without knowing 8037
exists. Anything 8038 said about state gas was a restatement of 8037 content — and
restatements across documents are where the specs have historically drifted apart.

## Changes and reasoning

### 1. Drop `requires: 8037` (header)

The cycle edge itself. 8038 keeps `requires: 7904`.

### 2. SSTORE section is now complete and standalone

- The intro now states explicitly that the rules **replace** the `SSTORE` charging and
  refund rules of EIP-2200 and EIP-2929. *Why:* the previous "updated to include" could
  be read as surcharges stacked on top of the existing schedule (double-charging the
  set); a complete-replacement statement removes that ambiguity and is required for the
  EIP to be implementable from its own text.
- Cost item 3 charges `SSTORE_SET_GAS` (previously `GAS_STORAGE_SET` "per EIP-8037"),
  explicitly not repriced by this EIP. *Why:* the set component belongs to the complete
  SSTORE formula, so it must be stated here — but its value is owned elsewhere
  (EIP-2200). Under 8037 this is the component that moves to the state-gas dimension;
  8038 does not need to know that.
- New refund rule 4: the full `SSTORE_SET_GAS` is refunded on `0 → x → 0`. *Why:*
  previously this behavior was only reachable via the EIP-8037 reference, leaving the
  standalone reading ambiguous (EIP-2200 refunded `SSTORE_SET_GAS` minus a read cost).
  The full refund is the consistent choice under the new decomposition: access is now
  charged explicitly and separately in every case, so the round trip nets to exactly
  its access costs. It also composes cleanly with 8037's refill semantics.
- The case table's "State-gas charges/refills" column is now the "`SSTORE_SET_GAS`
  charges/refunds" column, with the same entries. *Why:* same information, no
  state-gas vocabulary — the dimension assignment is 8037's job; when 8037 is active it
  is implicit that this column is metered as state gas.
- Minor: "present value" → "current value" (the section's own taxonomy), and the
  EIP-3529 refund-cap sentence is untouched (the cap and the `SELFDESTRUCT`-refund
  removal are not SSTORE rules and remain in force).

### 3. CREATE/CREATE2

"charged `CREATE_ACCESS` in regular-gas and `GAS_NEW_ACCOUNT` in state-gas (per
EIP-8037)" became "charged `CREATE_ACCESS` plus the account-creation charge
`GAS_NEW_ACCOUNT` … not repriced by this EIP". *Why:* same complete-formula principle —
8038 redefines only the access-and-write component; the account-creation component is a
pre-existing schedule constant (the Yellow Paper's `G_newaccount`; it predates the EIP
process, and EIP-7928 uses the same `GAS_NEW_ACCOUNT` name), and its dimension is
8037's concern.

### 4. Reuse canonical symbol names

Policy applied: **if only the value changes, keep the established symbol; introduce a
new symbol only for new mechanics.** *Why:* a renamed constant with unchanged semantics
forces every reader and every other EIP to carry a mental alias table, and it is
exactly how cross-EIP inconsistencies creep in.

Renamed back (value-only changes):

| This PR | Was | Defined in |
| --- | --- | --- |
| `COLD_ACCOUNT_ACCESS_COST` | `COLD_ACCOUNT_ACCESS` | EIP-2929 |
| `COLD_SLOAD_COST` | `COLD_STORAGE_ACCESS` | EIP-2929 |
| `WARM_STORAGE_READ_COST` | `WARM_ACCESS` (value unchanged, +0%) | EIP-2929 |
| `SSTORE_CLEARS_SCHEDULE` | `STORAGE_CLEAR_REFUND` | EIP-2200 (value per EIP-3529) |
| `SSTORE_RESET_GAS`, `COLD_SLOAD_COST`, `WARM_STORAGE_READ_COST` (footnote ²) | `GAS_STORAGE_UPDATE`, `GAS_COLD_SLOAD`, `GAS_WARM_ACCESS` | EIP-2200 / EIP-2929 |

Kept as new symbols (genuinely new mechanics, no pre-existing counterpart):
`ACCOUNT_WRITE` (first write to an account leaf), `STORAGE_WRITE` (first-change
surcharge, now also charged on the set path), `CREATE_ACCESS` (new decomposition). The
"current value" column for these shows derived equivalents under the pre-existing
schedule, per the footnotes.

A sentence after the Parameters table now states, for every reused symbol, the EIP that
defines it — so first use always points at the definition.

### 5. No spec change — how to check

For every SSTORE case (the case table) and for CREATE/CALL/SELFDESTRUCT/EXT*, the
charged components and amounts are identical to the previous revision of this EIP; only
symbol names and the location of the state-dimension assignment (moved to 8037) differ.
When 8037 is applied on top, its Parameter-changes table redefines `SSTORE_SET_GAS` and
`GAS_NEW_ACCOUNT` and assigns them to the state-gas dimension — same numbers, same
behavior as the current pair of documents intends.

A companion PR updates EIP-8037 to absorb the dimension-assignment text (and a third
updates EIP-2780 for the 2780 ⇄ 8037 edge). Each EIP gets its own PR so they can be
reviewed and merged independently; this PR is mergeable on its own.
