### PR TITLE
Update EIP-8141: canonical P256 sender account for no-simulation admission

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -865,15 +865,15 @@ available_paymaster_balance = state.balance(paymaster) - reserved_pending_cost(p
 
 #### Canonical P256 sender account
 
-Analogous to the [canonical paymaster](#canonical-paymaster), a *canonical P256 sender account* is a standardized sender-account implementation whose validation prefix a public mempool node admits by runtime-code match, without applying the generic validation trace and opcode rules. It extends protocol-defined, no-simulation admission — available today to `SECP256K1` senders through [default code](#default-code) — to `P256` (secp256r1) senders such as passkey / WebAuthn wallets delegated via an [EIP-7702](./eip-7702.md) indicator.
+Analogous to the [canonical paymaster](#canonical-paymaster), a *canonical P256 sender account* is a standardized sender-account implementation whose validation prefix a public mempool node admits by a stable canonical identity, without applying the generic validation trace and opcode rules. It extends protocol-defined, no-simulation admission — available today to `SECP256K1` senders through [default code](#default-code) — to `P256` (secp256r1) senders such as passkey / WebAuthn wallets delegated via an [EIP-7702](./eip-7702.md) indicator.
 
 For public mempool purposes, a `self_verify` or `only_verify` frame is admitted under this rule if and only if:
 
-- the runtime code at `resolved_target` (following the EIP-7702 delegation indicator) exactly matches the canonical P256 sender account implementation,
+- `resolved_target` resolves to the canonical P256 sender account of the active fork by stable identity - either an [EIP-7702](./eip-7702.md) delegation to the reserved `CANONICAL_P256_ACCOUNT` address (installed at activation, versioned by address), or a runtime code hash equal to the canonical implementation code hash pinned for the active fork - rather than by an exact-runtime-bytecode comparison against an unpinned implementation,
 - the frame successfully calls `APPROVE` with a scope matching `frame.flags`, and
 - there is exactly one `P256` signature at `sig_index` (as defined in [default code](#default-code)) whose `resolved_signer` matches the account's configured secp256r1 credential and `sig.msg == Bytes()`.
 
-The single `P256` verification counts against `MAX_VERIFY_GAS` at the `P256` signature validation cost. Because the implementation is standardized to be safe for public mempool use, nodes identify it by runtime-code match and apply this rule rather than requiring the frame to satisfy each generic validation rule individually.
+The single `P256` verification counts against `MAX_VERIFY_GAS` at the `P256` signature validation cost. Because the implementation is standardized to be safe for public mempool use, nodes identify it by this stable canonical identity and apply this rule rather than requiring the frame to satisfy each generic validation rule individually. Recognizing the account by a reserved address or a pinned code hash, rather than by exact runtime-bytecode equality, keeps it versionable and avoids propagation fragmentation when the same source compiles to slightly different bytecode across toolchains.
 
 The account's authorized secp256r1 credential is held in the account's own storage. Because admission reads it, that slot is part of the transaction's mempool dependency set — rotating the credential invalidates the sender's pending transactions — and its storage layout is normative for each canonical implementation version. As with the canonical paymaster's single secp256k1 signer, this account authorizes with a single secp256r1 credential and may change in later specifications, in which case a new canonical implementation version would be required.
 

--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -863,6 +863,18 @@ available_paymaster_balance = state.balance(paymaster) - reserved_pending_cost(p
 
 [See here for rationale](#non-canonical-paymasters-in-the-mempool) for enabling non-canonical paymasters in the mempool.
 
+#### Canonical P256 sender account
+
+Analogous to the [canonical paymaster](#canonical-paymaster), a *canonical P256 sender account* is a standardized sender-account implementation whose validation prefix a public mempool node admits by runtime-code match, without applying the generic validation trace and opcode rules. It extends protocol-defined, no-simulation admission — available today to `SECP256K1` senders through [default code](#default-code) — to `P256` (secp256r1) senders such as passkey / WebAuthn wallets delegated via an [EIP-7702](./eip-7702.md) indicator.
+
+For public mempool purposes, a `self_verify` or `only_verify` frame is admitted under this rule if and only if:
+
+- the runtime code at `resolved_target` (following the EIP-7702 delegation indicator) exactly matches the canonical P256 sender account implementation,
+- the frame successfully calls `APPROVE` with a scope matching `frame.flags`, and
+- there is exactly one `P256` signature at `sig_index` (as defined in [default code](#default-code)) whose `resolved_signer` matches the account's configured secp256r1 credential and `sig.msg == Bytes()`.
+
+The single `P256` verification counts against `MAX_VERIFY_GAS` at the `P256` signature validation cost. Because the implementation is standardized to be safe for public mempool use, nodes identify it by runtime-code match and apply this rule rather than requiring the frame to satisfy each generic validation rule individually. As with the canonical paymaster, the canonical P256 account authorizes with a single secp256r1 credential and may change in later specifications, in which case a new canonical implementation version would be required.
+
 #### Acceptance Algorithm
 
 1. A transaction is received over the wire and the node decides whether to accept or reject it.

--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -873,7 +873,9 @@ For public mempool purposes, a `self_verify` or `only_verify` frame is admitted 
 - the frame successfully calls `APPROVE` with a scope matching `frame.flags`, and
 - there is exactly one `P256` signature at `sig_index` (as defined in [default code](#default-code)) whose `resolved_signer` matches the account's configured secp256r1 credential and `sig.msg == Bytes()`.
 
-The single `P256` verification counts against `MAX_VERIFY_GAS` at the `P256` signature validation cost. Because the implementation is standardized to be safe for public mempool use, nodes identify it by runtime-code match and apply this rule rather than requiring the frame to satisfy each generic validation rule individually. As with the canonical paymaster, the canonical P256 account authorizes with a single secp256r1 credential and may change in later specifications, in which case a new canonical implementation version would be required.
+The single `P256` verification counts against `MAX_VERIFY_GAS` at the `P256` signature validation cost. Because the implementation is standardized to be safe for public mempool use, nodes identify it by runtime-code match and apply this rule rather than requiring the frame to satisfy each generic validation rule individually.
+
+The account's authorized secp256r1 credential is held in the account's own storage. Because admission reads it, that slot is part of the transaction's mempool dependency set — rotating the credential invalidates the sender's pending transactions — and its storage layout is normative for each canonical implementation version. As with the canonical paymaster's single secp256k1 signer, this account authorizes with a single secp256r1 credential and may change in later specifications, in which case a new canonical implementation version would be required.
 
 #### Acceptance Algorithm
 


### PR DESCRIPTION
## Motivation

EIP-8141's protocol-defined, no-simulation admission paths — default code, the canonical paymaster, and the expiry verifier (the last formalized in #12001) — are `SECP256K1`-only. Passkey / WebAuthn wallets (secp256r1) are a large and growing share of smart accounts, but today an [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702)-delegated P256 account must be admitted through full validation-prefix simulation under the generic trace rules, even though its validation is a single P256 signature check.

This adds a **canonical P256 sender account** recognized by runtime-code match — the secp256r1 analog of the canonical paymaster — so a P256 `self_verify` / `only_verify` frame is admitted by code match + one `P256VERIFY` + scope check, with no wallet-code simulation. It is intended to compose with #12001's "protocol-defined frames" direct-evaluation set as a fourth species alongside default code, the expiry verifier, and the canonical paymaster.

This directly answers the fair validation-cost critique of frames: it broadens the no-simulation admission surface to match the breadth of curated schemes other native-AA proposals offer, while keeping everything block validity depends on inside the consensus spec.

## Resolved

- **Credential binding** — now pinned in the spec text: the account's secp256r1 credential is held in its own storage, so the slot is part of the transaction's mempool dependency set (a rotation invalidates the sender's pending transactions) and its layout is normative per canonical implementation version, mirroring the canonical paymaster's signer.

## Open questions (for discussion)

- **Canonical bytecode + versioning** — the exact reference implementation and its code-match set (the canonical paymaster's "many instances, one code" model).
- **Acceptance Algorithm integration** — extending step 4's code-match exception to the P256 verify frame; if #12001 lands, whoever merges second adds this account to its enumeration of protocol-defined species (no textual conflict).
