### PR TITLE
Update EIP-8347: hashed-key order and fixed-width preimage records

### DIFF
--- a/EIPS/eip-8347.md
+++ b/EIPS/eip-8347.md
@@ -84,22 +84,20 @@ The MPT is hash-keyed, and most clients do not persist the plain account address
 
 Recovering the full set is the expensive part, and the anchor state alone does not yield it, since Keccak cannot be inverted. A preimage is either retained when the key is first seen, or recovered by replaying the chain. Block-Level Access Lists ([EIP-7928](./eip-7928.md)) carry plain addresses and slot keys, so they yield preimages for every key touched since BAL activation, but the anchor state also holds long-dormant keys untouched since then. A complete set therefore needs a client-side preimage store or a full replay; BALs shorten the work without removing it.
 
-The preimage file is a concatenation of per-account records with no framing between them. Each record is the RLP encoding of:
+The preimage file is a concatenation of fixed-width per-account records with no framing between them. Each record is:
 
 ```text
-[address, [slotKey, slotKey, ...]]
+address[20] | slotCount[4, big-endian] | slotKey[32] * slotCount
 ```
 
-that is, the 20-byte account address followed by the list of that account's storage-slot keys. An account with no storage carries an empty list. RLP framing makes each record self-delimiting, so the file is parsed by decoding records sequentially until end of input. The file ends immediately after the final record. There is no terminator, padding, or trailing newline, and any trailing byte makes the file invalid.
+that is, the 20-byte account address, the number of that account's storage-slot keys as a 4-byte big-endian integer, then each slot key as the full 32-byte big-endian slot number, leading zero bytes included. An account with no storage carries `slotCount == 0`. `slotCount` makes each record self-delimiting, so the file is parsed by reading records sequentially until end of input. The file ends immediately after the final record. There is no terminator, padding, or trailing newline, and any trailing byte makes the file invalid.
 
-The file MUST be byte-canonical, so independent producers emit bit-identical output. To achieve this, the encoding and ordering are fixed:
+The file MUST be byte-canonical, so independent producers emit bit-identical output. Keys are ordered by their hash:
 
-- `address` MUST be encoded as exactly 20 bytes, including any leading zero bytes.
-- Each `slotKey` MUST be encoded as a canonical RLP integer: the 256-bit slot number in big-endian form, with all leading zero bytes removed. Slot 0 encodes as the empty string, slot 1 as a single byte. A leading zero byte makes the record invalid. Most slot keys are mapping-derived and fill all 32 bytes, but low-numbered slots are common and this drops their padding.
-- Records MUST be sorted by `address` ascending, compared as 20-byte big-endian (byte-lexicographic) values. Each address MUST appear at most once.
-- Within a record, `slotKey` entries MUST be sorted ascending by slot number, with no duplicates.
+- Records MUST be sorted ascending by `keccak256(address)`, compared byte-lexicographically. Each address MUST appear at most once.
+- Within a record, `slotKey` entries MUST be sorted ascending by `keccak256(slotKey)`, with no duplicates.
 
-A verifier recovers the MPT account path as `keccak256(address)` and each storage path as `keccak256(slotKey)`, where `slotKey` is first left-padded back to 32 bytes. This is what makes the consensus-anchoring check against `ANCHOR_BLOCK`'s header `stateRoot` possible.
+These sort keys are exactly the MPT paths: a verifier recovers the account path as `keccak256(address)` and each storage path as `keccak256(slotKey)`, which is what makes the consensus-anchoring check against `ANCHOR_BLOCK`'s header `stateRoot` possible. Hashed-key order therefore lays the file out in MPT iteration order, over the account trie and within each account's storage trie alike, so its two consumers, the consensus-anchoring re-hash and a hash-keyed self-converter, walk their trie and the file as one sequential merge, with no random access and no index held in memory. The producer pays the sort once, with the same external merge-sort the snapshot build already requires.
 
 Grouping slot keys under their account is deliberate. A globally deduplicated list would be smaller, but only slightly: the repetition sits in low-numbered slots, while most storage keys are mapping-derived and unique to one account. Grouping buys something better, namely that a converter can stream one account's storage trie at a time rather than hold a global lookup table in memory.
 
@@ -108,7 +106,7 @@ Grouping slot keys under their account is deliberate. A globally deduplicated li
 The converter is a deterministic function from MPT state to PBT state. Given the state at `ANCHOR_BLOCK` (i.e., the MPT, the contract bytecode it references, and the preimages), it MUST:
 
 1. Scan the source (MPT) leaves, recovering each leaf's full hashed path. A leaf node holds only the tail of that path, so the walk accumulates the rest from the branch indices and extension segments above it. The path is `keccak256(address)` in the account trie and `keccak256(slotKey)` in a storage trie, where `slotKey` is the 32-byte big-endian slot number.
-2. Index the preimages by `keccak256(preimage)`, and require that this index and the set of leaf paths from step 1 match **exactly**, in both directions. A leaf path with no preimage means the set is incomplete. A preimage matching no leaf path means the set is not the one committed by `ANCHOR_BLOCK`'s `stateRoot`. The converter MUST reject either case. Per-leaf hash equality is not a check on its own, since a preimage is only ever found by hashing it. What is enforced is the exact match of the two sets.
+2. Match the preimages, by `keccak256(preimage)`, against the leaf paths from step 1, and require that the two sets match **exactly**, in both directions. The [preimage file](#preimages) is sorted by these very hashes, so the match runs as a sequential merge against the scan. A leaf path with no preimage means the set is incomplete. A preimage matching no leaf path means the set is not the one committed by `ANCHOR_BLOCK`'s `stateRoot`. The converter MUST reject either case. Per-leaf hash equality is not a check on its own, since a preimage is only ever found by hashing it. What is enforced is the exact match of the two sets.
 3. Derive PBT keys per [EIP-8297](./eip-8297.md) using the preimages. Most of an account's state lands under its header stem in `ACCOUNT_ZONE`: basic data, `code_hash` or a delegation, and storage slots 0 through 63 at sub-indices `HEADER_STORAGE_OFFSET`..`HEADER_STORAGE_OFFSET + 63`. Only slots 64 and above take storage-zone keys.
 4. For each account with code, fetch the bytecode from the code store using the account's `code_hash`, chunk it per [EIP-8297](./eip-8297.md), and emit the resulting code leaves in `CODE_ZONE`, content-addressed by `code_hash`, so accounts sharing bytecode share them: a converter MUST emit each code leaf exactly once, since a duplicate key would break byte-canonicality. A chunk whose 32-byte value is all zero, that is 31 zero code bytes carrying no PUSHDATA, MUST NOT be emitted, since [EIP-8297](./eip-8297.md) requires a zero-valued key to be absent. An account whose code is a delegation indicator instead takes a single header leaf at `DELEGATION_LEAF_KEY`, and emits neither code leaves nor a `code_hash` leaf.
 5. Sort leaves by PBT key order (an external merge-sort for mainnet-scale state).
@@ -149,7 +147,7 @@ Each leaf of the [EIP-8297](./eip-8297.md) PBT is serialized as the RLP encoding
 [key, value]
 ```
 
-where `key` is the full PBT tree key and `value` its 32-byte leaf value. As in the [preimage file](#preimages), RLP framing makes each record self-delimiting and the encoding is pinned so that producers agree byte for byte:
+where `key` is the full PBT tree key and `value` its 32-byte leaf value. RLP framing makes each record self-delimiting and the encoding is pinned so that producers agree byte for byte:
 
 - `key` MUST be encoded at its full zone-determined length, including any leading zero bytes.
 - `value` MUST be encoded as a canonical RLP integer: the 32-byte leaf value in big-endian form, with all leading zero bytes removed. A leading zero byte makes the record invalid, and so does a value of zero, which [EIP-8297](./eip-8297.md) requires to be absent from the tree rather than stored. This is where most of the saving is. [EIP-8297](./eip-8297.md) packs `version`, `code_size`, `nonce`, and `balance` into the basic-data leaf, low-magnitude fields first. So a typical account header value carries a long run of leading zero bytes, as do small storage values.


### PR DESCRIPTION
Change the preimage file to:

- sort by hashed keys: records by `keccak256(address)`, slot keys inside each record by `keccak256(slotKey)`
- fixed-width format instead of RLP: `address[20] | slotCount[4] | slotKey[32] * slotCount`

Sorted by hash, the file comes out in the same order clients walk the MPT, so importing it is sequential reads instead of random ones. The generator sorts once, every consumer just streams it. Fixed width since we are dropping RLP from the state anyways, and it matches what the Erigon exporter already writes (erigontech/erigon#22645).

This was agreed between the authors but the EIP wasn't reflecting it yet.
