### PR TITLE
Update EIP-8246: Move to Last Call

### DIFF
--- a/EIPS/eip-8246.md
+++ b/EIPS/eip-8246.md
@@ -4,7 +4,8 @@ title: Remove SELFDESTRUCT Burn
 description: Eliminate the remaining cases where SELFDESTRUCT burns ETH.
 author: Paweł Bylica (@chfast)
 discussions-to: https://ethereum-magicians.org/t/eip-8246-remove-selfdestruct-burn/28416
-status: Review
+status: Last Call
+last-call-deadline: 2026-11-04
 type: Standards Track
 category: Core
 created: 2026-05-01


### PR DESCRIPTION
Moves EIP-8246 from `Review` to `Last Call`, with a review end date of 2026-11-04.

The specification is stable: the most recent changes ([#12234](https://github.com/ethereum/EIPs/pull/12234), [#12237](https://github.com/ethereum/EIPs/pull/12237)) touched Backwards Compatibility and Security Considerations only, leaving the Specification section unmodified.