### PR TITLE
Update EIP-8141: define the Receipts message encoding for frame transaction receipts

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -832,15 +832,11 @@ Validation logic for other transaction types remains unchanged, i.e. the transac
 
 ### Networking
 
-A receipt for a frame transaction carries fields that existing wire encodings cannot express: [EIP-7642](./eip-7642.md) (eth/69) encodes every receipt as `[tx-type, post-state-or-status, cumulative-gas, logs]`, which has no place for `payer` or the per-frame entries, and eth/68 pins typed receipts to the legacy `[status, cumulative-gas, bloom, logs]` payload. A syncing peer needs the full receipt payload to recompute `receiptsRoot`.
-
 In the `Receipts` message of the protocol version carrying this fork, a frame transaction receipt is encoded mirroring its consensus `ReceiptPayload`:
 
 ```
 receipt = [tx-type, cumulative-gas, payer, [[status, gas-used, logs], ...]]
 ```
-
-Because the eth/69 receipt schema is fixed, carrying this fork requires a wire protocol version that adds this encoding.
 
 ## Rationale
 

--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -830,6 +830,18 @@ Do not apply the restriction put in place by [EIP-3607](./eip-3607.md) to frame 
 Specifically, `SENDER` frames originate calls where `tx.sender` is a contract account.
 Validation logic for other transaction types remains unchanged, i.e. the transaction is only valid if the sender account's code is either empty or a valid delegation indicator.
 
+### Networking
+
+A receipt for a frame transaction carries fields that existing wire encodings cannot express: [EIP-7642](./eip-7642.md) (eth/69) encodes every receipt as `[tx-type, post-state-or-status, cumulative-gas, logs]`, which has no place for `payer` or the per-frame entries, and eth/68 pins typed receipts to the legacy `[status, cumulative-gas, bloom, logs]` payload. A syncing peer needs the full receipt payload to recompute `receiptsRoot`.
+
+In the `Receipts` message of the protocol version carrying this fork, a frame transaction receipt is encoded mirroring its consensus `ReceiptPayload`:
+
+```
+receipt = [tx-type, cumulative-gas, payer, [[status, gas-used, logs], ...]]
+```
+
+Because the eth/69 receipt schema is fixed, carrying this fork requires a wire protocol version that adds this encoding.
+
 ## Rationale
 
 ### Canonical signature hash


### PR DESCRIPTION
The receipt payload for frame transactions is `[cumulative_gas_used, payer, [frame_receipt, ...]]`, but nothing defines how these receipts are exchanged between peers. A syncing peer has to recompute `receiptsRoot` from the receipts it downloads, and `payer` and the per-frame `[status, gas_used, logs]` entries are part of the hashed payload and derivable from nothing else, so without a defined encoding, implementations each invent their own (we had to when prototyping).

This adds a Networking subsection defining the `Receipts` message encoding as the mirror of the consensus payload:

```
receipt = [tx-type, cumulative-gas, payer, [[status, gas-used, logs], ...]]
```

Kept deliberately minimal per review, no wire-protocol version specifics; those belong to the devp2p specs when the encoding is adopted there.
