### PR TITLE
Update EIP-8288: specify the dependency verification frame's receipt

### DIFF
--- a/EIPS/eip-8288.md
+++ b/EIPS/eip-8288.md
@@ -53,7 +53,7 @@ This EIP introduces a new frame mode for [EIP-8141](./eip-8141.md) frame transac
 
 #### Dependency Verification Frame (`DEP_VERIFY_FRAME_MODE`)
 
-We modify EIP-8141 to also allow frames with mode `DEP_VERIFY_FRAME_MODE`, in addition to all previously allowed modes. A frame with mode `DEP_VERIFY_FRAME_MODE` is a **dependency verification frame**. It declares a set of **dependencies** as `(scheme, data_hash, verification_key_hash)` triples. These triples are not executed as EVM code; instead, they are recorded as dependencies that must be proven valid by the recursive STARK in the block.
+We modify EIP-8141 to also allow frames with mode `DEP_VERIFY_FRAME_MODE`, in addition to all previously allowed modes. The static constraint `assert frame.mode < 3` on each frame is replaced by `assert frame.mode <= DEP_VERIFY_FRAME_MODE`, admitting `DEP_VERIFY_FRAME_MODE` as a valid mode value. A frame with mode `DEP_VERIFY_FRAME_MODE` is a **dependency verification frame**. It declares a set of **dependencies** as `(scheme, data_hash, verification_key_hash)` triples. These triples are not executed as EVM code; instead, they are recorded as dependencies that must be proven valid by the recursive STARK in the block.
 
 The **payload encoding** is a simple `96*k` byte concatenation of `k` triples, each consisting of:
 
@@ -68,10 +68,11 @@ This data is stored in the frame's `data` field.
 - The frame's `data` must be exactly `96*k` bytes, and the first 31 bytes of each set of 96 must be zero.
 - For each set of 96 bytes, `scheme` (byte 31) must be either `LEANSPHINCS_SCHEME` or `LEANSTARK_SCHEME`.
 - Number of triples must be `>= 1` and `<= MAX_DEPENDENCIES_PER_FRAME`.
-- The frame's `target` must be `None` (address `0x00...00`).
+- The frame's `target` must be `None`. This is EIP-8141's absent target, not the zero address: `resolved_target` is then `tx.sender`, and `FRAMEPARAM(0x00, i)` returns the sender's address. Contracts identify dependency verification frames by `mode`, not by target.
 - The frame's `value` must be `0`.
 - The frame's `flags` must be `0`.
-- The frame's `gas_limit` must be `sum(LEANSPHINCS_VERIFICATION_GAS if triple.scheme == LEANSPHINCS_SCHEME else LEANSTARK_VERIFICATION_GAS for triple in frame.data_triples)`.
+- The frame's `limits.execution` must be `sum(LEANSPHINCS_VERIFICATION_GAS if triple.scheme == LEANSPHINCS_SCHEME else LEANSTARK_VERIFICATION_GAS for triple in frame.data_triples)`.
+- The frame's `limits.state` must be `0`. The frame executes no code, so it can consume no state gas.
 
 ### Transaction Dependencies
 
@@ -81,7 +82,7 @@ The complete list of dependencies for a transaction is the concatenation of all 
 
 ```
 frame.data_triples = [
-    (data[31], data[32:64], data[64:])
+    (data[31], data[32:64], data[64:96])
     for data in chunks(frame.data, 96)
 ]
 
@@ -111,9 +112,9 @@ def deduplicate_and_sort(deps):
 
 ### Transaction Execution Visibility
 
-During EVM execution, the transaction's dependencies are made available through the existing [EIP-8141](./eip-8141.md) `FRAMEPARAM`, `FRAMEDATASIZE`, and `FRAMEDATACOPY` instructions.
+During EVM execution, the transaction's dependencies are made available through the existing [EIP-8141](./eip-8141.md) `FRAMEPARAM` and `FRAMEDATACOPY` instructions.
 
-Contracts can iterate over all frames in the transaction using `FRAMEPARAM` to identify `DEP_VERIFY_FRAME_MODE` frames, then use `FRAMEDATASIZE` and `FRAMEDATACOPY` to read the dependency data from each frame's `data` field.
+Contracts can iterate over all frames in the transaction using `FRAMEPARAM` to identify `DEP_VERIFY_FRAME_MODE` frames, then use `FRAMEPARAM(0x04, i)` and `FRAMEDATACOPY` to read the dependency data from each frame's `data` field.
 
 Specifically:
 
@@ -359,7 +360,7 @@ The verification key `AGGREGATED_VK` used to verify the recursive STARK is a fix
 
 ### Gas Accounting
 
-The gas cost for a dependency verification frame is:
+The frame's `limits.execution` for a dependency verification frame is:
 
 ```
 verification_gas(dep_verify_frame) = sum(

--- a/EIPS/eip-8288.md
+++ b/EIPS/eip-8288.md
@@ -63,6 +63,10 @@ The **payload encoding** is a simple `96*k` byte concatenation of `k` triples, e
 
 This data is stored in the frame's `data` field.
 
+**Receipt**:
+
+A dependency verification frame produces an [EIP-8141](./eip-8141.md) frame receipt like any other frame, with `status = 1`, `gas_used.execution` equal to the frame's `limits.execution`, `gas_used.state = 0`, and no logs.
+
 **Validity constraints**:
 
 - The frame's `data` must be exactly `96*k` bytes, and the first 31 bytes of each set of 96 must be zero.
@@ -424,6 +428,10 @@ There may be two valid reasons to adjust the current fixed-cost approach and swi
 
 - **Mixed k-time and unlimited-time usage of leanSPHINCS**: k-time signatures are significantly smaller than unlimited-time signatures, and SPHINCS could expose a parametrization that supports both. In this case, the former would need to have appropriately lower gas costs.
 - **Different STARK sizes based on client-side proving time tradeoffs** Smaller proofs take longer to generate. We want larger proofs (cheaper to generate) to be possible, while still encouraging smaller proofs that put less load on the mempool nodes. This can be achieved by making gas cost proportional to proof size (or a related metric, like query count, and even polynomial degree).
+
+### Why the dependency frame still gets a receipt
+
+[EIP-8141](./eip-8141.md) requires a frame receipt per frame, builds the transaction's logs by concatenating them in frame order, and exposes per-frame results through `FRAMEPARAM` `0x05`, `0x0A` and `0x0B`, which read by frame index. Omitting the entry for a frame that does not execute would renumber every later frame's results, on exactly the transactions [Transaction Execution Visibility](#transaction-execution-visibility) invites contracts to walk. EIP-8141's own rationale prices its per-frame cost as covering the receipt sub-entry that each frame adds.
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
> [!NOTE]
> This branch carries #12322, so the diff below includes that PR's changes as well as this one. That is deliberate: the text added here names EIP-8141's current field names, which #12322 is what brings into EIP-8288. Once #12322 merges, rebasing this reduces the diff.

The specification says a dependency verification frame is not executed and stops there, leaving open whether it produces a frame receipt and what that receipt holds. The two readings are not symmetric, so the omission is not neutral.

[EIP-8141](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-8141.md) requires a frame receipt per frame, builds the transaction's logs by concatenating them in frame order, and exposes per-frame results through `FRAMEPARAM` `0x05`, `0x0A` and `0x0B`, which read by frame index. Omitting the entry for a frame that does not execute renumbers every later frame's results, so a contract walking the frame list reads the wrong frame or falls out of bounds. That is the same walk Transaction Execution Visibility tells contracts to perform.

EIP-8141's own rationale prices its per-frame cost as covering "the `[status, gas_used, logs]` receipt sub-entry that each frame adds", which suggests the entry was always expected.

The values are in Specification; the reasoning above is in Rationale.
