### PR TITLE
Update EIP-8037: correct the general state-gas charge timing

### DIFF
--- a/EIPS/eip-8037.md
+++ b/EIPS/eip-8037.md
@@ -176,7 +176,7 @@ Gas charges for [EIP-7702](./eip-7702.md) authorizations follow the specificatio
 
 #### Pre-state and post-state gas validation
 
-[EIP-7928](./eip-7928.md) defines two-phase gas validation for state-accessing opcodes: pre-state costs (determinable without state access) and post-state costs (requiring state access). Under this EIP, the execution-gas portion of these opcodes follows the [EIP-7928](./eip-7928.md) rules unchanged and is charged at opcode time against `gas_left`. The state-gas portion is also charged at the opcode level; it is computed and deducted at the end of the opcode execution, drawing first from `state_gas_reservoir` and then from `gas_left`.
+[EIP-7928](./eip-7928.md) defines two-phase gas validation for state-accessing opcodes: pre-state costs (determinable without state access) and post-state costs (requiring state access). Under this EIP, the execution-gas portion of these opcodes follows the [EIP-7928](./eip-7928.md) rules unchanged and is charged at opcode time against `gas_left`. The state-gas portion is also charged at the opcode level, with the timing given for each opcode above.
 
 For `SSTORE`, the `GAS_CALL_STIPEND` pre-state check ([EIP-7928](./eip-7928.md)) applies to `gas_left` only, excluding the `state_gas_reservoir`.
 


### PR DESCRIPTION
"Pre-state and post-state gas validation" claimed the state-gas portion of every state-accessing opcode "is computed and deducted at the end of the opcode execution". That holds for `SSTORE` but not for the account-creation charge: `CALL*` applies it right before entering the child frame and `CREATE`/`CREATE2` in the creating frame, before 63/64 of the remaining gas is forwarded. The Rationale rejects the end-of-opcode alternative twice, under "Why not charge after the create frame exits?" and "Why not charge inside the create frame?".

Defer to the per-opcode rules instead of restating one of them as a blanket rule. The drawing order the sentence also repeated is already given once, in the counter rules.