### PR TITLE
Update EIP-8250: forbid reverting approval effects on validation-prefix restore

### DIFF
--- a/EIPS/eip-8250.md
+++ b/EIPS/eip-8250.md
@@ -173,7 +173,7 @@ Only after those checks and costs succeed, and before any approval effect is com
 
 Steps 3 through 5 are one approval transition. The state gas charge, nonce consumption, `max_cost` collection, `payer` update, and any `sender_approved` update either all apply or none apply.
 
-If the enclosing EIP-8141 frame reverts or halts exceptionally, clients MUST revert the transition. Once that frame succeeds, a later frame failure or atomic batch rollback MUST NOT revert it unless the transaction is invalid under EIP-8141. Clients MUST discard all effects of an invalid transaction.
+If the enclosing EIP-8141 frame reverts or halts exceptionally, clients MUST revert the transition. Once that frame succeeds, a later frame failure, an atomic batch rollback, or a validation-prefix state restore such as a `POST_TX` assertion failure that discards the transaction body MUST NOT revert it unless the transaction is invalid under EIP-8141. Clients MUST discard all effects of an invalid transaction.
 
 The charge counts toward the transaction's and block's state gas totals and is included in fee settlement. It does not consume execution gas or increase `gas_used.execution`.
 


### PR DESCRIPTION
The Nonce consumption section lists the state rollbacks that must not revert a payment-scoped APPROVE's effects: a later frame revert, skipping later frames, and restoring an atomic-batch state snapshot. It does not name the validation-prefix restore that a POST_TX assertion failure performs, which discards the transaction body while keeping the transaction valid and included.

This adds that case to the MUST NOT list so the spent-once guarantee holds identically across every post-approval rollback, not only the atomic-batch one. No behavior change for conforming clients; it closes an enumeration gap.