### PR TITLE
Update EIP-8141: ban SLOTNUM during validation-prefix execution

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -832,6 +832,7 @@ For `VERIFY` frames, the usual `STATICCALL` restrictions apply except for the pr
 - BASEFEE (0x48)
 - BLOBHASH (0x49)
 - BLOBBASEFEE (0x4A)
+- SLOTNUM (0x4B, [EIP-7843](./eip-7843.md))
 - GAS (0x5A)
     - Except when followed immediately by a `*CALL` instruction. This is the standard method of passing gas to a child call and does not create an additional public mempool dependency.
 - CREATE (0xF0)


### PR DESCRIPTION
The validation prefix bans the opcodes whose value changes between the moment a node admits a transaction and the moment it is included: `TIMESTAMP`, `NUMBER`, `PREVRANDAO`, `BASEFEE`, `BLOBBASEFEE`. A prefix that branches on one of them can pass simulation at admission and revert on inclusion, which is what the rule exists to prevent.

`SLOTNUM` ([EIP-7843](https://eips.ethereum.org/EIPS/eip-7843), `0x4B`) has exactly that property and is absent from the list, which was written before it was allocated. It is not covered transitively either: it reads the header's slot number directly rather than deriving it from `TIMESTAMP`.

This is more than a completeness fix now that [EIP-8272](https://eips.ethereum.org/EIPS/eip-8272) makes the slot number a load-bearing value for frame transactions — a reference is valid only for `1 <= current_slot - slot <= RECENT_ROOT_LENGTH - 1`, so a prefix reading `SLOTNUM` and branching on the age of its own reference is a natural thing to write and an admission/inclusion divergence to execute.

Adds `SLOTNUM` to the banned-opcode list, in numeric order with the other block-dependent opcodes.
