### PR TITLE
Update EIP-8141: note sponsor repayment reversibility and batch the repayment in Example 3

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -1001,17 +1001,17 @@ Frame 0 uses a signature entry with empty `msg` and calls `APPROVE(APPROVE_EXECU
 | ----- | ------- | ----------- | ------------------ | ------------- | ----- | ---------------------- |
 | 0     | VERIFY  | ENTRY_POINT | APPROVE_EXECUTION  | Null (sender) | 0     | Empty                  |
 | 1     | VERIFY  | ENTRY_POINT | APPROVE_PAYMENT    | Sponsor       | 0     | Sponsor data           |
-| 2     | SENDER  | Sender      | APPROVE_SCOPE_NONE | ERC-20        | 0     | transfer(Sponsor,fees) |
+| 2     | SENDER  | Sender      | ATOMIC_BATCH_FLAG  | ERC-20        | 0     | transfer(Sponsor,fees) |
 | 3     | SENDER  | Sender      | APPROVE_SCOPE_NONE | Target addr   | 0     | Call data              |
 | 4     | DEFAULT | ENTRY_POINT | APPROVE_SCOPE_NONE | Sponsor       | 0     | Post op call           |
 
 - Frame 0: Uses the sender's signature entry with empty `msg` and calls `APPROVE(APPROVE_EXECUTION)` to authorize execution from sender.
-- Frame 1: Inspects signature metadata in `tx.signatures` if needed, and checks that the next frame is an ERC-20 send of the right size to the sponsor. Calls `APPROVE(APPROVE_PAYMENT)` to authorize payment.
-- Frame 2: Sends tokens to sponsor.
-- Frame 3: User's intended call.
+- Frame 1: Inspects signature metadata in `tx.signatures` if needed, and checks that the next frame is an ERC-20 send of the right size to the sponsor, that it begins an atomic batch, and that no `SENDER` frame lies outside that batch. Calls `APPROVE(APPROVE_PAYMENT)` to authorize payment.
+- Frame 2: Sends tokens to sponsor. It sets `ATOMIC_BATCH_FLAG` so it is batched with frame 3: if either the repayment or the intended call reverts, both are unrolled. This prevents the sponsee from letting the repayment revert while its intended call still executes.
+- Frame 3: User's intended call, and the terminating frame of the atomic batch begun in frame 2.
 - Frame 4 (optional): Check unpaid gas, refund tokens, possibly convert tokens to ETH on an AMM.
 
-Note: to be included in the public mempool under the current model, sponsors must accept some risk of frontrunning by the sponsee who can zero out their ERC-20 balance before the sponsored transaction lands on-chain.
+Note: payment collected at `APPROVE(APPROVE_PAYMENT)` in frame 1 is final and is not reverted by a later frame. Because every `SENDER` frame is inside the atomic batch begun by the repayment, a sponsee that zeroes its ERC-20 balance only causes its own intended call to be skipped and gains nothing; the sponsor still pays gas for the reverted attempt, which is the residual, unprofitable griefing risk inherent to public sponsorship.
 
 ### Data Efficiency
 
@@ -1129,6 +1129,10 @@ Because `tx.sender` is explicit in the transaction envelope, an attacker can sub
 #### Cross-frame Data Visibility During Validation
 
 `FRAMEPARAM`, `FRAMEDATALOAD`, and `FRAMEDATACOPY` allow validation code to inspect other frames, including later `SENDER` frames and their `value`s. As a result, paymasters and other `VERIFY` frames can observe user operation parameters before approval and may condition their behavior on that information. Users should therefore treat non-`VERIFY` frame parameters and data as visible to validation logic and should not rely on untrusted paymasters or verifiers to keep such information private.
+
+#### Sponsor Repayment Reversibility
+
+Payment collected when a frame calls `APPROVE(APPROVE_PAYMENT)` or `APPROVE(APPROVE_EXECUTION_AND_PAYMENT)` is not reverted by the failure of any later frame. A frame that repays a sponsor (for example, an ERC-20 transfer to the sponsor) executing after payment approval is an ordinary frame: if it is not part of an atomic batch, its revert discards only that frame while the remaining frames, including the sponsee's intended operation, continue. A sponsee could therefore let the repayment frame revert while its intended operation still executes, obtaining execution without paying the sponsor. Sponsors should place the repayment frame and the sponsee's intended `SENDER` frame(s) in the same atomic batch so that they share fate, as shown in Example 3. The check must cover the whole frame list: the repayment frame begins an atomic batch and no `SENDER` frame lies outside it. A `SENDER` frame placed before the repayment or after the batch's terminal frame executes regardless of the repayment's fate. A `VERIFY` frame can perform this scan with `FRAMEPARAM` (mode and flags of every frame) before calling `APPROVE(APPROVE_PAYMENT)`. Only the gas payment itself is guaranteed final; all repayment and other post-payment effects are reversible.
 
 #### Arbitrary Signature Malleability
 


### PR DESCRIPTION
A follow-up from implementing EIP-8141, on the sponsor side.

Payment is collected when a frame calls `APPROVE(APPROVE_PAYMENT)` and is not reverted by a later frame. In Example 3 (Sponsored Transaction), the sponsor approves payment in frame 1, and the ERC-20 repayment to the sponsor (frame 2) and the sponsee's intended call (frame 3) are separate, non-batched frames. Per §Behavior, a non-batched frame that reverts only discards itself while later frames continue. So a sponsee can make the repayment (frame 2) revert while its intended call (frame 3) still executes — obtaining execution without paying the sponsor. This is a stronger version of the frontrunning risk the current note under Example 3 already mentions, since it needs no frontrun and the intended call still lands.

This PR:

- Adds a "Sponsor Repayment Reversibility" note to Security Considerations describing this and the mitigation.
- Updates Example 3 to place the repayment frame in the same atomic batch as the intended call (`ATOMIC_BATCH_FLAG` on frame 2), so if the repayment fails the intended call is unrolled with it, removing the incentive. A `VERIFY` frame can confirm this structure via `FRAMEPARAM` before approving payment.

No consensus change — this is an informative note plus an example fix.
