### PR TITLE
Update EIP-8288: move DEP_VERIFY_FRAME_MODE to 4

### DIFF
--- a/EIPS/eip-8288.md
+++ b/EIPS/eip-8288.md
@@ -34,7 +34,7 @@ This EIP solves this problem by adding **STARK-based aggregation**. Instead of a
 
 | Name                              | Value             |
 |-----------------------------------|-------------------|
-| `DEP_VERIFY_FRAME_MODE`           | `3`               |
+| `DEP_VERIFY_FRAME_MODE`           | `4`               |
 | `MAX_DEPENDENCIES_PER_FRAME`      | `256`             |
 | `LEANSPHINCS_SCHEME`              | `0x10`            |
 | `LEANSTARK_SCHEME`                | `0x11`            |


### PR DESCRIPTION
Frame mode `3` is allocated twice.

[EIP-7906](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-7906.md) (created 2025-02-21) allocates it to `POST_TX`:

| Name | Value |
|---|---|
| `POST_TX` | `3` |

and amends the parent spec accordingly — *"The static constraint `assert frame.mode < 3` on each frame is replaced by `assert frame.mode < 4`, admitting `POST_TX` as a valid mode value."*

EIP-8288 (created 2026-06-03) also allocates `3`, to `DEP_VERIFY_FRAME_MODE`. Both are Draft and both are merged, so as written a client enabling both forks has two meanings for the same mode byte — the failure the frame-mode registry exists to prevent.

`4` is the value already proposed for this EIP. The frame-transaction family registry in #12253 reserves:

| Mode | Meaning | Defining EIP |
|------|---------|--------------|
| 3 | POST_TX | 7906 |
| **4** | **DEP_VERIFY (reserved)** | **8288** |

This change makes EIP-8288 agree with that allocation. It does not depend on #12253 merging — the collision with EIP-7906 exists today either way — but it does mean the two land consistent rather than needing a follow-up.

### Scope

One line. The constants table held the only literal; every other mention refers to `DEP_VERIFY_FRAME_MODE` by name, so nothing else needed touching:

```diff
-| `DEP_VERIFY_FRAME_MODE`           | `3`               |
+| `DEP_VERIFY_FRAME_MODE`           | `4`               |
```

I deliberately did **not** add a sentence deferring to the EIP-8141 registry the way EIP-7906 does, since that section is still unmerged in #12253 and referencing it now would be premature. Happy to add it once that lands.

### For the authors

@vbuterin @tcoratger — this is a normative value in your EIP, so it is entirely your call. If you would rather `DEP_VERIFY` keep `3` and `POST_TX` move instead, the right fix is in EIP-7906 and #12253 rather than here, and I will close this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
