### PR TITLE
Update EIP-7773: Use Unicode emoji for mascot

### DIFF
--- a/EIPS/eip-7773.md
+++ b/EIPS/eip-7773.md
@@ -100,7 +100,7 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Declined
 
 ### Mascot
 
-Polar bear :polar_bear: is the mascot for the Glamsterdam network upgrade, as per the [EIP-8066](./eip-8066.md) process.
+Polar bear 🐻‍❄️ is the mascot for the Glamsterdam network upgrade, as per the [EIP-8066](./eip-8066.md) process.
 
 ### Activation
 


### PR DESCRIPTION
Follow-up to #12116.

That PR added the mascot using the `:polar_bear:` emoji shortcode, which renders on GitHub but not on the EIP site — `jemoji` is not enabled in `_config.yml`, so the shortcode is published as literal text.

This replaces it with the literal Unicode polar bear (U+1F43B U+200D U+2744 U+FE0F), which kramdown passes through unchanged. Other EIPs already use raw Unicode emoji this way (see EIP-7940).

🤖 Generated with [Claude Code](https://claude.com/claude-code)