### PR TITLE
Update EIP-8141: Move mode section under Frame definition

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -102,6 +102,18 @@ Below are high-level definitions of each field in the transaction definition. De
 - `value` -- the amount in wei that should transferred from the `sender` as part of the frame execution.
 - `data` -- the calldata provided to the top level call frame.
 
+###### Mode
+
+The `mode` of each frame sets the context of execution. It allows the protocol to identify
+the purpose of the frame within the execution loop.
+
+| `mode`  | Name           | Summary                                    |
+|---------|----------------|--------------------------------------------|
+| 0       | `DEFAULT` mode | Execute frame as `ENTRY_POINT`             |
+| 1       | `VERIFY` mode  | Frame identifies as transaction validation |
+| 2       | `SENDER` mode  | Execute frame as `sender`                  |
+
+
 ###### Flags
 
 The `flags` field configures additional execution constraints. Bit positions are zero-based, with the least significant bit numbered `0`.
@@ -123,16 +135,6 @@ The `flags` field configures additional execution constraints. Bit positions are
 - `signer` -- scheme-dependent signer metadata; for `SECP256K1` and `P256`, this is a 20-byte address.
 - `msg` -- either empty, indicating the canonical transaction signature hash, or an explicit 32-byte digest.
 - `signature` -- raw signature bytes interpreted according to `scheme`.
-
-The `mode` of each frame sets the context of execution. It allows the protocol to identify
-the purpose of the frame within the execution loop.
-
-| `mode`  | Name           | Summary                                    |
-|---------|----------------|--------------------------------------------|
-| 0       | `DEFAULT` mode | Execute frame as `ENTRY_POINT`             |
-| 1       | `VERIFY` mode  | Frame identifies as transaction validation |
-| 2       | `SENDER` mode  | Execute frame as `sender`                  |
-
 
 #### Constraints
 


### PR DESCRIPTION
### Summary

* **Kind:**  📝 Editorial 
* **Breaking Change:**  No

Move "mode" section under Frame definition.

---

### What changed

The section for frame's mode field moved from "Signature object" to  "Frame object".

---

### Why

It was placed under the wrong header.

---

### For Implementers


* **Action Required:** No

Prose-only clarification. No implementation changes needed.

