### PR TITLE
Update EIP-8141: recognize the canonical paymaster by stable identity, not exact bytecode match

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -784,7 +784,7 @@ A node MUST drop a frame transaction from the public mempool if it contains an `
 
 #### Canonical Paymaster Exception
 
-The generic validation trace and opcode rules below apply to all frames in the validation prefix except a `pay` frame whose target runtime code exactly matches the canonical paymaster implementation. The canonical paymaster implementation is explicitly designed to be safe for public mempool use and is therefore admitted by code match, successful `APPROVE(APPROVE_PAYMENT)`, and the paymaster accounting rules in this section, rather than by requiring it to satisfy each generic validation rule individually.
+The generic validation trace and opcode rules below apply to all frames in the validation prefix except a `pay` frame whose target is a canonical paymaster instance (recognized by stable identity, per [Canonical paymaster](#canonical-paymaster)). The canonical paymaster is explicitly designed to be safe for public mempool use and is therefore admitted by that identity match, successful `APPROVE(APPROVE_PAYMENT)`, and the paymaster accounting rules in this section, rather than by requiring it to satisfy each generic validation rule individually.
 
 #### Direct Evaluation of Protocol-Defined Frames
 
@@ -856,7 +856,7 @@ We address this conflict in two ways:
 
 ##### Canonical paymaster
 
-The canonical paymaster is not a singleton deployment. Many instances may be deployed. For public mempool purposes, a paymaster instance is considered canonical if and only if the runtime code at the `pay` frame target exactly matches the canonical paymaster implementation.
+The canonical paymaster is not a singleton deployment. Many instances may be deployed. For public mempool purposes, a paymaster instance is considered canonical if and only if the `pay` frame target resolves to the canonical paymaster of the active fork by stable identity - either an [EIP-7702](./eip-7702.md) delegation to the reserved `CANONICAL_PAYMASTER` address, or a runtime code hash equal to the canonical paymaster code hash pinned for the active fork - rather than by an exact-runtime-bytecode comparison against an unpinned implementation. Recognizing instances by a reserved address or a pinned code hash keeps the canonical paymaster versionable and avoids propagation fragmentation when the same source compiles to slightly different bytecode across toolchains.
 
 The canonical paymaster in this draft authorizes with a single secp256k1 signer via `ecrecover`, does not support contract-signature schemes, and may change in later specifications, in which case a new canonical implementation version would be required.
 
@@ -897,7 +897,7 @@ available_paymaster_balance = state.balance(paymaster) - reserved_pending_cost(p
 1. A transaction is received over the wire and the node decides whether to accept or reject it.
 2. The node validates all protocol-validated signatures and structurally checks all `ARBITRARY` signatures. If any signature is malformed or invalid, reject.
 3. The node analyzes the frame structure and determines the validation prefix. If the prefix is not one of the recognized prefixes, reject.
-4. The node simulates the validation prefix and enforces the structural and trace rules above, except that a `pay` frame whose target runtime code exactly matches the canonical paymaster implementation is handled via the canonical paymaster exception and the paymaster-specific rules below.
+4. The node simulates the validation prefix and enforces the structural and trace rules above, except that a `pay` frame whose target is a canonical paymaster instance (recognized by stable identity, per [Canonical paymaster](#canonical-paymaster)) is handled via the canonical paymaster exception and the paymaster-specific rules below.
 5. The node records the sender storage slots read during validation. Calls into helper contracts do not create additional mutable-state dependencies unless they cause disallowed storage access under the trace rules above.
 6. If a canonical paymaster instance is used, the node verifies paymaster solvency using the reservation rule above.
 7. A node should keep at most one pending frame transaction per sender in the public mempool. A new transaction from the same sender MAY replace the existing one only if it uses the same nonce and satisfies the node's fee bump rules.


### PR DESCRIPTION
**Draft / RFC.** Recognize a canonical paymaster instance by a **stable identity** - an EIP-7702 delegation to a reserved `CANONICAL_PAYMASTER` address, or a runtime code hash pinned for the active fork - instead of an exact-runtime-bytecode comparison against an unpinned "canonical paymaster implementation".

## Why

The spec admits a `pay` frame without the generic trace rules iff its target's runtime code "exactly matches the canonical paymaster implementation". Two problems:

- That implementation is not pinned in the spec (it is TBD), so "exactly matches" has no concrete referent.
- Exact-bytecode equality is fragile: the same source compiles to slightly different bytecode across compiler versions/toolchains, so nodes could disagree on whether an instance is canonical - fragmenting mempool propagation. It also makes the canonical paymaster hard to version.

## Change

Define canonical recognition by stable identity - a reserved address reached via an EIP-7702 delegation (installed and versioned like other predeploys), or a fork-pinned code hash - and update the two references in the validation trace rules and the Acceptance Algorithm to match. The "many instances" model is preserved: every instance shares the reserved delegation target or the pinned hash.

The same principle is applied to the canonical P256 sender account in #12004.
