### PR TITLE
Add EIP: ePBS Mandatory Burn of Execution Rewards

### DIFF
--- a/EIPS/eip-8375.md
+++ b/EIPS/eip-8375.md
@@ -17,7 +17,7 @@ This EIP changes execution-layer fee accounting and the [EIP-7732](./eip-7732.md
 
 Every executed payload burns a configured fraction of its transaction priority fees. For an external build, the same fraction of the selected builder's `gross_value` is an auction target. The whole-Gwei part of the priority-fee burn credits up to that target, so the builder supplies only the remaining top-up. External total MEV burn is therefore the greater of the priority-fee burn and auction target, except that a sub-Gwei priority-fee remainder can make it less than one Gwei higher. The [EIP-1559](./eip-1559.md) base-fee burn remains separate.
 
-The builder reserves the full target and trustless proposer payment at bid time. The payment decision remains atomic, while final burn realization waits for the canonical payload outcome.
+The builder reserves the full target and trustless proposer payment at bid time. The payment decision remains atomic. A zero-credit burn resolves immediately when payable; other burn realization waits for the canonical payload outcome.
 
 PTC members also report their highest eligible public bids. Timely gossiped reports produce a robust local floor below which honest validators do not support an external bid. Self-build remains unconditional, has no external target or floor, and pays the priority-fee burn.
 
@@ -314,7 +314,7 @@ class BuilderPendingSettlement(Container):
 
 `BuilderPendingSettlement` is consensus-derived. Consensus derives `burn_target`, copies the signed bid's `priority_fee_burn_credit`, controls `is_payable`, and stores the credit so later burn realization does not depend on an uncommitted Engine API result or local cache.
 
-Replace `builder_pending_payments` with an equivalent `builder_pending_settlements` vector. A payable entry remains in that vector until its burn is resolved.
+Replace `builder_pending_payments` with an equivalent `builder_pending_settlements` vector. A payable entry with nonzero credit remains in that vector until its burn is resolved.
 
 ### Pending builder liability
 
@@ -362,7 +362,7 @@ Builder exit processing MUST treat a pending burn as a pending builder liability
 
 A builder MUST NOT exit while a pending auction target, payable burn reserve, or pending trustless proposer payment exists.
 
-Before the liability decision, the settlement counts `A + V`. After `PAYABLE`, the withdrawal queue counts `V` and the settlement counts only `A`.
+Before the liability decision, the settlement counts `A + V`. While a payable settlement remains, the withdrawal queue counts `V` and the settlement counts only `A`.
 
 Pending consensus liabilities have priority over later builder-balance deductions. A transition MUST leave enough balance to cover every remaining pending liability.
 
@@ -460,7 +460,7 @@ That path MUST NOT charge `A` or `V`.
 
 ### Apply a payable settlement
 
-When a settlement becomes payable, consensus MUST queue `V` exactly once if `V > 0`. It MUST set `is_payable = True` and keep `A` reserved. It resolves the burn only from a canonical FULL or EMPTY payload outcome.
+When a settlement becomes payable, consensus MUST queue `V` exactly once if `V > 0` and set `is_payable = True`. If stored `R == 0`, it MUST deduct `A` and clear the settlement immediately. Otherwise, it MUST keep `A` reserved until a canonical FULL or EMPTY payload outcome resolves the burn.
 
 Conceptually:
 
@@ -475,6 +475,8 @@ def mark_builder_settlement_payable(
     if settlement.withdrawal.amount > 0:
         state.builder_pending_withdrawals.append(settlement.withdrawal)
     settlement.is_payable = True
+    if settlement.priority_fee_burn_credit == 0:
+        realize_payable_builder_burn(state, settlement_index, Gwei(0))
 
 
 def realize_payable_builder_burn(
@@ -502,9 +504,11 @@ def realize_payable_builder_burn(
 
 `mark_builder_settlement_payable` is the only transition that queues `V`. Calling it for an already payable settlement is invalid.
 
-For a canonical FULL payload, `priority_fee_burn_credit` MUST equal `settlement.priority_fee_burn_credit`. FULL requires successful payload-envelope verification, including agreement between the execution result and the signed bid's `priority_fee_burn_credit`. For a canonical EMPTY or no-payload path, the realized credit MUST be zero. Local payload absence alone MUST NOT select the zero value.
+When stored `R == 0`, FULL and EMPTY both imply `D == A`; no payload outcome is needed to realize the burn. This includes the zero-numerator case, where `A == 0` and the settlement clears after queuing `V`.
 
-An execution payload for which the Engine API returns `INVALID` fails payload-envelope verification and MUST NOT create a FULL payload branch. It provides no priority-fee credit. If the canonical EIP-7732 outcome for the commitment is EMPTY and the settlement is `PAYABLE`, consensus uses zero credit and charges the full `A`; if the settlement is `RELEASED`, consensus charges neither `A` nor `V`.
+For a remaining settlement, a canonical FULL payload MUST use `settlement.priority_fee_burn_credit`. FULL requires successful payload-envelope verification, including agreement between the execution result and the signed bid's `priority_fee_burn_credit`. A canonical EMPTY or no-payload path MUST use zero. Local payload absence alone MUST NOT select the zero value.
+
+An execution payload for which the Engine API returns `INVALID` fails payload-envelope verification and MUST NOT create a FULL payload branch. It provides no priority-fee credit. If the canonical EIP-7732 outcome for the commitment is EMPTY and a remaining settlement is `PAYABLE`, consensus uses zero credit and charges the full `A`; if the settlement is `RELEASED`, consensus charges neither `A` nor `V`.
 
 The balance reduction for `D` is the consensus-layer builder burn.
 
@@ -520,10 +524,10 @@ The EIP-7732 epoch transition processes the older half of `builder_pending_settl
 
 1. Apply the existing quorum rule to every nonempty older entry whose liability is not yet decided. A quorum result makes it `PAYABLE`; otherwise it becomes `RELEASED`.
 2. Clear every `RELEASED` entry without charging `A` or `V`.
-3. Resolve every `PAYABLE` entry from the canonical payload outcome. An EMPTY status uses zero priority-fee credit. A FULL status uses the stored `settlement.priority_fee_burn_credit` after successful payload-envelope verification.
+3. Resolve every remaining `PAYABLE` entry from the canonical payload outcome. An EMPTY status uses zero priority-fee credit. A FULL status uses the stored `settlement.priority_fee_burn_credit` after successful payload-envelope verification.
 4. Assert that every entry in the older half is empty. Then shift the newer half into the older half and initialize the newer half with empty `BuilderPendingSettlement` values.
 
-An unresolved entry in the newer half MAY shift once into the older half. An unresolved entry MUST NOT be discarded or survive the next rotation. A node that lacks the canonical payload outcome cannot verify the epoch transition until it obtains that outcome; it MUST NOT substitute zero credit for a FULL outcome. A payload received after a canonical EMPTY outcome does not reopen the settlement.
+An unresolved entry in the newer half MAY shift once into the older half. An unresolved entry MUST NOT be discarded or survive the next rotation. For a payable entry with nonzero stored `R`, a node that lacks the canonical payload outcome cannot verify the epoch transition until it obtains that outcome; it MUST NOT substitute zero credit for a FULL outcome. A payload received after a canonical EMPTY outcome does not reopen the settlement.
 
 ### Attestation weight accounting
 
@@ -848,7 +852,7 @@ A colluding proposer cannot neutralize the rule by omitting reports from a block
 
 The burn remains objective. The signed bid commits `R` in the beacon block, payload-envelope verification checks it against canonical execution, `A` comes from the bid, and `D` is a deterministic function of `A` and `R`. Local PTC observations affect only same-slot external-bid eligibility.
 
-One `BuilderPendingSettlement` stores the target, proposer liability, and bid-derived credit, so historical settlement does not read an uncommitted Engine API result. The `is_payable` flag records the atomic liability decision. A released entry reserves nothing. A payable entry queues `V` once and keeps `A` reserved until the canonical payload outcome selects either stored `R` for FULL or zero credit for EMPTY.
+One `BuilderPendingSettlement` stores the target, proposer liability, and bid-derived credit, so historical settlement does not read an uncommitted Engine API result. The `is_payable` flag records the atomic liability decision. A released entry reserves nothing. A payable entry queues `V` once; zero stored `R` resolves immediately, while nonzero `R` keeps `A` reserved until the canonical payload outcome selects stored credit for FULL or zero credit for EMPTY.
 
 The signed bid commits `R` rather than placing it only in the payload envelope because consensus creates and retains the settlement from the bid. Appending one field to the progressive bid container keeps the prior field order and lets the settlement remain self-contained. Payload-envelope verification accepts neither an overstated nor an understated `R`.
 
@@ -869,7 +873,7 @@ A static builder-payment backcast is insufficient for the combined mechanism. It
 7. For nonzero floor targets, the ratio `U / (get_mev_burn_amount(F) * 10**9)`, the fraction of high-`F` slots that self-build, and the frequency of large-`F`, low-`U` self-builds.
 8. High-`F` self-build concentration by identifiable staking operator and sensitivity to the configured burn rate.
 9. Trusted-payment defaults, builder collateral concentration, proposer-payment tails, and missed proposal or payload rates.
-10. Public-floor coverage by selected external-`G` quantile: the fraction with `F > 0`, the distribution of `F / G`, and the high-`G` share with `F = 0`, split by public or private selected bid.
+10. Public-floor coverage by selected external-`G` quantile: the fraction with `F > 0`, `F / G` for `G > 0`, and the high-`G` share with `F = 0`, split by public or private selected bid.
 
 The rate should reduce security-relevant proposer windfalls while retaining enough protocol-visible bidding for the mechanism to remain effective.
 
@@ -981,15 +985,17 @@ No pending builder settlement is created. A self-build is invalid if `G != 0`, `
 
 ### Settlement lifecycle
 
-Start with `A = 3`, `V = 6`, and `is_payable = False`.
+Start with `A = 3`, `V = 6`, stored `R = 1`, and `is_payable = False`.
 
 For `PAYABLE`, `mark_builder_settlement_payable` queues `V` once, sets `is_payable = True`, and keeps all three units of `A` reserved. A second call is invalid. If a canonical FULL payload has `U = 1 Gwei`, then `R = 1 Gwei`; consensus deducts `D = 2` and clears the settlement. If the canonical outcome is EMPTY, it uses `R = 0`, deducts `D = 3`, and clears the settlement.
 
 For `RELEASED`, consensus queues no withdrawal, deducts no burn, and clears the settlement.
 
+With `A = 0`, `V > 0`, and stored `R = 0`, `PAYABLE` queues `V` and clears immediately. With `A > 0` and stored `R = 0`, it deducts `A` and clears immediately. Only stored `R > 0` waits for FULL or EMPTY.
+
 If envelope validation returns `INVALID`, the envelope cannot create a FULL branch and cannot supply priority-fee credit. A later payable EMPTY outcome therefore deducts `D = A`; a released outcome deducts nothing.
 
-At an epoch rotation, every older-half settlement must become `PAYABLE` or `RELEASED` and then clear. An unresolved newer-half entry can shift into the older half once. A nonempty older entry after processing makes the epoch transition invalid. A node that lacks the canonical payload outcome cannot verify the transition and must not substitute zero credit for a FULL outcome.
+At an epoch rotation, every older-half settlement must become `PAYABLE` or `RELEASED` and then clear. An unresolved newer-half entry can shift into the older half once. A nonempty older entry after processing makes the epoch transition invalid. For stored `R > 0`, a node that lacks the canonical payload outcome cannot verify the transition and must not substitute zero credit for a FULL outcome.
 
 After rotation, every newer-half entry is empty. Processing a new bid against a nonempty destination entry is invalid and must not overwrite that entry.
 
@@ -1030,7 +1036,7 @@ The mechanism is not coalition-proof. An adversary can suppress bids or reports,
 
 An adversary can delay reports or bid evidence, eclipse participants, or deny service to the new gossip and request/response protocols. Missing verified reports lower `F`. Conversely, a malicious builder can deliver one valid high bid to at least `q` honest PTC members without making it timely retrievable by every validator. Their honest reports can then raise `F` only where the evidence arrives before the snapshot. Malicious PTC members can create the same disagreement. Bid-by-root retrieval reduces this selective-evidence risk but cannot eliminate deadline, eclipse, or targeted-delivery effects.
 
-A floor-setting bid is a signed, fully collateralized public offer that the eligible proposer can select, not a fabricated oracle value. An artificially high bid therefore exposes its builder to the corresponding `G` liability, and evidence retrieval makes that offer more widely actionable. This does not eliminate selective-delivery griefing, especially near the deadline.
+A floor-setting bid is a signed, fully collateralized public offer that the eligible proposer can select, not a fabricated oracle value. An artificially high bid therefore requires collateral for `G` and exposes the builder to that consensus liability under the EIP-7732 settlement conditions. Evidence retrieval makes the offer more widely actionable but does not eliminate selective-delivery griefing, especially near the deadline.
 
 The frozen snapshot and expiry rule define recovery. Reports received after the target-slot boundary have no effect. At the next slot, the filter expires and every affected subtree returns to ordinary fork choice. The rule can directly remove at most the target slot's head and attestation opportunity. It does not bound indirect economic loss or later LMD-GHOST effects from the votes cast during that slot.
 
@@ -1058,17 +1064,17 @@ A one-third rate still leaves about two thirds of a fully trustless gross bid as
 
 This EIP does not solve EIP-7732 payload withholding. A payable no-payload outcome burns all of `A` because no `R` exists to credit.
 
-The `PAYABLE` or `RELEASED` decision must remain atomic for `A` and `V`. Burn realization must use the same settlement and canonical payload outcome. An implementation must not:
+The `PAYABLE` or `RELEASED` decision must remain atomic for `A` and `V`. For stored `R > 0`, burn realization must use the same settlement and canonical payload outcome. An implementation must not:
 
 - queue `V` twice;
 - charge both `A` and `D`;
 - use `R` from a noncanonical or execution-invalid payload;
-- substitute `R = 0` merely because a local node lacks a payload;
+- substitute zero for nonzero stored `R` merely because a local node lacks a payload;
 - release `A` after a payable no-payload outcome;
 - discard a payable unresolved settlement; or
 - let a builder exit while a related liability remains.
 
-Tests must cover reorganization, proposer slashing, payload absence, quorum payment, delayed local processing, and settlement rotation.
+Tests must cover reorganization, proposer slashing, payload absence, quorum payment, zero-credit settlement, delayed local processing, and settlement rotation.
 
 ### Supply and cross-layer agreement
 

--- a/EIPS/eip-8375.md
+++ b/EIPS/eip-8375.md
@@ -732,7 +732,9 @@ When `BUILDER_PAYMENT_BURN_NUMERATOR > 0`, an honest proposer MUST NOT select an
 selected_bid.gross_value < H
 ```
 
-During `target_slot` and `target_slot + 1`, an honest validator MUST exclude such a block and its descendants from head selection and MUST NOT attest to them as head. An honest proposer applying the filter in `target_slot + 1` MUST NOT extend the filtered subtree and, absent an eligible sibling, builds on the filtered block's parent to create one. When the numerator is zero, this filter is disabled. The filter expires at the start of `target_slot + 2`; both branches then use ordinary fork choice. Prior votes are not revised.
+During `target_slot` and `target_slot + 1`, an honest validator MUST exclude such a block and its descendants from head selection and MUST NOT attest to them as head. The filter applies before ordinary head selection. An honest proposer in `target_slot + 1` MUST propose on the resulting head, normally the filtered block's parent when no eligible sibling exists. When the numerator is zero, this filter is disabled. The filter expires at the start of `target_slot + 2`; both branches then use ordinary fork choice. Prior votes are not revised.
+
+Reports and external bids are not transferable between parent contexts. If filtering changes the head for `target_slot + 1`, reports and bids referencing the filtered subtree MUST NOT establish `F` or be selected for the new context. An honest proposer that produces a block MUST self-build if no compatible external bid is available.
 
 Bid-floor head filtering is independent of the EIP-7732 payload-timeliness duty. A PTC member observing a below-floor block MUST continue its normal payload observation and attestation duties for that commitment. A floor decision MUST NOT be treated as a payload-unavailability vote.
 
@@ -855,7 +857,7 @@ PTC members report signed, collateral-backed public bids, not estimates of MEV. 
 
 The threshold trades off two failures. A low threshold makes selective delivery easier. A high threshold makes ordinary propagation failure or report suppression more likely to produce a low floor. The haircut reduces false filtering from marginal bid-view differences but creates a bounded under-declaration band. Mainnet values must follow propagation and adversarial analysis, so all three constants remain `TBD`.
 
-Each validator freezes its report set at the start of the target slot. Late reports do not revise the floor. The below-floor filter remains through the next slot so an honest proposer can create a supported sibling, then expires. This bounds its direct effect to two slots of head selection, although ordinary LMD-GHOST consequences can persist.
+Each validator freezes its report set at the start of the target slot. Late reports do not revise the floor. The below-floor filter remains through the next slot so an honest proposer can create a supported sibling, then expires. Changing the parent can make prepared external bids incompatible and force self-build fallback. This bounds the filter's direct effect to two slots of head selection, although ordinary LMD-GHOST consequences can persist.
 
 A colluding proposer cannot neutralize the rule by omitting reports from a block because timely gossip, not inclusion, gives a report effect. Signed reports make conflicting messages attributable. However, the main selective delivery attack needs only one valid report per PTC member. An equivocation penalty alone would therefore not prevent it.
 
@@ -883,7 +885,7 @@ A static builder-payment backcast is insufficient for the combined mechanism. It
 6. Self-build probability by local-`F` quantile and the distribution of `F` for self-built slots.
 7. For nonzero floor targets, the ratio `U / (get_mev_burn_amount(F) * 10**9)`, the fraction of high-`F` slots that self-build, and the frequency of large-`F`, low-`U` self-builds.
 8. High-`F` self-build concentration by identifiable staking operator and sensitivity to the configured burn rate.
-9. Trusted-payment defaults, builder collateral concentration, proposer-payment tails, and missed proposal or payload rates.
+9. Trusted-payment defaults, builder collateral concentration, proposer-payment tails, and missed proposal or payload rates, including external-bid availability and self-build rates immediately after floor-triggered reorgs.
 10. Across instrumented nodes, public-floor coverage by selected external-`G` quantile: the fraction with `F > 0`, `F / G` and `H / G` for `G > 0`, and the high-`G` share with `F = 0`, split by public or private selected bid.
 
 The rate should reduce security-relevant proposer windfalls while retaining enough protocol-visible bidding for the mechanism to remain effective.
@@ -1029,6 +1031,8 @@ A positive report received without its signed bid does not initially contribute.
 
 Given `F = 9 ETH` and a hypothetical 500 basis-point haircut, `H = 8.55 ETH`. An external block with `G = 8.5 ETH` and its descendants lose local head eligibility through `target_slot + 1`. An honest proposer applying the filter in that next slot builds a sibling on the lower block's parent. An external block with `G = 8.55 ETH` and any self-build remain eligible under this EIP.
 
+If every observed external bid for `target_slot + 1` references the filtered subtree, none is eligible for the reorg context and compatible reports establish `F = H = 0`. An honest proposer that produces a block self-builds unless it receives a compatible external bid.
+
 A report received after the target-slot snapshot does not change `F`. At `target_slot + 2`, this EIP's filter expires. Both branches are again considered under ordinary fork choice. The lower block's state transition was never invalid.
 
 ## Reference Implementation
@@ -1049,11 +1053,13 @@ The mechanism is not coalition-proof. An adversary can suppress bids or reports,
 
 An adversary can delay reports or bid evidence, eclipse participants, or deny service to the new gossip and request/response protocols. Missing verified reports lower `F`. Conversely, a malicious builder can deliver one valid high bid to at least `q` honest PTC members without making it timely retrievable by every validator. Their honest reports can then raise `F` only where the evidence arrives before the snapshot. Malicious PTC members can create the same disagreement. Bid-by-root retrieval reduces this selective-evidence risk but cannot eliminate deadline, eclipse, or targeted-delivery effects.
 
+Because the filter persists into the next slot, disagreement in `H` can cause honest proposers to create competing branches. The deadline, threshold, and haircut therefore jointly determine avoidance resistance and short-reorg risk.
+
 A floor-setting bid is a signed, fully collateralized public offer that the eligible proposer can select, not a fabricated oracle value. An artificially high bid therefore requires collateral for `G` and exposes the builder to that consensus liability under the EIP-7732 settlement conditions. Evidence retrieval makes the offer more widely actionable but does not eliminate selective-delivery griefing, especially near the deadline.
 
-The frozen snapshot and expiry rule define recovery. Reports received after the target-slot boundary have no effect. During `target_slot + 1`, filtered proposers build on the below-floor block's parent and filtered validators support that competing branch. At `target_slot + 2`, both branches return to ordinary fork choice. The rule directly affects at most two slots; it does not bound indirect economic loss or later LMD-GHOST effects.
+The frozen snapshot and expiry rule define recovery. Reports received after the target-slot boundary have no effect. During `target_slot + 1`, validators run head selection without the filtered subtree and support the resulting branch; in the simple case this creates a sibling on the below-floor block's parent. At `target_slot + 2`, both branches return to ordinary fork choice. The rule directly affects at most two slots; it does not bound indirect economic loss or later LMD-GHOST effects.
 
-Enforcement is probabilistic and does not guarantee orphaning. If `B` is the avoided burn, `L` is the coalition value lost on orphaning, and `p` is the orphaning probability, the simplified deterrence condition is `p * L > B`. This becomes approximately `p > t` only when `B` is approximately `t * L` and orphaning loses all `L`. Control or loss of the next proposal can prevent creation of the competing branch, so effectiveness depends on colluding stake, report propagation, and ordinary fork choice.
+Enforcement is probabilistic and does not guarantee orphaning. If `B` is the avoided burn, `L` is the coalition economic surplus lost on orphaning, and `p` is the orphaning probability, the simplified deterrence condition is `p * L > B`. This becomes approximately `p > t` only when `B` is approximately `t * L` and orphaning loses all `L`. Control or loss of the next proposal can prevent creation of the competing branch, so effectiveness depends on colluding stake, report propagation, and ordinary fork choice.
 
 Signed conflicting reports make equivocation attributable. However, the selective-delivery attack can use one valid message from each participating member and requires no equivocation. An equivocation penalty would not prevent the main attack, so this EIP does not add a new slashing system. Clients should retain conflicting messages and expose report-receipt metrics.
 

--- a/EIPS/eip-8375.md
+++ b/EIPS/eip-8375.md
@@ -13,101 +13,51 @@ requires: 7732
 
 ## Abstract
 
-This EIP changes the execution-layer fee accounting and the enshrined Proposer-Builder Separation (ePBS) payment mechanism from [EIP-7732](./eip-7732.md).
+This EIP changes execution-layer fee accounting and the [EIP-7732](./eip-7732.md) enshrined Proposer-Builder Separation (ePBS) payment mechanism.
 
-Every executed payload burns a configured fraction of its transaction priority fees. For a selected external-builder bid, the same configured fraction of the builder's declared `gross_value` is an auction burn target. Priority-fee burn from the payload counts toward that target, and the builder supplies only the remaining top-up. Therefore, the total MEV burn for an executed external-builder payload is the greater of the priority-fee burn and the auction burn target. The [EIP-1559](./eip-1559.md) base-fee burn remains separate.
+Every executed payload burns a configured fraction of its transaction priority fees. For an external build, the same fraction of the selected builder's `gross_value` is an auction target. The priority-fee burn credits that target, so the builder supplies only the remaining top-up. External total MEV burn is the greater of the two amounts. The [EIP-1559](./eip-1559.md) base-fee burn remains separate.
 
-The builder must fully collateralize the auction burn target and the trustless proposer payment at bid time. Consensus does not guarantee an optional trusted execution-layer payment. The EIP-7732 liability decision remains atomic, but final realization of the builder burn is deferred until the priority-fee burn is known.
+The builder reserves the full target and trustless proposer payment at bid time. The payment decision remains atomic, while final burn realization waits for the execution result.
 
-This EIP also extends the EIP-7732 Payload Timeliness Committee (PTC). Each member reports the highest eligible public bid it observed before a deadline. Honest validators derive a robust local external-bid floor from directly gossiped reports and do not support an external bid below that floor.
-
-> Every payload burns the configured fraction of priority fees. External-builder payloads additionally target the configured fraction of their declared gross bid, and competing public bids establish a minimum acceptable external `gross_value`.
-
-Self-building remains unconditionally available and is exempt from the external auction target and bid floor. Its executed payload still pays the universal priority-fee burn.
+PTC members also report their highest eligible public bids. Timely gossiped reports produce a robust local floor below which honest validators do not support an external bid. Self-build remains unconditional, has no external target or floor, and pays the priority-fee burn.
 
 ## Motivation
 
-[EIP-7732](./eip-7732.md) makes a builder payment an explicit protocol object. This gives the protocol a direct value that it can split.
+[EIP-7732](./eip-7732.md) makes a builder payment a protocol object. This lets the protocol burn a deterministic share without a second auction or a subjective MEV oracle.
 
-The protocol can use this value to reduce proposer windfalls from execution auctions. The protocol can do this without a second auction. The protocol can also do this without a subjective price oracle.
+### Variable validator revenue
 
-### MEV as variable validator revenue
+Execution payloads can contain arbitrage, liquidations, order-flow advantages, and other maximal extractable value (MEV). Competitive builders pay some of this value to proposers. These payments are highly skewed: rare slots can produce large rewards.
 
-An execution payload can contain value that does not come from normal blockspace pricing. Examples include arbitrage, liquidations, order-flow advantages, and other forms of maximal extractable value (MEV).
+Large variable rewards can increase incentives for reorganization, denial of service, key theft, reward pooling, and specialized infrastructure. Large operators also spread fixed costs and income variance across more validators. This EIP targets that reward component; it does not try to measure physical nodes or independent operator control.
 
-In a competitive builder market, a builder can pay part of this value to the proposer. The builder makes this payment to increase the chance that the proposer selects its payload.
+The objective is to reduce the share and variance of validator revenue from random execution-auction value without materially increasing the advantage of large or vertically integrated operators.
 
-Builder payments can have a highly skewed distribution. Most proposal slots have modest value. A small number of slots can have very large value.
+### Protocol-visible value
 
-Large and rare payments can create these effects:
+[EIP-1559](./eip-1559.md) burns the base fee, not priority fees or builder payments. This EIP adds one rate for two visible value streams:
 
-- A high-value slot can increase the reward from a reorganization or a targeted denial-of-service attack.
-- A high-value slot can increase the reward from key compromise or operator theft.
-- Variable rewards can increase demand for reward smoothing and pooling.
-- Large operators can spread specialized infrastructure costs across many validators.
-- Large operators receive more proposal opportunities because they control more stake.
-- More proposal opportunities reduce the relative variance of operator income.
+- Every executed payload burns a fraction of priority fees.
+- An external bid targets the same fraction of `gross_value`.
+- Priority-fee burn credits the external target instead of being charged twice.
+- Self-build is not a zero-burn path.
 
-A large operator does not receive more expected MEV per unit of stake only because it has more validators. The main scale advantage comes from lower relative variance, fixed-cost sharing, and better infrastructure economics.
+The protocol cannot measure value retained internally or paid outside both streams. PTC reports therefore do not estimate MEV. They only constrain external `gross_value` using real public offers.
 
-Stake in one operational failure domain still adds slashable economic weight. However, more validators in the same failure domain do not add independent nodes, operators, network paths, or failure domains in the same proportion.
-
-Ethereum cannot directly measure independent physical nodes or independent operational control. Therefore, this EIP does not try to reward these properties directly.
-
-This EIP has a narrower decentralization objective. It reduces one reward component that can make large-scale validator operation more attractive.
-
-The objective is measurable:
-
-> Reduce the share and variance of validator revenue that comes from random execution-auction value. Do not materially increase the advantage of large or vertically integrated staking operators.
-
-### Redirect execution-auction value
-
-[EIP-1559](./eip-1559.md) burns the execution base fee. It does not give the base fee to the block producer.
-
-Builder payments are not base fees. However, builder payments are another protocol-visible value stream that is connected to execution rights.
-
-A universal priority-fee burn and an external auction burn target have these properties:
-
-- Every executed payload has a protocol-visible minimum MEV burn.
-- The external auction target increases when the selected builder bid increases.
-- Priority-fee burn counts toward the external target instead of being charged twice.
-- A self-built payload is not a zero-burn path.
-- The protocol does not need a new recipient set.
-- The protocol does not need a redistribution mechanism.
-- The burn reduces ETH supply.
-
-This EIP does not burn all MEV. It burns a fixed fraction of priority fees and, for an external build, targets the same fraction of value that appears in the selected ePBS bid.
-
-The protocol cannot directly measure value that a self-builder keeps internally. The protocol also cannot directly burn a payment that a builder and proposer keep outside the signed bid and outside priority fees.
-
-### Why use a proportional burn
-
-A proposer has no direct reason to select a larger voluntary burn. If a builder can use the same expenditure as a proposer payment, the proposer prefers the payment.
-
-A separate burn field creates an incentive conflict. It also creates a second auction dimension.
-
-This EIP removes that choice. The protocol fixes one burn fraction for priority fees and external auction targets.
-
-For public bids, the burn fraction is constant and `execution_payment == 0`. Therefore, a larger `gross_value` also gives a larger trustless proposer payment.
-
-A proposer can maximize its own public-bid revenue without choosing the burn amount.
-
-The burn remains a deterministic result of canonical execution, the selected signed bid, and the fork constant. Local PTC observations do not calculate the burn. They constrain the minimum external `gross_value` that an honest validator supports.
+A voluntary burn field would create a second auction dimension because a proposer prefers payment over an otherwise equal burn. A fixed fraction removes that choice. For fully collateralized public bids, a larger `gross_value` still gives a larger proposer payment.
 
 ### Design goals
 
-This EIP has these goals:
+This EIP aims to:
 
-1. Every executed payload pays an objective priority-fee burn.
-2. The external auction target is objective and derivable from the selected signed bid.
-3. Local PTC observations constrain external-bid eligibility but do not calculate the amount burned.
-4. The proposer does not select the burn fraction.
-5. The public ePBS bid path remains fully collateralized.
-6. A public ePBS bid does not expose the proposer to trusted-payment risk.
-7. A private or relay bid can use a declared trusted payment.
-8. The auction target and trustless proposer payment use one liability decision.
-9. Proposer omission cannot neutralize locally received bid-floor reports.
-10. Self-building remains unconditionally available and pays the priority-fee burn.
+1. Burn an objective share of priority fees for every executed payload.
+2. Derive an external target from the selected signed bid.
+3. Credit priority-fee burn toward that target.
+4. Keep public bids fully collateralized and allow declared trusted payments on private paths.
+5. Keep the target and trustless proposer payment in one liability decision.
+6. Use local PTC observations only for external-bid eligibility.
+7. Prevent proposer omission from neutralizing timely reports.
+8. Keep self-build unconditional.
 
 ## Specification
 
@@ -122,7 +72,7 @@ Types, constants, and helper functions not defined in this document have the mea
 For an executed payload and, where applicable, one selected external-builder bid, use these terms:
 
 - `G`: `gross_value`. This is the signed external-bid amount that determines the auction target and declared proposer compensation.
-- `T`: aggregate transaction priority fees in the executed payload.
+- `T`: aggregate transaction priority fees in the executed payload, in `Gwei`.
 - `U`: `priority_fee_burn`. The execution layer destroys this amount for every executed payload.
 - `A`: `burn_target`. This is the external auction burn target reserved from the builder.
 - `D`: `builder_burn`. Consensus destroys this top-up from builder balance.
@@ -181,14 +131,14 @@ Add:
 ```python
 BID_FLOOR_DUE_BPS = uint64(TBD)
 BID_FLOOR_THRESHOLD = uint64(TBD)
-DOMAIN_BID_FLOOR = DomainType(TBD)
+DOMAIN_BID_FLOOR = DomainType('0x0F000000')
 ```
 
 `BID_FLOOR_DUE_BPS` is measured in basis points into the slot immediately preceding the report's `target_slot`. It ends the public-bid observation window.
 
 `BID_FLOOR_DUE_BPS` MUST be less than `10_000`, leaving time for reports to propagate before `target_slot`.
 
-`BID_FLOOR_THRESHOLD` is a number of distinct target-slot PTC members. Its mainnet value is intentionally TBD pending propagation and adversarial analysis. It MUST be greater than zero and MUST NOT exceed `PTC_SIZE`.
+`BID_FLOOR_THRESHOLD` is a number of distinct target-slot PTC members. Its mainnet value is TBD pending propagation and adversarial analysis. It MUST be greater than zero and MUST NOT exceed `PTC_SIZE`.
 
 A devnet or testnet MAY use a different fraction.
 
@@ -202,39 +152,33 @@ The active values MUST be part of chain configuration and MUST NOT change withou
 
 An implementation MUST use integer floor division to calculate `U` and `A`.
 
-An implementation MUST calculate multiplication for `T` and `G` without intermediate integer overflow. A fixed-width implementation MUST use a sufficiently wide intermediate type or an equivalent overflow-safe algorithm.
+An implementation MUST calculate products for `T` and `G` without intermediate overflow. It MUST use a wide intermediate type or an equivalent overflow-safe algorithm.
 
 Any division remainder from calculating `A` stays in `P`. Therefore, `A + P == G` always holds.
 
 ### Execution layer
 
-This EIP requires an execution-layer consensus change.
-
-For every transaction `i`, define:
+All burn accounting uses `Gwei`, matching builder balances. For transaction `i`, define:
 
 ```text
-priority_fee_per_gas_i = effective_gas_price_i - base_fee_per_gas
-priority_fee_value_i = priority_fee_per_gas_i * gas_used_i
-```
-
-`gas_used_i` is the gas actually charged after execution and refund accounting. Failed transactions contribute priority fees in the same way as successful transactions.
-
-The execution layer MUST calculate:
-
-```text
-T = sum(priority_fee_value_i)
+tip_wei_i = (effective_gas_price_i - base_fee_per_gas) * gas_used_i
+tip_i = floor(tip_wei_i / 10**9)
+T = sum(tip_i)
 U = floor(T * BUILDER_PAYMENT_BURN_NUMERATOR / BUILDER_PAYMENT_BURN_DENOMINATOR)
 ```
 
-The execution layer MUST destroy `U` rather than crediting that portion of priority fees to the payload fee recipient. This is not the EIP-1559 base-fee burn.
+`gas_used_i` includes failed transactions and reflects refund accounting. The sub-Gwei remainder of each `tip_wei_i` is credited to the fee recipient.
 
-Successful payload execution MUST make both `priority_fee_value` and `priority_fee_burn` available to the consensus layer. The consensus layer MUST verify that `priority_fee_burn` is the configured fraction of `priority_fee_value`.
+The execution layer MUST withhold `U * 10**9` wei from priority-fee credits. It initializes `T_running = 0` and `U_previous = 0`. After each transaction, it adds `tip_i` to `T_running` and calculates `U_current = get_mev_burn_amount(T_running)`. It burns `(U_current - U_previous) * 10**9` wei from that transaction's tip, credits the remainder, and sets `U_previous = U_current`. The increment cannot exceed `tip_i` because the fraction is at most one.
 
-The exact common accounting unit, rounding rule, and Engine API response that carry these values are TBD. They MUST be specified so that `U` and the Gwei-denominated `A` can be compared deterministically without double counting or intermediate overflow.
+The next fork version of `engine_newPayload` MUST extend a successful payload-status response with these `QUANTITY` fields:
 
-For an external build, the protocol applies only `D` directly to the EIP-7732 consensus-layer builder balance.
+```text
+priorityFeeValue: T
+priorityFeeBurn: U
+```
 
-`execution_payment` keeps its EIP-7732 trusted-payment meaning.
+Consensus MUST verify `priorityFeeBurn == get_mev_burn_amount(priorityFeeValue)`. For an external build, it deducts only `D` from builder balance. `execution_payment` keeps its EIP-7732 meaning.
 
 ### Modified `ExecutionPayloadBid`
 
@@ -262,9 +206,9 @@ The builder MUST NOT supply `trustless_payment` as an independent field.
 
 The builder MUST NOT supply `burn_target` or `builder_burn` as an independent field.
 
-Consensus MUST derive the auction target and trustless payment from `gross_value` and `execution_payment`. It MUST derive the builder top-up from the auction target and the executed payload's priority-fee burn.
+Consensus MUST derive the auction target and trustless payment from `gross_value` and `execution_payment`. It MUST derive the builder top-up from that target and the executed payload's priority-fee burn.
 
-No additional field is required in `ExecutionPayloadBid` for the PTC floor. The signed bid already commits to the builder, slot, parent context, block commitment, proposer preferences, and `gross_value` needed as floor evidence.
+No additional `ExecutionPayloadBid` field is required for the PTC floor. The signed bid already contains the builder, slot, parent context, block commitment, proposer preferences, and `gross_value`.
 
 ### Builder bid construction
 
@@ -310,7 +254,7 @@ def get_bid_consensus_liability(bid: ExecutionPayloadBid) -> Gwei:
     return Gwei(burn_target + trustless_payment)
 
 
-def get_builder_burn(
+def get_builder_burn_top_up(
     burn_target: Gwei,
     priority_fee_burn: Gwei,
 ) -> Gwei:
@@ -336,23 +280,18 @@ class BuilderPendingSettlement(Container):
     proposer_index: ValidatorIndex
     gross_value: Gwei
     burn_target: Gwei
+    is_payable: boolean
 ```
 
-`withdrawal.amount` MUST equal `V`.
-
-`burn_target` MUST equal `A`.
+`withdrawal.amount` MUST equal `V`, `burn_target` MUST equal `A`, and `is_payable` MUST initially be `False`.
 
 `proposer_index` identifies the proposer for the existing EIP-7732 proposer-slashing release path. It is not a payment recipient.
 
 `withdrawal.fee_recipient` keeps the existing EIP-7732 fee-recipient semantics. It is the proposer-designated recipient used by the existing bid flow.
 
-`gross_value` and `burn_target` are stored values in the settlement object. They make the obligation easy to audit from consensus state.
+The builder supplies neither `burn_target` nor `is_payable`. Consensus derives the target from `gross_value` and controls the lifecycle flag.
 
-The builder does not supply `burn_target` as a separate signed input. Consensus derives it from the signed `gross_value`.
-
-Replace the EIP-7732 `builder_pending_payments` state vector with an equivalent `builder_pending_settlements` vector.
-
-The settlement mechanism MUST be able to retain a `PAYABLE` burn reserve until the canonical payload accounting result, or the canonical absence of a payload, is known. The exact consensus-state encoding of this payable-but-burn-unresolved state is TBD.
+Replace `builder_pending_payments` with an equivalent `builder_pending_settlements` vector. A payable entry remains in that vector until its burn is resolved.
 
 ### Pending builder liability
 
@@ -368,7 +307,8 @@ def get_pending_builder_liability(state: BeaconState, builder_index: BuilderInde
         if withdrawal.builder_index == builder_index
     )
     pending_settlements = sum(
-        settlement.withdrawal.amount + settlement.burn_target
+        settlement.burn_target
+        + (0 if settlement.is_payable else settlement.withdrawal.amount)
         for settlement in state.builder_pending_settlements
         if settlement.withdrawal.builder_index == builder_index
     )
@@ -399,9 +339,9 @@ Builder exit processing MUST treat a pending burn as a pending builder liability
 
 A builder MUST NOT exit while a pending auction target, payable burn reserve, or pending trustless proposer payment exists.
 
-Before the liability decision, the settlement counts `A + V`. After a `PAYABLE` decision but before burn realization, `V` is counted by the existing pending-withdrawal path and the settlement continues to reserve `A`. Implementations MUST count each amount exactly once.
+Before the liability decision, the settlement counts `A + V`. After `PAYABLE`, the withdrawal queue counts `V` and the settlement counts only `A`.
 
-Pending consensus liabilities have priority over later deductions from builder balance. A state transition that decreases a builder balance MUST leave enough balance to cover all pending builder liabilities that remain after that transition.
+Pending consensus liabilities have priority over later builder-balance deductions. A transition MUST leave enough balance to cover every remaining pending liability.
 
 For each builder after such a transition, this invariant MUST hold:
 
@@ -458,6 +398,7 @@ if consensus_liability > 0:
         proposer_index=get_beacon_proposer_index(state),
         gross_value=bid.gross_value,
         burn_target=burn_target,
+        is_payable=False,
     )
     state.builder_pending_settlements[
         SLOTS_PER_EPOCH + bid.slot % SLOTS_PER_EPOCH
@@ -487,63 +428,43 @@ That path MUST NOT charge `A` or `V`.
 
 ### Apply a payable settlement
 
-When a settlement becomes payable, consensus MUST do these steps:
-
-1. If `withdrawal.amount > 0`, append the `BuilderPendingWithdrawal` for `V` exactly once.
-2. Keep the full `burn_target` reserved.
-3. Do not destroy the reserve until either a valid canonical execution result is available or the canonical path resolves that no payload is executed.
+When a settlement becomes payable, consensus MUST queue `V` exactly once if `V > 0`. It MUST set `is_payable = True` and keep `A` reserved. It resolves the burn only from a canonical execution result or canonical no-payload outcome.
 
 Conceptually:
 
 ```python
 def realize_payable_builder_burn(
     state: BeaconState,
-    settlement: BuilderPendingSettlement,
-    priority_fee_burn: Optional[Gwei],
+    settlement_index: uint64,
+    priority_fee_burn: Gwei,
 ) -> None:
+    settlement = state.builder_pending_settlements[settlement_index]
+    assert settlement.is_payable
     builder_index = settlement.withdrawal.builder_index
-    if priority_fee_burn is None:
-        # Canonical no-payload or withheld-payload path.
-        priority_fee_burn = Gwei(0)
-
-    builder_burn = get_builder_burn(
+    builder_burn = get_builder_burn_top_up(
         settlement.burn_target,
         priority_fee_burn,
     )
     assert state.builders[builder_index].balance >= builder_burn
     state.builders[builder_index].balance -= builder_burn
-    release_unused_burn_reserve(
-        state,
-        settlement,
-        Gwei(settlement.burn_target - builder_burn),
-    )
-    clear_builder_burn_reserve(state, settlement)
+    state.builder_pending_settlements[
+        settlement_index
+    ] = BuilderPendingSettlement()
 ```
 
-For a valid executed payload, `priority_fee_burn` MUST equal `U`, so the balance reduction is `D = max(0, A - U)`.
-
-For a canonical no-payload or withheld-payload path, `U = 0` and the balance reduction is the full `A`.
+For a valid executed payload, `priority_fee_burn` MUST equal `U`. For a canonical no-payload path, it MUST be zero. Local payload absence alone MUST NOT select the zero value.
 
 The balance reduction for `D` is the consensus-layer builder burn.
+
+Clearing the settlement releases the unused `A - D` reserve.
 
 The protocol MUST NOT represent `D` as an execution-layer transfer to a burn address.
 
 The existing withdrawal path continues to process `V`.
 
-### Settlements outside the pending window
+### Settlement eviction
 
-EIP-7732 has a direct-payment path for a parent payload whose pending-payment entry is no longer in the bounded window.
-
-Any equivalent path under this EIP MUST preserve the single liability decision and MUST resolve the burn reserve exactly once.
-
-The implementation MUST derive `A` and `V` from the cached signed bid and obtain `U` from the canonical payload execution result.
-
-The implementation MUST then do these actions in one settlement operation:
-
-1. Deduct `max(0, A - U)` from the builder's consensus-layer balance.
-2. Queue `V` as a builder withdrawal if `V > 0`.
-
-A late-payload path MUST NOT queue `V` twice, charge both `A` and `D`, or count `U` from a noncanonical payload.
+A payable entry MUST resolve before its vector position is reused. An empty canonical payload-availability status sets `U = 0`. A full status requires the canonical execution result and its `U`. A node missing that payload cannot yet verify the transition. A payload received after an empty outcome does not reopen the settlement.
 
 ### Attestation weight accounting
 
@@ -557,7 +478,10 @@ An implementation MUST use a check equivalent to this check:
 
 ```python
 def has_pending_consensus_liability(settlement: BuilderPendingSettlement) -> bool:
-    return settlement.withdrawal.amount + settlement.burn_target > 0
+    return (
+        not settlement.is_payable
+        and settlement.withdrawal.amount + settlement.burn_target > 0
+    )
 ```
 
 After the liability decision becomes `PAYABLE`, further attestation weight does not change the result. The full `A` remains reserved until burn realization.
@@ -584,7 +508,7 @@ A public bid is fully collateralized for its complete gross commitment.
 
 Public gossip MUST compare `gross_value` instead of the former `value` field.
 
-For public bids, the auction-target fraction is constant and `execution_payment == 0`. Therefore, ordering by `gross_value` is also ordering by the declared trustless proposer payment.
+For public bids, the target fraction is constant and `execution_payment == 0`. Ordering by `gross_value` therefore also orders the declared trustless proposer payment.
 
 The existing EIP-7732 one-bid-per-builder-per-slot-and-parent gossip policy does not change.
 
@@ -629,7 +553,7 @@ class SignedBidFloorMessage(Container):
     signature: BLSSignature
 ```
 
-For a positive report, `bid_root` MUST equal `hash_tree_root(signed_bid)` for the referenced `SignedExecutionPayloadBid`, and `gross_value` MUST equal `signed_bid.message.gross_value`.
+For a positive report, `bid_root` MUST equal `hash_tree_root(signed_bid)` for the referenced `SignedExecutionPayloadBid`. Its `gross_value` MUST equal `signed_bid.message.gross_value`.
 
 A member that observed no eligible public bid MAY report:
 
@@ -653,13 +577,13 @@ A PTC member MUST report only a public bid that satisfied the normal public-bid 
 7. The builder has sufficient consensus collateral for `gross_value` and its other pending liabilities.
 8. All other EIP-7732 public-gossip checks hold.
 
-A positive report MUST NOT contribute to a validator's floor until that validator has the referenced signed bid and has verified these conditions for the candidate proposal context.
+A positive report MUST NOT contribute to a floor until the validator has the referenced signed bid and has verified it for the candidate proposal context.
 
 ### PTC public-bid observation duty
 
 Each PTC member assigned to `target_slot` MUST observe eligible public bids during the pre-proposal window in the preceding slot.
 
-At `BID_FLOOR_DUE_BPS`, the member MUST choose the eligible public bid with the greatest `gross_value` that it observed. Equal-value ties MUST be broken by the lexicographically smallest `bid_root`.
+At `BID_FLOOR_DUE_BPS`, the member MUST choose its observed eligible public bid with the greatest `gross_value`. It MUST break equal-value ties by the lexicographically smallest `bid_root`.
 
 The member MUST sign and broadcast a `SignedBidFloorMessage` on the `bid_floor_message` gossip topic. An honest member MUST issue at most one nonzero report for a target slot and proposal context.
 
@@ -677,13 +601,13 @@ Gossip validation MUST verify at least:
 4. A positive report references a matching, verified, floor-eligible `SignedExecutionPayloadBid`.
 5. A zero report uses both zero sentinel values.
 
-Validators MUST store locally timely reports and their signed-bid evidence. Reports received at or after the start of `target_slot` MUST NOT change that validator's floor for the slot.
+Validators MUST store timely reports and their evidence. At the start of `target_slot`, each validator freezes its report set. Later reports MUST NOT change that slot's floor or an earlier fork-choice decision.
 
-If a member equivocates, a validator that received multiple valid reports from that member MUST use only the greatest reported eligible `gross_value`. The signed messages MAY be retained as equivocation evidence. This EIP does not define a slashing condition for bid-floor equivocation.
+For multiple valid reports from one member, a validator MUST use only the greatest eligible `gross_value`. It MAY retain the signed messages as equivocation evidence. This EIP does not add a slashing condition.
 
 ### Local PTC floor
 
-For a candidate external bid, a validator forms one value `m_i` for each distinct PTC member whose timely report references an eligible public bid compatible with the candidate's slot, parent context, and proposer preferences. `m_i` is that report's `gross_value`.
+From the frozen set, a validator forms one value `m_i` per distinct PTC member. The report must reference an eligible public bid compatible with the candidate's slot, parent context, and proposer preferences.
 
 Let `q = BID_FLOOR_THRESHOLD`. If fewer than `q` distinct compatible positive reports are available, set `F = 0`. Otherwise:
 
@@ -715,13 +639,13 @@ An honest proposer MUST NOT select an external bid for which:
 selected_bid.gross_value < local_ptc_floor
 ```
 
-An honest validator MUST treat a beacon block selecting such an external bid, and descendants of that block, as ineligible for head selection in its local fork choice. It MUST NOT attest to that block as its head while the violation applies.
+During `target_slot`, an honest validator MUST exclude such a block from head selection and MUST NOT attest to it as head. The filter expires at the start of `target_slot + 1`. The block and its descendants then use ordinary fork choice. Prior votes are not revised.
 
-The floor is a fork-choice eligibility rule, not a state-transition validity rule. Honest nodes can have different floors because timely message receipt is local.
+The floor is not a state-transition validity rule. Its direct effect is bounded to same-slot head selection; normal LMD-GHOST consequences of those votes can persist.
 
-The floor MUST NOT change the amount charged for a selected bid. In particular, this EIP does not charge a proposer or validator `t * (F - G)` and does not define `burn = t * max(G, F)`.
+The floor MUST NOT change the amount charged for a selected bid. This EIP does not charge a proposer or validator `t * (F - G)`. It does not define `burn = t * max(G, F)`.
 
-PTC reports do not need to be included in the beacon block. Proposer omission MUST NOT remove a locally received report from fork-choice enforcement. A future specification MAY define inclusion or aggregation for rewards and auditability, but inclusion MUST NOT be what gives a report force.
+PTC reports do not need beacon-block inclusion. Proposer omission MUST NOT remove a locally received report from fork-choice enforcement. A future specification MAY add inclusion or aggregation for rewards and auditing. Inclusion MUST NOT give a report its force.
 
 ### Self-built payloads
 
@@ -770,277 +694,92 @@ This EIP does not define a specific API endpoint.
 
 ## Rationale
 
-### Why `gross_value` defines the external target
+### Why these rules activate together
 
-`gross_value` is the signed external-bid amount that determines the auction target and declared proposer compensation.
+The three rules address different parts of the same accounting path.
 
-At bid time it decomposes into the reserved auction target and all declared proposer compensation:
+The universal priority-fee burn gives every executed payload a minimum burn. The auction target covers value declared by an external builder. The competitive floor limits trivial under-declaration of that value. Priority-fee burn must credit the auction target to avoid charging both rules for the same value.
+
+A single activation also gives both layers one rate and one set of cross-layer tests. An activation that omits a rule would restore either double counting, the self-build zero-burn path, or low-value external bids.
+
+### Auction accounting
+
+The signed external bid decomposes as follows:
 
 ```text
 G = A + V + E
+A = floor(t * G)
+V = G - A - E
 ```
 
-This definition keeps the burn fraction easy to understand.
+The builder supplies only `gross_value` and `execution_payment`. Consensus derives `burn_target` and `trustless_payment`. This avoids redundant monetary fields.
 
-At a one-third rate, `A` is about one third of `G`. The remaining amount is declared proposer compensation.
-
-The auction target is not a charge on the declared proposer payment. The proposer-payment calculation is `P = G - A` even when `U` later reduces the builder top-up.
-
-Because priority-fee burn counts toward `A`, the builder's realized consensus-layer deduction can be smaller than the bid-time reserve. `gross_value` therefore defines the external commitment and target calculation; it is not a promise that every component is ultimately deducted from builder balance.
-
-An alternative definition could make `gross_value` equal only to proposer compensation. The burn would then be an extra cost on top of `gross_value`.
-
-That alternative changes the meaning of the rate constant. It also makes historical backcasts and payment-avoidance calculations use a different parameter.
-
-This EIP uses expenditure-inclusive `gross_value` so that the rate has one meaning in all parts of the analysis.
-
-### Why derive `V`
-
-The builder supplies only two monetary fields:
-
-- `gross_value`;
-- `execution_payment`.
-
-Consensus derives `burn_target` and `trustless_payment`. After payload execution, it derives `builder_burn` from `burn_target` and `priority_fee_burn`.
-
-This design removes redundant monetary fields.
-
-If the builder supplied all four values, consensus would have to check the same accounting identity in many places.
-
-A derived value cannot disagree with the source fields.
-
-### Why retain `execution_payment`
-
-If all proposer compensation had to be trustless, builders would need consensus-layer collateral for the complete proposer payment.
-
-A rare high-value block could then require a very large builder balance.
-
-Large collateral requirements can favor the largest builders.
-
-`execution_payment` keeps the EIP-7732 distinction between trustless and trusted proposer compensation.
-
-The builder fully collateralizes its protocol commitments at bid time:
+The proposer amount is `G - A`. It does not change when `U` reduces the later builder top-up. The full protocol liability is reserved at bid time:
 
 ```text
 C = A + V
 ```
 
-The builder does not collateralize `E` through consensus.
+After execution, the realized builder deduction is `max(0, A - U)`. Thus, `gross_value` defines the external commitment and target. It does not state that every part of `A` is deducted from builder balance.
 
-The auction target still uses `G`. It does not use only `V`.
+### Priority-fee credit and channel substitution
 
-Therefore, a declared trusted payment does not remove its share of the burn.
+For a gross value `X` represented entirely in either `T` or `G`, the burn target is `t * X`. To deliver a fixed post-burn amount `x`, either channel requires gross value `x / (1 - t)` and burns `t * x / (1 - t)`. The two endpoints therefore have the same marginal rate.
 
-If a builder increases `G` to advertise a larger trusted payment, the builder also increases its fully reserved auction target.
+This is not a proof for two disjoint additive value streams. Because the external total is `max(U, A)`, extra value below the larger measure does not increase the burn. The design treats priority fees as one expression of the value covered by the external target. Evaluation must test whether builders can make `T` and `G` economically disjoint. The public-bid floor constrains `G`, and `U` remains unavoidable for every executed payload.
 
-This makes a false high trusted-payment declaration more expensive than a design that burns only the trustless payment.
+### Priority-fee scope and precision
 
-This rule does not make `E` trustless. The builder can still fail to deliver `E`. Consensus does not resolve that default.
+Both layers account in Gwei. The execution layer first rounds each transaction's priority fee down to Gwei. It credits the sub-Gwei remainder to the fee recipient. This rule makes `T`, `U`, `A`, and `D` directly comparable and gives clients one rounding order.
 
-### Why public bids require `E == 0`
+Failed transactions are included because they consume gas and pay priority fees. Excluding them would make the burn depend on the success flag and would let equivalent gas demand avoid `U` by reverting.
 
-The public ePBS topic is the default path for proposers that do not use a relay-specific credit relationship.
+### Trusted payments
 
-A public bid must have `execution_payment == 0`.
+`execution_payment` preserves the EIP-7732 distinction between trustless and trusted proposer compensation. Consensus reserves `A + V` but does not collateralize `E`. The target still uses all of `G`, so moving compensation into `E` does not reduce `A`.
 
-Therefore, every public bid is fully collateralized:
+Public bids require `E == 0` and are fully collateralized. Private paths may use trusted payments. This EIP does not set a minimum `V` because that would add an arbitrary credit-risk rule and increase collateral requirements.
 
-```text
-C = G
-```
+### Self-build
 
-A proposer that uses only public gossip does not accept trusted-payment risk by default.
+A self-built payload has no measurable external `gross_value`. The protocol cannot prove who constructed it or require a truthful declaration of its MEV. Self-build therefore has no auction target or competitive floor. It still pays `U`.
 
-Private and relay paths can use trusted payments. This can reduce builder collateral needs without changing the trust model of public gossip.
+This preserves local construction as the unconditional fallback. It also leaves vertical integration and outsourced self-build as residual avoidance paths.
 
-### Why there is no minimum trustless payment
+### PTC order statistic and local snapshot
 
-This EIP does not set a minimum `V`.
+PTC members report signed, collateral-backed public bids, not estimates of MEV. Different members can observe different bids. The `q`-th greatest distinct-member maximum uses these observations without requiring an identical `bid_root`.
 
-A proposer can accept a private bid in which some or all proposer compensation is trusted.
+The threshold trades off two failures. A low threshold makes selective delivery easier. A high threshold makes ordinary propagation failure or report suppression more likely to produce a low floor. Mainnet values must follow propagation and adversarial analysis, so the deadline and threshold remain configuration constants marked `TBD`.
 
-The protocol still fully collateralizes the auction target and any nonzero trustless payment at bid time.
+Each validator freezes its report set at the start of the target slot. Late reports do not revise the floor. The below-floor filter applies only during that slot and expires at the next slot. This bounds its direct effect to one slot of head selection, although ordinary LMD-GHOST consequences can persist.
 
-A minimum `V` would make consensus choose an arbitrary credit-risk floor.
+A colluding proposer cannot neutralize the rule by omitting reports from a block because timely gossip, not inclusion, gives a report effect. Signed reports make conflicting messages attributable. However, the main selective delivery attack needs only one valid report per PTC member. An equivocation penalty alone would therefore not prevent it.
 
-A minimum `V` would also increase builder collateral needs.
+### Objective accounting and deferred settlement
 
-A minimum could cause bids to group at the minimum value.
+The burn remains objective. `U` comes from canonical execution, `A` comes from the canonical signed bid, and `D` is a deterministic function of both. Local PTC observations affect only same-slot external-bid eligibility.
 
-The public path stays fully trustless because it requires `E == 0`.
+One `BuilderPendingSettlement` stores the target and proposer liability. The `is_payable` flag records the atomic liability decision. A released entry reserves nothing. A payable entry queues `V` once and keeps `A` reserved until canonical execution supplies `U` or a canonical no-payload outcome sets `U = 0`.
 
-### Why self-build is exempt
+The execution layer destroys `U` by withholding it from priority-fee credit. The consensus layer destroys `D` by reducing builder balance without creating a withdrawal. No burn address is used.
 
-A self-built block has no external builder payment that the protocol can measure as `gross_value`.
+### Proposed fraction and evaluation
 
-A rule that asks a self-builder to declare its own MEV is not enforceable.
+The proposed mainnet fraction remains one third. For an expenditure-inclusive bid, a fraction `t` requires extra gross expenditure `t / (1 - t)` per unit of proposer compensation. At one third, the extra gross expenditure is one half.
 
-A self-builder can keep value in many execution-layer accounts. A self-builder can also use private order flow or integrated search.
+A static builder-payment backcast is insufficient for the combined mechanism. It omits priority-fee overlap, the competitive floor, and behavioral changes. Before activation, evaluation should measure:
 
-Therefore, self-build has no external auction target or bid floor under this EIP. Its executed priority fees still produce `U`.
+1. Distributions of `T`, `U`, `A`, and `D`.
+2. Declared external value retained at the proposed rate.
+3. Public, private, and self-build shares by count and estimated value.
+4. PTC propagation by deadline and local-floor disagreement.
+5. Below-floor blocks and same-slot fork-choice outcomes.
+6. Trusted-payment defaults and builder collateral concentration.
+7. Proposer-payment tail percentiles.
+8. Missed proposal and missed payload rates.
 
-The exemption also keeps local building as a fallback against builder concentration.
-
-Local building is often most competitive in low-value slots. The external auction target can increase local building in this part of the distribution.
-
-A large staking operator can also own a builder and use self-build to avoid the external target and floor on high-value slots. The "Outsourced self-build avoidance" subsection describes this risk.
-
-### Why use a robust PTC-observed floor
-
-Ordinary propagation differences mean PTC members can receive different high bids. Requiring a threshold to report the exact same `bid_root` would discard useful evidence.
-
-Each PTC member instead reports its best actual eligible bid. Selecting the `q`-th greatest distinct-member maximum gives the highest value supported by at least `q` observations, even when those observations reference different bids.
-
-Every positive observation remains backed by an individually signed, collateral-backed builder commitment.
-
-### Why the floor threshold remains TBD
-
-A low threshold lets a small number of selectively targeted or malicious reports create a high local floor. A high threshold makes report suppression and ordinary propagation failures more likely to reduce `F` to zero.
-
-The correct trade-off depends on measured bid propagation, PTC size, topology, and adversarial simulations. This EIP does not assume that the EIP-7732 builder-payment quorum or a fixed percentage is also the correct floor threshold.
-
-### Why the floor does not depend on proposer inclusion
-
-If block inclusion gave reports force, a colluding proposer could omit them and select a low external bid. Direct gossip makes omission ineffective for validators that already received the reports.
-
-Later inclusion or aggregation can support rewards and auditability, but it cannot be the source of the local eligibility rule.
-
-### Objective burn and subjective eligibility
-
-The amount burned remains objective. `U` comes from canonical execution, `A` comes from the canonical signed bid, and `D` is a deterministic function of the two.
-
-The external-bid floor is subjective because it depends on timely local PTC reports. Local observations constrain which external `gross_value` an honest validator supports; they do not enter supply accounting.
-
-PTC members do not estimate MEV. They report real eligible public commitments observed before the deadline.
-
-### Why target and payment use one settlement lifecycle
-
-The auction target and the trustless proposer payment come from the same builder commitment.
-
-A separate liability rule for the burn can create an error during a reorganization or withholding case.
-
-For example, one path could charge the burn while another path releases the proposer payment.
-
-`BuilderPendingSettlement` prevents this split.
-
-One state object contains both protocol liabilities. One liability transition makes both payable or releases both.
-
-Final burn realization is deferred because `U` is known only after payload execution. Deferral does not reduce collateral: the full `A` remains reserved until the execution result or canonical no-payload outcome is known.
-
-### Why the burn occurs in both layers
-
-The execution layer destroys `U` by withholding it from priority-fee credit. EIP-7732 stores builder balance in the consensus layer, so consensus destroys the remaining `D` by reducing that balance without creating a matching withdrawal.
-
-The protocol must not send `D` to an execution-layer burn address.
-
-An execution-layer burn address still has an execution-layer balance. It does not express direct supply destruction.
-
-### Proposed burn fraction and historical scale
-
-The proposed mainnet rate is one third.
-
-This rate is intended to be large enough to reduce visible proposer windfalls. It also leaves most gross builder expenditure as proposer compensation.
-
-The following historical comparison uses aggregate data from August 2025 through July 2026.
-
-During this period:
-
-- gross MEV-Boost proposer payments were approximately 72,619 ETH;
-- execution base-fee burn was approximately 27,546 ETH.
-
-The following table is a static backcast of external auction targets. It does not include priority-fee burn, overlap between `U` and `A`, the PTC floor, or behavioral changes.
-
-| Burn rate | External auction target | Relative to execution base-fee burn | Proposer share of gross bid |
-| ---: | ---: | ---: | ---: |
-| 25% | about 18,155 ETH | about 65.9% | 75% |
-| 33 1/3% | about 24,206 ETH | about 87.9% | about 66 2/3% |
-| 40% | about 29,048 ETH | about 105.5% | 60% |
-
-The 365-day period has 2,628,000 scheduled slots.
-
-The same aggregate data gives these approximate values per scheduled slot:
-
-| Quantity | ETH per scheduled slot |
-| --- | ---: |
-| Gross external builder payments | 0.0276 |
-| Execution base-fee burn | 0.0105 |
-| 25% builder-payment burn | 0.0069 |
-| 33 1/3% builder-payment burn | 0.0092 |
-| 40% builder-payment burn | 0.0111 |
-
-These numbers show the possible scale of `A`. They do not predict total realized burn. For an executed external payload, total MEV burn is `max(U, A)`, not `U + A`.
-
-A burn can change proposer and builder behavior. It can change how much value stays in declared external-builder bids.
-
-Let `q(t)` be the fraction of baseline gross builder-payment value that remains in declared external ePBS bids at burn rate `t`.
-
-Then:
-
-```text
-external_auction_target(t) = t * q(t) * baseline_gross_value
-```
-
-This equation gives direct tests for candidate rates.
-
-For example:
-
-```text
-one-third external target is greater than the 25% target if:
-q(1/3) / q(1/4) > 0.75
-```
-
-Also:
-
-```text
-40% external target is greater than the one-third target if:
-q(0.40) / q(1/3) > 0.8333
-```
-
-A higher rate can reduce the external-target component if it causes enough gross value to leave the bid path. The universal priority-fee burn continues to apply to executed payloads on other paths.
-
-For an expenditure-inclusive bid, the extra gross expenditure that is required to give a fixed proposer payment is:
-
-```text
-t / (1 - t)
-```
-
-The following table shows this amount:
-
-| Burn rate | Extra gross expenditure per unit of proposer compensation |
-| ---: | ---: |
-| 25% | 33.3% |
-| 33 1/3% | 50% |
-| 40% | 66.7% |
-
-A higher rate gives more reason to use self-build or undeclared payment channels. The PTC floor limits low-`G` avoidance on the normal external path when enough competitive reports propagate.
-
-For this reason, payment retention and self-build behavior are primary evaluation metrics.
-
-### Rate evaluation metrics
-
-Before mainnet activation, evaluations should measure these items:
-
-1. Priority-fee value and priority-fee burn distributions.
-2. The gap between `A`, `U`, and the realized builder top-up `D`.
-3. The value-weighted share of builder payments that stays in declared ePBS `gross_value`.
-4. The public-bid share and the private-bid share.
-5. The distribution of `execution_payment / proposer_amount`.
-6. PTC public-bid propagation by deadline and network region.
-7. The distribution of distinct PTC report values and bid roots.
-8. Frequency and duration of honest-node floor disagreement.
-9. Below-floor external blocks and their fork-choice outcomes.
-10. Self-build share by block count and estimated value.
-11. High-value self-build concentration by identifiable staking operator.
-12. Builder market and collateral concentration.
-13. Proposer-payment percentiles, including p50, p95, p99, and p99.9.
-14. Trusted-payment defaults when they are observable.
-15. Missed-payload and missed-proposal rates.
-
-The burn rate should not be selected only to reach a target amount of ETH burn.
-
-The main objective is to reduce security-relevant proposer windfalls and concentration pressure.
-
-The mechanism must also keep enough value in protocol-visible external bidding to remain effective.
+The rate should reduce security-relevant proposer windfalls while retaining enough protocol-visible bidding for the mechanism to remain effective.
 
 ## Backwards Compatibility
 
@@ -1048,11 +787,11 @@ This EIP changes execution consensus, consensus-layer state transition, networki
 
 It changes the SSZ semantics and field name of `ExecutionPayloadBid.value` to `gross_value`. The field keeps its position and its type. The container layout does not change.
 
-It changes the builder pending-payment state object and settlement lifecycle.
+It replaces the builder pending-payment object with a settlement object that adds `gross_value`, `burn_target`, and `is_payable`.
 
 It changes builder collateral accounting.
 
-It adds the universal priority-fee burn and an EL-to-CL accounting result.
+It adds the universal priority-fee burn and the `priorityFeeValue` and `priorityFeeBurn` fields to a successful payload-status response.
 
 It adds `BidFloorMessage`, `SignedBidFloorMessage`, `DOMAIN_BID_FLOOR`, and the `bid_floor_message` gossip topic.
 
@@ -1060,196 +799,55 @@ A pre-fork signed bid is not valid as a post-fork bid.
 
 Execution clients, consensus clients, validator clients, builders, relays, and APIs must use the new semantics after activation.
 
-The public bid path keeps the same trust model. Public bids still have `execution_payment == 0`. Public bids are fully collateralized. Public bids use one scalar value for ordering.
+The public bid path keeps the same trust model. Public bids still have `execution_payment == 0`, full collateral, and one scalar value for ordering.
 
 ## Test Cases
 
-The following examples use a one-third burn rate.
+Unless stated otherwise, these examples use a one-third rate and Gwei.
 
-The examples use simple integer units.
+### Priority-fee burn and rounding
 
-### Universal priority-fee burn
-
-Input:
+The transaction priority-fee values in Wei are:
 
 ```text
-transaction priority-fee values = [120, 60, 120]
+120_000_000_999
+ 60_000_000_500  # failed transaction
+120_000_000_001
+```
+
+After per-transaction conversion:
+
+```text
+tip = [120, 60, 120]
 T = 300
-```
-
-Expected result:
-
-```text
 U = 100
-fee-recipient priority-fee credit = 200
 ```
 
-The EIP-1559 base-fee burn is additional and is not included in `U`.
+The execution layer burns `100_000_000_000` Wei. It credits `200_000_001_500` Wei to the fee recipient. The result includes the failed transaction. The EIP-1559 base-fee burn is additional.
 
-### Fully trustless public bid
+### Bid derivation
 
-Input:
+| Rate | `G` | `E` | `A` | `P` | `V` | `C` | Result                        |
+| ---: | --: | --: | --: | --: | --: | --: | ----------------------------- |
+|  1/3 |   9 |   0 |   3 |   6 |   6 |   9 | valid public bid              |
+|  1/3 |   9 |   2 |   3 |   6 |   4 |   7 | valid private bid             |
+|  1/3 |   9 |   6 |   3 |   6 |   0 |   3 | valid private bid             |
+|  1/3 |   9 |   7 |   3 |   6 |   - |   - | invalid because `E > P`       |
+|  1/3 |  10 |   0 |   3 |   7 |   7 |  10 | valid; remainder stays in `P` |
+|    0 |   9 |   0 |   0 |   9 |   9 |   9 | both burn rules disabled      |
+|    1 |   9 |   0 |   9 |   0 |   0 |   9 | full burn                     |
 
-```text
-G = 9
-E = 0
-```
+The row with `V = 0` still accumulates attestation weight because `C > 0`.
 
-Expected result:
-
-```text
-A = 3
-P = 6
-V = 6
-C = 9
-```
-
-The bid is valid for public gossip.
-
-The builder needs 9 units of consensus collateral. A later `U` reduces only the realized builder top-up, not `P`, `V`, or bid-time collateral.
-
-### Partially trusted private bid
-
-Input:
+For the overflow vector, use these inputs:
 
 ```text
-G = 9
-E = 2
-```
-
-Expected result:
-
-```text
-A = 3
-P = 6
-V = 4
-C = 7
-```
-
-The bid is not valid for public gossip.
-
-Consensus requires 7 units of builder collateral.
-
-### All proposer compensation is trusted
-
-Input:
-
-```text
-G = 9
-E = 6
-```
-
-Expected result:
-
-```text
-A = 3
-P = 6
-V = 0
-C = 3
-```
-
-The bid is valid only through a private or relay path.
-
-The auction target is fully collateralized.
-
-The proposer payment is fully trusted.
-
-Attestation weight must still accumulate because `C > 0`.
-
-### Invalid trusted payment
-
-Input:
-
-```text
-G = 9
-E = 7
-```
-
-Derived values:
-
-```text
-A = 3
-P = 6
-```
-
-The bid is invalid because `E > P`.
-
-### Rounding
-
-Input:
-
-```text
-G = 10
-E = 0
-```
-
-Expected result:
-
-```text
-A = 3
-P = 7
-V = 7
-C = 10
-```
-
-The division remainder stays in proposer compensation.
-
-### Zero burn rate
-
-Use this test configuration:
-
-```text
-BUILDER_PAYMENT_BURN_NUMERATOR = 0
-BUILDER_PAYMENT_BURN_DENOMINATOR = 1
-G = 9
-E = 0
-```
-
-Expected result:
-
-```text
-A = 0
-P = 9
-V = 9
-C = 9
-```
-
-Both the priority-fee burn and external auction target are disabled. Payment accounting is equivalent to the fully trustless EIP-7732 payment path after mapping `gross_value` to the former trustless bid value.
-
-### Full burn rate
-
-Use this test configuration:
-
-```text
-BUILDER_PAYMENT_BURN_NUMERATOR = 1
-BUILDER_PAYMENT_BURN_DENOMINATOR = 1
-G = 9
-E = 0
-```
-
-Expected result:
-
-```text
-A = 9
-P = 0
-V = 0
-C = 9
-```
-
-A bid with `G = 9` and `E > 0` is invalid at a full burn rate because `P = 0`.
-
-### Large-value multiplication
-
-Use this test configuration:
-
-```text
-BUILDER_PAYMENT_BURN_NUMERATOR = 2
-BUILDER_PAYMENT_BURN_DENOMINATOR = 3
+rate = 2/3
 G = 18446744073709551615
 E = 0
 ```
 
-Expected result:
+The expected values are:
 
 ```text
 A = 12297829382473034410
@@ -1258,109 +856,11 @@ V = 6148914691236517205
 C = 18446744073709551615
 ```
 
-The mathematical product `G * 2` is greater than the maximum `uint64` value. The implementation must still calculate the expected result without intermediate overflow.
+The implementation must obtain this result without fixed-width intermediate overflow.
 
-### Self-build
+### Auction-target credit
 
-Input:
-
-```text
-builder_index = BUILDER_INDEX_SELF_BUILD
-G = 0
-E = 0
-T = 3
-```
-
-Expected result:
-
-```text
-A = 0
-V = 0
-C = 0
-U = 1
-```
-
-The protocol does not create a pending builder settlement. The execution layer burns one unit of priority fees.
-
-A self-build is invalid if `G != 0` or `E != 0`.
-
-### Pending-liability balance invariant
-
-Assume a builder has 12 units of consensus-layer balance. Assume the builder has 9 units of pending consensus liability.
-
-A separate state transition tries to deduct 4 units before the pending liability is resolved.
-
-The transition is invalid because the resulting balance would be 8 and the remaining pending liability would be 9.
-
-A deduction that leaves at least 9 units can satisfy this EIP invariant. Other EIP-7732 balance rules can still make that deduction invalid.
-
-### Successful payload settlement
-
-Given this pending settlement:
-
-```text
-A = 3
-V = 6
-U = 1
-```
-
-When the normal EIP-7732 payment path makes the settlement payable, consensus must do these actions:
-
-1. Queue a builder withdrawal of 6 for the proposer.
-2. Retain the full target reserve until `U` is known.
-3. Decrease the builder consensus balance by `D = 2`.
-4. Release the unused one unit of target reserve.
-5. Clear the settlement.
-
-### Quorum settlement without the normal payload path
-
-Use this pending settlement:
-
-```text
-A = 3
-V = 6
-```
-
-If the EIP-7732 builder-payment quorum makes the settlement payable before the payload accounting result is known:
-
-1. Queue a builder withdrawal of 6 exactly once.
-2. Keep all 3 units of `A` reserved.
-3. Defer the builder burn.
-
-If the canonical outcome later resolves to no executed payload, set `U = 0`, deduct all 3 units, and clear the reserve. If a valid canonical execution result supplies `U`, deduct only `max(0, 3 - U)`.
-
-### Released settlement
-
-If EIP-7732 releases the builder from the pending payment, consensus must produce this result:
-
-```text
-burn charged = 0
-withdrawal queued = 0
-```
-
-Consensus must clear the pending settlement.
-
-### Late parent settlement
-
-A parent payload can arrive after its pending settlement leaves the bounded pending-settlement window.
-
-In this case, the implementation must derive `A` and `V` from the cached bid and obtain `U` from the canonical payload result.
-
-The implementation must queue `V` at most once and deduct `max(0, A - U)` at most once.
-
-A test must fail if the implementation can charge both `A` and `D`, reuse noncanonical `U`, release the same reserve twice, or queue `V` twice.
-
-### External target with priority-fee credit
-
-Input:
-
-```text
-G = 9 ETH
-T = 0.3 ETH
-rate = 1/3
-```
-
-Expected result:
+For `G = 9 ETH` and `T = 0.3 ETH`:
 
 ```text
 A = 3.0 ETH
@@ -1369,163 +869,107 @@ D = 2.9 ETH
 total_mev_burn = 3.0 ETH
 ```
 
-### Robust PTC floor
+If `A = 3` and `U = 4`, then `D = 0` and total MEV burn is `4`. Priority-fee credit never makes the total less than either component.
 
-Use `BID_FLOOR_THRESHOLD = 10` and these distinct-member maxima:
+### Self-build
+
+For `BUILDER_INDEX_SELF_BUILD`, `G = 0`, `E = 0`, and `T = 3`:
+
+```text
+A = 0
+V = 0
+C = 0
+U = 1
+```
+
+No pending builder settlement is created. A self-build is invalid if `G != 0` or `E != 0`.
+
+### Settlement lifecycle
+
+Start with `A = 3`, `V = 6`, and `is_payable = False`.
+
+For `PAYABLE`, consensus queues `V` once, sets `is_payable = True`, and keeps all three units of `A` reserved. If canonical execution later returns `U = 1`, consensus deducts `D = 2` and clears the settlement. If the canonical outcome has no payload, it uses `U = 0`, deducts `D = 3`, and clears the settlement.
+
+For `RELEASED`, consensus queues no withdrawal, deducts no burn, and clears the settlement.
+
+A payable entry must not be evicted before burn resolution. If canonical payload availability is full but a node lacks the execution result, that node cannot verify the transition. It must not substitute `U = 0`. A late payload does not reopen a settlement after a canonical no-payload outcome.
+
+A builder with balance 12 and pending liability 9 cannot make another deduction that leaves balance 8. The remaining balance must cover all pending liability.
+
+### PTC floor and expiry
+
+For `BID_FLOOR_THRESHOLD = 10`, use these distinct-member maxima:
 
 ```text
 10.0, 10.0, 9.9, 9.9, 9.8, 9.8, 9.7, 9.7,
 9.5, 9.4, 8.9, 8.8, 8.7, 8.6, 8.5, 8.0
 ```
 
-Expected result:
+The floor is `F = 9.4`. The reports can reference different signed bid roots. With fewer than ten compatible positive reports, `F = 0`.
 
-```text
-F = 9.4
-```
+Given `F = 9`, an external block with `G = 1` is excluded from local head selection during the target slot. An external block with `G = 9` and any self-build remain eligible under this EIP.
 
-The reports may reference different signed bid roots.
-
-### Floor enforcement
-
-Given `F = 9 ETH`:
-
-```text
-external G = 1 ETH  -> locally ineligible for head selection
-external G = 9 ETH  -> locally eligible
-self-build          -> locally eligible regardless of F
-```
-
-The first external block is not made state-transition invalid; it is excluded by honest local fork choice.
-
-With fewer than `BID_FLOOR_THRESHOLD` distinct compatible positive reports, `F = 0`.
+A report received after the target-slot snapshot does not change `F`. At the next slot, this EIP's filter expires. The lower block is again considered under ordinary fork choice. Its state transition was never invalid.
 
 ## Reference Implementation
 
-A complete reference implementation requires coordinated changes to the execution specification, Engine API, Gloas beacon-chain specification, P2P specification, fork choice, and honest validator guide.
+A complete implementation requires changes to the execution specification, Engine API, Gloas beacon-chain specification, P2P specification, fork choice, and honest validator guide.
 
-The Specification section is the normative source for an implementation. The principal open integration items are the common accounting unit and Engine API encoding for `T` and `U`, the consensus-state encoding and bounded lifetime of a payable-but-burn-unresolved reserve, and final mainnet values for the bid-floor deadline, threshold, and domain.
+The Specification section is normative. The remaining mainnet configuration items are `BID_FLOOR_DUE_BPS` and `BID_FLOOR_THRESHOLD`. Their values require propagation measurement and adversarial network analysis.
 
 ## Security Considerations
 
-### Competitive under-declaration
+### Limits of the competitive floor
 
-Without the PTC floor, an external builder and proposer can declare a low `G`, transfer the remaining compensation through a side channel, and reduce the auction target toward zero.
+Without the floor, an external builder and proposer can declare a low `G` and move compensation to a side channel. With the floor, validators that received enough competing reports do not support that external block during its slot. This removes trivial bilateral under-declaration from the normal external ePBS path when public bids reach the threshold.
 
-With the floor, an honest validator that received enough competing public-bid reports does not support that low-`G` external block. The mechanism therefore removes trivial bilateral under-declaration from the normal external ePBS path when competing public bids propagate to the PTC threshold.
+The mechanism is not coalition-proof. An adversary can suppress bids or reports, possess value that competitors cannot price, receive value after the deadline, or leave the external-builder path. Ethereum can burn only visible priority fees, signed bid value, and builder balance.
 
-It does not make MEV burn coalition-proof. Avoidance remains possible when actors can suppress enough bids or reports, possess value that competitors cannot price, receive value after the deadline, corrupt the relevant PTC view, or leave the external-builder path.
+### PTC divergence and griefing
 
-### Bid and report suppression
+An adversary can delay reports, eclipse PTC members, or deny service to the new topic. Missing reports lower `F`. Conversely, a valid high bid delivered to only part of the network can raise `F` for those validators. A coalition of at least `q` PTC members can therefore make honest validators disagree about same-slot eligibility, even though every reported bid is real and collateral-backed.
 
-The floor depends on public bids reaching PTC members and PTC reports reaching validators before the target slot.
+The frozen snapshot and expiry rule define recovery. Reports received after the target-slot boundary have no effect. At the next slot, the filter expires and every affected subtree returns to ordinary fork choice. The rule can directly remove at most the target slot's head and attestation opportunity. It does not bound indirect economic loss or later LMD-GHOST effects from the votes cast during that slot.
 
-An adversary can try to eclipse PTC members, selectively distribute bids, delay reports, or deny service to the new topic. If fewer than `BID_FLOOR_THRESHOLD` compatible reports reach a validator, its floor is zero.
+Signed conflicting reports make equivocation attributable. However, the selective-delivery attack can use one valid message from each participating member and requires no equivocation. An equivocation penalty would not prevent the main attack, so this EIP does not add a new slashing system. Clients should retain conflicting messages and expose report-receipt metrics.
 
-Threshold and deadline selection must account for ordinary propagation failures as well as targeted suppression. Clients should expose report receipt and evidence metrics so suppression is observable.
+The deadline and threshold require propagation measurement and adversarial network analysis before mainnet activation. These values must account for both targeted behavior and ordinary network variance.
 
-### Selective high reports and fork-choice divergence
+### Unpriced and self-build value
 
-A valid high bid or report sent to only part of the network can create different local floors. Honest nodes can then disagree about whether a lower external bid is eligible.
+The floor cannot price late, exclusive, or private value that public builders did not bid for. Such value can move through undeclared transfers or integrated accounting. The universal priority-fee burn still applies, but value outside `T` and `G` is not burned.
 
-Requiring threshold support limits the influence of one report but does not eliminate this risk. A malicious coalition at or above the threshold can selectively raise floors. The reported bids are real signed, collateral-backed commitments, but selective propagation can still cause temporary fork-choice divergence.
+A proposer and external constructor can also present a payload through `BUILDER_INDEX_SELF_BUILD`. The protocol cannot prove who constructed it. The constructor must reveal payload or order-flow information before proposer authorization, or establish an off-protocol way for the proposer to authorize an uninspected payload. Vertically integrated operators have lower costs for this path. Every executed self-build still pays `U`.
 
-The floor threshold, observation deadline, report propagation time, and fork-choice recovery behavior require adversarial network analysis before activation.
+### Trusted payments, capital, and residual jackpots
 
-### PTC misreporting and equivocation
+`execution_payment` remains trusted. A proposer that accepts `E > 0` accepts default risk. Public bids avoid this risk because `E == 0`. Consensus does not define a global credit model for ranking private bids.
 
-A PTC member can omit a higher bid it observed. The protocol cannot prove receipt and therefore cannot prove that a report was the member's true maximum.
+The builder reserves all of `A + V` even if `U` later reduces `D`. Exceptional slots, concurrent liabilities, and unresolved targets can favor builders with more capital.
 
-A positive false-value report is constrained by the requirement to provide a matching eligible signed builder bid. A member cannot invent a higher `gross_value` without builder cooperation and sufficient collateral for the referenced bid.
+A one-third rate still leaves about two thirds of a fully trustless gross bid as proposer compensation. Remaining tail payments can motivate reorganizations, key theft, denial of service, or operator misconduct. Evaluation must track tail payments, self-build concentration, and builder capital concentration.
 
-Equivocation is publicly provable from signed messages. This EIP uses the highest valid report per member locally and does not define a slashing penalty. A future proposal may add rewards, inclusion, or penalties without making proposer inclusion the source of floor enforcement.
+### Payload withholding and settlement safety
 
-### Late and exclusive MEV
+This EIP does not solve EIP-7732 payload withholding. A payable no-payload outcome burns all of `A` because no `U` exists to credit.
 
-The floor reflects public bids observed by the deadline. It cannot price MEV that becomes available afterward or is visible only to an exclusive builder.
-
-A proposer and builder with exclusive late value may select an external bid at the existing floor and move additional compensation off protocol. The universal priority-fee burn still applies, but private value not expressed as priority fees or `gross_value` is not burned.
-
-### Outsourced self-build avoidance
-
-A proposer and external constructor can avoid the external bid floor and auction target by presenting the payload through `BUILDER_INDEX_SELF_BUILD`.
-
-The protocol cannot prove who physically constructed a payload. An external constructor using this path does not receive the normal ePBS builder relationship. It must reveal payload or order-flow information before proposer authorization, or use an off-protocol mechanism that lets the proposer authorize a payload it did not independently construct or inspect.
-
-Vertically integrated proposer-builders have lower costs for this path. High-value outsourced and integrated self-build concentration is therefore an important residual risk.
-
-Every executed payload on this path still pays the universal priority-fee burn.
-
-### Undeclared proposer compensation
-
-Ethereum can burn only protocol-visible priority fees, signed bid value, and collateralized builder balance.
-
-Later transfers, bilateral agreements, vertically integrated accounting, and other side payments remain outside direct measurement. The competitive floor raises the cost of under-declaration when public competition exists; it does not make undeclared value observable.
-
-### Trusted payment default
-
-`execution_payment` remains trusted.
-
-A proposer that accepts `E > 0` accepts counterparty risk. Consensus does not insure that risk.
-
-A larger `G` causes a larger fully collateralized auction target, but the builder can still fail to deliver `E`. The public gossip path avoids this risk because it requires `E == 0`.
-
-### Proposer ranking across trust classes
-
-The auction target increases with `gross_value`.
-
-A rational proposer values a private bid according to the expected value of its trusted payment. The proposer can therefore select a lower-`gross_value` bid if another bid has more trusted-payment risk, provided the selected external bid is not below `F`.
-
-This is normal credit-risk pricing. The protocol does not define a global credit model.
-
-### Builder capital concentration
-
-The builder must reserve the full `A + V` even when `U` may later reduce the realized builder burn. A fully trustless public bid therefore requires collateral for all of `G`.
-
-Exceptional slots, multiple pending liabilities, and delayed release of unused burn reserves can create large working-capital requirements. These requirements can favor large builders.
-
-Builder balance concentration and builder market concentration should be measured before and after activation.
-
-### Residual proposer jackpots
-
-The mechanism does not burn all execution value.
-
-At a one-third rate, about two thirds of a fully trustless declared gross bid remains proposer compensation. Priority fees not included in `U` also remain available to the fee recipient.
-
-Exceptional remaining payments can preserve incentives for reorganization, key theft, targeted denial of service, or operator misconduct. Security analysis should examine tail proposer-payment percentiles rather than aggregate burn alone.
-
-### Builder payload withholding
-
-This EIP does not solve the EIP-7732 builder free-option or payload-withholding problem.
-
-For a payable no-payload path, the builder pays the full `A` because there is no executed priority-fee burn to count toward the target. This changes burn realization but does not add a delivery bond or withholding penalty.
-
-### Reorganizations and liability coupling
-
-The `PAYABLE` or `RELEASED` decision must remain atomic for `A` and `V`. Burn realization is later, but it must be tied to the same settlement and canonical payload outcome.
-
-An implementation must not:
+The `PAYABLE` or `RELEASED` decision must remain atomic for `A` and `V`. Burn realization must use the same settlement and canonical payload outcome. An implementation must not:
 
 - queue `V` twice;
 - charge both `A` and `D`;
-- count `U` from a noncanonical payload;
+- use `U` from a noncanonical payload;
+- substitute `U = 0` merely because a local node lacks a payload;
 - release `A` after a payable no-payload outcome;
-- retain an unresolved reserve after final realization; or
-- let a builder exit while any related liability remains.
+- evict a payable unresolved settlement; or
+- let a builder exit while a related liability remains.
 
-Tests must cover proposer slashing, reorganization, payload absence, quorum payment, delayed payload processing, and settlement eviction.
+Tests must cover reorganization, proposer slashing, payload absence, quorum payment, delayed local processing, and settlement eviction.
 
-### Supply accounting
+### Supply and cross-layer agreement
 
-`U` is destroyed by withholding that amount from the execution-layer priority-fee credit. `D` is destroyed by decreasing consensus-layer builder balance without a matching withdrawal.
+The execution layer reports `T` and `U` in Gwei and destroys `U * 10**9` Wei by withholding priority-fee credit. The consensus layer destroys `D` by reducing builder balance without a withdrawal. Each amount must be counted once, and neither is sent to a burn address.
 
-Supply accounting must count each component exactly once. Neither component may be represented as a transfer to an execution-layer burn address.
-
-### Integer arithmetic and cross-layer agreement
-
-All burn calculations use integer floor division. Implementations must not use floating-point arithmetic or overflow fixed-width intermediates.
-
-Execution and consensus clients must agree on the common accounting unit, `T`, and `U`. A mismatch can change builder balances and supply. Priority-fee rounding, the Engine API result, late payload processing, and reserve release all require consensus test vectors.
+All calculations use integer floor division. Clients must follow the specified per-transaction Wei-to-Gwei rounding and must avoid floating-point arithmetic and fixed-width intermediate overflow. A disagreement in `T` or `U` changes builder balances and supply.
 
 ## Copyright
 

--- a/EIPS/eip-8375.md
+++ b/EIPS/eip-8375.md
@@ -13,32 +13,11 @@ requires: 7732
 
 ## Abstract
 
-This EIP changes the ePBS payment mechanism from [EIP-7732](./eip-7732.md).
+This EIP changes the enshrined Proposer-Builder Separation (ePBS) payment mechanism from [EIP-7732](./eip-7732.md).
 
-An external `ExecutionPayloadBid` declares `gross_value`. `gross_value` is the total value that the builder commits if the bid becomes payable.
+For a selected external-builder bid, the protocol splits the builder's declared gross value into a burned fraction, a trustless proposer payment, and an optional trusted execution-layer payment. The exact accounting identities and validity rules are given in the Specification.
 
-The protocol divides `gross_value` into three parts:
-
-- a consensus-layer burn;
-- a trustless proposer payment;
-- an optional trusted execution-layer payment.
-
-The following identity must hold:
-
-```text
-G = B + V + E
-```
-
-The terms have these meanings:
-
-- `G` is `gross_value`.
-- `B` is the burn.
-- `V` is the trustless proposer payment.
-- `E` is `execution_payment`.
-
-The builder must fully collateralize `B` and `V`. Consensus does not guarantee `E`.
-
-A public bid must have `execution_payment == 0`. Therefore, a public bid is fully collateralized.
+The builder must fully collateralize the burn and the trustless proposer payment. Consensus does not guarantee the trusted payment. A bid distributed on the public ePBS gossip topic (a public bid) cannot include a trusted payment and is therefore fully collateralized.
 
 The burn and the trustless proposer payment use one settlement lifecycle. They become payable together or they are released together. The same EIP-7732 liability conditions control both amounts.
 
@@ -133,7 +112,11 @@ This EIP has these goals:
 
 ## Specification
 
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119) and [RFC 8174](https://www.rfc-editor.org/rfc/rfc8174).
+
 This specification changes the consensus-layer ePBS mechanism from [EIP-7732](./eip-7732.md).
+
+Types, constants, and helper functions not defined in this document have the meanings given in [EIP-7732](./eip-7732.md) and the [consensus specifications](https://github.com/ethereum/consensus-specs/tree/c94138e73e0e70eb4b27f9be4d4e9325fa1aebf7/specs/gloas).
 
 ### Definitions
 
@@ -146,7 +129,7 @@ For one selected external-builder bid, use these terms:
 - `V`: `trustless_payment`. Consensus guarantees this proposer-payment amount.
 - `C`: `consensus_liability`. The builder MUST cover this amount with consensus-layer builder balance.
 
-The following equations MUST hold:
+The following equations MUST hold, using the burn constants defined in Configuration below:
 
 ```text
 B = floor(G * BUILDER_PAYMENT_BURN_NUMERATOR / BUILDER_PAYMENT_BURN_DENOMINATOR)
@@ -171,6 +154,10 @@ The proposed mainnet configuration is:
 BUILDER_PAYMENT_BURN_NUMERATOR = uint64(1)
 BUILDER_PAYMENT_BURN_DENOMINATOR = uint64(3)
 ```
+
+A devnet or testnet MAY use a different fraction.
+
+The active values MUST be part of chain configuration and MUST NOT change without a protocol upgrade.
 
 `BUILDER_PAYMENT_BURN_DENOMINATOR` MUST be greater than zero.
 
@@ -224,7 +211,7 @@ Consensus MUST derive both values from `gross_value` and `execution_payment`.
 
 An external builder MUST use `gross_value` for the total declared expenditure of the bid.
 
-The builder MUST choose `execution_payment` so that `execution_payment <= proposer_amount`.
+The builder MUST choose `execution_payment` so that `execution_payment <= P`.
 
 A public bid MUST set `execution_payment = 0`.
 
@@ -576,21 +563,6 @@ This exposure supports supply accounting and post-fork economic analysis.
 
 This EIP does not define a specific API endpoint.
 
-### Chain specifics
-
-Mainnet is proposed to use this burn fraction:
-
-```text
-BUILDER_PAYMENT_BURN_NUMERATOR   = 1
-BUILDER_PAYMENT_BURN_DENOMINATOR = 3
-```
-
-A devnet or testnet MAY use a different fraction.
-
-The active values MUST be part of chain configuration.
-
-The values MUST NOT change without a protocol upgrade.
-
 ## Rationale
 
 ### Why `gross_value` includes all builder expenditure
@@ -864,14 +836,6 @@ A pre-fork signed bid is not valid as a post-fork bid.
 Consensus clients, validator clients, builders, relays, and APIs must use the new bid semantics after activation.
 
 The public bid path keeps the same trust model. Public bids still have `execution_payment == 0`. Public bids are fully collateralized. Public bids use one scalar value for ordering.
-
-If the final EIP-7732 container keeps the field name `value`, an implementation-compatible fallback reuses the existing field in place.
-
-In this fallback, consensus reads `value` as `gross_value`. The field keeps its position and its type. The fallback does not add a field. The fallback does not change the container layout.
-
-Consensus then derives `burn_amount` and `trustless_payment` from `value` and `execution_payment`. This derivation is the same as the Specification derivation for `gross_value`.
-
-The fallback does not add a redundant field.
 
 ## Test Cases
 

--- a/EIPS/eip-8375.md
+++ b/EIPS/eip-8375.md
@@ -124,6 +124,8 @@ BUILDER_PAYMENT_BURN_NUMERATOR = uint64(1)
 BUILDER_PAYMENT_BURN_DENOMINATOR = uint64(3)
 ```
 
+A devnet or testnet MAY configure a different burn numerator and denominator.
+
 The same numerator and denominator MUST be used to calculate both `U` and `A`. There is no separate priority-fee, self-build, or external-builder burn rate.
 
 Add:
@@ -134,13 +136,13 @@ BID_FLOOR_THRESHOLD = uint64(TBD)
 DOMAIN_BID_FLOOR = DomainType('0x0F000000')
 ```
 
+`0x0F000000` is a proposed domain value. It MUST be deconflicted and allocated in the consensus specifications before activation.
+
 `BID_FLOOR_DUE_BPS` is measured in basis points into the slot immediately preceding the report's `target_slot`. It ends the public-bid observation window.
 
 `BID_FLOOR_DUE_BPS` MUST be less than `10_000`, leaving time for reports to propagate before `target_slot`.
 
 `BID_FLOOR_THRESHOLD` is a number of distinct target-slot PTC members. Its mainnet value is TBD pending propagation and adversarial analysis. It MUST be greater than zero and MUST NOT exceed `PTC_SIZE`.
-
-A devnet or testnet MAY use a different fraction.
 
 The active values MUST be part of chain configuration and MUST NOT change without a protocol upgrade.
 
@@ -171,12 +173,14 @@ U = floor(T * BUILDER_PAYMENT_BURN_NUMERATOR / BUILDER_PAYMENT_BURN_DENOMINATOR)
 
 The execution layer MUST withhold `U * 10**9` wei from priority-fee credits. It initializes `T_running = 0` and `U_previous = 0`. After each transaction, it adds `tip_i` to `T_running` and calculates `U_current = get_mev_burn_amount(T_running)`. It burns `(U_current - U_previous) * 10**9` wei from that transaction's tip, credits the remainder, and sets `U_previous = U_current`. The increment cannot exceed `tip_i` because the fraction is at most one.
 
-The next fork version of `engine_newPayload` MUST extend a successful payload-status response with these `QUANTITY` fields:
+The next fork version of `engine_newPayload` MUST extend a payload-status response whose `status` is `VALID` with these `QUANTITY` fields:
 
 ```text
 priorityFeeValue: T
 priorityFeeBurn: U
 ```
+
+Both fields MUST be present when `status == VALID` and MUST be absent for every other payload status.
 
 Consensus MUST verify `priorityFeeBurn == get_mev_burn_amount(priorityFeeValue)`. For an external build, it deducts only `D` from builder balance. `execution_payment` keeps its EIP-7732 meaning.
 
@@ -805,7 +809,7 @@ It replaces the builder pending-payment object with a settlement object that add
 
 It changes builder collateral accounting.
 
-It adds the universal priority-fee burn and the `priorityFeeValue` and `priorityFeeBurn` fields to a successful payload-status response.
+It adds the universal priority-fee burn and the `priorityFeeValue` and `priorityFeeBurn` fields to a `VALID` payload-status response.
 
 It adds `BidFloorMessage`, `SignedBidFloorMessage`, `DOMAIN_BID_FLOOR`, and the `bid_floor_message` gossip topic.
 
@@ -914,16 +918,16 @@ A builder with balance 12 and pending liability 9 cannot make another deduction 
 
 ### PTC floor and expiry
 
-For `BID_FLOOR_THRESHOLD = 10`, use these distinct-member maxima:
+For `BID_FLOOR_THRESHOLD = 10`, use these distinct-member maxima in ETH:
 
 ```text
 10.0, 10.0, 9.9, 9.9, 9.8, 9.8, 9.7, 9.7,
 9.5, 9.4, 8.9, 8.8, 8.7, 8.6, 8.5, 8.0
 ```
 
-The floor is `F = 9.4`. The reports can reference different signed bid roots. With fewer than ten compatible positive reports, `F = 0`.
+The floor is `F = 9.4 ETH`. The reports can reference different signed bid roots. With fewer than ten compatible positive reports, `F = 0`.
 
-Given `F = 9`, an external block with `G = 1` is excluded from local head selection during the target slot. An external block with `G = 9` and any self-build remain eligible under this EIP.
+Given `F = 9 ETH`, an external block with `G = 1 ETH` is excluded from local head selection during the target slot. An external block with `G = 9 ETH` and any self-build remain eligible under this EIP.
 
 A report received after the target-slot snapshot does not change `F`. At the next slot, this EIP's filter expires. The lower block is again considered under ordinary fork choice. Its state transition was never invalid.
 
@@ -978,10 +982,10 @@ The `PAYABLE` or `RELEASED` decision must remain atomic for `A` and `V`. Burn re
 - use `U` from a noncanonical payload;
 - substitute `U = 0` merely because a local node lacks a payload;
 - release `A` after a payable no-payload outcome;
-- evict a payable unresolved settlement; or
+- discard a payable unresolved settlement; or
 - let a builder exit while a related liability remains.
 
-Tests must cover reorganization, proposer slashing, payload absence, quorum payment, delayed local processing, and settlement eviction.
+Tests must cover reorganization, proposer slashing, payload absence, quorum payment, delayed local processing, and settlement rotation.
 
 ### Supply and cross-layer agreement
 

--- a/EIPS/eip-8375.md
+++ b/EIPS/eip-8375.md
@@ -15,9 +15,9 @@ requires: 7732
 
 This EIP changes execution-layer fee accounting and the [EIP-7732](./eip-7732.md) enshrined Proposer-Builder Separation (ePBS) payment mechanism.
 
-Every executed payload burns a configured fraction of its transaction priority fees. For an external build, the same fraction of the selected builder's `gross_value` is an auction target. The priority-fee burn credits that target, so the builder supplies only the remaining top-up. External total MEV burn is the greater of the two amounts. The [EIP-1559](./eip-1559.md) base-fee burn remains separate.
+Every executed payload burns a configured fraction of its transaction priority fees. For an external build, the same fraction of the selected builder's `gross_value` is an auction target. The whole-Gwei part of the priority-fee burn credits up to that target, so the builder supplies only the remaining top-up. External total MEV burn is therefore the greater of the priority-fee burn and auction target, except that a sub-Gwei priority-fee remainder can make it less than one Gwei higher. The [EIP-1559](./eip-1559.md) base-fee burn remains separate.
 
-The builder reserves the full target and trustless proposer payment at bid time. The payment decision remains atomic, while final burn realization waits for the execution result.
+The builder reserves the full target and trustless proposer payment at bid time. The payment decision remains atomic, while final burn realization waits for the canonical payload outcome.
 
 PTC members also report their highest eligible public bids. Timely gossiped reports produce a robust local floor below which honest validators do not support an external bid. Self-build remains unconditional, has no external target or floor, and pays the priority-fee burn.
 
@@ -72,8 +72,9 @@ Types, constants, and helper functions not defined in this document have the mea
 For an executed payload and, where applicable, one selected external-builder bid, use these terms:
 
 - `G`: `gross_value`. This is the signed external-bid amount that determines the auction target and declared proposer compensation.
-- `T`: aggregate transaction priority fees in the executed payload, in `Gwei`.
-- `U`: `priority_fee_burn`. The execution layer destroys this amount for every executed payload.
+- `T`: `priority_fee_value`, the aggregate transaction priority fees in the executed payload, in Wei.
+- `U`: `priority_fee_burn`, the amount in Wei that the execution layer destroys for every executed payload.
+- `R`: `priority_fee_burn_credit`, the whole-Gwei part of `U` credited against the external auction target, capped at `A`.
 - `A`: `burn_target`. This is the external auction burn target reserved from the builder.
 - `D`: `builder_burn`. Consensus destroys this top-up from builder balance.
 - `P`: total proposer compensation after the burn.
@@ -87,6 +88,7 @@ The following equations MUST hold, using the burn constants defined in Configura
 ```text
 U = floor(T * BUILDER_PAYMENT_BURN_NUMERATOR / BUILDER_PAYMENT_BURN_DENOMINATOR)
 A = floor(G * BUILDER_PAYMENT_BURN_NUMERATOR / BUILDER_PAYMENT_BURN_DENOMINATOR)
+R = min(A, floor(U / 10**9))
 P = G - A
 V = P - E
 G = A + V + E
@@ -103,17 +105,19 @@ A larger `E` does not reduce the auction target if `G` stays the same. A larger 
 For a payable external-builder commitment with a valid executed payload:
 
 ```text
-D = max(0, A - U)
-total_mev_burn = U + D = max(U, A)
+D = max(0, A - R)
+total_mev_burn_wei = U + D * 10**9
 ```
 
-For a payable external-builder commitment on a no-payload or withheld-payload path, `U = 0` and `D = A`.
+The external total is at least `max(U, A * 10**9)` and less than one Gwei above it. The possible excess is the sub-Gwei part of `U`, which consensus cannot credit against a Gwei-denominated builder balance.
 
-For a self-built executed payload, `total_mev_burn = U`.
+For a payable external-builder commitment on a no-payload or withheld-payload path, realized `U = R = 0` and `D = A`.
 
-The proposer-compensation calculation MUST use `A`, not `D`. A high `U` MUST NOT increase `P`, `V`, or `E` for a fixed `G`.
+For a self-built executed payload, `total_mev_burn_wei = U`.
 
-The EIP-1559 base-fee burn is separate and is not included in `T`, `U`, `A`, or `D`.
+The proposer-compensation calculation MUST use `A`, not `D`. A high `R` MUST NOT increase `P`, `V`, or `E` for a fixed `G`.
+
+The EIP-1559 base-fee burn is separate and is not included in `T`, `U`, `R`, `A`, or `D`.
 
 ### Configuration
 
@@ -148,30 +152,29 @@ The active values MUST be part of chain configuration and MUST NOT change withou
 
 `BUILDER_PAYMENT_BURN_DENOMINATOR` MUST be greater than zero.
 
-`BUILDER_PAYMENT_BURN_NUMERATOR` MAY be zero. A zero numerator disables both `U` and `A` without disabling the payment path or external-bid floor.
+`BUILDER_PAYMENT_BURN_NUMERATOR` MAY be zero. A zero numerator disables `U`, `A`, the PTC bid-floor duty, and external-bid floor enforcement without disabling ordinary ePBS payments.
 
 `BUILDER_PAYMENT_BURN_NUMERATOR` MUST NOT be greater than `BUILDER_PAYMENT_BURN_DENOMINATOR`.
 
 An implementation MUST use integer floor division to calculate `U` and `A`.
 
-An implementation MUST calculate products for `T` and `G` without intermediate overflow. It MUST use a wide intermediate type or an equivalent overflow-safe algorithm.
+An implementation MUST calculate products for `T` and `G` without intermediate overflow. It MUST use a sufficiently wide intermediate type or an equivalent overflow-safe algorithm.
 
 Any division remainder from calculating `A` stays in `P`. Therefore, `A + P == G` always holds.
 
 ### Execution layer
 
-All burn accounting uses `Gwei`, matching builder balances. For transaction `i`, define:
+For transaction `i`, define:
 
 ```text
 tip_wei_i = (effective_gas_price_i - base_fee_per_gas) * gas_used_i
-tip_i = floor(tip_wei_i / 10**9)
-T = sum(tip_i)
+T = sum(tip_wei_i)
 U = floor(T * BUILDER_PAYMENT_BURN_NUMERATOR / BUILDER_PAYMENT_BURN_DENOMINATOR)
 ```
 
-`gas_used_i` includes failed transactions and reflects refund accounting. The sub-Gwei remainder of each `tip_wei_i` is credited to the fee recipient.
+`gas_used_i` includes failed transactions and reflects refund accounting.
 
-The execution layer MUST withhold `U * 10**9` wei from priority-fee credits. It initializes `T_running = 0` and `U_previous = 0`. After each transaction, it adds `tip_i` to `T_running` and calculates `U_current = get_mev_burn_amount(T_running)`. It burns `(U_current - U_previous) * 10**9` wei from that transaction's tip, credits the remainder, and sets `U_previous = U_current`. The increment cannot exceed `tip_i` because the fraction is at most one.
+The execution layer MUST withhold exactly `U` Wei from priority-fee credits. It initializes `T_running = 0` and `U_previous = 0`. After each transaction, it adds `tip_wei_i` to `T_running` and calculates `U_current = get_priority_fee_burn(T_running)`. It burns `U_current - U_previous` Wei from that transaction's tip, credits the remainder, and sets `U_previous = U_current`. The increment cannot exceed `tip_wei_i` because the fraction is at most one. The increments telescope to `U` and do not depend on transaction boundaries.
 
 The next fork version of `engine_newPayload` MUST extend a payload-status response whose `status` is `VALID` with these `QUANTITY` fields:
 
@@ -182,14 +185,14 @@ priorityFeeBurn: U
 
 Both fields MUST be present when `status == VALID` and MUST be absent for every other payload status.
 
-Consensus MUST verify `priorityFeeBurn == get_mev_burn_amount(priorityFeeValue)`. For an external build, it deducts only `D` from builder balance. `execution_payment` keeps its EIP-7732 meaning.
+Both fields are Wei-denominated. Payload-envelope verification MUST derive `burn_target = get_mev_burn_amount(bid.gross_value)` and verify `priorityFeeBurn == get_priority_fee_burn(priorityFeeValue)` and `bid.priority_fee_burn_credit == get_priority_fee_burn_credit(priorityFeeValue, burn_target)`. The canonical signed bid therefore carries `R`; the Engine API result verifies the commitment but is not itself an input to a later beacon state transition.
 
 ### Modified `ExecutionPayloadBid`
 
 Replace `ExecutionPayloadBid.value` with `gross_value`:
 
 ```python
-class ExecutionPayloadBid(ProgressiveContainer(active_fields=[1] * 12)):
+class ExecutionPayloadBid(ProgressiveContainer(active_fields=[1] * 13)):
     parent_block_hash: Hash32
     parent_block_root: Root
     block_hash: Hash32
@@ -202,15 +205,16 @@ class ExecutionPayloadBid(ProgressiveContainer(active_fields=[1] * 12)):
     execution_payment: Gwei
     blob_kzg_commitments: BlobKZGCommitments
     execution_requests_root: Root
+    priority_fee_burn_credit: Gwei
 ```
 
-`SignedExecutionPayloadBid` signs `gross_value` as part of the bid.
+`SignedExecutionPayloadBid` signs `gross_value` and `priority_fee_burn_credit`. A builder knows `R` because the bid already commits to a completed payload by `block_hash`. The builder MUST set it to `get_priority_fee_burn_credit(T, A)`.
 
 The builder MUST NOT supply `trustless_payment` as an independent field.
 
 The builder MUST NOT supply `burn_target` or `builder_burn` as an independent field.
 
-Consensus MUST derive the auction target and trustless payment from `gross_value` and `execution_payment`. It MUST derive the builder top-up from that target and the executed payload's priority-fee burn.
+Consensus MUST derive the auction target and trustless payment from `gross_value` and `execution_payment`. For a verified canonical payload, it MUST derive the builder top-up from that target and `bid.priority_fee_burn_credit`.
 
 No additional `ExecutionPayloadBid` field is required for the PTC floor. The signed bid already contains the builder, slot, parent context, block commitment, proposer preferences, and `gross_value`.
 
@@ -245,6 +249,18 @@ def get_mev_burn_amount(value: Gwei) -> Gwei:
     )
 
 
+def get_priority_fee_burn(value: uint256) -> uint256:
+    return (
+        value
+        * BUILDER_PAYMENT_BURN_NUMERATOR
+        // BUILDER_PAYMENT_BURN_DENOMINATOR
+    )
+
+
+def get_priority_fee_burn_credit(value: uint256, burn_target: Gwei) -> Gwei:
+    return Gwei(min(burn_target, get_priority_fee_burn(value) // 10**9))
+
+
 def get_bid_payment_components(bid: ExecutionPayloadBid) -> tuple[Gwei, Gwei, Gwei]:
     burn_target = get_mev_burn_amount(bid.gross_value)
     proposer_amount = Gwei(bid.gross_value - burn_target)
@@ -260,11 +276,11 @@ def get_bid_consensus_liability(bid: ExecutionPayloadBid) -> Gwei:
 
 def get_builder_burn_top_up(
     burn_target: Gwei,
-    priority_fee_burn: Gwei,
+    priority_fee_burn_credit: Gwei,
 ) -> Gwei:
-    if priority_fee_burn >= burn_target:
+    if priority_fee_burn_credit >= burn_target:
         return Gwei(0)
-    return Gwei(burn_target - priority_fee_burn)
+    return Gwei(burn_target - priority_fee_burn_credit)
 ```
 
 For every valid external bid, the following equation is also valid:
@@ -284,16 +300,17 @@ class BuilderPendingSettlement(Container):
     proposer_index: ValidatorIndex
     gross_value: Gwei
     burn_target: Gwei
+    priority_fee_burn_credit: Gwei
     is_payable: boolean
 ```
 
-`withdrawal.amount` MUST equal `V`, `burn_target` MUST equal `A`, and `is_payable` MUST initially be `False`.
+`withdrawal.amount` MUST equal `V`, `burn_target` MUST equal `A`, `priority_fee_burn_credit` MUST equal the signed bid's `priority_fee_burn_credit`, and `is_payable` MUST initially be `False`.
 
 `proposer_index` identifies the proposer for the existing EIP-7732 proposer-slashing release path. It is not a payment recipient.
 
 `withdrawal.fee_recipient` keeps the existing EIP-7732 fee-recipient semantics. It is the proposer-designated recipient used by the existing bid flow.
 
-The builder supplies neither `burn_target` nor `is_payable`. Consensus derives the target from `gross_value` and controls the lifecycle flag.
+`BuilderPendingSettlement` is consensus-derived. Consensus derives `burn_target`, copies the signed bid's `priority_fee_burn_credit`, controls `is_payable`, and stores the credit so later burn realization does not depend on an uncommitted Engine API result or local cache.
 
 Replace `builder_pending_payments` with an equivalent `builder_pending_settlements` vector. A payable entry remains in that vector until its burn is resolved.
 
@@ -362,6 +379,7 @@ For `BUILDER_INDEX_SELF_BUILD`, these conditions MUST hold:
 ```text
 gross_value == 0
 execution_payment == 0
+priority_fee_burn_credit == 0
 ```
 
 A self-build does not create an auction target or a pending builder settlement. Its executed payload remains subject to `U`.
@@ -369,10 +387,10 @@ A self-build does not create an auction target or a pending builder settlement. 
 For an external builder, the implementation MUST do these steps:
 
 1. Calculate `A`, `V`, and `C`.
-2. Verify that `execution_payment <= gross_value - A`.
+2. Verify that `execution_payment <= gross_value - A` and `priority_fee_burn_credit <= A`.
 3. Perform the existing EIP-7732 builder activity, version, and signature checks.
 4. Verify that the builder can cover `C` and all other pending liabilities.
-5. If `C > 0`, record one `BuilderPendingSettlement` that contains `A` and `V`.
+5. If `C > 0`, record one `BuilderPendingSettlement` that contains `A`, `V`, and the bid-derived `R`.
 6. Cache the bid as the latest execution payload bid as specified by EIP-7732.
 
 Conceptually:
@@ -380,10 +398,12 @@ Conceptually:
 ```python
 burn_target, trustless_payment, _ = get_bid_payment_components(bid)
 consensus_liability = Gwei(burn_target + trustless_payment)
+assert bid.priority_fee_burn_credit <= burn_target
 
 if bid.builder_index == BUILDER_INDEX_SELF_BUILD:
     assert bid.gross_value == 0
     assert bid.execution_payment == 0
+    assert bid.priority_fee_burn_credit == 0
     assert signed_bid.signature == bls.G2_POINT_AT_INFINITY
 else:
     assert is_active_builder(state, bid.builder_index)
@@ -402,6 +422,7 @@ if consensus_liability > 0:
         proposer_index=get_beacon_proposer_index(state),
         gross_value=bid.gross_value,
         burn_target=burn_target,
+        priority_fee_burn_credit=bid.priority_fee_burn_credit,
         is_payable=False,
     )
     settlement_index = SLOTS_PER_EPOCH + bid.slot % SLOTS_PER_EPOCH
@@ -437,22 +458,38 @@ That path MUST NOT charge `A` or `V`.
 
 ### Apply a payable settlement
 
-When a settlement becomes payable, consensus MUST queue `V` exactly once if `V > 0`. It MUST set `is_payable = True` and keep `A` reserved. It resolves the burn only from a canonical execution result or canonical no-payload outcome.
+When a settlement becomes payable, consensus MUST queue `V` exactly once if `V > 0`. It MUST set `is_payable = True` and keep `A` reserved. It resolves the burn only from a canonical FULL or EMPTY payload outcome.
 
 Conceptually:
 
 ```python
+def mark_builder_settlement_payable(
+    state: BeaconState,
+    settlement_index: uint64,
+) -> None:
+    settlement = state.builder_pending_settlements[settlement_index]
+    assert settlement != BuilderPendingSettlement()
+    assert not settlement.is_payable
+    if settlement.withdrawal.amount > 0:
+        state.builder_pending_withdrawals.append(settlement.withdrawal)
+    settlement.is_payable = True
+
+
 def realize_payable_builder_burn(
     state: BeaconState,
     settlement_index: uint64,
-    priority_fee_burn: Gwei,
+    priority_fee_burn_credit: Gwei,
 ) -> None:
     settlement = state.builder_pending_settlements[settlement_index]
     assert settlement.is_payable
+    assert priority_fee_burn_credit in (
+        Gwei(0),
+        settlement.priority_fee_burn_credit,
+    )
     builder_index = settlement.withdrawal.builder_index
     builder_burn = get_builder_burn_top_up(
         settlement.burn_target,
-        priority_fee_burn,
+        priority_fee_burn_credit,
     )
     assert state.builders[builder_index].balance >= builder_burn
     state.builders[builder_index].balance -= builder_burn
@@ -461,7 +498,11 @@ def realize_payable_builder_burn(
     ] = BuilderPendingSettlement()
 ```
 
-For a valid executed payload, `priority_fee_burn` MUST equal `U`. For a canonical no-payload path, it MUST be zero. Local payload absence alone MUST NOT select the zero value.
+`mark_builder_settlement_payable` is the only transition that queues `V`. Calling it for an already payable settlement is invalid.
+
+For a canonical FULL payload, `priority_fee_burn_credit` MUST equal `settlement.priority_fee_burn_credit`. FULL requires successful payload-envelope verification, including agreement between the execution result and the signed bid's `priority_fee_burn_credit`. For a canonical EMPTY or no-payload path, the realized credit MUST be zero. Local payload absence alone MUST NOT select the zero value.
+
+An execution payload for which the Engine API returns `INVALID` fails payload-envelope verification and MUST NOT create a FULL payload branch. It provides no priority-fee credit. If the canonical EIP-7732 outcome for the commitment is EMPTY and the settlement is `PAYABLE`, consensus uses zero credit and charges the full `A`; if the settlement is `RELEASED`, consensus charges neither `A` nor `V`.
 
 The balance reduction for `D` is the consensus-layer builder burn.
 
@@ -477,10 +518,10 @@ The EIP-7732 epoch transition processes the older half of `builder_pending_settl
 
 1. Apply the existing quorum rule to every nonempty older entry whose liability is not yet decided. A quorum result makes it `PAYABLE`; otherwise it becomes `RELEASED`.
 2. Clear every `RELEASED` entry without charging `A` or `V`.
-3. Resolve every `PAYABLE` entry from the canonical payload outcome. An empty payload-availability status sets `U = 0`. A full status requires the canonical execution result and its `U`.
+3. Resolve every `PAYABLE` entry from the canonical payload outcome. An EMPTY status uses zero priority-fee credit. A FULL status uses the stored `settlement.priority_fee_burn_credit` after successful payload-envelope verification.
 4. Assert that every entry in the older half is empty. Then shift the newer half into the older half and initialize the newer half with empty `BuilderPendingSettlement` values.
 
-An unresolved entry in the newer half MAY shift once into the older half. An unresolved entry MUST NOT be discarded or survive the next rotation. A node that lacks a required canonical execution result cannot verify the epoch transition until it obtains that result; it MUST NOT substitute `U = 0`. A payload received after a canonical empty outcome does not reopen the settlement.
+An unresolved entry in the newer half MAY shift once into the older half. An unresolved entry MUST NOT be discarded or survive the next rotation. A node that lacks the canonical payload outcome cannot verify the epoch transition until it obtains that outcome; it MUST NOT substitute zero credit for a FULL outcome. A payload received after a canonical EMPTY outcome does not reopen the settlement.
 
 ### Attestation weight accounting
 
@@ -582,22 +623,22 @@ The signature is over `BidFloorMessage` under `DOMAIN_BID_FLOOR` for the epoch c
 
 ### Floor-eligible public bids
 
-A PTC member MUST report only a public bid that satisfied the normal public-bid checks in the member's view by `BID_FLOOR_DUE_BPS`:
+A PTC member MUST report only a public bid that it received by `BID_FLOOR_DUE_BPS` and that satisfies these objective checks against the referenced proposal context:
 
-1. The builder signature is valid.
-2. The builder is active.
-3. The bid is for `target_slot`.
-4. The bid has the correct parent execution hash and parent beacon root for the member's target proposal context.
-5. The bid matches the target proposer's valid preferences, including fee-recipient and gas-limit constraints.
-6. `execution_payment == 0`.
-7. The builder has sufficient consensus collateral for `gross_value` and its other pending liabilities.
-8. All other EIP-7732 public-gossip checks hold.
+1. The container is well formed, its builder signature is valid, its commitments satisfy the EIP-7732 limits, and `priority_fee_burn_credit <= burn_target`.
+2. The builder is active and has the required builder version in the state referenced by the bid's parent context.
+3. The bid is for `target_slot` and has the correct parent execution hash, parent beacon root, and `prev_randao` for that context.
+4. The bid matches the target proposer's valid signed preferences, including fee-recipient and gas-limit constraints.
+5. `execution_payment == 0`.
+6. The builder has sufficient consensus collateral for `gross_value` and its other pending liabilities in the referenced state.
 
-A positive report MUST NOT contribute to a floor until the validator has the referenced signed bid and has verified it for the candidate proposal context.
+Local public-gossip admission policy is not objective bid eligibility. First-seen rules, duplicate suppression, highest-seen rules, rate limits, current-head compatibility, and whether local context data was available when the bid arrived MUST NOT make otherwise valid retrieved evidence ineligible. These rules can affect which bids a PTC member receives or forwards, but another validator MUST be able to verify a reported bid from the signed object and referenced context alone.
+
+A positive report MUST NOT contribute to a floor until the validator has the referenced signed bid and has verified these objective checks for the candidate proposal context.
 
 ### PTC public-bid observation duty
 
-Each PTC member assigned to `target_slot` MUST observe eligible public bids during the pre-proposal window in the preceding slot.
+If `BUILDER_PAYMENT_BURN_NUMERATOR == 0`, the PTC bid-floor duty is disabled and members MUST NOT issue `SignedBidFloorMessage` objects. Otherwise, each PTC member assigned to `target_slot` MUST observe eligible public bids during the pre-proposal window in the preceding slot.
 
 At `BID_FLOOR_DUE_BPS`, the member MUST choose its observed eligible public bid with the greatest `gross_value`. It MUST break equal-value ties by the lexicographically smallest `bid_root`.
 
@@ -621,6 +662,23 @@ Validators MUST store timely reports and their evidence. At the start of `target
 
 For multiple valid reports from one member, a validator MUST use only the greatest eligible `gross_value`. It MAY retain the signed messages as equivocation evidence. This EIP does not add a slashing condition.
 
+### Bid evidence retrieval
+
+Add the `ExecutionPayloadBidsByRoot` request/response protocol:
+
+```text
+MAX_REQUEST_BIDS = MAX_REQUEST_PAYLOADS
+Protocol: /eth2/beacon_chain/req/execution_payload_bids_by_root/1/
+Request:  List[Root, MAX_REQUEST_BIDS]
+Response: zero or more SignedExecutionPayloadBid chunks
+```
+
+Each request root is `hash_tree_root(signed_bid)`. A response MUST contain no more than one bid for each requested root, MUST NOT contain an unrequested bid, and MAY omit an unavailable bid. Each chunk uses the fork digest for the epoch containing the bid's slot.
+
+A PTC member that publishes a positive report MUST retain and serve its referenced signed bid until the start of `target_slot + 1`. A node that obtains the bid SHOULD serve it for the same period.
+
+When a validator receives a positive report but lacks its bid, it MUST defer validation and request the bid from one or more peers. It MUST NOT count or forward the report as valid until it has verified the bid. Only reports whose evidence is verified before the target-slot snapshot contribute to `F`.
+
 ### Local PTC floor
 
 From the frozen set, a validator forms one value `m_i` per distinct PTC member. The report must reference an eligible public bid compatible with the candidate's slot, parent context, and proposer preferences.
@@ -640,6 +698,8 @@ Conceptually:
 def get_local_ptc_floor(
     reports: Sequence[VerifiedBidFloorReport],
 ) -> Gwei:
+    if BUILDER_PAYMENT_BURN_NUMERATOR == 0:
+        return Gwei(0)
     maxima_by_member = get_highest_compatible_report_per_member(reports)
     values = sorted(maxima_by_member.values(), reverse=True)
     if len(values) < BID_FLOOR_THRESHOLD:
@@ -649,13 +709,13 @@ def get_local_ptc_floor(
 
 ### External-bid floor enforcement
 
-An honest proposer MUST NOT select an external bid for which:
+When `BUILDER_PAYMENT_BURN_NUMERATOR > 0`, an honest proposer MUST NOT select an external bid for which:
 
 ```text
 selected_bid.gross_value < local_ptc_floor
 ```
 
-During `target_slot`, an honest validator MUST exclude such a block from head selection and MUST NOT attest to it as head. The filter expires at the start of `target_slot + 1`. The block and its descendants then use ordinary fork choice. Prior votes are not revised.
+During `target_slot`, an honest validator MUST exclude such a block from head selection and MUST NOT attest to it as head. When the numerator is zero, this filter is disabled. The filter expires at the start of `target_slot + 1`. The block and its descendants then use ordinary fork choice. Prior votes are not revised.
 
 The floor is not a state-transition validity rule. Its direct effect is bounded to same-slot head selection; normal LMD-GHOST consequences of those votes can persist.
 
@@ -673,6 +733,7 @@ A self-built payload MUST have these values:
 builder_index == BUILDER_INDEX_SELF_BUILD
 gross_value == 0
 execution_payment == 0
+priority_fee_burn_credit == 0
 ```
 
 A self-built payload does not create an external auction target or pending builder settlement. The external PTC floor does not apply.
@@ -691,6 +752,7 @@ builder_index
 gross_value
 priority_fee_value
 priority_fee_burn
+priority_fee_burn_credit
 burn_target
 builder_burn
 trustless_payment
@@ -698,9 +760,9 @@ execution_payment
 settlement outcome
 ```
 
-The signed bid is the source of truth for `gross_value` and `execution_payment`.
+The signed bid is the canonical commitment to `gross_value`, `execution_payment`, and `priority_fee_burn_credit`.
 
-Execution derives `priority_fee_value` and `priority_fee_burn`. Consensus derives `burn_target`, `builder_burn`, and `trustless_payment`.
+Execution derives `priority_fee_value` and `priority_fee_burn` and verifies the signed `priority_fee_burn_credit`. Consensus derives `burn_target`, `builder_burn`, and `trustless_payment`.
 
 Consensus clients SHOULD expose these values through a stable state-inspection, event, or API surface.
 
@@ -732,23 +794,23 @@ V = G - A - E
 
 The builder supplies only `gross_value` and `execution_payment`. Consensus derives `burn_target` and `trustless_payment`. This avoids redundant monetary fields.
 
-The proposer amount is `G - A`. It does not change when `U` reduces the later builder top-up. The full protocol liability is reserved at bid time:
+The proposer amount is `G - A`. It does not change when `R` reduces the later builder top-up. The full protocol liability is reserved at bid time:
 
 ```text
 C = A + V
 ```
 
-After execution, the realized builder deduction is `max(0, A - U)`. Thus, `gross_value` defines the external commitment and target. It does not state that every part of `A` is deducted from builder balance.
+After execution, the realized builder deduction is `max(0, A - R)`. Thus, `gross_value` defines the external commitment and target. It does not state that every part of `A` is deducted from builder balance.
 
 ### Priority-fee credit and channel substitution
 
-For a gross value `X` represented entirely in either `T` or `G`, the burn target is `t * X`. To deliver a fixed post-burn amount `x`, either channel requires gross value `x / (1 - t)` and burns `t * x / (1 - t)`. The two endpoints therefore have the same marginal rate.
+For a whole-Gwei gross value `X` represented entirely in either `T` or `G`, the burn is the configured fraction of `X`, subject to integer rounding. To deliver a fixed post-burn amount `x`, either endpoint requires gross value `x / (1 - t)` and burns `t * x / (1 - t)`. The two endpoints therefore have the same marginal rate apart from rounding.
 
-This is not a proof for two disjoint additive value streams. Because the external total is `max(U, A)`, extra value below the larger measure does not increase the burn. The design treats priority fees as one expression of the value covered by the external target. Evaluation must test whether builders can make `T` and `G` economically disjoint. The public-bid floor constrains `G`, and `U` remains unavoidable for every executed payload.
+This is not a proof for two disjoint additive value streams. While `R < A`, each credited Gwei reduces the builder top-up by one Gwei. After `R >= A`, additional priority-fee burn increases total burn. The external total is at least `max(U, A * 10**9)` and can exceed it only by the sub-Gwei part of `U`. The design treats priority fees as one expression of the value covered by the external target. Evaluation must test whether builders can make `T` and `G` economically disjoint. The public-bid floor constrains `G`, and `U` remains unavoidable for every executed payload.
 
 ### Priority-fee scope and precision
 
-Both layers account in Gwei. The execution layer first rounds each transaction's priority fee down to Gwei. It credits the sub-Gwei remainder to the fee recipient. This rule makes `T`, `U`, `A`, and `D` directly comparable and gives clients one rounding order.
+The execution layer aggregates priority fees in Wei before applying the burn fraction. It burns the exact Wei-denominated `U`, so splitting the same total fees across transactions cannot change the result. Consensus builder balances remain Gwei-denominated and therefore use `R = min(A, floor(U / 10**9))`. Any sub-Gwei part of `U` is still burned but cannot reduce the builder top-up.
 
 Failed transactions are included because they consume gas and pay priority fees. Excluding them would make the burn depend on the success flag and would let equivalent gas demand avoid `U` by reverting.
 
@@ -776,9 +838,11 @@ A colluding proposer cannot neutralize the rule by omitting reports from a block
 
 ### Objective accounting and deferred settlement
 
-The burn remains objective. `U` comes from canonical execution, `A` comes from the canonical signed bid, and `D` is a deterministic function of both. Local PTC observations affect only same-slot external-bid eligibility.
+The burn remains objective. The signed bid commits `R` in the beacon block, payload-envelope verification checks it against canonical execution, `A` comes from the bid, and `D` is a deterministic function of `A` and `R`. Local PTC observations affect only same-slot external-bid eligibility.
 
-One `BuilderPendingSettlement` stores the target and proposer liability. The `is_payable` flag records the atomic liability decision. A released entry reserves nothing. A payable entry queues `V` once and keeps `A` reserved until canonical execution supplies `U` or a canonical no-payload outcome sets `U = 0`.
+One `BuilderPendingSettlement` stores the target, proposer liability, and bid-derived credit, so historical settlement does not read an uncommitted Engine API result. The `is_payable` flag records the atomic liability decision. A released entry reserves nothing. A payable entry queues `V` once and keeps `A` reserved until the canonical payload outcome selects either stored `R` for FULL or zero credit for EMPTY.
+
+The signed bid commits `R` rather than placing it only in the payload envelope because consensus creates and retains the settlement from the bid. Appending one field to the progressive bid container keeps the prior field order and lets the settlement remain self-contained. Payload-envelope verification accepts neither an overstated nor an understated `R`.
 
 The execution layer destroys `U` by withholding it from priority-fee credit. The consensus layer destroys `D` by reducing builder balance without creating a withdrawal. No burn address is used.
 
@@ -788,11 +852,11 @@ The proposed mainnet fraction remains one third. For an expenditure-inclusive bi
 
 A static builder-payment backcast is insufficient for the combined mechanism. It omits priority-fee overlap, the competitive floor, and behavioral changes. Before activation, evaluation should measure:
 
-1. Distributions of `T`, `U`, `A`, and `D`.
+1. Distributions of `T`, `U`, `R`, `A`, and `D`.
 2. Declared external value retained at the proposed rate.
 3. Public, private, and self-build shares by count and estimated value.
 4. PTC propagation by deadline and local-floor disagreement.
-5. Below-floor blocks and same-slot fork-choice outcomes.
+5. The probability that a below-floor block becomes canonical, conditioned on colluding stake, report and evidence propagation, and `BID_FLOOR_THRESHOLD`.
 6. Trusted-payment defaults and builder collateral concentration.
 7. Proposer-payment tail percentiles.
 8. Missed proposal and missed payload rates.
@@ -803,15 +867,15 @@ The rate should reduce security-relevant proposer windfalls while retaining enou
 
 This EIP changes execution consensus, consensus-layer state transition, networking, honest validator behavior, and fork choice. It requires a hard fork.
 
-It changes the SSZ semantics and field name of `ExecutionPayloadBid.value` to `gross_value`. The field keeps its position and its type. The container layout does not change.
+It changes the SSZ semantics and field name of `ExecutionPayloadBid.value` to `gross_value`. The field keeps its position and type, and the container adds the Gwei-denominated `priority_fee_burn_credit` commitment.
 
-It replaces the builder pending-payment object with a settlement object that adds `gross_value`, `burn_target`, and `is_payable`.
+It replaces the builder pending-payment object with a settlement object that adds `gross_value`, `burn_target`, `priority_fee_burn_credit`, and `is_payable`.
 
 It changes builder collateral accounting.
 
 It adds the universal priority-fee burn and the `priorityFeeValue` and `priorityFeeBurn` fields to a `VALID` payload-status response.
 
-It adds `BidFloorMessage`, `SignedBidFloorMessage`, `DOMAIN_BID_FLOOR`, and the `bid_floor_message` gossip topic.
+It adds `BidFloorMessage`, `SignedBidFloorMessage`, `DOMAIN_BID_FLOOR`, the `bid_floor_message` gossip topic, and the `ExecutionPayloadBidsByRoot` request/response protocol.
 
 A pre-fork signed bid is not valid as a post-fork bid.
 
@@ -821,7 +885,7 @@ The public bid path keeps the same trust model. Public bids still have `executio
 
 ## Test Cases
 
-Unless stated otherwise, these examples use a one-third rate and Gwei.
+Unless stated otherwise, these examples use a one-third rate, and monetary values use Gwei unless labeled Wei or ETH.
 
 ### Priority-fee burn and rounding
 
@@ -833,15 +897,15 @@ The transaction priority-fee values in Wei are:
 120_000_000_001
 ```
 
-After per-transaction conversion:
+Aggregate before applying the fraction:
 
 ```text
-tip = [120, 60, 120]
-T = 300
-U = 100
+T = 300_000_001_500 Wei
+U = 100_000_000_500 Wei
+R = 100 Gwei
 ```
 
-The execution layer burns `100_000_000_000` Wei. It credits `200_000_001_500` Wei to the fee recipient. The result includes the failed transaction. The EIP-1559 base-fee burn is additional.
+The execution layer burns `100_000_000_500` Wei and credits `200_000_001_000` Wei to the fee recipient. The result includes the failed transaction. Repartitioning the same aggregate priority fees across transactions does not change `U`. The EIP-1559 base-fee burn is additional.
 
 ### Bid derivation
 
@@ -852,7 +916,7 @@ The execution layer burns `100_000_000_000` Wei. It credits `200_000_001_500` We
 |  1/3 |   9 |   6 |   3 |   6 |   0 |   3 | valid private bid             |
 |  1/3 |   9 |   7 |   3 |   6 |   - |   - | invalid because `E > P`       |
 |  1/3 |  10 |   0 |   3 |   7 |   7 |  10 | valid; remainder stays in `P` |
-|    0 |   9 |   0 |   0 |   9 |   9 |   9 | both burn rules disabled      |
+|    0 |   9 |   0 |   0 |   9 |   9 |   9 | burn and bid floor disabled   |
 |    1 |   9 |   0 |   9 |   0 |   0 |   9 | full burn                     |
 
 The row with `V = 0` still accumulates attestation weight because `C > 0`.
@@ -883,15 +947,18 @@ For `G = 9 ETH` and `T = 0.3 ETH`:
 ```text
 A = 3.0 ETH
 U = 0.1 ETH
+R = 0.1 ETH
 D = 2.9 ETH
 total_mev_burn = 3.0 ETH
 ```
 
-If `A = 3` and `U = 4`, then `D = 0` and total MEV burn is `4`. Priority-fee credit never makes the total less than either component.
+If `A = 3 Gwei` and `U = 4 Gwei`, then `R = 3 Gwei`, `D = 0`, and total MEV burn is `4 Gwei`.
+
+If `A = 3 Gwei` and `U = 1.5 Gwei`, then `R = 1 Gwei`, `D = 2 Gwei`, and total MEV burn is `3.5 Gwei`. The sub-Gwei burn remains destroyed even though it cannot credit the builder balance.
 
 ### Self-build
 
-For `BUILDER_INDEX_SELF_BUILD`, `G = 0`, `E = 0`, and `T = 3`:
+For `BUILDER_INDEX_SELF_BUILD`, `G = 0`, `E = 0`, and `T = 3 Gwei`:
 
 ```text
 A = 0
@@ -900,17 +967,19 @@ C = 0
 U = 1
 ```
 
-No pending builder settlement is created. A self-build is invalid if `G != 0` or `E != 0`.
+No pending builder settlement is created. A self-build is invalid if `G != 0`, `E != 0`, or `R != 0`.
 
 ### Settlement lifecycle
 
 Start with `A = 3`, `V = 6`, and `is_payable = False`.
 
-For `PAYABLE`, consensus queues `V` once, sets `is_payable = True`, and keeps all three units of `A` reserved. If canonical execution later returns `U = 1`, consensus deducts `D = 2` and clears the settlement. If the canonical outcome has no payload, it uses `U = 0`, deducts `D = 3`, and clears the settlement.
+For `PAYABLE`, `mark_builder_settlement_payable` queues `V` once, sets `is_payable = True`, and keeps all three units of `A` reserved. A second call is invalid. If a canonical FULL payload has `U = 1 Gwei`, then `R = 1 Gwei`; consensus deducts `D = 2` and clears the settlement. If the canonical outcome is EMPTY, it uses `R = 0`, deducts `D = 3`, and clears the settlement.
 
 For `RELEASED`, consensus queues no withdrawal, deducts no burn, and clears the settlement.
 
-At an epoch rotation, every older-half settlement must become `PAYABLE` or `RELEASED` and then clear. An unresolved newer-half entry can shift into the older half once. A nonempty older entry after processing makes the epoch transition invalid. A node that lacks a required canonical execution result cannot verify the transition and must not substitute `U = 0`.
+If envelope validation returns `INVALID`, the envelope cannot create a FULL branch and cannot supply priority-fee credit. A later payable EMPTY outcome therefore deducts `D = A`; a released outcome deducts nothing.
+
+At an epoch rotation, every older-half settlement must become `PAYABLE` or `RELEASED` and then clear. An unresolved newer-half entry can shift into the older half once. A nonempty older entry after processing makes the epoch transition invalid. A node that lacks the canonical payload outcome cannot verify the transition and must not substitute zero credit for a FULL outcome.
 
 After rotation, every newer-half entry is empty. Processing a new bid against a nonempty destination entry is invalid and must not overwrite that entry.
 
@@ -925,9 +994,11 @@ For `BID_FLOOR_THRESHOLD = 10`, use these distinct-member maxima in ETH:
 9.5, 9.4, 8.9, 8.8, 8.7, 8.6, 8.5, 8.0
 ```
 
-The floor is `F = 9.4 ETH`. The reports can reference different signed bid roots. With fewer than ten compatible positive reports, `F = 0`.
+The floor is `F = 9.4 ETH`. The reports can reference different signed bid roots. With fewer than ten compatible positive reports, `F = 0`. If the burn numerator is zero, `F = 0` regardless of reports.
 
-Given `F = 9 ETH`, an external block with `G = 1 ETH` is excluded from local head selection during the target slot. An external block with `G = 9 ETH` and any self-build remain eligible under this EIP.
+A positive report received without its signed bid does not initially contribute. If `ExecutionPayloadBidsByRoot` returns the matching bid and its objective checks succeed before the target-slot snapshot, the report contributes even if a local first-seen gossip rule would have ignored that bid. Evidence obtained after the snapshot does not revise `F`.
+
+Given `F = 9 ETH`, an external block with `G = 1 ETH` loses local head eligibility during the target slot. An external block with `G = 9 ETH` and any self-build remain eligible under this EIP.
 
 A report received after the target-slot snapshot does not change `F`. At the next slot, this EIP's filter expires. The lower block is again considered under ordinary fork choice. Its state transition was never invalid.
 
@@ -941,13 +1012,13 @@ The Specification section is normative. The remaining mainnet configuration item
 
 ### Limits of the competitive floor
 
-Without the floor, an external builder and proposer can declare a low `G` and move compensation to a side channel. With the floor, validators that received enough competing reports do not support that external block during its slot. This removes trivial bilateral under-declaration from the normal external ePBS path when public bids reach the threshold.
+Without the floor, an external builder and proposer can declare a low `G` and move compensation to a side channel. With the floor, a low external bid must overcome the loss of same-slot honest fork-choice support from validators that received enough competing reports. This mitigates trivial bilateral under-declaration in the normal external ePBS path when public bids reach the threshold.
 
 The mechanism is not coalition-proof. An adversary can suppress bids or reports, possess value that competitors cannot price, receive value after the deadline, or leave the external-builder path. Ethereum can burn only visible priority fees, signed bid value, and builder balance.
 
 ### PTC divergence and griefing
 
-An adversary can delay reports, eclipse PTC members, or deny service to the new topic. Missing reports lower `F`. Conversely, a valid high bid delivered to only part of the network can raise `F` for those validators. A coalition of at least `q` PTC members can therefore make honest validators disagree about same-slot eligibility, even though every reported bid is real and collateral-backed.
+An adversary can delay reports or bid evidence, eclipse participants, or deny service to the new gossip and request/response protocols. Missing verified reports lower `F`. Conversely, a malicious builder can deliver one valid high bid to at least `q` honest PTC members without making it timely retrievable by every validator. Their honest reports can then raise `F` only where the evidence arrives before the snapshot. Malicious PTC members can create the same disagreement. Bid-by-root retrieval reduces this selective-evidence risk but cannot eliminate deadline, eclipse, or targeted-delivery effects.
 
 The frozen snapshot and expiry rule define recovery. Reports received after the target-slot boundary have no effect. At the next slot, the filter expires and every affected subtree returns to ordinary fork choice. The rule can directly remove at most the target slot's head and attestation opportunity. It does not bound indirect economic loss or later LMD-GHOST effects from the votes cast during that slot.
 
@@ -955,7 +1026,7 @@ Enforcement is therefore probabilistic. It is strong only when the loss of same-
 
 Signed conflicting reports make equivocation attributable. However, the selective-delivery attack can use one valid message from each participating member and requires no equivocation. An equivocation penalty would not prevent the main attack, so this EIP does not add a new slashing system. Clients should retain conflicting messages and expose report-receipt metrics.
 
-The deadline and threshold require propagation measurement and adversarial network analysis before mainnet activation. These values must account for both targeted behavior and ordinary network variance.
+The deadline and threshold require propagation measurement and adversarial network analysis before mainnet activation. These values must account for both targeted behavior and ordinary network variance. Simulations must estimate the probability that a below-floor block eventually becomes canonical as a function of colluding stake, report and evidence propagation, and `BID_FLOOR_THRESHOLD`.
 
 ### Unpriced and self-build value
 
@@ -967,20 +1038,20 @@ A proposer and external constructor can also present a payload through `BUILDER_
 
 `execution_payment` remains trusted. A proposer that accepts `E > 0` accepts default risk. Public bids avoid this risk because `E == 0`. Consensus does not define a global credit model for ranking private bids.
 
-The builder reserves all of `A + V` even if `U` later reduces `D`. Exceptional slots, concurrent liabilities, and unresolved targets can favor builders with more capital.
+The builder reserves all of `A + V` even if `R` later reduces `D`. Exceptional slots, concurrent liabilities, and unresolved targets can favor builders with more capital.
 
 A one-third rate still leaves about two thirds of a fully trustless gross bid as proposer compensation. Remaining tail payments can motivate reorganizations, key theft, denial of service, or operator misconduct. Evaluation must track tail payments, self-build concentration, and builder capital concentration.
 
 ### Payload withholding and settlement safety
 
-This EIP does not solve EIP-7732 payload withholding. A payable no-payload outcome burns all of `A` because no `U` exists to credit.
+This EIP does not solve EIP-7732 payload withholding. A payable no-payload outcome burns all of `A` because no `R` exists to credit.
 
 The `PAYABLE` or `RELEASED` decision must remain atomic for `A` and `V`. Burn realization must use the same settlement and canonical payload outcome. An implementation must not:
 
 - queue `V` twice;
 - charge both `A` and `D`;
-- use `U` from a noncanonical payload;
-- substitute `U = 0` merely because a local node lacks a payload;
+- use `R` from a noncanonical or execution-invalid payload;
+- substitute `R = 0` merely because a local node lacks a payload;
 - release `A` after a payable no-payload outcome;
 - discard a payable unresolved settlement; or
 - let a builder exit while a related liability remains.
@@ -989,9 +1060,9 @@ Tests must cover reorganization, proposer slashing, payload absence, quorum paym
 
 ### Supply and cross-layer agreement
 
-The execution layer reports `T` and `U` in Gwei and destroys `U * 10**9` Wei by withholding priority-fee credit. The consensus layer destroys `D` by reducing builder balance without a withdrawal. Each amount must be counted once, and neither is sent to a burn address.
+The execution layer reports and verifies `T` and `U` in Wei and destroys exactly `U` Wei by withholding priority-fee credit. The consensus layer derives `R = min(A, floor(U / 10**9))` from the verified signed commitment and destroys `D` Gwei by reducing builder balance without a withdrawal. Each amount must be counted once, and neither is sent to a burn address.
 
-All calculations use integer floor division. Clients must follow the specified per-transaction Wei-to-Gwei rounding and must avoid floating-point arithmetic and fixed-width intermediate overflow. A disagreement in `T` or `U` changes builder balances and supply.
+All calculations use integer floor division. Clients must aggregate transaction priority fees in Wei before calculating `U`, convert only the builder credit `R` to Gwei, and avoid floating-point arithmetic and fixed-width intermediate overflow. A disagreement in `T`, `U`, or `R` changes builder balances or supply.
 
 ## Copyright
 

--- a/EIPS/eip-8375.md
+++ b/EIPS/eip-8375.md
@@ -1,7 +1,7 @@
 ---
 eip: 8375
 title: ePBS Mandatory Burn of Execution Rewards
-description: Burns a fixed fraction of the gross value committed by selected ePBS builder bids.
+description: Burns priority fees and targets external builder bids subject to a PTC-observed competitive floor.
 author: Ben Adams (@benaadams)
 discussions-to: https://ethereum-magicians.org/t/eip-8375-ember-epbs-mandatory-burn-of-execution-rewards/29380
 status: Draft
@@ -13,17 +13,17 @@ requires: 7732
 
 ## Abstract
 
-This EIP changes the enshrined Proposer-Builder Separation (ePBS) payment mechanism from [EIP-7732](./eip-7732.md).
+This EIP changes the execution-layer fee accounting and the enshrined Proposer-Builder Separation (ePBS) payment mechanism from [EIP-7732](./eip-7732.md).
 
-For a selected external-builder bid, the protocol splits the builder's declared gross value into a burned fraction, a trustless proposer payment, and an optional trusted execution-layer payment. The exact accounting identities and validity rules are given in the Specification.
+Every executed payload burns a configured fraction of its transaction priority fees. For a selected external-builder bid, the same configured fraction of the builder's declared `gross_value` is an auction burn target. Priority-fee burn from the payload counts toward that target, and the builder supplies only the remaining top-up. Therefore, the total MEV burn for an executed external-builder payload is the greater of the priority-fee burn and the auction burn target. The [EIP-1559](./eip-1559.md) base-fee burn remains separate.
 
-The builder must fully collateralize the burn and the trustless proposer payment. Consensus does not guarantee the trusted payment. A bid distributed on the public ePBS gossip topic (a public bid) cannot include a trusted payment and is therefore fully collateralized.
+The builder must fully collateralize the auction burn target and the trustless proposer payment at bid time. Consensus does not guarantee an optional trusted execution-layer payment. The EIP-7732 liability decision remains atomic, but final realization of the builder burn is deferred until the priority-fee burn is known.
 
-The burn and the trustless proposer payment use one settlement lifecycle. They become payable together or they are released together. The same EIP-7732 liability conditions control both amounts.
+This EIP also extends the EIP-7732 Payload Timeliness Committee (PTC). Each member reports the highest eligible public bid it observed before a deadline. Honest validators derive a robust local external-bid floor from directly gossiped reports and do not support an external bid below that floor.
 
-A self-built payload has no burn. The protocol cannot measure the external payment value of a self-built payload.
+> Every payload burns the configured fraction of priority fees. External-builder payloads additionally target the configured fraction of their declared gross bid, and competing public bids establish a minimum acceptable external `gross_value`.
 
-This EIP does not add an attester duty. This EIP does not add a burn rule to fork choice.
+Self-building remains unconditionally available and is exempt from the external auction target and bid floor. Its executed payload still pays the universal priority-fee burn.
 
 ## Motivation
 
@@ -66,18 +66,19 @@ The objective is measurable:
 
 Builder payments are not base fees. However, builder payments are another protocol-visible value stream that is connected to execution rights.
 
-A proportional burn has these properties:
+A universal priority-fee burn and an external auction burn target have these properties:
 
-- The burn increases when the selected builder bid increases.
-- A high-value block creates a high burn.
-- The protocol removes a known fraction of each visible builder bid before the proposer payment.
+- Every executed payload has a protocol-visible minimum MEV burn.
+- The external auction target increases when the selected builder bid increases.
+- Priority-fee burn counts toward the external target instead of being charged twice.
+- A self-built payload is not a zero-burn path.
 - The protocol does not need a new recipient set.
 - The protocol does not need a redistribution mechanism.
 - The burn reduces ETH supply.
 
-This EIP does not burn all MEV. It burns a fixed fraction of value that appears in a selected external ePBS bid.
+This EIP does not burn all MEV. It burns a fixed fraction of priority fees and, for an external build, targets the same fraction of value that appears in the selected ePBS bid.
 
-The protocol cannot burn value that a self-builder keeps internally. The protocol also cannot burn a payment that the builder and proposer keep outside the signed bid.
+The protocol cannot directly measure value that a self-builder keeps internally. The protocol also cannot directly burn a payment that a builder and proposer keep outside the signed bid and outside priority fees.
 
 ### Why use a proportional burn
 
@@ -85,58 +86,61 @@ A proposer has no direct reason to select a larger voluntary burn. If a builder 
 
 A separate burn field creates an incentive conflict. It also creates a second auction dimension.
 
-This EIP removes that choice. The protocol fixes the burn fraction for all external bids.
+This EIP removes that choice. The protocol fixes one burn fraction for priority fees and external auction targets.
 
 For public bids, the burn fraction is constant and `execution_payment == 0`. Therefore, a larger `gross_value` also gives a larger trustless proposer payment.
 
 A proposer can maximize its own public-bid revenue without choosing the burn amount.
 
-This design also avoids an attester-observed burn floor. A local burn floor can differ between honest nodes because nodes can receive different bids before a deadline.
-
-This EIP does not use local bid observations for consensus. The burn is a deterministic result of the selected signed bid and the fork constant.
+The burn remains a deterministic result of canonical execution, the selected signed bid, and the fork constant. Local PTC observations do not calculate the burn. They constrain the minimum external `gross_value` that an honest validator supports.
 
 ### Design goals
 
 This EIP has these goals:
 
-1. The burn is objective and is derivable from canonical consensus data.
-2. The burn does not depend on local attester observations of builder bids.
-3. The proposer does not select the burn fraction.
-4. The public ePBS bid path remains fully collateralized.
-5. A public ePBS bid does not expose the proposer to trusted-payment risk.
-6. A private or relay bid can use a declared trusted payment.
-7. A declared trusted payment contributes to the burn calculation.
-8. The burn and the trustless proposer payment use one liability decision.
-9. Self-building remains possible without a declared MEV value.
-10. The mechanism makes post-fork economic effects easy to measure.
+1. Every executed payload pays an objective priority-fee burn.
+2. The external auction target is objective and derivable from the selected signed bid.
+3. Local PTC observations constrain external-bid eligibility but do not calculate the amount burned.
+4. The proposer does not select the burn fraction.
+5. The public ePBS bid path remains fully collateralized.
+6. A public ePBS bid does not expose the proposer to trusted-payment risk.
+7. A private or relay bid can use a declared trusted payment.
+8. The auction target and trustless proposer payment use one liability decision.
+9. Proposer omission cannot neutralize locally received bid-floor reports.
+10. Self-building remains unconditionally available and pays the priority-fee burn.
 
 ## Specification
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119) and [RFC 8174](https://www.rfc-editor.org/rfc/rfc8174).
 
-This specification changes the consensus-layer ePBS mechanism from [EIP-7732](./eip-7732.md).
+This specification changes both the execution layer and the consensus-layer ePBS mechanism from [EIP-7732](./eip-7732.md).
 
 Types, constants, and helper functions not defined in this document have the meanings given in [EIP-7732](./eip-7732.md) and the [consensus specifications](https://github.com/ethereum/consensus-specs/tree/c94138e73e0e70eb4b27f9be4d4e9325fa1aebf7/specs/gloas).
 
 ### Definitions
 
-For one selected external-builder bid, use these terms:
+For an executed payload and, where applicable, one selected external-builder bid, use these terms:
 
-- `G`: `gross_value`. This is the builder's total declared expenditure if the bid becomes payable.
-- `B`: `burn_amount`. Consensus destroys this amount if the builder commitment becomes payable.
+- `G`: `gross_value`. This is the signed external-bid amount that determines the auction target and declared proposer compensation.
+- `T`: aggregate transaction priority fees in the executed payload.
+- `U`: `priority_fee_burn`. The execution layer destroys this amount for every executed payload.
+- `A`: `burn_target`. This is the external auction burn target reserved from the builder.
+- `D`: `builder_burn`. Consensus destroys this top-up from builder balance.
 - `P`: total proposer compensation after the burn.
 - `E`: `execution_payment`. This is the trusted proposer-payment amount from EIP-7732.
 - `V`: `trustless_payment`. Consensus guarantees this proposer-payment amount.
 - `C`: `consensus_liability`. The builder MUST cover this amount with consensus-layer builder balance.
+- `F`: the robust local PTC-observed public-bid floor.
 
 The following equations MUST hold, using the burn constants defined in Configuration below:
 
 ```text
-B = floor(G * BUILDER_PAYMENT_BURN_NUMERATOR / BUILDER_PAYMENT_BURN_DENOMINATOR)
-P = G - B
+U = floor(T * BUILDER_PAYMENT_BURN_NUMERATOR / BUILDER_PAYMENT_BURN_DENOMINATOR)
+A = floor(G * BUILDER_PAYMENT_BURN_NUMERATOR / BUILDER_PAYMENT_BURN_DENOMINATOR)
+P = G - A
 V = P - E
-G = B + V + E
-C = B + V
+G = A + V + E
+C = A + V
 C = G - E
 ```
 
@@ -144,7 +148,22 @@ A bid is invalid if `E > P`.
 
 Consensus does not guarantee `E`.
 
-A larger `E` does not reduce the burn if `G` stays the same. A larger declared total commitment requires a larger `G`. A larger `G` increases `B`.
+A larger `E` does not reduce the auction target if `G` stays the same. A larger declared total commitment requires a larger `G`. A larger `G` increases `A`.
+
+For a payable external-builder commitment with a valid executed payload:
+
+```text
+D = max(0, A - U)
+total_mev_burn = U + D = max(U, A)
+```
+
+For a payable external-builder commitment on a no-payload or withheld-payload path, `U = 0` and `D = A`.
+
+For a self-built executed payload, `total_mev_burn = U`.
+
+The proposer-compensation calculation MUST use `A`, not `D`. A high `U` MUST NOT increase `P`, `V`, or `E` for a fixed `G`.
+
+The EIP-1559 base-fee burn is separate and is not included in `T`, `U`, `A`, or `D`.
 
 ### Configuration
 
@@ -155,27 +174,65 @@ BUILDER_PAYMENT_BURN_NUMERATOR = uint64(1)
 BUILDER_PAYMENT_BURN_DENOMINATOR = uint64(3)
 ```
 
+The same numerator and denominator MUST be used to calculate both `U` and `A`. There is no separate priority-fee, self-build, or external-builder burn rate.
+
+Add:
+
+```python
+BID_FLOOR_DUE_BPS = uint64(TBD)
+BID_FLOOR_THRESHOLD = uint64(TBD)
+DOMAIN_BID_FLOOR = DomainType(TBD)
+```
+
+`BID_FLOOR_DUE_BPS` is measured in basis points into the slot immediately preceding the report's `target_slot`. It ends the public-bid observation window.
+
+`BID_FLOOR_DUE_BPS` MUST be less than `10_000`, leaving time for reports to propagate before `target_slot`.
+
+`BID_FLOOR_THRESHOLD` is a number of distinct target-slot PTC members. Its mainnet value is intentionally TBD pending propagation and adversarial analysis. It MUST be greater than zero and MUST NOT exceed `PTC_SIZE`.
+
 A devnet or testnet MAY use a different fraction.
 
 The active values MUST be part of chain configuration and MUST NOT change without a protocol upgrade.
 
 `BUILDER_PAYMENT_BURN_DENOMINATOR` MUST be greater than zero.
 
-`BUILDER_PAYMENT_BURN_NUMERATOR` MAY be zero. A zero numerator disables the burn without disabling the payment path.
+`BUILDER_PAYMENT_BURN_NUMERATOR` MAY be zero. A zero numerator disables both `U` and `A` without disabling the payment path or external-bid floor.
 
 `BUILDER_PAYMENT_BURN_NUMERATOR` MUST NOT be greater than `BUILDER_PAYMENT_BURN_DENOMINATOR`.
 
-An implementation MUST use integer floor division to calculate `B`.
+An implementation MUST use integer floor division to calculate `U` and `A`.
 
-An implementation MUST calculate `G * BUILDER_PAYMENT_BURN_NUMERATOR // BUILDER_PAYMENT_BURN_DENOMINATOR` without intermediate integer overflow. A fixed-width implementation MUST use a sufficiently wide intermediate type or an equivalent overflow-safe algorithm.
+An implementation MUST calculate multiplication for `T` and `G` without intermediate integer overflow. A fixed-width implementation MUST use a sufficiently wide intermediate type or an equivalent overflow-safe algorithm.
 
-Any division remainder stays in `P`. Therefore, `B + P == G` always holds.
+Any division remainder from calculating `A` stays in `P`. Therefore, `A + P == G` always holds.
 
 ### Execution layer
 
-This EIP does not require an execution-layer consensus change.
+This EIP requires an execution-layer consensus change.
 
-The protocol applies the burn directly to the EIP-7732 consensus-layer builder balance.
+For every transaction `i`, define:
+
+```text
+priority_fee_per_gas_i = effective_gas_price_i - base_fee_per_gas
+priority_fee_value_i = priority_fee_per_gas_i * gas_used_i
+```
+
+`gas_used_i` is the gas actually charged after execution and refund accounting. Failed transactions contribute priority fees in the same way as successful transactions.
+
+The execution layer MUST calculate:
+
+```text
+T = sum(priority_fee_value_i)
+U = floor(T * BUILDER_PAYMENT_BURN_NUMERATOR / BUILDER_PAYMENT_BURN_DENOMINATOR)
+```
+
+The execution layer MUST destroy `U` rather than crediting that portion of priority fees to the payload fee recipient. This is not the EIP-1559 base-fee burn.
+
+Successful payload execution MUST make both `priority_fee_value` and `priority_fee_burn` available to the consensus layer. The consensus layer MUST verify that `priority_fee_burn` is the configured fraction of `priority_fee_value`.
+
+The exact common accounting unit, rounding rule, and Engine API response that carry these values are TBD. They MUST be specified so that `U` and the Gwei-denominated `A` can be compared deterministically without double counting or intermediate overflow.
+
+For an external build, the protocol applies only `D` directly to the EIP-7732 consensus-layer builder balance.
 
 `execution_payment` keeps its EIP-7732 trusted-payment meaning.
 
@@ -203,19 +260,21 @@ class ExecutionPayloadBid(ProgressiveContainer(active_fields=[1] * 12)):
 
 The builder MUST NOT supply `trustless_payment` as an independent field.
 
-The builder MUST NOT supply `burn_amount` as an independent field.
+The builder MUST NOT supply `burn_target` or `builder_burn` as an independent field.
 
-Consensus MUST derive both values from `gross_value` and `execution_payment`.
+Consensus MUST derive the auction target and trustless payment from `gross_value` and `execution_payment`. It MUST derive the builder top-up from the auction target and the executed payload's priority-fee burn.
+
+No additional field is required in `ExecutionPayloadBid` for the PTC floor. The signed bid already commits to the builder, slot, parent context, block commitment, proposer preferences, and `gross_value` needed as floor evidence.
 
 ### Builder bid construction
 
-An external builder MUST use `gross_value` for the total declared expenditure of the bid.
+An external builder MUST use `gross_value` for the amount that determines both the auction burn target and declared proposer compensation.
 
 The builder MUST choose `execution_payment` so that `execution_payment <= P`.
 
 A public bid MUST set `execution_payment = 0`.
 
-For a public bid, the trustless proposer payment is `gross_value - burn_amount`.
+For a public bid, the trustless proposer payment is `gross_value - burn_target`.
 
 A private or relay bid MAY set `execution_payment > 0`.
 
@@ -230,25 +289,34 @@ Consensus implementations MUST calculate the bid components deterministically.
 The following pseudocode is normative in behavior:
 
 ```python
-def get_builder_burn(gross_value: Gwei) -> Gwei:
+def get_mev_burn_amount(value: Gwei) -> Gwei:
     return Gwei(
-        gross_value
+        value
         * BUILDER_PAYMENT_BURN_NUMERATOR
         // BUILDER_PAYMENT_BURN_DENOMINATOR
     )
 
 
 def get_bid_payment_components(bid: ExecutionPayloadBid) -> tuple[Gwei, Gwei, Gwei]:
-    burn_amount = get_builder_burn(bid.gross_value)
-    proposer_amount = Gwei(bid.gross_value - burn_amount)
+    burn_target = get_mev_burn_amount(bid.gross_value)
+    proposer_amount = Gwei(bid.gross_value - burn_target)
     assert bid.execution_payment <= proposer_amount
     trustless_payment = Gwei(proposer_amount - bid.execution_payment)
-    return burn_amount, trustless_payment, bid.execution_payment
+    return burn_target, trustless_payment, bid.execution_payment
 
 
 def get_bid_consensus_liability(bid: ExecutionPayloadBid) -> Gwei:
-    burn_amount, trustless_payment, _ = get_bid_payment_components(bid)
-    return Gwei(burn_amount + trustless_payment)
+    burn_target, trustless_payment, _ = get_bid_payment_components(bid)
+    return Gwei(burn_target + trustless_payment)
+
+
+def get_builder_burn(
+    burn_target: Gwei,
+    priority_fee_burn: Gwei,
+) -> Gwei:
+    if priority_fee_burn >= burn_target:
+        return Gwei(0)
+    return Gwei(burn_target - priority_fee_burn)
 ```
 
 For every valid external bid, the following equation is also valid:
@@ -267,26 +335,28 @@ class BuilderPendingSettlement(Container):
     withdrawal: BuilderPendingWithdrawal
     proposer_index: ValidatorIndex
     gross_value: Gwei
-    burn_amount: Gwei
+    burn_target: Gwei
 ```
 
 `withdrawal.amount` MUST equal `V`.
 
-`burn_amount` MUST equal `B`.
+`burn_target` MUST equal `A`.
 
 `proposer_index` identifies the proposer for the existing EIP-7732 proposer-slashing release path. It is not a payment recipient.
 
 `withdrawal.fee_recipient` keeps the existing EIP-7732 fee-recipient semantics. It is the proposer-designated recipient used by the existing bid flow.
 
-`gross_value` and `burn_amount` are stored values in the settlement object. They make the obligation easy to audit from consensus state.
+`gross_value` and `burn_target` are stored values in the settlement object. They make the obligation easy to audit from consensus state.
 
-The builder does not supply `burn_amount` as a separate signed input. Consensus derives it from the signed `gross_value`.
+The builder does not supply `burn_target` as a separate signed input. Consensus derives it from the signed `gross_value`.
 
 Replace the EIP-7732 `builder_pending_payments` state vector with an equivalent `builder_pending_settlements` vector.
 
+The settlement mechanism MUST be able to retain a `PAYABLE` burn reserve until the canonical payload accounting result, or the canonical absence of a payload, is known. The exact consensus-state encoding of this payable-but-burn-unresolved state is TBD.
+
 ### Pending builder liability
 
-The pending-liability helper MUST count both trustless proposer payments and burns.
+The pending-liability helper MUST count both trustless proposer payments and full auction burn targets.
 
 Conceptually:
 
@@ -298,7 +368,7 @@ def get_pending_builder_liability(state: BeaconState, builder_index: BuilderInde
         if withdrawal.builder_index == builder_index
     )
     pending_settlements = sum(
-        settlement.withdrawal.amount + settlement.burn_amount
+        settlement.withdrawal.amount + settlement.burn_target
         for settlement in state.builder_pending_settlements
         if settlement.withdrawal.builder_index == builder_index
     )
@@ -327,7 +397,9 @@ def can_builder_cover_bid(
 
 Builder exit processing MUST treat a pending burn as a pending builder liability.
 
-A builder MUST NOT exit while a pending burn or a pending trustless proposer payment exists.
+A builder MUST NOT exit while a pending auction target, payable burn reserve, or pending trustless proposer payment exists.
+
+Before the liability decision, the settlement counts `A + V`. After a `PAYABLE` decision but before burn realization, `V` is counted by the existing pending-withdrawal path and the settlement continues to reserve `A`. Implementations MUST count each amount exactly once.
 
 Pending consensus liabilities have priority over later deductions from builder balance. A state transition that decreases a builder balance MUST leave enough balance to cover all pending builder liabilities that remain after that transition.
 
@@ -348,22 +420,22 @@ gross_value == 0
 execution_payment == 0
 ```
 
-A self-build does not create a burn or a pending settlement.
+A self-build does not create an auction target or a pending builder settlement. Its executed payload remains subject to `U`.
 
 For an external builder, the implementation MUST do these steps:
 
-1. Calculate `B`, `V`, and `C`.
-2. Verify that `execution_payment <= gross_value - B`.
+1. Calculate `A`, `V`, and `C`.
+2. Verify that `execution_payment <= gross_value - A`.
 3. Perform the existing EIP-7732 builder activity, version, and signature checks.
 4. Verify that the builder can cover `C` and all other pending liabilities.
-5. If `C > 0`, record one `BuilderPendingSettlement` that contains `B` and `V`.
+5. If `C > 0`, record one `BuilderPendingSettlement` that contains `A` and `V`.
 6. Cache the bid as the latest execution payload bid as specified by EIP-7732.
 
 Conceptually:
 
 ```python
-burn_amount, trustless_payment, _ = get_bid_payment_components(bid)
-consensus_liability = Gwei(burn_amount + trustless_payment)
+burn_target, trustless_payment, _ = get_bid_payment_components(bid)
+consensus_liability = Gwei(burn_target + trustless_payment)
 
 if bid.builder_index == BUILDER_INDEX_SELF_BUILD:
     assert bid.gross_value == 0
@@ -385,7 +457,7 @@ if consensus_liability > 0:
         ),
         proposer_index=get_beacon_proposer_index(state),
         gross_value=bid.gross_value,
-        burn_amount=burn_amount,
+        burn_target=burn_target,
     )
     state.builder_pending_settlements[
         SLOTS_PER_EPOCH + bid.slot % SLOTS_PER_EPOCH
@@ -394,56 +466,67 @@ if consensus_liability > 0:
 
 ### Atomic settlement lifecycle
 
-The burn and the trustless proposer payment MUST use one liability decision.
+The auction burn target and the trustless proposer payment MUST use one liability decision.
 
 A pending settlement has only two final results:
 
-1. `PAYABLE`: `B` and `V` both become payable.
-2. `RELEASED`: the protocol charges neither `B` nor `V`.
+1. `PAYABLE`: `V` becomes a proposer payment and the full `A` reserve remains locked until burn realization.
+2. `RELEASED`: the protocol charges neither `A` nor `V`.
 
-The protocol MUST NOT charge `B` and release `V`.
+The protocol MUST NOT retain or charge `A` and release `V`.
 
-The protocol MUST NOT pay `V` and release `B`.
+The protocol MUST NOT pay `V` and later release `A` without resolving it according to this EIP.
 
 The existing EIP-7732 payment conditions MUST control the complete settlement. These conditions include the normal payload path and the builder-payment quorum path.
 
 This EIP does not add a separate burn-liability condition.
 
-If an EIP-7732 proposer-slashing path clears a pending payment, it MUST clear the matching `BuilderPendingSettlement`.
+If an EIP-7732 proposer-slashing path clears a pending payment before it becomes payable, it MUST clear the matching `BuilderPendingSettlement`.
 
-That path MUST NOT charge `B` or `V`.
+That path MUST NOT charge `A` or `V`.
 
 ### Apply a payable settlement
 
 When a settlement becomes payable, consensus MUST do these steps:
 
-1. Deduct `burn_amount` from the builder's consensus-layer balance.
-2. Do not create an execution-layer credit for `burn_amount`.
-3. If `withdrawal.amount > 0`, append the `BuilderPendingWithdrawal` for the trustless proposer payment.
-4. Clear the `BuilderPendingSettlement`.
+1. If `withdrawal.amount > 0`, append the `BuilderPendingWithdrawal` for `V` exactly once.
+2. Keep the full `burn_target` reserved.
+3. Do not destroy the reserve until either a valid canonical execution result is available or the canonical path resolves that no payload is executed.
 
 Conceptually:
 
 ```python
-def settle_builder_settlement(state: BeaconState, settlement_index: Uint64) -> None:
-    settlement = state.builder_pending_settlements[settlement_index]
+def realize_payable_builder_burn(
+    state: BeaconState,
+    settlement: BuilderPendingSettlement,
+    priority_fee_burn: Optional[Gwei],
+) -> None:
     builder_index = settlement.withdrawal.builder_index
-    settlement_liability = settlement.burn_amount + settlement.withdrawal.amount
+    if priority_fee_burn is None:
+        # Canonical no-payload or withheld-payload path.
+        priority_fee_burn = Gwei(0)
 
-    assert state.builders[builder_index].balance >= settlement_liability
-
-    if settlement.burn_amount > 0:
-        state.builders[builder_index].balance -= settlement.burn_amount
-
-    if settlement.withdrawal.amount > 0:
-        state.builder_pending_withdrawals.append(settlement.withdrawal)
-
-    state.builder_pending_settlements[settlement_index] = BuilderPendingSettlement()
+    builder_burn = get_builder_burn(
+        settlement.burn_target,
+        priority_fee_burn,
+    )
+    assert state.builders[builder_index].balance >= builder_burn
+    state.builders[builder_index].balance -= builder_burn
+    release_unused_burn_reserve(
+        state,
+        settlement,
+        Gwei(settlement.burn_target - builder_burn),
+    )
+    clear_builder_burn_reserve(state, settlement)
 ```
 
-The balance reduction for `B` is the burn.
+For a valid executed payload, `priority_fee_burn` MUST equal `U`, so the balance reduction is `D = max(0, A - U)`.
 
-The protocol MUST NOT represent `B` as an execution-layer transfer to a burn address.
+For a canonical no-payload or withheld-payload path, `U = 0` and the balance reduction is the full `A`.
+
+The balance reduction for `D` is the consensus-layer builder burn.
+
+The protocol MUST NOT represent `D` as an execution-layer transfer to a burn address.
 
 The existing withdrawal path continues to process `V`.
 
@@ -451,16 +534,16 @@ The existing withdrawal path continues to process `V`.
 
 EIP-7732 has a direct-payment path for a parent payload whose pending-payment entry is no longer in the bounded window.
 
-Any equivalent path under this EIP MUST settle the burn and the trustless proposer payment together.
+Any equivalent path under this EIP MUST preserve the single liability decision and MUST resolve the burn reserve exactly once.
 
-The implementation MUST derive `B` and `V` from the cached signed bid.
+The implementation MUST derive `A` and `V` from the cached signed bid and obtain `U` from the canonical payload execution result.
 
 The implementation MUST then do these actions in one settlement operation:
 
-1. Deduct `B` from the builder's consensus-layer balance.
+1. Deduct `max(0, A - U)` from the builder's consensus-layer balance.
 2. Queue `V` as a builder withdrawal if `V > 0`.
 
-A late-payload path MUST NOT queue `V` without the matching burn.
+A late-payload path MUST NOT queue `V` twice, charge both `A` and `D`, or count `U` from a noncanonical payload.
 
 ### Attestation weight accounting
 
@@ -468,14 +551,16 @@ EIP-7732 uses attestation weight to decide when a pending builder payment become
 
 Under this EIP, weight MUST accumulate when the pending `consensus_liability` is not zero.
 
-This rule also applies when `V == 0` and `B > 0`.
+This rule also applies when `V == 0` and `A > 0`.
 
 An implementation MUST use a check equivalent to this check:
 
 ```python
 def has_pending_consensus_liability(settlement: BuilderPendingSettlement) -> bool:
-    return settlement.withdrawal.amount + settlement.burn_amount > 0
+    return settlement.withdrawal.amount + settlement.burn_target > 0
 ```
+
+After the liability decision becomes `PAYABLE`, further attestation weight does not change the result. The full `A` remains reserved until burn realization.
 
 The quorum threshold does not change.
 
@@ -499,7 +584,7 @@ A public bid is fully collateralized for its complete gross commitment.
 
 Public gossip MUST compare `gross_value` instead of the former `value` field.
 
-For public bids, the burn fraction is constant and `execution_payment == 0`. Therefore, ordering by `gross_value` is also ordering by the trustless proposer payment.
+For public bids, the auction-target fraction is constant and `execution_payment == 0`. Therefore, ordering by `gross_value` is also ordering by the declared trustless proposer payment.
 
 The existing EIP-7732 one-bid-per-builder-per-slot-and-parent gossip policy does not change.
 
@@ -510,20 +595,133 @@ A bid that does not use the public gossip topic MAY have `execution_payment > 0`
 The following condition MUST hold:
 
 ```text
-execution_payment <= gross_value - burn_amount
+execution_payment <= gross_value - burn_target
 ```
 
-Consensus guarantees only `B + V`.
+Consensus reserves `A + V`.
 
-The builder MUST provide consensus collateral for `B + V`.
+The builder MUST provide consensus collateral for `A + V` at bid time. A later priority-fee credit does not reduce this requirement.
 
 Consensus does not define the credit value of `E`.
 
 A proposer MAY discount or reject `E`. A proposer MAY use relay guarantees, builder reputation, or other local information to value `E`.
 
-`gross_value` sets the burn and the builder's declared total commitment.
+`gross_value` sets the auction burn target and the builder's declared total commitment.
 
 `gross_value` does not tell the proposer how to compare bids that have different trusted-payment risk.
+
+The external PTC floor applies equally to a public, private, or relay-selected external bid. Only eligible public bids provide evidence for the floor.
+
+### Bid-floor messages
+
+Add:
+
+```python
+class BidFloorMessage(Container):
+    validator_index: ValidatorIndex
+    target_slot: Slot
+    bid_root: Root
+    gross_value: Gwei
+
+
+class SignedBidFloorMessage(Container):
+    message: BidFloorMessage
+    signature: BLSSignature
+```
+
+For a positive report, `bid_root` MUST equal `hash_tree_root(signed_bid)` for the referenced `SignedExecutionPayloadBid`, and `gross_value` MUST equal `signed_bid.message.gross_value`.
+
+A member that observed no eligible public bid MAY report:
+
+```text
+bid_root == Root()
+gross_value == 0
+```
+
+The signature is over `BidFloorMessage` under `DOMAIN_BID_FLOOR` for the epoch containing `target_slot`.
+
+### Floor-eligible public bids
+
+A PTC member MUST report only a public bid that satisfied the normal public-bid checks in the member's view by `BID_FLOOR_DUE_BPS`:
+
+1. The builder signature is valid.
+2. The builder is active.
+3. The bid is for `target_slot`.
+4. The bid has the correct parent execution hash and parent beacon root for the member's target proposal context.
+5. The bid matches the target proposer's valid preferences, including fee-recipient and gas-limit constraints.
+6. `execution_payment == 0`.
+7. The builder has sufficient consensus collateral for `gross_value` and its other pending liabilities.
+8. All other EIP-7732 public-gossip checks hold.
+
+A positive report MUST NOT contribute to a validator's floor until that validator has the referenced signed bid and has verified these conditions for the candidate proposal context.
+
+### PTC public-bid observation duty
+
+Each PTC member assigned to `target_slot` MUST observe eligible public bids during the pre-proposal window in the preceding slot.
+
+At `BID_FLOOR_DUE_BPS`, the member MUST choose the eligible public bid with the greatest `gross_value` that it observed. Equal-value ties MUST be broken by the lexicographically smallest `bid_root`.
+
+The member MUST sign and broadcast a `SignedBidFloorMessage` on the `bid_floor_message` gossip topic. An honest member MUST issue at most one nonzero report for a target slot and proposal context.
+
+The PTC member is not estimating MEV. It is reporting the highest real, signed, collateral-backed public offer it received by the deadline.
+
+### Bid-floor gossip
+
+Add the `bid_floor_message` global gossip topic for `SignedBidFloorMessage` objects.
+
+Gossip validation MUST verify at least:
+
+1. `target_slot` is within the permitted propagation range.
+2. `validator_index` is a member of the PTC assigned to `target_slot`.
+3. The PTC signature is valid under `DOMAIN_BID_FLOOR`.
+4. A positive report references a matching, verified, floor-eligible `SignedExecutionPayloadBid`.
+5. A zero report uses both zero sentinel values.
+
+Validators MUST store locally timely reports and their signed-bid evidence. Reports received at or after the start of `target_slot` MUST NOT change that validator's floor for the slot.
+
+If a member equivocates, a validator that received multiple valid reports from that member MUST use only the greatest reported eligible `gross_value`. The signed messages MAY be retained as equivocation evidence. This EIP does not define a slashing condition for bid-floor equivocation.
+
+### Local PTC floor
+
+For a candidate external bid, a validator forms one value `m_i` for each distinct PTC member whose timely report references an eligible public bid compatible with the candidate's slot, parent context, and proposer preferences. `m_i` is that report's `gross_value`.
+
+Let `q = BID_FLOOR_THRESHOLD`. If fewer than `q` distinct compatible positive reports are available, set `F = 0`. Otherwise:
+
+```text
+F = highest value such that at least q distinct PTC members
+    reported an eligible public bid with gross_value >= F
+```
+
+Equivalently, sort the distinct-member values in descending order and use the `q`-th value. The reports do not need to reference the same bid root.
+
+Conceptually:
+
+```python
+def get_local_ptc_floor(
+    reports: Sequence[VerifiedBidFloorReport],
+) -> Gwei:
+    maxima_by_member = get_highest_compatible_report_per_member(reports)
+    values = sorted(maxima_by_member.values(), reverse=True)
+    if len(values) < BID_FLOOR_THRESHOLD:
+        return Gwei(0)
+    return Gwei(values[BID_FLOOR_THRESHOLD - 1])
+```
+
+### External-bid floor enforcement
+
+An honest proposer MUST NOT select an external bid for which:
+
+```text
+selected_bid.gross_value < local_ptc_floor
+```
+
+An honest validator MUST treat a beacon block selecting such an external bid, and descendants of that block, as ineligible for head selection in its local fork choice. It MUST NOT attest to that block as its head while the violation applies.
+
+The floor is a fork-choice eligibility rule, not a state-transition validity rule. Honest nodes can have different floors because timely message receipt is local.
+
+The floor MUST NOT change the amount charged for a selected bid. In particular, this EIP does not charge a proposer or validator `t * (F - G)` and does not define `burn = t * max(G, F)`.
+
+PTC reports do not need to be included in the beacon block. Proposer omission MUST NOT remove a locally received report from fork-choice enforcement. A future specification MAY define inclusion or aggregation for rewards and auditability, but inclusion MUST NOT be what gives a report force.
 
 ### Self-built payloads
 
@@ -535,19 +733,24 @@ gross_value == 0
 execution_payment == 0
 ```
 
-A self-built payload does not create a burn.
+A self-built payload does not create an external auction target or pending builder settlement. The external PTC floor does not apply.
 
-The protocol does not estimate MEV that a proposer keeps inside a self-built payload.
+The execution layer MUST still calculate `T` and burn `U` for the executed payload.
+
+The protocol does not estimate MEV that a proposer keeps inside a self-built payload and does not attempt to prove who physically constructed it.
 
 ### Burn observability
 
-For each selected external-builder bid, canonical data MUST make these values derivable:
+For each executed payload and, where applicable, selected external-builder bid, canonical data MUST make these values derivable:
 
 ```text
 slot
 builder_index
 gross_value
-burn_amount
+priority_fee_value
+priority_fee_burn
+burn_target
+builder_burn
 trustless_payment
 execution_payment
 settlement outcome
@@ -555,9 +758,11 @@ settlement outcome
 
 The signed bid is the source of truth for `gross_value` and `execution_payment`.
 
-Consensus derives `burn_amount` and `trustless_payment`.
+Execution derives `priority_fee_value` and `priority_fee_burn`. Consensus derives `burn_target`, `builder_burn`, and `trustless_payment`.
 
 Consensus clients SHOULD expose these values through a stable state-inspection, event, or API surface.
+
+Clients SHOULD also expose locally timely PTC reports, verified bid evidence, and the local `F` used for fork-choice decisions.
 
 This exposure supports supply accounting and post-fork economic analysis.
 
@@ -565,21 +770,23 @@ This EIP does not define a specific API endpoint.
 
 ## Rationale
 
-### Why `gross_value` includes all builder expenditure
+### Why `gross_value` defines the external target
 
-`gross_value` is the total economic expenditure in the selected builder bid.
+`gross_value` is the signed external-bid amount that determines the auction target and declared proposer compensation.
 
-It includes the burn and all declared proposer compensation:
+At bid time it decomposes into the reserved auction target and all declared proposer compensation:
 
 ```text
-G = B + V + E
+G = A + V + E
 ```
 
 This definition keeps the burn fraction easy to understand.
 
-At a one-third burn rate, the protocol destroys about one third of the builder's declared gross expenditure. The remaining amount is proposer compensation.
+At a one-third rate, `A` is about one third of `G`. The remaining amount is declared proposer compensation.
 
-The burn is not a charge on proposer revenue. The protocol removes the burn from the builder's gross bid. The proposer revenue is only the net amount `P = G - B`.
+The auction target is not a charge on the declared proposer payment. The proposer-payment calculation is `P = G - A` even when `U` later reduces the builder top-up.
+
+Because priority-fee burn counts toward `A`, the builder's realized consensus-layer deduction can be smaller than the bid-time reserve. `gross_value` therefore defines the external commitment and target calculation; it is not a promise that every component is ultimately deducted from builder balance.
 
 An alternative definition could make `gross_value` equal only to proposer compensation. The burn would then be an extra cost on top of `gross_value`.
 
@@ -594,7 +801,7 @@ The builder supplies only two monetary fields:
 - `gross_value`;
 - `execution_payment`.
 
-Consensus derives `burn_amount` and `trustless_payment`.
+Consensus derives `burn_target` and `trustless_payment`. After payload execution, it derives `builder_burn` from `burn_target` and `priority_fee_burn`.
 
 This design removes redundant monetary fields.
 
@@ -612,19 +819,19 @@ Large collateral requirements can favor the largest builders.
 
 `execution_payment` keeps the EIP-7732 distinction between trustless and trusted proposer compensation.
 
-The builder fully collateralizes its protocol commitments:
+The builder fully collateralizes its protocol commitments at bid time:
 
 ```text
-C = B + V
+C = A + V
 ```
 
 The builder does not collateralize `E` through consensus.
 
-The burn still uses `G`. It does not use only `V`.
+The auction target still uses `G`. It does not use only `V`.
 
 Therefore, a declared trusted payment does not remove its share of the burn.
 
-If a builder increases `G` to advertise a larger trusted payment, the builder also increases its fully collateralized burn liability.
+If a builder increases `G` to advertise a larger trusted payment, the builder also increases its fully reserved auction target.
 
 This makes a false high trusted-payment declaration more expensive than a design that burns only the trustless payment.
 
@@ -652,7 +859,7 @@ This EIP does not set a minimum `V`.
 
 A proposer can accept a private bid in which some or all proposer compensation is trusted.
 
-The protocol still fully collateralizes the burn and any nonzero trustless payment.
+The protocol still fully collateralizes the auction target and any nonzero trustless payment at bid time.
 
 A minimum `V` would make consensus choose an arbitrary credit-risk floor.
 
@@ -670,33 +877,45 @@ A rule that asks a self-builder to declare its own MEV is not enforceable.
 
 A self-builder can keep value in many execution-layer accounts. A self-builder can also use private order flow or integrated search.
 
-Therefore, self-build has no burn under this EIP.
+Therefore, self-build has no external auction target or bid floor under this EIP. Its executed priority fees still produce `U`.
 
 The exemption also keeps local building as a fallback against builder concentration.
 
-Local building is often most competitive in low-value slots. The burn on external builder payments can increase local building in this part of the distribution.
+Local building is often most competitive in low-value slots. The external auction target can increase local building in this part of the distribution.
 
-A large staking operator can also own a builder and use self-build to avoid the burn on high-value slots. The "Self-build avoidance and vertical integration" subsection describes this risk.
+A large staking operator can also own a builder and use self-build to avoid the external target and floor on high-value slots. The "Outsourced self-build avoidance" subsection describes this risk.
 
-### Why there is no attester burn floor
+### Why use a robust PTC-observed floor
 
-A burn floor based on bids that each attester saw before a deadline is not an objective consensus value.
+Ordinary propagation differences mean PTC members can receive different high bids. Requiring a threshold to report the exact same `bid_root` would discard useful evidence.
 
-Honest nodes can receive different bids because of normal network delay.
+Each PTC member instead reports its best actual eligible bid. Selecting the `q`-th greatest distinct-member maximum gives the highest value supported by at least `q` observations, even when those observations reference different bids.
 
-An attacker can also send a bid to only part of the network.
+Every positive observation remains backed by an individually signed, collateral-backed builder commitment.
 
-Different local bid sets can create different local burn floors.
+### Why the floor threshold remains TBD
 
-This EIP does not use local bid observations for burn decisions.
+A low threshold lets a small number of selectively targeted or malicious reports create a high local floor. A high threshold makes report suppression and ordinary propagation failures more likely to reduce `F` to zero.
 
-Attesters do not price MEV. Attesters do not add a burn rule to fork choice.
+The correct trade-off depends on measured bid propagation, PTC size, topology, and adversarial simulations. This EIP does not assume that the EIP-7732 builder-payment quorum or a fixed percentage is also the correct floor threshold.
 
-The protocol derives the burn from the selected signed bid and a chain constant.
+### Why the floor does not depend on proposer inclusion
 
-### Why burn and payment use one settlement lifecycle
+If block inclusion gave reports force, a colluding proposer could omit them and select a low external bid. Direct gossip makes omission ineffective for validators that already received the reports.
 
-The burn and the trustless proposer payment come from the same builder commitment.
+Later inclusion or aggregation can support rewards and auditability, but it cannot be the source of the local eligibility rule.
+
+### Objective burn and subjective eligibility
+
+The amount burned remains objective. `U` comes from canonical execution, `A` comes from the canonical signed bid, and `D` is a deterministic function of the two.
+
+The external-bid floor is subjective because it depends on timely local PTC reports. Local observations constrain which external `gross_value` an honest validator supports; they do not enter supply accounting.
+
+PTC members do not estimate MEV. They report real eligible public commitments observed before the deadline.
+
+### Why target and payment use one settlement lifecycle
+
+The auction target and the trustless proposer payment come from the same builder commitment.
 
 A separate liability rule for the burn can create an error during a reorganization or withholding case.
 
@@ -704,17 +923,17 @@ For example, one path could charge the burn while another path releases the prop
 
 `BuilderPendingSettlement` prevents this split.
 
-One state object contains both protocol liabilities. One liability transition resolves both liabilities.
+One state object contains both protocol liabilities. One liability transition makes both payable or releases both.
 
-### Why the burn occurs in the consensus layer
+Final burn realization is deferred because `U` is known only after payload execution. Deferral does not reduce collateral: the full `A` remains reserved until the execution result or canonical no-payload outcome is known.
 
-EIP-7732 stores builder balance in the consensus layer.
+### Why the burn occurs in both layers
 
-The protocol can destroy `B` by reducing that balance without creating a matching withdrawal.
+The execution layer destroys `U` by withholding it from priority-fee credit. EIP-7732 stores builder balance in the consensus layer, so consensus destroys the remaining `D` by reducing that balance without creating a matching withdrawal.
 
-The protocol must not send `B` to an execution-layer burn address.
+The protocol must not send `D` to an execution-layer burn address.
 
-An execution-layer burn address still has an execution-layer balance. It does not express direct consensus-layer supply destruction.
+An execution-layer burn address still has an execution-layer balance. It does not express direct supply destruction.
 
 ### Proposed burn fraction and historical scale
 
@@ -729,9 +948,9 @@ During this period:
 - gross MEV-Boost proposer payments were approximately 72,619 ETH;
 - execution base-fee burn was approximately 27,546 ETH.
 
-The following table is a static backcast. It does not include behavioral changes after a burn is introduced.
+The following table is a static backcast of external auction targets. It does not include priority-fee burn, overlap between `U` and `A`, the PTC floor, or behavioral changes.
 
-| Burn rate | Additional builder-payment burn | Relative to execution base-fee burn | Proposer share of gross bid |
+| Burn rate | External auction target | Relative to execution base-fee burn | Proposer share of gross bid |
 | ---: | ---: | ---: | ---: |
 | 25% | about 18,155 ETH | about 65.9% | 75% |
 | 33 1/3% | about 24,206 ETH | about 87.9% | about 66 2/3% |
@@ -749,7 +968,7 @@ The same aggregate data gives these approximate values per scheduled slot:
 | 33 1/3% builder-payment burn | 0.0092 |
 | 40% builder-payment burn | 0.0111 |
 
-These numbers show the possible scale of the mechanism. They do not predict the final market result.
+These numbers show the possible scale of `A`. They do not predict total realized burn. For an executed external payload, total MEV burn is `max(U, A)`, not `U + A`.
 
 A burn can change proposer and builder behavior. It can change how much value stays in declared external-builder bids.
 
@@ -758,7 +977,7 @@ Let `q(t)` be the fraction of baseline gross builder-payment value that remains 
 Then:
 
 ```text
-realized_burn(t) = t * q(t) * baseline_gross_value
+external_auction_target(t) = t * q(t) * baseline_gross_value
 ```
 
 This equation gives direct tests for candidate rates.
@@ -766,18 +985,18 @@ This equation gives direct tests for candidate rates.
 For example:
 
 ```text
-one-third burn is greater than 25% burn if:
+one-third external target is greater than the 25% target if:
 q(1/3) / q(1/4) > 0.75
 ```
 
 Also:
 
 ```text
-40% burn is greater than one-third burn if:
+40% external target is greater than the one-third target if:
 q(0.40) / q(1/3) > 0.8333
 ```
 
-A higher rate is counterproductive if it causes enough gross value to leave the bid path where the burn applies.
+A higher rate can reduce the external-target component if it causes enough gross value to leave the bid path. The universal priority-fee burn continues to apply to executed payloads on other paths.
 
 For an expenditure-inclusive bid, the extra gross expenditure that is required to give a fixed proposer payment is:
 
@@ -793,7 +1012,7 @@ The following table shows this amount:
 | 33 1/3% | 50% |
 | 40% | 66.7% |
 
-A higher rate gives more reason to use self-build or undeclared payment channels.
+A higher rate gives more reason to use self-build or undeclared payment channels. The PTC floor limits low-`G` avoidance on the normal external path when enough competitive reports propagate.
 
 For this reason, payment retention and self-build behavior are primary evaluation metrics.
 
@@ -801,19 +1020,21 @@ For this reason, payment retention and self-build behavior are primary evaluatio
 
 Before mainnet activation, evaluations should measure these items:
 
-1. The value-weighted share of builder payments that stays in declared ePBS `gross_value`.
-2. The public-bid share and the private-bid share.
-3. The distribution of `execution_payment / proposer_amount`.
-4. Self-build share by block count.
-5. Self-build share by estimated value that would otherwise go to an external builder.
-6. High-value self-build concentration by identifiable staking operator.
-7. Builder market concentration.
-8. Builder collateral concentration.
-9. Proposer-payment percentiles, including p50, p95, p99, and p99.9.
-10. Realized burn as a fraction of declared gross external-builder value.
-11. Trusted-payment defaults when they are observable.
-12. Missed-payload and missed-proposal rates.
-13. The gap between shadow local payload value and the best external bid.
+1. Priority-fee value and priority-fee burn distributions.
+2. The gap between `A`, `U`, and the realized builder top-up `D`.
+3. The value-weighted share of builder payments that stays in declared ePBS `gross_value`.
+4. The public-bid share and the private-bid share.
+5. The distribution of `execution_payment / proposer_amount`.
+6. PTC public-bid propagation by deadline and network region.
+7. The distribution of distinct PTC report values and bid roots.
+8. Frequency and duration of honest-node floor disagreement.
+9. Below-floor external blocks and their fork-choice outcomes.
+10. Self-build share by block count and estimated value.
+11. High-value self-build concentration by identifiable staking operator.
+12. Builder market and collateral concentration.
+13. Proposer-payment percentiles, including p50, p95, p99, and p99.9.
+14. Trusted-payment defaults when they are observable.
+15. Missed-payload and missed-proposal rates.
 
 The burn rate should not be selected only to reach a target amount of ETH burn.
 
@@ -823,17 +1044,21 @@ The mechanism must also keep enough value in protocol-visible external bidding t
 
 ## Backwards Compatibility
 
-This EIP changes consensus and requires a hard fork.
+This EIP changes execution consensus, consensus-layer state transition, networking, honest validator behavior, and fork choice. It requires a hard fork.
 
 It changes the SSZ semantics and field name of `ExecutionPayloadBid.value` to `gross_value`. The field keeps its position and its type. The container layout does not change.
 
-It changes the builder pending-payment state object.
+It changes the builder pending-payment state object and settlement lifecycle.
 
 It changes builder collateral accounting.
 
+It adds the universal priority-fee burn and an EL-to-CL accounting result.
+
+It adds `BidFloorMessage`, `SignedBidFloorMessage`, `DOMAIN_BID_FLOOR`, and the `bid_floor_message` gossip topic.
+
 A pre-fork signed bid is not valid as a post-fork bid.
 
-Consensus clients, validator clients, builders, relays, and APIs must use the new bid semantics after activation.
+Execution clients, consensus clients, validator clients, builders, relays, and APIs must use the new semantics after activation.
 
 The public bid path keeps the same trust model. Public bids still have `execution_payment == 0`. Public bids are fully collateralized. Public bids use one scalar value for ordering.
 
@@ -842,6 +1067,24 @@ The public bid path keeps the same trust model. Public bids still have `executio
 The following examples use a one-third burn rate.
 
 The examples use simple integer units.
+
+### Universal priority-fee burn
+
+Input:
+
+```text
+transaction priority-fee values = [120, 60, 120]
+T = 300
+```
+
+Expected result:
+
+```text
+U = 100
+fee-recipient priority-fee credit = 200
+```
+
+The EIP-1559 base-fee burn is additional and is not included in `U`.
 
 ### Fully trustless public bid
 
@@ -855,7 +1098,7 @@ E = 0
 Expected result:
 
 ```text
-B = 3
+A = 3
 P = 6
 V = 6
 C = 9
@@ -863,7 +1106,7 @@ C = 9
 
 The bid is valid for public gossip.
 
-The builder needs 9 units of consensus collateral.
+The builder needs 9 units of consensus collateral. A later `U` reduces only the realized builder top-up, not `P`, `V`, or bid-time collateral.
 
 ### Partially trusted private bid
 
@@ -877,7 +1120,7 @@ E = 2
 Expected result:
 
 ```text
-B = 3
+A = 3
 P = 6
 V = 4
 C = 7
@@ -899,7 +1142,7 @@ E = 6
 Expected result:
 
 ```text
-B = 3
+A = 3
 P = 6
 V = 0
 C = 3
@@ -907,7 +1150,7 @@ C = 3
 
 The bid is valid only through a private or relay path.
 
-The burn is fully collateralized.
+The auction target is fully collateralized.
 
 The proposer payment is fully trusted.
 
@@ -925,7 +1168,7 @@ E = 7
 Derived values:
 
 ```text
-B = 3
+A = 3
 P = 6
 ```
 
@@ -943,7 +1186,7 @@ E = 0
 Expected result:
 
 ```text
-B = 3
+A = 3
 P = 7
 V = 7
 C = 10
@@ -965,13 +1208,13 @@ E = 0
 Expected result:
 
 ```text
-B = 0
+A = 0
 P = 9
 V = 9
 C = 9
 ```
 
-The payment accounting is equivalent to the fully trustless EIP-7732 payment path after mapping `gross_value` to the former trustless bid value.
+Both the priority-fee burn and external auction target are disabled. Payment accounting is equivalent to the fully trustless EIP-7732 payment path after mapping `gross_value` to the former trustless bid value.
 
 ### Full burn rate
 
@@ -987,7 +1230,7 @@ E = 0
 Expected result:
 
 ```text
-B = 9
+A = 9
 P = 0
 V = 0
 C = 9
@@ -1009,7 +1252,7 @@ E = 0
 Expected result:
 
 ```text
-B = 12297829382473034410
+A = 12297829382473034410
 P = 6148914691236517205
 V = 6148914691236517205
 C = 18446744073709551615
@@ -1025,17 +1268,19 @@ Input:
 builder_index = BUILDER_INDEX_SELF_BUILD
 G = 0
 E = 0
+T = 3
 ```
 
 Expected result:
 
 ```text
-B = 0
+A = 0
 V = 0
 C = 0
+U = 1
 ```
 
-The protocol does not create a pending settlement.
+The protocol does not create a pending builder settlement. The execution layer burns one unit of priority fees.
 
 A self-build is invalid if `G != 0` or `E != 0`.
 
@@ -1054,32 +1299,35 @@ A deduction that leaves at least 9 units can satisfy this EIP invariant. Other E
 Given this pending settlement:
 
 ```text
-B = 3
+A = 3
 V = 6
+U = 1
 ```
 
 When the normal EIP-7732 payment path makes the settlement payable, consensus must do these actions:
 
-1. Decrease the builder consensus balance by 3.
-2. Queue a builder withdrawal of 6 for the proposer.
-3. Clear the pending settlement.
+1. Queue a builder withdrawal of 6 for the proposer.
+2. Retain the full target reserve until `U` is known.
+3. Decrease the builder consensus balance by `D = 2`.
+4. Release the unused one unit of target reserve.
+5. Clear the settlement.
 
 ### Quorum settlement without the normal payload path
 
-Use the same pending settlement:
+Use this pending settlement:
 
 ```text
-B = 3
+A = 3
 V = 6
 ```
 
-If the EIP-7732 builder-payment quorum makes the settlement payable, consensus must do the same actions:
+If the EIP-7732 builder-payment quorum makes the settlement payable before the payload accounting result is known:
 
-1. Decrease the builder consensus balance by 3.
-2. Queue a builder withdrawal of 6.
-3. Clear the pending settlement.
+1. Queue a builder withdrawal of 6 exactly once.
+2. Keep all 3 units of `A` reserved.
+3. Defer the builder burn.
 
-The burn and trustless payment must have the same result.
+If the canonical outcome later resolves to no executed payload, set `U = 0`, deduct all 3 units, and clear the reserve. If a valid canonical execution result supplies `U`, deduct only `max(0, 3 - U)`.
 
 ### Released settlement
 
@@ -1096,190 +1344,188 @@ Consensus must clear the pending settlement.
 
 A parent payload can arrive after its pending settlement leaves the bounded pending-settlement window.
 
-In this case, the implementation must derive `B` and `V` from the cached bid.
+In this case, the implementation must derive `A` and `V` from the cached bid and obtain `U` from the canonical payload result.
 
-The implementation must apply both components in the same settlement operation.
+The implementation must queue `V` at most once and deduct `max(0, A - U)` at most once.
 
-A test must fail if the implementation can queue `V` without also applying `B`.
+A test must fail if the implementation can charge both `A` and `D`, reuse noncanonical `U`, release the same reserve twice, or queue `V` twice.
+
+### External target with priority-fee credit
+
+Input:
+
+```text
+G = 9 ETH
+T = 0.3 ETH
+rate = 1/3
+```
+
+Expected result:
+
+```text
+A = 3.0 ETH
+U = 0.1 ETH
+D = 2.9 ETH
+total_mev_burn = 3.0 ETH
+```
+
+### Robust PTC floor
+
+Use `BID_FLOOR_THRESHOLD = 10` and these distinct-member maxima:
+
+```text
+10.0, 10.0, 9.9, 9.9, 9.8, 9.8, 9.7, 9.7,
+9.5, 9.4, 8.9, 8.8, 8.7, 8.6, 8.5, 8.0
+```
+
+Expected result:
+
+```text
+F = 9.4
+```
+
+The reports may reference different signed bid roots.
+
+### Floor enforcement
+
+Given `F = 9 ETH`:
+
+```text
+external G = 1 ETH  -> locally ineligible for head selection
+external G = 9 ETH  -> locally eligible
+self-build          -> locally eligible regardless of F
+```
+
+The first external block is not made state-transition invalid; it is excluded by honest local fork choice.
+
+With fewer than `BID_FLOOR_THRESHOLD` distinct compatible positive reports, `F = 0`.
 
 ## Reference Implementation
 
-A complete reference implementation requires a consensus-spec change against the final post-EIP-7732 fork specification.
+A complete reference implementation requires coordinated changes to the execution specification, Engine API, Gloas beacon-chain specification, P2P specification, fork choice, and honest validator guide.
 
-The Specification section is the normative source for an implementation. It defines the modified `ExecutionPayloadBid`, the `BuilderPendingSettlement` state object, the burn and payment helpers, and the settlement, liability, and gossip rules.
+The Specification section is the normative source for an implementation. The principal open integration items are the common accounting unit and Engine API encoding for `T` and `U`, the consensus-state encoding and bounded lifetime of a payable-but-burn-unresolved reserve, and final mainnet values for the bid-floor deadline, threshold, and domain.
 
 ## Security Considerations
 
+### Competitive under-declaration
+
+Without the PTC floor, an external builder and proposer can declare a low `G`, transfer the remaining compensation through a side channel, and reduce the auction target toward zero.
+
+With the floor, an honest validator that received enough competing public-bid reports does not support that low-`G` external block. The mechanism therefore removes trivial bilateral under-declaration from the normal external ePBS path when competing public bids propagate to the PTC threshold.
+
+It does not make MEV burn coalition-proof. Avoidance remains possible when actors can suppress enough bids or reports, possess value that competitors cannot price, receive value after the deadline, corrupt the relevant PTC view, or leave the external-builder path.
+
+### Bid and report suppression
+
+The floor depends on public bids reaching PTC members and PTC reports reaching validators before the target slot.
+
+An adversary can try to eclipse PTC members, selectively distribute bids, delay reports, or deny service to the new topic. If fewer than `BID_FLOOR_THRESHOLD` compatible reports reach a validator, its floor is zero.
+
+Threshold and deadline selection must account for ordinary propagation failures as well as targeted suppression. Clients should expose report receipt and evidence metrics so suppression is observable.
+
+### Selective high reports and fork-choice divergence
+
+A valid high bid or report sent to only part of the network can create different local floors. Honest nodes can then disagree about whether a lower external bid is eligible.
+
+Requiring threshold support limits the influence of one report but does not eliminate this risk. A malicious coalition at or above the threshold can selectively raise floors. The reported bids are real signed, collateral-backed commitments, but selective propagation can still cause temporary fork-choice divergence.
+
+The floor threshold, observation deadline, report propagation time, and fork-choice recovery behavior require adversarial network analysis before activation.
+
+### PTC misreporting and equivocation
+
+A PTC member can omit a higher bid it observed. The protocol cannot prove receipt and therefore cannot prove that a report was the member's true maximum.
+
+A positive false-value report is constrained by the requirement to provide a matching eligible signed builder bid. A member cannot invent a higher `gross_value` without builder cooperation and sufficient collateral for the referenced bid.
+
+Equivocation is publicly provable from signed messages. This EIP uses the highest valid report per member locally and does not define a slashing penalty. A future proposal may add rewards, inclusion, or penalties without making proposer inclusion the source of floor enforcement.
+
+### Late and exclusive MEV
+
+The floor reflects public bids observed by the deadline. It cannot price MEV that becomes available afterward or is visible only to an exclusive builder.
+
+A proposer and builder with exclusive late value may select an external bid at the existing floor and move additional compensation off protocol. The universal priority-fee burn still applies, but private value not expressed as priority fees or `gross_value` is not burned.
+
+### Outsourced self-build avoidance
+
+A proposer and external constructor can avoid the external bid floor and auction target by presenting the payload through `BUILDER_INDEX_SELF_BUILD`.
+
+The protocol cannot prove who physically constructed a payload. An external constructor using this path does not receive the normal ePBS builder relationship. It must reveal payload or order-flow information before proposer authorization, or use an off-protocol mechanism that lets the proposer authorize a payload it did not independently construct or inspect.
+
+Vertically integrated proposer-builders have lower costs for this path. High-value outsourced and integrated self-build concentration is therefore an important residual risk.
+
+Every executed payload on this path still pays the universal priority-fee burn.
+
 ### Undeclared proposer compensation
 
-Ethereum can burn only value that appears in consensus-visible bid data.
+Ethereum can burn only protocol-visible priority fees, signed bid value, and collateralized builder balance.
 
-A builder and proposer can try to move compensation outside `gross_value`.
-
-Examples include later transfers, bilateral agreements, vertically integrated accounting, or other side payments.
-
-This EIP does not make undeclared value observable.
-
-This EIP does not claim to burn undeclared value.
-
-A higher burn fraction gives a stronger incentive to use a payment path where the burn does not apply.
-
-For this reason, mainnet activation should use measurements or simulations of value-weighted payment retention for candidate rates.
-
-### Collusion and evasion economics
-
-This EIP does not prevent collusion.
-
-Two evasion paths remain open:
-
-- A group of builders can agree to declare a low `gross_value`. They can settle the rest through another channel.
-- A builder and a proposer can agree to declare a low `gross_value`. They can move the rest through a side payment.
-
-Each path can reduce the declared burn to near zero for the affected bids. The protocol cannot burn value that does not appear in a signed bid. The "Undeclared proposer compensation" and "Self-build avoidance and vertical integration" subsections describe this same limit.
-
-The partial burn fraction is a deliberate response to this limit. The rate does not try to capture all execution value. The rate stays below the value at which evasion is worthwhile in the common case.
-
-Two properties support a moderate rate.
-
-First, most slots have modest builder payments. A fraction of a small payment is a small amount. The fixed cost and the counterparty risk of a side channel are larger than this burn. The fixed cost and the counterparty risk of a sustained cartel are also larger than this burn. For most blocks and most proposers, honest declaration through the public bid path costs less than evasion.
-
-Second, the large and rare opportunities occur in unpredictable slots. A builder cannot move a high-value opportunity to a chosen proposer. A proposer cannot choose to receive one. A single high-value opportunity occurs in one slot. That slot has one fixed proposer. To evade the burn on this tail, an actor needs one of two things. The first is a standing side channel with a large share of proposers. The second is a builder and a large staker under one control that self-builds these slots. In a competitive builder market, the proposer for the slot selects the best public bid, and the burn applies.
-
-A higher rate would increase the reward for evasion in every block. A higher rate would lower the value at which a side channel or a cartel becomes worthwhile. A higher rate would move more value out of the bid path where the burn applies. The `q(t)` analysis in the Rationale describes this effect.
-
-A moderate rate keeps the public bid path the lowest-cost path for most blocks. A moderate rate still burns a meaningful share of the visible high-value tail that lands on proposers outside a cartel.
-
-This reasoning reduces the incentive to evade. It does not remove the evasion paths. A sustained builder cartel is a residual risk. A vertically integrated large staker is also a residual risk. Evaluation must measure declared payment retention and high-value self-build concentration. The "Rate evaluation metrics" subsection lists these measurements.
+Later transfers, bilateral agreements, vertically integrated accounting, and other side payments remain outside direct measurement. The competitive floor raises the cost of under-declaration when public competition exists; it does not make undeclared value observable.
 
 ### Trusted payment default
 
 `execution_payment` remains trusted.
 
-A proposer that accepts `E > 0` accepts counterparty risk.
+A proposer that accepts `E > 0` accepts counterparty risk. Consensus does not insure that risk.
 
-Consensus does not insure that risk.
-
-This EIP makes a large declared trusted payment costly to exaggerate if it increases `G`.
-
-A larger `G` causes a larger fully collateralized burn.
-
-However, the builder can still fail to deliver `E`.
-
-The public gossip path avoids this risk because it requires `E == 0`.
+A larger `G` causes a larger fully collateralized auction target, but the builder can still fail to deliver `E`. The public gossip path avoids this risk because it requires `E == 0`.
 
 ### Proposer ranking across trust classes
 
-The burn increases with `gross_value`.
+The auction target increases with `gross_value`.
 
-A rational proposer values a private bid according to the expected value of the trusted payment.
+A rational proposer values a private bid according to the expected value of its trusted payment. The proposer can therefore select a lower-`gross_value` bid if another bid has more trusted-payment risk, provided the selected external bid is not below `F`.
 
-Therefore, the proposer can select a lower-`gross_value` bid if the other bid has more trusted-payment risk.
-
-This result is normal credit-risk pricing. It is not a consensus failure.
-
-The protocol does not define a global credit model.
-
-### Self-build avoidance and vertical integration
-
-Self-build has no burn because the protocol cannot objectively measure internal MEV.
-
-This exemption can create an avoidance path.
-
-A large staking operator can own or control a specialized builder. The operator can then use self-build for valuable slots.
-
-If high-value external-builder slots move to integrated self-build, realized burn can decrease.
-
-This behavior can also increase the advantage of large or vertically integrated staking operators.
-
-Evaluation must measure more than the self-build block count.
-
-Evaluation should estimate the value that moved from external bidding to self-build.
-
-Evaluation should also measure the concentration of high-value self-build by operator.
+This is normal credit-risk pricing. The protocol does not define a global credit model.
 
 ### Builder capital concentration
 
-The builder must fully collateralize the burn.
+The builder must reserve the full `A + V` even when `U` may later reduce the realized builder burn. A fully trustless public bid therefore requires collateral for all of `G`.
 
-A fully trustless public bid requires collateral for all of `G`.
-
-A private bid can reduce consensus collateral by using `E` for part of proposer compensation.
-
-A high burn rate still creates material collateral requirements.
-
-Exceptional-MEV slots can create especially large requirements.
-
-Multiple pending liabilities can also increase working-capital needs.
-
-Large collateral requirements can favor large builders.
+Exceptional slots, multiple pending liabilities, and delayed release of unused burn reserves can create large working-capital requirements. These requirements can favor large builders.
 
 Builder balance concentration and builder market concentration should be measured before and after activation.
 
 ### Residual proposer jackpots
 
-A proportional burn reduces a visible proposer payment by the configured fraction.
+The mechanism does not burn all execution value.
 
-It does not remove the remaining payment.
+At a one-third rate, about two thirds of a fully trustless declared gross bid remains proposer compensation. Priority fees not included in `U` also remain available to the fee recipient.
 
-At a one-third burn rate, about two thirds of a fully trustless gross bid remains proposer compensation.
-
-An exceptional bid can therefore still create a large proposer windfall.
-
-Large remaining windfalls can preserve incentives for reorganization, key theft, targeted denial of service, or operator misconduct.
-
-For security analysis, proposer-payment percentiles are more useful than aggregate burn alone.
-
-The analysis should include p99 and p99.9 proposer payments.
+Exceptional remaining payments can preserve incentives for reorganization, key theft, targeted denial of service, or operator misconduct. Security analysis should examine tail proposer-payment percentiles rather than aggregate burn alone.
 
 ### Builder payload withholding
 
 This EIP does not solve the EIP-7732 builder free-option or payload-withholding problem.
 
-This EIP changes the destination of a payable builder commitment.
-
-This EIP does not add a delivery bond or a new withholding penalty.
-
-A future EIP-7732 liability change must preserve the atomic relationship between `B` and `V`.
+For a payable no-payload path, the builder pays the full `A` because there is no executed priority-fee burn to count toward the target. This changes burn realization but does not add a delivery bond or withholding penalty.
 
 ### Reorganizations and liability coupling
 
-The burn and the trustless proposer payment must use the same payable condition.
+The `PAYABLE` or `RELEASED` decision must remain atomic for `A` and `V`. Burn realization is later, but it must be tied to the same settlement and canonical payload outcome.
 
-An implementation must not charge the burn before the shared liability decision.
+An implementation must not:
 
-An implementation must not release one component and charge the other component.
+- queue `V` twice;
+- charge both `A` and `D`;
+- count `U` from a noncanonical payload;
+- release `A` after a payable no-payload outcome;
+- retain an unresolved reserve after final realization; or
+- let a builder exit while any related liability remains.
 
-An incorrect implementation can create supply-accounting errors or unfair builder losses.
-
-Tests must cover reorganization, proposer slashing, payload absence, quorum payment, and delayed payload processing.
+Tests must cover proposer slashing, reorganization, payload absence, quorum payment, delayed payload processing, and settlement eviction.
 
 ### Supply accounting
 
-The burn decreases a consensus-layer builder balance.
+`U` is destroyed by withholding that amount from the execution-layer priority-fee credit. `D` is destroyed by decreasing consensus-layer builder balance without a matching withdrawal.
 
-The protocol does not create an execution-layer withdrawal for the burned amount.
+Supply accounting must count each component exactly once. Neither component may be represented as a transfer to an execution-layer burn address.
 
-Supply accounting must count the destruction exactly once.
+### Integer arithmetic and cross-layer agreement
 
-The protocol must not also represent the burn as an execution-layer transfer or withdrawal.
+All burn calculations use integer floor division. Implementations must not use floating-point arithmetic or overflow fixed-width intermediates.
 
-### Integer arithmetic and rounding
-
-The burn uses integer floor division.
-
-The division remainder stays in proposer compensation.
-
-Implementations must not use floating-point arithmetic.
-
-Implementations must not allow intermediate overflow in the burn calculation. This requirement applies even when `gross_value` is near the maximum `Gwei` value and the configured numerator is greater than one.
-
-All implementations must calculate the same integer result.
-
-### No new attester pricing duty
-
-An implementation must not reject an otherwise valid block because the node saw a higher builder bid locally.
-
-This requirement prevents consensus behavior from depending on local message history. The "Why there is no attester burn floor" subsection explains why the burn does not use local bid observations.
+Execution and consensus clients must agree on the common accounting unit, `T`, and `U`. A mismatch can change builder balances and supply. Priority-fee rounding, the Engine API result, late payload processing, and reserve release all require consensus test vectors.
 
 ## Copyright
 

--- a/EIPS/eip-8375.md
+++ b/EIPS/eip-8375.md
@@ -84,6 +84,7 @@ For an executed payload and, where applicable, one selected external-builder bid
 - `V`: `trustless_payment`. Consensus guarantees this proposer-payment amount.
 - `C`: `consensus_liability`. The builder MUST cover this amount with consensus-layer builder balance.
 - `F`: the robust local PTC-observed public-bid floor.
+- `H`: the local floor after applying the configured haircut.
 
 The following equations MUST hold, using the burn constants defined in Configuration below:
 
@@ -139,6 +140,7 @@ Add:
 ```python
 BID_FLOOR_DUE_BPS = uint64(TBD)
 BID_FLOOR_THRESHOLD = uint64(TBD)
+BID_FLOOR_HAIRCUT_BPS = uint64(TBD)
 DOMAIN_BID_FLOOR = DomainType('0x0F000000')
 ```
 
@@ -146,9 +148,11 @@ DOMAIN_BID_FLOOR = DomainType('0x0F000000')
 
 `BID_FLOOR_DUE_BPS` is measured in basis points into the slot immediately preceding the report's `target_slot`. It ends the public-bid observation window.
 
-`BID_FLOOR_DUE_BPS` MUST be less than `10_000`, leaving time for reports to propagate before `target_slot`.
+`BID_FLOOR_DUE_BPS` MUST be less than `10_000`, leaving time for reports to propagate before `target_slot`. Its selection MUST account for concurrent pre-proposal deadlines, including [EIP-7805](./eip-7805.md) inclusion-list freezing when active.
 
 `BID_FLOOR_THRESHOLD` is a number of distinct target-slot PTC members. Its mainnet value is TBD pending propagation and adversarial analysis. It MUST be greater than zero and MUST NOT exceed `PTC_SIZE`.
+
+`BID_FLOOR_HAIRCUT_BPS` is the proportional margin below `F`. It MUST be less than `10_000`.
 
 The active values MUST be part of chain configuration and MUST NOT change without a protocol upgrade.
 
@@ -681,9 +685,9 @@ Response: zero or more SignedExecutionPayloadBid chunks
 
 Each request root is `hash_tree_root(signed_bid)`. A response MUST contain no more than one bid for each requested root, MUST NOT contain an unrequested bid, and MAY omit an unavailable bid. Each chunk uses the fork digest for the epoch containing the bid's slot.
 
-A PTC member that publishes a positive report MUST retain and serve its referenced signed bid until the start of `target_slot + 1`. A node that obtains the bid SHOULD serve it for the same period.
+A PTC member that publishes a positive report MUST retain and serve its referenced signed bid until the start of `target_slot + 2`. A node that obtains the bid SHOULD serve it for the same period.
 
-When a validator receives a positive report but lacks its bid, it MUST defer validation and request the bid from one or more peers. It MUST NOT count or forward the report as valid until it has verified the bid. Only reports whose evidence is verified before the target-slot snapshot contribute to `F`.
+When a validator, including a proposer, receives a positive report but lacks its bid, it MUST defer validation and request the bid from one or more peers. It MUST NOT count or forward the report as valid until it has verified the bid. Only reports whose evidence is verified before the target-slot snapshot contribute to `F`.
 
 ### Local PTC floor
 
@@ -711,23 +715,30 @@ def get_local_ptc_floor(
     if len(values) < BID_FLOOR_THRESHOLD:
         return Gwei(0)
     return Gwei(values[BID_FLOOR_THRESHOLD - 1])
+
+def get_enforced_bid_floor(floor: Gwei) -> Gwei:
+    return Gwei(
+        uint256(floor) * (10_000 - BID_FLOOR_HAIRCUT_BPS) // 10_000
+    )
 ```
+
+Set `H = get_enforced_bid_floor(F)`.
 
 ### External-bid floor enforcement
 
 When `BUILDER_PAYMENT_BURN_NUMERATOR > 0`, an honest proposer MUST NOT select an external bid for which:
 
 ```text
-selected_bid.gross_value < local_ptc_floor
+selected_bid.gross_value < H
 ```
 
-During `target_slot`, an honest validator MUST exclude such a block from head selection and MUST NOT attest to it as head. When the numerator is zero, this filter is disabled. The filter expires at the start of `target_slot + 1`. The block and its descendants then use ordinary fork choice. Prior votes are not revised.
+During `target_slot` and `target_slot + 1`, an honest validator MUST exclude such a block and its descendants from head selection and MUST NOT attest to them as head. An honest proposer applying the filter in `target_slot + 1` MUST NOT extend the filtered subtree and, absent an eligible sibling, builds on the filtered block's parent to create one. When the numerator is zero, this filter is disabled. The filter expires at the start of `target_slot + 2`; both branches then use ordinary fork choice. Prior votes are not revised.
 
 Bid-floor head filtering is independent of the EIP-7732 payload-timeliness duty. A PTC member observing a below-floor block MUST continue its normal payload observation and attestation duties for that commitment. A floor decision MUST NOT be treated as a payload-unavailability vote.
 
-The floor is not a state-transition validity rule. Its direct effect is bounded to same-slot head selection; normal LMD-GHOST consequences of those votes can persist.
+The floor is not a state-transition validity rule. Its direct effect is bounded to two slots of head selection; normal LMD-GHOST consequences of those votes can persist.
 
-Expiry does not permanently exclude the branch. A later proposer can extend it, and ordinary fork choice can make it canonical.
+Expiry does not permanently exclude the branch. If no competing proposal is produced or supported, ordinary fork choice can still make the below-floor branch canonical.
 
 The floor MUST NOT change the amount charged for a selected bid. This EIP does not charge a proposer or validator `t * (F - G)`. It does not define `burn = t * max(G, F)`.
 
@@ -774,7 +785,7 @@ Execution derives `priority_fee_value` and `priority_fee_burn` and verifies the 
 
 Consensus clients SHOULD expose these values through a stable state-inspection, event, or API surface.
 
-Clients SHOULD also expose locally timely PTC reports, verified bid evidence, and the local `F` used for fork-choice decisions.
+Clients SHOULD also expose locally timely PTC reports, verified bid evidence, and the local `F` and `H` used for fork-choice decisions.
 
 Implementations used for activation evaluation SHOULD retain signed floor reports and referenced bids long enough for cross-node analysis of high-floor self-build behavior.
 
@@ -842,19 +853,19 @@ Disclosure gives the proposer an option to copy, reorder, leak, or extract from 
 
 PTC members report signed, collateral-backed public bids, not estimates of MEV. Different members can observe different bids. The `q`-th greatest distinct-member maximum uses these observations without requiring an identical `bid_root`.
 
-The threshold trades off two failures. A low threshold makes selective delivery easier. A high threshold makes ordinary propagation failure or report suppression more likely to produce a low floor. Mainnet values must follow propagation and adversarial analysis, so the deadline and threshold remain configuration constants marked `TBD`.
+The threshold trades off two failures. A low threshold makes selective delivery easier. A high threshold makes ordinary propagation failure or report suppression more likely to produce a low floor. The haircut reduces false filtering from marginal bid-view differences but creates a bounded under-declaration band. Mainnet values must follow propagation and adversarial analysis, so all three constants remain `TBD`.
 
-Each validator freezes its report set at the start of the target slot. Late reports do not revise the floor. The below-floor filter applies only during that slot and expires at the next slot. This bounds its direct effect to one slot of head selection, although ordinary LMD-GHOST consequences can persist.
+Each validator freezes its report set at the start of the target slot. Late reports do not revise the floor. The below-floor filter remains through the next slot so an honest proposer can create a supported sibling, then expires. This bounds its direct effect to two slots of head selection, although ordinary LMD-GHOST consequences can persist.
 
 A colluding proposer cannot neutralize the rule by omitting reports from a block because timely gossip, not inclusion, gives a report effect. Signed reports make conflicting messages attributable. However, the main selective delivery attack needs only one valid report per PTC member. An equivocation penalty alone would therefore not prevent it.
 
 ### Objective accounting and deferred settlement
 
-The burn remains objective. The signed bid commits `R` in the beacon block, payload-envelope verification checks it against canonical execution, `A` comes from the bid, and `D` is a deterministic function of `A` and `R`. Local PTC observations affect only same-slot external-bid eligibility.
+The burn remains objective. The signed bid commits `R` in the beacon block, payload-envelope verification checks it against canonical execution, `A` comes from the bid, and `D` is a deterministic function of `A` and `R`. Local PTC observations affect only bounded external-bid fork-choice eligibility.
 
 One `BuilderPendingSettlement` stores the target, proposer liability, and bid-derived credit, so historical settlement does not read an uncommitted Engine API result. The `is_payable` flag records the atomic liability decision. A released entry reserves nothing. A payable entry queues `V` once; zero stored `R` resolves immediately, while nonzero `R` keeps `A` reserved until the canonical payload outcome selects stored credit for FULL or zero credit for EMPTY.
 
-The signed bid commits `R` rather than placing it only in the payload envelope because consensus creates and retains the settlement from the bid. Appending one field to the progressive bid container keeps the prior field order and lets the settlement remain self-contained. Payload-envelope verification accepts neither an overstated nor an understated `R`.
+The signed bid commits `R` rather than placing it only in the payload envelope because consensus creates and retains the settlement from the bid. Appending one field to the progressive bid container keeps the prior field order and lets the settlement remain self-contained. Payload-envelope verification accepts neither an overstated nor an understated `R`. Before payload reveal, `R < A` discloses the whole-Gwei part of `U`; a capped `R` discloses only that the cap was reached.
 
 The execution layer destroys `U` by withholding it from priority-fee credit. The consensus layer destroys `D` by reducing builder balance without creating a withdrawal. No burn address is used.
 
@@ -868,18 +879,20 @@ A static builder-payment backcast is insufficient for the combined mechanism. It
 2. Declared external value retained at the proposed rate.
 3. Public, private, and self-build shares by count and estimated value.
 4. PTC propagation by deadline and local-floor disagreement.
-5. The probability that a below-floor block becomes canonical, conditioned on colluding stake, report and evidence propagation, and `BID_FLOOR_THRESHOLD`.
+5. The probability that a below-floor block becomes canonical, conditioned on colluding stake, report and evidence propagation, threshold, and haircut.
 6. Self-build probability by local-`F` quantile and the distribution of `F` for self-built slots.
 7. For nonzero floor targets, the ratio `U / (get_mev_burn_amount(F) * 10**9)`, the fraction of high-`F` slots that self-build, and the frequency of large-`F`, low-`U` self-builds.
 8. High-`F` self-build concentration by identifiable staking operator and sensitivity to the configured burn rate.
 9. Trusted-payment defaults, builder collateral concentration, proposer-payment tails, and missed proposal or payload rates.
-10. Public-floor coverage by selected external-`G` quantile: the fraction with `F > 0`, `F / G` for `G > 0`, and the high-`G` share with `F = 0`, split by public or private selected bid.
+10. Across instrumented nodes, public-floor coverage by selected external-`G` quantile: the fraction with `F > 0`, `F / G` and `H / G` for `G > 0`, and the high-`G` share with `F = 0`, split by public or private selected bid.
 
 The rate should reduce security-relevant proposer windfalls while retaining enough protocol-visible bidding for the mechanism to remain effective.
 
 ## Backwards Compatibility
 
 This EIP changes execution consensus, consensus-layer state transition, networking, honest validator behavior, and fork choice. It requires a hard fork.
+
+This specification assumes activation with EIP-7732, when no live `BuilderPendingPayment` entries exist. A later activation requires a separate legacy-settlement transition.
 
 It changes the SSZ semantics and field name of `ExecutionPayloadBid.value` to `gross_value`. The field keeps its position and type, and the container adds the Gwei-denominated `priority_fee_burn_credit` commitment.
 
@@ -1014,21 +1027,21 @@ The floor is `F = 9.4 ETH`. The reports can reference different signed bid roots
 
 A positive report received without its signed bid does not initially contribute. If `ExecutionPayloadBidsByRoot` returns the matching bid and its objective checks succeed before the target-slot snapshot, the report contributes even if a local first-seen gossip rule would have ignored that bid. Evidence obtained after the snapshot does not revise `F`.
 
-Given `F = 9 ETH`, an external block with `G = 1 ETH` loses local head eligibility during the target slot. An external block with `G = 9 ETH` and any self-build remain eligible under this EIP.
+Given `F = 9 ETH` and a hypothetical 500 basis-point haircut, `H = 8.55 ETH`. An external block with `G = 8.5 ETH` and its descendants lose local head eligibility through `target_slot + 1`. An honest proposer applying the filter in that next slot builds a sibling on the lower block's parent. An external block with `G = 8.55 ETH` and any self-build remain eligible under this EIP.
 
-A report received after the target-slot snapshot does not change `F`. At the next slot, this EIP's filter expires. The lower block is again considered under ordinary fork choice. Its state transition was never invalid.
+A report received after the target-slot snapshot does not change `F`. At `target_slot + 2`, this EIP's filter expires. Both branches are again considered under ordinary fork choice. The lower block's state transition was never invalid.
 
 ## Reference Implementation
 
 A complete implementation requires changes to the execution specification, Engine API, Gloas beacon-chain specification, P2P specification, fork choice, and honest validator guide.
 
-The Specification section is normative. The remaining mainnet configuration items are `BID_FLOOR_DUE_BPS` and `BID_FLOOR_THRESHOLD`. Their values require propagation measurement and adversarial network analysis.
+The Specification section is normative. The remaining mainnet configuration items are `BID_FLOOR_DUE_BPS`, `BID_FLOOR_THRESHOLD`, and `BID_FLOOR_HAIRCUT_BPS`. Their values require propagation measurement and adversarial network analysis.
 
 ## Security Considerations
 
 ### Limits of the competitive floor
 
-Without the floor, an external builder and proposer can declare a low `G` and move compensation to a side channel. With the floor, a low external bid must overcome the loss of same-slot honest fork-choice support from validators that received enough competing reports. This mitigates trivial bilateral under-declaration in the normal external ePBS path when public bids reach the threshold.
+Without the floor, an external builder and proposer can declare a low `G` and move compensation to a side channel. With the floor, an external bid below `H` must overcome a competing branch built and supported during the next slot by validators that received enough reports. This mitigates trivial bilateral under-declaration beyond the configured haircut in the normal external ePBS path when public bids reach the threshold.
 
 The mechanism is not coalition-proof. An adversary can suppress bids or reports, possess value that competitors cannot price, receive value after the deadline, or leave the external-builder path. Ethereum can burn only visible priority fees, signed bid value, and builder balance.
 
@@ -1038,13 +1051,13 @@ An adversary can delay reports or bid evidence, eclipse participants, or deny se
 
 A floor-setting bid is a signed, fully collateralized public offer that the eligible proposer can select, not a fabricated oracle value. An artificially high bid therefore requires collateral for `G` and exposes the builder to that consensus liability under the EIP-7732 settlement conditions. Evidence retrieval makes the offer more widely actionable but does not eliminate selective-delivery griefing, especially near the deadline.
 
-The frozen snapshot and expiry rule define recovery. Reports received after the target-slot boundary have no effect. At the next slot, the filter expires and every affected subtree returns to ordinary fork choice. The rule can directly remove at most the target slot's head and attestation opportunity. It does not bound indirect economic loss or later LMD-GHOST effects from the votes cast during that slot.
+The frozen snapshot and expiry rule define recovery. Reports received after the target-slot boundary have no effect. During `target_slot + 1`, filtered proposers build on the below-floor block's parent and filtered validators support that competing branch. At `target_slot + 2`, both branches return to ordinary fork choice. The rule directly affects at most two slots; it does not bound indirect economic loss or later LMD-GHOST effects.
 
-Enforcement is probabilistic and does not guarantee orphaning. Its deterrence is the expected cost of losing same-slot honest support. A below-floor block that later becomes canonical can still realize the avoided burn, so effectiveness depends on report propagation, colluding stake, later proposers, and ordinary fork choice.
+Enforcement is probabilistic and does not guarantee orphaning. If `B` is the avoided burn, `L` is the coalition value lost on orphaning, and `p` is the orphaning probability, the simplified deterrence condition is `p * L > B`. This becomes approximately `p > t` only when `B` is approximately `t * L` and orphaning loses all `L`. Control or loss of the next proposal can prevent creation of the competing branch, so effectiveness depends on colluding stake, report propagation, and ordinary fork choice.
 
 Signed conflicting reports make equivocation attributable. However, the selective-delivery attack can use one valid message from each participating member and requires no equivocation. An equivocation penalty would not prevent the main attack, so this EIP does not add a new slashing system. Clients should retain conflicting messages and expose report-receipt metrics.
 
-The deadline and threshold require propagation measurement and adversarial network analysis before mainnet activation. These values must account for both targeted behavior and ordinary network variance. Simulations must estimate the probability that a below-floor block eventually becomes canonical as a function of colluding stake, report and evidence propagation, and `BID_FLOOR_THRESHOLD`.
+The deadline, threshold, and haircut require propagation measurement and adversarial network analysis before mainnet activation. These values must account for targeted behavior and ordinary network variance. Simulations must estimate the probability that a below-floor block eventually becomes canonical as a function of colluding stake, report and evidence propagation, threshold, and haircut.
 
 ### Unpriced and self-build value
 

--- a/EIPS/eip-8375.md
+++ b/EIPS/eip-8375.md
@@ -44,6 +44,8 @@ The objective is to reduce the share and variance of validator revenue from rand
 
 The protocol cannot measure value retained internally or paid outside both streams. PTC reports therefore do not estimate MEV. They only constrain external `gross_value` using real public offers.
 
+The competitive floor does not eliminate off-protocol avoidance. It makes ordinary external-path under-declaration harder and shifts the principal bilateral avoidance routes toward proposer-authorized self-build, suppressed public price discovery, and value competitors cannot observe.
+
 A voluntary burn field would create a second auction dimension because a proposer prefers payment over an otherwise equal burn. A fixed fraction removes that choice. For fully collateralized public bids, a larger `gross_value` still gives a larger proposer payment.
 
 ### Design goals
@@ -717,6 +719,8 @@ selected_bid.gross_value < local_ptc_floor
 
 During `target_slot`, an honest validator MUST exclude such a block from head selection and MUST NOT attest to it as head. When the numerator is zero, this filter is disabled. The filter expires at the start of `target_slot + 1`. The block and its descendants then use ordinary fork choice. Prior votes are not revised.
 
+Bid-floor head filtering is independent of the EIP-7732 payload-timeliness duty. A PTC member observing a below-floor block MUST continue its normal payload observation and attestation duties for that commitment. A floor decision MUST NOT be treated as a payload-unavailability vote.
+
 The floor is not a state-transition validity rule. Its direct effect is bounded to same-slot head selection; normal LMD-GHOST consequences of those votes can persist.
 
 Expiry does not permanently exclude the branch. A later proposer can extend it, and ordinary fork choice can make it canonical.
@@ -768,6 +772,8 @@ Consensus clients SHOULD expose these values through a stable state-inspection, 
 
 Clients SHOULD also expose locally timely PTC reports, verified bid evidence, and the local `F` used for fork-choice decisions.
 
+Implementations used for activation evaluation SHOULD retain signed floor reports and referenced bids long enough for cross-node analysis of high-floor self-build behavior.
+
 This exposure supports supply accounting and post-fork economic analysis.
 
 This EIP does not define a specific API endpoint.
@@ -806,7 +812,7 @@ After execution, the realized builder deduction is `max(0, A - R)`. Thus, `gross
 
 For a whole-Gwei gross value `X` represented entirely in either `T` or `G`, the burn is the configured fraction of `X`, subject to integer rounding. To deliver a fixed post-burn amount `x`, either endpoint requires gross value `x / (1 - t)` and burns `t * x / (1 - t)`. The two endpoints therefore have the same marginal rate apart from rounding.
 
-This is not a proof for two disjoint additive value streams. While `R < A`, each credited Gwei reduces the builder top-up by one Gwei. After `R >= A`, additional priority-fee burn increases total burn. The external total is at least `max(U, A * 10**9)` and can exceed it only by the sub-Gwei part of `U`. The design treats priority fees as one expression of the value covered by the external target. Evaluation must test whether builders can make `T` and `G` economically disjoint. The public-bid floor constrains `G`, and `U` remains unavoidable for every executed payload.
+When `T` and `G` are economically distinct additive streams, crediting `U` against `A` deliberately burns less than applying the rate to `T + G`; third-party priority fees can reduce `D`. Each credited Gwei replaces one Gwei of `D` until `R = A`; further priority-fee burn increases the total. This follows from treating `U` as a universal minimum rather than an additive burn. The external total is at least `max(U, A * 10**9)` and can exceed it only by the sub-Gwei part of `U`. Evaluation must test this overlap assumption. The public-bid floor constrains `G`, and `U` remains unavoidable for every executed payload.
 
 ### Priority-fee scope and precision
 
@@ -824,7 +830,9 @@ Public bids require `E == 0` and are fully collateralized. Private paths may use
 
 A self-built payload has no measurable external `gross_value`. The protocol cannot prove who constructed it or require a truthful declaration of its MEV. Self-build therefore has no auction target or competitive floor. It still pays `U`.
 
-This preserves local construction as the unconditional fallback. It also leaves vertical integration and outsourced self-build as residual avoidance paths.
+This preserves local construction as the unconditional fallback. Once the floor constrains low-value external bids, proposer-authorized outsourced self-build becomes the primary bilateral residual. An external constructor leaves the normal ePBS builder relationship and must either disclose the payload before authorization or arrange off-protocol authorization of a payload the proposer has not inspected.
+
+Disclosure gives the proposer an option to copy, reorder, leak, or extract from the payload and can make confidential order-flow providers less willing to share flow. Keeping the payload hidden instead adds counterparty, validation, signing, and fair-exchange infrastructure risk. These are economic frictions, not consensus guarantees. Vertically integrated proposer-builders can internalize much of them, giving them lower avoidance costs and creating vertical-integration pressure.
 
 ### PTC order statistic and local snapshot
 
@@ -857,9 +865,11 @@ A static builder-payment backcast is insufficient for the combined mechanism. It
 3. Public, private, and self-build shares by count and estimated value.
 4. PTC propagation by deadline and local-floor disagreement.
 5. The probability that a below-floor block becomes canonical, conditioned on colluding stake, report and evidence propagation, and `BID_FLOOR_THRESHOLD`.
-6. Trusted-payment defaults and builder collateral concentration.
-7. Proposer-payment tail percentiles.
-8. Missed proposal and missed payload rates.
+6. Self-build probability by local-`F` quantile and the distribution of `F` for self-built slots.
+7. For nonzero floor targets, the ratio `U / (get_mev_burn_amount(F) * 10**9)`, the fraction of high-`F` slots that self-build, and the frequency of large-`F`, low-`U` self-builds.
+8. High-`F` self-build concentration by identifiable staking operator and sensitivity to the configured burn rate.
+9. Trusted-payment defaults, builder collateral concentration, proposer-payment tails, and missed proposal or payload rates.
+10. Public-floor coverage by selected external-`G` quantile: the fraction with `F > 0`, the distribution of `F / G`, and the high-`G` share with `F = 0`, split by public or private selected bid.
 
 The rate should reduce security-relevant proposer windfalls while retaining enough protocol-visible bidding for the mechanism to remain effective.
 
@@ -1020,9 +1030,11 @@ The mechanism is not coalition-proof. An adversary can suppress bids or reports,
 
 An adversary can delay reports or bid evidence, eclipse participants, or deny service to the new gossip and request/response protocols. Missing verified reports lower `F`. Conversely, a malicious builder can deliver one valid high bid to at least `q` honest PTC members without making it timely retrievable by every validator. Their honest reports can then raise `F` only where the evidence arrives before the snapshot. Malicious PTC members can create the same disagreement. Bid-by-root retrieval reduces this selective-evidence risk but cannot eliminate deadline, eclipse, or targeted-delivery effects.
 
+A floor-setting bid is a signed, fully collateralized public offer that the eligible proposer can select, not a fabricated oracle value. An artificially high bid therefore exposes its builder to the corresponding `G` liability, and evidence retrieval makes that offer more widely actionable. This does not eliminate selective-delivery griefing, especially near the deadline.
+
 The frozen snapshot and expiry rule define recovery. Reports received after the target-slot boundary have no effect. At the next slot, the filter expires and every affected subtree returns to ordinary fork choice. The rule can directly remove at most the target slot's head and attestation opportunity. It does not bound indirect economic loss or later LMD-GHOST effects from the votes cast during that slot.
 
-Enforcement is therefore probabilistic. It is strong only when the loss of same-slot honest support prevents the below-floor branch from winning fork choice. A later proposer can extend that branch after expiry, and it can still become canonical.
+Enforcement is probabilistic and does not guarantee orphaning. Its deterrence is the expected cost of losing same-slot honest support. A below-floor block that later becomes canonical can still realize the avoided burn, so effectiveness depends on report propagation, colluding stake, later proposers, and ordinary fork choice.
 
 Signed conflicting reports make equivocation attributable. However, the selective-delivery attack can use one valid message from each participating member and requires no equivocation. An equivocation penalty would not prevent the main attack, so this EIP does not add a new slashing system. Clients should retain conflicting messages and expose report-receipt metrics.
 
@@ -1032,7 +1044,7 @@ The deadline and threshold require propagation measurement and adversarial netwo
 
 The floor cannot price late, exclusive, or private value that public builders did not bid for. Such value can move through undeclared transfers or integrated accounting. The universal priority-fee burn still applies, but value outside `T` and `G` is not burned.
 
-A proposer and external constructor can also present a payload through `BUILDER_INDEX_SELF_BUILD`. The protocol cannot prove who constructed it. The constructor must reveal payload or order-flow information before proposer authorization, or establish an off-protocol way for the proposer to authorize an uninspected payload. Vertically integrated operators have lower costs for this path. Every executed self-build still pays `U`.
+Once the floor constrains ordinary external under-declaration, proposer-authorized outsourced self-build is the primary remaining bilateral avoidance path. Holding the payload and `U` fixed, this avoids `D * 10**9` Wei, where `D = A - R` when `R < A`. Avoidance is attractive when that saving exceeds expected disclosure, counterparty, signing, reputation, and infrastructure costs. The protocol does not assume those costs always exceed the avoided top-up; exceptional-MEV slots and vertically integrated operators are the most attractive cases. Every executed self-build still pays `U`.
 
 ### Trusted payments, capital, and residual jackpots
 

--- a/EIPS/eip-8375.md
+++ b/EIPS/eip-8375.md
@@ -1,8 +1,9 @@
 ---
+eip: 8375
 title: ePBS Mandatory Burn of Execution Rewards
 description: Burns a fixed fraction of the gross value committed by selected ePBS builder bids.
 author: Ben Adams (@benaadams)
-discussions-to: <DISCUSSION URL>
+discussions-to: https://ethereum-magicians.org/t/eip-8375-ember-epbs-mandatory-burn-of-execution-rewards/29380
 status: Draft
 type: Standards Track
 category: Core

--- a/EIPS/eip-8375.md
+++ b/EIPS/eip-8375.md
@@ -400,10 +400,15 @@ if consensus_liability > 0:
         burn_target=burn_target,
         is_payable=False,
     )
-    state.builder_pending_settlements[
-        SLOTS_PER_EPOCH + bid.slot % SLOTS_PER_EPOCH
-    ] = settlement
+    settlement_index = SLOTS_PER_EPOCH + bid.slot % SLOTS_PER_EPOCH
+    assert (
+        state.builder_pending_settlements[settlement_index]
+        == BuilderPendingSettlement()
+    )
+    state.builder_pending_settlements[settlement_index] = settlement
 ```
+
+The destination entry MUST be empty before a new settlement is written. A beacon block that targets a nonempty entry is invalid, and processing MUST NOT overwrite the existing liability.
 
 ### Atomic settlement lifecycle
 
@@ -462,9 +467,16 @@ The protocol MUST NOT represent `D` as an execution-layer transfer to a burn add
 
 The existing withdrawal path continues to process `V`.
 
-### Settlement eviction
+### Settlement rotation and collision
 
-A payable entry MUST resolve before its vector position is reused. An empty canonical payload-availability status sets `U = 0`. A full status requires the canonical execution result and its `U`. A node missing that payload cannot yet verify the transition. A payload received after an empty outcome does not reopen the settlement.
+The EIP-7732 epoch transition processes the older half of `builder_pending_settlements`, shifts the newer half into the older half, and initializes an empty newer half. This EIP modifies that transition as follows:
+
+1. Apply the existing quorum rule to every nonempty older entry whose liability is not yet decided. A quorum result makes it `PAYABLE`; otherwise it becomes `RELEASED`.
+2. Clear every `RELEASED` entry without charging `A` or `V`.
+3. Resolve every `PAYABLE` entry from the canonical payload outcome. An empty payload-availability status sets `U = 0`. A full status requires the canonical execution result and its `U`.
+4. Assert that every entry in the older half is empty. Then shift the newer half into the older half and initialize the newer half with empty `BuilderPendingSettlement` values.
+
+An unresolved entry in the newer half MAY shift once into the older half. An unresolved entry MUST NOT be discarded or survive the next rotation. A node that lacks a required canonical execution result cannot verify the epoch transition until it obtains that result; it MUST NOT substitute `U = 0`. A payload received after a canonical empty outcome does not reopen the settlement.
 
 ### Attestation weight accounting
 
@@ -642,6 +654,8 @@ selected_bid.gross_value < local_ptc_floor
 During `target_slot`, an honest validator MUST exclude such a block from head selection and MUST NOT attest to it as head. The filter expires at the start of `target_slot + 1`. The block and its descendants then use ordinary fork choice. Prior votes are not revised.
 
 The floor is not a state-transition validity rule. Its direct effect is bounded to same-slot head selection; normal LMD-GHOST consequences of those votes can persist.
+
+Expiry does not permanently exclude the branch. A later proposer can extend it, and ordinary fork choice can make it canonical.
 
 The floor MUST NOT change the amount charged for a selected bid. This EIP does not charge a proposer or validator `t * (F - G)`. It does not define `burn = t * max(G, F)`.
 
@@ -892,7 +906,9 @@ For `PAYABLE`, consensus queues `V` once, sets `is_payable = True`, and keeps al
 
 For `RELEASED`, consensus queues no withdrawal, deducts no burn, and clears the settlement.
 
-A payable entry must not be evicted before burn resolution. If canonical payload availability is full but a node lacks the execution result, that node cannot verify the transition. It must not substitute `U = 0`. A late payload does not reopen a settlement after a canonical no-payload outcome.
+At an epoch rotation, every older-half settlement must become `PAYABLE` or `RELEASED` and then clear. An unresolved newer-half entry can shift into the older half once. A nonempty older entry after processing makes the epoch transition invalid. A node that lacks a required canonical execution result cannot verify the transition and must not substitute `U = 0`.
+
+After rotation, every newer-half entry is empty. Processing a new bid against a nonempty destination entry is invalid and must not overwrite that entry.
 
 A builder with balance 12 and pending liability 9 cannot make another deduction that leaves balance 8. The remaining balance must cover all pending liability.
 
@@ -930,6 +946,8 @@ The mechanism is not coalition-proof. An adversary can suppress bids or reports,
 An adversary can delay reports, eclipse PTC members, or deny service to the new topic. Missing reports lower `F`. Conversely, a valid high bid delivered to only part of the network can raise `F` for those validators. A coalition of at least `q` PTC members can therefore make honest validators disagree about same-slot eligibility, even though every reported bid is real and collateral-backed.
 
 The frozen snapshot and expiry rule define recovery. Reports received after the target-slot boundary have no effect. At the next slot, the filter expires and every affected subtree returns to ordinary fork choice. The rule can directly remove at most the target slot's head and attestation opportunity. It does not bound indirect economic loss or later LMD-GHOST effects from the votes cast during that slot.
+
+Enforcement is therefore probabilistic. It is strong only when the loss of same-slot honest support prevents the below-floor branch from winning fork choice. A later proposer can extend that branch after expiry, and it can still become canonical.
 
 Signed conflicting reports make equivocation attributable. However, the selective-delivery attack can use one valid message from each participating member and requires no equivocation. An equivocation penalty would not prevent the main attack, so this EIP does not add a new slashing system. Clients should retain conflicting messages and expose report-receipt metrics.
 

--- a/EIPS/eip-XXXX.md
+++ b/EIPS/eip-XXXX.md
@@ -90,7 +90,7 @@ A proportional burn has these properties:
 
 - The burn increases when the selected builder bid increases.
 - A high-value block creates a high burn.
-- The protocol reduces proposer income from visible builder bids by a known fraction.
+- The protocol removes a known fraction of each visible builder bid before the proposer payment.
 - The protocol does not need a new recipient set.
 - The protocol does not need a redistribution mechanism.
 - The burn reduces ETH supply.
@@ -606,6 +606,8 @@ This definition keeps the burn fraction easy to understand.
 
 At a one-third burn rate, the protocol destroys about one third of the builder's declared gross expenditure. The remaining amount is proposer compensation.
 
+The burn is not a charge on proposer revenue. The protocol removes the burn from the builder's gross bid. The proposer revenue is only the net amount `P = G - B`.
+
 An alternative definition could make `gross_value` equal only to proposer compensation. The burn would then be an extra cost on top of `gross_value`.
 
 That alternative changes the meaning of the rate constant. It also makes historical backcasts and payment-avoidance calculations use a different parameter.
@@ -699,7 +701,7 @@ Therefore, self-build has no burn under this EIP.
 
 The exemption also keeps local building as a fallback against builder concentration.
 
-Local building is often most competitive in low-value slots. A tax on external builder payments can increase local building in this part of the distribution.
+Local building is often most competitive in low-value slots. The burn on external builder payments can increase local building in this part of the distribution.
 
 However, a large staking operator can also own or control a specialized builder. Such an operator can use self-build to avoid the burn on high-value slots.
 
@@ -804,7 +806,7 @@ Also:
 q(0.40) / q(1/3) > 0.8333
 ```
 
-A higher rate is counterproductive if it causes enough gross value to leave the taxable bid path.
+A higher rate is counterproductive if it causes enough gross value to leave the bid path where the burn applies.
 
 For an expenditure-inclusive bid, the extra gross expenditure that is required to give a fixed proposer payment is:
 
@@ -852,7 +854,7 @@ The mechanism must also keep enough value in protocol-visible external bidding t
 
 This EIP changes consensus and requires a hard fork.
 
-It changes the SSZ semantics and field name of `ExecutionPayloadBid.value` to `gross_value`.
+It changes the SSZ semantics and field name of `ExecutionPayloadBid.value` to `gross_value`. The field keeps its position and its type. The container layout does not change.
 
 It changes the builder pending-payment state object.
 
@@ -864,15 +866,13 @@ Consensus clients, validator clients, builders, relays, and APIs must use the ne
 
 The public bid path keeps the same trust model. Public bids still have `execution_payment == 0`. Public bids are fully collateralized. Public bids use one scalar value for ordering.
 
-If the final EIP-7732 container cannot replace `value`, an implementation-compatible fallback may keep `value` and add `gross_value`.
+If the final EIP-7732 container keeps the field name `value`, an implementation-compatible fallback reuses the existing field in place.
 
-In that fallback, consensus must enforce this identity:
+In this fallback, consensus reads `value` as `gross_value`. The field keeps its position and its type. The fallback does not add a field. The fallback does not change the container layout.
 
-```text
-value + execution_payment + burn_amount == gross_value
-```
+Consensus then derives `burn_amount` and `trustless_payment` from `value` and `execution_payment`. This derivation is the same as the Specification derivation for `gross_value`.
 
-The preferred design derives the trustless proposer payment and does not keep a redundant supplied `value` field.
+The fallback does not add a redundant field.
 
 ## Test Cases
 
@@ -1190,7 +1190,7 @@ This EIP does not make undeclared value observable.
 
 This EIP does not claim to burn undeclared value.
 
-A higher burn fraction gives a stronger incentive to use an untaxed payment path.
+A higher burn fraction gives a stronger incentive to use a payment path where the burn does not apply.
 
 For this reason, mainnet activation should use measurements or simulations of value-weighted payment retention for candidate rates.
 
@@ -1213,7 +1213,7 @@ First, most slots have modest builder payments. A fraction of a small payment is
 
 Second, the large and rare opportunities occur in unpredictable slots. A builder cannot move a high-value opportunity to a chosen proposer. A proposer cannot choose to receive one. A single high-value opportunity occurs in one slot. That slot has one fixed proposer. To evade the burn on this tail, an actor needs one of two things. The first is a standing side channel with a large share of proposers. The second is a builder and a large staker under one control that self-builds these slots. In a competitive builder market, the proposer for the slot selects the best public bid, and the burn applies.
 
-A higher rate would increase the reward for evasion in every block. A higher rate would lower the value at which a side channel or a cartel becomes worthwhile. A higher rate would move more value out of the taxable bid path. The `q(t)` analysis in the Rationale describes this effect.
+A higher rate would increase the reward for evasion in every block. A higher rate would lower the value at which a side channel or a cartel becomes worthwhile. A higher rate would move more value out of the bid path where the burn applies. The `q(t)` analysis in the Rationale describes this effect.
 
 A moderate rate keeps the public bid path the lowest-cost path for most blocks. A moderate rate still burns a meaningful share of the visible high-value tail that lands on proposers outside a cartel.
 

--- a/EIPS/eip-XXXX.md
+++ b/EIPS/eip-XXXX.md
@@ -1194,6 +1194,31 @@ A higher burn fraction gives a stronger incentive to use an untaxed payment path
 
 For this reason, mainnet activation should use measurements or simulations of value-weighted payment retention for candidate rates.
 
+### Collusion and evasion economics
+
+This EIP does not prevent collusion.
+
+Two evasion paths remain open:
+
+- A group of builders can agree to declare a low `gross_value`. They can settle the rest through another channel.
+- A builder and a proposer can agree to declare a low `gross_value`. They can move the rest through a side payment.
+
+Each path can reduce the declared burn to near zero for the affected bids. The protocol cannot burn value that does not appear in a signed bid. The "Undeclared proposer compensation" and "Self-build avoidance and vertical integration" subsections describe this same limit.
+
+The partial burn fraction is a deliberate response to this limit. The rate does not try to capture all execution value. The rate stays below the value at which evasion is worthwhile in the common case.
+
+Two properties support a moderate rate.
+
+First, most slots have modest builder payments. A fraction of a small payment is a small amount. The fixed cost and the counterparty risk of a side channel are larger than this burn. The fixed cost and the counterparty risk of a sustained cartel are also larger than this burn. For most blocks and most proposers, honest declaration through the public bid path costs less than evasion.
+
+Second, the large and rare opportunities occur in unpredictable slots. A builder cannot move a high-value opportunity to a chosen proposer. A proposer cannot choose to receive one. A single high-value opportunity occurs in one slot. That slot has one fixed proposer. To evade the burn on this tail, an actor needs one of two things. The first is a standing side channel with a large share of proposers. The second is a builder and a large staker under one control that self-builds these slots. In a competitive builder market, the proposer for the slot selects the best public bid, and the burn applies.
+
+A higher rate would increase the reward for evasion in every block. A higher rate would lower the value at which a side channel or a cartel becomes worthwhile. A higher rate would move more value out of the taxable bid path. The `q(t)` analysis in the Rationale describes this effect.
+
+A moderate rate keeps the public bid path the lowest-cost path for most blocks. A moderate rate still burns a meaningful share of the visible high-value tail that lands on proposers outside a cartel.
+
+This reasoning reduces the incentive to evade. It does not remove the evasion paths. A sustained builder cartel is a residual risk. A vertically integrated large staker is also a residual risk. Evaluation must measure declared payment retention and high-value self-build concentration. The "Rate evaluation metrics" subsection lists these measurements.
+
 ### Trusted payment default
 
 `execution_payment` remains trusted.

--- a/EIPS/eip-XXXX.md
+++ b/EIPS/eip-XXXX.md
@@ -703,9 +703,7 @@ The exemption also keeps local building as a fallback against builder concentrat
 
 Local building is often most competitive in low-value slots. The burn on external builder payments can increase local building in this part of the distribution.
 
-However, a large staking operator can also own or control a specialized builder. Such an operator can use self-build to avoid the burn on high-value slots.
-
-The Security Considerations section describes this risk.
+A large staking operator can also own a builder and use self-build to avoid the burn on high-value slots. The "Self-build avoidance and vertical integration" subsection describes this risk.
 
 ### Why there is no attester burn floor
 
@@ -1143,38 +1141,7 @@ A test must fail if the implementation can queue `V` without also applying `B`.
 
 A complete reference implementation requires a consensus-spec change against the final post-EIP-7732 fork specification.
 
-The minimum changes are:
-
-1. Replace `ExecutionPayloadBid.value` with `gross_value`.
-2. Add deterministic helper functions for burn and payment components.
-3. Replace `BuilderPendingPayment` with `BuilderPendingSettlement`.
-4. Count burn in pending builder liability.
-5. Reserve `G - E` when consensus accepts a selected external bid.
-6. Apply `B` and `V` together in the normal settlement path.
-7. Apply `B` and `V` together in the quorum settlement path.
-8. Apply the same burn in the late-parent direct-payment path.
-9. Accumulate payment-quorum weight for burn-only consensus liabilities.
-10. Keep `execution_payment == 0` for public gossip.
-11. Rank public bids by `gross_value`.
-12. Require `gross_value == 0` and `execution_payment == 0` for self-builds.
-13. Preserve pending settlement liabilities across all builder-balance deductions.
-14. Calculate the burn without intermediate integer overflow.
-
-The following helper shows the core accounting:
-
-```python
-def compute_builder_bid_accounting(bid: ExecutionPayloadBid) -> tuple[Gwei, Gwei, Gwei]:
-    burn = Gwei(
-        bid.gross_value
-        * BUILDER_PAYMENT_BURN_NUMERATOR
-        // BUILDER_PAYMENT_BURN_DENOMINATOR
-    )
-    proposer_amount = Gwei(bid.gross_value - burn)
-    assert bid.execution_payment <= proposer_amount
-    trustless = Gwei(proposer_amount - bid.execution_payment)
-    consensus_liability = Gwei(burn + trustless)
-    return burn, trustless, consensus_liability
-```
+The Specification section is the normative source for an implementation. It defines the modified `ExecutionPayloadBid`, the `BuilderPendingSettlement` state object, the burn and payment helpers, and the settlement, liability, and gossip rules.
 
 ## Security Considerations
 
@@ -1343,27 +1310,11 @@ Implementations must not allow intermediate overflow in the burn calculation. Th
 
 All implementations must calculate the same integer result.
 
-### Burn observability
-
-The burn is a consensus-layer balance reduction. It is not an execution-layer transfer.
-
-Supply tools and economic monitors still need a simple way to audit each burn.
-
-Canonical data must make each burn derivable.
-
-Clients should expose `gross_value`, burn, trusted payment, trustless payment, and settlement status through stable inspection surfaces.
-
 ### No new attester pricing duty
-
-This EIP does not add a local burn floor.
-
-This EIP does not add MEV-price attestations.
-
-This EIP does not add a burn rule to fork choice.
 
 An implementation must not reject an otherwise valid block because the node saw a higher builder bid locally.
 
-This requirement prevents consensus behavior from depending on local message history.
+This requirement prevents consensus behavior from depending on local message history. The "Why there is no attester burn floor" subsection explains why the burn does not use local bid observations.
 
 ## Copyright
 

--- a/EIPS/eip-XXXX.md
+++ b/EIPS/eip-XXXX.md
@@ -1,0 +1,1345 @@
+---
+title: ePBS Mandatory Burn of Execution Rewards
+description: Burns a fixed fraction of the gross value committed by selected ePBS builder bids.
+author: Ben Adams (@benaadams)
+discussions-to: <DISCUSSION URL>
+status: Draft
+type: Standards Track
+category: Core
+created: 2026-08-07
+requires: 7732
+---
+
+## Abstract
+
+This EIP changes the ePBS payment mechanism from [EIP-7732](./eip-7732.md).
+
+An external `ExecutionPayloadBid` declares `gross_value`. `gross_value` is the total value that the builder commits if the bid becomes payable.
+
+The protocol divides `gross_value` into three parts:
+
+- a consensus-layer burn;
+- a trustless proposer payment;
+- an optional trusted execution-layer payment.
+
+The following identity must hold:
+
+```text
+G = B + V + E
+```
+
+The terms have these meanings:
+
+- `G` is `gross_value`.
+- `B` is the burn.
+- `V` is the trustless proposer payment.
+- `E` is `execution_payment`.
+
+The builder must fully collateralize `B` and `V`. Consensus does not guarantee `E`.
+
+A public bid must have `execution_payment == 0`. Therefore, a public bid is fully collateralized.
+
+The burn and the trustless proposer payment use one settlement lifecycle. They become payable together or they are released together. The same EIP-7732 liability conditions control both amounts.
+
+A self-built payload has no burn. The protocol cannot measure the external payment value of a self-built payload.
+
+This EIP does not add an attester duty. This EIP does not add a burn rule to fork choice.
+
+## Motivation
+
+[EIP-7732](./eip-7732.md) makes a builder payment an explicit protocol object. This gives the protocol a direct value that it can split.
+
+The protocol can use this value to reduce proposer windfalls from execution auctions. The protocol can do this without a second auction. The protocol can also do this without a subjective price oracle.
+
+### MEV as variable validator revenue
+
+An execution payload can contain value that does not come from normal blockspace pricing. Examples include arbitrage, liquidations, order-flow advantages, and other forms of maximal extractable value (MEV).
+
+In a competitive builder market, a builder can pay part of this value to the proposer. The builder makes this payment to increase the chance that the proposer selects its payload.
+
+Builder payments can have a highly skewed distribution. Most proposal slots have modest value. A small number of slots can have very large value.
+
+Large and rare payments can create these effects:
+
+- A high-value slot can increase the reward from a reorganization or a targeted denial-of-service attack.
+- A high-value slot can increase the reward from key compromise or operator theft.
+- Variable rewards can increase demand for reward smoothing and pooling.
+- Large operators can spread specialized infrastructure costs across many validators.
+- Large operators receive more proposal opportunities because they control more stake.
+- More proposal opportunities reduce the relative variance of operator income.
+
+A large operator does not receive more expected MEV per unit of stake only because it has more validators. The main scale advantage comes from lower relative variance, fixed-cost sharing, and better infrastructure economics.
+
+Stake in one operational failure domain still adds slashable economic weight. However, more validators in the same failure domain do not add independent nodes, operators, network paths, or failure domains in the same proportion.
+
+Ethereum cannot directly measure independent physical nodes or independent operational control. Therefore, this EIP does not try to reward these properties directly.
+
+This EIP has a narrower decentralization objective. It reduces one reward component that can make large-scale validator operation more attractive.
+
+The objective is measurable:
+
+> Reduce the share and variance of validator revenue that comes from random execution-auction value. Do not materially increase the advantage of large or vertically integrated staking operators.
+
+### Redirect execution-auction value
+
+[EIP-1559](./eip-1559.md) burns the execution base fee. It does not give the base fee to the block producer.
+
+Builder payments are not base fees. However, builder payments are another protocol-visible value stream that is connected to execution rights.
+
+A proportional burn has these properties:
+
+- The burn increases when the selected builder bid increases.
+- A high-value block creates a high burn.
+- The protocol reduces proposer income from visible builder bids by a known fraction.
+- The protocol does not need a new recipient set.
+- The protocol does not need a redistribution mechanism.
+- The burn reduces ETH supply.
+
+This EIP does not burn all MEV. It burns a fixed fraction of value that appears in a selected external ePBS bid.
+
+The protocol cannot burn value that a self-builder keeps internally. The protocol also cannot burn a payment that the builder and proposer keep outside the signed bid.
+
+### Why use a proportional burn
+
+A proposer has no direct reason to select a larger voluntary burn. If a builder can use the same expenditure as a proposer payment, the proposer prefers the payment.
+
+A separate burn field creates an incentive conflict. It also creates a second auction dimension.
+
+This EIP removes that choice. The protocol fixes the burn fraction for all external bids.
+
+For public bids, the burn fraction is constant and `execution_payment == 0`. Therefore, a larger `gross_value` also gives a larger trustless proposer payment.
+
+A proposer can maximize its own public-bid revenue without choosing the burn amount.
+
+This design also avoids an attester-observed burn floor. A local burn floor can differ between honest nodes because nodes can receive different bids before a deadline.
+
+This EIP does not use local bid observations for consensus. The burn is a deterministic result of the selected signed bid and the fork constant.
+
+### Design goals
+
+This EIP has these goals:
+
+1. The burn is objective and is derivable from canonical consensus data.
+2. The burn does not depend on local attester observations of builder bids.
+3. The proposer does not select the burn fraction.
+4. The public ePBS bid path remains fully collateralized.
+5. A public ePBS bid does not expose the proposer to trusted-payment risk.
+6. A private or relay bid can use a declared trusted payment.
+7. A declared trusted payment contributes to the burn calculation.
+8. The burn and the trustless proposer payment use one liability decision.
+9. Self-building remains possible without a declared MEV value.
+10. The mechanism makes post-fork economic effects easy to measure.
+
+## Specification
+
+This specification changes the consensus-layer ePBS mechanism from [EIP-7732](./eip-7732.md).
+
+### Definitions
+
+For one selected external-builder bid, use these terms:
+
+- `G`: `gross_value`. This is the builder's total declared expenditure if the bid becomes payable.
+- `B`: `burn_amount`. Consensus destroys this amount if the builder commitment becomes payable.
+- `P`: total proposer compensation after the burn.
+- `E`: `execution_payment`. This is the trusted proposer-payment amount from EIP-7732.
+- `V`: `trustless_payment`. Consensus guarantees this proposer-payment amount.
+- `C`: `consensus_liability`. The builder MUST cover this amount with consensus-layer builder balance.
+
+The following equations MUST hold:
+
+```text
+B = floor(G * BUILDER_PAYMENT_BURN_NUMERATOR / BUILDER_PAYMENT_BURN_DENOMINATOR)
+P = G - B
+V = P - E
+G = B + V + E
+C = B + V
+C = G - E
+```
+
+A bid is invalid if `E > P`.
+
+Consensus does not guarantee `E`.
+
+A larger `E` does not reduce the burn if `G` stays the same. A larger declared total commitment requires a larger `G`. A larger `G` increases `B`.
+
+### Configuration
+
+The proposed mainnet configuration is:
+
+```python
+BUILDER_PAYMENT_BURN_NUMERATOR = uint64(1)
+BUILDER_PAYMENT_BURN_DENOMINATOR = uint64(3)
+```
+
+`BUILDER_PAYMENT_BURN_DENOMINATOR` MUST be greater than zero.
+
+`BUILDER_PAYMENT_BURN_NUMERATOR` MAY be zero. A zero numerator disables the burn without disabling the payment path.
+
+`BUILDER_PAYMENT_BURN_NUMERATOR` MUST NOT be greater than `BUILDER_PAYMENT_BURN_DENOMINATOR`.
+
+An implementation MUST use integer floor division to calculate `B`.
+
+An implementation MUST calculate `G * BUILDER_PAYMENT_BURN_NUMERATOR // BUILDER_PAYMENT_BURN_DENOMINATOR` without intermediate integer overflow. A fixed-width implementation MUST use a sufficiently wide intermediate type or an equivalent overflow-safe algorithm.
+
+Any division remainder stays in `P`. Therefore, `B + P == G` always holds.
+
+### Execution layer
+
+This EIP does not require an execution-layer consensus change.
+
+The protocol applies the burn directly to the EIP-7732 consensus-layer builder balance.
+
+`execution_payment` keeps its EIP-7732 trusted-payment meaning.
+
+### Modified `ExecutionPayloadBid`
+
+Replace `ExecutionPayloadBid.value` with `gross_value`:
+
+```python
+class ExecutionPayloadBid(ProgressiveContainer(active_fields=[1] * 12)):
+    parent_block_hash: Hash32
+    parent_block_root: Root
+    block_hash: Hash32
+    prev_randao: Bytes32
+    fee_recipient: ExecutionAddress
+    gas_limit: Uint64
+    builder_index: BuilderIndex
+    slot: Slot
+    gross_value: Gwei
+    execution_payment: Gwei
+    blob_kzg_commitments: BlobKZGCommitments
+    execution_requests_root: Root
+```
+
+`SignedExecutionPayloadBid` signs `gross_value` as part of the bid.
+
+The builder MUST NOT supply `trustless_payment` as an independent field.
+
+The builder MUST NOT supply `burn_amount` as an independent field.
+
+Consensus MUST derive both values from `gross_value` and `execution_payment`.
+
+### Builder bid construction
+
+An external builder MUST use `gross_value` for the total declared expenditure of the bid.
+
+The builder MUST choose `execution_payment` so that `execution_payment <= proposer_amount`.
+
+A public bid MUST set `execution_payment = 0`.
+
+For a public bid, the trustless proposer payment is `gross_value - burn_amount`.
+
+A private or relay bid MAY set `execution_payment > 0`.
+
+For a private or relay bid, the trustless proposer payment is the remaining proposer compensation after `execution_payment`.
+
+A builder MUST NOT treat `execution_payment` as an amount in addition to `gross_value`.
+
+### Burn and payment helpers
+
+Consensus implementations MUST calculate the bid components deterministically.
+
+The following pseudocode is normative in behavior:
+
+```python
+def get_builder_burn(gross_value: Gwei) -> Gwei:
+    return Gwei(
+        gross_value
+        * BUILDER_PAYMENT_BURN_NUMERATOR
+        // BUILDER_PAYMENT_BURN_DENOMINATOR
+    )
+
+
+def get_bid_payment_components(bid: ExecutionPayloadBid) -> tuple[Gwei, Gwei, Gwei]:
+    burn_amount = get_builder_burn(bid.gross_value)
+    proposer_amount = Gwei(bid.gross_value - burn_amount)
+    assert bid.execution_payment <= proposer_amount
+    trustless_payment = Gwei(proposer_amount - bid.execution_payment)
+    return burn_amount, trustless_payment, bid.execution_payment
+
+
+def get_bid_consensus_liability(bid: ExecutionPayloadBid) -> Gwei:
+    burn_amount, trustless_payment, _ = get_bid_payment_components(bid)
+    return Gwei(burn_amount + trustless_payment)
+```
+
+For every valid external bid, the following equation is also valid:
+
+```text
+consensus_liability = gross_value - execution_payment
+```
+
+### `BuilderPendingSettlement`
+
+Replace `BuilderPendingPayment` with a settlement object that contains both protocol liabilities:
+
+```python
+class BuilderPendingSettlement(Container):
+    weight: Gwei
+    withdrawal: BuilderPendingWithdrawal
+    proposer_index: ValidatorIndex
+    gross_value: Gwei
+    burn_amount: Gwei
+```
+
+`withdrawal.amount` MUST equal `V`.
+
+`burn_amount` MUST equal `B`.
+
+`proposer_index` identifies the proposer for the existing EIP-7732 proposer-slashing release path. It is not a payment recipient.
+
+`withdrawal.fee_recipient` keeps the existing EIP-7732 fee-recipient semantics. It is the proposer-designated recipient used by the existing bid flow.
+
+`gross_value` and `burn_amount` are stored values in the settlement object. They make the obligation easy to audit from consensus state.
+
+The builder does not supply `burn_amount` as a separate signed input. Consensus derives it from the signed `gross_value`.
+
+Replace the EIP-7732 `builder_pending_payments` state vector with an equivalent `builder_pending_settlements` vector.
+
+### Pending builder liability
+
+The pending-liability helper MUST count both trustless proposer payments and burns.
+
+Conceptually:
+
+```python
+def get_pending_builder_liability(state: BeaconState, builder_index: BuilderIndex) -> Gwei:
+    pending_withdrawals = sum(
+        withdrawal.amount
+        for withdrawal in state.builder_pending_withdrawals
+        if withdrawal.builder_index == builder_index
+    )
+    pending_settlements = sum(
+        settlement.withdrawal.amount + settlement.burn_amount
+        for settlement in state.builder_pending_settlements
+        if settlement.withdrawal.builder_index == builder_index
+    )
+    return Gwei(pending_withdrawals + pending_settlements)
+```
+
+`can_builder_cover_bid` MUST use the new bid's `consensus_liability`.
+
+`can_builder_cover_bid` MUST NOT require collateral for the trusted `execution_payment`.
+
+Conceptually:
+
+```python
+def can_builder_cover_bid(
+    state: BeaconState,
+    builder_index: BuilderIndex,
+    consensus_liability: Gwei,
+) -> bool:
+    builder_balance = state.builders[builder_index].balance
+    pending_liability = get_pending_builder_liability(state, builder_index)
+    min_balance = MIN_DEPOSIT_AMOUNT + pending_liability
+    if builder_balance < min_balance:
+        return False
+    return builder_balance - min_balance >= consensus_liability
+```
+
+Builder exit processing MUST treat a pending burn as a pending builder liability.
+
+A builder MUST NOT exit while a pending burn or a pending trustless proposer payment exists.
+
+Pending consensus liabilities have priority over later deductions from builder balance. A state transition that decreases a builder balance MUST leave enough balance to cover all pending builder liabilities that remain after that transition.
+
+For each builder after such a transition, this invariant MUST hold:
+
+```text
+builder_balance >= get_pending_builder_liability(state, builder_index)
+```
+
+A future penalty or slashing rule that decreases builder balance MUST preserve this invariant or MUST first resolve the affected pending liabilities.
+
+### Process an execution payload bid
+
+For `BUILDER_INDEX_SELF_BUILD`, these conditions MUST hold:
+
+```text
+gross_value == 0
+execution_payment == 0
+```
+
+A self-build does not create a burn or a pending settlement.
+
+For an external builder, the implementation MUST do these steps:
+
+1. Calculate `B`, `V`, and `C`.
+2. Verify that `execution_payment <= gross_value - B`.
+3. Perform the existing EIP-7732 builder activity, version, and signature checks.
+4. Verify that the builder can cover `C` and all other pending liabilities.
+5. If `C > 0`, record one `BuilderPendingSettlement` that contains `B` and `V`.
+6. Cache the bid as the latest execution payload bid as specified by EIP-7732.
+
+Conceptually:
+
+```python
+burn_amount, trustless_payment, _ = get_bid_payment_components(bid)
+consensus_liability = Gwei(burn_amount + trustless_payment)
+
+if bid.builder_index == BUILDER_INDEX_SELF_BUILD:
+    assert bid.gross_value == 0
+    assert bid.execution_payment == 0
+    assert signed_bid.signature == bls.G2_POINT_AT_INFINITY
+else:
+    assert is_active_builder(state, bid.builder_index)
+    assert state.builders[bid.builder_index].version == PAYLOAD_BUILDER_VERSION
+    assert can_builder_cover_bid(state, bid.builder_index, consensus_liability)
+    assert verify_execution_payload_bid_signature(state, signed_bid)
+
+if consensus_liability > 0:
+    settlement = BuilderPendingSettlement(
+        weight=0,
+        withdrawal=BuilderPendingWithdrawal(
+            fee_recipient=bid.fee_recipient,
+            amount=trustless_payment,
+            builder_index=bid.builder_index,
+        ),
+        proposer_index=get_beacon_proposer_index(state),
+        gross_value=bid.gross_value,
+        burn_amount=burn_amount,
+    )
+    state.builder_pending_settlements[
+        SLOTS_PER_EPOCH + bid.slot % SLOTS_PER_EPOCH
+    ] = settlement
+```
+
+### Atomic settlement lifecycle
+
+The burn and the trustless proposer payment MUST use one liability decision.
+
+A pending settlement has only two final results:
+
+1. `PAYABLE`: `B` and `V` both become payable.
+2. `RELEASED`: the protocol charges neither `B` nor `V`.
+
+The protocol MUST NOT charge `B` and release `V`.
+
+The protocol MUST NOT pay `V` and release `B`.
+
+The existing EIP-7732 payment conditions MUST control the complete settlement. These conditions include the normal payload path and the builder-payment quorum path.
+
+This EIP does not add a separate burn-liability condition.
+
+If an EIP-7732 proposer-slashing path clears a pending payment, it MUST clear the matching `BuilderPendingSettlement`.
+
+That path MUST NOT charge `B` or `V`.
+
+### Apply a payable settlement
+
+When a settlement becomes payable, consensus MUST do these steps:
+
+1. Deduct `burn_amount` from the builder's consensus-layer balance.
+2. Do not create an execution-layer credit for `burn_amount`.
+3. If `withdrawal.amount > 0`, append the `BuilderPendingWithdrawal` for the trustless proposer payment.
+4. Clear the `BuilderPendingSettlement`.
+
+Conceptually:
+
+```python
+def settle_builder_settlement(state: BeaconState, settlement_index: Uint64) -> None:
+    settlement = state.builder_pending_settlements[settlement_index]
+    builder_index = settlement.withdrawal.builder_index
+    settlement_liability = settlement.burn_amount + settlement.withdrawal.amount
+
+    assert state.builders[builder_index].balance >= settlement_liability
+
+    if settlement.burn_amount > 0:
+        state.builders[builder_index].balance -= settlement.burn_amount
+
+    if settlement.withdrawal.amount > 0:
+        state.builder_pending_withdrawals.append(settlement.withdrawal)
+
+    state.builder_pending_settlements[settlement_index] = BuilderPendingSettlement()
+```
+
+The balance reduction for `B` is the burn.
+
+The protocol MUST NOT represent `B` as an execution-layer transfer to a burn address.
+
+The existing withdrawal path continues to process `V`.
+
+### Settlements outside the pending window
+
+EIP-7732 has a direct-payment path for a parent payload whose pending-payment entry is no longer in the bounded window.
+
+Any equivalent path under this EIP MUST settle the burn and the trustless proposer payment together.
+
+The implementation MUST derive `B` and `V` from the cached signed bid.
+
+The implementation MUST then do these actions in one settlement operation:
+
+1. Deduct `B` from the builder's consensus-layer balance.
+2. Queue `V` as a builder withdrawal if `V > 0`.
+
+A late-payload path MUST NOT queue `V` without the matching burn.
+
+### Attestation weight accounting
+
+EIP-7732 uses attestation weight to decide when a pending builder payment becomes payable if the normal payload path is not available.
+
+Under this EIP, weight MUST accumulate when the pending `consensus_liability` is not zero.
+
+This rule also applies when `V == 0` and `B > 0`.
+
+An implementation MUST use a check equivalent to this check:
+
+```python
+def has_pending_consensus_liability(settlement: BuilderPendingSettlement) -> bool:
+    return settlement.withdrawal.amount + settlement.burn_amount > 0
+```
+
+The quorum threshold does not change.
+
+The other EIP-7732 attestation rules do not change.
+
+### Public bid gossip
+
+The existing EIP-7732 public-gossip rule MUST remain unchanged:
+
+```text
+execution_payment == 0
+```
+
+Therefore, every public bid has:
+
+```text
+C = G
+```
+
+A public bid is fully collateralized for its complete gross commitment.
+
+Public gossip MUST compare `gross_value` instead of the former `value` field.
+
+For public bids, the burn fraction is constant and `execution_payment == 0`. Therefore, ordering by `gross_value` is also ordering by the trustless proposer payment.
+
+The existing EIP-7732 one-bid-per-builder-per-slot-and-parent gossip policy does not change.
+
+### Private and relay bids
+
+A bid that does not use the public gossip topic MAY have `execution_payment > 0`.
+
+The following condition MUST hold:
+
+```text
+execution_payment <= gross_value - burn_amount
+```
+
+Consensus guarantees only `B + V`.
+
+The builder MUST provide consensus collateral for `B + V`.
+
+Consensus does not define the credit value of `E`.
+
+A proposer MAY discount or reject `E`. A proposer MAY use relay guarantees, builder reputation, or other local information to value `E`.
+
+`gross_value` sets the burn and the builder's declared total commitment.
+
+`gross_value` does not tell the proposer how to compare bids that have different trusted-payment risk.
+
+### Self-built payloads
+
+A self-built payload MUST have these values:
+
+```text
+builder_index == BUILDER_INDEX_SELF_BUILD
+gross_value == 0
+execution_payment == 0
+```
+
+A self-built payload does not create a burn.
+
+The protocol does not estimate MEV that a proposer keeps inside a self-built payload.
+
+### Burn observability
+
+For each selected external-builder bid, canonical data MUST make these values derivable:
+
+```text
+slot
+builder_index
+gross_value
+burn_amount
+trustless_payment
+execution_payment
+settlement outcome
+```
+
+The signed bid is the source of truth for `gross_value` and `execution_payment`.
+
+Consensus derives `burn_amount` and `trustless_payment`.
+
+Consensus clients SHOULD expose these values through a stable state-inspection, event, or API surface.
+
+This exposure supports supply accounting and post-fork economic analysis.
+
+This EIP does not define a specific API endpoint.
+
+### Chain specifics
+
+Mainnet is proposed to use this burn fraction:
+
+```text
+BUILDER_PAYMENT_BURN_NUMERATOR   = 1
+BUILDER_PAYMENT_BURN_DENOMINATOR = 3
+```
+
+A devnet or testnet MAY use a different fraction.
+
+The active values MUST be part of chain configuration.
+
+The values MUST NOT change without a protocol upgrade.
+
+## Rationale
+
+### Why `gross_value` includes all builder expenditure
+
+`gross_value` is the total economic expenditure in the selected builder bid.
+
+It includes the burn and all declared proposer compensation:
+
+```text
+G = B + V + E
+```
+
+This definition keeps the burn fraction easy to understand.
+
+At a one-third burn rate, the protocol destroys about one third of the builder's declared gross expenditure. The remaining amount is proposer compensation.
+
+An alternative definition could make `gross_value` equal only to proposer compensation. The burn would then be an extra cost on top of `gross_value`.
+
+That alternative changes the meaning of the rate constant. It also makes historical backcasts and payment-avoidance calculations use a different parameter.
+
+This EIP uses expenditure-inclusive `gross_value` so that the rate has one meaning in all parts of the analysis.
+
+### Why derive `V`
+
+The builder supplies only two monetary fields:
+
+- `gross_value`;
+- `execution_payment`.
+
+Consensus derives `burn_amount` and `trustless_payment`.
+
+This design removes redundant monetary fields.
+
+If the builder supplied all four values, consensus would have to check the same accounting identity in many places.
+
+A derived value cannot disagree with the source fields.
+
+### Why retain `execution_payment`
+
+If all proposer compensation had to be trustless, builders would need consensus-layer collateral for the complete proposer payment.
+
+A rare high-value block could then require a very large builder balance.
+
+Large collateral requirements can favor the largest builders.
+
+`execution_payment` keeps the EIP-7732 distinction between trustless and trusted proposer compensation.
+
+The builder fully collateralizes its protocol commitments:
+
+```text
+C = B + V
+```
+
+The builder does not collateralize `E` through consensus.
+
+The burn still uses `G`. It does not use only `V`.
+
+Therefore, a declared trusted payment does not remove its share of the burn.
+
+If a builder increases `G` to advertise a larger trusted payment, the builder also increases its fully collateralized burn liability.
+
+This makes a false high trusted-payment declaration more expensive than a design that burns only the trustless payment.
+
+This rule does not make `E` trustless. The builder can still fail to deliver `E`. Consensus does not resolve that default.
+
+### Why public bids require `E == 0`
+
+The public ePBS topic is the default path for proposers that do not use a relay-specific credit relationship.
+
+A public bid must have `execution_payment == 0`.
+
+Therefore, every public bid is fully collateralized:
+
+```text
+C = G
+```
+
+A proposer that uses only public gossip does not accept trusted-payment risk by default.
+
+Private and relay paths can use trusted payments. This can reduce builder collateral needs without changing the trust model of public gossip.
+
+### Why there is no minimum trustless payment
+
+This EIP does not set a minimum `V`.
+
+A proposer can accept a private bid in which some or all proposer compensation is trusted.
+
+The protocol still fully collateralizes the burn and any nonzero trustless payment.
+
+A minimum `V` would make consensus choose an arbitrary credit-risk floor.
+
+A minimum `V` would also increase builder collateral needs.
+
+A minimum could cause bids to group at the minimum value.
+
+The public path stays fully trustless because it requires `E == 0`.
+
+### Why self-build is exempt
+
+A self-built block has no external builder payment that the protocol can measure as `gross_value`.
+
+A rule that asks a self-builder to declare its own MEV is not enforceable.
+
+A self-builder can keep value in many execution-layer accounts. A self-builder can also use private order flow or integrated search.
+
+Therefore, self-build has no burn under this EIP.
+
+The exemption also keeps local building as a fallback against builder concentration.
+
+Local building is often most competitive in low-value slots. A tax on external builder payments can increase local building in this part of the distribution.
+
+However, a large staking operator can also own or control a specialized builder. Such an operator can use self-build to avoid the burn on high-value slots.
+
+The Security Considerations section describes this risk.
+
+### Why there is no attester burn floor
+
+A burn floor based on bids that each attester saw before a deadline is not an objective consensus value.
+
+Honest nodes can receive different bids because of normal network delay.
+
+An attacker can also send a bid to only part of the network.
+
+Different local bid sets can create different local burn floors.
+
+This EIP does not use local bid observations for burn decisions.
+
+Attesters do not price MEV. Attesters do not add a burn rule to fork choice.
+
+The protocol derives the burn from the selected signed bid and a chain constant.
+
+### Why burn and payment use one settlement lifecycle
+
+The burn and the trustless proposer payment come from the same builder commitment.
+
+A separate liability rule for the burn can create an error during a reorganization or withholding case.
+
+For example, one path could charge the burn while another path releases the proposer payment.
+
+`BuilderPendingSettlement` prevents this split.
+
+One state object contains both protocol liabilities. One liability transition resolves both liabilities.
+
+### Why the burn occurs in the consensus layer
+
+EIP-7732 stores builder balance in the consensus layer.
+
+The protocol can destroy `B` by reducing that balance without creating a matching withdrawal.
+
+The protocol must not send `B` to an execution-layer burn address.
+
+An execution-layer burn address still has an execution-layer balance. It does not express direct consensus-layer supply destruction.
+
+### Proposed burn fraction and historical scale
+
+The proposed mainnet rate is one third.
+
+This rate is intended to be large enough to reduce visible proposer windfalls. It also leaves most gross builder expenditure as proposer compensation.
+
+The following historical comparison uses aggregate data from August 2025 through July 2026.
+
+During this period:
+
+- gross MEV-Boost proposer payments were approximately 72,619 ETH;
+- execution base-fee burn was approximately 27,546 ETH.
+
+The following table is a static backcast. It does not include behavioral changes after a burn is introduced.
+
+| Burn rate | Additional builder-payment burn | Relative to execution base-fee burn | Proposer share of gross bid |
+| ---: | ---: | ---: | ---: |
+| 25% | about 18,155 ETH | about 65.9% | 75% |
+| 33 1/3% | about 24,206 ETH | about 87.9% | about 66 2/3% |
+| 40% | about 29,048 ETH | about 105.5% | 60% |
+
+The 365-day period has 2,628,000 scheduled slots.
+
+The same aggregate data gives these approximate values per scheduled slot:
+
+| Quantity | ETH per scheduled slot |
+| --- | ---: |
+| Gross external builder payments | 0.0276 |
+| Execution base-fee burn | 0.0105 |
+| 25% builder-payment burn | 0.0069 |
+| 33 1/3% builder-payment burn | 0.0092 |
+| 40% builder-payment burn | 0.0111 |
+
+These numbers show the possible scale of the mechanism. They do not predict the final market result.
+
+A burn can change proposer and builder behavior. It can change how much value stays in declared external-builder bids.
+
+Let `q(t)` be the fraction of baseline gross builder-payment value that remains in declared external ePBS bids at burn rate `t`.
+
+Then:
+
+```text
+realized_burn(t) = t * q(t) * baseline_gross_value
+```
+
+This equation gives direct tests for candidate rates.
+
+For example:
+
+```text
+one-third burn is greater than 25% burn if:
+q(1/3) / q(1/4) > 0.75
+```
+
+Also:
+
+```text
+40% burn is greater than one-third burn if:
+q(0.40) / q(1/3) > 0.8333
+```
+
+A higher rate is counterproductive if it causes enough gross value to leave the taxable bid path.
+
+For an expenditure-inclusive bid, the extra gross expenditure that is required to give a fixed proposer payment is:
+
+```text
+t / (1 - t)
+```
+
+The following table shows this amount:
+
+| Burn rate | Extra gross expenditure per unit of proposer compensation |
+| ---: | ---: |
+| 25% | 33.3% |
+| 33 1/3% | 50% |
+| 40% | 66.7% |
+
+A higher rate gives more reason to use self-build or undeclared payment channels.
+
+For this reason, payment retention and self-build behavior are primary evaluation metrics.
+
+### Rate evaluation metrics
+
+Before mainnet activation, evaluations should measure these items:
+
+1. The value-weighted share of builder payments that stays in declared ePBS `gross_value`.
+2. The public-bid share and the private-bid share.
+3. The distribution of `execution_payment / proposer_amount`.
+4. Self-build share by block count.
+5. Self-build share by estimated value that would otherwise go to an external builder.
+6. High-value self-build concentration by identifiable staking operator.
+7. Builder market concentration.
+8. Builder collateral concentration.
+9. Proposer-payment percentiles, including p50, p95, p99, and p99.9.
+10. Realized burn as a fraction of declared gross external-builder value.
+11. Trusted-payment defaults when they are observable.
+12. Missed-payload and missed-proposal rates.
+13. The gap between shadow local payload value and the best external bid.
+
+The burn rate should not be selected only to reach a target amount of ETH burn.
+
+The main objective is to reduce security-relevant proposer windfalls and concentration pressure.
+
+The mechanism must also keep enough value in protocol-visible external bidding to remain effective.
+
+## Backwards Compatibility
+
+This EIP changes consensus and requires a hard fork.
+
+It changes the SSZ semantics and field name of `ExecutionPayloadBid.value` to `gross_value`.
+
+It changes the builder pending-payment state object.
+
+It changes builder collateral accounting.
+
+A pre-fork signed bid is not valid as a post-fork bid.
+
+Consensus clients, validator clients, builders, relays, and APIs must use the new bid semantics after activation.
+
+The public bid path keeps the same trust model. Public bids still have `execution_payment == 0`. Public bids are fully collateralized. Public bids use one scalar value for ordering.
+
+If the final EIP-7732 container cannot replace `value`, an implementation-compatible fallback may keep `value` and add `gross_value`.
+
+In that fallback, consensus must enforce this identity:
+
+```text
+value + execution_payment + burn_amount == gross_value
+```
+
+The preferred design derives the trustless proposer payment and does not keep a redundant supplied `value` field.
+
+## Test Cases
+
+The following examples use a one-third burn rate.
+
+The examples use simple integer units.
+
+### Fully trustless public bid
+
+Input:
+
+```text
+G = 9
+E = 0
+```
+
+Expected result:
+
+```text
+B = 3
+P = 6
+V = 6
+C = 9
+```
+
+The bid is valid for public gossip.
+
+The builder needs 9 units of consensus collateral.
+
+### Partially trusted private bid
+
+Input:
+
+```text
+G = 9
+E = 2
+```
+
+Expected result:
+
+```text
+B = 3
+P = 6
+V = 4
+C = 7
+```
+
+The bid is not valid for public gossip.
+
+Consensus requires 7 units of builder collateral.
+
+### All proposer compensation is trusted
+
+Input:
+
+```text
+G = 9
+E = 6
+```
+
+Expected result:
+
+```text
+B = 3
+P = 6
+V = 0
+C = 3
+```
+
+The bid is valid only through a private or relay path.
+
+The burn is fully collateralized.
+
+The proposer payment is fully trusted.
+
+Attestation weight must still accumulate because `C > 0`.
+
+### Invalid trusted payment
+
+Input:
+
+```text
+G = 9
+E = 7
+```
+
+Derived values:
+
+```text
+B = 3
+P = 6
+```
+
+The bid is invalid because `E > P`.
+
+### Rounding
+
+Input:
+
+```text
+G = 10
+E = 0
+```
+
+Expected result:
+
+```text
+B = 3
+P = 7
+V = 7
+C = 10
+```
+
+The division remainder stays in proposer compensation.
+
+### Zero burn rate
+
+Use this test configuration:
+
+```text
+BUILDER_PAYMENT_BURN_NUMERATOR = 0
+BUILDER_PAYMENT_BURN_DENOMINATOR = 1
+G = 9
+E = 0
+```
+
+Expected result:
+
+```text
+B = 0
+P = 9
+V = 9
+C = 9
+```
+
+The payment accounting is equivalent to the fully trustless EIP-7732 payment path after mapping `gross_value` to the former trustless bid value.
+
+### Full burn rate
+
+Use this test configuration:
+
+```text
+BUILDER_PAYMENT_BURN_NUMERATOR = 1
+BUILDER_PAYMENT_BURN_DENOMINATOR = 1
+G = 9
+E = 0
+```
+
+Expected result:
+
+```text
+B = 9
+P = 0
+V = 0
+C = 9
+```
+
+A bid with `G = 9` and `E > 0` is invalid at a full burn rate because `P = 0`.
+
+### Large-value multiplication
+
+Use this test configuration:
+
+```text
+BUILDER_PAYMENT_BURN_NUMERATOR = 2
+BUILDER_PAYMENT_BURN_DENOMINATOR = 3
+G = 18446744073709551615
+E = 0
+```
+
+Expected result:
+
+```text
+B = 12297829382473034410
+P = 6148914691236517205
+V = 6148914691236517205
+C = 18446744073709551615
+```
+
+The mathematical product `G * 2` is greater than the maximum `uint64` value. The implementation must still calculate the expected result without intermediate overflow.
+
+### Self-build
+
+Input:
+
+```text
+builder_index = BUILDER_INDEX_SELF_BUILD
+G = 0
+E = 0
+```
+
+Expected result:
+
+```text
+B = 0
+V = 0
+C = 0
+```
+
+The protocol does not create a pending settlement.
+
+A self-build is invalid if `G != 0` or `E != 0`.
+
+### Pending-liability balance invariant
+
+Assume a builder has 12 units of consensus-layer balance. Assume the builder has 9 units of pending consensus liability.
+
+A separate state transition tries to deduct 4 units before the pending liability is resolved.
+
+The transition is invalid because the resulting balance would be 8 and the remaining pending liability would be 9.
+
+A deduction that leaves at least 9 units can satisfy this EIP invariant. Other EIP-7732 balance rules can still make that deduction invalid.
+
+### Successful payload settlement
+
+Given this pending settlement:
+
+```text
+B = 3
+V = 6
+```
+
+When the normal EIP-7732 payment path makes the settlement payable, consensus must do these actions:
+
+1. Decrease the builder consensus balance by 3.
+2. Queue a builder withdrawal of 6 for the proposer.
+3. Clear the pending settlement.
+
+### Quorum settlement without the normal payload path
+
+Use the same pending settlement:
+
+```text
+B = 3
+V = 6
+```
+
+If the EIP-7732 builder-payment quorum makes the settlement payable, consensus must do the same actions:
+
+1. Decrease the builder consensus balance by 3.
+2. Queue a builder withdrawal of 6.
+3. Clear the pending settlement.
+
+The burn and trustless payment must have the same result.
+
+### Released settlement
+
+If EIP-7732 releases the builder from the pending payment, consensus must produce this result:
+
+```text
+burn charged = 0
+withdrawal queued = 0
+```
+
+Consensus must clear the pending settlement.
+
+### Late parent settlement
+
+A parent payload can arrive after its pending settlement leaves the bounded pending-settlement window.
+
+In this case, the implementation must derive `B` and `V` from the cached bid.
+
+The implementation must apply both components in the same settlement operation.
+
+A test must fail if the implementation can queue `V` without also applying `B`.
+
+## Reference Implementation
+
+A complete reference implementation requires a consensus-spec change against the final post-EIP-7732 fork specification.
+
+The minimum changes are:
+
+1. Replace `ExecutionPayloadBid.value` with `gross_value`.
+2. Add deterministic helper functions for burn and payment components.
+3. Replace `BuilderPendingPayment` with `BuilderPendingSettlement`.
+4. Count burn in pending builder liability.
+5. Reserve `G - E` when consensus accepts a selected external bid.
+6. Apply `B` and `V` together in the normal settlement path.
+7. Apply `B` and `V` together in the quorum settlement path.
+8. Apply the same burn in the late-parent direct-payment path.
+9. Accumulate payment-quorum weight for burn-only consensus liabilities.
+10. Keep `execution_payment == 0` for public gossip.
+11. Rank public bids by `gross_value`.
+12. Require `gross_value == 0` and `execution_payment == 0` for self-builds.
+13. Preserve pending settlement liabilities across all builder-balance deductions.
+14. Calculate the burn without intermediate integer overflow.
+
+The following helper shows the core accounting:
+
+```python
+def compute_builder_bid_accounting(bid: ExecutionPayloadBid) -> tuple[Gwei, Gwei, Gwei]:
+    burn = Gwei(
+        bid.gross_value
+        * BUILDER_PAYMENT_BURN_NUMERATOR
+        // BUILDER_PAYMENT_BURN_DENOMINATOR
+    )
+    proposer_amount = Gwei(bid.gross_value - burn)
+    assert bid.execution_payment <= proposer_amount
+    trustless = Gwei(proposer_amount - bid.execution_payment)
+    consensus_liability = Gwei(burn + trustless)
+    return burn, trustless, consensus_liability
+```
+
+## Security Considerations
+
+### Undeclared proposer compensation
+
+Ethereum can burn only value that appears in consensus-visible bid data.
+
+A builder and proposer can try to move compensation outside `gross_value`.
+
+Examples include later transfers, bilateral agreements, vertically integrated accounting, or other side payments.
+
+This EIP does not make undeclared value observable.
+
+This EIP does not claim to burn undeclared value.
+
+A higher burn fraction gives a stronger incentive to use an untaxed payment path.
+
+For this reason, mainnet activation should use measurements or simulations of value-weighted payment retention for candidate rates.
+
+### Trusted payment default
+
+`execution_payment` remains trusted.
+
+A proposer that accepts `E > 0` accepts counterparty risk.
+
+Consensus does not insure that risk.
+
+This EIP makes a large declared trusted payment costly to exaggerate if it increases `G`.
+
+A larger `G` causes a larger fully collateralized burn.
+
+However, the builder can still fail to deliver `E`.
+
+The public gossip path avoids this risk because it requires `E == 0`.
+
+### Proposer ranking across trust classes
+
+The burn increases with `gross_value`.
+
+A rational proposer values a private bid according to the expected value of the trusted payment.
+
+Therefore, the proposer can select a lower-`gross_value` bid if the other bid has more trusted-payment risk.
+
+This result is normal credit-risk pricing. It is not a consensus failure.
+
+The protocol does not define a global credit model.
+
+### Self-build avoidance and vertical integration
+
+Self-build has no burn because the protocol cannot objectively measure internal MEV.
+
+This exemption can create an avoidance path.
+
+A large staking operator can own or control a specialized builder. The operator can then use self-build for valuable slots.
+
+If high-value external-builder slots move to integrated self-build, realized burn can decrease.
+
+This behavior can also increase the advantage of large or vertically integrated staking operators.
+
+Evaluation must measure more than the self-build block count.
+
+Evaluation should estimate the value that moved from external bidding to self-build.
+
+Evaluation should also measure the concentration of high-value self-build by operator.
+
+### Builder capital concentration
+
+The builder must fully collateralize the burn.
+
+A fully trustless public bid requires collateral for all of `G`.
+
+A private bid can reduce consensus collateral by using `E` for part of proposer compensation.
+
+A high burn rate still creates material collateral requirements.
+
+Exceptional-MEV slots can create especially large requirements.
+
+Multiple pending liabilities can also increase working-capital needs.
+
+Large collateral requirements can favor large builders.
+
+Builder balance concentration and builder market concentration should be measured before and after activation.
+
+### Residual proposer jackpots
+
+A proportional burn reduces a visible proposer payment by the configured fraction.
+
+It does not remove the remaining payment.
+
+At a one-third burn rate, about two thirds of a fully trustless gross bid remains proposer compensation.
+
+An exceptional bid can therefore still create a large proposer windfall.
+
+Large remaining windfalls can preserve incentives for reorganization, key theft, targeted denial of service, or operator misconduct.
+
+For security analysis, proposer-payment percentiles are more useful than aggregate burn alone.
+
+The analysis should include p99 and p99.9 proposer payments.
+
+### Builder payload withholding
+
+This EIP does not solve the EIP-7732 builder free-option or payload-withholding problem.
+
+This EIP changes the destination of a payable builder commitment.
+
+This EIP does not add a delivery bond or a new withholding penalty.
+
+A future EIP-7732 liability change must preserve the atomic relationship between `B` and `V`.
+
+### Reorganizations and liability coupling
+
+The burn and the trustless proposer payment must use the same payable condition.
+
+An implementation must not charge the burn before the shared liability decision.
+
+An implementation must not release one component and charge the other component.
+
+An incorrect implementation can create supply-accounting errors or unfair builder losses.
+
+Tests must cover reorganization, proposer slashing, payload absence, quorum payment, and delayed payload processing.
+
+### Supply accounting
+
+The burn decreases a consensus-layer builder balance.
+
+The protocol does not create an execution-layer withdrawal for the burned amount.
+
+Supply accounting must count the destruction exactly once.
+
+The protocol must not also represent the burn as an execution-layer transfer or withdrawal.
+
+### Integer arithmetic and rounding
+
+The burn uses integer floor division.
+
+The division remainder stays in proposer compensation.
+
+Implementations must not use floating-point arithmetic.
+
+Implementations must not allow intermediate overflow in the burn calculation. This requirement applies even when `gross_value` is near the maximum `Gwei` value and the configured numerator is greater than one.
+
+All implementations must calculate the same integer result.
+
+### Burn observability
+
+The burn is a consensus-layer balance reduction. It is not an execution-layer transfer.
+
+Supply tools and economic monitors still need a simple way to audit each burn.
+
+Canonical data must make each burn derivable.
+
+Clients should expose `gross_value`, burn, trusted payment, trustless payment, and settlement status through stable inspection surfaces.
+
+### No new attester pricing duty
+
+This EIP does not add a local burn floor.
+
+This EIP does not add MEV-price attestations.
+
+This EIP does not add a burn rule to fork choice.
+
+An implementation must not reject an otherwise valid block because the node saw a higher builder bid locally.
+
+This requirement prevents consensus behavior from depending on local message history.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](../LICENSE.md).


### PR DESCRIPTION
## Summary

Adds EIP-8375, a unified MEV-burn mechanism for EIP-7732 ePBS.

- Burns a configured fraction of aggregate transaction priority fees on every executed payload, including self-builds.
- Treats the same fraction of an external builder's `gross_value` as an auction burn target. The signed whole-Gwei priority-fee credit offsets the builder top-up, avoiding an additive double burn while preserving atomic payment and full bid-time collateral.
- Extends the PTC to report verifiable public bids. A robust order statistic and configurable haircut produce the local external-bid threshold.
- Filters a below-threshold external subtree through the following slot so honest fork choice can create and support a competing branch, then returns both branches to ordinary fork choice. Self-build remains unconditional.
- Adds coordinated EL, CL, Engine API, P2P, settlement, and honest-validator changes. Floor timing, threshold, and haircut remain TBD pending propagation and adversarial analysis.

## Aim

Reduce protocol-visible proposer windfalls and make trivial bilateral under-declaration costly on the normal external-builder path when public price discovery propagates. The mechanism does not claim coalition-proof burn: private or late value and proposer-authorized outsourced self-build remain explicit residual paths.