### PR TITLE
Update EIP-1153: Move test link to execution-specs

### DIFF
--- a/EIPS/eip-1153.md
+++ b/EIPS/eip-1153.md
@@ -99,7 +99,7 @@ Since this EIP does not change behavior of any existing opcodes, it is backwards
 
 ## Test Cases
 
-A test suite for this EIP can be found [here](https://github.com/ethereum/execution-spec-tests/tree/1983444bbe1a471886ef7c0e82253ffe2a4053e1/tests/cancun/eip1153_tstore).
+A test suite for this EIP can be found [here](https://github.com/ethereum/execution-specs/tree/27174ca81b09dee4d41db23b40305cd1bb70f5bf/tests/cancun/eip1153_tstore).
 
 ## Reference Implementation
 

--- a/EIPS/eip-1153.md
+++ b/EIPS/eip-1153.md
@@ -13,7 +13,7 @@ requires: 2200, 3529
 
 ## Abstract
 
-This proposal introduces transient storage opcodes, which manipulate state that behaves identically to storage, except that transient storage is discarded after every transaction, and `TSTORE` is not subject to the gas stipend check as defined in [EIP-2200](./eip-2200.md). In other words, the values of transient storage are never deserialized from storage or serialized to storage. Thus transient storage is cheaper since it never requires disk access. Transient storage is accessible to smart contracts via 2 new opcodes, `TLOAD` and `TSTORE`, where “T” stands for "transient:"
+This proposal introduces transient storage opcodes, which manipulate state that behaves identically to storage, except that transient storage is discarded after every transaction, and `TSTORE` is not subject to the gas stipend check as defined in [EIP-2200](./eip-2200.md). In other words, the values of transient storage are never deserialized from storage or serialized to storage. Thus transient storage is cheaper since it never requires disk access. Transient storage is accessible to smart contracts via 2 new opcodes, `TLOAD` and `TSTORE`, where "T" stands for "transient:"
 
 ```
 TLOAD  (0x5c)


### PR DESCRIPTION
This PR is a follow-up to [#11845](https://github.com/ethereum/EIPs/pull/11845), which updated EIP-1 to stop accepting links to the archived `ethereum/execution-spec-tests` repository. It repoints this EIP's test-suite link to its new home in [`ethereum/execution-specs`](https://github.com/ethereum/execution-specs).

**Background:** The Ethereum Execution Specification Tests (EEST) moved from `ethereum/execution-spec-tests` to `ethereum/execution-specs` in October 2025 as part of ["The Weld"](https://steel.ethereum.foundation/blog/2025-11-04_weld_final/). The `execution-spec-tests` repository is no longer maintained and was archived on 2026-07-02.

**Test-suite link updated:**

- Old: https://github.com/ethereum/execution-spec-tests/tree/1983444bbe1a471886ef7c0e82253ffe2a4053e1/tests/cancun/eip1153_tstore
- New: https://github.com/ethereum/execution-specs/tree/27174ca81b09dee4d41db23b40305cd1bb70f5bf/tests/cancun/eip1153_tstore

This is one of a series of per-EIP follow-ups to #11845, opened individually per the editors' request.
