### PR TITLE
Update EIP-8141: specify stack operand order for FRAMEDATALOAD and FRAMEDATACOPY

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -443,7 +443,7 @@ Frame transactions can be used by accounts who do not have deployed code, nor an
 
 ### `APPROVE` Instruction (`0xaa`)
 
-The `APPROVE` instruction exits the current EVM call frame successfully and updates the transaction-scoped approval context based on the `scope` operand.
+The `APPROVE` instruction exits the current EVM call frame successfully and updates the transaction-scoped approval context based on the `scope` operand. The `offset` and `length` operands designate a memory region that becomes the frame's return data, following `RETURN` semantics.
 
 #### Stack
 
@@ -521,8 +521,12 @@ Undefined `param` values result in an exceptional halt.
 
 This opcode loads one 32-byte word of data from frame input. Gas cost: 3 (matches CALLDATALOAD).
 
-It takes two values from the stack, an `offset` and `frameIndex`.
-It places the retrieved data on the stack.
+It takes two values from the stack and places the retrieved word on the stack:
+
+| Stack     | Value        |
+| --------- | ------------ |
+| `top - 0` | `offset`     |
+| `top - 1` | `frameIndex` |
 
 When the `frameIndex` is out-of-bounds, an exceptional halt occurs.
 
@@ -535,8 +539,14 @@ This opcode copies data frame input into the contract's memory. Its gas cost is 
 exactly as for `CALLDATACOPY`, including the fixed cost of 3, the per-word copy cost, and
 the standard EVM memory expansion cost.
 
-It takes four values from the stack: `memOffset`, `dataOffset`, `length` and `frameIndex`.
-No stack output value is produced.
+It takes four values from the stack and produces no output:
+
+| Stack     | Value        |
+| --------- | ------------ |
+| `top - 0` | `memOffset`  |
+| `top - 1` | `dataOffset` |
+| `top - 2` | `length`     |
+| `top - 3` | `frameIndex` |
 
 When the `frameIndex` is out-of-bounds, an exceptional halt occurs.
 


### PR DESCRIPTION
`FRAMEDATALOAD` and `FRAMEDATACOPY` are the only frame instructions whose operand order isn't nailed down. `TXPARAM`, `FRAMEPARAM`, and `SIGPARAM` each say which operand sits on top, and `APPROVE` has a stack table. These two describe their operands only in prose:

- `FRAMEDATALOAD` : "an offset and frameIndex", with no statement of which is on top.
- `FRAMEDATACOPY` : "memOffset, dataOffset, length and frameIndex", a list that implies an order but doesn't state one.

Since these are read directly from the stack, an implementation that orders them differently produces different results for the same bytecode. For a consensus-executed instruction that means a block valid for one implementation and invalid for another.

This adds an explicit stack table to each, matching the order the prose already reads top-to-bottom: `offset` above `frameIndex` for `FRAMEDATALOAD` (the same layout as `CALLDATALOAD`), and `memOffset, dataOffset, length, frameIndex` from the top down for `FRAMEDATACOPY` (`CALLDATACOPY` with the frame selector deepest). If a different order was intended, this is the place to pin it.

It also states what `APPROVE` does with its `offset`/`length` operands: the memory region they designate becomes the frame's return data, following `RETURN` semantics. The instruction pops them today but never says what they do.

Surfaced while implementing the instruction set in Nethermind.