### PR TITLE
Update EIP-7906: reference the frame-family registry for opcode bytes

### DIFF
--- a/EIPS/eip-7906.md
+++ b/EIPS/eip-7906.md
@@ -27,6 +27,8 @@ By providing the Wallets and dApps with the ability to observe and restrict the 
 
 ## Specification
 
+The opcode bytes for `TXTRACE`, `TXDIFF`, and `EVENTDATACOPY`, and the `POST_TX` frame mode value, are allocated by the frame-transaction family registry in [EIP-8141](./eip-8141.md), which carries the authoritative opcode and frame-mode assignments for the family. The `TXTRACE` and `TXDIFF` parameter spaces are those opcodes' own operands and are defined here rather than in that registry.
+
 ### Constants
 
 | Name                   | Value |


### PR DESCRIPTION
EIP-7906 introduces the `TXTRACE`, `TXDIFF`, and `EVENTDATACOPY` opcodes and the `POST_TX` frame mode but does not assign their opcode bytes; those are allocated by the frame-transaction family registry in EIP-8141. This adds a one-line pointer from EIP-7906 to that registry, so an implementer of EIP-7906 finds the byte assignments from the EIP they are implementing rather than having to locate them in EIP-8141 unaided.

This mirrors the cross-reference pattern other dependent EIPs use to point at the shared registry. The parameter spaces of `TXTRACE`/`TXDIFF` remain those opcodes' own operands, defined in EIP-7906, and the note says so explicitly.

Companion to the registry PR #12253. No normative change to EIP-7906 behavior.