### PR TITLE
Update EIP-8037: rename "regular gas" to "execution gas" and update requires

### DIFF
--- a/EIPS/eip-8037.md
+++ b/EIPS/eip-8037.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2025-10-01
-requires: 2780, 6780, 7623, 7702, 7825, 7904, 7928, 7976, 7981, 8038
+requires: 161, 684, 2780, 6780, 7610, 7623, 7702, 7825, 7928, 7976, 8038
 ---
 
 ## Abstract
@@ -39,9 +39,9 @@ The state-growth response we observe is not linear in the gas limit increase: a 
 
 ### Parameter changes
 
-Upon activation of this EIP, the following parameters of the gas model are updated. The "New State Gas" column shows the state gas cost (charged to the state-gas dimension), while the "New Regular Gas" column shows additional regular gas costs that accompany the state gas charge.
+Upon activation of this EIP, the following parameters of the gas model are updated. The "New State Gas" column shows the state gas cost (charged to the state-gas dimension), while the "New Execution Gas" column shows additional execution gas costs that accompany the state gas charge.
 
-| **Parameter** | **Current** | **New State Gas** | **New Regular Gas** | **Operations affected** |
+| **Parameter** | **Current** | **New State Gas** | **New Execution Gas** | **Operations affected** |
 |---|---|---|---|---|
 | `GAS_CREATE` | 32,000 | `STATE_BYTES_PER_NEW_ACCOUNT x CPSB` | `CREATE_ACCESS` | `CREATE`, `CREATE2` |
 | `GAS_CODE_DEPOSIT` | 200/byte | `CPSB` per byte | `6 × ceil(len/32)` (hash cost) | `CREATE`, `CREATE2` |
@@ -53,7 +53,7 @@ Upon activation of this EIP, the following parameters of the gas model are updat
 The `REGULAR_PER_AUTH_BASE_COST` is defined as the sum of:
 
 - Calldata cost: 1,616 (101 bytes × 16), where 101 is the byte size of an [EIP-7702](./eip-7702.md) authorization tuple (`chain_id` 8 + `address` 20 + `nonce` 8 + `y_parity` 1 + `r` 32 + `s` 32). This is a representative size, not a worst case, since `chain_id` is a `uint256` and may exceed 8 bytes.
-- Recovering authority address (ecRecover): `PRECOMPILE_ECRECOVER` (is updated by [EIP-7904](./eip-7904.md))
+- Recovering authority address (ecRecover): `PRECOMPILE_ECRECOVER`
 - Reading nonce and code of authority (cold access): `COLD_ACCOUNT_ACCESS` (is updated by [EIP-8038](./eip-8038.md))
 - Storing values in an already warm account: 2 x `WARM_ACCESS`
 
@@ -61,9 +61,9 @@ The `REGULAR_PER_AUTH_BASE_COST` is defined as the sum of:
 
 ### Multidimensional metering for state creation costs
 
-Besides the parameter changes, this proposal introduces an independent metering for state creation costs. Two gas dimensions are introduced, regular-gas and state-gas. For state creation operations, the "new state costs" are charged to state-gas, while the "new regular costs" are charged to regular-gas. The costs of all other operations are charged to regular-gas.
+Besides the parameter changes, this proposal introduces an independent metering for state creation costs. Two gas dimensions are introduced, execution-gas and state-gas. For state creation operations, the "new state costs" are charged to state-gas, while the "new execution costs" are charged to execution-gas. The costs of all other operations are charged to execution-gas.
 
-At transaction level, the user pays for both regular-gas and state-gas. The total gas cost of a transaction is the sum of both dimensions. In addition, the transaction gas limit set in [EIP-7825](./eip-7825.md) only applies to regular-gas, while state-gas is only capped by `tx.gas`.
+At transaction level, the user pays for both execution-gas and state-gas. The total gas cost of a transaction is the sum of both dimensions. In addition, the transaction gas limit set in [EIP-7825](./eip-7825.md) only applies to execution-gas, while state-gas is only capped by `tx.gas`.
 
 At the block level, only the gas used in the bottleneck resource is considered when checking if the block is full and when updating the base fee for the next block. This gives a new meaning to the block's gas limit and the block's gas target: each now bounds the bottleneck resource (the dimension with the highest cumulative gas used) rather than a single combined gas counter.
 
@@ -71,12 +71,12 @@ At the block level, only the gas used in the bottleneck resource is considered w
 
 Before transaction execution, inclusion of a transaction in a block requires that:
 
-1. The transaction's **intrinsic gas is not higher than [EIP-7825](./eip-7825.md)'s transaction cap**. Concretely, `max(intrinsic_gas, calldata_floor_gas_cost) <= TX_MAX_GAS_LIMIT`. Under [EIP-2780](./eip-2780.md), `intrinsic_gas` is state-independent and charged entirely in regular-gas; there is no intrinsic state-gas component.
-2. For each gas dimension, the **cumulative gas used of all previous transactions added to the transaction's contribution does not exceed the block gas limit**. Concretely, `min(TX_MAX_GAS_LIMIT, tx.gas) <= regular_gas_available` and `tx.gas <= state_gas_available`, where `regular_gas_available = block_env.block_gas_limit - block_output.block_regular_gas_used` and `state_gas_available = block_env.block_gas_limit - block_output.block_state_gas_used`.
+1. The transaction's **intrinsic gas is not higher than [EIP-7825](./eip-7825.md)'s transaction cap**. Concretely, `max(intrinsic_gas, calldata_floor_gas_cost) <= TX_MAX_GAS_LIMIT`. Under [EIP-2780](./eip-2780.md), `intrinsic_gas` is state-independent and charged entirely in execution-gas; there is no intrinsic state-gas component.
+2. For each gas dimension, the **cumulative gas used of all previous transactions added to the transaction's contribution does not exceed the block gas limit**. Concretely, `min(TX_MAX_GAS_LIMIT, tx.gas) <= execution_gas_available` and `tx.gas <= state_gas_available`, where `execution_gas_available = block_env.block_gas_limit - block_output.block_execution_gas_used` and `state_gas_available = block_env.block_gas_limit - block_output.block_state_gas_used`.
 
 This check is performed before transaction inclusion in a block.
 
-`intrinsic_gas` is the state-independent intrinsic cost defined by [EIP-2780](./eip-2780.md), charged entirely in regular-gas (base transaction cost, calldata, access lists, the recipient touch, value costs, and per-authorization base costs). It is the sole input to the transaction-validity check.
+`intrinsic_gas` is the state-independent intrinsic cost defined by [EIP-2780](./eip-2780.md), charged entirely in execution-gas (base transaction cost, calldata, access lists, the recipient touch, value costs, and per-authorization base costs). It is the sole input to the transaction-validity check.
 
 All state-dependent charges — new account creation and [EIP-7702](./eip-7702.md) delegation costs — are no longer part of intrinsic gas. Per [EIP-2780](./eip-2780.md), they are **runtime charges** applied in the pre-execution phase, after the transaction is deemed valid but before the first EVM frame is entered.
 
@@ -89,25 +89,25 @@ This EIP defines how the split and the counters are computed. The remaining acco
 `gas_left` and `state_gas_reservoir` are initialized as follows:
 
 ```python
-execution_gas = tx.gas - intrinsic_gas
-regular_gas_budget = TX_MAX_GAS_LIMIT - intrinsic_gas
-gas_left = min(regular_gas_budget, execution_gas)
-state_gas_reservoir = execution_gas - gas_left
+evm_gas = tx.gas - intrinsic_gas
+execution_gas_budget = TX_MAX_GAS_LIMIT - intrinsic_gas
+gas_left = min(execution_gas_budget, evm_gas)
+state_gas_reservoir = evm_gas - gas_left
 ```
 
 Because [EIP-2780](./eip-2780.md) makes intrinsic gas state-independent, no state-gas component is subtracted from `tx.gas` here and none is seeded into the reservoir. The state-dependent costs are applied as runtime charges — later in the pre-execution phase and during execution — drawing from `state_gas_reservoir` first and from `gas_left` once the reservoir is exhausted.
 
 This means that the `state_gas_reservoir` holds gas that exceeds [EIP-7825](./eip-7825.md)'s budget. Additionally, three new counters are introduced:
 
-- `execution_regular_gas_used` encodes the total regular-gas used by the transaction, and it is initialized as `execution_regular_gas_used = 0`.
-- `execution_state_gas_used` encodes the total state-gas used by the transaction, and it is initialized as `execution_state_gas_used = 0`.
+- `evm_execution_gas_used` encodes the total execution-gas used by the transaction, and it is initialized as `evm_execution_gas_used = 0`.
+- `evm_state_gas_used` encodes the total state-gas used by the transaction, and it is initialized as `evm_state_gas_used = 0`.
 - `state_gas_from_gas_left` encodes how much of the current frame's `gas_left` has been spent on state-gas charges (i.e., the state-gas not covered by the reservoir). Like `gas_left`, it is frame-local: it is initialized to `0` at the start of each call frame and is used to refill state-gas in last-in, first-out (LIFO) order.
 
 The gas counters operate as follows:
 
-- Regular-gas charges deduct from `gas_left` only and increment `execution_regular_gas_used`.
-- State-gas charges deduct from `state_gas_reservoir` first. When the reservoir is exhausted, the remainder deducts from `gas_left` and increments `state_gas_from_gas_left` by that remainder. State-gas charges increment `execution_state_gas_used`.
-- If a state creation is undone during execution, the corresponding amount of state-gas is **refilled in last-in, first-out (LIFO) order**: because charges deduct from `state_gas_reservoir` first and from `gas_left` last, refills credit the pool charged last (`gas_left`) first. It is credited to `gas_left` first (decrementing `state_gas_from_gas_left` by the same amount) up to the current value of `state_gas_from_gas_left`, and any remainder is credited to `state_gas_reservoir`. State-gas refills decrement `execution_state_gas_used`. Throughout this specification, "refilling state-gas" refers to this LIFO operation.
+- Execution-gas charges deduct from `gas_left` only and increment `evm_execution_gas_used`.
+- State-gas charges deduct from `state_gas_reservoir` first. When the reservoir is exhausted, the remainder deducts from `gas_left` and increments `state_gas_from_gas_left` by that remainder. State-gas charges increment `evm_state_gas_used`.
+- If a state creation is undone during execution, the corresponding amount of state-gas is **refilled in last-in, first-out (LIFO) order**: because charges deduct from `state_gas_reservoir` first and from `gas_left` last, refills credit the pool charged last (`gas_left`) first. It is credited to `gas_left` first (decrementing `state_gas_from_gas_left` by the same amount) up to the current value of `state_gas_from_gas_left`, and any remainder is credited to `state_gas_reservoir`. State-gas refills decrement `evm_state_gas_used`. Throughout this specification, "refilling state-gas" refers to this LIFO operation.
 - The `GAS` opcode returns `gas_left` only (excluding the reservoir).
 - State-gas is metered at the end of all state-mutating opcodes, call-frame boundaries (in case of exceptional halts and reverts) and at the end of the transaction.
 
@@ -138,13 +138,13 @@ In particular, an address that holds a balance but has no code and a zero nonce 
 
 State-gas accounting for `CALL*` and `CREATE`/`CREATE2` operations is performed right before the respective call frame. In both families the `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` account-creation charge is applied *conditionally*: only when the operation is about to create a new account. The families differ only in *when* the destination account may be read, which [EIP-7928](./eip-7928.md) constrains (see [Account-creation charging and EIP-7928](#account-creation-charging-and-eip-7928)).
 
-**`CALL*` family (conditional charge).** The `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` account-creation charge is applied *conditionally* right before entering the child frame: only when the target account does not exist and a positive value is transferred. If the operation is unsuccessful before entering the call frame (e.g., due to insufficient balance or due to the stack depth), or if the child frame reverts or halts exceptionally, the charged state-gas is refilled in LIFO order and `execution_state_gas_used` decreases by the same amount.
+**`CALL*` family (conditional charge).** The `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` account-creation charge is applied *conditionally* right before entering the child frame: only when the target account does not exist and a positive value is transferred. If the operation is unsuccessful before entering the call frame (e.g., due to insufficient balance or due to the stack depth), or if the child frame reverts or halts exceptionally, the charged state-gas is refilled in LIFO order and `evm_state_gas_used` decreases by the same amount.
 
 **`CREATE`/`CREATE2` family (conditional charge).** [EIP-7928](./eip-7928.md) defers reading the computed destination address until creation has passed the checks that precede any state access: sender balance for the endowment, nonce overflow, and the call-stack depth limit. A creation failing those checks never reads the destination, and no account-creation state-gas is charged. Once the checks pass, the destination is accessed — a single read that also performs the [EIP-7610](./eip-7610.md) collision check:
 
 - If the destination is non-existent (per the existence rule above), `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` is charged in the creating frame, before 63/64ths of the remaining gas is forwarded: a portion drawn from `gas_left` reduces the gas forwarded to the create frame, and a failed charge exceptionally halts the creating frame — exactly as for `CALL*`. If the destination pre-exists (e.g., it holds a balance), nothing is charged. The charge is decided by existence alone, independently of the collision outcome below.
 - On an address collision ([EIP-7610](./eip-7610.md)) the creation fails as an exceptional halt of the create frame, consuming the forwarded gas. A colliding destination is usually existent (non-zero nonce or non-empty code) and therefore was not charged; the one exception is a destination that collides on storage alone while having zero nonce, zero balance, and empty code — it is non-existent, so it was charged, and the charge is refilled by the failure rule below.
-- If the create frame reverts or halts exceptionally (including an address collision and a failed code deposit), the account creation is rolled back and any charged account-creation state-gas is refilled in LIFO order, decreasing `execution_state_gas_used` by the same amount — exactly as for `CALL*`.
+- If the create frame reverts or halts exceptionally (including an address collision and a failed code deposit), the account creation is rolled back and any charged account-creation state-gas is refilled in LIFO order, decreasing `evm_state_gas_used` by the same amount — exactly as for `CALL*`.
 
 The code-deposit portion (`L × CPSB`) is unaffected by this rule and is charged at code-deposit time as usual.
 
@@ -154,9 +154,9 @@ Charges for account creation with `SELFDESTRUCT` are charged at the point where 
 
 ##### Gas refills for `SELFDESTRUCT`
 
-`SELFDESTRUCT` for accounts created in the same transaction does not produce increases in state size as the account, its data and its storage is not included in the state trie. However, this operation does not produce any state-gas refills and there are no changes to `execution_state_gas_used`.
+`SELFDESTRUCT` for accounts created in the same transaction does not produce increases in state size as the account, its data and its storage is not included in the state trie. However, this operation does not produce any state-gas refills and there are no changes to `evm_state_gas_used`.
 
-For an account that existed before the transaction, `SELFDESTRUCT` only transfers its balance and the account is not removed. Thus, no state-gas refill applies and no changes to `execution_state_gas_used`. This is consistent with the behavior of [EIP-6780](./eip-6780.md).
+For an account that existed before the transaction, `SELFDESTRUCT` only transfers its balance and the account is not removed. Thus, no state-gas refill applies and no changes to `evm_state_gas_used`. This is consistent with the behavior of [EIP-6780](./eip-6780.md).
 
 ##### Gas accounting for halts and reverts
 
@@ -164,11 +164,11 @@ A call frame's state changes are rolled back on both reverts and exceptional hal
 
 When a child frame **succeeds**, its remaining `gas_left` is returned to the parent and its `state_gas_from_gas_left` is added to the parent's `state_gas_from_gas_left` (the state-gas it funded from `gas_left` persists and is now backed by the merged `gas_left`).
 
-When a child frame **reverts**, all of its state changes are rolled back and the state-gas charged within the frame is refilled: credited to the child's `gas_left` up to `state_gas_from_gas_left`, with any remainder credited to `state_gas_reservoir`. The child's resulting `gas_left` (including the refilled portion) is then returned to the parent. `execution_state_gas_used` is decreased by the refilled amount, while `execution_regular_gas_used` is updated according to the regular gas consumed by the child frame before the revert.
+When a child frame **reverts**, all of its state changes are rolled back and the state-gas charged within the frame is refilled: credited to the child's `gas_left` up to `state_gas_from_gas_left`, with any remainder credited to `state_gas_reservoir`. The child's resulting `gas_left` (including the refilled portion) is then returned to the parent. `evm_state_gas_used` is decreased by the refilled amount, while `evm_execution_gas_used` is updated according to the execution gas consumed by the child frame before the revert.
 
 When a child frame **halts exceptionally**, the same refill is applied, but the child's `gas_left` is consumed (set to zero) rather than returned. Because the portion refilled to `gas_left` is part of the consumed `gas_left`, only the portion refilled to `state_gas_reservoir` survives — which is exactly the reservoir's value at the start of the child frame. No separate reservoir-reset rule is therefore required: refilling in LIFO order makes the reservoir whole automatically, while the regular `gas_left` the parent forwarded to the child is consumed in full as usual.
 
-The same rules apply when the top-level call frame reverts or halts, treating the frame as a child of the transaction boundary. In particular, for address collisions in contract-creation transactions, `gas_left` is consumed in full and `execution_regular_gas_used` is incremented by the initial `gas_left`; any account-creation state-gas charged for the destination (possible only for a storage-only collision, since a destination with nonce, code, or balance is existent) is refilled by the rules above, and the `state_gas_reservoir` is returned to the sender by the normal end-of-transaction settlement.
+The same rules apply when the top-level call frame reverts or halts, treating the frame as a child of the transaction boundary. In particular, for address collisions in contract-creation transactions, `gas_left` is consumed in full and `evm_execution_gas_used` is incremented by the initial `gas_left`; any account-creation state-gas charged for the destination (possible only for a storage-only collision, since a destination with nonce, code, or balance is existent) is refilled by the rules above, and the `state_gas_reservoir` is returned to the sender by the normal end-of-transaction settlement.
 
 ##### Gas accounting for [EIP-7702](./eip-7702.md) authorizations
 
@@ -176,7 +176,7 @@ Gas charges for [EIP-7702](./eip-7702.md) authorizations follow the specificatio
 
 #### Pre-state and post-state gas validation
 
-[EIP-7928](./eip-7928.md) defines two-phase gas validation for state-accessing opcodes: pre-state costs (determinable without state access) and post-state costs (requiring state access). Under this EIP, the regular-gas portion of these opcodes follows the [EIP-7928](./eip-7928.md) rules unchanged and is charged at opcode time against `gas_left`. The state-gas portion is also charged at the opcode level; it is computed and deducted at the end of the opcode execution, drawing first from `state_gas_reservoir` and then from `gas_left`.
+[EIP-7928](./eip-7928.md) defines two-phase gas validation for state-accessing opcodes: pre-state costs (determinable without state access) and post-state costs (requiring state access). Under this EIP, the execution-gas portion of these opcodes follows the [EIP-7928](./eip-7928.md) rules unchanged and is charged at opcode time against `gas_left`. The state-gas portion is also charged at the opcode level; it is computed and deducted at the end of the opcode execution, drawing first from `state_gas_reservoir` and then from `gas_left`.
 
 For `SSTORE`, the `GAS_CALL_STIPEND` pre-state check ([EIP-7928](./eip-7928.md)) applies to `gas_left` only, excluding the `state_gas_reservoir`.
 
@@ -195,26 +195,26 @@ The refund cap remains at 20% of gas used. `tx_gas_used` applies the [EIP-7623](
 
 #### Block-level gas accounting
 
-At block level, instead of tracking a single `gas_used` counter, we keep track of two counters, one for `state-gas` and one for `regular-gas`:
+At block level, instead of tracking a single `gas_used` counter, we keep track of two counters, one for `state-gas` and one for `execution-gas`:
 
 ```python
-tx_state_gas = tx_output.execution_state_gas_used
-tx_regular_gas = max(tx_gas_used_after_refund - tx_state_gas, calldata_floor_gas_cost)
+tx_state_gas = tx_output.evm_state_gas_used
+tx_execution_gas = max(tx_gas_used_after_refund - tx_state_gas, calldata_floor_gas_cost)
 
-block_output.block_regular_gas_used += tx_regular_gas
+block_output.block_execution_gas_used += tx_execution_gas
 block_output.block_state_gas_used += tx_state_gas
 ```
 
-Since all state-gas charges are now applied as runtime or execution-time charges (per [EIP-2780](./eip-2780.md)), the transaction's total state-gas is fully captured by `execution_state_gas_used`; there is no separate intrinsic state-gas term to add.
+Since all state-gas charges are now applied as runtime or execution-time charges (per [EIP-2780](./eip-2780.md)), the transaction's total state-gas is fully captured by `evm_state_gas_used`; there is no separate intrinsic state-gas term to add.
 
-The [EIP-7623](./eip-7623.md) calldata floor participates in block accounting through the `max` term, applied to the regular-gas dimension: calldata is a regular-gas resource, and the floor's bound on worst-case block size holds only if a data-heavy transaction contributes at least the floor to the block's gas accounting. The floor is compared against the transaction's regular-gas portion alone — not the transaction total — so regular gas (including execution gas) may absorb the floor exactly as under [EIP-7623](./eip-7623.md), while state-gas spending cannot (see [Calldata floor in block accounting](#calldata-floor-in-block-accounting)).
+The [EIP-7623](./eip-7623.md) calldata floor participates in block accounting through the `max` term, applied to the execution-gas dimension: calldata is an execution-gas resource, and the floor's bound on worst-case block size holds only if a data-heavy transaction contributes at least the floor to the block's gas accounting. The floor is compared against the transaction's execution-gas portion alone — not the transaction total — so execution gas may absorb the floor exactly as under [EIP-7623](./eip-7623.md), while state-gas spending cannot (see [Calldata floor in block accounting](#calldata-floor-in-block-accounting)).
 
 Note: `tx_gas_used` applies the [EIP-7623](./eip-7623.md) calldata floor after refunds, so the floor can effectively negate part of a refund when `calldata_floor_gas_cost > tx_gas_used_after_refund`. The receipt `cumulative_gas_used` uses this post-floor value.
 
 The block header `gas_used` field is set to:
 
 ```python
-gas_used = max(block_output.block_regular_gas_used, block_output.block_state_gas_used)
+gas_used = max(block_output.block_execution_gas_used, block_output.block_state_gas_used)
 ```
 
 The block validity condition uses this value:
@@ -231,17 +231,17 @@ gas_used_delta = parent.gas_used - parent.gas_target
 
 ##### Integration with [EIP-7778](./eip-7778.md)
 
-[EIP-7778](./eip-7778.md) excludes transaction refunds from block gas accounting. The refunds in question are those of the transaction refund counter — a regular-gas quantity. State-gas refills are not refunds in this sense: a refill reverses a charge for state that was never durably created (a reverted or exceptionally halted frame, a failed `CALL*`/`CREATE`, or a slot set and reset within the same transaction), so the resource metered by the state-gas dimension was never consumed. Refills therefore remain netted into `execution_state_gas_used` regardless of [EIP-7778](./eip-7778.md), and only the regular-gas dimension changes (see [State-gas refills under EIP-7778](#state-gas-refills-under-eip-7778)). If implemented together with [EIP-7778](./eip-7778.md), the block level would be updated to:
+[EIP-7778](./eip-7778.md) excludes transaction refunds from block gas accounting. The refunds in question are those of the transaction refund counter — a execution-gas quantity. State-gas refills are not refunds in this sense: a refill reverses a charge for state that was never durably created (a reverted or exceptionally halted frame, a failed `CALL*`/`CREATE`, or a slot set and reset within the same transaction), so the resource metered by the state-gas dimension was never consumed. Refills therefore remain netted into `evm_state_gas_used` regardless of [EIP-7778](./eip-7778.md), and only the execution-gas dimension changes (see [State-gas refills under EIP-7778](#state-gas-refills-under-eip-7778)). If implemented together with [EIP-7778](./eip-7778.md), the block level would be updated to:
 
 ```python
-tx_state_gas = tx_output.execution_state_gas_used
-tx_regular_gas = max(tx_gas_used_before_refund - tx_state_gas, calldata_floor_gas_cost)
+tx_state_gas = tx_output.evm_state_gas_used
+tx_execution_gas = max(tx_gas_used_before_refund - tx_state_gas, calldata_floor_gas_cost)
 
-block_output.block_regular_gas_used += tx_regular_gas
+block_output.block_execution_gas_used += tx_execution_gas
 block_output.block_state_gas_used += tx_state_gas
 ```
 
-The `max` term preserves [EIP-7778](./eip-7778.md)'s block accounting rule `block.gas_used += max(tx_gas_used, calldata_floor_gas_cost)`, applied here to the regular-gas dimension.
+The `max` term preserves [EIP-7778](./eip-7778.md)'s block accounting rule `block.gas_used += max(tx_gas_used, calldata_floor_gas_cost)`, applied here to the execution-gas dimension.
 
 #### Receipt semantics
 
@@ -259,7 +259,7 @@ This ensures preservation of the existing execution margin for system contracts 
 
 Here, `SYSTEM_MAX_SSTORES_PER_CALL = 16` is the upper bound on the number of new storage slots a single system call is expected to write. This value matches `MAX_WITHDRAWAL_REQUESTS_PER_BLOCK` ([EIP-7002](./eip-7002.md)), the largest per-block bound across the existing system contracts.
 
-The additional `STATE_BYTES_PER_STORAGE_SET × CPSB × SYSTEM_MAX_SSTORES_PER_CALL` is placed in `state_gas_reservoir` while the rest of the system call's execution gas is placed in `gas_left`. System calls remain not subject to the [EIP-7825](./eip-7825.md) `TX_MAX_GAS_LIMIT` cap, do not count against the block gas limit, and do not contribute to either `block_regular_gas_used` or `block_state_gas_used`.
+The additional `STATE_BYTES_PER_STORAGE_SET × CPSB × SYSTEM_MAX_SSTORES_PER_CALL` is placed in `state_gas_reservoir` while the rest of the system call's gas is placed in `gas_left`. System calls remain not subject to the [EIP-7825](./eip-7825.md) `TX_MAX_GAS_LIMIT` cap, do not count against the block gas limit, and do not contribute to either `block_execution_gas_used` or `block_state_gas_used`.
 
 ## Rationale
 
@@ -368,13 +368,13 @@ These figures account only for the leaf payload and its keccak256 key. They do n
 
 #### EIP-7825 limit on contract size
 
-[EIP-7825](./eip-7825.md) introduces `TX_MAX_GAS_LIMIT` (16.7M) as the maximum gas for a single transaction, in particular stipulating `tx.gas < TX_MAX_GAS_LIMIT`as a validity condition. Were we to continue enforcing this validity condition, with `CPSB = 1530`, this proposal would limit the maximum contract size that can be deployed to roughly 7.5kB. Assuming a representative constructor execution budget of 5M regular gas on top of the 21,000 base transaction cost and the `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` account-creation cost, the remaining budget for code-deposit state gas yields $\frac{16,777,216 - 21,000 - 5,000,000 - 120 \times 1530}{1530} \approx 7{,}564$ bytes. This maximum size would only decrease if `CPSB` is re-derived upward in a future EIP.
+[EIP-7825](./eip-7825.md) introduces `TX_MAX_GAS_LIMIT` (16.7M) as the maximum gas for a single transaction, in particular stipulating `tx.gas < TX_MAX_GAS_LIMIT`as a validity condition. Were we to continue enforcing this validity condition, with `CPSB = 1530`, this proposal would limit the maximum contract size that can be deployed to roughly 7.5kB. Assuming a representative constructor execution budget of 5M execution gas on top of the 21,000 base transaction cost and the `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` account-creation cost, the remaining budget for code-deposit state gas yields $\frac{16,777,216 - 21,000 - 5,000,000 - 120 \times 1530}{1530} \approx 7{,}564$ bytes. This maximum size would only decrease if `CPSB` is re-derived upward in a future EIP.
 
-To solve this issue, we only apply this gas limit to regular gas, not state gas. Doing so does not weaken the intended scaling effect of [EIP-7825](./eip-7825.md), because regular gas meters all resources that benefit from parallelization. In particular, state growth does not: growing the state always requires writing to disk, a parallelizable operation, but crucially this part of the cost of a state growth operation has to be metered in regular gas, not state gas. In other words, any operation that grows the state should consume both regular gas and state gas, and the regular gas should fully account for all costs other than the long term effect of growing the state.
+To solve this issue, we only apply this gas limit to execution gas, not state gas. Doing so does not weaken the intended scaling effect of [EIP-7825](./eip-7825.md), because execution gas meters all resources that benefit from parallelization. In particular, state growth does not: growing the state always requires writing to disk, a parallelizable operation, but crucially this part of the cost of a state growth operation has to be metered in execution gas, not state gas. In other words, any operation that grows the state should consume both execution gas and state gas, and the execution gas should fully account for all costs other than the long term effect of growing the state.
 
-However, we cannot statically enforce a regular gas consumption of `TX_MAX_GAS_LIMIT`, while still allowing a higher state gas consumption, because transactions only have a single gas limit parameter, `tx.gas`. This is solved through a **reservoir model**: at transaction start, execution gas is split into `gas_left` (capped at `TX_MAX_GAS_LIMIT - intrinsic_gas`) and a `state_gas_reservoir` (the overflow). State gas charges draw from the reservoir first, then from `gas_left` when the reservoir is empty. Regular gas charges draw from `gas_left` only. Exceeding the regular gas budget behaves identically to running out of gas — no special error is needed.
+However, we cannot statically enforce an execution gas consumption of `TX_MAX_GAS_LIMIT`, while still allowing a higher state gas consumption, because transactions only have a single gas limit parameter, `tx.gas`. This is solved through a **reservoir model**: at transaction start, `evm_gas` is split into `gas_left` (capped at `TX_MAX_GAS_LIMIT - intrinsic_gas`) and a `state_gas_reservoir` (the overflow). State gas charges draw from the reservoir first, then from `gas_left` when the reservoir is empty. Execution gas charges draw from `gas_left` only. Exceeding the execution gas budget behaves identically to running out of gas — no special error is needed.
 
-State-gas refills are applied in last-in, first-out (LIFO) order: because charges draw from the reservoir first and from `gas_left` last, refills credit `gas_left` first (up to the gas it borrowed, tracked by the frame-local `state_gas_from_gas_left` counter), then the reservoir. Undoing a state creation therefore restores the exact pools the charge drew from, so the two pools never drift into one another — `gas_left` is never inflated beyond `TX_MAX_GAS_LIMIT - intrinsic_gas`, and regular gas is never permanently stranded in the state-only reservoir. This LIFO refill also subsumes the exceptional-halt case: refilling into a child's `gas_left` and then consuming that `gas_left` leaves the reservoir at exactly its start-of-frame value, so no dedicated reservoir-reset rule is needed (see [Gas accounting for halts and reverts](#gas-accounting-for-halts-and-reverts)).
+State-gas refills are applied in last-in, first-out (LIFO) order: because charges draw from the reservoir first and from `gas_left` last, refills credit `gas_left` first (up to the gas it borrowed, tracked by the frame-local `state_gas_from_gas_left` counter), then the reservoir. Undoing a state creation therefore restores the exact pools the charge drew from, so the two pools never drift into one another — `gas_left` is never inflated beyond `TX_MAX_GAS_LIMIT - intrinsic_gas`, and execution gas is never permanently stranded in the state-only reservoir. This LIFO refill also subsumes the exceptional-halt case: refilling into a child's `gas_left` and then consuming that `gas_left` leaves the reservoir at exactly its start-of-frame value, so no dedicated reservoir-reset rule is needed (see [Gas accounting for halts and reverts](#gas-accounting-for-halts-and-reverts)).
 
 #### Higher throughput
 
@@ -382,17 +382,17 @@ Another advantage of metering contract creation separately is that increasing th
 
 #### Calldata floor in block accounting
 
-The [EIP-7623](./eip-7623.md) calldata floor (raised further by [EIP-7976](./eip-7976.md)) bounds worst-case block size only because it participates in block gas accounting: a data-heavy transaction must occupy at least the floor's worth of the block gas limit, which is also what [EIP-7778](./eip-7778.md) preserves with `max(tx_gas_used, calldata_floor_gas_cost)`. Omitting the floor from the two-dimensional accounting would let such a transaction pay the floor while contributing only its pre-floor gas to `block_regular_gas_used`, re-expanding the maximum bytes per block by the ratio of floor to standard calldata pricing and hiding the difference from the base-fee update. The transaction-validity check `max(intrinsic_gas, calldata_floor_gas_cost) <= TX_MAX_GAS_LIMIT` does not provide this bound: it caps a single transaction's calldata against the [EIP-7825](./eip-7825.md) transaction limit but contributes nothing to the block's cumulative counters, so a block could otherwise be filled with individually valid transactions whose floors were paid but never counted.
+The [EIP-7623](./eip-7623.md) calldata floor (raised further by [EIP-7976](./eip-7976.md)) bounds worst-case block size only because it participates in block gas accounting: a data-heavy transaction must occupy at least the floor's worth of the block gas limit, which is also what [EIP-7778](./eip-7778.md) preserves with `max(tx_gas_used, calldata_floor_gas_cost)`. Omitting the floor from the two-dimensional accounting would let such a transaction pay the floor while contributing only its pre-floor gas to `block_execution_gas_used`, re-expanding the maximum bytes per block by the ratio of floor to standard calldata pricing and hiding the difference from the base-fee update. The transaction-validity check `max(intrinsic_gas, calldata_floor_gas_cost) <= TX_MAX_GAS_LIMIT` does not provide this bound: it caps a single transaction's calldata against the [EIP-7825](./eip-7825.md) transaction limit but contributes nothing to the block's cumulative counters, so a block could otherwise be filled with individually valid transactions whose floors were paid but never counted.
 
-The floor is compared against the transaction's regular-gas portion (`tx_gas_used_after_refund - tx_state_gas`, or the before-refund equivalent under [EIP-7778](./eip-7778.md)) rather than the transaction total. This is the per-dimension restatement of [EIP-7623](./eip-7623.md)'s existing rule, not a new restriction. Under single-dimensional accounting, gas spent on execution may absorb the floor, and this is sound because the absorbing gas occupies the very block budget the floor protects: with or without the floor binding, a transaction carrying `B` calldata bytes occupies at least the floor's worth of block gas, which is the invariant that bounds bytes per block. Regular gas — including execution gas — retains exactly this absorbing role here.
+The floor is compared against the transaction's execution-gas portion (`tx_gas_used_after_refund - tx_state_gas`, or the before-refund equivalent under [EIP-7778](./eip-7778.md)) rather than the transaction total. This is the per-dimension restatement of [EIP-7623](./eip-7623.md)'s existing rule, not a new restriction. Under single-dimensional accounting, gas spent on execution may absorb the floor, and this is sound because the absorbing gas occupies the very block budget the floor protects: with or without the floor binding, a transaction carrying `B` calldata bytes occupies at least the floor's worth of block gas, which is the invariant that bounds bytes per block. Execution gas retains exactly this absorbing role here.
 
-What the per-dimension comparison rules out is absorption *across* dimensions. State-gas occupies the state dimension's separate budget, so under a transaction-total comparison (`max(tx_gas_used_after_refund, calldata_floor_gas_cost) - tx_state_gas`) a transaction padded with state creation would enter its calldata into the regular dimension below the floor rate. The bytes-per-block bound would then no longer be a property of the regular dimension: it would hold only to the extent that the padding fills the state dimension, making the effective calldata bound a function of the state-gas schedule (`CPSB` and the per-item byte sizes) and silently weakening it whenever that schedule is re-derived. The per-dimension comparison keeps the bound unconditional and independent of state-gas pricing.
+What the per-dimension comparison rules out is absorption *across* dimensions. State-gas occupies the state dimension's separate budget, so under a transaction-total comparison (`max(tx_gas_used_after_refund, calldata_floor_gas_cost) - tx_state_gas`) a transaction padded with state creation would enter its calldata into the execution dimension below the floor rate. The bytes-per-block bound would then no longer be a property of the execution dimension: it would hold only to the extent that the padding fills the state dimension, making the effective calldata bound a function of the state-gas schedule (`CPSB` and the per-item byte sizes) and silently weakening it whenever that schedule is re-derived. The per-dimension comparison keeps the bound unconditional and independent of state-gas pricing.
 
 A consequence of the per-dimension comparison is that the sum of a transaction's block-accounted gas across dimensions can exceed the gas its sender pays; this is intentional — block accounting bounds resource consumption per dimension, while the payment rule remains the transaction-level floor of [EIP-7623](./eip-7623.md).
 
 #### State-gas refills under [EIP-7778](./eip-7778.md)
 
-[EIP-7778](./eip-7778.md) counts refunds toward block gas because a refund rebates work that was actually performed: a refunded `SSTORE` executed and its computational cost was real, so the rebate is an incentive, not evidence of less work. A state-gas refill is the opposite case. State-gas meters durable state growth, and a refill fires only when that growth is undone — the resource the dimension meters was never consumed. Counting gross (pre-refill) state-gas would make `block_state_gas_used` overstate actual state growth and invalidate the `CPSB` derivation, which assumes the block's state-gas approximates bytes written to state. There is no smuggling vector in excluding refills: the transient computation of rolled-back operations remains fully counted, since their regular-gas charges stay consumed and, under [EIP-7778](./eip-7778.md), are counted before refunds.
+[EIP-7778](./eip-7778.md) counts refunds toward block gas because a refund rebates work that was actually performed: a refunded `SSTORE` executed and its computational cost was real, so the rebate is an incentive, not evidence of less work. A state-gas refill is the opposite case. State-gas meters durable state growth, and a refill fires only when that growth is undone — the resource the dimension meters was never consumed. Counting gross (pre-refill) state-gas would make `block_state_gas_used` overstate actual state growth and invalidate the `CPSB` derivation, which assumes the block's state-gas approximates bytes written to state. There is no smuggling vector in excluding refills: the transient computation of rolled-back operations remains fully counted, since their execution-gas charges stay consumed and, under [EIP-7778](./eip-7778.md), are counted before refunds.
 
 ### Account-creation charging and [EIP-7928](./eip-7928.md)
 
@@ -404,7 +404,7 @@ An earlier revision of this EIP instead charged the account-creation portion unc
 
 Placement of the charge among the remaining alternatives:
 
-- **Why not charge after the create frame exits?** Up to 63/64 of the parent's regular gas is forwarded to the child, and deployment code may legitimately consume nearly all of it. Deferring the charge until the frame returns could make an otherwise-successful deployment fail with out-of-gas at frame exit, introducing semantic uncertainty.
+- **Why not charge after the create frame exits?** Up to 63/64 of the parent's execution gas is forwarded to the child, and deployment code may legitimately consume nearly all of it. Deferring the charge until the frame returns could make an otherwise-successful deployment fail with out-of-gas at frame exit, introducing semantic uncertainty.
 - **Why not charge inside the create frame?** That would silently move the out-of-gas condition from the parent frame (the pre-existing behavior for account-creation charges) to the child frame. Charging in the creating frame, right after the destination access and before the 63/64ths split, keeps the out-of-gas locus and the forwarded-gas computation identical to the `CALL*` family.
 
 For the `CALL*` family the charge remains conditional and is unchanged: the callee is already resolved (including [EIP-7702](./eip-7702.md) delegation resolution) before the child frame, so there is no deferred-access conflict, and unconditionally pre-charging every call would create significant compatibility concerns (e.g., Solidity's `address.transfer()` forwards no gas to the child frame).
@@ -417,7 +417,7 @@ This is a backwards-incompatible gas repricing that requires a scheduled network
 
 Wallet developers and node operators MUST update gas estimation handling to accommodate the new state creation costs and the two-dimensional metering model. Specifically:
 
-- Wallets: Wallets using `eth_estimateGas` MUST be updated to ensure they correctly account for the updated state creation costs and report `tx.gas` covering both the regular-gas and state-gas dimensions. Failure to do so could result in underestimating gas, leading to failed transactions.
+- Wallets: Wallets using `eth_estimateGas` MUST be updated to ensure they correctly account for the updated state creation costs and report `tx.gas` covering both the execution-gas and state-gas dimensions. Failure to do so could result in underestimating gas, leading to failed transactions.
 - Node Software: RPC methods such as `eth_estimateGas` MUST incorporate the new state-gas charges, the reservoir-model accounting, and the two-dimensional block accounting when computing gas estimates.
 
 Users can maintain their usual workflows without modification, as wallet and RPC updates will handle these changes.
@@ -430,7 +430,7 @@ This does not affect existing networks where these factories are already deploye
 
 ### Estimated price impacts
 
-Users and dApp developers will experience an increase in transaction costs associated with creating a new state. The next table summarizes the state-gas portion of state creation costs for common operations under the proposed `CPSB` of 1,530. Additional regular-gas charges (e.g., `ACCOUNT_WRITE`, `STORAGE_WRITE`, hash cost) defined in [EIP-8038](./eip-8038.md) apply on top.
+Users and dApp developers will experience an increase in transaction costs associated with creating a new state. The next table summarizes the state-gas portion of state creation costs for common operations under the proposed `CPSB` of 1,530. Additional execution-gas charges (e.g., `ACCOUNT_WRITE`, `STORAGE_WRITE`, hash cost) defined in [EIP-8038](./eip-8038.md) apply on top.
 
 | Case | Current gas cost | Proposed gas cost | Gas cost increase | Proposed cost (ETH) |
 |:---:|---|---|---|---|


### PR DESCRIPTION
## Summary

Terminology and metadata update for EIP-8037 (multidimensional state-creation
metering). No changes to the gas model, formulas, or values.

## Changes

- **Terminology.** Renamed the "regular gas" dimension to "execution gas"
  throughout, for consistency with the rest of the multidimensional-metering
  spec:
  - prose: "regular-gas" → "execution-gas", "New Regular Gas" → "New Execution Gas"
  - counters/variables: `execution_regular_gas_used` → `evm_execution_gas_used`,
    `execution_state_gas_used` → `evm_state_gas_used`,
    `regular_gas_available` → `execution_gas_available`,
    `block_regular_gas_used` → `block_execution_gas_used`,
    `tx_regular_gas` → `tx_execution_gas`,
    `execution_gas`/`regular_gas_budget` → `evm_gas`/`execution_gas_budget`
- **`requires`:** now `161, 684, 2780, 6780, 7610, 7623, 7702, 7825, 7928, 7976, 8038`
  (added `161`, `684`, `7610`; removed `7904`, `7981`).

Purely renaming/metadata; all pricing, reservoir mechanics, and LIFO refill rules
are unchanged.
