### PR TITLE
Update EIP-7997: simplify spec, clarify rationale

### DIFF
--- a/EIPS/eip-7997.md
+++ b/EIPS/eip-7997.md
@@ -42,6 +42,8 @@ The chain's state MUST include `FACTORY_ADDRESS` with runtime code:
 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf3
 ```
 
+This is checked at the fork activation block. If the exact code is not present, the block is invalid. If [EIP-7928](./eip-7928.md) is active or activated at the fork activation block, this thus inserts an account read at block access list index 0 into the BAL.
+
 This is a contract that invokes the `CREATE2` instruction ([EIP-1014](./eip-1014.md)) with a salt equal to the first 32 bytes of the call's input data, init code equal to the remaining data, and value equal to the call's value. If input data is smaller than 32 bytes, the contract will attempt to copy close to 2^256 bytes of calldata and should revert as a result. If contract creation fails (`CREATE2` outputs `0`), the call reverts with empty return data. When successful, the address is returned in exactly 20 bytes of data with no padding.
 
 The above runtime bytecode disassembles to the following:

--- a/EIPS/eip-7997.md
+++ b/EIPS/eip-7997.md
@@ -32,15 +32,15 @@ Keyless transactions have been the most successful approach. However, since such
 
 ## Specification
 
+The key words "MUST", "MUST NOT", "REQUIRED", "SHOULD", "SHOULD NOT", and "MAY" in this document are to be interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119) and [RFC 8174](https://www.rfc-editor.org/rfc/rfc8174).
+
 * `FACTORY_ADDRESS` = `0x4e59b44847b379578588920cA78FbF26c0B4956C`
 
-The chain's state MUST include `FACTORY_ADDRESS` with nonzero nonce and this runtime code:
+The chain's state MUST include `FACTORY_ADDRESS` with runtime code:
 
 ```
 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf3
 ```
-
-A chain may satisfy this requirement by either of the following means that results in the account above: deploying the factory with an ordinary transaction (for example, its keyless creation transaction) where the chain's gas parameters permit it, or including the account in the genesis state with a nonce equal to `1`. Regardless of the method used, the resulting `FACTORY_ADDRESS` account MUST have the runtime code specified above. If the chain is already running with gas parameters that no longer allow deployment via the keyless transaction, the only way to add the contract at the expected address is a coordinated irregular state transition, which is outside the scope of this EIP. Client software MUST NOT check for the existence of the contract at the fork boundary.
 
 This is a contract that invokes the `CREATE2` instruction ([EIP-1014](./eip-1014.md)) with a salt equal to the first 32 bytes of the call's input data, init code equal to the remaining data, and value equal to the call's value. If input data is smaller than 32 bytes, the contract will attempt to copy close to 2^256 bytes of calldata and should revert as a result. If contract creation fails (`CREATE2` outputs `0`), the call reverts with empty return data. When successful, the address is returned in exactly 20 bytes of data with no padding.
 
@@ -95,6 +95,10 @@ The factory at `0x4e59b44847b379578588920cA78FbF26c0B4956C` has been used close 
 The bytecode is compatible with any EVM chain that has activated EIP-1014, which Ethereum included in Constantinople. In particular, it does not depend on the more recent `PUSH0` ([EIP-3855](./eip-3855.md)).
 
 Two known downsides of this factory were considered. First, the address of the created account is returned with no padding, and may need to be decoded differently to other address-returning calls. Second, returndata is not propagated in case of revert, and an EVM trace may be required for obtaining a diagnostic error message. Both issues were considered non-blocking due to the existence of workarounds, including the possibility of using this factory to deploy further improved factories. Notably, if such factories are fully deterministic and permissionlessly deployable (and only require baseline EVM features), they are guaranteed to exist or be deployable at the same address on the same set of chains.
+
+### Meeting factory existence requirements
+
+A chain may satisfy this requirement by either of the following means that results in the account above: deploying the factory with an ordinary transaction (for example, its keyless creation transaction) where the chain's gas parameters permit it, or including the account in the genesis state with a nonce equal to `1`. Regardless of the method used, the resulting `FACTORY_ADDRESS` account MUST have the runtime code specified above. If the chain is already running with gas parameters that no longer allow deployment via the keyless transaction, a way to add the contract at the expected address is a coordinated irregular state transition, which is outside the scope of this EIP. Client software MUST NOT check for the existence of the contract at the fork boundary. This EIP merely guarantees that once this EIP is active, the referenced code exists at the `FACTORY_ADDRESS`.
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
This simplifies EIP-7997 and is a "counter-PR" to https://github.com/ethereum/EIPs/pull/11991

EIP-7997 only guarantees that contract code exists at the `FACTORY_ADDRESS`. This is what we enshrine. This is a no-op for Mainnet.
We do not specify what happens if the code is incorrect. 
This EIP "simply" guarantees that once this EIP is included in a fork, runtime code exists at an address.
There are no explicit checks (this interferes with BAL)
There are also no definitions if this contract does not exist. The only guarantee of this EIP is that the `FACTORY_ADDRESS` has specific runtime code.

I also removed the "nonzero nonce" part. For the EVM, it does not matter if the nonce is 0 or not. The only opcode invoked here is CREATE2, not CREATE. There is also no DELEGATECALL. So in this context, the nonce has no purpose, except that you can use it to count the amount of contracts created. For mainnet this is `nonce - 1`, for chains where the contract is inserted this is `current_nonce - original_nonce`.
I believe we should not specify this. The only specification or guarantee this EIP gives is that code exists at a specific address, nothing more. If it does not exist, the EIP cannot be activated (or active). If this is not clear from text, we/I should clarify. We do not introduce any specifications about inserting it, because this is the responsibility of the target chain.
If we include such specs, then this is part of the canonical test suite, which is something I think we do not want.

Discussions either here or to the EIP-7997 thread https://discord.com/channels/595666850260713488/1521881988288479272/1523103379893653605

CC @frangio @marioevz @nerolation 

Note: this is my view on how the EIP should look like, with a focus on the Specification part, because I believe this is what "matters" in the end (this defines the spec). I could put the nonzero nonce back, but am (again) convinced that this is not necessary. Users want the CREATE2 code at an address, and thats it. Nothing more.