### PR TITLE
Update EIP-8250: Define keyed mempool concurrency

### DIFF
--- a/EIPS/eip-8250.md
+++ b/EIPS/eip-8250.md
@@ -21,7 +21,7 @@ A frame transaction currently consumes one linear sender nonce, so a delayed tra
 
 The leading example is privacy protocols. To avoid binding onchain activity to a unique public sender, users transact through a single shared sender address. With one linear nonce, that shared sender becomes a throughput bottleneck: one user's inclusion invalidates every other user's pending withdrawal even when the spends are otherwise unrelated. Smart-wallet session keys and relayer-style senders face the same problem.
 
-Keyed nonces let each spend pick its own nonce domain, for example one derived from a privacy nullifier. Transactions on disjoint non-zero key sets are replay-independent. This removes the protocol-level nonce obstacle to future keyed-aware mempools that admit concurrent transactions from the same sender. This EIP preserves EIP-8141's limit of one pending frame transaction per sender in the public mempool.
+Keyed nonces let each spend pick its own nonce domain, for example one derived from a privacy nullifier. Transactions on disjoint non-zero key sets are replay-independent. This EIP permits public mempools to admit concurrent transactions from the same sender under a policy that assigns each selected nonce key to at most one pending transaction.
 
 Tying nonce consumption to EIP-8141's payment-approval step also gives single-use-key applications, such as nullifiers, an atomic spent-once guarantee: if validation requires every selected key to be unused, successful inclusion makes all selected keys used, regardless of whether later frames revert.
 
@@ -230,7 +230,19 @@ For the EIP-8141 public mempool rules:
 
 If the validation prefix reads `TXPARAM(0x0C)`, the sender's legacy account nonce is an additional dependency.
 
-Nodes MUST revalidate a pending transaction when any of its selected nonce sequences changes. If the validation prefix reads `TXPARAM(0x0C)`, nodes MUST also revalidate when the sender's legacy account nonce changes. All other EIP-8141 public mempool rules, including the limit of one pending frame transaction per sender, remain unchanged.
+For `nonce_keys == [0]`, the EIP-8141 limit of one pending frame transaction per sender remains unchanged.
+
+For `nonce_keys != [0]`, a node MAY admit multiple pending frame transactions from the same sender only if every pending frame transaction from that sender uses non-zero keys and all of the following conditions hold for every such transaction:
+
+- `tx.sender` has non-empty code that is not an [EIP-7702](./eip-7702.md) delegation. The validation prefix has no `deploy` frame, the validation trace records no sender storage reads, and validation does not read `TXPARAM(0x0C)`.
+- The transaction's `nonce_seq` equals `current_nonce_seq(tx.sender, nonce_key)` for every selected `nonce_key`. Nodes MUST NOT queue future sequences.
+- The node indexes the transaction by every selected `(tx.sender, nonce_key)` pair, and each pair is owned by at most one pending transaction.
+- A transaction that overlaps an owned pair is rejected unless it replaces a transaction with the same `(sender, nonce_keys, nonce_seq)` and satisfies the EIP-8141 replacement rules. Partial overlap is not a replacement.
+- After every other admission check succeeds, the node MUST atomically recheck and acquire all selected key ownership records together with transaction insertion and the EIP-8141 payer reservation changes. Replacement and removal MUST release every affected key ownership record and payer reservation in the same atomic update.
+
+A node that does not apply this exception, or a transaction that does not satisfy its conditions, remains subject to the EIP-8141 limit of one pending frame transaction per sender.
+
+Nodes MUST revalidate a pending transaction when any of its selected nonce sequences changes. If the validation prefix reads `TXPARAM(0x0C)`, nodes MUST also revalidate when the sender's legacy account nonce changes. Except for the sender limit relaxed above, all other EIP-8141 public mempool rules remain unchanged.
 
 ## Rationale
 
@@ -246,7 +258,9 @@ Keyed-nonce state lives in the storage of one `NONCE_MANAGER` system contract ra
 
 `KEYED_NONCE_FIRST_USE_GAS = 20000` uses the zero-to-nonzero `SSTORE` state-creation cost as a reference point. It is a keyed-nonce state-growth surcharge, not ordinary user-level `SSTORE` pricing. Subsequent increments of a consumed key are not separately surcharged: keyed-nonce progression is replay-protection bookkeeping analogous to legacy-nonce progression, not user storage.
 
-This EIP does not relax EIP-8141's public-mempool one-pending-frame-transaction-per-sender guidance, but it removes the protocol-level obstacle to doing so. A future policy MAY admit multiple pending frame transactions for the same sender on disjoint non-zero key sets, subject to its own dependency-tracking and replacement rules.
+The public mempool indexes each selected key separately rather than indexing only `nonce_keys_hash`. Indexing only the complete set would treat `{a, b}` and `{b, c}` as unrelated even though including either transaction changes a nonce sequence required by the other. With individual key ownership, one included transaction can invalidate at most `len(nonce_keys) <= MAX_NONCE_KEYS` locally pending transactions through nonce overlap, because each consumed key belongs to at most one pending transaction. Admitting only current sequences prevents a queue on one key from recreating the same cascading invalidation.
+
+The concurrency exception excludes mutable sender state from validation. Payer reservations, paymaster limits, expiry handling, and every other EIP-8141 public mempool dependency remain in force.
 
 ## Backwards Compatibility
 
@@ -261,6 +275,8 @@ If activated after EIP-8141, pre-fork frame transactions become invalid at the f
 ## Security Considerations
 
 Replay protection is scoped to `(sender, nonce_keys, nonce_seq)`, with validity requiring every selected key to have the selected sequence. Disjoint non-zero key sets remove only the replay-ordering dependency; transactions on disjoint keys may still conflict on sender or payer balance, contract storage, paymaster state, or any other shared state. This EIP provides replay-domain separation, not confidentiality of key selection: `nonce_keys` are visible in the payload and committed by `compute_sig_hash(tx)`.
+
+The concurrent public mempool policy bounds invalidation caused by nonce overlap. It does not make other shared dependencies independent. Nodes must continue to apply EIP-8141 payer reservations, paymaster limits, dependency tracking, revalidation, and eviction rules.
 
 Single-use-key applications, such as nullifiers, MUST authenticate at least `(sender, nonce_keys_hash, nonce_seq == 0)` in `VERIFY` and SHOULD bind the canonical signature hash via `TXPARAM(0x08)`. Treating `nonce_seq == 0` alone as authorization is unsafe. Authenticating only `TXPARAM_NONCE_KEY_0` is also unsafe when `TXPARAM_NONCE_KEY_COUNT > 1`, because an attacker could add unauthorized keys that would be consumed by payment approval. Applications deriving nonce keys from per-use identifiers SHOULD domain-separate the input and reject derived keys equal to `0`.
 


### PR DESCRIPTION
EIP-8250 gives frame transactions independent replay domains, but the current public mempool section retains EIP-8141's limit of one pending frame transaction per sender. This leaves shared sender designs serialized and does not define how clients should handle overlapping key sets.

This PR defines a narrow optional exception:

- key zero and transactions with mutable sender validation dependencies remain under the EIP-8141 sender limit;
- nonzero keyed transactions use individual `(sender, nonce_key)` ownership, current sequences, and exact identity replacement;
- after the other admission checks pass, clients atomically recheck and acquire key ownership together with transaction insertion and payer reservation changes.

The change affects public mempool policy only. It does not change transaction validity, nonce consumption, frame execution, or fee settlement. All EIP-8141 payer, paymaster, dependency, revalidation, and eviction rules remain in force.

With individual key ownership, one included transaction can invalidate at most `len(nonce_keys) <= MAX_NONCE_KEYS` locally pending transactions through nonce overlap.