### PR TITLE
Update EIP-8148: Allow setting the sweep threshold at deposit time and reduce `MIN_SWEEP_THRESHOLD` to 32 ETH

### DIFF
--- a/EIPS/eip-8148.md
+++ b/EIPS/eip-8148.md
@@ -2,7 +2,7 @@
 eip: 8148
 title: Custom sweep threshold for validators
 description: Allow setting custom balance thresholds for sweep withdrawals for validators with compounding withdrawal credentials (`0x02`).
-author: Dmitry Gusakov (@dgusakov), Dmitry Chernukhin (@madlabman), Greg Koumoutsos (@gkoumout)
+author: Dmitry Gusakov (@dgusakov), Dmitry Chernukhin (@madlabman), Greg Koumoutsos (@gkoumout), Manu (@nalepae)
 discussions-to: https://ethereum-magicians.org/t/eip-8148-custom-sweep-threshold-for-validators/27669
 status: Draft
 type: Standards Track
@@ -51,16 +51,16 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 #### Consensus layer
 
-| Name                                 | Value                                               | Comment                                                                |
-| ------------------------------------ | --------------------------------------------------- | ---------------------------------------------------------------------- |
-| `MIN_SWEEP_THRESHOLD`                | `MIN_ACTIVATION_BALANCE + Gwei(1 * 10**9)` (33 ETH) |                                                                        |
-| `SWEEP_THRESHOLD_CREDENTIAL_OFFSET`  | `10`                                                | Byte offset of the threshold embedded in `0x02` withdrawal credentials |
+| Name                                 | Value                             | Comment                                                                |
+| ------------------------------------ | --------------------------------- | ---------------------------------------------------------------------- |
+| `MIN_SWEEP_THRESHOLD`                | `MIN_ACTIVATION_BALANCE` (32 ETH) |                                                                        |
+| `SWEEP_THRESHOLD_CREDENTIAL_OFFSET`  | `10`                              | Byte offset of the threshold embedded in `0x02` withdrawal credentials |
 
 ### Execution layer
 
 #### Definitions
 
-* **`FORK_BLOCK`** -- the first block in a blockchain after this EIP has been activated.
+- **`FORK_BLOCK`** -- the first block in a blockchain after this EIP has been activated.
 
 #### Set sweep threshold request
 
@@ -152,21 +152,21 @@ When the input to the contract has zero-length, interpret this as a get request 
 
 At the end of processing any execution block starting from the `FORK_BLOCK` (i.e. after processing all transactions), call `SET_SWEEP_THRESHOLD_REQUEST_PREDEPLOY_ADDRESS` as `SYSTEM_ADDRESS` with no calldata. The invocation triggers the following:
 
-* The contract's queue is updated based on set sweep threshold requests dequeued and the set sweep threshold requests queue head/tail are reset if the queue has been cleared (`dequeue_set_sweep_threshold_requests()`)
-* The contract's excess set sweep threshold requests are updated based on usage in the current block (`update_excess_set_sweep_threshold_requests()`)
-* The contract's set sweep threshold requests count is reset to 0 (`reset_set_sweep_threshold_requests_count()`)
+- The contract's queue is updated based on set sweep threshold requests dequeued and the set sweep threshold requests queue head/tail are reset if the queue has been cleared (`dequeue_set_sweep_threshold_requests()`)
+- The contract's excess set sweep threshold requests are updated based on usage in the current block (`update_excess_set_sweep_threshold_requests()`)
+- The contract's set sweep threshold requests count is reset to 0 (`reset_set_sweep_threshold_requests_count()`)
 
 In response to the system call, the contract returns an opaque byte array of concatenated SSZ-serialized dequeued requests. There's no specific reasoning behind it, except aligning with the existing behaviour of the similar EIP, see [EIP-7002](./eip-7002.md), and possible simplification of the processing flow for client teams.
 Each set sweep threshold request must appear in the EIP-7685 requests list in the exact order returned by `dequeue_set_sweep_threshold_requests()`.
 
 Additionally, the system call and the processing of that block must conform to the following:
 
-* The call has a dedicated gas limit of `30_000_000` (`SYSTEM_TRANSACTION_GAS`) and is not subject to the transaction limit cap introduced in [EIP-7825](./eip-7825.md).
-* Gas consumed by this call does not count against the block’s overall gas usage.
-* Both the gas limit assigned to the call and the gas consumed are excluded from any checks against the block’s gas limit.
-* The call does not follow [EIP-1559](./eip-1559.md) fee burn semantics — no value should be transferred as part of this call.
-* If there is no code at `SET_SWEEP_THRESHOLD_REQUEST_PREDEPLOY_ADDRESS`, the corresponding block **MUST** be marked invalid.
-* If the call to the contract fails or returns an error, the block **MUST** be invalidated.
+- The call has a dedicated gas limit of `30_000_000` (`SYSTEM_TRANSACTION_GAS`) and is not subject to the transaction limit cap introduced in [EIP-7825](./eip-7825.md).
+- Gas consumed by this call does not count against the block’s overall gas usage.
+- Both the gas limit assigned to the call and the gas consumed are excluded from any checks against the block’s gas limit.
+- The call does not follow [EIP-1559](./eip-1559.md) fee burn semantics — no value should be transferred as part of this call.
+- If there is no code at `SET_SWEEP_THRESHOLD_REQUEST_PREDEPLOY_ADDRESS`, the corresponding block **MUST** be marked invalid.
+- If the call to the contract fails or returns an error, the block **MUST** be invalidated.
 
 The functionality triggered by the system call is defined in pseudocode as the function `read_set_sweep_threshold_requests()`:
 
@@ -665,7 +665,7 @@ def add_validator_to_registry(
     set_or_append_list(state.validator_sweep_thresholds, index, threshold)
 ```
 
-Full consensus layer specification can be found in `specs/_features/eip8148/beacon-chain.md` (PR 4901 in the consensus-specs repository).
+Full consensus layer specification can be found in `specs/_features/eip8148/beacon-chain.md`.
 
 ## Rationale
 
@@ -688,10 +688,6 @@ This design decision is made to prevent usage of the custom sweep threshold mech
 ### Immediate requests processing instead of queuing on consensus layer
 
 Unlike partial withdrawal requests, which are queued on the consensus layer, set sweep threshold requests are processed immediately upon being dequeued from the execution layer contract. This design choice simplifies the implementation and reduces the complexity of managing a separate queue on the consensus layer.
-
-### `MIN_SWEEP_THRESHOLD` of 33 ETH
-
-To ensure that validators do not set sweep threshold equal to `MIN_ACTIVATION_BALANCE`, we introduce a minimum sweep threshold of `MIN_ACTIVATION_BALANCE + 1` ETH (33 ETH). This ensures that people will opt-in to compounding withdrawal credentials only if they really want to accumulate rewards on the validator balance.
 
 ### Custom Sweep Threshold should be a multiple of `EFFECTIVE_BALANCE_INCREMENT`
 

--- a/EIPS/eip-8148.md
+++ b/EIPS/eip-8148.md
@@ -51,9 +51,10 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 #### Consensus layer
 
-| Name                       | Value                                               |
-| -------------------------- | --------------------------------------------------- |
-| `MIN_SWEEP_THRESHOLD`      | `MIN_ACTIVATION_BALANCE + Gwei(1 * 10**9)` (33 ETH) |
+| Name                                 | Value                                               | Comment                                                                |
+| ------------------------------------ | --------------------------------------------------- | ---------------------------------------------------------------------- |
+| `MIN_SWEEP_THRESHOLD`                | `MIN_ACTIVATION_BALANCE + Gwei(1 * 10**9)` (33 ETH) |                                                                        |
+| `SWEEP_THRESHOLD_CREDENTIAL_OFFSET`  | `10`                                                | Byte offset of the threshold embedded in `0x02` withdrawal credentials |
 
 ### Execution layer
 
@@ -600,8 +601,69 @@ The [Rationale](#rationale) section contains an explanation for this proposed co
 6. Modify the `is_partially_withdrawable_validator` predicate to take into account the custom sweep threshold.
 7. Add `get_effective_sweep_threshold` helper function to compute the effective sweep threshold for a validator.
 8. Modify the `get_expected_withdrawals` function to use the custom sweep threshold when determining partial withdrawals.
+9. Add `get_credential_sweep_threshold` helper function to decode a threshold embedded in withdrawal credentials.
+10. Modify the `add_validator_to_registry` function to initialize a new validator's threshold from its withdrawal credentials.
 
-By default, all validators will have their sweep thresholds set to the current default `MAX_EFFECTIVE_BALANCE`, both for existing validators and new ones. Validators can choose to set a custom threshold above their current balance by submitting a set sweep threshold request through the execution layer contract.
+Validators with compounding withdrawal credentials (`0x02`) that already exist at the fork, and new `0x02` validators whose credentials carry no threshold, are given a threshold of `MAX_EFFECTIVE_BALANCE_ELECTRA`. Validators with `0x00` or `0x01` credentials are given a threshold of `0`.
+
+A `0x02` validator may instead be created with a custom threshold, by encoding it in the withdrawal credentials of the deposit that creates it. In every case the threshold can be changed afterwards to any value at or above the validator's current balance by submitting a set sweep threshold request through the execution layer contract.
+
+#### Setting the threshold at deposit time
+
+A validator MAY be created with a custom threshold already in place, by encoding it in the `0x02` withdrawal credentials of the deposit that creates it. Compounding credentials reserve bytes `1` through `11`. The two bytes at `SWEEP_THRESHOLD_CREDENTIAL_OFFSET` are redefined to hold the threshold, expressed in units of `EFFECTIVE_BALANCE_INCREMENT` as a big-endian `uint16`:
+
+| Bytes     | Contents                                                       |
+| --------- | -------------------------------------------------------------- |
+| `0`       | `COMPOUNDING_WITHDRAWAL_PREFIX` (`0x02`)                       |
+| `1..9`    | Reserved, MUST be zero                                         |
+| `10..11`  | Threshold in `EFFECTIVE_BALANCE_INCREMENT` units, big-endian   |
+| `12..31`  | Execution address                                              |
+
+A value of zero means no threshold was requested. Because a threshold is constrained to be a multiple of `EFFECTIVE_BALANCE_INCREMENT` anyway, two bytes express every permitted value: the largest encodable threshold is `65535 * EFFECTIVE_BALANCE_INCREMENT`, or 65,535 ETH. Nine reserved bytes are left untouched.
+
+```python
+def get_credential_sweep_threshold(withdrawal_credentials: Bytes32) -> Gwei:
+    """
+    Decode the optional sweep threshold embedded in compounding withdrawal credentials.
+    Returns 0 when unset or out of range, in which case the default threshold applies.
+    """
+    increments = (
+        withdrawal_credentials[SWEEP_THRESHOLD_CREDENTIAL_OFFSET] * 256
+        + withdrawal_credentials[SWEEP_THRESHOLD_CREDENTIAL_OFFSET + 1]
+    )
+
+    threshold = Gwei(increments * EFFECTIVE_BALANCE_INCREMENT)
+    if threshold < MIN_SWEEP_THRESHOLD or threshold > MAX_EFFECTIVE_BALANCE_ELECTRA:
+        return Gwei(0)
+
+    return threshold
+```
+
+Only the deposit that creates the validator is read. `add_validator_to_registry` is reached solely when the public key is absent from the registry, so the credentials of a subsequent top-up deposit, and any threshold they carry, are ignored exactly as the withdrawal address already is.
+
+`add_validator_to_registry` is modified to consult the embedded value. A threshold that is out of range, or that is below the deposited amount, is ignored rather than rejected, so that a deposit built by tooling unaware of this EIP, or carrying a nonsensical value, still creates a validator with the default threshold:
+
+```python
+def add_validator_to_registry(
+    state: BeaconState, pubkey: BLSPubkey, withdrawal_credentials: Bytes32, amount: uint64
+) -> None:
+    index = get_index_for_new_validator(state)
+    validator = get_validator_from_deposit(pubkey, withdrawal_credentials, amount)
+    set_or_append_list(state.validators, index, validator)
+    set_or_append_list(state.balances, index, amount)
+    set_or_append_list(state.previous_epoch_participation, index, ParticipationFlags(0b0000_0000))
+    set_or_append_list(state.current_epoch_participation, index, ParticipationFlags(0b0000_0000))
+    set_or_append_list(state.inactivity_scores, index, uint64(0))
+
+    # [New in EIP-8148]
+    threshold = Gwei(0)
+    if has_compounding_withdrawal_credential(validator):
+        threshold = get_credential_sweep_threshold(withdrawal_credentials)
+        if threshold < amount:
+            threshold = MAX_EFFECTIVE_BALANCE_ELECTRA
+
+    set_or_append_list(state.validator_sweep_thresholds, index, threshold)
+```
 
 Full consensus layer specification can be found in `specs/_features/eip8148/beacon-chain.md` (PR 4901 in the consensus-specs repository).
 
@@ -638,6 +700,10 @@ To maintain consistency with the existing balance increments in the protocol, we
 ## Backwards Compatibility
 
 This EIP introduces backwards incompatible changes to the block structure and block validation rule set. But neither of these changes break anything related to the current user activity and experience.
+
+Bytes `10` and `11` of compounding withdrawal credentials are given a meaning they did not previously have. No consensus function read them before this EIP, so no existing validator's behaviour changes: thresholds for validators that already exist at the fork are initialized from the fork transition, not from their credentials, and only deposits processed after the fork are interpreted. A pre-existing validator whose credentials happen to carry a non-zero value in those bytes is therefore unaffected.
+
+Deposits that leave the bytes zero, which is every deposit produced by tooling written before this EIP, behave exactly as they do today and receive the default threshold.
 
 ## Security Considerations
 

--- a/EIPS/eip-8148.md
+++ b/EIPS/eip-8148.md
@@ -162,8 +162,8 @@ Each set sweep threshold request must appear in the EIP-7685 requests list in th
 Additionally, the system call and the processing of that block must conform to the following:
 
 - The call has a dedicated gas limit of `30_000_000` (`SYSTEM_TRANSACTION_GAS`) and is not subject to the transaction limit cap introduced in [EIP-7825](./eip-7825.md).
-- Gas consumed by this call does not count against the block’s overall gas usage.
-- Both the gas limit assigned to the call and the gas consumed are excluded from any checks against the block’s gas limit.
+- Gas consumed by this call does not count against the block's overall gas usage.
+- Both the gas limit assigned to the call and the gas consumed are excluded from any checks against the block's gas limit.
 - The call does not follow [EIP-1559](./eip-1559.md) fee burn semantics — no value should be transferred as part of this call.
 - If there is no code at `SET_SWEEP_THRESHOLD_REQUEST_PREDEPLOY_ADDRESS`, the corresponding block **MUST** be marked invalid.
 - If the call to the contract fails or returns an error, the block **MUST** be invalidated.


### PR DESCRIPTION
An updated version of https://github.com/ethereum/EIPs/pull/12146