### PR TITLE
Update EIP-8261: Clarify epoch-based activation

### DIFF
--- a/EIPS/eip-8261.md
+++ b/EIPS/eip-8261.md
@@ -1,7 +1,7 @@
 ---
 eip: 8261
 title: Gas Limit Schedule
-description: Recommend an optional consensus layer gas limit schedule that serves as both the default target and the recommended maximum per fork.
+description: Recommend an optional post-Gloas consensus layer gas limit schedule for epoch-based defaults and maximum recommendations.
 author: Barnabas Busa (@barnabasbusa)
 discussions-to: https://ethereum-magicians.org/t/eip-8261-gas-limit-schedule/28494
 status: Draft
@@ -12,19 +12,19 @@ requires: 1559, 7732, 7892, 7935
 
 ## Abstract
 
-This EIP recommends that consensus layer clients source their gas limit preference from a hard-fork-keyed schedule — an optional `GAS_LIMIT_SCHEDULE` field in the consensus layer `config.yaml` — instead of hardcoded, release-scoped defaults. Each fork (including BPO-style lightweight "Gas Parameter Only" forks) pins a single value that plays two roles: it is the **default** gas limit that validator clients target in the absence of operator configuration, and the **recommended maximum**. Operators remain free to configure any value; clients should warn when a configured preference exceeds the scheduled value, but honor it — the maximum is a recommendation, not a rule. The schedule lives only on the consensus layer because, starting with Gloas ([EIP-7732](./eip-7732.md)), the CL drives the gas limit: the validator's preference flows through validator registrations and the builder pipeline, with no execution layer configuration involved. No consensus rules are changed: the [EIP-1559](./eip-1559.md) ±1/1024 elasticity rule remains the only gas-limit validity rule, and blocks above or below the scheduled value remain valid.
+This EIP recommends that, starting with Gloas ([EIP-7732](./eip-7732.md)), consensus layer clients source their gas limit preference from an optional `GAS_LIMIT_SCHEDULE` field in the consensus layer `config.yaml` instead of hardcoded, release-scoped defaults. Each entry activates at the start of its specified epoch and provides a value that plays two roles: it is the **default** gas limit that validator clients target in the absence of operator configuration, and the **recommended maximum**. The schedule is ignored before Gloas, preserving existing gas limit behavior. Operators remain free to configure any value; clients should warn when a configured preference exceeds the active scheduled value, but honor it because the maximum is a recommendation, not a rule. The schedule lives only on the consensus layer because post-Gloas the validator's preference flows through validator registrations and the builder pipeline, with no execution layer configuration involved. No consensus rules are changed: the [EIP-1559](./eip-1559.md) ±1/1024 elasticity rule remains the only gas-limit validity rule, and blocks above or below the scheduled value remain valid.
 
 ## Motivation
 
 Today the block gas limit is set by each block proposer, driven by validator client "preferred gas limit" settings, client default configurations, and builder bids, with the ±1/1024 elasticity rule from [EIP-1559](./eip-1559.md) moving the realized limit block by block.
 
-The pain point this EIP addresses is that gas limit defaults are **release-scoped** rather than **fork-scoped**: a new default activates whenever an operator happens to update their node, not when the network intends the change to happen. This creates a concrete coordination problem for large increases. Suppose clients want to raise the default from 60M toward a substantially higher value for an upcoming fork:
+The pain point this EIP addresses is that gas limit defaults are **release-scoped** rather than **epoch-based**: a new default activates whenever an operator happens to update their node, not at a network-coordinated epoch. This creates a concrete coordination problem for large increases. Suppose clients want to raise the default from 60M toward a substantially higher value at a future epoch:
 
-- If clients ship the new default in releases ahead of the fork, every node updated early starts voting the gas limit up *immediately* — before the fork's other capacity-relevant changes are active and before the network has agreed the new value is safe to reach.
-- The alternative — shipping the new default in a back-to-back release immediately after the fork and asking all operators to update quickly — is operationally inconvenient and slow to take effect.
-- Per-fork override flags (e.g., a `post_<fork>_gas_limit` option) push the coordination burden onto every individual operator.
+- If clients ship the new default in releases ahead of the activation epoch, every node updated early starts voting the gas limit up *immediately*, before the network has agreed the new value is safe to reach.
+- The alternative, shipping the new default in a back-to-back release immediately after the intended activation epoch and asking all operators to update quickly, is operationally inconvenient and slow to take effect.
+- One-off override flags for each planned increase push the coordination burden onto every individual operator.
 
-There is also no single place where "the gas limit the network should run at" is written down: moving the network today requires either every client team shipping a new hardcoded default, or a large share of operators updating flags, coordinated socially over months. [EIP-7935](./eip-7935.md) demonstrated that tying a default gas limit recommendation to a hard fork works; this EIP generalizes that approach into a reusable, machine-readable schedule, mirroring how [EIP-7892](./eip-7892.md) handles blob parameters with `BLOB_SCHEDULE`.
+There is also no single place where "the gas limit the network should run at" is written down: moving the network today requires either every client team shipping a new hardcoded default, or a large share of operators updating flags, coordinated socially over months. [EIP-7935](./eip-7935.md) demonstrated that coordinating a default gas limit recommendation at a known epoch works; this EIP generalizes that approach into a reusable, machine-readable schedule, mirroring the epoch-based `BLOB_SCHEDULE` configuration format from [EIP-7892](./eip-7892.md).
 
 With Gloas ([EIP-7732](./eip-7732.md)), the consensus layer becomes the natural single home for this schedule: the gas limit a block is built to originates from the validator side of the builder flow, so a CL configuration entry can drive the network's gas limit end to end without any execution layer configuration.
 
@@ -40,76 +40,88 @@ The consensus layer `config.yaml` MAY be extended with a `GAS_LIMIT_SCHEDULE` fi
 
 ```yaml
 GAS_LIMIT_SCHEDULE:
-  - EPOCH: 500000     # Activation fork (e.g., Gloas)
+  - EPOCH: 500000     # Gloas activation epoch
     GAS_LIMIT: 60000000
-  - EPOCH: 520000     # A future GPO fork
+  - EPOCH: 520000     # A later scheduled increase
     GAS_LIMIT: 75000000
-  - EPOCH: 540000     # A future GPO fork
+  - EPOCH: 540000     # Another scheduled increase
     GAS_LIMIT: 90000000
 ```
 
 `EPOCH` and `GAS_LIMIT` are `uint64` values; `GAS_LIMIT` matches the type of `ExecutionPayload.gas_limit` in the consensus specifications.
 
-The field is OPTIONAL: CL clients MAY add support for it, and clients that do not recognize it ignore it, per the existing convention for unknown configuration keys. A client that is not using the parameter — because it has not implemented support, because the field is absent from its configuration, or because the duty's epoch predates the earliest schedule entry — simply keeps whatever default gas limit it used before; nothing about its behavior changes.
+The field is OPTIONAL: CL clients MAY add support for it, and clients that do not recognize it ignore it, per the existing convention for unknown configuration keys. Supporting clients MUST ignore the schedule for duties before `GLOAS_FORK_EPOCH`. A client that is not using the parameter because the duty is pre-Gloas, the field is absent, or no schedule entry is active simply keeps its existing gas limit behavior.
 
-`gpo<index>` ("Gas Parameter Only") forks follow the same naming convention and lifecycle as BPO forks defined in [EIP-7892](./eip-7892.md): a lightweight fork whose only change is a new `GAS_LIMIT_SCHEDULE` entry. Each fork that changes the recommended gas limit adds its own entry; forks that do not change it need no new entry.
+Each entry independently schedules a recommended gas limit change at its `EPOCH`. An entry MAY align with a protocol upgrade, but the schedule itself does not create or require a fork.
 
 Define:
 
 ```python
-def get_scheduled_gas_limit(epoch: Epoch, config: Config) -> int:
+def get_scheduled_gas_limit(epoch: Epoch, config: Config) -> Optional[int]:
+    if epoch < config.GLOAS_FORK_EPOCH:
+        return None
+    active_entries = [
+        entry for entry in config.GAS_LIMIT_SCHEDULE
+        if entry.EPOCH <= epoch
+    ]
+    if not active_entries:
+        return None
     # Latest schedule entry whose EPOCH <= epoch
-    return max(
-        (entry for entry in config.GAS_LIMIT_SCHEDULE if entry.EPOCH <= epoch),
-        key=lambda entry: entry.EPOCH,
-    ).GAS_LIMIT
+    return max(active_entries, key=lambda entry: entry.EPOCH).GAS_LIMIT
 ```
 
 ### Recommended client behavior
 
-For CL clients that support `GAS_LIMIT_SCHEDULE`, the scheduled value serves as both the default gas limit and the recommended maximum:
+For CL clients that support `GAS_LIMIT_SCHEDULE`, an active scheduled value serves as both the default gas limit and the recommended maximum:
 
-- **Default.** When no operator preference is supplied, the client SHOULD use `get_scheduled_gas_limit(epoch)` as the gas limit preference, where `epoch` is the epoch of the slot the registration or proposal applies to. Clients supporting the schedule SHOULD NOT ship a separate hardcoded gas limit default; the schedule is the single source of defaults.
-- **Recommended maximum.** If an operator-supplied preference exceeds the scheduled value, the client SHOULD honor it — since this EIP introduces no enforcement, there is nothing to enforce it against — but SHOULD log a clear warning, e.g., `configured gas limit 100000000 exceeds the recommended maximum of 90000000 for this fork`. Exceeding the recommendation is thereby a deliberate, visible operator decision rather than a silent one.
+- **Default.** When no operator preference is supplied and `get_scheduled_gas_limit(epoch)` returns a value, the client SHOULD use it as the gas limit preference, where `epoch` is the epoch of the slot the registration or proposal applies to. Before Gloas or when no entry is active, the client SHOULD retain its existing default behavior. Clients SHOULD NOT introduce a separate release-scoped default for epochs covered by an active schedule entry.
+- **Recommended maximum.** If an operator-supplied preference exceeds the active scheduled value, the client SHOULD honor it, since this EIP introduces no enforcement, but SHOULD log a clear warning, e.g., `configured gas limit 100000000 exceeds the recommended maximum of 90000000 at epoch 540000`. Exceeding the recommendation is thereby a deliberate, visible operator decision rather than a silent one.
 - **Operator preferences are always honored.** Values below the scheduled value work unchanged, as today.
-- **Builders and relays.** Builders SHOULD produce, and relays SHOULD prefer, bids whose `gas_limit` does not exceed the scheduled value for the bid's slot.
+- **Builders and relays.** When a schedule entry is active, builders SHOULD produce, and relays SHOULD prefer, bids whose `gas_limit` does not exceed the scheduled value for the bid's slot.
 
-#### Fork-boundary switching
+#### Epoch-based switching
 
-The schedule only delivers its benefit if the effective default changes exactly at the fork boundary, which requires new client logic: today, gas limit defaults are read once (at startup, or when a validator registration is created) and held constant. Under this EIP, the scheduled value SHOULD be looked up per duty — against the epoch of the slot being proposed or registered for — never against wall-clock time or a value cached at startup. A node running across a fork boundary then switches its preference at the first post-fork slot with no restart, no follow-up release, and no operator action. Since validator registrations are re-issued periodically, registrations naturally roll over to a new scheduled value as duties cross the fork epoch.
+The schedule only delivers its benefit if the effective default changes exactly at the configured epoch boundary, which requires new client logic: today, gas limit defaults are read once (at startup, or when a validator registration is created) and held constant. Under this EIP, the scheduled value SHOULD be looked up per duty against the epoch of the slot being proposed or registered for, never against wall-clock time or a value cached at startup. A running node then switches its preference at the first slot of the configured epoch with no restart, follow-up release, or operator action. Since validator registrations are re-issued periodically, registrations naturally roll over to a new scheduled value as duties cross the activation epoch.
 
-Because the schedule is keyed by fork epoch, a release shipped months before a fork keeps using the current fork's value until the fork activates, then switches automatically. This makes it safe to ship large future increases well ahead of time: early updaters do not begin voting toward the new value before the fork is live.
+Because the schedule is keyed by epoch, a release shipped months before an entry activates keeps using the current value until that epoch, then switches automatically. This makes it safe to ship large future increases well ahead of time: early updaters do not begin voting toward the new value before its configured activation epoch.
 
 #### The consensus layer drives the gas limit
 
-Starting with Gloas ([EIP-7732](./eip-7732.md)), the gas limit a block is built to originates on the consensus layer side of the builder flow — the validator's preference, expressed through validator registrations and the payload bid path — rather than from execution layer configuration. The schedule therefore lives only in the CL `config.yaml`; no execution layer chain-configuration counterpart is needed, and EL gas limit flags retain their existing (pre-Gloas and local-tooling) meaning.
+Starting with Gloas ([EIP-7732](./eip-7732.md)), the gas limit a block is built to originates on the consensus layer side of the builder flow — the validator's preference, expressed through validator registrations and the payload bid path — rather than from execution layer configuration. The schedule therefore lives only in the CL `config.yaml`; no execution layer chain-configuration counterpart is needed, and EL gas limit flags retain their existing pre-Gloas and local-tooling meaning. This EIP does not change gas limit selection before Gloas.
 
 Illustrative preference selection:
 
 ```python
-def effective_gas_limit_preference(operator_preference: Optional[int], epoch: Epoch, config: Config) -> int:
+def effective_gas_limit_preference(
+    operator_preference: Optional[int],
+    existing_default: int,
+    epoch: Epoch,
+    config: Config,
+) -> int:
     scheduled = get_scheduled_gas_limit(epoch, config)
+    if scheduled is None:
+        return operator_preference if operator_preference is not None else existing_default
     if operator_preference is None:
         return scheduled
     if operator_preference > scheduled:
         log.warning(
             f"configured gas limit {operator_preference} exceeds the recommended "
-            f"maximum of {scheduled} for this fork"
+            f"maximum of {scheduled} at epoch {epoch}"
         )
     return operator_preference
 ```
 
-The realized network gas limit continues to move under the [EIP-1559](./eip-1559.md) ±1/1024 rule, so a scheduled increase plays out as a gradual, bounded ramp starting at the fork boundary rather than an instant step.
+The realized network gas limit continues to move under the [EIP-1559](./eip-1559.md) ±1/1024 rule, so a scheduled increase plays out as a gradual, bounded ramp starting at the activation epoch rather than an instant step.
 
 ## Rationale
 
-### Why fork-scoped defaults instead of release-scoped defaults?
+### Why epoch-based defaults instead of release-scoped defaults?
 
-Keying the default on the duty's epoch rather than the release version decouples *shipping* a new gas limit from *activating* it — the same property hard forks already provide for every other parameter. This directly resolves the large-increase dilemma described in the Motivation: clients can ship the schedule entry for a big raise arbitrarily early, and no node will begin voting toward it until the fork (with whatever accompanying changes make the raise safe) is live.
+Keying the default on the duty's epoch rather than the release version decouples *shipping* a new gas limit from *activating* it. This directly resolves the large-increase dilemma described in the Motivation: clients can ship the schedule entry for a big raise arbitrarily early, and no node will begin voting toward it until the configured epoch. An entry can align with a hard fork when desired, but the mechanism itself is only an epoch-based client configuration.
 
 ### Why one value for both the default and the recommended maximum?
 
-The number the community coordinates on — "the gas limit for this fork" — is the number the network runs at and the number operators are asked not to exceed. A single dial means there is no second parameter to negotiate or get out of sync, and no untested operating region between a default and a higher ceiling. Operators who want to run below it can; running above it is possible (nothing in consensus prevents it) but happens against a clear warning, which is a much stronger signal than today's silently configurable free-for-all.
+The number the community coordinates on for an epoch is the number the network runs at and the number operators are asked not to exceed. A single dial means there is no second parameter to negotiate or get out of sync, and no untested operating region between a default and a higher ceiling. Operators who want to run below it can; running above it is possible (nothing in consensus prevents it) but happens against a clear warning, which is a much stronger signal than today's silently configurable free-for-all.
 
 ### Why does the schedule live only on the consensus layer?
 
@@ -119,7 +131,7 @@ Post-Gloas, the CL is authoritative for the gas limit in practice: the validator
 
 An earlier draft of this EIP made the scheduled value a consensus-enforced maximum (and, before that, an exact-match requirement). This version is deliberately advisory:
 
-- **Adoptability.** A recommendation requires no fork, no engine API changes, and no coordination risk. The configuration field is optional, so CL teams can adopt it independently and incrementally, and it can accompany any fork as an informational companion, as [EIP-7935](./eip-7935.md) did.
+- **Adoptability.** A recommendation requires no fork, no engine API changes, and no coordination risk. The configuration field is optional, so CL teams can adopt it independently and incrementally, and entries can activate at any coordinated post-Gloas epoch.
 - **Validator sovereignty is preserved.** Gas limit choice remains, in the limit, with proposers — this EIP changes the *defaults and social convention* around that choice, not the protocol.
 - **It solves the actual coordination problem.** The premature-voting and back-to-back-release problems are default-management problems, and defaults are client behavior. Consensus enforcement addresses a different (drift-above-tested-envelope) risk, and can be pursued later as a separate Core EIP layered on the same schedule if the community wants it.
 
@@ -129,17 +141,17 @@ Clamping a preference down to the scheduled value would be enforcement — just 
 
 ### Relationship to EIP-7935
 
-[EIP-7935](./eip-7935.md) recommended a single default (60M) tied to a single fork (Fusaka). This EIP generalizes that one-off into a standing, machine-readable schedule so that every future change — including lightweight `gpo<index>` forks — reuses the same mechanism instead of requiring a new EIP and a fresh round of client-default coordination.
+[EIP-7935](./eip-7935.md) recommended a single default (60M) tied to Fusaka's activation. This EIP generalizes that one-off into a standing, machine-readable epoch schedule so future changes reuse the same mechanism instead of requiring a new EIP and a fresh round of client-default coordination.
 
 ## Backwards Compatibility
 
-No consensus rules change and no blocks become invalid. Existing operator settings keep working; the only behavioral changes, in CL clients that opt into the schedule, are that unconfigured validators derive their gas limit preference from the schedule instead of a hardcoded constant, and configured values above the scheduled maximum produce a warning (but are honored). CL clients that do not adopt the field, and all EL clients, are unaffected. Tooling that reads `block.gas_limit` is unaffected.
+No consensus rules change and no blocks become invalid. Pre-Gloas behavior and existing operator settings remain unchanged. For post-Gloas duties covered by an active schedule entry, unconfigured validators derive their gas limit preference from the schedule instead of a hardcoded constant, and configured values above the scheduled maximum produce a warning but are honored. CL clients that do not adopt the field, and all EL clients, are unaffected. Tooling that reads `block.gas_limit` is unaffected.
 
 ## Security Considerations
 
 **The ceiling is advisory.** Nothing in consensus prevents a proposer from exceeding the scheduled value, so this EIP does not protect against a deliberately non-conforming actor. It does protect against the accidental paths — a default shipped early, a stale setting, an uncoordinated bump — which historically are how unintended gas limit movement happens. The ±1/1024 elasticity rule further rate-limits how fast any actor, conforming or not, can move the realized limit.
 
-**Herding on the schedule.** If most validators follow the schedule, the network's gas limit becomes highly predictable, which is the goal. It also means an error in a scheduled value propagates widely; scheduled values should receive the same devnet and worst-case-block testing that gas limit increases receive today (as described in [EIP-7935](./eip-7935.md)) before being added to a fork's configuration.
+**Herding on the schedule.** If most validators follow the schedule, the network's gas limit becomes highly predictable, which is the goal. It also means an error in a scheduled value propagates widely; scheduled values should receive the same devnet and worst-case-block testing that gas limit increases receive today (as described in [EIP-7935](./eip-7935.md)) before being added to a network's configuration.
 
 **Partial adoption.** Because the field is optional, clients that do not support it keep their existing defaults, and their operators keep coordinating manually. The mechanism's coordination benefit is proportional to adoption; a mixed network is no worse than today, since non-supporting clients behave exactly as they do now.
 


### PR DESCRIPTION
Aligns the EIP terminology and activation behavior with the epoch-keyed `GAS_LIMIT_SCHEDULE` implementation.

- replace fork-scoped and GPO wording with epoch-based activation language
- ignore the schedule before `GLOAS_FORK_EPOCH`
- preserve existing client defaults when the schedule is unavailable or has no active entry
- update the lookup and preference-selection pseudocode accordingly

@barnabasbusa this changes specification wording and makes the post-Gloas activation rule explicit, so author approval is required.

> This PR was written primarily by Codex.
