### PR TITLE
Update EIP-8141: relax banned opcode list

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -971,7 +971,6 @@ A public mempool node must simulate the validation prefix and reject the transac
 
 For `VERIFY` frames, the usual `STATICCALL` restrictions apply except for the protocol-defined effects of `APPROVE`. In addition, the following opcodes are banned during the validation prefix, with a few caveats:
 
-- ORIGIN (0x32)
 - GASPRICE (0x3A)
 - BLOCKHASH (0x40)
 - COINBASE (0x41)
@@ -981,7 +980,6 @@ For `VERIFY` frames, the usual `STATICCALL` restrictions apply except for the pr
 - PREVRANDAO/DIFFICULTY (0x44)
 - GASLIMIT (0x45)
 - BASEFEE (0x48)
-- BLOBHASH (0x49)
 - BLOBBASEFEE (0x4A)
 - SLOTNUM (0x4B, [EIP-7843](./eip-7843.md))
 - GAS (0x5A)
@@ -997,8 +995,7 @@ For `VERIFY` frames, the usual `STATICCALL` restrictions apply except for the pr
 - BALANCE (0x31)
 - SELFBALANCE (0x47)
 - SSTORE (0x55)
-- TLOAD (0x5C)
-- TSTORE (0x5D)
+    - Except `SSTORE`s to `tx.sender`'s storage inside the first `deploy` frame.
 
 `SLOAD` can be used only to access `tx.sender` storage, including when reached transitively via `CALL*` or `DELEGATECALL`.
 


### PR DESCRIPTION
The Validation Trace Rules permit a state write inside the first `deploy` frame for `SSTORE`s to `tx.sender`'s storage, but the banned opcode list bans `SSTORE` outright while giving `CREATE`, `CREATE2` and `SETDELEGATE` an explicit carve-out for that frame. A `deploy` frame initialising the new account's storage is therefore both permitted and forbidden. This adds the matching carve-out to `SSTORE`.

It also removes `ORIGIN`, `TLOAD`, `TSTORE` and `BLOBHASH`. `ORIGIN` is redefined to return the frame's `caller`, transient storage is discarded between frames so `TLOAD` can only observe what the same frame wrote, and `BLOBHASH` returns an element of `tx.blob_versioned_hashes`. Each is determined by the frame or the transaction payload rather than the block environment, so none introduces a dependency that differs between simulation and inclusion.

Separately, and not addressed here: the state dependency set for direct evaluation lists the sender's code hash, nonce, and balance, while the preceding paragraph on revalidation refers to the sender's nonce, code, and storage.