### PR TITLE
Update EIP-8272: restore signatures field in payload and elide signature bytes in compute_sig_hash

### DIFF
--- a/EIPS/eip-8272.md
+++ b/EIPS/eip-8272.md
@@ -191,20 +191,17 @@ The `slot` field is a slot number, not a timestamp or block number.
 
 The frame layout and frame execution rules are otherwise unchanged. `recent_root_references` is a top-level transaction field and is included in `compute_sig_hash(tx)`.
 
-The post-fork signature hash follows EIP-8141 over the ten-field payload. It applies EIP-8141's signature-byte elision (any signature with empty `msg` has its raw `signature` bytes elided) together with the VERIFY-frame `data` elision:
+The post-fork signature hash follows EIP-8141 over the ten-field payload, eliding the raw `signature` bytes of any signature with empty `msg`:
 
 ```python
 def compute_sig_hash(tx: FrameTx) -> Hash:
-    for i, frame in enumerate(tx.frames):
-        if frame.mode == VERIFY and frame.target != EXPIRY_VERIFIER:
-            tx.frames[i].data = Bytes()
     for i, sig in enumerate(tx.signatures):
         if len(sig.msg) == 0:
             tx.signatures[i].signature = Bytes()
     return keccak(bytes([FRAME_TX_TYPE]) + rlp(tx))
 ```
 
-where `rlp(tx)` is the post-fork ten-field payload. `recent_root_references` is not elided by the VERIFY-frame data elision rule.
+where `rlp(tx)` is the post-fork ten-field payload.
 
 Frame data, including VERIFY frame data, MUST NOT add, remove, or modify the transaction's recent root reference set.
 

--- a/EIPS/eip-8272.md
+++ b/EIPS/eip-8272.md
@@ -162,10 +162,10 @@ Each `(source_id, S)` has at most one referenceable root on the canonical chain.
 
 ### Transaction payload
 
-The pre-fork EIP-8141 frame-transaction payload has eight fields:
+The pre-fork EIP-8141 frame-transaction payload has nine fields:
 
 ```text
-[chain_id, nonce, sender, frames,
+[chain_id, nonce, sender, frames, signatures,
  max_priority_fee_per_gas, max_fee_per_gas,
  max_fee_per_blob_gas, blob_versioned_hashes]
 ```
@@ -173,7 +173,7 @@ The pre-fork EIP-8141 frame-transaction payload has eight fields:
 The post-fork frame-transaction payload becomes:
 
 ```text
-[chain_id, nonce, sender, frames,
+[chain_id, nonce, sender, frames, signatures,
  max_priority_fee_per_gas, max_fee_per_gas,
  max_fee_per_blob_gas, blob_versioned_hashes,
  recent_root_references]
@@ -191,17 +191,20 @@ The `slot` field is a slot number, not a timestamp or block number.
 
 The frame layout and frame execution rules are otherwise unchanged. `recent_root_references` is a top-level transaction field and is included in `compute_sig_hash(tx)`.
 
-The post-fork signature hash follows EIP-8141 over the nine-field payload:
+The post-fork signature hash follows EIP-8141 over the ten-field payload. It applies EIP-8141's signature-byte elision (any signature with empty `msg` has its raw `signature` bytes elided) together with the VERIFY-frame `data` elision:
 
 ```python
 def compute_sig_hash(tx: FrameTx) -> Hash:
     for i, frame in enumerate(tx.frames):
         if frame.mode == VERIFY and frame.target != EXPIRY_VERIFIER:
             tx.frames[i].data = Bytes()
+    for i, sig in enumerate(tx.signatures):
+        if len(sig.msg) == 0:
+            tx.signatures[i].signature = Bytes()
     return keccak(bytes([FRAME_TX_TYPE]) + rlp(tx))
 ```
 
-where `rlp(tx)` is the post-fork nine-field payload. `recent_root_references` is not elided by the VERIFY-frame data elision rule.
+where `rlp(tx)` is the post-fork ten-field payload. `recent_root_references` is not elided by the VERIFY-frame data elision rule.
 
 Frame data, including VERIFY frame data, MUST NOT add, remove, or modify the transaction's recent root reference set.
 


### PR DESCRIPTION
While implementing the frame-transaction family, I noticed EIP-8272's payload and signature hash are out of sync with the current EIP-8141, which can make clients disagree on the signature hash.

EIP-8141's payload has nine fields including `signatures` (added during EIP-8141's development), and its `compute_sig_hash` elides the raw `signature` bytes of any signature with empty `msg`. EIP-8272 currently:

- describes the pre-fork EIP-8141 payload as eight fields, omitting `signatures`, and its post-fork payload likewise omits `signatures`; and
- redefines `compute_sig_hash` to elide `VERIFY`-frame `data` but not the signature bytes.

Two consequences: the payload schema is missing a field that EIP-8141 has, and a signature would sign over a hash that still contains its own bytes (the circularity EIP-8141's signature-byte elision exists to avoid). A client following EIP-8272 and a client following EIP-8141 would compute different signature hashes for the same transaction.

This PR brings EIP-8272 in line with the current EIP-8141:

- restores `signatures` in the pre-fork (nine-field) and post-fork (ten-field) payloads; and
- keeps EIP-8272's `VERIFY`-frame `data` elision and adds back EIP-8141's signature-byte elision in `compute_sig_hash`.

Note: this does not define the combined payload / signature hash when EIP-8250 and EIP-8272 are both active (EIP-8250 also omits `signatures` and moves the nonce fields). That composition still needs a single owner — happy to follow up separately.