### PR TITLE
Update EIP-8297: remove CODE_OFFSET and stale header-code references

### DIFF
--- a/EIPS/eip-8297.md
+++ b/EIPS/eip-8297.md
@@ -61,9 +61,9 @@ does not always correspond to a distinct node at a fixed depth, but the region
 of keys it owns is exact. This is what later proposals for state expiry and
 partial statelessness build on.
 
-**Code deduplication.** Code beyond the first chunks is content-addressed by code
-hash rather than by account, so thousands of contracts deployed from the same
-factory share their code leaves instead of each storing a copy.
+**Code deduplication.** Code is content-addressed by code hash rather than by
+account, so thousands of contracts deployed from the same factory share their
+code leaves instead of each storing a copy.
 
 ## Specification
 
@@ -268,7 +268,7 @@ is not in the header; it lives in `CODE_ZONE`, content-addressed (see
 | BASIC_DATA_LEAF_KEY     | 0     |
 | CODE_HASH_LEAF_KEY      | 1     |
 | HEADER_STORAGE_OFFSET   | 64    |
-| CODE_OFFSET             | 128   |
+| HEADER_STORAGE_SLOTS    | 64    |
 | STEM_SUBTREE_WIDTH      | 256   |
 | ACCOUNT_ZONE            | 0x00  |
 | CODE_ZONE               | 0x01  |
@@ -277,8 +277,8 @@ is not in the header; it lives in `CODE_ZONE`, content-addressed (see
 | CODE_KEY_LENGTH         | 34    |
 | STORAGE_KEY_LENGTH      | 66    |
 
-It is a required invariant that `STEM_SUBTREE_WIDTH > CODE_OFFSET >
-HEADER_STORAGE_OFFSET`.
+It is a required invariant that `HEADER_STORAGE_OFFSET + HEADER_STORAGE_SLOTS
+<= STEM_SUBTREE_WIDTH`.
 
 Every key produced by this embedding has a length fixed by its zone:
 `ACCOUNT_KEY_LENGTH`, `CODE_KEY_LENGTH` and `STORAGE_KEY_LENGTH` for the
@@ -346,8 +346,9 @@ Setting any header field also sets `version` to zero. `code_hash` and
 account with no code holds the Keccak hash of empty bytecode, unaffected by
 this EIP's choice of merkelization hash (see "Backwards Compatibility").
 
-Header sub-indices `CODE_OFFSET`..`255` are unallocated and reserved. No
-key defined by this EIP resolves to one.
+The header sub-indices in use are `BASIC_DATA_LEAF_KEY`, `CODE_HASH_LEAF_KEY`,
+and `HEADER_STORAGE_OFFSET`..`HEADER_STORAGE_OFFSET + HEADER_STORAGE_SLOTS - 1`.
+No key defined by this EIP resolves to any other sub-index.
 
 ### Code
 
@@ -412,8 +413,8 @@ witness proves such a chunk absent where it would otherwise prove its value.
 ### Storage
 
 Storage slots 0 through 63 live in the account header's stem at
-sub-indices `HEADER_STORAGE_OFFSET`..`127`. Slots 64 and above live in the
-storage zone.
+sub-indices `HEADER_STORAGE_OFFSET`..`HEADER_STORAGE_OFFSET +
+HEADER_STORAGE_SLOTS - 1`. Slots 64 and above live in the storage zone.
 
 A storage key's stem begins with the storage zone byte, followed by its
 tree position: two full hash digests.
@@ -434,7 +435,7 @@ def storage_tree_position(address: Address32, tree_index: int) -> bytes:
     return prefix + suffix
 
 def get_tree_key_for_storage_slot(address: Address32, storage_key: int):
-    if storage_key < CODE_OFFSET - HEADER_STORAGE_OFFSET:   # storage_key < 64
+    if storage_key < HEADER_STORAGE_SLOTS:
         return get_tree_key_for_header(address, HEADER_STORAGE_OFFSET + storage_key)
     tree_index = storage_key // STEM_SUBTREE_WIDTH
     sub_index  = storage_key %  STEM_SUBTREE_WIDTH
@@ -480,7 +481,8 @@ The MPT checked `storage_root` to decide whether an address has non-empty
 storage (i.e., the that condition [EIP-7610](./eip-7610.md) checks before contract
 creation). This tree has no such node, and thus the address has non-empty storage
 exactly when a leaf exists at one of its header sub-indices
-`HEADER_STORAGE_OFFSET`..`127` or anywhere in its storage bucket.
+`HEADER_STORAGE_OFFSET`..`HEADER_STORAGE_OFFSET + HEADER_STORAGE_SLOTS - 1`
+or anywhere in its storage bucket.
 
 ### Fork
 
@@ -646,8 +648,8 @@ ever created.
 Per-account and per-bucket expiry is a natural operation on the zone
 topology. The storage bucket keyed by `key_hash(address)` roots one
 account's storage in the common case. Record its hash and prune below it.
-The account header's stem expires the account's core data, hot
-storage, and initial code in one step. Content-addressed code needs
+The account header's stem expires the account's core data and hot
+storage in one step. Content-addressed code needs
 reference counting or deferral to a state sweep, since its leaves may be
 shared. Resurrection re-attaches a subtree consistent with the recorded
 commitment. The mechanism itself is left to a separate EIP.
@@ -740,8 +742,10 @@ distinct bytecodes mapping to the same stem would need a 256-bit
 collision, on Keccak for `code_hash` or on `key_hash(code_hash ||
 tree_index)`, either of which is infeasible.
 
-**Sub-index.** The sub-index is `storage_key % 256` or the analogous code
-arithmetic, a direct mapping rather than a hash. Two distinct keys share a
+**Sub-index.** The sub-index is a direct mapping rather than a hash:
+`HEADER_STORAGE_OFFSET + storage_key` in the header, `storage_key %
+STEM_SUBTREE_WIDTH` in the storage zone, and `chunk_id % STEM_SUBTREE_WIDTH`
+in the code zone. Two distinct keys share a
 sub-index only if they also share a stem, in which case they are
 the same item, so no collision is possible between distinct items.
 


### PR DESCRIPTION
Follow-up to #12082, addressing its review comments.

That PR moved all code chunks into `CODE_ZONE` but left residues pointed out by @kevaundray 

This PR fixes them and closes the gap. No more code in the account header for PBT.