### PR TITLE
Update EIP-4844: Move test link to execution-specs

### DIFF
--- a/EIPS/eip-4844.md
+++ b/EIPS/eip-4844.md
@@ -420,7 +420,7 @@ In addition, we recommend including a 1.1x base fee per blob gas bump requiremen
 
 ## Test Cases
 
-Execution layer test cases for this EIP can be found in the [`eip4844_blobs`](https://github.com/ethereum/execution-spec-tests/tree/1983444bbe1a471886ef7c0e82253ffe2a4053e1/tests/cancun/eip4844_blobs) of the `ethereum/execution-spec-tests` repository. Consensus layer test cases can be found [here](https://github.com/ethereum/consensus-specs/tree/2297c09b7e457a13f7b2261a28cb45777be82f83/tests/core/pyspec/eth2spec/test/deneb). 
+Execution layer test cases for this EIP can be found in the [`eip4844_blobs`](https://github.com/ethereum/execution-specs/tree/27174ca81b09dee4d41db23b40305cd1bb70f5bf/tests/cancun/eip4844_blobs) of the `ethereum/execution-specs` repository. Consensus layer test cases can be found [here](https://github.com/ethereum/consensus-specs/tree/2297c09b7e457a13f7b2261a28cb45777be82f83/tests/core/pyspec/eth2spec/test/deneb). 
 
 ## Security Considerations
 


### PR DESCRIPTION
This PR is a follow-up to [#11845](https://github.com/ethereum/EIPs/pull/11845), which updated EIP-1 to stop accepting links to the archived `ethereum/execution-spec-tests` repository. It repoints this EIP's test-suite link to its new home in [`ethereum/execution-specs`](https://github.com/ethereum/execution-specs).

**Background:** The Ethereum Execution Specification Tests (EEST) moved from `ethereum/execution-spec-tests` to `ethereum/execution-specs` in October 2025 as part of ["The Weld"](https://steel.ethereum.foundation/blog/2025-11-04_weld_final/). The `execution-spec-tests` repository is no longer maintained and was archived on 2026-07-02.

**Test-suite link updated:**

- Old: https://github.com/ethereum/execution-spec-tests/tree/1983444bbe1a471886ef7c0e82253ffe2a4053e1/tests/cancun/eip4844_blobs
- New: https://github.com/ethereum/execution-specs/tree/27174ca81b09dee4d41db23b40305cd1bb70f5bf/tests/cancun/eip4844_blobs

This is one of a series of per-EIP follow-ups to #11845, opened individually per the editors' request.
