### PR TITLE
Update EIP-8272: move RECENTROOTREFLOAD off 0xB5

### DIFF
--- a/EIPS/eip-8272.md
+++ b/EIPS/eip-8272.md
@@ -50,7 +50,7 @@ This specification is a delta against [EIP-8141](./eip-8141.md). Terms not defin
 | `RECENT_ROOT_REFERENCE_ADDRESS_GAS`   |                                                       `ACCESS_LIST_ADDRESS_COST` |
 | `RECENT_ROOT_REFERENCE_GAS`           | `ACCESS_LIST_STORAGE_KEY_COST + 2 * KECCAK256_BASE_GAS + 7 * KECCAK256_WORD_GAS` |
 | `TXPARAM_RECENT_ROOT_REFERENCE_COUNT` |                                                                           `0x0F` |
-| `RECENTROOTREFLOAD`                   |                                                                           `0xB5` |
+| `RECENTROOTREFLOAD`                   |                                                                           `0xB6` |
 | `RECENTROOTREFLOAD_GAS`               |                                                                              `3` |
 
 All concatenations below use fixed-length encodings. Domains are 32 bytes. Addresses are 20 bytes. Slots and indices are unsigned 64-bit big-endian integers. Roots, salts, source identifiers, entry hashes, and storage keys are 32 bytes.
@@ -269,7 +269,7 @@ The [EIP-8141](./eip-8141.md) definitions of `max_gas`, `gas_used`, and fee sett
 
 One new `TXPARAM` index and one new opcode are added:
 
-[EIP-8141](./eip-8141.md) assigns opcode `0xB4` to `SIGPARAM`. `RECENTROOTREFLOAD` uses `0xB5` to avoid that collision.
+[EIP-8141](./eip-8141.md) assigns opcodes `0xB4` to `SIGPARAM` and `0xB5` to `SIGDATACOPY`. `RECENTROOTREFLOAD` uses `0xB6` to avoid those collisions.
 
 | Name                                 |  Value | Return value                 |
 | ------------------------------------ | -----: | ---------------------------- |

--- a/EIPS/eip-8272.md
+++ b/EIPS/eip-8272.md
@@ -49,7 +49,7 @@ This specification is a delta against [EIP-8141](./eip-8141.md). Terms not defin
 | `RECENT_ROOT_STORAGE_DOMAIN`          |                                                `keccak256("RECENT_ROOT_STORAGE")` |
 | `RECENT_ROOT_REFERENCE_ADDRESS_GAS`   |                                                       `ACCESS_LIST_ADDRESS_COST` |
 | `RECENT_ROOT_REFERENCE_GAS`           | `ACCESS_LIST_STORAGE_KEY_COST + 2 * KECCAK256_BASE_GAS + 7 * KECCAK256_WORD_GAS` |
-| `TXPARAM_RECENT_ROOT_REFERENCE_COUNT` |                                                                           `0x0F` |
+| `TXPARAM_RECENT_ROOT_REFERENCE_COUNT` |                                                                           `0x11` |
 | `RECENTROOTREFLOAD`                   |                                                                           `0xB6` |
 | `RECENTROOTREFLOAD_GAS`               |                                                                              `3` |
 
@@ -273,7 +273,7 @@ One new `TXPARAM` index and one new opcode are added:
 
 | Name                                 |  Value | Return value                 |
 | ------------------------------------ | -----: | ---------------------------- |
-| `TXPARAM_RECENT_ROOT_REFERENCE_COUNT` | `0x0F` | `len(recent_root_references)` |
+| `TXPARAM_RECENT_ROOT_REFERENCE_COUNT` | `0x11` | `len(recent_root_references)` |
 
 `TXPARAM(TXPARAM_RECENT_ROOT_REFERENCE_COUNT)` costs the standard `TXPARAM` gas.
 


### PR DESCRIPTION
EIP-8141 assigns opcode `0xB5` to `SIGDATACOPY` ([eip-8141.md @ 275bc163, L833](https://github.com/ethereum/EIPs/blob/275bc1631a855bca7b8c9b162e68e4d8dab5043b/EIPS/eip-8141.md#L833)). EIP-8272 currently assigns `0xB5` to `RECENTROOTREFLOAD`, so on a chain enabling both the two claim the same opcode.

This moves `RECENTROOTREFLOAD` to the free `0xB6`. Does that match the intended ownership, or should `SIGDATACOPY` move instead?
