### PR TITLE
Update EIP-2935: Move test link to execution-specs

### DIFF
--- a/EIPS/eip-2935.md
+++ b/EIPS/eip-2935.md
@@ -214,7 +214,7 @@ This EIP introduces backwards incompatible changes to the block validation rule 
 
 ## Test Cases
 
-[EIP-2935 Execution Spec Tests](https://github.com/ethereum/execution-spec-tests/tree/3810d22f84f206866f66f4f6bf856187c2893ab1/tests/prague/eip2935_historical_block_hashes_from_state)
+[EIP-2935 Execution Spec Tests](https://github.com/ethereum/execution-specs/tree/27174ca81b09dee4d41db23b40305cd1bb70f5bf/tests/prague/eip2935_historical_block_hashes_from_state)
 
 ## Security Considerations
 


### PR DESCRIPTION
This PR is a follow-up to [#11845](https://github.com/ethereum/EIPs/pull/11845), which updated EIP-1 to stop accepting links to the archived `ethereum/execution-spec-tests` repository. It repoints this EIP's test-suite link to its new home in [`ethereum/execution-specs`](https://github.com/ethereum/execution-specs).

**Background:** The Ethereum Execution Specification Tests (EEST) moved from `ethereum/execution-spec-tests` to `ethereum/execution-specs` in October 2025 as part of ["The Weld"](https://steel.ethereum.foundation/blog/2025-11-04_weld_final/). The `execution-spec-tests` repository is no longer maintained and was archived on 2026-07-02.

**Test-suite link updated:**

- Old: https://github.com/ethereum/execution-spec-tests/tree/3810d22f84f206866f66f4f6bf856187c2893ab1/tests/prague/eip2935_historical_block_hashes_from_state
- New: https://github.com/ethereum/execution-specs/tree/27174ca81b09dee4d41db23b40305cd1bb70f5bf/tests/prague/eip2935_historical_block_hashes_from_state

This is one of a series of per-EIP follow-ups to #11845, opened individually per the editors' request.
