### PR TITLE
Update EIP-8141: formalize the signature scheme registry

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -201,6 +201,21 @@ The explicit 32-byte zero digest is invalid. This reserves the zero stack value 
 
 For `P256`, the signer address must be `keccak256(qx || qy)[12:]`.
 
+#### Signature scheme registry
+
+The `scheme` table above is a *registry* maintained in this consensus specification: the set of accepted signature schemes, and the exact validation and gas of each, are protocol constants that every node evaluates identically. New schemes are added by a network upgrade that appends a registry entry; there is no out-of-protocol allowlist or companion document a node must track to decide validity.
+
+Each registry entry defines:
+
+- a one-byte `scheme` id from the reserved `0x03..0xFF` space;
+- a **verifier**: a precompile or protocol-enshrined verification routine that reduces the raw `signature` (with the `signer` metadata) to accept or reject, so a node validates a scheme entry without executing account code;
+- a **fixed `signature_verification_cost`** counted against the transaction gas and, in the public mempool, against `MAX_VERIFY_GAS`; and
+- a **signer-derivation rule** producing the resolved signer address (for example `keccak256(qx || qy)[12:]` for `P256`).
+
+Because entries are fixed-cost, precompile-backed, and evaluated with no account-code execution, a scheme validates in constant time and is safe for public-mempool admission - the same property a curated-authenticator design obtains, but with the accepted set living in the consensus specification rather than an out-of-protocol allowlist, so nodes cannot diverge on which schemes are valid.
+
+A registry entry MAY verify more than one signature at once (an aggregate scheme), consistent with the raw `signature` bytes of protocol-validated schemes being non-introspectable by EVM code. The `ARBITRARY` (`0x0`) scheme is the escape hatch for any scheme not yet in the registry: its witness is verified by ordinary account EVM in a validation frame, priced at the `ARBITRARY` cost and bounded by `MAX_VERIFY_GAS`, and its raw bytes are introspectable and therefore not aggregatable. A scheme graduates from `ARBITRARY` to a registry entry once it warrants enshrined, fixed-cost, mempool-friendly support.
+
 #### Receipt Encoding
 
 The `ReceiptPayload` is defined as:


### PR DESCRIPTION
Formalizes EIP-8141's `scheme` table as an in-protocol **signature scheme registry**, following the discussion in #12004: a signature scheme is a cryptographic operation the protocol provides optimized support for, not an account.

## What

Adds a "Signature scheme registry" subsection defining:

- the accepted scheme set, and each scheme's validation and gas, as consensus-spec constants - no out-of-protocol allowlist or companion document a node must track to decide validity;
- a registry-entry structure: a one-byte id from the reserved `0x03..0xFF` space, a precompile/enshrined verifier (no account-code execution), a fixed verification cost (counted against tx gas and `MAX_VERIFY_GAS`), and a signer-derivation rule;
- the growth process: new schemes are added by a network upgrade that appends an entry;
- aggregation-awareness: an entry MAY verify multiple signatures at once, consistent with the existing rule that protocol-validated raw signature bytes are non-introspectable by EVM code;
- `ARBITRARY` (`0x0`) as the escape hatch for schemes not yet in the registry, from which a scheme graduates to a registry entry once it warrants enshrined, fixed-cost, mempool-friendly support.

## Why

This gives the cheap, fixed-cost, no-account-code signature validation a curated-authenticator design offers, while keeping the accepted set in the consensus specification so nodes cannot diverge on validity. It canonicalizes the naturally-small signature layer in the L1-appropriate place (the spec, not an external allowlist) and leaves the naturally-diverse account/policy layer to arbitrary account code.

No behavior change to the existing `0x0`/`0x1`/`0x2` schemes - this makes the registry model and its extension process explicit.
