### PR TITLE
Update EIP-8141: opcode and frame-mode registry for the frame-transaction family

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -635,6 +635,58 @@ For `ARBITRARY` signature entries, requesting `resolved_signer` results in excep
 
 For `param == 0x04`, if the referenced signature entry's `scheme` is not `ARBITRARY`, an exceptional halt occurs. The operation semantics match `CALLDATACOPY`, copying `length` bytes from the chosen signature's raw `signature` bytes, starting at the given byte `dataOffset`, into a memory region starting at `memOffset`. Bytes beyond the end of the signature are copied as zeroes.
 
+### Frame-Transaction Family Registry
+
+This EIP carries the authoritative allocation for the identifier spaces the frame-transaction family shares: opcode bytes, frame modes, `TXPARAM` indices, and signature schemes. A dependent EIP ([EIP-8250](./eip-8250.md), [EIP-8272](./eip-8272.md), [EIP-7906](./eip-7906.md), and later frame-family drafts) references a value from these tables rather than assigning its own, so that two conforming clients cannot resolve an allocation differently and fork.
+
+#### Opcodes
+
+| Byte | Opcode | Defining EIP |
+|------|--------|--------------|
+| 0xAA | APPROVE | 8141 |
+| 0xB0 | TXPARAM | 8141 |
+| 0xB1 | FRAMEDATALOAD | 8141 |
+| 0xB2 | FRAMEDATACOPY | 8141 |
+| 0xB3 | FRAMEPARAM | 8141 |
+| 0xB4 | SIGPARAM | 8141 |
+| 0xB5 | SIGDATACOPY | 8141 |
+| 0xB6 | RECENTROOTREFLOAD | 8272 |
+| 0xB7 | TXTRACE | 7906 |
+| 0xB8 | TXDIFF | 7906 |
+| 0xB9 | EVENTDATACOPY | 7906 |
+
+#### Frame modes
+
+| Mode | Meaning | Defining EIP |
+|------|---------|--------------|
+| 0 | DEFAULT | 8141 |
+| 1 | VERIFY | 8141 |
+| 2 | SENDER | 8141 |
+| 3 | POST_TX | 7906 |
+| 4 | DEP_VERIFY (reserved) | 8288 |
+| 5 | UTXO | 8312 |
+
+#### TXPARAM indices
+
+EIP-8141 allocates `TXPARAM` indices `0x00` through `0x0B`. A dependent EIP allocates a new index above that range from this registry rather than reusing an 8141-owned index.
+
+| Index range | Owner |
+|-------------|-------|
+| 0x00–0x0B | 8141 |
+| 0x0C and above | dependent EIPs, allocated here |
+
+#### Signature schemes
+
+EIP-8141 allocates the signature `scheme` identifiers below. A dependent EIP adding a protocol-validated scheme allocates its identifier from this registry rather than choosing one independently.
+
+| Scheme | Name | Defining EIP |
+|--------|------|--------------|
+| 0x0 | ARBITRARY | 8141 |
+| 0x1 | SECP256K1 | 8141 |
+| 0x2 | P256 | 8141 |
+
+A client MUST reject a frame whose mode, opcode byte, `TXPARAM` index, or signature scheme is absent from these tables under the forks it has enabled, and MUST treat an unallocated byte in the `0xB0`-`0xBF` range as an invalid instruction.
+
 ### Mempool
 
 The transaction mempool must carefully handle frame transactions, as a naive implementation could introduce denial-of-service vulnerabilities. The fundamental goal of the public mempool rules is to avoid allowing an arbitrary number of transactions to be invalidated by a single environmental change or state modification. Beyond this, the rules also aim to minimize the amount of work needed to complete the initial validation phase of a transaction before an acceptance decision can be made.

--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -668,12 +668,16 @@ This EIP carries the authoritative allocation for the identifier spaces the fram
 
 #### TXPARAM indices
 
-EIP-8141 allocates `TXPARAM` indices `0x00` through `0x0B`. A dependent EIP allocates a new index above that range from this registry rather than reusing an 8141-owned index.
+EIP-8141 allocates `TXPARAM` indices `0x00` through `0x0C`. A dependent EIP allocates a new index above that range from this registry rather than reusing an 8141-owned index.
 
 | Index range | Owner |
 |-------------|-------|
-| 0x00–0x0B | 8141 |
-| 0x0C and above | dependent EIPs, allocated here |
+| 0x00–0x0C | 8141 |
+| 0x0D–0x10 | 8250 |
+| 0x11 | 8272 |
+| 0x12 and above | dependent EIPs, allocated here |
+
+EIP-7906's `TXTRACE` and `TXDIFF` parameter tables are those opcodes' own operand spaces, not `TXPARAM` indices, and are allocated by EIP-7906 rather than from this table.
 
 #### Signature schemes
 
@@ -685,7 +689,7 @@ EIP-8141 allocates the signature `scheme` identifiers below. A dependent EIP add
 | 0x1 | SECP256K1 | 8141 |
 | 0x2 | P256 | 8141 |
 
-A client MUST reject a frame whose mode, opcode byte, `TXPARAM` index, or signature scheme is absent from these tables under the forks it has enabled, and MUST treat an unallocated byte in the `0xB0`-`0xBF` range as an invalid instruction.
+A frame whose `mode`, or a signature whose `scheme`, is absent from these tables under the forks the client has enabled makes the transaction statically invalid. The family reserves the whole `0xB0`–`0xBF` opcode range: an unallocated byte in it is an invalid instruction, and executing `TXPARAM` with an unallocated index results in an exceptional halt, as the defining instruction sections specify.
 
 ### Mempool
 


### PR DESCRIPTION
# EIP-8141: add a normative opcode and frame-mode registry for the frame-transaction family

## Motivation

The 8141 family (8141, 8250, 8272, 7906, 8288, 8312) allocates opcode bytes and
frame modes per draft. This has already produced two live collisions:

- Opcode `0xB5`: EIP-8272 assigns `RECENTROOTREFLOAD`, EIP-8141 later added
  `SIGDATACOPY` at the same byte.
- Frame mode `3`: EIP-7906 assigns `POST_TX`, EIP-8312 (UTXO) also claims `3`.

Two conforming clients that resolve a collision differently fork. A single
registry in the base EIP, from which dependent EIPs draw, removes the class.

## Specification

EIP-8141 carries the authoritative allocation. A dependent EIP references a
byte/mode from this table instead of assigning its own.

### Opcodes (0xB region)

| Byte | Opcode | EIP |
|------|--------|-----|
| 0xAA | APPROVE | 8141 |
| 0xB0 | TXPARAM | 8141 |
| 0xB1 | FRAMEDATALOAD | 8141 |
| 0xB2 | FRAMEDATACOPY | 8141 |
| 0xB3 | FRAMEPARAM | 8141 |
| 0xB4 | SIGPARAM | 8141 |
| 0xB5 | SIGDATACOPY | 8141 |
| 0xB6 | RECENTROOTREFLOAD | 8272 |
| 0xB7 | TXTRACE | 7906 |
| 0xB8 | TXDIFF | 7906 |
| 0xB9 | EVENTDATACOPY | 7906 |

### Frame modes

| Mode | Meaning | EIP |
|------|---------|-----|
| 0 | DEFAULT | 8141 |
| 1 | VERIFY | 8141 |
| 2 | SENDER | 8141 |
| 3 | POST_TX | 7906 |
| 4 | DEP_VERIFY (reserved) | 8288 |
| 5 | UTXO | 8312 |

A client MUST reject a frame whose mode is absent from this table under the
forks it has enabled, and MUST treat an unallocated byte in the 0xB0-0xBF range
as an invalid instruction.

## Rationale

`SIGDATACOPY` keeps `0xB5` because it is a base-8141 opcode and the family core;
`RECENTROOTREFLOAD` moves to `0xB6`, and 7906's three opcodes follow at
`0xB7`-`0xB9`. `POST_TX` keeps mode `3` (already live), and UTXO takes `5`,
leaving `4` reserved for EIP-8288 `DEP_VERIFY`. The specific assignment matters
less than its being single-sourced.

## Backwards Compatibility

Registry-conformant allocation supersedes any per-draft byte a dependent EIP
previously specified. Chains that ran a superseded allocation re-spin onto the
registry values.