### PR TITLE
Update EIP-8360: clarify ephemeral account semantics and fix EIP-684 references

### DIFF
--- a/EIPS/eip-8360.md
+++ b/EIPS/eip-8360.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2026-08-03
-requires: 161, 1014, 1153, 3529, 7610, 8037, 8038
+requires: 161, 684, 1014, 1153, 3529, 8037, 8038
 ---
 
 ## Abstract
@@ -47,30 +47,49 @@ The behavior of `CREATE2` is defined in [EIP-1014](./eip-1014.md).
 
 - The address is computed as `keccak256(0xfe || deployer_address || salt || keccak256(init_code))[12:]` where `||` denotes byte concatenation.
 - At the end of the transaction, all code, nonce, and storage created during transaction execution are removed from the target account. The account balance is preserved. An account that becomes empty is removed from the state trie at the end of the transaction in accordance with [EIP-161](./eip-161.md). The semantics are clarified further [here](#state-transition-handling).
-- Code deployment rules and collision semantics are identical to `CREATE2`. A target account is considered non-empty during the transaction, and address collisions therefore revert execution in accordance with [EIP-7610](./eip-7610.md). The semantics are clarified further [here](#state-transition-handling).
+- Code deployment rules and collision semantics are identical to `CREATE2`. A target account is considered non-empty during the transaction, and address collisions therefore revert execution in accordance with [EIP-684](./eip-684.md). The semantics are clarified further [here](#state-transition-handling).
 
-### State transition handling
+This mean `TCREATE` creates an ephemeral account whose lifetime is limited to the current transaction. The account may execute arbitrary EVM code and may modify its balance, code, and storage during execution. These modifications are not retained as persistent state when the transaction terminates, except for state changes explicitly made to other accounts.
 
-At the end of the transaction, the account state of every contract created by `TCREATE` is finalized as follows:
+### Nonce Semantics
 
-- The account nonce is reset to 0.
-- The account code is removed.
-- All storage associated with the account is removed.
-- The account balance is preserved.
+`TCREATE` follows the account-creation nonce semantics of the existing account-creation opcodes during execution, while ensuring that no nonce increment introduced solely by `TCREATE` becomes persistent.
 
-For the deploying account, an implementation must maintain a temporary record of the account's original nonce together with all permanent nonce increments that occur during the transaction (for example, those resulting from `CREATE` or `CREATE2`).
+At the beginning of the transaction, the client records the deployer's `original_nonce`. During execution, nonce increments caused by `CREATE` and `CREATE2` are treated as persistent nonce increments, while nonce increments introduced solely by `TCREATE` are temporary.
 
-When transaction execution completes, the deployer's nonce is restored to `original_nonce + permanent_nonce_increments`, where `permanent_nonce_increments` excludes nonce increments introduced solely by `TCREATE`.
+At the end of the transaction, the deployer's nonce is restored to:
+`original_nonce + permanent_nonce_increments`
+where `permanent_nonce_increments` includes nonce increments caused by `CREATE` and `CREATE2`, but excludes nonce increments caused solely by `TCREATE`.
 
-### Opcode Behavior Changes
+This rule applies regardless of the order in which `TCREATE`, `CREATE`, and `CREATE2` are executed within the transaction. For example, if a transaction executes `TCREATE` followed by `CREATE`, the nonce increment associated with `TCREATE` is discarded while the nonce increment associated with `CREATE` is retained.
 
-#### `SSTORE` and `SLOAD`
+The nonce of an ephemeral account is also temporary. Any nonce value assigned to or produced by the ephemeral account during execution MUST NOT be persisted. At the end of the transaction, the nonce of the ephemeral account is reset to zero together with its other temporary state.
 
-Within the execution context of a contract deployed via `TCREATE`, `SLOAD` and `SSTORE` operate on an ephemeral storage space rather than the persistent storage trie.
+This preserves the distinction between an account that is created and used during execution and an account whose state survives the transaction, while allowing `TCREATE` to retain the execution semantics of account-creation operations.
 
-This ephemeral storage is local to the `TCREATE` account and is discarded when the transaction completes together with the account's transient state. Consequently, writes performed through `SSTORE` are never committed to the global state, and subsequent transactions observe the storage as empty.
+### Storage Semantics
 
-The separation between this ephemeral storage and the transient storage defined by [EIP-1153](./eip-1153.md) is an implementation detail. Clients must ensure that writes performed through `SSTORE` are isolated from persistent storage while preserving the observable semantics of the `SLOAD` and `SSTORE` opcodes.
+An ephemeral account does not retain storage after the transaction terminates.
+
+SLOAD and SSTORE executed in the context of an ephemeral account operate with transaction-local semantics equivalent to TLOAD and TSTORE, respectively. Storage written by SSTORE is therefore available to subsequent execution within the same transaction but is not persisted as account state after the transaction terminates.
+
+This behavior allows existing EVM code that relies on the SLOAD and SSTORE instruction family to operate within an ephemeral account without introducing persistent state.
+
+SLOAD and SSTORE operations performed on an ephemeral account MUST NOT add storage entries for that account to the block access list. Since no storage state is persisted by the ephemeral account, these operations do not represent persistent state changes that need to be included in the block access list.
+The implementation and accounting details of these operations are intentionally kept separate from the semantics of persistent storage. Client implementations MAY internally represent ephemeral storage using the same mechanisms as transient storage.
+
+The distinction between ephemeral storage used by `SLOAD` and `SSTORE` and the transient storage defined by [EIP-1153](./eip-1153.md) is intentionally invisible to contracts. It exists solely to simplify client implementations while preserving the expected semantics of both storage models.
+
+### Value Transfer
+
+An ephemeral account MAY receive and transfer Ether during execution.
+
+The temporary nature of the account does not exempt value transfers from state-access accounting. In particular, if a value transfer causes an account state change that would otherwise require an account-creation charge under EIP-8038, the corresponding charge MUST be applied.
+
+This is particularly relevant when an ephemeral account receives Ether and the resulting balance is retained as account state during execution. Such an account MUST be accounted for as an account with persistent balance state for the duration in which that balance exists.
+
+If the temporary account's balance is subsequently removed before the end of the transaction, the corresponding ACCOUNT_WRITE charge MAY be refilled according to the refund accounting rules defined by this EIP.
+At the end of the transaction, the ephemeral account's balance MUST be zero and MUST NOT be persisted as part of the ephemeral account's state.
 
 ### Gas Accounting
 

--- a/EIPS/eip-8360.md
+++ b/EIPS/eip-8360.md
@@ -8,7 +8,7 @@ status: Draft
 type: Standards Track
 category: Core
 created: 2026-08-03
-requires: 161, 684, 1014, 1153, 3529, 8037, 8038
+requires: 161, 684, 1014, 1153, 3529, 7928, 8037, 8038
 ---
 
 ## Abstract
@@ -49,47 +49,34 @@ The behavior of `CREATE2` is defined in [EIP-1014](./eip-1014.md).
 - At the end of the transaction, all code, nonce, and storage created during transaction execution are removed from the target account. The account balance is preserved. An account that becomes empty is removed from the state trie at the end of the transaction in accordance with [EIP-161](./eip-161.md). The semantics are clarified further [here](#state-transition-handling).
 - Code deployment rules and collision semantics are identical to `CREATE2`. A target account is considered non-empty during the transaction, and address collisions therefore revert execution in accordance with [EIP-684](./eip-684.md). The semantics are clarified further [here](#state-transition-handling).
 
-This mean `TCREATE` creates an ephemeral account whose lifetime is limited to the current transaction. The account may execute arbitrary EVM code and may modify its balance, code, and storage during execution. These modifications are not retained as persistent state when the transaction terminates, except for state changes explicitly made to other accounts.
+### State transition handling
 
-### Nonce Semantics
+At the end of the transaction, the account state of every contract created by `TCREATE` is finalized as follows:
 
-`TCREATE` follows the account-creation nonce semantics of the existing account-creation opcodes during execution, while ensuring that no nonce increment introduced solely by `TCREATE` becomes persistent.
+- The account nonce is reset to 0.
+- The account code is removed.
+- All storage associated with the account is removed.
+- The account balance is preserved.
 
-At the beginning of the transaction, the client records the deployer's `original_nonce`. During execution, nonce increments caused by `CREATE` and `CREATE2` are treated as persistent nonce increments, while nonce increments introduced solely by `TCREATE` are temporary.
+For the deploying account, an implementation must maintain a temporary record of the account's original nonce together with all permanent nonce increments that occur during the transaction (for example, those resulting from `CREATE` or `CREATE2`).
 
-At the end of the transaction, the deployer's nonce is restored to:
-`original_nonce + permanent_nonce_increments`
-where `permanent_nonce_increments` includes nonce increments caused by `CREATE` and `CREATE2`, but excludes nonce increments caused solely by `TCREATE`.
+When transaction execution completes, the deployer's nonce is restored to `original_nonce + permanent_nonce_increments`, where `permanent_nonce_increments` excludes nonce increments introduced solely by `TCREATE`.
 
-This rule applies regardless of the order in which `TCREATE`, `CREATE`, and `CREATE2` are executed within the transaction. For example, if a transaction executes `TCREATE` followed by `CREATE`, the nonce increment associated with `TCREATE` is discarded while the nonce increment associated with `CREATE` is retained.
+### Opcode Behavior Changes
 
-The nonce of an ephemeral account is also temporary. Any nonce value assigned to or produced by the ephemeral account during execution MUST NOT be persisted. At the end of the transaction, the nonce of the ephemeral account is reset to zero together with its other temporary state.
+#### `SSTORE` and `SLOAD` handling
 
-This preserves the distinction between an account that is created and used during execution and an account whose state survives the transaction, while allowing `TCREATE` to retain the execution semantics of account-creation operations.
-
-### Storage Semantics
-
-An ephemeral account does not retain storage after the transaction terminates.
-
-SLOAD and SSTORE executed in the context of an ephemeral account operate with transaction-local semantics equivalent to TLOAD and TSTORE, respectively. Storage written by SSTORE is therefore available to subsequent execution within the same transaction but is not persisted as account state after the transaction terminates.
-
-This behavior allows existing EVM code that relies on the SLOAD and SSTORE instruction family to operate within an ephemeral account without introducing persistent state.
-
-SLOAD and SSTORE operations performed on an ephemeral account MUST NOT add storage entries for that account to the block access list. Since no storage state is persisted by the ephemeral account, these operations do not represent persistent state changes that need to be included in the block access list.
-The implementation and accounting details of these operations are intentionally kept separate from the semantics of persistent storage. Client implementations MAY internally represent ephemeral storage using the same mechanisms as transient storage.
+Mapping `SLOAD` and `SSTORE` to ephemeral storage preserves compatibility with existing contract code that assumes the availability of state storage while preventing persistent state growth. Prohibiting these opcodes entirely would introduce unnecessary incompatibilities, whereas allowing writes to persistent storage would conflict with the ephemeral nature of `TCREATE` accounts and the requirement that no storage root remains after transaction completion.
 
 The distinction between ephemeral storage used by `SLOAD` and `SSTORE` and the transient storage defined by [EIP-1153](./eip-1153.md) is intentionally invisible to contracts. It exists solely to simplify client implementations while preserving the expected semantics of both storage models.
 
-### Value Transfer
+#### BAL handling
 
-An ephemeral account MAY receive and transfer Ether during execution.
+Storage accesses performed by `SLOAD` and `SSTORE` within a `TCREATE` account MUST NOT be recorded in the block-level Block Access List (BAL) defined by [EIP-7928](./eip-7928.md).
 
-The temporary nature of the account does not exempt value transfers from state-access accounting. In particular, if a value transfer causes an account state change that would otherwise require an account-creation charge under EIP-8038, the corresponding charge MUST be applied.
+Although these operations may read from or modify the ephemeral storage of the `TCREATE` account during transaction execution, none of these storage changes can affect the persistent state after the transaction completes. Excluding them from the BAL therefore avoids recording state accesses that have no persistent state effect and reduces the size of the block access list.
 
-This is particularly relevant when an ephemeral account receives Ether and the resulting balance is retained as account state during execution. Such an account MUST be accounted for as an account with persistent balance state for the duration in which that balance exists.
-
-If the temporary account's balance is subsequently removed before the end of the transaction, the corresponding ACCOUNT_WRITE charge MAY be refilled according to the refund accounting rules defined by this EIP.
-At the end of the transaction, the ephemeral account's balance MUST be zero and MUST NOT be persisted as part of the ephemeral account's state.
+This exclusion applies to both `SLOAD` and `SSTORE`. A `SLOAD` performed by a `TCREATE` account MUST NOT create a BAL entry for the accessed storage slot, and an `SSTORE` performed by a `TCREATE` account MUST NOT create or update a BAL entry for the modified storage slot.
 
 ### Gas Accounting
 
@@ -160,6 +147,12 @@ Preserving balance semantics while accounting only for temporary state changes p
 ### Extended state accounting method
 
 Unlike `CREATE2`, whose state-gas accounting is tied to permanent account creation, `TCREATE` accounts are ephemeral. Therefore, charging for account creation itself would overestimate the persistent state introduced by the opcode. Instead, this EIP generalizes the state-accounting model of [EIP-8037](./eip-8037.md) by charging only for state that remains after transaction execution and refilling charges when transient state is completely eliminated.
+
+### State creation gas is not upfront
+
+The absence of upfront account-creation and code-deposit charges is possible because the client knows from the execution of `TCREATE` that the target account is temporary. Unlike `CREATE2`, whose resulting account may persist after the transaction, a `TCREATE` account is guaranteed by the protocol to have its code, nonce, and storage removed at the end of the transaction. The client therefore does not need to reserve gas in advance for persistent account state that cannot survive the transaction.
+
+This does not make account creation or code execution free. The execution costs required to initialize and execute the account are still charged normally, and state-gas is charged whenever execution creates state that may persist beyond the temporary lifetime of the account. In particular, a non-zero balance transferred to a `TCREATE` account is charged as account state because the balance is preserved at the end of the transaction. If that balance is subsequently transferred out in full during the same transaction, the corresponding state-gas charge is refilled because the state no longer needs to be preserved.
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
Supersedes #12318 with the same changes plus two fixes, so the text is complete for the Hegotá scoping discussion on ACDE #246 (Sep 24). @Helkomine's commit is included as-is; the two commits on top are mine.

From #12318 (Helkomine):
- `requires`: EIP-7610 replaced by EIP-684 (the collision rule in force), EIP-7928 added.
- New "BAL handling" section: `SLOAD`/`SSTORE` inside a `TCREATE` account are not recorded in the block access list.
- Rationale: "State creation gas is not upfront".

Added here:
- The Specification's `SSTORE`/`SLOAD` section in #12318 kept only the rationale text and dropped the rule itself. Restored, phrased as @jochem-brouwer suggested on Magicians: inside a `TCREATE`-created account, `SSTORE` and `SLOAD` MUST behave as `TSTORE` and `TLOAD`; the persistent trie is never written. The rationale stays once, under Rationale.
- Security Considerations still referenced EIP-7610; now EIP-684, consistent with `requires` and Semantics.

This answers the Nethermind scoping feedback (EIP-7610 dependency, BAL handling) and Jochem's dependency and storage points. His remaining points, nonce restoration and code-deposit charging, are open and will be discussed on the call.
