### PR TITLE
Update EIP-8250: Preserve nested fees in transaction payload

### DIFF
--- a/EIPS/eip-8250.md
+++ b/EIPS/eip-8250.md
@@ -57,9 +57,9 @@ This specification is a delta against [EIP-8141](./eip-8141.md).
 This EIP replaces the `nonce` field in the EIP-8141 `FRAME_TX_TYPE` payload with two consecutive fields, `nonce_keys` followed by `nonce_seq`. No other payload field is changed. Applied to the EIP-8141 payload, the result is:
 
 ```text
-[chain_id, nonce_keys, nonce_seq, sender, frames, signatures,
- max_priority_fee_per_gas, max_fee_per_gas,
- max_fee_per_blob_gas, blob_versioned_hashes]
+[chain_id, nonce_keys, nonce_seq, sender, frames, signatures, fees, blob_versioned_hashes]
+
+fees = [max_priority_fee_per_gas, max_fee_per_gas, max_fee_per_blob_gas]
 ```
 
 `nonce_keys` is a list of `uint256` values; `nonce_seq` is a `uint64`. Each nonce key and `nonce_seq` MUST be encoded as canonical minimal-length RLP integers. The frame layout and all other EIP-8141 transaction fields are unchanged.


### PR DESCRIPTION
Correct EIP-8250's transaction payload to retain EIP-8141's nested `fees` list. EIP-8141 includes `fees` as [one field in the outer RLP payload](https://github.com/ethereum/EIPs/blob/d2a64c2d4cc44f2f507577d0ebfb110dcc21d358/EIPS/eip-8141.md?plain=1#L64-L69) and defines it as [a list of the three fee parameters](https://github.com/ethereum/EIPs/blob/d2a64c2d4cc44f2f507577d0ebfb110dcc21d358/EIPS/eip-8141.md?plain=1#L74).

EIP-8250 says it only replaces `nonce` with `nonce_keys` and `nonce_seq`, but its payload block currently flattens the fee parameters into the outer list. This change makes that block consistent with the stated replacement and the decoder rule that requires the resulting EIP-8141 schema.
