### PR TITLE
Update EIP-2028: repoint dead link in reference [3]

### DIFF
--- a/EIPS/eip-2028.md
+++ b/EIPS/eip-2028.md
@@ -71,7 +71,7 @@ To suggest the gas cost of calldata we shall conduct two types of tests:
 
 [2] Rafael Pass, Lior Seeman, Abhi Shelat: [Analysis of the Blockchain Protocol in Asynchronous Networks](https://eprint.iacr.org/2016/454.pdf), ePrint report 2016/454
 
-[3] Christian Decker, Roger Wattenhofer: [Information propagation in the Bitcoin network](https://www.gsd.inesc-id.pt/~ler/docencia/rcs1314/papers/P2P2013_041.pdf). P2P 2013: 1-10
+[3] Christian Decker, Roger Wattenhofer: [Information propagation in the Bitcoin network](https://tik-old.ee.ethz.ch/file/49318d3f56c1d525aabf7fda78b23fc0/P2P2013_041.pdf). P2P 2013: 1-10
 
 [4] Vitalik Buterin: [Uncle Rate and Transaction Fee Analysis](https://blog.ethereum.org/2016/10/31/uncle-rate-transaction-fee-analysis/)
 


### PR DESCRIPTION
Fixing a broken link in EIP-2028. One EIP, one topic, per the contributor guidelines.

## The problem

Reference [3] points at a university course page that no longer resolves:

```
000  https://www.gsd.inesc-id.pt/~ler/docencia/rcs1314/papers/P2P2013_041.pdf
```

(connection fails, checked with `curl -o /dev/null -w '%{http_code}' -L`)

That was a course mirror of the paper, not its home.

## The change

Repointed to the copy hosted by ETH Zurich, the first author's institution:

```diff
-[3] Christian Decker, Roger Wattenhofer: [Information propagation in the Bitcoin network](https://www.gsd.inesc-id.pt/~ler/docencia/rcs1314/papers/P2P2013_041.pdf). P2P 2013: 1-10
+[3] Christian Decker, Roger Wattenhofer: [Information propagation in the Bitcoin network](https://tik-old.ee.ethz.ch/file/49318d3f56c1d525aabf7fda78b23fc0/P2P2013_041.pdf). P2P 2013: 1-10
```

Returns 200. I downloaded it and checked the contents rather than matching on the filename: it is
"Information Propagation in the Bitcoin Network", Christian Decker and Roger Wattenhofer, 13th
IEEE International Conference on Peer-to-Peer Computing - the same paper reference [3] cites.

cc @AlexeyAkhunov
