### PR TITLE
Update EIP-8297: Update EIP-8297.md

### DIFF
--- a/EIPS/eip-8297.md
+++ b/EIPS/eip-8297.md
@@ -8,22 +8,21 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2026-06-11
-requires: 7612
+requires: 4762, 7612
 ---
 
 ## Abstract
 
 Introduce a new binary state tree to replace the hexary Patricia tries. Account
-and storage tries are merged into a single tree with 32-byte keys that also holds
-contract code. Account data is broken into independent leaves grouped by 256 to
-provide locality.
+and storage tries are merged into a single tree with variable-length,
+prefix-free keys that also holds contract code. Account data is broken into
+independent leaves grouped under a shared key prefix to provide locality.
 
-The tree is partitioned into zones. The high 4 bits of every key are a zone
+The tree is partitioned into zones. The first byte of every key is a zone
 identifier that labels the category of state the key holds: account headers,
-contract code, or storage. Storage takes the entire upper half of the zone space
-(any key with the high bit set), so it is rooted at depth 1 and occupies about half
-the tree. Account headers and code take fixed low zones, and the remaining low
-zones are reserved for future categories.
+contract code, or storage. Account headers and code take fixed low zones,
+storage takes a fixed high zone, and the remaining zones are reserved for
+future categories.
 
 Note: the hash function used in this draft is not final. The reference
 implementation uses BLAKE3 to reduce friction for clients experimenting with this
@@ -36,14 +35,14 @@ verification is as simple and fast as possible. Part of this work consists of pr
 state read during EVM execution.
 
 The Merkle Patricia Trie (MPT) is unfriendly to validity proofs: it uses RLP for
-node encoding, Keccak for hashing, is a "tree of trees", and does not allow for the efficient proving of segments of bytecode. It also produces large Merkle proofs. As an example, the account trie today reaches a maximum depth of about 12, so the
-expected size of a single branch is `15 * 32 * 12 = 5760` bytes: 15 sibling hashes of
+node encoding, Keccak for hashing, is a "tree of trees", and does not allow for the efficient proving of segments of bytecode. It also produces large Merkle proofs. As an example, the account trie today reaches a maximum depth of about 12, so a
+branch at that depth is `15 * 32 * 12 = 5760` bytes: 15 sibling hashes of
 32 bytes at each of the 12 levels. From a worst-case block perspective, spending all
 60M gas to touch a single byte of many distinct account codes, none of which is
 chunked, needs `60M/2400 * (12*480 + 64k) ≈ 1.8GB`. Here `2400` is the cheapest gas
-to touch a fresh account (the [EIP-2930](./eip-2930.md) access-list address cost. A
-cold account access under [EIP-2929](./eip-2929.md) is `2600`), `12*480` is the
-branch to that account, and `64k` is the [EIP-7954](./eip-7954.md) 64 KiB code size
+to touch a fresh account, the [EIP-2930](./eip-2930.md) access-list address cost
+(a cold access under [EIP-2929](./eip-2929.md) costs `2600`); `12*480` is the
+branch to that account; and `64k` is the [EIP-7954](./eip-7954.md) 64 KiB code size
 limit that must be revealed in full to prove any single byte of unchunked code.
 
 A binary tree shrinks regular Merkle proofs, because proof size scales with
@@ -53,11 +52,14 @@ proving-friendly hash improves circuit performance.
 Partitioning the tree into zones adds two properties on top of a flat unified
 tree:
 
-**Structural boundaries.** A node at a known depth is always the root of a known
-category: all storage at depth 1, the account zone and code zone at depth 4, one
-account's storage bucket at depth 61. Protocols can reference these subtree roots
-as commitments without a side structure. This is what later proposals for state
-expiry and partial statelessness build on.
+**Structural boundaries.** A key prefix of a known length is always the root of
+a known category: the zone byte identifies account headers, code, or storage;
+within storage, `key_hash(address)` identifies one account's bucket. Protocols
+can reference these key-space regions as commitments without a side structure.
+Because the tree compresses shared prefixes (see "Tree structure"), a boundary
+does not always correspond to a distinct node at a fixed depth, but the region
+of keys it owns is exact. This is what later proposals for state expiry and
+partial statelessness build on.
 
 **Code deduplication.** Code beyond the first chunks is content-addressed by code
 hash rather than by account, so thousands of contracts deployed from the same
@@ -69,7 +71,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ### Notable changes from the hexary structure
 
-- The account and storage tries are merged into a single trie.
+- The account and storage tries are merged into a single tree.
 - RLP is no longer used.
 - The account's code is chunked and included in the tree.
 - Account data (balance, nonce, first storage slots, first code chunks) is
@@ -77,83 +79,85 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ### Notable changes from EIP-7864
 
-[EIP-7864](./eip-7864.md) specifies a flat unified binary tree where every key is
-`key_hash(address || tree_index)[:31] || sub_index`. This proposal keeps that
-tree, its node types, and its merkelization, and changes how keys are assigned:
+[EIP-7864](./eip-7864.md) specifies a flat unified binary tree with fixed
+32-byte keys (`key_hash(address || tree_index)[:31] || sub_index`) and a
+dedicated stem node holding a fixed 256-leaf subtree. This proposal changes
+the key scheme and the node types:
 
-- A 4-bit zone prefix is added to every stem. In EIP-7864 all of an account's
-  data (header, storage, code) is derived from its address and scattered through
-  the tree by `tree_index`. Here each category lives in its own zone.
-- Overflow code (chunks at index 128 and above) moves to zone `0x1` and is keyed
-  by `code_hash` instead of by account, so contracts with identical bytecode share
-  leaves. EIP-7864 keys all code per account, storing a copy for every contract.
-- Overflow storage (slots 64 and above) moves to the storage zone, where a stem is
-  the storage high bit, a 60-bit address prefix, and a 187-bit suffix. EIP-7864
-  uses `key_hash(address || tree_index)[:31]` with no per-account bucket boundary.
-- `MAIN_STORAGE_OFFSET` is removed. EIP-7864 offsets main storage by `256**31` to
-  keep it clear of the header and code region. Here the storage zone bit separates
-  storage structurally, so no numeric offset is needed.
-- Non-storage stems are a 4-bit zone followed by a 244-bit hash. The hash is
-  truncated to 244 bits rather than EIP-7864's 248, since the zone takes the high
-  4 bits of the stem.
+- Keys are variable length: a one-byte zone identifier, one or two full
+  32-byte digests, and a sub-index byte. Every key of a zone shares one
+  fixed length (see "Tree embedding"), which keeps keys prefix-free.
+- The tree is partitioned into zones (see "Zones"); EIP-7864 has none. Each
+  category of state (account headers, code, storage) gets its own zone
+  and its own region of the key space, rather than being scattered
+  uniformly across the tree by `tree_index`.
+- A storage key's stem is `0xFF || key_hash(address) || key_hash(address ||
+  tree_index)`: a zone byte and two full digests. This gives every account
+  its own storage bucket and binds the group-spreading digest to the
+  address (see "Security Considerations").
+- Overflow code (chunks at index 128 and above) is keyed by `code_hash`
+  rather than by account; EIP-7864 keys all code per account, storing a
+  copy for every contract.
+- `MAIN_STORAGE_OFFSET` is unnecessary: the storage zone byte separates
+  storage structurally, so no numeric offset into a shared address space is
+  needed.
+- The tree has no dedicated stem node and no separate extension node (see
+  "Tree structure"); EIP-7864's `StemNode` commits a fixed 256-leaf subtree
+  regardless of how sparse it is.
 
-The account header layout (`BASIC_DATA` packing, `CODE_HASH`, the first 64 storage
-slots, the first 128 code chunks), the code chunkification, and the four node types
-are unchanged from EIP-7864.
+The account header layout (`CODE_HASH`, the first 64 storage slots, the
+first 128 code chunks) and the code chunkification are unchanged from
+EIP-7864. In `BASIC_DATA`, `code_size` widens from three bytes at offset 5
+to four bytes at offset 4, taking one reserved byte; every other field
+keeps its position.
 
 ### Tree structure
 
-The tree stores key-value entries where both key and value are 32 bytes. The first
-31 bytes of the key are the entry stem, and the last byte is the sub-index within
-that stem. Two keys with the same stem live in the same group of 256 leaves.
+The tree stores key-value entries where the key is a non-empty,
+variable-length byte string of at most `MAX_KEY_LENGTH` bytes (see
+"Maximum key length") and the value is 32 bytes. Keys MUST be prefix-free:
+no key in the tree may be a prefix of another key in the tree. `insert`
+rejects keys that violate either constraint.
 
-![Image](../assets/eip-8297/diagram.png)
+<!-- TODO: the diagram below (../assets/eip-8297/diagram.png) depicts the
+     earlier stem-node model and needs to be redrawn for the node types
+     described here. -->
 
-There are four node types:
+![Tree structure diagram](../assets/eip-8297/diagram.png)
 
-- `InternalNode` has `left_hash` and `right_hash`.
-- `StemNode` has `stem`, `left_hash`, and `right_hash`.
-- `LeafNode` has a `value` that is a 32-byte blob or empty.
-- `EmptyNode` represents an empty node or subtree.
+There are two node types:
 
-Keys are traversed in big-endian bit order. A key is expanded to a bit list by
-`_bytes_to_bits` (defined below), most significant bit (MSB) first: bit 0 of the
-path is the MSB of the first byte, and the last bit is the least significant bit
-(LSB) of the last byte. Depth `d` in the tree selects bit `d` of this list, so the
-zone identifier in the high 4 bits of the stem governs the top four levels.
+- `LeafNode` has `key` (the complete key) and `value` (32 bytes).
+- `BranchNode` has `prefix` (a bit string, possibly empty), `left`, and
+  `right`.
 
-The path to a `StemNode` is the stem's 248 bits in this MSB-to-LSB order. From that
-node a subtree of 256 values is indexed by the last byte. The path does not use the
-full 248 bits: it contains the minimal number of `InternalNode`s needed to separate
-stems that share a prefix. Walking the path to insert a new stem ends on an
-`EmptyNode` (replace it with the stem) or a `StemNode` (create as many
-`InternalNode`s as the two stems share prefix bits). There are no extension nodes.
+There is no separate extension node. A `BranchNode`'s `prefix` carries the
+run of bits shared by every key below it that are not already consumed by
+an ancestor.
 
-This minimal-internal-node rule keeps the zone prefix cheap. Only a few low zones
-are populated, so the zone bits between the root and a populated zone collapse to
-the minimal set of internal nodes rather than a full four-level chain.
+A `BranchNode` MUST have two non-empty children: a prefix shorter than the
+true shared run would leave the keys still agreeing at the next bit,
+emptying one side, which is not a valid `BranchNode`. This forces every
+prefix to be exactly the shared run, so each key/value set has exactly one
+valid tree.
+
+A `LeafNode` commits its complete key rather than a suffix relative to its
+position in the tree, so its meaning never depends on where it sits;
+splitting or merging branches elsewhere never changes an unrelated leaf's
+hash.
 
 ```python
 def _bytes_to_bits(data: bytes) -> list[int]:
     return [(byte >> (7 - i)) & 1 for byte in data for i in range(8)]
 
-def _bits_to_bytes(bits: list[int]) -> bytes:
-    return bytes(
-        sum(bits[i + j] << (7 - j) for j in range(8))
-        for i in range(0, len(bits), 8)
-    )
+class LeafNode:
+    def __init__(self, key: bytes, value: bytes):
+        self.key = key
+        self.value = value
 
-class StemNode:
-    def __init__(self, stem: bytes):
-        assert len(stem) == 31, "stem must be 31 bytes"
-        self.stem = stem
-        self.values: list[Optional[bytes]] = [None] * 256
-
-    def set_value(self, index: int, value: bytes):
-        self.values[index] = value
-
-class InternalNode:
-    def __init__(self):
+class BranchNode:
+    def __init__(self, prefix: list[int]):
+        self.prefix = prefix
         self.left = None
         self.right = None
 
@@ -162,188 +166,194 @@ class BinaryTree:
         self.root = None
 
     def insert(self, key: bytes, value: bytes):
-        assert len(key) == 32, "key must be 32 bytes"
+        assert 1 <= len(key) <= MAX_KEY_LENGTH, "key length out of range"
         assert len(value) == 32, "value must be 32 bytes"
-        stem = key[:31]
-        subindex = key[31]
-
         if self.root is None:
-            self.root = StemNode(stem)
-            self.root.set_value(subindex, value)
+            self.root = LeafNode(key, value)
             return
+        self.root = self._insert(self.root, _bytes_to_bits(key), key, value, 0)
 
-        self.root = self._insert(self.root, stem, subindex, value, 0)
+    def _insert(self, node, bits, key, value, depth):
+        if isinstance(node, LeafNode):
+            if node.key == key:
+                node.value = value
+                return node
+            other_bits = _bytes_to_bits(node.key)
+            limit = min(len(bits), len(other_bits))
+            run = 0
+            while depth + run < limit and bits[depth + run] == other_bits[depth + run]:
+                run += 1
+            assert depth + run < limit, "insert violates prefix-freedom"
+            prefix = bits[depth:depth + run]
+            new_leaf = LeafNode(key, value)
+            branch = BranchNode(prefix)
+            if bits[depth + run] == 0:
+                branch.left, branch.right = new_leaf, node
+            else:
+                branch.left, branch.right = node, new_leaf
+            return branch
 
-    def _insert(self, node, stem, subindex, value, depth):
-        assert depth < 248, "depth must be less than 248"
-
-        if node is None:
-            node = StemNode(stem)
-            node.set_value(subindex, value)
+        matched = 0
+        while (matched < len(node.prefix) and depth + matched < len(bits)
+               and bits[depth + matched] == node.prefix[matched]):
+            matched += 1
+        assert depth + matched < len(bits), "insert violates prefix-freedom"
+        if matched == len(node.prefix):
+            split = depth + matched
+            if bits[split] == 0:
+                node.left = self._insert(node.left, bits, key, value, split + 1)
+            else:
+                node.right = self._insert(node.right, bits, key, value, split + 1)
             return node
 
-        stem_bits = _bytes_to_bits(stem)
-        if isinstance(node, StemNode):
-            if node.stem == stem:
-                node.set_value(subindex, value)
-                return node
-            existing_stem_bits = _bytes_to_bits(node.stem)
-            return self._split_leaf(
-                node, stem_bits, existing_stem_bits, subindex, value, depth
-            )
-
-        bit = stem_bits[depth]
-        if bit == 0:
-            node.left = self._insert(node.left, stem, subindex, value, depth + 1)
+        # The key diverges inside the prefix: split the branch at the
+        # divergence point. The surviving branch keeps the bits after it;
+        # a new branch takes the bits before it.
+        survivor = BranchNode(node.prefix[matched + 1:])
+        survivor.left, survivor.right = node.left, node.right
+        new_leaf = LeafNode(key, value)
+        new_branch = BranchNode(node.prefix[:matched])
+        if bits[depth + matched] == 0:
+            new_branch.left, new_branch.right = new_leaf, survivor
         else:
-            node.right = self._insert(node.right, stem, subindex, value, depth + 1)
-        return node
-
-    def _split_leaf(self, leaf, stem_bits, existing_stem_bits, subindex, value, depth):
-        if stem_bits[depth] == existing_stem_bits[depth]:
-            new_internal = InternalNode()
-            bit = stem_bits[depth]
-            if bit == 0:
-                new_internal.left = self._split_leaf(
-                    leaf, stem_bits, existing_stem_bits, subindex, value, depth + 1
-                )
-            else:
-                new_internal.right = self._split_leaf(
-                    leaf, stem_bits, existing_stem_bits, subindex, value, depth + 1
-                )
-            return new_internal
-        else:
-            new_internal = InternalNode()
-            bit = stem_bits[depth]
-            stem = _bits_to_bytes(stem_bits)
-            if bit == 0:
-                new_internal.left = StemNode(stem)
-                new_internal.left.set_value(subindex, value)
-                new_internal.right = leaf
-            else:
-                new_internal.right = StemNode(stem)
-                new_internal.right.set_value(subindex, value)
-                new_internal.left = leaf
-            return new_internal
+            new_branch.left, new_branch.right = survivor, new_leaf
+        return new_branch
 ```
 
 ### Node merkelization
 
-Define `hash(value)` as:
+Define tags `LEAF_TAG = 0x00` and `BRANCH_TAG = 0x01`. `H` is the tree's
+32-byte hash function, the same function as `key_hash` (see the note in
+the Abstract).
 
-- `hash([0x00] * 64) = [0x00] * 32`
-- `hash(value) = H(value)`, where `H` is the selected hash function.
-
-The `value` length is 32 or 64. Merkelize each node type as:
-
-- `internal_node_hash = hash(left_hash || right_hash)`
-- `stem_node_hash = hash(stem || 0x00 || hash(left_hash || right_hash))`
-- `leaf_node_hash = hash(value)`
-- `empty_node_hash = [0x00] * 32`
+`encode_bit_prefix` packs a bit string for hashing as a two-byte big-endian
+bit count followed by the bits themselves, most significant bit first,
+zero-padded to a byte boundary:
 
 ```python
-def _hash(self, data):
-    if data in (None, b"\x00" * 64):
-        return b"\x00" * 32
-    assert len(data) == 64 or len(data) == 32, "data must be 32 or 64 bytes"
-    return blake3(data).digest()
-
-def merkelize(self):
-    def _merkelize(node):
-        if node is None:
-            return b"\x00" * 32
-        if isinstance(node, InternalNode):
-            left_hash = _merkelize(node.left)
-            right_hash = _merkelize(node.right)
-            return self._hash(left_hash + right_hash)
-
-        level = [self._hash(x) for x in node.values]
-        while len(level) > 1:
-            new_level = []
-            for i in range(0, len(level), 2):
-                new_level.append(self._hash(level[i] + level[i + 1]))
-            level = new_level
-        return self._hash(node.stem + b"\0" + level[0])
-
-    return _merkelize(self.root)
+def encode_bit_prefix(prefix: list[int]) -> bytes:
+    assert len(prefix) < 2**16, "prefix exceeds encodable bit count"
+    packed = bytearray((len(prefix) + 7) // 8)
+    for i, bit in enumerate(prefix):
+        packed[i // 8] |= bit << (7 - i % 8)
+    return len(prefix).to_bytes(2, "big") + bytes(packed)
 ```
+
+Merkelize each node type as:
+
+- `leaf_hash = H(LEAF_TAG || key || value)`
+- `branch_hash = H(BRANCH_TAG || encode_bit_prefix(prefix) || left_hash || right_hash)`
+- The hash of an empty tree is `[0x00] * 32`
+
+```python
+def merkelize(node) -> bytes:
+    if node is None:
+        return b"\x00" * 32
+    if isinstance(node, LeafNode):
+        return H(bytes([LEAF_TAG]) + node.key + node.value)
+    return H(
+        bytes([BRANCH_TAG])
+        + encode_bit_prefix(node.prefix)
+        + merkelize(node.left)
+        + merkelize(node.right)
+    )
+```
+
+### Maximum key length
+
+`MAX_KEY_LENGTH = 8192` bytes. `encode_bit_prefix` stores a branch's bit
+count in two bytes, so the largest representable prefix is `2**16 - 1 =
+65535` bits. A prefix is a run shared by at least two keys, ending at the
+first bit where they diverge, which is not itself part of the prefix; two
+`L`-byte keys can be forced to share a prefix of up to `8*L - 1` bits
+(agreeing on every bit but the last). Solving `8*L - 1 <= 65535` gives `L <=
+8192`, and the bound is tight: two 8192-byte keys differing only in their
+final bit force a prefix of exactly 65535 bits.
+
+`insert` MUST reject keys longer than `MAX_KEY_LENGTH`. Enforcing this
+unconditionally at insertion, rather than only inside `encode_bit_prefix`,
+keeps the bound a stated property of every key instead of a failure that
+depends on which other keys happen to be present: a key longer than
+`MAX_KEY_LENGTH` is not itself invalid until a second key shares enough of
+its prefix to overflow the count field.
 
 ### Zones
 
-The high 4 bits of every stem are the zone identifier `Z`. The most significant
-bit separates storage from everything else.
+The first byte of every key is the zone identifier `Z`.
 
-| Zone `Z` | Category |
-|---|---|
-| `0x0` | Account headers |
-| `0x1` | Code chunks (content-addressed overflow) |
-| `0x2`–`0x7` | Reserved for future categories (e.g. nullifiers) |
-| `0x8`–`0xF` | Storage |
+| Zone `Z`      | Category                                    |
+| ------------- | -------------------------------------------- |
+| `0x00`        | Account headers                             |
+| `0x01`        | Code chunks (content-addressed overflow)    |
+| `0x02`-`0xFE` | Reserved for future categories              |
+| `0xFF`        | Storage                                     |
 
-New categories MUST be allocated from `0x2`–`0x7`. The storage range MUST NOT be subdivided for other categories, since that would remove address entropy from
-storage keys.
-
-The zones place deterministic boundaries at fixed depths:
-
-| Depth | Boundary                                                      |
-| ----- | ------------------------------------------------------------- |
-| d=1   | Storage (right) vs. non-storage (left)                        |
-| d=4   | Account zone vs. code zone vs. other low zones                |
-| d=61  | Storage per-account bucket (high bit + 60-bit address prefix) |
-| d=248 | Stem level in every zone                                      |
-| d=256 | Leaf level                                                    |
+New categories MUST be allocated from `0x02`-`0xFE` and MUST keep their
+keys mutually prefix-free (see "Tree embedding").
 
 ### Tree embedding
 
-All state is embedded into the single key/value space. Data accessed together is
-co-located in one stem to reduce branch openings. The account header stem holds an
-account's basic data, code hash, first 64 storage slots, and first 128 code chunks.
-Storage slots and code chunks beyond those live in their own zones, grouped 256 to
-a stem.
+All state is embedded into the single key/value space. Data accessed
+together is co-located under one shared key prefix ("stem") to reduce
+branch openings. The account header holds an account's basic data, code
+hash, first 64 storage slots, and first 128 code chunks under keys sharing
+one header stem.
 
-| Parameter             | Value |
-| --------------------- | ----- |
-| BASIC_DATA_LEAF_KEY   | 0     |
-| CODE_HASH_LEAF_KEY    | 1     |
-| HEADER_STORAGE_OFFSET | 64    |
-| CODE_OFFSET           | 128   |
-| STEM_SUBTREE_WIDTH    | 256   |
-| ZONE_BITS             | 4     |
-| ACCOUNT_ZONE          | 0     |
-| CODE_ZONE             | 1     |
+| Parameter              | Value |
+| ----------------------- | ----- |
+| BASIC_DATA_LEAF_KEY     | 0     |
+| CODE_HASH_LEAF_KEY      | 1     |
+| HEADER_STORAGE_OFFSET   | 64    |
+| CODE_OFFSET             | 128   |
+| STEM_SUBTREE_WIDTH      | 256   |
+| ACCOUNT_ZONE            | 0x00  |
+| CODE_ZONE               | 0x01  |
+| STORAGE_ZONE            | 0xFF  |
+| ACCOUNT_KEY_LENGTH      | 34    |
+| CODE_KEY_LENGTH         | 34    |
+| STORAGE_KEY_LENGTH      | 66    |
 
 It is a required invariant that `STEM_SUBTREE_WIDTH > CODE_OFFSET >
-HEADER_STORAGE_OFFSET` and that `HEADER_STORAGE_OFFSET` is greater than the leaf keys.
+HEADER_STORAGE_OFFSET`.
 
-Addresses are passed as `Address32`. Convert a legacy address by prepending 12 zero
-bytes:
+Every key produced by this embedding has a length fixed by its zone:
+`ACCOUNT_KEY_LENGTH`, `CODE_KEY_LENGTH` and `STORAGE_KEY_LENGTH` for the
+account, code and storage zones respectively.
+
+Fixing one length per zone is what keeps keys prefix-free within a zone, since
+a shorter key of the same zone would otherwise be a proper prefix of a longer one.
+Keys of different zones already differ in their first byte. Implementations MUST assert the length of every key they construct.
+
+Addresses are passed as `Address32`. Convert a legacy address by prepending
+12 zero bytes:
 
 ```python
 def address20_to_address32(address: Address) -> Address32:
     return b'\x00' * 12 + address
 ```
 
-Stems in a non-storage zone are a 4-bit zone prefix followed by 244 bits of hash:
+A key is built from a zone byte, a hash-derived tree position, and a
+sub-index byte. The zone byte and the tree position together are a key's
+stem:
 
 ```python
 def key_hash(inp: bytes) -> bytes32:
-    return blake3(inp).digest() 
+    return blake3(inp).digest()
 
-def zone_stem(zone: int, digest: bytes) -> bytes:
-    # 4-bit zone || 244-bit hash = 248-bit (31-byte) stem
-    zone_bits = [(zone >> (ZONE_BITS - 1 - i)) & 1 for i in range(ZONE_BITS)]
-    return _bits_to_bytes(zone_bits + _bytes_to_bits(digest)[:248 - ZONE_BITS])
+def get_tree_key(zone: int, tree_position: bytes, sub_index: int) -> bytes:
+    return bytes([zone]) + tree_position + bytes([sub_index])
 ```
 
 ### Header values
 
-The account header stem is in `ACCOUNT_ZONE` and is keyed by the address alone, so
-each account has exactly one header stem.
+The account header's stem is in `ACCOUNT_ZONE` and is keyed by the
+address alone, so each account has exactly one header stem.
 
 ```python
 def get_tree_key_for_header(address: Address32, sub_index: int) -> bytes:
-    stem = zone_stem(ACCOUNT_ZONE, key_hash(address))
-    return stem + bytes([sub_index])
+    key = get_tree_key(ACCOUNT_ZONE, key_hash(address), sub_index)
+    assert len(key) == ACCOUNT_KEY_LENGTH
+    return key
 
 def get_tree_key_for_basic_data(address: Address32):
     return get_tree_key_for_header(address, BASIC_DATA_LEAF_KEY)
@@ -365,14 +375,19 @@ at `BASIC_DATA_LEAF_KEY`:
 Bytes 1 through 3 are reserved. The 4-byte `code_size` holds values up to `2^32 - 1`
 bytes, far beyond any foreseeable contract size limit. Packing these fields into one
 leaf needs one branch opening instead of three or four, which lowers gas and
-simplifies witness generation. Setting any header field also sets `version` to zero.
-`code_hash` and `code_size` are set on contract or EOA creation.
+simplifies witness generation.
+
+Setting any header field also sets `version` to zero. `code_hash` and
+`code_size` are set on contract or EOA creation; a codeless account's code
+hash leaf holds the Keccak hash of empty bytecode, unaffected by this EIP's
+choice of merkelization hash (see "Backwards Compatibility").
 
 ### Code
 
-Code chunks 0 through 127 live in the account header stem at sub-indices
-`CODE_OFFSET`..`255`. Chunks at index 128 and above live in `CODE_ZONE`,
-content-addressed by `code_hash` so contracts with identical bytecode share leaves.
+Code chunks 0 through 127 live in the account header's stem at
+sub-indices `CODE_OFFSET`..`255`. Chunks at index 128 and above live in
+`CODE_ZONE`, content-addressed by `code_hash` so contracts with identical
+bytecode share leaves.
 
 ```python
 def get_tree_key_for_code_chunk(address: Address32, code_hash: bytes32, chunk_id: int):
@@ -381,8 +396,11 @@ def get_tree_key_for_code_chunk(address: Address32, code_hash: bytes32, chunk_id
     overflow = chunk_id - (STEM_SUBTREE_WIDTH - CODE_OFFSET)
     tree_index = overflow // STEM_SUBTREE_WIDTH
     sub_index  = overflow %  STEM_SUBTREE_WIDTH
-    stem = zone_stem(CODE_ZONE, key_hash(code_hash + tree_index.to_bytes(32, "big")))
-    return stem + bytes([sub_index])
+    key = get_tree_key(
+        CODE_ZONE, key_hash(code_hash + tree_index.to_bytes(32, "big")), sub_index
+    )
+    assert len(key) == CODE_KEY_LENGTH
+    return key
 ```
 
 Chunk `i` stores a 32-byte value where bytes 1..31 are the i'th 31-byte slice of the
@@ -416,81 +434,101 @@ def chunkify_code(code: bytes) -> Sequence[bytes32]:
 
 ### Storage
 
-Storage slots 0 through 63 live in the account header stem at sub-indices
-`HEADER_STORAGE_OFFSET`..`127`. Slots 64 and above live in the storage zone.
+Storage slots 0 through 63 live in the account header's stem at
+sub-indices `HEADER_STORAGE_OFFSET`..`127`. Slots 64 and above live in the
+storage zone.
 
-A storage stem is 248 bits: the high bit is `1` (the storage zone), the next 60
-bits are an address prefix, and the last 187 bits are a suffix bound to both the
-address and the `tree_index`. The address prefix groups one account's storage under
-a common bucket at depth 61. The suffix hashes the address with `tree_index`, so two
-accounts that share a prefix still produce independent stems.
+A storage key's stem begins with the storage zone byte, followed by its
+tree position: two full hash digests.
+
+`key_hash(address)` places all of an account's overflow storage under
+one shared prefix.
+
+An aligned range of `STEM_SUBTREE_WIDTH` slots sharing one `tree_index`
+is a storage group; its slots share a stem and differ only in the
+sub-index byte. `key_hash(address || tree_index)` spreads the account's
+storage groups within that bucket. The second digest is bound to the
+address as well as `tree_index` (see "Security Considerations").
 
 ```python
-STORAGE_ADDR_PREFIX_BITS = 60
-STORAGE_SUFFIX_BITS      = 187
-
-def storage_stem(address: Address32, tree_index: int) -> bytes:
+def storage_tree_position(address: Address32, tree_index: int) -> bytes:
     prefix = key_hash(address)
     suffix = key_hash(address + tree_index.to_bytes(32, "big"))
-    bits = [1]                                              # storage zone high bit
-    bits += _bytes_to_bits(prefix)[:STORAGE_ADDR_PREFIX_BITS]
-    bits += _bytes_to_bits(suffix)[:STORAGE_SUFFIX_BITS]    # 1 + 60 + 187 = 248
-    return _bits_to_bytes(bits)
+    return prefix + suffix
 
 def get_tree_key_for_storage_slot(address: Address32, storage_key: int):
     if storage_key < CODE_OFFSET - HEADER_STORAGE_OFFSET:   # storage_key < 64
         return get_tree_key_for_header(address, HEADER_STORAGE_OFFSET + storage_key)
     tree_index = storage_key // STEM_SUBTREE_WIDTH
     sub_index  = storage_key %  STEM_SUBTREE_WIDTH
-    return storage_stem(address, tree_index) + bytes([sub_index])
+    key = get_tree_key(
+        STORAGE_ZONE, storage_tree_position(address, tree_index), sub_index
+    )
+    assert len(key) == STORAGE_KEY_LENGTH
+    return key
 ```
 
-Slots within one `STEM_SUBTREE_WIDTH` range share a stem, except for slots 0..63,
-which are in the header. Adjacent slots, common in mappings and arrays, group
-together.
+Group 0 is the exception: slots 0..63 live in the header, so its
+storage-zone leaves are slots 64..255 only. Adjacent slots, common in
+mappings and arrays, share a group.
+
+### Zero values and deletion
+
+Writing 32 zero bytes stores that value like any other: the leaf stays
+present, and a zero-valued leaf is distinct from an absent key, committing
+to a different root. EVM execution never removes entries from the tree, so
+insertion and in-place update are the only mutations, and implementations
+never need delete logic that restores the canonical form by merging a lone
+surviving child back into its parent. Removing entries is reserved for a
+future state-expiry mechanism (see "State expiry").
 
 ### Fork
 
-Described in [EIP-7612](./eip-7612.md).
+Described in [EIP-7612](./eip-7612.md): the overlay-tree transition
+applies with this EIP's tree in place of the Verkle tree.
 
 ### Access events
 
 Partitioned Binary Tree (PBT) adopts [EIP-4762](./eip-4762.md)'s access-event framework with two required modifications:
 
-1. Content-addressed code. [EIP-4762](./eip-4762.md) keys code-chunk access events per account at `(CODE_OFFSET + i) // STEM_SUBTREE_WIDTH`. PBT moves chunks ≥ 128 to a leaf shared by all contracts with the same `code_hash`. Access events for overflow code MUST be keyed by the `(zone, stem, sub-index)` tree-key, not by `(address, chunk)`, so that a shared chunk is charged once per block regardless of which contract triggers the access and so the witness contains one copy. Header chunks (0–127) remain per-account.
+1. Content-addressed code. [EIP-4762](./eip-4762.md) keys code-chunk access events per account at `(CODE_OFFSET + i) // STEM_SUBTREE_WIDTH`. Because overflow chunks are shared between contracts (see "Code"), their access events MUST be keyed by the `(zone, tree_position, sub-index)` tree-key, not by `(address, chunk)`, so a shared chunk is charged once per block regardless of which contract triggers the access and the witness contains one copy. Header chunks (0..127) remain per-account.
 
-2. Branch-cost calibration. `WITNESS_BRANCH_COST (1900)` is calibrated in [EIP-4762](./eip-4762.md) to ≈13.2 gas/byte assuming a ~144-byte average branch for the EIP-7864 depth profile. PBT's branches are deeper, so we need to adjust the values.
+2. Branch-cost calibration. [EIP-4762](./eip-4762.md) prices a witness branch at `WITNESS_BRANCH_COST = 1900`, calibrated for the shallow branches of the Verkle tree it targets. PBT's branches are deeper (see "Arity-2"), so the witness gas constants MUST be recalibrated for PBT's depth profile. The recalibrated values are not yet fixed in this draft.
 
 ## Rationale
 
 This EIP defines a binary tree that starts empty. Only new state changes are stored
 in it. The MPT continues to exist but is frozen, setting up a later hard fork that
-migrates MPT data into the binary tree ([EIP-7748](./eip-7748.md)).
+migrates MPT data into the binary tree ([EIP-7748](./eip-7748.md), adapted from the Verkle tree to this one).
 
 ### Single tree with zones
 
 A single key/value tree is simpler to work with than a tree of tries: database
 access, caching, syncing, and proof code all operate on one abstraction, and
-witness gas rules are clearer. State spreads uniformly, so one contract's millions
-of slots are not concentrated in one place, which helps state sync and blunts
-unbalanced-tree-filling attacks.
+witness gas rules are clearer. Placement is hash-derived at every level: stems
+scatter uniformly within their zone, and an account's storage groups scatter
+uniformly within its bucket, so the tree stays balanced up to the deliberate
+shared prefixes, which compression folds away (see "Tree depth").
 
-Zones add structure without giving up that uniformity. Each zone is a self-contained
-subtree at a known depth, so a node can sync, prove, or expire one category without
-touching the rest. Because no leaf stores a `storage_root`, an account's nonce in
-the account zone and one of its slots in the storage zone are independent writes.
-The root recomputes in one bottom-up pass and the two branches meet near the root.
-This admits parallelism across zones, across accounts within a zone, and across
-stems within an account.
+Zones add structure without giving up that balance. Each zone is a
+self-contained key-space region, so a node can sync, prove, or expire one
+category without touching the rest. Because no leaf stores a `storage_root`,
+an account's nonce in the account zone and one of its slots in the storage
+zone are independent writes. The root recomputes in one bottom-up pass and
+the two branches meet near the root. This admits parallelism across zones,
+across accounts within a zone, and across stems within an account.
 
 ### Storage layout
 
-Storage takes the upper half of the tree because it is the largest category and the
-most frequently proven, so it should branch earliest and shallowest. The 60-bit
-address prefix gives each account its own storage bucket at depth 61, which is the
-unit later expiry and partial-statefulness schemes can prune or sync. The 187-bit
-suffix is bound to the address and `tree_index` so a prefix collision cannot
-correlate two accounts' storage layouts.
+Storage is the largest state category by a wide margin and the most
+frequently proven, so its bucket assignment gets the strongest available
+guarantee: the full `key_hash(address)` digest gives each account its own
+storage bucket, with negligible chance of two accounts sharing one; the
+bucket is the unit later expiry and partial-statefulness schemes can
+prune or sync.
+Binding the group-spreading digest to the address as well as `tree_index`
+restricts the grinding analyzed in "Security Considerations" to the
+attacker's own bucket.
 
 ### Content-addressed code
 
@@ -502,10 +540,9 @@ the account and need no reference counting. Only chunks beyond ~4 KB are shared.
 
 ### SNARK friendliness and post-quantum security
 
-The design avoids complex branching: no extension nodes mid-branch, no RLP. This
-keeps circuit implementations simple and lowers proving overhead. The dominant
-factor is the merkelization hash, which should be efficient in and out of circuit.
-The choice is open, with candidates:
+The design avoids RLP and the MPT's variable-arity branching. The dominant
+factor, though, is the merkelization hash, which should be efficient in and
+out of circuit. The choice is open, with candidates:
 
 1. **BLAKE3**: good native performance, reasonable in-circuit, well-studied,
    currently used in the reference implementation.
@@ -514,10 +551,10 @@ The choice is open, with candidates:
    the Ethereum Foundation (EF) cryptography initiative, needs extra specification for field encoding.
 
 Because the tree depends only on a hash function and not on elliptic curves, it
-stays secure under the post-quantum assumptions that NIST's 2030 guidance and
-Verkle's curve-based stack do not. Progress in proving systems suggests pre-state
-and post-state proofs can be generated fast enough, which was Verkle's main
-advantage.
+remains secure against quantum adversaries; Verkle's curve-based stack does not,
+and NIST guidance calls for retiring elliptic-curve cryptography by 2030.
+Progress in proving systems suggests pre-state and post-state proofs can be
+generated fast enough, matching Verkle's main advantage.
 
 ### Arity-2
 
@@ -526,61 +563,76 @@ node, the average branch is roughly `32 * (k-1) * log(N) / log(k)` bytes, minimi
 at `k = 2`. For `N = 2**24`:
 
 | `k` | Branch length (chunks) | Branch length (bytes) |
-| --- | ---------------------- | --------------------- |
-| 2   | 24                     | 768                   |
-| 4   | 36                     | 1152                  |
-| 8   | 56                     | 1792                  |
-| 16  | 90                     | 2880                  |
+| --- | ---------------------- | ---------------------- |
+| 2   | 24                     | 768                    |
+| 4   | 36                     | 1152                   |
+| 8   | 56                     | 1792                   |
+| 16  | 90                     | 2880                   |
 
 ### Tree depth
 
-The tree design attempts to be as simple as possible considering both out-of-circuit and circuit implementations, while satisfying our throughput constraints on proving hashes.
+The proposed design avoids a full-depth Sparse Merkle Tree (SMT), which
+helps reduce the hashing load in proving systems, currently a throughput
+bottleneck on commodity hardware.
 
-The proposed design avoids a full 248-bit depth as it would happen in a Sparse Merkle Tree (SMT). This approach helps reduce the hashing load in proving systems, which is currently a throughput bottleneck on commodity hardware.
-
-Moreover, we could push this further trying to introduce extension nodes in the middle of paths as done in an MPT, but this also adds complexity that might not be worth it considering the tree should be quite balanced.
+A `BranchNode`'s prefix exists because storage buckets manufacture long
+shared runs: every one of an account's overflow storage groups shares the
+same `key_hash(address)`, up to 256 bits. Without compression this would
+produce long chains of branch nodes with a single occupied child. Folding
+the shared run into the branch's prefix (see "Tree structure") collapses
+each such chain to one node, which is also what bounds the proof-size cost
+of a grinded set of groups in "Security Considerations".
 
 ### State expiry
 
-Per-account and per-bucket expiry is a natural operation on the zone topology. The
-storage bucket at depth 61 roots one account's storage in the common case. Record
-its hash and prune below it. The account header stem expires the account's core
-data, hot storage, and initial code in one step. Content-addressed code needs
-reference counting or deferral to a state sweep, since its leaves may be shared.
-Resurrection re-attaches a subtree consistent with the recorded commitment. The
-mechanism itself is left to a separate EIP.
+Per-account and per-bucket expiry is a natural operation on the zone
+topology. The storage bucket keyed by `key_hash(address)` roots one
+account's storage in the common case. Record its hash and prune below it.
+The account header's stem expires the account's core data, hot
+storage, and initial code in one step. Content-addressed code needs
+reference counting or deferral to a state sweep, since its leaves may be
+shared. Resurrection re-attaches a subtree consistent with the recorded
+commitment. The mechanism itself is left to a separate EIP.
 
 ## Backwards Compatibility
 
 The main breaking changes are:
 
-1. Gas costs for code chunk access can affect application economics. This can be
-   mitigated by raising the gas limit alongside this EIP.
-2. The tree structure change makes in-EVM proofs of historical state stop working.
+1. Gas costs for code chunk access can affect application economics. Raising the
+   gas limit alongside this EIP restores block capacity, but relative prices are
+   set by the gas schedule so transactions dominated by cold code
+   reads pay more by design, as we need to also price in the witness data they force into every proof.
+2. The tree structure change breaks in-EVM verification of MPT state proofs.
+   Post-fork state roots commit to the new tree, so contracts that verify
+   proofs against them must adopt the new tree's proof format.
 
 The change is invisible to the EVM. Contracts address storage by 256-bit slot
 numbers through `SLOAD` and `SSTORE` and never see tree keys. Key derivation runs
 inside the client, below the EVM, exactly as the MPT already hashes slot keys and
 addresses. No contract, Solidity, or Yul code changes.
 
+`EXTCODEHASH` is unaffected since the `code_hash` leaf stores the Keccak hash of the
+account's code regardless of the tree's own merkelization hash.
+
 ## Test Cases
 
-The hash function is not fixed, so digests cannot be pinned. The deterministic parts
-of the derivation are given as vectors. `H(...)[:n]` is the high `n` bits.
+The hash function is not fixed, so digests cannot be pinned. The
+deterministic parts of the derivation are given as vectors. `H(x)` is the
+full 32-byte digest of `x`.
 
 Account header, `BASIC_DATA` of address `A`:
 
 ```
-stem    = 0x0 || H(A)[:244]      (4-bit zone || 244-bit hash)
-sub_idx = 0x00
-widths  = 4 + 244 + 8 = 256
+key    = 0x00 || H(A) || 0x00
+length = 1 + 32 + 1 = 34 bytes
 ```
 
 Storage slot `storage_key = 5` of address `A` (in the header, since 5 < 64):
 
 ```
 sub_idx = HEADER_STORAGE_OFFSET + 5 = 69 (0x45)
-key     = 0x0 || H(A)[:244] || 0x45
+key     = 0x00 || H(A) || 0x45
+length  = 34 bytes
 ```
 
 Storage slot `storage_key = 1000` (in the storage zone, since 1000 >= 64):
@@ -588,15 +640,16 @@ Storage slot `storage_key = 1000` (in the storage zone, since 1000 >= 64):
 ```
 tree_index = 1000 // 256 = 3
 sub_idx    = 1000 %  256 = 232 (0xE8)
-stem       = 1 || H(A)[:60] || H(A || 3)[:187]      (high bit = 1)
-widths     = 1 + 60 + 187 + 8 = 256
+key        = 0xFF || H(A) || H(A || 3) || 0xE8
+length     = 1 + 32 + 32 + 1 = 66 bytes
 ```
 
 Code chunk `chunk_id = 5` (in the header, since 5 < 128):
 
 ```
 sub_idx = CODE_OFFSET + 5 = 133 (0x85)
-key     = 0x0 || H(A)[:244] || 0x85
+key     = 0x00 || H(A) || 0x85
+length  = 34 bytes
 ```
 
 Code chunk `chunk_id = 300` of bytecode with hash `C` (overflow, since 300 >= 128):
@@ -605,40 +658,57 @@ Code chunk `chunk_id = 300` of bytecode with hash `C` (overflow, since 300 >= 12
 overflow   = 300 - 128 = 172
 tree_index = 172 // 256 = 0
 sub_idx    = 172 %  256 = 172 (0xAC)
-stem       = 0x1 || H(C || 0)[:244]
-widths     = 4 + 244 + 8 = 256
+key        = 0x01 || H(C || 0) || 0xAC
+length     = 34 bytes
 ```
+
+`A || 3` and `C || 0` denote `A` (respectively `C`) concatenated with the
+32-byte big-endian encoding of the integer.
 
 ## Security Considerations
 
-A collision means two distinct items derive the same stem.
+A collision means two distinct items derive the same key.
 
-| Field | Bits | Birthday bound | Assessment |
-|---|---|---|---|
-| Account stem (`0x0`) | 244 | 2^122 | Far beyond reach |
-| Code stem (`0x1`) | 244 | 2^122 | Far beyond reach |
-| Storage address prefix | 60 | ~43 colliding pairs at 10^10 accounts | Benign, see below |
-| Storage stem suffix | 187 | 2^93.5 | Future-proof |
+| Field                                       | Bits | Birthday bound | Assessment       |
+| -------------------------------------------- | ---- | --------------- | ----------------- |
+| Account stem (`0x00`)                       | 256  | 2^128           | Far beyond reach |
+| Code stem (`0x01`)                          | 256  | 2^128           | Far beyond reach |
+| Storage bucket (`key_hash(address)`)        | 256  | 2^128           | Far beyond reach |
+| Storage suffix (`key_hash(address\|\|tree_index)`) | 256  | 2^128    | Far beyond reach |
 
-**Storage prefix collisions are not consensus-fatal.** At 10 billion accounts, about
-43 address pairs share a 60-bit prefix and so share a bucket. Their leaves interleave
-below depth 61 but stay distinct, because the suffix hashes the address with
-`tree_index`. An attacker who finds a prefix collision cannot overwrite
-the other account's storage. The only effect is reduced parallelism at that bucket.
+Every hash-derived component of a key is a 256-bit
+digest, so collision resistance is the hash function's full birthday bound
+throughout.
 
-**Content-addressed code.** Two contracts with identical bytecode share code-zone
-leaves by design, which is deduplication, not a collision. Two distinct bytecodes
-mapping to the same stem would need a 244-bit collision on `H(code_hash ||
-tree_index)`, which is infeasible.
+**Content-addressed code.** Two contracts with identical bytecode share
+code-zone leaves by design, which is deduplication, not a collision. Two
+distinct bytecodes mapping to the same stem would need a 256-bit
+collision on `key_hash(code_hash || tree_index)`, which is infeasible.
 
-**Sub-index.** The sub-index is `storage_key % 256` or the analogous code arithmetic,
-a direct mapping rather than a hash. Two distinct keys share a sub-index only if they
-also share a `tree_index`, in which case they are the same item, so no collision is
-possible between distinct items.
+**Sub-index.** The sub-index is `storage_key % 256` or the analogous code
+arithmetic, a direct mapping rather than a hash. Two distinct keys share a
+sub-index only if they also share a stem, in which case they are
+the same item, so no collision is possible between distinct items.
 
-The hash function selection is the dominant security parameter and remains open. The
-collision bounds above assume a hash with uniform 256-bit output truncated to the
-stated widths.
+**Grinding.** `key_hash(address || tree_index)` places a storage group in
+its account's bucket, and `tree_index` comes from the slot number. An
+attacker chooses slots freely: directly in their own contract, or through
+mapping keys in any contract that hashes them into slots.
+
+Grinding for digests that share `k` leading bits would deepen the tree. Without
+compression that buys a `k`-node chain for about `2^(k/2)` work.
+
+Compression folds the run into one `BranchNode` prefix of about `k/8`
+bytes (see "Tree depth"), and `d` real extra nodes cost about `2^d` work.
+The address in the digest stops cross-contract reuse, so a slot set grinded for one
+contract is random in every other.
+
+**Preimage.** Every node's hash preimage begins with a one-byte tag
+(`LEAF_TAG` or `BRANCH_TAG`) distinguishing the two node types, and a
+`BranchNode`'s prefix carries an explicit bit count.
+This makes the mapping from logical node to preimage injective; no leaf and branch
+preimage can coincide, and no two prefixes of different bit length pack to
+the same bytes.
 
 ## Copyright
 

--- a/EIPS/eip-8297.md
+++ b/EIPS/eip-8297.md
@@ -261,14 +261,16 @@ def merkelize(node) -> bytes:
 
 ### Maximum key length
 
-`MAX_KEY_LENGTH = 8192` bytes. `encode_bit_prefix` stores a branch's bit
-count in two bytes, so the largest representable prefix is `2**16 - 1 =
-65535` bits. A prefix is a run shared by at least two keys, ending at the
-first bit where they diverge, which is not itself part of the prefix; two
-`L`-byte keys can be forced to share a prefix of up to `8*L - 1` bits
-(agreeing on every bit but the last). Solving `8*L - 1 <= 65535` gives `L <=
-8192`, and the bound is tight: two 8192-byte keys differing only in their
-final bit force a prefix of exactly 65535 bits.
+`MAX_KEY_LENGTH = 8192` bytes. The bound comes from the branch prefix encoding:
+
+- `encode_bit_prefix` stores a branch's bit count in two bytes, so the
+  largest representable prefix is `2**16 - 1 = 65535` bits.
+- A branch's prefix is the run of bits its keys agree on, ending just
+  before the first bit where they diverge.
+- Two distinct keys of `L` bytes (`8*L` bits) must differ in at least one
+  bit, so the longest run they can share is `8*L - 1` bits: agreement on
+  everything except the final bit.
+- To encode this, we require `8*L - 1 <= 65535`, giving `L <= 8192`.
 
 `insert` MUST reject keys longer than `MAX_KEY_LENGTH`. Enforcing this
 unconditionally at insertion, rather than only inside `encode_bit_prefix`,
@@ -601,7 +603,7 @@ The main breaking changes are:
 1. Gas costs for code chunk access can affect application economics. Raising the
    gas limit alongside this EIP restores block capacity, but relative prices are
    set by the gas schedule so transactions dominated by cold code
-   reads pay more by design, as we need to also price in the witness data they force into every proof.
+   reads pay more by design, as the schedule must also price the witness data they force into every proof.
 2. The tree structure change breaks in-EVM verification of MPT state proofs.
    Post-fork state roots commit to the new tree, so contracts that verify
    proofs against them must adopt the new tree's proof format.

--- a/EIPS/eip-8297.md
+++ b/EIPS/eip-8297.md
@@ -669,21 +669,21 @@ length     = 34 bytes
 
 A collision means two distinct items derive the same key.
 
-| Field                                       | Bits | Birthday bound | Assessment       |
-| -------------------------------------------- | ---- | --------------- | ----------------- |
-| Account stem (`0x00`)                       | 256  | 2^128           | Far beyond reach |
-| Code stem (`0x01`)                          | 256  | 2^128           | Far beyond reach |
-| Storage bucket (`key_hash(address)`)        | 256  | 2^128           | Far beyond reach |
-| Storage suffix (`key_hash(address\|\|tree_index)`) | 256  | 2^128    | Far beyond reach |
+Keys contain three hash-derived components:
 
-Every hash-derived component of a key is a 256-bit
-digest, so collision resistance is the hash function's full birthday bound
-throughout.
+- `key_hash(address)`: both the account stem and the storage bucket.
+- `key_hash(address || tree_index)`: the storage suffix.
+- `key_hash(code_hash || tree_index)`: the code stem.
+
+Each is a full 256-bit digest, so any collision costs about `2^128`
+birthday work, far beyond reach. Keys of different zones differ in their
+first byte and cannot collide at all.
 
 **Content-addressed code.** Two contracts with identical bytecode share
 code-zone leaves by design, which is deduplication, not a collision. Two
 distinct bytecodes mapping to the same stem would need a 256-bit
-collision on `key_hash(code_hash || tree_index)`, which is infeasible.
+collision, on Keccak for `code_hash` or on `key_hash(code_hash ||
+tree_index)`, either of which is infeasible.
 
 **Sub-index.** The sub-index is `storage_key % 256` or the analogous code
 arithmetic, a direct mapping rather than a hash. Two distinct keys share a


### PR DESCRIPTION
- Used variable length keys instead of sticking to 32 byte keys
- Added path compression (extension nodes) but do not add a separate extension node object
- Removed concept of "fix 256 values for a stem" in the trie
- Leaf nodes contain the full key and value, so they are position independent. (This is similar to what we had with the fixed group of 256 values)
- Explicitly note that code_size takes up 4 bytes 
- Add a note on the max key length for the trie, due to the encoding being used for branch nodes prefixes
- Add a note, re prefix free keys. Before keys were exactly the same size, even across zones so this was implicit. Now we explicitly state that keys within a zone should have the same length. 


**ATTENTION: ERC-RELATED PULL REQUESTS NOW OCCUR IN [ETHEREUM/ERCS](https://github.com/ethereum/ercs)**

--

When opening a pull request to submit a new EIP, please use the suggested template: https://github.com/ethereum/EIPs/blob/master/eip-template.md

We have a GitHub bot that automatically merges some PRs. It will merge yours immediately if certain criteria are met:

 - The PR edits only existing draft PRs.
 - The build passes.
 - Your GitHub username or email address is listed in the 'author' header of all affected PRs, inside <triangular brackets>.
 - If matching on email address, the email address is the one publicly listed on your GitHub profile.
