### PR TITLE
Update EIP-8037: decouple SYSTEM_MAX_SSTORES_PER_CALL from request bounds

### DIFF
--- a/EIPS/eip-8037.md
+++ b/EIPS/eip-8037.md
@@ -257,7 +257,7 @@ SYSTEM_CALL_GAS_LIMIT = 30_000_000 + STATE_BYTES_PER_STORAGE_SET × CPSB × SYST
 
 This ensures preservation of the existing execution margin for system contracts under higher state creation costs.
 
-Here, `SYSTEM_MAX_SSTORES_PER_CALL = 16` is the upper bound on the number of new storage slots a single system call is expected to write. This value matches `MAX_WITHDRAWAL_REQUESTS_PER_BLOCK` ([EIP-7002](./eip-7002.md)), the largest per-block bound across the existing system contracts.
+Here, `SYSTEM_MAX_SSTORES_PER_CALL = 16` is the upper bound on the number of new storage slots a single system call is expected to write. It is a margin rather than a bound derived from any particular system contract, and must be re-derived if a system call can write more new slots.
 
 The additional `STATE_BYTES_PER_STORAGE_SET × CPSB × SYSTEM_MAX_SSTORES_PER_CALL` is placed in `state_gas_reservoir` while the rest of the system call's gas is placed in `gas_left`. System calls remain not subject to the [EIP-7825](./eip-7825.md) `TX_MAX_GAS_LIMIT` cap, do not count against the block gas limit, and do not contribute to either `block_execution_gas_used` or `block_state_gas_used`.
 


### PR DESCRIPTION
The value was justified as matching MAX_WITHDRAWAL_REQUESTS_PER_BLOCK, but that constant counts records dequeued, and dequeuing writes no record slots: the queue entries are written by the submitters' own calls, while the system call only advances the head pointer and updates the contract's header slots. The justification is also stale, since EIP-8282 adds a system contract whose per-block bound is larger. State the value as a margin with an explicit re-derivation condition instead.