### PR TITLE
Update EIP-779: repoint dead blog.slock.it reference

### DIFF
--- a/EIPS/eip-779.md
+++ b/EIPS/eip-779.md
@@ -193,7 +193,7 @@ Blocks with block numbers in the range [1_920_000, 1_920_009] **MUST** have `0x6
 
 ## References
 
-1. https://blog.slock.it/hard-fork-specification-24b889e70703
+1. https://web.archive.org/web/20200509211658/https://blog.slock.it/hard-fork-specification-24b889e70703
 2. https://blog.ethereum.org/2016/07/15/to-fork-or-not-to-fork/
 
 ## Copyright


### PR DESCRIPTION
Fixing a broken link in EIP-779. One EIP, one topic, per the contributor guidelines.

## The problem

Reference 1 points at `blog.slock.it`, which no longer resolves:

```
000  https://blog.slock.it/hard-fork-specification-24b889e70703
```

(connection fails, checked with `curl -o /dev/null -w '%{http_code}' -L`)

The host is gone, so there is no live replacement to point at. There is an archived copy.

## The change

```diff
 ## References
 
-1. https://blog.slock.it/hard-fork-specification-24b889e70703
+1. https://web.archive.org/web/20200509211658/https://blog.slock.it/hard-fork-specification-24b889e70703
 2. https://blog.ethereum.org/2016/07/15/to-fork-or-not-to-fork/
```

The snapshot returns 200. It is the DAO hard fork specification this EIP cites.

Worth flagging for the editors: `web.archive.org` is not on the permitted external resources list
in EIP-1. I went with it because the alternative is deleting a reference from a Final EIP and
losing the citation entirely. If the editors would rather drop the line, say so and I will change
it to a removal.

cc @cdetrio
