### PR TITLE
Update EIP-8141: specify block inclusion gating and payer solvency

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -489,6 +489,12 @@ payer_refund = max_cost - charged_fee
 
 After execution, return `payer_refund` to the payer. This is the `resolved_target` that called `APPROVE(APPROVE_PAYMENT)` or `APPROVE(APPROVE_EXECUTION_AND_PAYMENT)`. Return `max_gas - gas_used` to the block gas pool.
 
+##### Block inclusion
+
+A frame transaction reserves `max_gas` against the block gas limit, so it may be included in a block only if `max_gas` does not exceed that block's remaining gas. A frame transaction carries no transaction-level gas limit field to gate on, and the sum of its `frame.gas_limit` values under-counts the reservation by at least `FRAME_TX_INTRINSIC_COST`.
+
+Solvency at inclusion time is a property of `payer`, which is known only once the validation prefix has executed. `tx.sender` is not required to hold any balance, and in the sponsored case typically holds none. Inclusion eligibility must therefore be established by executing the validation prefix and applying the payer reservation rules of the [Mempool](#mempool) section to the resulting `payer`, rather than by comparing the balance of `tx.sender` against `max_cost`.
+
 ##### Blob handling
 
 When `blob_versioned_hashes` is non-empty, the transaction is a blob-carrying transaction and follows [EIP-4844](./eip-4844.md), where the payer is also the blob-fee payer. The following distinctions from EIP-4844 must also be adhered to:


### PR DESCRIPTION
Adds a Block inclusion subsection to EIP-8141, stating what a block builder must gate on.

Two facts are currently implied rather than normative. The block gas reservation is `max_gas`, which today follows only from "return `max_gas - gas_used` to the block gas pool"; and solvency belongs to `payer`, which appears only in the Mempool section, a section a block builder is not required to follow.

An implementation that reuses its existing transaction selection path inherits two defects from it. It gates on the sum of `frame.gas_limit` values, which under-counts the reservation by at least `FRAME_TX_INTRINSIC_COST`, so a block can exceed its own gas limit and be rejected by its own header validation. And it checks the balance of `tx.sender`, which drops every sponsored transaction whose sender holds nothing, the flow this EIP is built around.

Both were real defects in an implementation of this EIP, found while reviewing the block production path against the spec, and both are fixed there now.

No change to consensus behaviour; this only makes existing requirements explicit.
