### PR TITLE
Update EIP-2780: fold transfer log cost into TX_VALUE_COST

### DIFF
--- a/EIPS/eip-2780.md
+++ b/EIPS/eip-2780.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2020-07-11
-requires: 2718, 2929, 2930, 6780, 7523, 7623, 7702, 7708, 7928, 8037, 8038
+requires: 2718, 2929, 2930, 6780, 7623, 7702, 7708, 7928, 8037, 8038
 ---
 
 ## Abstract
@@ -25,7 +25,7 @@ The flat `21,000` intrinsic cost charges every transaction the same amount regar
 
 This EIP replaces the constant with a decomposition into named primitives, each priced to the resource it represents. The goal is to make every transaction's cost reflect its actual work:
 
-- **Accuracy.** Signature recovery, account accesses, account writes, the transfer log, and state creation are billed separately, so cost tracks usage.
+- **Accuracy.** Signature recovery, account accesses, account writes, value transfers, and state creation are billed separately, so cost tracks usage.
 - **State growth is internalized.** A value transfer that creates an account, like a contract-creation transaction, pays `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` in state gas. This aligns top-level value transfers with internal `CALL`-based account creation, which already pays for the new leaf, and prices the durable state cost the flat base ignored.
 - **Composability.** Pricing intrinsic cost as a sum of the same primitives used elsewhere in the gas schedule lets future repricings (e.g. of cold-account access in [EIP-8038](./eip-8038.md), or of state bytes in [EIP-8037](./eip-8037.md)) flow through automatically, without re-deriving a bespoke constant.
 - **No worst-case reservation.** State-dependent costs, such as new account creation and delegation resolution, are charged at runtime only when a transaction incurs them, rather than reserved up front. Intrinsic gas covers only inclusion and remains the sole validity input, so a transaction that funds inclusion but not a runtime charge is included, charged for the gas consumed, and reverted, exactly like an out-of-gas halt inside a call frame.
@@ -37,8 +37,7 @@ This EIP replaces the constant with a decomposition into named primitives, each 
 | Name | Value | Definition |
 | :----: | :----: | :---- |
 | `TX_BASE_COST` | 12,000 | Sender cost: ECDSA recovery, the sender's account access, the sender's account write and inclusion in block |
-| `TX_VALUE_COST` | 4,244 | Recipient balance write performed by a value transfer |
-| `TRANSFER_LOG_COST` | 1,756 | [EIP-7708](./eip-7708.md) transfer log: `GAS_LOG + 3 × GAS_LOG_TOPIC + 32 × GAS_LOG_DATA_PER_BYTE` |
+| `TX_VALUE_COST` | 6,000 | Recipient balance write and [EIP-7708](./eip-7708.md) transfer log performed by a value transfer |
 
 The remaining values are defined in other EIPs and referenced here:
 
@@ -66,8 +65,8 @@ A transaction's intrinsic base cost is decomposed into the following explicit pr
 - `tx.value` is charged based on its value:
   - if zero, there are no charges;
   - if non-zero and self-transfer, there are no charges;
-  - if non-zero and contract creation, charge `TRANSFER_LOG_COST` in regular gas;
-  - otherwise, charge `TRANSFER_LOG_COST + TX_VALUE_COST` in regular gas.
+  - if non-zero and contract creation, there are no charges; the recipient balance write is already covered by `CREATE_ACCESS`;
+  - otherwise, charge `TX_VALUE_COST` in regular gas.
 - each [EIP-7702](./eip-7702.md) authorization is charged `REGULAR_PER_AUTH_BASE_COST` in regular gas.
 
 The recipient touch and the authority access (inside `REGULAR_PER_AUTH_BASE_COST`) are charged at the cold rate every time, even if the account would be warm (for example, via an access list) keeping intrinsic gas computable without any state read. =
@@ -89,7 +88,7 @@ Like every charge in this EIP, each runtime charge is split into regular gas and
 
 Running out of gas during these runtime charges does **not** invalidate the transaction. Validity is decided solely by the intrinsic gas check.
 
-If the transaction goes out-of-gas in this pre-execution phase, the sender pays for all gas consumed, and all state changes are reverted, including any [EIP-7702](./eip-7702.md) delegations. By contrast, if the transaction goes out-of-gas after entering the first EVM frame, the already applied delegations during pre-execution phase stay in place, per [EIP-7702](./eip-7702.md), and all runtime charges remain consumed.
+If the transaction goes out-of-gas in this pre-execution phase, the sender pays for all gas consumed, and all state changes are reverted, including any [EIP-7702](./eip-7702.md) delegations. By contrast, if the transaction goes out-of-gas after entering the first EVM frame, the delegations applied during the pre-execution phase stay in place, per [EIP-7702](./eip-7702.md); the state gas that paid for them — each authority's account-creation and delegation-indicator bytes — therefore stays consumed, since that state persists beyond the frame. Runtime state charges whose state is instead rolled back with the frame (for example, a contract-creation transaction's new-account charge; see below) are refilled in LIFO order per [EIP-8037](./eip-8037.md), and regular-gas runtime charges (such as a delegation-target access) remain consumed as ordinary execution gas.
 
 If a contract-creation transaction's initcode reverts, the transaction remains valid and any state gas charged at runtime is refilled in last-in, first-out (LIFO) order, per [EIP-8037](./eip-8037.md): the portion the charge drew from `gas_left` is credited back to `gas_left`, and only the remainder returns to the `state_gas_reservoir`.
 
@@ -126,23 +125,23 @@ Costs are split between the intrinsic phase and the runtime phase, each in regul
 | ETH transfer to self | `TX_BASE_COST` / 0 | 0 / 0 | 12,000 / 0 |
 | No-transfer to EOA / empty account | `TX_BASE_COST + COLD_ACCOUNT_ACCESS` / 0 | 0 / 0 | 15,000 / 0 |
 | No-transfer to contract | `TX_BASE_COST + COLD_ACCOUNT_ACCESS` / 0 | execution / 0 | 15,000 + execution / 0 |
-| ETH transfer to existing EOA | `TX_BASE_COST + COLD_ACCOUNT_ACCESS + TX_VALUE_COST + TRANSFER_LOG_COST` / 0 | 0 / 0 | 21,000 / 0 |
-| ETH transfer to contract | `TX_BASE_COST + COLD_ACCOUNT_ACCESS + TX_VALUE_COST + TRANSFER_LOG_COST` / 0 | execution / 0 | 21,000 + execution / 0 |
+| ETH transfer to existing EOA | `TX_BASE_COST + COLD_ACCOUNT_ACCESS + TX_VALUE_COST` / 0 | 0 / 0 | 21,000 / 0 |
+| ETH transfer to contract | `TX_BASE_COST + COLD_ACCOUNT_ACCESS + TX_VALUE_COST` / 0 | execution / 0 | 21,000 + execution / 0 |
 | No-transfer to 7702 delegated | `TX_BASE_COST + COLD_ACCOUNT_ACCESS` / 0 | `COLD_ACCOUNT_ACCESS` + execution / 0 | 18,000 + execution / 0 |
-| ETH transfer to 7702 delegated | `TX_BASE_COST + COLD_ACCOUNT_ACCESS + TX_VALUE_COST + TRANSFER_LOG_COST` / 0 | `COLD_ACCOUNT_ACCESS` + execution / 0 | 24,000 + execution / 0 |
+| ETH transfer to 7702 delegated | `TX_BASE_COST + COLD_ACCOUNT_ACCESS + TX_VALUE_COST` / 0 | `COLD_ACCOUNT_ACCESS` + execution / 0 | 24,000 + execution / 0 |
 | ETH transfer to self, sender 7702 delegated | `TX_BASE_COST` / 0 | `COLD_ACCOUNT_ACCESS` + execution / 0 | 15,000 + execution / 0 |
-| ETH transfer creating new account | `TX_BASE_COST + COLD_ACCOUNT_ACCESS + TX_VALUE_COST + TRANSFER_LOG_COST` / 0 | 0 / `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` | 21,000 / 183,600 |
+| ETH transfer creating new account | `TX_BASE_COST + COLD_ACCOUNT_ACCESS + TX_VALUE_COST` / 0 | 0 / `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` | 21,000 / 183,600 |
 | Create transaction, `tx.value` = 0 | `TX_BASE_COST + CREATE_ACCESS` / 0 | 0 / `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` | 23,000 / 183,600 |
-| Create transaction, `tx.value` > 0 | `TX_BASE_COST + CREATE_ACCESS + TRANSFER_LOG_COST` / 0 | 0 / `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` | 24,756 / 183,600 |
-| Create transaction, `tx.value` > 0, `created_address.balance` > 0 | `TX_BASE_COST + CREATE_ACCESS + TRANSFER_LOG_COST` / 0 | 0 / 0 | 24,756 / 0 |
+| Create transaction, `tx.value` > 0 | `TX_BASE_COST + CREATE_ACCESS` / 0 | 0 / `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` | 23,000 / 183,600 |
+| Create transaction, `tx.value` > 0, `created_address.balance` > 0 | `TX_BASE_COST + CREATE_ACCESS` / 0 | 0 / 0 | 23,000 / 0 |
 
 ### Interactions with other EIPs
 
 - **[EIP-2929](./eip-2929.md) (warm/cold accounting).** The sender access folded into `TX_BASE_COST`, the recipient's `COLD_ACCOUNT_ACCESS`, and the authority access inside `REGULAR_PER_AUTH_BASE_COST` are all charged at the intrinsic phase at fixed cold rates, independent of the account's warm/cold state — an access-list entry for the recipient or an authority does not discount them. The sender, the recipient, and each processed authority are added to `accessed_addresses`, so subsequent execution-level touches are warm. The only runtime account access is the delegation-target load, which follows the standard EIP-2929 warm/cold model: `COLD_ACCOUNT_ACCESS` if cold, `WARM_ACCESS` if warm. The same model governs all execution-level account touches, including internal `CALL`s.
 - **[EIP-2930](./eip-2930.md) (access lists).** Access lists keep their existing per-entry charges and warming semantics for execution-level touches. Listing the recipient or an authority does not reduce the intrinsic cold-rate charges; it only pre-warms the address for execution.
-- **[EIP-7623](./eip-7623.md) (calldata floor).** EIP-7623 floors a transaction's cost at `21,000 + TOTAL_COST_FLOOR_PER_TOKEN × tokens_in_calldata`, where the flat `21,000` is the intrinsic base this EIP decomposes. With this EIP active, that base term is replaced by the transaction's decomposed regular-gas intrinsic — the sum of the regular-gas intrinsic primitives (`TX_BASE_COST + COLD_ACCOUNT_ACCESS + TX_VALUE_COST + TRANSFER_LOG_COST` for value transfers, `TX_BASE_COST + CREATE_ACCESS` for contract creation) — so the floor and its validity check rest on the same per-transaction base as the rest of intrinsic gas rather than a stale constant. Like the floor, this base is state-independent, so the state-dependent runtime charges (the new-account state-gas charge and the delegation-target access) do not enter it. The calldata schedule itself is unchanged; only the base the floor sits on moves.
+- **[EIP-7623](./eip-7623.md) (calldata floor).** EIP-7623 floors a transaction's cost at `21,000 + TOTAL_COST_FLOOR_PER_TOKEN × tokens_in_calldata`, where the flat `21,000` is the intrinsic base this EIP decomposes. With this EIP active, that base term is replaced by the transaction's decomposed regular-gas intrinsic — the sum of the regular-gas intrinsic primitives (`TX_BASE_COST + COLD_ACCOUNT_ACCESS + TX_VALUE_COST` for value transfers, `TX_BASE_COST + CREATE_ACCESS` for contract creation) — so the floor and its validity check rest on the same per-transaction base as the rest of intrinsic gas rather than a stale constant. Like the floor, this base is state-independent, so the state-dependent runtime charges (the new-account state-gas charge and the delegation-target access) do not enter it. The calldata schedule itself is unchanged; only the base the floor sits on moves.
 - **[EIP-7702](./eip-7702.md) (set EOA code).** `TX_BASE_COST` is unchanged even when the sender temporarily assumes code; clients must not perform a disk code load to classify the sender, since EIP-7702 provides the code inline. When `tx.to` is a delegated account, resolving the delegation loads the target's code, charged `COLD_ACCOUNT_ACCESS` on first touch or warm thereafter, following the standard EIP-2929 `accessed_addresses` model. Setting a delegation (writing the 23-byte pointer) is distinct from resolving one (reading the target's code); the resolution charge is genuine work and is not prepaid by the authorization. Authorization cost itself is decomposed: `REGULAR_PER_AUTH_BASE_COST` — which already includes the authority's cold access — is charged per authorization at the intrinsic phase, while the state-dependent charges (`STATE_BYTES_PER_NEW_ACCOUNT × CPSB` for a non-existent authority, `ACCOUNT_WRITE` for the first write to the authority within the transaction, and `STATE_BYTES_PER_AUTH_BASE × CPSB` for net-new delegation bytes) are charged at runtime during authorization processing, replacing the worst-case `PER_EMPTY_ACCOUNT_COST` intrinsic charge and refund.
-- **[EIP-7708](./eip-7708.md) (ETH transfers emit a log).** Every non-zero-value transfer to a different account emits a transfer log, priced explicitly as `TRANSFER_LOG_COST` rather than absorbed into the base.
+- **[EIP-7708](./eip-7708.md) (ETH transfers emit a log).** Every non-zero-value transfer to a different account emits a transfer log; its cost is folded into `TX_VALUE_COST` alongside the recipient balance write rather than priced as a separate primitive.
 - **[EIP-7928](./eip-7928.md) (block-level access lists).** `tx.sender` is accessed at the intrinsic phase and `tx.to` at the runtime phase, so both are included in the BAL even when the transaction reverts.
 
 ## Rationale
@@ -155,7 +154,7 @@ Charging the runtime part as the first frame is entered makes the top-level tran
 
 ### Pricing only the work each transaction does
 
-The decomposition charges each primitive once, where the resource is consumed: signature recovery and the sender's access and write in `TX_BASE_COST`; the recipient touch in `COLD_ACCOUNT_ACCESS`; the recipient balance write in `TX_VALUE_COST`; the transfer log in `TRANSFER_LOG_COST`; and durable state creation in `STATE_BYTES_PER_NEW_ACCOUNT × CPSB`. A zero-value transaction pays only for the touches it makes, while a value transfer that creates an account pays for the new leaf it adds. This removes the cross-subsidy in the flat base, where simple transactions overpaid and state-creating ones underpaid.
+The decomposition charges each primitive once, where the resource is consumed: signature recovery and the sender's access and write in `TX_BASE_COST`; the recipient touch in `COLD_ACCOUNT_ACCESS`; the recipient balance write and transfer log in `TX_VALUE_COST`; and durable state creation in `STATE_BYTES_PER_NEW_ACCOUNT × CPSB`. A zero-value transaction pays only for the touches it makes, while a value transfer that creates an account pays for the new leaf it adds. This removes the cross-subsidy in the flat base, where simple transactions overpaid and state-creating ones underpaid.
 
 The new-account state charge does not apply to `CREATE`/`CREATE2`: the `GAS_CREATE` opcode base already prices internal account creation, and top-level contract-creation transactions pay `CREATE_ACCESS` intrinsically plus the same state-gas charge at runtime when the deployment target does not already exist. Charging the state-growth cost on top-level value transfers that create accounts aligns them with the `CALL`-based creation path, which has always paid for the new leaf.
 
@@ -177,17 +176,11 @@ For any candidate target, the analysis surfaces each client's worst case across 
 The two empirical coefficients map onto the decomposition as follows:
 
 - the per-transfer base runtime covers signature recovery, the sender's access and write, and the recipient touch → `TX_BASE_COST + COLD_ACCOUNT_ACCESS`;
-- the value increment covers the recipient balance write and the transfer log → `TX_VALUE_COST + TRANSFER_LOG_COST`.
+- the value increment covers the recipient balance write and the transfer log → `TX_VALUE_COST`.
 
-`COLD_ACCOUNT_ACCESS` is taken directly from [EIP-8038](./eip-8038.md), since the recipient touch is the same cold-account access priced there, and `TRANSFER_LOG_COST` is fixed by the [EIP-7708](./eip-7708.md) log shape (see [Transfer log cost](#transfer-log-cost)). `TX_BASE_COST` and `TX_VALUE_COST` are the residual parameters this EIP introduces.
+`COLD_ACCOUNT_ACCESS` is taken directly from [EIP-8038](./eip-8038.md), since the recipient touch is the same cold-account access priced there. `TX_BASE_COST` and `TX_VALUE_COST` are the residual parameters this EIP introduces.
 
 As in [EIP-8038](./eip-8038.md), these numbers are provisional. At the 100 Mgas/s anchor some clients are currently slower than the target on the heaviest paths and must optimize to meet it; the values will be refined as client optimizations land and the benchmarks mature.
-
-### Transfer log cost
-
-`TRANSFER_LOG_COST` assumes a 32-byte log data payload because that is exactly the [EIP-7708](./eip-7708.md) transfer-log shape, not an arbitrary choice. The log is `LOG3`-shaped: three indexed topics (`keccak256("Transfer(address,address,uint256)")`, `from`, `to`) and a `data` field carrying a single `uint256` wei amount. Indexed topics do not count as data bytes, so the only data payload is the 32-byte amount — always a full word, never variable length. Hence:
-
-`TRANSFER_LOG_COST = GAS_LOG + 3 × GAS_LOG_TOPIC + 32 × GAS_LOG_DATA_PER_BYTE = 375 + 3 × 375 + 32 × 8 = 1,756`
 
 ### Not metering the transaction envelope as calldata
 
@@ -215,7 +208,7 @@ Costs are given as intrinsic + runtime, by case:
 4. Value transfer creating a new account (recipient non-existent): `21,000` intrinsic regular; `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` = `183,600` runtime state.
 5. Value transfer to a 7702-delegated account: `21,000` intrinsic + `COLD_ACCOUNT_ACCESS` runtime = `24,000` regular plus execution.
 6. Contract-creation transaction, `value = 0`: `23,000` intrinsic regular; `183,600` runtime state if the deployment target did not exist, `0` otherwise.
-7. Contract-creation transaction, `value > 0`: `24,756` intrinsic regular; `183,600` runtime state if the deployment target did not exist, `0` otherwise.
+7. Contract-creation transaction, `value > 0`: `23,000` intrinsic regular (identical to the `value = 0` case, since the recipient balance write is covered by `CREATE_ACCESS`); `183,600` runtime state if the deployment target did not exist, `0` otherwise.
 8. EIP-7702 transaction: `TX_BASE_COST` is unchanged even when the sender assumes code. Each authorization is charged `REGULAR_PER_AUTH_BASE_COST` (which already covers the cold authority access) at the intrinsic phase; at runtime, a non-existent authority additionally pays `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` state, the first write to the authority within the transaction pays `ACCOUNT_WRITE` regular, and net-new delegation bytes add `STATE_BYTES_PER_AUTH_BASE × CPSB` state — replacing the flat `PER_EMPTY_ACCOUNT_COST` intrinsic charge and refund.
 9. Contract-creation transaction whose initcode reverts (value-bearing or not): the transaction remains valid; the `183,600` new-account state-gas charge is refilled in LIFO order per [EIP-8037](./eip-8037.md) — credited to `gas_left` up to the portion the charge drew from it, with the remainder returning to the `state_gas_reservoir`.
 10. Transaction whose gas covers intrinsic cost but not a runtime charge — e.g. a value transfer to a non-existent recipient or a contract creation to a non-existent target lacking gas for the new-account state charge, or a transfer to a delegated account lacking gas for the delegation-target access: the transaction is valid and included, halts out-of-gas, and all runtime state changes — including any applied EIP-7702 delegations — are reverted; it is **not** invalidated.


### PR DESCRIPTION
## Summary

Simplifies the intrinsic-cost decomposition in EIP-2780 by removing the standalone
`TRANSFER_LOG_COST` primitive and folding the EIP-7708 transfer-log cost into
`TX_VALUE_COST`.

**Note**: specs and test need to update; cost of create transaction with value changes

## Changes

- **Parameters.** Removed `TRANSFER_LOG_COST` (1,756). `TX_VALUE_COST` becomes
  6,000 (previously 4,244) and now covers both the recipient balance write and the
  EIP-7708 transfer log.
- **Value charging.** A non-zero, non-self value transfer is now charged
  `TX_VALUE_COST` (was `TRANSFER_LOG_COST + TX_VALUE_COST`). A value-bearing
  contract-creation transaction incurs no value charge — the recipient balance
  write is already covered by `CREATE_ACCESS`.
- **Cost table / examples.** Updated the worked cost table and worked examples
  accordingly. The value-bearing create case is now 23,000 intrinsic (identical to
  `value = 0`), replacing the former 24,756.
- **Out-of-gas semantics.** Expanded the pre-execution out-of-gas paragraph to
  distinguish state gas that persists (EIP-7702 delegation bytes) from
  runtime state charges rolled back with the frame and refilled in LIFO order per
  EIP-8037.
- **Interactions / rationale.** Refreshed the EIP-7623, EIP-7708, and rationale
  sections; removed the dedicated "Transfer log cost" subsection.
- **`requires`:** removed `7523`.