### PR TITLE
Update EIP-8081: Call out Hegotá headliner

### DIFF
--- a/EIPS/eip-8081.md
+++ b/EIPS/eip-8081.md
@@ -20,7 +20,11 @@ Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Declined
 
 ### EIPs Scheduled for Inclusion
 
+#### Headliners
+
 * [EIP-7805](./eip-7805.md): Fork-choice enforced Inclusion Lists (FOCIL)
+
+#### Non-headliners
 
 ### Considered for Inclusion
 


### PR DESCRIPTION
Splits `EIPs Scheduled for Inclusion` into `Headliners` and `Non-headliners`, naming [EIP-7805](https://eips.ethereum.org/EIPS/eip-7805) (FOCIL) as the Hegotá headliner.

### Why

Headliners drive the scoping and scheduling of a network upgrade, but no Network Upgrade Meta EIP currently records which EIPs hold that status. The intent is to make headliner status explicit in Network Upgrade Meta EIPs, so the upgrade's anchor change is recorded in the same document that lists its contents.

Companion to #12254, which applies the same convention to EIP-7773 (Glamsterdam).

### Notes

- No EIPs are added or removed. EIP-7805 was already the sole `Scheduled for Inclusion` entry.
- `Non-headliners` is currently empty, matching this EIP's existing convention of retaining empty `Declined for Inclusion` and `Proposed for Inclusion` sections. Happy to drop the empty heading until it has entries if editors prefer.
- If editors prefer this convention, it could be defined in [EIP-7723](https://eips.ethereum.org/EIPS/eip-7723) alongside the other inclusion stages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)