### PR TITLE
Update EIP-8272: pin RECENT_ROOT_ADDRESS to 0x...8272

### DIFF
--- a/EIPS/eip-8272.md
+++ b/EIPS/eip-8272.md
@@ -40,7 +40,7 @@ This specification is a delta against EIP-8141. Terms not defined here, includin
 | Name                                 |                                                                            Value |
 | ------------------------------------ | -------------------------------------------------------------------------------: |
 | `FORK_TIMESTAMP`                     |                                                                            `TBD` |
-| `RECENT_ROOT_ADDRESS`                 |                                                                            `TBD` |
+| `RECENT_ROOT_ADDRESS`                 |                     `0x0000000000000000000000000000000000008272` |
 | `RECENT_ROOT_CODE`                    |                                                                            `TBD` |
 | `RECENT_ROOT_LENGTH`                  |                                                                           `8192` |
 | `RECENT_ROOT_USABLE_WINDOW`           |                                                                           `8191` |

--- a/EIPS/eip-8272.md
+++ b/EIPS/eip-8272.md
@@ -13,7 +13,7 @@ requires: 7623, 7843, 8141
 
 ## Abstract
 
-EIP-8141 frame transactions can reference recent roots without reading mutable storage during validation. A root source writes roots to a system contract, with each root keyed by `(source_id, slot)`, where `source_id` derives from the writer address and a salt. A frame transaction may declare recent root references of the form:
+[EIP-8141](./eip-8141.md) frame transactions can reference recent roots without reading mutable storage during validation. A root source writes roots to a system contract, with each root keyed by `(source_id, slot)`, where `source_id` derives from the writer address and a salt. A frame transaction may declare recent root references of the form:
 
 ```text
 (source_id, slot, root)
@@ -23,7 +23,7 @@ Before frame execution, clients check each reference against the transaction pre
 
 ## Motivation
 
-EIP-8141 validation must not read arbitrary storage controlled by another account or application in the public mempool. Some validation rules still need to depend on recent application state, such as privacy tree roots, wallet authorization roots, or account validation roots.
+[EIP-8141](./eip-8141.md) validation must not read arbitrary storage controlled by another account or application in the public mempool. Some validation rules still need to depend on recent application state, such as privacy tree roots, wallet authorization roots, or account validation roots.
 
 Recent root references let a transaction explicitly name recent roots in its signed transaction envelope. Each reference maps to one system-contract storage key and can be checked before validation code runs.
 
@@ -33,7 +33,7 @@ Privacy applications, for example, keep a tree of commitments and prove spends a
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
 
-This specification is a delta against EIP-8141. Terms not defined here, including `FrameTx`, `FRAME_TX_TYPE`, `VERIFY`, `EXPIRY_VERIFIER`, frame modes, and `TXPARAM`, have the meanings defined in EIP-8141.
+This specification is a delta against [EIP-8141](./eip-8141.md). Terms not defined here, including `FrameTx`, `FRAME_TX_TYPE`, `VERIFY`, `EXPIRY_VERIFIER`, frame modes, and `TXPARAM`, have the meanings defined in [EIP-8141](./eip-8141.md).
 
 ### Constants
 
@@ -59,7 +59,7 @@ All concatenations below use fixed-length encodings. Domains are 32 bytes. Addre
 
 For block validation, `current_slot` is the consensus slot of the beacon block that contains the execution payload being validated.
 
-Execution clients MUST obtain `current_slot` from the EIP-7843 `slotNumber` field. Clients MUST NOT derive `current_slot` from `block.timestamp` using a fixed slot duration.
+Execution clients MUST obtain `current_slot` from the [EIP-7843](./eip-7843.md) `slotNumber` field. Clients MUST NOT derive `current_slot` from `block.timestamp` using a fixed slot duration.
 
 For transaction pool handling, `current_slot` is the node's current slot at receipt, recheck, or eviction time. It is local policy, not block validity.
 
@@ -162,7 +162,7 @@ Each `(source_id, S)` has at most one referenceable root on the canonical chain.
 
 ### Transaction payload
 
-This EIP inserts `recent_root_references` immediately after `blob_versioned_hashes` in the EIP-8141 `FRAME_TX_TYPE` payload. No other payload field is changed. Applied to the EIP-8141 payload, the result is:
+This EIP inserts `recent_root_references` immediately after `blob_versioned_hashes` in the [EIP-8141](./eip-8141.md) `FRAME_TX_TYPE` payload. No other payload field is changed. Applied to the [EIP-8141](./eip-8141.md) payload, the result is:
 
 ```text
 [chain_id, nonce, sender, frames, signatures,
@@ -183,7 +183,7 @@ The `slot` field is a slot number, not a timestamp or block number.
 
 The frame layout and frame execution rules are otherwise unchanged.
 
-The EIP-8141 signature hash procedure applies after this field is inserted. The signing payload contains `recent_root_references` immediately after `blob_versioned_hashes`.
+The [EIP-8141](./eip-8141.md) signature hash procedure applies after this field is inserted. The signing payload contains `recent_root_references` immediately after `blob_versioned_hashes`.
 
 Frame data, including VERIFY frame data, MUST NOT add, remove, or modify the transaction's recent root reference set.
 
@@ -191,7 +191,7 @@ Frame data, including VERIFY frame data, MUST NOT add, remove, or modify the tra
 
 Decoders MUST reject a frame transaction to which this EIP applies if any of the following is true:
 
-* the payload does not match the EIP-8141 payload schema after inserting exactly one `recent_root_references` field immediately after `blob_versioned_hashes`;
+* the payload does not match the [EIP-8141](./eip-8141.md) payload schema after inserting exactly one `recent_root_references` field immediately after `blob_versioned_hashes`;
 * `recent_root_references` is not an RLP list;
 * `len(recent_root_references) > MAX_RECENT_ROOT_REFERENCES`;
 * any reference is not an RLP list of exactly three elements;
@@ -201,7 +201,7 @@ Decoders MUST reject a frame transaction to which this EIP applies if any of the
 
 ### Reference validity
 
-Within block execution, recent root references are checked after the EIP-8141 nonce check and before frame execution, against the transaction pre-state. The transaction pre-state includes all prior transactions in the same block.
+Within block execution, recent root references are checked after the [EIP-8141](./eip-8141.md) nonce check and before frame execution, against the transaction pre-state. The transaction pre-state includes all prior transactions in the same block.
 
 Competing blocks at the same slot may have different recent-root state, and a reference is valid only in a block whose transaction pre-state contains the referenced entry. `current_slot` is the consensus slot of that block.
 
@@ -236,7 +236,7 @@ Recent root writes are ordinary writes to `RECENT_ROOT_ADDRESS[storage_key]`.
 
 ### Gas accounting
 
-This EIP adds the data cost and reference checks introduced by `recent_root_references` to the EIP-8141 gas quantities. Define:
+This EIP adds the data cost and reference checks introduced by `recent_root_references` to the [EIP-8141](./eip-8141.md) gas quantities. Define:
 
 ```text
 recent_root_reference_intrinsic_gas =
@@ -261,7 +261,7 @@ Apply the following additions:
 * add `recent_root_reference_intrinsic_gas` to `calldata_floor_gas`;
 * add `recent_root_calldata_tokens` to `calldata_tokens`.
 
-The EIP-8141 definitions of `max_gas`, `gas_used`, and fee settlement remain unchanged and use these updated quantities.
+The [EIP-8141](./eip-8141.md) definitions of `max_gas`, `gas_used`, and fee settlement remain unchanged and use these updated quantities.
 
 `RECENT_ROOT_REFERENCE_GAS` covers one declared storage key and the two Keccak computations used to derive `storage_key` and `entry_hash`.
 
@@ -269,7 +269,7 @@ The EIP-8141 definitions of `max_gas`, `gas_used`, and fee settlement remain unc
 
 One new `TXPARAM` index and one new opcode are added:
 
-EIP-8141 assigns opcode `0xB4` to `SIGPARAM`. `RECENTROOTREFLOAD` uses `0xB5` to avoid that collision.
+[EIP-8141](./eip-8141.md) assigns opcode `0xB4` to `SIGPARAM`. `RECENTROOTREFLOAD` uses `0xB5` to avoid that collision.
 
 | Name                                 |  Value | Return value                 |
 | ------------------------------------ | -----: | ---------------------------- |
@@ -312,7 +312,7 @@ Nodes SHOULD recheck pending transactions with recent root references when the h
 
 ### Activation
 
-This EIP MUST activate at or after EIP-8141.
+This EIP MUST activate at or after [EIP-8141](./eip-8141.md).
 
 If `timestamp < FORK_TIMESTAMP`, clients MUST NOT insert `recent_root_references` and MUST NOT apply recent root logic.
 
@@ -332,7 +332,7 @@ Pre-fork frame transactions and authorizations bound to the pre-fork canonical s
 
 ## Rationale
 
-EIP-8141 validation needs inputs that are known before validation starts. General reads from storage controlled by another account or application are unsafe for the public mempool because one mutable cell can invalidate many pending transactions.
+[EIP-8141](./eip-8141.md) validation needs inputs that are known before validation starts. General reads from storage controlled by another account or application are unsafe for the public mempool because one mutable cell can invalidate many pending transactions.
 
 Recent root references provide a narrow exception. The root is declared in the signed transaction envelope, checked by clients before validation code runs, and exposed to validation code only through introspection. Recent root references are intentionally narrow: each reference names one recent `bytes32` root and one system-contract storage key.
 
@@ -358,7 +358,7 @@ For validation checks, each declared reference names exactly one storage key und
 
 ## Backwards Compatibility
 
-This EIP does not modify EIP-7702 or other transaction types. An EIP-7702-delegated EOA may be a source address; `source_id` is derived from `msg.sender` of the write call.
+This EIP does not modify [EIP-7702](./eip-7702.md) or other transaction types. An [EIP-7702](./eip-7702.md)-delegated EOA may be a source address; `source_id` is derived from `msg.sender` of the write call.
 
 References to slots before this EIP's activation are not satisfiable because recent root storage is empty at activation.
 


### PR DESCRIPTION
`RECENT_ROOT_ADDRESS` is a consensus constant twice over: it is the account the activation transition writes, and it is the account whose storage every reference is checked against, so two clients on different values disagree on which transactions are valid.

Both implementations I know of independently chose the address equal to the EIP number, matching `EXPIRY_VERIFIER = 0x…8141` in EIP-8141. This PR writes that value down so a devnet can be interoperable by reading the spec rather than by reading another client's source.

`RECENT_ROOT_CODE` is deliberately left `TBD` here: unlike `NONCE_MANAGER_CODE` in EIP-8250 it is a real write path, not a storage namespace, so its bytecode is a design decision for the authors rather than something to infer from implementations that currently handle the write natively. Happy to follow up with a candidate if that is wanted. `FORK_TIMESTAMP` is likewise left `TBD`, since it is decided by fork scheduling.
