### PR TITLE
Update EIP-7756: Move EOF test link to execution-specs

### DIFF
--- a/EIPS/eip-7756.md
+++ b/EIPS/eip-7756.md
@@ -220,7 +220,7 @@ in EIP-7692.
 ## Test Cases
 
 This is the trace output from the Ethereum Execution Specification Test from one of the
-parameterized executions of [test_eof_functions_contract_call_succeed](https://github.com/ethereum/execution-spec-tests/blob/632d151ea8a71d09a3a0acbdb85d97fa18c8456b/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_execution_function.py#L304-L335).
+parameterized executions of [test_eof_functions_contract_call_succeed](https://github.com/ethereum/execution-specs/blob/b84b68a2d8aeb707c9cbe8525948768b2affee3c/tests/unscheduled/eip7692_eof_v1/eip3540_eof_v1/test_execution_function.py#L314-L346).
 Memory and return data is disabled.
 
 ```json lines


### PR DESCRIPTION
This PR is a follow-up to [#11845](https://github.com/ethereum/EIPs/pull/11845), which updated EIP-1 to stop accepting links to the archived `ethereum/execution-spec-tests` repository. It repoints this EIP's test-suite link to its new home in [`ethereum/execution-specs`](https://github.com/ethereum/execution-specs).

**Background:** The Ethereum Execution Specification Tests (EEST) moved from `ethereum/execution-spec-tests` to `ethereum/execution-specs` in October 2025 as part of ["The Weld"](https://steel.ethereum.foundation/blog/2025-11-04_weld_final/). The `execution-spec-tests` repository is no longer maintained and was archived on 2026-07-02.

**Test-suite link updated:**

- Old: https://github.com/ethereum/execution-spec-tests/blob/632d151ea8a71d09a3a0acbdb85d97fa18c8456b/tests/prague/eip7692_eof_v1/eip3540_eof_v1/test_execution_function.py#L304-L335
- New: https://github.com/ethereum/execution-specs/blob/b84b68a2d8aeb707c9cbe8525948768b2affee3c/tests/unscheduled/eip7692_eof_v1/eip3540_eof_v1/test_execution_function.py#L314-L346

Note: unlike the other EEST suites, this was not a same-path swap — the EOF tests were relocated within `execution-specs` (`tests/prague/…` → `tests/unscheduled/…`) and the line anchor was updated accordingly (`#L304-L335` → `#L314-L346`). This pins to commit `b84b68a2`, a commit on which this test still exists; the EOF tests were subsequently removed from `execution-specs` in [ethereum/execution-specs#1873](https://github.com/ethereum/execution-specs/pull/1873).

This is one of a series of per-EIP follow-ups to #11845, opened individually per the editors' request.
