### PR TITLE
Update EIP-7773: Add EIP-8254 to DFI EIPs

### DIFF
--- a/EIPS/eip-7773.md
+++ b/EIPS/eip-7773.md
@@ -96,6 +96,7 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Declined
 * [EIP-8068](./eip-8068.md): Neutral effective balance design
 * [EIP-8071](./eip-8071.md): Prevent using consolidations as withdrawals
 * [EIP-8080](./eip-8080.md): Let exits use the consolidation queue
+* [EIP-8254](./eip-8254.md): Cap Deposit Requests Per Block
 
 ### Activation
 


### PR DESCRIPTION
for the sake of completeness:
EIP-8254 was PFI'd on [ACDE236](https://forkcast.org/calls/acde/236/#t=3375) but has been superseded by a new deposit contract for builders, so can be moved to DFI for Glamsterdam
