### PR TITLE
Update EIP-8141: charge for each arbitrary sig entry

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -170,7 +170,7 @@ The `scheme` identifies how the raw `signature` bytes are interpreted.
 
 | `scheme`   | Name         | `signature` encoding                           | Gas cost |
 |------------|--------------|------------------------------------------------|----------|
-| 0x0        | `ARBITRARY`  | arbitrary bytes                                | 0        |
+| 0x0        | `ARBITRARY`  | arbitrary bytes                                | 100      |
 | 0x1        | `SECP256K1`  | `v (1 byte) || r (32 bytes) || s (32 bytes)`   | 2800     |
 | 0x2        | `P256`       | `r || s || qx || qy` (32 bytes each)           | 6700     |
 | 0x3..255   | reserved     | reserved                                       | reserved |
@@ -392,7 +392,7 @@ def signature_gas(sig):
     if sig.scheme == P256:
         return 6700
     if sig.scheme == ARBITRARY:
-        return 0
+        return 100
     invalid_transaction()
 
 signature_verification_cost = sum(signature_gas(sig) for sig in tx.signatures)


### PR DESCRIPTION
*alternative for #11935*

To avoid large number of empty `ARBITRARY` signature entries not being fairly charged, we introduce a flat 100 gas fee per entry on top of regular calldata costs applied to all signatures.