### PR TITLE
Update EIP-8173: blank line after footnote definitions

### DIFF
--- a/EIPS/eip-8173.md
+++ b/EIPS/eip-8173.md
@@ -247,6 +247,7 @@ This Informational proposal itself specifies no changes to the protocol.  Theref
 <!-- markdownlint-disable code-block-style -->
 
 [^1]:
+
     ```csl-json
     {
       "type": "article",
@@ -269,6 +270,7 @@ This Informational proposal itself specifies no changes to the protocol.  Theref
     ```
 
 [^2]:
+
     ```csl-json
     {
       "type": "article",
@@ -291,6 +293,7 @@ This Informational proposal itself specifies no changes to the protocol.  Theref
     ```
 
 [^3]:
+
     ```csl-json
     {
       "type": "article",
@@ -313,6 +316,7 @@ This Informational proposal itself specifies no changes to the protocol.  Theref
     ```
 
 [^4]:
+
     ```csl-json
     {
       "type": "article",
@@ -335,6 +339,7 @@ This Informational proposal itself specifies no changes to the protocol.  Theref
     ```
 
 [^5]:
+
     ```csl-json
     {
       "type": "article",
@@ -357,6 +362,7 @@ This Informational proposal itself specifies no changes to the protocol.  Theref
     ```
 
 [^6]:
+
     ```csl-json
     {
       "type": "article",
@@ -379,6 +385,7 @@ This Informational proposal itself specifies no changes to the protocol.  Theref
     ```
 
 [^7]:
+
     ```csl-json
     {
       "type": "article",
@@ -401,6 +408,7 @@ This Informational proposal itself specifies no changes to the protocol.  Theref
     ```
 
 [^8]:
+
     ```csl-json
     {
       "type": "article",


### PR DESCRIPTION
Markdownlint fix, split out of #12070 so each EIP is reviewed on its own.

`markdownlint` MD031 (`blanks-around-fences`, enabled with `list_items: true` in `config/.markdownlint.yaml`) requires fenced code blocks to be surrounded by blank lines. The eight `csl-json` fences under the `[^1]:`–`[^8]:` footnote definitions are not, so the file currently fails the linter with 8 errors:

```
EIPS/eip-8173.md:250 error MD031/blanks-around-fences Fenced code blocks should be surrounded by blank lines [Context: "```csl-json"]
... (8 total, lines 250-404)
```

The `<!-- markdownlint-disable code-block-style -->` comment already present in that section suppresses MD046 only, not MD031.

This went unnoticed because the Markdown Linter job lints only files changed in a PR, so untouched files are never re-checked.

Verified locally with `markdownlint-cli2 --config config/.markdownlint.yaml EIPS/eip-8173.md`: 8 issues before, 0 after. Adding a blank line after the footnote marker does not change rendering; the indented block remains part of the footnote definition. Only whitespace is added — no prose, no normative content.

cc @gcolvin as author.