### PR TITLE
Update EIP-8272: fix TXPARAM_RECENT_ROOT_REFERENCE_COUNT value inconsistency

### DIFF
--- a/EIPS/eip-8272.md
+++ b/EIPS/eip-8272.md
@@ -292,7 +292,7 @@ One new `TXPARAM` index and one new opcode are added:
 
 | Name                                 |  Value | Return value                 |
 | ------------------------------------ | -----: | ---------------------------- |
-| `TXPARAM_RECENT_ROOT_REFERENCE_COUNT` | `0x0D` | `len(recent_root_references)` |
+| `TXPARAM_RECENT_ROOT_REFERENCE_COUNT` | `0x0F` | `len(recent_root_references)` |
 
 `TXPARAM(TXPARAM_RECENT_ROOT_REFERENCE_COUNT)` costs the standard `TXPARAM` gas.
 


### PR DESCRIPTION
The constants table defines `TXPARAM_RECENT_ROOT_REFERENCE_COUNT` as `0x0F`, but the `TXPARAM` table in the "TXPARAM and RECENTROOTREFLOAD" section lists it as `0x0D`. This makes the selector ambiguous for implementers.

This aligns the usage table with the constant's defined value (`0x0F`). `0x0F` is also the correct choice for the wider frame-transaction family: `0x0D` is already used by EIP-8250 (`TXPARAM_NONCE_KEY_COUNT`), so keeping `0x0F` avoids a cross-EIP collision.

Discussion: https://ethereum-magicians.org/t/eip-8272-recent-roots-for-frame-transactions/28621
