### PR TITLE
Update EIP-8141: frame-aware inclusion-list (FOCIL) validity

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -939,11 +939,11 @@ The [EIP-7805](./eip-7805.md) (FOCIL) end-of-block check decides whether an unin
 
 A frame transaction's validity is not captured by that check: its sender need not be the payer (which may be a paymaster), and validity is established only by evaluating the validation prefix. Any protocol-level check of whether a frame transaction could be validly included MUST therefore evaluate its validation prefix — the frames up to and including the one that sets `payer` — against the block's state at the append position, rather than checking nonce and balance. For a legacy or default-code externally owned account transaction the prefix is the ordinary signature check, so admissible transactions are validated as they are today.
 
-The evaluation is bounded by `MAX_IL_VERIFY_GAS`, a cap dedicated to this check (so it does not depend on the mempool's `MAX_VERIFY_GAS`) but which MUST NOT be below `MAX_VERIFY_GAS`, so that a mempool-admissible transaction is never excluded. Signature validation counts against the cap, and the prefix's simulated state changes (sender nonce, `payer`, `max_cost`) are discarded. A prefix that does not set `payer` within the cap is not includable, and the inclusion list's bounded size caps the aggregate per-block cost.
+As with existing FOCIL checks the per-block cost is bounded by the inclusion list's size; the prefix evaluation is additionally capped at `MAX_IL_VERIFY_GAS`, and its simulated state changes are discarded.
 
 Unlike mempool admission, this check does not apply the mempool admissibility restrictions (the banned validation-prefix opcodes and recognized-shape rules): the block is concrete, so those reads take their actual values and a transaction is includable whenever its prefix succeeds at the append position.
 
-The block-space test must likewise use a frame transaction's full reservation: it compares the transaction's `max_gas` against the remaining block gas, not a `gas` field (frame transactions have none) nor the bare sum of frame `gas_limit` values, which under-counts by at least `FRAME_TX_INTRINSIC_COST`. A builder that uses EIP-7805's incremental nonce and balance tracking to skip re-checking pending inclusion-list transactions must extend it for frame transactions — whose validity can also depend on the sender's code and storage and the payer's balance and code — or re-evaluate the prefix.
+The block-space test compares the transaction's `max_gas` against the remaining block gas. A frame transaction's validity can also depend on the sender's code and storage and on the payer's balance and code, so an implementation that avoids re-evaluating a pending inclusion-list transaction on every block must track that wider dependency set, not only the sender's nonce and balance.
 
 ### Networking
 

--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -43,7 +43,7 @@ Ultimately, frame transactions realize the original vision of account abstractio
 | `SECP256K1N`               | `0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141` |
 | `SECP256R1N`               | `0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551` |
 | `VERSIONED_HASH_VERSION_KZG` | `Bytes1(0x01)` |
-| `MAX_IL_VERIFY_GAS`         | `100_000`         |
+| `MAX_IL_VERIFY_GAS`         | `TBD`             |
 
 ### Frame Transaction
 
@@ -937,9 +937,13 @@ Validation logic for other transaction types remains unchanged, i.e. the transac
 
 The [EIP-7805](./eip-7805.md) (FOCIL) end-of-block check decides whether an unincluded inclusion-list transaction could be validly appended to a block, skipping it otherwise. For non-frame transactions this is a check of the sender's nonce and balance.
 
-A frame transaction's validity is not captured by that check: its sender need not be the payer (which may be a paymaster), and validity is established only by evaluating the validation prefix. Any protocol-level check of whether a frame transaction could be validly included MUST therefore evaluate its validation prefix — the frames up to and including the one that sets `payer`, bounded by `MAX_IL_VERIFY_GAS` (a dedicated cap, so this consensus check does not depend on the mempool's `MAX_VERIFY_GAS`) — against the block's state at the append position, rather than checking nonce and balance. A prefix that does not complete within `MAX_IL_VERIFY_GAS` is treated as not includable. For a legacy or default-code externally owned account transaction this reduces to the existing checks, so the change is backwards compatible.
+A frame transaction's validity is not captured by that check: its sender need not be the payer (which may be a paymaster), and validity is established only by evaluating the validation prefix. Any protocol-level check of whether a frame transaction could be validly included MUST therefore evaluate its validation prefix — the frames up to and including the one that sets `payer` — against the block's state at the append position, rather than checking nonce and balance. For a legacy or default-code externally owned account transaction the prefix is the ordinary signature check, so admissible transactions are validated as they are today.
+
+The evaluation is bounded by `MAX_IL_VERIFY_GAS`, a cap dedicated to this check (so it does not depend on the mempool's `MAX_VERIFY_GAS`) but which MUST NOT be below `MAX_VERIFY_GAS`, so that a mempool-admissible transaction is never excluded. Signature validation counts against the cap, and the prefix's simulated state changes (sender nonce, `payer`, `max_cost`) are discarded. A prefix that does not set `payer` within the cap is not includable, and the inclusion list's bounded size caps the aggregate per-block cost.
 
 Unlike mempool admission, this check does not apply the mempool admissibility restrictions (the banned validation-prefix opcodes and recognized-shape rules): the block is concrete, so those reads take their actual values and a transaction is includable whenever its prefix succeeds at the append position.
+
+The block-space test must likewise use a frame transaction's full reservation: it compares the transaction's `max_gas` against the remaining block gas, not a `gas` field (frame transactions have none) nor the bare sum of frame `gas_limit` values, which under-counts by at least `FRAME_TX_INTRINSIC_COST`. A builder that uses EIP-7805's incremental nonce and balance tracking to skip re-checking pending inclusion-list transactions must extend it for frame transactions — whose validity can also depend on the sender's code and storage and the payer's balance and code — or re-evaluate the prefix.
 
 ### Networking
 

--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -43,6 +43,7 @@ Ultimately, frame transactions realize the original vision of account abstractio
 | `SECP256K1N`               | `0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141` |
 | `SECP256R1N`               | `0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551` |
 | `VERSIONED_HASH_VERSION_KZG` | `Bytes1(0x01)` |
+| `MAX_IL_VERIFY_GAS`         | `100_000`         |
 
 ### Frame Transaction
 
@@ -931,6 +932,14 @@ When a new canonical block is accepted, the node removes any included frame tran
 Do not apply the restriction put in place by [EIP-3607](./eip-3607.md) to frame transactions.
 Specifically, `SENDER` frames originate calls where `tx.sender` is a contract account.
 Validation logic for other transaction types remains unchanged, i.e. the transaction is only valid if the sender account's code is either empty or a valid delegation indicator.
+
+### Inclusion List Validity
+
+The [EIP-7805](./eip-7805.md) (FOCIL) end-of-block check decides whether an unincluded inclusion-list transaction could be validly appended to a block, skipping it otherwise. For non-frame transactions this is a check of the sender's nonce and balance.
+
+A frame transaction's validity is not captured by that check: its sender need not be the payer (which may be a paymaster), and validity is established only by evaluating the validation prefix. Any protocol-level check of whether a frame transaction could be validly included MUST therefore evaluate its validation prefix — the frames up to and including the one that sets `payer`, bounded by `MAX_IL_VERIFY_GAS` (a dedicated cap, so this consensus check does not depend on the mempool's `MAX_VERIFY_GAS`) — against the block's state at the append position, rather than checking nonce and balance. A prefix that does not complete within `MAX_IL_VERIFY_GAS` is treated as not includable. For a legacy or default-code externally owned account transaction this reduces to the existing checks, so the change is backwards compatible.
+
+Unlike mempool admission, this check does not apply the mempool admissibility restrictions (the banned validation-prefix opcodes and recognized-shape rules): the block is concrete, so those reads take their actual values and a transaction is includable whenever its prefix succeeds at the append position.
 
 ### Networking
 


### PR DESCRIPTION
Requires inclusion-list (FOCIL, [EIP-7805](https://eips.ethereum.org/EIPS/eip-7805)) validity checks to evaluate a frame transaction's validation prefix instead of its nonce and balance, and adds `MAX_IL_VERIFY_GAS`.