### PR TITLE
Update EIP-8066: Use Unicode emoji, genericize POAP reference

### DIFF
--- a/EIPS/eip-8066.md
+++ b/EIPS/eip-8066.md
@@ -18,7 +18,7 @@ This EIP establishes a mascot for each Ethereum network upgrade. Mascots serve t
 Ethereum network upgrades often introduce complex technical changes that can feel abstract to the broader community. Mascots provide a fun, memorable, and relatable symbol for each upgrade, drawing inspiration from its headliner(s). By mandating emoji-representable mascots that are cute and non-offensive, this process:
 
 - Enhances community participation and excitement around network upgrades.
-- Creates opportunities for creative expression in upgrade event branding (e.g., watch parties, POAPs).
+- Creates opportunities for creative expression in upgrade event branding (e.g., watch parties, attendance NFTs).
 - Builds a consistent, whimsical tradition that differentiates Ethereum's upgrade narrative from other ecosystems.
 
 ## Specification
@@ -28,7 +28,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 ### 1. Mascot Requirements
 
 - **Relevance**: The mascot **SHOULD** relate thematically to the network upgrade's headliner(s).
-- **Representation**: The mascot **MUST** be expressible using one or more standard Unicode emojis (e.g., :panda: for the Merge).
+- **Representation**: The mascot **MUST** be expressible using one or more standard Unicode emojis (e.g., 🐼 for the Merge).
 - **Form**: The mascot **SHOULD** depict an animal (real, mythical, or stylized, but always animal-adjacent).
 - **Tone**: The mascot **MUST NOT** be offensive (no depictions of violence, discrimination, or controversy) and **SHOULD** be inherently cute (e.g., avoiding aggressive or fearsome traits unless softened for adorability).
 

--- a/EIPS/eip-8066.md
+++ b/EIPS/eip-8066.md
@@ -73,7 +73,7 @@ Alternatives considered:
 
 ## Backwards Compatibility
 
-This EIP does not directly change the Ethereum protocol. It formalizes part of the current network upgrade process.  Past upgrades (e.g., Shapella's owl :owl:) are retroactively honored if they fit the criteria; future upgrades **MUST** comply starting with the next hard fork post-adoption.
+This EIP does not directly change the Ethereum protocol. It formalizes part of the current network upgrade process.  Past upgrades (e.g., Shapella's owl 🦉) are retroactively honored if they fit the criteria; future upgrades **MUST** comply starting with the next hard fork post-adoption.
 
 ## Security Considerations
 


### PR DESCRIPTION
Editorial fixes to EIP-8066.

**Emoji shortcodes.** The `:panda:` and `:owl:` shortcodes render on GitHub but not on the EIP site — `jemoji` is not enabled in `_config.yml`, so they are published as literal text. Replaced with the literal Unicode 🐼 (U+1F43C) and 🦉 (U+1F989). Same issue as #12152.

**POAP reference.** Replaced the POAP brand name in the Motivation section with the generic "attendance NFTs".

The Draft → Review status change previously in this PR has been split out into its own PR so these editorial fixes are not blocked behind editor review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)