### PR TITLE
Update EIP-8282: only exit contract sets inhibitor

### DIFF
--- a/EIPS/eip-8282.md
+++ b/EIPS/eip-8282.md
@@ -87,7 +87,9 @@ fee = fake_exponential(MIN_REQUEST_FEE, excess, REQUEST_FEE_UPDATE_FRACTION)
 
 where `fake_exponential` is the integer approximation of `MIN_REQUEST_FEE · e^(excess / REQUEST_FEE_UPDATE_FRACTION)` used by [EIP-1559](./eip-1559.md). Because `excess` grows whenever a block contains more than `TARGET_REQUESTS_PER_BLOCK` requests and decays otherwise, the fee rises super-linearly under sustained demand and returns to `MIN_REQUEST_FEE` when demand subsides. The fee is charged on top of any staked value (see the request sections below) and is left locked in the contract.
 
-As in EIP-7002/EIP-7251, each contract's `excess` is initialized to `EXCESS_INHIBITOR` at deployment, and the fee getter reverts while `excess == EXCESS_INHIBITOR`. Since a request is only appended after its fee is paid, this blocks every request between deployment and the first end-of-block system call; that call clears the inhibitor (treating the prior `excess` as `0`), and normal fee operation runs from the activation block onward.
+As in EIP-7002/EIP-7251, the exit contract's `excess` is initialized to `EXCESS_INHIBITOR` at deployment, and the fee getter reverts while `excess == EXCESS_INHIBITOR`. Since a request is only appended after its fee is paid, this blocks every request between deployment and the first end-of-block system call; that call clears the inhibitor (treating the prior `excess` as `0`), and normal fee operation runs from the activation block onward.
+
+The deposit contract computes the fee with each call, so it is safe to accept requests before the fork. This allows builders to begin queuing ahead of time. At the moment of the fork, the system will call the contract to begin processing the queue.
 
 ### Deposit requests
 


### PR DESCRIPTION
Updating text to match implementation.