### PR TITLE
Update EIP-7716: Move to Draft

### DIFF
--- a/EIPS/eip-7716.md
+++ b/EIPS/eip-7716.md
@@ -137,7 +137,7 @@ The penalty factor compares the current slot's offline balance to a slow EMA of 
 
 ### Normalization by active balance
 
-The excess is divided by `get_slot_reference_balance` (per-slot active balance) rather than by the EMA itself. Dividing by the EMA would make every onset factor, and the point at which the cap binds, proportional to the network's baseline offline rate: at a 0.3% baseline instead of 0.5%, an EMA-relative curve steepens by two thirds and saturates near 19% instead of one third. Normalizing by active balance makes the curve invariant to participation drift, and reduces the value of manipulating the reference: inflating the EMA now only shifts the subtracted baseline instead of rescaling the slope.
+The excess is divided by `get_slot_reference_balance` (per-slot active balance) rather than by the EMA itself. Dividing by the EMA would make every onset factor, and the point at which the cap binds, proportional to the network's baseline offline rate: at the ~0.3% offline rate observed on mainnet in mid-2026, an EMA-relative curve calibrated against a 0.5% assumption steepens by two thirds and saturates near 19% instead of one third. Normalizing by active balance makes the curve invariant to participation drift, and reduces the value of manipulating the reference: inflating the EMA now only shifts the subtracted baseline instead of rescaling the slope.
 
 Committee selection is not stake-weighted, so realized per-slot committee balances vary with the mix of consolidated ([EIP-7251](./eip-7251.md)) and 32-ETH validators. This variance is small — roughly 1.2% relative standard deviation at the current validator count, and near 2% even under heavy consolidation — and the reference balance used in the denominator is the deterministic per-slot average, so sampling noise enters only through the numerator, where the EMA absorbs it.
 
@@ -165,7 +165,7 @@ Scaling is restricted to the timely target penalty of validators that missed **b
 
 ### Parameter calibration
 
-Illustrative costs per 32 ETH of stake, assuming ~40M ETH staked, a ~0.5% baseline offline rate, and expressing losses as multiples of expected total staking rewards (consensus and execution layer). "Down for" is the individual operator's rectification time within an event where the correlated cohort is offline for 24 hours:
+Illustrative costs per 32 ETH of stake, assuming ~40M ETH staked and expressing losses as multiples of expected total staking rewards (consensus and execution layer). The figures are independent of the baseline offline rate: under the active-balance normalization, the excess above the EMA — and therefore every penalty factor — depends only on the size of the anomaly. "Down for" is the individual operator's rectification time within an event where the correlated cohort is offline for 24 hours:
 
 | Correlated offline stake | Down for | Cost vs today | Total loss | Share of 32 ETH principal |
 | - | - | - | - | - |

--- a/EIPS/eip-7716.md
+++ b/EIPS/eip-7716.md
@@ -1,10 +1,10 @@
 ---
 eip: 7716
 title: Anti-correlation attestation penalties
-description: Adjust penalties for missed attestations based on in-slot correlation of missed attestation
-author: dapplion (@dapplion), Toni Wahrstätter (@nerolation), Vitalik Buterin (@vbuterin)
+description: Scale penalties for fully-offline validators by the excess of concurrently offline stake over its trailing average
+author: dapplion (@dapplion), Toni Wahrstätter (@nerolation), Vitalik Buterin (@vbuterin), Oisín Kyne (@OisinKyne)
 discussions-to: https://ethereum-magicians.org/t/eip-7716-anti-correlation-attestation-penalties/20137
-status: Stagnant
+status: Draft
 type: Standards Track
 category: Core
 created: 2024-05-25
@@ -13,73 +13,221 @@ created: 2024-05-25
 
 ## Abstract
 
-The decentralization of the validator set is one of the most important properties of Ethereum for credible neutrality and censorship resistance. By adjusting penalties to foster decentralization, diversification and fault-tolerance, this EIP proposes to adjust penalties in a way that more diversified entities get lower penalties while entities with high correlations in their setup face more severe ones.
+The decentralization of the validator set is one of the most important properties of Ethereum for credible neutrality and censorship resistance. This EIP scales the attestation penalty of validators that fail to attest as a function of how many *other* validators failed at the same time. Each slot receives a `penalty_factor` proportional to the excess of that slot's offline balance over a slow-moving average of offline balance, capped at `MAX_PENALTY_FACTOR`. Validators whose failures are uncorrelated with the rest of the network pay the same penalties as today; validators that fail together — same node, cloud provider, client, geography, or operator — pay up to `MAX_PENALTY_FACTOR` times more during the onset of a correlated outage.
+
+The penalty factor is deliberately front-loaded: it is highest in the first hours of a correlated failure and decays as the moving average absorbs the event, so that the marginal cost of remaining offline returns toward the status quo. This punishes correlated *setups* without punishing slow *rectification*, which disproportionately affects smaller operators.
 
 
 ## Motivation
 
-As of now, during times of usual network operation, there are no economic incentives to diversify node operations through using multiple different nodes, geographical locations, clients, ISP providers, etc., except for reducing the risk of penalties affecting all validators simultaneously, thereby limiting the impact to only a fraction of them. 
+During normal network operation there is no economic incentive to diversify node operations across nodes, geographies, clients, ISPs, or cloud providers, other than reducing the chance that all of one's validators fail simultaneously. Attestation penalties are agnostic to the behavior of other participants: a validator that fails alone and a validator that fails together with 30% of the network pay exactly the same penalty per epoch.
 
-Attestation penalties are currently agnostic to other participation actions. This proposal scales attestation penalties as a function of other participants' actions. The goal is to decrease the profitability of participants that exhibit correlated behavior.
+Correlation is the natural discriminator between large and small staking operations. Empirical analysis of historical attestation data shows strong excess correlated failures within operator clusters: validators belonging to the same entity miss together far more often than chance predicts, while solo stakers behave almost independently. Penalizing correlated failure therefore reduces the economies of scale of large, homogeneous staking setups without requiring the protocol to identify entities, and without harming solo stakers on average.
 
+The protocol already prices correlated failure — but only above the finality threshold. If more than one third of stake goes offline, the inactivity leak imposes quadratic, principal-level losses. Below one third, correlation is free: the protocol prices it as a step function at 33%. This EIP extends correlation pricing smoothly into the 1%–33% band, front-loaded at outage onset, with severity that scales with the size of the correlated event. The existing inactivity leak remains unchanged and continues to own principal-level punishment for finality failures; the two mechanisms layer naturally.
 
 
 ## Specification
 
-| Parameter | Value |
-| - | - |
-| `PENALTY_ADJUSTMENT_FACTOR`    |  `4096` |
-| `MAX_PENALTY_FACTOR`    |  `4` |
+| Parameter | Value | Description |
+| - | - | - |
+| `EXCESS_MISS_MULTIPLIER` | `uint64(6)` | Slope of the penalty factor in the excess offline fraction |
+| `MAX_PENALTY_FACTOR` | `uint64(64)` | Ceiling on the penalty factor |
+| `MISS_EMA_SHIFT` | `uint64(17)` | EMA smoothing shift; half-life of roughly 91,000 slots (~12.6 days) |
+| `MIN_MISS_EMA_QUOTIENT` | `uint64(2048)` | Floor on the EMA reference, as a fraction of per-slot active balance |
 
+### Beacon state
 
-Add a variable `NET_EXCESS_PENALTIES` to the beacon state.
+Add a single field to the `BeaconState`:
 
-Let `penalty_factor` be determined through 
-
+```python
+offline_balance_ema: Gwei
 ```
-min(
-    (non_attesting_balance * PENALTY_ADJUSTMENT_FACTOR) // (NET_EXCESS_PENALTIES * total_active_balance + 1), 
-    MAX_PENALTY_FACTOR
+
+`offline_balance_ema` is an exponential moving average of the per-slot *offline balance*, defined below.
+
+### Offline balance
+
+A validator is *offline* for an epoch if it is active, not slashed, and has **neither** the timely source **nor** the timely target participation flag set for that epoch. Validators that attested with an incorrect target but a correct and timely source are *not* offline: they demonstrated liveness, and their failure is a view disagreement rather than an infrastructure fault.
+
+```python
+def get_slot_offline_balance(state: BeaconState, slot: Slot) -> Gwei:
+    """
+    Sum of effective balances of offline validators whose committees
+    were assigned to ``slot`` in the previous epoch.
+    """
+    offline_indices = [
+        index for index in get_eligible_validator_indices(state)
+        if index in get_committee_assignment_indices(state, slot)
+        and not has_flag(state.previous_epoch_participation[index], TIMELY_SOURCE_FLAG_INDEX)
+        and not has_flag(state.previous_epoch_participation[index], TIMELY_TARGET_FLAG_INDEX)
+    ]
+    return Gwei(sum(state.validators[index].effective_balance for index in offline_indices))
+```
+
+### Penalty factor
+
+At the start of epoch processing, before `process_rewards_and_penalties`, compute one `penalty_factor` per slot of the previous epoch, updating the EMA slot by slot:
+
+```python
+def get_min_miss_ema(state: BeaconState) -> Gwei:
+    return Gwei(get_total_active_balance(state) // SLOTS_PER_EPOCH // MIN_MISS_EMA_QUOTIENT)
+
+
+def process_penalty_factors(state: BeaconState) -> Sequence[uint64]:
+    factors = []
+    for slot in get_previous_epoch_slots(state):
+        offline_balance = get_slot_offline_balance(state, slot)
+        reference = max(state.offline_balance_ema, get_min_miss_ema(state))
+        excess = offline_balance - min(offline_balance, reference)
+        penalty_factor = min(
+            uint64(1) + EXCESS_MISS_MULTIPLIER * excess // reference,
+            MAX_PENALTY_FACTOR,
+        )
+        factors.append(penalty_factor)
+        # EMA update
+        if offline_balance > state.offline_balance_ema:
+            state.offline_balance_ema += (offline_balance - state.offline_balance_ema) >> MISS_EMA_SHIFT
+        else:
+            state.offline_balance_ema -= (state.offline_balance_ema - offline_balance) >> MISS_EMA_SHIFT
+    return factors
+```
+
+When the offline balance equals the reference, `penalty_factor` is exactly `1`. The factor is never below `1`: there are no discount windows.
+
+### Penalty application
+
+In `get_flag_index_deltas`, the timely target penalty of an *offline* validator (as defined above) is scaled by the `penalty_factor` of the slot its committee was assigned to:
+
+```python
+elif flag_index == TIMELY_TARGET_FLAG_INDEX:
+    if is_offline(state, index):  # missed both source and target
+        slot = get_assigned_slot(state, index)
+        penalty_factor = penalty_factors[slot_index(slot)]
+        penalties[index] += Gwei(penalty_factor * base_reward * weight // WEIGHT_DENOMINATOR)
+    else:
+        penalties[index] += Gwei(base_reward * weight // WEIGHT_DENOMINATOR)
+```
+
+All other rewards and penalties are unchanged:
+
+* The timely source penalty is not scaled.
+* Timely head misses carry no penalty, as today.
+* Proposer and sync committee rewards and penalties are unchanged.
+* Inactivity leak penalties are unchanged.
+
+### Fork transition
+
+At the fork epoch, initialize:
+
+```python
+offline_balance_ema = max(
+    mean_per_slot_offline_balance_of_previous_epoch(pre_state),
+    get_min_miss_ema(pre_state),
 )
 ```
 
-Let `NET_EXCESS_PENALTIES` be `max(1, NET_EXCESS_PENALTIES + penalty_factor) - 1`
-
+This seeds the reference with the observed pre-fork baseline so that no spurious penalty factor occurs at activation.
 
 
 ## Rationale
 
-### PENALTY_ADJUSTMENT_FACTOR
+### Relative-to-trailing-average design
 
-This variable impacts the sensitivity of the `NET_EXCESS_PENALTIES`.
+The penalty factor compares the current slot's offline balance to a slow EMA of the same quantity. This has three consequences:
 
-Given stable participation, the `penalty_factor` is one.
-If participation decreases, the `penalty_factor` will temporarily increase above one until `net_excess_penalties` catches up.
-If participation increases, the `penalty_factor` will temporarily be zero until `net_excess_penalties` catches up.
+1. **Front-loading.** At the onset of a correlated outage the factor jumps to a value proportional to the size of the anomaly, then decays over roughly a day as the EMA absorbs the event. The marginal cost of each additional hour offline falls back toward the status quo. Operators are punished for *being correlated*, not for *taking time to recover* — the latter would disproportionately harm small operators, who rectify more slowly than professional ones.
+2. **Severity scales with the event.** Onset factors are approximately `1 + EXCESS_MISS_MULTIPLIER * spike / baseline`: with a ~0.5% baseline offline rate, a 1% correlated failure opens at ~13x, 3% at ~37x, and events of 5% or more saturate the 64x cap. Uncorrelated failures continue to pay ~1x.
+3. **Predictable steady state.** Under stable participation the factor is exactly 1 for every slot. There is no penalty noise for ordinary uncorrelated misses, and no below-1 discount windows that would reward being offline during recovery periods.
 
-The `PENALTY_ADJUSTMENT_FACTOR` regulates how fast `net_excess_penalties` catches up.
-In other words, the `PENALTY_ADJUSTMENT_FACTOR` determines the frequency that the penalty_factor is not one.
+### Replacement of the earlier `NET_EXCESS_PENALTIES` mechanism
 
-A high `PENALTY_ADJUSTMENT_FACTOR` causes the `net_excess_penalties` to adjust slower.
-A low `PENALTY_ADJUSTMENT_FACTOR` causes the `net_excess_penalties` to react more sensitively to changes in participation.
+Earlier drafts of this EIP tracked a `NET_EXCESS_PENALTIES` counter with a fixed decrement per slot. That mechanism has an invariant: the sum of factor-above-one over any step change in participation equals a fixed budget, independent of `MAX_PENALTY_FACTOR` and of outage duration. Three defects follow at deterrent magnitudes:
 
+1. The cap is nearly irrelevant to total penalties — raising it only concentrates the same budget into fewer slots. At the previous constants (`PENALTY_ADJUSTMENT_FACTOR = 4096`, cap 4), a correlated outage of *any* size and duration cost at most a few percent more than the status quo.
+2. At mainnet participation rates the counter's equilibrium is below 1, so it oscillates around zero and ordinary uncorrelated misses draw random factors between 0 and the cap.
+3. The counter decays by 1 per slot, so at magnitudes large enough to deter, the post-event recovery window stretches to months, during which the mechanism is blind to further correlated events.
+
+An explicit EMA reference fixes all three: totals are governed by the factor curve rather than a fixed budget, the steady state is exactly 1, and the mechanism re-arms with a fixed ~two-week half-life regardless of event size.
+
+### Scope: timely target only, offline validators only
+
+Scaling is restricted to the timely target penalty of validators that missed **both** source and target, for robustness rather than leniency:
+
+* **Target has the widest inclusion window** (the entire next epoch), so a target flag reliably reflects validator liveness rather than block-space or timing luck. Source timeliness fails after five slots without a block, so a builder, relay, or proposer outage can fabricate source misses for perfectly healthy validators; it cannot fabricate target misses short of a halted chain.
+* **The both-flags requirement excludes view disagreements.** A validator that attests with a correct source but a wrong target — because an epoch-boundary block was late, because a proposer split views, or because its (correct-minority) client disagreed with a buggy majority — demonstrated liveness and pays only today's unscaled penalty. Only validators that produced no timely attestation at all, the signature of an infrastructure failure, are subject to scaling. This eliminates the profitable variants of proposer view-splitting attacks and avoids punishing operators who correctly remain on a minority client during a majority-client incident.
+* Timely head misses remain unpenalized, as today; head voting is the flag most sensitive to proposer timing games.
+
+### Parameter calibration
+
+Illustrative costs per 32 ETH of stake, assuming ~40M ETH staked, a ~0.5% baseline offline rate, and expressing losses as multiples of expected total staking rewards (consensus and execution layer). "Down for" is the individual operator's rectification time within an event where the correlated cohort is offline for 24 hours:
+
+| Correlated offline stake | Down for | Cost vs today | Total loss | Share of 32 ETH principal |
+| - | - | - | - | - |
+| uncorrelated (any) | 24 h | 1.0x | ~1 day of rewards | ~0.01% |
+| 1% | 24 h | ~4x | ~5 days of rewards | 0.04% |
+| 5% | 24 h | ~14x | ~2.4 weeks of rewards | 0.15% |
+| 10% | 6 h | ~18x | ~6 days of rewards | 0.05% |
+| 10% | 24 h | ~18x | ~3 weeks of rewards | 0.19% |
+| 10% | 72 h | ~7x | ~3.5 weeks of rewards | 0.21% |
+| 40% (leak active) | 24 h | ~2x | ~6 weeks of rewards | 0.35% |
+| 40%, 3-day outage (leak active) | 72 h | ~1.3x | ~7 months of rewards | 1.85% |
+
+Note the 72-hour rows: a straggler that recovers two days after its cohort pays little more than a 24-hour rectifier, because the factor collapses once the aggregate anomaly ends. Above one third offline, the quadratic inactivity leak dominates and this mechanism becomes a secondary contributor — by design.
 
 ### `MAX_PENALTY_FACTOR`
 
-The `MAX_PENALTY_FACTOR` puts a ceiling onto the maximum factor with which the penalty for missed attestations is scaled to prevent overly harsh punishments.
+The cap serves three purposes: it bounds the worst-case bleed rate (at cap 64 with target-only scope, a fully offline validator loses at most ~0.19% of a 32 ETH principal per day), it bounds the payoff of any attack that manufactures misses, and it bounds collateral damage to uncorrelated validators that happen to be offline during someone else's crisis. Because the cap saturates at ~5% events, severity is flat between roughly 10% and 33%; the inactivity leak provides the escalation above that band. Attestation-penalty scaling is deliberately a *flow-level* deterrent: principal-level punishment remains reserved for finality failures (the leak) and equivocation (slashing).
+
+### FAQ
+
+**Could this cost me my stake?** No. The mechanism scales an existing flow-level penalty. Its hard ceiling is ~0.19% of principal per day of full offline-ness during a maximal correlated event, and realistic events cost days-to-weeks of *rewards*. Principal-level losses remain exclusive to the inactivity leak and slashing, both unchanged.
+
+**Does this hurt solo stakers?** Solo staker failures are almost entirely uncorrelated, so they pay factor ~1 — exactly today's penalties. Historical backtesting of correlation penalties consistently shows small and solo operators paying *less* than large clusters relative to the status quo. The residual exposure is being offline by coincidence during someone else's crisis (see Security Considerations).
+
+**Does this discourage minority clients?** The opposite. A minority client bug takes down a small fraction of stake (small factor); a majority client bug takes down a large fraction (capped factor). Moreover, operators on a *correct* minority client during a majority-client incident are online with correct sources, hence explicitly not scaled.
+
+**Can a large operator just consolidate validators ([EIP-7251](./eip-7251.md)) to dodge this?** No. All quantities are balance-weighted; 4,000 ETH failing together is penalized identically whether it is one validator or 125.
+
+**What about a relay or builder outage?** Missing blocks do not prevent attesting; attesters vote the prior head and retain full credit. The only artifact — timely-source loss when five or more consecutive slots are empty — is excluded because scaling requires missing the *target* flag too, which has a full-epoch inclusion window.
+
+**What if an outage flaps on and off?** The EMA remains elevated after the first onset, so repeated flapping within the ~two-week half-life is charged less than the equivalent number of isolated events. Oscillation cannot compound the penalty.
+
+**Why is a 20% event not much worse than a 10% one?** Both saturate the cap; totals are then governed by the factor decay curve. Escalation above the cap band is delegated to the inactivity leak, which activates beyond one third.
 
 
 ## Backwards Compatibility
 
-This is a backwards incompatible adjustment of attestations rewards and penalties that requires a scheduled network upgrade.
+This is a backwards incompatible adjustment of attestation penalties that requires a scheduled network upgrade. Rewards are unchanged; only the penalty of validators missing both source and target votes is scaled. Staking-reward estimators and dashboards that model penalties should incorporate the per-slot penalty factor.
 
 
 ## Security Considerations
 
-We acknowledge that splitting validator views can be leveraged as an attack to increase the `penalty_factor` for validators of consecutive slots with little risk for the proposer. 
-TBD.
+### Manufactured misses (view splitting, timing games)
+
+A proposer can attempt to split views or release blocks late so that some committees attest incorrectly, hoping to inflate their penalties. Under this design the profitable variants are removed: head votes are never penalized, wrong-target-but-live attestations are never scaled, and a validator can only be scaled if it produces no timely attestation at all — which a proposer cannot induce in a healthy victim. Suppressing a victim's attestations entirely (e.g., censorship of aggregates for a full epoch across all inclusion opportunities) is the residual vector; it requires sustained control of block space, is publicly visible, and its payoff per victim is bounded by the cap.
+
+### Reference suppression (griefing the EMA)
+
+An entity could sustain elevated offline balance for weeks to inflate `offline_balance_ema`, cheapening a future correlated event. This costs the griefer full attestation penalties on the sustained offline stake for the duration, is publicly visible on-chain, decays with the same ~two-week half-life, and cannot suppress the reference below `MIN_MISS_EMA_QUOTIENT`. The inactivity leak is unaffected by any reference manipulation.
+
+### Collateral damage to bystanders
+
+During a large correlated event, an uncorrelated validator that is coincidentally offline pays the same elevated factor as the correlated cohort — roughly six days of rewards for six hours of downtime during a 40% crisis at the calibrated constants. This is an unavoidable property of statistical correlation penalties: the protocol cannot distinguish membership in the failing cluster. The cap bounds this exposure, and the expected cost remains small because such coincidences are rare; conversely, remaining online during crises is precisely the behavior the mechanism pays for.
+
+### Repeated events and re-arming
+
+Because the reference decays with a fixed half-life, the mechanism re-arms within days regardless of event size, unlike counter-based designs whose blind window scales with event magnitude. Sawtooth outage patterns are charged strictly less than the same downtime as isolated events.
+
+### Interaction with the inactivity leak
+
+Above one third offline, both mechanisms are active: this EIP front-loads the first day of losses while the quadratic leak grows to dominate multi-day finality failures. Their combined effect at the calibrated constants is roughly 1–3% of principal for multi-day finality-losing outages, preserving the leak's role as the primary recovery mechanism. No change to leak behavior is made.
+
+### Worst-case bounds
+
+The maximum penalty flow, sustained only while at least ~5% of stake is newly offline and the validator itself is fully offline, is `(TIMELY_SOURCE_WEIGHT + MAX_PENALTY_FACTOR * TIMELY_TARGET_WEIGHT) / WEIGHT_DENOMINATOR` base rewards per epoch — approximately 0.19% of principal per day at current network size. Integer arithmetic is total-order safe: the reference is floored at `get_min_miss_ema`, all divisions have nonzero denominators, and `offline_balance_ema` is bounded above by per-slot active balance.
+
 
 ## Copyright
 
 Copyright and related rights waived via [CC0](../LICENSE.md).
-

--- a/EIPS/eip-7716.md
+++ b/EIPS/eip-7716.md
@@ -31,10 +31,9 @@ The protocol already prices correlated failure — but only above the finality t
 
 | Parameter | Value | Description |
 | - | - | - |
-| `EXCESS_MISS_MULTIPLIER` | `uint64(6)` | Slope of the penalty factor in the excess offline fraction |
-| `MAX_PENALTY_FACTOR` | `uint64(64)` | Ceiling on the penalty factor |
+| `MAX_PENALTY_FACTOR` | `uint64(128)` | Ceiling on the penalty factor; the single severity parameter |
+| `PENALTY_SLOPE` | `uint64(381)` | Slope of the penalty factor in excess offline stake; equal to `3 * (MAX_PENALTY_FACTOR - 1)`, which makes the cap bind at exactly one third of stake |
 | `MISS_EMA_SHIFT` | `uint64(17)` | EMA smoothing shift; half-life of roughly 91,000 slots (~12.6 days) |
-| `MIN_MISS_EMA_QUOTIENT` | `uint64(2048)` | Floor on the EMA reference, as a fraction of per-slot active balance |
 
 ### Beacon state
 
@@ -70,18 +69,17 @@ def get_slot_offline_balance(state: BeaconState, slot: Slot) -> Gwei:
 At the start of epoch processing, before `process_rewards_and_penalties`, compute one `penalty_factor` per slot of the previous epoch, updating the EMA slot by slot:
 
 ```python
-def get_min_miss_ema(state: BeaconState) -> Gwei:
-    return Gwei(get_total_active_balance(state) // SLOTS_PER_EPOCH // MIN_MISS_EMA_QUOTIENT)
+def get_slot_reference_balance(state: BeaconState) -> Gwei:
+    return Gwei(get_total_active_balance(state) // SLOTS_PER_EPOCH)
 
 
 def process_penalty_factors(state: BeaconState) -> Sequence[uint64]:
     factors = []
     for slot in get_previous_epoch_slots(state):
         offline_balance = get_slot_offline_balance(state, slot)
-        reference = max(state.offline_balance_ema, get_min_miss_ema(state))
-        excess = offline_balance - min(offline_balance, reference)
+        excess = offline_balance - min(offline_balance, state.offline_balance_ema)
         penalty_factor = min(
-            uint64(1) + EXCESS_MISS_MULTIPLIER * excess // reference,
+            uint64(1) + PENALTY_SLOPE * excess // get_slot_reference_balance(state),
             MAX_PENALTY_FACTOR,
         )
         factors.append(penalty_factor)
@@ -93,7 +91,7 @@ def process_penalty_factors(state: BeaconState) -> Sequence[uint64]:
     return factors
 ```
 
-When the offline balance equals the reference, `penalty_factor` is exactly `1`. The factor is never below `1`: there are no discount windows.
+When the offline balance does not exceed the EMA, `penalty_factor` is exactly `1`. The factor is never below `1`: there are no discount windows. The EMA sets only the subtracted baseline; the slope is normalized by per-slot active balance, so the shape of the penalty curve does not depend on the network's prevailing participation rate.
 
 ### Penalty application
 
@@ -121,10 +119,7 @@ All other rewards and penalties are unchanged:
 At the fork epoch, initialize:
 
 ```python
-offline_balance_ema = max(
-    mean_per_slot_offline_balance_of_previous_epoch(pre_state),
-    get_min_miss_ema(pre_state),
-)
+offline_balance_ema = mean_per_slot_offline_balance_of_previous_epoch(pre_state)
 ```
 
 This seeds the reference with the observed pre-fork baseline so that no spurious penalty factor occurs at activation.
@@ -137,8 +132,18 @@ This seeds the reference with the observed pre-fork baseline so that no spurious
 The penalty factor compares the current slot's offline balance to a slow EMA of the same quantity. This has three consequences:
 
 1. **Front-loading.** At the onset of a correlated outage the factor jumps to a value proportional to the size of the anomaly, then decays over roughly a day as the EMA absorbs the event. The marginal cost of each additional hour offline falls back toward the status quo. Operators are punished for *being correlated*, not for *taking time to recover* — the latter would disproportionately harm small operators, who rectify more slowly than professional ones.
-2. **Severity scales with the event.** Onset factors are approximately `1 + EXCESS_MISS_MULTIPLIER * spike / baseline`: with a ~0.5% baseline offline rate, a 1% correlated failure opens at ~13x, 3% at ~37x, and events of 5% or more saturate the 64x cap. Uncorrelated failures continue to pay ~1x.
+2. **Severity scales with the event, across the entire sub-finality band, independently of the baseline.** Onset factors are `1 + PENALTY_SLOPE * spike`: a 1% correlated failure opens at ~5x, 5% at ~20x, 10% at ~39x, and 20% at ~77x. Because `PENALTY_SLOPE = 3 * (MAX_PENALTY_FACTOR - 1)`, the cap binds at exactly one third of stake — the finality threshold where the inactivity leak takes over — as an identity rather than a calibration. Uncorrelated failures continue to pay ~1x.
 3. **Predictable steady state.** Under stable participation the factor is exactly 1 for every slot. There is no penalty noise for ordinary uncorrelated misses, and no below-1 discount windows that would reward being offline during recovery periods.
+
+### Normalization by active balance
+
+The excess is divided by `get_slot_reference_balance` (per-slot active balance) rather than by the EMA itself. Dividing by the EMA would make every onset factor, and the point at which the cap binds, proportional to the network's baseline offline rate: at a 0.3% baseline instead of 0.5%, an EMA-relative curve steepens by two thirds and saturates near 19% instead of one third. Normalizing by active balance makes the curve invariant to participation drift, and reduces the value of manipulating the reference: inflating the EMA now only shifts the subtracted baseline instead of rescaling the slope.
+
+Committee selection is not stake-weighted, so realized per-slot committee balances vary with the mix of consolidated ([EIP-7251](./eip-7251.md)) and 32-ETH validators. This variance is small — roughly 1.2% relative standard deviation at the current validator count, and near 2% even under heavy consolidation — and the reference balance used in the denominator is the deterministic per-slot average, so sampling noise enters only through the numerator, where the EMA absorbs it.
+
+### Linearity
+
+A non-linear (convex) factor was considered and rejected. The aggregate network-wide penalty under a linear individual factor is already quadratic in event size — the affected stake and the factor each grow linearly — mirroring the structure of the existing correlated slashing penalty, where the individual penalty is linear in the slashed cohort fraction. A convex individual factor would push the aggregate to cubic while removing deterrence from the 1–15% band, which is where the events controlled by any single operator's choices (client, cloud, geography) actually occur; events above 20% arise from combinations of operators that no single decision controls.
 
 ### Replacement of the earlier `NET_EXCESS_PENALTIES` mechanism
 
@@ -165,35 +170,36 @@ Illustrative costs per 32 ETH of stake, assuming ~40M ETH staked, a ~0.5% baseli
 | Correlated offline stake | Down for | Cost vs today | Total loss | Share of 32 ETH principal |
 | - | - | - | - | - |
 | uncorrelated (any) | 24 h | 1.0x | ~1 day of rewards | ~0.01% |
-| 1% | 24 h | ~4x | ~5 days of rewards | 0.04% |
-| 5% | 24 h | ~14x | ~2.4 weeks of rewards | 0.15% |
-| 10% | 6 h | ~18x | ~6 days of rewards | 0.05% |
-| 10% | 24 h | ~18x | ~3 weeks of rewards | 0.19% |
-| 10% | 72 h | ~7x | ~3.5 weeks of rewards | 0.21% |
-| 40% (leak active) | 24 h | ~2x | ~6 weeks of rewards | 0.35% |
-| 40%, 3-day outage (leak active) | 72 h | ~1.3x | ~7 months of rewards | 1.85% |
+| 1% | 24 h | ~2x | ~2.5 days of rewards | 0.02% |
+| 5% | 24 h | ~6x | ~1 week of rewards | 0.06% |
+| 10% | 6 h | ~11x | ~3.5 days of rewards | 0.03% |
+| 10% | 24 h | ~11x | ~2 weeks of rewards | 0.12% |
+| 10% | 72 h | ~4.4x | ~2.3 weeks of rewards | 0.14% |
+| 20% | 24 h | ~21x | ~3.7 weeks of rewards | 0.23% |
+| 40% (leak active) | 24 h | ~3.3x | ~2 months of rewards | 0.53% |
+| 40%, 3-day outage (leak active) | 72 h | ~1.8x | ~9.5 months of rewards | 2.5% |
 
 Note the 72-hour rows: a straggler that recovers two days after its cohort pays little more than a 24-hour rectifier, because the factor collapses once the aggregate anomaly ends. Above one third offline, the quadratic inactivity leak dominates and this mechanism becomes a secondary contributor — by design.
 
 ### `MAX_PENALTY_FACTOR`
 
-The cap serves three purposes: it bounds the worst-case bleed rate (at cap 64 with target-only scope, a fully offline validator loses at most ~0.19% of a 32 ETH principal per day), it bounds the payoff of any attack that manufactures misses, and it bounds collateral damage to uncorrelated validators that happen to be offline during someone else's crisis. Because the cap saturates at ~5% events, severity is flat between roughly 10% and 33%; the inactivity leak provides the escalation above that band. Attestation-penalty scaling is deliberately a *flow-level* deterrent: principal-level punishment remains reserved for finality failures (the leak) and equivocation (slashing).
+The cap serves three purposes: it bounds the worst-case bleed rate (at cap 128 with target-only scope, a fully offline validator loses at most ~0.38% of a 32 ETH principal per day), it bounds the payoff of any attack that manufactures misses, and it bounds collateral damage to uncorrelated validators that happen to be offline during someone else's crisis. Because `PENALTY_SLOPE` is derived from it, `MAX_PENALTY_FACTOR` is the single severity parameter: raising or lowering the cap rescales the whole curve while saturation stays at one third. Attestation-penalty scaling is deliberately a *flow-level* deterrent: principal-level punishment remains reserved for finality failures (the leak) and equivocation (slashing).
 
 ### FAQ
 
-**Could this cost me my stake?** No. The mechanism scales an existing flow-level penalty. Its hard ceiling is ~0.19% of principal per day of full offline-ness during a maximal correlated event, and realistic events cost days-to-weeks of *rewards*. Principal-level losses remain exclusive to the inactivity leak and slashing, both unchanged.
+**Could this cost me my stake?** No. The mechanism scales an existing flow-level penalty. Its hard ceiling is ~0.38% of principal per day of full offline-ness during a maximal correlated event, and realistic events cost days-to-weeks of *rewards*. Principal-level losses remain exclusive to the inactivity leak and slashing, both unchanged.
 
 **Does this hurt solo stakers?** Solo staker failures are almost entirely uncorrelated, so they pay factor ~1 — exactly today's penalties. Historical backtesting of correlation penalties consistently shows small and solo operators paying *less* than large clusters relative to the status quo. The residual exposure is being offline by coincidence during someone else's crisis (see Security Considerations).
 
-**Does this discourage minority clients?** The opposite. A minority client bug takes down a small fraction of stake (small factor); a majority client bug takes down a large fraction (capped factor). Moreover, operators on a *correct* minority client during a majority-client incident are online with correct sources, hence explicitly not scaled.
+**Does this discourage minority clients?** No; if anything it encourages them. A minority client bug takes down a small fraction of stake and draws a small factor, while a majority client bug takes down a large fraction and draws the cap. Operators on a correct minority client during a majority-client incident are online with correct sources, and are therefore not scaled at all.
 
-**Can a large operator just consolidate validators ([EIP-7251](./eip-7251.md)) to dodge this?** No. All quantities are balance-weighted; 4,000 ETH failing together is penalized identically whether it is one validator or 125.
+**Can a large operator just consolidate validators ([EIP-7251](./eip-7251.md)) to dodge this?** No. All quantities are balance-weighted; 4,000 ETH failing together is penalized identically whether it is two consolidated validators or 125 32-ETH ones.
 
 **What about a relay or builder outage?** Missing blocks do not prevent attesting; attesters vote the prior head and retain full credit. The only artifact — timely-source loss when five or more consecutive slots are empty — is excluded because scaling requires missing the *target* flag too, which has a full-epoch inclusion window.
 
 **What if an outage flaps on and off?** The EMA remains elevated after the first onset, so repeated flapping within the ~two-week half-life is charged less than the equivalent number of isolated events. Oscillation cannot compound the penalty.
 
-**Why is a 20% event not much worse than a 10% one?** Both saturate the cap; totals are then governed by the factor decay curve. Escalation above the cap band is delegated to the inactivity leak, which activates beyond one third.
+**What happens above one third offline?** The factor saturates at the cap, and the inactivity leak — which activates once finality is lost — provides the escalation: quadratic, principal-level losses that dwarf attestation penalties within days. The two mechanisms are calibrated to hand over at the same point.
 
 
 ## Backwards Compatibility
@@ -205,19 +211,19 @@ This is a backwards incompatible adjustment of attestation penalties that requir
 
 ### Manufactured misses (view splitting, timing games)
 
-A proposer can attempt to split views or release blocks late so that some committees attest incorrectly, hoping to inflate their penalties. Under this design the profitable variants are removed: head votes are never penalized, wrong-target-but-live attestations are never scaled, and a validator can only be scaled if it produces no timely attestation at all — which a proposer cannot induce in a healthy victim. Suppressing a victim's attestations entirely (e.g., censorship of aggregates for a full epoch across all inclusion opportunities) is the residual vector; it requires sustained control of block space, is publicly visible, and its payoff per victim is bounded by the cap.
+A proposer can attempt to split views or release blocks late so that some committees attest incorrectly, hoping to inflate their penalties. Under this design those strategies are unprofitable: head votes are never penalized, wrong-target-but-live attestations are never scaled, and a validator can only be scaled if it produces no timely attestation at all, which a proposer cannot induce in a healthy validator. The residual vector is suppressing a validator's attestations entirely (censorship of its aggregates across a full epoch of inclusion opportunities); this requires sustained control of block space, is publicly visible, and its payoff per affected validator is bounded by the cap.
 
 ### Reference suppression (griefing the EMA)
 
-An entity could sustain elevated offline balance for weeks to inflate `offline_balance_ema`, cheapening a future correlated event. This costs the griefer full attestation penalties on the sustained offline stake for the duration, is publicly visible on-chain, decays with the same ~two-week half-life, and cannot suppress the reference below `MIN_MISS_EMA_QUOTIENT`. The inactivity leak is unaffected by any reference manipulation.
+An entity could sustain elevated offline balance for weeks to inflate `offline_balance_ema`, cheapening a future correlated event. This costs the griefer full attestation penalties on the sustained offline stake for the duration and is publicly visible on-chain. Because the slope is normalized by active balance, inflating the EMA only shifts the subtracted baseline: reducing a future 10% event's factor by half would require sustaining roughly 5% of stake offline for weeks. The inactivity leak is unaffected by any reference manipulation.
 
 ### Collateral damage to bystanders
 
-During a large correlated event, an uncorrelated validator that is coincidentally offline pays the same elevated factor as the correlated cohort — roughly six days of rewards for six hours of downtime during a 40% crisis at the calibrated constants. This is an unavoidable property of statistical correlation penalties: the protocol cannot distinguish membership in the failing cluster. The cap bounds this exposure, and the expected cost remains small because such coincidences are rare; conversely, remaining online during crises is precisely the behavior the mechanism pays for.
+During a large correlated event, an uncorrelated validator that is coincidentally offline pays the same elevated factor as the correlated cohort — roughly eleven days of rewards for six hours of downtime during a 40% crisis at the calibrated constants. This is an unavoidable property of statistical correlation penalties, since the protocol cannot observe membership in the failing cluster. The cap bounds the exposure, the expected cost is small because such coincidences are rare, and remaining online during network-wide incidents is the behavior the mechanism is designed to reward.
 
 ### Repeated events and re-arming
 
-Because the reference decays with a fixed half-life, the mechanism re-arms within days regardless of event size, unlike counter-based designs whose blind window scales with event magnitude. Sawtooth outage patterns are charged strictly less than the same downtime as isolated events.
+Because the reference decays with a fixed half-life, the mechanism re-arms within weeks regardless of event size, unlike counter-based designs whose blind window scales with event magnitude. Sawtooth outage patterns are charged strictly less than the same downtime as isolated events. A cohort that remains offline keeps paying an elevated factor until the EMA absorbs the event (on the order of the half-life); an individual validator's scaling ends the moment it resumes attesting.
 
 ### Interaction with the inactivity leak
 
@@ -225,7 +231,7 @@ Above one third offline, both mechanisms are active: this EIP front-loads the fi
 
 ### Worst-case bounds
 
-The maximum penalty flow, sustained only while at least ~5% of stake is newly offline and the validator itself is fully offline, is `(TIMELY_SOURCE_WEIGHT + MAX_PENALTY_FACTOR * TIMELY_TARGET_WEIGHT) / WEIGHT_DENOMINATOR` base rewards per epoch — approximately 0.19% of principal per day at current network size. Integer arithmetic is total-order safe: the reference is floored at `get_min_miss_ema`, all divisions have nonzero denominators, and `offline_balance_ema` is bounded above by per-slot active balance.
+The maximum penalty flow, sustained only while roughly a third of stake is newly offline and the validator itself is fully offline, is `(TIMELY_SOURCE_WEIGHT + MAX_PENALTY_FACTOR * TIMELY_TARGET_WEIGHT) / WEIGHT_DENOMINATOR` base rewards per epoch — approximately 0.38% of principal per day at current network size. Integer arithmetic is total-order safe: the divisor is per-slot active balance (nonzero for any non-empty validator set), and `offline_balance_ema` is bounded above by per-slot active balance.
 
 
 ## Copyright

--- a/EIPS/eip-7716.md
+++ b/EIPS/eip-7716.md
@@ -181,6 +181,25 @@ Illustrative costs per 32 ETH of stake, assuming ~40M ETH staked and expressing 
 
 Note the 72-hour rows: a straggler that recovers two days after its cohort pays little more than a 24-hour rectifier, because the factor collapses once the aggregate anomaly ends. Above one third offline, the quadratic inactivity leak dominates and this mechanism becomes a secondary contributor — by design.
 
+### Validation against historical incidents
+
+Both mechanisms were replayed over per-slot offline balances reconstructed from public chain data for four mainnet incidents, each scored under the participation-flag rules in force at its epoch and its era's measured execution-layer income. Days-to-recoup is per 32 ETH over the incident window:
+
+| Incident | Peak offline stake | As drafted | This revision |
+| - | - | - | - |
+| May 11+12 2023 finality incidents | 69% (cap binds) | 1.16x | 39.8x (0.97 days) |
+| Besu halt, 2024-01-06 | 12.4% | 1.04x | 2.2x (2.8 hours) |
+| Nethermind consensus bug, 2024-01-21 | 18.8% | 1.01x | 7.5x (11.2 hours) |
+| Prysm post-Fusaka outage, 2025-12-04 | 29.8% | 1.01x | 22.7x (2.40 days) |
+
+The drafted mechanism is within a few percent of the status quo on all four incidents — including the May 2023 events that motivated it — confirming the fixed-budget invariant on real data. The revision scales with severity, and the cap binds only in the single incident that crossed one third of stake. Because the reconstruction records each validator's offline epochs individually, the front-loading claim is also measurable: on the 2025 incident, a validator recovering at 24–36 hours paid 1.40x one recovering at 6–8 hours, versus 4.1x for the same spread under current rules, and validators offline for equal durations *after* their cohort recovered paid roughly 40% of what peak-timed downtime cost.
+
+### Smoothing window
+
+`OFFLINE_BALANCE_SMOOTHING_FACTOR = 2**17` gives the reference a half-life of ln(2)·2^17 slots ≈ 12.6 days; 2^17 slots is exactly 16 sync-committee periods. Replaying the four incidents above under half-lives from 1.6 to 25 days moves none of them materially: recorded outages are cliffs, hours-scale against any days-scale window, so their severity is set by the slope and cap. What the window prices is *sustained* correlated absence — at 2^17, a cohort of 10% of stake staying offline for a week forfeits roughly 92 days of income, versus 39 days at 2^14 — and how long the reference remembers an event, which bounds both the elevated-baseline period after a crisis and the re-arm time before a second event is priced in full (a repeat of the 2025 incident three days later would have met 99% of the original onset factor).
+
+An asymmetric variant — a reference that rises with an hours-scale half-life so the factor decays with time since onset regardless of cohort behavior — was evaluated and rejected. For any per-slot factor computed from aggregate balances, forgiveness for slow-recovering individuals and forgiveness for deliberately sustained outages are the same quantity: a reference fast enough to spare a 24-hour straggler also prices a 20%-of-stake, 3-day outage at a mean factor near 2.7, removing the sustained deterrent entirely, while improving the measured straggler premium only from 1.40x to roughly 1.2x.
+
 ### `MAX_PENALTY_FACTOR`
 
 The cap serves three purposes: it bounds the worst-case bleed rate (at cap 128 with target-only scope, a fully offline validator loses at most ~0.38% of a 32 ETH principal per day), it bounds the payoff of any attack that manufactures misses, and it bounds collateral damage to uncorrelated validators that happen to be offline during someone else's crisis. Because `PENALTY_SLOPE` is derived from it, `MAX_PENALTY_FACTOR` is the single severity parameter: raising or lowering the cap rescales the whole curve while saturation stays at one third. Attestation-penalty scaling is deliberately a *flow-level* deterrent: principal-level punishment remains reserved for finality failures (the leak) and equivocation (slashing).
@@ -201,6 +220,12 @@ The cap serves three purposes: it bounds the worst-case bleed rate (at cap 128 w
 
 **What happens above one third offline?** The factor saturates at the cap, and the inactivity leak — which activates once finality is lost — provides the escalation: quadratic, principal-level losses that dwarf attestation penalties within days. The two mechanisms are calibrated to hand over at the same point.
 
+**Does this punish operators who are slow to apply a patch?** Far less than current rules do, relative to their peers. The factor tracks the current excess offline balance, so it collapses as the cohort recovers; whoever is still down afterwards pays close to today's rates. Measured on the December 2025 incident: recovering at 24–36 hours cost 1.40x recovering at 6–8 hours, versus 4.1x under current rules. The mechanism charges for joining the correlation, not for leaving it slowly.
+
+**Why are the increased penalties burned rather than redistributed?** Redistributing them across time (the drafted mechanism's sub-1x recovery windows) restores the fixed-budget no-op and subsidizes misses during post-crisis recovery. Redistributing them to online validators would fund discouragement attacks: a large correlated event creates a pool worth thousands of ETH, and any staker able to cause a competitor outage would collect its stake-share of that pool — whereas a burn pays attackers nothing, consistent with every existing penalty in the protocol. The issuance impact of the burn is event-contingent and small: replayed over the historical incidents above, the worst single event reduces issuance by roughly 0.3% of one year's issuance, once, and the steady-state impact is zero because the factor is exactly 1 at baseline participation.
+
+**Is this compatible with decoupling finality from fork choice?** Yes. Proposed fast-finality designs split today's attestation into separate fork-choice and finality votes. This mechanism scales only the finality-side penalty (timely target) and gates on the source and target flags, deliberately leaving head votes untouched — so the scaled signal lives entirely in the component that remains a full-validator-set finality vote under such designs, while the fork-choice message, which may move to small committees, is the part this EIP never scales. Nothing in the mechanism depends on epoch structure beyond the smoothing constant, which is a tunable.
+
 
 ## Backwards Compatibility
 
@@ -219,7 +244,7 @@ An entity could sustain elevated offline balance for weeks to inflate `smoothed_
 
 ### Collateral damage to bystanders
 
-During a large correlated event, an uncorrelated validator that is coincidentally offline pays the same elevated factor as the correlated cohort — roughly eleven days of rewards for six hours of downtime during a 40% crisis at the calibrated constants. This is an unavoidable property of statistical correlation penalties, since the protocol cannot observe membership in the failing cluster. The cap bounds the exposure, the expected cost is small because such coincidences are rare, and remaining online during network-wide incidents is the behavior the mechanism is designed to reward.
+During a large correlated event, an uncorrelated validator that is coincidentally offline pays the same elevated factor as the correlated cohort — roughly eleven days of rewards for six hours of downtime during a 40% crisis at the calibrated constants. This is an unavoidable property of statistical correlation penalties, since the protocol cannot observe membership in the failing cluster. The cap bounds the exposure, the expected cost is small because such coincidences are rare, and remaining online during network-wide incidents is the behavior the mechanism is designed to reward. The historical replay bounds the realized exposure: in the May 2023 finality incidents — the worst case for bystanders, since stalled block production left even healthy validators' attestations unincluded under that era's inclusion rules — a validator swept in for one or two epochs paid about 0.22 days of income, and 90% of the non-attesting stake at the plateau had produced no timely attestation at all.
 
 ### Repeated events and re-arming
 

--- a/EIPS/eip-7716.md
+++ b/EIPS/eip-7716.md
@@ -31,8 +31,8 @@ The protocol already prices correlated failure — but only above the finality t
 
 | Parameter | Value | Description |
 | - | - | - |
-| `MAX_PENALTY_FACTOR` | `uint64(128)` | Ceiling on the penalty factor; the single severity parameter |
-| `PENALTY_SLOPE` | `uint64(381)` | Slope of the penalty factor in excess offline stake; equal to `3 * (MAX_PENALTY_FACTOR - 1)`, which makes the cap bind at exactly one third of stake |
+| `MAX_PENALTY_FACTOR` | `uint64(256)` | Ceiling on the penalty factor; the single severity parameter |
+| `PENALTY_SLOPE` | `uint64(765)` | Slope of the penalty factor in excess offline stake; equal to `3 * (MAX_PENALTY_FACTOR - 1)`, which makes the cap bind at exactly one third of stake |
 | `OFFLINE_BALANCE_SMOOTHING_FACTOR` | `uint64(2**17)` | Smoothing divisor of the offline balance moving average; half-life of roughly 91,000 slots (~12.6 days) |
 
 ### Beacon state
@@ -132,7 +132,7 @@ This seeds the reference with the observed pre-fork baseline so that no spurious
 The penalty factor compares the current slot's offline balance to a slowly-updating exponential moving average of the same quantity. This has three consequences:
 
 1. **Front-loading.** At the onset of a correlated outage the factor jumps to a value proportional to the size of the anomaly, then decays over roughly a day as the moving average absorbs the event. The marginal cost of each additional hour offline falls back toward the status quo. Operators are punished for *being correlated*, not for *taking time to recover* — the latter would disproportionately harm small operators, who rectify more slowly than professional ones.
-2. **Severity scales with the event, across the entire sub-finality band, independently of the baseline.** Onset factors are `1 + PENALTY_SLOPE * spike`: a 1% correlated failure opens at ~5x, 5% at ~20x, 10% at ~39x, and 20% at ~77x. Because `PENALTY_SLOPE = 3 * (MAX_PENALTY_FACTOR - 1)`, the cap binds at exactly one third of stake — the finality threshold where the inactivity leak takes over — as an identity rather than a calibration. Uncorrelated failures continue to pay ~1x.
+2. **Severity scales with the event, across the entire sub-finality band, independently of the baseline.** Onset factors are `1 + PENALTY_SLOPE * spike`: a 1% correlated failure opens at ~9x, 5% at ~39x, 10% at ~78x, and 20% at ~154x. Because `PENALTY_SLOPE = 3 * (MAX_PENALTY_FACTOR - 1)`, the cap binds at exactly one third of stake — the finality threshold where the inactivity leak takes over — as an identity rather than a calibration. Uncorrelated failures continue to pay ~1x.
 3. **Predictable steady state.** Under stable participation the factor is exactly 1 for every slot. There is no penalty noise for ordinary uncorrelated misses, and no below-1 discount windows that would reward being offline during recovery periods.
 
 ### Normalization by active balance
@@ -170,16 +170,16 @@ Illustrative costs per 32 ETH of stake, assuming ~40M ETH staked and expressing 
 | Correlated offline stake | Down for | Cost vs today | Total loss | Share of 32 ETH principal |
 | - | - | - | - | - |
 | uncorrelated (any) | 24 h | 1.0x | ~1 day of rewards | ~0.01% |
-| 1% | 24 h | ~2x | ~2.5 days of rewards | 0.02% |
-| 5% | 24 h | ~6x | ~1 week of rewards | 0.06% |
-| 10% | 6 h | ~11x | ~3.5 days of rewards | 0.03% |
-| 10% | 24 h | ~11x | ~2 weeks of rewards | 0.12% |
-| 10% | 72 h | ~4.4x | ~2.3 weeks of rewards | 0.14% |
-| 20% | 24 h | ~21x | ~3.7 weeks of rewards | 0.23% |
-| 40% (leak active) | 24 h | ~3.3x | ~2 months of rewards | 0.53% |
-| 40%, 3-day outage (leak active) | 72 h | ~1.8x | ~9.5 months of rewards | 2.5% |
+| 1% | 24 h | ~3x | ~half a week of rewards | 0.03% |
+| 5% | 24 h | ~11x | ~2 weeks of rewards | 0.12% |
+| 10% | 6 h | ~22x | ~1 week of rewards | 0.06% |
+| 10% | 24 h | ~22x | ~3.7 weeks of rewards | 0.23% |
+| 10% | 72 h | ~8x | ~4 weeks of rewards | 0.25% |
+| 20% | 24 h | ~42x | ~7 weeks of rewards | 0.44% |
+| 40% (leak active) | 24 h | ~5.6x | ~3.4 months of rewards | 0.90% (0.75% this EIP + 0.15% leak) |
+| 40%, 3-day outage (leak active) | 72 h | ~2.6x | ~14 months of rewards | 3.6% (2.2% this EIP + 1.4% leak) |
 
-Note the 72-hour rows: a straggler that recovers two days after its cohort pays little more than a 24-hour rectifier, because the factor collapses once the aggregate anomaly ends. Above one third offline, the quadratic inactivity leak dominates and this mechanism becomes a secondary contributor — by design.
+Note the 72-hour rows: a straggler that recovers two days after its cohort pays little more than a 24-hour rectifier, because the factor collapses once the aggregate anomaly ends. In the leak-active rows the totals are decomposed because the inactivity leak already exists today and is unchanged by this EIP: above one third offline the two mechanisms layer, with the quadratic leak growing to dominate multi-day finality failures — by design. Per-validator numbers understate what the mechanism means to the operators it targets: 0.23% of principal for the 10%/24h row is roughly 900 ETH per 1% of total stake an operator runs — an operator whose 10%-of-stake fleet fails together for a day forfeits on the order of 9,000 ETH.
 
 ### Validation against historical incidents
 
@@ -187,26 +187,28 @@ Both mechanisms were replayed over per-slot offline balances reconstructed from 
 
 | Incident | Peak offline stake | As drafted | This revision |
 | - | - | - | - |
-| May 11+12 2023 finality incidents | 69% (cap binds) | 1.16x | 39.8x (0.97 days) |
-| Besu halt, 2024-01-06 | 12.4% | 1.04x | 2.2x (2.8 hours) |
-| Nethermind consensus bug, 2024-01-21 | 18.8% | 1.01x | 7.5x (11.2 hours) |
-| Prysm post-Fusaka outage, 2025-12-04 | 29.8% | 1.01x | 22.7x (2.40 days) |
+| May 11+12 2023 finality incidents | 69% (cap binds) | 1.16x | 79x (1.9 days) |
+| Besu halt, 2024-01-06 | 12.4% | 1.04x | 3.5x (4.3 hours) |
+| Nethermind consensus bug, 2024-01-21 | 18.8% | 1.01x | 14x (21 hours) |
+| Prysm post-Fusaka outage, 2025-12-04 | 29.8% | 1.01x | 45x (4.7 days) |
 
-The drafted mechanism is within a few percent of the status quo on all four incidents — including the May 2023 events that motivated it — confirming the fixed-budget invariant on real data. The revision scales with severity, and the cap binds only in the single incident that crossed one third of stake. Because the reconstruction records each validator's offline epochs individually, the front-loading claim is also measurable: on the 2025 incident, a validator recovering at 24–36 hours paid 1.40x one recovering at 6–8 hours, versus 4.1x for the same spread under current rules, and validators offline for equal durations *after* their cohort recovered paid roughly 40% of what peak-timed downtime cost.
+The drafted mechanism is within a few percent of the status quo on all four incidents — including the May 2023 events that motivated it — confirming the fixed-budget invariant on real data. The revision scales with severity, and the cap binds only in the single incident that crossed one third of stake. In operator terms, the 2025 incident prices at roughly 240 ETH per 1% of total stake run — around 2,400 ETH for a 10%-of-stake operator caught for the full 4.5 hours — against low single-digit ETH under current rules. Because the reconstruction records each validator's offline epochs individually, the front-loading claim is also measurable: on the 2025 incident, a validator recovering at 24–36 hours paid 1.40x one recovering at 6–8 hours, versus 4.1x for the same spread under current rules, and validators offline for equal durations *after* their cohort recovered paid roughly 40% of what peak-timed downtime cost.
 
 ### Smoothing window
 
-`OFFLINE_BALANCE_SMOOTHING_FACTOR = 2**17` gives the reference a half-life of ln(2)·2^17 slots ≈ 12.6 days; 2^17 slots is exactly 16 sync-committee periods. Replaying the four incidents above under half-lives from 1.6 to 25 days moves none of them materially: recorded outages are cliffs, hours-scale against any days-scale window, so their severity is set by the slope and cap. What the window prices is *sustained* correlated absence — at 2^17, a cohort of 10% of stake staying offline for a week forfeits roughly 92 days of income, versus 39 days at 2^14 — and how long the reference remembers an event, which bounds both the elevated-baseline period after a crisis and the re-arm time before a second event is priced in full (a repeat of the 2025 incident three days later would have met 99% of the original onset factor).
+`OFFLINE_BALANCE_SMOOTHING_FACTOR = 2**17` gives the reference a half-life of ln(2)·2^17 slots ≈ 12.6 days; 2^17 slots is exactly 16 sync-committee periods. Replaying the four incidents above under half-lives from 1.6 to 25 days moves none of them materially: recorded outages are cliffs, hours-scale against any days-scale window, so their severity is set by the slope and cap. What the window prices is *sustained* correlated absence — at 2^17, a cohort of 10% of stake staying offline for a week forfeits roughly 158 days of income, versus 65 days at 2^14 — and how long the reference remembers an event, which bounds both the elevated-baseline period after a crisis and the re-arm time before a second event is priced in full (a repeat of the 2025 incident three days later would have met 99% of the original onset factor).
 
-An asymmetric variant — a reference that rises with an hours-scale half-life so the factor decays with time since onset regardless of cohort behavior — was evaluated and rejected. For any per-slot factor computed from aggregate balances, forgiveness for slow-recovering individuals and forgiveness for deliberately sustained outages are the same quantity: a reference fast enough to spare a 24-hour straggler also prices a 20%-of-stake, 3-day outage at a mean factor near 2.7, removing the sustained deterrent entirely, while improving the measured straggler premium only from 1.40x to roughly 1.2x.
+An asymmetric variant — a reference that rises with an hours-scale half-life so the factor decays with time since onset regardless of cohort behavior — was evaluated and rejected. For any per-slot factor computed from aggregate balances, forgiveness for slow-recovering individuals and forgiveness for deliberately sustained outages are the same quantity: a reference fast enough to spare a 24-hour straggler also prices a 20%-of-stake, 3-day outage at a mean factor in the low single digits, removing the sustained deterrent entirely, while improving the measured straggler premium only from 1.40x to roughly 1.2x.
 
 ### `MAX_PENALTY_FACTOR`
 
-The cap serves three purposes: it bounds the worst-case bleed rate (at cap 128 with target-only scope, a fully offline validator loses at most ~0.38% of a 32 ETH principal per day), it bounds the payoff of any attack that manufactures misses, and it bounds collateral damage to uncorrelated validators that happen to be offline during someone else's crisis. Because `PENALTY_SLOPE` is derived from it, `MAX_PENALTY_FACTOR` is the single severity parameter: raising or lowering the cap rescales the whole curve while saturation stays at one third. Attestation-penalty scaling is deliberately a *flow-level* deterrent: principal-level punishment remains reserved for finality failures (the leak) and equivocation (slashing).
+The cap serves three purposes: it bounds the worst-case bleed rate (at cap 256 with target-only scope, a fully offline validator loses at most ~0.75% of a 32 ETH principal per day), it bounds the payoff of any attack that manufactures misses, and it bounds collateral damage to uncorrelated validators that happen to be offline during someone else's crisis. Because `PENALTY_SLOPE` is derived from it, `MAX_PENALTY_FACTOR` is the single severity parameter: raising or lowering the cap rescales the whole curve while saturation stays at one third. Attestation-penalty scaling is deliberately a *flow-level* deterrent: principal-level punishment remains reserved for finality failures (the leak) and equivocation (slashing).
+
+The value 256 was selected from a severity sweep over the historical incidents. Caps from 128 to 512 (slope tied at `3 * (cap - 1)`) and slope-decoupled variants (steeper slope, cap held at 128, saturation below one third) were each scored on the four replayed events plus the worst-case scenarios. Cap 512 was rejected because its tails overreach — a solo staker caught in a majority-client bug during a three-day finality loss approaches 6% of principal, and an innocent bystander offline six hours during a 40% crisis pays six weeks of income. Slope-decoupled variants keep every worst-case bound at the cap-128 level but price a 17% event and a 30% event identically and forfeit the saturation-at-one-third identity. Cap 256 doubles the deterrent across the band where operator choices live while keeping the three-day-finality-loss worst case near 3.6% of principal, most of the gap to which is the pre-existing leak.
 
 ### FAQ
 
-**Could this cost me my stake?** No. The mechanism scales an existing flow-level penalty. Its hard ceiling is ~0.38% of principal per day of full offline-ness during a maximal correlated event, and realistic events cost days-to-weeks of *rewards*. Principal-level losses remain exclusive to the inactivity leak and slashing, both unchanged.
+**Could this cost me my stake?** No. The mechanism scales an existing flow-level penalty. Its hard ceiling is ~0.75% of principal per day of full offline-ness during a maximal correlated event, and realistic events cost days-to-weeks of *rewards*. Principal-level losses remain exclusive to the inactivity leak and slashing, both unchanged.
 
 **Does this hurt solo stakers?** Solo staker failures are almost entirely uncorrelated, so they pay factor ~1 — exactly today's penalties. Historical backtesting of correlation penalties consistently shows small and solo operators paying *less* than large clusters relative to the status quo. The residual exposure is being offline by coincidence during someone else's crisis (see Security Considerations).
 
@@ -222,7 +224,7 @@ The cap serves three purposes: it bounds the worst-case bleed rate (at cap 128 w
 
 **Does this punish operators who are slow to apply a patch?** Far less than current rules do, relative to their peers. The factor tracks the current excess offline balance, so it collapses as the cohort recovers; whoever is still down afterwards pays close to today's rates. Measured on the December 2025 incident: recovering at 24–36 hours cost 1.40x recovering at 6–8 hours, versus 4.1x under current rules. The mechanism charges for joining the correlation, not for leaving it slowly.
 
-**Why are the increased penalties burned rather than redistributed?** Redistributing them across time (the drafted mechanism's sub-1x recovery windows) restores the fixed-budget no-op and subsidizes misses during post-crisis recovery. Redistributing them to online validators would fund discouragement attacks: a large correlated event creates a pool worth thousands of ETH, and any staker able to cause a competitor outage would collect its stake-share of that pool — whereas a burn pays attackers nothing, consistent with every existing penalty in the protocol. The issuance impact of the burn is event-contingent and small: replayed over the historical incidents above, the worst single event reduces issuance by roughly 0.3% of one year's issuance, once, and the steady-state impact is zero because the factor is exactly 1 at baseline participation.
+**Why are the increased penalties burned rather than redistributed?** Redistributing them across time (the drafted mechanism's sub-1x recovery windows) restores the fixed-budget no-op and subsidizes misses during post-crisis recovery. Redistributing them to online validators would fund discouragement attacks: a large correlated event creates a pool worth thousands of ETH, and any staker able to cause a competitor outage would collect its stake-share of that pool — whereas a burn pays attackers nothing, consistent with every existing penalty in the protocol. The issuance impact of the burn is event-contingent and small: replayed over the historical incidents above, the worst single event reduces issuance by roughly 0.6% of one year's issuance, once, and the steady-state impact is zero because the factor is exactly 1 at baseline participation.
 
 **Is this compatible with decoupling finality from fork choice?** Yes. Proposed fast-finality designs split today's attestation into separate fork-choice and finality votes. This mechanism scales only the finality-side penalty (timely target) and gates on the source and target flags, deliberately leaving head votes untouched — so the scaled signal lives entirely in the component that remains a full-validator-set finality vote under such designs, while the fork-choice message, which may move to small committees, is the part this EIP never scales. Nothing in the mechanism depends on epoch structure beyond the smoothing constant, which is a tunable.
 
@@ -244,7 +246,7 @@ An entity could sustain elevated offline balance for weeks to inflate `smoothed_
 
 ### Collateral damage to bystanders
 
-During a large correlated event, an uncorrelated validator that is coincidentally offline pays the same elevated factor as the correlated cohort — roughly eleven days of rewards for six hours of downtime during a 40% crisis at the calibrated constants. This is an unavoidable property of statistical correlation penalties, since the protocol cannot observe membership in the failing cluster. The cap bounds the exposure, the expected cost is small because such coincidences are rare, and remaining online during network-wide incidents is the behavior the mechanism is designed to reward. The historical replay bounds the realized exposure: in the May 2023 finality incidents — the worst case for bystanders, since stalled block production left even healthy validators' attestations unincluded under that era's inclusion rules — a validator swept in for one or two epochs paid about 0.22 days of income, and 90% of the non-attesting stake at the plateau had produced no timely attestation at all.
+During a large correlated event, an uncorrelated validator that is coincidentally offline pays the same elevated factor as the correlated cohort — roughly three weeks of rewards for six hours of downtime during a 40% crisis at the calibrated constants. This is an unavoidable property of statistical correlation penalties, since the protocol cannot observe membership in the failing cluster. The cap bounds the exposure, the expected cost is small because such coincidences are rare, and remaining online during network-wide incidents is the behavior the mechanism is designed to reward. The historical replay bounds the realized exposure: in the May 2023 finality incidents — the worst case for bystanders, since stalled block production left even healthy validators' attestations unincluded under that era's inclusion rules — a validator swept in for one or two epochs would have paid about 0.44 days of income at the calibrated constants, and 90% of the non-attesting stake at the plateau had produced no timely attestation at all.
 
 ### Repeated events and re-arming
 
@@ -256,7 +258,7 @@ Above one third offline, both mechanisms are active: this EIP front-loads the fi
 
 ### Worst-case bounds
 
-The maximum penalty flow, sustained only while roughly a third of stake is newly offline and the validator itself is fully offline, is `(TIMELY_SOURCE_WEIGHT + MAX_PENALTY_FACTOR * TIMELY_TARGET_WEIGHT) / WEIGHT_DENOMINATOR` base rewards per epoch — approximately 0.38% of principal per day at current network size. Integer arithmetic is total-order safe: the divisor is per-slot active balance (nonzero for any non-empty validator set), and `smoothed_offline_balance` is bounded above by per-slot active balance.
+The maximum penalty flow, sustained only while roughly a third of stake is newly offline and the validator itself is fully offline, is `(TIMELY_SOURCE_WEIGHT + MAX_PENALTY_FACTOR * TIMELY_TARGET_WEIGHT) / WEIGHT_DENOMINATOR` base rewards per epoch — approximately 0.75% of principal per day at current network size. Integer arithmetic is total-order safe: the divisor is per-slot active balance (nonzero for any non-empty validator set), and `smoothed_offline_balance` is bounded above by per-slot active balance.
 
 
 ## Copyright

--- a/EIPS/eip-7716.md
+++ b/EIPS/eip-7716.md
@@ -33,17 +33,17 @@ The protocol already prices correlated failure — but only above the finality t
 | - | - | - |
 | `MAX_PENALTY_FACTOR` | `uint64(128)` | Ceiling on the penalty factor; the single severity parameter |
 | `PENALTY_SLOPE` | `uint64(381)` | Slope of the penalty factor in excess offline stake; equal to `3 * (MAX_PENALTY_FACTOR - 1)`, which makes the cap bind at exactly one third of stake |
-| `MISS_EMA_SHIFT` | `uint64(17)` | EMA smoothing shift; half-life of roughly 91,000 slots (~12.6 days) |
+| `OFFLINE_BALANCE_SMOOTHING_FACTOR` | `uint64(2**17)` | Smoothing divisor of the offline balance moving average; half-life of roughly 91,000 slots (~12.6 days) |
 
 ### Beacon state
 
 Add a single field to the `BeaconState`:
 
 ```python
-offline_balance_ema: Gwei
+smoothed_offline_balance: Gwei
 ```
 
-`offline_balance_ema` is an exponential moving average of the per-slot *offline balance*, defined below.
+`smoothed_offline_balance` is an exponential moving average of the per-slot *offline balance*, defined below.
 
 ### Offline balance
 
@@ -66,7 +66,7 @@ def get_slot_offline_balance(state: BeaconState, slot: Slot) -> Gwei:
 
 ### Penalty factor
 
-At the start of epoch processing, before `process_rewards_and_penalties`, compute one `penalty_factor` per slot of the previous epoch, updating the EMA slot by slot:
+At the start of epoch processing, before `process_rewards_and_penalties`, compute one `penalty_factor` per slot of the previous epoch, updating the moving average slot by slot:
 
 ```python
 def get_slot_reference_balance(state: BeaconState) -> Gwei:
@@ -77,21 +77,21 @@ def process_penalty_factors(state: BeaconState) -> Sequence[uint64]:
     factors = []
     for slot in get_previous_epoch_slots(state):
         offline_balance = get_slot_offline_balance(state, slot)
-        excess = offline_balance - min(offline_balance, state.offline_balance_ema)
+        excess = offline_balance - min(offline_balance, state.smoothed_offline_balance)
         penalty_factor = min(
             uint64(1) + PENALTY_SLOPE * excess // get_slot_reference_balance(state),
             MAX_PENALTY_FACTOR,
         )
         factors.append(penalty_factor)
-        # EMA update
-        if offline_balance > state.offline_balance_ema:
-            state.offline_balance_ema += (offline_balance - state.offline_balance_ema) >> MISS_EMA_SHIFT
+        # Moving average update
+        if offline_balance > state.smoothed_offline_balance:
+            state.smoothed_offline_balance += (offline_balance - state.smoothed_offline_balance) // OFFLINE_BALANCE_SMOOTHING_FACTOR
         else:
-            state.offline_balance_ema -= (state.offline_balance_ema - offline_balance) >> MISS_EMA_SHIFT
+            state.smoothed_offline_balance -= (state.smoothed_offline_balance - offline_balance) // OFFLINE_BALANCE_SMOOTHING_FACTOR
     return factors
 ```
 
-When the offline balance does not exceed the EMA, `penalty_factor` is exactly `1`. The factor is never below `1`: there are no discount windows. The EMA sets only the subtracted baseline; the slope is normalized by per-slot active balance, so the shape of the penalty curve does not depend on the network's prevailing participation rate.
+When the offline balance does not exceed the moving average, `penalty_factor` is exactly `1`. The factor is never below `1`: there are no discount windows. The moving average sets only the subtracted baseline; the slope is normalized by per-slot active balance, so the shape of the penalty curve does not depend on the network's prevailing participation rate.
 
 ### Penalty application
 
@@ -119,7 +119,7 @@ All other rewards and penalties are unchanged:
 At the fork epoch, initialize:
 
 ```python
-offline_balance_ema = mean_per_slot_offline_balance_of_previous_epoch(pre_state)
+smoothed_offline_balance = mean_per_slot_offline_balance_of_previous_epoch(pre_state)
 ```
 
 This seeds the reference with the observed pre-fork baseline so that no spurious penalty factor occurs at activation.
@@ -129,17 +129,17 @@ This seeds the reference with the observed pre-fork baseline so that no spurious
 
 ### Relative-to-trailing-average design
 
-The penalty factor compares the current slot's offline balance to a slow EMA of the same quantity. This has three consequences:
+The penalty factor compares the current slot's offline balance to a slowly-updating exponential moving average of the same quantity. This has three consequences:
 
-1. **Front-loading.** At the onset of a correlated outage the factor jumps to a value proportional to the size of the anomaly, then decays over roughly a day as the EMA absorbs the event. The marginal cost of each additional hour offline falls back toward the status quo. Operators are punished for *being correlated*, not for *taking time to recover* — the latter would disproportionately harm small operators, who rectify more slowly than professional ones.
+1. **Front-loading.** At the onset of a correlated outage the factor jumps to a value proportional to the size of the anomaly, then decays over roughly a day as the moving average absorbs the event. The marginal cost of each additional hour offline falls back toward the status quo. Operators are punished for *being correlated*, not for *taking time to recover* — the latter would disproportionately harm small operators, who rectify more slowly than professional ones.
 2. **Severity scales with the event, across the entire sub-finality band, independently of the baseline.** Onset factors are `1 + PENALTY_SLOPE * spike`: a 1% correlated failure opens at ~5x, 5% at ~20x, 10% at ~39x, and 20% at ~77x. Because `PENALTY_SLOPE = 3 * (MAX_PENALTY_FACTOR - 1)`, the cap binds at exactly one third of stake — the finality threshold where the inactivity leak takes over — as an identity rather than a calibration. Uncorrelated failures continue to pay ~1x.
 3. **Predictable steady state.** Under stable participation the factor is exactly 1 for every slot. There is no penalty noise for ordinary uncorrelated misses, and no below-1 discount windows that would reward being offline during recovery periods.
 
 ### Normalization by active balance
 
-The excess is divided by `get_slot_reference_balance` (per-slot active balance) rather than by the EMA itself. Dividing by the EMA would make every onset factor, and the point at which the cap binds, proportional to the network's baseline offline rate: at the ~0.3% offline rate observed on mainnet in mid-2026, an EMA-relative curve calibrated against a 0.5% assumption steepens by two thirds and saturates near 19% instead of one third. Normalizing by active balance makes the curve invariant to participation drift, and reduces the value of manipulating the reference: inflating the EMA now only shifts the subtracted baseline instead of rescaling the slope.
+The excess is divided by `get_slot_reference_balance` (per-slot active balance) rather than by the moving average itself. Dividing by the moving average would make every onset factor, and the point at which the cap binds, proportional to the network's baseline offline rate: at the ~0.3% offline rate observed on mainnet in mid-2026, a moving-average-relative curve calibrated against a 0.5% assumption steepens by two thirds and saturates near 19% instead of one third. Normalizing by active balance makes the curve invariant to participation drift, and reduces the value of manipulating the reference: inflating the moving average now only shifts the subtracted baseline instead of rescaling the slope.
 
-Committee selection is not stake-weighted, so realized per-slot committee balances vary with the mix of consolidated ([EIP-7251](./eip-7251.md)) and 32-ETH validators. This variance is small — roughly 1.2% relative standard deviation at the current validator count, and near 2% even under heavy consolidation — and the reference balance used in the denominator is the deterministic per-slot average, so sampling noise enters only through the numerator, where the EMA absorbs it.
+Committee selection is not stake-weighted, so realized per-slot committee balances vary with the mix of consolidated ([EIP-7251](./eip-7251.md)) and 32-ETH validators. This variance is small — roughly 1.2% relative standard deviation at the current validator count, and near 2% even under heavy consolidation — and the reference balance used in the denominator is the deterministic per-slot average, so sampling noise enters only through the numerator, where the moving average absorbs it.
 
 ### Linearity
 
@@ -153,7 +153,7 @@ Earlier drafts of this EIP tracked a `NET_EXCESS_PENALTIES` counter with a fixed
 2. At mainnet participation rates the counter's equilibrium is below 1, so it oscillates around zero and ordinary uncorrelated misses draw random factors between 0 and the cap.
 3. The counter decays by 1 per slot, so at magnitudes large enough to deter, the post-event recovery window stretches to months, during which the mechanism is blind to further correlated events.
 
-An explicit EMA reference fixes all three: totals are governed by the factor curve rather than a fixed budget, the steady state is exactly 1, and the mechanism re-arms with a fixed ~two-week half-life regardless of event size.
+An explicit moving-average reference fixes all three: totals are governed by the factor curve rather than a fixed budget, the steady state is exactly 1, and the mechanism re-arms with a fixed ~two-week half-life regardless of event size.
 
 ### Scope: timely target only, offline validators only
 
@@ -165,7 +165,7 @@ Scaling is restricted to the timely target penalty of validators that missed **b
 
 ### Parameter calibration
 
-Illustrative costs per 32 ETH of stake, assuming ~40M ETH staked and expressing losses as multiples of expected total staking rewards (consensus and execution layer). The figures are independent of the baseline offline rate: under the active-balance normalization, the excess above the EMA — and therefore every penalty factor — depends only on the size of the anomaly. "Down for" is the individual operator's rectification time within an event where the correlated cohort is offline for 24 hours:
+Illustrative costs per 32 ETH of stake, assuming ~40M ETH staked and expressing losses as multiples of expected total staking rewards (consensus and execution layer). The figures are independent of the baseline offline rate: under the active-balance normalization, the excess above the moving average — and therefore every penalty factor — depends only on the size of the anomaly. "Down for" is the individual operator's rectification time within an event where the correlated cohort is offline for 24 hours:
 
 | Correlated offline stake | Down for | Cost vs today | Total loss | Share of 32 ETH principal |
 | - | - | - | - | - |
@@ -197,7 +197,7 @@ The cap serves three purposes: it bounds the worst-case bleed rate (at cap 128 w
 
 **What about a relay or builder outage?** Missing blocks do not prevent attesting; attesters vote the prior head and retain full credit. The only artifact — timely-source loss when five or more consecutive slots are empty — is excluded because scaling requires missing the *target* flag too, which has a full-epoch inclusion window.
 
-**What if an outage flaps on and off?** The EMA remains elevated after the first onset, so repeated flapping within the ~two-week half-life is charged less than the equivalent number of isolated events. Oscillation cannot compound the penalty.
+**What if an outage flaps on and off?** The moving average remains elevated after the first onset, so repeated flapping within the ~two-week half-life is charged less than the equivalent number of isolated events. Oscillation cannot compound the penalty.
 
 **What happens above one third offline?** The factor saturates at the cap, and the inactivity leak — which activates once finality is lost — provides the escalation: quadratic, principal-level losses that dwarf attestation penalties within days. The two mechanisms are calibrated to hand over at the same point.
 
@@ -213,9 +213,9 @@ This is a backwards incompatible adjustment of attestation penalties that requir
 
 A proposer can attempt to split views or release blocks late so that some committees attest incorrectly, hoping to inflate their penalties. Under this design those strategies are unprofitable: head votes are never penalized, wrong-target-but-live attestations are never scaled, and a validator can only be scaled if it produces no timely attestation at all, which a proposer cannot induce in a healthy validator. The residual vector is suppressing a validator's attestations entirely (censorship of its aggregates across a full epoch of inclusion opportunities); this requires sustained control of block space, is publicly visible, and its payoff per affected validator is bounded by the cap.
 
-### Reference suppression (griefing the EMA)
+### Reference suppression (griefing the moving average)
 
-An entity could sustain elevated offline balance for weeks to inflate `offline_balance_ema`, cheapening a future correlated event. This costs the griefer full attestation penalties on the sustained offline stake for the duration and is publicly visible on-chain. Because the slope is normalized by active balance, inflating the EMA only shifts the subtracted baseline: reducing a future 10% event's factor by half would require sustaining roughly 5% of stake offline for weeks. The inactivity leak is unaffected by any reference manipulation.
+An entity could sustain elevated offline balance for weeks to inflate `smoothed_offline_balance`, cheapening a future correlated event. This costs the griefer full attestation penalties on the sustained offline stake for the duration and is publicly visible on-chain. Because the slope is normalized by active balance, inflating the moving average only shifts the subtracted baseline: reducing a future 10% event's factor by half would require sustaining roughly 5% of stake offline for weeks. The inactivity leak is unaffected by any reference manipulation.
 
 ### Collateral damage to bystanders
 
@@ -223,7 +223,7 @@ During a large correlated event, an uncorrelated validator that is coincidentall
 
 ### Repeated events and re-arming
 
-Because the reference decays with a fixed half-life, the mechanism re-arms within weeks regardless of event size, unlike counter-based designs whose blind window scales with event magnitude. Sawtooth outage patterns are charged strictly less than the same downtime as isolated events. A cohort that remains offline keeps paying an elevated factor until the EMA absorbs the event (on the order of the half-life); an individual validator's scaling ends the moment it resumes attesting.
+Because the reference decays with a fixed half-life, the mechanism re-arms within weeks regardless of event size, unlike counter-based designs whose blind window scales with event magnitude. Sawtooth outage patterns are charged strictly less than the same downtime as isolated events. A cohort that remains offline keeps paying an elevated factor until the moving average absorbs the event (on the order of the half-life); an individual validator's scaling ends the moment it resumes attesting.
 
 ### Interaction with the inactivity leak
 
@@ -231,7 +231,7 @@ Above one third offline, both mechanisms are active: this EIP front-loads the fi
 
 ### Worst-case bounds
 
-The maximum penalty flow, sustained only while roughly a third of stake is newly offline and the validator itself is fully offline, is `(TIMELY_SOURCE_WEIGHT + MAX_PENALTY_FACTOR * TIMELY_TARGET_WEIGHT) / WEIGHT_DENOMINATOR` base rewards per epoch — approximately 0.38% of principal per day at current network size. Integer arithmetic is total-order safe: the divisor is per-slot active balance (nonzero for any non-empty validator set), and `offline_balance_ema` is bounded above by per-slot active balance.
+The maximum penalty flow, sustained only while roughly a third of stake is newly offline and the validator itself is fully offline, is `(TIMELY_SOURCE_WEIGHT + MAX_PENALTY_FACTOR * TIMELY_TARGET_WEIGHT) / WEIGHT_DENOMINATOR` base rewards per epoch — approximately 0.38% of principal per day at current network size. Integer arithmetic is total-order safe: the divisor is per-slot active balance (nonzero for any non-empty validator set), and `smoothed_offline_balance` is bounded above by per-slot active balance.
 
 
 ## Copyright


### PR DESCRIPTION
## What this PR does

- Moves EIP-7716 from Stagnant back to Draft, it is currently [PFI for Hegotá](https://forkcast.org/upgrade/hegota/#eip-7716).
- Replaces the `NET_EXCESS_PENALTIES` penalty-factor mechanism with an excess-over-moving-average design: one new `Gwei` state field, factor `min(1 + PENALTY_SLOPE · max(0, offline − smoothed_offline_balance) // committee_balance, MAX_PENALTY_FACTOR)`, with `PENALTY_SLOPE = 3 · (MAX_PENALTY_FACTOR − 1)` so the cap binds at exactly one third of stake and `MAX_PENALTY_FACTOR` is the single severity parameter.
- Narrows the scaling scope to the timely-**target** penalty of validators that missed *both* source and target (the "offline indicator"). Source penalties stay at 1x, head votes remain penalty-free, this mitigates concerns around short term proposal disruptions pushing online validators into the penalty case.
- Specifies what was previously ambiguous or missing: per-slot computation, fork-transition initialisation of the state variable, and which penalty components are scaled (the prior draft, its explainer post, and the prototype Lighthouse implementation each disagreed on scope).
- Replaces the `TBD` Security Considerations section with analysis of view-splitting/timing attacks, relay and builder outages, reference-suppression griefing, bystander exposure, repeated/sawtooth outages, worst-case bleed bounds, and interaction with the inactivity leak.
- Adds a calibration table and FAQ to the Rationale.
- Adds me (@OisinKyne) as an author to champion the EIP through the SFI process.

## Why the mechanism changed rather than just the constants

I modelled the drafted algorithm with exact spec integer arithmetic against mid-2026 network parameters. Three findings, each structural rather than parametric:

1. The update rule has a fixed-budget invariant, `Σ(factor − 1) = PENALTY_ADJUSTMENT_FACTOR · Δmiss / 32`, independent of the cap and of outage duration. At the drafted constants a validator caught in a 10%-of-stake, 24-hour correlated outage lost the same $6-ish as an uncorrelated failure — and raising `MAX_PENALTY_FACTOR` (suggested by several commenters in 2024) provably doesn't change the total, only how few slots it's concentrated into.
2. At mainnet participation the counter's equilibrium sits below 1, so ordinary uncorrelated misses drew random factors between 0 and the cap depending on slot luck.
3. The counter decays 1/slot, so at deterrent magnitudes the post-event blind window stretches to months, during which a repeat correlated event of any size lands at factor ~1.

Under the revised mechanism and constants, a 10%/24h correlated outage costs ~3.7 weeks of rewards per affected validator (~22x the status quo), a 20%/24h outage ~7 weeks, and a 3-day finality-losing outage reaches ~3.6% of principal in combination with the unchanged inactivity leak (of which the pre-existing leak is ~1.4%) — while uncorrelated failures and validators that attest with a live source (relay outages, late boundary blocks, correct-minority clients during a majority-client bug) pay exactly what they pay today. Full analysis, scenario tables, and figures are in [the ethresear.ch post](https://ethresear.ch/t/supporting-decentralized-staking-through-more-anti-correlation-incentives/19116/18) — simulation code at [OisinKyne/7716](https://github.com/OisinKyne/7716).

## Backtested against five years of mainnet outages

The parameters are no longer only synthetic. A historical harness (contributed by @ksale001, [OisinKyne/7716#1](https://github.com/OisinKyne/7716/pull/1)) reconstructs per-slot offline balances from ethPandaOps Xatu public Parquet, validates against the executable consensus-specs functions, reproduces each incident's published postmortem figures, and scores both mechanisms under each era's own flag rules and measured EL income:

| Incident | peak offline | as drafted | this revision |
| --- | --- | --- | --- |
| May 11+12 2023 finality incidents | 69% (cap binds) | **1.16x** | **79x** |
| Besu halt, 2024-01-06 | 12.4% | 1.04x | **3.5x** |
| Nethermind bug, 2024-01-21 | 18.8% | 1.01x | **14x** |
| Prysm post-Fusaka, 2025-12-04 | 29.8% | 1.01x | **45x** |

The drafted mechanism is a measured no-op on all four, including its own motivating incident. Three follow-on results are folded into the EIP text (new Rationale subsections "Validation against historical incidents" and "Smoothing window", three new FAQ entries, and a measured bystander bound in Security Considerations):

- **Front-loading measured per-operator**: on the Dec 2025 event, recovering at 24–36 h cost 1.40x recovering at 6–8 h; today's rules charge 4.1x for the same spread ([WINDOW_TUNING.md](https://github.com/OisinKyne/7716/blob/main/WINDOW_TUNING.md)).
- **Window sweep**: half-lives 1.6–25 d are indistinguishable on every real (cliff) event; the window prices sustained outages, and 2^17 keeps that deterrent (~158 days of income for a 10%-of-stake week). Asymmetric fast-rise skews rejected with data.
- **Burn vs redistribute**: quantified — worst historical event burns ~0.6% of one year's issuance, once; redistribution would either restore the no-op or fund discouragement attacks ([REDISTRIBUTION.md](https://github.com/OisinKyne/7716/blob/main/REDISTRIBUTION.md)).

The EIP also gains a FAQ noting forward-compatibility with the decoupled-consensus / fast-finality direction: the mechanism scales only the finality-vote penalty and never touches head/fork-choice votes, which is exactly the split that design makes physical.

## Note on attribution and design departure

One deliberate departure from the 2024 design to flag: the original goal of revenue-neutrality ("same average validator revenue at all levels of percent attesting correctly") is dropped, and excess penalties are burned. That neutrality guarantee is the direct cause of finding 1 above, so keeping it means keeping the inertness. I consider this to be a win for those who feel issuance and staking in general are too lucrative and "risk-free" for those taking part, and fear 100% of stake will decide to take part due to the lack of downside or risk to staking. Keeping this penalty re-distributive could risk discouragement attacks, where the online group keep the offline group down to earn boosted rewards.

## Follow-ups (not in this PR)

- The executable spec is up as [consensus-specs#5452](https://github.com/ethereum/consensus-specs/pull/5452) (supersedes #3780); the draft Lighthouse implementation (igorline/lighthouse#1) already built the per-slot participation bookkeeping this spec relies on.
- We intend to propose this for CFI in Hegotá once the discussion settles.
- Constants (`MAX_PENALTY_FACTOR = 256`, `OFFLINE_BALANCE_SMOOTHING_FACTOR = 2**17`) were chosen from a severity sweep over the four real events ([SEVERITY.md](https://github.com/OisinKyne/7716/blob/main/SEVERITY.md)): caps 128–512 and slope-decoupled variants were scored on event costs, bystander exposure, and worst-case bounds; 512 overreaches (6% of principal for a solo staker in a 3-day majority-client finality loss), slope-decoupled variants flatten severity-proportionality, and 256 doubles the deterrent with every identity intact. A milder cap-128 variant halves the curve with saturation still at one third — argue with the calibration in the discussions-to thread, the model makes any alternative a constants change.

Discussion: https://ethereum-magicians.org/t/eip-7716-anti-correlation-attestation-penalties/20137
