### PR TITLE
Update EIP-8288: exclude dependency verification frames from atomic batches

### DIFF
--- a/EIPS/eip-8288.md
+++ b/EIPS/eip-8288.md
@@ -71,6 +71,7 @@ This data is stored in the frame's `data` field.
 - The frame's `target` must be `None`. This is EIP-8141's absent target, not the zero address: `resolved_target` is then `tx.sender`, and `FRAMEPARAM(0x00, i)` returns the sender's address. Contracts identify dependency verification frames by `mode`, not by target.
 - The frame's `value` must be `0`.
 - The frame's `flags` must be `0`.
+- The frame must not be part of an [EIP-8141](./eip-8141.md) atomic batch. Its `flags` are `0`, so this means the preceding frame, if any, must not carry `ATOMIC_BATCH_FLAG`.
 - The frame's `limits.execution` must be `sum(LEANSPHINCS_VERIFICATION_GAS if triple.scheme == LEANSPHINCS_SCHEME else LEANSTARK_VERIFICATION_GAS for triple in frame.data_triples)`.
 - The frame's `limits.state` must be `0`. The frame executes no code, so it can consume no state gas.
 
@@ -424,6 +425,12 @@ There may be two valid reasons to adjust the current fixed-cost approach and swi
 
 - **Mixed k-time and unlimited-time usage of leanSPHINCS**: k-time signatures are significantly smaller than unlimited-time signatures, and SPHINCS could expose a parametrization that supports both. In this case, the former would need to have appropriately lower gas costs.
 - **Different STARK sizes based on client-side proving time tradeoffs** Smaller proofs take longer to generate. We want larger proofs (cheaper to generate) to be possible, while still encouraging smaller proofs that put less load on the mempool nodes. This can be achieved by making gas cost proportional to proof size (or a related metric, like query count, and even polynomial degree).
+
+### Why dependency frames may not sit in an atomic batch
+
+Requiring `flags == 0` keeps a dependency verification frame from being a flagged batch member, but leaves it a valid terminator. [EIP-8141](./eip-8141.md) defines an atomic batch as a maximal run `[i, j]` where frames `i` through `j-1` carry `ATOMIC_BATCH_FLAG` and frame `j` does not, and its successor rule excludes only `VERIFY` frames.
+
+The terminator is the frame at which the batch commits. When a batch fails its remaining frames are skipped and take receipt status `0x2`, but a dependency is declared at the transaction body level and, as [Gas Accounting](#gas-accounting) states, is unaffected by execution reverting and charged regardless. A dependency verification frame in that position would be skipped and binding on the block at once. EIP-8141 already restricts the batch flag by mode, so a mode rule here is consistent with it.
 
 ## Backwards Compatibility
 

--- a/EIPS/eip-8288.md
+++ b/EIPS/eip-8288.md
@@ -53,7 +53,7 @@ This EIP introduces a new frame mode for [EIP-8141](./eip-8141.md) frame transac
 
 #### Dependency Verification Frame (`DEP_VERIFY_FRAME_MODE`)
 
-We modify EIP-8141 to also allow frames with mode `DEP_VERIFY_FRAME_MODE`, in addition to all previously allowed modes. A frame with mode `DEP_VERIFY_FRAME_MODE` is a **dependency verification frame**. It declares a set of **dependencies** as `(scheme, data_hash, verification_key_hash)` triples. These triples are not executed as EVM code; instead, they are recorded as dependencies that must be proven valid by the recursive STARK in the block.
+We modify EIP-8141 to also allow frames with mode `DEP_VERIFY_FRAME_MODE`, in addition to all previously allowed modes. The static constraint `assert frame.mode < 3` on each frame is replaced by `assert frame.mode <= DEP_VERIFY_FRAME_MODE`, admitting `DEP_VERIFY_FRAME_MODE` as a valid mode value. A frame with mode `DEP_VERIFY_FRAME_MODE` is a **dependency verification frame**. It declares a set of **dependencies** as `(scheme, data_hash, verification_key_hash)` triples. These triples are not executed as EVM code; instead, they are recorded as dependencies that must be proven valid by the recursive STARK in the block.
 
 The **payload encoding** is a simple `96*k` byte concatenation of `k` triples, each consisting of:
 
@@ -68,10 +68,11 @@ This data is stored in the frame's `data` field.
 - The frame's `data` must be exactly `96*k` bytes, and the first 31 bytes of each set of 96 must be zero.
 - For each set of 96 bytes, `scheme` (byte 31) must be either `LEANSPHINCS_SCHEME` or `LEANSTARK_SCHEME`.
 - Number of triples must be `>= 1` and `<= MAX_DEPENDENCIES_PER_FRAME`.
-- The frame's `target` must be `None` (address `0x00...00`).
+- The frame's `target` must be `None`. This is EIP-8141's absent target, not the zero address: `resolved_target` is then `tx.sender`, and `FRAMEPARAM(0x00, i)` returns the sender's address. Contracts identify dependency verification frames by `mode`, not by target.
 - The frame's `value` must be `0`.
 - The frame's `flags` must be `0`.
-- The frame's `gas_limit` must be `sum(LEANSPHINCS_VERIFICATION_GAS if triple.scheme == LEANSPHINCS_SCHEME else LEANSTARK_VERIFICATION_GAS for triple in frame.data_triples)`.
+- The frame's `limits.execution` must be `sum(LEANSPHINCS_VERIFICATION_GAS if triple.scheme == LEANSPHINCS_SCHEME else LEANSTARK_VERIFICATION_GAS for triple in frame.data_triples)`.
+- The frame's `limits.state` must be `0`. The frame executes no code, so it can consume no state gas.
 
 ### Transaction Dependencies
 
@@ -81,7 +82,7 @@ The complete list of dependencies for a transaction is the concatenation of all 
 
 ```
 frame.data_triples = [
-    (data[31], data[32:64], data[64:])
+    (data[31], data[32:64], data[64:96])
     for data in chunks(frame.data, 96)
 ]
 
@@ -111,9 +112,9 @@ def deduplicate_and_sort(deps):
 
 ### Transaction Execution Visibility
 
-During EVM execution, the transaction's dependencies are made available through the existing [EIP-8141](./eip-8141.md) `FRAMEPARAM`, `FRAMEDATASIZE`, and `FRAMEDATACOPY` instructions.
+During EVM execution, the transaction's dependencies are made available through the existing [EIP-8141](./eip-8141.md) `FRAMEPARAM` and `FRAMEDATACOPY` instructions.
 
-Contracts can iterate over all frames in the transaction using `FRAMEPARAM` to identify `DEP_VERIFY_FRAME_MODE` frames, then use `FRAMEDATASIZE` and `FRAMEDATACOPY` to read the dependency data from each frame's `data` field.
+Contracts can iterate over all frames in the transaction using `FRAMEPARAM` to identify `DEP_VERIFY_FRAME_MODE` frames, then use `FRAMEPARAM(0x04, i)` and `FRAMEDATACOPY` to read the dependency data from each frame's `data` field.
 
 Specifically:
 
@@ -359,7 +360,7 @@ The verification key `AGGREGATED_VK` used to verify the recursive STARK is a fix
 
 ### Gas Accounting
 
-The gas cost for a dependency verification frame is:
+The frame's `limits.execution` for a dependency verification frame is:
 
 ```
 verification_gas(dep_verify_frame) = sum(


### PR DESCRIPTION
> [!NOTE]
> This branch carries #12322, so the diff below includes that PR's changes as well as this one. That is deliberate: the text added here names EIP-8141's current field names, which #12322 is what brings into EIP-8288. Once #12322 merges, rebasing this reduces the diff.

The specification does not mention atomic batches, and requiring `flags == 0` does not keep a dependency verification frame out of one.

[EIP-8141](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-8141.md) defines an atomic batch as a maximal run `[i, j]` where frames `i` through `j-1` carry `ATOMIC_BATCH_FLAG` and frame `j` does not, and its rationale confirms the terminator is a member: "Approval scope flags are disallowed on the frames of an atomic batch, including its terminating frame." Its successor rule excludes only `VERIFY` frames. So `flags == 0` stops a dependency verification frame being a flagged member while leaving it a valid terminator, which is the frame at which the batch commits.

That is a contradiction rather than an oddity. A failed batch marks its remaining frames skipped with receipt status `0x2`, but a dependency is declared at the transaction body level, and Gas Accounting says it is unaffected by execution reverting and charged regardless. A dependency verification frame in that position would be skipped and binding on the block at the same time.

EIP-8141 already restricts the batch flag by mode, so a mode rule here is consistent with it.

The rule is one bullet in Specification; the reasoning above is in Rationale.
