### PR TITLE
Update EIP-8070: specify bit ordering for the 16-byte cell bitarrays

### DIFF
--- a/EIPS/eip-8070.md
+++ b/EIPS/eip-8070.md
@@ -38,7 +38,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 We introduce a new devp2p protocol version, `eth/72` extending the existing `eth/71` protocol.
 
 **Modify `NewPooledTransactionHashes` (`0x08`) message.**
-Add a new field `cell_mask` of type `B_16` (`uint128`). This field MUST be interpreted as a bitarray of length `CELLS_PER_EXT_BLOB`, carrying `1` in the indices of columns the announcer has available for **all type 3 txs announced within the message**. This field MUST be set to `nil` when no transactions of such type are announced. (TODO: this approach is not expressive enough if the node wants to offer randomly sampled columns, nor if it wants to announce transactions with full and partial availability in a single message).
+Add a new field `cell_mask` of type `B_16` (`uint128`). This field MUST be interpreted as a bitarray of length `CELLS_PER_EXT_BLOB`, carrying `1` in the indices of columns the announcer has available for **all type 3 txs announced within the message**. Column `i` is bit `i % 8` of byte `i / 8`, that is, the SSZ serialization of `BitVector[CELLS_PER_EXT_BLOB]`. The field is a 16-byte string and is not encoded as an RLP integer. This field MUST be set to `nil` when no transactions of such type are announced. (TODO: this approach is not expressive enough if the node wants to offer randomly sampled columns, nor if it wants to announce transactions with full and partial availability in a single message).
 
 - old schema (`eth/71`): `[types: B, [size_0: P, size_1: P, ...], [hash_0: B_32, hash_1: B_32, ...]]`
 - new schema (`eth/72`): `[types: B, [size_0: P, size_1: P, ...], [hash_0: B_32, hash_1: B_32, ...], cell_mask: B_16]`
@@ -96,7 +96,7 @@ Request:
 - params:
   1. `forkchoiceState`: `ForkchoiceStateV1`.
   2. `payloadAttributes`: `Object|null` - Instance of `PayloadAttributesV4` or `null`.
-  3. `custodyColumns`: `DATA|null` - 16-byte value interpreted as a bitarray of length `CELLS_PER_EXT_BLOB`, where a `1` at position `i` indicates the CL node has custody of column `i`. `null` if the CL does not provide custody services.
+  3. `custodyColumns`: `DATA|null` - 16-byte value interpreted as a bitarray of length `CELLS_PER_EXT_BLOB`, where a `1` at position `i` indicates the CL node has custody of column `i`. The value is the SSZ serialization of `BitVector[CELLS_PER_EXT_BLOB]`: column `i` is bit `i % 8` of byte `i / 8`. `null` if the CL does not provide custody services.
 - timeout: 8s
 
 Response:
@@ -121,7 +121,7 @@ Request:
 - method: `engine_getBlobsV4`
 - params:
   - `versioned_blob_hashes`: []bytes32, an array of blob versioned hashes.
-  - `indices_bitarray`: uint128, a bitarray denoting the indices of the cells to retrieve.
+  - `indices_bitarray`: uint128, a bitarray denoting the indices of the cells to retrieve. The value is the SSZ serialization of `BitVector[CELLS_PER_EXT_BLOB]`: cell index `i` is bit `i % 8` of byte `i / 8`.
 - timeout: 500ms
 
 Response:


### PR DESCRIPTION
Scope: clarify the bit ordering of the three 16-byte bitarrays (`cell_mask`, `custodyColumns`, `indices_bitarray`). No change to logic or intent.

None of them states how bit positions map onto bytes, and the failure is silent: a reversed order still decodes to a well-formed 128-bit set, so a node samples the wrong columns instead of returning an error. Worse, `cell_mask` and `indices_bitarray` are annotated `uint128`, and RLP encodes integers big-endian, so following that annotation puts column 0 in the last byte, the opposite of what clients do.

The ordering specified is the SSZ serialization of `BitVector[CELLS_PER_EXT_BLOB]` ([consensus specs](https://github.com/ethereum/consensus-specs/blob/master/ssz/simple-serialize.md#bitvectorn)), `array[i // 8] |= value[i] << (i % 8)`. The custody set is SSZ-native, so this introduces no new convention. It matches go-ethereum, where `core/types/custody_bitmap.go` sets `result[i/8] |= 1 << (i % 8)` and marshals the 16 bytes as plain hex. ethrex implements the same ordering.

Companion pull request for the two Engine API fields: ethereum/execution-apis#856, wording kept identical so the documents cannot drift.
