### PR TITLE
Update EIP-8081: SFI EIP-8141

### DIFF
--- a/EIPS/eip-8081.md
+++ b/EIPS/eip-8081.md
@@ -21,10 +21,9 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Declined
 ### EIPs Scheduled for Inclusion
 
 * [EIP-7805](./eip-7805.md): Fork-choice enforced Inclusion Lists (FOCIL)
+* [EIP-8141](./eip-8141.md): Frame Transaction
 
 ### Considered for Inclusion
-
-* [EIP-8141](./eip-8141.md): Frame Transaction
 
 ### Declined for Inclusion
 


### PR DESCRIPTION
Per decision on [ACDE 244](https://forkcast.org/calls/acde/244/): SFI Frames with the understanding that AA will ship in Hegotá and the specific implementation may change, including EIP number. Follow updates at the AA breakouts [here](https://forkcast.org/calls?filter=breakouts&breakoutType=aa)