### PR TITLE
Update EIP-8297: Delete leaves on zeroization

### DIFF
--- a/EIPS/eip-8297.md
+++ b/EIPS/eip-8297.md
@@ -344,9 +344,9 @@ leaf needs one branch opening instead of three or four, which lowers gas and
 simplifies witness generation.
 
 Setting any header field also sets `version` to zero. `code_hash` and
-`code_size` are set on contract or EOA creation; a codeless account's code
-hash leaf holds the Keccak hash of empty bytecode, unaffected by this EIP's
-choice of merkelization hash (see "Backwards Compatibility").
+`code_size` are set on contract or EOA creation; an account with no code
+holds the Keccak hash of empty bytecode in its code hash leaf, unaffected by
+this EIP's choice of merkelization hash (see "Backwards Compatibility").
 
 ### Code
 
@@ -407,7 +407,7 @@ deletion"). Chunk presence therefore does not delimit a contract's code: the
 chunk count is `ceil(code_size / 31)`, and an absent chunk reads back as the
 32 zero bytes it would have held, so the EVM cannot distinguish the two. A
 contract whose code is entirely zeros has no code leaves at all and is still
-distinguished from a codeless account by `code_size` and `code_hash`. A
+distinguished from an account with no code by `code_size` and `code_hash`. A
 witness proves such a chunk absent where it would otherwise prove its value.
 
 ### Storage
@@ -466,7 +466,7 @@ def state_write(entries: dict[bytes, bytes], key: bytes, value: bytes) -> None:
 Writing zero to an absent key is therefore a no-op, no key in the state's
 tree holds 32 zero bytes, and reading an absent key yields zero. Zero and
 absent are the same state and commit to the same root, as in the MPT (see
-"Zero means absent").
+"Collapsing zero and absent").
 
 Deleting an account ([EIP-161](./eip-161.md) state clearing, or
 `SELFDESTRUCT` in the transaction that created the account, per
@@ -581,7 +581,7 @@ the shared run into the branch's prefix (see "Tree structure") collapses
 each such chain to one node, which is also what bounds the proof-size cost
 of a grinded set of groups in "Security Considerations".
 
-### Zero means absent
+### Collapsing zero and absent
 
 Collapsing zero and absent keeps the root a function of the state alone and
 not of the writes that produced it, as in the MPT. A client's flat state can

--- a/EIPS/eip-8297.md
+++ b/EIPS/eip-8297.md
@@ -203,10 +203,7 @@ def state_root(entries: dict[bytes, bytes]) -> bytes:
 
 The tree has two mutations: insertion, which sets a key's value, and
 deletion, which removes a key. Both are generic over the value space.
-Neither inspects the value, and the tree has no distinguished value that
-means absence: any 32-byte value may be stored, and only the presence of a
-key distinguishes it from an absent one. The root after a mutation is
-`state_root` of the resulting entry set.
+The root after a mutation is `state_root` of the resulting entry set.
 
 ```python
 def insert(entries: dict[bytes, bytes], key: bytes, value: bytes) -> None:
@@ -268,7 +265,7 @@ branch openings. The account header holds an account's basic data, code
 hash, first 64 storage slots, and first 128 code chunks under keys sharing
 one header stem.
 
-| Parameter              | Value |
+| Parameter               | Value |
 | ----------------------- | ----- |
 | BASIC_DATA_LEAF_KEY     | 0     |
 | CODE_HASH_LEAF_KEY      | 1     |
@@ -401,6 +398,18 @@ def chunkify_code(code: bytes) -> Sequence[bytes32]:
     ]
 ```
 
+A chunk encodes to 32 zero bytes when its 31 code bytes are all `0x00` and
+byte 0's PUSHDATA count is zero too, as in a run of `STOP` or a zero-filled
+data region. Zero bytes that continue PUSHDATA from an earlier chunk do not
+qualify, since byte 0 then records the continuation. Such a zero chunk is
+absent from the tree like any other zero value (see "Zero values and
+deletion"). Chunk presence therefore does not delimit a contract's code: the
+chunk count is `ceil(code_size / 31)`, and an absent chunk reads back as the
+32 zero bytes it would have held, so the EVM cannot distinguish the two. A
+contract whose code is entirely zeros has no code leaves at all and is still
+distinguished from a codeless account by `code_size` and `code_hash`. A
+witness proves such a chunk absent where it would otherwise prove its value.
+
 ### Storage
 
 Storage slots 0 through 63 live in the account header's stem at
@@ -443,10 +452,8 @@ mappings and arrays, share a group.
 
 ### Zero values and deletion
 
-The tree itself has no zero rule: it stores and removes any 32-byte value
-(see "Insertion and deletion"). Mapping zero to absence belongs to the state
-transition function, which MUST resolve a write of 32 zero bytes to a
-deletion rather than an insertion:
+Mapping zero to absence belongs to the state transition function, which
+MUST resolve a write of 32 zero bytes to a deletion rather than an insertion:
 
 ```python
 def state_write(entries: dict[bytes, bytes], key: bytes, value: bytes) -> None:
@@ -601,6 +608,19 @@ as in [EIP-7864](./eip-7864.md). The only account whose `BASIC_DATA` is all
 zero is the empty account of [EIP-161](./eip-161.md), with zero nonce, zero
 balance and no code, which the EVM cannot distinguish from a nonexistent
 account and which state clearing deletes when it is touched.
+
+The rule applies to code chunks too, which are the one value in this tree
+whose zero encoding carries meaning rather than being the natural spelling of
+"unset" (see "Code"). Exempting them would make the rule depend on the key
+rather than the value, and the exemption is not a zone: chunks 0 through 127
+share the account header's stem with `BASIC_DATA`, `code_hash`, and the first
+64 storage slots, so the carve-out is a sub-index range within
+`ACCOUNT_ZONE`, which every consumer of the invariant would have to
+reproduce. The uniform rule buys that simplicity for nothing, since
+`code_size` already delimits the code and an absent chunk reads as the zeros
+it would have held. What it does not buy is a smaller state, since an
+exemption stores only leaves whose contents are already implied by
+`code_size`.
 
 The alternative, a zero-valued leaf that stays in the tree and is distinct
 from an absent key, is what a multi-tree state expiry design requires, where

--- a/EIPS/eip-8297.md
+++ b/EIPS/eip-8297.md
@@ -242,19 +242,19 @@ branch openings. The account header holds an account's basic data, code
 hash, first 64 storage slots, and first 128 code chunks under keys sharing
 one header stem.
 
-| Parameter              | Value |
+| Parameter | Value |
 | ----------------------- | ----- |
-| BASIC_DATA_LEAF_KEY     | 0     |
-| CODE_HASH_LEAF_KEY      | 1     |
-| HEADER_STORAGE_OFFSET   | 64    |
-| CODE_OFFSET             | 128   |
-| STEM_SUBTREE_WIDTH      | 256   |
-| ACCOUNT_ZONE            | 0x00  |
-| CODE_ZONE               | 0x01  |
-| STORAGE_ZONE            | 0xFF  |
-| ACCOUNT_KEY_LENGTH      | 34    |
-| CODE_KEY_LENGTH         | 34    |
-| STORAGE_KEY_LENGTH      | 66    |
+| BASIC_DATA_LEAF_KEY | 0 |
+| CODE_HASH_LEAF_KEY | 1 |
+| HEADER_STORAGE_OFFSET | 64 |
+| CODE_OFFSET | 128 |
+| STEM_SUBTREE_WIDTH | 256 |
+| ACCOUNT_ZONE | 0x00 |
+| CODE_ZONE | 0x01 |
+| STORAGE_ZONE | 0xFF |
+| ACCOUNT_KEY_LENGTH | 34 |
+| CODE_KEY_LENGTH | 34 |
+| STORAGE_KEY_LENGTH | 66 |
 
 It is a required invariant that `STEM_SUBTREE_WIDTH > CODE_OFFSET >
 HEADER_STORAGE_OFFSET`.
@@ -320,10 +320,7 @@ bytes, far beyond any foreseeable contract size limit. Packing these fields into
 leaf needs one branch opening instead of three or four, which lowers gas and
 simplifies witness generation.
 
-`version` identifies this layout and is 1. Setting any header field also
-sets it. An existing account therefore always has a non-zero `BASIC_DATA`
-value, so the account exists exactly when that leaf is present (see "Zero
-values and deletion"). `code_hash` and
+Setting any header field also sets `version` to zero. `code_hash` and
 `code_size` are set on contract or EOA creation; a codeless account's code
 hash leaf holds the Keccak hash of empty bytecode, unaffected by this EIP's
 choice of merkelization hash (see "Backwards Compatibility").
@@ -423,33 +420,19 @@ mappings and arrays, share a group.
 A key whose value is 32 zero bytes MUST NOT be present in the tree. Writing
 zero to a key removes it, writing zero to an absent key is a no-op, and
 reading an absent key yields zero. Zero and absent are the same state and
-commit to the same root, as in the MPT, so the root is a function of the
-state alone and not of the writes that produced it.
-
-The root is a function of the entry set (see "Tree structure"), so dropping
-the entry defines the new root and the canonical form is restored by
-construction. An implementation that maintains the tree incrementally
-performs that restoration as a merge: the removed leaf's parent
-`BranchNode` is left with one child and is replaced by it, a surviving
-`LeafNode` unchanged because it commits its complete key, a surviving
-`BranchNode` rebuilt with its parent's prefix, the branch bit leading to
-it, and its own prefix concatenated. The merge stops there, because the
-grandparent still has two non-empty children.
+commit to the same root, as in the MPT (see "Zero means absent").
 
 Deleting an account ([EIP-161](./eip-161.md) state clearing, or
 `SELFDESTRUCT` in the transaction that created the account, per
 [EIP-6780](./eip-6780.md)) MUST remove its header leaves and its storage
-leaves. Leaves in `CODE_ZONE` are content-addressed and may be shared, so
-they MUST NOT be removed; reclaiming them requires reference counting and is
-left to a future state-expiry mechanism (see "State expiry").
+leaves. Its `CODE_ZONE` leaves are content-addressed and may be shared with
+other accounts, so they MUST NOT be removed.
 
-Presence answers the questions the MPT answered with an account node and a
-`storage_root`. An account exists exactly when its `BASIC_DATA` leaf is
-present, which the non-zero `version` field guarantees for every existing
-account (see "Header values"). An address has non-empty storage, the
-condition [EIP-7610](./eip-7610.md) tests before contract creation, exactly
-when a storage leaf exists for it in its header stem or its storage bucket,
-equivalently when any of its slots is non-zero.
+The MPT checked `storage_root` to decide whether an address has non-empty
+storage (i.e., the that condition [EIP-7610](./eip-7610.md) checks before contract
+creation). This tree has no such node, and thus the address has non-empty storage
+exactly when a leaf exists at one of its header sub-indices
+`HEADER_STORAGE_OFFSET`..`127` or anywhere in its storage bucket.
 
 ### Fork
 
@@ -554,26 +537,31 @@ of a grinded set of groups in "Security Considerations".
 
 ### Zero means absent
 
-Collapsing zero and absent keeps the root a function of the state alone. A
-client's flat state can keep representing zero as the absence of a record, a
-tree rebuilt from a state dump reproduces the root, and a state description
-such as a test fixture can express any pre-state. It also leaves one
-representation of zero at the proof layer, and it makes a tree converted
-from the MPT, which carries no record of slots cleared before the fork,
-agree with one maintained incrementally across it.
+Collapsing zero and absent keeps the root a function of the state alone and
+not of the writes that produced it, as in the MPT. A client's flat state can
+keep representing zero as the absence of a record, a tree rebuilt from a
+state dump reproduces the root, a test fixture can express any pre-state,
+and a tree converted from the MPT, which carries no record of slots cleared
+before the fork, agrees with one maintained incrementally across it. Zero
+also has a single representation at the proof layer.
+
+Accounts need no existence marker under this rule, so `version` stays zero
+as in [EIP-7864](./eip-7864.md). The only account whose `BASIC_DATA` is all
+zero is the empty account of [EIP-161](./eip-161.md), with zero nonce, zero
+balance and no code, which the EVM cannot distinguish from a nonexistent
+account and which state clearing deletes when it is touched.
 
 The alternative, a zero-valued leaf that stays in the tree and is distinct
-from an absent key, is what a multi-tree state expiry design requires: there
-"absent" means "the latest version of this object may be in an older tree,
-check those first", so it cannot also mean "zero". Expiry on this tree does
-not work that way. It marks an expired region with a stub introduced at the
-expiry fork (see "State expiry"), and its soundness comes from that stub
-rather than from leaves left at zero.
+from an absent key, is what a multi-tree state expiry design requires, where
+"absent" means the latest version of the object may be in an older tree.
+Expiry on this tree instead marks an expired region with a stub introduced
+at the expiry fork (see "State expiry").
 
-The cost is the merge logic in "Zero values and deletion" and re-paying
-state-creation gas for a slot that is cleared and later rewritten. The merge
-is bounded to one level and is the inverse of the split that adding the key
-performs, which an incremental implementation already does.
+The cost is deletion logic in clients that maintain the tree incrementally,
+and re-paying state-creation gas for a slot that is cleared and later
+rewritten. Removing an entry leaves its parent branch with one child and
+merges that child up, which is bounded to one level and inverts the split
+insertion already performs.
 The gas asymmetry is a pricing question, better answered in the gas schedule
 than by holding roughly a hundred bytes of consensus state for every slot
 ever created.

--- a/EIPS/eip-8297.md
+++ b/EIPS/eip-8297.md
@@ -472,7 +472,8 @@ Deleting an account ([EIP-161](./eip-161.md) state clearing, or
 `SELFDESTRUCT` in the transaction that created the account, per
 [EIP-6780](./eip-6780.md)) MUST remove its header leaves and its storage
 leaves. Its `CODE_ZONE` leaves are content-addressed and may be shared with
-other accounts, so they MUST NOT be removed.
+other accounts, so they MUST be removed only if no account in the resulting
+state has the same `code_hash`, and MUST be kept otherwise.
 
 The MPT checked `storage_root` to decide whether an address has non-empty
 storage (i.e., the that condition [EIP-7610](./eip-7610.md) checks before contract
@@ -532,8 +533,13 @@ identical bytecode share leaves. Most deployed contracts repeat a small number o
 templates, so this removes a large amount of duplicate code from the state. For
 the same reason, a block witness contains at most one copy of a shared chunk, no
 matter how many contracts touch it. The first 128 chunks stay in the account
-header, keyed per account, so they expire with the account and need no reference
-counting. Only chunks beyond ~4 KB are shared between contracts.
+header, keyed per account, so they are removed with the account and need no
+reference counting. Only chunks beyond ~4 KB are shared between contracts, and
+only those need the check account deletion applies before removing them (see
+"Zero values and deletion"). That check is cheap in practice: the accounts a
+block deletes are those [EIP-161](./eip-161.md) clears, which have no code at
+all, and those `SELFDESTRUCT` removes in their creation transaction, whose code
+the same transaction wrote.
 
 ### SNARK friendliness and post-quantum security
 

--- a/EIPS/eip-8297.md
+++ b/EIPS/eip-8297.md
@@ -194,11 +194,37 @@ def state_root(entries: dict[bytes, bytes]) -> bytes:
     for key, value in entries.items():
         assert 1 <= len(key) <= MAX_KEY_LENGTH, "key length out of range"
         assert len(value) == 32, "value must be 32 bytes"
-        assert value != b"\x00" * 32, "zero value must be absent"
     if len(entries) == 0:
         return b"\x00" * 32
     return merkelize(binarize(entries, 0))
 ```
+
+### Insertion and deletion
+
+The tree has two mutations: insertion, which sets a key's value, and
+deletion, which removes a key. Both are generic over the value space.
+Neither inspects the value, and the tree has no distinguished value that
+means absence: any 32-byte value may be stored, and only the presence of a
+key distinguishes it from an absent one. The root after a mutation is
+`state_root` of the resulting entry set.
+
+```python
+def insert(entries: dict[bytes, bytes], key: bytes, value: bytes) -> None:
+    entries[key] = value
+
+def delete(entries: dict[bytes, bytes], key: bytes) -> None:
+    entries.pop(key, None)
+```
+
+An implementation that maintains the tree incrementally rather than
+rebuilding it MUST produce `state_root` of the resulting entry set. For
+deletion this means restoring the canonical form: removing a key leaves its
+parent branch with a single child, which MUST take that branch's place. A
+surviving `LeafNode` is promoted unchanged, since it commits its complete
+key. A surviving `BranchNode` takes the parent's prefix, followed by the bit
+that selected it, followed by its own prefix. Only the direct parent can be
+left with one child, so the merge is bounded to one level, and it inverts
+the split that insertion performs.
 
 ### Maximum key length
 
@@ -417,10 +443,23 @@ mappings and arrays, share a group.
 
 ### Zero values and deletion
 
-A key whose value is 32 zero bytes MUST NOT be present in the tree. Writing
-zero to a key removes it, writing zero to an absent key is a no-op, and
-reading an absent key yields zero. Zero and absent are the same state and
-commit to the same root, as in the MPT (see "Zero means absent").
+The tree itself has no zero rule: it stores and removes any 32-byte value
+(see "Insertion and deletion"). Mapping zero to absence belongs to the state
+transition function, which MUST resolve a write of 32 zero bytes to a
+deletion rather than an insertion:
+
+```python
+def state_write(entries: dict[bytes, bytes], key: bytes, value: bytes) -> None:
+    if value == b"\x00" * 32:
+        delete(entries, key)
+    else:
+        insert(entries, key, value)
+```
+
+Writing zero to an absent key is therefore a no-op, no key in the state's
+tree holds 32 zero bytes, and reading an absent key yields zero. Zero and
+absent are the same state and commit to the same root, as in the MPT (see
+"Zero means absent").
 
 Deleting an account ([EIP-161](./eip-161.md) state clearing, or
 `SELFDESTRUCT` in the transaction that created the account, per
@@ -545,6 +584,18 @@ and a tree converted from the MPT, which carries no record of slots cleared
 before the fork, agrees with one maintained incrementally across it. Zero
 also has a single representation at the proof layer.
 
+The rule sits in the state transition function and leaves the tree generic,
+which is the MPT's split: the trie is defined over arbitrary key/value pairs
+with no distinguished value, and the storage trie holding only non-zero
+slots is a property of how state maps into it rather than of the trie. Keeping
+the layers apart means the tree can be specified, tested, and reused without
+carrying a rule that belongs to the EVM's value semantics, and a client is
+free to spell a zero write as an explicit delete or as a write its own tree
+layer collapses, since only the resulting entry set is committed. Zero is the
+trigger because the EVM has no other spelling of "unset": a storage slot is a
+256-bit word that reads as zero before it is ever written, and `SSTORE` of
+zero is how a contract clears one.
+
 Accounts need no existence marker under this rule, so `version` stays zero
 as in [EIP-7864](./eip-7864.md). The only account whose `BASIC_DATA` is all
 zero is the empty account of [EIP-161](./eip-161.md), with zero nonce, zero
@@ -559,9 +610,8 @@ at the expiry fork (see "State expiry").
 
 The cost is deletion logic in clients that maintain the tree incrementally,
 and re-paying state-creation gas for a slot that is cleared and later
-rewritten. Removing an entry leaves its parent branch with one child and
-merges that child up, which is bounded to one level and inverts the split
-insertion already performs.
+rewritten. The merge that deletion requires is bounded to one level and
+inverts the split insertion already performs (see "Insertion and deletion").
 The gas asymmetry is a pricing question, better answered in the gas schedule
 than by holding roughly a hundred bytes of consensus state for every slot
 ever created.

--- a/EIPS/eip-8297.md
+++ b/EIPS/eip-8297.md
@@ -201,27 +201,22 @@ def state_root(entries: dict[bytes, bytes]) -> bytes:
 
 ### Insertion and deletion
 
-The tree has two mutations: insertion, which sets a key's value, and
-deletion, which removes a key. Both are generic over the value space.
-The root after a mutation is `state_root` of the resulting entry set.
-
-```python
-def insert(entries: dict[bytes, bytes], key: bytes, value: bytes) -> None:
-    entries[key] = value
-
-def delete(entries: dict[bytes, bytes], key: bytes) -> None:
-    entries.pop(key, None)
-```
+A mutation is an update to the entry set: insertion, which sets a key's
+value, or deletion, which removes the key. Both are generic over the value
+space. The tree has no distinguished value that means absence: any 32-byte
+value may be stored, and only the presence of a key distinguishes it from
+an absent one. The root after a mutation is `state_root` of the resulting
+entry set.
 
 An implementation that maintains the tree incrementally rather than
-rebuilding it MUST produce `state_root` of the resulting entry set. For
-deletion this means restoring the canonical form: removing a key leaves its
-parent branch with a single child, which MUST take that branch's place. A
-surviving `LeafNode` is promoted unchanged, since it commits its complete
-key. A surviving `BranchNode` takes the parent's prefix, followed by the bit
-that selected it, followed by its own prefix. Only the direct parent can be
-left with one child, so the merge is bounded to one level, and it inverts
-the split that insertion performs.
+rebuilding it MUST still produce that root. For deletion this means
+restoring the canonical form: removing a key leaves its parent branch with
+a single child, which MUST take that branch's place. A surviving `LeafNode`
+is promoted unchanged, since it commits its complete key. A surviving
+`BranchNode` takes the parent's prefix, followed by the bit that selected
+it, followed by its own prefix. Only the direct parent can be left with one
+child, so the merge is bounded to one level, and it inverts the split that
+insertion performs.
 
 ### Maximum key length
 
@@ -458,9 +453,9 @@ MUST resolve a write of 32 zero bytes to a deletion rather than an insertion:
 ```python
 def state_write(entries: dict[bytes, bytes], key: bytes, value: bytes) -> None:
     if value == b"\x00" * 32:
-        delete(entries, key)
+        entries.pop(key, None)
     else:
-        insert(entries, key, value)
+        entries[key] = value
 ```
 
 Writing zero to an absent key is therefore a no-op, no key in the state's

--- a/EIPS/eip-8297.md
+++ b/EIPS/eip-8297.md
@@ -194,6 +194,7 @@ def state_root(entries: dict[bytes, bytes]) -> bytes:
     for key, value in entries.items():
         assert 1 <= len(key) <= MAX_KEY_LENGTH, "key length out of range"
         assert len(value) == 32, "value must be 32 bytes"
+        assert value != b"\x00" * 32, "zero value must be absent"
     if len(entries) == 0:
         return b"\x00" * 32
     return merkelize(binarize(entries, 0))
@@ -319,7 +320,10 @@ bytes, far beyond any foreseeable contract size limit. Packing these fields into
 leaf needs one branch opening instead of three or four, which lowers gas and
 simplifies witness generation.
 
-Setting any header field also sets `version` to zero. `code_hash` and
+`version` identifies this layout and is 1. Setting any header field also
+sets it. An existing account therefore always has a non-zero `BASIC_DATA`
+value, so the account exists exactly when that leaf is present (see "Zero
+values and deletion"). `code_hash` and
 `code_size` are set on contract or EOA creation; a codeless account's code
 hash leaf holds the Keccak hash of empty bytecode, unaffected by this EIP's
 choice of merkelization hash (see "Backwards Compatibility").
@@ -416,13 +420,36 @@ mappings and arrays, share a group.
 
 ### Zero values and deletion
 
-Writing 32 zero bytes stores that value like any other: the leaf stays
-present, and a zero-valued leaf is distinct from an absent key, committing
-to a different root. EVM execution never removes entries from the tree, so
-insertion and in-place update are the only mutations, and implementations
-never need delete logic that restores the canonical form by merging a lone
-surviving child back into its parent. Removing entries is reserved for a
-future state-expiry mechanism (see "State expiry").
+A key whose value is 32 zero bytes MUST NOT be present in the tree. Writing
+zero to a key removes it, writing zero to an absent key is a no-op, and
+reading an absent key yields zero. Zero and absent are the same state and
+commit to the same root, as in the MPT, so the root is a function of the
+state alone and not of the writes that produced it.
+
+The root is a function of the entry set (see "Tree structure"), so dropping
+the entry defines the new root and the canonical form is restored by
+construction. An implementation that maintains the tree incrementally
+performs that restoration as a merge: the removed leaf's parent
+`BranchNode` is left with one child and is replaced by it, a surviving
+`LeafNode` unchanged because it commits its complete key, a surviving
+`BranchNode` rebuilt with its parent's prefix, the branch bit leading to
+it, and its own prefix concatenated. The merge stops there, because the
+grandparent still has two non-empty children.
+
+Deleting an account ([EIP-161](./eip-161.md) state clearing, or
+`SELFDESTRUCT` in the transaction that created the account, per
+[EIP-6780](./eip-6780.md)) MUST remove its header leaves and its storage
+leaves. Leaves in `CODE_ZONE` are content-addressed and may be shared, so
+they MUST NOT be removed; reclaiming them requires reference counting and is
+left to a future state-expiry mechanism (see "State expiry").
+
+Presence answers the questions the MPT answered with an account node and a
+`storage_root`. An account exists exactly when its `BASIC_DATA` leaf is
+present, which the non-zero `version` field guarantees for every existing
+account (see "Header values"). An address has non-empty storage, the
+condition [EIP-7610](./eip-7610.md) tests before contract creation, exactly
+when a storage leaf exists for it in its header stem or its storage bucket,
+equivalently when any of its slots is non-zero.
 
 ### Fork
 
@@ -524,6 +551,32 @@ produce long chains of branch nodes with a single occupied child. Folding
 the shared run into the branch's prefix (see "Tree structure") collapses
 each such chain to one node, which is also what bounds the proof-size cost
 of a grinded set of groups in "Security Considerations".
+
+### Zero means absent
+
+Collapsing zero and absent keeps the root a function of the state alone. A
+client's flat state can keep representing zero as the absence of a record, a
+tree rebuilt from a state dump reproduces the root, and a state description
+such as a test fixture can express any pre-state. It also leaves one
+representation of zero at the proof layer, and it makes a tree converted
+from the MPT, which carries no record of slots cleared before the fork,
+agree with one maintained incrementally across it.
+
+The alternative, a zero-valued leaf that stays in the tree and is distinct
+from an absent key, is what a multi-tree state expiry design requires: there
+"absent" means "the latest version of this object may be in an older tree,
+check those first", so it cannot also mean "zero". Expiry on this tree does
+not work that way. It marks an expired region with a stub introduced at the
+expiry fork (see "State expiry"), and its soundness comes from that stub
+rather than from leaves left at zero.
+
+The cost is the merge logic in "Zero values and deletion" and re-paying
+state-creation gas for a slot that is cleared and later rewritten. The merge
+is bounded to one level and is the inverse of the split that adding the key
+performs, which an incremental implementation already does.
+The gas asymmetry is a pricing question, better answered in the gas schedule
+than by holding roughly a hundred bytes of consensus state for every slot
+ever created.
 
 ### State expiry
 

--- a/EIPS/eip-8297.md
+++ b/EIPS/eip-8297.md
@@ -242,19 +242,19 @@ branch openings. The account header holds an account's basic data, code
 hash, first 64 storage slots, and first 128 code chunks under keys sharing
 one header stem.
 
-| Parameter | Value |
+| Parameter              | Value |
 | ----------------------- | ----- |
-| BASIC_DATA_LEAF_KEY | 0 |
-| CODE_HASH_LEAF_KEY | 1 |
-| HEADER_STORAGE_OFFSET | 64 |
-| CODE_OFFSET | 128 |
-| STEM_SUBTREE_WIDTH | 256 |
-| ACCOUNT_ZONE | 0x00 |
-| CODE_ZONE | 0x01 |
-| STORAGE_ZONE | 0xFF |
-| ACCOUNT_KEY_LENGTH | 34 |
-| CODE_KEY_LENGTH | 34 |
-| STORAGE_KEY_LENGTH | 66 |
+| BASIC_DATA_LEAF_KEY     | 0     |
+| CODE_HASH_LEAF_KEY      | 1     |
+| HEADER_STORAGE_OFFSET   | 64    |
+| CODE_OFFSET             | 128   |
+| STEM_SUBTREE_WIDTH      | 256   |
+| ACCOUNT_ZONE            | 0x00  |
+| CODE_ZONE               | 0x01  |
+| STORAGE_ZONE            | 0xFF  |
+| ACCOUNT_KEY_LENGTH      | 34    |
+| CODE_KEY_LENGTH         | 34    |
+| STORAGE_KEY_LENGTH      | 66    |
 
 It is a required invariant that `STEM_SUBTREE_WIDTH > CODE_OFFSET >
 HEADER_STORAGE_OFFSET`.


### PR DESCRIPTION
Flips "Zero values and deletion" to zero-means-absent, matching MPT semantics: a key whose value is 32 zero bytes is not present in the tree, and writing zero removes it.

This resolves the divergence between the EIP as written and both `ethereum.state_pbt` and EIP-8347's BAL-replay rules, which already delete on zeroization. See ethereum/execution-specs#3254, surfaced by the fixture work in ethereum/execution-specs#3246.