### PR TITLE
Update EIP-8141: Specify blob support for frame transactions

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -42,6 +42,7 @@ Ultimately, frame transactions realize the original vision of account abstractio
 | `MAX_FRAMES`               | `64`              |
 | `SECP256K1N`               | `0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141` |
 | `SECP256R1N`               | `0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551` |
+| `VERSIONED_HASH_VERSION_KZG` | `Bytes1(0x01)` |
 
 ### Frame Transaction
 
@@ -125,9 +126,10 @@ assert tx.nonce < 2**64
 assert len(tx.frames) > 0 and len(tx.frames) <= MAX_FRAMES
 assert len(tx.sender) == 20
 
-# Blob-gas accounting for frame transactions is not yet specified.
-assert len(tx.blob_versioned_hashes) == 0
-assert tx.max_fee_per_blob_gas == 0
+for h in tx.blob_versioned_hashes:
+    assert len(h) == 32 and h[0] == VERSIONED_HASH_VERSION_KZG
+if len(tx.blob_versioned_hashes) == 0:
+    assert tx.max_fee_per_blob_gas == 0
 
 for sig in tx.signatures:
     if sig.scheme in [SECP256K1, P256]:
@@ -462,6 +464,14 @@ blob_fees = len(blob_versioned_hashes) * GAS_PER_BLOB * blob_base_fee
 
 The `effective_gas_price` is calculated per [EIP-1559](./eip-1559.md) and `blob_fees` is calculated as per [EIP-4844](./eip-4844.md).
 
+When `blob_versioned_hashes` is non-empty, the transaction is a blob-carrying transaction and follows [EIP-4844](./eip-4844.md), with the payer in the role of the blob-fee payer:
+
+- The transaction is only valid for inclusion in a block if `tx.max_fee_per_blob_gas >= blob_base_fee` of that block.
+- It contributes `len(blob_versioned_hashes) * GAS_PER_BLOB` to the block's `blob_gas_used` and counts against the blob limits of the active fork. The per-transaction blob limit of [EIP-7594](./eip-7594.md) applies unchanged.
+- `blob_fees` are charged to the payer as part of `tx_fee` and burned. They are not refunded regardless of frame outcomes.
+- Unlike EIP-4844 transactions, a frame transaction is not required to carry blobs.
+- The `BLOBHASH` instruction returns `tx.blob_versioned_hashes[index]` in every frame, per EIP-4844.
+
 Any `frame.value` transferred by `SENDER` frames is separate from `tx_fee` and follows ordinary `CALL` value-transfer semantics. The gas cost of sending `frame.value` is the same as for any `CALL` instruction.
 
 Each frame has its own `gas_limit` allocation. Unused gas from a frame is **not** available to subsequent frames. A rolling total `tx_unused_gas` is tracked throughout the transaction.
@@ -555,7 +565,7 @@ This instruction gives access to transaction-scoped information. The gas cost of
 | 0x03    | `max_priority_fee_per_gas`                                                  |
 | 0x04    | `max_fee_per_gas`                                                           |
 | 0x05    | `max_fee_per_blob_gas`                                                      |
-| 0x06    | max cost (basefee=max, all gas used, includes blob cost, intrinsic cost, and signature verification cost) |
+| 0x06    | max cost (basefee=max, all gas used, includes blob cost at `max_fee_per_blob_gas`, intrinsic cost, and signature verification cost) |
 | 0x07    | `len(blob_versioned_hashes)`                                                |
 | 0x08    | `compute_sig_hash(tx)`                                                      |
 | 0x09    | `len(frames)`                                                               |
@@ -896,6 +906,18 @@ In the `Receipts` message of the protocol version carrying this fork, a frame tr
 receipt = [tx-type, cumulative-gas, payer, [[status, gas-used, logs], ...]]
 ```
 
+A frame transaction with non-empty `blob_versioned_hashes` is propagated with its blob sidecar exactly as an [EIP-4844](./eip-4844.md) blob transaction. During transaction gossip responses (`PooledTransactions`), its [EIP-2718](./eip-2718.md) `TransactionPayload` is wrapped per [EIP-7594](./eip-7594.md):
+
+```
+rlp([tx_payload_body, wrapper_version, blobs, commitments, cell_proofs])
+```
+
+The wrapper is validated with the same rules as EIP-7594: matching counts, `commitments` corresponding to `blob_versioned_hashes` via `kzg_to_versioned_hash`, and cell proof verification. Like blob transactions, blob-carrying frame transactions are not broadcast in full `Transactions` messages; they are announced via `NewPooledTransactionHashes` and requested on demand.
+
+For body retrieval responses (`BlockBodies`), the plain `TransactionPayload` is used, as for blob transactions.
+
+A frame transaction with empty `blob_versioned_hashes` uses the plain `TransactionPayload` with no wrapper.
+
 ## Rationale
 
 ### Canonical signature hash
@@ -1117,6 +1139,10 @@ Notes: Sponsor can read info from other fields. ERC-20 transfer call is 68 bytes
 
 There is some inefficiency in the sponsor case, because the same sponsor address must appear in three places (sponsor validation, send to sponsor inside ERC-20 calldata, post op frame), and the ABI is inefficient (~12 + 24 bytes wasted on zeroes). This is difficult to mitigate in a "clean" way, because one of the duplicates is inside the ERC-20 call, "opaque" to the protocol. However, it is much less inefficient than ERC-4337, because not all of the data takes the hit of the 32-byte-per-field ABI overhead.
 
+
+### Blob support
+
+Blobs are optional for frame transactions because `FRAME_TX_TYPE` is a general-purpose transaction type, unlike [EIP-4844](./eip-4844.md) transactions which exist only to carry blobs. Sponsorship composes with blobs: the payer covers `blob_fees`, so data posting can be gas-sponsored, which a blob transaction cannot express. The networking wrapper is reused from [EIP-7594](./eip-7594.md) unchanged so that existing blob pool handling and future data availability sampling changes apply to frame transactions uniformly.
 
 ## Backwards Compatibility
 

--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -126,6 +126,7 @@ assert len(tx.sender) == 20
 
 # Blob-gas accounting for frame transactions is not yet specified.
 assert len(tx.blob_versioned_hashes) == 0
+assert tx.max_fee_per_blob_gas == 0
 
 for sig in tx.signatures:
     if sig.scheme in [SECP256K1, P256]:

--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2026-01-29
-requires: 1559, 2718, 3607, 4844, 7623, 7702
+requires: 1559, 2718, 3607, 4844, 7594, 7623, 7702
 ---
 
 ## Abstract

--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -124,6 +124,9 @@ assert tx.nonce < 2**64
 assert len(tx.frames) > 0 and len(tx.frames) <= MAX_FRAMES
 assert len(tx.sender) == 20
 
+# Blob-gas accounting for frame transactions is not yet specified.
+assert len(tx.blob_versioned_hashes) == 0
+
 for sig in tx.signatures:
     if sig.scheme in [SECP256K1, P256]:
         assert len(sig.signer) == 0 or len(sig.signer) == 20


### PR DESCRIPTION
Follow-up to the discussion above -- instead of forbidding blobs, this specifies them. The fee side already existed (`blob_fees` in `tx_fee`, `TXPARAM` `0x05`/`0x07`); what was missing was inclusion validity, block-level blob gas accounting, and the networking form. Nearly all of it is EIP-4844/EIP-7594 by reference, with the payer in the role of the blob-fee payer; the two exceptions are flagged below.

Changes:

- **Constraints**: versioned hashes must be 32 bytes with the KZG version byte (EIP-4844); `max_fee_per_blob_gas` must be `0` when no blobs are carried (enforces the existing field definition).
- **Fees/accounting**: inclusion requires `max_fee_per_blob_gas >= blob_base_fee`; blob gas counts toward the block's `blob_gas_used` and the fork's blob limits, including EIP-7594's per-transaction limit; blob fees are charged to the payer and burned, never refunded, regardless of frame outcomes (blobs don't interact with frame reverts or batch unrolls); `BLOBHASH` returns the transaction's hashes in every frame.
- **Networking**: blob-carrying frame transactions use the EIP-7594 pooled wrapper unchanged and are announced rather than broadcast, like blob transactions. Blobless frame transactions stay unwrapped.
- **TXPARAM 0x06**: pins the blob leg of max cost at `max_fee_per_blob_gas` -- the price basis wasn't stated, and max cost is consensus-visible.
- Short Rationale note: optional blobs, sponsored data posting, wrapper reuse.

Two deliberate choices worth flagging:

- Unlike EIP-4844, blobs are optional -- this is the general-purpose transaction type, so no >=1-blob rule. Stated explicitly in the spec so it reads as intent, not omission.
- The wrapper applies only when blobs are present. Always-wrapping would change the encoding of the common blobless case for nothing, and the two forms are structurally unambiguous to a decoder.

Out of scope here, same repo split as EIP-4844 itself: the engine API change (extracting `blobVersionedHashes` from type-`0x06` transactions in `newPayload`) and the RPC receipt fields live in execution-apis.

For the initial devnets nothing changes: no blob-carrying frame transactions are sent, and implementations can land the validity rules before the pool wrapper.
