### PR TITLE
Update EIP-8146: CL must deliver the BAL to the EL before the payload

### DIFF
--- a/EIPS/eip-8146.md
+++ b/EIPS/eip-8146.md
@@ -250,9 +250,13 @@ def on_block_access_list_sidecar(store: Store, sidecar: BlockAccessListSidecar) 
     EXECUTION_ENGINE.notify_block_access_list(sidecar.block_access_list, bid.block_hash)
 ```
 
+If the CL cached an execution payload envelope for this `beacon_block_root` because the envelope arrived first, it processes that envelope now, after the BAL has been delivered to the EL.
+
 #### Modified `on_execution_payload_envelope`
 
 BAL availability is required before processing the execution payload. The BAL has already been delivered to the EL via `engine_notifyBlockAccessListV1` when the sidecar was received; `verify_execution_payload_envelope` itself is unchanged.
+
+If the envelope arrives before the sidecar, the BAL availability check fails. The CL MUST NOT drop the envelope in that case: it caches the envelope and runs this handler again once `on_block_access_list_sidecar` has stored the BAL for the same `beacon_block_root`. Until then the envelope MUST NOT be passed to the EL.
 
 ```python
 def on_execution_payload_envelope(
@@ -279,7 +283,7 @@ def on_execution_payload_envelope(
 
 ### Engine API
 
-EIP-8146 splits BAL delivery and payload delivery into two engine calls so the EL can start work on the BAL while the payload envelope is still in flight. The CL forwards the BAL the instant the sidecar passes gossip validation, without waiting for the envelope. This is the operational core of the EIP.
+EIP-8146 splits BAL delivery and payload delivery into two engine calls so the EL can start work on the BAL while the payload envelope is still in flight. The CL forwards the BAL the instant the sidecar passes gossip validation, without waiting for the envelope. This is the operational core of the EIP. Ordering the two calls is the CL's responsibility: for a given `blockHash`, `engine_notifyBlockAccessListV1` MUST be called before `engine_newPayloadV5`.
 
 #### `engine_getPayloadV6`
 
@@ -304,7 +308,7 @@ The CL MUST call this method from `on_block_access_list_sidecar` immediately aft
 
 #### `engine_newPayloadV5`
 
-Unchanged from [EIP-7732](./eip-7732.md). It does not carry the BAL. The EL pairs the incoming payload with the previously delivered BAL by `blockHash` and runs execution against the warmed state. If the BAL has not yet arrived (out-of-order receipt), the EL MAY queue the payload until `engine_notifyBlockAccessListV1` is called for the same `blockHash`.
+Unchanged from [EIP-7732](./eip-7732.md). It does not carry the BAL. The EL pairs the incoming payload with the previously delivered BAL by `blockHash` and runs execution against the warmed state. The CL MUST NOT call `engine_newPayloadV5` for a `blockHash` before it has called `engine_notifyBlockAccessListV1` for that same `blockHash`. If the envelope arrives first, the CL caches it locally and holds it until the matching sidecar arrives. The EL can therefore rely on the BAL being present whenever a payload is delivered.
 
 #### Best-case sequencing
 
@@ -315,6 +319,8 @@ t2:  CL <----------- {status: VALID} ------ EL
 ```
 
 The `t1 - t0` gap is the head start the EIP creates. With the BAL inside the envelope (pre-EIP-8146), `t0 = t1` and the head start is zero.
+
+If the envelope arrives before the sidecar, the CL caches the envelope and sends it only after the BAL, so the order above always holds; the head start is then zero, but the EL never sees a payload without its BAL.
 
 ### Execution Layer
 


### PR DESCRIPTION
Clarifies the ordering between the BAL sidecar and the execution payload.

cc @LukaszRozmej 