### PR TITLE
Update EIP-8141: link the first reference to each cited proposal

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -70,9 +70,9 @@ Below are high-level definitions of each field in the transaction definition. De
 - `sender` -- the address of the intended sender of the transaction.
 - `frames` -- list of frames to execute.
 - `signatures` -- list of validated signatures available to the transaction.
-- `max_priority_fee_per_gas` -- the EIP-1559 priority fee per gas the transaction will pay.
+- `max_priority_fee_per_gas` -- the [EIP-1559](./eip-1559.md) priority fee per gas the transaction will pay.
 - `max_fee_per_gas` -- the maximum EIP-1559 fee the transaction is willing to pay, per gas.
-- `max_fee_per_blob_gas` -- the maximum EIP-4844 fee per blob gas the transaction is willing to pay. Must be `0` if `blob_versioned_hashes` is empty.
+- `max_fee_per_blob_gas` -- the maximum [EIP-4844](./eip-4844.md) fee per blob gas the transaction is willing to pay. Must be `0` if `blob_versioned_hashes` is empty.
 - `blob_versioned_hashes` -- list of EIP-4844 blob versioned hashes.
 
 ##### Frame object
@@ -464,7 +464,7 @@ tx_unused_gas = sum(
 )
 ```
 
-Storage gas refunds ([EIP-3529](./eip-3529.md)) accumulate across frames into a single transaction-scoped `refund_counter`. Changes made to the counter by a reverted frame, or by frames unrolled as part of a failed atomic batch, are discarded together with that frame's state changes. At the end of the transaction, apply the storage refund and EIP-7623 rules to get the final `gas_used` value:
+Storage gas refunds ([EIP-3529](./eip-3529.md)) accumulate across frames into a single transaction-scoped `refund_counter`. Changes made to the counter by a reverted frame, or by frames unrolled as part of a failed atomic batch, are discarded together with that frame's state changes. At the end of the transaction, apply the storage refund and [EIP-7623](./eip-7623.md) rules to get the final `gas_used` value:
 
 ```python
 gas_used_before_refund = standard_gas_limit - tx_unused_gas
@@ -982,7 +982,7 @@ The EIP-7702 authorization list heavily relies on ECDSA cryptography to determin
 
 ### No access list
 
-The access list was introduced to address a particular backwards compatibility issue that was caused by EIP-2929. The risk-reward of using an access list successfully is high. A single miss, paying to warm a storage slot that does not end up getting used, causes the overall transaction cost to be greater than had it not been included at all.
+The access list was introduced to address a particular backwards compatibility issue that was caused by [EIP-2929](./eip-2929.md). The risk-reward of using an access list successfully is high. A single miss, paying to warm a storage slot that does not end up getting used, causes the overall transaction cost to be greater than had it not been included at all.
 
 Future optimizations based on pre-announcing state elements a transaction will touch will be covered by block level access lists.
 
@@ -1020,7 +1020,7 @@ That extension could also define a `PUBLISHPK` instruction to validate a public 
 
 While we expect EOA users to migrate to smart accounts eventually, we recognize that most Ethereum users today are using EOAs, so we want to improve UX for them where we can.
 
-Thanks to the default code, EOAs today can use frame transactions to reap many benefits of account abstraction, including sending sponsored transactions, paying gas in ERC-20 tokens, batch transactions, and more.
+Thanks to the default code, EOAs today can use frame transactions to reap many benefits of account abstraction, including sending sponsored transactions, paying gas in [ERC-20](./eip-20.md) tokens, batch transactions, and more.
 
 ### Non-canonical paymasters in the mempool
 
@@ -1171,7 +1171,7 @@ Notes: Gas assumes cost < 2^24. Calldata assumes small proxy.
 
 Notes: Sponsor can read info from other fields. ERC-20 transfer call is 68 bytes.
 
-There is some inefficiency in the sponsor case, because the same sponsor address must appear in three places (sponsor validation, send to sponsor inside ERC-20 calldata, post op frame), and the ABI is inefficient (~12 + 24 bytes wasted on zeroes). This is difficult to mitigate in a "clean" way, because one of the duplicates is inside the ERC-20 call, "opaque" to the protocol. However, it is much less inefficient than ERC-4337, because not all of the data takes the hit of the 32-byte-per-field ABI overhead.
+There is some inefficiency in the sponsor case, because the same sponsor address must appear in three places (sponsor validation, send to sponsor inside ERC-20 calldata, post op frame), and the ABI is inefficient (~12 + 24 bytes wasted on zeroes). This is difficult to mitigate in a "clean" way, because one of the duplicates is inside the ERC-20 call, "opaque" to the protocol. However, it is much less inefficient than [ERC-4337](./eip-4337.md), because not all of the data takes the hit of the 32-byte-per-field ABI overhead.
 
 
 ### Blob support


### PR DESCRIPTION
`eipw`'s `markdown-link-first` fails on `EIPS/eip-8141.md` as it stands on master: EIP-1559, EIP-4844, EIP-7623, EIP-2929, ERC-20 and ERC-4337 are cited in prose but never linked, so every occurrence is reported. Nineteen errors in total.

This links the first prose occurrence of each and leaves the rest of the text untouched. No normative change.

With this applied, `eipw --config config/eipw.toml EIPS/eip-8141.md` reports no `markdown-link-first` errors.