### PR TITLE
Update EIP-8272: clarify public mempool scope

### DIFF
--- a/EIPS/eip-8272.md
+++ b/EIPS/eip-8272.md
@@ -15,7 +15,7 @@ requires: 7843, 8141
 
 [EIP-8141](./eip-8141.md) frame transactions can verify recent roots through a canonical `VERIFY` frame. The frame carries one to sixteen `(source_id, slot, root)` tuples and calls a recent root contract that checks each tuple against its storage. Root sources write to the same contract. Each root is keyed by `(source_id, slot)`, where `source_id` is derived from the writer address and a salt.
 
-The frame runs before account validation in the public mempool. A failed check invalidates the transaction, while account validation can read the verified tuples through existing frame introspection. This requires no change to the `FrameTx` envelope and no new opcode.
+The frame runs before account validation in the public mempool, allowing account validation to read the verified tuples through existing frame introspection. A failed `VERIFY` frame invalidates the transaction under EIP-8141's block execution rules. Public mempool support extends EIP-8141's validation rules without changing the `FrameTx` envelope or adding an opcode.
 
 ## Motivation
 
@@ -230,6 +230,8 @@ In a transaction eligible for the public mempool, the recent root verifier frame
 
 EIP-8141's public mempool policy is extended to permit the `current_slot` value defined above and the code and storage reads required by a `recent_root_verify` frame, subject to the rules below.
 
+The rules in this section govern public mempool admission, retention, and propagation. They do not change transaction execution or block validity under EIP-8141.
+
 A transaction eligible for the public mempool MUST contain no more than one recent root verifier frame. If present, it MUST appear immediately after an optional `expiry_verify` frame and before every other frame:
 
 ```text
@@ -285,9 +287,9 @@ For all other blocks, clients MUST NOT run this initialization. Clients MUST han
 
 ### Canonical frame instead of an envelope field
 
-The canonical frame reuses EIP-8141's transaction encoding, signature hash, execution semantics, gas accounting, and frame introspection. An envelope field would require a new transaction schema, native checks before frame execution, special gas and warming rules, and a new introspection opcode.
+The canonical frame reuses EIP-8141's transaction encoding, signature hash, execution semantics, gas accounting, and frame introspection.
 
-A contract and an informal transaction pool convention are not enough. EIP-8141 has a closed public mempool validation prefix grammar and normally bans both `SLOTNUM` and reads from storage outside `tx.sender`. The protocol must define the frame's shape, position, work bound, allowed storage reads, and revalidation rules.
+Once the contract is installed, the verifier executes as an ordinary EIP-8141 `VERIFY` frame. Public mempool support requires extending EIP-8141's policy to recognize the frame's shape and position, permit its `SLOTNUM` and recent root storage reads, and specify its validation gas accounting and revalidation rules. The [Activation](#activation) section separately defines the fork state transition that installs the contract.
 
 ### Full tuples in frame data
 


### PR DESCRIPTION
Clarify that the recent root verifier executes as an ordinary EIP-8141 `VERIFY` frame. Its recognition, validation permissions, validation gas accounting, and revalidation rules extend EIP-8141's public mempool policy. Contract installation under Activation is a separate fork state transition.

Remove the claim that an envelope field necessarily requires a new introspection opcode or special gas and warming rules.