### PR TITLE
Update EIP-1186: repoint dead ethereum/wiki JSON-RPC links

### DIFF
--- a/EIPS/eip-1186.md
+++ b/EIPS/eip-1186.md
@@ -33,17 +33,17 @@ Offering these already existing function through the RPC-Interface as well would
 
 As Part of the eth-Module, an additional Method called `eth_getProof` should be defined as follows:
 
-#### eth_getProof
+### eth_getProof
 
 Returns the account- and storage-values of the specified account including the Merkle-proof.  
 
-##### Parameters
+#### Parameters
 
 1. `DATA`, 20 Bytes - address of the account.
 2. `ARRAY`, 32 Bytes - array of storage-keys which should be proofed and included. See [`eth_getStorageAt`](./eip-1474.md#eth_getstorageat)  
 3. `QUANTITY|TAG` - integer block number, or the string `"latest"` or `"earliest"`, see the [default block parameter](./eip-1474.md#block-identifier)
 
-##### Returns
+#### Returns
 
 `Object` - A account object:
 
@@ -59,7 +59,7 @@ Returns the account- and storage-values of the specified account including the M
       - `proof`: `ARRAY` - Array of rlp-serialized MerkleTree-Nodes, starting with the storageHash-Node, following the path of the SHA3 (key) as path. 
       
 
-##### Example
+#### Example
 
 
 ```json
@@ -135,4 +135,5 @@ Since this only adds a new Method there are no issues with Backwards Compatibili
 TODO: Tests still need to be implemented, but the core function creating the proof already exists inside the clients and are well tested.
 
 ## Copyright
+
 Copyright and related rights waived via [CC0](../LICENSE.md).

--- a/EIPS/eip-1186.md
+++ b/EIPS/eip-1186.md
@@ -40,16 +40,16 @@ Returns the account- and storage-values of the specified account including the M
 ##### Parameters
 
 1. `DATA`, 20 Bytes - address of the account.
-2. `ARRAY`, 32 Bytes - array of storage-keys which should be proofed and included. See [`eth_getStorageAt`](https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_getstorageat)  
-3. `QUANTITY|TAG` - integer block number, or the string `"latest"` or `"earliest"`, see the [default block parameter](https://github.com/ethereum/wiki/wiki/JSON-RPC#the-default-block-parameter)
+2. `ARRAY`, 32 Bytes - array of storage-keys which should be proofed and included. See [`eth_getStorageAt`](./eip-1474.md#eth_getstorageat)  
+3. `QUANTITY|TAG` - integer block number, or the string `"latest"` or `"earliest"`, see the [default block parameter](./eip-1474.md#block-identifier)
 
 ##### Returns
 
 `Object` - A account object:
 
-  - `balance`: `QUANTITY` - the balance of the account. See [`eth_getBalance`](https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_getbalance) 
+  - `balance`: `QUANTITY` - the balance of the account. See [`eth_getBalance`](./eip-1474.md#eth_getbalance) 
   - `codeHash`: `DATA`, 32 Bytes - hash of the code of the account. For a simple Account without code it will return `"0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"` 
-  - `nonce`: `QUANTITY`, - nonce of the account. See [`eth_getTransactionCount`](https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_gettransactioncount) 
+  - `nonce`: `QUANTITY`, - nonce of the account. See [`eth_getTransactionCount`](./eip-1474.md#eth_gettransactioncount) 
   - `storageHash`: `DATA`, 32 Bytes - SHA3 of the StorageRoot. All storage will deliver a MerkleProof starting with this rootHash.
   - `accountProof`: `ARRAY` - Array of rlp-serialized MerkleTree-Nodes, starting with the stateRoot-Node, following the path of the SHA3 (address) as key. 
   - `storageProof`: `ARRAY` - Array of storage-entries as requested. Each entry is an object with these properties:


### PR DESCRIPTION
Fixing four broken links in EIP-1186. Scope is one EIP, one topic, per the contributor guidelines.

## The problem

The JSON-RPC references point at `github.com/ethereum/wiki`, which no longer serves that content. All four 404:

```
404  https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_getstorageat
404  https://github.com/ethereum/wiki/wiki/JSON-RPC#the-default-block-parameter
404  https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_getbalance
404  https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_gettransactioncount
```

(checked with `curl -o /dev/null -w '%{http_code}' -L`)

## The change

They now point at EIP-1474, which specifies each of these methods and which EIP-1186 already lists in `requires: 1474`:

| line | was | now |
|---|---|---|
| 43 | `.../JSON-RPC#eth_getstorageat` | `./eip-1474.md#eth_getstorageat` |
| 44 | `.../JSON-RPC#the-default-block-parameter` | `./eip-1474.md#block-identifier` |
| 50 | `.../JSON-RPC#eth_getbalance` | `./eip-1474.md#eth_getbalance` |
| 52 | `.../JSON-RPC#eth_gettransactioncount` | `./eip-1474.md#eth_gettransactioncount` |

EIP-1474 felt like the right target rather than an external docs site: it is the in-repo specification for these methods, it is already a declared dependency of this EIP, and its `Block Identifier` section happens to list `eth_getProof` among the methods that take that parameter — which is exactly what EIP-1186 defines.

All four anchors exist on the rendered page (`id="eth_getbalance"`, `id="eth_getstorageat"`, `id="eth_gettransactioncount"`, `id="block-identifier"` in the HTML of https://eips.ethereum.org/EIPS/eip-1474). The relative-link-with-anchor form matches existing usage elsewhere in the repo, e.g. `[`Quantity`](./eip-1474.md#quantity)`.

## eipw

The change removes four warnings the linter was already emitting on these lines:

```
warning[markdown-rel-links]: non-relative link or image
  --> EIPS/eip-1186.md:43:88
  --> EIPS/eip-1186.md:44:93
  --> EIPS/eip-1186.md:50:61
  --> EIPS/eip-1186.md:52:54
```

Running `eipw -c config/eipw.toml EIPS/eip-1186.md` before and after, the only difference is those four disappearing. The nine remaining warnings (`preamble-req`, `preamble-re-discussions-to`, `preamble-len-title`) are pre-existing and untouched.

## Notes

- EIP-1186 is `Stagnant`, not Final, so this isn't constrained to errata-only changes — though a link repair would qualify either way.
- The one other wiki-style link in the file, `zsfelfoldi/go-ethereum/wiki/Light-Ethereum-Subprotocol...` on line 27, still resolves (200) and is left alone.
- Trailing whitespace on lines 43/50/52 is pre-existing and byte-identical to `master`; I left it rather than mixing an unrelated whitespace change into this PR.

cc @simon-jentzsch @cjentzsch