### PR TITLE
Update EIP-8250: clarify NONCE_MANAGER activation

### DIFF
--- a/EIPS/eip-8250.md
+++ b/EIPS/eip-8250.md
@@ -50,6 +50,8 @@ This specification is a delta against [EIP-8141](./eip-8141.md).
 
 `NONCE_MANAGER` MUST be selected so that no code or storage exists at the address on every intended activation network at fork-configuration finalization. If the selected address has non-empty code or non-empty storage on any intended activation network at fork-configuration finalization, a different address MUST be selected. This EIP does not define a normal activation transition that clears non-empty storage or overwrites non-empty code at `NONCE_MANAGER`.
 
+`NONCE_MANAGER` MUST differ from EIP-8141's `EXPIRY_VERIFIER`.
+
 ### Transaction payload
 
 The frame-transaction payload becomes:
@@ -227,6 +229,8 @@ For every block `B` with `B.timestamp >= FORK_TIMESTAMP` whose parent has `paren
 If `NONCE_MANAGER` does not exist, clients MUST create it with balance `0`, nonce `1`, code `NONCE_MANAGER_CODE`, and empty storage.
 
 If `NONCE_MANAGER` already exists with empty code and empty storage, clients MUST set its code to `NONCE_MANAGER_CODE`, set its nonce to `max(existing_nonce, 1)`, preserve its balance, and leave storage empty.
+
+If `NONCE_MANAGER` has non-empty code or non-empty storage in `B`'s parent state, `B` is invalid.
 
 For all other blocks, clients MUST NOT run this initialization. Clients MUST handle reorgs across the fork boundary by applying or undoing this transition according to the canonical chain.
 


### PR DESCRIPTION
EIP-8250 requires `NONCE_MANAGER` to be empty when the fork configuration is finalized, but does not define the result if code or storage appears before activation.

This PR:

- requires `NONCE_MANAGER` to differ from EIP-8141's `EXPIRY_VERIFIER`; and
- makes the activation block invalid if `NONCE_MANAGER` has code or storage in the parent state.

No transaction, nonce, gas, or payload rules change.

Checks:

- `git diff --check`
- `markdownlint-cli2 EIPS/eip-8250.md`
- `codespell EIPS/eip-8250.md --ignore-words=config/.codespell-whitelist`
