### PR TITLE
Update EIP-8081: remove 8268, add 8077, 8094, 8372

### DIFF
--- a/EIPS/eip-8081.md
+++ b/EIPS/eip-8081.md
@@ -48,6 +48,8 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Declined
 * [EIP-7979](./eip-7979.md): Call and Return Opcodes for the EVM
 * [EIP-8015](./eip-8015.md): Remove `deposit` and `eth1data` fields
 * [EIP-8025](./eip-8025.md): Optional Execution Proofs
+* [EIP-8077](./eip-8077.md): eth/XX - announce transactions with nonce
+* [EIP-8094](./eip-8094.md): eth/vhash - Blob-Aware Mempool
 * [EIP-8115](./eip-8115.md): Batch priority fees at end of block
 * [EIP-8116](./eip-8116.md): Replace cumulative receipt fields
 * [EIP-8131](./eip-8131.md): Unified Transaction Content Floor
@@ -64,13 +66,13 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Declined
 * [EIP-8243](./eip-8243.md): Batching Attestations at Source
 * [EIP-8250](./eip-8250.md): Keyed Nonces for Frame Transactions
 * [EIP-8253](./eip-8253.md): Bump nonce of zero-nonce storage accounts
-* [EIP-8268](./eip-8268.md): Storage Roots in Block Access Lists
 * [EIP-8272](./eip-8272.md): Recent Roots for Frame Transactions
 * [EIP-8279](./eip-8279.md): Block Access List Byte Floor
 * [EIP-8298](./eip-8298.md): SETCODEFROM Code Reuse Instruction
 * [EIP-8304](./eip-8304.md): Trustless log and transaction index
 * [EIP-8333](./eip-8333.md): Align Checkpoint with Epoch Boundary Block
 * [EIP-8363](./eip-8363.md): Tapered Issuance Burn
+* [EIP-8372](./eip-8372.md): Normalized state gas limit
 
 ### Activation
 


### PR DESCRIPTION
EIP-8268 withdrawn by author
EIPs -8077, -8094, -8372 presented on [ACDE 234](https://github.com/ethereum/pm/issues/2178)
