### PR TITLE
Update EIP-8250: restore signatures in payload and correct signature-hash description

### DIFF
--- a/EIPS/eip-8250.md
+++ b/EIPS/eip-8250.md
@@ -55,10 +55,10 @@ This specification is a delta against [EIP-8141](./eip-8141.md).
 The frame-transaction payload becomes:
 
 ```text
-[chain_id, nonce_keys, nonce_seq, sender, frames,
+[chain_id, nonce_keys, nonce_seq, sender, frames, signatures,
  max_priority_fee_per_gas, max_fee_per_gas,
  max_fee_per_blob_gas, blob_versioned_hashes]
-````
+```
 
 `nonce_keys` is a list of `uint256` values; `nonce_seq` is a `uint64`. Each nonce key and `nonce_seq` MUST be encoded as canonical minimal-length RLP integers. The frame layout, signature-hash procedure, and all other EIP-8141 transaction fields are unchanged.
 

--- a/EIPS/eip-8250.md
+++ b/EIPS/eip-8250.md
@@ -60,7 +60,7 @@ The frame-transaction payload becomes:
  max_fee_per_blob_gas, blob_versioned_hashes]
 ````
 
-`nonce_keys` is a list of `uint256` values; `nonce_seq` is a `uint64`. Each nonce key and `nonce_seq` MUST be encoded as canonical minimal-length RLP integers. The frame layout, signature-hash procedure with `VERIFY`-frame `data` elided, and all other EIP-8141 transaction fields are unchanged.
+`nonce_keys` is a list of `uint256` values; `nonce_seq` is a `uint64`. Each nonce key and `nonce_seq` MUST be encoded as canonical minimal-length RLP integers. The frame layout, signature-hash procedure, and all other EIP-8141 transaction fields are unchanged.
 
 Decoders MUST reject a post-fork `FRAME_TX_TYPE` transaction if any of the following is true:
 


### PR DESCRIPTION
Small correction to the signature-hash description.

EIP-8250 says the "signature-hash procedure with `VERIFY`-frame `data` elided" is unchanged from EIP-8141. EIP-8141's `compute_sig_hash` hashes every frame's `data` verbatim and elides only the raw `signature` bytes of signatures with empty `msg`; it does not elide `VERIFY`-frame `data`. This PR drops the incorrect "with `VERIFY`-frame `data` elided" clause, so the reference to EIP-8141's procedure is accurate.

Same correction as the EIP-8272 one in #11959.