### PR TITLE
Update EIP-8038: derive access list costs from cold access costs

### DIFF
--- a/EIPS/eip-8038.md
+++ b/EIPS/eip-8038.md
@@ -166,7 +166,7 @@ For simple operations (i.e., without additional parameters), the model estimates
 
 For variable operations, the model estimates: `runtime = intercept + slope × operation_count + param1_coef × operation_count × param1 + param2_coef × operation_count × param2 + ...`
 
-Independent models are created for each client, operations, and configuration. Only operations and parameters with good model fits (R² > 0.5 and p-value < 0.05) are included in the gas cost proposal to ensure the reliability of the estimates.
+Independent models are created for each client, operations, and configuration. Only operations and parameters with good model fits (R-squared > 0.5 and p-value < 0.05) are included in the gas cost proposal to ensure the reliability of the estimates.
 
 **Glue opcode adjustment**
 

--- a/EIPS/eip-8038.md
+++ b/EIPS/eip-8038.md
@@ -48,8 +48,8 @@ Upon activation of this EIP, the following parameters of the gas model are intro
 | `STORAGE_WRITE` | Write | Write that changes a storage slot's value; net-metered per transaction. New named parameter (previously derived, see footnote ²) | 2,800² | 10,000 | +257% | `SSTORE` |
 | `CREATE_ACCESS` | Access + write | Combined access-and-write cost of contract deployment: `ACCOUNT_WRITE` + `COLD_ACCOUNT_ACCESS`. New named parameter (previously derived, see footnote ³) | 7,000³ | 11,000 | +57% | `CREATE`/ `CREATE2` and contract creation txs |
 | `STORAGE_CLEAR_REFUND` | Refund | Refund for clearing a storage slot. Renamed from `SSTORE_CLEARS_SCHEDULE` ([EIP-3529](./eip-3529.md)) | 4,800 | 12,480 | +160% | `SSTORE` |
-| `ACCESS_LIST_STORAGE_KEY_COST` | Access (prepaid) | Gas charged per storage key included in a transaction's access list. Unchanged name from [EIP-2930](./eip-2930.md) | 1,900 | 3,000 | +58% | `SSTORE` and `SLOAD` |
-| `ACCESS_LIST_ADDRESS_COST` | Access (prepaid) | Gas charged per address included in a transaction's access list. Unchanged name from [EIP-2930](./eip-2930.md) | 2,400 | 3,000 | +25% | `*CALL` opcodes, `BALANCE`, `SELFDESTRUCT` and `EXT*` opcodes |
+| `ACCESS_LIST_STORAGE_KEY_COST` | Access (prepaid) | Gas charged per storage key included in a transaction's access list. Unchanged name from [EIP-2930](./eip-2930.md) | 1,900 | 2,900 | +53% | `SSTORE` and `SLOAD` |
+| `ACCESS_LIST_ADDRESS_COST` | Access (prepaid) | Gas charged per address included in a transaction's access list. Unchanged name from [EIP-2930](./eip-2930.md) | 2,400 | 2,900 | +21% | `*CALL` opcodes, `BALANCE`, `SELFDESTRUCT` and `EXT*` opcodes |
 
 ¹: 6,700 = `CALL_VALUE` (the Yellow Paper's `G_callvalue`, 9,000) - `CALL_STIPEND` (`G_callstipend`, 2,300)
 
@@ -219,10 +219,12 @@ Where:
 
 ```
 STORAGE_CLEAR_REFUND         = (STORAGE_WRITE + COLD_STORAGE_ACCESS) * (4800/5000)
-ACCESS_LIST_STORAGE_KEY_COST = COLD_STORAGE_ACCESS
-ACCESS_LIST_ADDRESS_COST     = COLD_ACCOUNT_ACCESS
+ACCESS_LIST_STORAGE_KEY_COST = COLD_STORAGE_ACCESS - WARM_ACCESS
+ACCESS_LIST_ADDRESS_COST     = COLD_ACCOUNT_ACCESS - WARM_ACCESS
 CREATE_ACCESS                = ACCOUNT_WRITE + COLD_ACCOUNT_ACCESS
 ```
+
+The two access-list parameters price the same database load as their cold counterparts, so they are derived from those cold costs. `WARM_ACCESS` is subtracted because a slot or account named in the access list is already warm when the transaction touches it and is therefore still charged `WARM_ACCESS` at that point: prepaying via the access list must not cost more in total than taking the cold access. Without the subtraction, an access-list entry that is used exactly once would cost `COLD_ACCESS + WARM_ACCESS`, making the list strictly more expensive than not using it.
 
 ### Interaction with [EIP-7928](./eip-7928.md)
 

--- a/EIPS/eip-8038.md
+++ b/EIPS/eip-8038.md
@@ -44,20 +44,20 @@ Upon activation of this EIP, the following parameters of the gas model are intro
 | `COLD_ACCOUNT_ACCESS` | Access | Cold touch of an account. Renamed from `COLD_ACCOUNT_ACCESS_COST` ([EIP-2929](./eip-2929.md)) | 2,600 | 3,000 | +15% | `*CALL` opcodes, `BALANCE`, `SELFDESTRUCT`, `EXT*` opcodes, EOA delegations, contract creation txs and ETH transfers |
 | `COLD_STORAGE_ACCESS` | Access | Cold touch of a storage slot. Renamed from `COLD_SLOAD_COST` ([EIP-2929](./eip-2929.md)) | 2,100 | 3,000 | +43% | `SSTORE` and `SLOAD` |
 | `WARM_ACCESS` | Access | Touch of an already-warm account or storage slot. Renamed from `WARM_STORAGE_READ_COST` ([EIP-2929](./eip-2929.md)) | 100 | 100 | +0% | `SSTORE`, `SLOAD`, `*CALL` opcodes, `BALANCE`, `SELFDESTRUCT` and `EXT*` opcodes |
-| `ACCOUNT_WRITE` | Write | Write to an account's leaf values (nonce, balance, code hash); charged per operation. New named parameter (previously embedded in `CALL_VALUE`, see footnote ¹) | 6,700¹ | 8,000 | +19% | value-transferring `*CALL` opcodes, `SELFDESTRUCT`, `CREATE`/`CREATE2`, EOA delegations and ETH transfers |
-| `STORAGE_WRITE` | Write | Write that changes a storage slot's value; net-metered per transaction. New named parameter (previously derived, see footnote ²) | 2,800² | 10,000 | +257% | `SSTORE` |
-| `CREATE_ACCESS` | Access + write | Combined access-and-write cost of contract deployment: `ACCOUNT_WRITE` + `COLD_ACCOUNT_ACCESS`. New named parameter (previously derived, see footnote ³) | 7,000³ | 11,000 | +57% | `CREATE`/ `CREATE2` and contract creation txs |
+| `ACCOUNT_WRITE` | Write | Write to an account's leaf values (nonce, balance, code hash); charged per operation. New named parameter (previously embedded in `CALL_VALUE`, see footnote 1) | 6,700 (1) | 8,000 | +19% | value-transferring `*CALL` opcodes, `SELFDESTRUCT`, `CREATE`/`CREATE2`, EOA delegations and ETH transfers |
+| `STORAGE_WRITE` | Write | Write that changes a storage slot's value; net-metered per transaction. New named parameter (previously derived, see footnote 2) | 2,800 (2) | 10,000 | +257% | `SSTORE` |
+| `CREATE_ACCESS` | Access + write | Combined access-and-write cost of contract deployment: `ACCOUNT_WRITE` + `COLD_ACCOUNT_ACCESS`. New named parameter (previously derived, see footnote 3) | 7,000 (3) | 11,000 | +57% | `CREATE`/ `CREATE2` and contract creation txs |
 | `STORAGE_CLEAR_REFUND` | Refund | Refund for clearing a storage slot. Renamed from `SSTORE_CLEARS_SCHEDULE` ([EIP-3529](./eip-3529.md)) | 4,800 | 12,480 | +160% | `SSTORE` |
 | `ACCESS_LIST_STORAGE_KEY_COST` | Access (prepaid) | Gas charged per storage key included in a transaction's access list. Unchanged name from [EIP-2930](./eip-2930.md) | 1,900 | 2,900 | +53% | `SSTORE` and `SLOAD` |
 | `ACCESS_LIST_ADDRESS_COST` | Access (prepaid) | Gas charged per address included in a transaction's access list. Unchanged name from [EIP-2930](./eip-2930.md) | 2,400 | 2,900 | +21% | `*CALL` opcodes, `BALANCE`, `SELFDESTRUCT` and `EXT*` opcodes |
 
-¹: 6,700 = `CALL_VALUE` (the Yellow Paper's `G_callvalue`, 9,000) - `CALL_STIPEND` (`G_callstipend`, 2,300)
+(1): 6,700 = `CALL_VALUE` (the Yellow Paper's `G_callvalue`, 9,000) - `CALL_STIPEND` (`G_callstipend`, 2,300)
 
-²: 2,800 = `GAS_STORAGE_UPDATE` ([EIP-2200](./eip-2200.md)'s `SSTORE_RESET_GAS`, 5,000) - `GAS_COLD_SLOAD` (2,100) - `GAS_WARM_ACCESS` (100)
+(2): 2,800 = `GAS_STORAGE_UPDATE` ([EIP-2200](./eip-2200.md)'s `SSTORE_RESET_GAS`, 5,000) - `GAS_COLD_SLOAD` (2,100) - `GAS_WARM_ACCESS` (100)
 
-³: 7,000 = `GAS_CREATE` (the Yellow Paper's `G_create`, 32,000) - `GAS_NEW_ACCOUNT` (`G_newaccount`, 25,000)
+(3): 7,000 = `GAS_CREATE` (the Yellow Paper's `G_create`, 32,000) - `GAS_NEW_ACCOUNT` (`G_newaccount`, 25,000)
 
-`ACCOUNT_WRITE`, `STORAGE_WRITE` and `CREATE_ACCESS` are new parameters with no pre-existing counterpart; their "Current value" column shows the equivalent cost extracted from the pre-existing composite constants per the footnotes above. The pre-existing schedule is not exactly separable into these components, so these equivalents are approximate: footnote ² yields the write component of the current warm-case `SSTORE` charge exactly (2,900 = `GAS_WARM_ACCESS` + 2,800), while the cold-case charge of 5,000 exceeds the sum of its components by 100; footnote ³ is discussed in the `CREATE`/`CREATE2` section below.
+`ACCOUNT_WRITE`, `STORAGE_WRITE` and `CREATE_ACCESS` are new parameters with no pre-existing counterpart; their "Current value" column shows the equivalent cost extracted from the pre-existing composite constants per the footnotes above. The pre-existing schedule is not exactly separable into these components, so these equivalents are approximate: footnote 2 yields the write component of the current warm-case `SSTORE` charge exactly (2,900 = `GAS_WARM_ACCESS` + 2,800), while the cold-case charge of 5,000 exceeds the sum of its components by 100; footnote 3 is discussed in the `CREATE`/`CREATE2` section below.
 
 ### `SSTORE` pricing
 
@@ -109,7 +109,7 @@ For `CALL` and `CALLCODE` operations, `CALL_VALUE` (the Yellow Paper's `G_callva
 
 `CREATE` and `CREATE2` operations don't have explicit warm/cold pricing. Instead, the flat `GAS_CREATE` (the Yellow Paper's `G_create`, 32,000) is replaced by `CREATE_ACCESS`, charged in regular-gas, plus `GAS_NEW_ACCOUNT`, charged in state-gas (per [EIP-8037](./eip-8037.md)). `CREATE_ACCESS`, defined as `ACCOUNT_WRITE` + `COLD_ACCOUNT_ACCESS`, is the combined access-and-write component of the deployment; `GAS_NEW_ACCOUNT` is its state-creation component and is not repriced by this EIP.
 
-Note: this definition does not exactly match the legacy decomposition shown in footnote ³ of the Parameters table (`GAS_CREATE` - `GAS_NEW_ACCOUNT` = 7,000). The pre-existing accounting in the protocol is not internally consistent here, and this EIP keeps the discrepancy rather than attempting to reconcile it.
+Note: this definition does not exactly match the legacy decomposition shown in footnote 3 of the Parameters table (`GAS_CREATE` - `GAS_NEW_ACCOUNT` = 7,000). The pre-existing accounting in the protocol is not internally consistent here, and this EIP keeps the discrepancy rather than attempting to reconcile it.
 
 #### `SELFDESTRUCT`
 
@@ -138,7 +138,7 @@ The cases for account-related operations and their corresponding cost components
 
 #### Selecting which Operations to Reprice
 
-The parameters selected for repricing in this EIP were chosen based on the estimated million gas per second (Mgas/s) performance of their respective operations. For this EIP, a performance target of **100 million gas per second** is chosen. With this performance target, we will be able to increase the base throughput of the chain by 5x from our current 20Mgas/s performance.
+The parameters selected for repricing in this EIP were chosen based on the estimated million gas per second (Mgas/s) performance of their respective operations. For this EIP, a performance target of **100 million gas per second** is chosen. With this performance target, we will be able to increase the base throughput of the chain by a factor of 5 from our current 20 Mgas/s performance.
 
 #### Data Collection
 
@@ -146,7 +146,7 @@ The gas costs proposed in this EIP are based on the actual time each execution c
 
 Concretely, to benchmark a single operation/parameter, different blocks are created by varying the number of times the target operation is executed and by changing the parameter values to the operation. The EEST benchmark suite contains the tests used to generate these blocks.
 
-Then, the Benchmarkoor tool is used to collect the needed metrics. This tool returns the total execution time of the block and the number of times each operation was executed. Each test block is run multiple times on each client to account for variability in execution time.
+Then, the `Benchmarkoor` tool is used to collect the needed metrics. This tool returns the total execution time of the block and the number of times each operation was executed. Each test block is run multiple times on each client to account for variability in execution time.
 
 All benchmarks were run on top of a snapshot with the same size as mainnet in March 2026, so they reflect the current performance of state access operations.
 
@@ -156,9 +156,9 @@ Ultimately, we require a single cost model that is independent of the client's i
 
 #### Runtime Estimation
 
-To estimate the runtime of a single operation from the total execution time of the corresponding synthetic blocks, a **Non-Negative Least Squares (NNLS) Linear Regression** is used. This model enforces that all coefficients are non-negative, thus ensuring execution time cannot be negative. The model estimates runtime as a linear combination of:
+To estimate the runtime of a single operation from the total execution time of the corresponding synthetic blocks, a **Non-Negative Least Squares Linear Regression** is used. This model enforces that all coefficients are non-negative, thus ensuring execution time cannot be negative. The model estimates runtime as a linear combination of:
 
-- **Constant term (intercept)**: Base overhead for executing the test, which includes setup and teardown time
+- **Constant term (intercept)**: Base overhead for executing the test, which includes setup and tear-down time
 - **Operation count (slope)**: Number of times the operation is executed in the test. This parameter is the one that allows us to estimate the per-operation runtime.
 - **Operation-specific parameters (e.g., update)**: Extra per-operation runtime contributed by an additional, operation-specific binary or numeric input (e.g., whether a `CALL` is made with value, or whether the `SSTORE` writes a new value). The `update` coefficient gives the marginal runtime added per execution for storage writes.
 
@@ -193,17 +193,17 @@ The following table lists the directly estimated parameters and their mapping to
 
 | Test name | Configuration | Model | Parameter mapping |
 | :---: | :---: | :---: | :---: |
-| `test_account_access` | CacheStrategy = NO_CACHE | runtime = intercept + slope × operation_count + update × value_sent x operation_count | `slope` → `COLD_ACCOUNT_ACCESS`; `update` → `ACCOUNT_WRITE` |
-| `test_sload_bloated` | CacheStrategy = NO_CACHE | runtime = intercept + slope × operation_count | `slope` → `COLD_STORAGE_ACCESS` |
-| `test_sstore_bloated` | CacheStrategy = NO_CACHE | runtime = intercept + slope × operation_count + update × write_new_value x operation_count | `slope` → `COLD_STORAGE_ACCESS`; `update` → `STORAGE_WRITE` |
-| `test_storage_sload_same_key_benchmark` | NA | runtime = intercept + slope × operation_count | `slope` → `WARM_ACCESS` |
-| `test_ext_account_query_warm` | NA | runtime = intercept + slope × operation_count | `slope` → `WARM_ACCESS` |
+| `test_account_access` | `CacheStrategy = NO_CACHE` | runtime = intercept + slope × operation_count + update × value_sent x operation_count | `slope` → `COLD_ACCOUNT_ACCESS`; `update` → `ACCOUNT_WRITE` |
+| `test_sload_bloated` | `CacheStrategy = NO_CACHE` | runtime = intercept + slope × operation_count | `slope` → `COLD_STORAGE_ACCESS` |
+| `test_sstore_bloated` | `CacheStrategy = NO_CACHE` | runtime = intercept + slope × operation_count + update × write_new_value x operation_count | `slope` → `COLD_STORAGE_ACCESS`; `update` → `STORAGE_WRITE` |
+| `test_storage_sload_same_key_benchmark` | — | runtime = intercept + slope × operation_count | `slope` → `WARM_ACCESS` |
+| `test_ext_account_query_warm` | — | runtime = intercept + slope × operation_count | `slope` → `WARM_ACCESS` |
 
-`test_sstore_bloated` and `test_sload_bloated` targeted a bespoke contract with a storage size of 10GB, which is the size of the largest mainnet contract.
+`test_sstore_bloated` and `test_sload_bloated` targeted a bespoke contract with a storage size of 10 gigabytes, which is the size of the largest mainnet contract.
 
 #### Conversion to gas costs
 
-New gas costs are calculated using the same target performance of 100Mgas/s. The formula used is:
+New gas costs are calculated using the same target performance of 100 Mgas/s. The formula used is:
 
 ```
 new_gas = (anchor_rate * runtime_ms) / 1000
@@ -211,7 +211,7 @@ new_gas = (anchor_rate * runtime_ms) / 1000
 
 Where:
 
-- `anchor_rate` is the target performance expressed in gas per second (e.g., `100_000_000` for a 100Mgas/s target).
+- `anchor_rate` is the target performance expressed in gas per second (e.g., `100_000_000` for a 100 Mgas/s target).
 - `runtime_ms` is the estimated runtime per operation, in milliseconds, taken from the regression models (the `adjusted_slope` defined above).
 - The factor `1000` converts `runtime_ms` from milliseconds to seconds, so that the product with `anchor_rate` (gas/second) yields a result in gas units.
 
@@ -228,7 +228,7 @@ The two access-list parameters price the same database load as their cold counte
 
 ### Interaction with [EIP-7928](./eip-7928.md)
 
-[EIP-7928](./eip-7928.md) introduces Block-Level Access Lists, which enable parallel disk reads, parallel transaction validation, and executionless state updates through client optimizations. Our benchmarks already consider these optimization gains by running on clients with the optimizations implemented.
+[EIP-7928](./eip-7928.md) introduces Block-Level Access Lists, which enable parallel disk reads, parallel transaction validation, and state updates without execution through client optimizations. Our benchmarks already consider these optimization gains by running on clients with the optimizations implemented.
 
 ### Special case for `EXTCODESIZE` and `EXTCODECOPY`
 


### PR DESCRIPTION
`ACCESS_LIST_ADDRESS_COST` and `ACCESS_LIST_STORAGE_KEY_COST` were both set to 3,000, equal to the cold costs. Since a prepaid entry is still charged `WARM_ACCESS` when touched, using an access list cost 3,100 vs 3,000 for the cold access — inverting the EIP-2930 discount.

Both are now **2,900**, keeping them derived from the cold costs.
