### PR TITLE
Update EIP-8070: clarify RLP empty-list encoding

### DIFF
--- a/EIPS/eip-8070.md
+++ b/EIPS/eip-8070.md
@@ -43,8 +43,11 @@ Add a new field `cell_mask` of type `B_16` (`uint128`). This field MUST be inter
 - old schema (`eth/71`): `[types: B, [size_0: P, size_1: P, ...], [hash_0: B_32, hash_1: B_32, ...]]`
 - new schema (`eth/72`): `[types: B, [size_0: P, size_1: P, ...], [hash_0: B_32, hash_1: B_32, ...], cell_mask: B_16]`
 
-**Modify `GetPooledTransactions` (`0x09`) / `PooledTransactions` (`0x10`) behaviour.**
+**Modify `GetPooledTransactions` (`0x09`) / `PooledTransactions` (`0x0a`) behaviour.**
 Responses MUST elide blob payloads for type 3 transactions requested via this RPC by encoding the transaction's `blobs` field as the RLP empty list (`0xc0`, the encoding of `[]`). The field MUST NOT be encoded as the RLP empty byte string (`0x80`). Cell proofs and commitments are unaffected and continue to be sent.
+
+- old schema (`eth/71`): `[request_id: P, [tx_0, tx_1, ...]]`, where type 3 transactions are encoded as `0x03 || rlp([tx_payload_body, wrapper_version, blobs, commitments, cell_proofs])`
+- new schema (`eth/72`): `[request_id: P, [tx_0, tx_1, ...]]`, where type 3 transactions are encoded as `0x03 || rlp([tx_payload_body, wrapper_version, [], commitments, cell_proofs])`
 
 **New message type `GetCells` (`0x14`).** Used to request cells for type 3 transactions. It specifies the transaction hashes being requested, along with a `cell_mask` specifying which cell indices are needed, with syntax identical as `cell_mask` in `NewPooledTransactionHashes`.
 

--- a/EIPS/eip-8070.md
+++ b/EIPS/eip-8070.md
@@ -44,7 +44,7 @@ Add a new field `cell_mask` of type `B_16` (`uint128`). This field MUST be inter
 - new schema (`eth/72`): `[types: B, [size_0: P, size_1: P, ...], [hash_0: B_32, hash_1: B_32, ...], cell_mask: B_16]`
 
 **Modify `GetPooledTransactions` (`0x09`) / `PooledTransactions` (`0x10`) behaviour.**
-Responses now elide blob payloads for type 3 transactions requested via this RPC. This is performed by setting an RLP `nil` literal in the list position corresponding to the transaction's blob data. Cell proofs and commitments are unaffected and continue to be sent.
+Responses MUST elide blob payloads for type 3 transactions requested via this RPC by encoding the transaction's `blobs` field as the RLP empty list (`0xc0`, the encoding of `[]`). The field MUST NOT be encoded as the RLP empty byte string (`0x80`). Cell proofs and commitments are unaffected and continue to be sent.
 
 **New message type `GetCells` (`0x14`).** Used to request cells for type 3 transactions. It specifies the transaction hashes being requested, along with a `cell_mask` specifying which cell indices are needed, with syntax identical as `cell_mask` in `NewPooledTransactionHashes`.
 


### PR DESCRIPTION
Clarifies the `eth/72` wire encoding for elided blob payloads by requiring the `blobs` field to use the RLP empty list (`0xc0`) and explicitly excluding the empty byte string (`0x80`).

Also documents the `eth/71` and `eth/72` `PooledTransactions` schemas and corrects the message code to `0x0a`.

cc @raulk @healthykim @fradamt @cskiraly @fjl @mariosioannou-create @ralexstokes @kamilsa