### PR TITLE
Update EIP-8025: require seeded container hashing in the guest

### DIFF
--- a/EIPS/eip-8025.md
+++ b/EIPS/eip-8025.md
@@ -672,6 +672,11 @@ The reference implementation has one implementation for each fork. Thus, its
 Amsterdam guest does not compare the payload timestamp with fork activation
 data. Production implementations MUST perform this comparison.
 
+A guest that holds state in hash maps whose keys the payload chooses — storage
+slots, account addresses, code hashes — MUST mix `new_payload_request_root` into
+the hash function those maps use. No pair of keys may collide for every value of
+`new_payload_request_root`.
+
 ```python
 def compute_new_payload_request_root(
     stateless_input: StatelessInput,
@@ -1086,6 +1091,14 @@ This step moves the network measurably closer to low-resource validation. Statel
 
 The central design choice is to deploy execution proofs as an opt-in feature. Stateless validation, the witness format, and the proof system itself are maturing, but we need operational experience before making execution proofs load-bearing. Treating execution proofs as a non-critical artefact lets the stack mature on a live network — proof sizes, generation latency, verifier throughput, gossip behaviour, prover diversity — without placing any of that on the path of fork choice or attestation. A bug, outage, or poor parameter choice is contained to the nodes that opted in; it cannot fork the chain or affect validators that did not subscribe.
 
+### Seeded container hashing
+
+Execution clients look up state in hash maps whose keys the payload chooses. The hash functions are fast rather than collision resistant, so clients seed them randomly at startup: a set of keys that collide on one node does not collide on another, nor on the same node after a restart. A guest has no source of randomness — everything it reads comes from its input — so every guest of a given version puts a given key in the same bucket indefinitely, and one colliding set found offline serves against every prover.
+
+The payload still validates to the same result. What grows is the work needed to prove it, which can exceed a prover's budget and leave no proof.
+
+`new_payload_request_root` is computed before execution. It differs per payload, so a colliding set cannot be reused.
+
 ## Backwards Compatibility
 
 This EIP is fully opt-in and does not change consensus validity rules. Validators that do not enable either mode see no change to their behaviour, their bandwidth, or their attestation duties. Nodes that opt in additionally subscribe to the proof gossip topic, advertise themselves via the `eproof` ENR field, and may run a prover; this affects only their local resource profile.
@@ -1108,6 +1121,8 @@ Conformance tests are maintained in the canonical specification repositories:
 **Soundness and consensus implications.** This EIP does not wire proof verification into fork choice or any other consensus rule: `process_execution_proof` runs outside the beacon-block state-transition function. A forged proof therefore cannot fork the chain, slash a validator, or otherwise affect consensus state — its effect is bounded to a verifying node's local view of payload validity.
 
 **Liveness and critical-path latency.** Proof generation and verification are off the attestation hot path. Validators must not delay block validation or attestation production while waiting for a proof; if a proof is missing or late, the node attests using the fork choice determined by the execution engine's re-execution of payloads.
+
+**Guest hash flooding.** A guest whose hash maps use a fast hash with nothing mixed in can be driven to superlinear work by a payload whose keys share a bucket, inflating the cycles needed to prove an ordinary block past a prover's budget.
 
 **Verifier–prover decentralisation asymmetry.** Stateless, constant-time payload verification lowers the resource floor for validators, but proof generation itself remains demanding: a prover must hold the full EL state used during execution and run a non-trivial proving stack whose cost scales as `O(n log² n)` in the size `n` of the witnessed computation. If the proportion of verifying-only nodes grows faster than the proportion of nodes able to generate proofs, the set of actors who maintain the full EL state and produce proofs may become more concentrated even as overall validator participation broadens.
 


### PR DESCRIPTION
## What this changes

Two sentences in `Guest validation`, plus a Rationale subsection and a Security Considerations paragraph:

1. A guest that holds state in hash maps whose keys the payload chooses MUST mix `new_payload_request_root` into the hash function those maps use.
2. No pair of keys may collide for every value of `new_payload_request_root`.

## Why

A guest has no source of randomness, so it cannot do what execution clients do — seed their state hash maps from a CSPRNG at startup, which stops a colliding key set found against one node from working anywhere else. Every guest of a given version puts a given key in the same bucket indefinitely, so one colliding set can be found offline against the published guest and reused against every prover, turning constant-time lookups into scans.

The payload still validates to the same result. What grows is the work to prove it, which can exceed a prover's budget and leave no proof.

`new_payload_request_root` is computed before execution. It differs per payload, so a colliding set cannot be reused.

## Current usage in the guests that exist today

Because a guest has no source of randomness, implementations either seed these maps from a compile-time constant or do not seed them at all. The four public zkEVM guest programs, as examples:

| guest | hash map | hash | seed |
|---|---|---|---|
| **ethrex** (Rust) | `hashbrown::HashMap` | rustc-hash `FxHash` | fixed `SEED` constant |
| **Zilkworm** (C++) | `std::unordered_map` | evmc `std::hash`, FNV-1a | fixed `fnv::offset_basis` |
| **Nethermind** (C#) | `Dictionary`, unbounded per block | multiply-and-mix | fixed literal |
| **evm-asm** (verified RV64) | fixed-capacity arena, linear scan | none | n/a |

**ethrex** — `crates/vm/levm/src/account.rs:19` declares `pub storage: FxHashMap<H256, U256>`, and `crates/blockchain/vm.rs:23` the account cache as `FxHashMap<Address, Option<AccountStateCacheEntry>>`. The alias at `crates/common/trie/trie.rs:53` is `hashbrown::HashMap<K, V, rustc_hash::FxBuildHasher>`. `FxHash`'s round is `(hash.rotate_left(5) ^ word).wrapping_mul(SEED)` with `SEED` a fixed constant. `RandomState` does not appear in the repository.

**Zilkworm** — `zilk_core/core/common/hash_maps.hpp` aliases `FlatHashMap` to `std::unordered_map`. State is `FlatHashMap<evmc::address, FlatHashMap<evmc::bytes32, evmc::bytes32>>` (`in_memory_state.hpp:25`), with `intra_block_state.hpp:134-153` holding the per-block objects, storage, code and transient-storage maps. Keying goes through evmc's `std::hash`, which chains `fnv1a_by64(h, x) = (h ^ x) * prime` over 8-byte words from `fnv::offset_basis`, a constant in upstream evmc.

**Nethermind** — `SpanExtensions.zkevm.cs` sets `InstanceRandom` to a compile-time constant where the host build derives it from `RandomNumberGenerator`. `PartialStorageProviderBase._intraBlockCache` and `PersistentStorageProvider._originalValues` are unbounded per-block `Dictionary<StorageCell, _>`; `StorageCell.GetHashCode64` mixes the `UInt256` slot index.

**evm-asm** — no hashing on the storage path. Fixed-capacity arenas with capacity constants and count guards (`EvmAsm/Codegen/ArenaCapacities.lean`); `CODEGEN.md` records access as "Linear scan: O(slot_count) per access. Fine for tests".

Three of the four replaced or neutered their platform's randomized-seed defence independently, in three different languages, for the same reason.

I am not an author of this EIP; offered for the authors' consideration.
