### PR TITLE
Add EIP-8367: Balance sunset for retired BLS validators

### DIFF
--- a/EIPS/eip-8367.md
+++ b/EIPS/eip-8367.md
@@ -1,0 +1,144 @@
+---
+eip: 8367
+title: Balance sunset for retired BLS validators
+description: Gradually reduce balances of retired 0x00 validators to zero on a published schedule ahead of the post-quantum transition
+author: NC (@ensi321)
+discussions-to: https://ethereum-magicians.org/t/eip-8367-balance-sunset-for-retired-bls-validators/29299
+status: Draft
+type: Standards Track
+category: Core
+created: 2026-07-18
+---
+
+## Abstract
+
+This EIP introduces a published, epoch-keyed schedule under which the balances of retired `0x00`-credentialed validators are gradually reduced to zero. Each epoch, every `0x00` balance is clamped to a ceiling that declines linearly from a starting value to zero across the sunset window. Rotating credentials to `0x01` via the unchanged `BLSToExecutionChange` operation stops the reduction at any point and releases the entire remaining balance through the withdrawal sweep. The schedule constants are ordinary specification parameters, revisitable at each hard fork between activation and the post-quantum transition.
+
+The goal state is that by the post-quantum signature switch, every `0x00` validator carries a zero balance, so the final-stage removal of `0x00` machinery (`BLSToExecutionChange`, its gossip topic and pool, and the registry entries themselves) deletes nothing that anyone owns.
+
+## Motivation
+
+A companion proposal retires `0x00` validators from duty participation and freezes their balances. Freezing alone is not an end state: it leaves thousands of registry entries with non-zero balances that the consensus layer must carry indefinitely. Whatever registry compaction or state redesign the post-quantum transition brings, entries with zero balance can be dropped or archived freely, since nothing is owed and nothing is lost, while entries holding 32 ETH cannot be removed without that removal itself being a confiscation decision. Deferring that decision to the post-quantum fork means having it at the moment of maximum protocol-engineering load, with only abrupt options remaining (permanent freeze, deletion at full balance, or bespoke claim infrastructure carried forever).
+
+A gradual, published reduction resolves this ahead of time:
+
+- **It reaches the owners that announcements do not.** Conversion inclusions have decayed to double digits per month despite three years of guidance since Capella. Announcement channels have saturated. By reducing the balance over time, the deprecation message is delivered through whatever monitoring channel a stakeholder still watches (validator dashboards, balance alerts, custodial statements), and every reduction is a fresh prompt to act, with credential rotation available as the immediate remedy.
+- **It preserves a salvage path until the end.** At any epoch during the window, rotating credentials releases the full remaining balance. Missing a year of the schedule costs a fraction, while missing a one-time deadline (such as a future disabling of `BLSToExecutionChange`) would cost everything at once.
+- **It makes the final removal owe nobody anything.** Balances reach zero before the post-quantum switch, and deleting zero-balance entries is state cleanup in the tradition of empty-account clearing ([EIP-158](./eip-158.md)), not expropriation.
+
+The mechanism class is already anticipated by post-quantum planning: published registry designs propose gradually applying an inactivity leak, or initiating forced exits, for validators that fail to register post-quantum keys. This EIP applies the same instrument to the credential class that structurally cannot complete that migration.
+
+## Specification
+
+### Constants
+
+| Name                     | Value                              | Comment                                     |
+| ------------------------ | ---------------------------------- | ------------------------------------------- |
+| `SUNSET_START_EPOCH`     | TBD                                | First epoch at which the ceiling declines   |
+| `SUNSET_END_EPOCH`       | TBD                                | Epoch at which the ceiling reaches zero     |
+| `SUNSET_INITIAL_CEILING` | `Gwei(2**6 * 10**9)` (= 64 ETH)    | Ceiling value before and at the start epoch |
+
+`SUNSET_START_EPOCH` and `SUNSET_END_EPOCH` are absolute epochs, not offsets from fork activation, so the schedule is unaffected by fork timing slippage. The window between them is intended to span multiple fork cycles (indicatively two to three years).
+
+### Consensus Layer
+
+#### Sunset Ceiling
+
+```python
+def get_sunset_ceiling(epoch: Epoch) -> Gwei:
+    if epoch < SUNSET_START_EPOCH:
+        return SUNSET_INITIAL_CEILING
+    if epoch >= SUNSET_END_EPOCH:
+        return Gwei(0)
+    elapsed = epoch - SUNSET_START_EPOCH
+    span = SUNSET_END_EPOCH - SUNSET_START_EPOCH
+    return Gwei(SUNSET_INITIAL_CEILING - SUNSET_INITIAL_CEILING * elapsed // span)
+```
+
+#### Epoch Processing
+
+A new per-epoch step, `process_balance_sunset`, is added to `process_epoch`:
+
+```python
+def process_balance_sunset(state: BeaconState) -> None:
+    ceiling = get_sunset_ceiling(get_current_epoch(state))
+    if ceiling >= SUNSET_INITIAL_CEILING:
+        return
+    for index, validator in enumerate(state.validators):
+        if validator.withdrawal_credentials[:1] == BLS_WITHDRAWAL_PREFIX:
+            balance = state.balances[index]
+            if balance > ceiling:
+                decrease_balance(state, ValidatorIndex(index), balance - ceiling)
+```
+
+The clamp applies to every validator whose withdrawal credentials carry the `0x00` prefix. Under the companion retirement proposal all such validators are exited (or exiting), so the clamp never interacts with rewards, penalties, or effective-balance accounting of active validators. Validators that rotated credentials no longer match the predicate, so their balances are untouched from that epoch on and are paid out by the withdrawal sweep.
+
+#### Unchanged Operations
+
+`process_bls_to_execution_change` is unchanged and remains available throughout and beyond the sunset window.
+
+## Rationale
+
+### Ceiling Clamp Rather Than a Periodic Decrement
+
+A clamp (`balance = min(balance, ceiling(epoch))`) gives a deterministic zero date readable directly from the constants, is idempotent, and makes top-ups to sunsetting validators visibly pointless (the ceiling absorbs them next epoch) without any special-case handling. With a per-epoch decrement, the epoch at which a balance reaches zero depends on its starting value and any top-ups received along the way, so a validator can be kept above zero past the intended end of the window by periodically topping it up.
+
+### Starting Ceiling of 64 ETH
+
+The highest observed `0x00` validator balance on mainnet is well below 64 ETH (the population averages ~37 ETH, with excess above the 32 ETH effective-balance cap accumulated from pre-Capella rewards). Starting the ceiling above every observed balance means no balance is reduced abruptly at the start epoch, and every validator experiences the same continuous linear decline.
+
+### Plain Specification Constants, Adjustable at Fork Boundaries
+
+The schedule constants are ordinary specification parameters. Each hard fork between activation and the post-quantum transition is an opportunity to revisit them with full governance review if the post-quantum timeline moves. No runtime configurability or novel parameter-distribution mechanism is introduced. The schedule is expected to track the post-quantum timeline through these adjustments: the transition will be known at least one or two forks in advance, leaving time to move `SUNSET_END_EPOCH` at an intermediate fork so that it lines up with the post-quantum fork epoch. Zeroing residual balances at the post-quantum transition itself remains available as a last-resort backstop. If the transition arrives after `SUNSET_END_EPOCH`, balances simply sit at zero until it does.
+
+### Relation to the Inactivity Leak
+
+The consensus layer already reduces the balances of honest validators by posted, uniform rule when protocol health requires it: the inactivity leak burns the stake of non-participating validators during non-finality, including validators that are unable rather than unwilling to respond. This EIP is the same shape, a rule-based, class-conditional, forward-announced reduction with a permissionless way out, applied on a multi-year timescale to a credential class that blocks the post-quantum transition. The measured passive penalty rate (~0.55 ETH/year) would take roughly 28 years to drain a 32 ETH balance, while the sunset schedule compresses this to the available window while retaining the gradient character.
+
+### Notice Accounting
+
+By `SUNSET_END_EPOCH`, a `0x00` holder will have had: the years since Capella (2023) in which conversion has been continuously available and recommended, the publication of this EIP and the companion retirement proposal, fork activation of the retirement, and the entire sunset window during which their balance declines visibly and the salvage path remains open. Total notice from this EIP's publication to zero is several years: roughly six months to fork activation plus the multi-year sunset window. The only parties who lose funds are those who take no action across all of it: predominantly holders of lost keys, whose funds are unrecoverable under every alternative as well.
+
+### Why Not Freeze Indefinitely Instead
+
+A permanent freeze preserves the balance *number* while the asset it records is already economically inert (no key exists that can move it). The costs of the freeze are concrete: registry entries carried by every client through every future state redesign, credential-change machinery maintained solely for this population, and an unavoidable future decision about the entries at the post-quantum fork under worse conditions. Sunset trades a number that nobody can spend for a clean terminal state, with multi-year notice and an exit open until the final epoch.
+
+### Staged Deprecation
+
+This EIP is the second stage of the retire → drain → remove arc described in the companion retirement proposal, following the multi-EIP, multi-fork pattern of the `SELFDESTRUCT` deprecation ([EIP-6049](./eip-6049.md), [EIP-6780](./eip-6780.md), [EIP-4758](./eip-4758.md)). It depends on that retirement stage: clamping the balances of *active* validators would interact with rewards, penalties and effective-balance accounting, and is not a design this EIP contemplates. The two stages may activate in the same fork or consecutive forks, and the schedule constants are independent of which.
+
+## Backwards Compatibility
+
+This EIP introduces backward-incompatible changes to consensus-layer state transition and must be scheduled with a hard fork. No execution-layer changes are required.
+
+## Test Cases
+
+Reference tests are provided with the consensus-specs implementation and cover:
+
+- `get_sunset_ceiling` at the boundary epochs `SUNSET_START_EPOCH - 1`, `SUNSET_START_EPOCH`, `SUNSET_END_EPOCH - 1`, and `SUNSET_END_EPOCH`, and its monotonic decline in between.
+- `process_balance_sunset` reducing an exited `0x00` balance that exceeds the ceiling, and leaving balances at or below the ceiling unchanged.
+- A top-up to a sunsetting validator being absorbed by the ceiling in the following epoch.
+- Credential rotation mid-window removing the validator from the clamp predicate and releasing the remaining balance through the withdrawal sweep.
+- Balances of `0x01`-credentialed validators being unaffected at every epoch of the window.
+
+## Security Considerations
+
+### Property Considerations
+
+This EIP reduces balances of validators that take no action over a multi-year window despite a permissionless, zero-cost remedy. This is the central trade-off and is discussed at length in the Rationale (inactivity-leak precedent, notice accounting, comparison with the freeze alternative). The reduction is a burn: no party receives the funds, the protocol selects no beneficiary, and total supply decreases correspondingly (bounded above by ~343,000 ETH, in practice far less as live holders rotate).
+
+### No New Attack Surface
+
+The clamp is a pure function of the epoch number and existing state: it processes no operations, verifies no signatures, and accepts no external input. It cannot be triggered, accelerated, or redirected by any actor. A malicious top-up to a sunsetting validator only burns the attacker's own ETH.
+
+### Epoch Processing Cost
+
+The predicate scan touches each validator record once per epoch alongside existing full-registry passes (effective-balance updates). Clients may maintain an index of `0x00` validators, a bounded and shrinking set numbering in the thousands, to reduce this to negligible cost.
+
+### Interaction With the Withdrawal Sweep
+
+Sunsetting validators are exited `0x00` validators and are skipped by the sweep (not fully withdrawable without execution credentials), so the clamp is the only mechanism affecting their balances. Upon credential rotation the validator becomes fully withdrawable and the sweep pays the remaining balance, and the clamp no longer applies from the same epoch.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](../LICENSE.md).


### PR DESCRIPTION
Adds `EIPS/eip-8367.md`, split out of #12151 so the EIP is reviewed on its own without unrelated CI workflow changes.

Discussions-to: https://ethereum-magicians.org/t/eip-8367-balance-sunset-for-retired-bls-validators/29299

Only `EIPS/eip-8367.md` is added; no workflow or tooling files are touched.