### PR TITLE
Update EIP-8141: use skipped receipt status code

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -196,7 +196,7 @@ The `ReceiptPayload` is defined as:
 frame_receipt = [status, gas_used, logs]
 ```
 
-`payer` is the address of the account that paid the fees for the transaction. `status` is the return code of the top-level call. A new code `0x3` is introduced for frames which are skipped due to failed atomic batch.
+`payer` is the address of the account that paid the fees for the transaction. `status` is the return code of the top-level call. A new code `0x2` is introduced for frames which are skipped due to failed atomic batch.
 
 #### Signature Hash
 
@@ -562,7 +562,7 @@ This instruction gives access to frame-scoped information. The gas cost of this 
 
 Notes:
 
-- The `status` field (0x05) returns `0` for failure or `1` for success.
+- The `status` field (0x05) returns `0` for failure, `1` for success, or `2` for a frame skipped due to a failed atomic batch.
 - Undefined `param` values result in an exceptional halt.
 - Out-of-bounds access for `frameIndex` results in an exceptional halt.
 - Attempting to access the return `status` of the current frame or a subsequent frame results in an exceptional halt.


### PR DESCRIPTION
For some reason thought 0x3 was the next available status code, but actually was 0x2. Updating accordingly.