### PR TITLE
Update EIP-8141: fix calldata floor to use EIP-7976 uniform token count

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -463,6 +463,9 @@ def tokens_in(data):
     nonzero_bytes = len(data) - zero_bytes
     return zero_bytes + nonzero_bytes * 4
 
+def floor_tokens_in(data):
+    return len(data) * 4
+
 def calldata_cost(data):
     return STANDARD_TOKEN_COST * tokens_in(data)
 
@@ -495,9 +498,9 @@ standard_gas_limit = (
     + sum(frame.limits.state for frame in tx.frames)
 )
 
-calldata_tokens = (
-    sum(tokens_in(frame.data) for frame in tx.frames)
-    + sum(tokens_in(sig.signer) + tokens_in(sig.msg) + tokens_in(sig.signature) for sig in tx.signatures)
+calldata_floor_tokens = (
+    sum(floor_tokens_in(frame.data) for frame in tx.frames)
+    + sum(floor_tokens_in(sig.signer) + floor_tokens_in(sig.msg) + floor_tokens_in(sig.signature) for sig in tx.signatures)
 )
 
 calldata_floor_gas = (
@@ -505,13 +508,13 @@ calldata_floor_gas = (
     + len(tx.frames) * FRAME_TX_PER_FRAME_COST
     + signature_verification_cost
     + value_transfer_cost
-    + TOTAL_COST_FLOOR_PER_TOKEN * calldata_tokens
+    + TOTAL_COST_FLOOR_PER_TOKEN * calldata_floor_tokens
 )
 
 max_gas = max(standard_gas_limit, calldata_floor_gas + sum(frame.limits.state for frame in tx.frames))
 ```
 
-`frame_tx_intrinsic_gas` is the transaction's intrinsic cost in the sense of [EIP-2780](./eip-2780.md). It is derivable from the transaction fields alone, with no state access. It is charged entirely in the execution dimension and, together with the sum of the declared frame execution-gas limits, is limited by the [EIP-7825](./eip-7825.md) cap explained in [Constraints](#constraints). `value_transfer_cost` charges `TX_VALUE_COST` for each frame which carries value, covering the recipient balance write and transfer log exactly as EIP-2780 prices top-level value transfers. State dependent costs do not enter this calculation and are charged at runtime inside frame state-gas budgets, as described below.
+`frame_tx_intrinsic_gas` is the transaction's intrinsic cost in the sense of [EIP-2780](./eip-2780.md). It is derivable from the transaction fields alone, with no state access. It is charged entirely in the execution dimension and, together with the sum of the declared frame execution-gas limits, is limited by the [EIP-7825](./eip-7825.md) cap explained in [Constraints](#constraints). `value_transfer_cost` charges `TX_VALUE_COST` for each frame which carries value, covering the recipient balance write and transfer log exactly as EIP-2780 prices top-level value transfers. State dependent costs do not enter this calculation and are charged at runtime inside frame state-gas budgets, as described below. The two token counts differ as in [EIP-7976](./eip-7976.md): the standard intrinsic prices the weighted count (`tokens_in`), while the floor prices every charged byte uniformly (`floor_tokens_in`).
 
 ###### Frame gas pools
 


### PR DESCRIPTION
`calldata_floor_gas` multiplies `TOTAL_COST_FLOOR_PER_TOKEN` by `calldata_tokens`, which is built from `tokens_in()`, the weighted count (`zero_bytes + nonzero_bytes * 4`). Combined with `TOTAL_COST_FLOOR_PER_TOKEN = 16`, that prices the floor at 16 gas per zero byte and 64 per nonzero byte, which matches neither EIP-7623 (10/40, weighted count) nor EIP-7976 (64/64, uniform count). The constant is already taken from EIP-7976, so the token count should come from there too.

This adds a `floor_tokens_in()` helper and prices the floor over it, mirroring EIP-7976's distinction between `tokens_in_calldata` and `floor_tokens_in_calldata`.

No implementation change is implied: execution-specs already counts floor tokens uniformly (see https://github.com/ethereum/execution-specs/pull/3396), both for ordinary Amsterdam transactions and in the in-flight EIP-8141 update, and ethrex matches. Only the EIP text diverged.
