### PR TITLE
Update EIP-8130: Optional checkpointed actors

### DIFF
--- a/EIPS/eip-8130.md
+++ b/EIPS/eip-8130.md
@@ -150,7 +150,7 @@ checkpoint_actor_blocked(account, actorId) -> bool
 
 `source` is the only contract permitted to resolve checkpointed actors for the account. `commitment` binds its authorization configuration, such as a root, an update-authority key, or a checkpoint-verification mechanism. The source defines the corresponding proof format. `generation` separates successive source registrations and MUST NOT wrap. Setting `source = address(0)` disables checkpointed authorization and requires a zero commitment; it does not delete the generation or revocation markers.
 
-The [config change](#config-change-format) operations `SetActorSource` and `ReleaseActor` require an onchain admin, an unlocked account, and a sequenced Local or Multichain batch. They are invalid in an unsequenced/JIT batch. `SetActorSource` requires the signed generation to equal the stored generation plus one, including when disabling or reinstalling the same source. Existing proofs MUST NOT be relabeled for a new generation without new authorization under the source's committed rules.
+The [config change](#config-change-format) operations `SetActorSource` and `ReleaseActor` require an onchain admin, an unlocked account, and a sequenced Local or Multichain batch. They are invalid in an unsequenced/JIT batch. `SetActorSource` requires the signed generation to equal the stored generation plus one, including when disabling or reinstalling the same source. `ReleaseActor` requires its signed generation to equal the currently enabled source's generation, so a pending release cannot be applied to a replacement source. Existing proofs MUST NOT be relabeled for a new generation without new authorization under the source's committed rules.
 
 Onchain actor configuration takes precedence. A checkpointed authorization MUST be rejected if an `actor_config` record exists for that actor, even when the stored record is expired or uses another authenticator. An ordinary authorization MUST NOT fall back to the source after failing an onchain check.
 
@@ -688,7 +688,7 @@ The operation-specific `payload` is an opaque `bytes` blob carried in the RLP en
 | `3` | `Lock` | `abi.encode(uint16 unlockDelay)` | **Local only, standalone.** Locks the account. See [Account Lock](#account-lock). |
 | `4` | `Unlock` | empty | **Local only, standalone.** Initiates unlock. See [Account Lock](#account-lock). |
 | `5` | `SetActorSource` | `abi.encode(address source, uint64 generation, bytes32 commitment)` | Enable, replace, or disable the optional actor source. Requires the next generation, an onchain admin, an unlocked account, and a sequenced batch. Emits `ActorSourceSet`. See [Source Configuration and Onchain Overrides](#source-configuration-and-onchain-overrides). |
-| `6` | `ReleaseActor` | `abi.encode(bytes32 actorId)` | Remove an onchain override and revocation marker for a non-admin, non-self actor, allowing the enabled source to authorize it. Requires an onchain admin, an unlocked account, and a sequenced batch. Emits `ActorReleased`. See [Source Configuration and Onchain Overrides](#source-configuration-and-onchain-overrides). |
+| `6` | `ReleaseActor` | `abi.encode(bytes32 actorId, uint64 generation)` | Remove an onchain override and revocation marker for a non-admin, non-self actor, allowing the enabled source to authorize it. Requires the current source generation, an onchain admin, an unlocked account, and a sequenced batch. Emits `ActorReleased`. See [Source Configuration and Onchain Overrides](#source-configuration-and-onchain-overrides). |
 
 #### Config Change Authorization
 
@@ -1046,7 +1046,8 @@ interface IKeystore {
     struct AccountChange {
         ChangeType changeType;
         bytes payload;        // AuthorizeActor: abi.encode(bytes32 actorId, ActorConfig, bytes policyData);
-                              // RevokeActor/ReleaseActor: abi.encode(bytes32 actorId); Lock: abi.encode(uint16 unlockDelay);
+                              // RevokeActor: abi.encode(bytes32 actorId); ReleaseActor: abi.encode(bytes32 actorId, uint64 generation);
+                              // Lock: abi.encode(uint16 unlockDelay);
                               // SetActorSource: abi.encode(address source, uint64 generation, bytes32 commitment); others empty
     }
 

--- a/EIPS/eip-8130.md
+++ b/EIPS/eip-8130.md
@@ -1,7 +1,7 @@
 ---
 eip: 8130
 title: Keystore Accounts
-description: Enable account abstraction through onchain keystore accounts and a new transaction type
+description: Enable account abstraction through onchain keystores with optional checkpointed actors and a new transaction type
 author: Chris Hunter (@chunter-cb) <chris.hunter@coinbase.com>
 discussions-to: https://ethereum-magicians.org/t/eip-8130-account-abstraction-by-account-configurations/25952
 status: Draft
@@ -30,6 +30,8 @@ Portability is also a top concern: the keystore lets accounts manage their authe
 ### Overview
 
 An account manages its authentication configuration via the keystore, a contract that maps an account to its configured authenticators and stores their authorizations. An **actor** on the account is one that has an authorization in the keystore. Each actor is bound to an **authenticator**, an onchain contract that checks a signature and returns the actor's identity (`actorId`).
+
+Accounts MAY enable [Optional Checkpointed Actors](#optional-checkpointed-actors) alongside their onchain actors. A registered source verifies individual non-admin actor configurations from transaction witnesses; admins remain exclusively onchain. Enabling, replacing, or disabling the source does not change the account's address or require a different creation or import path.
 
 A new [EIP-2718](./eip-2718.md) transaction type (`AA_TX_TYPE`) names the authenticator that authenticates it. Because the authenticator is declared explicitly, a node can tell exactly what computation a transaction requires, and reject unknown authenticators before executing any code. Validation reads the account's configuration, runs the named authenticator, and checks the resolved actor's permissions; execution then dispatches the transaction's calls.
 
@@ -130,6 +132,88 @@ policy_manager(account, actorId)    → address   // set when POLICY is set
 ```
 
 These slots are read only during execution (see [Actor Policies](#actor-policies)); validity is decided by the single `actor_config` SLOAD giving cheap, predictable validation and invalidation.
+
+#### Optional Checkpointed Actors
+
+An account MAY register one actor source, a contract that verifies offchain actor configurations. Onchain actors continue to use the existing validation path. A checkpointed authorization instead supplies an authenticated configuration for one actor, including its authenticator, expiry, scope, and policy. A configuration root commits to multiple actors; it is not the authenticated `actorId`. `IAuthenticator` and the existing scope, expiry, nonce, sponsorship, and call-execution rules are unchanged except for the configuration-resolution rules below.
+
+Only onchain actors can be admins. A checkpointed authorization MUST NOT satisfy any admin-required check, modify onchain actor records, change delegation, or configure the actor source. The account's self-actorId remains exclusively onchain, including when its implicit EOA authority has been revoked.
+
+##### Source Configuration and Onchain Overrides
+
+The Keystore stores the following additional state, initially zero:
+
+```text
+actor_source(account)          -> (address source, uint64 generation, bytes32 commitment)
+checkpoint_actor_blocked(account, actorId) -> bool
+```
+
+`source` is the only contract permitted to resolve checkpointed actors for the account. `commitment` binds its authorization configuration, such as a root, an update-authority key, or a checkpoint-verification mechanism. The source defines the corresponding proof format. `generation` separates successive source registrations and MUST NOT wrap. Setting `source = address(0)` disables checkpointed authorization and requires a zero commitment; it does not delete the generation or revocation markers.
+
+The [config change](#config-change-format) operations `SetActorSource` and `ReleaseActor` require an onchain admin, an unlocked account, and a sequenced Local or Multichain batch. They are invalid in an unsequenced/JIT batch. `SetActorSource` requires the signed generation to equal the stored generation plus one, including when disabling or reinstalling the same source. Existing proofs MUST NOT be relabeled for a new generation without new authorization under the source's committed rules.
+
+Onchain actor configuration takes precedence. A checkpointed authorization MUST be rejected if an `actor_config` record exists for that actor, even when the stored record is expired or uses another authenticator. An ordinary authorization MUST NOT fall back to the source after failing an onchain check.
+
+Once an account has configured a source (`generation != 0`), every applied `RevokeActor` additionally sets `checkpoint_actor_blocked(account, actorId) = true`, even if no onchain actor record exists or the source is currently disabled. The marker blocks only checkpointed authorization and survives source changes. Ordinary `AuthorizeActor` still grants onchain authority and takes precedence without clearing the marker. `ReleaseActor` explicitly hands a non-admin, non-self actor back to the enabled source: it deletes any onchain actor and policy slots and clears the marker. It MUST reject an existing scope-zero actor, even if expired; an admin must first revoke that actor through the ordinary onchain operation. It does not itself authorize a leaf, and the source proof remains required.
+
+Disabling a source immediately rejects its actors but leaves onchain actors usable. Moving checkpointed actors onchain requires ordinary admin-authorized `AuthorizeActor` operations with the desired configurations; disabling does not enumerate or materialize the tree. Offchain services MAY replicate onchain changes, but their synchronization MUST NOT override these onchain checks. Source registrations and overrides are chain-local state; multichain signed batches remain subject to the existing counters and the signed source generation on each chain.
+
+##### Actor Source Interface
+
+```solidity
+struct EffectiveActor {
+    bytes32 actorId;
+    address authenticator;
+    uint48 expiry;
+    uint16 scope;
+    address policyManager;
+    bytes32 policyCommitment;
+}
+
+interface IActorSource {
+    function resolveActor(
+        address account,
+        uint64 generation,
+        bytes32 commitment,
+        bytes32 actorId,
+        bytes calldata proof
+    ) external view returns (EffectiveActor memory actor);
+}
+```
+
+The Keystore MUST call only the registered source via `STATICCALL`, passing the account being authenticated and the stored generation and commitment. The source MUST verify the actor's entire returned configuration against its committed authorization and freshness rules. Proofs MUST bind the account, Keystore address, source, generation, and commitment; any chain-specific authorization MUST additionally bind its chain. A proof of membership in a root does not alone establish that root's authority or continuing validity. Merkle topology, checkpoint publication, and authorized root-transition formats are defined by the source rather than by this EIP.
+
+A revert, malformed return, or invalid proof makes the authorization invalid. The returned value MUST be the canonical ABI encoding of `EffectiveActor`, match the requested nonzero `actorId`, and contain a nonzero authenticator and nonzero scope. When `POLICY` is unset, `policyManager` and `policyCommitment` MUST both be zero; when set, they have the existing policy semantics. Unknown scope bits remain fail-closed. The source cannot choose a replacement source or change its registered commitment through a proof.
+
+##### Checkpointed Authorization
+
+The previously invalid zero authenticator selector introduces a checkpointed wrapper:
+
+```text
+address(0) (20 bytes) || leaf_authenticator (20 bytes) ||
+abi.encode(bytes32 actorId, uint64 generation, bytes sourceProof, bytes authenticatorData)
+```
+
+The ABI encoding MUST be canonical with no trailing bytes. `leaf_authenticator` MUST be nonzero and is the effective authenticator for acceptance, signature verification, and gas accounting; the zero selector is never called as a contract. This wrapper is permitted wherever a configured actor's `authenticator || data` authorization is accepted, including `sender_auth`, `payer_auth`, and Keystore signature verification. It is invalid for the empty-sender EOA path and for admin authorization. In a `validateSignature` envelope the existing `sigType` still precedes the complete wrapper. Ordinary authorization bytes are unchanged.
+
+For the wrapper, replace onchain actor resolution with the following steps, against the same effective account state used by ordinary validation:
+
+1. Require an enabled source, the stored generation to match the wrapper, and the account to be unlocked. Reject the self-actorId, an existing onchain actor record, or a set revocation marker.
+2. Resolve the actor through `IActorSource` and require its authenticator to equal `leaf_authenticator`.
+3. Authenticate the unchanged transaction or message digest with `leaf_authenticator.authenticate(hash, authenticatorData)`, or the existing native k1 equivalent. Require the returned identity to equal the witnessed `actorId`.
+4. Apply the existing expiry and context-specific scope checks to this individual actor. For a transaction, retain its effective configuration for execution; do not resolve it again after account changes or calls.
+
+Checkpointed authorizations are invalid while the account is locked, including message verification and payer authentication. Onchain authentication and the existing lock/unlock lifecycle remain unchanged. Disabling, replacing, or advancing a source, adding an onchain override, revoking an actor, or locking the account can invalidate pending checkpointed authorizations; nodes MUST revalidate affected transactions against inclusion state and track any additional mutable state read by the source.
+
+##### Policies, Signatures, and Gas
+
+For a checkpointed sender, the policy gate and policy manager use the authenticated `EffectiveActor`, replacing reads of that actor's policy slots. `getTransactionSenderActor()` exposes this configuration during execution. Its value is fixed for the transaction and source updates or earlier calls MUST NOT retarget the gate. Onchain senders retain the existing policy-resolution timing; their effective actor getter uses the configuration and policy snapshot selected for execution.
+
+The Keystore additionally exposes `authenticateActorWithConfig(account, hash, auth)`, returning the full authenticated `EffectiveActor` for either authorization path. It performs the same authentication and expiry checks as `authenticateActor`; consumers remain responsible for context-specific authorization. Message-policy consumers MUST apply the existing `replaySafeHash`/`envelopeDigest` domain before using this raw-digest method. Existing `authenticateActor` and `validateSignature` results remain `(actorId, scope)`, while getters without a witness continue to describe onchain storage only. Non-8130 execution adapters use the authenticated configuration directly rather than relying on the Transaction Context precompile.
+
+Checkpointing introduces no login grant and does not expand the default [ERC-1271](./eip-1271.md) operational predicate. A key used both for website login and restricted transactions needs explicit message-policy validation of the permitted domain and message type, independently of its transaction policy. Its committed expiry applies to both authentication paths. Expiration rejects new authentication without removing the leaf or updating the root; an existing website session needs its own expiry or revalidation policy.
+
+On a permissive transaction path, source verification is metered EVM execution. The complete checkpointed authentication cost, including wrapper decoding, state reads, source verification, and leaf authentication, MUST fit within `MAX_AUTHENTICATION_GAS` for each sender or payer authorization. These costs replace that authorization's existing authentication-execution component; the wrapper's bytes are charged once through the existing payload rules. Source-state and revocation-marker writes use the existing `account_changes_cost` storage-write schedule. A canonical-only transaction path accepts the wrapper only when both the source and leaf authenticator are enshrined by the chain at consensus-defined fixed validation costs; source registration alone does not confer transaction-path acceptance.
 
 #### Actor Scope
 
@@ -299,6 +383,8 @@ An account is delegated when its code is exactly `0xef0100 || target`, where `ta
 
 The Keystore exposes one raw primitive, `authenticateActor(account, hash, auth)`, which maps a hash and signature to a verified `(actorId, scope)`. Wallet-originated flows — transactions, account changes, and other protocol paths — authenticate directly against it over their own digest.
 
+`authenticateActorWithConfig` exposes the same authentication with the full effective configuration for consumers of [Optional Checkpointed Actors](#optional-checkpointed-actors), including message-policy verifiers. Both authorization paths return the individual actor's identity.
+
 Applications that instead request a signature (Sign-In with Ethereum, `Permit`, order flow) use `validateSignature(account, hash, auth)`. This wraps `authenticateActor` with an identity binding that makes the signature replay-safe: `replaySafeHash(account, chainId, hash) = keccak256(SIGNED_MESSAGE_TYPEHASH, account, chainId, hash)` binds the signature to a specific account and chain (`chainId = 0` binds all chains). The `auth` blob is `sigType(1) ‖ authenticator(20) ‖ data`, where `sigType` selects the **Local** (`0x01`) or **Multichain** (`0x02`) domain.
 
 Because both methods return `(actorId, scope)` rather than a bare boolean, a consumer can attribute a signature to a specific key and make a granular authorization decision — the "who signed" and capability set that plain ERC-1271 discards, surfaced only when a consumer needs it.
@@ -306,6 +392,8 @@ Because both methods return `(actorId, scope)` rather than a bare boolean, a con
 This supersedes ERC-1271 while remaining backwards compatible: an 8130 account implements `isValidSignature(hash, signature)` on top of `validateSignature`, returning the magic value when the resolved actor is operational and treating any revert as invalid. The recommended wrapper is `Scopes.isOperator` (admin, or `SENDER` without `POLICY`; see [Actor Scope](#actor-scope)); the canonical `DefaultAccount` in the contract repository ships this wrapper.
 
 **Precompiles and native signature verification.** A precompile calling back into the EVM is both undesirable and unimplemented at the time of writing, so ERC-1271 — which verifies by calling the account's `isValidSignature` — is unavailable for native or precompile-based checks. 8130 removes that dependency: the canonical authenticator set is small and enshrinable (see [Canonical Authenticator Set](#canonical-authenticator-set)) and authority lives in a flat `actor_config` slot, so `validateSignature` can run entirely in native code and be exposed as a precompile, producing identical results to EVM execution on non-8130 chains. Future applications may depend on this, as it replaces both `ecrecover` and ERC-1271 cleanly across all chain types.
+
+For checkpointed authorization this native-only path additionally requires an enshrined actor source; a custom source does not become natively verifiable merely because the leaf's authenticator is canonical.
 
 ### AA Transaction Type
 
@@ -437,12 +525,14 @@ Signature format is determined by the `sender` field:
 authenticator (20 bytes) || data
 ```
 
-The first 20 bytes identify the authenticator address. When the authenticator is `K1_AUTHENTICATOR`, `data` is raw ECDSA `(r || s || v)` and the protocol handles ecrecover natively. For all other authenticators, `data` is authenticator-specific; each authenticator defines its own wire format.
+The first 20 bytes identify the authenticator address, except that `address(0)` selects the [checkpointed authorization wrapper](#checkpointed-authorization). When the authenticator is `K1_AUTHENTICATOR`, `data` is raw ECDSA `(r || s || v)` and the protocol handles ecrecover natively. For all other authenticators, `data` is authenticator-specific; each authenticator defines its own wire format.
 
 ##### Validation
 
+For a checkpointed wrapper, use [Checkpointed Authorization](#checkpointed-authorization) to resolve and authenticate the individual actor before applying the same context-specific checks. The following steps describe ordinary onchain authorization.
+
 1. **Resolve sender**: If `sender` empty, ecrecover derives the sender address (EOA path) with `actorId = bytes32(uint256(uint160(sender)))`. If `sender` set, read the first 20 bytes of `sender_auth` as the authenticator address.
-2. **Authenticate**: Route by authenticator address. For the EOA path (`sender` empty), ecrecover was already performed in step 1. For `K1_AUTHENTICATOR` (`address(1)`), the protocol natively ecrecovers from `data` (as `r || s || v`), returning `actorId = bytes32(uint256(uint160(recovered_address)))`. For all other authenticators, call `authenticator.authenticate(hash, data)` via STATICCALL, returning `actorId` (or `bytes32(0)` for invalid). `address(0)` is never a valid authenticator selector (it is the empty `actor_config` sentinel).
+2. **Authenticate**: Route by authenticator address. For the EOA path (`sender` empty), ecrecover was already performed in step 1. For `K1_AUTHENTICATOR` (`address(1)`), the protocol natively ecrecovers from `data` (as `r || s || v`), returning `actorId = bytes32(uint256(uint160(recovered_address)))`. For all other authenticators, call `authenticator.authenticate(hash, data)` via STATICCALL, returning `actorId` (or `bytes32(0)` for invalid). `address(0)` is never an authenticator (it remains the empty `actor_config` sentinel).
 3. **Authorize**: **Self-actor (native secp256k1) rule**: if authentication in step 2 used the native secp256k1 path (the EOA path or `K1_AUTHENTICATOR`) and `actorId == bytes32(uint256(uint160(sender)))`, resolve the self-actor from the inline default-EOA config in the packed account-state slot: reject if `DEFAULT_EOA_REVOKED` is set; otherwise take `scope` and `expiry` from the inline fields (all-zero = unrestricted, non-expiring full owner, i.e. admin). Otherwise SLOAD `actor_config(sender, actorId)`, reject if its reserved bytes are nonzero (version gate, see [Storage Layout](#storage-layout)), and require that the stored authenticator address matches the effective authenticator (this covers every other actor, including a non-secp256k1 self). In either case, if the resolved `expiry` is non-zero, also require `block.timestamp <= expiry`; an expired actor is rejected.
 4. **Check scope**: Read the resolved `scope` byte (from the inline default-EOA config for the secp256k1 self-actor, or `actor_config` otherwise) and check it against the context being authorized per [Actor Scope](#actor-scope) (for `sender_auth`: `scope == 0x00 || (scope & (SENDER | POLICY)) != 0`, with `POLICY` gating the actor to its `manager`). Payer scope is checked when the payer is resolved (see [Validation Flow](#validation-flow) step 6).
 5. **Check nonce scope** (sender-context only, when `nonce_key != NONCE_KEY_MAX`): require the resolved actor be admin or carry `NONCE`, per [Actor Nonce Scope](#actor-nonce-scope).
@@ -581,7 +671,7 @@ rlp([
 ])
 
 change = rlp([
-  change_type,        // uint8: 0 AuthorizeActor, 1 RevokeActor, 2 IncrementLocalEpoch, 3 Lock, 4 Unlock
+  change_type,        // uint8: 0 AuthorizeActor, 1 RevokeActor, 2 IncrementLocalEpoch, 3 Lock, 4 Unlock, 5 SetActorSource, 6 ReleaseActor
   payload             // bytes: operation-specific, ABI-encoded (see below)
 ])
 ```
@@ -597,6 +687,8 @@ The operation-specific `payload` is an opaque `bytes` blob carried in the RLP en
 | `2` | `IncrementLocalEpoch` | empty | **Either channel.** Increments `local_epoch` and resets `local_sequence` to `0`, invalidating every unlanded local signature (sequenced and unsequenced) at the prior epoch. Always targets the local epoch, even when carried in a Multichain batch. Consumes no sequence itself. See [Epoch System](#epoch-system). |
 | `3` | `Lock` | `abi.encode(uint16 unlockDelay)` | **Local only, standalone.** Locks the account. See [Account Lock](#account-lock). |
 | `4` | `Unlock` | empty | **Local only, standalone.** Initiates unlock. See [Account Lock](#account-lock). |
+| `5` | `SetActorSource` | `abi.encode(address source, uint64 generation, bytes32 commitment)` | Enable, replace, or disable the optional actor source. Requires the next generation, an onchain admin, an unlocked account, and a sequenced batch. Emits `ActorSourceSet`. See [Source Configuration and Onchain Overrides](#source-configuration-and-onchain-overrides). |
+| `6` | `ReleaseActor` | `abi.encode(bytes32 actorId)` | Remove an onchain override and revocation marker for a non-admin, non-self actor, allowing the enabled source to authorize it. Requires an onchain admin, an unlocked account, and a sequenced batch. Emits `ActorReleased`. See [Source Configuration and Onchain Overrides](#source-configuration-and-onchain-overrides). |
 
 #### Config Change Authorization
 
@@ -607,7 +699,7 @@ The `channel` selects the replay domain and how `sequence` is interpreted:
 - **Multichain** (`chain_id 0`): a plain monotonic `uint64` counter, valid on any chain, for synchronizing actor state across chains. Each applied batch consumes the counter (`sequence` MUST equal the current value, then it increments). There is no epoch and no unsequenced mode on this channel, though a Multichain batch MAY still carry an `IncrementLocalEpoch` change that bumps the account's local epoch.
 - **Local** (`block.chainid`): `sequence` is the packed word `local_epoch(high 32) || local_sequence(low 32)`. The batch is rejected with `StaleEpoch` unless its high half equals the current `local_epoch`. The low half selects one of two modes:
   - **Sequenced** (low half `< UNSEQUENCED`): the low half MUST equal the current `local_sequence`; on success `local_sequence` increments. This is the ordered, replay-once mode.
-  - **Unsequenced / JIT** (low half `== UNSEQUENCED`, i.e. `uint32` max): consumes no counter and does not increment `local_sequence`. It is permissive — any change may ride an unsequenced batch — and remains replayable until the epoch moves. Because it consumes no counter, ordering between two unsequenced batches is undefined. Retiring an unsequenced (JIT) authorization durably is done by bumping the epoch (`IncrementLocalEpoch`), typically batched with the reducing change. See [Epoch System](#epoch-system).
+  - **Unsequenced / JIT** (low half `== UNSEQUENCED`, i.e. `uint32` max): consumes no counter and does not increment `local_sequence`. It is permissive — any change except `SetActorSource` and `ReleaseActor` may ride an unsequenced batch — and remains replayable until the epoch moves. Because it consumes no counter, ordering between two unsequenced batches is undefined. Retiring an unsequenced (JIT) authorization durably is done by bumping the epoch (`IncrementLocalEpoch`), typically batched with the reducing change. See [Epoch System](#epoch-system).
 
 **Expiry on `AuthorizeActor` is channel/mode-aware and never reverts.** On the **unsequenced/JIT path**, an already-lapsed grant (a non-zero `expiry` that has passed per [Actor Expiry](#actor-expiry)) is **silently skipped**: the change is not applied and does not revert, and any live sibling changes in the same batch still apply. A JIT grant is replayable, so skipping a lapsed one keeps it from ever clobbering its slot — a renewed grant cannot be overwritten by replaying the old, expired one. A **single-consume** batch (any Multichain batch, or a **Sequenced** local batch) cannot be replayed, so an already-lapsed grant is instead installed **inert** — the `actor_config` slot is written (the actor is present and revocable) but the actor is not live, since authentication yields expired per [Actor Expiry](#actor-expiry) — and still consumes its sequence. Multichain relies on this: a chain catching up must replay a historical expiring grant's slot (e.g. a periodically-renewed operator) in order to reach the current live grant, so dropping the stale slot would strand its counter. A zero `expiry` is the "no expiry" sentinel and is always accepted.
 
@@ -681,13 +773,13 @@ Calls carry no ETH value. ETH transfers are initiated by the account's wallet by
 
 Phases execute in order from a single gas pool (`gas_limit`). Within each phase, calls execute in order and are **atomic** so if any call in a phase reverts, all state changes for that phase are discarded and remaining phases are **skipped**. Completed phases **persist** and their state changes are committed and survive later phase reverts.
 
-**Policy gate**: When the transaction's authenticating actor has `POLICY` set (and exclusivity checks passed), each call is gated before dispatch. The protocol resolves the actor's allowed target (`policy_manager(sender, actorId)`) once at the start of `calls` execution, and that snapshot gates every call in every phase; a config change applied by an earlier call does not retarget the gate for later calls. If `call.to` is not that address, the call is **not dispatched** and fails deterministically with the protocol revert `ActorPolicyViolation(bytes32 actorId, address target)`:
+**Policy gate**: When the transaction's authenticating actor has `POLICY` set (and exclusivity checks passed), each call is gated before dispatch. For an onchain actor, the protocol resolves the allowed target (`policy_manager(sender, actorId)`) once at the start of `calls` execution; for a checkpointed actor it uses the authenticated configuration. That snapshot gates every call in every phase; a config change applied by an earlier call does not retarget the gate for later calls. If `call.to` is not that address, the call is **not dispatched** and fails deterministically with the protocol revert `ActorPolicyViolation(bytes32 actorId, address target)`:
 
 ```solidity
 error ActorPolicyViolation(bytes32 actorId, address target);
 ```
 
-The frame's return data is `abi.encodeWithSelector(ActorPolicyViolation.selector, actorId, call.to)`. This is a consensus-level result, not a validity error, so standard atomicity applies: the enclosing phase's state changes roll back, later phases are skipped, and the phase is reported as failed in `phaseStatuses`. Only work already performed is charged (intrinsic gas plus the one `policy_manager` SLOAD); the undispatched call body costs nothing and the transaction is still included with its nonce consumed.
+The frame's return data is `abi.encodeWithSelector(ActorPolicyViolation.selector, actorId, call.to)`. This is a consensus-level result, not a validity error, so standard atomicity applies: the enclosing phase's state changes roll back, later phases are skipped, and the phase is reported as failed in `phaseStatuses`. Only work already performed is charged (intrinsic gas plus policy-target resolution); the undispatched call body costs nothing and the transaction is still included with its nonce consumed.
 
 **Common patterns**:
 
@@ -708,10 +800,11 @@ The static, sender-signed fields (`sender`, `payer`, `calls`, `gas_limit`) are p
 | `getTransactionCalls()` | `Call[][]`, the full `calls` array (`Call = (address to, bytes data)`) | Validation + Execution |
 | `getTransactionGasLimit()` | `uint256`, the sender-side gas budget (`gas_limit`) before intrinsic costs and call execution | Validation + Execution |
 | `getTransactionSenderActorId()` | `bytes32`, authenticated actor's actorId | Execution only |
+| `getTransactionSenderActor()` | `EffectiveActor`, authenticated actor configuration and execution policy snapshot | Execution only |
 
 Under the [L1 profile](#adoption-profiles) this getter set and its validation-time availability are normative; under the L2 profile a chain MAY populate the precompile during execution only.
 
-If the wallet needs the authenticator address or scope, it calls `getActorConfig(account, actorId)` on the Keystore contract. A policy target reached as a `call.to` identifies which key it is acting for by combining `getTransactionSender()` and the authenticated `getTransactionSenderActorId()` from this precompile, then reads the actor's gate target and signed `commitment` via `getActor(account, actorId)` in one call and validates the presented policy parameters against the commitment. The commitment lives in Keystore storage (where it is written and revoked), not the precompile, keeping the precompile to immutable transaction context.
+For onchain actors, wallets can read configuration from the Keystore as before. A policy target identifies the account and actor through `getTransactionSender()` and `getTransactionSenderActorId()`. For checkpointed actors it reads the authenticated manager and commitment from `getTransactionSenderActor()` and checks its policy parameters against that commitment; no policy slot exists for the leaf. This getter is an immutable execution snapshot, not an additional persistent configuration store.
 
 **Non-8130 chains**: No code at `TX_CONTEXT_ADDRESS`; STATICCALL returns zero/default values.
 
@@ -723,6 +816,7 @@ The system is split into storage and authentication layers with different portab
 |-----------|-------------|-----------------|
 | **Keystore contract** | Protocol reads storage directly for validation; EVM interface available | Standard contract (ERC-4337 compatible factory) |
 | **Authenticator Contracts** | Protocol calls authenticators via STATICCALL | Same onchain contracts callable by the Keystore contract and wallets |
+| **Actor Source Contracts** | Protocol resolves checkpointed actors through accepted sources | Same source interface callable by the Keystore; execution adapters consume the authenticated configuration |
 | **Code Delegation** | Delegation entry in `account_changes` (EOA-only authorization in this version) | Standard [EIP-7702](./eip-7702.md) transactions (ECDSA authority) |
 | **Transaction Context** | Precompile at `TX_CONTEXT_ADDRESS`; protocol populates, authenticators read | No code at address; STATICCALL returns zero/default values |
 | **Nonce Manager** | Precompile at `NONCE_MANAGER_ADDRESS` | Not applicable; nonce management by existing systems (e.g., ERC-4337 EntryPoint) |
@@ -843,6 +937,14 @@ The two [adoption profiles](#adoption-profiles) make that split explicit rather 
 
 Session keys often need narrow authority: only this token, only this much per day, only this action. `POLICY` makes gated initiation a first-class grant, distinct from ungated `SENDER`: the key may originate transactions, but only to a single call target, bound to a signed opaque **commitment**. The protocol's only policy responsibility is the single-target gate plus storing the commitment. Allowing `POLICY | SELF_PAYER` lets a session key self-pay; note this exposes the account's full ETH balance to gas spend (see [Payer Modes](#payer-modes)).
 
+### Why Optional Checkpointed Actors?
+
+Keeping admins onchain preserves ordinary account creation, import, recovery, and configuration changes. An optional source makes offchain grants reversible and allows them to coexist with stored actors. The source verifies configuration proofs, authenticators verify signatures, and the Keystore applies individual actor permissions; a root does not collapse its leaves into one actor identity. Proof systems can evolve independently behind the source interface without standardizing their tree encoding or update history in the core protocol.
+
+A wallet can issue a separate key for each of ten websites visited on different days, commit each key's seven-day expiry and transaction policy, and use different authenticators for different leaves. An expiry takes effect without a root update. Adding another key needs authorization under the source's rules but no individual onchain actor slot. Website login still needs a message policy distinct from transaction permissions. Disabling the source leaves onchain admins available to install a replacement or register individual actors directly.
+
+Onchain precedence and revocation markers make hybrid authority deterministic even when the offchain service is delayed. Explicit release is needed to delegate a previously overridden actor back to the source. Rejecting checkpointed authentication while locked avoids relying on an external service to freeze its state. The tradeoff is that source-enabled accounts retain revocation markers and cannot use their checkpointed actors during a lock.
+
 ### Why a Local Epoch?
 
 Session keys and just-in-time (JIT) authorizations want two things that pull against a shared counter: they should be usable in any order (no coordination), and the account should be able to cancel any it has handed out that have not yet landed. A single monotonic `local_sequence` gives ordering but forces every signature to burn the next slot, so parallel keys contend and a stale signature can still land later. Splitting the local word into `local_epoch || local_sequence` separates the two concerns: sequenced changes still consume `local_sequence` for ordered, replay-once semantics, while an epoch bump is a single blunt "cancel everything outstanding on the local channel" that resets the counter and invalidates every not-yet-landed local signature at the prior epoch (`StaleEpoch`). Crucially it cancels *signatures*, not *authority* — actors from landed batches survive — so bumping the epoch is cheap to reason about and cannot brick a live actor set. That is what makes the unsequenced/JIT mode (`UNSEQUENCED`) safe: a JIT batch is intentionally replayable within its epoch, and durable retirement is just an epoch bump batched with the reducing change (see [Epoch System](#epoch-system)).
@@ -937,14 +1039,15 @@ interface IKeystore {
     }
 
     enum AccountChangeChannel { Local, Multichain }
-    enum ChangeType { AuthorizeActor, RevokeActor, IncrementLocalEpoch, Lock, Unlock }
+    enum ChangeType { AuthorizeActor, RevokeActor, IncrementLocalEpoch, Lock, Unlock, SetActorSource, ReleaseActor }
     // Leading byte of a signature envelope: Local (0x01) binds block.chainid, Multichain (0x02) binds chainId 0.
     enum SignatureType { Invalid, Local, Multichain }
 
     struct AccountChange {
         ChangeType changeType;
         bytes payload;        // AuthorizeActor: abi.encode(bytes32 actorId, ActorConfig, bytes policyData);
-                              // RevokeActor: abi.encode(bytes32 actorId); Lock: abi.encode(uint16 unlockDelay); others empty
+                              // RevokeActor/ReleaseActor: abi.encode(bytes32 actorId); Lock: abi.encode(uint16 unlockDelay);
+                              // SetActorSource: abi.encode(address source, uint64 generation, bytes32 commitment); others empty
     }
 
     struct SignedAccountChanges {
@@ -958,6 +1061,8 @@ interface IKeystore {
 
     event ActorAuthorized(address indexed account, bytes32 indexed actorId, bytes actorData);
     event ActorRevoked(address indexed account, bytes32 indexed actorId);
+    event ActorSourceSet(address indexed account, address source, uint64 generation, bytes32 commitment);
+    event ActorReleased(address indexed account, bytes32 indexed actorId);
     event AccountCreated(address indexed account, bytes32 userSalt, bytes32 codeHash);
     event AccountImported(address indexed account);
     event LocalEpochIncremented(address indexed account, uint32 localEpoch);
@@ -985,10 +1090,13 @@ interface IKeystore {
     function envelopeDigest(SignatureType sigType, address account, bytes32 hash) external view returns (bytes32);
     // Lower-level: authenticate an actor over a raw digest (no envelope). Used by off-8130 (e.g. ERC-4337) consumers.
     function authenticateActor(address account, bytes32 hash, bytes calldata auth) external view returns (bytes32 actorId, uint16 scope);
+    function authenticateActorWithConfig(address account, bytes32 hash, bytes calldata auth) external view returns (EffectiveActor memory);
 
     // Storage views (see the canonical repository for the complete set).
     function getActorConfig(address account, bytes32 actorId) external view returns (ActorConfig memory);
     function getActor(address account, bytes32 actorId) external view returns (ActorConfig memory config, address policyManager, bytes32 policyCommitment);
+    function getActorSource(address account) external view returns (address source, uint64 generation, bytes32 commitment);
+    function isCheckpointActorBlocked(address account, bytes32 actorId) external view returns (bool);
     function getChangeSequences(address account) external view returns (ChangeSequences memory);
     function getLockStatus(address account) external view returns (bool locked, bool hasInitiatedUnlock, uint48 unlocksAt, uint16 unlockDelay);
 }
@@ -1019,10 +1127,11 @@ interface ITransactionContext {
     function getTransactionCalls() external view returns (Call[][] memory);
     function getTransactionGasLimit() external view returns (uint256);
     function getTransactionSenderActorId() external view returns (bytes32);
+    function getTransactionSenderActor() external view returns (EffectiveActor memory);
 }
 ```
 
-Read-only. Gas is charged as a base cost plus 3 gas per 32 bytes of returned data. `getTransactionSender`, `getTransactionPayer`, `getTransactionCalls`, and `getTransactionGasLimit` read static sender-signed fields and are available during both authentication and call execution; `getTransactionSenderActorId` is available during execution only (the actor is resolved after authentication).
+Read-only. Gas is charged as a base cost plus 3 gas per 32 bytes of returned data. `getTransactionSender`, `getTransactionPayer`, `getTransactionCalls`, and `getTransactionGasLimit` read static sender-signed fields and are available during both authentication and call execution; `getTransactionSenderActorId` and `getTransactionSenderActor` are available during execution only (the actor is resolved after authentication).
 
 ### INonceManager (Precompile)
 
@@ -1036,7 +1145,7 @@ Read-only. The protocol manages nonce storage directly; there are no state-modif
 
 ## Security Considerations
 
-**Validation Surface**: For canonical authenticators, invalidators are `actor_config` changes and nonce consumption. Canonical authenticators are pure functions of `(hash, data)` and the resolved `actor_config`, so a validated transaction is invalidated only by those two events, keeping the mempool invalidator set small and enumerable (this is why a canonical-only acceptance policy suits high-throughput chains).
+**Validation Surface**: For onchain actors using canonical authenticators, invalidators are `actor_config` changes and nonce consumption. Canonical authenticators are pure functions of `(hash, data)` and the resolved `actor_config`, so a validated transaction is invalidated only by those two events, keeping the mempool invalidator set small and enumerable (this is why a canonical-only acceptance policy suits high-throughput chains).
 
 A **permissive** acceptance policy (see [Adoption Profiles](#adoption-profiles)) deliberately widens this surface: accepting non-canonical authenticators on the transaction path means accepting authenticators that may read mutable state, so an accepted transaction can be invalidated by state beyond `actor_config` and the nonce, and a node MUST run additional mempool-validation machinery to bound that (for example, tracking the state an authenticator touches and re-validating on change). A base layer typically wants this larger surface; the execution cost is already bounded per call by `MAX_AUTHENTICATION_GAS` and each authentication is a single `STATICCALL` returning an `actorId`, so the extra machinery is about *invalidation tracking*, not unbounded execution. 8130 makes this an opt-in, allow-only-what-you-need extension rather than an all-or-nothing choice: the declared-authenticator model lets a chain enshrine the pure canonical set and admit specific, focused stateful authenticators only where a use case needs them (and a chain that needs none runs no such machinery at all), instead of having to admit arbitrary wallet-defined validation code wholesale.
 
@@ -1054,9 +1163,13 @@ All three cases resolve to the same `replay_id` (fee bumps included, since `repl
 
 **Policy Target as Trust Anchor**: For a policy-bearing actor, the resolved target is fully trusted to enforce the committed limits; the key can only reach that target, which decides what happens next. A buggy or malicious manager can do anything its own authority over the account allows. Accounts SHOULD point restricted keys only at audited managers and treat installing one with the same care as granting that contract authority over the account. A manager (and any policy it enforces) SHOULD be non-upgradeable: an upgradeable manager lets whoever controls the upgrade rewrite enforcement, which is equivalent to granting that party root access over everything the manager can do for the account. The committed parameters and any target-held state are the target's own authorization surface; checking that `keccak256(params)` matches the stored commitment is the target's responsibility, not the protocol's. How the target obtains authority to act for the account is out of scope for this specification.
 
-**Policy State on Revocation**: `revokeActor` clears `actor_config`, `policy_commitment`, and `policy_manager` (all keyed by `(account, actorId)`), which immediately stops the key from reaching its target; there are no per-target protocol entries to enumerate or resurrect, and storage is fully reclaimed. Any parameters a target keeps in its own storage are not protocol state and are not auto-cleared; wallets uninstall them through the target when retiring a key, and an `expiry` bounds the window during which a not-yet-uninstalled key could otherwise be used.
+**Policy State on Revocation**: `revokeActor` clears `actor_config`, `policy_commitment`, and `policy_manager` (all keyed by `(account, actorId)`), which immediately stops the key from reaching its target. Accounts that have configured an actor source retain a revocation marker to prevent offchain resurrection. Any parameters a target keeps in its own storage are not protocol state and are not auto-cleared; wallets uninstall them through the target when retiring a key, and an `expiry` bounds the window during which a not-yet-uninstalled key could otherwise be used.
 
 **Actor Management**: Config change authorization requires the authorizing actor be admin (`scope == 0x00`). The EOA actor is implicitly authorized with unrestricted (admin) scope; revocable via portable config change. All actor modification paths are blocked when the account is locked.
+
+**Actor Source Authority**: An actor source verifies configuration authority in addition to membership and freshness. A source that can attest arbitrary configurations controls the account's offchain non-admin grants. Keeping admins onchain protects administrative configuration but does not limit spending if the source can grant ungated operational authority. Source code, upgrade authority, and any permission ceiling enforced by its committed configuration are therefore part of the account's trust model.
+
+**Source Revocation and Availability**: Generations prevent replay across source registrations, while persistent onchain markers prevent revoked keys from returning through old or new roots. `ReleaseActor` is an explicit delegation back to the source. A missing proof or unavailable source can interrupt checkpointed actors; onchain actors remain independent of it. Wallets retain the configuration data needed to produce witnesses or register replacement onchain actors. Source synchronization cannot delay an onchain override or revocation.
 
 **Actor Expiry**: Prefer non-expiring admins and apply `expiry` only to restricted keys; a sole expiring admin bricks the account and breaks cross-chain reconstruction (see [Actor Expiry](#actor-expiry)).
 

--- a/EIPS/eip-8130.md
+++ b/EIPS/eip-8130.md
@@ -181,9 +181,34 @@ interface IActorSource {
 }
 ```
 
-The Keystore MUST call only the registered source via `STATICCALL`, passing the account being authenticated and the stored generation and commitment. The source MUST verify the actor's entire returned configuration against its committed authorization and freshness rules. Proofs MUST bind the account, Keystore address, source, generation, and commitment; any chain-specific authorization MUST additionally bind its chain. A proof of membership in a root does not alone establish that root's authority or continuing validity. Merkle topology, checkpoint publication, and authorized root-transition formats are defined by the source rather than by this EIP.
+The Keystore MUST call only the registered source via `STATICCALL`, passing the account being authenticated and the stored generation and commitment. The source MUST verify the actor's entire returned configuration against its committed membership and freshness rules. Proofs MUST bind the account, Keystore address, source, generation, and commitment; any chain-specific authorization MUST additionally bind its chain. Source acceptance is one part of authorization: the Keystore MUST additionally verify the independent onchain admin approval below. Merkle topology, checkpoint publication, and root-transition formats are defined by the source rather than by this EIP.
 
 A revert, malformed return, or invalid proof makes the authorization invalid. The returned value MUST be the canonical ABI encoding of `EffectiveActor`, match the requested nonzero `actorId`, and contain a nonzero authenticator and nonzero scope. When `POLICY` is unset, `policyManager` and `policyCommitment` MUST both be zero; when set, they have the existing policy semantics. Unknown scope bits remain fail-closed. The source cannot choose a replacement source or change its registered commitment through a proof.
+
+##### Onchain Admin Co-Authorization
+
+Every checkpointed actor requires an admin's approval of its complete leaf configuration in addition to source acceptance and the acting key's signature. The Keystore computes:
+
+```text
+actor_commitment = keccak256(abi.encode(
+    actor.actorId, actor.authenticator, actor.expiry, actor.scope,
+    actor.policyManager, actor.policyCommitment
+))
+approval_hash = keccak256(abi.encode(
+    keccak256("CheckpointedActorApproval(address keystore,address source,uint64 generation,bytes32 sourceCommitment,bytes32 actorCommitment)"),
+    KEYSTORE_ADDRESS, source, generation, commitment, actor_commitment
+))
+```
+
+`adminAuth` is an ordinary `sigType || authenticator || data` message envelope over `approval_hash`. The Keystore MUST apply the existing `replaySafeHash(account, chainId, approval_hash)` domain, with `chainId` selected by the Local or Multichain `sigType`, and authenticate the signer exclusively against the account's onchain configuration. It MUST require the signer's configured authenticator to match, its expiry to be live, and its scope to be zero. A checkpointed wrapper is invalid in `adminAuth`; neither the actor source nor a checkpoint witness can supply the approver's authority. The Keystore MUST perform this check itself, independently of `resolveActor`.
+
+The approval binds the account, chain domain, source registration, and all permissions of the leaf. An approval of one leaf cannot authorize another leaf, extend its expiry, replace its authenticator, or change its policy. Approving a root only inside an opaque source proof is insufficient: without independently checking membership against that approved root, the Keystore could not prevent a malicious source from returning a different actor. This extension therefore co-authorizes leaves directly while keeping source proof formats modular.
+
+An unchanged leaf approval MAY be reused across transactions and source root updates within the same generation; the admin need not sign each transaction. The Keystore MUST recheck the onchain admin's authority on every use. Revoking, expiring, or changing that admin can invalidate these witness-carried approvals, unlike an ordinary actor grant already installed onchain. Source replacement, leaf expiry, and onchain actor overrides or revocation markers remain independently enforced.
+
+These approvals are message authorizations, not account-change batches: `IncrementLocalEpoch` does not revoke them. Restoring an admin can make its prior approvals valid again if their source generation, leaf configuration, and other validity conditions still hold.
+
+Issuing or broadening a leaf requires an available admin signer; the source cannot create additional authority unattended. Each leaf needs its own approval, adding signature data and verification work, but unrelated root updates do not require that leaf to be re-signed.
 
 ##### Checkpointed Authorization
 
@@ -191,7 +216,7 @@ The previously invalid zero authenticator selector introduces a checkpointed wra
 
 ```text
 address(0) (20 bytes) || leaf_authenticator (20 bytes) ||
-abi.encode(bytes32 actorId, uint64 generation, bytes sourceProof, bytes authenticatorData)
+abi.encode(bytes32 actorId, uint64 generation, bytes sourceProof, bytes authenticatorData, bytes adminAuth)
 ```
 
 The ABI encoding MUST be canonical with no trailing bytes. `leaf_authenticator` MUST be nonzero and is the effective authenticator for acceptance, signature verification, and gas accounting; the zero selector is never called as a contract. This wrapper is permitted wherever a configured actor's `authenticator || data` authorization is accepted, including `sender_auth`, `payer_auth`, and Keystore signature verification. It is invalid for the empty-sender EOA path and for admin authorization. In a `validateSignature` envelope the existing `sigType` still precedes the complete wrapper. Ordinary authorization bytes are unchanged.
@@ -200,10 +225,11 @@ For the wrapper, replace onchain actor resolution with the following steps, agai
 
 1. Require an enabled source, the stored generation to match the wrapper, and the account to be unlocked. Reject the self-actorId, an existing onchain actor record, or a set revocation marker.
 2. Resolve the actor through `IActorSource` and require its authenticator to equal `leaf_authenticator`.
-3. Authenticate the unchanged transaction or message digest with `leaf_authenticator.authenticate(hash, authenticatorData)`, or the existing native k1 equivalent. Require the returned identity to equal the witnessed `actorId`.
-4. Apply the existing expiry and context-specific scope checks to this individual actor. For a transaction, retain its effective configuration for execution; do not resolve it again after account changes or calls.
+3. Verify `adminAuth` over the full resolved actor as specified in [Onchain Admin Co-Authorization](#onchain-admin-co-authorization), using only onchain admin configuration.
+4. Authenticate the unchanged transaction or message digest with `leaf_authenticator.authenticate(hash, authenticatorData)`, or the existing native k1 equivalent. Require the returned identity to equal the witnessed `actorId`.
+5. Apply the existing expiry and context-specific scope checks to this individual actor. For a transaction, retain its effective configuration for execution; do not resolve it again after account changes or calls.
 
-Checkpointed authorizations are invalid while the account is locked, including message verification and payer authentication. Onchain authentication and the existing lock/unlock lifecycle remain unchanged. Disabling, replacing, or advancing a source, adding an onchain override, revoking an actor, or locking the account can invalidate pending checkpointed authorizations; nodes MUST revalidate affected transactions against inclusion state and track any additional mutable state read by the source.
+Checkpointed authorizations are invalid while the account is locked, including message verification and payer authentication. Onchain authentication and the existing lock/unlock lifecycle remain unchanged. Disabling, replacing, or advancing a source, adding an onchain override, revoking an actor, changing an approving admin, or locking the account can invalidate pending checkpointed authorizations; nodes MUST revalidate affected transactions against inclusion state and track any additional mutable state read by the source or either authenticator.
 
 ##### Policies, Signatures, and Gas
 
@@ -213,7 +239,7 @@ The Keystore additionally exposes `authenticateActorWithConfig(account, hash, au
 
 Checkpointing introduces no login grant and does not expand the default [ERC-1271](./eip-1271.md) operational predicate. A key used both for website login and restricted transactions needs explicit message-policy validation of the permitted domain and message type, independently of its transaction policy. Its committed expiry applies to both authentication paths. Expiration rejects new authentication without removing the leaf or updating the root; an existing website session needs its own expiry or revalidation policy.
 
-On a permissive transaction path, source verification is metered EVM execution. The complete checkpointed authentication cost, including wrapper decoding, state reads, source verification, and leaf authentication, MUST fit within `MAX_AUTHENTICATION_GAS` for each sender or payer authorization. These costs replace that authorization's existing authentication-execution component; the wrapper's bytes are charged once through the existing payload rules. Source-state and revocation-marker writes use the existing `account_changes_cost` storage-write schedule. A canonical-only transaction path accepts the wrapper only when both the source and leaf authenticator are enshrined by the chain at consensus-defined fixed validation costs; source registration alone does not confer transaction-path acceptance.
+On a permissive transaction path, source verification is metered EVM execution. The complete checkpointed authentication cost, including wrapper decoding, state reads, source verification, admin approval verification, and leaf authentication, MUST fit within `MAX_AUTHENTICATION_GAS` for each sender or payer authorization. These costs replace that authorization's existing authentication-execution component; the wrapper's bytes are charged once through the existing payload rules. Source-state and revocation-marker writes use the existing `account_changes_cost` storage-write schedule. A canonical-only transaction path accepts the wrapper only when the source, admin authenticator, and leaf authenticator are enshrined by the chain at consensus-defined fixed validation costs; source registration alone does not confer transaction-path acceptance.
 
 #### Actor Scope
 
@@ -941,7 +967,7 @@ Session keys often need narrow authority: only this token, only this much per da
 
 Keeping admins onchain preserves ordinary account creation, import, recovery, and configuration changes. An optional source makes offchain grants reversible and allows them to coexist with stored actors. The source verifies configuration proofs, authenticators verify signatures, and the Keystore applies individual actor permissions; a root does not collapse its leaves into one actor identity. Proof systems can evolve independently behind the source interface without standardizing their tree encoding or update history in the core protocol.
 
-A wallet can issue a separate key for each of ten websites visited on different days, commit each key's seven-day expiry and transaction policy, and use different authenticators for different leaves. An expiry takes effect without a root update. Adding another key needs authorization under the source's rules but no individual onchain actor slot. Website login still needs a message policy distinct from transaction permissions. Disabling the source leaves onchain admins available to install a replacement or register individual actors directly.
+A wallet can issue a separate key for each of ten websites visited on different days, have an onchain admin co-sign each key's seven-day expiry and transaction policy offchain, and use different authenticators for different leaves. An expiry takes effect without a root update. Adding another key needs both admin approval and source acceptance but no individual onchain actor slot or onchain approval transaction. Website login still needs a message policy distinct from transaction permissions. Disabling the source leaves onchain admins available to install a replacement or register individual actors directly.
 
 Onchain precedence and revocation markers make hybrid authority deterministic even when the offchain service is delayed. Explicit release is needed to delegate a previously overridden actor back to the source. Rejecting checkpointed authentication while locked avoids relying on an external service to freeze its state. The tradeoff is that source-enabled accounts retain revocation markers and cannot use their checkpointed actors during a lock.
 
@@ -1168,7 +1194,7 @@ All three cases resolve to the same `replay_id` (fee bumps included, since `repl
 
 **Actor Management**: Config change authorization requires the authorizing actor be admin (`scope == 0x00`). The EOA actor is implicitly authorized with unrestricted (admin) scope; revocable via portable config change. All actor modification paths are blocked when the account is locked.
 
-**Actor Source Authority**: An actor source verifies configuration authority in addition to membership and freshness. A source that can attest arbitrary configurations controls the account's offchain non-admin grants. Keeping admins onchain protects administrative configuration but does not limit spending if the source can grant ungated operational authority. Source code, upgrade authority, and any permission ceiling enforced by its committed configuration are therefore part of the account's trust model.
+**Actor Source Authority**: Source acceptance and onchain admin approval are both required. Independent verification of the complete leaf prevents a compromised source from inventing actors or expanding permissions beyond an admin's signed grant. The source still controls availability and freshness within the set of approved leaves: it can withhold a leaf or re-present a still-approved leaf unless expiry, source rules, or an onchain revocation prevents it. Co-authorization does not prove that a snapshot is the latest. Source code and upgrade authority remain part of this narrower trust model.
 
 **Source Revocation and Availability**: Generations prevent replay across source registrations, while persistent onchain markers prevent revoked keys from returning through old or new roots. `ReleaseActor` is an explicit delegation back to the source. A missing proof or unavailable source can interrupt checkpointed actors; onchain actors remain independent of it. Wallets retain the configuration data needed to produce witnesses or register replacement onchain actors. Source synchronization cannot delay an onchain override or revocation.
 


### PR DESCRIPTION
Adds an optional source of checkpointed non-admin actors alongside existing onchain actors. Admins remain onchain; sources can be enabled, replaced, or disabled, while the Keystore enforces each actor's identity, expiry, scope, and policy. Proof formats remain modular behind the actor-source interface.

Every checkpointed leaf requires both source acceptance and an onchain admin's signature over its complete configuration. The Keystore verifies that approval independently, so a compromised source cannot invent actors or broaden their permissions. Approvals bind the account, chain domain, Keystore, and source registration, and remain reusable across transactions and unrelated root updates. New or broader grants require a new admin approval. Freshness and availability remain source responsibilities.

Alternative to #12293 that preserves ordinary account creation and import. Includes onchain override/revocation rules and the example of separate website keys with seven-day expiries. Each leaf needs its own approval rather than one signature over the entire root.

Validation: Markdown lint, EIPW, and `git diff --check` pass. Specification change only; contract and client implementation are not included.
