### PR TITLE
Update EIP-8250: move TXPARAM_LEGACY_NONCE off 0x0C

### DIFF
--- a/EIPS/eip-8250.md
+++ b/EIPS/eip-8250.md
@@ -41,7 +41,7 @@ This specification is a delta against [EIP-8141](./eip-8141.md).
 | `KEYED_NONCE_FIRST_USE_GAS` | `20000` |
 | `MAX_NONCE_SEQ` | `2**64 - 1` |
 | `MAX_NONCE_KEYS` | `16` |
-| `TXPARAM_LEGACY_NONCE` | `0x0C` |
+| `TXPARAM_LEGACY_NONCE` | `0x11` |
 | `TXPARAM_NONCE_KEY_COUNT` | `0x0D` |
 | `TXPARAM_NONCE_KEYS_HASH` | `0x0E` |
 | `TXPARAM_NONCE_KEY_0` | `0x10` |
@@ -183,7 +183,7 @@ Keyed-nonce reads and writes performed by stateful validity and `consume_nonce_s
 
 | `param` | Return value |
 | ------- | ------------ |
-| `0x0C` | pre-state legacy sender nonce |
+| `0x11` | pre-state legacy sender nonce |
 | `0x0D` | `len(tx.nonce_keys)` |
 | `0x0E` | `nonce_keys_hash(tx)` |
 | `0x10` | `tx.nonce_keys[0]` |
@@ -199,9 +199,9 @@ keccak256(
 
 Because valid `nonce_keys` are strictly increasing, `nonce_keys_hash(tx)` has one canonical encoding for each selected key set.
 
-`TXPARAM(0x0C)` returns `tx_legacy_nonce`, the value of `state[tx.sender].nonce` observed during stateful validity before any frame executes. It is transaction-scoped and is not updated by payment approval, keyed-nonce consumption, account deployment, `CREATE`, or `CREATE2` within the same transaction.
+`TXPARAM(0x11)` returns `tx_legacy_nonce`, the value of `state[tx.sender].nonce` observed during stateful validity before any frame executes. It is transaction-scoped and is not updated by payment approval, keyed-nonce consumption, account deployment, `CREATE`, or `CREATE2` within the same transaction.
 
-For `nonce_keys == [0]`, stateful validity requires `TXPARAM(0x01) == TXPARAM(0x0C)` at transaction start. For `nonce_keys != [0]`, they may differ.
+For `nonce_keys == [0]`, stateful validity requires `TXPARAM(0x01) == TXPARAM(0x11)` at transaction start. For `nonce_keys != [0]`, they may differ.
 
 ### Activation
 
@@ -228,9 +228,9 @@ For the EIP-8141 public mempool rules:
 - replace the pending transaction identity `(sender, nonce)` with `(sender, nonce_keys, nonce_seq)`;
 - replace every EIP-8141 public mempool dependency on the sender nonce with `current_nonce_seq(sender, nonce_key)` for each `nonce_key` in `nonce_keys`.
 
-If the validation prefix reads `TXPARAM(0x0C)`, the sender's legacy account nonce is an additional dependency.
+If the validation prefix reads `TXPARAM(0x11)`, the sender's legacy account nonce is an additional dependency.
 
-Nodes MUST revalidate a pending transaction when any of its selected nonce sequences changes. If the validation prefix reads `TXPARAM(0x0C)`, nodes MUST also revalidate when the sender's legacy account nonce changes. All other EIP-8141 public mempool rules, including the limit of one pending frame transaction per sender, remain unchanged.
+Nodes MUST revalidate a pending transaction when any of its selected nonce sequences changes. If the validation prefix reads `TXPARAM(0x11)`, nodes MUST also revalidate when the sender's legacy account nonce changes. All other EIP-8141 public mempool rules, including the limit of one pending frame transaction per sender, remain unchanged.
 
 ## Rationale
 
@@ -254,7 +254,7 @@ This EIP does not relax EIP-8141's public-mempool one-pending-frame-transaction-
 
 `TXPARAM(0x01)` continues to return the transaction's replay-protection sequence, which equals the sender's legacy nonce only when `nonce_keys == [0]`. Verifier code that previously assumed `TXPARAM(0x01)` is the legacy account nonce MUST either enforce `TXPARAM(0x0D) == 1 and TXPARAM(0x10) == 0` or be updated to handle keyed sequences.
 
-`TXPARAM(0x0C)` provides explicit pre-state legacy-account-nonce access for verifier code that needs it.
+`TXPARAM(0x11)` provides explicit pre-state legacy-account-nonce access for verifier code that needs it.
 
 If activated after EIP-8141, pre-fork frame transactions become invalid at the fork boundary and any authorization bound to the pre-fork signature hash MUST be regenerated.
 
@@ -264,7 +264,7 @@ Replay protection is scoped to `(sender, nonce_keys, nonce_seq)`, with validity 
 
 Single-use-key applications, such as nullifiers, MUST authenticate at least `(sender, nonce_keys_hash, nonce_seq == 0)` in `VERIFY` and SHOULD bind the canonical signature hash via `TXPARAM(0x08)`. Treating `nonce_seq == 0` alone as authorization is unsafe. Authenticating only `TXPARAM_NONCE_KEY_0` is also unsafe when `TXPARAM_NONCE_KEY_COUNT > 1`, because an attacker could add unauthorized keys that would be consumed by payment approval. Applications deriving nonce keys from per-use identifiers SHOULD domain-separate the input and reject derived keys equal to `0`.
 
-A non-zero-key frame transaction does not advance the sender's legacy account nonce during payment approval. If such a transaction executes `CREATE` at `tx.sender`, the created address depends on the sender's legacy account nonce at execution time. Another transaction that advances the sender's legacy nonce before inclusion can therefore change the `CREATE` address without invalidating the keyed transaction. Applications whose semantics depend on a `CREATE` address SHOULD use `CREATE2` or MUST authenticate the expected pre-state legacy nonce via `TXPARAM(0x0C)`.
+A non-zero-key frame transaction does not advance the sender's legacy account nonce during payment approval. If such a transaction executes `CREATE` at `tx.sender`, the created address depends on the sender's legacy account nonce at execution time. Another transaction that advances the sender's legacy nonce before inclusion can therefore change the `CREATE` address without invalidating the keyed transaction. Applications whose semantics depend on a `CREATE` address SHOULD use `CREATE2` or MUST authenticate the expected pre-state legacy nonce via `TXPARAM(0x11)`.
 
 Nonce consumption persists through later-frame reverts and EIP-8141 atomic-batch rollback because it is part of payment approval. Single-use applications SHOULD minimize post-approval revert paths.
 

--- a/EIPS/eip-8250.md
+++ b/EIPS/eip-8250.md
@@ -41,9 +41,9 @@ This specification is a delta against [EIP-8141](./eip-8141.md).
 | `KEYED_NONCE_FIRST_USE_GAS` | `20000` |
 | `MAX_NONCE_SEQ` | `2**64 - 1` |
 | `MAX_NONCE_KEYS` | `16` |
-| `TXPARAM_LEGACY_NONCE` | `0x11` |
-| `TXPARAM_NONCE_KEY_COUNT` | `0x0D` |
-| `TXPARAM_NONCE_KEYS_HASH` | `0x0E` |
+| `TXPARAM_LEGACY_NONCE` | `0x0D` |
+| `TXPARAM_NONCE_KEY_COUNT` | `0x0E` |
+| `TXPARAM_NONCE_KEYS_HASH` | `0x0F` |
 | `TXPARAM_NONCE_KEY_0` | `0x10` |
 
 `NONCE_MANAGER_CODE` is a runtime equivalent to `revert(0, 0)`: any ordinary call to `NONCE_MANAGER` immediately reverts with empty returndata.
@@ -179,13 +179,13 @@ Keyed-nonce reads and writes performed by stateful validity and `consume_nonce_s
 
 ### Transaction introspection
 
-`TXPARAM(0x01)` returns `tx.nonce_seq`. EIP-8141 assigns `TXPARAM` indices through `0x0B`, including `0x0B = len(signatures)`. This EIP adds four non-conflicting indices:
+`TXPARAM(0x01)` returns `tx.nonce_seq`. EIP-8141 assigns `TXPARAM` indices through `0x0C`, including `0x0B = len(signatures)`. This EIP adds four non-conflicting indices:
 
 | `param` | Return value |
 | ------- | ------------ |
-| `0x11` | pre-state legacy sender nonce |
-| `0x0D` | `len(tx.nonce_keys)` |
-| `0x0E` | `nonce_keys_hash(tx)` |
+| `0x0D` | pre-state legacy sender nonce |
+| `0x0E` | `len(tx.nonce_keys)` |
+| `0x0F` | `nonce_keys_hash(tx)` |
 | `0x10` | `tx.nonce_keys[0]` |
 
 `nonce_keys_hash(tx)` is defined as:
@@ -199,9 +199,9 @@ keccak256(
 
 Because valid `nonce_keys` are strictly increasing, `nonce_keys_hash(tx)` has one canonical encoding for each selected key set.
 
-`TXPARAM(0x11)` returns `tx_legacy_nonce`, the value of `state[tx.sender].nonce` observed during stateful validity before any frame executes. It is transaction-scoped and is not updated by payment approval, keyed-nonce consumption, account deployment, `CREATE`, or `CREATE2` within the same transaction.
+`TXPARAM(0x0D)` returns `tx_legacy_nonce`, the value of `state[tx.sender].nonce` observed during stateful validity before any frame executes. It is transaction-scoped and is not updated by payment approval, keyed-nonce consumption, account deployment, `CREATE`, or `CREATE2` within the same transaction.
 
-For `nonce_keys == [0]`, stateful validity requires `TXPARAM(0x01) == TXPARAM(0x11)` at transaction start. For `nonce_keys != [0]`, they may differ.
+For `nonce_keys == [0]`, stateful validity requires `TXPARAM(0x01) == TXPARAM(0x0D)` at transaction start. For `nonce_keys != [0]`, they may differ.
 
 ### Activation
 
@@ -228,9 +228,9 @@ For the EIP-8141 public mempool rules:
 - replace the pending transaction identity `(sender, nonce)` with `(sender, nonce_keys, nonce_seq)`;
 - replace every EIP-8141 public mempool dependency on the sender nonce with `current_nonce_seq(sender, nonce_key)` for each `nonce_key` in `nonce_keys`.
 
-If the validation prefix reads `TXPARAM(0x11)`, the sender's legacy account nonce is an additional dependency.
+If the validation prefix reads `TXPARAM(0x0D)`, the sender's legacy account nonce is an additional dependency.
 
-Nodes MUST revalidate a pending transaction when any of its selected nonce sequences changes. If the validation prefix reads `TXPARAM(0x11)`, nodes MUST also revalidate when the sender's legacy account nonce changes. All other EIP-8141 public mempool rules, including the limit of one pending frame transaction per sender, remain unchanged.
+Nodes MUST revalidate a pending transaction when any of its selected nonce sequences changes. If the validation prefix reads `TXPARAM(0x0D)`, nodes MUST also revalidate when the sender's legacy account nonce changes. All other EIP-8141 public mempool rules, including the limit of one pending frame transaction per sender, remain unchanged.
 
 ## Rationale
 
@@ -252,9 +252,9 @@ This EIP does not relax EIP-8141's public-mempool one-pending-frame-transaction-
 
 `nonce_keys == [0]` preserves EIP-8141 replay behavior. Legacy account objects, non-frame transaction types, and `eth_getTransactionCount` are unchanged.
 
-`TXPARAM(0x01)` continues to return the transaction's replay-protection sequence, which equals the sender's legacy nonce only when `nonce_keys == [0]`. Verifier code that previously assumed `TXPARAM(0x01)` is the legacy account nonce MUST either enforce `TXPARAM(0x0D) == 1 and TXPARAM(0x10) == 0` or be updated to handle keyed sequences.
+`TXPARAM(0x01)` continues to return the transaction's replay-protection sequence, which equals the sender's legacy nonce only when `nonce_keys == [0]`. Verifier code that previously assumed `TXPARAM(0x01)` is the legacy account nonce MUST either enforce `TXPARAM(0x0E) == 1 and TXPARAM(0x10) == 0` or be updated to handle keyed sequences.
 
-`TXPARAM(0x11)` provides explicit pre-state legacy-account-nonce access for verifier code that needs it.
+`TXPARAM(0x0D)` provides explicit pre-state legacy-account-nonce access for verifier code that needs it.
 
 If activated after EIP-8141, pre-fork frame transactions become invalid at the fork boundary and any authorization bound to the pre-fork signature hash MUST be regenerated.
 
@@ -264,7 +264,7 @@ Replay protection is scoped to `(sender, nonce_keys, nonce_seq)`, with validity 
 
 Single-use-key applications, such as nullifiers, MUST authenticate at least `(sender, nonce_keys_hash, nonce_seq == 0)` in `VERIFY` and SHOULD bind the canonical signature hash via `TXPARAM(0x08)`. Treating `nonce_seq == 0` alone as authorization is unsafe. Authenticating only `TXPARAM_NONCE_KEY_0` is also unsafe when `TXPARAM_NONCE_KEY_COUNT > 1`, because an attacker could add unauthorized keys that would be consumed by payment approval. Applications deriving nonce keys from per-use identifiers SHOULD domain-separate the input and reject derived keys equal to `0`.
 
-A non-zero-key frame transaction does not advance the sender's legacy account nonce during payment approval. If such a transaction executes `CREATE` at `tx.sender`, the created address depends on the sender's legacy account nonce at execution time. Another transaction that advances the sender's legacy nonce before inclusion can therefore change the `CREATE` address without invalidating the keyed transaction. Applications whose semantics depend on a `CREATE` address SHOULD use `CREATE2` or MUST authenticate the expected pre-state legacy nonce via `TXPARAM(0x11)`.
+A non-zero-key frame transaction does not advance the sender's legacy account nonce during payment approval. If such a transaction executes `CREATE` at `tx.sender`, the created address depends on the sender's legacy account nonce at execution time. Another transaction that advances the sender's legacy nonce before inclusion can therefore change the `CREATE` address without invalidating the keyed transaction. Applications whose semantics depend on a `CREATE` address SHOULD use `CREATE2` or MUST authenticate the expected pre-state legacy nonce via `TXPARAM(0x0D)`.
 
 Nonce consumption persists through later-frame reverts and EIP-8141 atomic-batch rollback because it is part of payment approval. Single-use applications SHOULD minimize post-approval revert paths.
 


### PR DESCRIPTION
EIP-8141 assigns `TXPARAM` index `0x0C` to `state_gas_left` ([eip-8141.md @ 275bc163, L745](https://github.com/ethereum/EIPs/blob/275bc1631a855bca7b8c9b162e68e4d8dab5043b/EIPS/eip-8141.md#L745)). EIP-8250 currently assigns `0x0C` to `TXPARAM_LEGACY_NONCE`, so on a chain enabling both the two claim the same index.

This moves `TXPARAM_LEGACY_NONCE` to the free `0x11`. Does that match the intended ownership, or should `state_gas_left` move instead?
