### PR TITLE
Update EIP-8272: count recent root verification gas

### DIFF
--- a/EIPS/eip-8272.md
+++ b/EIPS/eip-8272.md
@@ -249,19 +249,7 @@ No nested call receives either permission. No other opcode, call, storage read, 
 
 The frame MUST execute successfully. During public mempool validation, a client MAY evaluate this frame directly instead of executing `RECENT_ROOT_CODE`, even when other frames in the validation prefix require simulation. This direct evaluation MUST produce the same frame receipt and gas use as EVM execution. It MUST also apply the same warm account and storage key updates and rollbacks as EVM execution. A client MUST reject the transaction if EVM execution would revert or halt exceptionally, including when `frame.limits.execution` is insufficient.
 
-For EIP-8141's public mempool checks on declared limits and total validation work, clients MUST exclude the recent root verifier frame:
-
-```text
-signature_verification_cost
-    + sum(
-        frame.limits.execution
-        for frame in validation_prefix
-        if frame is not recent_root_verify
-    )
-    <= MAX_VERIFY_GAS
-```
-
-This exclusion changes only public mempool admission accounting. The frame's declared execution limit remains part of the EIP-8141 transaction maximum cost and block execution gas reservation, and the payer is charged for the frame's actual gas use under the ordinary EIP-8141 rules.
+Clients MUST count the recent root verifier frame's `limits.execution` toward EIP-8141's `MAX_VERIFY_GAS` limit.
 
 Clients MUST reject a transaction from the public mempool if any tuple has `slot >= current_slot`.
 
@@ -317,9 +305,7 @@ The fixed position affects public mempool eligibility, not block validity. Priva
 
 ### Public mempool validation budget
 
-Checking sixteen distinct roots requires sixteen cold storage reads in the worst case. Counting this work toward `MAX_VERIFY_GAS` would leave less gas for the application's own validation.
-
-`MAX_VERIFY_GAS` excludes the recent root verifier frame. A transaction eligible for the public mempool can contain only one such frame, its data can contain at most sixteen tuples, and its target code must equal `RECENT_ROOT_CODE`. These rules limit the work without a second gas counter.
+The frame's `limits.execution` counts toward `MAX_VERIFY_GAS`, together with the declared execution limits of the other frames in the validation prefix and the cost of checking the transaction signatures. This uses EIP-8141's existing validation budget. EIP-8141 can change that budget later if needed.
 
 Direct evaluation does not change the frame's execution gas or fees. The frame's declared execution limit still contributes to the transaction's maximum cost and block gas reservation, and the payer still pays for the gas used.
 
@@ -363,8 +349,8 @@ Implementations should cover at least the following cases. Rejection from the pu
 | More than one matching frame | each frame executes normally | reject |
 | Matching frame after deployment or account validation | executes normally | reject |
 | `limits.execution` is one gas less than the recent root verifier frame requires | halts exceptionally | reject |
-| Generic declared limit plus signature cost equals `MAX_VERIFY_GAS`, with a valid recent root verifier frame | ordinary execution | accept |
-| Generic declared limit plus signature cost exceeds `MAX_VERIFY_GAS` by one | ordinary execution if sufficiently funded | reject |
+| Signature verification cost plus all validation prefix execution limits, including `recent_root_verify`, equals `MAX_VERIFY_GAS` | ordinary execution | accept |
+| Signature verification cost plus all validation prefix execution limits, including `recent_root_verify`, exceeds `MAX_VERIFY_GAS` by one | ordinary execution if sufficiently funded | reject |
 | Direct evaluation instead of EVM execution | identical frame receipt, gas use, and warm access sets | same admission result |
 | Root removed by a reorganization | revert after revalidation | evict |
 | Activation installs `RECENT_ROOT_CODE` with empty storage | subsequent writes and validation use `RECENT_ROOT_CODE` | revalidate; reject until every referenced entry exists |
@@ -413,7 +399,7 @@ The same `(source_address, salt)` pair produces the same `source_id` on differen
 
 Recent roots create persistent storage under `RECENT_ROOT_ADDRESS`. Existing root sources overwrite at most `RECENT_ROOT_LENGTH` cells, while new root sources create additional cells. A future proposal may add a source registration cost or a surcharge for the first write if ordinary state growth pricing is insufficient.
 
-The recent root verifier frame can add up to sixteen root checks beyond `MAX_VERIFY_GAS`. An invalid final tuple or a frame with slightly too little execution gas can force almost all of this work before the transaction is rejected, without paying an inclusion fee. Implementations should account for this work in limits on invalid transactions from each peer and in limits on total transaction pool work. A reorganization or synchronized expiry may evict many transactions that use one popular root, but dependency indexing lets clients identify affected transactions without rerunning unrelated validation prefixes.
+Because the recent root verifier frame counts toward `MAX_VERIFY_GAS`, EIP-8141 bounds the total work a node may do to check signatures and execute the validation prefix before admitting a transaction to the public mempool. A reorganization or synchronized expiry may evict many transactions that use one popular root, but dependency indexing lets clients identify affected transactions without rerunning unrelated validation prefixes.
 
 ## Copyright
 


### PR DESCRIPTION
EIP-8272 currently excludes the recent root verifier frame from EIP-8141’s `MAX_VERIFY_GAS` calculation.
This change removes that exception. The frame’s `limits.execution` now counts toward the same limit as transaction signature verification and the declared execution limits of the other frames in the validation prefix. It does not add a separate allowance or change block gas, maximum cost, or fee accounting.
Using EIP-8141’s existing validation budget is the simplest rule for now. If the limit is too low near activation, EIP-8141 can change it then.
