### PR TITLE
Update EIP-8141: apply charged_gas to fee settlement

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -460,24 +460,39 @@ where `TOTAL_COST_FLOOR_PER_TOKEN` is as defined in EIP-7623. A transaction whos
 
 Clients MUST use `charged_gas` as the transaction's gas used for block gas accounting. The receipt's `cumulative_gas_used` MUST equal the preceding receipt's value plus `charged_gas`, using zero as the preceding value for the first transaction in a block.
 
-Using execution-time prices, the transaction fee before unused gas is refunded is:
+Payment approval collects the transaction's maximum cost from the payer. Fee settlement is calculated as:
 
 ```python
-tx_fee = tx_gas_limit * effective_gas_price + blob_fees
-blob_fees = len(blob_versioned_hashes) * GAS_PER_BLOB * blob_base_fee
+blob_gas = len(blob_versioned_hashes) * GAS_PER_BLOB
+collected_max_cost = (
+    tx_gas_limit * max_fee_per_gas
+    + blob_gas * max_fee_per_blob_gas
+)
+actual_blob_fee = blob_gas * blob_base_fee
+charged_fee = charged_gas * effective_gas_price + actual_blob_fee
+payer_escrow_refund = collected_max_cost - charged_fee
+gas_pool_refund = tx_gas_limit - charged_gas
 ```
 
-The `effective_gas_price` is calculated per [EIP-1559](./eip-1559.md) and `blob_fees` is calculated as per [EIP-4844](./eip-4844.md).
+The `effective_gas_price` is calculated per [EIP-1559](./eip-1559.md), and `actual_blob_fee` is calculated per [EIP-4844](./eip-4844.md). Transaction validity and the floor-validity check above guarantee:
+
+```python
+0 <= charged_gas <= tx_gas_limit
+0 <= charged_fee <= collected_max_cost
+charged_fee + payer_escrow_refund == collected_max_cost
+```
 
 When `blob_versioned_hashes` is non-empty, the transaction is a blob-carrying transaction and follows [EIP-4844](./eip-4844.md), with the payer in the role of the blob-fee payer:
 
 - The transaction is only valid for inclusion in a block if `tx.max_fee_per_blob_gas >= blob_base_fee` of that block.
 - It contributes `len(blob_versioned_hashes) * GAS_PER_BLOB` to the block's `blob_gas_used` and counts against the blob limits of the active fork. The per-transaction blob limit of [EIP-7594](./eip-7594.md) applies unchanged.
-- `blob_fees` are charged to the payer as part of `tx_fee` and burned. They are not refunded regardless of frame outcomes.
+- `actual_blob_fee` is charged to the payer as part of `charged_fee` and burned. It is not refunded based on frame outcomes.
 - Unlike EIP-4844 transactions, a frame transaction is not required to carry blobs.
 - The `BLOBHASH` instruction returns `tx.blob_versioned_hashes[index]` in every frame, per EIP-4844.
 
-Any `frame.value` transferred by `SENDER` frames is separate from `tx_fee` and follows ordinary `CALL` value-transfer semantics. The gas cost of sending `frame.value` is the same as for any `CALL` instruction.
+After execution, `payer_escrow_refund` is returned to the payer (the `resolved_target` that called `APPROVE(APPROVE_PAYMENT)` or `APPROVE(APPROVE_EXECUTION_AND_PAYMENT)`), and `gas_pool_refund` gas units are returned to the block gas pool. The execution base fee and `actual_blob_fee` are burned according to EIP-1559 and EIP-4844, and the execution priority fee is credited according to EIP-1559. Actual blob gas is not refundable, but unused `max_fee_per_blob_gas` escrow is included in `payer_escrow_refund`.
+
+Any `frame.value` transferred by `SENDER` frames is separate from `charged_fee` and follows ordinary `CALL` value-transfer semantics. The gas cost of sending `frame.value` is the same as for any `CALL` instruction.
 
 Each frame has its own `gas_limit` allocation. Unused gas from a frame is **not** available to subsequent frames. A rolling total `tx_unused_gas` is tracked throughout the transaction.
 
@@ -487,13 +502,7 @@ Storage gas refunds ([EIP-3529](./eip-3529.md)) accumulate across frames into a 
 gas_used_before_refund = tx_gas_limit - tx_unused_gas
 applied_refund = min(refund_counter, gas_used_before_refund // 5)
 gas_used = gas_used_before_refund - applied_refund
-
-unused_gas_refund = tx_gas_limit - charged_gas
-fee_refund = unused_gas_refund * effective_gas_price
-charged_fee = charged_gas * effective_gas_price + blob_fees
 ```
-
-The floor-validity check above and the per-frame gas limits guarantee `0 <= charged_gas <= tx_gas_limit`, and `tx_fee == charged_fee + fee_refund`. The `fee_refund` is returned to the gas payer (the `resolved_target` that called `APPROVE(APPROVE_PAYMENT)` or `APPROVE(APPROVE_EXECUTION_AND_PAYMENT)`), and `unused_gas_refund` is added back to the block gas pool. Blob fees are not refunded.
 
 ##### Default code
 

--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -458,7 +458,7 @@ charged_gas = (
 
 where `TOTAL_COST_FLOOR_PER_TOKEN` is as defined in EIP-7623. A transaction whose `tx_gas_limit` is below `FRAME_TX_INTRINSIC_COST + len(tx.frames) * FRAME_TX_PER_FRAME_COST + signature_verification_cost + TOTAL_COST_FLOOR_PER_TOKEN * calldata_tokens` is invalid, so the floor is reserved independently of execution as required by EIP-7623.
 
-The total fee is defined as:
+Using execution-time prices, the transaction fee before unused gas is refunded is:
 
 ```python
 tx_fee = tx_gas_limit * effective_gas_price + blob_fees
@@ -485,9 +485,13 @@ Storage gas refunds ([EIP-3529](./eip-3529.md)) accumulate across frames into a 
 gas_used_before_refund = tx_gas_limit - tx_unused_gas
 applied_refund = min(refund_counter, gas_used_before_refund // 5)
 gas_used = gas_used_before_refund - applied_refund
+
+unused_gas_refund = tx_gas_limit - charged_gas
+fee_refund = unused_gas_refund * effective_gas_price
+charged_fee = charged_gas * effective_gas_price + blob_fees
 ```
 
-This refund is returned to the gas payer (the `resolved_target` that called `APPROVE(APPROVE_PAYMENT)` or `APPROVE(APPROVE_EXECUTION_AND_PAYMENT)`) and added back to the block gas pool.
+The floor-validity check above and the per-frame gas limits guarantee `0 <= charged_gas <= tx_gas_limit`, and `tx_fee == charged_fee + fee_refund`. The `fee_refund` is returned to the gas payer (the `resolved_target` that called `APPROVE(APPROVE_PAYMENT)` or `APPROVE(APPROVE_EXECUTION_AND_PAYMENT)`), and `unused_gas_refund` is added back to the block gas pool. Blob fees are not refunded.
 
 ##### Default code
 

--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -458,6 +458,8 @@ charged_gas = (
 
 where `TOTAL_COST_FLOOR_PER_TOKEN` is as defined in EIP-7623. A transaction whose `tx_gas_limit` is below `FRAME_TX_INTRINSIC_COST + len(tx.frames) * FRAME_TX_PER_FRAME_COST + signature_verification_cost + TOTAL_COST_FLOOR_PER_TOKEN * calldata_tokens` is invalid, so the floor is reserved independently of execution as required by EIP-7623.
 
+Clients MUST use `charged_gas` as the transaction's gas used for block gas accounting. The receipt's `cumulative_gas_used` MUST equal the preceding receipt's value plus `charged_gas`, using zero as the preceding value for the first transaction in a block.
+
 Using execution-time prices, the transaction fee before unused gas is refunded is:
 
 ```python

--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2026-01-29
-requires: 1559, 2718, 3607, 4844, 7594, 7623, 7702
+requires: 1559, 2718, 3529, 3607, 4844, 7594, 7623, 7702
 ---
 
 ## Abstract
@@ -491,6 +491,8 @@ charged_fee = charged_gas * effective_gas_price + actual_blob_fee
 payer_escrow_refund = collected_max_cost - charged_fee
 gas_pool_refund = tx_gas_limit - charged_gas
 ```
+
+The transaction is invalid if `collected_max_cost >= 2**256`.
 
 The `effective_gas_price` is calculated per [EIP-1559](./eip-1559.md), and `actual_blob_fee` is calculated per [EIP-4844](./eip-4844.md). A valid transaction has `effective_gas_price <= max_fee_per_gas`. If `blob_gas > 0`, it also has `blob_base_fee <= max_fee_per_blob_gas`. Together with the floor validity check above, this guarantees:
 
@@ -1180,7 +1182,7 @@ There is some inefficiency in the sponsor case, because the same sponsor address
 
 ### Blob support
 
-Blobs are optional for frame transactions because `FRAME_TX_TYPE` is a general-purpose transaction type, unlike [EIP-4844](./eip-4844.md) transactions which exist only to carry blobs. Sponsorship composes with blobs: the payer covers `blob_fees`, so data posting can be gas-sponsored, which a blob transaction cannot express. The networking wrapper is reused from [EIP-7594](./eip-7594.md) unchanged so that existing blob pool handling and future data availability sampling changes apply to frame transactions uniformly.
+Blobs are optional for frame transactions because `FRAME_TX_TYPE` is a general-purpose transaction type, unlike [EIP-4844](./eip-4844.md) transactions which exist only to carry blobs. Sponsorship composes with blobs: the payer covers `actual_blob_fee` as part of `charged_fee`, so data posting can be gas-sponsored, which a blob transaction cannot express. The networking wrapper is reused from [EIP-7594](./eip-7594.md) unchanged so that existing blob pool handling and future data availability sampling changes apply to frame transactions uniformly.
 
 ## Backwards Compatibility
 

--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -210,7 +210,7 @@ The `ReceiptPayload` is defined as:
 frame_receipt = [status, gas_used, logs]
 ```
 
-`payer` is the address of the account that paid the fees for the transaction. `status` is the return code of the top-level call. A new code `0x2` is introduced for frames which are skipped due to failed atomic batch. `gas_used` is total gas used by the frame, not accounting for refunds.
+`payer` is the address of the account that paid the fees for the transaction. `status` is the return code of the top-level call. A new code `0x2` is introduced for frames which are skipped due to failed atomic batch. `gas_used` is total gas used by the frame, not accounting for refunds. `cumulative_gas_used` is still computed by adding the total gas used by the transaction with the previous cumulative sum.
 
 #### Signature Hash
 
@@ -388,7 +388,7 @@ Then for each frame:
     - Since skipped frames are not executed, the gas value allotted to them is refunded at the end of the transaction.
     - If the frame does not have an associated atomic batch, further special handling is not needed, simple revert the individual frame.
 
-After executing all frames, verify that `payer` has been set (i.e. `payer != None`). If `payer` is set, settle fees as defined in [Gas Accounting](#gas-accounting), returning `payer_escrow_refund` to the payer. If it is not, the whole transaction is invalid.
+After executing all frames, verify that `payer` has been set (i.e. `payer != None`). If it is not, the whole transaction is invalid. Then, settle fees as defined in [Gas Accounting](#gas-accounting), returning `payer_refund` to the payer.
 
 ##### Cross-frame interactions
 
@@ -412,6 +412,14 @@ def signature_gas(sig):
         return 100
     invalid_transaction()
 
+def tokens_in(data):
+    zero_bytes = data.count(b"\x00")
+    nonzero_bytes = len(data) - zero_bytes
+    return zero_bytes + nonzero_bytes * 4
+
+def calldata_cost(data):
+    return STANDARD_TOKEN_COST * tokens_in(data)
+
 signature_verification_cost = sum(signature_gas(sig) for sig in tx.signatures)
 
 frame_data_cost = sum(calldata_cost(frame.data) for frame in tx.frames)
@@ -420,7 +428,7 @@ signature_data_cost = sum(
     for sig in tx.signatures
 )
 
-tx_gas_limit = (
+standard_gas_limit = (
     FRAME_TX_INTRINSIC_COST
     + len(tx.frames) * FRAME_TX_PER_FRAME_COST
     + frame_data_cost
@@ -428,37 +436,11 @@ tx_gas_limit = (
     + signature_verification_cost
     + sum(frame.gas_limit for all frames)
 )
-```
 
-Where `calldata_cost` is calculated per standard [EIP-7623](./eip-7623.md) rules.
-
-The [EIP-7623](./eip-7623.md) calldata floor applies to a frame transaction's frame and signature data, so that it cannot carry large payloads while paying only the standard per-token cost. Let `calldata_tokens` be the EIP-7623 token count over that data:
-
-```python
 calldata_tokens = (
     sum(tokens_in(frame.data) for frame in tx.frames)
-    + sum(tokens_in(sig.signer) + tokens_in(sig.msg) + tokens_in(sig.signature)
-          for sig in tx.signatures)
+    + sum(tokens_in(sig.signer) + tokens_in(sig.msg) + tokens_in(sig.signature) for sig in tx.signatures)
 )
-```
-
-where `tokens_in` counts tokens as in EIP-7623.
-
-Each frame has its own `gas_limit` allocation. Unused gas from a frame is **not** available to subsequent frames. Let `frame_receipts` be the ordered frame receipt list. After all frames execute:
-
-```python
-tx_unused_gas = sum(
-    frame.gas_limit - frame_receipt.gas_used
-    for frame, frame_receipt in zip(tx.frames, frame_receipts)
-)
-```
-
-Storage gas refunds ([EIP-3529](./eip-3529.md)) accumulate across frames into a single transaction-scoped `refund_counter`. Changes made to the counter by a reverted frame, or by frames unrolled as part of a failed atomic batch, are discarded together with that frame's state changes. At the end of the transaction, apply the storage refund before the EIP-7623 calldata floor:
-
-```python
-gas_used_before_refund = tx_gas_limit - tx_unused_gas
-applied_refund = min(refund_counter, gas_used_before_refund // 5)
-gas_used_after_refund = gas_used_before_refund - applied_refund
 
 calldata_floor_gas = (
     FRAME_TX_INTRINSIC_COST
@@ -467,52 +449,52 @@ calldata_floor_gas = (
     + TOTAL_COST_FLOOR_PER_TOKEN * calldata_tokens
 )
 
-charged_gas = max(gas_used_after_refund, calldata_floor_gas)
+max_gas = max(standard_gas_limit, calldata_floor_gas)
 ```
 
-where `TOTAL_COST_FLOOR_PER_TOKEN` is as defined in EIP-7623. A transaction whose `tx_gas_limit` is below `calldata_floor_gas` is invalid, so the floor is reserved independently of execution as required by EIP-7623.
+Each frame has its own `gas_limit` allocation and the receipt reports the frame's gross gas used. These values do not generally sum to `gas_used`: the intrinsic, per-frame, calldata, and signature verification costs are charged outside frame gas limits, and the storage refund and calldata floor apply at the transaction level.
 
-Each frame receipt reports the frame's gross gas used. These values do not generally sum to `charged_gas`: the intrinsic, per-frame, calldata, and signature verification costs are charged outside frame gas limits, and the storage refund and calldata floor apply at the transaction level.
+Unused gas from a frame is **not** available to subsequent frames. Let `frame_receipts` be the ordered frame receipt list. After all frames, unused gas can be calculated as:
 
-Before execution, clients MUST subtract `tx_gas_limit` from the available block gas. A block is invalid if `tx_gas_limit` exceeds the gas available at that point.
+```python
+tx_unused_gas = sum(
+    frame.gas_limit - frame_receipt.gas_used
+    for frame, frame_receipt in zip(tx.frames, frame_receipts)
+)
+```
 
-Clients MUST use `charged_gas` as the transaction's gas used for block gas accounting. The receipt's `cumulative_gas_used` MUST equal the preceding receipt's value plus `charged_gas`, using zero as the preceding value for the first transaction in a block.
+Storage gas refunds ([EIP-3529](./eip-3529.md)) accumulate across frames into a single transaction-scoped `refund_counter`. Changes made to the counter by a reverted frame, or by frames unrolled as part of a failed atomic batch, are discarded together with that frame's state changes. At the end of the transaction, apply the storage refund and EIP-7623 rules to get the final `gas_used` value:
 
-Payment approval collects the transaction's maximum cost (`TXPARAM(0x06)`) from the payer. This value MUST equal `collected_max_cost` as defined below:
+```python
+gas_used_before_refund = standard_gas_limit - tx_unused_gas
+applied_refund = min(refund_counter, gas_used_before_refund // 5)
+gas_used_after_refund = gas_used_before_refund - applied_refund
+
+gas_used = max(gas_used_after_refund, calldata_floor_gas)
+```
+
+The payer's refund is then computed below using the final `gas_used` value:
 
 ```python
 blob_gas = len(blob_versioned_hashes) * GAS_PER_BLOB
-collected_max_cost = (
-    tx_gas_limit * max_fee_per_gas
-    + blob_gas * max_fee_per_blob_gas
+max_cost = (
+    max_gas * max_fee_per_gas
+    + blob_gas * blob_base_fee
 )
-actual_blob_fee = blob_gas * blob_base_fee
-charged_fee = charged_gas * effective_gas_price + actual_blob_fee
-payer_escrow_refund = collected_max_cost - charged_fee
-gas_pool_refund = tx_gas_limit - charged_gas
+charged_fee = gas_used * effective_gas_price + blob_gas * blob_base_fee
+payer_refund = max_cost - charged_fee
 ```
 
-The transaction is invalid if `collected_max_cost >= 2**256`.
+After execution, return `payer_refund` to the payer. This is the `resolved_target` that called `APPROVE(APPROVE_PAYMENT)` or `APPROVE(APPROVE_EXECUTION_AND_PAYMENT)`. Return `max_gas - gas_used` to the block gas pool.
 
-The `effective_gas_price` is calculated per [EIP-1559](./eip-1559.md), and `actual_blob_fee` is calculated per [EIP-4844](./eip-4844.md). A valid transaction has `effective_gas_price <= max_fee_per_gas`. If `blob_gas > 0`, it also has `blob_base_fee <= max_fee_per_blob_gas`. Together with the floor validity check above, this guarantees:
+##### Blob handling
 
-```python
-0 <= charged_gas <= tx_gas_limit
-0 <= charged_fee <= collected_max_cost
-charged_fee + payer_escrow_refund == collected_max_cost
-```
-
-When `blob_versioned_hashes` is non-empty, the transaction is a blob-carrying transaction and follows [EIP-4844](./eip-4844.md), with the payer in the role of the blob-fee payer:
+When `blob_versioned_hashes` is non-empty, the transaction is a blob-carrying transaction and follows [EIP-4844](./eip-4844.md), where the payer is also the blob-fee payer. The following distinctions from EIP-4844 must also be adhered to:
 
 - The transaction is only valid for inclusion in a block if `tx.max_fee_per_blob_gas >= blob_base_fee` of that block.
 - It contributes `len(blob_versioned_hashes) * GAS_PER_BLOB` to the block's `blob_gas_used` and counts against the blob limits of the active fork. The per-transaction blob limit of [EIP-7594](./eip-7594.md) applies unchanged.
-- `actual_blob_fee` is charged to the payer as part of `charged_fee` and burned. It is not refunded based on frame outcomes.
 - Unlike EIP-4844 transactions, a frame transaction is not required to carry blobs.
 - The `BLOBHASH` instruction returns `tx.blob_versioned_hashes[index]` in every frame, per EIP-4844.
-
-After execution, return `payer_escrow_refund` to the payer (the `resolved_target` that called `APPROVE(APPROVE_PAYMENT)` or `APPROVE(APPROVE_EXECUTION_AND_PAYMENT)`). Return `gas_pool_refund` gas units to the block gas pool. The net reduction in available block gas is therefore `charged_gas`. The execution base fee is burned and the execution priority fee is credited to the block beneficiary according to EIP-1559. The `actual_blob_fee` is burned according to EIP-4844. The payer is charged `actual_blob_fee` for all blobs; any difference between the maximum blob fee included in `collected_max_cost` and `actual_blob_fee` is part of `payer_escrow_refund`.
-
-Any `frame.value` transferred by `SENDER` frames is separate from `charged_fee` and follows ordinary `CALL` value transfer semantics. The gas cost of sending `frame.value` is the same as for any `CALL` instruction.
 
 ##### Default code
 
@@ -568,12 +550,12 @@ The behavior of `APPROVE` is defined as follows:
         - If `payer` was already set, revert the frame.
         - If `resolved_target` has insufficient balance, revert the frame.
         - If `sender_approved == false`, revert the frame.
-        - Increment the sender's nonce, set `payer = resolved_target`, and collect the transaction's maximum cost from `payer`,
+        - Increment the sender's nonce, set `payer = resolved_target`, and collect the transaction's `max_cost` from `payer`,
     - For `APPROVE_EXECUTION_AND_PAYMENT`:
         - If `sender_approved` or `payer` was already set, revert the frame.
         - If `resolved_target` != `tx.sender`, revert the frame.
         - If `resolved_target` has insufficient balance, revert the frame.
-        - Set `sender_approved = true`, increment the sender's nonce, set `payer = resolved_target`, and collect the transaction's maximum cost (`TXPARAM(0x06)`) from `payer`.
+        - Set `sender_approved = true`, increment the sender's nonce, set `payer = resolved_target`, and collect the transaction's `max_cost` from `payer`.
 
 #### Gas
 
@@ -597,7 +579,7 @@ This instruction gives access to transaction-scoped information. The gas cost of
 | 0x03    | `max_priority_fee_per_gas`                                                  |
 | 0x04    | `max_fee_per_gas`                                                           |
 | 0x05    | `max_fee_per_blob_gas`                                                      |
-| 0x06    | max cost (basefee=max, all gas used, includes blob cost at `max_fee_per_blob_gas`, intrinsic cost, and signature verification cost) |
+| 0x06    | max cost (basefee=max, all gas used, includes blob cost at `blob_base_fee`, intrinsic cost, and signature verification cost) |
 | 0x07    | `len(blob_versioned_hashes)`                                                |
 | 0x08    | `compute_sig_hash(tx)`                                                      |
 | 0x09    | `len(frames)`                                                               |
@@ -1182,7 +1164,7 @@ There is some inefficiency in the sponsor case, because the same sponsor address
 
 ### Blob support
 
-Blobs are optional for frame transactions because `FRAME_TX_TYPE` is a general-purpose transaction type, unlike [EIP-4844](./eip-4844.md) transactions which exist only to carry blobs. Sponsorship composes with blobs: the payer covers `actual_blob_fee` as part of `charged_fee`, so data posting can be gas-sponsored, which a blob transaction cannot express. The networking wrapper is reused from [EIP-7594](./eip-7594.md) unchanged so that existing blob pool handling and future data availability sampling changes apply to frame transactions uniformly.
+Blobs are optional for frame transactions because `FRAME_TX_TYPE` is a general-purpose transaction type, unlike [EIP-4844](./eip-4844.md) transactions which exist only to carry blobs. The networking wrapper is reused from [EIP-7594](./eip-7594.md) unchanged so that existing blob pool handling and future data availability sampling changes apply to frame transactions uniformly.
 
 ## Backwards Compatibility
 

--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -388,7 +388,7 @@ Then for each frame:
     - Since skipped frames are not executed, the gas value allotted to them is refunded at the end of the transaction.
     - If the frame does not have an associated atomic batch, further special handling is not needed, simple revert the individual frame.
 
-After executing all frames, verify that `payer` has been set (i.e. `payer != None`). If `payer` is set, refund any unpaid gas to the payer. If it is not, the whole transaction is invalid.
+After executing all frames, verify that `payer` has been set (i.e. `payer != None`). If `payer` is set, settle fees as defined in [Gas Accounting](#gas-accounting), returning `payer_escrow_refund` to the payer. If it is not, the whole transaction is invalid.
 
 ##### Cross-frame interactions
 
@@ -472,13 +472,13 @@ charged_gas = max(gas_used_after_refund, calldata_floor_gas)
 
 where `TOTAL_COST_FLOOR_PER_TOKEN` is as defined in EIP-7623. A transaction whose `tx_gas_limit` is below `calldata_floor_gas` is invalid, so the floor is reserved independently of execution as required by EIP-7623.
 
-Each frame receipt reports the frame's gross gas used. The sum of these values does not generally equal `charged_gas`, which also includes costs outside frames and applies the transaction refund and calldata floor.
+Each frame receipt reports the frame's gross gas used. These values do not generally sum to `charged_gas`: the intrinsic, per-frame, calldata, and signature verification costs are charged outside frame gas limits, and the storage refund and calldata floor apply at the transaction level.
 
 Before execution, clients MUST subtract `tx_gas_limit` from the available block gas. A block is invalid if `tx_gas_limit` exceeds the gas available at that point.
 
 Clients MUST use `charged_gas` as the transaction's gas used for block gas accounting. The receipt's `cumulative_gas_used` MUST equal the preceding receipt's value plus `charged_gas`, using zero as the preceding value for the first transaction in a block.
 
-Payment approval collects `TXPARAM(0x06)` from the payer. This value MUST equal `collected_max_cost` as defined below:
+Payment approval collects the transaction's maximum cost (`TXPARAM(0x06)`) from the payer. This value MUST equal `collected_max_cost` as defined below:
 
 ```python
 blob_gas = len(blob_versioned_hashes) * GAS_PER_BLOB

--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -481,6 +481,7 @@ max_cost = (
     max_gas * max_fee_per_gas
     + blob_gas * blob_base_fee
 )
+assert max_cost < 2**256
 charged_fee = gas_used * effective_gas_price + blob_gas * blob_base_fee
 payer_refund = max_cost - charged_fee
 ```
@@ -491,7 +492,7 @@ After execution, return `payer_refund` to the payer. This is the `resolved_targe
 
 When `blob_versioned_hashes` is non-empty, the transaction is a blob-carrying transaction and follows [EIP-4844](./eip-4844.md), where the payer is also the blob-fee payer. The following distinctions from EIP-4844 must also be adhered to:
 
-- The transaction is only valid for inclusion in a block if `tx.max_fee_per_blob_gas >= blob_base_fee` of that block.
+- The transaction is only valid for inclusion in a block if `tx.max_fee_per_blob_gas >= blob_base_fee` of that block. `max_fee_per_blob_gas` is used only for this inclusion check. The payer is charged `blob_gas * blob_base_fee`; no additional blob fee is collected or refunded.
 - It contributes `len(blob_versioned_hashes) * GAS_PER_BLOB` to the block's `blob_gas_used` and counts against the blob limits of the active fork. The per-transaction blob limit of [EIP-7594](./eip-7594.md) applies unchanged.
 - Unlike EIP-4844 transactions, a frame transaction is not required to carry blobs.
 - The `BLOBHASH` instruction returns `tx.blob_versioned_hashes[index]` in every frame, per EIP-4844.

--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -506,8 +506,6 @@ applied_refund = min(refund_counter, gas_used_before_refund // 5)
 gas_used = gas_used_before_refund - applied_refund
 ```
 
-The `gas_used` in each frame receipt is the gas consumed by that frame before the transaction refund defined by EIP-3529. It equals the frame's `gas_limit` minus the gas remaining when the frame exits. An exceptional halt consumes the frame's full `gas_limit`. A skipped frame uses zero gas. Transaction intrinsic cost, per frame cost, transaction data cost, signature verification cost, and any calldata floor increase are not assigned to frame receipts. The sum of frame receipt `gas_used` values therefore need not equal `charged_gas`.
-
 ##### Default code
 
 Frame transactions can be used by accounts who do not have deployed code, nor an [EIP-7702](./eip-7702.md) delegation indicator via the "default code" mechanism. The behavior of the default code is defined below:

--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -460,7 +460,7 @@ where `TOTAL_COST_FLOOR_PER_TOKEN` is as defined in EIP-7623. A transaction whos
 
 Clients MUST use `charged_gas` as the transaction's gas used for block gas accounting. The receipt's `cumulative_gas_used` MUST equal the preceding receipt's value plus `charged_gas`, using zero as the preceding value for the first transaction in a block.
 
-Payment approval collects the transaction's maximum cost from the payer. Fee settlement is calculated as:
+Payment approval collects `TXPARAM(0x06)`, the transaction's maximum cost, from the payer. Define:
 
 ```python
 blob_gas = len(blob_versioned_hashes) * GAS_PER_BLOB
@@ -474,7 +474,7 @@ payer_escrow_refund = collected_max_cost - charged_fee
 gas_pool_refund = tx_gas_limit - charged_gas
 ```
 
-The `effective_gas_price` is calculated per [EIP-1559](./eip-1559.md), and `actual_blob_fee` is calculated per [EIP-4844](./eip-4844.md). Transaction validity and the floor-validity check above guarantee:
+The `effective_gas_price` is calculated per [EIP-1559](./eip-1559.md), and `actual_blob_fee` is calculated per [EIP-4844](./eip-4844.md). A valid transaction has `effective_gas_price <= max_fee_per_gas` and `blob_base_fee <= max_fee_per_blob_gas`. Together with the floor-validity check above, this guarantees:
 
 ```python
 0 <= charged_gas <= tx_gas_limit
@@ -490,7 +490,7 @@ When `blob_versioned_hashes` is non-empty, the transaction is a blob-carrying tr
 - Unlike EIP-4844 transactions, a frame transaction is not required to carry blobs.
 - The `BLOBHASH` instruction returns `tx.blob_versioned_hashes[index]` in every frame, per EIP-4844.
 
-After execution, `payer_escrow_refund` is returned to the payer (the `resolved_target` that called `APPROVE(APPROVE_PAYMENT)` or `APPROVE(APPROVE_EXECUTION_AND_PAYMENT)`), and `gas_pool_refund` gas units are returned to the block gas pool. The execution base fee and `actual_blob_fee` are burned according to EIP-1559 and EIP-4844, and the execution priority fee is credited according to EIP-1559. Actual blob gas is not refundable, but unused `max_fee_per_blob_gas` escrow is included in `payer_escrow_refund`.
+After execution, return `payer_escrow_refund` to the payer (the `resolved_target` that called `APPROVE(APPROVE_PAYMENT)` or `APPROVE(APPROVE_EXECUTION_AND_PAYMENT)`). Return `gas_pool_refund` gas units to the block gas pool. The execution base fee is burned and the execution priority fee is credited to the block beneficiary according to EIP-1559. The `actual_blob_fee` is burned according to EIP-4844. The payer is charged `actual_blob_fee` for all blobs; any difference between the maximum blob fee included in `collected_max_cost` and `actual_blob_fee` is part of `payer_escrow_refund`.
 
 Any `frame.value` transferred by `SENDER` frames is separate from `charged_fee` and follows ordinary `CALL` value-transfer semantics. The gas cost of sending `frame.value` is the same as for any `CALL` instruction.
 

--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -442,21 +442,37 @@ calldata_tokens = (
 )
 ```
 
-where `tokens_in` counts tokens as in EIP-7623. Mirroring EIP-7623, mandatory costs are always charged and the calldata cost is floored against execution, so the gas charged to the payer is:
+where `tokens_in` counts tokens as in EIP-7623.
+
+Each frame has its own `gas_limit` allocation. Unused gas from a frame is **not** available to subsequent frames. Let `frame_receipts` be the ordered frame receipt list. After all frames execute:
 
 ```python
-charged_gas = (
-    FRAME_TX_INTRINSIC_COST
-    + len(tx.frames) * FRAME_TX_PER_FRAME_COST
-    + signature_verification_cost
-    + max(
-        frame_data_cost + signature_data_cost + total_gas_used,
-        TOTAL_COST_FLOOR_PER_TOKEN * calldata_tokens,
-    )
+tx_unused_gas = sum(
+    frame.gas_limit - frame_receipt.gas_used
+    for frame, frame_receipt in zip(tx.frames, frame_receipts)
 )
 ```
 
-where `TOTAL_COST_FLOOR_PER_TOKEN` is as defined in EIP-7623. A transaction whose `tx_gas_limit` is below `FRAME_TX_INTRINSIC_COST + len(tx.frames) * FRAME_TX_PER_FRAME_COST + signature_verification_cost + TOTAL_COST_FLOOR_PER_TOKEN * calldata_tokens` is invalid, so the floor is reserved independently of execution as required by EIP-7623.
+Storage gas refunds ([EIP-3529](./eip-3529.md)) accumulate across frames into a single transaction-scoped `refund_counter`. Changes made to the counter by a reverted frame, or by frames unrolled as part of a failed atomic batch, are discarded together with that frame's state changes. At the end of the transaction, apply the storage refund before the EIP-7623 calldata floor:
+
+```python
+gas_used_before_refund = tx_gas_limit - tx_unused_gas
+applied_refund = min(refund_counter, gas_used_before_refund // 5)
+gas_used_after_refund = gas_used_before_refund - applied_refund
+
+calldata_floor_gas = (
+    FRAME_TX_INTRINSIC_COST
+    + len(tx.frames) * FRAME_TX_PER_FRAME_COST
+    + signature_verification_cost
+    + TOTAL_COST_FLOOR_PER_TOKEN * calldata_tokens
+)
+
+charged_gas = max(gas_used_after_refund, calldata_floor_gas)
+```
+
+where `TOTAL_COST_FLOOR_PER_TOKEN` is as defined in EIP-7623. A transaction whose `tx_gas_limit` is below `calldata_floor_gas` is invalid, so the floor is reserved independently of execution as required by EIP-7623.
+
+Each frame receipt reports the frame's gross gas used. The sum of these values does not generally equal `charged_gas`, which also includes costs outside frames and applies the transaction refund and calldata floor.
 
 Before execution, clients MUST subtract `tx_gas_limit` from the available block gas. A block is invalid if `tx_gas_limit` exceeds the gas available at that point.
 
@@ -476,7 +492,7 @@ payer_escrow_refund = collected_max_cost - charged_fee
 gas_pool_refund = tx_gas_limit - charged_gas
 ```
 
-The `effective_gas_price` is calculated per [EIP-1559](./eip-1559.md), and `actual_blob_fee` is calculated per [EIP-4844](./eip-4844.md). A valid transaction has `effective_gas_price <= max_fee_per_gas` and `blob_base_fee <= max_fee_per_blob_gas`. Together with the floor validity check above, this guarantees:
+The `effective_gas_price` is calculated per [EIP-1559](./eip-1559.md), and `actual_blob_fee` is calculated per [EIP-4844](./eip-4844.md). A valid transaction has `effective_gas_price <= max_fee_per_gas`. If `blob_gas > 0`, it also has `blob_base_fee <= max_fee_per_blob_gas`. Together with the floor validity check above, this guarantees:
 
 ```python
 0 <= charged_gas <= tx_gas_limit
@@ -495,16 +511,6 @@ When `blob_versioned_hashes` is non-empty, the transaction is a blob-carrying tr
 After execution, return `payer_escrow_refund` to the payer (the `resolved_target` that called `APPROVE(APPROVE_PAYMENT)` or `APPROVE(APPROVE_EXECUTION_AND_PAYMENT)`). Return `gas_pool_refund` gas units to the block gas pool. The net reduction in available block gas is therefore `charged_gas`. The execution base fee is burned and the execution priority fee is credited to the block beneficiary according to EIP-1559. The `actual_blob_fee` is burned according to EIP-4844. The payer is charged `actual_blob_fee` for all blobs; any difference between the maximum blob fee included in `collected_max_cost` and `actual_blob_fee` is part of `payer_escrow_refund`.
 
 Any `frame.value` transferred by `SENDER` frames is separate from `charged_fee` and follows ordinary `CALL` value transfer semantics. The gas cost of sending `frame.value` is the same as for any `CALL` instruction.
-
-Each frame has its own `gas_limit` allocation. Unused gas from a frame is **not** available to subsequent frames. A rolling total `tx_unused_gas` is tracked throughout the transaction.
-
-Storage gas refunds ([EIP-3529](./eip-3529.md)) accumulate across frames into a single transaction-scoped `refund_counter`. Changes made to the counter by a reverted frame, or by frames unrolled as part of a failed atomic batch, are discarded together with that frame's state changes. At the end of the transaction:
-
-```python
-gas_used_before_refund = tx_gas_limit - tx_unused_gas
-applied_refund = min(refund_counter, gas_used_before_refund // 5)
-gas_used = gas_used_before_refund - applied_refund
-```
 
 ##### Default code
 

--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -458,9 +458,11 @@ charged_gas = (
 
 where `TOTAL_COST_FLOOR_PER_TOKEN` is as defined in EIP-7623. A transaction whose `tx_gas_limit` is below `FRAME_TX_INTRINSIC_COST + len(tx.frames) * FRAME_TX_PER_FRAME_COST + signature_verification_cost + TOTAL_COST_FLOOR_PER_TOKEN * calldata_tokens` is invalid, so the floor is reserved independently of execution as required by EIP-7623.
 
+Before execution, clients MUST subtract `tx_gas_limit` from the available block gas. A block is invalid if `tx_gas_limit` exceeds the gas available at that point.
+
 Clients MUST use `charged_gas` as the transaction's gas used for block gas accounting. The receipt's `cumulative_gas_used` MUST equal the preceding receipt's value plus `charged_gas`, using zero as the preceding value for the first transaction in a block.
 
-Payment approval collects `TXPARAM(0x06)`, the transaction's maximum cost, from the payer. Define:
+Payment approval collects `TXPARAM(0x06)` from the payer. This value MUST equal `collected_max_cost` as defined below:
 
 ```python
 blob_gas = len(blob_versioned_hashes) * GAS_PER_BLOB
@@ -474,7 +476,7 @@ payer_escrow_refund = collected_max_cost - charged_fee
 gas_pool_refund = tx_gas_limit - charged_gas
 ```
 
-The `effective_gas_price` is calculated per [EIP-1559](./eip-1559.md), and `actual_blob_fee` is calculated per [EIP-4844](./eip-4844.md). A valid transaction has `effective_gas_price <= max_fee_per_gas` and `blob_base_fee <= max_fee_per_blob_gas`. Together with the floor-validity check above, this guarantees:
+The `effective_gas_price` is calculated per [EIP-1559](./eip-1559.md), and `actual_blob_fee` is calculated per [EIP-4844](./eip-4844.md). A valid transaction has `effective_gas_price <= max_fee_per_gas` and `blob_base_fee <= max_fee_per_blob_gas`. Together with the floor validity check above, this guarantees:
 
 ```python
 0 <= charged_gas <= tx_gas_limit
@@ -490,9 +492,9 @@ When `blob_versioned_hashes` is non-empty, the transaction is a blob-carrying tr
 - Unlike EIP-4844 transactions, a frame transaction is not required to carry blobs.
 - The `BLOBHASH` instruction returns `tx.blob_versioned_hashes[index]` in every frame, per EIP-4844.
 
-After execution, return `payer_escrow_refund` to the payer (the `resolved_target` that called `APPROVE(APPROVE_PAYMENT)` or `APPROVE(APPROVE_EXECUTION_AND_PAYMENT)`). Return `gas_pool_refund` gas units to the block gas pool. The execution base fee is burned and the execution priority fee is credited to the block beneficiary according to EIP-1559. The `actual_blob_fee` is burned according to EIP-4844. The payer is charged `actual_blob_fee` for all blobs; any difference between the maximum blob fee included in `collected_max_cost` and `actual_blob_fee` is part of `payer_escrow_refund`.
+After execution, return `payer_escrow_refund` to the payer (the `resolved_target` that called `APPROVE(APPROVE_PAYMENT)` or `APPROVE(APPROVE_EXECUTION_AND_PAYMENT)`). Return `gas_pool_refund` gas units to the block gas pool. The net reduction in available block gas is therefore `charged_gas`. The execution base fee is burned and the execution priority fee is credited to the block beneficiary according to EIP-1559. The `actual_blob_fee` is burned according to EIP-4844. The payer is charged `actual_blob_fee` for all blobs; any difference between the maximum blob fee included in `collected_max_cost` and `actual_blob_fee` is part of `payer_escrow_refund`.
 
-Any `frame.value` transferred by `SENDER` frames is separate from `charged_fee` and follows ordinary `CALL` value-transfer semantics. The gas cost of sending `frame.value` is the same as for any `CALL` instruction.
+Any `frame.value` transferred by `SENDER` frames is separate from `charged_fee` and follows ordinary `CALL` value transfer semantics. The gas cost of sending `frame.value` is the same as for any `CALL` instruction.
 
 Each frame has its own `gas_limit` allocation. Unused gas from a frame is **not** available to subsequent frames. A rolling total `tx_unused_gas` is tracked throughout the transaction.
 
@@ -503,6 +505,8 @@ gas_used_before_refund = tx_gas_limit - tx_unused_gas
 applied_refund = min(refund_counter, gas_used_before_refund // 5)
 gas_used = gas_used_before_refund - applied_refund
 ```
+
+The `gas_used` in each frame receipt is the gas consumed by that frame before the transaction refund defined by EIP-3529. It equals the frame's `gas_limit` minus the gas remaining when the frame exits. An exceptional halt consumes the frame's full `gas_limit`. A skipped frame uses zero gas. Transaction intrinsic cost, per frame cost, transaction data cost, signature verification cost, and any calldata floor increase are not assigned to frame receipts. The sum of frame receipt `gas_used` values therefore need not equal `charged_gas`.
 
 ##### Default code
 


### PR DESCRIPTION
EIP-8141 defines frame gas limits, a transaction level EIP-3529 refund, and the EIP-7623 calldata floor, but the current gas accounting does not connect them consistently. `charged_gas` still references `total_gas_used`, while fee settlement uses the older `tx_fee` model without reconciling the payer's maximum fee escrow.

This PR:

- defines unused frame gas from the ordered frame receipts;
- applies the EIP-3529 refund before the EIP-7623 calldata floor to obtain `charged_gas`;
- uses `charged_gas` for block gas accounting and receipt `cumulative_gas_used`;
- reserves `tx_gas_limit` before execution and returns `tx_gas_limit - charged_gas` to the block gas pool;
- collects the maximum execution and blob cost from the payer;
- charges execution and blob gas at their effective prices and returns unused escrow; and
- preserves the EIP-1559 and EIP-4844 burn and priority fee rules.

This PR is rebased on merged #11940 and #11955. #11940 defines the transaction level refund counter and gross frame receipt gas. #11955 defines which approval effects survive frame and atomic batch rollback.