### PR TITLE
Update EIP-8250: align transaction introspection assignments

### DIFF
--- a/EIPS/eip-8250.md
+++ b/EIPS/eip-8250.md
@@ -45,8 +45,6 @@ This specification is a delta against [EIP-8141](./eip-8141.md).
 | `TXPARAM_NONCE_KEY_COUNT` | `0x0D` |
 | `TXPARAM_NONCE_KEYS_HASH` | `0x0E` |
 | `TXPARAM_NONCE_KEY_0` | `0x10` |
-| `NONCEKEYLOAD` | `0xB9` |
-| `NONCEKEYLOAD_GAS` | `3` |
 
 `NONCE_MANAGER_CODE` is a runtime equivalent to `revert(0, 0)`: any ordinary call to `NONCE_MANAGER` immediately reverts with empty returndata.
 
@@ -188,8 +186,6 @@ Because valid `nonce_keys` are strictly increasing, `nonce_keys_hash(tx)` has on
 
 For `nonce_keys == [0]`, stateful validity requires `TXPARAM(0x01) == TXPARAM(0x0C)` at transaction start. For `nonce_keys != [0]`, they may differ.
 
-`NONCEKEYLOAD` pops `index` and pushes `tx.nonce_keys[index]`. It costs `NONCEKEYLOAD_GAS` and exceptional-halts if `index >= len(tx.nonce_keys)`. It reads only the signed transaction envelope and MAY be used in any frame mode, including VERIFY frames.
-
 ### Activation
 
 This EIP MUST activate at or after [EIP-8141](./eip-8141.md).
@@ -238,7 +234,7 @@ If activated after EIP-8141, pre-fork frame transactions become invalid at the f
 
 Replay protection is scoped to `(sender, nonce_keys, nonce_seq)`, with validity requiring every selected key to have the selected sequence. Disjoint non-zero key sets remove only the replay-ordering dependency; transactions on disjoint keys may still conflict on sender or payer balance, contract storage, paymaster state, or any other shared state. This EIP provides replay-domain separation, not confidentiality of key selection: `nonce_keys` are visible in the payload and committed by `compute_sig_hash(tx)`.
 
-Single-use-key applications, such as nullifiers, MUST authenticate at least `(sender, nonce_keys_hash, nonce_seq == 0)` in `VERIFY` and SHOULD bind the canonical signature hash via `TXPARAM(0x08)`. Treating `nonce_seq == 0` alone as authorization is unsafe. Authenticating only `TXPARAM_NONCE_KEY_0` or `NONCEKEYLOAD(0)` is also unsafe when `TXPARAM_NONCE_KEY_COUNT > 1`, because an attacker could add unauthorized keys that would be consumed by payment approval. Applications deriving nonce keys from per-use identifiers SHOULD domain-separate the input and reject derived keys equal to `0`.
+Single-use-key applications, such as nullifiers, MUST authenticate at least `(sender, nonce_keys_hash, nonce_seq == 0)` in `VERIFY` and SHOULD bind the canonical signature hash via `TXPARAM(0x08)`. Treating `nonce_seq == 0` alone as authorization is unsafe. Authenticating only `TXPARAM_NONCE_KEY_0` is also unsafe when `TXPARAM_NONCE_KEY_COUNT > 1`, because an attacker could add unauthorized keys that would be consumed by payment approval. Applications deriving nonce keys from per-use identifiers SHOULD domain-separate the input and reject derived keys equal to `0`.
 
 A non-zero-key frame transaction does not advance the sender's legacy account nonce during payment approval. If such a transaction executes `CREATE` at `tx.sender`, the created address depends on the sender's legacy account nonce at execution time. Another transaction that advances the sender's legacy nonce before inclusion can therefore change the `CREATE` address without invalidating the keyed transaction. Applications whose semantics depend on a `CREATE` address SHOULD use `CREATE2` or MUST authenticate the expected pre-state legacy nonce via `TXPARAM(0x0C)`.
 

--- a/EIPS/eip-8250.md
+++ b/EIPS/eip-8250.md
@@ -41,10 +41,12 @@ This specification is a delta against [EIP-8141](./eip-8141.md).
 | `KEYED_NONCE_FIRST_USE_GAS` | `20000` |
 | `MAX_NONCE_SEQ` | `2**64 - 1` |
 | `MAX_NONCE_KEYS` | `16` |
-| `TXPARAM_NONCE_KEY_0` | `0x0B` |
 | `TXPARAM_LEGACY_NONCE` | `0x0C` |
 | `TXPARAM_NONCE_KEY_COUNT` | `0x0D` |
 | `TXPARAM_NONCE_KEYS_HASH` | `0x0E` |
+| `TXPARAM_NONCE_KEY_0` | `0x10` |
+| `NONCEKEYLOAD` | `0xB9` |
+| `NONCEKEYLOAD_GAS` | `3` |
 
 `NONCE_MANAGER_CODE` is a runtime equivalent to `revert(0, 0)`: any ordinary call to `NONCE_MANAGER` immediately reverts with empty returndata.
 
@@ -132,7 +134,7 @@ def consume_nonce_set(sender, nonce_keys, nonce_seq):
             state[NONCE_MANAGER].storage[slot(sender, nonce_key)] = nonce_seq + 1
 ```
 
-`consume_nonce_set` runs exactly once per transaction, on the unique successful payment-scoped `APPROVE` that sets `payer_approved = true`.
+`consume_nonce_set` runs exactly once per transaction, on the unique successful payment-scoped `APPROVE` that sets `payer` from `None` to `resolved_target`.
 
 A payment-scoped `APPROVE` is an `APPROVE` whose scope includes `APPROVE_PAYMENT`, i.e. scope `0x1` or `0x3`.
 
@@ -154,22 +156,22 @@ Only after those checks and costs succeed, and before any approval effect is com
 
 Steps 3 through 5 are a single approval transition. Either all are committed, or none are committed.
 
-Nonce consumption, maximum-cost collection, payer recording, first-use gas charging, and approval-flag updates performed by a successful payment-scoped `APPROVE` are approval effects, not ordinary frame-local state changes. They MUST be journaled outside the current frame's revert journal and outside any `SENDER` atomic-batch snapshot. They MUST NOT be reverted by a later frame revert, by skipping later frames, or by restoring an atomic-batch state snapshot.
+Nonce consumption, maximum-cost collection, payer recording, first-use gas charging, and scope-dependent approval-context updates performed by a successful payment-scoped `APPROVE` are approval effects, not ordinary frame-local state changes. They MUST be journaled outside the current frame's revert journal and outside any EIP-8141 atomic-batch snapshot. They MUST NOT be reverted by a later frame revert, by skipping later frames, or by restoring an atomic-batch state snapshot.
 
 Gas deducted as `KEYED_NONCE_FIRST_USE_GAS` is gas used by the frame executing `APPROVE`. When charged, the surcharge is included in the frame's `gas_used` receipt value, transaction gas accounting, and EIP-8141 unpaid-gas refund calculation.
 
 Keyed-nonce reads and writes performed by stateful validity and `consume_nonce_set` are protocol bookkeeping: they do NOT add `NONCE_MANAGER` or its slots to [EIP-2929](./eip-2929.md) `accessed_addresses` or `accessed_storage_keys`, are NOT charged under [EIP-2200](./eip-2200.md) `SSTORE` pricing, and do NOT warm the address or slot for later user-level access.
 
-### TXPARAM
+### Transaction introspection
 
-`TXPARAM(0x01)` returns `tx.nonce_seq`. Four new indices are added:
+`TXPARAM(0x01)` returns `tx.nonce_seq`. EIP-8141 assigns `TXPARAM` indices through `0x0B`, including `0x0B = len(signatures)`. This EIP adds four non-conflicting indices:
 
 | `param` | Return value |
 | ------- | ------------ |
-| `0x0B` | `tx.nonce_keys[0]` |
 | `0x0C` | pre-state legacy sender nonce |
 | `0x0D` | `len(tx.nonce_keys)` |
 | `0x0E` | `nonce_keys_hash(tx)` |
+| `0x10` | `tx.nonce_keys[0]` |
 
 `nonce_keys_hash(tx)` is defined as:
 
@@ -185,6 +187,8 @@ Because valid `nonce_keys` are strictly increasing, `nonce_keys_hash(tx)` has on
 `TXPARAM(0x0C)` returns `tx_legacy_nonce`, the value of `state[tx.sender].nonce` observed during stateful validity before any frame executes. It is transaction-scoped and is not updated by payment approval, keyed-nonce consumption, account deployment, `CREATE`, or `CREATE2` within the same transaction.
 
 For `nonce_keys == [0]`, stateful validity requires `TXPARAM(0x01) == TXPARAM(0x0C)` at transaction start. For `nonce_keys != [0]`, they may differ.
+
+`NONCEKEYLOAD` pops `index` and pushes `tx.nonce_keys[index]`. It costs `NONCEKEYLOAD_GAS` and exceptional-halts if `index >= len(tx.nonce_keys)`. It reads only the signed transaction envelope and MAY be used in any frame mode, including VERIFY frames.
 
 ### Activation
 
@@ -224,7 +228,7 @@ This EIP does not relax EIP-8141's public-mempool one-pending-frame-transaction-
 
 `nonce_keys == [0]` preserves EIP-8141 replay behavior. Legacy account objects, non-frame transaction types, and `eth_getTransactionCount` are unchanged.
 
-`TXPARAM(0x01)` continues to return the transaction's replay-protection sequence, which equals the sender's legacy nonce only when `nonce_keys == [0]`. Verifier code that previously assumed `TXPARAM(0x01)` is the legacy account nonce MUST either enforce `TXPARAM(0x0D) == 1 and TXPARAM(0x0B) == 0` or be updated to handle keyed sequences.
+`TXPARAM(0x01)` continues to return the transaction's replay-protection sequence, which equals the sender's legacy nonce only when `nonce_keys == [0]`. Verifier code that previously assumed `TXPARAM(0x01)` is the legacy account nonce MUST either enforce `TXPARAM(0x0D) == 1 and TXPARAM(0x10) == 0` or be updated to handle keyed sequences.
 
 `TXPARAM(0x0C)` provides explicit pre-state legacy-account-nonce access for verifier code that needs it.
 
@@ -234,11 +238,11 @@ If activated after EIP-8141, pre-fork frame transactions become invalid at the f
 
 Replay protection is scoped to `(sender, nonce_keys, nonce_seq)`, with validity requiring every selected key to have the selected sequence. Disjoint non-zero key sets remove only the replay-ordering dependency; transactions on disjoint keys may still conflict on sender or payer balance, contract storage, paymaster state, or any other shared state. This EIP provides replay-domain separation, not confidentiality of key selection: `nonce_keys` are visible in the payload and committed by `compute_sig_hash(tx)`.
 
-Single-use-key applications, such as nullifiers, MUST authenticate at least `(sender, nonce_keys_hash, nonce_seq == 0)` in `VERIFY` and SHOULD bind the canonical signature hash via `TXPARAM(0x08)`. Treating `nonce_seq == 0` alone as authorization is unsafe. Authenticating only `TXPARAM_NONCE_KEY_0` is also unsafe when `TXPARAM_NONCE_KEY_COUNT > 1`, because an attacker could add unauthorized keys that would be consumed by payment approval. Applications deriving nonce keys from per-use identifiers SHOULD domain-separate the input and reject derived keys equal to `0`.
+Single-use-key applications, such as nullifiers, MUST authenticate at least `(sender, nonce_keys_hash, nonce_seq == 0)` in `VERIFY` and SHOULD bind the canonical signature hash via `TXPARAM(0x08)`. Treating `nonce_seq == 0` alone as authorization is unsafe. Authenticating only `TXPARAM_NONCE_KEY_0` or `NONCEKEYLOAD(0)` is also unsafe when `TXPARAM_NONCE_KEY_COUNT > 1`, because an attacker could add unauthorized keys that would be consumed by payment approval. Applications deriving nonce keys from per-use identifiers SHOULD domain-separate the input and reject derived keys equal to `0`.
 
 A non-zero-key frame transaction does not advance the sender's legacy account nonce during payment approval. If such a transaction executes `CREATE` at `tx.sender`, the created address depends on the sender's legacy account nonce at execution time. Another transaction that advances the sender's legacy nonce before inclusion can therefore change the `CREATE` address without invalidating the keyed transaction. Applications whose semantics depend on a `CREATE` address SHOULD use `CREATE2` or MUST authenticate the expected pre-state legacy nonce via `TXPARAM(0x0C)`.
 
-Nonce consumption persists through later-frame reverts and `SENDER` atomic-batch rollback because it is part of payment approval. Single-use applications SHOULD minimize post-approval revert paths.
+Nonce consumption persists through later-frame reverts and EIP-8141 atomic-batch rollback because it is part of payment approval. Single-use applications SHOULD minimize post-approval revert paths.
 
 A "send another transaction with the same legacy nonce" cancellation strategy does not invalidate a pending non-zero-key frame transaction. Replacement requires the same `(sender, nonce_keys, nonce_seq)` under the relevant mempool replacement rules, or another transaction that intentionally consumes an overlapping keyed domain.
 


### PR DESCRIPTION
EIP-8250 assigns `TXPARAM_NONCE_KEY_0` to `0x0B`, which EIP-8141 already assigns to `len(signatures)`. It also uses approval and rollback wording from an older EIP-8141 model.

This PR:

- moves `TXPARAM_NONCE_KEY_0` to `0x10`; and
- aligns the nonce consumption trigger and rollback wording with EIP-8141's current `payer` and atomic batch model.

This does not add an introspection opcode or change the transaction payload, gas accounting, or public mempool policy.
