### PR TITLE
Update EIP-8141: Remove a redundant check for frame's state gas limit

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -172,12 +172,11 @@ for i, frame in enumerate(tx.frames):
     assert frame.mode < 3
     assert frame.flags < 8
     assert frame.target is None or len(frame.target) == 20
-    assert frame.limits.state <= 2**64 - 1
     assert frame.value < 2**256
     assert frame.mode == SENDER or frame.value == 0
     total_frame_execution_gas += frame.limits.execution
     total_frame_gas += frame.limits.execution + frame.limits.state
-    assert total_frame_gas <= 2**64 - 1
+    assert total_frame_gas < 2**64
 
     # Approval of execution is allowed only when target equals to None or tx.sender.
     if frame.flags & APPROVE_EXECUTION:


### PR DESCRIPTION
### Summary

* **Kind:** ♻️ Refactor
* **Breaking Change:** No

Remove a redundant check for frame's state gas limit.

---

### What changed

* Removes an explicit boundary check for state gas.
* Changes the boundary condition for consistency:

 ```diff
 - <= 2**64 - 1
 + < 2**64

 ```
---

### Rationale

Total gas limit accumulates state gas for each frame, and is bounded using a constraint.

```py
assert total_frame_gas < 2**64
```
And so an explicit check for its state gas component is redundant.

---

### For Implementers 🔔

* **Action Required:** Yes

#### Actions

* Remove explicit boundary check for each frame's state gas.