### PR TITLE
Update EIP-8037: keep pre-execution state-gas out of the frame rollback

### DIFF
--- a/EIPS/eip-8037.md
+++ b/EIPS/eip-8037.md
@@ -97,11 +97,12 @@ state_gas_reservoir = evm_gas - gas_left
 
 Because [EIP-2780](./eip-2780.md) makes intrinsic gas state-independent, no state-gas component is subtracted from `tx.gas` here and none is seeded into the reservoir. The state-dependent costs are applied as runtime charges — later in the pre-execution phase and during execution — drawing from `state_gas_reservoir` first and from `gas_left` once the reservoir is exhausted.
 
-This means that the `state_gas_reservoir` holds gas that exceeds [EIP-7825](./eip-7825.md)'s budget. Additionally, three new counters are introduced:
+This means that the `state_gas_reservoir` holds gas that exceeds [EIP-7825](./eip-7825.md)'s budget. Additionally, four new counters are introduced:
 
 - `evm_state_gas_used` encodes the total state-gas used by the transaction, and it is initialized as `evm_state_gas_used = 0`.
 - `state_gas_from_gas_left` encodes how much of the current frame's `gas_left` has been drawn for state-gas charges and not yet credited back (i.e., the state-gas not covered by the reservoir). Like `gas_left`, it is frame-local: it is initialized to `0` at the start of each call frame and is used to refill state-gas in last-in, first-out (LIFO) order.
 - `state_gas_baseline` records the value of `state_gas_reservoir` at the start of the state changes a frame's rollback undoes, which for a call frame is its entry. Like `gas_left`, it is frame-local.
+- `state_gas_committed` records the part of `state_gas_from_gas_left` that a frame's rollback must not credit back to `gas_left`, because the state it paid for is not rolled back. Like `gas_left`, it is frame-local. Only the top-level frame uses it; in other frames it is always `0`.
 
 The gas counters operate as follows:
 
@@ -171,7 +172,19 @@ state_gas_from_gas_left = 0
 state_gas_reservoir = state_gas_baseline
 ```
 
-`net_state_gas` is negative for a frame that refilled more than it charged, so `evm_state_gas_used` increases: the rollback also restores the state whose removal the refill credited. The restore assigns `state_gas_reservoir` where a refill credits it, so it is applied before any refill its parent makes for the failed operation. The baseline and frame entry coincide for every frame but the top-level one, whose rollback leaves the [EIP-7702](./eip-7702.md) authorizations applied in the pre-execution phase in place ([EIP-2780](./eip-2780.md)): its baseline sits after their charges and before the account-creation charge for the transaction's target, which the rollback does undo. The two cases differ only in how the frame's `gas_left` is treated, exactly as in existing EVM semantics.
+`net_state_gas` is negative for a frame that refilled more than it charged, so `evm_state_gas_used` increases: the rollback also restores the state whose removal the refill credited. The restore assigns `state_gas_reservoir` where a refill credits it, so it is applied before any refill its parent makes for the failed operation. The two cases differ only in how the frame's `gas_left` is treated, exactly as in existing EVM semantics.
+
+Only the top-level frame can have a baseline that is not its entry, and only when the transaction has [EIP-7702](./eip-7702.md) authorizations. Its rollback does not undo the authorizations applied in the pre-execution phase ([EIP-2780](./eip-2780.md)), so the state-gas charged for them must not be refilled. The baseline is taken after the authorization charges and before the account-creation charge for the transaction's target, so that charge is refilled. At this point the frame commits the state-gas charged so far:
+
+```python
+state_gas_committed += state_gas_from_gas_left
+state_gas_baseline = state_gas_reservoir
+state_gas_from_gas_left = 0
+```
+
+Note: A commit moves no gas and does not change `evm_state_gas_used`. It marks the state-gas as not refillable, so the rollback above does not credit it to `gas_left`.
+
+If the transaction fails before the top-level frame is entered, the pre-execution phase is rolled back, including the authorizations ([EIP-2780](./eip-2780.md)). All state-gas charged in that phase is refilled: `state_gas_from_gas_left` and `state_gas_committed` are both credited to `gas_left`, and `state_gas_baseline` and `state_gas_reservoir` are set back to the values they had at the start of the transaction.
 
 When a child frame **succeeds**, its remaining `gas_left` is returned to the parent and its `state_gas_from_gas_left` is added to the parent's `state_gas_from_gas_left` (the state-gas it funded from `gas_left` persists and is now backed by the merged `gas_left`). Then, with the child's `state_gas_reservoir` merged in, the frame returns state-gas to `gas_left`, up to the amount it has outstanding:
 


### PR DESCRIPTION
Follow-up to #12256, which specified a frame's rollback as a restore to its baseline. The baseline covers `state_gas_reservoir` only. Nothing removes a pre-execution charge from `state_gas_from_gas_left`, so a top-level rollback credits that gas back to `gas_left` while the state it paid for stays written. For a transaction with one EIP-7702 authorization the whole `STATE_BYTES_PER_AUTH_BASE` charge is refilled although the delegation stays applied, so it is missing from `evm_state_gas_used` and from `block_state_gas_used`.

Add a counter `state_gas_committed` and a commit step at the point the top-level frame's baseline is taken. The commit moves no gas: it records that this much of `gas_left` paid for state the rollback does not undo, so the restore does not credit it back. The restore itself does not change.

Also state the case the text did not cover: when the transaction fails before the top-level frame is entered, the pre-execution phase is rolled back with the authorizations, so `state_gas_from_gas_left` and `state_gas_committed` are both credited to `gas_left` and the reservoir and the baseline are reset.

No change for clients matching the reference implementation. `commit_state_gas` and `restore_state_gas_to_entry` in EELS `vm/gas.py` are what this describes, and the behaviour is covered by tests/amsterdam/eip2780_reduce_intrinsic_tx_gas/test_authorization_oog.py.