### PR TITLE
Update EIP-8141: define FrameTx gas estimation RPC

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -1113,6 +1113,90 @@ For body retrieval responses (`BlockBodies`), the plain `TransactionPayload` is 
 
 A frame transaction with empty `blob_versioned_hashes` uses the plain `TransactionPayload` with no wrapper.
 
+### JSON-RPC Gas Estimation
+
+Frame transactions require independent execution and state gas limits for every frame. A scalar `eth_estimateGas` result is therefore insufficient to construct a frame transaction. Nodes supporting frame transaction origination MUST expose `eth_estimateFrameTransactionGas`.
+
+The method accepts a frame-transaction call object and returns an execution and state gas estimate for each frame. The call object uses the transaction fields defined above, except that either element of `frame.limits` MAY be `null` to request estimation for that dimension. Non-null limits are treated as caller-supplied upper bounds.
+
+```text
+Wallet                                      Node
+  |                                           |
+  | unsigned FrameTx                          |
+  | null limits + signature stubs             |
+  |------------------------------------------>|
+  |                                           | choose provisional ceilings
+  |                                           | execute complete FrameTx
+  |                                           | derive candidate limits
+  |                                           | re-execute with candidates
+  |                                           | iterate if required
+  |<------------------------------------------|
+  | intrinsicGas + per-frame limits           |
+```
+
+The request object is:
+
+```typescript
+type FrameTransactionEstimate = {
+  chainId: `0x${string}`;
+  nonce: `0x${string}`;
+  sender: `0x${string}`;
+  frames: Array<{
+    mode: `0x${string}`;
+    flags: `0x${string}`;
+    target: `0x${string}` | null;
+    limits: {
+      execution: `0x${string}` | null;
+      state: `0x${string}` | null;
+    };
+    value: `0x${string}`;
+    data: `0x${string}`;
+  }>;
+  signatures: Array<{
+    scheme: `0x${string}`;
+    signer: `0x${string}`;
+    msg: `0x${string}`;
+    signature: `0x${string}` | null;
+  }>;
+  fees: {
+    maxPriorityFeePerGas: `0x${string}`;
+    maxFeePerGas: `0x${string}`;
+    maxFeePerBlobGas: `0x${string}`;
+  };
+  blobVersionedHashes: `0x${string}`[];
+};
+```
+
+The result is:
+
+```typescript
+type FrameTransactionGasEstimate = {
+  intrinsicGas: `0x${string}`;
+  frames: Array<{
+    execution: `0x${string}`;
+    state: `0x${string}`;
+  }>;
+};
+```
+
+The returned `frames` array MUST have the same length and ordering as the request's `frames` array.
+
+For every `null` limit, the node selects a provisional simulation ceiling, estimates a candidate limit, places the candidate into the transaction, and re-executes the complete transaction from the same pre-state. A node MUST NOT return an estimate unless the complete transaction can be executed with exactly the returned limits under the estimation rules below. Implementations MAY iterate, binary-search, or apply safety margins and are not required to return minimal limits. If no stable successful assignment can be found, the method returns an error.
+
+A non-null limit is an upper bound. The node MUST NOT return a value greater than it for that frame and dimension. If successful estimation requires a larger value, the method returns an error.
+
+During estimation, protocol-validated `SECP256K1` and `P256` signature entries with empty `msg` MAY set `signature` to `null`. The node treats such entries as cryptographically valid for simulation, charges the signature-verification gas for their scheme, and computes intrinsic calldata gas using an all-nonzero byte string of the scheme's required signature length. This is a gas-safe upper bound because the final signature has the same length and may contain zero bytes. Signature metadata, including `scheme`, `signer`, and `msg`, is otherwise used exactly as supplied.
+
+A protocol-validated signature with an explicit 32-byte `msg` MUST provide its raw `signature` bytes. Those bytes are committed by `compute_sig_hash(tx)` and replacing them can change EVM-visible transaction data. An `ARBITRARY` signature MUST also provide its raw bytes because EVM execution may inspect them through `SIGPARAM`. Such bytes are executed and charged exactly as supplied.
+
+Skipping cryptographic verification of a permitted placeholder affects only the protocol signature check. It does not skip any frame. `VERIFY` frames execute normally and MUST succeed. In particular, custom account validation, paymaster validation, and any other authorization performed in EVM execution must provide an estimation-time witness or stub path that succeeds under the provisional transaction. A failing `VERIFY` frame causes the estimation call to return an error.
+
+A non-`VERIFY` frame reverting does not by itself make estimation invalid because such a revert is a valid frame-transaction outcome. The node MUST distinguish a normal revert from an exceptional halt caused by an insufficient provisional execution or state limit. It MAY increase an estimated limit and retry when the latter occurs.
+
+Because frame code can inspect `limits` through `FRAMEPARAM`, the final confirmation execution with the returned limits is required even if an earlier simulation succeeded with larger provisional ceilings. Gas estimation is not guaranteed to converge for validation logic whose behavior intentionally changes with the proposed limits; such transactions may fail estimation even though a manually constructed transaction could be valid.
+
+The method estimates the transaction against the requested block state using the same state-selection conventions as `eth_estimateGas`. The returned values are estimates, not consensus-validity guarantees. Wallets MAY apply additional margins, but after changing any limit that validation logic commits to or inspects they SHOULD re-run estimation or otherwise verify that the completed transaction remains valid.
+
 ## Rationale
 
 ### Canonical signature hash
@@ -1172,6 +1256,14 @@ Restricting non-zero `value` to `SENDER` frames keeps `VERIFY` and `DEFAULT` fra
 The frame transaction is a new envelope, so the split is explicitly declared. Each frame's `limits` list carries a `state` budget next to its `execution` budget, and the two pools never mix. This avoids the reservoir accounting entirely, keeps the EIP-7825 check static, lets the mempool bound the validation prefix per dimension without simulation, and makes block reservations exact. A deploy frame that needs tens of millions of state gas for a code deposit just declares it.
 
 Budgets are per-frame rather than per-transaction for the same reason unused gas does not roll over between frames. Frames belong to mutually distrusting parties. With a shared pool, a user operation could drain the state gas a paymaster's `post_op` frame depends on. [ERC-4337](./eip-4337.md) works around this by reserving `postOp` gas in the `EntryPoint`; here the reservation is part of the transaction. Since `GAS` never reports state gas, `FRAMEPARAM` and `TXPARAM` expose state budgets and usage directly, allowing a paymaster to check budgets before approving payment and attribute usage afterwards.
+
+### Gas estimation is part of FrameTx
+
+Frame transactions cannot reuse scalar `eth_estimateGas` without inventing an out-of-band rule for distributing one number among frames and between execution and state gas. Those limits are transaction fields, are visible through `FRAMEPARAM`, contribute to `max_cost`, and can affect whether validation approves the transaction. Estimation is therefore part of the FrameTx origination interface rather than a paymaster-specific service concern.
+
+The estimator requires a final confirmation execution because a frame may branch on its own or another frame's declared limit. Estimating usage under a large temporary ceiling and returning the observed usage without replaying the candidate would be unsound: the candidate itself could take a different path or fail validation.
+
+Only protocol signatures whose raw bytes are elided from `compute_sig_hash(tx)` can be omitted safely before the final transaction is known. This is why placeholder handling is limited to `SECP256K1` and `P256` entries with empty `msg`. Arbitrary witnesses and explicit-message signature bytes remain part of the execution-visible or hash-visible input and must be supplied by the caller.
 
 ### Calldata floor and payment
 


### PR DESCRIPTION
Defines `eth_estimateFrameTransactionGas` directly in EIP-8141 because FrameTx requires independent execution and state gas limits for every frame, which cannot be constructed from scalar `eth_estimateGas`.

- accepts `null` execution/state limits as estimation targets and non-null limits as caller-supplied caps
- returns intrinsic gas plus per-frame execution/state limits
- requires a confirmation execution with exactly the returned limits because `FRAMEPARAM` exposes frame limits to validation and execution code
- defines placeholder handling for protocol-validated signatures with empty `msg`, while requiring actual bytes for `ARBITRARY` and explicit-message signatures
- never skips `VERIFY` frames during estimation; custom validation and sponsorship flows must provide estimation-safe witnesses/stubs
- treats ordinary non-`VERIFY` reverts as valid FrameTx outcomes while allowing retries for exceptional halts caused by insufficient provisional gas