### PR TITLE
Update EIP-8141: recognize a canonical passkey wallet for no-simulation admission

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -43,6 +43,7 @@ Ultimately, frame transactions realize the original vision of account abstractio
 | `SECP256K1N`               | `0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141` |
 | `SECP256R1N`               | `0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551` |
 | `VERSIONED_HASH_VERSION_KZG` | `Bytes1(0x01)` |
+| `CANONICAL_PASSKEY_WALLET_CODE_HASH` | `TBD` (pinned per fork) |
 
 ### Frame Transaction
 
@@ -797,11 +798,19 @@ The generic validation trace and opcode rules below apply to all frames in the v
 
 #### Direct Evaluation of Protocol-Defined Frames
 
-Three frame species in the validation prefix have fully protocol-defined semantics, leaving no deployed code whose behavior a node would need to discover by execution: a frame whose resolved target has the empty code hash (default code), an expiry verifier frame whose runtime code at `EXPIRY_VERIFIER` matches the canonical expiry verifier code, and a `pay` frame admitted by canonical paymaster code match per the previous section.
+Four frame species in the validation prefix have fully protocol-defined semantics, leaving no deployed code whose behavior a node would need to discover by execution: a frame whose resolved target has the empty code hash (default code), an expiry verifier frame whose runtime code at `EXPIRY_VERIFIER` matches the canonical expiry verifier code, a `pay` frame admitted by canonical paymaster code match per the previous section, and a `self_verify` or `only_verify` frame whose resolved target is a canonical passkey wallet (defined below).
 
 When every frame in the validation prefix is one of these, direct evaluation of the protocol-defined semantics is equivalent to simulation, and a node MAY use it to satisfy the validation requirements below. Direct evaluation MUST apply the same limits as simulation: signature validation and the evaluated frames' work count against `MAX_VERIFY_GAS`, and the paymaster accounting rules in this section apply unchanged.
 
 The complete state dependency set of such a validation prefix is: the sender's code hash and nonce, the payer's code hash and balance (or the canonical paymaster's tracked state), the runtime code at `EXPIRY_VERIFIER` together with the frame's deadline when an expiry verifier frame is present, and the current block timestamp. Nodes SHOULD index pending transactions by this set so that head-of-chain changes are revalidated without re-execution.
+
+#### Canonical Passkey Wallet
+
+Passkey wallets authenticate with a single P256 (`secp256r1`) signature and are a large and growing share of smart accounts. A P256 wallet reached through an [EIP-7702](./eip-7702.md) delegation is nonetheless admitted only through full validation-prefix simulation, even though its validation is one signature check.
+
+A **canonical passkey wallet** is a smart account whose runtime code hash equals `CANONICAL_PASSKEY_WALLET_CODE_HASH` for the active fork and whose `self_verify` or `only_verify` frame validates the transaction with a single scheme `0x2` (P256) signature over the canonical signature hash. Its runtime is a full smart wallet, not a bare key: it can answer [ERC-1271](./eip-1271.md) verification, be the target of `CALL*` callbacks, and be installed by a factory in a `deploy` frame. This is what separates it from a raw P256 signer, which the protocol already provides as signature scheme `0x2` and which is a cryptographic operation rather than an account.
+
+For the purposes of the previous section, a `self_verify` or `only_verify` frame whose resolved target is a canonical passkey wallet is a protocol-defined frame: its validation is the single P256 check with no wallet-specific storage read, so direct evaluation of that check is equivalent to simulation. A node MAY admit it by code-hash match, one P256 verification, and the scope check, counting the verification against `MAX_VERIFY_GAS` and adding the wallet's code hash and nonce to the state dependency set. Recognition is by the pinned per-fork code hash, versioned across forks, rather than by exact bytecode equality against an unpinned implementation, so a toolchain bytecode difference cannot fragment mempool propagation.
 
 #### Validation Trace Rules
 


### PR DESCRIPTION
The direct-evaluation set from #12001 lets nodes admit the common flows with no wallet-code simulation, but it is limited to default code, the expiry verifier, and the canonical paymaster, all `SECP256K1`. A passkey wallet delegated to a P256 signer still goes through full validation-prefix simulation even though its validation is a single P256 check.

A canonical P256 sender account was proposed for this in #12004 and closed, on the ground that a bare P256 account with no ERC-1271, no permit, no callbacks, and no self-deploy is a degenerate account class, and that P256 is a signature scheme rather than an account. This takes the other route: recognize a real smart wallet whose runtime is pinned by a per-fork code hash and whose validation is one scheme `0x2` signature, and add it as a fourth direct-evaluation species. It stays a full smart wallet, so the objection to #12004 does not apply, and recognition by pinned per-fork code hash rather than exact bytecode avoids the propagation fragmentation that closed #12010.

The wallet runtime is left as `CANONICAL_PASSKEY_WALLET_CODE_HASH` TBD, in the same shape the canonical paymaster carries a TBD implementation.

Two questions. Is a fourth direct-evaluation species the right home for passkey admission, or should it stay under generic simulation? And should the canonical wallet runtime be pinned in this EIP, or specified in a companion PR the way the canonical paymaster implementation is in #12012?
