### PR TITLE
8141: add sigdatacopy so that stack requirement for sigparam is static

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -207,7 +207,7 @@ The `signatures` list contains signatures that may be referenced by `VERIFY` fra
 
 The `signatures` list is optional. Contracts may still ignore it entirely and perform bespoke signature verification inside frame execution. Bespoke signature schemes must place their witness bytes in an `ARBITRARY` signature entry rather than in frame data when the witness signs the canonical transaction signature hash.
 
-The raw `signature` byte strings of protocol-validated schemes are intentionally not introspectable by EVM code to allow future aggregation schemes. Contracts can inspect only the metadata of protocol-validated signature entries through transaction introspection. The raw `signature` byte strings of `ARBITRARY` entries are introspectable by EVM code through `SIGPARAM`'s copy operation. This means that they cannot be aggregated in the future.
+The raw `signature` byte strings of protocol-validated schemes are intentionally not introspectable by EVM code to allow future aggregation schemes. Contracts can inspect only the metadata of protocol-validated signature entries through transaction introspection. The raw `signature` byte strings of `ARBITRARY` entries are introspectable by EVM code through the `SIGDATACOPY` instruction. This means that they cannot be aggregated in the future.
 
 The `scheme` identifies how the raw `signature` bytes are interpreted.
 
@@ -814,28 +814,40 @@ Notes:
 
 #### `SIGPARAM` Instruction (`0xb4`)
 
-This instruction gives access to signature-scoped metadata. The raw `signature` bytes of protocol-validated schemes are intentionally not accessible from the EVM. `ARBITRARY` signature bytes are validated during EVM execution and therefore can be accessed with the copy operation.
+This instruction gives access to signature-scoped metadata. The gas cost of this operation is `2`. It takes two values from the stack, `signatureIndex` on top and `param` second from top, and returns the associated value to the stack.
 
-For `param` values `0x00` through `0x03`, the gas cost of this operation is `2`. It takes two values from the stack, `signatureIndex` on top and `param` second from top, and returns the associated value to the stack.
-
-For `param == 0x04`, this instruction copies bytes from an `ARBITRARY` signature's raw `signature` bytes into memory. Its gas cost is calculated exactly as for `CALLDATACOPY`, including the fixed cost of 3, the per-word copy cost, and the standard EVM memory expansion cost. It takes five values from the stack: `signatureIndex` on top, `param` second from top, followed by `memOffset`, `dataOffset`, and `length`. No stack output value is produced.
-
-| `param` | `signatureIndex` | Behavior                                     |
-|---------|------------------|----------------------------------------------|
-| 0x00    | signatureIndex   | returns `resolved_signer`                    |
-| 0x01    | signatureIndex   | returns `scheme`                             |
-| 0x02    | signatureIndex   | returns `msg`                                |
-| 0x03    | signatureIndex   | returns `len(signature)`                     |
-| 0x04    | signatureIndex   | copies `ARBITRARY` signature bytes to memory |
+| `param` | `signatureIndex` | Return value       |
+|---------|------------------|--------------------|
+| 0x00    | signatureIndex   | `resolved_signer`  |
+| 0x01    | signatureIndex   | `scheme`           |
+| 0x02    | signatureIndex   | `msg`              |
+| 0x03    | signatureIndex   | `len(signature)` (`ARBITRARY` only) |
 
 Notes:
 
 - Undefined `param` values result in an exceptional halt.
 - Out-of-bounds access for `signatureIndex` results in an exceptional halt.
+- For `ARBITRARY` signature entries, requesting `resolved_signer` results in an exceptional halt.
+- For signature entries of any other `scheme`, requesting `len(signature)` results in an exceptional halt. The raw `signature` bytes of protocol-validated schemes, including their length, are not introspectable.
 
-For `ARBITRARY` signature entries, requesting `resolved_signer` results in exceptional halt
+#### `SIGDATACOPY` Instruction (`0xb5`)
 
-For `param == 0x04`, if the referenced signature entry's `scheme` is not `ARBITRARY`, an exceptional halt occurs. The operation semantics match `CALLDATACOPY`, copying `length` bytes from the chosen signature's raw `signature` bytes, starting at the given byte `dataOffset`, into a memory region starting at `memOffset`. Bytes beyond the end of the signature are copied as zeroes.
+This opcode copies a signature's raw `signature` bytes into the contract's memory. The raw `signature` bytes of protocol-validated schemes are intentionally not accessible from the EVM. `ARBITRARY` signature bytes are validated during EVM execution and therefore may be copied. Its gas cost is calculated exactly as for `CALLDATACOPY`, including the fixed cost of 3, the per-word copy cost, and the standard EVM memory expansion cost.
+
+It takes four values from the stack and produces no output:
+
+| Stack     | Value            |
+| --------- | ---------------- |
+| `top - 0` | `memOffset`      |
+| `top - 1` | `dataOffset`     |
+| `top - 2` | `length`         |
+| `top - 3` | `signatureIndex` |
+
+When the `signatureIndex` is out-of-bounds, an exceptional halt occurs. If the referenced signature entry's `scheme` is not `ARBITRARY`, an exceptional halt occurs.
+
+The operation semantics match `CALLDATACOPY`, copying `length` bytes from the chosen signature's raw `signature` bytes, starting at the given byte `dataOffset`, into a memory region starting at `memOffset`. Bytes beyond the end of the signature are copied as zeroes.
+
+The byte length of an `ARBITRARY` signature entry is available via `SIGPARAM` with `param == 0x03`.
 
 ### Mempool
 


### PR DESCRIPTION
It's been noted a couple times that having a dynamic stack size for `SIGPARAM` when copying the `ARBITRARY` sigdata is problematic for a number of reasons.

This PR splits that behavior out into a separate instruction `SIGDATACOPY`.