### PR TITLE
Update EIP-8038: restate the gas schedule as an access/write/creation component model

### DIFF
--- a/EIPS/eip-8038.md
+++ b/EIPS/eip-8038.md
@@ -13,7 +13,7 @@ requires: 8037
 
 ## Abstract
 
-This EIP updates the gas cost of state-access operations to reflect Ethereum's larger state and the consequent slowdown of these operations. It raises the base costs for `STORAGE_WRITE`, `COLD_STORAGE_ACCESS`, and `COLD_ACCOUNT_ACCESS` and updates the access cost for `EXTCODESIZE` and `EXTCODECOPY`.
+This EIP updates the gas cost of state-access operations to reflect Ethereum's larger state and the consequent slowdown of these operations. It dissects the cost of state-touching operations into three components — access, write, and state creation: the cold access costs (`COLD_ACCOUNT_ACCESS`, `COLD_STORAGE_ACCESS`) are raised, explicit write surcharges (`ACCOUNT_WRITE`, `STORAGE_WRITE`) are introduced, state-creation costs are left to [EIP-8037](./eip-8037.md), and `EXTCODESIZE` and `EXTCODECOPY` are charged for their second database read.
 
 ## Motivation
 
@@ -23,43 +23,57 @@ Additionally, `EXTCODESIZE` and `EXTCODECOPY` have the same access cost as `BALA
 
 ## Specification
 
+### Cost components
+
+The gas cost of a state-touching operation is the sum of up to three independent components:
+
+1. **Access** — the cost of loading an account or storage slot from the database: `COLD_ACCOUNT_ACCESS`, `COLD_STORAGE_ACCESS` and `WARM_ACCESS`, renamed by this EIP from the [EIP-2929](./eip-2929.md) parameters. This EIP raises the two cold costs; the [EIP-2929](./eip-2929.md) rules that determine whether an access is cold or warm are unchanged.
+2. **Write** — the cost of updating an object that already has a leaf in the state trie, when its value changes: `STORAGE_WRITE` for a storage slot and `ACCOUNT_WRITE` for an account's leaf values (nonce, balance, code hash), both introduced by this EIP. The pre-existing schedule has no standalone constant for this component; it is fused into composites such as `GAS_STORAGE_UPDATE` ([EIP-2200](./eip-2200.md)'s `SSTORE_RESET_GAS`), `CALL_VALUE` (the Yellow Paper's `G_callvalue`) and `GAS_CREATE` (`G_create`). The two write surcharges follow different charging disciplines, stated once here and applying everywhere below:
+   - `STORAGE_WRITE` is net-metered within a transaction: it is charged by each `SSTORE` that moves a slot away from its transaction-start value and credited back by each later `SSTORE` that restores that value (refund rule 3 below), so a slot that ends the transaction with a changed value pays it exactly once and a slot that ends unchanged pays only access costs, subject to the refund cap.
+   - `ACCOUNT_WRITE` is charged per operation that writes an account's leaf values. For every operation specified in this EIP there is no per-account tracking and no refund: a value-bearing `CALL` to the same recipient pays it on each call. ([EIP-2780](./eip-2780.md) charges it at most once per authority per transaction when processing [EIP-7702](./eip-7702.md) authorizations; that first-write rule is defined there and applies only to authorization processing.)
+3. **State creation** — the cost of adding a new leaf to the state: `GAS_STORAGE_SET` for a new storage slot and `GAS_NEW_ACCOUNT` for a new account. This EIP does not reprice these constants; they are repriced by [EIP-8037](./eip-8037.md) and charged to its state-gas dimension. This EIP states where the component applies so that each operation's complete cost is visible in one place.
+
+The sections below specify each operation as a consumer of this model: which access cost applies, whether and when a write surcharge applies, and which state-creation charge accompanies it.
+
 ### Parameters
 
 Upon activation of this EIP, the following parameters of the gas model are introduced/updated:
 
-| **Parameter** | **Description** | **Current value** | **New value** | **Increase** | **Operations affected** |
-| :---: | :---: | :---: | :---: | :---: | :---: |
-| `COLD_ACCOUNT_ACCESS` | Cold touch of an account. Renamed from `COLD_ACCOUNT_ACCESS_COST` ([EIP-2929](./eip-2929.md)) | 2,600 | 3,000 | +15% | `*CALL` opcodes, `BALANCE`, `SELFDESTRUCT`, `EXT*` opcodes, EOA delegations, contract creation txs and ETH transfers |
-| `ACCOUNT_WRITE` | Surcharge for when writing to an account changes one account leaf value for the first time. New named parameter (previously embedded in `CALL_VALUE`, see footnote ¹) | 6,700¹ | 8,000 | +19% | `*CALL` opcodes, `SELFDESTRUCT`, EOA delegations and ETH transfers |
-| `COLD_STORAGE_ACCESS` | Cold touch of a storage slot. Renamed from `COLD_SLOAD_COST` ([EIP-2929](./eip-2929.md)) | 2,100 | 3,000 | +43% | `SSTORE` and `SLOAD` |
-| `STORAGE_WRITE` | Surcharge for when writing to a storage slot changes its value for the first time. New named parameter (previously derived, see footnote ²) | 2,800² | 10,000 | +257% | `SSTORE` |
-| `WARM_ACCESS` | Touch of an already-warm account or storage slot. Renamed from `WARM_STORAGE_READ_COST` ([EIP-2929](./eip-2929.md)) | 100 | 100 | +0% | `SSTORE`, `SLOAD`, `*CALL` opcodes, `BALANCE` and `EXT*` opcodes |
-| `STORAGE_CLEAR_REFUND` | Refund for clearing a storage slot. Renamed from `SSTORE_CLEARS_SCHEDULE` ([EIP-3529](./eip-3529.md)) | 4,800 | 12,480 | +160% | `SSTORE` |
-| `CREATE_ACCESS` | State access costs for contract deployment (include account cold access and account write). New named parameter (previously derived, see footnote ³) | 7,000³ | 11,000 | +57% | `CREATE`/ `CREATE2` |
-| `ACCESS_LIST_STORAGE_KEY_COST` | Gas charged per storage key included in a transaction's access list. Unchanged name from [EIP-2930](./eip-2930.md) | 1,900 | 3,000 | +58% | `SSTORE` and `SLOAD` |
-| `ACCESS_LIST_ADDRESS_COST` | Gas charged per address included in a transaction's access list. Unchanged name from [EIP-2930](./eip-2930.md) | 2,400 | 3,000 | +25% | `*CALL` opcodes, `BALANCE`, `SELFDESTRUCT` and `EXT*` opcodes |
+| **Parameter** | **Component** | **Description** | **Current value** | **New value** | **Increase** | **Operations affected** |
+| :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+| `COLD_ACCOUNT_ACCESS` | Access | Cold touch of an account. Renamed from `COLD_ACCOUNT_ACCESS_COST` ([EIP-2929](./eip-2929.md)) | 2,600 | 3,000 | +15% | `*CALL` opcodes, `BALANCE`, `SELFDESTRUCT`, `EXT*` opcodes, EOA delegations, contract creation txs and ETH transfers |
+| `COLD_STORAGE_ACCESS` | Access | Cold touch of a storage slot. Renamed from `COLD_SLOAD_COST` ([EIP-2929](./eip-2929.md)) | 2,100 | 3,000 | +43% | `SSTORE` and `SLOAD` |
+| `WARM_ACCESS` | Access | Touch of an already-warm account or storage slot. Renamed from `WARM_STORAGE_READ_COST` ([EIP-2929](./eip-2929.md)) | 100 | 100 | +0% | `SSTORE`, `SLOAD`, `*CALL` opcodes, `BALANCE`, `SELFDESTRUCT` and `EXT*` opcodes |
+| `ACCOUNT_WRITE` | Write | Write to an account's leaf values (nonce, balance, code hash); charged per operation. New named parameter (previously embedded in `CALL_VALUE`, see footnote ¹) | 6,700¹ | 8,000 | +19% | value-transferring `*CALL` opcodes, `SELFDESTRUCT`, `CREATE`/`CREATE2`, EOA delegations and ETH transfers |
+| `STORAGE_WRITE` | Write | Write that changes a storage slot's value; net-metered per transaction. New named parameter (previously derived, see footnote ²) | 2,800² | 10,000 | +257% | `SSTORE` |
+| `CREATE_ACCESS` | Access + write | Combined access-and-write cost of contract deployment: `ACCOUNT_WRITE` + `COLD_ACCOUNT_ACCESS`. New named parameter (previously derived, see footnote ³) | 7,000³ | 11,000 | +57% | `CREATE`/ `CREATE2` and contract creation txs |
+| `STORAGE_CLEAR_REFUND` | Refund | Refund for clearing a storage slot. Renamed from `SSTORE_CLEARS_SCHEDULE` ([EIP-3529](./eip-3529.md)) | 4,800 | 12,480 | +160% | `SSTORE` |
+| `ACCESS_LIST_STORAGE_KEY_COST` | Access (prepaid) | Gas charged per storage key included in a transaction's access list. Unchanged name from [EIP-2930](./eip-2930.md) | 1,900 | 3,000 | +58% | `SSTORE` and `SLOAD` |
+| `ACCESS_LIST_ADDRESS_COST` | Access (prepaid) | Gas charged per address included in a transaction's access list. Unchanged name from [EIP-2930](./eip-2930.md) | 2,400 | 3,000 | +25% | `*CALL` opcodes, `BALANCE`, `SELFDESTRUCT` and `EXT*` opcodes |
 
-¹: 6,700 = `CALL_VALUE` (9,000) - `CALL_STIPEND`(2,300)
+¹: 6,700 = `CALL_VALUE` (the Yellow Paper's `G_callvalue`, 9,000) - `CALL_STIPEND` (`G_callstipend`, 2,300)
 
-²: 2,800 = `GAS_STORAGE_UPDATE` (5,000) - `GAS_COLD_SLOAD` (2,100) - `GAS_WARM_ACCESS` (100)
+²: 2,800 = `GAS_STORAGE_UPDATE` ([EIP-2200](./eip-2200.md)'s `SSTORE_RESET_GAS`, 5,000) - `GAS_COLD_SLOAD` (2,100) - `GAS_WARM_ACCESS` (100)
 
-³: 7,000 = `GAS_CREATE` (32,000) - `GAS_NEW_ACCOUNT` (25,000)
+³: 7,000 = `GAS_CREATE` (the Yellow Paper's `G_create`, 32,000) - `GAS_NEW_ACCOUNT` (`G_newaccount`, 25,000)
+
+`ACCOUNT_WRITE`, `STORAGE_WRITE` and `CREATE_ACCESS` are new parameters with no pre-existing counterpart; their "Current value" column shows the equivalent cost extracted from the pre-existing composite constants per the footnotes above. The pre-existing schedule is not exactly separable into these components, so these equivalents are approximate: footnote ² yields the write component of the current warm-case `SSTORE` charge exactly (2,900 = `GAS_WARM_ACCESS` + 2,800), while the cold-case charge of 5,000 exceeds the sum of its components by 100; footnote ³ is discussed in the `CREATE`/`CREATE2` section below.
 
 ### `SSTORE` pricing
 
-In addition, the `SSTORE` cost formula is updated to include the following independent costs:
+In addition, the `SSTORE` cost formula is updated. As in [EIP-2200](./eip-2200.md), the *original value* is the slot's value at the start of the current transaction and the *current value* is its value just before the `SSTORE` executes. The complete `SSTORE` charge is the sum of its three cost components:
 
-1. Access costs: `COLD_STORAGE_ACCESS` or `WARM_ACCESS`, depending on whether the storage slot is cold or warm.
-2. Write cost: additionally charge `STORAGE_WRITE` if the new value is different from the present value and the present value equals the original value (First time change).
-3. State creation cost: additionally charge `GAS_STORAGE_SET` (per [EIP-8037](./eip-8037.md)) if the original value is zero, the current value is zero, and the new value is non-zero.
+1. Access component: `COLD_STORAGE_ACCESS` or `WARM_ACCESS`, depending on whether the storage slot is cold or warm.
+2. Write component: additionally charge `STORAGE_WRITE` if the new value is different from the current value and the current value equals the original value (the write moves the slot away from its transaction-start value).
+3. State-creation component: additionally charge `GAS_STORAGE_SET` (per [EIP-8037](./eip-8037.md), metered in state-gas) if the original value is zero, the current value is zero, and the new value is non-zero.
 
 Refunds are also updated as follows. Each rule is an adjustment to the transaction's refund counter and is evaluated on every `SSTORE`:
 
 1. `STORAGE_CLEAR_REFUND` is added if the original value is non-zero, the current value is non-zero and the new value is zero (a slot is cleared).
 2. `STORAGE_CLEAR_REFUND` is subtracted if the original value is non-zero, the current value is zero and the new value is non-zero (a slot that was cleared earlier in the same transaction is restored). This reverses the refund granted by rule 1, so that clearing and then restoring a slot within the same transaction is never net-profitable.
-3. `STORAGE_WRITE` is refunded if the new value equals the original value and differs from the current value (a first-time change made earlier in the same transaction is reset back to its original value).
+3. `STORAGE_WRITE` is refunded if the new value equals the original value and differs from the current value (a change made earlier in the same transaction is undone, restoring the slot's transaction-start value).
 
-Rules 2 and 3 mirror the refund accounting of [EIP-2200](./eip-2200.md) and [EIP-3529](./eip-3529.md) for slots that are modified more than once within a transaction: a `STORAGE_WRITE` charge or `STORAGE_CLEAR_REFUND` granted on an earlier `SSTORE` to the same slot is undone when a later `SSTORE` returns the slot to its original value. Without these reversals, a round trip such as `x → 0 → x` would yield a net refund even though the slot ends the transaction unchanged.
+Rules 2 and 3 mirror the refund accounting of [EIP-2200](./eip-2200.md) and [EIP-3529](./eip-3529.md) for slots that are modified more than once within a transaction: a `STORAGE_WRITE` charge or `STORAGE_CLEAR_REFUND` granted on an earlier `SSTORE` to the same slot is undone when a later `SSTORE` returns the slot to its original value. Without these reversals, a round trip such as `x → 0 → x` would yield a net refund even though the slot ends the transaction unchanged. Net over the whole transaction, a slot that ends at a changed value pays its write and state-creation components exactly once, and a slot that ends at its original value pays only its access costs — in both cases regardless of how often the slot was written, and subject to the refund cap.
 
 These refunds go to the transaction's refund counter and are capped to 20% of the total gas used by the transaction, as per the current refund mechanism.
 
@@ -76,28 +90,30 @@ Cases and their corresponding costs are detailed in the table below:
 | x | x | 0 | Cold | Cleared slot, non-zero at transaction start | `COLD_STORAGE_ACCESS` + `STORAGE_WRITE` charged, `STORAGE_CLEAR_REFUND` refunded | no state-gas adjustments |
 | x | x | 0 | Warm | Cleared slot, non-zero at transaction start | `WARM_ACCESS` + `STORAGE_WRITE` charged, `STORAGE_CLEAR_REFUND` refunded | no state-gas adjustments |
 | 0 | x | 0 | Warm | Set slot reset to zero (zero at transaction start) | `WARM_ACCESS` charged, `STORAGE_WRITE` refunded | `GAS_STORAGE_SET` refilled |
+| 0 | x | y | Warm | Slot set earlier in the transaction written to a different non-zero value | `WARM_ACCESS` charged | no state-gas adjustments |
 | x | y | x | Warm | Previously-modified slot reset to original value | `WARM_ACCESS` charged, `STORAGE_WRITE` refunded | no state-gas adjustments |
+| x | y | 0 | Warm | Previously-modified slot cleared, non-zero at transaction start | `WARM_ACCESS` charged, `STORAGE_CLEAR_REFUND` refunded | no state-gas adjustments |
 | x | 0 | x | Warm | Cleared slot restored to original value | `WARM_ACCESS` charged, `STORAGE_WRITE` refunded, `STORAGE_CLEAR_REFUND` reversed | no state-gas adjustments |
 | x | 0 | y | Warm | Cleared slot written to a new non-zero value | `WARM_ACCESS` charged, `STORAGE_CLEAR_REFUND` reversed | no state-gas adjustments |
-| x | y | z | Warm | Previously-modified slot written to again | `WARM_ACCESS` charged | no state-gas adjustments |
+| x | y | z | Warm | Previously-modified slot written to another non-zero value | `WARM_ACCESS` charged | no state-gas adjustments |
 
 ### Account access pricing
 
-The rules that determine when `COLD_ACCOUNT_ACCESS` and `WARM_ACCESS` are charged for account-related operations are unchanged; only the parameter values themselves are updated.
+The [EIP-2929](./eip-2929.md) rules that determine whether an account access is cold or warm are unchanged; this EIP raises the cold access cost and states explicitly, per operation below, where the write and state-creation components apply.
 
 #### `CALL`/`CALLCODE`
 
-For `CALL` and `CALLCODE` operations, `CALL_VALUE` is set to `ACCOUNT_WRITE + CALL_STIPEND`, where `CALL_STIPEND` = 2,300.
+For `CALL` and `CALLCODE` operations, `CALL_VALUE` (the Yellow Paper's `G_callvalue`) is redefined as `ACCOUNT_WRITE + CALL_STIPEND`, where `CALL_STIPEND` (`G_callstipend`, 2,300) is unchanged. `ACCOUNT_WRITE` here prices the write to the recipient's balance leaf and, per its charging discipline, is paid on every value-transferring call. The state-creation component of a value-transferring call to a dead account (as defined in [EIP-161](./eip-161.md)) is `GAS_NEW_ACCOUNT`, which this EIP does not reprice; it is repriced and metered in state-gas by [EIP-8037](./eip-8037.md).
 
 #### `CREATE`/`CREATE2`
 
-`CREATE` and `CREATE2` operations don't have explicit warm/cold pricing. Instead, they are charged `CREATE_ACCESS` in regular-gas and `GAS_NEW_ACCOUNT` in state-gas (per [EIP-8037](./eip-8037.md)). `CREATE_ACCESS` is defined as `ACCOUNT_WRITE` + `COLD_STORAGE_ACCESS`.
+`CREATE` and `CREATE2` operations don't have explicit warm/cold pricing. Instead, the flat `GAS_CREATE` (the Yellow Paper's `G_create`, 32,000) is replaced by `CREATE_ACCESS`, charged in regular-gas, plus `GAS_NEW_ACCOUNT`, charged in state-gas (per [EIP-8037](./eip-8037.md)). `CREATE_ACCESS`, defined as `ACCOUNT_WRITE` + `COLD_ACCOUNT_ACCESS`, is the combined access-and-write component of the deployment; `GAS_NEW_ACCOUNT` is its state-creation component and is not repriced by this EIP.
 
 Note: this definition does not exactly match the legacy decomposition shown in footnote ³ of the Parameters table (`GAS_CREATE` - `GAS_NEW_ACCOUNT` = 7,000). The pre-existing accounting in the protocol is not internally consistent here, and this EIP keeps the discrepancy rather than attempting to reconcile it.
 
 #### `SELFDESTRUCT`
 
-For `SELFDESTRUCT`, an additional charge of `ACCOUNT_WRITE` is added if a positive balance is sent to an empty account.
+For `SELFDESTRUCT`, an additional charge of `ACCOUNT_WRITE` is added if a positive balance is sent to a dead account (as defined in [EIP-161](./eip-161.md)) — the write component of creating the beneficiary's leaf. The state-creation component in this same case is `GAS_NEW_ACCOUNT`, which remains in place alongside the new `ACCOUNT_WRITE` charge and is metered in state-gas by [EIP-8037](./eip-8037.md).
 
 #### `EXT*` family update
 
@@ -105,16 +121,16 @@ Besides the current access costs, `EXTCODESIZE` and `EXTCODECOPY` are charged an
 
 #### Overview
 
-The cases for account-related operations and their corresponding costs are summarized in the table below:
+The cases for account-related operations and their corresponding cost components are summarized in the table below. The state-creation column is charged in state-gas and is not repriced by this EIP (see [EIP-8037](./eip-8037.md)).
 
-| Operation | Access charge | `ACCOUNT_WRITE` charged | Additional charge |
+| Operation | Access component | Write component (`ACCOUNT_WRITE`) | State-creation component |
 | :--- | :---: | :--- | :--- |
-| `CALL` / `CALLCODE` | `COLD_ACCOUNT_ACCESS` or `WARM_ACCESS` | when value is transferred (via `CALL_VALUE` = `ACCOUNT_WRITE` + `CALL_STIPEND`) | — |
+| `CALL` / `CALLCODE` | `COLD_ACCOUNT_ACCESS` or `WARM_ACCESS` | when value is transferred (via `CALL_VALUE` = `ACCOUNT_WRITE` + `CALL_STIPEND`) | `GAS_NEW_ACCOUNT` when value is transferred to a dead account |
 | `DELEGATECALL` / `STATICCALL` | `COLD_ACCOUNT_ACCESS` or `WARM_ACCESS` | never (no value transfer) | — |
-| `CREATE` / `CREATE2` | `CREATE_ACCESS` (= `ACCOUNT_WRITE` + `COLD_STORAGE_ACCESS`) | always (folded into `CREATE_ACCESS`) | `GAS_NEW_ACCOUNT` in state-gas (per [EIP-8037](./eip-8037.md)) |
-| `SELFDESTRUCT` | `COLD_ACCOUNT_ACCESS` or `WARM_ACCESS` | when a positive balance is sent to an empty account | — |
+| `CREATE` / `CREATE2` | folded into `CREATE_ACCESS` | always (folded into `CREATE_ACCESS` = `ACCOUNT_WRITE` + `COLD_ACCOUNT_ACCESS`, replacing `GAS_CREATE`) | `GAS_NEW_ACCOUNT`, plus the per-byte code-deposit cost |
+| `SELFDESTRUCT` | `COLD_ACCOUNT_ACCESS` or `WARM_ACCESS` | when a positive balance is sent to a dead account | `GAS_NEW_ACCOUNT` in the same case |
 | `BALANCE` / `EXTCODEHASH` | `COLD_ACCOUNT_ACCESS` or `WARM_ACCESS` | never | — |
-| `EXTCODESIZE` / `EXTCODECOPY` | `COLD_ACCOUNT_ACCESS` or `WARM_ACCESS` | never | `WARM_ACCESS` (second database read) |
+| `EXTCODESIZE` / `EXTCODECOPY` | `COLD_ACCOUNT_ACCESS` or `WARM_ACCESS`, plus `WARM_ACCESS` for the second database read | never | — |
 
 ## Rationale
 
@@ -169,7 +185,7 @@ Only glue opcodes with a statistically significant fit (p-value < 0.05) are incl
 
 **Parameter mapping**
 
-Each gas parameter is derived from one or more benchmark models by selecting a specific regression coefficient (`slope` or `update`) after applying the relevant filters (test name, cache strategy, account mode).
+Each gas parameter is derived from one or more benchmark models by selecting a specific regression coefficient (`slope` or `update`) after applying the relevant filters (test name, cache strategy, account mode). The two coefficients correspond directly to the two cost components this EIP prices: the `slope` measures the cost of loading the object from the database (the access component), while the `update` coefficient measures the marginal cost of changing its value (the write component). The state-creation component is not estimated from runtime at all — it prices durable state growth rather than execution time — which is why it is derived separately in [EIP-8037](./eip-8037.md) and left unchanged here.
 
 For each parameter and client, the worst-case value across all matching model configurations is used. The final proposal takes the worst case across clients.
 
@@ -205,7 +221,7 @@ Where:
 STORAGE_CLEAR_REFUND         = (STORAGE_WRITE + COLD_STORAGE_ACCESS) * (4800/5000)
 ACCESS_LIST_STORAGE_KEY_COST = COLD_STORAGE_ACCESS
 ACCESS_LIST_ADDRESS_COST     = COLD_ACCOUNT_ACCESS
-CREATE_ACCESS                = ACCOUNT_WRITE + COLD_STORAGE_ACCESS
+CREATE_ACCESS                = ACCOUNT_WRITE + COLD_ACCOUNT_ACCESS
 ```
 
 ### Interaction with [EIP-7928](./eip-7928.md)


### PR DESCRIPTION
Makes the cost model EIP-8038 already uses implicitly — every state-touching operation priced as the sum of an **access**, a **write**, and a **state-creation** component — the explicit structure of the Specification. A new "Cost components" section opens the Specification and every other section becomes a consumer of it, so each write surcharge's charging discipline is stated exactly once: `STORAGE_WRITE` is net-metered per transaction, `ACCOUNT_WRITE` is charged per operation.

This resolves several self-contradictions (the Abstract claimed to "raise" a parameter the EIP introduces; the write surcharges were described as charged "for the first time" with no rule implementing that for accounts; "the rules … are unchanged" was contradicted by the new `EXT*` second-read charge) and fills gaps a standalone implementer could not answer (`GAS_CREATE` is replaced by `CREATE_ACCESS` + `GAS_NEW_ACCOUNT`; `SELFDESTRUCT`'s `GAS_NEW_ACCOUNT` stacks with `ACCOUNT_WRITE`, with the trigger corrected to "dead" account per EIP-161).

No charge value, condition, timing, or refund behavior changes. Two points for reviewers:

- `CREATE_ACCESS` is now consistently `ACCOUNT_WRITE + COLD_ACCOUNT_ACCESS`; the Rationale previously derived it from cold *storage* access, as does the `eips/amsterdam/eip-2780-8038` execution-specs branch. Value unchanged at 11,000, so it's unobservable today — but execution-specs should match.
- Two reachable `SSTORE` case rows were missing and are added: `0 → x → y` and `x → y → 0`.

This follows from https://github.com/jochem-brouwer/EIPs/pull/1