### PR TITLE
Update EIP-145: repoint dead ethereum/tests shift test links

### DIFF
--- a/EIPS/eip-145.md
+++ b/EIPS/eip-145.md
@@ -400,14 +400,8 @@ Compiler support:
 
 ### Tests
 
-Sources:
-
-- https://github.com/ethereum/tests/tree/develop/src/GeneralStateTestsFiller/stShift
-
-Filled Tests:
-
-- https://github.com/ethereum/tests/tree/develop/GeneralStateTests/stShift
-- https://github.com/ethereum/tests/tree/develop/BlockchainTests/GeneralStateTests/stShift
+- [`stShift`](https://github.com/ethereum/execution-specs/tree/27174ca81b09dee4d41db23b40305cd1bb70f5bf/tests/ported_static/stShift) of the `ethereum/execution-specs` repository, ported from the static fillers this section previously linked.
+- [`eip145_bitwise_shift`](https://github.com/ethereum/execution-specs/tree/27174ca81b09dee4d41db23b40305cd1bb70f5bf/tests/constantinople/eip145_bitwise_shift) of the same repository.
 
 ## Copyright
 


### PR DESCRIPTION
Fixing three broken links in EIP-145. One EIP, one topic, per the contributor guidelines.

## The problem

The Tests section points at `ethereum/tests`, which no longer serves that content. All three 404:

```
404  https://github.com/ethereum/tests/tree/develop/src/GeneralStateTestsFiller/stShift
404  https://github.com/ethereum/tests/tree/develop/GeneralStateTests/stShift
404  https://github.com/ethereum/tests/tree/develop/BlockchainTests/GeneralStateTests/stShift
```

(checked with `curl -o /dev/null -w '%{http_code}' -L`)

The repository is still live and `develop` is still its default branch, so this is not a branch
rename: the `stShift` directories were removed when the static tests were migrated.

## The change

The tests are now in `ethereum/execution-specs`. Two directories cover this EIP:

- `tests/ported_static/stShift`, which that repository's `tests/ported_static/README.md`
  describes as "auto-converted from the static fillers in ethereum/tests" - that is exactly what
  the old `src/GeneralStateTestsFiller/stShift` link pointed at.
- `tests/constantinople/eip145_bitwise_shift`, written against this EIP directly.

Coverage lines up with the test cases in this EIP: 11 `SHL` cases here and 11 `shl` files there,
11 `SHR` here and 11 `shr` there, 16 `SAR` here and 18 `sar` files there, plus
`test_shift_signed_combinations.py`.

The separate "Sources" and "Filled Tests" headings are dropped because that split no longer
applies - execution-specs does not check filled fixtures into the repository, it generates them.

```diff
 ### Tests
 
-Sources:
-
-- https://github.com/ethereum/tests/tree/develop/src/GeneralStateTestsFiller/stShift
-
-Filled Tests:
-
-- https://github.com/ethereum/tests/tree/develop/GeneralStateTests/stShift
-- https://github.com/ethereum/tests/tree/develop/BlockchainTests/GeneralStateTests/stShift
+- [`stShift`](https://github.com/ethereum/execution-specs/tree/27174ca81b09dee4d41db23b40305cd1bb70f5bf/tests/ported_static/stShift) of the `ethereum/execution-specs` repository, ported from the static fillers this section previously linked.
+- [`eip145_bitwise_shift`](https://github.com/ethereum/execution-specs/tree/27174ca81b09dee4d41db23b40305cd1bb70f5bf/tests/constantinople/eip145_bitwise_shift) of the same repository.
```

Both new URLs are commit-pinned, per the execution-specs rule in EIP-1, and both return 200. The
commit is the same one used by the in-flight test-link moves (#12100 - #12106).

cc @axic @chfast
