### PR TITLE
Update EIP-8141: bound the signatures list with MAX_SIGNATURES

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -40,6 +40,7 @@ Ultimately, frame transactions realize the original vision of account abstractio
 | `EXPIRY_VERIFIER`          | `address(0x8141)` |
 | `EXPIRY_DATA_LENGTH`       | `8`               |
 | `MAX_FRAMES`               | `64`              |
+| `MAX_SIGNATURES`           | `64`              |
 
 ### Frame Transaction
 
@@ -122,6 +123,7 @@ assert tx.chain_id < 2**256
 assert tx.nonce < 2**64
 assert len(tx.frames) > 0 and len(tx.frames) <= MAX_FRAMES
 assert len(tx.sender) == 20
+assert len(tx.signatures) <= MAX_SIGNATURES
 
 for sig in tx.signatures:
     if sig.scheme in [SECP256K1, P256]:


### PR DESCRIPTION
The `signatures` list is currently the only variable-length list in the frame-transaction family without an explicit bound: `frames` is capped by `MAX_FRAMES`, and the companion EIPs cap `nonce_keys` (EIP-8250) and `recent_root_references` (EIP-8272). The number of signatures is limited only implicitly by `tx_gas_limit`, which allows on the order of thousands of entries.

This is worth bounding explicitly for two reasons:

1. The signatures array is decoded before gas is charged, so an unbounded list is a large decode-time allocation surface.
2. More importantly, without a consensus bound each client is left to limit the list itself. Any client-chosen decode cap below the gas-implied maximum would reject a transaction other clients accept — a consensus split. A spec-level constant makes the bound uniform.

This adds `MAX_SIGNATURES` and the corresponding static check, mirroring `MAX_FRAMES`.

The proposed value (`64`, matching `MAX_FRAMES`) is a starting point — happy to adjust. Multi-signature accounts and future signature aggregation (e.g. #11772) are the cases that inform the ceiling.

Discussion: https://ethereum-magicians.org/t/eip-8141-frame-transaction/27617
