### PR TITLE
Update EIP-1: blank line after footnote definitions

### DIFF
--- a/EIPS/eip-1.md
+++ b/EIPS/eip-1.md
@@ -420,6 +420,7 @@ Links qualified with a Digital Object Identifier (DOI) may be included using the
 This is a sentence with a footnote.[^1]
 
 [^1]:
+
     ```csl-json
     {
       "type": "article",
@@ -455,6 +456,7 @@ Which renders to:
 This is a sentence with a footnote.[^1]
 
 [^1]:
+
     ```csl-json
     {
       "type": "article",


### PR DESCRIPTION
Markdownlint fix, split out of #12070 so each EIP is reviewed on its own.

`markdownlint` MD031 (`blanks-around-fences`, enabled with `list_items: true` in `config/.markdownlint.yaml`) requires fenced code blocks to be surrounded by blank lines. The `csl-json` fences under the `[^1]:` footnote definitions are not, so the file currently fails the linter:

```
EIPS/eip-1.md:478 error MD031/blanks-around-fences Fenced code blocks should be surrounded by blank lines [Context: "```csl-json"]
```

This went unnoticed because the Markdown Linter job lints only files changed in a PR, so untouched files are never re-checked.

Both occurrences are updated: the live footnote, and the example inside the fenced `markdown` block that documents the syntax — otherwise authors copying the documented example would produce markdown that fails CI.

Verified locally with `markdownlint-cli2 --config config/.markdownlint.yaml EIPS/eip-1.md`: 0 issues. Adding a blank line after `[^1]:` does not change rendering; the indented block remains part of the footnote definition.