### PR TITLE
Update EIP-8025: Refresh execution layer section

### DIFF
--- a/EIPS/eip-8025.md
+++ b/EIPS/eip-8025.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2025-09-17
-requires: 4844, 6110, 7002, 7251, 7732, 7892, 7928
+requires: 4844, 6110, 7002, 7251, 7688, 7732, 7928, 8282
 ---
 
 ## Abstract
@@ -467,31 +467,30 @@ in-block proof commitments.
 
 ### Execution Layer
 
-This EIP introduces a stateless execution guest and prover side logic to construct the input used by
-that guest. The prover runs the guest over private `StatelessInput` bytes. The
-proof exposes `StatelessValidationResult` as public output, allowing a verifier
-to bind the proof to the payload request being checked.
+This EIP introduces a stateless execution guest and prover-side logic that
+constructs the guest input. The prover runs the guest over private
+`StatelessInput` bytes. The proof exposes `StatelessValidationResult` as public
+output. This output binds the proof to the payload request and execution schema.
 
 A proof-verifying node accepts the execution-layer result only if:
 
-- the proof verifies for the expected guest program;
-- `successful_validation` is `true`;
+- the proof verifies for the expected guest program.
+- `successful_validation` is `true`.
 - `new_payload_request_root` equals the SSZ `hash_tree_root` of the
-  `NewPayloadRequest` associated with the payload being validated; and
-- `chain_config` matches the chain ID and fork configuration expected by the
-  verifier.
+  `NewPayloadRequest` associated with the payload being validated.
+- `chain_id` and `schema_id` match the values expected by the verifier.
 
 At a high level, proof generation follows this flow:
 
 1. A host, usually a stateful execution-layer client, executes or constructs
    the block while recording the account, storage, code, and ancestor-header
    data used during execution.
-2. The host builds an `ExecutionWitness`, wraps it with the Engine API
-   `NewPayloadRequest`, chain configuration, and transaction public keys into a
-   `StatelessInput`, and serialises that input as schema-prefixed SSZ bytes.
-3. A prover runs the guest program on the serialised `StatelessInput`. The
-   guest validates the chain configuration and witness scaffolding, executes the
-   payload against witness-backed state, and returns `StatelessValidationResult`.
+2. The host builds an `ExecutionWitness` and combines it with the Engine API
+   request, chain ID, and transaction public keys.
+3. The host serializes this `StatelessInput` as schema-prefixed SSZ bytes.
+4. A prover runs the guest program on the serialized `StatelessInput`.
+5. The guest validates the witness and executes the payload against
+   witness-backed state. It then returns `StatelessValidationResult`.
 
 #### Stateless input and output
 
@@ -501,7 +500,7 @@ The top-level guest input is private prover input:
 class StatelessInput:
     new_payload_request: NewPayloadRequest
     witness: ExecutionWitness
-    chain_config: ChainConfig
+    chain_id: U64
     public_keys: Tuple[Bytes, ...]
 ```
 
@@ -511,11 +510,9 @@ The guest output is public:
 class StatelessValidationResult:
     new_payload_request_root: Hash32
     successful_validation: bool
-    chain_config: ChainConfig
+    chain_id: U64
+    schema_id: U16
 ```
-
-Note this struct is the EL-counterpart of `PublicInput` described in the _Proof types and containers_
-section.
 
 At this level:
 
@@ -523,12 +520,18 @@ At this level:
   consensus layer.
 - `witness` is the account, storage, code, and ancestor-header data needed to
   execute the payload without local EL state.
-- `chain_config` tells the guest which chain ID and fork configuration to
-  validate against.
+- `chain_id` identifies the chain used during payload validation and execution.
 - `public_keys` contains one 65-byte uncompressed secp256k1 public key for
-  each transaction signer, in the same order as the transactions in the payload.
-  Optimised guests can use these keys to avoid public-key recovery, but
+  each transaction signer. The keys use the transaction order from the payload.
+  Optimized guests can use these keys to avoid public-key recovery, but
   transaction signatures and supplied public keys MUST still be verified.
+- `schema_id` identifies the exact input schema and fork rules that the guest
+  executed.
+
+If the guest cannot decode the input, it returns a failed result with sentinel
+values. The request root, chain ID, and schema ID are all zero in this result.
+If validation fails after decoding, the result retains the decoded request root,
+chain ID, and schema ID.
 
 The `NewPayloadRequest` commits to the payload, blob versioned hashes,
 `parent_beacon_block_root`, and typed execution requests.
@@ -536,6 +539,8 @@ The `versioned_hashes` field carries the versioned hashes introduced by
 [EIP-4844](./eip-4844.md). The typed deposit, withdrawal, and consolidation
 requests are specified by [EIP-6110](./eip-6110.md),
 [EIP-7002](./eip-7002.md), and [EIP-7251](./eip-7251.md), respectively.
+Builder deposit and exit requests are specified by
+[EIP-8282](./eip-8282.md).
 The `block_access_list` field in `ExecutionPayload` is the block-level access
 list defined by [EIP-7928](./eip-7928.md).
 
@@ -566,6 +571,7 @@ class ExecutionPayload:
     blob_gas_used: U64
     excess_blob_gas: U64
     block_access_list: Bytes
+    slot_number: U64
 ```
 
 The execution requests are represented as typed containers, matching the
@@ -592,47 +598,33 @@ class ConsolidationRequest:
     target_pubkey: Bytes48
 
 
+class BuilderDepositRequest:
+    pubkey: Bytes48
+    withdrawal_credentials: Bytes32
+    amount: U64
+    signature: Bytes96
+
+
+class BuilderExitRequest:
+    source_address: Address
+    pubkey: Bytes48
+
+
 class ExecutionRequests:
     deposits: Tuple[DepositRequest, ...]
     withdrawals: Tuple[WithdrawalRequest, ...]
     consolidations: Tuple[ConsolidationRequest, ...]
+    builder_deposits: Tuple[BuilderDepositRequest, ...]
+    builder_exits: Tuple[BuilderExitRequest, ...]
 ```
 
-The remaining top-level fields define the witness and chain context consumed by
-the guest:
+The remaining top-level field defines the witness consumed by the guest:
 
 ```python
 class ExecutionWitness:
     state: Tuple[Bytes, ...]
     codes: Tuple[Bytes, ...]
     headers: Tuple[Bytes, ...]
-
-
-class ChainConfig:
-    chain_id: U64
-    active_fork: ForkConfig
-
-
-class ForkConfig:
-    fork: ProtocolFork
-    activation: ForkActivation
-    blob_schedule: BlobSchedule | None
-
-
-class ForkActivation:
-    block_number: U64 | None
-    timestamp: U64 | None
-
-
-class BlobSchedule:
-    target: U64
-    max: U64
-    base_fee_update_fraction: U64
-
-
-class ProtocolFork(StrEnum):
-    ...
-    Amsterdam = "Amsterdam"
 ```
 
 The `ExecutionWitness` fields have the following roles:
@@ -649,20 +641,36 @@ The `ExecutionWitness` fields have the following roles:
 
 #### Guest validation
 
-The guest entry point decodes schema-prefixed SSZ input, runs stateless payload
-validation, and serialises the result.
+The guest entry point decodes schema-prefixed SSZ input and runs stateless
+payload validation. It always serializes a result, including for invalid input.
 
 ```python
+def _default_failed_stateless_output() -> StatelessValidationResult:
+    return StatelessValidationResult(
+        new_payload_request_root=Hash32(b"\0" * 32),
+        successful_validation=False,
+        chain_id=U64(0),
+        schema_id=U16(0),
+    )
+
+
 def run_stateless_guest(input_bytes: Bytes) -> Bytes:
-    stateless_input = deserialize_stateless_input(input_bytes)
-    stateless_output = verify_stateless_new_payload(stateless_input)
+    try:
+        stateless_input = deserialize_stateless_input(input_bytes)
+    except Exception:
+        stateless_output = _default_failed_stateless_output()
+    else:
+        stateless_output = verify_stateless_new_payload(stateless_input)
     return serialize_stateless_output(stateless_output)
 ```
 
 The main validation path first computes the public payload-request commitment.
-It then validates fork configuration, checks the header witness, creates a
-`WitnessState`, and delegates payload execution to the same `new_payload` path
-used by the execution engine:
+It then validates the header witness and creates a `WitnessState`. Finally, it
+uses the same `new_payload` path as the execution engine.
+
+The reference implementation has one implementation for each fork. Thus, its
+Amsterdam guest does not compare the payload timestamp with fork activation
+data. Production implementations MUST perform this comparison.
 
 ```python
 def compute_new_payload_request_root(
@@ -670,23 +678,6 @@ def compute_new_payload_request_root(
 ) -> Hash32:
     ssz_npr = _new_payload_request_to_ssz(stateless_input.new_payload_request)
     return Hash32(ssz_npr.hash_tree_root())
-
-
-def validate_chain_config(
-    chain_config: ChainConfig,
-    new_payload_request: NewPayloadRequest,
-) -> ForkConfig:
-    active_fork = chain_config.active_fork
-    execution_payload = new_payload_request.execution_payload
-
-    if not _is_activation_active(active_fork.activation, execution_payload):
-        raise InactiveForkConfigError(...)
-    if active_fork.fork not in guest_supported_forks():
-        raise UnsupportedForkConfigError(...)
-    if active_fork.blob_schedule != _expected_amsterdam_blob_schedule():
-        raise UnsupportedForkConfigError(...)
-
-    return active_fork
 
 
 def validate_headers(
@@ -710,16 +701,11 @@ def verify_stateless_new_payload(
     witness = stateless_input.witness
 
     try:
-        validate_chain_config(
-            stateless_input.chain_config,
-            stateless_input.new_payload_request,
-        )
-
         decoded_headers, block_hashes = validate_headers(witness.headers)
         parent_header = decoded_headers[-1]
 
         chain_context = ChainContext(
-            chain_id=stateless_input.chain_config.chain_id,
+            chain_id=stateless_input.chain_id,
             block_hashes=block_hashes,
             parent_header=parent_header,
         )
@@ -743,7 +729,8 @@ def verify_stateless_new_payload(
     return StatelessValidationResult(
         new_payload_request_root=new_payload_request_root,
         successful_validation=successful_validation,
-        chain_config=stateless_input.chain_config,
+        chain_id=stateless_input.chain_id,
+        schema_id=U16(STATELESS_INPUT_SCHEMA_ID),
     )
 ```
 
@@ -820,13 +807,13 @@ def recover_sender_from_public_key(
     return _sender_address_from_public_key(public_key)
 ```
 
-Optimised guests may avoid full public-key recovery, but they must still verify
-that the supplied key validates the transaction signature and is consistent with
-the recovery id or y-parity bit.
+Optimized guests can avoid full public-key recovery. They MUST still verify that
+the supplied key validates the transaction signature. The key MUST also match
+the recovery ID or y-parity bit.
 
 #### Host-side input construction
 
-On the host side, `build_stateless_input` receives the artefacts gathered during
+On the host side, `build_stateless_input` receives the data gathered during
 block execution or construction and packages them for the guest:
 
 ```python
@@ -840,6 +827,12 @@ def build_stateless_input(
 ) -> StatelessInput:
     ...
 
+    payload = ExecutionPayload(
+        ...,
+        block_access_list=Bytes(rlp.encode(block_access_list)),
+        slot_number=header.slot_number,
+    )
+
     new_payload = NewPayloadRequest(
         execution_payload=payload,
         versioned_hashes=tuple(versioned_hashes),
@@ -850,48 +843,20 @@ def build_stateless_input(
     return StatelessInput(
         new_payload_request=new_payload,
         witness=execution_witness,
-        chain_config=build_chain_config(chain_id),
+        chain_id=chain_id,
         public_keys=tuple(public_keys),
     )
 ```
 
-The host also provides the fork configuration corresponding to the payload being
-validated:
-
-```python
-def build_chain_config(chain_id: U64) -> ChainConfig:
-    return ChainConfig(
-        chain_id=chain_id,
-        active_fork=ForkConfig(
-            fork=ProtocolFork.Amsterdam,
-            activation=ForkActivation(
-                block_number=None,
-                timestamp=U64(0),
-            ),
-            blob_schedule=BlobSchedule(
-                target=BLOB_SCHEDULE_TARGET,
-                max=BLOB_SCHEDULE_MAX,
-                base_fee_update_fraction=U64(BLOB_BASE_FEE_UPDATE_FRACTION),
-            ),
-        ),
-    )
-```
-
-The blob schedule fields and their `target`, `max`, and
-`base_fee_update_fraction` parameters are defined by
-[EIP-7892](./eip-7892.md); this EIP introduces no new blob-schedule
-parameters.
-
 The execution witness is built from the block-level read/write tracker and
-pre-state trie data. The read/write tracker is a component already used in ELs
-to track which data is touched during execution to assist for block access lists (BALs)
-construction. Conceptually, witness construction:
+pre-state trie data. ELs already use this tracker to construct block access
+lists (BALs). Conceptually, witness construction:
 
-1. collects the parent header and any older ancestors touched by `BLOCKHASH`;
-2. collects pre-state bytecode reads;
-3. captures account and storage trie nodes needed for all reads and writes;
-4. captures any potential sibling requires because of branch compression
-   during post-state root calculation.
+1. collects the parent header and any older ancestors touched by `BLOCKHASH`.
+2. collects pre-state bytecode reads.
+3. captures account and storage trie nodes needed for all reads and writes.
+4. captures potential sibling nodes that branch compression requires during
+   post-state root calculation.
 
 ```python
 def build_execution_witness(
@@ -944,12 +909,21 @@ def build_execution_witness(
 
 #### SSZ encoding
 
-The host serialises a `StatelessInput` by prefixing the SSZ bytes with
-`STATELESS_INPUT_SCHEMA_ID`. This lets future guest programs select the correct
-input schema as forks or encoding rules evolve.
+The host serializes a `StatelessInput` by prefixing the SSZ bytes with a
+two-byte schema ID. The high byte identifies the fork, and the low byte
+identifies the schema revision. Amsterdam revision 1 uses schema ID `0x1501`.
 
 ```python
-STATELESS_INPUT_SCHEMA_ID = 0x0001
+class ProtocolFork(IntEnum):
+    ...
+    Amsterdam = 0x15
+
+
+STATELESS_INPUT_SCHEMA_FORK_INDEX = ProtocolFork.Amsterdam
+STATELESS_INPUT_SCHEMA_REVISION = 0x01
+STATELESS_INPUT_SCHEMA_ID = (
+    STATELESS_INPUT_SCHEMA_FORK_INDEX << 8
+) | STATELESS_INPUT_SCHEMA_REVISION
 STATELESS_INPUT_SCHEMA_ID_SIZE = 2
 STATELESS_INPUT_SCHEMA_ID_BYTES = STATELESS_INPUT_SCHEMA_ID.to_bytes(
     STATELESS_INPUT_SCHEMA_ID_SIZE,
@@ -977,55 +951,41 @@ def deserialize_stateless_input(data: Bytes) -> StatelessInput:
         raise ValueError(
             f"Unsupported stateless input schema id: 0x{schema_id:04x}"
         )
-    ssz_obj = SszStatelessInput.decode_bytes(
+    ssz_obj = SSZStatelessInput.decode_bytes(
         data[STATELESS_INPUT_SCHEMA_ID_SIZE:]
     )
     return ssz_to_stateless_input(ssz_obj)
 ```
 
-Current SSZ maximum sizes are still subject to tuning. The reference
-implementation uses the following bounds:
+The guest output is an SSZ-encoded `SSZStatelessValidationResult`. Its
+`schema_id` field reports the exact input schema that the guest executed.
+
+The progressive containers and lists follow [EIP-7688](./eip-7688.md).
+Progressive lists and progressive byte lists do not use fixed capacity
+constants. The schema keeps these fixed bounds and vector sizes:
 
 | Bound | Value |
 | - | - |
-| `MAX_TRANSACTIONS_PER_PAYLOAD` | `2**20` |
-| `MAX_BYTES_PER_TRANSACTION` | `2**30` |
 | `MAX_EXTRA_DATA_BYTES` | `32` |
-| `MAX_WITHDRAWALS_PER_PAYLOAD` | `2**4` |
-| `MAX_BLOCK_ACCESS_LIST_BYTES` | `2**24` |
-| `MAX_BLOB_COMMITMENTS_PER_BLOCK` | `4096` |
-| `MAX_DEPOSIT_REQUESTS_PER_PAYLOAD` | `2**13` |
-| `MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD` | `2**4` |
-| `MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD` | `2**1` |
-| `MAX_WITNESS_NODES` | `2**20` |
-| `MAX_WITNESS_CODES` | `2**16` |
 | `MAX_WITNESS_HEADERS` | `256` |
-| `MAX_BYTES_PER_WITNESS_NODE` | `2**20` |
-| `MAX_BYTES_PER_CODE` | `2**24` |
+| `MAX_BYTES_PER_CODE` | `2**16` |
 | `MAX_BYTES_PER_HEADER` | `2**10` |
-| `MAX_OPTIONAL_FORK_ACTIVATION_VALUES` | `1` |
-| `MAX_BLOB_SCHEDULES_PER_FORK` | `1` |
-| `MAX_PUBLIC_KEYS` | `2**20` |
+| `MAX_BYTES_PER_WITNESS_NODE` | `2**10` |
 | `PUBLIC_KEY_BYTES` | `65` |
 
-The SSZ schema mirrors the dataclasses and applies these bounded-list limits to
-the wire representation:
+The SSZ schema mirrors the dataclasses:
 
 ```python
-class SszExecutionWitness(Container):
-    state: SszList[ByteList[MAX_BYTES_PER_WITNESS_NODE], MAX_WITNESS_NODES]
-    codes: SszList[ByteList[MAX_BYTES_PER_CODE], MAX_WITNESS_CODES]
-    headers: SszList[ByteList[MAX_BYTES_PER_HEADER], MAX_WITNESS_HEADERS]
-
-
-class SszWithdrawal(Container):
+class SSZWithdrawal(Container):
     index: uint64
     validator_index: uint64
     address: ByteVector[20]
     amount: uint64
 
 
-class SszExecutionPayload(Container):
+class SSZExecutionPayload(
+    ProgressiveContainer(active_fields=[1] * 19)
+):
     parent_hash: Bytes32
     fee_recipient: ByteVector[20]
     state_root: Bytes32
@@ -1039,16 +999,15 @@ class SszExecutionPayload(Container):
     extra_data: ByteList[MAX_EXTRA_DATA_BYTES]
     base_fee_per_gas: uint256
     block_hash: Bytes32
-    transactions: SszList[
-        ByteList[MAX_BYTES_PER_TRANSACTION], MAX_TRANSACTIONS_PER_PAYLOAD
-    ]
-    withdrawals: SszList[SszWithdrawal, MAX_WITHDRAWALS_PER_PAYLOAD]
+    transactions: ProgressiveList[ProgressiveByteList]
+    withdrawals: ProgressiveList[SSZWithdrawal]
     blob_gas_used: uint64
     excess_blob_gas: uint64
-    block_access_list: ByteList[MAX_BLOCK_ACCESS_LIST_BYTES]
+    block_access_list: ProgressiveByteList
+    slot_number: uint64
 
 
-class SszDepositRequest(Container):
+class SSZDepositRequest(Container):
     pubkey: ByteVector[48]
     withdrawal_credentials: Bytes32
     amount: uint64
@@ -1056,68 +1015,65 @@ class SszDepositRequest(Container):
     index: uint64
 
 
-class SszWithdrawalRequest(Container):
+class SSZWithdrawalRequest(Container):
     source_address: ByteVector[20]
     validator_pubkey: ByteVector[48]
     amount: uint64
 
 
-class SszConsolidationRequest(Container):
+class SSZConsolidationRequest(Container):
     source_address: ByteVector[20]
     source_pubkey: ByteVector[48]
     target_pubkey: ByteVector[48]
 
 
-class SszExecutionRequests(Container):
-    deposits: SszList[SszDepositRequest, MAX_DEPOSIT_REQUESTS_PER_PAYLOAD]
-    withdrawals: SszList[
-        SszWithdrawalRequest, MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD
-    ]
-    consolidations: SszList[
-        SszConsolidationRequest, MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD
-    ]
+class SSZBuilderDepositRequest(Container):
+    pubkey: ByteVector[48]
+    withdrawal_credentials: Bytes32
+    amount: uint64
+    signature: ByteVector[96]
 
 
-class SszNewPayloadRequest(Container):
-    execution_payload: SszExecutionPayload
-    versioned_hashes: SszList[Bytes32, MAX_BLOB_COMMITMENTS_PER_BLOCK]
+class SSZBuilderExitRequest(Container):
+    source_address: ByteVector[20]
+    pubkey: ByteVector[48]
+
+
+class SSZExecutionRequests(
+    ProgressiveContainer(active_fields=[1] * 5)
+):
+    deposits: ProgressiveList[SSZDepositRequest]
+    withdrawals: ProgressiveList[SSZWithdrawalRequest]
+    consolidations: ProgressiveList[SSZConsolidationRequest]
+    builder_deposits: ProgressiveList[SSZBuilderDepositRequest]
+    builder_exits: ProgressiveList[SSZBuilderExitRequest]
+
+
+class SSZNewPayloadRequest(Container):
+    execution_payload: SSZExecutionPayload
+    versioned_hashes: ProgressiveList[Bytes32]
     parent_beacon_block_root: Bytes32
-    execution_requests: SszExecutionRequests
+    execution_requests: SSZExecutionRequests
 
 
-class SszForkActivation(Container):
-    block_number: SszList[uint64, MAX_OPTIONAL_FORK_ACTIVATION_VALUES]
-    timestamp: SszList[uint64, MAX_OPTIONAL_FORK_ACTIVATION_VALUES]
+class SSZExecutionWitness(Container):
+    state: ProgressiveList[ByteList[MAX_BYTES_PER_WITNESS_NODE]]
+    codes: ProgressiveList[ByteList[MAX_BYTES_PER_CODE]]
+    headers: SSZList[ByteList[MAX_BYTES_PER_HEADER], MAX_WITNESS_HEADERS]
 
 
-class SszBlobSchedule(Container):
-    target: uint64
-    max: uint64
-    base_fee_update_fraction: uint64
-
-
-class SszForkConfig(Container):
-    fork: uint64
-    activation: SszForkActivation
-    blob_schedule: SszList[SszBlobSchedule, MAX_BLOB_SCHEDULES_PER_FORK]
-
-
-class SszChainConfig(Container):
+class SSZStatelessInput(Container):
+    new_payload_request: SSZNewPayloadRequest
+    witness: SSZExecutionWitness
     chain_id: uint64
-    active_fork: SszForkConfig
+    public_keys: ProgressiveList[ByteVector[PUBLIC_KEY_BYTES]]
 
 
-class SszStatelessInput(Container):
-    new_payload_request: SszNewPayloadRequest
-    witness: SszExecutionWitness
-    chain_config: SszChainConfig
-    public_keys: SszList[ByteVector[PUBLIC_KEY_BYTES], MAX_PUBLIC_KEYS]
-
-
-class SszStatelessValidationResult(Container):
+class SSZStatelessValidationResult(Container):
     new_payload_request_root: Bytes32
     successful_validation: boolean
-    chain_config: SszChainConfig
+    chain_id: uint64
+    schema_id: uint16
 ```
 
 ## Rationale


### PR DESCRIPTION
This PR refreshes the _Execution Layer_ section of EIP-8025 in line with the latest [`execution-specs` changes](https://github.com/ethereum/execution-specs/tree/projects/zkevm).

Several upstream changes simplified the stateless guest interface. Those simplifications also make the EIP text shorter and remove obsolete configuration and SSZ limits.

## Changes

- Replace `chain_config` with `chain_id` and the explicit input `schema_id`.
- Document failed guest outputs and their sentinel values.
- Update the Amsterdam schema ID to `0x1501`.
- Use progressive SSZ containers and lists where required.
- Remove obsolete list-capacity constants and fork-configuration structures.
- Add `slot_number` and the EIP-8282 builder request types.
- Update the `requires` metadata for EIP-7688 and EIP-8282.

This PR does not change the Consensus Layer section or the overall design of EIP-8025. It only updates the Execution Layer description and its related dependency metadata.