### PR TITLE
Update EIP-7773: Add polar bear mascot

### DIFF
--- a/EIPS/eip-7773.md
+++ b/EIPS/eip-7773.md
@@ -98,6 +98,10 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Declined
 * [EIP-8080](./eip-8080.md): Let exits use the consolidation queue
 * [EIP-8254](./eip-8254.md): Cap Deposit Requests Per Block
 
+### Mascot
+
+Polar bear :polar_bear: is the mascot for the Glamsterdam network upgrade, as per the [EIP-8066](./eip-8066.md) process.
+
 ### Activation
 
 | Network Name | Activation Epoch | Activation Timestamp |


### PR DESCRIPTION
Polar bear :polar_bear: is the mascot for the Glamsterdam network upgrade, as per the [EIP-8066](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-8066.md) process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)