### PR TITLE
Update EIP-7906: specify handling of reserved `must be 0` inputs

### DIFF
--- a/EIPS/eip-7906.md
+++ b/EIPS/eip-7906.md
@@ -163,6 +163,10 @@ For params `0x00`–`0x05`, the accessed slot or address is added to the respect
 
 `codehash_before` is equal to the empty-code hash for undeployed contracts.
 
+### Reserved Inputs
+
+Any `in2`/`in3` operand marked *must be 0* in the parameter tables above MUST be zero; supplying a non-zero value causes an exceptional halt.
+
 ### Results Ordering
 
 Balance and storage slot changes returned by the `TXTRACE` opcode are enumerated in ascending order sorted by the affected address as a numerical `uint160` value.


### PR DESCRIPTION
The `TXTRACE`/`TXDIFF` parameter tables mark several `in2`/`in3` operands as *must be 0*, but the spec never defines what happens on a non-zero value — so clients will diverge (and because these run in a `POST_TX` frame, a divergence changes post-transaction state and thus block validity). This PR states that a non-zero value causes an exceptional halt, i.e. reserved-field semantics, so the operand space can be given meaning by a later EIP.

The alternative reading is "ignore unused inputs"; if that is preferred, the same sentence can say so instead. Either way it needs to be stated.
