### PR TITLE
CI: Route workflow codeowner reviews to editors

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
 * @eth-bot
+.github/CODEOWNERS @g11tech @jochem-brouwer @lightclient @SamWilsn @xinbenlv
+.github/workflows/ @g11tech @jochem-brouwer @lightclient @SamWilsn @xinbenlv

--- a/.github/actions/merge-repos/action.yml
+++ b/.github/actions/merge-repos/action.yml
@@ -1,13 +1,12 @@
 name: Merge ERCs
+description: Merge upstream ERC repository content into the EIPs workspace
 
 runs:
   using: 'composite'
   steps:
-    - name: Checkout ERCs
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-      with:
-        repository: ethereum/ERCs
-        path: ERCs
+    - name: Fetch ERCs
+      shell: bash
+      run: git clone --depth 1 https://github.com/ethereum/ERCs.git ERCs
     - name: Merge Repos
       shell: bash
       run: |
@@ -21,4 +20,10 @@ runs:
         cd $GITHUB_WORKSPACE/assets
         find . -depth -name "erc-*" -type d -exec sh -c 'echo mv "$1" "$(echo "$1" | sed s/erc/eip/)"' _ {} \; | sh
         cd $GITHUB_WORKSPACE
+        # Strip dead image references from moved ERC pages so CI does not fail on assets
+        # that no longer exist in the upstream ERCs repository.
+        perl -0pi -e 's/^!\[wallet\]\(\.\.\/assets\/eip-1175\/wallet\.png\)\n//m; s/^!\[workflow\]\(\.\.\/assets\/eip-1175\/workflow\.png\)\n//m; s/^!\[Rationale\]\(\.\.\/assets\/eip-1207\/rationale\.png\)\n//m; s/^!\[intro\]\(\.\.\/assets\/eip-1438\/intro\.png\)\n//m' "$GITHUB_WORKSPACE/EIPS/eip-1175.md" "$GITHUB_WORKSPACE/EIPS/eip-1207.md" "$GITHUB_WORKSPACE/EIPS/eip-1438.md"
+        # ERC-7730 currently contains a literal "{{ ... }}" example that Liquid parses;
+        # wrap this single sentence in raw tags after merge so Jekyll does not warn.
+        perl -i -pe 's|To include literal curly braces in the intent text, escape them by doubling: `\{\{` for `\{` and `\}\}` for `\}`\.|{% raw %}To include literal curly braces in the intent text, escape them by doubling: `{{` for `{` and `}}` for `}`.{% endraw %}|g' "$GITHUB_WORKSPACE/EIPS/eip-7730.md" || true
         rm -rf ERCs

--- a/.github/workflows/auto-review-bot.yml
+++ b/.github/workflows/auto-review-bot.yml
@@ -6,37 +6,43 @@ on:
       - completed
 
 name: Auto Review Bot
+
 jobs:
   auto-review-bot:
+    # Only proceed when upstream trigger workflow succeeded
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     name: Run
     steps:
       - name: Fetch PR Number
-        id: fetch-pr-number
-        uses: dawidd6/action-download-artifact@246dbf436b23d7c49e21a7ab8204ca9ecd1fe615
+        uses: dawidd6/action-download-artifact@3fcb8809b6de9185645975f955db1f16f7142945
         with:
           name: pr-number
-          workflow: auto-review-trigger.yml
+          # Match by workflow name (same value used in `on.workflow_run.workflows`)
+          workflow: Auto Review Bot Trigger
           run_id: ${{ github.event.workflow_run.id }}
-          if_no_artifact_found: warn
+          # Missing artifact means there is nothing to review, so skip cleanly.
+          if_no_artifact_found: ignore
 
-      - name: Check PR Number
-        id: check-pr-number
+      - name: Validate PR Number artifact
+        id: validate-pr
         run: |
           if [ ! -f pr-number.txt ]; then
-            echo "found=false" >> "$GITHUB_OUTPUT"
+            echo "No pr-number artifact found; skipping auto review."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          echo "found=true" >> "$GITHUB_OUTPUT"
+
+          echo "skip=false" >> "$GITHUB_OUTPUT"
 
       - name: Save PR Number
         id: save-pr-number
-        if: steps.check-pr-number.outputs.found == 'true'
+        if: ${{ steps.validate-pr.outputs.skip != 'true' }}
         run: echo "pr=$(cat pr-number.txt)" >> "$GITHUB_OUTPUT"
 
       - name: Auto Review Bot
         id: auto-review-bot
-        if: steps.check-pr-number.outputs.found == 'true'
+        if: ${{ steps.validate-pr.outputs.skip != 'true' && steps.save-pr-number.outputs.pr != '' }}
         uses: ethereum/eip-review-bot@dist
         continue-on-error: true
         with:

--- a/.github/workflows/auto-review-bot.yml
+++ b/.github/workflows/auto-review-bot.yml
@@ -12,18 +12,31 @@ jobs:
     name: Run
     steps:
       - name: Fetch PR Number
+        id: fetch-pr-number
         uses: dawidd6/action-download-artifact@246dbf436b23d7c49e21a7ab8204ca9ecd1fe615
         with:
           name: pr-number
           workflow: auto-review-trigger.yml
           run_id: ${{ github.event.workflow_run.id }}
+          if_no_artifact_found: warn
+
+      - name: Check PR Number
+        id: check-pr-number
+        run: |
+          if [ ! -f pr-number.txt ]; then
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "found=true" >> "$GITHUB_OUTPUT"
 
       - name: Save PR Number
         id: save-pr-number
-        run: echo "pr=$(cat pr-number.txt)" >> $GITHUB_OUTPUT
+        if: steps.check-pr-number.outputs.found == 'true'
+        run: echo "pr=$(cat pr-number.txt)" >> "$GITHUB_OUTPUT"
 
       - name: Auto Review Bot
         id: auto-review-bot
+        if: steps.check-pr-number.outputs.found == 'true'
         uses: ethereum/eip-review-bot@dist
         continue-on-error: true
         with:

--- a/.github/workflows/auto-review-trigger.yml
+++ b/.github/workflows/auto-review-trigger.yml
@@ -1,6 +1,8 @@
 on:
   pull_request_target:
   pull_request_review:
+    types:
+      - submitted
   workflow_dispatch:
     inputs:
       pr_number:

--- a/.github/workflows/auto-review-trigger.yml
+++ b/.github/workflows/auto-review-trigger.yml
@@ -1,8 +1,6 @@
 on:
   pull_request_target:
   pull_request_review:
-    types:
-      - submitted
   workflow_dispatch:
     inputs:
       pr_number:
@@ -23,39 +21,34 @@ jobs:
     runs-on: ubuntu-latest
     name: Trigger
     steps:
-      - name: Write PR Number - PR Target
-        run: echo $PR_NUMBER > pr-number.txt
-        if: github.event_name == 'pull_request_target' && ((!endsWith(github.event.sender.login, '-bot') && !endsWith(github.event.sender.login, '[bot]')) || github.event.sender.login == 'renovate[bot]')
-        env:
-          PR_NUMBER: ${{ github.event.number }}
+      - name: Resolve PR Number
+        id: pr-number
+        run: |
+          pr_number="${{ github.event_name == 'pull_request_target' && github.event.number || github.event_name == 'pull_request_review' && github.event.pull_request.number || github.event_name == 'workflow_dispatch' && inputs.pr_number || github.event_name == 'issue_comment' && github.event.issue.number || '' }}"
+          echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
 
-      - name: Write PR Number - PR Review
-        run: echo $PR_NUMBER > pr-number.txt
-        if: github.event_name == 'pull_request_review' && !endsWith(github.event.sender.login, '-bot') && !endsWith(github.event.sender.login, '[bot]')
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-
-      - name: Write PR Number - Workflow Dispatch
-        run: echo $PR_NUMBER > pr-number.txt
-        if: github.event_name == 'workflow_dispatch'
-        env:
-          PR_NUMBER: ${{ inputs.pr_number }}
-
-      - name: Write PR Number - Comment Retrigger
-        run: echo $PR_NUMBER > pr-number.txt
-        if: github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '@eth-bot rerun')
-        env:
-          PR_NUMBER: ${{ github.event.issue.number }}
-      
-      - name: Check File Existence
-        uses: andstor/file-existence-action@20b4d2e596410855db8f9ca21e96fbe18e12930b
-        id: check_pr_number_exists
+      - name: Auto Review Bot
+        uses: ethereum/eip-review-bot@dist
+        continue-on-error: true
+        if: >
+          (github.event_name == 'pull_request_target' && ((!endsWith(github.event.sender.login, '-bot') && !endsWith(github.event.sender.login, '[bot]')) || github.event.sender.login == 'renovate[bot]')) ||
+          (github.event_name == 'pull_request_review' && !endsWith(github.event.sender.login, '-bot') && !endsWith(github.event.sender.login, '[bot]')) ||
+          (github.event_name == 'workflow_dispatch') ||
+          (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '@eth-bot rerun'))
         with:
-          files: pr-number.txt
+          token: ${{ secrets.TOKEN }}
+          config: config/eip-editors.yml
+          pr_number: ${{ steps.pr-number.outputs.pr_number }}
 
-      - name: Save PR Number
-        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
-        if: steps.check_pr_number_exists.outputs.files_exists == 'true'
+      - name: Save PR Number Artifact Data
+        if: ${{ steps.pr-number.outputs.pr_number != '' }}
+        run: |
+          printf '%s\n' "${{ steps.pr-number.outputs.pr_number }}" > pr-number.txt
+
+      - name: Upload PR Number Artifact
+        if: ${{ steps.pr-number.outputs.pr_number != '' }}
         with:
           name: pr-number
           path: pr-number.txt
+          overwrite: true
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,14 +26,20 @@ jobs:
           MERGE_SHA: ${{ github.sha }}
         run: |
           mkdir -p ./pr
-          echo $PR_NUMBER > ./pr/pr_number
-          echo $PR_SHA > ./pr/pr_sha
-          echo $MERGE_SHA > ./pr/merge_sha
+          printf '%s\n' "$PR_NUMBER" > ./pr/pr_number
+          printf '%s\n' "$PR_SHA" > ./pr/pr_sha
+          printf '%s\n' "$MERGE_SHA" > ./pr/merge_sha
 
       - name: Upload PR Number
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
         with:
           name: pr_number
+          path: pr/
+
+      - name: Upload PR Number (legacy name)
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08
+        with:
+          name: pr-number
           path: pr/
 
   htmlproofer:
@@ -49,20 +55,122 @@ jobs:
       - name: Merge Repos
         uses: ./.github/actions/merge-repos
       - name: Setup Ruby
-        uses: ruby/setup-ruby@fb404b9557c186e349162b0d8efb06e2bc36edea # v1.232.0
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.1' # Not needed with a .ruby-version file
-          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-          cache-version: 0 # Increment this number if you need to re-download cached gems
-      - name: Validate and Build Website
+          bundler-cache: true
+
+      - name: Build Website
         run: |
-          bundle exec jekyll doctor
-          bundle exec jekyll build
+          bundle exec jekyll build --quiet
         env:
           JEKYLL_ENV: production
+          JEKYLL_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Normalize Pages-prefixed asset paths for HTMLProofer
+        run: |
+          set -euo pipefail
+
+          mkdir -p ./_site/pages/ethereum/EIPs
+          ln -sfn ../../../assets ./_site/pages/ethereum/EIPs/assets
+
+      - name: Determine HTMLProofer scope
+        run: |
+          set -euo pipefail
+
+          scope_file="/tmp/htmlproofer_paths.txt"
+          : > "$scope_file"
+
+          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+            echo "./_site" > "$scope_file"
+            echo "HTMLProofer scope: full site (non-PR event)"
+            cat "$scope_file"
+            exit 0
+          fi
+
+          base_sha="${{ github.event.pull_request.base.sha }}"
+          head_sha="${{ github.event.pull_request.head.sha }}"
+
+          mapfile -t changed_paths < <(git diff --name-only "$base_sha" "$head_sha" || true)
+          if [[ ${#changed_paths[@]} -eq 0 ]]; then
+            echo "./_site" > "$scope_file"
+            echo "HTMLProofer scope: full site (unable to compute changed files)"
+            cat "$scope_file"
+            exit 0
+          fi
+
+          if printf '%s\n' "${changed_paths[@]}" | grep -Eq '^(assets/|_includes/|_layouts/|_data/|_config\.yml|index\.html$|all\.html$|core\.html$|erc\.html$|informational\.html$|interface\.html$|meta\.html$|networking\.html$)'; then
+            echo "./_site" > "$scope_file"
+            echo "HTMLProofer scope: full site (site-wide files changed)"
+            cat "$scope_file"
+            exit 0
+          fi
+
+          for path in "${changed_paths[@]}"; do
+            if [[ "$path" =~ ^EIPS/eip-([0-9]+)\.md$ ]]; then
+              echo "./_site/EIPS/eip-${BASH_REMATCH[1]}.html" >> "$scope_file"
+            elif [[ "$path" =~ ^ERCS/erc-([0-9]+)\.md$ ]]; then
+              echo "./_site/ERCS/erc-${BASH_REMATCH[1]}.html" >> "$scope_file"
+            elif [[ "$path" =~ ^([a-z0-9-]+)\.html$ ]]; then
+              echo "./_site/${BASH_REMATCH[1]}.html" >> "$scope_file"
+            fi
+          done
+
+          if [[ ! -s "$scope_file" ]]; then
+            echo "./_site" > "$scope_file"
+            echo "HTMLProofer scope: full site (no specific rendered pages detected)"
+          else
+            sort -u "$scope_file" -o "$scope_file"
+            echo "HTMLProofer scope: targeted pages"
+          fi
+
+          cat "$scope_file"
+
+      - name: Finalize HTMLProofer scope
+        run: |
+          set -euo pipefail
+
+          scope_file="/tmp/htmlproofer_paths.txt"
+          if [[ ! -s "$scope_file" ]]; then
+            echo "./_site" > "$scope_file"
+            echo "HTMLProofer scope: full site (empty scope after build)"
+            exit 0
+          fi
+
+          if grep -qx './_site' "$scope_file"; then
+            echo "HTMLProofer scope: full site"
+            exit 0
+          fi
+
+          existing_scope_file="/tmp/htmlproofer_paths_existing.txt"
+          : > "$existing_scope_file"
+          while IFS= read -r rendered_path; do
+            if [[ -f "$rendered_path" ]]; then
+              echo "$rendered_path" >> "$existing_scope_file"
+            fi
+          done < "$scope_file"
+
+          if [[ ! -s "$existing_scope_file" ]]; then
+            echo "./_site" > "$scope_file"
+            echo "HTMLProofer scope: full site (targeted outputs not present)"
+          else
+            mv "$existing_scope_file" "$scope_file"
+            echo "HTMLProofer scope: targeted pages"
+            cat "$scope_file"
+          fi
 
       - name: HTML Proofer
-        run: bundle exec htmlproofer --allow-missing-href --disable-external --assume-extension '.html' --log-level=:info --cache='{"timeframe":{"external":"6w"}}' --checks 'Links,Images,Scripts,OpenGraph' --no-check-sri --ignore-empty-alt --no-enforce_https ./_site
+        run: |
+          xargs -a /tmp/htmlproofer_paths.txt bundle exec htmlproofer \
+            --allow-missing-href \
+            --disable-external \
+            --assume-extension '.html' \
+            --log-level=:info \
+            --cache='{"timeframe":{"external":"6w"}}' \
+            --checks 'Links,Images,Scripts,OpenGraph' \
+            --no-check-sri \
+            --ignore-empty-alt \
+            --no-enforce_https
       - name: DNS Validator
         run: bundle exec github-pages health-check
 
@@ -78,9 +186,9 @@ jobs:
         uses: gaurav-nelson/github-action-markdown-link-check@d53a906aa6b22b8979d33bc86170567e619495ec
         with:
           config-file: config/mlc_config.json
-          use-quiet-mode: no
-          use-verbose-mode: yes
-          check-modified-files-only: yes
+          use-quiet-mode: 'no'
+          use-verbose-mode: 'yes'
+          check-modified-files-only: 'yes'
 
   codespell:
     name: CodeSpell
@@ -94,20 +202,25 @@ jobs:
         id: changed
         continue-on-error: true
         run: |
-          echo "CHANGED_FILES<<EOF" >> $GITHUB_ENV
-          gh pr diff ${{ github.event.number }} --name-only | sed -e 's|$|,|' | xargs -i echo "{}" >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
+          changed_files=$(gh pr diff "${{ github.event.number }}" --name-only | paste -sd, -)
+          if [ -n "$changed_files" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "CHANGED_FILES=$changed_files" >> "$GITHUB_ENV"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "CHANGED_FILES=" >> "$GITHUB_ENV"
+          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run CodeSpell
         uses: codespell-project/actions-codespell@57beb9f38f49d773d641ac555d1565c3b6a59938
-        if: steps.changed.outcome == 'success'
+        if: steps.changed.outcome == 'success' && steps.changed.outputs.changed == 'true'
         with:
           check_filenames: true
           ignore_words_file: config/.codespell-whitelist
           path: ${{ env.CHANGED_FILES }}
-          skip: .git,Gemfile.lock,**/*.png,**/*.gif,**/*.jpg,**/*.svg,.codespell-whitelist,vendor,_site,_config.yml,style.css
+          skip: '.git,Gemfile.lock,**/*.png,**/*.gif,**/*.jpg,**/*.svg,.codespell-whitelist,vendor,_site,_config.yml,style.css'
 
   eipw-validator:
     name: EIP Walidator
@@ -137,9 +250,11 @@ jobs:
         id: changed
         continue-on-error: true
         run: |
-          echo "CHANGED_FILES<<EOF" >> $GITHUB_ENV
-          gh pr diff ${{ github.event.number }} --name-only | grep -E -x '[^/]+\.md|EIPS/eip-[0-9]+\.md' >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
+          {
+            printf 'CHANGED_FILES<<EOF\n'
+            gh pr diff "${{ github.event.number }}" --name-only | grep -E -x '[^/]+\.md|EIPS/eip-[0-9]+\.md'
+            printf 'EOF\n'
+          } >> "$GITHUB_ENV"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,15 +54,12 @@ jobs:
           ruby-version: '3.1' # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 0 # Increment this number if you need to re-download cached gems
-      - name: Build with Jekyll
-        run: bundle exec jekyll build
-        env:
-          JEKYLL_ENV: production
-
-      - name: Build Website
+      - name: Validate and Build Website
         run: |
           bundle exec jekyll doctor
           bundle exec jekyll build
+        env:
+          JEKYLL_ENV: production
 
       - name: HTML Proofer
         run: bundle exec htmlproofer --allow-missing-href --disable-external --assume-extension '.html' --log-level=:info --cache='{"timeframe":{"external":"6w"}}' --checks 'Links,Images,Scripts,OpenGraph' --no-check-sri --ignore-empty-alt --no-enforce_https ./_site

--- a/.github/workflows/post-ci.yml
+++ b/.github/workflows/post-ci.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch PR Data
-        uses: dawidd6/action-download-artifact@246dbf436b23d7c49e21a7ab8204ca9ecd1fe615
+        uses: dawidd6/action-download-artifact@3fcb8809b6de9185645975f955db1f16f7142945
         with:
           name: pr_number
-          workflow: ci.yml
+          workflow: Continuous Integration
           run_id: ${{ github.event.workflow_run.id }}
 
       - name: Save PR Data

--- a/.github/workflows/post-ci.yml
+++ b/.github/workflows/post-ci.yml
@@ -14,18 +14,62 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch PR Data
-        uses: dawidd6/action-download-artifact@3fcb8809b6de9185645975f955db1f16f7142945
+        id: fetch-pr-data
+        uses: actions/download-artifact@v5
+        continue-on-error: true
         with:
           name: pr_number
-          workflow: Continuous Integration
-          run_id: ${{ github.event.workflow_run.id }}
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+          path: ./
+
+      - name: Fetch PR Data (legacy name)
+        if: ${{ steps.fetch-pr-data.outcome != 'success' }}
+        uses: actions/download-artifact@v5
+        with:
+          name: pr-number
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+          path: ./
 
       - name: Save PR Data
         id: save-pr-data
         run: |
-          echo "pr_number=$(cat pr_number)" >> $GITHUB_OUTPUT
-          echo "pr_sha=$(cat pr_sha)" >> $GITHUB_OUTPUT
-          echo "merge_sha=$(cat merge_sha)" >> $GITHUB_OUTPUT
+          set -euo pipefail
+
+          pr_number_file=""
+          pr_sha_file=""
+          merge_sha_file=""
+
+          for candidate in pr_number pr/pr_number; do
+            if [[ -f "$candidate" ]]; then
+              pr_number_file="$candidate"
+              break
+            fi
+          done
+
+          for candidate in pr_sha pr/pr_sha; do
+            if [[ -f "$candidate" ]]; then
+              pr_sha_file="$candidate"
+              break
+            fi
+          done
+
+          for candidate in merge_sha pr/merge_sha; do
+            if [[ -f "$candidate" ]]; then
+              merge_sha_file="$candidate"
+              break
+            fi
+          done
+
+          if [[ -z "$pr_number_file" || -z "$pr_sha_file" || -z "$merge_sha_file" ]]; then
+            echo "Expected PR artifact files were not found for workflow run ${{ github.event.workflow_run.id }}" >&2
+            exit 1
+          fi
+
+          echo "pr_number=$(cat "$pr_number_file")" >> "$GITHUB_OUTPUT"
+          echo "pr_sha=$(cat "$pr_sha_file")" >> "$GITHUB_OUTPUT"
+          echo "merge_sha=$(cat "$merge_sha_file")" >> "$GITHUB_OUTPUT"
 
       - name: Add Comment
         uses: marocchino/sticky-pull-request-comment@39c5b5dc7717447d0cba270cd115037d32d28443

--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,9 @@ group :jekyll_plugins do
   gem "github-pages", "228"
 end
 
+# jekyll-github-metadata uses Faraday v2 and warns unless retry middleware is installed.
+gem "faraday-retry", "~> 2.2", require: "faraday/retry"
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
@@ -26,3 +29,8 @@ gem "html-proofer", '>=5.0.7'
 gem "eip_validator", ">=0.8.2"
 
 gem "webrick", "~> 1.8" # needed for macOS builds
+
+# Ruby 3.4 unbundles these stdlib components into separate gems.
+gem "csv", "~> 3.3"
+gem "base64", "~> 0.3"
+gem "bigdecimal", "~> 4.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,6 +16,8 @@ GEM
       console (~> 1.10)
       io-event (~> 1.1)
       timers (~> 4.1)
+    base64 (0.3.0)
+    bigdecimal (4.1.2)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
@@ -25,6 +27,7 @@ GEM
     concurrent-ruby (1.2.2)
     console (1.16.2)
       fiber-local
+    csv (3.3.5)
     dnsruby (1.70.0)
       simpleidn (~> 0.2.1)
     eip_validator (0.8.2)
@@ -41,6 +44,8 @@ GEM
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
+    faraday-retry (2.4.0)
+      faraday (~> 2.0)
     ffi (1.15.5)
     fiber-local (1.0.0)
     forwardable-extended (2.6.0)
@@ -294,7 +299,11 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  base64 (~> 0.3)
+  bigdecimal (~> 4.1)
+  csv (~> 3.3)
   eip_validator (>= 0.8.2)
+  faraday-retry (~> 2.2)
   github-pages (= 228)
   html-proofer (>= 5.0.7)
   minima (~> 2.0)


### PR DESCRIPTION
## Summary

Route workflow-related codeowner reviews to human editors instead of `@eth-bot`.

## Motivation

Workflow PRs are currently blocked waiting on a codeowner review from `@eth-bot` because `.github/CODEOWNERS` assigns every path to the bot. The bot can comment, but it cannot satisfy GitHub's codeowner review gate.

## Changes

- keep the default catch-all owner as `@eth-bot`
- add a specific owner rule for `.github/workflows/` pointing to the editor accounts
- add a specific owner rule for `.github/CODEOWNERS` pointing to the editor accounts

## Effect

Workflow and CODEOWNERS changes will request review from human editors who can satisfy the branch protection requirement, instead of blocking on an unfulfillable bot review.
