### PR TITLE
Add EIP: Contract Storage Layout Descriptor Format

### DIFF
--- a/EIPS/eip-8317.md
+++ b/EIPS/eip-8317.md
@@ -1,0 +1,344 @@
+---
+eip: 8317
+title: Contract Storage Layout Descriptor Format
+description: A language-neutral extensible format for describing storage layouts of EVM contracts
+author: Alex Forshtat (@forshtat)
+discussions-to: https://ethereum-magicians.org/t/erc-8317-contract-storage-layout-descriptor-format/28864
+status: Draft
+type: Standards Track
+category: Interface
+created: 2026-06-25
+requires: 7201, 7730, 8042
+---
+
+## Abstract
+
+Definition of a JSON format for describing the "storage layout" of an EVM contract.
+
+The storage layout represents the mapping from the smart contracts' state variables as defined in the source code to their EVM-level storage locations.
+
+The format is extensible and is therefore not tied to any single source language or compiler. It can accommodate layouts produced by any EVM-targeting compiler, as well as more advanced and manually controlled use-cases like ([ERC-7201](./eip-7201.md)), ([ERC-8042](./eip-8042.md)), and a hand-written EVM assembly storage.
+
+Consumers of these descriptors — block explorers, debuggers, source-verification services, security tooling, and wallets performing clear signing, transaction simulations, and transaction assertions — can use a single, predictable schema regardless of how a contract was written.
+
+## Motivation
+
+Tools that need to make sense of raw storage slots, such as block explorers, debuggers, wallets that show users the outcome of a transaction before they sign, and other similar projects, currently have no common and trusted layout description format and have to rely on their own custom storage layout interpretation.
+
+Solidity's `storageLayout` JSON output often serves as a de facto standard, but it has some structural problems making it unfit to be used in scenarios where a finalized ERC-level standard would be required:
+
+1. **It is Solidity specific.** For example, type identifiers such as `t_uint256` are Solidity-internal naming. As of this writing, no other EVM language emits the storage layout descriptors in a compatible format. 
+2. **It is not stable.** The format documentation states the storage layout is experimental and the format is subject to change in non-breaking releases.
+3. **It does not support any common alternative layouts.** For example, namespaced storage ([ERC-7201](./eip-7201.md)) and diamond storage ([ERC-8042](./eip-8042.md)) place structs at a `keccak256`-derived slot reached through an inline-assembly pointer. Solidity compiler is not aware of these standards and is unable to generate their layout's descriptor.
+
+The proposed storage layout format is intended for cross-chain, cross-tool, and cross-language wallets that need to translate raw `(contract, slot, old_value, new_value)` tuples from transaction simulation or [EIP-7906](./eip-7906.md) transaction assertions into a meaningful description of *which variable* changed as the result of this transaction.
+
+Therefore, this format must satisfy the following requirements:
+
+* Use a type and encoding vocabulary that is not coupled to any specific compiler's internal naming.
+* Verifiably describe the slot derivation algorithms rather than providing opaque trusted constants for complex types.
+* Allow storage regions to declare how their base slots were derived. This includes but is not limited to namespaced and diamond schemes.
+* Allow entries explicitly marked as either compiler-derived or hand-authored, since for a significant share of production contracts, such as upgradeable proxies, diamonds, [EIP-7702](./eip-7702.md) delegates, etc., there is no compiler output to derive them from.
+* Carry optional display annotations that wallets may use to present storage changes in human-readable form, following the [ERC-7730](./eip-7730.md) display vocabulary.
+
+## Specification
+
+### File structure
+
+A storage layout file is a JSON object with the following top-level members. See [`storage-layout.schema.json`](../assets/eip-8317/storage-layout.schema.json) for the full JSON Schema, [`example-erc20.json`](../assets/eip-8317/example-erc20.json) for an ordinary sequential layout, [`example-eip7702-namespaced.json`](../assets/eip-8317/example-eip7702-namespaced.json) for a layout mixing sequential and ERC-7201 namespaced storage, and [`example-erc8042-diamond.json`](../assets/eip-8317/example-erc8042-diamond.json) for an ERC-8042 Diamond Storage layout.
+
+| Field      | Required | Description                                                                                        |
+|------------|----------|----------------------------------------------------------------------------------------------------|
+| `$schema`  | No       | URI of the JSON Schema this file conforms to.                                                      |
+| `$comment` | No       | Free-text documentation of the file's purpose or provenance.                                       |
+| `compiler` | Yes      | Object identifying the source language and compiler used. See [Compiler object](#compiler-object). |
+| `storage`  | Yes      | Ordered array of top-level [storage entries](#storage-entry).                                      |
+| `types`    | Yes      | Object mapping type identifiers to [type definitions](#type-definition).                           |
+
+#### Compiler object
+
+| Field      | Required | Description                                                                                    |
+|------------|----------|------------------------------------------------------------------------------------------------|
+| `language` | Yes      | Source language. This ERC defines support for `"Solidity"`, `"Vyper"`, and `"manual"`.        |
+| `version`  | No       | Compiler version string (e.g. `"0.8.24"`).                                                    |
+| `settings` | No       | Arbitrary compiler settings object.                                                            |
+
+A single file MAY mix entries whose slots were assigned by the declared compiler with entries that were defined manually.
+
+`"manual"` MUST be used as `language` when no compiler produced any part of the layout (e.g. Huff, raw Yul, hand-written assembly).
+
+#### Storage entry
+
+Each element of the top-level `storage` array, and each element of a struct type's `members` array, is a storage entry:
+
+| Field                | Required | Description                                                                                                                                                                                |
+|----------------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `label`              | Yes      | Source-level variable name.                                                                                                                                                                |
+| `slot`               | Yes      | Decimal string of the storage slot where this entry resides or starts.                                                                                                                     |
+| `offset`             | Yes      | Byte offset within the slot where this entry begins. `0` for any type occupying a full slot or more.                                                                                       |
+| `type`               | Yes      | Identifier referencing an entry in the file's `types` object.                                                                                                                              |
+| `path`               | No       | Stable dot-separated identifier for this entry (e.g. `"vaults.lockedAmount"`). If absent, consumers MUST compute it by joining `label` values from the top-level entry down through struct members. |
+| `source`             | No       | `"compiler"` (default) or `"manual"`. `"compiler"` means the slot and offset were emitted by the declared compiler from verifiable source. `"manual"` means the author declared them directly. |
+| `baseSlotDerivation` | No       | For entries whose base slot was computed via an alternative scheme rather than simple sequential compiler assignment. See [Base Slot Derivation](#base-slot-derivation).                   |
+| `display`            | No       | Optional display annotations for wallets. See [Display Annotations](#display-annotations).                                                                                                 |
+
+#### Type definition
+
+Each value in the top-level `types` object describes one type referenced by `type` fields elsewhere in the file:
+
+| Field           | Required                             | Description                                                                                                        |
+|-----------------|--------------------------------------|--------------------------------------------------------------------------------------------------------------------|
+| `encoding`      | Yes                                  | Storage encoding: `inplace`, `inplace_struct`, `mapping`, `dynamic_array`, or `bytes`. See [Slot Derivation Formulas](#slot-derivation-formulas). |
+| `label`         | Yes                                  | Human-readable type name as it appears in the source language (e.g. `"uint256"`, `"mapping(address => uint256)"`). |
+| `numberOfBytes` | Yes                                  | Decimal string: number of bytes this type occupies. Used with the entry's `offset` to extract a packed value.      |
+| `key`           | `mapping` only                       | Type identifier of the mapping key.                                                                                |
+| `value`         | `mapping` and `dynamic_array` only   | Type identifier of the mapping value or array element.                                                             |
+| `base`          | `dynamic_array` only                 | Alias of `value`, kept for literal compatibility with Solidity compiler output.                                    |
+| `members`       | `inplace_struct` only                | Ordered array of [storage entries](#storage-entry) describing the struct's members.                                |
+
+### Base Slot Derivation
+
+An entry's `baseSlotDerivation` object names the scheme used to compute its `slot`, so that consumers can independently recompute and verify it:
+
+| Field         | Required                    | Description                                                                                           |
+|---------------|-----------------------------|-------------------------------------------------------------------------------------------------------|
+| `scheme`      | Yes                         | One of supported base slot calculation algorithms. Currently `"erc7201"`, `"erc8042"`, or `"custom"`. |
+| `namespaceId` | `erc7201`, `erc8042` only   | The namespace id string the scheme hashes.                                                            |
+| `formula`     | `custom` only               | Free-text, non-machine-verified description of how `slot` was computed.                               |
+
+For `scheme: "erc7201"`, consumers MAY verify `slot == keccak256(keccak256(namespaceId) - 1) & ~0xff` per [ERC-7201](./eip-7201.md).
+
+For `scheme: "erc8042"`, consumers MAY verify `slot == keccak256(namespaceId)` per [ERC-8042](./eip-8042.md).
+
+`"custom"` exists for schemes not yet standardized by an ERC; its `slot` is hand-authored.
+
+`baseSlotDerivation` MUST NOT be used for sequential, compiler-assigned slots, including slots shifted by Solidity's native `layout at` base-slot syntax — in both cases the compiler emits the final, absolute slot directly, and no separate re-derivation is meaningful.
+
+### Packed Variables
+
+Solidity and Vyper may pack multiple small variables into a single 32-byte slot. When a packed slot is modified, consumers MUST identify which variables changed by inspecting each entry whose `slot` matches, using `offset` and `numberOfBytes` from the entry's type to extract the specific bytes.
+
+To extract the value of a packed variable from a raw 32-byte slot word: read `numberOfBytes` bytes starting at byte `offset` within the slot.
+
+When a packed slot changes, wallets MAY omit variables whose extracted old and new values are identical.
+
+### Slot Derivation Formulas
+
+`inplace` types (primitives and fixed-size value types such as `uint256`, `address`, `bytes32`) are stored directly at their declared `slot` and `offset`; no further derivation is needed.
+
+Complex types are not stored directly at their entry's `slot`; child values are stored at a position computed from the entry's `slot` (acting as a base slot), the type's `encoding`, and the declared `compiler.language`. Wallets and other consumers that need to map a raw modified slot back to a storage entry MUST implement the formulas below for every `compiler.language` value they support:
+
+| Language | `encoding`        | Derivation formula                                                                                                                                                                                                                                              |
+|----------|-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Solidity | `inplace_struct`  | `baseSlot + member.slot`                                                                                                                                                                                                                                        |
+| Solidity | `mapping`         | `keccak256(abi.encode(key, baseSlot))`                                                                                                                                                                                                                          |
+| Solidity | `dynamic_array`   | `keccak256(baseSlot) + index * elementSlots`                                                                                                                                                                                                                    |
+| Solidity | `bytes`           | Short form (`numberOfBytes(value) <= 31`): inline in `baseSlot`. Long form: data at `keccak256(baseSlot)`, sequential. Length is stored in the low-order byte of `baseSlot`. |
+| Vyper    | `inplace_struct`  | `baseSlot + member.slot`                                                                                                                                                                                                                                        |
+| Vyper    | `mapping`         | `keccak256(abi.encode(key, baseSlot))` (Vyper ≥ 0.3.0) or `keccak256(abi.encode(baseSlot, key))` (Vyper < 0.3.0) — note the reversed key/slot order in legacy Vyper.                                                                                           |
+| Vyper    | `dynamic_array`   | `baseSlot + 1 + index * elementSlots`                                                                                                                                                                                                                           |
+| Vyper    | `bytes`           | Stored inline starting at `baseSlot`, spanning `ceil(length / 32)` slots sequentially. Unlike Solidity, Vyper never relocates `bytes`/`string` data behind a `keccak256` indirection.                                                                          |
+
+Where `elementSlots = ceil(elementSize / 32)`, derived from the element type's `numberOfBytes`. For nested types, derivation is applied recursively at each level.
+
+This table is the canonical, normative source of derivation formulas defined by this ERC. Support for additional values of `compiler.language` MUST be added via an update to this ERC.
+
+### Nested and Complex Types
+
+Storage can involve complex nesting of mappings, arrays, and structs. Consumers resolve nested types recursively:
+
+1. **Mappings:** Each nesting level adds a key. `mapping(address => mapping(uint256 => uint256))` uses `{key[0]}` for the outer key and `{key[1]}` for the inner key.
+2. **Arrays:** Each nesting level adds an index. `uint256[][]` uses `{index[0]}` for the outer dimension and `{index[1]}` for the inner.
+3. **Structs:** Members are defined in the `types` object (with `encoding: "inplace_struct"`), each with their own optional `display` annotation. When a struct member changes, the wallet displays the parent variable's resolved label alongside the member's own label.
+
+### Display Annotations
+
+Each storage entry and each struct member in `types` may carry an optional `display` object. These annotations follow the [ERC-7730](./eip-7730.md) display vocabulary and are consumed by wallets to present storage changes in human-readable form during transaction simulation and clear signing.
+
+| Field        | Required | Description                                                                                                                                                       |
+|--------------|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `label`      | No       | User-facing name for the variable. Supports `{key[N]}` and `{index[N]}` placeholders. See [Labels and Placeholders](#labels-and-placeholders).                    |
+| `description`| No       | Human-readable explanation of the variable's semantic meaning. Informative only — MUST NOT be relied upon for security decisions without additional authenticity assurances. |
+| `keyFormats` | No       | Array of formatters applied to mapping keys or array indices before they are embedded in `label`. See [Key Formats](#key-formats).                                 |
+| `format`     | No       | The ERC-7730 formatter (`tokenAmount`, `addressName`, `raw`, `date`, etc.) applied to the storage value itself. Same vocabulary as `display.formats[*].fields[*].format` in ERC-7730. |
+| `params`     | No       | Formatter parameters for `format`. Same structure as `display.formats[*].fields[*].params` in ERC-7730.                                                           |
+| `template`   | No       | Natural-language description of the change to this variable. See [Templates and JSON Logic](#templates-and-json-logic).                                            |
+
+#### Labels and Placeholders
+
+The `label` string may embed placeholder tokens that are resolved at display time:
+
+- `{key[N]}` — the Nth mapping key (outermost = `{key[0]}`), formatted by `keyFormats[N]` if provided.
+- `{index[N]}` — the Nth array element index (outermost = `{index[0]}`), formatted by `keyFormats[N]` if provided.
+
+#### Key Formats
+
+`keyFormats` is an ordered array of formatter objects. Each entry has the same `format` and `params` structure as ERC-7730 field formatters and is applied to the corresponding key or index level before it is embedded in `label`.
+
+`keyFormats[0]` applies to `{key[0]}` or `{index[0]}`, `keyFormats[1]` to `{key[1]}` or `{index[1]}`, and so on.
+
+#### Templates and JSON Logic
+
+`template` is either a plain string or an ordered array of conditional entries:
+
+- **Plain string**: used unconditionally.
+- **Array**: each entry has a `value` string and an optional `condition`. The wallet evaluates entries in order and uses the first entry whose condition is satisfied. An entry without `condition` matches unconditionally and SHOULD appear last as the fallback.
+
+Template strings support the following placeholders:
+
+- `{label}` — the resolved `label` of this entry.
+- `{oldValue}` — the storage value before the transaction, after applying `format`/`params`.
+- `{newValue}` — the storage value after the transaction, after applying `format`/`params`.
+
+Conditions are JSON Logic expressions as defined in [JSON Logic](#json-logic).
+
+#### Display Examples
+
+*[ERC-20](./eip-20.md) balances mapping:*
+
+```json
+{
+    "label": "_balances",
+    "slot": "1",
+    "type": "t_mapping(t_address,t_uint256)",
+    "display": {
+        "label": "Balance of {key[0]}",
+        "description": "Token balance held by each account.",
+        "keyFormats": [{ "format": "addressName" }],
+        "format": "tokenAmount",
+        "params": { "tokenPath": "@.to" },
+        "template": [
+            {
+                "condition": { ">": [{ "var": "newValue" }, { "var": "oldValue" }] },
+                "value": "Balance of {key[0]} increased from {oldValue} to {newValue}"
+            },
+            {
+                "condition": { "<": [{ "var": "newValue" }, { "var": "oldValue" }] },
+                "value": "Balance of {key[0]} decreased from {oldValue} to {newValue}"
+            },
+            {
+                "value": "Balance of {key[0]} changed from {oldValue} to {newValue}"
+            }
+        ]
+    }
+}
+```
+
+*Mapping to a struct (vault pattern):*
+
+```solidity
+struct VaultInfo {
+    uint256 lockedAmount;
+}
+
+mapping(address => VaultInfo) private vaults;
+```
+
+```json
+{
+    "storage": [{
+        "label": "vaults",
+        "slot": "10",
+        "type": "t_mapping(t_address,t_struct(VaultInfo))",
+        "display": {
+            "label": "Vault belonging to {key[0]}",
+            "keyFormats": [{ "format": "addressName" }]
+        }
+    }],
+    "types": {
+        "t_struct(VaultInfo)": {
+            "encoding": "inplace_struct",
+            "label": "struct VaultInfo",
+            "numberOfBytes": "32",
+            "members": [
+                {
+                    "label": "lockedAmount",
+                    "slot": "0",
+                    "offset": 0,
+                    "type": "t_uint256",
+                    "display": {
+                        "label": "Locked Amount",
+                        "format": "tokenAmount",
+                        "params": { "tokenPath": "@.to" },
+                        "template": [
+                            {
+                                "condition": { ">": [{ "var": "newValue" }, { "var": "oldValue" }] },
+                                "value": "Locked Amount increased from {oldValue} to {newValue}"
+                            },
+                            {
+                                "condition": { "<": [{ "var": "newValue" }, { "var": "oldValue" }] },
+                                "value": "Locked Amount decreased from {oldValue} to {newValue}"
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+}
+```
+
+When `vaults[0xAlice].lockedAmount` changes, the wallet presents the parent label `"Vault belonging to Alice.eth"` alongside the member label `"Locked Amount"`.
+
+### JSON Logic
+
+Conditions are JSON Logic expressions. This ERC normatively defines the subset of JSON Logic used by conditions and does not depend on the external JSON Logic specification.
+
+A JSON Logic expression is a JSON object with exactly one key naming the operator and an array of operands as its value:
+
+```json
+{ "<operator>": [<operand>, <operand>, ...] }
+```
+
+Operands are themselves JSON Logic expressions or literal JSON values. A condition passes when its top-level expression evaluates to a truthy value.
+
+Expressions are evaluated against the following context:
+
+| Variable   | Type  | Description                                                       |
+|------------|-------|-------------------------------------------------------------------|
+| `oldValue` | value | Storage value before the transaction, after applying `format`.    |
+| `newValue` | value | Storage value after the transaction, after applying `format`.     |
+| `key`      | array | Raw mapping keys at each nesting level, outermost first.          |
+| `index`    | array | Array element indices at each nesting level, outermost first.     |
+
+The `var` operator returns the value of a context variable: `{"var": "oldValue"}` evaluates to the `oldValue` variable. Elements of `key` and `index` are addressed with dot-separated paths: `{"var": "key.0"}` returns the outermost mapping key, `{"var": "index.1"}` returns the second array index, and so on.
+
+The following operators MUST be supported:
+
+| Operator | Example              | Returns                                       |
+|----------|----------------------|-----------------------------------------------|
+| `==`     | `{"==": [a, b]}`     | `true` if `a` equals `b`.                     |
+| `!=`     | `{"!=": [a, b]}`     | `true` if `a` does not equal `b`.             |
+| `>`      | `{">": [a, b]}`      | `true` if `a` is greater than `b`.            |
+| `>=`     | `{">=": [a, b]}`     | `true` if `a` is greater than or equal to `b`. |
+| `<`      | `{"<": [a, b]}`      | `true` if `a` is less than `b`.               |
+| `<=`     | `{"<=": [a, b]}`     | `true` if `a` is less than or equal to `b`.   |
+| `!`      | `{"!": [a]}`         | `true` if `a` is falsy.                       |
+| `and`    | `{"and": [a, b]}`    | `true` if both `a` and `b` are truthy.        |
+| `or`     | `{"or": [a, b]}`     | `true` if either `a` or `b` is truthy.        |
+| `var`    | `{"var": "<path>"}`  | Value of the context variable at `<path>`.    |
+
+The comparison operators accept two operands and return a boolean. `!` accepts a single operand. `and` and `or` accept one or more operands. `var` accepts a single string operand. The values `false`, `0`, the empty string, the empty array, and `null` are falsy; all other values are truthy.
+
+Wallets MUST NOT rely on any other JSON Logic operators or features being available.
+
+## Rationale
+
+### Transient storage is out of scope
+
+While any change persisted in the contract's storage may be extremely consequential for the user, the transient storage is cleared after the transaction completes and bears no effect on the transaction outcome.
+
+There is no use-case that would require knowledge of the transient storage variable layout in the same way as the persistent one.
+
+## Backwards Compatibility
+
+This ERC defines a new file format and introduces no backwards compatibility concerns.
+
+## Security Considerations
+
+A storage layout file that misrepresents a slot's `type` or `path` could cause a consumer to display a misleading variable name or formatted value for a real storage change.
+This ERC does not define a trust or distribution mechanism for storage layout files. Standards that reference files conforming to this ERC, such as ERC-7730, are responsible for defining how a layout file's authenticity is established before it is relied upon for any security-relevant display.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](../LICENSE.md).

--- a/EIPS/eip-8317.md
+++ b/EIPS/eip-8317.md
@@ -168,8 +168,8 @@ Each storage entry and each struct member in `types` may carry an optional `disp
 
 The `label` string may embed placeholder tokens that are resolved at display time:
 
-- `{key[N]}` — the Nth mapping key (outermost = `{key[0]}`), formatted by `keyFormats[N]` if provided.
-- `{index[N]}` — the Nth array element index (outermost = `{index[0]}`), formatted by `keyFormats[N]` if provided.
+* `{key[N]}` — the Nth mapping key (outermost = `{key[0]}`), formatted by `keyFormats[N]` if provided.
+* `{index[N]}` — the Nth array element index (outermost = `{index[0]}`), formatted by `keyFormats[N]` if provided.
 
 #### Key Formats
 
@@ -181,14 +181,14 @@ The `label` string may embed placeholder tokens that are resolved at display tim
 
 `template` is either a plain string or an ordered array of conditional entries:
 
-- **Plain string**: used unconditionally.
-- **Array**: each entry has a `value` string and an optional `condition`. The wallet evaluates entries in order and uses the first entry whose condition is satisfied. An entry without `condition` matches unconditionally and SHOULD appear last as the fallback.
+* **Plain string**: used unconditionally.
+* **Array**: each entry has a `value` string and an optional `condition`. The wallet evaluates entries in order and uses the first entry whose condition is satisfied. An entry without `condition` matches unconditionally and SHOULD appear last as the fallback.
 
 Template strings support the following placeholders:
 
-- `{label}` — the resolved `label` of this entry.
-- `{oldValue}` — the storage value before the transaction, after applying `format`/`params`.
-- `{newValue}` — the storage value after the transaction, after applying `format`/`params`.
+* `{label}` — the resolved `label` of this entry.
+* `{oldValue}` — the storage value before the transaction, after applying `format`/`params`.
+* `{newValue}` — the storage value after the transaction, after applying `format`/`params`.
 
 Conditions are JSON Logic expressions as defined in [JSON Logic](#json-logic).
 

--- a/assets/eip-8317/example-eip7702-namespaced.json
+++ b/assets/eip-8317/example-eip7702-namespaced.json
@@ -1,0 +1,116 @@
+{
+    "$schema": "./storage-layout.schema.json",
+
+    "$comment": "Storage layout for an EIP-7702 delegate contract mixing sequential and ERC-7201 namespaced storage. '_owner' is ordinary sequential storage emitted by solc. 'spendingLimit' is a struct reached through an ERC-7201 namespaced pointer in inline assembly — solc's own storageLayout output is empty for it, so it is declared manually here with a verifiable baseSlotDerivation.",
+
+    "compiler": {
+        "language": "Solidity",
+        "version": "0.8.26"
+    },
+
+    "storage": [
+        {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_address",
+            "display": {
+                "label": "Owner",
+                "description": "The account that controls this delegate.",
+                "format": "addressName"
+            }
+        },
+        {
+            "label": "spendingLimit",
+            "path": "spendingLimit",
+            "offset": 0,
+            "slot": "112319066037093618069807655578501645787519347644613079360284539174630667485440",
+            "type": "t_struct(SpendingLimit)",
+            "source": "manual",
+            "baseSlotDerivation": {
+                "scheme": "erc7201",
+                "namespaceId": "erc7702delegate.storage.SpendingLimit"
+            },
+            "display": {
+                "label": "Spending Limit",
+                "description": "Daily spending limit configuration for this delegate."
+            }
+        }
+    ],
+
+    "types": {
+        "t_address": {
+            "encoding": "inplace",
+            "label": "address",
+            "numberOfBytes": "20"
+        },
+        "t_uint256": {
+            "encoding": "inplace",
+            "label": "uint256",
+            "numberOfBytes": "32"
+        },
+        "t_uint48": {
+            "encoding": "inplace",
+            "label": "uint48",
+            "numberOfBytes": "6"
+        },
+        "t_struct(SpendingLimit)": {
+            "encoding": "inplace_struct",
+            "label": "struct SpendingLimit",
+            "numberOfBytes": "96",
+            "members": [
+                {
+                    "label": "dailyLimit",
+                    "path": "spendingLimit.dailyLimit",
+                    "offset": 0,
+                    "slot": "0",
+                    "type": "t_uint256",
+                    "source": "manual",
+                    "display": {
+                        "label": "Daily Limit",
+                        "description": "Maximum amount that may be spent in a 24-hour window.",
+                        "format": "tokenAmount",
+                        "params": { "tokenPath": "@.to" }
+                    }
+                },
+                {
+                    "label": "spentToday",
+                    "path": "spendingLimit.spentToday",
+                    "offset": 0,
+                    "slot": "1",
+                    "type": "t_uint256",
+                    "source": "manual",
+                    "display": {
+                        "label": "Spent Today",
+                        "description": "Cumulative amount spent within the current 24-hour window.",
+                        "format": "tokenAmount",
+                        "params": { "tokenPath": "@.to" },
+                        "template": [
+                            {
+                                "condition": { ">": [{ "var": "newValue" }, { "var": "oldValue" }] },
+                                "value": "Spent Today increased from {oldValue} to {newValue}"
+                            },
+                            {
+                                "condition": { "<": [{ "var": "newValue" }, { "var": "oldValue" }] },
+                                "value": "Spent Today reset from {oldValue} to {newValue}"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "label": "windowResetAt",
+                    "path": "spendingLimit.windowResetAt",
+                    "offset": 0,
+                    "slot": "2",
+                    "type": "t_uint48",
+                    "source": "manual",
+                    "display": {
+                        "label": "Window Resets At",
+                        "description": "Unix timestamp when the current spending window expires.",
+                        "format": "date"
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/assets/eip-8317/example-erc20.json
+++ b/assets/eip-8317/example-erc20.json
@@ -1,0 +1,122 @@
+{
+    "$schema": "./storage-layout.schema.json",
+
+    "$comment": "Storage layout for a standard ERC-20 token, taken from solc --storage-layout output and annotated with ERC-7730 display hints. Every entry is compiler-derived sequential storage, so 'source' and 'baseSlotDerivation' are omitted throughout.",
+
+    "compiler": {
+        "language": "Solidity",
+        "version": "0.8.24"
+    },
+
+    "storage": [
+        {
+            "label": "_totalSupply",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint256",
+            "display": {
+                "label": "Total Supply",
+                "description": "The total number of tokens in circulation.",
+                "format": "tokenAmount",
+                "params": { "tokenPath": "@.to" }
+            }
+        },
+        {
+            "label": "_balances",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_mapping(t_address,t_uint256)",
+            "display": {
+                "label": "Balance of {key[0]}",
+                "description": "Token balance held by each account.",
+                "keyFormats": [
+                    { "format": "addressName" }
+                ],
+                "format": "tokenAmount",
+                "params": { "tokenPath": "@.to" },
+                "template": [
+                    {
+                        "condition": { ">": [{ "var": "newValue" }, { "var": "oldValue" }] },
+                        "value": "Balance of {key[0]} increased from {oldValue} to {newValue}"
+                    },
+                    {
+                        "condition": { "<": [{ "var": "newValue" }, { "var": "oldValue" }] },
+                        "value": "Balance of {key[0]} decreased from {oldValue} to {newValue}"
+                    },
+                    {
+                        "value": "Balance of {key[0]} changed from {oldValue} to {newValue}"
+                    }
+                ]
+            }
+        },
+        {
+            "label": "_allowances",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+            "display": {
+                "label": "Allowance of {key[1]} granted by {key[0]}",
+                "description": "Spending allowances: the amount account key[1] is permitted to transfer on behalf of account key[0].",
+                "keyFormats": [
+                    { "format": "addressName" },
+                    { "format": "addressName" }
+                ],
+                "format": "tokenAmount",
+                "params": { "tokenPath": "@.to" },
+                "template": "Allowance of {key[1]} granted by {key[0]} changed from {oldValue} to {newValue}"
+            }
+        },
+        {
+            "label": "_name",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_string_storage",
+            "display": {
+                "label": "Token name",
+                "format": "raw"
+            }
+        },
+        {
+            "label": "_symbol",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_string_storage",
+            "display": {
+                "label": "Token symbol",
+                "format": "raw"
+            }
+        }
+    ],
+
+    "types": {
+        "t_uint256": {
+            "encoding": "inplace",
+            "label": "uint256",
+            "numberOfBytes": "32"
+        },
+        "t_address": {
+            "encoding": "inplace",
+            "label": "address",
+            "numberOfBytes": "20"
+        },
+        "t_string_storage": {
+            "encoding": "bytes",
+            "label": "string",
+            "numberOfBytes": "32"
+        },
+        "t_mapping(t_address,t_uint256)": {
+            "encoding": "mapping",
+            "key": "t_address",
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32",
+            "value": "t_uint256"
+        },
+        "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+            "encoding": "mapping",
+            "key": "t_address",
+            "label": "mapping(address => mapping(address => uint256))",
+            "numberOfBytes": "32",
+            "value": "t_mapping(t_address,t_uint256)"
+        }
+    }
+}

--- a/assets/eip-8317/example-erc8042-diamond.json
+++ b/assets/eip-8317/example-erc8042-diamond.json
@@ -1,0 +1,56 @@
+{
+    "$schema": "./storage-layout.schema.json",
+
+    "$comment": "Storage layout for a Diamond proxy mixing manually defined ERC-8042 storage with standard sequential layout.",
+
+    "compiler": {
+        "language": "Solidity",
+        "version": "0.8.26"
+    },
+
+    "storage": [
+        {
+            "label": "diamondStorage",
+            "path": "diamondStorage",
+            "offset": 0,
+            "slot": "42469820562479799825417469720884591996671680000710712918799708120930930543920",
+            "type": "t_struct(DiamondStorage)",
+            "source": "manual",
+            "baseSlotDerivation": {
+                "scheme": "erc8042",
+                "namespaceId": "diamond.storage.Example"
+            },
+            "display": {
+                "label": "Diamond Storage",
+                "description": "Diamond facet tracking."
+            }
+        }
+    ],
+
+    "types": {
+        "t_address": {
+            "encoding": "inplace",
+            "label": "address",
+            "numberOfBytes": "20"
+        },
+        "t_struct(DiamondStorage)": {
+            "encoding": "inplace_struct",
+            "label": "struct DiamondStorage",
+            "numberOfBytes": "32",
+            "members": [
+                {
+                    "label": "facetAddress",
+                    "path": "diamondStorage.facetAddress",
+                    "offset": 0,
+                    "slot": "0",
+                    "type": "t_address",
+                    "source": "manual",
+                    "display": {
+                        "label": "Facet Address",
+                        "format": "addressName"
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/assets/eip-8317/storage-layout.schema.json
+++ b/assets/eip-8317/storage-layout.schema.json
@@ -1,0 +1,241 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "EVM Contract Storage Layout",
+    "type": "object",
+    "description": "Language-neutral description of an EVM contract's storage layout. See ERC-8317 (Contract Storage Layout Descriptor Format).",
+
+    "properties": {
+
+        "$schema": {
+            "title": "Schema",
+            "type": "string",
+            "format": "uri-reference",
+            "description": "The schema this file conforms to."
+        },
+
+        "$comment": {
+            "title": "Comment",
+            "type": "string",
+            "description": "An optional comment string documenting the purpose or provenance of this file."
+        },
+
+        "compiler": {
+            "title": "Compiler information",
+            "type": "object",
+            "description": "Identifies the source language and compiler used to produce this storage layout. Used to select the correct slot derivation formula.",
+            "properties": {
+                "language": {
+                    "type": "string",
+                    "description": "Source language. This ERC defines formulas for 'Solidity' and 'Vyper'. 'manual' MUST be used when no compiler produced any part of the layout (e.g. Huff, raw Yul, hand-written assembly)."
+                },
+                "version": {
+                    "type": "string",
+                    "description": "Compiler version string (e.g. '0.8.24'). Informative only."
+                },
+                "settings": {
+                    "type": "object",
+                    "description": "Compiler settings (e.g. optimizer configuration). Informative only.",
+                    "additionalProperties": true
+                }
+            },
+            "required": ["language"],
+            "additionalProperties": false
+        },
+
+        "storage": {
+            "title": "Storage entries",
+            "type": "array",
+            "description": "Ordered list of top-level contract state variables.",
+            "items": { "$ref": "#/$defs/storageEntry" }
+        },
+
+        "types": {
+            "title": "Type definitions",
+            "type": "object",
+            "description": "Type definitions referenced by storage entries.",
+            "additionalProperties": { "$ref": "#/$defs/typeDefinition" }
+        }
+    },
+
+    "required": ["compiler", "storage", "types"],
+    "additionalProperties": false,
+
+    "$defs": {
+
+        "storageEntry": {
+            "title": "Storage entry",
+            "type": "object",
+            "description": "A single state variable or struct member.",
+            "properties": {
+                "label": {
+                    "type": "string",
+                    "description": "Source-level variable name."
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Stable dot-separated identifier for this entry (e.g. 'vaults.lockedAmount'). If absent, consumers MUST compute it by joining label values from the top-level entry down through struct members."
+                },
+                "offset": {
+                    "type": "integer",
+                    "description": "Byte offset within the storage slot where this entry begins."
+                },
+                "slot": {
+                    "type": "string",
+                    "description": "Storage slot as a decimal string. For struct members, relative to the struct's base slot. For mappings and dynamic arrays, the base slot used to derive child slots."
+                },
+                "type": {
+                    "type": "string",
+                    "description": "Type identifier referencing an entry in the file's 'types' object."
+                },
+                "source": {
+                    "type": "string",
+                    "enum": ["compiler", "manual"],
+                    "default": "compiler",
+                    "description": "'compiler' (default): slot/offset were emitted by the compiler named in compiler.language from verifiable source code. 'manual': the file author declared slot directly."
+                },
+                "baseSlotDerivation": {
+                    "$ref": "#/$defs/baseSlotDerivation"
+                },
+                "display": {
+                    "$ref": "#/$defs/displayAnnotation"
+                }
+            },
+            "required": ["label", "offset", "slot", "type"],
+            "additionalProperties": false
+        },
+
+        "baseSlotDerivation": {
+            "title": "Base slot derivation",
+            "type": "object",
+            "description": "Names the scheme used to compute this entry's base slot, so it can be independently re-derived and verified instead of trusted as an opaque constant. MUST NOT be used for sequential, compiler-assigned slots.",
+            "properties": {
+                "scheme": {
+                    "type": "string",
+                    "enum": ["erc7201", "erc8042", "custom"]
+                },
+                "namespaceId": {
+                    "type": "string",
+                    "description": "Required for 'erc7201' and 'erc8042': the human-readable namespace id string the scheme hashes."
+                },
+                "formula": {
+                    "type": "string",
+                    "description": "Required for 'custom': free-text, non-machine-verified description of how 'slot' was computed."
+                }
+            },
+            "required": ["scheme"],
+            "additionalProperties": false
+        },
+
+        "typeDefinition": {
+            "title": "Type definition",
+            "type": "object",
+            "description": "A type definition referenced by storage entries via 'type'.",
+            "properties": {
+                "encoding": {
+                    "type": "string",
+                    "enum": ["inplace", "inplace_struct", "mapping", "dynamic_array", "bytes"],
+                    "description": "Storage encoding. 'inplace': primitive value type stored directly at its slot. 'inplace_struct': struct type with members. 'mapping', 'dynamic_array', 'bytes': complex types requiring slot derivation per compiler.language."
+                },
+                "label": {
+                    "type": "string",
+                    "description": "Human-readable type name as it appears in the source language (e.g. 'uint256', 'mapping(address => uint256)')."
+                },
+                "numberOfBytes": {
+                    "type": "string",
+                    "description": "Number of bytes this type occupies in storage, as a decimal string."
+                },
+                "key": {
+                    "type": "string",
+                    "description": "For mapping types: type identifier of the mapping key."
+                },
+                "value": {
+                    "type": "string",
+                    "description": "For mapping and dynamic_array types: type identifier of the value/element type."
+                },
+                "base": {
+                    "type": "string",
+                    "description": "For dynamic_array types: type identifier of the element type (alias of 'value', kept for compatibility with Solidity compiler output)."
+                },
+                "members": {
+                    "type": "array",
+                    "description": "For inplace_struct types only: ordered list of struct member entries.",
+                    "items": { "$ref": "#/$defs/storageEntry" }
+                }
+            },
+            "required": ["encoding", "label", "numberOfBytes"],
+            "additionalProperties": false
+        },
+
+        "displayAnnotation": {
+            "title": "Display annotation",
+            "type": "object",
+            "description": "Optional ERC-7730 display hints for this storage entry. Consumed by wallets to present the variable's value in human-readable form during transaction simulation and clear signing.",
+            "properties": {
+                "label": {
+                    "type": "string",
+                    "description": "User-facing name for the variable. For mappings, use {key[N]} to embed the Nth mapping key (outermost = {key[0]}). For arrays, use {index[N]} to embed the Nth element index."
+                },
+                "description": {
+                    "type": "string",
+                    "description": "Human-readable explanation of the variable's semantic meaning. Informative only — MUST NOT be relied upon for security decisions without additional authenticity assurances."
+                },
+                "keyFormats": {
+                    "type": "array",
+                    "description": "Array of formatters applied to mapping keys or array indices before they are embedded in label. keyFormats[0] applies to {key[0]}/{index[0]}, and so on.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "format": {
+                                "type": "string",
+                                "description": "ERC-7730 formatter name (e.g. 'addressName', 'raw', 'date')."
+                            },
+                            "params": {
+                                "type": "object",
+                                "description": "Formatter parameters. Same structure as ERC-7730 field formatter params.",
+                                "additionalProperties": true
+                            }
+                        },
+                        "required": ["format"],
+                        "additionalProperties": false
+                    }
+                },
+                "format": {
+                    "type": "string",
+                    "description": "ERC-7730 formatter (tokenAmount, addressName, raw, date, etc.) applied to the storage value itself. Same vocabulary as display.formats[*].fields[*].format in ERC-7730."
+                },
+                "params": {
+                    "type": "object",
+                    "description": "Formatter parameters for format. Same structure as display.formats[*].fields[*].params in ERC-7730.",
+                    "additionalProperties": true
+                },
+                "template": {
+                    "description": "Natural-language description of the change. Either a plain string or an ordered array of conditional entries evaluated with JSON Logic. Supports {label}, {oldValue}, and {newValue} placeholders.",
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "condition": {
+                                        "type": "object",
+                                        "description": "JSON Logic expression evaluated against {oldValue, newValue, key, index}. Omit for an unconditional fallback entry."
+                                    },
+                                    "value": {
+                                        "type": "string",
+                                        "description": "Template string with {label}, {oldValue}, {newValue} placeholders."
+                                    }
+                                },
+                                "required": ["value"],
+                                "additionalProperties": false
+                            }
+                        }
+                    ]
+                }
+            },
+            "additionalProperties": false
+        }
+    }
+}


### PR DESCRIPTION
This proposal was originally opened as ethereum/ERCs#1841, but interface standards should be EIPs, so it is being re-opened here. Number has been assigned in the ERC repository.

## Summary

A language-neutral, extensible JSON format for describing the storage layout of EVM contracts, so that block explorers, debuggers, source-verification services, security tooling, and wallets performing clear signing, transaction simulations, and transaction assertions can consistently map raw storage slots back to source-level variables.