### PR TITLE
Update EIP-7745: fix gti_vector operator precedence in reference code

### DIFF
--- a/assets/eip-7745/binary_tree.py
+++ b/assets/eip-7745/binary_tree.py
@@ -131,7 +131,7 @@ def gti_vector(root: U256, index, height: Uint) -> U256:
     """
     Returns the generalized tree index of a vector item.
     """
-    return root << height + index
+    return (root << height) + index
 
 
 def gti_merge(index, sub_index: U256) -> U256:


### PR DESCRIPTION
## Summary

- Fixes operator precedence in `gti_vector`: `root << height + index` was parsed as `root << (height + index)` because `+` binds tighter than `<<`.
- Parenthesizes the expression as `(root << height) + index`, matching the intended generalized tree index for a vector item.

cc @zsfelfoldi

## Test plan

- [ ] Confirm `gti_vector` returns `(root << height) + index`
- [ ] Spot-check call sites of `gti_vector` / related GTI helpers for consistent indexing