### PR TITLE
Update EIP-8250: charge keyed nonce first use as state gas

### DIFF
--- a/EIPS/eip-8250.md
+++ b/EIPS/eip-8250.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2026-04-16
-requires: 7623, 8141
+requires: 7623, 8037, 8141
 ---
 
 ## Abstract
@@ -38,13 +38,15 @@ This specification is a delta against [EIP-8141](./eip-8141.md).
 | `FORK_TIMESTAMP` | `TBD` |
 | `NONCE_MANAGER` | `0x0000000000000000000000000000000000008250` |
 | `NONCE_MANAGER_CODE` | `0x60006000fd` |
-| `KEYED_NONCE_FIRST_USE_GAS` | `20000` |
+| `KEYED_NONCE_FIRST_USE_STATE_GAS` | `STATE_BYTES_PER_STORAGE_SET * CPSB` |
 | `MAX_NONCE_SEQ` | `2**64 - 1` |
 | `MAX_NONCE_KEYS` | `16` |
 | `TXPARAM_LEGACY_NONCE` | `0x0D` |
 | `TXPARAM_NONCE_KEY_COUNT` | `0x0E` |
 | `TXPARAM_NONCE_KEYS_HASH` | `0x0F` |
 | `TXPARAM_NONCE_KEY_0` | `0x10` |
+
+`STATE_BYTES_PER_STORAGE_SET` and `CPSB` are defined by [EIP-8037](./eip-8037.md). EIP-8037 currently sets `STATE_BYTES_PER_STORAGE_SET = 64` and `CPSB = 1530`, so each fresh key costs `97920` state gas.
 
 `NONCE_MANAGER_CODE` is a runtime equivalent to `revert(0, 0)`: any ordinary call to `NONCE_MANAGER` immediately reverts with empty returndata.
 
@@ -159,21 +161,21 @@ If `nonce_keys == [0]` and `increment_account_nonce(sender)` would make `state[s
 
 For `nonce_keys != [0]`, stateful validity guarantees `tx.nonce_seq < MAX_NONCE_SEQ`, so `tx.nonce_seq + 1` is in range.
 
-For a payment-scoped `APPROVE`, clients first apply all EIP-8141 `APPROVE` exceptional-condition checks and ordinary opcode execution costs, including any `RETURN`-like memory costs, but excluding the legacy nonce increment that this EIP replaces.
+For a payment-scoped `APPROVE`, clients first perform all EIP-8141 approval checks and execution gas charges, including memory expansion, except the sender existence and state gas checks tied to its nonce increment. The transition below replaces those checks, the state gas charge, and the sender nonce increment.
 
 Only after those checks and costs succeed, and before any approval effect is committed, clients MUST perform:
 
-1. If `tx.nonce_keys != [0]`, read `raw_before[nonce_key] = state[NONCE_MANAGER].storage[slot(tx.sender, nonce_key)]` for every `nonce_key` in `tx.nonce_keys`. Otherwise skip to step 4.
-2. Let `first_use_count` be the number of read values where `raw_before[nonce_key] == 0`. If the current frame has less than `KEYED_NONCE_FIRST_USE_GAS * first_use_count` gas remaining, the `APPROVE` halts out-of-gas and no approval effects occur.
-3. Deduct `KEYED_NONCE_FIRST_USE_GAS * first_use_count` from the current frame's remaining gas.
+1. If `tx.nonce_keys == [0]`, set `nonce_state_gas = STATE_BYTES_PER_NEW_ACCOUNT * CPSB` when `tx.sender` does not exist under EIP-8037's existence rule immediately before approval. Otherwise set it to `0`. If `tx.nonce_keys != [0]`, read each selected slot and set `nonce_state_gas = KEYED_NONCE_FIRST_USE_STATE_GAS * first_use_count`, where `first_use_count` is the number of slots whose value is `0`.
+2. If `state_gas_left < nonce_state_gas`, halt the current call frame exceptionally without applying any approval effects.
+3. Charge `nonce_state_gas` as state gas from `state_gas_left`. EIP-8141 attributes the charge to the current frame's receipt.
 4. Execute `consume_nonce_set(tx.sender, tx.nonce_keys, tx.nonce_seq)`.
-5. Commit the remaining EIP-8141 payment-approval effects, excluding the legacy nonce increment replaced above.
+5. Commit the remaining EIP-8141 payment approval effects, excluding the sender nonce increment and sender account creation charge replaced above.
 
-Steps 3 through 5 are a single approval transition. Either all are committed, or none are committed.
+Steps 3 through 5 are one approval transition. The state gas charge, nonce consumption, `max_cost` collection, `payer` update, and any `sender_approved` update either all apply or none apply.
 
-Nonce consumption, maximum-cost collection, payer recording, first-use gas charging, and scope-dependent approval-context updates performed by a successful payment-scoped `APPROVE` are approval effects, not ordinary frame-local state changes. They MUST be journaled outside the current frame's revert journal and outside any EIP-8141 atomic-batch snapshot. They MUST NOT be reverted by a later frame revert, by skipping later frames, or by restoring an atomic-batch state snapshot.
+If the enclosing EIP-8141 frame reverts or halts exceptionally, clients MUST revert the transition. Once that frame succeeds, a later frame failure or atomic batch rollback MUST NOT revert it unless the transaction is invalid under EIP-8141. Clients MUST discard all effects of an invalid transaction.
 
-Gas deducted as `KEYED_NONCE_FIRST_USE_GAS` is gas used by the frame executing `APPROVE`. When charged, the surcharge is included in the frame's `gas_used` receipt value, transaction gas accounting, and EIP-8141 unpaid-gas refund calculation.
+The charge counts toward the transaction's and block's state gas totals and is included in fee settlement. It does not consume execution gas or increase `gas_used.execution`.
 
 Keyed-nonce reads and writes performed by stateful validity and `consume_nonce_set` are protocol bookkeeping: they do NOT add `NONCE_MANAGER` or its slots to [EIP-2929](./eip-2929.md) `accessed_addresses` or `accessed_storage_keys`, are NOT charged under [EIP-2200](./eip-2200.md) `SSTORE` pricing, and do NOT warm the address or slot for later user-level access.
 
@@ -230,7 +232,11 @@ For the EIP-8141 public mempool rules:
 
 If the validation prefix reads `TXPARAM(0x0D)`, the sender's legacy account nonce is an additional dependency.
 
-Nodes MUST revalidate a pending transaction when any of its selected nonce sequences changes. If the validation prefix reads `TXPARAM(0x0D)`, nodes MUST also revalidate when the sender's legacy account nonce changes. All other EIP-8141 public mempool rules, including the limit of one pending frame transaction per sender, remain unchanged.
+Nodes MUST revalidate a pending transaction when any of its selected nonce sequences changes. If the validation prefix reads `TXPARAM(0x0D)`, nodes MUST also revalidate when the sender's legacy account nonce changes.
+
+For transactions under this EIP, EIP-8141 Structural Rule 6 also allows a `VERIFY` frame to use state gas when a payment-scoped `APPROVE` creates a keyed nonce slot. That state gas draws from the frame's `limits.state` and does not count toward `MAX_VERIFY_GAS`. The existing `MAX_VERIFY_STATE_GAS` cap on the sum of state limits in the validation prefix is unchanged.
+
+All other EIP-8141 public mempool rules, including the limit of one pending frame transaction per sender, remain unchanged.
 
 ## Rationale
 
@@ -244,7 +250,7 @@ This EIP intentionally uses one `nonce_seq` shared by all selected `nonce_keys`,
 
 Keyed-nonce state lives in the storage of one `NONCE_MANAGER` system contract rather than extending account state, since the latter would change the account MPT layout. This minimizes consensus-surface change while keeping keyed state committed under the existing execution `stateRoot`.
 
-`KEYED_NONCE_FIRST_USE_GAS = 20000` uses the zero-to-nonzero `SSTORE` state-creation cost as a reference point. It is a keyed-nonce state-growth surcharge, not ordinary user-level `SSTORE` pricing. Subsequent increments of a consumed key are not separately surcharged: keyed-nonce progression is replay-protection bookkeeping analogous to legacy-nonce progression, not user storage.
+The first use of a keyed nonce creates one storage slot, so it pays EIP-8037's state gas for one new slot. Later uses update the same slot and do not pay the creation charge again.
 
 This EIP does not relax EIP-8141's public-mempool one-pending-frame-transaction-per-sender guidance, but it removes the protocol-level obstacle to doing so. A future policy MAY admit multiple pending frame transactions for the same sender on disjoint non-zero key sets, subject to its own dependency-tracking and replacement rules.
 
@@ -270,7 +276,7 @@ Nonce consumption persists through later-frame reverts and EIP-8141 atomic-batch
 
 A "send another transaction with the same legacy nonce" cancellation strategy does not invalidate a pending non-zero-key frame transaction. Replacement requires the same `(sender, nonce_keys, nonce_seq)` under the relevant mempool replacement rules, or another transaction that intentionally consumes an overlapping keyed domain.
 
-Each consumed `(sender, nonce_key != 0)` occupies one persistent slot in `NONCE_MANAGER` storage; entries are not deleted. State growth is priced by `KEYED_NONCE_FIRST_USE_GAS` per first-use key, bounding new keyed slots per block by the block gas limit divided by `20000`, before accounting for other transaction costs. `nonce_seq == MAX_NONCE_SEQ` is reserved as the exhausted state; a key whose current sequence reaches it cannot be advanced further.
+Each consumed `(sender, nonce_key != 0)` occupies one persistent slot in `NONCE_MANAGER` storage, and entries are never deleted. Creating a slot consumes state gas, so a block can create at most `block_gas_limit // KEYED_NONCE_FIRST_USE_STATE_GAS` new keyed nonce slots. `nonce_seq == MAX_NONCE_SEQ` represents an exhausted key; a key at that sequence cannot advance further.
 
 Ordinary direct calls to `NONCE_MANAGER` revert. However, the account may still receive ETH through force-send mechanisms where applicable. Any balance held at `NONCE_MANAGER` is outside the scope of this EIP and is not recoverable by protocol logic defined here.
 


### PR DESCRIPTION
## Summary

EIP-8141 gives each frame separate execution gas and state gas budgets. EIP-8250 still charges 20,000 gas for creating a keyed nonce from the approving frame's execution gas.

This PR:

- charges keyed nonce creation as state gas, drawn from `state_gas_left` and recorded in `gas_used.state`, not `gas_used.execution`;
- prices it at EIP-8037's cost for one new storage slot, `STATE_BYTES_PER_STORAGE_SET * CPSB` (currently 97,920), since each fresh key creates one ordinary persistent slot;
- states the sender account creation charge for the legacy key `[0]` in the same transition, so keyed nonce transactions, which never create the sender account, do not pay it;
- keeps the state gas charge, nonce consumption, and payment approval atomic;
- extends EIP-8141 Structural Rule 6 so a `VERIFY` frame may use state gas for this charge. It counts toward `MAX_VERIFY_STATE_GAS`, not `MAX_VERIFY_GAS`.

For example, a transaction with two fresh keys budgets 195,840 state gas on its approving frame. The payer still pays it and it still counts toward block state gas, but it no longer consumes validation execution gas. Under the current 500,000 `MAX_VERIFY_STATE_GAS`, a validation prefix with no other state budget can create at most five fresh keys.
