### PR TITLE
Update EIP-5920: Add `isEmitLog` flag

### DIFF
--- a/EIPS/eip-5920.md
+++ b/EIPS/eip-5920.md
@@ -47,7 +47,7 @@ Having a dedicated opcode for ether transfers solves all of these issues, and wo
 A new opcode is introduced: `PAY` (`0xfc`), which:
 
 - Halt with exceptional failure if the current frame is static, as defined in [EIP-214](./eip-214.md).
-- Pops two values from the stack: `addr`, `val` then `isEmitLog`
+- Pops two values from the stack: `addr`, `val` then `isEmitLog`.
 - If the `isEmitLog` flag is enabled, the Ether transfer will emit a log, as defined in [EIP-7708](./eip-7708.md).
 - Exceptionally halts if `addr` has any of the high 12 bytes set to a non-zero value (i.e. it does not contain a 20-byte address).
 - Charges the gas cost detailed below.

--- a/EIPS/eip-5920.md
+++ b/EIPS/eip-5920.md
@@ -8,7 +8,7 @@ status: Stagnant
 type: Standards Track
 category: Core
 created: 2022-03-14
-requires: 214, 2929, 7523
+requires: 214, 2929, 7523, 7708
 ---
 
 ## Abstract
@@ -47,7 +47,8 @@ Having a dedicated opcode for ether transfers solves all of these issues, and wo
 A new opcode is introduced: `PAY` (`0xfc`), which:
 
 - Halt with exceptional failure if the current frame is static, as defined in [EIP-214](./eip-214.md).
-- Pops two values from the stack: `addr` then `val`.
+- Pops two values from the stack: `addr`, `val` then `isEmitLog`
+- If the `isEmitLog` flag is enabled, the Ether transfer will emit a log, as defined in [EIP-7708](./eip-7708.md).
 - Exceptionally halts if `addr` has any of the high 12 bytes set to a non-zero value (i.e. it does not contain a 20-byte address).
 - Charges the gas cost detailed below.
 - Marks `addr` as warm (adding `addr` to `accessed_addresses`).


### PR DESCRIPTION
This update adds an emit log flag to the parameters of the PAY opcode. This addition is implemented in the context of the proposal being integrated into Hegota.

Rationale

- To incorporate EIP-7708 behavior into this opcode's functionality.
EIP-7708 mandates unconditional log emission for Ether transfers; however, not all operations require this (e.g., bridge adapters often move Ether between contracts within their systems, whereas bridge validators only need an event emitted at the entry point).
- There is a significant disparity between the cost of emitting a log and the cost of a warm account access (1,756 vs. 100—more than 17 times the base cost). This disadvantages Ether transfer transactions, even when accounting for optimizations from previous repricing rounds.
- The opcode is still under development, leaving substantial room for improvement.

This update only adds functionality; the specific pricing for this feature will depend on the completion of repricing proposals.