### PR TITLE
Update EIP-8272: clarify signature hashing and predeploy address

### DIFF
--- a/EIPS/eip-8272.md
+++ b/EIPS/eip-8272.md
@@ -55,6 +55,8 @@ This specification is a delta against EIP-8141. Terms not defined here, includin
 
 All concatenations below use fixed-length encodings. Domains are 32 bytes. Addresses are 20 bytes. Slots and indices are unsigned 64-bit big-endian integers. Roots, salts, source identifiers, entry hashes, and storage keys are 32 bytes.
 
+`RECENT_ROOT_ADDRESS` MUST differ from EIP-8141's `EXPIRY_VERIFIER`.
+
 ### Current slot
 
 For block validation, `current_slot` is the consensus slot of the beacon block that contains the execution payload being validated.
@@ -191,17 +193,7 @@ The `slot` field is a slot number, not a timestamp or block number.
 
 The frame layout and frame execution rules are otherwise unchanged. `recent_root_references` is a top-level transaction field and is included in `compute_sig_hash(tx)`.
 
-The post-fork signature hash follows EIP-8141 over the ten-field payload, eliding the raw `signature` bytes of any signature with empty `msg`:
-
-```python
-def compute_sig_hash(tx: FrameTx) -> Hash:
-    for i, sig in enumerate(tx.signatures):
-        if len(sig.msg) == 0:
-            tx.signatures[i].signature = Bytes()
-    return keccak(bytes([FRAME_TX_TYPE]) + rlp(tx))
-```
-
-where `rlp(tx)` is the post-fork ten-field payload.
+The post-fork signature hash is `compute_sig_hash(tx)` as defined by EIP-8141, applied to the applicable post-fork payload defined by this EIP. The function hashes a copy in which every signature with empty `msg` has an empty `signature`; it does not modify the decoded transaction.
 
 Frame data, including VERIFY frame data, MUST NOT add, remove, or modify the transaction's recent root reference set.
 


### PR DESCRIPTION
EIP-8272 repeats EIP-8141's signature hash pseudocode, hardcodes the standalone payload with ten fields, and mutates the decoded transaction while constructing the hash.

This PR:

- applies EIP-8141's `compute_sig_hash` definition to the EIP-8272 payload;
- states that signature hashing does not modify the decoded transaction; and
- requires `RECENT_ROOT_ADDRESS` to differ from EIP-8141's `EXPIRY_VERIFIER`.

Recent root validation, writes, gas accounting, payload composition, and networking rules are unchanged.

Checks:

- `git diff --check`
- `markdownlint-cli2 EIPS/eip-8272.md`
- `codespell EIPS/eip-8272.md --ignore-words=config/.codespell-whitelist`
