### PR TITLE
Update EIP-8141: statically exclude VERIFY frames from atomic batches

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -90,7 +90,7 @@ The `flags` field configures additional execution constraints. Bit positions are
 | Flag bits | Meaning                      | Valid with  |
 |-----------|------------------------------| ----------- |
 | 0-1       | Approval scope               | Any mode    |
-| 2         | Atomic batch                 | Any mode    |
+| 2         | Atomic batch                 | `DEFAULT`, `SENDER` |
 | 3..       | reserved                     | No mode     |
 
 > The `Valid with` column indicates the mode under which the flag is valid. If a flag is not valid under the current mode, the transaction is invalid.
@@ -154,9 +154,12 @@ for i, frame in enumerate(tx.frames):
     if frame.flags & APPROVE_EXECUTION:
         assert frame.target is None or frame.target == tx.sender
 
-    # Atomic batch flag requires a subsequent frame to batch with.
+    # Atomic batch flag is only valid on non-VERIFY frames and requires
+    # a subsequent non-VERIFY frame to batch with.
     if frame.flags & ATOMIC_BATCH_FLAG:
-        assert i + 1 < len(tx.frames)    # must not be last frame
+        assert frame.mode != VERIFY
+        assert i + 1 < len(tx.frames)            # must not be last frame
+        assert tx.frames[i + 1].mode != VERIFY   # batches never contain VERIFY frames
 ```
 
 #### Transaction Signatures
@@ -371,7 +374,7 @@ Then for each frame:
         - Only `APPROVE` can modify the state or transaction context in `VERIFY`.
     - If the frame reverts, the transaction is invalid. This would unroll any effects of `APPROVE`.
 1. If a frame is part of an atomic batch and it fails, unroll the associated atomic batch.
-    - An **atomic batch** is a maximal contiguous sequence of frames `[i, j]` where `j > i`, non-`VERIFY` frames `i` through `j - 1` have `ATOMIC_BATCH_FLAG` set, and frame `j` does not have `ATOMIC_BATCH_FLAG` set.
+    - An **atomic batch** is a maximal contiguous sequence of frames `[i, j]` where `j > i`, frames `i` through `j - 1` have `ATOMIC_BATCH_FLAG` set, and frame `j` does not have `ATOMIC_BATCH_FLAG` set.
     - When a frame in the batch fails, the state must be rolled back to the condition it was immediately before the atomic batch began. All remaining frames in the atomic batch are skipped.
     - Since skipped frames are not executed, the gas value allotted to them is refunded at the end of the transaction.
     - If the frame does not have an associated atomic batch, further special handling is not needed, simple revert the individual frame.


### PR DESCRIPTION
Realized that the wording for the ban on VERIFY in batches was still kind of unclear. This should fix it.