### PR TITLE
Update EIP-8141: make the expiry frame a new mode

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -37,7 +37,6 @@ Ultimately, frame transactions realize the original vision of account abstractio
 | `FRAME_TX_INTRINSIC_COST`  | `12000`           |
 | `FRAME_TX_PER_FRAME_COST`  | `475`             |
 | `ENTRY_POINT`              | `address(0xaa)`   |
-| `EXPIRY_VERIFIER`          | `address(0x8141)` |
 | `EXPIRY_DATA_LENGTH`       | `8`               |
 | `MAX_FRAMES`               | `64`              |
 | `SECP256K1N`               | `0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141` |
@@ -108,7 +107,7 @@ The `flags` field configures additional execution constraints. Bit positions are
 
 | Flag bits | Meaning                      | Valid with  |
 |-----------|------------------------------| ----------- |
-| 0-1       | Approval scope               | Any mode    |
+| 0-1       | Approval scope               | `DEFAULT`, `VERIFY`, `SENDER` |
 | 2         | Atomic batch                 | `DEFAULT`, `SENDER` |
 | 3..       | reserved                     | No mode     |
 
@@ -132,6 +131,7 @@ the purpose of the frame within the execution loop.
 | 0       | `DEFAULT` mode | Execute frame as `ENTRY_POINT`             |
 | 1       | `VERIFY` mode  | Frame identifies as transaction validation |
 | 2       | `SENDER` mode  | Execute frame as `sender`                  |
+| 3       | `EXPIRY` mode  | Frame declares a transaction deadline      |
 
 
 #### Constraints
@@ -169,7 +169,7 @@ for sig in tx.signatures:
 total_frame_gas = 0
 total_frame_execution_gas = 0
 for i, frame in enumerate(tx.frames):
-    assert frame.mode < 3
+    assert frame.mode < 4
     assert frame.flags < 8
     assert frame.target is None or len(frame.target) == 20
     assert frame.limits.state <= 2**64 - 1
@@ -183,12 +183,12 @@ for i, frame in enumerate(tx.frames):
     if frame.flags & APPROVE_EXECUTION:
         assert frame.target is None or frame.target == tx.sender
 
-    # Atomic batch flag is only valid on non-VERIFY frames and requires
-    # a subsequent non-VERIFY frame to batch with.
+    # Atomic batch flag is only valid on DEFAULT and SENDER frames and
+    # requires a subsequent frame of one of those modes to batch with.
     if frame.flags & ATOMIC_BATCH_FLAG:
-        assert frame.mode != VERIFY
-        assert i + 1 < len(tx.frames)            # must not be last frame
-        assert tx.frames[i + 1].mode != VERIFY   # batches never contain VERIFY frames
+        assert frame.mode in (DEFAULT, SENDER)
+        assert i + 1 < len(tx.frames)                      # must not be last frame
+        assert tx.frames[i + 1].mode in (DEFAULT, SENDER)  # batches hold only these modes
 
     # A frame belongs to a batch when it or its predecessor carries ATOMIC_BATCH_FLAG.
     if frame.flags & ATOMIC_BATCH_FLAG or (i > 0 and tx.frames[i - 1].flags & ATOMIC_BATCH_FLAG):
@@ -319,70 +319,30 @@ def validate_signature(sig, tx_sender, sig_hash) -> bool:
 
 Note: since the signature validation does not happen in EVM execution, the related precompiles `ecrecover` and `P256VERIFY` must not be added to the block-level access list.
 
-#### Expiry Verifier Frame
+#### Expiry Frame
 
-A `VERIFY` frame whose `frame.target` equals `EXPIRY_VERIFIER` is an **expiry verifier frame**. It calls the expiry verifier contract deployed at `EXPIRY_VERIFIER` with `frame.data` as calldata. The calldata is interpreted as an 8-byte unsigned big-endian expiry timestamp. The call reverts unless `block.timestamp <= expiry_timestamp`.
+A frame with mode `EXPIRY` sets a deadline for the transaction. Its `data` is an `EXPIRY_DATA_LENGTH`-byte unsigned big-endian timestamp. The frame calls no account and runs no code.
 
-An expiry verifier frame is invalid unless all of the following hold:
+An `EXPIRY` frame is invalid unless all of the following hold:
 
 - `frame.flags == 0`
+- `frame.target` is null
 - `frame.value == 0`
+- `frame.limits.execution == 0`
 - `frame.limits.state == 0`
 - `len(frame.data) == EXPIRY_DATA_LENGTH`
 
-A transaction can contain at most one expiry verifier frame.
+A transaction can contain at most one `EXPIRY` frame.
 
-At activation, clients must install the following expiry verifier contract runtime code at `EXPIRY_VERIFIER`. The expiry verifier contract's runtime code must be:
-
-```asm
-push1 0x08
-calldatasize
-eq
-push1 0x0a
-jumpi
-push0
-push0
-revert
-
-jumpdest
-push0
-calldataload
-push1 0xc0
-shr
-timestamp
-gt
-push1 0x16
-jumpi
-stop
-
-jumpdest
-push0
-push0
-revert
-```
-
-The runtime bytecode is:
-
-```text
-0x60083614600a575f5ffd5b5f3560c01c4211601657005b5f5ffd
-```
-
-Equivalently, the runtime behavior is:
+The frame is processed as:
 
 ```python
-if len(evm.calldata) != EXPIRY_DATA_LENGTH:
-    revert()
-
-expiry_timestamp = int.from_bytes(evm.calldata, "big")
-if evm.timestamp > expiry_timestamp:
-    revert()
-
-stop()
+expiry_timestamp = int.from_bytes(frame.data, "big")
+if block.timestamp > expiry_timestamp:
+    invalid_transaction()
 ```
 
-If the check passes, the frame succeeds with no return data and no logs. The frame consumes gas according to normal EVM execution rules.
-
-Clients may omit the explicit EVM execution and directly perform the expiry check above, provided the externally observable result is identical to executing the canonical contract. Note: While this is a valid optimization for Ethereum mainnet, it could be problematic on non-mainnet situations in case a different contract is used.
+If the deadline has not passed, the frame succeeds with no return data and no logs, and its receipt reports `status = 1` and `gas_used = [0, 0]`.
 
 #### Behavior
 
@@ -399,11 +359,12 @@ To begin processing a frame transaction:
 
 Then for each frame:
 
+1. Let `resolved_target = frame.target if frame.target is not None else tx.sender`.
+    - Unless otherwise stated, checks that refer to the target account during execution use the resolved target.
+1. If the frame has mode `EXPIRY`, process it as defined in [Expiry Frame](#expiry-frame) and continue with the next frame. The steps below apply to the other modes.
 1. Execute a call with the specified `mode`, `flags`, `target`, `limits`, `value`, and `data`.
     - Initialize the frame's receipt with `gas_used = [0, 0]`.
     - At frame entry, initialize the frame's gas pools per [Gas Accounting](#gas-accounting): `gas_left = frame.limits.execution` and `state_gas_left = frame.limits.state`.
-    - Let `resolved_target = frame.target if frame.target is not None else tx.sender`
-        - Unless otherwise stated, checks that refer to the target account during execution use the resolved target.
     - Set frame's `caller`:
         - If mode is `SENDER`:
             - `sender_approved` must be `true`. If not, the transaction is invalid.
@@ -864,7 +825,7 @@ For public mempool accounting, signature validation is treated as part of the tr
 A frame transaction is eligible for public mempool propagation only if its validation prefix depends exclusively on:
 
 1. transaction fields, including the canonical signature hash,
-2. the block timestamp as read by an expiry verifier frame,
+2. the block timestamp, when an `EXPIRY` frame is present,
 3. the sender's nonce, code, and storage,
 4. if a deploy frame is present, the code of the factory targeted by that frame (subject to the deploy-frame trace rules below),
 5. if a paymaster frame is present, either a canonical paymaster instance together with explicit paymaster balance reservation, or a non-canonical paymaster being used by less than `MAX_PENDING_TXS_USING_NON_CANONICAL_PAYMASTER` pending transactions,
@@ -882,7 +843,7 @@ While the frames are designed to be generic, we refine some frame modes for the 
 | `deploy` | DEFAULT | `0x0` | Deploys a new smart account, typically via a deterministic factory such as the [EIP-7997](./eip-7997.md) predeploy |
 | `only_verify` | VERIFY | `0x2` | Validates the transaction and approves only the sender |
 | `pay` | VERIFY | `0x1` | Validates the transaction and approves only the payer |
-| `expiry_verify` | VERIFY | `0x0` | Calls the expiry verifier contract (target = `EXPIRY_VERIFIER`) |
+| `expiry` | EXPIRY | `0x0` | Sets the transaction deadline |
 | `user_op` | SENDER | any | Executes the intended user operation |
 | `post_op` | DEFAULT | any | Executes an optional post-op action as needed by the paymaster |
 
@@ -944,13 +905,11 @@ To be accepted into the public mempool, a frame transaction must satisfy the fol
 7. Nodes should stop simulation immediately once `payer` has been set and the associated `VERIFY` frame completes successfully.
 8. There must not be `VERIFY` frame after validation prefix.
 
-#### Expiry Verifier Frame
+#### Expiry Frame
 
-Although `TIMESTAMP` is generally banned during validation-prefix execution, it is permitted when executing the canonical expiry verifier runtime code at `EXPIRY_VERIFIER`; clients may optimize the frame by performing the same deadline check without explicit EVM execution.
+An `expiry` frame MAY appear only as first frame in the frame list. For the purposes of matching the recognized validation-prefix shapes above, the expiry frame is skipped (e.g., `[expiry, self_verify]` is recognized as `[self_verify]`).
 
-An `expiry_verify` frame MAY appear only as first frame in the frame list. For the purposes of matching the recognized validation-prefix shapes above, expiry verifier frame is skipped (e.g., `[expiry_verify, self_verify]` is recognized as `[self_verify]`).
-
-A node MUST drop a frame transaction from the public mempool if it contains an `expiry_verify` frame whose deadline is less than the node's view of the current block timestamp at any point.
+A node MUST drop a frame transaction from the public mempool if it contains an `expiry` frame whose deadline is less than the node's view of the current block timestamp at any point.
 
 #### Canonical Paymaster Exception
 
@@ -958,11 +917,11 @@ The generic validation trace and opcode rules below apply to all frames in the v
 
 #### Direct Evaluation of Protocol-Defined Frames
 
-Three frame species in the validation prefix have fully protocol-defined semantics, leaving no deployed code whose behavior a node would need to discover by execution: a frame whose resolved target has the empty code hash (default code), an expiry verifier frame whose runtime code at `EXPIRY_VERIFIER` matches the canonical expiry verifier code, and a `pay` frame admitted by canonical paymaster code match per the previous section.
+Two frame species in the validation prefix have fully protocol-defined semantics, leaving no deployed code whose behavior a node would need to discover by execution: a frame whose resolved target has the empty code hash (default code), and a `pay` frame admitted by canonical paymaster code match per the previous section. An `expiry` frame runs no code at all.
 
-When every frame in the validation prefix is one of these, direct evaluation of the protocol-defined semantics is equivalent to simulation, and a node MAY use it to satisfy the validation requirements below. Direct evaluation MUST apply the same limits as simulation: signature validation and the evaluated frames' work count against `MAX_VERIFY_GAS`, and the paymaster accounting rules in this section apply unchanged.
+When every frame in the validation prefix is one of these two species or an `expiry` frame, direct evaluation of the protocol-defined semantics is equivalent to simulation, and a node MAY use it to satisfy the validation requirements below. Direct evaluation MUST apply the same limits as simulation: signature validation and the evaluated frames' work count against `MAX_VERIFY_GAS`, and the paymaster accounting rules in this section apply unchanged.
 
-The complete state dependency set of such a validation prefix is: the sender's code hash, nonce, and balance (the balance participates in the sender-existence check that decides the `APPROVE` account-creation state-gas charge), the payer's code hash and balance (or the canonical paymaster's tracked state), the runtime code at `EXPIRY_VERIFIER` together with the frame's deadline when an expiry verifier frame is present, and the current block timestamp. Nodes SHOULD index pending transactions by this set so that head-of-chain changes are revalidated without re-execution.
+The complete state dependency set of such a validation prefix is: the sender's code hash, nonce, and balance (the balance participates in the sender-existence check that decides the `APPROVE` account-creation state-gas charge), the payer's code hash and balance (or the canonical paymaster's tracked state), and the current block timestamp. Nodes SHOULD index pending transactions by this set so that head-of-chain changes are revalidated without re-execution.
 
 #### Validation Trace Rules
 
@@ -986,7 +945,6 @@ For `VERIFY` frames, the usual `STATICCALL` restrictions apply except for the pr
 - BLOCKHASH (0x40)
 - COINBASE (0x41)
 - TIMESTAMP (0x42)
-    - Except in an expiry verifier frame executing the canonical runtime code at `EXPIRY_VERIFIER`.
 - NUMBER (0x43)
 - PREVRANDAO/DIFFICULTY (0x44)
 - GASLIMIT (0x45)
@@ -1155,6 +1113,10 @@ Atomic batching allows multiple frames to be grouped into a single all-or-nothin
 Using a flag to indicate atomic batches saves us from having to introduce a new mode. Batches are identified purely by consecutive frames with the flag set, terminated by a frame without it. This design enables consecutive atomic batches since the batch boundary is clearly indicated by the frame without the flag.
 
 Approval scope flags are disallowed on the frames of an atomic batch, including its terminating frame. Since `APPROVE` requires its scope to be present in `frame.flags`, this restriction is statically checkable, and it keeps the approval context constant across a batch. Unrolling a failed batch therefore never rolls back the sender nonce increment or the `max_cost` collection, a batch failure cannot retroactively withdraw an execution approval that later `SENDER` frames rely on, and whether the transaction sets `payer` never depends on a batch outcome. Approval can always be placed in a frame preceding the batch instead.
+
+### Expiry as a frame mode
+
+A deadline is a property of the transaction rather than of any account, so a mode expresses it directly. The frame has no target and runs no code, so the deadline is readable from the transaction fields alone and both nodes and block builders can check it without simulation. The alternative, a verifier contract predeployed at a reserved address and selected by frame target, requires canonical runtime code, an exception to the `TIMESTAMP` ban during validation, and an optional client short circuit to skip executing it.
 
 ### Per-frame cost
 
@@ -1394,7 +1356,7 @@ Frame transactions introduce new denial-of-service vectors for transaction pools
 
 #### Example Attack
 
-A simple example is transactions that check `block.timestamp`, without using expiry verifier frame:
+A simple example is transactions that check `block.timestamp` without using an `EXPIRY` frame:
 
 ```solidity
 function validateTransaction() external {

--- a/EIPS/eip-8266.md
+++ b/EIPS/eip-8266.md
@@ -63,7 +63,7 @@ slot_ring_ptr    = left_pad_32(2)                     # uint64 monotonic counter
 
 ### Stateful validity
 
-Let `now = block.timestamp`. Let `expiry_frames` be the list of frames in `tx.frames` with `mode == VERIFY` and `target == EXPIRY_VERIFIER`. A post-fork frame transaction in expiring-nonce mode is statefully valid only if:
+Let `now = block.timestamp`. Let `expiry_frames` be the list of frames in `tx.frames` with `mode == EXPIRY`. A post-fork frame transaction in expiring-nonce mode is statefully valid only if:
 
 ```python
 assert len(expiry_frames) == 1
@@ -115,7 +115,7 @@ Nodes MAY admit multiple pending expiring-nonce transactions per sender; EIP-814
 
 ### Activation
 
-This EIP MUST activate at or after [EIP-8141](./eip-8141.md). At activation, on the first execution payload with `timestamp >= FORK_TIMESTAMP` and before any transaction in that payload runs, clients MUST install `NONCE_RING_CODE` at `NONCE_RING` with nonce `1` and empty storage, preserving any pre-existing balance. The same address-selection and existing-account-handling requirements as EIP-8141's `EXPIRY_VERIFIER` activation apply.
+This EIP MUST activate at or after [EIP-8141](./eip-8141.md). At activation, on the first execution payload with `timestamp >= FORK_TIMESTAMP` and before any transaction in that payload runs, clients MUST install `NONCE_RING_CODE` at `NONCE_RING` with nonce `1` and empty storage, preserving any pre-existing balance.
 
 Pre-fork frame transactions and authorizations bound to the pre-fork canonical signature hash do not survive the boundary and MUST be evicted from mempools and regenerated.
 
@@ -125,9 +125,9 @@ Pre-fork frame transactions and authorizations bound to the pre-fork canonical s
 
 The sentinel reuses an existing field whose range (`< 2**64`) already covers `EXPIRING_NONCE_SENTINEL`. No payload schema change is required, the canonical signature hash continues to commit to the mode marker through the existing `nonce` field, and the design composes cleanly with [EIP-8250](./eip-8250.md) (see below).
 
-### Reusing `expiry_verify`
+### Reusing the `EXPIRY` frame
 
-EIP-8141 already defines the `expiry_verify` frame: canonical contract, 8-byte big-endian calldata, and a signature-hash exception that makes the deadline sender-authenticated. Adding a parallel deadline field on the envelope would duplicate all of that. Reusing the existing frame keeps the signature-hash procedure unchanged.
+EIP-8141 already defines the `EXPIRY` frame mode: an 8-byte big-endian deadline carried in the frame data and committed to by the canonical signature hash, which makes it sender-authenticated. Adding a parallel deadline field on the envelope would duplicate all of that. Reusing the existing frame keeps the signature-hash procedure unchanged.
 
 ### Ring buffer instead of permanent per-tx slots
 
@@ -151,7 +151,7 @@ Transactions with `tx.nonce != EXPIRING_NONCE_SENTINEL` behave exactly as in EIP
 
 ## Security Considerations
 
-The replay window of an expiring-nonce transaction is its deadline `d`. Rebroadcasts after `d` are rejected by the `expiry_verify` frame itself; rebroadcasts at or before `d` are rejected by the `seen[h].deadline < now` check (a strict inequality is required to block same-block reuse when `d == block.timestamp`). The ring guarantees that an entry is not evicted while still live as long as `MAX_EXPIRY_SECS × peak_tps ≤ RING_CAPACITY`; `BufferFull` enforces this invariant at execution time.
+The replay window of an expiring-nonce transaction is its deadline `d`. Rebroadcasts after `d` are rejected by the `EXPIRY` frame itself; rebroadcasts at or before `d` are rejected by the `seen[h].deadline < now` check (a strict inequality is required to block same-block reuse when `d == block.timestamp`). The ring guarantees that an entry is not evicted while still live as long as `MAX_EXPIRY_SECS × peak_tps ≤ RING_CAPACITY`; `BufferFull` enforces this invariant at execution time.
 
 Because expiring-nonce transactions do not advance the sender's legacy account nonce, an EOA can have many pending expiring-nonce transactions plus an unrelated legacy-nonce transaction outstanding at the same time. Single-use applications that derive intent from the legacy nonce SHOULD authenticate the pre-state legacy nonce explicitly rather than relying on transaction ordering.
 

--- a/EIPS/eip-8272.md
+++ b/EIPS/eip-8272.md
@@ -33,7 +33,7 @@ Privacy applications, for example, keep a tree of commitments and prove spends a
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
 
-This specification is a delta against [EIP-8141](./eip-8141.md). Terms not defined here, including `FrameTx`, `FRAME_TX_TYPE`, `VERIFY`, `EXPIRY_VERIFIER`, frame modes, and `TXPARAM`, have the meanings defined in [EIP-8141](./eip-8141.md).
+This specification is a delta against [EIP-8141](./eip-8141.md). Terms not defined here, including `FrameTx`, `FRAME_TX_TYPE`, `VERIFY`, frame modes, and `TXPARAM`, have the meanings defined in [EIP-8141](./eip-8141.md).
 
 ### Constants
 


### PR DESCRIPTION
That's what it'd look like if we'd revert back from using a special-target VERIFY frame for the expiry mechanism and instead have it be a new frame mode.