### PR TITLE
Add EIP: EVM Verification Key Registry

### DIFF
--- a/EIPS/eip-8357.md
+++ b/EIPS/eip-8357.md
@@ -30,15 +30,10 @@ upgrade process instead of maintaining a bespoke verifier and its governance.
 The rollup contract must therefore identify the verification key that L1 has
 approved for proving EVM execution.
 
-Proof-verification mechanisms can verify a proof under an exact key without
-identifying which key represents the canonical L1 EVM or exposing its
-activation timestamp. [EIP-8288](./eip-8288.md) is one such mechanism.
-Hard-coding those values would force each rollup to upgrade through its own
-governance at every L1 feature fork or remain on an older EVM.
-
-This EIP makes the fork-selected key and activation timestamp available inside
-the EVM, allowing rollups to follow Ethereum upgrades automatically or retain
-historical EVM semantics.
+[EIP-8288](./eip-8288.md) verifies proofs against explicitly supplied keys, but
+does not tell contracts which keys L1 recognizes, which one is current, or when
+each became active. Hard-coding those values would force each rollup to upgrade
+through its own governance at every L1 feature fork or remain on an older EVM.
 
 ## Specification
 
@@ -77,7 +72,7 @@ available through exact-key lookup.
 
 Entries are append-only. A registered key MUST NOT be deleted or overwritten.
 
-For each nonzero `verification_key`, define the base activation slot using the
+For each nonzero `verification_key`, define its activation slot using the
 standard Solidity mapping layout:
 
 ```python
@@ -90,14 +85,8 @@ def activation_slot(verification_key: Bytes32) -> U256:
     )
 ```
 
-The registry stores:
-
-| Slot | Value |
-|---|---|
-| `activation_slot(verification_key)` | activation timestamp |
-
-An entry is registered if this slot is nonzero. Its value MUST be at most
-`2**64 - 1`.
+A key is registered if `sload(activation_slot(verification_key))` is nonzero.
+The stored value MUST be at most `2**64 - 1`.
 
 ### Contract interface
 
@@ -212,9 +201,8 @@ That EIP MUST define:
 1. the exact `verification_key`;
 2. the L1 feature fork whose EVM semantics the key represents.
 
-The registry activation fork is the first hard fork that activates this EIP.
-It MUST also activate exactly one Core EIP defining a `verification_key` as
-specified above. That key is the registry's initial `verification_key`.
+The hard fork that activates this EIP MUST also activate exactly one such Core
+EIP. Its key is the registry's initial `verification_key`.
 
 ### Reactivating a key
 
@@ -227,26 +215,11 @@ distinct Core EIP that lists this EIP in its `requires` header MUST define:
 Reactivation changes only `CURRENT_VERIFICATION_KEY_SLOT`. It MUST NOT change
 the key's stored activation timestamp.
 
-### Constructing the update
-
-For a new key, clients construct the update calldata from the
-`verification_key` defined by its Core EIP and the `activation_timestamp`
-supplied by the hard-fork meta-EIP:
-
-```text
-EVM_VK_REGISTRY_UPDATE =
-    verification_key
-    || activation_timestamp
-```
-
-For a reactivated key, clients construct:
-
-```text
-EVM_VK_REGISTRY_UPDATE =
-    verification_key
-```
-
 ### Block processing
+
+`EVM_VK_REGISTRY_UPDATE` is the registration or reactivation calldata defined
+above. For a registration, `activation_timestamp` is supplied by the hard-fork
+meta-EIP.
 
 In the first block where a hard fork selects a new or reactivated
 `verification_key` as current, including the registry activation fork, before
@@ -275,18 +248,18 @@ The call MUST NOT be performed in any other block.
 The registry runtime bytecode, `REGISTRY_RUNTIME_CODE`, is:
 
 ```text
-TBD
+0x3460a1573373fffffffffffffffffffffffffffffffffffffffe14604a576020360360a1575f3580602c57545b801560a1575f52600160205260405f2054801560a15760205260405ff35b602036146085576040360360a1575f35801560a157805f52600160205260405f20805460a157602035801560a1578060401c60a15790555f55005b5f35801560a157805f52600160205260405f20541560a1575f55005b5f5ffd
 ```
 
 The registry initcode, `REGISTRY_INITCODE`, is:
 
 ```text
-TBD
+0x60a58060095f395ff33460a1573373fffffffffffffffffffffffffffffffffffffffe14604a576020360360a1575f3580602c57545b801560a1575f52600160205260405f2054801560a15760205260405ff35b602036146085576040360360a1575f35801560a157805f52600160205260405f20805460a157602035801560a1578060401c60a15790555f55005b5f35801560a157805f52600160205260405f20541560a1575f55005b5f5ffd
 ```
 
-`REGISTRY_INITCODE` is a simple constructor prefixing
-`REGISTRY_RUNTIME_CODE`. It returns that runtime bytecode without initializing
-storage.
+The initcode consists of a simple constructor followed by
+`REGISTRY_RUNTIME_CODE`. The constructor returns the runtime bytecode without
+initializing storage.
 
 ### Deployment
 
@@ -323,47 +296,33 @@ From the registry activation fork onward:
 
 - the account at `EVM_VK_REGISTRY_ADDRESS` MUST contain
   `REGISTRY_RUNTIME_CODE` and have nonce `1` under [EIP-161](./eip-161.md); and
-- the `systemContracts` object in every applicable
-  [EIP-7910](./eip-7910.md) configuration MUST contain the key
-  `EVM_VK_REGISTRY_ADDRESS` and the exact registry address, preserving the
-  object's required alphabetical key order.
+- every applicable [EIP-7910](./eip-7910.md) `systemContracts` object MUST
+  include an `EVM_VK_REGISTRY_ADDRESS` member with the registry address,
+  preserving alphabetical key order.
 
 ## Rationale
 
 ### Deterministic deployment
 
-`CREATE2` derives `EVM_VK_REGISTRY_ADDRESS` from `FACTORY_ADDRESS`,
-`REGISTRY_DEPLOYMENT_SALT`, and the hash of `REGISTRY_INITCODE`. Because the
-fixed initcode returns `REGISTRY_RUNTIME_CODE`, deploying different runtime
-bytecode requires different initcode and therefore produces a different
-address.
+[EIP-7997](./eip-7997.md) allows any account to deploy the contract. Because
+`EVM_VK_REGISTRY_ADDRESS` is bound to `REGISTRY_INITCODE`, changing the runtime
+requires different initcode and therefore produces a different address.
 
 ### Current and pinned verification keys
 
-A native rollup that queries the current entry when verifying a proof follows
-L1 EVM upgrades without requiring a separate rollup governance action for each
-new verification key.
-
-Registrations remain available through exact-key lookup so that a native
-rollup can instead pin a historical key while its infrastructure adapts to an
-L1 upgrade. Storing the activation timestamp with each key lets both
-current-following and pinned consumers construct the corresponding
+A native rollup can query the current entry to follow L1 EVM upgrades without
+a separate governance action, or pin a historical key while its infrastructure
+adapts. The stored activation timestamp lets either mode construct the corresponding
 [`ChainConfig`](https://github.com/ethereum/execution-specs/blob/1d1b61039fb8bc3ab8909ba92f924c37adc001bd/src/ethereum/forks/amsterdam/stateless.py)
 using the timestamp coordinate with the block-number coordinate absent.
 
 ### Registry instead of a verifier wildcard
 
-A verifier wildcard could also provide automatic upgrades, but it would make
-each proof-verification mechanism responsible for selecting the key currently
-approved by L1.
-
-The registry separates key selection from proof verification. It records the
-current and historical keys once in shared, EVM-readable state and resolves a
-current-entry query to a concrete, nonzero verification key. Verification
-mechanisms can continue to accept exact keys, while contracts can choose
-between following the current pointer and pinning any registered key. The
-all-zero selector is a registry lookup convention and is never itself a
-verification key.
+A verifier wildcard could select the current key, but would duplicate that
+policy in every proof-verification mechanism. The registry records current and
+historical keys once, while verifiers continue accepting exact keys. Contracts
+can follow the current pointer or pin any registered key. The all-zero value is
+only a registry lookup selector, never a verification key.
 
 ### Reactivating a historical key
 
@@ -386,18 +345,56 @@ are unchanged.
 
 ## Test Cases
 
-TBD. Registration test vectors are network-specific because the
-`activation_timestamp` is supplied by the network's hard-fork schedule.
+Let:
+
+```text
+K1 = 0x0000000000000000000000000000000000000000000000000000000000000001
+K2 = 0x0000000000000000000000000000000000000000000000000000000000000002
+T1 = 0x0000000000000000000000000000000000000000000000000000000000000001
+T2 = 0x000000000000000000000000000000000000000000000000ffffffffffffffff
+S1 = 0xcc69885fda6bcc1a4ace058b4a62bf5e179ea78fd58a1ccd71c22cc9b688792f
+S2 = 0xd9d16d34ffb15ba3a3d852f0d403e2ce1d691fb54de27ac87cd2f993f3ec330f
+```
+
+`S1` and `S2` are `activation_slot(K1)` and `activation_slot(K2)`,
+respectively. Starting from a registry deployed with `REGISTRY_INITCODE` and
+empty storage:
+
+1. A zero-value, non-system call with calldata `bytes32(0)` reverts with no
+   return data.
+2. A zero-value system call with calldata `K1 || T1` succeeds with no return
+   data. Storage slot `0` becomes `K1` and storage slot `S1` becomes `T1`.
+3. Zero-value, non-system calls with calldata `bytes32(0)` and `K1` each return
+   `K1 || T1`.
+4. A zero-value system call with calldata `K1 || T2` reverts with no return
+   data and leaves both storage slots unchanged.
+5. A zero-value system call with calldata `K2 || T2` succeeds with no return
+   data. Storage slot `0` becomes `K2`, storage slot `S2` becomes `T2`, and
+   storage slot `S1` remains `T1`.
+6. A zero-value system call with calldata `K1` succeeds with no return data.
+   Storage slot `0` becomes `K1`, while `S1` and `S2` remain unchanged.
+7. A zero-value, non-system call with calldata `bytes32(0)` returns `K1 || T1`,
+   and one with calldata `K2` returns `K2 || T2`.
+
+Calls with nonzero value revert with no return data. Non-system calldata
+lengths other than 32 bytes and system calldata lengths other than 32 or 64
+bytes also revert with no return data. Registrations with a zero key, zero
+timestamp, or timestamp greater than `2**64 - 1`, and attempts to reactivate a
+zero or unregistered key, revert without changing state.
 
 ## Reference Implementation
 
-TBD.
+See [`src/verification_key_registry`](https://github.com/ethereum/sys-asm/tree/210c4af9b94c3d53a1a7fce00161a056bf4b8b6e/src/verification_key_registry).
 
 ## Security Considerations
 
-Historical lookup never revokes a registered verification key. Past keys are
-not maintained by L1 and remain available even if they are known to be
-compromised. Consumers selecting a historical key assume that risk.
+Consumers that select the current entry automatically adopt each fork-selected
+key. Proofs generated for the previous key may fail after the switch. A rollup
+unable to produce proofs under the new key may halt. Consumers requiring an
+independent upgrade window can pin an exact registered key.
+
+Registered keys are never revoked, even if proofs under them are later
+considered insecure. Consumers selecting a historical key assume this risk.
 
 ## Copyright
 

--- a/EIPS/eip-8357.md
+++ b/EIPS/eip-8357.md
@@ -71,8 +71,9 @@ Each key stores the nonzero `uint64` timestamp at which its L1 feature fork
 activates.
 
 Storage slot `CURRENT_VERIFICATION_KEY_SLOT` stores the current
-`verification_key`. Registering a new key replaces this value. Previously
-registered entries remain available through exact-key lookup.
+`verification_key`. Registering a new key or reactivating a previously
+registered key replaces this value. Previously registered entries remain
+available through exact-key lookup.
 
 Entries are append-only. A registered key MUST NOT be deleted or overwritten.
 
@@ -138,23 +139,39 @@ The read operation MUST NOT modify state.
 
 #### Fork update
 
-The system caller supplies exactly one 64-byte registration:
+The system caller supplies either a 64-byte registration or a 32-byte
+reactivation.
+
+For a registration, calldata is:
 
 ```text
 verification_key
 || activation_timestamp
 ```
 
-The call registers that key and updates the current pointer to it. The first
-call registers only the key active at the registry's activation.
+The call registers a new key and updates the current pointer to it. The first
+fork update registers only the key active at the registry's activation.
 
 - `verification_key` MUST be nonzero;
 - the key MUST NOT already be registered;
 - `activation_timestamp` MUST be nonzero and at most `2**64 - 1`.
 
-If any condition fails, the call MUST revert. On success, the activation
-timestamp is stored, `CURRENT_VERIFICATION_KEY_SLOT` is set to
-`verification_key`, and no data is returned.
+For a reactivation, calldata is:
+
+```text
+verification_key
+```
+
+The call updates the current pointer to a previously registered key without
+modifying its activation timestamp.
+
+- `verification_key` MUST be nonzero;
+- the key MUST already be registered.
+
+If any condition fails, the call MUST revert. On success,
+`CURRENT_VERIFICATION_KEY_SLOT` is set to `verification_key` and no data is
+returned. A successful registration also stores the supplied activation
+timestamp.
 
 The fork-update operation is:
 
@@ -162,18 +179,26 @@ The fork-update operation is:
 def update_registry(calldata: Bytes) -> None:
     assert caller == SYSTEM_ADDRESS
     assert callvalue == 0
-    assert len(calldata) == 64
 
-    verification_key = calldata[0:32]
-    activation_timestamp = uint256_be_decode(calldata[32:64])
+    if len(calldata) == 64:
+        verification_key = calldata[0:32]
+        activation_timestamp = uint256_be_decode(calldata[32:64])
 
-    assert verification_key != bytes32(0)
-    assert 0 < activation_timestamp <= 2**64 - 1
+        assert verification_key != bytes32(0)
+        assert 0 < activation_timestamp <= 2**64 - 1
 
-    slot = activation_slot(verification_key)
-    assert sload(slot) == 0
+        slot = activation_slot(verification_key)
+        assert sload(slot) == 0
 
-    sstore(slot, activation_timestamp)
+        sstore(slot, activation_timestamp)
+    elif len(calldata) == 32:
+        verification_key = calldata[0:32]
+
+        assert verification_key != bytes32(0)
+        assert sload(activation_slot(verification_key)) != 0
+    else:
+        assert False
+
     sstore(CURRENT_VERIFICATION_KEY_SLOT, verification_key)
 ```
 
@@ -191,10 +216,22 @@ The registry activation fork is the first hard fork that activates this EIP.
 It MUST also activate exactly one Core EIP defining a `verification_key` as
 specified above. That key is the registry's initial `verification_key`.
 
-Clients construct the update calldata from the `verification_key` defined by
-the Core EIP and the `activation_timestamp` supplied by the hard-fork meta-EIP.
+### Reactivating a key
 
-For every registration, clients construct:
+A hard fork MAY reactivate a previously registered `verification_key`. A
+distinct Core EIP that lists this EIP in its `requires` header MUST define:
+
+1. the exact previously registered `verification_key` to reactivate;
+2. the L1 feature fork whose EVM semantics that key represents.
+
+Reactivation changes only `CURRENT_VERIFICATION_KEY_SLOT`. It MUST NOT change
+the key's stored activation timestamp.
+
+### Constructing the update
+
+For a new key, clients construct the update calldata from the
+`verification_key` defined by its Core EIP and the `activation_timestamp`
+supplied by the hard-fork meta-EIP:
 
 ```text
 EVM_VK_REGISTRY_UPDATE =
@@ -202,11 +239,18 @@ EVM_VK_REGISTRY_UPDATE =
     || activation_timestamp
 ```
 
+For a reactivated key, clients construct:
+
+```text
+EVM_VK_REGISTRY_UPDATE =
+    verification_key
+```
+
 ### Block processing
 
-In the first block where a hard fork activates a `verification_key`, including
-the registry activation fork, before processing transactions, execution clients
-MUST call
+In the first block where a hard fork selects a new or reactivated
+`verification_key` as current, including the registry activation fork, before
+processing transactions, execution clients MUST call
 `EVM_VK_REGISTRY_ADDRESS` as `SYSTEM_ADDRESS` with
 `EVM_VK_REGISTRY_UPDATE` as calldata and value `0`.
 
@@ -320,6 +364,19 @@ mechanisms can continue to accept exact keys, while contracts can choose
 between following the current pointer and pinning any registered key. The
 all-zero selector is a registry lookup convention and is never itself a
 verification key.
+
+### Reactivating a historical key
+
+A later hard fork can restore a previously registered key as current without
+inventing a different key for the same verification relation. The key retains
+its original activation timestamp because that timestamp is part of the
+fork-specific EVM program's `ChainConfig`. The hard fork that reactivates the
+key is independently identified by its meta-EIP and does not redefine the
+program's original activation point.
+
+Caller-based operation selection makes the 32-byte system reactivation
+unambiguous from a 32-byte read: only `SYSTEM_ADDRESS` executes the fork-update
+operation, while every other caller executes the read operation.
 
 ## Backwards Compatibility
 

--- a/EIPS/eip-8357.md
+++ b/EIPS/eip-8357.md
@@ -48,8 +48,8 @@ document are to be interpreted as described in
 | Constant | Value |
 |---|---:|
 | `SYSTEM_ADDRESS` | `0xfffffffffffffffffffffffffffffffffffffffe` |
-| `EVM_VK_REGISTRY_ADDRESS` | `TBD` |
-| `REGISTRY_DEPLOYMENT_SALT` | `TBD` |
+| `EVM_VK_REGISTRY_ADDRESS` | `0x0000709b303ef147cee6c13f3af6c5a402da8357` |
+| `REGISTRY_DEPLOYMENT_SALT` | `0x2b93ca1f7fa5102ac4e1a6d161cff2ae1701cf709bfa1a7a6cb213ec61125f0a` |
 | `CURRENT_VERIFICATION_KEY_SLOT` | `0` |
 | `ACTIVATION_MAPPING_SLOT` | `1` |
 

--- a/EIPS/eip-8357.md
+++ b/EIPS/eip-8357.md
@@ -206,8 +206,12 @@ before processing transactions, execution clients MUST call
 
 This is a system operation and therefore:
 
-- the call MUST use the system-call gas accounting specified by
+- the call MUST have the dedicated `SYSTEM_CALL_GAS_LIMIT` defined by
   [EIP-8037](./eip-8037.md);
+- gas consumed by the call MUST NOT contribute to either
+  `block_execution_gas_used` or `block_state_gas_used`;
+- both the gas limit assigned to the call and the gas consumed MUST be excluded
+  from checks against the block's gas limit;
 - the call MUST NOT follow [EIP-1559](./eip-1559.md) fee-burning semantics;
 - the call MUST be treated as a pre-execution system-contract call under
   [EIP-7928](./eip-7928.md); and

--- a/EIPS/eip-8357.md
+++ b/EIPS/eip-8357.md
@@ -148,7 +148,7 @@ The call registers that key and updates the current pointer to it. The first
 call registers only the key active at the registry's activation.
 
 - `verification_key` MUST be nonzero;
-- the key MUST not already be registered;
+- the key MUST NOT already be registered;
 - `activation_timestamp` MUST be nonzero and at most `2**64 - 1`.
 
 If any condition fails, the call MUST revert. On success, the activation

--- a/EIPS/eip-8357.md
+++ b/EIPS/eip-8357.md
@@ -1,8 +1,9 @@
 ---
+eip: 8357
 title: EVM Verification Key Registry
 description: Exposes fork-approved EVM verification keys and activation timestamps to contracts
 author: Luca Donno (@lucadonnoh)
-discussions-to: https://ethereum-magicians.org/t/eip-8079-native-rollups/26565
+discussions-to: https://ethereum-magicians.org/t/eip-8357-evm-verification-key-registry/29222
 status: Draft
 type: Standards Track
 category: Core

--- a/EIPS/eip-8357.md
+++ b/EIPS/eip-8357.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2026-07-30
-requires: 161, 1559, 7910, 7928, 8037, 8288
+requires: 161, 1559, 7910, 7928, 7997, 8037, 8288
 ---
 
 ## Abstract
@@ -186,6 +186,10 @@ That EIP MUST define:
 1. the exact `verification_key`;
 2. the L1 feature fork whose EVM semantics the key represents.
 
+The registry activation fork is the first hard fork that activates this EIP.
+It MUST also activate exactly one Core EIP defining a `verification_key` as
+specified above. That key is the registry's initial `verification_key`.
+
 Clients construct the update calldata from the `verification_key` defined by
 the Core EIP and the `activation_timestamp` supplied by the hard-fork meta-EIP.
 
@@ -199,8 +203,9 @@ EVM_VK_REGISTRY_UPDATE =
 
 ### Block processing
 
-In the first block where a hard fork adding a `verification_key` is active,
-before processing transactions, execution clients MUST call
+In the first block where a hard fork activates a `verification_key`, including
+the registry activation fork, before processing transactions, execution clients
+MUST call
 `EVM_VK_REGISTRY_ADDRESS` as `SYSTEM_ADDRESS` with
 `EVM_VK_REGISTRY_UPDATE` as calldata and value `0`.
 
@@ -222,22 +227,35 @@ The call MUST NOT be performed in any other block.
 
 ### Deployment
 
-The exact runtime bytecode, synthetic deployment transaction,
-`EVM_VK_REGISTRY_ADDRESS`, and initial record are `TBD`.
+The exact runtime bytecode, `REGISTRY_INITCODE`, 32-byte
+`REGISTRY_DEPLOYMENT_SALT`, and `EVM_VK_REGISTRY_ADDRESS` are `TBD`.
 
-Before activation:
+The registry MUST be deployed through the `FACTORY_ADDRESS` defined by
+[EIP-7997](./eip-7997.md). Any account MAY deploy it with an ordinary
+transaction that calls the factory with:
 
-- the exact registry runtime bytecode MUST be deployed at
-  `EVM_VK_REGISTRY_ADDRESS`;
-- the account MUST have nonce `1` and be exempt from
-  [EIP-161](./eip-161.md) cleanup; and
+```text
+REGISTRY_DEPLOYMENT_SALT
+|| REGISTRY_INITCODE
+```
+
+`EVM_VK_REGISTRY_ADDRESS` MUST equal the `CREATE2` address returned by that
+factory call. `REGISTRY_INITCODE` MUST deploy the exact registry runtime
+bytecode and leave all registry storage slots zero. Deploying the contract does
+not activate this EIP or register a `verification_key`.
+
+The deployment transaction MUST be included in a block preceding the first
+block of the registry activation fork because the initial registry system call
+is performed before transactions in the activation block.
+
+From the registry activation fork onward:
+
+- the account at `EVM_VK_REGISTRY_ADDRESS` MUST contain the exact registry
+  runtime bytecode and have nonce `1` under [EIP-161](./eip-161.md); and
 - the `systemContracts` object in every applicable
-  [EIP-7910](./eip-7910.md) configuration from the activation fork onward MUST
-  contain the key `EVM_VK_REGISTRY_ADDRESS` and the exact registry address,
-  preserving the object's required alphabetical key order.
-
-At the registry's initial activation, the registry call MUST register exactly
-one key: the key current for that fork.
+  [EIP-7910](./eip-7910.md) configuration MUST contain the key
+  `EVM_VK_REGISTRY_ADDRESS` and the exact registry address, preserving the
+  object's required alphabetical key order.
 
 ## Rationale
 

--- a/EIPS/eip-8357.md
+++ b/EIPS/eip-8357.md
@@ -54,6 +54,7 @@ document are to be interpreted as described in
 |---|---:|
 | `SYSTEM_ADDRESS` | `0xfffffffffffffffffffffffffffffffffffffffe` |
 | `EVM_VK_REGISTRY_ADDRESS` | `TBD` |
+| `REGISTRY_DEPLOYMENT_SALT` | `TBD` |
 | `CURRENT_VERIFICATION_KEY_SLOT` | `0` |
 | `ACTIVATION_MAPPING_SLOT` | `1` |
 
@@ -225,24 +226,50 @@ This is a system operation and therefore:
 
 The call MUST NOT be performed in any other block.
 
-### Deployment
+### Bytecode
 
-The exact runtime bytecode, `REGISTRY_INITCODE`, 32-byte
-`REGISTRY_DEPLOYMENT_SALT`, and `EVM_VK_REGISTRY_ADDRESS` are `TBD`.
+The registry runtime bytecode, `REGISTRY_RUNTIME_CODE`, is:
+
+```text
+TBD
+```
+
+The registry initcode, `REGISTRY_INITCODE`, is:
+
+```text
+TBD
+```
+
+`REGISTRY_INITCODE` is a simple constructor prefixing
+`REGISTRY_RUNTIME_CODE`. It returns that runtime bytecode without initializing
+storage.
+
+### Deployment
 
 The registry MUST be deployed through the `FACTORY_ADDRESS` defined by
 [EIP-7997](./eip-7997.md). Any account MAY deploy it with an ordinary
-transaction that calls the factory with:
+transaction that calls the factory with the 32-byte deployment salt followed
+by the initcode:
 
 ```text
 REGISTRY_DEPLOYMENT_SALT
 || REGISTRY_INITCODE
 ```
 
-`EVM_VK_REGISTRY_ADDRESS` MUST equal the `CREATE2` address returned by that
-factory call. `REGISTRY_INITCODE` MUST deploy the exact registry runtime
-bytecode and leave all registry storage slots zero. Deploying the contract does
-not activate this EIP or register a `verification_key`.
+Under [EIP-1014](./eip-1014.md), the registry address is:
+
+```text
+EVM_VK_REGISTRY_ADDRESS =
+    keccak256(
+        0xff
+        || FACTORY_ADDRESS
+        || REGISTRY_DEPLOYMENT_SALT
+        || keccak256(REGISTRY_INITCODE)
+    )[12:]
+```
+
+Deploying the contract does not activate this EIP or register a
+`verification_key`.
 
 The deployment transaction MUST be included in a block preceding the first
 block of the registry activation fork because the initial registry system call
@@ -250,14 +277,22 @@ is performed before transactions in the activation block.
 
 From the registry activation fork onward:
 
-- the account at `EVM_VK_REGISTRY_ADDRESS` MUST contain the exact registry
-  runtime bytecode and have nonce `1` under [EIP-161](./eip-161.md); and
+- the account at `EVM_VK_REGISTRY_ADDRESS` MUST contain
+  `REGISTRY_RUNTIME_CODE` and have nonce `1` under [EIP-161](./eip-161.md); and
 - the `systemContracts` object in every applicable
   [EIP-7910](./eip-7910.md) configuration MUST contain the key
   `EVM_VK_REGISTRY_ADDRESS` and the exact registry address, preserving the
   object's required alphabetical key order.
 
 ## Rationale
+
+### Deterministic deployment
+
+`CREATE2` derives `EVM_VK_REGISTRY_ADDRESS` from `FACTORY_ADDRESS`,
+`REGISTRY_DEPLOYMENT_SALT`, and the hash of `REGISTRY_INITCODE`. Because the
+fixed initcode returns `REGISTRY_RUNTIME_CODE`, deploying different runtime
+bytecode requires different initcode and therefore produces a different
+address.
 
 ### Current and pinned verification keys
 

--- a/EIPS/eip-draft_evm-vk-registry.md
+++ b/EIPS/eip-draft_evm-vk-registry.md
@@ -1,0 +1,289 @@
+---
+title: EVM Verification Key Registry
+description: Exposes fork-approved EVM verification keys and activation timestamps to contracts
+author: Luca Donno (@lucadonnoh)
+discussions-to: https://ethereum-magicians.org/t/eip-8079-native-rollups/26565
+status: Draft
+type: Standards Track
+category: Core
+created: 2026-07-30
+requires: 161, 1559, 7910, 7928, 8037, 8288
+---
+
+## Abstract
+
+This EIP creates a fixed-address system contract containing the canonical EVM
+verification key for each registered L1 feature fork. Each entry maps one
+exact verification key to the activation timestamp of the fork-specific EVM
+program bound by that key.
+
+The contract stores one `current_verification_key`. A caller may retrieve
+either the current entry or an exact historical entry. This lets a native
+rollup follow L1 EVM upgrades automatically or deliberately remain on a
+historical EVM fork.
+
+## Motivation
+
+Native rollups are intended to inherit Ethereum's execution environment and
+upgrade process instead of maintaining a bespoke verifier and its governance.
+The rollup contract must therefore identify the verification key that L1 has
+approved for proving EVM execution.
+
+Proof-verification mechanisms can verify a proof under an exact key without
+identifying which key represents the canonical L1 EVM or exposing its
+activation timestamp. [EIP-8288](./eip-8288.md) is one such mechanism.
+Hard-coding those values would force each rollup to upgrade through its own
+governance at every L1 feature fork or remain on an older EVM.
+
+This EIP makes the fork-selected key and activation timestamp available inside
+the EVM, allowing rollups to follow Ethereum upgrades automatically or retain
+historical EVM semantics.
+
+## Specification
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this
+document are to be interpreted as described in
+[RFC 2119](https://www.rfc-editor.org/rfc/rfc2119) and
+[RFC 8174](https://www.rfc-editor.org/rfc/rfc8174).
+
+### Parameters
+
+| Constant | Value |
+|---|---:|
+| `SYSTEM_ADDRESS` | `0xfffffffffffffffffffffffffffffffffffffffe` |
+| `EVM_VK_REGISTRY_ADDRESS` | `TBD` |
+| `CURRENT_VERIFICATION_KEY_SLOT` | `0` |
+| `ACTIVATION_MAPPING_SLOT` | `1` |
+
+The all-zero verification key is reserved for current-entry lookup and MUST
+NOT be registered.
+
+### Registry state
+
+`verification_key` is the 32-byte field defined by EIP-8288 for
+`LEANSTARK_SCHEME`. It is the L1-approved key for a deterministic,
+fork-specific EVM stateless-validation program.
+
+Each key stores the nonzero `uint64` timestamp at which its L1 feature fork
+activates.
+
+Storage slot `CURRENT_VERIFICATION_KEY_SLOT` stores the current
+`verification_key`. Registering a new key replaces this value. Previously
+registered entries remain available through exact-key lookup.
+
+Entries are append-only. A registered key MUST NOT be deleted or overwritten.
+
+For each nonzero `verification_key`, define the base activation slot using the
+standard Solidity mapping layout:
+
+```python
+def activation_slot(verification_key: Bytes32) -> U256:
+    return U256(
+        keccak256(
+            verification_key
+            + uint256_be(ACTIVATION_MAPPING_SLOT)
+        )
+    )
+```
+
+The registry stores:
+
+| Slot | Value |
+|---|---|
+| `activation_slot(verification_key)` | activation timestamp |
+
+An entry is registered if this slot is nonzero. Its value MUST be at most
+`2**64 - 1`.
+
+### Contract interface
+
+The contract selects its operation by `CALLER`:
+
+- if `CALLER == SYSTEM_ADDRESS`, execute the fork-update operation;
+- otherwise, execute the read operation.
+
+All calls MUST have value `0`.
+
+In calldata and return data, `activation_timestamp` MUST be encoded as a
+zero-padded, 32-byte big-endian word.
+
+#### Read
+
+A non-system caller MUST provide exactly 32 bytes of calldata:
+
+- an all-zero word requests the current entry; or
+- a nonzero word requests that exact `verification_key`.
+
+For a valid request, the contract MUST return exactly 64 bytes:
+
+```text
+verification_key
+|| activation_timestamp
+```
+
+For an all-zero query, `verification_key` MUST be loaded from
+`CURRENT_VERIFICATION_KEY_SLOT`. For a nonzero query, `verification_key` MUST
+equal the supplied value.
+
+The call MUST revert without return data if:
+
+- calldata is malformed;
+- call value is nonzero;
+- no registered entry exists for the selected `verification_key`.
+
+The read operation MUST NOT modify state.
+
+#### Fork update
+
+The system caller supplies exactly one 64-byte registration:
+
+```text
+verification_key
+|| activation_timestamp
+```
+
+The call registers that key and updates the current pointer to it. The first
+call registers only the key active at the registry's activation.
+
+- `verification_key` MUST be nonzero;
+- the key MUST not already be registered;
+- `activation_timestamp` MUST be nonzero and at most `2**64 - 1`.
+
+If any condition fails, the call MUST revert. On success, the activation
+timestamp is stored, `CURRENT_VERIFICATION_KEY_SLOT` is set to
+`verification_key`, and no data is returned.
+
+The fork-update operation is:
+
+```python
+def update_registry(calldata: Bytes) -> None:
+    assert caller == SYSTEM_ADDRESS
+    assert callvalue == 0
+    assert len(calldata) == 64
+
+    verification_key = calldata[0:32]
+    activation_timestamp = uint256_be_decode(calldata[32:64])
+
+    assert verification_key != bytes32(0)
+    assert 0 < activation_timestamp <= 2**64 - 1
+
+    slot = activation_slot(verification_key)
+    assert sload(slot) == 0
+
+    sstore(slot, activation_timestamp)
+    sstore(CURRENT_VERIFICATION_KEY_SLOT, verification_key)
+```
+
+### Adding a key
+
+Each new `verification_key` MUST be specified by a distinct Core EIP that lists
+this EIP in its `requires` header. The key is activated in a hard fork.
+
+That EIP MUST define:
+
+1. the exact `verification_key`;
+2. the L1 feature fork whose EVM semantics the key represents.
+
+Clients construct the update calldata from the `verification_key` defined by
+the Core EIP and the `activation_timestamp` supplied by the hard-fork meta-EIP.
+
+For every registration, clients construct:
+
+```text
+EVM_VK_REGISTRY_UPDATE =
+    verification_key
+    || activation_timestamp
+```
+
+### Block processing
+
+In the first block where a hard fork adding a `verification_key` is active,
+before processing transactions, execution clients MUST call
+`EVM_VK_REGISTRY_ADDRESS` as `SYSTEM_ADDRESS` with
+`EVM_VK_REGISTRY_UPDATE` as calldata and value `0`.
+
+This is a system operation and therefore:
+
+- the call MUST use the system-call gas accounting specified by
+  [EIP-8037](./eip-8037.md);
+- the call MUST NOT follow [EIP-1559](./eip-1559.md) fee-burning semantics;
+- the call MUST be treated as a pre-execution system-contract call under
+  [EIP-7928](./eip-7928.md); and
+- the block MUST be invalid if `EVM_VK_REGISTRY_ADDRESS` contains no code or
+  the call fails.
+
+The call MUST NOT be performed in any other block.
+
+### Deployment
+
+The exact runtime bytecode, synthetic deployment transaction,
+`EVM_VK_REGISTRY_ADDRESS`, and initial record are `TBD`.
+
+Before activation:
+
+- the exact registry runtime bytecode MUST be deployed at
+  `EVM_VK_REGISTRY_ADDRESS`;
+- the account MUST have nonce `1` and be exempt from
+  [EIP-161](./eip-161.md) cleanup; and
+- the `systemContracts` object in every applicable
+  [EIP-7910](./eip-7910.md) configuration from the activation fork onward MUST
+  contain the key `EVM_VK_REGISTRY_ADDRESS` and the exact registry address,
+  preserving the object's required alphabetical key order.
+
+At the registry's initial activation, the registry call MUST register exactly
+one key: the key current for that fork.
+
+## Rationale
+
+### Current and pinned verification keys
+
+A native rollup that queries the current entry when verifying a proof follows
+L1 EVM upgrades without requiring a separate rollup governance action for each
+new verification key.
+
+Registrations remain available through exact-key lookup so that a native
+rollup can instead pin a historical key while its infrastructure adapts to an
+L1 upgrade. Storing the activation timestamp with each key lets both
+current-following and pinned consumers construct the corresponding
+[`ChainConfig`](https://github.com/ethereum/execution-specs/blob/1d1b61039fb8bc3ab8909ba92f924c37adc001bd/src/ethereum/forks/amsterdam/stateless.py)
+using the timestamp coordinate with the block-number coordinate absent.
+
+### Registry instead of a verifier wildcard
+
+A verifier wildcard could also provide automatic upgrades, but it would make
+each proof-verification mechanism responsible for selecting the key currently
+approved by L1.
+
+The registry separates key selection from proof verification. It records the
+current and historical keys once in shared, EVM-readable state and resolves a
+current-entry query to a concrete, nonzero verification key. Verification
+mechanisms can continue to accept exact keys, while contracts can choose
+between following the current pointer and pinning any registered key. The
+all-zero selector is a registry lookup convention and is never itself a
+verification key.
+
+## Backwards Compatibility
+
+This EIP introduces backward-incompatible changes to the block validation
+rules and must be activated through a hard fork. Existing transaction formats
+are unchanged.
+
+## Test Cases
+
+TBD. Registration test vectors are network-specific because the
+`activation_timestamp` is supplied by the network's hard-fork schedule.
+
+## Reference Implementation
+
+TBD.
+
+## Security Considerations
+
+Historical lookup never revokes a registered verification key. Past keys are
+not maintained by L1 and remain available even if they are known to be
+compromised. Consumers selecting a historical key assume that risk.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](../LICENSE.md).


### PR DESCRIPTION
Adds a new Standards Track Core EIP defining a fixed-address system contract that exposes fork-approved EVM verification keys and their activation timestamps.

The registry lets native rollups either follow the current key automatically or pin a previously registered key. Registrations are append-only and occur only through hard-fork system calls.

The current draft references EIP-8288 (#11772) for the 32-byte `verification_key` format.