### PR TITLE
Update EIP-8141: scope APPROVE failure modes to the current call frame

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -528,7 +528,7 @@ The pools are independent:
 - State-gas draws from `state_gas_left` only. `state_gas_left` is frame-scoped. EVM call frames at any depth within the frame draw from it directly. It is not forwarded, split, or divided per callframe like execution gas.
 - A charge exceeding its remaining pool is an exceptional halt of the current callframe, with ordinary out-of-gas semantics. Execution gas can never be spent on state charges.
 
-Charge points follow EIP-8037 unchanged. `SSTORE` state gas at the end of the opcode, the conditional account-creation charge of the `CALL*` and `CREATE`/`CREATE2` families in the creating frame, and code-deposit gas at deposit time. In addition, the frame-level account creation charge for value carrying frames ([Behavior](#behavior)) and the account creation charge applied by [`APPROVE`](#approve-instruction-0xaa) mirror EIP-2780's runtime account creation charges. A charge that exhausts either pool fails the frame rather than changing the transaction's static validity. As specified above, failure of a `VERIFY` frame nevertheless makes the transaction invalid.
+Charge points follow EIP-8037 unchanged. `SSTORE` state gas at the end of the opcode, the conditional account-creation charge of the `CALL*` and `CREATE`/`CREATE2` families in the creating frame, and code-deposit gas at deposit time. In addition, the frame-level account creation charge for value carrying frames ([Behavior](#behavior)) and the account creation charge applied by [`APPROVE`](#approve-instruction-0xaa) mirror EIP-2780's runtime account creation charges. A charge that exhausts either pool halts the current call frame rather than changing the transaction's static validity. As specified above, failure of a `VERIFY` frame nevertheless makes the transaction invalid.
 
 ###### State-gas attribution and refills
 
@@ -666,7 +666,7 @@ Frame transactions can be used by accounts who do not have deployed code, nor an
 
 ### `APPROVE` Instruction (`0xaa`)
 
-The `APPROVE` instruction exits the current EVM call frame successfully and updates the transaction-scoped approval context based on the `scope` operand. The `offset` and `length` operands designate a memory region that becomes the frame's return data, following `RETURN` semantics.
+The `APPROVE` instruction exits the current EVM call frame successfully and updates the transaction-scoped approval context based on the `scope` operand. The `offset` and `length` operands designate a memory region that becomes the call frame's return data, following `RETURN` semantics.
 
 #### Stack
 
@@ -698,20 +698,20 @@ The behavior of `APPROVE` is defined as follows:
     - To check this, evaluate that `scope != 0` and `scope & ~(frame.flags & APPROVE_SCOPE_MASK) == 0`.
 - Depending on the value of `scope`, perform the following:
     - For `APPROVE_EXECUTION`:
-        - If `sender_approved == true`, revert the frame.
-        - If `resolved_target != tx.sender`, revert the frame.
+        - If `sender_approved == true`, revert the current call frame.
+        - If `resolved_target != tx.sender`, revert the current call frame.
         - Set `sender_approved = true`.
     - For `APPROVE_PAYMENT`
-        - If `payer` was already set, revert the frame.
-        - If `resolved_target` has insufficient balance, revert the frame.
-        - If `sender_approved == false`, revert the frame.
-        - Immediately before incrementing the sender's nonce, if `tx.sender` does not exist under the existence rule of [EIP-8037](./eip-8037.md), charge `STATE_BYTES_PER_NEW_ACCOUNT * CPSB` from the current frame's `state_gas_left`. If the pool cannot cover the charge, halt the frame exceptionally without applying any approval effects.
+        - If `payer` was already set, revert the current call frame.
+        - If `resolved_target` has insufficient balance, revert the current call frame.
+        - If `sender_approved == false`, revert the current call frame.
+        - Immediately before incrementing the sender's nonce, if `tx.sender` does not exist under the existence rule of [EIP-8037](./eip-8037.md), charge `STATE_BYTES_PER_NEW_ACCOUNT * CPSB` from the current frame's `state_gas_left`. If the pool cannot cover the charge, halt the current call frame exceptionally without applying any approval effects.
         - Increment the sender's nonce, set `payer = resolved_target`, and collect the transaction's `max_cost` from `payer`.
     - For `APPROVE_EXECUTION_AND_PAYMENT`:
-        - If `sender_approved` or `payer` was already set, revert the frame.
-        - If `resolved_target` != `tx.sender`, revert the frame.
-        - If `resolved_target` has insufficient balance, revert the frame.
-        - Immediately before incrementing the sender's nonce, if `tx.sender` does not exist under the existence rule of [EIP-8037](./eip-8037.md), charge `STATE_BYTES_PER_NEW_ACCOUNT * CPSB` from the current frame's `state_gas_left`. If the pool cannot cover the charge, halt the frame exceptionally without applying any approval effects.
+        - If `sender_approved` or `payer` was already set, revert the current call frame.
+        - If `resolved_target` != `tx.sender`, revert the current call frame.
+        - If `resolved_target` has insufficient balance, revert the current call frame.
+        - Immediately before incrementing the sender's nonce, if `tx.sender` does not exist under the existence rule of [EIP-8037](./eip-8037.md), charge `STATE_BYTES_PER_NEW_ACCOUNT * CPSB` from the current frame's `state_gas_left`. If the pool cannot cover the charge, halt the current call frame exceptionally without applying any approval effects.
         - Set `sender_approved = true`, increment the sender's nonce, set `payer = resolved_target`, and collect the transaction's `max_cost` from `payer`.
 
 #### Gas
@@ -1201,7 +1201,7 @@ Crediting a cross-frame refill to the executing frame would hand it budget it ne
 
 Value-bearing frames are charged `TX_VALUE_COST` for the recipient balance write and transfer log, as EIP-2780 charges top-level transfers. The charge is static because `value` and `target` are transaction fields. Frame targets do not pay EIP-2780's unconditional cold-rate recipient touch. Frames behave like internal calls, which stay on the [EIP-2929](./eip-2929.md) warm/cold model, and a transaction repeatedly targeting the same account would otherwise overpay.
 
-EIP-2780's split between intrinsic and runtime gas carries over. Intrinsic gas is state-independent and decides validity. Every state-dependent charge, including frame-entry account creation and sender creation by `APPROVE`, is metered inside a frame's `limits.state`. Exhausting it fails the frame. After approval the transaction is still included and pays for the gas consumed, while a failed `VERIFY` frame invalidates the transaction as usual.
+EIP-2780's split between intrinsic and runtime gas carries over. Intrinsic gas is state-independent and decides validity. Every state-dependent charge, including frame-entry account creation and sender creation by `APPROVE`, is metered inside a frame's `limits.state`. Exhausting it halts the current call frame. After approval the transaction is still included and pays for the gas consumed, while a failed `VERIFY` frame invalidates the transaction as usual.
 
 ### Transaction execution gas cap
 


### PR DESCRIPTION
The `APPROVE` behavior section words precondition failures as "revert the frame" and "halt the frame exceptionally", while the ADDRESS and scope checks say only "revert" — readable as aborting the entire 8141-frame from any call depth. That reading contradicts the rest of the spec: `APPROVE`'s success path "exits the current EVM call frame", the gas-pools section defines a pool-exhausting charge as "an exceptional halt of the current callframe". A whole-frame abort from arbitrary depth would also be a control-flow primitive nothing else in the EVM has — even exceptional halts only consume the current call frame.