### PR TITLE
Update EIP-8288: state the aggregation circuit's required properties

### DIFF
--- a/EIPS/eip-8288.md
+++ b/EIPS/eip-8288.md
@@ -209,6 +209,12 @@ The recursive STARK is verified using a fixed protocol-level `AGGREGATED_VK`.
 
 To enable unlimited-depth recursion, we need to pass the `AGGREGATED_VK` in as an input to the proof itself.
 
+The aggregation circuit MUST satisfy all of the following, for any number of dependencies proven:
+
+1. The serialized size of a recursive STARK MUST be bounded by a constant.
+2. The cost of verifying a recursive STARK MUST be independent of the number of claims it proves.
+3. The cost of absorbing a recursive STARK as a nested proof MUST be independent of the number of claims that nested proof covers.
+
 #### Block Validity Rules
 
 A block is valid if and only if:
@@ -368,6 +374,8 @@ verification_gas(dep_verify_frame) = sum(
 )
 ```
 
+`LEANSPHINCS_VERIFICATION_GAS` and `LEANSTARK_VERIFICATION_GAS` price establishing a dependency for the first time. They do not price a recursive aggregation round.
+
 The actual STARK verification is performed off-chain by the builder, so the gas cost represents the _expected_ cost of verifying the recursive STARK, not the actual cost. It is much cheaper than the onchain costs for similar operations because the cost is only paid by the builder and the mempool, not by all validating nodes.
 
 The `recursive_stark` header field has its own gas cost, charged as part of the block's base fee:
@@ -423,6 +431,16 @@ There may be two valid reasons to adjust the current fixed-cost approach and swi
 
 - **Mixed k-time and unlimited-time usage of leanSPHINCS**: k-time signatures are significantly smaller than unlimited-time signatures, and SPHINCS could expose a parametrization that supports both. In this case, the former would need to have appropriately lower gas costs.
 - **Different STARK sizes based on client-side proving time tradeoffs** Smaller proofs take longer to generate. We want larger proofs (cheaper to generate) to be possible, while still encouraging smaller proofs that put less load on the mempool nodes. This can be achieved by making gas cost proportional to proof size (or a related metric, like query count, and even polynomial degree).
+
+The per-dependency charge prices the first hop, where a client establishes its own dependencies before any aggregation has happened. It does not price a recursive round: by the third circuit requirement, absorbing a nested proof costs the same regardless of how many dependencies it covers, so the marginal cost of one more dependency to a node already aggregating is not proportional to the charge. Like the corresponding values in [EIP-8141](./eip-8141.md), these are provisional benchmark targets, expected to be recalibrated against the aggregation implementation as it stabilizes.
+
+### Why the circuit requirements?
+
+Three properties of the aggregation circuit are load-bearing for the rest of this specification.
+
+Bounded proof size is what allows the proof to ride in the block header without its size scaling with the block's contents. Bounded verification cost is what keeps validating a block independent of how many dependencies that block declares. Bounded absorption cost is what allows a mempool node to broadcast one wrapper per `AGGREGATION_INTERVAL` covering all currently active transactions: a node absorbs its own previous aggregate rather than re-proving its pool, so its per-round cost does not grow with the size of that pool.
+
+A circuit without all three does not support the constant-per-peer bandwidth claimed in [Censorship Resistance](#censorship-resistance) or the fixed per-interval overhead claimed above.
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
The specification depends on three properties of the aggregation circuit. It states two of them as observations about one implementation, and does not state the third at all, though the mempool loop depends on it entirely.

The two currently asserted:

> The bandwidth overhead of recursive STARKs is constant per peer, regardless of the number of transactions.

> the STARK-related overhead for the builder is a fixed ~256 kB per `AGGREGATION_INTERVAL` milliseconds

The third, bounded absorption cost, is what makes "a mempool node broadcasts exactly one wrapper containing all currently active transactions" achievable. Only if absorbing the previous round's aggregate costs the same regardless of what it covers does a node's per-round cost stay independent of its pool.

As requirements rather than observations they give a bound on `stark_proof` something to rest on, make `AGGREGATION_INTERVAL` satisfiable by construction rather than by measurement, and mean a circuit that breaks the economics fails a stated requirement instead of silently invalidating Rationale and Censorship Resistance.

The Gas Accounting sentence follows from the third property. `verification_gas` is charged per dependency, which prices establishing one for the first time. It does not price a recursive round, because absorbing a nested proof costs the same whatever it covers. The reasoning for both is in Rationale, under a new entry and under the existing Gas costs.

We implemented this EIP against a working leanVM backend and measured all three properties. Proof size moved from 225 KB to 305 KB across a 128-fold increase in dependencies; verification stayed between 3 and 10 ms over that range; absorbing children covering 8, 16 and 32 dependencies took 295, 273 and 237 ms. Those figures belong to one revision on one machine and will change, which is the reason to propose the properties rather than the numbers.
