### PR TITLE
Update EIP-8037: cap the transaction gas limit at 2^32-1

### DIFF
--- a/EIPS/eip-8037.md
+++ b/EIPS/eip-8037.md
@@ -36,6 +36,7 @@ The state-growth response we observe is not linear in the gas limit increase: a 
 | `STATE_BYTES_PER_NEW_ACCOUNT` | 120 |
 | `STATE_BYTES_PER_AUTH_BASE` | 23 |
 | `SYSTEM_MAX_SSTORES_PER_CALL` | 16 |
+| `TX_MAX_TOTAL_GAS_LIMIT` | 4,294,967,295 (2^32 - 1) |
 
 ### Parameter changes
 
@@ -63,7 +64,7 @@ The `EXECUTION_PER_AUTH_BASE_COST` is defined as the sum of:
 
 Besides the parameter changes, this proposal introduces an independent metering for state creation costs. Two gas dimensions are introduced, execution-gas and state-gas. For state creation operations, the "new state costs" are charged to state-gas, while the "new execution costs" are charged to execution-gas. The costs of all other operations are charged to execution-gas.
 
-At transaction level, the user pays for both execution-gas and state-gas. The total gas cost of a transaction is the sum of both dimensions. In addition, the transaction gas limit set in [EIP-7825](./eip-7825.md) only applies to execution-gas, while state-gas is only capped by `tx.gas`.
+At transaction level, the user pays for both execution-gas and state-gas. The total gas cost of a transaction is the sum of both dimensions. In addition, the transaction gas limit set in [EIP-7825](./eip-7825.md) only applies to execution-gas, while state-gas is capped by `tx.gas`, which this proposal in turn caps at `TX_MAX_TOTAL_GAS_LIMIT`.
 
 At the block level, only the gas used in the bottleneck resource is considered when checking if the block is full and when updating the base fee for the next block. This gives a new meaning to the block's gas limit and the block's gas target: each now bounds the bottleneck resource (the dimension with the highest cumulative gas used) rather than a single combined gas counter.
 
@@ -71,8 +72,9 @@ At the block level, only the gas used in the bottleneck resource is considered w
 
 Before transaction execution, inclusion of a transaction in a block requires that:
 
-1. The transaction's **intrinsic gas is not higher than [EIP-7825](./eip-7825.md)'s transaction cap**. Concretely, `max(intrinsic_gas, calldata_floor_gas_cost) <= TX_MAX_GAS_LIMIT`. Under [EIP-2780](./eip-2780.md), `intrinsic_gas` is state-independent and charged entirely in execution-gas; there is no intrinsic state-gas component.
-2. For each gas dimension, the **cumulative gas used of all previous transactions added to the transaction's contribution does not exceed the block gas limit**. Concretely, `min(TX_MAX_GAS_LIMIT, tx.gas) <= execution_gas_available` and `tx.gas <= state_gas_available`, where `execution_gas_available = block_env.block_gas_limit - block_output.block_execution_gas_used` and `state_gas_available = block_env.block_gas_limit - block_output.block_state_gas_used`.
+1. The transaction's **gas limit is not higher than `TX_MAX_TOTAL_GAS_LIMIT`**. Concretely, `tx.gas <= TX_MAX_TOTAL_GAS_LIMIT`. Unlike [EIP-7825](./eip-7825.md)'s `TX_MAX_GAS_LIMIT`, which this proposal applies to execution-gas only, this bound applies to `tx.gas` as a whole and therefore to the sum of both dimensions.
+2. The transaction's **intrinsic gas is not higher than [EIP-7825](./eip-7825.md)'s transaction cap**. Concretely, `max(intrinsic_gas, calldata_floor_gas_cost) <= TX_MAX_GAS_LIMIT`. Under [EIP-2780](./eip-2780.md), `intrinsic_gas` is state-independent and charged entirely in execution-gas; there is no intrinsic state-gas component.
+3. For each gas dimension, the **cumulative gas used of all previous transactions added to the transaction's contribution does not exceed the block gas limit**. Concretely, `min(TX_MAX_GAS_LIMIT, tx.gas) <= execution_gas_available` and `tx.gas <= state_gas_available`, where `execution_gas_available = block_env.block_gas_limit - block_output.block_execution_gas_used` and `state_gas_available = block_env.block_gas_limit - block_output.block_state_gas_used`.
 
 This check is performed before transaction inclusion in a block.
 
@@ -390,13 +392,19 @@ These figures account only for the leaf payload and its keccak256 key. They do n
 
 #### EIP-7825 limit on contract size
 
-[EIP-7825](./eip-7825.md) introduces `TX_MAX_GAS_LIMIT` (16.7M) as the maximum gas for a single transaction, in particular stipulating `tx.gas < TX_MAX_GAS_LIMIT`as a validity condition. Were we to continue enforcing this validity condition, with `CPSB = 1530`, this proposal would limit the maximum contract size that can be deployed to roughly 7.5kB. Assuming a representative constructor execution budget of `5M` execution gas on top of the 21,000 base transaction cost and the `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` account-creation cost, the remaining budget for code-deposit state gas yields $\frac{16,777,216 - 21,000 - 5,000,000 - 120 \times 1530}{1530} \approx 7{,}564$ bytes. This maximum size would only decrease if `CPSB` is re-derived upward in a future EIP.
+[EIP-7825](./eip-7825.md) introduces `TX_MAX_GAS_LIMIT` (16.7M) as the maximum gas for a single transaction, in particular stipulating `tx.gas <= TX_MAX_GAS_LIMIT` as a validity condition. Were we to continue enforcing this validity condition, with `CPSB = 1530`, this proposal would limit the maximum contract size that can be deployed to roughly 7.5kB. Assuming a representative constructor execution budget of `5M` execution gas on top of the 21,000 base transaction cost and the `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` account-creation cost, the remaining budget for code-deposit state gas yields $\frac{16,777,216 - 21,000 - 5,000,000 - 120 \times 1530}{1530} \approx 7{,}564$ bytes. This maximum size would only decrease if `CPSB` is re-derived upward in a future EIP.
 
 To solve this issue, we only apply this gas limit to execution gas, not state gas. Doing so does not weaken the intended scaling effect of [EIP-7825](./eip-7825.md), because execution gas meters all resources that benefit from parallelization. In particular, state growth does not: growing the state always requires writing to disk, an operation that can be parallelized, but crucially this part of the cost of a state growth operation has to be metered in execution gas, not state gas. In other words, any operation that grows the state should consume both execution gas and state gas, and the execution gas should fully account for all costs other than the long term effect of growing the state.
 
 However, we cannot statically enforce an execution gas consumption of `TX_MAX_GAS_LIMIT`, while still allowing a higher state gas consumption, because transactions only have a single gas limit parameter, `tx.gas`. This is solved through a **reservoir model**: at transaction start, `evm_gas` is split into `gas_left` (capped at `TX_MAX_GAS_LIMIT - intrinsic_gas`) and a `state_gas_reservoir` (the overflow). State gas charges draw from the reservoir first, then from `gas_left` when the reservoir is empty. Execution gas charges draw from `gas_left` only. Exceeding the execution gas budget behaves identically to running out of gas — no special error is needed.
 
 State-gas refills are applied in last-in, first-out (LIFO) order: because charges draw from the reservoir first and from `gas_left` last, refills credit `gas_left` first (up to the gas it borrowed, tracked by the frame-local `state_gas_from_gas_left` counter), then the reservoir. Undoing a state creation therefore restores the exact pools the charge drew from, as long as both happen in the same frame. Because the original value in the `SSTORE` table above is the value at transaction start rather than at frame entry, a refill may land in a frame other than the one that was charged; the counter is frame-local, so the gas then stays in the reservoir while the `gas_left` that funded the charge stays reduced. Returning it to `gas_left` on the merge keeps the two pools from drifting into one another: `gas_left` is never inflated beyond `TX_MAX_GAS_LIMIT - intrinsic_gas`, and state-gas is not left in the reservoir while a frame is still owed it. The same mismatch is why LIFO order alone does not make a frame's rollback correct: a frame may credit a refill it never funded, so rollback is specified as a restore to the frame's baseline (see [Gas accounting for halts and reverts](#gas-accounting-for-halts-and-reverts)).
+
+#### Keeping an absolute transaction gas limit
+
+Applying [EIP-7825](./eip-7825.md)'s cap to execution-gas alone would leave `tx.gas` itself bounded only by the block gas limit. That is not the intent of this proposal: a per-transaction gas limit is worth keeping. [EIP-7825](./eip-7825.md) introduced one so that the work a single transaction can represent stays a small and predictable unit for proving, parallel execution, and scheduling, and so that this bound is fixed by the protocol rather than drifting upward with every block gas limit increase. This proposal raises that limit for the state dimension; it does not abolish it.
+
+`tx.gas` is therefore capped at `TX_MAX_TOTAL_GAS_LIMIT`, which keeps every transaction's gas limit within an unsigned 32-bit integer. The bound is chosen to sit far above the deployments this proposal sets out to enable. Reusing the figures above (the 21,000 base transaction cost, a representative `5M` execution gas constructor budget, and the `STATE_BYTES_PER_NEW_ACCOUNT × CPSB` account-creation cost), the code-deposit budget it leaves is $\frac{2^{32} - 1 - 21,000 - 5,000,000 - 120 \times 1530}{1530} \approx 2{,}803{,}766$ bytes, roughly 2.8 MB and about 43 times [EIP-7954](./eip-7954.md)'s 65,536-byte contract size limit, so a single transaction can still deploy dozens of maximum-size contracts. While the block gas limit stays below `TX_MAX_TOTAL_GAS_LIMIT`, the per-dimension block checks are the tighter bound and the cap rejects nothing that could be included today; what it adds is a ceiling that no later block gas limit increase can lift.
 
 #### Higher throughput
 


### PR DESCRIPTION
Applying EIP-7825's cap to execution-gas alone leaves tx.gas bounded only by the block gas limit. Keep an absolute per-transaction limit by capping tx.gas at TX_MAX_TOTAL_GAS_LIMIT (4,294,967,295), so a transaction's gas limit still fits in an unsigned 32-bit integer.

The bound is far from binding: it leaves a code-deposit budget of roughly 2.8 MB, about 43 times the EIP-7954 contract size limit.

Also fix the neighbouring rationale sentence, which stated EIP-7825's condition as tx.gas < TX_MAX_GAS_LIMIT; the cap value itself is valid.