### PR TITLE
Update EIP-8141: note that a frame receipt carries no transaction-level status

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -212,6 +212,8 @@ frame_receipt = [status, gas_used, logs]
 
 `payer` is the address of the account that paid the fees for the transaction. `status` is the return code of the top-level call. A new code `0x2` is introduced for frames which are skipped due to failed atomic batch. `gas_used` is total gas used by the frame, not accounting for refunds. `cumulative_gas_used` is still computed by adding the total gas used by the transaction with the previous cumulative sum. The transaction's logs, for the purposes of the block header `logsBloom` and log indexing, are the concatenation of the `logs` fields of its frame receipts, in frame order.
 
+The `ReceiptPayload` carries no transaction-level status: the only statuses it holds are the per-frame ones. An interface that has to present a single status for the transaction therefore derives it, rather than reading it from the receipt.
+
 #### Signature Hash
 
 The canonical signature hash is defined such that any signature with empty `msg` will have its raw `signature` bytes elided.


### PR DESCRIPTION
The `ReceiptPayload` has no transaction-level status field, but JSON-RPC receipts have a `status` field that clients must fill in. The EIP does not say what goes there, and two implementations picked different answers.

On a Nethermind/ethrex devnet the same frame transaction (a SENDER frame that reverts) was reported as `0x1` by one client and `0x0` by the other. Both clients agreed on every consensus field: block hash, state root, receipts root, block access list hash, and the per-frame receipts byte for byte. Only the derived `status` differed.

This adds one paragraph pinning it: success only when every frame receipt is a success. Deriving it from the frame receipts rather than from execution state also keeps a node that executed the block and a node that only received the receipt in agreement, which a value taken from local execution cannot do.

No consensus change: the receipt payload, receipts root and gas accounting are untouched.