### PR TITLE
Update EIP-2982: repoint dead eth2.0-specs merkle proofs link

### DIFF
--- a/EIPS/eip-2982.md
+++ b/EIPS/eip-2982.md
@@ -376,7 +376,7 @@ These requirements together make a Merkle tree structure the obvious choice.
 
 #### Generalized indices
 
-See https://github.com/ethereum/eth2.0-specs/blob/dev/ssz/merkle-proofs.md for a description of generalized indices, and how they allow for very easy verification of Merkle proofs "poking into" arbitrary positions in an object by representing paths as an integer or bitfield.
+See [`ssz/merkle-proofs.md`](https://github.com/ethereum/consensus-specs/blob/0ddf13b3dcdae1cc855c9aa8aa28af5e8c6f3c82/ssz/merkle-proofs.md) for a description of generalized indices, and how they allow for very easy verification of Merkle proofs "poking into" arbitrary positions in an object by representing paths as an integer or bitfield.
 
 ### The validator lifecycle
 


### PR DESCRIPTION
Fixing a broken link in EIP-2982. One EIP, one topic, per the contributor guidelines.

## The problem

The generalized indices reference points at a branch path that no longer resolves:

```
404  https://github.com/ethereum/eth2.0-specs/blob/dev/ssz/merkle-proofs.md
```

(checked with `curl -o /dev/null -w '%{http_code}' -L`)

`ethereum/eth2.0-specs` was renamed to `ethereum/consensus-specs`, and `ssz/merkle-proofs.md` was
then removed from it by "Remove SSZ specifications" (ethereum/consensus-specs#5523)
on 2026-08-12, which moved the SSZ specifications to `ethereum/ssz-specs`.

## The change

Repointed to the same file in `ethereum/consensus-specs`, pinned to the last commit that contains
it (`0ddf13b3`, immediately before the removal):

```diff
-See https://github.com/ethereum/eth2.0-specs/blob/dev/ssz/merkle-proofs.md for a description of generalized indices, and how they allow for very easy verification of Merkle proofs "poking into" arbitrary positions in an object by representing paths as an integer or bitfield.
+See [`ssz/merkle-proofs.md`](https://github.com/ethereum/consensus-specs/blob/0ddf13b3dcdae1cc855c9aa8aa28af5e8c6f3c82/ssz/merkle-proofs.md) for a description of generalized indices, and how they allow for very easy verification of Merkle proofs "poking into" arbitrary positions in an object by representing paths as an integer or bitfield.
```

The new URL returns 200 and the file does describe generalized indices, as the sentence claims.
It is also commit-pinned, which the old `blob/dev/` link was not, so it now matches the consensus
specs pattern EIP-1 requires:

```regex
^https://github.com/ethereum/consensus-specs/(blob|commit)/[0-9a-f]{40}/.*$
```

cc @djrtwo @vbuterin
