### PR TITLE
Update EIP-8250: price nonce_keys and nonce_seq as transaction data

### DIFF
--- a/EIPS/eip-8250.md
+++ b/EIPS/eip-8250.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2026-04-16
-requires: 8141
+requires: 7623, 8141
 ---
 
 ## Abstract
@@ -68,11 +68,25 @@ The bytes this EIP adds to the payload are priced as transaction data. Define:
 nonce_calldata = rlp(nonce_keys) || rlp(nonce_seq)
 ```
 
-`nonce_calldata` is priced exactly as EIP-8141 prices frame and signature data under [EIP-7623](./eip-7623.md):
+`nonce_calldata` is priced exactly as EIP-8141 prices frame and signature data under [EIP-7623](./eip-7623.md), by adding it to EIP-8141's three gas quantities:
 
-- add `calldata_cost(nonce_calldata)` to `tx_gas_limit`;
-- add `calldata_cost(nonce_calldata)` to the non-floor branch of `charged_gas`, i.e. to `frame_data_cost + signature_data_cost + total_gas_used`;
-- add `tokens_in(nonce_calldata)` to `calldata_tokens` for the EIP-7623 floor.
+- `calldata_cost(nonce_calldata)` is added to `tx_gas_limit`;
+- `calldata_cost(nonce_calldata)` is added to the non-floor argument of the `max` in `charged_gas`;
+- `tokens_in(nonce_calldata)` is added to `calldata_tokens`, which feeds the EIP-7623 floor argument `TOTAL_COST_FLOOR_PER_TOKEN * calldata_tokens`.
+
+Explicitly, `charged_gas` becomes:
+
+```python
+charged_gas = (
+    FRAME_TX_INTRINSIC_COST
+    + len(tx.frames) * FRAME_TX_PER_FRAME_COST
+    + signature_verification_cost
+    + max(
+        frame_data_cost + signature_data_cost + calldata_cost(nonce_calldata) + total_gas_used,
+        TOTAL_COST_FLOOR_PER_TOKEN * calldata_tokens,
+    )
+)
+```
 
 This keeps `nonce_keys` and `nonce_seq` consistent with the pricing of EIP-8141's other transaction data, and keeps `tx_gas_limit` and `charged_gas` consistent.
 

--- a/EIPS/eip-8250.md
+++ b/EIPS/eip-8250.md
@@ -62,16 +62,30 @@ The frame-transaction payload becomes:
 
 `nonce_keys` is a list of `uint256` values; `nonce_seq` is a `uint64`. Each nonce key and `nonce_seq` MUST be encoded as canonical minimal-length RLP integers. The frame layout, signature-hash procedure, and all other EIP-8141 transaction fields are unchanged.
 
+The bytes this EIP adds to the payload are priced as transaction data. Define:
+
+```python
+nonce_calldata = rlp(nonce_keys) || rlp(nonce_seq)
+```
+
+`nonce_calldata` is priced exactly as EIP-8141 prices frame and signature data under [EIP-7623](./eip-7623.md):
+
+- add `calldata_cost(nonce_calldata)` to `tx_gas_limit`;
+- add `calldata_cost(nonce_calldata)` to the non-floor branch of `charged_gas`, i.e. to `frame_data_cost + signature_data_cost + total_gas_used`;
+- add `tokens_in(nonce_calldata)` to `calldata_tokens` for the EIP-7623 floor.
+
+This keeps `nonce_keys` and `nonce_seq` consistent with the pricing of EIP-8141's other transaction data, and keeps `tx_gas_limit` and `charged_gas` consistent.
+
 Decoders MUST reject a post-fork `FRAME_TX_TYPE` transaction if any of the following is true:
 
-* the payload does not match the post-fork schema;
-* `nonce_keys` is not an RLP list;
-* `len(nonce_keys) < 1` or `len(nonce_keys) > MAX_NONCE_KEYS`;
-* any item in `nonce_keys`, or `nonce_seq`, is not encoded as a canonical RLP integer;
-* any item in `nonce_keys` is greater than or equal to `2**256`;
-* `nonce_seq >= 2**64`;
-* `nonce_keys` is not strictly increasing by numeric value;
-* any item in `nonce_keys` is `0` and `nonce_keys != [0]`.
+- the payload does not match the post-fork schema;
+- `nonce_keys` is not an RLP list;
+- `len(nonce_keys) < 1` or `len(nonce_keys) > MAX_NONCE_KEYS`;
+- any item in `nonce_keys`, or `nonce_seq`, is not encoded as a canonical RLP integer;
+- any item in `nonce_keys` is greater than or equal to `2**256`;
+- `nonce_seq >= 2**64`;
+- `nonce_keys` is not strictly increasing by numeric value;
+- any item in `nonce_keys` is `0` and `nonce_keys != [0]`.
 
 ### Nonce state
 


### PR DESCRIPTION
A small gas-accounting gap noticed while implementing EIP-8250.

This EIP adds `nonce_keys` (up to `MAX_NONCE_KEYS = 16` 32-byte values) and `nonce_seq` to the frame-transaction payload, but does not add their cost to EIP-8141's `tx_gas_limit`. EIP-8141 charges frame `data` and the signature fields under EIP-7623 calldata rules; the bytes this EIP adds are not charged, so up to ~512 bytes of `nonce_keys` ride for free relative to other transaction data.

This PR states that `tx_gas_limit` additionally includes `calldata_cost(nonce_keys) + calldata_cost(nonce_seq)` under EIP-7623, consistent with how EIP-8141 prices its other data. This mirrors the fix made for EIP-8272 in #11931.
