### PR TITLE
Update EIP-8333: add helper to handle fork transition

### DIFF
--- a/EIPS/eip-8333.md
+++ b/EIPS/eip-8333.md
@@ -34,19 +34,32 @@ This requires no changes to the execution layer.
 
 ### Consensus layer
 
+#### New `get_checkpoint_slot`
+
+`get_checkpoint_slot(epoch)` returns the slot anchoring the checkpoint for `epoch`. From the activation epoch onward, it's the last slot before the epoch begins. Epochs before activation resolve under the previous anchoring. The genesis epoch, which has no slot before it, anchors at `GENESIS_SLOT`. The helper takes only an epoch, so the state accessor `get_checkpoint_root` and the fork choice's `get_checkpoint_block` both resolve through it and the two views of the same checkpoint cannot diverge.
+
+```python
+def get_checkpoint_slot(epoch: Epoch) -> Slot:
+    """
+    Return the slot anchoring the checkpoint for ``epoch``
+    """
+    if epoch == GENESIS_EPOCH:
+        return GENESIS_SLOT
+    if epoch < EIP8333_FORK_EPOCH:
+        return compute_start_slot_at_epoch(epoch)
+    return Slot(compute_start_slot_at_epoch(epoch) - 1)
+```
+
 #### New `get_checkpoint_root`
 
-`get_checkpoint_root(state, epoch)` returns the root of the boundary block anchoring the checkpoint for `epoch`: the last block before the epoch begins. In a healthy network this is the last block of the previous epoch; if the previous epoch's trailing slots are empty, it is an earlier block. The genesis epoch, which has no previous epoch, resolves to the genesis block.
+`get_checkpoint_root(state, epoch)` returns the root of the block anchoring the checkpoint for `epoch`, the most recent block at or before `get_checkpoint_slot(epoch)`. From the activation epoch onward this is the boundary block. In a healthy network this is the last block of the previous epoch; if the previous epoch's trailing slots are empty, it is an earlier block. The genesis epoch, which has no previous epoch, resolves to the genesis block.
 
 ```python
 def get_checkpoint_root(state: BeaconState, epoch: Epoch) -> Root:
     """
-    Return the block root anchoring the checkpoint for ``epoch`` -- the last
-    block before ``epoch`` (the epoch boundary).
+    Return the block root anchoring the checkpoint for ``epoch``
     """
-    if epoch == GENESIS_EPOCH:
-        return get_block_root_at_slot(state, GENESIS_SLOT)
-    return get_block_root_at_slot(state, Slot(compute_start_slot_at_epoch(epoch) - 1))
+    return get_block_root_at_slot(state, get_checkpoint_slot(epoch))
 ```
 
 #### Modified functions
@@ -58,7 +71,17 @@ The following functions resolve checkpoint roots via `get_checkpoint_root(state,
 
 #### Fork choice
 
-`get_checkpoint_block(store, root, epoch)` resolves the checkpoint to the ancestor at slot `compute_start_slot_at_epoch(epoch) - 1`, or at the genesis slot for the genesis epoch. Its consumers (`on_attestation` validation, `filter_block_tree`, and the gossip conditions on the target block) need no further changes.
+`get_checkpoint_block(store, root, epoch)` resolves the checkpoint to the ancestor at `get_checkpoint_slot(epoch)`. Its consumers (`on_attestation` validation, `filter_block_tree`, and the gossip conditions on the target block) need no further changes.
+
+```python
+def get_checkpoint_block(store: Store, root: Root, epoch: Epoch) -> Root:
+    """
+    Compute the checkpoint block for epoch ``epoch`` in the chain of block ``root``
+    """
+    node = ForkChoiceNode(root=root, payload_status=PAYLOAD_STATUS_PENDING)
+    # [Modified in EIP8333]
+    return get_ancestor(store, node, get_checkpoint_slot(epoch)).root
+```
 
 #### Honest validator
 
@@ -66,9 +89,9 @@ The FFG target is set to `Checkpoint(epoch=get_current_epoch(head_state), root=g
 
 #### Fork transition
 
-`get_checkpoint_root` and `get_checkpoint_block` MUST resolve epochs before the activation epoch via `compute_start_slot_at_epoch(epoch)`, i.e. under the previous anchoring. This is required for correctness:
+`get_checkpoint_slot` MUST resolve epochs before the activation epoch to `compute_start_slot_at_epoch(epoch)`, i.e. under the previous anchoring. This is required for correctness:
 
-- Checkpoints recorded before activation use the previous anchoring. `filter_block_tree` requires the finalized checkpoint root to match `get_checkpoint_block` on every viable branch. Re-resolving the finalized epoch under the new rule breaks this match, and with it head computation, until a post-activation checkpoint is finalized.
+- Checkpoints recorded before activation use the previous anchoring. For example, `on_block` and `filter_block_tree` require the finalized checkpoint root to match `get_checkpoint_block` on every incoming block's parent and on every viable branch, respectively. Re-resolving the finalized epoch under the new rule breaks this match, and with it block import and head computation.
 - Attestations with pre-activation target epochs remain includable for an epoch after activation. Evaluating them under the previous anchoring preserves their validity and rewards.
 
 ## Rationale


### PR DESCRIPTION
This PR introduces `get_checkpoint_slot` to make fork transition handling cleaner and more explicit. It also updates function descriptions for consistency.