### PR TITLE
Update EIP-8272: add source_id test vector

### DIFF
--- a/EIPS/eip-8272.md
+++ b/EIPS/eip-8272.md
@@ -53,7 +53,7 @@ This specification is a delta against EIP-8141. Terms not defined here, includin
 | `RECENTROOTREFLOAD`                   |                                                                           `0xB4` |
 | `RECENTROOTREFLOAD_GAS`               |                                                                              `3` |
 
-All concatenations below use fixed-length encodings. Domains are 32 bytes. Addresses are 20 bytes before any explicitly specified padding. `pad32(address)` left-pads an address with 12 zero bytes to 32 bytes. Slots and indices are unsigned 64-bit big-endian integers. Roots, salts, source identifiers, entry hashes, and storage keys are 32 bytes.
+All concatenations below use fixed-length encodings. Domains are 32 bytes. Addresses are 20 bytes. Slots and indices are unsigned 64-bit big-endian integers. Roots, salts, source identifiers, entry hashes, and storage keys are 32 bytes.
 
 ### Current slot
 
@@ -70,18 +70,18 @@ References MUST target slots strictly before `current_slot`. A root written duri
 A root source is identified by:
 
 ```text
-source_id = keccak256(pad32(source_address) || salt)
+source_id = keccak256(source_address || salt)
 ```
 
 where `source_address` is an address and `salt` is a `bytes32` value.
 
-The following test vector pins the 64-byte preimage:
+The following test vector pins the 52-byte preimage:
 
 ```text
-source_address        = 0x000000000000000000000000000000000000beef
-pad32(source_address) = 0x000000000000000000000000000000000000000000000000000000000000beef
-salt                  = 0x0000000000000000000000000000000000000000000000000000000000000007
-source_id             = 0x93be371628ba90461c1988f904614363a3d7c6cf8ba98ae973416a0339a040f5
+source_address = 0x000000000000000000000000000000000000beef
+salt           = 0x0000000000000000000000000000000000000000000000000000000000000007
+preimage       = 0x000000000000000000000000000000000000beef0000000000000000000000000000000000000000000000000000000000000007
+source_id      = 0x348f6292a0af3e9c0cf912304b4054f8923f9718fc7af19efd22212d0ae0d92c
 ```
 
 The source address MAY be an externally owned account or a contract, and MAY use multiple root sources by using different salts. Applications using a root source are responsible for controlling who can write to it and how salts are allocated.
@@ -144,7 +144,7 @@ When a successful call is made during slot `S`, the contract computes:
 
 ```text
 source_address = msg.sender
-source_id = keccak256(pad32(source_address) || salt)
+source_id = keccak256(source_address || salt)
 i = S mod RECENT_ROOT_LENGTH
 entry_hash = keccak256(
     RECENT_ROOT_ENTRY_DOMAIN ||

--- a/EIPS/eip-8272.md
+++ b/EIPS/eip-8272.md
@@ -53,7 +53,7 @@ This specification is a delta against EIP-8141. Terms not defined here, includin
 | `RECENTROOTREFLOAD`                   |                                                                           `0xB4` |
 | `RECENTROOTREFLOAD_GAS`               |                                                                              `3` |
 
-All concatenations below use fixed-length encodings. Domains are 32 bytes. Addresses are 20 bytes. Slots and indices are unsigned 64-bit big-endian integers. Roots, salts, source identifiers, entry hashes, and storage keys are 32 bytes.
+All concatenations below use fixed-length encodings. Domains are 32 bytes. Addresses are 20 bytes before any explicitly specified padding. `pad32(address)` left-pads an address with 12 zero bytes to 32 bytes. Slots and indices are unsigned 64-bit big-endian integers. Roots, salts, source identifiers, entry hashes, and storage keys are 32 bytes.
 
 ### Current slot
 
@@ -70,10 +70,19 @@ References MUST target slots strictly before `current_slot`. A root written duri
 A root source is identified by:
 
 ```text
-source_id = keccak256(source_address || salt)
+source_id = keccak256(pad32(source_address) || salt)
 ```
 
 where `source_address` is an address and `salt` is a `bytes32` value.
+
+The following test vector pins the 64-byte preimage:
+
+```text
+source_address        = 0x000000000000000000000000000000000000beef
+pad32(source_address) = 0x000000000000000000000000000000000000000000000000000000000000beef
+salt                  = 0x0000000000000000000000000000000000000000000000000000000000000007
+source_id             = 0x93be371628ba90461c1988f904614363a3d7c6cf8ba98ae973416a0339a040f5
+```
 
 The source address MAY be an externally owned account or a contract, and MAY use multiple root sources by using different salts. Applications using a root source are responsible for controlling who can write to it and how salts are allocated.
 
@@ -135,7 +144,7 @@ When a successful call is made during slot `S`, the contract computes:
 
 ```text
 source_address = msg.sender
-source_id = keccak256(source_address || salt)
+source_id = keccak256(pad32(source_address) || salt)
 i = S mod RECENT_ROOT_LENGTH
 entry_hash = keccak256(
     RECENT_ROOT_ENTRY_DOMAIN ||


### PR DESCRIPTION
EIP-8272 defines `source_id = keccak256(source_address || salt)`, with addresses encoded as 20 bytes and salts as 32 bytes, but does not include a deterministic example.

This PR adds a test vector that pins the existing 52-byte preimage and resulting `source_id`.

It does not change the derivation or any consensus behavior.
