### PR TITLE
CI: Replace deprecated artifact download action in workflows

### DIFF
--- a/.github/workflows/auto-review-bot.yml
+++ b/.github/workflows/auto-review-bot.yml
@@ -13,13 +13,20 @@ jobs:
     name: Run
     steps:
       - name: Fetch PR Number
+        env:
+          GH_TOKEN: ${{ github.token }}
         id: fetch-pr-number
-        uses: dawidd6/action-download-artifact@246dbf436b23d7c49e21a7ab8204ca9ecd1fe615
-        continue-on-error: true
-        with:
-          name: pr-number
-          workflow: auto-review-trigger.yml
-          run_id: ${{ github.event.workflow_run.id }}
+        run: |
+          artifact_id="$(gh api repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/artifacts --jq '.artifacts[] | select(.name == "pr-number") | .id' | head -n 1)"
+
+          if [ -z "$artifact_id" ]; then
+            echo "pr-number artifact not found for workflow run ${{ github.event.workflow_run.id }}"
+            exit 0
+          fi
+
+          gh api repos/${{ github.repository }}/actions/artifacts/$artifact_id/zip > pr-number.zip
+          unzip -o pr-number.zip
+          rm -f pr-number.zip
 
       - name: Check PR Number file
         id: check-pr-number

--- a/.github/workflows/auto-review-bot.yml
+++ b/.github/workflows/auto-review-bot.yml
@@ -8,21 +8,35 @@ on:
 name: Auto Review Bot
 jobs:
   auto-review-bot:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     name: Run
     steps:
       - name: Fetch PR Number
+        id: fetch-pr-number
         uses: dawidd6/action-download-artifact@246dbf436b23d7c49e21a7ab8204ca9ecd1fe615
+        continue-on-error: true
         with:
           name: pr-number
           workflow: auto-review-trigger.yml
           run_id: ${{ github.event.workflow_run.id }}
 
+      - name: Check PR Number file
+        id: check-pr-number
+        run: |
+          if [ -f pr-number.txt ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Save PR Number
+        if: steps.check-pr-number.outputs.exists == 'true'
         id: save-pr-number
-        run: echo "pr=$(cat pr-number.txt)" >> $GITHUB_OUTPUT
+        run: echo "pr=$(cat pr-number.txt)" >> "$GITHUB_OUTPUT"
 
       - name: Auto Review Bot
+        if: steps.check-pr-number.outputs.exists == 'true'
         id: auto-review-bot
         uses: ethereum/eip-review-bot@dist
         continue-on-error: true

--- a/.github/workflows/post-ci.yml
+++ b/.github/workflows/post-ci.yml
@@ -14,18 +14,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch PR Data
-        uses: dawidd6/action-download-artifact@246dbf436b23d7c49e21a7ab8204ca9ecd1fe615
-        with:
-          name: pr_number
-          workflow: ci.yml
-          run_id: ${{ github.event.workflow_run.id }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          artifact_id="$(gh api repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/artifacts --jq '.artifacts[] | select(.name == "pr_number") | .id' | head -n 1)"
+
+          if [ -z "$artifact_id" ]; then
+            echo "pr_number artifact not found for workflow run ${{ github.event.workflow_run.id }}"
+            exit 1
+          fi
+
+          gh api repos/${{ github.repository }}/actions/artifacts/$artifact_id/zip > pr_number.zip
+          unzip -o pr_number.zip
+          rm -f pr_number.zip
 
       - name: Save PR Data
         id: save-pr-data
         run: |
-          echo "pr_number=$(cat pr_number)" >> $GITHUB_OUTPUT
-          echo "pr_sha=$(cat pr_sha)" >> $GITHUB_OUTPUT
-          echo "merge_sha=$(cat merge_sha)" >> $GITHUB_OUTPUT
+          echo "pr_number=$(cat pr/pr_number)" >> "$GITHUB_OUTPUT"
+          echo "pr_sha=$(cat pr/pr_sha)" >> "$GITHUB_OUTPUT"
+          echo "merge_sha=$(cat pr/merge_sha)" >> "$GITHUB_OUTPUT"
 
       - name: Add Comment
         uses: marocchino/sticky-pull-request-comment@39c5b5dc7717447d0cba270cd115037d32d28443


### PR DESCRIPTION
## Summary

Replace deprecated artifact download usage in review-related workflows.

## Changes

- switch `auto-review-bot.yml` from `dawidd6/action-download-artifact` to `gh api`
- keep auto review execution gated on `pr-number.txt` existing
- switch `post-ci.yml` to the same artifact download approach
- read PR metadata from the unpacked `pr/` artifact paths

## Motivation

Recent runs were failing due to Node 20 deprecation warnings and missing-artifact handling in the auto review flow.

## Validation

Validated both workflow files locally with no reported errors.
