### PR TITLE
Update EIP-8038: Preserve the warm SELFDESTRUCT access exemption

### DIFF
--- a/EIPS/eip-8038.md
+++ b/EIPS/eip-8038.md
@@ -113,6 +113,10 @@ Note: this definition does not exactly match the legacy decomposition shown in f
 
 #### `SELFDESTRUCT`
 
+For `SELFDESTRUCT`, charge `COLD_ACCOUNT_ACCESS` if the beneficiary is cold, or `WARM_ACCESS` (100 gas) if it is warm. This access component is charged in execution gas in addition to the unchanged opcode base cost, regardless of the balance being transferred or whether the beneficiary is dead. It also applies when the beneficiary is the executing account itself or a precompile.
+
+This replaces the [EIP-2929](./eip-2929.md) exemption under which a warm `SELFDESTRUCT` beneficiary incurs no access charge. The rules for determining and updating the beneficiary's cold or warm status are unchanged.
+
 For `SELFDESTRUCT`, an additional charge of `ACCOUNT_WRITE` is added if a positive balance is sent to a dead account (as defined in [EIP-161](./eip-161.md)) — the write component of creating the beneficiary's leaf. The state-creation component in this same case is `GAS_NEW_ACCOUNT`, which remains in place alongside the new `ACCOUNT_WRITE` charge and is metered in state-gas by [EIP-8037](./eip-8037.md).
 
 #### `EXT*` family update

--- a/EIPS/eip-8038.md
+++ b/EIPS/eip-8038.md
@@ -43,7 +43,7 @@ Upon activation of this EIP, the following parameters of the gas model are intro
 | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
 | `COLD_ACCOUNT_ACCESS` | Access | Cold touch of an account. Renamed from `COLD_ACCOUNT_ACCESS_COST` ([EIP-2929](./eip-2929.md)) | 2,600 | 3,000 | +15% | `*CALL` opcodes, `BALANCE`, `SELFDESTRUCT`, `EXT*` opcodes, EOA delegations, contract creation txs and ETH transfers |
 | `COLD_STORAGE_ACCESS` | Access | Cold touch of a storage slot. Renamed from `COLD_SLOAD_COST` ([EIP-2929](./eip-2929.md)) | 2,100 | 2,100 | +0% | `SSTORE` and `SLOAD` |
-| `WARM_ACCESS` | Access | Touch of an already-warm account or storage slot. Renamed from `WARM_STORAGE_READ_COST` ([EIP-2929](./eip-2929.md)) | 100 | 100 | +0% | `SSTORE`, `SLOAD`, `*CALL` opcodes, `BALANCE`, `SELFDESTRUCT` and `EXT*` opcodes |
+| `WARM_ACCESS` | Access | Touch of an already-warm account or storage slot. Renamed from `WARM_STORAGE_READ_COST` ([EIP-2929](./eip-2929.md)) | 100 | 100 | +0% | `SSTORE`, `SLOAD`, `*CALL` opcodes, `BALANCE` and `EXT*` opcodes |
 | `ACCOUNT_WRITE` | Write | Write to an account's leaf values (nonce, balance, code hash); charged per operation. New named parameter (previously embedded in `CALL_VALUE`, see footnote 1) | 6,700 (1) | 9,000 | +34% | value-transferring `*CALL` opcodes, `SELFDESTRUCT`, `CREATE`/`CREATE2`, EOA delegations and ETH transfers |
 | `STORAGE_WRITE` | Write | Write that changes a storage slot's value; net-metered per transaction. New named parameter (previously derived, see footnote 2) | 2,800 (2) | 10,000 | +257% | `SSTORE` |
 | `CREATE_ACCESS` | Access + write | Combined access-and-write cost of contract deployment: `ACCOUNT_WRITE` + `COLD_ACCOUNT_ACCESS`. New named parameter (previously derived, see footnote 3) | 7,000 (3) | 12,000 | +71% | `CREATE`/ `CREATE2` and contract creation txs |
@@ -113,9 +113,7 @@ Note: this definition does not exactly match the legacy decomposition shown in f
 
 #### `SELFDESTRUCT`
 
-For `SELFDESTRUCT`, charge `COLD_ACCOUNT_ACCESS` if the beneficiary is cold, or `WARM_ACCESS` (100 gas) if it is warm. This access component is charged in execution gas in addition to the unchanged opcode base cost, regardless of the balance being transferred or whether the beneficiary is dead. It also applies when the beneficiary is the executing account itself or a precompile.
-
-This replaces the [EIP-2929](./eip-2929.md) exemption under which a warm `SELFDESTRUCT` beneficiary incurs no access charge. The rules for determining and updating the beneficiary's cold or warm status are unchanged.
+For `SELFDESTRUCT`, charge `COLD_ACCOUNT_ACCESS` in execution gas if the beneficiary is cold, regardless of the balance being transferred. A warm beneficiary incurs no access charge: the [EIP-2929](./eip-2929.md) exemption from `WARM_ACCESS` is preserved, including when the beneficiary is the executing account itself or a precompile. The opcode base cost and the rules for determining and updating the beneficiary's cold or warm status are unchanged.
 
 For `SELFDESTRUCT`, an additional charge of `ACCOUNT_WRITE` is added if a positive balance is sent to a dead account (as defined in [EIP-161](./eip-161.md)) — the write component of creating the beneficiary's leaf. The state-creation component in this same case is `GAS_NEW_ACCOUNT`, which remains in place alongside the new `ACCOUNT_WRITE` charge and is metered in state-gas by [EIP-8037](./eip-8037.md).
 
@@ -132,7 +130,7 @@ The cases for account-related operations and their corresponding cost components
 | `CALL` / `CALLCODE` | `COLD_ACCOUNT_ACCESS` or `WARM_ACCESS` | when value is transferred (via `CALL_VALUE` = `ACCOUNT_WRITE` + `CALL_STIPEND`) | `GAS_NEW_ACCOUNT` when value is transferred to a dead account |
 | `DELEGATECALL` / `STATICCALL` | `COLD_ACCOUNT_ACCESS` or `WARM_ACCESS` | never (no value transfer) | — |
 | `CREATE` / `CREATE2` | folded into `CREATE_ACCESS` | always (folded into `CREATE_ACCESS` = `ACCOUNT_WRITE` + `COLD_ACCOUNT_ACCESS`, replacing `GAS_CREATE`) | `GAS_NEW_ACCOUNT`, plus the per-byte code-deposit cost |
-| `SELFDESTRUCT` | `COLD_ACCOUNT_ACCESS` or `WARM_ACCESS` | when a positive balance is sent to a dead account | `GAS_NEW_ACCOUNT` in the same case |
+| `SELFDESTRUCT` | `COLD_ACCOUNT_ACCESS` if cold; zero if warm | when a positive balance is sent to a dead account | `GAS_NEW_ACCOUNT` in the same case |
 | `BALANCE` / `EXTCODEHASH` | `COLD_ACCOUNT_ACCESS` or `WARM_ACCESS` | never | — |
 | `EXTCODESIZE` / `EXTCODECOPY` | `COLD_ACCOUNT_ACCESS` or `WARM_ACCESS`, plus `WARM_ACCESS` for the second database read | never | — |
 


### PR DESCRIPTION
EIP-8038's parameter and overview tables currently imply a 100-gas access charge for a warm SELFDESTRUCT beneficiary. That conflicts with EIP-2929's explicit warm-beneficiary exception and the behavior encoded by the execution-specs tests and Geth revisions linked below.

This draft proposes resolving the mismatch in favor of the existing exception: **cold beneficiaries pay `COLD_ACCOUNT_ACCESS`; warm beneficiaries pay no access charge.** It corrects both tables and states the rule in the SELFDESTRUCT subsection, including self and precompile beneficiaries. The opcode base cost and conditional account-write/state-creation charges are unaffected.

The proposed interpretation is supported by:

- [EIP-2929's SELFDESTRUCT rule](https://eips.ethereum.org/EIPS/eip-2929#selfdestruct-changes), which explicitly omits the warm-access charge.
- Execution-specs at `622620d`: the [existing-beneficiary test](https://github.com/ethereum/execution-specs/blob/622620d84a70efe1337abdafaecd7bdfeb254b92/tests/amsterdam/eip8038_state_access_gas_cost_increase/test_selfdestruct_gas.py#L137) and [self/precompile test](https://github.com/ethereum/execution-specs/blob/622620d84a70efe1337abdafaecd7bdfeb254b92/tests/amsterdam/eip8038_state_access_gas_cost_increase/test_selfdestruct_gas.py#L338) assert gas usage with no warm-beneficiary access charge.
- [Geth at `101035a`](https://github.com/ethereum/go-ethereum/blob/101035a1049c7dc468bfe973478b579d9883d7b6/core/vm/gas_table.go#L648-L664), which adds beneficiary-access gas only when cold.

The accounting rewrite in #12028 also states that it changes no charging behavior. That supports preserving the exception, but does not by itself establish the authors' intended rule.

@misilva73 @weiihann @adietrichs: please confirm whether the zero-charge warm exception should be preserved. This remains a draft pending that confirmation.