### PR TITLE
Update EIP-7928: Amend storage-read gas-feasibility check

### DIFF
--- a/EIPS/eip-7928.md
+++ b/EIPS/eip-7928.md
@@ -569,6 +569,10 @@ Validating access lists and balance diffs adds validation overhead but is essent
 
 Increased block size impacts propagation but overhead (~70 KiB average) is reasonable for performance gains.
 
+### Spurious Storage Reads
+
+Since `storage_reads` entries are not mapped to specific transaction indices, their validity can only be confirmed after executing all transactions. A malicious proposer could exploit this by declaring spurious storage reads that are never accessed, forcing clients into unnecessary I/O prefetching and data download while the block remains unrejectable until completion. The `bal_items` constraint bounds the number of such entries. Clients SHOULD additionally consider mechanisms to detect infeasible `storage_reads` during execution and reject the block before it completes. Any such mechanism MUST NOT reject a valid block; in particular, the storage reads performed by system calls are not paid for by block gas and cannot be bounded by it.
+
 ## Copyright
 
 Copyright and related rights waived via [CC0](../LICENSE.md).

--- a/EIPS/eip-7928.md
+++ b/EIPS/eip-7928.md
@@ -229,7 +229,7 @@ Record **post‑transaction** balances (`uint256`) for:
 
 For unaltered account balances:
 
-If an account’s balance changes during a transaction, but its post-transaction balance is equal to its pre-transaction balance, then the change MUST NOT be recorded in `balance_changes`. The sender and recipient address MUST still be included in `AccountChanges`.
+If an account's balance changes during a transaction, but its post-transaction balance is equal to its pre-transaction balance, then the change MUST NOT be recorded in `balance_changes`. The sender and recipient address MUST still be included in `AccountChanges`.
 
 The following special cases require addresses to be included with empty changes if no other state changes occur:
 
@@ -568,23 +568,6 @@ Validating access lists and balance diffs adds validation overhead but is essent
 ### Block Size
 
 Increased block size impacts propagation but overhead (~70 KiB average) is reasonable for performance gains.
-
-### Early Rejection of Malicious BALs
-
-Since `storage_reads` entries are not mapped to specific transaction indices, their validity can only be confirmed after executing all transactions. A malicious proposer could exploit this by declaring phantom storage reads that are never accessed, forcing clients into unnecessary I/O prefetching and significant data download while the block remains unrejectable until completion.
-
-To mitigate this, clients SHOULD enforce a gas-budget feasibility check at transaction boundaries. Let:
-
-- `R_remaining` = number of declared storage reads not yet accessed
-- `G_remaining` = remaining block gas
-
-The following invariant must hold:
-
-```
-G_remaining >= R_remaining * 2000
-```
-
-Where 2000 is the minimum gas cost for a storage read (via [EIP-2930](./eip-2930.md) access lists: 1900 upfront + 100 warm read). If this check fails, the block can be rejected immediately as invalid, since insufficient gas remains to access the declared reads. This check SHOULD be performed periodically (e.g., every 8 transactions) to enable early rejection without impacting parallel execution.
 
 ## Copyright
 


### PR DESCRIPTION
The [Security Considerations](https://eips.ethereum.org/EIPS/eip-7928#early-rejection-of-malicious-bals) section recommends that clients reject a block at any transaction boundary where:

`G_remaining <= R_remaining × 2000`

The intent is to catch declared reads that no remaining gas could pay for. In its current form, though, the check can also reject valid blocks. `storage_reads` carry no `block_access_index`, so reads performed by the post-execution system calls (the EIP-7002, EIP-7251, and EIP-8282) are indistinguishable from reads that transactions have yet to perform. Those system calls read storage without consuming block gas, so their reads remain in `R_remaining` while contributing nothing to `G_remaining`. A valid block filled to its gas limit reaches its final boundary with `G_remaining = 0` and up to a few hundred such reads outstanding, and the invariant fails. With only the Prague contracts the threshold is exactly 58 × 2000 = 116,000 gas of leftover; with the EIP-8282 queues it is on the order of 1M gas. 

`execution-specs` fixtures reproduce this (draft PR [here](https://github.com/ethereum/execution-specs/pull/3484)). I believe is there is only one client (Nethermind) to implement this, checking at every 8 txs, but they explicitly exclude reads from post-execution system contracts by address, which avoids rejecting valid blocks. But this is not something the EIP currently describes. Since the check is a `SHOULD` that can lead to rejecting a valid block, clients that implement it may end up resolving this issue differently, or not at all. Either way, as written, it doesn't account for this.

Phantom-read I/O is already bounded by the size constraint, which is exact and checked before execution begins. The feasibility check can still carry up to roughly unused_gas / 2000 phantom reads without ever failing it. This change removes the section. No client changes are required, and conformance test fixtures asserting that full blocks with full sys contract reads will remain as tests in `execution-specs`.

---

Happy to consider other alternatives but I think this is probably my favored solution from what I mulled through, given this is a `SHOULD` and not a `MUST`.

cc: @jochem-brouwer @nerolation 