### PR TITLE
Update EIP-8130: apply EIP-7623 calldata floor to intrinsic gas

### DIFF
--- a/EIPS/eip-8130.md
+++ b/EIPS/eip-8130.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2025-10-14
-requires: 155, 170, 712, 1271, 1559, 2028, 2718, 2929, 4337, 6780, 7702, 7708, 7819
+requires: 155, 170, 712, 1271, 1559, 2028, 2718, 2929, 4337, 6780, 7623, 7702, 7708, 7819
 ---
 
 ## Abstract
@@ -414,16 +414,51 @@ effective_gas_limit = gas_limit + MAX_AUTHENTICATION_GAS
 
 **`sender_auth_cost`**: authenticator execution + 1 SLOAD (`actor_config`).
 
-**`payer_auth_cost`**: 0 for self-pay (`payer` empty). Otherwise, the same `sender_auth_cost` model applies to the payer's authenticator (authenticator execution + 1 `actor_config` SLOAD), **plus** the data-availability cost of the serialized `payer_auth` field itself (16 gas per non-zero byte, 4 per zero byte, per [EIP-2028](./eip-2028.md)). These `payer_auth` bytes are excluded from `tx_payload_cost` and metered here instead, so the entire payer-authentication cost, execution and bytes alike, sits outside `gas_limit` and is paid by the payer.
+**`payer_auth_cost`**: 0 for self-pay (`payer` empty). Otherwise, the same `sender_auth_cost` model applies to the payer's authenticator (authenticator execution + 1 `actor_config` SLOAD), **plus** the data-availability cost of the serialized `payer_auth` field itself (16 gas per non-zero byte, 4 per zero byte, per [EIP-2028](./eip-2028.md)), subject to the [calldata floor](#calldata-floor) over the `payer_auth` bytes (so the payer-chosen field cannot be padded to post cheap data availability either). These `payer_auth` bytes are excluded from `tx_payload_cost` and metered here instead, so the entire payer-authentication cost, execution and bytes alike, sits outside `gas_limit` and is paid by the payer.
 
 | Component | Value |
 |-----------|-------|
 | `AA_BASE_COST` | 15,000 gas: the fixed per-transaction overhead of the AA path, analogous to the standard 21,000 base cost but excluding the components broken out separately below (signature authentication is `sender_auth_cost`/`payer_auth_cost`; calldata is `tx_payload_cost`). It covers transaction decoding, sender/actor resolution and the `actor_config` access accounting common to every AA transaction, nonce-mode dispatch, and receipt assembly. Like the other values it is a protocol constant under the L1 profile that only an L2-profile chain MAY reprice (see [Adoption Profiles](#adoption-profiles)) |
-| `tx_payload_cost` | Standard per-byte cost over the RLP-serialized transaction **excluding the `payer_auth` field**: 16 gas per non-zero byte, 4 gas per zero byte, consistent with [EIP-2028](./eip-2028.md). Ensures all sender-signed fields (`account_changes`, `sender_auth`, `calls`, `metadata`, etc.) are charged for data availability. The `payer_auth` bytes are chosen unilaterally by the payer and excluded from the signed hashes, so their byte cost is metered in `payer_auth_cost` (outside `gas_limit`) rather than here |
+| `tx_payload_cost` | Standard per-byte cost over the RLP-serialized transaction **excluding the `payer_auth` field**: 16 gas per non-zero byte, 4 gas per zero byte, consistent with [EIP-2028](./eip-2028.md). Ensures all sender-signed fields (`account_changes`, `sender_auth`, `calls`, `metadata`, etc.) are charged for data availability. This is the *standard* rate only; it is subject to the [calldata floor](#calldata-floor) below, so a data-heavy 8130 transaction cannot post data availability more cheaply than a standard [EIP-7623](./eip-7623.md) transaction on the same chain. The `payer_auth` bytes are chosen unilaterally by the payer and excluded from the signed hashes, so their byte cost is metered in `payer_auth_cost` (outside `gas_limit`) rather than here |
 | `nonce_key_cost` | `NONCE_KEY_MAX`: 13,000 gas (ring-buffer replay state: 2 cold SLOADs + 1 warm SLOAD + 3 warm SSTORE resets; the ring pointer's SLOAD/SSTORE are amortized across the block). Otherwise: 22,100 gas for first use of a `nonce_key` (cold SLOAD + SSTORE set), 5,000 gas for existing keys (cold SLOAD + warm SSTORE reset) |
 | `bytecode_cost` | 0 if no create entry in `account_changes`. Otherwise: 32,000 (deployment base) + code deposit cost (200 gas per deployed byte). Byte costs for `code` are covered by `tx_payload_cost`; the create entry's initial-actor slot writes are covered by `account_changes_cost` |
 | `account_changes_cost` | Per applied **create** entry: one `actor_config` slot write per initial actor (22,100 gas each: cold SLOAD + SSTORE set); a `POLICY` actor also writes its `policy_manager`/`policy_commitment` slots (~3 slot-sets, ~66,300 gas). Per applied **config change** entry: auth authentication cost (same model as `sender_auth_cost`) plus the storage writes for each mutated slot (`actor_config`, plus policy slots when `POLICY` is set); self-actor changes mutate the packed account-state slot instead. Per applied **delegation** entry: 4,600 gas (indicator deposit, 200 × 23 bytes). Per **skipped** config-change entry: 2,100 gas (sequence SLOAD). `0` when there is no create, config-change, or delegation entry. Expiry is not expressible at create; `policyData` bytes are charged through `tx_payload_cost` |
 | `auto_delegation_cost` | Delegation indicator deposit: 4,600 gas (200 × 23 bytes for the `0xef0100 \|\| address` indicator) when a code-less `sender` is auto-delegated to `DEFAULT_ACCOUNT_ADDRESS` (Block Execution step 4). 0 otherwise. |
+
+#### Calldata Floor
+
+The per-byte components above price data availability at [EIP-2028](./eip-2028.md)'s 16/4 rate. On a chain that has adopted [EIP-7623](./eip-7623.md) that is only the *standard* rate: EIP-7623 additionally imposes a per-transaction **floor** so that a transaction spending little gas on execution relative to the bytes it posts cannot drive the maximum block size back up. The floor is a data-availability bound on worst-case block size, not a user-facing fee, so it MUST bind on the 8130 transaction type as well. Because an 8130 transaction has no single `data` field — its bytes live in `account_changes`, `sender_auth`, `calls`, `metadata`, and `payer_auth` — the floor is evaluated over the serialized transaction rather than over a `data` field. Without it, a data-heavy 8130 transaction would post data availability at the 2028 rate that EIP-7623 removed for every other transaction type on the chain.
+
+Define, consistent with [EIP-7623](./eip-7623.md):
+
+| Parameter | Value |
+|-----------|-------|
+| `STANDARD_TOKEN_COST` | 4 |
+| `TOTAL_COST_FLOOR_PER_TOKEN` | 10 |
+
+Let `payload_tokens = zero_bytes + 4 * nonzero_bytes` counted over the same bytes `tx_payload_cost` covers (the RLP-serialized transaction **excluding the `payer_auth` field**), so that `tx_payload_cost == STANDARD_TOKEN_COST * payload_tokens`. Let `execution_gas_used` be the gas used by the transaction's `calls` (phase 3), net of refunds.
+
+The sender-metered gas is floored exactly as in EIP-7623 — the floor competes with execution, so a computation-heavy transaction is unaffected and only data-heavy transactions pay it:
+
+```
+sender_metered_gas = max(
+    sender_intrinsic_gas + execution_gas_used,
+    (sender_intrinsic_gas - tx_payload_cost) + TOTAL_COST_FLOOR_PER_TOKEN * payload_tokens
+)
+```
+
+As in EIP-7623, a transaction whose `gas_limit` is below `(sender_intrinsic_gas - tx_payload_cost) + TOTAL_COST_FLOOR_PER_TOKEN * payload_tokens` is invalid at [Mempool Acceptance](#mempool-acceptance): the floor must be reserved in the sender-signed gas limit rather than relying on execution to cover it.
+
+The `payer_auth` bytes are on-chain data just the same, so the same floor applies to them within `payer_auth_cost` (outside `gas_limit`, charged to the payer). Letting `payer_auth_tokens` be the token count of the serialized `payer_auth` field and `payer_auth_exec` the payer authenticator's execution plus its `actor_config` SLOAD:
+
+```
+payer_auth_cost = max(
+    payer_auth_exec + STANDARD_TOKEN_COST * payer_auth_tokens,
+    TOTAL_COST_FLOOR_PER_TOKEN * payer_auth_tokens
+)
+```
+
+Under both [adoption profiles](#adoption-profiles) the floor is part of the normative **structure** of the intrinsic-gas formula (the `max` and the token count), not a repriceable constant. An L2-profile chain MAY reprice `TOTAL_COST_FLOOR_PER_TOKEN` (for example to track a local EIP-7623 repricing) but MUST NOT set it below `STANDARD_TOKEN_COST` and MUST NOT drop the floor term; a chain cannot restore the pre-EIP-7623 data-availability rate through this transaction type.
 
 #### Signature Format
 


### PR DESCRIPTION
## Motivation

EIP-8130 `requires` EIP-2028 but not [EIP-7623](https://eips.ethereum.org/EIPS/eip-7623). Its `tx_payload_cost` prices the serialized transaction at a flat 16/4 per byte with no floor, so on any chain that has adopted EIP-7623 the calldata floor never binds on an 0x79 transaction: EIP-7623 computes its floor over `tx.data`, and an 8130 transaction has no `data` field (its bytes live in `calls`, `account_changes`, `sender_auth`, `metadata`, and `payer_auth`).

The practical effect is that data-heavy transactions can post data availability ~40% cheaper than an equivalent type-2 transaction on the same chain. Measured on the same 20,000 zero bytes:

| tx type | gasUsed |
|---|---|
| type-2 | 221,000 (the EIP-7623 floor) |
| 0x79, self-paid | ~129,000 |

EIP-7623's floor is a worst-case-block-size / data-availability bound, not a user-facing fee, so a transaction type that walks around it reopens the max-block-size hole EIP-7623 was created to close. The sibling spec EIP-8141 already `requires` EIP-7623 and defines a `calldata_floor_tokens` term over every frame's data and every signature; EIP-8130 was missing the equivalent.

The L2 adoption profile allows repricing the intrinsic-gas *constants* but states that the formula's *structure* is normative under both profiles, so this cannot be fixed in chain configuration — it belongs in the transaction EIP.

## Changes

- Add `7623` to `requires`.
- Add a **Calldata Floor** subsection to Intrinsic Gas that ports EIP-7623's `max(standard, floor)` form over the serialized transaction (so computation-heavy transactions are unaffected and only data-heavy ones pay the floor).
- Note the `gas_limit` reservation validity rule (mirroring EIP-7623).
- Apply the same floor to the payer-chosen `payer_auth` bytes within `payer_auth_cost`, closing the equivalent padding vector on that field.
- Mark the floor term as normative structure: an L2-profile chain may reprice `TOTAL_COST_FLOOR_PER_TOKEN` but may not set it below `STANDARD_TOKEN_COST` or drop the term.

Opening as **draft** for discussion on the exact placement of the payer_auth floor and whether the floor should be expressed at the transaction level vs. inside `tx_payload_cost`.
