### PR TITLE
Update EIP-8037: note that gas_left can increase within a frame

### DIFF
--- a/EIPS/eip-8037.md
+++ b/EIPS/eip-8037.md
@@ -454,6 +454,10 @@ One potential concern is the cost of creating a new account (`STATE_BYTES_PER_NE
 
 Optimal block construction becomes more complex, since builders must now balance resource usage across multiple dimensions rather than a single gas metric. Sophisticated builders may gain an advantage by applying advanced optimization techniques, raising concerns about further builder centralization. However, practical heuristics (e.g., greedily filling blocks until one resource dimension saturates) remain effective for most use cases. These heuristics limit centralization pressure by keeping block construction feasible for local and less sophisticated builders.
 
+### `gas_left` can increase
+
+State-gas refills credit `gas_left` before `state_gas_reservoir`, so `gas_left` can increase within a frame. For example, if the reservoir is empty, setting a storage slot that was zero at transaction start charges `gas_left`. Clearing the slot again refills it. The refill can exceed the execution gas consumed between consecutive executions of the `GAS` opcode, so the second can return a larger value. Code that calculates gas consumed by subtracting the later reading from the earlier one can therefore obtain a negative result.
+
 ### Interaction with [ERC-4337](./eip-4337.md) bundles
 
 The `GAS` opcode returns `gas_left` only and cannot observe `state_gas_reservoir`. Bundling protocols that meter sub-call consumption via `gasleft()` deltas (e.g., the [ERC-4337](./eip-4337.md) `EntryPoint`) therefore cannot accurately attribute state-gas usage when it is funded by the reservoir. Because all user operations in a bundle share the transaction's reservoir, one user operation's state-gas refunds can subsidize another's state-gas charges without appearing in either's `gasleft()` delta. Bundlers and `EntryPoint` implementations MUST account for state-gas charges and refunds explicitly rather than relying on `gasleft()` differences alone.


### PR DESCRIPTION
This PR adds a Security Considerations section describing that `GAS` is no longer monotonic. It does not change the specification's semantics.

