### PR TITLE
Update EIP-8148: Allow setting the sweep threshold at deposit time.

### DIFF
--- a/EIPS/eip-8148.md
+++ b/EIPS/eip-8148.md
@@ -51,9 +51,10 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 #### Consensus layer
 
-| Name                       | Value                                               |
-| -------------------------- | --------------------------------------------------- |
-| `MIN_SWEEP_THRESHOLD`      | `MIN_ACTIVATION_BALANCE + Gwei(1 * 10**9)` (33 ETH) |
+| Name                                 | Value                                               | Comment                                                                |
+| ------------------------------------ | --------------------------------------------------- | ---------------------------------------------------------------------- |
+| `MIN_SWEEP_THRESHOLD`                | `MIN_ACTIVATION_BALANCE + Gwei(1 * 10**9)` (33 ETH) |                                                                        |
+| `SWEEP_THRESHOLD_CREDENTIAL_OFFSET`  | `10`                                                | Byte offset of the threshold embedded in `0x02` withdrawal credentials |
 
 ### Execution layer
 
@@ -600,8 +601,69 @@ The [Rationale](#rationale) section contains an explanation for this proposed co
 6. Modify the `is_partially_withdrawable_validator` predicate to take into account the custom sweep threshold.
 7. Add `get_effective_sweep_threshold` helper function to compute the effective sweep threshold for a validator.
 8. Modify the `get_expected_withdrawals` function to use the custom sweep threshold when determining partial withdrawals.
+9. Add `get_credential_sweep_threshold` helper function to decode a threshold embedded in withdrawal credentials.
+10. Modify the `add_validator_to_registry` function to initialize a new validator's threshold from its withdrawal credentials.
 
-By default, all validators will have their sweep thresholds set to the current default `MAX_EFFECTIVE_BALANCE`, both for existing validators and new ones. Validators can choose to set a custom threshold above their current balance by submitting a set sweep threshold request through the execution layer contract.
+Validators with compounding withdrawal credentials (`0x02`) that already exist at the fork, and new `0x02` validators whose credentials carry no threshold, are given a threshold of `MAX_EFFECTIVE_BALANCE_ELECTRA`. Validators with `0x00` or `0x01` credentials are given a threshold of `0`.
+
+A `0x02` validator may instead be created with a custom threshold, by encoding it in the withdrawal credentials of the deposit that creates it. In every case the threshold can be changed afterwards to any value at or above the validator's current balance by submitting a set sweep threshold request through the execution layer contract.
+
+#### Setting the threshold at deposit time
+
+A validator MAY be created with a custom threshold already in place, by encoding it in the `0x02` withdrawal credentials of the deposit that creates it. Compounding credentials reserve bytes `1` through `11`. The two bytes at `SWEEP_THRESHOLD_CREDENTIAL_OFFSET` are redefined to hold the threshold, expressed in units of `EFFECTIVE_BALANCE_INCREMENT` as a big-endian `uint16`:
+
+| Bytes     | Contents                                                       |
+| --------- | -------------------------------------------------------------- |
+| `0`       | `COMPOUNDING_WITHDRAWAL_PREFIX` (`0x02`)                       |
+| `1..9`    | Reserved, MUST be zero                                         |
+| `10..11`  | Threshold in `EFFECTIVE_BALANCE_INCREMENT` units, big-endian   |
+| `12..31`  | Execution address                                              |
+
+A value of zero means no threshold was requested. Because a threshold is constrained to be a multiple of `EFFECTIVE_BALANCE_INCREMENT` anyway, two bytes express every permitted value: the largest encodable threshold is `65535 * EFFECTIVE_BALANCE_INCREMENT`, or 65,535 ETH. Nine reserved bytes are left untouched.
+
+```python
+def get_credential_sweep_threshold(withdrawal_credentials: Bytes32) -> Gwei:
+    """
+    Decode the optional sweep threshold embedded in compounding withdrawal credentials.
+    Returns 0 when unset or out of range, in which case the default threshold applies.
+    """
+    increments = (
+        withdrawal_credentials[SWEEP_THRESHOLD_CREDENTIAL_OFFSET] * 256
+        + withdrawal_credentials[SWEEP_THRESHOLD_CREDENTIAL_OFFSET + 1]
+    )
+
+    threshold = Gwei(increments * EFFECTIVE_BALANCE_INCREMENT)
+    if threshold < MIN_SWEEP_THRESHOLD or threshold > MAX_EFFECTIVE_BALANCE_ELECTRA:
+        return Gwei(0)
+
+    return threshold
+```
+
+Only the deposit that creates the validator is read. `add_validator_to_registry` is reached solely when the public key is absent from the registry, so the credentials of a subsequent top-up deposit, and any threshold they carry, are ignored exactly as the withdrawal address already is.
+
+`add_validator_to_registry` is modified to consult the embedded value. A threshold that is out of range, or that is below the deposited amount, is ignored rather than rejected, so that a deposit built by tooling unaware of this EIP, or carrying a nonsensical value, still creates a validator with the default threshold:
+
+```python
+def add_validator_to_registry(
+    state: BeaconState, pubkey: BLSPubkey, withdrawal_credentials: Bytes32, amount: uint64
+) -> None:
+    index = get_index_for_new_validator(state)
+    validator = get_validator_from_deposit(pubkey, withdrawal_credentials, amount)
+    set_or_append_list(state.validators, index, validator)
+    set_or_append_list(state.balances, index, amount)
+    set_or_append_list(state.previous_epoch_participation, index, ParticipationFlags(0b0000_0000))
+    set_or_append_list(state.current_epoch_participation, index, ParticipationFlags(0b0000_0000))
+    set_or_append_list(state.inactivity_scores, index, uint64(0))
+
+    # [New in EIP-8148]
+    threshold = Gwei(0)
+    if has_compounding_withdrawal_credential(validator):
+        threshold = get_credential_sweep_threshold(withdrawal_credentials)
+        if threshold < amount:
+            threshold = MAX_EFFECTIVE_BALANCE_ELECTRA
+
+    set_or_append_list(state.validator_sweep_thresholds, index, threshold)
+```
 
 Full consensus layer specification can be found in `specs/_features/eip8148/beacon-chain.md` (PR 4901 in the consensus-specs repository).
 
@@ -638,6 +700,10 @@ To maintain consistency with the existing balance increments in the protocol, we
 ## Backwards Compatibility
 
 This EIP introduces backwards incompatible changes to the block structure and block validation rule set. But neither of these changes break anything related to the current user activity and experience.
+
+Bytes `10` and `11` of compounding withdrawal credentials are given a meaning they did not previously have. No consensus function read them before this EIP, so no existing validator's behaviour changes: thresholds for validators that already exist at the fork are initialized from the fork transition, not from their credentials, and only deposits processed after the fork are interpreted. A pre-existing validator whose credentials happen to carry a non-zero value in those bytes is therefore unaffected.
+
+Deposits that leave the bytes zero, which is every deposit produced by tooling written before this EIP, behave exactly as they do today and receive the default threshold.
 
 ## Security Considerations
 


### PR DESCRIPTION
Currently, the EIP-8148 allows to set a custom sweep threshold only for an already existing validator.
As a consequence, to create a new (`0x02`) validator with a custom sweep threshold, two steps are needed:
1. Deposit the `0x02` validator. The threshold will be automatically set at 2,048 ETH.
2. Send a "Set sweep threshold request".

This pull requests proposes to target 2 of the unused bytes of the `0x02` withdrawal credential to directly set a custom sweep threshold at deposit time.

**Note:** This PR does **not** offer a way to set a custom threshold when using a self consolidation when changing `a 0x01` to a `0x02` validator. This part would be less straightforward. 


Corresponding consensus spec change:
- https://github.com/ethereum/consensus-specs/pull/5537