### PR TITLE
Update EIP-8141: bound the signatures list with MAX_SIGNATURES

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -40,6 +40,7 @@ Ultimately, frame transactions realize the original vision of account abstractio
 | `EXPIRY_VERIFIER`          | `address(0x8141)` |
 | `EXPIRY_DATA_LENGTH`       | `8`               |
 | `MAX_FRAMES`               | `64`              |
+| `MAX_SIGNATURES`           | `64`              |
 | `SECP256K1N`               | `0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141` |
 
 ### Frame Transaction
@@ -123,6 +124,7 @@ assert tx.chain_id < 2**256
 assert tx.nonce < 2**64
 assert len(tx.frames) > 0 and len(tx.frames) <= MAX_FRAMES
 assert len(tx.sender) == 20
+assert len(tx.signatures) <= MAX_SIGNATURES
 
 for sig in tx.signatures:
     if sig.scheme in [SECP256K1, P256]:


### PR DESCRIPTION
The `signatures` list is the only variable-length list in the frame-transaction family without an explicit bound. `frames` is capped by `MAX_FRAMES`, and the companion EIPs cap their own lists (`nonce_keys` in EIP-8250, `recent_root_references` in EIP-8272). Right now `signatures` is limited only implicitly by `tx_gas_limit`, which still leaves room for on the order of thousands of entries.

Two reasons to bound it explicitly:

- The list is decoded before any gas is charged, so an unbounded one is a decode-time allocation surface.
- More importantly, without a consensus bound each client has to choose its own decode limit. Any client-chosen cap below the gas-implied maximum would reject a transaction that other clients accept, which is a consensus split. A spec-level constant keeps the bound uniform.

This adds `MAX_SIGNATURES` and the matching static check, mirroring how `MAX_FRAMES` already bounds `frames`.

I set the value to `64` (same as `MAX_FRAMES`) as a starting point, happy to adjust. Multi-signature accounts and future aggregation (e.g. #11772) are the cases that inform the ceiling. Worth noting that aggregation tends to collapse many signatures into a single entry rather than inflate the count, so the realistic ceiling is lower than it first looks.

Leaving as a draft while the value settles.