### PR TITLE
Update EIP-7793: Move to Draft

### DIFF
--- a/EIPS/eip-7793.md
+++ b/EIPS/eip-7793.md
@@ -1,51 +1,46 @@
 ---
 eip: 7793
-title: Conditional Transactions
-description: Transactions that only executes at a specific index and slot
+title: TXINDEX opcode
+description: An opcode that returns the current transaction's index within the block
 author: Marc Harvey-Hill (@Marchhill), Ahmad Bitar (@smartprogrammer93)
 discussions-to: https://ethereum-magicians.org/t/eip-7793-asserttxindex-opcode/21513
-status: Stagnant
+status: Draft
 type: Standards Track
 category: Core
 created: 2024-10-17
-requires: 7843
+requires: 8141
 ---
 
 ## Abstract
 
-This EIP proposes to add a new transaction format for "conditional transactions", that are only valid at a specified slot and index within the block. A new opcode `TXINDEX` is introduced to expose the conditional transaction index onchain.
+This EIP introduces a new opcode `TXINDEX` that pushes the index of the current transaction within
+its block onto the stack. It gives the EVM the one piece of positional information it cannot
+otherwise observe, so that an application can require a transaction to execute only at its intended
+position — enforced in ordinary execution rather than through block validity.
 
 ## Motivation
 
-The proposal aims to improve support for encrypted mempools. Transactions in an encrypted mempool are ordered while the transactions are encrypted, before being decrypted and included onchain at the top of the block. If the builder does not respect the order when including the decrypted transactions then they could frontrun decrypted transactions. The new transaction type can be used to make this impossible; if a decrypted transaction is not included at the correct index, it will be invalid.
+This EIP aims to improve support for encrypted mempools. Transactions in an encrypted mempool are
+ordered while still encrypted, then decrypted and included at the top of the block. If a builder
+does not respect that order when including the decrypted transactions, it could frontrun them.
+
+A transaction can defend itself against misplacement by carrying a *guard frame* ahead of its body,
+built on the frame transactions of [EIP-8141](./eip-8141.md). The guard checks that the required
+conditions hold — in particular that the transaction's own index in the block matches the position
+it was committed to — and, if they do not, ensures the body frame (e.g. a swap) does not execute.
+`TXINDEX` supplies the one input this check is missing: the transaction's index within its block.
 
 ## Specification
+
+The key words "MUST", "MUST NOT", "SHOULD", and "MAY" in this document are to be interpreted as
+described in RFC 2119 and RFC 8174.
 
 ### Parameters
 
 | Constant | Value |
 | - | - |
-| `COND_TX_TYPE` | `Bytes1(0x05)` |
 | `TXINDEX_OPCODE_BYTE` | `Bytes1(0x4c)` |
 | `TXINDEX_OPCODE_GAS` | `2` |
-
-### Conditional Transaction Type
-
-We introduce a new type of [EIP-2718](./eip-2718.md) transaction, "conditional transactions", where the `TransactionType` is `COND_TX_TYPE` and the `TransactionPayload` is the RLP serialization of the following `TransactionPayloadBody`:
-
-```
-[chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit, to, value, data, access_list, max_fee_per_blob_gas, blob_versioned_hashes, conditional_slot, conditional_tx_index, y_parity, r, s]
-```
-
-The fields `chain_id`, `nonce`, `max_priority_fee_per_gas`, `max_fee_per_gas`, `gas_limit`, `to`, `value`, `data`, `access_list`, `max_fee_per_blob_gas` follow the same semantics as [EIP-4844](./eip-4844.md). The field `blob_versioned_hashes` is the same except that the list may be empty for a conditional transaction.
-
-The fields `conditional_slot` and `conditional_tx_index` are both `uint64` and specify the slot and transaction index in which this transaction should be considered valid respectively. In order to verify that `conditional_slot` is correct, [EIP-7843](./eip-7843.md) is a dependency, as this adds the slot number to the header. For both fields `-1` is used as a sentinel value for which the slot or transaction index check will not take place.
-
-#### Signature
-
-The signature values `y_parity`, `r`, and `s` are calculated by constructing a secp256k1 signature over the following digest:
-
-`keccak256(COND_TX_TYPE || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit, to, value, data, access_list, max_fee_per_blob_gas, blob_versioned_hashes, conditional_slot, conditional_tx_index]))`.
 
 ### TXINDEX opcode
 
@@ -53,25 +48,56 @@ A new opcode `TXINDEX` is introduced at `TXINDEX_OPCODE_BYTE`.
 
 #### Output
 
-One element `TransactionIndex` is added to the stack. `TransactionIndex` is a `uint64` in big endian encoding. It is equal to `conditional_tx_index` if the current transaction is a conditional transaction, and `-1` otherwise.
+One element `TransactionIndex` is added to the stack. `TransactionIndex` is the zero-based index of
+the current transaction within the block in which it is executed, encoded as a 32-byte big-endian
+word.
 
 #### Gas Cost
 
 The gas cost for `TXINDEX` is a fixed fee of `TXINDEX_OPCODE_GAS`.
 
+#### Availability
+
+`TXINDEX` MUST be added to the set of environmental opcodes EIP-8141 bans during the validation
+prefix (`NUMBER`, `TIMESTAMP`, `COINBASE`, and others; see EIP-8141 "Banned Opcodes"). It is
+available in every other execution context.
+
 ## Rationale
 
-### Transaction Type
+### Opcode form
 
-An alternative design could simply return the current transaction index without adding a new transaction type. Adding a new transaction type is favoured as it means that the expected transaction index must be declared statically upfront, rather than allowing dynamic behaviour based on the returned transaction index. This prevents complex constraints being imposed that makes it difficult to build a block.
+`TXINDEX` is exposed as an opcode rather than a precompile or system contract, for consistency with
+the frame introspection surface EIP-8141 introduces (`TXPARAM`, `FRAMEPARAM`). Routing a two-gas
+environment read through precompile call-frame overhead would cost far more than the value it
+returns.
 
-### Gas Price
+### The index never affects validity
+
+Neither block validity nor mempool admissibility depends on a transaction's index, because `TXINDEX`
+is barred from the validation prefix and so can only be read after payment is approved. A
+transaction that reverts on a `TXINDEX` condition therefore reverts *after* committing to pay: it is
+still validly included on-chain — only its body frame (e.g. the swap) is skipped — so a misplaced
+transaction is neither an invalid block nor an inadmissible one. The user wastes some gas but is
+protected from frontrunning, and the guard cannot be evaded because frame order is fixed inside the
+*signed* transaction, so no builder can reorder or strip it. Block building therefore never becomes
+constraint satisfaction: no building pipeline needs to change, and a non-participating builder can
+ignore positional intent at zero risk. Builders are incentivised to place transactions at their
+committed index by additional tips the transaction pays out only on correct placement.
+
+This bounds builder griefing: a transaction that branches into expensive, position-varying behavior
+on `TXINDEX` could make a builder re-simulate it at several candidate placements — the ordering cost
+any transactions touching the same state already imposes — but a builder is never obliged to place
+it correctly and can include it at any index or drop it. In ordinary cases the `TXINDEX` will be
+part of a standard guard frame, and enforce a very simple condition on the index that the builder
+can easily follow.
+
+### Gas price
 
 The opcode is priced to match similar opcodes in the `W_base` set.
 
 ## Backwards Compatibility
 
-No backward compatibility issues found.
+N/A
 
 ## Test Cases
 
@@ -79,7 +105,8 @@ N/A
 
 ## Security Considerations
 
-None.
+The security-relevant properties of `TXINDEX` around builder and mempool griefing are established in
+the rationale.
 
 ## Copyright
 

--- a/EIPS/eip-7793.md
+++ b/EIPS/eip-7793.md
@@ -100,7 +100,7 @@ The opcode is priced to match similar opcodes in the `W_base` set.
 
 ## Backwards Compatibility
 
-N/A
+No backwards compatibility issues found.
 
 ## Test Cases
 

--- a/EIPS/eip-7793.md
+++ b/EIPS/eip-7793.md
@@ -14,15 +14,18 @@ requires: 8141
 ## Abstract
 
 This EIP introduces a new opcode `TXINDEX` that pushes the index of the current transaction within
-its block onto the stack. It gives the EVM the one piece of positional information it cannot
-otherwise observe, so that an application can require a transaction to execute only at its intended
-position — enforced in ordinary execution rather than through block validity.
+its block onto the stack. It allows an application to vary its behavior depending on position, for
+example only executing its main operation (e.g. a swap) if it's being executed in the correct
+position.
 
 ## Motivation
 
-This EIP aims to improve support for encrypted mempools. Transactions in an encrypted mempool are
-ordered while still encrypted, then decrypted and included at the top of the block. If a builder
-does not respect that order when including the decrypted transactions, it could frontrun them.
+This EIP aims to improve support for encrypted mempools. Encrypted mempools work by transactions
+being submitted onchain in encrypted form, and ordered while still encrypted. The next slot they are
+decrypted and *should* be included in the committed order at the top of the block. The problem is
+that a malicious builder may not respect that order when including the decrypted transactions,
+inserting its own transactions before the decrypted ones in order to frontrun them - the aim of this
+EIP is to protect from this attack, making frontrunning impossible.
 
 A transaction can defend itself against misplacement by carrying a *guard frame* ahead of its body,
 built on the frame transactions of [EIP-8141](./eip-8141.md). The guard checks that the required

--- a/EIPS/eip-7793.md
+++ b/EIPS/eip-7793.md
@@ -8,14 +8,14 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2024-10-17
-requires: 8141
+requires: 7843, 8141
 ---
 
 ## Abstract
 
 This EIP introduces a new opcode `TXINDEX` that pushes the index of the current transaction within
 its block onto the stack. It allows an application to vary its behavior depending on position, for
-example only executing its main operation (e.g. a swap) if it's being executed in the correct
+example only executing its main operation (e.g. a swap) if it is being executed in the correct
 position.
 
 ## Motivation
@@ -27,11 +27,11 @@ that a malicious builder may not respect that order when including the decrypted
 inserting its own transactions before the decrypted ones in order to frontrun them - the aim of this
 EIP is to protect from this attack, making frontrunning impossible.
 
-A transaction can defend itself against misplacement by carrying a *guard frame* ahead of its body,
-built on the frame transactions of [EIP-8141](./eip-8141.md). The guard checks that the required
-conditions hold — in particular that the transaction's own index in the block matches the position
-it was committed to — and, if they do not, ensures the body frame (e.g. a swap) does not execute.
-`TXINDEX` supplies the one input this check is missing: the transaction's index within its block.
+A transaction defends itself against misplacement with a *guard*: a validation-prefix check, built
+on the frame transactions of [EIP-8141](./eip-8141.md), that reads `TXINDEX` and requires it to
+equal the position the transaction was committed to. Included anywhere else the transaction is
+invalid, so it never lands and a builder gains nothing by misplacing it. `TXINDEX` supplies the one
+input this check is missing: the transaction's index within its block.
 
 ## Specification
 
@@ -44,6 +44,9 @@ described in RFC 2119 and RFC 8174.
 | - | - |
 | `TXINDEX_OPCODE_BYTE` | `Bytes1(0x4c)` |
 | `TXINDEX_OPCODE_GAS` | `2` |
+| `GUARD_VERIFIER` | `TBD` |
+| `GUARD_VERIFIER_CODE` | `TBD` |
+| `GUARD_DATA_LENGTH` | `96` |
 
 ### TXINDEX opcode
 
@@ -51,19 +54,75 @@ A new opcode `TXINDEX` is introduced at `TXINDEX_OPCODE_BYTE`.
 
 #### Output
 
-One element `TransactionIndex` is added to the stack. `TransactionIndex` is the zero-based index of
-the current transaction within the block in which it is executed, encoded as a 32-byte big-endian
-word.
+One element `TransactionIndex` is added to the stack: the zero-based index of the current
+transaction within the block in which it is executed, encoded as a 32-byte big-endian word.
 
 #### Gas Cost
 
 The gas cost for `TXINDEX` is a fixed fee of `TXINDEX_OPCODE_GAS`.
 
-#### Availability
+### Guard verifier frame
 
-`TXINDEX` MUST be added to the set of environmental opcodes EIP-8141 bans during the validation
-prefix (`NUMBER`, `TIMESTAMP`, `COINBASE`, and others; see EIP-8141 "Banned Opcodes"). It is
-available in every other execution context.
+Following the expiry verifier frame of [EIP-8141](./eip-8141.md), a `VERIFY` frame whose
+`frame.target` equals `GUARD_VERIFIER` is a **guard verifier frame**. It calls the guard verifier
+contract deployed at `GUARD_VERIFIER` with `frame.data` as calldata, interpreted as
+`abi.encode(coordinator, queueId, entryIndex)`. The call reverts unless
+`coordinator.verifyPosition(queueId, entryIndex, TXINDEX, SLOTNUM)` returns true. The sender
+specifies the coordinator contract, which provides the ordering information.
+
+A guard verifier frame is invalid unless all of the following hold:
+
+- `frame.flags == 0`,
+- `frame.value == 0`, and
+- `len(frame.data) == GUARD_DATA_LENGTH`.
+
+A transaction can contain at most one guard verifier frame. `TXINDEX` and `SLOTNUM`
+([EIP-7843](./eip-7843.md)) are banned during validation-prefix execution, but permitted when
+executing the canonical guard verifier runtime code at `GUARD_VERIFIER` — mirroring EIP-8141's
+treatment of `TIMESTAMP` in the expiry verifier.
+
+At activation, clients must install the guard verifier runtime code `GUARD_VERIFIER_CODE` at
+`GUARD_VERIFIER`. Its behavior is equivalent to:
+
+```solidity
+interface ICoordinator {
+    function verifyPosition(bytes32 queueId, uint256 entryIndex, uint256 txIndex, uint256 slotNum)
+        external view returns (bool);
+}
+
+fallback() external {
+    require(msg.data.length == 96);
+    (address coordinator, bytes32 queueId, uint256 entryIndex) =
+        abi.decode(msg.data, (address, bytes32, uint256));
+    uint256 txIndex; uint256 slotNum;
+    assembly { txIndex := txindex() slotNum := slotnum() } // 0x4c, 0x4b
+    require(ICoordinator(coordinator).verifyPosition(queueId, entryIndex, txIndex, slotNum));
+}
+```
+
+The runtime bytecode is:
+
+```text
+GUARD_VERIFIER_CODE = TBD
+```
+
+A reverting guard verifier frame yields no `APPROVE`, invalidating the transaction (existing
+EIP-8141 behavior).
+
+#### New recognized shape
+
+The guard verifier frame extends EIP-8141's recognized validation-prefix shapes with one additional
+optional frame. For the purposes of matching those shapes it is skipped, exactly like the expiry
+verifier frame, and the two MAY be combined: an expiry verifier frame supplies the transaction's
+bounded lifetime, and the guard verifier frame pins its position. For example `[expiry_verify,
+guard_verify, self_verify]` is recognized as `[self_verify]`.
+
+Unlike the expiry frame, the guard verifier frame reads `TXINDEX`, whose value is not assigned until
+the transaction is placed in a block, so a node cannot evaluate it at admission. Instead the node
+admits the transaction and holds it for its committed slot. At execution the frame is evaluated
+normally: the transaction is valid at exactly one coordinate and invalid everywhere else. Because
+the node holds rather than executes the frame at admission, its `gas_limit` is excluded from
+EIP-8141's `MAX_VERIFY_GAS` sum; it is charged normally at execution.
 
 ## Rationale
 
@@ -74,25 +133,20 @@ the frame introspection surface EIP-8141 introduces (`TXPARAM`, `FRAMEPARAM`). R
 environment read through precompile call-frame overhead would cost far more than the value it
 returns.
 
-### The index never affects validity
+### Positional validity is a mempool concern
 
-Neither block validity nor mempool admissibility depends on a transaction's index, because `TXINDEX`
-is barred from the validation prefix and so can only be read after payment is approved. A
-transaction that reverts on a `TXINDEX` condition therefore reverts *after* committing to pay: it is
-still validly included on-chain — only its body frame (e.g. the swap) is skipped — so a misplaced
-transaction is neither an invalid block nor an inadmissible one. The user wastes some gas but is
-protected from frontrunning, and the guard cannot be evaded because frame order is fixed inside the
-*signed* transaction, so no builder can reorder or strip it. Block building therefore never becomes
-constraint satisfaction: no building pipeline needs to change, and a non-participating builder can
-ignore positional intent at zero risk. Builders are incentivised to place transactions at their
-committed index by additional tips the transaction pays out only on correct placement.
-
-This bounds builder griefing: a transaction that branches into expensive, position-varying behavior
-on `TXINDEX` could make a builder re-simulate it at several candidate placements — the ordering cost
-any transactions touching the same state already imposes — but a builder is never obliged to place
-it correctly and can include it at any index or drop it. In ordinary cases the `TXINDEX` will be
-part of a standard guard frame, and enforce a very simple condition on the index that the builder
-can easily follow.
+Through the guard verifier frame, a transaction's index can determine its validity: placed at the
+wrong index it is invalid and never lands. What keeps this tractable is that the dependence is
+confined to a single canonical shape. Arbitrary `TXINDEX` conditions stay banned from the public
+mempool — during validation-prefix admission the opcode may be read only through the canonical guard
+frame — so a builder never has to reason about complex validity conditions based on transaction
+ordering. It reasons about one fixed condition: each guard transaction is valid only at the index it
+committed to. Block building therefore does not become constraint satisfaction; a builder places
+such a transaction at its committed index or drops it, a non-participating builder can drop it at
+zero risk, and default pipelines are untouched. Misplacement earns a builder nothing — an invalid
+transaction pays no gas — and cannot frontrun, because the guard frame is fixed inside the *signed*
+transaction and cannot be reordered or stripped. Builders could be incentivised to place these
+transactions at their committed index by additional tips at the application layer.
 
 ### Gas price
 
@@ -108,8 +162,20 @@ N/A
 
 ## Security Considerations
 
-The security-relevant properties of `TXINDEX` around builder and mempool griefing are established in
-the rationale.
+Letting a transaction's validity depend on `TXINDEX` is confined to the canonical guard verifier
+frame, so it cannot be used to grief builders with arbitrary position-dependent validation: the
+opcode is banned from the public mempool except through the canonical guard frame, and the guard
+enforces a single fixed condition — valid only at the committed index — that a builder can trivially
+check and a misplaced transaction simply fails, becoming invalid and discarded (see Rationale). A
+transaction *body* may still branch on `TXINDEX`, so a builder may re-simulate it at different
+positions when searching for the best block, just as it must for transactions touching shared state;
+this is bounded, because the builder is never obliged to place such a transaction correctly and may
+always drop it.
+
+A frame transaction with arbitrary `TXINDEX` usage in its validation prefix can be force-included
+via [EIP-7805](./eip-7805.md) (FOCIL). This is simple for a builder to check: with spare space at
+the end of the block, it checks validity against the end-of-block state and index, as for any other
+transaction — only a single position needs to be checked.
 
 ## Copyright
 


### PR DESCRIPTION
Reworks EIP-7793 from the earlier *Conditional Transactions* design into a single `TXINDEX` opcode — a pure environment read that returns the current transaction's index within its block.

The motivation is unchanged (encrypted-mempool ordering), but the enforcement model is simplified:

- Positional enforcement moves from block **validity** to ordinary **execution**. A transaction carries a guard frame that skips its body when the index does not match the committed position, so a misplaced transaction is a paid revert, never an invalid block. This removes the dedicated transaction type and the constraint-satisfaction burden on block builders that the previous design imposed.
- The dependency changes from EIP-7843 to **EIP-8141** (frame transactions), which supplies the guard-frame mechanism. `TXINDEX` is banned in the EIP-8141 validation prefix alongside the other environmental opcodes, so a transaction's admissibility can never depend on its index.
- Status returns from Stagnant to Draft.

Discussion-to: https://ethereum-magicians.org/t/eip-7793-asserttxindex-opcode/21513
