### PR TITLE
Update EIP-8141: bound the fee fields in the static constraints

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -122,6 +122,9 @@ Some validity constraints can be determined statically. They are outlined below:
 ```python
 assert tx.chain_id < 2**256
 assert tx.nonce < 2**64
+assert tx.max_priority_fee_per_gas < 2**256
+assert tx.max_fee_per_gas < 2**256
+assert tx.max_fee_per_blob_gas < 2**256
 assert len(tx.frames) > 0 and len(tx.frames) <= MAX_FRAMES
 assert len(tx.sender) == 20
 


### PR DESCRIPTION
The static Constraints block bounds `chain_id`, `nonce`, `frame.gas_limit`, and `frame.value`, but the three fee fields have no bounds anywhere in the spec. RLP admits arbitrarily long integers, and `TXPARAM` `0x03`/`0x04`/`0x05` push these fields onto the EVM stack, so an unbounded value would not fit a stack word. Adds the missing asserts in the block's existing style, next to the other scalar bounds.
