### PR TITLE
Update EIP-3372: fix truncated FNV specification link

### DIFF
--- a/EIPS/eip-3372.md
+++ b/EIPS/eip-3372.md
@@ -77,7 +77,7 @@ Finally, Ethereum has always sought to pursue "minimum issuance". By reducing th
 ### Technical Overview
 
 Ethash 1.1 will replace the only FNV prime with five new primes at the stage of the hash computation. The prime used for the DAG generation is remained unchanged, while all others are be changed. This will not prevent ASIC companies from creating new ASICs that adapt but so close to the merge it is unlikely they will do so, and even if they do they are unlikely to be able to produce enough to again be a threat.
-The choice of FNV constants are based on the formal specification that is available on [https://tools.ietf.org/html/draft-eastlake-fnv-14#section-2.1](https://ietf)
+The choice of FNV constants are based on the formal specification that is available on [https://tools.ietf.org/html/draft-eastlake-fnv-14#section-2.1](https://tools.ietf.org/html/draft-eastlake-fnv-14#section-2.1)
 
 We apologize for the delay in submitting the justification for this EIP. As the community may or may not be aware, the original champion was forced to stop working on this EIP due to legal attacks from ASIC companies. It has taken us this long to review his work and find a new champion. To protect ourselves we are submitting this anonymously and would request the community's aid in our endeavor to maintain our anonymity and some lenience given the circumstances and threats we face pursuing this EIP.
 

--- a/EIPS/eip-3372.md
+++ b/EIPS/eip-3372.md
@@ -46,6 +46,7 @@ Prior to this change, `fnv` hash function is used throughout the `hashimoto` fun
 ```
 
 Prior to this EIP, all parts of Ethash are using the `fnv` (hereinafter referenced as `fnv0`) function.  As of the introduction of this EIP:
+
 * `fnvA` replaces `fnv0` in the DAG item selection step
 * `fnvB` replaces `fnv0` in the DAG item mix step
 * `fnvC(fnvD(fnvE` replaces `fnv0(fnv0(fnv0(` in the compress mix step


### PR DESCRIPTION
The reference to the FNV specification in EIP-3372 points at `https://ietf`:

```markdown
[https://tools.ietf.org/html/draft-eastlake-fnv-14#section-2.1](https://ietf)
```

The link text carries the full URL, so the target looks like a truncated paste. This points it at the URL already shown in the text, which resolves (200). Rendered text is unchanged.

`https://datatracker.ietf.org/doc/html/draft-eastlake-fnv-14#section-2.1` is the modern canonical form and keeps the `#section-2.1` anchor, which the `tools.ietf.org` redirect drops. Happy to switch to that instead if you prefer, though it would change the visible text too.

I checked the other 954 EIPs for the same pattern — a link target whose host has no dot — and this is the only one.

The second commit adds a blank line before the `fnv` list. That MD032 violation is pre-existing, not something this PR introduced; the linter only runs on changed files, so it surfaced as soon as this PR touched the file. `markdownlint-cli2-config config/.markdownlint.yaml EIPS/eip-3372.md` reports 0 errors with it.

EIP-3372 is Stagnant and I am not the author, so this needs an editor.
