### PR TITLE
Update EIP-7906: add POST_TX_EXEMPT frame flag

### DIFF
--- a/EIPS/eip-7906.md
+++ b/EIPS/eip-7906.md
@@ -96,13 +96,13 @@ When multiple frames write the same storage slot or balance, settlement re-appli
 
 #### Example
 
-Sponsored ERC-20 gas payment with a trailing assertion, extending EIP-8141 Example 3:
+Sponsored [ERC-20](./eip-20.md) gas payment with a trailing assertion, extending [EIP-8141](./eip-8141.md) Example 3:
 
 | Frame | Mode    | Caller      | Flags                         | Target        | Value | Data                   |
 | ----- | ------- | ----------- | ----------------------------- | ------------- | ----- | ---------------------- |
 | 0     | VERIFY  | ENTRY_POINT | APPROVE_EXECUTION             | Null (sender) | 0     | Empty                  |
 | 1     | VERIFY  | ENTRY_POINT | APPROVE_PAYMENT               | Sponsor       | 0     | Sponsor data           |
-| 2     | SENDER  | Sender      | `POST_TX_EXEMPT` (`0x8`)      | ERC-20        | 0     | transfer(Sponsor, fees) |
+| 2     | SENDER  | Sender      | `POST_TX_EXEMPT` (`0x8`)      | Token         | 0     | transfer(Sponsor, fees) |
 | 3     | SENDER  | Sender      | APPROVE_SCOPE_NONE            | Target addr   | 0     | Call data              |
 | 4     | POST_TX | ENTRY_POINT | APPROVE_SCOPE_NONE            | Assertion     | 0     | Assertion data         |
 
@@ -113,12 +113,12 @@ Sponsored ERC-20 gas payment with a trailing assertion, extending EIP-8141 Examp
 
 #### Example: Exempt Atomic Batch
 
-Approve + swap as one atomic batch that must both survive `POST_TX` revert, extending EIP-8141 Example 2:
+Approve + swap as one atomic batch that must both survive `POST_TX` revert, extending [EIP-8141](./eip-8141.md) Example 2:
 
 | Frame | Mode    | Caller      | Flags                                      | Target | Value | Data                   |
 | ----- | ------- | ----------- | ------------------------------------------ | ------ | ----- | ---------------------- |
 | 0     | VERIFY  | ENTRY_POINT | APPROVE_EXECUTION_AND_PAYMENT              | Null (sender) | 0 | Empty                  |
-| 1     | SENDER  | Sender      | `ATOMIC_BATCH_FLAG \| POST_TX_EXEMPT` (`0xC`) | ERC-20 | 0 | approve(DEX, amount)   |
+| 1     | SENDER  | Sender      | `ATOMIC_BATCH_FLAG \| POST_TX_EXEMPT` (`0xC`) | Token | 0 | approve(DEX, amount)   |
 | 2     | SENDER  | Sender      | `POST_TX_EXEMPT` (`0x8`)                   | DEX    | 0     | swap(...)              |
 | 3     | POST_TX | ENTRY_POINT | APPROVE_SCOPE_NONE                         | Assertion | 0  | Assertion data         |
 

--- a/EIPS/eip-7906.md
+++ b/EIPS/eip-7906.md
@@ -36,6 +36,7 @@ The opcode bytes for `TXTRACE`, `TXDIFF`, and `EVENTDATACOPY`, and the `POST_TX`
 | TXTRACE_GAS_COST       | TBD   |
 | EVENTDATACOPY_GAS_COST | TBD   |
 | `POST_TX`              | `3`   |
+| `POST_TX_EXEMPT`       | `0x8` |
 
 ### The `POST_TX` Frame Mode
 
@@ -47,12 +48,85 @@ The following rules apply to EIP-8141 frame transactions wherever this EIP is ac
 - `POST_TX` frames must form a contiguous trailing suffix of `tx.frames`: once any frame has mode `POST_TX`, every subsequent frame in the transaction must also have mode `POST_TX`. A frame transaction violating this is invalid.
 - As with `DEFAULT` and `VERIFY` frames, the `caller` of a `POST_TX` frame is `ENTRY_POINT`.
 - A `POST_TX` frame is executed as a `STATICCALL`, disallowing all state manipulation. Unlike `VERIFY` frames, `POST_TX` frames are not granted the `APPROVE` exception defined in [EIP-8141](./eip-8141.md#approve-instruction-0xaa): calling `APPROVE` anywhere in a `POST_TX` frame's call subtree is an ordinary `STATICCALL` violation and causes an exceptional halt of that call frame, handled like any other `POST_TX` failure per the rule below.
-- If a `POST_TX` frame reverts or halts exceptionally, the entire execution body of a transaction is reverted unconditionally. This overrides the atomic-batch unrolling behavior that would otherwise apply: a `POST_TX` failure always validates or reverts the whole transaction execution, up to the "validation prefix", rather than merely unwinding an atomic batch.
+- If a `POST_TX` frame reverts or halts exceptionally, the execution body is rolled back subject to [`POST_TX_EXEMPT`](#post_tx_exempt-flag). Absent exemptions, the entire execution body is reverted. This overrides the atomic-batch unrolling behavior that would otherwise apply: a `POST_TX` failure always settles the whole transaction execution against the "validation prefix", rather than merely unwinding an atomic batch.
 - Neither a `POST_TX` revert nor an exceptional halt invalidates the transaction (unlike a `VERIFY` frame revert). The transaction remains valid, is included in the block, and generates a receipt with a failed status (`status = 0`).
 - All state changes made within the validation prefix (such as gas payment via `APPROVE` and account creation in a `deploy` frame) are permanently committed to the state, and the payer is fully charged for the gas consumed up to the point of the failure.
 - Under EIP-8141's [default code](./eip-8141.md#default-code), a `POST_TX` frame is handled the same way as `SENDER` or `DEFAULT`.
 
-### Transaction Trace Opcode 
+### `POST_TX_EXEMPT` Flag
+
+A frame may set the `POST_TX_EXEMPT` flag to opt its write-set into preservation when a `POST_TX` frame reverts or halts exceptionally. Frames without the flag are rolled back. If no execution-body frame sets the flag, behavior is identical to reverting the entire execution body.
+
+This EIP amends EIP-8141's frame `flags` as follows:
+
+| Flag bits | Name             | Value  | Valid with           |
+|-----------|------------------|--------|---------------------|
+| 3         | `POST_TX_EXEMPT` | `0x8`  | `DEFAULT`, `SENDER` |
+
+`POST_TX_EXEMPT` occupies the next reserved bit after EIP-8141's `ATOMIC_BATCH_FLAG` (`0x4`, bit 2).
+
+Wherever this EIP is active:
+
+- The static constraint `assert frame.flags < 8` is replaced by `assert frame.flags < 16`, admitting bit 3.
+- `POST_TX_EXEMPT` is valid only with `DEFAULT` and `SENDER`. A `VERIFY` or `POST_TX` frame with the flag set is invalid.
+- `POST_TX_EXEMPT` may be combined with EIP-8141's `ATOMIC_BATCH_FLAG` (`0x4`). A frame that is both batched and exempt uses `flags = 0xC` (`0x4 | 0x8`). EIP-8141's rule that atomic-batch frames must have approval-scope bits clear still applies.
+- Interaction with atomic batches: per EIP-8141, an atomic batch is a maximal contiguous sequence of frames `[i, j]` where frames `i` through `j - 1` have `ATOMIC_BATCH_FLAG` set and frame `j` does not. Frame `j` is still part of the batch. If any frame in that batch has `POST_TX_EXEMPT` set, every frame in the batch — including the terminator `j` — must have `POST_TX_EXEMPT` set; otherwise the transaction is invalid. This prevents preserving only part of an all-or-nothing batch on `POST_TX` revert.
+
+The flag is part of `frame.flags` and is therefore committed under EIP-8141's `compute_sig_hash`. `VERIFY` frames can inspect it before calling `APPROVE` via the existing `FRAMEPARAM` param `0x03` (`flags`): bit 3 set means `POST_TX_EXEMPT`.
+
+During every `POST_TX` frame, `TXTRACE` and `TXDIFF` observe the full, un-exempted prestate → end-of-execution-body state difference. Exemptions do not alter the diff observed by any assertion.
+
+Exemptions apply only at final settlement, after all `POST_TX` frames have run (or after the first `POST_TX` failure aborts the remaining `POST_TX` suffix).
+
+Let `E` be the set of execution-body frame indices whose `POST_TX_EXEMPT` flag is set.
+
+If any `POST_TX` frame reverts or halts exceptionally:
+
+- The validation prefix remains committed.
+- For every execution-body frame index `j` not in `E`, the write-set of frame `j` is rolled back.
+- For every execution-body frame index `j` in `E`, the write-set of frame `j` is preserved (committed) atomically.
+- The transaction remains valid, is included, and generates a receipt with a failed status (`status = 0`), except that preserved exempt write-sets remain in state.
+- The payer is fully charged for the gas consumed up to the point of the failure.
+
+If every `POST_TX` frame succeeds, the full execution body commits and `E` has no additional effect.
+
+The **write-set** of a frame is the set of durable state modifications attributable to that frame's execution: account balance changes, storage slot writes, and code deployments performed while that frame was the current top-level frame (including its call subtree), after applying that frame's own internal reverts. Logs emitted by a frame are part of that frame's effects: on rollback of a non-exempt frame its logs do not appear in the transaction's final log list; logs of an exempt preserved frame remain.
+
+When multiple frames write the same storage slot or balance, settlement re-applies the net recorded write-set of each preserved frame onto the post-validation-prefix state in ascending frame-index order after rolling back non-exempt frames.
+
+#### Example
+
+Sponsored ERC-20 gas payment with a trailing assertion, extending EIP-8141 Example 3:
+
+| Frame | Mode    | Caller      | Flags                         | Target        | Value | Data                   |
+| ----- | ------- | ----------- | ----------------------------- | ------------- | ----- | ---------------------- |
+| 0     | VERIFY  | ENTRY_POINT | APPROVE_EXECUTION             | Null (sender) | 0     | Empty                  |
+| 1     | VERIFY  | ENTRY_POINT | APPROVE_PAYMENT               | Sponsor       | 0     | Sponsor data           |
+| 2     | SENDER  | Sender      | `POST_TX_EXEMPT` (`0x8`)      | ERC-20        | 0     | transfer(Sponsor, fees) |
+| 3     | SENDER  | Sender      | APPROVE_SCOPE_NONE            | Target addr   | 0     | Call data              |
+| 4     | POST_TX | ENTRY_POINT | APPROVE_SCOPE_NONE            | Assertion     | 0     | Assertion data         |
+
+- Frames 0–1 are the validation prefix. Frame 1 calls `APPROVE(APPROVE_PAYMENT)` only after confirming via `FRAMEPARAM` that frame 2 has `POST_TX_EXEMPT` set, and that frame 2 is the expected `transfer(Sponsor, fees)` on an accepted token.
+- Frame 2 is the fee-payer repayment (exempted).
+- Frame 3 is the user's operation (not exempted).
+- Frame 4 is the assertion. If it reverts, frame 3 rolls back and frame 2's transfer remains committed.
+
+#### Example: Exempt Atomic Batch
+
+Approve + swap as one atomic batch that must both survive `POST_TX` revert, extending EIP-8141 Example 2:
+
+| Frame | Mode    | Caller      | Flags                                      | Target | Value | Data                   |
+| ----- | ------- | ----------- | ------------------------------------------ | ------ | ----- | ---------------------- |
+| 0     | VERIFY  | ENTRY_POINT | APPROVE_EXECUTION_AND_PAYMENT              | Null (sender) | 0 | Empty                  |
+| 1     | SENDER  | Sender      | `ATOMIC_BATCH_FLAG \| POST_TX_EXEMPT` (`0xC`) | ERC-20 | 0 | approve(DEX, amount)   |
+| 2     | SENDER  | Sender      | `POST_TX_EXEMPT` (`0x8`)                   | DEX    | 0     | swap(...)              |
+| 3     | POST_TX | ENTRY_POINT | APPROVE_SCOPE_NONE                         | Assertion | 0  | Assertion data         |
+
+- Frames 1–2 form one atomic batch: frame 1 carries `ATOMIC_BATCH_FLAG`, frame 2 terminates the batch.
+- Both frames set `POST_TX_EXEMPT`. Setting it only on frame 1 would be invalid.
+- If frame 3 reverts, both the approval and the swap remain committed.
+
+### Transaction Trace Opcode
 
 We introduce a new `TXTRACE` opcode.
 
@@ -135,7 +209,7 @@ The count params (`0x06`, `0x08`) return the size of this view, returning `0` fo
 
 The index params (`0x07`, `0x09`) map a per-address, local index, passed as `in3`, to the entry's global index in the corresponding table. The returned global index can be used directly with the per-entry `TXTRACE` params and with `EVENTDATACOPY`.
 
-If `TXDIFF` recevied an invalid local index, i.e. value greater than or equal to the view's count, an exceptional halt occurs.
+If `TXDIFF` received an invalid local index, i.e. value greater than or equal to the view's count, an exceptional halt occurs.
 
 #### Account Change Flags
 
@@ -258,7 +332,7 @@ The `TXTRACE` and `EVENTDATACOPY` opcodes provide significant introspection capa
 
 By only allowing their execution inside a `POST_TX` frame we ensure this capability may only be used to determine the outcome validity and decide whether to revert the entire transaction.
 
-Because `POST_TX` frames are required to be a trailing suffix of `tx.frames`, the diff `TXTRACE` observes is always the final outcome of the transaction, and because a `POST_TX` revert unconditionally invalidates the whole transaction, a failed assertion can never be partially bypassed by atomic-batch semantics or by frames that ran before it.
+Because `POST_TX` frames are required to be a trailing suffix of `tx.frames`, the diff `TXTRACE` observes is always the final outcome of the transaction, and because a `POST_TX` revert settles the whole execution body against the validation prefix (subject only to `POST_TX_EXEMPT`), a failed assertion can never be partially bypassed by atomic-batch semantics or by frames that ran before it.
 
 Allowing multiple `POST_TX` frames allows independent assertion providers to compose without a need for an active collaboration.
 
@@ -288,13 +362,19 @@ Exposing `gas_pre_charge` directly lets callers subtract it with a single opcode
 
 State changes use address-sorted order because the state diff model collapses all intermediate writes into a single entry per `(address, slot)`. Sequence of execution does not define a deterministic order for the collapsed state diff, as the same slot may be written multiple times across interleaved reentrant calls, yet produce exactly one entry. Sorting by address and slot key ensures a canonical, deterministic enumeration independent of execution flow.
 
-Events can use emission order because each event is a distinct, non-collapsed entity with a canonical position corresponding to its log index. Assertion contracts that verify cross-contract event sequencing require this ordering. 
+Events can use emission order because each event is a distinct, non-collapsed entity with a canonical position corresponding to its log index. Assertion contracts that verify cross-contract event sequencing require this ordering.
+
+### `POST_TX_EXEMPT` Flag
+
+Encoding exemption as flag bit 3 reuses EIP-8141's `flags` field instead of extending the frame RLP object. Preserving a whole frame write-set keeps related effects atomic without the protocol interpreting token semantics. Applying exemptions only at final settlement keeps every `POST_TX` frame on the same full end-of-body `TXTRACE` / `TXDIFF` baseline.
 
 ## Backwards Compatibility
 
 `TXTRACE`, `EVENTDATACOPY`, and `TXDIFF` occupy previously unused opcode slots. No changes are made to existing opcodes, transaction types, or precompiles, so existing contracts and tooling are unaffected.
 
 This proposal has a hard dependency on [EIP-8141](./eip-8141.md) (`requires: 8141`): `TXTRACE`, `EVENTDATACOPY`, and `TXDIFF` can only execute inside an EIP-8141 `POST_TX` frame, as defined under [The `POST_TX` Frame Mode](#the-post_tx-frame-mode). Legacy transactions, [EIP-1559](./eip-1559.md) transactions, and any other EIP-8141 frame mode cannot use any of these opcodes.
+
+`POST_TX_EXEMPT` widens the allowed `flags` range from `< 8` to `< 16` and amends `POST_TX` settlement when the flag is set. Transactions that do not set bit 3 are semantically identical to unconditional execution-body rollback. Fee payers that require repayment finality need to check bit 3 of `FRAMEPARAM` param `0x03` (`flags`) before approving payment.
 
 ## Security Considerations
 
@@ -304,7 +384,7 @@ The main risk is a false sense of security: an assertion contract that checks to
 
 Wallets and dApps that build on `TXTRACE` must ensure their assertion logic covers all relevant state changes for the protected operation. It is critical that the ecosystem treats incomplete assertions as no better than no assertion at all.
 
-The `POST_TX` frame mode requirement strengthens, but does not replace, this guarantee: it ensures a triggered assertion cleanly and unconditionally invalidates the entire transaction, including any gas payment already approved by an earlier frame, and that this cannot be partially bypassed via atomic-batch flags or frames ordered after the assertion. It does not, by itself, make any individual assertion more restrictive or correct.
+The `POST_TX` frame mode requirement strengthens, but does not replace, this guarantee: it ensures a triggered assertion cleanly settles the entire execution body against the validation prefix (subject only to `POST_TX_EXEMPT`), including retention of any gas payment already approved by an earlier frame, and that this cannot be partially bypassed via atomic-batch flags or frames ordered after the assertion. It does not, by itself, make any individual assertion more restrictive or correct.
 
 ### Enforcing `POST_TX` Frame Inclusion
 


### PR DESCRIPTION
## Summary
- Add `POST_TX_EXEMPT` (`0x8`, bit 3) on `DEFAULT`/`SENDER` frames so their write-sets can survive a `POST_TX` revert.
- Empty / unset bit 3 preserves today's unconditional execution-body rollback.
- Specifies combination with `ATOMIC_BATCH_FLAG` (`0xC`), whole-batch exemption rule, settlement semantics, and worked examples (fee-payer repayment; exempt approve+swap batch).