### PR TITLE
Update EIP-8141: charge the resolved target's access at frame entry

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -404,6 +404,7 @@ Then for each frame:
     - At frame entry, initialize the frame's gas pools per [Gas Accounting](#gas-accounting): `gas_left = frame.limits.execution` and `state_gas_left = frame.limits.state`.
     - Let `resolved_target = frame.target if frame.target is not None else tx.sender`
         - Unless otherwise stated, checks that refer to the target account during execution use the resolved target.
+    - Charge the resolved target's warm or cold account access ([EIP-2929](./eip-2929.md)) from `gas_left`, before the balance check and before dispatch. Resolving the target's code is how the frame is dispatched, so the charge applies uniformly, whether the frame goes on to run contract code, delegated code, or the [default code](#default-code). If `gas_left` cannot cover the charge, the frame halts exceptionally.
     - Set frame's `caller`:
         - If mode is `SENDER`:
             - `sender_approved` must be `true`. If not, the transaction is invalid.
@@ -412,7 +413,7 @@ Then for each frame:
             - Set `caller` to `ENTRY_POINT`.
         - The `ORIGIN` opcode returns frame's `caller` throughout all call depths.
     - In the top-level frame call, `CALLVALUE` is `frame.value`.
-        - As with an ordinary `CALL`, if the caller does not have sufficient balance to transfer `frame.value`, the frame reverts.
+        - As with an ordinary `CALL`, if the caller does not have sufficient balance to transfer `frame.value`, the frame reverts, consuming the gas charged so far.
         - If `frame.value > 0` and `resolved_target` does not exist, `STATE_BYTES_PER_NEW_ACCOUNT * CPSB` state gas is charged after the balance check and before the frame's code executes, as in [EIP-2780](./eip-2780.md). If `state_gas_left` cannot cover the charge, the frame halts exceptionally.
         - A non-zero value transfer to an address other than `tx.sender` emits the transfer log specified by [EIP-7708](./eip-7708.md).
     - If `resolved_target` code hash is empty, i.e. `0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470`, execute the logic described in [default code](#default-code).
@@ -436,7 +437,7 @@ After executing all frames, verify that `payer` has been set (i.e. `payer != Non
 
 A few cross-frame interactions to note:
 
-- When frame-transaction processing begins, `accessed_addresses` is initialized as in [EIP-2929](./eip-2929.md) and [EIP-3651](./eip-3651.md) (`tx.sender`, the coinbase, and precompiles warm), and `accessed_storage_keys` empty (there is no access list). Being a frame target does not warm an address: a `resolved_target`'s warm/cold access is charged within the frame's own `limits.execution`. The payer is added to `accessed_addresses` when an `APPROVE` with payment scope sets it and collects `max_cost`, as for any protocol-touched account. `ENTRY_POINT` is not pre-warmed, so `ORIGIN` is cold in `DEFAULT` and `VERIFY` frames (where it is `ENTRY_POINT`) and warm in a `SENDER` frame (where it is `tx.sender`).
+- When frame-transaction processing begins, `accessed_addresses` is initialized as in [EIP-2929](./eip-2929.md) and [EIP-3651](./eip-3651.md) (`tx.sender`, the coinbase, and precompiles warm), and `accessed_storage_keys` empty (there is no access list). Being a frame target does not warm an address: a `resolved_target`'s warm/cold access is charged at frame entry within the frame's own `limits.execution`. The payer needs no separate warming rule: it is the executing frame's `resolved_target`, whose access was charged at frame entry and journaled like any other [EIP-2929](./eip-2929.md) access. `ENTRY_POINT` is not pre-warmed, so `ORIGIN` is cold in `DEFAULT` and `VERIFY` frames (where it is `ENTRY_POINT`) and warm in a `SENDER` frame (where it is `tx.sender`).
 - For the purposes of gas accounting of warm / cold state status, the journal of such touches is shared across frames.
 - If a frame reverts, warm / cold status reverts to the state before the frame.
 - State-gas ownership records and changes to frame receipts' `gas_used.state` fields journaled alongside the state changes that produced them. Reverting a call, frame, or atomic batch restores all of them to the corresponding checkpoint.
@@ -663,6 +664,8 @@ Frame transactions can be used by accounts who do not have deployed code, nor an
   - Call `APPROVE(allowed_scope)`.
 - If `mode` is `SENDER` or `DEFAULT`:
   - Return successfully as if calling empty code.
+
+The default code draws no execution gas of its own: the frame's only execution charge is the resolved target's access, taken at frame entry ([Behavior](#behavior)). Its `APPROVE` may charge state gas for sender-account creation, as specified in the [`APPROVE`](#approve-instruction-0xaa) instruction's behavior. A frame whose `limits.execution` cannot cover the entry access charge halts exceptionally before the default code is evaluated — which, for a `VERIFY` frame, invalidates the transaction.
 
 ### `APPROVE` Instruction (`0xaa`)
 
@@ -1168,6 +1171,10 @@ Approval scope flags are disallowed on the frames of an atomic batch, including 
 ### Per-frame cost
 
 Each frame incurs a fixed CALL execution-context overhead (100) plus `G_log` (375) for the receipt sub-entry it produces, giving `FRAME_TX_PER_FRAME_COST = 475`. The execution-context component covers context setup, mode dispatch, and the two-pool gas accounting at the frame boundary, analogous to the fixed overhead of a CALL. The `G_log` component covers the `[status, gas_used, logs]` receipt sub-entry that each frame adds to the transaction receipt, which must be serialized, hashed into the receipt trie, and proven by ZK-EVM implementations. Cold/warm access costs for the frame's target account are charged within the frame's own `limits.execution` through the normal EVM warm/cold accounting, not through the per-frame cost.
+
+### Frame entry access charge
+
+The resolved target's warm/cold access is charged at frame entry, before the balance check and before dispatch, because resolving the target's code — the read the charge prices — is what dispatch is. Charging at entry makes the cost uniform across dispatch outcomes: a frame pays the same access whether its target carries contract code, an [EIP-7702](./eip-7702.md) delegation, or no code at all. This follows the same principle as the expiry verifier frame, which consumes gas according to normal EVM execution rules even when clients evaluate it directly: protocol-defined evaluation is an optimization, never a pricing change. It also keeps sponsorship neutral: a code-less payer approving through the default code and a contract payer approving through its own code price identically, and the payer needs no separate warming rule, since the payer is always the executing frame's resolved target. The intrinsic cost's payer-settlement component covers the settlement balance writes — the escrow and the refund — not the payer's first account touch, which is this charge.
 
 ### Per-frame value
 


### PR DESCRIPTION
The spec charges a `resolved_target`'s warm/cold access "within the frame's own `limits.execution`" but never says when, and defines no execution cost at all for frames dispatched to the default code. Implementations can therefore diverge on the frame receipt's `gas_used.execution`, on warmth, and on validity itself (a default-code `VERIFY` frame with `limits.execution = 0` is valid under one reading, invalid under the other).

This pins one rule: the target's access is charged at frame entry, before the balance check and before dispatch — resolving the target's code is the read the charge prices, so it applies uniformly to contract code, delegated code, and the default code. Consequences:

- The separate payer-warming rule becomes unnecessary: the payer is always the executing frame's resolved target, already charged and journaled at entry.
- A value frame failing the balance check reverts consuming the gas charged so far, matching ordinary `CALL` ordering.
- A new Rationale section records why: dispatch is the priced read, protocol evaluation must not change observable gas (the expiry-verifier principle), and sponsorship prices identically for code-less and contract payers. The intrinsic's payer-settlement component covers the settlement balance writes, not the payer's first account touch.
