### PR TITLE
Update EIP-8141: define the transaction log set and unrolled-batch log semantics

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -385,7 +385,7 @@ Then for each frame:
 1. If a frame is part of an atomic batch and it fails, unroll the associated atomic batch.
     - An **atomic batch** is a maximal contiguous sequence of frames `[i, j]` where `j > i`, frames `i` through `j - 1` have `ATOMIC_BATCH_FLAG` set, and frame `j` does not have `ATOMIC_BATCH_FLAG` set.
     - When a frame in the batch fails, the state must be rolled back to the condition it was immediately before the atomic batch began. All remaining frames in the atomic batch are skipped.
-    - Logs emitted by frames that executed before the failure are discarded together with their state changes when the batch is unrolled. Those frames' receipts retain their execution status and gas used, with empty logs; batch membership remains readable from the transaction's frame flags.
+    - Logs emitted by frames that executed before the failure are discarded together with their state changes when the batch is unrolled. Those frame receipts retain their execution status and gas used, with empty logs.
     - Since skipped frames are not executed, the gas value allotted to them is refunded at the end of the transaction.
     - If the frame does not have an associated atomic batch, further special handling is not needed, simple revert the individual frame.
 

--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -210,7 +210,7 @@ The `ReceiptPayload` is defined as:
 frame_receipt = [status, gas_used, logs]
 ```
 
-`payer` is the address of the account that paid the fees for the transaction. `status` is the return code of the top-level call. A new code `0x2` is introduced for frames which are skipped due to failed atomic batch. `gas_used` is total gas used by the frame, not accounting for refunds. `cumulative_gas_used` is still computed by adding the total gas used by the transaction with the previous cumulative sum.
+`payer` is the address of the account that paid the fees for the transaction. `status` is the return code of the top-level call. A new code `0x2` is introduced for frames which are skipped due to failed atomic batch. `gas_used` is total gas used by the frame, not accounting for refunds. `cumulative_gas_used` is still computed by adding the total gas used by the transaction with the previous cumulative sum. The transaction's logs, for the purposes of the block header `logsBloom` and log indexing, are the concatenation of the `logs` fields of its frame receipts, in frame order.
 
 #### Signature Hash
 
@@ -385,6 +385,7 @@ Then for each frame:
 1. If a frame is part of an atomic batch and it fails, unroll the associated atomic batch.
     - An **atomic batch** is a maximal contiguous sequence of frames `[i, j]` where `j > i`, frames `i` through `j - 1` have `ATOMIC_BATCH_FLAG` set, and frame `j` does not have `ATOMIC_BATCH_FLAG` set.
     - When a frame in the batch fails, the state must be rolled back to the condition it was immediately before the atomic batch began. All remaining frames in the atomic batch are skipped.
+    - Logs emitted by frames that executed before the failure are discarded together with their state changes when the batch is unrolled. Those frames' receipts retain their execution status and gas used, with empty logs; batch membership remains readable from the transaction's frame flags.
     - Since skipped frames are not executed, the gas value allotted to them is refunded at the end of the transaction.
     - If the frame does not have an associated atomic batch, further special handling is not needed, simple revert the individual frame.
 


### PR DESCRIPTION
The receipt encoding defines per-frame logs but never defines the transaction's log set: nothing states what feeds the block header `logsBloom` or log indexing for a type-0x06 transaction, and nothing states what happens to logs emitted by frames that executed inside an atomic batch that later unrolled. Two clients can agree on the receipt encoding and still disagree on the header bloom.

Two sentences close it:

- the transaction's logs are the concatenation of its frame receipts' logs, in frame order;
- an unrolled frame's logs are discarded together with its state changes, matching EVM revert semantics (rolled-back logs never happened). Its receipt keeps the execution status and gas used with empty logs, and batch membership remains readable from the transaction's frame flags, so the batch outcome stays reconstructible.

Found while writing block-level receipt tests: keeping unrolled logs inside frame receipts while excluding them from the transaction's log set makes receipts diverge from the bloom.
