### PR TITLE
Update EIP-8141: apply the EIP-7623 calldata floor to frame and signature data

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -410,6 +410,32 @@ tx_gas_limit = (
 
 Where `calldata_cost` is calculated per standard [EIP-7623](./eip-7623.md) rules.
 
+The [EIP-7623](./eip-7623.md) calldata floor applies to a frame transaction's frame and signature data, so that it cannot carry large payloads while paying only the standard per-token cost. Let `calldata_tokens` be the EIP-7623 token count over that data:
+
+```python
+calldata_tokens = (
+    sum(tokens_in(frame.data) for frame in tx.frames)
+    + sum(tokens_in(sig.signer) + tokens_in(sig.msg) + tokens_in(sig.signature)
+          for sig in tx.signatures)
+)
+```
+
+where `tokens_in` counts tokens as in EIP-7623. Mirroring EIP-7623, mandatory costs are always charged and the calldata cost is floored against execution, so the gas charged to the payer is:
+
+```python
+charged_gas = (
+    FRAME_TX_INTRINSIC_COST
+    + len(tx.frames) * FRAME_TX_PER_FRAME_COST
+    + signature_verification_cost
+    + max(
+        frame_data_cost + signature_data_cost + total_gas_used,
+        TOTAL_COST_FLOOR_PER_TOKEN * calldata_tokens,
+    )
+)
+```
+
+where `TOTAL_COST_FLOOR_PER_TOKEN` is as defined in EIP-7623. A transaction whose `tx_gas_limit` is below `FRAME_TX_INTRINSIC_COST + len(tx.frames) * FRAME_TX_PER_FRAME_COST + signature_verification_cost + TOTAL_COST_FLOOR_PER_TOKEN * calldata_tokens` is invalid, so the floor is reserved independently of execution as required by EIP-7623.
+
 The total fee is defined as:
 
 ```python


### PR DESCRIPTION
The gas accounting section computes `frame_data_cost` and `signature_data_cost` with the standard [EIP-7623](./eip-7623.md) per-token cost, but the transaction's gas is never floored. EIP-7623's defining feature is that floor, `max(standard + execution, TOTAL_COST_FLOOR_PER_TOKEN * tokens)`, which makes a transaction pay for its calldata independently of how little it executes, and it exists to bound calldata's contribution to block size.

Frame data and signature bytes are the calldata-equivalent payloads of a frame transaction: they occupy block space just like ordinary calldata. Without the floor, a frame transaction can carry large frame or signature data while doing minimal execution and pay only the standard per-token cost, a way around the very bound EIP-7623 introduces. It is also a consensus question: reading "per EIP-7623 rules" as including the floor, versus reading the literal sum formula, gives a different charged gas and a different minimum gas limit, so implementations have to agree.

This applies the floor over the frame and signature data, expressed in the section's existing terms: a `calldata_tokens` count over `frame.data` and the signature fields, and a `charged_gas` that keeps the mandatory costs (intrinsic, per-frame, signature verification) always paid while flooring the calldata cost against execution, mirroring EIP-7623. It also states the reservation floor, so the minimum is covered independently of execution.

If the intent was to exempt frame transactions from the floor, that is a notable departure worth stating explicitly with its rationale. Otherwise this closes the gap. The placement can be adjusted to fit the gas model; the terms used here are the ones already in the section.

Surfaced while implementing the gas-accounting path in Nethermind