### PR TITLE
Update EIP-6780: Move test link to execution-specs

### DIFF
--- a/EIPS/eip-6780.md
+++ b/EIPS/eip-6780.md
@@ -65,7 +65,7 @@ Previously it was possible to burn ether by calling `SELFDESTRUCT` targeting the
 
 ## Test Cases 
 
-Test cases for this EIP can be found in the Execution Spec Tests suite [`eip6780_selfdestruct`](https://github.com/ethereum/execution-spec-tests/tree/1983444bbe1a471886ef7c0e82253ffe2a4053e1/tests/cancun/eip6780_selfdestruct).
+Test cases for this EIP can be found in the Execution Spec Tests suite [`eip6780_selfdestruct`](https://github.com/ethereum/execution-specs/tree/27174ca81b09dee4d41db23b40305cd1bb70f5bf/tests/cancun/eip6780_selfdestruct).
 
 ## Security Considerations
 


### PR DESCRIPTION
This PR is a follow-up to [#11845](https://github.com/ethereum/EIPs/pull/11845), which updated EIP-1 to stop accepting links to the archived `ethereum/execution-spec-tests` repository. It repoints this EIP's test-suite link to its new home in [`ethereum/execution-specs`](https://github.com/ethereum/execution-specs).

**Background:** The Ethereum Execution Specification Tests (EEST) moved from `ethereum/execution-spec-tests` to `ethereum/execution-specs` in October 2025 as part of ["The Weld"](https://steel.ethereum.foundation/blog/2025-11-04_weld_final/). The `execution-spec-tests` repository is no longer maintained and was archived on 2026-07-02.

**Test-suite link updated:**

- Old: https://github.com/ethereum/execution-spec-tests/tree/1983444bbe1a471886ef7c0e82253ffe2a4053e1/tests/cancun/eip6780_selfdestruct
- New: https://github.com/ethereum/execution-specs/tree/27174ca81b09dee4d41db23b40305cd1bb70f5bf/tests/cancun/eip6780_selfdestruct

This is one of a series of per-EIP follow-ups to #11845, opened individually per the editors' request.
