### PR TITLE
Update EIP-7773: SFI remaining Glamsterdam EIPs

### DIFF
--- a/EIPS/eip-7773.md
+++ b/EIPS/eip-7773.md
@@ -20,6 +20,9 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Declined
 
 ### EIPs Scheduled for Inclusion
 
+* [EIP-2780](./eip-2780.md): Reduce intrinsic transaction gas
+* [EIP-7610](./eip-7610.md): Revert creation in case of non-empty storage
+* [EIP-7688](./eip-7688.md): Forward compatible consensus data structures
 * [EIP-7708](./eip-7708.md): ETH transfers emit a log
 * [EIP-7732](./eip-7732.md): Enshrined Proposer-Builder Separation
 * [EIP-7778](./eip-7778.md): Block Gas Accounting without Refunds
@@ -28,15 +31,9 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Declined
 * [EIP-7954](./eip-7954.md): Increase Maximum Contract Size
 * [EIP-7976](./eip-7976.md): Increase Calldata Floor Cost
 * [EIP-7981](./eip-7981.md): Increase Access List Cost
+* [EIP-7997](./eip-7997.md): Deterministic Factory Predeploy
 * [EIP-8024](./eip-8024.md): Backward compatible SWAPN, DUPN, EXCHANGE
 * [EIP-8037](./eip-8037.md): State Creation Gas Cost Increase
-
-### Considered for Inclusion
-
-* [EIP-2780](./eip-2780.md): Reduce intrinsic transaction gas
-* [EIP-7610](./eip-7610.md): Revert creation in case of non-empty storage
-* [EIP-7688](./eip-7688.md): Forward compatible consensus data structures
-* [EIP-7997](./eip-7997.md): Deterministic Factory Predeploy
 * [EIP-8038](./eip-8038.md): State-access gas cost increase
 * [EIP-8045](./eip-8045.md): Exclude slashed validators from proposing
 * [EIP-8061](./eip-8061.md): Increase exit and consolidation churn


### PR DESCRIPTION
Schedule for Inclusion the remaining CFI EIPs in Glamsterdam: EIP-2780, 7610, 7688, 7997, 8038, 8045, 8061, 8246 and 8282. Follow-up to #11399.