### PR TITLE
Update EIP-7923: get rid of transaction-wide memory cap

### DIFF
--- a/EIPS/eip-7923.md
+++ b/EIPS/eip-7923.md
@@ -12,7 +12,7 @@ created: 2025-03-27
 
 ## Abstract
 
-This EIP replaces the quadratic memory model in the EVM with a linear, page-based costing model. Memory is virtually addressable. Page allocation is included in the cost model. After applying this EIP, memory limits are invariant to the state of the message call stack.
+This EIP replaces the quadratic memory model in the EVM with a linear, page-based costing model. Memory is virtually addressable. Page allocation is included in the cost model. The amount of memory a message call may allocate is bounded by the gas it was given, and the gas a message call can forward to a child is reduced by the memory it has allocated. Together these rules bound the total memory of a transaction to `BYTES_PER_GAS` bytes per unit of gas, i.e. 64 MiB for a transaction with the maximum gas limit of 2^24 ([EIP-7825](./eip-7825.md)).
 
 ## Motivation
 
@@ -43,20 +43,50 @@ Consider the following constants:
 ```python
 ALLOCATE_PAGE_COST = 100
 PAGE_SIZE = 4096
-MAXIMUM_MEMORY_SIZE = 64 * 1024 * 1024
+BYTES_PER_GAS = 4
+GAS_PER_PAGE = PAGE_SIZE // BYTES_PER_GAS  # 1024
 ```
+
+Each message call frame (including the top-level frame of a transaction and the initcode frame of `CREATE`/`CREATE2`) tracks:
+
+- `initial_gas`: the gas available to the frame at the start of its execution.
+- `pages`: the set of pages touched by the frame so far. Page 0 (addresses `0..PAGE_SIZE-1`) is included in this set as soon as it is touched. `len(pages)` is referred to as `allocated_pages`.
+
+### Memory costing
 
 The memory costing algorithm is changed as follows:
 
-1. For each page touched by an instruction, charge `ALLOCATE_PAGE_COST` gas if it has not been touched before in this message call, except for page 0 which is free.
+1. For each page touched by an instruction, if it is not yet in `pages`:
+   1. If `len(pages) + 1 > 1 + initial_gas // GAS_PER_PAGE`, raise an exceptional halt (out of memory).
+   2. Otherwise, add the page to `pages` and charge `ALLOCATE_PAGE_COST` gas, except for page 0, for which no gas is charged.
 2. The base gas cost for all memory instructions, e.g. `MLOAD` and `MSTORE`, remains the same, at 3.
 3. The linear and quadratic terms in the memory expansion cost are removed.
+
+In other words, a frame may allocate at most `1 + initial_gas // GAS_PER_PAGE` pages: one page (page 0) that is exempt from both the gas charge and the gas-based limit, plus one page per `GAS_PER_PAGE` gas the frame was started with.
 
 The behavior of `msize` remains the same. It returns the maximum byte touched by any memory instruction, rounded up by 32.
 
 Memory addresses are restricted to 32-bits. If an address is larger than `2**32 - 1`, an exceptional halt should be raised.
 
-A transaction-global memory limit is imposed. If the number of pages allocated in a transaction exceeds `MAXIMUM_MEMORY_SIZE // PAGE_SIZE` (i.e., 16384), an exceptional halt should be raised.
+### Gas forwarded to child frames
+
+For every instruction that creates a child frame (`CALL`, `CALLCODE`, `DELEGATECALL`, `STATICCALL`, `CREATE`, `CREATE2`), the maximum gas that can be forwarded to the child is changed from the [EIP-150](./eip-150.md) definition:
+
+```python
+def max_call_gas(gas):
+    return gas - gas // 64
+```
+
+To:
+
+```python
+def max_call_gas(gas, allocated_pages):
+    return max(0, gas - max(gas // 64, allocated_pages * GAS_PER_PAGE))
+```
+
+where `gas` is the gas remaining in the calling frame after all other costs of the instruction have been charged, and `allocated_pages` is `len(pages)` of the calling frame at the time of the call. The gas stipend for value-transferring calls (`2300`) is added to the forwarded gas as before.
+
+The transaction-global memory limit of earlier drafts of this EIP is removed.
 
 ## Rationale
 
@@ -77,9 +107,55 @@ These suggest the following prices:
 
 Note that the cost to execute `mmap` (~11 gas) is already well-paid for by the base cost of the CALL series of instructions (100 gas). For the same reason, page 0 is free, since the CALL overhead already pays for the initial page allocation. This also improves backwards compatibility, since it keeps the cost for any access within the first page either the same as or lower than current pricing.
 
-There is a desire among client implementations to be able to enforce global limits separately from the gas limit due to DoS reasons. For example, RPC providers may be designed to allow many concurrent `eth_call` computations with a much higher gas limit than on mainnet. Not implicitly tying the memory limit to the gas limit results in one less vector for misconfiguration. That is not to say that in the future, a clean formula cannot be created which allows the memory limit to scale with future hardware improvements (e.g., proportional to the sqrt of the gas limit), but to limit the scope of things that need to be reasoned about for this EIP, the hard limit is introduced.
+### Bounding memory by gas instead of by a hard limit
 
-The hard limit is specified as a transaction-global limit rather than a message-call limit. That is, a reasonable alternative could be to limit the number of pages that can be allocated in a given message call, e.g., to 2MB, but it doesn't significantly improve implementation complexity.
+Earlier drafts of this EIP imposed a transaction-global hard limit of 64 MiB on allocated pages. A transaction-global counter has an undesirable property: a parent frame can allocate pages it does not need in order to exhaust the counter, so that a child frame fails on its first memory access even though it was given ample gas. The child has no way to detect this from its own state, since its memory allowance depends on what its ancestors did rather than on the gas it received.
+
+This EIP instead adopts the mechanism of [EIP-7686](./eip-7686.md): a frame's memory allowance is a function of its own `initial_gas`, and the memory a frame allocates is deducted from the gas it can forward to children. A child can always compute its allowance from `GAS` alone, and a parent that allocates garbage pays for it out of its own ability to make calls, not out of the child's allowance.
+
+`BYTES_PER_GAS = 4` is chosen so that the memory target of earlier drafts is preserved: with the transaction gas limit of `2**24` ([EIP-7825](./eip-7825.md)), `4 * 2**24 = 64 MiB`. `GAS_PER_PAGE = PAGE_SIZE // BYTES_PER_GAS = 1024` is the amount of gas one page "reserves" from the forwardable gas. Note that this reservation is not a price: allocating a page still costs `ALLOCATE_PAGE_COST = 100` gas. Setting the price itself to `1024` would bound memory without any change to the call rules, but would make 64 MiB cost the entire transaction gas limit. The reservation only affects how much gas can be forwarded, so a frame that allocates a lot of memory and does not make calls pays nothing extra.
+
+### The bound holds for the entire call depth
+
+Claim: a frame started with `N` gas, together with all frames nested below it, holds at most `BYTES_PER_GAS * N + PAGE_SIZE` bytes of live memory at any time.
+
+Proof by induction on the call depth. Let the frame have allocated `P` pages when it makes a call (pages are never freed within a frame, so `P` is monotonic and at the time of the call all `P` pages are live).
+
+- By the allocation rule, `P <= 1 + N // GAS_PER_PAGE`, so the frame's own memory is `PAGE_SIZE * P <= BYTES_PER_GAS * N + PAGE_SIZE`. A frame that makes no calls (the base case) therefore satisfies the claim.
+- The child receives at most `gas - P * GAS_PER_PAGE <= N - P * GAS_PER_PAGE` gas, since `gas <= N`. By the induction hypothesis the child's subtree holds at most `BYTES_PER_GAS * (N - P * GAS_PER_PAGE) + PAGE_SIZE = BYTES_PER_GAS * N - PAGE_SIZE * P + PAGE_SIZE` bytes.
+- The total live memory is the parent's `PAGE_SIZE * P` plus the child's subtree, which is at most `BYTES_PER_GAS * N + PAGE_SIZE`.
+
+Only nested frames are live simultaneously; the memory of a child that has returned is released before the next child is created, so sequential children do not add up. The `+ PAGE_SIZE` term is a single page for the whole transaction, not one page per frame, because page 0 is counted in `allocated_pages` for the purpose of `max_call_gas` even though it is exempt from the allocation limit and the gas charge.
+
+The gas stipend does not break the bound. A value-transferring call charges the parent `9000` gas and adds `2300` gas to the child. The stipend's memory allowance of `2300 * BYTES_PER_GAS + PAGE_SIZE = 13296` bytes is less than the `9000 * BYTES_PER_GAS = 36000` bytes of allowance the parent gave up by paying for the transfer.
+
+Applying the claim to the top-level frame of a transaction with the maximum gas limit gives `4 * 2**24 + 4096` bytes, i.e. 64 MiB plus one page.
+
+### Page 0
+
+Page 0 is treated specially in two ways:
+
+1. It is free: touching it does not charge `ALLOCATE_PAGE_COST`. The `CALL` overhead already pays for the initial page allocation, and this keeps the cost for any access within the first page the same as or lower than current pricing.
+2. It is exempt from the gas-based allocation limit. Without this exemption, a frame started with less than `GAS_PER_PAGE = 1024` gas could not touch memory at all, whereas today such a frame can `MSTORE` at offset 0 for 6 gas.
+
+Page 0 is, however, counted in `allocated_pages` when computing `max_call_gas`. This is what keeps the slack in the memory bound to a single page across the whole call stack rather than one page per frame (up to 4 MiB at the call depth limit of 1024).
+
+### Effect on the first frame
+
+The gas-based limit does not constrain the top-level frame in practice. Under the current quadratic model, a frame that spends its entire `2**24` gas on memory expansion reaches about 2.8 MiB; allocating 2 MiB alone costs 8,585,216 gas. Under this EIP the top-level frame of a transaction with the maximum gas limit may allocate `1 + 2**24 // 1024 = 16385` pages, or 64 MiB, for 1,638,400 gas.
+
+| Frame `initial_gas` | Max memory today (quadratic) | Max memory under this EIP |
+| --- | --- | --- |
+| 2,300 (stipend) | 17.5 KiB | 12 KiB (3 pages) |
+| 10,000 | 50.7 KiB | 40 KiB (10 pages) |
+| 30,000 | 100.8 KiB | 120 KiB (30 pages) |
+| 100,000 | 200.9 KiB | 392 KiB (98 pages) |
+| 1,000,000 | 683.5 KiB | 3.8 MiB (977 pages) |
+| 16,777,216 | 2.8 MiB | 64 MiB (16385 pages) |
+
+The 63/64 rule is retained so that the de-facto call depth limit is unchanged. Note that the memory term dominates `max_call_gas` as soon as `allocated_pages * GAS_PER_PAGE > gas // 64`, which for a frame with 1,000,000 gas remaining happens above 15 pages (60 KiB).
+
+RPC providers that allow `eth_call` with gas limits far above `2**24` should note that the memory bound scales linearly with the gas limit, and may wish to enforce a separate client-side memory cap for such calls. Such a cap cannot be reached by a valid mainnet transaction and therefore does not reintroduce the griefing vector described above.
 
 On keeping the semantics of `MSIZE` the same:
 With users expected to use the full address space instead of growing it linearly, the rationale for keeping `MSIZE` semantics the same is to avoid breaking backwards compatibility with existing contracts which expect it to grow linearly. New contracts taking advantage of the new virtual addressing scheme should not rely on `MSIZE` for memory allocation.
@@ -88,242 +164,56 @@ A hard limit of `2**32` bytes was imposed on the addressing. This makes it simpl
 
 ## Backwards Compatibility
 
-Addressed in Security Considerations section. No backwards compatibility is broken, although some contracts that previously ran out of gas may now successfully complete.
+Some contracts that previously ran out of gas may now successfully complete, since memory is much cheaper.
+
+Conversely, the gas-based allocation limit can cause a frame to fail that would succeed today, if it touches a high memory offset while having been given little gas. As shown in the table in the Rationale, this can only happen for frames started with between roughly 400 and 18,500 gas; above that, this EIP always allows more memory than the quadratic model. A frame with 2,300 gas (the value-transfer stipend) may touch 12 KiB of memory, which is more than such a frame could fill with `MSTORE` in the remaining gas anyway. Contracts that touch memory beyond 12 KiB while having been forwarded less than about 18,500 gas would be affected. This is expected to be rare: any frame that performs a state change must have at least 5,000 gas, and the memory layouts of high-level languages stay well below these sizes in frames with so little gas. A survey of mainnet traces to confirm this is recommended before this EIP is scheduled for inclusion.
+
+The reduction of forwardable gas by `allocated_pages * GAS_PER_PAGE` means that a frame which has allocated memory can forward less gas to a child than under EIP-150 alone. Contracts that forward "all remaining gas" via the 63/64 rule and rely on the child receiving a specific amount could observe a lower amount if the parent has allocated more than `gas // (64 * GAS_PER_PAGE)` pages.
 
 ## Test Cases
 
 ## Reference Implementation
 
-A ~60-line reference implementation is provided below. It is implemented as a patch against the `py-evm` codebase at commit ethereum/py-evm@fec63b8c4b9dad9fcb1022c48c863bdd584820c6. (This is a reference implementation, it does not, for example, contain fork choice rules).
+The following pseudocode describes the per-frame memory costing and the change to the gas forwarded to child frames. It is not tied to a particular client.
 
-```diff
-diff --git a/eth/vm/computation.py b/eth/vm/computation.py
-index bf34fbee..db85aee7 100644
---- a/eth/vm/computation.py
-+++ b/eth/vm/computation.py
-@@ -454,34 +454,40 @@ class BaseComputation(ComputationAPI, Configurable):
-         validate_uint256(start_position, title="Memory start position")
-         validate_uint256(size, title="Memory size")
-
--        before_size = ceil32(len(self._memory))
--        after_size = ceil32(start_position + size)
--
--        before_cost = memory_gas_cost(before_size)
--        after_cost = memory_gas_cost(after_size)
--
--        if self.logger.show_debug2:
--            self.logger.debug2(
--                f"MEMORY: size ({before_size} -> {after_size}) | "
--                f"cost ({before_cost} -> {after_cost})"
--            )
--
--        if size:
--            if before_cost < after_cost:
--                gas_fee = after_cost - before_cost
--                self._gas_meter.consume_gas(
--                    gas_fee,
--                    reason=" ".join(
--                        (
--                            "Expanding memory",
--                            str(before_size),
--                            "->",
--                            str(after_size),
--                        )
--                    ),
--                )
--
--            self._memory.extend(start_position, size)
-+        if size == 0:
-+            return
-+
-+        ALLOCATE_PAGE_COST = 100
-+        LOWER_BITS = 12  # bits ignored for page calculations
-+        PAGE_SIZE = 4096
-+        assert 2**LOWER_BITS == PAGE_SIZE   # sanity check
-+        MAXIMUM_MEMORY_SIZE = 64 * 1024 * 1024
-+        TRANSACTION_MAX_PAGES = MAXIMUM_MEMORY_SIZE // PAGE_SIZE
-+
-+        end_position = start_position + size - 1
-+
-+        start_page = start_position >> LOWER_BITS
-+        end_page = end_position >> LOWER_BITS
-+
-+        for page in range(start_page, end_page + 1):
-+            if page not in self._memory.pages:
-+                if self.transaction_context.num_pages >= TRANSACTION_MAX_PAGES:
-+                    raise VMError("Out Of Memory")
-+                self.transaction_context.num_pages += 1
-+
-+                reason = f"Allocating page {hex(page << LOWER_BITS)}"
-+                self._gas_meter.consume_gas(ALLOCATE_PAGE_COST, reason)
-+                self._memory.pages[page] = True
-
-     def memory_write(self, start_position: int, size: int, value: bytes) -> None:
-         return self._memory.write(start_position, size, value)
-diff --git a/eth/vm/forks/frontier/computation.py b/eth/vm/forks/frontier/computation.py
-index 51666ae0..443f82b5 100644
---- a/eth/vm/forks/frontier/computation.py
-+++ b/eth/vm/forks/frontier/computation.py
-@@ -29,6 +29,7 @@ from eth.exceptions import (
-     InsufficientFunds,
-     OutOfGas,
-     StackDepthLimit,
-+    VMError,
- )
- from eth.vm.computation import (
-     BaseComputation,
-@@ -87,12 +88,21 @@ class FrontierComputation(BaseComputation):
-
-         state.touch_account(message.storage_address)
-
--        computation = cls.apply_computation(
--            state,
--            message,
--            transaction_context,
--            parent_computation=parent_computation,
--        )
-+        # implement transaction-global memory limit
-+        num_pages_anchor = transaction_context.num_pages
-+        try:
-+            computation = cls.apply_computation(
-+                state,
-+                message,
-+                transaction_context,
-+                parent_computation=parent_computation,
-+            )
-+        finally:
-+            # "deallocate" all the pages allocated in the child computation
-+
-+            # sanity check an invariant:
-+            allocated_pages = len(computation._memory.pages)
-+            assert transaction_context.num_pages == num_pages_anchor + allocated pages
-+            transaction_context.num_pages = num_pages_anchor
-
-         if computation.is_error:
-             state.revert(snapshot)
-diff --git a/eth/vm/logic/memory.py b/eth/vm/logic/memory.py
-index 806dbd8b..247b3c74 100644
---- a/eth/vm/logic/memory.py
-+++ b/eth/vm/logic/memory.py
-@@ -43,7 +43,7 @@ def mload(computation: ComputationAPI) -> None:
+```python
+ALLOCATE_PAGE_COST = 100
+PAGE_SIZE = 4096
+BYTES_PER_GAS = 4
+GAS_PER_PAGE = PAGE_SIZE // BYTES_PER_GAS  # 1024
+LOWER_BITS = 12  # log2(PAGE_SIZE)
 
 
- def msize(computation: ComputationAPI) -> None:
--    computation.stack_push_int(len(computation._memory))
-+    computation.stack_push_int(computation._memory.msize)
+class Frame:
+    def __init__(self, initial_gas):
+        self.initial_gas = initial_gas
+        self.gas = initial_gas
+        self.pages = set()
+        self.max_pages = 1 + initial_gas // GAS_PER_PAGE
 
+    def touch_memory(self, start, size):
+        if size == 0:
+            return
+        end = start + size - 1
+        if end > 2**32 - 1:
+            raise ExceptionalHalt("address out of range")
+        for page in range(start >> LOWER_BITS, (end >> LOWER_BITS) + 1):
+            if page in self.pages:
+                continue
+            if len(self.pages) + 1 > self.max_pages:
+                raise ExceptionalHalt("out of memory")
+            self.pages.add(page)
+            if page != 0:
+                self.consume_gas(ALLOCATE_PAGE_COST)
 
- def mcopy(computation: ComputationAPI) -> None:
-diff --git a/eth/vm/memory.py b/eth/vm/memory.py
-index 2ccfd090..9002b559 100644
---- a/eth/vm/memory.py
-+++ b/eth/vm/memory.py
-@@ -1,8 +1,11 @@
- import logging
-
-+import mmap
-+
- from eth._utils.numeric import (
-     ceil32,
- )
-+from eth.exceptions import VMError
- from eth.abc import (
-     MemoryAPI,
- )
-@@ -13,52 +16,48 @@ from eth.validation import (
-     validate_uint256,
- )
-
- class Memory(MemoryAPI):
--    __slots__ = ["_bytes"]
-+    __slots__ = ("pages", "msize")
-     logger = logging.getLogger("eth.vm.memory.Memory")
-
-     def __init__(self) -> None:
--        self._bytes = bytearray()
-+        self.memview = mmap.mmap(-1, 2**32, flags=mmap.MAP_PRIVATE | mmap.MAP_ANONYMOUS)
-+        self.pages = {0: True}  # page 0 is free (per spec)
-+        self.msize = 0
-
-     def extend(self, start_position: int, size: int) -> None:
-         if size == 0:
-             return
-
--        new_size = ceil32(start_position + size)
--        if new_size <= len(self):
-+        if start_position + size > self.msize:
-+            self.msize = ceil32(start_position + size)
-+
-+    def write(self, start_position: int, size: int, value: bytes) -> None:
-+        if size == 0:
-             return
-
--        size_to_extend = new_size - len(self)
--        try:
--            self._bytes.extend(bytearray(size_to_extend))
--        except BufferError:
--            # we can't extend the buffer (which might involve relocating it) if a
--            # memoryview (which stores a pointer into the buffer) has been created by
--            # read() and not released. Callers of read() will never try to write to the
--            # buffer so we're not missing anything by making a new buffer and forgetting
--            # about the old one. We're keeping too much memory around but this is still
--            # a net savings over having read() return a new bytes() object every time.
--            self._bytes = self._bytes + bytearray(size_to_extend)
--
--    def __len__(self) -> int:
--        return len(self._bytes)
-+        if start_position + size >= 2**32:
-+            raise VMError("Non 32-bit address")
-
--    def write(self, start_position: int, size: int, value: bytes) -> None:
--        if size:
--            validate_uint256(start_position)
--            validate_uint256(size)
--            validate_is_bytes(value)
--            validate_length(value, length=size)
--            validate_lte(start_position + size, maximum=len(self))
-+        validate_uint256(start_position)
-+        validate_uint256(size)
-+        validate_is_bytes(value)
-+        validate_length(value, length=size)
-+
-+        end_position = start_position + size
-
--            self._bytes[start_position : start_position + len(value)] = value
-+        self.memview[start_position : end_position] = value
-
-+    # unused
-     def read(self, start_position: int, size: int) -> memoryview:
--        return memoryview(self._bytes)[start_position : start_position + size]
-+        return memoryview(self.memview)[start_position : start_position + size]
-
-     def read_bytes(self, start_position: int, size: int) -> bytes:
--        return bytes(self._bytes[start_position : start_position + size])
-+        return bytes(self.memview[start_position : start_position + size])
-
-     def copy(self, destination: int, source: int, length: int) -> None:
-         if length == 0:
-@@ -69,5 +68,5 @@ class Memory(MemoryAPI):
-         validate_uint256(length)
-         validate_lte(max(destination, source) + length, maximum=len(self))
-
--        buf = memoryview(self._bytes)
-+        buf = memoryview(self.memview)
-         buf[destination : destination + length] = buf[source : source + length]
-diff --git a/eth/vm/transaction_context.py b/eth/vm/transaction_context.py
-index 79b570e9..5943f897 100644
---- a/eth/vm/transaction_context.py
-+++ b/eth/vm/transaction_context.py
-@@ -36,6 +36,9 @@ class BaseTransactionContext(TransactionContextAPI):
-         # post-cancun
-         self._blob_versioned_hashes = blob_versioned_hashes or []
-
-+        # eip-7923
-+        self.num_pages = 0
-+
-     def get_next_log_counter(self) -> int:
-         return next(self._log_counter)
+    def max_call_gas(self):
+        # `self.gas` is the remaining gas after all other costs of the
+        # call instruction have been charged.
+        reserved = max(self.gas // 64, len(self.pages) * GAS_PER_PAGE)
+        return max(0, self.gas - reserved)
 ```
+
+The set `pages` is only used for costing. The memory contents themselves can be held in a `2**32` byte anonymous `mmap` region, as described in the Motivation, or in a `map[page_id -> char[PAGE_SIZE]]` for systems without virtual memory facilities.
 
 ## Security Considerations
 
@@ -331,11 +221,15 @@ There are two primary security considerations regarding this EIP.
 
 One, does it break existing contracts? That is, do existing contracts depend on memory being restricted?
 
-Outside of gas costing, existing contracts may simply execute to completion rather than running out of gas.
+Outside of gas costing, existing contracts may simply execute to completion rather than running out of gas. The one exception is frames with very little gas that touch high memory offsets; see Backwards Compatibility.
 
 Two, does this enable memory-based DoS attacks against clients?
 
-This requires a maximum-memory usage analysis. Based on a gas limit today of 30mm gas, recursively calling a contract that allocates 256KB of memory in each call stack can allocate 54MB of total memory, which is not substantially different than the 64MB limit proposed in this EIP. Note that the transaction-global memory limit proposed in this EIP provides a useful invariant, which is that future changes to call stack limits will not affect the total amount of memory that can be allocated in a given transaction.
+This requires a maximum-memory usage analysis. Under the current quadratic model with the `2**24` transaction gas limit, the worst case is obtained by recursively calling a contract that spends about 2% of its gas on memory in each frame, which reaches roughly 18 MiB of live memory. Under this EIP the bound is `BYTES_PER_GAS * gas_limit + PAGE_SIZE`, i.e. 64 MiB plus one page, as proven in the Rationale. This is a modest increase over the current worst case, while the amount of memory usable by a single frame increases by more than 20x.
+
+Two properties of the bound are worth noting. First, it is tight: a single top-level frame can allocate 64 MiB directly, so there is no hidden slack that a more complex call pattern could exploit. Second, it does not depend on the call depth limit or on the 63/64 rule; future changes to either do not affect the total amount of memory a transaction can allocate. It does depend on the transaction gas limit of [EIP-7825](./eip-7825.md); raising that limit raises the memory bound proportionally.
+
+Note that a per-frame limit of `BYTES_PER_GAS` bytes per gas alone, without the change to `max_call_gas`, would not be sufficient. Since each frame can forward 63/64 of its gas, the allowances across the call stack sum to roughly 64 times the per-frame allowance; a greedy allocation at every level reaches over 570 MiB. The deduction of allocated memory from the forwardable gas is what makes the bound linear.
 
 ## Copyright
 

--- a/EIPS/eip-7923.md
+++ b/EIPS/eip-7923.md
@@ -12,7 +12,7 @@ created: 2025-03-27
 
 ## Abstract
 
-This EIP replaces the quadratic memory model in the EVM with a linear, page-based costing model. Memory is virtually addressable. Page allocation is included in the cost model. The amount of memory a message call may allocate is bounded by the gas it was given, and the gas a message call can forward to a child is reduced by the memory it has allocated. Together these rules bound the total memory of a transaction to `BYTES_PER_GAS` bytes per unit of gas, i.e. 64 MiB for a transaction with the maximum gas limit of 2^24 ([EIP-7825](./eip-7825.md)).
+This EIP replaces the quadratic memory model in the EVM with a linear, page-based costing model. Memory is virtually addressable. Page allocation is included in the cost model. The amount of memory a message call may allocate is bounded by the gas it was given, and the gas a message call can forward to a child is reduced by the memory it has allocated. Together these rules bound the total memory of a transaction to `BYTES_PER_GAS` bytes per unit of gas plus one page per call frame, i.e. 64 MiB plus at most 4 MiB for a transaction with the maximum gas limit of 2^24 ([EIP-7825](./eip-7825.md)).
 
 ## Motivation
 
@@ -49,20 +49,24 @@ GAS_PER_PAGE = PAGE_SIZE // BYTES_PER_GAS  # 1024
 
 Each message call frame (including the top-level frame of a transaction and the initcode frame of `CREATE`/`CREATE2`) tracks:
 
-- `initial_gas`: the gas available to the frame at the start of its execution.
-- `pages`: the set of pages touched by the frame so far. Page 0 (addresses `0..PAGE_SIZE-1`) is included in this set as soon as it is touched. `len(pages)` is referred to as `allocated_pages`.
+- `initial_gas`: the gas available to the frame at the start of its execution. For the top-level frame of a transaction this is the transaction gas limit minus the intrinsic gas. For a child frame it is `child_initial_gas` as defined below.
+- `pages`: the set of pages touched by the frame so far. A page is identified by `address >> 12`. Page 0 (addresses `0..PAGE_SIZE-1`) is tracked in this set but is exempt from all accounting below.
+- `allocated_pages`: the number of pages in `pages` other than page 0.
+
+A new frame starts with an empty `pages` set.
 
 ### Memory costing
 
 The memory costing algorithm is changed as follows:
 
 1. For each page touched by an instruction, if it is not yet in `pages`:
-   1. If `len(pages) + 1 > 1 + initial_gas // GAS_PER_PAGE`, raise an exceptional halt (out of memory).
-   2. Otherwise, add the page to `pages` and charge `ALLOCATE_PAGE_COST` gas, except for page 0, for which no gas is charged.
+   1. If the page is page 0, add it to `pages` and charge nothing.
+   2. Otherwise, if `(allocated_pages + 1) * GAS_PER_PAGE > initial_gas`, raise an exceptional halt. All remaining gas of the frame is consumed, as for any other exceptional halt.
+   3. Otherwise, add the page to `pages`, increment `allocated_pages`, and charge `ALLOCATE_PAGE_COST` gas.
 2. The base gas cost for all memory instructions, e.g. `MLOAD` and `MSTORE`, remains the same, at 3.
 3. The linear and quadratic terms in the memory expansion cost are removed.
 
-In other words, a frame may allocate at most `1 + initial_gas // GAS_PER_PAGE` pages: one page (page 0) that is exempt from both the gas charge and the gas-based limit, plus one page per `GAS_PER_PAGE` gas the frame was started with.
+In other words, a frame may allocate page 0 plus at most `initial_gas // GAS_PER_PAGE` further pages, i.e. `BYTES_PER_GAS` bytes per unit of gas it was started with.
 
 The behavior of `msize` remains the same. It returns the maximum byte touched by any memory instruction, rounded up by 32.
 
@@ -70,21 +74,24 @@ Memory addresses are restricted to 32-bits. If an address is larger than `2**32 
 
 ### Gas forwarded to child frames
 
-For every instruction that creates a child frame (`CALL`, `CALLCODE`, `DELEGATECALL`, `STATICCALL`, `CREATE`, `CREATE2`), the maximum gas that can be forwarded to the child is changed from the [EIP-150](./eip-150.md) definition:
+For every instruction that creates a child frame (`CALL`, `CALLCODE`, `DELEGATECALL`, `STATICCALL`, `CREATE`, `CREATE2`), the gas given to the child is currently determined by [EIP-150](./eip-150.md) as:
 
 ```python
-def max_call_gas(gas):
-    return gas - gas // 64
+forwarded_gas = min(requested_gas, gas - gas // 64)
+child_initial_gas = forwarded_gas + stipend
 ```
 
-To:
+where `gas` is the gas remaining in the calling frame after all other costs of the instruction have been charged, `requested_gas` is the gas argument of the instruction (for `CREATE` and `CREATE2` it is unbounded), and `stipend` is `2300` for value-transferring `CALL` and `CALLCODE` and `0` otherwise.
+
+This is changed to:
 
 ```python
-def max_call_gas(gas, allocated_pages):
-    return max(0, gas - max(gas // 64, allocated_pages * GAS_PER_PAGE))
+memory_budget = initial_gas - allocated_pages * GAS_PER_PAGE
+forwarded_gas = min(requested_gas, gas - gas // 64, memory_budget)
+child_initial_gas = min(forwarded_gas + stipend, memory_budget)
 ```
 
-where `gas` is the gas remaining in the calling frame after all other costs of the instruction have been charged, and `allocated_pages` is `len(pages)` of the calling frame at the time of the call. The gas stipend for value-transferring calls (`2300`) is added to the forwarded gas as before.
+where `initial_gas` and `allocated_pages` are those of the calling frame at the time of the call. `memory_budget` is never negative, since the memory costing rule guarantees `allocated_pages * GAS_PER_PAGE <= initial_gas`. The gas deducted from the calling frame is `forwarded_gas`, as before; the stipend is not deducted from the caller.
 
 The transaction-global memory limit of earlier drafts of this EIP is removed.
 
@@ -113,32 +120,37 @@ Earlier drafts of this EIP imposed a transaction-global hard limit of 64 MiB on 
 
 This EIP instead adopts the mechanism of [EIP-7686](./eip-7686.md): a frame's memory allowance is a function of its own `initial_gas`, and the memory a frame allocates is deducted from the gas it can forward to children. A child can always compute its allowance from `GAS` alone, and a parent that allocates garbage pays for it out of its own ability to make calls, not out of the child's allowance.
 
-`BYTES_PER_GAS = 4` is chosen so that the memory target of earlier drafts is preserved: with the transaction gas limit of `2**24` ([EIP-7825](./eip-7825.md)), `4 * 2**24 = 64 MiB`. `GAS_PER_PAGE = PAGE_SIZE // BYTES_PER_GAS = 1024` is the amount of gas one page "reserves" from the forwardable gas. Note that this reservation is not a price: allocating a page still costs `ALLOCATE_PAGE_COST = 100` gas. Setting the price itself to `1024` would bound memory without any change to the call rules, but would make 64 MiB cost the entire transaction gas limit. The reservation only affects how much gas can be forwarded, so a frame that allocates a lot of memory and does not make calls pays nothing extra.
+`BYTES_PER_GAS = 4` is chosen so that the memory target of earlier drafts is preserved: with the transaction gas limit of `2**24` ([EIP-7825](./eip-7825.md)), `4 * 2**24 = 64 MiB`. `GAS_PER_PAGE = PAGE_SIZE // BYTES_PER_GAS = 1024` is the amount of gas one page "reserves" from the frame's memory budget. Note that this reservation is not a price: allocating a page still costs `ALLOCATE_PAGE_COST = 100` gas. Setting the price itself to `1024` would bound memory without any change to the call rules, but would make 64 MiB cost the entire transaction gas limit. The reservation only affects how much gas can be given to a child, so a frame that allocates a lot of memory and does not make calls pays nothing extra.
+
+The memory budget is measured against `initial_gas`, not against the gas remaining at the time of the call. A frame's gas at entry represents a budget of `BYTES_PER_GAS * initial_gas` bytes that is split between the frame's own pages and the budgets of its children. Gas the frame spends on computation does not change that split; it only limits what can be forwarded through the ordinary 63/64 term. Measuring against remaining gas instead (as [EIP-7686](./eip-7686.md) does) would penalise a frame twice: a frame that has spent most of its gas on computation and holds a few pages would be unable to make any call at all, even though its memory is well within budget.
+
+The stipend is included under the budget cap. The bound below is a statement about the child's `initial_gas`, and for a value-transferring call that is the forwarded gas plus the stipend. Capping only the forwarded gas would let each value-transferring frame hand its child up to `2300 * BYTES_PER_GAS` bytes of allowance beyond its own budget; a chain of such frames can accumulate roughly 1.8 MiB above the bound at the transaction gas limit. With the cap applied after the stipend the bound is exact. The only observable difference is that a caller which has reserved almost its entire budget can give a recipient less than 2300 gas; such a caller must have allocated close to `BYTES_PER_GAS` bytes for every unit of gas it was started with, which no contract can do under the current quadratic model.
 
 ### The bound holds for the entire call depth
 
-Claim: a frame started with `N` gas, together with all frames nested below it, holds at most `BYTES_PER_GAS * N + PAGE_SIZE` bytes of live memory at any time.
+Claim: a frame started with `N` gas at call depth `d` (the top-level frame has `d = 0`), together with all frames nested below it, holds at most `BYTES_PER_GAS * N + PAGE_SIZE * (1024 - d)` bytes of live memory at any time.
 
-Proof by induction on the call depth. Let the frame have allocated `P` pages when it makes a call (pages are never freed within a frame, so `P` is monotonic and at the time of the call all `P` pages are live).
+Proof by induction on the remaining call depth. Let the frame have `P` non-zero pages allocated when it makes a call (pages are never freed within a frame, so `P` is monotonic and at the time of the call all `P` pages are live). The frame's own memory is at most `PAGE_SIZE * (P + 1)`, counting page 0.
 
-- By the allocation rule, `P <= 1 + N // GAS_PER_PAGE`, so the frame's own memory is `PAGE_SIZE * P <= BYTES_PER_GAS * N + PAGE_SIZE`. A frame that makes no calls (the base case) therefore satisfies the claim.
-- The child receives at most `gas - P * GAS_PER_PAGE <= N - P * GAS_PER_PAGE` gas, since `gas <= N`. By the induction hypothesis the child's subtree holds at most `BYTES_PER_GAS * (N - P * GAS_PER_PAGE) + PAGE_SIZE = BYTES_PER_GAS * N - PAGE_SIZE * P + PAGE_SIZE` bytes.
-- The total live memory is the parent's `PAGE_SIZE * P` plus the child's subtree, which is at most `BYTES_PER_GAS * N + PAGE_SIZE`.
+- By the memory costing rule, `P * GAS_PER_PAGE <= N`, so the frame's own memory is at most `BYTES_PER_GAS * N + PAGE_SIZE`. A frame that makes no calls, in particular a frame at depth `1023`, therefore satisfies the claim.
+- By the call rule, `child_initial_gas <= memory_budget = N - P * GAS_PER_PAGE`. This holds including the stipend, since the cap is applied after the stipend is added. By the induction hypothesis the child's subtree, at depth `d + 1`, holds at most `BYTES_PER_GAS * (N - P * GAS_PER_PAGE) + PAGE_SIZE * (1023 - d) = BYTES_PER_GAS * N - PAGE_SIZE * P + PAGE_SIZE * (1023 - d)` bytes.
+- The total live memory is the parent's `PAGE_SIZE * (P + 1)` plus the child's subtree, which is at most `BYTES_PER_GAS * N + PAGE_SIZE * (1024 - d)`.
 
-Only nested frames are live simultaneously; the memory of a child that has returned is released before the next child is created, so sequential children do not add up. The `+ PAGE_SIZE` term is a single page for the whole transaction, not one page per frame, because page 0 is counted in `allocated_pages` for the purpose of `max_call_gas` even though it is exempt from the allocation limit and the gas charge.
+Only nested frames are live simultaneously; the memory of a child that has returned is released before the next child is created, so sequential children do not add up. The proof uses only `initial_gas`, never the gas remaining at the time of the call, which is why the budget can be measured against `initial_gas` without weakening the bound.
 
-The gas stipend does not break the bound. A value-transferring call charges the parent `9000` gas and adds `2300` gas to the child. The stipend's memory allowance of `2300 * BYTES_PER_GAS + PAGE_SIZE = 13296` bytes is less than the `9000 * BYTES_PER_GAS = 36000` bytes of allowance the parent gave up by paying for the transfer.
-
-Applying the claim to the top-level frame of a transaction with the maximum gas limit gives `4 * 2**24 + 4096` bytes, i.e. 64 MiB plus one page.
+The `PAGE_SIZE` per frame of slack comes from page 0, which is exempt from the reservation. Applying the claim to the top-level frame of a transaction with the maximum gas limit gives `4 * 2**24 + 4096 * 1024` bytes, i.e. 64 MiB plus at most 4 MiB. In practice the 63/64 rule exhausts the gas of a `2**24` gas transaction at a depth of roughly 760, so about 3 MiB of the slack is reachable. The top-level frame's `initial_gas` is the gas limit minus the intrinsic gas, so the `64 MiB` term is itself slightly smaller than 64 MiB.
 
 ### Page 0
 
-Page 0 is treated specially in two ways:
+Page 0 is exempt from all three accounting rules: it is not charged `ALLOCATE_PAGE_COST`, it does not count toward the frame's page limit, and it does not reduce the frame's memory budget. Every frame starts with an empty page set; the first access to any address below `PAGE_SIZE` allocates page 0 at no cost, and every other page costs `ALLOCATE_PAGE_COST`.
 
-1. It is free: touching it does not charge `ALLOCATE_PAGE_COST`. The `CALL` overhead already pays for the initial page allocation, and this keeps the cost for any access within the first page the same as or lower than current pricing.
-2. It is exempt from the gas-based allocation limit. Without this exemption, a frame started with less than `GAS_PER_PAGE = 1024` gas could not touch memory at all, whereas today such a frame can `MSTORE` at offset 0 for 6 gas.
+The reasons are backwards compatibility and simplicity:
 
-Page 0 is, however, counted in `allocated_pages` when computing `max_call_gas`. This is what keeps the slack in the memory bound to a single page across the whole call stack rather than one page per frame (up to 4 MiB at the call depth limit of 1024).
+1. Gas. The `CALL` overhead already pays for the initial page allocation, and charging nothing keeps the cost for any access within the first page the same as or lower than current pricing.
+2. Page limit. Without the exemption, a frame started with less than `GAS_PER_PAGE = 1024` gas could not touch memory at all, whereas today such a frame can `MSTORE` at offset 0 for 6 gas.
+3. Memory budget. A frame that only touches page 0, which covers the scratch space and free-memory pointer of Solidity and Vyper and therefore the majority of small frames, must be able to forward exactly what EIP-150 allows today. Counting page 0 in the reservation would take 1024 gas of forwardable gas from every such frame, which is a breaking change for frames with little gas: a frame running on the 2300 stipend could forward only 1276 gas instead of 2168.
+
+The cost of the exemption is one page of slack per frame in the memory bound, at most 4 MiB at the call depth limit, as computed above. Counting page 0 in the reservation would reduce this to a single page for the whole transaction, but at the price of the breaking change in point 3.
 
 ### Effect on the first frame
 
@@ -153,7 +165,19 @@ The gas-based limit does not constrain the top-level frame in practice. Under th
 | 1,000,000 | 683.5 KiB | 3.8 MiB (977 pages) |
 | 16,777,216 | 2.8 MiB | 64 MiB (16385 pages) |
 
-The 63/64 rule is retained so that the de-facto call depth limit is unchanged. Note that the memory term dominates `max_call_gas` as soon as `allocated_pages * GAS_PER_PAGE > gas // 64`, which for a frame with 1,000,000 gas remaining happens above 15 pages (60 KiB).
+The 63/64 rule is retained so that the de-facto call depth limit is unchanged. The memory budget only becomes the binding term when `initial_gas - allocated_pages * GAS_PER_PAGE < gas - gas // 64`, i.e. when the frame has reserved more budget through pages than it has spent in gas (plus the 1/64). A frame that has spent more gas on computation than `GAS_PER_PAGE` times its page count never notices the memory term. For frames that do, the table below compares the gas such a frame can forward to a child today with the gas it can forward under this EIP, for a frame started with `G` gas that has spent nothing but the memory itself and holds `M` bytes:
+
+| `G` | `M` | Forwardable today | Forwardable under this EIP |
+| --- | --- | --- | --- |
+| 2,300 | 1 KiB | 2,168 | 2,265 |
+| 10,000 | 1 KiB | 9,748 | 9,844 |
+| 10,000 | 32 KiB | 4,804 | 2,132 |
+| 30,000 | 32 KiB | 24,492 | 22,132 |
+| 100,000 | 32 KiB | 93,398 | 92,132 |
+| 100,000 | 128 KiB | 54,086 | 65,156 |
+| 1,000,000 | 512 KiB | 419,895 | 857,252 |
+
+Frames that only use page 0 forward slightly more than today, since memory expansion is now free for them. Frames holding tens of KiB with less than about 100,000 gas forward somewhat less than today, because the `GAS_PER_PAGE` reservation (1024 gas per 4 KiB) is steeper than the linear term of the current model (384 gas per 4 KiB); the quadratic term of the current model only overtakes it around 100 KiB. Above that, or for frames with more gas, this EIP is strictly more permissive.
 
 RPC providers that allow `eth_call` with gas limits far above `2**24` should note that the memory bound scales linearly with the gas limit, and may wish to enforce a separate client-side memory cap for such calls. Such a cap cannot be reached by a valid mainnet transaction and therefore does not reintroduce the griefing vector described above.
 
@@ -168,7 +192,9 @@ Some contracts that previously ran out of gas may now successfully complete, sin
 
 Conversely, the gas-based allocation limit can cause a frame to fail that would succeed today, if it touches a high memory offset while having been given little gas. As shown in the table in the Rationale, this can only happen for frames started with between roughly 400 and 18,500 gas; above that, this EIP always allows more memory than the quadratic model. A frame with 2,300 gas (the value-transfer stipend) may touch 12 KiB of memory, which is more than such a frame could fill with `MSTORE` in the remaining gas anyway. Contracts that touch memory beyond 12 KiB while having been forwarded less than about 18,500 gas would be affected. This is expected to be rare: any frame that performs a state change must have at least 5,000 gas, and the memory layouts of high-level languages stay well below these sizes in frames with so little gas. A survey of mainnet traces to confirm this is recommended before this EIP is scheduled for inclusion.
 
-The reduction of forwardable gas by `allocated_pages * GAS_PER_PAGE` means that a frame which has allocated memory can forward less gas to a child than under EIP-150 alone. Contracts that forward "all remaining gas" via the 63/64 rule and rely on the child receiving a specific amount could observe a lower amount if the parent has allocated more than `gas // (64 * GAS_PER_PAGE)` pages.
+The memory budget cap means that a frame which has allocated memory can give less gas to a child than under EIP-150 alone. This only happens when the frame has spent less gas than `allocated_pages * GAS_PER_PAGE` (plus 1/64 of its remaining gas), i.e. it holds a lot of memory relative to the work it has done. Frames that only touch page 0 are never affected. The table in the Rationale quantifies the effect; it is confined to frames holding tens of KiB of memory with less than about 100,000 gas, where the difference is a few thousand gas.
+
+In the extreme case where a frame has reserved almost its entire budget, the cap also applies to the 2300 gas stipend of a value-transferring call, so the recipient may receive less than 2300 gas. Reaching that state requires the caller to have allocated close to 4 bytes of memory per unit of its initial gas, which is not possible under the current quadratic model, so no existing contract can be in it.
 
 ## Test Cases
 
@@ -188,8 +214,9 @@ class Frame:
     def __init__(self, initial_gas):
         self.initial_gas = initial_gas
         self.gas = initial_gas
-        self.pages = set()
-        self.max_pages = 1 + initial_gas // GAS_PER_PAGE
+        self.pages = set()          # all touched pages, including page 0
+        self.allocated_pages = 0    # touched pages other than page 0
+        self.max_pages = initial_gas // GAS_PER_PAGE
 
     def touch_memory(self, start, size):
         if size == 0:
@@ -200,17 +227,23 @@ class Frame:
         for page in range(start >> LOWER_BITS, (end >> LOWER_BITS) + 1):
             if page in self.pages:
                 continue
-            if len(self.pages) + 1 > self.max_pages:
+            if page == 0:
+                self.pages.add(page)
+                continue
+            if self.allocated_pages + 1 > self.max_pages:
                 raise ExceptionalHalt("out of memory")
             self.pages.add(page)
-            if page != 0:
-                self.consume_gas(ALLOCATE_PAGE_COST)
+            self.allocated_pages += 1
+            self.consume_gas(ALLOCATE_PAGE_COST)
 
-    def max_call_gas(self):
+    def child_gas(self, requested_gas, stipend):
         # `self.gas` is the remaining gas after all other costs of the
-        # call instruction have been charged.
-        reserved = max(self.gas // 64, len(self.pages) * GAS_PER_PAGE)
-        return max(0, self.gas - reserved)
+        # call instruction have been charged. Returns the gas deducted
+        # from this frame and the initial gas of the child frame.
+        memory_budget = self.initial_gas - self.allocated_pages * GAS_PER_PAGE
+        forwarded = min(requested_gas, self.gas - self.gas // 64, memory_budget)
+        child_initial_gas = min(forwarded + stipend, memory_budget)
+        return forwarded, child_initial_gas
 ```
 
 The set `pages` is only used for costing. The memory contents themselves can be held in a `2**32` byte anonymous `mmap` region, as described in the Motivation, or in a `map[page_id -> char[PAGE_SIZE]]` for systems without virtual memory facilities.
@@ -225,11 +258,11 @@ Outside of gas costing, existing contracts may simply execute to completion rath
 
 Two, does this enable memory-based DoS attacks against clients?
 
-This requires a maximum-memory usage analysis. Under the current quadratic model with the `2**24` transaction gas limit, the worst case is obtained by recursively calling a contract that spends about 2% of its gas on memory in each frame, which reaches roughly 18 MiB of live memory. Under this EIP the bound is `BYTES_PER_GAS * gas_limit + PAGE_SIZE`, i.e. 64 MiB plus one page, as proven in the Rationale. This is a modest increase over the current worst case, while the amount of memory usable by a single frame increases by more than 20x.
+This requires a maximum-memory usage analysis. Under the current quadratic model with the `2**24` transaction gas limit, the worst case is obtained by recursively calling a contract that spends about 2% of its gas on memory in each frame, which reaches roughly 18 MiB of live memory. Under this EIP the bound is `BYTES_PER_GAS * gas_limit + PAGE_SIZE * 1024`, i.e. 64 MiB plus at most 4 MiB of free page-0 slack, as proven in the Rationale. This is a modest increase over the current worst case, while the amount of memory usable by a single frame increases by more than 20x.
 
-Two properties of the bound are worth noting. First, it is tight: a single top-level frame can allocate 64 MiB directly, so there is no hidden slack that a more complex call pattern could exploit. Second, it does not depend on the call depth limit or on the 63/64 rule; future changes to either do not affect the total amount of memory a transaction can allocate. It does depend on the transaction gas limit of [EIP-7825](./eip-7825.md); raising that limit raises the memory bound proportionally.
+Two properties of the bound are worth noting. First, the `BYTES_PER_GAS * gas_limit` term is tight: a single top-level frame can allocate 64 MiB directly, so there is no hidden slack that a more complex call pattern could exploit beyond the one free page per frame. Second, the term does not depend on the 63/64 rule, and the slack term depends only on the call depth limit; future changes to the 63/64 rule do not affect the total amount of memory a transaction can allocate, and a change to the depth limit changes only the slack. The bound does depend on the transaction gas limit of [EIP-7825](./eip-7825.md); raising that limit raises the memory bound proportionally.
 
-Note that a per-frame limit of `BYTES_PER_GAS` bytes per gas alone, without the change to `max_call_gas`, would not be sufficient. Since each frame can forward 63/64 of its gas, the allowances across the call stack sum to roughly 64 times the per-frame allowance; a greedy allocation at every level reaches over 570 MiB. The deduction of allocated memory from the forwardable gas is what makes the bound linear.
+Note that a per-frame limit of `BYTES_PER_GAS` bytes per gas alone, without the memory budget cap on child gas, would not be sufficient. Since each frame can forward 63/64 of its gas, the allowances across the call stack sum to roughly 64 times the per-frame allowance; a greedy allocation at every level reaches over 570 MiB. The deduction of allocated memory from the forwardable gas is what makes the bound linear.
 
 ## Copyright
 

--- a/EIPS/eip-7923.md
+++ b/EIPS/eip-7923.md
@@ -2,7 +2,7 @@
 eip: 7923
 title: Linear, Page-Based Memory Costing
 description: Linearize Memory Costing and replace the current quadratic formula with a page-based cost model.
-author: Charles Cooper (@charles-cooper), Qi Zhou (@qizhou)
+author: Charles Cooper (@charles-cooper), Qi Zhou (@qizhou), Jochem Brouwer (@jochem-brouwer)
 discussions-to: https://ethereum-magicians.org/t/eip-linearize-memory-costing/23290
 status: Draft
 type: Standards Track


### PR DESCRIPTION
This change is the raw output of an LLM. It has added a lot. The main thing to look through initially is the Specifications section, I think I am finally getting ok with the content :smile: :+1: 