### PR TITLE
Update EIP-8131: Highlight block-size cap upfront

### DIFF
--- a/EIPS/eip-8131.md
+++ b/EIPS/eip-8131.md
@@ -1,7 +1,7 @@
 ---
 eip: 8131
 title: Unified Transaction Content Floor
-description: Flat 64 gas per content byte at the floor, covering calldata, access-list entries, authorizations, and blob versioned hashes.
+description: Flat 64 gas per content byte at the floor, covering all user-controlled transaction fields and capping worst-case block size.
 author: Toni Wahrstätter (@nerolation)
 discussions-to: https://ethereum-magicians.org/t/eip-9999-add-auth-data-to-eip-7623-floor/12345
 status: Draft
@@ -13,11 +13,11 @@ requires: 2028, 4844, 7623, 7702, 7976, 7981
 
 ## Abstract
 
-Charge every user-controlled byte in a transaction (calldata, access-list entries, [EIP-7702](./eip-7702.md) auths, [EIP-4844](./eip-4844.md) blob hashes) at a flat 64 gas at the floor. One rule replaces [EIP-7623](./eip-7623.md)/[EIP-7976](./eip-7976.md) and [EIP-7981](./eip-7981.md) and closes the auth and blob hash floor gaps. Worst-case user-controlled tx content per block is bounded by `block_gas_limit / 64 ≈ 0.89 MB`. Fewer than 4% of mainnet transactions hit the new floor.
+Charge every user-controlled byte in a transaction (calldata, access-list entries, [EIP-7702](./eip-7702.md) auths, [EIP-4844](./eip-4844.md) blob hashes) at a flat 64 gas at the floor. One rule replaces [EIP-7623](./eip-7623.md)/[EIP-7976](./eip-7976.md) and [EIP-7981](./eip-7981.md) and closes the auth and blob hash floor gaps. Worst-case user-controlled tx content per block is bounded by `block_gas_limit / 64 ≈ 0.89 MB`, a hard cap that keeps worst-case blocks small enough to propagate safely as the gas limit rises. Fewer than 4% of mainnet transactions hit the new floor.
 
 ## Motivation
 
-[EIP-7623](./eip-7623.md) introduced a floor cost on calldata bytes to cap worst-case block size. [EIP-7976](./eip-7976.md) raised that floor to a uniform 64 gas per calldata byte, zero and non-zero alike (by treating every byte as 4 floor tokens at 16 gas each). [EIP-7981](./eip-7981.md) extended the same 64 gas/B rate to access-list bytes via a flat data-cost surcharge of 1,280 gas per address and 2,048 gas per storage key. The principle is consistent across both: every user-controlled content byte priced at 64 gas at the floor.
+Worst-case block size constrains scaling: the gas limit can only be raised as far as the largest block an attacker can build still propagates reliably. [EIP-7623](./eip-7623.md) introduced a floor cost on calldata bytes to cap worst-case block size. [EIP-7976](./eip-7976.md) raised that floor to a uniform 64 gas per calldata byte, zero and non-zero alike (by treating every byte as 4 floor tokens at 16 gas each). [EIP-7981](./eip-7981.md) extended the same 64 gas/B rate to access-list bytes via a flat data-cost surcharge of 1,280 gas per address and 2,048 gas per storage key. The principle is consistent across both: every user-controlled content byte priced at 64 gas at the floor.
 
 [EIP-7702](./eip-7702.md) authorization tuples (up to 108 B each) and [EIP-4844](./eip-4844.md) blob versioned hashes (32 B each) were added without matching floor terms and still pay nothing at the floor.
 


### PR DESCRIPTION
Improve wording