### PR TITLE
Update EIP-8250: make keyed nonce changes additive

### DIFF
--- a/EIPS/eip-8250.md
+++ b/EIPS/eip-8250.md
@@ -21,7 +21,7 @@ A frame transaction currently consumes one linear sender nonce, so a delayed tra
 
 The leading example is privacy protocols. To avoid binding onchain activity to a unique public sender, users transact through a single shared sender address. With one linear nonce, that shared sender becomes a throughput bottleneck: one user's inclusion invalidates every other user's pending withdrawal even when the spends are otherwise unrelated. Smart-wallet session keys and relayer-style senders face the same problem.
 
-Keyed nonces let each spend pick its own nonce domain, for example one derived from a privacy nullifier. Transactions on disjoint non-zero key sets are replay-independent. This removes the protocol-level nonce obstacle to future keyed-aware mempools that admit concurrent transactions from the same sender. This EIP does not by itself change EIP-8141's public-mempool guidance.
+Keyed nonces let each spend pick its own nonce domain, for example one derived from a privacy nullifier. Transactions on disjoint non-zero key sets are replay-independent. This removes the protocol-level nonce obstacle to future keyed-aware mempools that admit concurrent transactions from the same sender. This EIP preserves EIP-8141's limit of one pending frame transaction per sender in the public mempool.
 
 Tying nonce consumption to EIP-8141's payment-approval step also gives single-use-key applications, such as nullifiers, an atomic spent-once guarantee: if validation requires every selected key to be unused, successful inclusion makes all selected keys used, regardless of whether later frames revert.
 
@@ -60,7 +60,7 @@ This EIP replaces the `nonce` field in the EIP-8141 `FRAME_TX_TYPE` payload with
  max_fee_per_blob_gas, blob_versioned_hashes]
 ```
 
-`nonce_keys` is a list of `uint256` values; `nonce_seq` is a `uint64`. Each nonce key and `nonce_seq` MUST use canonical RLP integer encoding. The frame layout and all other transaction fields are unchanged.
+`nonce_keys` is a list of `uint256` values; `nonce_seq` is a `uint64`. Each nonce key and `nonce_seq` MUST be encoded as canonical minimal-length RLP integers. The frame layout and all other EIP-8141 transaction fields are unchanged.
 
 The EIP-8141 signature hash procedure applies after this replacement. The signing payload contains `nonce_keys` and `nonce_seq` at the position previously occupied by `nonce`.
 
@@ -81,7 +81,7 @@ The EIP-8141 definitions of `calldata_floor_gas`, `max_gas`, `gas_used`, and fee
 
 Decoders MUST reject a `FRAME_TX_TYPE` transaction to which this EIP applies if any of the following is true:
 
-- the payload does not contain `nonce_keys` and `nonce_seq` in place of `nonce`;
+- the payload does not match the EIP-8141 schema after replacing `nonce` with consecutive fields `nonce_keys` and `nonce_seq`;
 - `nonce_keys` is not an RLP list;
 - `len(nonce_keys) < 1` or `len(nonce_keys) > MAX_NONCE_KEYS`;
 - any item in `nonce_keys`, or `nonce_seq`, is not encoded as a canonical RLP integer;
@@ -219,16 +219,18 @@ If `NONCE_MANAGER` already exists with empty code and empty storage, clients MUS
 
 For all other blocks, clients MUST NOT run this initialization. Clients MUST handle reorgs across the fork boundary by applying or undoing this transition according to the canonical chain.
 
-Frame transactions and authorizations bound to the canonical signature hash before activation do not survive the boundary and MUST be evicted from mempools and regenerated.
+Pre-fork frame transactions and authorizations bound to the pre-fork canonical signature hash do not survive the boundary and MUST be evicted from mempools and regenerated.
 
 ### Mempool
 
 For the EIP-8141 public mempool rules:
 
 - replace the pending transaction identity `(sender, nonce)` with `(sender, nonce_keys, nonce_seq)`;
-- replace the sender nonce dependency with `current_nonce_seq(sender, nonce_key)` for every `nonce_key` in `nonce_keys`.
+- replace every EIP-8141 public mempool dependency on the sender nonce with `current_nonce_seq(sender, nonce_key)` for each `nonce_key` in `nonce_keys`.
 
-Nodes MUST revalidate a pending transaction when any of its selected nonce sequences changes. All other EIP-8141 public mempool rules, including the limit of one pending frame transaction per sender, remain unchanged.
+If the validation prefix reads `TXPARAM(0x0C)`, the sender's legacy account nonce is an additional dependency.
+
+Nodes MUST revalidate a pending transaction when any of its selected nonce sequences changes. If the validation prefix reads `TXPARAM(0x0C)`, nodes MUST also revalidate when the sender's legacy account nonce changes. All other EIP-8141 public mempool rules, including the limit of one pending frame transaction per sender, remain unchanged.
 
 ## Rationale
 

--- a/EIPS/eip-8250.md
+++ b/EIPS/eip-8250.md
@@ -52,7 +52,7 @@ This specification is a delta against [EIP-8141](./eip-8141.md).
 
 ### Transaction payload
 
-The frame-transaction payload becomes:
+This EIP replaces the `nonce` field in the EIP-8141 `FRAME_TX_TYPE` payload with two consecutive fields, `nonce_keys` followed by `nonce_seq`. No other payload field is changed. Applied to the EIP-8141 payload, the result is:
 
 ```text
 [chain_id, nonce_keys, nonce_seq, sender, frames, signatures,
@@ -60,39 +60,28 @@ The frame-transaction payload becomes:
  max_fee_per_blob_gas, blob_versioned_hashes]
 ```
 
-`nonce_keys` is a list of `uint256` values; `nonce_seq` is a `uint64`. Each nonce key and `nonce_seq` MUST be encoded as canonical minimal-length RLP integers. The frame layout, signature-hash procedure, and all other EIP-8141 transaction fields are unchanged.
+`nonce_keys` is a list of `uint256` values; `nonce_seq` is a `uint64`. Each nonce key and `nonce_seq` MUST use canonical RLP integer encoding. The frame layout and all other transaction fields are unchanged.
 
-The bytes this EIP adds to the payload are priced as transaction data. Define:
+The EIP-8141 signature hash procedure applies after this replacement. The signing payload contains `nonce_keys` and `nonce_seq` at the position previously occupied by `nonce`.
+
+The `nonce_keys` and `nonce_seq` encodings are priced as transaction data. Define:
 
 ```python
 nonce_calldata = rlp(nonce_keys) || rlp(nonce_seq)
+nonce_calldata_cost = calldata_cost(nonce_calldata)
+nonce_calldata_tokens = tokens_in(nonce_calldata)
 ```
 
-`nonce_calldata` is priced exactly as EIP-8141 prices frame and signature data under [EIP-7623](./eip-7623.md), by adding it to EIP-8141's three gas quantities:
+`nonce_calldata` is priced exactly as EIP-8141 prices frame and signature data under [EIP-7623](./eip-7623.md):
 
-- `calldata_cost(nonce_calldata)` is added to `tx_gas_limit`;
-- `calldata_cost(nonce_calldata)` is added to the non-floor argument of the `max` in `charged_gas`;
-- `tokens_in(nonce_calldata)` is added to `calldata_tokens`, which feeds the EIP-7623 floor argument `TOTAL_COST_FLOOR_PER_TOKEN * calldata_tokens`.
+- add `nonce_calldata_cost` to `standard_gas_limit`;
+- add `nonce_calldata_tokens` to `calldata_tokens`.
 
-Explicitly, `charged_gas` becomes:
+The EIP-8141 definitions of `calldata_floor_gas`, `max_gas`, `gas_used`, and fee settlement remain unchanged and use these updated quantities.
 
-```python
-charged_gas = (
-    FRAME_TX_INTRINSIC_COST
-    + len(tx.frames) * FRAME_TX_PER_FRAME_COST
-    + signature_verification_cost
-    + max(
-        frame_data_cost + signature_data_cost + calldata_cost(nonce_calldata) + total_gas_used,
-        TOTAL_COST_FLOOR_PER_TOKEN * calldata_tokens,
-    )
-)
-```
+Decoders MUST reject a `FRAME_TX_TYPE` transaction to which this EIP applies if any of the following is true:
 
-This keeps `nonce_keys` and `nonce_seq` consistent with the pricing of EIP-8141's other transaction data, and keeps `tx_gas_limit` and `charged_gas` consistent.
-
-Decoders MUST reject a post-fork `FRAME_TX_TYPE` transaction if any of the following is true:
-
-- the payload does not match the post-fork schema;
+- the payload does not contain `nonce_keys` and `nonce_seq` in place of `nonce`;
 - `nonce_keys` is not an RLP list;
 - `len(nonce_keys) < 1` or `len(nonce_keys) > MAX_NONCE_KEYS`;
 - any item in `nonce_keys`, or `nonce_seq`, is not encoded as a canonical RLP integer;
@@ -218,9 +207,9 @@ For `nonce_keys == [0]`, stateful validity requires `TXPARAM(0x01) == TXPARAM(0x
 
 This EIP MUST activate at or after [EIP-8141](./eip-8141.md).
 
-If `timestamp < FORK_TIMESTAMP`, clients MUST apply the pre-fork EIP-8141 `FRAME_TX_TYPE` schema and MUST NOT apply keyed-nonce logic.
+If `timestamp < FORK_TIMESTAMP`, clients MUST NOT replace `nonce` and MUST NOT apply keyed nonce logic.
 
-If `timestamp >= FORK_TIMESTAMP`, clients MUST apply the post-fork `FRAME_TX_TYPE` schema defined in this EIP.
+If `timestamp >= FORK_TIMESTAMP`, clients MUST replace `nonce` with `nonce_keys` and `nonce_seq` and MUST apply keyed nonce logic.
 
 For every block `B` with `B.timestamp >= FORK_TIMESTAMP` whose parent has `parent.timestamp < FORK_TIMESTAMP`, and before any transaction in `B` runs, clients MUST initialize `NONCE_MANAGER` with `NONCE_MANAGER_CODE`, nonce `1`, and empty storage, preserving any pre-existing balance.
 
@@ -230,7 +219,16 @@ If `NONCE_MANAGER` already exists with empty code and empty storage, clients MUS
 
 For all other blocks, clients MUST NOT run this initialization. Clients MUST handle reorgs across the fork boundary by applying or undoing this transition according to the canonical chain.
 
-Pre-fork frame transactions and authorizations bound to the pre-fork canonical signature hash do not survive the boundary and MUST be evicted from mempools and regenerated.
+Frame transactions and authorizations bound to the canonical signature hash before activation do not survive the boundary and MUST be evicted from mempools and regenerated.
+
+### Mempool
+
+For the EIP-8141 public mempool rules:
+
+- replace the pending transaction identity `(sender, nonce)` with `(sender, nonce_keys, nonce_seq)`;
+- replace the sender nonce dependency with `current_nonce_seq(sender, nonce_key)` for every `nonce_key` in `nonce_keys`.
+
+Nodes MUST revalidate a pending transaction when any of its selected nonce sequences changes. All other EIP-8141 public mempool rules, including the limit of one pending frame transaction per sender, remain unchanged.
 
 ## Rationale
 


### PR DESCRIPTION
EIP-8250 currently restates parts of the EIP-8141 payload and gas accounting. This can make its changes appear to replace other frame transaction extensions, and the old gas text refers to variables superseded by merged #11969.

This PR expresses EIP-8250 only as changes to EIP-8141:

- replace `nonce` in place with `nonce_keys` and `nonce_seq`;
- apply the EIP-8141 signature hash after that replacement;
- add `nonce_calldata_cost` to `standard_gas_limit`;
- add `nonce_calldata_tokens` to `calldata_tokens`;
- replace the public mempool identity and replay dependencies with their keyed nonce equivalents, while retaining the legacy account nonce as a dependency when validation reads `TXPARAM(0x0C)`; and
- activate only the field replacement and keyed nonce rules defined by this EIP.

The EIP-8141 definitions of `calldata_floor_gas`, `max_gas`, `gas_used`, and fee settlement remain unchanged. The limit of one pending frame transaction per sender also remains unchanged.

This leaves #11970 to apply EIP-8272's independent additions to the same EIP-8141 gas quantities.