### PR TITLE
Update EIP-8141: pin the SECP256K1 signature encoding (recovery id and low-s)

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -40,6 +40,7 @@ Ultimately, frame transactions realize the original vision of account abstractio
 | `EXPIRY_VERIFIER`          | `address(0x8141)` |
 | `EXPIRY_DATA_LENGTH`       | `8`               |
 | `MAX_FRAMES`               | `64`              |
+| `SECP256K1N`               | `0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141` |
 
 ### Frame Transaction
 
@@ -240,8 +241,12 @@ def validate_signature(sig, tx_sender, sig_hash) -> bool:
         if len(sig.signature) != 65:
             return False
         v = sig.signature[0]
-        r = sig.signature[1:33]
-        s = sig.signature[33:65]
+        r = int.from_bytes(sig.signature[1:33], "big")
+        s = int.from_bytes(sig.signature[33:65], "big")
+        # v is the recovery id (0 or 1), matching EIP-2718 typed transactions.
+        # r and s must be canonical, with low-s per EIP-2, so each signature has one encoding.
+        if v > 1 or not (0 < r < SECP256K1N) or not (0 < s <= SECP256K1N // 2):
+            return False
         return resolved_signer == ecrecover(msg, v, r, s)
 
     elif sig.scheme == P256:


### PR DESCRIPTION
`validate_signature` passes the SECP256K1 signature straight into `ecrecover(msg, v, r, s)` without pinning how `v` is encoded or requiring `s` to be canonical, and neither is defined anywhere else in the document.

That leaves the recovery id ambiguous. The `ECRECOVER` precompile reads `v` as `27`/`28`, while every EIP-2718 typed transaction, the family this type belongs to (`requires: 2718`), uses a `0`/`1` y-parity. One implementation reading `v` the first way and another reading it the second way disagree on whether the same signature is valid; since this is a protocol-validated signature, that means they disagree on whether the transaction, and any block containing it, is valid. It isn't hypothetical: a signing tool in the ecosystem already emits `v` as `27`/`28` while an independent implementation rejects anything outside `0`/`1`.

I propose fixing `v` to the `0`/`1` recovery id, since that's consistent with the rest of the typed-transaction family.

Separately, `s` is unconstrained, so a signature and its malleated counterpart (`s` and `N - s`) are both accepted, which makes the transaction hash malleable. Legacy transactions handled this with the low-s rule in EIP-2, and the same fits here: `0 < r < N` and `0 < s <= N/2`.

The change adds `SECP256K1N` (the curve order) to the constants and the matching checks in `validate_signature`.

Surfaced while implementing the spec in Nethermind and reconciling signatures across two implementations.