### PR TITLE
Update EIP-7805: skip IL transactions needing data the IL cannot carry

### DIFF
--- a/EIPS/eip-7805.md
+++ b/EIPS/eip-7805.md
@@ -93,11 +93,13 @@ Let `gas_left` be the gas remaining after execution of B.
 
 For each transaction `T` in ILs, perform the following:
 
-1. Check whether `T` is present in `B`. If `T` is present, then jump to the next transaction, else continue with next step.
+1. Check whether `T` can be included from the encoding the IL carries alone. If `T` additionally requires data that is not part of the block — currently any [EIP-4844](./eip-4844.md) blob transaction, whose blobs, commitments and proofs travel only in its network wrapper — then jump to the next transaction, else continue with next step.
 
-2. Check whether `B` has enough remaining gas to execute `T`. If `T.gas` > `gas_left`, then jump to the next transaction, else continue with next step.
+2. Check whether `T` is present in `B`. If `T` is present, then jump to the next transaction, else continue with next step.
 
-3. Validate `T` against `S` by checking the nonce and balance of `T.origin`.
+3. Check whether `B` has enough remaining gas to execute `T`. If `T.gas` > `gas_left`, then jump to the next transaction, else continue with next step.
+
+4. Validate `T` against `S` by checking the nonce and balance of `T.origin`.
 
   - If `T` is invalid, then continue to the next transaction. 
   
@@ -113,7 +115,7 @@ We make the following changes to the engine API:
 
 #### IL Building
 
-The rules for building ILs are left to the discretion of implementers. For instance, they may select transactions from the public mempool in various ways such as at random, by priority fee, or based on how long they have been pending. The IL has a maximum size of `MAX_BYTES_PER_INCLUSION_LIST = 8 KiB` for all of the RLP encoded transactions.
+The rules for building ILs are left to the discretion of implementers. For instance, they may select transactions from the public mempool in various ways such as at random, by priority fee, or based on how long they have been pending. The IL has a maximum size of `MAX_BYTES_PER_INCLUSION_LIST = 8 KiB` for all of the RLP encoded transactions. IL builders MUST NOT select a transaction that step 1 of the execution layer check skips, since no proposer could act on it.
 
 ### Consensus Layer
 
@@ -181,6 +183,12 @@ This EIP introduces backward incompatible changes to the block validation rule s
 ### Consensus Liveness
 
 The builder of `slot N+1` cannot construct a canonical block without first receiving the ILs broadcast during `slot N`. This means that the builder (including cases in which the proposer locally builds its block) must be well-connected to the IL committee members to ensure timely access to these inclusion lists. Additionally, there must be sufficient time between the view freeze deadline (`t=9s` of `slot N`) and the moment the proposer must broadcast `block B` to the rest of the network. This buffer allows the builder to gather all available ILs and update the execution payload of `block B` accordingly.
+
+### Transactions Requiring Data Outside The IL
+
+An `InclusionList` carries only the canonical encoding of each transaction, so a transaction that also needs data travelling outside the block cannot be included by any proposer, honest or not. A blob transaction's blobs, commitments and proofs reach the network only in its wrapper, which the IL has no field for; a proposer that saw the transaction in an IL and nowhere else therefore cannot produce a payload containing it.
+
+Without step 1 of the execution layer check, one IL committee member placing such a transaction in its IL makes every block built against that IL report as not satisfying the constraints. Fork choice declines to extend a payload in that state, so the slot's payload is dropped — at no cost to the attacker, and repeatable in every slot the member is on the committee. Restricting IL construction alone does not close this: construction rules bind only honest members, and nothing enforces them, since the CL P2P validation rules deliberately perform no EL-side checks and such a transaction propagates and is stored like any other. The check therefore belongs on the validation side, where every attester applies it.
 
 ### IL Equivocation
 

--- a/EIPS/eip-7805.md
+++ b/EIPS/eip-7805.md
@@ -12,7 +12,7 @@ created: 2024-11-01
 
 ## Abstract
 
-FOCIL implements a robust mechanism to preserve Ethereum’s censorship resistance properties by guaranteeing timely transaction inclusion.
+FOCIL implements a robust mechanism to preserve Ethereum's censorship resistance properties by guaranteeing timely transaction inclusion.
 
 FOCIL (**Fo**rk-**c**hoice enforced **I**nclusion **L**ists) is built in a few simple steps:
 
@@ -23,7 +23,7 @@ FOCIL (**Fo**rk-**c**hoice enforced **I**nclusion **L**ists) is built in a few s
 
 ## Motivation
 
-In an effort to shield the Ethereum validator set from centralizing forces, the right to build blocks has been auctioned off to specialized entities known as *builders*. This has led to a few sophisticated builders dominating block production, leading to a deterioration of the network’s censorship resistance properties. To address this issue, research has focused on improving Ethereum's transaction inclusion guarantees by enabling validators to impose constraints on builders. This is achieved by force-including transactions in blocks via ILs.
+In an effort to shield the Ethereum validator set from centralizing forces, the right to build blocks has been auctioned off to specialized entities known as *builders*. This has led to a few sophisticated builders dominating block production, leading to a deterioration of the network's censorship resistance properties. To address this issue, research has focused on improving Ethereum's transaction inclusion guarantees by enabling validators to impose constraints on builders. This is achieved by force-including transactions in blocks via ILs.
 
 ### High-level Overview
 
@@ -38,7 +38,7 @@ This section outlines the workflow of FOCIL, detailing the roles and responsibil
 #### IL Committee Members
 
 - **`Slot N`, `t=0 to 8s`**:
-IL committee members construct their ILs by including transactions pending in the public mempool, and broadcast them over the P2P network after processing the block for `slot N` and confirming it as the head. If no block is received by `t=7s`, they should run `get_head` and build and release their ILs based on the node’s local head.
+IL committee members construct their ILs by including transactions pending in the public mempool, and broadcast them over the P2P network after processing the block for `slot N` and confirming it as the head. If no block is received by `t=7s`, they should run `get_head` and build and release their ILs based on the node's local head.
 
 IL committee members may follow different strategies for constructing their ILs as discussed in [IL Building](#il-building).
 
@@ -68,7 +68,7 @@ The proposer broadcasts its block with the up-to-date execution payload satisfyi
 #### Attesters
 
 - **`Slot N+1`, `t=4s`**:
-Attesters monitor the P2P network for the proposer’s block. Upon detecting it, they verify whether all transactions from their stored ILs are included in the proposer’s execution payload, except for ILs whose sender has equivocated. Based on their frozen view of the ILs from `t=9s` in the previous slot, attesters check if the execution payload satisfies IL conditions. This is done either by confirming that all transactions are present or by determining if any missing transactions are invalid when appended to the end of the payload. In such cases, attesters use the EL to perform nonce and balance checks to validate the missing transactions and check whether there is enough space in the block to include the transaction(s).
+Attesters monitor the P2P network for the proposer's block. Upon detecting it, they verify whether all transactions from their stored ILs are included in the proposer's execution payload, except for ILs whose sender has equivocated. Based on their frozen view of the ILs from `t=9s` in the previous slot, attesters check if the execution payload satisfies IL conditions. This is done either by confirming that all transactions are present or by determining if any missing transactions are invalid when appended to the end of the payload. In such cases, attesters use the EL to perform nonce and balance checks to validate the missing transactions and check whether there is enough space in the block to include the transaction(s).
 
 #### CL P2P Validation Rules
 


### PR DESCRIPTION
The satisfaction check in the execution layer validates every inclusion-list entry on nonce, balance and gas alone. A blob transaction passes all three, but an `InclusionList` carries only canonical transaction encodings — a blob transaction's blobs, commitments and proofs travel in its network wrapper, which the IL has no field for. So a proposer that saw the transaction only in an IL cannot produce a payload containing it.

Consequence: one IL committee member placing such a transaction in its list makes every block built against that list report as not satisfying the constraints. `specs/heze/fork-choice.md` states that "A valid payload that fails to satisfy those constraints remains valid, but fork choice does not extend it", so the slot's payload is dropped — at no cost, and repeatable in every slot that member is on the committee.

The construction side already forbids this: `engine_getInclusionListV1` in the engine API specification says client software MUST NOT include a blob transaction in the returned list. But construction rules bind only honest members, and nothing enforces them — the CL P2P validation rules deliberately perform no execution-layer checks, so such a transaction propagates and is stored like any other. The matching rule therefore belongs on the validation side, where every attester applies it.

This adds it as step 1 of the execution layer check, phrased on the general principle ("requires data that is not part of the block") rather than naming type 3 alone, so it survives future transaction types carrying out-of-band data. It also states the construction-side counterpart explicitly in the IL Building section, and adds a Security Considerations subsection covering the vector.

An alternative resolution, if the intent is that such an entry genuinely does make a block non-compliant: leave the check as it is and specify what an honest proposer is expected to do instead. I think that is the weaker option — it leaves a cost-free liveness attack open on a mechanism whose purpose is censorship resistance — but the choice belongs to the authors.

Note the reference implementation is currently moving the other way: its blob filter was recently removed and the corresponding fixture expectation inverted. If this change is accepted, that filled test needs to change with it.

`ethereum/EIPs#12023` touches the same numbered list and will conflict.
