### PR TITLE
Update EIP-8333: add twoeths as author

### DIFF
--- a/EIPS/eip-8333.md
+++ b/EIPS/eip-8333.md
@@ -2,7 +2,7 @@
 eip: 8333
 title: Align Checkpoint with Epoch Boundary Block
 description: Resolve FFG checkpoints to the last block before the epoch instead of the first block of the epoch
-author: Cayman (@wemeetagain), Nico Flaig (@nflaig), Lodekeeper (@lodekeeper)
+author: Cayman (@wemeetagain), Nico Flaig (@nflaig), Lodekeeper (@lodekeeper), twoeths (@twoeths)
 discussions-to: https://ethereum-magicians.org/t/eip-8333-align-checkpoint-with-epoch-boundary-block/29003
 status: Draft
 type: Standards Track


### PR DESCRIPTION
Adds `twoeths (@twoeths)` to the EIP-8333 author list at the author's request.

- Opened by @lodekeeper, an existing listed author.
- @twoeths confirmed the GitHub handle to use.

Frontmatter `author:` line only; no other changes.