### PR TITLE
Update EIP-8141: admit paymasters by a node-decidable egress property, not only exact code match

### DIFF
--- a/EIPS/eip-8141.md
+++ b/EIPS/eip-8141.md
@@ -1080,6 +1080,20 @@ available_paymaster_balance = state.balance(paymaster) - reserved_pending_cost(p
 
 [See here for rationale](#non-canonical-paymasters-in-the-mempool) for enabling non-canonical paymasters in the mempool.
 
+##### Egress-decidable paymaster
+
+*This subsection is a draft proposal under discussion. The exact egress predicate and its gas cost are open; see the notes at the end.*
+
+The canonical paymaster is admitted by exact runtime-code match because that match lets a node conclude one property: the paymaster's ether can leave only as an `APPROVE(APPROVE_PAYMENT)` collection the node has reserved, or after a delay. A node that can decide this property directly from the target's runtime code does not need an exact code match to reach the same conclusion.
+
+A `pay` frame target is *egress-decidable* if a node can determine from its runtime code alone that ether cannot leave the account except through an `APPROVE(APPROVE_PAYMENT)` collection, or after a delay of at least the reservation horizon. Nodes MAY recognise such a target and admit it under the reservation accounting used for a canonical paymaster, with `pending_withdrawal_amount` equal to zero when the code exposes no withdrawal path, and MUST NOT apply `MAX_PENDING_TXS_USING_NON_CANONICAL_PAYMASTER` to it.
+
+Unlike a canonical paymaster, an egress-decidable paymaster is not exempt from the generic validation trace and opcode rules. Its sponsorship decision is therefore expressed without reading third-party mutable storage: the sponsor commits its policy as a leaf under its own recent root (see [EIP-8272](./eip-8272.md)) and the `pay` frame carries a membership proof of that leaf. Because `FRAMEPARAM`, `FRAMEDATALOAD`, and `FRAMEDATACOPY` let a `VERIFY` frame inspect later frames, the policy can be evaluated against the sponsored operation before approval, without a live per-transaction signer.
+
+This admits any payer with the decidable property rather than only an exact code match. It is complementary to the canonical paymaster, which remains the recognised instance offering a timelocked withdrawal.
+
+Open items for discussion: the exact normative form of the egress predicate over runtime code, and whether a recent-root frame together with a membership proof and a signature check fits within `MAX_VERIFY_GAS` for the `pay` frame. The latter is not yet measured.
+
 #### Acceptance Algorithm
 
 1. A transaction is received over the wire and the node decides whether to accept or reject it.


### PR DESCRIPTION
Right now a paymaster is safe for the public mempool in one of two ways. Either its runtime code exactly matches the canonical implementation, or it is treated as non-canonical and capped at one pending transaction. The spec says the cap is there only because a non-canonical paymaster's ETH egress is uncontrolled (mempool section, non-canonical paymaster paragraph). And reservation accounting already applies to every payer, not just canonical ones (same section).

So the exact code hash is really standing in for one property the node needs: that the payer's ETH can only leave as a payment it reserved, or after a delay. If a node can decide that property directly from the code, it can give any such payer the same reservation treatment, without a blessed hash.

This PR proposes an additive paymaster class admitted by that decidable egress property. The sponsorship policy moves off the contract: the sponsor publishes it as a leaf under its own recent root ([EIP-8272](https://eips.ethereum.org/EIPS/eip-8272)) and the pay frame carries a membership proof, the same shape ERC-8403 uses for account authority (ethereum/ERCs#1979). Later-frame introspection already lets a VERIFY frame read the sponsored operation before approving, so no live per-transaction signer is needed.

This is complementary to #12041, not a replacement. That PR blesses one contract by hash with a timelocked withdrawal; here that stays the withdrawable instance, while any egress-decidable payer becomes eligible without waiting on a blessed bytecode.

Two things are open and flagged inline in the diff rather than hidden. First, the exact opcode set for code re-pointing under the active fork's account model, which should be pinned against the fork's opcode table before the predicate is normative. Second, the gas budget. The proof machinery itself is cheap under the fixed gas schedule (ecrecover 3,000, a keccak Merkle path a few thousand at a realistic depth, field checks under a thousand, so single-digit thousands against the 100,000 MAX_VERIFY_GAS), so the open question is narrower than "does the proof fit": it is the gas the recent-root verification frame draws from the same budget, and whether proof calldata bills against MAX_VERIFY_GAS or only at the tx intrinsic level. Nothing here is measured end-to-end since no client implements the sealed pay frame yet, so treat it as a design proposal for discussion.
