### PR TITLE
Update EIP-8025: require seeded container hashing in the guest

### DIFF
--- a/EIPS/eip-8025.md
+++ b/EIPS/eip-8025.md
@@ -672,6 +672,22 @@ The reference implementation has one implementation for each fork. Thus, its
 Amsterdam guest does not compare the payload timestamp with fork activation
 data. Production implementations MUST perform this comparison.
 
+A guest that keys internal containers by payload-controlled data — accessed
+storage cells, touched accounts, code by hash — MUST derive those containers'
+hash functions from `new_payload_request_root` combined with the key width. A
+guest that keys no such container ignores this requirement.
+
+The derivation MUST be one that no choice of keys can cancel. Keying a
+pseudorandom function is the conservative choice; a cheaper mixer needs
+checking, because a perturbation that every multiplier maps identically — the
+top bit of a machine word, against any odd multiplier — cancels between two
+terms however those multipliers were seeded.
+
+No ordering that reaches the guest output may come from the iteration order of
+such a container; orderings MUST be derived by sorting keys. Two conformant
+guests that chose different hash functions would otherwise disagree on
+`StatelessValidationResult` for the same input.
+
 ```python
 def compute_new_payload_request_root(
     stateless_input: StatelessInput,
@@ -1086,6 +1102,14 @@ This step moves the network measurably closer to low-resource validation. Statel
 
 The central design choice is to deploy execution proofs as an opt-in feature. Stateless validation, the witness format, and the proof system itself are maturing, but we need operational experience before making execution proofs load-bearing. Treating execution proofs as a non-critical artefact lets the stack mature on a live network — proof sizes, generation latency, verifier throughput, gossip behaviour, prover diversity — without placing any of that on the path of fork choice or attestation. A bug, outage, or poor parameter choice is contained to the nodes that opted in; it cannot fork the chain or affect validators that did not subscribe.
 
+### Seeded container hashing
+
+A guest keys internal containers by data the payload's author chooses. Execution clients use non-cryptographic hashes for these lookups and rely on a per-process random seed, so that a colliding key set found against one node does not transfer to another. A guest cannot draw its own randomness: everything it reads comes from its committed input, so absent a seed every guest of a given version maps a given key to the same bucket indefinitely, and one colliding set found offline serves against every prover. The cost falls on proving rather than consensus — a proof that fails to arrive degrades to the re-execution fallback above — but it is cheap to deny.
+
+`new_payload_request_root` is already computed by the guest before execution, so requiring it costs no input field and no schema revision. It is not secret: a proposer knows the payload and therefore the digest. What it does deny is precomputation that outlives a single payload, which is what makes a fixed constant weak. Grinding it is bounded to the slot, because the digest covers the parent hash and the timestamp, and each attempt costs a merkleization of the payload. A value the payload's author cannot know would be stronger still, but needs an input field the guest does not currently receive.
+
+Placement matters more than where the value comes from. A seed applied to the accumulated result rather than to the key-dependent terms cancels in the difference between two keys, so every colliding pair survives every seed. That is the failure the requirement exists to prevent, and it is independent of whether the seed is derived or drawn.
+
 ## Backwards Compatibility
 
 This EIP is fully opt-in and does not change consensus validity rules. Validators that do not enable either mode see no change to their behaviour, their bandwidth, or their attestation duties. Nodes that opt in additionally subscribe to the proof gossip topic, advertise themselves via the `eproof` ENR field, and may run a prover; this affects only their local resource profile.
@@ -1108,6 +1132,8 @@ Conformance tests are maintained in the canonical specification repositories:
 **Soundness and consensus implications.** This EIP does not wire proof verification into fork choice or any other consensus rule: `process_execution_proof` runs outside the beacon-block state-transition function. A forged proof therefore cannot fork the chain, slash a validator, or otherwise affect consensus state — its effect is bounded to a verifying node's local view of payload validity.
 
 **Liveness and critical-path latency.** Proof generation and verification are off the attestation hot path. Validators must not delay block validation or attestation production while waiting for a proof; if a proof is missing or late, the node attests using the fork choice determined by the execution engine's re-execution of payloads.
+
+**Guest hash flooding.** A guest keying containers by payload-controlled data under an unseeded non-cryptographic hash can be driven to superlinear work by a payload built to collide, inflating an ordinary block's cycle count past a prover's budget. The effect is on proof availability rather than validity: the result is unchanged and a missing proof falls back to re-execution. Seeding denies precomputation that outlives one payload only where applied as the Specification requires — a seed that any choice of keys can cancel is no defence.
 
 **Verifier–prover decentralisation asymmetry.** Stateless, constant-time payload verification lowers the resource floor for validators, but proof generation itself remains demanding: a prover must hold the full EL state used during execution and run a non-trivial proving stack whose cost scales as `O(n log² n)` in the size `n` of the witnessed computation. If the proportion of verifying-only nodes grows faster than the proportion of nodes able to generate proofs, the set of actors who maintain the full EL state and produce proofs may become more concentrated even as overall validator participation broadens.
 


### PR DESCRIPTION
## What this changes

Two sentences in `Guest validation`, plus a Rationale subsection and a Security Considerations paragraph:

1. A guest that holds state in hash maps whose keys the payload chooses MUST mix `new_payload_request_root` into the hash function those maps use.
2. No pair of keys may collide for every value of `new_payload_request_root`.

The second is not redundant: folding the digest into each per-key multiplier satisfies the first while still admitting key pairs that collide for every value, measured at 3000 out of 3000 against such a mixer.

## Why

A guest has no source of randomness, so it cannot do what execution clients do — seed their state hash maps from a CSPRNG at startup, which stops a colliding key set found against one node from working anywhere else. Every guest of a given version puts a given key in the same bucket indefinitely, so one colliding set can be found offline against the published guest and reused against every prover, turning constant-time lookups into scans.

The payload still validates to the same result. What grows is the work to prove it, which can exceed a prover's budget and leave no proof.

`new_payload_request_root` is computed before execution. It differs per payload, so a colliding set cannot be reused.

## Current usage in the guests that exist today

Because a guest has no source of randomness, implementations either seed these maps from a compile-time constant or do not seed them at all. The four public zkEVM guest programs, as examples:

| guest | hash map | hash | seed |
|---|---|---|---|
| **ethrex** (Rust) | `hashbrown::HashMap` | rustc-hash `FxHash` | fixed `SEED` constant |
| **Zilkworm** (C++) | `std::unordered_map` | evmc `std::hash`, FNV-1a | fixed `fnv::offset_basis` |
| **Nethermind** (C#) | `Dictionary`, unbounded per block | multiply-and-mix | fixed literal |
| **evm-asm** (verified RV64) | fixed-capacity arena, linear scan | none | n/a |

**ethrex** — `crates/vm/levm/src/account.rs:19` declares `pub storage: FxHashMap<H256, U256>`, and `crates/blockchain/vm.rs:23` the account cache as `FxHashMap<Address, Option<AccountStateCacheEntry>>`. The alias at `crates/common/trie/trie.rs:53` is `hashbrown::HashMap<K, V, rustc_hash::FxBuildHasher>`. `FxHash`'s round is `(hash.rotate_left(5) ^ word).wrapping_mul(SEED)` with `SEED` a fixed constant. `RandomState` does not appear in the repository.

**Zilkworm** — `zilk_core/core/common/hash_maps.hpp` aliases `FlatHashMap` to `std::unordered_map`. State is `FlatHashMap<evmc::address, FlatHashMap<evmc::bytes32, evmc::bytes32>>` (`in_memory_state.hpp:25`), with `intra_block_state.hpp:134-153` holding the per-block objects, storage, code and transient-storage maps. Keying goes through evmc's `std::hash`, which chains `fnv1a_by64(h, x) = (h ^ x) * prime` over 8-byte words from `fnv::offset_basis`, a constant in upstream evmc.

**Nethermind** — `SpanExtensions.zkevm.cs` sets `InstanceRandom` to a compile-time constant where the host build derives it from `RandomNumberGenerator`. `PartialStorageProviderBase._intraBlockCache` and `PersistentStorageProvider._originalValues` are unbounded per-block `Dictionary<StorageCell, _>`; `StorageCell.GetHashCode64` mixes the `UInt256` slot index.

**evm-asm** — no hashing on the storage path. Fixed-capacity arenas with capacity constants and count guards (`EvmAsm/Codegen/ArenaCapacities.lean`); `CODEGEN.md` records access as "Linear scan: O(slot_count) per access. Fine for tests".

Three of the four replaced or neutered their platform's randomized-seed defence independently, in three different languages, for the same reason.

I am not an author of this EIP; offered for the authors' consideration.
