### PR TITLE
Update EIP-8038: document parameter provenance and drop EIP-7904 from requires

### DIFF
--- a/EIPS/eip-8038.md
+++ b/EIPS/eip-8038.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2025-10-03
-requires: 7904, 8037
+requires: 8037
 ---
 
 ## Abstract
@@ -29,15 +29,15 @@ Upon activation of this EIP, the following parameters of the gas model are intro
 
 | **Parameter** | **Description** | **Current value** | **New value** | **Increase** | **Operations affected** |
 | :---: | :---: | :---: | :---: | :---: | :---: |
-| `COLD_ACCOUNT_ACCESS` | Cold touch of an account | 2,600 | 3,000 | +15% | `*CALL` opcodes, `BALANCE`, `SELFDESTRUCT`, `EXT*` opcodes, EOA delegations, contract creation txs and ETH transfers |
-| `ACCOUNT_WRITE` | Surcharge for when writing to an account changes one account leaf value for the first time | 6,700¹ | 8,000 | +19% | `*CALL` opcodes, `SELFDESTRUCT`, EOA delegations and ETH transfers |
-| `COLD_STORAGE_ACCESS` | Cold touch of a storage slot | 2,100 | 3,000 | +43% | `SSTORE` and `SLOAD` |
-| `STORAGE_WRITE` | Surcharge for when writing to a storage slot changes its value for the first time | 2,800² | 10,000 | +257% | `SSTORE` |
-| `WARM_ACCESS` | Touch of an already-warm account or storage slot | 100 | 100 | +0% | `SSTORE`, `SLOAD`, `*CALL` opcodes, `BALANCE` and `EXT*` opcodes |
-| `STORAGE_CLEAR_REFUND` | Refund for clearing a storage slot | 4,800 | 12,480 | +160% | `SSTORE` |
-| `CREATE_ACCESS` | State access costs for contract deployment (include account cold access and account write) | 7,000³ | 11,000 | +57% | `CREATE`/ `CREATE2` |
-| `ACCESS_LIST_STORAGE_KEY_COST` | Gas charged per storage key included in a transaction's access list | 1,900 | 3,000 | +58% | `SSTORE` and `SLOAD` |
-| `ACCESS_LIST_ADDRESS_COST` | Gas charged per address included in a transaction's access list | 2,400 | 3,000 | +25% | `*CALL` opcodes, `BALANCE`, `SELFDESTRUCT` and `EXT*` opcodes |
+| `COLD_ACCOUNT_ACCESS` | Cold touch of an account. Renamed from `COLD_ACCOUNT_ACCESS_COST` ([EIP-2929](./eip-2929.md)) | 2,600 | 3,000 | +15% | `*CALL` opcodes, `BALANCE`, `SELFDESTRUCT`, `EXT*` opcodes, EOA delegations, contract creation txs and ETH transfers |
+| `ACCOUNT_WRITE` | Surcharge for when writing to an account changes one account leaf value for the first time. New named parameter (previously embedded in `CALL_VALUE`, see footnote ¹) | 6,700¹ | 8,000 | +19% | `*CALL` opcodes, `SELFDESTRUCT`, EOA delegations and ETH transfers |
+| `COLD_STORAGE_ACCESS` | Cold touch of a storage slot. Renamed from `COLD_SLOAD_COST` ([EIP-2929](./eip-2929.md)) | 2,100 | 3,000 | +43% | `SSTORE` and `SLOAD` |
+| `STORAGE_WRITE` | Surcharge for when writing to a storage slot changes its value for the first time. New named parameter (previously derived, see footnote ²) | 2,800² | 10,000 | +257% | `SSTORE` |
+| `WARM_ACCESS` | Touch of an already-warm account or storage slot. Renamed from `WARM_STORAGE_READ_COST` ([EIP-2929](./eip-2929.md)) | 100 | 100 | +0% | `SSTORE`, `SLOAD`, `*CALL` opcodes, `BALANCE` and `EXT*` opcodes |
+| `STORAGE_CLEAR_REFUND` | Refund for clearing a storage slot. Renamed from `SSTORE_CLEARS_SCHEDULE` ([EIP-3529](./eip-3529.md)) | 4,800 | 12,480 | +160% | `SSTORE` |
+| `CREATE_ACCESS` | State access costs for contract deployment (include account cold access and account write). New named parameter (previously derived, see footnote ³) | 7,000³ | 11,000 | +57% | `CREATE`/ `CREATE2` |
+| `ACCESS_LIST_STORAGE_KEY_COST` | Gas charged per storage key included in a transaction's access list. Unchanged name from [EIP-2930](./eip-2930.md) | 1,900 | 3,000 | +58% | `SSTORE` and `SLOAD` |
+| `ACCESS_LIST_ADDRESS_COST` | Gas charged per address included in a transaction's access list. Unchanged name from [EIP-2930](./eip-2930.md) | 2,400 | 3,000 | +25% | `*CALL` opcodes, `BALANCE`, `SELFDESTRUCT` and `EXT*` opcodes |
 
 ¹: 6,700 = `CALL_VALUE` (9,000) - `CALL_STIPEND`(2,300)
 


### PR DESCRIPTION
## Summary

Two clarifications to EIP-8038 (state-access gas repricing), no changes to any gas values.

## Changes

- **Parameter provenance.** Each row in the parameters table now records where the
  parameter name comes from:
  - `COLD_ACCOUNT_ACCESS` — renamed from `COLD_ACCOUNT_ACCESS_COST` (EIP-2929)
  - `COLD_STORAGE_ACCESS` — renamed from `COLD_SLOAD_COST` (EIP-2929)
  - `WARM_ACCESS` — renamed from `WARM_STORAGE_READ_COST` (EIP-2929)
  - `STORAGE_CLEAR_REFUND` — renamed from `SSTORE_CLEARS_SCHEDULE` (EIP-3529)
  - `ACCOUNT_WRITE`, `STORAGE_WRITE`, `CREATE_ACCESS` — new named parameters
    (previously embedded/derived; footnotes referenced)
  - `ACCESS_LIST_STORAGE_KEY_COST`, `ACCESS_LIST_ADDRESS_COST` — unchanged names from EIP-2930
- **`requires`:** removed `7904`, keeping only `8037`.

All current/new values and percentages are unchanged.
