### PR TITLE
Update EIP-8141: specify the APPROVE opcode gas cost

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -533,6 +533,10 @@ The behavior of `APPROVE` is defined as follows:
         - If `resolved_target` has insufficient balance, revert the frame.
         - Set `sender_approved = true`, increment the sender's nonce, set `payer = resolved_target`, and collect the transaction's maximum cost (`TXPARAM(0x06)`) from `payer`.
 
+#### Gas
+
+`APPROVE` charges only the memory expansion gas for the return-data region `[offset, offset + length)`, with no additional base cost, matching `RETURN`. Updating the transaction-scoped approval context has no gas cost.
+
 ### Introspection
 
 The instructions in this section provide the needed introspection capabilities of the new frame transaction type and the frame objects themselves, including some runtime information like the execution result status.

--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -535,7 +535,7 @@ The behavior of `APPROVE` is defined as follows:
 
 #### Gas
 
-`APPROVE` charges only the memory expansion gas for the return-data region `[offset, offset + length)`, with no additional base cost, matching `RETURN`. Updating the transaction-scoped approval context has no gas cost.
+`APPROVE` charges only the memory expansion gas for the return-data region `[offset, offset + length)`, with no additional base cost, matching `RETURN`. Updating the transaction-scoped approval context has no gas cost: its once-per-transaction effects — the sender nonce increment, setting `payer`, and collecting the maximum cost — are already covered by the frame transaction's intrinsic cost, exactly as they are for a standard transaction, so charging nothing extra here is consistent pricing rather than a free state write.
 
 ### Introspection
 


### PR DESCRIPTION
The `APPROVE` (`0xaa`) instruction is the only new frame-transaction opcode whose gas cost is left unspecified. Every other new opcode states it — `TXPARAM` and `FRAMEPARAM` cost `2`, `FRAMEDATALOAD` costs `3`, and `FRAMEDATACOPY` gives a formula — but the `APPROVE` section documents Stack, Scope, and Behavior with no gas.

`APPROVE` "exits the current EVM call frame successfully", and its `offset`/`length` operands designate return data "following `RETURN` semantics". This pins the gas to match `RETURN`: memory expansion for the `[offset, offset + length)` region, no additional base cost, and no cost for the approval-context update.

An undefined per-opcode gas cost is a latent cross-client divergence (all nodes must agree on exact gas for the state root); this closes it.
