### PR TITLE
Update EIP-7906: define `contracts_deployed` precisely and specify absent-topic halts

### DIFF
--- a/EIPS/eip-7906.md
+++ b/EIPS/eip-7906.md
@@ -77,9 +77,9 @@ The available parameters are listed in the table below.
 | 0x0D    | index in `events_count`       | `events_address` - the address of the contract that emitted the event         |
 | 0x0E    | index in `events_count`       | `event_topic_count` - the number of topics of the event (0–4)                 |
 | 0x0F    | index in `events_count`       | `event_topic0` - the first topic of the event; exceptional halt if no topic   |
-| 0x10    | index in `events_count`       | `event_topic1` - the second topic of the event                                |
-| 0x11    | index in `events_count`       | `event_topic2` - the third topic of the event                                 |
-| 0x12    | index in `events_count`       | `event_topic3` - the fourth topic of the event                                |
+| 0x10    | index in `events_count`       | `event_topic1` - the second topic of the event; exceptional halt if no such topic |
+| 0x11    | index in `events_count`       | `event_topic2` - the third topic of the event; exceptional halt if no such topic  |
+| 0x12    | index in `events_count`       | `event_topic3` - the fourth topic of the event; exceptional halt if no such topic |
 | 0x13    | index in `events_count`       | `event_data_len` - the byte length of the event's non-indexed data            |
 | 0x14    | must be 0                     | `gas_pre_charge` - the total amount deducted from the gas payer               |
 | 0x15    | must be 0                     | `gas_payer_address` - the address charged the gas pre-charge                  |
@@ -96,6 +96,8 @@ The `gas_payer_address` is the target of whichever frame called `APPROVE(APPROVE
 The `before` values reflect the transaction prestate values recorded before the start of entire transaction's execution, before any state writes made in relation to this transaction. The `after` values reflect the current state as of the `TXTRACE` opcode call. Intermediary writes between transaction start and the `TXTRACE` call are not observable separately.
 
 An address will appear in `balances_changed` when its balance at the time of the `TXTRACE` call differs from its balance at transaction start. This includes the gas fee pre-charge applied to the gas payer address. Callers computing the net ETH transferred to or from an address can look up the gas payer via `gas_payer_address` (param `0x15`) and subtract `gas_pre_charge` (param `0x14`) from that address's balance delta.
+
+An address appears in `contracts_deployed` when its code hash changed during the transaction from the empty-code hash to a non-empty code hash that is not an [EIP-7702](./eip-7702.md) delegation designator. An account that a `CREATE`/`CREATE2` leaves with empty code is not enumerated, as it has no code change.
 
 ### Transaction Diff Lookup Opcode
 


### PR DESCRIPTION
**`contracts_deployed`.** "Newly deployed contract" is ambiguous, and the only signal derivable from the state diff is the code-hash transition. This adds a precise definition — code hash going from the empty-code hash to a non-empty, non-designator code hash — which:
- excludes an [EIP-7702](./eip-7702.md) delegation designator written to a fresh EOA (a code change, not a contract deployment — still observable via the code change-flag / codehash params);
- notes that a `CREATE`/`CREATE2` leaving empty code is not enumerated, since it produces no code change.

If the author would rather have `contracts_deployed` count 7702 designators too, that is the alternative; the point is that it must be pinned down, as clients otherwise classify these cases inconsistently.

**Absent topics.** The Rationale (*Individual Topic Access*) already says accessing a topic at or beyond `event_topic_count` halts, but the normative table states this only for topic 0 (`0x0F`). This makes rows `0x10`–`0x12` say the same, so the Specification is self-consistent.