### PR TITLE
Update EIP-8025: add a prover-supplied hash seed to StatelessInput

### DIFF
--- a/EIPS/eip-8025.md
+++ b/EIPS/eip-8025.md
@@ -502,6 +502,7 @@ class StatelessInput:
     witness: ExecutionWitness
     chain_id: U64
     public_keys: Tuple[Bytes, ...]
+    hash_seed: U64
 ```
 
 The guest output is public:
@@ -525,6 +526,9 @@ At this level:
   each transaction signer. The keys use the transaction order from the payload.
   Optimized guests can use these keys to avoid public-key recovery, but
   transaction signatures and supplied public keys MUST still be verified.
+- `hash_seed` is a uniformly random 64-bit value drawn per proof attempt. It
+  is private prover input, governed by the guest validation rules below; a
+  construction wanting a wider key MAY stretch it.
 - `schema_id` identifies the exact input schema and fork rules that the guest
   executed.
 
@@ -671,6 +675,16 @@ uses the same `new_payload` path as the execution engine.
 The reference implementation has one implementation for each fork. Thus, its
 Amsterdam guest does not compare the payload timestamp with fork activation
 data. Production implementations MUST perform this comparison.
+
+A guest that keys internal containers by payload-controlled data — accessed
+storage cells, touched accounts, code by hash — MUST derive those containers'
+hash functions from `hash_seed`, positioned so that no choice of keys can
+cancel it. A guest that keys no such container ignores the field.
+
+The guest output MUST NOT depend on `hash_seed`: for all other input held
+equal, `StatelessValidationResult` MUST be identical for every value. Any
+ordering reaching the output MUST therefore be derived by sorting keys, never
+from the iteration order of a seeded container.
 
 ```python
 def compute_new_payload_request_root(
@@ -824,6 +838,7 @@ def build_stateless_input(
     execution_requests: ExecutionRequests,
     block_access_list: BlockAccessList,
     chain_id: U64,
+    hash_seed: U64,
 ) -> StatelessInput:
     ...
 
@@ -845,8 +860,14 @@ def build_stateless_input(
         witness=execution_witness,
         chain_id=chain_id,
         public_keys=tuple(public_keys),
+        hash_seed=hash_seed,
     )
 ```
+
+`hash_seed` MUST be drawn independently per proof attempt from a
+cryptographically secure random source, MUST NOT be derived from the block,
+the witness, or anything else available to the payload's author, and MUST NOT
+be published.
 
 The execution witness is built from the block-level read/write tracker and
 pre-state trie data. ELs already use this tracker to construct block access
@@ -911,7 +932,9 @@ def build_execution_witness(
 
 The host serializes a `StatelessInput` by prefixing the SSZ bytes with a
 two-byte schema ID. The high byte identifies the fork, and the low byte
-identifies the schema revision. Amsterdam revision 1 uses schema ID `0x1501`.
+identifies the schema revision. Amsterdam revision 2 uses schema ID `0x1502`;
+it appends `hash_seed` to the fixed-layout `SSZStatelessInput`, which changes
+the serialization and so takes a new revision.
 
 ```python
 class ProtocolFork(IntEnum):
@@ -920,7 +943,7 @@ class ProtocolFork(IntEnum):
 
 
 STATELESS_INPUT_SCHEMA_FORK_INDEX = ProtocolFork.Amsterdam
-STATELESS_INPUT_SCHEMA_REVISION = 0x01
+STATELESS_INPUT_SCHEMA_REVISION = 0x02
 STATELESS_INPUT_SCHEMA_ID = (
     STATELESS_INPUT_SCHEMA_FORK_INDEX << 8
 ) | STATELESS_INPUT_SCHEMA_REVISION
@@ -1067,6 +1090,7 @@ class SSZStatelessInput(Container):
     witness: SSZExecutionWitness
     chain_id: uint64
     public_keys: ProgressiveList[ByteVector[PUBLIC_KEY_BYTES]]
+    hash_seed: uint64
 
 
 class SSZStatelessValidationResult(Container):
@@ -1086,6 +1110,25 @@ This step moves the network measurably closer to low-resource validation. Statel
 
 The central design choice is to deploy execution proofs as an opt-in feature. Stateless validation, the witness format, and the proof system itself are maturing, but we need operational experience before making execution proofs load-bearing. Treating execution proofs as a non-critical artefact lets the stack mature on a live network — proof sizes, generation latency, verifier throughput, gossip behaviour, prover diversity — without placing any of that on the path of fork choice or attestation. A bug, outage, or poor parameter choice is contained to the nodes that opted in; it cannot fork the chain or affect validators that did not subscribe.
 
+### Prover-supplied hash seed
+
+A guest keys internal containers — accessed storage cells, touched accounts, code by hash — by data the payload's author chooses. Execution clients use non-cryptographic hashes for these lookups and rely on a per-process random seed, so that a colliding key set found against one node does not transfer to another. A guest cannot draw its own randomness: everything it reads comes from its committed input, so absent a seed there, every guest of a given version maps a given key to the same bucket indefinitely.
+
+That makes hash flooding cheap and reusable. A storage slot index is an unconstrained 256-bit value chosen by the contract touching it, and the guest keys its per-block containers by that value under a hash that is public, fixed, and — for the multiply-and-fold constructions typically used — invertible, so colliding keys are derived rather than searched for. The work is done once, offline, against the published guest, and stays valid against every prover running that version. A payload touching `n` such slots then costs the guest quadratic container work for the ordinary gas of `n` storage operations; the gas limit bounds `n`, but a bounded quadratic still decides whether a block proves inside a cycle budget.
+
+The cost falls on proving, not consensus: the payload validates to the same result, and a proof that fails to arrive degrades to the fallback this EIP already specifies.
+
+Determinism of a proof is a property of the guest as a function of its input, not of the guest behaving identically across runs. A per-attempt seed therefore keeps the proof reproducible while making the key-to-bucket mapping unpredictable to whoever built the payload, and because the result cannot depend on it, a prover that exhausts its cycle budget may retry with a fresh one.
+
+Nothing needs distributing. The seed is absent from `PublicInput`, so proofs produced under different seeds share the same public input and remain interchangeable, leaving proof deduplication untouched; and it rides the single `StatelessInput` for one logical execution, so segmented proving inherits it.
+
+Alternatives considered:
+
+- **Derive the seed from public data**, such as `new_payload_request_root` or `prev_randao`. RANDAO for the slot is known before the payload is built, so it denies nothing. A payload digest is stronger, and does protect against a transaction sender, who cannot predict the rest of the block; it does not protect against a proposer, for whom keys derived from prior state leave the digest's remaining fields free to grind offline at no cost. It also fixes one seed per payload for all time, removing the retry described above, and correlates failure across the prover set where independent seeds leave the others able to produce a proof.
+- **Require collision-resistant hashing of container keys.** Sound, but prices every lookup at a cryptographic hash, paid on every payload to defend against an occasional one.
+- **Bound every container and evict.** Caps the worst case without touching the schema, but eviction is observable in execution semantics and the caps are hard to size against a changing gas limit.
+- **A long-lived per-node seed.** Cheaper to plumb, but one inference burns that node until it restarts and gives an attacker a stable target.
+
 ## Backwards Compatibility
 
 This EIP is fully opt-in and does not change consensus validity rules. Validators that do not enable either mode see no change to their behaviour, their bandwidth, or their attestation duties. Nodes that opt in additionally subscribe to the proof gossip topic, advertise themselves via the `eproof` ENR field, and may run a prover; this affects only their local resource profile.
@@ -1096,6 +1139,10 @@ Conformance tests are maintained in the canonical specification repositories:
 
 - [Execution Layer](https://github.com/ethereum/execution-specs/tree/85fc20ca5937719a854472a87cb48d01ef1dffca/tests/amsterdam/eip8025_optional_proofs)
 - [Consensus Layer](https://github.com/ethereum/consensus-specs/tree/031e521f0a82b0e475ecfc13f79dd251a6284fc2/specs/_features/eip8025)
+
+Execution-layer conformance MUST include a `hash_seed` invariance case: one
+input under two differing seeds, asserting byte-identical
+`StatelessValidationResult`.
 
 ## Reference Implementation
 
@@ -1108,6 +1155,10 @@ Conformance tests are maintained in the canonical specification repositories:
 **Soundness and consensus implications.** This EIP does not wire proof verification into fork choice or any other consensus rule: `process_execution_proof` runs outside the beacon-block state-transition function. A forged proof therefore cannot fork the chain, slash a validator, or otherwise affect consensus state — its effect is bounded to a verifying node's local view of payload validity.
 
 **Liveness and critical-path latency.** Proof generation and verification are off the attestation hot path. Validators must not delay block validation or attestation production while waiting for a proof; if a proof is missing or late, the node attests using the fork choice determined by the execution engine's re-execution of payloads.
+
+**Guest hash flooding.** A guest keying containers by payload-controlled data under an unseeded non-cryptographic hash can be driven to superlinear work by a payload built to collide, inflating an ordinary block's cycle count past a prover's budget. The effect is on proof availability, not validity: the result is unchanged and a missing proof falls back to re-execution. `hash_seed` denies the precomputation only where applied as the Specification requires — a seed that any choice of keys can cancel is no defence. Keying a pseudorandom function with it avoids that; a cheaper mixer must apply it to each key word rather than to the accumulated result alone.
+
+**Hash-seed invariance.** The seed is prover-chosen and unconstrained, so a guest whose output varied with it would let a prover search for a seed yielding a different accepted result — hence the invariance requirement, and the rule that no ordering derived from a seeded container may reach the output. A prover MUST NOT publish or reuse a seed; revealing one forfeits the protection for that attempt.
 
 **Verifier–prover decentralisation asymmetry.** Stateless, constant-time payload verification lowers the resource floor for validators, but proof generation itself remains demanding: a prover must hold the full EL state used during execution and run a non-trivial proving stack whose cost scales as `O(n log² n)` in the size `n` of the witnessed computation. If the proportion of verifying-only nodes grows faster than the proportion of nodes able to generate proofs, the set of actors who maintain the full EL state and produce proofs may become more concentrated even as overall validator participation broadens.
 


### PR DESCRIPTION
## What this changes

One field, `hash_seed: uint64`, appended to `StatelessInput` (private prover input), plus the normative rules that make it safe and useful:

- **Host** MUST draw it independently per proof attempt from a CSPRNG, MUST NOT derive it from the block or witness, MUST NOT publish it.
- **Guest** that keys containers by payload-controlled data MUST derive those hash functions from it, and MUST apply it where no choice of keys can cancel it; a guest with no such container ignores the field. Either way the guest output MUST be invariant under it.
- **Schema** revision bumps `0x1501` → `0x1502`, since `SSZStatelessInput` is a fixed-layout `Container` — `ProgressiveContainer` would not help, as EIP-7688 changes merkleization only and leaves serialization unchanged.
- **Conformance** MUST include an invariance case: one input under two seeds, byte-identical result.

It does not touch the public input, gossip, `ProofType`, or the proof-dedup key `(root, proof_type)` — deliberately, see below.

## Why

A guest keys internal containers by data the payload's author chooses: accessed storage cells, touched accounts, code by hash. Execution clients use non-cryptographic hashes for these lookups and rely on a **per-process random seed** so that a colliding key set found against one node does not transfer to another node or survive a restart.

A guest cannot draw its own randomness — everything it reads must come from its committed input. So every guest of a given implementation and version maps a given key to the same bucket, forever. One colliding key set can be found offline, once, and replayed against every prover: a constant-time lookup becomes a linear scan and the loop around it becomes quadratic.

The consequence is proving cost, not consensus. The payload still validates to the same result; what grows is the cycle count needed to prove it — potentially past a prover's budget, so no proof is produced. Under EIP-8025 that degrades to the fallback already specified (verifiers re-execute), which makes this a **proof-availability** concern rather than a soundness one. Worth denying anyway, because restoring the mitigation the EL already depends on costs one field.

## Current usage in the guests that exist today

| guest | container | hash | seed | keys |
|---|---|---|---|---|
| **ethrex** (Rust) | `hashbrown::HashMap`, open addressing | rustc-hash `FxHash` | fixed `SEED` constant | `FxHashMap<H256, U256>` storage; `FxHashMap<Address, _>` account cache |
| **Zilkworm** (C++) | `std::unordered_map`, chaining | evmc `std::hash`, FNV-1a | fixed `fnv::offset_basis` | `FlatHashMap<address, FlatHashMap<bytes32, bytes32>>` state |
| **Nethermind** (C#) | `Dictionary`, unbounded per block | multiply-and-fold | constant `InstanceRandom` | `Dictionary<StorageCell, _>`, slot index in the key |
| **evm-asm** (verified RV64) | fixed-capacity arena, linear scan | none | n/a | n/a |

**ethrex** — `crates/vm/levm/src/account.rs:19` declares `pub storage: FxHashMap<H256, U256>`; `crates/blockchain/vm.rs:23` declares the account cache as `FxHashMap<Address, Option<AccountStateCacheEntry>>` and `:387` a `FxHashMap<H256, Code>`. The alias at `crates/common/trie/trie.rs:53` is `hashbrown::HashMap<K, V, rustc_hash::FxBuildHasher>`. `FxHash`'s round is `(hash.rotate_left(5) ^ word).wrapping_mul(SEED)` with `SEED` a fixed constant. `RandomState` does not appear in the repository.

**Zilkworm** — `zilk_core/core/common/hash_maps.hpp` aliases `FlatHashMap` to `std::unordered_map`. State is `FlatHashMap<evmc::address, FlatHashMap<evmc::bytes32, evmc::bytes32>>` (`in_memory_state.hpp:25`); `intra_block_state.hpp:134-153` holds the per-block objects, storage, code and transient-storage maps. Keying goes through evmc's `std::hash`, which chains `fnv1a_by64(h, x) = (h ^ x) * prime` over 8-byte words from `fnv::offset_basis`, a constant in upstream evmc.

**Nethermind** — `SpanExtensions.zkevm.cs` sets `InstanceRandom` to a compile-time constant where the host build derives it from `RandomNumberGenerator`. `PartialStorageProviderBase._intraBlockCache` and `PersistentStorageProvider._originalValues` are unbounded per-block `Dictionary<StorageCell, _>`; `StorageCell.GetHashCode64` mixes the `UInt256` slot index.

**evm-asm** — no hashing on the storage path. Fixed-capacity arenas with capacity constants and count guards (`EvmAsm/Codegen/ArenaCapacities.lean`); `CODEGEN.md` records access as "Linear scan: O(slot_count) per access. Fine for tests".

## Design notes

**Private input, not public — and nothing to distribute.** The verifier does not need the seed, since the result is invariant under it. Putting it in `PublicInput` would be harmful: two provers with different seeds would produce different public inputs for the same payload, breaking the `[IGNORE] no valid proof already received for (root, proof_type)` rule and the `MAX_EXECUTION_PROOFS_PER_PAYLOAD` accounting, and it would publish the seed to anyone watching gossip. Inside a prover it rides the single `StatelessInput` for one execution, so segmented proving inherits it. No new gossip, no ENR field, no coordination.

**Invariance is a MUST.** The seed is prover-chosen and unconstrained, so a guest whose output varied with it would let a prover grind seeds for a different accepted result — a soundness break introduced by the mitigation. The spec requires invariance and names the hazard: orderings reaching the output must come from sorted keys, not container iteration order. The case that motivated the rule is EIP-7928's block access list, order-sensitive and typically built from the same read/write tracking that fills the seeded containers — an example rather than a rule, so it stays out of the normative text.

**Placement, not width, is the security parameter.** A seed folded once into an accumulator that key words are afterwards combined into drops out of the difference between two keys, so the collisions hold for every seed — which is how the host-layer construction above was defeated, with a per-process CSPRNG seed in place. Hence the normative placement requirement. Nethermind's own guest mixer applies its seed in that position today.

**Retry is sound.** Because the output cannot depend on the seed, a prover that blows its cycle budget on an adversarial seed can retry with a fresh one, which keeps variable proving cost from becoming a liveness problem.

I am not an author of this EIP; this is offered for the authors' consideration and I will follow whatever direction they prefer, including dropping it if they judge it out of scope for a Draft that is still stabilising.
