### PR TITLE
Update EIP-8130: remove CONTRACT_ESTABLISHED flag

### DIFF
--- a/EIPS/eip-8130.md
+++ b/EIPS/eip-8130.md
@@ -264,12 +264,6 @@ Lock and unlock are **local-only** account changes carried in a signed batch thr
 
 The `signature` is validated against the account via [ERC-1271](./eip-1271.md) over a typed ([EIP-712](./eip-712.md)-style) `ActorInitialization` digest that omits the EIP-712 domain separator (anti-phishing) and binds the account's own actorId (`bytes32(bytes20(account))`, so it cannot be replayed against another account), `chainId` (matching the `applySignedAccountChanges` replay domain), and each initial actor with `expiry = 0` (imported actors are always non-expiring; an actor-provided expiry MUST NOT be accepted). `policyData` follows `authorizeActor`'s rule and, unlike create, `manager = account` is expressible here. On success `importAccount` sets `DEFAULT_EOA_REVOKED` (parity with `createAccount`); to keep using the native key past import, include the self-actorId as a `K1_AUTHENTICATOR` entry in `initialActors`. Exact typehashes and digest construction are defined in the canonical repository (`src/Keystore.sol`).
 
-#### Account Establishment
-
-Both `createAccount` and `importAccount` set the `CONTRACT_ESTABLISHED` flag (`flags` bit 0) in the packed account-state slot, regardless of the account's code shape (fresh deployment, plain contract, or [EIP-7702](./eip-7702.md) delegate). The flag is permanent, has no effect on authentication, and marks the account as **keystore-established rather than backed by a proven address-bound key**.
-
-It exists because 8130 state can outlive code: an account established and `SELFDESTRUCT`ed in the same transaction ([EIP-6780](./eip-6780.md)) is left with empty code but retains its 8130 state. Consumers (and protocol logic that makes code-delegation decisions) therefore MUST NOT treat "empty code (or a delegate) plus 8130 state" as proof of a known EOA key; they check `CONTRACT_ESTABLISHED` instead. A future genuinely key-backed native path MAY deliberately leave the bit clear. The flag does not infer an address-bound key from code shape — delegate imports remain fully supported.
-
 #### Delegation Indicator
 
 The delegation indicator is the [EIP-7702](./eip-7702.md) mechanism for pointing an account's code at a shared implementation contract. This proposal relies on it as the foundation for account code: an EOA sending its first AA transaction is auto-delegated to `DEFAULT_ACCOUNT_ADDRESS` when it has no code (see [Block Execution](#block-execution)), and accounts MAY set or clear delegation explicitly via a [Delegation Entry](#delegation-entry) in `account_changes`. Because 8130 depends on this behavior directly, the delegation indicator MUST be supported on 8130 chains even when standalone [EIP-7702](./eip-7702.md) transactions are not enabled.
@@ -739,10 +733,9 @@ Unused gas from `gas_limit` is refunded to the payer. For step 5, the protocol S
 | `AA_BASE_COST` | 15000 | Base intrinsic gas cost |
 | `KEYSTORE_ADDRESS` | CREATE2-derived (resolved at deployment) | Keystore system contract address |
 | `K1_AUTHENTICATOR` | `address(1)` | Native secp256k1 (ECDSA) authenticator (implicit default EOA and explicitly registered k1 actors) |
-| `CONTRACT_ESTABLISHED` | `0x01` | Account-state `flags` bit marking a keystore-established account (see [Account Establishment](#account-establishment)) |
-| `DEFAULT_EOA_REVOKED` | `0x02` | Account-state `flags` bit that disables the implicit default-EOA path |
-| `LOCKED` | `0x04` | Account-state `flags` bit that freezes actor configuration (see [Account Lock](#account-lock)) |
-| `UNLOCK_INITIATED` | `0x08` | Account-state `flags` bit selecting the `lock_union` interpretation (`unlock_delay` vs `unlocks_at`) |
+| `DEFAULT_EOA_REVOKED` | `0x01` | Account-state `flags` bit that disables the implicit default-EOA path |
+| `LOCKED` | `0x02` | Account-state `flags` bit that freezes actor configuration (see [Account Lock](#account-lock)) |
+| `UNLOCK_INITIATED` | `0x04` | Account-state `flags` bit selecting the `lock_union` interpretation (`unlock_delay` vs `unlocks_at`) |
 | `NONCE_MANAGER_ADDRESS` | `0x813000000000000000000000000000000000aa01` | Nonce Manager precompile address |
 | `TX_CONTEXT_ADDRESS` | `0x813000000000000000000000000000000000aa02` | Transaction Context precompile address |
 | `DEFAULT_ACCOUNT_ADDRESS` | CREATE2-derived (resolved at deployment) | Default wallet implementation for auto-delegation |
@@ -931,7 +924,6 @@ interface IKeystore {
     function getActor(address account, bytes32 actorId) external view returns (ActorConfig memory config, address policyManager, bytes32 policyCommitment);
     function getChangeSequences(address account) external view returns (ChangeSequences memory);
     function getLockStatus(address account) external view returns (bool locked, bool hasInitiatedUnlock, uint48 unlocksAt, uint16 unlockDelay);
-    function isContractEstablished(address account) external view returns (bool); // keystore-established, not a proven address key
 }
 ```
 


### PR DESCRIPTION
## Summary

- Removes the `CONTRACT_ESTABLISHED` account-establishment flag from EIP-8130, along with its dedicated "Account Establishment" section, its entry in the constants table, and the `isContractEstablished` view on `IKeystore`.
- Reclaims the vacated flags-byte bit 0 by shifting the remaining account-state flags down one bit: `DEFAULT_EOA_REVOKED` (`0x02` → `0x01`), `LOCKED` (`0x04` → `0x02`), and `UNLOCK_INITIATED` (`0x08` → `0x04`).

These flags were only defined by value in the constants table; every other reference in the spec is by name, so no further changes were required.