### PR TITLE
Update EIP-8141: allow EOA sponsor again

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -436,7 +436,8 @@ Frame transactions can be used by accounts who do not have deployed code, nor an
 - If `mode` is `VERIFY`:
   - Read the allowed approval scope from the flags field: `allowed_scope = frame.flags & APPROVE_SCOPE_MASK`.
   - If `allowed_scope == APPROVE_SCOPE_NONE`, revert.
-  - If there is not a `SECP256K1` signature `sig` at index `0` such that `resolved_signer == resolved_target` and `sig.msg == Bytes()`, revert.
+  - Let `sig_index = 0` if `allowed_scope & APPROVE_EXECUTION != 0`, else `sig_index = 1`.
+  - If there is not a `SECP256K1` signature `sig` at index `sig_index` such that `resolved_signer == resolved_target` and `sig.msg == Bytes()`, revert.
   - Call `APPROVE(allowed_scope)`.
 - If `mode` is `SENDER` or `DEFAULT`:
   - Return successfully as if calling empty code.


### PR DESCRIPTION
In #11814, we thought restricting the signature in the default code to index 0 would be a simplification since the default code would no longer need to loop through all signatures. This unfortunately broke the ability for codeless EOA to sponsor a transaction. So now, we check based on the frame scope which index the signature is expected.

For execution and pay+execution, it's in index 0. For pay it is in index 1.