### PR TITLE
Update EIP-8037: refill state-gas for a SELFDESTRUCTed account

### DIFF
--- a/EIPS/eip-8037.md
+++ b/EIPS/eip-8037.md
@@ -8,7 +8,7 @@ status: Review
 type: Standards Track
 category: Core
 created: 2025-10-01
-requires: 161, 684, 2780, 6780, 7610, 7623, 7702, 7825, 7928, 7976, 8038
+requires: 161, 684, 2780, 6780, 7610, 7623, 7702, 7825, 7928, 7976, 8038, 8246
 ---
 
 ## Abstract
@@ -154,9 +154,13 @@ Charges for account creation with `SELFDESTRUCT` are charged at the point where 
 
 ##### Gas refills for `SELFDESTRUCT`
 
-`SELFDESTRUCT` for accounts created in the same transaction does not produce increases in state size as the account, its data and its storage is not included in the state trie. However, this operation does not produce any state-gas refills and there are no changes to `evm_state_gas_used`.
+`SELFDESTRUCT` produces no state-gas refill at the point where it executes. Its accounting is deferred to transaction finalization, where the fate of the account is decided. For each account that was created during the transaction and `SELFDESTRUCT`ed:
 
-For an account that existed before the transaction, `SELFDESTRUCT` only transfers its balance and the account is not removed. Thus, no state-gas refill applies and no changes to `evm_state_gas_used`. This is consistent with the behavior of [EIP-6780](./eip-6780.md).
+- Its code is cleared, so the code-deposit charge (`L × CPSB`, where `L` is the length of the cleared code) is refilled.
+- If the account is removed, its leaf is not included in the state trie, so the `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` account-creation charge is refilled as well, unless the address already had a leaf at the start of the transaction and was therefore never charged for creation. An account whose final balance is nonzero is not removed ([EIP-8246](./eip-8246.md)); its leaf persists and that charge stands.
+- The state-gas charged for its storage slots is not refilled.
+
+For an account that was not created in the same transaction, `SELFDESTRUCT` only transfers its balance and the account is not removed. Thus, no state-gas refill applies and no changes to `evm_state_gas_used`. This is consistent with the behavior of [EIP-6780](./eip-6780.md).
 
 ##### Gas accounting for halts and reverts
 


### PR DESCRIPTION
An account created and SELFDESTRUCTed in the same transaction has its code cleared and, unless it keeps a balance, its leaf removed, yet the creation and code-deposit charges stand. A 1 kB deployment followed by SELFDESTRUCT pays about 1.7M state-gas for state that never lands.

The rule existed until b549622c dropped it, and this restores it where it was: at transaction finalization, the only point where the fate of the account is known. EIP-8246 keeps the leaf of an account whose final balance is nonzero, balance can arrive after the opcode runs, and code can be deposited after it as well, so the refill is keyed on the final state rather than on what the creation charged. Storage slots of the account stay charged.