### PR TITLE
Update EIP-8141: bound chain_id to 2**64

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -139,7 +139,7 @@ the purpose of the frame within the execution loop.
 Some validity constraints can be determined statically. They are outlined below:
 
 ```python
-assert tx.chain_id < 2**256
+assert tx.chain_id < 2**64
 assert tx.nonce < 2**64
 assert tx.fees.max_priority_fee_per_gas < 2**256
 assert tx.fees.max_fee_per_gas < 2**256


### PR DESCRIPTION
Narrows the static-validity bound on the frame transaction's `chain_id` from `2**256` to `2**64`, so the EIP agrees with its reference implementation.

## Why

The constraint block currently reads:

```python
assert tx.chain_id < 2**256
assert tx.nonce < 2**64
```

but the reference implementation in `ethereum/execution-specs` (branch `eips/amsterdam/eip-8141`, `src/ethereum/forks/amsterdam/transactions/frame_transaction.py`) declares:

```python
class FrameTransaction:
    chain_id: U64
```

That is not a cosmetic annotation: the field width is normative there, because the frame transaction is decoded with `rlp.decode_to(FrameTransaction, ...)`, so a `chain_id` encoded in more than eight bytes is rejected at decode time rather than accepted. As written, the two documents disagree about whether a transaction with `chain_id == 2**64` is well-formed.

### The wider bound admits nothing

`chain_id` identifies the chain the transaction is valid on, and a transaction whose `chain_id` differs from the current chain's is rejected. The current chain's identifier is itself a 64-bit value, so no value in `[2**64, 2**256)` can ever match it. Every `chain_id` the wider bound admits over the narrower one is therefore invalid regardless, and the amendment changes no accept/reject outcome — only where a rejection is decided. It removes a range of the field that is unreachable by construction.

### The bound looks inherited rather than intended

The identical pair of asserts, in the same order, appears in EIP-7702 — but there it constrains an *authorization tuple*, not the transaction:

```python
assert auth.chain_id < 2**256
assert auth.nonce < 2**64
```

For the authorization tuple the wide bound is deliberate and is implemented as such (`Authorization.chain_id: U256`), because that field is a payload value carried inside the transaction and compared against the current chain, with `0` given a distinguished meaning. Copying the pair onto a transaction envelope carries the wide bound somewhere it was never argued for.

### `U64` is the established envelope width

Every other typed transaction in the reference implementation — the access-list, fee-market, blob, and set-code types — declares `chain_id: U64`, as does the block environment the transaction's value is compared against. The frame transaction is the only one whose prose claims a wider field, and its own implementation has declared `U64` since that implementation's first commit. Note also that EIP-2294 (Informational, Stagnant) argues for a `chain_id` ceiling well below `2**64`, so `2**64` is if anything already generous.

## Alternative considered

Widening the reference implementation to `U256` instead. Rejected: it would make the frame transaction the sole typed transaction with a 256-bit envelope `chain_id`, forcing 256-bit handling of a field that implementations already carry as a 64-bit value, in exchange for a range in which every value is unusable.

## On test coverage

Fixtures cannot settle this one. Because a mismatched `chain_id` is rejected either way, both readings produce the same verdict for every value a test could encode, and no test chain has an identifier that would separate them. Accordingly, no fixture in the current devnet release exercises a transaction-level `chain_id` above `2**64 - 1` for any transaction type — the only wider `chainId` anywhere in it is the EIP-7702 authorization tuple. Aligning the text is the only thing that resolves the ambiguity.
