### PR TITLE
Update EIP-7805: skip blob transactions in the inclusion list check

### DIFF
--- a/EIPS/eip-7805.md
+++ b/EIPS/eip-7805.md
@@ -12,7 +12,7 @@ created: 2024-11-01
 
 ## Abstract
 
-FOCIL implements a robust mechanism to preserve Ethereum’s censorship resistance properties by guaranteeing timely transaction inclusion.
+FOCIL implements a robust mechanism to preserve Ethereum's censorship resistance properties by guaranteeing timely transaction inclusion.
 
 FOCIL (**Fo**rk-**c**hoice enforced **I**nclusion **L**ists) is built in a few simple steps:
 
@@ -23,7 +23,7 @@ FOCIL (**Fo**rk-**c**hoice enforced **I**nclusion **L**ists) is built in a few s
 
 ## Motivation
 
-In an effort to shield the Ethereum validator set from centralizing forces, the right to build blocks has been auctioned off to specialized entities known as *builders*. This has led to a few sophisticated builders dominating block production, leading to a deterioration of the network’s censorship resistance properties. To address this issue, research has focused on improving Ethereum's transaction inclusion guarantees by enabling validators to impose constraints on builders. This is achieved by force-including transactions in blocks via ILs.
+In an effort to shield the Ethereum validator set from centralizing forces, the right to build blocks has been auctioned off to specialized entities known as *builders*. This has led to a few sophisticated builders dominating block production, leading to a deterioration of the network's censorship resistance properties. To address this issue, research has focused on improving Ethereum's transaction inclusion guarantees by enabling validators to impose constraints on builders. This is achieved by force-including transactions in blocks via ILs.
 
 ### High-level Overview
 
@@ -38,7 +38,7 @@ This section outlines the workflow of FOCIL, detailing the roles and responsibil
 #### IL Committee Members
 
 - **`Slot N`, `t=0 to 8s`**:
-IL committee members construct their ILs by including transactions pending in the public mempool, and broadcast them over the P2P network after processing the block for `slot N` and confirming it as the head. If no block is received by `t=7s`, they should run `get_head` and build and release their ILs based on the node’s local head.
+IL committee members construct their ILs by including transactions pending in the public mempool, and broadcast them over the P2P network after processing the block for `slot N` and confirming it as the head. If no block is received by `t=7s`, they should run `get_head` and build and release their ILs based on the node's local head.
 
 IL committee members may follow different strategies for constructing their ILs as discussed in [IL Building](#il-building).
 
@@ -68,7 +68,7 @@ The proposer broadcasts its block with the up-to-date execution payload satisfyi
 #### Attesters
 
 - **`Slot N+1`, `t=4s`**:
-Attesters monitor the P2P network for the proposer’s block. Upon detecting it, they verify whether all transactions from their stored ILs are included in the proposer’s execution payload, except for ILs whose sender has equivocated. Based on their frozen view of the ILs from `t=9s` in the previous slot, attesters check if the execution payload satisfies IL conditions. This is done either by confirming that all transactions are present or by determining if any missing transactions are invalid when appended to the end of the payload. In such cases, attesters use the EL to perform nonce and balance checks to validate the missing transactions and check whether there is enough space in the block to include the transaction(s).
+Attesters monitor the P2P network for the proposer's block. Upon detecting it, they verify whether all transactions from their stored ILs are included in the proposer's execution payload, except for ILs whose sender has equivocated. Based on their frozen view of the ILs from `t=9s` in the previous slot, attesters check if the execution payload satisfies IL conditions. This is done either by confirming that all transactions are present or by determining if any missing transactions are invalid when appended to the end of the payload. In such cases, attesters use the EL to perform nonce and balance checks to validate the missing transactions and check whether there is enough space in the block to include the transaction(s).
 
 #### CL P2P Validation Rules
 

--- a/EIPS/eip-7805.md
+++ b/EIPS/eip-7805.md
@@ -93,15 +93,19 @@ Let `gas_left` be the gas remaining after execution of B.
 
 For each transaction `T` in ILs, perform the following:
 
-1. Check whether `T` is present in `B`. If `T` is present, then jump to the next transaction, else continue with next step.
+1. Check whether `T` is a [blob transaction](./eip-4844.md#blob-transaction). If `T` is a blob transaction, then jump to the next transaction, else continue with next step.
 
-2. Check whether `B` has enough remaining gas to execute `T`. If `T.gas` > `gas_left`, then jump to the next transaction, else continue with next step.
+2. Check whether `T` is present in `B`. If `T` is present, then jump to the next transaction, else continue with next step.
 
-3. Validate `T` against `S` by checking the nonce and balance of `T.origin`.
+3. Check whether `B` has enough remaining gas to execute `T`. If `T.gas` > `gas_left`, then jump to the next transaction, else continue with next step.
+
+4. Validate `T` against `S` by checking the nonce and balance of `T.origin`.
 
   - If `T` is invalid, then continue to the next transaction. 
   
   - If `T` is valid, terminate process and return an `INCLUSION_LIST_UNSATISFIED` status.
+
+Step 1 mirrors the constraint already placed on IL construction, where `engine_getInclusionListV1` requires that the transaction list not include any blob transaction. An IL entry carries only the transaction and not the associated blobs, so a block proposer that collected such an entry could not supply the corresponding blobs. The CL P2P validation rules perform no EL-side validation of IL contents, so an IL that does not respect the construction constraint still propagates. Without step 1, a single committee member deviating from that constraint would cause every block in the slot to be judged unsatisfied, which is incompatible with the `1-out-of-N` honesty assumption the mechanism relies on.
 
 #### Engine API Changes
 


### PR DESCRIPTION
Adds a step to the Execution Layer check so that a blob transaction appearing in an inclusion list is skipped rather than evaluated for appendability. Draft, to gauge agreement before it is settled — cc @soispoke.

The two sides of the mechanism are currently asymmetric:

- IL construction: `engine_getInclusionListV1` in the engine API specification requires that the transaction list not include any blob transaction. An IL entry is the transaction payload alone, with no blob sidecar, so a proposer that collected such an entry could not supply the corresponding blobs for the payload it produces.
- IL validation: the Execution Layer algorithm in this EIP has no corresponding step, so a blob transaction that is absent from the block passes the nonce, balance and gas checks and yields `INCLUSION_LIST_UNSATISFIED`.

Nothing between the two rules out a blob entry. The CL P2P validation rules in this EIP state that there is no EL verification of IL contents, and the consensus specification passes IL transactions through to the EL unfiltered, so an IL containing a blob transaction propagates, is stored, and is handed to the EL for validation.

The consequence is that one committee member not following the construction constraint makes every block in the slot unsatisfied, so attesters withhold their vote from blocks that are otherwise valid. That is a 1-of-16 failure in a mechanism whose stated property is a `1-out-of-N` honesty assumption.

Placing the step here rather than in the engine API specification keeps the per-transaction check defined in one place: the engine API `newPayload` method defers the satisfaction constraints to this EIP and does not restate the algorithm, so no change there appears necessary.

Skipping is the conservative resolution of the two: the block is valid either way, and skipping means attesting to it. The alternative reading — that a blob entry must be honoured — would require lifting the construction constraint first, since otherwise the entry can never be satisfied.

A second commit replaces four pre-existing smart quotes with straight ones; the linter checks the whole file, so it fails on them as soon as the file is touched.
