### PR TITLE
Update EIP-2780: Move to Review

### DIFF
--- a/EIPS/eip-2780.md
+++ b/EIPS/eip-2780.md
@@ -4,7 +4,7 @@ title: Resource-based intrinsic transaction gas
 description: Decompose the flat intrinsic transaction cost into explicit primitives priced to match the resources a transaction actually consumes
 author: Matt Garnett (@lightclient), Uri Klarman (@uriklarman), Ben Adams (@benaadams), Maria Inês Silva (@misilva73), Anders Elowsson (@anderselowsson), Anthony Sassano (@sassal), Dragan Rakita (@rakita)
 discussions-to: https://ethereum-magicians.org/t/eip-2780-reduce-intrinsic-cost-of-transactions/4413
-status: Draft
+status: Review
 type: Standards Track
 category: Core
 created: 2020-07-11

--- a/EIPS/eip-8037.md
+++ b/EIPS/eip-8037.md
@@ -4,7 +4,7 @@ title: State Creation Gas Cost Increase
 description: Harmonization, increase and separate metering of state creation gas costs to mitigate state growth and unblock scaling
 author: Maria Silva (@misilva73), Carlos Perez (@CPerezz), Jochem Brouwer (@jochem-brouwer), Ansgar Dietrichs (@adietrichs), Łukasz Rozmej (@LukaszRozmej), Anders Elowsson (@anderselowsson), Francesco D'Amato (@fradamt), Dragan Rakita (@rakita)
 discussions-to: https://ethereum-magicians.org/t/eip-8037-state-creation-gas-cost-increase/25694
-status: Draft
+status: Review
 type: Standards Track
 category: Core
 created: 2025-10-01
@@ -378,7 +378,7 @@ State-gas refills are applied in last-in, first-out (LIFO) order: because charge
 
 #### Higher throughput
 
-Another advantage of metering contract creation separately is that increasing the cost of state creation operation in line with the block limit will not affect the available gas for other operations. This allows for higher throughput, as explained in the original multidimensional gas metering introduced in [EIP-8011](./eip-8011.md).
+Another advantage of metering contract creation separately is that increasing the cost of state creation operation in line with the block limit will not affect the available gas for other operations. This allows for higher throughput, as explained in the original multidimensional gas metering introduced in EIP-8011.
 
 #### Calldata floor in block accounting
 

--- a/EIPS/eip-8037.md
+++ b/EIPS/eip-8037.md
@@ -378,7 +378,7 @@ State-gas refills are applied in last-in, first-out (LIFO) order: because charge
 
 #### Higher throughput
 
-Another advantage of metering contract creation separately is that increasing the cost of state creation operation in line with the block limit will not affect the available gas for other operations. This allows for higher throughput, as explained in the original multidimensional gas metering introduced in EIP-8011.
+Another advantage of metering contract creation separately is that increasing the cost of state creation operation in line with the block limit will not affect the available gas for other operations. This allows for higher throughput.
 
 #### Calldata floor in block accounting
 

--- a/EIPS/eip-8038.md
+++ b/EIPS/eip-8038.md
@@ -4,7 +4,7 @@ title: State-access gas cost update
 description: Increases the gas cost of state-access operations to reflect Ethereum’s larger state
 author: Maria Silva (@misilva73), Wei Han Ng (@weiihann), Ansgar Dietrichs (@adietrichs)
 discussions-to: https://ethereum-magicians.org/t/eip-8038-state-access-gas-cost-update/25693
-status: Draft
+status: Review
 type: Standards Track
 category: Core
 created: 2025-10-03
@@ -216,16 +216,16 @@ CREATE_ACCESS                = ACCOUNT_WRITE + COLD_STORAGE_ACCESS
 
 Differently from other account read operations, `EXTCODESIZE` and `EXTCODECOPY` make two reads to the database. The first read is the same, where the object of the target account is loaded. This object includes the account's `nonce`, `balance`, `codeHash` and `storageRoot`. Then, these operations do another read to collect either the code size or the bytecode of the account. This second read is to an already warmed account, and thus we propose to price it as `WARM_ACCESS` for consistency.
 
-### Interaction with [EIP-8032](./eip-8032.md)
+### Interaction with EIP-8032
 
-[EIP-8032](./eip-8032.md) proposes modifying the `SSTORE` cost formula to account for the storage size of a contract. This is a more accurate method for pricing storage writes. It allows writes to smaller contracts to be cheaper than writes to large contracts, which helps with scaling and is fairer to users. However, [EIP-8032](./eip-8032.md) is not yet scheduled for inclusion in a fork, and, as such, this proposal considers two cases for setting the values of `STORAGE_WRITE` and `COLD_STORAGE_ACCESS`:
+EIP-8032 proposes modifying the `SSTORE` cost formula to account for the storage size of a contract. This is a more accurate method for pricing storage writes. It allows writes to smaller contracts to be cheaper than writes to large contracts, which helps with scaling and is fairer to users. However, EIP-8032 is not yet scheduled for inclusion in a fork, and, as such, this proposal considers two cases for setting the values of `STORAGE_WRITE` and `COLD_STORAGE_ACCESS`:
 
-1. Before [EIP-8032](./eip-8032.md). In this case, we set the parameters assuming a worst-case contract size, which makes state-accessing operations more expensive, independently of the contract size.
-2. After [EIP-8032](./eip-8032.md). In this case, we set the parameters assuming the worst-case until `ACTIVATION_THRESHOLD`, which is the parameter in [EIP-8032](./eip-8032.md) that triggers the depth-based cost. This means that contract sizes below the threshold have the same access costs, while contracts above the threshold get exponentially more expensive with increasing size.
+1. Before EIP-8032. In this case, we set the parameters assuming a worst-case contract size, which makes state-accessing operations more expensive, independently of the contract size.
+2. After EIP-8032. In this case, we set the parameters assuming the worst-case until `ACTIVATION_THRESHOLD`, which is the parameter in EIP-8032 that triggers the depth-based cost. This means that contract sizes below the threshold have the same access costs, while contracts above the threshold get exponentially more expensive with increasing size.
 
-### Interaction with [EIP-2926](./eip-2926.md)
+### Interaction with EIP-2926
 
-[EIP-2926](./eip-2926.md) proposes to change how code is stored in the state trie. One of the changes of this proposal is to include the code size as a new field in the account object (`codeSize`). With this change, the code size can be directly accessed with a single read to the database and thus `EXTCODESIZE` should maintain its previous cost formula, without including the additional `WARM_ACCESS`.
+EIP-2926 proposes to change how code is stored in the state trie. One of the changes of this proposal is to include the code size as a new field in the account object (`codeSize`). With this change, the code size can be directly accessed with a single read to the database and thus `EXTCODESIZE` should maintain its previous cost formula, without including the additional `WARM_ACCESS`.
 
 ## Backwards Compatibility
 

--- a/EIPS/eip-8038.md
+++ b/EIPS/eip-8038.md
@@ -216,17 +216,6 @@ CREATE_ACCESS                = ACCOUNT_WRITE + COLD_STORAGE_ACCESS
 
 Differently from other account read operations, `EXTCODESIZE` and `EXTCODECOPY` make two reads to the database. The first read is the same, where the object of the target account is loaded. This object includes the account's `nonce`, `balance`, `codeHash` and `storageRoot`. Then, these operations do another read to collect either the code size or the bytecode of the account. This second read is to an already warmed account, and thus we propose to price it as `WARM_ACCESS` for consistency.
 
-### Interaction with EIP-8032
-
-EIP-8032 proposes modifying the `SSTORE` cost formula to account for the storage size of a contract. This is a more accurate method for pricing storage writes. It allows writes to smaller contracts to be cheaper than writes to large contracts, which helps with scaling and is fairer to users. However, EIP-8032 is not yet scheduled for inclusion in a fork, and, as such, this proposal considers two cases for setting the values of `STORAGE_WRITE` and `COLD_STORAGE_ACCESS`:
-
-1. Before EIP-8032. In this case, we set the parameters assuming a worst-case contract size, which makes state-accessing operations more expensive, independently of the contract size.
-2. After EIP-8032. In this case, we set the parameters assuming the worst-case until `ACTIVATION_THRESHOLD`, which is the parameter in EIP-8032 that triggers the depth-based cost. This means that contract sizes below the threshold have the same access costs, while contracts above the threshold get exponentially more expensive with increasing size.
-
-### Interaction with EIP-2926
-
-EIP-2926 proposes to change how code is stored in the state trie. One of the changes of this proposal is to include the code size as a new field in the account object (`codeSize`). With this change, the code size can be directly accessed with a single read to the database and thus `EXTCODESIZE` should maintain its previous cost formula, without including the additional `WARM_ACCESS`.
-
 ## Backwards Compatibility
 
 This is a backwards-incompatible gas repricing that requires a scheduled network upgrade.


### PR DESCRIPTION
Moves EIP-2780, EIP-8037, and EIP-8038 from Draft to Review. The three proposals form the gas-repricing set and are being advanced together so their cross-references stay at the same maturity tier.

References to proposals still in Draft (EIP-8011 in EIP-8037; EIP-8032 and EIP-2926 in EIP-8038) are converted from relative links to plain-text mentions, since `markdown-link-status` does not allow a Review proposal to link to a Draft one. The prose and the substance of those references are unchanged.

No normative changes.
