### PR TITLE
Update EIP-2780: revise COLD_STORAGE_ACCESS and ACCOUNT_WRITE values

### DIFF
--- a/EIPS/eip-2780.md
+++ b/EIPS/eip-2780.md
@@ -45,8 +45,8 @@ The remaining values are defined in other EIPs and referenced here:
 | :---- | :----: | :----: | :---- |
 | `COLD_ACCOUNT_ACCESS` | 3,000 | [EIP-8038](./eip-8038.md) | Cold account touch |
 | `WARM_ACCESS` | 100 | [EIP-8038](./eip-8038.md) | Warm account touch |
-| `ACCOUNT_WRITE` | 8,000 | [EIP-8038](./eip-8038.md) | First write to an account leaf |
-| `CREATE_ACCESS` | 11,000 | [EIP-8038](./eip-8038.md) | Contract-deployment account access and write |
+| `ACCOUNT_WRITE` | 9,000 | [EIP-8038](./eip-8038.md) | First write to an account leaf |
+| `CREATE_ACCESS` | 12,000 | [EIP-8038](./eip-8038.md) | Contract-deployment account access and write |
 | `EXECUTION_PER_AUTH_BASE_COST` | 7,816 | [EIP-8037](./eip-8037.md) | Per-authorization base: calldata, ECDSA recovery, cold authority access, and warm writes |
 | `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` | 183,600 | [EIP-8037](./eip-8037.md) | State gas for one new account leaf |
 | `STATE_BYTES_PER_AUTH_BASE × CPSB` | 35,190 | [EIP-8037](./eip-8037.md) | State gas for one 23-byte delegation indicator |
@@ -131,9 +131,9 @@ Costs are split between the intrinsic phase and the runtime phase, each in execu
 | ETH transfer to 7702 delegated | `TX_BASE_COST + COLD_ACCOUNT_ACCESS + TX_VALUE_COST` / 0 | `COLD_ACCOUNT_ACCESS` + execution / 0 | 24,000 + execution / 0 |
 | ETH transfer to self, sender 7702 delegated | `TX_BASE_COST` / 0 | `COLD_ACCOUNT_ACCESS` + execution / 0 | 15,000 + execution / 0 |
 | ETH transfer creating new account | `TX_BASE_COST + COLD_ACCOUNT_ACCESS + TX_VALUE_COST` / 0 | 0 / `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` | 21,000 / 183,600 |
-| Create transaction, `tx.value` = 0 | `TX_BASE_COST + CREATE_ACCESS` / 0 | 0 / `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` | 23,000 / 183,600 |
-| Create transaction, `tx.value` > 0 | `TX_BASE_COST + CREATE_ACCESS` / 0 | 0 / `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` | 23,000 / 183,600 |
-| Create transaction, `tx.value` > 0, `created_address.balance` > 0 | `TX_BASE_COST + CREATE_ACCESS` / 0 | 0 / 0 | 23,000 / 0 |
+| Create transaction, `tx.value` = 0 | `TX_BASE_COST + CREATE_ACCESS` / 0 | 0 / `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` | 24,000 / 183,600 |
+| Create transaction, `tx.value` > 0 | `TX_BASE_COST + CREATE_ACCESS` / 0 | 0 / `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` | 24,000 / 183,600 |
+| Create transaction, `tx.value` > 0, `created_address.balance` > 0 | `TX_BASE_COST + CREATE_ACCESS` / 0 | 0 / 0 | 24,000 / 0 |
 
 ### Interactions with other EIPs
 
@@ -207,8 +207,8 @@ Costs are given as intrinsic + runtime, by case:
 3. Value transfer to an existing EOA: `21,000` intrinsic, `0` runtime, `0` state.
 4. Value transfer creating a new account (recipient non-existent): `21,000` intrinsic execution; `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` = `183,600` runtime state.
 5. Value transfer to a 7702-delegated account: `21,000` intrinsic + `COLD_ACCOUNT_ACCESS` runtime = `24,000` execution gas plus contract execution.
-6. Contract-creation transaction, `value = 0`: `23,000` intrinsic execution; `183,600` runtime state if the deployment target did not exist, `0` otherwise.
-7. Contract-creation transaction, `value > 0`: `23,000` intrinsic execution (identical to the `value = 0` case, since the recipient balance write is covered by `CREATE_ACCESS`); `183,600` runtime state if the deployment target did not exist, `0` otherwise.
+6. Contract-creation transaction, `value = 0`: `24,000` intrinsic execution; `183,600` runtime state if the deployment target did not exist, `0` otherwise.
+7. Contract-creation transaction, `value > 0`: `24,000` intrinsic execution (identical to the `value = 0` case, since the recipient balance write is covered by `CREATE_ACCESS`); `183,600` runtime state if the deployment target did not exist, `0` otherwise.
 8. EIP-7702 transaction: `TX_BASE_COST` is unchanged even when the sender assumes code. Each authorization is charged `EXECUTION_PER_AUTH_BASE_COST` (which already covers the cold authority access) at the intrinsic phase; at runtime, a non-existent authority additionally pays `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` state, the first write to the authority within the transaction pays `ACCOUNT_WRITE` execution, and net-new delegation bytes add `STATE_BYTES_PER_AUTH_BASE × CPSB` state — replacing the flat `PER_EMPTY_ACCOUNT_COST` intrinsic charge and refund.
 9. Contract-creation transaction whose initcode reverts (value-bearing or not): the transaction remains valid; the `183,600` new-account state-gas charge is refilled in LIFO order per [EIP-8037](./eip-8037.md) — credited to `gas_left` up to the portion the charge drew from it, with the remainder returning to the `state_gas_reservoir`.
 10. Transaction whose gas covers intrinsic cost but not a runtime charge — e.g. a value transfer to a non-existent recipient or a contract creation to a non-existent target lacking gas for the new-account state charge, or a transfer to a delegated account lacking gas for the delegation-target access: the transaction is valid and included, halts out-of-gas, and all runtime state changes — including any applied EIP-7702 delegations — are reverted; it is **not** invalidated.

--- a/EIPS/eip-8007.md
+++ b/EIPS/eip-8007.md
@@ -38,7 +38,7 @@ The following table lists all EIPs related to repricings that are being discusse
 | [EIP-7976](./eip-7976.md) | Increase the calldata floor cost to 64/64 gas per byte to reduce maximum block size. | Pricing extension | Data | Increase calldata floor cost (10/40 → 64/64 per byte) |
 | [EIP-7981](./eip-7981.md) | Price access lists for data to reduce maximum block size. | Pricing extension | Data | Increase: new flat surcharge of 64 gas per access list byte (1,280 per address, 2,048 per storage key), charged outside the calldata floor `max` |
 | [EIP-8037](./eip-8037.md) | Harmonization, increase and separate metering of state creation gas costs to mitigate state growth and unblock scaling. | Broad harmonization | State | All increase via a fixed `CPSB` (1,530 gas/byte), metered in a separate state-gas dimension: `GAS_CREATE`, `GAS_CODE_DEPOSIT`, `GAS_NEW_ACCOUNT`, `GAS_STORAGE_SET`, `PER_AUTH_BASE_COST`, `PER_EMPTY_ACCOUNT_COST` |
-| [EIP-8038](./eip-8038.md) | Increases the gas cost of state-access operations to reflect Ethereum's larger state. | Broad harmonization | State | Increase: `STORAGE_WRITE`, `COLD_STORAGE_ACCESS`, `COLD_ACCOUNT_ACCESS`, `ACCOUNT_WRITE`, `CREATE_ACCESS`, access list costs; `EXTCODESIZE`/`EXTCODECOPY` extra warm read; `WARM_ACCESS` unchanged |
+| [EIP-8038](./eip-8038.md) | Increases the gas cost of state-access operations to reflect Ethereum's larger state. | Broad harmonization | State | Increase: `STORAGE_WRITE`, `COLD_ACCOUNT_ACCESS`, `ACCOUNT_WRITE`, `CREATE_ACCESS`, access list costs; `EXTCODESIZE`/`EXTCODECOPY` extra warm read; `COLD_STORAGE_ACCESS`, `WARM_ACCESS` unchanged |
 
 ### Declined for Inclusion
 
@@ -71,16 +71,16 @@ The following tables summarize the preliminary gas cost changes. Numbers are not
 | Opcode(s) | Component | Current | New | Direction |
 | --- | --- | ---: | ---: | --- |
 | `SSTORE` | `STORAGE_WRITE` (first-time write surcharge) | 2,800 | 10,000 | increase |
-| `SSTORE`, `SLOAD` | `COLD_STORAGE_ACCESS` | 2,100 | 3,000 | increase |
+| `SSTORE`, `SLOAD` | `COLD_STORAGE_ACCESS` | 2,100 | 2,100 | unchanged |
 | `*CALL`, `BALANCE`, `EXT*`, `SELFDESTRUCT` | `COLD_ACCOUNT_ACCESS` | 2,600 | 3,000 | increase |
-| `*CALL`, `SELFDESTRUCT`, ETH transfers | `ACCOUNT_WRITE` (first-time account-leaf write surcharge) | 6,700 | 8,000 | increase |
+| `*CALL`, `SELFDESTRUCT`, ETH transfers | `ACCOUNT_WRITE` (first-time account-leaf write surcharge) | 6,700 | 9,000 | increase |
 | All state ops (warm) | `WARM_ACCESS` | 100 | 100 | unchanged |
-| `CREATE`, `CREATE2` | `CREATE_ACCESS` | 7,000 | 11,000 | increase |
+| `CREATE`, `CREATE2` | `CREATE_ACCESS` | 7,000 | 12,000 | increase |
 | `EXTCODESIZE` | Extra warm read for 2nd DB lookup | 0 | +`WARM_ACCESS` | increase (new) |
 | `EXTCODECOPY` | Extra warm read for 2nd DB lookup | 0 | +`WARM_ACCESS` | increase (new) |
-| `SSTORE`, `SLOAD` (access list) | `ACCESS_LIST_STORAGE_KEY_COST` | 1,900 | 3,000 | increase |
-| `*CALL` etc. (access list) | `ACCESS_LIST_ADDRESS_COST` | 2,400 | 3,000 | increase |
-| `SSTORE` | `STORAGE_CLEAR_REFUND` | 4,800 | 12,480 | increase (refund) |
+| `SSTORE`, `SLOAD` (access list) | `ACCESS_LIST_STORAGE_KEY_COST` | 1,900 | 2,000 | increase |
+| `*CALL` etc. (access list) | `ACCESS_LIST_ADDRESS_COST` | 2,400 | 2,900 | increase |
+| `SSTORE` | `STORAGE_CLEAR_REFUND` | 4,800 | 11,616 | increase (refund) |
 
 #### State Creation — [EIP-8037](./eip-8037.md) (all increase)
 
@@ -101,12 +101,12 @@ The following tables summarize the preliminary gas cost changes. Numbers are not
 | --- | ---: | --- | --- | --- |
 | Intrinsic base (plain transfer to existing account) | 21,000 | 21,000, decomposed into `TX_BASE_COST` (12,000) + `COLD_ACCOUNT_ACCESS` (3,000) + `TX_VALUE_COST` (6,000) | unchanged (decomposed) | [2780](./eip-2780.md) |
 | Intrinsic base (zero-value transaction) | 21,000 | `TX_BASE_COST + COLD_ACCOUNT_ACCESS` = 15,000 (12,000 for a self-transaction) | decrease | [2780](./eip-2780.md) |
-| Intrinsic base (contract-creation transaction) | 53,000 (21,000 + `TX_CREATE_COST` 32,000) | `TX_BASE_COST + CREATE_ACCESS` = 23,000 execution gas | decrease (execution gas) | [2780](./eip-2780.md), [8038](./eip-8038.md) |
+| Intrinsic base (contract-creation transaction) | 53,000 (21,000 + `TX_CREATE_COST` 32,000) | `TX_BASE_COST + CREATE_ACCESS` = 24,000 execution gas | decrease (execution gas) | [2780](./eip-2780.md), [8038](./eip-8038.md) |
 | New-account charge (value transfer or contract creation that creates an account) | 0 for value transfers; folded into `TX_CREATE_COST` for creations | `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` = 183,600 state gas, charged at runtime | increase | [2780](./eip-2780.md), [8037](./eip-8037.md) |
 | Per-[EIP-7702](./eip-7702.md) authorization | `PER_EMPTY_ACCOUNT_COST` (25,000) intrinsic, refunded down to `PER_AUTH_BASE_COST` (12,500) when the authority already exists | `EXECUTION_PER_AUTH_BASE_COST` (7,816) intrinsic; state-dependent charges at runtime: `ACCOUNT_WRITE` on first write to the authority, 183,600 state gas for a non-existent authority, 35,190 state gas for net-new delegation bytes | increase | [2780](./eip-2780.md), [8037](./eip-8037.md) |
 | Calldata floor cost | 10/40 per byte | 64/64 per byte | increase | [7976](./eip-7976.md) |
 | Access list data cost | 0 | flat 64 gas per access list byte (1,280 per address, 2,048 per storage key) | increase (new) | [7981](./eip-7981.md) |
-| Access list entry cost | `ACCESS_LIST_ADDRESS_COST` 2,400, `ACCESS_LIST_STORAGE_KEY_COST` 1,900 | 3,000 each, stacking with the data cost above | increase | [8038](./eip-8038.md) |
+| Access list entry cost | `ACCESS_LIST_ADDRESS_COST` 2,400, `ACCESS_LIST_STORAGE_KEY_COST` 1,900 | `ACCESS_LIST_ADDRESS_COST` 2,900, `ACCESS_LIST_STORAGE_KEY_COST` 2,000, stacking with the data cost above | increase | [8038](./eip-8038.md) |
 
 Two further transaction-level changes come from [EIP-8037](./eip-8037.md)'s separate state-gas dimension. [EIP-7825](./eip-7825.md)'s `TX_MAX_GAS_LIMIT` applies to execution gas only, with state gas bounded by `tx.gas` alone, so large contract deployments are no longer capped by the per-transaction gas limit. The system-call gas limit is raised from `30,000,000` to `30,000,000 + STATE_BYTES_PER_STORAGE_SET × CPSB × SYSTEM_MAX_SSTORES_PER_CALL`, preserving the existing execution margin for system contracts under the higher state creation costs.
 

--- a/EIPS/eip-8038.md
+++ b/EIPS/eip-8038.md
@@ -13,7 +13,7 @@ requires: 8037
 
 ## Abstract
 
-This EIP updates the gas cost of state-access operations to reflect Ethereum's larger state and the consequent slowdown of these operations. It dissects the cost of state-touching operations into three components — access, write, and state creation: the cold access costs (`COLD_ACCOUNT_ACCESS`, `COLD_STORAGE_ACCESS`) are raised, explicit write surcharges (`ACCOUNT_WRITE`, `STORAGE_WRITE`) are introduced, state-creation costs are left to [EIP-8037](./eip-8037.md), and `EXTCODESIZE` and `EXTCODECOPY` are charged for their second database read.
+This EIP updates the gas cost of state-access operations to reflect Ethereum's larger state and the consequent slowdown of these operations. It dissects the cost of state-touching operations into three components — access, write, and state creation: the cold account access cost (`COLD_ACCOUNT_ACCESS`) is raised, explicit write surcharges (`ACCOUNT_WRITE`, `STORAGE_WRITE`) are introduced, state-creation costs are left to [EIP-8037](./eip-8037.md), and `EXTCODESIZE` and `EXTCODECOPY` are charged for their second database read.
 
 ## Motivation
 
@@ -27,7 +27,7 @@ Additionally, `EXTCODESIZE` and `EXTCODECOPY` have the same access cost as `BALA
 
 The gas cost of a state-touching operation is the sum of up to three independent components:
 
-1. **Access** — the cost of loading an account or storage slot from the database: `COLD_ACCOUNT_ACCESS`, `COLD_STORAGE_ACCESS` and `WARM_ACCESS`, renamed by this EIP from the [EIP-2929](./eip-2929.md) parameters. This EIP raises the two cold costs; the [EIP-2929](./eip-2929.md) rules that determine whether an access is cold or warm are unchanged.
+1. **Access** — the cost of loading an account or storage slot from the database: `COLD_ACCOUNT_ACCESS`, `COLD_STORAGE_ACCESS` and `WARM_ACCESS`, renamed by this EIP from the [EIP-2929](./eip-2929.md) parameters. This EIP raises `COLD_ACCOUNT_ACCESS`, while `COLD_STORAGE_ACCESS` and `WARM_ACCESS` are unchanged; the [EIP-2929](./eip-2929.md) rules that determine whether an access is cold or warm are unchanged.
 2. **Write** — the cost of updating an object that already has a leaf in the state trie, when its value changes: `STORAGE_WRITE` for a storage slot and `ACCOUNT_WRITE` for an account's leaf values (nonce, balance, code hash), both introduced by this EIP. The pre-existing schedule has no standalone constant for this component; it is fused into composites such as `GAS_STORAGE_UPDATE` ([EIP-2200](./eip-2200.md)'s `SSTORE_RESET_GAS`), `CALL_VALUE` (the Yellow Paper's `G_callvalue`) and `GAS_CREATE` (`G_create`). The two write surcharges follow different charging disciplines, stated once here and applying everywhere below:
    - `STORAGE_WRITE` is net-metered within a transaction: it is charged by each `SSTORE` that moves a slot away from its transaction-start value and credited back by each later `SSTORE` that restores that value (refund rule 3 below), so a slot that ends the transaction with a changed value pays it exactly once and a slot that ends unchanged pays only access costs, subject to the refund cap.
    - `ACCOUNT_WRITE` is charged per operation that writes an account's leaf values. For every operation specified in this EIP there is no per-account tracking and no refund: a value-bearing `CALL` to the same recipient pays it on each call. ([EIP-2780](./eip-2780.md) charges it at most once per authority per transaction when processing [EIP-7702](./eip-7702.md) authorizations; that first-write rule is defined there and applies only to authorization processing.)
@@ -42,13 +42,13 @@ Upon activation of this EIP, the following parameters of the gas model are intro
 | **Parameter** | **Component** | **Description** | **Current value** | **New value** | **Increase** | **Operations affected** |
 | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
 | `COLD_ACCOUNT_ACCESS` | Access | Cold touch of an account. Renamed from `COLD_ACCOUNT_ACCESS_COST` ([EIP-2929](./eip-2929.md)) | 2,600 | 3,000 | +15% | `*CALL` opcodes, `BALANCE`, `SELFDESTRUCT`, `EXT*` opcodes, EOA delegations, contract creation txs and ETH transfers |
-| `COLD_STORAGE_ACCESS` | Access | Cold touch of a storage slot. Renamed from `COLD_SLOAD_COST` ([EIP-2929](./eip-2929.md)) | 2,100 | 3,000 | +43% | `SSTORE` and `SLOAD` |
+| `COLD_STORAGE_ACCESS` | Access | Cold touch of a storage slot. Renamed from `COLD_SLOAD_COST` ([EIP-2929](./eip-2929.md)) | 2,100 | 2,100 | +0% | `SSTORE` and `SLOAD` |
 | `WARM_ACCESS` | Access | Touch of an already-warm account or storage slot. Renamed from `WARM_STORAGE_READ_COST` ([EIP-2929](./eip-2929.md)) | 100 | 100 | +0% | `SSTORE`, `SLOAD`, `*CALL` opcodes, `BALANCE`, `SELFDESTRUCT` and `EXT*` opcodes |
-| `ACCOUNT_WRITE` | Write | Write to an account's leaf values (nonce, balance, code hash); charged per operation. New named parameter (previously embedded in `CALL_VALUE`, see footnote 1) | 6,700 (1) | 8,000 | +19% | value-transferring `*CALL` opcodes, `SELFDESTRUCT`, `CREATE`/`CREATE2`, EOA delegations and ETH transfers |
+| `ACCOUNT_WRITE` | Write | Write to an account's leaf values (nonce, balance, code hash); charged per operation. New named parameter (previously embedded in `CALL_VALUE`, see footnote 1) | 6,700 (1) | 9,000 | +34% | value-transferring `*CALL` opcodes, `SELFDESTRUCT`, `CREATE`/`CREATE2`, EOA delegations and ETH transfers |
 | `STORAGE_WRITE` | Write | Write that changes a storage slot's value; net-metered per transaction. New named parameter (previously derived, see footnote 2) | 2,800 (2) | 10,000 | +257% | `SSTORE` |
-| `CREATE_ACCESS` | Access + write | Combined access-and-write cost of contract deployment: `ACCOUNT_WRITE` + `COLD_ACCOUNT_ACCESS`. New named parameter (previously derived, see footnote 3) | 7,000 (3) | 11,000 | +57% | `CREATE`/ `CREATE2` and contract creation txs |
-| `STORAGE_CLEAR_REFUND` | Refund | Refund for clearing a storage slot. Renamed from `SSTORE_CLEARS_SCHEDULE` ([EIP-3529](./eip-3529.md)) | 4,800 | 12,480 | +160% | `SSTORE` |
-| `ACCESS_LIST_STORAGE_KEY_COST` | Access (prepaid) | Gas charged per storage key included in a transaction's access list. Unchanged name from [EIP-2930](./eip-2930.md) | 1,900 | 2,900 | +53% | `SSTORE` and `SLOAD` |
+| `CREATE_ACCESS` | Access + write | Combined access-and-write cost of contract deployment: `ACCOUNT_WRITE` + `COLD_ACCOUNT_ACCESS`. New named parameter (previously derived, see footnote 3) | 7,000 (3) | 12,000 | +71% | `CREATE`/ `CREATE2` and contract creation txs |
+| `STORAGE_CLEAR_REFUND` | Refund | Refund for clearing a storage slot. Renamed from `SSTORE_CLEARS_SCHEDULE` ([EIP-3529](./eip-3529.md)) | 4,800 | 11,616 | +142% | `SSTORE` |
+| `ACCESS_LIST_STORAGE_KEY_COST` | Access (prepaid) | Gas charged per storage key included in a transaction's access list. Unchanged name from [EIP-2930](./eip-2930.md) | 1,900 | 2,000 | +5% | `SSTORE` and `SLOAD` |
 | `ACCESS_LIST_ADDRESS_COST` | Access (prepaid) | Gas charged per address included in a transaction's access list. Unchanged name from [EIP-2930](./eip-2930.md) | 2,400 | 2,900 | +21% | `*CALL` opcodes, `BALANCE`, `SELFDESTRUCT` and `EXT*` opcodes |
 
 (1): 6,700 = `CALL_VALUE` (the Yellow Paper's `G_callvalue`, 9,000) - `CALL_STIPEND` (`G_callstipend`, 2,300)


### PR DESCRIPTION
Changes `COLD_STORAGE_ACCESS` to 2,100 (unchanged from its current value) and `ACCOUNT_WRITE` to 9,000 in EIP-8038, recomputing the dependent derived parameters (`CREATE_ACCESS`, `STORAGE_CLEAR_REFUND`, `ACCESS_LIST_STORAGE_KEY_COST`) accordingly.

## Changes

- **EIP-8038**: updated `COLD_STORAGE_ACCESS` and `ACCOUNT_WRITE` new values, recomputed `CREATE_ACCESS`, `STORAGE_CLEAR_REFUND`, and `ACCESS_LIST_STORAGE_KEY_COST`, and fixed the Abstract / Access-component prose that no longer held now that `COLD_STORAGE_ACCESS` is unchanged.
- **EIP-8007**: updated stale cross-references to the revised EIP-8038 values.
- **EIP-2780**: updated stale cross-references to the revised EIP-8038 values.
