### PR TITLE
Update EIP-8070: point size_i at the encoding this EIP specifies

### DIFF
--- a/EIPS/eip-8070.md
+++ b/EIPS/eip-8070.md
@@ -43,6 +43,8 @@ Add a new field `cell_mask` of type `B_16` (`uint128`). This field MUST be inter
 - old schema (`eth/71`): `[types: B, [size_0: P, size_1: P, ...], [hash_0: B_32, hash_1: B_32, ...]]`
 - new schema (`eth/72`): `[types: B, [size_0: P, size_1: P, ...], [hash_0: B_32, hash_1: B_32, ...], cell_mask: B_16]`
 
+The definition of `size_i` is unchanged in form from [EIP-5793](./eip-5793.md), but the quantity it denotes follows the encoding this EIP specifies for `PooledTransactions` below: see the `txsize` definition in the [Ethereum Wire Protocol specification](https://github.com/ethereum/devp2p/blob/master/caps/eth.md#newpooledtransactionhashes-0x08).
+
 **Modify `GetPooledTransactions` (`0x09`) / `PooledTransactions` (`0x0a`) behaviour.**
 Responses MUST elide blob payloads for type 3 transactions requested via this RPC by encoding the transaction's `blobs` field as the RLP empty list (`0xc0`, the encoding of `[]`). The field MUST NOT be encoded as the RLP empty byte string (`0x80`). Cell proofs and commitments are unaffected and continue to be sent.
 


### PR DESCRIPTION
## Motivation

The `NewPooledTransactionHashes` schema in this EIP carries `size_i` over from `eth/71` unchanged:

https://github.com/ethereum/EIPs/blob/b6d3f2c65aad65bb09856db6db50ae612b8bf8aa/EIPS/eip-8070.md#L43-L44

while the EIP *does* change the encoding `PooledTransactions` returns for type 3 transactions, eight lines later:

https://github.com/ethereum/EIPs/blob/b6d3f2c65aad65bb09856db6db50ae612b8bf8aa/EIPS/eip-8070.md#L49-L50

A reader of this EIP alone therefore cannot tell which quantity `size_i` now denotes — the consensus size, the full network size, or the blob-elided size this EIP introduces.

That ambiguity has a measured cost. On a 7-client devnet, one client announced the consensus-encoding size while serving the blob-elided encoding, and go-ethereum force-disconnected it **55,130 times over four days, 61.5% of all announced-size disconnects on the network**.

## What this PR does — and deliberately does not do

This adds **two non-normative lines**: a cross-reference telling the reader that `size_i` follows the encoding this EIP specifies, and pointing at the wire-protocol definition.

It deliberately does **not** restate the definition here. `size_i` was introduced by EIP-5793 and is specified in the devp2p wire spec; adding a second normative source for it is what created this class of problem in the first place. The substantive fix belongs in `caps/eth.md`, where the (currently incorrect) definition actually lives:

**ethereum/devp2p#281**

That PR should land first; this one is then just a signpost. No `requires:` change, no new normative requirement, nothing that should reset review.

## Background

Full write-up: https://panda-uploads-production.devops-539.workers.dev/panda/uploads/a7974b/teardown.html


---

## Related PRs

This is one of four coordinated changes from the same investigation:

| | |
|---|---|
| **ethereum/devp2p#281** | the normative fix — `txsize` definition and the pooled encoding (this is the load-bearing one) |
| **ethereum/EIPs#12275** | non-normative signpost in EIP-8070 |
| **NethermindEth/nethermind#13049** | client fix — announces the consensus size on eth/72 (61.5% of observed disconnects) |
| **besu-eth/besu#11203** | client fix — announces the pre-upgrade v0 size while serving v1 on eth/71 (21.2%). Independent of the spec question; inconsistent under any reading |
| **lambdaclass/ethrex#7235** | client fix — announces an empty-bundle size when the sidecar is gone (16.7%) |
| **ethereum/go-ethereum#35620** | corrects a comment in `tx_fetcher.go` claiming geth "only warn[s], but doesn't drop" while calling `dropPeer` — the sentence that makes this behaviour easy to misread |

Suggested order: the spec change first, then the client fixes, then the EIP signpost.




## Client survey

All seven execution clients on the devnet were checked against the proposed definition. **The clarification breaks nobody**, and two clients are already exactly conformant:

| client | behaviour | verdict |
|---|---|---|
| **erigon** | announces `len(txBytes)` where `txBytes` is *the same buffer* it later serves | ✅ conformant by construction — effectively the reference implementation of this wording |
| **nimbus-eth1** | encodes exactly what it will serve | ✅ conformant by construction |
| go-ethereum | self-consistent; its `Size()` is a shortcut that coincides with the true length at blob scale | ✅ conformant |
| reth | announces the un-elided size on eth/72 | ❌ — already being fixed in paradigmxyz/reth#26574 |
| nethermind, besu, ethrex | see the table above | ❌ — PRs linked |

Two points that the wording above tries to make unambiguous, because they are exactly where implementations diverged:

1. The quantity is the **true length of the pooled encoding**, not any particular client's helper. go-ethereum's `Size()` computes `1 + P + S + hdr(S)` where the true length is `1 + P + S + hdr(P+S)`; these agree only because both headers are 4 bytes at realistic blob counts. erigon's and nimbus-eth1's are structural identities and are the better model.
2. Under `eth/72` the elided length still **includes** the `wrapper-version` element and the empty `blobs` list (`0xc0`). "Serialize with empty blobs" and "full size minus blob bytes" then give the same answer — which is worth stating rather than leaving implementers to rediscover.
