### PR TITLE
Update EIP-8141: state that installing the expiry verifier leaves the nonce

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -332,7 +332,7 @@ An expiry verifier frame is invalid unless all of the following hold:
 
 A transaction can contain at most one expiry verifier frame.
 
-At activation, clients must install the following expiry verifier contract runtime code at `EXPIRY_VERIFIER`. The expiry verifier contract's runtime code must be:
+At activation, clients must install the following expiry verifier contract runtime code at `EXPIRY_VERIFIER`. Only the code is installed: the account's nonce, balance and storage are unchanged, so an account that did not previously exist is left at nonce 0. The expiry verifier contract's runtime code must be:
 
 ```asm
 push1 0x08


### PR DESCRIPTION
The expiry verifier install specifies the runtime code and nothing else:

> At activation, clients must install the following expiry verifier contract runtime code at `EXPIRY_VERIFIER`.

That leaves the account's nonce open. The other system-contract predeploys sit at nonce 1, which invites copying — but there the nonce is a consequence of the deployment mechanism rather than a chosen value. [EIP-2935](./eip-2935.md) says so directly: the bytecode "will be deployed à la [EIP-4788](./eip-4788.md). As such the account at `HISTORY_STORAGE_ADDRESS` will have code and a nonce of 1". [EIP-7002](./eip-7002.md) and [EIP-7251](./eip-7251.md) likewise derive a synthetic sender from a deployment transaction.

EIP-8141 installs code at activation with no deployment transaction, so no account creation occurs and nothing sets a nonce. The reference implementation preserves the existing nonce, and the fixtures place `EXPIRY_VERIFIER` at nonce 0 in both pre- and post-state.

The distinction is consensus-visible: writing a nonce adds a state change and, under [EIP-7928](./eip-7928.md), an entry in the block-level access list.

The EIP-161 concern that motivates mentioning the nonce elsewhere does not arise here — the account has code, so it is not empty and is not subject to state clearing at nonce 0.

This states the existing behaviour; it does not change it.
