### PR TITLE
Update EIP-8141: add valid_after to the expiry verifier frame

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -38,7 +38,7 @@ Ultimately, frame transactions realize the original vision of account abstractio
 | `FRAME_TX_PER_FRAME_COST`  | `475`             |
 | `ENTRY_POINT`              | `address(0xaa)`   |
 | `EXPIRY_VERIFIER`          | `address(0x8141)` |
-| `EXPIRY_DATA_LENGTH`       | `8`               |
+| `EXPIRY_DATA_LENGTH`       | `16`              |
 | `MAX_FRAMES`               | `64`              |
 | `SECP256K1N`               | `0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141` |
 | `SECP256R1N`               | `0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551` |
@@ -321,7 +321,7 @@ Note: since the signature validation does not happen in EVM execution, the relat
 
 #### Expiry Verifier Frame
 
-A `VERIFY` frame whose `frame.target` equals `EXPIRY_VERIFIER` is an **expiry verifier frame**. It calls the expiry verifier contract deployed at `EXPIRY_VERIFIER` with `frame.data` as calldata. The calldata is interpreted as an 8-byte unsigned big-endian expiry timestamp. The call reverts unless `block.timestamp <= expiry_timestamp`.
+A `VERIFY` frame whose `frame.target` equals `EXPIRY_VERIFIER` is an **expiry verifier frame**. It calls the expiry verifier contract deployed at `EXPIRY_VERIFIER` with `frame.data` as calldata. The calldata is interpreted as two 8-byte unsigned big-endian timestamps, `valid_after` followed by `expiry_timestamp`. The call reverts unless `valid_after <= block.timestamp <= expiry_timestamp`.
 
 An expiry verifier frame is invalid unless all of the following hold:
 
@@ -335,7 +335,7 @@ A transaction can contain at most one expiry verifier frame.
 At activation, clients must install the following expiry verifier contract runtime code at `EXPIRY_VERIFIER`. The expiry verifier contract's runtime code must be:
 
 ```asm
-push1 0x08
+push1 0x10
 calldatasize
 eq
 push1 0x0a
@@ -350,8 +350,16 @@ calldataload
 push1 0xc0
 shr
 timestamp
+lt
+push1 0x21
+jumpi
+push1 0x08
+calldataload
+push1 0xc0
+shr
+timestamp
 gt
-push1 0x16
+push1 0x21
 jumpi
 stop
 
@@ -364,7 +372,7 @@ revert
 The runtime bytecode is:
 
 ```text
-0x60083614600a575f5ffd5b5f3560c01c4211601657005b5f5ffd
+0x60103614600a575f5ffd5b5f3560c01c421060215760083560c01c4211602157005b5f5ffd
 ```
 
 Equivalently, the runtime behavior is:
@@ -373,8 +381,9 @@ Equivalently, the runtime behavior is:
 if len(evm.calldata) != EXPIRY_DATA_LENGTH:
     revert()
 
-expiry_timestamp = int.from_bytes(evm.calldata, "big")
-if evm.timestamp > expiry_timestamp:
+valid_after = int.from_bytes(evm.calldata[0:8], "big")
+expiry_timestamp = int.from_bytes(evm.calldata[8:16], "big")
+if evm.timestamp < valid_after or evm.timestamp > expiry_timestamp:
     revert()
 
 stop()
@@ -967,11 +976,11 @@ To be accepted into the public mempool, a frame transaction must satisfy the fol
 
 #### Expiry Verifier Frame
 
-Although `TIMESTAMP` is generally banned during validation-prefix execution, it is permitted when executing the canonical expiry verifier runtime code at `EXPIRY_VERIFIER`; clients may optimize the frame by performing the same deadline check without explicit EVM execution.
+Although `TIMESTAMP` is generally banned during validation-prefix execution, it is permitted when executing the canonical expiry verifier runtime code at `EXPIRY_VERIFIER`; clients may optimize the frame by performing the same validity-window check without explicit EVM execution.
 
 An `expiry_verify` frame MAY appear only as first frame in the frame list. For the purposes of matching the recognized validation-prefix shapes above, expiry verifier frame is skipped (e.g., `[expiry_verify, self_verify]` is recognized as `[self_verify]`).
 
-A node MUST drop a frame transaction from the public mempool if it contains an `expiry_verify` frame whose deadline is less than the node's view of the current block timestamp at any point.
+A node MUST drop a frame transaction from the public mempool if it contains an `expiry_verify` frame whose `[valid_after, expiry_timestamp]` window does not contain the node's view of the current block timestamp at any point. A transaction that is not yet valid is therefore not held until its window opens; it must be resubmitted afterwards.
 
 #### Canonical Paymaster Exception
 
@@ -983,7 +992,7 @@ Three frame species in the validation prefix have fully protocol-defined semanti
 
 When every frame in the validation prefix is one of these, direct evaluation of the protocol-defined semantics is equivalent to simulation, and a node MAY use it to satisfy the validation requirements below. Direct evaluation MUST apply the same limits as simulation: signature validation and the evaluated frames' work count against `MAX_VERIFY_GAS`, and the paymaster accounting rules in this section apply unchanged.
 
-The complete state dependency set of such a validation prefix is: the sender's code hash, nonce, and balance (the balance participates in the sender-existence check that decides the `APPROVE` account-creation state-gas charge), the payer's code hash and balance (or the canonical paymaster's tracked state), the runtime code at `EXPIRY_VERIFIER` together with the frame's deadline when an expiry verifier frame is present, and the current block timestamp. Nodes SHOULD index pending transactions by this set so that head-of-chain changes are revalidated without re-execution.
+The complete state dependency set of such a validation prefix is: the sender's code hash, nonce, and balance (the balance participates in the sender-existence check that decides the `APPROVE` account-creation state-gas charge), the payer's code hash and balance (or the canonical paymaster's tracked state), the runtime code at `EXPIRY_VERIFIER` together with the frame's validity window when an expiry verifier frame is present, and the current block timestamp. Nodes SHOULD index pending transactions by this set so that head-of-chain changes are revalidated without re-execution.
 
 #### Validation Trace Rules
 

--- a/EIPS/eip-8266.md
+++ b/EIPS/eip-8266.md
@@ -67,7 +67,7 @@ Let `now = block.timestamp`. Let `expiry_frames` be the list of frames in `tx.fr
 
 ```python
 assert len(expiry_frames) == 1
-d = int.from_bytes(expiry_frames[0].data, "big")            # 8-byte big-endian deadline
+d = int.from_bytes(expiry_frames[0].data[8:16], "big")      # deadline: second half of the frame data
 assert now <= d <= now + MAX_EXPIRY_SECS
 assert uint64(state[NONCE_RING].storage[slot_seen(h)]) < now
 ```
@@ -127,7 +127,7 @@ The sentinel reuses an existing field whose range (`< 2**64`) already covers `EX
 
 ### Reusing `expiry_verify`
 
-EIP-8141 already defines the `expiry_verify` frame: canonical contract, 8-byte big-endian calldata, and a signature-hash exception that makes the deadline sender-authenticated. Adding a parallel deadline field on the envelope would duplicate all of that. Reusing the existing frame keeps the signature-hash procedure unchanged.
+EIP-8141 already defines the `expiry_verify` frame: canonical contract, 16-byte big-endian `valid_after || deadline` calldata, and a signature-hash exception that makes the deadline sender-authenticated. Adding a parallel deadline field on the envelope would duplicate all of that. Reusing the existing frame keeps the signature-hash procedure unchanged.
 
 ### Ring buffer instead of permanent per-tx slots
 


### PR DESCRIPTION
The expiry verifier frame can currently only say when a transaction stops being valid. This adds a lower bound so it can also say when it starts.


* Frame data goes from 8 to 16 bytes: `valid_after || expiry_timestamp`, both 8-byte big-endian.
* The contract reverts unless `valid_after <= block.timestamp <= expiry_timestamp`. Setting `valid_after` to 0 keeps the current behaviour.
* Mempool: the drop rule now checks the whole window, and nodes do not hold transactions that are not yet valid. Those have to be resubmitted once the window opens.
* New runtime code is 37 bytes, checked against geth's `evm` for the window and calldata length cases.

EIP-8266 reads the deadline from this frame, so it now takes the second 8 bytes.
