### PR TITLE
Update EIP-8164: document effects on converted accounts

### DIFF
--- a/EIPS/eip-8164.md
+++ b/EIPS/eip-8164.md
@@ -370,6 +370,15 @@ This EIP introduces new behavior gated behind a new transaction type and an expl
 2. **New transaction type** (`0x06`). Standard [EIP-2718](./eip-2718.md) typed transaction rollout. Unrecognized types are ignored by older clients.
 3. **Extended [EIP-3607](./eip-3607.md) exception.** Transaction origination is now permitted for both `0xef0100` and `0xef0101` code prefixes.
 4. **ECDSA rejection for converted accounts.** This is a new validation rule, but applies only to accounts that explicitly opted in. No existing account is affected without an explicit on-chain authorization.
+5. **Effects on converted accounts.** Conversion changes how existing contracts classify the account. A native key account has 1,315 bytes of code and executes none of it, so code-length checks classify it as a contract while calls to it return no data. None of the effects below are signalled on-chain, and none are under the control of the converting account.
+
+   - **Token receiver hooks.** [ERC-721](./eip-721.md) `safeTransferFrom` and all [ERC-1155](./eip-1155.md) transfers gate the receiver hook on `to.code.length > 0` and then require the hook's return value. A native key account passes the gate and returns nothing, so decoding the return value fails and the transfer reverts. The revert carries no return data, so the sender receives no error selector or reason identifying the cause. ERC-721 exposes `transferFrom` as an unchecked alternative; ERC-1155 defines none, so no workaround exists there.
+
+   - **Off-chain signatures.** Verification helpers dispatch on `code.length`, and the two forms in common use fail in opposite directions. Helpers that treat an account with code as an [ERC-1271](./eip-1271.md) signer take that path and receive no response, so signatures the account produced before conversion stop validating after conversion, even though the signature bytes are unchanged. This affects outstanding marketplace listings, unused [ERC-2612](./eip-2612.md) permits, long-dated intent or limit orders, and pre-signed multisig operations; the failure surfaces only when a third party submits a transaction that consumes one. Helpers that instead attempt `ecrecover` first and fall back to ERC-1271 fail the other way: recovery is unaffected by the account's code, so the account's secp256k1 key remains authoritative for those contracts notwithstanding the ECDSA rejection rule above.
+
+   - **EOA-only gates.** Contracts requiring `extcodesize == 0` reject native key accounts. Gates based on `msg.sender == tx.origin` are unaffected.
+
+   Wallets SHOULD enumerate and cancel outstanding off-chain signatures before conversion, SHOULD warn that the account cannot receive tokens through checked transfers, and SHOULD NOT represent conversion as removing secp256k1 authority over assets held in contracts whose verification path is unknown.
 
 ## Test Cases
 


### PR DESCRIPTION
Adds a Backwards Compatibility item describing what changes for an account once
it converts. The existing four items describe why *other* accounts are
unaffected; the section's opening sentence scopes them with "unless the account
owner explicitly converts," and the case that clause names is not described
anywhere in the document. This fills that in. No normative behaviour is changed.

Discussion: https://ethereum-magicians.org/t/eip-8164-native-key-delegation/27770

cc @GregTheGreek @prestwich — this edits your draft, so please say if you'd
rather it were raised only in the discussion thread, or worded differently.

## Evidence

### Receiver hooks

The Specification states `EXTCODESIZE` returns `1315`, and that `CALL`,
`CALLCODE`, `DELEGATECALL` and `STATICCALL` targeting a native-key account
"execute no code." OpenZeppelin's `ERC721Utils.checkOnERC721Received` invokes the
hook when `to.code.length > 0` and decodes a `bytes4` result:

https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v5.5.0/contracts/token/ERC721/utils/ERC721Utils.sol#L32-L47

I reproduced the failure without 8164 client support. It depends only on the two
observable properties above, and a contract with an empty `fallback()` has both.
Identical results on solc 0.8.24, 0.8.26 and 0.8.30:

| recipient | `safeTransferFrom` |
| --- | --- |
| plain EOA | succeeds |
| contract implementing the hook | succeeds |
| native-key account model | **reverts** |
| native-key account model, via `transferFrom` | succeeds |

The revert carries no error data. OpenZeppelin's `try/catch` converts an
empty-data revert *raised by the hook* into `ERC721InvalidReceiver(to)`, but a
*return-data decoding* failure is not caught by `try/catch` at all and propagates
as a bare revert:

| recipient | revert data |
| --- | --- |
| contract that reverts inside the hook | `0x64a0ae92…` (`ERC721InvalidReceiver`) |
| native-key account model | `0x` (empty) |

Test: https://github.com/nezu511/eip8164-repro

### Off-chain signatures

Dispatch behaviour differs by library version, which is why the added text
describes both directions rather than asserting one. OpenZeppelin
`SignatureChecker` branches on `code.length` from v5.1.0 onward, and attempts
`ecrecover` first with an ERC-1271 fallback in v5.0.2 and earlier:

- v5.1.0+ https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v5.1.0/contracts/utils/cryptography/SignatureChecker.sol#L22-L28
- v5.0.2 https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v5.0.2/contracts/utils/cryptography/SignatureChecker.sol#L22-L27

### Relationship to EIP-8225

EIP-8225 (#11515) does not cover the receiver hook issue — `ecrecover` does not
appear on that path at all. It does reinforce the signature issue: closing the
`ecrecover` branch means both dispatch forms end up failing for converted
accounts rather than only one.