### PR TITLE
Update EIP-8297: store delegation indicators in the account header

### DIFF
--- a/EIPS/eip-8297.md
+++ b/EIPS/eip-8297.md
@@ -259,14 +259,15 @@ keys mutually prefix-free (see "Tree embedding").
 All state is embedded into the single key/value space. Data accessed
 together is co-located under one shared key prefix ("stem") to reduce
 branch openings. The account header holds an account's basic data, code
-hash, and first 64 storage slots under keys sharing one header stem. Code
-is not in the header; it lives in `CODE_ZONE`, content-addressed (see
-"Code").
+hash or delegation, and first 64 storage slots under keys sharing one header
+stem. Code is not in the header; it lives in `CODE_ZONE`, content-addressed
+(see "Code").
 
 | Parameter               | Value |
 | ----------------------- | ----- |
 | BASIC_DATA_LEAF_KEY     | 0     |
 | CODE_HASH_LEAF_KEY      | 1     |
+| DELEGATION_LEAF_KEY     | 2     |
 | HEADER_STORAGE_OFFSET   | 64    |
 | HEADER_STORAGE_SLOTS    | 64    |
 | STEM_SUBTREE_WIDTH      | 256   |
@@ -347,8 +348,31 @@ account with no code holds the Keccak hash of empty bytecode, unaffected by
 this EIP's choice of merkelization hash (see "Backwards Compatibility").
 
 The header sub-indices in use are `BASIC_DATA_LEAF_KEY`, `CODE_HASH_LEAF_KEY`,
-and `HEADER_STORAGE_OFFSET`..`HEADER_STORAGE_OFFSET + HEADER_STORAGE_SLOTS - 1`.
+`DELEGATION_LEAF_KEY`, and
+`HEADER_STORAGE_OFFSET`..`HEADER_STORAGE_OFFSET + HEADER_STORAGE_SLOTS - 1`.
 No key defined by this EIP resolves to any other sub-index.
+
+### Delegation
+
+An account whose code is an [EIP-7702](./eip-7702.md) delegation indicator, the
+23 bytes `0xef0100 || target`, holds it in its header stem rather than as code:
+
+```python
+def get_tree_key_for_delegation(address: Address32):
+    return get_tree_key_for_header(address, DELEGATION_LEAF_KEY)
+```
+
+The value is the indicator followed by nine zero bytes, and `code_size` is 23.
+Such an account has no `CODE_ZONE` leaves and no `code_hash` leaf, since this
+leaf determines both the code and its hash: a code read takes the first
+`code_size` bytes and `EXTCODEHASH` hashes them. Being delegated and holding
+contract code are exclusive, so every account that exists holds exactly one of
+the `CODE_HASH_LEAF_KEY` and `DELEGATION_LEAF_KEY` leaves. An authorization to
+the zero address clears the delegation, replacing this leaf with a `code_hash`
+leaf holding the hash of empty bytecode and zeroing `code_size`.
+
+An indicator cannot be deployed as contract code ([EIP-3541](./eip-3541.md)), so
+an account holds one only by delegation.
 
 ### Code
 
@@ -473,9 +497,7 @@ Deleting an account ([EIP-161](./eip-161.md) state clearing, or
 [EIP-6780](./eip-6780.md)) MUST remove its header leaves and its storage
 leaves. Its code is content-addressed and may be shared with other accounts,
 so its `CODE_ZONE` leaves MUST be removed only if no account in the
-resulting state has the same `code_hash`, and MUST be kept otherwise. The
-same applies when an account's `code_hash` changes rather than the account
-being deleted.
+resulting state has the same `code_hash`, and MUST be kept otherwise.
 
 The MPT checked `storage_root` to decide whether an address has non-empty
 storage (i.e., the that condition [EIP-7610](./eip-7610.md) checks before contract
@@ -536,15 +558,35 @@ identical bytecode share leaves. Most deployed contracts repeat a small number o
 templates, so this removes a large amount of duplicate code from the state. For
 the same reason, a block witness contains at most one copy of a shared chunk, no
 matter how many contracts touch it. Sharing is also why account deletion checks
-before removing a chunk (see "Zero values and deletion"). That check is cheap in
-practice: the accounts a block deletes are those [EIP-161](./eip-161.md) clears,
-which have no code at all, and those `SELFDESTRUCT` removes in their creation
-transaction, whose code the same transaction wrote.
+before removing a chunk (see "Zero values and deletion").
+
+That check is decidable from the transaction alone. A code leaf is present
+exactly while some account has that code, and [EIP-161](./eip-161.md) clearing
+reaches only accounts with no code, so an account with code is deleted only by
+`SELFDESTRUCT` in the transaction that created it. A leaf that predates the
+transaction is therefore held by an account the transaction cannot delete and
+stays; a leaf the transaction inserted is held only by accounts the transaction
+wrote that code to, and goes when none of them remain. Neither case reads state
+older than the transaction, so no reference count over the state is needed.
+
+Delegation indicators are the one code a live account replaces, which is why
+they are not kept as code (see "Delegation"). Whether another account still
+delegates to the same target is answerable neither from the transaction nor from
+a witness, since a shared leaf is byte-identical whether one account holds it or
+a million; it would need a reference count over the whole state, kept correct
+across restart, snap sync and reorgs. A later change that lets a live account
+replace code in `CODE_ZONE` would have to say how the check stays local.
+
+An indicator takes its own sub-index rather than sharing the code-hash leaf the
+account never needs at the same time, because telling the two apart by their
+leading bytes would let an attacker grind code whose hash begins `0xef0100` and
+have the contract read as a delegation.
 
 Keeping a prefix of the code in the account header instead would avoid that
 check, but it would key that prefix by address, so the templates above would
 each store one copy per deployment: the duplication this zone exists to
-remove.
+remove. That reasoning does not extend to a delegation indicator, which is 23
+bytes and replaces the code-hash leaf the account would hold anyway.
 
 ### SNARK friendliness and post-quantum security
 
@@ -648,11 +690,11 @@ ever created.
 Per-account and per-bucket expiry is a natural operation on the zone
 topology. The storage bucket keyed by `key_hash(address)` roots one
 account's storage in the common case. Record its hash and prune below it.
-The account header's stem expires the account's core data and hot
-storage in one step. Content-addressed code needs
-reference counting or deferral to a state sweep, since its leaves may be
-shared. Resurrection re-attaches a subtree consistent with the recorded
-commitment. The mechanism itself is left to a separate EIP.
+The account header's stem expires the account's core data, hot storage and
+delegation in one step. Content-addressed code needs reference counting or
+deferral to a state sweep, since its leaves may be shared and a sweep has no
+transaction to reason from. Resurrection re-attaches a subtree consistent
+with the recorded commitment. The mechanism itself is left to a separate EIP.
 
 ## Backwards Compatibility
 
@@ -682,6 +724,15 @@ Account header, `BASIC_DATA` of address `A`:
 ```
 key    = 0x00 || H(A) || 0x00
 length = 1 + 32 + 1 = 34 bytes
+```
+
+Delegation of address `A` to target `T`:
+
+```
+sub_idx = DELEGATION_LEAF_KEY = 2 (0x02)
+key     = 0x00 || H(A) || 0x02
+length  = 34 bytes
+value   = 0xef0100 || T || 0x00 * 9
 ```
 
 Storage slot `storage_key = 5` of address `A` (in the header, since 5 < 64):

--- a/EIPS/eip-8297.md
+++ b/EIPS/eip-8297.md
@@ -366,21 +366,22 @@ The value is the indicator followed by nine zero bytes, and `code_size` is 23.
 Such an account has no `CODE_ZONE` leaves and no `code_hash` leaf, since this
 leaf determines both the code and its hash: a code read takes the first
 `code_size` bytes and `EXTCODEHASH` hashes them. Being delegated and holding
-contract code are exclusive, so every account that exists holds exactly one of
-the `CODE_HASH_LEAF_KEY` and `DELEGATION_LEAF_KEY` leaves. An authorization to
-the zero address clears the delegation, replacing this leaf with a `code_hash`
-leaf holding the hash of empty bytecode and zeroing `code_size`.
+contract code are mutually exclusive, so every account that exists holds
+exactly one of the `CODE_HASH_LEAF_KEY` and `DELEGATION_LEAF_KEY` leaves. An
+authorization to the zero address clears the delegation, replacing this leaf
+with a `code_hash` leaf holding the hash of empty bytecode and zeroing
+`code_size`.
 
-An indicator cannot be deployed as contract code ([EIP-3541](./eip-3541.md)), so
-an account holds one only by delegation.
+An indicator cannot be deployed as contract code and none predates the ban
+([EIP-3541](./eip-3541.md)), so an account holds one only by delegation.
 
 ### Code
 
 Every code chunk lives in `CODE_ZONE`, content-addressed by `code_hash` so
 contracts with identical bytecode share leaves. An aligned range of
 `STEM_SUBTREE_WIDTH` chunks sharing one `tree_index` is a code group; its
-chunks share a stem and differ only in the sub-index byte. No code is keyed
-by address.
+chunks share a stem and differ only in the sub-index byte. No code chunk is
+keyed by address.
 
 ```python
 def get_tree_key_for_code_chunk(code_hash: bytes32, chunk_id: int):
@@ -561,21 +562,23 @@ matter how many contracts touch it. Sharing is also why account deletion checks
 before removing a chunk (see "Zero values and deletion").
 
 That check is decidable from the transaction alone. A code leaf is present
-exactly while some account has that code, and [EIP-161](./eip-161.md) clearing
-reaches only accounts with no code, so an account with code is deleted only by
-`SELFDESTRUCT` in the transaction that created it. A leaf that predates the
-transaction is therefore held by an account the transaction cannot delete and
-stays; a leaf the transaction inserted is held only by accounts the transaction
-wrote that code to, and goes when none of them remain. Neither case reads state
-older than the transaction, so no reference count over the state is needed.
+exactly while some account has that contract code, and [EIP-161](./eip-161.md)
+clearing reaches only accounts with no code, so an account with code is deleted
+only by `SELFDESTRUCT` in the transaction that created it. A leaf that predates
+the transaction is therefore held by an account the transaction cannot delete
+and stays; a leaf the transaction inserted is held only by accounts the
+transaction wrote that code to, and goes when none of them remain. Neither case
+reads state older than the transaction, so no reference count over the state is
+needed.
 
-Delegation indicators are the one code a live account replaces, which is why
-they are not kept as code (see "Delegation"). Whether another account still
-delegates to the same target is answerable neither from the transaction nor from
-a witness, since a shared leaf is byte-identical whether one account holds it or
-a million; it would need a reference count over the whole state, kept correct
-across restart, snap sync and reorgs. A later change that lets a live account
-replace code in `CODE_ZONE` would have to say how the check stays local.
+An account can replace a delegation indicator but never contract code, which
+is why indicators are not kept as code (see "Delegation"). Whether another
+account still delegates to the same target is answerable neither from the
+transaction nor from a witness, since a shared leaf is byte-identical whether
+one account holds it or a million; it would need a reference count over the
+whole state, kept correct across restart, snap sync and reorgs. A later change
+that lets a live account replace code in `CODE_ZONE` would have to say how the
+check stays local.
 
 An indicator takes its own sub-index rather than sharing the code-hash leaf the
 account never needs at the same time, because telling the two apart by their
@@ -710,8 +713,9 @@ numbers through `SLOAD` and `SSTORE` and never see tree keys. Key derivation run
 inside the client, below the EVM, exactly as the MPT already hashes slot keys and
 addresses. No contract, Solidity, or Yul code changes.
 
-`EXTCODEHASH` is unaffected since the `code_hash` leaf stores the Keccak hash of the
-account's code regardless of the tree's own merkelization hash.
+`EXTCODEHASH` is unaffected. The account's code hash is a Keccak hash
+regardless of the tree's own merkelization hash, held in the `code_hash` leaf
+or, for a delegated account, computed from the delegation leaf.
 
 ## Test Cases
 


### PR DESCRIPTION
EIP-7702 delegation indicators currently become ordinary content-addressed code chunks in `CODE_ZONE`, so every account delegating to the same target shares one leaf. Because code leaves must be "removed only if no account in the resulting state has the same `code_hash`", clearing or replacing a delegation forces a client to determine whether any other account anywhere still delegates to that target. That is not answerable from block-local data

This moves the indicator into the account's own header stem, where it replaces the `code_hash` leaf it makes redundant. Raised by @matkt from the Besu side. Thanks for pointing it out!

### Why 7702 is the only case that breaks locality

For genuine deployed code the check is decidable from the transaction alone: a code leaf exists only while some account has that code, so a leaf that predates the transaction is held by an account the transaction cannot delete, and a leaf the transaction inserted is held only by accounts the transaction wrote that code to. 
- EIP-6780 confines `SELFDESTRUCT` to the creation transaction.
- EIP-3541 forbids deploying `0xEF`-prefixed code.
- EIP-7702 step 5 requires an authority's code to be "empty or already delegated", so a live account with deployed code can never change its `code_hash`. 
Delegation is the one exception, and it defeats the test precisely because the shared leaf is already present *because of the account doing the clearing*.

### Why the delegation gets its own sub-index and we don't reuse CODE_HASH?

Being delegated and holding contract code are mutually exclusive, so the obvious move is a single polymorphic leaf at sub-index 1 holding either a 32-byte code hash or a 23-byte indicator. 
That was deliberately rejected: **any discriminator based on the value's leading bytes is grindable for about 2^24 offline Keccaks**. 
Hash candidate bytecodes until one's code hash begins `0xef0100`, deploy it, and every client reads that contract as delegated to an attacker-chosen address and executes that target's code in its context. 
Requiring `code_size == 23` could maybe rescue it? But it just seems safer to go this way. With a separate sub-index the leaf set is self-describing: which key is present *is* the answer. And on top, the RLP will collapse one of both fields since will be all 0's.

### Alternatives considered

**Never remove a code leaf when a delegation is cleared**, and **make `CODE_ZONE` append-only**. Both were rejected by EIP-8347's own invariant: **"the PBT obtained by replaying from `ANCHOR_BLOCK` to a block `B` MUST be bit-identical to the PBT obtained by converting the MPT state at `B` directly.** 

Both routes are in use at once." The converter emits code leaves for each account *with* code, reading the current MPT, so it cannot emit a leaf for code nobody holds any more. A node that converted at an earlier anchor and replayed forward would hold that leaf; a node that converted at the next re-anchor point would not. With `REANCHOR_CADENCE` at 50400 blocks and joining nodes selecting the most recent re-anchor, both nodes exist simultaneously by design — different roots at the same block. Append-only also breaks this EIP's own "Collapsing zero and absent" commitments, since a tree rebuilt from a state dump would no longer reproduce the root.

### Changes

- `DELEGATION_LEAF_KEY = 2` and a short "Delegation" section. Sub-index 2 is deliberately below `HEADER_STORAGE_OFFSET`, so EIP-7610's non-empty-storage test is unaffected.
- Normative invariant: every account that exists holds exactly one of the `CODE_HASH_LEAF_KEY` and `DELEGATION_LEAF_KEY` leaves.
- The now-vacuous "The same applies when an account's `code_hash` changes" clause is dropped from "Zero values and deletion" — after this change nothing can trigger it.
- The Rationale's "that check is cheap in practice" justification is replaced. It was wrong twice over: it never covered the `code_hash`-change limb at all, and its `SELFDESTRUCT` argument said the code was "written" by the same transaction when writing already-existing code is a no-op. A transaction that deploys bytecode 10,000 accounts already have and then self-destructs it must *not* remove the shared leaves.
- Test vector for the delegation leaf.

### Open question

EIP-7851 proposes an `0xef0101` indicator variant and EIP-7819 creates indicators from an opcode. This text defines the leaf by reference to EIP-7702's indicator and stores the raw bytes, so a variant is representable without a layout change, but should those EIPs amend this one when they land, or should the wording generalise now?

cc @matkt @awskii — and @Ashraf, since all three of you are prototyping this.

cc @kevaundray too
