### PR TITLE
Update EIP-7773: Call out Glamsterdam headliners

### DIFF
--- a/EIPS/eip-7773.md
+++ b/EIPS/eip-7773.md
@@ -20,13 +20,18 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Declined
 
 ### EIPs Scheduled for Inclusion
 
+#### Headliners
+
+* [EIP-7732](./eip-7732.md): Enshrined Proposer-Builder Separation (ePBS)
+* [EIP-7928](./eip-7928.md): Block-Level Access Lists (BALs)
+
+#### Non-headliners
+
 * [EIP-2780](./eip-2780.md): Reduce intrinsic transaction gas
 * [EIP-7688](./eip-7688.md): Forward compatible consensus data structures
 * [EIP-7708](./eip-7708.md): ETH transfers emit a log
-* [EIP-7732](./eip-7732.md): Enshrined Proposer-Builder Separation
 * [EIP-7778](./eip-7778.md): Block Gas Accounting without Refunds
 * [EIP-7843](./eip-7843.md): SLOTNUM opcode
-* [EIP-7928](./eip-7928.md): Block-Level Access Lists
 * [EIP-7954](./eip-7954.md): Increase Maximum Contract Size
 * [EIP-7976](./eip-7976.md): Increase Calldata Floor Cost
 * [EIP-7981](./eip-7981.md): Increase Access List Cost


### PR DESCRIPTION
Splits `EIPs Scheduled for Inclusion` into `Headliners` and `Non-headliners`, naming [EIP-7732](https://eips.ethereum.org/EIPS/eip-7732) (ePBS) and [EIP-7928](https://eips.ethereum.org/EIPS/eip-7928) (BALs) as the Glamsterdam headliners.

### Why

Headliners drive the scoping and scheduling of a network upgrade, but no Network Upgrade Meta EIP currently records which EIPs hold that status. The information lives in ACD calls, forum threads and client team discussions, and is referenced from other EIPs — [EIP-8075](https://eips.ethereum.org/EIPS/eip-8075) already describes EIP-7732 and EIP-7928 as "headliner proposals" — but the Meta EIP that defines the upgrade does not state it.

The intent is to make headliner status explicit in Network Upgrade Meta EIPs, so the upgrade's anchor changes are recorded in the same document that lists its contents.

### Notes

- No EIPs are added or removed. All 18 Scheduled for Inclusion entries are preserved; EIP-7732 and EIP-7928 are moved under `Headliners` rather than duplicated.
- The subheading nesting matches the existing `Other EIPs` → `Networking EIPs` / `Informational EIP` structure in this EIP.
- If editors prefer this convention, it could be applied to future Meta EIPs, and potentially defined in [EIP-7723](https://eips.ethereum.org/EIPS/eip-7723) alongside the other inclusion stages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)