### PR TITLE
Update EIP-8141: statically disallow approval scope on atomic-batch frames

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -417,7 +417,7 @@ Then for each frame:
         - A non-zero value transfer to an address other than `tx.sender` emits the transfer log specified by [EIP-7708](./eip-7708.md).
     - If `resolved_target` code hash is empty, i.e. `0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470`, execute the logic described in [default code](#default-code).
         - Otherwise, if `resolved_target` uses an [EIP-7702](./eip-7702.md) delegation indicator, execute according to [EIP-7702](./eip-7702.md)'s delegated-code semantics.
-    - If a frame's execution reverts, its state changes are discarded. Any changes it made to the transaction-scoped approval context (`payer`, `sender_approved`) are discarded with them. Additionally, if this frame has the atomic batch flag set, mark all subsequent frames in the same atomic group as skipped.
+    - If a frame's execution reverts, its state changes and approval context (`payer`, `sender_approved`) are discarded. Additionally, if this frame has the atomic batch flag set, mark all subsequent frames in the same atomic group as skipped.
 1. If frame has mode `VERIFY` the following additional requirements are imposed:
     - Execute the frame as a `STATICCALL`, disallowing state manipulation.
         - Only `APPROVE` can modify the state or transaction context in `VERIFY`.
@@ -425,10 +425,10 @@ Then for each frame:
 1. If a frame is part of an atomic batch and it fails, unroll the associated atomic batch.
     - An **atomic batch** is a maximal contiguous sequence of frames `[i, j]` where `j > i`, frames `i` through `j - 1` have `ATOMIC_BATCH_FLAG` set, and frame `j` does not have `ATOMIC_BATCH_FLAG` set.
     - When a frame in the batch fails, the state must be rolled back to the condition it was immediately before the atomic batch began. All remaining frames in the atomic batch are skipped.
-    - The transaction-scoped approval context (`payer`, `sender_approved`) cannot change inside an atomic batch: approval scope flags are statically disallowed on its frames (see [Constraints](#constraints)), so `APPROVE` cannot succeed there, and unrolling never involves the approval context, the sender nonce increment, or the `max_cost` collection.
     - Logs emitted by frames that executed before the failure are discarded together with their state changes when the batch is unrolled. Changes to any frame receipt's `gas_used.state` during the batch are reverted, as the batch's state modifications are reverted. Executed frame receipts retain their execution status and execution gas used, with empty logs and zero state gas used.
     - Since skipped frames are not executed, the execution and state gas allotted to them are refunded at the end of the transaction.
-    - If the frame does not have an associated atomic batch, further special handling is not needed, simple revert the individual frame.
+    - `APPROVE` is not possible within a batch, so it is not necessary to rollback anything related to `payer` or `sender_approved`.
+    - If the frame does not have an associated atomic batch, further special handling is not needed, simply revert the individual frame.
 
 After executing all frames, verify that `payer` has been set (i.e. `payer != None`). If it is not, the whole transaction is invalid. Then, settle fees as defined in [Gas Accounting](#gas-accounting), returning `payer_refund` to the payer.
 

--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -413,7 +413,7 @@ Then for each frame:
         - A non-zero value transfer to an address other than `tx.sender` emits the transfer log specified by [EIP-7708](./eip-7708.md).
     - If `resolved_target` code hash is empty, i.e. `0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470`, execute the logic described in [default code](#default-code).
         - Otherwise, if `resolved_target` uses an [EIP-7702](./eip-7702.md) delegation indicator, execute according to [EIP-7702](./eip-7702.md)'s delegated-code semantics.
-    - If a frame's execution reverts, its state changes are discarded. Additionally, if this frame has the atomic batch flag set, mark all subsequent frames in the same atomic group as skipped.
+    - If a frame's execution reverts, its state changes are discarded. Any changes it made to the transaction-scoped approval context (`payer`, `sender_approved`) are discarded with them. Additionally, if this frame has the atomic batch flag set, mark all subsequent frames in the same atomic group as skipped.
 1. If frame has mode `VERIFY` the following additional requirements are imposed:
     - Execute the frame as a `STATICCALL`, disallowing state manipulation.
         - Only `APPROVE` can modify the state or transaction context in `VERIFY`.
@@ -421,6 +421,7 @@ Then for each frame:
 1. If a frame is part of an atomic batch and it fails, unroll the associated atomic batch.
     - An **atomic batch** is a maximal contiguous sequence of frames `[i, j]` where `j > i`, frames `i` through `j - 1` have `ATOMIC_BATCH_FLAG` set, and frame `j` does not have `ATOMIC_BATCH_FLAG` set.
     - When a frame in the batch fails, the state must be rolled back to the condition it was immediately before the atomic batch began. All remaining frames in the atomic batch are skipped.
+    - The transaction-scoped approval context (`payer`, `sender_approved`) is rolled back together with the state: an `APPROVE` executed by a frame in the batch is unrolled, including its sender nonce increment and `max_cost` collection. If `payer` is left unset once all frames have been processed, the transaction is invalid, per the payer check below.
     - Logs emitted by frames that executed before the failure are discarded together with their state changes when the batch is unrolled. Changes to any frame receipt's `gas_used.state` during the batch are reverted, as the batch's state modifications are reverted. Executed frame receipts retain their execution status and execution gas used, with empty logs and zero state gas used.
     - Since skipped frames are not executed, the execution and state gas allotted to them are refunded at the end of the transaction.
     - If the frame does not have an associated atomic batch, further special handling is not needed, simple revert the individual frame.

--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -377,7 +377,7 @@ Then for each frame:
         - As with an ordinary `CALL`, if the caller does not have sufficient balance to transfer `frame.value`, the frame reverts.
     - If `resolved_target` code hash is empty, i.e. `0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470`, execute the logic described in [default code](#default-code).
         - Otherwise, if `resolved_target` uses an [EIP-7702](./eip-7702.md) delegation indicator, execute according to [EIP-7702](./eip-7702.md)'s delegated-code semantics.
-    - If a frame's execution reverts, its state changes are discarded. Additionally, if this frame has the atomic batch flag set, mark all subsequent frames in the same atomic group as skipped.
+    - If a frame's execution reverts, its state changes are discarded. Any changes it made to the transaction-scoped approval context (`payer`, `sender_approved`) are discarded with them. Additionally, if this frame has the atomic batch flag set, mark all subsequent frames in the same atomic group as skipped.
 1. If frame has mode `VERIFY` the following additional requirements are imposed:
     - Execute the frame as a `STATICCALL`, disallowing state manipulation.
         - Only `APPROVE` can modify the state or transaction context in `VERIFY`.
@@ -385,6 +385,7 @@ Then for each frame:
 1. If a frame is part of an atomic batch and it fails, unroll the associated atomic batch.
     - An **atomic batch** is a maximal contiguous sequence of frames `[i, j]` where `j > i`, frames `i` through `j - 1` have `ATOMIC_BATCH_FLAG` set, and frame `j` does not have `ATOMIC_BATCH_FLAG` set.
     - When a frame in the batch fails, the state must be rolled back to the condition it was immediately before the atomic batch began. All remaining frames in the atomic batch are skipped.
+    - The transaction-scoped approval context (`payer`, `sender_approved`) is rolled back together with the state: an `APPROVE` executed by a frame in the batch is unrolled, including its sender nonce increment and `max_cost` collection. If `payer` is left unset once all frames have been processed, the transaction is invalid, per the payer check below.
     - Logs emitted by frames that executed before the failure are discarded together with their state changes when the batch is unrolled. Those frame receipts retain their execution status and gas used, with empty logs.
     - Since skipped frames are not executed, the gas value allotted to them is refunded at the end of the transaction.
     - If the frame does not have an associated atomic batch, further special handling is not needed, simple revert the individual frame.

--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -170,10 +170,7 @@ for i, frame in enumerate(tx.frames):
         assert i + 1 < len(tx.frames)            # must not be last frame
         assert tx.frames[i + 1].mode != VERIFY   # batches never contain VERIFY frames
 
-    # Approval scope flags are disallowed on every frame of an atomic batch,
-    # including its terminating frame, so the approval context cannot change
-    # inside a batch. A frame belongs to a batch when it or its predecessor
-    # carries ATOMIC_BATCH_FLAG.
+    # A frame belongs to a batch when it or its predecessor carries ATOMIC_BATCH_FLAG.
     if frame.flags & ATOMIC_BATCH_FLAG or (i > 0 and tx.frames[i - 1].flags & ATOMIC_BATCH_FLAG):
         assert frame.flags & APPROVE_SCOPE_MASK == 0
 ```

--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -96,7 +96,7 @@ The `flags` field configures additional execution constraints. Bit positions are
 
 > The `Valid with` column indicates the mode under which the flag is valid. If a flag is not valid under the current mode, the transaction is invalid.
 
-- *Approval scope*: a bitmask with values defined in the `APPROVE` instruction section [Scope Operand](#scope-operand).
+- *Approval scope*: a bitmask with values defined in the `APPROVE` instruction section [Scope Operand](#scope-operand). Approval scope flags must be zero on every frame of an atomic batch, including its terminating frame (see [Constraints](#constraints)).
 - *Atomic batch*: flag indicates that the frame is in a batch with the following frame or frames. All frames in a batch must succeed, or all of them revert. We define `ATOMIC_BATCH_FLAG` constant with value `0x4`.
 
 ##### Signature object
@@ -169,6 +169,13 @@ for i, frame in enumerate(tx.frames):
         assert frame.mode != VERIFY
         assert i + 1 < len(tx.frames)            # must not be last frame
         assert tx.frames[i + 1].mode != VERIFY   # batches never contain VERIFY frames
+
+    # Approval scope flags are disallowed on every frame of an atomic batch,
+    # including its terminating frame, so the approval context cannot change
+    # inside a batch. A frame belongs to a batch when it or its predecessor
+    # carries ATOMIC_BATCH_FLAG.
+    if frame.flags & ATOMIC_BATCH_FLAG or (i > 0 and tx.frames[i - 1].flags & ATOMIC_BATCH_FLAG):
+        assert frame.flags & APPROVE_SCOPE_MASK == 0
 ```
 
 #### Transaction Signatures
@@ -385,7 +392,7 @@ Then for each frame:
 1. If a frame is part of an atomic batch and it fails, unroll the associated atomic batch.
     - An **atomic batch** is a maximal contiguous sequence of frames `[i, j]` where `j > i`, frames `i` through `j - 1` have `ATOMIC_BATCH_FLAG` set, and frame `j` does not have `ATOMIC_BATCH_FLAG` set.
     - When a frame in the batch fails, the state must be rolled back to the condition it was immediately before the atomic batch began. All remaining frames in the atomic batch are skipped.
-    - The transaction-scoped approval context (`payer`, `sender_approved`) is rolled back together with the state: an `APPROVE` executed by a frame in the batch is unrolled, including its sender nonce increment and `max_cost` collection. If `payer` is left unset once all frames have been processed, the transaction is invalid, per the payer check below.
+    - The transaction-scoped approval context (`payer`, `sender_approved`) cannot change inside an atomic batch: approval scope flags are statically disallowed on its frames (see [Constraints](#constraints)), so `APPROVE` cannot succeed there, and unrolling never involves the approval context, the sender nonce increment, or the `max_cost` collection.
     - Logs emitted by frames that executed before the failure are discarded together with their state changes when the batch is unrolled. Those frame receipts retain their execution status and gas used, with empty logs.
     - Since skipped frames are not executed, the gas value allotted to them is refunded at the end of the transaction.
     - If the frame does not have an associated atomic batch, further special handling is not needed, simple revert the individual frame.
@@ -488,7 +495,7 @@ charged_fee = gas_used * effective_gas_price + blob_gas * blob_base_fee
 payer_refund = max_cost - charged_fee
 ```
 
-After execution, return `payer_refund` to the payer. This is the `resolved_target` that called `APPROVE(APPROVE_PAYMENT)` or `APPROVE(APPROVE_EXECUTION_AND_PAYMENT)`. Return `max_gas - gas_used` to the block gas pool.
+After execution, return `payer_refund` to the final value of `payer`: the `resolved_target` whose `APPROVE(APPROVE_PAYMENT)` or `APPROVE(APPROVE_EXECUTION_AND_PAYMENT)` was not discarded by a frame revert. Return `max_gas - gas_used` to the block gas pool.
 
 ##### Blob handling
 
@@ -992,6 +999,8 @@ Future optimizations based on pre-announcing state elements a transaction will t
 Atomic batching allows multiple frames to be grouped into a single all-or-nothing unit. This is useful when a sequence of calls is only meaningful if all succeed together, such as an approval followed by a swap, or a series of interdependent state changes. Without this feature, a revert in one frame would leave the preceding frames' state changes applied, potentially leaving the account in an undesirable intermediate state.
 
 Using a flag to indicate atomic batches saves us from having to introduce a new mode. Batches are identified purely by consecutive frames with the flag set, terminated by a frame without it. This design enables consecutive atomic batches since the batch boundary is clearly indicated by the frame without the flag.
+
+Approval scope flags are disallowed on the frames of an atomic batch, including its terminating frame. Since `APPROVE` requires its scope to be present in `frame.flags`, this restriction is statically checkable, and it keeps the approval context constant across a batch. Unrolling a failed batch therefore never rolls back the sender nonce increment or the `max_cost` collection, a batch failure cannot retroactively withdraw an execution approval that later `SENDER` frames rely on, and whether the transaction sets `payer` never depends on a batch outcome. Approval can always be placed in a frame preceding the batch instead.
 
 ### Per-frame cost
 

--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -114,7 +114,7 @@ The `flags` field configures additional execution constraints. Bit positions are
 
 > The `Valid with` column indicates the mode under which the flag is valid. If a flag is not valid under the current mode, the transaction is invalid.
 
-- *Approval scope*: a bitmask with values defined in the `APPROVE` instruction section [Scope Operand](#scope-operand). Approval scope flags must be zero on every frame of an atomic batch, including its terminating frame (see [Constraints](#constraints)).
+- *Approval scope*: a bitmask with values defined in the `APPROVE` instruction section [Scope Operand](#scope-operand).
 - *Atomic batch*: flag indicates that the frame is in a batch with the following frame or frames. All frames in a batch must succeed, or all of them revert. We define `ATOMIC_BATCH_FLAG` constant with value `0x4`.
 
 ##### Signature object

--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -613,7 +613,7 @@ charged_fee = gas_used * effective_gas_price + blob_gas * blob_base_fee
 payer_refund = max_cost - charged_fee
 ```
 
-After execution, return `payer_refund` to the final value of `payer`: the `resolved_target` whose `APPROVE(APPROVE_PAYMENT)` or `APPROVE(APPROVE_EXECUTION_AND_PAYMENT)` was not discarded by a frame revert.
+After execution, return `payer_refund` to the payer. This is the `resolved_target` that called `APPROVE(APPROVE_PAYMENT)` or `APPROVE(APPROVE_EXECUTION_AND_PAYMENT)`.
 
 ###### Block-level gas accounting
 

--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -114,7 +114,7 @@ The `flags` field configures additional execution constraints. Bit positions are
 
 > The `Valid with` column indicates the mode under which the flag is valid. If a flag is not valid under the current mode, the transaction is invalid.
 
-- *Approval scope*: a bitmask with values defined in the `APPROVE` instruction section [Scope Operand](#scope-operand).
+- *Approval scope*: a bitmask with values defined in the `APPROVE` instruction section [Scope Operand](#scope-operand). Approval scope flags must be zero on every frame of an atomic batch, including its terminating frame (see [Constraints](#constraints)).
 - *Atomic batch*: flag indicates that the frame is in a batch with the following frame or frames. All frames in a batch must succeed, or all of them revert. We define `ATOMIC_BATCH_FLAG` constant with value `0x4`.
 
 ##### Signature object
@@ -189,6 +189,13 @@ for i, frame in enumerate(tx.frames):
         assert frame.mode != VERIFY
         assert i + 1 < len(tx.frames)            # must not be last frame
         assert tx.frames[i + 1].mode != VERIFY   # batches never contain VERIFY frames
+
+    # Approval scope flags are disallowed on every frame of an atomic batch,
+    # including its terminating frame, so the approval context cannot change
+    # inside a batch. A frame belongs to a batch when it or its predecessor
+    # carries ATOMIC_BATCH_FLAG.
+    if frame.flags & ATOMIC_BATCH_FLAG or (i > 0 and tx.frames[i - 1].flags & ATOMIC_BATCH_FLAG):
+        assert frame.flags & APPROVE_SCOPE_MASK == 0
 
 # Intrinsic and execution gas must fit the EIP-7825 transaction cap.
 assert max(
@@ -421,7 +428,7 @@ Then for each frame:
 1. If a frame is part of an atomic batch and it fails, unroll the associated atomic batch.
     - An **atomic batch** is a maximal contiguous sequence of frames `[i, j]` where `j > i`, frames `i` through `j - 1` have `ATOMIC_BATCH_FLAG` set, and frame `j` does not have `ATOMIC_BATCH_FLAG` set.
     - When a frame in the batch fails, the state must be rolled back to the condition it was immediately before the atomic batch began. All remaining frames in the atomic batch are skipped.
-    - The transaction-scoped approval context (`payer`, `sender_approved`) is rolled back together with the state: an `APPROVE` executed by a frame in the batch is unrolled, including its sender nonce increment and `max_cost` collection. If `payer` is left unset once all frames have been processed, the transaction is invalid, per the payer check below.
+    - The transaction-scoped approval context (`payer`, `sender_approved`) cannot change inside an atomic batch: approval scope flags are statically disallowed on its frames (see [Constraints](#constraints)), so `APPROVE` cannot succeed there, and unrolling never involves the approval context, the sender nonce increment, or the `max_cost` collection.
     - Logs emitted by frames that executed before the failure are discarded together with their state changes when the batch is unrolled. Changes to any frame receipt's `gas_used.state` during the batch are reverted, as the batch's state modifications are reverted. Executed frame receipts retain their execution status and execution gas used, with empty logs and zero state gas used.
     - Since skipped frames are not executed, the execution and state gas allotted to them are refunded at the end of the transaction.
     - If the frame does not have an associated atomic batch, further special handling is not needed, simple revert the individual frame.
@@ -609,7 +616,7 @@ charged_fee = gas_used * effective_gas_price + blob_gas * blob_base_fee
 payer_refund = max_cost - charged_fee
 ```
 
-After execution, return `payer_refund` to the payer. This is the `resolved_target` that called `APPROVE(APPROVE_PAYMENT)` or `APPROVE(APPROVE_EXECUTION_AND_PAYMENT)`.
+After execution, return `payer_refund` to the final value of `payer`: the `resolved_target` whose `APPROVE(APPROVE_PAYMENT)` or `APPROVE(APPROVE_EXECUTION_AND_PAYMENT)` was not discarded by a frame revert.
 
 ###### Block-level gas accounting
 
@@ -1148,6 +1155,8 @@ Future optimizations based on pre-announcing state elements a transaction will t
 Atomic batching allows multiple frames to be grouped into a single all-or-nothing unit. This is useful when a sequence of calls is only meaningful if all succeed together, such as an approval followed by a swap, or a series of interdependent state changes. Without this feature, a revert in one frame would leave the preceding frames' state changes applied, potentially leaving the account in an undesirable intermediate state.
 
 Using a flag to indicate atomic batches saves us from having to introduce a new mode. Batches are identified purely by consecutive frames with the flag set, terminated by a frame without it. This design enables consecutive atomic batches since the batch boundary is clearly indicated by the frame without the flag.
+
+Approval scope flags are disallowed on the frames of an atomic batch, including its terminating frame. Since `APPROVE` requires its scope to be present in `frame.flags`, this restriction is statically checkable, and it keeps the approval context constant across a batch. Unrolling a failed batch therefore never rolls back the sender nonce increment or the `max_cost` collection, a batch failure cannot retroactively withdraw an execution approval that later `SENDER` frames rely on, and whether the transaction sets `payer` never depends on a batch outcome. Approval can always be placed in a frame preceding the batch instead.
 
 ### Per-frame cost
 

--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -190,10 +190,7 @@ for i, frame in enumerate(tx.frames):
         assert i + 1 < len(tx.frames)            # must not be last frame
         assert tx.frames[i + 1].mode != VERIFY   # batches never contain VERIFY frames
 
-    # Approval scope flags are disallowed on every frame of an atomic batch,
-    # including its terminating frame, so the approval context cannot change
-    # inside a batch. A frame belongs to a batch when it or its predecessor
-    # carries ATOMIC_BATCH_FLAG.
+    # A frame belongs to a batch when it or its predecessor carries ATOMIC_BATCH_FLAG.
     if frame.flags & ATOMIC_BATCH_FLAG or (i > 0 and tx.frames[i - 1].flags & ATOMIC_BATCH_FLAG):
         assert frame.flags & APPROVE_SCOPE_MASK == 0
 

--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -70,9 +70,9 @@ Below are high-level definitions of each field in the transaction definition. De
 - `sender` -- the address of the intended sender of the transaction.
 - `frames` -- list of frames to execute.
 - `signatures` -- list of validated signatures available to the transaction.
-- `max_priority_fee_per_gas` -- the EIP-1559 priority fee per gas the transaction will pay.
+- `max_priority_fee_per_gas` -- the [EIP-1559](./eip-1559.md) priority fee per gas the transaction will pay.
 - `max_fee_per_gas` -- the maximum EIP-1559 fee the transaction is willing to pay, per gas.
-- `max_fee_per_blob_gas` -- the maximum EIP-4844 fee per blob gas the transaction is willing to pay. Must be `0` if `blob_versioned_hashes` is empty.
+- `max_fee_per_blob_gas` -- the maximum [EIP-4844](./eip-4844.md) fee per blob gas the transaction is willing to pay. Must be `0` if `blob_versioned_hashes` is empty.
 - `blob_versioned_hashes` -- list of EIP-4844 blob versioned hashes.
 
 ##### Frame object
@@ -465,7 +465,7 @@ tx_unused_gas = sum(
 )
 ```
 
-Storage gas refunds ([EIP-3529](./eip-3529.md)) accumulate across frames into a single transaction-scoped `refund_counter`. Changes made to the counter by a reverted frame, or by frames unrolled as part of a failed atomic batch, are discarded together with that frame's state changes. At the end of the transaction, apply the storage refund and EIP-7623 rules to get the final `gas_used` value:
+Storage gas refunds ([EIP-3529](./eip-3529.md)) accumulate across frames into a single transaction-scoped `refund_counter`. Changes made to the counter by a reverted frame, or by frames unrolled as part of a failed atomic batch, are discarded together with that frame's state changes. At the end of the transaction, apply the storage refund and [EIP-7623](./eip-7623.md) rules to get the final `gas_used` value:
 
 ```python
 gas_used_before_refund = standard_gas_limit - tx_unused_gas
@@ -983,7 +983,7 @@ The EIP-7702 authorization list heavily relies on ECDSA cryptography to determin
 
 ### No access list
 
-The access list was introduced to address a particular backwards compatibility issue that was caused by EIP-2929. The risk-reward of using an access list successfully is high. A single miss, paying to warm a storage slot that does not end up getting used, causes the overall transaction cost to be greater than had it not been included at all.
+The access list was introduced to address a particular backwards compatibility issue that was caused by [EIP-2929](./eip-2929.md). The risk-reward of using an access list successfully is high. A single miss, paying to warm a storage slot that does not end up getting used, causes the overall transaction cost to be greater than had it not been included at all.
 
 Future optimizations based on pre-announcing state elements a transaction will touch will be covered by block level access lists.
 
@@ -1021,7 +1021,7 @@ That extension could also define a `PUBLISHPK` instruction to validate a public 
 
 While we expect EOA users to migrate to smart accounts eventually, we recognize that most Ethereum users today are using EOAs, so we want to improve UX for them where we can.
 
-Thanks to the default code, EOAs today can use frame transactions to reap many benefits of account abstraction, including sending sponsored transactions, paying gas in ERC-20 tokens, batch transactions, and more.
+Thanks to the default code, EOAs today can use frame transactions to reap many benefits of account abstraction, including sending sponsored transactions, paying gas in [ERC-20](./eip-20.md) tokens, batch transactions, and more.
 
 ### Non-canonical paymasters in the mempool
 
@@ -1172,7 +1172,7 @@ Notes: Gas assumes cost < 2^24. Calldata assumes small proxy.
 
 Notes: Sponsor can read info from other fields. ERC-20 transfer call is 68 bytes.
 
-There is some inefficiency in the sponsor case, because the same sponsor address must appear in three places (sponsor validation, send to sponsor inside ERC-20 calldata, post op frame), and the ABI is inefficient (~12 + 24 bytes wasted on zeroes). This is difficult to mitigate in a "clean" way, because one of the duplicates is inside the ERC-20 call, "opaque" to the protocol. However, it is much less inefficient than ERC-4337, because not all of the data takes the hit of the 32-byte-per-field ABI overhead.
+There is some inefficiency in the sponsor case, because the same sponsor address must appear in three places (sponsor validation, send to sponsor inside ERC-20 calldata, post op frame), and the ABI is inefficient (~12 + 24 bytes wasted on zeroes). This is difficult to mitigate in a "clean" way, because one of the duplicates is inside the ERC-20 call, "opaque" to the protocol. However, it is much less inefficient than [ERC-4337](./eip-4337.md), because not all of the data takes the hit of the 32-byte-per-field ABI overhead.
 
 
 ### Blob support


### PR DESCRIPTION
Statically disallows approval scope on any frame of an atomic batch (including its terminating frame), closing the in-batch `APPROVE_PAYMENT` divergence before execution — no nonce/`max_cost` rollback and no `sender_approved`-rollback escalation. Since `APPROVE` requires the scope in `frame.flags`, the check is static. Keeps the frame-revert clause (the inner-call-`APPROVE`-then-enclosing-revert case, independent of batches) and ties the refund to the final `payer`. Supersedes the earlier batch-unroll rollback approach per review.

Also: fixed linting.