### PR TITLE
Update EIP-8037: remove the duplicated calldata floor note

### DIFF
--- a/EIPS/eip-8037.md
+++ b/EIPS/eip-8037.md
@@ -209,8 +209,6 @@ Since all state-gas charges are now applied as runtime or execution-time charges
 
 The [EIP-7623](./eip-7623.md) calldata floor participates in block accounting through the `max` term, applied to the execution-gas dimension: calldata is an execution-gas resource, and the floor's bound on worst-case block size holds only if a data-heavy transaction contributes at least the floor to the block's gas accounting. The floor is compared against the transaction's execution-gas portion alone — not the transaction total — so execution gas may absorb the floor exactly as under [EIP-7623](./eip-7623.md), while state-gas spending cannot (see [Calldata floor in block accounting](#calldata-floor-in-block-accounting)).
 
-Note: `tx_gas_used` applies the [EIP-7623](./eip-7623.md) calldata floor after refunds, so the floor can effectively negate part of a refund when `calldata_floor_gas_cost > tx_gas_used_after_refund`. The receipt `cumulative_gas_used` uses this post-floor value.
-
 The block header `gas_used` field is set to:
 
 ```python


### PR DESCRIPTION
The "Note:" paragraph in "Block-level gas accounting" repeats, word for word, the second and third sentences of the paragraph that closes "Transaction gas used". Both state that `tx_gas_used` applies the EIP-7623 calldata floor after refunds and that the receipt `cumulative_gas_used` uses the post-floor value.