### PR TITLE
Update EIP-8288: align with EIP-8141's current frame fields and instructions

### DIFF
--- a/EIPS/eip-8288.md
+++ b/EIPS/eip-8288.md
@@ -53,7 +53,7 @@ This EIP introduces a new frame mode for [EIP-8141](./eip-8141.md) frame transac
 
 #### Dependency Verification Frame (`DEP_VERIFY_FRAME_MODE`)
 
-We modify EIP-8141 to also allow frames with mode `DEP_VERIFY_FRAME_MODE`, in addition to all previously allowed modes. A frame with mode `DEP_VERIFY_FRAME_MODE` is a **dependency verification frame**. It declares a set of **dependencies** as `(scheme, data_hash, verification_key_hash)` triples. These triples are not executed as EVM code; instead, they are recorded as dependencies that must be proven valid by the recursive STARK in the block.
+We modify EIP-8141 to also allow frames with mode `DEP_VERIFY_FRAME_MODE`, in addition to all previously allowed modes. The static constraint `assert frame.mode < 3` on each frame is replaced by `assert frame.mode <= DEP_VERIFY_FRAME_MODE`, admitting `DEP_VERIFY_FRAME_MODE` as a valid mode value. A frame with mode `DEP_VERIFY_FRAME_MODE` is a **dependency verification frame**. It declares a set of **dependencies** as `(scheme, data_hash, verification_key_hash)` triples. These triples are not executed as EVM code; instead, they are recorded as dependencies that must be proven valid by the recursive STARK in the block.
 
 The **payload encoding** is a simple `96*k` byte concatenation of `k` triples, each consisting of:
 
@@ -68,10 +68,11 @@ This data is stored in the frame's `data` field.
 - The frame's `data` must be exactly `96*k` bytes, and the first 31 bytes of each set of 96 must be zero.
 - For each set of 96 bytes, `scheme` (byte 31) must be either `LEANSPHINCS_SCHEME` or `LEANSTARK_SCHEME`.
 - Number of triples must be `>= 1` and `<= MAX_DEPENDENCIES_PER_FRAME`.
-- The frame's `target` must be `None` (address `0x00...00`).
+- The frame's `target` must be `None`. This is EIP-8141's absent target, not the zero address: `resolved_target` is then `tx.sender`, and `FRAMEPARAM(0x00, i)` returns the sender's address. Contracts identify dependency verification frames by `mode`, not by target.
 - The frame's `value` must be `0`.
 - The frame's `flags` must be `0`.
-- The frame's `gas_limit` must be `sum(LEANSPHINCS_VERIFICATION_GAS if triple.scheme == LEANSPHINCS_SCHEME else LEANSTARK_VERIFICATION_GAS for triple in frame.data_triples)`.
+- The frame's `limits.execution` must be `sum(LEANSPHINCS_VERIFICATION_GAS if triple.scheme == LEANSPHINCS_SCHEME else LEANSTARK_VERIFICATION_GAS for triple in frame.data_triples)`.
+- The frame's `limits.state` must be `0`. The frame executes no code, so it can consume no state gas.
 
 ### Transaction Dependencies
 
@@ -81,7 +82,7 @@ The complete list of dependencies for a transaction is the concatenation of all 
 
 ```
 frame.data_triples = [
-    (data[31], data[32:64], data[64:])
+    (data[31], data[32:64], data[64:96])
     for data in chunks(frame.data, 96)
 ]
 
@@ -111,9 +112,9 @@ def deduplicate_and_sort(deps):
 
 ### Transaction Execution Visibility
 
-During EVM execution, the transaction's dependencies are made available through the existing [EIP-8141](./eip-8141.md) `FRAMEPARAM`, `FRAMEDATASIZE`, and `FRAMEDATACOPY` instructions.
+During EVM execution, the transaction's dependencies are made available through the existing [EIP-8141](./eip-8141.md) `FRAMEPARAM` and `FRAMEDATACOPY` instructions.
 
-Contracts can iterate over all frames in the transaction using `FRAMEPARAM` to identify `DEP_VERIFY_FRAME_MODE` frames, then use `FRAMEDATASIZE` and `FRAMEDATACOPY` to read the dependency data from each frame's `data` field.
+Contracts can iterate over all frames in the transaction using `FRAMEPARAM` to identify `DEP_VERIFY_FRAME_MODE` frames, then use `FRAMEPARAM(0x04, i)` and `FRAMEDATACOPY` to read the dependency data from each frame's `data` field.
 
 Specifically:
 
@@ -359,7 +360,7 @@ The verification key `AGGREGATED_VK` used to verify the recursive STARK is a fix
 
 ### Gas Accounting
 
-The gas cost for a dependency verification frame is:
+The frame's `limits.execution` for a dependency verification frame is:
 
 ```
 verification_gas(dep_verify_frame) = sum(


### PR DESCRIPTION
EIP-8288 references an older shape of EIP-8141: one field it has since renamed, and two conventions it replaced when it superseded [EIP-7701](./eip-7701.md). An implementer working from the current EIP-8141 text cannot satisfy EIP-8288 as written.

Reference alignment only: no change to what the EIP asks for, and none to the frame-mode value, which #12309 handles.
