### PR TITLE
Update EIP-8347: add EIP-7523 to requires

### DIFF
--- a/EIPS/eip-8347.md
+++ b/EIPS/eip-8347.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2026-07-23
-requires: 7928, 8159, 8297
+requires: 7523, 7928, 8159, 8297
 ---
 
 ## Abstract


### PR DESCRIPTION
Adding lacking mention of `7523` in required list