### PR TITLE
Update EIP-8077: define source and nonce for frame transactions

### DIFF
--- a/EIPS/eip-8077.md
+++ b/EIPS/eip-8077.md
@@ -36,15 +36,31 @@ Modify the NewPooledTransactionHashes (0x08) message as follows:
 
 (eth/XX): [txtypes: B, [txsize₁: P, txsize₂: P, ...], [txhash₁: B_32, txhash₂: B_32, ...], [txsource₁: B_20, txsource₂: B_20, ...], [txnonce₁: P, txnonce₂: P, ...]]
 
+### Announced source and nonce
+
+`txsource` is the account whose nonce the transaction consumes, and `txnonce` is the nonce value it consumes.
+
+For transaction types `0x00` through `0x04`, `txsource` is the address recovered from the transaction's signature and `txnonce` is the transaction's `nonce` field.
+
+For [EIP-8141](./eip-8141.md) frame transactions, `txsource` is the transaction's explicit `sender` field and `txnonce` is its `nonce` field. [EIP-8250](./eip-8250.md) replaces that `nonce` field with `nonce_keys` and `nonce_seq`, and `txnonce` is then `nonce_seq`. The sender is not recovered from a signature, is not necessarily the address of any entry in the transaction's `signatures` list, and may be a contract account.
+
 ### Changes to message handling
 
 Changes on the sender side of `NewPooledTransactionHashes` messages are trivial. Only the transmitted data changes. Since the size of announcements is increased, implementations MAY revisit the condition (typically transaction size) to select between eager push and announcement.
 
 At the receiver side of `NewPooledTransactionHashes` messages the extra information can be used to improve scheduling choices, however these are not mandated by the protocol and thus we leave it to implementations.
 
+The announced nonce is not always an account nonce. Where [EIP-8250](./eip-8250.md) is active, a frame transaction may consume a keyed nonce sequence instead of the sender's account nonce, in which case `txnonce` is that sequence's value and is unrelated to `state[txsource].nonce`; a valid transaction can announce a sequence value either far below or far above it. Which of the two a frame transaction uses is not visible in the announcement. Receivers therefore MUST NOT compare the `txnonce` of a frame transaction against `state[txsource].nonce`, neither to discard the announcement as stale nor to infer a nonce gap, and MUST NOT use `<txsource, txnonce>` as the identity of a frame transaction, since under [EIP-8250](./eip-8250.md) the pending transaction identity is `<sender, nonce_keys, nonce_seq>`. The announced type distinguishes these transactions from the ones the account nonce check remains valid for.
+
 ## Rationale
 
 To solve the transaction propagation issues mentioned in the Motivation section, nodes require more information about a transaction then its hash, size, and type. By adding the source and the nonce, the receiver has enough information to make better fetch decisions.
+
+### Account abstraction
+
+[EIP-8141](./eip-8141.md) makes the sender an explicit transaction field rather than a value recovered from a signature, so a receiver has no way to derive it before fetching. Its public mempool admits at most one pending frame transaction per sender, requires that transaction's nonce to equal the sender's current nonce, and identifies pending transactions by `<sender, nonce>`. There are therefore no nonce gaps to fill for these transactions, and the announcement instead answers whether the receiver already holds a candidate for that sender. That answer is worth more than for other transaction types, because validating a frame transaction means simulating its validation prefix, so a fetch that ends in rejection costs the receiver execution and not just bandwidth.
+
+[EIP-8250](./eip-8250.md) replaces the frame transaction nonce with `<nonce_keys, nonce_seq>` and announcements carry only `nonce_seq`. Announcing the key set would reproduce the pending transaction identity exactly, but it holds up to sixteen words, and even its canonical 32-byte hash would be paid for by every announcement of every transaction type. Since the public mempool still admits only one pending frame transaction per sender, the source already carries the scheduling decision for these transactions and the nonce is left as a hint.
 
 ### Overhead
 
@@ -76,6 +92,8 @@ This EIP does not change consensus rules of the EVM and does not require a hard 
 ## Security Considerations
 
 The announced source address and nonce cannot be verified by the recipient until the transaction is actually fetched (or received through eager push). Therefore, it should not be handled as trusted information. This does not compromise the security of the protocol.
+
+Announcing a transaction whose source is chosen freely costs an attacker nothing, and a receiver that answers each announcement with a lookup of `state[txsource].nonce` performs one state read per announcement for an attacker-chosen address. This is the announcement-level form of the sender state-read amplification described in [EIP-8141](./eip-8141.md), and it argues for applying cheap checks, such as peer and rate limits, before any state access driven by announced metadata.
 
 A mismatch between the announced <txhash,type,size,address,nonce> tuple and a received transaction should be handled as a protocol violation. More in detail, after the verification of the transaction hash, it becomes clear that the sender of the announcement was either malicious, or it sent an announcement without verifying its content. Thus, the sender of the offending announcement can be treated as a node that violated the protocol.
 


### PR DESCRIPTION
clarify interaction with EIP-8141 and EIP-8250.