### PR TITLE
Update EIP-8369: Clarify EIP-8369 review follow-ups

### DIFF
--- a/EIPS/eip-8369.md
+++ b/EIPS/eip-8369.md
@@ -18,7 +18,7 @@ This EIP describes two validity-only partial statelessness (VOPS) profiles for f
 
 FOCIL ([EIP-7805](./eip-7805.md)) requires builders to include IL transactions unless a missing transaction is invalid when appended to the payload or the payload does not have enough remaining gas to append it. That rule is cheap for Profile 1 transactions because the omission check depends mainly on gas, nonce, and balance. Frame transactions have programmable validation, so validity may also depend on keyed nonces, payer state, recent roots, or bounded account storage.
 
-This EIP defines which transactions remain cheap enough to enforce. Profile 1 keeps EIP-7805's end-of-payload rule. Profile 2 evaluates an omitted frame transaction at a builder-claimed index against a fixed validation state surface. Because the builder chooses the index, Profile 2 is weaker when another transaction can move a validation dependency within the block; [Security Considerations](#security-considerations) defines that boundary.
+This EIP defines which transactions remain cheap enough to enforce. Profile 1 keeps EIP-7805's end of payload rule. Profile 2 evaluates an omitted frame transaction at a builder-claimed index against a fixed validation state surface. Because the builder chooses the index, Profile 2 is weaker when another transaction can move a validation dependency within the block; [Security Considerations](#security-considerations) defines that boundary.
 
 FOCIL eligibility is not mempool policy. An includer may receive an eligible transaction through the public mempool, a custom mempool, or direct submission. The submission path affects whether a transaction reaches an IL, not whether its omission is enforceable.
 
@@ -33,9 +33,9 @@ This EIP defines two VOPS profiles. A transaction that satisfies neither may sti
 | Profile | Purpose | Transaction shape | Adds to validation state surface |
 |---|---|---|---|
 | 1: Base VOPS | end of payload omission check | legacy, [EIP-2930](./eip-2930.md), [EIP-1559](./eip-1559.md), and [EIP-7702](./eip-7702.md) transactions | none |
-| 2: FOCIL AA-VOPS | frame transaction validation | [EIP-8141](./eip-8141.md) frame transactions | code and `codeHash`; first `AA_VOPS_SLOT_COUNT` storage slots; keyed nonces; recent roots |
+| 2: FOCIL AA-VOPS | frame transaction validation | [EIP-8141](./eip-8141.md) frame transactions | code and `codeHash`; first [`AA_VOPS_SLOT_COUNT`](#constants) storage slots; keyed nonces; recent roots |
 
-The base VOPS proposal keeps `(address, nonce, balance, codeFlag)` for every account. Profile 2 defines a FOCIL-specific AA-VOPS extension: VOPS nodes also keep the code corpus, the first `AA_VOPS_SLOT_COUNT` storage slots of every account, keyed nonce state, and recent root state. Code is authenticated by `codeHash`; delegated accounts also require the delegated target's code. The surface has a fixed shape, not a fixed total size.
+The base VOPS proposal keeps `(address, nonce, balance, codeFlag)` for every account. `codeFlag` is `0` when the account has empty code and `1` otherwise, including when its code is an [EIP-7702](./eip-7702.md) delegation indicator. Profile 2 defines a FOCIL-specific AA-VOPS extension: VOPS nodes also keep the code corpus, the first `AA_VOPS_SLOT_COUNT` storage slots of every account, keyed nonce state, and recent root state. Code is authenticated by `codeHash`; delegated accounts also require the delegated target's code. The surface has a fixed shape, not a fixed total size.
 
 Transaction type and blob fields decide the candidate profile. Legacy, [EIP-2930](./eip-2930.md), [EIP-1559](./eip-1559.md), and [EIP-7702](./eip-7702.md) transactions are Profile 1 candidates. [EIP-8141](./eip-8141.md) frame transactions with an empty `blob_versioned_hashes` list are Profile 2 candidates. [EIP-4844](./eip-4844.md) transactions and frame transactions with a non-empty `blob_versioned_hashes` list are not candidates for either profile. A candidate that fails the remaining conditions of its profile is outside FOCIL enforcement.
 
@@ -57,7 +57,7 @@ For both profiles, `fee_valid(tx, block)` requires `max_fee_per_gas >= block.bas
 
 `AA_VOPS_SLOT_COUNT` is a parameter of this reference model, not a fixed consensus constant. No implementation can classify Profile 2 for enforcement until the enforcing Standards Track EIP selects a value.
 
-For Profile 2, VERIFY budget cost is static: the signature verification gas counted by [EIP-8141](./eip-8141.md) plus the declared gas limits of every frame in the EIP-8141 validation prefix, including an optional expiry verifier frame. The expiry verifier frame is skipped only when matching the four allowed prefix shapes. Whether validation succeeds is decided by replay, not by budget fit.
+For Profile 2, VERIFY budget cost is static: the signature verification gas counted by [EIP-8141](./eip-8141.md) plus the declared gas limits of every frame in the EIP-8141 validation prefix, including an optional expiry verifier frame. The expiry verifier frame still counts toward the budget, even though shape matching ignores it when checking [the four admitted prefixes](#profile-2-focil-aa-vops). Whether validation succeeds is decided by replay, not by budget fit.
 
 `MAX_VERIFY_GAS_PER_IL = 2**20`, about 1.05M gas, is a candidate value for the claimed index design. Checking each omitted transaction at one claimed index avoids the earlier quadratic append loop. Across [EIP-7805](./eip-7805.md)'s 16 includers, this bounds the metered Profile 2 budget at `2**24`, about 16.8M gas per slot. The final value requires full pipeline benchmarks.
 
@@ -119,7 +119,7 @@ Transactions that are neither Profile 1 nor Profile 2 are not eligible for FOCIL
 
 ### Reserved for future work
 
-A future Profile 3 could admit declared external storage reads backed by a witness or validity proof. It would need an envelope commitment, byte limits, anchor and freshness rules, retained [EIP-7928](./eip-7928.md) write history, and an omission proof. External state writable by others also lets a builder stale a witness before the claimed index. Until those rules are specified, external storage reads are not eligible.
+A future Profile 3 could admit declared external storage reads backed by a witness or validity proof. It would need an envelope commitment, byte limits, anchor and freshness rules, retained [EIP-7928](./eip-7928.md) write history, and an omission proof. If another transaction can write the external state, a builder can invalidate the witness before the claimed index. Until those rules are specified, external storage reads are not eligible.
 
 ### Mempool admission and FOCIL eligibility
 
@@ -135,17 +135,15 @@ An includer may source Profile 1 or Profile 2 transactions from the public mempo
 
 Profile 2 budget fill is static and evaluated per IL occurrence before deduplication. Starting with `MAX_VERIFY_GAS_PER_IL`, process occurrences in IL order. First compute the signature cost and validation prefix cost. If their sum exceeds the per transaction or remaining per IL limit, ignore the transaction. Otherwise, deduct the signature cost before checking protocol signatures. If a signature fails, keep only that debit. Deduct the validation prefix cost only after the signatures pass. The occurrence is admitted only if it then passes every Profile 2 candidate check. A failed candidate keeps the budget debit but is not admitted. This bounds signature-verification work from structurally valid transactions with invalid signatures. Stateful eligibility is not part of fill because it depends on the evaluation index. A Profile 2 transaction is enforceable only if it is eligible at that index and at least one occurrence was admitted by this fill rule.
 
-
-
 #### Builders
 
 For each omitted Profile 2 candidate, a builder may commit an index in `[0, len(block.transactions)]`, where `0` is before the first block transaction. A missing, malformed, or out-of-range index defaults to `len(block.transactions)`, the end of the payload. This avoids making private receipt of an IL transaction part of consensus.
 
 #### Attesters
 
-For Profile 1, attesters apply the [EIP-7805](./eip-7805.md) end-of-payload check plus the sender and fee validity conditions from [Profile 1](#profile-1-base-vops).
+For Profile 1, attesters apply the [EIP-7805](./eip-7805.md) end of payload check plus the sender and fee validity conditions from [Profile 1](#profile-1-base-vops).
 
-For Profile 2, attesters use the committed index or the default end-of-payload index.
+For Profile 2, attesters use the committed index or the default end of payload index.
 
 Attesters start from the parent VOPS state, apply pre-execution system updates, and apply the [EIP-7928](./eip-7928.md) block-level access list (BAL) changes for transactions before the evaluation index. This reconstructs balances, nonces, storage, code, delegation indicators, keyed nonces, and recent roots. Eligibility replay uses full EIP-8141 and EIP-8250 `APPROVE` (`0xaa`) semantics, including maximum-cost collection. The gas remaining is the block gas limit minus cumulative gas used before the index. Omission is unjustified if and only if all of the following hold:
 
@@ -193,9 +191,9 @@ This Informational EIP changes no consensus rules by itself. Enforcing Profile 2
 
 Profile 2 trades guarantee strength for replay cost. Because the builder chooses the index, a transaction is protected only if it is valid at every claimable index. This EIP accepts that property and does not treat the index as evidence that insertion was attempted.
 
-For position-stable transactions, this is equivalent to EIP-7805's end-of-payload rule. A dependency is position-stable if it is constant within the payload or changes monotonically, so invalidity at any index persists to the end. Fresh nonzero keyed nonces with `nonce_seq == 0` and recent roots have this property. A queued transaction that requires a keyed or legacy nonce predecessor in the same payload can be invalid before the predecessor and valid afterward, so it receives the weaker guarantee. Validation slots qualify only if no other authorized transaction can change them, and payment capacity qualifies only if it is reserved for the transaction. Shared payers without such a reservation receive the weaker guarantee: another sponsored transaction may reduce the payer balance before the claimed index.
+For position-stable transactions, this is equivalent to EIP-7805's end of payload rule. A dependency is position-stable if it is constant within the payload or changes monotonically, so invalidity at any index persists to the end. Fresh nonzero keyed nonces with `nonce_seq == 0` and recent roots have this property. A queued transaction that requires a keyed or legacy nonce predecessor in the same payload can be invalid before the predecessor and valid afterward, so it receives the weaker guarantee. Validation slots qualify only if no other authorized transaction can change them, and payment capacity qualifies only if it is reserved for the transaction. Shared payers without such a reservation receive the weaker guarantee: another sponsored transaction may reduce the payer balance before the claimed index.
 
-The maximum metered Profile 2 budget is about 16.8M gas per slot, but total attester work is higher. In particular, EVM gas does not directly bound the bytes loaded when validation touches many distinct maximum-size code bodies. Omitted transactions pay no fees, so the full reconstruction and replay path must be benchmarked against the attestation deadline, and code-body count and byte limits must be fixed, before the caps are adopted by a Standards Track EIP. 
+The maximum metered Profile 2 budget is about 16.8M gas per slot, but total attester work is higher. In particular, EVM gas does not directly bound the bytes loaded when validation touches many distinct code bodies at their maximum size. Benchmarks must also cover Profile 2 frame transactions at the largest size allowed by EIP-7805's IL byte limit. Omitted transactions pay no fees, so the full reconstruction and replay path must be benchmarked against the attestation deadline, and code body count and byte limits must be fixed, before the caps are adopted by a Standards Track EIP.
 
 An invalid EIP-8141 signature consumes only its signature cost, not the validation prefix budget. A transaction that passes signature checks can still use its full per transaction budget and later fail replay if state changes before the claimed index. This affects only the IL that included it. The enforcing EIP must consider this risk when setting `MAX_VERIFY_GAS_PER_TX`.
 


### PR DESCRIPTION
This follows up on the nonblocking comments from @jochem-brouwer in #12110 after EIP-8369 was merged.

- Link AA_VOPS_SLOT_COUNT and the admitted Profile 2 prefixes to their definitions.
- Define both codeFlag values, including the EIP-7702 delegation case.
- Use "end of payload" consistently without unnecessary hyphens.
- Clarify witness invalidation and remove extra blank lines.
- Add the largest Profile 2 frame transaction to the benchmark scope.

This does not change eligibility, budget accounting, replay behavior, or activation semantics.