### PR TITLE
Update EIP-8272: verify recent roots with a canonical frame

### DIFF
--- a/EIPS/eip-8272.md
+++ b/EIPS/eip-8272.md
@@ -13,39 +13,38 @@ requires: 7843, 8141
 
 ## Abstract
 
-[EIP-8141](./eip-8141.md) frame transactions can verify recent roots through a canonical `VERIFY` frame. The frame carries one to sixteen `(source_id, slot, root)` tuples and calls a recent-root contract that checks each tuple against its storage. A root source writes roots to the same contract, with each root keyed by `(source_id, slot)`, where `source_id` derives from the writer address and a salt.
+[EIP-8141](./eip-8141.md) frame transactions can verify recent roots through a canonical `VERIFY` frame. The frame carries one to sixteen `(source_id, slot, root)` tuples and calls a recent root contract that checks each tuple against its storage. Root sources write to the same contract. Each root is keyed by `(source_id, slot)`, where `source_id` is derived from the writer address and a salt.
 
-The frame runs before account validation in the public mempool. A failed check invalidates the transaction, while account validation can read the verified tuples through existing frame introspection. This requires no change to the frame-transaction envelope and no new opcode.
+The frame runs before account validation in the public mempool. A failed check invalidates the transaction, while account validation can read the verified tuples through existing frame introspection. This requires no change to the `FrameTx` envelope and no new opcode.
 
 ## Motivation
 
-[EIP-8141](./eip-8141.md) public-mempool validation cannot read arbitrary storage controlled by another account or application. Some validation rules still need recent application state, such as privacy tree roots, wallet authorization roots, or account validation roots.
+Public mempool validation under [EIP-8141](./eip-8141.md) cannot read arbitrary storage controlled by another account or application. Some validation rules still need recent application state, such as privacy tree roots, wallet authorization roots, or account validation roots.
 
-A rolling recent-root contract makes this dependency safe. A stored entry cannot change while it is referenceable, except through a chain reorganization, and each reference names exactly one storage key. A canonical frame lets clients recognize, bound, index, and revalidate these reads without extending the transaction envelope.
+The recent root contract stores each entry under a key determined by its source and slot. Except after a chain reorganization, that entry cannot change while a transaction may reference it. The canonical frame lets clients check and index these dependencies without changing the transaction envelope.
 
-Privacy applications, for example, keep a tree of commitments and prove spends against a recent tree root. The application writes roots by slot, and a spend transaction verifies one of those roots before its account-validation frame runs.
+Privacy applications, for example, keep a tree of commitments and prove spends against a recent tree root. The application writes roots by slot, and a spend transaction verifies one of those roots before its account validation frame runs.
 
 ## Specification
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
 
-This specification is a delta against [EIP-8141](./eip-8141.md). Terms not defined here, including `FrameTx`, `VERIFY`, `expiry_verify`, the validation prefix, `MAX_VERIFY_GAS`, `FRAMEPARAM`, `FRAMEDATALOAD`, and `FRAMEDATACOPY`, have the meanings defined in EIP-8141.
+This specification extends [EIP-8141](./eip-8141.md). Terms not defined here, including `FrameTx`, `VERIFY`, `expiry_verify`, the validation prefix, `MAX_VERIFY_GAS`, `FRAMEPARAM`, `FRAMEDATALOAD`, and `FRAMEDATACOPY`, have the meanings defined in EIP-8141.
 
 ### Constants
 
 | Name | Value |
 | --- | ---: |
 | `RECENT_ROOT_ADDRESS` | `0x0000000000000000000000000000000000008272` |
-| `RECENT_ROOT_CODE_HASH` | `0xb2427f08a58430ff05c99b5c232e5ad620a593ad8c9f881ad8c966746562e785` |
+| `RECENT_ROOT_CODE` | `TBD` |
 | `RECENT_ROOT_LENGTH` | `8192` |
 | `RECENT_ROOT_USABLE_WINDOW` | `8191` |
 | `MAX_RECENT_ROOT_REFERENCES` | `16` |
 | `RECENT_ROOT_TUPLE_BYTES` | `72` |
-| `MAX_RECENT_ROOT_VERIFY_GAS` | `50_000` |
 | `RECENT_ROOT_ENTRY_DOMAIN` | `keccak256("RECENT_ROOT_ENTRY")` |
 | `RECENT_ROOT_STORAGE_DOMAIN` | `keccak256("RECENT_ROOT_STORAGE")` |
 
-All concatenations below use fixed-length encodings. Domains are 32 bytes. Addresses are 20 bytes. Slots and indices are unsigned 64-bit big-endian integers. Roots, salts, source identifiers, entry hashes, and storage keys are 32 bytes.
+All concatenations below use encodings with fixed lengths. Domains are 32 bytes. Addresses are 20 bytes. Slots and indices are unsigned integers encoded in eight bytes, with the most significant byte first. Roots, salts, source identifiers, entry hashes, and storage keys are 32 bytes.
 
 ### Current slot
 
@@ -53,7 +52,7 @@ During block execution, `current_slot` is the consensus slot of the beacon block
 
 Execution clients MUST obtain `current_slot` from the [EIP-7843](./eip-7843.md) `slotNumber` field. Clients MUST NOT derive it from `block.timestamp` using a fixed slot duration.
 
-During public-mempool validation, `current_slot` is one greater than the `slotNumber` in the latest canonical execution header. The simulated `SLOTNUM` value MUST equal this slot. This value deliberately does not advance during empty slots. Before including a transaction in a payload, a client MUST revalidate it with `SLOTNUM` set to that payload's `slotNumber`.
+During public mempool validation, `current_slot` is one greater than the `slotNumber` in the latest canonical execution header. The simulated `SLOTNUM` value MUST equal this slot. This value deliberately does not advance during empty slots. Before including a transaction in a payload, a client MUST revalidate it with `SLOTNUM` set to that payload's `slotNumber`.
 
 References MUST target slots strictly before `current_slot`. A root written during slot `S` becomes referenceable beginning in slot `S + 1`.
 
@@ -146,7 +145,7 @@ storage[storage_key] = entry_hash
 
 In static context, the write MUST fail and storage MUST remain unchanged.
 
-Only execution whose storage context is `RECENT_ROOT_ADDRESS` writes recent-root storage. `DELEGATECALL` and `CALLCODE` use the invoking account's storage context, while [EIP-7702](./eip-7702.md) delegated code uses the delegating account's storage context. None modifies recent-root storage unless that context is `RECENT_ROOT_ADDRESS`.
+Only execution whose storage context is `RECENT_ROOT_ADDRESS` writes recent root storage. `DELEGATECALL` and `CALLCODE` use the invoking account's storage context, while [EIP-7702](./eip-7702.md) delegated code uses the delegating account's storage context. None modifies recent root storage unless that context is `RECENT_ROOT_ADDRESS`.
 
 Each `(source_id, S)` has at most one referenceable root on the canonical chain. Multiple writes by the same source address and salt during slot `S` target the same storage key. The final write in canonical block execution order overwrites earlier writes, and only that root is referenceable beginning in slot `S + 1`.
 
@@ -192,17 +191,9 @@ storage[storage_key] == entry_hash
 
 The call MUST revert if any tuple fails. Duplicate tuples are valid and are checked independently. If every tuple passes, the call MUST succeed with no return data, logs, or state changes.
 
-The validation operation MUST read the current slot with `SLOTNUM`, MUST NOT call another account, and MUST read only the recent-root storage keys derived from its calldata.
+The validation operation MUST read the current slot with `SLOTNUM`, MUST NOT call another account, and MUST read only the recent root storage keys derived from its calldata.
 
 All calls use ordinary EVM execution and gas accounting.
-
-#### Canonical runtime code
-
-`RECENT_ROOT_CODE` is the following 344-byte runtime bytecode. Its Keccak-256 hash MUST equal `RECENT_ROOT_CODE_HASH`.
-
-```text
-0x3461015257368060401460d15780604811610152576104808111610152578060489006610152574b9060005b81811460cf578035816020013560c01c8085111561015257808503611fff9011610152577f8f42481679c8e6fefa040974b3c905e0ce3f2e464ba93acdb074a41181617efc60005280602852816020528260280160209060483760686000207fbdc897da2177d260ff5f4be5d4b2aad43f89c3347a305b584fa5a2546d053daa60005281611fff16602852826020526048600020541415610152575050604801602b565b005b5033600052602060006020376034600c20807f8f42481679c8e6fefa040974b3c905e0ce3f2e464ba93acdb074a41181617efc6040524b606852606052602060206088376068604020817fbdc897da2177d260ff5f4be5d4b2aad43f89c3347a305b584fa5a2546d053daa60a852611fff4b1660d05260c852604860a82055005b60006000fd
-```
 
 ### Recent root verifier frame
 
@@ -219,11 +210,11 @@ len(frame.data) <= MAX_RECENT_ROOT_REFERENCES * RECENT_ROOT_TUPLE_BYTES
 len(frame.data) mod RECENT_ROOT_TUPLE_BYTES == 0
 ```
 
-For public-mempool classification, this frame is named `recent_root_verify`.
+For public mempool classification, this frame is named `recent_root_verify`.
 
 The frame executes the validation operation through the `STATICCALL` semantics of EIP-8141. If the contract reverts or the frame halts exceptionally, EIP-8141 makes the transaction invalid.
 
-The frame consumes ordinary EVM gas. Its target access and storage reads follow the normal warm and cold access rules, and its data follows the normal EIP-8141 transaction-data pricing. This EIP introduces no special intrinsic gas, access warming, or block-level gas exemption.
+The frame consumes ordinary EVM gas. Its target access and storage reads follow the normal warm and cold access rules, and its data follows the normal EIP-8141 transaction data pricing. This EIP adds no special intrinsic gas, warming rule, or exemption from block gas.
 
 EIP-8141's canonical signature hash already covers the complete frame list, including each frame's data. This EIP does not change the transaction payload or signature hash.
 
@@ -231,54 +222,48 @@ EIP-8141's canonical signature hash already covers the complete frame list, incl
 
 Applications read a recent root verifier frame through EIP-8141's existing `FRAMEPARAM`, `FRAMEDATALOAD`, and `FRAMEDATACOPY` instructions. This EIP adds no transaction parameter or opcode.
 
-Application validation can identify a completed recent root verifier frame through `FRAMEPARAM` by checking `resolved_target == RECENT_ROOT_ADDRESS`, `mode == VERIFY`, `flags == 0`, `limits.state == 0`, a valid recent-root data length, and `status == 1`.
+Application validation can identify a completed recent root verifier frame through `FRAMEPARAM` by checking `resolved_target == RECENT_ROOT_ADDRESS`, `mode == VERIFY`, `flags == 0`, `limits.state == 0`, a valid recent root data length, and `status == 1`.
 
-In a public-mempool-eligible transaction, the recent root verifier frame is frame `0`, or frame `1` when an `expiry_verify` frame is present.
+In a transaction eligible for the public mempool, the recent root verifier frame is frame `0`, or frame `1` when an `expiry_verify` frame is present.
 
 ### Public mempool handling
 
-EIP-8141's public-mempool policy summary is extended to permit `current_slot` as defined above and the recent-root contract code and storage read by a `recent_root_verify` frame, subject to the rules below.
+EIP-8141's public mempool policy is extended to permit the `current_slot` value defined above and the code and storage reads required by a `recent_root_verify` frame, subject to the rules below.
 
-A public-mempool-eligible transaction MUST contain no more than one recent root verifier frame. If present, it MUST appear immediately after an optional `expiry_verify` frame and before every other frame:
+A transaction eligible for the public mempool MUST contain no more than one recent root verifier frame. If present, it MUST appear immediately after an optional `expiry_verify` frame and before every other frame:
 
 ```text
 [expiry_verify?] [recent_root_verify?] [deploy?] [account validation] ...
 ```
 
-For the purpose of matching EIP-8141's four recognized validation-prefix shapes, clients MUST skip both optional leading protocol verifier frames. The EIP-8141 rule that `deploy` is first applies after these frames are skipped.
+For the purpose of matching EIP-8141's four recognized validation prefix shapes, clients MUST skip both optional leading protocol verifier frames. The EIP-8141 rule that `deploy` is first applies after these frames are skipped.
 
-Clients MUST check this frame shape and its fixed-width data encoding before reading sender state.
+Clients MUST check this frame shape and data encoding before reading sender state.
 
-A recent root verifier frame is subject to EIP-8141's generic validation trace and opcode rules with exactly two additional permissions. Only during the top-level execution of this frame, while the runtime code at `RECENT_ROOT_ADDRESS` exactly equals `RECENT_ROOT_CODE`:
+A recent root verifier frame is subject to EIP-8141's generic validation trace and opcode rules with exactly two additional permissions. These permissions apply only while this frame executes at the top level and the runtime code at `RECENT_ROOT_ADDRESS` exactly equals `RECENT_ROOT_CODE`:
 
 1. `SLOTNUM` MAY execute inside `RECENT_ROOT_CODE`.
 2. `SLOAD` MAY read `RECENT_ROOT_ADDRESS[storage_key]` for storage keys derived from the frame's tuples as specified above.
 
-No nested call receives either permission. No other opcode, call, state-read, or state-write exception is added. Clients MUST reject the transaction from the public mempool if the code at `RECENT_ROOT_ADDRESS` does not equal `RECENT_ROOT_CODE`.
+No nested call receives either permission. No other opcode, call, storage read, or storage write exception is added. Clients MUST reject the transaction from the public mempool if the code at `RECENT_ROOT_ADDRESS` does not equal `RECENT_ROOT_CODE`.
 
-The generic EIP-8141 simulation rules apply, and the frame MUST execute successfully. This EIP does not add a direct-evaluation exception. The frame's `limits.execution` MUST NOT exceed `MAX_RECENT_ROOT_VERIFY_GAS`.
+The frame MUST execute successfully. During public mempool validation, a client MAY evaluate this frame directly instead of executing `RECENT_ROOT_CODE`, even when other frames in the validation prefix require simulation. This direct evaluation MUST produce the same frame receipt and gas use as EVM execution. It MUST also apply the same warm account and storage key updates and rollbacks as EVM execution. A client MUST reject the transaction if EVM execution would revert or halt exceptionally, including when `frame.limits.execution` is insufficient.
 
-EIP-8141's declared-limit check is amended to use two independent allowances:
+For EIP-8141's public mempool checks on declared limits and total validation work, clients MUST exclude the recent root verifier frame:
 
 ```text
 signature_verification_cost
-    + sum(frame.limits.execution for non-recent-root frames in validation_prefix)
+    + sum(
+        frame.limits.execution
+        for frame in validation_prefix
+        if frame is not recent_root_verify
+    )
     <= MAX_VERIFY_GAS
-
-recent_root_verify.limits.execution <= MAX_RECENT_ROOT_VERIFY_GAS
 ```
 
-During simulation, clients MUST likewise maintain two counters. Signature verification and execution gas spent by every non-recent-root frame count toward a generic counter capped at `MAX_VERIFY_GAS`. Execution gas spent by the recent root verifier frame counts only toward a recent-root counter capped at `MAX_RECENT_ROOT_VERIFY_GAS`.
+This exclusion changes only public mempool admission accounting. The frame's declared execution limit remains part of the EIP-8141 transaction maximum cost and block execution gas reservation, and the payer is charged for the frame's actual gas use under the ordinary EIP-8141 rules.
 
-Because actual frame execution cannot exceed its declared limit, the total metered public-mempool validation gas is bounded by:
-
-```text
-MAX_VERIFY_GAS + MAX_RECENT_ROOT_VERIFY_GAS
-```
-
-This separate allowance changes only public-mempool admission accounting. The frame's declared execution limit remains part of the EIP-8141 transaction maximum cost and block execution-gas reservation, and the payer is charged for the frame's actual gas use under the ordinary EIP-8141 rules.
-
-Clients MUST reject a transaction from the public mempool if any tuple has `slot >= current_slot` or if the frame does not execute successfully against the current head.
+Clients MUST reject a transaction from the public mempool if any tuple has `slot >= current_slot`.
 
 Clients MUST evict a pending transaction if any tuple has `slot >= current_slot`. Otherwise, they MUST evict it when any tuple reaches:
 
@@ -286,9 +271,9 @@ Clients MUST evict a pending transaction if any tuple has `slot >= current_slot`
 current_slot - slot >= RECENT_ROOT_LENGTH
 ```
 
-To avoid admitting a transaction that expires almost immediately, clients SHOULD NOT admit a transaction whose oldest reference is within a small node-chosen margin of expiry.
+To avoid admitting a transaction that expires almost immediately, clients SHOULD NOT admit a transaction whose oldest reference is within a margin chosen by the node.
 
-On admission, clients MUST record each distinct `(storage_key, entry_hash)` dependency and the first `current_slot` at which it expires. Clients SHOULD index pending transactions by these values so that a slot advance or chain reorganization does not require scanning unrelated transactions. Clients MUST also track the code and activation status of `RECENT_ROOT_ADDRESS` as dependencies. These records MUST be removed when the transaction leaves the public mempool and MUST be replaced atomically with the transaction during replacement.
+On admission, clients MUST record each distinct `(storage_key, entry_hash)` dependency and the first `current_slot` at which it expires. Clients SHOULD index pending transactions by these values so that a slot advance or chain reorganization does not require scanning unrelated transactions. Clients MUST also track the code and activation status of `RECENT_ROOT_ADDRESS` as dependencies. These records MUST be removed when the transaction leaves the public mempool. When one transaction replaces another, clients MUST replace these records atomically with the transaction.
 
 When any recorded dependency may have changed, clients MUST recheck the complete age and storage predicates for each affected transaction and evict transactions that no longer satisfy them. Reorganization handling MUST consider state changes on both the removed and added branches, including a referenced entry removed by rollback without a replacement write. A change to the code or activation status of `RECENT_ROOT_ADDRESS` requires revalidation of every pending transaction containing a recent root verifier frame. The ordinary EIP-8141 revalidation rules continue to apply to all other dependencies.
 
@@ -308,88 +293,89 @@ For all other blocks, clients MUST NOT run this initialization. Clients MUST han
 
 ## Rationale
 
-[EIP-8141](./eip-8141.md) public-mempool validation normally rejects reads from shared mutable storage. Recent-root storage is a narrow exception because a valid entry cannot be overwritten during its usable window. A current-slot write uses the only ring-buffer index that could collide with a root exactly `RECENT_ROOT_LENGTH` slots old, and that older root is already expired.
+[EIP-8141](./eip-8141.md) public mempool validation normally rejects reads from shared mutable storage. Recent root storage is a narrow exception because a valid entry cannot be overwritten during its usable window. A write in the current slot uses the only ring buffer index that could collide with a root exactly `RECENT_ROOT_LENGTH` slots old, and that older root is already expired.
 
 ### Canonical frame instead of an envelope field
 
-The canonical frame reuses EIP-8141's transaction encoding, signature hash, execution semantics, gas accounting, and frame introspection. An envelope field would require a new transaction schema, native pre-execution checks, special gas and warming rules, and a new introspection opcode.
+The canonical frame reuses EIP-8141's transaction encoding, signature hash, execution semantics, gas accounting, and frame introspection. An envelope field would require a new transaction schema, native checks before frame execution, special gas and warming rules, and a new introspection opcode.
 
-A contract and an informal transaction-pool convention are not sufficient. EIP-8141 has a closed public-mempool validation-prefix grammar and normally bans both `SLOTNUM` and reads from storage outside `tx.sender`. This EIP therefore standardizes the frame's shape, position, resource bound, state-read exception, and revalidation rules.
+A contract and an informal transaction pool convention are not enough. EIP-8141 has a closed public mempool validation prefix grammar and normally bans both `SLOTNUM` and reads from storage outside `tx.sender`. The protocol must define the frame's shape, position, work bound, allowed storage reads, and revalidation rules.
 
 ### Full tuples in frame data
 
 Including `(source_id, slot, root)` in the frame lets clients derive every storage dependency without executing application validation. After a reorganization, a client can identify and evict transactions that reference an orphaned root.
 
-The 72-byte packed encoding is fixed-width and has no redundant count or selector. Its valid lengths do not collide with the contract's 64-byte write operation.
+The packed encoding uses 72 bytes per tuple and has no redundant count or selector. Its valid lengths do not collide with the write operation, which uses 64 bytes.
 
-The stored entry commits to `source_id`, `slot`, and `root`. This prevents a root from another source or a stale occupant of the same ring-buffer index from satisfying the tuple.
+The stored entry commits to `source_id`, `slot`, and `root`. This prevents a root from another source or a stale occupant of the same ring buffer index from satisfying the tuple.
 
 ### Fixed early position
 
-The recent root verifier frame runs after the optional expiry check and before deployment or account validation. Invalid or orphaned roots are therefore rejected before more expensive application validation runs, and every dependent validation frame can inspect an already successful frame.
+The recent root verifier frame runs after the optional expiry check and before deployment or account validation. This order rejects invalid or orphaned roots before more expensive application validation runs and lets every dependent validation frame inspect a successful frame.
 
-The fixed position is a public-mempool eligibility rule, not an additional block-validity rule. A privately submitted transaction remains governed by ordinary EIP-8141 execution, including the rule that a failed `VERIFY` frame invalidates the transaction.
+The fixed position affects public mempool eligibility, not block validity. Privately submitted transactions remain subject to ordinary EIP-8141 execution, including its rule that a failed `VERIFY` frame invalidates the transaction.
 
-### Separate public-mempool allowance
+### Public mempool validation budget
 
-Checking sixteen distinct roots requires sixteen cold storage reads in the worst case. Charging this work inside `MAX_VERIFY_GAS` would reduce the gas available to the application's own validation even though the recent-root frame is protocol-defined and independently bounded.
+Checking sixteen distinct roots requires sixteen cold storage reads in the worst case. Counting this work toward `MAX_VERIFY_GAS` would leave less gas for the application's own validation.
 
-The separate `MAX_RECENT_ROOT_VERIFY_GAS` allowance preserves the generic validation budget while increasing worst-case public-mempool validation work by a fixed amount. It is not free execution: the frame still reserves block gas and the payer still pays for it.
+`MAX_VERIFY_GAS` excludes the recent root verifier frame. A transaction eligible for the public mempool can contain only one such frame, its data can contain at most sixteen tuples, and its target code must equal `RECENT_ROOT_CODE`. These rules limit the work without a second gas counter.
 
-The canonical runtime uses 42,210 execution gas for sixteen distinct cold storage keys, including EIP-8141's 3,000 gas cold target charge. The 50,000 gas allowance leaves margin without changing block-level gas accounting.
+Direct evaluation does not change the frame's execution gas or fees. The frame's declared execution limit still contributes to the transaction's maximum cost and block gas reservation, and the payer still pays for the gas used.
 
 ### Window choice
 
-References are limited to slots strictly before `current_slot`. During slot `S`, writes update index `S mod RECENT_ROOT_LENGTH`, but references to `S` are invalid and references old enough to share that index are expired. Current-slot writes therefore cannot invalidate currently valid references.
+References are limited to slots strictly before `current_slot`. During slot `S`, writes update index `S mod RECENT_ROOT_LENGTH`, but references to `S` are invalid and references old enough to share that index are expired. Writes in the current slot cannot invalidate valid references.
 
 `RECENT_ROOT_LENGTH = 8192` gives `RECENT_ROOT_USABLE_WINDOW = 8191`, because the current slot is not referenceable.
 
-For public-mempool simulation, the latest canonical header slot plus one is the minimum successor slot derivable from the execution header alone. Skipped slots can make a near-expiry reference stale before the next payload, so builders revalidate against the exact payload slot before inclusion.
+For public mempool simulation, the latest canonical header slot plus one is the earliest possible slot for the next payload. A reference close to expiry may become stale if slots are skipped, so builders revalidate it against the exact payload slot before inclusion.
 
 ### Implicit source creation
 
-No creation transaction is required. A root source is created implicitly when a source address first writes with a new `(source_address, salt)` pair. Each root source has a bounded rolling window. Aggregate storage grows linearly with the number of written root sources, and writes that create storage entries pay the ordinary state-growth cost.
+No creation transaction is required. A root source is created when a source address first writes with a new `(source_address, salt)` pair. Each root source has a bounded rolling window. Aggregate storage grows linearly with the number of written root sources, and writes that create storage entries pay the ordinary state growth cost.
 
 ## Backwards Compatibility
 
 This EIP does not change the EIP-8141 transaction payload or signature hash and does not modify other transaction types.
 
-The account at `RECENT_ROOT_ADDRESS` must have empty code and storage before activation. Calls to that address change behavior after activation because the canonical runtime code is installed there.
+The account at `RECENT_ROOT_ADDRESS` must have empty code and storage before activation. Calls to that address change behavior after activation because `RECENT_ROOT_CODE` is installed there.
 
-References to slots before activation are not satisfiable because recent-root storage is empty at activation.
+References to slots before activation are not satisfiable because recent root storage is empty at activation.
 
 ## Test Cases
 
-Implementations should cover at least the following cases. A public-mempool rejection is not by itself a block-validity result; the contract and EIP-8141 columns state any independent block-execution or static-validity result.
+Implementations should cover at least the following cases. Rejection from the public mempool does not by itself make a transaction invalid in a block. The contract and EIP-8141 columns state any separate block execution or static validity result.
 
 | Case | Contract or EIP-8141 result | Public mempool result |
 | --- | --- | --- |
 | One valid tuple from the previous slot | success | accept if all other EIP-8141 rules pass |
-| Sixteen valid tuples with distinct cold storage keys | success within `MAX_RECENT_ROOT_VERIFY_GAS` | accept |
+| Sixteen valid tuples with distinct cold storage keys | success when `limits.execution` is sufficient | accept if all other EIP-8141 rules pass |
 | Duplicate valid tuples | success | accept |
 | Wrong root, source, or slot | revert | reject |
-| Current-slot or future-slot tuple | revert | reject |
+| Tuple for the current or a future slot | revert | reject |
 | Ages `8191` and `8192` slots | success, then revert | accept, then reject |
-| Empty, 71-byte, 73-byte, or seventeen-tuple validation data | revert | reject |
+| Empty validation data, data of length 71 or 73 bytes, or data with seventeen tuples | revert | reject |
 | Nonzero `VERIFY` value | statically invalid under EIP-8141 | reject |
 | `flags == 1` | contract executes normally | reject; not `recent_root_verify` |
 | `flags` contains `ATOMIC_BATCH_FLAG` | statically invalid under EIP-8141 | reject |
-| Nonzero state-gas limit | contract executes normally | reject; not `recent_root_verify` |
+| Nonzero state gas limit | contract executes normally | reject; not `recent_root_verify` |
 | More than one matching frame | each frame executes normally | reject |
 | Matching frame after deployment or account validation | executes normally | reject |
-| `limits.execution > MAX_RECENT_ROOT_VERIFY_GAS` | executes normally if sufficiently funded | reject |
-| Generic declared limit plus signature cost equals `MAX_VERIFY_GAS`, and root limit equals `MAX_RECENT_ROOT_VERIFY_GAS` | ordinary execution | accept |
-| Either allowance exceeds its maximum by one | ordinary execution if sufficiently funded | reject |
+| `limits.execution` is one gas less than the recent root verifier frame requires | halts exceptionally | reject |
+| Generic declared limit plus signature cost equals `MAX_VERIFY_GAS`, with a valid recent root verifier frame | ordinary execution | accept |
+| Generic declared limit plus signature cost exceeds `MAX_VERIFY_GAS` by one | ordinary execution if sufficiently funded | reject |
+| Direct evaluation instead of EVM execution | identical frame receipt, gas use, and warm access sets | same admission result |
 | Root removed by a reorganization | revert after revalidation | evict |
-| Activation installs `RECENT_ROOT_CODE` with empty storage | subsequent writes and validation use the canonical runtime | revalidate; reject until every referenced entry exists |
-| Activation finds empty code and storage with a pre-existing balance and nonce | preserve balance and set nonce to `max(existing_nonce, 1)` | revalidate |
+| Activation installs `RECENT_ROOT_CODE` with empty storage | subsequent writes and validation use `RECENT_ROOT_CODE` | revalidate; reject until every referenced entry exists |
+| Activation finds empty code and storage with an existing balance and nonce | preserve balance and set nonce to `max(existing_nonce, 1)` | revalidate |
 | Activation finds nonempty code or storage | first active block is invalid | not applicable |
 | A later block follows successful activation | do not rerun initialization or clear storage | retain and revalidate normally |
 | Reorganization crosses back before activation | this EIP is inactive | evict |
 
-The maximum-size case must include the cold target-account access charged at frame entry by EIP-8141, not only the contract's internal execution.
+The case with sixteen tuples must include the cold target account access charged at frame entry by EIP-8141, not only the contract's internal execution.
 
-Each of EIP-8141's four recognized validation-prefix shapes must be tested with no protocol verifier, with `recent_root_verify`, with `expiry_verify`, and with `expiry_verify` followed by `recent_root_verify`. Reversed or duplicate protocol verifiers must be rejected from the public mempool.
+Each of EIP-8141's four recognized validation prefix shapes must be tested with no protocol verifier, with `recent_root_verify`, with `expiry_verify`, and with `expiry_verify` followed by `recent_root_verify`. Reversed or duplicate protocol verifiers must be rejected from the public mempool.
 
 ### Reference vector
 
@@ -411,7 +397,7 @@ The 72-byte validation calldata is:
 0xb9382d35273c75a50631a3e84d3c75ec9266e2b18c35a627e16cdbf26a18ca8500000000000000010000000000000000000000000000000000000000000000000000000000000002
 ```
 
-With `storage[storage_key] = entry_hash`, the canonical runtime succeeds. It consumes 2,595 gas with a cold storage key. Including EIP-8141's 3,000 gas cold target charge, the frame consumes 5,595 execution gas.
+With `storage[storage_key] = entry_hash`, the validation operation succeeds.
 
 ## Security Considerations
 
@@ -419,15 +405,15 @@ Consensus treats `root` as an opaque `bytes32`. Applications define what it comm
 
 EIP-8141's canonical signature hash covers the frame data, but EIP-8141 also permits validation based on an explicit 32-byte signature message. Validation logic that does not authorize the canonical signature hash must bind the recent root verifier frame and every other relevant frame itself.
 
-Each `(source_id, slot)` has one referenceable root on the canonical chain. The referenceable root is last-write-wins according to canonical execution order. An application that needs multiple roots from the same source and slot should write an aggregate commitment.
+For each `(source_id, slot)`, only the last root written in canonical execution order is referenceable. An application that needs multiple roots from the same source and slot should write an aggregate commitment.
 
 This EIP does not guarantee inclusion of root writes. Applications that rely on timely publication need their own publication path, redundant root sources, or an inclusion policy for write transactions.
 
-The same `(source_address, salt)` pair produces the same `source_id` on different chains, but each chain maintains independent recent-root state. Proofs, bridge messages, and off-chain attestations that carry recent-root references must bind the intended chain domain outside the tuple.
+The same `(source_address, salt)` pair produces the same `source_id` on different chains, but each chain maintains its own recent root state. Proofs, bridge messages, and attestations produced off chain that carry recent root references must bind the intended chain domain outside the tuple.
 
-Recent roots create ordinary persistent storage under `RECENT_ROOT_ADDRESS`. Existing root sources overwrite at most `RECENT_ROOT_LENGTH` cells, while new root sources create additional cells. A future proposal may add a one-time source registration cost or first-write surcharge if ordinary state-growth pricing is insufficient.
+Recent roots create persistent storage under `RECENT_ROOT_ADDRESS`. Existing root sources overwrite at most `RECENT_ROOT_LENGTH` cells, while new root sources create additional cells. A future proposal may add a source registration cost or a surcharge for the first write if ordinary state growth pricing is insufficient.
 
-The separate recent-root allowance raises the maximum public-mempool validation work for one candidate transaction from `MAX_VERIFY_GAS` to `MAX_VERIFY_GAS + MAX_RECENT_ROOT_VERIFY_GAS`. Implementations should include both allowances in peer-level invalid-transaction throttling and global transaction-pool resource limits. A reorganization or synchronized expiry may still evict many transactions that use one popular root, but dependency indexing avoids re-executing each transaction's full validation prefix merely to discover the mismatch.
+The recent root verifier frame can add up to sixteen root checks beyond `MAX_VERIFY_GAS`. An invalid final tuple or a frame with slightly too little execution gas can force almost all of this work before the transaction is rejected, without paying an inclusion fee. Implementations should account for this work in limits on invalid transactions from each peer and in limits on total transaction pool work. A reorganization or synchronized expiry may evict many transactions that use one popular root, but dependency indexing lets clients identify affected transactions without rerunning unrelated validation prefixes.
 
 ## Copyright
 

--- a/EIPS/eip-8272.md
+++ b/EIPS/eip-8272.md
@@ -1,67 +1,59 @@
 ---
 eip: 8272
 title: Recent Roots for Frame Transactions
-description: Frame transactions can declare verified recent roots
+description: Frame transactions can verify recent roots through a canonical frame
 author: Thomas Thiery (@soispoke), Vitalik Buterin (@vbuterin), Toni Wahrstätter (@nerolation)
 discussions-to: https://ethereum-magicians.org/t/eip-8272-recent-roots-for-frame-transactions/28621
 status: Draft
 type: Standards Track
 category: Core
 created: 2026-05-15
-requires: 7623, 7843, 8141
+requires: 7843, 8141
 ---
 
 ## Abstract
 
-[EIP-8141](./eip-8141.md) frame transactions can reference recent roots without reading mutable storage during validation. This helps privacy applications validate spends using proofs against recent commitment tree roots named in the signed transaction envelope. A root source writes roots to a system contract, with each root keyed by `(source_id, slot)`, where `source_id` derives from the writer address and a salt. A frame transaction may declare recent root references of the form:
+[EIP-8141](./eip-8141.md) frame transactions can verify recent roots through a canonical `VERIFY` frame. The frame carries one to sixteen `(source_id, slot, root)` tuples and calls a recent-root contract that checks each tuple against its storage. A root source writes roots to the same contract, with each root keyed by `(source_id, slot)`, where `source_id` derives from the writer address and a salt.
 
-```text
-(source_id, slot, root)
-```
-
-Before frame execution, clients check each reference against the transaction pre-state. The check succeeds only if the named root is stored for the named source and slot, and the slot is still recent. Validation code can then read the verified reference through transaction introspection.
+The frame runs before account validation in the public mempool. A failed check invalidates the transaction, while account validation can read the verified tuples through existing frame introspection. This requires no change to the frame-transaction envelope and no new opcode.
 
 ## Motivation
 
-[EIP-8141](./eip-8141.md) validation must not read arbitrary storage controlled by another account or application in the public mempool. Some validation rules still need to depend on recent application state, such as privacy tree roots, wallet authorization roots, or account validation roots.
+[EIP-8141](./eip-8141.md) public-mempool validation cannot read arbitrary storage controlled by another account or application. Some validation rules still need recent application state, such as privacy tree roots, wallet authorization roots, or account validation roots.
 
-Recent root references let a transaction explicitly name recent roots in its signed transaction envelope. Each reference maps to one system-contract storage key and can be checked before validation code runs.
+A rolling recent-root contract makes this dependency safe. A stored entry cannot change while it is referenceable, except through a chain reorganization, and each reference names exactly one storage key. A canonical frame lets clients recognize, bound, index, and revalidate these reads without extending the transaction envelope.
 
-Privacy applications, for example, keep a tree of commitments and prove spends against a recent tree root. With this EIP, the application writes roots by slot, and spend transactions reference one of those roots directly instead of reading the application's changing tree state during validation.
+Privacy applications, for example, keep a tree of commitments and prove spends against a recent tree root. The application writes roots by slot, and a spend transaction verifies one of those roots before its account-validation frame runs.
 
 ## Specification
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
 
-This specification is a delta against [EIP-8141](./eip-8141.md). Terms not defined here, including `FrameTx`, `FRAME_TX_TYPE`, `VERIFY`, `EXPIRY_VERIFIER`, frame modes, and `TXPARAM`, have the meanings defined in [EIP-8141](./eip-8141.md).
+This specification is a delta against [EIP-8141](./eip-8141.md). Terms not defined here, including `FrameTx`, `VERIFY`, `expiry_verify`, the validation prefix, `MAX_VERIFY_GAS`, `FRAMEPARAM`, `FRAMEDATALOAD`, and `FRAMEDATACOPY`, have the meanings defined in EIP-8141.
 
 ### Constants
 
-| Name                                 |                                                                            Value |
-| ------------------------------------ | -------------------------------------------------------------------------------: |
-| `FORK_TIMESTAMP`                     |                                                                            `TBD` |
-| `RECENT_ROOT_ADDRESS`                 |                     `0x0000000000000000000000000000000000008272` |
-| `RECENT_ROOT_CODE`                    |                                                                            `TBD` |
-| `RECENT_ROOT_LENGTH`                  |                                                                           `8192` |
-| `RECENT_ROOT_USABLE_WINDOW`           |                                                                           `8191` |
-| `MAX_RECENT_ROOT_REFERENCES`          |                                                                             `16` |
-| `RECENT_ROOT_ENTRY_DOMAIN`            |                                                  `keccak256("RECENT_ROOT_ENTRY")` |
-| `RECENT_ROOT_STORAGE_DOMAIN`          |                                                `keccak256("RECENT_ROOT_STORAGE")` |
-| `RECENT_ROOT_REFERENCE_ADDRESS_GAS`   |                                                       `ACCESS_LIST_ADDRESS_COST` |
-| `RECENT_ROOT_REFERENCE_GAS`           | `ACCESS_LIST_STORAGE_KEY_COST + 2 * KECCAK256_BASE_GAS + 7 * KECCAK256_WORD_GAS` |
-| `TXPARAM_RECENT_ROOT_REFERENCE_COUNT` |                                                                           `0x11` |
-| `RECENTROOTREFLOAD`                   |                                                                           `0xB6` |
-| `RECENTROOTREFLOAD_GAS`               |                                                                              `3` |
+| Name | Value |
+| --- | ---: |
+| `RECENT_ROOT_ADDRESS` | `0x0000000000000000000000000000000000008272` |
+| `RECENT_ROOT_CODE_HASH` | `0xb2427f08a58430ff05c99b5c232e5ad620a593ad8c9f881ad8c966746562e785` |
+| `RECENT_ROOT_LENGTH` | `8192` |
+| `RECENT_ROOT_USABLE_WINDOW` | `8191` |
+| `MAX_RECENT_ROOT_REFERENCES` | `16` |
+| `RECENT_ROOT_TUPLE_BYTES` | `72` |
+| `MAX_RECENT_ROOT_VERIFY_GAS` | `50_000` |
+| `RECENT_ROOT_ENTRY_DOMAIN` | `keccak256("RECENT_ROOT_ENTRY")` |
+| `RECENT_ROOT_STORAGE_DOMAIN` | `keccak256("RECENT_ROOT_STORAGE")` |
 
 All concatenations below use fixed-length encodings. Domains are 32 bytes. Addresses are 20 bytes. Slots and indices are unsigned 64-bit big-endian integers. Roots, salts, source identifiers, entry hashes, and storage keys are 32 bytes.
 
 ### Current slot
 
-For block validation, `current_slot` is the consensus slot of the beacon block that contains the execution payload being validated.
+During block execution, `current_slot` is the consensus slot of the beacon block containing the execution payload.
 
-Execution clients MUST obtain `current_slot` from the [EIP-7843](./eip-7843.md) `slotNumber` field. Clients MUST NOT derive `current_slot` from `block.timestamp` using a fixed slot duration.
+Execution clients MUST obtain `current_slot` from the [EIP-7843](./eip-7843.md) `slotNumber` field. Clients MUST NOT derive it from `block.timestamp` using a fixed slot duration.
 
-For transaction pool handling, `current_slot` is the node's current slot at receipt, recheck, or eviction time. It is local policy, not block validity.
+During public-mempool validation, `current_slot` is one greater than the `slotNumber` in the latest canonical execution header. The simulated `SLOTNUM` value MUST equal this slot. This value deliberately does not advance during empty slots. Before including a transaction in a payload, a client MUST revalidate it with `SLOTNUM` set to that payload's `slotNumber`.
 
 References MUST target slots strictly before `current_slot`. A root written during slot `S` becomes referenceable beginning in slot `S + 1`.
 
@@ -75,7 +67,7 @@ source_id = keccak256(source_address || salt)
 
 where `source_address` is an address and `salt` is a `bytes32` value.
 
-The source address MAY be an externally owned account or a contract, and MAY use multiple root sources by using different salts. Applications using a root source are responsible for controlling who can write to it and how salts are allocated.
+The source address MAY be an externally owned account or a contract, and MAY use multiple root sources through different salts. Applications using a root source are responsible for controlling who can write to it and how salts are allocated.
 
 ### Entry and storage keys
 
@@ -114,7 +106,11 @@ Each root source uses at most `RECENT_ROOT_LENGTH` storage keys. The global stor
 
 At activation, clients MUST create or update the account at `RECENT_ROOT_ADDRESS` as specified in [Activation](#activation).
 
-The contract accepts one write operation with 64 bytes of calldata:
+Calls with nonzero value MUST revert. Calldata selects one of two operations by length.
+
+#### Write operation
+
+The write operation has exactly 64 bytes of calldata:
 
 ```text
 salt: bytes32
@@ -123,15 +119,7 @@ root: bytes32
 
 Bytes `0..31` are `salt`. Bytes `32..63` are `root`.
 
-Calls MUST revert unless calldata is exactly 64 bytes and call value is zero.
-
-In static context, the write MUST fail and storage MUST remain unchanged.
-
-The source address for a successful write is `msg.sender` of the call to `RECENT_ROOT_ADDRESS`.
-
-Only a direct call to `RECENT_ROOT_ADDRESS` can write recent-root storage. `DELEGATECALL` and `CALLCODE` MUST NOT write recent-root storage.
-
-When a successful call is made during slot `S`, the contract computes:
+The source address is `msg.sender` of the call to `RECENT_ROOT_ADDRESS`. When a successful call is made during slot `S`, the contract computes:
 
 ```text
 source_address = msg.sender
@@ -156,59 +144,37 @@ and sets:
 storage[storage_key] = entry_hash
 ```
 
-The call follows normal EVM execution and gas accounting. A successful call returns zero bytes. The contract exposes no read operation.
+In static context, the write MUST fail and storage MUST remain unchanged.
 
-Each `(source_id, S)` has at most one referenceable root on the canonical chain. Multiple writes by the same source address and salt during slot `S` target the same storage key. If multiple writes are included, the final write in canonical block execution order overwrites earlier writes. Only that final root is referenceable beginning in slot `S + 1`.
+Only execution whose storage context is `RECENT_ROOT_ADDRESS` writes recent-root storage. `DELEGATECALL` and `CALLCODE` use the invoking account's storage context, while [EIP-7702](./eip-7702.md) delegated code uses the delegating account's storage context. None modifies recent-root storage unless that context is `RECENT_ROOT_ADDRESS`.
 
-### Transaction payload
+Each `(source_id, S)` has at most one referenceable root on the canonical chain. Multiple writes by the same source address and salt during slot `S` target the same storage key. The final write in canonical block execution order overwrites earlier writes, and only that root is referenceable beginning in slot `S + 1`.
 
-This EIP inserts `recent_root_references` immediately after `blob_versioned_hashes` in the [EIP-8141](./eip-8141.md) `FRAME_TX_TYPE` payload. No other payload field is changed. Applied to the [EIP-8141](./eip-8141.md) payload, the result is:
+A successful write returns no data or logs.
+
+#### Validation operation
+
+The validation operation has `n * RECENT_ROOT_TUPLE_BYTES` bytes of calldata, where:
 
 ```text
-[chain_id, nonce, sender, frames, signatures,
- max_priority_fee_per_gas, max_fee_per_gas,
- max_fee_per_blob_gas, blob_versioned_hashes,
- recent_root_references]
+1 <= n <= MAX_RECENT_ROOT_REFERENCES
 ```
 
-where:
+The calldata is the concatenation of `n` tuples without a selector or length prefix:
 
 ```text
-recent_root_references = [[source_id, slot, root], ...]
+source_id: bytes32
+slot:       uint64_be
+root:       bytes32
 ```
 
-`recent_root_references` MUST be an RLP list. Each item MUST be an RLP list of exactly three elements. `source_id` MUST be a byte string of length 32. `slot` MUST be a canonical RLP integer satisfying `slot < 2**64`. `root` MUST be a byte string of length 32. Consensus treats `root` as opaque bytes; applications define what it commits to. The number of references MUST NOT exceed `MAX_RECENT_ROOT_REFERENCES`.
+The contract MUST revert for empty calldata, for a length that is not a multiple of `RECENT_ROOT_TUPLE_BYTES`, or for more than `MAX_RECENT_ROOT_REFERENCES` tuples. The 64-byte write encoding and every valid validation encoding are disjoint.
 
-The `slot` field is a slot number, not a timestamp or block number.
-
-The frame layout and frame execution rules are otherwise unchanged.
-
-The [EIP-8141](./eip-8141.md) signature hash procedure applies after this field is inserted. The signing payload contains `recent_root_references` immediately after `blob_versioned_hashes`.
-
-Frame data, including VERIFY frame data, MUST NOT add, remove, or modify the transaction's recent root reference set.
-
-### Static validity
-
-Decoders MUST reject a frame transaction to which this EIP applies if any of the following is true:
-
-* the payload does not match the [EIP-8141](./eip-8141.md) payload schema after inserting exactly one `recent_root_references` field immediately after `blob_versioned_hashes`;
-* `recent_root_references` is not an RLP list;
-* `len(recent_root_references) > MAX_RECENT_ROOT_REFERENCES`;
-* any reference is not an RLP list of exactly three elements;
-* any `source_id` is not a byte string of length 32;
-* any `slot` is not a canonical RLP integer or satisfies `slot >= 2**64`;
-* any `root` is not a byte string of length 32.
-
-### Reference validity
-
-Within block execution, recent root references are checked after the [EIP-8141](./eip-8141.md) nonce check and before frame execution, against the transaction pre-state. The transaction pre-state includes all prior transactions in the same block.
-
-Competing blocks at the same slot may have different recent-root state, and a reference is valid only in a block whose transaction pre-state contains the referenced entry. `current_slot` is the consensus slot of that block.
-
-A recent root reference `(source_id, slot, root)` is valid only if:
+For each tuple, the contract MUST check:
 
 ```text
-1 <= current_slot - slot <= RECENT_ROOT_USABLE_WINDOW
+slot < current_slot
+current_slot - slot <= RECENT_ROOT_USABLE_WINDOW
 i = slot mod RECENT_ROOT_LENGTH
 entry_hash = keccak256(
     RECENT_ROOT_ENTRY_DOMAIN ||
@@ -221,124 +187,156 @@ storage_key = keccak256(
     source_id ||
     uint64_be(i)
 )
-RECENT_ROOT_ADDRESS[storage_key] == entry_hash
+storage[storage_key] == entry_hash
 ```
 
-If any reference is invalid, the transaction is invalid and no frame is executed. A block containing such a transaction is invalid.
+The call MUST revert if any tuple fails. Duplicate tuples are valid and are checked independently. If every tuple passes, the call MUST succeed with no return data, logs, or state changes.
 
-Duplicate references are valid. They are checked, charged, and preserved independently. Accessed address and storage-key sets deduplicate normally.
+The validation operation MUST read the current slot with `SLOTNUM`, MUST NOT call another account, and MUST read only the recent-root storage keys derived from its calldata.
 
-Each valid reference MUST add `RECENT_ROOT_ADDRESS` and its `storage_key` to the transaction's accessed address and storage-key sets. This affects warm/cold gas accounting only.
+All calls use ordinary EVM execution and gas accounting.
 
-### Access lists
+#### Canonical runtime code
 
-Recent root writes are ordinary writes to `RECENT_ROOT_ADDRESS[storage_key]`.
-
-### Gas accounting
-
-This EIP adds the data cost and reference checks introduced by `recent_root_references` to the [EIP-8141](./eip-8141.md) gas quantities. Define:
+`RECENT_ROOT_CODE` is the following 344-byte runtime bytecode. Its Keccak-256 hash MUST equal `RECENT_ROOT_CODE_HASH`.
 
 ```text
-recent_root_reference_intrinsic_gas =
-    0
-        if len(recent_root_references) == 0
-    RECENT_ROOT_REFERENCE_ADDRESS_GAS
-        + len(recent_root_references) * RECENT_ROOT_REFERENCE_GAS
-        otherwise
+0x3461015257368060401460d15780604811610152576104808111610152578060489006610152574b9060005b81811460cf578035816020013560c01c8085111561015257808503611fff9011610152577f8f42481679c8e6fefa040974b3c905e0ce3f2e464ba93acdb074a41181617efc60005280602852816020528260280160209060483760686000207fbdc897da2177d260ff5f4be5d4b2aad43f89c3347a305b584fa5a2546d053daa60005281611fff16602852826020526048600020541415610152575050604801602b565b005b5033600052602060006020376034600c20807f8f42481679c8e6fefa040974b3c905e0ce3f2e464ba93acdb074a41181617efc6040524b606852606052602060206088376068604020817fbdc897da2177d260ff5f4be5d4b2aad43f89c3347a305b584fa5a2546d053daa60a852611fff4b1660d05260c852604860a82055005b60006000fd
 ```
 
-and:
+### Recent root verifier frame
+
+A **recent root verifier frame** is a frame with all of the following properties:
 
 ```text
-recent_root_calldata = rlp(recent_root_references)
-recent_root_calldata_cost = calldata_cost(recent_root_calldata)
-recent_root_calldata_tokens = tokens_in(recent_root_calldata)
+frame.mode == VERIFY
+frame.target == RECENT_ROOT_ADDRESS
+frame.flags == 0
+frame.value == 0
+frame.limits.state == 0
+RECENT_ROOT_TUPLE_BYTES <= len(frame.data)
+len(frame.data) <= MAX_RECENT_ROOT_REFERENCES * RECENT_ROOT_TUPLE_BYTES
+len(frame.data) mod RECENT_ROOT_TUPLE_BYTES == 0
 ```
 
-Apply the following additions:
+For public-mempool classification, this frame is named `recent_root_verify`.
 
-* add `recent_root_calldata_cost + recent_root_reference_intrinsic_gas` to `standard_gas_limit`;
-* add `recent_root_reference_intrinsic_gas` to `calldata_floor_gas`;
-* add `recent_root_calldata_tokens` to `calldata_tokens`.
+The frame executes the validation operation through the `STATICCALL` semantics of EIP-8141. If the contract reverts or the frame halts exceptionally, EIP-8141 makes the transaction invalid.
 
-The [EIP-8141](./eip-8141.md) definitions of `max_gas`, `gas_used`, and fee settlement remain unchanged and use these updated quantities.
+The frame consumes ordinary EVM gas. Its target access and storage reads follow the normal warm and cold access rules, and its data follows the normal EIP-8141 transaction-data pricing. This EIP introduces no special intrinsic gas, access warming, or block-level gas exemption.
 
-`RECENT_ROOT_REFERENCE_GAS` covers one declared storage key and the two Keccak computations used to derive `storage_key` and `entry_hash`.
+EIP-8141's canonical signature hash already covers the complete frame list, including each frame's data. This EIP does not change the transaction payload or signature hash.
 
-### TXPARAM and RECENTROOTREFLOAD
+### Application introspection
 
-One new `TXPARAM` index and one new opcode are added:
+Applications read a recent root verifier frame through EIP-8141's existing `FRAMEPARAM`, `FRAMEDATALOAD`, and `FRAMEDATACOPY` instructions. This EIP adds no transaction parameter or opcode.
 
-[EIP-8141](./eip-8141.md) assigns opcodes `0xB4` to `SIGPARAM` and `0xB5` to `SIGDATACOPY`. `RECENTROOTREFLOAD` uses `0xB6` to avoid those collisions.
+Application validation can identify a completed recent root verifier frame through `FRAMEPARAM` by checking `resolved_target == RECENT_ROOT_ADDRESS`, `mode == VERIFY`, `flags == 0`, `limits.state == 0`, a valid recent-root data length, and `status == 1`.
 
-| Name                                 |  Value | Return value                 |
-| ------------------------------------ | -----: | ---------------------------- |
-| `TXPARAM_RECENT_ROOT_REFERENCE_COUNT` | `0x11` | `len(recent_root_references)` |
-
-`TXPARAM(TXPARAM_RECENT_ROOT_REFERENCE_COUNT)` costs the standard `TXPARAM` gas.
-
-`RECENTROOTREFLOAD` pops two stack items:
-
-```text
-field
-index
-```
-
-where `field` is the top stack item and `index` is the second stack item. It pushes one word from `recent_root_references[index]`:
-
-| `field` | Return value                               |
-| ------: | ------------------------------------------ |
-|     `0` | `source_id`                                 |
-|     `1` | `slot`, as a zero-extended 256-bit integer |
-|     `2` | `root`                                     |
-
-`RECENTROOTREFLOAD` costs `RECENTROOTREFLOAD_GAS`. It MUST exceptional-halt if `index >= len(recent_root_references)` or `field > 2`.
-
-`RECENTROOTREFLOAD` reads only fields from the signed transaction envelope. It does not read recent root contract storage. It MAY be used in any frame mode, including VERIFY frames.
+In a public-mempool-eligible transaction, the recent root verifier frame is frame `0`, or frame `1` when an `expiry_verify` frame is present.
 
 ### Public mempool handling
 
-Recent root storage is not exposed to validation code through EVM execution. During public mempool validation, recent root state may affect a transaction only through pre-execution reference checks and declared roots exposed by introspection.
+EIP-8141's public-mempool policy summary is extended to permit `current_slot` as defined above and the recent-root contract code and storage read by a `recent_root_verify` frame, subject to the rules below.
 
-Nodes SHOULD admit a transaction to the public mempool only if all declared recent root references are valid against the node's current head.
+A public-mempool-eligible transaction MUST contain no more than one recent root verifier frame. If present, it MUST appear immediately after an optional `expiry_verify` frame and before every other frame:
 
-Nodes SHOULD NOT admit a transaction while any reference has `slot >= current_slot`. Nodes SHOULD evict a transaction with any reference where `current_slot - slot >= RECENT_ROOT_LENGTH`, so that expired transactions do not accumulate.
+```text
+[expiry_verify?] [recent_root_verify?] [deploy?] [account validation] ...
+```
 
-To avoid admitting a transaction that expires almost immediately, nodes SHOULD NOT admit a transaction whose oldest reference is within a small margin of expiry, i.e. where `current_slot - slot >= RECENT_ROOT_LENGTH - m` for a node-chosen margin `m` of a few slots.
+For the purpose of matching EIP-8141's four recognized validation-prefix shapes, clients MUST skip both optional leading protocol verifier frames. The EIP-8141 rule that `deploy` is first applies after these frames are skipped.
 
-To keep expiry and reorg eviction bounded without restricting application concurrency, public mempool nodes SHOULD index pending transactions by declared reference and by expiry slot, so that the transactions affected by a slot advance or a reorg can be found and evicted efficiently.
+Clients MUST check this frame shape and its fixed-width data encoding before reading sender state.
 
-Nodes SHOULD recheck pending transactions with recent root references when the head changes, when the node's current slot advances, or after any reorg that may affect referenced entries.
+A recent root verifier frame is subject to EIP-8141's generic validation trace and opcode rules with exactly two additional permissions. Only during the top-level execution of this frame, while the runtime code at `RECENT_ROOT_ADDRESS` exactly equals `RECENT_ROOT_CODE`:
+
+1. `SLOTNUM` MAY execute inside `RECENT_ROOT_CODE`.
+2. `SLOAD` MAY read `RECENT_ROOT_ADDRESS[storage_key]` for storage keys derived from the frame's tuples as specified above.
+
+No nested call receives either permission. No other opcode, call, state-read, or state-write exception is added. Clients MUST reject the transaction from the public mempool if the code at `RECENT_ROOT_ADDRESS` does not equal `RECENT_ROOT_CODE`.
+
+The generic EIP-8141 simulation rules apply, and the frame MUST execute successfully. This EIP does not add a direct-evaluation exception. The frame's `limits.execution` MUST NOT exceed `MAX_RECENT_ROOT_VERIFY_GAS`.
+
+EIP-8141's declared-limit check is amended to use two independent allowances:
+
+```text
+signature_verification_cost
+    + sum(frame.limits.execution for non-recent-root frames in validation_prefix)
+    <= MAX_VERIFY_GAS
+
+recent_root_verify.limits.execution <= MAX_RECENT_ROOT_VERIFY_GAS
+```
+
+During simulation, clients MUST likewise maintain two counters. Signature verification and execution gas spent by every non-recent-root frame count toward a generic counter capped at `MAX_VERIFY_GAS`. Execution gas spent by the recent root verifier frame counts only toward a recent-root counter capped at `MAX_RECENT_ROOT_VERIFY_GAS`.
+
+Because actual frame execution cannot exceed its declared limit, the total metered public-mempool validation gas is bounded by:
+
+```text
+MAX_VERIFY_GAS + MAX_RECENT_ROOT_VERIFY_GAS
+```
+
+This separate allowance changes only public-mempool admission accounting. The frame's declared execution limit remains part of the EIP-8141 transaction maximum cost and block execution-gas reservation, and the payer is charged for the frame's actual gas use under the ordinary EIP-8141 rules.
+
+Clients MUST reject a transaction from the public mempool if any tuple has `slot >= current_slot` or if the frame does not execute successfully against the current head.
+
+Clients MUST evict a pending transaction if any tuple has `slot >= current_slot`. Otherwise, they MUST evict it when any tuple reaches:
+
+```text
+current_slot - slot >= RECENT_ROOT_LENGTH
+```
+
+To avoid admitting a transaction that expires almost immediately, clients SHOULD NOT admit a transaction whose oldest reference is within a small node-chosen margin of expiry.
+
+On admission, clients MUST record each distinct `(storage_key, entry_hash)` dependency and the first `current_slot` at which it expires. Clients SHOULD index pending transactions by these values so that a slot advance or chain reorganization does not require scanning unrelated transactions. Clients MUST also track the code and activation status of `RECENT_ROOT_ADDRESS` as dependencies. These records MUST be removed when the transaction leaves the public mempool and MUST be replaced atomically with the transaction during replacement.
+
+When any recorded dependency may have changed, clients MUST recheck the complete age and storage predicates for each affected transaction and evict transactions that no longer satisfy them. Reorganization handling MUST consider state changes on both the removed and added branches, including a referenced entry removed by rollback without a replacement write. A change to the code or activation status of `RECENT_ROOT_ADDRESS` requires revalidation of every pending transaction containing a recent root verifier frame. The ordinary EIP-8141 revalidation rules continue to apply to all other dependencies.
 
 ### Activation
 
-This EIP MUST activate at or after [EIP-8141](./eip-8141.md).
+This EIP MUST activate at or after EIP-8141 and EIP-7843.
 
-If `timestamp < FORK_TIMESTAMP`, clients MUST NOT insert `recent_root_references` and MUST NOT apply recent root logic.
-
-If `timestamp >= FORK_TIMESTAMP`, clients MUST insert `recent_root_references` and MUST apply recent root logic.
-
-For every block `B` with `B.timestamp >= FORK_TIMESTAMP` whose parent has `parent.timestamp < FORK_TIMESTAMP`, clients MUST initialize `RECENT_ROOT_ADDRESS` against `B`'s parent state before executing any transaction in `B`.
+For the first block in which this EIP is active, clients MUST initialize `RECENT_ROOT_ADDRESS` against the parent state before executing any transaction.
 
 If `RECENT_ROOT_ADDRESS` does not exist, clients MUST create it with balance 0, nonce 1, code `RECENT_ROOT_CODE`, and empty storage.
 
 If `RECENT_ROOT_ADDRESS` already exists with empty code and empty storage, clients MUST set its code to `RECENT_ROOT_CODE`, set its nonce to `max(existing_nonce, 1)`, preserve its balance, and leave storage empty.
 
-The fork configuration MUST choose a `RECENT_ROOT_ADDRESS` with empty code and empty storage in the parent state of the first post-fork payload. If this condition is false at activation, the payload is invalid.
+The fork configuration MUST choose a `RECENT_ROOT_ADDRESS` with empty code and empty storage in the parent state of the first active block. If this condition is false, the first active block is invalid.
 
-For all other blocks, clients MUST NOT run this initialization. Clients MUST handle reorgs across the fork boundary by applying or undoing this transition according to the canonical chain.
-
-Pre-fork frame transactions and authorizations bound to the pre-fork canonical signature hash do not survive the boundary and MUST be evicted from mempools and regenerated.
+For all other blocks, clients MUST NOT run this initialization. Clients MUST handle reorganizations across activation by applying or undoing this transition according to the canonical chain.
 
 ## Rationale
 
-[EIP-8141](./eip-8141.md) validation needs inputs that are known before validation starts. General reads from storage controlled by another account or application are unsafe for the public mempool because one mutable cell can invalidate many pending transactions.
+[EIP-8141](./eip-8141.md) public-mempool validation normally rejects reads from shared mutable storage. Recent-root storage is a narrow exception because a valid entry cannot be overwritten during its usable window. A current-slot write uses the only ring-buffer index that could collide with a root exactly `RECENT_ROOT_LENGTH` slots old, and that older root is already expired.
 
-Recent root references provide a narrow exception. The root is declared in the signed transaction envelope, checked by clients before validation code runs, and exposed to validation code only through introspection. Recent root references are intentionally narrow: each reference names one recent `bytes32` root and one system-contract storage key.
+### Canonical frame instead of an envelope field
 
-### Entry binding
+The canonical frame reuses EIP-8141's transaction encoding, signature hash, execution semantics, gas accounting, and frame introspection. An envelope field would require a new transaction schema, native pre-execution checks, special gas and warming rules, and a new introspection opcode.
 
-Each stored entry commits to the root source, slot, and root. This prevents an old root at the same array index, or a root from another root source, from satisfying a reference.
+A contract and an informal transaction-pool convention are not sufficient. EIP-8141 has a closed public-mempool validation-prefix grammar and normally bans both `SLOTNUM` and reads from storage outside `tx.sender`. This EIP therefore standardizes the frame's shape, position, resource bound, state-read exception, and revalidation rules.
+
+### Full tuples in frame data
+
+Including `(source_id, slot, root)` in the frame lets clients derive every storage dependency without executing application validation. After a reorganization, a client can identify and evict transactions that reference an orphaned root.
+
+The 72-byte packed encoding is fixed-width and has no redundant count or selector. Its valid lengths do not collide with the contract's 64-byte write operation.
+
+The stored entry commits to `source_id`, `slot`, and `root`. This prevents a root from another source or a stale occupant of the same ring-buffer index from satisfying the tuple.
+
+### Fixed early position
+
+The recent root verifier frame runs after the optional expiry check and before deployment or account validation. Invalid or orphaned roots are therefore rejected before more expensive application validation runs, and every dependent validation frame can inspect an already successful frame.
+
+The fixed position is a public-mempool eligibility rule, not an additional block-validity rule. A privately submitted transaction remains governed by ordinary EIP-8141 execution, including the rule that a failed `VERIFY` frame invalidates the transaction.
+
+### Separate public-mempool allowance
+
+Checking sixteen distinct roots requires sixteen cold storage reads in the worst case. Charging this work inside `MAX_VERIFY_GAS` would reduce the gas available to the application's own validation even though the recent-root frame is protocol-defined and independently bounded.
+
+The separate `MAX_RECENT_ROOT_VERIFY_GAS` allowance preserves the generic validation budget while increasing worst-case public-mempool validation work by a fixed amount. It is not free execution: the frame still reserves block gas and the payer still pays for it.
+
+The canonical runtime uses 42,210 execution gas for sixteen distinct cold storage keys, including EIP-8141's 3,000 gas cold target charge. The 50,000 gas allowance leaves margin without changing block-level gas accounting.
 
 ### Window choice
 
@@ -346,33 +344,90 @@ References are limited to slots strictly before `current_slot`. During slot `S`,
 
 `RECENT_ROOT_LENGTH = 8192` gives `RECENT_ROOT_USABLE_WINDOW = 8191`, because the current slot is not referenceable.
 
+For public-mempool simulation, the latest canonical header slot plus one is the minimum successor slot derivable from the execution header alone. Skipped slots can make a near-expiry reference stale before the next payload, so builders revalidate against the exact payload slot before inclusion.
+
 ### Implicit source creation
 
-No creation transaction is required. A root source is created implicitly when a source address first writes with a new `(source_address, salt)` pair. Each root source has a bounded rolling window. Aggregate storage grows linearly with the number of written root sources. State growth is paid incrementally by the writes that create storage entries.
-
-### Bounded validation work
-
-For validation checks, each declared reference names exactly one storage key under `RECENT_ROOT_ADDRESS`.
-
-`MAX_RECENT_ROOT_REFERENCES = 16` bounds pre-execution reference checks while covering the expected root set for privacy, wallet authorization, and historical state root use cases.
+No creation transaction is required. A root source is created implicitly when a source address first writes with a new `(source_address, salt)` pair. Each root source has a bounded rolling window. Aggregate storage grows linearly with the number of written root sources, and writes that create storage entries pay the ordinary state-growth cost.
 
 ## Backwards Compatibility
 
-This EIP does not modify [EIP-7702](./eip-7702.md) or other transaction types. An [EIP-7702](./eip-7702.md)-delegated EOA may be a source address; `source_id` is derived from `msg.sender` of the write call.
+This EIP does not change the EIP-8141 transaction payload or signature hash and does not modify other transaction types.
 
-References to slots before this EIP's activation are not satisfiable because recent root storage is empty at activation.
+The account at `RECENT_ROOT_ADDRESS` must have empty code and storage before activation. Calls to that address change behavior after activation because the canonical runtime code is installed there.
+
+References to slots before activation are not satisfiable because recent-root storage is empty at activation.
+
+## Test Cases
+
+Implementations should cover at least the following cases. A public-mempool rejection is not by itself a block-validity result; the contract and EIP-8141 columns state any independent block-execution or static-validity result.
+
+| Case | Contract or EIP-8141 result | Public mempool result |
+| --- | --- | --- |
+| One valid tuple from the previous slot | success | accept if all other EIP-8141 rules pass |
+| Sixteen valid tuples with distinct cold storage keys | success within `MAX_RECENT_ROOT_VERIFY_GAS` | accept |
+| Duplicate valid tuples | success | accept |
+| Wrong root, source, or slot | revert | reject |
+| Current-slot or future-slot tuple | revert | reject |
+| Ages `8191` and `8192` slots | success, then revert | accept, then reject |
+| Empty, 71-byte, 73-byte, or seventeen-tuple validation data | revert | reject |
+| Nonzero `VERIFY` value | statically invalid under EIP-8141 | reject |
+| `flags == 1` | contract executes normally | reject; not `recent_root_verify` |
+| `flags` contains `ATOMIC_BATCH_FLAG` | statically invalid under EIP-8141 | reject |
+| Nonzero state-gas limit | contract executes normally | reject; not `recent_root_verify` |
+| More than one matching frame | each frame executes normally | reject |
+| Matching frame after deployment or account validation | executes normally | reject |
+| `limits.execution > MAX_RECENT_ROOT_VERIFY_GAS` | executes normally if sufficiently funded | reject |
+| Generic declared limit plus signature cost equals `MAX_VERIFY_GAS`, and root limit equals `MAX_RECENT_ROOT_VERIFY_GAS` | ordinary execution | accept |
+| Either allowance exceeds its maximum by one | ordinary execution if sufficiently funded | reject |
+| Root removed by a reorganization | revert after revalidation | evict |
+| Activation installs `RECENT_ROOT_CODE` with empty storage | subsequent writes and validation use the canonical runtime | revalidate; reject until every referenced entry exists |
+| Activation finds empty code and storage with a pre-existing balance and nonce | preserve balance and set nonce to `max(existing_nonce, 1)` | revalidate |
+| Activation finds nonempty code or storage | first active block is invalid | not applicable |
+| A later block follows successful activation | do not rerun initialization or clear storage | retain and revalidate normally |
+| Reorganization crosses back before activation | this EIP is inactive | evict |
+
+The maximum-size case must include the cold target-account access charged at frame entry by EIP-8141, not only the contract's internal execution.
+
+Each of EIP-8141's four recognized validation-prefix shapes must be tested with no protocol verifier, with `recent_root_verify`, with `expiry_verify`, and with `expiry_verify` followed by `recent_root_verify`. Reversed or duplicate protocol verifiers must be rejected from the public mempool.
+
+### Reference vector
+
+The following vector uses `current_slot = 2`:
+
+| Name | Value |
+| --- | --- |
+| `source_address` | `0x0000000000000000000000000000000000000001` |
+| `salt` | `0x0000000000000000000000000000000000000000000000000000000000000000` |
+| `source_id` | `0xb9382d35273c75a50631a3e84d3c75ec9266e2b18c35a627e16cdbf26a18ca85` |
+| `slot` | `1`, encoded as `0x0000000000000001` |
+| `root` | `0x0000000000000000000000000000000000000000000000000000000000000002` |
+| `entry_hash` | `0x0a0d1254c851be5a133b4c9a9e300f5602fc0f43dbe65aa6a66930d4ca0a51b8` |
+| `storage_key` | `0x5f027aa1cbe2df279bf6518edd4b44ea5409fd800189ec35224e10ab05e574c3` |
+
+The 72-byte validation calldata is:
+
+```text
+0xb9382d35273c75a50631a3e84d3c75ec9266e2b18c35a627e16cdbf26a18ca8500000000000000010000000000000000000000000000000000000000000000000000000000000002
+```
+
+With `storage[storage_key] = entry_hash`, the canonical runtime succeeds. It consumes 2,595 gas with a cold storage key. Including EIP-8141's 3,000 gas cold target charge, the frame consumes 5,595 execution gas.
 
 ## Security Considerations
 
-Consensus treats `root` as an opaque `bytes32`. Applications define what it commits to and MUST bind the expected `source_id`, slot window, and root in their validation logic. A privacy proof using root `R` should include `(source_id, slot, R)` or an application-specific commitment to those fields as a public input, and validation logic MUST check the same tuple through `RECENTROOTREFLOAD`.
+Consensus treats `root` as an opaque `bytes32`. Applications define what it commits to and should bind the expected `(source_id, slot, root)` tuple to the statement being authorized. Before treating frame data as verified, application validation should check the completed frame's defining fields and success status as described in [Application introspection](#application-introspection). A successful recent root verifier frame proves only that the tuple is currently stored and recent.
 
-Each `(source_id, slot)` has one referenceable root on the canonical chain. The referenceable root is last-write-wins according to canonical execution order and is finalized with the containing block. An application that needs multiple roots from the same slot SHOULD write an aggregate commitment.
+EIP-8141's canonical signature hash covers the frame data, but EIP-8141 also permits validation based on an explicit 32-byte signature message. Validation logic that does not authorize the canonical signature hash must bind the recent root verifier frame and every other relevant frame itself.
 
-This EIP does not guarantee inclusion of root writes. Applications that rely on timely root publication need their own publication path, redundant root sources, or an inclusion policy for write transactions.
+Each `(source_id, slot)` has one referenceable root on the canonical chain. The referenceable root is last-write-wins according to canonical execution order. An application that needs multiple roots from the same source and slot should write an aggregate commitment.
 
-The same `(source_address, salt)` pair produces the same `source_id` on different chains, but each chain maintains independent recent root state. Proofs, bridge messages, and offchain attestations that carry recent root references MUST bind the intended chain domain outside the tuple.
+This EIP does not guarantee inclusion of root writes. Applications that rely on timely publication need their own publication path, redundant root sources, or an inclusion policy for write transactions.
 
-Recent roots create ordinary persistent storage under `RECENT_ROOT_ADDRESS`. Existing root sources overwrite at most `RECENT_ROOT_LENGTH` cells, while new root sources create additional cells. The natural pricing point for aggregate state growth is source creation, not recurring writes. Future versions MAY add a one-time source registration cost or first-write surcharge for each new `source_id`.
+The same `(source_address, salt)` pair produces the same `source_id` on different chains, but each chain maintains independent recent-root state. Proofs, bridge messages, and off-chain attestations that carry recent-root references must bind the intended chain domain outside the tuple.
+
+Recent roots create ordinary persistent storage under `RECENT_ROOT_ADDRESS`. Existing root sources overwrite at most `RECENT_ROOT_LENGTH` cells, while new root sources create additional cells. A future proposal may add a one-time source registration cost or first-write surcharge if ordinary state-growth pricing is insufficient.
+
+The separate recent-root allowance raises the maximum public-mempool validation work for one candidate transaction from `MAX_VERIFY_GAS` to `MAX_VERIFY_GAS + MAX_RECENT_ROOT_VERIFY_GAS`. Implementations should include both allowances in peer-level invalid-transaction throttling and global transaction-pool resource limits. A reorganization or synchronized expiry may still evict many transactions that use one popular root, but dependency indexing avoids re-executing each transaction's full validation prefix merely to discover the mismatch.
 
 ## Copyright
 


### PR DESCRIPTION
This replaces the `recent_root_references` transaction field with a canonical `VERIFY` frame that calls the recent root contract.

The frame carries up to sixteen packed `(source_id, slot, root)` tuples and appears before application validation in the public mempool. Public mempool validation permits only the `SLOTNUM` and recent root storage reads required by this frame. Clients may evaluate the frame directly.

The frame does not count toward `MAX_VERIFY_GAS`, leaving that budget for signature checks and application validation. A transaction eligible for the public mempool can contain only one recognized frame with at most sixteen tuples, and its target code must equal `RECENT_ROOT_CODE`. The frame still needs enough execution gas, counts toward block gas reservation and the transaction's maximum cost, and charges the payer for the gas used.

Applications read the verified tuples through the existing EIP-8141 frame introspection instructions. This adds no transaction field, signature rule, opcode, or separate recent root gas counter.

### Runtime and deployment

This PR leaves `RECENT_ROOT_CODE` as `TBD`. #12131 and ethereum/sys-asm#53 need to provide the combined write and validation runtime used here. They must also settle one address and deployment method before either PR merges. Until then, this PR defines the design but is not an implementation target.

### Cold access charge

EIP-8272 does not restate the cold target charge. The frame uses whatever EIP-8141 charges at frame entry. EIP-8141 currently points to EIP-2929. If EIP-8038 is meant to change this charge, EIP-8141 should say so.
