### PR TITLE
Update EIP-8205: adapt to the latest Gloas specification

### DIFF
--- a/EIPS/eip-8205.md
+++ b/EIPS/eip-8205.md
@@ -45,7 +45,7 @@ For an extended analysis of the problem scope, existing application-layer defens
 | `TARGET_PREREGISTRATION_REQUESTS_PER_BLOCK`       | `1`                                          |                                                                              |
 | `MIN_PREREGISTRATION_REQUEST_FEE`                 | `1`                                          |                                                                              |
 | `PREREGISTRATION_REQUEST_FEE_UPDATE_FRACTION`     | `17`                                         |                                                                              |
-| `EXCESS_INHIBITOR`                                | `2**256-1`                                   | Excess value used to compute the fee before the first system call            |
+| `EXCESS_INHIBITOR`                                | `2**256-1`                                   | Excess value that blocks requests before activation and while disabled       |
 
 #### Consensus layer
 
@@ -83,7 +83,7 @@ Each serialized request record is 176 bytes (`pubkey ++ withdrawal_credentials +
 
 The contract has three different code paths, which can be summarized at a high level as follows:
 
-1. System process - if called by system address, pop off the preregistration requests for the current block from the queue.
+1. System process - if called by system address, pop off the preregistration requests for the current block from the queue. If the call carries non-empty calldata, additionally disable the queue (see Rationale).
 2. Add preregistration request - for any other caller, requires a `176` byte input, the validator's public key concatenated with withdrawal credentials and a BLS signature. An accepted request is emitted verbatim as an anonymous log (`LOG0`, no topics).
 3. Fee getter - for any other caller, if the input length is zero, return the current fee required to add a preregistration request.
 
@@ -179,6 +179,8 @@ Additionally, the system call and the processing of that block must conform to t
 - If there is no code at `PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS`, the corresponding block **MUST** be marked invalid.
 - If the call to the contract fails or returns an error, the block **MUST** be invalidated.
 
+A system call with non-empty calldata dequeues requests as usual but then stores `EXCESS_INHIBITOR` into the excess slot, disabling the queue: subsequent preregistration requests revert until a system call with empty calldata re-enables it. Under this EIP the system call is always made with empty calldata, so this path is unreachable; it is reserved for a future upgrade (see Rationale).
+
 The functionality triggered by the system call is defined in pseudocode as the function `read_preregistration_requests()`:
 
 ```python
@@ -242,8 +244,14 @@ def dequeue_preregistration_requests():
     return reqs
 
 def update_excess_preregistration_requests():
+    # A system call with non-empty calldata disables the queue (see Rationale)
+    if len(msg.data) > 0:
+        sstore(PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, EXCESS_PREREGISTRATION_REQUESTS_STORAGE_SLOT, EXCESS_INHIBITOR)
+        return
+
     previous_excess = sload(PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, EXCESS_PREREGISTRATION_REQUESTS_STORAGE_SLOT)
-    # Check if excess needs to be reset to 0 for first iteration after activation
+    # Reset excess to 0 on the first system call after activation and when
+    # re-enabling a disabled queue
     if previous_excess == EXCESS_INHIBITOR:
         previous_excess = 0
 
@@ -491,6 +499,10 @@ A dedicated domain is used rather than reusing `DOMAIN_DEPOSIT` because `DOMAIN_
 ### BLS verification on CL only
 
 BLS verification happens on the CL, not in the EL system contract. The signing domain includes `genesis_validators_root`, and the CL must perform semantic validation before storing the preregistration. Repeating the verification on the EL would duplicate that work, so the system contract acts only as a rate-limited queue. Submission is permissionless, and the BLS signature is the sole authorization mechanism. Invalid signatures are silently discarded by the CL, costing only the system contract fee.
+
+### Disabling the queue
+
+A system call with non-empty calldata stores `EXCESS_INHIBITOR` into the excess slot and thereby disables the queue; a later system call with empty calldata restores it, through the same code path that clears the inhibitor at activation. Under this EIP every system call is made with empty calldata, so the path is unreachable. It exists for a future upgrade that retires or suspends the contract: without it, once the protocol stops making the per-block system call, the contract would keep accepting requests and fees into a queue that never drains. The [EIP-8282](./eip-8282.md) builder request contracts' reference implementation uses the same mechanism.
 
 ### Parameter choices
 

--- a/EIPS/eip-8205.md
+++ b/EIPS/eip-8205.md
@@ -1,19 +1,19 @@
 ---
 eip: 8205
 title: Withdrawal credentials preregistration
-description: Bind a validator public key to withdrawal credentials before deposit via an EL system contract enforced by the CL
+description: Bind a validator public key to withdrawal credentials before validator deposit via an EL system contract enforced by the CL
 author: George Avsetsin (@avsetsin), Dmitry Gusakov (@dgusakov), Greg Koumoutsos (@gkoumout), Eugene Mamin (@TheDZhon)
 discussions-to: https://ethereum-magicians.org/t/eip-8205-withdrawal-credentials-preregistration/28084
 status: Draft
 type: Standards Track
 category: Core
 created: 2026-03-26
-requires: 4788, 6110, 7685, 7732
+requires: 6110, 7685, 7732
 ---
 
 ## Abstract
 
-This EIP introduces a preregistration mechanism that allows a validator key holder to commit to specific withdrawal credentials before any deposit is made, addressing a known deposit front-running vulnerability in delegated staking. Preregistrations are submitted through a new [EIP-7685](./eip-7685.md) request type via a system contract on the execution layer, rate-limited by an [EIP-1559](./eip-1559.md)-style exponential fee mechanism. The consensus layer stores the preregistration in beacon state and enforces it at deposit processing time: matching deposits proceed and the preregistration is consumed; mismatched deposits are silently rejected. The mechanism is fully optional — deposits for public keys without a preregistration are processed exactly as today.
+This EIP introduces a preregistration mechanism that allows a validator key holder to commit to specific withdrawal credentials before any validator deposit is made, addressing a known deposit front-running vulnerability in delegated staking. Preregistrations are submitted through a new [EIP-7685](./eip-7685.md) request contract on the execution layer, following the same queue, fee, and system-call pattern as [EIP-7002](./eip-7002.md) and [EIP-7251](./eip-7251.md). The consensus layer stores the expirable preregistration in beacon state and enforces it at deposit processing time: matching deposits proceed and the preregistration is consumed; mismatched deposits are silently rejected. The mechanism is fully optional — deposits for public keys without a preregistration are processed exactly as today.
 
 ## Motivation
 
@@ -21,7 +21,7 @@ In delegated staking, the entity funding a validator and the entity generating t
 
 At least a third of all staked ETH flows through delegated architectures with identifiable protocol-level protections against this attack. Since no on-chain mechanism exists to bind a public key to withdrawal credentials before the first deposit, every affected product has independently built application-layer defenses — bond-based pre-deposit schemes, guardian committees, or both. These defenses work (no known exploits have occurred in production), but each one is built, audited, and maintained independently, and new entrants are vulnerable by default until they do the same.
 
-Preregistration addresses this at the protocol layer: the key holder signs a binding commitment to specific withdrawal credentials before any deposit is made, and the consensus layer enforces this commitment at deposit processing time.
+Preregistration addresses this at the protocol layer: the key holder signs a binding commitment to specific withdrawal credentials before any validator deposit is made, and the consensus layer enforces this commitment at deposit processing time.
 
 For an extended analysis of the problem scope, existing application-layer defenses, and data sources, see the discussion thread linked in the header.
 
@@ -31,60 +31,63 @@ For an extended analysis of the problem scope, existing application-layer defens
 
 #### Execution layer
 
-| Name                                                        | Value                                        | Comment                                                                      |
-| ----------------------------------------------------------- | -------------------------------------------- | ---------------------------------------------------------------------------- |
-| `VALIDATOR_PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS`       | `TBD`                                        | Where to call and store relevant details about preregistration mechanism     |
-| `VALIDATOR_PREREGISTRATION_REQUEST_TYPE`                    | `TBD`                                        | The [EIP-7685](./eip-7685.md) type prefix for preregistration request        |
-| `SYSTEM_ADDRESS`                                            | `0xfffffffffffffffffffffffffffffffffffffffe` | Address used to invoke system operation on contract                          |
-| `EXCESS_VALIDATOR_PREREGISTRATION_REQUESTS_STORAGE_SLOT`    | `0`                                          |                                                                              |
-| `VALIDATOR_PREREGISTRATION_REQUEST_COUNT_STORAGE_SLOT`      | `1`                                          |                                                                              |
-| `VALIDATOR_PREREGISTRATION_REQUEST_QUEUE_HEAD_STORAGE_SLOT` | `2`                                          | Pointer to head of the preregistration request message queue                 |
-| `VALIDATOR_PREREGISTRATION_REQUEST_QUEUE_TAIL_STORAGE_SLOT` | `3`                                          | Pointer to the tail of the preregistration request message queue             |
-| `VALIDATOR_PREREGISTRATION_REQUEST_QUEUE_STORAGE_OFFSET`    | `4`                                          | The start memory slot of the in-state preregistration request message queue  |
-| `MAX_VALIDATOR_PREREGISTRATION_REQUESTS_PER_BLOCK`          | `4`                                          | Maximum number of preregistration requests that can be dequeued into a block |
-| `TARGET_VALIDATOR_PREREGISTRATION_REQUESTS_PER_BLOCK`       | `1`                                          |                                                                              |
-| `MIN_VALIDATOR_PREREGISTRATION_REQUEST_FEE`                 | `1`                                          |                                                                              |
-| `VALIDATOR_PREREGISTRATION_REQUEST_FEE_UPDATE_FRACTION`     | `17`                                         |                                                                              |
-| `EXCESS_INHIBITOR`                                          | `2**256-1`                                   | Excess value used to compute the fee before the first system call            |
+| Name                                              | Value                                        | Comment                                                                      |
+| ------------------------------------------------- | -------------------------------------------- | ---------------------------------------------------------------------------- |
+| `PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS`       | `TBD`                                        | Where to call and store relevant details about preregistration mechanism     |
+| `PREREGISTRATION_REQUEST_TYPE`                    | `TBD`                                        | The [EIP-7685](./eip-7685.md) type prefix for preregistration request        |
+| `SYSTEM_ADDRESS`                                  | `0xfffffffffffffffffffffffffffffffffffffffe` | Address used to invoke system operation on contract                          |
+| `EXCESS_PREREGISTRATION_REQUESTS_STORAGE_SLOT`    | `0`                                          |                                                                              |
+| `PREREGISTRATION_REQUEST_COUNT_STORAGE_SLOT`      | `1`                                          |                                                                              |
+| `PREREGISTRATION_REQUEST_QUEUE_HEAD_STORAGE_SLOT` | `2`                                          | Pointer to head of the preregistration request message queue                 |
+| `PREREGISTRATION_REQUEST_QUEUE_TAIL_STORAGE_SLOT` | `3`                                          | Pointer to the tail of the preregistration request message queue             |
+| `PREREGISTRATION_REQUEST_QUEUE_STORAGE_OFFSET`    | `4`                                          | The start memory slot of the in-state preregistration request message queue  |
+| `MAX_PREREGISTRATION_REQUESTS_PER_BLOCK`          | `4`                                          | Maximum number of preregistration requests that can be dequeued into a block |
+| `TARGET_PREREGISTRATION_REQUESTS_PER_BLOCK`       | `1`                                          |                                                                              |
+| `MIN_PREREGISTRATION_REQUEST_FEE`                 | `1`                                          |                                                                              |
+| `PREREGISTRATION_REQUEST_FEE_UPDATE_FRACTION`     | `17`                                         |                                                                              |
+| `EXCESS_INHIBITOR`                                | `2**256-1`                                   | Excess value used to compute the fee before the first system call            |
 
 #### Consensus layer
 
-| Name                                                 | Value                       | Comment                                                |
-| ---------------------------------------------------- | --------------------------- | ------------------------------------------------------ |
-| `DOMAIN_VALIDATOR_PREREGISTRATION`                   | `DomainType('0x0E000000')`  | Uses `GENESIS_FORK_VERSION` (stable across forks)      |
-| `MAX_VALIDATOR_PREREGISTRATION_REQUESTS_PER_PAYLOAD` | `uint64(2**2)` (= 4)        | Maximum preregistration requests per execution payload |
-| `VALIDATOR_PREREGISTRATIONS_LIMIT`                   | `uint64(2**19)` (= 524,288) | Maximum stored preregistrations in beacon state        |
-| `VALIDATOR_PREREGISTRATION_EXPIRY_SLOTS`             | `uint64(2**18)` (= 262,144) | Lifetime in finalized slots (~36 days at 12s/slot)     |
+| Name                                       | Value                       | Comment                                                |
+| ------------------------------------------ | --------------------------- | ------------------------------------------------------ |
+| `DOMAIN_PREREGISTRATION`                   | `DomainType('0x11000000')`  | Uses `GENESIS_FORK_VERSION` (stable across forks)      |
+| `MAX_PREREGISTRATION_REQUESTS_PER_PAYLOAD` | `Uint64(2**2)` (= 4)        | Maximum preregistration requests per execution payload |
+| `PREREGISTRATIONS_LIMIT`                   | `Uint64(2**19)` (= 524,288) | State-transition limit on active preregistrations      |
+| `PREREGISTRATION_EXPIRY_SLOTS`             | `Slot(2**18)` (= 262,144)   | Lifetime in slots (~36 days at 12 seconds per slot)    |
 
 ### Execution layer
 
 #### Definitions
 
-- **`FORK_BLOCK`** -- the first block in a blockchain after this EIP has been activated.
+- **`FORK_BLOCK`** — the first block in a blockchain after this EIP has been activated.
 
 #### Preregistration request operation
 
-The new preregistration request is an [EIP-7685](./eip-7685.md) request with type `VALIDATOR_PREREGISTRATION_REQUEST_TYPE` and consists of the following fields:
+The new preregistration request is an [EIP-7685](./eip-7685.md) request with type `PREREGISTRATION_REQUEST_TYPE` and consists of the following fields:
 
-1. `source_address`: `Bytes20`
-2. `pubkey`: `Bytes48`
-3. `withdrawal_credentials`: `Bytes32`
-4. `signature`: `Bytes96`
+1. `pubkey`: `Bytes48`
+2. `withdrawal_credentials`: `Bytes32`
+3. `signature`: `Bytes96`
 
 The [EIP-7685](./eip-7685.md) encoding of a preregistration request is computed as follows.
 
 ```python
-request_type = VALIDATOR_PREREGISTRATION_REQUEST_TYPE
+request_type = PREREGISTRATION_REQUEST_TYPE
 request_data = read_preregistration_requests()
 ```
+
+Each serialized request record is 176 bytes (`pubkey ++ withdrawal_credentials ++ signature`), and `request_data` is the flat concatenation of all dequeued records in queue order.
 
 #### Preregistration Request Contract
 
 The contract has three different code paths, which can be summarized at a high level as follows:
 
-1. Add preregistration request - requires a `176` byte input, the validator's public key concatenated with withdrawal credentials and a BLS signature.
-2. Fee getter - if the input length is zero, return the current fee required to add a preregistration request.
-3. System process - if called by system address, pop off the preregistration requests for the current block from the queue.
+1. System process - if called by system address, pop off the preregistration requests for the current block from the queue.
+2. Add preregistration request - for any other caller, requires a `176` byte input, the validator's public key concatenated with withdrawal credentials and a BLS signature. An accepted request is emitted verbatim as an anonymous log (`LOG0`, no topics).
+3. Fee getter - for any other caller, if the input length is zero, return the current fee required to add a preregistration request.
+
+For non-system callers, any other input length MUST cause the call to revert.
 
 ##### Add Preregistration Request
 
@@ -92,13 +95,14 @@ If call data input to the contract is exactly `176` bytes, perform the following
 
 1. Ensure enough ETH was sent to cover the current preregistration request fee (`check_fee()`)
 2. Increase preregistration request count by `1` for the current block (`increment_count()`)
-3. Insert a preregistration request into the queue for the source address, pubkey, withdrawal credentials, and signature (`insert_preregistration_request_into_queue()`)
+3. Insert a preregistration request into the queue for the pubkey, withdrawal credentials, and signature (`insert_preregistration_request_into_queue()`)
+4. Emit the accepted `pubkey ++ withdrawal_credentials ++ signature` request as an anonymous log
 
 Specifically, the functionality is defined in pseudocode as the function `add_preregistration_request()`:
 
 ```python
 def add_preregistration_request(Bytes48: pubkey, Bytes32: withdrawal_credentials,
-                                 Bytes96: signature):
+                                Bytes96: signature):
     """
     Add preregistration request adds new request to the preregistration request queue,
     so long as a sufficient fee is provided.
@@ -109,20 +113,20 @@ def add_preregistration_request(Bytes48: pubkey, Bytes32: withdrawal_credentials
     require(msg.value >= fee, 'Insufficient value for fee')
 
     # Increment preregistration request count.
-    count = sload(VALIDATOR_PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, VALIDATOR_PREREGISTRATION_REQUEST_COUNT_STORAGE_SLOT)
-    sstore(VALIDATOR_PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, VALIDATOR_PREREGISTRATION_REQUEST_COUNT_STORAGE_SLOT, count + 1)
+    count = sload(PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, PREREGISTRATION_REQUEST_COUNT_STORAGE_SLOT)
+    sstore(PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, PREREGISTRATION_REQUEST_COUNT_STORAGE_SLOT, count + 1)
 
     # Insert into queue.
-    queue_tail_index = sload(VALIDATOR_PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, VALIDATOR_PREREGISTRATION_REQUEST_QUEUE_TAIL_STORAGE_SLOT)
-    queue_storage_slot = VALIDATOR_PREREGISTRATION_REQUEST_QUEUE_STORAGE_OFFSET + queue_tail_index * 7
-    sstore(VALIDATOR_PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, queue_storage_slot, msg.sender)
-    sstore(VALIDATOR_PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, queue_storage_slot + 1, pubkey[0:32])
-    sstore(VALIDATOR_PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, queue_storage_slot + 2, pubkey[32:48] ++ withdrawal_credentials[0:16])
-    sstore(VALIDATOR_PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, queue_storage_slot + 3, withdrawal_credentials[16:32] ++ signature[0:16])
-    sstore(VALIDATOR_PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, queue_storage_slot + 4, signature[16:48])
-    sstore(VALIDATOR_PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, queue_storage_slot + 5, signature[48:80])
-    sstore(VALIDATOR_PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, queue_storage_slot + 6, signature[80:96])
-    sstore(VALIDATOR_PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, VALIDATOR_PREREGISTRATION_REQUEST_QUEUE_TAIL_STORAGE_SLOT, queue_tail_index + 1)
+    queue_tail_index = sload(PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, PREREGISTRATION_REQUEST_QUEUE_TAIL_STORAGE_SLOT)
+    queue_storage_slot = PREREGISTRATION_REQUEST_QUEUE_STORAGE_OFFSET + queue_tail_index * 6
+    sstore(PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, queue_storage_slot, pubkey[0:32])
+    sstore(PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, queue_storage_slot + 1, pubkey[32:48] ++ withdrawal_credentials[0:16])
+    sstore(PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, queue_storage_slot + 2, withdrawal_credentials[16:32] ++ signature[0:16])
+    sstore(PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, queue_storage_slot + 3, signature[16:48])
+    sstore(PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, queue_storage_slot + 4, signature[48:80])
+    sstore(PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, queue_storage_slot + 5, signature[80:96])
+    log0(pubkey ++ withdrawal_credentials ++ signature)
+    sstore(PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, PREREGISTRATION_REQUEST_QUEUE_TAIL_STORAGE_SLOT, queue_tail_index + 1)
 ```
 
 ###### Fee calculation
@@ -131,12 +135,12 @@ The following pseudocode can compute the cost of an individual preregistration r
 
 ```python
 def get_fee() -> int:
-    excess = sload(VALIDATOR_PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, EXCESS_VALIDATOR_PREREGISTRATION_REQUESTS_STORAGE_SLOT)
+    excess = sload(PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, EXCESS_PREREGISTRATION_REQUESTS_STORAGE_SLOT)
     require(excess != EXCESS_INHIBITOR, 'Inhibitor still active')
     return fake_exponential(
-        MIN_VALIDATOR_PREREGISTRATION_REQUEST_FEE,
+        MIN_PREREGISTRATION_REQUEST_FEE,
         excess,
-        VALIDATOR_PREREGISTRATION_REQUEST_FEE_UPDATE_FRACTION
+        PREREGISTRATION_REQUEST_FEE_UPDATE_FRACTION
     )
 
 def fake_exponential(factor: int, numerator: int, denominator: int) -> int:
@@ -150,13 +154,15 @@ def fake_exponential(factor: int, numerator: int, denominator: int) -> int:
     return output // denominator
 ```
 
+As in [EIP-7002](./eip-7002.md) and [EIP-7251](./eip-7251.md), `get_fee()` uses only the persisted `excess` value. It does not include requests accumulated in `count` during the current block. The end-of-block system call incorporates `count` into `excess`, so requests submitted in block `N` affect the fee starting in block `N + 1`.
+
 ##### Fee Getter
 
-When the input to the contract is length zero, interpret this as a get request for the current fee, i.e. the contract returns the result of `get_fee()`.
+When the input to the contract is length zero and the caller is not `SYSTEM_ADDRESS`, interpret this as a get request for the current fee. The call MUST carry no value and returns the result of `get_fee()` without modifying state; a value-bearing fee getter call MUST revert.
 
 ##### System Call
 
-At the end of processing any execution block starting from the `FORK_BLOCK` (i.e. after processing all transactions and after performing the block body preregistration requests validations), call `VALIDATOR_PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS` as `SYSTEM_ADDRESS` with no calldata. The invocation triggers the following:
+At the end of processing any execution block starting from the `FORK_BLOCK`, call `PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS` as `SYSTEM_ADDRESS` with no calldata. The invocation triggers the following:
 
 - The contract's queue is updated based on preregistration requests dequeued and the preregistration requests queue head/tail are reset if the queue has been cleared (`dequeue_preregistration_requests()`)
 - The contract's excess preregistration requests are updated based on usage in the current block (`update_excess_preregistration_requests()`)
@@ -169,8 +175,8 @@ Additionally, the system call and the processing of that block must conform to t
 - The call has a dedicated gas limit of `30_000_000`.
 - Gas consumed by this call does not count against the block's overall gas usage.
 - Both the gas limit assigned to the call and the gas consumed are excluded from any checks against the block's gas limit.
-- The call does not follow [EIP-1559](./eip-1559.md) fee burn semantics -- no value should be transferred as part of this call.
-- If there is no code at `VALIDATOR_PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS`, the corresponding block **MUST** be marked invalid.
+- The call does not follow [EIP-1559](./eip-1559.md) fee burn semantics — no value should be transferred as part of this call.
+- If there is no code at `PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS`, the corresponding block **MUST** be marked invalid.
 - If the call to the contract fails or returns an error, the block **MUST** be invalidated.
 
 The functionality triggered by the system call is defined in pseudocode as the function `read_preregistration_requests()`:
@@ -191,37 +197,34 @@ def read_preregistration_requests():
 ###########
 
 class PreregistrationRequest(object):
-    source_address: Bytes20
     pubkey: Bytes48
     withdrawal_credentials: Bytes32
     signature: Bytes96
 
 def dequeue_preregistration_requests():
-    queue_head_index = sload(VALIDATOR_PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, VALIDATOR_PREREGISTRATION_REQUEST_QUEUE_HEAD_STORAGE_SLOT)
-    queue_tail_index = sload(VALIDATOR_PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, VALIDATOR_PREREGISTRATION_REQUEST_QUEUE_TAIL_STORAGE_SLOT)
+    queue_head_index = sload(PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, PREREGISTRATION_REQUEST_QUEUE_HEAD_STORAGE_SLOT)
+    queue_tail_index = sload(PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, PREREGISTRATION_REQUEST_QUEUE_TAIL_STORAGE_SLOT)
     num_in_queue = queue_tail_index - queue_head_index
-    num_dequeued = min(num_in_queue, MAX_VALIDATOR_PREREGISTRATION_REQUESTS_PER_BLOCK)
+    num_dequeued = min(num_in_queue, MAX_PREREGISTRATION_REQUESTS_PER_BLOCK)
 
     reqs = []
     for i in range(num_dequeued):
-        queue_storage_slot = VALIDATOR_PREREGISTRATION_REQUEST_QUEUE_STORAGE_OFFSET + (queue_head_index + i) * 7
-        source_address = address(sload(VALIDATOR_PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, queue_storage_slot)[0:20])
+        queue_storage_slot = PREREGISTRATION_REQUEST_QUEUE_STORAGE_OFFSET + (queue_head_index + i) * 6
         pubkey = (
-            sload(VALIDATOR_PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, queue_storage_slot + 1)[0:32]
-            + sload(VALIDATOR_PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, queue_storage_slot + 2)[0:16]
+            sload(PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, queue_storage_slot)[0:32]
+            + sload(PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, queue_storage_slot + 1)[0:16]
         )
         withdrawal_credentials = (
-            sload(VALIDATOR_PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, queue_storage_slot + 2)[16:32]
-            + sload(VALIDATOR_PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, queue_storage_slot + 3)[0:16]
+            sload(PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, queue_storage_slot + 1)[16:32]
+            + sload(PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, queue_storage_slot + 2)[0:16]
         )
         signature = (
-            sload(VALIDATOR_PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, queue_storage_slot + 3)[16:32]
-            + sload(VALIDATOR_PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, queue_storage_slot + 4)[0:32]
-            + sload(VALIDATOR_PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, queue_storage_slot + 5)[0:32]
-            + sload(VALIDATOR_PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, queue_storage_slot + 6)[0:16]
+            sload(PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, queue_storage_slot + 2)[16:32]
+            + sload(PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, queue_storage_slot + 3)[0:32]
+            + sload(PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, queue_storage_slot + 4)[0:32]
+            + sload(PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, queue_storage_slot + 5)[0:16]
         )
         req = PreregistrationRequest(
-            source_address=Bytes20(source_address),
             pubkey=Bytes48(pubkey),
             withdrawal_credentials=Bytes32(withdrawal_credentials),
             signature=Bytes96(signature)
@@ -231,29 +234,29 @@ def dequeue_preregistration_requests():
     new_queue_head_index = queue_head_index + num_dequeued
     if new_queue_head_index == queue_tail_index:
         # Queue is empty, reset queue pointers
-        sstore(VALIDATOR_PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, VALIDATOR_PREREGISTRATION_REQUEST_QUEUE_HEAD_STORAGE_SLOT, 0)
-        sstore(VALIDATOR_PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, VALIDATOR_PREREGISTRATION_REQUEST_QUEUE_TAIL_STORAGE_SLOT, 0)
+        sstore(PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, PREREGISTRATION_REQUEST_QUEUE_HEAD_STORAGE_SLOT, 0)
+        sstore(PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, PREREGISTRATION_REQUEST_QUEUE_TAIL_STORAGE_SLOT, 0)
     else:
-        sstore(VALIDATOR_PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, VALIDATOR_PREREGISTRATION_REQUEST_QUEUE_HEAD_STORAGE_SLOT, new_queue_head_index)
+        sstore(PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, PREREGISTRATION_REQUEST_QUEUE_HEAD_STORAGE_SLOT, new_queue_head_index)
 
     return reqs
 
 def update_excess_preregistration_requests():
-    previous_excess = sload(VALIDATOR_PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, EXCESS_VALIDATOR_PREREGISTRATION_REQUESTS_STORAGE_SLOT)
+    previous_excess = sload(PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, EXCESS_PREREGISTRATION_REQUESTS_STORAGE_SLOT)
     # Check if excess needs to be reset to 0 for first iteration after activation
     if previous_excess == EXCESS_INHIBITOR:
         previous_excess = 0
 
-    count = sload(VALIDATOR_PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, VALIDATOR_PREREGISTRATION_REQUEST_COUNT_STORAGE_SLOT)
+    count = sload(PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, PREREGISTRATION_REQUEST_COUNT_STORAGE_SLOT)
 
     new_excess = 0
-    if previous_excess + count > TARGET_VALIDATOR_PREREGISTRATION_REQUESTS_PER_BLOCK:
-        new_excess = previous_excess + count - TARGET_VALIDATOR_PREREGISTRATION_REQUESTS_PER_BLOCK
+    if previous_excess + count > TARGET_PREREGISTRATION_REQUESTS_PER_BLOCK:
+        new_excess = previous_excess + count - TARGET_PREREGISTRATION_REQUESTS_PER_BLOCK
 
-    sstore(VALIDATOR_PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, EXCESS_VALIDATOR_PREREGISTRATION_REQUESTS_STORAGE_SLOT, new_excess)
+    sstore(PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, EXCESS_PREREGISTRATION_REQUESTS_STORAGE_SLOT, new_excess)
 
 def reset_preregistration_requests_count():
-    sstore(VALIDATOR_PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, VALIDATOR_PREREGISTRATION_REQUEST_COUNT_STORAGE_SLOT, 0)
+    sstore(PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS, PREREGISTRATION_REQUEST_COUNT_STORAGE_SLOT, 0)
 ```
 
 ##### Bytecode
@@ -268,6 +271,16 @@ TBD — the deterministic deployment transaction will be provided with the refer
 
 A sketch of the key consensus layer changes is included below.
 
+#### New types
+
+```python
+class PreregistrationRequests(ProgressiveList[PreregistrationRequest]):
+    """The preregistration requests pertaining to a single execution payload."""
+
+class ValidatorPreregistrations(ProgressiveList[StoredPreregistration]):
+    """The stored preregistrations, including expired records not yet garbage-collected."""
+```
+
 #### New containers
 
 ```python
@@ -276,7 +289,6 @@ class ValidatorPreregistration(Container):
     withdrawal_credentials: Bytes32    # 32 bytes — withdrawal credentials to lock in
 
 class PreregistrationRequest(Container):
-    source_address: ExecutionAddress   # 20 bytes — msg.sender of the system contract call
     pubkey: BLSPubkey                  # 48 bytes
     withdrawal_credentials: Bytes32    # 32 bytes
     signature: BLSSignature            # 96 bytes — BLS proof of key ownership
@@ -284,7 +296,7 @@ class PreregistrationRequest(Container):
 class StoredPreregistration(Container):
     pubkey: BLSPubkey
     withdrawal_credentials: Bytes32
-    inclusion_slot: Slot               # CL beacon slot when stored; used for expiry and Merkle provability
+    expiry_slot: Slot                  # absolute expiry slot, set when the preregistration is stored
 ```
 
 #### Modified containers
@@ -292,45 +304,50 @@ class StoredPreregistration(Container):
 `ExecutionRequests` is extended with a new field:
 
 ```python
-class ExecutionRequests(Container):
-    deposits: List[DepositRequest, MAX_DEPOSIT_REQUESTS_PER_PAYLOAD]
-    withdrawals: List[WithdrawalRequest, MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD]
-    consolidations: List[ConsolidationRequest, MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD]
-    preregistrations: List[PreregistrationRequest, MAX_VALIDATOR_PREREGISTRATION_REQUESTS_PER_PAYLOAD]  # [New]
+preregistrations: PreregistrationRequests  # [New]
 ```
 
-Preregistration requests are processed after deposit requests. The processing order is defined by explicit `for_ops()` calls in `process_operations`, following the same pattern as deposits, withdrawals, and consolidations:
-
-```python
-# In process_operations (sketch):
-for_ops(body.execution_requests.deposits, process_deposit_request)
-for_ops(body.execution_requests.withdrawals, process_withdrawal_request)
-for_ops(body.execution_requests.consolidations, process_consolidation_request)
-for_ops(body.execution_requests.preregistrations, process_preregistration_request)  # [New]
-```
+Preregistration requests are applied from `parent_execution_requests` after deposit requests — under [EIP-7732](./eip-7732.md), a payload's execution requests are carried in the next block and applied while processing it. The number of preregistration requests in a payload MUST NOT exceed `MAX_PREREGISTRATION_REQUESTS_PER_PAYLOAD`.
 
 `BeaconState` is extended with a new field:
 
 ```python
-class BeaconState(Container):
-    # ... existing fields ...
-    validator_preregistrations: List[StoredPreregistration, VALIDATOR_PREREGISTRATIONS_LIMIT]  # [New]
+validator_preregistrations: ValidatorPreregistrations  # [New]
 ```
 
 #### Helper functions
 
 ```python
-def get_stored_preregistration(state: BeaconState, pubkey: BLSPubkey) -> Optional[StoredPreregistration]:
-    for pre_reg in state.validator_preregistrations:
+def get_stored_preregistration_index(state: BeaconState, pubkey: BLSPubkey) -> Optional[Uint64]:
+    for index, pre_reg in enumerate(state.validator_preregistrations):
         if pre_reg.pubkey == pubkey:
-            return pre_reg
+            return Uint64(index)
     return None
 
+def is_active_preregistration(state: BeaconState, pre_reg: StoredPreregistration) -> bool:
+    # Activity is evaluated against the outstanding parent payload, whose
+    # execution requests are the ones being applied during block processing
+    parent_slot = state.latest_execution_payload_bid.slot
+    return parent_slot < pre_reg.expiry_slot
+
 def remove_stored_preregistration(state: BeaconState, pubkey: BLSPubkey) -> None:
-    state.validator_preregistrations = [
+    state.validator_preregistrations = ValidatorPreregistrations([
         pre_reg for pre_reg in state.validator_preregistrations
         if pre_reg.pubkey != pubkey
-    ]
+    ])
+
+def is_pending_validator(pending_deposits: Sequence[PendingDeposit], pubkey: BLSPubkey) -> bool:
+    for pending_deposit in pending_deposits:
+        if pending_deposit.pubkey != pubkey:
+            continue
+        if is_valid_deposit_signature(
+            pending_deposit.pubkey,
+            pending_deposit.withdrawal_credentials,
+            pending_deposit.amount,
+            pending_deposit.signature,
+        ):
+            return True
+    return False
 ```
 
 _Note_: Clients SHOULD maintain a secondary index by pubkey for efficient lookup rather than performing a linear scan.
@@ -345,9 +362,10 @@ def process_preregistration_request(
     pubkey = preregistration_request.pubkey
     withdrawal_credentials = preregistration_request.withdrawal_credentials
     signature = preregistration_request.signature
+    index = get_stored_preregistration_index(state, pubkey)
 
-    # Reject if a preregistration already exists for this pubkey
-    if get_stored_preregistration(state, pubkey) is not None:
+    # Reject if an active preregistration already exists for this pubkey
+    if index is not None and is_active_preregistration(state, state.validator_preregistrations[index]):
         return
 
     # Reject if a validator with this pubkey already exists
@@ -355,11 +373,18 @@ def process_preregistration_request(
         return
 
     # Reject if this pubkey already has a valid pending deposit
-    if is_pending_validator(state, pubkey):
+    if is_pending_validator(state.pending_deposits, pubkey):
         return
 
-    # Reject if state list is at capacity
-    if len(state.validator_preregistrations) >= VALIDATOR_PREREGISTRATIONS_LIMIT:
+    # Reject if active records are at capacity. Only active records count, so
+    # the timing of the garbage-collection sweep does not affect admission.
+    # The check applies to appends and to replacements alike, since both
+    # create an active binding
+    active_count = len([
+        pre_reg for pre_reg in state.validator_preregistrations
+        if is_active_preregistration(state, pre_reg)
+    ])
+    if active_count >= PREREGISTRATIONS_LIMIT:
         return
 
     # Verify BLS signature: proof of key ownership.
@@ -369,32 +394,38 @@ def process_preregistration_request(
         withdrawal_credentials=withdrawal_credentials,
     )
     domain = compute_domain(
-        DOMAIN_VALIDATOR_PREREGISTRATION,
+        DOMAIN_PREREGISTRATION,
         genesis_validators_root=state.genesis_validators_root,
     )
     signing_root = compute_signing_root(preregistration, domain)
     if not bls.Verify(pubkey, signing_root, signature):
         return
 
-    state.validator_preregistrations.append(StoredPreregistration(
+    stored = StoredPreregistration(
         pubkey=pubkey,
         withdrawal_credentials=withdrawal_credentials,
-        inclusion_slot=state.slot,
-    ))
+        expiry_slot=Slot(state.slot + PREREGISTRATION_EXPIRY_SLOTS),
+    )
+    if index is not None:
+        # Replace the expired record in place
+        state.validator_preregistrations[index] = stored
+    else:
+        state.validator_preregistrations.append(stored)
 ```
 
 #### Modified deposit request ingestion
 
-`process_deposit_request` is modified to enforce preregistration constraints. The preregistration check MUST precede any builder routing logic (e.g. [EIP-7732](./eip-7732.md)) to prevent bypass via builder withdrawal credentials. When a preregistration exists, the deposit is accepted only if both the withdrawal credentials match and the deposit BLS signature is valid. This early BLS check prevents an attacker from consuming a preregistration with an invalid-signature deposit (see Security Considerations).
+`process_deposit_request` ([EIP-6110](./eip-6110.md)) is modified to enforce preregistration constraints for validator deposits. Builder deposits use a separate request type and `process_builder_deposit_request`. When an active preregistration exists, the validator deposit is accepted only if both the withdrawal credentials match and the deposit BLS signature is valid. This early BLS check prevents an attacker from consuming a preregistration with an invalid-signature deposit (see Security Considerations).
 
 ```python
 def process_deposit_request(
     state: BeaconState,
     deposit_request: DepositRequest,
 ) -> None:
-    # Preregistration check — MUST precede builder routing.
-    pre_reg = get_stored_preregistration(state, deposit_request.pubkey)
-    if pre_reg is not None:
+    # Only an active binding is enforced; an expired record is ignored
+    index = get_stored_preregistration_index(state, deposit_request.pubkey)
+    if index is not None and is_active_preregistration(state, state.validator_preregistrations[index]):
+        pre_reg = state.validator_preregistrations[index]
         if deposit_request.withdrawal_credentials != pre_reg.withdrawal_credentials:
             return  # Withdrawal credentials mismatch: reject
         if not is_valid_deposit_signature(
@@ -406,8 +437,6 @@ def process_deposit_request(
             return  # Invalid BLS sig: reject, preserve preregistration
         remove_stored_preregistration(state, deposit_request.pubkey)
 
-    # ... [Gloas builder routing logic, if applicable] ...
-
     state.pending_deposits.append(PendingDeposit(
         pubkey=deposit_request.pubkey,
         withdrawal_credentials=deposit_request.withdrawal_credentials,
@@ -417,74 +446,61 @@ def process_deposit_request(
     ))
 ```
 
-The key invariant: **deposits in `pending_deposits` cannot have an active preregistration.** Either the preregistration was consumed or the deposit was rejected. This means `apply_pending_deposit` requires no modifications — it operates on deposits that have already passed the preregistration check.
+The key invariant: **a valid pending new-validator deposit cannot coexist with an active preregistration for the same pubkey.** An invalid-signature `PendingDeposit` may coexist when it was queued before the preregistration and is ignored by normal pending-deposit processing. `apply_pending_deposit` requires no modifications.
 
-#### Preregistration expiry (epoch processing)
+#### Preregistration expiry
 
 ```python
-def process_validator_preregistration_expiry(state: BeaconState) -> None:
-    finalized_slot = compute_start_slot_at_epoch(state.finalized_checkpoint.epoch)
-    state.validator_preregistrations = [
+def process_preregistration_expiry(state: BeaconState) -> None:
+    state.validator_preregistrations = ValidatorPreregistrations([
         pre_reg for pre_reg in state.validator_preregistrations
-        if finalized_slot < Slot(pre_reg.inclusion_slot + VALIDATOR_PREREGISTRATION_EXPIRY_SLOTS)
-    ]
+        if is_active_preregistration(state, pre_reg)
+    ])
 ```
 
-Called once per epoch during `process_epoch`.
+The sweep runs during epoch processing (`process_epoch`) and is garbage collection only: once stored, a binding remains active for subsequently processed payloads whose slots are below its stored `expiry_slot`, even if the expired record remains stored until the next sweep (see Rationale).
 
 ## Rationale
 
 ### Enforcement at deposit ingestion
 
-Invalid deposits are already silently ignored by the consensus layer if the signature is invalid. This EIP adds one optional validation condition: if a preregistration exists for a pubkey, only deposits with matching withdrawal credentials and a valid BLS signature are accepted. Deposits with mismatched credentials or invalid signatures are treated as invalid and ignored. The check only applies to pubkeys that have been preregistered — all other deposits are processed as before.
-
-### Deposit BLS verification at ingestion
-
-Without early BLS verification, an attacker could consume a preregistration by depositing with matching withdrawal credentials but an invalid signature, stripping protection from the pubkey. This is not a new pattern — [EIP-7732](./eip-7732.md) already verifies deposit BLS signatures at block time for builder routing. Preregistration applies the same approach to the narrow subset of deposits targeting preregistered pubkeys.
+Invalid deposits are already silently ignored by the consensus layer if the signature is invalid. This EIP adds one optional validation condition: if an active preregistration exists for a pubkey, only deposits with matching withdrawal credentials and a valid BLS signature are accepted. Deposits with mismatched credentials or invalid signatures are treated as invalid and ignored. The check only applies to pubkeys with an active preregistration — all other deposits are processed as before.
 
 ### Permanent rejection of mismatched deposits
 
-When a deposit's withdrawal credentials do not match a preregistration, the deposit is silently rejected — the ETH remains in the Deposit Contract, which has no withdrawal function. This is a deliberate design choice: returning mismatched deposits would allow an attacker to front-run at no cost (deposit, get rejected, recover funds, repeat). Permanent loss makes front-running economically self-defeating.
+When a deposit's withdrawal credentials do not match an active preregistration, the deposit is silently rejected — the ETH remains in the Deposit Contract, which has no withdrawal function. This is a deliberate design choice: returning mismatched deposits would allow an attacker to front-run at no cost (deposit, get rejected, recover funds, repeat). Permanent loss makes front-running economically self-defeating.
 
-The risk of accidental mismatch is low in practice. Preregistration requires a dedicated BLS signing step separate from deposit data. Staking protocols verify the preregistration on-chain via [EIP-4788](./eip-4788.md) before submitting deposits. Preregistrations expire automatically after ~36 days if unused, freeing beacon state. However, because the signed message is publicly visible on-chain, anyone can replay it to re-establish the same binding after expiry. Operators should treat preregistration signing as a permanent, irrevocable decision for that key.
+The risk of accidental mismatch is low in practice. Preregistration requires a dedicated BLS signing step separate from deposit data. Staking protocols verify the preregistration on-chain via [EIP-4788](./eip-4788.md) before submitting deposits. At the current 12-second slot duration, preregistrations expire automatically after ~36 days if unused, freeing beacon state.
 
 ### System contract vs CL gossip
 
-CL gossip has no economic cost — generating BLS keypairs is cheap (~2ms), and verification cost (~1.5ms per message) falls on every node, creating an asymmetry favoring an attacker. The EL system contract solves this with an [EIP-1559](./eip-1559.md)-style fee that starts at 1 wei but increases exponentially with demand, making sustained spam prohibitively expensive. Staking protocols can call the system contract directly from their own contracts.
+CL gossip has no economic cost — generating BLS keypairs is cheap (~2ms), and verification cost (~1.5ms per message) falls on every node, creating an asymmetry favoring an attacker. The EL system contract adds an [EIP-1559](./eip-1559.md)-style fee that starts at 1 wei and increases exponentially in response to sustained demand above the target rate. The fee update takes effect in the following block. Staking protocols can call the system contract directly from their own contracts.
 
-### Expiry measured against finalized slot
+### Expiry keyed to the outstanding payload slot
 
-Preregistration expiry is computed against `finalized_slot` rather than the current slot to prevent a race condition during extended non-finality (inactivity leak). During such periods, [EIP-6110](./eip-6110.md) freezes pending deposits. If preregistration expiry used the current slot, a preregistration could expire while the staking protocol's deposit transaction has not yet been included — silently removing the withdrawal credentials protection without any action by either party. Using `finalized_slot` keeps preregistrations and deposits in lockstep: neither advances while finality is stalled.
+Expiry is enforced logically through `is_active_preregistration`, which compares the outstanding parent bid's slot against the stored `expiry_slot`, not against the slot in which the requests are applied. Under [EIP-7732](./eip-7732.md) a payload's requests are applied one block later, so this guarantees that a deposit is checked against the bindings that were active for the slot in which its payload was created. The comparison is strict: a payload at `expiry_slot` is no longer protected. The epoch-processing sweep is pure garbage collection: its timing does not affect whether a binding is enforced or a request is admitted. Consequently, an expired record may remain physically present until the next sweep and can be replaced by a new preregistration in place, subject to the active-capacity check.
+
+The absolute deadline is computed once, when the preregistration is stored. This prevents a future change to `PREREGISTRATION_EXPIRY_SLOTS` from retroactively changing existing deadlines and makes the same window exactly verifiable on the execution layer without knowing the lifetime parameter, slot duration, or `SLOTS_PER_EPOCH`: a verification contract proves `expiry_slot` through [EIP-4788](./eip-4788.md) and requires the current [EIP-7843](./eip-7843.md) `SLOTNUM` to be below it, making the deposit atomically either protected or reverted. Expiry does not depend on finality and therefore continues while finality stalls. A binding that expires unused can be re-established by replaying the same signed message.
 
 ### Domain choice
 
-`DOMAIN_VALIDATOR_PREREGISTRATION` uses `GENESIS_FORK_VERSION` (the default when no `fork_version` is passed to `compute_domain`), so a preregistration signed once is valid across all past and future forks. This allows signing on air-gapped hardware without knowledge of the current fork version. Chain separation is achieved via `genesis_validators_root`, which is an immutable per-chain constant.
+`DOMAIN_PREREGISTRATION` uses `GENESIS_FORK_VERSION` (the default when no `fork_version` is passed to `compute_domain`), so a preregistration signed once is valid across all past and future forks. This allows signing on air-gapped hardware without knowledge of the current fork version. Chain separation is achieved via `genesis_validators_root`, which is an immutable per-chain constant.
 
 A dedicated domain is used rather than reusing `DOMAIN_DEPOSIT` because `DOMAIN_DEPOSIT` does not include `genesis_validators_root`, meaning deposit-domain signatures can be replayed across chains.
 
-### `source_address` field
-
-`source_address` is included for [EIP-7685](./eip-7685.md) framework consistency. It is not used in CL validation — the BLS signature is the sole authorization mechanism. Any address may submit a preregistration on behalf of a key holder.
-
 ### BLS verification on CL only
 
-BLS verification happens on the CL, not in the EL system contract. The system contract acts as a rate-limited queue; the CL performs semantic validation. EL verification would require [EIP-2537](./eip-2537.md) BLS precompiles and cost upwards of 150,000 gas per preregistration (hash-to-curve + pairing check), unnecessarily increasing cost. Invalid signatures are silently discarded by the CL, costing only the system contract fee.
+BLS verification happens on the CL, not in the EL system contract. The signing domain includes `genesis_validators_root`, and the CL must perform semantic validation before storing the preregistration. Repeating the verification on the EL would duplicate that work, so the system contract acts only as a rate-limited queue. Submission is permissionless, and the BLS signature is the sole authorization mechanism. Invalid signatures are silently discarded by the CL, costing only the system contract fee.
 
 ### Parameter choices
 
-`TARGET_VALIDATOR_PREREGISTRATION_REQUESTS_PER_BLOCK = 1` keeps the baseline fee minimal for an infrequent operation, with burst capacity up to 4 per block.
+`TARGET_PREREGISTRATION_REQUESTS_PER_BLOCK = 1` keeps the baseline fee minimal for an infrequent operation. `MAX_PREREGISTRATION_REQUESTS_PER_BLOCK = 4` allows up to four queued requests to be dequeued into each block; it does not cap the number of submissions accepted by the contract within a block.
 
-`VALIDATOR_PREREGISTRATIONS_LIMIT = 524,288` (2^19) is chosen so that the list cannot saturate at the target rate. At 1 preregistration per block, filling 2^19 entries takes ~72.8 days — well beyond the 2^18-slot (~36-day) expiry window. In steady state at target rate, the list stabilizes around 2^18 entries (~50% capacity) as new arrivals are balanced by expiring entries. Sustained saturation requires an average rate above target, which causes `excess` to accumulate and the fee to grow exponentially — making prolonged spam economically prohibitive.
-
-During extended non-finality the finalized checkpoint stalls and expiry pauses, so the list may eventually fill; this is an acceptable liveness degradation for the optional preregistration path, not a safety issue, and the backlog clears once finality resumes. Worst-case state size is ~46 MB (88 bytes × 524,288 entries).
-
-### Complementarity with EIP-7684
-
-This EIP protects new validator creation; [EIP-7684](./eip-7684.md) protects top-ups to existing validators by returning mismatched deposits minus a penalty. Without preregistration, EIP-7684 alone turns theft into griefing (the rogue validator still exists). Without EIP-7684, preregistration does not cover mismatched top-ups. The two are orthogonal and could ship in the same fork.
+`PREREGISTRATIONS_LIMIT = 524,288` (2^19) is chosen so that active capacity cannot be exhausted at the target rate. At 1 preregistration per block, accumulating 2^19 active entries takes ~72.8 days at 12 seconds per slot — well beyond the 2^18-slot expiry window (~36 days at 12 seconds per slot). In steady state at target rate, the active count stabilizes around 2^18 entries (~50% of the limit) as new arrivals are balanced by expiring entries. Sustained saturation requires an average rate above target, which causes `excess` to accumulate and the fee to grow exponentially — making prolonged spam economically prohibitive. Worst-case state size is ~46 MB of active records (88 bytes × 524,288 entries), plus bounded headroom for expired records awaiting the next epoch's sweep — at most `MAX_PREREGISTRATION_REQUESTS_PER_PAYLOAD × (SLOTS_PER_EPOCH − 1)` = 124 additional records.
 
 ### Deposit process for staking protocols
 
-Preregistration is fully optional. Protocols that already have their own defenses can adopt it at their own pace, or not at all. For protocols that do adopt it, the intended flow is: the operator signs a preregistration, the protocol submits it to the system contract, waits for finalization (~12.8 minutes), verifies it on-chain via [EIP-4788](./eip-4788.md) Merkle proof, and submits the deposit. The verification and deposit steps can be combined into a single transaction using a shared verification contract — not part of this specification, but a reference implementation will be provided separately.
+Protocols that already have their own defenses can adopt preregistration at their own pace, or not at all. For protocols that do adopt it, the intended flow is: the operator signs a preregistration, the protocol submits it to the system contract, verifies its presence in beacon state on-chain via an [EIP-4788](./eip-4788.md) Merkle proof, and submits the deposit. When the verification and the deposit are combined into a single transaction — using a shared verification contract, not part of this specification but provided separately as a reference implementation — no finality wait is needed: on any fork branch that lacks the preregistration, the proof fails and the transaction reverts. When verification is a separate transaction, the protocol MUST wait until a beacon state containing the preregistration is finalized before depositing. In both flows, the deposit transaction MUST revert unless the current [EIP-7843](./eip-7843.md) `SLOTNUM` is below the proven `expiry_slot`: an expired record may remain provable in beacon state until it is garbage-collected, while the consensus layer no longer enforces it.
 
 ## Backwards Compatibility
 
@@ -516,29 +532,31 @@ Preregistration is fully optional. Without a preregistration for a given pubkey,
 
 ### Preregistration signature is permanent
 
-The preregistration signature is fork-agnostic and does not expire cryptographically — only the on-chain record has a validity window (~36 days). Anyone who obtains a signed preregistration message can resubmit it at any time to re-establish the on-chain record after expiry. Once an operator signs a preregistration binding a pubkey to specific withdrawal credentials, that commitment is effectively permanent: the signed message can always be replayed. Operators must treat preregistration signing as an irrevocable decision for that key.
+The preregistration signature is fork-agnostic and does not expire cryptographically — only the on-chain record has a 262,144-slot validity window (~36 days at the current 12-second slot duration). Anyone who obtains a signed preregistration message can resubmit it at any time to re-establish the on-chain record after expiry. Once an operator signs a preregistration binding a pubkey to specific withdrawal credentials, that commitment is effectively permanent. The protocol does not restrict credential prefixes beyond the existing validator deposit rules, so operators must ensure that the selected credentials are supported by their intended withdrawal flow.
+
+### Builder deposits
+
+Preregistration applies only to validator deposits. Builder deposits ([EIP-8282](./eip-8282.md)) use an independent request type and registry: a preregistration may coexist with a builder for the same pubkey and is neither checked nor consumed by builder deposits. It MUST NOT be treated as authorization of a builder's execution address. In particular, preregistering `0xB0` withdrawal credentials does not register or protect a builder; submitted through the validator deposit path, matching `0xB0` credentials create a validator that cannot currently withdraw.
 
 ### Race between preregistration and deposit
 
-If an attacker deposits for a pubkey before the preregistration is processed, the deposit creates a validator under `first-deposit-wins` and the preregistration is rejected. If both arrive in the same block, deposits are processed before preregistrations (see processing order in `process_operations`), so the same outcome applies. Staking protocols detect this via [EIP-4788](./eip-4788.md): they MUST verify the preregistration is finalized and present in beacon state before depositing.
+If an attacker deposits for a pubkey before the preregistration is processed, the deposit creates a validator under `first-deposit-wins` and the preregistration is rejected. If both arrive in the same execution payload, deposits are processed before preregistrations, so the same outcome applies. Staking protocols detect this via [EIP-4788](./eip-4788.md): they MUST verify an active preregistration — both its presence in beacon state and its expiry deadline — atomically with the deposit. When verifying in a separate transaction instead, they MUST wait until its inclusion is finalized and enforce the deadline in the deposit transaction.
 
 ### Invalid-signature deposit attack
 
 An adversary could attempt to strip preregistration protection by depositing with matching withdrawal credentials but an invalid BLS signature. This EIP prevents this attack by verifying the deposit's BLS signature in `process_deposit_request` before consuming the preregistration. Only deposits with both matching withdrawal credentials and a valid BLS signature can consume a preregistration. Invalid-signature deposits are silently rejected without affecting the preregistration.
 
-### Builder routing interaction (EIP-7732)
-
-When [EIP-7732](./eip-7732.md) (ePBS) builder routing is active, deposits with `0x03` (builder) withdrawal credentials are routed directly to the builder registry, bypassing the standard pending deposit flow. The preregistration withdrawal credentials check must precede builder routing in `process_deposit_request` to prevent bypass.
-
 ### DoS and state growth
 
-The [EIP-1559](./eip-1559.md)-style fee mechanism is the primary spam defense. Every submission in a block increments `count`, and at block end `excess` updates as `excess += count − target` (floored at zero). The fee grows as `e^(excess/17)` wei, so a high-volume block raises the fee immediately for all subsequent requests. For example, at a sustained rate of `n` submissions per block, excess grows by `n − 1` per block and the fee exceeds 1 ETH after roughly `17 × ln(10^18) / (n − 1)` blocks.
+The [EIP-1559](./eip-1559.md)-style fee mechanism is the primary defense against sustained above-target spam. Every accepted submission in block `N` increments `count`, while all submissions in that block face the same required minimum fee computed from the `excess` stored before transaction processing. At the end of block `N`, the system call updates `excess` to `max(0, previous_excess + count − TARGET_PREREGISTRATION_REQUESTS_PER_BLOCK)`; the resulting fee, which approximates `e**(excess / 17)` wei, applies in block `N + 1`. Thus, a high-volume block does not increase the fee for later submissions in the same block, but it does increase the fee for requests in subsequent blocks. At a sustained rate of `n` accepted submissions per block where `n > 1`, `excess` grows by `n − 1` per block and the fee exceeds 1 ETH after roughly `17 × ln(10^18) / (n − 1)` blocks.
 
-Under normal operation, the state list stays near zero (preregistrations consumed within hours). The 524,288 entry limit (~46 MB) is sized so that saturation requires a sustained rate above target — and therefore an exponentially growing fee. During extended non-finality, the list may fill as expiry pauses; this degrades liveness for the optional preregistration path but is not a safety issue.
+Under normal operation, the state list stays near zero (preregistrations consumed within hours). However, starting from zero `excess`, one accepted request per block keeps the fee at its minimum and can maintain approximately 2^18 active entries — about 23 MB of serialized records plus client overhead. The 524,288 active-entry limit is sized so that saturation requires a sustained rate above target — and therefore an exponentially growing fee.
+
+At exactly the target rate, `excess` and the current fee do not decay. Maintaining an elevated `excess` still requires paying the elevated fee on every request; once demand falls below target, `excess` decays. The fee is a rate limiter, not a guarantee of low-cost availability.
 
 ### Censorship resistance
 
-The 262,144-slot validity window (~36 days) gives ample time for inclusion.
+The 262,144-slot validity window (~36 days at 12 seconds per slot) is deliberately generous because the workflow spans preregistration, operational coordination, proof availability, and a deposit transaction. The lifetime is intentionally defined in slots, so a future slot-duration change changes its wall-clock duration without changing its consensus or contract interpretation. A much shorter window would make completion more sensitive to temporary censorship, congestion, or high fees; replaying the signature restarts that flow rather than eliminating it.
 
 ### Fee overpayment
 
@@ -550,7 +568,7 @@ If the system call to the preregistration contract fails for any reason, the blo
 
 ### Empty code failure
 
-If there is no code at `VALIDATOR_PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS`, the block MUST be deemed invalid. This is the same consideration as in [EIP-7002](./eip-7002.md).
+If there is no code at `PREREGISTRATION_REQUEST_PREDEPLOY_ADDRESS`, the block MUST be deemed invalid. This is the same consideration as in [EIP-7002](./eip-7002.md).
 
 ## Copyright
 


### PR DESCRIPTION
Updates the draft to match the current Gloas specs and simplifies the request format.

- **EIP-7732 alignment**: preregistration requests are applied from `parent_execution_requests`
  after deposits; the payload list and the state list use `ProgressiveList`.
- **Drop `source_address`** from the request — the BLS signature is the only authorization.
  The record is now 176 bytes / 6 storage slots, and an accepted request is emitted as an
  anonymous log instead.
- **Expiry rework**: the stored record now holds an absolute `expiry_slot` instead of
  `inclusion_slot`, so an EL contract can prove that a preregistration is still valid without
  extra proofs or protocol constants.
- **Naming**: drop the `VALIDATOR_` prefix from all constants and helpers; set
  `DOMAIN_PREREGISTRATION` to `0x11000000`.
- **Builder deposits**: EIP-8282 uses its own request type and registry, so the builder-routing
  section is replaced by an explicit statement that preregistration covers validator deposits only.

The protection itself is unchanged: a matching deposit consumes the preregistration, a
mismatched one is silently rejected, and pubkeys without a preregistration behave exactly as today.
