### PR TITLE
Update EIP-8297: Move all code chunks into the code zone

### DIFF
--- a/EIPS/eip-8297.md
+++ b/EIPS/eip-8297.md
@@ -74,8 +74,10 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 - The account and storage tries are merged into a single tree.
 - RLP is no longer used.
 - The account's code is chunked and included in the tree.
-- Account data (balance, nonce, first storage slots, first code chunks) is
-  co-located to reduce branch openings.
+- Account data (balance, nonce, first storage slots) is co-located to reduce
+  branch openings.
+- Code is content-addressed rather than keyed by account, so contracts with
+  identical bytecode share it.
 
 ### Tree structure
 
@@ -245,7 +247,7 @@ The first byte of every key is the zone identifier `Z`.
 | Zone `Z`      | Category                                    |
 | ------------- | -------------------------------------------- |
 | `0x00`        | Account headers                             |
-| `0x01`        | Code chunks (content-addressed overflow)    |
+| `0x01`        | Code chunks (content-addressed)             |
 | `0x02`-`0xFE` | Reserved for future categories              |
 | `0xFF`        | Storage                                     |
 
@@ -257,8 +259,9 @@ keys mutually prefix-free (see "Tree embedding").
 All state is embedded into the single key/value space. Data accessed
 together is co-located under one shared key prefix ("stem") to reduce
 branch openings. The account header holds an account's basic data, code
-hash, first 64 storage slots, and first 128 code chunks under keys sharing
-one header stem.
+hash, and first 64 storage slots under keys sharing one header stem. Code
+is not in the header; it lives in `CODE_ZONE`, content-addressed (see
+"Code").
 
 | Parameter               | Value |
 | ----------------------- | ----- |
@@ -343,20 +346,21 @@ Setting any header field also sets `version` to zero. `code_hash` and
 account with no code holds the Keccak hash of empty bytecode, unaffected by
 this EIP's choice of merkelization hash (see "Backwards Compatibility").
 
+Header sub-indices `CODE_OFFSET`..`255` are unallocated and reserved. No
+key defined by this EIP resolves to one.
+
 ### Code
 
-Code chunks 0 through 127 live in the account header's stem at
-sub-indices `CODE_OFFSET`..`255`. Chunks at index 128 and above live in
-`CODE_ZONE`, content-addressed by `code_hash` so contracts with identical
-bytecode share leaves.
+Every code chunk lives in `CODE_ZONE`, content-addressed by `code_hash` so
+contracts with identical bytecode share leaves. An aligned range of
+`STEM_SUBTREE_WIDTH` chunks sharing one `tree_index` is a code group; its
+chunks share a stem and differ only in the sub-index byte. No code is keyed
+by address.
 
 ```python
-def get_tree_key_for_code_chunk(address: Address32, code_hash: bytes32, chunk_id: int):
-    if chunk_id < STEM_SUBTREE_WIDTH - CODE_OFFSET:        # chunk_id < 128
-        return get_tree_key_for_header(address, CODE_OFFSET + chunk_id)
-    overflow = chunk_id - (STEM_SUBTREE_WIDTH - CODE_OFFSET)
-    tree_index = overflow // STEM_SUBTREE_WIDTH
-    sub_index  = overflow %  STEM_SUBTREE_WIDTH
+def get_tree_key_for_code_chunk(code_hash: bytes32, chunk_id: int):
+    tree_index = chunk_id // STEM_SUBTREE_WIDTH
+    sub_index  = chunk_id %  STEM_SUBTREE_WIDTH
     key = get_tree_key(
         CODE_ZONE, key_hash(code_hash + tree_index.to_bytes(32, "big")), sub_index
     )
@@ -466,9 +470,11 @@ absent are the same state and commit to the same root, as in the MPT (see
 Deleting an account ([EIP-161](./eip-161.md) state clearing, or
 `SELFDESTRUCT` in the transaction that created the account, per
 [EIP-6780](./eip-6780.md)) MUST remove its header leaves and its storage
-leaves. Its `CODE_ZONE` leaves are content-addressed and may be shared with
-other accounts, so they MUST be removed only if no account in the resulting
-state has the same `code_hash`, and MUST be kept otherwise.
+leaves. Its code is content-addressed and may be shared with other accounts,
+so its `CODE_ZONE` leaves MUST be removed only if no account in the
+resulting state has the same `code_hash`, and MUST be kept otherwise. The
+same applies when an account's `code_hash` changes rather than the account
+being deleted.
 
 The MPT checked `storage_root` to decide whether an address has non-empty
 storage (i.e., the that condition [EIP-7610](./eip-7610.md) checks before contract
@@ -523,18 +529,20 @@ attacker's own bucket.
 
 ### Content-addressed code
 
-Keying overflow code by `code_hash` rather than by account lets all contracts with
+Keying code by `code_hash` rather than by account lets all contracts with
 identical bytecode share leaves. Most deployed contracts repeat a small number of
 templates, so this removes a large amount of duplicate code from the state. For
 the same reason, a block witness contains at most one copy of a shared chunk, no
-matter how many contracts touch it. The first 128 chunks stay in the account
-header, keyed per account, so they are removed with the account and need no
-reference counting. Only chunks beyond ~4 KB are shared between contracts, and
-only those need the check account deletion applies before removing them (see
-"Zero values and deletion"). That check is cheap in practice: the accounts a
-block deletes are those [EIP-161](./eip-161.md) clears, which have no code at
-all, and those `SELFDESTRUCT` removes in their creation transaction, whose code
-the same transaction wrote.
+matter how many contracts touch it. Sharing is also why account deletion checks
+before removing a chunk (see "Zero values and deletion"). That check is cheap in
+practice: the accounts a block deletes are those [EIP-161](./eip-161.md) clears,
+which have no code at all, and those `SELFDESTRUCT` removes in their creation
+transaction, whose code the same transaction wrote.
+
+Keeping a prefix of the code in the account header instead would avoid that
+check, but it would key that prefix by address, so the templates above would
+each store one copy per deployment: the duplication this zone exists to
+remove.
 
 ### SNARK friendliness and post-quantum security
 
@@ -612,13 +620,10 @@ account and which state clearing deletes when it is touched.
 The rule applies to code chunks too, which are the one value in this tree
 whose zero encoding carries meaning rather than being the natural spelling of
 "unset" (see "Code"). Exempting them would make the rule depend on the key
-rather than the value, and the exemption is not a zone: chunks 0 through 127
-share the account header's stem with `BASIC_DATA`, `code_hash`, and the first
-64 storage slots, so the carve-out is a sub-index range within
-`ACCOUNT_ZONE`, which every consumer of the invariant would have to
-reproduce. The uniform rule buys that simplicity for nothing, since
-`code_size` already delimits the code and an absent chunk reads as the zeros
-it would have held. What it does not buy is a smaller state, since an
+rather than the value. With all code in `CODE_ZONE` the exemption would at
+least fall on a zone boundary rather than on a sub-index range, but it still
+buys nothing: `code_size` already delimits the code and an absent chunk reads
+as the zeros it would have held. Nor does it buy a smaller state, since an
 exemption stores only leaves whose contents are already implied by
 `code_size`.
 
@@ -694,25 +699,25 @@ key        = 0xFF || H(A) || H(A || 3) || 0xE8
 length     = 1 + 32 + 32 + 1 = 66 bytes
 ```
 
-Code chunk `chunk_id = 5` (in the header, since 5 < 128):
+Code chunk `chunk_id = 5` of bytecode with hash `C`:
 
 ```
-sub_idx = CODE_OFFSET + 5 = 133 (0x85)
-key     = 0x00 || H(A) || 0x85
-length  = 34 bytes
-```
-
-Code chunk `chunk_id = 300` of bytecode with hash `C` (overflow, since 300 >= 128):
-
-```
-overflow   = 300 - 128 = 172
-tree_index = 172 // 256 = 0
-sub_idx    = 172 %  256 = 172 (0xAC)
-key        = 0x01 || H(C || 0) || 0xAC
+tree_index = 5 // 256 = 0
+sub_idx    = 5 %  256 = 5 (0x05)
+key        = 0x01 || H(C || 0) || 0x05
 length     = 34 bytes
 ```
 
-`A || 3` and `C || 0` denote `A` (respectively `C`) concatenated with the
+Code chunk `chunk_id = 300` of the same bytecode:
+
+```
+tree_index = 300 // 256 = 1
+sub_idx    = 300 %  256 = 44 (0x2C)
+key        = 0x01 || H(C || 1) || 0x2C
+length     = 34 bytes
+```
+
+`A || 3` and `C || 1` denote `A` (respectively `C`) concatenated with the
 32-byte big-endian encoding of the integer.
 
 ## Security Considerations


### PR DESCRIPTION
Code chunks 0..127 were keyed by address in the account header, so only code beyond ~4 KB was shared between contracts. Every chunk is now content-addressed in CODE_ZONE, which drops the per-account copy and the overflow rebasing along with it.

Header sub-indices CODE_OFFSET..255 become unallocated and reserved.

Some of the reasoning arround the removal decision can be found in: https://github.com/ethereum/execution-specs/pull/3286#issuecomment-5169426301

