### PR TITLE
Update EIP-8246: note the CREATE2 redeploy of a funded remnant

### DIFF
--- a/EIPS/eip-8246.md
+++ b/EIPS/eip-8246.md
@@ -118,6 +118,7 @@ Each of the following test cases should be executed (where physically meaningful
 
 1. `SELFDESTRUCT` behavior modification has a combinatorial effect on a vast number of test scenarios involving multi-call/create contract interactions. This EIP requires significant testing effort. However, many existing test cases for EIP-6780 can be adapted to the new behavior.
 2. When a use case relies on the ETH burn happening, the transaction will create dust-like accounts with potentially locked non-zero balance. However, the new account creation gas cost is paid by the transaction, so dust accounts are not a free DoS vector. Only 2 such events have been recorded on Mainnet (Cancun–25M) so far.
+3. Preserving the balance leaves a funded account whose nonce, code and storage are cleared, which makes the address a valid `CREATE2` target again (a non-zero balance alone never triggers a creation collision, per [EIP-684](./eip-684.md)). The `(sender, salt, initcode)` of a deployment is public data, so when the `sender` is a permissionless factory anyone can redeploy the account and potentially take the preserved balance.
 
 ## Copyright
 


### PR DESCRIPTION
Clearing nonce, code and storage while preserving the balance reopens the address as a CREATE2 target, since a non-zero balance alone never triggers a creation collision.

Answer to https://ethereum-magicians.org/t/eip-proposal-remove-selfdestruct-burn/28416/3 by @Carsons-Eels .