### PR TITLE
CI: delete duplicate jekyll build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,15 +55,11 @@ jobs:
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 0 # Increment this number if you need to re-download cached gems
       - name: Build with Jekyll
-        run: bundle exec jekyll build
-        env:
-          JEKYLL_ENV: production
-
-      - name: Build Website
         run: |
           bundle exec jekyll doctor
           bundle exec jekyll build
-
+        env:
+          JEKYLL_ENV: production
       - name: HTML Proofer
         run: bundle exec htmlproofer --allow-missing-href --disable-external --assume-extension '.html' --log-level=:info --cache='{"timeframe":{"external":"6w"}}' --checks 'Links,Images,Scripts,OpenGraph' --no-check-sri --ignore-empty-alt --no-enforce_https ./_site
       - name: DNS Validator

--- a/_config.yml
+++ b/_config.yml
@@ -18,6 +18,7 @@ description: >-
   Ethereum Improvement Proposals (EIPs) describe standards for the Ethereum
   platform, such as core protocol specifications.
 url: "https://eips.ethereum.org"
+"baseurl": ""
 github_username:  ethereum
 repository: ethereum/EIPs
 lang: en


### PR DESCRIPTION
the jekyll build step was accidentally duplicated in this PR three years ago: https://github.com/ethereum/EIPs/commit/d72afdac516fd9a2cc82f363e252caba2f6acbba

this is why the HTMLProofer takes 17 minutes every time - the duplication is responsible for at least ~5 minutes of that, potentially more. pls let me delete the useless duplication so the eipbot will run faster. it is so tiring to wait 20 minutes for the bot