### PR TITLE
Update EIP-8272: strengthen public-mempool handling of recent root references

### DIFF
--- a/EIPS/eip-8272.md
+++ b/EIPS/eip-8272.md
@@ -325,7 +325,7 @@ Nodes SHOULD NOT admit a transaction while any reference has `slot >= current_sl
 
 To avoid admitting a transaction that expires almost immediately, nodes SHOULD NOT admit a transaction whose oldest reference is within a small margin of expiry, i.e. where `current_slot - slot >= RECENT_ROOT_LENGTH - m` for a node-chosen margin `m` of a few slots.
 
-Because a single slot advance can expire many pending transactions that share one reference, public mempool nodes SHOULD bound the number of pending transactions that share the same `(source_id, slot)` reference, analogous to the per-paymaster limit `MAX_PENDING_TXS_USING_NON_CANONICAL_PAYMASTER` in EIP-8141.
+To keep expiry and reorg eviction bounded without restricting application concurrency, public mempool nodes SHOULD index pending transactions by declared reference and by expiry slot, so that the transactions affected by a slot advance or a reorg can be found and evicted efficiently.
 
 Nodes SHOULD recheck pending transactions with recent root references when the head changes, when the node's current slot advances, or after any reorg that may affect referenced entries.
 

--- a/EIPS/eip-8272.md
+++ b/EIPS/eip-8272.md
@@ -321,7 +321,11 @@ Recent root storage is not exposed to validation code through EVM execution. Dur
 
 Nodes SHOULD admit a transaction to the public mempool only if all declared recent root references are valid against the node's current head.
 
-Nodes SHOULD NOT admit a transaction while any reference has `slot >= current_slot`. Nodes MAY evict a transaction with any reference where `current_slot - slot >= RECENT_ROOT_LENGTH`.
+Nodes SHOULD NOT admit a transaction while any reference has `slot >= current_slot`. Nodes SHOULD evict a transaction with any reference where `current_slot - slot >= RECENT_ROOT_LENGTH`, so that expired transactions do not accumulate.
+
+To avoid admitting a transaction that expires almost immediately, nodes SHOULD NOT admit a transaction whose oldest reference is within a small margin of expiry, i.e. where `current_slot - slot >= RECENT_ROOT_LENGTH - m` for a node-chosen margin `m` of a few slots.
+
+Because a single slot advance can expire many pending transactions that share one reference, public mempool nodes SHOULD bound the number of pending transactions that share the same `(source_id, slot)` reference, analogous to the per-paymaster limit `MAX_PENDING_TXS_USING_NON_CANONICAL_PAYMASTER` in EIP-8141.
 
 Nodes SHOULD recheck pending transactions with recent root references when the head changes, when the node's current slot advances, or after any reorg that may affect referenced entries.
 


### PR DESCRIPTION
A mempool-policy hardening for recent root references. These are node-policy recommendations, not consensus changes.

Recent root references expire by slot: a reference to slot `S` is valid for about `RECENT_ROOT_LENGTH` slots, then expires. Because many pending transactions can share the same reference, a single slot advance can invalidate a batch at once, and the current "Public mempool handling" guidance leaves eviction and admission somewhat soft.

This PR tightens that section:

- **Firm eviction:** change "MAY evict" a reference past `RECENT_ROOT_LENGTH` to "SHOULD evict", so expired transactions do not accumulate.
- **Admission safety margin:** recommend not admitting a transaction whose reference is within a few slots of expiry, so it is not admitted and then evicted almost immediately.
- **Shared-reference cap:** recommend bounding how many pending transactions share the same `(source_id, slot)` reference, analogous to EIP-8141's `MAX_PENDING_TXS_USING_NON_CANONICAL_PAYMASTER`, so one expiry cannot churn an unbounded batch.

These keep the section's existing SHOULD/MAY style and do not affect block validity.
