### PR TITLE
Update EIP-8081: Propose EIP-8333 for inclusion

### DIFF
--- a/EIPS/eip-8081.md
+++ b/EIPS/eip-8081.md
@@ -61,6 +61,7 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Declined
 * [EIP-8279](./eip-8279.md): Block Access List Byte Floor
 * [EIP-8298](./eip-8298.md): SETCODEFROM Code Reuse Instruction
 * [EIP-8304](./eip-8304.md): Trustless log and transaction index
+* [EIP-8333](./eip-8333.md): Align Checkpoint with Epoch Boundary Block
 
 ### Activation
 


### PR DESCRIPTION
Proposes EIP-8333 (Align Checkpoint with Epoch Boundary Block) for inclusion in Hegotá, per the EIP-7723 process.

Discussion: https://ethereum-magicians.org/t/eip-8333-align-checkpoint-with-epoch-boundary-block/29003