### PR TITLE
Update EIP-8333: Clarify EIP-8333 boundary rationale

### DIFF
--- a/EIPS/eip-8333.md
+++ b/EIPS/eip-8333.md
@@ -79,7 +79,7 @@ Keeping the checkpoint epoch and moving only the root confines the change to a s
 
 When the first slot of epoch `N` is empty, `get_block_root(state, N)` already returns the boundary block. This proposal is therefore a no-op for such epochs. It makes that missed-slot fallback the rule rather than the exception; behavior changes only when a block occupies the epoch's first slot. The genesis epoch, which has no block before it, resolves to the genesis block, as today.
 
-The checkpoint root for epoch `N` also matches the epoch-boundary shuffling dependent root for epoch `N`: `get_block_root_at_slot(state, compute_start_slot_at_epoch(N) - 1)`. Beacon API `head_v2` events expose this boundary root as the dependent root for the relevant epoch, whether that epoch is current or next relative to the event slot. This gives FFG checkpoints the same boundary anchor that validators use when checking duties against a head event.
+The checkpoint root for epoch `N` also matches the epoch-boundary shuffling dependent root for epoch `N`: `get_block_root_at_slot(state, compute_start_slot_at_epoch(N) - 1)`. Beacon API `head_v2` events expose this boundary root as either `current_epoch_dependent_root` or `next_epoch_dependent_root`, depending on whether epoch `N` is current or next relative to the event slot. This gives FFG checkpoints the same boundary anchor that validators use when checking duties against a head event.
 
 ## Backwards Compatibility
 

--- a/EIPS/eip-8333.md
+++ b/EIPS/eip-8333.md
@@ -77,7 +77,9 @@ The boundary block, run through the state transition function, deterministically
 
 Keeping the checkpoint epoch and moving only the root confines the change to a single question, which block anchors an epoch. Slashing conditions, justification bits, and finalization rules are untouched, and no containers change, so serialization, gossip formats, and slashing-protection databases are unaffected.
 
-`get_block_root(state, epoch)` already returns the boundary block when the epoch's first slot is empty. This proposal makes that resolution the rule rather than the fallback; behavior changes only when a block occupies the epoch's first slot. The genesis epoch, which has no block before it, resolves to the genesis block, as today.
+When the first slot of epoch `N` is empty, `get_block_root(state, N)` already returns the boundary block. This proposal is therefore a no-op for such epochs. It makes that missed-slot fallback the rule rather than the exception; behavior changes only when a block occupies the epoch's first slot. The genesis epoch, which has no block before it, resolves to the genesis block, as today.
+
+The checkpoint root for epoch `N` also matches the epoch-boundary dependent root exposed by Beacon API `head_v2` events as `next_epoch_dependent_root` for heads in epoch `N`: `get_block_root_at_slot(state, compute_start_slot_at_epoch(N) - 1)`. This gives FFG checkpoints the same boundary anchor that validators use when checking next-epoch duties against a head event.
 
 ## Backwards Compatibility
 

--- a/EIPS/eip-8333.md
+++ b/EIPS/eip-8333.md
@@ -79,7 +79,7 @@ Keeping the checkpoint epoch and moving only the root confines the change to a s
 
 When the first slot of epoch `N` is empty, `get_block_root(state, N)` already returns the boundary block. This proposal is therefore a no-op for such epochs. It makes that missed-slot fallback the rule rather than the exception; behavior changes only when a block occupies the epoch's first slot. The genesis epoch, which has no block before it, resolves to the genesis block, as today.
 
-The checkpoint root for epoch `N` also matches the epoch-boundary shuffling dependent root for epoch `N`: `get_block_root_at_slot(state, compute_start_slot_at_epoch(N) - 1)`. Beacon API `head_v2` events expose this boundary root as either `current_epoch_dependent_root` or `next_epoch_dependent_root`, depending on whether epoch `N` is current or next relative to the event slot. This gives FFG checkpoints the same boundary anchor that validators use when checking duties against a head event.
+The checkpoint root for epoch `N` also matches the epoch-boundary root used as the shuffling dependent root for a duty epoch whose lookahead points back to `N`: `get_block_root_at_slot(state, compute_start_slot_at_epoch(N) - 1)`. In fork-choice terms, this is the root selected by `get_shuffling_dependent_root(store, root, N + MIN_SEED_LOOKAHEAD)` for the same chain view. Beacon API `head_v2` events expose this boundary root as either `current_epoch_dependent_root` or `next_epoch_dependent_root`, depending on whether epoch `N` is current or next relative to the event slot. This gives FFG checkpoints the same boundary anchor that validators use when checking duties against a head event.
 
 ## Backwards Compatibility
 

--- a/EIPS/eip-8333.md
+++ b/EIPS/eip-8333.md
@@ -79,7 +79,7 @@ Keeping the checkpoint epoch and moving only the root confines the change to a s
 
 When the first slot of epoch `N` is empty, `get_block_root(state, N)` already returns the boundary block. This proposal is therefore a no-op for such epochs. It makes that missed-slot fallback the rule rather than the exception; behavior changes only when a block occupies the epoch's first slot. The genesis epoch, which has no block before it, resolves to the genesis block, as today.
 
-The checkpoint root for epoch `N` also matches the epoch-boundary root used as the shuffling dependent root for a duty epoch whose lookahead points back to `N`: `get_block_root_at_slot(state, compute_start_slot_at_epoch(N) - 1)`. In fork-choice terms, this is the root selected by `get_shuffling_dependent_root(store, root, N + MIN_SEED_LOOKAHEAD)` for the same chain view. Beacon API `head_v2` events expose this boundary root as either `current_epoch_dependent_root` or `next_epoch_dependent_root`, depending on whether epoch `N` is current or next relative to the event slot. This gives FFG checkpoints the same boundary anchor that validators use when checking duties against a head event.
+The checkpoint root for epoch `N` also matches the epoch-boundary root used as the shuffling dependent root for a duty epoch whose lookahead points back to `N`: `get_block_root_at_slot(state, compute_start_slot_at_epoch(N) - 1)`. In fork-choice terms, this is the root selected by `get_shuffling_dependent_root(store, root, N + MIN_SEED_LOOKAHEAD)` for the same chain view. This gives FFG checkpoints the same boundary anchor used for shuffling-dependent duty checks.
 
 ## Backwards Compatibility
 

--- a/EIPS/eip-8333.md
+++ b/EIPS/eip-8333.md
@@ -79,7 +79,7 @@ Keeping the checkpoint epoch and moving only the root confines the change to a s
 
 When the first slot of epoch `N` is empty, `get_block_root(state, N)` already returns the boundary block. This proposal is therefore a no-op for such epochs. It makes that missed-slot fallback the rule rather than the exception; behavior changes only when a block occupies the epoch's first slot. The genesis epoch, which has no block before it, resolves to the genesis block, as today.
 
-The checkpoint root for epoch `N` also matches the epoch-boundary dependent root exposed by Beacon API `head_v2` events as `next_epoch_dependent_root` for heads in epoch `N`: `get_block_root_at_slot(state, compute_start_slot_at_epoch(N) - 1)`. This gives FFG checkpoints the same boundary anchor that validators use when checking next-epoch duties against a head event.
+The checkpoint root for epoch `N` also matches the epoch-boundary shuffling dependent root for epoch `N`: `get_block_root_at_slot(state, compute_start_slot_at_epoch(N) - 1)`. Beacon API `head_v2` events expose this boundary root as the dependent root for the relevant epoch, whether that epoch is current or next relative to the event slot. This gives FFG checkpoints the same boundary anchor that validators use when checking duties against a head event.
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
## Summary
- clarify that EIP-8333 is a no-op when the first slot of an epoch is missed, since current `get_block_root(state, N)` already resolves to the boundary block then
- add the equivalence between the new checkpoint root and the `head_v2.next_epoch_dependent_root` boundary root

## Validation
- `git diff --check origin/master...HEAD`

## AI assistance
- Drafted with AI assistance by Lodekeeper (@lodekeeper).
