### PR TITLE
Update EIP-8141: account block execution gas before refund (EIP-7778)

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2026-01-29
-requires: 1559, 2718, 2780, 3529, 3607, 4844, 7594, 7623, 7702, 7708, 7825, 8037
+requires: 1559, 2718, 2780, 3529, 3607, 4844, 7594, 7623, 7702, 7708, 7778, 7825, 8037
 ---
 
 ## Abstract
@@ -620,14 +620,16 @@ After execution, return `payer_refund` to the payer. This is the `resolved_targe
 
 ###### Block-level gas accounting
 
-Blocks account for the two dimensions separately, per EIP-8037. A frame transaction contributes its settlement dimensions directly:
+Blocks account for the two dimensions separately, per EIP-8037. Because this EIP requires [EIP-7778](./eip-7778.md), the storage refund does not reduce the gas counted toward the block gas limit, so the execution dimension is accounted before the refund. This is the EIP-8037 EIP-7778 integration applied to the frame transaction's explicit dimensions: the state dimension stays net, since a state-gas refill reverses a charge for state that was never durably created rather than rebating performed work.
 
 ```python
-block_output.block_execution_gas_used += tx_execution_gas
+block_execution_gas = max(gas_used_before_refund - tx_state_gas, calldata_floor_gas)
+
+block_output.block_execution_gas_used += block_execution_gas
 block_output.block_state_gas_used += tx_state_gas
 ```
 
-All intrinsic costs are execution gas, so the execution dimension is the transaction total less its net state gas. Because `gas_used = tx_execution_gas + tx_state_gas`, the payer pays for exactly the capacity the transaction occupies across both dimensions, and receipt `cumulative_gas_used` deltas reconcile with the block counters. The block header `gas_used`, the block validity condition, and the base fee update rule follow EIP-8037 unchanged.
+All intrinsic costs are execution gas, so the execution dimension is the transaction total less its net state gas. The payer is charged `gas_used = tx_execution_gas + tx_state_gas` (post-refund), while the block counts `block_execution_gas + tx_state_gas` (execution pre-refund): the refund lowers the payer's cost without freeing the block capacity the transaction occupied, exactly as EIP-7778 intends. The block header `gas_used`, the block validity condition, and the base fee update rule follow EIP-8037 unchanged.
 
 A frame transaction may be included in a block only if its worst case fits the remaining capacity of **each** dimension:
 


### PR DESCRIPTION
EIP-8141 adopts the two-dimensional gas model of EIP-8037 and activates on a fork that also includes EIP-7778 (Amsterdam). EIP-8037's "Integration with EIP-7778" section accounts the block execution dimension **before** the storage refund, so a refund lowers the payer's cost without freeing the block capacity the transaction occupied — the DoS bound EIP-7778 exists to keep.

The current EIP-8141 settlement accounts `block_execution_gas_used` from `gas_used_after_refund` (post-refund), so a frame transaction re-opens the refund-based block-limit circumvention that EIP-7778 closes for every other transaction type on the same fork.

This PR:
- adds `7778` to `requires:`;
- accounts the block execution dimension from `gas_used_before_refund` (`block_execution_gas = max(gas_used_before_refund - tx_state_gas, calldata_floor_gas)`), mirroring EIP-8037's EIP-7778 integration;
- keeps the payer charge and receipt `cumulative_gas_used` on the post-refund `gas_used` unchanged; the state dimension stays net, since a state-gas refill is not a refund in the EIP-7778 sense.

Is the omission of the EIP-7778 integration a spec bug rather than an intended departure? EIP-8141's only documented departure from EIP-8037 is the calldata-floor payment rule; the refund/block-accounting integration appears to have been carried over from the pre-7778 form.
