### PR TITLE
Update EIP-8333: shorten dependent-root rationale

### DIFF
--- a/EIPS/eip-8333.md
+++ b/EIPS/eip-8333.md
@@ -79,7 +79,7 @@ Keeping the checkpoint epoch and moving only the root confines the change to a s
 
 When the first slot of epoch `N` is empty, `get_block_root(state, N)` already returns the boundary block. This proposal is therefore a no-op for such epochs. It makes that missed-slot fallback the rule rather than the exception; behavior changes only when a block occupies the epoch's first slot. The genesis epoch, which has no block before it, resolves to the genesis block, as today.
 
-The checkpoint root for epoch `N` also matches the epoch-boundary root used as the shuffling dependent root for a duty epoch whose lookahead points back to `N`: `get_block_root_at_slot(state, compute_start_slot_at_epoch(N) - 1)`. In fork-choice terms, this is the root selected by `get_shuffling_dependent_root(store, root, N + MIN_SEED_LOOKAHEAD)` for the same chain view. This gives FFG checkpoints the same boundary anchor used for shuffling-dependent duty checks.
+`get_checkpoint_root(state, N)` is also the boundary root used for shuffling-dependent duty checks: `get_block_root_at_slot(state, compute_start_slot_at_epoch(N) - 1)`. In fork-choice terms, this is `get_shuffling_dependent_root(store, root, N + MIN_SEED_LOOKAHEAD)` for the same chain view.
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
Follow-up to #12090 after review discussion.

This shortens the dependent-root rationale paragraph while keeping:
- the explicit boundary-slot formula
- the consensus-specs fork-choice helper reference with the `MIN_SEED_LOOKAHEAD` offset

AI assistance disclosed: drafted by Lodekeeper using OpenAI Codex.