### PR TITLE
CI: route workflow reviews to editors and document merge blockers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,5 @@
 * @eth-bot
+
+# Workflow changes cannot be reviewed by the bot that the workflows configure,
+# so route them to the governance editors instead.
+.github/workflows/** @lightclient @SamWilsn @xinbenlv @g11tech @jochem-brouwer

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,3 +10,9 @@ We have a GitHub bot that automatically merges some PRs. It will merge yours imm
  - The build passes.
  - Your GitHub username or email address is listed in the 'author' header of all affected PRs, inside <triangular brackets>.
  - If matching on email address, the email address is the one publicly listed on your GitHub profile.
+
+If your PR is green but still will not merge:
+
+ - Check the labels. Process labels such as `e-consensus` or `e-review` mean an editor still has to act.
+ - Changes under `.github/workflows/**` are owned by the governance editors, not the bot, so they need a human review.
+ - A PR that mixes an EIP with tooling or workflow changes needs sign-off from both, which is usually slower than splitting it in two.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,6 +123,15 @@ To clarify the merge blocker if needed, add applicable labels.
 Your contributions help maintain the integrity and accessibility of Ethereum’s open-source governance process.  
 Together, we make the protocol and its documentation stronger, clearer, and more collaborative.
 
+## When a green PR does not merge
+
+Passing CI is necessary but not always sufficient. If every check is green and the PR still will not merge:
+
+* Check the labels. `e-consensus`, `e-review` and similar process labels mean an editor still has to act.
+* Confirm author acknowledgement. Editing someone else's EIP needs that author's approval, even for typo and lint fixes.
+* Files under `.github/workflows/**` are owned by the governance editors rather than `@eth-bot`, so they require a human review.
+* Avoid mixing categories in one PR. An EIP bundled with workflow or tooling changes needs approval from both sets of reviewers; splitting it is normally faster.
+
 ## References
 
 * [EIP-1: EIP Purpose and Guidelines](https://eips.ethereum.org/EIPS/eip-1) 


### PR DESCRIPTION
Replaces the CODEOWNERS and documentation parts of #12017 and #12070, without the unrelated workflow rewrites those PRs also carried.

## CODEOWNERS

`.github/CODEOWNERS` is currently just `* @eth-bot`, so the workflow files that configure the bot are owned by the bot itself and have no human reviewer. This adds:

```
.github/workflows/** @lightclient @SamWilsn @xinbenlv @g11tech @jochem-brouwer
```

Those five names are exactly the `governance` group in `config/eip-editors.yml`, not a hand-picked list. CODEOWNERS applies the last matching pattern, so everything else still falls to `@eth-bot` as before; only `.github/workflows/**` changes owner.

## Documentation

`CONTRIBUTING.md` and `.github/PULL_REQUEST_TEMPLATE.md` explain what makes CI pass but say nothing about why an all-green PR might still not merge. Both now note process labels, author acknowledgement for edits to someone else's EIP, the new workflow ownership, and that mixing an EIP with tooling changes requires two sets of approvals.

That last point is not hypothetical: #12151 sat blocked precisely because it bundled a new EIP with CI changes, and had to be split into #12177 and #12178.

## Verification

`markdownlint-cli2 --config config/.markdownlint.yaml CONTRIBUTING.md` is clean. The two pre-existing violations in `PULL_REQUEST_TEMPLATE.md` (MD041 line 1, MD033 line 11) are untouched, and that path is outside the CI linter's glob in any case.

No EIP or workflow logic is modified.