### PR TITLE
Update EIP-8141: pin the P256 signature canonicality (low-s)

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -258,6 +258,7 @@ def validate_signature(sig, tx_sender, sig_hash) -> bool:
         qx = sig.signature[64:96]
         qy = sig.signature[96:128]
         # r and s must be canonical, with low-s, so each signature has one encoding.
+        # P256VERIFY itself accepts high-s signatures, so signers that produce a high-s value must normalize it to SECP256R1N - s before use.
         if not (0 < r < SECP256R1N) or not (0 < s <= SECP256R1N // 2):
             return False
         if resolved_signer != keccak256(qx + qy)[12:]:

--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -41,6 +41,7 @@ Ultimately, frame transactions realize the original vision of account abstractio
 | `EXPIRY_DATA_LENGTH`       | `8`               |
 | `MAX_FRAMES`               | `64`              |
 | `SECP256K1N`               | `0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141` |
+| `SECP256R1N`               | `0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551` |
 
 ### Frame Transaction
 
@@ -252,10 +253,13 @@ def validate_signature(sig, tx_sender, sig_hash) -> bool:
     elif sig.scheme == P256:
         if len(sig.signature) != 128:
             return False
-        r  = sig.signature[0:32]
-        s  = sig.signature[32:64]
+        r  = int.from_bytes(sig.signature[0:32], "big")
+        s  = int.from_bytes(sig.signature[32:64], "big")
         qx = sig.signature[64:96]
         qy = sig.signature[96:128]
+        # r and s must be canonical, with low-s, so each signature has one encoding.
+        if not (0 < r < SECP256R1N) or not (0 < s <= SECP256R1N // 2):
+            return False
         if resolved_signer != keccak256(qx + qy)[12:]:
             return False
         return P256VERIFY(msg, r, s, qx, qy)


### PR DESCRIPTION
`validate_signature` pins the SECP256K1 path to a 0/1 recovery id and EIP-2 low-s (#11937) so each signature has exactly one valid encoding. The P256 path has no equivalent rule, and the P256VERIFY precompile ([EIP-7951](./eip-7951.md)) accepts both `s` and `n − s`.

A signature entry's raw bytes are part of the transaction's identity, for canonical-hash entries they are elided from `compute_sig_hash` but still hash into the transaction hash, and for explicit-digest entries they are committed by `compute_sig_hash` itself. So a P256 entry admits two encodings that verify identically: two distinct transaction hashes, same effect, the same malleability #11937 removed for SECP256K1.

This adds `SECP256R1N` and requires `0 < s ≤ n/2` (and `r` in range), making each P256 frame signature single-encoded. High-s outputs from hardware signers can be normalized by tooling before inclusion, since `n − s` is computable from the signature alone.