### PR TITLE
Update EIP-8141: note that execution approval authorizes all subsequent sender frames

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -1102,6 +1102,14 @@ For deployment of the sender account in the first frame, the mempool enforces de
 
 In general, it can be assumed that handling of frame transactions imposes similar restrictions as EIP-7702 on mempool relay, i.e. only a single transaction can be pending for an account that uses frame transactions.
 
+### Execution Approval Authorizes All Subsequent Sender Frames
+
+`sender_approved` is a single transaction-scoped flag. Once a frame grants `APPROVE_EXECUTION` (or `APPROVE_EXECUTION_AND_PAYMENT`), every subsequent `SENDER` frame executes with `caller` set to `tx.sender`, not only the frame the approving code inspected. The approval is not scoped to a particular frame or call target.
+
+Validation code must therefore bind its approval to the entire set of frames it is willing to authorize. A signature with an empty `msg` commits to this, because it is verified over `compute_sig_hash(tx)`, which covers the full frame list; the default validation code relies on exactly such a signature. A validator that instead approves on the basis of an explicit 32-byte `msg` signature, or any check that does not commit to the frames, authorizes an open-ended list. Because a frame transaction carries no outer signature over the whole envelope, an observer can then reuse that approval with a different set of `SENDER` frames, since those frames were never part of what the validator verified. This is the "unchecked fields" class of issue familiar from account-abstraction relaying, now expressed in-protocol.
+
+Custom validation contracts that grant `APPROVE_EXECUTION` should verify against the canonical signature hash, or otherwise constrain every subsequent `SENDER` frame, before approving.
+
 ## Copyright
 
 Copyright and related rights waived via [CC0](../LICENSE.md).


### PR DESCRIPTION
`sender_approved` is a single transaction-scoped flag: once any frame grants `APPROVE_EXECUTION` (or `APPROVE_EXECUTION_AND_PAYMENT`), every later `SENDER` frame runs as `tx.sender`. The approval is global, not scoped to the frame or target the approving code inspected.

The existing Security Considerations note that validation code can *observe* later frames (Cross-frame Data Visibility), but not that granting execution approval *authorizes* all of them. Whether that authorization is safe depends on what the approval is bound to:

- A signature with empty `msg` is verified over `compute_sig_hash(tx)`, which commits to the full frame list. The default validation code uses exactly this, so a default-code sender only authorizes the frames it signed.
- A validator that approves on the basis of an explicit 32-byte `msg` signature, or any check that doesn't commit to the frames, authorizes an open-ended list. Since a frame transaction carries no outer signature over the whole envelope, an observer can reuse that approval with a substituted set of `SENDER` frames and validation still passes.

This is the "unchecked fields" footgun from account-abstraction relaying, now in-protocol. The added subsection states the authorization scope and the mitigation: validators granting `APPROVE_EXECUTION` should bind approval to the full frame list, e.g. by verifying against the canonical signature hash.

Surfaced while implementing the validation and frame-execution path in Nethermind.