### PR TITLE
Config: prevent ERC merge from overwriting EIP-1

### DIFF
--- a/.github/actions/merge-repos/action.yml
+++ b/.github/actions/merge-repos/action.yml
@@ -11,14 +11,29 @@ runs:
     - name: Merge Repos
       shell: bash
       run: |
-        mkdir -p $GITHUB_WORKSPACE/ERCs/ERCS
-        mkdir -p $GITHUB_WORKSPACE/ERCs/EIPS
-        cp -rp $GITHUB_WORKSPACE/ERCs/ERCS/. $GITHUB_WORKSPACE/EIPS
-        cp -rp $GITHUB_WORKSPACE/ERCs/EIPS/. $GITHUB_WORKSPACE/EIPS
-        cp -rp $GITHUB_WORKSPACE/ERCs/assets/. $GITHUB_WORKSPACE/assets
-        cd $GITHUB_WORKSPACE/EIPS
+        set -euo pipefail
+
+        mkdir -p "$GITHUB_WORKSPACE/ERCs/ERCS"
+        mkdir -p "$GITHUB_WORKSPACE/ERCs/EIPS"
+
+        # ERCS may contain compatibility copies of EIP files; protect canonical EIP-1.
+        canonical_eip_1="$GITHUB_WORKSPACE/EIPS/eip-1.md"
+        canonical_eip_1_sha="$(sha256sum "$canonical_eip_1" | awk '{print $1}')"
+
+        find "$GITHUB_WORKSPACE/ERCs/ERCS" -maxdepth 1 -type f -name "erc-*.md" \
+          -exec cp -p {} "$GITHUB_WORKSPACE/EIPS/" \;
+        cp -rp "$GITHUB_WORKSPACE/ERCs/EIPS/." "$GITHUB_WORKSPACE/EIPS"
+        cp -rp "$GITHUB_WORKSPACE/ERCs/assets/." "$GITHUB_WORKSPACE/assets"
+        cd "$GITHUB_WORKSPACE/EIPS"
         find . -name "erc-*.md" -type f -exec sh -c 'echo mv "$1" "$(echo "$1" | sed s/erc/eip/)"' _ {} \; | sh
-        cd $GITHUB_WORKSPACE/assets
+
+        merged_eip_1_sha="$(sha256sum "$canonical_eip_1" | awk '{print $1}')"
+        if [[ "$canonical_eip_1_sha" != "$merged_eip_1_sha" ]]; then
+          echo "::error::Merge changed canonical EIPS/eip-1.md (before: $canonical_eip_1_sha, after: $merged_eip_1_sha)"
+          exit 1
+        fi
+
+        cd "$GITHUB_WORKSPACE/assets"
         find . -depth -name "erc-*" -type d -exec sh -c 'echo mv "$1" "$(echo "$1" | sed s/erc/eip/)"' _ {} \; | sh
-        cd $GITHUB_WORKSPACE
+        cd "$GITHUB_WORKSPACE"
         rm -rf ERCs


### PR DESCRIPTION

## Summary

The `merge-repos` action currently copies the entire `ERCs/ERCS` directory into `EIPS` before renaming `erc-*.md` files.

The `ethereum/ERCs` repository currently contains `ERCS/eip-1.md`. As a result, this file overwrites the canonical `EIPS/eip-1.md` from the EIPs repository. The generated website can therefore publish stale EIP-1 content, including obsolete `execution-spec-tests` links.

## Changes

- Copy only `erc-*.md` proposal files from `ERCs/ERCS`.
- Preserve the canonical `EIPS/eip-1.md`.
- Add a SHA-256 regression check before and after the merge.
- Fail the action if canonical EIP-1 changes unexpectedly.

## Testing

- `git diff --check`
- YAML parsing of `.github/actions/merge-repos/action.yml`
- Simulated merge using the current `ethereum/ERCs` tree
- Simulated conflicting `eip-1.md` overwrite detection
