### PR TITLE
Update EIP-8070: Clarify custodyColumns `null` behavior

### DIFF
--- a/EIPS/eip-8070.md
+++ b/EIPS/eip-8070.md
@@ -96,7 +96,7 @@ Request:
 - params:
   1. `forkchoiceState`: `ForkchoiceStateV1`.
   2. `payloadAttributes`: `Object|null` - Instance of `PayloadAttributesV4` or `null`.
-  3. `custodyColumns`: `DATA|null` - 16-byte value interpreted as a bitarray of length `CELLS_PER_EXT_BLOB`, where a `1` at position `i` indicates the CL node has custody of column `i`. `null` if the CL does not provide custody services.
+  3. `custodyColumns`: `DATA|null` - 16-byte value interpreted as a bitarray of length `CELLS_PER_EXT_BLOB`, where a `1` at position `i` indicates the CL node has custody of column `i`. `null` if the CL is unable to provide an update.
 - timeout: 8s
 
 Response:
@@ -110,7 +110,7 @@ Specification:
 3. For type 3 transactions pending in the blobpool:
     1. If the custody set has expanded relative to the previously known set, the Execution client MUST issue new sampling requests for the delta columns. It SHOULD broadcast updated `NewPooledTransactionHashes` announcements reflecting the expanded available set when act as a sampler.
     2. If the custody set has contracted, the Execution client MAY prune dropped cells from local storage, but only AFTER broadcasting an updated `NewPooledTransactionHashes` announcement with the reduced available set, to avoid peers perceiving availability fault.
-4. The Execution client MUST treat a `custodyColumns` value identical to the current custody set as a no-op with respect to blobpool state, while still processing the rest of the forkchoice update normally.
+4. The Execution client MUST treat a `custodyColumns` value identical to the current custody set or a `null` value as a no-op with respect to blobpool state, while still processing the rest of the forkchoice update normally.
 
 **Method `engine_getBlobsV4`**
 


### PR DESCRIPTION
EIP-8070 specifies that in fcuV4, `custodyColumns` should be `null` if the CL does not provide custody services. This is not really meaningful as CLs must provide "custody services". 

Geth currently ignores `null` values and continues to use the previously sent value. Codify this in the EIP.