### PR TITLE
Update EIP-8141: allow direct evaluation of protocol-defined validation prefixes

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -765,6 +765,14 @@ A node MUST drop a frame transaction from the public mempool if it contains an `
 
 The generic validation trace and opcode rules below apply to all frames in the validation prefix except a `pay` frame whose target runtime code exactly matches the canonical paymaster implementation. The canonical paymaster implementation is explicitly designed to be safe for public mempool use and is therefore admitted by code match, successful `APPROVE(APPROVE_PAYMENT)`, and the paymaster accounting rules in this section, rather than by requiring it to satisfy each generic validation rule individually.
 
+#### Direct Evaluation of Protocol-Defined Frames
+
+Three frame species in the validation prefix have fully protocol-defined semantics, leaving no deployed code whose behavior a node would need to discover by execution: a frame whose resolved target has the empty code hash (default code), an expiry verifier frame whose runtime code at `EXPIRY_VERIFIER` matches the canonical expiry verifier code, and a `pay` frame admitted by canonical paymaster code match per the previous section.
+
+When every frame in the validation prefix is one of these, direct evaluation of the protocol-defined semantics is equivalent to simulation, and a node MAY use it to satisfy the validation requirements below. Direct evaluation MUST apply the same limits as simulation: signature validation and the evaluated frames' work count against `MAX_VERIFY_GAS`, and the paymaster accounting rules in this section apply unchanged.
+
+The complete state dependency set of such a validation prefix is: the sender's code hash and nonce, the payer's code hash and balance (or the canonical paymaster's tracked state), the runtime code at `EXPIRY_VERIFIER` together with the frame's deadline when an expiry verifier frame is present, and the current block timestamp. Nodes SHOULD index pending transactions by this set so that head-of-chain changes are revalidated without re-execution.
+
 #### Validation Trace Rules
 
 A public mempool node must simulate the validation prefix and reject the transaction if any of the following occurs before `payer` has been set:


### PR DESCRIPTION
The mempool section requires nodes to simulate the validation prefix, but three frame species have fully protocol-defined semantics with no deployed code to discover by execution: default code (spec text, not bytecode), the canonical expiry verifier, and the canonical paymaster -- which this section already admits by code match instead of the generic trace rules. For a prefix made only of these, simulation and direct evaluation are the same computation. This makes that equivalence explicit and enumerates the state the admission decision actually depends on.

Why it is worth spelling out: the common flows -- `self_verify` EOA-style transactions and canonical-paymaster-sponsored transactions, with or without an expiry frame -- land entirely in this class. The paragraph pins three things:

- their admission cost is signature checks plus a few state reads, no EVM and no tracing infrastructure;
- `MAX_VERIFY_GAS` accounting is identical on both paths, so the two admission strategies accept exactly the same set of transactions;
- revalidation on head changes needs only the enumerated dependency set (sender code hash and nonce, payer code hash and balance or paymaster tracked state, the `EXPIRY_VERIFIER` code and deadline when present, and the block timestamp), not re-execution.

No behavior changes for any other prefix; a prefix containing any other frame (including `deploy`, which calls arbitrary factory code) falls through to the existing trace rules unchanged.
