### PR TITLE
Update EIP-8297: point migration at EIP-8347, drop Verkle refs

### DIFF
--- a/EIPS/eip-8297.md
+++ b/EIPS/eip-8297.md
@@ -37,12 +37,13 @@ The Merkle Patricia Trie (MPT) is unfriendly to validity proofs: it uses RLP for
 node encoding, Keccak for hashing, is a "tree of trees", and does not allow for the efficient proving of segments of bytecode. It also produces large Merkle proofs. As an example, the account trie today reaches a maximum depth of about 12, so a
 branch at that depth is `15 * 32 * 12 = 5760` bytes: 15 sibling hashes of
 32 bytes at each of the 12 levels. From a worst-case block perspective, spending all
-60M gas to touch a single byte of many distinct account codes, none of which is
+`60M` gas to touch a single byte of many distinct account codes, none of which is
 chunked, needs `60M/2400 * (12*480 + 64k) ≈ 1.8GB`. Here `2400` is the cheapest gas
 to touch a fresh account, the [EIP-2930](./eip-2930.md) access-list address cost
 (a cold access under [EIP-2929](./eip-2929.md) costs `2600`); `12*480` is the
 branch to that account; and `64k` is the [EIP-7954](./eip-7954.md) 64 KiB code size
-limit that must be revealed in full to prove any single byte of unchunked code.
+limit that must be revealed in full to prove any single byte of code that is
+not chunked.
 
 A binary tree shrinks regular Merkle proofs, because proof size scales with
 `siblings * log_arity(N)` and arity 2 minimizes it. Switching from Keccak to a more
@@ -341,9 +342,9 @@ leaf needs one branch opening instead of three or four, which lowers gas and
 simplifies witness generation.
 
 Setting any header field also sets `version` to zero. `code_hash` and
-`code_size` are set on contract or EOA creation; a codeless account's code
-hash leaf holds the Keccak hash of empty bytecode, unaffected by this EIP's
-choice of merkelization hash (see "Backwards Compatibility").
+`code_size` are set on contract or EOA creation; the code hash leaf of an
+account with no code holds the Keccak hash of empty bytecode, unaffected by
+this EIP's choice of merkelization hash (see "Backwards Compatibility").
 
 ### Code
 
@@ -498,7 +499,7 @@ templates, so this removes a large amount of duplicate code from the state. For
 the same reason, a block witness contains at most one copy of a shared chunk, no
 matter how many contracts touch it. The first 128 chunks stay in the account
 header, keyed per account, so they expire with the account and need no reference
-counting. Only chunks beyond ~4 KB are deduplicated.
+counting. Only chunks beyond ~4 KB are shared between contracts.
 
 ### SNARK friendliness and post-quantum security
 
@@ -543,7 +544,7 @@ same `key_hash(address)`, up to 256 bits. Without compression this would
 produce long chains of branch nodes with a single occupied child. Folding
 the shared run into the branch's prefix (see "Tree structure") collapses
 each such chain to one node, which is also what bounds the proof-size cost
-of a grinded set of groups in "Security Considerations".
+of grinding a set of groups in "Security Considerations".
 
 ### State expiry
 
@@ -659,8 +660,8 @@ compression that buys a `k`-node chain for about `2^(k/2)` work.
 
 Compression folds the run into one `BranchNode` prefix of about `k/8`
 bytes (see "Tree depth"), and `d` real extra nodes cost about `2^d` work.
-The address in the digest stops cross-contract reuse, so a slot set grinded for one
-contract is random in every other.
+The address in the digest stops cross-contract reuse, so a slot set found by
+grinding for one contract is random in every other.
 
 **Preimage.** Every node's hash preimage begins with a one-byte tag
 (`LEAF_TAG` or `BRANCH_TAG`) distinguishing the two node types, and a

--- a/EIPS/eip-8297.md
+++ b/EIPS/eip-8297.md
@@ -458,10 +458,8 @@ fork.
 
 ## Rationale
 
-This EIP defines the tree; it does not define how existing state reaches
-it. Migration is specified in [EIP-8347](./eip-8347.md): the MPT state is
-converted offline and the tree activates fully populated at the fork,
-with no overlay phase and no in-consensus conversion.
+This EIP defines the tree; it does not define how existing state is converted to it. Migration is specified in [EIP-8347](./eip-8347.md): the MPT state is
+converted offline and the tree activates fully populated at the fork.
 
 ### Single tree with zones
 
@@ -500,7 +498,7 @@ templates, so this removes a large amount of duplicate code from the state. For
 the same reason, a block witness contains at most one copy of a shared chunk, no
 matter how many contracts touch it. The first 128 chunks stay in the account
 header, keyed per account, so they expire with the account and need no reference
-counting. Only chunks beyond ~4 KB are shared.
+counting. Only chunks beyond ~4 KB are deduplicated.
 
 ### SNARK friendliness and post-quantum security
 

--- a/EIPS/eip-8297.md
+++ b/EIPS/eip-8297.md
@@ -8,7 +8,6 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2026-06-11
-requires: 4762, 7612
 ---
 
 ## Abstract
@@ -448,22 +447,21 @@ future state-expiry mechanism (see "State expiry").
 
 ### Fork
 
-Described in [EIP-7612](./eip-7612.md): the overlay-tree transition
-applies with this EIP's tree in place of the Verkle tree.
-
-### Access events
-
-Partitioned Binary Tree (PBT) adopts [EIP-4762](./eip-4762.md)'s access-event framework with two required modifications:
-
-1. Content-addressed code. [EIP-4762](./eip-4762.md) keys code-chunk access events per account at `(CODE_OFFSET + i) // STEM_SUBTREE_WIDTH`. Because overflow chunks are shared between contracts (see "Code"), their access events MUST be keyed by the `(zone, tree_position, sub-index)` tree-key, not by `(address, chunk)`, so a shared chunk is charged once per block regardless of which contract triggers the access and the witness contains one copy. Header chunks (0..127) remain per-account.
-
-2. Branch-cost calibration. [EIP-4762](./eip-4762.md) prices a witness branch at `WITNESS_BRANCH_COST = 1900`, calibrated for the shallow branches of the Verkle tree it targets. PBT's branches are deeper (see "Arity-2"), so the witness gas constants MUST be recalibrated for PBT's depth profile. The recalibrated values are not yet fixed in this draft.
+Activation and the migration of existing MPT state into this tree are
+specified in [EIP-8347](./eip-8347.md). Migration happens off the
+consensus-critical path in every case: a node either converts the state
+itself at a finalized anchor block, or downloads a snapshot and verifies
+it against the anchor's state root. The converted state is caught up to
+the chain head by replaying Block-Level Access Lists, and the tree
+becomes the canonical state commitment at a single coordinated hard
+fork.
 
 ## Rationale
 
-This EIP defines a binary tree that starts empty. Only new state changes are stored
-in it. The MPT continues to exist but is frozen, setting up a later hard fork that
-migrates MPT data into the binary tree ([EIP-7748](./eip-7748.md), adapted from the Verkle tree to this one).
+This EIP defines the tree; it does not define how existing state reaches
+it. Migration is specified in [EIP-8347](./eip-8347.md): the MPT state is
+converted offline and the tree activates fully populated at the fork,
+with no overlay phase and no in-consensus conversion.
 
 ### Single tree with zones
 
@@ -498,9 +496,11 @@ attacker's own bucket.
 
 Keying overflow code by `code_hash` rather than by account lets all contracts with
 identical bytecode share leaves. Most deployed contracts repeat a small number of
-templates, so this removes a large amount of duplicate code from the state. The
-first 128 chunks stay in the account header, keyed per account, so they expire with
-the account and need no reference counting. Only chunks beyond ~4 KB are shared.
+templates, so this removes a large amount of duplicate code from the state. For
+the same reason, a block witness contains at most one copy of a shared chunk, no
+matter how many contracts touch it. The first 128 chunks stay in the account
+header, keyed per account, so they expire with the account and need no reference
+counting. Only chunks beyond ~4 KB are shared.
 
 ### SNARK friendliness and post-quantum security
 
@@ -560,15 +560,12 @@ commitment. The mechanism itself is left to a separate EIP.
 
 ## Backwards Compatibility
 
-The main breaking changes are:
+The main breaking change is that the tree structure change breaks in-EVM
+verification of MPT state proofs. Post-fork state roots commit to the new
+tree, so contracts that verify proofs against them must adopt the new
+tree's proof format.
 
-1. Gas costs for code chunk access can affect application economics. Raising the
-   gas limit alongside this EIP restores block capacity, but relative prices are
-   set by the gas schedule so transactions dominated by cold code
-   reads pay more by design, as the schedule must also price the witness data they force into every proof.
-2. The tree structure change breaks in-EVM verification of MPT state proofs.
-   Post-fork state roots commit to the new tree, so contracts that verify
-   proofs against them must adopt the new tree's proof format.
+This EIP does not change the gas schedule.
 
 The change is invisible to the EVM. Contracts address storage by 256-bit slot
 numbers through `SLOAD` and `SSTORE` and never see tree keys. Key derivation runs


### PR DESCRIPTION
Removes the stale Verkle-lineage references from EIP-8297 and points the migration path at EIP-8347 (Offline State Migration to the PBT).

- Drop `requires: 4762, 7612` — EIP-7612 is Stagnant and described an overlay transition that no longer applies; EIP-4762's access-event framework is out of scope. No reverse `requires: 8347` is added since EIP-8347 already `requires: 8297`.
- Rewrite `Fork`: activation and migration defer to EIP-8347 — conversion happens off the consensus-critical path in every case (a node self-converts at the finalized anchor or downloads and verifies a snapshot), catches up via BAL replay, and the tree becomes canonical at a single coordinated fork.
- Delete the `Access events` section (EIP-4762 adaptation, including the witness gas recalibration point). Backwards Compatibility now states this EIP does not change the gas schedule.
- Rewrite the Rationale opening: the tree activates fully populated at the fork — no overlay phase, no in-consensus conversion (was citing EIP-7748).
- Keep the witness-deduplication property of content-addressed code as a non-normative sentence in the Rationale.

