### PR TITLE
Update EIP-8133: Update EIP-8133 requirements and naming conventions

### DIFF
--- a/EIPS/eip-8133.md
+++ b/EIPS/eip-8133.md
@@ -7,7 +7,7 @@ discussions-to: https://ethereum-magicians.org/t/eip-8133-upgrade-nomenclature/2
 status: Review
 type: Informational
 created: 2026-01-23
-requires: 150, 606, 607, 608, 609, 779, 1013, 1283, 1679, 1716, 2387, 4345, 5133, 7569, 7600, 7607, 7892
+requires: 150, 606, 607, 608, 609, 779, 1013, 1283, 1679, 1716, 2387, 4345, 5133, 7569, 7600, 7607, 7892, 8134, 8135
 ---
 
 ## Abstract
@@ -137,7 +137,7 @@ Observed examples include:
 * **[Pectra](./eip-7600.md)**:  **P**rague (EL) and El**ectr**a (CL)
 * **[Fusaka](./eip-7607.md)**: **Fu**lu (CL) and O**saka** (EL)
 * **Glamsterdam**: **Gl**oas (CL) and **Amsterdam** (EL)
-* **Hegotá**: **He**ka (CL) and Bo**gotá** (Execution Layer)
+* **Hegotá**: **He**ze (CL) and Bo**gotá** (Execution Layer)
 
 Additional combined names MAY be adopted in future upgrades following the same convention.
 
@@ -155,8 +155,8 @@ The BPO naming convention is specified in [EIP-7892](./eip-7892.md) and applies 
 
 Observed examples include:
 
-* BPO1 
-* BPO2 
+* [BPO1](./eip-8134.md) 
+* [BPO2](./eip-8135.md) 
 * BPO3 
 
 BPO upgrades MAY be deployed independently or alongside larger multi-change upgrades. The numeric identifier remains the canonical reference.

--- a/EIPS/eip-8133.md
+++ b/EIPS/eip-8133.md
@@ -47,7 +47,7 @@ These names reflect the exploratory nature of early protocol development.
 
 ### Historic City Naming
 
-During the Metropolis development phase, upgrades adopted names based on historically connected cities to provide consistency and symbolic continuity. The naming reflected Ethereum’s transition toward a more mature, user-friendly platform.
+During the Metropolis development phase, upgrades adopted names based on historically connected cities to provide consistency and symbolic continuity. The naming reflected Ethereum's transition toward a more mature, user-friendly platform.
 
 Observed upgrades include:
 
@@ -145,7 +145,7 @@ Additional combined names MAY be adopted in future upgrades following the same c
 
 Blob-Parameter-Only upgrades (BPO upgrades) are network upgrades whose scope is limited to modifying blob-related parameters, including blob target and maximum limits, without introducing additional protocol changes.
 
-BPO upgrades support Ethereum’s data availability scaling objectives under the Surge roadmap by enabling incremental capacity increases with reduced operational risk.
+BPO upgrades support Ethereum's data availability scaling objectives under the Surge roadmap by enabling incremental capacity increases with reduced operational risk.
 
 BPO upgrades MUST be named using a sequential numeric identifier in the format BPO&lt;n&gt;, where `n` is a monotonically increasing positive integer starting from 1.
 


### PR DESCRIPTION
Updated the 'requires' section to include EIPs 8134 and 8135, and corrected the naming convention for 'Hegotá'.


