### PR TITLE
Update EIP-8141: specify EIP-3529 storage refund accounting for frames

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -197,7 +197,7 @@ The `ReceiptPayload` is defined as:
 frame_receipt = [status, gas_used, logs]
 ```
 
-`payer` is the address of the account that paid the fees for the transaction. `status` is the return code of the top-level call. A new code `0x2` is introduced for frames which are skipped due to failed atomic batch.
+`payer` is the address of the account that paid the fees for the transaction. `status` is the return code of the top-level call. A new code `0x2` is introduced for frames which are skipped due to failed atomic batch. `gas_used` is total gas used by the frame, not accounting for refunds.
 
 #### Signature Hash
 
@@ -452,19 +452,14 @@ The `effective_gas_price` is calculated per [EIP-1559](./eip-1559.md) and `blob_
 
 Any `frame.value` transferred by `SENDER` frames is separate from `tx_fee` and follows ordinary `CALL` value-transfer semantics. The gas cost of sending `frame.value` is the same as for any `CALL` instruction.
 
-Each frame has its own `gas_limit` allocation. Unused gas from a frame is **not** available to subsequent frames.
+Each frame has its own `gas_limit` allocation. Unused gas from a frame is **not** available to subsequent frames. A rolling total `tx_unused_gas` is tracked throughout the transaction.
 
-Storage gas refunds ([EIP-3529](./eip-3529.md)) are accounted at the transaction level: refunds accumulate across frames into a single transaction-scoped `refund_counter`. Changes made to the counter by a reverted frame, or by frames unrolled as part of a failed atomic batch, are discarded together with that frame's state changes. Let `gross_gas_used` be the sum of gas used by all frames before any refund is applied. At the end of the transaction:
-
-```python
-applied_refund = min(refund_counter, gross_gas_used // 5)
-total_gas_used = gross_gas_used - applied_refund
-```
-
-Each frame receipt reports the frame's gross gas used, since the transaction-level refund cannot be attributed to any single frame. After all frames execute, the gas refund is calculated as:
+Storage gas refunds ([EIP-3529](./eip-3529.md)) accumulate across frames into a single transaction-scoped `refund_counter`. Changes made to the counter by a reverted frame, or by frames unrolled as part of a failed atomic batch, are discarded together with that frame's state changes. At the end of the transaction:
 
 ```python
-refund = sum(frame.gas_limit for frame in tx.frames) - total_gas_used
+gas_used_before_refund = tx_gas_limit - tx_unused_gas
+applied_refund = min(refund_counter, gas_used_before_refund // 5)
+gas_used = gas_used_before_refund - applied_refund
 ```
 
 This refund is returned to the gas payer (the `resolved_target` that called `APPROVE(APPROVE_PAYMENT)` or `APPROVE(APPROVE_EXECUTION_AND_PAYMENT)`) and added back to the block gas pool.

--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -452,7 +452,16 @@ The `effective_gas_price` is calculated per [EIP-1559](./eip-1559.md) and `blob_
 
 Any `frame.value` transferred by `SENDER` frames is separate from `tx_fee` and follows ordinary `CALL` value-transfer semantics. The gas cost of sending `frame.value` is the same as for any `CALL` instruction.
 
-Each frame has its own `gas_limit` allocation. Unused gas from a frame is **not** available to subsequent frames. Storage gas refunds ([EIP-3529](./eip-3529.md)) are accounted at the transaction level: refunds accumulate across frames into a single counter and are applied once at the end of the transaction, capped at one fifth of the total gas used by all frames. `total_gas_used` below is that post-refund total. After all frames execute, the gas refund is calculated as:
+Each frame has its own `gas_limit` allocation. Unused gas from a frame is **not** available to subsequent frames.
+
+Storage gas refunds ([EIP-3529](./eip-3529.md)) are accounted at the transaction level: refunds accumulate across frames into a single transaction-scoped `refund_counter`. Changes made to the counter by a reverted frame, or by frames unrolled as part of a failed atomic batch, are discarded together with that frame's state changes. Let `gross_gas_used` be the sum of gas used by all frames before any refund is applied. At the end of the transaction:
+
+```python
+applied_refund = min(refund_counter, gross_gas_used // 5)
+total_gas_used = gross_gas_used - applied_refund
+```
+
+Each frame receipt reports the frame's gross gas used, since the transaction-level refund cannot be attributed to any single frame. After all frames execute, the gas refund is calculated as:
 
 ```python
 refund = sum(frame.gas_limit for frame in tx.frames) - total_gas_used

--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -452,7 +452,7 @@ The `effective_gas_price` is calculated per [EIP-1559](./eip-1559.md) and `blob_
 
 Any `frame.value` transferred by `SENDER` frames is separate from `tx_fee` and follows ordinary `CALL` value-transfer semantics. The gas cost of sending `frame.value` is the same as for any `CALL` instruction.
 
-Each frame has its own `gas_limit` allocation. Unused gas from a frame is **not** available to subsequent frames. After all frames execute, the gas refund is calculated as:
+Each frame has its own `gas_limit` allocation. Unused gas from a frame is **not** available to subsequent frames. Storage gas refunds ([EIP-3529](./eip-3529.md)) are likewise accounted per frame: within each frame the refund is capped at one fifth of that frame's gas used, and a refund earned in one frame cannot offset gas spent in another. `total_gas_used` below is the sum of each frame's gas used after its own refund is applied. After all frames execute, the gas refund is calculated as:
 
 ```python
 refund = sum(frame.gas_limit for frame in tx.frames) - total_gas_used

--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -452,7 +452,7 @@ The `effective_gas_price` is calculated per [EIP-1559](./eip-1559.md) and `blob_
 
 Any `frame.value` transferred by `SENDER` frames is separate from `tx_fee` and follows ordinary `CALL` value-transfer semantics. The gas cost of sending `frame.value` is the same as for any `CALL` instruction.
 
-Each frame has its own `gas_limit` allocation. Unused gas from a frame is **not** available to subsequent frames. Storage gas refunds ([EIP-3529](./eip-3529.md)) are likewise accounted per frame: within each frame the refund is capped at one fifth of that frame's gas used, and a refund earned in one frame cannot offset gas spent in another. `total_gas_used` below is the sum of each frame's gas used after its own refund is applied. After all frames execute, the gas refund is calculated as:
+Each frame has its own `gas_limit` allocation. Unused gas from a frame is **not** available to subsequent frames. Storage gas refunds ([EIP-3529](./eip-3529.md)) are accounted at the transaction level: refunds accumulate across frames into a single counter and are applied once at the end of the transaction, capped at one fifth of the total gas used by all frames. `total_gas_used` below is that post-refund total. After all frames execute, the gas refund is calculated as:
 
 ```python
 refund = sum(frame.gas_limit for frame in tx.frames) - total_gas_used


### PR DESCRIPTION
The gas accounting section defines the end-of-transaction refund as `sum(frame.gas_limit) - total_gas_used`, i.e. the unused portion of each frame's allocation. It doesn't say how [EIP-3529](./eip-3529.md) storage refunds (from clearing storage) are handled, or how `total_gas_used` incorporates them.

This matters for consensus: a frame transaction whose frames clear storage produces a different `gas_used`, receipt, payer charge, and state root depending on the choice, so every implementation has to make the same one.

Per the discussion below, this specifies **transaction-level** accounting: refunds accumulate across frames into a single counter and are applied once at the end of the transaction, capped at one fifth of the total gas used by all frames — the same shape as ordinary transactions, and the machinery every client already has. Frame gas limits remain per-frame, so execution isolation is untouched; only the settlement accounting is shared.

Surfaced while implementing the gas-accounting path.