### PR TITLE
Update EIP-8141: clarify floor repricing, signature validation, and frame.value gas

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -284,6 +284,8 @@ def validate_signature(sig, tx_sender, sig_hash) -> bool:
         return False
 ```
 
+Signature validation is protocol-level cryptography, not EVM execution: `ecrecover` and `P256VERIFY` above denote the verification functions, not calls to the precompile accounts that expose the same operations. Validating the `signatures` list therefore accesses no precompile address, and in particular adds no entry for the [EIP-7951](./eip-7951.md) precompile to an [EIP-7928](./eip-7928.md) block-level access list, just as sender recovery of other transaction types does not access the `ecrecover` precompile. A precompile address is recorded there only when frame execution actually accesses it.
+
 #### Expiry Verifier Frame
 
 A `VERIFY` frame whose `frame.target` equals `EXPIRY_VERIFIER` is an **expiry verifier frame**. It calls the expiry verifier contract deployed at `EXPIRY_VERIFIER` with `frame.data` as calldata. The calldata is interpreted as an 8-byte unsigned big-endian expiry timestamp. The call reverts unless `block.timestamp <= expiry_timestamp`.
@@ -438,22 +440,26 @@ standard_gas_limit = (
     + sum(frame.gas_limit for all frames)
 )
 
-calldata_tokens = (
-    sum(tokens_in(frame.data) for frame in tx.frames)
-    + sum(tokens_in(sig.signer) + tokens_in(sig.msg) + tokens_in(sig.signature) for sig in tx.signatures)
+floor_data_cost = (
+    sum(floor_cost(frame.data) for frame in tx.frames)
+    + sum(floor_cost(sig.signer) + floor_cost(sig.msg) + floor_cost(sig.signature) for sig in tx.signatures)
 )
 
 calldata_floor_gas = (
     FRAME_TX_INTRINSIC_COST
     + len(tx.frames) * FRAME_TX_PER_FRAME_COST
     + signature_verification_cost
-    + TOTAL_COST_FLOOR_PER_TOKEN * calldata_tokens
+    + floor_data_cost
 )
 
 max_gas = max(standard_gas_limit, calldata_floor_gas)
 ```
 
+`floor_cost` is the calldata floor data cost function of the fork in force: under [EIP-7623](./eip-7623.md) it is `TOTAL_COST_FLOOR_PER_TOKEN * tokens_in(data)`, i.e. 10 gas per zero byte and 40 gas per non-zero byte; where a scheduled repricing of the calldata floor such as [EIP-7976](./eip-7976.md) is active, its floor parameters and token weighting apply instead, i.e. 64 gas per byte, zero and non-zero alike. Frame and signature data thus pay the same per-byte floor as calldata carried by any other transaction type at the same fork.
+
 Each frame has its own `gas_limit` allocation and the receipt reports the frame's gross gas used. These values do not generally sum to `gas_used`: the intrinsic, per-frame, calldata, and signature verification costs are charged outside frame gas limits, and the storage refund and calldata floor apply at the transaction level.
+
+Any `frame.value` transferred by a `SENDER` frame is separate from the transaction fee and follows ordinary `CALL` value-transfer semantics. The gas cost of sending `frame.value` is the same as for any `CALL` instruction and is charged within the frame's `gas_limit`, including the account-creation cost of the fork in force (for example [EIP-8037](./eip-8037.md), where scheduled) when the transfer creates the recipient account. A frame that cannot cover these costs reverts without transferring, so no [EIP-7708](./eip-7708.md) transfer log is emitted.
 
 Unused gas from a frame is **not** available to subsequent frames. Let `frame_receipts` be the ordered frame receipt list. After all frames, unused gas can be calculated as:
 

--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -311,6 +311,8 @@ def validate_signature(sig, tx_sender, sig_hash) -> bool:
         return False
 ```
 
+Note: since the signature validation does not happen in EVM execution, the related precompiles `ecrecover` and `P256VERIFY` must not be added to the block-level access list.
+
 #### Expiry Verifier Frame
 
 A `VERIFY` frame whose `frame.target` equals `EXPIRY_VERIFIER` is an **expiry verifier frame**. It calls the expiry verifier contract deployed at `EXPIRY_VERIFIER` with `frame.data` as calldata. The calldata is interpreted as an 8-byte unsigned big-endian expiry timestamp. The call reverts unless `block.timestamp <= expiry_timestamp`.


### PR DESCRIPTION
I'm implementing EIP-8141 in Nethermind and cross-testing against ethrex on a devnet. Three places in the current text can be read in more than one way, and we already hit real divergences from two of them. This PR proposes minimal wording to pin each one. It is a clarification request from an implementer, not a design change - Stavros, as the author, please confirm if these readings match the intent. Happy to switch any of them to the other reading if not.

### 1. Which calldata floor applies to frame and signature data

`calldata_floor_gas` charges `TOTAL_COST_FLOOR_PER_TOKEN * calldata_tokens`, but the constant is not defined in this EIP. The header requires EIP-7623 (value 10), and the sentence "as defined in EIP-7623" was removed in #11969 during the settlement restructure. EIP-7976 (scheduled for Glamsterdam) redefines that same constant to 16 and the floor token weighting to 4 tokens per byte, i.e. 64 gas per byte flat. Frame transactions exist only from a later fork (CFI for Hegota in EIP-8081), so both EIPs are active wherever a frame tx is valid, and the text supports three different results:

- 10/40: pin the constant to EIP-7623's table via the requires chain. Nethermind's integration branch implements this.
- 16/64: re-resolve the named constant to 16 but keep this EIP's inline token weighting. Probably nobody wants this, but it is the most literal composition of the two texts.
- 64/64: apply the floor model in force at the fork. ethrex main implements this (see lambdaclass/ethrex#7049).

So the two clients disagree today, and our cross-client devnet converged on floor = 10 only because we forced the same value into both integration branches - a shared value that cross-client testing cannot check against the spec. The proposed wording makes the floor fork-relative (64/64 wherever EIP-7976 is active), since the floor's purpose is a uniform per-byte bound across transaction types. If the intent is to pin 10/40 permanently, restoring the removed sentence is the right fix instead; either way the text should say which.

### 2. Signature validation vs EIP-7928 block access lists

`validate_signature` evaluates `P256VERIFY` (and `ecrecover`) as functions, outside EVM execution. EIP-7928 includes precompiles "when accessed", and neither EIP says whether protocol-level evaluation counts as accessing the `0x100` account. This produced a real split on our devnet: Nethermind recorded a read-only BAL entry for `0x...0100`, ethrex did not, and block 137 failed cross-validation (blockAccessListHash mismatch, 10 account entries vs 9). Both clients now agree on "no entry" only because we aligned them. The proposed sentence pins the reading that matches existing precedent: transaction sender recovery and EIP-7702 authority recovery never record the ecrecover precompile, and blob KZG verification never records the point evaluation precompile.

### 3. Gas of `frame.value` transfers

#11969 also removed "The gas cost of sending `frame.value` is the same as for any `CALL` instruction", so the cost of the top-level value transfer is now unspecified. With EIP-8037 the difference is large: an ordinary `CALL` that creates the recipient pays `STATE_BYTES_PER_NEW_ACCOUNT x CPSB` = 183,600 state gas, while a frame's top-level transfer currently creates the recipient account for no charge in both implementations (and always emits the EIP-7708 transfer log, where the regular path performs no transfer and emits no log when the creation charge cannot be paid). The proposed wording restores the removed sentence and makes the account-creation and transfer-log consequences explicit. If the intent is that the top-level frame transfer is deliberately unmetered, the text should state that instead.
