### PR TITLE
Update EIP-8250: align NONCE_MANAGER activation wording with EIP-8272

### DIFF
--- a/EIPS/eip-8250.md
+++ b/EIPS/eip-8250.md
@@ -194,13 +194,13 @@ If `timestamp < FORK_TIMESTAMP`, clients MUST apply the pre-fork EIP-8141 `FRAME
 
 If `timestamp >= FORK_TIMESTAMP`, clients MUST apply the post-fork `FRAME_TX_TYPE` schema defined in this EIP.
 
-At activation, on the first execution payload with `timestamp >= FORK_TIMESTAMP` and before any transaction in that payload runs, clients MUST initialize `NONCE_MANAGER` with `NONCE_MANAGER_CODE`, nonce `1`, and empty storage, preserving any pre-existing balance.
+For every block `B` with `B.timestamp >= FORK_TIMESTAMP` whose parent has `parent.timestamp < FORK_TIMESTAMP`, and before any transaction in `B` runs, clients MUST initialize `NONCE_MANAGER` with `NONCE_MANAGER_CODE`, nonce `1`, and empty storage, preserving any pre-existing balance.
 
 If `NONCE_MANAGER` does not exist, clients MUST create it with balance `0`, nonce `1`, code `NONCE_MANAGER_CODE`, and empty storage.
 
 If `NONCE_MANAGER` already exists with empty code and empty storage, clients MUST set its code to `NONCE_MANAGER_CODE`, set its nonce to `max(existing_nonce, 1)`, preserve its balance, and leave storage empty.
 
-This initialization runs exactly once at fork activation and MUST NOT be re-applied during normal chain progression after activation. Clients MUST handle reorgs across the fork boundary by applying or undoing this transition according to the canonical chain.
+For all other blocks, clients MUST NOT run this initialization. Clients MUST handle reorgs across the fork boundary by applying or undoing this transition according to the canonical chain.
 
 Pre-fork frame transactions and authorizations bound to the pre-fork canonical signature hash do not survive the boundary and MUST be evicted from mempools and regenerated.
 


### PR DESCRIPTION
A small consistency fix between the two frame-transaction system-contract activations.

EIP-8250 triggers `NONCE_MANAGER` initialization "on the first execution payload with `timestamp >= FORK_TIMESTAMP`", while EIP-8272 triggers `RECENT_ROOT_ADDRESS` initialization on "every block whose parent has `parent.timestamp < FORK_TIMESTAMP`". Both include the same reorg clause, so a correct implementation behaves the same, but EIP-8250's "first payload" wording is less precise about which block runs the transition after a fork-boundary reorg.

This PR aligns EIP-8250's wording with EIP-8272's per-parent-boundary formulation (initialize on any block whose parent is pre-fork; MUST NOT initialize on other blocks), so the two activations read identically. No behavioral change beyond removing the ambiguity.