### PR TITLE
Update EIP-8246: give a concrete example of L2 burn usage

### DIFF
--- a/EIPS/eip-8246.md
+++ b/EIPS/eip-8246.md
@@ -69,7 +69,9 @@ For the balance-only accounts created this way, `CREATE2` still may recreate a c
 
 For contracts not created in the same transaction in which `SELFDESTRUCT` is executed, the behavior is unchanged from [EIP-6780](./eip-6780.md).
 
-Unlike Mainnet, Optimism-based L2 chains use the burn feature of `SELFDESTRUCT` regularly. These chains will require a separate migration plan.
+Unlike Mainnet, some L2 chains use the burn feature of `SELFDESTRUCT` regularly and will require a separate migration plan.
+
+In the OP Stack, ETH withdrawn to L1 accumulates in the `L2ToL1MessagePasser` predeploy at `0x4200000000000000000000000000000000000016`. It provides a permissionless `burn()` function which destroys that balance by creating a contract whose constructor executes `SELFDESTRUCT` with itself as the beneficiary, so the L2 ETH supply does not inflate. Chains derived from that codebase inherit the dependency unless they modify the predeploy, including those not commonly identified as Optimism-based. Such contracts are deployed with `CREATE`, so the balance-only accounts they leave behind cannot be recreated by the `CREATE2` pattern described above.
 
 ## Test Cases
 


### PR DESCRIPTION
The Backwards Compatibility note named Optimism-based chains without saying what the dependency is. Point at the OP Stack withdrawal burn: a permissionless burn() in a system predeploy, inherited by derivatives of that codebase.