### PR TITLE
Update EIP-7975: clarify upper bound

### DIFF
--- a/EIPS/eip-7975.md
+++ b/EIPS/eip-7975.md
@@ -53,7 +53,7 @@ receipt lists cannot be verified against the block header, so in responses with
 
 ## Rationale
 
-Since [EIP-7825] caps the gas limit of a single transaction to ~16.7M gas, a single
+Since [EIP-7825](./eip-7825.md) caps the gas limit of a single transaction to ~16.7M gas, a single
 transaction receipt will always be limited in size. Specifically, a transaction can
 produce at most 16777216/8 = 2MiB of log data.
 

--- a/EIPS/eip-7975.md
+++ b/EIPS/eip-7975.md
@@ -51,8 +51,6 @@ receipt lists cannot be verified against the block header, so in responses with
   i.e. reject if it is larger than gaslimit/8.
 - Verify the total downloaded receipts size is no larger than allowed by the block gas limit.
 
-A more precise upper bound is obtained from the gas cost of log data, not from the number of receipts. Each byte of log data currently costs 8 gas units. Therefore, the maximum log data per transaction receipt is at most the transaction gas limit (bounded by [EIP-7825](./eip-7825.md)) divided by 8, and the total size of receipt log data is bounded by the block gas limit.
-
 ## Rationale
 
 Since [EIP-7825] caps the gas limit of a single transaction to ~16.7M gas, a single

--- a/EIPS/eip-7975.md
+++ b/EIPS/eip-7975.md
@@ -51,7 +51,7 @@ receipt lists cannot be verified against the block header, so in responses with
   i.e. reject if it is larger than gaslimit/8.
 - Verify the total downloaded receipts size is no larger than allowed by the block gas limit.
 
-<!-- Needs exact formula -->
+A more precise upper bound is obtained from the gas cost of log data, not from the number of receipts. Each byte of log data currently costs 8 gas units. Therefore, the maximum log data per transaction receipt is at most the transaction gas limit (bounded by [EIP-7825](./eip-7825.md)) divided by 8, and the total size of receipt log data is bounded by the block gas limit.
 
 ## Rationale
 
@@ -87,5 +87,3 @@ None
 ## Copyright
 
 Copyright and related rights waived via [CC0](../LICENSE.md).
-
-[EIP-7825]: ./eip-7825.md


### PR DESCRIPTION
Clarifies upper bound to mitigate DoS vector.

Also removes unused footnote.

CC @Giulio2002 @fjl 