### PR TITLE
Update EIP-8250: exclude KEYED_NONCE_FIRST_USE_GAS from MAX_VERIFY_GAS accounting

### DIFF
--- a/EIPS/eip-8250.md
+++ b/EIPS/eip-8250.md
@@ -160,6 +160,8 @@ Gas deducted as `KEYED_NONCE_FIRST_USE_GAS` is gas used by the frame executing `
 
 Keyed-nonce reads and writes performed by stateful validity and `consume_nonce_set` are protocol bookkeeping: they do NOT add `NONCE_MANAGER` or its slots to [EIP-2929](./eip-2929.md) `accessed_addresses` or `accessed_storage_keys`, are NOT charged under [EIP-2200](./eip-2200.md) `SSTORE` pricing, and do NOT warm the address or slot for later user-level access.
 
+For EIP-8141 public-mempool accounting, `KEYED_NONCE_FIRST_USE_GAS` is a state-growth surcharge rather than validation work. A node evaluating `MAX_VERIFY_GAS` for a post-fork frame transaction MUST exclude `KEYED_NONCE_FIRST_USE_GAS * first_use_count` from the validation-prefix gas it counts under EIP-8141's mempool structural rules. Without this exclusion, the payment-scoped `APPROVE` frame (which sets `payer` and therefore terminates the validation prefix) must reserve `KEYED_NONCE_FIRST_USE_GAS * first_use_count` within its own `gas_limit`, so `MAX_VERIFY_GAS = 100000` would admit only about five first-use keys — below `MAX_NONCE_KEYS = 16` and below the key counts that the privacy withdrawals motivating this EIP require.
+
 ### TXPARAM
 
 `TXPARAM(0x01)` returns `tx.nonce_seq`. Four new indices are added:


### PR DESCRIPTION
While implementing EIP-8250 on top of EIP-8141, I hit an interaction between the keyed-nonce first-use surcharge and the public-mempool gas cap.

`KEYED_NONCE_FIRST_USE_GAS` (20000 per first-use key) is charged to the frame executing the payment-scoped `APPROVE`. That `APPROVE` sets `payer`, which by EIP-8141's definition is the last frame of the validation prefix. EIP-8141's mempool structural rule caps "the sum of `gas_limit` values across the validation prefix" at `MAX_VERIFY_GAS = 100000`. So the `APPROVE` frame must reserve `20000 * first_use_count` inside a `gas_limit` that counts against 100000 — only about 5 first-use keys fit, and fewer after the signature intrinsic and verify work.

This is below `MAX_NONCE_KEYS = 16`, and below what this EIP's motivating use case needs: a privacy withdrawal spending several nullifier-derived keys (all first-use at `nonce_seq == 0`) cannot enter the public mempool, which pushes exactly those transactions to private channels.

The surcharge is a state-growth price, not validation work the node performs (the node only does one `SLOAD` per selected key). This PR states that `MAX_VERIFY_GAS` accounting excludes `KEYED_NONCE_FIRST_USE_GAS * first_use_count`, mirroring the EIP-2929 / EIP-2200 exemption this EIP already gives keyed-nonce reads and writes.

An alternative would be to account the surcharge as a transaction-level term (added to `tx_gas_limit` like `signature_verification_cost`) rather than deducting it from the validation-prefix frame's gas. Filing as a draft — happy to take whichever direction the authors prefer.
