### PR TITLE
Update EIP-8250: pin NONCE_MANAGER to 0x...8250

### DIFF
--- a/EIPS/eip-8250.md
+++ b/EIPS/eip-8250.md
@@ -36,7 +36,7 @@ This specification is a delta against [EIP-8141](./eip-8141.md).
 | Name | Value |
 |---|---|
 | `FORK_TIMESTAMP` | `TBD` |
-| `NONCE_MANAGER` | `0xTBD` |
+| `NONCE_MANAGER` | `0x0000000000000000000000000000000000008250` |
 | `NONCE_MANAGER_CODE` | `0x60006000fd` |
 | `KEYED_NONCE_FIRST_USE_GAS` | `20000` |
 | `MAX_NONCE_SEQ` | `2**64 - 1` |


### PR DESCRIPTION
`NONCE_MANAGER` is a consensus constant: its address determines the storage slots keyed nonces live in, so two clients that pick different values do not share a chain. It is currently `0xTBD` while `NONCE_MANAGER_CODE` is already pinned.

Both implementations I know of independently chose the address equal to the EIP number, matching the convention `EXPIRY_VERIFIER = 0x…8141` already uses in EIP-8141. This PR writes that value down so devnets are interoperable by reading the spec rather than by reading each other's source.

The value is a proposal, not a claim on the address space — renumbering before Last Call costs nothing, and pinning it now costs nothing either. `FORK_TIMESTAMP` is left `TBD`, since that is decided by fork scheduling rather than by this EIP.
