### PR TITLE
Update EIP-8141: define early rejection and payer revalidation rules

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -954,7 +954,7 @@ Frames after these prefixes are outside public mempool validation. For example, 
 To be accepted into the public mempool, a frame transaction must satisfy the following:
 
 1. Its validation prefix must match one of the four recognized prefixes above.
-2. If present, `deploy` must be the first frame. This implies there can be at most one `deploy` frame in the validation prefix.
+2. If present, `deploy` must be the first frame. This implies there can be at most one `deploy` frame in the validation prefix. Its resolved target must not have an [EIP-7702](./eip-7702.md) delegation indicator. The node must check this before executing the frame. This restriction applies to the factory itself and does not prevent the frame from installing a delegation indicator at `tx.sender`.
 3. `self_verify` and `only_verify` must execute in `VERIFY` mode, target `tx.sender` (either explicitly or via a null target), must successfully call `APPROVE`, and `frame.flags` must match the scope of the `APPROVE` call.
     - `self_verify` must call `APPROVE(APPROVE_EXECUTION_AND_PAYMENT)`.
     - `only_verify` must call `APPROVE(APPROVE_EXECUTION)`.
@@ -1083,13 +1083,17 @@ available_paymaster_balance = state.balance(paymaster) - reserved_pending_cost(p
 #### Acceptance Algorithm
 
 1. A transaction is received over the wire and the node decides whether to accept or reject it.
-2. The node validates all protocol-validated signatures and structurally checks all `ARBITRARY` signatures. If any signature is malformed or invalid, reject.
-3. The node analyzes the frame structure and determines the validation prefix. If the prefix is not one of the recognized prefixes, reject.
-4. The node simulates the validation prefix and enforces the structural and trace rules above, except that a `pay` frame whose target runtime code exactly matches the canonical paymaster implementation is handled via the canonical paymaster exception and the paymaster-specific rules below.
-5. The node records the sender storage slots read during validation. Calls into helper contracts do not create additional mutable-state dependencies unless they cause disallowed storage access under the trace rules above.
-6. If a canonical paymaster instance is used, the node verifies paymaster solvency using the reservation rule above.
-7. A node should keep at most one pending frame transaction per sender in the public mempool. A new transaction from the same sender MAY replace the existing one only if it uses the same nonce and satisfies the replacement rules below.
-8. If all checks pass, the transaction may be accepted into the public mempool and propagated to peers.
+2. The node checks the transaction encoding, the static constraints, and the structure of all signature entries, including `ARBITRARY` entries. If any check fails, reject.
+3. The node analyzes the frame structure and determines the validation prefix. If the prefix is not one of the recognized prefixes, or violates any structural rule that can be checked without execution or state access, reject.
+4. The node checks the sender's nonce. If `tx.nonce != state[tx.sender].nonce`, reject.
+5. A node should keep at most one pending frame transaction per sender in the public mempool. A new transaction from the same sender MAY replace the existing one only if it uses the same nonce and satisfies the replacement rules below.
+6. If a `deploy` frame is present, the node checks that its resolved target does not have an EIP-7702 delegation indicator. If it does, reject.
+7. If the payer and its classification can be determined without execution, the node checks payer solvency using the reservation or exposure rule below and applies the non-canonical paymaster pending-transaction limit where applicable. If either check fails, reject. For a replacement, these checks account for the transaction being replaced.
+8. The node validates all protocol-validated signatures. If any signature is invalid, reject.
+9. The node simulates the validation prefix and enforces the structural and trace rules above, except that a `pay` frame whose target runtime code exactly matches the canonical paymaster implementation is handled via the canonical paymaster exception and the paymaster-specific rules below.
+10. The node records the state dependencies used during validation as described in [Revalidation](#revalidation), including the sender storage slots read and whether the payer used default code.
+11. The node verifies solvency for the payer established by execution using the reservation or exposure rule below, including the paymaster-specific rules when applicable.
+12. If all checks pass, the transaction may be accepted into the public mempool and propagated to peers.
 
 #### Replacement and Eviction
 
@@ -1103,7 +1107,18 @@ When local resource limits are reached, a node should evict in this order: first
 
 #### Revalidation
 
-When a new canonical block is accepted, the node removes any included frame transactions from the public mempool, updates paymaster reservations accordingly, and identifies the remaining pending transactions whose tracked dependencies were touched by the block. This includes at least transactions for the same sender, transactions whose recorded sender storage slots changed, transactions that reference a canonical paymaster instance whose balance, code, or delayed-withdrawal state changed, and transactions whose payer's balance or code changed. The node then re-simulates the validation prefix of only those affected transactions against the new head and evicts any transaction that no longer satisfies the public mempool rules.
+When a new canonical block is accepted, the node removes any included frame transactions from the public mempool, updates payer reservations accordingly, and identifies the remaining pending transactions whose tracked dependencies changed. The node must record the state on which validation depends, including the sender's nonce, code, and storage slots read during validation; code reached during validation, including any sender delegation target and deploy-frame factory; and the payer's code and balance, or the canonical paymaster's tracked state. Protocol-defined checks, including expiry and the sender-existence check in `APPROVE`, must also be evaluated against the new head.
+
+If a transaction was admitted with a payer that approved payment through default code, and that payer no longer has the empty code hash, the node MUST drop the transaction without executing the payer's new code and release its reservation. This includes a payer that acquires an EIP-7702 delegation indicator.
+
+If the payer's balance changed and no other dependency change requires re-simulation, the node must handle the balance change as follows:
+
+- If the balance increased, update the available balance used for reservation accounting without re-simulating the validation prefix. The increase does not itself change `reserved_pending_cost`.
+- If the balance decreased, recompute payer solvency against the aggregate pending reservation or exposure without re-simulating the validation prefix. If the payer can no longer cover it, evict transactions and release their reservations until the remaining exposure satisfies the rules above. For a canonical paymaster, the pending delayed withdrawal amount must still be deducted.
+
+A payer balance change alone must not cause custom sender validation to be repeated when the state on which that validation depends is unchanged. The node must reuse the successful result and separately apply the payment checks above. If the payer is also `tx.sender`, the sender-existence check and any resulting account-creation state-gas charge must still be checked; a balance change must not cause the node to reuse an outdated result of those checks.
+
+For other dependency changes, the node revalidates the affected transactions, using direct evaluation where applicable and otherwise re-simulating the validation prefix. A result may be reused only while its dependencies match the state against which it was successfully validated. The node evicts any transaction that no longer satisfies the public mempool rules and releases its reservation.
 
 #### Transaction origination
 
@@ -1449,7 +1464,7 @@ Node implementations should consider restricting which opcodes and storage slots
 
 It's recommended that to *validate* the transaction, a specific frame structure is enforced and the amount of gas that is expended executing the validation phase must be limited. Once the validation prefix reaches payer approval via `APPROVE(APPROVE_PAYMENT)` or `APPROVE(APPROVE_EXECUTION_AND_PAYMENT)`, the transaction can be included in the mempool and propagated to peers safely.
 
-For deployment of the sender account in the first frame, the mempool enforces deploy-frame determinism via the validation trace rules. Any contract may be used as `frame.target`, provided the frame's execution satisfies those rules — notably, it must not read mutable state outside `tx.sender` or maintain per-deploy factory storage (counters, reentrancy flags, etc.), so that the deployment result is independent of chain state. Factories deployed via the [EIP-7997](./eip-7997.md) deterministic factory predeploy are the canonical choice for acquiring a cross-chain-stable factory address.
+For deployment of the sender account in the first frame, the mempool enforces deploy-frame determinism via the structural and validation trace rules. Any non-delegated contract may be used as `frame.target`, provided the frame's execution satisfies those rules — notably, it must not read mutable state outside `tx.sender` or maintain per-deploy factory storage (counters, reentrancy flags, etc.), so that the deployment result is independent of chain state. The top-level factory target is checked separately because entering a frame does not execute a `CALL*` or `EXTCODE*` opcode. Factories deployed via the [EIP-7997](./eip-7997.md) deterministic factory predeploy are the canonical choice for acquiring a cross-chain-stable factory address.
 
 In general, it can be assumed that handling of frame transactions imposes similar restrictions as EIP-7702 on mempool relay, i.e. only a single transaction can be pending for an account that uses frame transactions.
 


### PR DESCRIPTION
The current public mempool rules can require expensive validation work for transactions that already fail structural checks, or repeat validation across many pending transactions after a single change to a shared payer or factory.

This PR addresses four sources of public mempool validation-work amplification:

1. **Static and structural rejection before signature verification**

   Check transaction encoding, static constraints, signature-entry structure, and validation-prefix structure before verifying protocol signatures. This prevents submissions that already fail these checks from consuming cryptographic verification work before rejection.

2. **Accounting-only handling of payer balance changes**

   A shared payer's balance can change without affecting the validity of any sender's custom validation. Re-simulating every dependent transaction after such a change allows a small deposit to trigger expensive validation across many otherwise valid transactions.

   When no other dependency change requires re-simulation, balance increases only update the available balance used for reservation accounting. Balance decreases require an aggregate solvency check and eviction where necessary. Custom sender validation is reused when its dependencies remain unchanged, while protocol-defined checks such as the sender-existence state-gas charge remain applicable.

3. **Immediate eviction when a default-code payer acquires code**

   A payer admitted with empty code can later acquire an EIP-7702 delegation indicator. Re-simulating its pending transactions may repeat expensive sender validation before discovering that the payer no longer uses the default-code payment path.

   Transactions admitted with that default-code payer are instead dropped when it acquires code, and their reservations are released. The node does not execute the payer's new code to preserve the existing admission.

4. **Exclude EIP-7702 delegated top-level factories**

   A delegated factory introduces a mutable code dependency shared by otherwise independent counterfactual senders. Changing its delegation can trigger re-simulation of every dependent transaction, even when the new implementation leaves those transactions valid.

   The deploy frame's resolved target must therefore not carry an EIP-7702 delegation indicator. This check complements the existing restrictions on delegated targets reached through `CALL*` and `EXTCODE*`, which do not cover top-level frame dispatch. The deploy frame may still install a delegation indicator at `tx.sender`.

These changes apply to public mempool admission and revalidation policy only. They do not change consensus validity or replace re-simulation for other validation dependency changes.