### PR TITLE
Update EIP-7906: specify EIP-7928 recording of TXDIFF state reads

### DIFF
--- a/EIPS/eip-7906.md
+++ b/EIPS/eip-7906.md
@@ -159,7 +159,7 @@ The actual nonce value is not observable through `TXTRACE` or `TXDIFF`.
 - Balance and codehash params (`0x02`–`0x05`): `COLD_ACCOUNT_ACCESS_COST` (2600) if the address is not in the accessed addresses set; `WARM_STORAGE_READ_COST` (100) otherwise.
 - Per-address view and flags params (`0x06`–`0x0A`): a flat cost of `TXTRACE_GAS_COST`. These params are answered entirely from the transaction-local state diff and never read the live state.
 
-For params `0x00`–`0x05`, the accessed slot or address is added to the respective access list after the call. Params `0x06`–`0x0A` do not interact with the [EIP-2929](./eip-2929.md) access lists.
+For params `0x00`–`0x05`, the accessed slot or address is added to the [EIP-2929](./eip-2929.md) access list after the call, and — where [EIP-7928](./eip-7928.md) is active — recorded in the block-level access list, like any other state-reading opcode. `TXTRACE` and `EVENTDATACOPY` read only already-recorded diff and log data and therefore add no new accesses. Params `0x06`–`0x0A` do not interact with the [EIP-2929](./eip-2929.md) access lists.
 
 `codehash_before` is equal to the empty-code hash for undeployed contracts.
 


### PR DESCRIPTION
`TXDIFF` params `0x00`–`0x05` read live current state and, per the spec, update the EIP-2929 access list. Under [EIP-7928](./eip-7928.md) every state access during block execution is recorded in the block-level access list, which is committed in the block header. The spec does not say whether these POST_TX-frame reads are recorded, so clients that disagree produce different BALs and reject each other's blocks — a consensus split.

This states that they **are** recorded, like any other state-reading opcode: `POST_TX` frames are re-executed by validators, so the state they touch is genuinely needed, and it is the natural result of routing the reads through the normal state accessor. Scope is narrow — `TXTRACE` and `EVENTDATACOPY` read already-recorded diff/log data and add no accesses.

If the author prefers that assertion-frame reads be excluded from the BAL, that is the alternative to state instead; either way it needs to be defined.