### PR TITLE
Update EIP-8333: use the attestation deadline, not a specific fraction of a slot

### DIFF
--- a/EIPS/eip-8333.md
+++ b/EIPS/eip-8333.md
@@ -16,9 +16,9 @@ Anchor the Casper Friendly Finality Gadget (FFG) checkpoint for epoch `N` to the
 
 ## Motivation
 
-Every attestation carries an FFG target vote naming a checkpoint `(epoch, root)`. Today the root for epoch `N` is the block at the epoch's first slot, and every attestation in epoch `N` names this same target. Committees in later slots know the target by the time they vote, but the first slot's committee must vote one third of a slot after the target block itself is proposed. If the block arrives late, some of those attesters vote for it while others vote for the previous block. Only one of the two matches the checkpoint the chain settles on; the other votes are lost to justification, and their attesters forfeit target rewards. The effect is systematic and measurable: on the live network, target-vote misses concentrate in the first slot of each epoch, with roughly `1/SLOTS_PER_EPOCH` of FFG weight exposed every epoch.
+Every attestation carries an FFG target vote naming a checkpoint `(epoch, root)`. Today the root for epoch `N` is the block at the epoch's first slot, and every attestation in epoch `N` names this same target. Committees in later slots know the target by the time they vote, but the first slot's committee must vote by the attestation deadline after the target block itself is proposed. If the block arrives late, some of those attesters vote for it while others vote for the previous block. Only one of the two matches the checkpoint the chain settles on; the other votes are lost to justification, and their attesters forfeit target rewards. The effect is systematic and measurable: on the live network, target-vote misses concentrate in the first slot of each epoch, with roughly `1/SLOTS_PER_EPOCH` of FFG weight exposed every epoch.
 
-This EIP instead anchors the checkpoint for epoch `N` to the boundary block, the last block before epoch `N`. The target is then fixed before the epoch begins, so no block produced during epoch `N` can change it. The earliest committee gains more than a full slot of propagation margin, up from a third of a slot.
+This EIP instead anchors the checkpoint for epoch `N` to the boundary block, the last block before epoch `N`. The target is then fixed before the epoch begins, so no block produced during epoch `N` can change it. The earliest committee gains a full slot of additional propagation time before the attestation deadline.
 
 The current anchoring is also a long-standing off-by-one rather than a deliberate design decision (`ethereum/consensus-specs` issues 2174 and 652), and it makes finalization semantics misleading. "Epoch `N` finalized" today means only that the first block of epoch `N` is finalized; the rest of the epoch's blocks can still be reorged. Under this proposal a checkpoint for epoch `N` names the chain through the end of epoch `N - 1`, so finalizing it finalizes whole epochs, nothing more and nothing less. Explorers and tooling that report finality per epoch become accurate.
 
@@ -103,7 +103,7 @@ Testing for this EIP should cover the following:
 
 FFG safety is unaffected: justification, finalization, and slashing operate on checkpoint epochs, which do not change.
 
-The remaining attack surface is a maliciously late boundary block, which can still split the next epoch's first-slot target votes. This is the same attack that late first-slot blocks enable today, made strictly harder: the propagation margin grows from a third of a slot to over a full slot. Withholding the boundary block outright achieves nothing, since the target falls back to an earlier, already-propagated block.
+The remaining attack surface is a maliciously late boundary block, which can still split the next epoch's first-slot target votes. This is the same attack that late first-slot blocks enable today, made strictly harder: the propagation margin grows from the time until the attestation deadline to over a full slot. Withholding the boundary block outright achieves nothing, since the target falls back to an earlier, already-propagated block.
 
 ## Copyright
 


### PR DESCRIPTION
The attestation deadline will become one quarter of a slot after ePBS. Given that there is an expectation that we might bring this forward into the slot, it would be forward compatible to use the deadline, rather than being tided to a specific portion of a slot. 