### PR TITLE
Update EIP-7745: remove shadowed log_index assignment in reference code

### DIFF
--- a/assets/eip-7745/log_index.py
+++ b/assets/eip-7745/log_index.py
@@ -148,7 +148,6 @@ def log_index_add_log_entries(
     Adds address and topic entries to the current filter map and a log entry to
     the index entries tree according to the given list of log events.
     """
-    log_index = Uint(0)
     for log in logs:
         prepare_index(log_index, Uint(len(log.topics) + 1))
         add_to_filter_maps(log_index, map_value_hash_address(log.address))


### PR DESCRIPTION
## Summary

- Removes the erroneous local `log_index = Uint(0)` in `log_index_add_log_entries` that shadowed the `LogIndexState` parameter.
- Without this fix, address/topic filter-map and entry updates would operate on a `Uint` instead of the index state.

cc @zsfelfoldi

## Test plan

- [ ] Confirm `log_index_add_log_entries` uses the `LogIndexState` parameter throughout the loop
- [ ] Spot-check that related helpers (`prepare_index`, `add_to_filter_maps`, `add_log_entry`, `advance_index`) still receive a `LogIndexState`