### PR TITLE
Update EIP-8272: resolve RECENTROOTREFLOAD opcode collision

### DIFF
--- a/EIPS/eip-8272.md
+++ b/EIPS/eip-8272.md
@@ -50,7 +50,7 @@ This specification is a delta against EIP-8141. Terms not defined here, includin
 | `RECENT_ROOT_REFERENCE_ADDRESS_GAS`   |                                                       `ACCESS_LIST_ADDRESS_COST` |
 | `RECENT_ROOT_REFERENCE_GAS`           | `ACCESS_LIST_STORAGE_KEY_COST + 2 * KECCAK256_BASE_GAS + 7 * KECCAK256_WORD_GAS` |
 | `TXPARAM_RECENT_ROOT_REFERENCE_COUNT` |                                                                           `0x0F` |
-| `RECENTROOTREFLOAD`                   |                                                                           `0xB4` |
+| `RECENTROOTREFLOAD`                   |                                                                           `0xB5` |
 | `RECENTROOTREFLOAD_GAS`               |                                                                              `3` |
 
 All concatenations below use fixed-length encodings. Domains are 32 bytes. Addresses are 20 bytes. Slots and indices are unsigned 64-bit big-endian integers. Roots, salts, source identifiers, entry hashes, and storage keys are 32 bytes.
@@ -292,6 +292,8 @@ The EIP-7623 calldata cost MUST be computed over `recent_root_calldata` as one b
 ### TXPARAM and RECENTROOTREFLOAD
 
 One new `TXPARAM` index and one new opcode are added:
+
+EIP-8141 assigns opcode `0xB4` to `SIGPARAM`. `RECENTROOTREFLOAD` uses `0xB5` to avoid that collision.
 
 | Name                                 |  Value | Return value                 |
 | ------------------------------------ | -----: | ---------------------------- |


### PR DESCRIPTION
EIP-8272 currently assigns `RECENTROOTREFLOAD` to `0xB4`, which EIP-8141 already assigns to `SIGPARAM`.

This PR moves `RECENTROOTREFLOAD` to `0xB5` and records the reason for the assignment. No opcode semantics or gas costs change.

This draft applies only while EIP-8272 defines `RECENTROOTREFLOAD` as a frame transaction opcode.
