### PR TITLE
Update EIP-8130: right-align address-derived actorIds

### DIFF
--- a/EIPS/eip-8130.md
+++ b/EIPS/eip-8130.md
@@ -70,10 +70,10 @@ This specification defines a canonical authenticator set which is the set of sig
 
 | Name | Algorithm | Authenticator | `actorId` Derivation |
 |------|-----------|----------|----------------------|
-| k1 | secp256k1 | `K1_AUTHENTICATOR` (native sentinel) | `bytes32(bytes20(recovered_address))` |
+| k1 | secp256k1 | `K1_AUTHENTICATOR` (native sentinel) | `bytes32(uint256(uint160(recovered_address)))` (the address right-aligned into a 32-byte word: low 20 bytes, high 12 bytes zero) |
 | p256 | P-256 | Onchain contract | `keccak256(abi.encodePacked(x, y))` |
 | passkey | WebAuthn / FIDO2 | Onchain contract | `keccak256(abi.encodePacked(x, y))` |
-| delegate | Signature delegation | Onchain contract | `bytes32(bytes20(delegated_address))`: signatures from `delegated_address` are valid for the registering account (see [Delegate Authenticator](#delegate-authenticator)) |
+| delegate | Signature delegation | Onchain contract | `bytes32(uint256(uint160(delegated_address)))` (address right-aligned, high 12 bytes zero): signatures from `delegated_address` are valid for the registering account (see [Delegate Authenticator](#delegate-authenticator)) |
 
 The canonical authenticator set and corresponding contract addresses are maintained in a companion ERC (number TBD) and deployed at deterministic CREATE2 addresses across chains. The canonical set is expected to grow as new algorithms are adopted (e.g., post-quantum) through the companion ERC process.
 
@@ -81,7 +81,7 @@ Nodes MUST include all canonical authenticators in their allowlist and SHOULD NO
 
 #### Delegate Authenticator
 
-The delegate authenticator lets one account act on behalf of another: account **A** registers a delegate actor with `actorId = bytes32(bytes20(B))`, after which any key that can authenticate as account **B** may authenticate as **A**, bounded by the scope **A** grants that actor. Delegation MUST NOT chain (depth-1: the nested authenticator MUST NOT itself be the delegate authenticator) and the nested authenticator MUST be canonical, keeping total validation work bounded. The remaining details are defined in the canonical repository.
+The delegate authenticator lets one account act on behalf of another: account **A** registers a delegate actor with `actorId = bytes32(uint256(uint160(B)))`, after which any key that can authenticate as account **B** may authenticate as **A**, bounded by the scope **A** grants that actor. Delegation MUST NOT chain (depth-1: the nested authenticator MUST NOT itself be the delegate authenticator) and the nested authenticator MUST be canonical, keeping total validation work bounded. The remaining details are defined in the canonical repository.
 
 ### Keystore and Account Configuration
 
@@ -95,7 +95,7 @@ Actor enumeration is performed off-chain via `ActorAuthorized` and `ActorRevoked
 
 Each actor occupies a single `actor_config` slot containing the authenticator address, an optional expiry, and the scope bitmask. The protocol reads this slot directly during validation, so its packing is normative: `authenticator(20) ‖ expiry(6) ‖ scope(2) ‖ reserved(4)`, where `expiry` is a `uint48` Unix timestamp in **seconds** (`0` = no expiry; the actor is invalid once `block.timestamp > expiry`) and `scope` is the `uint16` permission bitmask (`0x0000` = unrestricted, also the admin predicate; see [Actor Scope](#actor-scope)). The exact slot derivation and byte offsets are defined in the canonical repository (`src/Keystore.sol`).
 
-When `scope` includes `POLICY` (`0x02`), the actor also carries a signed policy commitment and a manager address in the separate policy slots `policy_commitment`/`policy_manager` (see [Actor Policies](#actor-policies)). Actors are revoked by deleting the `actor_config` slot. The self-actor (`actorId == bytes32(bytes20(account))`) is the one exception: it is held inline in the packed account-state slot and resolved per [Validation](#validation).
+When `scope` includes `POLICY` (`0x02`), the actor also carries a signed policy commitment and a manager address in the separate policy slots `policy_commitment`/`policy_manager` (see [Actor Policies](#actor-policies)). Actors are revoked by deleting the `actor_config` slot. The self-actor (`actorId == bytes32(uint256(uint160(account)))`) is the one exception: it is held inline in the packed account-state slot and resolved per [Validation](#validation).
 
 When `scope & POLICY != 0`, the actor's policy is held in two additional slots:
 
@@ -262,7 +262,7 @@ Lock and unlock are **local-only** account changes carried in a signed batch thr
 - The account already has 8130 state: **either** change-sequence channel is non-zero. Import is a one-time bootstrap, so it requires both the local and multichain channels empty. A locked account is always caught here: a `lock` is a signed local config change, so it has advanced `local_sequence` and the account is considered initialized (see [Account Lock](#account-lock)).
 - The account has no bytecode (there is no contract to run the ERC-1271 signature check against), or its ERC-1271 check does not return the magic value.
 
-The `signature` is validated against the account via [ERC-1271](./eip-1271.md) over a typed ([EIP-712](./eip-712.md)-style) `ActorInitialization` digest that omits the EIP-712 domain separator (anti-phishing) and binds the account's own actorId (`bytes32(bytes20(account))`, so it cannot be replayed against another account), `chainId` (matching the `applySignedAccountChanges` replay domain), and each initial actor with `expiry = 0` (imported actors are always non-expiring; an actor-provided expiry MUST NOT be accepted). `policyData` follows `authorizeActor`'s rule and, unlike create, `manager = account` is expressible here. On success `importAccount` sets `DEFAULT_EOA_REVOKED` (parity with `createAccount`); to keep using the native key past import, include the self-actorId as a `K1_AUTHENTICATOR` entry in `initialActors`. Exact typehashes and digest construction are defined in the canonical repository (`src/Keystore.sol`).
+The `signature` is validated against the account via [ERC-1271](./eip-1271.md) over a typed ([EIP-712](./eip-712.md)-style) `ActorInitialization` digest that omits the EIP-712 domain separator (anti-phishing) and binds the account's own actorId (`bytes32(uint256(uint160(account)))`, so it cannot be replayed against another account), `chainId` (matching the `applySignedAccountChanges` replay domain), and each initial actor with `expiry = 0` (imported actors are always non-expiring; an actor-provided expiry MUST NOT be accepted). `policyData` follows `authorizeActor`'s rule and, unlike create, `manager = account` is expressible here. On success `importAccount` sets `DEFAULT_EOA_REVOKED` (parity with `createAccount`); to keep using the native key past import, include the self-actorId as a `K1_AUTHENTICATOR` entry in `initialActors`. Exact typehashes and digest construction are defined in the canonical repository (`src/Keystore.sol`).
 
 #### Account Establishment
 
@@ -394,9 +394,9 @@ The first 20 bytes identify the authenticator address. When the authenticator is
 
 ##### Validation
 
-1. **Resolve sender**: If `sender` empty, ecrecover derives the sender address (EOA path) with `actorId = bytes32(bytes20(sender))`. If `sender` set, read the first 20 bytes of `sender_auth` as the authenticator address.
-2. **Authenticate**: Route by authenticator address. For the EOA path (`sender` empty), ecrecover was already performed in step 1. For `K1_AUTHENTICATOR` (`address(1)`), the protocol natively ecrecovers from `data` (as `r || s || v`), returning `actorId = bytes32(bytes20(recovered_address))`. For all other authenticators, call `authenticator.authenticate(hash, data)` via STATICCALL, returning `actorId` (or `bytes32(0)` for invalid). `address(0)` is never a valid authenticator selector (it is the empty `actor_config` sentinel).
-3. **Authorize**: **Self-actor (native secp256k1) rule**: if authentication in step 2 used the native secp256k1 path (the EOA path or `K1_AUTHENTICATOR`) and `actorId == bytes32(bytes20(sender))`, resolve the self-actor from the inline default-EOA config in the packed account-state slot: reject if `DEFAULT_EOA_REVOKED` is set; otherwise take `scope` and `expiry` from the inline fields (all-zero = unrestricted, non-expiring full owner, i.e. admin). Otherwise SLOAD `actor_config(sender, actorId)`, reject if its reserved bytes are nonzero (version gate, see [Storage Layout](#storage-layout)), and require that the stored authenticator address matches the effective authenticator (this covers every other actor, including a non-secp256k1 self). In either case, if the resolved `expiry` is non-zero, also require `block.timestamp <= expiry`; an expired actor is rejected.
+1. **Resolve sender**: If `sender` empty, ecrecover derives the sender address (EOA path) with `actorId = bytes32(uint256(uint160(sender)))`. If `sender` set, read the first 20 bytes of `sender_auth` as the authenticator address.
+2. **Authenticate**: Route by authenticator address. For the EOA path (`sender` empty), ecrecover was already performed in step 1. For `K1_AUTHENTICATOR` (`address(1)`), the protocol natively ecrecovers from `data` (as `r || s || v`), returning `actorId = bytes32(uint256(uint160(recovered_address)))`. For all other authenticators, call `authenticator.authenticate(hash, data)` via STATICCALL, returning `actorId` (or `bytes32(0)` for invalid). `address(0)` is never a valid authenticator selector (it is the empty `actor_config` sentinel).
+3. **Authorize**: **Self-actor (native secp256k1) rule**: if authentication in step 2 used the native secp256k1 path (the EOA path or `K1_AUTHENTICATOR`) and `actorId == bytes32(uint256(uint160(sender)))`, resolve the self-actor from the inline default-EOA config in the packed account-state slot: reject if `DEFAULT_EOA_REVOKED` is set; otherwise take `scope` and `expiry` from the inline fields (all-zero = unrestricted, non-expiring full owner, i.e. admin). Otherwise SLOAD `actor_config(sender, actorId)`, reject if its reserved bytes are nonzero (version gate, see [Storage Layout](#storage-layout)), and require that the stored authenticator address matches the effective authenticator (this covers every other actor, including a non-secp256k1 self). In either case, if the resolved `expiry` is non-zero, also require `block.timestamp <= expiry`; an expired actor is rejected.
 4. **Check scope**: Read the resolved `scope` byte (from the inline default-EOA config for the secp256k1 self-actor, or `actor_config` otherwise) and check it against the context being authorized per [Actor Scope](#actor-scope) (for `sender_auth`: `scope == 0x00 || (scope & (SENDER | POLICY)) != 0`, with `POLICY` gating the actor to its `manager`). Payer scope is checked when the payer is resolved (see [Validation Flow](#validation-flow) step 6).
 5. **Check nonce scope** (sender-context only, when `nonce_key != NONCE_KEY_MAX`): require the resolved actor be admin or carry `NONCE`, per [Actor Nonce Scope](#actor-nonce-scope).
 
@@ -508,15 +508,14 @@ When a create entry is present in `account_changes`:
 
 1. Parse `[0x00, user_salt, code, initial_actors]` where each entry is `[actorId, authenticator, scope, policyData]`. `scope` is stored verbatim (unknown scope bits allowed, per [Actor Scope](#actor-scope)). Apply `authorizeActor`'s frozen `policyData` rule: reject unless `policyData` is exactly `manager (20) ‖ commitment (32)` when `scope & POLICY != 0`, or empty otherwise. `expiry` is not accepted in the create entry
 2. Require `initial_actors` are sorted by `actorId` in strictly ascending order; reject any unsorted set (strict ascending order also rejects duplicate `actorId` values).
-3. Reject if `code` is empty or `len(code) > MAX_CODE_SIZE` ([EIP-170](./eip-170.md): 24576 bytes), to keep the placed code within the EVM contract size limit that CREATE/CREATE2 would otherwise enforce
-4. Use `initial_actors` in the provided (sorted) order
-5. Compute `actors_commitment` per [Address Derivation](#address-derivation)
-6. Compute `effective_salt = keccak256(user_salt || actors_commitment)`
-7. Compute `deployment_code = DEPLOYMENT_HEADER(len(code)) || code`
-8. Compute `expected = keccak256(0xff || KEYSTORE_ADDRESS || effective_salt || keccak256(deployment_code))[12:]`
-9. Require `sender == expected`
-10. Require the destination matches CREATE2 freshness: `code_size(sender) == 0` and `nonce(sender) == 0` (matching the conditions under which CREATE2 would be permitted to deploy)
-11. Validate `sender_auth` against one of `initial_actors` (actorId resolved from auth must match an entry's actorId and the auth authenticator must match that entry's authenticator)
+3. Use `initial_actors` in the provided (sorted) order
+4. Compute `actors_commitment` per [Address Derivation](#address-derivation)
+5. Compute `effective_salt = keccak256(user_salt || actors_commitment)`
+6. Compute `deployment_code = DEPLOYMENT_HEADER(len(code)) || code`
+7. Compute `expected = keccak256(0xff || KEYSTORE_ADDRESS || effective_salt || keccak256(deployment_code))[12:]`
+8. Require `sender == expected`
+9. Require the destination matches CREATE2 freshness: `code_size(sender) == 0` and `nonce(sender) == 0` (matching the conditions under which CREATE2 would be permitted to deploy)
+10. Validate `sender_auth` against one of `initial_actors` (actorId resolved from auth must match an entry's actorId and the auth authenticator must match that entry's authenticator)
 
 #### Config Change Entry
 
@@ -547,7 +546,7 @@ The operation-specific `payload` is an opaque `bytes` blob carried in the RLP en
 | change_type | Name | `payload` | Description |
 |-------------|------|-----------|-------------|
 | `0` | `AuthorizeActor` | `abi.encode(bytes32 actorId, ActorConfig config, bytes policyData)` (see [`ActorConfig`](#ikeystore)) | Upsert an actor. Writes `actor_config` with `authenticator`, `expiry` (`0` = no expiry; on the unsequenced/JIT path an already-lapsed non-zero expiry causes the grant to be **silently skipped** — not applied, no revert — otherwise the grant installs **inert** — see [Config Change Authorization](#config-change-authorization)), and `scope` verbatim (unknown scope bits stored as-is), reserved bytes zeroed. If `POLICY` is set, requires `policyData = manager ‖ commitment` (exactly 52 bytes) and writes those slots; otherwise requires empty `policyData` and clears policy slots. Does **not** enforce scope-combination exclusivity (that is use-time / protocol). Emits `ActorAuthorized` whose `actorData` is 32 bytes (`authenticator ‖ expiry ‖ scope ‖ reserved`) when `POLICY` is unset, or 84 bytes (appending `manager ‖ commitment`) when `POLICY` is set. |
-| `1` | `RevokeActor` | `abi.encode(bytes32 actorId)` | Revoke an actor. Deletes `actor_config` / the default EOA config (and `policy_commitment`/`policy_manager`). Emits `ActorRevoked`. |
+| `1` | `RevokeActor` | `abi.encode(bytes32 actorId)` | Revoke an actor. For a non-self actor, deletes `actor_config` (and `policy_commitment`/`policy_manager`). For the self-actorId, both homes are handled together: a k1 self (held inline in the packed account-state slot) is revoked by setting `DEFAULT_EOA_REVOKED` with no `actor_config` write, while a non-k1 self (held in `actor_config`, per [Storage Layout](#storage-layout)) has that slot deleted like any other actor; either way the inline default-EOA path is disabled. Emits `ActorRevoked`. |
 | `2` | `IncrementLocalEpoch` | empty | **Either channel.** Increments `local_epoch` and resets `local_sequence` to `0`, invalidating every unlanded local signature (sequenced and unsequenced) at the prior epoch. Always targets the local epoch, even when carried in a Multichain batch. Consumes no sequence itself. See [Epoch System](#epoch-system). |
 | `3` | `Lock` | `abi.encode(uint16 unlockDelay)` | **Local only, standalone.** Locks the account. See [Account Lock](#account-lock). |
 | `4` | `Unlock` | empty | **Local only, standalone.** Initiates unlock. See [Account Lock](#account-lock). |
@@ -582,7 +581,7 @@ Both paths carry the same batch, share the same channels and counters, and are e
 
 #### Delegation Entry
 
-Delegation entries set [EIP-7702](./eip-7702.md)-style code delegation for the sender's account, replacing the need for an `authorization_list` in the transaction. Delegation is authorized by the transaction's `sender_auth`, no separate signature is required. The sender must have been **authenticated via the native secp256k1 path** (the EOA path or `K1_AUTHENTICATOR`; mirroring the [Implicit EOA Rule Scoping](#security-considerations)), with `actorId == bytes32(bytes20(sender))` and admin (`scope == 0x00`). A non-secp256k1 self authenticator that returns the self-actorId does not qualify, keeping delegation authority ECDSA/7702-portable.
+Delegation entries set [EIP-7702](./eip-7702.md)-style code delegation for the sender's account, replacing the need for an `authorization_list` in the transaction. Delegation is authorized by the transaction's `sender_auth`, no separate signature is required. The sender must have been **authenticated via the native secp256k1 path** (the EOA path or `K1_AUTHENTICATOR`; mirroring the [Implicit EOA Rule Scoping](#security-considerations)), with `actorId == bytes32(uint256(uint160(sender)))` and admin (`scope == 0x00`). A non-secp256k1 self authenticator that returns the self-actorId does not qualify, keeping delegation authority ECDSA/7702-portable.
 
 ##### Delegation Format
 
@@ -816,7 +815,7 @@ The create entry uses the CREATE2 address formula with `KEYSTORE_ADDRESS` as the
 
 ### Why Delegation via Account Changes?
 
-[EIP-7702](./eip-7702.md) introduced `authorization_list` as a transaction-level field for code delegation, with ECDSA authority. This proposal moves delegation into `account_changes`, authorized by the transaction's `sender_auth`. Delegation is restricted to senders authenticated via the native secp256k1 path (EOA path or `K1_AUTHENTICATOR`) with `actorId == bytes32(bytes20(sender))`, so that code delegation remains portable across non-8130 chains via standard [EIP-7702](./eip-7702.md) transactions (a non-secp256k1 self authenticator does not qualify, even if it returns the self-actorId). Eventually this can be expanded to all authenticator types, not just K1 EOAs. 
+[EIP-7702](./eip-7702.md) introduced `authorization_list` as a transaction-level field for code delegation, with ECDSA authority. This proposal moves delegation into `account_changes`, authorized by the transaction's `sender_auth`. Delegation is restricted to senders authenticated via the native secp256k1 path (EOA path or `K1_AUTHENTICATOR`) with `actorId == bytes32(uint256(uint160(sender)))`, so that code delegation remains portable across non-8130 chains via standard [EIP-7702](./eip-7702.md) transactions (a non-secp256k1 self authenticator does not qualify, even if it returns the self-actorId). Eventually this can be expanded to all authenticator types, not just K1 EOAs. 
 
 ### External Account Factories
 
@@ -994,7 +993,7 @@ All three cases resolve to the same `replay_id` (fee bumps included, since `repl
 
 **Local Epoch and Outstanding Signatures**: `IncrementLocalEpoch` cancels every unlanded **local** signature at the prior epoch (`StaleEpoch`), including unsequenced/JIT batches; it does **not** revoke live actors or affect the multichain channel (see [Epoch System](#epoch-system)). Because an unsequenced (JIT) batch is replayable within its epoch, wallets MUST treat epoch increment — not mere non-inclusion — as the durable retirement of a JIT authorization, batching the reducing `RevokeActor`/`AuthorizeActor` with `IncrementLocalEpoch`. Since the epoch does not walk authorizer lineage, an actor added by a landed batch survives later epoch bumps and must be removed with an explicit `RevokeActor`.
 
-**Implicit EOA Rule Scoping**: The implicit EOA authorization rule only applies when authentication used the native secp256k1 path, either the EOA path (`sender` empty) or `K1_AUTHENTICATOR`, and the account's `DEFAULT_EOA_REVOKED` flag is unset. Generic authenticator contracts MUST NOT satisfy the implicit branch even if they return `bytes32(bytes20(sender))`, otherwise an arbitrary authenticator could authenticate as any EOA whose implicit actor slot has never been written.
+**Implicit EOA Rule Scoping**: The implicit EOA authorization rule only applies when authentication used the native secp256k1 path, either the EOA path (`sender` empty) or `K1_AUTHENTICATOR`, and the account's `DEFAULT_EOA_REVOKED` flag is unset. Generic authenticator contracts MUST NOT satisfy the implicit branch even if they return `bytes32(uint256(uint160(sender)))`, otherwise an arbitrary authenticator could authenticate as any EOA whose implicit actor slot has never been written.
 
 **actorId Binding**: The protocol checks that the authenticator's returned `actorId` maps back to that authenticator in `actor_config`, preventing a malicious authenticator from claiming control of another authenticator's actors.
 
@@ -1002,7 +1001,7 @@ All three cases resolve to the same `replay_id` (fee bumps included, since `repl
 
 **Cross-sender Payer Replay**: The payer signature hash binds to the resolved sender via the `sender` field (see [Signature Payload](#signature-payload)). In the EOA path where `sender` is empty in the wire format, the recovered sender address MUST be substituted into the `sender` position before computing the hash. Without this substitution, two different EOAs that construct otherwise identical transaction data (same `chain_id`, `nonce_key`, `nonce_sequence`, `expiry`, fees, `account_changes`, `calls`) would produce identical payer hashes, allowing a second EOA to reuse a payer signature originally issued for the first and drain the payer's gas deposit. The 2D nonce alone does not prevent this: `nonce_key` and `nonce_sequence` are fields in the transaction payload, so each attacker controls their own values. Substituting the recovered sender into the hash makes the payer's commitment per-sender and closes this replay path. The configured-actor path is unaffected because `sender` is non-empty by definition.
 
-**Account Creation Security**: `initial_actors` (`actorId`, `authenticator`, `scope`, and `policyData`; expiry is not expressible at create, per [Address Derivation](#address-derivation)) are salt-committed, preventing front-running of actor assignment. Wallet bytecode should be inert when uninitialized as it can be permissionlessly deployed. The create entry applies only to addresses that satisfy CREATE2 freshness. Without the nonce check, a create entry could be replayed against an EOA that has transaction history at the counterfactual address. Direct code placement also bypasses CREATE/CREATE2's [EIP-170](./eip-170.md) `MAX_CODE_SIZE` check, so the protocol enforces `len(code) <= MAX_CODE_SIZE` explicitly to keep the placed code within the EVM contract size limit.
+**Account Creation Security**: `initial_actors` (`actorId`, `authenticator`, `scope`, and `policyData`; expiry is not expressible at create, per [Address Derivation](#address-derivation)) are salt-committed, preventing front-running of actor assignment. Wallet bytecode should be inert when uninitialized as it can be permissionlessly deployed. The create entry applies only to addresses that satisfy CREATE2 freshness. Without the nonce check, a create entry could be replayed against an EOA that has transaction history at the counterfactual address.
 
 ## Copyright
 


### PR DESCRIPTION
## Summary

Corrects the address-derived `actorId` encoding in EIP-8130 to match the canonical Keystore contract, plus two related reconciliations:

- **Right-aligned actorIds.** All address-derived `actorId` formulas were written as the left-aligned `bytes32(bytes20(x))`, but the reference Keystore (`ActorId.fromAddress`) right-aligns: `bytes32(uint256(uint160(x)))`, i.e. the address in the low 20 bytes with the high 12 bytes zero. Updated all occurrences (k1 and delegate derivations, self-actorId, EOA/`K1_AUTHENTICATOR` validation, delegation authorization, and security-considerations references) and added a short clarifying note where the derivations are first defined.
- **Drop the create-entry code-size check.** Removed the "reject if `code` empty or `len > MAX_CODE_SIZE`" validation step (and its rationale sentence); the deployment path is already protected and the exact bound is a contract implementation detail rather than protocol surface.
- **Clarify `RevokeActor` for the self-actorId.** A k1 self (held inline in the account-state slot) is revoked by setting `DEFAULT_EOA_REVOKED` with no `actor_config` write, while a non-k1 self (held in `actor_config`) is deleted like any other actor; either way the inline default-EOA path is disabled.

No normative behavior change beyond aligning the documented encoding with the deployed/reference implementation.

## Test plan

- [ ] EIP CI (eipw / markdown lint / link check) passes