### PR TITLE
Update EIP-8151: State the revoked-key invariant

### DIFF
--- a/EIPS/eip-8151.md
+++ b/EIPS/eip-8151.md
@@ -119,6 +119,10 @@ When an account fails the account-code check, `ecrecover` returns the same 32 ze
 
 This EIP only modifies the `ecrecover` precompile. Contracts that perform ECDSA recovery in application-level code (e.g., pure Solidity implementations) bypass the precompile and will not observe the account-code restriction.
 
+### Other ECDSA-Derived Authorization Surfaces
+
+An ECDSA key that has been revoked as an authorization method for an account must not remain presentable as one anywhere in the protocol; otherwise the migration to post-quantum authorization is only partial, and the old key stays exploitable through whichever surface still honors it. The normative scope of this EIP is the `ecRecover` precompile. Any other mechanism that derives an address from an ECDSA signature and exposes it to executing code must state the same raw-code restriction in its own specification, as [EIP-8141](./eip-8141.md) does for `SIGPARAM(0x00)`.
+
 ### Cross-Domain / L2 Fault Proof Implications
 
 Some systems re-execute `ecrecover` in a different context (different chain, different layer, or asynchronously at a later time) and assume it is a pure function of `(hash, v, r, s)`. Because this EIP introduces a read of the recovered account's current raw code, that assumption no longer holds.


### PR DESCRIPTION
Adds a short Security Considerations note stating the invariant this EIP rests on: an ECDSA key revoked as an authorization method for an account must not remain presentable as one anywhere in the protocol. The normative scope stays exactly where it is, on the `ecRecover` precompile — the note simply says that other surfaces deriving an address from an ECDSA signature have to apply the same raw-code restriction in their own specifications, rather than this EIP reaching into theirs.

The motivating instance is #12168, which applies the restriction to EIP-8141's `SIGPARAM(0x00)`. Stating the invariant here gives future proposals that add an ECDSA-derived authorization surface something explicit to check themselves against.