### PR TITLE
Update EIP-8282: contracts can be disabled with system call with non-empty calldata

### DIFF
--- a/EIPS/eip-8282.md
+++ b/EIPS/eip-8282.md
@@ -77,6 +77,8 @@ The execution layer prepends the contract's request-type byte and includes `requ
 
 The end-of-block system call to each predeploy follows the same rules [EIP-7002](./eip-7002.md) and [EIP-7251](./eip-7251.md) specify, restated here because [EIP-7685](./eip-7685.md) does not: the call is made as `SYSTEM_ADDRESS` with a dedicated gas limit of `30_000_000`; the gas it consumes does not count against the block gas limit and no value is transferred; and **if any of the predeploys' system calls fails or returns an error, the block MUST be invalid.**
 
+Both contracts can disallow future request submissions if the `SYSTEM_ADDRESS` calls the contract with non-empty calldata. This is useful in the case of an upgrade to another contract, or when there is an emergency that requires temporarily disabling the contracts.
+
 ### Request fee
 
 Each request carries a fee, computed exactly as in [EIP-7002](./eip-7002.md):


### PR DESCRIPTION
This was added to sys-asm implementation, but no note of it was added to spec.