### PR TITLE
Update EIP-8141: Restrict SIGPARAM signer introspection to accounts with empty or delegated code

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -825,6 +825,8 @@ Notes:
 
 For `ARBITRARY` signature entries, requesting `resolved_signer` results in exceptional halt
 
+For `SECP256K1` and `P256` signature entries, `SIGPARAM(0x00)` returns `resolved_signer` only if that account's raw code is empty or exactly an [EIP-7702](./eip-7702.md) delegation indicator (`0xef0100 || delegate_address`), without following the delegation; an absent account is treated as having empty code. Otherwise it returns zero. Zero is returned rather than halting so that consumers comparing the result against a stored address fail closed. The check always passes for a default-code account, which has the empty code hash. Reading this parameter additionally charges the [EIP-2929](./eip-2929.md) warm/cold account-access cost for `resolved_signer`, adding it to `accessed_addresses` when cold.
+
 For `param == 0x04`, if the referenced signature entry's `scheme` is not `ARBITRARY`, an exceptional halt occurs. The operation semantics match `CALLDATACOPY`, copying `length` bytes from the chosen signature's raw `signature` bytes, starting at the given byte `dataOffset`, into a memory region starting at `memOffset`. Bytes beyond the end of the signature are copied as zeroes.
 
 ### Mempool
@@ -1431,6 +1433,10 @@ Frame state-gas budgets are deliberately not shared. A shared, transaction-scope
 Validation code must therefore bind its approval to the entire set of frames it is willing to authorize. A signature with an empty `msg` commits to this, because it is verified over `compute_sig_hash(tx)`, which covers the full frame list; the default validation code relies on exactly such a signature. A validator that instead approves on the basis of an explicit 32-byte `msg` signature, or any check that does not commit to the frames, authorizes an open-ended list. Because a frame transaction carries no outer signature over the whole envelope, an observer can then reuse that approval with a different set of `SENDER` frames, since those frames were never part of what the validator verified. This is the "unchecked fields" class of issue familiar from account-abstraction relaying, now expressed in-protocol.
 
 Custom validation contracts that grant `APPROVE_EXECUTION` should verify against the canonical signature hash, or otherwise constrain every subsequent `SENDER` frame, before approving.
+
+### Signature Validation Is Not Authorization
+
+An account that has migrated to post-quantum authorization carries non-empty code that disables its ECDSA transaction authority under [EIP-3607](./eip-3607.md), yet its old key can still produce a valid `SECP256K1` or `P256` entry. Contracts must therefore not treat the presence of a validated signature entry as authorization by its signer. [`SIGPARAM(0x00)`](#sigparam-instruction-0xb4) is the only accessor exposing signer identity for protocol-validated entries, since their raw `signature` bytes are not readable and the signer cannot be recovered independently, and it applies the account-code check specified there, mirroring the restriction [EIP-8151](./eip-8151.md) places on the `ecRecover` precompile.
 
 ## Copyright
 


### PR DESCRIPTION
[EIP-8151](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-8151.md) stops a migrated account's revoked ECDSA key being presented as authorization through `ecRecover`. EIP-8141 reopens that gap on a surface EIP-8151 cannot reach, since it is not a precompile call: `SIGPARAM(0x00)` hands `resolved_signer` to EVM code with no way for the consumer to tell a live key from a revoked one.

Patching that one accessor closes the surface. The raw `signature` bytes of protocol-validated entries are deliberately not introspectable, `param == 0x04` halts for any non-`ARBITRARY` scheme, and no other accessor identifies anyone — so a contract cannot re-recover the signer independently.

The check applies EIP-8151's rule at `SIGPARAM(0x00)`, returning zero rather than halting so that consumers comparing against a stored address fail closed. It sits at introspection rather than at `validate_signature` because signature verification is priced into `frame_tx_intrinsic_gas`, which the Rationale requires to be state-independent; a code read there would also make every frame transaction depend on the code of every address in `tx.signatures`.

**Open question:** is there an intended use that needs the raw signer even when revoked? If so, a separate `param` for the unchecked address would leave `0x00` checked.
