### PR TITLE
Update EIP-8141: forbid approval scope on frames inside an atomic batch

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -169,6 +169,14 @@ for i, frame in enumerate(tx.frames):
         assert frame.mode != VERIFY
         assert i + 1 < len(tx.frames)            # must not be last frame
         assert tx.frames[i + 1].mode != VERIFY   # batches never contain VERIFY frames
+
+    # A frame that belongs to an atomic batch must not be allowed to approve. Approval
+    # effects (payer, sender nonce increment, fee collection, and the transaction-scoped
+    # approval context) are not reverted when a failed atomic batch is unrolled, so a frame
+    # in a batch that approves would break the batch's all-or-nothing guarantee. A frame
+    # belongs to a batch when it sets ATOMIC_BATCH_FLAG or immediately follows one that does.
+    if (frame.flags & ATOMIC_BATCH_FLAG) or (i > 0 and tx.frames[i - 1].flags & ATOMIC_BATCH_FLAG):
+        assert not (frame.flags & APPROVE_SCOPE_MASK)
 ```
 
 #### Transaction Signatures


### PR DESCRIPTION
The frame well-formedness rules do not say whether a frame that belongs to an
atomic batch may declare an approval scope, and the two readings give opposite
validity verdicts for the same transaction.

Reading one: nothing forbids it, so a batched frame that calls APPROVE is
well-formed, and EIP-8250 already defines what happens to its effects when the
batch unrolls
(https://github.com/ethereum/EIPs/blob/a9584bbd20088bc85a12558f2fdcbe502c6b40aa/EIPS/eip-8250.md?plain=1#L174):
payer, nonce, and approval context survive the rollback.

Reading two: an atomic batch is all or nothing, but those approval effects are
explicitly not rolled back, so an approval inside a batch contradicts the batch
guarantee and should be rejected before execution.

An implementation has to pick one, and picking differently is a consensus split
on that transaction. The mempool rules already forbid ATOMIC_BATCH_FLAG in the
validation prefix, which points at reading two, but that is a propagation rule
and not a validity rule, so it does not settle the case reached outside the
public mempool.

This adds a well-formedness assertion for reading two: a frame that sets
ATOMIC_BATCH_FLAG, or immediately follows one that does, must not declare an
approval scope. It leaves the EIP-8250 paragraph untouched, since approval
effects still survive a later batch unroll when the approval frame precedes the
batch rather than sitting inside it. The canonical Approve plus Swap example is
unaffected, because there the batched frames are ordinary calls and the APPROVE
frame is outside the batch.

Is reading two the intended semantics? If approval inside a batch is meant to be
valid, this should be dropped and the survival rule kept as the normative answer.
