### PR TITLE
Update EIP-8141: dispatch a precompile targeted by a frame

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -415,7 +415,8 @@ Then for each frame:
         - As with an ordinary `CALL`, if the caller does not have sufficient balance to transfer `frame.value`, the frame reverts.
         - If `frame.value > 0` and `resolved_target` does not exist, `STATE_BYTES_PER_NEW_ACCOUNT * CPSB` state gas is charged after the balance check and before the frame's code executes, as in [EIP-2780](./eip-2780.md). If `state_gas_left` cannot cover the charge, the frame halts exceptionally.
         - A non-zero value transfer to an address other than `tx.sender` emits the transfer log specified by [EIP-7708](./eip-7708.md).
-    - If `resolved_target` code hash is empty, i.e. `0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470`, execute the logic described in [default code](#default-code).
+    - If `resolved_target` is an active precompile at the current fork, the frame dispatches it as an ordinary call would.
+    - Otherwise, if `resolved_target` code hash is empty, i.e. `0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470`, execute the logic described in [default code](#default-code).
         - Otherwise, if `resolved_target` uses an [EIP-7702](./eip-7702.md) delegation indicator, execute according to [EIP-7702](./eip-7702.md)'s delegated-code semantics.
     - If a frame's execution reverts, its state changes and approval context (`payer`, `sender_approved`) are discarded. Additionally, if this frame has the atomic batch flag set, mark all subsequent frames in the same atomic group as skipped.
 1. If frame has mode `VERIFY` the following additional requirements are imposed:


### PR DESCRIPTION
Frame execution never says what happens when `resolved_target` is a precompile. The default-code route is described as being for accounts with no deployed code:

> Frame transactions can be used by accounts who do not have deployed code, nor an [EIP-7702](./eip-7702.md) delegation indicator via the "default code" mechanism.

but it is selected on the empty code hash alone:

> - If `resolved_target` code hash is empty, i.e. `0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470`, execute the logic described in [default code](#default-code).

A precompile shares that code hash, so it takes the route incidentally, and in `SENDER` and `DEFAULT` default code is:

> - If `mode` is `SENDER` or `DEFAULT`:
>   - Return successfully as if calling empty code.

So a frame targeting `0x04` reports success without running identity and with `frame.data` ignored. Implementations diverged on this.

This states the precompile case explicitly and dispatches it, as the frame's top-level call already would. A precompile is not an account without code — its code lives in the client — so the default-code carve-out was presumably not meant to cover it, and no new behaviour is introduced beyond ordinary call semantics.

Note this applies in every mode, whereas `execute_frame` currently gates the default-code path on `VERIFY`. The difference is not consensus-observable: a `VERIFY` frame targeting a precompile fails either way, since no key can sign for a precompile address and a dispatched precompile never calls `APPROVE`.
