### PR TITLE
Update EIP-8141: align SIGPARAM copy operand order with CALLDATACOPY

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -658,7 +658,7 @@ This instruction gives access to signature-scoped metadata. The raw `signature` 
 
 For `param` values `0x00` through `0x03`, the gas cost of this operation is `2`. It takes two values from the stack, `signatureIndex` on top and `param` second from top, and returns the associated value to the stack.
 
-For `param == 0x04`, this instruction copies bytes from an `ARBITRARY` signature's raw `signature` bytes into memory. Its gas cost is calculated exactly as for `CALLDATACOPY`, including the fixed cost of 3, the per-word copy cost, and the standard EVM memory expansion cost. It takes five values from the stack: `signatureIndex` on top, `param` second from top, followed by `length`, `dataOffset`, and `memOffset`. No stack output value is produced.
+For `param == 0x04`, this instruction copies bytes from an `ARBITRARY` signature's raw `signature` bytes into memory. Its gas cost is calculated exactly as for `CALLDATACOPY`, including the fixed cost of 3, the per-word copy cost, and the standard EVM memory expansion cost. It takes five values from the stack: `signatureIndex` on top, `param` second from top, followed by `memOffset`, `dataOffset`, and `length`. No stack output value is produced.
 
 | `param` | `signatureIndex` | Behavior                                     |
 |---------|------------------|----------------------------------------------|


### PR DESCRIPTION
`SIGPARAM`'s copy form (`param == 0x04`) lists its `memOffset`/`dataOffset`/`length` operands in the reverse of the `CALLDATACOPY`/`CODECOPY`/`RETURNDATACOPY` convention, and the reverse of the sibling `FRAMEDATACOPY` — which was aligned to that convention in ethereum/EIPs#11938. This aligns `SIGPARAM`'s copy operands with `FRAMEDATACOPY`/`CALLDATACOPY` (`memOffset`, `dataOffset`, `length`, top to bottom), removing the internal inconsistency.

The two orders differ observably for asymmetric operands (wrong pop order gives the wrong source/destination, hence wrong memory and state root), so aligning them removes a correctness footgun.

This is a normative change: an implementation following the current reversed order must flip its `SIGPARAM` copy handling. If instead the reversed order is intended, an explicit stack table documenting it would resolve the inconsistency the other way — but matching the established convention and the already-fixed `FRAMEDATACOPY` is the safer default.