### PR TITLE
fix: unauthorized salary minting and broken firstToLastConditionInChain update

### DIFF
--- a/assets/eip-3267/contracts/BaseSalary.sol
+++ b/assets/eip-3267/contracts/BaseSalary.sol
@@ -83,6 +83,7 @@ contract BaseSalary is BaseBidOnAddresses {
     function mintSalary(uint64 _oracleId, uint256 _condition, bytes calldata _data)
         ensureLastConditionInChain(_condition) external
     {
+        require(msg.sender == salaryReceivers[_condition], "Only the salary receiver can mint.");
         uint _lastSalaryDate = lastSalaryDates[_condition];
         require(_lastSalaryDate != 0, "You are not registered.");
         // Note: Even if you withdraw once per 20 years, you will get only 630,720,000 tokens.
@@ -172,7 +173,7 @@ contract BaseSalary is BaseBidOnAddresses {
         uint256 _oldCondition = firstToLastConditionInChain[_condition];
         uint256 _newCondition = _doCreateCondition(_customer);
         firstConditionInChain[_newCondition] = _condition;
-
+        firstToLastConditionInChain[_condition] = _newCondition;
         uint256 _amount = _balances[_oldCondition][_customer];
         _balances[_newCondition][_customer] = _amount;
         _balances[_oldCondition][_customer] = 0;


### PR DESCRIPTION
## Summary

Fixes two bugs in `BaseSalary.sol`:

1. **Missing sender authorization in `mintSalary`** — the NatSpec states this
   function "can be called only by the salary receiver," but no such check
   exists. Any address can call `mintSalary` with someone else's registered
   `_condition` ID, causing tokens to be minted to `msg.sender` instead of the
   actual salary receiver, while also resetting `lastSalaryDates[_condition]`
   to the current block timestamp. This lets an attacker both steal accrued
   salary and reset the real recipient's accrual clock.

2. **`firstToLastConditionInChain` not updated in `_recreateCondition`** —
   when a condition is recreated, the mapping from the first condition in the
   chain to the *current* last condition is never reassigned to the new
   condition ID. This causes:
   - `isLastConditionInChain` to permanently return `false` for the new
     condition, so `mintSalary` can never be called again after a single
     recreation (via the `ensureLastConditionInChain` modifier).
   - A second recreation on the same chain to read a stale
     `firstToLastConditionInChain[_condition]` value, orphaning the
     customer's actual balance and creating the new condition with a
     balance of `0`.

## Changes

- Add `require(msg.sender == salaryReceivers[_condition], ...)` in
  `mintSalary` to enforce that only the registered receiver can mint their
  own salary.
- Add `firstToLastConditionInChain[_condition] = _newCondition;` in
  `_recreateCondition` so the chain's "last condition" pointer stays correct
  after recreation.

## Impact

- Bug 1 is an active theft vector allowing salary to be minted to an
  arbitrary caller.
- Bug 2 breaks the salary recreation mechanism after first use and can
  silently orphan customer balances on subsequent recreations.

## Testing

- [ ] Add a test asserting `mintSalary` reverts when called by a non-receiver
      address.
- [ ] Add a test that recreates a condition and confirms `mintSalary` still
      succeeds on the new condition.
- [ ] Add a test for double recreation confirming balances carry over
      correctly.

## Notes

Original source: `assets/eip-3267/contracts/BaseSalary.sol`
(https://github.com/ethereum/EIPs/blob/master/assets/eip-3267/contracts/BaseSalary.sol)