### PR TITLE
Update EIP-8272: restore EIP-8141 signature costs in tx_gas_limit

### DIFF
--- a/EIPS/eip-8272.md
+++ b/EIPS/eip-8272.md
@@ -261,6 +261,7 @@ tx_gas_limit =
     FRAME_TX_INTRINSIC_COST
     + len(tx.frames) * FRAME_TX_PER_FRAME_COST
     + calldata_cost(recent_root_calldata)
+    + signature_verification_cost
     + recent_root_reference_intrinsic_gas
     + sum(frame.gas_limit for all frames)
 ```
@@ -279,10 +280,12 @@ recent_root_reference_intrinsic_gas =
 and:
 
 ```text
-recent_root_calldata = rlp(tx.frames) || rlp(recent_root_references)
+recent_root_calldata = rlp(tx.signatures) || rlp(tx.frames) || rlp(recent_root_references)
 ```
 
 The EIP-7623 calldata cost MUST be computed over `recent_root_calldata` as one byte string.
+
+`signature_verification_cost` is defined by [EIP-8141](./eip-8141.md) and is unchanged by this EIP.
 
 `RECENT_ROOT_REFERENCE_GAS` covers one declared storage key and the two Keccak computations used to derive `storage_key` and `entry_hash`.
 


### PR DESCRIPTION
As a delta on EIP-8141, EIP-8272 restates `tx_gas_limit` but drops two terms that EIP-8141 charges: `signature_verification_cost`, and the signatures' contribution to the calldata cost (`recent_root_calldata` omits `rlp(tx.signatures)`). As written, a post-fork frame transaction is under-charged for its signatures relative to EIP-8141.

This restores both, keeping EIP-8272's single-byte-string calldata approach: signatures are added back to `recent_root_calldata`, and `signature_verification_cost` (defined by EIP-8141, unchanged here) is added to the formula.

Discussion: https://ethereum-magicians.org/t/eip-8272-recent-roots-for-frame-transactions/28621
