### PR TITLE
Update EIP-5920: make Glamsterdam-ready

### DIFF
--- a/EIPS/eip-5920.md
+++ b/EIPS/eip-5920.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2022-03-14
-requires: 214, 2929, 7523
+requires: 214, 2929, 7523, 7708, 7928, 8037, 8038
 ---
 
 ## Abstract
@@ -32,44 +32,68 @@ Having a dedicated opcode for ether transfers solves all of these issues, and wo
 
 ### Constants
 
-| Constant                   | Definition                |
-| -------------------------- | ------------------------- |
-| `WARM_STORAGE_READ_COST`   | [EIP-2929](./eip-2929.md) |
-| `COLD_ACCOUNT_ACCESS_COST` | [EIP-2929](./eip-2929.md) |
-| `GAS_NEW_ACCOUNT`          | [EELS][gna]               |
-| `GAS_CALL_VALUE`           | [EELS][gcv]               |
+| Constant                       | Definition                                                                                   |
+| ------------------------------ | -------------------------------------------------------------------------------------------- |
+| `COLD_ACCOUNT_ACCESS`          | [EIP-8038](./eip-8038.md)                                                                    |
+| `WARM_ACCESS`                  | [EIP-8038](./eip-8038.md)                                                                    |
+| `ACCOUNT_WRITE`                | [EIP-8038](./eip-8038.md)                                                                    |
+| `GAS_NEW_ACCOUNT`              | `STATE_BYTES_PER_NEW_ACCOUNT × CPSB`, charged in state-gas, [EIP-8037](./eip-8037.md)        |
 
-[gna]: https://github.com/ethereum/execution-specs/blob/4d953035fb0cceda7cf21d71b2ab7a9a6f4632f0/src/ethereum/frontier/vm/gas.py#L52
-[gcv]: https://github.com/ethereum/execution-specs/blob/4d953035fb0cceda7cf21d71b2ab7a9a6f4632f0/src/ethereum/frontier/vm/gas.py#L53
+Gas is metered in two dimensions, execution-gas and state-gas, as defined by [EIP-8037](./eip-8037.md). Unless a charge below is explicitly marked as state-gas, it is an execution-gas charge deducted from `gas_left`.
 
 ### Behavior
 
 A new opcode is introduced: `PAY` (`0xfc`), which:
 
-- Halt with exceptional failure if the current frame is static, as defined in [EIP-214](./eip-214.md).
+- Halts with exceptional failure if the current frame is static, as defined in [EIP-214](./eip-214.md).
 - Pops two values from the stack: `addr` then `val`.
 - Exceptionally halts if `addr` has any of the high 12 bytes set to a non-zero value (i.e. it does not contain a 20-byte address).
-- Charges the gas cost detailed below.
-- Marks `addr` as warm (adding `addr` to `accessed_addresses`).
-- Transfers `val` wei from the current address to the address `addr`, only if the current address has a balance greater than or equal to `val`.
-- Push `1` on the stack if the `PAY` operation was successful, or `0` if it failed.
+- Charges the pre-state execution-gas cost detailed below. If `gas_left` is insufficient, the frame halts exceptionally and `addr` is not accessed: it is not added to `accessed_addresses` and, per [EIP-7928](./eip-7928.md), is not included in the block-level access list.
+- Accesses `addr`, marking it as warm (adding `addr` to `accessed_addresses`) and recording it in the [EIP-7928](./eip-7928.md) block-level access list.
+- Charges the post-state state-gas cost detailed below, if any. If the charge cannot be covered, the frame halts exceptionally.
+- Does not resolve any [EIP-7702](./eip-7702.md) delegation of `addr`. No code is loaded or executed and no delegation-target access is charged.
+- Transfers `val` wei from the current address to the address `addr`, only if the current address has a balance greater than or equal to `val`. If the balance is insufficient, no transfer takes place and any state-gas charged in the previous step is refilled in last-in, first-out (LIFO) order, per the rule for unsuccessful `CALL*` operations in [EIP-8037](./eip-8037.md).
+- If the transfer takes place, `val` is non-zero and `addr` differs from the current address, emits the transfer log defined in [EIP-7708](./eip-7708.md), with `from` set to the current address and `to` set to `addr`.
+- Pushes `1` on the stack if the `PAY` operation was successful, or `0` if it failed.
   - Currently only insufficient balance would produce a `0` return value.
 
 ### Gas Cost
 
-The gas cost for `PAY` is the sum of the following:
+`PAY` follows the two-phase gas validation of [EIP-7928](./eip-7928.md): the pre-state cost is charged before `addr` is accessed, the post-state cost after.
+
+The pre-state cost is charged in execution-gas and is the sum of the following:
 
 - Is `addr` in `accessed_addresses`?
-    - If yes, `WARM_STORAGE_READ_COST`;
-    - Otherwise, `COLD_ACCOUNT_ACCESS_COST`.
-- Does `addr` exist or is `val` zero?
-    - If yes to either, zero;
-    - Otherwise, `GAS_NEW_ACCOUNT`.
+    - If yes, `WARM_ACCESS`;
+    - Otherwise, `COLD_ACCOUNT_ACCESS`.
 - Is `val` zero?
     - If yes, zero;
-    - Otherwise, `GAS_CALL_VALUE`.
+    - Otherwise, `ACCOUNT_WRITE`.
 
-`PAY` cannot be implemented on networks with empty accounts (see [EIP-7523](./eip-7523.md)).
+The post-state cost is charged in state-gas:
+
+- Does `addr` exist or is `val` zero?
+    - If yes to either, zero;
+    - Otherwise, `GAS_NEW_ACCOUNT` (`STATE_BYTES_PER_NEW_ACCOUNT × CPSB`).
+
+An account *exists* if it has a leaf in the state trie, i.e. a non-zero balance, a non-zero nonce, or non-empty code, following [EIP-161](./eip-161.md) and the existence rule of [EIP-8037](./eip-8037.md). `PAY` cannot be implemented on networks with empty accounts (see [EIP-7523](./eip-7523.md)).
+
+State-gas is drawn from `state_gas_reservoir` first and from `gas_left` once the reservoir is exhausted, and the charge increments `evm_state_gas_used`, as specified in [EIP-8037](./eip-8037.md). If the frame executing `PAY` later reverts or halts exceptionally, the frame's state-gas is restored to its baseline as part of the rollback, per [EIP-8037](./eip-8037.md); this EIP adds no rule of its own for that case.
+
+The cases and their costs are summarized below. The numeric values use the parameters proposed in [EIP-8037](./eip-8037.md) and [EIP-8038](./eip-8038.md) and change with them.
+
+| `addr` access status | `addr` exists | `val` | Execution-gas                                    | State-gas                   |
+| :------------------: | :-----------: | :---: | :----------------------------------------------- | :-------------------------- |
+| Warm                 | Yes           | 0     | `WARM_ACCESS` (100)                              | 0                           |
+| Warm                 | Yes           | > 0   | `WARM_ACCESS` + `ACCOUNT_WRITE` (9,100)          | 0                           |
+| Warm                 | No            | 0     | `WARM_ACCESS` (100)                              | 0                           |
+| Warm                 | No            | > 0   | `WARM_ACCESS` + `ACCOUNT_WRITE` (9,100)          | `GAS_NEW_ACCOUNT` (183,600) |
+| Cold                 | Yes           | 0     | `COLD_ACCOUNT_ACCESS` (3,000)                    | 0                           |
+| Cold                 | Yes           | > 0   | `COLD_ACCOUNT_ACCESS` + `ACCOUNT_WRITE` (12,000) | 0                           |
+| Cold                 | No            | 0     | `COLD_ACCOUNT_ACCESS` (3,000)                    | 0                           |
+| Cold                 | No            | > 0   | `COLD_ACCOUNT_ACCESS` + `ACCOUNT_WRITE` (12,000) | `GAS_NEW_ACCOUNT` (183,600) |
+
+A `PAY` that fails because of insufficient balance keeps its execution-gas charges and has its state-gas charge refilled, so it costs the execution-gas of the corresponding row and no state-gas.
 
 ## Rationale
 
@@ -85,15 +109,55 @@ If the address space were extended beyond 20 bytes, `PAY` would either not be ab
 
 Because this behavior may be changed, contracts should not rely on this halting behavior and use methods designated to intentionally halt (such as the [`INVALID`](./eip-141.md) opcode).
 
+### Gas cost decomposition
+
+The gas cost of `PAY` is built from the same components that [EIP-8038](./eip-8038.md) uses for a value-transferring `CALL`: an access component, a write component and a state-creation component. `PAY` differs from `CALL` in a single respect: it creates no call frame, so there is no stipend to forward. [EIP-8038](./eip-8038.md) redefines `CALL_VALUE` as `ACCOUNT_WRITE + CALL_STIPEND`, where `CALL_STIPEND` is the gas handed to the callee's frame. `PAY` therefore charges `ACCOUNT_WRITE` alone: the write to the recipient's balance leaf is the same work, and the stipend has nothing to fund.
+
+`ACCOUNT_WRITE` is charged per operation and, as for `CALL`, also covers the [EIP-7708](./eip-7708.md) transfer log. This mirrors [EIP-2780](./eip-2780.md), which folds the transfer log of a value-bearing transaction into the recipient balance write rather than pricing it separately.
+
+A transfer to the current address itself (`addr` equal to the executing address) charges `ACCOUNT_WRITE` like any other non-zero `val`, consistent with `CALL`, even though [EIP-7708](./eip-7708.md) emits no log for it. No special case is introduced.
+
+### Account creation in state-gas
+
+Under [EIP-8037](./eip-8037.md), creating an account leaf is durable state growth and is metered in the state-gas dimension as `STATE_BYTES_PER_NEW_ACCOUNT × CPSB`. `PAY` charges exactly the same amount, under the same condition, as a value-bearing `CALL` to a non-existent account. `PAY` is thus never a cheaper route to account creation than `CALL`, and the state-growth pricing of [EIP-8037](./eip-8037.md) is not weakened by the new opcode.
+
+The charge is conditional and is applied right before the transfer, mirroring the `CALL*` family in [EIP-8037](./eip-8037.md). If the transfer does not happen because the sender's balance is insufficient, the leaf is not created and the charge is refilled, exactly as for a `CALL` that fails its balance check. Keeping the ordering identical to `CALL` means that a single rule in [EIP-8037](./eip-8037.md) governs both opcodes.
+
+### No delegation resolution
+
+A `CALL` to an [EIP-7702](./eip-7702.md) delegated account must load the delegation target's code and pays the corresponding access cost. `PAY` executes no code, so it has no reason to read the delegation indicator or to touch the target. Not charging a delegation-target access is therefore not a discount but the absence of work, and it realizes one of the motivations of this EIP: sending ether to a delegated EOA no longer executes, or pays for, the delegate's code.
+
+### Interaction with [EIP-7928](./eip-7928.md)
+
+[EIP-7928](./eip-7928.md) requires state-accessing opcodes to charge every cost that can be computed without state access before the target is touched, so that a frame lacking that gas never accesses the target and the target never enters the block-level access list. For `PAY`, the access cost and `ACCOUNT_WRITE` depend only on `accessed_addresses` and on `val`, so they form the pre-state cost. Whether `addr` exists requires reading state, so `GAS_NEW_ACCOUNT` is the post-state cost and, like `GAS_NEW_ACCOUNT` for `CALL`, does not affect access-list inclusion. This is the same split [EIP-7928](./eip-7928.md) specifies for `CALL`, with `ACCOUNT_WRITE` in place of `CALL_VALUE`.
+
 ## Backwards Compatibility
 
 This change requires a hard fork.
+
+## Test Cases
+
+Below is a non-exhaustive list of tests to be added as test suite:
+
+- Each row of the gas cost table, including a `PAY` to a cold and to a warm `addr`, to an existing and to a non-existent `addr`, and with zero and non-zero `val`, checking both the execution-gas and the state-gas charged.
+- Insufficient sender balance: `0` is pushed, no transfer or log occurs, the execution-gas is consumed and the state-gas charge is refilled.
+- Out-of-gas on the pre-state cost: `addr` is neither warmed nor included in the block-level access list.
+- Out-of-gas on the state-gas charge, both with an empty and with a non-empty `state_gas_reservoir`.
+- A `PAY` inside a frame that later reverts: the account creation and its state-gas charge are undone by the frame's rollback.
+- Transfer log emission per [EIP-7708](./eip-7708.md), including the absence of a log for zero `val` and for a transfer to the current address.
+- A `PAY` to an [EIP-7702](./eip-7702.md) delegated account: no code is executed, no delegation-target access is charged, and the delegation target does not appear in the block-level access list.
+- `PAY` in a static frame and `PAY` with an `addr` whose high 12 bytes are non-zero, both halting exceptionally.
+- `PAY` to a precompile, to the system address and to `block.coinbase`.
 
 ## Security Considerations
 
 Existing contracts should not rely on their balance being under their control, since it is already possible to send ether to an address without calling it, by using the `SELFDESTRUCT` opcode (somewhat restricted in [EIP-6780](./eip-6780.md)).
 It is also possible to involuntarily fund an account with priority fees sent to a `block.coinbase`.
 However, this opcode does make this process cheaper and easier. It thus does not break an invariant.
+
+A value-bearing `PAY` costs at least `WARM_ACCESS + ACCOUNT_WRITE` in execution-gas, well above the cost of a `LOG3`, so the [EIP-7708](./eip-7708.md) transfer log it emits does not increase the worst-case number of logs per block.
+
+`PAY` charges the same state-gas as a value-bearing `CALL` for creating an account, so it does not open a cheaper path to state growth than the paths already priced by [EIP-8037](./eip-8037.md).
 
 ## Copyright
 


### PR DESCRIPTION
EIP-5920 is not yet ready for Glamsterdam, in the sense that it has not updated the gas schedule to be compliant with EIP-8037 and friends. This PR does that.

There are some minor changes to the spec of `PAY` itself. For consistency I made `PAY` function equal to `CALL`, especially in the behavior if the `value`  attempted to send is higher than the current balance. This actually enters the new call frame and will then immediately abort (so 0 is pushed on stack, but we have not left the call frame which invoked the opcode).

I would like an extra set of eyes on this one before merging.