### PR TITLE
Update EIP-8130: rename to Keystore Accounts

### DIFF
--- a/EIPS/eip-8130.md
+++ b/EIPS/eip-8130.md
@@ -1,7 +1,7 @@
 ---
 eip: 8130
-title: Account Abstraction by Account Configuration
-description: Enable account abstraction feature set through onchain account configurations and a new transaction type
+title: Keystore Accounts
+description: Enable account abstraction through onchain keystore accounts and a new transaction type
 author: Chris Hunter (@chunter-cb) <chris.hunter@coinbase.com>
 discussions-to: https://ethereum-magicians.org/t/eip-8130-account-abstraction-by-account-configurations/25952
 status: Draft


### PR DESCRIPTION
## Summary

- Renames EIP-8130 from **Account Abstraction by Account Configuration** to **Keystore Accounts**.
- Updates the preamble description to match: account abstraction via onchain keystore accounts and a new transaction type.
- No specification, wire-format, or protocol changes.

## Test plan

- [ ] EIP Walidator (CI)
- [ ] Confirm title is within the 44-character preamble limit
- [ ] Confirm Magicians `discussions-to` thread still resolves (URL slug is unchanged)