### PR TITLE
Update EIP-8198: target 10-second slots and align with the reference specs

### DIFF
--- a/EIPS/eip-8198.md
+++ b/EIPS/eip-8198.md
@@ -13,7 +13,7 @@ requires: 7892
 
 ## Abstract
 
-This EIP makes `SLOT_DURATION_MS` a runtime configuration on the consensus layer rather than a compile-time constant, then uses that infrastructure to reduce slot duration. Block gas limits and blob parameters scale proportionally to maintain constant throughput per unit time.
+This EIP makes the slot duration a scheduled consensus-layer configuration — a `SLOT_DURATION_SCHEDULE` analogous to the `BLOB_SCHEDULE` of [EIP-7892](./eip-7892.md) — rather than a compile-time constant, then uses that infrastructure to reduce slot duration from twelve to ten seconds. Duration-dependent quantities are rescaled by the exact slot-duration ratio, applied inline in each formula, so that issuance, penalties, churn, gas throughput, blob throughput, and fee responsiveness are unchanged per unit of wall-clock time.
 
 ## Motivation
 
@@ -25,7 +25,7 @@ Twelve seconds is slow. It is perceptible in payments, exchange deposits, and ev
 
 ### DEX pricing and MEV
 
-Arbitrage losses scale with the square root of inter-block time. Going from twelve to eight seconds cuts this by roughly 18%, tightening on-chain pricing and reducing value extracted from users. MEV extraction is also non-linear in slot time: shorter slots compress the surplus available per block, squeezing the entire MEV supply chain.
+Arbitrage losses scale with the square root of inter-block time. Going from twelve to ten seconds cuts this by roughly 9%, tightening on-chain pricing and reducing value extracted from users. MEV extraction is also non-linear in slot time: shorter slots compress the surplus available per block, squeezing the entire MEV supply chain.
 
 ### Empty blocks and ePBS
 
@@ -45,92 +45,169 @@ L2s that use the L1 for interop between themselves also inherit the L1's slot du
 
 Nobody knows the safe minimum slot duration with today's client implementations. Rather than stalling on the choice of a number, this EIP separates the work into three phases:
 
-1. **Variable slot timing infrastructure** — Remove the assumption that slots are twelve seconds. Update background task scheduling, timing constants, functions such as `compute_time_at_slot(...)`, and fork transition logic to derive timing from a runtime configuration.
+1. **Variable slot timing infrastructure** — Remove the assumption that slots are twelve seconds. Update background task scheduling, timing constants, functions such as `compute_time_at_slot(...)`, and fork transition logic to derive timing from a scheduled configuration.
 2. **CL performance characterization** — Systematically identify consensus layer bottlenecks through devnets and benchmarks, analogous to the execution layer's bloat-nets and perf-nets. Current understanding of blob propagation limits, attestation aggregation capacity, and local block building times remains incomplete.
 3. **Iterative slot time reduction** — Cut slack from the slot duration based on the results of phase 2. Address client constraints, reduce further as headroom emerges, iterate.
 
-Phase 1 has value regardless of the final number. It turns `SLOT_DURATION_MS` from a compile-time constant into a runtime configuration, so future slot duration changes become configuration updates rather than contentious protocol upgrades. If analysis ultimately shows twelve seconds is optimal, the effort still delivers a cleaner client architecture, a comprehensive CL performance characterization, and the readiness to reduce when conditions permit.
+Phase 1 has value regardless of the final number. It turns the slot duration from a compile-time constant into a scheduled configuration (`SLOT_DURATION_SCHEDULE`), so future slot duration changes become configuration entries rather than contentious protocol upgrades. If analysis ultimately shows twelve seconds is optimal, the effort still delivers a cleaner client architecture, a comprehensive CL performance characterization, and the readiness to reduce when conditions permit.
 
 ## Specification
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119) and [RFC 8174](https://www.rfc-editor.org/rfc/rfc8174).
 
-All arithmetic in this specification uses integer division (truncating toward zero). Formulas are written with the multiply performed before the divide to preserve precision.
+All arithmetic in this specification uses integer division (truncating toward zero) unless otherwise noted. Formulas are written with every multiply performed before the divide (deferred division), so the exact rational ratio applies rather than a rounded intermediate constant.
 
-### Parameters
+### Slot duration schedule
 
-At `<FORK_EPOCH>`, the following constants take effect. All consensus layer timing derivations MUST use the fork-activated values from the fork epoch onward. Functions that compute wall-clock time from slot numbers, such as `compute_time_at_slot(...)`, MUST account for the duration change at the fork boundary.
+A new consensus-layer configuration, `SLOT_DURATION_SCHEDULE`, is introduced following the `BLOB_SCHEDULE` mechanism of [EIP-7892](./eip-7892.md): a list of records, each activating a new slot duration (in milliseconds) at an epoch. A helper `get_slot_duration_ms(epoch)` returns the duration in effect at a given epoch; epochs before the first entry use `SLOT_DURATION_MS` (12,000), which is unchanged and remains the pre-schedule base duration.
 
-| Constant | Current | New |
-| -------- | ------- | --- |
-| `SLOT_DURATION_MS` | 12,000 | 8,000 |
-| `BASE_REWARD_FACTOR` | 64 | 42 |
-| `INACTIVITY_PENALTY_QUOTIENT_BELLATRIX` | 16,777,216 | 37,748,736 |
-| `MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS` | 4,096 | 6,144 |
-| `MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS` | 4,096 | 6,144 |
-| `CHURN_LIMIT_QUOTIENT` | 65,536 | 98,304 |
-| `MIN_PER_EPOCH_CHURN_LIMIT_ELECTRA` | 128,000,000,000 | 85,333,333,333 |
-| `MAX_PER_EPOCH_ACTIVATION_EXIT_CHURN_LIMIT` | 256,000,000,000 | 170,666,666,666 |
+The schedule MUST satisfy the following:
 
-### Gas limit adjustment
+- There MUST NOT exist multiple entries with the same epoch value.
+- The epoch of each entry MUST be greater than or equal to the fork epoch of this EIP. An entry with an epoch of `FAR_FUTURE_EPOCH` is not scheduled and has no effect.
+- The slot duration in each entry MUST be a positive multiple of 1,000 ms, so that every slot boundary has an exact integer-second timestamp.
+- Every entry that changes the slot duration MUST be accompanied by a `BLOB_SCHEDULE` entry at the same epoch, per [Blob schedule](#blob-schedule) below.
+- Entries SHOULD be sorted by epoch in ascending order. The schedule MAY be empty.
 
-The first block produced at or after the fork activation timestamp MUST set its gas limit to:
+The intended first mainnet entry, activating at the fork epoch, is:
+
+| Epoch | Slot duration (ms) |
+| ----- | ------------------ |
+| `<FORK_EPOCH>` | 10,000 |
+
+Throughout this specification, the *slot-duration ratio* `r = get_slot_duration_ms(epoch) / SLOT_DURATION_MS` denotes the ratio of the duration in effect to the pre-schedule duration — `5/6` for the intended entry.
+
+### Wall-clock timeline
+
+Slot boundaries after a duration change are no longer aligned to genesis at a fixed duration, so the mapping between wall-clock time and slot number becomes piecewise over the schedule's eras: each era runs at its own slot duration, starting from the end of the previous era. All conversions between time and slot MUST be derived from this piecewise timeline, in particular:
+
+- Execution payload timestamp validation (`compute_time_at_slot`).
+- The fork choice store clock, which gains millisecond precision (`time_ms`, driven by a new `on_tick_ms` handler; the whole-second `on_tick` remains only as a compatibility adapter). Store initialization from an anchor state past a duration change (e.g. checkpoint sync) MUST derive the initial store time from the piecewise timeline.
+- Every intra-slot timeliness measurement (attestation and payload-timeliness recording, the proposer reorg cutoff, the inclusion list deadline), rebased on a time-into-slot helper rather than `time % SLOT_DURATION_MS`.
+- The gossip slot-range validation gates, duty schedulers, expiry and gossip-scoring windows, and light-client local-clock slot derivation.
+
+Intra-slot deadlines remain specified in basis points of the slot duration and rescale automatically. The deadline helpers gain a `slot` parameter and MUST be evaluated with the duty's slot, whose era determines the duration; the basis-point values themselves are unchanged. Duty schedulers MUST keep millisecond precision, since deadlines are not generally whole seconds.
+
+### Consensus economics
+
+No consensus constant changes value. Instead, the duration-dependent per-epoch rates are rescaled by the exact ratio `r`, applied inline with deferred division:
+
+| Quantity | Scaling | Effect for `r = 5/6` |
+| -------- | ------- | -------------------- |
+| Base reward per increment | `× r` | Effective `BASE_REWARD_FACTOR` of exactly 64 × 5/6 = 53.33 |
+| Inactivity penalty | `× r²` (folded into the penalty denominator) | Effective inactivity penalty quotient × 36/25 |
+| Activation, exit, and consolidation churn limits | `× r` | Effective per-epoch churn × 5/6 |
+
+For the churn limits, the minimum and maximum bounds are applied before scaling — so the bounds are scaled too — and the `EFFECTIVE_BALANCE_INCREMENT` rounding is applied once, after scaling. Exit and consolidation epochs assigned before a duration change keep their assigned epochs and consumed quota.
+
+Epoch- and slot-denominated quantities — withdrawability and slashing windows, sync committee periods, `SLOTS_PER_EPOCH`, per-payload and per-epoch processing limits — keep their counts, so their wall-clock spans scale with the slot duration.
+
+### Data availability retention
+
+The data column sidecar retention window is preserved in wall-clock terms: in the inherited request validations and pruning guidance, the rolling `current_epoch - MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS` term is replaced by a retention-start helper that subtracts the window's pre-schedule wall-clock length (`MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS × SLOTS_PER_EPOCH × SLOT_DURATION_MS`) on the piecewise timeline. The inherited `FULU_FORK_EPOCH` floor is unchanged. A node retaining the inherited window when a change activates never serves a shorter wall-clock history, with no pre-change over-retention or backfill required.
+
+The blob sidecar Req/Resp messages are already deprecated as of `FULU_FORK_EPOCH + MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS`, so their retention window needs no treatment. Epoch-denominated retention windows without a wall-clock target — in particular the block retention window — keep their epoch counts.
+
+### Execution layer
+
+#### Gas limit at a duration change
+
+The first execution payload whose slot duration differs from that of its parent payload scales its gas limit one time by the slot-duration ratio, preserving the gas-per-second throughput target:
 
 ```
-fork_gas_limit = (parent_gas_limit * SLOT_DURATION_MS) // old_slot_duration_ms
+gas_limit_reference = parent_gas_limit * new_slot_duration_ms // old_slot_duration_ms
 ```
 
-where `old_slot_duration_ms` is the pre-fork value (12,000). The normal gas limit adjustment rule (±1/1024) does not apply to this block. From the following block onward, normal gas limit voting resumes using `fork_gas_limit` as the base.
+On the execution layer, this block's gas limit is validated against `gas_limit_reference` with the regular ±1/1024 adjustment band around the rescaled reference (instead of around `parent_gas_limit`). The base fee calculation for this block still derives the parent gas target from the parent's true gas limit. From the following block onward, normal gas limit validation resumes.
 
-### Blob parameter adjustment
+On the consensus layer, the execution payload bid gossip check and the honest builder rule mirror this: at a duration change the bid's gas limit MUST equal `parent_gas_limit` scaled by the ratio of the two durations (rounding down), and the proposer's `target_gas_limit` does not alter this transition. The transition condition is keyed to the slot durations in effect at the parent execution payload's slot and at the bid's slot — not the parent beacon block's — so the one-time scaling cannot be bypassed by missed slots or withheld payloads around a duration change.
 
-A new entry MUST be appended to the `BLOB_SCHEDULE` (as defined in [EIP-7892](./eip-7892.md)) at `<FORK_EPOCH>` with:
+#### Base fee responsiveness
+
+The maximum per-block base fee change is scaled by the slot-duration ratio so the base fee reacts to congestion at the same rate per unit of wall-clock time:
 
 ```
-new_max_blobs = (old_max_blobs * SLOT_DURATION_MS) // old_slot_duration_ms
+base_fee_per_gas_delta = target_fee_gas_delta * new_slot_duration_ms // (old_slot_duration_ms * BASE_FEE_MAX_CHANGE_DENOMINATOR)
 ```
 
-where `old_max_blobs` is the `MAX_BLOBS_PER_BLOCK` from the most recent preceding `BLOB_SCHEDULE` entry. The blob target is derived from `MAX_BLOBS_PER_BLOCK` as usual.
+`BASE_FEE_MAX_CHANGE_DENOMINATOR` itself is unchanged (8). The single deferred division makes the effective maximum per-block change the exact rational `new/old × 1/8` — `5/48` per block (an effective denominator of 9.6) for the intended twelve-to-ten change.
+
+#### Blob schedule
+
+The `BLOB_SCHEDULE` entry accompanying a slot duration change scales the maximum blobs per block by the slot-duration ratio, rounding down:
+
+```
+new_max_blobs = old_max_blobs * new_slot_duration_ms // old_slot_duration_ms
+```
+
+where `old_max_blobs` is the `MAX_BLOBS_PER_BLOCK` from the most recent preceding `BLOB_SCHEDULE` entry. The blob target is scaled from the previous target by the same ratio, rounding to the nearest integer, and `BLOB_BASE_FEE_UPDATE_FRACTION` is rescaled so that the maximum sustained blob base fee growth rate per unit of wall-clock time is preserved. For the intended twelve-to-ten change, starting from a maximum of 21 and target of 14:
+
+| Parameter | Current | New |
+| --------- | ------- | --- |
+| `MAX_BLOBS_PER_BLOCK` | 21 | 17 |
+| `BLOB_SCHEDULE_TARGET` | 14 | 12 |
+| `BLOB_BASE_FEE_UPDATE_FRACTION` | 11,684,671 | 10,015,432 |
+
+#### System contracts
+
+The [EIP-4788](./eip-4788.md) beacon roots contract and the [EIP-2935](./eip-2935.md) block hash history contract keep their 8,191-entry buffers; the buffer lengths are part of the deployed contracts and are deliberately not changed. Their wall-clock coverage shrinks from ~27.3 hours to ~22.8 hours under ten-second slots.
+
+### Networking
+
+- No gossip message types are added and no gossip validation conditions change beyond the gas-limit bid check above. All topics carry over, re-keyed under the new fork digest; clients SHOULD subscribe to the new-digest topics ahead of the fork epoch as with previous upgrades.
+- `ATTESTATION_PROPAGATION_SLOT_RANGE` remains 32 slots (one epoch plus margin); its wall-clock duration scales with the slot duration.
+- Absolute wall-clock allowances — `MAXIMUM_GOSSIP_CLOCK_DISPARITY` and the Req/Resp timeouts (`TTFB_TIMEOUT`, `RESP_TIMEOUT`) — MUST NOT be rescaled.
+- The gossipsub `seen_ttl` parameter follows its defining formula (two epochs) computed on the piecewise timeline, so it remains correct when the window crosses a duration change.
 
 ## Rationale
 
 ### Why infrastructure first
 
-The bottleneck is not picking a number. It is the hardcoded twelve-second assumption spread across every consensus and execution client. Delivering this change as a fork forces client teams to audit and remove these assumptions — once that work is done, future slot duration changes become straightforward fork-activated parameter updates rather than invasive refactors. The infrastructure work compounds across future upgrades.
+The bottleneck is not picking a number. It is the hardcoded twelve-second assumption spread across every consensus and execution client. Delivering this change as a fork forces client teams to audit and remove these assumptions — once that work is done, future slot duration changes become new `SLOT_DURATION_SCHEDULE` entries rather than invasive refactors, exactly as blob throughput changes became `BLOB_SCHEDULE` entries. The infrastructure work compounds across future upgrades.
 
-### Why eight seconds
+### Why ten seconds
 
-This EIP takes the approach of building the variable slot timing infrastructure first, then reduce the slot duration conservatively as a non-headliner change. Eight seconds is chosen as a reasonable placeholder value that would provide a real UX win, if we discover we can go lower, we should. Even ten seconds would be a meaningful win. The exact target follows from phase 2 performance characterization and may be revised before deployment.
+This EIP takes the approach of building the variable slot timing infrastructure first, then reduce the slot duration conservatively as a non-headliner change. Ten seconds is chosen as a reasonable placeholder value that would provide a real UX win, if we discover we can go lower, we should. The exact target follows from phase 2 performance characterization and may be revised before deployment.
+
+### Exact ratios instead of rescaled constants
+
+Duration-dependent rates are rescaled by applying the slot-duration ratio inline in each formula, with the division deferred, rather than by pre-computing rounded replacement constants. This keeps `SLOT_DURATION_SCHEDULE` the single source of truth — no shadow set of per-duration constants to keep consistent — and it applies the exact ratio: the effective base reward factor for the intended change is exactly 64 × 5/6 = 53.33, not a rounded 53, so there is no systematic issuance drift (the residual truncation error is at most one Gwei per computation).
 
 ### Constant scaling
 
-The general principle is: **do not adjust a constant unless there is a concrete security or economic failure from leaving it unchanged.** Most epoch- and slot-denominated constants have generous margins: `EPOCHS_PER_SLASHINGS_VECTOR` shrinks from ~36 to ~24 days but remains far longer than any plausible attack window; `MIN_VALIDATOR_WITHDRAWABILITY_DELAY` shrinks from ~27 to ~18 hours but slashing detection takes minutes. `SLOTS_PER_EPOCH` remains 32; the resulting ~4.3 minute epochs mean finality improves from ~13 to ~8.5 minutes for free. Only four categories require adjustment:
+The general principle is: **do not adjust a quantity unless there is a concrete security or economic failure from leaving it unchanged.** Most epoch- and slot-denominated constants have generous margins: `EPOCHS_PER_SLASHINGS_VECTOR` shrinks from ~36 to ~30 days but remains far longer than any plausible attack window; `MIN_VALIDATOR_WITHDRAWABILITY_DELAY` shrinks from ~27 to ~22.5 hours but slashing detection takes minutes. `SLOTS_PER_EPOCH` remains 32; the resulting ~5.3 minute epochs mean finality improves from ~13 to ~10.7 minutes for free. Only four categories require adjustment:
 
-**Issuance.** `BASE_REWARD_FACTOR` scales linearly with epoch duration to preserve annualized issuance. Integer truncation (42 vs. ideal 42.667) under-issues by ~1.6%, less than typical participation rate fluctuations.
+**Issuance.** The base reward scales linearly with epoch duration to preserve annualized issuance.
 
-**Inactivity leak.** The cumulative penalty is quadratic in epoch count (`K^2`), so the quotient scales by the square of the epoch ratio. As a divisor, a larger quotient produces a smaller per-epoch penalty, compensating for the faster epoch cadence. `INACTIVITY_SCORE_BIAS` cancels algebraically between the score numerator and penalty denominator and needs no adjustment. `INACTIVITY_SCORE_RECOVERY_RATE` governs post-leak decay; modestly faster recovery is benign.
+**Inactivity leak.** The cumulative penalty is quadratic in epoch count (`K^2`), so the penalty scales by the square of the epoch ratio, folded into the penalty denominator. As a divisor, a larger denominator produces a smaller per-epoch penalty, compensating for the faster epoch cadence. `INACTIVITY_SCORE_BIAS` cancels algebraically between the score numerator and penalty denominator and needs no adjustment. `INACTIVITY_SCORE_RECOVERY_RATE` governs post-leak decay; modestly faster recovery is benign.
 
-**Data availability windows.** Hard external dependency on rollup challenge periods (~7 days). Scaled inversely to preserve wall-clock duration.
+**Data availability windows.** Hard external dependency on rollup challenge periods (~7 days). Preserved by computing the window's start on the piecewise timeline rather than by rescaling the epoch count — this is exact across any number of duration changes and requires no backfill at a change.
 
-**Churn limits.** Preserve the wall-clock weak subjectivity period. Per-epoch limits scale by `new // old`; the quotient (a divisor) scales by `old // new`.
+**Churn limits.** Preserve the wall-clock weak subjectivity period. The per-epoch churn is scaled by `r` in-formula, after the quotient division and the min/max bounds, so the quotients and Gwei-denominated bound constants themselves are unchanged.
 
-Blob parameters scale proportionally; integer truncation can reduce per-slot capacity by at most one blob when `old_max_blobs` is not a multiple of 3 (for 12→8s).
+Blob capacity scales proportionally; integer truncation can reduce per-slot capacity by at most one blob when `old_max_blobs` is not a multiple of 6 (for 12→10s). The blob target is scaled from the previous target and rounded to nearest (14 → 12) rather than re-derived from the truncated maximum, and the blob base fee update fraction is rescaled so the maximum sustained blob fee growth rate per second is preserved.
 
 ### Gas limit
 
-The gas limit scales by `new_slot_duration_ms // old_slot_duration_ms`, preserving the gas-per-second invariant. This is enforced at the fork block rather than relying on validator voting, which at ±1/1024 per block would take ~45 minutes to converge — during which gas-per-second throughput would exceed the target by up to 50%. The steady-state base fee is unchanged because the gas-per-second target is preserved. A worst-case one-time transient of ~12.5% resolves within one to two blocks. After the fork block, normal gas limit voting resumes; validator sovereignty over this parameter is unchanged.
+The gas limit scales one time by the slot-duration ratio, preserving the gas-per-second invariant. This is enforced at the transition rather than left to validator voting, which at ±1/1024 per block would take ~30 minutes to converge — during which gas-per-second throughput would exceed the target by up to 20%. The regular ±1/1024 band still applies, around the rescaled reference, so validator sovereignty over the gas limit is uninterrupted — including at the transition block itself. The steady-state base fee is unchanged because the gas-per-second target is preserved, and the transition block's base fee update is computed against the parent's true gas limit, so it is undistorted by the one-time rescale.
+
+### Base fee responsiveness
+
+The EIP-1559 maximum per-block base fee change of 1/8 was calibrated for twelve-second blocks. Left unchanged, the base fee would respond to congestion 20% faster per unit of wall-clock time under ten-second slots. Scaling the per-block delta by the slot-duration ratio preserves the reaction rate per unit time; deferring the division yields the exact effective denominator 48/5 = 9.6 rather than a rounded integer.
 
 ### Attestation deadlines
 
-Intra-slot timing deadlines are specified in basis points of `SLOT_DURATION_MS` and scale automatically with slot duration. Whether the resulting absolute deadlines remain feasible is a phase 2 question; the BPS values may need tuning based on empirical results.
+Intra-slot timing deadlines are specified in basis points of the slot duration and scale automatically, evaluated against the duration in effect at the duty's slot. Whether the resulting absolute deadlines remain feasible is a phase 2 question; the BPS values may need tuning based on empirical results (a future upgrade MAY introduce new basis-point values, as Gloas did).
 
 ### Fallback
 
-If going below twelve seconds proves infeasible, the outcome defaults to the status quo plus a properly characterized CL and future-ready infrastructure. The slot duration stays at twelve seconds, but the work of removing hardcoded timing assumptions delivers a cleaner client architecture and the readiness to reduce when conditions permit.
+If going below twelve seconds proves infeasible, the outcome defaults to the status quo plus a properly characterized CL and future-ready infrastructure. The `SLOT_DURATION_SCHEDULE` mechanism is inert until an entry is scheduled — an entry at `FAR_FUTURE_EPOCH` has no effect — so the slot duration stays at twelve seconds, but the work of removing hardcoded timing assumptions delivers a cleaner client architecture and the readiness to reduce when conditions permit.
 
 ## Backwards Compatibility
 
-This EIP requires a hard fork. The consensus layer bears most of the change: clients must replace hardcoded twelve-second slot assumptions with fork-aware timing derivations. The execution layer impact is limited to a one-time gas limit and blob parameter adjustment at the fork boundary. Applications and tooling that assume twelve-second block times will need updating.
+This EIP requires a hard fork. The consensus layer bears most of the change: clients must replace genesis-anchored twelve-second timing derivations with the piecewise timeline and drive the fork choice store at millisecond precision. The execution layer impact is limited to the one-time gas limit scaling, the base fee delta scaling, and the accompanying blob schedule entry.
+
+Applications and tooling that assume twelve-second block times will need updating. In particular, the EIP-4788 and EIP-2935 buffers keep their 8,191-entry lengths, so contracts relying on their wall-clock lookback coverage should note that it shrinks from ~27.3 to ~22.8 hours.
 
 ## Security Considerations
 

--- a/EIPS/eip-8198.md
+++ b/EIPS/eip-8198.md
@@ -27,15 +27,23 @@ Twelve seconds is slow. It is perceptible in payments, exchange deposits, and ev
 
 Arbitrage losses scale with the square root of inter-block time. Going from twelve to ten seconds cuts this by roughly 9%, tightening on-chain pricing and reducing value extracted from users. MEV extraction is also non-linear in slot time: shorter slots compress the surplus available per block, squeezing the entire MEV supply chain.
 
+### Fast finality and fast confirmation rule
+
+Faster slots pull forward time-to-finality and time-to-fast-confirmation. As further improvements roll out on these metrics, faster slots compound the decreases and improve interoperability.
+
 ### Empty blocks and ePBS
 
 Proposer builder separation grants builders a free option on the block — they can abandon it if prices move against them. The value of that option grows with slot duration. Shorter slots shrink it, mitigating the empty block problem.
+
+### Censorship-resistance
+
+More block proposers per unit of time increases censorship resistance, giving more opportunities for transactions to be included in the chain. In particular, economic censorship resistance increases too, i.e., the cost of bribing sequential block proposers to "turn off" access of a transaction or all transactions to the chain.
 
 ### Preconfirmation complexity
 
 Preconfirmation protocols exist to paper over twelve-second latency. Reducing slot time attacks the root cause, decreasing the need for additional trust assumptions and protocol complexity layered on top.
 
-### L2 sequencing & interop
+### Based rollups
 
 Based rollups inherit L1 block time as their sequencing interval. Faster L1 slots mean faster based rollups, with zero changes required on the rollup side.
 
@@ -71,9 +79,9 @@ The schedule MUST satisfy the following:
 
 The intended first mainnet entry, activating at the fork epoch, is:
 
-| Epoch | Slot duration (ms) |
-| ----- | ------------------ |
-| `<FORK_EPOCH>` | 10,000 |
+| Epoch          | Slot duration (ms) |
+| -------------- | ------------------ |
+| `<FORK_EPOCH>` | 10,000             |
 
 Throughout this specification, the *slot-duration ratio* `r = get_slot_duration_ms(epoch) / SLOT_DURATION_MS` denotes the ratio of the duration in effect to the pre-schedule duration — `5/6` for the intended entry.
 
@@ -92,11 +100,11 @@ Intra-slot deadlines remain specified in basis points of the slot duration and r
 
 No consensus constant changes value. Instead, the duration-dependent per-epoch rates are rescaled by the exact ratio `r`, applied inline with deferred division:
 
-| Quantity | Scaling | Effect for `r = 5/6` |
-| -------- | ------- | -------------------- |
-| Base reward per increment | `× r` | Effective `BASE_REWARD_FACTOR` of exactly 64 × 5/6 = 53.33 |
-| Inactivity penalty | `× r²` (folded into the penalty denominator) | Effective inactivity penalty quotient × 36/25 |
-| Activation, exit, and consolidation churn limits | `× r` | Effective per-epoch churn × 5/6 |
+| Quantity                                         | Scaling                                      | Effect for `r = 5/6`                                       |
+| ------------------------------------------------ | -------------------------------------------- | ---------------------------------------------------------- |
+| Base reward per increment                        | `× r`                                        | Effective `BASE_REWARD_FACTOR` of exactly 64 × 5/6 = 53.33 |
+| Inactivity penalty                               | `× r²` (folded into the penalty denominator) | Effective inactivity penalty quotient × 36/25              |
+| Activation, exit, and consolidation churn limits | `× r`                                        | Effective per-epoch churn × 5/6                            |
 
 For the churn limits, the minimum and maximum bounds are applied before scaling — so the bounds are scaled too — and the `EFFECTIVE_BALANCE_INCREMENT` rounding is applied once, after scaling. Exit and consolidation epochs assigned before a duration change keep their assigned epochs and consumed quota.
 
@@ -142,10 +150,10 @@ new_max_blobs = old_max_blobs * new_slot_duration_ms // old_slot_duration_ms
 
 where `old_max_blobs` is the `MAX_BLOBS_PER_BLOCK` from the most recent preceding `BLOB_SCHEDULE` entry. The blob target is scaled from the previous target by the same ratio, rounding to the nearest integer, and `BLOB_BASE_FEE_UPDATE_FRACTION` is rescaled so that the maximum sustained blob base fee growth rate per unit of wall-clock time is preserved. For the intended twelve-to-ten change, starting from a maximum of 21 and target of 14:
 
-| Parameter | Current | New |
-| --------- | ------- | --- |
-| `MAX_BLOBS_PER_BLOCK` | 21 | 17 |
-| `BLOB_SCHEDULE_TARGET` | 14 | 12 |
+| Parameter                       | Current    | New        |
+| ------------------------------- | ---------- | ---------- |
+| `MAX_BLOBS_PER_BLOCK`           | 21         | 17         |
+| `BLOB_SCHEDULE_TARGET`          | 14         | 12         |
 | `BLOB_BASE_FEE_UPDATE_FRACTION` | 11,684,671 | 10,015,432 |
 
 #### System contracts
@@ -167,7 +175,7 @@ The bottleneck is not picking a number. It is the hardcoded twelve-second assump
 
 ### Why ten seconds
 
-This EIP takes the approach of building the variable slot timing infrastructure first, then reduce the slot duration conservatively as a non-headliner change. Ten seconds is chosen as a reasonable placeholder value that would provide a real UX win, if we discover we can go lower, we should. The exact target follows from phase 2 performance characterization and may be revised before deployment.
+This EIP takes the approach of building the variable slot timing infrastructure first, then reduce the slot duration conservatively as a non-headliner change. Ten seconds is chosen as a reasonable placeholder value that would provide a real UX win, before future reductions further compound the benefits. The exact target follows from preliminary work on phase 2 performance characterization and may be revised before deployment.
 
 ### Exact ratios instead of rescaled constants
 
@@ -213,11 +221,11 @@ Applications and tooling that assume twelve-second block times will need updatin
 
 ### Network propagation
 
-Tighter slots shrink the window for block propagation, validation, and attestation aggregation. Intra-slot timing deadlines are specified in basis points and scale automatically, but the resulting absolute durations must remain feasible for real-world network conditions. Phase 2 (CL performance characterization) is explicitly designed to surface these bottlenecks before committing to a final slot duration.
+Tighter slots shrink the window for block propagation, validation, and attestation aggregation. Intra-slot timing deadlines are specified in basis points and scale automatically, but the resulting absolute durations must remain feasible for real-world network conditions. Phase 2 (CL performance characterization) is explicitly designed to surface these bottlenecks.
 
 ### Validator hardware requirements
 
-Shorter slots raise per-second computational and bandwidth demands. Validator hardware distribution should be considered when deciding the slot duration. Note that peak bandwidth per payload is not affected — gas per block and the number of blobs decreases proportionally with slot time.
+Faster blocks raise per-second computational and bandwidth demands. Validator hardware distribution should be considered when deciding the slot duration. Note that peak bandwidth per payload is affected positively — gas per block and the number of blobs decreases proportionally with slot time.
 
 ### Weak subjectivity period
 


### PR DESCRIPTION
Updates EIP-8198 (Quick Slots) to target 10-second slots and rewrites the specification to match the reference spec work (consensus-specs and execution-specs `eip8198-quick-slots` branches):

- Replace the single `SLOT_DURATION_MS` change and the rescaled-constants table with a `SLOT_DURATION_SCHEDULE` (modeled on EIP-7892's `BLOB_SCHEDULE`) and exact in-formula ratio scaling — base reward × r, inactivity penalty × r², churn × r — with deferred division so no constant is re-rounded.
- Specify the piecewise wall-clock timeline, millisecond store clock, and duty-slot-keyed intra-slot deadlines.
- Gas limit at the transition: regular ±1/1024 band around the rescaled reference on the EL, exact scaled value in the CL bid rule, keyed to the parent payload's slot.
- Add base fee delta scaling (effective max change 5/48 per block) and concrete blob schedule values (max 21→17, target 14→12, update fraction 11,684,671→10,015,432).
- Preserve DA retention windows in wall-clock terms via a piecewise retention-start helper instead of rescaled epoch counts.
- Document networking parameter treatment and the unchanged EIP-4788 / EIP-2935 ring buffers (~27.3h → ~22.8h coverage).
- Expand the motivation (fast finality and fast confirmation, censorship resistance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9zwiCe5KJPCGkAyE8vwis