### PR TITLE
Update EIP-8141: approval effects are not reverted by frame revert or atomic-batch unroll

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -371,6 +371,16 @@ Then for each frame:
     - Since skipped frames are not executed, the gas value allotted to them is refunded at the end of the transaction.
     - If the frame does not have an associated atomic batch, further special handling is not needed, simple revert the individual frame.
 
+The approval effects set by a successful `APPROVE` are, by scope:
+
+- `APPROVE_EXECUTION` sets `sender_approved`;
+- `APPROVE_PAYMENT` increments the sender nonce, sets `payer`, and collects the transaction's maximum cost;
+- `APPROVE_EXECUTION_AND_PAYMENT` performs both.
+
+These effects take hold only if the frame that executed `APPROVE` completes successfully; if that frame reverts, they are discarded with it. Once committed, they are transaction-scoped: a subsequent frame revert or an atomic-batch unroll MUST NOT roll them back, and they persist for the remainder of the transaction, even if the `APPROVE` frame is a member of an atomic batch that is later unrolled. They remain part of the enclosing transaction and block state, so they are discarded only if the transaction is invalid or its block is removed by a reorg.
+
+The nonce increment and cost collection are ordinary state writes. A client that implements atomic-batch rollback by restoring a snapshot taken at the start of the batch MUST exempt these writes, and the `payer` assignment, from that rollback (or re-apply them afterwards). Otherwise an in-batch `APPROVE_PAYMENT` whose batch is unrolled would have its debit and nonce reverted while `payer` survives, so the terminal `payer != None` check passes and the end-of-transaction refund pays the payer funds that were never collected.
+
 After executing all frames, verify that `payer` has been set (i.e. `payer != None`). If `payer` is set, refund any unpaid gas to the payer. If it is not, the whole transaction is invalid.
 
 ##### Cross-frame interactions
@@ -738,7 +748,7 @@ To be accepted into the public mempool, a frame transaction must satisfy the fol
 4. `pay` must execute in `VERIFY` mode, have flags set to `APPROVE_PAYMENT`, and must successfully call `APPROVE(APPROVE_PAYMENT)`
 5. No frame in the validation prefix may have the `ATOMIC_BATCH_FLAG` set.
 6. The sum of `gas_limit` values across the validation prefix, plus the intrinsic cost of validating `tx.signatures`, must not exceed `MAX_VERIFY_GAS`.
-7. Nodes should stop simulation immediately once `payer` has been set.
+7. Nodes should stop simulation immediately once `payer` has been set. As with the approval effects in the Behavior section, `payer` is set only when the frame that executes the payment-scoped `APPROVE` completes successfully; an `APPROVE` in an inner call does not set `payer` until that enclosing frame returns successfully, so simulation must continue through it.
 8. There must not be `VERIFY` frame after validation prefix.
 
 #### Expiry Verifier Frame

--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -364,22 +364,13 @@ Then for each frame:
 1. If frame has mode `VERIFY` the following additional requirements are imposed:
     - Execute the frame as a `STATICCALL`, disallowing state manipulation.
         - Only `APPROVE` can modify the state or transaction context in `VERIFY`.
-    - If the frame reverts, the transaction is invalid.
+    - If the frame reverts, the transaction is invalid. This would unroll any effects of `APPROVE`.
 1. If a frame is part of an atomic batch and it fails, unroll the associated atomic batch.
-    - An **atomic batch** is a maximal contiguous sequence of frames `[i, j]` where `j > i`, frames `i` through `j - 1` have `ATOMIC_BATCH_FLAG` set, and frame `j` does not have `ATOMIC_BATCH_FLAG` set.
+    - An **atomic batch** is a maximal contiguous sequence of frames `[i, j]` where `j > i`, non-`VERIFY` frames `i` through `j - 1` have `ATOMIC_BATCH_FLAG` set, and frame `j` does not have `ATOMIC_BATCH_FLAG` set.
     - When a frame in the batch fails, the state must be rolled back to the condition it was immediately before the atomic batch began. All remaining frames in the atomic batch are skipped.
     - Since skipped frames are not executed, the gas value allotted to them is refunded at the end of the transaction.
     - If the frame does not have an associated atomic batch, further special handling is not needed, simple revert the individual frame.
 
-The approval effects set by a successful `APPROVE` are, by scope:
-
-- `APPROVE_EXECUTION` sets `sender_approved`;
-- `APPROVE_PAYMENT` increments the sender nonce, sets `payer`, and collects the transaction's maximum cost;
-- `APPROVE_EXECUTION_AND_PAYMENT` performs both.
-
-These effects take hold only if the frame that executed `APPROVE` completes successfully; if that frame reverts, they are discarded with it. Once committed, they are transaction-scoped: a subsequent frame revert or an atomic-batch unroll MUST NOT roll them back, and they persist for the remainder of the transaction, even if the `APPROVE` frame is a member of an atomic batch that is later unrolled. They remain part of the enclosing transaction and block state, so they are discarded only if the transaction is invalid or its block is removed by a reorg.
-
-The nonce increment and cost collection are ordinary state writes. A client that implements atomic-batch rollback by restoring a snapshot taken at the start of the batch MUST exempt these writes, and the `payer` assignment, from that rollback (or re-apply them afterwards). Otherwise an in-batch `APPROVE_PAYMENT` whose batch is unrolled would have its debit and nonce reverted while `payer` survives, so the terminal `payer != None` check passes and the end-of-transaction refund pays the payer funds that were never collected.
 
 After executing all frames, verify that `payer` has been set (i.e. `payer != None`). If `payer` is set, refund any unpaid gas to the payer. If it is not, the whole transaction is invalid.
 
@@ -748,7 +739,7 @@ To be accepted into the public mempool, a frame transaction must satisfy the fol
 4. `pay` must execute in `VERIFY` mode, have flags set to `APPROVE_PAYMENT`, and must successfully call `APPROVE(APPROVE_PAYMENT)`
 5. No frame in the validation prefix may have the `ATOMIC_BATCH_FLAG` set.
 6. The sum of `gas_limit` values across the validation prefix, plus the intrinsic cost of validating `tx.signatures`, must not exceed `MAX_VERIFY_GAS`.
-7. Nodes should stop simulation immediately once `payer` has been set. As with the approval effects in the Behavior section, `payer` is set only when the frame that executes the payment-scoped `APPROVE` completes successfully; an `APPROVE` in an inner call does not set `payer` until that enclosing frame returns successfully, so simulation must continue through it.
+7. Nodes should stop simulation immediately once `payer` has been set and the associated `VERIFY` frame completes successfully.
 8. There must not be `VERIFY` frame after validation prefix.
 
 #### Expiry Verifier Frame

--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -371,7 +371,6 @@ Then for each frame:
     - Since skipped frames are not executed, the gas value allotted to them is refunded at the end of the transaction.
     - If the frame does not have an associated atomic batch, further special handling is not needed, simple revert the individual frame.
 
-
 After executing all frames, verify that `payer` has been set (i.e. `payer != None`). If `payer` is set, refund any unpaid gas to the payer. If it is not, the whole transaction is invalid.
 
 ##### Cross-frame interactions


### PR DESCRIPTION
While reviewing EIP-8141 implementation, I ran into a case where the revert scope of the approval effects is not fully specified.

`APPROVE(APPROVE_PAYMENT)` increments the sender nonce, sets `payer`, and collects the transaction's maximum cost (§Behavior, `APPROVE` Instruction). The atomic-batch rule says a failed batch rolls the state "back to the condition it was immediately before the atomic batch began." The spec does not say whether the transaction-scoped approval effects — the nonce increment, `payer`, `sender_approved`, and the collected cost — are part of that rolled-back state.

This can cause clients to diverge. If `APPROVE(APPROVE_PAYMENT)` is placed inside an atomic batch whose later member fails, one client could roll `payer` back to `None` (so the terminal `payer != None` check fails → transaction invalid), while another treats the approval effects as transaction-scoped (→ valid). The two clients would then disagree on the same block.

This PR adds one sentence to §Behavior stating that these approval effects are transaction-scoped and are not discarded by an individual frame revert or an atomic-batch unroll. This matches the intent of the "transaction-scoped variables" initialization, and it is also the rule that EIP-8250 already adds for keyed-nonce consumption — so it seems better to state it in EIP-8141 directly.